### PR TITLE
Page artifacts by output instead of target

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -198,7 +198,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
           />
 
           {(activeTab === "targets" || activeTab === "artifacts") && (
-            <InvocationFilterComponent hash={activeTab} search={this.props.search} />
+            <InvocationFilterComponent hash={this.props.hash} search={this.props.search} />
           )}
 
           {(activeTab === "all" || activeTab == "log") && this.state.model.aborted?.aborted.description && (

--- a/app/invocation/invocation_artifacts_card.tsx
+++ b/app/invocation/invocation_artifacts_card.tsx
@@ -91,7 +91,7 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
                   ))}
                   {target.hiddenOutputCount > 0 && (
                     <div className="artifact-hidden-count">
-                      + {target.hiddenOutputCount} more {target.hiddenOutputCount === 1 ? "artifact" : "artifacts"} for
+                      {target.hiddenOutputCount} more {target.hiddenOutputCount === 1 ? "artifact" : "artifacts"} for
                       this target
                     </div>
                   )}
@@ -100,7 +100,7 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
             ))}
             {hiddenTargetCount > 0 && (
               <div className="artifact-hidden-count">
-                + {hiddenTargetCount} more {hiddenTargetCount === 1 ? "target" : "targets"} with artifacts
+                {hiddenTargetCount} more {hiddenTargetCount === 1 ? "target" : "targets"} with artifacts
               </div>
             )}
             {totalOutputCount === 0 && <span>{this.props.filter ? "No matching artifacts" : "No artifacts"}</span>}

--- a/app/invocation/invocation_artifacts_card.tsx
+++ b/app/invocation/invocation_artifacts_card.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import InvocationModel from "./invocation_model";
 import rpcService from "../service/rpc_service";
+import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
 
 interface Props {
   model: InvocationModel;
@@ -12,9 +13,7 @@ interface State {
   numPages: number;
 }
 
-export default class ArtifactsCardComponent extends React.Component {
-  props: Props;
-
+export default class ArtifactsCardComponent extends React.Component<Props, State> {
   state: State = {
     numPages: 1,
   };
@@ -35,16 +34,42 @@ export default class ArtifactsCardComponent extends React.Component {
   }
 
   render() {
-    let targets = this.props.model.succeeded
-      .filter((completed) => completed.completed.importantOutput.length)
-      .filter(
-        (target) =>
-          !this.props.filter ||
-          target.id.targetCompleted.label.toLowerCase().includes(this.props.filter.toLowerCase()) ||
-          target.completed.importantOutput.some((output) =>
+    type Target = {
+      label: string;
+      outputs: build_event_stream.IFile[];
+      // The number of outputs hidden due to paging limits.
+      hiddenOutputCount?: number;
+    };
+    const filteredTargets = this.props.model.succeeded
+      .map((event) => ({
+        label: event.id.targetCompleted.label,
+        outputs: event.completed.importantOutput.filter(
+          (output) =>
+            !this.props.filter ||
+            event.id.targetCompleted.label.toLowerCase().includes(this.props.filter.toLowerCase()) ||
             output.name.toLowerCase().includes(this.props.filter.toLowerCase())
-          )
-      );
+        ),
+      }))
+      .filter((target) => target.outputs.length);
+
+    const visibleTargets: Target[] = [];
+    let visibleOutputCount = 0;
+    const visibleOutputLimit =
+      (this.props.pageSize && this.state.numPages * this.props.pageSize) || Number.MAX_SAFE_INTEGER;
+    const totalOutputCount = filteredTargets.map((target) => target.outputs.length).reduce((acc, val) => acc + val, 0);
+
+    for (const target of filteredTargets) {
+      const visibleOutputs = target.outputs.slice(0, visibleOutputLimit - visibleOutputCount);
+      if (!visibleOutputs.length) break;
+
+      visibleOutputCount += visibleOutputs.length;
+      visibleTargets.push({
+        ...target,
+        outputs: visibleOutputs,
+        hiddenOutputCount: target.outputs.length - visibleOutputs.length,
+      });
+    }
+    const hiddenTargetCount = filteredTargets.length - visibleTargets.length;
 
     return (
       <div className="card artifacts">
@@ -52,33 +77,35 @@ export default class ArtifactsCardComponent extends React.Component {
         <div className="content">
           <div className="title">Artifacts</div>
           <div className="details">
-            {targets
-              .slice(0, (this.props.pageSize && this.state.numPages * this.props.pageSize) || undefined)
-              .map((completed) => (
-                <div>
-                  <div className="artifact-section-title">{completed.id.targetCompleted.label}</div>
-                  {completed.completed.importantOutput
-                    .filter(
-                      (output) =>
-                        !this.props.filter ||
-                        completed.id.targetCompleted.label.toLowerCase().includes(this.props.filter.toLowerCase()) ||
-                        output.name.toLowerCase().includes(this.props.filter.toLowerCase())
-                    )
-                    .map((output) => (
-                      <a
-                        href={rpcService.getBytestreamFileUrl(output.name, output.uri, this.props.model.getId())}
-                        className="artifact-name"
-                        onClick={this.handleArtifactClicked.bind(this, output.uri, output.name)}>
-                        {output.name}
-                      </a>
-                    ))}
+            {visibleTargets.map((target) => (
+              <div>
+                <div className="artifact-section-title">{target.label}</div>
+                <div className="artifact-list">
+                  {target.outputs.map((output) => (
+                    <a
+                      href={rpcService.getBytestreamFileUrl(output.name, output.uri, this.props.model.getId())}
+                      className="artifact-name"
+                      onClick={this.handleArtifactClicked.bind(this, output.uri, output.name)}>
+                      {output.name}
+                    </a>
+                  ))}
+                  {target.hiddenOutputCount > 0 && (
+                    <div className="artifact-hidden-count">
+                      + {target.hiddenOutputCount} more {target.hiddenOutputCount === 1 ? "artifact" : "artifacts"} for
+                      this target
+                    </div>
+                  )}
                 </div>
-              ))}
-            {targets.flatMap((completed) => completed.completed.importantOutput).length == 0 && (
-              <span>{this.props.filter ? "No matching artifacts" : "No artifacts"}</span>
+              </div>
+            ))}
+            {hiddenTargetCount > 0 && (
+              <div className="artifact-hidden-count">
+                + {hiddenTargetCount} more {hiddenTargetCount === 1 ? "target" : "targets"} with artifacts
+              </div>
             )}
+            {totalOutputCount === 0 && <span>{this.props.filter ? "No matching artifacts" : "No artifacts"}</span>}
           </div>
-          {this.props.pageSize && targets.length > this.state.numPages * this.props.pageSize && !!this.state.numPages && (
+          {this.props.pageSize && visibleOutputCount < totalOutputCount && (
             <div className="more" onClick={this.handleMoreArtifactsClicked.bind(this)}>
               See more artifacts
             </div>

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1078,7 +1078,7 @@ code .comment {
 }
 
 .artifacts .artifact-hidden-count {
-  color: #9e9e9e;
+  color: #bdbdbd;
   margin-bottom: 8px;
 }
 

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -523,8 +523,9 @@ button {
 .card .more {
   margin-top: 16px;
   font-weight: 600;
-  color: #aaa;
+  color: #263238;
   cursor: pointer;
+  user-select: none;
 }
 
 .card-suggestion-message {
@@ -1059,15 +1060,26 @@ code .comment {
 .artifact-name {
   font-weight: 600;
   text-decoration: underline;
-  margin-left: 32px;
-  margin-top: 4px;
   cursor: pointer;
   display: block;
 }
 
 .artifact-section-title {
-  color: #aaa;
+  color: #757575;
   margin-top: 8px;
+}
+
+.artifacts .artifact-list {
+  padding-left: 32px;
+}
+
+.artifacts :is(.artifact-name, .artifact-hidden-count) {
+  margin-top: 4px;
+}
+
+.artifacts .artifact-hidden-count {
+  color: #9e9e9e;
+  margin-bottom: 8px;
 }
 
 .stat-cards {


### PR DESCRIPTION
Some targets have a large number of outputs, which causes the UI spend a long time rendering. This change shaves about 5s off of the page load time for our infamous 13 second invocation, and also reduces the time it takes to switch between the "app" and "artifacts" tabs from O(seconds) to O(~100ms).

Since we now only partially load targets, this PR adds little indicators in the list to make it clear that we're not showing all artifacts from each target.

---

![image](https://user-images.githubusercontent.com/2414826/126557626-c85c253f-ee46-425c-be2a-30d96db4811b.png)
---

Also fixed artifact filtering, which was broken in a previous PR but was unnoticed.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/661
