### PR TITLE
dev workflow: Allow setting docker --net=host via BB config

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -156,6 +156,7 @@ type ExecutorConfig struct {
 	LocalCacheDirectory string `yaml:"local_cache_directory" usage:"A local on-disk cache directory."`
 	LocalCacheSizeBytes int64  `yaml:"local_cache_size_bytes" usage:"The maximum size, in bytes, to use for the local on-disk cache"`
 	DockerSocket        string `yaml:"docker_socket" usage:"If set, run execution commands in docker using the provided socket."`
+	DockerNetHost       bool   `yaml:"docker_net_host" usage:"Sets --net=host on the docker command. Intended for local development only."`
 	ContainerdSocket    string `yaml:"containerd_socket" usage:"(UNSTABLE) If set, run execution commands in containerd using the provided socket."`
 }
 


### PR DESCRIPTION
This flag allows local Docker executors to run in the host's network namespace, so that `--bes_backend=grpc://localhost:1985` in the workflow execution command works.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
