### PR TITLE
Buffer chunked event logs for ANSI cursor modification

### DIFF
--- a/server/build_event_protocol/build_event_handler/BUILD
+++ b/server/build_event_protocol/build_event_handler/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//server/metrics",
         "//server/remote_cache/hit_tracker",
         "//server/tables",
-        "//server/terminal",
         "//server/util/log",
         "//server/util/perms",
         "//server/util/protofile",

--- a/server/build_event_protocol/build_event_handler/BUILD
+++ b/server/build_event_protocol/build_event_handler/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//proto:invocation_go_proto",
         "//proto:publish_build_event_go_proto",
         "//proto:user_id_go_proto",
-        "//server/backends/chunkstore",
         "//server/build_event_protocol/accumulator",
         "//server/build_event_protocol/build_status_reporter",
         "//server/build_event_protocol/event_parser",

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -172,7 +172,9 @@ func (e *EventChannel) MarkInvocationDisconnected(ctx context.Context, iid strin
 		return err
 	}
 	if e.logWriter != nil {
-		e.logWriter.Close()
+		if err := e.logWriter.Close(); err != nil {
+			return err
+		}
 		invocation.LastChunkId = chunkstore.ChunkIndexAsStringId(e.logWriter.ChunkstoreWriter.GetLastChunkIndex())
 	}
 
@@ -239,7 +241,9 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 		return err
 	}
 	if e.logWriter != nil {
-		e.logWriter.Close()
+		if err := e.logWriter.Close(); err != nil {
+			return err
+		}
 		invocation.LastChunkId = chunkstore.ChunkIndexAsStringId(e.logWriter.ChunkstoreWriter.GetLastChunkIndex())
 	}
 

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -172,6 +172,7 @@ func (e *EventChannel) MarkInvocationDisconnected(ctx context.Context, iid strin
 		return err
 	}
 	if e.logWriter != nil {
+		e.logWriter.Close()
 		invocation.LastChunkId = chunkstore.ChunkIndexAsStringId(e.logWriter.ChunkstoreWriter.GetLastChunkIndex())
 	}
 
@@ -238,6 +239,7 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 		return err
 	}
 	if e.logWriter != nil {
+		e.logWriter.Close()
 		invocation.LastChunkId = chunkstore.ChunkIndexAsStringId(e.logWriter.ChunkstoreWriter.GetLastChunkIndex())
 	}
 
@@ -289,9 +291,6 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 	iid := streamID.InvocationId
 
 	if isFinalEvent(event.OrderedBuildEvent) {
-		if e.logWriter != nil {
-			e.logWriter.Close()
-		}
 		return nil
 	}
 

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/server/backends/chunkstore"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/accumulator"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_status_reporter"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/event_parser"
@@ -175,7 +174,7 @@ func (e *EventChannel) MarkInvocationDisconnected(ctx context.Context, iid strin
 		if err := e.logWriter.Close(); err != nil {
 			return err
 		}
-		invocation.LastChunkId = chunkstore.ChunkIndexAsStringId(e.logWriter.ChunkstoreWriter.GetLastChunkIndex())
+		invocation.LastChunkId = e.logWriter.GetLastChunkId()
 	}
 
 	ti := tableInvocationFromProto(invocation, iid)
@@ -244,7 +243,7 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 		if err := e.logWriter.Close(); err != nil {
 			return err
 		}
-		invocation.LastChunkId = chunkstore.ChunkIndexAsStringId(e.logWriter.ChunkstoreWriter.GetLastChunkIndex())
+		invocation.LastChunkId = e.logWriter.GetLastChunkId()
 	}
 
 	ti := tableInvocationFromProto(invocation, iid)
@@ -341,7 +340,7 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 		}
 
 		if e.logWriter != nil {
-			ti.LastChunkId = chunkstore.ChunkIndexAsStringId(e.logWriter.ChunkstoreWriter.GetLastChunkIndex())
+			ti.LastChunkId = e.logWriter.GetLastChunkId()
 		}
 		if err := e.env.GetInvocationDB().InsertOrUpdateInvocation(e.ctx, ti); err != nil {
 			return err
@@ -429,7 +428,7 @@ func (e *EventChannel) writeBuildMetadata(ctx context.Context, invocationID stri
 		return err
 	}
 	if e.logWriter != nil {
-		invocationProto.LastChunkId = chunkstore.ChunkIndexAsStringId(e.logWriter.ChunkstoreWriter.GetLastChunkIndex())
+		invocationProto.LastChunkId = e.logWriter.GetLastChunkId()
 	}
 	ti = tableInvocationFromProto(invocationProto, ti.BlobID)
 	if err := db.InsertOrUpdateInvocation(ctx, ti); err != nil {

--- a/server/eventlog/BUILD
+++ b/server/eventlog/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//server/backends/chunkstore",
         "//server/environment",
         "//server/interfaces",
+        "//server/terminal",
         "//server/util/status",
     ],
 )

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -149,14 +149,12 @@ func GetEventLogChunk(ctx context.Context, env environment.Env, req *elpb.GetEve
 }
 
 func NewEventLogWriter(ctx context.Context, b interfaces.Blobstore, invocationId string) *EventLogWriter {
-	cw := chunkstore.New(
-		b,
-		&chunkstore.ChunkstoreOptions{
-			WriteBlockSize:       defaultLogChunkSize,
-			WriteTimeoutDuration: defaultChunkTimeout,
-			NoSplitWrite:         true,
-		},
-	).Writer(ctx, getEventLogPathFromInvocationId(invocationId))
+	chunkstoreOptions := &chunkstore.ChunkstoreOptions{
+		WriteBlockSize:       defaultLogChunkSize,
+		WriteTimeoutDuration: defaultChunkTimeout,
+		NoSplitWrite:         true,
+	}
+	cw := chunkstore.New(b,chunkstoreOptions).Writer(ctx, getEventLogPathFromInvocationId(invocationId))
 	return &EventLogWriter{
 		WriteCloser: &ANSICursorBufferWriter{
 			WriteCloser:  cw,

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -160,15 +160,18 @@ func NewEventLogWriter(ctx context.Context, b interfaces.Blobstore, invocationId
 			WriteCloser:  cw,
 			screenWriter: terminal.NewScreenWriter(),
 		},
-		ChunkstoreWriter: cw,
+		chunkstoreWriter: cw,
 	}
 }
 
 type EventLogWriter struct {
 	io.WriteCloser
-	ChunkstoreWriter *chunkstore.ChunkstoreWriter
+	chunkstoreWriter *chunkstore.ChunkstoreWriter
 }
 
+func (w *EventLogWriter) GetLastChunkId() string {
+	return chunkstore.ChunkIndexAsStringId(w.chunkstoreWriter.GetLastChunkIndex())
+}
 
 // Parses text passed into it as ANSI text and flushes it to the WriteCloser,
 // retaining a buffer of the last N lines. On Close, all lines are flushed. This

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -154,7 +154,7 @@ func NewEventLogWriter(ctx context.Context, b interfaces.Blobstore, invocationId
 		WriteTimeoutDuration: defaultChunkTimeout,
 		NoSplitWrite:         true,
 	}
-	cw := chunkstore.New(b,chunkstoreOptions).Writer(ctx, getEventLogPathFromInvocationId(invocationId))
+	cw := chunkstore.New(b, chunkstoreOptions).Writer(ctx, getEventLogPathFromInvocationId(invocationId))
 	return &EventLogWriter{
 		WriteCloser: &ANSICursorBufferWriter{
 			WriteCloser:  cw,

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -169,9 +169,6 @@ type EventLogWriter struct {
 	ChunkstoreWriter *chunkstore.ChunkstoreWriter
 }
 
-func (w *EventLogWriter) Write(p []byte) (int, error) {
-	return w.WriteCloser.Write(p)
-}
 
 // Parses text passed into it as ANSI text and flushes it to the WriteCloser,
 // retaining a buffer of the last N lines. On Close, all lines are flushed. This
@@ -201,8 +198,4 @@ func (w *ANSICursorBufferWriter) Close() error {
 		return err
 	}
 	return w.WriteCloser.Close()
-}
-
-type ANSILineWriter struct {
-	io.WriteCloser
 }

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -173,6 +173,10 @@ func (w *EventLogWriter) Write(p []byte) (int, error) {
 	return w.WriteCloser.Write(p)
 }
 
+// Parses text passed into it as ANSI text and flushes it to the WriteCloser,
+// retaining a buffer of the last N lines. On Close, all lines are flushed. This
+// is necessary so that ANSI cursor control sequences can freely modify the last
+// N lines.
 type ANSICursorBufferWriter struct {
 	io.WriteCloser
 	screenWriter *terminal.ScreenWriter

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -159,7 +159,7 @@ func NewEventLogWriter(ctx context.Context, b interfaces.Blobstore, invocationId
 	).Writer(ctx, getEventLogPathFromInvocationId(invocationId))
 	return &EventLogWriter{
 		WriteCloser: &ANSICursorBufferWriter{
-			WriteCloser: cw,
+			WriteCloser:  cw,
 			screenWriter: terminal.NewScreenWriter(),
 		},
 		ChunkstoreWriter: cw,
@@ -180,7 +180,7 @@ type ANSICursorBufferWriter struct {
 	screenWriter *terminal.ScreenWriter
 }
 
-func (w* ANSICursorBufferWriter) Write(p []byte) (int, error) {
+func (w *ANSICursorBufferWriter) Write(p []byte) (int, error) {
 	if p == nil || len(p) == 0 {
 		return w.WriteCloser.Write(p)
 	}
@@ -194,7 +194,7 @@ func (w* ANSICursorBufferWriter) Write(p []byte) (int, error) {
 	return w.WriteCloser.Write(append(popped, '\n'))
 }
 
-func (w* ANSICursorBufferWriter) Close() error {
+func (w *ANSICursorBufferWriter) Close() error {
 	if _, err := w.WriteCloser.Write(w.screenWriter.RenderAsANSI()); err != nil {
 		return err
 	}

--- a/server/terminal/screen.go
+++ b/server/terminal/screen.go
@@ -198,3 +198,14 @@ func (s *screen) backspace() {
 		s.x--
 	}
 }
+
+func (s *screen) popExtraLines(linesToRetain int) []byte {
+	extraLines := len(s.screen) - linesToRetain
+	if extraLines < 1 {
+		return []byte{}
+	}
+	poppedLines := (&screen{screen: s.screen[:extraLines]}).asANSI()
+	s.screen = s.screen[extraLines:]
+	s.y -= extraLines
+	return poppedLines
+}

--- a/server/terminal/terminal.go
+++ b/server/terminal/terminal.go
@@ -39,3 +39,7 @@ func (sw *ScreenWriter) Write(data []byte) (int, error) {
 func (sw *ScreenWriter) RenderAsANSI() []byte {
 	return sw.s.asANSI()
 }
+
+func (sw *ScreenWriter) PopExtraLinesAsANSI(linesToRetain int) []byte {
+	return sw.s.popExtraLines(linesToRetain)
+}


### PR DESCRIPTION

Buffer the logs so that ANSI can update the last six lines

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Adds a sub-writer to the event log writer that renders ANSI text and maintains a buffer of
the last 6 lines, flushing the preceding lines to the standard witer pipeline.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
