### PR TITLE
Replace Scan() with Take() on raw queries.

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -344,8 +344,8 @@ func (a *OpenIDAuthenticator) lookupUserFromSubID(subID string) (*tables.User, e
 	}
 	user := &tables.User{}
 	err := dbHandle.TransactionWithOptions(db.StaleReadOptions(), func(tx *gorm.DB) error {
-		userRow := tx.Raw(`SELECT * FROM Users WHERE sub_id = ? ORDER BY user_id ASC LIMIT 1`, subID)
-		if err := userRow.Scan(user).Error; err != nil {
+		userRow := tx.Raw(`SELECT * FROM Users WHERE sub_id = ? ORDER BY user_id ASC`, subID)
+		if err := userRow.Take(user).Error; err != nil {
 			return err
 		}
 		groupRows, err := tx.Raw(`SELECT g.* FROM `+"`Groups`"+` as g JOIN UserGroups as ug
@@ -379,7 +379,7 @@ func (a *OpenIDAuthenticator) lookupAPIKeyGroupFromAPIKey(apiKey string) (*apiKe
 			FROM `+"`Groups`"+` AS g, APIKeys AS ak
 			WHERE g.group_id = ak.group_id AND ak.value = ?`,
 			apiKey)
-		return existingRow.Scan(akg).Error
+		return existingRow.Take(akg).Error
 	})
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
@@ -402,7 +402,7 @@ func (a *OpenIDAuthenticator) lookupAPIKeyGroupFromBasicAuth(login, pass string)
 			FROM `+"`Groups`"+` AS g, APIKeys AS ak
 			WHERE g.group_id = ? AND g.write_token = ? AND g.group_id = ak.group_id`,
 			login, pass)
-		return existingRow.Scan(akg).Error
+		return existingRow.Take(akg).Error
 	})
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {

--- a/enterprise/server/workflow/workflow.go
+++ b/enterprise/server/workflow/workflow.go
@@ -190,7 +190,7 @@ func (ws *workflowService) DeleteWorkflow(ctx context.Context, req *wfpb.DeleteW
 	}
 	err = ws.env.GetDBHandle().Transaction(func(tx *gorm.DB) error {
 		var in tables.Workflow
-		if err := tx.Raw(`SELECT user_id, group_id, perms FROM Workflows WHERE workflow_id = ?`, workflowID).Scan(&in).Error; err != nil {
+		if err := tx.Raw(`SELECT user_id, group_id, perms FROM Workflows WHERE workflow_id = ?`, workflowID).Take(&in).Error; err != nil {
 			return err
 		}
 		acl := perms.ToACLProto(&uidpb.UserId{Id: in.UserID}, in.GroupID, in.Perms)
@@ -320,10 +320,9 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 func (ws *workflowService) apiKeyForWorkflow(ctx context.Context, wf *tables.Workflow) (*tables.APIKey, error) {
 	q := query_builder.NewQuery(`SELECT * FROM APIKeys`)
 	q.AddWhereClause("group_id = ?", wf.GroupID)
-	q.SetLimit(1)
 	qStr, qArgs := q.Build()
 	k := &tables.APIKey{}
-	if err := ws.env.GetDBHandle().Raw(qStr, qArgs...).Scan(&k).Error; err != nil {
+	if err := ws.env.GetDBHandle().Raw(qStr, qArgs...).Take(&k).Error; err != nil {
 		return nil, err
 	}
 	return k, nil

--- a/server/backends/invocationdb/invocationdb.go
+++ b/server/backends/invocationdb/invocationdb.go
@@ -79,11 +79,11 @@ func (d *InvocationDB) UpdateInvocationACL(ctx context.Context, authenticatedUse
 	}
 	return d.h.Transaction(func(tx *gorm.DB) error {
 		var in tables.Invocation
-		if err := tx.Raw(`SELECT user_id, group_id, perms FROM Invocations WHERE invocation_id = ?`, invocationID).Scan(&in).Error; err != nil {
+		if err := tx.Raw(`SELECT user_id, group_id, perms FROM Invocations WHERE invocation_id = ?`, invocationID).Take(&in).Error; err != nil {
 			return err
 		}
 		var group tables.Group
-		if err := tx.Raw(`SELECT sharing_enabled FROM `+"`Groups`"+` WHERE group_id = ?`, in.GroupID).Scan(&group).Error; err != nil {
+		if err := tx.Raw(`SELECT sharing_enabled FROM `+"`Groups`"+` WHERE group_id = ?`, in.GroupID).Take(&group).Error; err != nil {
 			return err
 		}
 		if !group.SharingEnabled {
@@ -105,7 +105,7 @@ func (d *InvocationDB) UpdateInvocationACL(ctx context.Context, authenticatedUse
 
 func (d *InvocationDB) LookupInvocation(ctx context.Context, invocationID string) (*tables.Invocation, error) {
 	ti := &tables.Invocation{}
-	if err := d.h.Raw(`SELECT * FROM Invocations WHERE invocation_id = ?`, invocationID).Scan(ti).Error; err != nil {
+	if err := d.h.Raw(`SELECT * FROM Invocations WHERE invocation_id = ?`, invocationID).Take(ti).Error; err != nil {
 		return nil, err
 	}
 	if ti.Perms&perms.OTHERS_READ == 0 {
@@ -129,7 +129,7 @@ func (d *InvocationDB) LookupGroupFromInvocation(ctx context.Context, invocation
 	}
 	queryStr, args := q.Build()
 	existingRow := d.h.Raw(queryStr, args...)
-	if err := existingRow.Scan(ti).Error; err != nil {
+	if err := existingRow.Take(ti).Error; err != nil {
 		return nil, err
 	}
 	return ti, nil
@@ -170,7 +170,7 @@ func (d *InvocationDB) FillCounts(ctx context.Context, stat *telpb.TelemetryStat
 		int64(time.Now().Truncate(24*time.Hour).Add(-24*time.Hour).UnixNano()/1000),
 		int64(time.Now().Truncate(24*time.Hour).UnixNano()/1000))
 
-	if err := counts.Scan(stat).Error; err != nil {
+	if err := counts.Take(stat).Error; err != nil {
 		return err
 	}
 	return nil
@@ -184,7 +184,7 @@ func (d *InvocationDB) DeleteInvocation(ctx context.Context, invocationID string
 func (d *InvocationDB) DeleteInvocationWithPermsCheck(ctx context.Context, authenticatedUser *interfaces.UserInfo, invocationID string) error {
 	return d.h.Transaction(func(tx *gorm.DB) error {
 		var in tables.Invocation
-		if err := tx.Raw(`SELECT user_id, group_id, perms FROM Invocations WHERE invocation_id = ?`, invocationID).Scan(&in).Error; err != nil {
+		if err := tx.Raw(`SELECT user_id, group_id, perms FROM Invocations WHERE invocation_id = ?`, invocationID).Take(&in).Error; err != nil {
 			return err
 		}
 		acl := perms.ToACLProto(&uidpb.UserId{Id: in.UserID}, in.GroupID, in.Perms)


### PR DESCRIPTION
In GORM v2, unlike v1, calling Scan() on a raw query that does not return any
results does not return an error.

Note that Take() implicitly adds a LIMIT 1 clause.

Part of fixing buildbuddy-io/buildbuddy-internal#250

**Version bump**: Patch
