### PR TITLE
workflows: Show history view when clicking a workflow

### DIFF
--- a/app/components/button/button.css
+++ b/app/components/button/button.css
@@ -7,7 +7,6 @@
   border: 0;
   border-radius: 8px;
   cursor: pointer;
-  display: block;
   box-sizing: border-box;
   text-align: center;
   line-height: normal;
@@ -16,7 +15,7 @@
 
   flex-shrink: 0;
   align-self: center;
-  display: flex;
+  display: inline-flex;
   align-items: center;
 }
 

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -550,19 +550,23 @@ button {
 }
 
 code {
-  display: block;
-  padding: 24px 32px;
   border: 1px solid #eee;
-  border-radius: 8px;
-  margin-top: 16px;
-  margin-bottom: 16px;
+  border-radius: 4px;
   background-color: #fafafa;
   font-family: "Source Code Pro", monospace;
+  box-sizing: border-box;
+}
+
+code:not(.inline-code) {
+  display: block;
+  border-radius: 8px;
+  padding: 24px 32px;
+  margin-top: 16px;
+  margin-bottom: 16px;
   line-height: 1.6em;
   white-space: nowrap;
   overflow-y: auto;
   max-width: 100%;
-  box-sizing: border-box;
   position: relative;
 }
 

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -559,8 +559,8 @@ code {
 
 code:not(.inline-code) {
   display: block;
-  border-radius: 8px;
   padding: 24px 32px;
+  border-radius: 8px;
   margin-top: 16px;
   margin-bottom: 16px;
   line-height: 1.6em;

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -108,6 +108,10 @@ class Router {
     this.navigateTo(Path.hostHistoryPath + host);
   }
 
+  navigateToWorkflowHistory(repo: string) {
+    this.navigateTo(`${Path.repoHistoryPath}${getRepoUrlPathParam}?workflows=true`);
+  }
+
   navigateToRepoHistory(repo: string) {
     if (!capabilities.canNavigateToPath(Path.repoHistoryPath)) {
       alert(
@@ -115,11 +119,7 @@ class Router {
       );
       return;
     }
-    if (repo.startsWith("https://github.com/") && repo.endsWith(".git")) {
-      this.navigateTo(Path.repoHistoryPath + format.formatGitUrl(repo));
-      return;
-    }
-    this.navigateTo(Path.repoHistoryPath + btoa(repo));
+    this.navigateTo(`${Path.repoHistoryPath}${getRepoUrlPathParam(repo)}`);
   }
 
   navigateToCommitHistory(commit: string) {
@@ -192,6 +192,13 @@ class Router {
   getHistoryCommit(path: string) {
     return this.getLastPathComponent(path, Path.commitHistoryPath);
   }
+}
+
+function getRepoUrlPathParam(repo: string): string {
+  if (repo.startsWith("https://github.com/") && repo.endsWith(".git")) {
+    return format.formatGitUrl(repo);
+  }
+  return btoa(repo);
 }
 
 function getQueryString(params: Record<string, string>) {

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -198,8 +198,18 @@ class Router {
   }
 }
 
+// If a repo matches https://github.com/{owner}/{repo} or https://github.com/{owner}/{repo}.git
+// then we'll show it directly in the URL like `{owner}/{repo}`. Otherwise we encode it
+// using `window.btoa`.
+const GITHUB_URL_PREFIX = "^https://github.com";
+const PATH_SEGMENT_PATTERN = "[^/]+";
+const OPTIONAL_DOTGIT_SUFFIX = "(\\.git)?$";
+const GITHUB_REPO_URL_PATTERN = new RegExp(
+  `${GITHUB_URL_PREFIX}/${PATH_SEGMENT_PATTERN}/${PATH_SEGMENT_PATTERN}${OPTIONAL_DOTGIT_SUFFIX}`
+);
+
 function getRepoUrlPathParam(repo: string): string {
-  if (repo.startsWith("https://github.com/")) {
+  if (repo.match(GITHUB_REPO_URL_PATTERN)) {
     return format.formatGitUrl(repo);
   }
   return window.btoa(repo);

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -108,8 +108,12 @@ class Router {
     this.navigateTo(Path.hostHistoryPath + host);
   }
 
+  getWorkflowHistoryPath(repo: string) {
+    return `${Path.repoHistoryPath}${getRepoUrlPathParam(repo)}?workflows=true`;
+  }
+
   navigateToWorkflowHistory(repo: string) {
-    this.navigateTo(`${Path.repoHistoryPath}${getRepoUrlPathParam}?workflows=true`);
+    this.navigateTo(this.getWorkflowHistoryPath(repo));
   }
 
   navigateToRepoHistory(repo: string) {
@@ -195,10 +199,10 @@ class Router {
 }
 
 function getRepoUrlPathParam(repo: string): string {
-  if (repo.startsWith("https://github.com/") && repo.endsWith(".git")) {
+  if (repo.startsWith("https://github.com/")) {
     return format.formatGitUrl(repo);
   }
-  return btoa(repo);
+  return window.btoa(repo);
 }
 
 function getQueryString(params: Record<string, string>) {

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -108,12 +108,12 @@ class Router {
     this.navigateTo(Path.hostHistoryPath + host);
   }
 
-  getWorkflowHistoryPath(repo: string) {
+  getWorkflowHistoryUrl(repo: string) {
     return `${Path.repoHistoryPath}${getRepoUrlPathParam(repo)}?workflows=true`;
   }
 
   navigateToWorkflowHistory(repo: string) {
-    this.navigateTo(this.getWorkflowHistoryPath(repo));
+    this.navigateTo(this.getWorkflowHistoryUrl(repo));
   }
 
   navigateToRepoHistory(repo: string) {

--- a/enterprise/app/history/BUILD
+++ b/enterprise/app/history/BUILD
@@ -9,6 +9,7 @@ ts_library(
     srcs = glob(["*.tsx"]),
     deps = [
         "//app/auth",
+        "//app/components/button",
         "//app/docs",
         "//app/format",
         "//app/router",

--- a/enterprise/app/history/history.css
+++ b/enterprise/app/history/history.css
@@ -13,6 +13,3 @@
 .history a.text-link {
   text-decoration: underline;
 }
-
-.history.empty-state button {
-}

--- a/enterprise/app/history/history.css
+++ b/enterprise/app/history/history.css
@@ -9,3 +9,10 @@
   padding: 16px;
   margin-right: 0;
 }
+
+.history a.text-link {
+  text-decoration: underline;
+}
+
+.history.empty-state button {
+}

--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { Subscription, fromEvent } from "rxjs";
+import { fromEvent, Subscription } from "rxjs";
 import { User } from "../../../app/auth/auth_service";
+import LinkButton from "../../../app/components/button/link_button";
 import format from "../../../app/format/format";
 import router from "../../../app/router/router";
 import rpcService from "../../../app/service/rpc_service";
@@ -405,7 +406,30 @@ export default class HistoryComponent extends React.Component {
           </div>
         )}
         {this.state.invocations.length == 0 && this.state.loading && <div className="loading"></div>}
-        {this.state.invocations.length == 0 && !this.state.loading && (
+        {this.state.invocations.length == 0 && !this.state.loading && this.isFilteredToWorkflows() && (
+          <div className="container narrow">
+            <div className="empty-state history">
+              <h2>No workflow runs yet!</h2>
+              <p>
+                Push commits or send pull requests to{" "}
+                <a href={this.props.repo} target="_new" className="text-link">
+                  {format.formatGitUrl(this.props.repo)}
+                </a>{" "}
+                to trigger BuildBuddy workflows.
+              </p>
+              <p>
+                By default, BuildBuddy will run <code className="inline-code">bazel test //...</code> on pushes to your
+                main branch and on pull request branches.
+              </p>
+              <div>
+                <LinkButton href="https://docs.buildbuddy.io/docs/workflows-config" target="_new">
+                  Learn more
+                </LinkButton>
+              </div>
+            </div>
+          </div>
+        )}
+        {this.state.invocations.length == 0 && !this.state.loading && !this.isFilteredToWorkflows() && (
           <div className="container narrow">
             <div className="empty-state history">
               <h2>No builds found!</h2>

--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -266,7 +266,9 @@ export default class HistoryComponent extends React.Component {
                 </span>
               )}
               {scope && <span>{scope}</span>}
-              {!this.props.username && !this.props.hostname && this.props.hash == "" && <span>Builds</span>}
+              {!this.props.username && !this.props.hostname && this.props.hash == "" && (
+                <>{this.isFilteredToWorkflows() ? <span>Workflow runs</span> : <span>Builds</span>}</>
+              )}
             </div>
             <div className="titles">
               <div className="title">

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -171,7 +171,14 @@ export default class EnterpriseRootComponent extends React.Component {
                 {historyHost && (
                   <HistoryComponent user={this.state.user} hostname={historyHost} hash={this.state.hash} />
                 )}
-                {historyRepo && <HistoryComponent user={this.state.user} repo={historyRepo} hash={this.state.hash} />}
+                {historyRepo && (
+                  <HistoryComponent
+                    user={this.state.user}
+                    repo={historyRepo}
+                    hash={this.state.hash}
+                    search={this.state.search}
+                  />
+                )}
                 {historyCommit && (
                   <HistoryComponent user={this.state.user} commit={historyCommit} hash={this.state.hash} />
                 )}

--- a/enterprise/app/workflows/workflows.tsx
+++ b/enterprise/app/workflows/workflows.tsx
@@ -263,7 +263,7 @@ class WorkflowItem extends React.Component<WorkflowItemProps, WorkflowItemState>
     const url = new URL(repoUrl);
     url.protocol = "https:";
 
-    const historyPath = getHistoryPath(url);
+    console.log({ repoUrl });
 
     return (
       <div className="workflow-item container">
@@ -271,7 +271,7 @@ class WorkflowItem extends React.Component<WorkflowItemProps, WorkflowItemState>
           <div className="workflow-item-row">
             <img className="git-merge-icon" src="/image/git-merge.svg" alt="" />
             <a
-              href={`/history/repo/${historyPath}?workflows=true`}
+              href={router.getWorkflowHistoryPath(repoUrl)}
               onClick={this.onClickRepoUrl.bind(this)}
               className="repo-url">
               {url.host}
@@ -302,12 +302,4 @@ class WorkflowItem extends React.Component<WorkflowItemProps, WorkflowItemState>
       </div>
     );
   }
-}
-
-// TODO (DO NOT MERGE): Does this already exist somewhere?
-function getHistoryPath(url: URL) {
-  if (url.hostname === "github.com") {
-    return url.pathname.substring(1).replace(/\.git$/, "");
-  }
-  return window.btoa(url.toString());
 }

--- a/enterprise/app/workflows/workflows.tsx
+++ b/enterprise/app/workflows/workflows.tsx
@@ -271,7 +271,7 @@ class WorkflowItem extends React.Component<WorkflowItemProps, WorkflowItemState>
           <div className="workflow-item-row">
             <img className="git-merge-icon" src="/image/git-merge.svg" alt="" />
             <a
-              href={router.getWorkflowHistoryPath(repoUrl)}
+              href={router.getWorkflowHistoryUrl(repoUrl)}
               onClick={this.onClickRepoUrl.bind(this)}
               className="repo-url">
               {url.host}

--- a/enterprise/app/workflows/workflows.tsx
+++ b/enterprise/app/workflows/workflows.tsx
@@ -263,8 +263,6 @@ class WorkflowItem extends React.Component<WorkflowItemProps, WorkflowItemState>
     const url = new URL(repoUrl);
     url.protocol = "https:";
 
-    console.log({ repoUrl });
-
     return (
       <div className="workflow-item container">
         <div className="workflow-item-column">

--- a/enterprise/app/workflows/workflows.tsx
+++ b/enterprise/app/workflows/workflows.tsx
@@ -136,12 +136,12 @@ class ListWorkflowsComponent extends React.Component<ListWorkflowsProps, State> 
       <div className="workflows-page">
         <div className="shelf">
           <div className="container">
-          <div>
-            <div className="breadcrumbs">
-              {this.props.user && <span>{this.props.user?.selectedGroupName()}</span>}
-              <span>Workflows</span>
-            </div>
-            <div className="title">Workflows</div>
+            <div>
+              <div className="breadcrumbs">
+                {this.props.user && <span>{this.props.user?.selectedGroupName()}</span>}
+                <span>Workflows</span>
+              </div>
+              <div className="title">Workflows</div>
             </div>
             {response && Boolean(response.workflow.length) && (
               <div className="buttons create-new-container">
@@ -250,19 +250,30 @@ class WorkflowItem extends React.Component<WorkflowItemProps, WorkflowItemState>
     this.props.onClickUnlinkItem(this.props.workflow);
   }
 
+  private onClickRepoUrl(e: React.MouseEvent) {
+    e.preventDefault();
+    const path = (e.target as HTMLAnchorElement).getAttribute("href");
+    router.navigateTo(path);
+  }
+
   render() {
-    const { name, repoUrl } = this.props.workflow;
+    const { repoUrl } = this.props.workflow;
     const { isMenuOpen, copiedToClipboard } = this.state;
 
     const url = new URL(repoUrl);
     url.protocol = "https:";
+
+    const historyPath = getHistoryPath(url);
 
     return (
       <div className="workflow-item container">
         <div className="workflow-item-column">
           <div className="workflow-item-row">
             <img className="git-merge-icon" src="/image/git-merge.svg" alt="" />
-            <a href={url.toString()} className="repo-url" target="_new">
+            <a
+              href={`/history/repo/${historyPath}?workflows=true`}
+              onClick={this.onClickRepoUrl.bind(this)}
+              className="repo-url">
               {url.host}
               {url.pathname}
             </a>
@@ -291,4 +302,12 @@ class WorkflowItem extends React.Component<WorkflowItemProps, WorkflowItemState>
       </div>
     );
   }
+}
+
+// TODO (DO NOT MERGE): Does this already exist somewhere?
+function getHistoryPath(url: URL) {
+  if (url.hostname === "github.com") {
+    return url.pathname.substring(1).replace(/\.git$/, "");
+  }
+  return window.btoa(url.toString());
 }

--- a/enterprise/server/invocation_search_service/invocation_search_service.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service.go
@@ -136,6 +136,9 @@ func (s *InvocationSearchService) QueryInvocations(ctx context.Context, req *inp
 	if group_id := req.GetQuery().GetGroupId(); group_id != "" {
 		q.AddWhereClause("i.group_id = ?", group_id)
 	}
+	if role := req.GetQuery().GetRole(); role != "" {
+		q.AddWhereClause("i.role = ?", role)
+	}
 
 	// Always add permissions check.
 	addPermissionsCheckToQuery(tu, q)

--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -162,6 +162,9 @@ message InvocationQuery {
 
   // The commit sha used for the build.
   string commit_sha = 5;
+
+  // The ROLE metadata set on the build.
+  string role = 6;
 }
 
 message InvocationSort {


### PR DESCRIPTION
* When clicking a workflow, navigate to the existing repo history view, but append the URL param `?workflows=true` which adds the filter `role = "CI_RUNNER"` to the query. e.g. `/history/repo/buildbuddy-io/buildbuddy?workflows=true`
* Customize the workflows view with a nicer title ("Workflow runs of $repo" instead of "Builds of $repo") and empty state:

![image](https://user-images.githubusercontent.com/2414826/123819619-ea8af980-d8c7-11eb-9d30-ef896d28faff.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
