### PR TITLE
Get frontend tests running

### DIFF
--- a/app/format/BUILD
+++ b/app/format/BUILD
@@ -30,6 +30,6 @@ ts_library(
 
 jasmine_node_test(
     name = "format_test",
-    srcs = [":format_test_ts"],
     templated_args = ["--bazel_patch_module_resolver"],
+    deps = [":format_test_ts"],
 )


### PR DESCRIPTION
The jasmine tests were passing, but not actually running (https://github.com/buildbuddy-io/buildbuddy-internal/issues/786)

Found the fix here: https://github.com/bazelbuild/rules_nodejs/blob/a3754e32b3f692a40bb8658c2440f98453a5a8a7/packages/jasmine/test/BUILD.bazel#L128

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/786
