### PR TITLE
Fix fuse build on mac.

### DIFF
--- a/buildpatches/com_github_hanwen_go_fuse_v2
+++ b/buildpatches/com_github_hanwen_go_fuse_v2
@@ -1,17 +1,8 @@
 diff --git a/fuse/server.go b/fuse/server.go
-index 4b5c242..aa4a963 100644
+index 4b5c242..6fe8188 100644
 --- a/fuse/server.go
 +++ b/fuse/server.go
-@@ -16,6 +16,8 @@ import (
- 	"syscall"
- 	"time"
- 	"unsafe"
-+
-+	"github.com/hanwen/go-fuse/v2/splice"
- )
- 
- const (
-@@ -134,8 +136,14 @@ func (ms *Server) Unmount() (err error) {
+@@ -134,8 +134,14 @@ func (ms *Server) Unmount() (err error) {
  	return err
  }
  
@@ -20,12 +11,41 @@ index 4b5c242..aa4a963 100644
  // NewServer creates a server and attaches it to the given directory.
  func NewServer(fs RawFileSystem, mountPoint string, opts *MountOptions) (*Server, error) {
 +	initSplice.Do(func() {
-+		splice.Init()
++		InitSplice()
 +	})
 +
  	if opts == nil {
  		opts = &MountOptions{
  			MaxBackground: _DEFAULT_BACKGROUND_TASKS,
+diff --git a/fuse/splice_darwin.go b/fuse/splice_darwin.go
+index dc4774a..4eaf99e 100644
+--- a/fuse/splice_darwin.go
++++ b/fuse/splice_darwin.go
+@@ -8,6 +8,9 @@ import (
+ 	"fmt"
+ )
+ 
++func InitSplice() {
++}
++
+ func (s *Server) setSplice() {
+ 	s.canSplice = false
+ }
+diff --git a/fuse/splice_linux.go b/fuse/splice_linux.go
+index 70f836a..b0fb4b7 100644
+--- a/fuse/splice_linux.go
++++ b/fuse/splice_linux.go
+@@ -11,6 +11,10 @@ import (
+ 	"github.com/hanwen/go-fuse/v2/splice"
+ )
+ 
++func InitSplice() {
++	splice.Init()
++}
++
+ func (s *Server) setSplice() {
+ 	s.canSplice = splice.Resizable()
+ }
 diff --git a/splice/splice.go b/splice/splice.go
 index cbb20b4..dea2913 100644
 --- a/splice/splice.go


### PR DESCRIPTION
The 'splice' package is not built on Linux so we need to call an Init
function in the 'fuse' package instead.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
