### PR TITLE
Fix bug that failed invocation can display as "in progress"

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -10,6 +10,8 @@ import format from "../format/format";
 
 export const CI_RUNNER_ROLE = "CI_RUNNER";
 
+export const InvocationStatus = invocation.Invocation.InvocationStatus;
+
 export default class InvocationModel {
   invocations: invocation.Invocation[] = [];
   cacheStats: cache.CacheStats[] = [];
@@ -375,31 +377,35 @@ export default class InvocationModel {
   }
 
   getStatus() {
-    let invocationStatus = this.invocations.find(() => true)?.invocationStatus;
-    if (invocationStatus == invocation.Invocation.InvocationStatus.DISCONNECTED_INVOCATION_STATUS) {
-      return "Disconnected";
+    const invocation = this.invocations[0];
+    if (!invocation) return "";
+
+    switch (invocation.invocationStatus) {
+      case InvocationStatus.COMPLETE_INVOCATION_STATUS:
+        return invocation.success ? "Succeeded" : "Failed";
+      case InvocationStatus.PARTIAL_INVOCATION_STATUS:
+        return "In progress...";
+      case InvocationStatus.DISCONNECTED_INVOCATION_STATUS:
+        return "Disconnected";
+      default:
+        return "";
     }
-    if (!this.started) {
-      return "Not started";
-    }
-    if (!this.finished) {
-      return "In progress...";
-    }
-    return this.finished.exitCode.code == 0 ? "Succeeded" : "Failed";
   }
 
   getStatusClass() {
-    let invocationStatus = this.invocations.find(() => true)?.invocationStatus;
-    if (invocationStatus == invocation.Invocation.InvocationStatus.DISCONNECTED_INVOCATION_STATUS) {
-      return "disconnected";
+    const invocation = this.invocations[0];
+    if (!invocation) return "";
+
+    switch (invocation.invocationStatus) {
+      case InvocationStatus.COMPLETE_INVOCATION_STATUS:
+        return invocation.success ? "success" : "failure";
+      case InvocationStatus.PARTIAL_INVOCATION_STATUS:
+        return "in-progress";
+      case InvocationStatus.DISCONNECTED_INVOCATION_STATUS:
+        return "disconnected";
+      default:
+        return "";
     }
-    if (!this.started) {
-      return "neutral";
-    }
-    if (!this.finished) {
-      return "in-progress";
-    }
-    return this.finished.exitCode.code == 0 ? "success" : "failure";
   }
 
   getFaviconType() {


### PR DESCRIPTION
Updates the status logic in the invocation overview to be the same as it is for the history card, which is based on the status + success fields, and not the presence of the started / finished build events.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/662
