### PR TITLE
Get status filter working on history aggregate pages

### DIFF
--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -32,10 +32,8 @@ class Router {
     window.history.pushState({}, "", targetUrl);
   }
 
-  setQuery(params: Record<string, string>) {
-    const search = getQueryString(params);
-    let url = search ? `?${search}` : window.location.pathname;
-    window.history.replaceState({}, "", url);
+  setQuery(query: Record<string, string>) {
+    window.history.replaceState({}, "", getModifiedUrl({ query }));
   }
 
   navigateHome(hash?: string) {


### PR DESCRIPTION
The existing logic wasn't preserving the `#users`, `#repos`, etc. part of the URL

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
