### PR TITLE
Update style for failed actions

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -33,6 +33,7 @@ ts_library(
         "//proto:command_line_ts_proto",
         "//proto:execution_stats_ts_proto",
         "//proto:group_ts_proto",
+        "//proto:grpc_code_ts_proto",
         "//proto:invocation_ts_proto",
         "//proto:remote_execution_ts_proto",
         "//proto:user_ts_proto",

--- a/app/invocation/invocation_execution_card.tsx
+++ b/app/invocation/invocation_execution_card.tsx
@@ -54,7 +54,7 @@ function getExecutionStatus(execution: execution_stats.Execution): ExecutionStat
         image: "/image/x-circle.svg",
       };
     }
-    return { name: "Completed", image: "/image/complete.svg" };
+    return { name: "Succeeded", image: "/image/complete.svg" };
   }
 
   return STATUSES_BY_STAGE[execution.stage];

--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -79,7 +79,8 @@ func tableExecToProto(in tables.Execution) (*espb.Execution, error) {
 			Code:    in.StatusCode,
 			Message: in.StatusMessage,
 		},
-		Stage: repb.ExecutionStage_Value(in.Stage),
+		ExitCode: in.ExitCode,
+		Stage:    repb.ExecutionStage_Value(in.Stage),
 		IoStats: &espb.IOStats{
 			FileDownloadCount:        in.FileDownloadCount,
 			FileDownloadSizeBytes:    in.FileDownloadSizeBytes,

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -181,6 +181,7 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 		if executeResponse := operation.ExtractExecuteResponse(op); executeResponse != nil {
 			execution.StatusCode = executeResponse.GetStatus().GetCode()
 			execution.StatusMessage = trimStatus(executeResponse.GetStatus().GetMessage())
+			execution.ExitCode = executeResponse.GetResult().GetExitCode()
 			if details := executeResponse.GetStatus().GetDetails(); details != nil && len(details) > 0 {
 				serializedDetails, err := proto.Marshal(details[0])
 				if err == nil {

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -640,6 +640,11 @@ ts_proto_library(
 )
 
 ts_proto_library(
+    name = "grpc_code_ts_proto",
+    proto = "@go_googleapis//google/rpc:code_proto",
+)
+
+ts_proto_library(
     name = "cache_ts_proto",
     proto = ":cache_proto",
 )

--- a/proto/defs.bzl
+++ b/proto/defs.bzl
@@ -71,7 +71,7 @@ def ts_proto_library(name, proto, **kwargs):
         # https://github.com/protobufjs/protobuf.js/tree/6.8.8#pbjs-for-javascript
         args = [
             "--target=static-module",
-            "--wrap=default",
+            "--wrap=es6",
             "--strict-long",  # Force usage of Long type with int64 fields
             "--out=$@",
             "$(execpaths %s)" % proto_target,

--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -104,6 +104,9 @@ message Execution {
   // A snippet of the command that ran as part of this execution.
   // Ex. /usr/bin/gcc foo.cc -o foo
   string command_snippet = 7;
+
+  // The exit code of the command. Should be ignored if status != OK.
+  int32 exit_code = 8;
 }
 
 message ExecutionLookup {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -307,6 +307,7 @@ type Execution struct {
 	OutputUploadCompletedTimestampUsec int64
 
 	StatusCode   int32
+	ExitCode     int32
 	CachedResult bool
 }
 


### PR DESCRIPTION
Completed actions with gRPC errors (e.g. INTERNAL) now render like this:

![image](https://user-images.githubusercontent.com/2414826/124661648-c5712a80-de75-11eb-817b-638dde080ab3.png)

Completed actions with non-zero exit code now render like this:

![image](https://user-images.githubusercontent.com/2414826/124661933-2ac51b80-de76-11eb-9505-55f6b3f8c1f9.png)

When sorting by status (ascending) the order is now
- Started
- Queued
- Running
- Completed
  - Successful (gRPC OK, exitCode == 0)
  - RBE error (gRPC != OK, sorted by gRPC code)
  - Command error (gRPC == OK, exitCode != 0, sorted by exit code)

So to see failed actions first (which is our general sort order for other parts of the UI), the user just needs to sort by Status Desc, if it isn't sorted that way already.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/672
