### PR TITLE
Only lazy-load the code component for now

### DIFF
--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -1,23 +1,23 @@
 import React, { Suspense } from "react";
 import authService, { User } from "../../../app/auth/auth_service";
 import capabilities from "../../../app/capabilities/capabilities";
-const CompareInvocationsComponent = React.lazy(() => import("../../../app/compare/compare_invocations"));
-const SetupComponent = React.lazy(() => import("../../../app/docs/setup"));
+import CompareInvocationsComponent from "../../../app/compare/compare_invocations";
+import SetupComponent from "../../../app/docs/setup";
 import AlertComponent from "../../../app/alert/alert";
 import faviconService from "../../../app/favicon/favicon";
 import FooterComponent from "../../../app/footer/footer";
 import WorkflowsComponent from "../workflows/workflows";
-const InvocationComponent = React.lazy(() => import("../../../app/invocation/invocation"));
+import InvocationComponent from "../../../app/invocation/invocation";
 import MenuComponent from "../../../app/menu/menu";
 import router, { Path } from "../../../app/router/router";
 import HistoryComponent from "../history/history";
 import LoginComponent from "../login/login";
 import CreateOrgComponent from "../org/create_org";
 import JoinOrgComponent from "../org/join_org";
-const SettingsComponent = React.lazy(() => import("../settings/settings"));
+import SettingsComponent from "../settings/settings";
 import SidebarComponent from "../sidebar/sidebar";
-const TapComponent = React.lazy(() => import("../tap/tap"));
-const TrendsComponent = React.lazy(() => import("../trends/trends"));
+import TapComponent from "../tap/tap";
+import TrendsComponent from "../trends/trends";
 const CodeComponent = React.lazy(() => import("../code/code"));
 // TODO(siggisim): lazy load all components that make sense more gracefully.
 


### PR DESCRIPTION
Lazy loading other components seems to lead to:
```
TypeError: Cannot read property 'Timestamp' of undefined
```
https://app.buildbuddy.dev/invocation/6ae67d53-469f-4e34-9db1-a94970e889cc

which I'll need to investigate further. Potentially due to https://esbuild.github.io/api/#splitting being a work in progress.

---

**Version bump**: TODO <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
