### PR TITLE
workflows: Prevent webhook endpoints from being retried

### DIFF
--- a/enterprise/server/workflow/workflow.go
+++ b/enterprise/server/workflow/workflow.go
@@ -443,5 +443,4 @@ func (ws *workflowService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Printf("failed to start workflow: %s", err)
 		return
 	}
-	w.Write([]byte("OK"))
 }


### PR DESCRIPTION
Return the HTTP response to the webhook endpoint client as soon as possible so that they don't try to retry the request, causing duplicate workflows to be kicked off.

Stumbled upon https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#webhook-endpoint-tips and figured we may as well implement the tips there.

---

**Version bump**: Patch

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
