### PR TITLE
Add config option to append a suffix to GitHub status check names

### DIFF
--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -138,7 +138,7 @@ func (r *BuildStatusReporter) newGithubStatusPayload(name, URL, description stri
 	if r.statusNameSuffix != "" {
 		name = fmt.Sprintf("%s %s", name, r.statusNameSuffix)
 	}
-	return r.newGithubStatusPayload(name, URL, description, state)
+	return github.NewGithubStatusPayload(name, URL, description, state)
 }
 
 func (r *BuildStatusReporter) githubPayloadFromWorkspaceStatusEvent(event *build_event_stream.BuildEvent) *github.GithubStatusPayload {

--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -19,11 +19,14 @@ type BuildStatusReporter struct {
 	env                       environment.Env
 	githubClient              *github.GithubClient
 	shouldReportStatusPerTest bool
-	statusNameSuffix          string
-	buildEventAccumulator     *accumulator.BEValues
-	payloads                  []*github.GithubStatusPayload
-	groups                    map[string]*GroupStatus
-	inFlight                  map[string]bool
+	// Suffix that gets appended to all reported status names. Useful for
+	// differentiating statuses reported by BuildBuddy deployment environments.
+	// Example: "(dev)"
+	statusNameSuffix      string
+	buildEventAccumulator *accumulator.BEValues
+	payloads              []*github.GithubStatusPayload
+	groups                map[string]*GroupStatus
+	inFlight              map[string]bool
 }
 
 type GroupStatus struct {

--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -19,6 +19,7 @@ type BuildStatusReporter struct {
 	env                       environment.Env
 	githubClient              *github.GithubClient
 	shouldReportStatusPerTest bool
+	statusNameSuffix          string
 	buildEventAccumulator     *accumulator.BEValues
 	payloads                  []*github.GithubStatusPayload
 	groups                    map[string]*GroupStatus
@@ -36,14 +37,16 @@ type GroupStatus struct {
 func NewBuildStatusReporter(env environment.Env, buildEventAccumulator *accumulator.BEValues) *BuildStatusReporter {
 	githubConfig := env.GetConfigurator().GetGithubConfig()
 	shouldReportStatusPerTest := false
-
+	statusNameSuffix := ""
 	if githubConfig != nil {
 		shouldReportStatusPerTest = githubConfig.StatusPerTestTarget
+		statusNameSuffix = githubConfig.StatusNameSuffix
 	}
 
 	return &BuildStatusReporter{
 		env:                       env,
 		shouldReportStatusPerTest: shouldReportStatusPerTest,
+		statusNameSuffix:          statusNameSuffix,
 		buildEventAccumulator:     buildEventAccumulator,
 		payloads:                  make([]*github.GithubStatusPayload, 0),
 		inFlight:                  make(map[string]bool),
@@ -97,7 +100,7 @@ func (r *BuildStatusReporter) ReportStatusForEvent(ctx context.Context, event *b
 
 func (r *BuildStatusReporter) ReportDisconnect(ctx context.Context) {
 	for label := range r.inFlight {
-		r.payloads = append(r.payloads, github.NewGithubStatusPayload(label, r.invocationURL(), "Disconnected", github.ErrorState))
+		r.payloads = append(r.payloads, r.newGithubStatusPayload(label, r.invocationURL(), "Disconnected", github.ErrorState))
 	}
 	r.flushPayloadsIfWorkspaceLoaded(ctx)
 }
@@ -131,8 +134,15 @@ func (r *BuildStatusReporter) flushPayloadsIfWorkspaceLoaded(ctx context.Context
 	r.payloads = make([]*github.GithubStatusPayload, 0)
 }
 
+func (r *BuildStatusReporter) newGithubStatusPayload(name, URL, description string, state github.State) *github.GithubStatusPayload {
+	if r.statusNameSuffix != "" {
+		name = fmt.Sprintf("%s %s", name, r.statusNameSuffix)
+	}
+	return r.newGithubStatusPayload(name, URL, description, state)
+}
+
 func (r *BuildStatusReporter) githubPayloadFromWorkspaceStatusEvent(event *build_event_stream.BuildEvent) *github.GithubStatusPayload {
-	return github.NewGithubStatusPayload(r.invocationLabel(), r.invocationURL(), "Running...", github.PendingState)
+	return r.newGithubStatusPayload(r.invocationLabel(), r.invocationURL(), "Running...", github.PendingState)
 }
 
 func (r *BuildStatusReporter) githubPayloadFromConfiguredEvent(event *build_event_stream.BuildEvent) *github.GithubStatusPayload {
@@ -147,10 +157,10 @@ func (r *BuildStatusReporter) githubPayloadFromConfiguredEvent(event *build_even
 	}
 
 	if groupStatus != nil && groupStatus.numTargets == 1 {
-		return github.NewGithubStatusPayload(groupStatus.name, r.groupURL(groupStatus.name), "Running...", github.PendingState)
+		return r.newGithubStatusPayload(groupStatus.name, r.groupURL(groupStatus.name), "Running...", github.PendingState)
 	}
 
-	return github.NewGithubStatusPayload(label, r.targetURL(label), "Running...", github.PendingState)
+	return r.newGithubStatusPayload(label, r.targetURL(label), "Running...", github.PendingState)
 }
 
 func (r *BuildStatusReporter) githubPayloadFromTestSummaryEvent(event *build_event_stream.BuildEvent) *github.GithubStatusPayload {
@@ -168,27 +178,27 @@ func (r *BuildStatusReporter) githubPayloadFromTestSummaryEvent(event *build_eve
 	description := descriptionFromOverallStatus(event.GetTestSummary().OverallStatus)
 
 	if groupStatus != nil && groupStatus.numFailed == 1 {
-		return github.NewGithubStatusPayload(groupStatus.name, r.groupURL(label), description, github.FailureState)
+		return r.newGithubStatusPayload(groupStatus.name, r.groupURL(label), description, github.FailureState)
 	}
 
 	if groupStatus != nil && groupStatus.numPassed == groupStatus.numTargets {
-		return github.NewGithubStatusPayload(groupStatus.name, r.groupURL(label), description, github.SuccessState)
+		return r.newGithubStatusPayload(groupStatus.name, r.groupURL(label), description, github.SuccessState)
 	}
 
 	if passed {
-		return github.NewGithubStatusPayload(label, r.targetURL(label), description, github.SuccessState)
+		return r.newGithubStatusPayload(label, r.targetURL(label), description, github.SuccessState)
 	}
 
-	return github.NewGithubStatusPayload(label, r.targetURL(label), description, github.FailureState)
+	return r.newGithubStatusPayload(label, r.targetURL(label), description, github.FailureState)
 }
 
 func (r *BuildStatusReporter) githubPayloadFromFinishedEvent(event *build_event_stream.BuildEvent) *github.GithubStatusPayload {
 	description := descriptionFromExitCodeName(event.GetFinished().ExitCode.Name)
 	if event.GetFinished().OverallSuccess {
-		return github.NewGithubStatusPayload(r.invocationLabel(), r.invocationURL(), description, github.SuccessState)
+		return r.newGithubStatusPayload(r.invocationLabel(), r.invocationURL(), description, github.SuccessState)
 	}
 
-	return github.NewGithubStatusPayload(r.invocationLabel(), r.invocationURL(), description, github.FailureState)
+	return r.newGithubStatusPayload(r.invocationLabel(), r.invocationURL(), description, github.FailureState)
 }
 
 func (r *BuildStatusReporter) githubPayloadFromAbortedEvent(event *build_event_stream.BuildEvent) *github.GithubStatusPayload {
@@ -203,10 +213,10 @@ func (r *BuildStatusReporter) githubPayloadFromAbortedEvent(event *build_event_s
 	}
 
 	if groupStatus != nil && groupStatus.numAborted == 1 {
-		return github.NewGithubStatusPayload(groupStatus.name, r.groupURL(groupStatus.name), "Cancelled", github.ErrorState)
+		return r.newGithubStatusPayload(groupStatus.name, r.groupURL(groupStatus.name), "Cancelled", github.ErrorState)
 	}
 
-	return github.NewGithubStatusPayload(label, r.targetURL(label), "Cancelled", github.ErrorState)
+	return r.newGithubStatusPayload(label, r.targetURL(label), "Cancelled", github.ErrorState)
 }
 
 func (r *BuildStatusReporter) invocationLabel() string {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -200,6 +200,7 @@ type GithubConfig struct {
 	ClientSecret        string `yaml:"client_secret" usage:"The client secret of your GitHub Oauth App. ** Enterprise only **"`
 	AccessToken         string `yaml:"access_token" usage:"The GitHub access token used to post GitHub commit statuses. ** Enterprise only **"`
 	StatusPerTestTarget bool   `yaml:"status_per_test_target" usage:"If true, report status per test target. ** Enterprise only **"`
+	StatusNameSuffix    string `yaml:"status_name_suffix" usage:"Suffix to be appended to all reported GitHub status names. Useful for differentiating BuildBuddy deployments. For example: '(dev)' ** Enterprise only **"`
 }
 
 type OrgConfig struct {


### PR DESCRIPTION
Since we'll enable workflows for both our dev environment and prod environment, and the status name is solely based on the action name, we'll need a way to tell apart which check corresponds to dev and which check corresponds to prod. The plan is to set this new config value to `(dev)` so that we'll see 2 checks in the GitHub UI -- `Test` and `Test (dev)`

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
