### PR TITLE
Add support for multiple "partitions" in disk cache.

### DIFF
--- a/enterprise/server/test/performance/cache/BUILD
+++ b/enterprise/server/test/performance/cache/BUILD
@@ -12,6 +12,8 @@ go_test(
         "//proto:remote_execution_go_proto",
         "//server/backends/disk_cache",
         "//server/backends/memory_cache",
+        "//server/config",
+        "//server/environment",
         "//server/interfaces",
         "//server/testutil/app",
         "//server/testutil/testauth",

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/docker/docker v20.10.7+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0
 	github.com/elastic/gosigar v0.11.0
 	github.com/firecracker-microvm/firecracker-go-sdk v0.22.0
 	github.com/go-git/go-git/v5 v5.2.0
@@ -53,7 +54,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20210324051608-47abb6519492
+	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887
 	google.golang.org/api v0.43.0
 	google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1
 	google.golang.org/grpc v1.38.0

--- a/server/backends/disk_cache/BUILD
+++ b/server/backends/disk_cache/BUILD
@@ -7,6 +7,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
+        "//server/config",
+        "//server/environment",
         "//server/interfaces",
         "//server/remote_cache/digest",
         "//server/util/disk",
@@ -15,6 +17,7 @@ go_library(
         "//server/util/prefix",
         "//server/util/status",
         "//server/util/statusz",
+        "@com_github_docker_go_units//:go-units",
         "@org_golang_x_sync//errgroup",
     ],
 )
@@ -25,6 +28,8 @@ go_test(
     deps = [
         ":disk_cache",
         "//proto:remote_execution_go_proto",
+        "//server/config",
+        "//server/environment",
         "//server/interfaces",
         "//server/remote_cache/digest",
         "//server/testutil/testauth",
@@ -33,6 +38,7 @@ go_test(
         "//server/util/disk",
         "//server/util/prefix",
         "//server/util/testing/flags",
+        "@com_github_stretchr_testify//require",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/server/backends/disk_cache/BUILD
+++ b/server/backends/disk_cache/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//server/util/prefix",
         "//server/util/status",
         "//server/util/statusz",
-        "@com_github_docker_go_units//:go-units",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -99,10 +99,11 @@ func (c *DiskCache) WithPrefix(prefix string) interfaces.Cache {
 	}
 
 	return &DiskCache{
-		env:        c.env,
-		prefix:     newPrefix,
-		partition:  c.partition,
-		partitions: c.partitions,
+		env:               c.env,
+		prefix:            newPrefix,
+		partition:         c.partition,
+		partitions:        c.partitions,
+		partitionMappings: c.partitionMappings,
 	}
 }
 
@@ -122,10 +123,11 @@ func (c *DiskCache) WithRemoteInstanceName(ctx context.Context, remoteInstanceNa
 				return nil, status.NotFoundErrorf("Mapping to unknown partition %q", m.PartitionID)
 			}
 			return &DiskCache{
-				env:        c.env,
-				prefix:     c.prefix,
-				partition:  p,
-				partitions: c.partitions,
+				env:               c.env,
+				prefix:            c.prefix,
+				partition:         p,
+				partitions:        c.partitions,
+				partitionMappings: c.partitionMappings,
 			}, nil
 		}
 	}

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -24,7 +24,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/statusz"
-	"github.com/docker/go-units"
 	"golang.org/x/sync/errgroup"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -58,11 +57,6 @@ func NewDiskCache(env environment.Env, config *config.DiskConfig, defaultMaxSize
 	partitions := make(map[string]*partition)
 	var defaultPartition *partition
 	for _, pc := range config.Partitions {
-		maxSizeBytes, err := units.FromHumanSize(pc.MaxSize)
-		if err != nil {
-			return nil, status.InvalidArgumentErrorf("Maximum size %q for partition %q is invalid: %s", pc.MaxSize, pc.ID, err)
-		}
-
 		rootDir := config.RootDirectory
 		if pc.ID != defaultPartitionID {
 			if pc.ID == "" {
@@ -71,7 +65,7 @@ func NewDiskCache(env environment.Env, config *config.DiskConfig, defaultMaxSize
 			rootDir = filepath.Join(rootDir, pc.ID)
 		}
 
-		p, err := newPartition(pc.ID, rootDir, maxSizeBytes)
+		p, err := newPartition(pc.ID, rootDir, pc.MaxSizeBytes)
 		if err != nil {
 			return nil, err
 		}

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -9,10 +9,13 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/config"
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
@@ -21,6 +24,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/statusz"
+	"github.com/docker/go-units"
 	"golang.org/x/sync/errgroup"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -35,23 +39,60 @@ const (
 	// check the cache size.
 	janitorCheckPeriod = 100 * time.Millisecond
 
-	defaultPartition = "default"
+	defaultPartitionID = "default"
 )
 
 // DiskCache stores data on disk as files.
 // It is broken up into partitions which are independent and maintain their own LRUs.
 type DiskCache struct {
+	env               environment.Env
+	partitions        map[string]*partition
+	partitionMappings []config.DiskCachePartitionMapping
+	// The currently selected partition. Initialized to the default partition.
+	// WithRemoteInstanceName can create a new cache accessor with a different selected partition.
 	partition *partition
 	prefix    string
 }
 
-func NewDiskCache(rootDir string, maxSizeBytes int64) (*DiskCache, error) {
-	p, err := newPartition(defaultPartition, rootDir, maxSizeBytes)
-	if err != nil {
-		return nil, err
+func NewDiskCache(env environment.Env, config *config.DiskConfig, defaultMaxSizeBytes int64) (*DiskCache, error) {
+	partitions := make(map[string]*partition)
+	var defaultPartition *partition
+	for _, pc := range config.Partitions {
+		maxSizeBytes, err := units.FromHumanSize(pc.MaxSize)
+		if err != nil {
+			return nil, status.InvalidArgumentErrorf("Maximum size %q for partition %q is invalid: %s", pc.MaxSize, pc.ID, err)
+		}
+
+		rootDir := config.RootDirectory
+		if pc.ID != defaultPartitionID {
+			if pc.ID == "" {
+				return nil, status.InvalidArgumentError("Non-default partition %q must have a valid ID")
+			}
+			rootDir = filepath.Join(rootDir, pc.ID)
+		}
+
+		p, err := newPartition(pc.ID, rootDir, maxSizeBytes)
+		if err != nil {
+			return nil, err
+		}
+		partitions[pc.ID] = p
+		if pc.ID == defaultPartitionID {
+			defaultPartition = p
+		}
 	}
+	if defaultPartition == nil {
+		p, err := newPartition(defaultPartitionID, config.RootDirectory, defaultMaxSizeBytes)
+		if err != nil {
+			return nil, err
+		}
+		defaultPartition = p
+	}
+
 	c := &DiskCache{
-		partition: p,
+		env:               env,
+		partitions:        partitions,
+		partitionMappings: config.PartitionMappings,
+		partition:         defaultPartition,
 	}
 	statusz.AddSection("disk_cache", "On disk LRU cache", c)
 	return c, nil
@@ -64,13 +105,46 @@ func (c *DiskCache) WithPrefix(prefix string) interfaces.Cache {
 	}
 
 	return &DiskCache{
-		prefix:    newPrefix,
-		partition: c.partition,
+		env:        c.env,
+		prefix:     newPrefix,
+		partition:  c.partition,
+		partitions: c.partitions,
 	}
 }
 
+func (c *DiskCache) WithRemoteInstanceName(ctx context.Context, remoteInstanceName string) interfaces.Cache {
+	auth := c.env.GetAuthenticator()
+	if auth == nil {
+		return c
+	}
+	user, err := auth.AuthenticatedUser(ctx)
+	if err != nil {
+		return c
+	}
+	for _, m := range c.partitionMappings {
+		if m.GroupID == user.GetGroupID() && strings.HasPrefix(remoteInstanceName, m.Prefix) {
+			p, ok := c.partitions[m.PartitionID]
+			if !ok {
+				log.Warningf("Mapping to unknown partition %q", m.PartitionID)
+				continue
+			}
+			return &DiskCache{
+				env:        c.env,
+				prefix:     c.prefix,
+				partition:  p,
+				partitions: c.partitions,
+			}
+		}
+	}
+	return c
+}
+
 func (c *DiskCache) Statusz(ctx context.Context) string {
-	return c.partition.Statusz(ctx)
+	buf := ""
+	for _, p := range c.partitions {
+		buf += p.Statusz(ctx)
+	}
+	return buf
 }
 
 func (c *DiskCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
@@ -187,7 +261,7 @@ func makeRecord(fullPath string, info os.FileInfo) *fileRecord {
 func (p *partition) Statusz(ctx context.Context) string {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	buf := ""
+	buf := "<br>"
 	buf += fmt.Sprintf("<div>Partition %q</div>", p.id)
 	buf += fmt.Sprintf("<div>Root directory: %s</div>", p.rootDir)
 	percentFull := float64(p.lru.Size()) / float64(p.lru.MaxSize()) * 100.0

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -473,12 +473,12 @@ func TestNonDefaultPartition(t *testing.T) {
 		RootDirectory: rootDir,
 		Partitions: []config.DiskCachePartition{
 			{
-				ID:      "default",
-				MaxSize: "10MiB",
+				ID:           "default",
+				MaxSizeBytes: 10_000_000,
 			},
 			{
-				ID:      otherPartitionID,
-				MaxSize: "10MiB",
+				ID:           otherPartitionID,
+				MaxSizeBytes: 10_000_000,
 			},
 		},
 		PartitionMappings: []config.DiskCachePartitionMapping{
@@ -529,7 +529,8 @@ func TestNonDefaultPartition(t *testing.T) {
 		require.NoError(t, err)
 		d, buf := testdigest.NewRandomDigestBuf(t, 1000)
 
-		c := dc.WithRemoteInstanceName(ctx, "nonmatchingprefix/")
+		c, err := dc.WithRemoteInstanceName(ctx, "nonmatchingprefix/")
+		require.NoError(t, err)
 		err = c.Set(ctx, d, buf)
 		require.NoError(t, err)
 
@@ -547,7 +548,8 @@ func TestNonDefaultPartition(t *testing.T) {
 		require.NoError(t, err)
 		d, buf := testdigest.NewRandomDigestBuf(t, 1000)
 
-		c := dc.WithRemoteInstanceName(ctx, otherPartitionPrefix+"hello")
+		c, err := dc.WithRemoteInstanceName(ctx, otherPartitionPrefix+"hello")
+		require.NoError(t, err)
 		err = c.Set(ctx, d, buf)
 		require.NoError(t, err)
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -81,8 +81,8 @@ type storageConfig struct {
 }
 
 type DiskCachePartition struct {
-	ID      string `yaml:"id" usage:"The ID of the partition."`
-	MaxSize string `yaml:"max_size" usage:"Maximum size of the partition in SI units, e.g. 100GiB."`
+	ID           string `yaml:"id" usage:"The ID of the partition."`
+	MaxSizeBytes int64  `yaml:"max_size" usage:"Maximum size of the partition."`
 }
 
 type DiskCachePartitionMapping struct {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -81,14 +81,14 @@ type storageConfig struct {
 }
 
 type DiskCachePartition struct {
-	ID           string `yaml:"id" usage:"The ID of the partition."`
-	MaxSizeBytes int64  `yaml:"max_size" usage:"Maximum size of the partition."`
+	ID           string `yaml:"id" json:"id" usage:"The ID of the partition."`
+	MaxSizeBytes int64  `yaml:"max_size" json:"max_size_bytes "usage:"Maximum size of the partition."`
 }
 
 type DiskCachePartitionMapping struct {
-	GroupID     string `yaml:"group_id" usage:"The Group ID to which this mapping applies."`
-	Prefix      string `yaml:"prefix" usage:"The remote instance name prefix used to select this partition."`
-	PartitionID string `yaml:"partition_id" usage:"The partition to use if the Group ID and prefix match."`
+	GroupID     string `yaml:"group_id" json:"group_id" usage:"The Group ID to which this mapping applies."`
+	Prefix      string `yaml:"prefix" json:"prefix" usage:"The remote instance name prefix used to select this partition."`
+	PartitionID string `yaml:"partition_id" json:"partition_id" usage:"The partition to use if the Group ID and prefix match."`
 }
 
 type DiskConfig struct {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -80,8 +80,21 @@ type storageConfig struct {
 	EnableChunkedEventLogs bool        `yaml:"enable_chunked_event_logs" usage:"If true, Event logs will be stored separately from the invocation proto in chunks."`
 }
 
+type DiskCachePartition struct {
+	ID      string `yaml:"id" usage:"The ID of the partition."`
+	MaxSize string `yaml:"max_size" usage:"Maximum size of the partition in SI units, e.g. 100GiB."`
+}
+
+type DiskCachePartitionMapping struct {
+	GroupID     string `yaml:"group_id" usage:"The Group ID to which this mapping applies."`
+	Prefix      string `yaml:"prefix" usage:"The remote instance name prefix used to select this partition."`
+	PartitionID string `yaml:"partition_id" usage:"The partition to use if the Group ID and prefix match."`
+}
+
 type DiskConfig struct {
-	RootDirectory string `yaml:"root_directory" usage:"The root directory to store all blobs in, if using disk based storage."`
+	RootDirectory     string                      `yaml:"root_directory" usage:"The root directory to store all blobs in, if using disk based storage."`
+	Partitions        []DiskCachePartition        `yaml:"partitions"`
+	PartitionMappings []DiskCachePartitionMapping `yaml:"partition_mappings"`
 }
 
 type GCSConfig struct {
@@ -313,10 +326,15 @@ func defineFlagsForMembers(parentStructNames []string, T reflect.Value) {
 		default:
 			// We know this is not flag compatible and it's here for
 			// long-term support reasons, so don't warn about it.
-			if fqFieldName != "auth.oauth_providers" {
-				log.Printf("Skipping flag: --%s, kind: %s", fqFieldName, f.Type().Kind())
+			if fqFieldName == "auth.oauth_providers" {
+				continue
 			}
-			continue
+			// Not supported via flags.
+			if fqFieldName == "storage.disk.partitions" || fqFieldName == "storage.disk.partition_mappings" ||
+				fqFieldName == "cache.disk.partitions" || fqFieldName == "cache.disk.partition_mappings" {
+				continue
+			}
+			log.Warningf("Skipping flag: --%s, kind: %s", fqFieldName, f.Type().Kind())
 		}
 	}
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -82,7 +82,7 @@ type storageConfig struct {
 
 type DiskCachePartition struct {
 	ID           string `yaml:"id" json:"id" usage:"The ID of the partition."`
-	MaxSizeBytes int64  `yaml:"max_size" json:"max_size_bytes "usage:"Maximum size of the partition."`
+	MaxSizeBytes int64  `yaml:"max_size" json:"max_size_bytes" usage:"Maximum size of the partition."`
 }
 
 type DiskCachePartitionMapping struct {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -329,11 +329,6 @@ func defineFlagsForMembers(parentStructNames []string, T reflect.Value) {
 			if fqFieldName == "auth.oauth_providers" {
 				continue
 			}
-			// Not supported via flags.
-			if fqFieldName == "storage.disk.partitions" || fqFieldName == "storage.disk.partition_mappings" ||
-				fqFieldName == "cache.disk.partitions" || fqFieldName == "cache.disk.partition_mappings" {
-				continue
-			}
 			log.Warningf("Skipping flag: --%s, kind: %s", fqFieldName, f.Type().Kind())
 		}
 	}

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -196,7 +196,7 @@ func GetConfiguredEnvironmentOrDie(configurator *config.Configurator, healthChec
 		cache = c
 	} else if configurator.GetCacheDiskConfig() != nil {
 		diskConfig := configurator.GetCacheDiskConfig()
-		c, err := disk_cache.NewDiskCache(diskConfig.RootDirectory, configurator.GetCacheMaxSizeBytes())
+		c, err := disk_cache.NewDiskCache(realEnv, diskConfig, configurator.GetCacheMaxSizeBytes())
 		if err != nil {
 			log.Fatalf("Error configuring cache: %s", err)
 		}


### PR DESCRIPTION
The disk cache config has a list of partition configs consisting
of an ID and a maximum size. The ID is used to determine where on disk
the cache partition is rooted & the max size is used to instantiate the
LRU.

The config also has a list of mappings which specify when a partition
should be used. Each mapping consists of a Group ID and an remote
instance name prefix. Partition will be used if a cache request is
received with matching group ID and a remote instance name that has a
matching prefix.

Finally, a `WithRemoteInstanceName` method is introduced to allow the
instance name to be passed to the cache implementation so it can make a
decision about which partition to use.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
