### PR TITLE
workflows: Fix some issues with run script

### DIFF
--- a/enterprise/server/workflowcmd/workflowcmd_test.go
+++ b/enterprise/server/workflowcmd/workflowcmd_test.go
@@ -9,14 +9,23 @@ import (
 
 func TestGenerateShellScript(t *testing.T) {
 	ci := &workflowcmd.CommandInfo{
-		RepoURL:   "git@github.com:buildbuddy-io/buildbuddy.git",
-		CommitSHA: "ABCD123",
+		RepoURL:   "https://github.com/buildbuddy-io/buildbuddy",
+		CommitSHA: "59ed6f6a4b185a7d8bcf25641bd3c23d2c0ca259",
 	}
 
 	scriptBytes, err := workflowcmd.GenerateShellScript(ci)
+
 	script := string(scriptBytes)
-	assert.Nil(t, err)
-	assert.Regexp(t, "git clone -q git@github.com:buildbuddy-io/buildbuddy.git", script, "script should clone repo")
-	assert.Regexp(t, "git checkout -q ABCD123", script, "script should checkout SHA")
-	assert.Regexp(t, "bazelisk test //...", script, "script should run bazelisk test")
+	assert.NoError(t, err)
+	assert.Equal(t, script, `#!/bin/bash
+set -o errexit
+set -o pipefail
+mkdir buildbuddy
+cd buildbuddy
+git init
+git remote add origin https://github.com/buildbuddy-io/buildbuddy
+git fetch origin 59ed6f6a4b185a7d8bcf25641bd3c23d2c0ca259
+git checkout 59ed6f6a4b185a7d8bcf25641bd3c23d2c0ca259
+bazelisk test //...
+`)
 }


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

* Fetch only the commit SHA from the git remote ("shallow clone")
* Make the `run.sh` script exit if any commands fail (e.g. if `git fetch` fails, then `bazel` shouldn't execute). This will also cause `bazel` commands to be skipped if a previous command failed.
* Update the test with a real repo URL and commit SHA -- you can try running `cd $(mktemp -d)` then run the script shown in the test, for verification that it works

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->
