### PR TITLE
Fix race condition with executor shutdown

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -724,8 +724,8 @@ func (p *Pool) Shutdown(ctx context.Context) error {
 			removeResults <- r.RemoveWithTimeout(ctx)
 		}()
 	}
-	errs := []error{}
-	for _, _ = range runners {
+	errs := make([]error, 0)
+	for range runners {
 		if err := <-removeResults; err != nil {
 			errs = append(errs, err)
 		}

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -33,7 +33,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/golang/protobuf/proto"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/sync/errgroup"
 
 	aclpb "github.com/buildbuddy-io/buildbuddy/proto/acl"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -720,6 +719,7 @@ func (p *Pool) Shutdown(ctx context.Context) error {
 		// to finish (if applicable). A single runner that takes a long time to
 		// upload its outputs should not block other runners from working on
 		// workspace removal in the meantime.
+		r := r
 		go func() {
 			removeResults <- r.RemoveWithTimeout(ctx)
 		}()

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -3,7 +3,6 @@ package workspace
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,8 +29,6 @@ var (
 	// whenever Remove was previously called on the workspace.
 	WorkspaceMarkedForRemovalError = status.UnavailableError("workspace is marked for removal")
 )
-
-type workspaceState int
 
 // Workspace holds the working tree for an action and keeps track of
 // inputs and outputs.

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/dirtools"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -22,6 +23,14 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
+var (
+	// WorkspaceMarkedForRemovalError is returned from workspace operations
+	// whenever Remove was previously called on the workspace.
+	WorkspaceMarkedForRemovalError = status.UnavailableError("workspace is marked for deletion")
+)
+
+type workspaceState int
+
 // Workspace holds the working tree for an action and keeps track of
 // inputs and outputs.
 type Workspace struct {
@@ -35,6 +44,9 @@ type Workspace struct {
 	// TODO: Make sure these files are written read-only
 	// to make sure this map accurately reflects the filesystem.
 	Inputs map[string]*repb.Digest
+
+	mu       sync.Mutex // protects(deleting)
+	removing bool
 }
 
 type Opts struct {
@@ -90,11 +102,23 @@ func (ws *Workspace) CommandWorkingDirectory() string {
 // CreateOutputDirs creates the required output directories for the current
 // action.
 func (ws *Workspace) CreateOutputDirs() error {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	if ws.removing {
+		return WorkspaceMarkedForRemovalError
+	}
+
 	return ws.dirHelper.CreateOutputDirs()
 }
 
 // DownloadInputs downloads any missing inputs for the current action.
 func (ws *Workspace) DownloadInputs(ctx context.Context) (*dirtools.TransferInfo, error) {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	if ws.removing {
+		return nil, WorkspaceMarkedForRemovalError
+	}
+
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
@@ -122,6 +146,12 @@ func (ws *Workspace) DownloadInputs(ctx context.Context) (*dirtools.TransferInfo
 // UploadOutputs uploads any outputs created by the last executed command
 // as well as the command's stdout and stderr.
 func (ws *Workspace) UploadOutputs(ctx context.Context, actionResult *repb.ActionResult, cmdResult *interfaces.CommandResult) (*dirtools.TransferInfo, error) {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	if ws.removing {
+		return nil, WorkspaceMarkedForRemovalError
+	}
+
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
@@ -164,17 +194,35 @@ func (ws *Workspace) UploadOutputs(ctx context.Context, actionResult *repb.Actio
 }
 
 func (ws *Workspace) Remove() error {
+	ws.mu.Lock()
+	ws.removing = true
+	// No need to keep the lock held while removing; other operations will
+	// immediately fail since we've set the removing bit.
+	ws.mu.Unlock()
+
 	return os.RemoveAll(ws.rootDir)
 }
 
 // Size computes the current workspace size in bytes.
 func (ws *Workspace) DiskUsageBytes() (int64, error) {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	if ws.removing {
+		return 0, WorkspaceMarkedForRemovalError
+	}
+
 	return disk.DirSize(ws.Path())
 }
 
 // Clean removes files and directories in the workspace which are not preserved
 // according to the workspace options.
 func (ws *Workspace) Clean() error {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	if ws.removing {
+		return WorkspaceMarkedForRemovalError
+	}
+
 	// No task is currently assigned; nothing to clean.
 	if ws.task == nil {
 		return nil

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -26,7 +26,7 @@ import (
 var (
 	// WorkspaceMarkedForRemovalError is returned from workspace operations
 	// whenever Remove was previously called on the workspace.
-	WorkspaceMarkedForRemovalError = status.UnavailableError("workspace is marked for deletion")
+	WorkspaceMarkedForRemovalError = status.UnavailableError("workspace is marked for removal")
 )
 
 type workspaceState int
@@ -45,7 +45,7 @@ type Workspace struct {
 	// to make sure this map accurately reflects the filesystem.
 	Inputs map[string]*repb.Digest
 
-	mu       sync.Mutex // protects(deleting)
+	mu       sync.Mutex // protects(removing)
 	removing bool
 }
 


### PR DESCRIPTION
* Make all workspace operations mutually exclusive. In particular, make sure `Remove` waits for uploads to complete.
* After `Remove` is called, return an error from all other workspace operations.
* Parallelize all runner removals in `runner.Pool.Shutdown`, since removal is now blocked on upload completion. Otherwise, if a single workspace takes a long time to upload its outputs (while the pool is shutting down), other runners would not be removed.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
