### PR TITLE
Download event chunk files from blobstore in parallel

### DIFF
--- a/server/backends/blobstore/BUILD
+++ b/server/backends/blobstore/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//server/config:go_default_library",
         "//server/interfaces:go_default_library",
         "//server/util/disk:go_default_library",
+        "//server/util/status:go_default_library",
         "@com_github_aws_aws_sdk_go//aws:go_default_library",
         "@com_github_aws_aws_sdk_go//aws/awserr:go_default_library",
         "@com_github_aws_aws_sdk_go//aws/credentials:go_default_library",

--- a/server/backends/blobstore/blobstore.go
+++ b/server/backends/blobstore/blobstore.go
@@ -300,7 +300,7 @@ func (a *AwsS3BlobStore) ReadBlob(ctx context.Context, blobName string) ([]byte,
 
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
-			if aerr.Code() == "NotFound" {
+			if aerr.Code() == "NoSuchKey" {
 				return nil, status.NotFoundError(err.Error())
 			}
 		}

--- a/server/util/disk/BUILD
+++ b/server/util/disk/BUILD
@@ -7,5 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/util/random:go_default_library",
+        "//server/util/status:go_default_library",
     ],
 )

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -50,7 +50,11 @@ func WriteFile(ctx context.Context, fullPath string, data []byte) (int, error) {
 }
 
 func ReadFile(ctx context.Context, fullPath string) ([]byte, error) {
-	return ioutil.ReadFile(fullPath)
+	data, err := ioutil.ReadFile(fullPath)
+	if os.IsNotExist(err) {
+		return nil, status.NotFoundError(err.Error())
+	}
+	return data, err
 }
 
 func DeleteFile(ctx context.Context, fullPath string) error {
@@ -73,9 +77,6 @@ func FileExists(ctx context.Context, fullPath string) (bool, error) {
 
 func FileReader(ctx context.Context, fullPath string, offset, length int64) (io.Reader, error) {
 	f, err := os.Open(fullPath)
-	if os.IsNotExist(err) {
-		return nil, status.NotFoundError(err.Error())
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
 
 func EnsureDirectoryExists(dir string) error {
@@ -72,6 +73,9 @@ func FileExists(ctx context.Context, fullPath string) (bool, error) {
 
 func FileReader(ctx context.Context, fullPath string, offset, length int64) (io.Reader, error) {
 	f, err := os.Open(fullPath)
+	if os.IsNotExist(err) {
+		return nil, status.NotFoundError(err.Error())
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/server/util/protofile/BUILD
+++ b/server/util/protofile/BUILD
@@ -9,5 +9,7 @@ go_library(
         "//server/interfaces:go_default_library",
         "//server/util/status:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
     ],
 )

--- a/server/util/protofile/BUILD
+++ b/server/util/protofile/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/interfaces:go_default_library",
+        "//server/util/status:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/server/util/protofile/protofile.go
+++ b/server/util/protofile/protofile.go
@@ -143,7 +143,7 @@ func newBlobQueue(blobstore interfaces.Blobstore, streamID string) *blobQueue {
 	return &blobQueue{
 		blobstore:      blobstore,
 		streamID:       streamID,
-		maxConnections: 8,
+		maxConnections: 16,
 		futures:        make([]blobFuture, 0),
 		numPopped:      0,
 		done:           false,

--- a/server/util/protofile/protofile.go
+++ b/server/util/protofile/protofile.go
@@ -163,24 +163,16 @@ func (q *blobQueue) pushNewFuture(ctx context.Context) {
 
 		tmpFilePath := chunkName(q.streamID, sequenceNumber)
 		data, err := q.blobstore.ReadBlob(ctx, tmpFilePath)
-		if err != nil {
-			future <- blobReadResult{
-				data: nil,
-				err:  err,
-			}
-			return
-		}
-
 		future <- blobReadResult{
 			data: data,
-			err:  nil,
+			err:  err,
 		}
 	}()
 }
 
 func (q *blobQueue) pop(ctx context.Context) ([]byte, error) {
 	if q.done {
-		return nil, status.FailedPreconditionError("Queue has been exhausted.")
+		return nil, status.ResourceExhaustedError("Queue has been exhausted.")
 	}
 	// Make sure maxConnections files are downloading
 	numLoading := len(q.futures) - q.numPopped

--- a/server/util/protofile/protofile.go
+++ b/server/util/protofile/protofile.go
@@ -13,6 +13,9 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/golang/protobuf/proto"
+
+	gcodes "google.golang.org/grpc/codes"
+	gstatus "google.golang.org/grpc/status"
 )
 
 // BufferedProtoWriter chunks together and writes protos to blobstore after
@@ -196,7 +199,10 @@ func (w *BufferedProtoReader) ReadProto(ctx context.Context, msg proto.Message) 
 			// Load file
 			fileData, err := w.q.pop(ctx)
 			if err != nil {
-				return io.EOF
+				if gstatus.Code(err) == gcodes.NotFound {
+					return io.EOF
+				}
+				return err
 			}
 			w.readBuf = bytes.NewBuffer(fileData)
 		}

--- a/server/util/protofile/protofile.go
+++ b/server/util/protofile/protofile.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -38,20 +39,17 @@ type BufferedProtoWriter struct {
 type BufferedProtoReader struct {
 	streamID string
 	bs       interfaces.Blobstore
+	q        *blobQueue
 
 	// Read Variables
-	readMutex          sync.Mutex // protects(readBuf), protects(readSequenceNumber)
-	readBuf            *bytes.Buffer
-	readSequenceNumber int
+	readBuf *bytes.Buffer
 }
 
 func NewBufferedProtoReader(bs interfaces.Blobstore, streamID string) *BufferedProtoReader {
 	return &BufferedProtoReader{
 		streamID: streamID,
 		bs:       bs,
-
-		readBuf:            new(bytes.Buffer),
-		readSequenceNumber: 0,
+		q:        newBlobQueue(bs, streamID),
 	}
 }
 
@@ -125,17 +123,90 @@ func (w *BufferedProtoWriter) WriteProtoToStream(ctx context.Context, msg proto.
 	return nil
 }
 
+type blobReadResult struct {
+	data []byte
+	err  error
+}
+
+type blobFuture chan blobReadResult
+
+type blobQueue struct {
+	blobstore      interfaces.Blobstore
+	streamID       string
+	maxConnections int
+	futures        []blobFuture
+	numPopped      int
+	done           bool
+}
+
+func newBlobQueue(blobstore interfaces.Blobstore, streamID string) *blobQueue {
+	return &blobQueue{
+		blobstore:      blobstore,
+		streamID:       streamID,
+		maxConnections: 8,
+		futures:        make([]blobFuture, 0),
+		numPopped:      0,
+		done:           false,
+	}
+}
+
+func newBlobFuture() blobFuture {
+	return make(blobFuture, 1)
+}
+
+func (q *blobQueue) pushNewFuture(ctx context.Context) {
+	future := newBlobFuture()
+	sequenceNumber := len(q.futures)
+	q.futures = append(q.futures, future)
+	go func() {
+		defer close(future)
+
+		tmpFilePath := chunkName(q.streamID, sequenceNumber)
+		data, err := q.blobstore.ReadBlob(ctx, tmpFilePath)
+		if err != nil {
+			future <- blobReadResult{
+				data: nil,
+				err:  err,
+			}
+			return
+		}
+
+		future <- blobReadResult{
+			data: data,
+			err:  nil,
+		}
+	}()
+}
+
+func (q *blobQueue) pop(ctx context.Context) ([]byte, error) {
+	if q.done {
+		return nil, status.FailedPreconditionError("Queue has been exhausted.")
+	}
+	// Make sure maxConnections files are downloading
+	numLoading := len(q.futures) - q.numPopped
+	numNewConnections := q.maxConnections - numLoading
+	for numNewConnections > 0 {
+		q.pushNewFuture(ctx)
+		numNewConnections--
+	}
+	result := <-q.futures[q.numPopped]
+	q.numPopped++
+	if result.err != nil {
+		q.done = true
+		return nil, result.err
+	}
+	return result.data, nil
+}
+
 func (w *BufferedProtoReader) ReadProto(ctx context.Context, msg proto.Message) error {
 	for {
 		if w.readBuf == nil {
 			// Load file
-			tmpFilePath := chunkName(w.streamID, w.readSequenceNumber)
-			fileData, err := w.bs.ReadBlob(ctx, tmpFilePath)
+			fileData, err := w.q.pop(ctx)
 			if err != nil {
 				return io.EOF
 			}
 			w.readBuf = bytes.NewBuffer(fileData)
-			w.readSequenceNumber += 1
 		}
 		// read proto from buf
 		count, err := binary.ReadVarint(w.readBuf)


### PR DESCRIPTION
Still need to run some benchmarks against GCS to see whether this is actually faster, and not sure whether `maxConnections: 8` is ideal, but sending this out to get some early feedback as to the implementation.