### PR TITLE
Update Bazel invoker to stream output to log.

### DIFF
--- a/server/util/bazel/bazel.go
+++ b/server/util/bazel/bazel.go
@@ -34,7 +34,7 @@ func (w *bazelStderrHandler) Write(b []byte) (int, error) {
 	if m := invocationIDRegexp.FindAllStringSubmatch(line, -1); len(m) > 0 {
 		w.invocationID = m[0][1]
 	}
-	log.Infof("[bazel] %s", strings.TrimSuffix(string(b), "\n"))
+	log.Infof("[bazel] %s", strings.TrimSuffix(line, "\n"))
 	return len(b), nil
 }
 


### PR DESCRIPTION
For the prober we don't get any Bazel output if the probe times out and
gets killed.

Note that this will also affect tests that invoke Bazel.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
