### PR TITLE
De-emphasize timestamp in flame chart hovercard

### DIFF
--- a/app/flame_chart/flame_chart.tsx
+++ b/app/flame_chart/flame_chart.tsx
@@ -550,11 +550,12 @@ class HoveredBlockInfo extends React.Component<{ buildDuration: number }, Hovere
           <div>{category}</div>
 
           <div className="duration">
-            <span className="data">{dur / MICROSECONDS_PER_SECOND}</span> seconds total (
-            <span className="data">{percentage}</span> of total build duration)
+            <span className="data">{truncateDecimals(dur / MICROSECONDS_PER_SECOND, 3)}</span>{" "}
+            seconds total (<span className="data">{percentage}</span> of total build duration)
           </div>
           <div>
-            @ {ts / MICROSECONDS_PER_SECOND} s &ndash; {(ts + dur) / MICROSECONDS_PER_SECOND} s
+            @ {truncateDecimals(ts / MICROSECONDS_PER_SECOND, 3)} s &ndash;{" "}
+            {truncateDecimals((ts + dur) / MICROSECONDS_PER_SECOND, 3)} s
           </div>
         </div>
       </div>

--- a/app/flame_chart/flame_chart.tsx
+++ b/app/flame_chart/flame_chart.tsx
@@ -548,13 +548,13 @@ class HoveredBlockInfo extends React.Component<{ buildDuration: number }, Hovere
         <div className="hovered-block-title">{name}</div>
         <div className="hovered-block-details">
           <div>{category}</div>
-          <div>
-            <span className="data">{ts / MICROSECONDS_PER_SECOND}</span> seconds &ndash;{" "}
-            <span className="data">{(ts + dur) / MICROSECONDS_PER_SECOND}</span> seconds
-          </div>
-          <div>
+
+          <div className="duration">
             <span className="data">{dur / MICROSECONDS_PER_SECOND}</span> seconds total (
             <span className="data">{percentage}</span> of total build duration)
+          </div>
+          <div>
+            @ {ts / MICROSECONDS_PER_SECOND} s &ndash; {(ts + dur) / MICROSECONDS_PER_SECOND} s
           </div>
         </div>
       </div>

--- a/app/flame_chart/flame_chart.tsx
+++ b/app/flame_chart/flame_chart.tsx
@@ -534,6 +534,8 @@ class HoveredBlockInfo extends React.Component<{ buildDuration: number }, Hovere
 
     const buildFraction = ((dur / buildDuration) * 100).toFixed(2);
     const percentage = buildFraction ? `${buildFraction} %` : "< 0.01 %";
+    const duration = truncateDecimals(dur / MICROSECONDS_PER_SECOND, 3);
+    const displayedDuration = duration === 0 ? "< 0.001" : `${duration}`;
 
     return (
       <div
@@ -550,8 +552,8 @@ class HoveredBlockInfo extends React.Component<{ buildDuration: number }, Hovere
           <div>{category}</div>
 
           <div className="duration">
-            <span className="data">{truncateDecimals(dur / MICROSECONDS_PER_SECOND, 3)}</span>{" "}
-            seconds total (<span className="data">{percentage}</span> of total build duration)
+            <span className="data">{displayedDuration}</span> seconds total (
+            <span className="data">{percentage}</span> of total build duration)
           </div>
           <div>
             @ {truncateDecimals(ts / MICROSECONDS_PER_SECOND, 3)} s &ndash;{" "}

--- a/static/style.css
+++ b/static/style.css
@@ -1639,10 +1639,19 @@ code .comment {
 .flame-chart-hovered-block-info .hovered-block-title {
   font-size: 13px;
   font-weight: bold;
+  margin-bottom: -2px;
 }
 
 .flame-chart-hovered-block-info .hovered-block-details {
   color: #888;
+}
+
+.flame-chart-hovered-block-info .duration {
+  font-size: 14px;
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid #eee;
+  margin-bottom: 4px;
 }
 
 .flame-chart-timestamp-header {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2414826/93361044-5e18ba00-f812-11ea-8805-2640b0da760a.png)
