### PR TITLE
Return PermissionDenied instead of Unimplemented when AuthenticatedUser is called and auth isn't configured

### DIFF
--- a/server/nullauth/nullauth.go
+++ b/server/nullauth/nullauth.go
@@ -20,7 +20,7 @@ func (a *NullAuthenticator) AuthenticateGRPCRequest(ctx context.Context) context
 }
 
 func (a *NullAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces.UserInfo, error) {
-	return nil, status.PermissionDeniedError("Auth not implemented context")
+	return nil, status.PermissionDeniedError("Auth not implemented")
 }
 
 func (a *NullAuthenticator) FillUser(ctx context.Context, user *tables.User) error {

--- a/server/nullauth/nullauth.go
+++ b/server/nullauth/nullauth.go
@@ -20,7 +20,7 @@ func (a *NullAuthenticator) AuthenticateGRPCRequest(ctx context.Context) context
 }
 
 func (a *NullAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces.UserInfo, error) {
-	return nil, status.UnimplementedError("Auth not implemented")
+	return nil, status.PermissionDeniedError("Auth not implemented context")
 }
 
 func (a *NullAuthenticator) FillUser(ctx context.Context, user *tables.User) error {

--- a/server/util/capabilities/BUILD
+++ b/server/util/capabilities/BUILD
@@ -31,6 +31,7 @@ go_test(
         "//enterprise/server/auth:go_default_library",
         "//proto:api_key_go_proto",
         "//server/interfaces:go_default_library",
+        "//server/nullauth:go_default_library",
         "//server/testutil/auth:go_default_library",
         "//server/testutil/environment:go_default_library",
         "//server/util/testing/flags:go_default_library",

--- a/server/util/capabilities/capabilities_test.go
+++ b/server/util/capabilities/capabilities_test.go
@@ -2,10 +2,11 @@ package capabilities_test
 
 import (
 	"context"
-	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/auth"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/nullauth"
 	"github.com/buildbuddy-io/buildbuddy/server/util/capabilities"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
@@ -73,6 +74,17 @@ func TestIsGranted_AnonymousUsageDisabled_AnonymousUser_False(t *testing.T) {
 func TestIsGranted_AnonymousUsageEnabled_AnonymousUser_True(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	flags.Set(t, "auth.enable_anonymous_usage", "true")
+	anonCtx := context.Background()
+
+	canWrite, err := capabilities.IsGranted(anonCtx, te, akpb.ApiKey_CACHE_WRITE_CAPABILITY)
+
+	assert.True(t, canWrite)
+	assert.Nil(t, err)
+}
+
+func TestIsGranted_NullAuthenticator(t *testing.T) {
+	te := getTestEnv(t, emptyUserMap)
+	te.SetAuthenticator(&nullauth.NullAuthenticator{})
 	anonCtx := context.Background()
 
 	canWrite, err := capabilities.IsGranted(anonCtx, te, akpb.ApiKey_CACHE_WRITE_CAPABILITY)


### PR DESCRIPTION
This allows us to hit this line in capabilities and behave as an anonymous user:
https://github.com/buildbuddy-io/buildbuddy/blob/92e09977857c8e006d0df62e7c85c62755e9c5b6/server/util/capabilities/capabilities.go#L55

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
