### PR TITLE
Add more task queue metrics for remote execution

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -254,6 +254,52 @@ var (
 	/// quantile(0.5, buildbuddy_remote_execution_queue_length)
 	/// ```
 
+	RemoteExecutionTasksExecuting = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name: "tasks_executing",
+		Help: "Number of tasks currently being executed by the executor.",
+	})
+
+	/// #### Examples
+	///
+	/// ```promql
+	/// # Fraction of idle executors
+	/// count_values(0, buildbuddy_remote_execution_tasks_executing)
+	///   /
+	/// count(buildbuddy_remote_execution_tasks_executing)
+	/// ```
+
+	RemoteExecutionAssignedRAMBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name: "assigned_ram_bytes",
+		Help: "Estimated RAM on the executor that is currently allocated for task execution, in **bytes**.",
+	})
+
+	RemoteExecutionAssignedMilliCPU = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name: "assigned_milli_cpu",
+		Help: "Estimated CPU time on the executor that is currently allocated for task execution, in Kubernetes milliCPU.",
+	})
+
+	/// #### Examples
+	///
+	/// ```promql
+	/// # Average CPU allocated to tasks (average is computed across executor instances).
+	/// # `label_replace` is needed because we export k8s pod name as "pod_name" in Prometheus,
+	/// # while k8s exports it as "pod".
+	/// avg(
+	///   buildbuddy_remote_execution_used_milli_cpu
+	///     /
+	///	  on (pod_name) (label_replace(
+	///     kube_pod_container_resource_limits_cpu_cores{pod=~"executor-.*"},
+	///     "pod_name", "$1", "pod", "(.*)"
+  ///   ) * 1000 * 0.6)
+  /// )
+	/// ```
+
 	FileDownloadCount = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -257,8 +257,8 @@ var (
 	RemoteExecutionTasksExecuting = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",
-		Name: "tasks_executing",
-		Help: "Number of tasks currently being executed by the executor.",
+		Name:      "tasks_executing",
+		Help:      "Number of tasks currently being executed by the executor.",
 	})
 
 	/// #### Examples
@@ -273,15 +273,15 @@ var (
 	RemoteExecutionAssignedRAMBytes = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",
-		Name: "assigned_ram_bytes",
-		Help: "Estimated RAM on the executor that is currently allocated for task execution, in **bytes**.",
+		Name:      "assigned_ram_bytes",
+		Help:      "Estimated RAM on the executor that is currently allocated for task execution, in **bytes**.",
 	})
 
 	RemoteExecutionAssignedMilliCPU = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",
-		Name: "assigned_milli_cpu",
-		Help: "Estimated CPU time on the executor that is currently allocated for task execution, in Kubernetes milliCPU.",
+		Name:      "assigned_milli_cpu",
+		Help:      "Estimated CPU time on the executor that is currently allocated for task execution, in Kubernetes milliCPU.",
 	})
 
 	/// #### Examples
@@ -296,8 +296,8 @@ var (
 	///	  on (pod_name) (label_replace(
 	///     kube_pod_container_resource_limits_cpu_cores{pod=~"executor-.*"},
 	///     "pod_name", "$1", "pod", "(.*)"
-  ///   ) * 1000 * 0.6)
-  /// )
+	///   ) * 1000 * 0.6)
+	/// )
 	/// ```
 
 	FileDownloadCount = promauto.NewHistogram(prometheus.HistogramOpts{


### PR DESCRIPTION
## Description

Add three new metrics for remote execution:
- `assigned_ram_bytes`: number of bytes that are currently assigned to tasks.
- `assigned_milli_cpu`: number of milliCPUs currently assigned to tasks.
- `tasks_executing`: number of tasks currently executing.

These metrics will enable the following:
- Observability on the number of idle executors, which may be a useful metric for autoscaling
- Observability on the fraction of executors which have almost maxed out the maximum number of resources they can allocate to tasks, which may be another useful metric for autoscaling.
- The ability to measure assigned resources vs actual RAM bytes used, which should give us understanding of how closely the "estimated" resource requests match the actual resources used. (e.g. if tasks are consistently using more RAM/CPU than they've estimated, we might want to add some scaling factor to each estimate.)

## Type of change

New feature (non-breaking change that adds functionality)
