### PR TITLE
Add tool for sanity checking JS bundle size diff

### DIFF
--- a/tools/js_size_diff.sh
+++ b/tools/js_size_diff.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 get_bundle_info() {
-  bazel build //enterprise/app:app_bundle >&2
+  bazel build -c opt //enterprise/app:app_bundle >&2
   local bundle_path="bazel-bin/enterprise/app/app_bundle/app.js"
   local size_bytes
   local compressed_size_bytes

--- a/tools/js_size_diff.sh
+++ b/tools/js_size_diff.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+get_bundle_info() {
+  bazel build //enterprise/app:app_bundle >&2
+  local bundle_path="bazel-bin/enterprise/app/app_bundle/app.js"
+  local size_bytes
+  local compressed_size_bytes
+  size_bytes=$(cat "$bundle_path" | wc -c)
+  compressed_size_bytes=$(cat "$bundle_path" | gzip | wc -c)
+
+  echo "{\"size_bytes\": $size_bytes, \"compressed_size_bytes\": $compressed_size_bytes}"
+}
+
+# Compute size AFTER (current dir)
+
+cd "$(dirname "$0")/.." # repo root
+after_info=$(get_bundle_info)
+
+# Compute size BEFORE
+
+: "${BEFORE_DIR:=}"
+if [[ -n "$BEFORE_DIR" ]]; then
+  cd "$BEFORE_DIR"
+else
+  cd "$(mktemp -d)"
+  pwd
+  tmpdir="$PWD"
+  cleanup() { rm -rf "$tmpdir"; }
+  trap cleanup EXIT
+  # Fresh clone repo to avoid messing with current working tree
+  git clone https://github.com/buildbuddy-io/buildbuddy --depth=1 .
+fi
+before_info=$(get_bundle_info)
+
+python3 -c "
+before = $before_info
+after = $after_info
+diff = {
+  'size_bytes': after['size_bytes'] - before['size_bytes'],
+  'compressed_size_bytes': after['compressed_size_bytes'] - before['compressed_size_bytes'],
+}
+
+def table(header, info):
+  print(header)
+  print('size (KB)\t%d' % (info['size_bytes'] / 1000))
+  print('gzipped (KB)\t%d' % (info['compressed_size_bytes'] / 1000))
+  print()
+
+table('BEFORE', before)
+table('AFTER', after)
+table('DIFF', diff)
+"


### PR DESCRIPTION
Example output:

```
BEFORE
size (KB)       4597
gzipped (KB)    814

AFTER
size (KB)       4746
gzipped (KB)    848

DIFF
size (KB)       148
gzipped (KB)    33
```

---

**Version bump**: TODO <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
