### PR TITLE
Fix NPE in capabilities.

### DIFF
--- a/server/util/capabilities/capabilities.go
+++ b/server/util/capabilities/capabilities.go
@@ -47,8 +47,11 @@ func ToInt(caps []akpb.ApiKey_Capability) int32 {
 func IsGranted(ctx context.Context, env environment.Env, cap akpb.ApiKey_Capability) (bool, error) {
 	authIsRequired := !env.GetConfigurator().GetAnonymousUsageEnabled()
 	a := env.GetAuthenticator()
-	if a == nil && authIsRequired {
-		return false, status.UnimplementedError("Not Implemented")
+	if a == nil {
+		if authIsRequired {
+			return false, status.UnimplementedError("Not Implemented")
+		}
+		return int32(cap)&AnonymousUserCapabilitiesMask > 0, nil
 	}
 	user, err := a.AuthenticatedUser(ctx)
 	if err != nil {

--- a/server/util/capabilities/capabilities_test.go
+++ b/server/util/capabilities/capabilities_test.go
@@ -93,6 +93,17 @@ func TestIsGranted_NullAuthenticator(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestIsGranted_NilAuthenticator(t *testing.T) {
+	te := getTestEnv(t, emptyUserMap)
+	te.SetAuthenticator(nil)
+	anonCtx := context.Background()
+
+	canWrite, err := capabilities.IsGranted(anonCtx, te, akpb.ApiKey_CACHE_WRITE_CAPABILITY)
+
+	assert.True(t, canWrite)
+	assert.Nil(t, err)
+}
+
 func TestIsGranted_TestUserWithCapability_True(t *testing.T) {
 	user := &auth.Claims{
 		UserID:       "US1",


### PR DESCRIPTION
A NPE is possible when anonymous access is enabled and the authenticator is nil. In this case, return the default anonymous capabilities.