### PR TITLE
Run bazel build on pre-push

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged",
+      "pre-push": "bazel build server"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
This is mostly for people like me since I can be very eager to send PRs, and often I'll realize I forgot to check whether the server builds until after the code is already up for review (at that point, someone may already be reviewing broken code).

Pre-push makes more sense to me instead of pre-commit, since commits are more frequent and the build can be somewhat slow at times.

Can be circumvented in trying times using `--no-verify`