### PR TITLE
Small distributed cache performance improvements.

### DIFF
--- a/enterprise/server/util/cacheproxy/BUILD
+++ b/enterprise/server/util/cacheproxy/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//server/environment",
         "//server/interfaces",
+        "//server/util/log",
         "//server/util/prefix",
         "//server/util/status",
         "@org_golang_google_grpc//codes",


### PR DESCRIPTION
Don't log access to distributed cache as frequently. Use pointer to local cache if doing a remote-{read,write,contains} from same node. Disambiguate HTTP handler paths.