### PR TITLE
Set up development workflow for Prometheus and Grafana

### DIFF
--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -62,7 +62,7 @@ var (
 	sslPort        = flag.Int("ssl_port", 8081, "The port to listen for HTTPS traffic on")
 	gRPCPort       = flag.Int("grpc_port", 1985, "The port to listen for gRPC traffic on")
 	gRPCSPort      = flag.Int("grpcs_port", 1986, "The port to listen for gRPCS traffic on")
-	monitoringPort = flag.Int("monitoring_port", 9090, "The port to listen for monitoring traffic on")
+	monitoringPort = flag.Int("monitoring_port", 9100, "The port to listen for monitoring traffic on")
 
 	staticDirectory = flag.String("static_directory", "/static", "the directory containing static files to host")
 	appDirectory    = flag.String("app_directory", "/app", "the directory containing app binary files to host")

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -62,7 +62,7 @@ var (
 	sslPort        = flag.Int("ssl_port", 8081, "The port to listen for HTTPS traffic on")
 	gRPCPort       = flag.Int("grpc_port", 1985, "The port to listen for gRPC traffic on")
 	gRPCSPort      = flag.Int("grpcs_port", 1986, "The port to listen for gRPCS traffic on")
-	monitoringPort = flag.Int("monitoring_port", 9100, "The port to listen for monitoring traffic on")
+	monitoringPort = flag.Int("monitoring_port", 9090, "The port to listen for monitoring traffic on")
 
 	staticDirectory = flag.String("static_directory", "/static", "the directory containing static files to host")
 	appDirectory    = flag.String("app_directory", "/app", "the directory containing app binary files to host")

--- a/tools/metrics/README.md
+++ b/tools/metrics/README.md
@@ -1,0 +1,20 @@
+# BuildBuddy metrics tools
+
+This directory contains tools to develop Prometheus metrics for BuildBuddy.
+
+## Getting started
+
+1. Install `docker-compose`.
+2. Run `./run.sh` in this directory to start Prometheus and Grafana (using Docker).
+3. Visit `http://localhost:4500`.
+4. Log in with the username and password `admin`.
+
+## Viewing metrics in Grafana
+
+To view BuildBuddy metrics in Grafana:
+
+1. In Grafana, create a new dashboard.
+2. In the `Metric` dropdown in the UI, check out the `buildbuddy` sub-menu.
+3. Select one of the metrics to view it in the graph.
+4. Run some tests against your local BuildBuddy server and make sure the metric
+   is updated as you'd expect.

--- a/tools/metrics/docker-compose.yml
+++ b/tools/metrics/docker-compose.yml
@@ -1,12 +1,20 @@
 version: "3.3"
 services:
   prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:v2.22.2
     network_mode: "host"
     volumes:
       - ${PWD}/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      [
+        "--config.file=/etc/prometheus/prometheus.yml",
+        "--storage.tsdb.path=/prometheus",
+        "--web.console.libraries=/usr/share/prometheus/console_libraries",
+        "--web.console.templates=/usr/share/prometheus/consoles",
+        "--web.listen-address=0.0.0.0:9100",
+      ]
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:7.3.3
     network_mode: "host"
     environment:
       - GF_SERVER_HTTP_PORT=4500

--- a/tools/metrics/docker-compose.yml
+++ b/tools/metrics/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.3"
+services:
+  prometheus:
+    image: prom/prometheus
+    network_mode: "host"
+    volumes:
+      - ${PWD}/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+  grafana:
+    image: grafana/grafana
+    network_mode: "host"
+    environment:
+      - GF_SERVER_HTTP_PORT=4500
+    volumes:
+      - ./grafana:/etc/grafana/provisioning

--- a/tools/metrics/grafana/datasources/prometheus.yml
+++ b/tools/metrics/grafana/datasources/prometheus.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+  - type: prometheus
+  - access: proxy
+  - uid: prom
+  - isDefault: true
+  # When running docker with --net=host, need to use 127.0.0.1 instead
+  # of localhost.
+  - url: http://127.0.0.1:9090
+  - version: 1
+  - editable: false

--- a/tools/metrics/grafana/datasources/prometheus.yml
+++ b/tools/metrics/grafana/datasources/prometheus.yml
@@ -8,6 +8,6 @@ datasources:
   - isDefault: true
   # When running docker with --net=host, need to use 127.0.0.1 instead
   # of localhost.
-  - url: http://127.0.0.1:9090
+  - url: http://127.0.0.1:9100
   - version: 1
   - editable: false

--- a/tools/metrics/prometheus/prometheus.yml
+++ b/tools/metrics/prometheus/prometheus.yml
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 10s
-  evaluation_interval: 10s
+  scrape_interval: 1s
+  evaluation_interval: 1s
 
 scrape_configs:
   - job_name: buildbuddy_server

--- a/tools/metrics/prometheus/prometheus.yml
+++ b/tools/metrics/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 10s
+  evaluation_interval: 10s
+
+scrape_configs:
+  - job_name: buildbuddy_server
+    static_configs:
+      - targets: ["localhost:9100"]

--- a/tools/metrics/prometheus/prometheus.yml
+++ b/tools/metrics/prometheus/prometheus.yml
@@ -5,4 +5,4 @@ global:
 scrape_configs:
   - job_name: buildbuddy_server
     static_configs:
-      - targets: ["localhost:9100"]
+      - targets: ["localhost:9090"]

--- a/tools/metrics/run.sh
+++ b/tools/metrics/run.sh
@@ -4,13 +4,13 @@ set -e -o pipefail
 __file__="$0"
 __dir__=$(dirname "$__file__")
 
-# Open grafana webpage in browser when ready
+# Open Grafana dashboard when the server is up and running
 (
   open=$(which open &>/dev/null && echo "open" || echo "xdg-open")
   tries=100
   grafana_url="http://localhost:4500"
   while ! curl "$grafana_url" &>/dev/null ; do
-    sleep 2
+    sleep 0.5
     tries=$(( tries - 1 ))
     if [[ $tries == 0 ]] ; then
       exit 1
@@ -19,5 +19,4 @@ __dir__=$(dirname "$__file__")
   "$open" "http://localhost:4500"
 ) &
 
-# Run docker-compose
 docker-compose up

--- a/tools/metrics/run.sh
+++ b/tools/metrics/run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e -o pipefail
+__file__="$0"
+__dir__=$(dirname "$__file__")
+
+# Open grafana webpage in browser when ready
+(
+  open=$(which open &>/dev/null && echo "open" || echo "xdg-open")
+  tries=100
+  grafana_url="http://localhost:4500"
+  while ! curl "$grafana_url" &>/dev/null ; do
+    sleep 2
+    tries=$(( tries - 1 ))
+    if [[ $tries == 0 ]] ; then
+      exit 1
+    fi
+  done
+  "$open" "http://localhost:4500"
+) &
+
+# Run docker-compose
+docker-compose up


### PR DESCRIPTION
* Created a `docker-compose.yml` file that can be used to run a local Prometheus and Grafana server.
* Changed the default Prometheus port on BuildBuddy from 9090 to 9100 since the main Prometheus server uses 9090 as the default port.
* Configured Grafana to run on port 4500 instead of the default 3000, since 3000 is commonly used as the default for various frontend tools (e.g. `nextjs`, `create-react-app`).
* Mounted Grafana's [provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/) directory to the `grafana` dir in the git repo. I figure we can export some sample dashboards from the UI and save them to this provisioning dir so that they are checked in to version control.

Here's a sample dashboard with a metric I added to try out Prometheus counters:

![image](https://user-images.githubusercontent.com/2414826/99562036-a16be200-2995-11eb-9f69-a22d744092ff.png)
