### PR TITLE
Add methods to auth service to support group creation and selection

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -5,6 +5,8 @@ import { grp } from "../../proto/group_ts_proto";
 import { context } from "../../proto/context_ts_proto";
 import capabilities from "../capabilities/capabilities";
 
+const SELECTED_GROUP_ID_LOCAL_STORAGE_KEY = "buildbuddy://auth/selected_group_id";
+
 export class User {
   displayUser: user.DisplayUser;
   groups: grp.Group[];
@@ -85,6 +87,10 @@ export class AuthService {
     requestContext.userId = new user.UserId();
     requestContext.userId.id = userIdFromCookie;
     return requestContext;
+  }
+
+  setSelectedGroupId(groupId: string) {
+    window.localStorage[SELECTED_GROUP_ID_LOCAL_STORAGE_KEY] = groupId;
   }
 
   login() {

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -97,6 +97,12 @@ export class AuthService {
 
   setSelectedGroupId(groupId: string) {
     window.localStorage[SELECTED_GROUP_ID_LOCAL_STORAGE_KEY] = groupId;
+    const selectedGroup = this.user.groups.find((group) => group.id === groupId);
+    if (!selectedGroup) {
+      this.refreshUser();
+    } else {
+      this.emitUser(Object.assign(new User(), this.user, { selectedGroup }));
+    }
   }
 
   login() {

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -5,7 +5,7 @@ import { grp } from "../../proto/group_ts_proto";
 import { context } from "../../proto/context_ts_proto";
 import capabilities from "../capabilities/capabilities";
 
-const SELECTED_GROUP_ID_LOCAL_STORAGE_KEY = "buildbuddy://auth/selected_group_id";
+const SELECTED_GROUP_ID_LOCAL_STORAGE_KEY = "selected_group_id";
 
 export class User {
   displayUser: user.DisplayUser;
@@ -47,6 +47,12 @@ export class AuthService {
           this.emitUser(null);
         }
       });
+  }
+
+  refreshUser() {
+    rpcService.service.getUser(new user.GetUserRequest()).then((response: user.GetUserResponse) => {
+      this.emitUser(this.userFromResponse(response));
+    });
   }
 
   createUser() {


### PR DESCRIPTION
The `selected_group_id` in `localStorage` is consumed in PR #73 to populate the request context. This PR allows setting that group ID after creating a group, or by using a group picker.