### PR TITLE
m1 release

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -76,6 +76,13 @@ build:release --stamp
 build:release --define release=true
 build:release --remote_download_toplevel
 
+# Configuration used for BuildBuddy release m1 workflow
+build:release-m1 --remote_instance_name=buildbuddy-io/buildbuddy/release
+build:release-m1 -c opt
+build:release-m1 --stamp
+build:release-m1 --define release=true
+build:release-m1 --remote_download_toplevel
+
 # By default, build logs get sent to the production server
 build --bes_results_url=https://app.buildbuddy.io/invocation/
 build --bes_backend=grpcs://remote.buildbuddy.io

--- a/.github/workflows/release-m1.yaml
+++ b/.github/workflows/release-m1.yaml
@@ -34,6 +34,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" build --config=release --remote_executor= --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} --define version=${{ steps.tag.outputs.TAG }} //enterprise/server/cmd/executor:executor
+          "${GITHUB_WORKSPACE}/bin/bazel" build --config=release-m1 --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} --define version=${{ steps.tag.outputs.TAG }} //enterprise/server/cmd/executor:executor
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-darwin-arm64
           # gh release upload ${{ steps.tag.outputs.TAG }} executor-enterprise-darwin-arm64 --clobber

--- a/.github/workflows/release-m1.yaml
+++ b/.github/workflows/release-m1.yaml
@@ -1,12 +1,9 @@
 name: "release-m1"
 
 on:
-  # push:
-  #   tags:
-  #     - "v*"
-  pull_request:
-    branches:
-      - master
+  push:
+    tags:
+      - "v*"
 
 jobs:
   build:
@@ -36,4 +33,4 @@ jobs:
         run: |
           "${GITHUB_WORKSPACE}/bin/bazel" build --config=release-m1 --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} --define version=${{ steps.tag.outputs.TAG }} //enterprise/server/cmd/executor:executor
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-darwin-arm64
-          # gh release upload ${{ steps.tag.outputs.TAG }} executor-enterprise-darwin-arm64 --clobber
+          gh release upload ${{ steps.tag.outputs.TAG }} executor-enterprise-darwin-arm64 --clobber

--- a/.github/workflows/release-m1.yaml
+++ b/.github/workflows/release-m1.yaml
@@ -1,0 +1,39 @@
+name: "release-m1"
+
+on:
+  # push:
+  #   tags:
+  #     - "v*"
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: m1
+    if: "!contains(github.event.head_commit.message, 'release skip')"
+    defaults:
+      run:
+        shell: "/usr/bin/arch -arch arm64e /bin/bash --noprofile --norc -eo pipefail {0}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Install bazelisk
+        run: |
+          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-darwin-arm64"
+          mkdir -p "${GITHUB_WORKSPACE}/bin/"
+          mv bazelisk-darwin-arm64 "${GITHUB_WORKSPACE}/bin/bazel"
+          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
+
+      - name: Get Tag
+        id: tag
+        run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+
+      - name: Upload Artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          "${GITHUB_WORKSPACE}/bin/bazel" build --config=release --remote_executor= --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} --define version=${{ steps.tag.outputs.TAG }} //enterprise/server/cmd/executor:executor
+          cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-darwin-arm64
+          # gh release upload ${{ steps.tag.outputs.TAG }} executor-enterprise-darwin-arm64 --clobber

--- a/BUILD
+++ b/BUILD
@@ -114,12 +114,10 @@ go_library(
     srcs = ["bundle.go"],
     embedsrcs = select({
         ":fastbuild": [
-            "//:VERSION",
             "//:config_files",
             "//static",
         ],
         "//conditions:default": [
-            "//:VERSION",
             "//:config_files",
             "//app:app_bundle",
             "//app:style.css",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,6 +44,13 @@ go_download_sdk(
     version = "1.16.7",
 )
 
+go_download_sdk(
+    name = "go_sdk_darwin_arm64",
+    goarch = "arm64",
+    goos = "darwin",
+    version = "1.16.7",
+)
+
 go_register_toolchains(
     nogo = "@//:vet",
 )

--- a/enterprise/BUILD
+++ b/enterprise/BUILD
@@ -38,7 +38,6 @@ go_library(
     name = "bundle",
     srcs = ["bundle.go"],
     embedsrcs = [
-        "//:VERSION",
         "//enterprise:config_files",
         "//enterprise:licenses",
         "//:config_files",

--- a/server/version/BUILD
+++ b/server/version/BUILD
@@ -10,7 +10,7 @@ go_library(
         "commitSha": "{COMMIT_SHA}",
     },
     deps = [
-        "//server/util/log",         
+        "//server/util/log",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/server/version/BUILD
+++ b/server/version/BUILD
@@ -9,5 +9,8 @@ go_library(
         "version": "{VERSION}",
         "commitSha": "{COMMIT_SHA}",
     },
-    deps = ["//server/util/log"],
+    deps = [
+        "//server/util/log",         
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+    ],
 )

--- a/server/version/BUILD
+++ b/server/version/BUILD
@@ -9,8 +9,5 @@ go_library(
         "version": "{VERSION}",
         "commitSha": "{COMMIT_SHA}",
     },
-    deps = [
-        "//server/util/log",
-        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
-    ],
+    deps = ["//server/util/log"],
 )

--- a/server/version/BUILD
+++ b/server/version/BUILD
@@ -6,10 +6,10 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/version",
     visibility = ["//visibility:public"],
     x_defs = {
+        "version": "{VERSION}",
         "commitSha": "{COMMIT_SHA}",
     },
     deps = [
-        "//:bundle",
         "//server/util/log",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],

--- a/server/version/version.go
+++ b/server/version/version.go
@@ -2,13 +2,8 @@ package version
 
 import (
 	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
 	"runtime"
-	"strings"
 
-	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 )
 

--- a/server/version/version.go
+++ b/server/version/version.go
@@ -21,9 +21,11 @@ const (
 
 // This is set by x_defs in the BUILD file.
 //    x_defs = {
+//        "version": "{VERSION}",
 //        "commitSha": "{COMMIT_SHA}",
 //    },
 var commitSha string
+var version string
 
 func Print() {
 	appVersion := fmt.Sprintf("BuildBuddy %s", AppVersion())
@@ -34,22 +36,8 @@ func Print() {
 }
 
 func AppVersion() string {
-	var versionBytes []byte
-	if rfp, err := bazel.RunfilesPath(); err == nil {
-		versionFile := filepath.Join(rfp, versionFilename)
-		if b, err := os.ReadFile(versionFile); err == nil {
-			versionBytes = b
-		}
-	}
-	if versionBytes == nil {
-		if bundleFS, err := bundle.Get(); err == nil {
-			if data, err := fs.ReadFile(bundleFS, versionFilename); err == nil {
-				versionBytes = data
-			}
-		}
-	}
-	if versionBytes != nil {
-		return strings.TrimSpace(string(versionBytes))
+	if commitSha != "{VERSION}" {
+		return commitSha
 	}
 	return unknownValue
 }

--- a/server/version/version.go
+++ b/server/version/version.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-
-	bundle "github.com/buildbuddy-io/buildbuddy"
 )
 
 const (

--- a/server/version/version.go
+++ b/server/version/version.go
@@ -2,8 +2,12 @@ package version
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 )
 
@@ -29,8 +33,18 @@ func Print() {
 }
 
 func AppVersion() string {
-	if commitSha != "{VERSION}" {
-		return commitSha
+	if version != "{VERSION}" {
+		return version
+	}
+	var versionBytes []byte
+	if rfp, err := bazel.RunfilesPath(); err == nil {
+		versionFile := filepath.Join(rfp, versionFilename)
+		if b, err := os.ReadFile(versionFile); err == nil {
+			versionBytes = b
+		}
+	}
+	if versionBytes != nil {
+		return strings.TrimSpace(string(versionBytes))
 	}
 	return unknownValue
 }

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -27,3 +27,6 @@ echo "GIT_BRANCH $git_branch"
 
 git_tree_status=$(git diff-index --quiet HEAD -- && echo 'Clean' || echo 'Modified')
 echo "GIT_TREE_STATUS $git_tree_status"
+
+version=$(cat VERSION)
+echo "VERSION $version"


### PR DESCRIPTION
This PR enables a darwin-arm64 executor release for m1 macs.

This only enabled the executor build for now, since much more work is needed to release m1 mac builds (we'll probably need to upgrade to rules_nodejs 4.0 which is an involved upgrade).

While doing this release, I discovered that the executor currently bundles the js app. This is because of the dependency chain executor => scheduler_client => version => bundle => app_bundle => js.

This PR breaks the chain by pulling the executor version number from a stamp rather than the version file in the bundle for release builds.

There are enough tweaks to the workflow needed that it's cleaner as a separate workflow. Once we're able to build apps, it will be pretty straightforward to combine these workflows and use the release matrix.

The build does not yet take place on remote executors because we need to deploy m1 remote executors with these binaries first.

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
