### PR TITLE
Remove credentials from repo URL in workspace_status

### DIFF
--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -12,7 +12,9 @@
 
 set -eo pipefail # exit immediately if any command fails.
 
-function remove_url_credentials() { perl -pe 's#//.*?:.*?@#//#'; }
+function remove_url_credentials() {
+  which perl >/dev/null && perl -pe 's#//.*?:.*?@#//#' || cat
+}
 
 repo_url=$(git config --get remote.origin.url | remove_url_credentials)
 echo "REPO_URL $repo_url"

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -10,36 +10,18 @@
 # If the script exits with non-zero code, it's considered as a failure
 # and the output will be discarded.
 
-# Git repo
-repo_url=$(git config --get remote.origin.url)
-if [[ $? != 0 ]];
-then
-    exit 1
-fi
-echo "REPO_URL ${repo_url}"
+set -eo pipefail # exit immediately if any command fails.
 
-# Commit SHA
+function remove_url_credentials() { sed -E 's#//.*?:.*?@#//#'; }
+
+repo_url=$(git config --get remote.origin.url | remove_url_credentials)
+echo "REPO_URL $repo_url"
+
 commit_sha=$(git rev-parse HEAD)
-if [[ $? != 0 ]];
-then
-    exit 1
-fi
-echo "COMMIT_SHA ${commit_sha}"
+echo "COMMIT_SHA $commit_sha"
 
-# Git branch
-repo_url=$(git rev-parse --abbrev-ref HEAD)
-if [[ $? != 0 ]];
-then
-    exit 1
-fi
-echo "GIT_BRANCH ${repo_url}"
+git_branch=$(git rev-parse --abbrev-ref HEAD)
+echo "GIT_BRANCH $git_branch"
 
-# Tree status
-git diff-index --quiet HEAD --
-if [[ $? == 0 ]];
-then
-    tree_status="Clean"
-else
-    tree_status="Modified"
-fi
-echo "GIT_TREE_STATUS ${tree_status}"
+git_tree_status=$(git diff-index --quiet HEAD -- && echo 'Clean' || echo 'Modified')
+echo "GIT_TREE_STATUS $git_tree_status"

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -12,7 +12,7 @@
 
 set -eo pipefail # exit immediately if any command fails.
 
-function remove_url_credentials() { sed -E 's#//.*?:.*?@#//#'; }
+function remove_url_credentials() { perl -pe 's#//.*?:.*?@#//#'; }
 
 repo_url=$(git config --get remote.origin.url | remove_url_credentials)
 echo "REPO_URL $repo_url"


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Roll-forward of a previous PR. Instead of `sed -r`, now using `perl -pe` and falling back to a no-op if `perl` does not exist.

Tested on:
* MacOS 10.15.7
* Ubuntu 16.04
* Ubuntu 20.04
* Debian 10.8

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
