### PR TITLE
workflows: Update prettier so it works on the CI runner

### DIFF
--- a/tools/prettier/BUILD
+++ b/tools/prettier/BUILD
@@ -1,15 +1,13 @@
+load(":defs.bzl", "prettier")
+
 package(default_visibility = ["//visibility:public"])
 
-sh_binary(
+prettier(
     name = "check",
-    srcs = ["prettier.sh"],
     args = ["--check"],
-    data = ["@npm//prettier"],
 )
 
-sh_binary(
+prettier(
     name = "fix",
-    srcs = ["prettier.sh"],
     args = ["--write"],
-    data = ["@npm//prettier"],
 )

--- a/tools/prettier/defs.bzl
+++ b/tools/prettier/defs.bzl
@@ -1,0 +1,13 @@
+def prettier(name, args):
+    native.sh_binary(
+        name = name,
+        srcs = ["prettier.sh"],
+        args = [
+            "$(location @nodejs//:node)",
+            "$(location @npm//:node_modules/prettier/bin-prettier.js)",
+        ] + args,
+        data = [
+            "@nodejs//:node",
+            "@npm//:node_modules/prettier/bin-prettier.js",
+        ],
+    )

--- a/tools/prettier/prettier.sh
+++ b/tools/prettier/prettier.sh
@@ -1,26 +1,31 @@
 #!/bin/bash
-set -e
 # Runs prettier on all files that differ from the main branch.
 
-: "${PRETTIER:=$(realpath ./external/npm/node_modules/prettier/bin-prettier.js)}"
+set -e
+
+NODE=$(realpath "${1?}")
+shift
+PRETTIER=$(realpath "${1?}")
+shift
 
 # note: BUILD_WORKSPACE_DIRECTORY points to the workspace root (containing all the
 # source code) and is set by `bazel run`.
 cd "${BUILD_WORKSPACE_DIRECTORY?}"
 
-# Diagram showing what `git merge-base HEAD master` is doing:
+# Diagram showing what `git merge-base HEAD refs/remotes/origin/master` is doing:
 #
-# o <- master
+# o <- fetched remote master branch (refs/remotes/origin/master)
 # |
-# o  o <- HEAD
+# o  o <- current local branch (HEAD)
 # | /
-# o <- $(git merge-base HEAD master)
+# o <- $(git merge-base HEAD refs/remotes/origin/master)
 # |
 #
-# It allows us to compare against the master branch as it was
-# before branching off into the current branch.
+# We're finding the latest common ancestor between the remote master branch
+# and the current branch, so that we only run the lint check on files added
+# in this branch.
 
-git merge-base HEAD master |
+git merge-base HEAD refs/remotes/origin/master |
   xargs git diff --name-only --diff-filter=AMRCT |
   grep -P '\.(js|jsx|ts|tsx|html|css|yaml|json|md|xml)$' |
-  xargs --no-run-if-empty "$PRETTIER" "$@"
+  xargs --no-run-if-empty "$NODE" "$PRETTIER" "$@"


### PR DESCRIPTION
* Use the `nodejs` binary that's installed by Bazel instead of a system-wide one. (The CI runner image doesn't have a system-wide nodejs installation, so it failed.)
* Compare against `refs/remotes/origin/master` instead of `refs/heads/master`, which would require checking out the `master` branch in the CI runner repo (this would create extra work for the runner -- we only want to have to check out the PR branch when doing linting).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
