### PR TITLE
Remove URL credentials from REPO_URL in workspace_status

### DIFF
--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -15,13 +15,13 @@ set -eo pipefail # exit immediately if any command fails.
 function remove_url_credentials() { sed -r 's#//.*?:.*?@#//#'; }
 
 repo_url=$(git config --get remote.origin.url | remove_url_credentials)
-echo REPO_URL "$repo_url"
+echo "REPO_URL $repo_url"
 
 commit_sha=$(git rev-parse HEAD)
-echo COMMIT_SHA "$commit_sha"
+echo "COMMIT_SHA $commit_sha"
 
 git_branch=$(git rev-parse --abbrev-ref HEAD)
-echo GIT_BRANCH "$git_branch"
+echo "GIT_BRANCH $git_branch"
 
 git_tree_status=$(git diff-index --quiet HEAD -- && echo 'Clean' || echo 'Modified')
-echo GIT_TREE_STATUS "$git_tree_status"
+echo "GIT_TREE_STATUS $git_tree_status"

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -10,36 +10,18 @@
 # If the script exits with non-zero code, it's considered as a failure
 # and the output will be discarded.
 
-# Git repo
-repo_url=$(git config --get remote.origin.url)
-if [[ $? != 0 ]];
-then
-    exit 1
-fi
-echo "REPO_URL ${repo_url}"
+set -eo pipefail # exit immediately if any command fails.
 
-# Commit SHA
+function remove_url_credentials() { sed -r 's#//.*?:.*?@#//#'; }
+
+repo_url=$(git config --get remote.origin.url | remove_url_credentials)
+echo REPO_URL "$repo_url"
+
 commit_sha=$(git rev-parse HEAD)
-if [[ $? != 0 ]];
-then
-    exit 1
-fi
-echo "COMMIT_SHA ${commit_sha}"
+echo COMMIT_SHA "$commit_sha"
 
-# Git branch
-repo_url=$(git rev-parse --abbrev-ref HEAD)
-if [[ $? != 0 ]];
-then
-    exit 1
-fi
-echo "GIT_BRANCH ${repo_url}"
+git_branch=$(git rev-parse --abbrev-ref HEAD)
+echo GIT_BRANCH "$git_branch"
 
-# Tree status
-git diff-index --quiet HEAD --
-if [[ $? == 0 ]];
-then
-    tree_status="Clean"
-else
-    tree_status="Modified"
-fi
-echo "GIT_TREE_STATUS ${tree_status}"
+git_tree_status=$(git diff-index --quiet HEAD -- && echo 'Clean' || echo 'Modified')
+echo GIT_TREE_STATUS "$git_tree_status"


### PR DESCRIPTION
People have the option of putting a personal access token inside their local `.git/config` in order to authenticate with the Git remote. We don't intend for this to get sent to BuildBuddy's servers, so updating the workspace_status command to strip it out.

Also cleaned up that file a bit.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
