### PR TITLE
Improve loading sequence for chunked event logs

### DIFF
--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -446,3 +446,7 @@ svg.invocation-query-graph .nodes rect {
   rx: 8px;
   ry: 8px;
 }
+
+.invocation .build-logs-card .loading.loading-dark {
+  background: transparent;
+}

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -51,8 +51,6 @@ interface Props {
 const largePageSize = 100;
 const smallPageSize = 10;
 
-const BUILD_LOGS_EMPTY_MSG = "No build logs...";
-
 export default class InvocationComponent extends React.Component<Props, State> {
   state: State = {
     loading: true,

--- a/app/invocation/invocation_build_logs_card.tsx
+++ b/app/invocation/invocation_build_logs_card.tsx
@@ -11,7 +11,10 @@ interface Props {
 export default class BuildLogsCardComponent extends React.Component<Props> {
   render() {
     return (
-      <div className={`card ${this.props.dark ? "dark" : "light-terminal"} ${this.props.expanded ? "expanded" : ""}`}>
+      <div
+        className={`card build-logs-card ${this.props.dark ? "dark" : "light-terminal"} ${
+          this.props.expanded ? "expanded" : ""
+        }`}>
         <img className="icon" src={this.props.dark ? "/image/log-circle-light.svg" : "/image/log-circle.svg"} />
         <div className="content">
           <div className="title">Build logs </div>
@@ -20,7 +23,7 @@ export default class BuildLogsCardComponent extends React.Component<Props> {
               // "terminal" class makes sure the loading container's size
               // is the same as the terminal that will take its place.
               <div className="terminal">
-                <div className="loading" />
+                <div className={`loading ${this.props.dark ? "loading-dark" : ""}`} />
               </div>
             ) : (
               <TerminalComponent value={this.props.value} lightTheme={!this.props.dark} />

--- a/app/invocation/invocation_build_logs_card.tsx
+++ b/app/invocation/invocation_build_logs_card.tsx
@@ -17,8 +17,8 @@ export default class BuildLogsCardComponent extends React.Component<Props> {
           <div className="title">Build logs </div>
           <div className="details">
             {this.props.loading ? (
-              // "terminal" makes sure the loading container's size is the same as the terminal
-              // that will take its place.
+              // "terminal" class makes sure the loading container's size
+              // is the same as the terminal that will take its place.
               <div className="terminal">
                 <div className="loading" />
               </div>

--- a/app/invocation/invocation_build_logs_card.tsx
+++ b/app/invocation/invocation_build_logs_card.tsx
@@ -11,10 +11,7 @@ interface Props {
 export default class BuildLogsCardComponent extends React.Component<Props> {
   render() {
     return (
-      <div
-        className={`build-logs-card card ${this.props.dark ? "dark" : "light-terminal"} ${
-          this.props.expanded ? "expanded" : ""
-        }`}>
+      <div className={`card ${this.props.dark ? "dark" : "light-terminal"} ${this.props.expanded ? "expanded" : ""}`}>
         <img className="icon" src={this.props.dark ? "/image/log-circle-light.svg" : "/image/log-circle.svg"} />
         <div className="content">
           <div className="title">Build logs </div>

--- a/app/invocation/invocation_logs_model.tsx
+++ b/app/invocation/invocation_logs_model.tsx
@@ -50,18 +50,20 @@ export default class InvocationLogsModel {
       )
     ).subscribe({
       next: (response) => {
-        const newLogs = this.logs + String.fromCharCode(...(response.buffer || []));
-        if (this.logs !== newLogs) {
-          this.logs = newLogs;
-          this.onChange.next();
-        }
+        this.logs = this.logs + String.fromCharCode(...(response.buffer || []));
 
         // Empty next chunk ID means the invocation is complete and we've reached
         // the end of the log.
         if (!response.nextChunkId) {
           this.responseSubscription = null;
+          // Notify of change to `isFetching` state.
           this.onChange.next();
           return;
+        }
+
+        if (response.buffer?.length) {
+          // Notify of change to `logs` state.
+          this.onChange.next();
         }
 
         // Unchanged next chunk ID means the invocation is still in progress and

--- a/app/invocation/invocation_logs_model.tsx
+++ b/app/invocation/invocation_logs_model.tsx
@@ -8,8 +8,8 @@ const POLL_TAIL_INTERVAL_MS = 3_000;
 const MIN_LINES = 100_000;
 
 /**
- * InvocationLogsModel holds the invocation log content and handles fetching
- * log chunks.
+ * InvocationLogsModel holds the invocation log content for chunkstore-enabled
+ * invocations, and handles fetching log chunks from chunkstore.
  */
 export default class InvocationLogsModel {
   /** Streams an event whenever the state of the model changes. */

--- a/app/invocation/invocation_logs_model.tsx
+++ b/app/invocation/invocation_logs_model.tsx
@@ -1,0 +1,81 @@
+import { Subject, Subscription, from } from "rxjs";
+import { eventlog } from "../../proto/eventlog_ts_proto";
+import errorService from "../errors/error_service";
+import rpcService from "../service/rpc_service";
+
+const POLL_TAIL_INTERVAL_MS = 3_000;
+// How many lines to request from the server on each chunk request.
+const MIN_LINES = 100_000;
+
+/**
+ * InvocationLogsModel holds the invocation log content and handles fetching
+ * log chunks.
+ */
+export default class InvocationLogsModel {
+  /** Streams an event whenever the state of the model changes. */
+  readonly onChange: Subject<undefined> = new Subject<undefined>();
+
+  private logs = "";
+  private responseSubscription: Subscription;
+  private pollTailTimeout: number | null = null;
+
+  constructor(private invocationId: string) {}
+
+  startFetching() {
+    this.fetchTail();
+  }
+
+  stopFetching() {
+    window.clearTimeout(this.pollTailTimeout);
+    this.responseSubscription?.unsubscribe();
+    this.responseSubscription = null;
+  }
+
+  getLogs(): string {
+    return this.logs;
+  }
+
+  isFetching(): boolean {
+    return Boolean(this.responseSubscription);
+  }
+
+  private fetchTail(chunkId = "") {
+    this.responseSubscription = from<Promise<eventlog.GetEventLogChunkResponse>>(
+      rpcService.service.getEventLogChunk(
+        new eventlog.GetEventLogChunkRequest({
+          invocationId: this.invocationId,
+          chunkId,
+          minLines: MIN_LINES,
+        })
+      )
+    ).subscribe({
+      next: (response) => {
+        const newLogs = this.logs + String.fromCharCode(...(response.buffer || []));
+        if (this.logs !== newLogs) {
+          this.logs = newLogs;
+          this.onChange.next();
+        }
+
+        // Empty next chunk ID means the invocation is complete and we've reached
+        // the end of the log.
+        if (!response.nextChunkId) {
+          this.responseSubscription = null;
+          this.onChange.next();
+          return;
+        }
+
+        // Unchanged next chunk ID means the invocation is still in progress and
+        // we should continue polling that chunk.
+        if (response.nextChunkId === chunkId) {
+          this.pollTailTimeout = window.setTimeout(() => this.fetchTail(chunkId), POLL_TAIL_INTERVAL_MS);
+          return;
+        }
+
+        // New next chunk ID means we successfully fetched the requested
+        // chunk, and more may be available. Try fetching it immediately.
+        this.fetchTail(response.nextChunkId);
+      },
+      error: (e) => errorService.handleError(e),
+    });
+  }
+}

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -46,6 +46,10 @@ func GetEventLogChunk(ctx context.Context, env environment.Env, req *elpb.GetEve
 	c := chunkstore.New(env.GetBlobstore(), &chunkstore.ChunkstoreOptions{})
 	eventLogPath := getEventLogPathFromInvocationId(req.InvocationId)
 
+	if inv.LastChunkId == "" {
+		return &elpb.GetEventLogChunkResponse{}, nil
+	}
+
 	lastChunkId, err := c.GetLastChunkId(ctx, eventLogPath, inv.LastChunkId)
 	if err != nil {
 		if inv.LastChunkId != chunkstore.ChunkIndexAsStringId(math.MaxUint16) {


### PR DESCRIPTION
* Fetch the first chunk in parallel with the invocation, instead of making 2 requests in serial (GetInvocationRequest followed by GetEventLogChunkRequest)
* Update server so that if chunking is not enabled for an invocation, we return EOF instead of an error. This allows us to make the requests in parallel, because we can now always fetch event log chunks even if we don't know whether chunking is enabled (the enabled bit is present in the GetInvocationResponse).
* Show a loading state while the chunk is loading, if it has not loaded by the time the GetInvocationResponse comes back. For non-chunked invocations, we never show this loading state, since we have a separate full-page loading state until the InvocationModel is created and the InvocationModel contains the logs. For chunked invocations, a loading spinner is displayed in the logs card until we see any logs in the GetEventLogChunkResponse:

![image](https://user-images.githubusercontent.com/2414826/127715827-6ef504f6-ccb1-439c-977e-5918b623af9c.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/765
