### PR TITLE
Add default redis target

### DIFF
--- a/docs/enterprise-config.md
+++ b/docs/enterprise-config.md
@@ -31,6 +31,19 @@ database:
 
 If using the [BuildBuddy Enterprise Helm charts](https://github.com/buildbuddy-io/buildbuddy-helm/tree/master/charts/buildbuddy-enterprise), MySQL can be configured for you using the `mysql.enabled`, `mysql.username`, and `mysql.password` values.
 
+### Default Redis Target
+
+For a BuildBuddy deployment running multiple apps, it is necessary to provide a default redis target for some features to work correctly. Metrics collection, usage tracking, and responsive build logs all depend on this.
+
+If no default redis target is configured, we will fall back to using the cache redis target, if available, and then the remote execution target, if available. The default redis target also acts as the primary fallback if the remote execution redis target is left unspecified. The default redis target does NOT act as a fallback for the cache redis target.
+
+The configuration below demostrates a default redis target:
+
+```
+app:
+  default_redis_target: "my-redis.local:6379"
+```
+
 ### GCS Based Cache / Object Storage / Redis
 
 By default, BuildBuddy will cache objects and store uploaded build events on the local disk. If you want to store them in a shared durable location, like a Google Cloud Storage bucket, you can do that by configuring a GCS cache or storage backend.

--- a/enterprise/config/buildbuddy.local.yaml
+++ b/enterprise/config/buildbuddy.local.yaml
@@ -4,6 +4,7 @@ app:
   create_group_per_user: true
   add_user_to_domain_group: true
   code_editor_enabled: true
+  default_redis_target: "localhost:6379"
 database:
   data_source: "sqlite3:///tmp/buildbuddy-enterprise.db"
 storage:
@@ -28,4 +29,3 @@ github:
   client_secret: "${BB_DEV_GITHUB_CLIENT_SECRET}"
 remote_execution:
   enable_remote_exec: true
-  redis_target: "localhost:6379"

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -193,11 +193,7 @@ func main() {
 	if redisTarget := configurator.GetDefaultRedisTarget(); redisTarget != "" {
 		redisClient := redisutil.NewClient(redisTarget, healthChecker, "default_redis")
 		realEnv.SetDefaultRedisClient(redisClient)
-		maxValueSizeBytes := int64(0)
-		if redisConfig := configurator.GetDefaultRedisConfig(); redisConfig != nil {
-			maxValueSizeBytes = redisConfig.MaxValueSizeBytes
-		}
-		r := redis_cache.NewCache(realEnv.GetDefaultRedisClient(), maxValueSizeBytes)
+		r := redis_cache.NewCache(realEnv.GetDefaultRedisClient(), 0)
 		realEnv.SetMetricsCollector(r)
 		realEnv.SetKeyValStore(r)
 	}

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -190,6 +190,11 @@ func main() {
 		realEnv.SetCacheRedisClient(redisClient)
 	}
 
+	if redisTarget := configurator.GetDefaultRedisTarget(); redisTarget != "" {
+		redisClient := redisutil.NewClient(redisTarget, healthChecker, "default_redis")
+		realEnv.SetDefaultRedisClient(redisClient)
+	}
+
 	if redisTarget := configurator.GetRemoteExecutionRedisTarget(); redisTarget != "" {
 		redisClient := redisutil.NewClient(redisTarget, healthChecker, "remote_execution_redis")
 		realEnv.SetRemoteExecutionRedisClient(redisClient)
@@ -203,7 +208,7 @@ func main() {
 	}
 
 	if configurator.GetAppUsageTrackingEnabled() {
-		if realEnv.GetRemoteExecutionRedisClient() == nil {
+		if realEnv.GetDefaultRedisClient() == nil {
 			log.Fatalf("Usage tracking is enabled, but no Redis client is configured.")
 		}
 		ut := usage.NewTracker(realEnv, timeutil.NewClock(), usage.NewFlushLock(realEnv))
@@ -262,7 +267,7 @@ func main() {
 		log.Infof("Enabling memcache layer with targets: %s", mcTargets)
 		mc := memcache.NewCache(mcTargets...)
 		realEnv.SetCache(composable_cache.NewComposableCache(mc, realEnv.GetCache(), composable_cache.ModeReadThrough|composable_cache.ModeWriteThrough))
-	} else if redisTarget := configurator.GetCacheRedisTarget(); redisTarget != "" {
+	} else if redisTarget := configurator.GetDefaultRedisTarget(); redisTarget != "" {
 		log.Infof("Enabling redis layer with targets: %s", redisTarget)
 		maxValueSizeBytes := int64(0)
 		if redisConfig := configurator.GetCacheRedisConfig(); redisConfig != nil {

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -80,7 +80,7 @@ var (
 // NewFlushLock returns a distributed lock that can be used with NewTracker
 // to help serialize access to the usage data in Redis across apps.
 func NewFlushLock(env environment.Env) interfaces.DistributedLock {
-	return redisutil.NewWeakLock(env.GetRemoteExecutionRedisClient(), redisUsageLockKey, redisUsageLockExpiry)
+	return redisutil.NewWeakLock(env.GetDefaultRedisClient(), redisUsageLockKey, redisUsageLockExpiry)
 }
 
 type tracker struct {
@@ -95,7 +95,7 @@ type tracker struct {
 func NewTracker(env environment.Env, clock timeutil.Clock, flushLock interfaces.DistributedLock) *tracker {
 	return &tracker{
 		env:       env,
-		rdb:       env.GetRemoteExecutionRedisClient(),
+		rdb:       env.GetDefaultRedisClient(),
 		clock:     clock,
 		flushLock: flushLock,
 		stopFlush: make(chan struct{}),

--- a/enterprise/server/usage/usage_test.go
+++ b/enterprise/server/usage/usage_test.go
@@ -38,7 +38,7 @@ func setupEnv(t *testing.T) *testenv.TestEnv {
 
 	redisTarget := testredis.Start(t)
 	rdb := redis.NewClient(redisutil.TargetToOptions(redisTarget))
-	te.SetRemoteExecutionRedisClient(rdb)
+	te.SetDefaultRedisClient(rdb)
 
 	auth := testauth.NewTestAuthenticator(testauth.TestUsers(
 		"US1", "GR1",
@@ -116,7 +116,7 @@ func TestUsageTracker_Increment_MultipleCollectionPeriodsInSameUsagePeriod(t *te
 	ut.Increment(ctx, &tables.UsageCounts{CASCacheHits: 2})
 	ut.Increment(ctx, &tables.UsageCounts{ActionCacheHits: 20})
 
-	rdb := te.GetRemoteExecutionRedisClient()
+	rdb := te.GetDefaultRedisClient()
 	keys, err := rdb.Keys(ctx, "usage/*").Result()
 	require.NoError(t, err)
 	countsKey1 := "usage/counts/GR1/" + timeStr(usage1Collection1Start)
@@ -185,7 +185,7 @@ func TestUsageTracker_Increment_MultipleGroupsInSameCollectionPeriod(t *testing.
 	ut.Increment(ctx1, &tables.UsageCounts{CASCacheHits: 1})
 	ut.Increment(ctx2, &tables.UsageCounts{CASCacheHits: 10})
 
-	rdb := te.GetRemoteExecutionRedisClient()
+	rdb := te.GetDefaultRedisClient()
 	ctx := context.Background()
 	keys, err := rdb.Keys(ctx, "usage/*").Result()
 	require.NoError(t, err)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -600,8 +600,13 @@ func (c *Configurator) GetDefaultRedisTarget() string {
 	if drc := c.GetDefaultRedisConfig(); drc != nil && drc.RedisTarget != "" {
 		return drc.RedisTarget
 	}
-	// Fall back to the remote execution redis target if default redis target is not specified.
-	// Historically we did not have a default redis target.
+
+	if crt := c.GetCacheRedisTarget(); crt != "" {
+		// Fall back to the cache redis target if default redis target is not specified.
+		return crt
+	}
+
+	// Otherwise, fall back to the remote exec redis target.
 	return c.GetRemoteExecutionRedisTarget()
 }
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -33,35 +33,35 @@ type generalConfig struct {
 }
 
 type appConfig struct {
-	BuildBuddyURL             string      `yaml:"build_buddy_url" usage:"The external URL where your BuildBuddy instance can be found."`
-	EventsAPIURL              string      `yaml:"events_api_url" usage:"Overrides the default build event protocol gRPC address shown by BuildBuddy on the configuration screen."`
-	CacheAPIURL               string      `yaml:"cache_api_url" usage:"Overrides the default remote cache protocol gRPC address shown by BuildBuddy on the configuration screen."`
-	RemoteExecutionAPIURL     string      `yaml:"remote_execution_api_url" usage:"Overrides the default remote execution protocol gRPC address shown by BuildBuddy on the configuration screen."`
-	LogLevel                  string      `yaml:"log_level" usage:"The desired log level. Logs with a level >= this level will be emitted. One of {'fatal', 'error', 'warn', 'info', 'debug'}"`
-	GRPCMaxRecvMsgSizeBytes   int         `yaml:"grpc_max_recv_msg_size_bytes" usage:"Configures the max GRPC receive message size [bytes]"`
-	GRPCOverHTTPPortEnabled   bool        `yaml:"grpc_over_http_port_enabled" usage:"Cloud-Only"`
-	AddUserToDomainGroup      bool        `yaml:"add_user_to_domain_group" usage:"Cloud-Only"`
-	DefaultToDenseMode        bool        `yaml:"default_to_dense_mode" usage:"Enables the dense UI mode by default."`
-	CreateGroupPerUser        bool        `yaml:"create_group_per_user" usage:"Cloud-Only"`
-	EnableTargetTracking      bool        `yaml:"enable_target_tracking" usage:"Cloud-Only"`
-	EnableStructuredLogging   bool        `yaml:"enable_structured_logging" usage:"If true, log messages will be json-formatted."`
-	LogIncludeShortFileName   bool        `yaml:"log_include_short_file_name" usage:"If true, log messages will include shortened originating file name."`
-	NoDefaultUserGroup        bool        `yaml:"no_default_user_group" usage:"Cloud-Only"`
-	LogEnableGCPLoggingFormat bool        `yaml:"log_enable_gcp_logging_format" usage:"If true, the output structured logs will be compatible with format expected by GCP Logging."`
-	LogErrorStackTraces       bool        `yaml:"log_error_stack_traces" usage:"If true, stack traces will be printed for errors that have them."`
-	TraceProjectID            string      `yaml:"trace_project_id" usage:"Optional GCP project ID to export traces to. If not specified, determined from default credentials or metadata server if running on GCP."`
-	TraceJaegerCollector      string      `yaml:"trace_jaeger_collector" usage:"Address of the Jager collector endpoint where traces will be sent."`
-	TraceServiceName          string      `yaml:"trace_service_name" usage:"Name of the service to associate with traces."`
-	TraceFraction             float64     `yaml:"trace_fraction" usage:"Fraction of requests to sample for tracing."`
-	TraceFractionOverrides    []string    `yaml:"trace_fraction_overrides" usage:"Tracing fraction override based on name in format name=fraction."`
-	IgnoreForcedTracingHeader bool        `yaml:"ignore_forced_tracing_header" usage:"If set, we will not honor the forced tracing header."`
-	CodeEditorEnabled         bool        `yaml:"code_editor_enabled" usage:"If set, code editor functionality will be enabled."`
-	UserManagementEnabled     bool        `yaml:"user_management_enabled" usage:"If set, the user management page will be enabled in the UI."`
-	GlobalFilterEnabled       bool        `yaml:"global_filter_enabled" usage:"If set, the global filter will be enabled in the UI."`
-	UsageEnabled              bool        `yaml:"usage_enabled" usage:"If set, the usage page will be enabled in the UI."`
-	UsageStartDate            string      `yaml:"usage_start_date" usage:"If set, usage data will only be viewable on or after this timestamp. Specified in RFC3339 format, like 2021-10-01T00:00:00Z"`
-	UsageTrackingEnabled      bool        `yaml:"usage_tracking_enabled" usage:"If set, enable usage data collection."`
-	DefaultRedisConfig        RedisConfig `yaml:"default_redis_target" usage:"A Redis target for storing remote shared state. To ease migration, the redis target from the remote execution config will be used if this value is not specified."`
+	BuildBuddyURL             string   `yaml:"build_buddy_url" usage:"The external URL where your BuildBuddy instance can be found."`
+	EventsAPIURL              string   `yaml:"events_api_url" usage:"Overrides the default build event protocol gRPC address shown by BuildBuddy on the configuration screen."`
+	CacheAPIURL               string   `yaml:"cache_api_url" usage:"Overrides the default remote cache protocol gRPC address shown by BuildBuddy on the configuration screen."`
+	RemoteExecutionAPIURL     string   `yaml:"remote_execution_api_url" usage:"Overrides the default remote execution protocol gRPC address shown by BuildBuddy on the configuration screen."`
+	LogLevel                  string   `yaml:"log_level" usage:"The desired log level. Logs with a level >= this level will be emitted. One of {'fatal', 'error', 'warn', 'info', 'debug'}"`
+	GRPCMaxRecvMsgSizeBytes   int      `yaml:"grpc_max_recv_msg_size_bytes" usage:"Configures the max GRPC receive message size [bytes]"`
+	GRPCOverHTTPPortEnabled   bool     `yaml:"grpc_over_http_port_enabled" usage:"Cloud-Only"`
+	AddUserToDomainGroup      bool     `yaml:"add_user_to_domain_group" usage:"Cloud-Only"`
+	DefaultToDenseMode        bool     `yaml:"default_to_dense_mode" usage:"Enables the dense UI mode by default."`
+	CreateGroupPerUser        bool     `yaml:"create_group_per_user" usage:"Cloud-Only"`
+	EnableTargetTracking      bool     `yaml:"enable_target_tracking" usage:"Cloud-Only"`
+	EnableStructuredLogging   bool     `yaml:"enable_structured_logging" usage:"If true, log messages will be json-formatted."`
+	LogIncludeShortFileName   bool     `yaml:"log_include_short_file_name" usage:"If true, log messages will include shortened originating file name."`
+	NoDefaultUserGroup        bool     `yaml:"no_default_user_group" usage:"Cloud-Only"`
+	LogEnableGCPLoggingFormat bool     `yaml:"log_enable_gcp_logging_format" usage:"If true, the output structured logs will be compatible with format expected by GCP Logging."`
+	LogErrorStackTraces       bool     `yaml:"log_error_stack_traces" usage:"If true, stack traces will be printed for errors that have them."`
+	TraceProjectID            string   `yaml:"trace_project_id" usage:"Optional GCP project ID to export traces to. If not specified, determined from default credentials or metadata server if running on GCP."`
+	TraceJaegerCollector      string   `yaml:"trace_jaeger_collector" usage:"Address of the Jager collector endpoint where traces will be sent."`
+	TraceServiceName          string   `yaml:"trace_service_name" usage:"Name of the service to associate with traces."`
+	TraceFraction             float64  `yaml:"trace_fraction" usage:"Fraction of requests to sample for tracing."`
+	TraceFractionOverrides    []string `yaml:"trace_fraction_overrides" usage:"Tracing fraction override based on name in format name=fraction."`
+	IgnoreForcedTracingHeader bool     `yaml:"ignore_forced_tracing_header" usage:"If set, we will not honor the forced tracing header."`
+	CodeEditorEnabled         bool     `yaml:"code_editor_enabled" usage:"If set, code editor functionality will be enabled."`
+	UserManagementEnabled     bool     `yaml:"user_management_enabled" usage:"If set, the user management page will be enabled in the UI."`
+	GlobalFilterEnabled       bool     `yaml:"global_filter_enabled" usage:"If set, the global filter will be enabled in the UI."`
+	UsageEnabled              bool     `yaml:"usage_enabled" usage:"If set, the usage page will be enabled in the UI."`
+	UsageStartDate            string   `yaml:"usage_start_date" usage:"If set, usage data will only be viewable on or after this timestamp. Specified in RFC3339 format, like 2021-10-01T00:00:00Z"`
+	UsageTrackingEnabled      bool     `yaml:"usage_tracking_enabled" usage:"If set, enable usage data collection."`
+	DefaultRedisTarget        string   `yaml:"default_redis_target" usage:"A Redis target for storing remote shared state. To ease migration, the redis target from the remote execution config will be used if this value is not specified."`
 }
 
 type buildEventProxy struct {
@@ -176,7 +176,7 @@ type DistributedCacheConfig struct {
 }
 
 type RedisConfig struct {
-	RedisTarget       string `yaml:"redis_target" usage:"A redis target to use for usage tracking, metrics collection, caching, or remote execution. Target can be provided as either a redis connection URI or a host:port pair. URI schemas supported: redis[s]://[[USER][:PASSWORD]@][HOST][:PORT][/DATABASE] or unix://[[USER][:PASSWORD]@]SOCKET_PATH[?db=DATABASE] ** Enterprise only **"`
+	RedisTarget       string `yaml:"redis_target" usage:"A redis target to use for usage tracking, metrics collection, caching, or remote execution, depending on configuration options. Target can be provided as either a redis connection URI or a host:port pair. URI schemas supported: redis[s]://[[USER][:PASSWORD]@][HOST][:PORT][/DATABASE] or unix://[[USER][:PASSWORD]@]SOCKET_PATH[?db=DATABASE] ** Enterprise only **"`
 	MaxValueSizeBytes int64  `yaml:"max_value_size_bytes" usage:"The maximum value size to store in redis (in bytes)."`
 }
 
@@ -597,8 +597,8 @@ func (c *Configurator) GetAppUsageTrackingEnabled() bool {
 }
 
 func (c *Configurator) GetDefaultRedisTarget() string {
-	if drc := c.GetDefaultRedisConfig(); drc != nil && drc.RedisTarget != "" {
-		return drc.RedisTarget
+	if c.gc.App.DefaultRedisTarget != "" {
+		return c.gc.App.DefaultRedisTarget
 	}
 
 	if crt := c.GetCacheRedisTarget(); crt != "" {
@@ -608,13 +608,6 @@ func (c *Configurator) GetDefaultRedisTarget() string {
 
 	// Otherwise, fall back to the remote exec redis target.
 	return c.GetRemoteExecutionRedisTarget()
-}
-
-func (c *Configurator) GetDefaultRedisConfig() *RedisConfig {
-	if c.gc.App.DefaultRedisConfig.RedisTarget != "" {
-		return &c.gc.App.DefaultRedisConfig
-	}
-	return nil
 }
 
 func (c *Configurator) GetGRPCMaxRecvMsgSizeBytes() int {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -175,9 +175,9 @@ type DistributedCacheConfig struct {
 	ClusterSize       int      `yaml:"cluster_size" usage:"The total number of nodes in this cluster. Required for health checking. ** Enterprise only **"`
 }
 
-type RedisConfig struct {
-	RedisTarget       string `yaml:"redis_target" usage:"A redis target to use for usage tracking, metrics collection, caching, or remote execution, depending on configuration options. Target can be provided as either a redis connection URI or a host:port pair. URI schemas supported: redis[s]://[[USER][:PASSWORD]@][HOST][:PORT][/DATABASE] or unix://[[USER][:PASSWORD]@]SOCKET_PATH[?db=DATABASE] ** Enterprise only **"`
-	MaxValueSizeBytes int64  `yaml:"max_value_size_bytes" usage:"The maximum value size to store in redis (in bytes)."`
+type RedisCacheConfig struct {
+	RedisTarget       string `yaml:"redis_target" usage:"A redis target for improved Caching/RBE performance. Target can be provided as either a redis connection URI or a host:port pair. URI schemas supported: redis[s]://[[USER][:PASSWORD]@][HOST][:PORT][/DATABASE] or unix://[[USER][:PASSWORD]@]SOCKET_PATH[?db=DATABASE] ** Enterprise only **"`
+	MaxValueSizeBytes int64  `yaml:"max_value_size_bytes" usage:"The maximum value size to cache in redis (in bytes)."`
 }
 
 type cacheConfig struct {
@@ -186,7 +186,7 @@ type cacheConfig struct {
 	S3               S3CacheConfig          `yaml:"s3"`
 	GCS              GCSCacheConfig         `yaml:"gcs"`
 	MemcacheTargets  []string               `yaml:"memcache_targets" usage:"Deprecated. Use Redis Target instead."`
-	Redis            RedisConfig            `yaml:"redis"`
+	Redis            RedisCacheConfig       `yaml:"redis"`
 	DistributedCache DistributedCacheConfig `yaml:"distributed_cache"`
 	MaxSizeBytes     int64                  `yaml:"max_size_bytes" usage:"How big to allow the cache to be (in bytes)."`
 	InMemory         bool                   `yaml:"in_memory" usage:"Whether or not to use the in_memory cache."`
@@ -679,7 +679,7 @@ func (c *Configurator) GetCacheRedisTarget() string {
 	return c.gc.Cache.RedisTarget
 }
 
-func (c *Configurator) GetCacheRedisConfig() *RedisConfig {
+func (c *Configurator) GetCacheRedisConfig() *RedisCacheConfig {
 	if c.gc.Cache.Redis.RedisTarget != "" {
 		return &c.gc.Cache.Redis
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -33,35 +33,35 @@ type generalConfig struct {
 }
 
 type appConfig struct {
-	BuildBuddyURL             string   `yaml:"build_buddy_url" usage:"The external URL where your BuildBuddy instance can be found."`
-	EventsAPIURL              string   `yaml:"events_api_url" usage:"Overrides the default build event protocol gRPC address shown by BuildBuddy on the configuration screen."`
-	CacheAPIURL               string   `yaml:"cache_api_url" usage:"Overrides the default remote cache protocol gRPC address shown by BuildBuddy on the configuration screen."`
-	RemoteExecutionAPIURL     string   `yaml:"remote_execution_api_url" usage:"Overrides the default remote execution protocol gRPC address shown by BuildBuddy on the configuration screen."`
-	LogLevel                  string   `yaml:"log_level" usage:"The desired log level. Logs with a level >= this level will be emitted. One of {'fatal', 'error', 'warn', 'info', 'debug'}"`
-	GRPCMaxRecvMsgSizeBytes   int      `yaml:"grpc_max_recv_msg_size_bytes" usage:"Configures the max GRPC receive message size [bytes]"`
-	GRPCOverHTTPPortEnabled   bool     `yaml:"grpc_over_http_port_enabled" usage:"Cloud-Only"`
-	AddUserToDomainGroup      bool     `yaml:"add_user_to_domain_group" usage:"Cloud-Only"`
-	DefaultToDenseMode        bool     `yaml:"default_to_dense_mode" usage:"Enables the dense UI mode by default."`
-	CreateGroupPerUser        bool     `yaml:"create_group_per_user" usage:"Cloud-Only"`
-	EnableTargetTracking      bool     `yaml:"enable_target_tracking" usage:"Cloud-Only"`
-	EnableStructuredLogging   bool     `yaml:"enable_structured_logging" usage:"If true, log messages will be json-formatted."`
-	LogIncludeShortFileName   bool     `yaml:"log_include_short_file_name" usage:"If true, log messages will include shortened originating file name."`
-	NoDefaultUserGroup        bool     `yaml:"no_default_user_group" usage:"Cloud-Only"`
-	LogEnableGCPLoggingFormat bool     `yaml:"log_enable_gcp_logging_format" usage:"If true, the output structured logs will be compatible with format expected by GCP Logging."`
-	LogErrorStackTraces       bool     `yaml:"log_error_stack_traces" usage:"If true, stack traces will be printed for errors that have them."`
-	TraceProjectID            string   `yaml:"trace_project_id" usage:"Optional GCP project ID to export traces to. If not specified, determined from default credentials or metadata server if running on GCP."`
-	TraceJaegerCollector      string   `yaml:"trace_jaeger_collector" usage:"Address of the Jager collector endpoint where traces will be sent."`
-	TraceServiceName          string   `yaml:"trace_service_name" usage:"Name of the service to associate with traces."`
-	TraceFraction             float64  `yaml:"trace_fraction" usage:"Fraction of requests to sample for tracing."`
-	TraceFractionOverrides    []string `yaml:"trace_fraction_overrides" usage:"Tracing fraction override based on name in format name=fraction."`
-	IgnoreForcedTracingHeader bool     `yaml:"ignore_forced_tracing_header" usage:"If set, we will not honor the forced tracing header."`
-	CodeEditorEnabled         bool     `yaml:"code_editor_enabled" usage:"If set, code editor functionality will be enabled."`
-	UserManagementEnabled     bool     `yaml:"user_management_enabled" usage:"If set, the user management page will be enabled in the UI."`
-	GlobalFilterEnabled       bool     `yaml:"global_filter_enabled" usage:"If set, the global filter will be enabled in the UI."`
-	UsageEnabled              bool     `yaml:"usage_enabled" usage:"If set, the usage page will be enabled in the UI."`
-	UsageStartDate            string   `yaml:"usage_start_date" usage:"If set, usage data will only be viewable on or after this timestamp. Specified in RFC3339 format, like 2021-10-01T00:00:00Z"`
-	UsageTrackingEnabled      bool     `yaml:"usage_tracking_enabled" usage:"If set, enable usage data collection."`
-	DefaultRedisTarget        string   `yaml:"default_redis_target" usage:"A Redis target for storing remote cache state. To ease migration, the redis target from the remote execution config will be used if this value is not specified."`
+	BuildBuddyURL             string      `yaml:"build_buddy_url" usage:"The external URL where your BuildBuddy instance can be found."`
+	EventsAPIURL              string      `yaml:"events_api_url" usage:"Overrides the default build event protocol gRPC address shown by BuildBuddy on the configuration screen."`
+	CacheAPIURL               string      `yaml:"cache_api_url" usage:"Overrides the default remote cache protocol gRPC address shown by BuildBuddy on the configuration screen."`
+	RemoteExecutionAPIURL     string      `yaml:"remote_execution_api_url" usage:"Overrides the default remote execution protocol gRPC address shown by BuildBuddy on the configuration screen."`
+	LogLevel                  string      `yaml:"log_level" usage:"The desired log level. Logs with a level >= this level will be emitted. One of {'fatal', 'error', 'warn', 'info', 'debug'}"`
+	GRPCMaxRecvMsgSizeBytes   int         `yaml:"grpc_max_recv_msg_size_bytes" usage:"Configures the max GRPC receive message size [bytes]"`
+	GRPCOverHTTPPortEnabled   bool        `yaml:"grpc_over_http_port_enabled" usage:"Cloud-Only"`
+	AddUserToDomainGroup      bool        `yaml:"add_user_to_domain_group" usage:"Cloud-Only"`
+	DefaultToDenseMode        bool        `yaml:"default_to_dense_mode" usage:"Enables the dense UI mode by default."`
+	CreateGroupPerUser        bool        `yaml:"create_group_per_user" usage:"Cloud-Only"`
+	EnableTargetTracking      bool        `yaml:"enable_target_tracking" usage:"Cloud-Only"`
+	EnableStructuredLogging   bool        `yaml:"enable_structured_logging" usage:"If true, log messages will be json-formatted."`
+	LogIncludeShortFileName   bool        `yaml:"log_include_short_file_name" usage:"If true, log messages will include shortened originating file name."`
+	NoDefaultUserGroup        bool        `yaml:"no_default_user_group" usage:"Cloud-Only"`
+	LogEnableGCPLoggingFormat bool        `yaml:"log_enable_gcp_logging_format" usage:"If true, the output structured logs will be compatible with format expected by GCP Logging."`
+	LogErrorStackTraces       bool        `yaml:"log_error_stack_traces" usage:"If true, stack traces will be printed for errors that have them."`
+	TraceProjectID            string      `yaml:"trace_project_id" usage:"Optional GCP project ID to export traces to. If not specified, determined from default credentials or metadata server if running on GCP."`
+	TraceJaegerCollector      string      `yaml:"trace_jaeger_collector" usage:"Address of the Jager collector endpoint where traces will be sent."`
+	TraceServiceName          string      `yaml:"trace_service_name" usage:"Name of the service to associate with traces."`
+	TraceFraction             float64     `yaml:"trace_fraction" usage:"Fraction of requests to sample for tracing."`
+	TraceFractionOverrides    []string    `yaml:"trace_fraction_overrides" usage:"Tracing fraction override based on name in format name=fraction."`
+	IgnoreForcedTracingHeader bool        `yaml:"ignore_forced_tracing_header" usage:"If set, we will not honor the forced tracing header."`
+	CodeEditorEnabled         bool        `yaml:"code_editor_enabled" usage:"If set, code editor functionality will be enabled."`
+	UserManagementEnabled     bool        `yaml:"user_management_enabled" usage:"If set, the user management page will be enabled in the UI."`
+	GlobalFilterEnabled       bool        `yaml:"global_filter_enabled" usage:"If set, the global filter will be enabled in the UI."`
+	UsageEnabled              bool        `yaml:"usage_enabled" usage:"If set, the usage page will be enabled in the UI."`
+	UsageStartDate            string      `yaml:"usage_start_date" usage:"If set, usage data will only be viewable on or after this timestamp. Specified in RFC3339 format, like 2021-10-01T00:00:00Z"`
+	UsageTrackingEnabled      bool        `yaml:"usage_tracking_enabled" usage:"If set, enable usage data collection."`
+	DefaultRedisConfig        RedisConfig `yaml:"default_redis_target" usage:"A Redis target for storing remote shared state. To ease migration, the redis target from the remote execution config will be used if this value is not specified."`
 }
 
 type buildEventProxy struct {
@@ -175,9 +175,9 @@ type DistributedCacheConfig struct {
 	ClusterSize       int      `yaml:"cluster_size" usage:"The total number of nodes in this cluster. Required for health checking. ** Enterprise only **"`
 }
 
-type RedisCacheConfig struct {
-	RedisTarget       string `yaml:"redis_target" usage:"A redis target for improved Caching/RBE performance. Target can be provided as either a redis connection URI or a host:port pair. URI schemas supported: redis[s]://[[USER][:PASSWORD]@][HOST][:PORT][/DATABASE] or unix://[[USER][:PASSWORD]@]SOCKET_PATH[?db=DATABASE] ** Enterprise only **"`
-	MaxValueSizeBytes int64  `yaml:"max_value_size_bytes" usage:"The maximum value size to cache in redis (in bytes)."`
+type RedisConfig struct {
+	RedisTarget       string `yaml:"redis_target" usage:"A redis target to use for usage tracking, metrics collection, caching, or remote execution. Target can be provided as either a redis connection URI or a host:port pair. URI schemas supported: redis[s]://[[USER][:PASSWORD]@][HOST][:PORT][/DATABASE] or unix://[[USER][:PASSWORD]@]SOCKET_PATH[?db=DATABASE] ** Enterprise only **"`
+	MaxValueSizeBytes int64  `yaml:"max_value_size_bytes" usage:"The maximum value size to store in redis (in bytes)."`
 }
 
 type cacheConfig struct {
@@ -186,7 +186,7 @@ type cacheConfig struct {
 	S3               S3CacheConfig          `yaml:"s3"`
 	GCS              GCSCacheConfig         `yaml:"gcs"`
 	MemcacheTargets  []string               `yaml:"memcache_targets" usage:"Deprecated. Use Redis Target instead."`
-	Redis            RedisCacheConfig       `yaml:"redis"`
+	Redis            RedisConfig            `yaml:"redis"`
 	DistributedCache DistributedCacheConfig `yaml:"distributed_cache"`
 	MaxSizeBytes     int64                  `yaml:"max_size_bytes" usage:"How big to allow the cache to be (in bytes)."`
 	InMemory         bool                   `yaml:"in_memory" usage:"Whether or not to use the in_memory cache."`
@@ -597,12 +597,19 @@ func (c *Configurator) GetAppUsageTrackingEnabled() bool {
 }
 
 func (c *Configurator) GetDefaultRedisTarget() string {
-	if c.gc.App.DefaultRedisTarget != "" {
-		return c.gc.App.DefaultRedisTarget
+	if drc := c.GetDefaultRedisConfig(); drc != nil && drc.RedisTarget != "" {
+		return drc.RedisTarget
 	}
 	// Fall back to the remote execution redis target if default redis target is not specified.
 	// Historically we did not have a default redis target.
 	return c.GetRemoteExecutionRedisTarget()
+}
+
+func (c *Configurator) GetDefaultRedisConfig() *RedisConfig {
+	if c.gc.App.DefaultRedisConfig.RedisTarget != "" {
+		return &c.gc.App.DefaultRedisConfig
+	}
+	return nil
 }
 
 func (c *Configurator) GetGRPCMaxRecvMsgSizeBytes() int {
@@ -674,7 +681,7 @@ func (c *Configurator) GetCacheRedisTarget() string {
 	return c.gc.Cache.RedisTarget
 }
 
-func (c *Configurator) GetCacheRedisConfig() *RedisCacheConfig {
+func (c *Configurator) GetCacheRedisConfig() *RedisConfig {
 	if c.gc.Cache.Redis.RedisTarget != "" {
 		return &c.gc.Cache.Redis
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -61,6 +61,7 @@ type appConfig struct {
 	UsageEnabled              bool     `yaml:"usage_enabled" usage:"If set, the usage page will be enabled in the UI."`
 	UsageStartDate            string   `yaml:"usage_start_date" usage:"If set, usage data will only be viewable on or after this timestamp. Specified in RFC3339 format, like 2021-10-01T00:00:00Z"`
 	UsageTrackingEnabled      bool     `yaml:"usage_tracking_enabled" usage:"If set, enable usage data collection."`
+	DefaultRedisTarget        string   `yaml:"default_redis_target" usage:"A Redis target for storing remote cache state. To ease migration, the redis target from the remote execution config will be used if this value is not specified."`
 }
 
 type buildEventProxy struct {
@@ -229,7 +230,7 @@ type RemoteExecutionConfig struct {
 	WorkflowsDefaultImage         string `yaml:"workflows_default_image" usage:"The default docker image to use for running workflows."`
 	WorkflowsCIRunnerDebug        bool   `yaml:"workflows_ci_runner_debug" usage:"Whether to run the CI runner in debug mode."`
 	WorkflowsCIRunnerBazelCommand string `yaml:"workflows_ci_runner_bazel_command" usage:"Bazel command to be used by the CI runner."`
-	RedisTarget                   string `yaml:"redis_target" usage:"A Redis target for storing remote execution state. Required for remote execution. To ease migration, the redis target from the cache config will be used if this value is not specified."`
+	RedisTarget                   string `yaml:"redis_target" usage:"A Redis target for storing remote execution state. Falls back to app.default_redis_target if unspecified. Required for remote execution. To ease migration, the redis target from the cache config will be used if neither this value nor app.default_redis_target are specified."`
 	SharedExecutorPoolGroupID     string `yaml:"shared_executor_pool_group_id" usage:"Group ID that owns the shared executor pool."`
 	RedisPubSubPoolSize           int    `yaml:"redis_pubsub_pool_size" usage:"Maximum number of connections used for waiting for execution updates."`
 	EnableRemoteExec              bool   `yaml:"enable_remote_exec" usage:"If true, enable remote-exec. ** Enterprise only **"`
@@ -595,6 +596,15 @@ func (c *Configurator) GetAppUsageTrackingEnabled() bool {
 	return c.gc.App.UsageTrackingEnabled
 }
 
+func (c *Configurator) GetDefaultRedisTarget() string {
+	if c.gc.App.DefaultRedisTarget != "" {
+		return c.gc.App.DefaultRedisTarget
+	}
+	// Fall back to the remote execution redis target if default redis target is not specified.
+	// Historically we did not have a default redis target.
+	return c.GetRemoteExecutionRedisTarget()
+}
+
 func (c *Configurator) GetGRPCMaxRecvMsgSizeBytes() int {
 	n := c.gc.App.GRPCMaxRecvMsgSizeBytes
 	if n == 0 {
@@ -719,7 +729,13 @@ func (c *Configurator) GetRemoteExecutionRedisTarget() string {
 	if rec := c.GetRemoteExecutionConfig(); rec != nil && rec.RedisTarget != "" {
 		return rec.RedisTarget
 	}
-	// Fall back to the cache redis target if redis target is not specified in remote execution config.
+
+	// If no remote execution target is defined, use the default.
+	if c.gc.App.DefaultRedisTarget != "" {
+		return c.gc.App.DefaultRedisTarget
+	}
+
+	// Fall back to the cache redis target if redis target is not specified in remote execution config or app config.
 	// Historically we did not have a separate redis target for remote execution.
 	return c.GetCacheRedisTarget()
 }

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -64,6 +64,7 @@ type Env interface {
 	GetSchedulerService() interfaces.SchedulerService
 	GetTaskRouter() interfaces.TaskRouter
 	GetCacheRedisClient() *redis.Client
+	GetDefaultRedisClient() *redis.Client
 	GetRemoteExecutionRedisClient() *redis.Client
 	GetRemoteExecutionRedisPubSubClient() *redis.Client
 	GetMetricsCollector() interfaces.MetricsCollector

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -68,6 +68,7 @@ type RealEnv struct {
 	configurator                     *config.Configurator
 	executionClients                 map[string]*executionClientConfig
 	cacheRedisClient                 *redis.Client
+	defaultRedisClient               *redis.Client
 	remoteExecutionRedisClient       *redis.Client
 	dbHandle                         *db.DBHandle
 	remoteExecutionRedisPubSubClient *redis.Client
@@ -328,6 +329,14 @@ func (r *RealEnv) SetCacheRedisClient(redisClient *redis.Client) {
 
 func (r *RealEnv) GetCacheRedisClient() *redis.Client {
 	return r.cacheRedisClient
+}
+
+func (r *RealEnv) SetDefaultRedisClient(redisClient *redis.Client) {
+	r.defaultRedisClient = redisClient
+}
+
+func (r *RealEnv) GetDefaultRedisClient() *redis.Client {
+	return r.defaultRedisClient
 }
 
 func (r *RealEnv) SetRemoteExecutionRedisClient(redisClient *redis.Client) {


### PR DESCRIPTION
- Add default redis target and use it
- Use default redis target in local enterprise config

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->
Defines a new redis target `app.default_redis_target` to use for usage tracking, metrics collection,
and event log caching. Falls back to the remote execution redis target if unspecified for migration reasons.
Acts as a fallback for the remote execution target if it is unspecified for intentional design reasons.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
