### PR TITLE
Reduce disk cache space usage further

### DIFF
--- a/enterprise/server/cmd/smash/BUILD
+++ b/enterprise/server/cmd/smash/BUILD
@@ -21,6 +21,7 @@ go_library(
         "@com_github_jhump_protoreflect//desc",
         "@go_googleapis//google/bytestream:bytestream_go_proto",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+        "@org_golang_google_grpc//metadata",
     ],
 )
 

--- a/enterprise/server/cmd/smash/smash.go
+++ b/enterprise/server/cmd/smash/smash.go
@@ -20,6 +20,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/monitoring"
+	"google.golang.org/grpc/metadata"
 	"github.com/golang/protobuf/proto"
 	"github.com/jhump/protoreflect/desc"
 
@@ -34,6 +35,7 @@ var (
 	testDuration = flag.Duration("test_duration", 10*time.Second, "The duration of the loadtest.")
 	concurrency  = flag.Uint("concurrency", 10, "Number of concurrent workers to use")
 	instanceName = flag.String("instance_name", "loadtest", "An optional Remote Instance name.")
+	apiKey       = flag.String("api_key", "", "An optional API key to use when reading / writing data.")
 
 	randomSeed         = flag.Int64("random_seed", 0, "Random seed.")
 	realisticBlobSizes = flag.Bool("realistic_blob_sizes", true, "If true, use realistic blob sizes, ignoring blob_size flag.")
@@ -116,6 +118,7 @@ func writeBlobsForReading() []*repb.Digest {
 	}
 	bsClient := bspb.NewByteStreamClient(conn)
 	ctx := context.Background()
+	ctx = metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-api-key", *apiKey)
 	digests := make([]*repb.Digest, 0)
 	for i := 0; uint(i) < *concurrency; i++ {
 		d, buf := newRandomDigestBuf(randomBlobSize())
@@ -214,6 +217,11 @@ func main() {
 	if *realisticBlobSizes {
 		blobSizeDesc = "simulating real blob sizes."
 	}
+
+	md := make(map[string]string)
+	if *apiKey != "" {
+		md["x-buildbuddy-api-key"] = *apiKey
+	}
 	log.Printf("Running a %s test @ %d r/sec, concurrency: %d, %s", *testDuration, *rps, *concurrency, blobSizeDesc)
 	report, err := runner.Run(
 		*method,
@@ -224,6 +232,7 @@ func main() {
 		runner.WithProtoset(protosetFile),
 		runner.WithInsecure(!*ssl),
 		runner.WithBinaryDataFunc(dataFunc),
+		runner.WithMetadata(md),
 	)
 
 	if err != nil {

--- a/enterprise/server/cmd/smash/smash.go
+++ b/enterprise/server/cmd/smash/smash.go
@@ -20,9 +20,9 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/monitoring"
-	"google.golang.org/grpc/metadata"
 	"github.com/golang/protobuf/proto"
 	"github.com/jhump/protoreflect/desc"
+	"google.golang.org/grpc/metadata"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	bspb "google.golang.org/genproto/googleapis/bytestream"

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -544,7 +544,7 @@ func (fk *fileKey) FromPartitionAndPath(part *partition, fullPath string) {
 	}
 
 	if len(parts) > 0 {
-		fk.remoteInstanceName = strings.Join(parts, "/")
+		fk.remoteInstanceName = fk.part.internString(strings.Join(parts, "/"))
 	}
 }
 
@@ -574,7 +574,7 @@ func (p *partition) key(ctx context.Context, cacheType interfaces.CacheType, rem
 		part:               p,
 		cacheType:          cacheType,
 		userPrefix:         p.internString(userPrefix),
-		remoteInstanceName: remoteInstanceName,
+		remoteInstanceName: p.internString(remoteInstanceName),
 		digestHash:         hash,
 	}, nil
 }


### PR DESCRIPTION
WIP

- Remove the concept of "prefix" as one big string and instead pass around remoteInstanceName (string) and cacheType (int).
- Add the concept of fileKey, a struct containing the pieces necessary to construct a full path to a file
- Add FromPartitionAndPath, which reconstructs a fileKey struct from a v1 or v2 file path on disk
- Add internString, which takes a string, hashes it, and if it's been seen before returns a reference to the initial string, else inserts it in a map and returns a reference to it. This should reduce the number of unique strings kept in memory. Intern both the remoteInstanceName and groupID prefix strings.


Before:
<img width="455" alt="Screen Shot 2021-09-21 at 10 13 14 AM" src="https://user-images.githubusercontent.com/141737/134216818-c0c2a832-a9e1-4ed9-ac89-11ac66692cba.png">

After:
<img width="351" alt="Screen Shot 2021-09-21 at 10 13 10 AM" src="https://user-images.githubusercontent.com/141737/134216864-36cbb63e-4b49-4c44-8386-404a8317052f.png">
