### PR TITLE
Move role utils to their own package

### DIFF
--- a/enterprise/server/backends/userdb/BUILD
+++ b/enterprise/server/backends/userdb/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//server/util/perms",
         "//server/util/query_builder",
         "//server/util/random",
+        "//server/util/role",
         "//server/util/status",
         "//server/util/timeutil",
     ],

--- a/server/tables/BUILD
+++ b/server/tables/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//proto:user_id_go_proto",
         "//server/util/log",
         "//server/util/random",
+        "//server/util/role",
         "//server/util/timeutil",
         "@io_gorm_gorm//:gorm",
     ],

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
+	"github.com/buildbuddy-io/buildbuddy/server/util/role"
 	"github.com/buildbuddy-io/buildbuddy/server/util/timeutil"
 	"gorm.io/gorm"
 
@@ -507,10 +508,7 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 	// Initialize UserGroups.role to Admin if the role column doesn't exist.
 	if m.HasTable("UserGroups") && !m.HasColumn(&UserGroup{}, "role") {
 		postMigrate = append(postMigrate, func() error {
-			// Hard-coding the perms constant here to avoid circular dep on
-			// perms => interfaces => tables.
-			const adminRole = 1 << 1
-			return db.Exec("UPDATE UserGroups SET role = ?", adminRole).Error
+			return db.Exec("UPDATE UserGroups SET role = ?", uint32(role.Admin)).Error
 		})
 	}
 

--- a/server/util/perms/BUILD
+++ b/server/util/perms/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//proto:acl_go_proto",
         "//proto:context_go_proto",
-        "//proto:group_go_proto",
         "//proto:user_id_go_proto",
         "//server/environment",
         "//server/interfaces",

--- a/server/util/perms/perms.go
+++ b/server/util/perms/perms.go
@@ -13,7 +13,6 @@ import (
 
 	aclpb "github.com/buildbuddy-io/buildbuddy/proto/acl"
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
-	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
 	uidpb "github.com/buildbuddy-io/buildbuddy/proto/user_id"
 )
 
@@ -30,28 +29,6 @@ const (
 	OTHERS_EXEC  = 0o01
 	ALL          = 0o0777
 )
-
-// Constants for UserGroup.Role. These are powers of 2 so that we can allow
-// assigning multiple roles to users and use these as bitmasks to check
-// role membership.
-const (
-	// DeveloperRole means a user cannot perform certain privileged actions such
-	// as creating API keys and viewing usage data, but can perform most other
-	// common actions such as viewing invocation history.
-	DeveloperRole Role = 1 << 0
-	// AdminRole means a user has unrestricted access within a group.
-	AdminRole Role = 1 << 1
-
-	// DefaultRole is the role assigned to users when joining a group they did
-	// not create.
-	// TODO(bduffany): Change this to DeveloperRole once we have a way to manage
-	// roles via the UI (otherwise, there would be no easy way to promote new
-	// users to admins in the meantime).
-	DefaultRole = AdminRole
-)
-
-// Role represents a value stored in the UserGroup.Role field.
-type Role uint32
 
 type UserGroupPerm struct {
 	UserID  string
@@ -121,20 +98,6 @@ func FromACL(acl *aclpb.ACL) (int, error) {
 		p |= OTHERS_WRITE
 	}
 	return p, nil
-}
-
-func RoleToProto(role Role) grpb.Group_Role {
-	if role&AdminRole == AdminRole {
-		return grpb.Group_ADMIN_ROLE
-	}
-	return grpb.Group_DEVELOPER_ROLE
-}
-
-func RoleFromProto(role grpb.Group_Role) Role {
-	if role == grpb.Group_ADMIN_ROLE {
-		return AdminRole
-	}
-	return DeveloperRole
 }
 
 func AuthenticatedUser(ctx context.Context, env environment.Env) (interfaces.UserInfo, error) {

--- a/server/util/role/BUILD
+++ b/server/util/role/BUILD
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "role",
+    srcs = ["role.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/role",
+    visibility = ["//visibility:public"],
+    deps = ["//proto:group_go_proto"],
+)

--- a/server/util/role/role.go
+++ b/server/util/role/role.go
@@ -1,0 +1,41 @@
+package role
+
+import (
+	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
+)
+
+// Constants for UserGroup.Role. These are powers of 2 so that we can allow
+// assigning multiple roles to users and use these as bitmasks to check
+// role membership.
+const (
+	// Developer means a user cannot perform certain privileged actions such
+	// as creating API keys and viewing usage data, but can perform most other
+	// common actions such as viewing invocation history.
+	Developer Role = 1 << 0
+	// Admin means a user has unrestricted access within a group.
+	Admin Role = 1 << 1
+
+	// DefaultRole is the role assigned to users when joining a group they did
+	// not create.
+	// TODO(bduffany): Change this to DeveloperRole once we have a way to manage
+	// roles via the UI (otherwise, there would be no easy way to promote new
+	// users to admins in the meantime).
+	Default = Admin
+)
+
+// Role represents a user's role within a group.
+type Role uint32
+
+func ToProto(role Role) grpb.Group_Role {
+	if role&Admin == Admin {
+		return grpb.Group_ADMIN_ROLE
+	}
+	return grpb.Group_DEVELOPER_ROLE
+}
+
+func FromProto(role grpb.Group_Role) Role {
+	if role == grpb.Group_ADMIN_ROLE {
+		return Admin
+	}
+	return Developer
+}


### PR DESCRIPTION
Breaks a circular dep when referencing roles from certain files (which itself is caused by the dep on `perms => interfaces`).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
