### PR TITLE
Don't show error alerts on invocations page for errors we already have pages for

### DIFF
--- a/app/errors/error_service.ts
+++ b/app/errors/error_service.ts
@@ -1,5 +1,5 @@
 import router from "../router/router";
-import { BuildBuddyError } from "../util/errors";
+import { BuildBuddyError, ErrorCode } from "../util/errors";
 import alertService from "../alert/alert_service";
 
 const ERROR_SEARCH_PARAM = "error";
@@ -13,11 +13,14 @@ export class ErrorService {
     }
   }
 
-  handleError(e: any) {
+  handleError(e: any, options?: { ignoreErrorCodes: ErrorCode[] }) {
     console.error(e);
-
-    const message = String(e instanceof BuildBuddyError ? e : BuildBuddyError.parse(e));
-    alertService.error(message);
+    const error = e instanceof BuildBuddyError ? e : BuildBuddyError.parse(e);
+    if (options?.ignoreErrorCodes?.includes(error.code)) {
+      console.log("Ignoring error code: " + error.code);
+      return;
+    }
+    alertService.error(String(error));
   }
 }
 

--- a/app/invocation/invocation_logs_model.tsx
+++ b/app/invocation/invocation_logs_model.tsx
@@ -77,7 +77,8 @@ export default class InvocationLogsModel {
         // chunk, and more may be available. Try fetching it immediately.
         this.fetchTail(response.nextChunkId);
       },
-      error: (e) => errorService.handleError(e),
+      error: (e) =>
+        errorService.handleError(e, { ignoreErrorCodes: ["NotFound", "PermissionDenied", "Unauthenticated"] }),
     });
   }
 }


### PR DESCRIPTION
Currently for invocations that we have error pages for, we also pop an errorService alert modal.

Example for not found: https://app.buildbuddy.io/invocation/dfldksfjlsfa

This PR fixes that.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
