### PR TITLE
Use hash of js bundle in the `js_entry_point_path`

### DIFF
--- a/enterprise/BUILD
+++ b/enterprise/BUILD
@@ -50,6 +50,7 @@ go_library(
         "//conditions:default": [
             "//enterprise/app:app_bundle",
             "//enterprise/app:style",
+            "//enterprise/app:sha",
         ],
     }),
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise",

--- a/enterprise/app/BUILD.bazel
+++ b/enterprise/app/BUILD.bazel
@@ -73,3 +73,10 @@ genrule(
         cat out > $@;
     """,
 )
+
+load("//rules/sha:index.bzl", "sha")
+
+sha(
+    name = "sha",
+    srcs = ["//enterprise/app:app_bundle"],
+)

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -62,6 +62,7 @@ go_binary(
         "//enterprise:config_files",
         "//enterprise:licenses",
         "//enterprise/app:app_bundle",
+        "//enterprise/app:sha",
         "//enterprise/app:style",
         "//static",
     ],

--- a/rules/sha/index.bzl
+++ b/rules/sha/index.bzl
@@ -4,7 +4,7 @@ def sha(name, srcs, **kwargs):
         name = name,
         srcs = srcs,
         outs = [name + ".sum"],
-        cmd = "echo \"$(SRCS)\" | xargs find | sort | xargs shasum | shasum | awk '{ print $$1 } > $@",
+        cmd = "echo \"$(SRCS)\" | xargs find | sort | xargs shasum | shasum | awk '{ print $$1 }' > $@",
         local = 1,
         **kwargs
     )

--- a/rules/sha/index.bzl
+++ b/rules/sha/index.bzl
@@ -1,5 +1,4 @@
-"""Calculates the sha1 of the contents of the files in `srcs` and outputs it to a file called `name`.sum"""
-
+# Calculates the sha1 of the contents of the files in `srcs` and outputs it to a file called `name`.sum.
 def sha(name, srcs, **kwargs):
     native.genrule(
         name = name,

--- a/rules/sha/index.bzl
+++ b/rules/sha/index.bzl
@@ -4,7 +4,7 @@ def sha(name, srcs, **kwargs):
         name = name,
         srcs = srcs,
         outs = [name + ".sum"],
-        cmd = "echo \"$(SRCS)\" | xargs find | sort | xargs shasum | shasum | awk '{ print $$1 }' > $@",
+        cmd = "xargs find $(SRCS) -type f | sort | xargs shasum | shasum | awk '{ print $$1 }' > $@",
         local = 1,
         **kwargs
     )

--- a/rules/sha/index.bzl
+++ b/rules/sha/index.bzl
@@ -4,7 +4,7 @@ def sha(name, srcs, **kwargs):
         name = name,
         srcs = srcs,
         outs = [name + ".sum"],
-        cmd = "xargs find $(SRCS) -type f | sort | xargs shasum | shasum | awk '{ print $$1 }' > $@",
+        cmd = "find $(SRCS) -type f | sort | xargs shasum | shasum | awk '{ print $$1 }' > $@",
         local = 1,
         **kwargs
     )

--- a/rules/sha/index.bzl
+++ b/rules/sha/index.bzl
@@ -1,0 +1,9 @@
+def sha(name, srcs, **kwargs):
+    native.genrule(
+        name = name,
+        srcs = srcs,
+        outs = [name + ".txt"],
+        cmd = "echo \"$$(echo \"$(SRCS)\" | xargs find | sort | xargs shasum | shasum | awk '{ print $$1 }')\" > $@",
+        local = 1,
+        **kwargs
+    )

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -324,7 +324,12 @@ func StartAndRunServices(env environment.Env) {
 		log.Printf("Error raising open files limit: %s", err)
 	}
 
-	staticFileServer, err := static.NewStaticFileServer(env, env.GetStaticFilesystem(), appRoutes, static.AppBundleHash(env.GetAppFilesystem()))
+	appBundleHash, err := static.AppBundleHash(env.GetAppFilesystem())
+	if err != nil {
+		log.Fatalf("Error reading app bundle hash: %s", err)
+	}
+
+	staticFileServer, err := static.NewStaticFileServer(env, env.GetStaticFilesystem(), appRoutes, appBundleHash)
 	if err != nil {
 		log.Fatalf("Error initializing static file server: %s", err)
 	}

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -324,12 +324,12 @@ func StartAndRunServices(env environment.Env) {
 		log.Printf("Error raising open files limit: %s", err)
 	}
 
-	staticFileServer, err := static.NewStaticFileServer(env, env.GetStaticFilesystem(), appRoutes)
+	staticFileServer, err := static.NewStaticFileServer(env, env.GetStaticFilesystem(), appRoutes, static.AppBundleHash(env.GetAppFilesystem()))
 	if err != nil {
 		log.Fatalf("Error initializing static file server: %s", err)
 	}
 
-	afs, err := static.NewStaticFileServer(env, env.GetAppFilesystem(), []string{})
+	afs, err := static.NewStaticFileServer(env, env.GetAppFilesystem(), []string{}, "")
 	if err != nil {
 		log.Fatalf("Error initializing app server: %s", err)
 	}

--- a/server/static/BUILD
+++ b/server/static/BUILD
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//proto:config_go_proto",
         "//server/environment",
+        "//server/util/status",
         "//server/version",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -60,7 +60,7 @@ func NewStaticFileServer(env environment.Env, fs fs.FS, rootPaths []string, appB
 		}
 
 		if strings.HasPrefix(jsPath, "http://") || strings.HasPrefix(jsPath, "https://") {
-			env.GetHealthChecker().AddHealthCheck("static_bundle", &healthChecker{jsPath: jsPath})
+			env.GetHealthChecker().AddHealthCheck("app_static_file_server", &healthChecker{jsPath: jsPath})
 		}
 
 		handler = handleRootPaths(env, rootPaths, template, version.AppVersion(), jsPath, handler)
@@ -139,15 +139,12 @@ func serveIndexTemplate(env environment.Env, tpl *template.Template, version str
 	}
 }
 
-func AppBundleHash(bundleFS fs.FS) string {
-	var hashBytes []byte
-	if data, err := fs.ReadFile(bundleFS, "sha.sum"); err == nil {
-		hashBytes = data
+func AppBundleHash(bundleFS fs.FS) (string, error) {
+	hashBytes, err := fs.ReadFile(bundleFS, "sha.sum")
+	if err != nil {
+		return "", err
 	}
-	if hashBytes != nil {
-		return strings.TrimSpace(string(hashBytes))
-	}
-	return ""
+	return strings.TrimSpace(string(hashBytes)), nil
 }
 
 type healthChecker struct {

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -135,7 +135,7 @@ func serveIndexTemplate(env environment.Env, tpl *template.Template, version str
 
 func AppBundleHash(bundleFS fs.FS) string {
 	var hashBytes []byte
-	if data, err := fs.ReadFile(bundleFS, "sha.txt"); err == nil {
+	if data, err := fs.ReadFile(bundleFS, "sha.sum"); err == nil {
 		hashBytes = data
 	}
 	if hashBytes != nil {


### PR DESCRIPTION
This replaces instance of `{APP_BUNDLE_HASH}` with that app bundle's hash in the `js_entry_point_path`.

We then place this as a query parameter when loading the default js bundle.

Like:
```
/app/app_bundle/app.js?hash=abc123
```

During local development, this means you should no longer have to force refresh when we make front-end changes and allows us to set aggressive cache headers.

In our production configs, this allows us to use the same variable to point do a CDN release like:
```
--js_entry_point_path=https://storage.googleapis.com/buildbuddy-static/app/{APP_BUNDLE_HASH}/app_bundle/app.js
```
or
```
--js_entry_point_path=https://static.buildbuddy.io/app/{APP_BUNDLE_HASH}/app_bundle/app.js
```

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
