### PR TITLE
cleanup: Remove container.Run codepath

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -20,13 +20,6 @@ type Stats struct {
 
 // CommandContainer provides an execution environment for commands.
 type CommandContainer interface {
-	// Run the given command within the container and remove the container after
-	// it is done executing.
-	//
-	// It is approximately the same as calling PullImageIfNecessary, Create,
-	// Exec, then Remove.
-	Run(ctx context.Context, command *repb.Command, workingDir string) *interfaces.CommandResult
-
 	// PullImageIfNecessary pulls the container image if it is not already
 	// available locally.
 	PullImageIfNecessary(ctx context.Context) error

--- a/enterprise/server/remote_execution/containers/bare/bare.go
+++ b/enterprise/server/remote_execution/containers/bare/bare.go
@@ -21,10 +21,6 @@ func NewBareCommandContainer() container.CommandContainer {
 	return &bareCommandContainer{}
 }
 
-func (c *bareCommandContainer) Run(ctx context.Context, command *repb.Command, workDir string) *interfaces.CommandResult {
-	return commandutil.Run(ctx, command, workDir)
-}
-
 func (c *bareCommandContainer) Create(ctx context.Context, workDir string) error {
 	c.WorkDir = workDir
 	return nil
@@ -32,7 +28,7 @@ func (c *bareCommandContainer) Create(ctx context.Context, workDir string) error
 
 func (c *bareCommandContainer) Exec(ctx context.Context, cmd *repb.Command, stdin io.Reader, stdout io.Writer) *interfaces.CommandResult {
 	// TODO(siggisim): Wire up stdin/stdout to support persistent workers on bare commands.
-	return c.Run(ctx, cmd, c.WorkDir)
+	return commandutil.Run(ctx, cmd, c.WorkDir)
 }
 
 func (c *bareCommandContainer) PullImageIfNecessary(ctx context.Context) error { return nil }

--- a/enterprise/server/remote_execution/containers/docker/BUILD
+++ b/enterprise/server/remote_execution/containers/docker/BUILD
@@ -30,6 +30,7 @@ go_test(
         ":docker",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
+        "//server/testutil/testfs",
         "@com_github_docker_docker//client:go_default_library",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
@@ -67,100 +68,6 @@ func NewDockerContainer(client *dockerclient.Client, image, hostRootDir string, 
 	}
 }
 
-func (r *dockerCommandContainer) Run(ctx context.Context, command *repb.Command, workDir string) *interfaces.CommandResult {
-	result := &interfaces.CommandResult{
-		CommandDebugString: fmt.Sprintf("(docker) %s", command.GetArguments()),
-		ExitCode:           commandutil.NoExitCode,
-	}
-
-	containerName, err := generateContainerName()
-	if err != nil {
-		result.Error = status.UnavailableErrorf("failed to generate docker container name: %s", err)
-		return result
-	}
-
-	// explicitly pull the image before running to avoid the
-	// pull output logs spilling into the execution logs.
-	if err := r.PullImageIfNecessary(ctx); err != nil {
-		result.Error = wrapDockerErr(err, fmt.Sprintf("failed to pull docker image %q", r.image))
-		return result
-	}
-
-	containerCfg := r.containerConfig(
-		command.GetArguments(),
-		commandutil.EnvStringList(command),
-		workDir,
-	)
-	createResponse, err := r.client.ContainerCreate(
-		ctx,
-		containerCfg,
-		r.hostConfig(workDir),
-		/*networkingConfig=*/ nil,
-		/*platform=*/ nil,
-		containerName,
-	)
-	if err != nil {
-		result.Error = wrapDockerErr(err, "failed to create docker container")
-		return result
-	}
-
-	cid := createResponse.ID
-	err = r.client.ContainerStart(ctx, cid, dockertypes.ContainerStartOptions{})
-	if err != nil {
-		result.Error = wrapDockerErr(err, "failed to start docker container")
-		return result
-	}
-
-	exitedCleanly := false
-	defer func() {
-		// Clean up the container in the background.
-		// TODO: Add this removal as a job to a centralized queue.
-		go func() {
-			ctx := context.Background()
-			if !exitedCleanly {
-				if err := r.client.ContainerKill(ctx, cid, "SIGKILL"); err != nil {
-					log.Errorf("Failed to kill docker container: %s", err)
-				}
-			}
-			if err := r.client.ContainerRemove(ctx, cid, dockertypes.ContainerRemoveOptions{}); err != nil {
-				log.Errorf("Failed to remove docker container: %s", err)
-			}
-		}()
-	}()
-
-	statusCh, errCh := r.client.ContainerWait(ctx, cid, dockercontainer.WaitConditionNotRunning)
-
-	select {
-	case err := <-errCh:
-		result.Error = wrapDockerErr(err, "container did not exit cleanly")
-	case s := <-statusCh:
-		exitedCleanly = true
-		if s.Error != nil {
-			result.Error = wrapDockerErr(status.UnknownError(s.Error.Message), "failed to get container status")
-			return result
-		}
-		result.ExitCode = int(s.StatusCode)
-		logOptions := dockertypes.ContainerLogsOptions{
-			ShowStdout: true,
-			ShowStderr: true,
-		}
-		logs, err := r.client.ContainerLogs(ctx, cid, logOptions)
-		if err != nil {
-			result.Error = wrapDockerErr(err, "failed to get docker container logs")
-			return result
-		}
-		err = copyOutputs(logs, result)
-		if closeErr := logs.Close(); closeErr != nil {
-			log.Warningf("Failed to close docker logs: %s", closeErr)
-		}
-		if err != nil {
-			result.Error = wrapDockerErr(err, "failed to read docker container logs")
-			return result
-		}
-	}
-	return result
-}
-
 func wrapDockerErr(err error, contextMsg string) error {
 	if err == nil {
 		return nil
@@ -217,7 +124,7 @@ func (r *dockerCommandContainer) hostConfig(workDir string) *dockercontainer.Hos
 
 func copyOutputs(reader io.Reader, result *interfaces.CommandResult) error {
 	var stdout, stderr bytes.Buffer
-	_, err := stdcopy.StdCopy(&stdout, &stderr, reader)
+	_, err := stdcopy.StdCopy(io.MultiWriter(&stdout, os.Stdout), io.MultiWriter(&stderr, os.Stderr), reader)
 	result.Stdout = stdout.Bytes()
 	result.Stderr = stderr.Bytes()
 	return err

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
@@ -124,7 +123,7 @@ func (r *dockerCommandContainer) hostConfig(workDir string) *dockercontainer.Hos
 
 func copyOutputs(reader io.Reader, result *interfaces.CommandResult) error {
 	var stdout, stderr bytes.Buffer
-	_, err := stdcopy.StdCopy(io.MultiWriter(&stdout, os.Stdout), io.MultiWriter(&stderr, os.Stderr), reader)
+	_, err := stdcopy.StdCopy(&stdout, &stderr, reader)
 	result.Stdout = stdout.Bytes()
 	result.Stderr = stderr.Bytes()
 	return err

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -170,13 +170,6 @@ func (r *CommandRunner) PrepareForTask(task *repb.ExecutionTask) error {
 }
 
 func (r *CommandRunner) Run(ctx context.Context, command *repb.Command) *interfaces.CommandResult {
-	if !r.PlatformProperties.RecycleRunner {
-		// If the container is not recyclable, then use `Run` to walk through
-		// the entire container lifecycle in a single step.
-		// TODO: Remove this `Run` method and call lifecycle methods directly.
-		return r.Container.Run(ctx, command, r.Workspace.Path())
-	}
-
 	// Get the container to "ready" state so that we can exec commands in it.
 	switch r.state {
 	case initial:


### PR DESCRIPTION
Did some benchmarking -- `container.Create` + `container.Exec` is slightly faster than `container.Run`, even if we make the benchmarks more fair by removing the "pull image" and "remove container" steps inside the impl of `Run`.

```
BenchmarkRun-8                         3         440955833 ns/op
BenchmarkCreateExec-8                  4         328038006 ns/op
```

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
