### PR TITLE
Remove group auth check from HTTP auth flow

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -29,7 +29,6 @@ import (
 	"google.golang.org/grpc/peer"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
-	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
 	oidc "github.com/coreos/go-oidc"
 )
 
@@ -666,26 +665,7 @@ func (a *OpenIDAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r 
 	if err != nil {
 		return authContextWithError(ctx, err)
 	}
-	err = a.authenticateGroup(ctx, claims)
-	if err != nil {
-		return authContextWithError(ctx, err)
-	}
 	return authContextFromClaims(ctx, claims, err)
-}
-
-func (a *OpenIDAuthenticator) authenticateGroup(ctx context.Context, claims *Claims) error {
-	reqCtx := requestcontext.ProtoRequestContextFromContext(ctx)
-	// If no group ID was provided in context then we'll fall back to a default.
-	if reqCtx == nil || reqCtx.GetGroupId() == "" {
-		return nil
-	}
-	groupID := reqCtx.GetGroupId()
-	for _, allowedGroupID := range claims.GetAllowedGroups() {
-		if groupID == allowedGroupID {
-			return nil
-		}
-	}
-	return status.PermissionDeniedError("User does not have access to the requested group.")
 }
 
 func (a *OpenIDAuthenticator) authenticateUser(w http.ResponseWriter, r *http.Request) (*Claims, *userToken, error) {


### PR DESCRIPTION
This check is not desired for some RPCs. For example, in #1064, `GetUser` might be called with a preferred group ID for a group that no longer exists (common in local development, where we commonly use temp DBs) or a group that they no longer have access to (this will be possible once the user management UI becomes available). As a result, `GetUser` would fail since we'd fail to authorize group access, resulting in a "User already exists" error when the UI subsequently tries to create the user.

This removal is safe because we already explicitly authorize group access in each RPC handler where applicable (full audit results are [here](https://docs.google.com/document/d/17nFSYcUDozN1V5ZXq2wblaB1RDoBgh9zqf4EKA4EaMI/edit)). This isn't too surprising because we don't use the group ID from the request context in most places, and instead explicitly check the authenticated user's groups. Also, selected group auth is an authorization concern (not an authentication concern) so it makes sense that RPC handlers weren't relying on the authenticator to authorize access to the selected group, and instead explicitly rely on functions like `perms.AuthenticateSelectedGroupID`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
