### PR TITLE
Set keepalive_timeout per GCP docs

### DIFF
--- a/server/util/grpc_server/BUILD
+++ b/server/util/grpc_server/BUILD
@@ -15,6 +15,6 @@ go_library(
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_google_grpc//keepalive:go_default_library",
+        "@org_golang_google_grpc//keepalive",
     ],
 )

--- a/server/util/grpc_server/BUILD
+++ b/server/util/grpc_server/BUILD
@@ -15,5 +15,6 @@ go_library(
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//keepalive:go_default_library",
     ],
 )

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -86,6 +86,6 @@ func CommonGRPCServerOptions(env environment.Env) []grpc.ServerOption {
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			// https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries
 			Timeout: 620 * time.Second,
-		})),
+		}),
 	}
 }

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 )
@@ -82,5 +83,9 @@ func CommonGRPCServerOptions(env environment.Env) []grpc.ServerOption {
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
 		grpc.MaxRecvMsgSize(env.GetConfigurator().GetGRPCMaxRecvMsgSizeBytes()),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			// https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries
+			Timeout: 620 * time.Second,
+		})),
 	}
 }


### PR DESCRIPTION
We see `backend_connection_closed_before_data_sent_to_client` in our gcp logs.

https://blog.percy.io/tuning-nginx-behind-google-cloud-platform-http-s-load-balancer-305982ddb340

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
