### PR TITLE
Gracefully shutdown distributed disk HTTP server

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -77,8 +77,7 @@ func NewDistributedCache(env environment.Env, c interfaces.Cache, config CacheCo
 		dc.heartbeatChannel = heartbeat.NewHeartbeatChannel(config.PubSub, heartbeatConfig)
 	}
 	hc.RegisterShutdownFunction(func(ctx context.Context) error {
-		dc.Shutdown()
-		return nil
+		return dc.Shutdown(ctx)
 	})
 	return dc, nil
 }
@@ -93,12 +92,12 @@ func (c *Cache) StartListening() {
 	}()
 }
 
-func (c *Cache) Shutdown() {
+func (c *Cache) Shutdown(ctx context.Context) error {
 	log.Printf("Distributed cache shutting down %q", c.myAddr)
 	if c.heartbeatChannel != nil {
 		c.heartbeatChannel.StopAdvertising()
 	}
-	c.cacheProxy.Server().Close()
+	return c.cacheProxy.Server().Shutdown(ctx)
 }
 
 func (c *Cache) WithPrefix(prefix string) interfaces.Cache {

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -178,7 +178,7 @@ func TestDroppedNode(t *testing.T) {
 		for i := 0; i < testStruct.replicasToFail; i++ {
 			randPeerIdx := rand.Intn(len(peers))
 			randomPeer := peers[randPeerIdx]
-			caches[randomPeer].Shutdown()
+			caches[randomPeer].Shutdown(ctx)
 			delete(caches, randomPeer)
 			peers = append(peers[:randPeerIdx], peers[randPeerIdx+1:]...)
 		}
@@ -206,7 +206,7 @@ func TestDroppedNode(t *testing.T) {
 
 		log.Printf("Shutting down caches")
 		for _, cache := range caches {
-			cache.Shutdown()
+			cache.Shutdown(ctx)
 		}
 
 		waitForNodes([]string{})
@@ -293,7 +293,7 @@ func TestEventualConsistency(t *testing.T) {
 			c := caches[p]
 			delete(caches, p)
 			peers = append(peers[:i], peers[i+1:]...)
-			c.Shutdown()
+			c.Shutdown(ctx)
 			waitForNodes(peers)
 			log.Printf("Finished shutting down %q", p)
 			return p
@@ -370,7 +370,7 @@ func TestEventualConsistency(t *testing.T) {
 
 		// Cleanup.
 		for _, cache := range caches {
-			cache.Shutdown()
+			cache.Shutdown(ctx)
 		}
 		waitForNodes([]string{})
 	}


### PR DESCRIPTION
Use http.Server.Shutdown(ctx) instead of http.Server.Close().