### PR TITLE
Add config option to enable "non local" scheduling.

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -168,6 +167,7 @@ type RemoteExecutionConfig struct {
 	DisableRedisListPubSub       bool   `yaml:"disable_redis_list_pubsub" usage:"If true, revert to native redis PubSub."`
 	RedisPubSubPoolSize          int    `yaml:"redis_pubsub_pool_size" usage:"Maximum number of connections used for waiting for execution updates."`
 	RequireExecutorAuthorization bool   `yaml:"require_executor_authorization" usage:"If true, executors connecting to this server must provide a valid executor API key."`
+	EnableNonLocalScheduling     bool   `yaml:"enable_non_local_scheduling" usage:"If true, schedulers can make RPCs to other schedulers to enqueue task reservations instead of always talking directly to executors."`
 }
 
 type ExecutorConfig struct {
@@ -287,7 +287,7 @@ func readConfig(fullConfigPath string) (*generalConfig, error) {
 		return nil, fmt.Errorf("Config file %s not found", fullConfigPath)
 	}
 
-	fileBytes, err := ioutil.ReadFile(fullConfigPath)
+	fileBytes, err := os.ReadFile(fullConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading config file: %s", err)
 	}


### PR DESCRIPTION
When this option is enabled, the scheduler server will start using the
EnqueueTaskReservations RPC for executors that are connected with a task
stream.

Note that this is a short-term config option and will be removed after
the feature is fully rolled out.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
