### PR TITLE
Clean up `Groups.api_key` column

### DIFF
--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -57,9 +57,10 @@ func singleUserGroup(u *tables.User) (*tables.Group, error) {
 	}
 
 	return &tables.Group{
-		GroupID: strings.Replace(u.UserID, "US", "GR", 1),
-		UserID:  u.UserID,
-		Name:    name,
+		GroupID:    strings.Replace(u.UserID, "US", "GR", 1),
+		UserID:     u.UserID,
+		Name:       name,
+		WriteToken: randomToken(10),
 	}, nil
 }
 
@@ -318,6 +319,7 @@ func (d *UserDB) InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (stri
 			}
 			groupID = pk
 			newGroup.GroupID = pk
+			newGroup.WriteToken = randomToken(10)
 
 			if err := tx.Create(&newGroup).Error; err != nil {
 				return err
@@ -483,6 +485,9 @@ func (d *UserDB) CreateDefaultGroup(ctx context.Context) error {
 			if db.IsRecordNotFound(err) {
 				if c.apiKeyValue == "" {
 					c.apiKeyValue = newAPIKeyToken()
+				}
+				if c.group.WriteToken == "" {
+					c.group.WriteToken = randomToken(10)
 				}
 				if err := tx.Create(&c.group).Error; err != nil {
 					return err

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -57,10 +57,9 @@ func singleUserGroup(u *tables.User) (*tables.Group, error) {
 	}
 
 	return &tables.Group{
-		GroupID:    strings.Replace(u.UserID, "US", "GR", 1),
-		UserID:     u.UserID,
-		Name:       name,
-		WriteToken: randomToken(10),
+		GroupID: strings.Replace(u.UserID, "US", "GR", 1),
+		UserID:  u.UserID,
+		Name:    name,
 	}, nil
 }
 
@@ -319,7 +318,6 @@ func (d *UserDB) InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (stri
 			}
 			groupID = pk
 			newGroup.GroupID = pk
-			newGroup.WriteToken = randomToken(10)
 
 			if err := tx.Create(&newGroup).Error; err != nil {
 				return err
@@ -485,9 +483,6 @@ func (d *UserDB) CreateDefaultGroup(ctx context.Context) error {
 			if db.IsRecordNotFound(err) {
 				if c.apiKeyValue == "" {
 					c.apiKeyValue = newAPIKeyToken()
-				}
-				if c.group.WriteToken == "" {
-					c.group.WriteToken = randomToken(10)
 				}
 				if err := tx.Create(&c.group).Error; err != nil {
 					return err

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -161,6 +161,10 @@ type Group struct {
 	// email belonging to that domain may be added to this group.
 	OwnedDomain string `gorm:"index:owned_domain_index"`
 
+	// The group access token. This token allows writing data for this
+	// group.
+	WriteToken string `gorm:"index:write_token_index"`
+
 	// The group's Github API token.
 	GithubToken string
 	Model
@@ -596,8 +600,6 @@ func PostAutoMigrate(db *gorm.DB) error {
 	}{
 		// Group.api_key has been migrated to a single row in the APIKeys table.
 		{&Group{}, "api_key"},
-		// Group.write_token has been superseded by API keys.
-		{&Group{}, "write_token"},
 	} {
 		if !m.HasColumn(ref.table, ref.column) {
 			continue

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -161,14 +161,6 @@ type Group struct {
 	// email belonging to that domain may be added to this group.
 	OwnedDomain string `gorm:"index:owned_domain_index"`
 
-	// The group access token. This token allows writing data for this
-	// group.
-	WriteToken string `gorm:"index:write_token_index"`
-
-	// The group's api key. This allows members of the group to make
-	// API requests on the group's behalf.
-	APIKey string `gorm:"index:api_key_index"`
-
 	// The group's Github API token.
 	GithubToken string
 	Model
@@ -531,7 +523,7 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 	}
 
 	// Migrate Groups.APIKey to APIKey rows.
-	if m.HasTable("Groups") && !m.HasTable("APIKeys") {
+	if m.HasTable("Groups") && m.HasColumn(&Group{}, "api_key") && !m.HasTable("APIKeys") {
 		postMigrate = append(postMigrate, func() error {
 			rows, err := db.Raw(`SELECT group_id, api_key FROM ` + "`Groups`" + ``).Rows()
 			if err != nil {
@@ -540,6 +532,7 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 			defer rows.Close()
 
 			var g Group
+			var apiKey string
 
 			// These constants are already defined in perms.go, but we can't reference that
 			// due to a circular dep (tables -> perms -> interfaces -> tables).
@@ -550,7 +543,7 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 			apiKeyPerms := groupRead | groupWrite
 
 			for rows.Next() {
-				if err := rows.Scan(&g.GroupID, &g.APIKey); err != nil {
+				if err := rows.Scan(&g.GroupID, &apiKey); err != nil {
 					return err
 				}
 				pk, err := PrimaryKeyForTable("APIKeys")
@@ -560,14 +553,13 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 
 				if err := db.Exec(
 					`INSERT INTO APIKeys (api_key_id, group_id, perms, value, label) VALUES (?, ?, ?, ?, ?)`,
-					pk, g.GroupID, apiKeyPerms, g.APIKey, "Default API key").Error; err != nil {
+					pk, g.GroupID, apiKeyPerms, apiKey, "Default API key").Error; err != nil {
 					return err
 				}
 			}
 			return nil
 		})
 	}
-
 	return postMigrate, nil
 }
 
@@ -594,6 +586,24 @@ func PostAutoMigrate(db *gorm.DB) error {
 			if err != nil {
 				log.Errorf("Error creating %s: %s", indexName, err)
 			}
+		}
+	}
+
+	// Drop old columns at the very end of the migration.
+	for _, ref := range []struct {
+		table  Table
+		column string
+	}{
+		// Group.api_key has been migrated to a single row in the APIKeys table.
+		{&Group{}, "api_key"},
+		// Group.write_token has been superseded by API keys.
+		{&Group{}, "write_token"},
+	} {
+		if !m.HasColumn(ref.table, ref.column) {
+			continue
+		}
+		if err := m.DropColumn(ref.table, ref.column); err != nil {
+			log.Warningf("Failed to drop column %s.%s", ref.table.TableName(), ref.column)
 		}
 	}
 	return nil


### PR DESCRIPTION
This has been replaced with the API keys table.

GORM doesn't delete old columns for us, so I added a migration to explicitly remove the column. I am OK with removing this though if we don't think it's worth the added migration code and/or the risk of losing data permanently due to incorrect migration logic. (I figure since this column hasn't been in use for such a long time, the risk is minimal)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
