### PR TITLE
Add a background janitor thread to the disk cache.

### DIFF
--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -47,6 +47,7 @@ type DiskCache struct {
 	rootDir      string
 	prefix       string
 	diskIsMapped *bool
+	lastGCTime   time.Time
 }
 
 type fileRecord struct {
@@ -128,6 +129,7 @@ func (c *DiskCache) Statusz(ctx context.Context) string {
 	}
 	buf += fmt.Sprintf("<div>%d items (oldest: %s)</div>", c.l.Len(), oldestItem.Format("Jan 02, 2006 15:04:05 PST"))
 	buf += fmt.Sprintf("<div>Mapped into LRU: %t</div>", *c.diskIsMapped)
+	buf += fmt.Sprintf("<div>GC Last run: %s</div>", c.lastGCTime.Format("Jan 02, 2006 15:04:05 PST"))
 	return buf
 }
 
@@ -147,6 +149,7 @@ func (c *DiskCache) WithPrefix(prefix string) interfaces.Cache {
 		prefix:       newPrefix,
 		fileChannel:  c.fileChannel,
 		diskIsMapped: c.diskIsMapped,
+		lastGCTime:   c.lastGCTime,
 	}
 }
 
@@ -163,6 +166,7 @@ func (c *DiskCache) reduceCacheSize(targetSize int64) bool {
 	if f, ok := value.(*fileRecord); ok {
 		log.Debugf("Delete thread removed item from cache. Last use was: %s", f.lastUse)
 	}
+	c.lastGCTime = time.Now()
 	return true
 }
 

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -24,6 +24,16 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
+const (
+	// cutoffThreshold is the point above which a janitor thread will run
+	// and delete the oldest items from the cache.
+	janitorCutoffThreshold = .90
+
+	// janitorCheckPeriod is how often the janitor thread will wake up to
+	// check the cache size.
+	janitorCheckPeriod = 100 * time.Millisecond
+)
+
 // We keep a record (in memory) of file atime (Last Access Time) and size, and
 // when our cache reaches maxSize we remove the oldest files. Rather than
 // serialize this ledger, we regenerate it from scratch on startup by looking
@@ -96,6 +106,7 @@ func NewDiskCache(rootDir string, maxSizeBytes int64) (*DiskCache, error) {
 	if err := c.initializeCache(); err != nil {
 		return nil, err
 	}
+	c.startJanitor()
 	return c, nil
 }
 
@@ -116,6 +127,38 @@ func (c *DiskCache) WithPrefix(prefix string) interfaces.Cache {
 		fileChannel:  c.fileChannel,
 		diskIsMapped: c.diskIsMapped,
 	}
+}
+
+func (c *DiskCache) reduceCacheSize(targetSize int64) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.l.Size() < targetSize {
+		return false
+	}
+	_, value, ok := c.l.RemoveOldest()
+	if !ok {
+		return false // should never happen
+	}
+	if f, ok := value.(*fileRecord); ok {
+		log.Debugf("Delete thread removed item from cache. Last use was: %s", f.lastUse)
+	}
+	return true
+}
+
+func (c *DiskCache) startJanitor() {
+	targetSize := int64(float64(c.l.MaxSize()) * janitorCutoffThreshold)
+	go func() {
+		for {
+			select {
+			case <-time.After(janitorCheckPeriod):
+				for {
+					if !c.reduceCacheSize(targetSize) {
+						break
+					}
+				}
+			}
+		}
+	}()
 }
 
 func (c *DiskCache) initializeCache() error {

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -62,7 +62,7 @@ func getTmpDir(t *testing.T) string {
 }
 
 func TestGetSet(t *testing.T) {
-	maxSizeBytes := int64(1000000000) // 1GB
+	maxSizeBytes := int64(1_000_000_000) // 1GB
 	rootDir := getTmpDir(t)
 	dc, err := disk_cache.NewDiskCache(rootDir, maxSizeBytes)
 	if err != nil {
@@ -103,7 +103,7 @@ func randomDigests(t *testing.T, sizes ...int64) map[*repb.Digest][]byte {
 }
 
 func TestMultiGetSet(t *testing.T) {
-	maxSizeBytes := int64(1000000000) // 1GB
+	maxSizeBytes := int64(1_000_000_000) // 1GB
 	rootDir := getTmpDir(t)
 	dc, err := disk_cache.NewDiskCache(rootDir, maxSizeBytes)
 	if err != nil {
@@ -138,7 +138,7 @@ func TestMultiGetSet(t *testing.T) {
 }
 
 func TestReadWrite(t *testing.T) {
-	maxSizeBytes := int64(1000000000) // 1GB
+	maxSizeBytes := int64(1_000_000_000) // 1GB
 	rootDir := getTmpDir(t)
 	dc, err := disk_cache.NewDiskCache(rootDir, maxSizeBytes)
 	if err != nil {
@@ -264,7 +264,7 @@ func TestLRU(t *testing.T) {
 }
 
 func TestFileAtomicity(t *testing.T) {
-	maxSizeBytes := int64(100000000) // 100MB
+	maxSizeBytes := int64(100_000_000) // 100MB
 	rootDir := getTmpDir(t)
 	dc, err := disk_cache.NewDiskCache(rootDir, maxSizeBytes)
 	if err != nil {
@@ -294,7 +294,7 @@ func TestFileAtomicity(t *testing.T) {
 }
 
 func TestAsyncLoading(t *testing.T) {
-	maxSizeBytes := int64(100000000) // 100MB
+	maxSizeBytes := int64(100_000_000) // 100MB
 	rootDir := getTmpDir(t)
 	ctx := getAnonContext(t)
 	anonPath := filepath.Join(rootDir, "ANON")
@@ -356,7 +356,7 @@ func TestAsyncLoading(t *testing.T) {
 }
 
 func TestJanitorThread(t *testing.T) {
-	maxSizeBytes := int64(10000000) // 10MB
+	maxSizeBytes := int64(100_000_000) // 10MB
 	ctx := getAnonContext(t)
 	rootDir := getTmpDir(t)
 	dc, err := disk_cache.NewDiskCache(rootDir, maxSizeBytes)
@@ -380,16 +380,18 @@ func TestJanitorThread(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(time.Second)
+	// GC runs after 100ms, so give it a little time to delete the files.
+	time.Sleep(300 * time.Millisecond)
 	for i, d := range digests {
 		if i < 500 {
-			contains, err := dc.Contains(ctx, d)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if contains {
-				t.Fatalf("Expected oldest digest %+v to be deleted", d)
-			}
+			break
+		}
+		contains, err := dc.Contains(ctx, d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if contains {
+			t.Fatalf("Expected oldest digest %+v to be deleted", d)
 		}
 	}
 }

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -356,7 +356,7 @@ func TestAsyncLoading(t *testing.T) {
 }
 
 func TestJanitorThread(t *testing.T) {
-	maxSizeBytes := int64(100_000_000) // 10MB
+	maxSizeBytes := int64(10_000_000) // 10MB
 	ctx := getAnonContext(t)
 	rootDir := getTmpDir(t)
 	dc, err := disk_cache.NewDiskCache(rootDir, maxSizeBytes)
@@ -381,9 +381,9 @@ func TestJanitorThread(t *testing.T) {
 		t.Fatal(err)
 	}
 	// GC runs after 100ms, so give it a little time to delete the files.
-	time.Sleep(300 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 	for i, d := range digests {
-		if i < 500 {
+		if i > 500 {
 			break
 		}
 		contains, err := dc.Contains(ctx, d)


### PR DESCRIPTION
This should prevent the cache from ever reaching max capacity, which means that writes will not have to evict something before completing.