### PR TITLE
Fix ReadFile calls when using bundle filesystem

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -17,7 +17,7 @@ import (
 var all embed.FS
 
 type aliasFS struct {
-	embed.FS
+	FS            embed.FS
 	remappedPaths map[string]string
 }
 
@@ -34,7 +34,7 @@ func Get() (fs.FS, error) {
 		FS:            all,
 		remappedPaths: make(map[string]string, 0),
 	}
-	// This is annoying but necesary -- we bundle some binary files that
+	// This is annoying but necessary -- we bundle some binary files that
 	// end up in a bazel-out/$arch/bin directory. Rather than try to read
 	// them by their full name, which is $arch dependent, we glob them
 	// and alias them under a path that does not contain the $arch


### PR DESCRIPTION
We call `fs.ReadFile(bundleFS, "sha.sum")` to get the sha of the app js bundle.

`ReadFile`'s documentation reads:
> If fs implements ReadFileFS, ReadFile calls fs.ReadFile. Otherwise ReadFile calls fs.Open and uses Read and Close on the returned file.

Because we were embedding `embed.FS` into `aliasFS`, we were implementing `ReadFileFS` which would not take our aliasing into account.

This only turned out to be a problem for builds built with `-c opt` that didn't specify an `app_directory`. Unfortunately this included the open source docker image builds between versions `2.3.3` and `2.4.9`.

Enterprise docker images and builds run with `bazel run` where not affected.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
