### PR TITLE
Cache should not use digest to get size of item

### DIFF
--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -260,8 +260,8 @@ func (c *DiskCache) Reader(ctx context.Context, d *repb.Digest, offset int64) (i
 	if err != nil {
 		return nil, err
 	}
-	length := d.GetSizeBytes()
-	r, err := disk.FileReader(ctx, k, offset, length)
+	// Can't specify length because this might be ActionCache
+	r, err := disk.FileReader(ctx, k, offset, 0)
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if err != nil {

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -76,28 +76,8 @@ func FileExists(fullPath string) (bool, error) {
 }
 
 type SectionReaderCloser struct {
-	sectionReader *io.SectionReader
-	closer        io.Closer
-}
-
-func (w *SectionReaderCloser) Read(b []byte) (int, error) {
-	return w.sectionReader.Read(b)
-}
-
-func (w *SectionReaderCloser) ReadAt(b []byte, offset int64) (int, error) {
-	return w.sectionReader.ReadAt(b, offset)
-}
-
-func (w *SectionReaderCloser) Seek(offset int64, whence int) (int64, error) {
-	return w.sectionReader.Seek(offset, whence)
-}
-
-func (w *SectionReaderCloser) Size() int64 {
-	return w.sectionReader.Size()
-}
-
-func (w *SectionReaderCloser) Close() error {
-	return w.closer.Close()
+	*io.SectionReader
+	io.Closer
 }
 
 func FileReader(ctx context.Context, fullPath string, offset, length int64) (*SectionReaderCloser, error) {
@@ -110,9 +90,9 @@ func FileReader(ctx context.Context, fullPath string, offset, length int64) (*Se
 		return nil, err
 	}
 	if length > 0 {
-		return &SectionReaderCloser{sectionReader: io.NewSectionReader(f, offset, length), closer: f}, nil
+		return &SectionReaderCloser{io.NewSectionReader(f, offset, length), f}, nil
 	}
-	return &SectionReaderCloser{sectionReader: io.NewSectionReader(f, offset, info.Size()-offset), closer: f}, nil
+	return &SectionReaderCloser{io.NewSectionReader(f, offset, info.Size()-offset), f}, nil
 }
 
 type writeMover struct {


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

The action cache does not guarantee that the digest will reflect the size of the stored data,
so our cache implementations should not use the digest to determine size.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
