### PR TITLE
Make request_context available in regular gRPC requests

### DIFF
--- a/server/http/protolet/BUILD
+++ b/server/http/protolet/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/http/protolet",
     visibility = ["//visibility:public"],
     deps = [
-        "//proto:context_go_proto",
         "//server/util/log",
         "//server/util/request_context",
         "@com_github_golang_protobuf//jsonpb:go_default_library_gen",

--- a/server/http/protolet/protolet.go
+++ b/server/http/protolet/protolet.go
@@ -12,8 +12,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/request_context"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
-
-	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
 )
 
 const (

--- a/server/rpc/filters/BUILD
+++ b/server/rpc/filters/BUILD
@@ -8,7 +8,9 @@ go_library(
     deps = [
         "//server/environment",
         "//server/util/log",
+        "//server/util/request_context",
         "//server/util/uuid",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_grpc_ecosystem_go_grpc_prometheus//:go-grpc-prometheus",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//metadata",

--- a/server/rpc/filters/filters.go
+++ b/server/rpc/filters/filters.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/uuid"
-
+	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
 	bblog "github.com/buildbuddy-io/buildbuddy/server/util/log"
+	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 )
 
@@ -130,6 +131,19 @@ func requestIDUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return contextReplacingUnaryServerInterceptor(addRequestIdToContext)
 }
 
+// requestContextProtoUnaryServerInterceptor is a server interceptor that
+// copies the request context from the request message into the context.
+func requestContextProtoUnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		msg, ok := req.(proto.Message)
+		if ok {
+			protoCtx := requestcontext.GetProtoRequestContext(msg)
+			ctx = requestcontext.ContextWithProtoRequestContext(ctx, protoCtx)
+		}
+		return handler(ctx, req)
+	}
+}
+
 // logRequestUnaryServerInterceptor defers a call to log the GRPC request.
 func logRequestUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
@@ -178,6 +192,7 @@ func GetUnaryInterceptor(env environment.Env) grpc.ServerOption {
 	return grpc.ChainUnaryInterceptor(
 		requestIDUnaryServerInterceptor(),
 		logRequestUnaryServerInterceptor(),
+		requestContextProtoUnaryServerInterceptor(),
 		authUnaryServerInterceptor(env),
 		copyHeadersUnaryServerInterceptor(),
 	)

--- a/server/util/request_context/BUILD
+++ b/server/util/request_context/BUILD
@@ -7,5 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:context_go_proto",
+        "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/server/util/request_context/request_context.go
+++ b/server/util/request_context/request_context.go
@@ -2,6 +2,9 @@ package requestcontext
 
 import (
 	"context"
+	"reflect"
+
+	"github.com/golang/protobuf/proto"
 
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
 )
@@ -20,4 +23,36 @@ func ProtoRequestContextFromContext(ctx context.Context) *ctxpb.RequestContext {
 		return nil
 	}
 	return val.(*ctxpb.RequestContext)
+}
+
+func GetProtoRequestContext(req proto.Message) *ctxpb.RequestContext {
+	protoType := reflect.TypeOf(req)
+	for i := 0; i < protoType.NumMethod(); i++ {
+		method := protoType.Method(i)
+		if !isGetRequestContextMethod(method) {
+			continue
+		}
+		args := []reflect.Value{reflect.ValueOf(req)}
+		ctxArr := method.Func.Call(args)
+		return ctxArr[0].Interface().(*ctxpb.RequestContext)
+	}
+	return nil
+}
+
+func isGetRequestContextMethod(m reflect.Method) bool {
+	t := m.Type
+	if t.Kind() != reflect.Func {
+		return false
+	}
+	if m.Name != "GetRequestContext" {
+		return false
+	}
+	if t.NumIn() != 1 || t.NumOut() != 1 {
+		return false
+	}
+	// TODO: Figure out why this doesn't work
+	// if !t.Out(0).Implements(reflect.TypeOf((*ctxpb.RequestContext)(nil)).Elem()) {
+	// 	return false
+	// }
+	return true
 }

--- a/server/util/request_context/request_context.go
+++ b/server/util/request_context/request_context.go
@@ -2,7 +2,6 @@ package requestcontext
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/golang/protobuf/proto"
 
@@ -25,34 +24,13 @@ func ProtoRequestContextFromContext(ctx context.Context) *ctxpb.RequestContext {
 	return val.(*ctxpb.RequestContext)
 }
 
-func GetProtoRequestContext(req proto.Message) *ctxpb.RequestContext {
-	protoType := reflect.TypeOf(req)
-	for i := 0; i < protoType.NumMethod(); i++ {
-		method := protoType.Method(i)
-		if !isGetRequestContextMethod(method) {
-			continue
-		}
-		args := []reflect.Value{reflect.ValueOf(req)}
-		ctxArr := method.Func.Call(args)
-		return ctxArr[0].Interface().(*ctxpb.RequestContext)
-	}
-	return nil
+type requestContextGetter interface {
+	GetRequestContext() *ctxpb.RequestContext
 }
 
-func isGetRequestContextMethod(m reflect.Method) bool {
-	t := m.Type
-	if t.Kind() != reflect.Func {
-		return false
+func GetProtoRequestContext(req proto.Message) *ctxpb.RequestContext {
+	if req, ok := req.(requestContextGetter); ok {
+		return req.GetRequestContext()
 	}
-	if m.Name != "GetRequestContext" {
-		return false
-	}
-	if t.NumIn() != 1 || t.NumOut() != 1 {
-		return false
-	}
-	// TODO: Figure out why this doesn't work
-	// if !t.Out(0).Implements(reflect.TypeOf((*ctxpb.RequestContext)(nil)).Elem()) {
-	// 	return false
-	// }
-	return true
+	return nil
 }

--- a/server/util/request_context/request_context.go
+++ b/server/util/request_context/request_context.go
@@ -24,12 +24,10 @@ func ProtoRequestContextFromContext(ctx context.Context) *ctxpb.RequestContext {
 	return val.(*ctxpb.RequestContext)
 }
 
-type requestContextGetter interface {
-	GetRequestContext() *ctxpb.RequestContext
-}
-
 func GetProtoRequestContext(req proto.Message) *ctxpb.RequestContext {
-	if req, ok := req.(requestContextGetter); ok {
+	if req, ok := req.(interface {
+		GetRequestContext() *ctxpb.RequestContext
+	}); ok {
 		return req.GetRequestContext()
 	}
 	return nil


### PR DESCRIPTION
If we pass `RequestContext` via a plain old gRPC (bypassing protolet, as we do in some unit tests) then it doesn't get set via the protolet filter and `ProtoRequestContextFromContext` returns `nil`, causing some codepaths not to work.

This makes the `RequestContext` universally available in `ctx` by adding the extraction logic to the RPC filters as well.

This also cleans up the unnecessary usage of the "reflect" package.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
