### PR TITLE
Configure TS project so generated proto files are recognized

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,24 +10,12 @@
     "outDir": "dist",
     "target": "ES2016",
     "baseUrl": ".",
-    "lib": [
-      "es2017",
-      "es2019",
-      "dom",
-      "dom.iterable"
-    ],
+    "lib": ["es2017", "es2019", "dom", "dom.iterable"],
+    "rootDirs": [".", "bazel-bin"],
     "paths": {
-      "buildbuddy/*": [
-        "*",
-        "bazel-bin/*"
-      ],
-      "*": [
-        "node_modules/*"
-      ]
+      "buildbuddy/*": ["*", "bazel-bin/*"],
+      "*": ["node_modules/*"]
     }
   },
-  "exclude": [
-    "bazel-out",
-    "bazel-bin"
-  ]
+  "exclude": ["bazel-out", "bazel-bin"]
 }


### PR DESCRIPTION
This allows the TS language server to recognize the sources under `bazel-bin`, so imported protos are properly recognized (they don't show up with a red underline, and you get editor auto-completion since the full proto type is known).

See here: https://github.com/bazelbuild/rules_nodejs/issues/561#issuecomment-450786421

