### PR TITLE
Use standard API key header in testauth.

### DIFF
--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -55,7 +55,7 @@ func TestCreate(t *testing.T) {
 			RepoUrl: "git@github.com:buildbuddy-io/buildbuddy.git",
 		},
 	}
-	ctx = metadata.AppendToOutgoingContext(ctx, testauth.TestApiKeyHeader, "USER1")
+	ctx = metadata.AppendToOutgoingContext(ctx, testauth.APIKeyHeader, "USER1")
 	rsp, err := bbClient.CreateWorkflow(ctx, req)
 	assert.Nil(t, err)
 	assert.Regexp(t, "^WF.*", rsp.GetId(), "workflow ID should exist and match WF.*")
@@ -92,7 +92,7 @@ func TestDelete(t *testing.T) {
 	assert.Nil(t, err)
 
 	req := &wfpb.DeleteWorkflowRequest{Id: "WF1"}
-	ctx = metadata.AppendToOutgoingContext(ctx, testauth.TestApiKeyHeader, "USER1")
+	ctx = metadata.AppendToOutgoingContext(ctx, testauth.APIKeyHeader, "USER1")
 	_, err = bbClient.DeleteWorkflow(ctx, req)
 	assert.Nil(t, err)
 
@@ -148,12 +148,12 @@ func TestList(t *testing.T) {
 	assert.Nil(t, err)
 
 	req := &wfpb.GetWorkflowsRequest{}
-	ctx1 := metadata.AppendToOutgoingContext(ctx, testauth.TestApiKeyHeader, "USER1")
+	ctx1 := metadata.AppendToOutgoingContext(ctx, testauth.APIKeyHeader, "USER1")
 	rsp, err := bbClient.GetWorkflows(ctx1, req)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(rsp.GetWorkflow()), "Two workflows owned by USER1 should be returned")
 
-	ctx2 := metadata.AppendToOutgoingContext(ctx, testauth.TestApiKeyHeader, "USER2")
+	ctx2 := metadata.AppendToOutgoingContext(ctx, testauth.APIKeyHeader, "USER2")
 	rsp, err = bbClient.GetWorkflows(ctx2, req)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(rsp.GetWorkflow()), "One workflow owned by USER2 should be returned")

--- a/server/build_event_protocol/build_event_handler/build_event_handler_test.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler_test.go
@@ -99,7 +99,7 @@ func TestAuthenticatedHandleEventWithStartedFirst(t *testing.T) {
 	channel := handler.OpenChannel(ctx, "test-invocation-id")
 
 	// Send authenticated started event with api key
-	request := streamRequest(startedEvent("--remote_upload_local_results --remote_header='"+testauth.TestApiKeyHeader+"=USER1' --remote_instance_name=foo"), "test-invocation-id", 1)
+	request := streamRequest(startedEvent("--remote_upload_local_results --remote_header='"+testauth.APIKeyHeader+"=USER1' --remote_instance_name=foo"), "test-invocation-id", 1)
 	err := channel.HandleEvent(request)
 	assert.NoError(t, err)
 
@@ -128,7 +128,7 @@ func TestAuthenticatedHandleEventWithProgressFirst(t *testing.T) {
 	assert.Error(t, err)
 
 	// Send started event with api key
-	request = streamRequest(startedEvent("--remote_header='"+testauth.TestApiKeyHeader+"=USER1'"), "test-invocation-id", 2)
+	request = streamRequest(startedEvent("--remote_header='"+testauth.APIKeyHeader+"=USER1'"), "test-invocation-id", 2)
 	err = channel.HandleEvent(request)
 	assert.NoError(t, err)
 
@@ -188,7 +188,7 @@ func TestHandleEventOver100ProgressEventsBeforeStarted(t *testing.T) {
 	assert.Error(t, err)
 
 	// Send started event with api key
-	request := streamRequest(startedEvent("--remote_header='"+testauth.TestApiKeyHeader+"=USER1'"), "test-invocation-id", 105)
+	request := streamRequest(startedEvent("--remote_header='"+testauth.APIKeyHeader+"=USER1'"), "test-invocation-id", 105)
 	err = channel.HandleEvent(request)
 	assert.NoError(t, err)
 
@@ -222,7 +222,7 @@ func TestHandleEventWithWorkspaceStatusBeforeStarted(t *testing.T) {
 	assert.Error(t, err)
 
 	// Send started event with api key
-	request = streamRequest(startedEvent("--remote_header='"+testauth.TestApiKeyHeader+"=USER1'"), "test-invocation-id", 3)
+	request = streamRequest(startedEvent("--remote_header='"+testauth.APIKeyHeader+"=USER1'"), "test-invocation-id", 3)
 	err = channel.HandleEvent(request)
 	assert.NoError(t, err)
 

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -33,12 +33,12 @@ import (
 const (
 	testAuthenticationHeader = "test-auth-header"
 
-	TestApiKeyHeader = "test-buildbuddy-api-key"
-	jwtHeader        = "x-buildbuddy-jwt"
+	APIKeyHeader = "x-buildbuddy-api-key"
+	jwtHeader    = "x-buildbuddy-jwt"
 )
 
 var (
-	testApiKeyRegex = regexp.MustCompile(TestApiKeyHeader + "=([a-zA-Z0-9]+)")
+	testApiKeyRegex = regexp.MustCompile(APIKeyHeader + "=([a-zA-Z0-9]+)")
 	jwtTestKey      = []byte("testKey")
 )
 
@@ -95,7 +95,7 @@ func NewTestAuthenticator(testUsers map[string]interfaces.UserInfo) *TestAuthent
 }
 
 func (a *TestAuthenticator) AuthenticateHTTPRequest(w http.ResponseWriter, r *http.Request) context.Context {
-	headerVal := r.Header.Get(TestApiKeyHeader)
+	headerVal := r.Header.Get(APIKeyHeader)
 	if user, ok := a.testUsers[headerVal]; ok {
 		return context.WithValue(r.Context(), testAuthenticationHeader, user)
 	}
@@ -104,7 +104,7 @@ func (a *TestAuthenticator) AuthenticateHTTPRequest(w http.ResponseWriter, r *ht
 
 func (a *TestAuthenticator) AuthenticateGRPCRequest(ctx context.Context) context.Context {
 	if grpcMD, ok := metadata.FromIncomingContext(ctx); ok {
-		for _, h := range []string{TestApiKeyHeader, jwtHeader} {
+		for _, h := range []string{APIKeyHeader, jwtHeader} {
 			headerVals := grpcMD[h]
 			for _, headerVal := range headerVals {
 				if user, ok := a.testUsers[headerVal]; ok {


### PR DESCRIPTION
Makes it simple to test clients (e.g. executors) that use the standard
header.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
