### PR TITLE
Allow static nodeset + remove distributed cache healthcheck

### DIFF
--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -63,8 +63,9 @@ func newDistributedCache(t *testing.T, te environment.Env, ps interfaces.PubSub,
 		ListenAddr:        peer,
 		GroupName:         heartbeatGroupName,
 		ReplicationFactor: replicationFactor,
+		PubSub:            ps,
 	}
-	c, err := NewDistributedCache(te, ps, mc, dcc, te.GetHealthChecker())
+	c, err := NewDistributedCache(te, mc, dcc, te.GetHealthChecker())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -110,6 +110,7 @@ type DistributedCacheConfig struct {
 	RedisTarget       string `yaml:"redis_target" usage:"A redis target for improved Caching/RBE performance. Target can be provided as either a redis connection URI or a host:port pair. URI schemas supported: redis[s]://[[USER][:PASSWORD]@][HOST][:PORT][/DATABASE] or unix://[[USER][:PASSWORD]@]SOCKET_PATH[?db=DATABASE] ** Enterprise only **"`
 	GroupName         string `yaml:"group_name" usage:"A unique name for this distributed cache group. ** Enterprise only **"`
 	ReplicationFactor int    `yaml:"replication_factor" usage:"How many total servers the data should be replicated to. Must be >= 1. ** Enterprise only **"`
+	Nodes             []string `yaml:"nodes" usage:"The hardcoded list of peer distributed cache nodes. If this is set, redis_target will be ignored. ** Enterprise only **"`
 }
 
 type RedisCacheConfig struct {


### PR DESCRIPTION
Allow setting the nodeset manually via config. Remove a healthcheck that could fail when not all nodes were already running; preventing a newly turnt-up cluster from becoming healthy.