### PR TITLE
Address feedback on org members page

### DIFF
--- a/enterprise/app/org/org_members.tsx
+++ b/enterprise/app/org/org_members.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { User } from "../../../app/auth/auth_service";
-import Button from "../../../app/components/button/button";
+import Button, { OutlinedButton } from "../../../app/components/button/button";
 import CheckboxButton from "../../../app/components/button/checkbox_button";
 import Checkbox from "../../../app/components/checkbox/checkbox";
 import alertService from "../../../app/alert/alert_service";
@@ -104,7 +104,13 @@ export default class OrgMembersComponent extends React.Component<OrgMembersProps
   // Edit role modal
 
   private onClickEditRole() {
-    this.setState({ isEditRoleModalVisible: true });
+    this.setState({
+      isEditRoleModalVisible: true,
+      // Set the initially selected role to match the current role of the
+      // first user. This is a sensible default when there's only one user
+      // selected.
+      roleToApply: this.getSelectedMembers()[0]?.role || DEFAULT_ROLE,
+    });
   }
   private onRequestCloseEditRoleModal() {
     if (this.state.isRoleUpdateLoading) return;
@@ -183,10 +189,12 @@ export default class OrgMembersComponent extends React.Component<OrgMembersProps
     return member.user.userId.id === this.props.user.displayUser.userId.id;
   }
 
+  private getSelectedMembers(): grp.GetGroupUsersResponse.IGroupUser[] {
+    return this.state.response.user.filter((member) => this.state.selectedUserIds.has(member.user.userId.id));
+  }
+
   private renderAffectedUsersList({ verb }: { verb: string }) {
-    const selectedMembers = this.state.response.user.filter((member) =>
-      this.state.selectedUserIds.has(member.user.userId.id)
-    );
+    const selectedMembers = this.getSelectedMembers();
     return (
       <>
         <div>
@@ -294,6 +302,11 @@ export default class OrgMembersComponent extends React.Component<OrgMembersProps
             <DialogFooter>
               <DialogFooterButtons>
                 {this.state.isRoleUpdateLoading && <Spinner />}
+                <OutlinedButton
+                  onClick={this.onRequestCloseEditRoleModal.bind(this)}
+                  disabled={this.state.isRoleUpdateLoading}>
+                  Cancel
+                </OutlinedButton>
                 <Button onClick={this.onClickApplyRoleEdits.bind(this)} disabled={this.state.isRoleUpdateLoading}>
                   Apply
                 </Button>
@@ -315,6 +328,11 @@ export default class OrgMembersComponent extends React.Component<OrgMembersProps
             <DialogFooter>
               <DialogFooterButtons>
                 {this.state.isRemoveLoading && <Spinner />}
+                <OutlinedButton
+                  onClick={this.onRequestCloseRemoveModal.bind(this)}
+                  disabled={this.state.isRemoveLoading}>
+                  Cancel
+                </OutlinedButton>
                 <Button
                   className="destructive"
                   onClick={this.onClickConfirmRemove.bind(this)}


### PR DESCRIPTION
* Add an explicit "Cancel" button to modals as an alternative to clicking outside the modal
* Set the default role based on the first selected user's role. This is probably better for the single-member case, and probably not worse than what we do currently for the multi-member case, which is to set "Developer" by default

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
