### PR TITLE
Some bug fixes / improvements to bazel usage in tests

### DIFF
--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -16,6 +16,7 @@ go_test(
         "//proto:invocation_go_proto",
         "//server/testutil/buildbuddy",
         "//server/testutil/testbazel",
+        "//server/testutil/testfs",
         "@com_github_google_uuid//:uuid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/server/testutil/testbazel/BUILD
+++ b/server/testutil/testbazel/BUILD
@@ -9,6 +9,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/util/bazel",
+        "//server/util/log",
         "@com_github_stretchr_testify//require",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],


### PR DESCRIPTION
CI runner test:
* Don't use `testbazel.MakeTempWorkspace` to create the CI runner's working directory -- the CI runner creates its own bazel workspace inside the working directory (under `repo-root`).
* Fix bug that we're forwarding the `TEST_TMPDIR` env var from the test to the CI runner process, which causes Bazel to write some stuff to cache directory on the local machine (`~/.cache/bazel/...`).
* Pass `--max_idle_time_secs=5` to prevent the CI runner's spawned bazel process from sticking around forever (the default is 3 hours). Also pass `--noblock_on_lock` as a way to assert that the CI runner never gets stuck waiting for another bazel process to release the lock.

testbazel util:
* Log `bazel shutdown` duration in test cleanup phase (to help diagnose the cause of slow bazel tests)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
