### PR TITLE
Add role field to group proto

### DIFF
--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -48,7 +48,11 @@ message Group {
 
   enum Role {
     UNKNOWN_ROLE = 0;
+    // Developers cannot perform certain privileged actions such as creating API
+    // keys and viewing usage data, but can perform most other common ations
+    // such as viewing invocation history.
     DEVELOPER_ROLE = 1;
+    // Admins have unrestricted access to any data owned by this group.
     ADMIN_ROLE = 2;
   }
 }

--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -5,6 +5,8 @@ import "proto/user_id.proto";
 
 package grp;
 
+// Group represents a group that a user is a member of.
+// Next tag: 10
 message Group {
   // The unique ID of this group.
   // Ex. "GR4576963743584254779"
@@ -39,6 +41,16 @@ message Group {
   // Whether builds for this group will use custom executors provided by the
   // group.
   bool use_group_owned_executors = 7;
+
+  // Role represent's the authenticated user's role within this group, which
+  // determines which actions the user is authorized to perform.
+  Role role = 9;
+
+  enum Role {
+    UNKNOWN_ROLE = 0;
+    DEVELOPER_ROLE = 1;
+    ADMIN_ROLE = 2;
+  }
 }
 
 message JoinGroupRequest {

--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -49,7 +49,7 @@ message Group {
   enum Role {
     UNKNOWN_ROLE = 0;
     // Developers cannot perform certain privileged actions such as creating API
-    // keys and viewing usage data, but can perform most other common ations
+    // keys and viewing usage data, but can perform most other common actions
     // such as viewing invocation history.
     DEVELOPER_ROLE = 1;
     // Admins have unrestricted access to any data owned by this group.


### PR DESCRIPTION
Adding `role` directly to `Group`, rather than creating a new `UserGroup` proto and then migrating the `GetUserResponse` from `repeated UserGroup` to `repeated Group`. Figured this would have little benefit since we only ever return `Group` protos for a particular user, so this proto already implicitly represents a user-group membership.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/868
