### PR TITLE
Remove globs from BUILD files for gazelle

### DIFF
--- a/enterprise/server/webhooks/bitbucket/test_data/BUILD
+++ b/enterprise/server/webhooks/bitbucket/test_data/BUILD
@@ -3,7 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "test_data",
     srcs = ["test_data.go"],
-    embedsrcs = glob(["*.json"]),
+    embedsrcs = [
+        "pull_request_event.json",
+        "push_event.json",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/bitbucket/test_data",
     visibility = [
         "//enterprise/server/webhooks/bitbucket:__subpackages__",

--- a/enterprise/server/webhooks/github/test_data/BUILD
+++ b/enterprise/server/webhooks/github/test_data/BUILD
@@ -3,7 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "test_data",
     srcs = ["test_data.go"],
-    embedsrcs = glob(["*.json"]),
+    embedsrcs = [
+        "pull_request_event.json",
+        "push_event.json",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/github/test_data",
     visibility = [
         "//enterprise/server/webhooks/github:__subpackages__",


### PR DESCRIPTION
Gazelle can't understand globs, so every time we run `fix` it produces
noise about these BUILD targets. Their input files are neither overly
numerous nor frequently changing, so it makes sense to just list them.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
