### PR TITLE
If a group has sso enabled, use that as the default login mechanism on their join page

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -91,6 +91,7 @@ export class AuthService {
     if (user.groups.length > 0) {
       user.selectedGroup =
         (selectedGroupId && user.groups.find((group) => group.id === selectedGroupId)) ||
+        user.groups.find((group) => group.urlIdentifier) ||
         user.groups.find((group) => group.ownedDomain) ||
         user.groups[0];
     }

--- a/enterprise/app/login/login.tsx
+++ b/enterprise/app/login/login.tsx
@@ -11,11 +11,13 @@ interface State {
   orgName?: string;
   showSSO: boolean;
   ssoSlug: string;
+  defaultToSSO: boolean;
 }
 
 export default class LoginComponent extends React.Component<{}, State> {
   state: State = {
     showSSO: false,
+    defaultToSSO: false,
     ssoSlug: this.getUrlSlug(),
   };
 
@@ -40,8 +42,8 @@ export default class LoginComponent extends React.Component<{}, State> {
 
   async fetchOrgName() {
     try {
-      const { name } = await rpcService.service.getGroup({ urlIdentifier: this.getUrlSlug() });
-      this.setState({ orgName: name });
+      const { name, ssoEnabled } = await rpcService.service.getGroup({ urlIdentifier: this.getUrlSlug() });
+      this.setState({ orgName: name, defaultToSSO: ssoEnabled });
     } catch (e) {
       // TODO: handle 404 errors better
       router.navigateHome();
@@ -52,7 +54,12 @@ export default class LoginComponent extends React.Component<{}, State> {
     document.title = `Login | BuildBuddy`;
   }
 
-  handleLoginClicked() {
+  handleLoginClicked(event: any) {
+    if (this.state.defaultToSSO) {
+      this.handleSSOClicked(event);
+      return;
+    }
+
     authService.login();
   }
 

--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -82,6 +82,9 @@ message GetGroupResponse {
   // Optional. The domains owned by this group.
   // Ex. "iterationinc.com"
   string owned_domain = 3;
+
+  // True if the group has SSO enabled.
+  bool sso_enabled = 5;
 }
 
 message GetGroupUsersRequest {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -195,6 +195,7 @@ func (s *BuildBuddyServer) GetGroup(ctx context.Context, req *grpb.GetGroupReque
 		// info should not be exposed here.
 		Name:        group.Name,
 		OwnedDomain: group.OwnedDomain,
+		SsoEnabled:  group.SamlIdpMetadataUrl != "",
 	}, nil
 }
 


### PR DESCRIPTION
When a user visits a "join organization" page and they're not logged in and the organization has SSO enabled, clicking the big login / signup button behaves the same as clicking the "Login with SSO" button.

Also prioritizes groups with a url slug over groups without one when picking a "default group" (so users in their user group and an SSO organization without an associated domain default to their SSO organization rather than their personal group).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
