### PR TITLE
Proto changes for role-based authorization

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -8,6 +8,7 @@ proto_library(
     name = "acl_proto",
     srcs = ["acl.proto"],
     deps = [
+        ":group_proto",
         ":user_id_proto",
     ],
 )
@@ -53,6 +54,9 @@ proto_library(
     name = "config_proto",
     srcs = [
         "config.proto",
+    ],
+    deps = [
+        ":acl_proto",
     ],
 )
 
@@ -325,6 +329,7 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/acl",
     proto = ":acl_proto",
     deps = [
+        ":group_go_proto",
         ":user_id_go_proto",
     ],
 )
@@ -357,6 +362,9 @@ go_proto_library(
     name = "config_go_proto",
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/config",
     proto = ":config_proto",
+    deps = [
+        ":acl_go_proto",
+    ],
 )
 
 go_proto_library(

--- a/proto/acl.proto
+++ b/proto/acl.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "proto/user_id.proto";
+import "proto/grp.proto";
 
 package acl;
 
@@ -12,12 +13,60 @@ message ACL {
   // ID of the group that owns the object.
   string group_id = 2;
 
+  // TODO(bduffany): define special roles for OWNER_USER, OWNER_GROUP, and
+  // OTHERS, and then migrate these fields to role_permissions.
+
   Permissions owner_permissions = 3;
   Permissions group_permissions = 4;
   Permissions others_permissions = 5;
+
+  // Permissions that are granted to roles within the owner group (given by
+  // group_id). These are unioned with group_permissions, meaning that group
+  // members are granted group_permissions in addition to any permissions
+  // granted to their roles within the group.
+  repeated RolePermissions role_permissions = 6;
 
   message Permissions {
     bool read = 1;
     bool write = 2;
   }
+}
+
+// Permissions granted to a particular role within a group.
+message RolePermissions {
+  // The group role that the user must have in order to be granted the
+  // associated permissions.
+  grp.Group.Role role = 1;
+
+  // The permissions that are granted.
+  ACL.Permissions permissions = 2;
+}
+
+// Types of resources which may be restricted by permissions.
+//
+// These are used to define resource types which don't necessarily correspond to
+// a single object with associated permissions bits. For example, API_KEYS
+// allows controlling the ability to create, read, update, and delete *any* API
+// key from the org, as opposed to the ability to do those actions on an
+// *individual* API key.
+//
+// These resource types are agnostic to the underlying DB representation,
+// although in most cases there is a direct mapping from resource types to
+// tables or subsets of table fields.
+enum ResourceType {
+  UNKNOWN = 0;
+  API_KEYS = 1;
+  ORG_DETAILS = 2;
+  ORG_MEMBERS = 3;
+  ORG_GITHUB_LINK = 4;
+  WORKFLOWS = 5;
+  EXECUTORS = 6;
+}
+
+// An ACL attached to a resource type.
+message ResourceTypeACL {
+  // The resource to which the ACL applies.
+  ResourceType resource_type = 1;
+  // The ACL defining who can do what with the resource type.
+  ACL acl = 2;
 }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package config;
 
+import "proto/acl.proto";
+
 message FrontendConfig {
   // The version of this buildbuddy instance.
   string version = 1;
@@ -50,4 +52,11 @@ message FrontendConfig {
 
   // Whether or not user management is enabled.
   bool user_management_enabled = 16;
+
+  // Default configuration as to which roles can access which resource types.
+  //
+  // This allows showing or hiding sections of the UI based on the user's role,
+  // and also rendering an explicit list of role permissions in the user
+  // management UI.
+  repeated acl.ResourceTypeACL resource_type_acl = 17;
 }


### PR DESCRIPTION
* Allow representing role pemissions in the ACL proto beyond the existing `owner_user`, `owner_group`, and `others` roles
* Allow configuring a mapping from resource types (API keys, Workflows, etc.) to role permissions, so the UI can decide who gets to read/write what. The server will use this same data to construct role-based ACLs when authorizing API calls.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
