### PR TITLE
Fix cache mode displayed in UI when remote_executor is set

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -123,8 +123,7 @@ export default class InvocationModel {
           model.buildToolLogs = buildEvent.buildToolLogs as build_event_stream.BuildToolLogs;
         }
         if (buildEvent.unstructuredCommandLine) {
-          model.unstructuredCommandLine =
-            buildEvent.unstructuredCommandLine as build_event_stream.UnstructuredCommandLine;
+          model.unstructuredCommandLine = buildEvent.unstructuredCommandLine as build_event_stream.UnstructuredCommandLine;
         }
       }
     }
@@ -222,7 +221,9 @@ export default class InvocationModel {
   }
 
   getCache() {
-    if (!this.optionsMap.get("remote_cache")) return "Cache off";
+    if (!this.optionsMap.get("remote_cache") && !this.optionsMap.get("remote_executor")) {
+      return "Cache off";
+    }
     if (this.optionsMap.get("remote_upload_local_results") == "0") {
       return "Log upload on";
     }


### PR DESCRIPTION
`--remote_cache` defaults to the value of `--remote_executor` if it is not set. See [here](https://github.com/bazelbuild/bazel/blob/718279b6c157769f48fbaa13e0aacb94682916ef/src/main/java/com/google/devtools/build/lib/remote/RemoteModule.java#L256-L260)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->


**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/666
