### PR TITLE
Add a release bazel rule

### DIFF
--- a/rules/release/index.bzl
+++ b/rules/release/index.bzl
@@ -1,0 +1,38 @@
+# Creates a release step that depends on another release step.
+#
+# When run, it will run the target specified by the `run` argument
+# after the target specifed by the `after` argument.
+#
+# Example usage:
+# ```
+#    release(
+#        name = "dev",
+#        run = ":k8s_dev"
+#        after = ":app_release_dev",
+#    )
+# ```
+#
+# Then to perform a release, run:
+#   `bazel run :dev.apply`
+#
+# To diff a release, run:
+#   `bazel run :dev.diff`
+#
+# To delete a release, run:
+#   `bazel run :dev.delete`
+#
+def release(name, run, after, enable_actions = True, **kwargs):
+    actions = [""]
+    if enable_actions:
+        actions = [".apply", ".diff", ".delete"]
+
+    for action in actions:
+        native.genrule(
+            name = name + action,
+            tools = [run + action, after + action],
+            outs = [name + action + ".out"],
+            cmd = "echo \"bash $(location %s);\nbash $(location %s);\" > $@" % (after + action, run + action),
+            local = 1,
+            executable = 1,
+            **kwargs
+        )


### PR DESCRIPTION
This will enable us to keep the master `dev.apply` rule that will deploy both the GCS bucket and then apply our k8s configs.

I'm working on adding a `.diff` action to the gcs deploy (in a separate PR) so we can keep the diff functionality.

There is prior art: https://github.com/atlassian/bazel-tools/tree/master/multirun

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
