### PR TITLE
Enable static file bundling in the OS server

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "nogo")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "nogo")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -13,6 +13,7 @@ nogo(
 # gazelle:exclude node_modules
 # Ignore generated proto files
 # gazelle:exclude **/*.pb.go
+# gazelle:exclude bundle.go
 # Prefer generated BUILD files to be called BUILD over BUILD.bazel
 # gazelle:build_file_name BUILD,BUILD.bazel
 # gazelle:prefix github.com/buildbuddy-io/buildbuddy

--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
-load("@io_bazel_rules_go//go:def.bzl", "nogo")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "nogo")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -60,5 +60,23 @@ package_group(
     name = "enterprise",
     packages = [
         "//enterprise/...",
+    ],
+)
+
+go_library(
+    name = "bundle",
+    srcs = ["bundle.go"],
+    embedsrcs = [
+        # keep
+        "//:VERSION",
+        "//:config_files",
+        "//app:app_bundle",
+        "//app:style.css",
+        "//static",
+    ],
+    importpath = "github.com/buildbuddy-io/buildbuddy/bundle",
+    deps = [
+        "//server/util/log",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/BUILD
+++ b/BUILD
@@ -64,11 +64,13 @@ package_group(
     ],
 )
 
+# N.B. this is ignored by gazelle so must be updated by hand.
+# It must live at the repo root to be able to bundle other files using
+# "go:embed".
 go_library(
     name = "bundle",
     srcs = ["bundle.go"],
     embedsrcs = [
-        # keep
         "//:VERSION",
         "//:config_files",
         "//app:app_bundle",
@@ -78,6 +80,5 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/bundle",
     deps = [
         "//server/util/log",
-        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/buildfix.sh
+++ b/buildfix.sh
@@ -5,11 +5,8 @@ set -e
 echo "Formatting WORKSPACE/BUILD files..."
 buildifier -r .
 
-# go fmt all .go files
 echo "Formatting .go files..."
-tldirs=$(find . -name "*.go" | cut -d"/" -f2 | uniq)
-for dir in $tldirs; do
-    gofmt -w "$dir/";
-done;
+# go fmt all .go files
+gofmt -w .
 
 echo "All Done!"

--- a/bundle.go
+++ b/bundle.go
@@ -9,8 +9,9 @@ import (
 )
 
 // NB: We cannot embed "static", "bazel-out", etc here, because when this
-// package is build as dependency of the enterprise package, those files
-// do not exist. Instead we bundle *, which never fails.
+// package is built as dependency of the enterprise package, those files
+// do not exist. Instead we bundle *, which never fails, although the
+// resulting filesystem may be empty.
 //
 //go:embed *
 var all embed.FS

--- a/bundle.go
+++ b/bundle.go
@@ -1,0 +1,71 @@
+package bundle
+
+import (
+	"embed"
+	"io/fs"
+	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+)
+
+// NB: We cannot embed "static", "bazel-out", etc here, because when this
+// package is build as dependency of the enterprise package, those files
+// do not exist. Instead we bundle *, which never fails.
+//
+//go:embed *
+var all embed.FS
+
+type aliasFS struct {
+	embed.FS
+	remappedPaths map[string]string
+}
+
+func (a *aliasFS) Open(name string) (fs.File, error) {
+	fileAlias, ok := a.remappedPaths[name]
+	if ok {
+		return a.FS.Open(fileAlias)
+	}
+	return a.FS.Open(name)
+}
+
+func Get() (fs.FS, error) {
+	afs := &aliasFS{
+		FS:            all,
+		remappedPaths: make(map[string]string, 0),
+	}
+	// This is annoying but necesary -- we bundle some binary files that
+	// end up in a bazel-out/$arch/bin directory. Rather than try to read
+	// them by their full name, which is $arch dependent, we glob them
+	// and alias them under a path that does not contain the $arch
+	// component. This path also matches what is present in the os.FS,
+	// so callsites that read these files do not need to change at all.
+	pathsToAlias := []string{
+		"bazel-out/*/bin",
+	}
+	for _, p := range pathsToAlias {
+		matches, err := fs.Glob(all, p)
+		if err != nil {
+			return nil, err
+		}
+		for _, match := range matches {
+			fs.WalkDir(all, match, func(path string, d fs.DirEntry, err error) error {
+				if path == match {
+					return nil
+				}
+				// This basically takes a path like:
+				//   'bazel-out/k8-fastbuild/bin/app/app_bundle.js'
+				// and aliases it under the new name:
+				//   'bin/app/app_bundle.js'
+				// complaining if anything was already aliased there.
+				unaliasedPath := strings.TrimPrefix(path, match+"/")
+				if _, ok := afs.remappedPaths[unaliasedPath]; ok {
+					log.Warningf("Named collision in bundled files: %q => %q", path, unaliasedPath)
+					return nil
+				}
+				afs.remappedPaths[unaliasedPath] = path
+				return nil
+			})
+		}
+	}
+	return afs, nil
+}

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -118,7 +118,7 @@ func (c *Cache) readPeers(d *repb.Digest) []string {
 	ordered := c.peers(d)
 	reordered := make([]string, 0, len(ordered))
 
-	for i := len(ordered)-1; i >= 0; i-- {
+	for i := len(ordered) - 1; i >= 0; i-- {
 		p := ordered[i]
 		if p == c.config.ListenAddr {
 			reordered = append(reordered, p)

--- a/server/cmd/buildbuddy/BUILD
+++ b/server/cmd/buildbuddy/BUILD
@@ -9,6 +9,8 @@ go_binary(
     args = [
         "--config_file=config/buildbuddy.local.yaml",
         "--max_shutdown_duration=3s",
+        "--static_directory=/static",
+        "--app_directory=/app",
     ],
     data = [
         "//:config_files",

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -1,6 +1,8 @@
 package environment
 
 import (
+	"io/fs"
+
 	"github.com/go-redis/redis/v8"
 
 	"github.com/buildbuddy-io/buildbuddy/server/config"
@@ -34,6 +36,8 @@ type Env interface {
 	// Optional dependencies below here. For example: enterprise-only things,
 	// or services that may not always be configured, like webhooks.
 	GetDBHandle() *db.DBHandle
+	GetStaticFilesystem() fs.FS
+	GetAppFilesystem() fs.FS
 	GetBlobstore() interfaces.Blobstore
 	GetInvocationDB() interfaces.InvocationDB
 	GetHealthChecker() interfaces.HealthChecker

--- a/server/libmain/BUILD
+++ b/server/libmain/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/libmain",
     visibility = ["//visibility:public"],
     deps = [
+        "//:bundle",
         "//proto:buildbuddy_service_go_proto",
         "//proto:publish_build_event_go_proto",
         "//proto:remote_asset_go_proto",

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -67,8 +67,8 @@ var (
 	gRPCSPort      = flag.Int("grpcs_port", 1986, "The port to listen for gRPCS traffic on")
 	monitoringPort = flag.Int("monitoring_port", 9090, "The port to listen for monitoring traffic on")
 
-	staticDirectory = flag.String("static_directory", "/static", "the directory containing static files to host")
-	appDirectory    = flag.String("app_directory", "/app", "the directory containing app binary files to host")
+	staticDirectory = flag.String("static_directory", "", "the directory containing static files to host")
+	appDirectory    = flag.String("app_directory", "", "the directory containing app binary files to host")
 
 	// URL path prefixes that should be handled by serving the app's HTML.
 	appRoutes = []string{

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -115,6 +115,7 @@ func configureFilesystemsOrDie(realEnv *real_environment.RealEnv) {
 			if err != nil {
 				log.Fatalf("Error getting static FS from bundle: %s", err)
 			}
+			log.Debug("Using bundled static filesystem.")
 			realEnv.SetStaticFilesystem(staticFS)
 		}
 		if realEnv.GetAppFilesystem() == nil {
@@ -122,6 +123,7 @@ func configureFilesystemsOrDie(realEnv *real_environment.RealEnv) {
 			if err != nil {
 				log.Fatalf("Error getting app FS from bundle: %s", err)
 			}
+			log.Debug("Using bundled app filesystem.")
 			realEnv.SetAppFilesystem(appFS)
 		}
 	}

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -1,6 +1,7 @@
 package real_environment
 
 import (
+	"io/fs"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -37,6 +38,8 @@ type RealEnv struct {
 	healthChecker interfaces.HealthChecker
 
 	dbHandle                         *db.DBHandle
+	staticFilesystem                fs.FS
+	appFilesystem                   fs.FS
 	blobstore                        interfaces.Blobstore
 	invocationDB                     interfaces.InvocationDB
 	authenticator                    interfaces.Authenticator
@@ -92,6 +95,20 @@ func (r *RealEnv) SetDBHandle(h *db.DBHandle) {
 }
 func (r *RealEnv) GetDBHandle() *db.DBHandle {
 	return r.dbHandle
+}
+
+func (r *RealEnv) SetStaticFilesystem(staticFS fs.FS) {
+	r.staticFilesystem = staticFS
+}
+func (r *RealEnv) GetStaticFilesystem() fs.FS {
+	return r.staticFilesystem
+}
+
+func (r *RealEnv) SetAppFilesystem(staticFS fs.FS) {
+	r.appFilesystem = staticFS
+}
+func (r *RealEnv) GetAppFilesystem() fs.FS {
+	return r.appFilesystem
 }
 
 func (r *RealEnv) GetBlobstore() interfaces.Blobstore {

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -38,8 +38,8 @@ type RealEnv struct {
 	healthChecker interfaces.HealthChecker
 
 	dbHandle                         *db.DBHandle
-	staticFilesystem                fs.FS
-	appFilesystem                   fs.FS
+	staticFilesystem                 fs.FS
+	appFilesystem                    fs.FS
 	blobstore                        interfaces.Blobstore
 	invocationDB                     interfaces.InvocationDB
 	authenticator                    interfaces.Authenticator

--- a/server/static/BUILD
+++ b/server/static/BUILD
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//proto:config_go_proto",
         "//server/environment",
-        "//server/util/log",
         "//server/version",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],

--- a/server/static/BUILD
+++ b/server/static/BUILD
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/static",
     visibility = ["//visibility:public"],
     deps = [
-        "//:bundle",
         "//proto:config_go_proto",
         "//server/environment",
         "//server/util/log",

--- a/server/static/BUILD
+++ b/server/static/BUILD
@@ -9,8 +9,10 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/static",
     visibility = ["//visibility:public"],
     deps = [
+        "//:bundle",
         "//proto:config_go_proto",
         "//server/environment",
+        "//server/util/log",
         "//server/version",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
-	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/version"
 
 	cfgpb "github.com/buildbuddy-io/buildbuddy/proto/config"
@@ -26,27 +25,12 @@ var (
 	disableGA        = flag.Bool("disable_ga", false, "If true; ga will be disabled")
 )
 
-func enumerate(efs fs.FS) {
-	matches, err := fs.Glob(efs, "*")
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	log.Printf("efs contained %d matches: %s", len(matches), matches)
-	for _, m := range matches {
-		fs.WalkDir(efs, m, func(path string, d fs.DirEntry, err error) error {
-			log.Printf("path: %s", path)
-			return nil
-		})
-	}
-}
-
 func FSFromRelPath(relPath string) (fs.FS, error) {
 	// Figure out where our runfiles (static content bundled with the binary) live.
 	rfp, err := bazel.RunfilesPath()
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("relpath is: %q", rfp)
 	dirFS := os.DirFS(filepath.Join(rfp, relPath))
 	return dirFS, nil
 }

--- a/server/version/version.go
+++ b/server/version/version.go
@@ -16,7 +16,7 @@ const (
 	versionFilename = "VERSION"
 )
 
-// This is set by x_defs the BUILD file.
+// This is set by x_defs in the BUILD file.
 //    x_defs = {
 //        "commitSha": "{COMMIT_SHA}",
 //    },


### PR DESCRIPTION
When static file paths are set to empty string, enable serving files out of the bundle.