### PR TITLE
Add some unit tests for query_builder.OrClauses

### DIFF
--- a/server/util/query_builder/BUILD
+++ b/server/util/query_builder/BUILD
@@ -1,8 +1,17 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "query_builder",
     srcs = ["query_builder.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/query_builder",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "query_builder_test",
+    srcs = ["query_builder_test.go"],
+    deps = [
+        ":query_builder",
+        "@com_github_stretchr_testify//assert",
+    ],
 )

--- a/server/util/query_builder/query_builder.go
+++ b/server/util/query_builder/query_builder.go
@@ -107,9 +107,7 @@ type OrClauses struct {
 
 func (o *OrClauses) AddOr(clause string, args ...interface{}) *OrClauses {
 	o.whereClauses = append(o.whereClauses, pad(clause))
-	for _, arg := range args {
-		o.arguments = append(o.arguments, arg)
-	}
+	o.arguments = append(o.arguments, args...)
 	return o
 }
 

--- a/server/util/query_builder/query_builder_test.go
+++ b/server/util/query_builder/query_builder_test.go
@@ -1,0 +1,39 @@
+package query_builder_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/query_builder"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrClauses_Empty(t *testing.T) {
+	q := query_builder.OrClauses{}
+
+	qStr, qArgs := q.Build()
+
+	assert.Empty(t, qStr, "query string built from empty OrClauses should be empty (no whitespace allowed)")
+	assert.Empty(t, qArgs)
+}
+
+func TestOrClauses_Single(t *testing.T) {
+	q := query_builder.OrClauses{}
+
+	q.AddOr("a = ?", 1)
+	qStr, qArgs := q.Build()
+
+	assert.Equal(t, "a = ?", strings.TrimSpace(qStr))
+	assert.Equal(t, []interface{}{1}, qArgs)
+}
+
+func TestOrClauses_Multiple(t *testing.T) {
+	q := query_builder.OrClauses{}
+
+	q.AddOr("a = ?", 1)
+	q.AddOr("b = ?", 2)
+	qStr, qArgs := q.Build()
+
+	assert.Equal(t, "a = ? OR b = ?", strings.TrimSpace(qStr))
+	assert.Equal(t, []interface{}{1, 2}, qArgs)
+}


### PR DESCRIPTION
There's a few places in the code where we rely on `query_builder.OrClauses` returning an empty string when there are no clauses present, but it feels a bit brittle since that function could just as easily return `" "` which still seems like a valid result (especially since the current impl pads the returned string with whitespace in the non-empty case). Adding a unit test to enforce this expected behavior and avoid accidentally breaking stuff in the future.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
