### PR TITLE
Add support for using MinIO as a replacement for s3

### DIFF
--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -52,9 +52,16 @@ func NewS3Cache(awsConfig *config.S3CacheConfig) (*S3Cache, error) {
 		creds = credentials.NewSharedCredentials("", awsConfig.CredentialsProfile)
 	}
 
+	if awsConfig.StaticCredentialsID != "" && awsConfig.StaticCredentialsSecret != "" {
+		creds = credentials.NewStaticCredentials(awsConfig.StaticCredentialsID, awsConfig.StaticCredentialsSecret, awsConfig.StaticCredentialsToken)
+	}
+
 	sess, err := session.NewSession(&aws.Config{
-		Region:      aws.String(awsConfig.Region),
-		Credentials: creds,
+		Region:           aws.String(awsConfig.Region),
+		Credentials:      creds,
+		Endpoint:         aws.String(awsConfig.Endpoint),
+		DisableSSL:       aws.Bool(awsConfig.DisableSSL),
+		S3ForcePathStyle: aws.Bool(awsConfig.S3ForcePathStyle),
 	})
 	if err != nil {
 		return nil, err

--- a/server/backends/blobstore/blobstore.go
+++ b/server/backends/blobstore/blobstore.go
@@ -322,9 +322,16 @@ func NewAwsS3BlobStore(awsConfig *config.AwsS3Config) (*AwsS3BlobStore, error) {
 		creds = credentials.NewSharedCredentials("", awsConfig.CredentialsProfile)
 	}
 
+	if awsConfig.StaticCredentialsID != "" && awsConfig.StaticCredentialsSecret != "" {
+		creds = credentials.NewStaticCredentials(awsConfig.StaticCredentialsID, awsConfig.StaticCredentialsSecret, awsConfig.StaticCredentialsToken)
+	}
+
 	sess, err := session.NewSession(&aws.Config{
-		Region:      aws.String(awsConfig.Region),
-		Credentials: creds,
+		Region:           aws.String(awsConfig.Region),
+		Credentials:      creds,
+		Endpoint:         aws.String(awsConfig.Endpoint),
+		DisableSSL:       aws.Bool(awsConfig.DisableSSL),
+		S3ForcePathStyle: aws.Bool(awsConfig.S3ForcePathStyle),
 	})
 
 	if err != nil {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -109,6 +109,14 @@ type AwsS3Config struct {
 	Region             string `yaml:"region" usage:"The AWS region."`
 	Bucket             string `yaml:"bucket" usage:"The AWS S3 bucket to store files in."`
 	CredentialsProfile string `yaml:"credentials_profile" usage:"A custom credentials profile to use."`
+
+	// Useful for configuring MinIO: https://docs.min.io/docs/how-to-use-aws-sdk-for-go-with-minio-server.html
+	Endpoint                string `yaml:"endpoint" usage:"The AWS endpoint to use, useful for configuring the use of MinIO."`
+	StaticCredentialsID     string `yaml:"static_credentials_id" usage:"Static credentials ID to use, useful for configuring the use of MinIO."`
+	StaticCredentialsSecret string `yaml:"static_credentials_secret" usage:"Static credentials secret to use, useful for configuring the use of MinIO."`
+	StaticCredentialsToken  string `yaml:"static_credentials_token" usage:"Static credentials token to use, useful for configuring the use of MinIO."`
+	DisableSSL              bool   `yaml:"disable_ssl" usage:"Disables the use of SSL, useful for configuring the use of MinIO."`
+	S3ForcePathStyle        bool   `yaml:"s3_force_path_style" usage:"Force path style urls for objects, useful for configuring the use of MinIO."`
 }
 
 type integrationsConfig struct {
@@ -131,6 +139,14 @@ type S3CacheConfig struct {
 	Bucket             string `yaml:"bucket" usage:"The AWS S3 bucket to store files in."`
 	CredentialsProfile string `yaml:"credentials_profile" usage:"A custom credentials profile to use."`
 	TTLDays            int64  `yaml:"ttl_days" usage:"The period after which cache files should be TTLd. Disabled if 0."`
+
+	// Useful for configuring MinIO: https://docs.min.io/docs/how-to-use-aws-sdk-for-go-with-minio-server.html
+	Endpoint                string `yaml:"endpoint" usage:"The AWS endpoint to use, useful for configuring the use of MinIO."`
+	StaticCredentialsID     string `yaml:"static_credentials_id" usage:"Static credentials ID to use, useful for configuring the use of MinIO."`
+	StaticCredentialsSecret string `yaml:"static_credentials_secret" usage:"Static credentials secret to use, useful for configuring the use of MinIO."`
+	StaticCredentialsToken  string `yaml:"static_credentials_token" usage:"Static credentials token to use, useful for configuring the use of MinIO."`
+	DisableSSL              bool   `yaml:"disable_ssl" usage:"Disables the use of SSL, useful for configuring the use of MinIO."`
+	S3ForcePathStyle        bool   `yaml:"s3_force_path_style" usage:"Force path style urls for objects, useful for configuring the use of MinIO."`
 }
 
 type DistributedCacheConfig struct {


### PR DESCRIPTION
This is useful for customers that are deploying offline clusters.

Based on these docs: https://docs.min.io/docs/how-to-use-aws-sdk-for-go-with-minio-server.html

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
