### PR TITLE
workflows: Fetch the main branch in the CI runner to support lint checks on changed files

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -585,9 +585,11 @@ func setupGitRepo(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
 	fetchOpts := &git.FetchOptions{
-		RefSpecs: []gitcfg.RefSpec{gitcfg.RefSpec(fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", *branch, *branch))},
+		RefSpecs: []gitcfg.RefSpec{
+			branchRefSpec(*branch),
+			branchRefSpec(*triggerBranch),
+		},
 	}
 	if err := remote.FetchContext(ctx, fetchOpts); err != nil {
 		return err
@@ -600,6 +602,10 @@ func setupGitRepo(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+func branchRefSpec(branch string) gitcfg.RefSpec {
+	return gitcfg.RefSpec(fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branch, branch))
 }
 
 func authRepoURL() (string, error) {


### PR DESCRIPTION
This is a small improvement to the CI runner: fetch the main branch in addition to just the branch that is being merged, so that lint checks can run `git merge-base HEAD refs/remotes/origin/master` to find the commit to compare against when running lint checks. Otherwise, lint checks would run on every file in the code base.

This shouldn't add much overhead for the git fetch, because the main branch and the PR branch should not have diverged a ton in most cases.

This will also pave the way a bit for people to be able to ignore paths in their `buildbuddy.yaml` -- e.g. `ignore_paths: [ docs/** ]` like we have in our GitHub workflow.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
