### PR TITLE
Fix zero state display for history aggregate views

### DIFF
--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -136,7 +136,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
       from<Promise<invocation.GetInvocationStatResponse>>(rpcService.service.getInvocationStat(request)).subscribe({
         next: (response) => {
           console.log(response);
-          this.setState({ aggregateStats: response.invocationStat });
+          this.setState({ aggregateStats: response.invocationStat.filter((stat) => stat.name) });
         },
         complete: () => this.setState({ loadingAggregateStats: false }),
       })

--- a/enterprise/app/history/history_invocation_stat_card.tsx
+++ b/enterprise/app/history/history_invocation_stat_card.tsx
@@ -76,10 +76,6 @@ export default class HistoryInvocationStatCardComponent extends React.Component<
   }
 
   render() {
-    if (!this.props.invocationStat.name) {
-      return null;
-    }
-
     return (
       <div onClick={this.handleStatClicked.bind(this)} className={`clickable card ${this.getClass()}`}>
         <div className="content">


### PR DESCRIPTION
Fixes a bug that if the only fetched stat card doesn't have a name (e.g. user="", repo="", etc.), then we just show a blank view instead of the zero state (can see this in the "branches" tab of the BB probers org).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
