### PR TITLE
Hide summary stats for scoped views

### DIFF
--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -335,7 +335,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
     // Note: we don't show summary stats for scoped views because the summary stats
     // don't currently get filtered by the scope as well.
     // TODO(bduffany): Make sure scope-filtered queries are optimized and remove this limitation.
-    const hideSummaryStats = !this.isAggregateView() && Boolean(scope);
+    const hideSummaryStats = Boolean(scope);
 
     return (
       <div className="history">


### PR DESCRIPTION
Hiding to avoid showing incorrect stats in the short term (we still fetch the stats to keep the RPC logic simple -- but this is what we did before the recent history page changes anyway). Eventually we might want to make sure the queries are optimized, and enable filtering for the summary stats queries.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
