### PR TITLE
Display (real) errors coming from CreateUser or GetUser using the ErrorService

### DIFF
--- a/app/auth/BUILD
+++ b/app/auth/BUILD
@@ -7,6 +7,7 @@ ts_library(
     srcs = glob(["*.ts"]),
     deps = [
         "//app/capabilities",
+        "//app/errors",
         "//app/service",
         "//proto:context_ts_proto",
         "//proto:group_ts_proto",

--- a/app/auth/BUILD
+++ b/app/auth/BUILD
@@ -9,6 +9,7 @@ ts_library(
         "//app/capabilities",
         "//app/errors",
         "//app/service",
+        "//app/util:errors",
         "//proto:context_ts_proto",
         "//proto:group_ts_proto",
         "//proto:user_id_ts_proto",

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -40,6 +40,7 @@ export class AuthService {
         this.emitUser(this.userFromResponse(response));
       })
       .catch((error: any) => {
+        // TODO(siggisim): Remove "not found" string matching after the next release.
         if (BuildBuddyError.parse(error).code == "Unauthenticated" || error.includes("not found")) {
           this.createUser();
         } else {

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -68,7 +68,8 @@ export class AuthService {
         this.refreshUser();
       })
       .catch((error: any) => {
-        if (BuildBuddyError.parse(error).code == "Unauthenticated") {
+        // TODO(siggisim): Remove "No user token" string matching after the next release.
+        if (BuildBuddyError.parse(error).code == "Unauthenticated" || error.includes("No user token")) {
           console.log("User was not created because no auth cookie was set, this is normal.");
           this.emitUser(null);
         } else {

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -67,7 +67,7 @@ export class AuthService {
         this.refreshUser();
       })
       .catch((error: any) => {
-        if (BuildBuddyError.parse(error).code == "Unauthenticated" || error.includes("No user token")) {
+        if (BuildBuddyError.parse(error).code == "Unauthenticated") {
           console.log("User was not created because no auth cookie was set, this is normal.");
           this.emitUser(null);
         } else {

--- a/app/util/errors.ts
+++ b/app/util/errors.ts
@@ -1,4 +1,4 @@
-export type ErrorCode = "Unknown" | "NotFound" | "PermissionDenied";
+export type ErrorCode = "Unknown" | "NotFound" | "PermissionDenied" | "Unauthenticated";
 
 export class BuildBuddyError extends Error {
   constructor(public code: ErrorCode, public description: string) {

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -748,9 +748,8 @@ func (a *OpenIDAuthenticator) authenticatedUser(ctx context.Context) (*Claims, e
 		}
 		return claims, nil
 	}
-	// NB: DO NOT CHANGE THIS ERROR MESSAGE. The client app matches it in
-	// order to trigger the CreateUser flow.
-	return nil, status.PermissionDeniedError("User not found")
+	// WARNING: app/auth/auth_service.ts depends on this string containing the text "not found" or using status UNAUTHENTICATED.
+	return nil, status.UnauthenticatedError("User not found")
 }
 
 func (a *OpenIDAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces.UserInfo, error) {
@@ -767,7 +766,8 @@ func (a *OpenIDAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces
 func (a *OpenIDAuthenticator) FillUser(ctx context.Context, user *tables.User) error {
 	t, ok := ctx.Value(contextUserKey).(*userToken)
 	if !ok {
-		return status.FailedPreconditionErrorf("No user token available to fill user")
+		// WARNING: app/auth/auth_service.ts depends on this string containing the text "No user token" or using status UNAUTHENTICATED.
+		return status.UnauthenticatedError("No user token available to fill user")
 	}
 
 	pk, err := tables.PrimaryKeyForTable("Users")
@@ -929,5 +929,6 @@ func UserFromTrustedJWT(ctx context.Context) (interfaces.UserInfo, error) {
 		}
 		return claims, nil
 	}
-	return nil, status.PermissionDeniedError("User not found")
+	// WARNING: app/auth/auth_service.ts depends on this string containing the text "not found" or using status UNAUTHENTICATED.
+	return nil, status.UnauthenticatedError("User not found")
 }

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -748,7 +748,7 @@ func (a *OpenIDAuthenticator) authenticatedUser(ctx context.Context) (*Claims, e
 		}
 		return claims, nil
 	}
-	// WARNING: app/auth/auth_service.ts depends on this string containing the text "not found" or using status UNAUTHENTICATED.
+	// WARNING: app/auth/auth_service.ts depends on this status being UNAUTHENTICATED.
 	return nil, status.UnauthenticatedError("User not found")
 }
 
@@ -929,6 +929,6 @@ func UserFromTrustedJWT(ctx context.Context) (interfaces.UserInfo, error) {
 		}
 		return claims, nil
 	}
-	// WARNING: app/auth/auth_service.ts depends on this string containing the text "not found" or using status UNAUTHENTICATED.
+	// WARNING: app/auth/auth_service.ts depends on this status being UNAUTHENTICATED.
 	return nil, status.UnauthenticatedError("User not found")
 }

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -766,7 +766,7 @@ func (a *OpenIDAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces
 func (a *OpenIDAuthenticator) FillUser(ctx context.Context, user *tables.User) error {
 	t, ok := ctx.Value(contextUserKey).(*userToken)
 	if !ok {
-		// WARNING: app/auth/auth_service.ts depends on this string containing the text "No user token" or using status UNAUTHENTICATED.
+		// WARNING: app/auth/auth_service.ts depends on this status being UNAUTHENTICATED.
 		return status.UnauthenticatedError("No user token available to fill user")
 	}
 

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -543,10 +543,10 @@ func (p *Pool) Get(ctx context.Context, task *repb.ExecutionTask) (*CommandRunne
 		return nil, err
 	}
 
-	// PermissionDenied and Unimplemented both imply that this is an
+	// PermissionDenied, Unauthenticated, Unimplemented both imply that this is an
 	// anonymous execution, so ignore those.
 	user, err := auth.UserFromTrustedJWT(ctx)
-	if err != nil && !status.IsPermissionDeniedError(err) && !status.IsUnimplementedError(err) {
+	if err != nil && !status.IsPermissionDeniedError(err) && !status.IsUnauthenticatedError(err) && !status.IsUnimplementedError(err) {
 		return nil, err
 	}
 	if props.RecycleRunner && err != nil {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -543,7 +543,7 @@ func (p *Pool) Get(ctx context.Context, task *repb.ExecutionTask) (*CommandRunne
 		return nil, err
 	}
 
-	// PermissionDenied, Unauthenticated, Unimplemented both imply that this is an
+	// PermissionDenied, Unauthenticated, Unimplemented all imply that this is an
 	// anonymous execution, so ignore those.
 	user, err := auth.UserFromTrustedJWT(ctx)
 	if err != nil && !status.IsPermissionDeniedError(err) && !status.IsUnauthenticatedError(err) && !status.IsUnimplementedError(err) {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -148,7 +148,7 @@ func (s *BuildBuddyServer) GetUser(ctx context.Context, req *uspb.GetUserRequest
 		return nil, err
 	}
 	if tu == nil {
-		// WARNING: app/auth/auth_service.ts depends on this string containing the text "not found" or using status UNAUTHENTICATED.
+		// WARNING: app/auth/auth_service.ts depends on this status being UNAUTHENTICATED.
 		return nil, status.UnauthenticatedError("User not found")
 	}
 	return &uspb.GetUserResponse{

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -148,6 +148,7 @@ func (s *BuildBuddyServer) GetUser(ctx context.Context, req *uspb.GetUserRequest
 		return nil, err
 	}
 	if tu == nil {
+		// WARNING: app/auth/auth_service.ts depends on this string containing the text "not found" or using status UNAUTHENTICATED.
 		return nil, status.UnauthenticatedError("User not found")
 	}
 	return &uspb.GetUserResponse{

--- a/server/nullauth/nullauth.go
+++ b/server/nullauth/nullauth.go
@@ -20,7 +20,7 @@ func (a *NullAuthenticator) AuthenticatedGRPCContext(ctx context.Context) contex
 }
 
 func (a *NullAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces.UserInfo, error) {
-	return nil, status.PermissionDeniedError("Auth not implemented")
+	return nil, status.UnauthenticatedError("Auth not implemented")
 }
 
 func (a *NullAuthenticator) FillUser(ctx context.Context, user *tables.User) error {

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -145,7 +145,7 @@ func (a *TestAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces.U
 			return u, nil
 		}
 	}
-	return nil, status.PermissionDeniedError("User not found")
+	return nil, status.UnauthenticatedError("User not found")
 }
 
 func (a *TestAuthenticator) FillUser(ctx context.Context, user *tables.User) error {

--- a/server/util/capabilities/BUILD
+++ b/server/util/capabilities/BUILD
@@ -9,8 +9,6 @@ go_library(
         "//proto:api_key_go_proto",
         "//server/environment",
         "//server/util/status",
-        "@org_golang_google_grpc//codes",
-        "@org_golang_google_grpc//status",
     ],
 )
 

--- a/server/util/capabilities/capabilities.go
+++ b/server/util/capabilities/capabilities.go
@@ -5,10 +5,8 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	"google.golang.org/grpc/codes"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
-	gstatus "google.golang.org/grpc/status"
 )
 
 var (

--- a/server/util/capabilities/capabilities.go
+++ b/server/util/capabilities/capabilities.go
@@ -55,7 +55,7 @@ func IsGranted(ctx context.Context, env environment.Env, cap akpb.ApiKey_Capabil
 	}
 	user, err := a.AuthenticatedUser(ctx)
 	if err != nil {
-		if isAnonymousUser := gstatus.Code(err) == codes.PermissionDenied; isAnonymousUser {
+		if isAnonymousUser := status.IsPermissionDeniedError(err) || status.IsUnauthenticatedError(err); isAnonymousUser {
 			if authIsRequired {
 				return false, nil
 			}

--- a/server/util/status/status_test.go
+++ b/server/util/status/status_test.go
@@ -33,7 +33,7 @@ func TestStatusIs(t *testing.T) {
 	assert.True(t, status.IsOutOfRangeError(err))
 	err = status.UnimplementedErrorf("Unimplemented")
 	assert.True(t, status.IsUnimplementedError(err))
-	err = status.InternalErrorf("nternal")
+	err = status.InternalErrorf("Internal")
 	assert.True(t, status.IsInternalError(err))
 	err = status.UnavailableErrorf("Unavailable")
 	assert.True(t, status.IsUnavailableError(err))


### PR DESCRIPTION
Right now we only console log errors from CreateUser / GetUser (we don't display them to the user).

This is because some of the errors are benign - specifically "User not found" from GetUser and "No user token available to fill user" from CreateUser.

This is mostly fine, but when we get real errors from CreateUser (like the auth token not containing an email address) - we just console log these errors which effectively swallows them.

This change clearly marks all of the server side errors that the client auth flow depends on and switches them to UNAUTHENTICATED errors. From the [status code docs](https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto#L86):
>   // The caller does not have permission to execute the specified
  // operation. `PERMISSION_DENIED` must not be used for rejections
  // caused by exhausting some resource (use `RESOURCE_EXHAUSTED`
  // instead for those errors). `PERMISSION_DENIED` must not be
  // used if the caller can not be identified (use `UNAUTHENTICATED`
  // instead for those errors). This error code does not imply the
  // request is valid or the requested entity exists or satisfies
  // other pre-conditions.

It then updates the client to look for those `UNAUTHENTICATED` statuses instead of doing more brittle error message string matching.

We still accept the string matching approach for the client side for one release to handle the case where a new client hits an old server during the rollout. After the next release, we can remove any string matching.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
