### PR TITLE
Fix auth error when looking up invocation for GCS webhook

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -75,9 +75,9 @@ type BuildEventHandler struct {
 
 func NewBuildEventHandler(env environment.Env) *BuildEventHandler {
 	openChannels := &sync.WaitGroup{}
-	statsRecorded := make(chan *recordStatsTask, 4096)
-	statsRecorder := newStatsRecorder(env, openChannels, statsRecorded)
-	webhookNotifier := newWebhookNotifier(env, statsRecorded)
+	onStatsRecorded := make(chan *invocationJWT, 4096)
+	statsRecorder := newStatsRecorder(env, openChannels, onStatsRecorded)
+	webhookNotifier := newWebhookNotifier(env, onStatsRecorded)
 
 	statsRecorder.Start()
 	webhookNotifier.Start()
@@ -126,13 +126,19 @@ func (b *BuildEventHandler) OpenChannel(ctx context.Context, iid string) interfa
 	}
 }
 
+// invocationJWT represents an invocation ID as well as the JWT granting access
+// to it. It should only be used for background tasks that need access to the
+// JWT after the build event stream is already closed.
+type invocationJWT struct {
+	id  string
+	jwt string
+}
+
 // recordStatsTask contains the info needed to record the stats for an
 // invocation. These tasks are enqueued to statsRecorder and executed in the
 // background.
 type recordStatsTask struct {
-	jwt        string
-	invocation *inpb.Invocation
-
+	*invocationJWT
 	// createdAt is the time at which this task was created.
 	createdAt time.Time
 }
@@ -142,26 +148,29 @@ type recordStatsTask struct {
 type statsRecorder struct {
 	env          environment.Env
 	openChannels *sync.WaitGroup
-	// statsRecorded is a channel that is notified after each recordStatsTask is
-	// completed by this statsRecorder.
-	statsRecorded chan<- *recordStatsTask
-	eg            errgroup.Group
+	// onStatsRecorded is a channel for this statsRecorder to notify after
+	// recording stats for each invocation. Invocations sent on this channel are
+	// considered "finalized".
+	onStatsRecorded chan<- *invocationJWT
+	eg              errgroup.Group
 
 	mu      sync.Mutex // protects(tasks, stopped)
 	tasks   chan *recordStatsTask
 	stopped bool
 }
 
-func newStatsRecorder(env environment.Env, openChannels *sync.WaitGroup, statsRecorded chan<- *recordStatsTask) *statsRecorder {
+func newStatsRecorder(env environment.Env, openChannels *sync.WaitGroup, onStatsRecorded chan<- *invocationJWT) *statsRecorder {
 	return &statsRecorder{
-		env:           env,
-		openChannels:  openChannels,
-		statsRecorded: statsRecorded,
-		tasks:         make(chan *recordStatsTask, 4096),
+		env:             env,
+		openChannels:    openChannels,
+		onStatsRecorded: onStatsRecorded,
+		tasks:           make(chan *recordStatsTask, 4096),
 	}
 }
 
-func (r *statsRecorder) MarkFinalized(ctx context.Context, invocation *inpb.Invocation) {
+// Enqueue enqueues a task for the given invocation's stats to be recorded
+// once they are available.
+func (r *statsRecorder) Enqueue(ctx context.Context, invocation *inpb.Invocation) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -177,9 +186,11 @@ func (r *statsRecorder) MarkFinalized(ctx context.Context, invocation *inpb.Invo
 		jwt = auth.TrustedJWTFromAuthContext(ctx)
 	}
 	req := &recordStatsTask{
-		jwt:        jwt,
-		invocation: invocation,
-		createdAt:  time.Now(),
+		invocationJWT: &invocationJWT{
+			id:  invocation.GetInvocationId(),
+			jwt: jwt,
+		},
+		createdAt: time.Now(),
 	}
 	select {
 	case r.tasks <- req:
@@ -199,10 +210,9 @@ func (r *statsRecorder) Start() {
 				// finalized, rather than relative to now. Otherwise each worker would be
 				// unnecessarily throttled.
 				time.Sleep(time.Until(task.createdAt.Add(cacheStatsFinalizationDelay)))
-				ti := &tables.Invocation{InvocationID: task.invocation.GetInvocationId()}
-				if stats := hit_tracker.CollectCacheStats(ctx, r.env, task.invocation.GetInvocationId()); stats != nil {
+				ti := &tables.Invocation{InvocationID: task.invocationJWT.id}
+				if stats := hit_tracker.CollectCacheStats(ctx, r.env, task.invocationJWT.id); stats != nil {
 					fillInvocationFromCacheStats(stats, ti)
-					task.invocation.CacheStats = stats
 				}
 				if err := r.env.GetInvocationDB().InsertOrUpdateInvocation(ctx, ti); err != nil {
 					log.Errorf("Failed to write cache stats for invocation: %s", err)
@@ -210,12 +220,12 @@ func (r *statsRecorder) Start() {
 				// Cleanup regardless of whether the stats are flushed successfully to
 				// the DB (since we won't retry the flush and we don't need these stats
 				// for any other purpose).
-				hit_tracker.CleanupCacheStats(ctx, r.env, task.invocation.GetInvocationId())
+				hit_tracker.CleanupCacheStats(ctx, r.env, task.invocationJWT.id)
 
-				// Once cache stats are populated, notify the statsRecorded channel in a
-				// non-blocking fashion.
+				// Once cache stats are populated, notify the onStatsRecorded channel in
+				// a non-blocking fashion.
 				select {
-				case r.statsRecorded <- task:
+				case r.onStatsRecorded <- task.invocationJWT:
 					break
 				default:
 					log.Warningf("Failed to notify stats recorder listeners: channel buffer is full")
@@ -228,7 +238,7 @@ func (r *statsRecorder) Start() {
 
 func (r *statsRecorder) Stop() {
 	// Wait for all EventHandler channels to be closed to ensure there will be
-	// no more calls to MarkFinalized.
+	// no more calls to Enqueue.
 	r.openChannels.Wait()
 
 	r.mu.Lock()
@@ -240,12 +250,15 @@ func (r *statsRecorder) Stop() {
 		log.Error(err.Error())
 	}
 
-	close(r.statsRecorded)
+	close(r.onStatsRecorded)
 }
 
 type notifyWebhookTask struct {
-	hook       interfaces.Webhook
-	jwt        string
+	// hook is the webhook to notify of a completed invocation.
+	hook interfaces.Webhook
+	// invocationJWT contains the invocation ID and JWT for the invocation.
+	*invocationJWT
+	// invocation is the complete invocation looked up from the invocationJWT.
 	invocation *inpb.Invocation
 }
 
@@ -253,8 +266,9 @@ func notifyWithTimeout(ctx context.Context, env environment.Env, t *notifyWebhoo
 	ctx, cancel := context.WithTimeout(ctx, webhookNotifyTimeout)
 	defer cancel()
 	// Run the webhook using the authenticated user from the build event stream.
+	ij := t.invocationJWT
 	if auth := env.GetAuthenticator(); auth != nil {
-		ctx = auth.AuthContextFromTrustedJWT(ctx, t.jwt)
+		ctx = auth.AuthContextFromTrustedJWT(ctx, ij.jwt)
 	}
 	return t.hook.NotifyComplete(ctx, t.invocation)
 }
@@ -262,18 +276,20 @@ func notifyWithTimeout(ctx context.Context, env environment.Env, t *notifyWebhoo
 // webhookNotifier listens for invocations to be finalized (including stats)
 // and notifies webhooks.
 type webhookNotifier struct {
-	env           environment.Env
-	statsRecorded <-chan *recordStatsTask
+	env environment.Env
+	// invocations is a channel of finalized invocations. On each invocation
+	// sent to this channel, we notify all configured webhooks.
+	invocations <-chan *invocationJWT
 
 	tasks chan *notifyWebhookTask
 	eg    errgroup.Group
 }
 
-func newWebhookNotifier(env environment.Env, statsRecorded <-chan *recordStatsTask) *webhookNotifier {
+func newWebhookNotifier(env environment.Env, invocations <-chan *invocationJWT) *webhookNotifier {
 	return &webhookNotifier{
-		env:           env,
-		statsRecorded: statsRecorded,
-		tasks:         make(chan *notifyWebhookTask, 4096),
+		env:         env,
+		invocations: invocations,
+		tasks:       make(chan *notifyWebhookTask, 4096),
 	}
 }
 
@@ -282,25 +298,25 @@ func (w *webhookNotifier) Start() {
 	ctx := context.Background()
 
 	w.eg.Go(func() error {
-		// Listen for invocations that have been finalized by the stats recorder,
-		// and start a notify webhook task for each webhook.
-		for task := range w.statsRecorded {
-			// Don't call webhooks for disconnected invocations.
-			if task.invocation.GetInvocationStatus() == inpb.Invocation_DISCONNECTED_INVOCATION_STATUS {
-				continue
-			}
-
-			invocation, err := w.lookupInvocation(ctx, task)
+		// Listen for invocations that have been finalized and start a notify
+		// webhook task for each webhook.
+		for ij := range w.invocations {
+			invocation, err := w.lookupInvocation(ctx, ij)
 			if err != nil {
 				log.Warningf("Failed to lookup invocation before notifying webhook: %s", err)
 				continue
 			}
 
+			// Don't call webhooks for disconnected invocations.
+			if invocation.GetInvocationStatus() == inpb.Invocation_DISCONNECTED_INVOCATION_STATUS {
+				continue
+			}
+
 			for _, hook := range w.env.GetWebhooks() {
 				w.tasks <- &notifyWebhookTask{
-					jwt:        task.jwt,
-					hook:       hook,
-					invocation: invocation,
+					hook:          hook,
+					invocationJWT: ij,
+					invocation:    invocation,
 				}
 			}
 		}
@@ -327,11 +343,11 @@ func (w *webhookNotifier) Stop() {
 	}
 }
 
-func (w *webhookNotifier) lookupInvocation(ctx context.Context, task *recordStatsTask) (*inpb.Invocation, error) {
+func (w *webhookNotifier) lookupInvocation(ctx context.Context, ij *invocationJWT) (*inpb.Invocation, error) {
 	if auth := w.env.GetAuthenticator(); auth != nil {
-		ctx = auth.AuthContextFromTrustedJWT(ctx, task.jwt)
+		ctx = auth.AuthContextFromTrustedJWT(ctx, ij.jwt)
 	}
-	return LookupInvocation(w.env, ctx, task.invocation.GetInvocationId())
+	return LookupInvocation(w.env, ctx, ij.id)
 }
 
 func isFinalEvent(obe *pepb.OrderedBuildEvent) bool {
@@ -450,7 +466,7 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 		return err
 	}
 
-	e.statsRecorder.MarkFinalized(e.ctx, invocation)
+	e.statsRecorder.Enqueue(e.ctx, invocation)
 	return nil
 }
 


### PR DESCRIPTION
`invocationdb.LookupInvocation` requires an authenticated user in the context, but because this is done in the background we no longer have access to the authenticated user. Fixed by forwarding the JWT from the build event channel context.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
