### PR TITLE
Fix gosec issues with severity MEDIUM or higher

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -45,7 +45,7 @@ const (
 	// NB: This value must match the value in
 	// bb/server/rpc/filters/filters.go which copies/reads this value
 	// to/from the outgoing/incoming request contexts.
-	contextTokenStringKey = "x-buildbuddy-jwt"
+	contextTokenStringKey = "x-buildbuddy-jwt" // #nosec G101
 
 	// The key that the basicAuth object is stored under in the
 	// context.

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -599,7 +599,7 @@ func setupGitRepo(ctx context.Context) error {
 		}
 	}
 
-	if err := os.Mkdir(repoDirName, 0o775); err != nil {
+	if err := os.Mkdir(repoDirName, 0750); err != nil {
 		return status.WrapErrorf(err, "mkdir %q", repoDirName)
 	}
 

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -718,7 +718,7 @@ func matchesAnyBranch(branches []string, branch string) bool {
 }
 
 func runCommand(ctx context.Context, executable string, args []string, env map[string]string, outputSink io.Writer) error {
-	cmd := exec.CommandContext(ctx, executable, args...)
+	cmd := exec.CommandContext(ctx, executable, args...) // #nosec G204
 	cmd.Stdout = outputSink
 	cmd.Stderr = outputSink
 	for k, v := range env {

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -390,7 +390,7 @@ func runnerBinaryFile() (*os.File, error) {
 	if err != nil {
 		return nil, status.FailedPreconditionErrorf("could not find runner binary runfile: %s", err)
 	}
-	return os.Open(path)
+	return os.Open(filepath.Clean(path))
 }
 
 func (ws *workflowService) apiKeyForWorkflow(ctx context.Context, wf *tables.Workflow) (*tables.APIKey, error) {

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -123,12 +123,12 @@ func (c *GithubClient) Link(w http.ResponseWriter, r *http.Request) {
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := client.Do(req)
-	defer resp.Body.Close()
 	if err != nil {
 		log.Warningf("Error getting access token: %v", err)
 		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 		return
 	}
+	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -82,15 +82,15 @@ func (c *GithubClient) Link(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		state_string := strconv.FormatUint(state, 10)
-		setCookie(w, stateCookieName, state_string)
+		stateString := strconv.FormatUint(state, 10)
+		setCookie(w, stateCookieName, stateString)
 		setCookie(w, redirectCookieName, r.FormValue("redirect_url"))
 
 		appURL := c.env.GetConfigurator().GetAppBuildBuddyURL()
 		url := fmt.Sprintf(
 			"https://github.com/login/oauth/authorize?client_id=%s&state=%s&redirect_uri=%s&scope=%s",
 			githubConfig.ClientID,
-			state_string,
+			stateString,
 			appURL+"/auth/github/link/",
 			"repo")
 		http.Redirect(w, r, url, http.StatusTemporaryRedirect)

--- a/server/build_event_protocol/build_event_handler/BUILD
+++ b/server/build_event_protocol/build_event_handler/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//server/metrics",
         "//server/remote_cache/hit_tracker",
         "//server/tables",
+        "//server/util/id",
         "//server/util/log",
         "//server/util/perms",
         "//server/util/protofile",

--- a/server/build_event_protocol/target_tracker/BUILD
+++ b/server/build_event_protocol/target_tracker/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//server/build_event_protocol/accumulator",
         "//server/environment",
         "//server/tables",
+        "//server/util/id",
         "//server/util/log",
         "//server/util/perms",
         "//server/util/query_builder",

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -283,7 +284,7 @@ func readConfig(fullConfigPath string) (*generalConfig, error) {
 		return nil, fmt.Errorf("Config file %s not found", fullConfigPath)
 	}
 
-	fileBytes, err := ioutil.ReadFile(fullConfigPath)
+	fileBytes, err := ioutil.ReadFile(filepath.Clean(fullConfigPath))
 	if err != nil {
 		return nil, fmt.Errorf("Error reading config file: %s", err)
 	}

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
@@ -67,7 +68,7 @@ func ComputeDigest(in io.ReadSeeker, instanceName string) (*digest.InstanceNameD
 }
 
 func ComputeFileDigest(fullFilePath, instanceName string) (d *digest.InstanceNameDigest, err error) {
-	f, err := os.Open(fullFilePath)
+	f, err := os.Open(filepath.Clean(fullFilePath))
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +187,7 @@ func UploadBlob(ctx context.Context, bsClient bspb.ByteStreamClient, instanceNam
 }
 
 func UploadFile(ctx context.Context, bsClient bspb.ByteStreamClient, instanceName, fullFilePath string) (d *repb.Digest, err error) {
-	f, err := os.Open(fullFilePath)
+	f, err := os.Open(filepath.Clean(fullFilePath))
 	if err != nil {
 		return
 	}

--- a/server/ssl/ssl.go
+++ b/server/ssl/ssl.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -261,12 +262,12 @@ func (s *SSLService) GenerateCerts(apiKey string) (string, string, error) {
 }
 
 func loadX509KeyPair(certFile, keyFile string) (*x509.Certificate, *rsa.PrivateKey, error) {
-	cf, err := ioutil.ReadFile(certFile)
+	cf, err := ioutil.ReadFile(filepath.Clean(certFile))
 	if err != nil {
 		return nil, nil, err
 	}
 
-	kf, err := ioutil.ReadFile(keyFile)
+	kf, err := ioutil.ReadFile(filepath.Clean(keyFile))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -44,7 +44,11 @@ func GetAllTables() []interface{} {
 func PrimaryKeyForTable(tableName string) (string, error) {
 	for _, d := range allTables {
 		if d.name == tableName {
-			return fmt.Sprintf("%s%d", d.prefix, random.RandUint64()), nil
+			n, err := random.RandUint64()
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("%s%d", d.prefix, n), nil
 		}
 	}
 	return "", fmt.Errorf("Unknown table: %s", tableName)

--- a/server/telemetry/telemetry_client.go
+++ b/server/telemetry/telemetry_client.go
@@ -145,7 +145,7 @@ func getAppVersion() string {
 		log.Debugf("Error reading getting version file path: %s", err)
 		return unknownFieldValue
 	}
-	versionBytes, err := ioutil.ReadFile(filepath.Join(rfp, versionFilename))
+	versionBytes, err := ioutil.ReadFile(filepath.Clean(filepath.Join(rfp, versionFilename)))
 	if err != nil {
 		log.Debugf("Error reading version file: %s", err)
 		return unknownFieldValue

--- a/server/testutil/app/app.go
+++ b/server/testutil/app/app.go
@@ -72,7 +72,7 @@ func Run(t *testing.T, commandPath string, commandArgs []string, configFilePath 
 		fmt.Sprintf("--cache.disk.root_directory=%s", filepath.Join(dataDir, "cache")),
 	}
 	args = append(args, commandArgs...)
-	cmd := exec.Command(runfile(t, commandPath), args...)
+	cmd := exec.Command(runfile(t, commandPath), args...) // #nosec G204
 	// TODO: Write server logs to files so they can be used to debug failed tests
 	cmd.Stdout = &app.stdout
 	cmd.Stderr = &app.stderr

--- a/server/testutil/bazel/bazel.go
+++ b/server/testutil/bazel/bazel.go
@@ -45,7 +45,7 @@ func Invoke(ctx context.Context, t *testing.T, workspaceDir string, subCommand s
 	bazelArgs := []string{"--max_idle_secs=5", subCommand}
 	bazelArgs = append(bazelArgs, args...)
 	var stderr, stdout bytes.Buffer
-	cmd := exec.CommandContext(ctx, bazelBinaryPath, bazelArgs...)
+	cmd := exec.CommandContext(ctx, bazelBinaryPath, bazelArgs...) // #nosec G204
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	cmd.Dir = workspaceDir

--- a/server/testutil/bazel/bazel.go
+++ b/server/testutil/bazel/bazel.go
@@ -97,10 +97,10 @@ func MakeTempWorkspace(t *testing.T, contents map[string]string) string {
 	})
 	for path, fileContents := range contents {
 		fullPath := filepath.Join(workspaceDir, path)
-		if err := os.MkdirAll(filepath.Dir(fullPath), 0777); err != nil {
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0750); err != nil {
 			t.Fatal(err)
 		}
-		if err := ioutil.WriteFile(fullPath, []byte(fileContents), 0777); err != nil {
+		if err := ioutil.WriteFile(fullPath, []byte(fileContents), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/server/testutil/testdigest/testdigest.go
+++ b/server/testutil/testdigest/testdigest.go
@@ -70,7 +70,12 @@ func NewRandomDigestBuf(t testing.TB, sizeBytes int64) (*repb.Digest, []byte) {
 }
 
 func ReadDigestAndClose(t *testing.T, r io.ReadCloser) *repb.Digest {
-	defer r.Close()
+	defer func() {
+		cerr := r.Close()
+		if cerr != nil {
+			t.Fatal(cerr)
+		}
+	}()
 
 	d, err := realdigest.Compute(r)
 	if err != nil {

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -114,7 +114,7 @@ func writeTmpConfigFile(testRootDir string) (string, error) {
 		return "", err
 	}
 	configPath := filepath.Join(testRootDir, "config.yaml")
-	if err := ioutil.WriteFile(configPath, buf.Bytes(), 0644); err != nil {
+	if err := ioutil.WriteFile(configPath, buf.Bytes(), 0600); err != nil {
 		return "", err
 	}
 	return configPath, nil

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -50,7 +50,7 @@ func WriteFile(ctx context.Context, fullPath string, data []byte) (int, error) {
 }
 
 func ReadFile(ctx context.Context, fullPath string) ([]byte, error) {
-	data, err := ioutil.ReadFile(fullPath)
+	data, err := ioutil.ReadFile(filepath.Clean(fullPath))
 	if os.IsNotExist(err) {
 		return nil, status.NotFoundError(err.Error())
 	}
@@ -81,7 +81,7 @@ type SectionReaderCloser struct {
 }
 
 func FileReader(ctx context.Context, fullPath string, offset, length int64) (*SectionReaderCloser, error) {
-	f, err := os.Open(fullPath)
+	f, err := os.Open(filepath.Clean(fullPath))
 	if err != nil {
 		return nil, err
 	}

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -112,23 +112,18 @@ func FileWriter(ctx context.Context, fullPath string) (io.WriteCloser, error) {
 	if err := EnsureDirectoryExists(filepath.Dir(fullPath)); err != nil {
 		return nil, err
 	}
-	randStr, err := random.RandomString(10)
-	if err != nil {
-		return nil, err
-	}
 
-	tmpFileName := fullPath + fmt.Sprintf(".%s.tmp", randStr)
-	f, err := os.OpenFile(tmpFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	tmpFile, err := ioutil.TempFile(filepath.Dir(fullPath), fmt.Sprintf("%s.*.tmp", filepath.Base(fullPath)))
 	if err != nil {
 		return nil, err
 	}
 	wm := &writeMover{
-		File:      f,
+		File:      tmpFile,
 		finalPath: fullPath,
 	}
 	// Ensure that the temp file is cleaned up here too!
 	runtime.SetFinalizer(wm, func(m *writeMover) {
-		DeleteLocalFileIfExists(tmpFileName)
+		DeleteLocalFileIfExists(tmpFile.Name())
 	})
 	return wm, nil
 }

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -15,7 +15,7 @@ import (
 
 func EnsureDirectoryExists(dir string) error {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		return os.MkdirAll(dir, 0755)
+		return os.MkdirAll(dir, 0750)
 	}
 	return nil
 }
@@ -43,7 +43,7 @@ func WriteFile(ctx context.Context, fullPath string, data []byte) (int, error) {
 	// still remove the tmp file.
 	defer DeleteLocalFileIfExists(tmpFileName)
 
-	if err := ioutil.WriteFile(tmpFileName, data, 0644); err != nil {
+	if err := ioutil.WriteFile(tmpFileName, data, 0600); err != nil {
 		return 0, err
 	}
 	return len(data), os.Rename(tmpFileName, fullPath)

--- a/server/util/id/BUILD
+++ b/server/util/id/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "id",
+    srcs = ["id.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/id",
+    visibility = ["//visibility:public"],
+)

--- a/server/util/id/id.go
+++ b/server/util/id/id.go
@@ -1,0 +1,17 @@
+package id
+
+import (
+	//MD5 is fine here, it's just making an ID and is not a security application
+	"crypto/md5" // #nosec G501
+	"encoding/binary"
+)
+
+func InvocationPKFromID(iid string) int64 {
+	hash := md5.Sum([]byte(iid)) // #nosec G401
+	return int64(binary.BigEndian.Uint64(hash[:8]))
+}
+
+func TargetIDFromTargetPath(path string) int64 {
+	hash := md5.Sum([]byte(path)) // #nosec G401
+	return int64(binary.BigEndian.Uint64(hash[:8]))
+}

--- a/server/util/random/random.go
+++ b/server/util/random/random.go
@@ -1,38 +1,26 @@
 package random
 
 import (
-	"io"
-	"sync"
-	"time"
-
-	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-
-	crand "crypto/rand"
-	mrand "math/rand"
+	"crypto/rand"
+	"math/big"
 )
 
-var once sync.Once
-
-func init() {
-	// Check that rand is working -- bail if not.
-	buf := make([]byte, 1)
-	if _, err := io.ReadFull(crand.Reader, buf); err != nil {
-		log.Fatalf("crypto/rand is unavailable: %s", err)
+func RandUint64() (uint64, error) {
+	max := big.NewInt(0)
+	// SetBytes is BE   0  1  2  3  4  5  6  7  8
+	max.SetBytes([]byte{1, 0, 0, 0, 0, 0, 0, 0, 0})
+	rand.Int(rand.Reader, max)
+	n, err := rand.Int(rand.Reader, max)
+	if err != nil {
+		return 0, err
 	}
-}
-
-func RandUint64() uint64 {
-	once.Do(func() {
-		mrand.Seed(time.Now().UnixNano())
-		log.Debugf("Seeded random with current time!")
-	})
-	return mrand.Uint64()
+	return n.Uint64(), nil
 }
 
 func RandomString(stringLength int) (string, error) {
 	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 	bytes := make([]byte, stringLength)
-	if _, err := crand.Read(bytes); err != nil {
+	if _, err := rand.Read(bytes); err != nil {
 		return "", err
 	}
 	// Run through bytes; replacing each with the equivalent random char.

--- a/server/version/version.go
+++ b/server/version/version.go
@@ -36,7 +36,7 @@ func AppVersion(in ...[]byte) string {
 		versionBytes = in[0]
 	} else if rfp, err := bazel.RunfilesPath(); err == nil {
 		versionFile := filepath.Join(rfp, versionFilename)
-		if b, err := ioutil.ReadFile(versionFile); err == nil {
+		if b, err := ioutil.ReadFile(filepath.Clean(versionFile)); err == nil {
 			versionBytes = b
 		}
 	}


### PR DESCRIPTION
- Fix use of weak random number generator (gosec)
- Fix use before error check (vim-go)
- Fix potential file inclusion via variable
- Fix deferring unsafe Close
- Silence gosec warnings for false positives
- Clean filepaths for gosec
- Tighten file and directory perms for gosec
- Move permissible md5 hashing to a utility with very narrow scope
- Clear gosec false positive for hard-coded credential
- missing filepath imports for potential file inclusion commit

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->
Prepare buildbuddy repo for addition of a `gosec` github action.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
