### PR TITLE
ci-runner: Fix multithreading issues with log writing

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -395,11 +395,13 @@ func (bep *buildEventPublisher) setError(err error) {
 
 // actionRunner runs a single action in the BuildBuddy config.
 type actionRunner struct {
-	action        *config.Action
-	log           *invocationLog
-	bep           *buildEventPublisher
-	username      string
-	hostname      string
+	action   *config.Action
+	log      *invocationLog
+	bep      *buildEventPublisher
+	username string
+	hostname string
+
+	mu            sync.Mutex // protects(progressCount)
 	progressCount int32
 }
 
@@ -587,18 +589,35 @@ func (ar *actionRunner) printCommandLine(bazelArgs []string) {
 }
 
 func (ar *actionRunner) flushProgress() error {
+	event, err := ar.nextProgressEvent()
+	if err != nil {
+		return err
+	}
+	if event == nil {
+		// No progress to flush.
+		return nil
+	}
+
+	return ar.bep.Publish(event)
+}
+
+func (ar *actionRunner) nextProgressEvent() (*bespb.BuildEvent, error) {
+	ar.mu.Lock()
+	defer ar.mu.Unlock()
+
 	buf, err := ioutil.ReadAll(ar.log)
 	if err != nil {
-		return status.WrapError(err, "failed to read action logs")
+		return nil, status.WrapError(err, "failed to read action logs")
 	}
 	if len(buf) == 0 {
-		return nil
+		return nil, nil
 	}
 	count := ar.progressCount
 	ar.progressCount++
+
 	output := string(buf)
 
-	return ar.bep.Publish(&bespb.BuildEvent{
+	return &bespb.BuildEvent{
 		Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_Progress{Progress: &bespb.BuildEventId_ProgressId{OpaqueCount: count}}},
 		Children: []*bespb.BuildEventId{
 			{Id: &bespb.BuildEventId_Progress{Progress: &bespb.BuildEventId_ProgressId{OpaqueCount: count + 1}}},
@@ -607,7 +626,7 @@ func (ar *actionRunner) flushProgress() error {
 			// Only outputting to stderr for now, like Bazel does.
 			Stderr: output,
 		}},
-	})
+	}, nil
 }
 
 // TODO: Handle shell variable expansion. Probably want to run this with sh -c

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -605,7 +604,7 @@ func (ar *actionRunner) nextProgressEvent() (*bespb.BuildEvent, error) {
 	ar.mu.Lock()
 	defer ar.mu.Unlock()
 
-	buf, err := ioutil.ReadAll(ar.log)
+	buf, err := ar.log.ReadAll()
 	if err != nil {
 		return nil, status.WrapError(err, "failed to read action logs")
 	}

--- a/server/util/lockingbuffer/BUILD
+++ b/server/util/lockingbuffer/BUILD
@@ -13,5 +13,6 @@ go_test(
     deps = [
         ":lockingbuffer",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/util/lockingbuffer/lockingbuffer.go
+++ b/server/util/lockingbuffer/lockingbuffer.go
@@ -2,6 +2,7 @@ package lockingbuffer
 
 import (
 	"bytes"
+	"io"
 	"sync"
 )
 
@@ -33,4 +34,12 @@ func (lb *LockingBuffer) Read(p []byte) (int, error) {
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
 	return lb.buffer.Read(p)
+}
+
+// ReadAll provides a thread-safe alternative to io.ReadAll for lockingbuffer.
+func (lb *LockingBuffer) ReadAll() ([]byte, error) {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	defer lb.buffer.Reset()
+	return io.ReadAll(bytes.NewReader(lb.buffer.Bytes()))
 }

--- a/server/util/lockingbuffer/lockingbuffer.go
+++ b/server/util/lockingbuffer/lockingbuffer.go
@@ -40,6 +40,7 @@ func (lb *LockingBuffer) Read(p []byte) (int, error) {
 func (lb *LockingBuffer) ReadAll() ([]byte, error) {
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
-	defer lb.buffer.Reset()
-	return io.ReadAll(bytes.NewReader(lb.buffer.Bytes()))
+	b, err := io.ReadAll(bytes.NewReader(lb.buffer.Bytes()))
+	lb.buffer.Reset()
+	return b, err
 }

--- a/server/util/lockingbuffer/lockingbuffer_test.go
+++ b/server/util/lockingbuffer/lockingbuffer_test.go
@@ -1,7 +1,7 @@
 package lockingbuffer_test
 
 import (
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"regexp"
 	"sync"
@@ -10,10 +10,93 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/lockingbuffer"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLockingBuffer_ReadWrite(t *testing.T) {
+	rand.Seed(int64(time.Now().UnixNano()))
+
+	buf := lockingbuffer.New()
+
+	writer := func(val string, writeCount int, done *bool, doneLock *sync.RWMutex) {
+		defer func() {
+			doneLock.Lock()
+			*done = true
+			doneLock.Unlock()
+		}()
+		for i := 0; i < writeCount; i++ {
+			if _, err := buf.Write([]byte(val)); err != nil {
+				t.Fail()
+				return
+			}
+			randDelay()
+		}
+	}
+
+	// Writer A: Write `strACount` copies of `strA` to the buffer
+	strA := "AAA"
+	strACount := 1187
+	writerADone := false
+	doneLock := sync.RWMutex{}
+	go writer(strA, strACount, &writerADone, &doneLock)
+
+	// Writer B: Write `strBCount` copies of `strB` to the buffer
+	strB := "BBBBBBB"
+	strBCount := 919
+	writerBDone := false
+	go writer(strB, strBCount, &writerBDone, &doneLock)
+
+	reader := func(acc *string, done chan struct{}) {
+		defer func() {
+			done <- struct{}{}
+		}()
+		chunk := make([]byte, 128)
+		for {
+			doneLock.RLock()
+			writersDone := writerADone && writerBDone
+			doneLock.RUnlock()
+			n, err := buf.Read(chunk)
+			if err != nil && err != io.EOF {
+				t.Error(err)
+				return
+			}
+			*acc += string(chunk[:n])
+			if writersDone && n == 0 {
+				return
+			}
+			randDelay()
+		}
+	}
+
+	// Readers 1 & 2: continually attempt to read all bytes from the buffer.
+	reader1Acc := ""
+	reader1Done := make(chan struct{}, 1)
+	go reader(&reader1Acc, reader1Done)
+
+	reader2Acc := ""
+	reader2Done := make(chan struct{}, 1)
+	go reader(&reader2Acc, reader2Done)
+
+	<-reader1Done
+	<-reader2Done
+
+	// Assert that we read the correct number of 'A' and 'B'.
+	acc := reader1Acc + reader2Acc
+	assert.Equal(t, strACount*len(strA), charCount(acc, 'A'))
+	assert.Equal(t, strBCount*len(strB), charCount(acc, 'B'))
+	assert.Equal(t, strACount*len(strA)+strBCount*len(strB), len(acc))
+}
+
+func charCount(s string, c byte) int {
+	n := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			n++
+		}
+	}
+	return n
+}
+
+func TestLockingBuffer_ReadAll(t *testing.T) {
 	rand.Seed(int64(time.Now().UnixNano()))
 
 	buf := lockingbuffer.New()
@@ -54,7 +137,7 @@ func TestLockingBuffer_ReadWrite(t *testing.T) {
 			doneLock.RLock()
 			writersDone := writerADone && writerBDone
 			doneLock.RUnlock()
-			b, err := ioutil.ReadAll(buf)
+			b, err := buf.ReadAll()
 			if err != nil {
 				t.Fail()
 				return
@@ -85,24 +168,6 @@ func TestLockingBuffer_ReadWrite(t *testing.T) {
 	assert.Equal(t, strACount, len(regexp.MustCompile(strA).FindAllStringSubmatch(acc, -1)))
 	assert.Equal(t, strBCount, len(regexp.MustCompile(strB).FindAllStringSubmatch(acc, -1)))
 	assert.Equal(t, strACount*len(strA)+strBCount*len(strB), len(acc))
-}
-
-func TestLockingBuffer_ReadAll_DrainsBuffer(t *testing.T) {
-	buf := lockingbuffer.New()
-
-	_, err := buf.Write([]byte("ABC"))
-
-	require.NoError(t, err)
-
-	b, err := buf.ReadAll()
-
-	require.NoError(t, err)
-	require.Equal(t, []byte("ABC"), b)
-
-	b, err = buf.ReadAll()
-
-	require.NoError(t, err)
-	require.Empty(t, b)
 }
 
 func randDelay() {

--- a/server/util/lockingbuffer/lockingbuffer_test.go
+++ b/server/util/lockingbuffer/lockingbuffer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/lockingbuffer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLockingBuffer_ReadWrite(t *testing.T) {
@@ -84,6 +85,24 @@ func TestLockingBuffer_ReadWrite(t *testing.T) {
 	assert.Equal(t, strACount, len(regexp.MustCompile(strA).FindAllStringSubmatch(acc, -1)))
 	assert.Equal(t, strBCount, len(regexp.MustCompile(strB).FindAllStringSubmatch(acc, -1)))
 	assert.Equal(t, strACount*len(strA)+strBCount*len(strB), len(acc))
+}
+
+func TestLockingBuffer_ReadAll_DrainsBuffer(t *testing.T) {
+	buf := lockingbuffer.New()
+
+	_, err := buf.Write([]byte("ABC"))
+
+	require.NoError(t, err)
+
+	b, err := buf.ReadAll()
+
+	require.NoError(t, err)
+	require.Equal(t, []byte("ABC"), b)
+
+	b, err = buf.ReadAll()
+
+	require.NoError(t, err)
+	require.Empty(t, b)
 }
 
 func randDelay() {


### PR DESCRIPTION
`flushProgress` can be called by multiple threads, but access to `ar.log` wasn't synchronized (even though we're using `lockingbuffer`, `ioutil.ReadAll` will call `Read` in a loop, meaning it is unlocked between reads), and also the progress counter was not synchronized. It also wasn't guaranteeing that progress counts would be assigned in the same order in which we called `ReadAll` on the log, so events could be reported with out-of-order event IDs.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
