### PR TITLE
workflows: Fix GitHub webhook auto-registration

### DIFF
--- a/enterprise/server/webhooks/github/github.go
+++ b/enterprise/server/webhooks/github/github.go
@@ -40,7 +40,8 @@ func RegisterWebhook(ctx context.Context, accessToken, repoURL, webhookURL strin
 	// name field. TODO: Is this actually required?
 	name := "web"
 	hook, _, err := client.Repositories.CreateHook(ctx, owner, repo, &gh.Hook{
-		Name: &name,
+		Name:   &name,
+		Events: eventsToReceive,
 		Config: map[string]interface{}{
 			"url":    webhookURL,
 			"events": eventsToReceive,


### PR DESCRIPTION
The list of events to listen to (`["push", "pull_request"]`) has to be passed via both the `events` param and `config.events` field, otherwise only the `push` event gets listened to (this isn't documented in GitHub API docs :cry: )

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
