### PR TITLE
Fix for live logs when logs haven't been written yet

### DIFF
--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -79,6 +79,8 @@ func GetEventLogChunk(ctx context.Context, env environment.Env, req *elpb.GetEve
 						Live:        true,
 					}, nil
 				}
+			} else if !status.IsNotFoundError(err) {
+				return nil, err
 			}
 			// If the invocation is in progress, logs may be written in the future.
 			// Return an empty chunk with NextChunkId set to 0.
@@ -123,6 +125,8 @@ func GetEventLogChunk(ctx context.Context, env environment.Env, req *elpb.GetEve
 							Live:        true,
 						}, nil
 					}
+				} else if !status.IsNotFoundError(err) {
+					return nil, err
 				}
 			}
 


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

There is a separate code path used when attempting to retrieve logs for an invocation that
has not yet committed any logs to disk, and this code path was not checking the redis cache
for possible log data. This PR addresses that.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
