### PR TITLE
Add server-side role check for GitHub account link

### DIFF
--- a/server/backends/github/BUILD
+++ b/server/backends/github/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//server/environment",
         "//server/tables",
+        "//server/util/authutil",
         "//server/util/log",
         "//server/util/perms",
         "//server/util/random",

--- a/server/http/role_filter/BUILD
+++ b/server/http/role_filter/BUILD
@@ -7,9 +7,11 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/environment",
+        "//server/util/authutil",
         "//server/util/perms",
         "//server/util/request_context",
         "//server/util/role",
+        "//server/util/status",
     ],
 )
 

--- a/server/util/authutil/BUILD
+++ b/server/util/authutil/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "authutil",
+    srcs = ["authutil.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/authutil",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/interfaces",
+        "//server/util/role",
+        "//server/util/status",
+    ],
+)

--- a/server/util/authutil/authutil.go
+++ b/server/util/authutil/authutil.go
@@ -1,0 +1,28 @@
+package authutil
+
+import (
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/role"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+)
+
+// AuthorizeGroupRole checks whether the given user has any of the allowed roles
+// within the given group.
+func AuthorizeGroupRole(u interfaces.UserInfo, groupID string, allowedRoles role.Role) error {
+	r := role.None
+	for _, m := range u.GetGroupMemberships() {
+		if m.GroupID == groupID {
+			r = m.Role
+			break
+		}
+	}
+	if r == role.None {
+		// User is not a member of the group at all; they were probably removed from
+		// their org during their current UI session.
+		return status.PermissionDeniedError("You do not have access to the requested organization")
+	}
+	if r&allowedRoles == 0 {
+		return status.PermissionDeniedError("You do not have the appropriate role within this organization")
+	}
+	return nil
+}


### PR DESCRIPTION
GitHub account linking is done via a regular HTTP request so the `role_filter` won't intercept this properly.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
