### PR TITLE
Add an error message when profile is missing

### DIFF
--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -15,6 +15,8 @@ interface State {
   threadMap: Map<number, Thread>;
   timingEnabled: boolean;
   buildInProgress: boolean;
+  /** Whether the "command.profile.gz" file is missing from BuildToolLogs. */
+  isMissingProfile: boolean;
   sortBy: string;
   groupBy: string;
   threadPageSize: number;
@@ -48,6 +50,7 @@ export default class InvocationTimingCardComponent extends React.Component {
     threadMap: new Map<number, Thread>(),
     timingEnabled: true,
     buildInProgress: false,
+    isMissingProfile: false,
     sortBy: window.localStorage[sortByStorageKey] || sortByTimeAscStorageValue,
     groupBy: window.localStorage[groupByStorageKey] || groupByThreadStorageValue,
     threadPageSize: window.localStorage[threadPageSizeStorageKey] || 10,
@@ -71,7 +74,12 @@ export default class InvocationTimingCardComponent extends React.Component {
     )?.uri;
 
     if (!profileUrl) {
-      this.setState({ ...this.state, buildInProgress: true });
+      const hasBuildToolLogs = this.props.model.buildToolLogs;
+      this.setState({
+        ...this.state,
+        buildInProgress: !hasBuildToolLogs,
+        isMissingProfile: hasBuildToolLogs,
+      });
       return;
     }
 
@@ -288,6 +296,12 @@ export default class InvocationTimingCardComponent extends React.Component {
             </div>
           </div>
           {this.state.buildInProgress && <div className="empty-state">Build is in progress...</div>}
+          {this.state.isMissingProfile && (
+            <div className="empty-state">
+              Could not find profile info. This might be because Bazel was invoked with a
+              non-default <span className="inline-code">--profile</span> flag.
+            </div>
+          )}
           {!this.state.timingEnabled && (
             <div className="empty-state">
               Profiling isn't enabled for this invocation.

--- a/static/style.css
+++ b/static/style.css
@@ -15,7 +15,7 @@ ul {
 }
 
 body {
-  font-family: 'Open Sans', sans-serif;
+  font-family: "Open Sans", sans-serif;
   display: flex;
   flex-direction: column;
   word-break: break-word;
@@ -73,7 +73,7 @@ button {
   font-size: 24px;
   z-index: 2;
   position: relative;
-  background-color: rgba(38,50,56 ,1);
+  background-color: rgba(38, 50, 56, 1);
   color: #fff;
 }
 
@@ -96,7 +96,7 @@ button {
 .menu-child-title {
   margin-left: 8px;
   font-weight: 400;
-  color: rgba(255,255,255,.5);
+  color: rgba(255, 255, 255, 0.5);
 }
 
 .menu .icon {
@@ -109,7 +109,7 @@ button {
   width: 40px;
   border-radius: 20px;
   cursor: pointer;
-  background-color: rgba(255, 255, 255, .95);
+  background-color: rgba(255, 255, 255, 0.95);
 }
 
 .menu .default-photo {
@@ -119,11 +119,11 @@ button {
 
 .menu-control {
   cursor: pointer;
-  opacity: .8;
+  opacity: 0.8;
 }
 
 .menu .title {
-  color: rgba(255, 255, 255, .90);
+  color: rgba(255, 255, 255, 0.9);
 }
 
 .menu-child {
@@ -153,7 +153,7 @@ button {
   position: absolute;
   top: 46px;
   right: 8px;
-  background-color: rgba(38,50,56 ,1);
+  background-color: rgba(38, 50, 56, 1);
   color: #fff;
   padding: 8px 32px 32px 32px;
   border-bottom-left-radius: 8px;
@@ -197,12 +197,12 @@ button {
 .shelf .subtitle {
   font-size: 18px;
   font-weight: 500;
-  color: rgba(0, 0, 0, .8);
+  color: rgba(0, 0, 0, 0.8);
   margin-bottom: 8px;
 }
 
 .shelf.success {
-  border-bottom: 6px solid #8BC34A;
+  border-bottom: 6px solid #8bc34a;
 }
 
 .shelf.failure {
@@ -210,7 +210,7 @@ button {
 }
 
 .shelf.in-progress {
-  border-bottom: 6px solid #03A9F4;
+  border-bottom: 6px solid #03a9f4;
 }
 
 .shelf.disconnected {
@@ -228,20 +228,20 @@ button {
 }
 
 .breadcrumbs span:after {
-  content: '›';
+  content: "›";
   padding: 0 8px;
   color: #ccc;
   font-weight: 600;
 }
 
 .breadcrumbs span:last-of-type:after {
-  content: '';
+  content: "";
 }
 
 .shelf .details {
   font-size: 16px;
   line-height: 1.6em;
-  color: rgba(0, 0, 0, .7);
+  color: rgba(0, 0, 0, 0.7);
   display: flex;
   align-items: center;
   flex-wrap: wrap;
@@ -265,7 +265,7 @@ button {
 
 .org-button {
   float: right;
-  background-color: rgba(38,50,56 ,1);
+  background-color: rgba(38, 50, 56, 1);
   padding: 8px 16px;
   border-radius: 32px;
   margin-top: -6px;
@@ -283,7 +283,7 @@ button {
 }
 
 .tab {
-  box-shadow: 0px 0px 2px rgba(0, 0, 0, .15);
+  box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.15);
   border-radius: 50px;
   margin-right: 8px;
   padding: 12px 32px;
@@ -298,7 +298,7 @@ button {
 }
 
 .tab.selected {
-  background: rgba(38,50,56 ,1);
+  background: rgba(38, 50, 56, 1);
   color: #fff;
 }
 
@@ -312,7 +312,7 @@ button {
 }
 
 .run {
-  box-shadow: 0px 0px 2px rgba(0, 0, 0, .15);
+  box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.15);
   border-radius: 4px;
   margin-right: 8px;
   padding: 12px 32px 8px 32px;
@@ -343,7 +343,7 @@ button {
 }
 
 .run.test-passed {
-  background-color: #8BC34A;
+  background-color: #8bc34a;
 }
 
 .run.test-failed {
@@ -359,7 +359,7 @@ button {
 }
 
 .run.selected {
-  border-bottom: 4px solid rgba(0, 0, 0, .2);
+  border-bottom: 4px solid rgba(0, 0, 0, 0.2);
 }
 
 /** Filter **/
@@ -380,7 +380,7 @@ button {
 .filter img {
   width: 16px;
   height: 16px;
-  opacity: .3;
+  opacity: 0.3;
   padding-left: 20px;
 }
 
@@ -402,7 +402,7 @@ button {
 /** Card **/
 
 .card {
-  box-shadow: 0px 1px 4px rgba(0, 0, 0, .10), 0px 1px 6px rgba(0, 0, 0, .05);
+  box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.1), 0px 1px 6px rgba(0, 0, 0, 0.05);
   margin: 32px 0;
   padding: 32px;
   border-radius: 8px;
@@ -415,11 +415,11 @@ button {
 
 .card.card-hovered,
 .card:hover {
-    box-shadow: 0px 2px 6px rgba(0, 0, 0, .10), 0px 1px 10px rgba(0, 0, 0, .05);
+  box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.1), 0px 1px 10px rgba(0, 0, 0, 0.05);
 }
 
 .card.card-success {
-  border-left: 6px solid #8BC34A;
+  border-left: 6px solid #8bc34a;
 }
 
 .card.card-failure {
@@ -439,7 +439,7 @@ button {
 }
 
 .card.card-in-progress {
-  border-left: 6px solid #03A9F4;
+  border-left: 6px solid #03a9f4;
 }
 
 .card.dark {
@@ -453,7 +453,7 @@ button {
 }
 
 .card-hovered.card-success {
-  border-left: 6px solid #7CB342;
+  border-left: 6px solid #7cb342;
 }
 
 .card-hovered.card-failure {
@@ -540,7 +540,7 @@ code {
   margin-top: 16px;
   margin-bottom: 16px;
   background-color: #fafafa;
-  font-family: 'Source Code Pro', monospace;
+  font-family: "Source Code Pro", monospace;
   line-height: 1.6em;
   white-space: nowrap;
   overflow-y: auto;
@@ -557,7 +557,7 @@ code button {
   border: 0;
   background-color: #eee;
   border-radius: 8px;
-  font-size: .6em;
+  font-size: 0.6em;
   font-weight: bold;
   outline: 0;
   box-shadow: 0;
@@ -579,13 +579,13 @@ code[data-header]:before {
   border-right: 1px solid #eee;
   border-bottom: 1px solid #eee;
   border-bottom-right-radius: 8px;
-  font-size: .8em;
+  font-size: 0.8em;
   font-weight: bold;
   pointer-events: none;
 }
 
 .code {
-  font-family: 'Source Code Pro', monospace;
+  font-family: "Source Code Pro", monospace;
 }
 
 code .comment {
@@ -597,7 +597,7 @@ code .comment {
 }
 
 .home p.callout {
-  background-color: #FFE082;
+  background-color: #ffe082;
   padding: 16px 32px;
   border-radius: 8px;
 }
@@ -677,7 +677,7 @@ code .comment {
 .footer {
   text-align: center;
   color: #aaa;
-  font-size: .8em;
+  font-size: 0.8em;
   padding: 32px 32px 64px 32px;
   height: 32px;
 }
@@ -708,7 +708,7 @@ code .comment {
 .history .details {
   font-size: 14px;
   line-height: 1.6em;
-  color: rgba(0, 0, 0, .7);
+  color: rgba(0, 0, 0, 0.7);
   display: flex;
   align-items: center;
   flex-wrap: wrap;
@@ -785,8 +785,15 @@ code .comment {
 
 .terminal-line {
   font-size: 14px;
-  font-family: 'Source Code Pro', monospace;
+  font-family: "Source Code Pro", monospace;
   color: #fff;
+}
+
+.inline-code {
+  font-family: "Source Code Pro", monospace;
+  background: #eee;
+  border-radius: 2px;
+  padding: 2px;
 }
 
 .expanded .terminal {
@@ -834,7 +841,7 @@ code .comment {
 }
 
 .list-percent {
-  background-color: #8BC34A;
+  background-color: #8bc34a;
   height: 6px;
   min-width: 1px;
   max-width: 100%;
@@ -869,7 +876,7 @@ code .comment {
 }
 
 .sort-control:after {
-  content: '•';
+  content: "•";
   margin-left: 12px;
 }
 
@@ -948,7 +955,7 @@ code .comment {
 
 .test-log {
   white-space: pre-wrap;
-  font-family: 'Source Code Pro', monospace;
+  font-family: "Source Code Pro", monospace;
   line-height: 1.4em;
   margin-top: 16px;
   word-break: break-word;
@@ -1003,7 +1010,7 @@ code .comment {
 
 .test-case-contents {
   white-space: pre-wrap;
-  font-family: 'Source Code Pro', monospace;
+  font-family: "Source Code Pro", monospace;
 }
 
 .test-class {
@@ -1013,7 +1020,7 @@ code .comment {
 .command-line-arg {
   margin-left: 32px;
   margin-top: 8px;
-  font-family: 'Source Code Pro', monospace;
+  font-family: "Source Code Pro", monospace;
 }
 
 .command-line-arg:first-of-type {
@@ -1104,10 +1111,10 @@ code .comment {
 }
 
 .login-hero {
-  border-right: 1px solid rgba(255, 255, 255, .5);
+  border-right: 1px solid rgba(255, 255, 255, 0.5);
   padding-right: 32px;
   margin-right: 32px;
-  color: rgba(255, 255, 255, .7);
+  color: rgba(255, 255, 255, 0.7);
   max-width: 40%;
   line-height: 1.6em;
   display: flex;
@@ -1146,7 +1153,7 @@ code .comment {
   margin-bottom: 12px;
   font-size: 18px;
   cursor: pointer;
-  border: 3px solid rgba(255, 255, 255, .9);
+  border: 3px solid rgba(255, 255, 255, 0.9);
   background-color: transparent;
   color: #fff;
   min-width: 360px;
@@ -1154,19 +1161,19 @@ code .comment {
 
 .login-buttons button:nth-of-type(3) {
   border: 0;
-  color: rgba(255, 255, 255, .4);
+  color: rgba(255, 255, 255, 0.4);
   background-color: transparent;
   margin-bottom: 0;
 }
 
 .login-buttons button:first-of-type {
-  border: 3px solid rgba(255, 255, 255, .4);
-  color: rgba(38,50,56 ,1);
+  border: 3px solid rgba(255, 255, 255, 0.4);
+  color: rgba(38, 50, 56, 1);
   background-color: #fff;
 }
 
 .login-interstitial {
-  background-color: rgba(38,50,56 ,1);
+  background-color: rgba(38, 50, 56, 1);
 }
 
 .login-interstitial,
@@ -1188,23 +1195,23 @@ code .comment {
   font-size: 18px;
   margin-bottom: 16px;
   font-weight: 600;
-  color: rgba(255,255,255,0.5);
+  color: rgba(255, 255, 255, 0.5);
 }
 
 .login .on-prem {
   width: 100%;
   text-align: center;
   color: #fff;
-  color: rgba(255, 255, 255, .5);
+  color: rgba(255, 255, 255, 0.5);
   margin-top: 64px;
 }
 
 .login .on-prem a {
   text-decoration: underline;
-  color: rgba(255, 255, 255, .7);
+  color: rgba(255, 255, 255, 0.7);
 }
 
-@media(max-width: 800px) {
+@media (max-width: 800px) {
   .login-hero {
     display: none;
   }
@@ -1235,7 +1242,7 @@ code .comment {
 }
 
 .grid-block-success {
-  background-color: #8BC34A;
+  background-color: #8bc34a;
 }
 
 .grid-block-failure {
@@ -1251,11 +1258,11 @@ code .comment {
 }
 
 .grid-block-in-progress {
-  background-color: #03A9F4;
+  background-color: #03a9f4;
 }
 
 .grid-block-success.grid-block-hover {
-  background-color: #7CB342;
+  background-color: #7cb342;
 }
 
 .grid-block-failure.grid-block-hover {
@@ -1271,7 +1278,7 @@ code .comment {
 }
 
 .grid-block-in-progress.grid-block-hover {
-  background-color: #039BE5;
+  background-color: #039be5;
 }
 
 /** Dense mode **/
@@ -1301,7 +1308,7 @@ code .comment {
 }
 
 .dense .empty-state {
-  padding: 0 16px;
+  padding: 0;
 }
 
 .dense .history-overview.container {
@@ -1338,14 +1345,14 @@ code .comment {
 
 .dense .tab.selected {
   background-color: transparent;
-  color: #455A64;
+  color: #455a64;
   position: relative;
 }
 
 .dense .tab.selected:after {
   display: block;
-  content: ' ';
-  background-color: #455A64;
+  content: " ";
+  background-color: #455a64;
   height: 4px;
   position: absolute;
   bottom: 0;
@@ -1367,7 +1374,7 @@ code .comment {
   margin-top: 4px;
   border-radius: 8px;
   border-top: 0;
-  box-shadow: 0px 1px 4px rgba(0, 0, 0, .10), 0px 1px 6px rgba(0, 0, 0, .05);
+  box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.1), 0px 1px 6px rgba(0, 0, 0, 0.05);
 }
 
 .dense .card .details {
@@ -1414,8 +1421,8 @@ code .comment {
 }
 
 .dense-invocation-status-bar.success {
-  border-top: 4px solid #8BC34A;
-  background-color: #E8F5E9;
+  border-top: 4px solid #8bc34a;
+  background-color: #e8f5e9;
 }
 
 .dense-invocation-status-bar.failure {
@@ -1424,8 +1431,8 @@ code .comment {
 }
 
 .dense-invocation-status-bar.in-progress {
-  border-top: 4px solid #03A9F4;
-  background-color: #E3F2FD;
+  border-top: 4px solid #03a9f4;
+  background-color: #e3f2fd;
 }
 
 .dense-invocation-status-bar.disconnected {


### PR DESCRIPTION
When the profile could not be found (named "command.profile.gz") we now show this message:

![image](https://user-images.githubusercontent.com/2414826/91908495-a57f4200-ec79-11ea-939e-69e742fd9a66.png)

Some ideas for the future:
- Use any file with a URL starting with `bytestream://`, assuming that there's only one file with that format
- Reinforce empty state with an icon or color accent