### PR TITLE
Serve minified app only when -c opt is present

### DIFF
--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -21,6 +21,19 @@ terser_minified(
     src = ":app_bundle",
 )
 
+config_setting(
+    name = "minified_js",
+    values = {"compilation_mode": "opt"},
+)
+
+alias(
+    name = "app_js_entry_point",
+    actual = select({
+        ":minified_js": ":app_bundle.min",
+        "//conditions:default": ":app_bundle",
+    }),
+)
+
 ts_library(
     name = "app",
     srcs = glob(["*.tsx"]),

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -2,6 +2,14 @@ syntax = "proto3";
 
 package config;
 
+message FrontendTemplateData {
+  // Contents of the JS global variable `window.buildBuddyConfig`.
+  FrontendConfig config = 1;
+
+  // Path to the JS entry point.
+  string js_entry_point_path = 2;
+}
+
 message FrontendConfig {
   // The version of this buildbuddy instance.
   string version = 1;

--- a/server/cmd/BUILD
+++ b/server/cmd/BUILD
@@ -9,10 +9,13 @@ go_binary(
     args = [
         "--config_file=config/buildbuddy.local.yaml",
         "--max_shutdown_duration=3s",
-    ],
+    ] + select({
+        "//app:minified_js": ["--js_entry_point_path=/app/app_bundle.min.js"],
+        "//conditions:default": ["--js_entry_point_path=/app/app_bundle.js"],
+    }),
     data = [
         "//:config_files",
-        "//app:app_bundle.min",
+        "//app:app_js_entry_point",
         "//static",
     ],
     embed = [":go_default_library"],

--- a/static/index.html
+++ b/static/index.html
@@ -23,7 +23,7 @@
     <meta charset="UTF-8" />
 
     <script>
-      window.buildbuddyConfig = {{.}};
+      window.buildbuddyConfig = {{.Config}};
     </script>
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-156160991-2"></script>
@@ -39,5 +39,5 @@
   <body>
     <div id="app"></div>
   </body>
-  <script type="text/javascript" src="/app/app_bundle.min.js"></script>
+  <script type="text/javascript" src="{{.JsEntryPointPath}}"></script>
 </html>


### PR DESCRIPTION
Doing this mostly because I want to be able to type `git add .` without it checking in my hacked version of `app/BUILD.bazel` :P

Tested manually with and without `-c opt` and verified that the correct `<script src>` is present.