### PR TITLE
Usability improvements and fixes for the flame chart

### DIFF
--- a/app/flame_chart/flame_chart.tsx
+++ b/app/flame_chart/flame_chart.tsx
@@ -39,6 +39,7 @@ export default class FlameChart extends React.Component<FlameChartProps, Profile
 
   private subscription = new Subscription();
 
+  private rulerRef = React.createRef<HTMLDivElement>();
   private viewportRef = React.createRef<HTMLDivElement>();
   private barsContainerRef = React.createRef<SVGSVGElement>();
   private headerRef = React.createRef<SVGGElement>();
@@ -59,16 +60,25 @@ export default class FlameChart extends React.Component<FlameChartProps, Profile
   private chartModel: FlameChartModel;
   private buildDuration: number;
 
-  constructor(props: FlameChartProps) {
-    super(props);
-
-    this.chartModel = buildFlameChartModel(props.profile.traceEvents);
+  componentDidMount() {
     this.buildDuration = Math.max(
-      ...props.profile.traceEvents.map((event) => (event.ts || 0) + (event.dur || 0))
+      ...this.props.profile.traceEvents.map((event) => (event.ts || 0) + (event.dur || 0))
     );
+    const rulerWidth = this.rulerRef.current.getBoundingClientRect().width;
+    const singlePixelDuration = this.buildDuration / rulerWidth;
+
+    this.chartModel = buildFlameChartModel(this.props.profile.traceEvents, {
+      visibilityThreshold: singlePixelDuration,
+    });
+
+    // Re-render now that the chart model has been computed with the container
+    // dimensions taken into account.
+    this.forceUpdate();
   }
 
-  componentDidMount() {
+  componentDidUpdate() {
+    if (!this.chartModel) return;
+
     this.viewport = this.viewportRef.current;
     this.barsContainerSvg = this.barsContainerRef.current;
     this.header = this.headerRef.current;
@@ -330,6 +340,12 @@ export default class FlameChart extends React.Component<FlameChartProps, Profile
   }
 
   render() {
+    if (!this.chartModel) {
+      // Return a div that is used to measure the area where the chart
+      // will be rendered.
+      return <div ref={this.rulerRef} />;
+    }
+
     // TODO: empty state
     return (
       <>

--- a/app/flame_chart/flame_chart.tsx
+++ b/app/flame_chart/flame_chart.tsx
@@ -13,16 +13,11 @@ import {
   SECTION_LABEL_HEIGHT,
   TIMESTAMP_FONT_SIZE,
   TIMESTAMP_HEADER_SIZE,
+  VERTICAL_SCROLLBAR_WIDTH,
 } from "./style_constants";
 
-// These are non-tweakable constants; tweakable values should be defined
-// in style_constants.ts
-const MICROSECONDS_TO_SECONDS = 0.000001;
-const VERTICAL_SCROLLBAR_WIDTH = 16; //Must match CSS styling
-
-type ProfileFlameChartState = {
-  hoveredBlock: BlockModel | null;
-};
+// NOTE: Do not add state to the flame chart since it is expensive to re-render.
+type ProfileFlameChartState = {};
 
 export type FlameChartProps = {
   profile: {
@@ -31,8 +26,6 @@ export type FlameChartProps = {
 };
 
 export default class FlameChart extends React.Component<FlameChartProps, ProfileFlameChartState> {
-  state: ProfileFlameChartState = { hoveredBlock: null };
-
   private animation = new AnimationLoop((dt: number) => this.draw(dt));
 
   private isDebugEnabled = window.localStorage.getItem("buildbuddy://debug/flame-chart") === "true";
@@ -53,6 +46,7 @@ export default class FlameChart extends React.Component<FlameChartProps, Profile
   private gridlinesRef = React.createRef<SVGGElement>();
   private debugRef = React.createRef<HTMLPreElement>();
   private horizontalScrollbarRef = React.createRef<HorizontalScrollbar>();
+  private hoveredBlockInfoRef = React.createRef<HoveredBlockInfo>();
 
   private viewport: HTMLDivElement;
   private barsContainerSvg: SVGSVGElement;
@@ -63,11 +57,15 @@ export default class FlameChart extends React.Component<FlameChartProps, Profile
   private horizontalScrollbar: HorizontalScrollbar;
 
   private chartModel: FlameChartModel;
+  private buildDuration: number;
 
   constructor(props: FlameChartProps) {
     super(props);
 
     this.chartModel = buildFlameChartModel(props.profile.traceEvents);
+    this.buildDuration = Math.max(
+      ...props.profile.traceEvents.map((event) => (event.ts || 0) + (event.dur || 0))
+    );
   }
 
   componentDidMount() {
@@ -104,7 +102,7 @@ export default class FlameChart extends React.Component<FlameChartProps, Profile
   }
 
   private onHoverBlock(hoveredBlock: BlockModel) {
-    this.setState({ hoveredBlock });
+    this.hoveredBlockInfoRef.current?.setState({ block: hoveredBlock });
   }
 
   private setMaxXCoordinate(value: number) {
@@ -125,7 +123,8 @@ export default class FlameChart extends React.Component<FlameChartProps, Profile
     return this.barsContainerSvg.clientWidth / this.endTimeSeconds;
   }
   private getMaxPixelsPerSecond() {
-    return this.barsContainerSvg.clientWidth / this.secondsPerX;
+    // Don't allow zooming in more than 1ms per 100 pixels.
+    return 100 / 0.001;
   }
 
   private draw(dt: number) {
@@ -232,7 +231,7 @@ export default class FlameChart extends React.Component<FlameChartProps, Profile
   }
 
   private get secondsPerX() {
-    return MICROSECONDS_TO_SECONDS;
+    return 1;
   }
 
   private updateDOM() {
@@ -432,7 +431,7 @@ export default class FlameChart extends React.Component<FlameChartProps, Profile
             />
           </div>
         </div>
-        <HoveredBlockInfo block={this.state.hoveredBlock} />
+        <HoveredBlockInfo ref={this.hoveredBlockInfoRef} buildDuration={this.buildDuration} />
       </>
     );
   }
@@ -443,11 +442,16 @@ export default class FlameChart extends React.Component<FlameChartProps, Profile
   }
 }
 
-type HoveredBlockInfoProps = { block: BlockModel };
+type HoveredBlockInfoState = { block?: BlockModel };
 
-class HoveredBlockInfo extends React.Component<HoveredBlockInfoProps> {
+const MICROSECONDS_PER_SECOND = 1_000_000;
+
+class HoveredBlockInfo extends React.Component<{ buildDuration: number }, HoveredBlockInfoState> {
+  state: HoveredBlockInfoState = {};
+
   render() {
-    const { block } = this.props;
+    const { block } = this.state;
+    const { buildDuration } = this.props;
 
     if (!block) {
       return (
@@ -458,13 +462,26 @@ class HoveredBlockInfo extends React.Component<HoveredBlockInfoProps> {
     }
 
     const {
-      event: { name, cat: category },
+      event: { name, cat: category, ts, dur },
     } = block;
+
+    const buildFraction = ((dur / buildDuration) * 100).toFixed(2);
+    const percentage = buildFraction ? `${buildFraction} %` : "< 0.01 %";
 
     return (
       <div className="flame-chart-hovered-block-info">
         <div className="hovered-block-title">{name}</div>
-        <div className="hovered-block-details">{category}</div>
+        <div className="hovered-block-details">
+          <div>{category}</div>
+          <div>
+            <span className="data">{ts / MICROSECONDS_PER_SECOND}</span> seconds &ndash;{" "}
+            <span className="data">{(ts + dur) / MICROSECONDS_PER_SECOND}</span> seconds
+          </div>
+          <div>
+            <span className="data">{dur / MICROSECONDS_PER_SECOND}</span> seconds total (
+            <span className="data">{percentage}</span> of total build duration)
+          </div>
+        </div>
       </div>
     );
   }

--- a/app/flame_chart/flame_chart_model.ts
+++ b/app/flame_chart/flame_chart_model.ts
@@ -8,6 +8,8 @@ import {
   SECTION_PADDING_TOP,
 } from "./style_constants";
 
+const MICROSECONDS_PER_SECOND = 1000 * 1000;
+
 export type FlameChartModel = {
   sections: SectionDecorationModel[];
   blocks: BlockModel[];
@@ -55,29 +57,26 @@ export function buildFlameChartModel(events: TraceEvent[]): FlameChartModel {
   const blocks: BlockModel[] = [];
 
   for (const { threadName, events, maxDepth } of timelines) {
+    if (!events.length) continue;
+
     blocks.push(
-      ...events
-        .map((event) => {
-          const { ts, dur, cat, tid, name, depth } = event;
-          if (ts === undefined || dur === undefined || cat === undefined || tid === undefined) {
-            console.debug("Skipping trace event", { ts, dur, cat, tid });
-            return null;
-          }
-          return {
-            rectProps: {
-              x: ts,
-              width: dur,
-              y:
-                currentThreadY +
-                depth * (BLOCK_HEIGHT + BLOCK_VERTICAL_GAP) +
-                SECTION_LABEL_HEIGHT +
-                SECTION_PADDING_TOP,
-              fill: getColor(`${cat}#${name}`),
-            },
-            event,
-          };
-        })
-        .filter(Boolean)
+      ...events.map((event) => {
+        const { ts, dur, cat, name, depth } = event;
+
+        return {
+          rectProps: {
+            x: ts / MICROSECONDS_PER_SECOND,
+            width: dur / MICROSECONDS_PER_SECOND,
+            y:
+              currentThreadY +
+              depth * (BLOCK_HEIGHT + BLOCK_VERTICAL_GAP) +
+              SECTION_LABEL_HEIGHT +
+              SECTION_PADDING_TOP,
+            fill: getColor(`${cat}#${name}`),
+          },
+          event,
+        };
+      })
     );
 
     const sectionHeight =

--- a/app/flame_chart/flame_chart_model.ts
+++ b/app/flame_chart/flame_chart_model.ts
@@ -49,10 +49,13 @@ function hash(value: string) {
   return hash;
 }
 
-export function buildFlameChartModel(events: TraceEvent[]): FlameChartModel {
+export function buildFlameChartModel(
+  events: TraceEvent[],
+  { visibilityThreshold = 0 } = {}
+): FlameChartModel {
   let currentThreadY = 0;
 
-  const timelines = buildThreadTimelines(events);
+  const timelines = buildThreadTimelines(events, { visibilityThreshold });
   const sections: SectionDecorationModel[] = [];
   const blocks: BlockModel[] = [];
 

--- a/app/flame_chart/profile_model.ts
+++ b/app/flame_chart/profile_model.ts
@@ -31,14 +31,14 @@ function eventComparator(a: TraceEvent, b: TraceEvent) {
   const threadIdDiff = a.tid - b.tid;
   if (threadIdDiff !== 0) return threadIdDiff;
 
-  // Order in increasing order of start time.
+  // Sort in increasing order of start time.
   const tsDiff = a.ts - b.ts;
   if (tsDiff !== 0) return tsDiff;
 
   // When two events have the same start time, longer events should come first, since
   // those are considered the parent events of the shorter events and we want to push them
   // to the stack first.
-  const durationDiff = a.dur - b.dur;
+  const durationDiff = b.dur - a.dur;
   return durationDiff;
 }
 

--- a/app/flame_chart/profile_model.ts
+++ b/app/flame_chart/profile_model.ts
@@ -42,12 +42,6 @@ function eventComparator(a: TraceEvent, b: TraceEvent) {
   return durationDiff;
 }
 
-// Don't show events smaller than 1ms for now.
-const EVENT_VISIBILITY_THRESHOLD_MICROSECONDS = 1 * 1000;
-// Don't show events that are a tiny fraction of the longest build event time.
-// These events probably aren't worth optimizing for most people.
-const EVENT_VISIBILITY_THRESHOLD_FRACTION_OF_LONGEST_EVENT = 0.0025;
-
 function getThreadNames(events: TraceEvent[]) {
   const threadNameByTid = new Map<number, string>();
   for (const event of events as ThreadEvent[]) {
@@ -62,14 +56,11 @@ function getThreadNames(events: TraceEvent[]) {
  * Builds the ThreadTimeline structures given the flat list of trace events
  * from the profile.
  */
-export function buildThreadTimelines(events: TraceEvent[]): ThreadTimeline[] {
+export function buildThreadTimelines(
+  events: TraceEvent[],
+  { visibilityThreshold = 0 } = {}
+): ThreadTimeline[] {
   const threadNameByTid = getThreadNames(events);
-
-  const longestEvent = Math.max(...events.map((event) => event.dur || 0));
-  const visibilityThreshold = Math.max(
-    EVENT_VISIBILITY_THRESHOLD_MICROSECONDS,
-    longestEvent * EVENT_VISIBILITY_THRESHOLD_FRACTION_OF_LONGEST_EVENT
-  );
 
   events = events.filter(
     (event) =>

--- a/app/flame_chart/profile_model.ts
+++ b/app/flame_chart/profile_model.ts
@@ -27,16 +27,35 @@ export type ThreadTimeline = {
 };
 
 function eventComparator(a: TraceEvent, b: TraceEvent) {
-  const tid = a.tid !== undefined && b.tid !== undefined ? a.tid - b.tid : 0;
-  if (tid !== 0) return tid;
+  // Group by thread ID.
+  const threadIdDiff = a.tid - b.tid;
+  if (threadIdDiff !== 0) return threadIdDiff;
 
-  const ts = a.ts !== undefined && b.ts !== undefined ? a.ts - b.ts : 0;
-  if (ts !== 0) return ts;
+  // Order in increasing order of start time.
+  const tsDiff = a.ts - b.ts;
+  if (tsDiff !== 0) return tsDiff;
 
-  const dur = a.dur !== undefined && b.dur !== undefined ? a.dur - b.dur : 0;
-  if (dur !== 0) return dur;
+  // When two events have the same start time, longer events should come first, since
+  // those are considered the parent events of the shorter events and we want to push them
+  // to the stack first.
+  const durationDiff = a.dur - b.dur;
+  return durationDiff;
+}
 
-  return 0;
+// Don't show events smaller than 1ms for now.
+const EVENT_VISIBILITY_THRESHOLD_MICROSECONDS = 1 * 1000;
+// Don't show events that are a tiny fraction of the longest build event time.
+// These events probably aren't worth optimizing for most people.
+const EVENT_VISIBILITY_THRESHOLD_FRACTION_OF_LONGEST_EVENT = 0.0025;
+
+function getThreadNames(events: TraceEvent[]) {
+  const threadNameByTid = new Map<number, string>();
+  for (const event of events as ThreadEvent[]) {
+    if (event.name === "thread_name") {
+      threadNameByTid.set(event.tid, event.args.name);
+    }
+  }
+  return threadNameByTid;
 }
 
 /**
@@ -44,26 +63,33 @@ function eventComparator(a: TraceEvent, b: TraceEvent) {
  * from the profile.
  */
 export function buildThreadTimelines(events: TraceEvent[]): ThreadTimeline[] {
+  const threadNameByTid = getThreadNames(events);
+
+  const longestEvent = Math.max(...events.map((event) => event.dur || 0));
+  const visibilityThreshold = Math.max(
+    EVENT_VISIBILITY_THRESHOLD_MICROSECONDS,
+    longestEvent * EVENT_VISIBILITY_THRESHOLD_FRACTION_OF_LONGEST_EVENT
+  );
+
+  events = events.filter(
+    (event) =>
+      event.tid !== undefined &&
+      event.ts !== undefined &&
+      // Some events have negative timestamps -- ignore these for now.
+      event.ts + event.dur >= 0 &&
+      event.dur &&
+      event.dur > visibilityThreshold
+  );
   events.sort(eventComparator);
 
   const timelines: ThreadTimeline[] = [];
   let tid = null;
   let timeline: ThreadTimeline | null = null;
-  let stack: ThreadEvent[] = [];
-  const threadNameByTid = new Map<number, string>();
+  let stack: ThreadEvent[];
   for (const event of events as ThreadEvent[]) {
-    if (event.name === "thread_name") {
-      threadNameByTid.set(event.tid, event.args.name);
-      continue;
-    }
-
-    if (event.tid === undefined || event.dur === undefined || event.ts === undefined) {
-      continue;
-    }
-
     if (tid === null || event.tid !== tid) {
-      // Encountered new thread
-      // (Note that events are sorted by tid first)
+      // Encountered new thread, and we're done processing events from the previous thread
+      // (note that events are sorted by tid first)
       tid = event.tid;
       timeline = {
         tid,
@@ -75,12 +101,25 @@ export function buildThreadTimelines(events: TraceEvent[]): ThreadTimeline[] {
       stack = [];
     }
 
-    // Traverse up the stack while the current event starts
-    // after the current stack frame ends.
-    let top = stack[stack.length - 1];
-    while (top && top.ts + top.dur <= event.ts) {
+    // Traverse up the stack to find the first event that this event fits inside. This works
+    // because events are sorted in increasing order of timestamp and ties are broken by sorting
+    // in decreasing order of duration.
+    //
+    // Occasionally, Bazel's profile info will contain an invalid sequence like this:
+    //
+    // E1: |-------|
+    // E2:        |-------|
+    //
+    // This is probably due to imprecise measurements.
+    //
+    // To deal with this, we pop the stack when seeing events like E2. This
+    // results in some overlap but it's hardly noticeable.
+    let top: ThreadEvent;
+    while (
+      (top = stack[stack.length - 1]) &&
+      (top.ts + top.dur < event.ts || top.ts + top.dur < event.ts + event.dur)
+    ) {
       stack.pop();
-      top = stack[stack.length - 1];
     }
     event.depth = stack.length;
     timeline.maxDepth = Math.max(event.depth, timeline.maxDepth);

--- a/app/flame_chart/style_constants.ts
+++ b/app/flame_chart/style_constants.ts
@@ -10,3 +10,6 @@ export const BLOCK_VERTICAL_GAP = 1;
 
 export const INITIAL_END_TIME_SECONDS = 1;
 export const BLOCK_HEIGHT = 16;
+
+// Keep in sync with CSS
+export const VERTICAL_SCROLLBAR_WIDTH = 14;

--- a/app/util/animated_value.ts
+++ b/app/util/animated_value.ts
@@ -69,7 +69,7 @@ export class AnimatedValue {
    * @param dt step time in milliseconds
    * @param options rate and threshold (optional)
    */
-  step(dt: number, { rate = 0.02, threshold = 2 } = {}) {
+  step(dt: number, { rate = 0.02, threshold = 0.000001 } = {}) {
     const distance = this.target_ - this.value_;
     const stepAmount = distance * rate * dt;
 

--- a/static/style.css
+++ b/static/style.css
@@ -1,7 +1,3 @@
-html {
-  --body-text-color: black;
-}
-
 h1,
 h2,
 h3,
@@ -1571,7 +1567,7 @@ code .comment {
 }
 
 .flame-chart-hovered-block-info .data {
-  color: var(--body-text-color);
+  color: #000;
 }
 
 .flame-chart-hovered-block-info.no-block-hovered {

--- a/static/style.css
+++ b/static/style.css
@@ -1508,9 +1508,9 @@ code .comment {
 .horizontal-scroll-track {
   position: absolute;
   bottom: 0;
-  height: 16px;
+  height: var(--scrollbar-width);
   left: 0;
-  right: 16px;
+  right: var(--scrollbar-width);
   background: transparent;
   overflow: hidden;
 }
@@ -1533,7 +1533,7 @@ code .comment {
 }
 
 .viewport::-webkit-scrollbar {
-  width: 16px;
+  width: var(--scrollbar-width);
 }
 
 .horizontal-scroll-thumb:hover,
@@ -1558,6 +1558,8 @@ code .comment {
   overflow: hidden;
 
   user-select: none;
+
+  --scrollbar-width: 16px;
 }
 
 .flame-chart-hovered-block-info {

--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,7 @@
+html {
+  --body-text-color: black;
+}
+
 h1,
 h2,
 h3,
@@ -1554,16 +1558,20 @@ code .comment {
   height: 320px;
   margin: 16px 0;
 
-  border-radius: 4px 2px 8px;
+  border-radius: 4px 2px 4px;
   overflow: hidden;
 
   user-select: none;
 
-  --scrollbar-width: 16px;
+  --scrollbar-width: 14px;
 }
 
 .flame-chart-hovered-block-info {
-  height: 64px;
+  height: 96px;
+}
+
+.flame-chart-hovered-block-info .data {
+  color: var(--body-text-color);
 }
 
 .flame-chart-hovered-block-info.no-block-hovered {
@@ -1580,7 +1588,7 @@ code .comment {
 }
 
 .flame-chart-timestamp-header {
-  fill: rgba(200, 200, 200, 0.8);
+  fill: rgba(220, 220, 220, 0.9);
 }
 
 .flame-chart-section {
@@ -1620,8 +1628,13 @@ code .comment {
   overflow: visible;
 }
 
-.flame-chart rect.hover {
-  stroke: black;
+.flame-chart rect {
   stroke-width: 1;
+  stroke: white;
+  vector-effect: non-scaling-stroke;
+}
+
+.flame-chart rect.hover {
+  opacity: 0.8;
   cursor: pointer;
 }


### PR DESCRIPTION
- Filter out events that are < 1px wide in the initial zoomed out view -- this improves chart performance for large builds and also fixes most cases where a thread timeline would appear empty, but in reality it just had a few events that were a few microseconds long. In these cases we now just hide the thread.
- Mitigate a bug in the timeline-building algorithm where events would sometimes be sorted out of order due to imprecise timing data, and the stack would incorrectly show longer events as children of shorter events.
- Surface event timing info in the area below the chart (start time, end time, duration, and % of build)
- Update the hover effect (opacity instead of stroke). The stroke effect had a visual flicker when zooming in and out, which was hard on the eyes.
- Add a white border around flame chart bars to ensure visual separation between bars that are the same color
- Fix bug that zooming in too far would cause the chart to behave erratically (the fix is to limit the zoom to 1ms / 100px)
- Fix dimensions of the scrollbar