### PR TITLE
workflows: Add git provider interface

### DIFF
--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -69,4 +69,5 @@ type Env interface {
 	GetMetricsCollector() interfaces.MetricsCollector
 	GetRepoDownloader() interfaces.RepoDownloader
 	GetWorkflowService() interfaces.WorkflowService
+	GetGitProviders() interfaces.GitProviders
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -243,21 +243,28 @@ type GitProviders []GitProvider
 
 type GitProvider interface {
 	// MatchRepoURL returns whether a given repo URL should be handled by this
-	// provider.
+	// provider. If multiple providers match, the first one in the GitProviders
+	// list is chosen to handle the repo URL.
 	MatchRepoURL(u *url.URL) bool
+
 	// MatchWebhookRequest returns whether a given webhook request was sent by
-	// this git provider.
+	// this git provider. If multiple providers match, the first one in the
+	// GitProviders list is chosen to handle the webhook.
 	MatchWebhookRequest(req *http.Request) bool
+
 	// ParseWebhookData parses webhook data from the given HTTP request sent to
 	// a webhook endpoint. It should only be called if MatchWebhookRequest returns
 	// true.
 	ParseWebhookData(req *http.Request) (*WebhookData, error)
+
 	// IsRepoPrivate returns whether the repo is only viewable by its owner and
 	// trusted users.
 	IsRepoPrivate(ctx context.Context, accessToken, repoURL string) (bool, error)
+
 	// RegisterWebhook registers the given webhook URL to listen for push and
 	// pull request (also called "merge request") events.
 	RegisterWebhook(ctx context.Context, accessToken, repoURL, webhookURL string) (string, error)
+
 	// UnregisterWebhook unregisters the webhook with the given ID from the repo.
 	UnregisterWebhook(ctx context.Context, accessToken, repoURL, webhookID string) error
 
@@ -268,6 +275,7 @@ type GitProvider interface {
 type WebhookData struct {
 	// EventName is the canonical event name that this data was created from.
 	EventName string
+
 	// PushedBranch is the name of the branch in the source repo that triggered the
 	// event when pushed. Note that for forks, the branch here references the branch
 	// name in the forked repository, and the TargetBranch references the branch in
@@ -290,19 +298,23 @@ type WebhookData struct {
 	// - PushedBranch: "bar-feature" // in "some-user/example-fork" repo
 	// - TargetBranch: "main"        // in "example/example" repo
 	PushedBranch string
+
 	// TargetBranch is the branch associated with the event that determines whether
 	// actions should be triggered. For push events this is the branch that was
 	// pushed to. For pull_request events this is the base branch into which the PR
 	// branch is being merged.
 	TargetBranch string
+
 	// RepoURL points to the canonical repo URL containing the sources needed for the
 	// workflow.
 	//
 	// This will be different from the workflow repo if the workflow is run on a forked
 	// repo as part of a pull request.
 	RepoURL string
+
 	// SHA of the commit to be checked out.
 	SHA string
+
 	// IsRepoPrivate returns whether the repo is private.
 	IsRepoPrivate bool
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
@@ -236,6 +237,74 @@ type WorkflowService interface {
 	ExecuteWorkflow(ctx context.Context, req *wfpb.ExecuteWorkflowRequest) (*wfpb.ExecuteWorkflowResponse, error)
 	GetRepos(ctx context.Context, req *wfpb.GetReposRequest) (*wfpb.GetReposResponse, error)
 	ServeHTTP(w http.ResponseWriter, r *http.Request)
+}
+
+type GitProviders []GitProvider
+
+type GitProvider interface {
+	// MatchRepoURL returns whether a given repo URL should be handled by this
+	// provider.
+	MatchRepoURL(u *url.URL) bool
+	// MatchWebhookRequest returns whether a given webhook request was sent by
+	// this git provider.
+	MatchWebhookRequest(req *http.Request) bool
+	// ParseWebhookData parses webhook data from the given HTTP request sent to
+	// a webhook endpoint. It should only be called if MatchWebhookRequest returns
+	// true.
+	ParseWebhookData(req *http.Request) (*WebhookData, error)
+	// IsRepoPrivate returns whether the repo is only viewable by its owner and
+	// trusted users.
+	IsRepoPrivate(ctx context.Context, accessToken, repoURL string) (bool, error)
+	// RegisterWebhook registers the given webhook URL to listen for push and
+	// pull request (also called "merge request") events.
+	RegisterWebhook(ctx context.Context, accessToken, repoURL, webhookURL string) (string, error)
+	// UnregisterWebhook unregisters the webhook with the given ID from the repo.
+	UnregisterWebhook(ctx context.Context, accessToken, repoURL, webhookID string) error
+
+	// TODO(bduffany): CreateStatus, ListRepos
+}
+
+// WebhookData represents the data extracted from a Webhook event.
+type WebhookData struct {
+	// EventName is the canonical event name that this data was created from.
+	EventName string
+	// PushedBranch is the name of the branch in the source repo that triggered the
+	// event when pushed. Note that for forks, the branch here references the branch
+	// name in the forked repository, and the TargetBranch references the branch in
+	// the main repository into which the PushedBranch will be merged.
+	//
+	// Some examples:
+	//
+	// Push main branch (e.g. `git push main` or merge a PR into main):
+	// - RepoURL: "https://github.com/example/example.git"
+	// - PushedBranch: "main" // in "example/example" repo
+	// - TargetBranch: "main" // in "example/example" repo
+	//
+	// Push to a PR branch within the mainline repo:
+	// - RepoURL: "https://github.com/example/example.git"
+	// - PushedBranch: "foo-feature" // in "example/example" repo
+	// - TargetBranch: "main"        // in "example/example" repo
+	//
+	// Push to a PR branch within a forked repo:
+	// - RepoURL: "https://github.com/some-user/example-fork.git"
+	// - PushedBranch: "bar-feature" // in "some-user/example-fork" repo
+	// - TargetBranch: "main"        // in "example/example" repo
+	PushedBranch string
+	// TargetBranch is the branch associated with the event that determines whether
+	// actions should be triggered. For push events this is the branch that was
+	// pushed to. For pull_request events this is the base branch into which the PR
+	// branch is being merged.
+	TargetBranch string
+	// RepoURL points to the canonical repo URL containing the sources needed for the
+	// workflow.
+	//
+	// This will be different from the workflow repo if the workflow is run on a forked
+	// repo as part of a pull request.
+	RepoURL string
+	// SHA of the commit to be checked out.
+	SHA string
+	// IsRepoPrivate returns whether the repo is private.
+	IsRepoPrivate bool
 }
 
 type SplashPrinter interface {

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -38,6 +38,7 @@ type RealEnv struct {
 	taskRouter                       interfaces.TaskRouter
 	healthChecker                    interfaces.HealthChecker
 	workflowService                  interfaces.WorkflowService
+	gitProviders                     interfaces.GitProviders
 	staticFilesystem                 fs.FS
 	appFilesystem                    fs.FS
 	blobstore                        interfaces.Blobstore
@@ -283,6 +284,12 @@ func (r *RealEnv) GetWorkflowService() interfaces.WorkflowService {
 }
 func (r *RealEnv) SetWorkflowService(wf interfaces.WorkflowService) {
 	r.workflowService = wf
+}
+func (r *RealEnv) GetGitProviders() interfaces.GitProviders {
+	return r.gitProviders
+}
+func (r *RealEnv) SetGitProviders(gp interfaces.GitProviders) {
+	r.gitProviders = gp
 }
 
 func (r *RealEnv) SetCacheRedisClient(redisClient *redis.Client) {


### PR DESCRIPTION
This is a first step towards having an automated E2E test for workflows that doesn't depend on third party Git provider APIs. The plan is for the test to create a webhook, trigger the webhook (the fake git provider will directly return some fake webhook data in its impl of `ParseWebhookData`), then poll the invocation ID in the DB and make sure we can eventually find a completed workflow invocation.

In the future, we can consolidate all provider-specific integrations into this interface (LinkAccount, GetAccessTokenForAuthenticatedGroup, CreateStatus, ListRepos) so that a new implementation of this interface is all that's needed to get full support for the Git provider. This will also allow us to create an automated test that `CreateStatus` gets called for workflow invocations (since that's one of the expected outcomes of the E2E test).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
