### PR TITLE
Increase max size of access & refresh tokens

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -236,8 +236,8 @@ type Token struct {
 	// The subscriber ID, a concatenated string of the
 	// auth Issuer ID and the subcriber ID string.
 	SubID        string `gorm:"primaryKey"`
-	AccessToken  string
-	RefreshToken string
+	AccessToken  string `gorm:"size:4096"`
+	RefreshToken string `gorm:"size:4096"`
 	Model
 	ExpiryUsec int64
 }
@@ -430,7 +430,7 @@ type Workflow struct {
 	GroupID     string `gorm:"index:workflow_group_id"`
 	Name        string
 	Username    string
-	AccessToken string
+	AccessToken string `gorm:"size:4096"`
 	WebhookID   string `gorm:"uniqueIndex:workflow_webhook_id_index"`
 	Model
 	Perms int `gorm:"index:workflow_perms"`


### PR DESCRIPTION
- Google's max seems to be 2048: https://developers.google.com/identity/protocols/oauth2
- Intuit is 4096: https://blogs.intuit.com/blog/2020/03/23/increased-lengths-for-oauth-2-0-fields/
- Facebook doesn't have one: https://www.quora.com/Whats-the-maximum-length-of-an-OAuth-access-token-key-secret-pair

4096 seems like a reasonable max.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
