### PR TITLE
Fix text overflow on history cards

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -782,6 +782,11 @@ code .comment {
   font-size: 24px;
   flex-shrink: 0;
   margin-right: 16px;
+
+  max-width: 100%;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .card .subtitle {


### PR DESCRIPTION
Before, the text would overflow past the right edge of the history card (and be clipped by the right edge). Now we truncate with ellipsis.