### PR TITLE
Check valid UTF8 on HTTP routes

### DIFF
--- a/server/http/filters/BUILD
+++ b/server/http/filters/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//server/http/protolet",
         "//server/metrics",
         "//server/util/log",
+        "//server/util/status",
         "//server/util/uuid",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_grpc//:go_default_library",


### PR DESCRIPTION
If people make an HTTP request with non-utf8 in the URL, it causes a panic in the Prometheus library, which checks that label values must be UTF-8. Checking valid UTF-8 fixes the panic (verified using `curl`)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
