### PR TITLE
workflows: Add CI runner image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -155,6 +155,14 @@ container_pull(
     repository = "distroless/base-debian10",
 )
 
+load("@io_bazel_rules_docker//contrib:dockerfile_build.bzl", "dockerfile_image")
+
+dockerfile_image(
+    name = "ci_runner_image",
+    dockerfile = "//enterprise/dockerfiles/ci_runner_image:Dockerfile",
+    visibility = ["//visibility:public"],
+)
+
 # BuildBuddy Toolchain
 
 http_archive(

--- a/enterprise/dockerfiles/ci_runner_image/Dockerfile
+++ b/enterprise/dockerfiles/ci_runner_image/Dockerfile
@@ -1,0 +1,11 @@
+FROM gcr.io/cloud-marketplace/google/debian10@sha256:c571e553cdaa91b1f16c190a049ccef828234ac47a0e8ef40c84240e62108591
+
+RUN apt-get update && apt-get install -y curl rpm build-essential
+
+# Install bazelisk
+RUN curl -Lo /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 && \
+    chmod +x /usr/local/bin/bazelisk
+
+# Pre-install bazel 3.7.0 to avoid bazelisk downloading & installing bazel on every
+# CI run, at least for our internal repo.
+RUN USE_BAZEL_VERSION=3.7.0 bazelisk version

--- a/enterprise/dockerfiles/ci_runner_image/Dockerfile
+++ b/enterprise/dockerfiles/ci_runner_image/Dockerfile
@@ -7,5 +7,5 @@ RUN curl -Lo /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/rele
     chmod +x /usr/local/bin/bazelisk
 
 # Pre-install bazel 3.7.0 to avoid bazelisk downloading & installing bazel on every
-# CI run, at least for our internal repo.
+# CI run, at least for CI runs on the BuildBuddy repo itself.
 RUN USE_BAZEL_VERSION=3.7.0 bazelisk version

--- a/enterprise/dockerfiles/ci_runner_image/Dockerfile
+++ b/enterprise/dockerfiles/ci_runner_image/Dockerfile
@@ -3,7 +3,7 @@ FROM gcr.io/cloud-marketplace/google/debian10@sha256:c571e553cdaa91b1f16c190a049
 RUN apt-get update && apt-get install -y curl rpm build-essential
 
 # Install bazelisk
-RUN curl -Lo /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 && \
+RUN curl -Lo /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.5/bazelisk-linux-amd64 && \
     chmod +x /usr/local/bin/bazelisk
 
 # Pre-install bazel 3.7.0 to avoid bazelisk downloading & installing bazel on every

--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
 go_library(
     name = "go_default_library",
@@ -27,5 +28,15 @@ go_library(
 go_binary(
     name = "ci_runner",
     embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+# Note: the CI runner image only includes the setup needed for the CI runner;
+# it doesn't include the CI runner binary itself. We ship the CI runner binary
+# to the CAS and the executor downloads it as needed.
+container_image(
+    name = "ci_runner_image",
+    base = "@ci_runner_image//image:dockerfile_image.tar",
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )

--- a/enterprise/server/deployment/BUILD
+++ b/enterprise/server/deployment/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_docker//container:push.bzl", "container_push")
+
+container_push(
+    name = "push_ci_runner",
+    format = "Docker",
+    image = "//enterprise/server/cmd/ci_runner:ci_runner_image",
+
+    # Any of these components may have variables. They are set by passing
+    # --define version=1.2.3 as arguments to the bazel build command.
+    registry = "gcr.io",
+    repository = "flame-public/buildbuddy-ci-runner",
+    tag = "$(version)",
+    tags = ["manual"],  # Don't include this target in wildcard patterns
+)

--- a/enterprise/server/workflow/workflow.go
+++ b/enterprise/server/workflow/workflow.go
@@ -308,6 +308,11 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 			"--trigger_event=" + wd.EventName,
 			"--trigger_branch=" + wd.TargetBranch,
 		},
+		Platform: &repb.Platform{
+			Properties: []*repb.Platform_Property{
+				{Name: "container-image", Value: "docker://gcr.io/flame-public/buildbuddy-ci-runner:v1.7.0"},
+			},
+		},
 	}
 	cmdDigest, err := cachetools.UploadProtoToCAS(ctx, cache, instanceName, cmd)
 	if err != nil {


### PR DESCRIPTION
The Dockerfile is the same as the one we use for the executor image (debian 10) except it also has bazelisk + bazel 3.7.0 pre-installed.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
