### PR TITLE
Extract metadata from Gitlab CI env vars

### DIFF
--- a/docs/guide-metadata.md
+++ b/docs/guide-metadata.md
@@ -36,7 +36,7 @@ Then you'll need to add a `workspace_status.sh` file to the root of your workspa
 
 ### Environment variables
 
-BuildBuddy will automatically pull your repo URL from environment variables if you're using a common CI platform like Github Actions, CircleCI, Travis, or BuildKite. The environment variables currently supported are `GITHUB_REPOSITORY`, `CIRCLE_REPOSITORY_URL`, `BUILDKITE_REPO`, and `TRAVIS_REPO_SLUG`.
+BuildBuddy will automatically pull your repo URL from environment variables if you're using a common CI platform like Github Actions, CircleCI, Travis, Gitlab CI, or BuildKite. The environment variables currently supported are `GITHUB_REPOSITORY`, `CIRCLE_REPOSITORY_URL`, `TRAVIS_REPO_SLUG`, `CI_REPOSITORY_URL`, and `BUILDKITE_REPO`.
 
 ## Commit SHA
 
@@ -64,7 +64,7 @@ Then you'll need to add a `workspace_status.sh` file to the root of your workspa
 
 ### Environment variables
 
-BuildBuddy will automatically pull your commit SHA from environment variables if you're using a common CI platform like Github Actions, CircleCI, Travis, or BuildKite. The environment variables currently supported are `GITHUB_SHA`, `CIRCLE_SHA1`, `BUILDKITE_COMMIT`, and `TRAVIS_COMMIT`.
+BuildBuddy will automatically pull your commit SHA from environment variables if you're using a common CI platform like Github Actions, CircleCI, Travis, Gitlab CI, or BuildKite. The environment variables currently supported are `GITHUB_SHA`, `CIRCLE_SHA1`, `TRAVIS_COMMIT`, `CI_COMMIT_SHA`, and `BUILDKITE_COMMIT`.
 
 ## Role
 
@@ -76,7 +76,7 @@ For CI builds, you can add the following line to your `.bazelrc` and run your CI
 build:ci --build_metadata=ROLE=CI
 ```
 
-This role will automatically be populated if the environment variable `CI` is set, which it is in most CI systems like CircleCI, BuildKite, Github Actions, Travis, and others.
+This role will automatically be populated if the environment variable `CI` is set, which it is in most CI systems like Github Actions, CircleCI, Travis, Gitlab CI, BuildKite, and others.
 
 ## Test groups
 

--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -117,17 +117,21 @@ func (r *BuildStatusReporter) populateWorkspaceInfoFromStructuredCommandLine(com
 			continue
 		}
 		for _, option := range section.GetOptionList().Option {
-			if option.OptionName != "ENV" {
+			if option.OptionName != "ENV" && option.OptionName != "client_env" {
 				continue
 			}
 			parts := strings.Split(option.OptionValue, "=")
-			if len(parts) == 2 && (parts[0] == "CIRCLE_REPOSITORY_URL" || parts[0] == "GITHUB_REPOSITORY" || parts[0] == "BUILDKITE_REPO" || parts[0] == "TRAVIS_REPO_SLUG") {
-				r.repoURL = parts[1]
+			if len(parts) != 2 {
+				continue
 			}
-			if len(parts) == 2 && (parts[0] == "CIRCLE_SHA1" || parts[0] == "GITHUB_SHA" || parts[0] == "BUILDKITE_COMMIT" || parts[0] == "TRAVIS_COMMIT") {
-				r.commitSHA = parts[1]
-			}
-			if len(parts) == 2 && parts[0] == "CI" && parts[1] != "" {
+			environmentVariable := parts[0]
+			value := parts[1]
+			switch environmentVariable {
+			case "CIRCLE_REPOSITORY_URL","GITHUB_REPOSITORY","BUILDKITE_REPO","TRAVIS_REPO_SLUG","CI_REPOSITORY_URL":
+				r.repoURL = value
+			case "CIRCLE_SHA1","GITHUB_SHA","BUILDKITE_COMMIT","TRAVIS_COMMIT","CI_COMMIT_SHA":
+				r.commitSHA = value
+			case "CI":
 				r.role = "CI"
 			}
 		}

--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -289,6 +289,15 @@ func fillInvocationFromStructuredCommandLine(commandLine *command_line.CommandLi
 	if ci, ok := envVarMap["CI"]; ok && ci != "" {
 		invocation.Role = "CI"
 	}
+
+	// Gitlab CI Environment Variables
+	// https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+	if url, ok := envVarMap["CI_REPOSITORY_URL"]; ok && url != "" {
+		invocation.RepoUrl = url
+	}
+	if sha, ok := envVarMap["CI_COMMIT_SHA"]; ok && sha != "" {
+		invocation.CommitSha = sha
+	}
 }
 
 func fillInvocationFromWorkspaceStatus(workspaceStatus *build_event_stream.WorkspaceStatus, invocation *inpb.Invocation) {


### PR DESCRIPTION
I saw BB didn't mention Gitlab CI as supported in it's docs. I did some grepping around and found everywhere I could find travis mentioned and added similar code as what is used to support travis CI. I think this is a quick hack to pull this build metadata out and I think a better solution would be to pull all of the hard coded strings being mentioned in here from some configuration but I don't know how you'd prefer to do that so I just stuck to what was there. 

Thanks! 