### PR TITLE
workflows: Set user / host metadata for CI runs

### DIFF
--- a/enterprise/server/workflow/workflow.go
+++ b/enterprise/server/workflow/workflow.go
@@ -26,8 +26,10 @@ import (
 )
 
 var (
-	workflowURLMatcher  = regexp.MustCompile(`^.*/webhooks/workflow/(?P<instance_name>.*)$`)
-	defaultInstanceName = "ci"
+	workflowURLMatcher   = regexp.MustCompile(`^.*/webhooks/workflow/(?P<instance_name>.*)$`)
+	defaultInstanceName  = "ci"
+	buildbuddyCIUserName = "buildbuddy"
+	buildbuddyCIHostName = "buildbuddy-ci-runner"
 )
 
 type webhookData struct {
@@ -339,7 +341,11 @@ func (ws *workflowService) checkStartWorkflowPreconditions(ctx context.Context) 
 
 func (ws *workflowService) getBazelFlags(ak *tables.APIKey) []string {
 	flags := make([]string, 0)
-	flags = append(flags, "--remote_header=x-buildbuddy-api-key="+ak.Value)
+	flags = append(flags,
+		"--remote_header=x-buildbuddy-api-key="+ak.Value,
+		"--build_metadata=USER="+buildbuddyCIUserName,
+		"--build_metadata=HOST="+buildbuddyCIHostName,
+	)
 	if eventsAPIURL := ws.env.GetConfigurator().GetAppEventsAPIURL(); eventsAPIURL != "" {
 		flags = append(flags, "--bes_backend="+eventsAPIURL)
 	}


### PR DESCRIPTION
For CI runs, this PR sets the user@host to `buildbuddy@buildbuddy-ci-runner`.

![image](https://user-images.githubusercontent.com/2414826/108122756-c6462300-7072-11eb-866f-0393be890053.png)

This changes the current behavior in the following ways:

* For Docker executors, this PR changes the current behavior of always using `root@localhost` as the user+host for CI runs.
* For bare executors, the existing behavior (AFAICT) was to show the real user + host of the deployed executor. Maybe this is actually desired? Happy to look for alternate solutions if we do want to preserve this behavior, but we should also talk about how to be consistent w/ Docker-based executors. Maybe for Docker based executors we should show the username and host as well.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
