### PR TITLE
Run docker-init in containers to reap zombie processes

### DIFF
--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -115,9 +115,12 @@ func (r *dockerCommandContainer) hostConfig(workDir string) *dockercontainer.Hos
 	if r.options.EnableSiblingContainers {
 		binds = append(binds, fmt.Sprintf("%s:%s%s", r.options.Socket, r.options.Socket, mountMode))
 	}
+	// Run an init process to reap zombies.
+	runInit := true
 	return &dockercontainer.HostConfig{
 		NetworkMode: networkMode,
 		Binds:       binds,
+		Init:        &runInit,
 	}
 }
 


### PR DESCRIPTION
This fixes the issue with bazel tests taking forever to shut down. The problem is that `bazel shutdown` does not treat the server as "shut down" if it is a zombie. https://github.com/bazelbuild/bazel/pull/13656 proposes an upstream fix.

It's problematic, still, that `bazel` becomes a zombie and never gets reaped. So, by specifying the `Init` option in this PR, the top-level Docker process in the container will be a [tiny init process](https://docs.docker.com/engine/reference/run/#specify-an-init-process) that reaps zombie processes.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
