### PR TITLE
Add prober that runs Bazel over a generated workspace.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -221,8 +221,8 @@ buildbuddy(name = "buildbuddy_toolchain")
 
 http_archive(
     name = "cloudprober",
+    build_file_content = "exports_files([\"cloudprober\"])",
     sha256 = "0a824a6e224d9810514f4a2f4a13f09488672ad483bb0e978c16d8a6b3372625",
     strip_prefix = "cloudprober-v0.11.2-ubuntu-x86_64",
     urls = ["https://github.com/google/cloudprober/releases/download/v0.11.2/cloudprober-v0.11.2-ubuntu-x86_64.zip"],
-    build_file_content = "exports_files([\"cloudprober\"])",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -218,3 +218,11 @@ buildbuddy_deps()
 load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "buildbuddy")
 
 buildbuddy(name = "buildbuddy_toolchain")
+
+http_archive(
+    name = "cloudprober",
+    sha256 = "0a824a6e224d9810514f4a2f4a13f09488672ad483bb0e978c16d8a6b3372625",
+    strip_prefix = "cloudprober-v0.11.2-ubuntu-x86_64",
+    urls = ["https://github.com/google/cloudprober/releases/download/v0.11.2/cloudprober-v0.11.2-ubuntu-x86_64.zip"],
+    build_file_content = "exports_files([\"cloudprober\"])",
+)

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -246,7 +246,7 @@ type invocationLog struct {
 
 func newInvocationLog() *invocationLog {
 	invLog := &invocationLog{writeListener: func() {}}
-	invLog.writer = io.MultiWriter(&invLog.LockingBuffer, os.Stdout)
+	invLog.writer = io.MultiWriter(&invLog.LockingBuffer, os.Stderr)
 	return invLog
 }
 

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -129,7 +129,7 @@ func init() {
 }
 
 func LocalLogger() zerolog.Logger {
-	output := zerolog.ConsoleWriter{Out: os.Stdout}
+	output := zerolog.ConsoleWriter{Out: os.Stderr}
 	output.FormatCaller = func(i interface{}) string {
 		s, ok := i.(string)
 		if !ok {

--- a/tools/probers/BUILD
+++ b/tools/probers/BUILD
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
+
+container_image(
+    name = "probers_image",
+    base = "@bazel_image_base//image",
+    entrypoint = [
+        "/cloudprober",
+        "--logtostderr",
+    ],
+    files = [
+        "//tools/probers/bazelrbe",
+        "@cloudprober",
+    ],
+    tars = [
+        "//server/util/bazel:bazel_binaries_tar",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+container_push(
+    name = "push_probers_image",
+    format = "Docker",
+    image = ":probers_image",
+
+    # Any of these components may have variables. They are set by passing
+    # --define version=1.2.3 as arguments to the bazel build command.
+    registry = "gcr.io",
+    repository = "flame-build/probers",  # Note flame-build, not flame-public.
+    tag = "$(version)",
+    tags = ["manual"],  # Don't include this target in wildcard patterns
+)

--- a/tools/probers/bazelrbe/BUILD
+++ b/tools/probers/bazelrbe/BUILD
@@ -17,4 +17,3 @@ go_binary(
     embed = [":bazelrbe_lib"],
     visibility = ["//visibility:public"],
 )
-

--- a/tools/probers/bazelrbe/BUILD
+++ b/tools/probers/bazelrbe/BUILD
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "bazelrbe_lib",
+    srcs = ["bazelrbe.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/tools/probers/bazelrbe",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//server/util/bazel",
+        "//server/util/log",
+        "//server/util/status",
+    ],
+)
+
+go_binary(
+    name = "bazelrbe",
+    embed = [":bazelrbe_lib"],
+    visibility = ["//visibility:public"],
+)
+

--- a/tools/probers/bazelrbe/bazelrbe.go
+++ b/tools/probers/bazelrbe/bazelrbe.go
@@ -1,0 +1,139 @@
+// bazelrbe is a prober that tests basic remote execution / caching.
+// This prober invokes Bazel on a workspace that contains targets that copy their inputs to outputs.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/bazel"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+)
+
+var (
+	bazelBinary = flag.String("bazel_binary", "", "Path to bazel binary")
+	bazelArgs   = flag.String("bazel_args", "", "Space separated list of args to pass to Bazel")
+
+	numTargets         = flag.Int("num_targets", 10, "Number targets to generate")
+	numInputsPerTarget = flag.Int("num_inputs_per_target", 10, "Number of inputs each generated target will have")
+	inputSizeBytes     = flag.Int("input_size_bytes", 100_000, "Size of each input file")
+)
+
+// createEchoRule creates a target that generates an action that echoes the contents of each input file to a separate
+// output file.
+func createEchoRule(targetName string, inputs, outputs []string) (string, error) {
+	if len(inputs) != len(outputs) {
+		return "", status.FailedPreconditionError("number inputs doesn't match number of outputs")
+	}
+
+	var srcs, outs []string
+	for i, input := range inputs {
+		srcs = append(srcs, `"`+input+`"`)
+		outs = append(outs, `"`+outputs[i]+`"`)
+	}
+
+	return fmt.Sprintf(`
+genrule(
+      name = "%s",
+      srcs = [%s],
+      outs = [%s],
+      cmd_bash = """
+		  srcs=($(SRCS))
+		  outs=($(OUTS))
+		  for ((i=0; i < $${#srcs[@]}; i++)); do
+			src=$${srcs[i]}  
+			out=$${outs[i]}
+			/bin/cat "$$src" > "$$out"
+		  done
+      """,
+)
+`, targetName, strings.Join(srcs, ","), strings.Join(outs, ",")), nil
+}
+
+func createWorkspace(dir string, numTargets, numInputsPerTarget, inputSizeBytes int) error {
+	err := os.WriteFile(filepath.Join(dir, "WORKSPACE"), []byte(""), 0644)
+	if err != nil {
+		return err
+	}
+
+	buildFile, err := os.Create(filepath.Join(dir, "BUILD"))
+	if err != nil {
+		return err
+	}
+	defer buildFile.Close()
+	inputBuf := make([]byte, inputSizeBytes)
+	for targetIdx := 0; targetIdx < numTargets; targetIdx++ {
+		var inputs []string
+		var outputs []string
+		for inputIdx := 0; inputIdx < numInputsPerTarget; inputIdx++ {
+			if _, err := rand.Read(inputBuf); err != nil {
+				return err
+			}
+			src := fmt.Sprintf("target%d_input%d", targetIdx, inputIdx)
+			out := fmt.Sprintf("target%d_output%d", targetIdx, inputIdx)
+			if err := os.WriteFile(filepath.Join(dir, src), inputBuf, 0644); err != nil {
+				return err
+			}
+			inputs = append(inputs, src)
+			outputs = append(outputs, out)
+		}
+		rule, err := createEchoRule(fmt.Sprintf("target%d", targetIdx), inputs, outputs)
+		if err != nil {
+			return err
+		}
+		if _, err = buildFile.WriteString(rule); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func runProbe() error {
+	workspaceDir, err := os.MkdirTemp("", "bazelrbeprober-*")
+	if err != nil {
+		log.Fatalf("Could not create temporary workspace directory: %s", err)
+	}
+	log.Infof("Workspace directory: %s", workspaceDir)
+	defer func() {
+		log.Infof("Cleaning up workspace directory %s", workspaceDir)
+		if err := os.RemoveAll(workspaceDir); err != nil {
+			log.Warningf("Could not cleanup temporary workspace: %s", err)
+		}
+	}()
+
+	err = createWorkspace(workspaceDir, *numTargets, *numInputsPerTarget, *inputSizeBytes)
+	if err != nil {
+		return status.UnknownErrorf("Could not populate workspace: %s", err)
+	}
+
+	args := []string{"//:all"}
+	if *bazelArgs != "" {
+		for _, extraArg := range strings.Split(*bazelArgs, " ") {
+			args = append(args, extraArg)
+		}
+	}
+	res := bazel.Invoke(context.Background(), *bazelBinary, workspaceDir, "build", args...)
+	if res.Error != nil {
+		return status.UnknownErrorf("Bazel did not exit successfully: %s", res.Error)
+	}
+	return nil
+}
+
+func main() {
+	flag.Parse()
+	if *bazelBinary == "" {
+		log.Fatalf("--bazel_binary is required")
+	}
+
+	err := runProbe()
+	if err != nil {
+		log.Fatalf("Probe failure: %s", err)
+	}
+}


### PR DESCRIPTION
The generated workspace includes rules that generate actions that copy
their inputs to their outputs.

This PR also adds a new container image that contains the cloudprober
binary, the bazelrbe prober binary as well as the bazel binaries.

Lastly this also changes console logging to write to stderr instead of
stdout which is a common convention.
(cloudprober consumes prober stdout for any custom metrics that the
prober wants to provide.)

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
