### PR TITLE
Move most basic redaction logic to StreamingRedactor

### DIFF
--- a/server/build_event_protocol/event_parser/event_parser_test.go
+++ b/server/build_event_protocol/event_parser/event_parser_test.go
@@ -15,7 +15,7 @@ func singleFile() *build_event_stream.File {
 	return &build_event_stream.File{
 		Name: "afile",
 		File: &build_event_stream.File_Uri{
-			Uri: "213wZJyTUyhXkj381312@uri",
+			Uri: "uri",
 		},
 	}
 }
@@ -42,7 +42,7 @@ func TestFillInvocation(t *testing.T) {
 	buildStarted := &build_event_stream.BuildStarted{
 		StartTimeMillis:    0,
 		Command:            "test",
-		OptionsDescription: "213wZJyTUyhXkj381312@foo",
+		OptionsDescription: "foo",
 	}
 	events = append(events, &inpb.InvocationEvent{
 		BuildEvent: &build_event_stream.BuildEvent{
@@ -92,8 +92,8 @@ func TestFillInvocation(t *testing.T) {
 	})
 
 	optionsParsed := &build_event_stream.OptionsParsed{
-		CmdLine:         []string{"213wZJyTUyhXkj381312@foo"},
-		ExplicitCmdLine: []string{"213wZJyTUyhXkj381312@explicit"},
+		CmdLine:         []string{"foo"},
+		ExplicitCmdLine: []string{"explicit"},
 	}
 	events = append(events, &inpb.InvocationEvent{
 		BuildEvent: &build_event_stream.BuildEvent{

--- a/server/util/redact/BUILD
+++ b/server/util/redact/BUILD
@@ -19,8 +19,6 @@ go_test(
         ":redact",
         "//proto:build_event_stream_go_proto",
         "//proto:command_line_go_proto",
-        "//proto:invocation_go_proto",
-        "//server/build_event_protocol/event_parser",
         "//server/testutil/testenv",
         "@com_github_stretchr_testify//assert",
     ],

--- a/server/util/redact/BUILD
+++ b/server/util/redact/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "redact",
@@ -9,5 +9,19 @@ go_library(
         "//proto:build_event_stream_go_proto",
         "//server/environment",
         "@com_github_golang_protobuf//proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "redact_test",
+    srcs = ["redact_test.go"],
+    deps = [
+        ":redact",
+        "//proto:build_event_stream_go_proto",
+        "//proto:command_line_go_proto",
+        "//proto:invocation_go_proto",
+        "//server/build_event_protocol/event_parser",
+        "//server/testutil/testenv",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/server/util/redact/redact.go
+++ b/server/util/redact/redact.go
@@ -56,7 +56,7 @@ func NewStreamingRedactor(env environment.Env) *StreamingRedactor {
 }
 
 func (r *StreamingRedactor) RedactMetadata(event *bespb.BuildEvent) {
-	switch p := event.BuildEvent.Payload.(type) {
+	switch p := event.Payload.(type) {
 	case *bespb.BuildEvent_Progress:
 		{
 		}
@@ -128,7 +128,6 @@ func (r *StreamingRedactor) RedactMetadata(event *bespb.BuildEvent) {
 		}
 	case *bespb.BuildEvent_BuildMetrics:
 		{
-			sep.actionCount = p.BuildMetrics.ActionSummary.ActionsExecuted
 		}
 	case *bespb.BuildEvent_WorkspaceInfo:
 		{

--- a/server/util/redact/redact.go
+++ b/server/util/redact/redact.go
@@ -15,6 +15,36 @@ const (
 	RedactionFlagStandardRedactions = 1
 )
 
+var (
+	urlSecretRegex = regexp.MustCompile(`[a-zA-Z-0-9-_=]+\@`)
+)
+
+func stripURLSecrets(input string) string {
+	return urlSecretRegex.ReplaceAllString(input, "")
+}
+
+func stripURLSecretsFromList(inputs []string) []string {
+	for index, input := range inputs {
+		inputs[index] = stripURLSecrets(input)
+	}
+	return inputs
+}
+
+func stripURLSecretsFromFile(file *bespb.File) *bespb.File {
+	switch p := file.GetFile().(type) {
+	case *bespb.File_Uri:
+		p.Uri = stripURLSecrets(p.Uri)
+	}
+	return file
+}
+
+func stripURLSecretsFromFiles(files []*bespb.File) []*bespb.File {
+	for index, file := range files {
+		files[index] = stripURLSecretsFromFile(file)
+	}
+	return files
+}
+
 // StreamingRedactor processes a stream of build events and redacts them as they are
 // received by the event handler.
 type StreamingRedactor struct {
@@ -26,7 +56,93 @@ func NewStreamingRedactor(env environment.Env) *StreamingRedactor {
 }
 
 func (r *StreamingRedactor) RedactMetadata(event *bespb.BuildEvent) {
-	// TODO(bduffs): Migrate redaction logic from parser.ParseEvent to here.
+	switch p := event.BuildEvent.Payload.(type) {
+	case *bespb.BuildEvent_Progress:
+		{
+		}
+	case *bespb.BuildEvent_Aborted:
+		{
+		}
+	case *bespb.BuildEvent_Started:
+		{
+			p.Started.OptionsDescription = stripURLSecrets(p.Started.OptionsDescription)
+		}
+	case *bespb.BuildEvent_UnstructuredCommandLine:
+		{
+			// Clear the unstructured command line so we don't have to redact it.
+			p.UnstructuredCommandLine.Args = []string{}
+		}
+	case *bespb.BuildEvent_StructuredCommandLine:
+		{
+		}
+	case *bespb.BuildEvent_OptionsParsed:
+		{
+			p.OptionsParsed.CmdLine = stripURLSecretsFromList(p.OptionsParsed.CmdLine)
+			p.OptionsParsed.ExplicitCmdLine = stripURLSecretsFromList(p.OptionsParsed.ExplicitCmdLine)
+		}
+	case *bespb.BuildEvent_WorkspaceStatus:
+		{
+		}
+	case *bespb.BuildEvent_Fetch:
+		{
+		}
+	case *bespb.BuildEvent_Configuration:
+		{
+		}
+	case *bespb.BuildEvent_Expanded:
+		{
+		}
+	case *bespb.BuildEvent_Configured:
+		{
+		}
+	case *bespb.BuildEvent_Action:
+		{
+			p.Action.Stdout = stripURLSecretsFromFile(p.Action.Stdout)
+			p.Action.Stderr = stripURLSecretsFromFile(p.Action.Stderr)
+			p.Action.PrimaryOutput = stripURLSecretsFromFile(p.Action.PrimaryOutput)
+			p.Action.ActionMetadataLogs = stripURLSecretsFromFiles(p.Action.ActionMetadataLogs)
+		}
+	case *bespb.BuildEvent_NamedSetOfFiles:
+		{
+			p.NamedSetOfFiles.Files = stripURLSecretsFromFiles(p.NamedSetOfFiles.Files)
+		}
+	case *bespb.BuildEvent_Completed:
+		{
+			p.Completed.ImportantOutput = stripURLSecretsFromFiles(p.Completed.ImportantOutput)
+		}
+	case *bespb.BuildEvent_TestResult:
+		{
+			p.TestResult.TestActionOutput = stripURLSecretsFromFiles(p.TestResult.TestActionOutput)
+		}
+	case *bespb.BuildEvent_TestSummary:
+		{
+			p.TestSummary.Passed = stripURLSecretsFromFiles(p.TestSummary.Passed)
+			p.TestSummary.Failed = stripURLSecretsFromFiles(p.TestSummary.Failed)
+		}
+	case *bespb.BuildEvent_Finished:
+		{
+		}
+	case *bespb.BuildEvent_BuildToolLogs:
+		{
+			p.BuildToolLogs.Log = stripURLSecretsFromFiles(p.BuildToolLogs.Log)
+		}
+	case *bespb.BuildEvent_BuildMetrics:
+		{
+			sep.actionCount = p.BuildMetrics.ActionSummary.ActionsExecuted
+		}
+	case *bespb.BuildEvent_WorkspaceInfo:
+		{
+		}
+	case *bespb.BuildEvent_BuildMetadata:
+		{
+		}
+	case *bespb.BuildEvent_ConvenienceSymlinksIdentified:
+		{
+		}
+	case *bespb.BuildEvent_WorkflowConfigured:
+		{
+		}
+	}
 	return
 }
 

--- a/server/util/redact/redact_test.go
+++ b/server/util/redact/redact_test.go
@@ -3,40 +3,54 @@ package redact_test
 import (
 	"testing"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	"github.com/buildbuddy-io/buildbuddy/proto/command_line"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/redact"
 	"github.com/stretchr/testify/assert"
+
+	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 )
 
-func singleFile() *build_event_stream.File {
-	return &build_event_stream.File{
-		Name: "afile",
-		File: &build_event_stream.File_Uri{
-			Uri: "213wZJyTUyhXkj381312@uri",
-		},
+func fileWithURI(uri string) *bespb.File {
+	return &bespb.File{
+		Name: "foo.txt",
+		File: &bespb.File_Uri{Uri: uri},
 	}
 }
 
-func singleFiles() []*build_event_stream.File {
-	return []*build_event_stream.File{
-		singleFile(),
-	}
-}
-
-func TestRedact(t *testing.T) {
+func TestRedactMetadata_BuildStarted_StripsSecrets(t *testing.T) {
 	redactor := redact.NewStreamingRedactor(testenv.GetTestEnv(t))
-
-	buildStarted := &build_event_stream.BuildStarted{
+	buildStarted := &bespb.BuildStarted{
 		OptionsDescription: "213wZJyTUyhXkj381312@foo",
 	}
-	redactor.RedactMetadata(&build_event_stream.BuildEvent{
-		Payload: &build_event_stream.BuildEvent_Started{Started: buildStarted},
+
+	redactor.RedactMetadata(&bespb.BuildEvent{
+		Payload: &bespb.BuildEvent_Started{Started: buildStarted},
 	})
 
 	assert.Equal(t, "foo", buildStarted.OptionsDescription)
+}
 
+func TestRedactMetadata_UnstructuredCommandLine_RemovesArgs(t *testing.T) {
+	redactor := redact.NewStreamingRedactor(testenv.GetTestEnv(t))
+	unstructuredCommandLine := &bespb.UnstructuredCommandLine{
+		Args: []string{"foo"},
+	}
+
+	redactor.RedactMetadata(&bespb.BuildEvent{
+		Payload: &bespb.BuildEvent_UnstructuredCommandLine{
+			UnstructuredCommandLine: unstructuredCommandLine,
+		},
+	})
+
+	assert.Equal(t, []string{}, unstructuredCommandLine.Args)
+}
+
+func TestRedactMetadata_StructuredCommandLine_RedactsEnvVars(t *testing.T) {
+	// TODO(bduffany): Migrate env redaction to redactor and enable.
+	t.Skip()
+
+	redactor := redact.NewStreamingRedactor(testenv.GetTestEnv(t))
 	shellOption := &command_line.Option{
 		CombinedForm: "--client_env=SHELL=/bin/bash",
 		OptionName:   "client_env",
@@ -63,103 +77,122 @@ func TestRedact(t *testing.T) {
 			},
 		},
 	}
-	redactor.RedactMetadata(&build_event_stream.BuildEvent{
-		Payload: &build_event_stream.BuildEvent_StructuredCommandLine{StructuredCommandLine: structuredCommandLine},
+
+	redactor.RedactMetadata(&bespb.BuildEvent{
+		Payload: &bespb.BuildEvent_StructuredCommandLine{StructuredCommandLine: structuredCommandLine},
 	})
 
-	// TODO(bduffs): Migrate env redaction to redactor and enable these assertions.
-	// assert.Equal(t, "--client_env=SECRET=<REDACTED>", secretOption.OptionValue)
-	// assert.Equal(t, "secret=<REDACTED>", secretOption.OptionValue)
+	assert.Equal(t, "--client_env=SECRET=<REDACTED>", secretOption.OptionValue)
+	assert.Equal(t, "secret=<REDACTED>", secretOption.OptionValue)
+}
 
-	optionsParsed := &build_event_stream.OptionsParsed{
+func TestRedactMetadata_OptionsParsed_StripsURLSecrets(t *testing.T) {
+	redactor := redact.NewStreamingRedactor(testenv.GetTestEnv(t))
+	optionsParsed := &bespb.OptionsParsed{
 		CmdLine:         []string{"213wZJyTUyhXkj381312@foo"},
 		ExplicitCmdLine: []string{"213wZJyTUyhXkj381312@explicit"},
 	}
-	redactor.RedactMetadata(&build_event_stream.BuildEvent{
-		Payload: &build_event_stream.BuildEvent_OptionsParsed{OptionsParsed: optionsParsed},
+
+	redactor.RedactMetadata(&bespb.BuildEvent{
+		Payload: &bespb.BuildEvent_OptionsParsed{OptionsParsed: optionsParsed},
 	})
 
 	assert.Equal(t, []string{"foo"}, optionsParsed.CmdLine)
 	assert.Equal(t, []string{"explicit"}, optionsParsed.ExplicitCmdLine)
+}
 
-	actionExecuted := &build_event_stream.ActionExecuted{
-		Stdout:             singleFile(),
-		Stderr:             singleFile(),
-		PrimaryOutput:      singleFile(),
-		ActionMetadataLogs: singleFiles(),
+func TestRedactMetadata_ActionExecuted_StripsURLSecrets(t *testing.T) {
+	redactor := redact.NewStreamingRedactor(testenv.GetTestEnv(t))
+	actionExecuted := &bespb.ActionExecuted{
+		Stdout:             fileWithURI("213wZJyTUyhXkj381312@uri"),
+		Stderr:             fileWithURI("213wZJyTUyhXkj381312@uri"),
+		PrimaryOutput:      fileWithURI("213wZJyTUyhXkj381312@uri"),
+		ActionMetadataLogs: []*bespb.File{fileWithURI("213wZJyTUyhXkj381312@uri")},
 	}
-	redactor.RedactMetadata(&build_event_stream.BuildEvent{
-		Payload: &build_event_stream.BuildEvent_Action{Action: actionExecuted},
+
+	redactor.RedactMetadata(&bespb.BuildEvent{
+		Payload: &bespb.BuildEvent_Action{Action: actionExecuted},
 	})
 
 	assert.Equal(t, "uri", actionExecuted.Stdout.GetUri())
 	assert.Equal(t, "uri", actionExecuted.Stderr.GetUri())
 	assert.Equal(t, "uri", actionExecuted.PrimaryOutput.GetUri())
 	assert.Equal(t, "uri", actionExecuted.ActionMetadataLogs[0].GetUri())
+}
 
-	namedSetOfFiles := &build_event_stream.NamedSetOfFiles{
-		Files: singleFiles(),
+func TestRedactMetadata_NamedSetOfFiles_StripsURLSecrets(t *testing.T) {
+	redactor := redact.NewStreamingRedactor(testenv.GetTestEnv(t))
+	namedSetOfFiles := &bespb.NamedSetOfFiles{
+		Files: []*bespb.File{fileWithURI("213wZJyTUyhXkj381312@uri")},
 	}
-	redactor.RedactMetadata(&build_event_stream.BuildEvent{
-		Payload: &build_event_stream.BuildEvent_NamedSetOfFiles{NamedSetOfFiles: namedSetOfFiles},
+
+	redactor.RedactMetadata(&bespb.BuildEvent{
+		Payload: &bespb.BuildEvent_NamedSetOfFiles{NamedSetOfFiles: namedSetOfFiles},
 	})
 
 	assert.Equal(t, "uri", namedSetOfFiles.Files[0].GetUri())
+}
 
-	targetComplete := &build_event_stream.TargetComplete{
+func TestRedactMetadata_TargetComplete_StripsURLSecrets(t *testing.T) {
+	redactor := redact.NewStreamingRedactor(testenv.GetTestEnv(t))
+	targetComplete := &bespb.TargetComplete{
 		Success:         true,
-		ImportantOutput: singleFiles(),
+		ImportantOutput: []*bespb.File{fileWithURI("213wZJyTUyhXkj381312@uri")},
 	}
-	redactor.RedactMetadata(&build_event_stream.BuildEvent{
-		Payload: &build_event_stream.BuildEvent_Completed{Completed: targetComplete},
+
+	redactor.RedactMetadata(&bespb.BuildEvent{
+		Payload: &bespb.BuildEvent_Completed{Completed: targetComplete},
 	})
 
 	assert.Equal(t, "uri", targetComplete.ImportantOutput[0].GetUri())
+}
 
-	testResult := &build_event_stream.TestResult{
-		Status:           build_event_stream.TestStatus_PASSED,
-		TestActionOutput: singleFiles(),
+func TestRedactMetadata_TestResult_StripsURLSecrets(t *testing.T) {
+	redactor := redact.NewStreamingRedactor(testenv.GetTestEnv(t))
+	testResult := &bespb.TestResult{
+		Status:           bespb.TestStatus_PASSED,
+		TestActionOutput: []*bespb.File{fileWithURI("213wZJyTUyhXkj381312@uri")},
 	}
-	redactor.RedactMetadata(&build_event_stream.BuildEvent{
-		Payload: &build_event_stream.BuildEvent_TestResult{TestResult: testResult},
+
+	redactor.RedactMetadata(&bespb.BuildEvent{
+		Payload: &bespb.BuildEvent_TestResult{TestResult: testResult},
 	})
 
 	assert.Equal(t, "uri", testResult.TestActionOutput[0].GetUri())
+}
 
-	testSummary := &build_event_stream.TestSummary{
-		Passed: singleFiles(),
-		Failed: singleFiles(),
+func TestRedactMetadata_TestSummary_StripsURLSecrets(t *testing.T) {
+	redactor := redact.NewStreamingRedactor(testenv.GetTestEnv(t))
+	testSummary := &bespb.TestSummary{
+		Passed: []*bespb.File{fileWithURI("213wZJyTUyhXkj381312@uri")},
+		Failed: []*bespb.File{fileWithURI("213wZJyTUyhXkj381312@uri")},
 	}
-	redactor.RedactMetadata(&build_event_stream.BuildEvent{
-		Payload: &build_event_stream.BuildEvent_TestSummary{TestSummary: testSummary},
+
+	redactor.RedactMetadata(&bespb.BuildEvent{
+		Payload: &bespb.BuildEvent_TestSummary{TestSummary: testSummary},
 	})
 
 	assert.Equal(t, "uri", testSummary.Passed[0].GetUri())
 	assert.Equal(t, "uri", testSummary.Failed[0].GetUri())
+}
 
-	buildFinished := &build_event_stream.BuildFinished{
-		FinishTimeMillis: 1,
-		ExitCode: &build_event_stream.BuildFinished_ExitCode{
-			Name: "Success",
-			Code: 0,
-		},
-	}
-	redactor.RedactMetadata(&build_event_stream.BuildEvent{
-		Payload: &build_event_stream.BuildEvent_Finished{Finished: buildFinished},
-	})
+func TestRedactMetadata_BuildMetadata_StripsURLSecrets(t *testing.T) {
+	// TODO(bduffany): Migrate BuildMetadata redaction from event_parser to redactor
+	// and enable.
+	t.Skip()
 
-	buildMetadata := &build_event_stream.BuildMetadata{
+	redactor := redact.NewStreamingRedactor(testenv.GetTestEnv(t))
+	buildMetadata := &bespb.BuildMetadata{
 		Metadata: map[string]string{
 			"ALLOW_ENV": "SHELL",
 			"ROLE":      "METADATA_CI",
 			"REPO_URL":  "https://USERNAME:PASSWORD@github.com/buildbuddy-io/metadata_repo_url",
 		},
 	}
-	redactor.RedactMetadata(&build_event_stream.BuildEvent{
-		Payload: &build_event_stream.BuildEvent_BuildMetadata{BuildMetadata: buildMetadata},
+
+	redactor.RedactMetadata(&bespb.BuildEvent{
+		Payload: &bespb.BuildEvent_BuildMetadata{BuildMetadata: buildMetadata},
 	})
 
-	// TODO(bduffs): Migrate BuildMetadata redaction from event_parser to redactor
-	// and enable this assertion.
-	// assert.Equal(t, "https://github.com/buildbuddy-io/metadata_repo_url", buildMetadata.Metadata["REPO_URL"])
+	assert.Equal(t, "https://github.com/buildbuddy-io/metadata_repo_url", buildMetadata.Metadata["REPO_URL"])
 }

--- a/server/util/redact/redact_test.go
+++ b/server/util/redact/redact_test.go
@@ -1,0 +1,165 @@
+package redact_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
+	"github.com/buildbuddy-io/buildbuddy/proto/command_line"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/redact"
+	"github.com/stretchr/testify/assert"
+)
+
+func singleFile() *build_event_stream.File {
+	return &build_event_stream.File{
+		Name: "afile",
+		File: &build_event_stream.File_Uri{
+			Uri: "213wZJyTUyhXkj381312@uri",
+		},
+	}
+}
+
+func singleFiles() []*build_event_stream.File {
+	return []*build_event_stream.File{
+		singleFile(),
+	}
+}
+
+func TestRedact(t *testing.T) {
+	redactor := redact.NewStreamingRedactor(testenv.GetTestEnv(t))
+
+	buildStarted := &build_event_stream.BuildStarted{
+		OptionsDescription: "213wZJyTUyhXkj381312@foo",
+	}
+	redactor.RedactMetadata(&build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_Started{Started: buildStarted},
+	})
+
+	assert.Equal(t, "foo", buildStarted.OptionsDescription)
+
+	shellOption := &command_line.Option{
+		CombinedForm: "--client_env=SHELL=/bin/bash",
+		OptionName:   "client_env",
+		OptionValue:  "SHELL=/bin/bash",
+	}
+	secretOption := &command_line.Option{
+		CombinedForm: "--client_env=SECRET=codez",
+		OptionName:   "client_env",
+		OptionValue:  "SECRET=codez",
+	}
+	structuredCommandLine := &command_line.CommandLine{
+		CommandLineLabel: "label",
+		Sections: []*command_line.CommandLineSection{
+			{
+				SectionLabel: "command",
+				SectionType: &command_line.CommandLineSection_OptionList{
+					OptionList: &command_line.OptionList{
+						Option: []*command_line.Option{
+							shellOption,
+							secretOption,
+						},
+					},
+				},
+			},
+		},
+	}
+	redactor.RedactMetadata(&build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_StructuredCommandLine{StructuredCommandLine: structuredCommandLine},
+	})
+
+	// TODO(bduffs): Migrate env redaction to redactor and enable these assertions.
+	// assert.Equal(t, "--client_env=SECRET=<REDACTED>", secretOption.OptionValue)
+	// assert.Equal(t, "secret=<REDACTED>", secretOption.OptionValue)
+
+	optionsParsed := &build_event_stream.OptionsParsed{
+		CmdLine:         []string{"213wZJyTUyhXkj381312@foo"},
+		ExplicitCmdLine: []string{"213wZJyTUyhXkj381312@explicit"},
+	}
+	redactor.RedactMetadata(&build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_OptionsParsed{OptionsParsed: optionsParsed},
+	})
+
+	assert.Equal(t, []string{"foo"}, optionsParsed.CmdLine)
+	assert.Equal(t, []string{"explicit"}, optionsParsed.ExplicitCmdLine)
+
+	actionExecuted := &build_event_stream.ActionExecuted{
+		Stdout:             singleFile(),
+		Stderr:             singleFile(),
+		PrimaryOutput:      singleFile(),
+		ActionMetadataLogs: singleFiles(),
+	}
+	redactor.RedactMetadata(&build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_Action{Action: actionExecuted},
+	})
+
+	assert.Equal(t, "uri", actionExecuted.Stdout.GetUri())
+	assert.Equal(t, "uri", actionExecuted.Stderr.GetUri())
+	assert.Equal(t, "uri", actionExecuted.PrimaryOutput.GetUri())
+	assert.Equal(t, "uri", actionExecuted.ActionMetadataLogs[0].GetUri())
+
+	namedSetOfFiles := &build_event_stream.NamedSetOfFiles{
+		Files: singleFiles(),
+	}
+	redactor.RedactMetadata(&build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_NamedSetOfFiles{NamedSetOfFiles: namedSetOfFiles},
+	})
+
+	assert.Equal(t, "uri", namedSetOfFiles.Files[0].GetUri())
+
+	targetComplete := &build_event_stream.TargetComplete{
+		Success:         true,
+		ImportantOutput: singleFiles(),
+	}
+	redactor.RedactMetadata(&build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_Completed{Completed: targetComplete},
+	})
+
+	assert.Equal(t, "uri", targetComplete.ImportantOutput[0].GetUri())
+
+	testResult := &build_event_stream.TestResult{
+		Status:           build_event_stream.TestStatus_PASSED,
+		TestActionOutput: singleFiles(),
+	}
+	redactor.RedactMetadata(&build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_TestResult{TestResult: testResult},
+	})
+
+	assert.Equal(t, "uri", testResult.TestActionOutput[0].GetUri())
+
+	testSummary := &build_event_stream.TestSummary{
+		Passed: singleFiles(),
+		Failed: singleFiles(),
+	}
+	redactor.RedactMetadata(&build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_TestSummary{TestSummary: testSummary},
+	})
+
+	assert.Equal(t, "uri", testSummary.Passed[0].GetUri())
+	assert.Equal(t, "uri", testSummary.Failed[0].GetUri())
+
+	buildFinished := &build_event_stream.BuildFinished{
+		FinishTimeMillis: 1,
+		ExitCode: &build_event_stream.BuildFinished_ExitCode{
+			Name: "Success",
+			Code: 0,
+		},
+	}
+	redactor.RedactMetadata(&build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_Finished{Finished: buildFinished},
+	})
+
+	buildMetadata := &build_event_stream.BuildMetadata{
+		Metadata: map[string]string{
+			"ALLOW_ENV": "SHELL",
+			"ROLE":      "METADATA_CI",
+			"REPO_URL":  "https://USERNAME:PASSWORD@github.com/buildbuddy-io/metadata_repo_url",
+		},
+	}
+	redactor.RedactMetadata(&build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_BuildMetadata{BuildMetadata: buildMetadata},
+	})
+
+	// TODO(bduffs): Migrate BuildMetadata redaction from event_parser to redactor
+	// and enable this assertion.
+	// assert.Equal(t, "https://github.com/buildbuddy-io/metadata_repo_url", buildMetadata.Metadata["REPO_URL"])
+}


### PR DESCRIPTION
This PR moves most "trivial" pieces of redaction logic from the event parser to the redactor. Since we redact before calling the event parser (as of #765), this is effectively a NOP.

Will do the build metadata and env var redaction in the next PR since it's not 100% straightforward (compared to the changes in this PR).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
