### PR TITLE
Add support for storing executor information in Redis.

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//enterprise/server/scheduling/executor_handle",
         "//enterprise/server/tasksize",
+        "//proto:acl_go_proto",
         "//proto:api_key_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",

--- a/enterprise/server/test/integration/remote_execution/BUILD
+++ b/enterprise/server/test/integration/remote_execution/BUILD
@@ -13,6 +13,7 @@ go_test(
         "//enterprise/server/test/integration/remote_execution/rbetest",
         "//proto:remote_execution_go_proto",
         "//server/testutil/testfs",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -270,6 +270,7 @@ proto_library(
     name = "scheduler_proto",
     srcs = ["scheduler.proto"],
     deps = [
+        ":acl_proto",
         ":context_proto",
         ":trace_proto",
     ],
@@ -555,6 +556,7 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/scheduler",
     proto = ":scheduler_proto",
     deps = [
+        ":acl_go_proto",
         ":context_go_proto",
         ":trace_go_proto",
     ],

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -205,4 +205,3 @@ message RegisteredExecutionNode {
   string group_id = 3;
   acl.ACL acl = 4;
 }
-

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "proto/acl.proto";
 import "proto/context.proto";
 import "proto/trace.proto";
 
@@ -196,3 +197,12 @@ message GetExecutionNodesResponse {
   repeated ExecutionNode execution_node = 2;
   bool user_owned_executors_supported = 3;
 }
+
+// Persisted information about connected executors.
+message RegisteredExecutionNode {
+  ExecutionNode registration = 1;
+  string scheduler_host_port = 2;
+  string group_id = 3;
+  acl.ACL acl = 4;
+}
+

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -214,6 +214,7 @@ type RemoteExecutionConfig struct {
 	RequireExecutorAuthorization  bool   `yaml:"require_executor_authorization" usage:"If true, executors connecting to this server must provide a valid executor API key."`
 	EnableUserOwnedExecutors      bool   `yaml:"enable_user_owned_executors" usage:"If enabled, users can register their own executors with the scheduler."`
 	EnableExecutorKeyCreation     bool   `yaml:"enable_executor_key_creation" usage:"If enabled, UI will allow executor keys to be created."`
+	UseRedisForExecutorPools      bool   `yaml:"use_redis_for_executor_pools" usage:"If enabled, executor pool information will be read from Redis instead of database."`
 }
 
 type ExecutorConfig struct {


### PR DESCRIPTION
We create a hash for each executor pool. The key is the executor ID and
the value is a new RegisteredExecutionNode proto.

Additionally we create a per-group set that tracks all the available
pools.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
