### PR TITLE
Start using zerolog for logging

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -42,6 +42,8 @@ type appConfig struct {
 	DefaultToDenseMode      bool   `yaml:"default_to_dense_mode" usage:"Enables the dense UI mode by default."`
 	GRPCMaxRecvMsgSizeBytes int    `yaml:"grpc_max_recv_msg_size_bytes" usage:"Configures the max GRPC receive message size [bytes]"`
 	EnableTargetTracking    bool   `yaml:"enable_target_tracking" usage:"Cloud-Only"`
+	EnableStructuredLogging bool   `yaml:"enable_structured_logging" usage:"If true, log messages will be json-formatted."`
+	LogLevel                string `yaml:"log_level" usage:"The desired log level. Logs with a level >= this level will be emitted. One of {"fatal", "error", "warn", "info", "debug"}`
 }
 
 type buildEventProxy struct {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -363,6 +363,14 @@ func (c *Configurator) GetAppAddUserToDomainGroup() bool {
 	return c.gc.App.AddUserToDomainGroup
 }
 
+func (c *Configurator) GetAppEnableStructuredLogging() bool {
+	return c.gc.App.EnableStructuredLogging
+}
+
+func (c *Configurator) GetAppLogLevel() string {
+	return c.gc.App.LogLevel
+}
+
 func (c *Configurator) GetGRPCOverHTTPPortEnabled() bool {
 	return c.gc.App.GRPCOverHTTPPortEnabled
 }

--- a/server/libmain/BUILD
+++ b/server/libmain/BUILD
@@ -43,6 +43,7 @@ go_library(
         "//server/util/db",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
+        "//server/util/log",
         "//server/util/monitoring",
         "//server/util/rlimit",
         "@com_github_grpc_ecosystem_go_grpc_prometheus//:go-grpc-prometheus",

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
+	"os"
 
 	"github.com/buildbuddy-io/buildbuddy/server/backends/blobstore"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/disk_cache"
@@ -38,6 +38,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
 	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/monitoring"
 	"github.com/buildbuddy-io/buildbuddy/server/util/rlimit"
 
@@ -92,6 +93,10 @@ func init() {
 // not substantially different enough yet to warrant the extra complexity of
 // always updating both main files.
 func GetConfiguredEnvironmentOrDie(configurator *config.Configurator, healthChecker *healthcheck.HealthChecker) *real_environment.RealEnv {
+	if err := log.Configure(configurator.GetAppLogLevel(), configurator.GetAppEnableStructuredLogging()); err != nil {
+		fmt.Printf("Error configuring logging: %s", err)
+		os.Exit(1)
+	}
 	bs, err := blobstore.GetConfiguredBlobstore(configurator)
 	if err != nil {
 		log.Fatalf("Error configuring blobstore: %s", err)
@@ -301,7 +306,7 @@ func StartAndRunServices(env environment.Env) {
 	if sslService.IsEnabled() {
 		creds, err := sslService.GetGRPCSTLSCreds()
 		if err != nil {
-			log.Fatal(err)
+			log.Fatalf("Error getting SSL creds: %s", err)
 		}
 
 		StartGRPCServiceOrDie(env, buildBuddyServer, gRPCSPort, grpc.Creds(creds))
@@ -365,7 +370,7 @@ func StartAndRunServices(env environment.Env) {
 	if sslService.IsEnabled() {
 		tlsConfig, sslHandler := sslService.ConfigureTLS(handler)
 		if err != nil {
-			log.Fatal(err)
+			log.Fatalf("Error configuring TLS: %s", err)
 		}
 		sslServer := &http.Server{
 			Addr:      fmt.Sprintf("%s:%d", *listen, *sslPort),

--- a/server/util/log/BUILD
+++ b/server/util/log/BUILD
@@ -9,6 +9,8 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//server/util/uuid",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_rs_zerolog//:zerolog",
+        "@com_github_rs_zerolog//log",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -124,6 +124,16 @@ func Printf(format string, v ...interface{}) {
 	log.Info().Msgf(format, v...)
 }
 
+// Debug logs to the DEBUG log.
+func Debug(message string) {
+	log.Debug().Msg(message)
+}
+
+// Debugf logs to the DEBUG log. Arguments are handled in the manner of fmt.Printf.
+func Debugf(format string, args ...interface{}) {
+	log.Debug().Msgf(format, args...)
+}
+
 // Info logs to the INFO log.
 func Info(message string) {
 	log.Info().Msg(message)

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -3,13 +3,15 @@ package log
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
+	"os"
 	"path"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/uuid"
 	"github.com/golang/protobuf/proto"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -64,13 +66,76 @@ func LogGRPCRequest(ctx context.Context, fullMethod string, dur time.Duration, e
 	reqID, _ := uuid.GetFromContext(ctx) // Ignore error, we're logging anyway.
 	shortPath := "/" + path.Base(fullMethod)
 	if iid := getInvocationIDFromMD(ctx); iid != "" {
-		log.Printf("%s %s %s %s %s [%s]", "gRPC", reqID, iid, shortPath, fmtErr(err), formatDuration(dur))
+		Printf("%s %s %s %s %s [%s]", "gRPC", reqID, iid, shortPath, fmtErr(err), formatDuration(dur))
 	} else {
-		log.Printf("%s %s %s %s [%s]", "gRPC", reqID, shortPath, fmtErr(err), formatDuration(dur))
+		Printf("%s %s %s %s [%s]", "gRPC", reqID, shortPath, fmtErr(err), formatDuration(dur))
 	}
 }
 
 func LogHTTPRequest(ctx context.Context, url string, dur time.Duration, statusCode int) {
 	reqID, _ := uuid.GetFromContext(ctx) // Ignore error, we're logging anyway.
-	log.Printf("HTTP %s %q %d %s [%s]", reqID, url, statusCode, http.StatusText(statusCode), formatDuration(dur))
+	Printf("HTTP %s %q %d %s [%s]", reqID, url, statusCode, http.StatusText(statusCode), formatDuration(dur))
+}
+
+
+func Configure(level int) {
+	output := zerolog.ConsoleWriter{Out: os.Stdout}
+	// 2021/03/30 15:29:37 gRPC 7c3b8119-aae8-4e8f-9842-15730bd15d00 7080eda9-e50a-4370-b821-5e634d66bb26 /FindMissingBlobs OK [49 us]
+	log.Logger = zerolog.New(output).With().Timestamp().Logger()
+}
+
+// TODO(tylerw): move this to main or libmain?
+func init() {
+	Configure(0)
+}
+
+// Zerolog convenience wrapper here:
+
+func Print(message string) {
+	log.Info().Msg(message)
+}
+func Printf(format string, v ...interface{}) {
+	log.Info().Msgf(format, v...)
+}
+
+// Info logs to the INFO log.
+func Info(message string) {
+	log.Info().Msg(message)
+}
+// Infof logs to the INFO log. Arguments are handled in the manner of fmt.Printf.
+func Infof(format string, args ...interface{}) {
+	log.Info().Msgf(format, args...)
+}
+
+// Warning logs to the WARNING log.
+func Warning(message string) {
+	log.Warn().Msg(message)
+}
+// Warningf logs to the WARNING log. Arguments are handled in the manner of fmt.Printf.
+func Warningf(format string, args ...interface{}) {
+	log.Warn().Msgf(format, args...)
+}
+
+// Error logs to the ERROR log.
+func Error(message string) {
+	log.Error().Msg(message)
+}
+// Errorf logs to the ERROR log. Arguments are handled in the manner of fmt.Printf.
+func Errorf(format string, args ...interface{}) {
+	log.Error().Msgf(format, args...)
+}
+
+// Fatal logs to the FATAL log. Arguments are handled in the manner of fmt.Print.
+// It calls os.Exit() with exit code 1.
+func Fatal(message string) {
+	log.Fatal().Msg(message)
+	// Make sure fatal logs will exit.
+	os.Exit(1)
+}
+// Fatalf logs to the FATAL log. Arguments are handled in the manner of fmt.Printf.
+// It calls os.Exit() with exit code 1.
+func Fatalf(format string, args ...interface{}) {
+	log.Fatal().Msgf(format, args...)
+	// Make sure fatal logs will exit.
+	os.Exit(1)
 }

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -77,18 +77,22 @@ func LogHTTPRequest(ctx context.Context, url string, dur time.Duration, statusCo
 	Printf("HTTP %s %q %d %s [%s]", reqID, url, statusCode, http.StatusText(statusCode), formatDuration(dur))
 }
 
-func ConfigureLogging(level string, enableStructured bool) error {
+func Configure(level string, enableStructured bool) error {
+	fmt.Printf("Configured called: level: %q, enableStructured: %t\n", level, enableStructured)
 	if enableStructured {
 		log.Logger = StructuredLogger()
 	} else {
 		log.Logger = LocalLogger(level)
 	}
-	l, err := zerolog.ParseLevel(level)
-	if err != nil {
-		fmt.Println(err)
-		return err
+	intLogLevel := zerolog.InfoLevel
+	if level != "" {
+		if l, err := zerolog.ParseLevel(level); err == nil {
+			intLogLevel = l
+		} else {
+			return err
+		}
 	}
-	zerolog.SetGlobalLevel(l)
+	zerolog.SetGlobalLevel(intLogLevel)
 	return nil
 }
 
@@ -124,6 +128,7 @@ func Printf(format string, v ...interface{}) {
 func Info(message string) {
 	log.Info().Msg(message)
 }
+
 // Infof logs to the INFO log. Arguments are handled in the manner of fmt.Printf.
 func Infof(format string, args ...interface{}) {
 	log.Info().Msgf(format, args...)
@@ -133,6 +138,7 @@ func Infof(format string, args ...interface{}) {
 func Warning(message string) {
 	log.Warn().Msg(message)
 }
+
 // Warningf logs to the WARNING log. Arguments are handled in the manner of fmt.Printf.
 func Warningf(format string, args ...interface{}) {
 	log.Warn().Msgf(format, args...)
@@ -142,6 +148,7 @@ func Warningf(format string, args ...interface{}) {
 func Error(message string) {
 	log.Error().Msg(message)
 }
+
 // Errorf logs to the ERROR log. Arguments are handled in the manner of fmt.Printf.
 func Errorf(format string, args ...interface{}) {
 	log.Error().Msgf(format, args...)
@@ -154,6 +161,7 @@ func Fatal(message string) {
 	// Make sure fatal logs will exit.
 	os.Exit(1)
 }
+
 // Fatalf logs to the FATAL log. Arguments are handled in the manner of fmt.Printf.
 // It calls os.Exit() with exit code 1.
 func Fatalf(format string, args ...interface{}) {

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -78,7 +78,6 @@ func LogHTTPRequest(ctx context.Context, url string, dur time.Duration, statusCo
 }
 
 func Configure(level string, enableStructured bool) error {
-	fmt.Printf("Configured called: level: %q, enableStructured: %t\n", level, enableStructured)
 	if enableStructured {
 		log.Logger = StructuredLogger()
 	} else {


### PR DESCRIPTION
This CL imports the zerolog library and configures it. It also makes available leveled log convenience functions in util/log -- which I intend to use to replace "log" in all our files in a followup CL.

level is configurable via config file or flag.
structured logging similarly, and should work nicely on GCS.