### PR TITLE
Add some basic task reservation balancing across groups.

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -303,7 +303,7 @@ func (s *ExecutionServer) Dispatch(ctx context.Context, req *repb.ExecuteRequest
 
 	os := defaultPlatformOSValue
 	arch := defaultPlatformArchValue
-	groupID, pool, err := s.env.GetSchedulerService().GetGroupIDAndDefaultPoolForUser(ctx)
+	executorGroupID, pool, err := s.env.GetSchedulerService().GetGroupIDAndDefaultPoolForUser(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -319,12 +319,18 @@ func (s *ExecutionServer) Dispatch(ctx context.Context, req *repb.ExecuteRequest
 		}
 	}
 
+	taskGroupID := "ANON"
+	if user, err := perms.AuthenticatedUser(ctx, s.env); err == nil {
+		taskGroupID = user.GetGroupID()
+	}
+
 	schedulingMetadata := &scpb.SchedulingMetadata{
-		Os:       os,
-		Arch:     arch,
-		Pool:     pool,
-		TaskSize: taskSize,
-		GroupId:  groupID,
+		Os:              os,
+		Arch:            arch,
+		Pool:            pool,
+		TaskSize:        taskSize,
+		ExecutorGroupId: executorGroupID,
+		TaskGroupId:     taskGroupID,
 	}
 	scheduleReq := &scpb.ScheduleTaskRequest{
 		TaskId:         executionID,
@@ -434,8 +440,7 @@ func (s *ExecutionServer) getGroupIDForMetrics(ctx context.Context) string {
 	if a := s.env.GetAuthenticator(); a != nil {
 		user, err := a.AuthenticatedUser(ctx)
 		if err != nil {
-			log.Warningf("Could not determine groupID for metrics: %s", err)
-			return "unknown"
+			return "ANON"
 		}
 		return user.GetGroupID()
 	}

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -319,7 +319,7 @@ func (s *ExecutionServer) Dispatch(ctx context.Context, req *repb.ExecuteRequest
 		}
 	}
 
-	taskGroupID := "ANON"
+	taskGroupID := interfaces.AuthAnonymousUser
 	if user, err := perms.AuthenticatedUser(ctx, s.env); err == nil {
 		taskGroupID = user.GetGroupID()
 	}
@@ -440,7 +440,7 @@ func (s *ExecutionServer) getGroupIDForMetrics(ctx context.Context) string {
 	if a := s.env.GetAuthenticator(); a != nil {
 		user, err := a.AuthenticatedUser(ctx)
 		if err != nil {
-			return "ANON"
+			return interfaces.AuthAnonymousUser
 		}
 		return user.GetGroupID()
 	}

--- a/enterprise/server/scheduling/priority_task_scheduler/BUILD
+++ b/enterprise/server/scheduling/priority_task_scheduler/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "priority_task_scheduler",
@@ -18,7 +18,18 @@ go_library(
         "//server/util/status",
         "//server/util/tracing",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
+    ],
+)
+
+go_test(
+    name = "priority_task_scheduler_test",
+    srcs = ["priority_task_scheduler_test.go"],
+    embed = [":priority_task_scheduler"],
+    deps = [
+        "//proto:scheduler_go_proto",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -1,6 +1,7 @@
 package priority_task_scheduler
 
 import (
+	"container/list"
 	"context"
 	"sync"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/golang/protobuf/proto"
+	"github.com/prometheus/client_golang/prometheus"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
@@ -28,6 +30,100 @@ const (
 
 var shuttingDownLogOnce sync.Once
 
+type groupPriorityQueue struct {
+	*priority_queue.PriorityQueue
+	groupID string
+}
+
+type taskQueue struct {
+	// List of *groupPriorityQueue items.
+	pqs *list.List
+	// Map to allow quick lookup of a specific *groupPriorityQueue element in the pqs list.
+	pqByGroupID map[string]*list.Element
+	// The *groupPriorityQueue element from which the next task will be obtained.
+	// Will be nil when there are no tasks remaining.
+	currentPQ *list.Element
+	// Number of tasks across all queues.
+	numTasks int
+}
+
+func newTaskQueue() *taskQueue {
+	return &taskQueue{
+		pqs:         list.New(),
+		pqByGroupID: make(map[string]*list.Element),
+		currentPQ:   nil,
+	}
+}
+
+func (p *taskQueue) Enqueue(req *scpb.EnqueueTaskReservationRequest) {
+	taskGroupID := req.GetSchedulingMetadata().GetTaskGroupId()
+	var pq *groupPriorityQueue
+	if el, ok := p.pqByGroupID[taskGroupID]; ok {
+		pq, ok = el.Value.(*groupPriorityQueue)
+		if !ok {
+			// Why would this ever happen?
+			log.Error("not a *groupPriorityQueue!??!")
+			return
+		}
+	} else {
+		pq = &groupPriorityQueue{
+			PriorityQueue: priority_queue.NewPriorityQueue(),
+			groupID:       taskGroupID,
+		}
+		el := p.pqs.PushBack(pq)
+		p.pqByGroupID[taskGroupID] = el
+		if p.currentPQ == nil {
+			p.currentPQ = el
+		}
+	}
+	pq.Push(req)
+	p.numTasks++
+	metrics.RemoteExecutionQueueLength.With(prometheus.Labels{metrics.GroupID: taskGroupID}).Set(float64(pq.Len()))
+}
+
+func (p *taskQueue) Dequeue() *scpb.EnqueueTaskReservationRequest {
+	if p.currentPQ == nil {
+		return nil
+	}
+	pqEl := p.currentPQ
+	pq, ok := pqEl.Value.(*groupPriorityQueue)
+	if !ok {
+		// Why would this ever happen?
+		log.Error("not a *groupPriorityQueue!??!")
+		return nil
+	}
+	req := pq.Pop()
+
+	p.currentPQ = p.currentPQ.Next()
+	if pq.Len() == 0 {
+		p.pqs.Remove(pqEl)
+		delete(p.pqByGroupID, pq.groupID)
+	}
+	if p.currentPQ == nil {
+		p.currentPQ = p.pqs.Front()
+	}
+	p.numTasks--
+	metrics.RemoteExecutionQueueLength.With(prometheus.Labels{metrics.GroupID: req.GetSchedulingMetadata().GetTaskGroupId()}).Set(float64(pq.Len()))
+	return req
+}
+
+func (p *taskQueue) Peek() *scpb.EnqueueTaskReservationRequest {
+	if p.currentPQ == nil {
+		return nil
+	}
+	pq, ok := p.currentPQ.Value.(*groupPriorityQueue)
+	if !ok {
+		// Why would this ever happen?
+		log.Error("not a *groupPriorityQueue!??!")
+		return nil
+	}
+	return pq.Peek()
+}
+
+func (p *taskQueue) Len() int {
+	return p.numTasks
+}
+
 type Options struct {
 	RAMBytesCapacityOverride  int64
 	CPUMillisCapacityOverride int64
@@ -37,7 +133,7 @@ type PriorityTaskScheduler struct {
 	env           environment.Env
 	log           log.Logger
 	shuttingDown  bool
-	pq            *priority_queue.PriorityQueue
+	q             *taskQueue
 	exec          *executor.Executor
 	newTaskSignal chan struct{}
 
@@ -64,7 +160,7 @@ func NewPriorityTaskScheduler(env environment.Env, exec *executor.Executor, opti
 	qes := &PriorityTaskScheduler{
 		env:                   env,
 		log:                   sublog,
-		pq:                    priority_queue.NewPriorityQueue(),
+		q:                     newTaskQueue(),
 		exec:                  exec,
 		newTaskSignal:         make(chan struct{}, 1),
 		activeTaskCancelFuncs: make(map[*context.CancelFunc]struct{}, 0),
@@ -103,7 +199,9 @@ func NewPriorityTaskScheduler(env environment.Env, exec *executor.Executor, opti
 }
 
 func (q *PriorityTaskScheduler) EnqueueTaskReservation(ctx context.Context, req *scpb.EnqueueTaskReservationRequest) (*scpb.EnqueueTaskReservationResponse, error) {
-	q.pq.Push(req)
+	q.mu.Lock()
+	q.q.Enqueue(req)
+	q.mu.Unlock()
 	q.log.Infof("Added task %+v to pq.", req)
 	q.newTaskSignal <- struct{}{}
 	return &scpb.EnqueueTaskReservationResponse{}, nil
@@ -168,7 +266,7 @@ func (q *PriorityTaskScheduler) canFitAnotherTask(res *scpb.EnqueueTaskReservati
 	willFit := knownRAMremaining >= res.GetTaskSize().GetEstimatedMemoryBytes() && knownCPUremaining >= res.GetTaskSize().GetEstimatedMilliCpu()
 
 	if willFit {
-		q.log.Infof("ram remaining: %d, cpu remaining: %d, tasks running: %d, q depth: %d", knownRAMremaining, knownCPUremaining, len(q.activeTaskCancelFuncs), q.pq.Len())
+		q.log.Infof("ram remaining: %d, cpu remaining: %d, tasks running: %d, q depth: %d", knownRAMremaining, knownCPUremaining, len(q.activeTaskCancelFuncs), q.q.Len())
 		if res.GetTaskSize().GetEstimatedMemoryBytes() == 0 {
 			q.log.Warningf("Scheduling another unknown size task. THIS SHOULD NOT HAPPEN! res: %+v", res)
 		} else {
@@ -190,16 +288,15 @@ func (q *PriorityTaskScheduler) handleTask() {
 		return
 	}
 
-	qLen := q.pq.Len()
-	metrics.RemoteExecutionQueueLength.Set(float64(qLen))
+	qLen := q.q.Len()
 	if qLen == 0 {
 		return
 	}
-	nextTask := q.pq.Peek()
+	nextTask := q.q.Peek()
 	if nextTask == nil || !q.canFitAnotherTask(nextTask) {
 		return
 	}
-	reservation := q.pq.Pop()
+	reservation := q.q.Dequeue()
 	if reservation == nil {
 		q.log.Warningf("reservation is nil")
 		return

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler_test.go
@@ -1,0 +1,71 @@
+package priority_task_scheduler
+
+import (
+	"testing"
+
+	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testGroupID1 = "group1"
+	testGroupID2 = "group2"
+	testGroupID3 = "group3"
+)
+
+func newTaskReservationRequest(taskID, taskGroupID string) *scpb.EnqueueTaskReservationRequest {
+	return &scpb.EnqueueTaskReservationRequest{TaskId: taskID, SchedulingMetadata: &scpb.SchedulingMetadata{TaskGroupId: taskGroupID}}
+}
+
+func TestTaskQueue_SingleGroup(t *testing.T) {
+	q := newTaskQueue()
+	require.Equal(t, 0, q.Len())
+	require.Nil(t, q.Peek())
+
+	q.Enqueue(newTaskReservationRequest("1", testGroupID1))
+	require.Equal(t, 1, q.Len())
+
+	// Peeking should return the reservation but not remove it.
+	req := q.Peek()
+	require.Equal(t, "1", req.GetTaskId())
+	require.Equal(t, 1, q.Len())
+
+	// Dequeueing should return the reservation and remove it.
+	req = q.Dequeue()
+	require.Equal(t, "1", req.GetTaskId())
+	require.Equal(t, 0, q.Len())
+
+	// Queue should be empty.
+	require.Equal(t, 0, q.Len())
+	require.Nil(t, q.Peek())
+
+	q.Enqueue(newTaskReservationRequest("1", testGroupID1))
+	q.Enqueue(newTaskReservationRequest("2", testGroupID1))
+	q.Enqueue(newTaskReservationRequest("3", testGroupID1))
+
+	require.Equal(t, "1", q.Dequeue().GetTaskId())
+	require.Equal(t, "2", q.Dequeue().GetTaskId())
+	require.Equal(t, "3", q.Dequeue().GetTaskId())
+}
+
+func TestTaskQueue_MultipleGroups(t *testing.T) {
+	q := newTaskQueue()
+
+	// First group has 3 task reservations.
+	q.Enqueue(newTaskReservationRequest("group1Task1", testGroupID1))
+	q.Enqueue(newTaskReservationRequest("group1Task2", testGroupID1))
+	q.Enqueue(newTaskReservationRequest("group1Task3", testGroupID1))
+	// Second group has 1 task reservation.
+	q.Enqueue(newTaskReservationRequest("group2Task1", testGroupID2))
+	// Third group has 2 task reservations.
+	q.Enqueue(newTaskReservationRequest("group3Task1", testGroupID3))
+	q.Enqueue(newTaskReservationRequest("group3Task2", testGroupID3))
+
+	require.Equal(t, "group1Task1", q.Dequeue().GetTaskId())
+	require.Equal(t, "group2Task1", q.Dequeue().GetTaskId())
+	require.Equal(t, "group3Task1", q.Dequeue().GetTaskId())
+	require.Equal(t, "group1Task2", q.Dequeue().GetTaskId())
+	require.Equal(t, "group3Task2", q.Dequeue().GetTaskId())
+	require.Equal(t, "group1Task3", q.Dequeue().GetTaskId())
+	require.Nil(t, q.Dequeue())
+}

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1095,7 +1095,7 @@ func (s *SchedulerServer) LeaseTask(stream scpb.Scheduler_LeaseTaskServer) error
 				os:      task.metadata.GetOs(),
 				arch:    task.metadata.GetArch(),
 				pool:    task.metadata.GetPool(),
-				groupID: task.metadata.GetGroupId(),
+				groupID: task.metadata.GetExecutorGroupId(),
 			}
 			nodePool, ok := s.getPool(key)
 			if ok {
@@ -1147,7 +1147,7 @@ func (s *SchedulerServer) enqueueTaskReservations(ctx context.Context, enqueueRe
 	os := enqueueRequest.GetSchedulingMetadata().GetOs()
 	arch := enqueueRequest.GetSchedulingMetadata().GetArch()
 	pool := enqueueRequest.GetSchedulingMetadata().GetPool()
-	groupID := enqueueRequest.GetSchedulingMetadata().GetGroupId()
+	groupID := enqueueRequest.GetSchedulingMetadata().GetExecutorGroupId()
 
 	key := nodePoolKey{os: os, arch: arch, pool: pool, groupID: groupID}
 

--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -158,7 +158,7 @@ func (tr *taskRouter) routingKey(ctx context.Context, cmd *repb.Command, remoteI
 	if u, err := perms.AuthenticatedUser(ctx, tr.env); err == nil {
 		parts = append(parts, u.GetGroupID())
 	} else {
-		parts = append(parts, "ANON")
+		parts = append(parts, interfaces.AuthAnonymousUser)
 	}
 
 	if remoteInstanceName != "" {

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -85,7 +85,8 @@ message SchedulingMetadata {
   string arch = 3;
   string pool = 4;
   // Group ID that owns the executors on which the task is to be executed.
-  // May be different from the Group ID of the user that issued the Execute request.
+  // May be different from the Group ID of the user that issued the Execute
+  // request.
   string executor_group_id = 5;
   // Group ID of the user that issued the Execute request.
   string task_group_id = 6;

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -84,7 +84,11 @@ message SchedulingMetadata {
   string os = 2;
   string arch = 3;
   string pool = 4;
-  string group_id = 5;
+  // Group ID that owns the executors on which the task is to be executed.
+  // May be different from the Group ID of the user that issued the Execute request.
+  string executor_group_id = 5;
+  // Group ID of the user that issued the Execute request.
+  string task_group_id = 6;
 }
 
 message ScheduleTaskRequest {

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -297,7 +297,7 @@ func TestAsyncLoading(t *testing.T) {
 	maxSizeBytes := int64(100_000_000) // 100MB
 	rootDir := getTmpDir(t)
 	ctx := getAnonContext(t)
-	anonPath := filepath.Join(rootDir, "ANON")
+	anonPath := filepath.Join(rootDir, interfaces.AuthAnonymousUser)
 	if err := disk.EnsureDirectoryExists(anonPath); err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +400,7 @@ func TestZeroLengthFiles(t *testing.T) {
 	maxSizeBytes := int64(100_000_000) // 100MB
 	rootDir := getTmpDir(t)
 	ctx := getAnonContext(t)
-	anonPath := filepath.Join(rootDir, "ANON")
+	anonPath := filepath.Join(rootDir, interfaces.AuthAnonymousUser)
 	if err := disk.EnsureDirectoryExists(anonPath); err != nil {
 		t.Fatal(err)
 	}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -50,6 +50,9 @@ type UserInfo interface {
 // Authenticator constants
 const (
 	AuthContextUserErrorKey = "auth.error"
+
+	// AuthAnonymousUser is the identifier for unauthenticated users in installations that allow anonymous users.
+	AuthAnonymousUser = "ANON"
 )
 
 type Authenticator interface {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -308,11 +308,13 @@ var (
 	/// )
 	/// ```
 
-	RemoteExecutionQueueLength = promauto.NewGauge(prometheus.GaugeOpts{
+	RemoteExecutionQueueLength = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",
 		Name:      "queue_length",
 		Help:      "Number of actions currently waiting in the executor queue.",
+	}, []string{
+		GroupID,
 	})
 
 	/// #### Examples

--- a/server/util/prefix/BUILD
+++ b/server/util/prefix/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/environment",
+        "//server/interfaces",
         "//server/util/log",
         "//server/util/status",
     ],

--- a/server/util/prefix/prefix.go
+++ b/server/util/prefix/prefix.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
@@ -32,7 +33,7 @@ func userPrefixCacheKey(ctx context.Context, env environment.Env, key string) (s
 		return "", status.PermissionDeniedErrorf("Anonymous access disabled, permission denied.")
 	}
 
-	return addPrefix("ANON", key), nil
+	return addPrefix(interfaces.AuthAnonymousUser, key), nil
 }
 
 func AttachUserPrefixToContext(ctx context.Context, env environment.Env) (context.Context, error) {


### PR DESCRIPTION
This PR creates a separate priority queue per group ID and then does a
round robin over the PQs to dequeue the next task.

This PR also adds a Group ID label to the remote_execution_queue_length
metric. This should not impact scaling as the metric is already
aggregated by other fields when being exposed to k8s.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
