### PR TITLE
Make role filters work the same way as status filters

### DIFF
--- a/enterprise/app/filter/filter.css
+++ b/enterprise/app/filter/filter.css
@@ -91,6 +91,10 @@
   --status-color: #aaa;
 }
 
+.global-filter .role-badge.DEFAULT {
+  background: #eee;
+}
+
 .global-filter .square {
   width: var(--row-height);
   height: var(--row-height);

--- a/enterprise/app/filter/filter_util.tsx
+++ b/enterprise/app/filter/filter_util.tsx
@@ -10,7 +10,7 @@ import {
 } from "../../../app/router/router";
 
 // URL param value representing the empty role (""), which is the default.
-const DEFAULT_ROLE = "DEFAULT";
+const DEFAULT_ROLE_PARAM_VALUE = "DEFAULT";
 
 export interface ProtoFilterParams {
   role?: string[];
@@ -44,12 +44,12 @@ export function statusFromString(value: string) {
 
 export function parseRoleParam(paramValue?: string): string[] {
   if (!paramValue) return [];
-  return paramValue.split(" ").map((role) => (role === DEFAULT_ROLE ? "" : role));
+  return paramValue.split(" ").map((role) => (role === DEFAULT_ROLE_PARAM_VALUE ? "" : role));
 }
 
 export function toRoleParam(roles: Iterable<string>): string {
   return [...roles]
-    .map((role) => (role === "" ? DEFAULT_ROLE : role))
+    .map((role) => (role === "" ? DEFAULT_ROLE_PARAM_VALUE : role))
     .sort()
     .join(" ");
 }

--- a/enterprise/app/filter/filter_util.tsx
+++ b/enterprise/app/filter/filter_util.tsx
@@ -9,8 +9,11 @@ import {
   STATUS_PARAM_NAME,
 } from "../../../app/router/router";
 
+// URL param value representing the empty role (""), which is the default.
+const DEFAULT_ROLE = "DEFAULT";
+
 export interface ProtoFilterParams {
-  role?: string;
+  role?: string[];
   updatedAfter?: google.protobuf.Timestamp;
   updatedBefore?: google.protobuf.Timestamp;
   status?: invocation.OverallStatus[];
@@ -18,9 +21,9 @@ export interface ProtoFilterParams {
 
 export function getProtoFilterParams(search: URLSearchParams): ProtoFilterParams {
   return {
-    role: search.get(ROLE_PARAM_NAME),
     updatedAfter: parseStartOfDay(search.get(START_DATE_PARAM_NAME)),
     updatedBefore: parseStartOfDay(search.get(END_DATE_PARAM_NAME), /*offsetDays=*/ +1),
+    role: parseRoleParam(search.get(ROLE_PARAM_NAME)),
     status: parseStatusParam(search.get(STATUS_PARAM_NAME)),
   };
 }
@@ -37,6 +40,18 @@ export function statusFromString(value: string) {
   return (invocation.OverallStatus[
     value.toUpperCase().replace(/-/g, "_") as any
   ] as unknown) as invocation.OverallStatus;
+}
+
+export function parseRoleParam(paramValue?: string): string[] {
+  if (!paramValue) return [];
+  return paramValue.split(" ").map((role) => (role === DEFAULT_ROLE ? "" : role));
+}
+
+export function toRoleParam(roles: Iterable<string>): string {
+  return [...roles]
+    .map((role) => (role === "" ? DEFAULT_ROLE : role))
+    .sort()
+    .join(" ");
 }
 
 export function parseStatusParam(paramValue?: string): invocation.OverallStatus[] {

--- a/enterprise/server/invocation_search_service/invocation_search_service.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service.go
@@ -138,8 +138,12 @@ func (s *InvocationSearchService) QueryInvocations(ctx context.Context, req *inp
 	if group_id := req.GetQuery().GetGroupId(); group_id != "" {
 		q.AddWhereClause("i.group_id = ?", group_id)
 	}
-	if role := req.GetQuery().GetRole(); role != "" {
-		q.AddWhereClause("i.role = ?", role)
+	roleClauses := query_builder.OrClauses{}
+	for _, role := range req.GetQuery().GetRole() {
+		roleClauses.AddOr("i.role = ?", role)
+	}
+	if roleQuery, roleArgs := roleClauses.Build(); roleQuery != "" {
+		q.AddWhereClause("("+roleQuery+")", roleArgs...)
 	}
 	if start := req.GetQuery().GetUpdatedAfter(); start.IsValid() {
 		q.AddWhereClause("i.updated_at_usec >= ?", timeutil.ToUsec(start.AsTime()))

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -97,11 +97,10 @@ func (i *InvocationStatService) GetTrend(ctx context.Context, req *inpb.GetTrend
 
 	roleClauses := query_builder.OrClauses{}
 	for _, role := range req.GetQuery().GetRole() {
-		roleClauses.AddOr(`role = ?`, role)
+		roleClauses.AddOr("i.role = ?", role)
 	}
-	roleQuery, roleArgs := roleClauses.Build()
-	if roleQuery != "" {
-		q.AddWhereClause(fmt.Sprintf("(%s)", roleQuery), roleArgs...)
+	if roleQuery, roleArgs := roleClauses.Build(); roleQuery != "" {
+		q.AddWhereClause("("+roleQuery+")", roleArgs...)
 	}
 
 	if start := req.GetQuery().GetUpdatedAfter(); start.IsValid() {
@@ -207,8 +206,12 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 		q.AddWhereClause("commit = ?", commitSHA)
 	}
 
-	if role := req.GetQuery().GetRole(); role != "" {
-		q.AddWhereClause("role = ?", role)
+	roleClauses := query_builder.OrClauses{}
+	for _, role := range req.GetQuery().GetRole() {
+		roleClauses.AddOr("i.role = ?", role)
+	}
+	if roleQuery, roleArgs := roleClauses.Build(); roleQuery != "" {
+		q.AddWhereClause("("+roleQuery+")", roleArgs...)
 	}
 
 	if start := req.GetQuery().GetUpdatedAfter(); start.IsValid() {

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -97,7 +97,7 @@ func (i *InvocationStatService) GetTrend(ctx context.Context, req *inpb.GetTrend
 
 	roleClauses := query_builder.OrClauses{}
 	for _, role := range req.GetQuery().GetRole() {
-		roleClauses.AddOr("i.role = ?", role)
+		roleClauses.AddOr("role = ?", role)
 	}
 	if roleQuery, roleArgs := roleClauses.Build(); roleQuery != "" {
 		q.AddWhereClause("("+roleQuery+")", roleArgs...)
@@ -208,7 +208,7 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 
 	roleClauses := query_builder.OrClauses{}
 	for _, role := range req.GetQuery().GetRole() {
-		roleClauses.AddOr("i.role = ?", role)
+		roleClauses.AddOr("role = ?", role)
 	}
 	if roleQuery, roleArgs := roleClauses.Build(); roleQuery != "" {
 		q.AddWhereClause("("+roleQuery+")", roleArgs...)

--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -168,8 +168,9 @@ message InvocationQuery {
   // The commit sha used for the build.
   string commit_sha = 5;
 
-  // The ROLE metadata set on the build.
-  string role = 6;
+  // The ROLE metadata set on the build. If multiple filters are specified, they
+  // are combined with "OR".
+  repeated string role = 6;
 
   // The timestamp on or after which the build was last updated (inclusive).
   google.protobuf.Timestamp updated_after = 7;
@@ -302,8 +303,9 @@ message InvocationStatQuery {
   // The commit sha used for the build.
   string commit_sha = 5;
 
-  // The role played by the build. Ex: "CI"
-  string role = 6;
+  // The role played by the build. Ex: "CI". If multiple role filters are
+  // specified, they are combined with "OR".
+  repeated string role = 6;
 
   // The timestamp on or after which the build was last updated (inclusive).
   google.protobuf.Timestamp updated_after = 7;
@@ -398,8 +400,8 @@ message TrendQuery {
   // The commit sha used for the build.
   string commit_sha = 5;
 
-  // The role played by the build. Ex: "CI". Multiple filters are combined with
-  // OR.
+  // The role played by the build. Ex: "CI". If multiple filters are specified,
+  // they are combined with "OR".
   repeated string role = 6;
 
   // The timestamp on or after which the build was last updated (inclusive).


### PR DESCRIPTION
Instead of radio buttons, now using checkboxes.

Required an API change to allow selecting any combination of roles. The API change is backwards-compatible.

![image](https://user-images.githubusercontent.com/2414826/128927344-53dcbc91-9ab4-4cd0-919f-45fc8310c4d4.png)


---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
