### PR TITLE
Add docs on filecache dir requirements

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -155,7 +155,7 @@ type RemoteExecutionConfig struct {
 type ExecutorConfig struct {
 	AppTarget               string `yaml:"app_target" usage:"The GRPC url of a buildbuddy app server."`
 	RootDirectory           string `yaml:"root_directory" usage:"The root directory to use for build files."`
-	LocalCacheDirectory     string `yaml:"local_cache_directory" usage:"A local on-disk cache directory."`
+	LocalCacheDirectory     string `yaml:"local_cache_directory" usage:"A local on-disk cache directory. Must be on the same device (disk partition, Docker volume, etc.) as the configured root_directory, since files are hard-linked to this cache for performance reasons. Otherwise, 'Invalid cross-device link' errors may result."`
 	LocalCacheSizeBytes     int64  `yaml:"local_cache_size_bytes" usage:"The maximum size, in bytes, to use for the local on-disk cache"`
 	DockerSocket            string `yaml:"docker_socket" usage:"If set, run execution commands in docker using the provided socket."`
 	DockerSiblingContainers bool   `yaml:"docker_sibling_containers" usage:"If set, mount the configured Docker socket to containers spawned for each action, to enable Docker-out-of-Docker (DooD). Takes effect only if docker_socket is also set. Should not be set by executors that can run untrusted code."`


### PR DESCRIPTION
When running the executor on Docker locally, I ran into an `Invalid cross-device link` error from the `fastcopy` util, because I was mounting the root dir and the file cache dir as separate volumes. Added some documentation to clarify that they have to be the on the same device (physical or virtual) otherwise the hard-linking won't work.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
