### PR TITLE
Fix Github status

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -432,7 +432,7 @@ func (c *Configurator) GetAPIConfig() *APIConfig {
 }
 
 func (c *Configurator) GetGithubConfig() *GithubConfig {
-	if c.gc.Github.ClientID == "" {
+	if c.gc.Github == (GithubConfig{}) {
 		return nil
 	}
 	ghc := c.gc.Github


### PR DESCRIPTION
## What?
The Github status using an access token is broken.
The Github config is nil if there is no client ID set
which is not required if you are using an access token.