### PR TITLE
Implement a real Xcode locator

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -1555,6 +1555,12 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         sum = "h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=",
         version = "v0.0.0-20180305231024-9cad4c3443a7",
     )
+    go_repository(
+        name = "com_github_groob_plist",
+        importpath = "github.com/groob/plist",
+        sum = "h1:RyfUvLxQ4XCqPzRlNc0rlN/yYaLgReYhpAWmBdtm6ak=",
+        version = "v0.0.0-20210519001750-9f754062e6d6",
+    )
 
     go_repository(
         name = "com_github_grpc_ecosystem_go_grpc_middleware",

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -34,6 +34,7 @@ go_library(
         "//server/util/log",
         "//server/util/monitoring",
         "//server/util/tracing",
+        "//server/xcode",
         "@com_github_google_uuid//:uuid",
         "@go_googleapis//google/bytestream:bytestream_go_proto",
         "@org_golang_google_api//option:go_default_library",

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -115,9 +115,7 @@ func GetConfiguredEnvironmentOrDie(configurator *config.Configurator, healthChec
 		log.Infof("No authentication will be configured: %s", err)
 	}
 
-	xcodeLocator := xcode.NewXcodeLocator()
-	xcodeLocator.Locate()
-	realEnv.SetXCodeLocator(xcodeLocator)
+	realEnv.SetXCodeLocator(xcode.NewXcodeLocator())
 
 	if gcsCacheConfig := configurator.GetCacheGCSConfig(); gcsCacheConfig != nil {
 		opts := make([]option.ClientOption, 0)

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -33,6 +33,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/monitoring"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
+	"github.com/buildbuddy-io/buildbuddy/server/xcode"
 
 	"github.com/google/uuid"
 	"google.golang.org/api/option"
@@ -113,6 +114,10 @@ func GetConfiguredEnvironmentOrDie(configurator *config.Configurator, healthChec
 	} else {
 		log.Infof("No authentication will be configured: %s", err)
 	}
+
+	xcodeLocator := xcode.NewXcodeLocator()
+	xcodeLocator.Locate()
+	realEnv.SetXCodeLocator(xcodeLocator)
 
 	if gcsCacheConfig := configurator.GetCacheGCSConfig(); gcsCacheConfig != nil {
 		opts := make([]option.ClientOption, 0)

--- a/enterprise/server/remote_execution/platform/BUILD
+++ b/enterprise/server/remote_execution/platform/BUILD
@@ -19,6 +19,7 @@ go_test(
     srcs = ["platform_test.go"],
     deps = [
         ":platform",
+        "//server/testutil/testenv",
         "//proto:remote_execution_go_proto",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/remote_execution/platform/BUILD
+++ b/enterprise/server/remote_execution/platform/BUILD
@@ -19,8 +19,8 @@ go_test(
     srcs = ["platform_test.go"],
     deps = [
         ":platform",
-        "//server/testutil/testenv",
         "//proto:remote_execution_go_proto",
+        "//server/testutil/testenv",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/server/remote_execution/platform/BUILD
+++ b/enterprise/server/remote_execution/platform/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//proto:remote_execution_go_proto",
         "//server/config",
+        "//server/environment",
         "//server/util/log",
         "//server/util/status",
     ],

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/server/config"
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	"github.com/buildbuddy-io/buildbuddy/server/environment"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )

--- a/enterprise/server/remote_execution/platform/platform_test.go
+++ b/enterprise/server/remote_execution/platform/platform_test.go
@@ -237,7 +237,6 @@ func TestParse_ApplyOverrides(t *testing.T) {
 	}
 }
 
-
 type xcodeLocator struct {
 }
 

--- a/enterprise/server/remote_execution/platform/platform_test.go
+++ b/enterprise/server/remote_execution/platform/platform_test.go
@@ -1,9 +1,11 @@
 package platform_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -43,7 +45,9 @@ func TestParse_ContainerImage_Success(t *testing.T) {
 		}}
 
 		platformProps := platform.ParseProperties(plat)
-		err := platform.ApplyOverrides(testCase.execProps, platformProps, &repb.Command{})
+		env := testenv.GetTestEnv(t)
+		env.RealEnv.SetXCodeLocator(&xcodeLocator{})
+		err := platform.ApplyOverrides(env, testCase.execProps, platformProps, &repb.Command{})
 		require.NoError(t, err)
 		assert.Equal(t, testCase.expected, platformProps.ContainerImage, testCase)
 	}
@@ -65,7 +69,9 @@ func TestParse_ContainerImage_Error(t *testing.T) {
 		}}
 
 		platformProps := platform.ParseProperties(plat)
-		err := platform.ApplyOverrides(testCase.execProps, platformProps, &repb.Command{})
+		env := testenv.GetTestEnv(t)
+		env.RealEnv.SetXCodeLocator(&xcodeLocator{})
+		err := platform.ApplyOverrides(env, testCase.execProps, platformProps, &repb.Command{})
 		assert.Error(t, err)
 	}
 }
@@ -192,8 +198,8 @@ func TestParse_ApplyOverrides(t *testing.T) {
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone11.1.sdk"},
-			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode.app/Contents/Developer"},
+			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone11.1.sdk"},
+			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 		},
 			"",
 		},
@@ -223,8 +229,26 @@ func TestParse_ApplyOverrides(t *testing.T) {
 		execProps := bare
 		execProps.DefaultXCodeVersion = testCase.defaultXCodeVersion
 		command := &repb.Command{EnvironmentVariables: testCase.startingEnvVars}
-		err := platform.ApplyOverrides(execProps, platformProps, command)
+		env := testenv.GetTestEnv(t)
+		env.RealEnv.SetXCodeLocator(&xcodeLocator{})
+		err := platform.ApplyOverrides(env, execProps, platformProps, command)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, command.EnvironmentVariables, append(testCase.startingEnvVars, testCase.expectedEnvVars...))
 	}
 }
+
+
+type xcodeLocator struct {
+}
+
+func (x *xcodeLocator) DeveloperDirForVersion(version string) (string, error) {
+	if strings.HasPrefix(version, "12.4") {
+		return "/Applications/Xcode_12.4.app/Contents/Developer", nil
+	}
+	if strings.HasPrefix(version, "12.2") {
+		return "/Applications/Xcode_12.2.app/Contents/Developer", nil
+	}
+	return "/Applications/Xcode.app/Contents/Developer", nil
+}
+
+func (x *xcodeLocator) Locate() {}

--- a/enterprise/server/remote_execution/platform/platform_test.go
+++ b/enterprise/server/remote_execution/platform/platform_test.go
@@ -91,8 +91,8 @@ func TestParse_ApplyOverrides(t *testing.T) {
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		},
 			[]*repb.Command_EnvironmentVariable{
-				{Name: "SDKROOT", Value: "/Applications/Xcode_12.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"},
-				{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.2.app/Contents/Developer"},
+				{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"},
+				{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 			},
 			"12.2",
 		},
@@ -103,18 +103,15 @@ func TestParse_ApplyOverrides(t *testing.T) {
 			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "11.1"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode_12.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"},
-			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.2.app/Contents/Developer"},
+			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"},
+			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 		},
 			"12.2",
 		},
 		// Darwin with no overrides
 		{[]*repb.Platform_Property{
 			{Name: "OSFamily", Value: "Darwin"},
-			{Name: "enablexcodeoverride", Value: "false"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "11.1"},
-			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{
 			{Name: "SDKROOT", Value: "/Applications/Xcode_12.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.2.app/Contents/Developer"},
@@ -124,27 +121,25 @@ func TestParse_ApplyOverrides(t *testing.T) {
 		// Darwin with sdk platform
 		{[]*repb.Platform_Property{
 			{Name: "OSFamily", Value: "Darwin"},
-			{Name: "enablexcodeoverride", Value: "false"},
 		}, []*repb.Command_EnvironmentVariable{
 			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "11.1"},
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode_12.2.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone.sdk"},
-			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.2.app/Contents/Developer"},
+			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone.sdk"},
+			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 		},
 			"12.2",
 		},
-		// Darwin with xcode override
+		// Darwin with valid sdk platform
 		{[]*repb.Platform_Property{
 			{Name: "OSFamily", Value: "Darwin"},
-			{Name: "enablexcodeoverride", Value: "true"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "11.1"},
+			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "ACTUALLY_EXISTS_11.1"},
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone11.1.sdk"},
+			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhoneACTUALLY_EXISTS_11.1.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 		},
 			"12.2",
@@ -165,13 +160,12 @@ func TestParse_ApplyOverrides(t *testing.T) {
 		// Case insensitive darwin with xcode override
 		{[]*repb.Platform_Property{
 			{Name: "OSFAMILY", Value: "dArWiN"},
-			{Name: "EnableXcodeOverride", Value: "true"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "11.1"},
+			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "ACTUALLY_EXISTS_11.1"},
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone11.1.sdk"},
+			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhoneACTUALLY_EXISTS_11.1.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 		},
 			"12.2",
@@ -182,23 +176,22 @@ func TestParse_ApplyOverrides(t *testing.T) {
 		}, []*repb.Command_EnvironmentVariable{
 			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "11.1"},
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
-			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
+			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.5.123"},
 		}, []*repb.Command_EnvironmentVariable{
 			{Name: "SDKROOT", Value: "/Applications/Xcode.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode.app/Contents/Developer"},
 		},
 			"",
 		},
-		// Case insensitive darwin with no default xcode version and xcode override
+		// Case insensitive darwin with no default xcode version and existing sdk
 		{[]*repb.Platform_Property{
 			{Name: "OSFAMILY", Value: "dArWiN"},
-			{Name: "EnableXcodeOverride", Value: "true"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "11.1"},
+			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "ACTUALLY_EXISTS_11.1"},
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone11.1.sdk"},
+			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhoneACTUALLY_EXISTS_11.1.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 		},
 			"",
@@ -250,4 +243,6 @@ func (x *xcodeLocator) DeveloperDirForVersion(version string) (string, error) {
 	return "/Applications/Xcode.app/Contents/Developer", nil
 }
 
-func (x *xcodeLocator) Locate() {}
+func (x *xcodeLocator) IsSDKPathPresentForVersion(sdkPath, version string) bool {
+	return strings.Contains(sdkPath, "ACTUALLY_EXISTS")
+}

--- a/enterprise/server/remote_execution/platform/platform_test.go
+++ b/enterprise/server/remote_execution/platform/platform_test.go
@@ -111,8 +111,7 @@ func TestParse_ApplyOverrides(t *testing.T) {
 		// Darwin with no overrides
 		{[]*repb.Platform_Property{
 			{Name: "OSFamily", Value: "Darwin"},
-		}, []*repb.Command_EnvironmentVariable{
-		}, []*repb.Command_EnvironmentVariable{
+		}, []*repb.Command_EnvironmentVariable{}, []*repb.Command_EnvironmentVariable{
 			{Name: "SDKROOT", Value: "/Applications/Xcode_12.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.2.app/Contents/Developer"},
 		},

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -575,7 +575,7 @@ func (p *Pool) Get(ctx context.Context, task *repb.ExecutionTask) (*CommandRunne
 	executorProps := platform.GetExecutorProperties(p.env.GetConfigurator().GetExecutorConfig())
 	props := platform.ParseProperties(task.GetCommand().GetPlatform())
 	// TODO: This mutates the task; find a cleaner way to do this.
-	if err := platform.ApplyOverrides(executorProps, props, task.GetCommand()); err != nil {
+	if err := platform.ApplyOverrides(p.env, executorProps, props, task.GetCommand()); err != nil {
 		return nil, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.2.0
+	github.com/groob/plist v0.0.0-20210519001750-9f754062e6d6 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hanwen/go-fuse/v2 v2.1.0
 	github.com/hashicorp/golang-lru v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -827,6 +827,8 @@ github.com/gostaticanalysis/analysisutil v0.0.3 h1:iwp+5/UAyzQSFgQ4uR2sni99sJ8Eo
 github.com/gostaticanalysis/analysisutil v0.0.3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/groob/plist v0.0.0-20210519001750-9f754062e6d6 h1:RyfUvLxQ4XCqPzRlNc0rlN/yYaLgReYhpAWmBdtm6ak=
+github.com/groob/plist v0.0.0-20210519001750-9f754062e6d6/go.mod h1:itkABA+w2cw7x5nYUS/pLRef6ludkZKOigbROmCTaFw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4 h1:z53tR0945TRRQO/fLEVPI6SMv7ZflF0TEaTAoU7tOzg=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -70,4 +70,5 @@ type Env interface {
 	GetRepoDownloader() interfaces.RepoDownloader
 	GetWorkflowService() interfaces.WorkflowService
 	GetGitProviders() interfaces.GitProviders
+	GetXCodeLocator() interfaces.XcodeLocator
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -499,8 +499,9 @@ type HealthChecker interface {
 
 // Locates all XCode versions installed on the host system.
 type XcodeLocator interface {
-	// Locates installed XCode versions, should be called once on startup.
-	Locate()
 	// Returns the developer directory and SDKs for the given XCode version.
 	DeveloperDirForVersion(version string) (string, error)
+
+	// Returns true if the given SDK path is present in the given XCode version.
+	IsSDKPathPresentForVersion(sdkPath, version string) bool
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -496,3 +496,11 @@ type HealthChecker interface {
 	// signal.
 	Shutdown()
 }
+
+// Locates all XCode versions installed on the host system.
+type XcodeLocator interface {
+	// Locates installed XCode versions, should be called once on startup.
+	Locate()
+	// Returns the developer directory and SDKs for the given XCode version.
+	DeveloperDirForVersion(version string) (string, error)
+}

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -70,6 +70,7 @@ type RealEnv struct {
 	remoteExecutionRedisPubSubClient *redis.Client
 	buildEventProxyClients           []pepb.PublishBuildEventClient
 	webhooks                         []interfaces.Webhook
+	xcodeLocator                     interfaces.XcodeLocator
 }
 
 func NewRealEnv(c *config.Configurator, h interfaces.HealthChecker) *RealEnv {
@@ -290,6 +291,12 @@ func (r *RealEnv) GetGitProviders() interfaces.GitProviders {
 }
 func (r *RealEnv) SetGitProviders(gp interfaces.GitProviders) {
 	r.gitProviders = gp
+}
+func (r *RealEnv) GetXCodeLocator() interfaces.XcodeLocator {
+	return r.xcodeLocator
+}
+func (r *RealEnv) SetXCodeLocator(xl interfaces.XcodeLocator) {
+	r.xcodeLocator = xl
 }
 
 func (r *RealEnv) SetCacheRedisClient(redisClient *redis.Client) {

--- a/server/xcode/BUILD
+++ b/server/xcode/BUILD
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "xcode",
+    srcs = [
+        "xcode.go",
+        "xcode_darwin.go",
+    ],
+    cgo = True,
+    clinkopts = select({
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "-framework CoreServices",
+        ],
+        "//conditions:default": [],
+    }),
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/xcode",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "//server/util/log",
+            "//server/util/status",
+            "@com_github_groob_plist//:plist",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/server/xcode/xcode.go
+++ b/server/xcode/xcode.go
@@ -13,4 +13,6 @@ func (x *xcodeLocator) DeveloperDirForVersion(version string) (string, error) {
 	return "", nil
 }
 
-func (x *xcodeLocator) Locate() {}
+func (x *xcodeLocator) IsSDKPathPresentForVersion(sdkPath, version string) bool {
+	return false
+}

--- a/server/xcode/xcode.go
+++ b/server/xcode/xcode.go
@@ -1,0 +1,16 @@
+// +build !darwin
+
+package xcode
+
+type xcodeLocator struct {
+}
+
+func NewXcodeLocator() *xcodeLocator {
+	return &xcodeLocator{}
+}
+
+func (x *xcodeLocator) DeveloperDirForVersion(version string) (string, error) {
+	return "", nil
+}
+
+func (x *xcodeLocator) Locate() {}

--- a/server/xcode/xcode_darwin.go
+++ b/server/xcode/xcode_darwin.go
@@ -94,13 +94,11 @@ func (x *xcodeLocator) locate() {
 	versionMap := make(map[string]*xcodeVersion)
 	for _, urlRef := range urlRefs {
 		path := "/" + strings.TrimLeft(stringFromCFString(C.CFURLGetString(C.CFURLRef(urlRef))), filePrefix)
-
 		versionFileReader, err := os.Open(path + versionPlistPath)
 		if err != nil {
 			log.Warningf("Error reading version file for XCode located at %s: %s", path, err.Error())
 			continue
 		}
-
 		// The interesting bits to pull from XCode's version plist.
 		var xcodePlist struct {
 			CFBundleShortVersionString string `plist:"CFBundleShortVersionString"`
@@ -110,15 +108,13 @@ func (x *xcodeLocator) locate() {
 			log.Warningf("Error decoding plist for XCode located at %s: %s", path, err.Error())
 			continue
 		}
-
 		developerDirPath := path + developerDirectoryPath
-
 		sdks, err := fs.Glob(os.DirFS(developerDirPath), "Platforms/*.platform/Developer/SDKs/*")
 		if err != nil {
 			log.Warningf("Error reading XCode SDKs from %s: %s", path, err.Error())
 			continue
 		}
-
+		log.Infof("Found XCode version %s.%s at path %s", xcodePlist.CFBundleShortVersionString, xcodePlist.ProductBuildVersion, path)
 		versions := expandXCodeVersions(xcodePlist.CFBundleShortVersionString, xcodePlist.ProductBuildVersion)
 		mostPreciseVersion := versions[len(versions)-1]
 		for _, version := range versions {
@@ -126,8 +122,7 @@ func (x *xcodeLocator) locate() {
 			if ok && mostPreciseVersion < existingXcode.version {
 				continue
 			}
-			log.Infof("Found XCode version: %s=>%s", version, developerDirPath)
-			log.Debugf("With SDKs %+v", sdks)
+			log.Debugf("Mapped XCode Version %s=>%s with SDKs %+v", version, developerDirPath, sdks)
 			versionMap[version] = &xcodeVersion{
 				version:          mostPreciseVersion,
 				developerDirPath: developerDirPath,
@@ -135,7 +130,6 @@ func (x *xcodeLocator) locate() {
 			}
 		}
 	}
-
 	x.versions = versionMap
 }
 

--- a/server/xcode/xcode_darwin.go
+++ b/server/xcode/xcode_darwin.go
@@ -1,0 +1,161 @@
+// +build darwin
+// +build !ios
+
+package xcode
+
+/*
+#cgo LDFLAGS: -framework CoreServices
+#import <CoreServices/CoreServices.h>
+*/
+import "C"
+
+import (
+	"os"
+	"strings"
+	"unicode/utf16"
+	"unsafe"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/groob/plist"
+)
+
+const xcodeBundleID = "com.apple.dt.Xcode"
+const versionPlistPath = "Contents/version.plist"
+const developerDirectoryPath = "Contents/Developer"
+const filePrefix = "file://"
+
+type xcodeLocator struct {
+	versions map[string]string
+}
+
+func NewXcodeLocator() *xcodeLocator {
+	return &xcodeLocator{}
+}
+
+// Finds the XCode developer directory that most closely matches the given XCode version.
+func (x *xcodeLocator) DeveloperDirForVersion(version string) (string, error) {
+	versionComponents := strings.Split(version, ".")
+	for i, _ := range versionComponents {
+		subVersion := strings.Join(versionComponents[0:len(versionComponents)-i], ".")
+		if path, ok := x.versions[subVersion]; ok {
+			return path, nil
+		}
+	}
+	return "", status.FailedPreconditionErrorf("XCode version %s not installed on remote executor. Available Xcode versions are %+v", version, x.versions)
+}
+
+// Locates all all XCode versions installed on the host machine.
+// Very losely based on https://github.com/bazelbuild/bazel/blob/master/tools/osx/xcode_locator.m
+func (x *xcodeLocator) Locate() {
+	bundleID := stringToCFString(xcodeBundleID)
+	defer C.CFRelease(C.CFTypeRef(bundleID))
+
+	urlsPointer := C.LSCopyApplicationURLsForBundleIdentifier(bundleID, nil)
+	defer C.CFRelease(C.CFTypeRef(urlsPointer))
+
+	urlsArrayRef := C.CFArrayRef(urlsPointer)
+	n := C.CFArrayGetCount(urlsArrayRef)
+
+	urlRefs := make([]C.CFURLRef, n)
+	C.CFArrayGetValues(urlsArrayRef, C.CFRange{0, n}, (*unsafe.Pointer)(unsafe.Pointer(&urlRefs[0])))
+
+	versionMap := make(map[string]string)
+	for _, urlRef := range urlRefs {
+		path := "/" + strings.TrimLeft(stringFromCFString(C.CFURLGetString(C.CFURLRef(urlRef))), filePrefix)
+
+		versionFileReader, err := os.Open(path + versionPlistPath)
+		if err != nil {
+			log.Warningf("Error reading version file for XCode located at %s: %s", path, err.Error())
+			continue
+		}
+
+		// The interesting bits to pull from XCode's version plist.
+		var xcodeVersion struct {
+			CFBundleShortVersionString string `plist:"CFBundleShortVersionString"`
+			ProductBuildVersion        string `plist:"ProductBuildVersion"`
+		}
+		if err := plist.NewXMLDecoder(versionFileReader).Decode(&xcodeVersion); err != nil {
+			log.Warningf("Error decoding plist for XCode located at %s: %s", path, err.Error())
+			continue
+		}
+
+		versions := expandXCodeVersions(xcodeVersion.CFBundleShortVersionString, xcodeVersion.ProductBuildVersion)
+		for _, version := range versions {
+			existingVersion, ok := versionMap[version]
+			if ok && version < existingVersion {
+				log.Debugf("Error decoding plist for XCode located at %s: %s", path, err.Error())
+				continue
+			}
+			versionMap[version] = path + developerDirectoryPath
+		}
+	}
+
+	x.versions = versionMap
+
+	log.Infof("Found XCode versions: %+v", x.versions)
+}
+
+// Expands a single XCode version into all component combinations.
+// i.e. 12.5 => 12, 12.5, 12.5.0, 12.5.0.abc123
+func expandXCodeVersions(xcodeVersion string, productVersion string) []string {
+	versions := make([]string, 0)
+
+	components := strings.Split(xcodeVersion, ".")
+	for len(components) < 3 {
+		components = append(components, "0")
+	}
+
+	versions = append(versions, components[0])
+	versions = append(versions, components[0]+"."+components[1])
+	versions = append(versions, components[0]+"."+components[1]+"."+components[2])
+	versions = append(versions, components[0]+"."+components[1]+"."+components[2]+"."+productVersion)
+
+	return versions
+}
+
+// Converts a go string into a CFStringRef.
+func stringToCFString(gostr string) C.CFStringRef {
+	cstr := C.CString(gostr)
+	defer C.free(unsafe.Pointer(cstr))
+
+	return C.CFStringCreateWithCString(0, cstr, C.kCFStringEncodingUTF8)
+}
+
+// Converts a CFStringRef into a go string.
+func stringFromCFString(s C.CFStringRef) string {
+	ptr := C.CFStringGetCStringPtr(s, C.kCFStringEncodingUTF8)
+	if ptr != nil {
+		return C.GoString(ptr)
+	}
+	length := uint32(C.CFStringGetLength(s))
+	uniPtr := C.CFStringGetCharactersPtr(s)
+	if uniPtr == nil || length == 0 {
+		return ""
+	}
+	return stringFromUint16Ptr((*uint16)(uniPtr), length)
+}
+
+// Converts a *uint64 into a go string.
+func stringFromUint16Ptr(p *uint16, length uint32) string {
+	r := []uint16{}
+	ptr := uintptr(unsafe.Pointer(p))
+	for i := uint32(0); i < length; i++ {
+		c := *(*uint16)(unsafe.Pointer(ptr))
+		r = append(r, c)
+		if c == 0 {
+			break
+		}
+		ptr = ptr + unsafe.Sizeof(c)
+	}
+	r = append(r, uint16(0))
+	decoded := utf16.Decode(r)
+	n := 0
+	for i, r := range decoded {
+		if r == rune(0) {
+			n = i
+			break
+		}
+	}
+	return string(decoded[:n])
+}

--- a/server/xcode/xcode_darwin.go
+++ b/server/xcode/xcode_darwin.go
@@ -64,6 +64,7 @@ func (x *xcodeLocator) IsSDKPathPresentForVersion(sdkPath, version string) bool 
 	return false
 }
 
+// Returns the xcodeVersion most closely matching the version string.
 func (x *xcodeLocator) xcodeVersionForVersionString(version string) *xcodeVersion {
 	versionComponents := strings.Split(version, ".")
 	for i := range versionComponents {


### PR DESCRIPTION
This removes the need to have hardcoded XCode paths in our code (and for folks running executors to place XCode at those paths), and also allows us to support XCode versions more precise than two components (i.e. 12.5.1 or 12.5.1.12E507).

Xcode location logic is losely based on Bazel's XCode locator: https://github.com/bazelbuild/bazel/blob/master/tools/osx/xcode_locator.m

This removes the need for enableXcodeOverride.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
