### PR TITLE
Fix permission bits bug in UploadFiles

### DIFF
--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -482,6 +482,9 @@ func uploadDir(ul *BatchCASUploader, dirPath string, visited []*repb.Directory) 
 				return nil, nil, err
 			}
 			info, err := entry.Info()
+			if err != nil {
+				return nil, nil, err
+			}
 			dir.Files = append(dir.Files, &repb.FileNode{
 				Name:         name,
 				Digest:       d,

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -458,15 +458,15 @@ func uploadDir(ul *BatchCASUploader, dirPath string, visited []*repb.Directory) 
 	// Append the directory before doing any other work, so that the root
 	// directory is located at visited[0] at the end of recursion.
 	visited = append(visited, dir)
-	infos, err := os.ReadDir(dirPath)
+	entries, err := os.ReadDir(dirPath)
 	if err != nil {
 		return nil, nil, err
 	}
-	for _, info := range infos {
-		name := info.Name()
+	for _, entry := range entries {
+		name := entry.Name()
 		path := filepath.Join(dirPath, name)
 
-		if info.IsDir() {
+		if entry.IsDir() {
 			var d *repb.Digest
 			visited, d, err = uploadDir(ul, path, visited)
 			if err != nil {
@@ -476,17 +476,18 @@ func uploadDir(ul *BatchCASUploader, dirPath string, visited []*repb.Directory) 
 				Name:   name,
 				Digest: d,
 			})
-		} else if info.Type().IsRegular() {
+		} else if entry.Type().IsRegular() {
 			d, err := ul.UploadFile(path)
 			if err != nil {
 				return nil, nil, err
 			}
+			info, err := entry.Info()
 			dir.Files = append(dir.Files, &repb.FileNode{
 				Name:         name,
 				Digest:       d,
-				IsExecutable: info.Type()&0100 != 0,
+				IsExecutable: info.Mode()&0100 != 0,
 			})
-		} else if info.Type()&os.ModeSymlink == os.ModeSymlink {
+		} else if entry.Type()&os.ModeSymlink == os.ModeSymlink {
 			target, err := os.Readlink(path)
 			if err != nil {
 				return nil, nil, err


### PR DESCRIPTION
Note that this code isn't used yet, but will be used starting with https://github.com/buildbuddy-io/buildbuddy-internal/pull/433 (which needs this bugfix to fix broken tests)

The bug is that after switching from `ioutil.ReadDir` to `os.ReadDir`, the call to `fileInfo.Mode()` was incorrectly migrated to `dirEntry.Type()` when checking the permission bits, which is wrong since `Type` only includes the type bits.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
