### PR TITLE
Add support for exclusive task scheduling.

### DIFF
--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -156,13 +156,14 @@ type PriorityTaskScheduler struct {
 	rootContext   context.Context
 	rootCancel    context.CancelFunc
 
-	mu                    sync.Mutex
-	q                     *taskQueue
-	activeTaskCancelFuncs map[*context.CancelFunc]struct{}
-	ramBytesCapacity      int64
-	ramBytesUsed          int64
-	cpuMillisCapacity     int64
-	cpuMillisUsed         int64
+	mu                      sync.Mutex
+	q                       *taskQueue
+	activeTaskCancelFuncs   map[*context.CancelFunc]struct{}
+	ramBytesCapacity        int64
+	ramBytesUsed            int64
+	cpuMillisCapacity       int64
+	cpuMillisUsed           int64
+	exclusiveTaskScheduling bool
 }
 
 func NewPriorityTaskScheduler(env environment.Env, exec *executor.Executor, options *Options) *PriorityTaskScheduler {
@@ -177,19 +178,21 @@ func NewPriorityTaskScheduler(env environment.Env, exec *executor.Executor, opti
 		cpuMillisCapacity = int64(float64(resources.GetAllocatedCPUMillis()) * tasksize.MaxResourceCapacityRatio)
 	}
 
+	executorConfig := env.GetConfigurator().GetExecutorConfig()
 	rootContext, rootCancel := context.WithCancel(context.Background())
 	qes := &PriorityTaskScheduler{
-		env:                   env,
-		log:                   sublog,
-		q:                     newTaskQueue(),
-		exec:                  exec,
-		newTaskSignal:         make(chan struct{}, 1),
-		rootContext:           rootContext,
-		rootCancel:            rootCancel,
-		activeTaskCancelFuncs: make(map[*context.CancelFunc]struct{}, 0),
-		shuttingDown:          false,
-		ramBytesCapacity:      ramBytesCapacity,
-		cpuMillisCapacity:     cpuMillisCapacity,
+		env:                     env,
+		log:                     sublog,
+		q:                       newTaskQueue(),
+		exec:                    exec,
+		newTaskSignal:           make(chan struct{}, 1),
+		rootContext:             rootContext,
+		rootCancel:              rootCancel,
+		activeTaskCancelFuncs:   make(map[*context.CancelFunc]struct{}, 0),
+		shuttingDown:            false,
+		ramBytesCapacity:        ramBytesCapacity,
+		cpuMillisCapacity:       cpuMillisCapacity,
+		exclusiveTaskScheduling: executorConfig.ExclusiveTaskScheduling,
 	}
 
 	env.GetHealthChecker().RegisterShutdownFunction(qes.Shutdown)
@@ -311,6 +314,12 @@ func (q *PriorityTaskScheduler) canFitAnotherTask(res *scpb.EnqueueTaskReservati
 	knownRAMremaining := q.ramBytesCapacity - q.ramBytesUsed
 	knownCPUremaining := q.cpuMillisCapacity - q.cpuMillisUsed
 	willFit := knownRAMremaining >= res.GetTaskSize().GetEstimatedMemoryBytes() && knownCPUremaining >= res.GetTaskSize().GetEstimatedMilliCpu()
+
+	// If we're running in exclusiveTaskScheduling mode, only ever allow one task to run at
+	// a time. Otherwise fall through to the logic below.
+	if willFit && q.exclusiveTaskScheduling && len(q.activeTaskCancelFuncs) >= 1 {
+		return false
+	}
 
 	if willFit {
 		q.log.Infof("ram remaining: %d, cpu remaining: %d, tasks running: %d, q depth: %d", knownRAMremaining, knownCPUremaining, len(q.activeTaskCancelFuncs), q.q.Len())

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -276,6 +276,7 @@ type ExecutorConfig struct {
 	DefaultImage              string                    `yaml:"default_image" usage:"The default docker image to use to warm up executors or if no platform property is set. Ex: gcr.io/flame-public/executor-docker-default:enterprise-v1.5.4"`
 	WarmupTimeoutSecs         int64                     `yaml:"warmup_timeout_secs" usage:"The default time (in seconds) to wait for an executor to warm up i.e. download the default docker image. Default is 120s"`
 	StartupWarmupMaxWaitSecs  int64                     `yaml:"startup_warmup_max_wait_secs" usage:"Maximum time to block startup while waiting for default image to be pulled. Default is no wait."`
+	ExclusiveTaskScheduling   bool                      `yaml:"exclusive_task_scheduling" usage:"If true, only one task will be scheduled at a time. Default is false"`
 }
 
 type ContainerRegistryConfig struct {

--- a/tools/goreman/procfiles/Procfile.rexec
+++ b/tools/goreman/procfiles/Procfile.rexec
@@ -1,2 +1,2 @@
 app: bazel run enterprise/server -- --config_file=enterprise/config/buildbuddy.local.yaml
-exec: bazel run enterprise/server/cmd/executor:executor -- --monitoring_port=9091 --executor.docker_socket=""
+exec: bazel run enterprise/server/cmd/executor:executor -- --monitoring_port=9091 --executor.docker_socket="" --executor.enable_firecracker=false


### PR DESCRIPTION
When this bit is set in the executor config, only a single task is scheduled at a time. This is useful for certain workloads that require exclusive access to some machine resources.