### PR TITLE
workflows: Use ROLE=CI_RUNNER for synthetic CI runner invocations

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -433,7 +433,7 @@ func (ar *actionRunner) Run(ctx context.Context, startTime time.Time) error {
 		Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_BuildMetadata{BuildMetadata: &bespb.BuildEventId_BuildMetadataId{}}},
 		Payload: &bespb.BuildEvent_BuildMetadata{BuildMetadata: &bespb.BuildMetadata{
 			Metadata: map[string]string{
-				"ROLE":                             "CI",
+				"ROLE":                             "CI_RUNNER",
 				"BUILDBUDDY_WORKFLOW_ID":           *workflowID,
 				"BUILDBUDDY_ACTION_NAME":           ar.action.Name,
 				"BUILDBUDDY_ACTION_TRIGGER_EVENT":  *triggerEvent,

--- a/server/build_event_protocol/accumulator/accumulator.go
+++ b/server/build_event_protocol/accumulator/accumulator.go
@@ -155,6 +155,8 @@ func (v *BEValues) populateWorkspaceInfoFromStructuredCommandLine(commandLine *c
 				v.setStringValue(commitSHAFieldName, value)
 			case "CI":
 				v.setStringValue(roleFieldName, "CI")
+			case "CI_RUNNER":
+				v.setStringValue(roleFieldName, "CI_RUNNER")
 			}
 		}
 	}

--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -61,6 +61,10 @@ func (r *BuildStatusReporter) initGHClient(ctx context.Context) *github.GithubCl
 }
 
 func (r *BuildStatusReporter) ReportStatusForEvent(ctx context.Context, event *build_event_stream.BuildEvent) {
+	if role := r.buildEventAccumulator.Role(); !(role == "CI" || role == "CI_RUNNER") {
+		return
+	}
+
 	// TODO: support other providers than just GitHub
 	var githubPayload *github.GithubStatusPayload
 
@@ -83,8 +87,7 @@ func (r *BuildStatusReporter) ReportStatusForEvent(ctx context.Context, event *b
 		githubPayload = r.githubPayloadFromFinishedEvent(event)
 	}
 
-	role := r.buildEventAccumulator.Role()
-	if githubPayload != nil && role == "CI" {
+	if githubPayload != nil {
 		r.payloads = append(r.payloads, githubPayload)
 		r.flushPayloadsIfWorkspaceLoaded(ctx)
 	}

--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -325,6 +325,9 @@ func fillInvocationFromStructuredCommandLine(commandLine *command_line.CommandLi
 	if ci, ok := envVarMap["CI"]; ok && ci != "" {
 		invocation.Role = "CI"
 	}
+	if ciRunner, ok := envVarMap["CI_RUNNER"]; ok && ciRunner != "" {
+		invocation.Role = "CI_RUNNER"
+	}
 
 	// Gitlab CI Environment Variables
 	// https://docs.gitlab.com/ee/ci/variables/predefined_variables.html


### PR DESCRIPTION
This new CI_RUNNER role allows us to do a few things:

- Determine whether an invocation in the UI should show in "workflow" mode, meaning that we hide a bunch of the parts of the UI that are specific to Bazel.
- In the "trends" page, when "CI builds only" is checked, we no longer include CI_RUNNER builds. It's undesirable to include CI_RUNNER builds because builds would be double counted (one for the outer runner invocation for each action, and one for the inner bazel  invocations for each bazel_command within the actions).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: buildbuddy-io/buildbuddy-internal#268

