### PR TITLE
Add `clean-workspace-inputs` platform argument that allows users to specify how workspace inputs are cleaned up when preserving workspaces

### DIFF
--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -28,13 +28,14 @@ const (
 	// empty or unset.
 	unsetContainerImageVal = "none"
 
-	RecycleRunnerPropertyName       = "recycle-runner"
-	preserveWorkspacePropertyName   = "preserve-workspace"
-	persistentWorkerPropertyName    = "persistent-workers"
-	persistentWorkerKeyPropertyName = "persistentWorkerKey"
-	WorkflowIDPropertyName          = "workflow-id"
-	workloadIsolationPropertyName   = "workload-isolation-type"
-	enableCASFSPropertyName         = "enable-casfs"
+	RecycleRunnerPropertyName        = "recycle-runner"
+	preserveWorkspacePropertyName    = "preserve-workspace"
+	cleanWorkspaceInputsPropertyName = "clean-workspace-inputs"
+	persistentWorkerPropertyName     = "persistent-workers"
+	persistentWorkerKeyPropertyName  = "persistentWorkerKey"
+	WorkflowIDPropertyName           = "workflow-id"
+	workloadIsolationPropertyName    = "workload-isolation-type"
+	enableCASFSPropertyName          = "enable-casfs"
 
 	enableXcodeOverridePropertyName = "enableXcodeOverride"
 
@@ -64,10 +65,11 @@ type Properties struct {
 	// PreserveWorkspace specifies whether to delete all files in the workspace
 	// before running each action. If true, all files are kept except for output
 	// files and directories.
-	PreserveWorkspace   bool
-	PersistentWorker    bool
-	PersistentWorkerKey string
-	WorkflowID          string
+	PreserveWorkspace    bool
+	CleanWorkspaceInputs string
+	PersistentWorker     bool
+	PersistentWorkerKey  string
+	WorkflowID           string
 }
 
 // ContainerType indicates the type of containerization required by an executor.
@@ -99,6 +101,7 @@ func ParseProperties(plat *repb.Platform) *Properties {
 		RecycleRunner:             boolProp(m, RecycleRunnerPropertyName, false),
 		EnableCASFS:               boolProp(m, enableCASFSPropertyName, false),
 		PreserveWorkspace:         boolProp(m, preserveWorkspacePropertyName, false),
+		CleanWorkspaceInputs:      stringProp(m, cleanWorkspaceInputsPropertyName, ""),
 		PersistentWorker:          boolProp(m, persistentWorkerPropertyName, false),
 		PersistentWorkerKey:       stringProp(m, persistentWorkerKeyPropertyName, ""),
 		WorkflowID:                stringProp(m, WorkflowIDPropertyName, ""),

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -619,7 +619,7 @@ func (p *Pool) Get(ctx context.Context, task *repb.ExecutionTask) (*CommandRunne
 			return r, nil
 		}
 	}
-	wsOpts := &workspace.Opts{Preserve: props.PreserveWorkspace}
+	wsOpts := &workspace.Opts{Preserve: props.PreserveWorkspace, CleanInputs: props.CleanWorkspaceInputs}
 	ws, err := workspace.New(p.env, p.buildRoot, wsOpts)
 	ctr, err := p.newContainer(ctx, props, task.GetCommand())
 	if err != nil {

--- a/enterprise/server/remote_execution/workspace/BUILD
+++ b/enterprise/server/remote_execution/workspace/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//server/util/log",
         "//server/util/status",
         "//server/util/tracing",
+        "@com_github_gobwas_glob//:glob",
         "@com_github_google_uuid//:uuid",
         "@org_golang_x_sync//errgroup",
     ],

--- a/enterprise/server/remote_execution/workspace/workspace_test.go
+++ b/enterprise/server/remote_execution/workspace/workspace_test.go
@@ -139,3 +139,93 @@ func TestWorkspaceCleanup_PreserveWorkspace_PreservesAllFilesExceptOutputs(t *te
 		"expected all KEEPME filePaths (and no others) in the workspace after cleanup",
 	)
 }
+
+func TestCleanInputsIfNecessary_CleanNone(t *testing.T) {
+	filePaths := []string{
+		"some_input_directory/foo.framework/KEEPME",
+		"some/nested/input/directory/KEEPME.h",
+		"some_input_file_KEEPME",
+		"some/nested/input/file/KEEPME",
+		"KEEPME",
+		"foo/KEEPME",
+		"foo/bar/KEEPME",
+	}
+	ws := newWorkspace(t, &workspace.Opts{Preserve: true})
+	writeEmptyFiles(t, ws, filePaths)
+
+	for _, file := range filePaths {
+		ws.Inputs[file] = &repb.Digest{}
+	}
+
+	keep := map[string]*repb.Digest{
+		"KEEPME":         &repb.Digest{},
+		"foo/KEEPME":     &repb.Digest{},
+		"foo/bar/KEEPME": &repb.Digest{}}
+
+	ws.CleanInputsIfNecessary(keep)
+
+	assert.Equal(
+		t, keepmePaths(filePaths), actualFilePaths(t, ws),
+		"expected all KEEPME filePaths (and no others) in the workspace after cleanup",
+	)
+}
+
+func TestCleanInputsIfNecessary_CleanAll(t *testing.T) {
+	filePaths := []string{
+		"some_input_directory/foo.framework/DELETEME",
+		"some/nested/input/directory/DELETEME.h",
+		"some_input_file_DELETEME",
+		"some/nested/input/file/DELETEME",
+		"KEEPME",
+		"foo/KEEPME",
+		"foo/bar/KEEPME",
+	}
+	ws := newWorkspace(t, &workspace.Opts{Preserve: true, CleanInputs: "*"})
+	writeEmptyFiles(t, ws, filePaths)
+
+	for _, file := range filePaths {
+		ws.Inputs[file] = &repb.Digest{}
+	}
+
+	keep := map[string]*repb.Digest{
+		"KEEPME":         &repb.Digest{},
+		"foo/KEEPME":     &repb.Digest{},
+		"foo/bar/KEEPME": &repb.Digest{}}
+
+	ws.CleanInputsIfNecessary(keep)
+
+	assert.Equal(
+		t, keepmePaths(filePaths), actualFilePaths(t, ws),
+		"expected all KEEPME filePaths (and no others) in the workspace after cleanup",
+	)
+}
+
+func TestCleanInputsIfNecessary_CleanMatching(t *testing.T) {
+	filePaths := []string{
+		"some_input_directory/foo.framework/DELETEME",
+		"some/nested/input/directory/DELETEME.h",
+		"some_input_file_KEEPME",
+		"some/nested/input/file/KEEPME",
+		"KEEPME",
+		"foo/KEEPME",
+		"foo/bar/KEEPME",
+	}
+	ws := newWorkspace(t, &workspace.Opts{Preserve: true, CleanInputs: ".h,.framework/"})
+	writeEmptyFiles(t, ws, filePaths)
+
+	for _, file := range filePaths {
+		ws.Inputs[file] = &repb.Digest{}
+	}
+
+	keep := map[string]*repb.Digest{
+		"KEEPME":         &repb.Digest{},
+		"foo/KEEPME":     &repb.Digest{},
+		"foo/bar/KEEPME": &repb.Digest{}}
+
+	ws.CleanInputsIfNecessary(keep)
+
+	assert.Equal(
+		t, keepmePaths(filePaths), actualFilePaths(t, ws),
+		"expected all KEEPME filePaths (and no others) in the workspace after cleanup",
+	)
+}

--- a/enterprise/server/remote_execution/workspace/workspace_test.go
+++ b/enterprise/server/remote_execution/workspace/workspace_test.go
@@ -162,7 +162,8 @@ func TestCleanInputsIfNecessary_CleanNone(t *testing.T) {
 		"foo/KEEPME":     &repb.Digest{},
 		"foo/bar/KEEPME": &repb.Digest{}}
 
-	ws.CleanInputsIfNecessary(keep)
+	err := ws.CleanInputsIfNecessary(keep)
+	require.NoError(t, err)
 
 	assert.Equal(
 		t, keepmePaths(filePaths), actualFilePaths(t, ws),
@@ -210,7 +211,7 @@ func TestCleanInputsIfNecessary_CleanMatching(t *testing.T) {
 		"foo/KEEPME",
 		"foo/bar/KEEPME",
 	}
-	ws := newWorkspace(t, &workspace.Opts{Preserve: true, CleanInputs: ".h,.framework/"})
+	ws := newWorkspace(t, &workspace.Opts{Preserve: true, CleanInputs: "**.h,**.framework/**"})
 	writeEmptyFiles(t, ws, filePaths)
 
 	for _, file := range filePaths {
@@ -222,7 +223,8 @@ func TestCleanInputsIfNecessary_CleanMatching(t *testing.T) {
 		"foo/KEEPME":     &repb.Digest{},
 		"foo/bar/KEEPME": &repb.Digest{}}
 
-	ws.CleanInputsIfNecessary(keep)
+	err := ws.CleanInputsIfNecessary(keep)
+	require.NoError(t, err)
 
 	assert.Equal(
 		t, keepmePaths(filePaths), actualFilePaths(t, ws),


### PR DESCRIPTION
Add `clean-workspace-inputs` platform argument that allows users to specify how workspace inputs are cleaned up when preserving workspaces.

- If unset or empty, the current behavior will be preserved where we only overwrite inputs that have changed between actions.
- If set to `*`, all old inputs that are not used in the current action are cleaned up.
- If set to another value, we split on commas and clean up any inputs glob matching those strings
  - For example  `clean-workspace-inputs: **.framework/**,**.h ` will clean up any old inputs that end in `.h` or contain `.framework/`.

This fixes: https://github.com/buildbuddy-io/buildbuddy-internal/issues/852

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
