### PR TITLE
First pass at migrating buildbuddy blog to GitHub

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,8 +22,16 @@ jobs:
           cd website
           yarn install && yarn build
 
-      - name: Deploy 🚀
+      - name: Deploy Docs 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.0
         with:
           branch: gh-pages
           folder: website/build
+      
+      - name: Deploy Blog 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.0
+        with:
+          branch: main
+          folder: website/build
+          repository-name: buildbuddy-io/buildbuddy-blog
+          token: ${{ BUILDBUDDY_APP_TOKEN }}

--- a/website/blog/buildbuddy-joins-y-combinator.md
+++ b/website/blog/buildbuddy-joins-y-combinator.md
@@ -1,0 +1,28 @@
+---
+slug: buildbuddy-joins-y-combinator
+title: BuildBuddy joins Y Combinator
+author: Siggi Simonarson
+author_title: BuildBuddy Co-founder
+date: 2020-03-16:12:00:00
+author_url: https://www.linkedin.com/in/siggisim/
+author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
+tags: [company]
+---
+
+If you've hung out around developers for any extended period --- you've probably heard "my code is compiling" as an excuse from them when they're slacking off and browsing Hacker News.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5eed4e21d97fc3603e86efdc_1*J-1MC3QGbIuwq4tb-yr-iA.png)
+
+"Compiling" via [XKCD](https://xkcd.com/303/)
+
+Slow, flaky builds waste hours of developer time --- leading to slow dev refresh cycles and unhappy, unproductive engineers. This is the problem we're solving at BuildBuddy.
+
+[BuildBuddy](http://buildbuddy.io/) is a managed [Bazel](https://bazel.build/) build system. It brings a Google-style development environment and 10x faster builds to any company.
+
+We're excited to share that we've been accepted into [Y Combinator](https://www.ycombinator.com/) and have been participating in their Winter 2020 batch. Here's a photo from our first batch dinner where the founders of Airbnb (YC Winter 2009) told us stories about their YC experience:
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5eed4e212a1f37493d85f9ee_1*ktcdbtOw6h_-hxMmR2VU2g.jpeg)
+
+Airbnb founders speak at our first batch dinner via [Gustaf Alstromer](https://twitter.com/gustaf/status/1215039947356270594)
+
+We're excited to share more about BuildBuddy in the coming months. If you intrigued and want to learn more --- feel free to shoot us an email at <hello@buildbuddy.io>.

--- a/website/blog/buildbuddy-v1-0-6-release-notes.md
+++ b/website/blog/buildbuddy-v1-0-6-release-notes.md
@@ -1,0 +1,53 @@
+---
+slug: buildbuddy-v1-0-6-release-notes
+title: BuildBuddy v1.0.6 Release Notes
+author: Siggi Simonarson
+author_title: BuildBuddy Co-founder
+date: 2020-05-20:12:00:00
+author_url: https://www.linkedin.com/in/siggisim/
+author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
+tags: [product, release-notes]
+---
+
+Excited to share that v1.0.6 of BuildBuddy is live on both [Cloud Hosted BuildBuddy](https://app.buildbuddy.io/) and open source via [Github](https://github.com/buildbuddy-io/buildbuddy) and [Docker](https://github.com/buildbuddy-io/buildbuddy/blob/master/SETUP.md#docker-image)!
+
+Thanks to all of you that have been using open source and cloud-hosted BuildBuddy. We've made lots of improvements in this release based on your feedback.
+
+A special thank you to our new contributors:
+
+-   [Roger Hu](https://github.com/rogerhu) who contributed [Amazon S3 storage support](https://github.com/buildbuddy-io/buildbuddy/commit/8ba12398e448b457cdbd1e0c8913e9aba46323cb).
+-   [Andrew Allen](https://github.com/achew22) who [updated BuildBuddy's open source repo](https://github.com/buildbuddy-io/buildbuddy/commit/59bee5228c7c3da9d0cdaba934fce2118e7e9adc) to conform to open source golang expectations.
+
+Our three major focuses for this release were on a better test results view, certificate based authentication, and our new results-store API.
+
+We also laid a lot of groundwork for remote build execution in this release, which will be available in the coming weeks.
+
+New to Open Source BuildBuddy
+-----------------------------
+
+-   **Test results view** - we've added support for parsing test.xml files that are uploaded to a BuildBuddy remote cache. This allows us to show information about individual test cases and quickly surface information on which test cases failed and why.
+
+-   **Large log file support** - we've improved BuildBuddy's log viewer to enable the rendering of 100MB+ log files with full ANSI color support in milliseconds using incremental rendering.
+
+-   **Timing controls** - BuildBuddy's timing tab now has improved controls that enable users to choose grouping and page size options. This allows you to easily see the slowest build phases across threads.
+
+-   **gRPCS support** - BuildBuddy now supports and defaults to encrypted gRPCS connections to Bazel using TLS. Support includes automatic obtaining of server-side TLS certificates using [ACME](https://en.wikipedia.org/wiki/Automated_Certificate_Management_Environment) and [Let's Encrypt](https://letsencrypt.org/). This also includes the ability to connect to remote caches over gRPCS via the bytestream API.
+-   **URL secret redaction** - we've updated our log scrubbing logic to redact any URLs that might contain secrets from uploaded build events.
+
+Our open source BuildBuddy distribution is targeted at individuals viewing and debugging their Bazel builds. For teams and organizations, we provide an enterprise version of BuildBuddy that adds support for team-specific features.
+
+Many of these Enterprise features are also available for free to individuals via [Cloud Hosted BuildBuddy](https://app.buildbuddy.io/).
+
+‍
+
+New to Cloud & Enterprise BuildBuddy
+------------------------------------
+
+-   **Certificate based auth** - authentication between Bazel and BuildBuddy can now be authenticated and encrypted using certificate-based [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication).
+-   **Auth configuration widget** - using BuildBuddy's new configuration widget, it's easy to setup an auth configuration that makes sense for your team. This includes options to pull credentials into user-specific .bazelrc files and download generated auth certificates.
+
+-   **Build Results API** - many teams want to do more with their build results. With BuildBuddy's [Build Results API](https://github.com/buildbuddy-io/buildbuddy/blob/master/proto/api/v1/service.proto) - users have programmatic access to an invocation's targets, actions, and build artifacts. This allows teams to build out custom integrations with their existing tooling. If you'd like access to the API, or have more information you'd like exposed, email [developers@buildbuddy.io](https://buildbuddy.io/blog/buildbuddy-v1-0-6-release-notes/developers@buildbuddy.io).
+
+That's it for this release. Stay tuned for more updates coming soon!
+
+As always, we love your feedback - email us at <hello@buildbuddy.io> with any questions, comments, or thoughts.

--- a/website/blog/buildbuddy-v1-1-0-release-notes.md
+++ b/website/blog/buildbuddy-v1-1-0-release-notes.md
@@ -1,0 +1,64 @@
+---
+slug: buildbuddy-v1-2-1-release-notes
+title: BuildBuddy v1.2.1 Release Notes
+author: Siggi Simonarson
+author_title: BuildBuddy Co-founder
+date: 2020-07-15:12:00:00
+author_url: https://www.linkedin.com/in/siggisim/
+author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
+tags: [product, release-notes, team]
+---
+
+Excited to share that v1.2.1 of BuildBuddy is live on both [Cloud Hosted BuildBuddy](https://app.buildbuddy.io/) and open source via [Github](https://github.com/buildbuddy-io/buildbuddy) and [Docker](https://github.com/buildbuddy-io/buildbuddy/blob/master/docs/on-prem.md#docker-image)!
+
+Thanks to everyone that has tested open source and cloud-hosted BuildBuddy. We've made lots of improvements in this release based on your feedback.
+
+A special welcome to our newest contributor and **team member**:
+
+-   [Brandon Duffany](https://github.com/bduffany) - Brandon is an ex-Googler and Cornell alumn who's worked as a software engineer on Google Assistant and Google Ads. He'll start off focused on surfacing better profiling and timing information to help users track down and fix slow builds!
+
+Our focus for this release was on expanding access to BuildBuddy as well as improving scalability and performance. 
+
+We're also excited to announce that we're expanding the BuildBuddy Cloud free tier. BuildBuddy Cloud is now **free for teams of up to 3 engineers** in addition to being free for individuals open source projects of any size.
+
+**New to Open Source BuildBuddy**
+---------------------------------
+
+-   **Official BuildBuddy Helm charts** - thanks to a [request](https://github.com/buildbuddy-io/buildbuddy/issues/35) from [Nathan Leung](https://github.com/nathanhleung) we've created official [BuildBuddy Helm Charts](https://github.com/buildbuddy-io/buildbuddy-helm) that are available for both [Open Source](https://github.com/buildbuddy-io/buildbuddy-helm/tree/master/charts/buildbuddy) and [Enterprise](https://github.com/buildbuddy-io/buildbuddy-helm/tree/master/charts/buildbuddy-enterprise) deployments. [Helm](https://helm.sh/) enables you to deploy BuildBuddy to a Kubernetes cluster with a single command, and makes configuration a breeze. The charts can optionally take care of provisioning a MySQL instance, an Nginx ingress, and even Memcached.**‍**
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f5044fa08c11ed1be6b7ddb_Screen%20Shot%202020-09-02%20at%206.19.37%20PM.png)
+
+-   **Build metadata** - a frequent request from users is the ability to associate a BuildBuddy invocation with a particular git commit and repo. To support this, we've added optional build metadata including repo URL, commit SHA, and CI role that can be passed up with your build. This metadata can be passed up using the **--build_metadata** flag, using a **--workspace_status_command** script, or using environment variables commonly set by CI providers like CircleCI, BuildKite, GitHub Actions, and others. More information on how to configure your metadata can be found in our [build metadata guide.](https://www.buildbuddy.io/docs/guide-metadata)
+
+-   **GitHub commit status publishing** - now that you can configure build metadata to associate invocations with a GitHub repo and commit, we've added the ability to publish commit statuses straight to GitHub when you've set your metadata role to **CI**. To enable this feature, simply click **Link GitHub Account** in your BuildBuddy profile dropdown (if you're using self hosted BuildBuddy, you'll need to [create a Github OAuth app](https://www.buildbuddy.io/docs/config-github) and add it to your config.yaml file).
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f5044c5bc9cf35e30ca6fb2_Screen%20Shot%202020-09-02%20at%206.19.15%20PM.png)
+
+BuildBuddy links directly on GitHub
+
+-   **Improved cache hit rate** - we've made improvement to our Action Cache validation logic that should result in higher cache hit rates.
+
+-   **New guides** - we've added new guides to our documentation, including our [Authentication Guide](https://www.buildbuddy.io/docs/guide-auth), [Build Metadata Guide](https://www.buildbuddy.io/docs/guide-metadata), [Remote Build Execution with Github Actions Guide](https://www.buildbuddy.io/docs/rbe-github-actions), with more coming soon. We've also started collecting troubleshooting documentation for common errors including [RBE Failures](https://www.buildbuddy.io/docs/troubleshooting-rbe), and [Slow Uploads](https://www.buildbuddy.io/docs/troubleshooting-slow-upload). Contributions [welcome](https://github.com/buildbuddy-io/buildbuddy/tree/master/docs)!
+
+-   **Target information in timing tab** - in Bazel 3.4.0, the experimental [flag](https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_profile_include_target_label) **--experimental_profile_include_target_label** was introduced which adds target information to profiling events. When this flag is enabled, this target information is now displayed in the BuildBuddy Timing tab.
+
+New to Cloud & Enterprise BuildBuddy
+------------------------------------
+
+-   **BuildBuddy Cloud is now free for teams of up to 3** - we want to make BuildBuddy available to every team - regardless of size. BuildBuddy has always been free for individuals and open source projects and today we're expanding this to teams of up to 3 engineers. As your team continues to grow, we have reasonably priced plans that scale from startups to the largest enterprises.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f50458c4b4e4668b318e974_Screen%20Shot%202020-09-02%20at%206.23.09%20PM.png)
+
+-   **Distributed scheduler** - the scheduler is a core component of any remote execution platform. In many cases, it is a single point of failure that turns an otherwise robust system into a fragile, stateful service that's hard to scale. In BuildBuddy 1.2.1, we rewrote our **distributed** Remote Build Execution scheduler from the ground up based on many learnings and best practices from state-of-the-art systems like Apache Spark. This enables BuildBuddy to scale to handle the largest workloads with no single point of failure, single digit millisecond queue wait times, and fault tolerance that enables execution on preemptible nodes. This allows for more cost effective high availability configurations, and allows you to deploy new BuildBuddy releases without a blip in ongoing executions.
+
+-   **Remote asset API ** - in Bazel 3.0.0 the Remote Asset API was introduced along with the --experimental_remote_downloader [flag](https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_remote_downloader). In this release, we've added basic support for this experimental API.
+
+-   **Organization configuration** - we've added configuration options for on-prem installs that allow you to configure an organization's name and limit signups to emails from a specific domain. More information in the [org config documentation](https://www.buildbuddy.io/docs/config-org).
+
+-   **Configurable anonymous access** - we've added a configuration option that allows organizations with authentication configured to choose whether or not anonymous access should be enabled. Anonymous access is off by default when auth is configured. More information in the [auth config documentation](https://www.buildbuddy.io/docs/config-auth).
+
+-   **S3 cache support** - BuildBuddy [previously](https://github.com/buildbuddy-io/buildbuddy/pull/12) had support for using Amazon S3 as a backing store for build events. In this release, we've added Amazon S3 support for as a backing store for caching as well, with support for streaming, ContainsMulti, and more.
+
+That's it for this release. Stay tuned for more updates coming soon!
+
+As always, we love your feedback - join our [Slack channel](https://slack.buildbuddy.io) or email us at <hello@buildbuddy.io> with any questions, comments, or thoughts.

--- a/website/blog/buildbuddy-v1-2-1-release-notes.md
+++ b/website/blog/buildbuddy-v1-2-1-release-notes.md
@@ -1,0 +1,77 @@
+---
+slug: buildbuddy-v1-1-0-release-notes
+title: BuildBuddy v1.1.0 Release Notes
+author: Siggi Simonarson
+author_title: BuildBuddy Co-founder
+date: 2020-09-03:12:00:00
+author_url: https://www.linkedin.com/in/siggisim/
+author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
+tags: [product, release-notes]
+---
+
+Excited to share that v1.1.0 of BuildBuddy is live on both [Cloud Hosted BuildBuddy](https://app.buildbuddy.io/) and open source via [Github](https://github.com/buildbuddy-io/buildbuddy) and [Docker](https://github.com/buildbuddy-io/buildbuddy/blob/master/SETUP.md#docker-image)!
+
+Thanks to everyone that has tested open source and cloud-hosted BuildBuddy. We've made lots of improvements in this release based on your feedback.
+
+A special thank you to our new contributors:
+
+-   [Sergio Rodriguez Orellana](https://github.com/SrodriguezO) who contributed support for making dense mode the default view mode.
+-   [Tim Glaser](https://twitter.com/timgl?lang=en) who made some major improvements to our documentation.
+
+Our focus for this release was on our new Remote Build Execution platform. This release marks a huge step in fulfilling our mission of making developers more productive by supporting the Bazel ecosystem.
+
+BuildBuddy's Remote Build Execution platform supports executing your Bazel build and tests in parallel across thousands of machines with automatic scaling, support for custom Docker images, and more. We've been iterating on and testing BuildBuddy RBE for months with companies of different sizes, and are excited to now make it available to everyone.
+
+While BuildBuddy RBE is not yet fully open source, we're offering Cloud RBE for free to individuals and open source projects to show our appreciation to the open source community.
+
+We'll be adding more documentation on getting started with BuildBuddy RBE in the coming weeks, but in the meantime feel free to email us at <rbe@buildbuddy.io> or ping us in the [BuildBuddy Slack](https://join.slack.com/t/buildbuddy/shared_invite/zt-e0cugoo1-GiHaFuzzOYBPQzl9rkUR_g) and we'll be happy to help you get started.
+
+**New to Open Source BuildBuddy**
+---------------------------------
+
+-   **Cache & remote execution badges - **BuildBuddy invocations pages now show badges that indicate whether or not caching and remote execution are enabled. Clicking on these badges takes you to instructions on how to configure these if they're enabled for your BuildBuddy instance.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f46c467b18b5b9b9a054e_Screen%20Shot%202020-07-15%20at%2011.10.53%20AM.png)
+
+-   **Remote build execution configuration options** - the BuildBuddy configuration widget has now been updated to enable configuring of remote build execution if it's enabled for your BuildBuddy instance.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f5044fdd7a1168e60f04d_Screen%20Shot%202020-07-15%20at%2011.51.30%20AM.png)
+
+-   **Better build status support** - BuildBuddy now better distinguishes between in-progress, failed, passed, and cancelled builds with new colorful status indicators, favicons, and more.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f482df789bfe48429ccdd_Screen%20Shot%202020-07-15%20at%2011.16.56%20AM.png)
+
+-   **Improved documentation and new website** - we've completely revamped the BuildBuddy documentation, and it's now sync'd between GitHub and [buildbuddy.io/docs/](https://buildbuddy.io/docs/), so your docs will be fresh regardless of where you're reading them. We'll be adding new sections on configuring RBE in the coming weeks. We've also completely revamped the BuildBuddy website to make it easier to navigate and perform actions like requesting a quote, or subscribing to our [newsletter](#wf-form-Newsletter-Form).
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f4c7722c95645285c77bc_Screen%20Shot%202020-07-15%20at%2011.35.08%20AM.png)
+
+-   **Test run grid** - BuildBuddy will now automatically display test runs as a grid when a single test target is run more than 10 times. This supports the use case of finding and fixing flaky tests by running them with **--runs_per_test=100**.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f4d62b65ec8097cb159df_Screen%20Shot%202020-07-15%20at%2011.38.57%20AM.png)
+
+-   **Performance and reliability improvements** - we put a lot of work into improving performance and reliability in this release. This includes changes like better event flushing (no more getting stuck on 15 build events), better shutdown behavior, speed improvements and optimizations in build artifact uploading and downloading, and more.
+
+‍
+
+New to Cloud & Enterprise BuildBuddy
+------------------------------------
+
+-   **Remote Build Execution** - BuildBuddy Cloud and enterprise on-prem now support Remote Build Execution. Features include custom Docker image support, automatic scaling, multiple caching layers, and more. Additional features like Mac support, viewing of remote build actions in BuildBuddy, and more are coming soon.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f463422c9562d965c6e96_Screen%20Shot%202020-07-15%20at%2011.08.27%20AM.png)
+
+-   **Invocation grouping** - BuildBuddy invocations can now be grouped by commit and by repo. These can be populated in one of three ways:
+
+1.  automatically by common CI environments like CircleCI and GitHub actions
+2.  manually by using build flags **--build_metadata=REPO_URL=** and **--build_metadata=COMMIT_SHA=**‍
+3.  by using a **--workspace_status_command** script like [this one](https://github.com/buildbuddy-io/buildbuddy/blob/master/workspace_status.sh)
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f4f1e86a5cb635333d937_Screen%20Shot%202020-07-15%20at%2011.46.30%20AM.png)
+
+-   **New cloud endpoint** - BuildBuddy now exposes a L7 load balanced gRPCS cloud endpoint at **cloud.buildbuddy.io** which can be used for BES, cache, and remote execution (see our [.bazelrc](https://github.com/buildbuddy-io/buildbuddy/blob/master/.bazelrc#L25) for an example). We'll gradually be migrating users to this from the old events.buildbuddy.io, and cache.buildbuddy.io endpoints with port numbers.
+
+-   **Easier enterprise deployment** - deploying enterprise BuildBuddy is now just as easy as deploying open source BuildBuddy, with a one line install script that deploys to your Kubernetes cluster. It takes your [BuildBuddy configuration file](https://www.buildbuddy.io/docs/config) as a parameter so you can easily configure things to your needs.
+
+That's it for this release. Stay tuned for more updates coming soon!
+
+As always, we love your feedback - email us at <hello@buildbuddy.io> with any questions, comments, or thoughts.

--- a/website/blog/buildbuddy-v1-3-0-release-notes.md
+++ b/website/blog/buildbuddy-v1-3-0-release-notes.md
@@ -1,0 +1,77 @@
+---
+slug: buildbuddy-v1-3-0-release-notes
+title: BuildBuddy v1.3.0 Release Notes
+author: Siggi Simonarson
+author_title: BuildBuddy Co-founder
+date: 2020-09-30:12:00:00
+author_url: https://www.linkedin.com/in/siggisim/
+author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
+tags: [product, release-notes]
+---
+
+Excited to share that v1.1.0 of BuildBuddy is live on both [Cloud Hosted BuildBuddy](https://app.buildbuddy.io/) and open source via [Github](https://github.com/buildbuddy-io/buildbuddy) and [Docker](https://github.com/buildbuddy-io/buildbuddy/blob/master/SETUP.md#docker-image)!
+
+Thanks to everyone that has tested open source and cloud-hosted BuildBuddy. We've made lots of improvements in this release based on your feedback.
+
+A special thank you to our new contributors:
+
+-   [Sergio Rodriguez Orellana](https://github.com/SrodriguezO) who contributed support for making dense mode the default view mode.
+-   [Tim Glaser](https://twitter.com/timgl?lang=en) who made some major improvements to our documentation.
+
+Our focus for this release was on our new Remote Build Execution platform. This release marks a huge step in fulfilling our mission of making developers more productive by supporting the Bazel ecosystem.
+
+BuildBuddy's Remote Build Execution platform supports executing your Bazel build and tests in parallel across thousands of machines with automatic scaling, support for custom Docker images, and more. We've been iterating on and testing BuildBuddy RBE for months with companies of different sizes, and are excited to now make it available to everyone.
+
+While BuildBuddy RBE is not yet fully open source, we're offering Cloud RBE for free to individuals and open source projects to show our appreciation to the open source community.
+
+We'll be adding more documentation on getting started with BuildBuddy RBE in the coming weeks, but in the meantime feel free to email us at <rbe@buildbuddy.io> or ping us in the [BuildBuddy Slack](https://join.slack.com/t/buildbuddy/shared_invite/zt-e0cugoo1-GiHaFuzzOYBPQzl9rkUR_g) and we'll be happy to help you get started.
+
+**New to Open Source BuildBuddy**
+---------------------------------
+
+-   **Cache & remote execution badges - **BuildBuddy invocations pages now show badges that indicate whether or not caching and remote execution are enabled. Clicking on these badges takes you to instructions on how to configure these if they're enabled for your BuildBuddy instance.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f46c467b18b5b9b9a054e_Screen%20Shot%202020-07-15%20at%2011.10.53%20AM.png)
+
+-   **Remote build execution configuration options** - the BuildBuddy configuration widget has now been updated to enable configuring of remote build execution if it's enabled for your BuildBuddy instance.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f5044fdd7a1168e60f04d_Screen%20Shot%202020-07-15%20at%2011.51.30%20AM.png)
+
+-   **Better build status support** - BuildBuddy now better distinguishes between in-progress, failed, passed, and cancelled builds with new colorful status indicators, favicons, and more.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f482df789bfe48429ccdd_Screen%20Shot%202020-07-15%20at%2011.16.56%20AM.png)
+
+-   **Improved documentation and new website** - we've completely revamped the BuildBuddy documentation, and it's now sync'd between GitHub and [buildbuddy.io/docs/](https://buildbuddy.io/docs/), so your docs will be fresh regardless of where you're reading them. We'll be adding new sections on configuring RBE in the coming weeks. We've also completely revamped the BuildBuddy website to make it easier to navigate and perform actions like requesting a quote, or subscribing to our [newsletter](#wf-form-Newsletter-Form).
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f4c7722c95645285c77bc_Screen%20Shot%202020-07-15%20at%2011.35.08%20AM.png)
+
+-   **Test run grid** - BuildBuddy will now automatically display test runs as a grid when a single test target is run more than 10 times. This supports the use case of finding and fixing flaky tests by running them with **--runs_per_test=100**.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f4d62b65ec8097cb159df_Screen%20Shot%202020-07-15%20at%2011.38.57%20AM.png)
+
+-   **Performance and reliability improvements** - we put a lot of work into improving performance and reliability in this release. This includes changes like better event flushing (no more getting stuck on 15 build events), better shutdown behavior, speed improvements and optimizations in build artifact uploading and downloading, and more.
+
+‍
+
+New to Cloud & Enterprise BuildBuddy
+------------------------------------
+
+-   **Remote Build Execution** - BuildBuddy Cloud and enterprise on-prem now support Remote Build Execution. Features include custom Docker image support, automatic scaling, multiple caching layers, and more. Additional features like Mac support, viewing of remote build actions in BuildBuddy, and more are coming soon.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f463422c9562d965c6e96_Screen%20Shot%202020-07-15%20at%2011.08.27%20AM.png)
+
+-   **Invocation grouping** - BuildBuddy invocations can now be grouped by commit and by repo. These can be populated in one of three ways:
+
+1.  automatically by common CI environments like CircleCI and GitHub actions
+2.  manually by using build flags **--build_metadata=REPO_URL=** and **--build_metadata=COMMIT_SHA=**‍
+3.  by using a **--workspace_status_command** script like [this one](https://github.com/buildbuddy-io/buildbuddy/blob/master/workspace_status.sh)
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f4f1e86a5cb635333d937_Screen%20Shot%202020-07-15%20at%2011.46.30%20AM.png)
+
+-   **New cloud endpoint** - BuildBuddy now exposes a L7 load balanced gRPCS cloud endpoint at **cloud.buildbuddy.io** which can be used for BES, cache, and remote execution (see our [.bazelrc](https://github.com/buildbuddy-io/buildbuddy/blob/master/.bazelrc#L25) for an example). We'll gradually be migrating users to this from the old events.buildbuddy.io, and cache.buildbuddy.io endpoints with port numbers.
+
+-   **Easier enterprise deployment** - deploying enterprise BuildBuddy is now just as easy as deploying open source BuildBuddy, with a one line install script that deploys to your Kubernetes cluster. It takes your [BuildBuddy configuration file](https://www.buildbuddy.io/docs/config) as a parameter so you can easily configure things to your needs.
+
+That's it for this release. Stay tuned for more updates coming soon!
+
+As always, we love your feedback - email us at <hello@buildbuddy.io> with any questions, comments, or thoughts.

--- a/website/blog/buildbuddy-v1-4-0-release-notes.md
+++ b/website/blog/buildbuddy-v1-4-0-release-notes.md
@@ -1,0 +1,68 @@
+---
+slug: buildbuddy-v1-4-0-release-notes
+title: BuildBuddy v1.4.0 Release Notes
+author: Siggi Simonarson
+author_title: BuildBuddy Co-founder
+date: 2020-11-12:12:00:00
+author_url: https://www.linkedin.com/in/siggisim/
+author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
+tags: [product, release-notes]
+---
+
+We're excited to share that v1.4.0 of BuildBuddy is live on both [Cloud Hosted BuildBuddy](https://app.buildbuddy.io/) and open-source via [Github](https://github.com/buildbuddy-io/buildbuddy) and [Docker](https://github.com/buildbuddy-io/buildbuddy/blob/master/docs/on-prem.md#docker-image)!
+
+Thanks to everyone using open source, cloud-hosted, and enterprise BuildBuddy. We've made lots of improvements in this release based on your feedback.
+
+A special thank you to our new contributors who we'll soon be sending BuildBuddy t-shirts and holographic BuildBuddy stickers:
+
+-   [**Daniel Purkhús**](https://github.com/purkhusid) who enabled environment variable expansion in BuildBuddy config files & more
+
+-   [**Joshua Katz**](https://github.com/gravypod) who added support for auto-populating build metadata from GitLab CI invocations
+
+Our focus for this release was on giving users new tools to share, compare, analyze, and manage BuildBuddy invocations - as well as major performance and reliability improvements to our remote build execution service.
+
+We're also excited to share that over the coming weeks and months, we'll be open sourcing much more of BuildBuddy - including our remote build execution platform. At BuildBuddy we're firmly committed to open source and believe that a transparent and open model is the only way to build truly great developer infrastructure for all.
+
+**New to Open Source BuildBuddy**
+---------------------------------
+
+-   **Invocation sharing & visibility controls** - while you've always been able to share BuildBuddy links with members of your organization, it's been difficult to share invocations more broadly (in GitHub issues or on StackOverflow). Now that working from home is the new norm, sharing links to your build logs or invocations details and artifacts has become more important than ever. To support this, we've added a **Share** button on the invocation page that allows you to control visibility of your invocations (this can be disabled at the organization level). We've also disabled the expiration of invocations and build logs for everyone on BuildBuddy Cloud - so you can share BuildBuddy links with confidence.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5fad7e7e02aaaabf670ca163_Screen%20Shot%202020-11-12%20at%2010.25.43%20AM.png)
+
+-   **Invocation diffing** - we've all run into the problem where a build works on your machine, but not on your coworker's machine. To support debugging these kinds of issues, we've added the ability to diff builds straight from the invocations page. This allows you to quickly find any flags or invocation details that may have changed between builds. Stay tuned for more diffing features here, including cache hit debugging and more.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5fad7f9eb7782df7e6d2ec76_Screen%20Shot%202020-11-12%20at%2010.31.25%20AM.png)
+
+-   **Suggested fixes** - as software engineers, we often find ourselves bumping into errors and issues that many others have bumped into before. A tool like BuildBuddy provides the perfect way to quickly surface these suggested fixes to developers quickly, without even so much as a Google search. We've started by adding suggestions for common issues that BuildBuddy users run into, but stay tuned for the ability to add your own custom fix suggestions and share them with your organization and beyond!
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5fad86d1f58677c468250e2c_Screen%20Shot%202020-11-12%20at%2011.01.13%20AM.png)
+
+-   **Easy invocation deletion** - you can now delete your BuildBuddy invocations directly from the invocation page "three dot" menu in case you want to share an invocation and delete it when you're done.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5fad85c7ae39b0100858c2b8_Screen%20Shot%202020-11-12%20at%2010.56.53%20AM.png)
+
+New to Cloud & Enterprise BuildBuddy
+------------------------------------
+
+-   **Cache stats & filters** - our trends page now allows you to see trends in caching performance broken down by the Action Cache (AC) and the Content Addressable Store (CAS). The trends page is now also filterable by CI vs non-CI builds, and by user, repo, commit, or host.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5fad8533a1566a7bd6c70deb_Screen%20Shot%202020-11-06%20at%2011.54.19%20AM.png)
+
+-   **Simplified API key header auth** - previously if you wanted to authenticate your BuildBuddy invocations using an API key (instead of using certificated based mTLS), you had to place your API key in each BuildBuddy flag that connected to BuildBuddy with YOUR_API_KEY@cloud.buildbuddy.io. This has been greatly simplified in this release with the support for the --remote_header flag, which allows you to more easily separate auth credentials into a separate .bazelrc file.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5fad8825c75ffe49d07e8b46_Screen%20Shot%202020-11-12%20at%2011.06.29%20AM.png)
+
+-   **Organization creation and invitations** - you can now create organizations and send invitation links to others.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5fad85aabb83d90aa2813edf_Screen%20Shot%202020-11-12%20at%2010.57.26%20AM.png)
+
+-   **Remote build execution performance and reliability improvements** - we've made a whole host of changes to our remote build execution executors and schedulers to make them more fault tolerant, easier to scale, and faster. We've also exposed support for executor pools on BuildBuddy Enterprise which allow you to route remote execution traffic based on OS, CPU architecture, GPU requirements, CPU/memory requirements, and more. Routing can be configured at both the platform and individual target level. Finally, we've added improved documentation to help get up and running with RBE more quickly.
+
+‍
+
+That's it for this release. Stay tuned for more updates coming soon!
+
+As always, we love your feedback - join our [Slack channel](https://slack.buildbuddy.io) or email us at <hello@buildbuddy.io> with any questions, comments, or thoughts.
+
+‍

--- a/website/blog/buildbuddy-v1-5-0-release-notes.md
+++ b/website/blog/buildbuddy-v1-5-0-release-notes.md
@@ -1,0 +1,47 @@
+---
+slug: buildbuddy-v1-5-0-release-notes
+title: BuildBuddy v1.5.0 Release Notes
+author: Siggi Simonarson
+author_title: BuildBuddy Co-founder
+date: 2021-01-08:12:00:00
+author_url: https://www.linkedin.com/in/siggisim/
+author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
+tags: [product, release-notes]
+---
+
+We're excited to share that v1.5.0 of BuildBuddy is live on both [Cloud Hosted BuildBuddy](https://app.buildbuddy.io/) and open-source via [Github](https://github.com/buildbuddy-io/buildbuddy), [Docker](https://github.com/buildbuddy-io/buildbuddy/blob/master/docs/on-prem.md#docker-image), and [our Helm Charts](https://github.com/buildbuddy-io/buildbuddy-helm)!
+
+Thanks to everyone using open source, cloud-hosted, and enterprise BuildBuddy. We've made lots of improvements in this release based on your feedback.
+
+A special thank you to our new open-source contributor:
+
+-   [**Corbin McNeely-Smith**](https://github.com/restingbull) who contributed to making our auth flow more resilient to error cases, and made our health-check handlers more flexible to support different load-balancers.
+
+Our focus for this release was on giving users more visibility into test flakiness, monitoring & scaling improvements, and security hardening.
+
+**New in v1.5.0**
+-----------------
+
+-   **Test flakiness dashboard** - one of the feature requests we get most frequently from BuildBuddy users is the ability to collect target-level data and analyze it across invocations. Today we're taking the first step in the direction with our new test dashboard. The test dashboard allows you to monitor per-target test statuses by commit - so you can quickly identify and fix flaky test targets that slow down developer velocity. It also has a timing view that gives you a heat-map to quickly identify slow targets. This is just the first step we're taking in exposing more target-level data and are excited to build additional features based on your feedback!
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/6010c6df601bb5e1c1e16a78_Screen%20Shot%202021-01-26%20at%205.49.46%20PM.png)
+
+-   **Prometheus metrics** - we've added a ton of new Prometheus metrics to BuildBuddy that allow open-source and Enterprise users to monitor not only BuildBuddy's performance, but the overall health of their developer productivity efforts. This allows you to hook into existing monitoring and alerting tools like Grafana to analyze and get notified when your developers are experiencing issues. Metrics include build duration, cache hit & miss rates, remote execution queue length, and more. For a full list of the new metrics we now expose, see our [Prometheus metric documentation](https://www.buildbuddy.io/docs/prometheus-metrics). Interested in some metrics that aren't on this list? Let us know!
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/6010ccfb707b665aa637bb30_Screen%20Shot%202021-01-26%20at%206.16.10%20PM.png)
+
+-   **Auto-scaling** - with the addition of our new Prometheus metrics, we've also made improvements to the autoscaling capabilities of BuildBuddy executors. Now in addition to scaling off of raw compute metrics like CPU and RAM, BuildBuddy executors can also be configured to scale based on executor queue length and other custom metrics. This allows you to achieve better performance under heavy load while also managing your compute resources more efficiently and cost-effectively.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/6010cd9f28a90e7c5a1dd1b4_Screen%20Shot%202021-01-26%20at%206.18.49%20PM.png)
+
+-   **Security hardening** - as part of our SOC 2 compliance controls, BuildBuddy undergoes regularly scheduled penetration tests by paid security professionals. This release contains fixes for all three non-critical findings from our January 2021 pen-test.
+
+-   **Memory leak fixes** - we found and fixed 2 memory leaks in our BuildBuddy app (using our new Prometheus metrics!) that would occasionally cause BuildBuddy app servers to restart due to memory pressure.
+
+-   **Mac executor bug fix** - we fixed a tricky bug caused by quirks in the way OS X handles hard-linking that significantly improves the reliability of our Mac RBE executors.
+
+-   **More bug fixes** - there are lots of other bug fixes in this release including improved deadline and timeout handling, executor task scheduling improvements, and more!
+
+That's it for this release. Stay tuned for more updates coming soon!
+
+As always, we love your feedback - join our [Slack channel](https://slack.buildbuddy.io) or email us at <hello@buildbuddy.io> with any questions, comments, or thoughts.

--- a/website/blog/buildbuddy-v1-8-0-release-notes.md
+++ b/website/blog/buildbuddy-v1-8-0-release-notes.md
@@ -1,0 +1,57 @@
+---
+slug: buildbuddy-v1-8-0-release-notes
+title: BuildBuddy v1.8.0 Release Notes
+author: Siggi Simonarson
+author_title: BuildBuddy Co-founder
+date: 2021-03-18:12:00:00
+author_url: https://www.linkedin.com/in/siggisim/
+author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
+tags: [product, release-notes, team]
+---
+
+We're excited to share that v1.8.0 of BuildBuddy is live on [Cloud Hosted BuildBuddy](https://app.buildbuddy.io/), Enterprise, and Open Source via [GitHub](https://github.com/buildbuddy-io/buildbuddy), [Docker](https://github.com/buildbuddy-io/buildbuddy/blob/master/docs/on-prem.md#docker-image), and [our Helm Charts](https://github.com/buildbuddy-io/buildbuddy-helm)!
+
+Thanks to everyone using open source, cloud-hosted, and enterprise BuildBuddy. We've made lots of improvements in this release based on your feedback.
+
+**A special thank you to our new open-source contributor:**
+
+-   [**Ashley Davies**](https://github.com/ashleydavies) who contributed several pull requests to our [Helm charts](https://github.com/buildbuddy-io/buildbuddy-helm/) in order to make them easier to use in clusters that already have an Nginx controller deployed.
+
+**And a warm welcome to our three new team members! **
+
+-   [**Pari Parajuli**](https://www.linkedin.com/in/pari-parajuli/) who joins our engineering team as an intern who's currently studying at University of California, Berkeley.
+-   [**Vadim Berezniker**](https://www.linkedin.com/in/vadimberezniker/) who joins our engineering team after 7 years at Google on the Google Cloud team. 
+-   [**Zoey Greer**](https://www.linkedin.com/in/zoey-greer/) who joins us as a software engineer from the Google Search team.
+
+We're excited to continue growing BuildBuddy and fulfill our mission of making developers more productive!
+
+Our focus for this release was on reliability, performance, improved documentation, and making BuildBuddy easier to release and monitor.
+
+**New in v1.8.0**
+-----------------
+
+-   **Read-only API keys** - when using Bazel remote caching, teams often need to configure which machines have write access to the cache. While Bazel has some flags to control cache writes, using these can be error prone and insecure. BuildBuddy now makes this easy by introducing the ability to create both read-only and read+write api keys on your organization settings page. You can create as many API keys (and certificates) as you'd like and distribute them to your CI machines, workstations, and other endpoints.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/60529f08fe396cda68cb1499_Screen%20Shot%202021-03-17%20at%205.29.09%20PM.png)
+
+-   **Improved docs** - we've completely revamped [our documentation](https://docs.buildbuddy.io/) and added support for tables of contents, syntax highlighting, better navigation, dark mode (!!), interactive widgets, and an "Edit this page" button that links directly to the correct file in our [GitHub docs directory](https://github.com/buildbuddy-io/buildbuddy/tree/master/docs) for submitting pull requests. With these great new features, we'll be ramping up documentation on both new and existing BuildBuddy features to make the lives of BuildBuddy users easier.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/60529f3ecbd5bf1d4ccb635b_Screen%20Shot%202021-03-17%20at%205.30.45%20PM.png)
+
+-   **Testing improvements** - we've invested heavily in our testing infrastructure, adding new integration tests and test fixtures that make testing BuildBuddy's interactions with Bazel easier. This will lead to more stable releases and faster iteration cycles going forward.
+
+-   **Remote execution improvements** - we've made more speed and reliability improvements to our remote build execution platform, including faster cache hit checking, faster auth checks, and better support for iOS builds.
+
+-   **Buildkite integration -** invocations that are kicked off from Buildkite now link back to the Buildkite job that triggered them.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/6052a05f32acfea7cc471cbb_Screen%20Shot%202021-03-17%20at%205.35.16%20PM.png)
+
+-   **Grafana** - our [Helm charts](https://github.com/buildbuddy-io/buildbuddy-helm) make deploying BuildBuddy to Kubernetess cluster a breeze. One thing that's been tricky for many users has been accessing the Prometheus data that BuildBuddy exports in an easily digestible format. To fix this, we made it easy to [deploy Grafana and Prometheus](https://github.com/buildbuddy-io/buildbuddy-helm/tree/master/charts/buildbuddy-enterprise#example-with-prometheus--grafana) via our Helm charts with just a couple lines of configuration. It comes out of the box with a default dashboard that shows popular BuildBuddy metrics and can be easily extended to add more graphs.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/6052a1f479e3910be45d5c1f_Screen%20Shot%202021-03-17%20at%205.42.10%20PM.png)
+
+-   **More to come** - we've been laying the groundwork for two major projects that will go live in the coming weeks to make building and testing your Bazel projects even faster.
+
+That's it for this release. Stay tuned for more updates coming soon!
+
+As always, we love your feedback - join our [Slack channel](https://slack.buildbuddy.io) or email us at **hello@buildbuddy.io** with any questions, comments, or thoughts.

--- a/website/blog/introducing-buildbuddy-v1.md
+++ b/website/blog/introducing-buildbuddy-v1.md
@@ -1,0 +1,64 @@
+---
+slug: introducing-buildbuddy-v1
+title: Introducing BuildBuddy Version 1.0
+author: Siggi Simonarson
+author_title: BuildBuddy Co-founder
+date: 2020-04-24:12:00:00
+author_url: https://www.linkedin.com/in/siggisim/
+author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
+tags: [product, release-notes]
+---
+
+We released our initial open source version of BuildBuddy to the Bazel community last month and have received a ton of interest, support, and feedback. We really appreciate everyone who's taken the time to kick the tires and try it out!
+
+We're excited to share that BuildBuddy has been run on-prem at over 20 companies, and hundreds more developers have tried our cloud-hosted version.
+
+People have found the shareable invocation links particularly useful when debugging builds remotely with co-workers while working from home. No more pasting console outputs into Pastebin!
+
+We've taken all of the feedback we've gotten and made lots of improvements to both the open source and enterprise versions of BuildBuddy.
+
+Our three major focuses for this release were on better build artifact handling, better test support, and enterprise authentication. We hope these changes help you continue to build and debug software faster. Keep the feedback coming!
+
+New to Open Source BuildBuddy
+-----------------------------
+
+-   **Remote cache support** - we've added a built-in Bazel remote cache to BuildBuddy, implementing the GRPC remote caching APIs. This allows BuildBuddy to optionally collect build artifacts, timing profile information, test logs, and more.
+
+-   **Clickable build artifacts** - this was our most requested feature. Clicking on build artifacts in the BuildBuddy UI now downloads the artifact when using either the built-in BuildBuddy cache, or a third-party cache running in GRPC mode that supports the bytestream API - like [bazel-remote](https://github.com/buchgr/bazel-remote).
+
+-   **Detailed timing information** - getting detailed timing information on your Bazel builds can be a hassle. Now BuildBuddy invocations include a new "Timing" tab - which pulls the Bazel profile logs from your build cache and displays them in a human-readable format. Stay tuned for flame charts!
+
+-   **Viewable test logs** - digging into test logs for your Bazel runs can be a pain. Now BuildBuddy surfaces test logs directly in the UI when you click on a test target (GRPC remote cache required).
+
+-   **Multiple test-run support** - one of our favorite features of Bazel is that it will rerun flaky tests for you. BuildBuddy now supports viewing information about multiple attempts of a single test run.
+
+-   **Client environment variable redaction** - client environment variables are now redacted from BuildBuddy's invocation details to avoid over-sharing.
+
+-   **Dense UI mode** - based on feedback on information density of the default BuildBuddy UI, we added a "Dense mode" that packs more information into every square inch.
+
+-   **BES backend multiplexing** - we heard from some of you that you'd like to try BuildBuddy, but were already pointing your bes_backend flag at another service. We've added the build_event_proxy configuration option that allows you to specify other backends that your build events should be forwarded to. See the [configuration docs](https://github.com/buildbuddy-io/buildbuddy/blob/master/CONFIG.md#buildeventproxy) for more information.
+
+-   **Slack webhook support** - we've added a configuration option that allows you to message a Slack channel when builds finish. This is a nice way of getting a quick notification when a long running build completes, or a CI build fails. See the [configuration docs](https://github.com/buildbuddy-io/buildbuddy/blob/master/CONFIG.md#integrations) for more information.
+
+Our open source BuildBuddy distribution is targeted at individuals viewing and debugging their Bazel builds. For teams and organizations, we provide an enterprise version of BuildBuddy that adds support for team-specific features.
+
+‍
+
+New to Enterprise BuildBuddy
+----------------------------
+
+-   **OpenID Connect auth support** - organizations can now specify an OpenID Connect provider to handle authentication for their BuildBuddy instance. This allows for the flexibility to use Google login if you use GSuite, auth services like Okta, or an in-house solution that supports OpenID Connect.
+
+-   **Authenticated build log & cache uploads** - BuildBuddy now supports generating authenticated upload urls for both the build event and remote cache backends. Events uploaded with authentication will be associated with your organziation and will not be viewable by unauthorized clients.
+
+-   **Organization support** - BuildBuddy now supports creating organizations that allow builds to be viewed and aggregated across your team/company.
+
+-   **Organization build history** - with organization support comes a new view that allows you to see recent builds across your organization.
+
+-   **User & host overviews** - you can now see all of the users and hosts that have uploaded builds to your organization. This allows you to drill into all of the builds uploaded from a CI machine for example.
+
+-   **Build grid** - the new build grid gives you a visual overview of the build history for an organization, host, or user. This allows you to quickly find and fix failing builds.
+
+That's it for this release. Stay tuned for more updates coming soon!
+
+As always, we love your feedback - email us at <hello@buildbuddy.io> with any questions, comments, or thoughts.

--- a/website/blog/meet-buildbuddy.md
+++ b/website/blog/meet-buildbuddy.md
@@ -1,0 +1,24 @@
+---
+slug: meet-buildbuddy
+title: Meet BuildBuddy
+author: Siggi Simonarson
+author_title: BuildBuddy Co-founder
+date: 2020-03-04:12:00:00
+author_url: https://www.linkedin.com/in/siggisim/
+author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
+tags: [company, product]
+---
+
+BuildBuddy is a managed [Bazel](https://bazel.build/) build system --- it brings a Google-style development environment to any company in minutes.
+
+The first product we've built is an [open-core](https://en.wikipedia.org/wiki/Open-core_model) Bazel build log viewer. It consumes the Bazel [build event protocol](https://docs.bazel.build/versions/master/build-event-protocol.html) and makes logs accessible through a user-friendly web UI. If you're familiar with [Google's Sponge tool](https://mike-bland.com/2012/10/01/tools.html#tap-and-sponge) - it's basically an open source version of that. It's available in 3 forms:
+
+-   **Open source** - You can find the core product open source and free to use with an MIT license on [Github](https://github.com/buildbuddy-io/buildbuddy).
+-   **Cloud hosted** - We also offer a cloud hosted version of the product at [buildbuddy.io](https://buildbuddy.io/). Plans range from a free version for personal use to an enterprise version suited for companies with complex needs.
+-   **On-prem** - We offer an enterprise version of the product that you can run on-premises or in your own cloud. This version comes with all the bells and whistles - like dashboards, user accounts, and dedicated support.
+
+The Bazel build log viewer is just the start. We're working on a [shared build cache](https://docs.bazel.build/versions/master/remote-caching.html), [remote build execution](https://docs.bazel.build/versions/master/remote-execution.html), and more.
+
+Our end goal is to take the pain out of managing Bazel, so you can focus on building your product.
+
+Reach out to us at <hello@buildbuddy.io> if you're interested, we'd love to chat!

--- a/website/blog/welcoming-george-li-head-of-sales.md
+++ b/website/blog/welcoming-george-li-head-of-sales.md
@@ -1,0 +1,20 @@
+---
+slug: welcoming-george-li-head-of-sales
+title: Welcoming George Li, Head of Sales
+author: Siggi Simonarson
+author_title: BuildBuddy Co-founder
+date: 2020-11-12:12:00:00
+author_url: https://www.linkedin.com/in/siggisim/
+author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
+tags: [company, team]
+---
+
+To fulfill our mission of bringing the world's best developer tools to every company, we're building a team that's ready to work with the world's best enterprises. That's why we're excited to share today that [**George Li**](https://www.linkedin.com/in/gli/) is joining BuildBuddy to lead our enterprise sales efforts as our Head of Sales.
+
+George joins us from Looker where he served as Head of APAC Sales Engineering. He joined Google Cloud through their [acquisition](https://techcrunch.com/2020/02/13/google-closes-2-6b-looker-acquisition/) of Looker in February, having helped the company grow to a $2.6B valuation.
+
+![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f84d59b112797724e0e8444_george.png)
+
+We look forward to working alongside George to build the future of developer tools.
+
+Welcome to BuildBuddy, George!

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -197,7 +197,9 @@ module.exports = {
           editUrl: 'https://github.com/buildbuddy-io/buildbuddy/edit/master/docs/',
         },
         blog: {
+          path: 'blog',
           showReadingTime: true,
+          blogSidebarCount: 5,
           editUrl: 'https://github.com/buildbuddy-io/buildbuddy/edit/master/blog/',
         },
         theme: {


### PR DESCRIPTION
This will make it easier for anyone to contribute BuildBuddy blog posts.

Things left to do after this change:
- Configure blog.buildbuddy.io ssl cert
- Figure out root domain redirection
- Some styling tweaks
- Migrate images for old posts (this can wait until we fully want to shutdown the webflow site).
- Redirect webflow blog to point at this new blog
- Configure canonical urls

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
