### PR TITLE
prometheus: Stop auto-syncing grafana dashboard JSON to local repo after switching Git branches

### DIFF
--- a/tools/metrics/run.sh
+++ b/tools/metrics/run.sh
@@ -52,7 +52,7 @@ function sync() {
   local current_branch
   current_branch=$(git branch --show-current)
   if [[ "$current_branch" != "$start_branch" ]]; then
-    echo -e "$0: \033[33mWARNING: git branch has changed since you started the grafana server. Changes to the dashboard will not be auto-saved.\033[0m"
+    echo -e "$0: \033[33mWARNING: git branch has changed. Changes to the dashboard will not be auto-saved.\033[0m"
     return
   fi
 

--- a/tools/metrics/run.sh
+++ b/tools/metrics/run.sh
@@ -6,7 +6,7 @@ __dir__=$(dirname "$__file__")
 
 cd "$__dir__"
 
-start_branch=$(git branch --show-current)
+START_BRANCH=$(git branch --show-current)
 
 : ${GRAFANA_PORT:=4500}
 : ${GRAFANA_ADMIN_PASSWORD:="admin"}
@@ -51,7 +51,7 @@ function sync() {
 
   local current_branch
   current_branch=$(git branch --show-current)
-  if [[ "$current_branch" != "$start_branch" ]]; then
+  if [[ "$current_branch" != "$START_BRANCH" ]]; then
     echo -e "$0: \033[33mWARNING: git branch has changed. Changes to the dashboard will not be auto-saved.\033[0m"
     return
   fi


### PR DESCRIPTION
This change prevents metrics from being auto-synced to the local repo after switching git branches. The old behavior was annoying, because after committing a change to the dashboard JSON then switching to a different branch, the script would see that the contents of the dashboard JSON changed, and then try to re-sync the dashboard config to the local repo, causing an unwanted diff in the current branch. And then if you ran `git restore` to revert the diff, the script would still keep overwriting that file, until you killed the script.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
