### PR TITLE
Remove readback from `MetricsCollector.IncrementCount` API

### DIFF
--- a/server/backends/memory_metrics_collector/memory_metrics_collector.go
+++ b/server/backends/memory_metrics_collector/memory_metrics_collector.go
@@ -28,7 +28,7 @@ func NewMemoryMetricsCollector() (*MemoryMetricsCollector, error) {
 	}, nil
 }
 
-func (m *MemoryMetricsCollector) IncrementCount(ctx context.Context, counterName string, n int64) (int64, error) {
+func (m *MemoryMetricsCollector) IncrementCount(ctx context.Context, counterName string, n int64) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -36,12 +36,12 @@ func (m *MemoryMetricsCollector) IncrementCount(ctx context.Context, counterName
 		if existingVal, ok := existingValIface.(int64); ok {
 			newVal := existingVal + n
 			m.l.Add(counterName, newVal)
-			return newVal, nil
+			return nil
 		}
 	}
 
 	m.l.Add(counterName, n)
-	return n, nil
+	return nil
 
 }
 

--- a/server/backends/redis_metrics_collector/redis_metrics_collector.go
+++ b/server/backends/redis_metrics_collector/redis_metrics_collector.go
@@ -15,7 +15,8 @@ func New(rdb *redis.Client) *collector {
 }
 
 func (c *collector) IncrementCount(ctx context.Context, counterName string, n int64) error {
-	return c.rdb.IncrBy(ctx, counterName, n).Result()
+	_, err := c.rdb.IncrBy(ctx, counterName, n).Result()
+	return err
 }
 
 func (c *collector) ReadCount(ctx context.Context, counterName string) (int64, error) {

--- a/server/backends/redis_metrics_collector/redis_metrics_collector.go
+++ b/server/backends/redis_metrics_collector/redis_metrics_collector.go
@@ -14,7 +14,7 @@ func New(rdb *redis.Client) *collector {
 	return &collector{rdb}
 }
 
-func (c *collector) IncrementCount(ctx context.Context, counterName string, n int64) (int64, error) {
+func (c *collector) IncrementCount(ctx context.Context, counterName string, n int64) error {
 	return c.rdb.IncrBy(ctx, counterName, n).Result()
 }
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -452,7 +452,7 @@ type PubSub interface {
 // evicted from the backing store that maintains them (usually memcache or
 // redis), so they should *not* be used in critical path code.
 type MetricsCollector interface {
-	IncrementCount(ctx context.Context, counterName string, n int64) (int64, error)
+	IncrementCount(ctx context.Context, counterName string, n int64) error
 	ReadCount(ctx context.Context, counterName string) (int64, error)
 }
 

--- a/server/remote_cache/hit_tracker/BUILD
+++ b/server/remote_cache/hit_tracker/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//server/metrics",
         "//server/tables",
         "//server/util/bazel_request",
-        "//server/util/timeutil",
         "@com_github_prometheus_client_golang//prometheus",
     ],
 )

--- a/server/remote_cache/hit_tracker/BUILD
+++ b/server/remote_cache/hit_tracker/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//server/metrics",
         "//server/tables",
         "//server/util/bazel_request",
+        "//server/util/timeutil",
         "@com_github_prometheus_client_golang//prometheus",
     ],
 )

--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -45,8 +45,6 @@ const (
 
 	CachedActionExecUsec
 
-	UploadThroughputBytesPerSecond
-	DownloadThroughputBytesPerSecond
 	// New counter types go here!
 )
 
@@ -76,10 +74,6 @@ func rawCounterName(actionCache bool, ct counterType) string {
 		return "upload-usec"
 	case CachedActionExecUsec:
 		return "cached-action-exec-usec"
-	case DownloadThroughputBytesPerSecond:
-		return "download-throughput-bytes-per-second"
-	case UploadThroughputBytesPerSecond:
-		return "upload-throughput-bytes-per-second"
 	default:
 		return "UNKNOWN-COUNTER-TYPE"
 	}
@@ -132,7 +126,7 @@ func (h *HitTracker) TrackMiss(d *repb.Digest) error {
 		metrics.CacheTypeLabel:      h.cacheTypeLabel(),
 		metrics.CacheEventTypeLabel: missLabel,
 	}).Inc()
-	_, err := h.c.IncrementCount(h.ctx, h.counterName(Miss), 1)
+	err := h.c.IncrementCount(h.ctx, h.counterName(Miss), 1)
 	return err
 }
 
@@ -144,7 +138,7 @@ func (h *HitTracker) TrackEmptyHit() error {
 	if h.c == nil || h.iid == "" {
 		return nil
 	}
-	_, err := h.c.IncrementCount(h.ctx, h.counterName(Hit), 1)
+	err := h.c.IncrementCount(h.ctx, h.counterName(Hit), 1)
 	return err
 }
 
@@ -182,7 +176,7 @@ func durationMetric(ct counterType) *prometheus.HistogramVec {
 	return metrics.CacheDownloadDurationUsec
 }
 
-func (h *HitTracker) makeCloseFunc(d *repb.Digest, start time.Time, actionCounter, sizeCounter, timeCounter, throughputCounter counterType) closeFunction {
+func (h *HitTracker) makeCloseFunc(d *repb.Digest, start time.Time, actionCounter, sizeCounter, timeCounter counterType) closeFunction {
 	return func() error {
 		dur := time.Since(start)
 
@@ -203,29 +197,13 @@ func (h *HitTracker) makeCloseFunc(d *repb.Digest, start time.Time, actionCounte
 			return nil
 		}
 
-		if _, err := h.c.IncrementCount(h.ctx, h.counterName(actionCounter), 1); err != nil {
+		if err := h.c.IncrementCount(h.ctx, h.counterName(actionCounter), 1); err != nil {
 			return err
 		}
-		if _, err := h.c.IncrementCount(h.ctx, h.counterName(sizeCounter), d.GetSizeBytes()); err != nil {
+		if err := h.c.IncrementCount(h.ctx, h.counterName(sizeCounter), d.GetSizeBytes()); err != nil {
 			return err
 		}
-		totalMicroseconds, err := h.c.IncrementCount(h.ctx, h.counterName(timeCounter), dur.Microseconds())
-		if err != nil {
-			return err
-		}
-
-		// Weighted streaming throughput calculation (see Welford's).
-		// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Weighted_incremental_algorithm
-		bytesPerSecond := int64(float64(d.GetSizeBytes()) / dur.Seconds())
-
-		// Weight by the duration of the upload / download.
-		weight := float64(dur.Microseconds()) / float64(totalMicroseconds)
-		oldMeanThroughput, err := h.c.ReadCount(h.ctx, h.counterName(throughputCounter))
-		if err != nil {
-			return err
-		}
-		throughputDelta := int64(float64(bytesPerSecond-oldMeanThroughput) * weight)
-		if _, err := h.c.IncrementCount(h.ctx, h.counterName(throughputCounter), throughputDelta); err != nil {
+		if err := h.c.IncrementCount(h.ctx, h.counterName(timeCounter), dur.Microseconds()); err != nil {
 			return err
 		}
 
@@ -246,7 +224,7 @@ func (h *HitTracker) makeCloseFunc(d *repb.Digest, start time.Time, actionCounte
 func (h *HitTracker) TrackDownload(d *repb.Digest) *transferTimer {
 	start := time.Now()
 	return &transferTimer{
-		closeFn: h.makeCloseFunc(d, start, Hit, DownloadSizeBytes, DownloadUsec, DownloadThroughputBytesPerSecond),
+		closeFn: h.makeCloseFunc(d, start, Hit, DownloadSizeBytes, DownloadUsec),
 	}
 }
 
@@ -259,7 +237,7 @@ func (h *HitTracker) TrackDownload(d *repb.Digest) *transferTimer {
 func (h *HitTracker) TrackUpload(d *repb.Digest) *transferTimer {
 	start := time.Now()
 	return &transferTimer{
-		closeFn: h.makeCloseFunc(d, start, Upload, UploadSizeBytes, UploadUsec, UploadThroughputBytesPerSecond),
+		closeFn: h.makeCloseFunc(d, start, Upload, UploadSizeBytes, UploadUsec),
 	}
 }
 
@@ -276,6 +254,11 @@ func (h *HitTracker) recordCacheUsage(d *repb.Digest, actionCounter counterType)
 		c.CASCacheHits = 1
 	}
 	return h.usage.Increment(h.ctx, c)
+}
+
+func computeThroughputBytesPerSecond(sizeBytes, durationUsec int64) int64 {
+	dur := time.Duration(durationUsec * int64(time.Microsecond))
+	return int64(float64(sizeBytes) / dur.Seconds())
 }
 
 func CollectCacheStats(ctx context.Context, env environment.Env, iid string) *capb.CacheStats {
@@ -298,8 +281,8 @@ func CollectCacheStats(ctx context.Context, env environment.Env, iid string) *ca
 	cs.TotalDownloadUsec, _ = c.ReadCount(ctx, counterName(false, DownloadUsec, iid))
 	cs.TotalUploadUsec, _ = c.ReadCount(ctx, counterName(false, UploadUsec, iid))
 
-	cs.DownloadThroughputBytesPerSecond, _ = c.ReadCount(ctx, counterName(false, DownloadThroughputBytesPerSecond, iid))
-	cs.UploadThroughputBytesPerSecond, _ = c.ReadCount(ctx, counterName(false, UploadThroughputBytesPerSecond, iid))
+	cs.DownloadThroughputBytesPerSecond = computeThroughputBytesPerSecond(cs.TotalDownloadSizeBytes, cs.TotalDownloadUsec)
+	cs.UploadThroughputBytesPerSecond = computeThroughputBytesPerSecond(cs.TotalUploadSizeBytes, cs.TotalUploadUsec)
 
 	cs.TotalCachedActionExecUsec, _ = c.ReadCount(ctx, counterName(false, CachedActionExecUsec, iid))
 

--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -126,8 +126,7 @@ func (h *HitTracker) TrackMiss(d *repb.Digest) error {
 		metrics.CacheTypeLabel:      h.cacheTypeLabel(),
 		metrics.CacheEventTypeLabel: missLabel,
 	}).Inc()
-	err := h.c.IncrementCount(h.ctx, h.counterName(Miss), 1)
-	return err
+	return h.c.IncrementCount(h.ctx, h.counterName(Miss), 1)
 }
 
 func (h *HitTracker) TrackEmptyHit() error {
@@ -138,8 +137,7 @@ func (h *HitTracker) TrackEmptyHit() error {
 	if h.c == nil || h.iid == "" {
 		return nil
 	}
-	err := h.c.IncrementCount(h.ctx, h.counterName(Hit), 1)
-	return err
+	return h.c.IncrementCount(h.ctx, h.counterName(Hit), 1)
 }
 
 type closeFunction func() error


### PR DESCRIPTION
Once we add Redis buffering, `MetricsCollector.IncrementCount` will no longer be able to return the count after incrementing, because the Redis command is only issued when flushing, which happens periodically in the background.

We could get around this by issuing a `GET` immediately after the `INCRBY` but this sort of defeats the purpose of buffering.

Instead, we can just remove the readback capability from the `Increment` function and update consumers to no longer depend on this readback capability.

The only place where we depend on this readback is in `hit_tracker.go` where we do throughput calculations. Luckily we can replace this with an equivalent calculation that doesn't rely on the readback. See this demo which shows that throughput calculations are the same: https://gist.github.com/bduffany/c5908f4664f45caf3e3aa91876dd1303

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
