### PR TITLE
workflows: Fix url-based auth in CI runner

### DIFF
--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//proto:build_event_stream_go_proto",
         "//proto:build_events_go_proto",
         "//proto:publish_build_event_go_proto",
+        "//server/util/git:go_default_library",
         "//server/util/grpc_client:go_default_library",
         "//server/util/lockingbuffer:go_default_library",
         "//server/util/status:go_default_library",

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -578,7 +578,6 @@ func setupGitRepo(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("AuthURL: ", authURL)
 	remote, err := repo.CreateRemote(&gitcfg.RemoteConfig{
 		Name: "origin",
 		URLs: []string{authURL},

--- a/server/backends/repo_downloader/BUILD
+++ b/server/backends/repo_downloader/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/backends/repo_downloader",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/util/git:go_default_library",
         "@com_github_go_git_go_git_v5//:go_default_library",
         "@com_github_go_git_go_git_v5//config:go_default_library",
         "@com_github_go_git_go_git_v5//storage/memory:go_default_library",

--- a/server/backends/repo_downloader/repo_downloader.go
+++ b/server/backends/repo_downloader/repo_downloader.go
@@ -2,10 +2,11 @@ package repo_downloader
 
 import (
 	"context"
-	"net/url"
 
-	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
+
+	gitutil "github.com/buildbuddy-io/buildbuddy/server/util/git"
+	git "github.com/go-git/go-git/v5"
 	memory "github.com/go-git/go-git/v5/storage/memory"
 )
 
@@ -16,18 +17,9 @@ func NewRepoDownloader() *gitRepoDownloader {
 }
 
 func (d *gitRepoDownloader) TestRepoAccess(ctx context.Context, repoURL, username, accessToken string) error {
-	authURL := repoURL
-
-	u, err := url.Parse(repoURL)
-	if err == nil {
-		if accessToken != "" {
-			if username != "" {
-				u.User = url.UserPassword(username, accessToken)
-			} else {
-				u.User = url.UserPassword(accessToken, "")
-			}
-			authURL = u.String()
-		}
+	authURL, err := gitutil.AuthRepoURL(repoURL, username, accessToken)
+	if err != nil {
+		return err
 	}
 
 	remote := git.NewRemote(memory.NewStorage(), &config.RemoteConfig{

--- a/server/util/git/BUILD
+++ b/server/util/git/BUILD
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["git.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/git",
+    visibility = ["//visibility:public"],
+    deps = ["//server/util/status:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["git_test.go"],
+    # keep
+    embed = [],
+    deps = [
+        ":go_default_library",  # keep
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
+)

--- a/server/util/git/git.go
+++ b/server/util/git/git.go
@@ -1,0 +1,40 @@
+package git
+
+import (
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"net/url"
+)
+
+const (
+	// DefaultUser is the default user set in a repo URL when the username is not
+	// known.
+	DefaultUser = "buildbuddy"
+)
+
+// AuthRepoURL returns a Git repo URL with the given credentials set. The
+// returned URL can be used as a git remote.
+//
+// The returned URL accounts for various Git provider quirks, so that if all
+// necessary credentials are provided, the returned URL will allow accessing
+// the repo. Note that if the credentials are invalid, this function does not
+// return an error (other parts of the system are responsible for that).
+func AuthRepoURL(repoURL, user, token string) (string, error) {
+	if user == "" && token == "" {
+		return repoURL, nil
+	}
+	u, err := url.Parse(repoURL)
+	if err != nil {
+		return "", status.InvalidArgumentErrorf("invalid repo URL %q", repoURL)
+	}
+	if user == "" {
+		// GitHub allows using only a token for auth, but a bogus (non-empty)
+		// username is required. GitLab does not have this requirement, and they
+		// simply ignore the username if it is set. Bitbucket *always* requires a
+		// username, but we don't handle Bitbucket specially and just let auth fail
+		// when querying the remote - the default username set here will probably be
+		// incorrect, but it yields the same error as an empty username.
+		user = DefaultUser
+	}
+	u.User = url.UserPassword(user, token)
+	return u.String(), nil
+}

--- a/server/util/git/git_test.go
+++ b/server/util/git/git_test.go
@@ -1,0 +1,32 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	gitutil "github.com/buildbuddy-io/buildbuddy/server/util/git"
+)
+
+func TestAuthRepoURL(t *testing.T) {
+	for _, test := range []struct {
+		url      string
+		user     string
+		token    string
+		expected string
+	}{
+		{"https://github.com/foo/bar", "", "TOKEN", "https://buildbuddy:TOKEN@github.com/foo/bar"},
+		{"https://gitlab.com/foo/bar", "", "TOKEN", "https://buildbuddy:TOKEN@gitlab.com/foo/bar"},
+		{"https://bitbucket.org/foo/bar", "USER", "TOKEN", "https://USER:TOKEN@bitbucket.org/foo/bar"},
+		{"https://github.com/foo-public/bar", "", "", "https://github.com/foo-public/bar"},
+	} {
+		authURL, err := gitutil.AuthRepoURL(test.url, test.user, test.token)
+
+		assert.NoError(t, err)
+		assert.Equal(t, test.expected, authURL)
+	}
+
+	authURL, err := gitutil.AuthRepoURL(" http @://INVALID_URL", "USER", "TOKEN")
+	assert.Empty(t, authURL)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
At some point I had convinced myself that GitHub supported both `TOKEN:` and `:TOKEN` as the user/password part of the URL, so I thought "great, we can just pass through the user/pass directly, even if user is empty, and it will work for all providers".

But looks like this is wrong -- GitHub only supports the token being used in the password field if you also pass a bogus username, like `buildbuddy:TOKEN`.

Consolidated that logic into `server/util/git` and updated the `repo_downloader` to use it as well. Note, the existing logic in `repo_downloader` would not have worked for GitLab. They don't require a username, but they don't support `TOKEN:` as the user/pass. They do support both `:TOKEN` (with an empty user) and `buildbuddy:TOKEN` (a bogus user), which is nice because it lets us use the same logic for all the providers.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
