### PR TITLE
Fix time range query for invocation history

### DIFF
--- a/enterprise/server/invocation_search_service/invocation_search_service.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service.go
@@ -141,11 +141,11 @@ func (s *InvocationSearchService) QueryInvocations(ctx context.Context, req *inp
 	if role := req.GetQuery().GetRole(); role != "" {
 		q.AddWhereClause("i.role = ?", role)
 	}
-	if start := req.GetQuery().GetUpdatedAfter().AsTime(); !start.IsZero() {
-		q.AddWhereClause("i.updated_at_usec >= ?", timeutil.ToUsec(start))
+	if start := req.GetQuery().UpdatedAfter; start != nil {
+		q.AddWhereClause("i.updated_at_usec >= ?", timeutil.ToUsec(start.AsTime()))
 	}
-	if end := req.GetQuery().GetUpdatedBefore().AsTime(); !end.IsZero() {
-		q.AddWhereClause("i.updated_at_usec < ?", timeutil.ToUsec(end))
+	if end := req.GetQuery().UpdatedBefore; end != nil {
+		q.AddWhereClause("i.updated_at_usec < ?", timeutil.ToUsec(end.AsTime()))
 	}
 
 	// Always add permissions check.

--- a/enterprise/server/invocation_search_service/invocation_search_service.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service.go
@@ -141,10 +141,10 @@ func (s *InvocationSearchService) QueryInvocations(ctx context.Context, req *inp
 	if role := req.GetQuery().GetRole(); role != "" {
 		q.AddWhereClause("i.role = ?", role)
 	}
-	if start := req.GetQuery().UpdatedAfter; start != nil {
+	if start := req.GetQuery().GetUpdatedAfter(); start.IsValid() {
 		q.AddWhereClause("i.updated_at_usec >= ?", timeutil.ToUsec(start.AsTime()))
 	}
-	if end := req.GetQuery().UpdatedBefore; end != nil {
+	if end := req.GetQuery().GetUpdatedBefore(); end.IsValid() {
 		q.AddWhereClause("i.updated_at_usec < ?", timeutil.ToUsec(end.AsTime()))
 	}
 


### PR DESCRIPTION
The code was assuming that `time.Unix(0, 0).IsZero()` returns true, but it actually returns false. As a result, the history query would always filter to the time range `epoch_local_time <= t < epoch_local_time`, returning 0 results.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
