### PR TITLE
Add role filtering support for invocation stats query

### DIFF
--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -190,6 +190,10 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 		q.AddWhereClause("commit = ?", commitSHA)
 	}
 
+	if role := req.GetQuery().GetRole(); role != "" {
+		q.AddWhereClause("role = ?", role)
+	}
+
 	if start := req.GetQuery().GetUpdatedAfter(); start.IsValid() {
 		q.AddWhereClause("updated_at_usec >= ?", timeutil.ToUsec(start.AsTime()))
 	}

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -546,6 +546,7 @@ func PostAutoMigrate(db *gorm.DB) error {
 		"invocations_stats_host_index":        "(`group_id`, `host`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
 		"invocations_stats_repo_index":        "(`group_id`, `repo_url`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
 		"invocations_stats_commit_index":      "(`group_id`, `commit_sha`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_role_index":        "(`group_id`, `role`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
 	}
 	m := db.Migrator()
 	if m.HasTable("Invocations") {


### PR DESCRIPTION
The proto already allows filtering by role, but the actual filtering wasn't implemented. This adds the SQL wiring and index necessary to make the query complete in a reasonable amount of time.

See performance details here https://github.com/buildbuddy-io/buildbuddy-internal/issues/617

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/617
