### PR TITLE
Disambiguate ByteStream and DistributedDisk RPCs in logs.

### DIFF
--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -92,6 +92,8 @@ func LogGRPCRequest(ctx context.Context, fullMethod string, dur time.Duration, e
 		return
 	}
 	reqID, _ := uuid.GetFromContext(ctx) // Ignore error, we're logging anyway.
+	// ByteStream and DistributedCache services share some method names.
+	// We disambiguate them in the logs by adding a D prefix to DistributedCache methods.
 	fullMethod = strings.Replace(fullMethod, "distributed_cache.DistributedCache/", "D", 1)
 	shortPath := "/" + path.Base(fullMethod)
 	if iid := getInvocationIDFromMD(ctx); iid != "" {

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -90,10 +92,12 @@ func LogGRPCRequest(ctx context.Context, fullMethod string, dur time.Duration, e
 		return
 	}
 	reqID, _ := uuid.GetFromContext(ctx) // Ignore error, we're logging anyway.
+	fullMethod = strings.Replace(fullMethod, "distributed_cache.DistributedCache/", "D", 1)
+	shortPath := "/" + path.Base(fullMethod)
 	if iid := getInvocationIDFromMD(ctx); iid != "" {
-		Infof("%s %s %s %s %s [%s]", "gRPC", reqID, iid, fullMethod, fmtErr(err), formatDuration(dur))
+		Infof("%s %s %s %s %s [%s]", "gRPC", reqID, iid, shortPath, fmtErr(err), formatDuration(dur))
 	} else {
-		Infof("%s %s %s %s [%s]", "gRPC", reqID, fullMethod, fmtErr(err), formatDuration(dur))
+		Infof("%s %s %s %s [%s]", "gRPC", reqID, shortPath, fmtErr(err), formatDuration(dur))
 	}
 	if logErrorStackTraces {
 		code := gstatus.Code(err)

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -91,11 +90,10 @@ func LogGRPCRequest(ctx context.Context, fullMethod string, dur time.Duration, e
 		return
 	}
 	reqID, _ := uuid.GetFromContext(ctx) // Ignore error, we're logging anyway.
-	shortPath := "/" + path.Base(fullMethod)
 	if iid := getInvocationIDFromMD(ctx); iid != "" {
-		Infof("%s %s %s %s %s [%s]", "gRPC", reqID, iid, shortPath, fmtErr(err), formatDuration(dur))
+		Infof("%s %s %s %s %s [%s]", "gRPC", reqID, iid, fullMethod, fmtErr(err), formatDuration(dur))
 	} else {
-		Infof("%s %s %s %s [%s]", "gRPC", reqID, shortPath, fmtErr(err), formatDuration(dur))
+		Infof("%s %s %s %s [%s]", "gRPC", reqID, fullMethod, fmtErr(err), formatDuration(dur))
 	}
 	if logErrorStackTraces {
 		code := gstatus.Code(err)


### PR DESCRIPTION
We now have services that contain the same methods (e.g. Read) and it's
useful to know which service is being called.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
