### PR TITLE
Use jsonpb for capabilities config

### DIFF
--- a/app/capabilities/BUILD
+++ b/app/capabilities/BUILD
@@ -6,5 +6,6 @@ ts_library(
     name = "capabilities",
     srcs = glob(["*.tsx"]),
     deps = [
+        "//proto:config_ts_proto",
     ],
 )

--- a/app/capabilities/capabilities.tsx
+++ b/app/capabilities/capabilities.tsx
@@ -2,6 +2,7 @@ import { config } from "../../proto/config_ts_proto";
 
 declare const window: Window & {
   buildbuddyConfigBase64: string;
+  buildbuddyConfig?: config.FrontendConfig;
   gtag?: (method: string, ...args: any[]) => void;
 };
 
@@ -46,8 +47,9 @@ export class Capabilities {
     this.manageApiKeys = true;
 
     this.config = getFrontendConfig();
-    // Log the config since it's useful for debugging.
+    // Log the config and assign it to a global for easier debugging.
     console.debug(this.config);
+    window.buildbuddyConfig = this.config;
 
     // Note: Please don't add any new config fields below;
     // get them from the config directly.

--- a/app/capabilities/capabilities.tsx
+++ b/app/capabilities/capabilities.tsx
@@ -1,8 +1,7 @@
 import { config } from "../../proto/config_ts_proto";
 
 declare const window: Window & {
-  buildbuddyConfigBase64: string;
-  buildbuddyConfig?: config.FrontendConfig;
+  buildbuddyConfig: config.IFrontendConfig;
   gtag?: (method: string, ...args: any[]) => void;
 };
 
@@ -11,7 +10,7 @@ export class Capabilities {
   paths: Set<string>;
   enterprise: boolean;
 
-  config: config.FrontendConfig;
+  config: config.IFrontendConfig;
 
   version: string;
   github: boolean;
@@ -46,10 +45,9 @@ export class Capabilities {
     this.deleteInvocation = true;
     this.manageApiKeys = true;
 
-    this.config = getFrontendConfig();
-    // Log the config and assign it to a global for easier debugging.
+    this.config = window.buildbuddyConfig;
+    // Log the config for easier debugging.
     console.debug(this.config);
-    window.buildbuddyConfig = this.config;
 
     // Note: Please don't add any new config fields below;
     // get them from the config directly.
@@ -92,12 +90,6 @@ export class Capabilities {
       });
     }
   }
-}
-
-function getFrontendConfig(): config.FrontendConfig {
-  const base64String = window.buildbuddyConfigBase64;
-  const bytes = Uint8Array.from(atob(base64String), (c) => c.charCodeAt(0));
-  return config.FrontendConfig.decode(bytes);
 }
 
 export default new Capabilities();

--- a/app/capabilities/capabilities.tsx
+++ b/app/capabilities/capabilities.tsx
@@ -46,8 +46,6 @@ export class Capabilities {
     this.manageApiKeys = true;
 
     this.config = window.buildbuddyConfig;
-    // Log the config for easier debugging.
-    console.debug(this.config);
 
     // Note: Please don't add any new config fields below;
     // get them from the config directly.

--- a/app/capabilities/capabilities.tsx
+++ b/app/capabilities/capabilities.tsx
@@ -94,8 +94,8 @@ export class Capabilities {
 
 function getFrontendConfig(): config.FrontendConfig {
   const base64String = window.buildbuddyConfigBase64;
-  const binary = Uint8Array.from(atob(base64String), (c) => c.charCodeAt(0));
-  return config.FrontendConfig.decode(binary);
+  const bytes = Uint8Array.from(atob(base64String), (c) => c.charCodeAt(0));
+  return config.FrontendConfig.decode(bytes);
 }
 
 export default new Capabilities();

--- a/app/preferences/BUILD
+++ b/app/preferences/BUILD
@@ -6,5 +6,6 @@ ts_library(
     name = "preferences",
     srcs = glob(["*.ts"]),
     deps = [
+        "//app/capabilities",
     ],
 )

--- a/app/preferences/preferences.ts
+++ b/app/preferences/preferences.ts
@@ -1,3 +1,5 @@
+import capabilities from "../capabilities/capabilities";
+
 const viewModeKey = "VIEW_MODE";
 const denseModeValue = "DENSE";
 const comfyModeValue = "COMFY";
@@ -17,7 +19,7 @@ export default class UserPreferences {
   denseModeEnabled =
     viewModeKey in window.localStorage
       ? window.localStorage.getItem(viewModeKey) == denseModeValue
-      : window.buildbuddyConfig && window.buildbuddyConfig.default_to_dense_mode;
+      : capabilities.config.defaultToDenseMode;
   lightTerminalEnabled = window.localStorage.getItem(terminalThemeKey) == terminalThemeLightValue || false;
 
   toggleDenseMode() {

--- a/app/root/root.tsx
+++ b/app/root/root.tsx
@@ -23,6 +23,8 @@ interface State {
   preferences: UserPreferences;
 }
 
+capabilities.register("BuildBuddy Community Edition", false, [Path.invocationPath]);
+
 export default class RootComponent extends React.Component {
   state: State = {
     user: null,
@@ -33,7 +35,6 @@ export default class RootComponent extends React.Component {
   };
 
   componentWillMount() {
-    capabilities.register("BuildBuddy Community Edition", false, [Path.invocationPath]);
     authService.register();
     router.register(this.handlePathChange.bind(this));
     authService.userStream.subscribe({

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -35,6 +35,21 @@ interface State {
   loading: boolean;
 }
 
+capabilities.register("BuildBuddy Enterprise", true, [
+  Path.invocationPath,
+  Path.userHistoryPath,
+  Path.hostHistoryPath,
+  Path.repoHistoryPath,
+  Path.branchHistoryPath,
+  Path.commitHistoryPath,
+  Path.workflowsPath,
+  Path.settingsPath,
+  Path.trendsPath,
+  Path.executorsPath,
+  Path.tapPath,
+  Path.codePath,
+]);
+
 export default class EnterpriseRootComponent extends React.Component {
   state: State = {
     loading: true,
@@ -46,20 +61,6 @@ export default class EnterpriseRootComponent extends React.Component {
   };
 
   componentWillMount() {
-    capabilities.register("BuildBuddy Enterprise", true, [
-      Path.invocationPath,
-      Path.userHistoryPath,
-      Path.hostHistoryPath,
-      Path.repoHistoryPath,
-      Path.branchHistoryPath,
-      Path.commitHistoryPath,
-      Path.workflowsPath,
-      Path.settingsPath,
-      Path.trendsPath,
-      Path.executorsPath,
-      Path.tapPath,
-      Path.codePath,
-    ]);
     if (!capabilities.auth) {
       this.setState({ ...this.state, user: null, loading: false });
     }

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -655,6 +655,11 @@ ts_proto_library(
 )
 
 ts_proto_library(
+    name = "config_ts_proto",
+    proto = ":config_proto",
+)
+
+ts_proto_library(
     name = "execution_stats_ts_proto",
     proto = ":execution_stats_proto",
 )

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -2,19 +2,6 @@ syntax = "proto3";
 
 package config;
 
-message FrontendTemplateData {
-  reserved 1;
-
-  // Path to the JS entry point.
-  string js_entry_point_path = 2;
-
-  // Whether or not to render GA tag.
-  bool ga_enabled = 3;
-
-  // Base64-encoded FrontendConfig proto.
-  string config_base64 = 4;
-}
-
 message FrontendConfig {
   // The version of this buildbuddy instance.
   string version = 1;

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -3,14 +3,16 @@ syntax = "proto3";
 package config;
 
 message FrontendTemplateData {
-  // Contents of the JS global variable `window.buildBuddyConfig`.
-  FrontendConfig config = 1;
+  reserved 1;
 
   // Path to the JS entry point.
   string js_entry_point_path = 2;
 
   // Whether or not to render GA tag.
   bool ga_enabled = 3;
+
+  // Base64-encoded FrontendConfig proto.
+  string config_base64 = 4;
 }
 
 message FrontendConfig {

--- a/server/static/BUILD
+++ b/server/static/BUILD
@@ -13,7 +13,7 @@ go_library(
         "//server/environment",
         "//server/util/status",
         "//server/version",
-        "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/server/static/BUILD
+++ b/server/static/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//server/environment",
         "//server/util/status",
         "//server/version",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/version"
 	"github.com/golang/protobuf/proto"
@@ -143,7 +142,6 @@ func serveIndexTemplate(env environment.Env, tpl *template.Template, version str
 		GlobalFilterEnabled:        env.GetConfigurator().GetAppGlobalFilterEnabled(),
 		UsageEnabled:               env.GetConfigurator().GetAppUsageEnabled(),
 		UserManagementEnabled:      env.GetConfigurator().GetAppUserManagementEnabled(),
-		ResourceRolePermissions:    perms.ResourceRolePermissions,
 	}
 
 	configBytes, err := proto.Marshal(&config)

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -154,13 +154,11 @@ func serveIndexTemplate(env environment.Env, tpl *template.Template, version str
 	}
 
 	configJSON := &bytes.Buffer{}
-	m := jsonpb.Marshaler{}
-	err := m.Marshal(configJSON, &config)
-	if err != nil {
+	if err := (&jsonpb.Marshaler{}).Marshal(configJSON, &config); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	err = tpl.ExecuteTemplate(w, indexTemplateFilename, &FrontendTemplateData{
+	err := tpl.ExecuteTemplate(w, indexTemplateFilename, &FrontendTemplateData{
 		JsEntryPointPath: jsPath,
 		GaEnabled:        !*disableGA,
 		Config:           template.JS(configJSON.String()),

--- a/static/index.html
+++ b/static/index.html
@@ -26,7 +26,7 @@
     </style>
 
     <script>
-      window.buildbuddyConfig = {{.Config}};
+      window.buildbuddyConfigBase64 = {{.ConfigBase64}};
       {{/* Monaco loads some libraries using require(), ignore these for now. */}}
       window.require = () => { };
     </script>

--- a/static/index.html
+++ b/static/index.html
@@ -26,7 +26,7 @@
     </style>
 
     <script>
-      window.buildbuddyConfigBase64 = {{.ConfigBase64}};
+      window.buildbuddyConfig = {{.Config}};
       {{/* Monaco loads some libraries using require(), ignore these for now. */}}
       window.require = () => { };
     </script>


### PR DESCRIPTION
This will allow us to use structured protos in the FrontendConfig (planning on using this for the per-role permissions config, which is a relatively small proto that doesn't seem worth adding an extra RPC for).

It's also nice to have the config available as a proto because we no longer need to extract individual fields from the proto and set them on the capabilities class.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
