### PR TITLE
Add GroupID column to ExecutionNodes table.

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -348,6 +348,7 @@ type ExecutionNode struct {
 	Arch                  string
 	Pool                  string
 	SchedulerHostPort     string
+	GroupID               string
 }
 
 func (n *ExecutionNode) TableName() string {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#404 Add GroupID column to ExecutionNodes table.**

This column indicates which group owns the executor.

---

**Version bump**: None
