### PR TITLE
Parallelize chunkstore reads

### DIFF
--- a/server/eventlog/BUILD
+++ b/server/eventlog/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//server/environment",
         "//server/interfaces",
         "//server/terminal",
+        "//server/util/log",
         "//server/util/status",
     ],
 )

--- a/server/eventlog/BUILD
+++ b/server/eventlog/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//server/environment",
         "//server/interfaces",
         "//server/terminal",
-        "//server/util/log",
         "//server/util/status",
     ],
 )

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -127,9 +127,6 @@ func GetEventLogChunk(ctx context.Context, env environment.Env, req *elpb.GetEve
 	// Fetch one chunk even if the minimum line count is 0
 	for chunkIndex := startIndex; chunkIndex != boundary+step; chunkIndex += step {
 		buffer, err := q.pop(ctx)
-		if err == io.EOF {
-			break
-		}
 		if err != nil {
 			return nil, err
 		}

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -163,6 +163,10 @@ type chunkReadResult struct {
 
 type chunkFuture chan chunkReadResult
 
+func newChunkFuture() chunkFuture {
+	return make(chunkFuture, 1)
+}
+
 type chunkQueue struct {
 	store          *chunkstore.Chunkstore
 	maxConnections int
@@ -186,10 +190,6 @@ func newChunkQueue(c *chunkstore.Chunkstore, eventLogPath string, start, step, b
 		step:           step,
 		boundary:       boundary,
 	}
-}
-
-func newChunkFuture() chunkFuture {
-	return make(chunkFuture, 1)
 }
 
 func (q *chunkQueue) pushNewFuture(ctx context.Context, index uint16) {

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -147,7 +147,6 @@ func GetEventLogChunk(ctx context.Context, env environment.Env, req *elpb.GetEve
 			rsp.Buffer = append(buffer, rsp.Buffer...)
 			rsp.PreviousChunkId = chunkstore.ChunkIndexAsStringId(chunkIndex + step)
 		}
-		chunkIndex += step
 		if lineCount >= int(req.MinLines) {
 			break
 		}

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -169,10 +169,11 @@ type chunkQueue struct {
 	start          uint16
 	step           uint16
 	boundary       uint16
-	futures        []chunkFuture
 	maxConnections int
-	numPopped      int
-	done           bool
+
+	futures   []chunkFuture
+	numPopped int
+	done      bool
 }
 
 func newChunkQueue(c *chunkstore.Chunkstore, eventLogPath string, start, step, boundary uint16) *chunkQueue {
@@ -183,9 +184,6 @@ func newChunkQueue(c *chunkstore.Chunkstore, eventLogPath string, start, step, b
 		step:           step,
 		boundary:       boundary,
 		maxConnections: numReadWorkers,
-		futures:        make([]chunkFuture, 0),
-		numPopped:      0,
-		done:           false,
 	}
 }
 

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -157,9 +157,8 @@ func GetEventLogChunk(ctx context.Context, env environment.Env, req *elpb.GetEve
 }
 
 type chunkReadResult struct {
-	index uint16
-	data  []byte
-	err   error
+	data []byte
+	err  error
 }
 
 type chunkFuture chan chunkReadResult

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -29,6 +29,9 @@ const (
 	// Number of lines to keep in the screen buffer so that they may be modified
 	// by ANSI Cursor control codes.
 	linesToRetainForANSICursor = 10
+
+	// Max number of workers to run in parallel when fetching chunks.
+	numReadWorkers = 16
 )
 
 func getEventLogPathFromInvocationId(invocationId string) string {
@@ -119,10 +122,14 @@ func GetEventLogChunk(ctx context.Context, env environment.Env, req *elpb.GetEve
 		boundary = 0
 		step = math.MaxUint16 // decrements the value when added
 	}
+	q := newChunkQueue(c, eventLogPath, startIndex, step, boundary)
+	chunkIndex := startIndex
 	lineCount := 0
-	// Fetch one chunk even if the minimum line count is 0
-	for chunkIndex := startIndex; chunkIndex != boundary+step; chunkIndex += step {
-		buffer, err := c.ReadChunk(ctx, eventLogPath, chunkIndex)
+	for {
+		buffer, err := q.pop(ctx)
+		if err == io.EOF {
+			break
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -140,6 +147,7 @@ func GetEventLogChunk(ctx context.Context, env environment.Env, req *elpb.GetEve
 			rsp.Buffer = append(buffer, rsp.Buffer...)
 			rsp.PreviousChunkId = chunkstore.ChunkIndexAsStringId(chunkIndex + step)
 		}
+		chunkIndex += step
 		if lineCount >= int(req.MinLines) {
 			break
 		}
@@ -150,6 +158,85 @@ func GetEventLogChunk(ctx context.Context, env environment.Env, req *elpb.GetEve
 	}
 
 	return rsp, nil
+}
+
+type chunkReadResult struct {
+	index uint16
+	data  []byte
+	err   error
+}
+
+type chunkFuture chan chunkReadResult
+
+type chunkQueue struct {
+	store          *chunkstore.Chunkstore
+	eventLogPath   string
+	start          uint16
+	step           uint16
+	boundary       uint16
+	futures        []chunkFuture
+	maxConnections int
+	numPopped      int
+	done           bool
+}
+
+func newChunkQueue(c *chunkstore.Chunkstore, eventLogPath string, start, step, boundary uint16) *chunkQueue {
+	return &chunkQueue{
+		store:          c,
+		eventLogPath:   eventLogPath,
+		start:          start,
+		step:           step,
+		boundary:       boundary,
+		maxConnections: numReadWorkers,
+		futures:        make([]chunkFuture, 0),
+		numPopped:      0,
+		done:           false,
+	}
+}
+
+func newChunkFuture() chunkFuture {
+	return make(chunkFuture, 1)
+}
+
+func (q *chunkQueue) pushNewFuture(ctx context.Context, index uint16) {
+	future := newChunkFuture()
+	q.futures = append(q.futures, future)
+
+	if index == q.boundary+q.step {
+		future <- chunkReadResult{err: io.EOF}
+		return
+	}
+
+	go func() {
+		defer close(future)
+
+		data, err := q.store.ReadChunk(ctx, q.eventLogPath, index)
+		future <- chunkReadResult{
+			data: data,
+			err:  err,
+		}
+	}()
+}
+
+func (q *chunkQueue) pop(ctx context.Context) ([]byte, error) {
+	if q.done {
+		return nil, status.ResourceExhaustedError("Queue has been exhausted.")
+	}
+	// Make sure maxConnections files are downloading
+	numLoading := len(q.futures) - q.numPopped
+	numNewConnections := q.maxConnections - numLoading
+	for numNewConnections > 0 {
+		index := q.start + uint16(len(q.futures))*q.step
+		q.pushNewFuture(ctx, index)
+		numNewConnections--
+	}
+	result := <-q.futures[q.numPopped]
+	q.numPopped++
+	if result.err != nil {
+		q.done = true
+		return nil, result.err
+	}
+	return result.data, nil
 }
 
 func NewEventLogWriter(ctx context.Context, b interfaces.Blobstore, invocationId string) *EventLogWriter {

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -123,9 +123,9 @@ func GetEventLogChunk(ctx context.Context, env environment.Env, req *elpb.GetEve
 		step = math.MaxUint16 // decrements the value when added
 	}
 	q := newChunkQueue(c, eventLogPath, startIndex, step, boundary)
-	chunkIndex := startIndex
 	lineCount := 0
-	for {
+	// Fetch one chunk even if the minimum line count is 0
+	for chunkIndex := startIndex; chunkIndex != boundary+step; chunkIndex += step {
 		buffer, err := q.pop(ctx)
 		if err == io.EOF {
 			break

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -165,11 +165,12 @@ type chunkFuture chan chunkReadResult
 
 type chunkQueue struct {
 	store          *chunkstore.Chunkstore
-	eventLogPath   string
-	start          uint16
-	step           uint16
-	boundary       uint16
 	maxConnections int
+
+	eventLogPath string
+	start        uint16
+	step         uint16
+	boundary     uint16
 
 	futures   []chunkFuture
 	numPopped int

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -180,11 +180,11 @@ type chunkQueue struct {
 func newChunkQueue(c *chunkstore.Chunkstore, eventLogPath string, start, step, boundary uint16) *chunkQueue {
 	return &chunkQueue{
 		store:          c,
+		maxConnections: numReadWorkers,
 		eventLogPath:   eventLogPath,
 		start:          start,
 		step:           step,
 		boundary:       boundary,
-		maxConnections: numReadWorkers,
 	}
 }
 


### PR DESCRIPTION
Took the tried and true [`blobQueue`](https://github.com/buildbuddy-io/buildbuddy/blob/c61f7d5e62fef4b17c553cfc0ee1d19b18a84710/server/util/protofile/protofile.go#L124-L189) from `protofile.go` and adapted it for chunkstore reads.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/774
