### PR TITLE
Fix bug in streaming uploads that caused us to flood server with empty messages.

### DIFF
--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -98,19 +98,20 @@ func UploadFromReader(ctx context.Context, bsClient bspb.ByteStreamClient, ad *d
 		if err != nil && err != io.EOF {
 			return nil, err
 		}
+		readDone := err == io.EOF
+
 		req := &bspb.WriteRequest{
 			ResourceName: resourceName,
 			WriteOffset:  bytesUploaded,
 			Data:         buf[:n],
-			FinishWrite:  err == io.EOF,
+			FinishWrite:  readDone,
 		}
-		err = stream.Send(req)
-		bytesUploaded += int64(n)
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
+		if err := stream.Send(req); err != nil {
 			return nil, err
+		}
+		bytesUploaded += int64(n)
+		if readDone {
+			break
 		}
 
 	}


### PR DESCRIPTION
We overwrote `err` from the input read with the `err` from the stream
send. At the end of the upload we would spin loop sending empty "finish
upload" requests until the server closed the stream.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
