### PR TITLE
Make usernames lowercase

### DIFF
--- a/app/invocation/invocation_overview.tsx
+++ b/app/invocation/invocation_overview.tsx
@@ -82,7 +82,7 @@ export default class InvocationOverviewComponent extends React.Component {
         <div className="titles">
           {isBazelInvocation && (
             <div className="title" title={this.props.model.getAllPatterns()}>
-              {format.sentenceCase(this.props.model.getUser(true))} {this.props.model.getCommand()}{" "}
+              {this.props.model.getUser(/*possessive=*/ true)} {this.props.model.getCommand()}{" "}
               {this.props.model.getPattern()}
             </div>
           )}

--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -274,7 +274,7 @@ export default class HistoryComponent extends React.Component {
               <div className="title">
                 {this.props.username && (
                   <span>
-                    <span>{format.sentenceCase(this.props.username)}'s builds</span>
+                    <span>{this.props.username}'s builds</span>
                     <a className="history-trends-button" href={`/trends/?user=${this.props.username}`}>
                       View trends
                     </a>
@@ -315,7 +315,7 @@ export default class HistoryComponent extends React.Component {
                   !this.props.username &&
                   !this.props.repo &&
                   !this.props.commit &&
-                  `${format.sentenceCase(this.props.user?.selectedGroupName() || "User")}'s ${viewType}`}
+                  `${this.props.user?.selectedGroupName() || "User"}'s ${viewType}`}
               </div>
             </div>
             {!scope &&

--- a/enterprise/app/history/history_invocation_card.tsx
+++ b/enterprise/app/history/history_invocation_card.tsx
@@ -132,27 +132,23 @@ export default class HistoryInvocationCardComponent extends React.Component {
 
     if (this.isInProgress()) {
       return this.props.invocation?.user
-        ? format.sentenceCase(
-            `${this.props.invocation.user}'s in progress ${
-              this.props.invocation.command || "build"
-            } ${format.truncateList(this.props.invocation.pattern)}...`
-          )
+        ? `${this.props.invocation.user}'s in progress ${
+            this.props.invocation.command || "build"
+          } ${format.truncateList(this.props.invocation.pattern)}...`
         : "In progress build...";
     }
 
     if (this.isDisconnected()) {
       return this.props.invocation?.user
-        ? format.sentenceCase(
-            `${this.props.invocation.user}'s disconnected ${
-              this.props.invocation.command || "build"
-            } ${format.truncateList(this.props.invocation.pattern)}`
-          )
+        ? `${this.props.invocation.user}'s disconnected ${
+            this.props.invocation.command || "build"
+          } ${format.truncateList(this.props.invocation.pattern)}`
         : "Disconnected build";
     }
 
-    return `${format.sentenceCase(this.props.invocation.user || "Unknown user")}'s ${
-      this.props.invocation.command
-    } ${format.truncateList(this.props.invocation.pattern)}`;
+    return `${this.props.invocation.user || "Unknown user"}'s ${this.props.invocation.command} ${format.truncateList(
+      this.props.invocation.pattern
+    )}`;
   }
 
   getDuration() {


### PR DESCRIPTION
Addressing feedback from https://github.com/buildbuddy-io/buildbuddy-internal/issues/672. Some (mild) problems with the current sentence-casing approach:

* It looks slightly odd if your username isn't just your first name (e.g. `jdoe` becomes `Jdoe`)
* It causes usernames beginning with `i` to look like they start with a lowercase `L` (though this could be mitigated by using a more readable font)
* Unix usernames are case-sensitive, so arguably this is causing the wrong data to be displayed.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/672