### PR TITLE
Ensure that ExtendContextForFinalization doesn't shorten the deadline

### DIFF
--- a/server/util/background/background.go
+++ b/server/util/background/background.go
@@ -29,5 +29,13 @@ func (ctx disconnectedContext) Value(key interface{}) interface{} {
 // to make a copy of your expired context and do your cleanup work.
 func ExtendContextForFinalization(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	ctx := disconnectedContext{parent: parent}
+	// If the original context already had a deadline, ensure that the given timeout
+	// doesn't result in a new deadline that's even shorter.
+	if originalDeadline, ok := parent.Deadline(); ok {
+		remainingTime := originalDeadline.Sub(time.Now())
+		if remainingTime > timeout {
+			timeout = remainingTime
+		}
+	}
 	return context.WithTimeout(ctx, timeout)
 }


### PR DESCRIPTION
## Description

Ensure that `ExtendContextForFinalization` doesn't shorten the deadline. This way, if the finalization phase of a request is taking too long and causing a timeout, the user can choose to extend the requested timeout to allow for the finalization to complete, instead of being limited to the timeout provided in the argument of this func.

## Type of change

Bug fix (non-breaking change that fixes an issue)
