### PR TITLE
Add spinner for summary stats in history view

### DIFF
--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -59,6 +59,7 @@ genrule(
         "//app/components/select:select.css",
         "//app/components/radio:radio.css",
         "//app/components/checkbox:checkbox.css",
+        "//app/components/spinner:spinner.css",
     ],
     outs = ["style.css"],
     cmd_bash = """

--- a/app/components/spinner/BUILD
+++ b/app/components/spinner/BUILD
@@ -1,0 +1,15 @@
+load("@npm//@bazel/typescript:index.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["*.css"]))
+
+ts_library(
+    name = "spinner",
+    srcs = glob(["*.tsx"]),
+    deps = [
+        "@npm//@types/react",
+        "@npm//react",
+        "@npm//tslib",
+    ],
+)

--- a/app/components/spinner/spinner.css
+++ b/app/components/spinner/spinner.css
@@ -1,0 +1,21 @@
+.spinner {
+  --size: 24px;
+
+  width: var(--size);
+  height: var(--size);
+
+  opacity: 0.8;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.spinner:before {
+  content: "";
+  display: block;
+  animation: rotate 2s linear infinite;
+  width: inherit;
+  height: inherit;
+  background-image: url("/image/loader.svg");
+  background-size: cover;
+}

--- a/app/components/spinner/spinner.tsx
+++ b/app/components/spinner/spinner.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export type SpinnerProps = JSX.IntrinsicElements["div"];
+
+export default function Spinner({ className, ...rest }: SpinnerProps) {
+  return <div className={`spinner ${className || ""}`} {...rest} />;
+}

--- a/enterprise/app/history/BUILD
+++ b/enterprise/app/history/BUILD
@@ -11,6 +11,7 @@ ts_library(
         "//app/auth",
         "//app/capabilities",
         "//app/components/button",
+        "//app/components/spinner",
         "//app/docs",
         "//app/format",
         "//app/router",

--- a/enterprise/app/history/history.css
+++ b/enterprise/app/history/history.css
@@ -33,3 +33,9 @@
 .history .breadcrumbs {
   margin-bottom: 0;
 }
+
+.history .details.loading-details {
+  display: flex;
+  margin-top: 16px;
+  gap: 8px;
+}

--- a/enterprise/app/history/history_invocation_card.tsx
+++ b/enterprise/app/history/history_invocation_card.tsx
@@ -6,7 +6,7 @@ import { invocation } from "../../../proto/invocation_ts_proto";
 const durationRefreshIntervalMillis = 3000;
 
 interface Props {
-  invocation: invocation.Invocation;
+  invocation: invocation.IInvocation;
   onMouseOver?: any;
   onMouseOut?: any;
   className?: string;
@@ -18,8 +18,7 @@ interface State {
   time: number;
 }
 
-export default class HistoryInvocationCardComponent extends React.Component {
-  props: Props;
+export default class HistoryInvocationCardComponent extends React.Component<Props, State> {
   state: State = {
     time: Date.now(),
   };
@@ -47,35 +46,35 @@ export default class HistoryInvocationCardComponent extends React.Component {
   }
 
   // Beware, this method isn't bound to this - so don't use any this. stuff. Event propagation is a nightmare.
-  handleUserClicked(event: any, invocation: invocation.Invocation) {
+  handleUserClicked(event: any, invocation: invocation.IInvocation) {
     router.navigateToUserHistory(invocation.user);
     event.stopPropagation();
     event.preventDefault();
   }
 
   // Beware, this method isn't bound to this - so don't use any this. stuff. Event propagation is a nightmare.
-  handleHostClicked(event: any, invocation: invocation.Invocation) {
+  handleHostClicked(event: any, invocation: invocation.IInvocation) {
     router.navigateToHostHistory(invocation.host);
     event.stopPropagation();
     event.preventDefault();
   }
 
   // Beware, this method isn't bound to this - so don't use any this. stuff. Event propagation is a nightmare.
-  handleCommitClicked(event: any, invocation: invocation.Invocation) {
+  handleCommitClicked(event: any, invocation: invocation.IInvocation) {
     router.navigateToCommitHistory(invocation.commitSha);
     event.stopPropagation();
     event.preventDefault();
   }
 
   // Beware, this method isn't bound to this - so don't use any this. stuff. Event propagation is a nightmare.
-  handleBranchClicked(event: any, invocation: invocation.Invocation) {
+  handleBranchClicked(event: any, invocation: invocation.IInvocation) {
     router.navigateToBranchHistory(invocation.commitSha);
     event.stopPropagation();
     event.preventDefault();
   }
 
   // Beware, this method isn't bound to this - so don't use any this. stuff. Event propagation is a nightmare.
-  handleRepoClicked(event: any, invocation: invocation.Invocation) {
+  handleRepoClicked(event: any, invocation: invocation.IInvocation) {
     router.navigateToRepoHistory(invocation.repoUrl);
     event.stopPropagation();
     event.preventDefault();

--- a/enterprise/app/history/history_invocation_stat_card.tsx
+++ b/enterprise/app/history/history_invocation_stat_card.tsx
@@ -5,13 +5,11 @@ import router from "../../../app/router/router";
 import format from "../../../app/format/format";
 
 interface Props {
-  invocationStat: invocation.InvocationStat;
+  invocationStat: invocation.IInvocationStat;
   type: invocation.AggType;
 }
 
-export default class HistoryInvocationStatCardComponent extends React.Component {
-  props: Props;
-
+export default class HistoryInvocationStatCardComponent extends React.Component<Props> {
   handleStatClicked() {
     console.log(this.props.invocationStat);
     if (this.props.type == invocation.AggType.USER_AGGREGATION_TYPE) {


### PR DESCRIPTION
Makes the experience less janky when loading the page and when changing the global filter, mainly when the stats response takes longer than the SearchInvocation response.

* Add a `<Spinner>` component which we can also use in a few other places, rather than using `<div className="loading" />` with brittle style overrides (will do the cleanup in follow-up PRs)
* Fix bugs where `this.setState({ ...this.state })` was called, preventing multiple calls to `setState` in the same async task
* Fix typing issues in history component and sub-components

https://user-images.githubusercontent.com/2414826/130646332-7867e1c1-f161-4b3d-b515-0dbdd67648f6.mp4

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
