### PR TITLE
Fix bugs with usage flush logic and improve concurrency tests

### DIFF
--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -46,6 +46,7 @@ go_library(
         "//server/util/grpc_client",
         "//server/util/healthcheck",
         "//server/util/log",
+        "//server/util/timeutil",
         "//server/util/tracing",
         "//server/version",
         "@org_golang_google_api//option:go_default_library",

--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//server/environment",
         "//server/tables",
-        "//server/util/db",
         "//server/util/log",
         "//server/util/perms",
         "//server/util/status",

--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -6,15 +6,16 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/usage",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/server/util/redisutil",
         "//server/environment",
+        "//server/interfaces",
         "//server/tables",
+        "//server/util/db",
         "//server/util/log",
         "//server/util/perms",
         "//server/util/status",
         "//server/util/timeutil",
         "@com_github_go_redis_redis_v8//:redis",
-        "@com_github_go_redsync_redsync_v4//:redsync",
-        "@com_github_go_redsync_redsync_v4//redis/goredis/v8:goredis",
     ],
 )
 

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -197,7 +197,7 @@ func (ut *tracker) FlushToDB(ctx context.Context) error {
 	}
 	defer func() {
 		if err := ut.flushLock.Unlock(ctx); err != nil {
-			log.Warningf("Failed to unlock Redis lock: %s", err)
+			log.Warningf("Failed to unlock distributed lock: %s", err)
 		}
 	}()
 	return ut.flushToDB(ctx)

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -256,9 +256,9 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, c collection
 		PeriodStartUsec: timeutil.ToUsec(c.UsagePeriod().Start()),
 	}
 	dbh := ut.env.GetDBHandle()
-	// Create a row for the corresponding usage period if one doesn't already
-	// exist.
 	return dbh.Transaction(ctx, func(tx *db.DB) error {
+		// Create a row for the corresponding usage period if one doesn't already
+		// exist.
 		res := tx.Exec(`
 			INSERT `+dbh.InsertIgnoreModifier()+` INTO Usages (
 				group_id,

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -16,7 +16,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/timeutil"
 	"github.com/go-redis/redis/v8"
-
 )
 
 const (
@@ -187,7 +186,7 @@ func (ut *tracker) StopDBFlush() {
 // Public for testing only; the server should call StartDBFlush to periodically
 // flush usage.
 func (ut *tracker) FlushToDB(ctx context.Context) error {
-	// Grab Redis lock. This will immediately return ResourceExhausted if
+	// Grab lock. This will immediately return ResourceExhausted if
 	// another client already holds the lock. In that case, we ignore the error.
 	err := ut.flushLock.Lock(ctx)
 	if status.IsResourceExhaustedError(err) {

--- a/enterprise/server/usage/usage_test.go
+++ b/enterprise/server/usage/usage_test.go
@@ -309,7 +309,11 @@ func TestUsageTracker_Flush_ConcurrentAccessAcrossApps(t *testing.T) {
 	ut, err := usage.NewTracker(te, &usage.TrackerOpts{Clock: clock})
 	require.NoError(t, err)
 
+	// Write 2 collection periods worth of data.
 	err = ut.Increment(ctx, &tables.UsageCounts{CASCacheHits: 1})
+	require.NoError(t, err)
+	clock.Set(clock.Now().Add(collectionPeriodDuration))
+	err = ut.Increment(ctx, &tables.UsageCounts{CASCacheHits: 1000})
 	require.NoError(t, err)
 	clock.Set(clock.Now().Add(2 * collectionPeriodDuration))
 
@@ -335,9 +339,9 @@ func TestUsageTracker_Flush_ConcurrentAccessAcrossApps(t *testing.T) {
 	require.Equal(t, []*tables.Usage{
 		{
 			GroupID:         "GR1",
-			PeriodStartUsec: timeutil.ToUsec(usage1Collection1Start),
-			FinalBeforeUsec: timeutil.ToUsec(usage1Collection2Start),
-			UsageCounts:     tables.UsageCounts{CASCacheHits: 1},
+			PeriodStartUsec: timeutil.ToUsec(usage1Start),
+			FinalBeforeUsec: timeutil.ToUsec(usage1Collection3Start),
+			UsageCounts:     tables.UsageCounts{CASCacheHits: 1001},
 		},
 	}, usages)
 }

--- a/enterprise/server/util/redisutil/BUILD
+++ b/enterprise/server/util/redisutil/BUILD
@@ -10,8 +10,11 @@ go_library(
     ],
     deps = [
         "//server/interfaces",
+        "//server/util/status",
         "@com_github_go_redis_redis_extra_redisotel_v8//:redisotel",
         "@com_github_go_redis_redis_v8//:redis",
+        "@com_github_go_redsync_redsync_v4//:redsync",
+        "@com_github_go_redsync_redsync_v4//redis/goredis/v8:goredis",
     ],
 )
 

--- a/enterprise/server/util/redisutil/redisutil.go
+++ b/enterprise/server/util/redisutil/redisutil.go
@@ -65,8 +65,8 @@ type redlock struct {
 	rmu *redsync.Mutex
 }
 
-// NewWeakRedlock returns a distributed lock implemented using a single Redis
-// client. This provides a "weak" implementation of the Redlock algorithm
+// NewWeakLock returns a distributed lock implemented using a single Redis
+// client. This provides a "weak" implementation of the Redlock algorithm,
 // in the sense that:
 //
 // (a) It is not resilient to Redis nodes failing (even if

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -543,3 +543,19 @@ type LRU interface {
 	// Returns metrics about the status of the LRU.
 	Metrics() string
 }
+
+// DistributedLock provides a way to serialize access to a resource, where the
+// accessors may be running on different nodes.
+//
+// Implementations should expire the lock after an appropriate length of time to
+// ensure that the lock will eventually be released even if this node goes down.
+type DistributedLock interface {
+	// Lock attempts to acquire the lock.
+	//
+	// Implementations may return ResourceExhaustedError if and only if the
+	// lock is already held.
+	Lock(ctx context.Context) error
+
+	// Unlock releases the lock.
+	Unlock(ctx context.Context) error
+}


### PR DESCRIPTION
* Fix the `final_before_usec` update condition; we want to update the usage row only if it is finalized up to the _start_ of the current collection period, not the end
* Improve the concurrent access tests to disable Redlock, so we can test that concurrent flushing is safe even if Redis fails. Also assert that the result is correct rather than just asserting that there was no error (this is what caught the bug above).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
