### PR TITLE
Don't clean up changed workspace inputs

### DIFF
--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -133,7 +133,7 @@ func (ws *Workspace) DownloadInputs(ctx context.Context, tree *repb.Tree) (*dirt
 	}
 	txInfo, err := dirtools.DownloadTree(ctx, ws.env, ws.task.GetExecuteRequest().GetInstanceName(), tree, ws.rootDir, opts)
 	if err == nil {
-		if err := ws.CleanInputsIfNecessary(txInfo.Skips); err != nil {
+		if err := ws.CleanInputsIfNecessary(txInfo.Exists); err != nil {
 			return txInfo, err
 		}
 


### PR DESCRIPTION
The input cleaning logic currently keeps any files that were "skipped" when downloading inputs.

This mostly works - however if an input file has changed, we do not "skip" it but instead we download the new file.

This means that when we go to clean up the files that were not "skipped", we'll accidentally clean up changed input files.

This change moves from tracking "skips" to tracking "exists", which are files that already existed when we went to download them.

This accurately maps to the overlap in input files between actions, and prevents us from incorrectly deleting files that changed.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
