### PR TITLE
Fix race condition in log library

### DIFF
--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -26,6 +26,8 @@ import (
 )
 
 func init() {
+	// Need to init logging in the main goroutine, otherwise the race detector
+	// will be unhappy. Related: https://github.com/rs/zerolog/issues/242
 	if err := log.Configure("debug", true, false); err != nil {
 		panic(err)
 	}

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -25,6 +25,12 @@ import (
 	rpcfilters "github.com/buildbuddy-io/buildbuddy/server/rpc/filters"
 )
 
+func init() {
+	if err := log.Configure("debug", true, false); err != nil {
+		panic(err)
+	}
+}
+
 type ConfigTemplateParams struct {
 	TestRootDir string
 }
@@ -32,8 +38,6 @@ type ConfigTemplateParams struct {
 const testConfigFileTemplate string = `
 app:
   build_buddy_url: "http://localhost:8080"
-  log_include_short_file_name: true
-  log_level: "debug"
 database:
   data_source: "sqlite3://:memory:"
 storage:
@@ -128,9 +132,6 @@ func GetTestEnv(t testing.TB) *TestEnv {
 	configurator, err := config.NewConfigurator(tmpConfigFile)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if err := log.Configure(configurator.GetAppLogLevel(), configurator.GetAppLogIncludeShortFileName(), configurator.GetAppEnableStructuredLogging()); err != nil {
-		t.Fatalf("Error configuring logging: %s", err)
 	}
 	healthChecker := healthcheck.NewTestingHealthChecker()
 	te := &TestEnv{

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/uuid"
@@ -20,11 +19,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-)
-
-var (
-	logMu     sync.Mutex
-	zerologMu sync.Mutex
 )
 
 func formatDuration(dur time.Duration) string {
@@ -101,9 +95,7 @@ func LocalLogger(level string) zerolog.Logger {
 		// we're not going to have any file names longer than that... right?
 		return fmt.Sprintf("%41s >", filepath.Base(s))
 	}
-	zerologMu.Lock()
 	zerolog.TimeFieldFormat = time.RFC3339Nano
-	zerologMu.Unlock()
 	output.TimeFormat = "2006/01/02 15:04:05.000"
 	// Skipping 3 frames prints the correct source file + line number, rather
 	// than printing a line number in this file or in the zerolog library.
@@ -113,11 +105,9 @@ func LocalLogger(level string) zerolog.Logger {
 func StructuredLogger() zerolog.Logger {
 	// These overrides configure the logger to emit structured
 	// events compatible with GCP's logging infrastructure.
-	zerologMu.Lock()
 	zerolog.LevelFieldName = "severity"
 	zerolog.TimestampFieldName = "timestamp"
 	zerolog.TimeFieldFormat = time.RFC3339Nano
-	zerologMu.Unlock()
 	return log.Logger
 }
 
@@ -136,15 +126,11 @@ func Configure(level string, enableFileName, enableStructured bool) error {
 			return err
 		}
 	}
-	zerologMu.Lock()
 	zerolog.SetGlobalLevel(intLogLevel)
-	zerologMu.Unlock()
 	if enableFileName {
 		logger = logger.With().CallerWithSkipFrameCount(3).Logger()
 	}
-	logMu.Lock()
 	log.Logger = logger
-	logMu.Unlock()
 	return nil
 }
 

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"


### PR DESCRIPTION
The race check fails in `remote_execution_test` because it spins up multiple BB servers which all try to write zerolog / log globals in the same process.

Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/384

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
