### PR TITLE
Expand environment variables in config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -64,3 +64,8 @@ Here's a full list of BuildBuddy's configuration sections:
 In addition to the config file, some BuildBuddy options (like port number) can only be configured via command line flags.
 
 More information on these flags, see our [flags documentation](config-flags.md).
+
+## Environment variables
+
+Environment variables in the config file are expanded at runtime.
+You only need to reference your environment variables like this `${ENV_VARIABLE}`. 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -180,8 +180,12 @@ func readConfig(fullConfigPath string) (*generalConfig, error) {
 		return nil, fmt.Errorf("Error reading config file: %s", err)
 	}
 
+	// expand environment variables
+	expandedFileBytes := []byte(os.ExpandEnv(string(fileBytes)))
+	fmt.Println(string(expandedFileBytes))
+
 	var gc generalConfig
-	if err := yaml.Unmarshal([]byte(fileBytes), &gc); err != nil {
+	if err := yaml.Unmarshal([]byte(expandedFileBytes), &gc); err != nil {
 		return nil, fmt.Errorf("Error parsing config file: %s", err)
 	}
 	return &gc, nil

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -182,7 +182,6 @@ func readConfig(fullConfigPath string) (*generalConfig, error) {
 
 	// expand environment variables
 	expandedFileBytes := []byte(os.ExpandEnv(string(fileBytes)))
-	fmt.Println(string(expandedFileBytes))
 
 	var gc generalConfig
 	if err := yaml.Unmarshal([]byte(expandedFileBytes), &gc); err != nil {


### PR DESCRIPTION
## What?
Adds expansion of environment variables in the BuildBuddy config file.

## Why?
My main motivation for this to be able to keep secrets out of the configmap and inject them via environment variables.

## How?
Using the `os.ExpandEnv` function which expands all environment variables that are of the form `${ENV_VAR}` in a string.