### PR TITLE
Add a primitive buffer for Redis counter values

### DIFF
--- a/enterprise/server/util/redisutil/BUILD
+++ b/enterprise/server/util/redisutil/BUILD
@@ -28,7 +28,6 @@ go_test(
     deps = [
         ":redisutil",
         "//enterprise/server/testutil/testredis",
-        "//server/target",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",

--- a/enterprise/server/util/redisutil/BUILD
+++ b/enterprise/server/util/redisutil/BUILD
@@ -27,8 +27,12 @@ go_test(
     ],
     deps = [
         ":redisutil",
+        "//enterprise/server/testutil/testredis",
+        "//server/target",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/util/redisutil/redisutil.go
+++ b/enterprise/server/util/redisutil/redisutil.go
@@ -100,8 +100,18 @@ func (r *redlock) Unlock(ctx context.Context) error {
 
 // CommandBuffer buffers and aggregates Redis commands in-memory and allows
 // flushing the aggregate results in batch. This is useful for reducing the load
-// placed on Redis, with the tradeoff that data is not updated immediately and
-// needs to be explicitly flushed.
+// placed on Redis in cases where several commands are performed on the same key
+// at a high rate.
+//
+// When using this buffer, the caller is responsible for explicitly flushing
+// the data. In most cases, flushing should be done at regular intervals, as well
+// as after writing the last command to the buffer, if applicable.
+//
+// There may be a non-negligible delay between the time that the data is written
+// to the buffer and the time that data is flushed, so callers may need extra
+// synchronization in order to ensure that buffers are flushed (on all nodes,
+// if applicable), before relying on the values of any keys updated via this
+// buffer.
 //
 // It is safe for concurrent access.
 type CommandBuffer struct {

--- a/enterprise/server/util/redisutil/redisutil.go
+++ b/enterprise/server/util/redisutil/redisutil.go
@@ -100,8 +100,9 @@ func (r *redlock) Unlock(ctx context.Context) error {
 
 // CommandBuffer buffers and aggregates Redis commands in-memory and allows
 // flushing the aggregate results in batch. This is useful for reducing the load
-// placed on Redis in cases where several commands are performed on a small
-// subset of Redis keys at a very high rate.
+// placed on Redis in cases where a high volume of commands are operating on
+// a relatively small subset of Redis keys (for example, counter values that
+// are incremented several times over a short time period).
 //
 // When using this buffer, the caller is responsible for explicitly flushing
 // the data. In most cases, flushing should be done at regular intervals, as well

--- a/enterprise/server/util/redisutil/redisutil.go
+++ b/enterprise/server/util/redisutil/redisutil.go
@@ -132,22 +132,6 @@ func (c *CommandBuffer) init() {
 	c.expire = map[string]time.Duration{}
 }
 
-// SAdd adds an SADD operation to the buffer. All buffered members of the set
-// will be added in a single SADD command.
-func (c *CommandBuffer) SAdd(key string, members ...interface{}) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	s, ok := c.sadd[key]
-	if !ok {
-		s = map[interface{}]struct{}{}
-		c.sadd[key] = s
-	}
-	for _, m := range members {
-		s[m] = struct{}{}
-	}
-}
-
 // IncrBy adds an INCRBY operation to the buffer.
 func (c *CommandBuffer) IncrBy(key string, increment int64) {
 	c.mu.Lock()
@@ -167,6 +151,22 @@ func (c *CommandBuffer) HIncrBy(key, field string, increment int64) {
 		c.hincr[key] = h
 	}
 	h[field] += increment
+}
+
+// SAdd adds an SADD operation to the buffer. All buffered members of the set
+// will be added in a single SADD command.
+func (c *CommandBuffer) SAdd(key string, members ...interface{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	s, ok := c.sadd[key]
+	if !ok {
+		s = map[interface{}]struct{}{}
+		c.sadd[key] = s
+	}
+	for _, m := range members {
+		s[m] = struct{}{}
+	}
 }
 
 // Expire adds an EXPIRE operation to the buffer, overwriting any previous

--- a/enterprise/server/util/redisutil/redisutil.go
+++ b/enterprise/server/util/redisutil/redisutil.go
@@ -181,7 +181,9 @@ func (c *CommandBuffer) SAdd(key string, members ...interface{}) {
 }
 
 // Expire adds an EXPIRE operation to the buffer, overwriting any previous
-// expiry currently buffered for the given key.
+// expiry currently buffered for the given key. Note that the expiry duration
+// will apply only from the time that the buffer is flushed. This implies that
+// the expiration does not affect any buffered keys.
 func (c *CommandBuffer) Expire(key string, duration time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/enterprise/server/util/redisutil/redisutil.go
+++ b/enterprise/server/util/redisutil/redisutil.go
@@ -98,11 +98,10 @@ func (r *redlock) Unlock(ctx context.Context) error {
 	return err
 }
 
-// CommandBuffer buffers and aggregates Redis commands in-memory. The buffer
-// This is useful for reducing the load placed on Redis, with a tradeoff that
-// data is not updated immediately and needs to be explicitly flushed.
-//
-// Callers should be careful
+// CommandBuffer buffers and aggregates Redis commands in-memory and allows
+// flushing the aggregate results in batch. This is useful for reducing the load
+// placed on Redis, with the tradeoff that data is not updated immediately and
+// needs to be explicitly flushed.
 //
 // It is safe for concurrent access.
 type CommandBuffer struct {

--- a/enterprise/server/util/redisutil/redisutil.go
+++ b/enterprise/server/util/redisutil/redisutil.go
@@ -100,8 +100,8 @@ func (r *redlock) Unlock(ctx context.Context) error {
 
 // CommandBuffer buffers and aggregates Redis commands in-memory and allows
 // flushing the aggregate results in batch. This is useful for reducing the load
-// placed on Redis in cases where several commands are performed on the same key
-// at a high rate.
+// placed on Redis in cases where several commands are performed on a small
+// subset of Redis keys at a very high rate.
 //
 // When using this buffer, the caller is responsible for explicitly flushing
 // the data. In most cases, flushing should be done at regular intervals, as well


### PR DESCRIPTION
This will be used to help reduce load on Redis; counter values will be collected via this buffer and periodically flushed to Redis at regular intervals.

This util on its own does not actually flush the values to Redis; the caller will be responsible for that.

The plan to integrate this with the app looks like this:
* Create one of these buffers and set them on the env
* In `main`, call `Flush` every 1s or so (will experiment in dev using some artificial invocations that generate a lot of INCRBY commands to see what a good value is for this)
* Update `RedisMetricsCollector` and `UsageTracker` to go through this buffer instead of writing directly to Redis
* In the build event handler, wait a few seconds at the end of the invocation (in the background) before writing invocation stats to the table, to give enough time for all buffers to be flushed. This means we'll need another write to the invocation table
  * This is not perfect, but probably better than what we have now (only writing 1/16 of the cache stats)
  * In the future we might want to consider some fancier synchronization protocol to avoid this delay and extra DB write

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
