### PR TITLE
Change default user role to Developer

### DIFF
--- a/enterprise/server/backends/userdb/userdb_test.go
+++ b/enterprise/server/backends/userdb/userdb_test.go
@@ -118,7 +118,7 @@ func TestCreateUser_OnPrem_OnlyFirstUserCreatedShouldBeMadeAdminOfDefaultGroup(t
 	us1 := findGroupUser(t, "US1", groupUsers)
 	require.Equal(t, grpb.Group_ADMIN_ROLE, us1.Role, "first user added to the default group should be made an admin")
 	us2 := findGroupUser(t, "US2", groupUsers)
-	require.Equal(t, grpb.Group_ADMIN_ROLE, us2.Role, "second user added to the default group should have the default role")
+	require.Equal(t, grpb.Group_DEVELOPER_ROLE, us2.Role, "second user added to the default group should have the default role")
 }
 
 func TestAddUserToGroup_AddsUserWithDefaultRole(t *testing.T) {
@@ -162,8 +162,7 @@ func TestAddUserToGroup_AddsUserWithDefaultRole(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, groupUsers, 2, "US1's group should have 2 members after adding US2")
 	us2 := findGroupUser(t, "US2", groupUsers)
-	// TODO(bduffany): This should be DEVELOPER once we have a user management UI.
-	require.Equal(t, grpb.Group_ADMIN_ROLE, us2.Role, "users should have default role after being added to another group")
+	require.Equal(t, grpb.Group_DEVELOPER_ROLE, us2.Role, "users should have default role after being added to another group")
 }
 
 func TestUpdateGroupUsers_Role(t *testing.T) {

--- a/server/util/role/role.go
+++ b/server/util/role/role.go
@@ -20,10 +20,7 @@ const (
 
 	// DefaultRole is the role assigned to users when joining a group they did
 	// not create.
-	// TODO(bduffany): Change this to DeveloperRole once we have a way to manage
-	// roles via the UI (otherwise, there would be no easy way to promote new
-	// users to admins in the meantime).
-	Default = Admin
+	Default = Developer
 )
 
 // Role represents a user's role within a group.


### PR DESCRIPTION
Since the user management UI will be enabled in the next release (https://github.com/buildbuddy-io/buildbuddy-internal/pull/915), we can now let existing admins decide whether new users have admin permissions or not, rather than giving new users admin access by default.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
