### PR TITLE
workflows: Add GitHub import view

### DIFF
--- a/app/components/button/button.css
+++ b/app/components/button/button.css
@@ -46,6 +46,7 @@
 /* Extra specificity here so the [disabled] style takes precedence. */
 .filled-button.filled-button.filled-button[disabled],
 .filled-button.filled-button.filled-button[disabled]:hover {
+  transition: 100ms ease;
   background: #bbb;
   cursor: not-allowed;
   box-shadow: none;

--- a/enterprise/app/workflows/BUILD
+++ b/enterprise/app/workflows/BUILD
@@ -15,6 +15,7 @@ ts_library(
         "//app/components/menu",
         "//app/components/modal",
         "//app/components/popup",
+        "//app/errors",
         "//app/router",
         "//app/service",
         "//app/util:clipboard",

--- a/enterprise/app/workflows/github_import.tsx
+++ b/enterprise/app/workflows/github_import.tsx
@@ -1,0 +1,172 @@
+import React from "react";
+import FilledButton, { OutlinedButton } from "../../../app/components/button/button";
+import FilledLinkButton from "../../../app/components/button/link_button";
+import Dialog, { DialogBody, DialogHeader, DialogTitle } from "../../../app/components/dialog/dialog";
+import Modal from "../../../app/components/modal/modal";
+import errorService from "../../../app/errors/error_service";
+import router from "../../../app/router/router";
+import rpcService from "../../../app/service/rpc_service";
+import { BuildBuddyError } from "../../../app/util/errors";
+import { workflow } from "../../../proto/workflow_ts_proto";
+
+type GitHubRepoPickerProps = {};
+
+type State = {
+  limit: number;
+
+  reposResponse?: workflow.IGetReposResponse;
+  workflowsResponse?: workflow.IGetWorkflowsResponse;
+  error?: BuildBuddyError;
+
+  importRequest?: workflow.ICreateWorkflowRequest;
+};
+
+const DEFAULT_REPO_LIMIT = 6;
+const SHOW_MORE_INCREMENT = 10;
+
+export default class GitHubImport extends React.Component<GitHubRepoPickerProps, State> {
+  state: State = {
+    limit: DEFAULT_REPO_LIMIT,
+  };
+
+  componentDidMount() {
+    // Fetch workflows and GitHub repos so we know which repos already have workflows
+    // created for them.
+    rpcService.service
+      .getRepos(new workflow.GetReposRequest({ gitProvider: workflow.GitProvider.GITHUB }))
+      .then((reposResponse) => this.setState({ reposResponse }))
+      .catch((error) => this.setState({ error: BuildBuddyError.parse(error) }));
+    rpcService.service
+      .getWorkflows(new workflow.GetWorkflowsRequest())
+      .then((workflowsResponse) => this.setState({ workflowsResponse }))
+      .catch((error) => this.setState({ error: BuildBuddyError.parse(error) }));
+  }
+
+  private onClickImport(url: string) {
+    const importRequest = new workflow.CreateWorkflowRequest({
+      gitRepo: new workflow.CreateWorkflowRequest.GitRepo({ repoUrl: url }),
+    });
+    this.setState({ importRequest });
+    rpcService.service
+      .createWorkflow(importRequest)
+      .then(() => {
+        // TODO: Show "Import succeeded" banner.
+        router.navigateToWorkflows();
+      })
+      .catch((error) => {
+        this.setState({ importRequest: null });
+        errorService.handleError(error);
+      });
+  }
+
+  private onClickShowMore() {
+    this.setState({ limit: this.state.limit + SHOW_MORE_INCREMENT });
+  }
+
+  private onClickWorkflowBreadcrumb(e: React.MouseEvent) {
+    e.preventDefault();
+    router.navigateToWorkflows();
+  }
+
+  private onClickImportOther(e: React.MouseEvent) {
+    e.preventDefault();
+    router.navigateTo("/workflows/new/custom");
+  }
+
+  private getImportedRepoUrls(): Set<string> {
+    return new Set(this.state.workflowsResponse.workflow.map((workflow) => workflow.repoUrl));
+  }
+
+  render() {
+    if (this.state.error) {
+      return <div className="error">{this.state.error}</div>;
+    }
+    if (!this.state.reposResponse || !this.state.workflowsResponse) {
+      return <div className="loading"></div>;
+    }
+    const alreadyImportedUrls = this.getImportedRepoUrls();
+    const isImporting = Boolean(this.state.importRequest);
+    return (
+      <div className="workflows-github-import">
+        <div className="shelf">
+          <div className="container">
+            <div className="breadcrumbs">
+              <span>
+                <a href="/workflows/" onClick={this.onClickWorkflowBreadcrumb.bind(this)}>
+                  Workflows
+                </a>
+              </span>
+              <span>Import GitHub repo</span>
+            </div>
+            <div className="title">Import GitHub repo</div>
+          </div>
+        </div>
+        <div className="container content-container">
+          <div className="repo-list">
+            {this.state.reposResponse.repo.slice(0, this.state.limit).map((repo) => {
+              const [owner, repoName] = parseOwnerRepo(repo.url);
+              return (
+                <div className="repo-item">
+                  <div className="owner-repo">
+                    <span>{owner}</span>
+                    <span className="repo-owner-separator">/</span>
+                    <span className="repo-name">{repoName}</span>
+                  </div>
+                  {alreadyImportedUrls.has(repo.url) ? (
+                    <div className="imported-indicator">
+                      <img src="/image/check.svg" title="Already imported" alt="" />
+                    </div>
+                  ) : isImporting && this.state.importRequest?.gitRepo?.repoUrl === repo.url ? (
+                    <div className="loading import-loading" />
+                  ) : (
+                    <FilledButton disabled={isImporting} onClick={this.onClickImport.bind(this, repo.url)}>
+                      Import
+                    </FilledButton>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          {this.state.limit < this.state.reposResponse.repo.length && (
+            <div className="show-more-button-container">
+              <OutlinedButton className="show-more-button" onClick={this.onClickShowMore.bind(this)}>
+                <span>Show more repos</span>
+                <img src="/image/chevrons-down.svg" alt="" className="show-more-icon" />
+              </OutlinedButton>
+            </div>
+          )}
+          <div className="import-other-container">
+            <a
+              className="import-other clickable"
+              href="/workflows/new/custom"
+              onClick={this.onClickImportOther.bind(this)}>
+              Import from another Git provider <img src="/image/arrow-right.svg" alt=""></img>
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+function parseOwnerRepo(url: string): [string, string] {
+  return new URL(url).pathname.split("/").slice(1, 3) as [string, string];
+}
+
+/* Returns a GitHub URL that pre-fills buildbuddy.yaml */
+function generateBuildBuddyYamlSetupUrl(repoUrl: string, branchName: string) {
+  const params = new URLSearchParams({
+    filename: "buildbuddy.yaml",
+    value: `name: Build and test
+triggers:
+  push:
+    branches: [ "${branchName}" ]
+  pull_request:
+    branches: [ "${branchName}" ]
+bazel_commands:
+  # See https://docs.buildbuddy.io/docs/workflow-guide
+  - test //... --build_metadata=ROLE=CI
+`,
+  });
+  return `${repoUrl}/new/${branchName}?${params}`;
+}

--- a/enterprise/app/workflows/github_import.tsx
+++ b/enterprise/app/workflows/github_import.tsx
@@ -1,8 +1,5 @@
 import React from "react";
 import FilledButton, { OutlinedButton } from "../../../app/components/button/button";
-import FilledLinkButton from "../../../app/components/button/link_button";
-import Dialog, { DialogBody, DialogHeader, DialogTitle } from "../../../app/components/dialog/dialog";
-import Modal from "../../../app/components/modal/modal";
 import errorService from "../../../app/errors/error_service";
 import router from "../../../app/router/router";
 import rpcService from "../../../app/service/rpc_service";
@@ -151,22 +148,4 @@ export default class GitHubImport extends React.Component<GitHubRepoPickerProps,
 
 function parseOwnerRepo(url: string): [string, string] {
   return new URL(url).pathname.split("/").slice(1, 3) as [string, string];
-}
-
-/* Returns a GitHub URL that pre-fills buildbuddy.yaml */
-function generateBuildBuddyYamlSetupUrl(repoUrl: string, branchName: string) {
-  const params = new URLSearchParams({
-    filename: "buildbuddy.yaml",
-    value: `name: Build and test
-triggers:
-  push:
-    branches: [ "${branchName}" ]
-  pull_request:
-    branches: [ "${branchName}" ]
-bazel_commands:
-  # See https://docs.buildbuddy.io/docs/workflow-guide
-  - test //... --build_metadata=ROLE=CI
-`,
-  });
-  return `${repoUrl}/new/${branchName}?${params}`;
 }

--- a/enterprise/app/workflows/github_import.tsx
+++ b/enterprise/app/workflows/github_import.tsx
@@ -9,21 +9,20 @@ import { workflow } from "../../../proto/workflow_ts_proto";
 type GitHubRepoPickerProps = {};
 
 type State = {
-  limit: number;
-
   reposResponse?: workflow.IGetReposResponse;
+  repoListLimit: number;
   workflowsResponse?: workflow.IGetWorkflowsResponse;
   error?: BuildBuddyError;
 
   importRequest?: workflow.ICreateWorkflowRequest;
 };
 
-const DEFAULT_REPO_LIMIT = 6;
-const SHOW_MORE_INCREMENT = 10;
+const REPO_LIST_DEFAULT_LIMIT = 6;
+const REPO_LIST_SHOW_MORE_INCREMENT = 10;
 
 export default class GitHubImport extends React.Component<GitHubRepoPickerProps, State> {
   state: State = {
-    limit: DEFAULT_REPO_LIMIT,
+    repoListLimit: REPO_LIST_DEFAULT_LIMIT,
   };
 
   componentDidMount() {
@@ -57,7 +56,7 @@ export default class GitHubImport extends React.Component<GitHubRepoPickerProps,
   }
 
   private onClickShowMore() {
-    this.setState({ limit: this.state.limit + SHOW_MORE_INCREMENT });
+    this.setState({ repoListLimit: this.state.repoListLimit + REPO_LIST_SHOW_MORE_INCREMENT });
   }
 
   private onClickWorkflowBreadcrumb(e: React.MouseEvent) {
@@ -100,7 +99,7 @@ export default class GitHubImport extends React.Component<GitHubRepoPickerProps,
         </div>
         <div className="container content-container">
           <div className="repo-list">
-            {this.state.reposResponse.repo.slice(0, this.state.limit).map((repo) => {
+            {this.state.reposResponse.repo.slice(0, this.state.repoListLimit).map((repo) => {
               const [owner, repoName] = parseOwnerRepo(repo.url);
               return (
                 <div className="repo-item">
@@ -124,7 +123,7 @@ export default class GitHubImport extends React.Component<GitHubRepoPickerProps,
               );
             })}
           </div>
-          {this.state.limit < this.state.reposResponse.repo.length && (
+          {this.state.repoListLimit < this.state.reposResponse.repo.length && (
             <div className="show-more-button-container">
               <OutlinedButton className="show-more-button" onClick={this.onClickShowMore.bind(this)}>
                 <span>Show more repos</span>

--- a/enterprise/app/workflows/workflows.css
+++ b/enterprise/app/workflows/workflows.css
@@ -164,6 +164,131 @@
   width: 100%;
 }
 
+/* GITHUB IMPORT */
+
+.workflows-github-import .content-container {
+  width: 480px;
+  max-width: 100%;
+}
+
+.workflows-github-import .content-container > :not(:last-child) {
+  margin-bottom: 8px;
+}
+
+.workflows-github-import .repo-list {
+  margin-top: 16px;
+}
+
+.workflows-github-import .repo-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+  border-bottom: 1px solid #eee;
+}
+
+.workflows-github-import .repo-item > :not(:last-child) {
+  margin-right: 8px;
+}
+
+.workflows-github-import .repo-owner-separator {
+  color: #777;
+  padding: 0 2px;
+}
+
+.workflows-github-import .repo-name {
+  font-weight: 600;
+}
+
+.workflows-github-import .imported-indicator,
+.workflows-github-import .import-loading {
+  text-align: center;
+  flex-grow: initial;
+
+  /* Match button sizing. */
+  width: 85px;
+  height: 40px;
+  padding: 8px 0;
+  box-sizing: border-box;
+}
+
+.workflows-github-import .show-more-button-container {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.workflows-github-import .show-more-button > :not(:last-child) {
+  margin-right: 8px;
+}
+
+.workflows-github-import .show-more-icon {
+  opacity: 0.7;
+}
+
+.workflows-github-import .import-other-container {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+
+.workflows-github-import .import-other,
+.workflows-github-import-dialog .do-later {
+  display: flex;
+  align-items: center;
+  padding: 8px 0;
+  font-weight: 600;
+  font-size: 14px;
+  opacity: 0.7;
+}
+
+.workflows-github-import .import-other img,
+.workflows-github-import-dialog .do-later img {
+  width: 16px;
+  height: 16px;
+}
+
+.workflows-github-import .import-other > :not(:last-child),
+.workflows-github-import-dialog .do-later > :not(:last-child) {
+  margin-right: 8px;
+}
+
+.workflows-github-import .import-other:hover,
+.workflows-github-import-dialog .do-later:hover {
+  opacity: 1;
+}
+
+.workflows-github-import-dialog .inline-code {
+  font-family: "Source Code Pro", monospace;
+  background: #fafafa;
+  border-radius: 2px;
+  border: 1px solid #eee;
+  padding: 2px 4px;
+}
+
+.workflows-github-import-dialog .import-dialog-buttons {
+  margin-top: 16px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.workflows-github-import-dialog .import-dialog-buttons > :not(:last-child) {
+  margin-right: 8px;
+}
+
+.workflows-github-import-dialog .import-dialog-link-button a {
+  display: flex;
+  align-items: center;
+}
+
+.workflows-github-import-dialog .import-dialog-link-button a > :not(:last-child) {
+  margin-right: 8px;
+}
+
+.workflows-github-import-dialog .import-dialog-link-button img {
+  width: 22px;
+  height: 22px;
+}
+
 /* ANIMATION STUFF BELOW */
 
 .workflows-page .no-workflows-card {

--- a/enterprise/app/workflows/workflows.css
+++ b/enterprise/app/workflows/workflows.css
@@ -231,8 +231,7 @@
   margin-top: 16px;
 }
 
-.workflows-github-import .import-other,
-.workflows-github-import-dialog .do-later {
+.workflows-github-import .import-other {
   display: flex;
   align-items: center;
   padding: 8px 0;
@@ -241,52 +240,17 @@
   opacity: 0.7;
 }
 
-.workflows-github-import .import-other img,
-.workflows-github-import-dialog .do-later img {
+.workflows-github-import .import-other img {
   width: 16px;
   height: 16px;
 }
 
-.workflows-github-import .import-other > :not(:last-child),
-.workflows-github-import-dialog .do-later > :not(:last-child) {
+.workflows-github-import .import-other > :not(:last-child) {
   margin-right: 8px;
 }
 
-.workflows-github-import .import-other:hover,
-.workflows-github-import-dialog .do-later:hover {
+.workflows-github-import .import-other:hover {
   opacity: 1;
-}
-
-.workflows-github-import-dialog .inline-code {
-  font-family: "Source Code Pro", monospace;
-  background: #fafafa;
-  border-radius: 2px;
-  border: 1px solid #eee;
-  padding: 2px 4px;
-}
-
-.workflows-github-import-dialog .import-dialog-buttons {
-  margin-top: 16px;
-  display: flex;
-  justify-content: space-between;
-}
-
-.workflows-github-import-dialog .import-dialog-buttons > :not(:last-child) {
-  margin-right: 8px;
-}
-
-.workflows-github-import-dialog .import-dialog-link-button a {
-  display: flex;
-  align-items: center;
-}
-
-.workflows-github-import-dialog .import-dialog-link-button a > :not(:last-child) {
-  margin-right: 8px;
-}
-
-.workflows-github-import-dialog .import-dialog-link-button img {
-  width: 22px;
-  height: 22px;
 }
 
 /* ANIMATION STUFF BELOW */

--- a/enterprise/app/workflows/workflows.tsx
+++ b/enterprise/app/workflows/workflows.tsx
@@ -1,17 +1,7 @@
 import React from "react";
 import { from, Subscription } from "rxjs";
 import { User } from "../../../app/auth/auth_service";
-import Button, {
-  OutlinedButton,
-} from "../../../app/components/button/button";
-import router from "../../../app/router/router";
-import rpcService from "../../../app/service/rpc_service";
-import { BuildBuddyError } from "../../../app/util/errors";
-import { workflow } from "../../../proto/workflow_ts_proto";
-import CreateWorkflowComponent from "./create_workflow";
-import WorkflowsZeroStateAnimation from "./zero_state";
-import Popup from "../../../app/components/popup/popup";
-import Menu, { MenuItem } from "../../../app/components/menu/menu";
+import Button, { OutlinedButton } from "../../../app/components/button/button";
 import Dialog, {
   DialogBody,
   DialogFooter,
@@ -19,8 +9,17 @@ import Dialog, {
   DialogHeader,
   DialogTitle,
 } from "../../../app/components/dialog/dialog";
+import Menu, { MenuItem } from "../../../app/components/menu/menu";
 import Modal from "../../../app/components/modal/modal";
+import Popup from "../../../app/components/popup/popup";
+import router from "../../../app/router/router";
+import rpcService from "../../../app/service/rpc_service";
 import { copyToClipboard } from "../../../app/util/clipboard";
+import { BuildBuddyError } from "../../../app/util/errors";
+import { workflow } from "../../../proto/workflow_ts_proto";
+import CreateWorkflowComponent from "./create_workflow";
+import GitHubImport from "./github_import";
+import WorkflowsZeroStateAnimation from "./zero_state";
 
 type Workflow = workflow.GetWorkflowsResponse.IWorkflow;
 
@@ -33,7 +32,17 @@ export default class WorkflowsComponent extends React.Component<WorkflowsProps> 
   render() {
     const { path, user } = this.props;
 
-    if (path.startsWith("/workflows/new")) {
+    if (path === "/workflows/new") {
+      if (user.selectedGroup.githubLinked) {
+        return <GitHubImport />;
+      } else {
+        return <CreateWorkflowComponent user={user} />;
+      }
+    }
+    if (path === "/workflows/new/github") {
+      return <GitHubImport />;
+    }
+    if (path === "/workflows/new/custom") {
       return <CreateWorkflowComponent user={user} />;
     }
 

--- a/static/image/arrow-right.svg
+++ b/static/image/arrow-right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-arrow-right"><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"></polyline></svg>

--- a/static/image/check.svg
+++ b/static/image/check.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#29772C"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class="feather feather-check"
+>
+  <polyline points="20 6 9 17 4 12"></polyline>
+</svg>

--- a/static/image/chevrons-down.svg
+++ b/static/image/chevrons-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevrons-down"><polyline points="7 13 12 18 17 13"></polyline><polyline points="7 6 12 11 17 6"></polyline></svg>


### PR DESCRIPTION
If the currently selected group has a GitHub account linked, we show the user a list of their GitHub repos (which they can import with one-click). Previously, we would make them fill out a form.

If the user doesn't see one of their GitHub repos in the list, or wants to import from BitBucket / GitLab, they can still access the form using "Import from another Git provider" at the bottom of the GitHub repo list.

Screenshot:

![image](https://user-images.githubusercontent.com/2414826/116288037-15898d80-a75f-11eb-9fab-52091f9de38d.png)


TODO (future PRs):
* Add a "configure" button to the workflows view that sends the user to a nice URL with a pre-configured `buildbuddy.yaml` (or just link to docs for Git providers that don't support `/new` URLs like GitHub does)
* Add a "View docs" button to the workflows view.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
