### PR TITLE
Fix vertical layout of flame chart bars

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1582,6 +1582,8 @@ code .comment {
 
 .flame-chart-section {
   border-bottom: 1px solid #ddd;
+  box-sizing: border-box;
+
   box-shadow: 0 1px -3px rgba(0, 0, 0, 0.12) inset;
 }
 
@@ -1610,9 +1612,9 @@ code .comment {
 }
 
 .flame-chart .tracks {
-  /* TODO: set height dynamically based on SVG content */
-  height: 500px;
+  height: inherit;
   min-width: 100%;
+  overflow: visible;
 }
 
 .flame-chart rect.hover {


### PR DESCRIPTION
* Fix off-by-1 error in section height due to specifying `border-bottom` without `box-sizing: border-box`
* Fix SVG container rect not showing all bars