### PR TITLE
Make some improvements to buildfix.sh

### DIFF
--- a/buildfix.sh
+++ b/buildfix.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"
 # If ~/go/bin exists, make sure we respect it
 export PATH="$PATH:$HOME/go/bin"
 
-gazelle=$([[ "$1" == '-g' ]] || [[ "$1" == '--gazelle' ]] && echo 1 || echo 0)
+gazelle=$([[ "${1:-}" == '-g' ]] || [[ "${1:-}" == '--gazelle' ]] && echo 1 || echo 0)
 
 c_yellow="\x1b[33m"
 c_reset="\x1b[0m"

--- a/buildfix.sh
+++ b/buildfix.sh
@@ -1,22 +1,47 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+
+cd "$(dirname "$0")"
 
 gazelle=0
+stage=0
+commit=0
 push=0
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
   -g | --gazelle)
     gazelle=1
     ;;
+  -s | --stage)
+    stage=1
+    ;;
+  -c | --commit)
+    stage=1
+    commit=1
+    ;;
   -p | --push)
+    stage=1
+    commit=1
     push=1
     ;;
+  *)
+    echo "Usage: $0 [-g] [-s | -c | -p]"
+    echo ""
+    echo "Fix options:"
+    echo "  -g, --gazelle  Run gazelle"
+    echo ""
+    echo "Git options:"
+    echo "  -s, --stage    Interactively stage files ('git add') after formatting."
+    echo "  -c, --commit   Commit staged files. Has no effect if there are existing staged changes. Implies -s."
+    echo "  -p, --push     Push any commits that are made. Implies -c."
+    exit 1
+    ;;
   esac
+
   shift
 done
 
 c_yellow="\x1b[33m"
-c_green="\x1b[32m"
 c_reset="\x1b[0m"
 
 modified_before=$(mktemp)
@@ -40,39 +65,46 @@ if which clang-format &>/dev/null; then
   echo "Formatting .proto files..."
   git ls-files --exclude-standard | grep '\.proto$' | xargs -d '\n' --no-run-if-empty clang-format -i --style=Google
 else
-  echo -e "${c_yellow}WARNING: Missing clang-format; will not format proto files.${c_reset}"
+  echo -e "${c_yellow}WARNING: Missing clang-format tool; will not format proto files.${c_reset}"
 fi
 
+echo "Formatting frontend and markup files..."
+bazel run --ui_event_filters=-info,-stdout,-stderr --noshow_progress //tools/prettier:fix
+
 if ((gazelle)); then
-  echo "Running gazelle..."
-  bazel run //:gazelle
+  echo "Fixing BUILD dependencies with gazelle..."
+  bazel run --ui_event_filters=-info,-stdout,-stderr --noshow_progress //:gazelle
 fi
 
 git diff --name-only | sort >"$modified_after"
 
 echo 'All done!'
 
-# If no stdin is attached, skip interactive prompts.
-[ -t 0 ] || exit 0
+if ! ((stage)); then
+  exit
+fi
+if ! [ -t 0 ] || ! [ -t 1 ]; then
+  echo -e "${c_yellow}WARNING: not connected to a terminal; skipping interactive staging.${c_reset}"
+  exit 1
+fi
 
 export PATH="$PATH:$HOME/go/bin"
-if ! which fzf path-extractor &>/dev/null; then
-  echo -e "${c_green}TIP${c_reset}: Install fzf and path-extractor to interactively stage formatted files:"
-  echo '  go get -u github.com/edi9999/path-extractor/path-extractor'
-  echo '  go get -u github.com/junegunn/fzf'
-  exit
+if ! which fzf &>/dev/null; then
+  echo -e "${c_yellow}WARNING: Missing fzf tool; did not stage any changes.${c_reset}"
+  exit 1
 fi
 
 # Auto-commit only if there are no files staged before
 # selecting files to add.
-autocommit=$(git diff --staged --quiet && echo '1' || echo '0')
+if ((commit)); then
+  commit=$(git diff --staged --quiet && echo '1' || echo '0')
+fi
 
 diff -Pdpru "$modified_before" "$modified_after" | perl -n -e '/^\+([^+].*)/ && print "./$1\n"' |
-  path-extractor |
   fzf --exit-0 --prompt='Stage modified files? Select with Arrows, Tab, Shift+Tab, Enter; quit with Ctrl+C > ' --multi |
   xargs -d '\n' --no-run-if-empty git add
 
-if ((autocommit)) && ! git diff --staged --quiet; then
+if ((commit)) && ! git diff --staged --quiet; then
   git commit -m "Fix formatting / build issues"
   if ((push)); then
     git push

--- a/buildfix.sh
+++ b/buildfix.sh
@@ -104,7 +104,7 @@ diff -Pdpru "$modified_before" "$modified_after" | perl -n -e '/^\+([^+].*)/ && 
 if ((commit)) && ! git diff --staged --quiet; then
   if ! ((prev_stage_clean)); then
     echo -e "${c_yellow}WARNING: Files will need to be manually committed since there were existing staged files.${c_reset}"
-    exit
+    exit 1
   fi
 
   git commit -m "Fix formatting / build issues"

--- a/buildfix.sh
+++ b/buildfix.sh
@@ -6,55 +6,10 @@ cd "$(dirname "$0")"
 # If ~/go/bin exists, make sure we respect it
 export PATH="$PATH:$HOME/go/bin"
 
-gazelle=0
-stage=0
-commit=0
-push=0
-while [[ "$#" -gt 0 ]]; do
-  case "$1" in
-  -g | --gazelle)
-    gazelle=1
-    ;;
-  -s | --stage)
-    stage=1
-    ;;
-  -c | --commit)
-    stage=1
-    commit=1
-    ;;
-  -p | --push)
-    stage=1
-    commit=1
-    push=1
-    ;;
-  *)
-    echo "Usage: $0 [-g] [-s | -c | -p]"
-    echo ""
-    echo "Fix options:"
-    echo "  -g, --gazelle  Run gazelle"
-    echo ""
-    echo "Git options:"
-    echo "  -s, --stage    Interactively stage files ('git add') after formatting."
-    echo "  -c, --commit   Commit staged files. Has no effect if there are existing staged changes. Implies -s."
-    echo "  -p, --push     Push any commits that are made. Implies -c."
-    exit 1
-    ;;
-  esac
-
-  shift
-done
+gazelle=$([[ "$1" == '-g' ]] || [[ "$1" == '--gazelle' ]] && echo 1 || echo 0)
 
 c_yellow="\x1b[33m"
 c_reset="\x1b[0m"
-
-modified_before=$(mktemp)
-modified_after=$(mktemp)
-cleanup() {
-  rm "$modified_before" "$modified_after"
-  trap cleanup EXIT
-}
-
-git diff --name-only | sort >"$modified_before"
 
 # buildifier format all BUILD files
 echo "Formatting WORKSPACE/BUILD files..."
@@ -75,7 +30,7 @@ echo "Formatting frontend and markup files with prettier..."
 if which node prettier &>/dev/null; then
   BUILD_WORKSPACE_PATH="$(pwd)" ./tools/prettier/prettier.sh "$(which node)" "$(which prettier)" --write
 else
-  bazel run --ui_event_filters=-info,-stdout,-stderr --noshow_progress //tools/prettier:fix
+  bazel run //tools/prettier:fix
 fi
 
 if ((gazelle)); then
@@ -83,42 +38,8 @@ if ((gazelle)); then
   if which gazelle &>/dev/null; then
     gazelle
   else
-    bazel run --ui_event_filters=-info,-stdout,-stderr --noshow_progress //:gazelle
+    bazel run //:gazelle
   fi
 fi
-
-git diff --name-only | sort >"$modified_after"
 
 echo 'All done!'
-
-if ! ((stage)); then
-  exit
-fi
-if ! [ -t 0 ] || ! [ -t 1 ]; then
-  echo -e "${c_yellow}WARNING: not connected to a terminal; skipping interactive staging.${c_reset}"
-  exit 1
-fi
-
-if ! which fzf &>/dev/null; then
-  echo -e "${c_yellow}WARNING: Missing fzf tool; did not stage any changes.${c_reset}"
-  exit 1
-fi
-
-# Only commit staged files if there were no files staged before running this script.
-prev_stage_clean=$(git diff --staged --quiet && echo 1 || echo 0)
-
-diff -Pdpru "$modified_before" "$modified_after" | perl -n -e '/^\+([^+].*)/ && print "./$1\n"' |
-  fzf --exit-0 --prompt='Stage modified files? Select with Arrows, Tab, Shift+Tab, Enter; quit with Ctrl+C > ' --multi |
-  xargs -d '\n' --no-run-if-empty git add
-
-if ((commit)) && ! git diff --staged --quiet; then
-  if ! ((prev_stage_clean)); then
-    echo -e "${c_yellow}WARNING: Files will need to be manually committed since there were existing staged files.${c_reset}"
-    exit 1
-  fi
-
-  git commit -m "Fix formatting / build issues (buildfix.sh)"
-  if ((push)); then
-    git push
-  fi
-fi

--- a/buildfix.sh
+++ b/buildfix.sh
@@ -21,7 +21,10 @@ gofmt -w .
 
 if which clang-format &>/dev/null; then
   echo "Formatting .proto files..."
-  git ls-files --exclude-standard | grep '\.proto$' | xargs -d '\n' --no-run-if-empty clang-format -i --style=Google
+  protos=("$(git ls-files --exclude-standard | grep '\.proto$')")
+  if [ ${#protos[@]} -gt 0 ]; then
+    clang-format -i --style=Google "${protos[@]}"
+  fi
 else
   echo -e "${c_yellow}WARNING: Missing clang-format tool; will not format proto files.${c_reset}"
 fi

--- a/buildfix.sh
+++ b/buildfix.sh
@@ -1,8 +1,32 @@
 #!/bin/bash
 set -e
 
+gazelle=0
+push=0
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+  -g | --gazelle)
+    gazelle=1
+    ;;
+  -p | --push)
+    push=1
+    ;;
+  esac
+  shift
+done
+
 c_yellow="\x1b[33m"
+c_green="\x1b[32m"
 c_reset="\x1b[0m"
+
+modified_before=$(mktemp)
+modified_after=$(mktemp)
+cleanup() {
+  rm "$modified_before" "$modified_after"
+  trap cleanup EXIT
+}
+
+git diff --name-only | sort >"$modified_before"
 
 # buildifier format all BUILD files
 echo "Formatting WORKSPACE/BUILD files..."
@@ -14,9 +38,43 @@ gofmt -w .
 
 if which clang-format &>/dev/null; then
   echo "Formatting .proto files..."
-  clang-format -i --style=Google $(git ls-files --exclude-standard | grep '\.proto$')
+  git ls-files --exclude-standard | grep '\.proto$' | xargs -d '\n' --no-run-if-empty clang-format -i --style=Google
 else
   echo -e "${c_yellow}WARNING: Missing clang-format; will not format proto files.${c_reset}"
 fi
 
-echo "All Done!"
+if ((gazelle)); then
+  echo "Running gazelle..."
+  bazel run //:gazelle
+fi
+
+git diff --name-only | sort >"$modified_after"
+
+echo 'All done!'
+
+# If no stdin is attached, skip interactive prompts.
+[ -t 0 ] || exit 0
+
+export PATH="$PATH:$HOME/go/bin"
+if ! which fzf path-extractor &>/dev/null; then
+  echo -e "${c_green}TIP${c_reset}: Install fzf and path-extractor to interactively stage formatted files:"
+  echo '  go get -u github.com/edi9999/path-extractor/path-extractor'
+  echo '  go get -u github.com/junegunn/fzf'
+  exit
+fi
+
+# Auto-commit only if there are no files staged before
+# selecting files to add.
+autocommit=$(git diff --staged --quiet && echo '1' || echo '0')
+
+diff -Pdpru "$modified_before" "$modified_after" | perl -n -e '/^\+([^+].*)/ && print "./$1\n"' |
+  path-extractor |
+  fzf --exit-0 --prompt='Stage modified files? Select with Arrows, Tab, Shift+Tab, Enter; quit with Ctrl+C > ' --multi |
+  xargs -d '\n' --no-run-if-empty git add
+
+if ((autocommit)) && ! git diff --staged --quiet; then
+  git commit -m "Fix formatting / build issues"
+  if ((push)); then
+    git push
+  fi
+fi

--- a/buildfix.sh
+++ b/buildfix.sh
@@ -28,7 +28,7 @@ fi
 
 echo "Formatting frontend and markup files with prettier..."
 if which node prettier &>/dev/null; then
-  BUILD_WORKSPACE_PATH="$(pwd)" ./tools/prettier/prettier.sh "$(which node)" "$(which prettier)" --write
+  BUILD_WORKSPACE_DIRECTORY="$(pwd)" ./tools/prettier/prettier.sh "$(which node)" "$(which prettier)" --write
 else
   bazel run //tools/prettier:fix
 fi

--- a/buildfix.sh
+++ b/buildfix.sh
@@ -117,7 +117,7 @@ if ((commit)) && ! git diff --staged --quiet; then
     exit 1
   fi
 
-  git commit -m "Fix formatting / build issues"
+  git commit -m "Fix formatting / build issues (buildfix.sh)"
   if ((push)); then
     git push
   fi

--- a/tools/prettier/prettier.sh
+++ b/tools/prettier/prettier.sh
@@ -40,7 +40,7 @@ paths=("$(
     done
 )")
 
-if [[ ${#paths[@]} -eq 0 ]]; then
+if [[ -z "${paths[*]}" ]]; then
   exit 0
 fi
 

--- a/tools/prettier/prettier.sh
+++ b/tools/prettier/prettier.sh
@@ -30,7 +30,18 @@ cd "${BUILD_WORKSPACE_DIRECTORY?}"
 # and the current branch, so that we only run the lint check on files added
 # in this branch.
 
-git merge-base HEAD refs/remotes/origin/master |
-  xargs git diff --name-only --diff-filter=AMRCT |
-  grep -P '\.(js|jsx|ts|tsx|html|css|yaml|json|md|xml)$' |
-  xargs --no-run-if-empty "$NODE" "$PRETTIER" "$@"
+paths=("$(
+  git merge-base HEAD refs/remotes/origin/master |
+    xargs git diff --name-only --diff-filter=AMRCT |
+    while read -r path; do
+      if [[ "$path" =~ \.(js|jsx|ts|tsx|html|css|yaml|json|md|xml)$ ]]; then
+        echo "$path"
+      fi
+    done
+)")
+
+if [[ ${#paths[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+"$NODE" "$PRETTIER" "$@"

--- a/tools/prettier/prettier.sh
+++ b/tools/prettier/prettier.sh
@@ -3,6 +3,11 @@
 
 set -e
 
+# Replacement for GNU realpath (not available on Mac)
+realpath() {
+  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
 NODE=$(realpath "${1?}")
 shift
 PRETTIER=$(realpath "${1?}")

--- a/tools/prettier/prettier.sh
+++ b/tools/prettier/prettier.sh
@@ -44,4 +44,4 @@ if [[ ${#paths[@]} -eq 0 ]]; then
   exit 0
 fi
 
-"$NODE" "$PRETTIER" "$@"
+"$NODE" "$PRETTIER" "$@" "${paths[@]}"


### PR DESCRIPTION
* Allow running `gazelle` with `-g` or `--gazelle` flags (not done by default because it is a bit slower compared to the other formatting commands).
* Run `prettier` by default (we'll want to add this to checkstyle to ensure the formatting of the frontend code is consistent, and it's quick enough assuming a cached build or pre-installed prettier binary).
* Update `prettier` to avoid dependence on `realpath` (not available on MacOS, IIUC)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
