### PR TITLE
[public] Consolidate redis client creation.

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -8,14 +8,13 @@ import (
 	"path/filepath"
 	"sync"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/cacheproxy"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/heartbeat"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/consistent_hash"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"golang.org/x/sync/errgroup"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )

--- a/enterprise/server/backends/pubsub/BUILD
+++ b/enterprise/server/backends/pubsub/BUILD
@@ -9,7 +9,6 @@ go_library(
         "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
-        "//enterprise/server/util/redisutil:go_default_library",
         "//server/interfaces:go_default_library",
         "@com_github_go_redis_redis_v8//:go_default_library",
     ],

--- a/enterprise/server/backends/pubsub/pubsub.go
+++ b/enterprise/server/backends/pubsub/pubsub.go
@@ -3,19 +3,18 @@ package pubsub
 import (
 	"context"
 
-	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/go-redis/redis/v8"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redisutil"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 )
 
 type PubSub struct {
 	rdb *redis.Client
 }
 
-func NewPubSub(redisTarget string) *PubSub {
+func NewPubSub(redisClient *redis.Client) *PubSub {
 	return &PubSub{
-		rdb: redis.NewClient(redisutil.TargetToOptions(redisTarget)),
+		rdb: redisClient,
 	}
 }
 

--- a/enterprise/server/backends/redis_cache/BUILD
+++ b/enterprise/server/backends/redis_cache/BUILD
@@ -9,7 +9,6 @@ go_library(
         "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
-        "//enterprise/server/util/redisutil:go_default_library",
         "//proto:remote_execution_go_proto",
         "//server/interfaces:go_default_library",
         "//server/remote_cache/digest:go_default_library",

--- a/enterprise/server/util/redisutil/BUILD
+++ b/enterprise/server/util/redisutil/BUILD
@@ -9,6 +9,7 @@ go_library(
         "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
+        "//server/interfaces:go_default_library",
         "@com_github_go_redis_redis_v8//:go_default_library",
     ],
 )

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -434,13 +434,7 @@ func (c *Configurator) GetCacheRedisTarget() string {
 	if redisConfig := c.GetCacheRedisConfig(); redisConfig != nil {
 		return redisConfig.RedisTarget
 	}
-	if c.gc.Cache.RedisTarget != "" {
-		return c.gc.Cache.RedisTarget
-	}
-	if dcc := c.GetDistributedCacheConfig(); dcc != nil && dcc.RedisTarget != "" {
-		return dcc.RedisTarget
-	}
-	return ""
+	return c.gc.Cache.RedisTarget
 }
 
 func (c *Configurator) GetCacheRedisConfig() *RedisCacheConfig {

--- a/server/environment/BUILD
+++ b/server/environment/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//server/config:go_default_library",
         "//server/interfaces:go_default_library",
         "//server/util/db:go_default_library",
+        "@com_github_go_redis_redis_v8//:go_default_library",
         "@go_googleapis//google/bytestream:bytestream_go_proto",
     ],
 )

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -1,6 +1,8 @@
 package environment
 
 import (
+	"github.com/go-redis/redis/v8"
+
 	"github.com/buildbuddy-io/buildbuddy/server/config"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
@@ -56,7 +58,8 @@ type Env interface {
 	GetFileCache() interfaces.FileCache
 	GetRemoteExecutionService() interfaces.RemoteExecutionService
 	GetSchedulerService() interfaces.SchedulerService
-	GetPubSub() interfaces.PubSub
+	GetCacheRedisClient() *redis.Client
+	GetRemoteExecutionRedisClient() *redis.Client
 	GetMetricsCollector() interfaces.MetricsCollector
 	GetRepoDownloader() interfaces.RepoDownloader
 	GetWorkflowService() interfaces.WorkflowService

--- a/server/real_environment/BUILD
+++ b/server/real_environment/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//server/config:go_default_library",
         "//server/interfaces:go_default_library",
         "//server/util/db:go_default_library",
+        "@com_github_go_redis_redis_v8//:go_default_library",
         "@go_googleapis//google/bytestream:bytestream_go_proto",
     ],
 )

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -3,14 +3,17 @@ package real_environment
 import (
 	"time"
 
+	"github.com/go-redis/redis/v8"
+
 	"github.com/buildbuddy-io/buildbuddy/server/config"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 
+	bspb "google.golang.org/genproto/googleapis/bytestream"
+
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
-	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
 type executionClientConfig struct {
@@ -56,11 +59,12 @@ type RealEnv struct {
 	fileCache                       interfaces.FileCache
 	remoteExecutionService          interfaces.RemoteExecutionService
 	schedulerService                interfaces.SchedulerService
-	pubSub                          interfaces.PubSub
 	metricsCollector                interfaces.MetricsCollector
 	executionService                interfaces.ExecutionService
 	repoDownloader                  interfaces.RepoDownloader
 	workflowService                 interfaces.WorkflowService
+	cacheRedisClient                *redis.Client
+	remoteExecutionRedisClient      *redis.Client
 }
 
 func NewRealEnv(c *config.Configurator, h interfaces.HealthChecker) *RealEnv {
@@ -232,12 +236,6 @@ func (r *RealEnv) SetSchedulerService(s interfaces.SchedulerService) {
 func (r *RealEnv) GetSchedulerService() interfaces.SchedulerService {
 	return r.schedulerService
 }
-func (r *RealEnv) SetPubSub(p interfaces.PubSub) {
-	r.pubSub = p
-}
-func (r *RealEnv) GetPubSub() interfaces.PubSub {
-	return r.pubSub
-}
 func (r *RealEnv) SetMetricsCollector(c interfaces.MetricsCollector) {
 	r.metricsCollector = c
 }
@@ -261,4 +259,20 @@ func (r *RealEnv) GetWorkflowService() interfaces.WorkflowService {
 }
 func (r *RealEnv) SetWorkflowService(wf interfaces.WorkflowService) {
 	r.workflowService = wf
+}
+
+func (r *RealEnv) SetCacheRedisClient(redisClient *redis.Client) {
+	r.cacheRedisClient = redisClient
+}
+
+func (r *RealEnv) GetCacheRedisClient() *redis.Client {
+	return r.cacheRedisClient
+}
+
+func (r *RealEnv) SetRemoteExecutionRedisClient(redisClient *redis.Client) {
+	r.remoteExecutionRedisClient = redisClient
+}
+
+func (r *RealEnv) GetRemoteExecutionRedisClient() *redis.Client {
+	return r.remoteExecutionRedisClient
 }


### PR DESCRIPTION
Separate Cache & Remote Execution Redis clients and configs.

 - Introduced a new 'redis_target' config option in the
'remote_execution' config. Falls back to the cache redis target if not
set.

 - Redis clients are initialized centrally and stored in the environment
instead of passing around the Redis targets.

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

Part of addressing buildbuddy-io/buildbuddy-internal#350

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
