### PR TITLE
Support jailer and networking

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -1,4 +1,6 @@
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
 go_library(
     name = "firecracker",
@@ -14,17 +16,21 @@ go_library(
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/util/ext4",
+        "//enterprise/server/util/networking",
         "//enterprise/server/util/vsock",
         "//proto:remote_execution_go_proto",
         "//proto:vmexec_go_proto",
+        "//server/environment",
         "//server/interfaces",
         "//server/util/disk",
         "//server/util/log",
         "//server/util/status",
         "@com_github_firecracker_microvm_firecracker_go_sdk//:firecracker-go-sdk",
         "@com_github_firecracker_microvm_firecracker_go_sdk//client/models",
+        "@com_github_google_uuid//:uuid",
         "@com_github_sirupsen_logrus//:logrus",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+        "@org_golang_x_sys//unix",
     ],
 )
 
@@ -41,4 +47,19 @@ go_test(
         "//server/util/disk",
         "@com_github_stretchr_testify//assert",
     ],
+)
+
+container_image(
+    name = "base_image",
+    base = "@executor_image//image:dockerfile_image.tar",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+go_image(
+    name = "firecracker_test_image",
+    testonly = 1,
+    base = ":base_image",
+    binary = ":firecracker_test",
+    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -1,6 +1,4 @@
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
 go_library(
     name = "firecracker",
@@ -20,7 +18,6 @@ go_library(
         "//enterprise/server/util/vsock",
         "//proto:remote_execution_go_proto",
         "//proto:vmexec_go_proto",
-        "//server/environment",
         "//server/interfaces",
         "//server/util/disk",
         "//server/util/log",
@@ -47,19 +44,4 @@ go_test(
         "//server/util/disk",
         "@com_github_stretchr_testify//assert",
     ],
-)
-
-container_image(
-    name = "base_image",
-    base = "@executor_image//image:dockerfile_image.tar",
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-)
-
-go_image(
-    name = "firecracker_test_image",
-    testonly = 1,
-    base = ":base_image",
-    binary = ":firecracker_test",
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	// How long to wait for the VMM to listen on the firecracker socket.
-	firecrackerSocketWaitTimeout = 30 * time.Second
+	firecrackerSocketWaitTimeout = 3 * time.Second
 
 	// How long to wait when dialing the vmexec server inside the VM.
 	vSocketDialTimeout = 3 * time.Second
@@ -306,7 +306,7 @@ func (c *firecrackerContainer) newID() error {
 	if err != nil {
 		return err
 	}
-	log.Printf("Container id changing from %q (%d) to %q (%d)", c.id, c.vmIdx, u.String(), vmIdx)
+	log.Debugf("Container id changing from %q (%d) to %q (%d)", c.id, c.vmIdx, u.String(), vmIdx)
 	c.id = u.String()
 
 	c.vmIdx = vmIdx
@@ -315,13 +315,6 @@ func (c *firecrackerContainer) newID() error {
 		vmIdx = 0
 	}
 
-	return nil
-}
-
-func (c *firecrackerContainer) cleanupNets(ctx context.Context) error {
-	if c.id == "" || c.vmIdx == 0 {
-		return nil
-	}
 	return nil
 }
 
@@ -502,8 +495,8 @@ func (c *firecrackerContainer) Create(ctx context.Context, actionWorkingDir stri
 	}
 	c.workspaceFSPath = wsPath
 
-	log.Printf("c.containerFSPath: %q", c.containerFSPath)
-	log.Printf("c.workspaceFSPath: %q", c.workspaceFSPath)
+	log.Debugf("c.containerFSPath: %q", c.containerFSPath)
+	log.Debugf("c.workspaceFSPath: %q", c.workspaceFSPath)
 
 	fcCfg, err := c.getConfig(ctx, c.containerFSPath, c.workspaceFSPath)
 	if err != nil {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -17,12 +17,15 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ext4"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/networking"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/vsock"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 
 	bundle "github.com/buildbuddy-io/buildbuddy/enterprise"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -33,14 +36,59 @@ import (
 
 const (
 	// How long to wait for the VMM to listen on the firecracker socket.
-	firecrackerSocketWaitTimeout = 3 * time.Second
+	firecrackerSocketWaitTimeout = 30 * time.Second
+
+	// How long to wait when dialing the vmexec server inside the VM.
+	vSocketDialTimeout = 3 * time.Second
+
+	// The firecracker socket path (will be relative to the chroot).
+	firecrackerSocketPath = "/run/fc.sock"
+
+	// The vSock path (also relative to the chroot).
+	firecrackerVSockPath = "/run/v.sock"
+
+	// The names to use when creating a full snapshot (relative to chroot).
+	fullDiskSnapshotName = "full-disk.snap"
+	fullMemSnapshotName  = "full-mem.snap"
+
+	// The networking deets for host and vm interfaces.
+	// All VMs are configured with the same IP and tap device via boot args,
+	// but because they run inside of a network namespace, they do not
+	// conflict. More details here:
+	// https://github.com/firecracker-microvm/firecracker/blob/main/docs/snapshotting/network-for-clones.md
+	tapDeviceName = "vmtap0"
+	tapDeviceMac  = "7a:a8:fa:dc:76:b7"
+	tapAddr       = "192.168.241.1/29"
+
+	vmIP   = "192.168.241.2"
+	vmAddr = vmIP + "/29"
+
+	// https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/networking_guide/sec-configuring_ip_networking_from_the_kernel_command_line
+	// ip<client-IP-number>:[<server-id>]:<gateway-IP-number>:<netmask>:<client-hostname>:<interface>:{dhcp|dhcp6|auto6|on|any|none|off}
+	machineIPBootArgs = "ip=" + vmIP + "::192.168.241.1:255.255.255.48::eth0:off"
+
+	// This is pretty arbitrary limit -- when vmIdx gets this big it will
+	// roll over to 0, causing new VMs to start re-using old local IPs. But
+	// net namespaces are deleted upon VM removal, so this should not cause
+	// any issue. If more than this many VMs were active on a single host at
+	// once -- it would cause an error.
+	maxVMSPerHost = 1000
 )
 
 var (
 	locateBinariesOnce  sync.Once
 	locateBinariesError error
-	kernelImagePath     string
-	initrdImagePath     string
+
+	// kernel + initrd
+	kernelImagePath string
+	initrdImagePath string
+
+	// firecracker + jailer
+	firecrackerBinPath string
+	jailerBinPath      string
+
+	vmIdx   int
+	vmIdxMu sync.Mutex
 )
 
 // getStaticFilePath returns the full path to a bundled file. If runfiles are
@@ -117,8 +165,8 @@ func getOrCreateContainerImage(ctx context.Context, containerImage string) (stri
 
 // convertContainerToExt4FS uses system tools to generate an ext4 filesystem
 // image from an OCI container image reference.
-// NB: We use docker because it's already installed - but podman can also be
-// used interchangeably and does not require root access.
+// NB: We use modern tools (not docker), that do not require root access. This
+// allows this binary to convert images even when not running as root.
 func convertContainerToExt4FS(ctx context.Context, containerImage string) (string, error) {
 	// Make a temp directory to work in. Delete it when this fuction returns.
 	rootUnpackDir, err := os.MkdirTemp("", "container-unpack-*")
@@ -167,42 +215,81 @@ func convertContainerToExt4FS(ctx context.Context, containerImage string) (strin
 	return imageFile, nil
 }
 
-// firecrackerContainer executes commands inside of a firecracker VM.
-type firecrackerContainer struct {
-	containerHome  string
-	containerImage string
-	workDir        string
+// waitUntilExists waits, up to maxWait, for localPath to exist. If the provided
+// context is cancelled, this method returns immediately.
+func waitUntilExists(ctx context.Context, maxWait time.Duration, localPath string) {
+	ctx, cancel := context.WithTimeout(ctx, maxWait)
+	defer cancel()
 
-	// Populated once PullImageIfNecessary is called.
-	workspaceFSPath string
+	start := time.Now()
+	defer func() {
+		log.Debugf("Waited %s for %q to be created.", time.Since(start), localPath)
+	}()
 
-	// Populated once Create is called.
-	rootFSPath string
-	machine    *fcclient.Machine
-	fcSocket   string
-	vSocket    string
-
-	// Snapshot paths are populated when the container is paused.
-	memSnapshotPath  string
-	diskSnapshotPath string
+	ticker := time.NewTicker(1 * time.Millisecond)
+	defer func() {
+		cancel()
+		ticker.Stop()
+	}()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := os.Stat(localPath); err != nil {
+				continue
+			}
+			return
+		}
+	}
 }
 
-func NewContainer(ctx context.Context, containerImage, hostRootDir string) (*firecrackerContainer, error) {
-	// Ensure our kernel and initrd exist. Bail if they don't.
-	initStaticFiles()
-	if locateBinariesError != nil {
-		return nil, locateBinariesError
-	}
+func getLogrusLogger() *logrus.Entry {
+	logrusLogger := logrus.New()
+	logrusLogger.SetLevel(logrus.ErrorLevel)
+	return logrus.NewEntry(logrusLogger)
+}
 
-	containerHome, err := os.MkdirTemp("", "fc-container-*")
-	if err != nil {
+// firecrackerContainer executes commands inside of a firecracker VM.
+type firecrackerContainer struct {
+	id    string // a random GUID, unique per-run of firecracker
+	vmIdx int    // the index of this vm on the host machine
+
+	containerImage   string // the OCI container image. ex "alpine:latest"
+	jailerRoot       string // the root dir the jailer will work in
+	actionWorkingDir string // the action directory with inputs / outputs
+	workspaceFSPath  string // the path to the workspace ext4 image
+	containerFSPath  string // the path to the container ext4 image
+
+	machine *fcclient.Machine // the firecracker machine object.
+}
+
+func NewContainer(ctx context.Context, containerImage, actionWorkingDir string) (*firecrackerContainer, error) {
+	// Ensure our kernel and initrd exist.
+	if err := locateStaticFiles(); err != nil {
 		return nil, err
 	}
-	return &firecrackerContainer{
-		containerHome:  containerHome,
-		containerImage: containerImage,
-		workDir:        hostRootDir,
-	}, nil
+	// WARNING: because of the limitation on the length of unix sock file
+	// paths (103), this directory path needs to be short. Specifically, a
+	// full sock path will look like:
+	// /tmp/firecracker/217d4de0-4b28-401b-891b-18e087718ad1/root/run/fc.sock
+	// everything after "/tmp" is 65 characters, so 38 are left for the
+	// jailerRoot.
+	jailerRoot := "/tmp/"
+	if err := disk.EnsureDirectoryExists(jailerRoot); err != nil {
+		return nil, err
+	}
+
+	c := &firecrackerContainer{
+		jailerRoot:       jailerRoot,
+		containerImage:   containerImage,
+		actionWorkingDir: actionWorkingDir,
+	}
+
+	if err := c.newID(); err != nil {
+		return nil, err
+	}
+	return c, nil
 }
 
 func nonCmdExit(err error) *interfaces.CommandResult {
@@ -212,10 +299,47 @@ func nonCmdExit(err error) *interfaces.CommandResult {
 	}
 }
 
-func (c *firecrackerContainer) getConfig(ctx context.Context, fcSocket, vSocket, containerFS, workspaceFS string) (*fcclient.Config, error) {
+func (c *firecrackerContainer) newID() error {
+	vmIdxMu.Lock()
+	defer vmIdxMu.Unlock()
+	u, err := uuid.NewRandom()
+	if err != nil {
+		return err
+	}
+	log.Printf("Container id changing from %q (%d) to %q (%d)", c.id, c.vmIdx, u.String(), vmIdx)
+	c.id = u.String()
+
+	c.vmIdx = vmIdx
+	vmIdx += 1
+	if vmIdx > maxVMSPerHost {
+		vmIdx = 0
+	}
+
+	return nil
+}
+
+func (c *firecrackerContainer) cleanupNets(ctx context.Context) error {
+	if c.id == "" || c.vmIdx == 0 {
+		return nil
+	}
+	return nil
+}
+
+func (c *firecrackerContainer) getChroot() string {
+	// This path matches the path the jailer will use when jailing
+	// firecracker. Because we need to copy some (snapshot) files into
+	// this directory before starting firecracker, we need to compute
+	// the same path.
+	return filepath.Join(c.jailerRoot, "firecracker", c.id, "root")
+}
+
+func (c *firecrackerContainer) getConfig(ctx context.Context, containerFS, workspaceFS string) (*fcclient.Config, error) {
 	bootArgs := "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules=1 random.trust_cpu=on i8042.noaux=1 tsc=reliable ipv6.disable=1 quiet"
+	bootArgs += " " + machineIPBootArgs
+
 	return &fcclient.Config{
-		SocketPath:      fcSocket,
+		VMID:            c.id,
+		SocketPath:      firecrackerSocketPath,
 		KernelImagePath: kernelImagePath,
 		InitrdPath:      initrdImagePath,
 		KernelArgs:      bootArgs,
@@ -235,8 +359,29 @@ func (c *firecrackerContainer) getConfig(ctx context.Context, fcSocket, vSocket,
 		},
 		VsockDevices: []fcclient.VsockDevice{
 			fcclient.VsockDevice{
-				Path: vSocket,
+				Path: firecrackerVSockPath,
 			},
+		},
+		NetworkInterfaces: []fcclient.NetworkInterface{
+			{
+				StaticConfiguration: &fcclient.StaticNetworkConfiguration{
+					HostDevName: tapDeviceName,
+					MacAddress:  tapDeviceMac,
+				},
+			},
+		},
+		JailerCfg: &fcclient.JailerConfig{
+			JailerBinary:  jailerBinPath,
+			ChrootBaseDir: c.jailerRoot,
+			ID:            c.id,
+			UID:           fcclient.Int(unix.Geteuid()),
+			GID:           fcclient.Int(unix.Getegid()),
+			//			Stdout:         os.Stdout, // STOPSHIP(tylerw): remove this?
+			//			Stderr:         os.Stderr, // STOPSHIP(tylerw): remove this?
+			//			Stdin:          os.Stdin,  // STOPSHIP(tylerw): remove this?
+			NumaNode:       fcclient.Int(0),
+			ExecFile:       firecrackerBinPath,
+			ChrootStrategy: fcclient.NewNaiveChrootStrategy(kernelImagePath),
 		},
 		MachineCfg: fcmodels.MachineConfiguration{
 			VcpuCount:  fcclient.Int64(1),
@@ -246,14 +391,22 @@ func (c *firecrackerContainer) getConfig(ctx context.Context, fcSocket, vSocket,
 	}, nil
 }
 
-func initStaticFiles() {
-	locateBinariesOnce.Do(func() {
-		initrdImagePath, locateBinariesError = getStaticFilePath("vmsupport/bin/initrd.cpio", 0755)
-		if locateBinariesError != nil {
-			return
-		}
-		kernelImagePath, locateBinariesError = getStaticFilePath("vmsupport/bin/vmlinux", 0755)
-	})
+func locateStaticFiles() error {
+	var err error
+	initrdImagePath, err = getStaticFilePath("vmsupport/bin/initrd.cpio", 0755)
+	if err != nil {
+		return err
+	}
+	kernelImagePath, err = getStaticFilePath("vmsupport/bin/vmlinux", 0755)
+	if err != nil {
+		return err
+	}
+	firecrackerBinPath, err = exec.LookPath("firecracker")
+	if err != nil {
+		return err
+	}
+	jailerBinPath, err = exec.LookPath("jailer")
+	return err
 }
 
 // copyOutputsToWorkspace copies output files from the workspace filesystem
@@ -262,11 +415,15 @@ func initStaticFiles() {
 // data has already been synced to the workspace filesystem and the VM has
 // been paused before calling this.
 func (c *firecrackerContainer) copyOutputsToWorkspace(ctx context.Context) error {
+	start := time.Now()
+	defer func() {
+		log.Debugf("copyOutputsToWorkspace took %s", time.Since(start))
+	}()
 	if exists, err := disk.FileExists(c.workspaceFSPath); err != nil || !exists {
 		return status.FailedPreconditionErrorf("workspacefs path %q not found", c.workspaceFSPath)
 	}
-	if exists, err := disk.FileExists(c.workDir); err != nil || !exists {
-		return status.FailedPreconditionErrorf("workDir path %q not found", c.workDir)
+	if exists, err := disk.FileExists(c.actionWorkingDir); err != nil || !exists {
+		return status.FailedPreconditionErrorf("actionWorkingDir path %q not found", c.actionWorkingDir)
 	}
 
 	unpackDir, err := os.MkdirTemp("", "unpacked-workspacefs-*")
@@ -283,14 +440,14 @@ func (c *firecrackerContainer) copyOutputsToWorkspace(ctx context.Context) error
 		if strings.HasPrefix(path, "bbvmroot/") || strings.HasPrefix(path, "bbvmwork/") {
 			return nil
 		}
-		targetLocation := filepath.Join(c.workDir, path)
+		targetLocation := filepath.Join(c.actionWorkingDir, path)
 		alreadyExists, err := disk.FileExists(targetLocation)
 		if err != nil {
 			return err
 		}
 		if !alreadyExists {
 			if d.IsDir() {
-				return disk.EnsureDirectoryExists(filepath.Join(c.workDir, path))
+				return disk.EnsureDirectoryExists(filepath.Join(c.actionWorkingDir, path))
 			}
 			return os.Rename(filepath.Join(unpackDir, path), targetLocation)
 		}
@@ -304,7 +461,7 @@ func (c *firecrackerContainer) copyOutputsToWorkspace(ctx context.Context) error
 //
 // It is approximately the same as calling PullImageIfNecessary, Create,
 // Exec, then Remove.
-func (c *firecrackerContainer) Run(ctx context.Context, command *repb.Command, workDir string) *interfaces.CommandResult {
+func (c *firecrackerContainer) Run(ctx context.Context, command *repb.Command, actionWorkingDir string) *interfaces.CommandResult {
 	start := time.Now()
 	defer func() {
 		log.Debugf("Run took %s", time.Since(start))
@@ -313,7 +470,7 @@ func (c *firecrackerContainer) Run(ctx context.Context, command *repb.Command, w
 		return nonCmdExit(err)
 	}
 
-	if err := c.Create(ctx, workDir); err != nil {
+	if err := c.Create(ctx, actionWorkingDir); err != nil {
 		return nonCmdExit(err)
 	}
 	defer c.Remove(ctx)
@@ -324,41 +481,71 @@ func (c *firecrackerContainer) Run(ctx context.Context, command *repb.Command, w
 
 // Create creates a new VM and starts a top-level process inside it listening
 // for commands to execute.
-func (c *firecrackerContainer) Create(ctx context.Context, workDir string) error {
+func (c *firecrackerContainer) Create(ctx context.Context, actionWorkingDir string) error {
 	start := time.Now()
 	defer func() {
 		log.Debugf("Create took %s", time.Since(start))
 	}()
-	c.workDir = workDir
-	workspaceSizeBytes, err := disk.DirSize(c.workDir)
+	c.actionWorkingDir = actionWorkingDir
+	workspaceSizeBytes, err := disk.DirSize(c.actionWorkingDir)
 	if err != nil {
 		return err
 	}
-	wsPath := filepath.Join(c.containerHome, "workspacefs.ext4")
-	if err := ext4.DirectoryToImage(ctx, c.workDir, wsPath, workspaceSizeBytes+1e9); err != nil {
+
+	containerHome, err := os.MkdirTemp("", "fc-container-*")
+	if err != nil {
+		return err
+	}
+	wsPath := filepath.Join(containerHome, "workspacefs.ext4")
+	if err := ext4.DirectoryToImage(ctx, c.actionWorkingDir, wsPath, workspaceSizeBytes+1e9); err != nil {
 		return err
 	}
 	c.workspaceFSPath = wsPath
 
-	logrusLogger := logrus.New()
-	logrusLogger.SetLevel(logrus.ErrorLevel)
+	log.Printf("c.containerFSPath: %q", c.containerFSPath)
+	log.Printf("c.workspaceFSPath: %q", c.workspaceFSPath)
 
-	machineOpts := []fcclient.Opt{
-		fcclient.WithLogger(logrus.NewEntry(logrusLogger)),
-	}
-
-	c.fcSocket = filepath.Join(c.containerHome, "firecracker.sock")
-	c.vSocket = filepath.Join(c.containerHome, "v.sock")
-
-	fcCfg, err := c.getConfig(ctx, c.fcSocket, c.vSocket, c.rootFSPath, c.workspaceFSPath)
+	fcCfg, err := c.getConfig(ctx, c.containerFSPath, c.workspaceFSPath)
 	if err != nil {
 		return err
 	}
-	cmd := fcclient.VMCommandBuilder{}.
-		WithBin("firecracker").
-		WithSocketPath(c.fcSocket).
+	if err := networking.CreateNetNamespace(ctx, c.id); err != nil {
+		return err
+	}
+	if err := networking.CreateTapInNamespace(ctx, c.id, tapDeviceName); err != nil {
+		return err
+	}
+	if err := networking.ConfigureTapInNamespace(ctx, c.id, tapDeviceName, tapAddr); err != nil {
+		return err
+	}
+	if err := networking.BringUpTapInNamespace(ctx, c.id, tapDeviceName); err != nil {
+		return err
+	}
+	if err := networking.SetupVethPair(ctx, c.id, vmIP, c.vmIdx); err != nil {
+		return err
+	}
+	cmd := fcclient.NewJailerCommandBuilder().
+		WithBin(jailerBinPath).
+		WithChrootBaseDir(c.jailerRoot).
+		WithID(c.id).
+		WithNetNS("/var/run/netns/"+c.id).
+		WithUID(unix.Geteuid()).
+		WithGID(unix.Getegid()).
+		//		WithStdin(os.Stdin).   // STOPSHIP(tylerw): remove this?
+		//		WithStdout(os.Stdout). // STOPSHIP(tylerw): remove this?
+		//		WithStderr(os.Stderr). // STOPSHIP(tylerw): remove this?
+		WithNumaNode(0).
+		WithExecFile(firecrackerBinPath).
+		WithFirecrackerArgs("--api-sock", firecrackerSocketPath).
 		Build(ctx)
-	machineOpts = append(machineOpts, fcclient.WithProcessRunner(cmd))
+
+	machineOpts := []fcclient.Opt{
+		fcclient.WithLogger(getLogrusLogger()),
+		fcclient.WithProcessRunner(cmd),
+	}
+	// Wait for the jailer directory to be created
+	waitUntilExists(ctx, time.Second, c.getChroot())
+
 	m, err := fcclient.NewMachine(ctx, *fcCfg, machineOpts...)
 	if err != nil {
 		return status.InternalErrorf("Failed creating machine: %s", err)
@@ -367,6 +554,14 @@ func (c *firecrackerContainer) Create(ctx context.Context, workDir string) error
 		return status.InternalErrorf("Failed starting machine: %s", err)
 	}
 	c.machine = m
+	dialCtx, cancel := context.WithTimeout(ctx, vSocketDialTimeout)
+	defer cancel()
+
+	vsockPath := filepath.Join(c.getChroot(), firecrackerVSockPath)
+	_, err = vsock.SimpleGRPCDial(dialCtx, vsockPath)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -386,7 +581,11 @@ func (c *firecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 		ExitCode:           commandutil.NoExitCode,
 	}
 
-	conn, err := vsock.SimpleGRPCDial(ctx, c.vSocket)
+	dialCtx, cancel := context.WithTimeout(ctx, vSocketDialTimeout)
+	defer cancel()
+
+	vsockPath := filepath.Join(c.getChroot(), firecrackerVSockPath)
+	conn, err := vsock.SimpleGRPCDial(dialCtx, vsockPath)
 	if err != nil {
 		result.Error = err
 		return result
@@ -438,14 +637,14 @@ func (c *firecrackerContainer) PullImageIfNecessary(ctx context.Context) error {
 	defer func() {
 		log.Debugf("PullImageIfNecessary took %s", time.Since(start))
 	}()
-	if c.rootFSPath != "" {
+	if c.containerFSPath != "" {
 		return nil
 	}
-	rootFSPath, err := getOrCreateContainerImage(ctx, c.containerImage)
+	containerFSPath, err := getOrCreateContainerImage(ctx, c.containerImage)
 	if err != nil {
 		return err
 	}
-	c.rootFSPath = rootFSPath
+	c.containerFSPath = containerFSPath
 
 	// TODO(tylerw): support loading a VM from snapshot instead for speed.
 	return nil
@@ -463,10 +662,12 @@ func (c *firecrackerContainer) Remove(ctx context.Context) error {
 		log.Errorf("Error shutting down machine: %s", err)
 	}
 	if err := c.machine.StopVMM(); err != nil {
-		return err
+		log.Errorf("Error stopping VM: %s", err)
 	}
-
-	return os.RemoveAll(c.containerHome)
+	if err := networking.RemoveNetNamespace(ctx, c.id); err != nil {
+		log.Errorf("Error removing net namespace: %s", err)
+	}
+	return nil
 }
 
 // Pause freezes a container so that it no longer consumes CPU resources.
@@ -478,33 +679,38 @@ func (c *firecrackerContainer) Pause(ctx context.Context) error {
 	if err := c.machine.PauseVM(ctx); err != nil {
 		return err
 	}
-	snapshotDir := filepath.Join(c.containerHome, "full-snapshot")
-	if err := disk.EnsureDirectoryExists(snapshotDir); err != nil {
-		return err
-	}
-	c.memSnapshotPath = filepath.Join(snapshotDir, "mem.snapshot")
-	c.diskSnapshotPath = filepath.Join(snapshotDir, "disk.snapshot")
+	memSnapshotPath := filepath.Join(c.getChroot(), fullDiskSnapshotName)
+	diskSnapshotPath := filepath.Join(c.getChroot(), fullMemSnapshotName)
 
 	// If an older snapshot is present -- nuke it since we're writing a new one.
-	disk.DeleteLocalFileIfExists(c.memSnapshotPath)
-	disk.DeleteLocalFileIfExists(c.diskSnapshotPath)
+	disk.DeleteLocalFileIfExists(memSnapshotPath)
+	disk.DeleteLocalFileIfExists(diskSnapshotPath)
 
-	snapStart := time.Now()
-	if err := c.machine.CreateSnapshot(ctx, c.memSnapshotPath, c.diskSnapshotPath); err != nil {
+	if err := c.machine.CreateSnapshot(ctx, fullMemSnapshotName, fullDiskSnapshotName); err != nil {
 		return err
 	}
-	log.Debugf("CreateSnapshot took %s", time.Since(snapStart))
 
 	if err := c.machine.StopVMM(); err != nil {
 		return err
 	}
 	c.machine = nil
+	return nil
+}
 
-	// Keep the socket and vsocket paths around -- they'll be reused when
-	// the machine is unpaused -- but delete the files so the VMM can
-	// recreate them.
-	disk.DeleteLocalFileIfExists(c.fcSocket)
-	disk.DeleteLocalFileIfExists(c.vSocket)
+func hardlinkFilesIntoDir(targetDir string, files ...string) error {
+	for _, f := range files {
+		fileName := filepath.Base(f)
+		stat, err := os.Stat(f)
+		if err != nil {
+			return err
+		}
+		if stat.IsDir() {
+			return status.FailedPreconditionErrorf("%q was dir, not file", f)
+		}
+		if err := os.Link(f, filepath.Join(targetDir, fileName)); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -514,27 +720,68 @@ func (c *firecrackerContainer) Unpause(ctx context.Context) error {
 	defer func() {
 		log.Debugf("Unpause took %s", time.Since(start))
 	}()
-	if exists, err := disk.FileExists(c.memSnapshotPath); err != nil || !exists {
-		return status.FailedPreconditionErrorf("memory snapshot %q not found", c.memSnapshotPath)
-	}
-	if exists, err := disk.FileExists(c.diskSnapshotPath); err != nil || !exists {
-		return status.FailedPreconditionErrorf("disk snapshot %q not found", c.diskSnapshotPath)
+
+	if err := networking.RemoveNetNamespace(ctx, c.id); err != nil {
+		log.Warningf("Error removing old net namespace: %s", err)
 	}
 
+	// Capture the previous snapshot path, so we can copy it into the
+	// new (jailed) directory where firecracker will be run from.
+	memSnapshotPath := filepath.Join(c.getChroot(), fullDiskSnapshotName)
+	diskSnapshotPath := filepath.Join(c.getChroot(), fullMemSnapshotName)
+	if err := c.newID(); err != nil {
+		return err
+	}
+
+	// We start firecracker with this reduced config because we will load a
+	// snapshot that is already configured.
 	cfg := fcclient.Config{
-		SocketPath:        c.fcSocket,
+		SocketPath:        firecrackerSocketPath,
 		DisableValidation: true,
+		JailerCfg: &fcclient.JailerConfig{
+			JailerBinary:   jailerBinPath,
+			ChrootBaseDir:  c.jailerRoot,
+			ID:             c.id,
+			UID:            fcclient.Int(unix.Geteuid()),
+			GID:            fcclient.Int(unix.Getegid()),
+			NumaNode:       fcclient.Int(0),
+			ExecFile:       firecrackerBinPath,
+			ChrootStrategy: fcclient.NewNaiveChrootStrategy(kernelImagePath),
+		},
 	}
 
-	cmd := fcclient.VMCommandBuilder{}.
-		WithBin("firecracker").
-		WithSocketPath(c.fcSocket).
+	if err := networking.CreateNetNamespace(ctx, c.id); err != nil {
+		return err
+	}
+	if err := networking.CreateTapInNamespace(ctx, c.id, tapDeviceName); err != nil {
+		return err
+	}
+	if err := networking.ConfigureTapInNamespace(ctx, c.id, tapDeviceName, tapAddr); err != nil {
+		return err
+	}
+	if err := networking.BringUpTapInNamespace(ctx, c.id, tapDeviceName); err != nil {
+		return err
+	}
+	if err := networking.SetupVethPair(ctx, c.id, vmIP, c.vmIdx); err != nil {
+		return err
+	}
+	cmd := fcclient.NewJailerCommandBuilder().
+		WithBin(jailerBinPath).
+		WithChrootBaseDir(c.jailerRoot).
+		WithID(c.id).
+		WithNetNS("/var/run/netns/"+c.id).
+		WithUID(unix.Geteuid()).
+		WithGID(unix.Getegid()).
+		//		WithStdin(os.Stdin).   // STOPSHIP(tylerw): remove this?
+		//		WithStdout(os.Stdout). // STOPSHIP(tylerw): remove this?
+		//		WithStderr(os.Stderr). // STOPSHIP(tylerw): remove this?
+		WithNumaNode(0).
+		WithExecFile(firecrackerBinPath).
+		WithFirecrackerArgs("--api-sock", firecrackerSocketPath).
 		Build(ctx)
 
-	logrusLogger := logrus.New()
-	logrusLogger.SetLevel(logrus.ErrorLevel)
 	machineOpts := []fcclient.Opt{
-		fcclient.WithLogger(logrus.NewEntry(logrusLogger)),
+		fcclient.WithLogger(getLogrusLogger()),
 		fcclient.WithProcessRunner(cmd),
 	}
 	// Start Firecracker
@@ -542,17 +789,35 @@ func (c *firecrackerContainer) Unpause(ctx context.Context) error {
 	if err != nil {
 		return status.InternalErrorf("Failed starting firecracker binary: %s", err)
 	}
+
+	// Wait for the jailer directory to be created
+	waitUntilExists(ctx, time.Second, c.getChroot())
+
+	requiredFiles := []string{
+		kernelImagePath,
+		initrdImagePath,
+		c.containerFSPath,
+		c.workspaceFSPath,
+		memSnapshotPath,
+		diskSnapshotPath,
+	}
+	if err := hardlinkFilesIntoDir(c.getChroot(), requiredFiles...); err != nil {
+		return err
+	}
+
 	machine, err := fcclient.NewMachine(ctx, cfg, machineOpts...)
 	if err != nil {
-		return status.InternalErrorf("failed to create new machine: %s", err)
+		return status.InternalErrorf("Failed creating machine: %s", err)
 	}
 	c.machine = machine
 
+	socketWaitStart := time.Now()
 	errCh := make(chan error)
 	if err := c.machine.WaitForSocket(firecrackerSocketWaitTimeout, errCh); err != nil {
 		return status.InternalErrorf("timeout waiting for firecracker socket: %s", err)
 	}
-	if err := c.machine.LoadSnapshot(ctx, c.memSnapshotPath, c.diskSnapshotPath); err != nil {
+	log.Debugf("waitforsocket took %s", time.Since(socketWaitStart))
+	if err := c.machine.LoadSnapshot(ctx, fullMemSnapshotName, fullDiskSnapshotName); err != nil {
 		return status.InternalErrorf("error loading snapshot: %s", err)
 	}
 	if err := c.machine.ResumeVM(ctx); err != nil {
@@ -560,6 +825,10 @@ func (c *firecrackerContainer) Unpause(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (c *firecrackerContainer) Wait(ctx context.Context) error {
+	return c.machine.Wait(ctx)
 }
 
 func (c *firecrackerContainer) Stats(ctx context.Context) (*container.Stats, error) {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -99,12 +99,6 @@ func TestFirecrackerSnapshotAndResume(t *testing.T) {
 	if err := c.Unpause(ctx); err != nil {
 		t.Fatalf("unable to unpause container: %s", err)
 	}
-	if err := c.Pause(ctx); err != nil {
-		t.Fatalf("unable to pause container: %s", err)
-	}
-	if err := c.Unpause(ctx); err != nil {
-		t.Fatalf("unable to unpause container: %s", err)
-	}
 
 	cmd := &repb.Command{
 		Arguments: []string{"sh", "-c", `printf "$GREETING $(cat world.txt)" && printf "foo" >&2`},

--- a/enterprise/server/util/networking/networking.go
+++ b/enterprise/server/util/networking/networking.go
@@ -25,7 +25,7 @@ func runCommand(ctx context.Context, args ...string) error {
 	if err != nil {
 		return status.InternalErrorf("Error running %q %s: %s", cmd.String(), string(out), err)
 	}
-	log.Printf("Succesfully ran: %q", cmd.String())
+	log.Debugf("Succesfully ran: %q", cmd.String())
 	return nil
 }
 
@@ -117,14 +117,10 @@ func attachAddressToVeth(ctx context.Context, netNamespace, ipAddr, vethName str
 	}
 }
 
-func RemoveVethPair(ctx context.Context, netNamespace string, vmIdx int) error {
+func RemoveNetNamespace(ctx context.Context, netNamespace string) error {
 	// This will delete the veth pair too, and the address attached
 	// to the host-size of the veth pair.
-	err := runCommand(ctx, "ip", "netns", "delete", netNamespace)
-	if err != nil {
-		return err
-	}
-	return nil
+	return runCommand(ctx, "ip", "netns", "delete", netNamespace)
 }
 
 // SetupVethPair is equivalent to:


### PR DESCRIPTION
This change runs firecracker inside of the jailer and also enables networking for VMs.

The [jailer](https://github.com/firecracker-microvm/firecracker/blob/main/docs/jailer.md) is another binary shipped with firecracker that creates a chroot + network namespace and runs the firecracker process inside. It's good for security, but also important for snapshotting + networking as it allows snapshots to have the same firecracker/vsock unix socket paths and IPs, and co-exist on the same host because they are in different chroot / namespaces.

Post this change, networking in containers works out of the box as soon as the default route is added (example:
ip route add default via 192.168.241.1). I'll send another CL after this one that makes that default route addition happen as part of init.

Want to run this CL locally?
 - sudo ./tools/enable_local_firecracker.sh on a linux machine (x86-64)
 - blaze build enterprise/server/remote_execution/containers/firecracker:firecracker_test
 - bazel-bin/enterprise/server/remote_execution/containers/firecracker/firecracker_test_/firecracker_test