### PR TITLE
workflows: Fix GitHub status name suffix being appended multiple times

### DIFF
--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -137,13 +137,13 @@ func (r *BuildStatusReporter) flushPayloadsIfWorkspaceLoaded(ctx context.Context
 	r.payloads = make([]*github.GithubStatusPayload, 0)
 }
 
-func (r *BuildStatusReporter) appendStatusNameSuffix(payload *github.GithubStatusPayload) *github.GithubStatusPayload {
+func (r *BuildStatusReporter) appendStatusNameSuffix(p *github.GithubStatusPayload) *github.GithubStatusPayload {
 	if r.statusNameSuffix == "" {
-		return payload
+		return p
 	}
-	clone := *payload
-	clone.Context = fmt.Sprintf("%s %s", clone.Context, r.statusNameSuffix)
-	return &clone
+	name := fmt.Sprintf("%s %s", p.Context, r.statusNameSuffix)
+	p = github.NewGithubStatusPayload(name, p.TargetURL, p.Description, p.State)
+	return p
 }
 
 func (r *BuildStatusReporter) githubPayloadFromWorkspaceStatusEvent(event *build_event_stream.BuildEvent) *github.GithubStatusPayload {

--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -142,8 +142,7 @@ func (r *BuildStatusReporter) appendStatusNameSuffix(p *github.GithubStatusPaylo
 		return p
 	}
 	name := fmt.Sprintf("%s %s", p.Context, r.statusNameSuffix)
-	p = github.NewGithubStatusPayload(name, p.TargetURL, p.Description, p.State)
-	return p
+	return github.NewGithubStatusPayload(name, p.TargetURL, p.Description, p.State)
 }
 
 func (r *BuildStatusReporter) githubPayloadFromWorkspaceStatusEvent(event *build_event_stream.BuildEvent) *github.GithubStatusPayload {

--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -103,7 +103,7 @@ func (r *BuildStatusReporter) ReportStatusForEvent(ctx context.Context, event *b
 
 func (r *BuildStatusReporter) ReportDisconnect(ctx context.Context) {
 	for label := range r.inFlight {
-		r.payloads = append(r.payloads, r.newGithubStatusPayload(label, r.invocationURL(), "Disconnected", github.ErrorState))
+		r.payloads = append(r.payloads, github.NewGithubStatusPayload(label, r.invocationURL(), "Disconnected", github.ErrorState))
 	}
 	r.flushPayloadsIfWorkspaceLoaded(ctx)
 }
@@ -131,21 +131,23 @@ func (r *BuildStatusReporter) flushPayloadsIfWorkspaceLoaded(ctx context.Context
 			break
 		}
 		commitSHA := r.buildEventAccumulator.CommitSHA()
-		r.githubClient.CreateStatus(ctx, ownerRepo, commitSHA, payload)
+		r.githubClient.CreateStatus(ctx, ownerRepo, commitSHA, r.appendStatusNameSuffix(payload))
 	}
 
 	r.payloads = make([]*github.GithubStatusPayload, 0)
 }
 
-func (r *BuildStatusReporter) newGithubStatusPayload(name, URL, description string, state github.State) *github.GithubStatusPayload {
-	if r.statusNameSuffix != "" {
-		name = fmt.Sprintf("%s %s", name, r.statusNameSuffix)
+func (r *BuildStatusReporter) appendStatusNameSuffix(payload *github.GithubStatusPayload) *github.GithubStatusPayload {
+	if r.statusNameSuffix == "" {
+		return payload
 	}
-	return github.NewGithubStatusPayload(name, URL, description, state)
+	clone := *payload
+	clone.Context = fmt.Sprintf("%s %s", clone.Context, r.statusNameSuffix)
+	return &clone
 }
 
 func (r *BuildStatusReporter) githubPayloadFromWorkspaceStatusEvent(event *build_event_stream.BuildEvent) *github.GithubStatusPayload {
-	return r.newGithubStatusPayload(r.invocationLabel(), r.invocationURL(), "Running...", github.PendingState)
+	return github.NewGithubStatusPayload(r.invocationLabel(), r.invocationURL(), "Running...", github.PendingState)
 }
 
 func (r *BuildStatusReporter) githubPayloadFromConfiguredEvent(event *build_event_stream.BuildEvent) *github.GithubStatusPayload {
@@ -160,10 +162,10 @@ func (r *BuildStatusReporter) githubPayloadFromConfiguredEvent(event *build_even
 	}
 
 	if groupStatus != nil && groupStatus.numTargets == 1 {
-		return r.newGithubStatusPayload(groupStatus.name, r.groupURL(groupStatus.name), "Running...", github.PendingState)
+		return github.NewGithubStatusPayload(groupStatus.name, r.groupURL(groupStatus.name), "Running...", github.PendingState)
 	}
 
-	return r.newGithubStatusPayload(label, r.targetURL(label), "Running...", github.PendingState)
+	return github.NewGithubStatusPayload(label, r.targetURL(label), "Running...", github.PendingState)
 }
 
 func (r *BuildStatusReporter) githubPayloadFromTestSummaryEvent(event *build_event_stream.BuildEvent) *github.GithubStatusPayload {
@@ -181,27 +183,27 @@ func (r *BuildStatusReporter) githubPayloadFromTestSummaryEvent(event *build_eve
 	description := descriptionFromOverallStatus(event.GetTestSummary().OverallStatus)
 
 	if groupStatus != nil && groupStatus.numFailed == 1 {
-		return r.newGithubStatusPayload(groupStatus.name, r.groupURL(label), description, github.FailureState)
+		return github.NewGithubStatusPayload(groupStatus.name, r.groupURL(label), description, github.FailureState)
 	}
 
 	if groupStatus != nil && groupStatus.numPassed == groupStatus.numTargets {
-		return r.newGithubStatusPayload(groupStatus.name, r.groupURL(label), description, github.SuccessState)
+		return github.NewGithubStatusPayload(groupStatus.name, r.groupURL(label), description, github.SuccessState)
 	}
 
 	if passed {
-		return r.newGithubStatusPayload(label, r.targetURL(label), description, github.SuccessState)
+		return github.NewGithubStatusPayload(label, r.targetURL(label), description, github.SuccessState)
 	}
 
-	return r.newGithubStatusPayload(label, r.targetURL(label), description, github.FailureState)
+	return github.NewGithubStatusPayload(label, r.targetURL(label), description, github.FailureState)
 }
 
 func (r *BuildStatusReporter) githubPayloadFromFinishedEvent(event *build_event_stream.BuildEvent) *github.GithubStatusPayload {
 	description := descriptionFromExitCodeName(event.GetFinished().ExitCode.Name)
 	if event.GetFinished().OverallSuccess {
-		return r.newGithubStatusPayload(r.invocationLabel(), r.invocationURL(), description, github.SuccessState)
+		return github.NewGithubStatusPayload(r.invocationLabel(), r.invocationURL(), description, github.SuccessState)
 	}
 
-	return r.newGithubStatusPayload(r.invocationLabel(), r.invocationURL(), description, github.FailureState)
+	return github.NewGithubStatusPayload(r.invocationLabel(), r.invocationURL(), description, github.FailureState)
 }
 
 func (r *BuildStatusReporter) githubPayloadFromAbortedEvent(event *build_event_stream.BuildEvent) *github.GithubStatusPayload {
@@ -216,10 +218,10 @@ func (r *BuildStatusReporter) githubPayloadFromAbortedEvent(event *build_event_s
 	}
 
 	if groupStatus != nil && groupStatus.numAborted == 1 {
-		return r.newGithubStatusPayload(groupStatus.name, r.groupURL(groupStatus.name), "Cancelled", github.ErrorState)
+		return github.NewGithubStatusPayload(groupStatus.name, r.groupURL(groupStatus.name), "Cancelled", github.ErrorState)
 	}
 
-	return r.newGithubStatusPayload(label, r.targetURL(label), "Cancelled", github.ErrorState)
+	return github.NewGithubStatusPayload(label, r.targetURL(label), "Cancelled", github.ErrorState)
 }
 
 func (r *BuildStatusReporter) invocationLabel() string {


### PR DESCRIPTION
If a build disconnects, then a status called "Test (dev) (dev)" would be reported (see screenshot below). The cause is that the disconnected status is generated from a previously reported one, which already had the suffix appended.

The fix is to only append the status suffix just before sending it out to GitHub, so we are not tempted to keep around the suffixed version and accidentally suffix it again.

![image](https://user-images.githubusercontent.com/2414826/120656106-5311c280-c451-11eb-8395-5456fefbe12b.png)


---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
