### PR TITLE
Disable code component for next release

### DIFF
--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -18,7 +18,8 @@ import SettingsComponent from "../settings/settings";
 import SidebarComponent from "../sidebar/sidebar";
 import TapComponent from "../tap/tap";
 import TrendsComponent from "../trends/trends";
-const CodeComponent = React.lazy(() => import("../code/code"));
+// TODO(siggisim): Re-enable once we have a better way to serve chunks during a rollout.
+// const CodeComponent = React.lazy(() => import("../code/code"));
 // TODO(siggisim): lazy load all components that make sense more gracefully.
 
 import ExecutorsComponent from "../executors/executors";
@@ -225,12 +226,12 @@ export default class EnterpriseRootComponent extends React.Component {
                 {workflows && <WorkflowsComponent path={this.state.path} user={this.state.user} />}
                 {code && (
                   <Suspense fallback={<div className="loading" />}>
-                    <CodeComponent
+                    {/* <CodeComponent
                       path={this.state.path}
                       user={this.state.user}
                       search={this.state.search}
                       hash={this.state.hash}
-                    />
+                    /> */}
                   </Suspense>
                 )}
                 {setup && (


### PR DESCRIPTION
Introducing the lazy-loaded code component cases esbuild to look for shared code between the two distinct js bundles.

These shared modules are loaded as chunks that look like:
`/app/app_bundle/chunk-abc123.js`

Where the `abc123` bit is a hash of the contents of the chunk.

This is problematic during a rollout because if hits multiple servers (behind a loadbalancer) with different chunks - the app will fail to load.

This PR comments out the code component, removing the generation of these chunks. We'll need to come up with a solution for serving these chunks during a rollout (likely by deploying the static js to a CDN) before re-enabling this component.

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
