### PR TITLE
Replace slow regex in API key redaction

### DIFF
--- a/enterprise/server/backends/userdb/BUILD
+++ b/enterprise/server/backends/userdb/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//proto:telemetry_go_proto",
         "//server/environment",
         "//server/tables",
+        "//server/util/apikey",
         "//server/util/capabilities",
         "//server/util/db",
         "//server/util/log",

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/util/apikey"
 	"github.com/buildbuddy-io/buildbuddy/server/util/capabilities"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -48,8 +49,8 @@ var (
 )
 
 func newAPIKeyToken() string {
-	// NB: Keep in sync with BuildBuddyServer#redactAPIKeys, which relies on this exact impl.
-	return randomToken(20)
+	// NB: apikey.RedactAll relies on this exact impl.
+	return randomToken(apikey.GeneratedAPIKeyLength)
 }
 
 func singleUserGroup(u *tables.User) (*tables.Group, error) {
@@ -62,7 +63,7 @@ func singleUserGroup(u *tables.User) (*tables.Group, error) {
 }
 
 func randomToken(length int) string {
-	// NB: Keep in sync with BuildBuddyServer#redactAPIKeys, which relies on this exact impl.
+	// NB: apikey.RedactAll relies on this exact impl.
 	token, err := random.RandomString(length)
 	if err != nil {
 		token = "bUiLdBuDdy"

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//server/ssl",
         "//server/tables",
         "//server/target",
+        "//server/util/apikey",
         "//server/util/capabilities",
         "//server/util/log",
         "//server/util/perms",

--- a/server/util/apikey/BUILD
+++ b/server/util/apikey/BUILD
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "apikey",
+    srcs = ["apikey.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/apikey",
+    visibility = ["//visibility:public"],
+    deps = ["//server/environment"],
+)
+
+go_test(
+    name = "apikey_test",
+    srcs = ["apikey_test.go"],
+    deps = [
+        ":apikey",
+        "//server/testutil/testenv",
+        "//server/util/testing/flags",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/server/util/apikey/apikey.go
+++ b/server/util/apikey/apikey.go
@@ -15,12 +15,9 @@ const (
 	apiKeyRedactionMarker = "<REDACTED>"
 )
 
+// RedactAll replaces all occurrences of API keys in the UTF-8 encoded text
+// with redaction markers.
 func RedactAll(env environment.Env, text string) string {
-	fmt.Printf("API key length: %d\n", len([]byte(text)))
-
-	// NB: this implementation depends on the way we generate API keys
-	// (20 alphanumeric characters).
-
 	// Replace x-buildbuddy-api-key header.
 	pat := regexp.MustCompile(fmt.Sprintf("x-buildbuddy-api-key=[[:alnum:]]{%d}", GeneratedAPIKeyLength))
 	text = pat.ReplaceAllLiteralString(text, fmt.Sprintf("x-buildbuddy-api-key=%s", apiKeyRedactionMarker))

--- a/server/util/apikey/apikey.go
+++ b/server/util/apikey/apikey.go
@@ -1,0 +1,71 @@
+package apikey
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+)
+
+const (
+	// GeneratedAPIKeyLength is the fixed length of generated API key tokens.
+	GeneratedAPIKeyLength = 20
+
+	apiKeyRedactionMarker = "<REDACTED>"
+)
+
+func RedactAll(env environment.Env, text string) string {
+	// NB: this implementation depends on the way we generate API keys
+	// (20 alphanumeric characters).
+
+	// Replace x-buildbuddy-api-key header.
+	pat := regexp.MustCompile(fmt.Sprintf("x-buildbuddy-api-key=[[:alnum:]]{%d}", GeneratedAPIKeyLength))
+	text = pat.ReplaceAllLiteralString(text, fmt.Sprintf("x-buildbuddy-api-key=%s", apiKeyRedactionMarker))
+
+	// Replace sequences that look like API keys immediately followed by '@',
+	// to account for patterns like "grpc://$API_KEY@app.buildbuddy.io"
+	// or "bes_backend=$API_KEY@domain.com".
+
+	text = redactAPIKeyBasicAuth(text, apiKeyRedactionMarker)
+
+	// Replace the literal API key in the configuration, which does not need
+	// to conform to the way we generate API keys.
+	configuredKey := getConfiguredAPIKey(env)
+	if configuredKey != "" {
+		text = strings.ReplaceAll(text, configuredKey, apiKeyRedactionMarker)
+	}
+	return text
+}
+
+// Replace the API key as it appears in patterns like `{key}@buildbuddy.io`,
+// `grpc://{key}@buildbuddy.io`, etc. Specifically, look for *exactly* 20
+// alphanumeric characters followed by "@" and replace the 20 chars with
+// the replacement string.
+func redactAPIKeyBasicAuth(text, replacement string) string {
+	out := make([]byte, 0, len(text))
+	alnumCount := 0
+	for _, b := range []byte(text) {
+		// NOTE: in UTF-8, all non-ASCII characters start with 1 in the highest bit
+		// position, so it's OK to iterate over bytes instead of runes here.
+		// (Iterating over runes is significantly slower.)
+		if (b >= '0' && b <= '9') || (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') {
+			alnumCount++
+		} else {
+			if b == '@' && alnumCount == GeneratedAPIKeyLength {
+				out = out[:len(out)-GeneratedAPIKeyLength]
+				out = append(out, []byte(replacement)...)
+			}
+			alnumCount = 0
+		}
+		out = append(out, b)
+	}
+	return string(out)
+}
+
+func getConfiguredAPIKey(env environment.Env) string {
+	if apiConfig := env.GetConfigurator().GetAPIConfig(); apiConfig != nil {
+		return apiConfig.APIKey
+	}
+	return ""
+}

--- a/server/util/apikey/apikey.go
+++ b/server/util/apikey/apikey.go
@@ -16,6 +16,8 @@ const (
 )
 
 func RedactAll(env environment.Env, text string) string {
+	fmt.Printf("API key length: %d\n", len([]byte(text)))
+
 	// NB: this implementation depends on the way we generate API keys
 	// (20 alphanumeric characters).
 
@@ -43,7 +45,7 @@ func RedactAll(env environment.Env, text string) string {
 // alphanumeric characters followed by "@" and replace the 20 chars with
 // the replacement string.
 func redactAPIKeyBasicAuth(text, replacement string) string {
-	out := make([]byte, 0, len(text))
+	out := make([]byte, 0, len([]byte(text)))
 	alnumCount := 0
 	for _, b := range []byte(text) {
 		// NOTE: in UTF-8, all non-ASCII characters start with 1 in the highest bit

--- a/server/util/apikey/apikey_test.go
+++ b/server/util/apikey/apikey_test.go
@@ -1,0 +1,45 @@
+package apikey_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/apikey"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	generatedKey  = "aBcDe54321AbCdE12345"
+	configuredKey = "password"
+)
+
+func TestRedactAll(t *testing.T) {
+	flags.Set(t, "api.api_key", configuredKey)
+	flags.Set(t, "api.enable_api", "true")
+	env := testenv.GetTestEnv(t)
+
+	// Test that it redacts when it should
+	for _, testCase := range []struct {
+		text     string
+		redacted string
+	}{
+		{generatedKey + "@", "<REDACTED>@"},
+		{"x-buildbuddy-api-key=" + generatedKey, "x-buildbuddy-api-key=<REDACTED>"},
+		{"//" + generatedKey + "@", "//<REDACTED>@"},
+		{configuredKey, "<REDACTED>"},
+		{"x-buildbuddy-api-key=" + configuredKey, "x-buildbuddy-api-key=<REDACTED>"},
+		{"A" + configuredKey + "B", "A<REDACTED>B"},
+		{"//" + configuredKey + "@", "//<REDACTED>@"},
+	} {
+		assert.Equal(t, testCase.redacted, apikey.RedactAll(env, testCase.text))
+	}
+	// Test that it does not redact when it shouldn't
+	for _, text := range []string{
+		generatedKey,
+		"//" + generatedKey[:len(generatedKey)-1] + "@",
+		"A" + generatedKey + "@",
+	} {
+		assert.Equal(t, text, apikey.RedactAll(env, text))
+	}
+}


### PR DESCRIPTION
In one large `GetInvocationResponse` (114 MB when serialized to string), this change reduces API key redaction time from about 7s to about 2s. The bottleneck was the slow regex `[^[:alnum]][[:alnum]]{20}@` which took around 5s. Now, almost all of the time is spent in proto serialization / deserialization.

Even in smaller invocations (e.g. https://app.buildbuddy.io/invocation/c59ba531-73f1-4d0e-ab1b-e71c12bf196f), this regexp was responsible for about 100ms of latency in the `GetInvocation` request.

Long term, we should redact when we store the data, instead of when returning the data from our API. But this change is still probably worth submitting, because this slow regex would still need to be done by the `BufferedProtoWriter` which is on the critical path for the build event handler currently. So this regexp would be contributing to reduced BES throughput and higher CPU usage.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/661
