### PR TITLE
Add Redactor skeleton for migrating redaction logic from event_parser

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -72,13 +72,12 @@ func (b *BuildEventHandler) OpenChannel(ctx context.Context, iid string) interfa
 		chunkFileSizeBytes = defaultChunkFileSizeBytes
 	}
 	buildEventAccumulator := accumulator.NewBEValues(iid)
-	redactor := redact.NewStreamingRedactor(b.env)
 	return &EventChannel{
 		env:                     b.env,
 		ctx:                     ctx,
 		pw:                      protofile.NewBufferedProtoWriter(b.env.GetBlobstore(), iid, chunkFileSizeBytes),
 		beValues:                buildEventAccumulator,
-		redactor:                redactor,
+		redactor:                redact.NewStreamingRedactor(b.env),
 		statusReporter:          build_status_reporter.NewBuildStatusReporter(b.env, buildEventAccumulator),
 		targetTracker:           target_tracker.NewTargetTracker(b.env, buildEventAccumulator),
 		hasReceivedStartedEvent: false,

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -72,11 +72,13 @@ func (b *BuildEventHandler) OpenChannel(ctx context.Context, iid string) interfa
 		chunkFileSizeBytes = defaultChunkFileSizeBytes
 	}
 	buildEventAccumulator := accumulator.NewBEValues(iid)
+	redactor := redact.NewStreamingRedactor(b.env)
 	return &EventChannel{
 		env:                     b.env,
 		ctx:                     ctx,
 		pw:                      protofile.NewBufferedProtoWriter(b.env.GetBlobstore(), iid, chunkFileSizeBytes),
 		beValues:                buildEventAccumulator,
+		redactor:                redactor,
 		statusReporter:          build_status_reporter.NewBuildStatusReporter(b.env, buildEventAccumulator),
 		targetTracker:           target_tracker.NewTargetTracker(b.env, buildEventAccumulator),
 		hasReceivedStartedEvent: false,
@@ -127,6 +129,7 @@ type EventChannel struct {
 	env                     environment.Env
 	pw                      *protofile.BufferedProtoWriter
 	beValues                *accumulator.BEValues
+	redactor                *redact.StreamingRedactor
 	statusReporter          *build_status_reporter.BuildStatusReporter
 	targetTracker           *target_tracker.TargetTracker
 	eventsBeforeStarted     []*inpb.InvocationEvent
@@ -136,12 +139,16 @@ type EventChannel struct {
 
 func (e *EventChannel) fillInvocationFromEvents(ctx context.Context, iid string, invocation *inpb.Invocation) error {
 	pr := protofile.NewBufferedProtoReader(e.env.GetBlobstore(), iid)
+	redactor := redact.NewStreamingRedactor(e.env)
 	parser := event_parser.NewStreamingEventParser()
 	parser.FillInvocation(invocation)
 	for {
 		event := &inpb.InvocationEvent{}
 		err := pr.ReadProto(ctx, event)
 		if err == nil {
+			if !*enableOptimizedRedaction {
+				redactor.RedactMetadata(event.BuildEvent)
+			}
 			parser.ParseEvent(event)
 		} else if err == io.EOF {
 			break
@@ -319,7 +326,7 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 			InvocationStatus: int64(inpb.Invocation_PARTIAL_INVOCATION_STATUS),
 		}
 		if *enableOptimizedRedaction {
-			ti.RedactionFlags = redact.RedactionFlagAPIKey
+			ti.RedactionFlags = redact.RedactionFlagStandardRedactions
 		}
 
 		if auth := e.env.GetAuthenticator(); auth != nil {
@@ -365,9 +372,10 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 
 func (e *EventChannel) processSingleEvent(event *inpb.InvocationEvent, iid string) error {
 	if *enableOptimizedRedaction {
-		if err := redact.APIKey(e.ctx, e.env, event.BuildEvent); err != nil {
+		if err := e.redactor.RedactAPIKey(e.ctx, event.BuildEvent); err != nil {
 			return err
 		}
+		e.redactor.RedactMetadata(event.BuildEvent)
 	}
 
 	e.beValues.AddEvent(event.BuildEvent) // in-memory structure to hold common values we want from the event.
@@ -456,6 +464,7 @@ func LookupInvocation(env environment.Env, ctx context.Context, iid string) (*in
 
 	invocation := TableInvocationToProto(ti)
 
+	redactor := redact.NewStreamingRedactor(env)
 	parser := event_parser.NewStreamingEventParser()
 	pr := protofile.NewBufferedProtoReader(env.GetBlobstore(), iid)
 	for {
@@ -468,10 +477,11 @@ func LookupInvocation(env environment.Env, ctx context.Context, iid string) (*in
 			log.Warningf("Error reading proto from log: %s", err)
 			return nil, err
 		}
-		if !*enableOptimizedRedaction || ti.RedactionFlags&redact.RedactionFlagAPIKey == 0 {
-			if err := redact.APIKeysWithSlowRegexp(ctx, env, event.BuildEvent); err != nil {
+		if !*enableOptimizedRedaction || ti.RedactionFlags&redact.RedactionFlagStandardRedactions == 0 {
+			if err := redactor.RedactAPIKeysWithSlowRegexp(ctx, event.BuildEvent); err != nil {
 				return nil, err
 			}
+			redactor.RedactMetadata(event.BuildEvent)
 		}
 		parser.ParseEvent(event)
 	}
@@ -511,7 +521,7 @@ func tableInvocationFromProto(p *inpb.Invocation, blobID string) *tables.Invocat
 	}
 	i.LastChunkId = p.LastChunkId
 	if *enableOptimizedRedaction {
-		i.RedactionFlags = redact.RedactionFlagAPIKey
+		i.RedactionFlags = redact.RedactionFlagStandardRedactions
 	}
 	return i
 }

--- a/server/util/redact/redact.go
+++ b/server/util/redact/redact.go
@@ -9,7 +9,6 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	bespb "github.com/buildbuddy-io/buildbuddy/proto/bespb"
-	clpb "github.com/buildbuddy-io/buildbuddy/proto/command_line"
 )
 
 const (

--- a/server/util/redact/redact.go
+++ b/server/util/redact/redact.go
@@ -8,7 +8,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/golang/protobuf/proto"
 
-	bespb "github.com/buildbuddy-io/buildbuddy/proto/bespb"
+	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 )
 
 const (


### PR DESCRIPTION
This PR is a NOP for now but lays the groundwork for us to be able to factor the redaction logic out of `StreamingEventParser.ParseEvent` (and into `StreamingRedactor.RedactMetadata`) without breaking anything.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
