### PR TITLE
Update test infra to support RBE auth patterns

### DIFF
--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -93,8 +93,7 @@ func NewTestAuthenticator(testUsers map[string]interfaces.UserInfo) *TestAuthent
 
 func (a *TestAuthenticator) AuthenticateHTTPRequest(w http.ResponseWriter, r *http.Request) context.Context {
 	headerVal := r.Header.Get(TestApiKeyHeader)
-	user, ok := a.testUsers[headerVal]
-	if ok {
+	if user, ok := a.testUsers[headerVal]; ok {
 		return context.WithValue(r.Context(), testAuthenticationHeader, user)
 	}
 	return r.Context()
@@ -105,8 +104,7 @@ func (a *TestAuthenticator) AuthenticateGRPCRequest(ctx context.Context) context
 		for _, h := range []string{TestApiKeyHeader, jwtHeader} {
 			headerVals := grpcMD[h]
 			for _, headerVal := range headerVals {
-				user, ok := a.testUsers[headerVal]
-				if ok {
+				if user, ok := a.testUsers[headerVal]; ok {
 					return context.WithValue(ctx, testAuthenticationHeader, user)
 				}
 			}

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -101,11 +101,7 @@ func (a *TestAuthenticator) AuthenticateHTTPRequest(w http.ResponseWriter, r *ht
 }
 
 func (a *TestAuthenticator) AuthenticateGRPCRequest(ctx context.Context) context.Context {
-	// log.Printf("\033[32m[DEBUG]\033[0m ctx=%+v\n", ctx)
-
 	if grpcMD, ok := metadata.FromIncomingContext(ctx); ok {
-		// log.Printf("\033[32m[DEBUG]\033[0m grpcMD=%+v\n", grpcMD)
-
 		for _, h := range []string{TestApiKeyHeader, jwtHeader} {
 			headerVals := grpcMD[h]
 			for _, headerVal := range headerVals {

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -107,8 +107,7 @@ func (a *TestAuthenticator) AuthenticateGRPCRequest(ctx context.Context) context
 			for _, headerVal := range headerVals {
 				user, ok := a.testUsers[headerVal]
 				if ok {
-					ctx = context.WithValue(ctx, jwtHeader, headerVal)
-					ctx = context.WithValue(ctx, testAuthenticationHeader, user)
+					return context.WithValue(ctx, testAuthenticationHeader, user)
 				}
 			}
 		}

--- a/server/testutil/testenv/BUILD
+++ b/server/testutil/testenv/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//server/rpc/filters",
         "//server/testutil/healthcheck",
         "//server/util/db",
+        "//server/util/grpc_client",
         "//server/util/log",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//test/bufconn",

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -17,6 +17,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/healthcheck"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 
 	"google.golang.org/grpc"
@@ -28,7 +29,7 @@ import (
 func init() {
 	// N.B. We do this here to avoid a data race condition that happens when
 	// multiple tests Configure the logger simultaneously.
-	if err := log.Configure("debug", true /*=logFileName*/, false /*=enableStructuredLogging*/); err != nil {
+	if err := log.Configure("info", true /*=logFileName*/, false /*=enableStructuredLogging*/); err != nil {
 		log.Fatalf("Error configuring logging: %s", err)
 	}
 }
@@ -82,7 +83,10 @@ func (te *TestEnv) LocalGRPCServer() (*grpc.Server, func()) {
 }
 
 func (te *TestEnv) LocalGRPCConn(ctx context.Context) (*grpc.ClientConn, error) {
-	return grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(te.bufDialer), grpc.WithInsecure())
+	dialOptions := grpc_client.CommonGRPCClientOptions()
+	dialOptions = append(dialOptions, grpc.WithContextDialer(te.bufDialer))
+	dialOptions = append(dialOptions, grpc.WithInsecure())
+	return grpc.DialContext(ctx, "bufnet", dialOptions...)
 }
 
 // GRPCServer starts a gRPC server with standard BuildBuddy filters that uses the given listener.

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -29,7 +29,7 @@ import (
 func init() {
 	// N.B. We do this here to avoid a data race condition that happens when
 	// multiple tests Configure the logger simultaneously.
-	if err := log.Configure("info", true /*=logFileName*/, false /*=enableStructuredLogging*/); err != nil {
+	if err := log.Configure("debug", true /*=logFileName*/, false /*=enableStructuredLogging*/); err != nil {
 		log.Fatalf("Error configuring logging: %s", err)
 	}
 }


### PR DESCRIPTION
* Update the test authenticator to get and set `x-buildbuddy-jwt` in the authenticated context, treating the value as just the user ID in the `testUsers` map. This is needed because the execution server directly reads the JWT using the literal string `x-buildbuddy-jwt` and stores it in the execution tasks table.
* Update the test env to use the common RPC filters, so that the x-buildbuddy-jwt in the context is automatically copied to the outgoing GRPC metadata.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
