### PR TITLE
Remove unused interface

### DIFF
--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -249,12 +249,6 @@ type ExecutionService interface {
 	GetExecution(ctx context.Context, req *espb.GetExecutionRequest) (*espb.GetExecutionResponse, error)
 }
 
-// CommandContainer provides an execution environment for commands.
-type CommandContainer interface {
-	// Run the given command within the container.
-	Run(ctx context.Context, command *repb.Command, workingDir string) *CommandResult
-}
-
 // CommandResult captures the output and details of an executed command.
 type CommandResult struct {
 	// Error is populated only if the command was unable to be started, or if it was


### PR DESCRIPTION
The actual interface definition for `CommandContainer` is in `container.go` in the internal repo.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
