### PR TITLE
Include Invocation command in prometheus metrics

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -181,9 +181,11 @@ func recordInvocationMetrics(ti *tables.Invocation) {
 	statusLabel := invocationStatusLabel(ti)
 	metrics.InvocationCount.With(prometheus.Labels{
 		metrics.InvocationStatusLabel: statusLabel,
+		metrics.BazelCommand:          ti.Command,
 	}).Inc()
 	metrics.InvocationDurationUs.With(prometheus.Labels{
 		metrics.InvocationStatusLabel: statusLabel,
+		metrics.BazelCommand:          ti.Command,
 	}).Observe(float64(ti.DurationUsec))
 }
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -58,6 +58,9 @@ const (
 
 	/// HTTP response code: `200`, `302`, `401`, `404`, `500`, ...
 	HTTPResponseCodeLabel = "code"
+
+	/// Command provided to the Bazel daemon: `run`, `test`, `build`, `coverage`, `mobile-install`, ...
+	BazelCommand = "bazel_command"
 )
 
 const (
@@ -75,8 +78,8 @@ var (
 		Name:      "count",
 		Help:      "The total number of invocations whose logs were uploaded to BuildBuddy.",
 	}, []string{
-		// TODO: Slice on build vs. test?
 		InvocationStatusLabel,
+		BazelCommand,
 	})
 
 	/// #### Examples
@@ -98,8 +101,8 @@ var (
 		Buckets:   prometheus.ExponentialBuckets(1, 10, 9),
 		Help:      "The total duration of each invocation, in **microseconds**.",
 	}, []string{
-		// TODO: Slice on build vs. test
 		InvocationStatusLabel,
+		BazelCommand,
 	})
 
 	/// #### Examples


### PR DESCRIPTION
## Description

Add the command provided to the bazel daemon for the following
prometheus metrics:

- buildbuddy_invocation_count
- buildbuddy_invocation_duration_usec

Implements TODO from [here](https://github.com/buildbuddy-io/buildbuddy/commit/80d1bb82a1dcb599450cc424230e35f5ae23e310#diff-fb24a922f09c46a70f00f742fb2d6b91d52eb8f1bab5ce24043c47759224ae99R51).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A
