### PR TITLE
Fix UI flickering when switching orgs

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -109,8 +109,13 @@ export class AuthService {
     return requestContext;
   }
 
-  async setSelectedGroupId(groupId: string) {
+  async setSelectedGroupId(groupId: string, { reload = false }: { reload?: boolean } = {}) {
     window.localStorage.setItem(SELECTED_GROUP_ID_LOCAL_STORAGE_KEY, groupId);
+    if (reload) {
+      // Don't publish a new user to avoid UI flickering.
+      window.location.reload();
+      return;
+    }
     const selectedGroup = this.user.groups.find((group) => group.id === groupId);
     if (!selectedGroup) {
       await this.refreshUser();

--- a/enterprise/app/sidebar/sidebar.tsx
+++ b/enterprise/app/sidebar/sidebar.tsx
@@ -32,9 +32,7 @@ export default class SidebarComponent extends React.Component {
   async handleOrgClicked(groupId: string) {
     if (this.props.user?.selectedGroup?.id === groupId) return;
 
-    // TODO: loading state
-    await authService.setSelectedGroupId(groupId);
-    window.location.reload();
+    await authService.setSelectedGroupId(groupId, { reload: true });
   }
 
   isHomeSelected() {


### PR DESCRIPTION
When picking a new org, don't emit a new user -- instead, only set the selected group ID in localStorage, and let the newly selected user be naturally refreshed via the reload.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
