### PR TITLE
Temporarily disable chunked log reading

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -502,6 +502,12 @@ export default class InvocationModel {
   }
 
   hasChunkedEventLogs(): boolean {
-    return this.invocations[0]?.hasChunkedEventLogs || false;
+    return false;
+
+    // TODO(bduffany): re-enable once we can confirm
+    // https://github.com/buildbuddy-io/buildbuddy-internal/issues/774
+    // is not an issue.
+
+    // return this.invocations[0]?.hasChunkedEventLogs || false;
   }
 }


### PR DESCRIPTION
This will allow us to enable chunked event logs without causing the client to start reading from them. We want to gather some data so that we can assess the severity of https://github.com/buildbuddy-io/buildbuddy-internal/issues/774 before enabling event log chunking on the client.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
