### PR TITLE
Add graph that shows # of execution result waiters.

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 1,
-  "iteration": 1624558938473,
+  "iteration": 1624665202964,
   "links": [],
   "panels": [
     {
@@ -2015,6 +2015,217 @@
         "x": 0,
         "y": 6
       },
+      "id": 384,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "hiddenSeries": false,
+          "id": 420,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.3.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "max(sum(buildbuddy_remote_execution_waiting_execution_result) by (pod_name,group_id)) by (group_id)",
+              "interval": "",
+              "legendFormat": "{{group_id}}",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Num Execution Result Waiters (Max Across Apps)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:101",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:102",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "hiddenSeries": false,
+          "id": 422,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.3.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(buildbuddy_remote_execution_waiting_execution_result) by (group_id)",
+              "interval": "",
+              "legendFormat": "{{group_id}}",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Num Execution Result Waiters (Sum Across Apps)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:183",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:184",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Remote execution",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
       "id": 28,
       "panels": [
         {
@@ -3149,7 +3360,7 @@
           "value": "executor"
         }
       },
-      "title": "Remote execution (${pool})",
+      "title": "Executor pool (${pool})",
       "type": "row"
     },
     {
@@ -3159,9 +3370,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 8
       },
-      "id": 349,
+      "id": 385,
       "panels": [
         {
           "aliasColors": {
@@ -3187,7 +3398,7 @@
             "y": 7
           },
           "hiddenSeries": false,
-          "id": 350,
+          "id": 386,
           "legend": {
             "avg": false,
             "current": false,
@@ -3208,7 +3419,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 190,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3305,7 +3516,7 @@
             "y": 7
           },
           "hiddenSeries": false,
-          "id": 351,
+          "id": 387,
           "legend": {
             "avg": false,
             "current": false,
@@ -3327,7 +3538,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 159,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3430,7 +3641,7 @@
             "y": 16
           },
           "hiddenSeries": false,
-          "id": 352,
+          "id": 388,
           "legend": {
             "avg": false,
             "current": false,
@@ -3451,7 +3662,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 210,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3564,7 +3775,7 @@
             "y": 16
           },
           "hiddenSeries": false,
-          "id": 353,
+          "id": 389,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -3586,7 +3797,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 178,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3679,7 +3890,7 @@
             "y": 24
           },
           "hiddenSeries": false,
-          "id": 354,
+          "id": 390,
           "legend": {
             "avg": false,
             "current": false,
@@ -3700,7 +3911,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 31,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3789,7 +4000,7 @@
             "y": 24
           },
           "hiddenSeries": false,
-          "id": 355,
+          "id": 391,
           "legend": {
             "avg": false,
             "current": false,
@@ -3810,7 +4021,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 35,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3898,7 +4109,7 @@
             "y": 32
           },
           "hiddenSeries": false,
-          "id": 356,
+          "id": 392,
           "legend": {
             "avg": false,
             "current": false,
@@ -3919,7 +4130,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 33,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4007,7 +4218,7 @@
             "y": 32
           },
           "hiddenSeries": false,
-          "id": 357,
+          "id": 393,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -4029,7 +4240,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 102,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4117,7 +4328,7 @@
             "y": 40
           },
           "hiddenSeries": false,
-          "id": 358,
+          "id": 394,
           "legend": {
             "avg": false,
             "current": false,
@@ -4138,7 +4349,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 129,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4226,7 +4437,7 @@
             "y": 40
           },
           "hiddenSeries": false,
-          "id": 359,
+          "id": 395,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -4250,7 +4461,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 180,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4317,7 +4528,7 @@
           }
         }
       ],
-      "repeatIteration": 1624558938473,
+      "repeatIteration": 1624665202964,
       "repeatPanelId": 28,
       "scopedVars": {
         "pool": {
@@ -4326,7 +4537,7 @@
           "value": "executor-workflows"
         }
       },
-      "title": "Remote execution (${pool})",
+      "title": "Executor pool (${pool})",
       "type": "row"
     },
     {
@@ -4336,7 +4547,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 9
       },
       "id": 264,
       "panels": [
@@ -5016,9 +5227,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 10
       },
-      "id": 360,
+      "id": 396,
       "panels": [
         {
           "aliasColors": {
@@ -5044,7 +5255,7 @@
             "y": 9
           },
           "hiddenSeries": false,
-          "id": 361,
+          "id": 397,
           "legend": {
             "avg": false,
             "current": false,
@@ -5066,7 +5277,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 274,
           "repeatedByRow": true,
           "scopedVars": {
@@ -5168,7 +5379,7 @@
             "y": 9
           },
           "hiddenSeries": false,
-          "id": 362,
+          "id": 398,
           "legend": {
             "avg": false,
             "current": false,
@@ -5189,7 +5400,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 276,
           "repeatedByRow": true,
           "scopedVars": {
@@ -5278,7 +5489,7 @@
             "y": 17
           },
           "hiddenSeries": false,
-          "id": 363,
+          "id": 399,
           "legend": {
             "avg": false,
             "current": false,
@@ -5299,7 +5510,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 290,
           "repeatedByRow": true,
           "scopedVars": {
@@ -5388,7 +5599,7 @@
             "y": 17
           },
           "hiddenSeries": false,
-          "id": 364,
+          "id": 400,
           "legend": {
             "avg": false,
             "current": false,
@@ -5409,7 +5620,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 292,
           "repeatedByRow": true,
           "scopedVars": {
@@ -5498,7 +5709,7 @@
             "y": 25
           },
           "hiddenSeries": false,
-          "id": 365,
+          "id": 401,
           "legend": {
             "avg": false,
             "current": false,
@@ -5519,7 +5730,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 278,
           "repeatedByRow": true,
           "scopedVars": {
@@ -5608,7 +5819,7 @@
             "y": 25
           },
           "hiddenSeries": false,
-          "id": 366,
+          "id": 402,
           "legend": {
             "avg": false,
             "current": false,
@@ -5629,7 +5840,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 280,
           "repeatedByRow": true,
           "scopedVars": {
@@ -5696,7 +5907,7 @@
           }
         }
       ],
-      "repeatIteration": 1624558938473,
+      "repeatIteration": 1624665202964,
       "repeatPanelId": 264,
       "scopedVars": {
         "pool": {
@@ -5715,7 +5926,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 11
       },
       "id": 38,
       "panels": [
@@ -6251,7 +6462,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 12
       },
       "id": 48,
       "panels": [
@@ -6656,7 +6867,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 13
       },
       "id": 107,
       "panels": [
@@ -7265,7 +7476,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 14
       },
       "id": 83,
       "panels": [
@@ -7719,9 +7930,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 15
       },
-      "id": 367,
+      "id": 403,
       "panels": [
         {
           "aliasColors": {},
@@ -7745,7 +7956,7 @@
             "y": 165
           },
           "hiddenSeries": false,
-          "id": 368,
+          "id": 404,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -7770,7 +7981,7 @@
           "points": false,
           "renderer": "flot",
           "repeat": null,
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 85,
           "repeatedByRow": true,
           "scopedVars": {
@@ -7858,7 +8069,7 @@
             "y": 165
           },
           "hiddenSeries": false,
-          "id": 369,
+          "id": 405,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -7882,7 +8093,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 87,
           "repeatedByRow": true,
           "scopedVars": {
@@ -7968,7 +8179,7 @@
             "y": 174
           },
           "hiddenSeries": false,
-          "id": 370,
+          "id": 406,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -7992,7 +8203,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 91,
           "repeatedByRow": true,
           "scopedVars": {
@@ -8078,7 +8289,7 @@
             "y": 174
           },
           "hiddenSeries": false,
-          "id": 371,
+          "id": 407,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -8102,7 +8313,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 93,
           "repeatedByRow": true,
           "scopedVars": {
@@ -8167,7 +8378,7 @@
           }
         }
       ],
-      "repeatIteration": 1624558938473,
+      "repeatIteration": 1624665202964,
       "repeatPanelId": 83,
       "scopedVars": {
         "job": {
@@ -8186,9 +8397,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 16
       },
-      "id": 372,
+      "id": 408,
       "panels": [
         {
           "aliasColors": {},
@@ -8212,7 +8423,7 @@
             "y": 165
           },
           "hiddenSeries": false,
-          "id": 373,
+          "id": 409,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -8237,7 +8448,7 @@
           "points": false,
           "renderer": "flot",
           "repeat": null,
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 85,
           "repeatedByRow": true,
           "scopedVars": {
@@ -8325,7 +8536,7 @@
             "y": 165
           },
           "hiddenSeries": false,
-          "id": 374,
+          "id": 410,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -8349,7 +8560,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 87,
           "repeatedByRow": true,
           "scopedVars": {
@@ -8435,7 +8646,7 @@
             "y": 174
           },
           "hiddenSeries": false,
-          "id": 375,
+          "id": 411,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -8459,7 +8670,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 91,
           "repeatedByRow": true,
           "scopedVars": {
@@ -8545,7 +8756,7 @@
             "y": 174
           },
           "hiddenSeries": false,
-          "id": 376,
+          "id": 412,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -8569,7 +8780,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 93,
           "repeatedByRow": true,
           "scopedVars": {
@@ -8634,7 +8845,7 @@
           }
         }
       ],
-      "repeatIteration": 1624558938473,
+      "repeatIteration": 1624665202964,
       "repeatPanelId": 83,
       "scopedVars": {
         "job": {
@@ -8653,7 +8864,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 17
       },
       "id": 71,
       "panels": [
@@ -8907,9 +9118,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 18
       },
-      "id": 377,
+      "id": 413,
       "panels": [
         {
           "aliasColors": {
@@ -8949,7 +9160,7 @@
             "y": 8
           },
           "hiddenSeries": false,
-          "id": 378,
+          "id": 414,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -8974,7 +9185,7 @@
           "points": false,
           "renderer": "flot",
           "repeat": null,
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 73,
           "repeatedByRow": true,
           "scopedVars": {
@@ -9059,7 +9270,7 @@
             "y": 8
           },
           "hiddenSeries": false,
-          "id": 379,
+          "id": 415,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -9084,7 +9295,7 @@
           "points": false,
           "renderer": "flot",
           "repeat": null,
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 79,
           "repeatedByRow": true,
           "scopedVars": {
@@ -9149,7 +9360,7 @@
           }
         }
       ],
-      "repeatIteration": 1624558938473,
+      "repeatIteration": 1624665202964,
       "repeatPanelId": 71,
       "scopedVars": {
         "job": {
@@ -9168,9 +9379,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 19
       },
-      "id": 380,
+      "id": 416,
       "panels": [
         {
           "aliasColors": {
@@ -9210,7 +9421,7 @@
             "y": 8
           },
           "hiddenSeries": false,
-          "id": 381,
+          "id": 417,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -9235,7 +9446,7 @@
           "points": false,
           "renderer": "flot",
           "repeat": null,
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 73,
           "repeatedByRow": true,
           "scopedVars": {
@@ -9320,7 +9531,7 @@
             "y": 8
           },
           "hiddenSeries": false,
-          "id": 382,
+          "id": 418,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -9345,7 +9556,7 @@
           "points": false,
           "renderer": "flot",
           "repeat": null,
-          "repeatIteration": 1624558938473,
+          "repeatIteration": 1624665202964,
           "repeatPanelId": 79,
           "repeatedByRow": true,
           "scopedVars": {
@@ -9410,7 +9621,7 @@
           }
         }
       ],
-      "repeatIteration": 1624558938473,
+      "repeatIteration": 1624665202964,
       "repeatPanelId": 71,
       "scopedVars": {
         "job": {
@@ -9429,7 +9640,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 20
       },
       "id": 8,
       "panels": [


### PR DESCRIPTION
I renamed the current "Remote execution" panel to "Executor pool" so I
could use the "Remote execution" name for global graphs.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
