### PR TITLE
Fix role applied when dropdown selection is unchanged from its initial value

### DIFF
--- a/enterprise/app/org/org_members.tsx
+++ b/enterprise/app/org/org_members.tsx
@@ -44,10 +44,13 @@ const ROLE_LABELS: Record<grp.Group.Role, string> = {
   [grp.Group.Role.DEVELOPER_ROLE]: "Developer",
 };
 
+const DEFAULT_ROLE = grp.Group.Role.DEVELOPER_ROLE;
+
 export default class OrgMembersComponent extends React.Component<OrgMembersProps, State> {
   state: State = {
     loading: true,
     selectedUserIds: new Set<string>(),
+    roleToApply: DEFAULT_ROLE,
   };
 
   componentDidMount() {
@@ -275,7 +278,7 @@ export default class OrgMembersComponent extends React.Component<OrgMembersProps
               <div className="role-description">
                 {/* TODO(bduffany): Get role metadata from the server so that we
                    don't have to keep these descriptions in sync. */}
-                {(this.state.roleToApply === grp.Group.Role.DEVELOPER_ROLE || this.state.roleToApply === undefined) && (
+                {this.state.roleToApply === grp.Group.Role.DEVELOPER_ROLE && (
                   <>
                     Developers can view invocations and stats, but do not have access to org settings, usage data, or
                     workflow configuration.


### PR DESCRIPTION
If the role dropdown was not changed from the default selection, then we were passing a role of `undefined` in the RPC, which is effectively a NOP.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
