### PR TITLE
testing: Have test env clean up after itself

### DIFF
--- a/enterprise/server/workflow/workflow_test.go
+++ b/enterprise/server/workflow/workflow_test.go
@@ -39,8 +39,7 @@ func runBBServer(ctx context.Context, env *environment.TestEnv, t *testing.T) *g
 
 func TestCreate(t *testing.T) {
 	ctx := context.Background()
-	te, err := environment.GetTestEnv()
-	assert.Nil(t, err)
+	te := environment.GetTestEnv(t)
 	te.SetWorkflowService(workflow.NewWorkflowService(te))
 
 	authenticator := auth.NewTestAuthenticator(auth.TestUsers("USER1", "GROUP1"))
@@ -72,10 +71,7 @@ func TestCreate(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	ctx := context.Background()
-	te, err := environment.GetTestEnv()
-	if err != nil {
-		t.Error(err)
-	}
+	te := environment.GetTestEnv(t)
 	te.SetWorkflowService(workflow.NewWorkflowService(te))
 	authenticator := auth.NewTestAuthenticator(auth.TestUsers("USER1", "GROUP1"))
 	te.SetAuthenticator(authenticator)
@@ -106,10 +102,7 @@ func TestDelete(t *testing.T) {
 
 func TestList(t *testing.T) {
 	ctx := context.Background()
-	te, err := environment.GetTestEnv()
-	if err != nil {
-		t.Error(err)
-	}
+	te := environment.GetTestEnv(t)
 	te.SetWorkflowService(workflow.NewWorkflowService(te))
 	authenticator := auth.NewTestAuthenticator(auth.TestUsers("USER1", "GROUP1", "USER2", "GROUP2"))
 	te.SetAuthenticator(authenticator)

--- a/enterprise/server/workflow/workflow_test.go
+++ b/enterprise/server/workflow/workflow_test.go
@@ -88,7 +88,7 @@ func TestDelete(t *testing.T) {
 		Perms:      48,
 		RepoURL:    "git@github.com:buildbuddy-io/buildbuddy.git",
 	}
-	err = te.GetDBHandle().Create(&row).Error
+	err := te.GetDBHandle().Create(&row).Error
 	assert.Nil(t, err)
 
 	req := &wfpb.DeleteWorkflowRequest{Id: "WF1"}
@@ -120,7 +120,7 @@ func TestList(t *testing.T) {
 		RepoURL:    "git@github.com:buildbuddy-io/buildbuddy.git",
 		WebhookID:  "WHID1",
 	}
-	err = te.GetDBHandle().Create(&row).Error
+	err := te.GetDBHandle().Create(&row).Error
 	assert.Nil(t, err)
 
 	row2 := &tables.Workflow{

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -97,7 +97,7 @@ func TestRPCRead(t *testing.T) {
 		},
 	}
 
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, te)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te)
 	if err != nil {
 		t.Errorf("error attaching user prefix: %v", err)
 	}

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -63,10 +63,7 @@ func readBlob(ctx context.Context, bsClient bspb.ByteStreamClient, d *digest.Ins
 
 func TestRPCRead(t *testing.T) {
 	ctx := context.Background()
-	te, err := environment.GetTestEnv()
-	if err != nil {
-		t.Error(err)
-	}
+	te := environment.GetTestEnv(t)
 	clientConn := runByteStreamServer(ctx, te, t)
 	bsClient := bspb.NewByteStreamClient(clientConn)
 

--- a/server/testutil/environment/environment.go
+++ b/server/testutil/environment/environment.go
@@ -98,7 +98,7 @@ func writeTmpConfigFile(testRootDir string) (string, error) {
 
 func GetTestEnv(t *testing.T) *TestEnv {
 	testRootDir, err := ioutil.TempDir("/tmp", "buildbuddy_test_*")
-	if err == nil {
+	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {

--- a/server/util/capabilities/capabilities_test.go
+++ b/server/util/capabilities/capabilities_test.go
@@ -20,10 +20,7 @@ var (
 )
 
 func getTestEnv(t *testing.T, users map[string]interfaces.UserInfo) *testenv.TestEnv {
-	te, err := testenv.GetTestEnv()
-	if err != nil {
-		t.Fatal(err)
-	}
+	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(users))
 	return te
 }


### PR DESCRIPTION
Update the test env so that it writes all files to a single output dir which is deleted at the end of each test.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
