### PR TITLE
workflows: Include only bazel invocations in trends view

### DIFF
--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -70,7 +70,9 @@ export default class TrendsComponent extends React.Component {
     request.query = new invocation.TrendQuery();
 
     if (this.state.filterOnlyCI) {
-      request.query.role = "CI";
+      request.query.role = ["CI"];
+    } else {
+      request.query.role = ["", "CI"];
     }
 
     if (this.props.search.get("user")) {

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -104,6 +104,10 @@ func (i *InvocationStatService) GetTrend(ctx context.Context, req *inpb.GetTrend
 
 	if role := req.GetQuery().GetRole(); role != "" {
 		q.AddWhereClause("role = ?", role)
+	} else {
+		// Don't include workflow invocations in trends since workflows just "wrap"
+		// other invocations, and we want to avoid double-counting.
+		q.AddWhereClause(`role != "CI_RUNNER"`)
 	}
 
 	q.AddWhereClause(`updated_at_usec > ?`, time.Now().Add(-lookbackWindowDays).UnixNano()/1000)

--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -355,8 +355,9 @@ message TrendQuery {
   // The commit sha used for the build.
   string commit_sha = 5;
 
-  // The role played by the build. Ex: "CI"
-  string role = 6;
+  // The role played by the build. Ex: "CI". Multiple filters are combined with
+  // OR.
+  repeated string role = 6;
 }
 
 message GetTrendRequest {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -536,12 +536,13 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 // Manual migration called after auto-migration.
 func PostAutoMigrate(db *gorm.DB) error {
 	indexes := map[string]string{
-		"invocations_trends_query_index":   "(`group_id`, `updated_at_usec`)",
-		"invocations_stats_group_id_index": "(`group_id`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_user_index":     "(`group_id`, `user`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_host_index":     "(`group_id`, `host`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_repo_index":     "(`group_id`, `repo_url`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_commit_index":   "(`group_id`, `commit_sha`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_trends_query_index":      "(`group_id`, `updated_at_usec`)",
+		"invocations_trends_query_role_index": "(`group_id`, `role`, `updated_at_usec`)",
+		"invocations_stats_group_id_index":    "(`group_id`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_user_index":        "(`group_id`, `user`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_host_index":        "(`group_id`, `host`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_repo_index":        "(`group_id`, `repo_url`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_commit_index":      "(`group_id`, `commit_sha`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
 	}
 	m := db.Migrator()
 	if m.HasTable("Invocations") {


### PR DESCRIPTION
Exclude `ROLE=CI_RUNNER` from trends queries so that we don't double-count invocations (the CI runner invocation should not be counted because it just spawns Bazel invocations).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
