### PR TITLE
Simplify and fix bugs with history component

### DIFF
--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -84,7 +84,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
       }),
       pageToken: nextPage ? this.state.pageToken : "",
       // TODO(siggisim): This gives us 2 nice rows of 63 blocks each. Handle this better.
-      count: 10,
+      count: 126,
     });
     if (capabilities.globalFilter) {
       request.query.role = filterParams.role;

--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -30,7 +30,7 @@ interface State {
 
   /**
    * Stats fetched for aggregate views.
-   * Each stat corresponds to a single rendered card displaying the stats for each repo, user, etc.
+   * Each stat corresponds to a card displaying the stats for a single repo (or user, etc.)
    */
   aggregateStats?: invocation.IInvocationStat[];
   loadingAggregateStats?: boolean;

--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -72,6 +72,13 @@ export default class HistoryComponent extends React.Component<Props, State> {
   }
 
   getInvocations(nextPage?: boolean) {
+    this.setState({
+      loadingInvocations: true,
+    });
+    if (!nextPage) {
+      this.setState({ invocations: undefined, pageToken: undefined });
+    }
+
     const filterParams = getProtoFilterParams(this.props.search);
     let request = new invocation.SearchInvocationRequest({
       query: new invocation.InvocationQuery({
@@ -91,13 +98,6 @@ export default class HistoryComponent extends React.Component<Props, State> {
       request.query.updatedAfter = filterParams.updatedAfter;
       request.query.updatedBefore = filterParams.updatedBefore;
       request.query.status = filterParams.status;
-    }
-
-    this.setState({
-      loadingInvocations: true,
-    });
-    if (!nextPage) {
-      this.setState({ invocations: undefined, pageToken: undefined });
     }
 
     this.fetchSubscription.add(

--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -16,20 +16,21 @@ import Spinner from "../../../app/components/spinner/spinner";
 
 interface State {
   /**
-   * Invocations are individual invocation cards that are fetched in history views
-   * that aren't aggregate (sliced) views.
+   * Invocations corresponding to individual invocation cards.
+   * Not fetched for aggregate (sliced) views.
    */
   invocations?: invocation.IInvocation[];
   loadingInvocations?: boolean;
   /**
-   * Stats summarizing the fetched invocations. Not fetched for aggregate (sliced) views.
+   * Stats summarizing the fetched invocations.
+   * Not fetched for aggregate (sliced) views.
    */
   summaryStat?: invocation.IInvocationStat;
   loadingSummaryStat?: boolean;
 
   /**
-   * Stats fetched for aggregate views. Each stat corresponds to a single rendered card
-   * displaying the stats for each repo, user, etc.
+   * Stats fetched for aggregate views.
+   * Each stat corresponds to a single rendered card displaying the stats for each repo, user, etc.
    */
   aggregateStats?: invocation.IInvocationStat[];
   loadingAggregateStats?: boolean;


### PR DESCRIPTION
* Fix bug that we would sometimes call certain RPCs unnecessarily. For example, we would always fetch invocations when looking at aggregate pages, and wait for the invocations to come back before displaying the aggregate stats, even though the invocations aren't needed in order to show aggregate stats. Now we always fetch _either_ invocations and summary stats, _or_ aggregated stats.
* Fix bug that we'd fetch summary stats when scoped to a user, repo, etc. but not actually display the stats.
* Fix bug that navigating to the users view would show "No users found" while the users are being fetched (can repro this easily in prod by going to the Users tab in the probers org)
* Fix bug that stale RPC data could be displayed (now we cancel all RPCs properly).

* Commented, renamed, and updated types of some state fields to improve readability. (I kept getting confused between `summaryStat` and `invocationStat` -- I find the new names and types harder to confuse)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
