### PR TITLE
Add more remote execution charts

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 1,
-  "iteration": 1608060929149,
+  "iteration": 1608672678808,
   "links": [],
   "panels": [
     {
@@ -76,7 +76,7 @@
           "repeat": "job",
           "scopedVars": {
             "job": {
-              "selected": false,
+              "selected": true,
               "text": "buildbuddy-app",
               "value": "buildbuddy-app"
             }
@@ -114,7 +114,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:571",
               "decimals": 0,
               "format": "short",
               "label": null,
@@ -124,7 +123,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:572",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -159,7 +157,7 @@
             "y": 1
           },
           "hiddenSeries": false,
-          "id": 133,
+          "id": 168,
           "legend": {
             "avg": false,
             "current": false,
@@ -181,11 +179,11 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1607988324442,
+          "repeatIteration": 1608573407811,
           "repeatPanelId": 21,
           "scopedVars": {
             "job": {
-              "selected": false,
+              "selected": true,
               "text": "buildbuddy-executor",
               "value": "buildbuddy-executor"
             }
@@ -223,7 +221,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:571",
               "decimals": 0,
               "format": "short",
               "label": null,
@@ -233,7 +230,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:572",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -285,7 +281,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 2
+            "y": 9
           },
           "hiddenSeries": false,
           "id": 13,
@@ -306,7 +302,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -343,7 +339,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:529",
               "format": "ops",
               "label": null,
               "logBase": 1,
@@ -352,7 +347,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:530",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -384,7 +378,7 @@
             "h": 8,
             "w": 10,
             "x": 9,
-            "y": 2
+            "y": 9
           },
           "hiddenSeries": false,
           "id": 25,
@@ -404,7 +398,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -441,7 +435,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:59",
               "format": "µs",
               "label": null,
               "logBase": 1,
@@ -450,7 +443,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:60",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -482,7 +474,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 10
+            "y": 17
           },
           "hiddenSeries": false,
           "id": 65,
@@ -502,7 +494,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -539,7 +531,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:318",
               "format": "ops",
               "label": null,
               "logBase": 1,
@@ -548,7 +539,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:319",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -596,7 +586,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 26
           },
           "hiddenSeries": false,
           "id": 17,
@@ -616,7 +606,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -653,7 +643,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:111",
               "format": "binBps",
               "label": null,
               "logBase": 1,
@@ -662,7 +651,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:112",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -695,7 +683,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 26
           },
           "hiddenSeries": false,
           "id": 19,
@@ -715,7 +703,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -752,7 +740,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:163",
               "format": "binBps",
               "label": null,
               "logBase": 1,
@@ -761,7 +748,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:164",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -796,7 +782,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 27
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 4,
@@ -817,16 +803,14 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
           "repeat": "cache_type",
           "repeatDirection": "h",
           "seriesOverrides": [
-            {
-              "$$hashKey": "object:137"
-            },
+            {},
             {
               "alias": "Misses",
               "yaxis": 2
@@ -868,7 +852,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:22",
               "format": "ops",
               "label": null,
               "logBase": 1,
@@ -877,7 +860,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:23",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -912,7 +894,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 27
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 9,
@@ -933,7 +915,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -971,7 +953,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:22",
               "format": "ops",
               "label": null,
               "logBase": 1,
@@ -980,7 +961,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:23",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -1010,12 +990,14 @@
       "id": 28,
       "panels": [
         {
-          "aliasColors": {},
+          "aliasColors": {
+            "Idle": "dark-purple"
+          },
           "bars": false,
           "dashLength": 10,
           "dashes": false,
           "datasource": "Prometheus",
-          "description": "",
+          "description": "Chart is stacked, so values always add up to 100%.",
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -1025,19 +1007,19 @@
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 8,
+            "h": 9,
             "w": 12,
             "x": 0,
             "y": 4
           },
           "hiddenSeries": false,
-          "id": 33,
+          "id": 190,
           "legend": {
             "avg": false,
             "current": false,
             "max": false,
             "min": false,
-            "show": false,
+            "show": true,
             "total": false,
             "values": false
           },
@@ -1054,22 +1036,28 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "stack": false,
+          "stack": true,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(buildbuddy_remote_execution_file_download_size_bytes_sum[${window}]))",
+              "expr": "count(buildbuddy_remote_execution_tasks_executing > 0) / count(buildbuddy_remote_execution_tasks_executing)",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "Working",
               "queryType": "randomWalk",
               "refId": "A"
+            },
+            {
+              "expr": "1 - count(buildbuddy_remote_execution_tasks_executing > 0) / count(buildbuddy_remote_execution_tasks_executing)",
+              "interval": "",
+              "legendFormat": "Idle",
+              "refId": "B"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Total downloaded bytes per second",
+          "title": "Fraction of working executors",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1085,16 +1073,16 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:95",
-              "format": "binBps",
+              "$$hashKey": "object:92",
+              "format": "percentunit",
               "label": null,
               "logBase": 1,
-              "max": null,
+              "max": "1",
               "min": "0",
               "show": true
             },
             {
-              "$$hashKey": "object:96",
+              "$$hashKey": "object:93",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -1110,7 +1098,9 @@
         },
         {
           "aliasColors": {
-            "Value": "yellow"
+            "Avg executor queue length": "dark-red",
+            "Executor instances": "dark-blue",
+            "Value": "dark-green"
           },
           "bars": false,
           "dashLength": 10,
@@ -1122,22 +1112,23 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
-            "h": 8,
+            "h": 9,
             "w": 12,
             "x": 12,
             "y": 4
           },
           "hiddenSeries": false,
-          "id": 35,
+          "id": 159,
           "legend": {
             "avg": false,
             "current": false,
             "max": false,
             "min": false,
-            "show": false,
+            "rightSide": false,
+            "show": true,
             "total": false,
             "values": false
           },
@@ -1152,24 +1143,36 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "$$hashKey": "object:369",
+              "alias": "Executor instances",
+              "linewidth": 3
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(buildbuddy_remote_execution_file_upload_size_bytes_sum[${window}]))",
+              "expr": "avg(buildbuddy_remote_execution_queue_length)",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "Avg executor queue length",
               "queryType": "randomWalk",
               "refId": "A"
+            },
+            {
+              "expr": "sum(up{job=\"buildbuddy-executor\"})",
+              "interval": "",
+              "legendFormat": "Executor instances",
+              "refId": "B"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Total uploaded bytes per second",
+          "title": "Executor autoscaling",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1185,8 +1188,8 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:219",
-              "format": "binBps",
+              "$$hashKey": "object:184",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -1194,7 +1197,7 @@
               "show": true
             },
             {
-              "$$hashKey": "object:220",
+              "$$hashKey": "object:185",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -1226,7 +1229,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 12
+            "y": 13
           },
           "hiddenSeries": false,
           "id": 31,
@@ -1283,7 +1286,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:83",
               "format": "ops",
               "label": "",
               "logBase": 1,
@@ -1292,7 +1294,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:84",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -1312,7 +1313,129 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "Prometheus",
-          "decimals": 0,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": null,
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "hiddenSeries": false,
+          "id": 178,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.3.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "avg(buildbuddy_remote_execution_assigned_milli_cpu{job=\"buildbuddy-executor\", pod_name=~\"executor-.*\"}\n  / on (pod_name) (\n  label_replace(kube_pod_container_resource_limits_cpu_cores{pod=~\"executor-.*\"} * 1000, \"pod_name\", \"$1\", \"pod\", \"(.*)\")))",
+              "interval": "",
+              "legendFormat": "Avg CPU assigned",
+              "queryType": "randomWalk",
+              "refId": "A"
+            },
+            {
+              "expr": "avg(buildbuddy_remote_execution_assigned_ram_bytes{job=\"buildbuddy-executor\", pod_name=~\"executor-.*\"}\n  / on (pod_name) (\n  label_replace(kube_pod_container_resource_limits_memory_bytes{pod=~\"executor-.*\"}, \"pod_name\", \"$1\", \"pod\", \"(.*)\")))",
+              "interval": "",
+              "legendFormat": "Avg RAM assigned",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Avg resources allocated to tasks",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:486",
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:487",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "",
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -1324,11 +1447,11 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 12,
-            "y": 12
+            "x": 0,
+            "y": 21
           },
           "hiddenSeries": false,
-          "id": 68,
+          "id": 33,
           "legend": {
             "avg": false,
             "current": false,
@@ -1355,7 +1478,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(up{job=\"buildbuddy-executor\"})",
+              "expr": "sum(rate(buildbuddy_remote_execution_file_download_size_bytes_sum[${window}]))",
               "interval": "",
               "legendFormat": "",
               "queryType": "randomWalk",
@@ -1366,7 +1489,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Remote executor instances",
+          "title": "Total downloaded bytes per second",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1382,9 +1505,7 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:105",
-              "decimals": 0,
-              "format": "short",
+              "format": "binBps",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -1392,7 +1513,104 @@
               "show": true
             },
             {
-              "$$hashKey": "object:106",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "Value": "yellow"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "hiddenSeries": false,
+          "id": 35,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.3.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(buildbuddy_remote_execution_file_upload_size_bytes_sum[${window}]))",
+              "interval": "",
+              "legendFormat": "",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total uploaded bytes per second",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "binBps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -1424,7 +1642,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 20
+            "y": 29
           },
           "hiddenSeries": false,
           "id": 129,
@@ -1481,7 +1699,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:139",
               "decimals": 0,
               "format": "short",
               "label": null,
@@ -1491,7 +1708,205 @@
               "show": true
             },
             {
-              "$$hashKey": "object:140",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 0,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "hiddenSeries": false,
+          "id": 68,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.3.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(up{job=\"buildbuddy-executor\"})",
+              "interval": "",
+              "legendFormat": "",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Remote executor instances",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 37
+          },
+          "hiddenSeries": false,
+          "id": 180,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.3.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"executor-dev\"}[${window}]))",
+              "interval": "",
+              "legendFormat": "CPU usage",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:323",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:324",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -1518,13 +1933,13 @@
             },
             "overrides": []
           },
-          "fill": 1,
+          "fill": 0,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 20
+            "y": 37
           },
           "hiddenSeries": false,
           "id": 102,
@@ -1535,8 +1950,6 @@
             "max": false,
             "min": false,
             "show": true,
-            "sort": "current",
-            "sortDesc": true,
             "total": false,
             "values": true
           },
@@ -1584,7 +1997,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:58",
               "decimals": 0,
               "format": "short",
               "label": null,
@@ -1594,7 +2006,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:59",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -1658,7 +2069,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 5
+            "y": 79
           },
           "hiddenSeries": false,
           "id": 40,
@@ -1683,7 +2094,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1704,7 +2115,6 @@
           "timeFrom": null,
           "timeRegions": [
             {
-              "$$hashKey": "object:1026",
               "colorMode": "background6",
               "fill": true,
               "fillColor": "rgba(234, 112, 112, 0.12)",
@@ -1730,7 +2140,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:144",
               "format": "ops",
               "label": null,
               "logBase": 1,
@@ -1739,7 +2148,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:145",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -1772,7 +2180,7 @@
             "h": 14,
             "w": 24,
             "x": 0,
-            "y": 18
+            "y": 92
           },
           "hiddenSeries": false,
           "id": 76,
@@ -1797,7 +2205,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1834,7 +2242,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:224",
               "format": "µs",
               "label": null,
               "logBase": 1,
@@ -1843,7 +2250,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:225",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -1875,7 +2281,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 32
+            "y": 106
           },
           "hiddenSeries": false,
           "id": 42,
@@ -1895,7 +2301,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1932,7 +2338,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:248",
               "format": "ops",
               "label": null,
               "logBase": 1,
@@ -1941,7 +2346,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:249",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -1975,7 +2379,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 32
+            "y": 106
           },
           "hiddenSeries": false,
           "id": 46,
@@ -1995,7 +2399,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2032,7 +2436,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:535",
               "format": "percent",
               "label": null,
               "logBase": 1,
@@ -2041,7 +2444,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:536",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -2075,7 +2477,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 40
+            "y": 114
           },
           "hiddenSeries": false,
           "id": 44,
@@ -2095,7 +2497,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2132,7 +2534,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:347",
               "format": "ops",
               "label": null,
               "logBase": 1,
@@ -2141,7 +2542,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:348",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -2188,7 +2588,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 6
+            "y": 123
           },
           "hiddenSeries": false,
           "id": 50,
@@ -2208,7 +2608,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2245,7 +2645,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:685",
               "format": "binBps",
               "label": null,
               "logBase": 1,
@@ -2254,7 +2653,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:686",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -2288,7 +2686,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 6
+            "y": 123
           },
           "hiddenSeries": false,
           "id": 53,
@@ -2308,7 +2706,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2345,7 +2743,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:1293",
               "format": "µs",
               "label": null,
               "logBase": 1,
@@ -2354,7 +2751,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:1294",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -2388,7 +2784,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 14
+            "y": 131
           },
           "hiddenSeries": false,
           "id": 51,
@@ -2408,7 +2804,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2445,7 +2841,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:685",
               "format": "binBps",
               "label": null,
               "logBase": 1,
@@ -2454,7 +2849,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:686",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -2488,7 +2882,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 14
+            "y": 131
           },
           "hiddenSeries": false,
           "id": 55,
@@ -2508,7 +2902,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.3.3",
+          "pluginVersion": "7.3.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2545,7 +2939,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:1349",
               "format": "µs",
               "label": null,
               "logBase": 1,
@@ -2554,7 +2947,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:1350",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -2603,7 +2995,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7
+            "y": 140
           },
           "hiddenSeries": false,
           "id": 122,
@@ -2660,7 +3052,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:81",
               "format": "percentunit",
               "label": null,
               "logBase": 1,
@@ -2669,7 +3060,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:82",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -2701,7 +3091,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 7
+            "y": 140
           },
           "hiddenSeries": false,
           "id": 116,
@@ -2762,7 +3152,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:42",
               "format": "ops",
               "label": null,
               "logBase": 1,
@@ -2771,7 +3160,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:43",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -2803,7 +3191,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 15
+            "y": 148
           },
           "hiddenSeries": false,
           "id": 112,
@@ -2864,7 +3252,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:42",
               "format": "ops",
               "label": null,
               "logBase": 1,
@@ -2873,7 +3260,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:43",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -2908,7 +3294,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 15
+            "y": 148
           },
           "hiddenSeries": false,
           "id": 120,
@@ -2969,7 +3355,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:295",
               "format": "ops",
               "label": null,
               "logBase": 1,
@@ -2978,7 +3363,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:296",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -3011,7 +3395,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 156
           },
           "hiddenSeries": false,
           "id": 118,
@@ -3068,7 +3452,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:106",
               "format": "µs",
               "label": null,
               "logBase": 1,
@@ -3077,7 +3460,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:107",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -3109,7 +3491,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 156
           },
           "hiddenSeries": false,
           "id": 124,
@@ -3166,7 +3548,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:182",
               "format": "bytes",
               "label": null,
               "logBase": 1,
@@ -3175,7 +3556,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:183",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -3223,7 +3603,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 7
+            "y": 165
           },
           "hiddenSeries": false,
           "id": 85,
@@ -3294,7 +3674,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:153",
               "format": "bytes",
               "label": null,
               "logBase": 1,
@@ -3303,7 +3682,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:154",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -3335,7 +3713,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 7
+            "y": 165
           },
           "hiddenSeries": false,
           "id": 87,
@@ -3402,7 +3780,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:232",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -3411,7 +3788,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:233",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -3444,7 +3820,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16
+            "y": 174
           },
           "hiddenSeries": false,
           "id": 91,
@@ -3511,7 +3887,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:383",
               "decimals": null,
               "format": "percentunit",
               "label": null,
@@ -3521,7 +3896,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:384",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -3553,7 +3927,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16
+            "y": 174
           },
           "hiddenSeries": false,
           "id": 93,
@@ -3620,7 +3994,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:487",
               "format": "s",
               "label": null,
               "logBase": 1,
@@ -3629,7 +4002,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:488",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -3664,7 +4036,7 @@
         "x": 0,
         "y": 8
       },
-      "id": 134,
+      "id": 181,
       "panels": [
         {
           "aliasColors": {},
@@ -3685,10 +4057,10 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 7
+            "y": 165
           },
           "hiddenSeries": false,
-          "id": 135,
+          "id": 182,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -3713,7 +4085,7 @@
           "points": false,
           "renderer": "flot",
           "repeat": null,
-          "repeatIteration": 1608060929149,
+          "repeatIteration": 1608672678808,
           "repeatPanelId": 85,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3759,7 +4131,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:153",
               "format": "bytes",
               "label": null,
               "logBase": 1,
@@ -3768,7 +4139,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:154",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -3800,10 +4170,10 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 7
+            "y": 165
           },
           "hiddenSeries": false,
-          "id": 136,
+          "id": 183,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -3827,7 +4197,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1608060929149,
+          "repeatIteration": 1608672678808,
           "repeatPanelId": 87,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3870,7 +4240,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:232",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -3879,7 +4248,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:233",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -3912,10 +4280,10 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16
+            "y": 174
           },
           "hiddenSeries": false,
-          "id": 137,
+          "id": 184,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -3939,7 +4307,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1608060929149,
+          "repeatIteration": 1608672678808,
           "repeatPanelId": 91,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3982,7 +4350,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:383",
               "decimals": null,
               "format": "percentunit",
               "label": null,
@@ -3992,7 +4359,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:384",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -4024,10 +4390,10 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16
+            "y": 174
           },
           "hiddenSeries": false,
-          "id": 138,
+          "id": 185,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -4051,7 +4417,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1608060929149,
+          "repeatIteration": 1608672678808,
           "repeatPanelId": 93,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4094,7 +4460,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:487",
               "format": "s",
               "label": null,
               "logBase": 1,
@@ -4103,7 +4468,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:488",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -4118,7 +4482,7 @@
           }
         }
       ],
-      "repeatIteration": 1608060929149,
+      "repeatIteration": 1608672678808,
       "repeatPanelId": 83,
       "scopedVars": {
         "job": {
@@ -4244,7 +4608,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:462",
               "format": "ops",
               "label": null,
               "logBase": 1,
@@ -4253,7 +4616,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:463",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -4353,7 +4715,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:408",
               "format": "ops",
               "label": null,
               "logBase": 1,
@@ -4362,7 +4723,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:409",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -4397,7 +4757,7 @@
         "x": 0,
         "y": 10
       },
-      "id": 139,
+      "id": 186,
       "panels": [
         {
           "aliasColors": {
@@ -4437,7 +4797,7 @@
             "y": 8
           },
           "hiddenSeries": false,
-          "id": 140,
+          "id": 187,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -4462,7 +4822,7 @@
           "points": false,
           "renderer": "flot",
           "repeat": null,
-          "repeatIteration": 1608060929149,
+          "repeatIteration": 1608672678808,
           "repeatPanelId": 73,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4505,7 +4865,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:462",
               "format": "ops",
               "label": null,
               "logBase": 1,
@@ -4514,7 +4873,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:463",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -4549,7 +4907,7 @@
             "y": 8
           },
           "hiddenSeries": false,
-          "id": 141,
+          "id": 188,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -4574,7 +4932,7 @@
           "points": false,
           "renderer": "flot",
           "repeat": null,
-          "repeatIteration": 1608060929149,
+          "repeatIteration": 1608672678808,
           "repeatPanelId": 79,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4617,7 +4975,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:408",
               "format": "ops",
               "label": null,
               "logBase": 1,
@@ -4626,7 +4983,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:409",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -4641,7 +4997,7 @@
           }
         }
       ],
-      "repeatIteration": 1608060929149,
+      "repeatIteration": 1608672678808,
       "repeatPanelId": 71,
       "scopedVars": {
         "job": {
@@ -4757,7 +5113,6 @@
           },
           "yaxes": [
             {
-              "$$hashKey": "object:33",
               "format": "µs",
               "label": "",
               "logBase": 1,
@@ -4766,7 +5121,6 @@
               "show": true
             },
             {
-              "$$hashKey": "object:34",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -4785,7 +5139,7 @@
       "type": "row"
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 26,
   "style": "dark",
   "tags": [],


### PR DESCRIPTION
Added the charts seen in this screenshot (except for the bottom left, which is already in the dashboard):

![image](https://user-images.githubusercontent.com/2414826/102936130-98c76980-4475-11eb-958e-3b2b101613ff.png)




