### PR TITLE
Add HTTP server-side metrics

### DIFF
--- a/server/http/filters/BUILD
+++ b/server/http/filters/BUILD
@@ -8,8 +8,10 @@ go_library(
     deps = [
         "//server/environment:go_default_library",
         "//server/http/protolet:go_default_library",
+        "//server/metrics:go_default_library",
         "//server/util/log:go_default_library",
         "//server/util/uuid:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/server/http/filters/filters.go
+++ b/server/http/filters/filters.go
@@ -141,7 +141,7 @@ func LogRequest(next http.Handler) http.Handler {
 			ResponseWriter: w,
 		}
 		next.ServeHTTP(ow, r)
-		duration := time.Now().Sub(start)
+		duration := time.Since(start)
 		log.LogHTTPRequest(r.Context(), r.URL.Path, duration, nil)
 		recordResponseMetrics(route, method, ow, duration)
 	})

--- a/server/http/filters/filters.go
+++ b/server/http/filters/filters.go
@@ -132,7 +132,7 @@ func LogRequest(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(irw, r)
 		duration := time.Since(start)
-		log.LogHTTPRequest(r.Context(), r.URL.Path, duration, irw.statusCode, nil)
+		log.LogHTTPRequest(r.Context(), r.URL.Path, duration, irw.statusCode)
 		recordResponseMetrics(rt, m, irw.statusCode, irw.responseSizeBytes, duration)
 	})
 }

--- a/server/http/filters/filters.go
+++ b/server/http/filters/filters.go
@@ -1,10 +1,14 @@
 package filters
 
 import (
+	"bufio"
 	"compress/gzip"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -13,7 +17,14 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/http/protolet"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+
+	metrics "github.com/buildbuddy-io/buildbuddy/server/metrics"
+)
+
+var (
+	uuidV4Regexp = regexp.MustCompile("[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}")
 )
 
 func RedirectHTTPS(env environment.Env, next http.Handler) http.Handler {
@@ -93,12 +104,94 @@ func RequestID(next http.Handler) http.Handler {
 	})
 }
 
+// instrumentedResponseWriter wraps http.ResponseWriter, recording info needed for
+// Prometheus metrics.
+type instrumentedResponseWriter struct {
+	http.ResponseWriter
+
+	statusCode        int
+	responseSizeBytes int
+}
+
+func (w instrumentedResponseWriter) Header() http.Header {
+	return w.ResponseWriter.Header()
+}
+func (w instrumentedResponseWriter) Write(bytes []byte) (int, error) {
+	w.responseSizeBytes += len(bytes)
+	return w.ResponseWriter.Write(bytes)
+}
+func (w instrumentedResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+func (w instrumentedResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.ResponseWriter.(http.Hijacker).Hijack()
+}
+func (w instrumentedResponseWriter) Flush() {
+	w.ResponseWriter.(http.Flusher).Flush()
+}
+
 func LogRequest(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
-		next.ServeHTTP(w, r)
-		log.LogHTTPRequest(r.Context(), r.URL.Path, time.Now().Sub(start), nil)
+		method := getMethod(r)
+		route := getRoute(r)
+		recordRequestMetrics(route, method)
+		ow := instrumentedResponseWriter{
+			ResponseWriter: w,
+		}
+		next.ServeHTTP(ow, r)
+		duration := time.Now().Sub(start)
+		log.LogHTTPRequest(r.Context(), r.URL.Path, duration, nil)
+		recordResponseMetrics(route, method, ow, duration)
 	})
+}
+
+func getRoute(r *http.Request) string {
+	path := r.URL.Path
+
+	// TODO(bduffany): migrate to a routing solution that doesn't require
+	// updating this function when we add new HTTP routes.
+
+	// Strip prefixes on large static file directories to avoid
+	// creating new metrics series for every static file that we serve.
+	if strings.HasPrefix(path, "/images/") {
+		return "/images/:path"
+	}
+	if strings.HasPrefix(path, "/favicon/") {
+		return "/favicon/:path"
+	}
+
+	// Replace path parameters to avoid creating a series for
+	// every possible parameter value.
+
+	// Currently we only use UUID v4 path params so this
+	// find-and-replace is good enough for now.
+	return uuidV4Regexp.ReplaceAllLiteralString(path, ":id")
+}
+
+func getMethod(r *http.Request) string {
+	if r.Method == "" {
+		return "GET"
+	}
+	return r.Method
+}
+
+func recordRequestMetrics(route, method string) {
+	metrics.HTTPRequestCount.With(prometheus.Labels{
+		metrics.HTTPRouteLabel:  route,
+		metrics.HTTPMethodLabel: method,
+	}).Inc()
+}
+
+func recordResponseMetrics(route, method string, w instrumentedResponseWriter, duration time.Duration) {
+	labels := prometheus.Labels{
+		metrics.HTTPRouteLabel:        route,
+		metrics.HTTPMethodLabel:       method,
+		metrics.HTTPResponseCodeLabel: strconv.Itoa(w.statusCode),
+	}
+	metrics.HTTPRequestHandlerDurationUsec.With(labels).Observe(float64(duration.Microseconds()))
+	metrics.HTTPResponseSizeBytes.With(labels).Observe(float64(w.responseSizeBytes))
 }
 
 type wrapFn func(http.Handler) http.Handler

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -256,8 +256,7 @@ func StartAndRunServices(env environment.Env) {
 	if err := rlimit.MaxRLimit(); err != nil {
 		log.Printf("Error raising open files limit: %s", err)
 	}
-	uiPathPrefixes := []string{"/invocation/", "/compare/", "/history/", "/docs/", "/settings/", "/org/", "/trends/", "/join/", "/tests/"}
-	staticFileServer, err := static.NewStaticFileServer(env, *staticDirectory, uiPathPrefixes)
+	staticFileServer, err := static.NewStaticFileServer(env, *staticDirectory, []string{"/invocation/", "/compare/", "/history/", "/docs/", "/settings/", "/org/", "/trends/", "/join/", "/tests/"})
 
 	if err != nil {
 		log.Fatalf("Error initializing static file server: %s", err)

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -339,15 +339,6 @@ func StartAndRunServices(env environment.Env) {
 		sp.PrintSplashScreen(*port, *gRPCPort)
 	}
 
-
-	mw := middleware.New(middleware.Config{
-		Recorder: gohttpmetrics.NewRecorder(gohttpmetrics.Config{
-			Prefix: "buildbuddy",
-			DurationBuckets: prometheus.ExponentialBuckets(1, 10, 9),
-		})
-	})
-	handler = middlewarestd.Handler(/* handlerID= */ "", mw, handler)
-
 	server := &http.Server{
 		Addr:    fmt.Sprintf("%s:%d", *listen, *port),
 		Handler: handler,

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -387,6 +387,18 @@ var (
 		HTTPMethodLabel,
 	})
 
+	/// #### Examples
+	///
+	/// ```promql
+	/// # Requests per second, by status code
+	/// sum by (code) (rate(buildbuddy_http_request_count[5m]))
+	///
+	/// # 5xx error ratio
+	/// sum(rate(buildbuddy_http_request_count{code=~"5.."}[5m]))
+	///   /
+	/// sum(rate(buildbuddy_http_request_count[5m]))
+	/// ```
+
 	HTTPRequestHandlerDurationUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "http",
@@ -398,6 +410,18 @@ var (
 		HTTPResponseCodeLabel,
 	})
 
+	/// #### Examples
+	///
+	/// ```promql
+	/// # Median request duration for successfuly processed (2xx) requests.
+	/// # Other status codes may be associated with early-exits and are
+	/// # likely to add too much noise.
+	/// histogram_quantile(
+	///   0.5,
+	///   sum by (le)	(rate(buildbuddy_http_request_handler_duration_usec{code=~"2.."}[5m]))
+	/// )
+	/// ```
+
 	HTTPResponseSizeBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "http",
@@ -408,6 +432,16 @@ var (
 		HTTPMethodLabel,
 		HTTPResponseCodeLabel,
 	})
+
+	/// #### Examples
+	///
+	/// ```promql
+	/// # Median HTTP response size
+	/// histogram_quantile(
+	///   0.5,
+	///   sum by (le)	(rate(buildbuddy_http_response_size_bytes[5m]))
+	/// )
+	/// ```
 
 	/// ## Internal metrics
 	///

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -45,6 +45,16 @@ const (
 	/// SQL DB replica role: `primary` for read+write replicas, or
 	/// `read_replica` for read-only DB replicas.
 	SQLDBRoleLabel = "sql_db_role"
+
+	/// HTTP route before substituting path parameters
+	/// (`/invocation/:id`, `/settings`, ...)
+	HTTPRouteLabel = "route"
+
+	/// HTTP method: `GET`, `POST`, ...
+	HTTPMethodLabel = "method"
+
+	/// HTTP response code: `200`, `302`, `401`, `404`, `500`, ...
+	HTTPResponseCodeLabel = "code"
 )
 
 const (
@@ -363,6 +373,40 @@ var (
 		Help:      "The total number of connections closed due to SetConnMaxLifetime.",
 	}, []string{
 		SQLDBRoleLabel,
+	})
+
+	/// ## HTTP metrics
+
+	HTTPRequestCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "http",
+		Name:      "request_count",
+		Help:      "HTTP request count.",
+	}, []string{
+		HTTPRouteLabel,
+		HTTPMethodLabel,
+	})
+
+	HTTPRequestHandlerDurationUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "http",
+		Name:      "request_handler_duration_usec",
+		Help:      "Time taken to handle each HTTP request in **microseconds**.",
+	}, []string{
+		HTTPRouteLabel,
+		HTTPMethodLabel,
+		HTTPResponseCodeLabel,
+	})
+
+	HTTPResponseSizeBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "http",
+		Name:      "response_size_bytes",
+		Help:      "Response size of each HTTP response in **bytes**.",
+	}, []string{
+		HTTPRouteLabel,
+		HTTPMethodLabel,
+		HTTPResponseCodeLabel,
 	})
 
 	/// ## Internal metrics

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -69,7 +69,7 @@ func LogGRPCRequest(ctx context.Context, fullMethod string, dur time.Duration, e
 	}
 }
 
-func LogHTTPRequest(ctx context.Context, url string, dur time.Duration, statusCode int, err error) {
+func LogHTTPRequest(ctx context.Context, url string, dur time.Duration, statusCode int) {
 	reqID, _ := uuid.GetFromContext(ctx) // Ignore error, we're logging anyway.
-	log.Printf("HTTP %s %q HTTP %d / grpc %s [%s]", reqID, url, statusCode, fmtErr(err), formatDuration(dur))
+	log.Printf("HTTP %s %q HTTP %d", reqID, url, statusCode, formatDuration(dur))
 }

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -69,7 +69,7 @@ func LogGRPCRequest(ctx context.Context, fullMethod string, dur time.Duration, e
 	}
 }
 
-func LogHTTPRequest(ctx context.Context, url string, dur time.Duration, err error) {
+func LogHTTPRequest(ctx context.Context, url string, dur time.Duration, statusCode int, err error) {
 	reqID, _ := uuid.GetFromContext(ctx) // Ignore error, we're logging anyway.
-	log.Printf("%s %s %q %s [%s]", "HTTP", reqID, url, fmtErr(err), formatDuration(dur))
+	log.Printf("HTTP %s %q HTTP %d / grpc %s [%s]", reqID, url, statusCode, fmtErr(err), formatDuration(dur))
 }

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"path"
 	"time"
 
@@ -71,5 +72,5 @@ func LogGRPCRequest(ctx context.Context, fullMethod string, dur time.Duration, e
 
 func LogHTTPRequest(ctx context.Context, url string, dur time.Duration, statusCode int) {
 	reqID, _ := uuid.GetFromContext(ctx) // Ignore error, we're logging anyway.
-	log.Printf("HTTP %s %q HTTP %d", reqID, url, statusCode, formatDuration(dur))
+	log.Printf("HTTP %s %q %d %s [%s]", reqID, url, statusCode, http.StatusText(statusCode), formatDuration(dur))
 }


### PR DESCRIPTION
I found https://github.com/slok/go-http-metrics which would have solved this for us, but it had a few downsides:
- Too many deps on misc HTTP frameworks, as opposed to using a plugin for each framework
- We can't change the units from `seconds` to `usec` to be consistent with the rest of our metrics

![image](https://user-images.githubusercontent.com/2414826/101692037-97417e80-3a3d-11eb-93da-c82e9b64ea4b.png)
