### PR TITLE
Store slug as a cookie to enable logins directly from the SAML /acs page

### DIFF
--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -140,6 +140,10 @@ func (a *SAMLAuthenticator) Auth(w http.ResponseWriter, r *http.Request) {
 		a.fallback.Auth(w, r)
 		return
 	}
+	// Store slug as a cookie to enable logins directly from the /acs page.
+	slug := r.URL.Query().Get(slugParam)
+	auth.SetCookie(w, slugCookie, slug, time.Now().Add(cookieDuration))
+
 	sp.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
We currently do this on the /Login endpoint, but don't do this for the /acs endpoint.

This change enables logging in directly from the Okta app directory chip.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
