### PR TITLE
Fix darwin executor build

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -16,6 +16,7 @@ go_library(
         "@io_bazel_rules_go//go/platform:darwin": [
             "//enterprise/server/remote_execution/container",
             "//proto:remote_execution_go_proto",
+            "//server/environment",
             "//server/interfaces",
             "//server/util/status",
         ],

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_darwin.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_darwin.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
@@ -46,7 +47,7 @@ type ContainerOpts struct {
 
 type firecrackerContainer struct{}
 
-func NewContainer(ctx context.Context, opts interface{}) (*firecrackerContainer, error) {
+func NewContainer(env environment.Env, opts ContainerOpts) (*firecrackerContainer, error) {
 	c := &firecrackerContainer{}
 	return c, nil
 }


### PR DESCRIPTION
Looks like I messed up this function signature when splitting darwin/linux firecracker packages.

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
