### PR TITLE
Remove role requirement for GetBazelConfig

### DIFF
--- a/server/http/role_filter/role_filter.go
+++ b/server/http/role_filter/role_filter.go
@@ -34,6 +34,9 @@ var (
 		// able to create another group or request to join an existing group.
 		"CreateGroup",
 		"JoinGroup",
+		// Anonymous users can see the Bazel config required to use BuildBuddy, so
+		// don't require a group role.
+		"GetBazelConfig",
 	}
 
 	// DeveloperRPCs can be called only by developers or admins of the selected
@@ -49,7 +52,6 @@ var (
 		"ExecuteWorkflow",
 		// Setup
 		"GetApiKeys",
-		"GetBazelConfig",
 	}
 
 	// AdminOnlyRPCs can only be called by admins of the selected group.


### PR DESCRIPTION
This fixes the setup page in the case where no auth is configured:

![image](https://user-images.githubusercontent.com/2414826/138122942-852855cf-14f1-45b8-b851-d63ce5c8941a.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/927