### PR TITLE
Add status filter field to invocation query protos

### DIFF
--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -177,7 +177,8 @@ message InvocationQuery {
   // The timestamp up to which the build was last updated (exclusive).
   google.protobuf.Timestamp updated_before = 8;
 
-  // Allowed invocation statuses. Must be explicitly specified, or no invocations will be returned.
+  // Allowed invocation statuses. Must be explicitly specified, or no
+  // invocations will be returned.
   repeated StatusFilterValue statuses = 9;
 }
 
@@ -308,7 +309,8 @@ message InvocationStatQuery {
   // The timestamp up to which the build was last updated (exclusive).
   google.protobuf.Timestamp updated_before = 8;
 
-  // Allowed invocation statuses. Must be explicitly specified, or no invocations will be returned.
+  // Allowed invocation statuses. Must be explicitly specified, or no
+  // invocations will be returned.
   repeated StatusFilterValue statuses = 9;
 }
 

--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -179,11 +179,11 @@ message InvocationQuery {
 
   // Allowed invocation statuses. Must be explicitly specified, or no
   // invocations will be returned.
-  repeated StatusFilterValue statuses = 9;
+  repeated OverallStatus status = 9;
 }
 
-enum StatusFilterValue {
-  UNKNOWN_STATUS_FILTER_VALUE = 0;
+enum OverallStatus {
+  UNKNOWN_OVERALL_STATUS = 0;
 
   // Filter value selecting `invocation_status == COMPLETE and success`.
   SUCCESS = 1;
@@ -311,7 +311,7 @@ message InvocationStatQuery {
 
   // Allowed invocation statuses. Must be explicitly specified, or no
   // invocations will be returned.
-  repeated StatusFilterValue statuses = 9;
+  repeated OverallStatus status = 9;
 }
 
 message GetInvocationStatRequest {

--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -177,7 +177,7 @@ message InvocationQuery {
   // The timestamp up to which the build was last updated (exclusive).
   google.protobuf.Timestamp updated_before = 8;
 
-  // Allowed invocation statuses.
+  // Allowed invocation statuses. Must be explicitly specified, or no invocations will be returned.
   repeated StatusFilterValue statuses = 9;
 }
 
@@ -308,7 +308,7 @@ message InvocationStatQuery {
   // The timestamp up to which the build was last updated (exclusive).
   google.protobuf.Timestamp updated_before = 8;
 
-  // Allowed invocation statuses.
+  // Allowed invocation statuses. Must be explicitly specified, or no invocations will be returned.
   repeated StatusFilterValue statuses = 9;
 }
 

--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -176,6 +176,25 @@ message InvocationQuery {
 
   // The timestamp up to which the build was last updated (exclusive).
   google.protobuf.Timestamp updated_before = 8;
+
+  // Allowed invocation statuses.
+  repeated StatusFilterValue statuses = 9;
+}
+
+enum StatusFilterValue {
+  UNKNOWN_STATUS_FILTER_VALUE = 0;
+
+  // Filter value selecting `invocation_status == COMPLETE and success`.
+  SUCCESS = 1;
+
+  // Filter value selecting `invocation_status == COMPLETE and not success`.
+  FAILURE = 2;
+
+  // Filter value selecting `invocation_status == PARTIAL`.
+  IN_PROGRESS = 3;
+
+  // Filter value selecting `invocation_status == DISCONNECTED`.
+  DISCONNECTED = 4;
 }
 
 message InvocationSort {
@@ -288,6 +307,9 @@ message InvocationStatQuery {
 
   // The timestamp up to which the build was last updated (exclusive).
   google.protobuf.Timestamp updated_before = 8;
+
+  // Allowed invocation statuses.
+  repeated StatusFilterValue statuses = 9;
 }
 
 message GetInvocationStatRequest {

--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -182,19 +182,21 @@ message InvocationQuery {
   repeated OverallStatus status = 9;
 }
 
+// OverallStatus is a status representing both the completion status and
+// success status of an invocation.
 enum OverallStatus {
   UNKNOWN_OVERALL_STATUS = 0;
 
-  // Filter value selecting `invocation_status == COMPLETE and success`.
+  // Status representing a completed, successful invocation.
   SUCCESS = 1;
 
-  // Filter value selecting `invocation_status == COMPLETE and not success`.
+  // Status representing a completed, unsuccessful invocation.
   FAILURE = 2;
 
-  // Filter value selecting `invocation_status == PARTIAL`.
+  // Status representing a partial invocation.
   IN_PROGRESS = 3;
 
-  // Filter value selecting `invocation_status == DISCONNECTED`.
+  // Status representing a disconnected invocation.
   DISCONNECTED = 4;
 }
 


### PR DESCRIPTION
Since the client's notion of "status" is really derived from 2 fields (`invocation_status` and `success`) it makes sense to define a new enum that represents this derived status, so that we can specify a list of statuses to fetch (which will be driven by the new global filtering UI).

In upcoming PRs, will update the client to always send all possible status filter values (by default -- this will later be controlled by the filtering UI), and then update the server to handle this new field appropriately.

Confirmed that status filtering does not make queries significantly slower for group IDs with the largest number of invocations (tried history, stats, and trends queries) -- even when combined with `role` filtering.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/617, https://github.com/buildbuddy-io/buildbuddy-internal/issues/647