### PR TITLE
Add invocation_id to RPC server span without modifying otel code.

### DIFF
--- a/server/util/grpc_server/BUILD
+++ b/server/util/grpc_server/BUILD
@@ -13,6 +13,7 @@ go_library(
         "@com_github_grpc_ecosystem_go_grpc_prometheus//:go-grpc-prometheus",
         "@io_opentelemetry_go_contrib_instrumentation_google_golang_org_grpc_otelgrpc//:otelgrpc",
         "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -50,13 +50,6 @@ func GRPCShutdownFunc(grpcServer *grpc.Server) func(ctx context.Context) error {
 	}
 }
 
-func extractInvocationID(ctx context.Context) []attribute.KeyValue {
-	if iid := bazel_request.GetInvocationID(ctx); iid != "" {
-		return []attribute.KeyValue{attribute.String("invocation_id", iid)}
-	}
-	return nil
-}
-
 func propagateInvocationIDToSpan(ctx context.Context) {
 	invocationId := bazel_request.GetInvocationID(ctx)
 	if invocationId == "" {

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
@@ -56,12 +57,35 @@ func extractInvocationID(ctx context.Context) []attribute.KeyValue {
 	return nil
 }
 
+func propagateInvocationIDToSpan(ctx context.Context) {
+	invocationId := bazel_request.GetInvocationID(ctx)
+	if invocationId == "" {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(attribute.String("invocation_id", invocationId))
+}
+
+func propagateInvocationIDToSpanUnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		propagateInvocationIDToSpan(ctx)
+		return handler(ctx, req)
+	}
+}
+
+func propagateInvocationIDToSpanStreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		propagateInvocationIDToSpan(stream.Context())
+		return handler(srv, stream)
+	}
+}
+
 func CommonGRPCServerOptions(env environment.Env) []grpc.ServerOption {
 	return []grpc.ServerOption{
 		filters.GetUnaryInterceptor(env),
 		filters.GetStreamInterceptor(env),
-		grpc.ChainUnaryInterceptor(otelgrpc.UnaryServerInterceptor(otelgrpc.WithContextAttrExtractor(extractInvocationID))),
-		grpc.ChainStreamInterceptor(otelgrpc.StreamServerInterceptor(otelgrpc.WithContextAttrExtractor(extractInvocationID))),
+		grpc.ChainUnaryInterceptor(otelgrpc.UnaryServerInterceptor(), propagateInvocationIDToSpanUnaryServerInterceptor()),
+		grpc.ChainStreamInterceptor(otelgrpc.StreamServerInterceptor(), propagateInvocationIDToSpanStreamServerInterceptor()),
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
 		grpc.MaxRecvMsgSize(env.GetConfigurator().GetGRPCMaxRecvMsgSizeBytes()),


### PR DESCRIPTION
Saw similar code while looking at the HTTP interceptors.

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
