### PR TITLE
Track unclaimed tasks in Redis.

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1,7 +1,6 @@
 package scheduler_server
 
 import (
-	"container/list"
 	"context"
 	"fmt"
 	"io"
@@ -71,7 +70,9 @@ const (
 	redisTaskClaimedField     = "claimed"
 
 	// Maximum number of unclaimed task IDs we track per pool.
-	maxUnclaimedTasksTracked = 1000
+	maxUnclaimedTasksTracked = 10_000
+	// TTL for sets used to track unclaimed tasks in Redis. TTL is extended when new tasks are added.
+	unclaimedTaskSetTTL = 1 * time.Hour
 
 	unusedSchedulerClientExpiration    = 5 * time.Minute
 	unusedSchedulerClientCheckInterval = 1 * time.Minute
@@ -178,32 +179,40 @@ type nodePoolKey struct {
 	pool    string
 }
 
-func (k *nodePoolKey) toRedisKey() string {
-	key := "executorPool/"
+func (k *nodePoolKey) redisKeySuffix() string {
+	key := ""
 	if k.groupID != "" {
 		key += k.groupID + "-"
 	}
 	return key + fmt.Sprintf("%s-%s-%s", k.os, k.arch, k.pool)
 }
 
+func (k *nodePoolKey) redisPoolKey() string {
+	return "executorPool/" + k.redisKeySuffix()
+}
+
+func (k *nodePoolKey) redisUnclaimedTasksKey() string {
+	return "unclaimedTasks/" + k.redisKeySuffix()
+}
+
 type nodePool struct {
-	env            environment.Env
-	mu             sync.Mutex
-	lastFetch      time.Time
-	useRedis       bool
-	nodes          []*executionNode
-	key            nodePoolKey
-	unclaimedTasks *unclaimedTasksList
+	env                     environment.Env
+	rdb                     *redis.Client
+	mu                      sync.Mutex
+	lastFetch               time.Time
+	fetchExecutorsFromRedis bool
+	nodes                   []*executionNode
+	key                     nodePoolKey
 	// Executors that are currently connected to this instance of the scheduler server.
 	connectedExecutors []*executionNode
 }
 
-func newNodePool(env environment.Env, key nodePoolKey, useRedis bool) *nodePool {
+func newNodePool(env environment.Env, key nodePoolKey, fetchExecutorsFromRedis bool) *nodePool {
 	np := &nodePool{
-		env:            env,
-		key:            key,
-		useRedis:       useRedis,
-		unclaimedTasks: newUnclaimedTasksList(),
+		env:                     env,
+		key:                     key,
+		rdb:                     env.GetRemoteExecutionRedisClient(),
+		fetchExecutorsFromRedis: fetchExecutorsFromRedis,
 	}
 	return np
 }
@@ -248,9 +257,7 @@ func (np *nodePool) fetchExecutionNodesFromDB(ctx context.Context) ([]*execution
 }
 
 func (np *nodePool) fetchExecutionNodesFromRedis(ctx context.Context) ([]*executionNode, error) {
-	rdb := np.env.GetRemoteExecutionRedisClient()
-
-	redisExecutors, err := rdb.HGetAll(ctx, np.key.toRedisKey()).Result()
+	redisExecutors, err := np.rdb.HGetAll(ctx, np.key.redisPoolKey()).Result()
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +280,7 @@ func (np *nodePool) fetchExecutionNodesFromRedis(ctx context.Context) ([]*execut
 }
 
 func (np *nodePool) fetchExecutionNodes(ctx context.Context) ([]*executionNode, error) {
-	if np.useRedis {
+	if np.fetchExecutorsFromRedis {
 		return np.fetchExecutionNodesFromRedis(ctx)
 	}
 	return np.fetchExecutionNodesFromDB(ctx)
@@ -361,70 +368,52 @@ func (np *nodePool) FindConnectedExecutorByID(executorID string) *executionNode 
 	return nil
 }
 
-// unclaimedTasksList maintains a subset of unclaimed task IDs that can be given out to newly registered executors.
-// Only the most recent maxUnclaimedTasksTracked task IDs are kept.
-type unclaimedTasksList struct {
-	taskList *list.List
-	taskMap  map[string]*list.Element
-	mu       sync.Mutex
+func (np *nodePool) AddUnclaimedTask(ctx context.Context, taskID string) error {
+	key := np.key.redisUnclaimedTasksKey()
+	m := &redis.Z{
+		Member: taskID,
+		Score:  float64(time.Now().Unix()),
+	}
+	err := np.rdb.ZAdd(ctx, key, m).Err()
+	if err != nil {
+		return err
+	}
+	err = np.rdb.Expire(ctx, key, unclaimedTaskSetTTL).Err()
+	if err != nil {
+		return err
+	}
+
+	// Trim the set if necessary.
+	// The next 2 commands are not atomic but it's okay if the list length is not exactly what we want.
+	n, err := np.rdb.ZCard(ctx, key).Result()
+	if err != nil {
+		return err
+	}
+	if n > maxUnclaimedTasksTracked {
+		// Trim the oldest tasks. We use the task insertion timestamp as the score so the oldest task is at rank 0, next
+		// oldest is at rank 1 and so on. We subtract 1 because the indexes are inclusive.
+		return np.rdb.ZRemRangeByRank(ctx, key, 0, n-maxUnclaimedTasksTracked-1).Err()
+	}
+	return nil
 }
 
-func newUnclaimedTasksList() *unclaimedTasksList {
-	l := &unclaimedTasksList{}
-	l.taskList = list.New()
-	l.taskMap = make(map[string]*list.Element)
-	return l
+func (np *nodePool) RemoveUnclaimedTask(ctx context.Context, taskID string) error {
+	return np.rdb.ZRem(ctx, np.key.redisUnclaimedTasksKey(), taskID).Err()
 }
 
-func (l *unclaimedTasksList) addTask(taskID string) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	if _, exists := l.taskMap[taskID]; exists {
-		return
+func (np *nodePool) SampleUnclaimedTasks(ctx context.Context, n int) ([]string, error) {
+	// Get all task IDs. Redis >=6.2 has a ZRANDMEMBER command, but we don't want to assume that onprem customers have a
+	// relatively new Redis version.
+	unclaimed, err := np.rdb.ZRange(ctx, np.key.redisUnclaimedTasksKey(), 0, -1).Result()
+	if err != nil {
+		return nil, err
 	}
-	e := l.taskList.PushBack(taskID)
-	l.taskMap[taskID] = e
-	if l.taskList.Len() > maxUnclaimedTasksTracked {
-		v := l.taskList.Remove(l.taskList.Front())
-		s, ok := v.(string)
-		if !ok { // Should never happen.
-			log.Warningf("non-string value in list: %T", v)
-			return
-		}
-		delete(l.taskMap, s)
-	}
-}
-
-func (l *unclaimedTasksList) removeTask(taskID string) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	e, ok := l.taskMap[taskID]
-	if !ok {
-		return
-	}
-	delete(l.taskMap, taskID)
-	l.taskList.Remove(e)
-}
-
-func (l *unclaimedTasksList) sample(n int) []string {
-	l.mu.Lock()
-	unclaimed := make([]string, 0, l.taskList.Len())
-	for e := l.taskList.Front(); e != nil; e = e.Next() {
-		taskID, ok := e.Value.(string)
-		if !ok {
-			log.Warningf("Unexpected type in container: %T", e.Value)
-			continue
-		}
-		unclaimed = append(unclaimed, taskID)
-	}
-	l.mu.Unlock()
-
 	// Random sample (without replacement) up to `count` tasks from the
 	// returned results.
 	rand.Shuffle(len(unclaimed), func(i, j int) {
 		unclaimed[i], unclaimed[j] = unclaimed[j], unclaimed[i]
 	})
-	return unclaimed[:minInt(n, len(unclaimed))]
+	return unclaimed[:minInt(n, len(unclaimed))], nil
 }
 
 type persistedTask struct {
@@ -636,7 +625,7 @@ func (s *SchedulerServer) deleteNodeFromRedis(ctx context.Context, node *scpb.Ex
 	if err := s.checkPreconditions(node); err != nil {
 		return err
 	}
-	return s.rdb.HDel(ctx, poolKey.toRedisKey(), node.GetExecutorId()).Err()
+	return s.rdb.HDel(ctx, poolKey.redisPoolKey(), node.GetExecutorId()).Err()
 }
 
 func (s *SchedulerServer) deleteNode(ctx context.Context, node *scpb.ExecutionNode, poolKey nodePoolKey) error {
@@ -734,7 +723,7 @@ func (s *SchedulerServer) insertOrUpdateNodeInRedis(ctx context.Context, executo
 	}
 
 	pipe := s.rdb.TxPipeline()
-	poolRedisKey := poolKey.toRedisKey()
+	poolRedisKey := poolKey.redisPoolKey()
 	pipe.HSet(ctx, poolRedisKey, node.GetExecutorId(), b)
 	pipe.SAdd(ctx, s.redisKeyForExecutorPools(groupID), poolRedisKey)
 	_, err = pipe.Exec(ctx)
@@ -1000,7 +989,10 @@ func (s *SchedulerServer) sampleUnclaimedTasks(ctx context.Context, count int, n
 	if !ok {
 		return nil, nil
 	}
-	taskIDs := nodePool.unclaimedTasks.sample(count)
+	taskIDs, err := nodePool.SampleUnclaimedTasks(ctx, count)
+	if err != nil {
+		return nil, err
+	}
 	tasks, err := s.readTasks(ctx, taskIDs)
 	if err != nil {
 		return nil, err
@@ -1150,7 +1142,10 @@ func (s *SchedulerServer) LeaseTask(stream scpb.Scheduler_LeaseTaskServer) error
 			}
 			nodePool, ok := s.getPool(key)
 			if ok {
-				nodePool.unclaimedTasks.removeTask(taskID)
+				err := nodePool.RemoveUnclaimedTask(ctx, taskID)
+				if err != nil {
+					log.Warningf("Could not remove task from unclaimed list: %s", err)
+				}
 			}
 
 			// Prometheus: observe queue wait time.
@@ -1210,7 +1205,10 @@ func (s *SchedulerServer) enqueueTaskReservations(ctx context.Context, enqueueRe
 		return err
 	}
 
-	nodeBalancer.unclaimedTasks.addTask(enqueueRequest.GetTaskId())
+	err = nodeBalancer.AddUnclaimedTask(ctx, enqueueRequest.GetTaskId())
+	if err != nil {
+		log.Warningf("Could not add task to unclaimed task list: %s", err)
+	}
 
 	probeCount := minInt(opts.numReplicas, nodeCount)
 	probesSent := 0

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -495,7 +495,7 @@ func TestMultipleSchedulersAndExecutors_RedisExecutorPools(t *testing.T) {
 func TestWorkSchedulingOnNewExecutor(t *testing.T) {
 	rbe := rbetest.NewRBETestEnv(t)
 
-	rbe.AddBuildBuddyServer()
+	rbe.AddBuildBuddyServers(5)
 	rbe.AddSingleTaskExecutorWithOptions(&rbetest.ExecutorOptions{Name: "busyExecutor1"})
 	rbe.AddSingleTaskExecutorWithOptions(&rbetest.ExecutorOptions{Name: "busyExecutor2"})
 


### PR DESCRIPTION
Sharing the state across schedulers will give us better scheduling
during upscaling.

We use a sorted set per executor pool to track unclaimed tasks.

This is a roll-forward of
https://github.com/buildbuddy-io/buildbuddy/pull/748.
This time around we don't rely on the availability of the ZRANDMEMBER
command which requires Redis 6.2
Instead we fetch the entire set of task IDs and do our own sampling.
The task ID set has a relatively small upper bound (10k) and in practice should be much smaller than that.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
