### PR TITLE
Lower read buffer size to avoid bazel error

### DIFF
--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// Keep under the limit of ~4MB (1024 * 1024 * 4).
-	readBufSizeBytes = (1024 * 1024 * 4) - 100
+	readBufSizeBytes = (1024 * 1024 * 3)
 )
 
 type ByteStreamServer struct {

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	// Keep under the limit of ~4MB (1024 * 1024 * 4).
-	readBufSizeBytes = (1024 * 1024 * 3)
+	// Keep under the limit of ~4MB (save 256KB).
+	readBufSizeBytes = (1024 * 1024 * 4) - (1024 * 256)
 )
 
 type ByteStreamServer struct {


### PR DESCRIPTION
This should fix Bazel errors that look like:
```
(Exit 34): io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED: gRPC message exceeds maximum size 4194304: 4194305
```
---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
