### PR TITLE
Fix redis connection refused errors in tests

### DIFF
--- a/enterprise/server/testutil/testredis/BUILD
+++ b/enterprise/server/testutil/testredis/BUILD
@@ -9,7 +9,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/util/redisutil",
-        "//server/testutil/app",
+        "//server/testutil/testfs",
         "//server/util/log",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_stretchr_testify//assert",

--- a/enterprise/server/testutil/testredis/BUILD
+++ b/enterprise/server/testutil/testredis/BUILD
@@ -8,8 +8,10 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/server/util/redisutil",
         "//server/testutil/app",
         "//server/util/log",
+        "@com_github_go_redis_redis_v8//:redis",
         "@com_github_stretchr_testify//assert",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],

--- a/enterprise/server/testutil/testredis/testredis.go
+++ b/enterprise/server/testutil/testredis/testredis.go
@@ -62,8 +62,8 @@ func Start(t testing.TB) string {
 	args = append(args, "--maxmemory-policy", "noeviction")
 	cmd := exec.CommandContext(ctx, redisBinPath, args...)
 	log.Printf("Starting redis server: %s", cmd)
-	cmd.Stdout = &logWriter{t}
-	cmd.Stderr = &logWriter{t}
+	cmd.Stdout = &logWriter{}
+	cmd.Stderr = &logWriter{}
 	err = cmd.Start()
 	if err != nil {
 		assert.FailNowf(t, "redis binary could not be started", err.Error())
@@ -100,9 +100,7 @@ func waitUntilHealthy(t testing.TB, target string) {
 	}
 }
 
-type logWriter struct {
-	t testing.TB
-}
+type logWriter struct{}
 
 func (w *logWriter) Write(b []byte) (int, error) {
 	lines := strings.Split(string(b), "\n")
@@ -110,7 +108,6 @@ func (w *logWriter) Write(b []byte) (int, error) {
 		if line == "" {
 			continue
 		}
-		w.t.Log(line)
 		log.Infof("[redis server] %s", line)
 	}
 	return len(b), nil

--- a/enterprise/server/testutil/testredis/testredis.go
+++ b/enterprise/server/testutil/testredis/testredis.go
@@ -23,7 +23,7 @@ const (
 	redisLinuxBinRunfilePath = "enterprise/server/test/bin/redis/redis-server-linux-x86_64"
 
 	startupTimeout      = 10 * time.Second
-	startupPingInterval = 1 * time.Millisecond
+	startupPingInterval = 5 * time.Millisecond
 )
 
 // Start spawns a Redis server for the given test and returns a Redis target
@@ -75,7 +75,7 @@ func Start(t testing.TB) string {
 		cancel()
 	})
 	target := fmt.Sprintf("localhost:%d", redisPort)
-	// waitUntilHealthy(t, target)
+	waitUntilHealthy(t, target)
 	return target
 }
 

--- a/enterprise/server/testutil/testredis/testredis.go
+++ b/enterprise/server/testutil/testredis/testredis.go
@@ -90,16 +90,21 @@ func waitUntilHealthy(t testing.TB, target string) {
 			return
 		}
 		if time.Since(start) > startupTimeout {
-			t.Fatalf("Failed to connect to redis within %s: %s", startupTimeout, err)
+			assert.FailNowf(t, "Failed to connect to redis", "Health check still failing after %s: %s", startupTimeout, err)
 		}
 		time.Sleep(startupPingInterval)
-		continue
 	}
 }
 
 type logWriter struct{}
 
 func (w *logWriter) Write(b []byte) (int, error) {
-	log.Infof("[redis server] %s", strings.TrimSuffix(string(b), "\n"))
+	lines := strings.Split(string(b), "\n")
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		log.Infof("[redis server] %s", line)
+	}
 	return len(b), nil
 }


### PR DESCRIPTION
* Add a startup healthcheck before allowing the test to use the server instance, to ensure that the server is ready to accept connections.
* Use a Unix socket instead of a random free TCP port to avoid race conditions where the port gets taken after the port is determined but before the server actually listens on it.

Tested locally with `--runs_per_test=2000` (12K total test funcs)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/767
