### PR TITLE
Use sql null types for group fields that can be null

### DIFF
--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -228,10 +228,10 @@ func (a *SAMLAuthenticator) getSAMLMetadataUrlForSlug(ctx context.Context, slug 
 	if err != nil {
 		return nil, err
 	}
-	if group.SamlIdpMetadataUrl == "" {
+	if group.SamlIdpMetadataUrl.String == "" {
 		return nil, status.NotFoundErrorf("Group %s does not have SAML configured", slug)
 	}
-	metadataUrl, err := url.Parse(group.SamlIdpMetadataUrl)
+	metadataUrl, err := url.Parse(group.SamlIdpMetadataUrl.String)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -473,10 +473,10 @@ func (ws *workflowService) gitHubTokenForAuthorizedGroup(ctx context.Context, re
 	if err != nil {
 		return "", err
 	}
-	if g.GithubToken == "" {
+	if g.GithubToken.String == "" {
 		return "", status.FailedPreconditionError("The selected group does not have a GitHub account linked")
 	}
-	return g.GithubToken, nil
+	return g.GithubToken.String, nil
 }
 
 func listGitHubRepoURLs(ctx context.Context, accessToken string) ([]string, error) {

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -229,7 +229,7 @@ func (c *GithubClient) populateTokenIfNecessary(ctx context.Context) error {
 		return err
 	}
 
-	c.githubToken = group.GithubToken
+	c.githubToken = group.GithubToken.String
 	return nil
 }
 

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -2,6 +2,7 @@ package buildbuddy_server
 
 import (
 	"context"
+	"database/sql"
 	"flag"
 	"fmt"
 	"net/http"
@@ -129,11 +130,11 @@ func makeGroups(grps []*tables.Group) []*grpb.Group {
 			Id:                     g.GroupID,
 			Name:                   g.Name,
 			OwnedDomain:            g.OwnedDomain,
-			GithubLinked:           g.GithubToken != "",
-			GithubToken:            g.GithubToken,
+			GithubLinked:           g.GithubToken.String != "",
+			GithubToken:            g.GithubToken.String,
 			UrlIdentifier:          urlIdentifier,
 			SharingEnabled:         g.SharingEnabled,
-			UseGroupOwnedExecutors: g.UseGroupOwnedExecutors,
+			UseGroupOwnedExecutors: g.UseGroupOwnedExecutors.Bool,
 		})
 	}
 	return r
@@ -195,7 +196,7 @@ func (s *BuildBuddyServer) GetGroup(ctx context.Context, req *grpb.GetGroupReque
 		// info should not be exposed here.
 		Name:        group.Name,
 		OwnedDomain: group.OwnedDomain,
-		SsoEnabled:  group.SamlIdpMetadataUrl != "",
+		SsoEnabled:  group.SamlIdpMetadataUrl.String != "",
 	}, nil
 }
 
@@ -256,7 +257,7 @@ func (s *BuildBuddyServer) CreateGroup(ctx context.Context, req *grpb.CreateGrou
 		Name:                   groupName,
 		OwnedDomain:            groupOwnedDomain,
 		SharingEnabled:         req.GetSharingEnabled(),
-		UseGroupOwnedExecutors: req.GetUseGroupOwnedExecutors(),
+		UseGroupOwnedExecutors: sql.NullBool{Valid: true, Bool: req.GetUseGroupOwnedExecutors()},
 	}
 	urlIdentifier := strings.TrimSpace(req.GetUrlIdentifier())
 
@@ -325,7 +326,7 @@ func (s *BuildBuddyServer) UpdateGroup(ctx context.Context, req *grpb.UpdateGrou
 		group.OwnedDomain = ""
 	}
 	group.SharingEnabled = req.GetSharingEnabled()
-	group.UseGroupOwnedExecutors = req.GetUseGroupOwnedExecutors()
+	group.UseGroupOwnedExecutors = sql.NullBool{Valid: true, Bool: req.GetUseGroupOwnedExecutors()}
 	if _, err := userDB.InsertOrUpdateGroup(ctx, group); err != nil {
 		return nil, err
 	}

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -1,6 +1,7 @@
 package tables
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 	"time"
@@ -167,17 +168,17 @@ type Group struct {
 	WriteToken string `gorm:"index:write_token_index"`
 
 	// The group's Github API token.
-	GithubToken string
+	GithubToken sql.NullString
 	Model
 
 	SharingEnabled bool `gorm:"default:true"`
 
 	// If enabled, builds for this group will always use their own executors instead of the installation-wide shared
 	// executors.
-	UseGroupOwnedExecutors bool
+	UseGroupOwnedExecutors sql.NullBool
 
 	// The SAML IDP Metadata URL for this group.
-	SamlIdpMetadataUrl string
+	SamlIdpMetadataUrl sql.NullString
 }
 
 func (g *Group) TableName() string {


### PR DESCRIPTION
When scanning into individual struct fields (e.g. with `db.Raw(someJoinQuery).Rows().Scan(&t1.Field1, &t2.Field2)`, GORM will give an error saying that it failed to convert NULL to string (or bool, etc.). We have NULLs in the DB in some places where we've added new fields but didn't mark them "not null" or give them default values when adding them initially.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
