### PR TITLE
Support a light terminal theme

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -22,6 +22,7 @@ ts_library(
         "//app/favicon",
         "//app/flame_chart",
         "//app/format",
+        "//app/preferences",
         "//app/router",
         "//app/service",
         "//app/target",

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -409,7 +409,12 @@
 
 .invocation-query-graph-card {
   padding: 0;
-  background: #f9f9f9;
+  background: #fafafa;
+  box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.2), 0px 1px 6px rgba(0, 0, 0, 0.1);
+}
+
+.invocation-query-graph-card:hover {
+  box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2), 0px 1px 10px rgba(0, 0, 0, 0.1);
 }
 
 svg.invocation-query-graph {

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -25,9 +25,10 @@ import RawLogsCardComponent from "./invocation_raw_logs_card";
 import InvocationTabsComponent, { getActiveTab } from "./invocation_tabs";
 import TimingCardComponent from "./invocation_timing_card";
 import ExecutionCardComponent from "./invocation_execution_card";
-import ActionCardComponent from "./invocation_action_card";
+import InvocationActionCardComponent from "./invocation_action_card";
 import TargetsComponent from "./invocation_targets";
 import { BuildBuddyError } from "../util/errors";
+import UserPreferences from "../preferences/preferences";
 
 interface State {
   loading: boolean;
@@ -42,7 +43,7 @@ interface Props {
   invocationId: string;
   hash: string;
   search: URLSearchParams;
-  denseMode: boolean;
+  preferences: UserPreferences;
 }
 
 const largePageSize = 100;
@@ -160,6 +161,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
           actionEvents={actionEvents}
           user={this.props.user}
           targetLabel={targetLabel}
+          dark={!this.props.preferences.lightTerminalEnabled}
         />
       );
     }
@@ -167,14 +169,14 @@ export default class InvocationComponent extends React.Component<Props, State> {
     const activeTab = getActiveTab({
       hash: this.props.hash,
       role: this.state.model.getRole(),
-      denseMode: this.props.denseMode,
+      denseMode: this.props.preferences.denseModeEnabled,
     });
     const isBazelInvocation = this.state.model.isBazelInvocation();
 
     return (
       <div className="invocation">
         <div className={`shelf nopadding-dense ${this.state.model.getStatusClass()}`}>
-          {this.props.denseMode ? (
+          {this.props.preferences.denseModeEnabled ? (
             <DenseInvocationOverviewComponent
               user={this.props.user}
               invocationId={this.props.invocationId}
@@ -191,7 +193,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
         <div className="container nopadding-dense">
           <InvocationTabsComponent
             hash={this.props.hash}
-            denseMode={this.props.denseMode}
+            denseMode={this.props.preferences.denseModeEnabled}
             role={this.state.model.getRole()}
           />
 
@@ -223,7 +225,11 @@ export default class InvocationComponent extends React.Component<Props, State> {
           )}
 
           {(activeTab === "all" || activeTab == "log") && (
-            <BuildLogsCardComponent model={this.state.model} expanded={activeTab == "log"} />
+            <BuildLogsCardComponent
+              dark={!this.props.preferences.lightTerminalEnabled}
+              model={this.state.model}
+              expanded={activeTab == "log"}
+            />
           )}
 
           {isBazelInvocation && (activeTab === "all" || activeTab == "targets") && (
@@ -257,7 +263,9 @@ export default class InvocationComponent extends React.Component<Props, State> {
             <ExecutionCardComponent model={this.state.model} inProgress={this.state.inProgress} />
           )}
 
-          {activeTab == "action" && <ActionCardComponent model={this.state.model} search={this.props.search} />}
+          {activeTab == "action" && (
+            <InvocationActionCardComponent model={this.state.model} search={this.props.search} />
+          )}
 
           {activeTab == "fetches" && <FetchCardComponent model={this.state.model} inProgress={this.state.inProgress} />}
 

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -17,7 +17,7 @@ interface State {
   error?: string;
 }
 
-export default class ActionCardComponent extends React.Component<Props, State> {
+export default class InvocationActionCardComponent extends React.Component<Props, State> {
   state: State = {};
   componentDidMount() {
     this.fetchAction();

--- a/app/invocation/invocation_build_logs_card.tsx
+++ b/app/invocation/invocation_build_logs_card.tsx
@@ -5,6 +5,7 @@ import { TerminalComponent } from "../terminal/terminal";
 interface Props {
   model: InvocationModel;
   expanded: boolean;
+  dark: boolean;
 }
 
 export default class BuildLogsCardComponent extends React.Component {
@@ -12,8 +13,8 @@ export default class BuildLogsCardComponent extends React.Component {
 
   render() {
     return (
-      <div className={`card dark ${this.props.expanded ? "expanded" : ""}`}>
-        <img className="icon" src="/image/log-circle-light.svg" />
+      <div className={`card ${this.props.dark ? "dark" : "light-terminal"} ${this.props.expanded ? "expanded" : ""}`}>
+        <img className="icon" src={this.props.dark ? "/image/log-circle-light.svg" : "/image/log-circle.svg"} />
         <div className="content">
           <div className="title">Build logs </div>
           <div className="details">

--- a/app/menu/BUILD
+++ b/app/menu/BUILD
@@ -8,6 +8,7 @@ ts_library(
     deps = [
         "//app/auth",
         "//app/capabilities",
+        "//app/preferences",
         "//app/router",
         "//app/service",
         "//proto:invocation_ts_proto",

--- a/app/menu/menu.tsx
+++ b/app/menu/menu.tsx
@@ -2,11 +2,11 @@ import React from "react";
 import authService, { User } from "../auth/auth_service";
 import capabilities from "../capabilities/capabilities";
 import router, { Path } from "../router/router";
+import UserPreferences from "../preferences/preferences";
 
 interface Props {
   children?: any;
-  denseModeEnabled: boolean;
-  handleDenseModeToggled: VoidFunction;
+  preferences: UserPreferences;
   user: User;
   showHamburger: boolean;
 }
@@ -34,7 +34,7 @@ export default class MenuComponent extends React.Component {
   }
 
   handleToggleDenseModeClicked() {
-    this.props.handleDenseModeToggled();
+    this.props.preferences.toggleDenseMode();
     this.dismissMenu();
   }
 
@@ -114,7 +114,7 @@ export default class MenuComponent extends React.Component {
                     </a>
                   </li>
                   <li onClick={this.handleToggleDenseModeClicked.bind(this)}>
-                    {this.props.denseModeEnabled ? "Disable" : "Enable"} dense mode
+                    {this.props.preferences.denseModeEnabled ? "Disable" : "Enable"} dense mode
                   </li>
                   <li onClick={this.handleSetupClicked.bind(this)}>Setup instructions</li>
                   {!capabilities.enterprise && (

--- a/app/preferences/BUILD
+++ b/app/preferences/BUILD
@@ -1,0 +1,10 @@
+load("@npm//@bazel/typescript:index.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "preferences",
+    srcs = glob(["*.ts"]),
+    deps = [
+    ],
+)

--- a/app/preferences/preferences.ts
+++ b/app/preferences/preferences.ts
@@ -8,16 +8,16 @@ const terminalThemeLightValue = "LIGHT";
 declare var window: any;
 
 export default class UserPreferences {
-
   handlePreferencesChanged: () => void;
 
   constructor(handlePreferencesChanged: () => void) {
     this.handlePreferencesChanged = handlePreferencesChanged;
   }
 
-  denseModeEnabled = viewModeKey in window.localStorage
-    ? window.localStorage.getItem(viewModeKey) == denseModeValue
-    : window.buildbuddyConfig && window.buildbuddyConfig.default_to_dense_mode;
+  denseModeEnabled =
+    viewModeKey in window.localStorage
+      ? window.localStorage.getItem(viewModeKey) == denseModeValue
+      : window.buildbuddyConfig && window.buildbuddyConfig.default_to_dense_mode;
   lightTerminalEnabled = window.localStorage.getItem(terminalThemeKey) == terminalThemeLightValue || false;
 
   toggleDenseMode() {

--- a/app/preferences/preferences.ts
+++ b/app/preferences/preferences.ts
@@ -1,0 +1,34 @@
+const viewModeKey = "VIEW_MODE";
+const denseModeValue = "DENSE";
+const comfyModeValue = "COMFY";
+
+const terminalThemeKey = "TERMINAL_THEME";
+const terminalThemeLightValue = "LIGHT";
+
+declare var window: any;
+
+export default class UserPreferences {
+
+  handlePreferencesChanged: () => void;
+
+  constructor(handlePreferencesChanged: () => void) {
+    this.handlePreferencesChanged = handlePreferencesChanged;
+  }
+
+  denseModeEnabled = viewModeKey in window.localStorage
+    ? window.localStorage.getItem(viewModeKey) == denseModeValue
+    : window.buildbuddyConfig && window.buildbuddyConfig.default_to_dense_mode;
+  lightTerminalEnabled = window.localStorage.getItem(terminalThemeKey) == terminalThemeLightValue || false;
+
+  toggleDenseMode() {
+    this.denseModeEnabled = !this.denseModeEnabled;
+    window.localStorage.setItem(viewModeKey, this.denseModeEnabled ? denseModeValue : comfyModeValue);
+    this.handlePreferencesChanged();
+  }
+
+  toggleLightTerminal() {
+    this.lightTerminalEnabled = !this.lightTerminalEnabled;
+    window.localStorage.setItem(terminalThemeKey, this.lightTerminalEnabled ? terminalThemeLightValue : "");
+    this.handlePreferencesChanged();
+  }
+}

--- a/app/root/BUILD.bazel
+++ b/app/root/BUILD.bazel
@@ -17,6 +17,7 @@ ts_library(
         "//app/footer",
         "//app/invocation",
         "//app/menu",
+        "//app/preferences",
         "//app/router",
         "//app/service",
         "//proto:user_ts_proto",

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -444,9 +444,17 @@ button {
 }
 
 .card.dark {
-  /* background-color: #263238; */
   background-color: #222;
   color: #fff;
+}
+
+.card.light-terminal {
+  background-color: #fafafa;
+  box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.2), 0px 1px 6px rgba(0, 0, 0, 0.1);
+}
+
+.card.light-terminal:hover {
+  box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2), 0px 1px 10px rgba(0, 0, 0, 0.1);
 }
 
 .grid-block:hover .card-hover {
@@ -898,6 +906,18 @@ code .comment {
   font-size: 14px;
   font-family: "Source Code Pro", monospace;
   color: #fff;
+}
+
+.light-terminal .terminal-line {
+  color: #222;
+}
+
+.light-terminal .terminal-line:hover {
+  background-color: #fafafa;
+}
+
+.light-terminal .react-lazylog {
+  background-color: #fafafa;
 }
 
 .inline-code {

--- a/app/root/root.tsx
+++ b/app/root/root.tsx
@@ -10,10 +10,7 @@ import { User } from "../auth/auth_service";
 import faviconService from "../favicon/favicon";
 import CompareInvocationsComponent from "../compare/compare_invocations";
 import AlertComponent from "../alert/alert";
-
-const viewModeKey = "VIEW_MODE";
-const denseModeValue = "DENSE";
-const comfyModeValue = "COMFY";
+import UserPreferences from "../preferences/preferences";
 
 declare var window: any;
 
@@ -22,7 +19,7 @@ interface State {
   hash: string;
   path: string;
   search: URLSearchParams;
-  denseMode: boolean;
+  preferences: UserPreferences;
 }
 
 export default class RootComponent extends React.Component {
@@ -31,10 +28,7 @@ export default class RootComponent extends React.Component {
     hash: window.location.hash,
     path: window.location.pathname,
     search: new URLSearchParams(window.location.search),
-    denseMode:
-      viewModeKey in window.localStorage
-        ? window.localStorage.getItem(viewModeKey) == denseModeValue
-        : window.buildbuddyConfig && window.buildbuddyConfig.default_to_dense_mode,
+    preferences: new UserPreferences(this.handlePreferencesChanged.bind(this)),
   };
 
   componentWillMount() {
@@ -59,10 +53,8 @@ export default class RootComponent extends React.Component {
     capabilities.didNavigateToPath();
   }
 
-  handleToggleDenseClicked() {
-    let newDenseMode = !this.state.denseMode;
-    this.setState({ ...this.state, denseMode: newDenseMode });
-    window.localStorage.setItem(viewModeKey, newDenseMode ? denseModeValue : comfyModeValue);
+  handlePreferencesChanged() {
+    this.setState({ ...this.state, preferences: this.state.preferences });
   }
 
   render() {
@@ -70,13 +62,8 @@ export default class RootComponent extends React.Component {
     let compareInvocationIds = router.getInvocationIdsForCompare(this.state.path);
     let showSetup = !invocationId && !compareInvocationIds;
     return (
-      <div className={this.state.denseMode ? "dense root" : "root"}>
-        <MenuComponent
-          user={this.state.user}
-          showHamburger={true}
-          denseModeEnabled={this.state.denseMode}
-          handleDenseModeToggled={this.handleToggleDenseClicked.bind(this)}
-        />
+      <div className={this.state.preferences.denseModeEnabled ? "dense root" : "root"}>
+        <MenuComponent user={this.state.user} showHamburger={true} preferences={this.state.preferences} />
         <div className="root-main">
           <div className="content">
             {invocationId && (
@@ -85,7 +72,7 @@ export default class RootComponent extends React.Component {
                 key={invocationId}
                 hash={this.state.hash}
                 search={this.state.search}
-                denseMode={this.state.denseMode}
+                preferences={this.state.preferences}
                 user={null}
               />
             )}

--- a/app/target/action_card.tsx
+++ b/app/target/action_card.tsx
@@ -10,6 +10,7 @@ import rpcService from "../service/rpc_service";
 interface Props {
   action: invocation.InvocationEvent;
   invocationId: string;
+  dark: boolean;
 }
 
 interface State {
@@ -113,10 +114,10 @@ export default class ActionCardComponent extends React.Component {
       <div>
         {this.props.action?.buildEvent?.action?.stderr?.uri && (
           <div
-            className={`card ${this.state.cacheEnabled && "dark"} ${
+            className={`card ${this.state.cacheEnabled && (this.props.dark ? "dark" : "light-terminal")} ${
               this.props.action.buildEvent.action.success ? "card-success" : "card-failure"
             }`}>
-            <img className="icon" src="/image/log-circle-light.svg" />
+            <img className="icon" src={this.props.dark ? "/image/log-circle-light.svg" : "/image/log-circle.svg"} />
             <div className="content">
               <div className="title">Error Log</div>
               <div className="test-subtitle">{this.getStatusTitle(this.props.action.buildEvent.action.success)}</div>
@@ -152,8 +153,8 @@ export default class ActionCardComponent extends React.Component {
         )}
 
         {this.props.action?.buildEvent?.action?.stdout?.uri && (
-          <div className={`card ${this.state.cacheEnabled && "dark"}`}>
-            <img className="icon" src="/image/log-circle-light.svg" />
+          <div className={`card ${this.state.cacheEnabled && (this.props.dark ? "dark" : "light-terminal")}`}>
+            <img className="icon" src={this.props.dark ? "/image/log-circle-light.svg" : "/image/log-circle.svg"} />
             <div className="content">
               <div className="title">Log</div>
               {!this.state.cacheEnabled && (

--- a/app/target/target.tsx
+++ b/app/target/target.tsx
@@ -22,6 +22,7 @@ interface Props {
   testResultEvents: invocation.InvocationEvent[];
   testSummaryEvent: invocation.InvocationEvent;
   actionEvents: invocation.InvocationEvent[];
+  dark: boolean;
 }
 
 export default class TargetComponent extends React.Component {
@@ -220,12 +221,20 @@ export default class TargetComponent extends React.Component {
             .filter((value, index) => `#${index + 1}` == (this.props.hash || "#1"))
             .map((result) => (
               <span>
-                <TargetTestDocumentCardComponent invocationId={this.props.invocationId} testResult={result} />
-                <TargetTestLogCardComponent invocationId={this.props.invocationId} testResult={result} />
+                <TargetTestDocumentCardComponent
+                  dark={this.props.dark}
+                  invocationId={this.props.invocationId}
+                  testResult={result}
+                />
+                <TargetTestLogCardComponent
+                  dark={this.props.dark}
+                  invocationId={this.props.invocationId}
+                  testResult={result}
+                />
               </span>
             ))}
           {actionEvents.map((action) => (
-            <ActionCardComponent invocationId={this.props.invocationId} action={action} />
+            <ActionCardComponent dark={this.props.dark} invocationId={this.props.invocationId} action={action} />
           ))}
           <TargetArtifactsCardComponent
             invocationId={this.props.invocationId}

--- a/app/target/target_log_card.tsx
+++ b/app/target/target_log_card.tsx
@@ -1,14 +1,12 @@
 import React from "react";
 
-import { invocation } from "../../proto/invocation_ts_proto";
-import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
 import { TerminalComponent } from "../terminal/terminal";
-import rpcService from "../service/rpc_service";
 
 interface Props {
   title: string;
   subtitle: string;
   contents: string;
+  dark: boolean;
 }
 
 export default class TargetLogCardComponent extends React.Component {
@@ -16,8 +14,8 @@ export default class TargetLogCardComponent extends React.Component {
 
   render() {
     return (
-      <div className={`card dark`}>
-        <img className="icon" src="/image/log-circle-light.svg" />
+      <div className={`card ${this.props.dark ? "dark" : "light-terminal"}`}>
+        <img className="icon" src={this.props.dark ? "/image/log-circle-light.svg" : "/image/log-circle.svg"} />
         <div className="content">
           <div className="title">{this.props.title}</div>
           <div className="test-subtitle">{this.props.subtitle}</div>

--- a/app/target/target_test_document_card.tsx
+++ b/app/target/target_test_document_card.tsx
@@ -8,6 +8,7 @@ import TargetLogCardComponent from "./target_log_card";
 interface Props {
   testResult: invocation.InvocationEvent;
   invocationId: string;
+  dark: boolean;
 }
 
 interface State {
@@ -137,6 +138,7 @@ export default class TargetTestDocumentCardComponent extends React.Component {
                       contents={child.innerHTML.replace("<![CDATA[", "").replace("--]]>", "")}
                       title={testSuite.getAttribute("name")}
                       subtitle={`${child.tagName}`}
+                      dark={this.props.dark}
                     />
                   ))}
               </div>

--- a/app/target/target_test_log_card.tsx
+++ b/app/target/target_test_log_card.tsx
@@ -10,6 +10,7 @@ import rpcService from "../service/rpc_service";
 interface Props {
   testResult: invocation.InvocationEvent;
   invocationId: string;
+  dark: boolean;
 }
 
 interface State {
@@ -92,12 +93,12 @@ export default class TargetTestLogCardComponent extends React.Component {
   render() {
     return (
       <div
-        className={`card ${this.state.cacheEnabled && "dark"} ${
+        className={`card ${this.state.cacheEnabled && (this.props.dark ? "dark" : "light-terminal")} ${
           this.props.testResult.buildEvent.testResult.status == build_event_stream.TestStatus.PASSED
             ? "card-success"
             : "card-failure"
         }`}>
-        <img className="icon" src="/image/log-circle-light.svg" />
+        <img className="icon" src={this.props.dark ? "/image/log-circle-light.svg" : "/image/log-circle.svg"} />
         <div className="content">
           <div className="title">Test log</div>
           <div className="test-subtitle">

--- a/enterprise/app/root/BUILD.bazel
+++ b/enterprise/app/root/BUILD.bazel
@@ -17,6 +17,7 @@ ts_library(
         "//app/footer",
         "//app/invocation",
         "//app/menu",
+        "//app/preferences",
         "//app/router",
         "//app/service",
         "//enterprise/app/code",

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -23,16 +23,14 @@ import TrendsComponent from "../trends/trends";
 // TODO(siggisim): lazy load all components that make sense more gracefully.
 
 import ExecutorsComponent from "../executors/executors";
-
-const denseModeKey = "VIEW_MODE";
-const denseModeValue = "DENSE";
+import UserPreferences from "../../../app/preferences/preferences";
 
 interface State {
   user: User;
   hash: string;
   path: string;
   search: URLSearchParams;
-  denseMode: boolean;
+  preferences: UserPreferences;
   loading: boolean;
 }
 
@@ -43,7 +41,7 @@ export default class EnterpriseRootComponent extends React.Component {
     hash: window.location.hash,
     path: window.location.pathname,
     search: new URLSearchParams(window.location.search),
-    denseMode: window.localStorage.getItem(denseModeKey) == denseModeValue || false,
+    preferences: new UserPreferences(this.handlePreferencesChanged.bind(this)),
   };
 
   componentWillMount() {
@@ -83,10 +81,8 @@ export default class EnterpriseRootComponent extends React.Component {
     capabilities.didNavigateToPath();
   }
 
-  handleToggleDenseClicked() {
-    let newDenseMode = !this.state.denseMode;
-    this.setState({ ...this.state, denseMode: newDenseMode });
-    window.localStorage.setItem(denseModeKey, newDenseMode ? denseModeValue : "");
+  handlePreferencesChanged() {
+    this.setState({ ...this.state, preferences: this.state.preferences });
   }
 
   handleOrganizationClicked() {
@@ -135,15 +131,14 @@ export default class EnterpriseRootComponent extends React.Component {
 
     return (
       <div
-        className={`root ${this.state.denseMode ? "dense" : ""} ${sidebar || code ? "left" : ""} ${
+        className={`root ${this.state.preferences.denseModeEnabled ? "dense" : ""} ${sidebar || code ? "left" : ""} ${
           login ? "dark" : ""
         }`}>
         {menu && (
           <MenuComponent
             user={this.state.user}
             showHamburger={!this.state.user && !!invocationId}
-            denseModeEnabled={this.state.denseMode}
-            handleDenseModeToggled={this.handleToggleDenseClicked.bind(this)}>
+            preferences={this.state.preferences}>
             <div onClick={this.handleOrganizationClicked.bind(this)}>{this.state.user?.selectedGroupName()}</div>
           </MenuComponent>
         )}
@@ -166,7 +161,7 @@ export default class EnterpriseRootComponent extends React.Component {
                       key={invocationId}
                       hash={this.state.hash}
                       search={this.state.search}
-                      denseMode={this.state.denseMode}
+                      preferences={this.state.preferences}
                     />
                   </Suspense>
                 )}
@@ -201,8 +196,7 @@ export default class EnterpriseRootComponent extends React.Component {
                   <Suspense fallback={<div className="loading" />}>
                     <SettingsComponent
                       user={this.state.user}
-                      denseModeEnabled={this.state.denseMode}
-                      handleDenseModeToggled={this.handleToggleDenseClicked.bind(this)}
+                      preferences={this.state.preferences}
                       path={this.state.path}
                     />
                   </Suspense>

--- a/enterprise/app/settings/BUILD
+++ b/enterprise/app/settings/BUILD
@@ -11,6 +11,7 @@ ts_library(
         "//app/auth",
         "//app/capabilities",
         "//app/components/button",
+        "//app/preferences",
         "//app/router",
         "//enterprise/app/api_keys",
         "//enterprise/app/org",

--- a/enterprise/app/settings/settings.css
+++ b/enterprise/app/settings/settings.css
@@ -32,6 +32,10 @@
   padding: 16px 32px;
 }
 
+.settings .settings-button {
+  margin-bottom: 32px;
+}
+
 .settings .settings-link-button {
   padding: 0;
 }

--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -5,11 +5,11 @@ import FilledButton from "../../../app/components/button/button";
 import ApiKeysComponent from "../api_keys/api_keys";
 import EditOrgComponent from "../org/edit_org";
 import router from "../../../app/router/router";
+import UserPreferences from "../../../app/preferences/preferences";
 
 export interface SettingsProps {
   user: User;
-  denseModeEnabled: boolean;
-  handleDenseModeToggled: VoidFunction;
+  preferences: UserPreferences;
   path: string;
 }
 
@@ -97,15 +97,18 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                   <div className="settings-option-description">
                     Dense mode packs more information density into the BuildBuddy UI.
                   </div>
-                  {this.props.denseModeEnabled ? (
-                    <FilledButton className="settings-button" onClick={this.props.handleDenseModeToggled.bind(this)}>
-                      Disable dense mode
-                    </FilledButton>
-                  ) : (
-                    <FilledButton className="settings-button" onClick={this.props.handleDenseModeToggled.bind(this)}>
-                      Enable dense mode
-                    </FilledButton>
-                  )}
+                  <FilledButton className="settings-button" onClick={() => this.props.preferences.toggleDenseMode()}>
+                    {this.props.preferences.denseModeEnabled ? "Disable" : "Enable"} dense mode
+                  </FilledButton>
+                  <div className="settings-option-title">Log viewer theme</div>
+                  <div className="settings-option-description">
+                    The log viewer theme allows you to switch between a light and dark log viewer.
+                  </div>
+                  <FilledButton
+                    className="settings-button"
+                    onClick={() => this.props.preferences.toggleLightTerminal()}>
+                    Switch to {this.props.preferences.lightTerminalEnabled ? "dark" : "light"} log viewer theme
+                  </FilledButton>
                 </>
               )}
               {capabilities.auth && this.props.user && (

--- a/static/image/log-circle.svg
+++ b/static/image/log-circle.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12Z" stroke="#104079" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M15 14H9" stroke="#104079" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M15 10H9" stroke="#104079" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12Z" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 14H9" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 10H9" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
Adds support for a light terminal theme that the user can switch to in `Personal Settings`.
<img width="1473" alt="Screen Shot 2021-07-15 at 2 36 05 PM" src="https://user-images.githubusercontent.com/1704556/125861314-c28499b9-acc1-4d2f-8f5d-671d69f6101a.png">

Does so by replacing the simple `denseMode` boolean with a simple `UserPreferences` object that manages dense mode and this new log viewer theme.

Also cleans up a few things I bumped into along the way:
- Updates invocation query style to match
- Renames ActionCardComponent => InvocationActionCardComponent (we have two components named ActionCardComponent right now).
- Cleans up some unused imports

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
