### PR TITLE
Temporarily disable tests that invoke bazel.

### DIFF
--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -7,6 +7,7 @@ go_test(
         "//enterprise/server/cmd/ci_runner",
     ],
     shard_count = 4,
+    tags = ["manual"],
     visibility = [
         "//enterprise:__subpackages__",
         "@buildbuddy_internal//enterprise:__subpackages__",

--- a/enterprise/server/test/integration/remote_cache/BUILD
+++ b/enterprise/server/test/integration/remote_cache/BUILD
@@ -4,6 +4,7 @@ go_test(
     name = "remote_cache_test",
     srcs = ["remote_cache_test.go"],
     shard_count = 4,
+    tags = ["manual"],
     deps = [
         "//enterprise/server/auth",
         "//enterprise/server/backends/userdb",

--- a/server/test/integration/build_event_protocol/BUILD
+++ b/server/test/integration/build_event_protocol/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "build_event_protocol_test",
     srcs = ["build_event_protocol_test.go"],
+    tags = ["manual"],
     deps = [
         "//server/testutil/buildbuddy",
         "//server/testutil/testbazel",


### PR DESCRIPTION
They are flaky because `bazel shutdown` sometimes takes forever.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
