### PR TITLE
Link GitHub account per-org

### DIFF
--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -125,7 +125,12 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                         <FilledButton className="settings-button success">GitHub account linked</FilledButton>
                       ) : (
                         <FilledButton className="settings-button settings-link-button">
-                          <a href="/auth/github/link/">Link GitHub account</a>
+                          <a
+                            href={`/auth/github/link/?groupID=${encodeURIComponent(
+                              this.props.user?.selectedGroup?.id
+                            )}`}>
+                            Link GitHub account
+                          </a>
                         </FilledButton>
                       )}
                     </>

--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -44,6 +44,14 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
     return path;
   }
 
+  private gitHubLinkUrl(): string {
+    const params = new URLSearchParams({
+      group_id: this.props.user?.selectedGroup?.id,
+      redirect_url: window.location.href,
+    });
+    return `/auth/github/link/?${params}`;
+  }
+
   render() {
     const activeTabId = this.getActiveTabId();
 
@@ -125,12 +133,7 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                         <FilledButton className="settings-button success">GitHub account linked</FilledButton>
                       ) : (
                         <FilledButton className="settings-button settings-link-button">
-                          <a
-                            href={`/auth/github/link/?groupID=${encodeURIComponent(
-                              this.props.user?.selectedGroup?.id
-                            )}`}>
-                            Link GitHub account
-                          </a>
+                          <a href={this.gitHubLinkUrl()}>Link GitHub account</a>
                         </FilledButton>
                       )}
                     </>

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -806,7 +806,7 @@ func (a *OpenIDAuthenticator) Auth(w http.ResponseWriter, r *http.Request) {
 	if authError != "" {
 		authErrorDesc := r.URL.Query().Get("error_desc")
 		authErrorDescription := r.URL.Query().Get("error_description")
-		log.Printf("Authenticator returned error: %s (%s %s)", authError, authErrorDesc, authErrorDescription)
+		log.Warningf("Authenticator returned error: %s (%s %s)", authError, authErrorDesc, authErrorDescription)
 		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 		return
 	}

--- a/server/backends/github/BUILD
+++ b/server/backends/github/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//server/environment",
         "//server/tables",
         "//server/util/log",
+        "//server/util/perms",
         "//server/util/random",
     ],
 )

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 )
 
@@ -26,6 +27,9 @@ const (
 
 	stateCookieName    = "Github-State-Token"
 	redirectCookieName = "Github-Redirect-Url"
+	groupIDCookieName  = "Github-Linked-Group-ID"
+
+	groupIDURLParam = "groupID"
 )
 
 // State represents a status value that GitHub's statuses API understands.
@@ -71,13 +75,18 @@ func NewGithubClient(env environment.Env, token string) *GithubClient {
 func (c *GithubClient) Link(w http.ResponseWriter, r *http.Request) {
 	githubConfig := c.env.GetConfigurator().GetGithubConfig()
 	if githubConfig == nil {
+		log.Warningf("Missing GitHub config; redirecting to home page.")
 		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+		return
 	}
+
+	groupID := r.URL.Query().Get(groupIDURLParam)
 
 	// If we don't have a state yet parameter, start oauth flow.
 	if r.FormValue("state") == "" {
 		state := fmt.Sprintf("%d", random.RandUint64())
 		setCookie(w, stateCookieName, state)
+		setCookie(w, groupIDCookieName, groupID)
 		setCookie(w, redirectCookieName, r.FormValue("redirect_url"))
 
 		appURL := c.env.GetConfigurator().GetAppBuildBuddyURL()
@@ -97,6 +106,8 @@ func (c *GithubClient) Link(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 		return
 	}
+	// Restore group ID from state.
+	groupID = getCookie(r, groupIDCookieName)
 
 	client := &http.Client{}
 	url := fmt.Sprintf(
@@ -134,16 +145,8 @@ func (c *GithubClient) Link(w http.ResponseWriter, r *http.Request) {
 	var accessTokenResponse GithubAccessTokenResponse
 	json.Unmarshal(body, &accessTokenResponse)
 
-	auth := c.env.GetAuthenticator()
-	if auth == nil {
-		log.Warningf("No authenticator configured")
-		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
-		return
-	}
-
-	userInfo, err := auth.AuthenticatedUser(r.Context())
-	if err != nil {
-		log.Warningf("Error getting authenticated user: %v", err)
+	if err := perms.AuthorizeGroupAccess(r.Context(), c.env, groupID); err != nil {
+		log.Warningf("Group auth failed; not linking GitHub account: %s", err)
 		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 		return
 	}
@@ -155,11 +158,9 @@ func (c *GithubClient) Link(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: instead of linking all groups in GetAllowedGroups,
-	// link only the group in the RequestContext.
 	err = dbHandle.Exec(
-		"UPDATE Groups SET github_token = ? WHERE group_id IN (?)",
-		accessTokenResponse.AccessToken, userInfo.GetAllowedGroups()).Error
+		"UPDATE Groups SET github_token = ? WHERE group_id = ?",
+		accessTokenResponse.AccessToken, groupID).Error
 	if err != nil {
 		log.Warningf("Error linking github account to user: %v", err)
 		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -28,8 +28,6 @@ const (
 	stateCookieName    = "Github-State-Token"
 	redirectCookieName = "Github-Redirect-Url"
 	groupIDCookieName  = "Github-Linked-Group-ID"
-
-	groupIDURLParam = "groupID"
 )
 
 // State represents a status value that GitHub's statuses API understands.
@@ -80,13 +78,11 @@ func (c *GithubClient) Link(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	groupID := r.URL.Query().Get(groupIDURLParam)
-
 	// If we don't have a state yet parameter, start oauth flow.
 	if r.FormValue("state") == "" {
 		state := fmt.Sprintf("%d", random.RandUint64())
 		setCookie(w, stateCookieName, state)
-		setCookie(w, groupIDCookieName, groupID)
+		setCookie(w, groupIDCookieName, r.FormValue("group_id"))
 		setCookie(w, redirectCookieName, r.FormValue("redirect_url"))
 
 		appURL := c.env.GetConfigurator().GetAppBuildBuddyURL()
@@ -106,8 +102,8 @@ func (c *GithubClient) Link(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 		return
 	}
-	// Restore group ID from state.
-	groupID = getCookie(r, groupIDCookieName)
+	// Restore group ID from cookie.
+	groupID := getCookie(r, groupIDCookieName)
 
 	client := &http.Client{}
 	url := fmt.Sprintf(

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -102,8 +102,6 @@ func (c *GithubClient) Link(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 		return
 	}
-	// Restore group ID from cookie.
-	groupID := getCookie(r, groupIDCookieName)
 
 	client := &http.Client{}
 	url := fmt.Sprintf(
@@ -141,6 +139,8 @@ func (c *GithubClient) Link(w http.ResponseWriter, r *http.Request) {
 	var accessTokenResponse GithubAccessTokenResponse
 	json.Unmarshal(body, &accessTokenResponse)
 
+	// Restore group ID from cookie.
+	groupID := getCookie(r, groupIDCookieName)
 	if err := perms.AuthorizeGroupAccess(r.Context(), c.env, groupID); err != nil {
 		log.Warningf("Group auth failed; not linking GitHub account: %s", err)
 		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)


### PR DESCRIPTION
* Set a `GitHub-Linked-Group-ID` cookie in the first step of the auth flow. The group ID comes from a URL param passed to the OAuth handler in the first step of the flow.
* When redirected back from the OAuth provider and after verifying the CSRF token, extract the group ID from the cookie and authorize group access.
* Only link the GitHub account to the authorized group.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
