### PR TITLE
Split trends/invocations rpcs & add indexes.

### DIFF
--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -15,9 +15,9 @@ interface Props {
 }
 
 interface State {
-  stats: invocation.InvocationStat[];
+  stats: invocation.TrendStat[];
   loading: boolean;
-  dateToStatMap: Map<string, invocation.InvocationStat>;
+  dateToStatMap: Map<string, invocation.TrendStat>;
   lastNDates: string[];
   filterOnlyCI: boolean;
 }
@@ -28,7 +28,7 @@ export default class TrendsComponent extends React.Component {
   state: State = {
     stats: [],
     loading: true,
-    dateToStatMap: new Map<string, invocation.InvocationStat>(),
+    dateToStatMap: new Map<string, invocation.TrendStat>(),
     lastNDates: [],
     filterOnlyCI: false,
   };
@@ -63,10 +63,9 @@ export default class TrendsComponent extends React.Component {
   }
 
   fetchStats() {
-    let request = new invocation.GetInvocationStatRequest();
-    request.aggregationType = invocation.AggType.DATE_AGGREGATION_TYPE;
-    request.limit = this.getLimit();
-    request.query = new invocation.InvocationStatQuery();
+    let request = new invocation.GetTrendRequest();
+    request.lookbackWindowDays = this.getLimit();
+    request.query = new invocation.TrendQuery();
 
     if (this.state.filterOnlyCI) {
       request.query.role = "CI";
@@ -89,16 +88,16 @@ export default class TrendsComponent extends React.Component {
     }
 
     this.setState({ ...this.state, loading: true });
-    rpcService.service.getInvocationStat(request).then((response) => {
+    rpcService.service.getTrend(request).then((response) => {
       console.log(response);
-      const lastNDates = this.getLastNDates(request.limit);
-      let dateToStatMap = new Map<string, invocation.InvocationStat>();
-      for (let stat of response.invocationStat) {
-        dateToStatMap.set(stat.name, stat as invocation.InvocationStat);
+      const lastNDates = this.getLastNDates(request.lookbackWindowDays);
+      let dateToStatMap = new Map<string, invocation.TrendStat>();
+      for (let stat of response.trendStat) {
+        dateToStatMap.set(stat.name, stat as invocation.TrendStat);
       }
       this.setState({
         ...this.state,
-        stats: response.invocationStat,
+        stats: response.trendStat,
         lastNDates: lastNDates,
         dateToStatMap: dateToStatMap,
         loading: false,

--- a/enterprise/server/invocation_stat_service/BUILD
+++ b/enterprise/server/invocation_stat_service/BUILD
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//proto:invocation_go_proto",
         "//server/environment",
+        "//server/util/blocklist",
         "//server/util/db",
         "//server/util/log",
         "//server/util/perms",

--- a/enterprise/server/invocation_stat_service/BUILD
+++ b/enterprise/server/invocation_stat_service/BUILD
@@ -11,9 +11,10 @@ go_library(
     deps = [
         "//proto:invocation_go_proto",
         "//server/environment",
-        "//server/util/blocklist",
         "//server/util/db",
+        "//server/util/log",
         "//server/util/perms",
+        "//server/util/query_builder",
         "//server/util/status",
     ],
 )

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -2,11 +2,14 @@ package invocation_stat_service
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
-	"github.com/buildbuddy-io/buildbuddy/server/util/blocklist"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
+	"github.com/buildbuddy-io/buildbuddy/server/util/query_builder"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
@@ -37,10 +40,91 @@ func (i *InvocationStatService) getAggColumn(aggType inpb.AggType) string {
 	case inpb.AggType_COMMIT_SHA_AGGREGATION_TYPE:
 		return "commit_sha"
 	case inpb.AggType_DATE_AGGREGATION_TYPE:
-		return i.h.DateFromUsecTimestamp("created_at_usec")
+		return i.h.DateFromUsecTimestamp("updated_at_usec")
 	default:
+		log.Errorf("Unknown aggregation column type: %s", aggType)
 		return ""
 	}
+}
+
+func (i *InvocationStatService) GetTrend(ctx context.Context, req *inpb.GetTrendRequest) (*inpb.GetTrendResponse, error) {
+	groupID := req.GetRequestContext().GetGroupId()
+	if err := perms.AuthorizeGroupAccess(ctx, i.env, groupID); err != nil {
+		return nil, err
+	}
+
+	lookbackWindowDays := 7 * 24 * time.Hour
+	if w := req.GetLookbackWindowDays(); w != 0 {
+		if w < 1 || w > 365 {
+			return nil, status.InvalidArgumentErrorf("lookback_window_days must be between 0 and 366")
+		}
+		lookbackWindowDays = time.Duration(w*24) * time.Hour
+	}
+
+	q := query_builder.NewQuery(fmt.Sprintf("SELECT %s as name,", i.h.DateFromUsecTimestamp("updated_at_usec")) + `
+	    SUM(CASE WHEN duration_usec > 0 THEN duration_usec END) as total_build_time_usec,
+	    COUNT(1) as total_num_builds,
+	    SUM(CASE WHEN duration_usec > 0 THEN 1 ELSE 0 END) as completed_invocation_count,
+	    COUNT(DISTINCT user) as user_count,
+	    COUNT(DISTINCT commit_sha) as commit_count,
+	    COUNT(DISTINCT host) as host_count,
+	    COUNT(DISTINCT repo_url) as repo_count,
+	    MAX(duration_usec) as max_duration_usec,
+	    SUM(action_cache_hits) as action_cache_hits,
+	    SUM(action_cache_misses) as action_cache_misses,
+	    SUM(action_cache_uploads) as action_cache_uploads,
+	    SUM(cas_cache_hits) as cas_cache_hits,
+	    SUM(cas_cache_misses) as cas_cache_misses,
+	    SUM(cas_cache_uploads) as cas_cache_uploads,
+	    SUM(total_download_size_bytes) as total_download_size_bytes,
+	    SUM(total_upload_size_bytes) as total_upload_size_bytes,
+	    SUM(total_download_usec) as total_download_usec,
+            SUM(total_upload_usec) as total_upload_usec
+            FROM Invocations`)
+
+	if user := req.GetQuery().GetUser(); user != "" {
+		q.AddWhereClause("user = ?", user)
+	}
+
+	if host := req.GetQuery().GetHost(); host != "" {
+		q.AddWhereClause("host = ?", host)
+	}
+
+	if repoURL := req.GetQuery().GetRepoUrl(); repoURL != "" {
+		q.AddWhereClause("repo = ?", repoURL)
+	}
+
+	if commitSHA := req.GetQuery().GetCommitSha(); commitSHA != "" {
+		q.AddWhereClause("commit = ?", commitSHA)
+	}
+
+	if role := req.GetQuery().GetRole(); role != "" {
+		q.AddWhereClause("role = ?", role)
+	}
+
+	q.AddWhereClause(`created_at_usec > ?`, lookbackWindowDays.Microseconds())
+	q.AddWhereClause(`group_id = ?`, groupID)
+	q.SetGroupBy("name")
+	q.SetOrderBy("MAX(updated_at_usec)" /*ascending=*/, false)
+
+	qStr, qArgs := q.Build()
+	rows, err := i.h.Raw(qStr, qArgs...).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	rsp := &inpb.GetTrendResponse{}
+	rsp.TrendStat = make([]*inpb.TrendStat, 0)
+
+	for rows.Next() {
+		stat := &inpb.TrendStat{}
+		if err := i.h.ScanRows(rows, &stat); err != nil {
+			return nil, err
+		}
+		rsp.TrendStat = append(rsp.TrendStat, stat)
+	}
+	return rsp, nil
 }
 
 func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb.GetInvocationStatRequest) (*inpb.GetInvocationStatResponse, error) {
@@ -53,97 +137,53 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 		return nil, err
 	}
 
-	if blocklist.IsBlockedForStatsQuery(groupID) {
-		return nil, status.ResourceExhaustedErrorf("Too many rows.")
-	}
-
 	limit := int32(100)
-	if requestLimit := req.Limit; requestLimit > 0 {
-		limit = requestLimit
-	}
-
-	if limit > 365 || limit <= 0 {
-		return nil, status.InvalidArgumentError("Limit must be between 1 and 365")
+	if l := req.GetLimit(); l != 0 {
+		if l < 1 || l > 1000 {
+			return nil, status.InvalidArgumentErrorf("limit must be between 0 and 1000")
+		}
+		limit = l
 	}
 
 	aggColumn := i.getAggColumn(req.AggregationType)
+	q := query_builder.NewQuery(fmt.Sprintf("SELECT %s as name,", aggColumn) + `
+	    SUM(CASE WHEN duration_usec > 0 THEN duration_usec END) as total_build_time_usec,
+	    MAX(updated_at_usec) as latest_build_time_usec,
+	    MAX(CASE WHEN (success AND invocation_status = 1) THEN updated_at_usec END) as last_green_build_usec,
+	    MAX(CASE WHEN (success != true AND invocation_status = 1) THEN updated_at_usec END) as last_red_build_usec,
+	    COUNT(1) as total_num_builds,
+	    COUNT(CASE WHEN (success AND invocation_status = 1) THEN 1 END) as total_num_sucessful_builds,
+	    COUNT(CASE WHEN (success != true AND invocation_status = 1) THEN 1 END) as total_num_failing_builds,
+	    SUM(action_count) as total_actions
+            FROM Invocations`)
 
-	filters := ""
-	values := []interface{}{groupID}
+	if req.AggregationType != inpb.AggType_DATE_AGGREGATION_TYPE {
+		q.AddWhereClause(`? != ""`, aggColumn)
+	}
 
 	if user := req.GetQuery().GetUser(); user != "" {
-		filters = filters + " AND user = ?"
-		values = append(values, user)
+		q.AddWhereClause("user = ?", user)
 	}
 
 	if host := req.GetQuery().GetHost(); host != "" {
-		filters = filters + " AND host = ?"
-		values = append(values, host)
+		q.AddWhereClause("host = ?", host)
 	}
 
 	if repoURL := req.GetQuery().GetRepoUrl(); repoURL != "" {
-		filters = filters + " AND repo_url = ?"
-		values = append(values, repoURL)
+		q.AddWhereClause("repo = ?", repoURL)
 	}
 
 	if commitSHA := req.GetQuery().GetCommitSha(); commitSHA != "" {
-		filters = filters + " AND commit_sha = ?"
-		values = append(values, commitSHA)
+		q.AddWhereClause("commit = ?", commitSHA)
 	}
 
-	if role := req.GetQuery().GetRole(); role != "" {
-		filters = filters + " AND role = ?"
-		values = append(values, role)
-	}
+	q.AddWhereClause(`group_id = ?`, groupID)
+	q.SetGroupBy("name")
+	q.SetOrderBy("latest_build_time_usec" /*ascending=*/, false)
+	q.SetLimit(int64(limit))
 
-	if req.AggregationType != inpb.AggType_DATE_AGGREGATION_TYPE {
-		filters = filters + ` AND ` + aggColumn + ` != ""`
-	}
-
-	filters = filters + ` AND ` + aggColumn + ` IS NOT NULL`
-
-	values = append(values, limit)
-
-	q := "SELECT " + aggColumn + " as name," + `
-                     SUM(CASE WHEN duration_usec > 0 THEN duration_usec END) as total_build_time_usec,
-                     COUNT(DISTINCT invocation_id) as total_num_builds,
-                     COUNT(DISTINCT CASE WHEN (success AND invocation_status = 1) THEN invocation_id END) as total_num_sucessful_builds,
-                     COUNT(DISTINCT CASE WHEN (success != true AND invocation_status = 1) THEN invocation_id END) as total_num_failing_builds,
-                     COUNT(DISTINCT CASE WHEN invocation_status != 1 THEN invocation_id END) as total_num_in_progress_builds,
-                     MAX(updated_at_usec) as latest_build_time_usec,
-                     SUM(action_count) as total_actions,
-                     MAX(CASE WHEN (success AND invocation_status = 1) THEN updated_at_usec END) as last_green_build_usec,
-                     MAX(CASE WHEN (success != true AND invocation_status = 1) THEN updated_at_usec END) as last_red_build_usec,
-                     SUM(CASE WHEN command = 'build' THEN 1 ELSE 0 END) as build_command_count,
-                     SUM(CASE WHEN command = 'test' THEN 1 ELSE 0 END) as test_command_count,
-                     SUM(CASE WHEN command = 'run' THEN 1 ELSE 0 END) as run_command_count,
-                     SUM(CASE WHEN duration_usec > 0 THEN 1 ELSE 0 END) as completed_invocation_count,
-
-                     SUM(action_cache_hits) as action_cache_hits,
-                     SUM(action_cache_misses) as action_cache_misses,
-                     SUM(action_cache_uploads) as action_cache_uploads,
-
-                     SUM(cas_cache_hits) as cas_cache_hits,
-                     SUM(cas_cache_misses) as cas_cache_misses,
-                     SUM(cas_cache_uploads) as cas_cache_uploads,
-
-                     SUM(total_download_size_bytes) as total_download_size_bytes,
-                     SUM(total_upload_size_bytes) as total_upload_size_bytes,
-                     SUM(total_download_usec) as total_download_usec,
-                     SUM(total_upload_usec) as total_upload_usec,
-
-                     MAX(duration_usec) as max_duration_usec,
-                     COUNT(DISTINCT user) as user_count,
-                     COUNT(DISTINCT host) as host_count,
-                     COUNT(DISTINCT commit_sha) as commit_count,
-                     COUNT(DISTINCT repo_url) as repo_count
-              FROM Invocations
-              WHERE group_id = ?
-              ` + filters + `
-              GROUP by name
-							ORDER BY latest_build_time_usec DESC
-							LIMIT ?`
-	rows, err := i.h.Raw(q, values...).Rows()
+	qStr, qArgs := q.Build()
+	rows, err := i.h.Raw(qStr, qArgs...).Rows()
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/util/blocklist"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
@@ -51,6 +52,9 @@ func (i *InvocationStatService) GetTrend(ctx context.Context, req *inpb.GetTrend
 	groupID := req.GetRequestContext().GetGroupId()
 	if err := perms.AuthorizeGroupAccess(ctx, i.env, groupID); err != nil {
 		return nil, err
+	}
+	if blocklist.IsBlockedForStatsQuery(groupID) {
+		return nil, status.ResourceExhaustedErrorf("Too many rows.")
 	}
 
 	lookbackWindowDays := 7 * 24 * time.Hour
@@ -135,6 +139,9 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 	groupID := req.GetRequestContext().GetGroupId()
 	if err := perms.AuthorizeGroupAccess(ctx, i.env, groupID); err != nil {
 		return nil, err
+	}
+	if blocklist.IsBlockedForStatsQuery(groupID) {
+		return nil, status.ResourceExhaustedErrorf("Too many rows.")
 	}
 
 	limit := int32(100)

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -106,7 +106,7 @@ func (i *InvocationStatService) GetTrend(ctx context.Context, req *inpb.GetTrend
 		q.AddWhereClause("role = ?", role)
 	}
 
-	q.AddWhereClause(`created_at_usec > ?`, lookbackWindowDays.Microseconds())
+	q.AddWhereClause(`updated_at_usec > ?`, time.Now().Add(-lookbackWindowDays).UnixNano()/1000)
 	q.AddWhereClause(`group_id = ?`, groupID)
 	q.SetGroupBy("name")
 	q.SetOrderBy("MAX(updated_at_usec)" /*ascending=*/, false)

--- a/proto/buildbuddy_service.proto
+++ b/proto/buildbuddy_service.proto
@@ -26,6 +26,8 @@ service BuildBuddyService {
       returns (invocation.UpdateInvocationResponse);
   rpc DeleteInvocation(invocation.DeleteInvocationRequest)
       returns (invocation.DeleteInvocationResponse);
+  rpc GetTrend(invocation.GetTrendRequest)
+      returns (invocation.GetTrendResponse);
 
   // Bazel Config API
   rpc GetBazelConfig(bazel_config.GetBazelConfigRequest)

--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -220,24 +220,14 @@ enum AggType {
 }
 
 message InvocationStat {
-  // The key these stats were aggregated by.
-  // USER_STAT_TYPE, or HOSTNAME_STAT_TYPE
-  AggType aggregation_type = 1;
-
   // The name of the entity used to aggregate these stats.
   string name = 2;
 
   // The sum of all invocation durations for this entity.
   int64 total_build_time_usec = 3;
 
-  // The total number of invocations completed by this entity.
-  int64 total_num_builds = 4;
-
   // The time (in usec since epoch) of the latest build by this entity.
   int64 latest_build_time_usec = 5;
-
-  // The total number of actions completed by this entity.
-  int64 total_actions = 6;
 
   // The time (in usec since epoch) of the latest green build by this entity.
   int64 last_green_build_usec = 7;
@@ -245,58 +235,17 @@ message InvocationStat {
   // The time (in usec since epoch) of the latest red build by this entity.
   int64 last_red_build_usec = 10;
 
+  // The total number of invocations completed by this entity.
+  int64 total_num_builds = 4;
+
   // The total number of invocations completed successfully by this entity.
   int64 total_num_sucessful_builds = 8;
 
   // The total number of invocations completed unsuccessfully by this entity.
   int64 total_num_failing_builds = 9;
 
-  // The total number of in-progress invocations by this entity.
-  int64 total_num_in_progress_builds = 11;
-
-  // The number of invocations using the 'build' command.
-  int64 build_command_count = 12;
-
-  // The number of invocations using the 'run' command.
-  int64 run_command_count = 13;
-
-  // The number of invocations using the 'test' command.
-  int64 test_command_count = 14;
-
-  // The number of invocations with a duration longer than 0 seconds.
-  int64 completed_invocation_count = 15;
-
-  // The number of unique users who stared a build.
-  int64 user_count = 16;
-
-  // The number of unique commits that caused a build.
-  int64 commit_count = 17;
-
-  // The number of unique hosts that ran a build.
-  int64 host_count = 18;
-
-  // The number of unique repos that were built.
-  int64 repo_count = 19;
-
-  // The duration (in microseconds) of the longest build.
-  int64 max_duration_usec = 20;
-
-  // Server-side Action-cache stats.
-  int64 action_cache_hits = 21;
-  int64 action_cache_misses = 22;
-  int64 action_cache_uploads = 23;
-
-  // Server-side CAS-cache stats.
-  int64 cas_cache_hits = 24;
-  int64 cas_cache_misses = 25;
-  int64 cas_cache_uploads = 26;
-
-  // Rough throughput can be computed using the total cache bytes
-  // {uploaded,downloaded}/{upload_time,download_time}.
-  int64 total_download_size_bytes = 27;
-  int64 total_upload_size_bytes = 28;
-  int64 total_download_usec = 29;
-  int64 total_upload_usec = 30;
+  // The total number of actions completed by this entity.
+  int64 total_actions = 6;
 }
 
 message InvocationStatQuery {
@@ -339,4 +288,86 @@ message GetInvocationStatResponse {
 
   // The list of invocation stats found.
   repeated InvocationStat invocation_stat = 2;
+}
+
+message TrendStat {
+  string name = 1;
+
+  // The sum of all invocation durations for this entity.
+  int64 total_build_time_usec = 2;
+
+  // The total number of invocations completed by this entity.
+  int64 total_num_builds = 3;
+
+  // The number of invocations with a duration longer than 0 seconds.
+  int64 completed_invocation_count = 4;
+
+  // The number of unique users who stared a build.
+  int64 user_count = 5;
+
+  // The number of unique commits that caused a build.
+  int64 commit_count = 6;
+
+  // The number of unique hosts that ran a build.
+  int64 host_count = 7;
+
+  // The number of unique repos that were built.
+  int64 repo_count = 8;
+
+  // The duration (in microseconds) of the longest build.
+  int64 max_duration_usec = 9;
+
+  // Server-side Action-cache stats.
+  int64 action_cache_hits = 10;
+  int64 action_cache_misses = 11;
+  int64 action_cache_uploads = 12;
+
+  // Server-side CAS-cache stats.
+  int64 cas_cache_hits = 13;
+  int64 cas_cache_misses = 14;
+  int64 cas_cache_uploads = 15;
+
+  // Download / upload stats.
+  int64 total_download_size_bytes = 16;
+  int64 total_upload_size_bytes = 17;
+  int64 total_download_usec = 18;
+  int64 total_upload_usec = 19;
+}
+
+message TrendQuery {
+  // The search parameters in this query will be ANDed when performing a
+  // query -- so if a client specifies both "user" and "host", all results
+  // returned must match both fields.
+
+  // The unix-user who performed the build.
+  string user = 1;
+
+  // The host this build was executed on.
+  string host = 2;
+
+  // The git repo the build was for.
+  string repo_url = 4;
+
+  // The commit sha used for the build.
+  string commit_sha = 5;
+
+  // The role played by the build. Ex: "CI"
+  string role = 6;
+}
+
+message GetTrendRequest {
+  context.RequestContext request_context = 1;
+
+  TrendQuery query = 2;
+
+  // The maximum number of past days to aggregate. If not set, the server will
+  // pick an appropriate value. Probably 7.
+  int32 lookback_window_days = 3;
+}
+
+message GetTrendResponse {
+  context.ResponseContext response_context = 1;
+
+  // The list of trend stats found.
+  repeated TrendStat trend_stat = 2;
 }

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -662,6 +662,13 @@ func (s *BuildBuddyServer) GetInvocationStat(ctx context.Context, req *inpb.GetI
 	return nil, status.UnimplementedError("Not implemented")
 }
 
+func (s *BuildBuddyServer) GetTrend(ctx context.Context, req *inpb.GetTrendRequest) (*inpb.GetTrendResponse, error) {
+	if iss := s.env.GetInvocationStatService(); iss != nil {
+		return iss.GetTrend(ctx, req)
+	}
+	return nil, status.UnimplementedError("Not implemented")
+}
+
 func (s *BuildBuddyServer) GetExecution(ctx context.Context, req *espb.GetExecutionRequest) (*espb.GetExecutionResponse, error) {
 	if es := s.env.GetExecutionService(); es != nil {
 		return es.GetExecution(ctx, req)

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -198,6 +198,7 @@ type Webhook interface {
 // Allows aggregating invocation statistics.
 type InvocationStatService interface {
 	GetInvocationStat(ctx context.Context, req *inpb.GetInvocationStatRequest) (*inpb.GetInvocationStatResponse, error)
+	GetTrend(ctx context.Context, req *inpb.GetTrendRequest) (*inpb.GetTrendResponse, error)
 }
 
 // Allows searching invocations.

--- a/server/tables/BUILD
+++ b/server/tables/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//proto:group_go_proto",
         "//proto:user_id_go_proto",
+        "//server/util/log",
         "//server/util/random",
         "@io_gorm_gorm//:gorm",
     ],

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"gorm.io/gorm"
 
@@ -534,6 +535,26 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 
 // Manual migration called after auto-migration.
 func PostAutoMigrate(db *gorm.DB) error {
+	indexes := map[string]string{
+		"invocations_group_id_created_at_index": "(`group_id`, `created_at_usec`)",
+		"invocations_group_id_index":            "(`group_id`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_user_index":                "(`group_id`, `user`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_host_index":                "(`group_id`, `host`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_repo_index":                "(`group_id`, `repo_url`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_commit_index":              "(`group_id`, `commit_sha`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+	}
+	m := db.Migrator()
+	if m.HasTable("Invocations") {
+		for indexName, cols := range indexes {
+			if m.HasIndex("Invocations", indexName) {
+				continue
+			}
+			err := db.Exec(fmt.Sprintf("CREATE INDEX `%s` ON `Invocations`%s", indexName, cols)).Error
+			if err != nil {
+				log.Errorf("Error creating %s: %s", indexName, err)
+			}
+		}
+	}
 	return nil
 }
 

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -536,12 +536,12 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 // Manual migration called after auto-migration.
 func PostAutoMigrate(db *gorm.DB) error {
 	indexes := map[string]string{
-		"invocations_group_id_created_at_index": "(`group_id`, `created_at_usec`)",
-		"invocations_group_id_index":            "(`group_id`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_user_index":                "(`group_id`, `user`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_host_index":                "(`group_id`, `host`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_repo_index":                "(`group_id`, `repo_url`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_commit_index":              "(`group_id`, `commit_sha`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_trends_query_index":   "(`group_id`, `updated_at_usec`)",
+		"invocations_stats_group_id_index": "(`group_id`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_user_index":     "(`group_id`, `user`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_host_index":     "(`group_id`, `host`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_repo_index":     "(`group_id`, `repo_url`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_commit_index":   "(`group_id`, `commit_sha`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
 	}
 	m := db.Migrator()
 	if m.HasTable("Invocations") {

--- a/server/util/blocklist/blocklist.go
+++ b/server/util/blocklist/blocklist.go
@@ -12,5 +12,5 @@ func hashGroupID(groupID string) string {
 }
 
 func IsBlockedForStatsQuery(groupID string) bool {
-	return hashGroupID(groupID) == "143c576ef9982fe57150273eef88726a3bb37abdd427082b3a05a9460c955181"
+	return false
 }


### PR DESCRIPTION
This CL fixes the unresponsive UI problem for certain big customers with 1M+ invocations by:
 - splitting GetInvocationStats into two RPCs: GetInvocationStats (fully covered by index) and GetTrends (partially indexed, reads more data and duration is proportional to lookback window)
 - adding a loopback window which limits the amount of data queried by GetTrends
 - modifies queries slightly to remove unnecessary DISTINCT's, and do COUNT(1) instead of COUNT(invocation_id)
 - unifies GetInvocationStats and GetTrendStats to only query updated_at_usec
 - modifies app callsites accordingly