### PR TITLE
Fix 'Maximum call stack size exceeded' in flame chart

### DIFF
--- a/app/flame_chart/flame_chart.tsx
+++ b/app/flame_chart/flame_chart.tsx
@@ -63,7 +63,9 @@ export default class FlameChart extends React.Component<FlameChartProps, Profile
   private buildDuration: number;
 
   componentDidMount() {
-    this.buildDuration = Math.max(...this.props.profile.traceEvents.map((event) => (event.ts || 0) + (event.dur || 0)));
+    this.buildDuration = this.props.profile.traceEvents
+      .map((event) => (event.ts || 0) + (event.dur || 0))
+      .reduce((a, b) => Math.max(a, b));
     const rulerWidth = this.rulerRef.current.getBoundingClientRect().width;
     const singlePixelDuration = this.buildDuration / rulerWidth;
 


### PR DESCRIPTION
Argument lists in JS have a size limit. Using an array and reducing with `Math.max` fixes the problem.

```tsx
let arr = new Array(1000000).fill(0);
Math.max(...arr) // error: 'Uncaught RangeError: Maximum call stack size exceeded'
arr.reduce((a, b) => Math.max(a, b)) // 0
```

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy/issues/997
