### PR TITLE
Fix panic in case BES stream contains no events

### DIFF
--- a/server/build_event_protocol/build_event_server/build_event_server.go
+++ b/server/build_event_protocol/build_event_server/build_event_server.go
@@ -120,9 +120,11 @@ func (s *BuildEventProtocolServer) PublishBuildToolEventStream(stream pepb.Publi
 		}
 	}
 
-	if err := channel.FinalizeInvocation(streamID.InvocationId); err != nil {
-		log.Warningf("Error finalizing invocation %q: %s", streamID.InvocationId, err)
-		return disconnectWithErr(err)
+	if channel != nil {
+		if err := channel.FinalizeInvocation(streamID.GetInvocationId()); err != nil {
+			log.Warningf("Error finalizing invocation %q: %s", streamID.GetInvocationId(), err)
+			return disconnectWithErr(err)
+		}
 	}
 
 	// Finally, ack everything.


### PR DESCRIPTION
Ran into this while trying to replay an invocation and I had a typo in the invocation ID.

---

**Version bump**: TODO <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
