### PR TITLE
Display errors passed through the `?error=` url query param using the error service

### DIFF
--- a/app/errors/BUILD
+++ b/app/errors/BUILD
@@ -10,6 +10,7 @@ ts_library(
     ]),
     deps = [
         "//app/alert",
+        "//app/router",
         "//app/util:errors",
     ],
 )

--- a/app/errors/error_service.ts
+++ b/app/errors/error_service.ts
@@ -1,7 +1,17 @@
-import { BuildBuddyError } from "../../app/util/errors";
+import router from "../router/router";
+import { BuildBuddyError } from "../util/errors";
 import alertService from "../alert/alert_service";
 
+const ERROR_SEARCH_PARAM = "error";
 export class ErrorService {
+  register() {
+    let searchParams = new URLSearchParams(window.location.search);
+    if (searchParams.has(ERROR_SEARCH_PARAM)) {
+      this.handleError(searchParams.get(ERROR_SEARCH_PARAM));
+    }
+    router.replaceParams({ ERROR_SEARCH_PARAM: undefined });
+  }
+
   handleError(e: any) {
     console.error(e);
 

--- a/app/root/BUILD.bazel
+++ b/app/root/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
         "//app/capabilities",
         "//app/compare",
         "//app/docs",
+        "//app/errors",
         "//app/favicon",
         "//app/footer",
         "//app/invocation",

--- a/app/root/root.tsx
+++ b/app/root/root.tsx
@@ -7,6 +7,7 @@ import capabilities from "../capabilities/capabilities";
 import router, { Path } from "../router/router";
 import authService from "../auth/auth_service";
 import { User } from "../auth/auth_service";
+import errorService from "../errors/error_service";
 import faviconService from "../favicon/favicon";
 import CompareInvocationsComponent from "../compare/compare_invocations";
 import AlertComponent from "../alert/alert";
@@ -39,6 +40,10 @@ export default class RootComponent extends React.Component {
       next: (user: User) => this.setState({ ...this.state, user }),
     });
     faviconService.setDefaultFavicon();
+  }
+
+  componentDidMount() {
+    errorService.register();
   }
 
   handlePathChange() {

--- a/app/util/errors.ts
+++ b/app/util/errors.ts
@@ -14,7 +14,7 @@ export class BuildBuddyError extends Error {
     const pattern = /code = (.*?) desc = (.*)$/;
     const match = error.match(pattern);
     if (!match) {
-      return new BuildBuddyError("Unknown", "Internal error");
+      return new BuildBuddyError("Unknown", error || "Internal error");
     }
 
     const [_, code, description] = match;

--- a/enterprise/app/root/BUILD.bazel
+++ b/enterprise/app/root/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
         "//app/capabilities",
         "//app/compare",
         "//app/docs",
+        "//app/errors",
         "//app/favicon",
         "//app/footer",
         "//app/invocation",

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -10,6 +10,7 @@ import WorkflowsComponent from "../workflows/workflows";
 import InvocationComponent from "../../../app/invocation/invocation";
 import MenuComponent from "../../../app/menu/menu";
 import router, { Path } from "../../../app/router/router";
+import errorService from "../../../app/errors/error_service";
 import HistoryComponent from "../history/history";
 import LoginComponent from "../login/login";
 import CreateOrgComponent from "../org/create_org";
@@ -67,6 +68,10 @@ export default class EnterpriseRootComponent extends React.Component {
     authService.register();
     router.register(this.handlePathChange.bind(this));
     faviconService.setDefaultFavicon();
+  }
+
+  componentDidMount() {
+    errorService.register();
   }
 
   handlePathChange() {


### PR DESCRIPTION
This uses the same BuildBuddyError parsing logic that will properly display golang-style errors.

Here's what this looks like:
<img width="1402" alt="Screen Shot 2021-08-13 at 11 56 02 AM" src="https://user-images.githubusercontent.com/1704556/129406171-b59fb1dc-ac87-4052-b343-4ed6063372c4.png">

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
