### PR TITLE
task-router: Add task router implementation

### DIFF
--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -18,7 +18,7 @@ const (
 	// empty or unset.
 	unsetContainerImageVal = "none"
 
-	recycleRunnerPropertyName       = "recycle-runner"
+	RecycleRunnerPropertyName       = "recycle-runner"
 	preserveWorkspacePropertyName   = "preserve-workspace"
 	persistentWorkerPropertyName    = "persistent-workers"
 	persistentWorkerKeyPropertyName = "persistentWorkerKey"
@@ -76,7 +76,7 @@ func ParseProperties(plat *repb.Platform, execProps *ExecutorProperties) (*Prope
 		ContainerImage:      containerImage,
 		DockerForceRoot:     boolProp(m, dockerRunAsRootPropertyName, false),
 		EnableXcodeOverride: boolProp(m, enableXcodeOverridePropertyName, false),
-		RecycleRunner:       boolProp(m, recycleRunnerPropertyName, false),
+		RecycleRunner:       boolProp(m, RecycleRunnerPropertyName, false),
 		PreserveWorkspace:   boolProp(m, preserveWorkspacePropertyName, false),
 		PersistentWorker:    boolProp(m, persistentWorkerPropertyName, false),
 		PersistentWorkerKey: stringProp(m, persistentWorkerKeyPropertyName, ""),
@@ -171,4 +171,21 @@ func stringListProp(props map[string]string, name string) []string {
 		}
 	}
 	return vals
+}
+
+// FindValue scans the platform properties for the given property name (ignoring
+// case) and returns the value of that property if it exists, otherwise "".
+func FindValue(platform *repb.Platform, name string) string {
+	name = strings.ToLower(name)
+	for _, prop := range platform.GetProperties() {
+		if prop.GetName() == name {
+			return strings.TrimSpace(prop.GetValue())
+		}
+	}
+	return ""
+}
+
+// IsTrue returns whether the given platform property value is truthy.
+func IsTrue(value string) bool {
+	return strings.EqualFold(value, "true")
 }

--- a/enterprise/server/scheduling/task_router/BUILD
+++ b/enterprise/server/scheduling/task_router/BUILD
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "task_router",
+    srcs = ["task_router.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_router",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//enterprise/server/remote_execution/platform",
+        "//proto:remote_execution_go_proto",
+        "//server/environment",
+        "//server/interfaces",
+        "//server/util/perms",
+        "//server/util/status",
+        "@com_github_go_redis_redis_v8//:redis",
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ],
+)

--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -1,0 +1,187 @@
+package task_router
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/go-redis/redis/v8"
+	"github.com/golang/protobuf/proto"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+const (
+	day = 24 * time.Hour
+
+	// The TTL for each node list in the routing table.
+	routingPropsKeyTTL = 7 * day
+
+	// The default max number of preferred nodes that are returned by the task
+	// router for routable tasks. This is intentionally less than the number of
+	// probes per task (for load balancing purposes).
+	defaultPreferredNodeLimit = 1
+	// The preferred node limit for workflows. This should be at least as big as
+	// the number of probes per task, since we strongly prefer to route workflow
+	// actions to executors that ran them previously.
+	workflowsPreferredNodeLimit = 6
+)
+
+type taskRouter struct {
+	env environment.Env
+	rdb *redis.Client
+}
+
+func New(env environment.Env) (interfaces.TaskRouter, error) {
+	rdb := env.GetRemoteExecutionRedisClient()
+	if rdb == nil {
+		return nil, status.FailedPreconditionError("Redis is required for task router")
+	}
+	return &taskRouter{
+		env: env,
+		rdb: rdb,
+	}, nil
+}
+
+// RankNodes returns the input nodes ordered by their affinity to the given
+// routing properties.
+func (tr *taskRouter) RankNodes(ctx context.Context, cmd *repb.Command, remoteInstanceName string, nodes []interfaces.ExecutionNode) ([]interfaces.ExecutionNode, error) {
+	nodes = copyNodes(nodes)
+
+	rand.Shuffle(len(nodes), func(i, j int) {
+		nodes[i], nodes[j] = nodes[j], nodes[i]
+	})
+
+	if cmd == nil {
+		return nodes, nil
+	}
+	preferredNodeLimit := getPreferredNodeLimit(cmd)
+	if preferredNodeLimit == 0 {
+		return nodes, nil
+	}
+
+	key, err := tr.routingKey(ctx, cmd, remoteInstanceName)
+	if err != nil {
+		return nil, status.WrapError(err, "rank nodes")
+	}
+	preferredNodeIDs, err := tr.rdb.LRange(ctx, key, 0, -1).Result()
+	if err != nil {
+		return nil, status.InternalErrorf("rank nodes: redis LRANGE failed: %s", err)
+	}
+
+	nodeByID := map[string]interfaces.ExecutionNode{}
+	for _, node := range nodes {
+		nodeByID[node.GetExecutorID()] = node
+	}
+	preferredSet := map[string]struct{}{}
+	ranked := make([]interfaces.ExecutionNode, 0, len(nodes))
+
+	// Place all preferred nodes first (in the order that they appear in the Redis
+	// list), then the remaining ones in shuffled order.
+	for _, id := range preferredNodeIDs[:minInt(preferredNodeLimit, len(preferredNodeIDs))] {
+		node := nodeByID[id]
+		if node == nil {
+			continue
+		}
+		preferredSet[id] = struct{}{}
+		ranked = append(ranked, node)
+	}
+	for _, node := range nodes {
+		if _, ok := preferredSet[node.GetExecutorID()]; ok {
+			continue
+		}
+		ranked = append(ranked, node)
+	}
+
+	return ranked, nil
+}
+
+// MarkComplete updates the routing table after a task is completed, so that
+// future tasks with those properties are more likely to be fulfilled by the
+// given node.
+func (tr *taskRouter) MarkComplete(ctx context.Context, cmd *repb.Command, remoteInstanceName, executorID string) error {
+	nodeListMaxLength := getPreferredNodeLimit(cmd)
+	if nodeListMaxLength == 0 {
+		return nil
+	}
+	key, err := tr.routingKey(ctx, cmd, remoteInstanceName)
+	if err != nil {
+		return status.WrapError(err, "mark task complete")
+	}
+
+	pipe := tr.rdb.TxPipeline()
+	// Push the node to the head of the list (but first remove it if already
+	// present to avoid dupes), trim to max length to prevent it from growing
+	// too large, and renew the TTL.
+	pipe.LRem(ctx, key, 1, executorID)
+	pipe.LPush(ctx, key, executorID)
+	pipe.LTrim(ctx, key, 0, int64(nodeListMaxLength)-1)
+	pipe.Expire(ctx, key, routingPropsKeyTTL)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return status.InternalErrorf("mark task complete: redis pipeline failed: %s", err)
+	}
+
+	return nil
+}
+
+// getPreferredNodeLimit returns the max number of nodes that should be stored
+// in the preferred executors list for each task key, as well as the max number
+// of preferred nodes that should be returned by RankNodes.
+func getPreferredNodeLimit(cmd *repb.Command) int {
+	isRunnerRecyclingEnabled := platform.IsTrue(platform.FindValue(cmd.GetPlatform(), platform.RecycleRunnerPropertyName))
+	if !isRunnerRecyclingEnabled {
+		return 0
+	}
+	workflowID := platform.FindValue(cmd.GetPlatform(), platform.WorkflowIDPropertyName)
+	if workflowID != "" {
+		return workflowsPreferredNodeLimit
+	}
+	return defaultPreferredNodeLimit
+}
+
+func (tr *taskRouter) routingKey(ctx context.Context, cmd *repb.Command, remoteInstanceName string) (string, error) {
+	parts := []string{"task_route"}
+
+	if u, _ := perms.AuthenticatedUser(ctx, tr.env); u != nil {
+		parts = append(parts, u.GetGroupID())
+	} else {
+		parts = append(parts, "ANON")
+	}
+
+	if remoteInstanceName != "" {
+		parts = append(parts, remoteInstanceName)
+	}
+
+	platform := cmd.GetPlatform()
+	if platform == nil {
+		platform = &repb.Platform{}
+	}
+	b, err := proto.Marshal(platform)
+	if err != nil {
+		return "", status.InternalErrorf("failed to marshal Command: %s", err)
+	}
+	parts = append(parts, fmt.Sprintf("%x", sha256.Sum256(b)))
+
+	return strings.Join(parts, "/"), nil
+}
+
+func copyNodes(nodes []interfaces.ExecutionNode) []interfaces.ExecutionNode {
+	out := make([]interfaces.ExecutionNode, len(nodes))
+	copy(out, nodes)
+	return out
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -31,7 +31,9 @@ const (
 	defaultPreferredNodeLimit = 1
 	// The preferred node limit for workflows. This should be at least as big as
 	// the number of probes per task, since we strongly prefer to route workflow
-	// actions to executors that ran them previously.
+	// actions to executors that ran them previously. Here, it's set slightly
+	// bigger than the number of probes, in case any of the nodes go down or
+	// a probe fails.
 	workflowsPreferredNodeLimit = 6
 )
 
@@ -70,7 +72,7 @@ func (tr *taskRouter) RankNodes(ctx context.Context, cmd *repb.Command, remoteIn
 
 	key, err := tr.routingKey(ctx, cmd, remoteInstanceName)
 	if err != nil {
-		return nil, status.WrapError(err, "rank nodes")
+		return nil, err
 	}
 	preferredNodeIDs, err := tr.rdb.LRange(ctx, key, 0, -1).Result()
 	if err != nil {
@@ -114,7 +116,7 @@ func (tr *taskRouter) MarkComplete(ctx context.Context, cmd *repb.Command, remot
 	}
 	key, err := tr.routingKey(ctx, cmd, remoteInstanceName)
 	if err != nil {
-		return status.WrapError(err, "mark task complete")
+		return err
 	}
 
 	pipe := tr.rdb.TxPipeline()

--- a/enterprise/server/test/integration/task_router/BUILD
+++ b/enterprise/server/test/integration/task_router/BUILD
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "task_router_test",
+    srcs = ["task_router_test.go"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//enterprise/server/scheduling/task_router",
+        "//enterprise/server/testutil/enterprise_testenv",
+        "//enterprise/server/testutil/testredis",
+        "//proto:remote_execution_go_proto",
+        "//server/environment",
+        "//server/interfaces",
+        "//server/real_environment",
+        "//server/testutil/testauth",
+        "//server/testutil/testenv",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/test/integration/task_router/BUILD
+++ b/enterprise/server/test/integration/task_router/BUILD
@@ -11,9 +11,7 @@ go_test(
         "//proto:remote_execution_go_proto",
         "//server/environment",
         "//server/interfaces",
-        "//server/real_environment",
         "//server/testutil/testauth",
-        "//server/testutil/testenv",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/test/integration/task_router/task_router_test.go
+++ b/enterprise/server/test/integration/task_router/task_router_test.go
@@ -1,0 +1,240 @@
+package task_router_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_router"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis"
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
+	"github.com/stretchr/testify/require"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+func TestTaskRouter_RankNodes_Workflows_ReturnsMultipleRunnersThatExecutedWorkflow(t *testing.T) {
+	env := newTestEnv(t)
+	router := newTaskRouter(t, env)
+	ctx := withAuthUser(t, context.Background(), env, "US1")
+	cmd := &repb.Command{
+		Platform: &repb.Platform{
+			Properties: []*repb.Platform_Property{
+				{Name: "recycle-runner", Value: "true"},
+				{Name: "workflow-id", Value: "WF1"},
+			},
+		},
+	}
+	instanceName := "test-instance"
+	executorID1 := "7"
+
+	err := router.MarkComplete(ctx, cmd, instanceName, executorID1)
+
+	require.NoError(t, err)
+
+	nodes := sequentiallyNumberedNodes(100)
+
+	ranked, err := router.RankNodes(ctx, cmd, instanceName, nodes)
+
+	require.NoError(t, err)
+	require.Equal(t, len(nodes), len(ranked))
+	require.Equal(t, executorID1, ranked[0].GetExecutorID())
+
+	executorID2 := "42"
+
+	err = router.MarkComplete(ctx, cmd, instanceName, executorID2)
+
+	require.NoError(t, err)
+
+	ranked, err = router.RankNodes(ctx, cmd, instanceName, nodes)
+
+	require.NoError(t, err)
+	require.Equal(t, len(nodes), len(ranked))
+	require.Equal(t, executorID2, ranked[0].GetExecutorID())
+	require.Equal(t, executorID1, ranked[1].GetExecutorID())
+}
+
+func TestTaskRouter_RankNodes_DefaultNodeLimit_ReturnsOnlyLatestNodeMarkedComplete(t *testing.T) {
+	env := newTestEnv(t)
+	router := newTaskRouter(t, env)
+	ctx := withAuthUser(t, context.Background(), env, "US1")
+	cmd := &repb.Command{
+		Platform: &repb.Platform{
+			Properties: []*repb.Platform_Property{
+				{Name: "recycle-runner", Value: "true"},
+			},
+		},
+	}
+	instanceName := "test-instance"
+	executorID1 := "7"
+
+	err := router.MarkComplete(ctx, cmd, instanceName, executorID1)
+
+	require.NoError(t, err)
+
+	nodes := sequentiallyNumberedNodes(100)
+
+	ranked, err := router.RankNodes(ctx, cmd, instanceName, nodes)
+
+	require.NoError(t, err)
+	require.Equal(t, len(nodes), len(ranked))
+	require.Equal(t, executorID1, ranked[0].GetExecutorID())
+
+	executorID2 := "42"
+
+	err = router.MarkComplete(ctx, cmd, instanceName, executorID2)
+
+	require.NoError(t, err)
+
+	ranked, err = router.RankNodes(ctx, cmd, instanceName, nodes)
+
+	require.NoError(t, err)
+	require.Equal(t, len(nodes), len(ranked))
+	require.Equal(t, executorID2, ranked[0].GetExecutorID())
+	requireNotAlwaysRanked(1, executorID1, t, router, ctx, cmd, instanceName)
+}
+
+func TestTaskRouter_RankNodes_JustShufflesIfCommandIsNotAvailable(t *testing.T) {
+	env := newTestEnv(t)
+	router := newTaskRouter(t, env)
+	nodes := sequentiallyNumberedNodes(100)
+	ctx := withAuthUser(t, context.Background(), env, "US1")
+	instanceName := ""
+
+	ranked, err := router.RankNodes(ctx, nil /*=cmd*/, instanceName, nodes)
+
+	require.NoError(t, err)
+	requireReordered(t, nodes, ranked)
+}
+
+func TestTaskRouter_MarkComplete_DoesNotAffectNonRecyclableTasks(t *testing.T) {
+	env := newTestEnv(t)
+	router := newTaskRouter(t, env)
+	ctx := withAuthUser(t, context.Background(), env, "US1")
+	cmd := &repb.Command{}
+	instanceName := "test-instance"
+	executorID := "17"
+
+	err := router.MarkComplete(ctx, cmd, instanceName, executorID)
+
+	require.NoError(t, err)
+	requireNotAlwaysRanked(0, executorID, t, router, ctx, cmd, instanceName)
+}
+
+func TestTaskRouter_MarkComplete_DoesNotAffectOtherGroups(t *testing.T) {
+	env := newTestEnv(t)
+	router := newTaskRouter(t, env)
+	ctx1 := withAuthUser(t, context.Background(), env, "US1")
+	cmd := &repb.Command{
+		Platform: &repb.Platform{
+			Properties: []*repb.Platform_Property{
+				{Name: "recycle-runner", Value: "true"},
+			},
+		},
+	}
+	instanceName := "test-instance"
+	executorID := "19"
+
+	err := router.MarkComplete(ctx1, cmd, instanceName, executorID)
+
+	ctx2 := withAuthUser(t, context.Background(), env, "US2")
+
+	require.NoError(t, err)
+	requireNotAlwaysRanked(0, executorID, t, router, ctx2, cmd, instanceName)
+}
+
+func TestTaskRouter_MarkComplete_DoesNotAffectOtherRemoteInstances(t *testing.T) {
+	env := newTestEnv(t)
+	router := newTaskRouter(t, env)
+	ctx := withAuthUser(t, context.Background(), env, "US1")
+	cmd := &repb.Command{
+		Platform: &repb.Platform{
+			Properties: []*repb.Platform_Property{
+				{Name: "recycle-runner", Value: "true"},
+			},
+		},
+	}
+	instanceName1 := "test-instance"
+	executorID := "17"
+
+	err := router.MarkComplete(ctx, cmd, instanceName1, executorID)
+
+	instanceName2 := "another-test-instance"
+
+	require.NoError(t, err)
+	requireNotAlwaysRanked(0, executorID, t, router, ctx, cmd, instanceName2)
+}
+
+func requireNotAlwaysRanked(rank int, executorID string, t *testing.T, router interfaces.TaskRouter, ctx context.Context, cmd *repb.Command, instanceName string) {
+	nodes := sequentiallyNumberedNodes(100)
+	nTrials := 10
+	for i := 0; i < nTrials; i++ {
+		ranked, err := router.RankNodes(ctx, cmd, instanceName, nodes)
+
+		require.Equal(t, len(nodes), len(ranked))
+		require.NoError(t, err)
+		if ranked[rank].GetExecutorID() != executorID {
+			return
+		}
+	}
+
+	require.FailNowf(
+		t,
+		"executor rank is not randomized",
+		"task router unexpectedly ranked executor #%s as rank %d in all %d trials, each with %d executors",
+		executorID, rank, nTrials, len(nodes),
+	)
+}
+
+func requireReordered(t *testing.T, nodes []interfaces.ExecutionNode, ranked []interfaces.ExecutionNode) {
+	require.ElementsMatch(t, nodes, ranked)
+
+	for i := range nodes {
+		if nodes[i] != ranked[i] {
+			return
+		}
+	}
+	require.FailNow(t, "nodes were not reordered")
+}
+
+func newTaskRouter(t *testing.T, env environment.Env) interfaces.TaskRouter {
+	router, err := task_router.New(env)
+	require.NoError(t, err)
+	return router
+}
+
+func newTestEnv(t *testing.T) environment.Env {
+	rand.Seed(time.Now().UnixNano())
+
+	redisTarget := testredis.Start(t)
+	env := enterprise_testenv.GetCustomTestEnv(t, &enterprise_testenv.Options{
+		RedisTarget: redisTarget,
+	})
+	userMap := testauth.TestUsers("US1", "GR1", "US2", "GR2")
+	env.SetAuthenticator(testauth.NewTestAuthenticator(userMap))
+	return env
+}
+
+func withAuthUser(t *testing.T, ctx context.Context, env environment.Env, userID string) context.Context {
+	a := env.GetAuthenticator().(*testauth.TestAuthenticator)
+	ctx, err := a.WithAuthenticatedUser(ctx, userID)
+	require.NoError(t, err)
+	return ctx
+}
+
+func sequentiallyNumberedNodes(n int) []interfaces.ExecutionNode {
+	nodes := make([]interfaces.ExecutionNode, 0, n)
+	for i := 0; i < n; i++ {
+		nodes = append(nodes, &testNode{i})
+	}
+	return nodes
+}
+
+type testNode struct{ id int }
+
+func (n *testNode) GetExecutorID() string { return fmt.Sprintf("%d", n.id) }


### PR DESCRIPTION
The impl is not used anywhere yet. It will be used after https://github.com/buildbuddy-io/buildbuddy/pull/522 is submitted.

Overview:
* For a given `(cmd, ctx, remoteInstanceName)` it computes a "task key" as `task_route/${groupIDFromCtx(ctx)}/${remoteInstanceName}/${sha256(marshal(command.GetPlatform()))}`
* For each task key, it stores a list of executor IDs which previously executed tasks with the same key.
* RankNodes will place executors first from that list, and randomize the rest of the executors.
  * RankNodes always returns the same executors as the ones passed via the input list, and only changes the order. So any executors in Redis which do not exist in the input list are never returned in the output list.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
