### PR TITLE
FUSE lib hack to avoid accessing /dev/null before it's available.

### DIFF
--- a/buildpatches/com_github_hanwen_go_fuse_v2
+++ b/buildpatches/com_github_hanwen_go_fuse_v2
@@ -1,0 +1,41 @@
+diff --git a/fuse/server.go b/fuse/server.go
+index 4b5c242..aa4a963 100644
+--- a/fuse/server.go
++++ b/fuse/server.go
+@@ -16,6 +16,8 @@ import (
+ 	"syscall"
+ 	"time"
+ 	"unsafe"
++
++	"github.com/hanwen/go-fuse/v2/splice"
+ )
+ 
+ const (
+@@ -134,8 +136,14 @@ func (ms *Server) Unmount() (err error) {
+ 	return err
+ }
+ 
++var initSplice sync.Once
++
+ // NewServer creates a server and attaches it to the given directory.
+ func NewServer(fs RawFileSystem, mountPoint string, opts *MountOptions) (*Server, error) {
++	initSplice.Do(func() {
++		splice.Init()
++	})
++
+ 	if opts == nil {
+ 		opts = &MountOptions{
+ 			MaxBackground: _DEFAULT_BACKGROUND_TASKS,
+diff --git a/splice/splice.go b/splice/splice.go
+index cbb20b4..dea2913 100644
+--- a/splice/splice.go
++++ b/splice/splice.go
+@@ -33,7 +33,7 @@ const DefaultPipeSize = 16 * 4096
+ // We empty pipes by splicing to /dev/null.
+ var devNullFD uintptr
+ 
+-func init() {
++func Init() {
+ 	content, err := ioutil.ReadFile("/proc/sys/fs/pipe-max-size")
+ 	if err != nil {
+ 		maxPipeSize = DefaultPipeSize

--- a/deps.bzl
+++ b/deps.bzl
@@ -1585,6 +1585,8 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         importpath = "github.com/hanwen/go-fuse/v2",
         sum = "h1:+32ffteETaLYClUj0a3aHjZ1hOPxxaNEHiZiujuDaek=",
         version = "v2.1.0",
+        patch_args = ["-p1"],
+        patches = ["@%s//buildpatches:com_github_hanwen_go_fuse_v2" % workspace_name],
     )
 
     go_repository(

--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -264,6 +264,8 @@ func main() {
 		}
 		log.Infof("Starting vm exec listener on vsock port: %d", *port)
 		server := grpc.NewServer()
+		// TODO(vadim): run this as a standalone binary so we don't need to worry about init() code running before
+		// VM is fully setup.
 		vmService := vmexec.NewServer(&reapMutex)
 		vmxpb.RegisterExecServer(server, vmService)
 		return server.Serve(listener)


### PR DESCRIPTION
We delay the splice package init() call until the FUSE server is
instantiated.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
