### PR TITLE
Avoid blocking RPCs between distributed disk peers.

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -534,13 +534,7 @@ func (c *Cache) distributedReader(ctx context.Context, d *repb.Digest, offset in
 	}
 
 	for peer := ps.GetNextPeer(); peer != ""; peer = ps.GetNextPeer() {
-		readStart := time.Now()
 		r, err := c.remoteReader(ctx, peer, c.prefix, d, offset)
-		elapsed := time.Now().Sub(readStart)
-		if elapsed > 5*time.Second {
-			log.Warningf("Reader(%q) on peer %s took %s with err %v", c.prefix+d.GetHash(), peer, elapsed, err)
-		}
-
 		if err == nil {
 			c.log.Debugf("Reader(%q) found on peer %s", c.prefix+d.GetHash(), peer)
 			backfill()

--- a/enterprise/server/util/cacheproxy/BUILD
+++ b/enterprise/server/util/cacheproxy/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//server/util/prefix",
         "//server/util/status",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//connectivity",
         "@org_golang_google_grpc//reflection",
     ],
 )


### PR DESCRIPTION
gRPC can block an RPC, regardless of its failfast settings, while the underlying connection remains in CONNECTING state which we have experienced during rollouts and node preemptions.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
