### PR TITLE
Support usage tracking across regions

### DIFF
--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -214,11 +214,12 @@ func main() {
 		if realEnv.GetDefaultRedisClient() == nil {
 			log.Fatalf("Usage tracking is enabled, but no Redis client is configured.")
 		}
-		opts := &usage.TrackerOpts{Region: realEnv.GetConfigurator().GetAppRegion()}
-		ut := usage.NewTracker(realEnv, timeutil.NewClock(), usage.NewFlushLock(realEnv), opts)
-		if err != nil {
-			log.Fatalf("Failed to create usage tracker: %s", err)
+		region := realEnv.GetConfigurator().GetAppRegion()
+		if region == "" {
+			log.Fatalf("Usage tracking requires app.region to be configured.")
 		}
+		opts := &usage.TrackerOpts{Region: region}
+		ut := usage.NewTracker(realEnv, timeutil.NewClock(), usage.NewFlushLock(realEnv), opts)
 		realEnv.SetUsageTracker(ut)
 
 		ut.StartDBFlush()

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -214,7 +214,8 @@ func main() {
 		if realEnv.GetDefaultRedisClient() == nil {
 			log.Fatalf("Usage tracking is enabled, but no Redis client is configured.")
 		}
-		ut := usage.NewTracker(realEnv, timeutil.NewClock(), usage.NewFlushLock(realEnv))
+		opts := &usage.TrackerOpts{Region: realEnv.GetConfigurator().GetAppRegion()}
+		ut := usage.NewTracker(realEnv, timeutil.NewClock(), usage.NewFlushLock(realEnv), opts)
 		if err != nil {
 			log.Fatalf("Failed to create usage tracker: %s", err)
 		}

--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -30,6 +30,7 @@ go_test(
         "//server/testutil/testauth",
         "//server/testutil/testclock",
         "//server/testutil/testenv",
+        "//server/util/testing/flags",
         "//server/util/timeutil",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_stretchr_testify//assert",

--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -30,7 +30,6 @@ go_test(
         "//server/testutil/testauth",
         "//server/testutil/testclock",
         "//server/testutil/testenv",
-        "//server/util/testing/flags",
         "//server/util/timeutil",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_stretchr_testify//assert",

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -83,19 +83,31 @@ func NewFlushLock(env environment.Env) interfaces.DistributedLock {
 	return redisutil.NewWeakLock(env.GetDefaultRedisClient(), redisUsageLockKey, redisUsageLockExpiry)
 }
 
+type TrackerOpts struct {
+	// Region identifies the datacenter in which the Redis deployment is running.
+	// Usage is tracked separately per Redis deployment.
+	Region string
+}
+
 type tracker struct {
-	env   environment.Env
-	rdb   *redis.Client
-	clock timeutil.Clock
+	env    environment.Env
+	rdb    *redis.Client
+	clock  timeutil.Clock
+	region string
 
 	flushLock interfaces.DistributedLock
 	stopFlush chan struct{}
 }
 
-func NewTracker(env environment.Env, clock timeutil.Clock, flushLock interfaces.DistributedLock) *tracker {
+func NewTracker(env environment.Env, clock timeutil.Clock, flushLock interfaces.DistributedLock, opts *TrackerOpts) *tracker {
+	region := opts.Region
+	if region == "" {
+		log.Warningf("Region is not configured; usage may not be tracked properly in multi-region deployments.")
+	}
 	return &tracker{
 		env:       env,
 		rdb:       env.GetDefaultRedisClient(),
+		region:    region,
 		clock:     clock,
 		flushLock: flushLock,
 		stopFlush: make(chan struct{}),
@@ -237,6 +249,7 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, c collection
 	pk := &tables.Usage{
 		GroupID:         groupID,
 		PeriodStartUsec: timeutil.ToUsec(c.UsagePeriod().Start()),
+		Region:          ut.region,
 	}
 	dbh := ut.env.GetDBHandle()
 	return dbh.Transaction(ctx, func(tx *db.DB) error {
@@ -246,15 +259,17 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, c collection
 			INSERT `+dbh.InsertIgnoreModifier()+` INTO Usages (
 				group_id,
 				period_start_usec,
+				region,
 				final_before_usec,
 				invocations,
 				cas_cache_hits,
 				action_cache_hits,
 				total_download_size_bytes
-			) VALUES (?, ?, ?, ?, ?, ?, ?)
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 			`,
 			pk.GroupID,
 			pk.PeriodStartUsec,
+			pk.Region,
 			timeutil.ToUsec(c.End()),
 			counts.Invocations,
 			counts.CASCacheHits,
@@ -282,6 +297,7 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, c collection
 			WHERE
 				group_id = ?
 				AND period_start_usec = ?
+				AND region = ?
 				AND final_before_usec <= ?
 		`,
 			timeutil.ToUsec(c.End()),
@@ -291,6 +307,7 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, c collection
 			counts.TotalDownloadSizeBytes,
 			pk.GroupID,
 			pk.PeriodStartUsec,
+			pk.Region,
 			timeutil.ToUsec(c.Start()),
 		).Error
 	})

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -100,14 +100,10 @@ type tracker struct {
 }
 
 func NewTracker(env environment.Env, clock timeutil.Clock, flushLock interfaces.DistributedLock, opts *TrackerOpts) *tracker {
-	region := opts.Region
-	if region == "" {
-		log.Warningf("Region is not configured; usage may not be tracked properly in multi-region deployments.")
-	}
 	return &tracker{
 		env:       env,
 		rdb:       env.GetDefaultRedisClient(),
-		region:    region,
+		region:    opts.Region,
 		clock:     clock,
 		flushLock: flushLock,
 		stopFlush: make(chan struct{}),

--- a/enterprise/server/usage/usage_test.go
+++ b/enterprise/server/usage/usage_test.go
@@ -62,7 +62,7 @@ func queryAllUsages(t *testing.T, te *testenv.TestEnv) []*tables.Usage {
 	dbh := te.GetDBHandle()
 	rows, err := dbh.Raw(`
 		SELECT * From Usages
-		ORDER BY group_id, period_start_usec ASC;
+		ORDER BY group_id, period_start_usec, region ASC;
 	`).Rows()
 	require.NoError(t, err)
 
@@ -101,7 +101,7 @@ func TestUsageTracker_Increment_MultipleCollectionPeriodsInSameUsagePeriod(t *te
 	clock := testclock.StartingAt(usage1Collection1Start)
 	te := setupEnv(t)
 	ctx := authContext(te, "US1")
-	ut := usage.NewTracker(te, clock, usage.NewFlushLock(te))
+	ut := usage.NewTracker(te, clock, usage.NewFlushLock(te), &usage.TrackerOpts{Region: "us-west1"})
 
 	// Increment some counts
 	ut.Increment(ctx, &tables.UsageCounts{CASCacheHits: 1})
@@ -162,6 +162,7 @@ func TestUsageTracker_Increment_MultipleCollectionPeriodsInSameUsagePeriod(t *te
 		{
 			PeriodStartUsec: timeutil.ToUsec(usage1Start),
 			GroupID:         "GR1",
+			Region:          "us-west1",
 			// We wrote 2 collection periods, so data should be final up to the 3rd
 			// collection period.
 			FinalBeforeUsec: timeutil.ToUsec(usage1Collection3Start),
@@ -179,7 +180,7 @@ func TestUsageTracker_Increment_MultipleGroupsInSameCollectionPeriod(t *testing.
 	te := setupEnv(t)
 	ctx1 := authContext(te, "US1")
 	ctx2 := authContext(te, "US2")
-	ut := usage.NewTracker(te, clock, usage.NewFlushLock(te))
+	ut := usage.NewTracker(te, clock, usage.NewFlushLock(te), &usage.TrackerOpts{Region: "us-west1"})
 
 	// Increment for group 1, then group 2
 	ut.Increment(ctx1, &tables.UsageCounts{CASCacheHits: 1})
@@ -225,6 +226,7 @@ func TestUsageTracker_Increment_MultipleGroupsInSameCollectionPeriod(t *testing.
 		{
 			PeriodStartUsec: timeutil.ToUsec(usage1Start),
 			GroupID:         "GR1",
+			Region:          "us-west1",
 			FinalBeforeUsec: timeutil.ToUsec(usage1Collection2Start),
 			UsageCounts: tables.UsageCounts{
 				CASCacheHits: 1,
@@ -233,6 +235,7 @@ func TestUsageTracker_Increment_MultipleGroupsInSameCollectionPeriod(t *testing.
 		{
 			PeriodStartUsec: timeutil.ToUsec(usage1Start),
 			GroupID:         "GR2",
+			Region:          "us-west1",
 			FinalBeforeUsec: timeutil.ToUsec(usage1Collection2Start),
 			UsageCounts: tables.UsageCounts{
 				CASCacheHits: 10,
@@ -245,7 +248,7 @@ func TestUsageTracker_Flush_DoesNotFlushUnsettledCollectionPeriods(t *testing.T)
 	clock := testclock.StartingAt(usage1Collection1Start)
 	te := setupEnv(t)
 	ctx := authContext(te, "US1")
-	ut := usage.NewTracker(te, clock, usage.NewFlushLock(te))
+	ut := usage.NewTracker(te, clock, usage.NewFlushLock(te), &usage.TrackerOpts{Region: "us-west1"})
 
 	err := ut.Increment(ctx, &tables.UsageCounts{CASCacheHits: 1})
 	require.NoError(t, err)
@@ -269,6 +272,7 @@ func TestUsageTracker_Flush_DoesNotFlushUnsettledCollectionPeriods(t *testing.T)
 	require.Equal(t, []*tables.Usage{
 		{
 			GroupID:         "GR1",
+			Region:          "us-west1",
 			PeriodStartUsec: timeutil.ToUsec(usage1Start),
 			FinalBeforeUsec: timeutil.ToUsec(usage1Collection2Start),
 			UsageCounts: tables.UsageCounts{
@@ -282,7 +286,7 @@ func TestUsageTracker_Flush_OnlyWritesToDBIfNecessary(t *testing.T) {
 	clock := testclock.StartingAt(usage1Collection1Start)
 	te := setupEnv(t)
 	ctx := authContext(te, "US1")
-	ut := usage.NewTracker(te, clock, usage.NewFlushLock(te))
+	ut := usage.NewTracker(te, clock, usage.NewFlushLock(te), &usage.TrackerOpts{Region: "us-west1"})
 
 	err := ut.Increment(ctx, &tables.UsageCounts{CASCacheHits: 1})
 	require.NoError(t, err)
@@ -307,7 +311,7 @@ func TestUsageTracker_Flush_ConcurrentAccessAcrossApps(t *testing.T) {
 	te := setupEnv(t)
 	ctx := authContext(te, "US1")
 
-	ut := usage.NewTracker(te, clock, usage.NewFlushLock(te))
+	ut := usage.NewTracker(te, clock, usage.NewFlushLock(te), &usage.TrackerOpts{Region: "us-west1"})
 
 	// Write 2 collection periods worth of data.
 	err := ut.Increment(ctx, &tables.UsageCounts{CASCacheHits: 1})
@@ -326,6 +330,7 @@ func TestUsageTracker_Flush_ConcurrentAccessAcrossApps(t *testing.T) {
 				// synchronized on their own. Redis is purely used as an optimization to
 				// reduce DB load, and we should not overcount data if Redis fails.
 				&nopDistributedLock{},
+				&usage.TrackerOpts{Region: "us-west1"},
 			)
 			require.NoError(t, err)
 			return ut.FlushToDB(ctx)
@@ -339,9 +344,52 @@ func TestUsageTracker_Flush_ConcurrentAccessAcrossApps(t *testing.T) {
 	require.Equal(t, []*tables.Usage{
 		{
 			GroupID:         "GR1",
+			Region:          "us-west1",
 			PeriodStartUsec: timeutil.ToUsec(usage1Start),
 			FinalBeforeUsec: timeutil.ToUsec(usage1Collection3Start),
 			UsageCounts:     tables.UsageCounts{CASCacheHits: 1001},
+		},
+	}, usages)
+}
+
+func TestUsageTracker_Flush_CrossRegion(t *testing.T) {
+	// Set up 2 envs, one for each region. DB should be the same for each, but
+	// Redis instances should be different.
+	te1 := setupEnv(t)
+	te2 := setupEnv(t)
+	te2.SetDBHandle(te1.GetDBHandle())
+	ctx1 := authContext(te1, "US1")
+	ctx2 := authContext(te2, "US1")
+	clock := testclock.StartingAt(usage1Collection1Start)
+	ut1 := usage.NewTracker(te1, clock, usage.NewFlushLock(te1), &usage.TrackerOpts{Region: "us-west1"})
+	ut2 := usage.NewTracker(te2, clock, usage.NewFlushLock(te2), &usage.TrackerOpts{Region: "europe-north1"})
+
+	// Record and flush usage in 2 different regions.
+	err := ut1.Increment(ctx1, &tables.UsageCounts{CASCacheHits: 1})
+	require.NoError(t, err)
+	err = ut2.Increment(ctx2, &tables.UsageCounts{CASCacheHits: 100})
+	clock.Set(clock.Now().Add(2 * collectionPeriodDuration))
+	err = ut1.FlushToDB(context.Background())
+	require.NoError(t, err)
+	err = ut2.FlushToDB(context.Background())
+	require.NoError(t, err)
+
+	// Make sure the usage was tracked in each region separately.
+	usages := queryAllUsages(t, te1)
+	require.Equal(t, []*tables.Usage{
+		{
+			GroupID:         "GR1",
+			Region:          "europe-north1",
+			PeriodStartUsec: timeutil.ToUsec(usage1Start),
+			FinalBeforeUsec: timeutil.ToUsec(usage1Collection2Start),
+			UsageCounts:     tables.UsageCounts{CASCacheHits: 100},
+		},
+		{
+			GroupID:         "GR1",
+			Region:          "us-west1",
+			PeriodStartUsec: timeutil.ToUsec(usage1Start),
+			FinalBeforeUsec: timeutil.ToUsec(usage1Collection2Start),
+			UsageCounts:     tables.UsageCounts{CASCacheHits: 1},
 		},
 	}, usages)
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -62,6 +62,7 @@ type appConfig struct {
 	UsageStartDate            string   `yaml:"usage_start_date" usage:"If set, usage data will only be viewable on or after this timestamp. Specified in RFC3339 format, like 2021-10-01T00:00:00Z"`
 	UsageTrackingEnabled      bool     `yaml:"usage_tracking_enabled" usage:"If set, enable usage data collection."`
 	DefaultRedisTarget        string   `yaml:"default_redis_target" usage:"A Redis target for storing remote shared state. To ease migration, the redis target from the remote execution config will be used if this value is not specified."`
+	Region                    string   `yaml:"region" usage:"The region in which the app is running."`
 }
 
 type buildEventProxy struct {
@@ -607,6 +608,10 @@ func (c *Configurator) GetAppUsageStartDate() string {
 
 func (c *Configurator) GetAppUsageTrackingEnabled() bool {
 	return c.gc.App.UsageTrackingEnabled
+}
+
+func (c *Configurator) GetAppRegion() string {
+	return c.gc.App.Region
 }
 
 func (c *Configurator) GetDefaultRedisTarget() string {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -451,13 +451,13 @@ type UsageCounts struct {
 type Usage struct {
 	Model
 
-	GroupID string `gorm:"uniqueIndex:group_id_period_start_usec_index,priority:1"`
+	GroupID string `gorm:"uniqueIndex:group_period_region_index,priority:1"`
 
 	// PeriodStartUsec is the time at which the usage period started, in
 	// microseconds since the Unix epoch. The usage period duration is 1 hour.
 	// Only usage data occurring in collection periods inside this 1 hour period
 	// is included in this usage row.
-	PeriodStartUsec int64 `gorm:"uniqueIndex:group_id_period_start_usec_index,priority:2"`
+	PeriodStartUsec int64 `gorm:"uniqueIndex:group_period_region_index,priority:2"`
 
 	// FinalBeforeUsec is the time before which all collection period data in this
 	// usage period is finalized. This is used to guarantee that collection period
@@ -479,6 +479,12 @@ type Usage struct {
 	//                     ^ FinalBefore (before update) = CollectionPeriodStart
 	//                            ^ FinalBefore (after update) = CollectionPeriodEnd
 	FinalBeforeUsec int64
+
+	// Region is the region in which the usage data was originally gathered.
+	// Since we have a global DB deployment but usage data is collected
+	// per-region, this effectively partitions the usage table by region, allowing
+	// the FinalBeforeUsec logic to work independently in each region.
+	Region string `gorm:"uniqueIndex:group_period_region_index,priority:3"`
 
 	UsageCounts
 }


### PR DESCRIPTION
Adding `region` to the composite key for the usage table, so that flushes from Redis -> DB in each region only finalize the current collection period + group's data for the current region, rather than all regions.

As a bonus, this will make it easy to allow users to segment usage by region in the UI (if that's something they're interested in).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
