### PR TITLE
Add a simpler version of WithAuthenticatedUser.

### DIFF
--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -33,7 +33,8 @@ message Group {
   // Whether sharing features are allowed by this group.
   bool sharing_enabled = 6;
 
-  // Whether builds for this group will use custom executors provided by the group.
+  // Whether builds for this group will use custom executors provided by the
+  // group.
   bool use_group_owned_executors = 7;
 }
 
@@ -153,7 +154,8 @@ message CreateGroupRequest {
   // Whether sharing features are allowed by this group.
   bool sharing_enabled = 5;
 
-  // Whether builds for this group will use custom executors provided by the group.
+  // Whether builds for this group will use custom executors provided by the
+  // group.
   bool use_group_owned_executors = 6;
 }
 
@@ -192,7 +194,8 @@ message UpdateGroupRequest {
   // Whether sharing features are allowed by this group.
   bool sharing_enabled = 6;
 
-  // Whether builds for this group will use custom executors provided by the group.
+  // Whether builds for this group will use custom executors provided by the
+  // group.
   bool use_group_owned_executors = 7;
 }
 

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -183,9 +183,7 @@ message ExecutionNode {
   string version = 8;
 }
 
-message GetExecutionNodesRequest {
-  context.RequestContext request_context = 1;
-}
+message GetExecutionNodesRequest { context.RequestContext request_context = 1; }
 
 message GetExecutionNodesResponse {
   context.ResponseContext response_context = 1;

--- a/server/util/capabilities/capabilities_test.go
+++ b/server/util/capabilities/capabilities_test.go
@@ -111,7 +111,7 @@ func TestIsGranted_TestUserWithCapability_True(t *testing.T) {
 	}
 	te := getTestEnv(t, map[string]interfaces.UserInfo{user.UserID: user})
 	flags.Set(t, "auth.enable_anonymous_usage", "false")
-	authCtx := testauth.WithAuthenticatedUser(context.Background(), user)
+	authCtx := testauth.WithAuthenticatedUserInfo(context.Background(), user)
 
 	canWrite, err := capabilities.IsGranted(authCtx, te, akpb.ApiKey_CACHE_WRITE_CAPABILITY)
 
@@ -127,7 +127,7 @@ func TestIsGranted_TestUserWithoutCapability_False(t *testing.T) {
 	}
 	te := getTestEnv(t, map[string]interfaces.UserInfo{user.UserID: user})
 	flags.Set(t, "auth.enable_anonymous_usage", "false")
-	authCtx := testauth.WithAuthenticatedUser(context.Background(), user)
+	authCtx := testauth.WithAuthenticatedUserInfo(context.Background(), user)
 
 	canWrite, err := capabilities.IsGranted(authCtx, te, akpb.ApiKey_CACHE_WRITE_CAPABILITY)
 


### PR DESCRIPTION
Rename an older method to clarify what it's doing; new method sets JWT so that context <-> header translation in RPC interceptors works correctly.