### PR TITLE
Add SQL connection metrics

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -55,6 +55,7 @@ type DatabaseConfig struct {
 	MaxIdleConns           int    `yaml:"max_idle_conns" usage:"The maximum number of idle connections to maintain to the db"`
 	ConnMaxLifetimeSeconds int    `yaml:"conn_max_lifetime_seconds" usage:"The maximum lifetime of a connection to the db"`
 	LogQueries             bool   `yaml:"log_queries" usage:"If true, log all queries"`
+	StatsPollInterval      string `yaml:"stats_poll_interval" usage:"How often to poll the DB client for connection stats (default: "5s")."`
 }
 
 type storageConfig struct {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -41,6 +41,10 @@ const (
 
 	/// Status of the database connection: `in_use` or `idle`
 	SQLConnectionStatusLabel = "connection_status"
+
+	/// SQL DB replica role: `primary` for read+write replicas, or
+	/// `read_replica` for read-only DB replicas.
+	SQLDBRoleLabel = "sql_db_role"
 )
 
 const (
@@ -290,11 +294,13 @@ var (
 	/// [DBStats](https://golang.org/pkg/database/sql/#DBStats) from the
 	/// `database/sql` Go package.
 
-	SQLMaxOpenConnections = promauto.NewGauge(prometheus.GaugeOpts{
+	SQLMaxOpenConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "sql",
 		Name:      "max_open_connections",
 		Help:      "Maximum number of open connections to the database.",
+	}, []string{
+		SQLDBRoleLabel,
 	})
 
 	SQLOpenConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -304,41 +310,52 @@ var (
 		Help:      "The number of established connections to the database.",
 	}, []string{
 		SQLConnectionStatusLabel,
+		SQLDBRoleLabel,
 	})
 
-	SQLWaitCount = promauto.NewCounter(prometheus.CounterOpts{
+	SQLWaitCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "sql",
 		Name:      "wait_count",
 		Help:      "The total number of connections waited for.",
+	}, []string{
+		SQLDBRoleLabel,
 	})
 
-	SQLWaitDuration = promauto.NewCounter(prometheus.CounterOpts{
+	SQLWaitDuration = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "sql",
 		Name:      "wait_duration_usec",
 		Help:      "The total time blocked waiting for a new connection, in **microseconds**.",
+	}, []string{
+		SQLDBRoleLabel,
 	})
 
-	SQLMaxIdleClosed = promauto.NewCounter(prometheus.CounterOpts{
+	SQLMaxIdleClosed = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "sql",
 		Name:      "max_idle_closed",
 		Help:      "The total number of connections closed due to SetMaxIdleConns.",
+	}, []string{
+		SQLDBRoleLabel,
 	})
 
-	SQLMaxIdleTimeClosed = promauto.NewCounter(prometheus.CounterOpts{
+	SQLMaxIdleTimeClosed = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "sql",
 		Name:      "max_idle_time_closed",
 		Help:      "The total number of connections closed due to SetConnMaxIdleTime.",
+	}, []string{
+		SQLDBRoleLabel,
 	})
 
-	SQLMaxLifetimeClosed = promauto.NewCounter(prometheus.CounterOpts{
+	SQLMaxLifetimeClosed = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "sql",
 		Name:      "max_lifetime_closed",
 		Help:      "The total number of connections closed due to SetConnMaxLifetime.",
+	}, []string{
+		SQLDBRoleLabel,
 	})
 
 	/// ## Internal metrics

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -38,6 +38,9 @@ const (
 
 	/// `gcs` (Google Cloud Storage), `aws_s3`, or `disk`.
 	BlobstoreTypeLabel = "blobstore_type"
+
+	/// Status of the database connection: `in_use` or `idle`
+	SQLConnectionStatusLabel = "connection_status"
 )
 
 const (
@@ -277,6 +280,65 @@ var (
 		Help:      "Delete duration per blobstore file deletion, in **microseconds**.",
 	}, []string{
 		BlobstoreTypeLabel,
+	})
+
+	/// # SQL metrics
+	///
+	/// ## `database/sql` metrics
+	///
+	/// The following metrics directly expose
+	/// [DBStats](https://golang.org/pkg/database/sql/#DBStats) from the
+	/// `database/sql` Go package.
+
+	SQLMaxOpenConnections = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "sql",
+		Name:      "max_open_connections",
+		Help:      "Maximum number of open connections to the database.",
+	})
+
+	SQLOpenConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "sql",
+		Name:      "open_connections",
+		Help:      "The number of established connections to the database.",
+	}, []string{
+		SQLConnectionStatusLabel,
+	})
+
+	SQLWaitCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "sql",
+		Name:      "wait_count",
+		Help:      "The total number of connections waited for.",
+	})
+
+	SQLWaitDuration = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "sql",
+		Name:      "wait_duration_usec",
+		Help:      "The total time blocked waiting for a new connection, in **microseconds**.",
+	})
+
+	SQLMaxIdleClosed = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "sql",
+		Name:      "max_idle_closed",
+		Help:      "The total number of connections closed due to SetMaxIdleConns.",
+	})
+
+	SQLMaxIdleTimeClosed = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "sql",
+		Name:      "max_idle_time_closed",
+		Help:      "The total number of connections closed due to SetConnMaxIdleTime.",
+	})
+
+	SQLMaxLifetimeClosed = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "sql",
+		Name:      "max_lifetime_closed",
+		Help:      "The total number of connections closed due to SetConnMaxLifetime.",
 	})
 
 	/// ## Internal metrics

--- a/server/util/db/BUILD
+++ b/server/util/db/BUILD
@@ -7,11 +7,13 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/config:go_default_library",
+        "//server/metrics:go_default_library",
         "//server/tables:go_default_library",
         "@com_github_googlecloudplatform_cloudsql_proxy//proxy/dialers/mysql:go_default_library",
         "@com_github_jinzhu_gorm//:go_default_library",
         "@com_github_jinzhu_gorm//dialects/mysql:go_default_library",
         "@com_github_jinzhu_gorm//dialects/postgres:go_default_library",
         "@com_github_jinzhu_gorm//dialects/sqlite:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
     ],
 )

--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -144,6 +144,7 @@ func setDBOptions(c *config.Configurator, dialect string, gdb *gorm.DB) {
 
 type dbStatsRecorder struct {
 	db                *sql.DB
+	role              string
 	lastRecordedStats sql.DBStats
 }
 
@@ -157,23 +158,31 @@ func (r *dbStatsRecorder) poll(interval time.Duration) {
 func (r *dbStatsRecorder) recordStats() {
 	stats := r.db.Stats()
 
-	metrics.SQLMaxOpenConnections.Set(float64(stats.MaxOpenConnections))
+	roleLabel := prometheus.Labels{
+		metrics.SQLDBRoleLabel: r.role,
+	}
+
+	metrics.SQLMaxOpenConnections.With(roleLabel).Set(float64(stats.MaxOpenConnections))
 	metrics.SQLOpenConnections.With(prometheus.Labels{
 		metrics.SQLConnectionStatusLabel: "in_use",
+		metrics.SQLDBRoleLabel:           r.role,
 	}).Set(float64(stats.InUse))
 	metrics.SQLOpenConnections.With(prometheus.Labels{
 		metrics.SQLConnectionStatusLabel: "idle",
+		metrics.SQLDBRoleLabel:           r.role,
 	}).Set(float64(stats.Idle))
 
 	// The following DBStats fields are already counters, so we have
 	// to subtract from the last observed value to know how much to
 	// increment by.
 	last := r.lastRecordedStats
-	metrics.SQLWaitCount.Add(float64(stats.WaitCount - last.WaitCount))
-	metrics.SQLWaitDuration.Add(float64(stats.WaitDuration-last.WaitDuration) / float64(time.Microsecond))
-	metrics.SQLMaxIdleClosed.Add(float64(stats.MaxIdleClosed - last.MaxIdleClosed))
-	metrics.SQLMaxIdleTimeClosed.Add(float64(stats.MaxIdleTimeClosed - last.MaxIdleTimeClosed))
-	metrics.SQLMaxLifetimeClosed.Add(float64(stats.MaxLifetimeClosed - last.MaxLifetimeClosed))
+
+	metrics.SQLWaitCount.With(roleLabel).Add(float64(stats.WaitCount - last.WaitCount))
+	metrics.SQLWaitDuration.With(roleLabel).Add(float64(stats.WaitDuration-last.WaitDuration) / float64(time.Microsecond))
+	metrics.SQLMaxIdleClosed.With(roleLabel).Add(float64(stats.MaxIdleClosed - last.MaxIdleClosed))
+	metrics.SQLMaxIdleTimeClosed.With(roleLabel).Add(float64(stats.MaxIdleTimeClosed - last.MaxIdleTimeClosed))
+	metrics.SQLMaxLifetimeClosed.With(roleLabel).Add(float64(stats.MaxLifetimeClosed - last.MaxLifetimeClosed))
+
 	r.lastRecordedStats = stats
 }
 
@@ -191,13 +200,17 @@ func GetConfiguredDatabase(c *config.Configurator) (*DBHandle, error) {
 	}
 	setDBOptions(c, dialect, primaryDB)
 
-	statsRecorder := &dbStatsRecorder{db: primaryDB.DB()}
 	statsPollInterval := defaultDbStatsPollInterval
 	dbConf := c.GetDatabaseConfig()
 	if dbConf != nil && dbConf.StatsPollInterval != "" {
 		if statsPollInterval, err = time.ParseDuration(dbConf.StatsPollInterval); err != nil {
 			return nil, err
 		}
+	}
+
+	statsRecorder := &dbStatsRecorder{
+		db:   primaryDB.DB(),
+		role: "primary",
 	}
 	go statsRecorder.poll(statsPollInterval)
 
@@ -223,6 +236,12 @@ func GetConfiguredDatabase(c *config.Configurator) (*DBHandle, error) {
 		setDBOptions(c, readDialect, replicaDB)
 		log.Print("Read replica was present -- connecting to it.")
 		dbh.readReplicaDB = replicaDB
+
+		statsRecorder := &dbStatsRecorder{
+			db:   replicaDB.DB(),
+			role: "read_replica",
+		}
+		go statsRecorder.poll(statsPollInterval)
 	}
 	return dbh, nil
 }

--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -154,10 +154,6 @@ func (r *dbStatsRecorder) poll(interval time.Duration) {
 	}
 }
 
-func usecFloat64(d time.Duration) float64 {
-	return d.Seconds() * (float64(time.Second) / float64(time.Microsecond))
-}
-
 func (r *dbStatsRecorder) recordStats() {
 	stats := r.db.Stats()
 
@@ -174,7 +170,7 @@ func (r *dbStatsRecorder) recordStats() {
 	// increment by.
 	last := r.lastRecordedStats
 	metrics.SQLWaitCount.Add(float64(stats.WaitCount - last.WaitCount))
-	metrics.SQLWaitDuration.Add(usecFloat64(stats.WaitDuration - last.WaitDuration))
+	metrics.SQLWaitDuration.Add(float64(stats.WaitDuration-last.WaitDuration) / float64(time.Microsecond))
 	metrics.SQLMaxIdleClosed.Add(float64(stats.MaxIdleClosed - last.MaxIdleClosed))
 	metrics.SQLMaxIdleTimeClosed.Add(float64(stats.MaxIdleTimeClosed - last.MaxIdleTimeClosed))
 	metrics.SQLMaxLifetimeClosed.Add(float64(stats.MaxLifetimeClosed - last.MaxLifetimeClosed))

--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -170,7 +170,7 @@ func (r *dbStatsRecorder) recordStats() {
 	// increment by.
 	last := r.lastRecordedStats
 	metrics.SQLWaitCount.Add(float64(stats.WaitCount - last.WaitCount))
-	metrics.SQLWaitDuration.Add(float64(stats.WaitDuration - last.WaitDuration))
+	metrics.SQLWaitDuration.Add(float64((stats.WaitDuration - last.WaitDuration).Microseconds()))
 	metrics.SQLMaxIdleClosed.Add(float64(stats.MaxIdleClosed - last.MaxIdleClosed))
 	metrics.SQLMaxIdleTimeClosed.Add(float64(stats.MaxIdleTimeClosed - last.MaxIdleTimeClosed))
 	metrics.SQLMaxLifetimeClosed.Add(float64(stats.MaxLifetimeClosed - last.MaxLifetimeClosed))

--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -154,6 +154,10 @@ func (r *dbStatsRecorder) poll(interval time.Duration) {
 	}
 }
 
+func usecFloat64(d time.Duration) float64 {
+	return d.Seconds() * (float64(time.Second) / float64(time.Microsecond))
+}
+
 func (r *dbStatsRecorder) recordStats() {
 	stats := r.db.Stats()
 
@@ -170,7 +174,7 @@ func (r *dbStatsRecorder) recordStats() {
 	// increment by.
 	last := r.lastRecordedStats
 	metrics.SQLWaitCount.Add(float64(stats.WaitCount - last.WaitCount))
-	metrics.SQLWaitDuration.Add(float64((stats.WaitDuration - last.WaitDuration).Microseconds()))
+	metrics.SQLWaitDuration.Add(usecFloat64(stats.WaitDuration - last.WaitDuration))
 	metrics.SQLMaxIdleClosed.Add(float64(stats.MaxIdleClosed - last.MaxIdleClosed))
 	metrics.SQLMaxIdleTimeClosed.Add(float64(stats.MaxIdleTimeClosed - last.MaxIdleTimeClosed))
 	metrics.SQLMaxLifetimeClosed.Add(float64(stats.MaxLifetimeClosed - last.MaxLifetimeClosed))


### PR DESCRIPTION
These metrics use a polling-based approach, but it just polls the `sql.DB` client (no DB queries are issued).