### PR TITLE
Two small changes to improve error handling and portability

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -43,15 +43,20 @@ export class AuthService {
         if (error.includes("not found")) {
           this.createUser();
         } else {
-          this.emitUser(null);
+          this.onUserRpcError(error);
         }
       });
   }
 
   refreshUser() {
-    return rpcService.service.getUser(new user.GetUserRequest()).then((response: user.GetUserResponse) => {
-      this.emitUser(this.userFromResponse(response));
-    });
+    return rpcService.service
+      .getUser(new user.GetUserRequest())
+      .then((response: user.GetUserResponse) => {
+        this.emitUser(this.userFromResponse(response));
+      })
+      .catch((error: any) => {
+        this.onUserRpcError(error);
+      });
   }
 
   createUser() {
@@ -59,13 +64,17 @@ export class AuthService {
     rpcService.service
       .createUser(request)
       .then((response: user.CreateUserResponse) => {
-        this.register();
+        this.refreshUser();
       })
       .catch((error: any) => {
-        console.log(error);
-        this.emitUser(null);
-        // TODO(siggisim): figure out what we should do in this case.
+        this.onUserRpcError(error);
       });
+  }
+
+  onUserRpcError(error: any) {
+    console.log(error);
+    this.emitUser(null);
+    // TODO(siggisim): figure out what we should do in this case.
   }
 
   userFromResponse(response: user.GetUserResponse) {


### PR DESCRIPTION
## Description
Bug ameliorate:
If the user authentication fails in AuthService.register(), the service enters an infinite loop of adding and getting users. This can, in some cases, continuously add users to the database as well as eat up bandwidth.
 
Configuration tweak:
GCP load balancer custom healthchecks do not allow sending headers. To allow healthchecks to play nice with that constraint, also consume `server-type` from query parameters. 


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

