### PR TITLE
Surface auth error in GetUser when the user is not found

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -40,8 +40,7 @@ export class AuthService {
         this.emitUser(this.userFromResponse(response));
       })
       .catch((error: any) => {
-        // TODO(siggisim): Remove "not found" string matching after the next release.
-        if (BuildBuddyError.parse(error).code == "Unauthenticated" || error.includes("not found")) {
+        if (BuildBuddyError.parse(error).code == "Unauthenticated") {
           this.createUser();
         } else {
           this.onUserRpcError(error);

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -750,8 +750,13 @@ func (a *OpenIDAuthenticator) authenticatedUser(ctx context.Context) (*Claims, e
 		}
 		return claims, nil
 	}
-	// WARNING: app/auth/auth_service.ts depends on this status being UNAUTHENTICATED.
-	return nil, status.UnauthenticatedError("User not found")
+	// WARNING: app/auth/auth_service.ts depends on this status being
+	// UNAUTHENTICATED.
+	err, ok := ctx.Value(contextUserErrorKey).(error)
+	if !ok {
+		err = status.UnknownError("unknown error occurred")
+	}
+	return nil, status.UnauthenticatedErrorf("User not found: %s", status.Message(err))
 }
 
 func (a *OpenIDAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces.UserInfo, error) {


### PR DESCRIPTION
This was useful for helping debug the "User already exists" error ("User already exists" was returned by `CreateUser`, which is only called when `GetUser` returns `Unauthenticated` -- in this case, it was returning `Unauthenticated` unexpectedly, so it was helpful to be able to see the root cause by looking at the response in the Network tab)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
