### PR TITLE
Add prettier to checkstyle workflow

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -50,9 +50,8 @@ jobs:
         run: |
           git merge-base HEAD origin/master |
             xargs git diff --name-only --diff-filter=AMRCT |
-            grep -P '\.(js|jsx|ts|tsx|html|css|yaml|yml|json|md)$' |
-            ( xargs --no-run-if-empty --delimiter='\n' npx prettier@2.2.1 --check || true ) |
-            ( grep -P '^\[warn\]' || true ) > prettier-errors.txt
+            grep -P '(README|\.(js|jsx|ts|tsx|html|css|yaml|yml|json|md))$' |
+            ( xargs --no-run-if-empty --delimiter='\n' npx prettier@2.2.1 --check 1>/dev/null || true ) > prettier-errors.txt
           echo "prettier errors:"
           cat prettier-errors.txt
 

--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -53,6 +53,8 @@ jobs:
             grep -P '\.(js|jsx|ts|tsx|html|css|yaml|json|md|xml)$' |
             ( xargs --no-run-if-empty --delimiter='\n' npx prettier@2.2.1 --check || true ) |
             ( grep -P '^\[warn\]' || true ) > prettier-errors.txt
+          echo "prettier errors:"
+          cat prettier-errors.txt
 
       - name: Summary
         run: |

--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -52,7 +52,7 @@ jobs:
             xargs git diff --name-only --diff-filter=AMRCT |
             grep -P '\.(js|jsx|ts|tsx|html|css|yaml|json|md|xml)$' |
             ( xargs --no-run-if-empty --delimiter='\n' npx prettier@2.2.1 --check || true ) |
-            grep -P '^\[warn\]' > prettier-errors.txt
+            ( grep -P '^\[warn\]' || true ) > prettier-errors.txt
 
       - name: Summary
         run: |

--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -48,7 +48,7 @@ jobs:
         # NOTE: Only run prettier on files that differ from master, since
         # prettier can be slow.
         run: |
-          git merge-base HEAD master |
+          git merge-base HEAD origin/master |
             xargs git diff --name-only --diff-filter=AMRCT |
             grep -P '\.(js|jsx|ts|tsx|html|css|yaml|json|md|xml)$' |
             ( xargs --no-run-if-empty --delimiter='\n' npx prettier@2.2.1 --check || true ) |

--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -17,10 +17,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Install tools
-        run: |
-          npm install --global prettier@2.2.1
-
       - name: gofmt
         run: |
           gofmt -d . > gofmt-diff.txt || true
@@ -55,7 +51,7 @@ jobs:
           git merge-base HEAD master |
             xargs git diff --name-only --diff-filter=AMRCT |
             grep -P '\.(js|jsx|ts|tsx|html|css|yaml|json|md|xml)$' |
-            ( xargs --no-run-if-empty --delimiter='\n' prettier --check || true ) |
+            ( xargs --no-run-if-empty --delimiter='\n' npx prettier@2.2.1 --check || true ) |
             grep -P '^\[warn\]' > prettier-errors.txt
 
       - name: Summary

--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -17,6 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
+      - name: Install tools
+        run: |
+          npm install --global prettier@2.2.1
+
       - name: gofmt
         run: |
           gofmt -d . > gofmt-diff.txt || true
@@ -44,6 +48,16 @@ jobs:
           echo "clang format errors:"
           cat clang-format-errors.txt
 
+      - name: prettier
+        # NOTE: Only run prettier on files that differ from master, since
+        # prettier can be slow.
+        run: |
+          git merge-base HEAD master |
+            xargs git diff --name-only --diff-filter=AMRCT |
+            grep -P '\.(js|jsx|ts|tsx|html|css|yaml|json|md|xml)$' |
+            ( xargs --no-run-if-empty --delimiter='\n' prettier --check || true ) |
+            grep -P '^\[warn\]' > prettier-errors.txt
+
       - name: Summary
         run: |
           echo "===== gofmt diff ====="
@@ -54,6 +68,8 @@ jobs:
           cat gazelle-diff.txt
           echo "===== clang-format errors ====="
           cat clang-format-errors.txt
+          echo "===== prettier errors ====="
+          cat prettier-errors.txt
 
       - name: Check
         run: |
@@ -61,3 +77,4 @@ jobs:
           if [ -s gofmt-diff.txt ]; then exit 1; fi
           if [ -s buildifier-diff.txt ]; then exit 1; fi
           if [ -s clang-format-errors.txt ]; then exit 1; fi
+          if [ -s prettier-errors.txt ]; then exit 1; fi

--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           git merge-base HEAD origin/master |
             xargs git diff --name-only --diff-filter=AMRCT |
-            grep -P '\.(js|jsx|ts|tsx|html|css|yaml|json|md|xml)$' |
+            grep -P '\.(js|jsx|ts|tsx|html|css|yaml|json|md)$' |
             ( xargs --no-run-if-empty --delimiter='\n' npx prettier@2.2.1 --check || true ) |
             ( grep -P '^\[warn\]' || true ) > prettier-errors.txt
           echo "prettier errors:"

--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           git merge-base HEAD origin/master |
             xargs git diff --name-only --diff-filter=AMRCT |
-            grep -P '\.(js|jsx|ts|tsx|html|css|yaml|json|md)$' |
+            grep -P '\.(js|jsx|ts|tsx|html|css|yaml|yml|json|md)$' |
             ( xargs --no-run-if-empty --delimiter='\n' npx prettier@2.2.1 --check || true ) |
             ( grep -P '^\[warn\]' || true ) > prettier-errors.txt
           echo "prettier errors:"


### PR DESCRIPTION
Now that prettier is included in `buildfix.sh`, we can include it in checkstyle with less hassle when there are errors. Formats the following file types: js, jsx, ts, tsx, html, css, yaml, json, md

---

**Version bump**: TODO <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
