### PR TITLE
Add GetGroup API

### DIFF
--- a/proto/buildbuddy_service.proto
+++ b/proto/buildbuddy_service.proto
@@ -24,6 +24,8 @@ service BuildBuddyService {
   rpc GetInvocationStat(invocation.GetInvocationStatRequest)
       returns (invocation.GetInvocationStatResponse);
 
+  rpc GetGroup(grp.GetGroupRequest) returns (grp.GetGroupResponse);
+
   rpc CreateGroup(grp.CreateGroupRequest) returns (grp.CreateGroupResponse);
 
   rpc UpdateGroup(grp.UpdateGroupRequest) returns (grp.UpdateGroupResponse);

--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -32,6 +32,16 @@ message GetGroupRequest {
   string url_identifier = 1;
 }
 
+message GetGroupResponse {
+  // The unique ID of the group.
+  // Ex. "GR4576963743584254779"
+  string id = 1;
+
+  // The name of this group (may be displayed to users).
+  // Ex. "Tyler Williams Group"
+  string name = 2;
+}
+
 message CreateGroupRequest {
   // The name of this group (may be displayed to users).
   // Ex. "Tyler Williams Group"

--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -29,6 +29,13 @@ message Group {
 }
 
 message GetGroupRequest {
+  // The unique URL segment for this group which is used
+  // to construct nice-looking URLs for this group, such as
+  // https://app.buildbuddy.com/join/:url-identifier
+  //
+  // May consist of only lowercase ASCII letters (a-z) and hyphens.
+  //
+  // Ex: "iteration-inc"
   string url_identifier = 1;
 }
 

--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -28,6 +28,10 @@ message Group {
   string url_identifier = 5;
 }
 
+message GetGroupRequest {
+  string url_identifier = 1;
+}
+
 message CreateGroupRequest {
   // The name of this group (may be displayed to users).
   // Ex. "Tyler Williams Group"

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -133,7 +133,7 @@ func (s *BuildBuddyServer) GetGroup(ctx context.Context, req *grpb.GetGroupReque
 		// NOTE: this RPC does not require authentication, so sensitive group
 		// info should not be exposed here.
 		Name: group.Name,
-	}
+	}, nil
 }
 
 func (s *BuildBuddyServer) CreateGroup(ctx context.Context, req *grpb.CreateGroupRequest) (*grpb.CreateGroupResponse, error) {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -125,7 +125,7 @@ func (s *BuildBuddyServer) GetGroup(ctx context.Context, req *grpb.GetGroupReque
 	group := &tables.Group{
 		URLIdentifier: req.UrlIdentifier,
 	}
-	if err := userDB.FillGroup(group); err != nil {
+	if err := userDB.FillGroup(ctx, group); err != nil {
 		return err
 	}
 	return &grpb.GetGroupResponse{

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -117,6 +117,21 @@ func (s *BuildBuddyServer) CreateUser(ctx context.Context, req *uspb.CreateUserR
 	}, nil
 }
 
+func (s *BuildBuddyServer) GetGroup(ctx context.Context, req *grpb.GetGroupRequest) (*grpb.GetGroupResponse, error) {
+	userDB := s.env.GetUserDB()
+	group := &tables.Group{
+		URLIdentifier: req.UrlIdentifier
+	}
+	if err := userDB.FillGroup(group); err != nil {
+		return err
+	}
+	return &grpb.GetGroupResponse{
+		// NOTE: this RPC does not require authentication, so sensitive group
+		// info should not be exposed here.
+		Name: group.Name
+	}
+}
+
 func (s *BuildBuddyServer) CreateGroup(ctx context.Context, req *grpb.CreateGroupRequest) (*grpb.CreateGroupResponse, error) {
 	auth := s.env.GetAuthenticator()
 	userDB := s.env.GetUserDB()

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -126,7 +126,7 @@ func (s *BuildBuddyServer) GetGroup(ctx context.Context, req *grpb.GetGroupReque
 		URLIdentifier: req.UrlIdentifier,
 	}
 	if err := userDB.FillGroup(ctx, group); err != nil {
-		return err
+		return nil, err
 	}
 	return &grpb.GetGroupResponse{
 		Id: group.GroupID,

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -119,6 +119,9 @@ func (s *BuildBuddyServer) CreateUser(ctx context.Context, req *uspb.CreateUserR
 
 func (s *BuildBuddyServer) GetGroup(ctx context.Context, req *grpb.GetGroupRequest) (*grpb.GetGroupResponse, error) {
 	userDB := s.env.GetUserDB()
+	if userDB == nil {
+		return nil, status.UnimplementedError("Not Implemented")
+	}
 	group := &tables.Group{
 		URLIdentifier: req.UrlIdentifier
 	}

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -126,6 +126,7 @@ func (s *BuildBuddyServer) GetGroup(ctx context.Context, req *grpb.GetGroupReque
 		return err
 	}
 	return &grpb.GetGroupResponse{
+		Id: group.GroupID
 		// NOTE: this RPC does not require authentication, so sensitive group
 		// info should not be exposed here.
 		Name: group.Name

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -123,7 +123,7 @@ func (s *BuildBuddyServer) GetGroup(ctx context.Context, req *grpb.GetGroupReque
 		return nil, status.UnimplementedError("Not Implemented")
 	}
 	group := &tables.Group{
-		URLIdentifier: req.UrlIdentifier
+		URLIdentifier: req.UrlIdentifier,
 	}
 	if err := userDB.FillGroup(group); err != nil {
 		return err

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -129,10 +129,10 @@ func (s *BuildBuddyServer) GetGroup(ctx context.Context, req *grpb.GetGroupReque
 		return err
 	}
 	return &grpb.GetGroupResponse{
-		Id: group.GroupID
+		Id: group.GroupID,
 		// NOTE: this RPC does not require authentication, so sensitive group
 		// info should not be exposed here.
-		Name: group.Name
+		Name: group.Name,
 	}
 }
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -141,7 +141,7 @@ type UserDB interface {
 	InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (string, error)
 	AddUserToGroup(ctx context.Context, userID string, groupID string) error
 	// Takes a group with url_identifier set and fills the remaining fields.
-	FillGroup(ctx context.Context, *tables.Group) error
+	FillGroup(ctx context.Context, g *tables.Group) error
 	GetAuthGroup(ctx context.Context) (*tables.Group, error)
 	DeleteGroup(ctx context.Context, groupID string) error
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -140,6 +140,8 @@ type UserDB interface {
 	// Groups API
 	InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (string, error)
 	AddUserToGroup(ctx context.Context, userID string, groupID string) error
+	// Takes a group with identifying properties and fills the remaining fields.
+	FillGroup(ctx context.Context, *tables.Group) error
 	GetAuthGroup(ctx context.Context) (*tables.Group, error)
 	DeleteGroup(ctx context.Context, groupID string) error
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -140,7 +140,7 @@ type UserDB interface {
 	// Groups API
 	InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (string, error)
 	AddUserToGroup(ctx context.Context, userID string, groupID string) error
-	// Takes a group with identifying properties and fills the remaining fields.
+	// Takes a group with url_identifier set and fills the remaining fields.
 	FillGroup(ctx context.Context, *tables.Group) error
 	GetAuthGroup(ctx context.Context) (*tables.Group, error)
 	DeleteGroup(ctx context.Context, groupID string) error


### PR DESCRIPTION
This API is used to get public group info from a group's slug, e.g. `app.buildbuddy.io/join/example-dot-com` will show "Sign in to join Example.com on BuildBuddy"