### PR TITLE
Fix panic in `screen.go` where `s.y` can be negative

### DIFF
--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -28,7 +28,7 @@ const (
 
 	// Number of lines to keep in the screen buffer so that they may be modified
 	// by ANSI Cursor control codes.
-	linesToRetainForANSICursor = 6
+	linesToRetainForANSICursor = 10
 )
 
 func getEventLogPathFromInvocationId(invocationId string) string {

--- a/server/terminal/screen.go
+++ b/server/terminal/screen.go
@@ -85,6 +85,7 @@ func (s *screen) growScreenHeight() {
 		if extraLines > 0 {
 			s.screen = s.screen[extraLines:]
 			s.y -= extraLines
+			s.y = int(math.Max(0, float64(s.y)))
 		}
 	}
 }
@@ -201,6 +202,7 @@ func (s *screen) backspace() {
 
 func (s *screen) popExtraLines(linesToRetain int) []byte {
 	extraLines := len(s.screen) - linesToRetain
+	extraLines = int(math.Min(float64(extraLines), float64(s.y)))
 	if extraLines < 1 {
 		return []byte{}
 	}

--- a/server/terminal/screen.go
+++ b/server/terminal/screen.go
@@ -4,6 +4,8 @@ import (
 	"math"
 	"strconv"
 	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 )
 
 // A terminal 'screen'. Current cursor position, cursor style, and characters
@@ -56,7 +58,10 @@ func pi(s string) int {
 // Move the cursor up, if we can
 func (s *screen) up(i string) {
 	s.y -= pi(i)
-	s.y = int(math.Max(0, float64(s.y)))
+	if s.y < 0 {
+		log.Warningf("Screen attempted to move cursor above the top of the screen by %d line(s).", -s.y)
+		s.y = 0
+	}
 }
 
 // Move the cursor down
@@ -85,7 +90,10 @@ func (s *screen) growScreenHeight() {
 		if extraLines > 0 {
 			s.screen = s.screen[extraLines:]
 			s.y -= extraLines
-			s.y = int(math.Max(0, float64(s.y)))
+			if s.y < 0 {
+				log.Warningf("Screen did not retain enough lines to maintain the cursor position. Screen retained %d too few line(s).", -s.y)
+				s.y = 0
+			}
 		}
 	}
 }
@@ -202,7 +210,10 @@ func (s *screen) backspace() {
 
 func (s *screen) popExtraLines(linesToRetain int) []byte {
 	extraLines := len(s.screen) - linesToRetain
-	extraLines = int(math.Min(float64(extraLines), float64(s.y)))
+	if extraLines > s.y {
+		log.Warningf("Screen attempted to pop line containing the current cursor position. Attempted to retain too few lines by %d line(s).", extraLines-s.y)
+		extraLines = s.y
+	}
 	if extraLines < 1 {
 		return []byte{}
 	}


### PR DESCRIPTION
- Prevent screen.y from ever becoming negative
- Increase lines to retain for event log ANSI cursor buffer

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

First, we guard against the possibility of `s.y` dropping below 0 by forcing more lines to be retained than requested when that would flush the current line the ANSI cursor is on out of the buffer. Second, as we saw an error where `s.y` went out of range by `2`, we increase the number of lines buffered by the `ANSICursorBufferWriter` in `eventlog.go` from 6 to 10, as we would prefer to anticipate the number of lines bazel will attempt to edit to maintain the log as an exact replica of the command line output. Finally, we add warnings to let us know if we are failing to edit the buffer as bazel intended.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
