### PR TITLE
Warmup all configured containers.

### DIFF
--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -31,6 +31,7 @@ go_library(
         "@com_github_docker_docker//client:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_prometheus_client_golang//prometheus",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -494,7 +494,7 @@ func (p *Pool) WarmupDefaultImage() {
 			log.Errorf("Error warming up %q: %s", containerType, err)
 			return
 		}
-		log.Printf("Starting warmup job for containerType: %q", containerType)
+
 		eg.Go(func() error {
 			if err := c.PullImageIfNecessary(egCtx); err != nil {
 				return err

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -34,6 +34,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/golang/protobuf/proto"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/errgroup"
 
 	aclpb "github.com/buildbuddy-io/buildbuddy/proto/acl"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -469,44 +470,54 @@ func (p *Pool) dockerOptions() *docker.DockerOptions {
 }
 
 func (p *Pool) WarmupDefaultImage() {
-	if p.dockerClient == nil {
-		return
-	}
-	c := docker.NewDockerContainer(
-		p.dockerClient, platform.DefaultContainerImage, p.hostBuildRoot(),
-		p.dockerOptions(),
-	)
 	start := time.Now()
 	// Give the pull up to 1 minute to succeed and 1 minute to create a warm up container.
 	// In practice I saw clean pulls take about 30 seconds.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	err := c.PullImageIfNecessary(ctx)
-	if err != nil {
-		log.Warningf("Warm up: could not pull default image %q: %s", platform.DefaultContainerImage, err)
-		return
-	}
-	log.Infof("Warm up: pulled default image %q in %s", platform.DefaultContainerImage, time.Since(start))
 
-	tmpDir, err := os.MkdirTemp("", "buildbuddy-warmup-*")
-	if err != nil {
-		log.Warningf("Warm up: could not create temp directory: %s", err)
-		return
+	eg, egCtx := errgroup.WithContext(ctx)
+	executorProps := platform.GetExecutorProperties(p.env.GetConfigurator().GetExecutorConfig())
+	for _, containerType := range executorProps.SupportedIsolationTypes {
+		containerType := containerType
+		image := platform.DefaultContainerImage
+		platProps := platform.ParseProperties(&repb.Platform{
+			Properties: []*repb.Platform_Property{
+				{Name: "container-image", Value: image},
+				{Name: "workload-isolation-type", Value: string(containerType)},
+			},
+		})
+		c, err := p.newContainer(egCtx, platProps, &repb.Command{
+			Arguments: []string{"echo", "'warmup'"},
+		})
+		if err != nil {
+			log.Errorf("Error warming up %q: %s", containerType, err)
+			return
+		}
+		log.Printf("Starting warmup job for containerType: %q", containerType)
+		eg.Go(func() error {
+			if err := c.PullImageIfNecessary(egCtx); err != nil {
+				return err
+			}
+			log.Infof("Warmup: %s pulled default image %q in %s", containerType, image, time.Since(start))
+			tmpDir, err := os.MkdirTemp("", "buildbuddy-warmup-*")
+			if err != nil {
+				return err
+			}
+			defer os.Remove(tmpDir)
+			if err = c.Create(egCtx, tmpDir); err != nil {
+				return err
+			}
+			if err := c.Remove(egCtx); err != nil {
+				return err
+			}
+			log.Infof("Warmup: %s finished in %s.", containerType, time.Since(start))
+			return nil
+		})
 	}
-	defer func() {
-		_ = os.Remove(tmpDir)
-	}()
-	err = c.Create(ctx, tmpDir)
-	if err != nil {
-		log.Warningf("Warm up: could not create warm up container: %s", err)
-		return
+	if err := eg.Wait(); err != nil {
+		log.Warningf("Error warming up containers: %s", err)
 	}
-	err = c.Remove(ctx)
-	if err != nil {
-		log.Warningf("Warm up: could not remove warm up container: %s", err)
-		return
-	}
-	log.Infof("Warm up finished for default image in %s.", time.Since(start))
 }
 
 // Get returns a runner that can be used to execute the given task. The caller


### PR DESCRIPTION
This warms up firecracker as well as docker; both need to pull the default image in different ways.