### PR TITLE
prometheus workflow: Make sure prometheus server is up before opening Grafana

### DIFF
--- a/tools/metrics/run.sh
+++ b/tools/metrics/run.sh
@@ -21,7 +21,7 @@ GRAFANA_DASHBOARD_FILE_PATH="./grafana/dashboards/buildbuddy.json"
 (
   open=$(which open &>/dev/null && echo "open" || echo "xdg-open")
   tries=100
-  while ! curl "$GRAFANA_STARTUP_URL" &>/dev/null ; do
+  while ! ( curl "$GRAFANA_STARTUP_URL" &>/dev/null && curl "http://localhost:9100/metrics" &>/dev/null ); do
     sleep 0.5
     tries=$(( tries - 1 ))
     if [[ $tries == 0 ]] ; then


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Have had this sitting in my local repo for a while. Just a small quality-of-life improvement (for local development only) that prevents Grafana from flooding the UI with "not found" errors while waiting for the Prometheus server to start up.

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
