### PR TITLE
workflows: Make CI runner image compatible with more repos

### DIFF
--- a/enterprise/dockerfiles/ci_runner_image/Dockerfile
+++ b/enterprise/dockerfiles/ci_runner_image/Dockerfile
@@ -1,11 +1,11 @@
-FROM gcr.io/cloud-marketplace/google/debian10@sha256:c571e553cdaa91b1f16c190a049ccef828234ac47a0e8ef40c84240e62108591
+FROM gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:5464e3e83dc656fc6e4eae6a01f5c2645f1f7e95854b3802b85e86484132d90e
 
-RUN apt-get update && apt-get install -y curl git rpm build-essential
+RUN apt-get update && apt-get install -y build-essential
 
 # Install bazelisk
 RUN curl -Lo /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.5/bazelisk-linux-amd64 && \
     chmod +x /usr/local/bin/bazelisk
 
-# Pre-install bazel 3.7.0 to avoid bazelisk downloading & installing bazel on every
+# Pre-install bazel 4.1.0 to avoid bazelisk downloading & installing bazel on every
 # CI run, at least for CI runs on the BuildBuddy repo itself.
-RUN USE_BAZEL_VERSION=3.7.0 bazelisk version
+RUN USE_BAZEL_VERSION=4.1.0 bazelisk version

--- a/enterprise/dockerfiles/ci_runner_image/Dockerfile
+++ b/enterprise/dockerfiles/ci_runner_image/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:5464e3e83dc656fc6e4eae6a01f5c2645f1f7e95854b3802b85e86484132d90e
+FROM gcr.io/cloud-marketplace/google/rbe-ubuntu18-04@sha256:48b67b41118dbcdfc265e7335f454fbefa62681ab8d47200971fc7a52fb32054
 
 RUN apt-get update && apt-get install -y build-essential
 

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -41,7 +41,7 @@ import (
 )
 
 const (
-	workflowsImage = "docker://gcr.io/flame-public/buildbuddy-ci-runner:v1.7.1"
+	workflowsImage = "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.2.7"
 )
 
 var (


### PR DESCRIPTION
Tested our existing CI runner image with a bunch of different repos. Results are here: https://docs.google.com/document/d/1W-pdf8a_AQIiI_dqk1r6nd6W2d_NcODZ5qsPVNC7vMQ/edit#heading=h.i42bw6n4ciwh

TL;DR is that we should switch over to the same base image that we use for our default execution image (google RBE / ubuntu 16.04), as it is compatible with a lot more repos (mainly because it has Java 8 and Python3 + Pip pre-installed).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
