### PR TITLE
Run TestHealthchecker shutdown funcs as test cleanup funcs

### DIFF
--- a/server/testutil/healthcheck/healthcheck.go
+++ b/server/testutil/healthcheck/healthcheck.go
@@ -1,28 +1,38 @@
 package healthcheck
 
 import (
+	"context"
 	"net/http"
+	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 )
 
-type TestingHealthChecker struct{}
-
-func NewTestingHealthChecker() interfaces.HealthChecker {
-	return &TestingHealthChecker{}
+type TestingHealthChecker struct {
+	t testing.TB
 }
 
-func (t *TestingHealthChecker) RegisterShutdownFunction(hc interfaces.CheckerFunc) {}
-func (t *TestingHealthChecker) AddHealthCheck(name string, f interfaces.Checker)   {}
-func (t *TestingHealthChecker) WaitForGracefulShutdown() {
+func NewTestingHealthChecker(t testing.TB) interfaces.HealthChecker {
+	return &TestingHealthChecker{t}
+}
+
+func (hc *TestingHealthChecker) RegisterShutdownFunction(f interfaces.CheckerFunc) {
+	hc.t.Cleanup(func() {
+		if err := f(context.Background()); err != nil {
+			hc.t.Fatal(err)
+		}
+	})
+}
+func (hc *TestingHealthChecker) AddHealthCheck(name string, f interfaces.Checker) {}
+func (hc *TestingHealthChecker) WaitForGracefulShutdown() {
 	select {}
 }
-func (t *TestingHealthChecker) LivenessHandler() http.Handler {
+func (hc *TestingHealthChecker) LivenessHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("OK"))
 	})
 }
-func (t *TestingHealthChecker) ReadinessHandler() http.Handler {
+func (hc *TestingHealthChecker) ReadinessHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("OK"))
 	})

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -127,7 +127,7 @@ func GetTestEnv(t testing.TB) *TestEnv {
 	if err != nil {
 		t.Fatal(err)
 	}
-	healthChecker := healthcheck.NewTestingHealthChecker()
+	healthChecker := healthcheck.NewTestingHealthChecker(t)
 	te := &TestEnv{
 		RealEnv: real_environment.NewRealEnv(configurator, healthChecker),
 	}


### PR DESCRIPTION
* Call registered shutdown functions in test cleanup
* Fail if any shutdown func returns an error
* Implement `WaitForGracefulShutdown` so that tests can make assertions about post-shutdown state

Motivation: Adding tests for the command runner pool. The pool registers a shutdown function to remove all registered runners, and we want to be able to exercise this logic.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
