### PR TITLE
Implement server-side invocation history status filtering and trends filtering

### DIFF
--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -177,8 +177,8 @@ message InvocationQuery {
   // The timestamp up to which the build was last updated (exclusive).
   google.protobuf.Timestamp updated_before = 8;
 
-  // Allowed invocation statuses. Must be explicitly specified, or no
-  // invocations will be returned.
+  // Status of the build. If multiple are specified, they are combined with
+  // "OR".
   repeated OverallStatus status = 9;
 }
 
@@ -311,8 +311,8 @@ message InvocationStatQuery {
   // The timestamp up to which the build was last updated (exclusive).
   google.protobuf.Timestamp updated_before = 8;
 
-  // Allowed invocation statuses. Must be explicitly specified, or no
-  // invocations will be returned.
+  // Status of the build. If multiple are specified, they are combined with
+  // "OR".
   repeated OverallStatus status = 9;
 }
 
@@ -401,6 +401,16 @@ message TrendQuery {
   // The role played by the build. Ex: "CI". Multiple filters are combined with
   // OR.
   repeated string role = 6;
+
+  // The timestamp on or after which the build was last updated (inclusive).
+  google.protobuf.Timestamp updated_after = 7;
+
+  // The timestamp up to which the build was last updated (exclusive).
+  google.protobuf.Timestamp updated_before = 8;
+
+  // Status of the build. If multiple are specified, they are combined with
+  // "OR".
+  repeated OverallStatus status = 9;
 }
 
 message GetTrendRequest {
@@ -410,7 +420,8 @@ message GetTrendRequest {
 
   // The maximum number of past days to aggregate. If not set, the server will
   // pick an appropriate value. Probably 7.
-  int32 lookback_window_days = 3;
+  // DEPRECATED: Use `query.updated_after` and `query.updated_before` instead.
+  int32 lookback_window_days = 3 [deprecated = true];
 }
 
 message GetTrendResponse {

--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -421,6 +421,7 @@ message GetTrendRequest {
   // The maximum number of past days to aggregate. If not set, the server will
   // pick an appropriate value. Probably 7.
   // DEPRECATED: Use `query.updated_after` and `query.updated_before` instead.
+  // TODO(bduffany): Delete this once clients no longer use it.
   int32 lookback_window_days = 3 [deprecated = true];
 }
 


### PR DESCRIPTION
* Implement status filtering for `SearchInvocationRequest`, `GetInvocationStatRequest`, `GetTrendRequest`
  * Change the documentated semantics for the `status` filter -- rather than requiring all desired statuses to be specified, it is more natural (and also backwards-compatible) to select all statuses by default, and for each filter to map one-to-one with an OR clause in SQL. It is also more natural for the user to build up a list of statuses they want to see (starting from an empty list, meaning "all statuses"), rather than subtract the ones they don't want to see.
* Update `GetTrendRequest` to allow filtering by the new timestamp fields instead of the `lookback_window`. Will remove the `lookback_window` support in another PR (once clients are using the new timestamp fields).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
