### PR TITLE
Add manual migration for status column

### DIFF
--- a/server/tables/BUILD
+++ b/server/tables/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/tables",
     visibility = ["//visibility:public"],
     deps = [
+        "//proto:group_go_proto",
         "//proto:user_id_go_proto",
         "//server/util/random:go_default_library",
         "@com_github_jinzhu_gorm//:go_default_library",

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -345,9 +345,8 @@ func (c *CacheLog) TableName() string {
 
 // Manual migration called before auto-migration.
 func PreAutoMigrate(db *gorm.DB) error {
-	m := db.Migrator()
-	if !m.HasColumn(&UserGroup{}, "status") {
-		if err := m.AddColumn(&UserGroup{}, "status"); err != nil {
+	if db.Dialect().HasTable("UserGroups") && !db.Dialect().HasColumn("UserGroups", "membership_status") {
+		if err := db.Exec("ALTER TABLE UserGroups ADD membership_status int"); err != nil {
 			return err
 		}
 		if err := db.Exec("UPDATE UserGroups SET membership_status = ?", int32(grpb.GroupMembershipStatus_MEMBER)); err != nil {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -7,6 +7,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/jinzhu/gorm"
 
+	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
 	uspb "github.com/buildbuddy-io/buildbuddy/proto/user_id"
 )
 
@@ -342,6 +343,11 @@ func (c *CacheLog) TableName() string {
 }
 
 func ManualMigrate(db *gorm.DB) error {
+	m := db.Migrator()
+	if !m.HasColumn(&UserGroup{}, "status") {
+		m.AddColumn(&UserGroup{}, "status")
+		db.Exec("UPDATE UserGroups SET status = ?", int32(grpb.GroupMembershipStatus_MEMBER))
+	}
 	// These types don't apply for sqlite -- just mysql.
 	if db.Dialect().GetName() == mySQLDialect {
 		db.Model(&Invocation{}).ModifyColumn("pattern", "text")

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -346,10 +346,10 @@ func (c *CacheLog) TableName() string {
 // Manual migration called before auto-migration.
 func PreAutoMigrate(db *gorm.DB) error {
 	if db.Dialect().HasTable("UserGroups") && !db.Dialect().HasColumn("UserGroups", "membership_status") {
-		if err := db.Exec("ALTER TABLE UserGroups ADD membership_status int"); err != nil {
+		if err := db.Exec("ALTER TABLE UserGroups ADD membership_status int").Error; err != nil {
 			return err
 		}
-		if err := db.Exec("UPDATE UserGroups SET membership_status = ?", int32(grpb.GroupMembershipStatus_MEMBER)); err != nil {
+		if err := db.Exec("UPDATE UserGroups SET membership_status = ?", int32(grpb.GroupMembershipStatus_MEMBER)).Error; err != nil {
 			return err
 		}
 	}

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -346,7 +346,7 @@ func ManualMigrate(db *gorm.DB) error {
 	m := db.Migrator()
 	if !m.HasColumn(&UserGroup{}, "status") {
 		m.AddColumn(&UserGroup{}, "status")
-		db.Exec("UPDATE UserGroups SET status = ?", int32(grpb.GroupMembershipStatus_MEMBER))
+		db.Exec("UPDATE UserGroups SET membership_status = ?", int32(grpb.GroupMembershipStatus_MEMBER))
 	}
 	// These types don't apply for sqlite -- just mysql.
 	if db.Dialect().GetName() == mySQLDialect {

--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -38,10 +38,13 @@ func NewDBHandle(dialect string, args ...interface{}) (*DBHandle, error) {
 	gdb.SingularTable(true)
 	gdb.LogMode(false)
 	if *autoMigrateDB {
-		if err := tables.ManualMigrate(gdb); err != nil {
+		if err := tables.PreAutoMigrate(gdb); err != nil {
 			return nil, err
 		}
 		gdb.AutoMigrate(tables.GetAllTables()...)
+		if err := tables.PostAutoMigrate(gdb); err != nil {
+			return nil, err
+		}
 	}
 	// SQLITE Special! To avoid "database is locked errors":
 	if dialect == sqliteDialect {

--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -38,10 +38,10 @@ func NewDBHandle(dialect string, args ...interface{}) (*DBHandle, error) {
 	gdb.SingularTable(true)
 	gdb.LogMode(false)
 	if *autoMigrateDB {
-		gdb.AutoMigrate(tables.GetAllTables()...)
 		if err := tables.ManualMigrate(gdb); err != nil {
 			return nil, err
 		}
+		gdb.AutoMigrate(tables.GetAllTables()...)
 	}
 	// SQLITE Special! To avoid "database is locked errors":
 	if dialect == sqliteDialect {


### PR DESCRIPTION
NOTE: This migration will not work for the dev environment since `status` has already been auto-migrated. May need to do a backfill in dev to get this to a good state. Also need to sanity check that the `status` column doesn't yet exist in prod.