### PR TITLE
Don't track targets for non-test invocations

### DIFF
--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -290,6 +290,10 @@ func (t *TargetTracker) handleWorkspaceStatusEvent(ctx context.Context, event *b
 		log.Warningf("Not all targets for %q reached state: %d, targets: %+v", t.buildEventAccumulator.InvocationID(), targetStateConfigured, t.targets)
 		return
 	}
+	if t.buildEventAccumulator.Command() != "test" {
+		log.Debugf("Not tracking targets for %q because it's not a test", t.buildEventAccumulator.InvocationID())
+		return
+	}
 	if t.buildEventAccumulator.Role() != "CI" {
 		log.Debugf("Not tracking targets for %q because it's not a CI build", t.buildEventAccumulator.InvocationID())
 		return
@@ -305,6 +309,10 @@ func (t *TargetTracker) handleWorkspaceStatusEvent(ctx context.Context, event *b
 }
 
 func (t *TargetTracker) handleFinishedEvent(ctx context.Context, event *build_event_stream.BuildEvent) {
+	if t.buildEventAccumulator.Command() != "test" {
+		log.Debugf("Not tracking targets statuses for %q because it's not a test", t.buildEventAccumulator.InvocationID())
+		return
+	}
 	if t.buildEventAccumulator.Role() != "CI" {
 		log.Debugf("Not tracking target statuses for %q because it's not a CI build", t.buildEventAccumulator.InvocationID())
 		return


### PR DESCRIPTION
The old target tracking code would never reach the status reporting step for tests (because no test-summary events were present).

When we moved to tracking in the finalize event, we started tracking statuses (of test targets) for build invocations too.

This brings back the old behavior.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
