### PR TITLE
Fix global filer alignment in Safari

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -47,6 +47,7 @@ a {
 
 button {
   outline: 0;
+  margin: 0;
 }
 
 /** Container **/


### PR DESCRIPTION
Looks like Safari applies a 2px margin to `<button>` elements by default.

Clicked around the UI and made sure this didn't break anything else.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
