### PR TITLE
Add flag to disable per test target Github status

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -151,9 +151,10 @@ type APIConfig struct {
 }
 
 type GithubConfig struct {
-	ClientID     string `yaml:"client_id"`
-	ClientSecret string `yaml:"client_secret"`
-	AccessToken  string `yaml:"access_token"`
+	ClientID            string `yaml:"client_id"`
+	ClientSecret        string `yaml:"client_secret"`
+	AccessToken         string `yaml:"access_token"`
+	StatusPerTestTarget *bool  `yaml:"status_per_test_target"`
 }
 
 type OrgConfig struct {


### PR DESCRIPTION
## What?
Adds a new config variable that disables/enables the status-per-test-target funcitonality that exists now.

## Why?
When you have hundreds or thousands of test targets the status indicators become very hard to navigate. In this case it might make more sense for the end user to explore the whole invocation instead.