### PR TITLE
Add memory_cache tests.

### DIFF
--- a/enterprise/server/util/cacheproxy/cacheproxy_test.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/app"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
-
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 
 	testauth "github.com/buildbuddy-io/buildbuddy/server/testutil/auth"

--- a/server/backends/memory_cache/BUILD
+++ b/server/backends/memory_cache/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -12,5 +12,21 @@ go_library(
         "//server/util/lru:go_default_library",
         "//server/util/prefix:go_default_library",
         "//server/util/status:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["memory_cache_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/interfaces:go_default_library",
+        "//server/remote_cache/digest:go_default_library",
+        "//server/testutil/auth:go_default_library",
+        "//server/testutil/digest:go_default_library",
+        "//server/testutil/environment:go_default_library",
+        "//server/util/prefix:go_default_library",
+        "//server/util/testing/flags:go_default_library",
     ],
 )

--- a/server/backends/memory_cache/memory_cache_test.go
+++ b/server/backends/memory_cache/memory_cache_test.go
@@ -1,0 +1,238 @@
+package memory_cache_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/backends/memory_cache"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	testauth "github.com/buildbuddy-io/buildbuddy/server/testutil/auth"
+	testdigest "github.com/buildbuddy-io/buildbuddy/server/testutil/digest"
+	testenv "github.com/buildbuddy-io/buildbuddy/server/testutil/environment"
+)
+
+var (
+	emptyUserMap = testauth.TestUsers()
+)
+
+func getTestEnv(t *testing.T, users map[string]interfaces.UserInfo) *testenv.TestEnv {
+	te := testenv.GetTestEnv(t)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(users))
+	return te
+}
+
+func getAnonContext(t *testing.T) context.Context {
+	flags.Set(t, "auth.enable_anonymous_usage", "true")
+	te := getTestEnv(t, emptyUserMap)
+	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), te)
+	if err != nil {
+		t.Errorf("error attaching user prefix: %v", err)
+	}
+	return ctx
+}
+
+func TestGetSet(t *testing.T) {
+	maxSizeBytes := int64(1000000000) // 1GB
+	mc, err := memory_cache.NewMemoryCache(maxSizeBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testSizes := []int64{
+		1, 10, 100, 1000, 10000, 1000000, 10000000,
+	}
+	for _, testSize := range testSizes {
+		ctx := getAnonContext(t)
+		d, buf := testdigest.NewRandomDigestBuf(t, testSize)
+		// Set() the bytes in the cache.
+		err := mc.Set(ctx, d, buf)
+		if err != nil {
+			t.Fatalf("Error setting %q in cache: %s", d.GetHash(), err.Error())
+		}
+		// Get() the bytes from the cache.
+		rbuf, err := mc.Get(ctx, d)
+		if err != nil {
+			t.Fatalf("Error getting %q from cache: %s", d.GetHash(), err.Error())
+		}
+
+		// Compute a digest for the bytes returned.
+		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		if d.GetHash() != d2.GetHash() {
+			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), d.GetHash())
+		}
+	}
+}
+
+func randomDigests(t *testing.T, sizes ...int64) map[*repb.Digest][]byte {
+	m := make(map[*repb.Digest][]byte)
+	for _, size := range sizes {
+		d, buf := testdigest.NewRandomDigestBuf(t, size)
+		m[d] = buf
+	}
+	return m
+}
+
+func TestMultiGetSet(t *testing.T) {
+	maxSizeBytes := int64(1000000000) // 1GB
+	mc, err := memory_cache.NewMemoryCache(maxSizeBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := getAnonContext(t)
+	digests := randomDigests(t, 10, 20, 11, 30, 40)
+	if err := mc.SetMulti(ctx, digests); err != nil {
+		t.Fatalf("Error multi-setting digests: %s", err.Error())
+	}
+	digestKeys := make([]*repb.Digest, 0, len(digests))
+	for d, _ := range digests {
+		digestKeys = append(digestKeys, d)
+	}
+	m, err := mc.GetMulti(ctx, digestKeys)
+	if err != nil {
+		t.Fatalf("Error multi-getting digests: %s", err.Error())
+	}
+	for d, _ := range digests {
+		rbuf, ok := m[d]
+		if !ok {
+			t.Fatalf("Multi-get failed to return expected digest: %q", d.GetHash())
+		}
+		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.GetHash() != d2.GetHash() {
+			t.Fatalf("Returned digest %q did not match multi-set value: %q", d2.GetHash(), d.GetHash())
+		}
+	}
+}
+
+func TestReadWrite(t *testing.T) {
+	maxSizeBytes := int64(1000000000) // 1GB
+	mc, err := memory_cache.NewMemoryCache(maxSizeBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testSizes := []int64{
+		1, 10, 100, 1000, 10000, 1000000, 10000000,
+	}
+	for _, testSize := range testSizes {
+		ctx := getAnonContext(t)
+		d, r := testdigest.NewRandomDigestReader(t, testSize)
+		// Use Writer() to set the bytes in the cache.
+		wc, err := mc.Writer(ctx, d)
+		if err != nil {
+			t.Fatalf("Error getting %q writer: %s", d.GetHash(), err.Error())
+		}
+		if _, err := io.Copy(wc, r); err != nil {
+			t.Fatalf("Error copying bytes to cache: %s", err.Error())
+		}
+		if err := wc.Close(); err != nil {
+			t.Fatalf("Error closing writer: %s", err.Error())
+		}
+		// Use Reader() to get the bytes from the cache.
+		reader, err := mc.Reader(ctx, d, 0)
+		if err != nil {
+			t.Fatalf("Error getting %q reader: %s", d.GetHash(), err.Error())
+		}
+
+		// Compute a digest for the bytes returned.
+		d2, err := digest.Compute(reader)
+		if d.GetHash() != d2.GetHash() {
+			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), d.GetHash())
+		}
+	}
+}
+
+func TestSizeLimit(t *testing.T) {
+	maxSizeBytes := int64(1000) // 1000 bytes
+	mc, err := memory_cache.NewMemoryCache(maxSizeBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := getAnonContext(t)
+	digestBufs := randomDigests(t, 400, 400, 400)
+	digestKeys := make([]*repb.Digest, 0, len(digestBufs))
+	for d, buf := range digestBufs {
+		if err := mc.Set(ctx, d, buf); err != nil {
+			t.Fatalf("Error setting %q in cache: %s", d.GetHash(), err.Error())
+		}
+		digestKeys = append(digestKeys, d)
+	}
+	// Expect the last *2* digests to be present.
+	// The first digest should have been evicted.
+	for i, d := range digestKeys {
+		rbuf, err := mc.Get(ctx, d)
+		if i == 0 {
+			if err == nil {
+				t.Fatalf("%q should have been evicted from cache", d.GetHash())
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("Error getting %q from cache: %s", d.GetHash(), err.Error())
+		}
+		// Compute a digest for the bytes returned.
+		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		if d.GetHash() != d2.GetHash() {
+			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), d.GetHash())
+		}
+	}
+}
+
+func TestLRU(t *testing.T) {
+	maxSizeBytes := int64(1000) // 1000 bytes
+	mc, err := memory_cache.NewMemoryCache(maxSizeBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := getAnonContext(t)
+	digestBufs := randomDigests(t, 400, 400)
+	digestKeys := make([]*repb.Digest, 0, len(digestBufs))
+	for d, buf := range digestBufs {
+		if err := mc.Set(ctx, d, buf); err != nil {
+			t.Fatalf("Error setting %q in cache: %s", d.GetHash(), err.Error())
+		}
+		digestKeys = append(digestKeys, d)
+	}
+	// Now "use" the first digest written so it is most recently used.
+	ok, err := mc.Contains(ctx, digestKeys[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatalf("Key %q was not present in cache, it should have been.", digestKeys[0].GetHash())
+	}
+	// Now write one more digest, which should evict the oldest digest,
+	// (the second one we wrote).
+	d, buf := testdigest.NewRandomDigestBuf(t, 400)
+	if err := mc.Set(ctx, d, buf); err != nil {
+		t.Fatal(err)
+	}
+	digestKeys = append(digestKeys, d)
+
+	// Expect the first and third digests to be present.
+	// The second digest should have been evicted.
+	for i, d := range digestKeys {
+		rbuf, err := mc.Get(ctx, d)
+		if i == 1 {
+			if err == nil {
+				t.Fatalf("%q should have been evicted from cache", d.GetHash())
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("Error getting %q from cache: %s", d.GetHash(), err.Error())
+		}
+		// Compute a digest for the bytes returned.
+		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		if d.GetHash() != d2.GetHash() {
+			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), d.GetHash())
+		}
+	}
+}

--- a/server/testutil/digest/BUILD
+++ b/server/testutil/digest/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["digest.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/digest",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/remote_cache/digest:go_default_library",
+    ],
+)

--- a/server/testutil/digest/digest.go
+++ b/server/testutil/digest/digest.go
@@ -1,0 +1,70 @@
+package digest
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	realdigest "github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+)
+
+var (
+	randomSeedOnce sync.Once
+	randomSrc      io.Reader
+)
+
+type randomDataMaker struct {
+	src rand.Source
+}
+
+func (r *randomDataMaker) Read(p []byte) (n int, err error) {
+	todo := len(p)
+	offset := 0
+	for {
+		val := int64(r.src.Int63())
+		for i := 0; i < 8; i++ {
+			p[offset] = byte(val & 0xff)
+			todo--
+			if todo == 0 {
+				return len(p), nil
+			}
+			offset++
+			val >>= 8
+		}
+	}
+
+	panic("unreachable")
+}
+
+func NewRandomDigestReader(t *testing.T, sizeBytes int64) (*repb.Digest, io.ReadSeeker) {
+	randomSeedOnce.Do(func() {
+		randomSrc = &randomDataMaker{rand.NewSource(time.Now().Unix())}
+	})
+
+	// Read some random bytes.
+	buf := new(bytes.Buffer)
+	io.CopyN(buf, randomSrc, sizeBytes)
+	readSeeker := bytes.NewReader(buf.Bytes())
+
+	// Compute a digest for the random bytes.
+	d, err := realdigest.Compute(readSeeker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	readSeeker.Seek(0, 0)
+	return d, readSeeker
+}
+
+func NewRandomDigestBuf(t *testing.T, sizeBytes int64) (*repb.Digest, []byte) {
+	d, rs := NewRandomDigestReader(t, sizeBytes)
+	buf, err := ioutil.ReadAll(rs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d, buf
+}

--- a/server/util/lru/lru.go
+++ b/server/util/lru/lru.go
@@ -89,8 +89,14 @@ func (c *LRU) Get(key interface{}) (value interface{}, ok bool) {
 // Contains checks if a key is in the cache, without updating the recent-ness
 // or deleting it for being stale.
 func (c *LRU) Contains(key interface{}) (ok bool) {
-	_, ok = c.items[key]
-	return ok
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		if ent.Value.(*Entry) == nil {
+			return false
+		}
+		return true
+	}
+	return false
 }
 
 // Peek returns the key value (or undefined if not found) without updating


### PR DESCRIPTION
Add tests and associated utils to test the in-memory LRU digest cache. This also fixes a small bug in the LRU where Contains was not properly updating the eviction list.