### PR TITLE
Redirect to main login page (with SSO) instead of using interstitial invocation login page

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -130,16 +130,17 @@ export class AuthService {
   }
 
   login(slug?: string) {
+    const search = new URLSearchParams(window.location.search);
     if (slug) {
       window.location.href = `/login/?${new URLSearchParams({
-        redirect_url: window.location.href,
+        redirect_url: search.get("redirect_url") || window.location.href,
         slug,
       })}`;
       return;
     }
 
     window.location.href = `/login/?${new URLSearchParams({
-      redirect_url: window.location.href,
+      redirect_url: search.get("redirect_url") || window.location.href,
       issuer_url: capabilities.auth,
     })}`;
   }

--- a/app/invocation/invocation_not_found.tsx
+++ b/app/invocation/invocation_not_found.tsx
@@ -21,19 +21,7 @@ export default class InvocationNotFoundComponent extends React.Component {
     const canLogin = capabilities.auth && !this.props.user;
 
     if (invocationExists && canLogin) {
-      return (
-        <div className="login-interstitial">
-          <div className="container">
-            <div className="login-box">
-              <div className="login-buttons">
-                <h2>Sign in to continue</h2>
-                <button onClick={this.handleLoginClicked.bind(this)}>Sign up for BuildBuddy</button>
-                <button onClick={this.handleLoginClicked.bind(this)}>Log in to BuildBuddy</button>
-              </div>
-            </div>
-          </div>
-        </div>
-      );
+      window.location.href = "/?" + new URLSearchParams({redirect_url: window.location.href});
     }
 
     return (

--- a/enterprise/app/login/login.tsx
+++ b/enterprise/app/login/login.tsx
@@ -14,7 +14,13 @@ interface State {
   defaultToSSO: boolean;
 }
 
-export default class LoginComponent extends React.Component<{}, State> {
+interface Props {
+  search: URLSearchParams;
+}
+
+export default class LoginComponent extends React.Component<Props, State> {
+  props: Props;
+
   state: State = {
     showSSO: false,
     defaultToSSO: false,
@@ -98,20 +104,22 @@ export default class LoginComponent extends React.Component<{}, State> {
       );
     }
 
+    let redirecting = this.props.search.has("redirect_url");
     return (
       <div className="login">
         <div className="container">
           <div className="login-box">
             <div className={`login-hero ${!this.isJoiningOrg() ? "hide-on-mobile" : ""}`}>
               <div className="login-hero-title">
-                {!this.isJoiningOrg() && (
+                {!redirecting && !this.isJoiningOrg() && (
                   <>
                     Faster Builds.
                     <br />
                     Happier Developers.
                   </>
                 )}
-                {this.isJoiningOrg() && this.state.orgName && <>Join {this.state.orgName} on BuildBuddy</>}
+                {!redirecting && this.isJoiningOrg() && this.state.orgName && <>Join {this.state.orgName} on BuildBuddy</>}
+                {redirecting && <>Login to continue</>}
               </div>
               <div className="hide-on-mobile">
                 BuildBuddy provides enterprise features for Bazel — the open source build system that allows you to

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -278,7 +278,7 @@ export default class EnterpriseRootComponent extends React.Component {
                     </SetupComponent>
                   </Suspense>
                 )}
-                {login && <LoginComponent />}
+                {login && <LoginComponent search={this.state.search} />}
               </div>
             )}
             {!this.state.loading && !code && <FooterComponent />}


### PR DESCRIPTION
The interstitial page doesn't support SSO, and keeping the two login pages in sync is probably not worth the hassle.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
