### PR TITLE
Fix logs initialization

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -70,6 +70,13 @@ export default class InvocationComponent extends React.Component<Props, State> {
     moment.relativeTimeThreshold("ss", 0);
 
     this.fetchInvocation();
+
+    this.logsModel = new InvocationLogsModel(this.props.invocationId);
+    // Re-render whenever we fetch new log chunks.
+    this.logsSubscription = this.logsModel.onChange.subscribe({
+      next: () => this.forceUpdate(),
+    });
+    this.logsModel.startFetching();
   }
 
   componentWillUnmount() {
@@ -111,13 +118,6 @@ export default class InvocationComponent extends React.Component<Props, State> {
           loading: false,
         });
       });
-
-    this.logsModel = new InvocationLogsModel(this.props.invocationId);
-    // Re-render whenever we fetch new log chunks.
-    this.logsSubscription = this.logsModel.onChange.subscribe({
-      next: () => this.forceUpdate(),
-    });
-    this.logsModel.startFetching();
   }
 
   fetchUpdatedProgress() {


### PR DESCRIPTION
The logs model was meant to be initialized only once. This PR initializes them in `componentWillMount` instead of `fetchInvocation` (which is called at an interval).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
