### PR TITLE
workflows: Do all work in the home directory instead of the mounted workspace volume

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -110,7 +110,9 @@ func main() {
 	// Put all files in the home directory to prevent any potential issues caused
 	// by the bazel cache directory living on a different filesystem than the
 	// workspace volume.
-	os.Chdir("/root")
+	if err := os.Chdir("/root"); err != nil {
+		fatal(err)
+	}
 	if err := setupGitRepo(ctx); err != nil {
 		fatal(status.WrapError(err, "failed to set up git repo"))
 	}

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -107,6 +107,10 @@ func main() {
 
 	ctx := context.Background()
 
+	// Put all files in the home directory to prevent any potential issues caused
+	// by the bazel cache directory living on a different filesystem than the
+	// workspace volume.
+	os.Chdir("/root")
 	if err := setupGitRepo(ctx); err != nil {
 		fatal(status.WrapError(err, "failed to set up git repo"))
 	}


### PR DESCRIPTION
This will let us rule out the "source forest creation failed" bug being due to the bazel workspace dir living on a different filesystem than the bazel cache dir (in `/root/.cache`).

The downside to this approach is that we are no longer computing accurate disk usage estimates, since the workspace is now essentially empty (except for the CI runner binary). In a follow-up PR, we can correct the disk usage estimate by having the CI runner compute its own disk usage at the end of each workflow run (and write a file like `du.txt` under the workspace root).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
