### PR TITLE
Return UNAUTHENTICATED error when API key header is invalid

### DIFF
--- a/server/build_event_protocol/build_event_handler/BUILD
+++ b/server/build_event_protocol/build_event_handler/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//server/tables:go_default_library",
         "//server/util/perms:go_default_library",
         "//server/util/protofile:go_default_library",
+        "//server/util/status:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
     ],

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/protofile"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 
@@ -217,6 +218,13 @@ func (e *EventChannel) HandleEvent(ctx context.Context, event *pepb.PublishBuild
 			}
 			if apiKey := auth.ParseAPIKeyFromString(options); apiKey != "" {
 				ctx = auth.AuthContextFromAPIKey(ctx, apiKey)
+				authError := ctx.Value(interfaces.AuthContextUserErrorKey)
+				if authError != nil {
+					if err, ok := authError.(error); ok {
+						return err
+					}
+					return status.UnknownError(fmt.Sprintf("%v", authError))
+				}
 			}
 		}
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -42,6 +42,11 @@ type UserInfo interface {
 	IsAdmin() bool
 }
 
+// Authenticator constants
+const (
+	AuthContextUserErrorKey = "auth.error"
+)
+
 type Authenticator interface {
 	// Redirect to configured authentication provider.
 	Login(w http.ResponseWriter, r *http.Request)


### PR DESCRIPTION
Since we'll soon provide the ability to manage API keys, it might be an issue that an API key is deleted, and you run a build with an invalid API key. Before, we'd silently continue to run the build, but the resulting invocation would be publicly accessible. Now, this case results in bazel printing out the error `UNAUTHENTICATED: Invalid API key abc123...`.