### PR TITLE
Fix release rule

### DIFF
--- a/rules/release/index.bzl
+++ b/rules/release/index.bzl
@@ -29,7 +29,7 @@ def release(name, run, after, enable_actions = True, **kwargs):
     for action in actions:
         native.genrule(
             name = name + action,
-            tools = [run + action, after + action],
+            exec_tools = [run + action, after + action],
             outs = [name + action + ".out"],
             cmd = "echo \"bash $(location %s) && bash $(location %s);\" > $@" % (after + action, run + action),
             local = 1,


### PR DESCRIPTION
From the `genrule` [documentation](https://docs.bazel.build/versions/main/be/general.html#genrule.tools) for `exec_tools`:

> A list of tool dependencies for this rule. This behaves exactly like the tools attribute, except that these dependencies will be configured for the rule's execution platform instead of the host configuration. This means that dependencies in exec_tools are not subject to the same limitations as dependencies in tools. In particular, they are not required to use the host configuration for their own transitive dependencies. See tools for further details.

>The Bazel team is migrating all uses of tools to use exec_tools semantics. Users are encouraged to prefer exec_tools to tools where this does not cause any issues. After the functional migration is complete, we may rename exec_tools to tools. You will receive a deprecation warning and migration instructions before this happens.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
