### PR TITLE
Move WorkspaceStatus and BuildMetadata redaction to redactor

### DIFF
--- a/server/build_event_protocol/build_event_handler/BUILD
+++ b/server/build_event_protocol/build_event_handler/BUILD
@@ -44,6 +44,7 @@ go_test(
         ":build_event_handler",
         "//proto:build_event_stream_go_proto",
         "//proto:build_events_go_proto",
+        "//proto:command_line_go_proto",
         "//proto:invocation_go_proto",
         "//proto:publish_build_event_go_proto",
         "//server/testutil/testauth",

--- a/server/build_event_protocol/build_event_handler/build_event_handler_test.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler_test.go
@@ -102,7 +102,6 @@ func structuredCommandLineEvent(env map[string]string) *anypb.Any {
 			},
 		},
 	}
-
 	commandLineAny := &anypb.Any{}
 	commandLineAny.MarshalFrom(&build_event_stream.BuildEvent{
 		Payload: &build_event_stream.BuildEvent_StructuredCommandLine{

--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -341,7 +341,7 @@ func fillInvocationFromBuildMetadata(metadata map[string]string, invocation *inp
 		invocation.CommitSha = sha
 	}
 	if url, ok := metadata["REPO_URL"]; ok && url != "" {
-		invocation.RepoUrl = gitutil.StripRepoURLCredentials(url)
+		invocation.RepoUrl = url
 	}
 	if user, ok := metadata["USER"]; ok && user != "" {
 		invocation.User = user

--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -329,7 +329,7 @@ func fillInvocationFromWorkspaceStatus(workspaceStatus *build_event_stream.Works
 		case "ROLE":
 			invocation.Role = item.Value
 		case "REPO_URL":
-			invocation.RepoUrl = gitutil.StripRepoURLCredentials(item.Value)
+			invocation.RepoUrl = item.Value
 		case "COMMIT_SHA":
 			invocation.CommitSha = item.Value
 		}

--- a/server/build_event_protocol/event_parser/event_parser_test.go
+++ b/server/build_event_protocol/event_parser/event_parser_test.go
@@ -183,7 +183,7 @@ func TestFillInvocation(t *testing.T) {
 		Metadata: map[string]string{
 			"ALLOW_ENV": "SHELL",
 			"ROLE":      "METADATA_CI",
-			"REPO_URL":  "https://USERNAME:PASSWORD@github.com/buildbuddy-io/metadata_repo_url",
+			"REPO_URL":  "https://github.com/buildbuddy-io/metadata_repo_url",
 		},
 	}
 	events = append(events, &inpb.InvocationEvent{

--- a/server/util/redact/BUILD
+++ b/server/util/redact/BUILD
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:build_event_stream_go_proto",
-        "//proto:command_line_go_proto",
         "//server/environment",
         "//server/util/git",
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/server/util/redact/BUILD
+++ b/server/util/redact/BUILD
@@ -7,7 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:build_event_stream_go_proto",
+        "//proto:command_line_go_proto",
         "//server/environment",
+        "//server/util/git",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/server/util/redact/BUILD
+++ b/server/util/redact/BUILD
@@ -23,5 +23,6 @@ go_test(
         "//proto:command_line_go_proto",
         "//server/testutil/testenv",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/util/redact/redact.go
+++ b/server/util/redact/redact.go
@@ -67,6 +67,7 @@ func stripRepoURLCredentialsFromWorkspaceStatus(status *bespb.WorkspaceStatus) {
 		for _, repoURLKey := range knownGitRepoURLKeys {
 			if item.Key == repoURLKey {
 				item.Value = gitutil.StripRepoURLCredentials(item.Value)
+				break
 			}
 		}
 	}

--- a/server/util/redact/redact.go
+++ b/server/util/redact/redact.go
@@ -14,11 +14,6 @@ import (
 
 const (
 	RedactionFlagStandardRedactions = 1
-
-	envVarPrefix              = "--"
-	envVarOptionName          = "client_env"
-	envVarSeparator           = "="
-	envVarRedactedPlaceholder = "<REDACTED>"
 )
 
 var (

--- a/server/util/redact/redact.go
+++ b/server/util/redact/redact.go
@@ -154,12 +154,9 @@ func (r *StreamingRedactor) RedactMetadata(event *bespb.BuildEvent) {
 }
 
 func stripRepoURLCredentialsFromBuildMetadata(metadata *bespb.BuildMetadata) {
-	for mdKey, mdVal := range metadata.Metadata {
-		for _, repoURLKey := range knownGitRepoURLKeys {
-			if mdKey == repoURLKey {
-				metadata.Metadata[mdKey] = gitutil.StripRepoURLCredentials(mdVal)
-				break
-			}
+	for _, repoURLKey := range knownGitRepoURLKeys {
+		if val := metadata.Metadata[repoURLKey]; val != "" {
+			metadata.Metadata[repoURLKey] = gitutil.StripRepoURLCredentials(val)
 		}
 	}
 }


### PR DESCRIPTION
* Strip repo URL credentials from WorkspaceStatus and BuildMetadata in redactor instead of event parser
* Strip repo URL credentials more uniformly
* Beef up `build_event_handler_test` to ensure the redactor is wired up to the build event handler properly whether or not `--enable_optimized_redaction` is set. Includes tests for StructuredCommandLine redaction, which will be useful for the next PR (which moves env var redaction to the redactor as well).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
