### PR TITLE
Bring back query count metric.

### DIFF
--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -151,6 +151,7 @@ func instrumentGORM(gdb *gorm.DB) {
 		labels := prometheus.Labels{
 			metrics.SQLQueryTemplateLabel: db.Statement.SQL.String(),
 		}
+		metrics.SQLQueryCount.With(labels).Inc()
 		// v will be nil if our key is not in the map so we can ignore the presence indicator.
 		v, _ := db.Statement.Settings.LoadAndDelete(gormStmtStartTimeKey)
 		if opStartTime, ok := v.(time.Time); ok {


### PR DESCRIPTION
I accidentally lost it in the gorm v2 transition.

Part of buildbuddy-io/buildbuddy-internal#250

**Version bump**: Patch
