### PR TITLE
Fix bug that each keystroke in invocation filter creates a new history entry

### DIFF
--- a/app/invocation/invocation_filter.tsx
+++ b/app/invocation/invocation_filter.tsx
@@ -13,7 +13,7 @@ export default class InvocationFilterComponent extends React.Component {
   handleFilterChange(event: any) {
     let value = event.target.value;
     let params = this.props.hash == "#artifacts" ? { artifactFilter: value } : { targetFilter: value };
-    router.updateParams(params);
+    router.replaceParams(params);
   }
 
   render() {

--- a/enterprise/app/tap/tap.tsx
+++ b/enterprise/app/tap/tap.tsx
@@ -131,7 +131,7 @@ export default class TapComponent extends React.Component<Props> {
   }
 
   handleFilterChange(event: any) {
-    router.updateParams({ filter: event.target.value });
+    router.replaceParams({ filter: event.target.value });
   }
 
   durationToNum(duration: any) {


### PR DESCRIPTION
`updateParams` calls `pushState` which means every time a char is typed into the filter input, it grows the history stack by 1, meaning that the back button has to be pressed once for every keystroke that was entered in order to actually go back.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
