### PR TITLE
Add capability to connect to redis with redis URIs

### DIFF
--- a/enterprise/server/backends/pubsub/BUILD
+++ b/enterprise/server/backends/pubsub/BUILD
@@ -9,6 +9,7 @@ go_library(
         "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
+        "//enterprise/server/util/redis:go_default_library",
         "//server/interfaces:go_default_library",
         "@com_github_go_redis_redis_v8//:go_default_library",
     ],

--- a/enterprise/server/backends/pubsub/pubsub.go
+++ b/enterprise/server/backends/pubsub/pubsub.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 
+	redisutils "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redis"
 	redis "github.com/go-redis/redis/v8"
 )
 
@@ -12,11 +13,9 @@ type PubSub struct {
 	rdb *redis.Client
 }
 
-func NewPubSub(redisServer string) *PubSub {
+func NewPubSub(redisTarget string) *PubSub {
 	return &PubSub{
-		rdb: redis.NewClient(&redis.Options{
-			Addr: redisServer,
-		}),
+		rdb: redis.NewClient(redisutils.TargetToOptions(redisTarget)),
 	}
 }
 

--- a/enterprise/server/backends/redis/BUILD
+++ b/enterprise/server/backends/redis/BUILD
@@ -9,6 +9,7 @@ go_library(
         "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
+        "//enterprise/server/util/redis:go_default_library",
         "//proto:remote_execution_go_proto",
         "//server/interfaces:go_default_library",
         "//server/remote_cache/digest:go_default_library",

--- a/enterprise/server/backends/redis/redis.go
+++ b/enterprise/server/backends/redis/redis.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"log"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -13,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
+	redisutils "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redis"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	redis "github.com/go-redis/redis/v8"
 )
@@ -38,14 +41,10 @@ type Cache struct {
 	rdb    *redis.Client
 }
 
-func NewCache(redisServer string, hc interfaces.HealthChecker) *Cache {
+func NewCache(redisTarget string, hc interfaces.HealthChecker) *Cache {
 	c := &Cache{
 		prefix: "",
-		rdb: redis.NewClient(&redis.Options{
-			Addr:     redisServer,
-			Password: "", // no password set
-			DB:       0,  // use default DB
-		}),
+		rdb:    redis.NewClient(redisutils.TargetToOptions(redisTarget)),
 	}
 	hc.AddHealthCheck("redis_cache", c)
 	return c
@@ -327,4 +326,19 @@ func (c *Cache) IncrementCount(ctx context.Context, counterName string, n int64)
 
 func (c *Cache) ReadCount(ctx context.Context, counterName string) (int64, error) {
 	return c.rdb.IncrBy(ctx, counterName, 0).Result()
+}
+
+func TargetToOptions(redisTarget string) *redis.Options {
+	if !strings.HasPrefix(redisTarget, "redis://") {
+		return &redis.Options{
+			Addr:     redisTarget,
+			Password: "", // no password set
+			DB:       0,  // use default DB
+		}
+	} else if opt, err := redis.ParseURL(redisTarget); err == nil {
+		return opt
+	} else {
+		log.Println(err)
+		return &redis.Options{}
+	}
 }

--- a/enterprise/server/backends/redis/redis.go
+++ b/enterprise/server/backends/redis/redis.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"log"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -326,19 +324,4 @@ func (c *Cache) IncrementCount(ctx context.Context, counterName string, n int64)
 
 func (c *Cache) ReadCount(ctx context.Context, counterName string) (int64, error) {
 	return c.rdb.IncrBy(ctx, counterName, 0).Result()
-}
-
-func TargetToOptions(redisTarget string) *redis.Options {
-	if !strings.HasPrefix(redisTarget, "redis://") {
-		return &redis.Options{
-			Addr:     redisTarget,
-			Password: "", // no password set
-			DB:       0,  // use default DB
-		}
-	} else if opt, err := redis.ParseURL(redisTarget); err == nil {
-		return opt
-	} else {
-		log.Println(err)
-		return &redis.Options{}
-	}
 }

--- a/enterprise/server/util/redis/BUILD
+++ b/enterprise/server/util/redis/BUILD
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["redis.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redis",
+    visibility = [
+        "//enterprise:__subpackages__",
+        "@buildbuddy_internal//enterprise:__subpackages__",
+    ],
+    deps = [
+        "@com_github_go_redis_redis_v8//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["redis_test.go"],
+    embed = [":go_default_library"],
+    visibility = [
+        "//enterprise:__subpackages__",
+        "@buildbuddy_internal//enterprise:__subpackages__",
+    ],
+    deps = [
+        "@com_github_go_redis_redis_v8//:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
+    ],
+)

--- a/enterprise/server/util/redis/redis.go
+++ b/enterprise/server/util/redis/redis.go
@@ -1,0 +1,35 @@
+package redis
+
+import (
+	"log"
+	"strings"
+
+	redis "github.com/go-redis/redis/v8"
+)
+
+func isRedisURI(redisTarget string) bool {
+	return strings.HasPrefix(redisTarget, "redis://") ||
+		strings.HasPrefix(redisTarget, "rediss://") ||
+		strings.HasPrefix(redisTarget, "unix://")
+}
+
+func TargetToOptions(redisTarget string) *redis.Options {
+	if !isRedisURI(redisTarget) {
+		return &redis.Options{
+			Addr:     redisTarget,
+			Password: "", // no password set
+			DB:       0,  // use default DB
+		}
+	} else if opt, err := redis.ParseURL(redisTarget); err == nil {
+		return opt
+	} else {
+		log.Println(err)
+		log.Println(
+			"The supported redis URI formats are:\n" +
+				"redis[s]://[[USER][:PASSWORD]@][HOST][:PORT]" +
+				"[/DATABASE]\nor:\nunix://[[USER][:PASSWORD]@]" +
+				"SOCKET_PATH[?db=DATABASE]\nIf using a socket path, " +
+				"path must be an absolute unix path.")
+		return &redis.Options{}
+	}
+}

--- a/enterprise/server/util/redis/redis_test.go
+++ b/enterprise/server/util/redis/redis_test.go
@@ -1,0 +1,309 @@
+package redis_test
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	redisutil "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redis"
+	redis "github.com/go-redis/redis/v8"
+)
+
+func genRedisOptions(
+	protocol string,
+	user string,
+	password string,
+	hostname string,
+	port string,
+	database string,
+) *redis.Options {
+	database_num, err := strconv.Atoi(database)
+	if database != "" && err != nil {
+		return &redis.Options{}
+	}
+	if hostname == "" {
+		hostname = "localhost"
+	}
+	if port == "" {
+		port = "6379"
+	}
+	opt := &redis.Options{
+		Network:  "tcp",
+		Username: user,
+		Password: password,
+		Addr:     net.JoinHostPort(hostname, port),
+		DB:       database_num,
+	}
+	if protocol == "rediss" {
+		opt.TLSConfig = &tls.Config{ServerName: hostname}
+	}
+	return opt
+}
+
+func genRedisURI(
+	protocol string,
+	user string,
+	password string,
+	hostname string,
+	port string,
+	database string,
+) string {
+	at := ""
+	if user != "" {
+		at = "@"
+	}
+	if password != "" {
+		password = ":" + password
+		at = "@"
+	}
+	hostport := hostname
+	if port != "" {
+		hostport = net.JoinHostPort(hostname, port)
+	}
+	if database != "" {
+		database = "/" + database
+	}
+
+	return fmt.Sprintf(
+		"%s://%s%s%s%s%s",
+		protocol,
+		user,
+		password,
+		at,
+		hostport,
+		database,
+	)
+}
+
+func genRedisURIOptionsMap(
+	protocols []string,
+	users []string,
+	passwords []string,
+	hostnames []string,
+	ports []string,
+	databases []string,
+) map[string]*redis.Options {
+	product := make(map[string]*redis.Options)
+	for _, protocol := range protocols {
+		for _, user := range users {
+			for _, password := range passwords {
+				for _, hostname := range hostnames {
+					for _, port := range ports {
+						for _, db := range databases {
+							uri := genRedisURI(
+								protocol,
+								user,
+								password,
+								hostname,
+								port,
+								db,
+							)
+							product[uri] =
+								genRedisOptions(
+									protocol,
+									user,
+									password,
+									hostname,
+									port,
+									db,
+								)
+						}
+					}
+				}
+			}
+		}
+	}
+	return product
+}
+
+func genUnixOptions(
+	user string,
+	password string,
+	socket_path string,
+	database string,
+) *redis.Options {
+	if socket_path == "" {
+		return &redis.Options{}
+	}
+	database_num, err := strconv.Atoi(database)
+	if database != "" && err != nil {
+		return &redis.Options{}
+	}
+	return &redis.Options{
+		Network:  "unix",
+		Username: user,
+		Password: password,
+		Addr:     socket_path,
+		DB:       database_num,
+	}
+}
+
+func genUnixURI(
+	user string,
+	password string,
+	socket_path string,
+	database string,
+) string {
+	at := ""
+	if user != "" {
+		at = "@"
+	}
+	if password != "" {
+		password = ":" + password
+		at = "@"
+	}
+	if database != "" {
+		database = "?db=" + database
+	}
+	return fmt.Sprintf(
+		"unix://%s%s%s%s%s",
+		user,
+		password,
+		at,
+		socket_path,
+		database,
+	)
+}
+
+func genUnixURIOptionsMap(
+	users []string,
+	passwords []string,
+	socket_paths []string,
+	databases []string,
+) map[string]*redis.Options {
+	product := make(map[string]*redis.Options)
+	for _, user := range users {
+		for _, password := range passwords {
+			for _, socket_path := range socket_paths {
+				for _, database := range databases {
+					uri := genUnixURI(
+						user,
+						password,
+						socket_path,
+						database,
+					)
+					product[uri] = genUnixOptions(
+						user,
+						password,
+						socket_path,
+						database,
+					)
+				}
+			}
+		}
+	}
+	return product
+}
+
+func assertOptionsEqual(
+	t *testing.T,
+	opt1 *redis.Options,
+	opt2 *redis.Options,
+	target string,
+	error_msg string,
+) {
+	ignore_opts := cmpopts.IgnoreFields(
+		redis.Options{},
+		"readOnly",
+		"TLSConfig.mutex",
+		"TLSConfig.sessionTicketKeys",
+		"TLSConfig.autoSessionTicketKeys",
+	)
+	if !cmp.Equal(
+		opt1,
+		opt2,
+		ignore_opts,
+	) {
+		t.Errorf(
+			fmt.Sprintf(
+				"%s\nFailing string: %s\nDiff:\n%s",
+				error_msg,
+				target,
+				cmp.Diff(
+					opt1,
+					opt2,
+					ignore_opts,
+				),
+			),
+		)
+	}
+}
+
+func TestTargetToOptionsWithoutRedisConnectionURI(t *testing.T) {
+
+	targets := []string{
+		"",
+		":",
+		":6379",
+		"hostname:6379",
+		"redis.example.com:90",
+		"redis",
+		"redis:100",
+		"rediss",
+		"rediss:100",
+		"http://tam",
+	}
+
+	for _, target := range targets {
+		assertOptionsEqual(
+			t,
+			&redis.Options{Addr: target},
+			redisutil.TargetToOptions(target),
+			target,
+			"Non-redis URI strings should produce "+
+				"options containing only an Addr with that "+
+				"string.",
+		)
+	}
+}
+
+func TestTargetToOptionsWithConnectionURI(t *testing.T) {
+
+	test_map := func(target_option_map map[string]*redis.Options) {
+		for target, opt := range target_option_map {
+			test_opt := redisutil.TargetToOptions(target)
+			assertOptionsEqual(
+				t,
+				opt,
+				test_opt,
+				target,
+				"Connection URI string did "+
+					"not match expectation.",
+			)
+		}
+	}
+
+	redis_targets_with_options := genRedisURIOptionsMap(
+		[]string{"redis", "rediss"},
+		[]string{"", "user", "redis"},
+		[]string{"", "password", "hunter2"},
+		[]string{"", "remotehost", "redis.example.com", "::1"},
+		[]string{"", "1000", "5", "6379"},
+		[]string{"", "0", "5", "500", "100/2", "200.1", "bad", "05a"},
+	)
+	test_map(redis_targets_with_options)
+
+	unix_targets_with_options := genUnixURIOptionsMap(
+		[]string{"", "user", "redis"},
+		[]string{"", "password", "hunter2"},
+		[]string{"", "/", "/path", "/path/to", "/path/to/socket"},
+		[]string{"", "0", "5", "500", "100/2", "200.1", "bad", "05a"},
+	)
+	test_map(unix_targets_with_options)
+
+	empty := &redis.Options{}
+	bad_targets_with_options := map[string]*redis.Options{
+		"redis://u:p@h:2/9?jam=tam":        empty,
+		"rediss://u:p@h:2?database=0":      empty,
+		"rediss://u@h:2/0?password=pw":     empty,
+		"rediss://u:p@::1?database=0":      empty,
+		"rediss://u@[::1]:5/0?password=pw": empty,
+	}
+	test_map(bad_targets_with_options)
+
+}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -107,7 +107,7 @@ type S3CacheConfig struct {
 
 type DistributedCacheConfig struct {
 	ListenAddr        string `yaml:"listen_addr" usage:"The address to listen for local BuildBuddy distributed cache traffic on."`
-	RedisTarget       string `yaml:"redis_target" usage:"A redis target for improved Caching/RBE performance. ** Enterprise only **"`
+	RedisTarget       string `yaml:"redis_target" usage:"A redis target for improved Caching/RBE performance. Target can be provided as either a redis connection URI or a host:port pair. URI schemas supported: redis[s]://[[USER][:PASSWORD]@][HOST][:PORT][/DATABASE] or unix://[[USER][:PASSWORD]@]SOCKET_PATH[?db=DATABASE] ** Enterprise only **"`
 	GroupName         string `yaml:"group_name" usage:"A unique name for this distributed cache group. ** Enterprise only **"`
 	ReplicationFactor int    `yaml:"replication_factor" usage:"How many total servers the data should be replicated to. Must be >= 1. ** Enterprise only **"`
 }
@@ -120,7 +120,7 @@ type cacheConfig struct {
 	InMemory         bool                   `yaml:"in_memory" usage:"Whether or not to use the in_memory cache."`
 	MaxSizeBytes     int64                  `yaml:"max_size_bytes" usage:"How big to allow the cache to be (in bytes)."`
 	MemcacheTargets  []string               `yaml:"memcache_targets" usage:"Deprecated. Use Redis Target instead."`
-	RedisTarget      string                 `yaml:"redis_target" usage:"A redis target for improved Caching/RBE performance. ** Enterprise only **"`
+	RedisTarget      string                 `yaml:"redis_target" usage:"A redis target for improved Caching/RBE performance. Target can be provided as either a redis connection URI or a host:port pair. URI schemas supported: redis[s]://[[USER][:PASSWORD]@][HOST][:PORT][/DATABASE] or unix://[[USER][:PASSWORD]@]SOCKET_PATH[?db=DATABASE] ** Enterprise only **"`
 }
 
 type authConfig struct {


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Allows the yaml config to specify a redis connection URI in one of the following formats:
`redis[s]://[[USER][:PASSWORD]@][HOST][:PORT][/DATABASE]`
`unix://[[USER][:PASSWORD]@]SOCKET_PATH[?db=DATABASE]`

This should resolve [buildbuddy-io/buildbuddy-internal#275]

---

**Version bump**: Minor<!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
