### PR TITLE
Move selected group logic to the server

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -6,7 +6,8 @@ import capabilities from "../capabilities/capabilities";
 import rpcService from "../service/rpc_service";
 import errorService from "../errors/error_service";
 import { BuildBuddyError } from "../../app/util/errors";
-import { SELECTED_GROUP_ID_LOCAL_STORAGE_KEY } from "../service/rpc_service";
+
+const SELECTED_GROUP_ID_LOCAL_STORAGE_KEY = "selected_group_id";
 
 export class User {
   displayUser: user_id.DisplayUser;
@@ -31,6 +32,9 @@ export class AuthService {
 
   register() {
     if (!capabilities.auth) return;
+    // Set initially preferred group ID from local storage.
+    rpcService.requestContext.groupId = window.localStorage.getItem(SELECTED_GROUP_ID_LOCAL_STORAGE_KEY);
+
     let request = new user.GetUserRequest();
     rpcService.service
       .getUser(request)

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -1,5 +1,4 @@
 import { Subject } from "rxjs";
-import { context } from "../../proto/context_ts_proto";
 import { grp } from "../../proto/group_ts_proto";
 import { user_id } from "../../proto/user_id_ts_proto";
 import { user } from "../../proto/user_ts_proto";
@@ -7,8 +6,7 @@ import capabilities from "../capabilities/capabilities";
 import rpcService from "../service/rpc_service";
 import errorService from "../errors/error_service";
 import { BuildBuddyError } from "../../app/util/errors";
-
-const SELECTED_GROUP_ID_LOCAL_STORAGE_KEY = "selected_group_id";
+import { SELECTED_GROUP_ID_LOCAL_STORAGE_KEY } from "../service/rpc_service";
 
 export class User {
   displayUser: user_id.DisplayUser;
@@ -87,14 +85,7 @@ export class AuthService {
     let user = new User();
     user.displayUser = response.displayUser as user_id.DisplayUser;
     user.groups = response.userGroup as grp.Group[];
-    let selectedGroupId = window.localStorage.getItem(SELECTED_GROUP_ID_LOCAL_STORAGE_KEY);
-    if (user.groups.length > 0) {
-      user.selectedGroup =
-        (selectedGroupId && user.groups.find((group) => group.id === selectedGroupId)) ||
-        user.groups.find((group) => group.urlIdentifier) ||
-        user.groups.find((group) => group.ownedDomain) ||
-        user.groups[0];
-    }
+    user.selectedGroup = response.userGroup.find((group) => group.id === response.selectedGroupId) as grp.Group;
     return user;
   }
 

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -6,6 +6,8 @@ import * as protobufjs from "protobufjs";
 
 export { CancelablePromise } from "../util/async";
 
+export const SELECTED_GROUP_ID_LOCAL_STORAGE_KEY = "selected_group_id";
+
 /**
  * ExtendedBuildBuddyService is an extended version of BuildBuddyService with
  * the following differences:
@@ -19,6 +21,7 @@ class RpcService {
   service: ExtendedBuildBuddyService;
   events: Subject<string>;
   requestContext = new context.RequestContext({
+    groupId: window.localStorage.getItem(SELECTED_GROUP_ID_LOCAL_STORAGE_KEY),
     timezoneOffsetMinutes: new Date().getTimezoneOffset(),
   });
 

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -6,8 +6,6 @@ import * as protobufjs from "protobufjs";
 
 export { CancelablePromise } from "../util/async";
 
-export const SELECTED_GROUP_ID_LOCAL_STORAGE_KEY = "selected_group_id";
-
 /**
  * ExtendedBuildBuddyService is an extended version of BuildBuddyService with
  * the following differences:
@@ -21,7 +19,6 @@ class RpcService {
   service: ExtendedBuildBuddyService;
   events: Subject<string>;
   requestContext = new context.RequestContext({
-    groupId: window.localStorage.getItem(SELECTED_GROUP_ID_LOCAL_STORAGE_KEY),
     timezoneOffsetMinutes: new Date().getTimezoneOffset(),
   });
 

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -202,6 +202,7 @@ proto_library(
     srcs = ["user.proto"],
     exports = [":user_id_proto"],
     deps = [
+        ":context_proto",
         ":group_proto",
         ":user_id_proto",
     ],
@@ -526,6 +527,7 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/user",
     proto = ":user_proto",
     deps = [
+        ":context_go_proto",
         ":group_go_proto",
         ":user_id_go_proto",
     ],

--- a/proto/user.proto
+++ b/proto/user.proto
@@ -1,11 +1,14 @@
 syntax = "proto3";
 
+import "proto/context.proto";
 import "proto/grp.proto";
 import "proto/user_id.proto";
 
 package user;
 
 message GetUserRequest {
+  context.RequestContext request_context = 2;
+
   user_id.UserId user_id = 1;
 }
 
@@ -14,6 +17,15 @@ message GetUserResponse {
 
   // The groups this user is a member of.
   repeated grp.Group user_group = 2;
+
+  // The ID of the user's currently selected group to be displayed in the UI.
+  //
+  // In most cases, this will match the group_id in the original request
+  // context, which should be populated from client preferences. However, if the
+  // user no longer has access to the group or if no group_id was set, this will
+  // be set to one of the group IDs in user_group as a fallback. If user_group
+  // is empty, this will also be empty.
+  string selected_group_id = 3;
 }
 
 message CreateUserRequest {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -153,8 +153,9 @@ func (s *BuildBuddyServer) GetUser(ctx context.Context, req *uspb.GetUserRequest
 		return nil, status.UnauthenticatedError("User not found")
 	}
 	return &uspb.GetUserResponse{
-		DisplayUser: tu.ToProto(),
-		UserGroup:   makeGroups(tu.Groups),
+		DisplayUser:     tu.ToProto(),
+		UserGroup:       makeGroups(tu.Groups),
+		SelectedGroupId: selectedGroupID(req.GetRequestContext().GetGroupId(), tu.Groups),
 	}, nil
 }
 
@@ -464,6 +465,30 @@ func (s *BuildBuddyServer) DeleteApiKey(ctx context.Context, req *akpb.DeleteApi
 		return nil, err
 	}
 	return &akpb.DeleteApiKeyResponse{}, nil
+}
+
+func selectedGroupID(preferredGroupID string, groups []*tables.Group) string {
+	if preferredGroupID != "" {
+		for _, group := range groups {
+			if group.GroupID == preferredGroupID {
+				return group.GroupID
+			}
+		}
+	}
+	for _, group := range groups {
+		if group.URLIdentifier != nil && *group.URLIdentifier != "" {
+			return group.GroupID
+		}
+	}
+	for _, group := range groups {
+		if group.OwnedDomain != "" {
+			return group.GroupID
+		}
+	}
+	if len(groups) > 0 {
+		return groups[0].GroupID
+	}
+	return ""
 }
 
 func getEmailDomain(email string) string {


### PR DESCRIPTION
This will allow us to expand `GetUserResponse` with the list of resources (API endpoints) that are accessible to the user within their currently selected group.

Replicating the exact logic that we use on the client to determine the "fallback" selected group when a preference is not set or the user no longer has access to the selected group.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
