### PR TITLE
Fix goroutine leak in gRPC stream interceptor and re-enable instrumentation.

### DIFF
--- a/buildpatches/grpc_tracing.patch
+++ b/buildpatches/grpc_tracing.patch
@@ -34,10 +34,18 @@ index 3575298..193c30a 100644
  	metadata *metadata.MD
  }
 diff --git a/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go b/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
-index 2117497..ef6ba02 100644
+index 2117497..5ebadbe 100644
 --- a/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
 +++ b/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go
-@@ -304,6 +304,16 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
+@@ -150,6 +150,7 @@ func (w *clientStream) RecvMsg(m interface{}) error {
+ 		w.sendStreamEvent(receiveEndEvent, nil)
+ 	} else if err == io.EOF {
+ 		w.sendStreamEvent(receiveEndEvent, nil)
++		w.sendStreamEvent(closeEvent, nil)
+ 	} else if err != nil {
+ 		w.sendStreamEvent(errorEvent, err)
+ 	} else {
+@@ -304,6 +305,16 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
  	}
  }
  
@@ -54,7 +62,7 @@ index 2117497..ef6ba02 100644
  // UnaryServerInterceptor returns a grpc.UnaryServerInterceptor suitable
  // for use in a grpc.NewServer call.
  func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
-@@ -319,12 +329,14 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
+@@ -319,12 +330,14 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
  		bags, spanCtx := Extract(ctx, &metadataCopy, opts...)
  		ctx = baggage.ContextWithBaggage(ctx, bags)
  
@@ -70,7 +78,7 @@ index 2117497..ef6ba02 100644
  		ctx, span := tracer.Start(
  			trace.ContextWithRemoteSpanContext(ctx, spanCtx),
  			name,
-@@ -408,12 +420,14 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
+@@ -408,12 +421,14 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
  		bags, spanCtx := Extract(ctx, &metadataCopy, opts...)
  		ctx = baggage.ContextWithBaggage(ctx, bags)
  

--- a/deps.bzl
+++ b/deps.bzl
@@ -3404,7 +3404,7 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         patch_args = ["-p5"],
         # Adds hook to add extra attrs to RPC server spans.
         # TODO(vadim): try to upstream this
-        patches = ["@%s//buildpatches:trace_extra_attrs.patch" % workspace_name],
+        patches = ["@%s//buildpatches:grpc_tracing.patch" % workspace_name],
         sum = "h1:sO4WKdPAudZGKPcpZT4MJn6JaDmpyLrMPDGGyA1SttE=",
         version = "v0.20.0",
     )

--- a/server/rpc/filters/filters.go
+++ b/server/rpc/filters/filters.go
@@ -218,6 +218,7 @@ func GetUnaryClientInterceptor() grpc.DialOption {
 
 func GetStreamClientInterceptor() grpc.DialOption {
 	return grpc.WithChainStreamInterceptor(
+		otelgrpc.StreamClientInterceptor(),
 		grpc_prometheus.StreamClientInterceptor,
 		setHeadersStreamClientInterceptor(),
 	)

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -61,6 +61,7 @@ func CommonGRPCServerOptions(env environment.Env) []grpc.ServerOption {
 		filters.GetUnaryInterceptor(env),
 		filters.GetStreamInterceptor(env),
 		grpc.ChainUnaryInterceptor(otelgrpc.UnaryServerInterceptor(otelgrpc.WithContextAttrExtractor(extractInvocationID))),
+		grpc.ChainStreamInterceptor(otelgrpc.StreamServerInterceptor(otelgrpc.WithContextAttrExtractor(extractInvocationID))),
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
 		grpc.MaxRecvMsgSize(env.GetConfigurator().GetGRPCMaxRecvMsgSizeBytes()),


### PR DESCRIPTION
The instrumentation code assumes the client stream is not done until
CloseSend() is called, but that's not a strict requirement. The client
stream should also be considered done if the server stream returns
io.EOF.

Upstream function being patched: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/d41f1f8fa3621b1ce3d70af48370eea4a984e3b1/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go#L152

I'll send an upstream patch shortly.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: TODO <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
