### PR TITLE
Split Authenticator interface

### DIFF
--- a/enterprise/server/saml/BUILD
+++ b/enterprise/server/saml/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//server/environment",
         "//server/interfaces",
         "//server/tables",
-        "//server/util/log",
         "//server/util/status",
         "@com_github_crewjam_saml//samlsp",
     ],

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -693,7 +693,7 @@ func (s *SchedulerServer) authorizeExecutor(ctx context.Context) (string, error)
 		return "", nil
 	}
 
-	auth := s.env.GetAuthenticator()
+	auth := s.env.GetGRPCAuthenticator()
 	if auth == nil {
 		return "", status.FailedPreconditionError("executor authorization required, but authenticator is not set")
 	}

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -783,7 +783,7 @@ func (r *Env) ExecuteCustomCommand(args ...string) *Command {
 }
 
 func (r *Env) WithUserID(ctx context.Context, userID string) context.Context {
-	ctx = r.testEnv.GetAuthenticator().AuthContextFromAPIKey(ctx, userID)
+	ctx = r.testEnv.GetAPIKeyAuthenticator().AuthContextFromAPIKey(ctx, userID)
 	jwt, _ := testauth.TestJWTForUserID(userID)
 	ctx = metadata.AppendToOutgoingContext(
 		ctx,

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -697,7 +697,7 @@ func (ws *workflowService) executeWorkflow(ctx context.Context, wf *tables.Workf
 	if err != nil {
 		return "", err
 	}
-	ctx = ws.env.GetAuthenticator().AuthContextFromAPIKey(ctx, key.Value)
+	ctx = ws.env.GetAPIKeyAuthenticator().AuthContextFromAPIKey(ctx, key.Value)
 	if ctx, err = prefix.AttachUserPrefixToContext(ctx, ws.env); err != nil {
 		return "", err
 	}

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -542,7 +542,7 @@ func TestNonDefaultPartition(t *testing.T) {
 
 	// Authenticated user on default partition.
 	{
-		ctx := te.GetAuthenticator().AuthContextFromAPIKey(context.Background(), testAPIKey1)
+		ctx := te.GetAPIKeyAuthenticator().AuthContextFromAPIKey(context.Background(), testAPIKey1)
 		ctx, err = prefix.AttachUserPrefixToContext(ctx, te)
 		require.NoError(t, err)
 		d, buf := testdigest.NewRandomDigestBuf(t, 1000)
@@ -558,7 +558,7 @@ func TestNonDefaultPartition(t *testing.T) {
 	// Authenticated user with group ID that matches custom partition, but without a matching instance name prefix.
 	// Data should go to the default partition.
 	{
-		ctx := te.GetAuthenticator().AuthContextFromAPIKey(context.Background(), testAPIKey2)
+		ctx := te.GetAPIKeyAuthenticator().AuthContextFromAPIKey(context.Background(), testAPIKey2)
 		ctx, err = prefix.AttachUserPrefixToContext(ctx, te)
 		require.NoError(t, err)
 		d, buf := testdigest.NewRandomDigestBuf(t, 1000)
@@ -578,7 +578,7 @@ func TestNonDefaultPartition(t *testing.T) {
 	// partition.
 	// Data should go to the matching partition.
 	{
-		ctx := te.GetAuthenticator().AuthContextFromAPIKey(context.Background(), testAPIKey2)
+		ctx := te.GetAPIKeyAuthenticator().AuthContextFromAPIKey(context.Background(), testAPIKey2)
 		ctx, err = prefix.AttachUserPrefixToContext(ctx, te)
 		require.NoError(t, err)
 		d, buf := testdigest.NewRandomDigestBuf(t, 1000)
@@ -723,7 +723,7 @@ func TestV2LayoutMigration(t *testing.T) {
 	}
 
 	{
-		ctx := te.GetAuthenticator().AuthContextFromAPIKey(context.Background(), testAPIKey)
+		ctx := te.GetAPIKeyAuthenticator().AuthContextFromAPIKey(context.Background(), testAPIKey)
 		ctx, err = prefix.AttachUserPrefixToContext(ctx, te)
 		require.NoError(t, err)
 		ic, err := dc.WithIsolation(ctx, interfaces.CASCacheType, "" /*=instanceName*/)
@@ -739,7 +739,7 @@ func TestV2LayoutMigration(t *testing.T) {
 	}
 
 	{
-		ctx := te.GetAuthenticator().AuthContextFromAPIKey(context.Background(), testAPIKey)
+		ctx := te.GetAPIKeyAuthenticator().AuthContextFromAPIKey(context.Background(), testAPIKey)
 		ctx, err = prefix.AttachUserPrefixToContext(ctx, te)
 		require.NoError(t, err)
 		ic, err := dc.WithIsolation(ctx, interfaces.CASCacheType, "prefix" /*=instanceName*/)

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -327,7 +327,7 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 			RedactionFlags:   redact.RedactionFlagStandardRedactions,
 		}
 
-		if auth := e.env.GetAuthenticator(); auth != nil {
+		if auth := e.env.GetAPIKeyAuthenticator(); auth != nil {
 			options, err := extractOptionsFromStartedBuildEvent(&bazelBuildEvent)
 			if err != nil {
 				return err

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -43,6 +43,12 @@ type Env interface {
 	GetHealthChecker() interfaces.HealthChecker
 	GetAuthenticator() interfaces.Authenticator
 	SetAuthenticator(a interfaces.Authenticator)
+	GetHTTPAuthenticator() interfaces.HTTPAuthenticator
+	SetHTTPAuthenticator(a interfaces.HTTPAuthenticator)
+	GetGRPCAuthenticator() interfaces.GRPCAuthenticator
+	SetGRPCAuthenticator(a interfaces.GRPCAuthenticator)
+	GetAPIKeyAuthenticator() interfaces.APIKeyAuthenticator
+	SetAPIKeyAuthenticator(a interfaces.APIKeyAuthenticator)
 	GetWebhooks() []interfaces.Webhook
 	GetBuildEventHandler() interfaces.BuildEventHandler
 	GetBuildEventProxyClients() []pepb.PublishBuildEventClient

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -380,10 +380,10 @@ func StartAndRunServices(env environment.Env) {
 	mux.Handle("/healthz", env.GetHealthChecker().LivenessHandler())
 	mux.Handle("/readyz", env.GetHealthChecker().ReadinessHandler())
 
-	if auth := env.GetAuthenticator(); auth != nil {
-		mux.Handle("/login/", httpfilters.SetSecurityHeaders(http.HandlerFunc(auth.Login)))
-		mux.Handle("/auth/", httpfilters.SetSecurityHeaders(http.HandlerFunc(auth.Auth)))
-		mux.Handle("/logout/", httpfilters.SetSecurityHeaders(http.HandlerFunc(auth.Logout)))
+	if auth := env.GetHTTPAuthenticator(); auth != nil {
+		mux.Handle("/login/", httpfilters.SetSecurityHeaders(httpfilters.HandlerFunc(auth.Login)))
+		mux.Handle("/auth/", httpfilters.SetSecurityHeaders(httpfilters.HandlerFunc(auth.Auth)))
+		mux.Handle("/logout/", httpfilters.SetSecurityHeaders(httpfilters.HandlerFunc(auth.Logout)))
 	}
 
 	if githubConfig := env.GetConfigurator().GetGithubConfig(); githubConfig != nil {

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -44,6 +44,9 @@ type RealEnv struct {
 	blobstore                        interfaces.Blobstore
 	invocationDB                     interfaces.InvocationDB
 	authenticator                    interfaces.Authenticator
+	httpAuthenticator                interfaces.HTTPAuthenticator
+	grpcAuthenticator                interfaces.GRPCAuthenticator
+	apiKeyAuthenticator              interfaces.APIKeyAuthenticator
 	repoDownloader                   interfaces.RepoDownloader
 	executionService                 interfaces.ExecutionService
 	cache                            interfaces.Cache
@@ -175,6 +178,27 @@ func (r *RealEnv) GetAuthenticator() interfaces.Authenticator {
 }
 func (r *RealEnv) SetAuthenticator(a interfaces.Authenticator) {
 	r.authenticator = a
+}
+
+func (r *RealEnv) GetHTTPAuthenticator() interfaces.HTTPAuthenticator {
+	return r.httpAuthenticator
+}
+func (r *RealEnv) SetHTTPAuthenticator(a interfaces.HTTPAuthenticator) {
+	r.httpAuthenticator = a
+}
+
+func (r *RealEnv) GetGRPCAuthenticator() interfaces.GRPCAuthenticator {
+	return r.grpcAuthenticator
+}
+func (r *RealEnv) SetGRPCAuthenticator(a interfaces.GRPCAuthenticator) {
+	r.grpcAuthenticator = a
+}
+
+func (r *RealEnv) GetAPIKeyAuthenticator() interfaces.APIKeyAuthenticator {
+	return r.apiKeyAuthenticator
+}
+func (r *RealEnv) SetAPIKeyAuthenticator(a interfaces.APIKeyAuthenticator) {
+	r.apiKeyAuthenticator = a
 }
 
 func (r *RealEnv) GetUserDB() interfaces.UserDB {

--- a/server/rpc/filters/filters.go
+++ b/server/rpc/filters/filters.go
@@ -68,7 +68,7 @@ func contextReplacingUnaryClientInterceptor(ctxFn func(ctx context.Context) cont
 }
 
 func addAuthToContext(env environment.Env, ctx context.Context) context.Context {
-	if auth := env.GetAuthenticator(); auth != nil {
+	if auth := env.GetGRPCAuthenticator(); auth != nil {
 		return auth.AuthenticatedGRPCContext(ctx)
 	}
 	return ctx


### PR DESCRIPTION
Splits the Authenticator interfaces into 4 interfaces:
- Authenticator
- HTTPAuthenticator
- GRPCAuthenticator
- APIKeyAuthenticator

Implements MultiHTTPAuthenticator and MultiAuthenticator to override those methods with the SAMLAuthenticator

Removes the concept of a fallback authenticator from SAMLAuthenticator and the extraneous methods that it didn't implement.

This PR does not change any functionality (except for displaying a "Logged Out!" message when logging out).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
