### PR TITLE
Mark bazel binary dependency as executable.

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -10,12 +10,14 @@ def install_buildbuddy_dependencies():
         name = "io_bazel_bazel-3.7.0-linux-x86_64",
         sha256 = "b7583eec83cc38302997098a40b8c870c37e0ab971a83cb3364c754a178b74ec",
         urls = ["https://github.com/bazelbuild/bazel/releases/download/3.7.0/bazel-3.7.0-linux-x86_64"],
+        executable = True,
     )
 
     http_file(
         name = "io_bazel_bazel-3.7.0-darwin-x86_64",
         sha256 = "54657467a38db95c6063692315fcdb59817688254eff39333935d5e356675ebd",
         urls = ["https://github.com/bazelbuild/bazel/releases/download/3.7.0/bazel-3.7.0-darwin-x86_64"],
+        executable = True,
     )
 
     go_embed_data_dependencies()


### PR DESCRIPTION
We use it in a test and new bazel release no longer makes files
executable by default.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
