### PR TITLE
[public] Changes to support RBE testing.

### DIFF
--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -12,8 +12,8 @@ const (
 
 	// This is the default resource estimate for a task that we can't
 	// otherwise determine the size for.
-	defaultMemEstimate = int64(400 * 1e6)
-	defaultCPUEstimate = int64(600)
+	DefaultMemEstimate = int64(400 * 1e6)
+	DefaultCPUEstimate = int64(600)
 )
 
 func testSize(testSize string) (int64, int64) {
@@ -42,8 +42,8 @@ func testSize(testSize string) (int64, int64) {
 }
 
 func Estimate(cmd *repb.Command) *scpb.TaskSize {
-	memEstimate := defaultMemEstimate
-	cpuEstimate := defaultCPUEstimate
+	memEstimate := DefaultMemEstimate
+	cpuEstimate := DefaultCPUEstimate
 	for _, envVar := range cmd.GetEnvironmentVariables() {
 		if envVar.GetName() == testSizeEnvVar {
 			memEstimate, cpuEstimate = testSize(envVar.GetValue())

--- a/server/testutil/environment/environment.go
+++ b/server/testutil/environment/environment.go
@@ -70,17 +70,7 @@ func (te *TestEnv) bufDialer(context.Context, string) (net.Conn, error) {
 // Call LocalGRPCConn to get a connection to the returned server.
 func (te *TestEnv) LocalGRPCServer() (*grpc.Server, func()) {
 	te.lis = bufconn.Listen(1024 * 1024)
-	grpcOptions := []grpc.ServerOption{
-		rpcfilters.GetUnaryInterceptor(te),
-		rpcfilters.GetStreamInterceptor(te),
-	}
-	srv := grpc.NewServer(grpcOptions...)
-	runFunc := func() {
-		if err := srv.Serve(te.lis); err != nil {
-			log.Fatal(err)
-		}
-	}
-	return srv, runFunc
+	return te.GRPCServer(te.lis)
 }
 
 func (te *TestEnv) LocalGRPCConn(ctx context.Context) (*grpc.ClientConn, error) {


### PR DESCRIPTION
- Add utility function to start gRPC server with custom listener.
  Executors need be started on a TCP port so that they are reachable
from the scheduler.

- Make default task sizes public to take advante of them to set executor
limits in tests.

- Enable remote execution in test environment config.

**Version bump**: None
