### PR TITLE
Remove unique_index temporarily from URLIdentifier column

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -145,7 +145,7 @@ type Group struct {
 	// An unique URL segment that is displayed in group-related URLs.
 	// e.g. "example-org" in app.buildbuddy.com/join/example-org or
 	// "example-org.buildbuddy.com" if we support subdomains in the future.
-	URLIdentifier string `gorm:"unique_index"`
+	URLIdentifier string `gorm:"index:url_identifier_index"`
 
 	// The "owned" domain. In enterprise/cloud version, we create a
 	// group for a customer's domain, and new users that sign up with an


### PR DESCRIPTION
`unique_index` is causing a unique constraint violation since empty strings are inserted when we create per-user groups. Reverting for now since this would prevent new users from being created if pushed to prod. (Approver can feel free to merge after approving)