### PR TITLE
[public] Add Gazelle directive to ignore generated proto code if it's present.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,7 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@io_bazel_rules_go//go:def.bzl", "nogo")
+
+package(default_visibility = ["//visibility:public"])
 
 nogo(
     name = "vet",
@@ -11,6 +11,8 @@ nogo(
 
 # Ignore the node_modules dir
 # gazelle:exclude node_modules
+# Ignore generated proto files
+# gazelle:exclude **/*.pb.go
 # Prefer generated BUILD files to be called BUILD over BUILD.bazel
 # gazelle:build_file_name BUILD,BUILD.bazel
 # gazelle:prefix github.com/buildbuddy-io/buildbuddy

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,9 +19,9 @@ http_archive(
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "86c6d481b3f7aedc1d60c1c211c6f76da282ae197c3b3160f54bd3a8f847896f",
+    sha256 = "bfd86b3cbe855d6c16c6fce60d76bd51f5c8dbc9cfcaef7a2bb5c1aafd0710e8",
     urls = [
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.21.0/bazel-gazelle-v0.21.0.tar.gz",
     ],
 )
 

--- a/proto/api/v1/BUILD
+++ b/proto/api/v1/BUILD
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(


### PR DESCRIPTION
Having the generated code locally is useful for code
completion/navigation but Gazelle tries to generate rules for them like
any other code which causes problems.

This required upgrading Gazelle to 0.21.0 because the older version
didn't support exclude patterns.

I tried upgrading to the latest, latest version but I was not able to
run Gazelle succesfully.

Misc changes due to clean run of Gazelle.

**Version bump**: None

