### PR TITLE
Add initial user management list view

### DIFF
--- a/app/capabilities/capabilities.tsx
+++ b/app/capabilities/capabilities.tsx
@@ -23,6 +23,7 @@ export class Capabilities {
   sso: boolean;
   globalFilter: boolean;
   usage: boolean;
+  userManagement: boolean;
 
   register(name: string, enterprise: boolean, paths: Array<string>) {
     this.name = name;
@@ -49,6 +50,7 @@ export class Capabilities {
     this.paths = new Set(paths);
     this.globalFilter = Boolean(config.global_filter_enabled);
     this.usage = Boolean(config.usage_enabled);
+    this.userManagement = Boolean(config.user_management_enabled);
     if (window.gtag) {
       window.gtag("set", {
         app_name: this.name,

--- a/app/components/button/BUILD
+++ b/app/components/button/BUILD
@@ -11,6 +11,7 @@ ts_library(
         "*.tsx",
     ]),
     deps = [
+        "//app/components/checkbox",
         "@npm//@types/react",
         "@npm//react",
         "@npm//tslib",

--- a/app/components/button/button.css
+++ b/app/components/button/button.css
@@ -84,7 +84,7 @@
 }
 
 .checkbox-button label {
-  padding: 8px 8px 8px 16px;
+  padding: 8px 16px;
   box-sizing: border-box;
   min-height: inherit;
   cursor: pointer;

--- a/app/components/button/checkbox_button.tsx
+++ b/app/components/button/checkbox_button.tsx
@@ -1,19 +1,24 @@
 import React from "react";
 import { OutlinedButton } from "./button";
+import Checkbox from "../checkbox/checkbox";
+
+export type CheckboxButtonProps = JSX.IntrinsicElements["input"] & {
+  checkboxOnLeft?: boolean;
+};
 
 export default function CheckboxButton({
   children,
+  checkboxOnLeft,
   checked,
   onChange,
   className,
   ...props
-}: JSX.IntrinsicElements["input"]) {
+}: CheckboxButtonProps) {
+  const nodes = [<span>{children}</span>, <Checkbox checked={checked} onChange={onChange} {...props} />];
+
   return (
     <OutlinedButton className={`checkbox-button ${className || ""}`}>
-      <label>
-        <span>{children} </span>
-        <input type="checkbox" checked={checked} onChange={onChange} {...props} />
-      </label>
+      <label>{checkboxOnLeft ? nodes.reverse() : nodes}</label>
     </OutlinedButton>
   );
 }

--- a/enterprise/app/org/BUILD
+++ b/enterprise/app/org/BUILD
@@ -11,6 +11,8 @@ ts_library(
         "//app/auth",
         "//app/capabilities",
         "//app/components/button",
+        "//app/components/checkbox",
+        "//app/errors",
         "//app/router",
         "//app/service",
         "//proto:group_ts_proto",

--- a/enterprise/app/org/org.css
+++ b/enterprise/app/org/org.css
@@ -243,3 +243,56 @@
 .org-join-requests .org-join-request-outcome > :not(:last-child) {
   margin-right: 8px;
 }
+
+.org-members {
+  margin-top: 16px;
+  max-width: 600px;
+}
+
+.org-members .org-members-list-controls {
+  display: flex;
+  align-items: center;
+  padding: 8px 0px;
+  gap: 8px;
+  min-height: 40px;
+}
+
+.org-members .select-all-button {
+  margin-right: auto;
+}
+
+.org-members .org-members-list-item {
+  cursor: pointer;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid #eee;
+  padding: 8px 16px;
+  min-height: 48px;
+  box-sizing: border-box;
+  gap: 8px;
+  transition: background-color 100ms ease-out;
+}
+
+.org-members .org-members-list-item:first-child {
+  border-top: 1px solid #eee;
+}
+
+.org-members .org-members-list-item:hover {
+  background-color: #fafafa;
+}
+
+.org-members .org-members-list-item.selected {
+  background-color: #bbdefb;
+}
+
+.org-members .org-member-email {
+  font-weight: 600;
+}
+
+.org-members .org-member-role {
+  margin-left: auto;
+  padding: 4px 12px;
+  border-radius: 13px;
+  border: 1px solid transparent;
+}

--- a/enterprise/app/org/org_members.tsx
+++ b/enterprise/app/org/org_members.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { User } from "../../../app/auth/auth_service";
+import Button from "../../../app/components/button/button";
+import CheckboxButton from "../../../app/components/button/checkbox_button";
+import Checkbox from "../../../app/components/checkbox/checkbox";
+import errorService from "../../../app/errors/error_service";
+import rpcService from "../../../app/service/rpc_service";
+import { grp } from "../../../proto/group_ts_proto";
+
+export type OrgMembersProps = {
+  user: User;
+};
+
+type State = {
+  loading?: boolean;
+  response?: grp.GetGroupUsersResponse;
+
+  isSelectingAll?: boolean;
+  selectedUserIds: Set<string>;
+};
+
+export default class OrgMembersComponent extends React.Component<OrgMembersProps, State> {
+  state: State = {
+    loading: true,
+    selectedUserIds: new Set<string>(),
+  };
+
+  componentDidMount() {
+    this.setState({ loading: true });
+    rpcService.service
+      .getGroupUsers(
+        new grp.GetGroupUsersRequest({
+          groupId: this.props.user.selectedGroup.id,
+          // Only show existing members in this table for now.
+          // TODO(bduffany): render 2 separate tables; one for membership
+          // requests and one for existing members.
+          groupMembershipStatus: [grp.GroupMembershipStatus.MEMBER],
+        })
+      )
+      .then((response) => this.setState({ response }))
+      .catch((e) => errorService.handleError(e))
+      .finally(() => this.setState({ loading: false }));
+  }
+
+  private onClickRow(userID: string) {
+    const clone = new Set(this.state.selectedUserIds);
+    if (clone.has(userID)) {
+      clone.delete(userID);
+    } else {
+      clone.add(userID);
+    }
+    this.setState({
+      isSelectingAll: (this.state.isSelectingAll && clone.size > 0) || clone.size === this.state.response.user.length,
+      selectedUserIds: clone,
+    });
+  }
+
+  private onClickSelectAllToggle() {
+    if (this.state.isSelectingAll) {
+      this.setState({
+        isSelectingAll: false,
+        selectedUserIds: new Set(),
+      });
+    } else {
+      this.setState({
+        isSelectingAll: true,
+        selectedUserIds: new Set(this.state.response.user.map((member) => member.user.userId.id)),
+      });
+    }
+  }
+
+  render() {
+    if (this.state.loading) {
+      return <div className="loading" />;
+    }
+    if (!this.state.response) return null;
+
+    const isSelectionEmpty = this.state.selectedUserIds.size === 0;
+
+    return (
+      <div className="org-members">
+        <div className="org-members-list-controls">
+          <CheckboxButton
+            className="select-all-button"
+            checked={this.state.isSelectingAll}
+            onClick={this.onClickSelectAllToggle.bind(this)}
+            checkboxOnLeft>
+            Select all
+          </CheckboxButton>
+
+          <Button disabled={isSelectionEmpty}>Edit role</Button>
+          <Button disabled={isSelectionEmpty} className="destructive org-member-remove-button">
+            Remove
+          </Button>
+        </div>
+        <div className="org-members-list">
+          {this.state.response.user.map((member) => (
+            <div
+              className={`org-members-list-item ${
+                this.state.selectedUserIds.has(member.user.userId.id) ? "selected" : ""
+              }`}
+              onClick={this.onClickRow.bind(this, member.user.userId.id)}>
+              <div>
+                <Checkbox
+                  title={`Select ${member.user.email}`}
+                  className="org-member-checkbox"
+                  checked={this.state.selectedUserIds.has(member.user.userId.id)}
+                />
+              </div>
+              <div className="org-member-email">{member.user.email}</div>
+              {/* TODO(bduffany): Read from the role field once it's implemented. */}
+              <div className="org-member-role">Admin</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+}

--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -4,6 +4,7 @@ import capabilities from "../../../app/capabilities/capabilities";
 import FilledButton from "../../../app/components/button/button";
 import ApiKeysComponent from "../api_keys/api_keys";
 import EditOrgComponent from "../org/edit_org";
+import OrgMembersComponent from "../org/org_members";
 import router from "../../../app/router/router";
 import UserPreferences from "../../../app/preferences/preferences";
 
@@ -15,6 +16,7 @@ export interface SettingsProps {
 
 enum TabId {
   OrgDetails = "org/details",
+  OrgMembers = "org/members",
   OrgGitHub = "org/github",
   OrgApiKeys = "org/api-keys",
   PersonalPreferences = "personal/preferences",
@@ -73,6 +75,11 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                 <SettingsTab id={TabId.OrgDetails} activeTabId={activeTabId}>
                   Org details
                 </SettingsTab>
+                {capabilities.userManagement && (
+                  <SettingsTab id={TabId.OrgMembers} activeTabId={activeTabId}>
+                    Members
+                  </SettingsTab>
+                )}
                 <SettingsTab id={TabId.OrgGitHub} activeTabId={activeTabId}>
                   GitHub link
                 </SettingsTab>
@@ -123,6 +130,12 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                         <div className="settings-section-subtitle">{this.props.user?.selectedGroupName()}</div>
                       )}
                       {capabilities.createOrg && <EditOrgComponent user={this.props.user} />}
+                    </>
+                  )}
+                  {activeTabId === TabId.OrgMembers && capabilities.userManagement && (
+                    <>
+                      <div className="settings-option-title">Members of {this.props.user?.selectedGroupName()}</div>
+                      <OrgMembersComponent user={this.props.user} />
                     </>
                   )}
                   {activeTabId === TabId.OrgGitHub && capabilities.github && (

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -58,4 +58,7 @@ message FrontendConfig {
 
   // Whether or not the usage page is enabled.
   bool usage_enabled = 15;
+
+  // Whether or not user management is enabled.
+  bool user_management_enabled = 16;
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -56,6 +56,7 @@ type appConfig struct {
 	TraceFractionOverrides    []string `yaml:"trace_fraction_overrides" usage:"Tracing fraction override based on name in format name=fraction."`
 	IgnoreForcedTracingHeader bool     `yaml:"ignore_forced_tracing_header" usage:"If set, we will not honor the forced tracing header."`
 	CodeEditorEnabled         bool     `yaml:"code_editor_enabled" usage:"If set, code editor functionality will be enabled."`
+	UserManagementEnabled     bool     `yaml:"user_management_enabled" usage:"If set, the user management page will be enabled in the UI."`
 	GlobalFilterEnabled       bool     `yaml:"global_filter_enabled" usage:"If set, the global filter will be enabled in the UI."`
 	UsageEnabled              bool     `yaml:"usage_enabled" usage:"If set, the usage page will be enabled in the UI."`
 }
@@ -560,6 +561,10 @@ func (c *Configurator) GetDefaultToDenseMode() bool {
 
 func (c *Configurator) GetCodeEditorEnabled() bool {
 	return c.gc.App.CodeEditorEnabled
+}
+
+func (c *Configurator) GetAppUserManagementEnabled() bool {
+	return c.gc.App.UserManagementEnabled
 }
 
 func (c *Configurator) GetAppGlobalFilterEnabled() bool {

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -139,6 +139,7 @@ func serveIndexTemplate(env environment.Env, tpl *template.Template, version str
 		SsoEnabled:                 ssoEnabled,
 		GlobalFilterEnabled:        env.GetConfigurator().GetAppGlobalFilterEnabled(),
 		UsageEnabled:               env.GetConfigurator().GetAppUsageEnabled(),
+		UserManagementEnabled:      env.GetConfigurator().GetAppUserManagementEnabled(),
 	}
 	err := tpl.ExecuteTemplate(w, indexTemplateFilename, &cfgpb.FrontendTemplateData{
 		Config:           &config,


### PR DESCRIPTION
Behind the config option `app.user_management_enabled`, show the "Members" tab in the settings page. It shows a list of group members. It also includes "Edit role" and "Remove" buttons, which don't do anything yet. The plan for "Edit role" is to show a modal dialog that shows the role selector as well as an explanation of each role. The plan for "Remove" is to show a modal with a confirm button. In both cases (edit role and remove) we'll show an extra warning if the changes will affect the current user (to protect against accidentally removing yourself or demoting yourself).

https://user-images.githubusercontent.com/2414826/133817736-ee7cbdeb-e63f-416a-877d-5d8b15deb42d.mp4

In a future PR, we should also consolidate the membership requests into this page.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
