### PR TITLE
Add proto for workflow action metadata

### DIFF
--- a/proto/workflow.proto
+++ b/proto/workflow.proto
@@ -134,3 +134,35 @@ message GetReposResponse {
   // Repos fetched from the provider.
   repeated Repo repo = 2;
 }
+
+// Metadata about a workflow that is sent as part of the build metadata BEP
+// event.
+message WorkflowActionMetadata {
+  // Action name as defined in `buildbuddy.yaml`.
+  //
+  // Example: "Test all targets"
+  string action_name = 1;
+  // Branch that caused the action to be executed.
+  //
+  // Example: "main"
+  string action_trigger_branch = 2;
+  // Webhook event name that triggered the action. Can be one of "push" or
+  // "pull_request".
+  string action_trigger_event = 3;
+
+  // Metadata for a Bazel invocation created by this workflow action.
+  message InvocationMetadata {
+    // Bazel invocation ID (UUIDV4). Should not be set for bazel commands that
+    // do not create invocations, such as `bazel version`.
+    //
+    // Example: "86083af6-4699-4957-a0a3-d6a806104bb3"
+    string invocation_id = 1;
+    // Bazel command as specified in `buildbuddy.yaml`.
+    //
+    // Example: "test //..."
+    string bazel_command = 2;
+  }
+
+  // Bazel commands invoked by the workflow action.
+  repeated InvocationMetadata invocation = 4;
+}

--- a/proto/workflow.proto
+++ b/proto/workflow.proto
@@ -139,13 +139,13 @@ message GetReposResponse {
 // event.
 message WorkflowActionMetadata {
   // Action name as defined in `buildbuddy.yaml`.
-  //
   // Example: "Test all targets"
   string action_name = 1;
+
   // Branch that caused the action to be executed.
-  //
   // Example: "main"
   string action_trigger_branch = 2;
+
   // Webhook event name that triggered the action. Can be one of "push" or
   // "pull_request".
   string action_trigger_event = 3;
@@ -154,11 +154,10 @@ message WorkflowActionMetadata {
   message InvocationMetadata {
     // Bazel invocation ID (UUIDV4). Should not be set for bazel commands that
     // do not create invocations, such as `bazel version`.
-    //
     // Example: "86083af6-4699-4957-a0a3-d6a806104bb3"
     string invocation_id = 1;
+
     // Bazel command as specified in `buildbuddy.yaml`.
-    //
     // Example: "test //..."
     string bazel_command = 2;
   }


### PR DESCRIPTION
Add workflow action metadata proto that we'll deserialize from a base64-encoded build metadata prop called "BUILDBUDDY_WORKFLOW_ACTION_METADATA". The plan is to read this in the UI from the existing build metadata event so that we can render the list of bazel commands and invocation URLs inside the workflow UI.

Will also clean up the existing logic for BUILDBUDDY_ACTION_NAME, BUILDBUDDY_ACTION_TRIGGER_EVENT, BUILDBUDDY_ACTION_TRIGGER_BRANCH, etc. to instead read from this proto.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/469
