### PR TITLE
Update server side error redirects to pass error via new `?error=` url param

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -790,16 +790,14 @@ func (a *OpenIDAuthenticator) Login(w http.ResponseWriter, r *http.Request) {
 	if slug := r.URL.Query().Get(slugParam); slug != "" {
 		auth = a.getAuthConfigForSlug(slug)
 		if auth == nil {
-			err := status.PermissionDeniedErrorf("No SSO config found for slug: %s", slug)
-			http.Error(w, err.Error(), http.StatusUnauthorized)
+			redirectWithError(w, r, status.PermissionDeniedErrorf("No SSO config found for slug: %s", slug))
 			return
 		}
 		issuer = auth.getIssuer()
 	}
 
 	if auth == nil {
-		err := status.PermissionDeniedErrorf("No config found for issuer: %s", issuer)
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		redirectWithError(w, r, status.PermissionDeniedErrorf("No config found for issuer: %s", issuer))
 		return
 	}
 
@@ -810,7 +808,7 @@ func (a *OpenIDAuthenticator) Login(w http.ResponseWriter, r *http.Request) {
 
 	redirectURL := r.URL.Query().Get(authRedirectParam)
 	if err := a.validateRedirectURL(redirectURL); err != nil {
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		redirectWithError(w, r, err)
 		return
 	}
 
@@ -842,17 +840,13 @@ func (a *OpenIDAuthenticator) Auth(w http.ResponseWriter, r *http.Request) {
 
 	// Verify "state" cookie match.
 	if r.FormValue("state") != getCookie(r, stateCookie) {
-		log.Printf("state mismatch: %s != %s", r.FormValue("state"), getCookie(r, stateCookie))
-		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+		redirectWithError(w, r, status.PermissionDeniedErrorf("state mismatch: %s != %s", r.FormValue("state"), getCookie(r, stateCookie)))
 		return
 	}
 
 	authError := r.URL.Query().Get("error")
 	if authError != "" {
-		authErrorDesc := r.URL.Query().Get("error_desc")
-		authErrorDescription := r.URL.Query().Get("error_description")
-		log.Warningf("Authenticator returned error: %s (%s %s)", authError, authErrorDesc, authErrorDescription)
-		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+		redirectWithError(w, r, status.PermissionDeniedErrorf("Authenticator returned error: %s (%s %s)", authError, r.URL.Query().Get("error_desc"), r.URL.Query().Get("error_description")))
 		return
 	}
 
@@ -860,29 +854,27 @@ func (a *OpenIDAuthenticator) Auth(w http.ResponseWriter, r *http.Request) {
 	issuer := getCookie(r, authIssuerCookie)
 	auth := a.getAuthConfig(issuer)
 	if auth == nil {
-		err := status.PermissionDeniedErrorf("No config found for issuer: %s", issuer)
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		redirectWithError(w, r, status.PermissionDeniedErrorf("No config found for issuer: %s", issuer))
 		return
 	}
 
 	code := r.URL.Query().Get("code")
 	oauth2Token, err := auth.exchange(ctx, code, authCodeOption...)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		redirectWithError(w, r, status.PermissionDeniedErrorf("Error exchanging code for auth token: %s", code))
 		return
 	}
 
 	// Extract the ID Token (JWT) from OAuth2 token.
 	jwt, ok := oauth2Token.Extra("id_token").(string)
 	if !ok {
-		err := status.PermissionDeniedErrorf("ID Token not present in auth response")
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		redirectWithError(w, r, status.PermissionDeniedErrorf("ID Token not present in auth response"))
 		return
 	}
 
 	ut, err := auth.verifyTokenAndExtractUser(ctx, jwt /*checkExpiry=*/, true)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		redirectWithError(w, r, err)
 		return
 
 	}
@@ -930,4 +922,9 @@ func UserFromTrustedJWT(ctx context.Context) (interfaces.UserInfo, error) {
 		return claims, nil
 	}
 	return nil, status.PermissionDeniedError("User not found")
+}
+
+func redirectWithError(w http.ResponseWriter, r *http.Request, err error) {
+	log.Warningf(err.Error())
+	http.Redirect(w, r, "/?error="+url.QueryEscape(err.Error()), http.StatusTemporaryRedirect)
 }

--- a/server/backends/github/BUILD
+++ b/server/backends/github/BUILD
@@ -11,5 +11,6 @@ go_library(
         "//server/util/log",
         "//server/util/perms",
         "//server/util/random",
+        "//server/util/status",
     ],
 )


### PR DESCRIPTION
This depends on https://github.com/buildbuddy-io/buildbuddy/pull/884 in order to display these errors to users

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
