### PR TITLE
[public] Disambiguate the redisii.

### DIFF
--- a/enterprise/server/backends/pubsub/BUILD
+++ b/enterprise/server/backends/pubsub/BUILD
@@ -9,7 +9,7 @@ go_library(
         "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
-        "//enterprise/server/util/redis:go_default_library",
+        "//enterprise/server/util/redisutil:go_default_library",
         "//server/interfaces:go_default_library",
         "@com_github_go_redis_redis_v8//:go_default_library",
     ],

--- a/enterprise/server/backends/pubsub/pubsub.go
+++ b/enterprise/server/backends/pubsub/pubsub.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/go-redis/redis/v8"
 
-	redisutils "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redis"
-	redis "github.com/go-redis/redis/v8"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redisutil"
 )
 
 type PubSub struct {
@@ -15,7 +15,7 @@ type PubSub struct {
 
 func NewPubSub(redisTarget string) *PubSub {
 	return &PubSub{
-		rdb: redis.NewClient(redisutils.TargetToOptions(redisTarget)),
+		rdb: redis.NewClient(redisutil.TargetToOptions(redisTarget)),
 	}
 }
 

--- a/enterprise/server/backends/redis_cache/BUILD
+++ b/enterprise/server/backends/redis_cache/BUILD
@@ -2,14 +2,14 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["redis.go"],
-    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis",
+    srcs = ["redis_cache.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_cache",
     visibility = [
         "//enterprise:__subpackages__",
         "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
-        "//enterprise/server/util/redis:go_default_library",
+        "//enterprise/server/util/redisutil:go_default_library",
         "//proto:remote_execution_go_proto",
         "//server/interfaces:go_default_library",
         "//server/remote_cache/digest:go_default_library",

--- a/enterprise/server/backends/redis_cache/redis_cache.go
+++ b/enterprise/server/backends/redis_cache/redis_cache.go
@@ -1,4 +1,4 @@
-package redis
+package redis_cache
 
 import (
 	"bytes"
@@ -12,10 +12,10 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/cache_metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/go-redis/redis/v8"
 
-	redisutils "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redis"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redisutil"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	redis "github.com/go-redis/redis/v8"
 )
 
 const (
@@ -42,7 +42,7 @@ type Cache struct {
 func NewCache(redisTarget string, hc interfaces.HealthChecker) *Cache {
 	c := &Cache{
 		prefix: "",
-		rdb:    redis.NewClient(redisutils.TargetToOptions(redisTarget)),
+		rdb:    redis.NewClient(redisutil.TargetToOptions(redisTarget)),
 	}
 	hc.AddHealthCheck("redis_cache", c)
 	return c

--- a/enterprise/server/util/redisutil/BUILD
+++ b/enterprise/server/util/redisutil/BUILD
@@ -2,8 +2,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["redis.go"],
-    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redis",
+    srcs = ["redisutil.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redisutil",
     visibility = [
         "//enterprise:__subpackages__",
         "@buildbuddy_internal//enterprise:__subpackages__",
@@ -15,7 +15,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["redis_test.go"],
+    srcs = ["redisutil_test.go"],
     embed = [":go_default_library"],
     visibility = [
         "//enterprise:__subpackages__",

--- a/enterprise/server/util/redisutil/redisutil.go
+++ b/enterprise/server/util/redisutil/redisutil.go
@@ -1,10 +1,10 @@
-package redis
+package redisutil
 
 import (
 	"log"
 	"strings"
 
-	redis "github.com/go-redis/redis/v8"
+	"github.com/go-redis/redis/v8"
 )
 
 func isRedisURI(redisTarget string) bool {

--- a/enterprise/server/util/redisutil/redisutil_test.go
+++ b/enterprise/server/util/redisutil/redisutil_test.go
@@ -1,4 +1,4 @@
-package redis_test
+package redisutil_test
 
 import (
 	"crypto/tls"
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-redis/redis/v8"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	redisutil "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redis"
-	redis "github.com/go-redis/redis/v8"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redisutil"
 )
 
 func genOptions(scheme, user, password, addr, database string) *redis.Options {


### PR DESCRIPTION
There are 3 'redis' packages in use in our code:
redis client
redis cache
redis utils

I renamed two of our redis packages to simplify imports & navigation:
redis cache becomes redis_cache
redis utils becomes redisutil

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
