### PR TITLE
Add an API to create subloggers that have the same API as the rest of log calls.

### DIFF
--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -126,7 +126,7 @@ func Configure(level string, enableFileName, enableStructured bool) error {
 			return err
 		}
 	}
-	zerolog.SetGlobalLevel(intLogLevel)
+	logger = logger.Level(intLogLevel)
 	if enableFileName {
 		logger = logger.With().CallerWithSkipFrameCount(3).Logger()
 	}
@@ -134,8 +134,73 @@ func Configure(level string, enableFileName, enableStructured bool) error {
 	return nil
 }
 
-// Zerolog convenience wrapper below here:
+type Logger struct {
+	zl zerolog.Logger
+}
 
+// Debug logs to the DEBUG log.
+func (l *Logger) Debug(message string) {
+	l.zl.Debug().Msg(message)
+}
+
+// Debugf logs to the DEBUG log. Arguments are handled in the manner of fmt.Printf.
+func (l *Logger) Debugf(format string, args ...interface{}) {
+	l.zl.Debug().Msgf(format, args...)
+}
+
+// Info logs to the INFO log.
+func (l *Logger) Info(message string) {
+	l.zl.Info().Msg(message)
+}
+
+// Infof logs to the INFO log. Arguments are handled in the manner of fmt.Printf.
+func (l *Logger) Infof(format string, args ...interface{}) {
+	l.zl.Info().Msgf(format, args...)
+}
+
+// Warning logs to the WARNING log.
+func (l *Logger) Warning(message string) {
+	l.zl.Warn().Msg(message)
+}
+
+// Warningf logs to the WARNING log. Arguments are handled in the manner of fmt.Printf.
+func (l *Logger) Warningf(format string, args ...interface{}) {
+	l.zl.Warn().Msgf(format, args...)
+}
+
+// Error logs to the ERROR log.
+func (l *Logger) Error(message string) {
+	l.zl.Error().Msg(message)
+}
+
+// Errorf logs to the ERROR log. Arguments are handled in the manner of fmt.Printf.
+func (l *Logger) Errorf(format string, args ...interface{}) {
+	l.zl.Error().Msgf(format, args...)
+}
+
+// Fatal logs to the FATAL log. Arguments are handled in the manner of fmt.Print.
+// It calls os.Exit() with exit code 1.
+func (l *Logger) Fatal(message string) {
+	log.Fatal().Msg(message)
+	// Make sure fatal logs will exit.
+	os.Exit(1)
+}
+
+// Fatalf logs to the FATAL log. Arguments are handled in the manner of fmt.Printf.
+// It calls os.Exit() with exit code 1.
+func (l *Logger) Fatalf(format string, args ...interface{}) {
+	log.Fatal().Msgf(format, args...)
+	// Make sure fatal logs will exit.
+	os.Exit(1)
+}
+
+func NamedSubLogger(name string) Logger {
+	return Logger{
+		zl: log.Logger.With().Str("name", name).Logger(),
+	}
+}
+
+// Zerolog convenience wrapper below here:
 // DEPRECATED: use log.Info instead!
 func Print(message string) {
 	log.Info().Msg(message)


### PR DESCRIPTION
Part of addressing buildbuddy-io/buildbuddy-internal#396

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
