### PR TITLE
Use Pacific Time for stats and trends queries

### DIFF
--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -42,7 +42,7 @@ func (i *InvocationStatService) getAggColumn(aggType inpb.AggType) string {
 	case inpb.AggType_COMMIT_SHA_AGGREGATION_TYPE:
 		return "commit_sha"
 	case inpb.AggType_DATE_AGGREGATION_TYPE:
-		return i.h.DateFromUsecTimestamp("updated_at_usec")
+		return i.h.PTDateFromUsecTimestamp("updated_at_usec")
 	default:
 		log.Errorf("Unknown aggregation column type: %s", aggType)
 		return ""
@@ -58,7 +58,7 @@ func (i *InvocationStatService) GetTrend(ctx context.Context, req *inpb.GetTrend
 		return nil, status.ResourceExhaustedErrorf("Too many rows.")
 	}
 
-	q := query_builder.NewQuery(fmt.Sprintf("SELECT %s as name,", i.h.DateFromUsecTimestamp("updated_at_usec")) + `
+	q := query_builder.NewQuery(fmt.Sprintf("SELECT %s as name,", i.h.PTDateFromUsecTimestamp("updated_at_usec")) + `
 	    SUM(CASE WHEN duration_usec > 0 THEN duration_usec END) as total_build_time_usec,
 	    COUNT(1) as total_num_builds,
 	    SUM(CASE WHEN duration_usec > 0 THEN 1 ELSE 0 END) as completed_invocation_count,


### PR DESCRIPTION
Queries that aggregate by calendar day (`YYYY-MM-DD`) suffer from timezone issues because they try to convert Unix timestamps to calendar days. Currently, we implicitly use UTC as the timezone when doing this conversion. This is a problem because the new global filter does date filtering according to the client's local timezone, which may not be UTC.

We decided that we don't yet want to implement full timezone support (which would require passing the timezone string from the client to the server). But for the global filter, we also don't want the client to filter according to their local time, because we don't support that for stats/trends queries and it is confusing to not use the same timezone across the UI.

So, we decided to standardize on using PT (`America/Los_Angeles`) everywhere, and this PR is the first step towards that.

* Our deployed MySQL instances have timezone data available for `America/Los_Angeles` (I tested the new query against one of our replicas), so we are covered on that front.
* In JS we can reliably convert a `Date` to a YYYY-MM-DD date in Pacific Time using `date.toLocaleDateString("fr-CA", {timeZone: "America/Los_Angeles"})`, so we are covered on the client as well.

In subsequent PRs we'll update the UI to use Pacific Time as well, including the timestamps requested by the client. The client will make all requests using the same time zone that we expect on the server. So for example, when filtering to 2021-01-01, they'll see results only from 2021-01-01 PT.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
