### PR TITLE
Fix broken BES stream when we receive progress event before started event

### DIFF
--- a/server/build_event_protocol/build_event_handler/BUILD
+++ b/server/build_event_protocol/build_event_handler/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -28,5 +28,23 @@ go_library(
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["build_event_handler_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//proto:build_event_stream_go_proto",
+        "//proto:build_events_go_proto",
+        "//proto:command_line_go_proto",
+        "//proto:invocation_go_proto",
+        "//proto:publish_build_event_go_proto",
+        "//server/build_event_protocol/event_parser:go_default_library",
+        "//server/testutil/auth:go_default_library",
+        "//server/testutil/environment:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:any_go_proto",
     ],
 )

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -308,8 +308,8 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 		}
 	} else if !e.hasReceivedStartedEvent {
 		e.eventsBeforeStarted = append(e.eventsBeforeStarted, event)
-		if len(e.eventsBeforeStarted) > 100 {
-			log.Printf("We got over 100 build events before the started event for invocation %s, dropping %+v", iid, e.eventsBeforeStarted[0])
+		if len(e.eventsBeforeStarted) > 10 {
+			log.Printf("We got over 10 build events before the started event for invocation %s, dropping %+v", iid, e.eventsBeforeStarted[0])
 			e.eventsBeforeStarted = e.eventsBeforeStarted[1:]
 		}
 		return nil

--- a/server/build_event_protocol/build_event_handler/build_event_handler_test.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler_test.go
@@ -1,0 +1,245 @@
+package build_event_handler_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
+	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_handler"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/environment"
+	"github.com/stretchr/testify/assert"
+
+	bepb "github.com/buildbuddy-io/buildbuddy/proto/build_events"
+	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
+	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
+	testauth "github.com/buildbuddy-io/buildbuddy/server/testutil/auth"
+	anypb "github.com/golang/protobuf/ptypes/any"
+)
+
+func streamRequest(anyEvent *anypb.Any, iid string, sequenceNumer int64) *pepb.PublishBuildToolEventStreamRequest {
+	return &pepb.PublishBuildToolEventStreamRequest{
+		OrderedBuildEvent: &pepb.OrderedBuildEvent{
+			SequenceNumber: sequenceNumer,
+			StreamId:       &bepb.StreamId{InvocationId: iid},
+			Event: &bepb.BuildEvent{
+				Event: &bepb.BuildEvent_BazelEvent{
+					BazelEvent: anyEvent,
+				},
+			},
+		},
+	}
+}
+
+func progressEvent() *anypb.Any {
+	progressAny := &anypb.Any{}
+	progressAny.MarshalFrom(&build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_Progress{
+			Progress: &build_event_stream.Progress{
+				Stderr: "stderr",
+				Stdout: "stdout",
+			},
+		},
+	})
+	return progressAny
+}
+
+func workspaceStatusEvent(key, value string) *anypb.Any {
+	progressAny := &anypb.Any{}
+	progressAny.MarshalFrom(&build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_WorkspaceStatus{
+			WorkspaceStatus: &build_event_stream.WorkspaceStatus{
+				Item: []*build_event_stream.WorkspaceStatus_Item{
+					&build_event_stream.WorkspaceStatus_Item{Key: key, Value: value},
+				},
+			},
+		},
+	})
+	return progressAny
+}
+
+func startedEvent(options string) *anypb.Any {
+	progressAny := &anypb.Any{}
+	progressAny.MarshalFrom(&build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_Started{
+			Started: &build_event_stream.BuildStarted{
+				OptionsDescription: options,
+			},
+		},
+	})
+	return progressAny
+}
+
+func TestUnauthenticatedHandleEventWithStartedFirst(t *testing.T) {
+	te := environment.GetTestEnv(t)
+	auth := testauth.NewTestAuthenticator(testauth.TestUsers("USER1", "GROUP1"))
+	te.SetAuthenticator(auth)
+	ctx := context.Background()
+
+	handler := build_event_handler.NewBuildEventHandler(te)
+	channel := handler.OpenChannel(ctx, "test-invocation-id")
+
+	// Send unauthenticated started event without an api key
+	request := streamRequest(startedEvent("--remote_upload_local_results"), "test-invocation-id", 1)
+	err := channel.HandleEvent(request)
+	assert.NoError(t, err)
+
+	// Look up the invocation and make sure it's public
+	invocation, err := build_event_handler.LookupInvocation(te, ctx, "test-invocation-id")
+	assert.NoError(t, err)
+	assert.Equal(t, inpb.InvocationPermission_PUBLIC, invocation.ReadPermission)
+}
+
+func TestAuthenticatedHandleEventWithStartedFirst(t *testing.T) {
+	te := environment.GetTestEnv(t)
+	auth := testauth.NewTestAuthenticator(testauth.TestUsers("USER1", "GROUP1"))
+	te.SetAuthenticator(auth)
+	ctx := context.Background()
+
+	handler := build_event_handler.NewBuildEventHandler(te)
+	channel := handler.OpenChannel(ctx, "test-invocation-id")
+
+	// Send authenticated started event with api key
+	request := streamRequest(startedEvent("--remote_upload_local_results --remote_header='"+testauth.TestApiKeyHeader+"=USER1' --remote_instance_name=foo"), "test-invocation-id", 1)
+	err := channel.HandleEvent(request)
+	assert.NoError(t, err)
+
+	// Look up the invocation and make sure it's only visible to group
+	invocation, err := build_event_handler.LookupInvocation(te, auth.AuthContextFromAPIKey(ctx, "USER1"), "test-invocation-id")
+	assert.NoError(t, err)
+	assert.Equal(t, inpb.InvocationPermission_GROUP, invocation.ReadPermission)
+}
+
+func TestAuthenticatedHandleEventWithProgressFirst(t *testing.T) {
+	te := environment.GetTestEnv(t)
+	auth := testauth.NewTestAuthenticator(testauth.TestUsers("USER1", "GROUP1"))
+	te.SetAuthenticator(auth)
+	ctx := context.Background()
+
+	handler := build_event_handler.NewBuildEventHandler(te)
+	channel := handler.OpenChannel(ctx, "test-invocation-id")
+
+	// Send progress event
+	request := streamRequest(progressEvent(), "test-invocation-id", 1)
+	err := channel.HandleEvent(request)
+	assert.NoError(t, err)
+
+	// Make sure invocation isn't written yet
+	invocation, err := build_event_handler.LookupInvocation(te, auth.AuthContextFromAPIKey(ctx, "USER1"), "test-invocation-id")
+	assert.Error(t, err)
+
+	// Send started event with api key
+	request = streamRequest(startedEvent("--remote_header='"+testauth.TestApiKeyHeader+"=USER1'"), "test-invocation-id", 2)
+	err = channel.HandleEvent(request)
+	assert.NoError(t, err)
+
+	// Look up the invocation and make sure it's only visible to group
+	invocation, err = build_event_handler.LookupInvocation(te, auth.AuthContextFromAPIKey(ctx, "USER1"), "test-invocation-id")
+	assert.NoError(t, err)
+	assert.Equal(t, inpb.InvocationPermission_GROUP, invocation.ReadPermission)
+}
+
+func TestUnAuthenticatedHandleEventWithProgressFirst(t *testing.T) {
+	te := environment.GetTestEnv(t)
+	auth := testauth.NewTestAuthenticator(testauth.TestUsers("USER1", "GROUP1"))
+	te.SetAuthenticator(auth)
+	ctx := context.Background()
+
+	handler := build_event_handler.NewBuildEventHandler(te)
+	channel := handler.OpenChannel(ctx, "test-invocation-id")
+
+	// Send progress event
+	request := streamRequest(progressEvent(), "test-invocation-id", 1)
+	err := channel.HandleEvent(request)
+	assert.NoError(t, err)
+
+	// Make sure invocation isn't written yet
+	invocation, err := build_event_handler.LookupInvocation(te, auth.AuthContextFromAPIKey(ctx, "USER1"), "test-invocation-id")
+	assert.Error(t, err)
+
+	// Send started event with no api key
+	request = streamRequest(startedEvent("--remote_upload_local_results"), "test-invocation-id", 2)
+	err = channel.HandleEvent(request)
+	assert.NoError(t, err)
+
+	// Look up the invocation and make sure it's publicly visible
+	invocation, err = build_event_handler.LookupInvocation(te, auth.AuthContextFromAPIKey(ctx, "USER1"), "test-invocation-id")
+	assert.NoError(t, err)
+	assert.Equal(t, inpb.InvocationPermission_PUBLIC, invocation.ReadPermission)
+}
+
+func TestHandleEventOver100ProgressEventsBeforeStarted(t *testing.T) {
+	te := environment.GetTestEnv(t)
+	auth := testauth.NewTestAuthenticator(testauth.TestUsers("USER1", "GROUP1"))
+	te.SetAuthenticator(auth)
+	ctx := context.Background()
+
+	handler := build_event_handler.NewBuildEventHandler(te)
+	channel := handler.OpenChannel(ctx, "test-invocation-id")
+
+	// Send 104 progress events
+	for i := 1; i < 105; i++ {
+		request := streamRequest(progressEvent(), "test-invocation-id", int64(i))
+		err := channel.HandleEvent(request)
+		assert.NoError(t, err)
+	}
+
+	// Make sure invocation isn't written
+	invocation, err := build_event_handler.LookupInvocation(te, auth.AuthContextFromAPIKey(ctx, "USER1"), "test-invocation-id")
+	assert.Error(t, err)
+
+	// Send started event with api key
+	request := streamRequest(startedEvent("--remote_header='"+testauth.TestApiKeyHeader+"=USER1'"), "test-invocation-id", 105)
+	err = channel.HandleEvent(request)
+	assert.NoError(t, err)
+
+	// Make sure invocation is only readable by group
+	invocation, err = build_event_handler.LookupInvocation(te, auth.AuthContextFromAPIKey(ctx, "USER1"), "test-invocation-id")
+	assert.NoError(t, err)
+	assert.Equal(t, inpb.InvocationPermission_GROUP, invocation.ReadPermission)
+}
+
+func TestHandleEventWithWorkspaceStatusBeforeStarted(t *testing.T) {
+	te := environment.GetTestEnv(t)
+	auth := testauth.NewTestAuthenticator(testauth.TestUsers("USER1", "GROUP1"))
+	te.SetAuthenticator(auth)
+	ctx := context.Background()
+
+	handler := build_event_handler.NewBuildEventHandler(te)
+	channel := handler.OpenChannel(ctx, "test-invocation-id")
+
+	// Send progress event
+	request := streamRequest(progressEvent(), "test-invocation-id", 1)
+	err := channel.HandleEvent(request)
+	assert.NoError(t, err)
+
+	// Send workspace status event with commit sha (which causes a flush)
+	request = streamRequest(workspaceStatusEvent("COMMIT_SHA", "abc123"), "test-invocation-id", 2)
+	err = channel.HandleEvent(request)
+	assert.NoError(t, err)
+
+	// Make invocation sure isn't written yet
+	invocation, err := build_event_handler.LookupInvocation(te, auth.AuthContextFromAPIKey(ctx, "USER1"), "test-invocation-id")
+	assert.Error(t, err)
+
+	// Send started event with api key
+	request = streamRequest(startedEvent("--remote_header='"+testauth.TestApiKeyHeader+"=USER1'"), "test-invocation-id", 3)
+	err = channel.HandleEvent(request)
+	assert.NoError(t, err)
+
+	// Make sure invocation is only readable by group and has commit sha
+	invocation, err = build_event_handler.LookupInvocation(te, auth.AuthContextFromAPIKey(ctx, "USER1"), "test-invocation-id")
+	assert.NoError(t, err)
+	assert.Equal(t, inpb.InvocationPermission_GROUP, invocation.ReadPermission)
+	assert.Equal(t, "abc123", invocation.CommitSha)
+	assert.Equal(t, inpb.Invocation_PARTIAL_INVOCATION_STATUS, invocation.InvocationStatus)
+
+	// Finalize the invocation
+	err = channel.FinalizeInvocation("test-invocation-id")
+	assert.NoError(t, err)
+
+	// Make sure it gets finalized properly
+	invocation, err = build_event_handler.LookupInvocation(te, auth.AuthContextFromAPIKey(ctx, "USER1"), "test-invocation-id")
+	assert.NoError(t, err)
+	assert.Equal(t, "abc123", invocation.CommitSha)
+	assert.Equal(t, inpb.Invocation_COMPLETE_INVOCATION_STATUS, invocation.InvocationStatus)
+}

--- a/server/testutil/environment/BUILD
+++ b/server/testutil/environment/BUILD
@@ -7,6 +7,8 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/environment",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/backends/blobstore:go_default_library",
+        "//server/backends/invocationdb:go_default_library",
         "//server/backends/memory_cache:go_default_library",
         "//server/config:go_default_library",
         "//server/real_environment:go_default_library",

--- a/server/testutil/environment/environment.go
+++ b/server/testutil/environment/environment.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/buildbuddy-io/buildbuddy/server/backends/blobstore"
+	"github.com/buildbuddy-io/buildbuddy/server/backends/invocationdb"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/memory_cache"
 	"github.com/buildbuddy-io/buildbuddy/server/config"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
@@ -125,7 +127,16 @@ func GetTestEnv(t *testing.T) *TestEnv {
 	}
 	te.SetCache(c)
 	dbHandle, err := db.GetConfiguredDatabase(configurator, healthChecker)
+	if err != nil {
+		t.Fatal(err)
+	}
 	te.SetDBHandle(dbHandle)
+	te.RealEnv.SetInvocationDB(invocationdb.NewInvocationDB(te, dbHandle))
+	bs, err := blobstore.GetConfiguredBlobstore(configurator)
+	if err != nil {
+		log.Fatalf("Error configuring blobstore: %s", err)
+	}
+	te.RealEnv.SetBlobstore(bs)
 
 	return te
 }


### PR DESCRIPTION
This fixes the issue where the BES stream breaks if an authenticated user sends us a progress event before a started event.

I did some testing with this repo for which this behavior is reproducible: https://github.com/rabbitmq/rabbitmq-server/runs/1950326723?check_suite_focus=true

Seems that usually we get a one or two progress events notifying us about "fetches" before receiving the started event.  

To fix this, I buffer up to 100 events received before the starting event and then flush them once we receive the starting event. 

I've added some logs so we can see when (if ever) we surpass this 100 event buffer.

I've also added tests for the build event handler for various auth'd and unauth'd scenarios.

---

**Version bump**: Patch

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
