### PR TITLE
Attempt to mitigate executor slowness on new nodes.

### DIFF
--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -93,7 +93,7 @@ func NewExecutor(env environment.Env, id string, options *Options) (*Executor, e
 	} else {
 		return nil, status.FailedPreconditionError("Missing health checker in env")
 	}
-	go s.runnerPool.PullDefaultImage()
+	go s.runnerPool.WarmupDefaultImage()
 	return s, nil
 }
 

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -450,30 +450,51 @@ func (p *Pool) hostBuildRoot() string {
 	return fmt.Sprintf("/var/lib/kubelet/pods/%s/volumes/kubernetes.io~empty-dir/executor-data/remotebuilds", p.podID)
 }
 
-func (p *Pool) PullDefaultImage() {
-	if p.dockerClient != nil {
-		cfg := p.env.GetConfigurator().GetExecutorConfig()
-		c := docker.NewDockerContainer(
-			p.dockerClient, platform.DefaultContainerImage, p.hostBuildRoot(),
-			&docker.DockerOptions{
-				Socket:                  cfg.DockerSocket,
-				EnableSiblingContainers: cfg.DockerSiblingContainers,
-				UseHostNetwork:          cfg.DockerNetHost,
-				DockerMountMode:         cfg.DockerMountMode,
-			},
-		)
-		start := time.Now()
-		// Give the command (which triggers a container pull) up to 1 minute
-		// to succeed. In practice I saw clean pulls take about 30 seconds.
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-		defer cancel()
-		err := c.PullImageIfNecessary(ctx)
-		if err == nil {
-			log.Debugf("Pulled default image %q in %s", platform.DefaultContainerImage, time.Since(start))
-		} else {
-			log.Debugf("Error pulling default image %q: %s", platform.DefaultContainerImage, err)
-		}
+func (p *Pool) WarmupDefaultImage() {
+	if p.dockerClient == nil {
+		return
 	}
+	cfg := p.env.GetConfigurator().GetExecutorConfig()
+	c := docker.NewDockerContainer(
+		p.dockerClient, platform.DefaultContainerImage, p.hostBuildRoot(),
+		&docker.DockerOptions{
+			Socket:                  cfg.DockerSocket,
+			EnableSiblingContainers: cfg.DockerSiblingContainers,
+			UseHostNetwork:          cfg.DockerNetHost,
+			DockerMountMode:         cfg.DockerMountMode,
+		},
+	)
+	start := time.Now()
+	// Give the pull up to 1 minute to succeed and 1 minute to create a warm up container.
+	// In practice I saw clean pulls take about 30 seconds.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	err := c.PullImageIfNecessary(ctx)
+	if err != nil {
+		log.Warningf("Warm up: could not pull default image %q: %s", platform.DefaultContainerImage, err)
+		return
+	}
+	log.Infof("Warm up: pulled default image %q in %s", platform.DefaultContainerImage, time.Since(start))
+
+	tmpDir, err := os.MkdirTemp("", "buildbuddy-warmup-*")
+	if err != nil {
+		log.Warningf("Warm up: could not create temp directory: %s", err)
+		return
+	}
+	defer func() {
+		_ = os.Remove(tmpDir)
+	}()
+	err = c.Create(ctx, tmpDir)
+	if err != nil {
+		log.Warningf("Warm up: could not create warm up container: %s", err)
+		return
+	}
+	err = c.Remove(ctx)
+	if err != nil {
+		log.Warningf("Warm up: could not remove warm up container: %s", err)
+		return
+	}
+	log.Infof("Warm up finished for default image in %s.", time.Since(start))
 }
 
 // Get returns a runner that can be used to execute the given task. The caller


### PR DESCRIPTION
According to the logs, creating new containers when the executor first
starts up can take ~20 seconds though it's unclear what docker is doing
at the time.

Try to mitigate this for the default image by creating a dummy container
as part of executor start-up.

Issue: https://github.com/buildbuddy-io/buildbuddy-internal/issues/684

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
