### PR TITLE
Switch from nogo excludes to manual includes

### DIFF
--- a/nogo_config.json
+++ b/nogo_config.json
@@ -1,66 +1,78 @@
 {
   "assign": {
-    "exclude_files": {
-      "external/*": "Third party code"
+    "only_files": {
+      "/server/": "Server code",
+      "/enterprise/server/": "Enterprise server code"
     }
   },
   "cgocall": {
-    "exclude_files": {
-      "external/*": "Third party code"
+    "only_files": {
+      "/server/": "Server code",
+      "/enterprise/server/": "Enterprise server code"
     }
   },
   "composites": {
-    "exclude_files": {
-      "external/*": "Third party code"
+    "only_files": {
+      "/server/": "Server code",
+      "/enterprise/server/": "Enterprise server code"
     }
   },
   "copylocks": {
-    "exclude_files": {
-      "external/*": "Third party code"
+    "only_files": {
+      "/server/": "Server code",
+      "/enterprise/server/": "Enterprise server code"
     }
   },
   "fieldalignment": {
+    "only_files": {
+      "/server/": "Server code",
+      "/enterprise/server/": "Enterprise server code"
+    },
     "exclude_files": {
-			".*": "Disable entirely for now",
-      "tmp/*": "Temp generated files",
-      "external/*": "Third party code",
-			".*\\.pb\\.go": "Auto-generated proto files"
+      ".*": "Disable entirely for now",
+      ".*\\.pb\\.go": "Auto-generated proto files"
     }
   },
   "lostcancel": {
-    "exclude_files": {
-      "external/*": "Third party code"
+    "only_files": {
+      "/server/": "Server code",
+      "/enterprise/server/": "Enterprise server code"
     }
   },
   "nilness": {
-    "exclude_files": {
-      "tmp/*": "Temp generated files",
-      "external/*": "Third party code"
+    "only_files": {
+      "/server/": "Server code",
+      "/enterprise/server/": "Enterprise server code"
     }
   },
   "stdmethods": {
-    "exclude_files": {
-      "external/*": "Third party code"
+    "only_files": {
+      "/server/": "Server code",
+      "/enterprise/server/": "Enterprise server code"
     }
   },
   "stringintconv": {
-    "exclude_files": {
-      "external/*": "Third party code"
+    "only_files": {
+      "/server/": "Server code",
+      "/enterprise/server/": "Enterprise server code"
     }
   },
   "structtag": {
-    "exclude_files": {
-      "external/*": "Third party code"
+    "only_files": {
+      "/server/": "Server code",
+      "/enterprise/server/": "Enterprise server code"
     }
   },
   "unreachable": {
-    "exclude_files": {
-      "external/*": "Third party code"
+    "only_files": {
+      "/server/": "Server code",
+      "/enterprise/server/": "Enterprise server code"
     }
   },
   "unsafeptr": {
-    "exclude_files": {
-      "external/*": "Third party code"
+    "only_files": {
+      "/server/": "Server code",
+      "/enterprise/server/": "Enterprise server code"
     }
   }
 }


### PR DESCRIPTION
When building go code, rules_go stores temp files in some random locations:
https://github.com/bazelbuild/rules_go/issues/2172

On linux - this generally ends up under the /tmp/ directory, which is fine because we can exclude the /tmp directory.

On mac - these file can end up in some random locations like:
`/var/folders/cn/q2gg_ww95f5249g5xtfm4jp40000gn/T/rules_go_work-702856088/_cgo_gotypes.go`

This change moves from having to exclude every file/directory that you don't want go vet to analyze to just including the directories that we have go code in and have control over:
- `/server/`
- `/enterprise/server`

This fixes https://github.com/buildbuddy-io/buildbuddy/issues/435

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
