### PR TITLE
Add a simple /statusz page to help introspect running servers.

### DIFF
--- a/server/backends/disk_cache/BUILD
+++ b/server/backends/disk_cache/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//server/util/lru",
         "//server/util/prefix",
         "//server/util/status",
+        "//server/util/statusz",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -2,6 +2,7 @@ package disk_cache
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -19,6 +20,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/lru"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/statusz"
 	"golang.org/x/sync/errgroup"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -96,7 +98,15 @@ func NewDiskCache(rootDir string, maxSizeBytes int64) (*DiskCache, error) {
 	if err := c.initializeCache(); err != nil {
 		return nil, err
 	}
+	statusz.AddSection("disk_cache", "On disk LRU cache", c)
 	return c, nil
+}
+
+func (c *DiskCache) Statusz(ctx context.Context) string {
+	buf := ""
+	buf += fmt.Sprintf("Root directory: %s<br>", c.rootDir)
+	buf += fmt.Sprintf("Mapped into LRU: %t<br>", *c.diskIsMapped)
+	return buf
 }
 
 func (c *DiskCache) WithPrefix(prefix string) interfaces.Cache {

--- a/server/util/monitoring/BUILD
+++ b/server/util/monitoring/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/util/log",
+        "//server/util/statusz",
         "@com_github_prometheus_client_golang//prometheus/promhttp",
     ],
 )

--- a/server/util/monitoring/monitoring.go
+++ b/server/util/monitoring/monitoring.go
@@ -5,6 +5,7 @@ import (
 	"net/http/pprof"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/statusz"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -20,6 +21,9 @@ func RegisterMonitoringHandlers(mux *http.ServeMux) {
 	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	// Statusz page
+	mux.Handle("/statusz", statusz.Server())
 }
 
 // StartMonitoringHandler enables the prometheus and pprof monitoring handlers

--- a/server/util/statusz/BUILD
+++ b/server/util/statusz/BUILD
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "statusz",
+    srcs = ["statusz.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/statusz",
+    visibility = ["//visibility:public"],
+    deps = ["//server/version"],
+)

--- a/server/util/statusz/statusz.go
+++ b/server/util/statusz/statusz.go
@@ -19,29 +19,30 @@ const templateContents = `<!DOCTYPE html>
   <head>
     <title>/statusz</title>
     <style>
-	body {
-	  font-family: sans-serif;
-	}
-	h1 {
-	  width: 100%;
-	  text-align: center;
-	  font-size: 120%;
-	  background: #eeeeff;
-	}
-	h2 {
-	  width: 100%;
-	  font-size: 110%;
-	  text-align: center;
-	  background: #fffddd;
-	}
-        .header {
-          display: flex;
-          justify-content: space-between;
-        }
+      body {
+	font-family: sans-serif;
+      }
+      h1 {
+	width: 100%;
+	text-align: center;
+	font-size: 120%;
+	background: #eeeeff;
+      }
+      h2 {
+	width: 100%;
+	font-size: 110%;
+	text-align: center;
+	background: #fffddd;
+      }
+      .header {
+	display: flex;
+	justify-content: space-between;
+	padding-bottom: 48px
+      }
     </style>
   </head>
   <h1>Status for {{.BinaryName}}</h1>
-  <div class=header>
+  <div class="header">
     <div>
       <div>Started at {{.StartTime.Format "Jan 02, 2006 15:04:05 PST" }}</div>
       <div>Current time {{.CurrentTime.Format "Jan 02, 2006 15:04:05 PST" }}</div>

--- a/server/util/statusz/statusz.go
+++ b/server/util/statusz/statusz.go
@@ -93,9 +93,8 @@ func init() {
 }
 
 type StatusReporter interface {
-	// Returns nil on success, error on failure. Returning an error will
-	// indicate to the health checker that this service is unhealthy and
-	// that the server is not ready to serve.
+	// Returns a text or HTML snippet that represents the service's current
+	// running state in a compact way.
 	Statusz(ctx context.Context) string
 }
 type StatusFunc func(ctx context.Context) string

--- a/server/util/statusz/statusz.go
+++ b/server/util/statusz/statusz.go
@@ -103,13 +103,13 @@ type Section struct {
 }
 
 type Handler struct {
-	mu       *sync.RWMutex // PROTECTS(sections)
+	mu       sync.RWMutex // PROTECTS(sections)
 	sections map[string]*Section
 }
 
 func NewHandler() *Handler {
 	return &Handler{
-		mu:       &sync.RWMutex{},
+		mu:       sync.RWMutex{},
 		sections: make(map[string]*Section, 0),
 	}
 }

--- a/server/util/statusz/statusz.go
+++ b/server/util/statusz/statusz.go
@@ -1,0 +1,189 @@
+package statusz
+
+import (
+	"context"
+	"html/template"
+	"net/http"
+	"os"
+	"os/user"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/version"
+)
+
+const templateContents = `<!DOCTYPE html>
+<html>
+  <head>
+    <title>/statusz</title>
+    <style>
+	body {
+	  font-family: sans-serif;
+	  background: #fff;
+	}
+	h1 {
+	  clear: both;
+	  width: 100%;
+	  text-align: center;
+	  font-size: 120%;
+	  background: #eeeeff;
+	}
+	h2 {
+	  clear: both;
+	  width: 100%;
+	  font-size: 110%;
+	  text-align: center;
+	  background: #fffddd;
+	}
+	.lefthand {
+	  float: left;
+	  width: 80%;
+	}
+	.righthand {
+	  text-align: right;
+	}
+    </style>
+  </head>
+    <h1>Status for {{.BinaryName}}</h1>
+  <div>
+  <div class=lefthand>
+    Started at <span>{{.StartTime.Format "Jan 02, 2006 15:04:05 PST" }}</span><br>
+    Current time <span>{{.CurrentTime.Format "Jan 02, 2006 15:04:05 PST" }}</span><br>
+    App Version <span>{{.AppVersion}} ({{.Commit}})</span><br>
+    Go Version <span>{{.GoVersion}}</span><br>
+  </div>
+  <div class=righthand>
+    {{.Username}}@{{.Hostname}}<br>
+  </div>
+
+  <br><br><br><br><br>
+  {{range $idx, $item := .Sections}}
+  <div>
+    <h2>
+      {{$item.Name}}
+    </h2>
+    <div>
+      {{$item.Description}}<br>
+      {{$item.HTML}}
+    </div>
+  </div>
+  {{end}}
+</html>
+`
+
+var (
+	startTime          time.Time
+	hostname           string
+	username           string
+	binaryName         = filepath.Base(os.Args[0])
+	statusPageTemplate = template.Must(template.New("statusz").Parse(templateContents))
+	DefaultHandler     = NewHandler()
+)
+
+func init() {
+	startTime = time.Now()
+	if h, err := os.Hostname(); err == nil {
+		hostname = h
+	}
+	if u, err := user.Current(); err == nil {
+		username = u.Username
+	}
+}
+
+type StatusReporter interface {
+	// Returns nil on success, error on failure. Returning an error will
+	// indicate to the health checker that this service is unhealthy and
+	// that the server is not ready to serve.
+	Statusz(ctx context.Context) string
+}
+type StatusFunc func(ctx context.Context) string
+
+func (f StatusFunc) Statusz(ctx context.Context) string {
+	return f(ctx)
+}
+
+type Section struct {
+	Name        string
+	Description string
+	Fn          StatusFunc
+}
+
+type Handler struct {
+	mu       *sync.RWMutex // PROTECTS(sections)
+	sections map[string]*Section
+}
+
+func NewHandler() *Handler {
+	return &Handler{
+		mu:       &sync.RWMutex{},
+		sections: make(map[string]*Section, 0),
+	}
+}
+
+func (h *Handler) AddSection(name, description string, statusReporter StatusReporter) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.sections[name] = &Section{
+		Name:        name,
+		Description: description,
+		Fn:          statusReporter.Statusz,
+	}
+}
+
+type renderedSection struct {
+	Name        string
+	Description string
+	HTML        template.HTML
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	ctx := r.Context()
+	orderedSections := make([]*renderedSection, 0, len(h.sections))
+	for _, s := range h.sections {
+		rs := &renderedSection{
+			Name:        s.Name,
+			Description: s.Description,
+			HTML:        template.HTML(s.Fn(ctx)),
+		}
+		orderedSections = append(orderedSections, rs)
+	}
+	sort.Slice(orderedSections, func(i, j int) bool {
+		return orderedSections[i].Name < orderedSections[j].Name
+	})
+
+	data := struct {
+		BinaryName  string
+		Commit      string
+		Username    string
+		Hostname    string
+		StartTime   time.Time
+		CurrentTime time.Time
+		AppVersion  string
+		GoVersion   string
+		Sections    []*renderedSection
+	}{
+		BinaryName:  binaryName,
+		Commit:      version.Commit(),
+		Username:    username,
+		Hostname:    hostname,
+		StartTime:   startTime,
+		CurrentTime: time.Now(),
+		AppVersion:  version.AppVersion(),
+		GoVersion:   version.GoVersion(),
+		Sections:    orderedSections,
+	}
+	statusPageTemplate.Execute(w, data)
+}
+
+func AddSection(name, description string, statusReporter StatusReporter) {
+	DefaultHandler.AddSection(name, description, statusReporter)
+}
+
+func Server() http.Handler {
+	return DefaultHandler
+}

--- a/server/util/statusz/statusz.go
+++ b/server/util/statusz/statusz.go
@@ -21,52 +21,45 @@ const templateContents = `<!DOCTYPE html>
     <style>
 	body {
 	  font-family: sans-serif;
-	  background: #fff;
 	}
 	h1 {
-	  clear: both;
 	  width: 100%;
 	  text-align: center;
 	  font-size: 120%;
 	  background: #eeeeff;
 	}
 	h2 {
-	  clear: both;
 	  width: 100%;
 	  font-size: 110%;
 	  text-align: center;
 	  background: #fffddd;
 	}
-	.lefthand {
-	  float: left;
-	  width: 80%;
-	}
-	.righthand {
-	  text-align: right;
-	}
+        .header {
+          display: flex;
+          justify-content: space-between;
+        }
     </style>
   </head>
-    <h1>Status for {{.BinaryName}}</h1>
-  <div>
-  <div class=lefthand>
-    Started at <span>{{.StartTime.Format "Jan 02, 2006 15:04:05 PST" }}</span><br>
-    Current time <span>{{.CurrentTime.Format "Jan 02, 2006 15:04:05 PST" }}</span><br>
-    App Version <span>{{.AppVersion}} ({{.Commit}})</span><br>
-    Go Version <span>{{.GoVersion}}</span><br>
+  <h1>Status for {{.BinaryName}}</h1>
+  <div class=header>
+    <div>
+      <div>Started at {{.StartTime.Format "Jan 02, 2006 15:04:05 PST" }}</div>
+      <div>Current time {{.CurrentTime.Format "Jan 02, 2006 15:04:05 PST" }}</div>
+      <div>App Version {{.AppVersion}} ({{.Commit}})</div>
+      <div>Go Version {{.GoVersion}}</div>
+    </div>
+    <div>
+      {{.Username}}@{{.Hostname}}
+    </div>
   </div>
-  <div class=righthand>
-    {{.Username}}@{{.Hostname}}<br>
-  </div>
-
-  <br><br><br><br><br>
   {{range $idx, $item := .Sections}}
   <div>
     <h2>
       {{$item.Name}}
     </h2>
     <div>
-      {{$item.Description}}<br>
-      {{$item.HTML}}
+      <div>{{$item.Description}}</div>
+      <div>{{$item.HTML}}</div>
     </div>
   </div>
   {{end}}


### PR DESCRIPTION
This pretty much mimics a 'traditional' statusz endpoint and allows various backend services to report their own status in an easily digestible (html) format.


Screenshot, to convey the gist:

<img width="1412" alt="image" src="https://user-images.githubusercontent.com/141737/122090709-edacc280-cdbc-11eb-864a-97325db53fd2.png">


Fixes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/139