### PR TITLE
Set buffer cap only, and check length more carefully.

### DIFF
--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -199,10 +199,10 @@ func (c *CacheProxy) Read(req *dcpb.ReadRequest, stream dcpb.DistributedCache_Re
 	defer reader.Close()
 
 	bufSize := int64(readBufSizeBytes)
-	if d.GetSizeBytes() < bufSize {
+	if d.GetSizeBytes() > 0 && d.GetSizeBytes() < bufSize {
 		bufSize = d.GetSizeBytes()
 	}
-	copyBuf := make([]byte, bufSize)
+	copyBuf := make([]byte, 0, bufSize)
 	_, err = io.CopyBuffer(&streamWriter{stream}, reader, copyBuf)
 	c.log.Debugf("Read(%q) succeeded (user prefix: %s)", req.GetPrefix()+d.GetHash(), up)
 	return err

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -107,10 +107,10 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 	downloadTracker := ht.TrackDownload(d)
 
 	bufSize := int64(readBufSizeBytes)
-	if d.GetSizeBytes() < bufSize {
+	if d.GetSizeBytes() > 0 && d.GetSizeBytes() < bufSize {
 		bufSize = d.GetSizeBytes()
 	}
-	copyBuf := make([]byte, bufSize)
+	copyBuf := make([]byte, 0, bufSize)
 	_, err = io.CopyBuffer(&streamWriter{stream}, reader, copyBuf)
 	if err == nil {
 		downloadTracker.Close()


### PR DESCRIPTION
This fixes an error we saw on the errors channel.