### PR TITLE
Use different redis client for usage tracker

### DIFF
--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -191,7 +191,8 @@ func main() {
 	}
 
 	if configurator.GetAppUsageTrackingEnabled() {
-		if realEnv.GetCacheRedisClient() == nil {
+		rdb := realEnv.GetRemoteExecutionRedisClient()
+		if rdb == nil {
 			log.Fatalf("Usage tracking is enabled, but no Redis client is configured.")
 		}
 		ut := usage.NewTracker(realEnv, timeutil.NewClock(), usage.NewFlushLock(realEnv))

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -191,8 +191,7 @@ func main() {
 	}
 
 	if configurator.GetAppUsageTrackingEnabled() {
-		rdb := realEnv.GetRemoteExecutionRedisClient()
-		if rdb == nil {
+		if realEnv.GetRemoteExecutionRedisClient() == nil {
 			log.Fatalf("Usage tracking is enabled, but no Redis client is configured.")
 		}
 		ut := usage.NewTracker(realEnv, timeutil.NewClock(), usage.NewFlushLock(realEnv))

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -80,7 +80,7 @@ var (
 // NewFlushLock returns a distributed lock that can be used with NewTracker
 // to help serialize access to the usage data in Redis across apps.
 func NewFlushLock(env environment.Env) interfaces.DistributedLock {
-	return redisutil.NewWeakLock(env.GetCacheRedisClient(), redisUsageLockKey, redisUsageLockExpiry)
+	return redisutil.NewWeakLock(env.GetRemoteExecutionRedisClient(), redisUsageLockKey, redisUsageLockExpiry)
 }
 
 type tracker struct {
@@ -95,7 +95,7 @@ type tracker struct {
 func NewTracker(env environment.Env, clock timeutil.Clock, flushLock interfaces.DistributedLock) *tracker {
 	return &tracker{
 		env:       env,
-		rdb:       env.GetCacheRedisClient(),
+		rdb:       env.GetRemoteExecutionRedisClient(),
 		clock:     clock,
 		flushLock: flushLock,
 		stopFlush: make(chan struct{}),

--- a/enterprise/server/usage/usage_test.go
+++ b/enterprise/server/usage/usage_test.go
@@ -38,7 +38,7 @@ func setupEnv(t *testing.T) *testenv.TestEnv {
 
 	redisTarget := testredis.Start(t)
 	rdb := redis.NewClient(redisutil.TargetToOptions(redisTarget))
-	te.SetCacheRedisClient(rdb)
+	te.SetRemoteExecutionRedisClient(rdb)
 
 	auth := testauth.NewTestAuthenticator(testauth.TestUsers(
 		"US1", "GR1",
@@ -116,7 +116,7 @@ func TestUsageTracker_Increment_MultipleCollectionPeriodsInSameUsagePeriod(t *te
 	ut.Increment(ctx, &tables.UsageCounts{CASCacheHits: 2})
 	ut.Increment(ctx, &tables.UsageCounts{ActionCacheHits: 20})
 
-	rdb := te.GetCacheRedisClient()
+	rdb := te.GetRemoteExecutionRedisClient()
 	keys, err := rdb.Keys(ctx, "usage/*").Result()
 	require.NoError(t, err)
 	countsKey1 := "usage/counts/GR1/" + timeStr(usage1Collection1Start)
@@ -185,7 +185,7 @@ func TestUsageTracker_Increment_MultipleGroupsInSameCollectionPeriod(t *testing.
 	ut.Increment(ctx1, &tables.UsageCounts{CASCacheHits: 1})
 	ut.Increment(ctx2, &tables.UsageCounts{CASCacheHits: 10})
 
-	rdb := te.GetCacheRedisClient()
+	rdb := te.GetRemoteExecutionRedisClient()
 	ctx := context.Background()
 	keys, err := rdb.Keys(ctx, "usage/*").Result()
 	require.NoError(t, err)


### PR DESCRIPTION
We don't set the redis_cache target in dev which makes the server fail to start when usage_tracking_enabled is configured as `true`.

Separately we'll think about whether it makes sense to define a new Redis target just for the usage tracker, and I can make that change afterwards. Just want to unbork dev.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
