### PR TITLE
Init: Name overlay root/work dirs something unmistakeably ours.

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -28,8 +28,8 @@ import (
 	"google.golang.org/grpc/peer"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
-	oidc "github.com/coreos/go-oidc"
 	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
+	oidc "github.com/coreos/go-oidc"
 )
 
 const (

--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -117,11 +117,11 @@ func main() {
 	die(mkdirp("/overlay", 0755))
 	die(mount("/dev/vdb", "/overlay", "ext4", syscall.MS_RELATIME, ""))
 
-	die(mkdirp("/overlay/root", 0755))
-	die(mkdirp("/overlay/work", 0755))
+	die(mkdirp("/overlay/bbvmroot", 0755))
+	die(mkdirp("/overlay/bbvmwork", 0755))
 
 	die(mkdirp("/mnt", 0755))
-	die(mount("overlayfs:/overlay/root", "/mnt", "overlay", syscall.MS_NOATIME, "lowerdir=/container,upperdir=/overlay/root,workdir=/overlay/work"))
+	die(mount("overlayfs:/overlay/bbvmroot", "/mnt", "overlay", syscall.MS_NOATIME, "lowerdir=/container,upperdir=/overlay/bbvmroot,workdir=/overlay/bbvmwork"))
 
 	die(mkdirp("/mnt/dev", 0755))
 	die(mount("/dev", "/mnt/dev", "", syscall.MS_MOVE, ""))

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -36,10 +36,10 @@ import (
 	"google.golang.org/grpc/codes"
 
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
-	gstatus "google.golang.org/grpc/status"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 	tspb "github.com/golang/protobuf/ptypes/timestamp"
+	gstatus "google.golang.org/grpc/status"
 )
 
 const (


### PR DESCRIPTION
This way, they can easily be skipped when copying files back out of the workspace fs