### PR TITLE
Fixes / improvements to clang-format check

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -39,7 +39,8 @@ jobs:
 
       - name: clang-format
         run: |
-          git ls-files | grep '\.proto$' | xargs -d'\n' clang-format -i --style=Google --dry-run > clang-format-errors.txt || true
+          git ls-files | grep '\.proto$' | xargs -d'\n' clang-format -i --style=Google --dry-run &> clang-format-errors.txt || true
+          clang-format --version
           echo "clang format errors:"
           cat clang-format-errors.txt
 


### PR DESCRIPTION
* Make sure clang-format's stderr gets included in `clang-format-errors.txt` - otherwise the check always passes even if there are errors
* Print clang-format version so we can see which version GitHub's action runner is using (helpful to diagnose inconsistencies w/ `buildfix.sh`)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
