### PR TITLE
Use gRPC for cacheproxy.

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -82,7 +82,7 @@ func (c *Cache) StartListening() {
 		if c.heartbeatChannel != nil {
 			c.heartbeatChannel.StartAdvertising()
 		}
-		c.cacheProxy.Server().ListenAndServe()
+		c.cacheProxy.StartListening()
 	}()
 }
 
@@ -91,7 +91,7 @@ func (c *Cache) Shutdown(ctx context.Context) error {
 	if c.heartbeatChannel != nil {
 		c.heartbeatChannel.StopAdvertising()
 	}
-	return c.cacheProxy.Server().Shutdown(ctx)
+	return c.cacheProxy.Shutdown(ctx)
 }
 
 func (c *Cache) WithPrefix(prefix string) interfaces.Cache {

--- a/enterprise/server/util/cacheproxy/BUILD
+++ b/enterprise/server/util/cacheproxy/BUILD
@@ -9,27 +9,22 @@ go_library(
         "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
+        "//proto:distributed_cache_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/environment",
         "//server/interfaces",
+        "//server/util/grpc_client",
+        "//server/util/grpc_server",
         "//server/util/log",
         "//server/util/prefix",
-        "//server/util/status",
-        "@org_golang_google_grpc//codes",
-        "@org_golang_google_grpc//status",
-        "@org_golang_x_net//http2",
-        "@org_golang_x_net//http2/h2c",
-        "@org_golang_x_sync//errgroup",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//reflection",
     ],
 )
 
 go_test(
     name = "cacheproxy_test",
     srcs = ["cacheproxy_test.go"],
-    visibility = [
-        "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
-    ],
     deps = [
         ":cacheproxy",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -206,7 +206,6 @@ func (c *CacheProxy) Write(stream dcpb.DistributedCache_WriteServer) error {
 		}
 		n, err := writeCloser.Write(req.Data)
 		if err != nil {
-			log.Printf("Error writing data?")
 			return err
 		}
 		bytesWritten += int64(n)

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	jwtHeader          = "x-buildbuddy-jwt"
-	maxDialTimeout     = 10 * time.Second
+	jwtHeader      = "x-buildbuddy-jwt"
+	maxDialTimeout = 10 * time.Second
 )
 
 type CacheProxy struct {

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -23,7 +23,6 @@ import (
 const (
 	jwtHeader          = "x-buildbuddy-jwt"
 	maxDialTimeout     = 10 * time.Second
-	uploadBufSizeBytes = 1000000 // 1MB
 )
 
 type CacheProxy struct {

--- a/enterprise/server/util/cacheproxy/cacheproxy_test.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy_test.go
@@ -77,9 +77,9 @@ func TestReader(t *testing.T) {
 
 	peer := fmt.Sprintf("localhost:%d", app.FreePort(t))
 	c := cacheproxy.NewCacheProxy(te, te.GetCache(), peer)
-	go func() {
-		c.Server().ListenAndServe()
-	}()
+	if err := c.StartListening(); err != nil {
+		t.Fatalf("Error setting up cacheproxy: %s", err)
+	}
 	waitUntilServerIsAlive(peer)
 
 	randomSrc := &randomDataMaker{rand.NewSource(time.Now().Unix())}
@@ -109,7 +109,7 @@ func TestReader(t *testing.T) {
 		}
 
 		// Remote-read the random bytes back.
-		r, err := c.RemoteReader(ctx, peer, prefix, d, 0 /*=offset*/)
+		r, err := c.RemoteReader(ctx, peer, prefix, d, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -132,9 +132,10 @@ func TestWriter(t *testing.T) {
 
 	peer := fmt.Sprintf("localhost:%d", app.FreePort(t))
 	c := cacheproxy.NewCacheProxy(te, te.GetCache(), peer)
-	go func() {
-		c.Server().ListenAndServe()
-	}()
+	if err := c.StartListening(); err != nil {
+		t.Fatalf("Error setting up cacheproxy: %s", err)
+	}
+
 	waitUntilServerIsAlive(peer)
 
 	randomSrc := &randomDataMaker{rand.NewSource(time.Now().Unix())}
@@ -144,7 +145,6 @@ func TestWriter(t *testing.T) {
 
 	for _, testSize := range testSizes {
 		prefix := fmt.Sprintf("prefix/%d", testSize)
-		prefix = ""
 
 		// Read some random bytes.
 		buf := new(bytes.Buffer)
@@ -173,7 +173,7 @@ func TestWriter(t *testing.T) {
 
 		// Read the bytes back directly from the cache and check that
 		// they match..
-		r, err := te.GetCache().WithPrefix(prefix).Reader(ctx, d, 0 /*=offset*/)
+		r, err := te.GetCache().WithPrefix(prefix).Reader(ctx, d, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -196,9 +196,9 @@ func TestContains(t *testing.T) {
 
 	peer := fmt.Sprintf("localhost:%d", app.FreePort(t))
 	c := cacheproxy.NewCacheProxy(te, te.GetCache(), peer)
-	go func() {
-		c.Server().ListenAndServe()
-	}()
+	if err := c.StartListening(); err != nil {
+		t.Fatalf("Error setting up cacheproxy: %s", err)
+	}
 	waitUntilServerIsAlive(peer)
 
 	randomSrc := &randomDataMaker{rand.NewSource(time.Now().Unix())}
@@ -264,9 +264,10 @@ func TestOversizeBlobs(t *testing.T) {
 
 	peer := fmt.Sprintf("localhost:%d", app.FreePort(t))
 	c := cacheproxy.NewCacheProxy(te, te.GetCache(), peer)
-	go func() {
-		c.Server().ListenAndServe()
-	}()
+	if err := c.StartListening(); err != nil {
+		t.Fatalf("Error setting up cacheproxy: %s", err)
+	}
+
 	waitUntilServerIsAlive(peer)
 
 	randomSrc := &randomDataMaker{rand.NewSource(time.Now().Unix())}
@@ -336,11 +337,11 @@ func TestContainsMulti(t *testing.T) {
 		t.Errorf("error attaching user prefix: %v", err)
 	}
 
-	peer := fmt.Sprintf("localhost:%d", app.FreePort(t))
+	peer := net.JoinHostPort("localhost", fmt.Sprintf("%d", app.FreePort(t)))
 	c := cacheproxy.NewCacheProxy(te, te.GetCache(), peer)
-	go func() {
-		c.Server().ListenAndServe()
-	}()
+	if err := c.StartListening(); err != nil {
+		t.Fatalf("Error starting cache proxy: %s", err)
+	}
 	waitUntilServerIsAlive(peer)
 
 	randomSrc := &randomDataMaker{rand.NewSource(time.Now().Unix())}
@@ -397,9 +398,9 @@ func TestGetMulti(t *testing.T) {
 
 	peer := fmt.Sprintf("localhost:%d", app.FreePort(t))
 	c := cacheproxy.NewCacheProxy(te, te.GetCache(), peer)
-	go func() {
-		c.Server().ListenAndServe()
-	}()
+	if err := c.StartListening(); err != nil {
+		t.Fatalf("Error setting up cacheproxy: %s", err)
+	}
 	waitUntilServerIsAlive(peer)
 
 	randomSrc := &randomDataMaker{rand.NewSource(time.Now().Unix())}

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -57,6 +57,13 @@ proto_library(
 )
 
 proto_library(
+    name = "distributed_cache_proto",
+    srcs = [
+        "distributed_cache.proto",
+    ],
+)
+
+proto_library(
     name = "execution_stats_proto",
     srcs = [
         "execution_stats.proto",
@@ -451,6 +458,14 @@ go_proto_library(
         ":api_key_go_proto",
         ":context_go_proto",
     ],
+)
+
+go_proto_library(
+    name = "distributed_cache_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/distributed_cache",
+    proto = ":distributed_cache_proto",
+    deps = [],
 )
 
 go_proto_library(

--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -1,0 +1,63 @@
+syntax = "proto3";
+
+package distributed_cache;
+
+message Key {
+  string key = 1;
+  int64 size_bytes = 2;
+}
+
+message ReadRequest {
+  string prefix = 1;
+  Key key = 2;
+  int64 offset = 3;
+}
+
+message ReadResponse {
+  bytes data = 1;
+}
+
+message WriteRequest {
+  string prefix = 1;
+  Key key = 2;
+  bool finish_write = 3;
+  bytes data = 4;
+}
+
+message WriteResponse {
+  int64 committed_size = 1;
+}
+
+message ContainsMultiRequest {
+  string prefix = 1;
+  repeated Key key = 2;
+}
+
+message ContainsMultiResponse {
+  message KeysFound {
+    Key key = 1;
+    bool exists = 2;
+  }
+  repeated KeysFound keys_found = 1;
+}
+
+message KV {
+  Key key = 1;
+  bytes value = 2;
+}
+
+message GetMultiRequest {
+  string prefix = 1;
+  repeated Key key = 2;
+}
+
+message GetMultiResponse {
+  repeated KV key_value = 1;
+}
+
+service DistributedCache {
+  rpc Read(ReadRequest) returns (stream ReadResponse);
+  rpc Write(stream WriteRequest) returns (WriteResponse);
+  rpc ContainsMulti(ContainsMultiRequest) returns (ContainsMultiResponse);
+  rpc GetMulti(GetMultiRequest) returns (GetMultiResponse);
+}


### PR DESCRIPTION
Redid the cacheproxy code with gRPC. It ended up being clearer, less code, and faster. This also enables us to hook into prometheus metrics + jwt forwarding for 'free'.

DDisk performance numbers before and after:

GRPC
BenchmarkSet/DDisk10-12      	    4065	    321699 ns/op	   0.03 MB/s	   14683 B/op	     284 allocs/op
BenchmarkSet/DDisk100-12     	    4015	    330311 ns/op	   0.30 MB/s	   14908 B/op	     284 allocs/op
BenchmarkSet/DDisk1000-12    	    4080	    330088 ns/op	   3.03 MB/s	   17790 B/op	     284 allocs/op
BenchmarkSet/DDisk10000-12   	    3400	    365825 ns/op	  27.34 MB/s	   45561 B/op	     284 allocs/op
BenchmarkGet/DDisk10-12      	    5481	    217092 ns/op	   0.05 MB/s	   45386 B/op	     243 allocs/op
BenchmarkGet/DDisk100-12     	    5373	    219005 ns/op	   0.46 MB/s	   45683 B/op	     243 allocs/op
BenchmarkGet/DDisk1000-12    	    5414	    222137 ns/op	   4.50 MB/s	   49476 B/op	     244 allocs/op
BenchmarkGet/DDisk10000-12   	    4179	    281699 ns/op	  35.50 MB/s	  124430 B/op	     253 allocs/op
BenchmarkGetMulti/DDisk10-12 	    		1286	    918341 ns/op	   1.09 MB/s	  282953 B/op	    2495 allocs/op
BenchmarkGetMulti/DDisk100-12         	    1239	    951678 ns/op	  10.51 MB/s	  314910 B/op	    2504 allocs/op
BenchmarkGetMulti/DDisk1000-12        	    1052	   1138146 ns/op	  87.86 MB/s	  667778 B/op	    2513 allocs/op
BenchmarkGetMulti/DDisk10000-12       	     451	   2498940 ns/op	 400.17 MB/s	 4372089 B/op	    2567 allocs/op
BenchmarkContainsMulti/DDisk10-12     	    1504	    789757 ns/op	  165617 B/op	    1892 allocs/op
BenchmarkContainsMulti/DDisk100-12    	    1471	    787776 ns/op	  165705 B/op	    1892 allocs/op
BenchmarkContainsMulti/DDisk1000-12   	    1434	    787321 ns/op	  165697 B/op	    1892 allocs/op
BenchmarkContainsMulti/DDisk10000-12  	    1446	    786720 ns/op	  165545 B/op	    1892 allocs/op

HTTP
BenchmarkSet/DDisk10-12      	    3710	    342730 ns/op	   0.03 MB/s	   46941 B/op	     177 allocs/op
BenchmarkSet/DDisk100-12     	    3974	    343267 ns/op	   0.29 MB/s	   46944 B/op	     177 allocs/op
BenchmarkSet/DDisk1000-12    	    3772	    341795 ns/op	   2.93 MB/s	   46925 B/op	     177 allocs/op
BenchmarkSet/DDisk10000-12   	    3808	    354726 ns/op	  28.19 MB/s	   62281 B/op	     177 allocs/op
BenchmarkGet/DDisk10-12      	    6234	    193029 ns/op	   0.05 MB/s	   44513 B/op	     136 allocs/op
BenchmarkGet/DDisk100-12     	    6044	    194064 ns/op	   0.52 MB/s	   44501 B/op	     138 allocs/op
BenchmarkGet/DDisk1000-12    	    5811	    197119 ns/op	   5.07 MB/s	   45569 B/op	     139 allocs/op
BenchmarkGet/DDisk10000-12   	    4160	    277453 ns/op	  36.04 MB/s	  107944 B/op	     151 allocs/op
BenchmarkGetMulti/DDisk10-12 	     		 650	   1850832 ns/op	   0.54 MB/s	  560784 B/op	    4601 allocs/op
BenchmarkGetMulti/DDisk100-12         	     614	   1886650 ns/op	   5.30 MB/s	  572049 B/op	    4612 allocs/op
BenchmarkGetMulti/DDisk1000-12        	     471	   2507928 ns/op	  39.87 MB/s	  771779 B/op	    4865 allocs/op
BenchmarkGetMulti/DDisk10000-12       	     138	   8575609 ns/op	 116.61 MB/s	 4658740 B/op	    5725 allocs/op
BenchmarkContainsMulti/DDisk10-12     	     952	   1259216 ns/op	  291984 B/op	    1591 allocs/op
BenchmarkContainsMulti/DDisk100-12    	     934	   1251364 ns/op	  292055 B/op	    1591 allocs/op
BenchmarkContainsMulti/DDisk1000-12   	     940	   1248650 ns/op	  294083 B/op	    1691 allocs/op
BenchmarkContainsMulti/DDisk10000-12  	     949	   1228154 ns/op	  294092 B/op	    1691 allocs/op
