### PR TITLE
Add vmexec server and implementation

### DIFF
--- a/enterprise/server/remote_execution/commandutil/commandutil.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil.go
@@ -67,7 +67,7 @@ func Run(ctx context.Context, command *repb.Command, workDir string) *interfaces
 		return cmd.Run()
 	})
 
-	exitCode, err := exitCode(ctx, cmd, err)
+	exitCode, err := ExitCode(ctx, cmd, err)
 
 	return &interfaces.CommandResult{
 		ExitCode:           exitCode,
@@ -97,7 +97,7 @@ func splitExecutableArgs(commandTokens []string) (executable string, args []stri
 
 // exitCode returns the exit code from the given command, based on the error returned.
 // If the command could not be started or did not exit cleanly, an error is returned.
-func exitCode(ctx context.Context, cmd *exec.Cmd, err error) (int, error) {
+func ExitCode(ctx context.Context, cmd *exec.Cmd, err error) (int, error) {
 	if err == nil {
 		return 0, nil
 	}

--- a/enterprise/server/vmexec/BUILD
+++ b/enterprise/server/vmexec/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/vmexec",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/server/remote_execution/commandutil",
         "//proto:vmexec_go_proto",
         "//server/util/status",
     ],

--- a/enterprise/server/vmexec/BUILD
+++ b/enterprise/server/vmexec/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "vmexec",
+    srcs = ["vmexec.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/vmexec",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:vmexec_go_proto",
+        "//server/util/status",
+    ],
+)

--- a/enterprise/server/vmexec/vmexec.go
+++ b/enterprise/server/vmexec/vmexec.go
@@ -7,8 +7,8 @@ import (
 	"os/exec"
 	"syscall"
 
-	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	vmxpb "github.com/buildbuddy-io/buildbuddy/proto/vmexec"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
 
 type execServer struct{}
@@ -35,8 +35,8 @@ func (*execServer) Exec(ctx context.Context, req *vmxpb.ExecRequest) (*vmxpb.Exe
 	}
 	if req.GetStderrVsockPort() != 0 {
 		return nil, status.UnimplementedError("Vsock stderr not implemented")
-	}	
-	
+	}
+
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf

--- a/enterprise/server/vmexec/vmexec.go
+++ b/enterprise/server/vmexec/vmexec.go
@@ -1,0 +1,58 @@
+package vmexec
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"syscall"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	vmxpb "github.com/buildbuddy-io/buildbuddy/proto/vmexec"
+)
+
+type execServer struct{}
+
+func NewServer() *execServer {
+	return &execServer{}
+}
+
+func (*execServer) Exec(ctx context.Context, req *vmxpb.ExecRequest) (*vmxpb.ExecResponse, error) {
+	if len(req.GetArguments()) < 1 {
+		return nil, status.InvalidArgumentError("Arguments not specified")
+	}
+	cmd := exec.CommandContext(ctx, req.GetArguments()[0], req.GetArguments()[1:]...)
+	if req.GetWorkingDirectory() != "" {
+		cmd.Dir = req.GetWorkingDirectory()
+	}
+
+	// TODO(tylerw): implement this.
+	if req.GetStdinVsockPort() != 0 {
+		return nil, status.UnimplementedError("Vsock stdin not implemented")
+	}
+	if req.GetStdoutVsockPort() != 0 {
+		return nil, status.UnimplementedError("Vsock stdout not implemented")
+	}
+	if req.GetStderrVsockPort() != 0 {
+		return nil, status.UnimplementedError("Vsock stderr not implemented")
+	}	
+	
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	for _, envVar := range req.GetEnvironmentVariables() {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", envVar.GetName(), envVar.GetValue()))
+	}
+
+	rsp := &vmxpb.ExecResponse{}
+	err := cmd.Run()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ProcessState != nil {
+			rsp.ExitCode = int32(exitErr.ProcessState.ExitCode())
+		}
+	}
+	rsp.Stdout = stdoutBuf.Bytes()
+	rsp.Stderr = stderrBuf.Bytes()
+	return rsp, nil
+}

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -122,6 +122,11 @@ proto_library(
 )
 
 proto_library(
+    name = "vmexec_proto",
+    srcs = ["vmexec.proto"],
+)
+
+proto_library(
     name = "build_event_stream_proto",
     srcs = ["build_event_stream.proto"],
     deps = [
@@ -364,6 +369,13 @@ go_proto_library(
     deps = [
         ":context_go_proto",
     ],
+)
+
+go_proto_library(
+    name = "vmexec_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/vmexec",
+    proto = ":vmexec_proto",
 )
 
 go_proto_library(

--- a/proto/vmexec.proto
+++ b/proto/vmexec.proto
@@ -34,6 +34,8 @@ message ExecResponse {
   bytes stderr = 3;
 }
 
+// This service is run inside of a VM. It executes commands sent to it over
+// gRPC in the local environment and returns the results.
 service Exec {
   rpc Exec(ExecRequest) returns (ExecResponse);
 }

--- a/proto/vmexec.proto
+++ b/proto/vmexec.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+package vmexec;
+
+message ExecRequest {
+  string working_directory = 1;
+
+  message EnvironmentVariable {
+    // The variable name.
+    string name = 1;
+
+    // The variable value.
+    string value = 2;
+  }
+
+  // The environment variables to set when running the program.
+  repeated EnvironmentVariable environment_variables = 2;
+
+  // The arguments to the command. The first argument must be the path to the
+  // executable.
+  repeated string arguments = 3;
+
+  // Optional. Ports are vsock ports where the host will read/write stdin,
+  // stdout, and stderr. If unset, or set to 0, input will be ignored and
+  // output will be buffered and returned in the ExecResponse.
+  int32 stdin_vsock_port = 4;
+  int32 stdout_vsock_port = 5;
+  int32 stderr_vsock_port = 6;
+}
+
+message ExecResponse {
+  int32 exit_code = 1;
+  bytes stdout = 2;
+  bytes stderr = 3;
+}
+
+service Exec {
+  rpc Exec(ExecRequest) returns (ExecResponse);
+}


### PR DESCRIPTION
This server accepts a proto command and executes it, returning the response. I did not use the repb command proto because it includes some fields (output files, etc) that we do not support.

Big ups to @bduffany for the original implementation of this in:
 - https://github.com/buildbuddy-io/buildbuddy-internal/pull/409 and
 - https://github.com/buildbuddy-io/buildbuddy/pull/346