### PR TITLE
Fix image caching related bug in Firecracker impl.

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -942,6 +942,9 @@ func (c *FirecrackerContainer) IsImageCached(ctx context.Context) (bool, error) 
 	if err != nil {
 		return false, err
 	}
+	if diskImagePath != "" {
+		c.containerFSPath = diskImagePath
+	}
 	return diskImagePath != "", nil
 }
 


### PR DESCRIPTION
The image path is only set in `PullImage` which is not called if
`IsImageCached` returns true.

Since this function can have side-effects perhaps it could use a better
name like `CheckCachedImage` or `FindCachedImage`?

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
