### PR TITLE
Dedupe writes differently depending on isolation type.

### DIFF
--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -479,9 +479,11 @@ func (c *CacheProxy) RemoteWriter(ctx context.Context, peer, handoffPeer, prefix
 	// duplicate writes, we call Contains before writing a new digest, and
 	// if it already exists, we'll return a devnull writecloser so no bytes
 	// are transmitted over the network.
-	if alreadyExists, err := c.RemoteContains(ctx, peer, prefix, isolation, d); err == nil && alreadyExists {
-		log.Debugf("Skipping duplicate write of %q", d.GetHash())
-		return devnull.NewWriteCloser(), nil
+	if isolation.GetCacheType() == dcpb.Isolation_CAS_CACHE {
+		if alreadyExists, err := c.RemoteContains(ctx, peer, prefix, isolation, d); err == nil && alreadyExists {
+			log.Debugf("Skipping duplicate write of %q", d.GetHash())
+			return devnull.NewWriteCloser(), nil
+		}
 	}
 	client, err := c.getClient(ctx, peer)
 	if err != nil {

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -481,7 +481,7 @@ func (c *CacheProxy) RemoteWriter(ctx context.Context, peer, handoffPeer, prefix
 	// are transmitted over the network.
 	if isolation.GetCacheType() == dcpb.Isolation_CAS_CACHE {
 		if alreadyExists, err := c.RemoteContains(ctx, peer, prefix, isolation, d); err == nil && alreadyExists {
-			log.Debugf("Skipping duplicate write of %q", d.GetHash())
+			log.Debugf("Skipping duplicate CAS write of %q", d.GetHash())
 			return devnull.NewWriteCloser(), nil
 		}
 	}


### PR DESCRIPTION
AC items may be re-written and we want to allow this -- so check that the isolation type is == CAS before deduping cache writes.

Also, clean up the tests slightly.