### PR TITLE
Handle bytestream /Read requests where read_offset == digest size

### DIFF
--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -436,6 +436,10 @@ func (c *CacheProxy) RemoteReader(ctx context.Context, peer, prefix string, isol
 		}
 	}()
 	err = <-firstError
+
+	if err == io.EOF {
+		return reader, nil
+	}
 	return reader, err
 }
 

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -437,7 +437,8 @@ func (c *CacheProxy) RemoteReader(ctx context.Context, peer, prefix string, isol
 	}()
 	err = <-firstError
 
-	if err == io.EOF {
+	// If we get an EOF, and we're expecting one - don't return an error.
+	if err == io.EOF && d.GetSizeBytes() == offset {
 		return reader, nil
 	}
 	return reader, err

--- a/enterprise/server/util/cacheproxy/cacheproxy_test.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy_test.go
@@ -131,6 +131,56 @@ func TestReader(t *testing.T) {
 	}
 }
 
+func TestReaderMaxOffset(t *testing.T) {
+	ctx := context.Background()
+	flags.Set(t, "auth.enable_anonymous_usage", "true")
+	te := getTestEnv(t, emptyUserMap)
+
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, te)
+	if err != nil {
+		t.Errorf("error attaching user prefix: %v", err)
+	}
+
+	peer := fmt.Sprintf("localhost:%d", app.FreePort(t))
+	c := cacheproxy.NewCacheProxy(te, te.GetCache(), peer)
+	if err := c.StartListening(); err != nil {
+		t.Fatalf("Error setting up cacheproxy: %s", err)
+	}
+	waitUntilServerIsAlive(peer)
+
+	randomSrc := &randomDataMaker{rand.NewSource(time.Now().Unix())}
+
+	// Read some random bytes.
+	buf := new(bytes.Buffer)
+	io.CopyN(buf, randomSrc, 100)
+	readSeeker := bytes.NewReader(buf.Bytes())
+
+	// Compute a digest for the random bytes.
+	d, err := digest.Compute(readSeeker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	readSeeker.Seek(0, 0)
+
+	// Set the random bytes in the cache (with a prefix)
+	err = te.GetCache().WithPrefix("foo").Set(ctx, d, buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Remote-read the random bytes back.
+	r, err := c.RemoteReader(ctx, peer, "foo", &dcpb.Isolation{}, d, d.GetSizeBytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	d2 := testdigest.ReadDigestAndClose(t, r)
+	emptyHash := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	if emptyHash != d2.GetHash() {
+		t.Fatalf("Digest uploaded %q != %q downloaded", emptyHash, d2.GetHash())
+	}
+
+}
+
 func TestWriter(t *testing.T) {
 	ctx := context.Background()
 	flags.Set(t, "auth.enable_anonymous_usage", "true")
@@ -619,8 +669,12 @@ func TestEmptyRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Remote-read the random bytes back.
-	_, err = c.RemoteReader(ctx, peer, prefix, &dcpb.Isolation{}, d, 0)
+	r, err := c.RemoteReader(ctx, peer, prefix, &dcpb.Isolation{}, d, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = r.Read(nil)
 	if err != io.EOF {
 		t.Fatal(err)
 	}
@@ -1098,9 +1152,14 @@ func TestEmptyRead_Isolation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Remote-read the random bytes back.
-	_, err = c.RemoteReader(ctx, peer, remoteInstanceName, isolation, d, 0)
+	r, err := c.RemoteReader(ctx, peer, remoteInstanceName, isolation, d, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = r.Read(nil)
 	if err != io.EOF {
 		t.Fatal(err)
 	}
+
 }

--- a/enterprise/server/util/cacheproxy/cacheproxy_test.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy_test.go
@@ -162,14 +162,15 @@ func TestReaderMaxOffset(t *testing.T) {
 	}
 	readSeeker.Seek(0, 0)
 
+	instanceName := "foo"
 	// Set the random bytes in the cache (with a prefix)
-	err = te.GetCache().WithPrefix("foo").Set(ctx, d, buf.Bytes())
+	err = te.GetCache().WithPrefix(instanceName).Set(ctx, d, buf.Bytes())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Remote-read the random bytes back.
-	r, err := c.RemoteReader(ctx, peer, "foo", &dcpb.Isolation{}, d, d.GetSizeBytes())
+	r, err := c.RemoteReader(ctx, peer, instanceName, &dcpb.Isolation{}, d, d.GetSizeBytes())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -103,9 +103,6 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 		ht.TrackEmptyHit()
 		return nil
 	}
-	if req.ReadOffset == d.GetSizeBytes() {
-		return nil
-	}
 	reader, err := cache.Reader(ctx, d, req.ReadOffset)
 	if err != nil {
 		ht.TrackMiss(d)

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -103,6 +103,9 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 		ht.TrackEmptyHit()
 		return nil
 	}
+	if req.ReadOffset == d.GetSizeBytes() {
+		return nil
+	}
 	reader, err := cache.Reader(ctx, d, req.ReadOffset)
 	if err != nil {
 		ht.TrackMiss(d)


### PR DESCRIPTION
The fix is the 3 line change in `byte_stream_server.go`, but this PR also adds tests for this scenario in:
- distributed_test.go
- cacheproxy_test.go
- disk_cache_test.go
- byte_stream_server_test.go

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
