### PR TITLE
Fix `RangeError` for large chunk buffers

### DIFF
--- a/app/invocation/invocation_logs_model.tsx
+++ b/app/invocation/invocation_logs_model.tsx
@@ -40,7 +40,6 @@ export default class InvocationLogsModel {
   }
 
   private fetchTail(chunkId = "") {
-    console.log("fetchTail");
     this.responseSubscription = from<Promise<eventlog.GetEventLogChunkResponse>>(
       rpcService.service.getEventLogChunk(
         new eventlog.GetEventLogChunkRequest({

--- a/app/invocation/invocation_logs_model.tsx
+++ b/app/invocation/invocation_logs_model.tsx
@@ -40,6 +40,7 @@ export default class InvocationLogsModel {
   }
 
   private fetchTail(chunkId = "") {
+    console.log("fetchTail");
     this.responseSubscription = from<Promise<eventlog.GetEventLogChunkResponse>>(
       rpcService.service.getEventLogChunk(
         new eventlog.GetEventLogChunkRequest({
@@ -50,7 +51,7 @@ export default class InvocationLogsModel {
       )
     ).subscribe({
       next: (response) => {
-        this.logs = this.logs + String.fromCharCode(...(response.buffer || []));
+        this.logs = this.logs + new TextDecoder().decode(response.buffer || new Uint8Array());
 
         // Empty next chunk ID means the invocation is complete and we've reached
         // the end of the log.


### PR DESCRIPTION
The number of function arguments that can be passed to a function has a relatively small limit, so `String.fromCharCode(...buffer)` results in a RangeError.

Try running this in the JS console: `console.log(...new Array(1000000))`

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
