### PR TITLE
Clear arp cache (and set time) after resuming from snapshot

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -665,10 +665,7 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 		UnixTimestampNanoseconds: time.Now().UnixNano(),
 		ClearArpCache:            true,
 	})
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func nonCmdExit(err error) *interfaces.CommandResult {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -650,6 +650,24 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 		return status.InternalErrorf("error resuming VM: %s", err)
 	}
 
+	dialCtx, cancel := context.WithTimeout(ctx, vSocketDialTimeout)
+	defer cancel()
+
+	vsockPath := filepath.Join(c.getChroot(), firecrackerVSockPath)
+	conn, err := vsock.SimpleGRPCDial(dialCtx, vsockPath)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	execClient := vmxpb.NewExecClient(conn)
+	_, err = execClient.Initialize(ctx, &vmxpb.InitializeRequest{
+		UnixTimestampNanoseconds: time.Now().UnixNano(),
+		ClearArpCache:            true,
+	})
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -659,6 +677,10 @@ func nonCmdExit(err error) *interfaces.CommandResult {
 		Error:    err,
 		ExitCode: -2,
 	}
+}
+
+func (c *FirecrackerContainer) startedFromSnapshot() bool {
+	return c.externalJailerCmd != nil
 }
 
 func (c *FirecrackerContainer) newID() error {
@@ -931,12 +953,10 @@ func (c *FirecrackerContainer) Run(ctx context.Context, command *repb.Command, a
 		return nonCmdExit(err)
 	}
 
-	startedFromSnapshot := false
 	// See if we can lookup a cached snapshot to run from; if not, it's not
 	// a huge deal, we can start a new VM and create one.
 	if c.allowSnapshotStart {
 		if err := c.LoadSnapshot(ctx, actionWorkingDir, "" /*=instanceName*/, snapDigest); err == nil {
-			startedFromSnapshot = true
 			log.Debugf("Started from snapshot %s/%d!", snapDigest.GetHash(), snapDigest.GetSizeBytes())
 		}
 	}
@@ -952,7 +972,7 @@ func (c *FirecrackerContainer) Run(ctx context.Context, command *repb.Command, a
 			return nonCmdExit(err)
 		}
 
-		if c.allowSnapshotStart && !startedFromSnapshot {
+		if c.allowSnapshotStart && !c.startedFromSnapshot() {
 			// save the workspaceFSPath in a local variable and null it out
 			// before saving the snapshot so it's not uploaded.
 			wsPath := c.workspaceFSPath

--- a/enterprise/server/vmexec/BUILD
+++ b/enterprise/server/vmexec/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//server/util/log",
         "//server/util/status",
         "@com_github_mdlayher_vsock//:vsock",
+        "@com_github_vishvananda_netlink//:netlink",
         "@go_googleapis//google/bytestream:bytestream_go_proto",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_sys//unix",

--- a/proto/vmexec.proto
+++ b/proto/vmexec.proto
@@ -53,8 +53,21 @@ message ExecResponse {
   bytes stderr = 3;
 }
 
+message InitializeRequest {
+  // The system's date will be set to this timestamp.
+  int64 unix_timestamp_nanoseconds = 1;
+
+  // If true, the arp cache will be cleared.
+  bool clear_arp_cache = 2;
+}
+
+message InitializeResponse {
+  // This page intentionally left empty.
+}
+
 // This service is run inside of a VM. It executes commands sent to it over
 // gRPC in the local environment and returns the results.
 service Exec {
   rpc Exec(ExecRequest) returns (ExecResponse);
+  rpc Initialize(InitializeRequest) returns (InitializeResponse);
 }


### PR DESCRIPTION
When a snapshotted VM is resumed we need to clear the ARP cache for networking to fully work, otherwise packets may go to the wrong place until the old ARP cache entry expires.

This CL adds an "Initialize" RPC to the vmexec server which clears the ARP cache and also sets the VM's system time. When a snapshot is resumed, this method is called once.




More context (from https://github.com/firecracker-microvm/firecracker/blob/main/docs/snapshotting/network-for-clones.md):

To make sure the guest also adjusts to the new environment, you can explicitly clear the ARP/neighbour table in the guest:

ip -family inet neigh flush any
ip -family inet6 neigh flush any

Otherwise, packets originating from the guest might be using old Link Layer Address for up to arp cache timeout seconds. After said timeout period, connectivity will work both ways even without an explicit flush.
