### PR TITLE
Move user_id proto to its own target and package

### DIFF
--- a/app/auth/BUILD
+++ b/app/auth/BUILD
@@ -10,6 +10,7 @@ ts_library(
         "//app/service",
         "//proto:context_ts_proto",
         "//proto:group_ts_proto",
+        "//proto:user_id_ts_proto",
         "//proto:user_ts_proto",
         "@npm//rxjs",
     ],

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -1,14 +1,15 @@
 import { Subject } from "rxjs";
-import rpcService from "../service/rpc_service";
-import { user } from "../../proto/user_ts_proto";
-import { grp } from "../../proto/group_ts_proto";
 import { context } from "../../proto/context_ts_proto";
+import { grp } from "../../proto/group_ts_proto";
+import { user_id } from "../../proto/user_id_ts_proto";
+import { user } from "../../proto/user_ts_proto";
 import capabilities from "../capabilities/capabilities";
+import rpcService from "../service/rpc_service";
 
 const SELECTED_GROUP_ID_LOCAL_STORAGE_KEY = "selected_group_id";
 
 export class User {
-  displayUser: user.DisplayUser;
+  displayUser: user_id.DisplayUser;
   groups: grp.Group[];
   selectedGroup: grp.Group;
 
@@ -71,7 +72,7 @@ export class AuthService {
 
   userFromResponse(response: user.GetUserResponse) {
     let user = new User();
-    user.displayUser = response.displayUser as user.DisplayUser;
+    user.displayUser = response.displayUser as user_id.DisplayUser;
     user.groups = response.userGroup as grp.Group[];
     let selectedGroupId = window.localStorage.getItem(SELECTED_GROUP_ID_LOCAL_STORAGE_KEY);
     if (user.groups.length > 0) {
@@ -94,7 +95,7 @@ export class AuthService {
     let match = document.cookie.match("(^|[^;]+)\\s*" + cookieName + "\\s*=\\s*([^;]+)");
     let userIdFromCookie = match ? match.pop() : "";
     let requestContext = new context.RequestContext();
-    requestContext.userId = new user.UserId();
+    requestContext.userId = new user_id.UserId();
     requestContext.userId.id = userIdFromCookie;
     requestContext.groupId = this.user?.selectedGroup?.id || "";
     return requestContext;

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -106,13 +106,17 @@ proto_library(
 
 proto_library(
     name = "user_proto",
-    srcs = [
-        "user.proto",
-        "user_id.proto",
-    ],
+    srcs = ["user.proto"],
     deps = [
+        ":user_id_proto",
         ":group_proto",
     ],
+    exports = [":user_id_proto"]
+)
+
+proto_library(
+    name = "user_id_proto",
+    srcs = ["user_id.proto"],
 )
 
 proto_library(
@@ -127,7 +131,7 @@ proto_library(
     name = "context_proto",
     srcs = ["context.proto"],
     deps = [
-        "user_proto",
+        ":user_id_proto",
     ],
 )
 
@@ -305,11 +309,18 @@ go_proto_library(
 )
 
 go_proto_library(
+    name = "user_id_go_proto",
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/user_id",
+    proto = ":user_id_proto",
+)
+
+go_proto_library(
     name = "user_go_proto",
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/user",
     proto = ":user_proto",
     deps = [
         ":group_go_proto",
+        ":user_id_go_proto",
     ],
 )
 
@@ -330,7 +341,7 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/context",
     proto = ":context_proto",
     deps = [
-        ":user_go_proto",
+        ":user_id_go_proto",
     ],
 )
 
@@ -422,6 +433,11 @@ ts_proto_library(
 ts_proto_library(
     name = "cache_ts_proto",
     deps = [":cache_proto"],
+)
+
+ts_proto_library(
+    name = "user_id_ts_proto",
+    deps = [":user_id_proto"],
 )
 
 ts_proto_library(

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -107,11 +107,11 @@ proto_library(
 proto_library(
     name = "user_proto",
     srcs = ["user.proto"],
+    exports = [":user_id_proto"],
     deps = [
-        ":user_id_proto",
         ":group_proto",
+        ":user_id_proto",
     ],
-    exports = [":user_id_proto"]
 )
 
 proto_library(

--- a/proto/context.proto
+++ b/proto/context.proto
@@ -5,7 +5,7 @@ import "proto/user_id.proto";
 package context;
 
 message RequestContext {
-  user.UserId user_id = 1;
+  user_id.UserId user_id = 1;
 
   // Group ID for the request.
   //

--- a/proto/user.proto
+++ b/proto/user.proto
@@ -5,10 +5,10 @@ import "proto/user_id.proto";
 
 package user;
 
-message GetUserRequest { UserId user_id = 1; }
+message GetUserRequest { user_id.UserId user_id = 1; }
 
 message GetUserResponse {
-  DisplayUser display_user = 1;
+  user_id.DisplayUser display_user = 1;
 
   // The groups this user is a member of.
   repeated grp.Group user_group = 2;
@@ -21,4 +21,4 @@ message CreateUserRequest {
   // from the authentication provider response.
 }
 
-message CreateUserResponse { DisplayUser display_user = 1; }
+message CreateUserResponse { user_id.DisplayUser display_user = 1; }

--- a/proto/user_id.proto
+++ b/proto/user_id.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package user;
+package user_id;
 
 message UserId {
   // The user's ID according to BuildBuddy.

--- a/server/tables/BUILD
+++ b/server/tables/BUILD
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/tables",
     visibility = ["//visibility:public"],
     deps = [
-        "//proto:user_go_proto",
+        "//proto:user_id_go_proto",
         "//server/util/random:go_default_library",
         "@com_github_jinzhu_gorm//:go_default_library",
     ],

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -7,7 +7,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/jinzhu/gorm"
 
-	uspb "github.com/buildbuddy-io/buildbuddy/proto/user"
+	uspb "github.com/buildbuddy-io/buildbuddy/proto/user_id"
 )
 
 const (


### PR DESCRIPTION
Moved it to a separate proto package to avoid having to do the following in TS code:

```
import {user} from '.../user_ts_proto';
import {user as user_id} from '.../user_id_ts_proto';
```