### PR TITLE
Warn about wrong-sized values.

### DIFF
--- a/server/build_event_protocol/build_status_reporter/BUILD
+++ b/server/build_event_protocol/build_status_reporter/BUILD
@@ -9,7 +9,6 @@ go_library(
         "//proto:build_event_stream_go_proto",
         "//server/backends/github:go_default_library",
         "//server/build_event_protocol/accumulator:go_default_library",
-        "//server/build_event_protocol/event_parser:go_default_library",
         "//server/environment:go_default_library",
         "//server/tables:go_default_library",
         "//server/util/git:go_default_library",

--- a/server/remote_cache/content_addressable_storage_server/BUILD
+++ b/server/remote_cache/content_addressable_storage_server/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -18,6 +18,23 @@ go_library(
         "//server/util/status:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@go_googleapis//google/rpc:status_go_proto",
+        "@org_golang_google_grpc//codes:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["content_addressable_storage_server_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/backends/memory_cache:go_default_library",
+        "//server/interfaces:go_default_library",
+        "//server/testutil/testdigest:go_default_library",
+        "//server/testutil/testenv:go_default_library",
+        "//server/util/prefix:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
     ],
 )

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -220,16 +220,15 @@ func (s *ContentAddressableStorageServer) BatchReadBlobs(ctx context.Context, re
 			Digest: d,
 			Data:   data,
 		}
-		if err == nil {
+		if d.GetSizeBytes() != int64(len(data)) {
+			log.Printf("Warning: cache returned a blob of %d bytes which doesn't match digest: %s/%d. Ignoring.", len(data), d.GetHash(), d.GetSizeBytes())
+			blobRsp.Status = &statuspb.Status{Code: int32(codes.NotFound)}
+		} else if err == nil {
 			blobRsp.Status = &statuspb.Status{Code: int32(codes.OK)}
 		} else if os.IsNotExist(err) {
 			blobRsp.Status = &statuspb.Status{Code: int32(codes.NotFound)}
 		} else {
 			blobRsp.Status = &statuspb.Status{Code: int32(codes.Internal)}
-		}
-		if d.GetSizeBytes() != int64(len(data)) {
-			log.Printf("Warning: cache returned a blob of %d bytes which doesn't match digest: %s/%d. Ignoring.", len(data), d.GetHash(), d.GetSizeBytes())
-			continue
 		}
 		rsp.Responses = append(rsp.Responses, blobRsp)
 	}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -226,7 +226,7 @@ func (s *ContentAddressableStorageServer) BatchReadBlobs(ctx context.Context, re
 		} else {
 			blobRsp.Status = &statuspb.Status{Code: int32(codes.Internal)}
 		}
-		if !d.GetSizeBytes() == len(data) {
+		if d.GetSizeBytes() != len(data) {
 			log.Printf("Warning: cache returned a blob of %d bytes which doesn't match digest: %s/%d. Ignoring.", len(data), d.GetHash(), d.GetSizeBytes())
 			continue
 		}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log"
 	"os"
 	"sync"
 
@@ -226,7 +227,7 @@ func (s *ContentAddressableStorageServer) BatchReadBlobs(ctx context.Context, re
 		} else {
 			blobRsp.Status = &statuspb.Status{Code: int32(codes.Internal)}
 		}
-		if d.GetSizeBytes() != len(data) {
+		if d.GetSizeBytes() != int64(len(data)) {
 			log.Printf("Warning: cache returned a blob of %d bytes which doesn't match digest: %s/%d. Ignoring.", len(data), d.GetHash(), d.GetSizeBytes())
 			continue
 		}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -226,6 +226,10 @@ func (s *ContentAddressableStorageServer) BatchReadBlobs(ctx context.Context, re
 		} else {
 			blobRsp.Status = &statuspb.Status{Code: int32(codes.Internal)}
 		}
+		if !d.GetSizeBytes() == len(data) {
+			log.Printf("Warning: cache returned a blob of %d bytes which doesn't match digest: %s/%d. Ignoring.", len(data), d.GetHash(), d.GetSizeBytes())
+			continue
+		}
 		rsp.Responses = append(rsp.Responses, blobRsp)
 	}
 	return rsp, nil

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -1,0 +1,92 @@
+package content_addressable_storage_server_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/backends/memory_cache"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/content_addressable_storage_server"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	gcodes "google.golang.org/grpc/codes"
+)
+
+func runCASServer(ctx context.Context, env *testenv.TestEnv, t *testing.T) *grpc.ClientConn {
+	casServer, err := content_addressable_storage_server.NewContentAddressableStorageServer(env)
+	if err != nil {
+		t.Error(err)
+	}
+
+	grpcServer, runFunc := env.LocalGRPCServer()
+	repb.RegisterContentAddressableStorageServer(grpcServer, casServer)
+
+	go runFunc()
+
+	clientConn, err := env.LocalGRPCConn(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	return clientConn
+}
+
+type evilCache struct {
+	interfaces.Cache
+}
+
+func (e *evilCache) GetMulti(ctx context.Context, digests []*repb.Digest) (map[*repb.Digest][]byte, error) {
+	rsp, err := e.Cache.GetMulti(ctx, digests)
+	for d, _ := range rsp {
+		rsp[d] = []byte{}
+	}
+	return rsp, err
+}
+
+func TestMalevolentCache(t *testing.T) {
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te)
+	if err != nil {
+		t.Errorf("error attaching user prefix: %v", err)
+	}
+
+	c, err := memory_cache.NewMemoryCache(1000000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	te.SetCache(&evilCache{c})
+	clientConn := runCASServer(ctx, te, t)
+	casClient := repb.NewContentAddressableStorageClient(clientConn)
+
+	d, buf := testdigest.NewRandomDigestBuf(t, 100)
+	set, err := casClient.BatchUpdateBlobs(ctx, &repb.BatchUpdateBlobsRequest{
+		Requests: []*repb.BatchUpdateBlobsRequest_Request{
+			&repb.BatchUpdateBlobsRequest_Request{
+				Digest: d,
+				Data: buf,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 1, len(set.GetResponses()))
+	assert.Equal(t, d.GetHash(), set.GetResponses()[0].GetDigest().GetHash())
+	assert.Equal(t, int32(gcodes.OK), set.GetResponses()[0].GetStatus().GetCode())
+
+	get, err := casClient.BatchReadBlobs(ctx, &repb.BatchReadBlobsRequest{
+		Digests: []*repb.Digest{d},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 1, len(get.GetResponses()))
+	assert.Equal(t, d.GetHash(), get.GetResponses()[0].GetDigest().GetHash())
+	assert.Equal(t, int32(gcodes.NotFound), get.GetResponses()[0].GetStatus().GetCode())
+}


### PR DESCRIPTION
Provide a warning if any cache backend returns a value in MultiGet that is not the expected size.