### PR TITLE
Allow the invocation overview grid to overflow

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -735,6 +735,7 @@ a {
 .dense-invocation-overview-grid {
   display: flex;
   background-color: #fff;
+  overflow: auto;
 }
 
 .dense-invocation-overview-grid-chunk {


### PR DESCRIPTION
On a narrow display (e.g. a phone), this is the only element that doesn't currently scale well  and causes the whole page to have an horizontal scroll.