### PR TITLE
Fix filesystem permissions for local docker-based executor

### DIFF
--- a/enterprise/config/executor.local.yaml
+++ b/enterprise/config/executor.local.yaml
@@ -1,6 +1,7 @@
 executor:
   root_directory: "/tmp/remote_build"
   docker_socket: /var/run/docker.sock
+  docker_inherit_user_ids: true
   app_target: "grpc://localhost:1985"
   local_cache_directory: "/tmp/filecache"
   local_cache_size_bytes: 1000000000 # 1GB

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -229,6 +229,7 @@ type ExecutorConfig struct {
 	RunnerPool              RunnerPoolConfig `yaml:"runner_pool"`
 	DockerNetHost           bool             `yaml:"docker_net_host" usage:"Sets --net=host on the docker command. Intended for local development only."`
 	DockerSiblingContainers bool             `yaml:"docker_sibling_containers" usage:"If set, mount the configured Docker socket to containers spawned for each action, to enable Docker-out-of-Docker (DooD). Takes effect only if docker_socket is also set. Should not be set by executors that can run untrusted code."`
+	DockerInheritUserIDs    bool             `yaml:"docker_inherit_user_ids" usage:"If set, run docker containers using the same uid and gid as the user running the executor process."`
 	DefaultXCodeVersion     string           `yaml:"default_xcode_version" usage:"Sets the default XCode version number to use if an action doesn't specify one. If not set, /Applications/Xcode.app/ is used."`
 }
 


### PR DESCRIPTION
Add a config option to inherit the uid and gid of the current user, and enable it for local development.

Before this change, when running the executor locally, all files are written with uid=0 and gid=0, causing various permissions errors.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
