### PR TITLE
workflows: Add git to the ci_runner image

### DIFF
--- a/enterprise/dockerfiles/ci_runner_image/Dockerfile
+++ b/enterprise/dockerfiles/ci_runner_image/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/cloud-marketplace/google/debian10@sha256:c571e553cdaa91b1f16c190a049ccef828234ac47a0e8ef40c84240e62108591
 
-RUN apt-get update && apt-get install -y curl rpm build-essential
+RUN apt-get update && apt-get install -y curl git rpm build-essential
 
 # Install bazelisk
 RUN curl -Lo /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.5/bazelisk-linux-amd64 && \

--- a/enterprise/server/workflow/workflow.go
+++ b/enterprise/server/workflow/workflow.go
@@ -320,7 +320,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 		},
 		Platform: &repb.Platform{
 			Properties: []*repb.Platform_Property{
-				{Name: "container-image", Value: "docker://gcr.io/flame-public/buildbuddy-ci-runner:v1.7.0"},
+				{Name: "container-image", Value: "docker://gcr.io/flame-public/buildbuddy-ci-runner:v1.7.1"},
 			},
 		},
 	}


### PR DESCRIPTION
The Dockerfile does need `git` after all, at least to be able to support our internal repo, because we have a `git_repository` rule that clones the OSS repo using `git`. See the CI failure here: https://app.buildbuddy.dev/invocation/d29488d2-edce-4ed5-bec0-56112d0b152b#log

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
