### PR TITLE
Cleanup jailer dir after execution.

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -905,6 +905,9 @@ func (c *FirecrackerContainer) Remove(ctx context.Context) error {
 	if err := os.RemoveAll(filepath.Dir(c.workspaceFSPath)); err != nil {
 		log.Errorf("Error removing workspace fs: %s", err)
 	}
+	if err := os.RemoveAll(filepath.Dir(c.getChroot())); err != nil {
+		log.Errorf("Error removing chroot: %s", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This removes the jailer directories so they don't pile up on disk. Also cleans up the snapshot impl a little bit by cleanly removing and restoring things between snapshots (all state lives in the snapshot).

Finally, it no longer does any container caching using the user's cache directory -- everything lives inside the root executor working directory (which is important as it means everything will be on SSD).