### PR TITLE
Add WithIsolation method to the Cache interface.

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -245,6 +245,23 @@ func (c *Cache) WithPrefix(prefix string) interfaces.Cache {
 	return &clone
 }
 
+func (c *Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+	newLocal, err := c.local.WithIsolation(ctx, cacheType, remoteInstanceName)
+	if err != nil {
+		return nil, err
+	}
+
+	newPrefix := filepath.Join(remoteInstanceName, cacheType.Prefix())
+	if len(newPrefix) > 0 && newPrefix[len(newPrefix)-1] != '/' {
+		newPrefix += "/"
+	}
+	clone := *c
+	// TODO(vadim): include cache type & remote instance name in distributed disk RPCs.
+	clone.prefix = newPrefix
+	clone.local = newLocal
+	return &clone, nil
+}
+
 // peers returns the ordered slice of replicationFactor peers responsible for
 // this key. They should be tried in order.
 func (c *Cache) peers(d *repb.Digest) *peerset.PeerSet {

--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -125,6 +125,21 @@ func (g *GCSCache) WithPrefix(prefix string) interfaces.Cache {
 	}
 }
 
+func (g *GCSCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+	newPrefix := filepath.Join(remoteInstanceName, cacheType.Prefix())
+	if len(newPrefix) > 0 && newPrefix[len(newPrefix)-1] != '/' {
+		newPrefix += "/"
+	}
+
+	return &GCSCache{
+		gcsClient:    g.gcsClient,
+		bucketHandle: g.bucketHandle,
+		projectID:    g.projectID,
+		ttlInDays:    g.ttlInDays,
+		prefix:       newPrefix,
+	}, nil
+}
+
 func (g *GCSCache) Get(ctx context.Context, d *repb.Digest) ([]byte, error) {
 	k, err := g.key(ctx, d)
 	if err != nil {

--- a/enterprise/server/backends/memcache/memcache.go
+++ b/enterprise/server/backends/memcache/memcache.go
@@ -87,6 +87,17 @@ func (c *Cache) WithPrefix(prefix string) interfaces.Cache {
 	}
 }
 
+func (c *Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+	newPrefix := filepath.Join(remoteInstanceName, cacheType.Prefix())
+	if len(newPrefix) > 0 && newPrefix[len(newPrefix)-1] != '/' {
+		newPrefix += "/"
+	}
+	return &Cache{
+		prefix: newPrefix,
+		mc:     c.mc,
+	}, nil
+}
+
 func (c *Cache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
 	key, err := c.key(ctx, d)
 	if err != nil {

--- a/enterprise/server/backends/redis_cache/redis_cache.go
+++ b/enterprise/server/backends/redis_cache/redis_cache.go
@@ -120,6 +120,18 @@ func (c *Cache) WithPrefix(prefix string) interfaces.Cache {
 	}
 }
 
+func (c *Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+	newPrefix := filepath.Join(remoteInstanceName, cacheType.Prefix())
+	if len(newPrefix) > 0 && newPrefix[len(newPrefix)-1] != '/' {
+		newPrefix += "/"
+	}
+	return &Cache{
+		prefix:          newPrefix,
+		rdb:             c.rdb,
+		cutoffSizeBytes: c.cutoffSizeBytes,
+	}, nil
+}
+
 func (c *Cache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
 	key, err := c.key(ctx, d)
 	if err != nil {

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -200,6 +200,21 @@ func (s3c *S3Cache) WithPrefix(prefix string) interfaces.Cache {
 	}
 }
 
+func (s3c *S3Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+	newPrefix := filepath.Join(remoteInstanceName, cacheType.Prefix())
+	if len(newPrefix) > 0 && newPrefix[len(newPrefix)-1] != '/' {
+		newPrefix += "/"
+	}
+	return &S3Cache{
+		s3:         s3c.s3,
+		bucket:     s3c.bucket,
+		downloader: s3c.downloader,
+		uploader:   s3c.uploader,
+		ttlInDays:  s3c.ttlInDays,
+		prefix:     newPrefix,
+	}, nil
+}
+
 func (s3c *S3Cache) Get(ctx context.Context, d *repb.Digest) ([]byte, error) {
 	k, err := s3c.key(ctx, d)
 	if err != nil {

--- a/enterprise/server/composable_cache/BUILD
+++ b/enterprise/server/composable_cache/BUILD
@@ -8,5 +8,6 @@ go_library(
     deps = [
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
+        "//server/util/status",
     ],
 )

--- a/enterprise/server/composable_cache/composable_cache.go
+++ b/enterprise/server/composable_cache/composable_cache.go
@@ -51,7 +51,7 @@ func (c *composableCache) WithIsolation(ctx context.Context, cacheType interface
 	return &composableCache{
 		inner: newInner,
 		outer: newOuter,
-		mode: c.mode,
+		mode:  c.mode,
 	}, nil
 }
 

--- a/enterprise/server/composable_cache/composable_cache.go
+++ b/enterprise/server/composable_cache/composable_cache.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
@@ -36,6 +37,22 @@ func (c *composableCache) WithPrefix(prefix string) interfaces.Cache {
 		outer: c.outer.WithPrefix(prefix),
 		mode:  c.mode,
 	}
+}
+
+func (c *composableCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+	newInner, err := c.inner.WithIsolation(ctx, cacheType, remoteInstanceName)
+	if err != nil {
+		return nil, status.WrapError(err, "WithIsolation failed on inner cache")
+	}
+	newOuter, err := c.outer.WithIsolation(ctx, cacheType, remoteInstanceName)
+	if err != nil {
+		return nil, status.WrapError(err, "WithIsolation failed on outer cache")
+	}
+	return &composableCache{
+		inner: newInner,
+		outer: newOuter,
+		mode: c.mode,
+	}, nil
 }
 
 func (c *composableCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -219,7 +219,10 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 // N.B. This should only be used if the calling code has already ensured the
 // action is valid and may be returned.
 func (s *ExecutionServer) getUnvalidatedActionResult(ctx context.Context, d *digest.InstanceNameDigest) (*repb.ActionResult, error) {
-	cache := namespace.ActionCache(s.cache, d.GetInstanceName())
+	cache, err := namespace.ActionCache(ctx, s.cache, d.GetInstanceName())
+	if err != nil {
+		return nil, err
+	}
 	data, err := cache.Get(ctx, d.Digest)
 	if err != nil {
 		if status.IsNotFoundError(err) {
@@ -239,7 +242,10 @@ func (s *ExecutionServer) getActionResultFromCache(ctx context.Context, d *diges
 	if err != nil {
 		return nil, err
 	}
-	casCache := namespace.CASCache(s.cache, d.GetInstanceName())
+	casCache, err := namespace.CASCache(ctx, s.cache, d.GetInstanceName())
+	if err != nil {
+		return nil, err
+	}
 	if err := action_cache_server.ValidateActionResult(ctx, casCache, actionResult); err != nil {
 		return nil, err
 	}

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -529,13 +529,14 @@ func TestNonDefaultPartition(t *testing.T) {
 		require.NoError(t, err)
 		d, buf := testdigest.NewRandomDigestBuf(t, 1000)
 
-		c, err := dc.WithRemoteInstanceName(ctx, "nonmatchingprefix/")
+		instanceName := "nonmatchingprefix"
+		c, err := dc.WithIsolation(ctx, interfaces.CASCacheType, instanceName)
 		require.NoError(t, err)
 		err = c.Set(ctx, d, buf)
 		require.NoError(t, err)
 
 		userRoot := filepath.Join(rootDir, testGroup2)
-		dPath := filepath.Join(userRoot, d.GetHash())
+		dPath := filepath.Join(userRoot, instanceName, d.GetHash())
 		require.FileExists(t, dPath)
 	}
 
@@ -548,13 +549,14 @@ func TestNonDefaultPartition(t *testing.T) {
 		require.NoError(t, err)
 		d, buf := testdigest.NewRandomDigestBuf(t, 1000)
 
-		c, err := dc.WithRemoteInstanceName(ctx, otherPartitionPrefix+"hello")
+		instanceName := otherPartitionPrefix + "hello"
+		c, err := dc.WithIsolation(ctx, interfaces.CASCacheType, instanceName)
 		require.NoError(t, err)
 		err = c.Set(ctx, d, buf)
 		require.NoError(t, err)
 
 		userRoot := filepath.Join(rootDir, otherPartitionID, testGroup2)
-		dPath := filepath.Join(userRoot, d.GetHash())
+		dPath := filepath.Join(userRoot, instanceName, d.GetHash())
 		require.FileExists(t, dPath)
 	}
 }

--- a/server/backends/memory_cache/memory_cache.go
+++ b/server/backends/memory_cache/memory_cache.go
@@ -69,6 +69,19 @@ func (m *MemoryCache) WithPrefix(prefix string) interfaces.Cache {
 	}
 }
 
+func (m *MemoryCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+	newPrefix := filepath.Join(remoteInstanceName, cacheType.Prefix())
+	if len(newPrefix) > 0 && newPrefix[len(newPrefix)-1] != '/' {
+		newPrefix += "/"
+	}
+
+	return &MemoryCache{
+		l:      m.l,
+		lock:   m.lock,
+		prefix: newPrefix,
+	}, nil
+}
+
 func (m *MemoryCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
 	k, err := m.key(ctx, d)
 	if err != nil {

--- a/server/interfaces/BUILD
+++ b/server/interfaces/BUILD
@@ -18,5 +18,6 @@ go_library(
         "//proto:workflow_go_proto",
         "//proto/api/v1:api_v1_go_proto",
         "//server/tables",
+        "//server/util/alert",
     ],
 )

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -126,6 +126,23 @@ type Blobstore interface {
 	DeleteBlob(ctx context.Context, blobName string) error
 }
 
+type CacheType int
+
+const (
+	ActionCacheType CacheType = iota
+	CASCacheType
+)
+
+func (t CacheType) Prefix() string {
+	switch t {
+	case ActionCacheType:
+		return "ac"
+	case CASCacheType:
+		return ""
+	}
+	return "unknown"
+}
+
 // Similar to a blobstore, a cache allows for reading and writing data, but
 // additionally it is responsible for deleting data that is past TTL to keep to
 // a manageable size.
@@ -137,6 +154,9 @@ type Cache interface {
 	// currently set prefix -- so this is a relative operation, not an
 	// absolute one.
 	WithPrefix(prefix string) Cache
+	// WithIsolation returns a cache accessor that guarantees that data for a given cacheType and
+	// remoteInstanceCombination is isolated from any other cacheType and remoteInstanceName combination.
+	WithIsolation(ctx context.Context, cacheType CacheType, remoteInstanceName string) (Cache, error)
 
 	// Normal cache-like operations.
 	Contains(ctx context.Context, d *repb.Digest) (bool, error)

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 
 	aclpb "github.com/buildbuddy-io/buildbuddy/proto/acl"
 	apipb "github.com/buildbuddy-io/buildbuddy/proto/api/v1"
@@ -139,8 +140,10 @@ func (t CacheType) Prefix() string {
 		return "ac"
 	case CASCacheType:
 		return ""
+	default:
+		alert.UnexpectedEvent("unknown_cache_type", "type: %v", t)
+		return "unknown"
 	}
-	return "unknown"
 }
 
 // Similar to a blobstore, a cache allows for reading and writing data, but

--- a/server/remote_asset/fetch_server/BUILD
+++ b/server/remote_asset/fetch_server/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//server/environment",
         "//server/interfaces",
         "//server/remote_cache/digest",
+        "//server/remote_cache/namespace",
         "//server/util/log",
         "//server/util/prefix",
         "//server/util/status",

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -221,12 +221,18 @@ func readProtoFromCache(ctx context.Context, cache interfaces.Cache, d *digest.I
 }
 
 func ReadProtoFromCAS(ctx context.Context, cache interfaces.Cache, d *digest.InstanceNameDigest, out proto.Message) error {
-	cas := namespace.CASCache(cache, d.GetInstanceName())
+	cas, err := namespace.CASCache(ctx, cache, d.GetInstanceName())
+	if err != nil {
+		return err
+	}
 	return readProtoFromCache(ctx, cas, d, out)
 }
 
 func ReadProtoFromAC(ctx context.Context, cache interfaces.Cache, d *digest.InstanceNameDigest, out proto.Message) error {
-	ac := namespace.ActionCache(cache, d.GetInstanceName())
+	ac, err := namespace.ActionCache(ctx, cache, d.GetInstanceName())
+	if err != nil {
+		return err
+	}
 	return readProtoFromCache(ctx, ac, d, out)
 }
 
@@ -251,7 +257,10 @@ func UploadBytesToCache(ctx context.Context, cache interfaces.Cache, in io.ReadS
 }
 
 func UploadBytesToCAS(ctx context.Context, cache interfaces.Cache, instanceName string, in io.ReadSeeker) (*repb.Digest, error) {
-	cas := namespace.CASCache(cache, instanceName)
+	cas, err := namespace.CASCache(ctx, cache, instanceName)
+	if err != nil {
+		return nil, err
+	}
 	return UploadBytesToCache(ctx, cas, in)
 }
 
@@ -266,12 +275,18 @@ func uploadProtoToCache(ctx context.Context, cache interfaces.Cache, instanceNam
 
 func UploadBlobToCAS(ctx context.Context, cache interfaces.Cache, instanceName string, blob []byte) (*repb.Digest, error) {
 	reader := bytes.NewReader(blob)
-	cas := namespace.CASCache(cache, instanceName)
+	cas, err := namespace.CASCache(ctx, cache, instanceName)
+	if err != nil {
+		return nil, err
+	}
 	return UploadBytesToCache(ctx, cas, reader)
 }
 
 func UploadProtoToCAS(ctx context.Context, cache interfaces.Cache, instanceName string, in proto.Message) (*repb.Digest, error) {
-	cas := namespace.CASCache(cache, instanceName)
+	cas, err := namespace.CASCache(ctx, cache, instanceName)
+	if err != nil {
+		return nil, err
+	}
 	return uploadProtoToCache(ctx, cas, instanceName, in)
 }
 
@@ -503,6 +518,9 @@ func uploadDir(ul *BatchCASUploader, dirPath string, visited []*repb.Directory) 
 }
 
 func UploadProtoToAC(ctx context.Context, cache interfaces.Cache, instanceName string, in proto.Message) (*repb.Digest, error) {
-	ac := namespace.ActionCache(cache, instanceName)
+	ac, err := namespace.ActionCache(ctx, cache, instanceName)
+	if err != nil {
+		return nil, err
+	}
 	return uploadProtoToCache(ctx, ac, instanceName, in)
 }

--- a/server/remote_cache/namespace/namespace.go
+++ b/server/remote_cache/namespace/namespace.go
@@ -1,25 +1,15 @@
 package namespace
 
 import (
+	"context"
+
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 )
 
-const (
-	acCachePrefix = "ac"
-)
-
-func CASCache(cache interfaces.Cache, instanceName string) interfaces.Cache {
-	c := cache
-	if instanceName != "" {
-		c = c.WithPrefix(instanceName)
-	}
-	return c
+func CASCache(ctx context.Context, cache interfaces.Cache, instanceName string) (interfaces.Cache, error) {
+	return cache.WithIsolation(ctx, interfaces.CASCacheType, instanceName)
 }
 
-func ActionCache(cache interfaces.Cache, instanceName string) interfaces.Cache {
-	c := cache
-	if instanceName != "" {
-		c = c.WithPrefix(instanceName)
-	}
-	return c.WithPrefix(acCachePrefix)
+func ActionCache(ctx context.Context, cache interfaces.Cache, instanceName string) (interfaces.Cache, error) {
+	return cache.WithIsolation(ctx, interfaces.ActionCacheType, instanceName)
 }


### PR DESCRIPTION
WithIsolation is an instruction to the cache implementation to return an
accessor for the cache that isolates the data for the given cache type +
remote instance name combination from any other combination.

This method will supersede WithPrefix, which can be removed once the
distributed disk implementation has been migrated to the new method.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
