### PR TITLE
Add support for publishing execution status updates via a Redis stream.

### DIFF
--- a/enterprise/server/backends/pubsub/BUILD
+++ b/enterprise/server/backends/pubsub/BUILD
@@ -10,6 +10,7 @@ go_library(
     ],
     deps = [
         "//server/interfaces",
+        "//server/util/log",
         "@com_github_go_redis_redis_v8//:redis",
     ],
 )

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -127,19 +127,22 @@ func redisKeyForTaskStatus(taskID string) string {
 	return "taskStatus/" + taskID
 }
 
+func redisKeyForTaskStatusStream(taskID string) string {
+	return "taskStatusStream/" + taskID
+}
+
 type Options struct {
-	DisableRedisNativePubSubFallback bool // TEST ONLY
-	DisableRedisListPubSub           bool // TEST ONLY
+	DisableRedisStreamPubSub bool // TEST ONLY
+	DisableRedisListPubSub   bool // TEST ONLY
 }
 
 type ExecutionServer struct {
 	env   environment.Env
 	cache interfaces.Cache
-	// We are in the process of transitioning execution status updates from using builtin Redis pub/sub mechanism to
-	// one based on Redis lists. The non-list PubSub will eventually go away.
-	pubsub                  interfaces.PubSub // OPTIONAL
-	listPubSub              interfaces.PubSub // OPTIONAL
-	disableDatabaseFallback bool
+	// We are in the process of transitioning execution status updates from using Redis lists to Redis streams.
+	// The list PubSub will go away soon.
+	listPubSub   interfaces.PubSub    // OPTIONAL
+	streamPubSub *pubsub.StreamPubSub // OPTIONAL
 	// If enabled, users may register their own executors.
 	// When enabled, the executor group ID becomes part of the executor key.
 	enableUserOwnedExecutors bool
@@ -154,23 +157,21 @@ func NewExecutionServerWithOptions(env environment.Env, options *Options) (*Exec
 	if cache == nil {
 		return nil, fmt.Errorf("A cache is required to enable the RemoteExecutionServer")
 	}
+	if env.GetRemoteExecutionRedisClient() == nil || env.GetRemoteExecutionRedisPubSubClient() == nil {
+		return nil, status.FailedPreconditionErrorf("Redis is required for remote execution")
+	}
 	es := &ExecutionServer{
 		env:                      env,
 		cache:                    cache,
 		enableUserOwnedExecutors: env.GetConfigurator().GetRemoteExecutionConfig().EnableUserOwnedExecutors,
 	}
 
-	disableRedisNativePubSub := env.GetConfigurator().GetRemoteExecutionConfig().DisableRedisNativePubSub
-	if options.DisableRedisNativePubSubFallback {
-		disableRedisNativePubSub = true
+	if !options.DisableRedisStreamPubSub && !env.GetConfigurator().GetRemoteExecutionConfig().DisableRedisStreamPubSub {
+		log.Info("Enabling PubSub stream based execution status updates.")
+		es.streamPubSub = pubsub.NewStreamPubSub(env.GetRemoteExecutionRedisPubSubClient())
 	}
-	if disableRedisNativePubSub {
-		es.disableDatabaseFallback = true
-	}
-	if env.GetRemoteExecutionRedisClient() != nil && !disableRedisNativePubSub {
-		es.pubsub = pubsub.NewPubSub(env.GetRemoteExecutionRedisClient())
-	}
-	if env.GetRemoteExecutionRedisPubSubClient() != nil && !options.DisableRedisListPubSub {
+	if !options.DisableRedisListPubSub && !env.GetConfigurator().GetRemoteExecutionConfig().DisableRedisListPubSub {
+		log.Info("Enabling PubSub list based execution status updates.")
 		es.listPubSub = pubsub.NewListPubSub(env.GetRemoteExecutionRedisPubSubClient())
 	}
 	return es, nil
@@ -492,14 +493,12 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 		Name: executionID,
 	}
 	return s.waitExecution(&waitReq, stream, waitOpts{
-		enableDBFallback: !s.disableDatabaseFallback,
-		// When database fallback is enabled we perform a read from the database at the start of the wait loop which
-		// sends an initial update so there's no need to send an explicit one.
-		sendInitialInProgressUpdate: s.disableDatabaseFallback,
+		enableDBFallback: false,
+		isExecuteRequest: true,
 	})
 }
 
-// Wait for an execution operation to complete. When the client initially
+// WaitExecution waits for an execution operation to complete. When the client initially
 // makes the request, the server immediately responds with the current status
 // of the execution. The server will leave the request stream open until the
 // operation completes, and then respond with the completed operation. The
@@ -507,12 +506,11 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 // such as to provide an update as to the state of the execution.
 func (s *ExecutionServer) WaitExecution(req *repb.WaitExecutionRequest, stream repb.Execution_WaitExecutionServer) error {
 	return s.waitExecution(req, stream, waitOpts{
-		// Always enable database fallback for WaitExecution requests.
+		// Enable database fallback for WaitExecution requests if list-based pubsub is being used.
 		// If Bazel switches from Execute to WaitExecution due to an error, there's a small chance that the pending
 		// Execute call could consume a message from the PubSub queue before WaitExecution sees it.
-		// We could get rid of this in the future by utilizing a Redis stream instead of a list.
-		enableDBFallback:            true,
-		sendInitialInProgressUpdate: false,
+		enableDBFallback: s.listPubSub != nil,
+		isExecuteRequest: false,
 	})
 }
 
@@ -577,10 +575,8 @@ func (e *InProgressExecution) processOpUpdate(op *longrunning.Operation) (done b
 type waitOpts struct {
 	// Whether we should fall back to checking execution status in the database in addition to PubSub.
 	enableDBFallback bool
-	// Whether an explicit "in progress" operation update should be generated at the start of the wait loop.
-	// The initial update contains the operation name which the client (Bazel) can use to call the WaitExecution API.
-	// Until the client receives the initial update it can only handle errors by retrying the entire execution request.
-	sendInitialInProgressUpdate bool
+	// Indicates whether the wait is being called from Execute or WaitExecution RPC.
+	isExecuteRequest bool
 }
 
 func (s *ExecutionServer) waitExecution(req *repb.WaitExecutionRequest, stream streamLike, opts waitOpts) error {
@@ -596,16 +592,20 @@ func (s *ExecutionServer) waitExecution(req *repb.WaitExecutionRequest, stream s
 		opName:       req.GetName(),
 	}
 
-	useAnyPubSub := false
-	var nativePubSubChan <-chan string
-	if s.pubsub != nil {
-		subscriber := s.pubsub.Subscribe(ctx, req.GetName())
+	var streamPubSubChan <-chan string
+	if s.streamPubSub != nil {
+		var subscriber interfaces.Subscriber
+		if opts.isExecuteRequest {
+			subscriber = s.streamPubSub.SubscribeHead(ctx, redisKeyForTaskStatusStream(req.GetName()))
+		} else {
+			// If this is a WaitExecution RPC, start the subscription from the last published status, inclusive.
+			subscriber = s.streamPubSub.SubscribeTail(ctx, redisKeyForTaskStatusStream(req.GetName()))
+		}
 		defer subscriber.Close()
-		nativePubSubChan = subscriber.Chan()
-		useAnyPubSub = true
+		streamPubSubChan = subscriber.Chan()
 	} else {
 		// Dummy channel that will never return anything.
-		nativePubSubChan = make(<-chan string)
+		streamPubSubChan = make(<-chan string)
 	}
 
 	var listPubSubChan <-chan string
@@ -613,13 +613,12 @@ func (s *ExecutionServer) waitExecution(req *repb.WaitExecutionRequest, stream s
 		subscriber := s.listPubSub.Subscribe(ctx, redisKeyForTaskStatus(req.GetName()))
 		defer subscriber.Close()
 		listPubSubChan = subscriber.Chan()
-		useAnyPubSub = true
 	} else {
 		// Dummy channel that will never return anything.
 		listPubSubChan = make(<-chan string)
 	}
 
-	if opts.sendInitialInProgressUpdate {
+	if opts.isExecuteRequest {
 		// Send a best-effort initial "in progress" update to client.
 		// Once Bazel receives the initial update, it will use WaitExecution to handle retry on error instead of
 		// requesting a new execution via Execute.
@@ -647,34 +646,29 @@ func (s *ExecutionServer) waitExecution(req *repb.WaitExecutionRequest, stream s
 				return err
 			}
 		}
-		if useAnyPubSub {
-			for {
-				done := false
-				select {
-				case serializedOp, ok := <-nativePubSubChan:
-					if !ok {
-						log.Debugf("Native pubsub channel closed for %q.", req.GetName())
-						return status.UnavailableErrorf("Native PubSub channel closed for %q", req.GetName())
-					}
-					done, err = e.processSerializedOpUpdate(serializedOp)
-				case serializedOp, ok := <-listPubSubChan:
-					if !ok {
-						log.Debugf("List pubsub channel closed for %q.", req.GetName())
-						return status.UnavailableErrorf("List PubSub channel closed for %q", req.GetName())
-					}
-					done, err = e.processSerializedOpUpdate(serializedOp)
-				case <-time.After(10 * time.Second):
-					if !s.disableDatabaseFallback {
-						done, err = e.updateFromDB(ctx)
-					}
+		for {
+			done := false
+			select {
+			case serializedOp, ok := <-streamPubSubChan:
+				if !ok {
+					return status.UnavailableErrorf("Stream PubSub channel closed for %q", req.GetName())
 				}
-				if done {
-					log.Debugf("WaitExecution %q: progress loop exited: err: %v, done: %t", req.GetName(), err, done)
-					return err
+				done, err = e.processSerializedOpUpdate(serializedOp)
+			case serializedOp, ok := <-listPubSubChan:
+				if !ok {
+					return status.UnavailableErrorf("List PubSub channel closed for %q", req.GetName())
+				}
+				done, err = e.processSerializedOpUpdate(serializedOp)
+			case <-time.After(10 * time.Second):
+				if opts.enableDBFallback {
+					done, err = e.updateFromDB(ctx)
 				}
 			}
+			if done {
+				log.Debugf("WaitExecution %q: progress loop exited: err: %v, done: %t", req.GetName(), err, done)
+				return err
+			}
 		}
-		time.Sleep(1 * time.Second)
 	}
 }
 
@@ -736,16 +730,16 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 
 		log.Debugf("PublishOperation: operation %q stage: %s", taskID, stage)
 
-		publishedOK := false
-		if s.pubsub != nil {
+		if s.streamPubSub != nil {
 			data, err := proto.Marshal(op)
 			if err != nil {
 				return err
 			}
-			if err := s.pubsub.Publish(stream.Context(), taskID, base64.StdEncoding.EncodeToString(data)); err != nil {
-				return status.InternalErrorf("Error publishing task %q on pubsub: %s", taskID, err.Error())
+			if err := s.streamPubSub.Publish(stream.Context(), redisKeyForTaskStatusStream(taskID), base64.StdEncoding.EncodeToString(data)); err != nil {
+				log.Warningf("Error publishing task %q on stream pubsub: %s", taskID, err)
+				// TODO(vadim): fail early after initial release
+				//return status.InternalErrorf("Error publishing task %q on stream pubsub: %s", taskID, err)
 			}
-			publishedOK = true
 		}
 
 		if s.listPubSub != nil {
@@ -757,10 +751,9 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 				log.Warningf("Error publishing task %q on list pubsub: %s", taskID, err)
 				return status.InternalErrorf("Error publishing task %q on list pubsub: %s", taskID, err)
 			}
-			publishedOK = true
 		}
 
-		if !publishedOK || stage == repb.ExecutionStage_COMPLETED {
+		if stage == repb.ExecutionStage_COMPLETED {
 			err := func() error {
 				mu.Lock()
 				defer mu.Unlock()

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -167,8 +167,8 @@ type RemoteExecutionConfig struct {
 	SharedExecutorPoolGroupID    string `yaml:"shared_executor_pool_group_id" usage:"Group ID that owns the shared executor pool."`
 	RedisPubSubPoolSize          int    `yaml:"redis_pubsub_pool_size" usage:"Maximum number of connections used for waiting for execution updates."`
 	EnableRemoteExec             bool   `yaml:"enable_remote_exec" usage:"If true, enable remote-exec. ** Enterprise only **"`
-	DisableRedisListPubSub       bool   `yaml:"disable_redis_list_pubsub" usage:"If true, revert to native redis PubSub."`
-	DisableRedisNativePubSub     bool   `yaml:"disable_redis_native_pubsub" usage:"If true, disable use of native redis PubSub in favor of list-based PubSub."`
+	DisableRedisListPubSub       bool   `yaml:"disable_redis_list_pubsub" usage:"If true, disable use of list Redis PubSub for status updates."`
+	DisableRedisStreamPubSub     bool   `yaml:"disable_redis_stream_pubsub" usage:"If true, disable use of stream redis PubSub for status updates."`
 	RequireExecutorAuthorization bool   `yaml:"require_executor_authorization" usage:"If true, executors connecting to this server must provide a valid executor API key."`
 	EnableNonLocalScheduling     bool   `yaml:"enable_non_local_scheduling" usage:"If true, schedulers can make RPCs to other schedulers to enqueue task reservations instead of always talking directly to executors."`
 	EnableUserOwnedExecutors     bool   `yaml:"enable_user_owned_executors" usage:"If enabled, users can register their own executors with the scheduler."`


### PR DESCRIPTION
This will address buildbuddy-io/buildbuddy-internal#590 once it's rolled out & list-based pubsub is disabled.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
