### PR TITLE
More distributed fixes.

### DIFF
--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -59,7 +59,12 @@ func newDistributedCache(t *testing.T, te environment.Env, peer string, replicat
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err := NewDistributedCache(te, mc, peer, heartbeatGroupName, replicationFactor)
+	dcc := CacheConfig{
+		ListenAddr:        peer,
+		GroupName:         heartbeatGroupName,
+		ReplicationFactor: replicationFactor,
+	}
+	c, err := NewDistributedCache(te, mc, dcc, te.GetHealthChecker())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -295,9 +295,6 @@ func (c *CacheProxy) RemoteWriter(ctx context.Context, peer, prefix string, d *r
 		client := &http.Client{}
 		rsp, err := client.Do(req)
 		if err != nil {
-			log.Printf("Error in goroutine running client.Do: %s", err)
-			err = status.UnavailableError(err.Error())
-			reader.CloseWithError(err)
 			return err
 		}
 		return rsp.Body.Close()

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -69,7 +69,7 @@ func TestMalevolentCache(t *testing.T) {
 		Requests: []*repb.BatchUpdateBlobsRequest_Request{
 			&repb.BatchUpdateBlobsRequest_Request{
 				Digest: d,
-				Data: buf,
+				Data:   buf,
 			},
 		},
 	})

--- a/server/util/consistent_hash/consistent_hash.go
+++ b/server/util/consistent_hash/consistent_hash.go
@@ -31,6 +31,12 @@ func (c *ConsistentHash) hashKey(key string) int {
 	return int(crc32.ChecksumIEEE([]byte(key)))
 }
 
+func (c *ConsistentHash) GetItems() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.items
+}
+
 func (c *ConsistentHash) Set(items ...string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()


### PR DESCRIPTION
Add health checking which only marks the server as ready after connecting to some peers, and stops advertising as soon as the server begins shutdown. Accept some params via a CacheConfig struct. Allow write failures before and during a write -- up to the allowable amount.