### PR TITLE
workflows: Fix cryptic `nil value of ""` error message

### DIFF
--- a/enterprise/server/util/fieldgetter/fieldgetter_test.go
+++ b/enterprise/server/util/fieldgetter/fieldgetter_test.go
@@ -41,6 +41,13 @@ func TestExtractValues(t *testing.T) {
 		path   string
 		errMsg string
 	}{
+		{nil, "<ANY_FIELD_NAME>", `call of ExtractValues on nil value`},
+		{&Parent{}, "<INVALID_FIELD_NAME>", `invalid field "<INVALID_FIELD_NAME>" (parent path: "")`},
+		{&Parent{Child: &Child{}}, "Child.<INVALID_FIELD_NAME>", `invalid field "<INVALID_FIELD_NAME>" (parent path: "Child")`},
+		{&Parent{}, "ChildList.9999999999", `strconv.ParseInt: parsing "9999999999": value out of range`},
+		{&Parent{}, "ChildList.Foo", `invalid field access of "Foo" on list (parent path: "ChildList")`},
+		{&Parent{}, "ChildList.0", `out of bounds: index 0 of "ChildList"`},
+		{&Parent{}, "Child", `nil value of "Child"`},
 		{&Parent{StrList: []string{"hello"}}, "Str.0", `cannot access field "0" of string "Str"`},
 		{&Parent{StrList: []string{"hello"}}, "Str.Foo", `cannot access field "Foo" of string "Str"`},
 	} {


### PR DESCRIPTION
Fixed cases where we would see cryptic error messages like `nil value of ""` which makes it impossible to tell which part of the GitHub webhook payload is actually missing.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
