### PR TITLE
Make proxy buffer size configurable

### DIFF
--- a/docs/config-misc.md
+++ b/docs/config-misc.md
@@ -13,6 +13,7 @@ sidebar_label: Misc
 **Optional**
 
 - `hosts` A list of host strings that BuildBudy should connect and forward events to.
+- `buffer_size` The number of build events to buffer locally when proxying build events.
 
 ## Example section
 
@@ -21,4 +22,5 @@ build_event_proxy:
   hosts:
     - "grpc://localhost:1985"
     - "grpc://events.buildbuddy.io:1985"
+  buffer_size: 1000
 ```

--- a/server/build_event_protocol/build_event_proxy/BUILD
+++ b/server/build_event_protocol/build_event_proxy/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:publish_build_event_go_proto",
+        "//server/environment:go_default_library",
         "//server/util/grpc_client:go_default_library",
         "@io_bazel_rules_go//proto/wkt:empty_go_proto",
         "@org_golang_google_grpc//:go_default_library",

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -45,7 +45,8 @@ type appConfig struct {
 }
 
 type buildEventProxy struct {
-	Hosts []string `yaml:"hosts" usage:"The list of hosts to pass build events onto."`
+	Hosts      []string `yaml:"hosts" usage:"The list of hosts to pass build events onto."`
+	BufferSize int      `yaml:"buffer_size" usage:"The number of build events to buffer locally when proxying build events."`
 }
 
 type DatabaseConfig struct {
@@ -377,6 +378,10 @@ func (c *Configurator) GetIntegrationsSlackConfig() *SlackConfig {
 
 func (c *Configurator) GetBuildEventProxyHosts() []string {
 	return c.gc.BuildEventProxy.Hosts
+}
+
+func (c *Configurator) GetBuildEventProxyBufferSize() int {
+	return c.gc.BuildEventProxy.BufferSize
 }
 
 func (c *Configurator) GetCacheMaxSizeBytes() int64 {

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -119,7 +119,7 @@ func GetConfiguredEnvironmentOrDie(configurator *config.Configurator, healthChec
 	for _, target := range configurator.GetBuildEventProxyHosts() {
 		// NB: This can block for up to a second on connecting. This would be a
 		// great place to have our health checker and mark these as optional.
-		buildEventProxyClients = append(buildEventProxyClients, build_event_proxy.NewBuildEventProxyClient(target))
+		buildEventProxyClients = append(buildEventProxyClients, build_event_proxy.NewBuildEventProxyClient(realEnv, target))
 		log.Printf("Proxy: forwarding build events to: %s", target)
 	}
 	realEnv.SetBuildEventProxyClients(buildEventProxyClients)


### PR DESCRIPTION
By default we buffer 100 build events locally when proxying the BES stream.

When doing this with larger fully cached builds and slower network connections - this buffer can be overwhelmed pretty easily.

This leads to lots of messages like this:
```
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
2021/03/10 08:03:45 BuildEventProxy dropped message.
```

This change makes this buffer size configurable, so folks using this feature can configure this behavior.

The default remains 100 events.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
