### PR TITLE
Fix bug with MakeTempWorkspace util

### DIFF
--- a/server/testutil/bazel/bazel.go
+++ b/server/testutil/bazel/bazel.go
@@ -97,7 +97,7 @@ func MakeTempWorkspace(t *testing.T, contents map[string]string) string {
 	})
 	for path, fileContents := range contents {
 		fullPath := filepath.Join(workspaceDir, path)
-		if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0777); err != nil {
 			t.Fatal(err)
 		}
 		if err := ioutil.WriteFile(fullPath, []byte(fileContents), 0777); err != nil {


### PR DESCRIPTION
It was using relative paths when `mkdir -p` for the files to be created inside the workspace, which doesn't work because the test CWD is different from the workspace dir. Existing tests aren't affected by this bug because they create all files in the root of the workspace which doesn't require creating any directories.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
