### PR TITLE
Respect platform header overrides in execution server

### DIFF
--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -24,6 +24,7 @@ const (
 	//     x-buildbuddy-platform.container-registry-username: _json_key
 	overrideHeaderPrefix = "x-buildbuddy-platform."
 
+	poolPropertyName = "Pool"
 	// DefaultPoolValue is the value for the "Pool" platform property that selects
 	// the default executor pool for remote execution.
 	DefaultPoolValue = "default"
@@ -51,6 +52,10 @@ const (
 	operatingSystemPropertyName = "OSFamily"
 	defaultOperatingSystemName  = "linux"
 	darwinOperatingSystemName   = "darwin"
+
+	cpuArchitecturePropertyName = "Arch"
+	defaultCPUArchitecture      = "amd64"
+
 	// Using the property defined here: https://github.com/bazelbuild/bazel-toolchains/blob/v5.1.0/rules/exec_properties/exec_properties.bzl#L164
 	dockerRunAsRootPropertyName = "dockerRunAsRoot"
 
@@ -63,6 +68,8 @@ const (
 // Properties represents the platform properties parsed from a command.
 type Properties struct {
 	OS                        string
+	Arch                      string
+	Pool                      string
 	ContainerImage            string
 	ContainerRegistryUsername string
 	ContainerRegistryPassword string
@@ -101,8 +108,17 @@ func ParseProperties(task *repb.ExecutionTask) *Properties {
 	for _, prop := range task.GetPlatformOverrides().GetProperties() {
 		m[strings.ToLower(prop.GetName())] = strings.TrimSpace(prop.GetValue())
 	}
+
+	pool := stringProp(m, poolPropertyName, "")
+	// Treat the explicit default pool value as empty string
+	if pool == DefaultPoolValue {
+		pool = ""
+	}
+
 	return &Properties{
 		OS:                        stringProp(m, operatingSystemPropertyName, defaultOperatingSystemName),
+		Arch:                      stringProp(m, cpuArchitecturePropertyName, defaultCPUArchitecture),
+		Pool:                      pool,
 		ContainerImage:            stringProp(m, containerImagePropertyName, ""),
 		ContainerRegistryUsername: stringProp(m, containerRegistryUsernamePropertyName, ""),
 		ContainerRegistryPassword: stringProp(m, containerRegistryPasswordPropertyName, ""),

--- a/enterprise/server/remote_execution/platform/platform_test.go
+++ b/enterprise/server/remote_execution/platform/platform_test.go
@@ -76,6 +76,72 @@ func TestParse_ContainerImage_Error(t *testing.T) {
 	}
 }
 
+func TestParse_OS(t *testing.T) {
+	for _, testCase := range []struct {
+		rawValue      string
+		expectedValue string
+	}{
+		{"", "linux"},
+		{"linux", "linux"},
+		{"darwin", "darwin"},
+	} {
+		plat := &repb.Platform{Properties: []*repb.Platform_Property{
+			{Name: "OSFamily", Value: testCase.rawValue},
+		}}
+		platformProps := platform.ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: plat}})
+		assert.Equal(t, testCase.expectedValue, platformProps.OS)
+	}
+
+	// Empty case
+	plat := &repb.Platform{Properties: []*repb.Platform_Property{}}
+	platformProps := platform.ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: plat}})
+	assert.Equal(t, "linux", platformProps.OS)
+}
+
+func TestParse_Arch(t *testing.T) {
+	for _, testCase := range []struct {
+		rawValue      string
+		expectedValue string
+	}{
+		{"", "amd64"},
+		{"amd64", "amd64"},
+		{"arm64", "arm64"},
+	} {
+		plat := &repb.Platform{Properties: []*repb.Platform_Property{
+			{Name: "Arch", Value: testCase.rawValue},
+		}}
+		platformProps := platform.ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: plat}})
+		assert.Equal(t, testCase.expectedValue, platformProps.Arch)
+	}
+
+	// Empty case
+	plat := &repb.Platform{Properties: []*repb.Platform_Property{}}
+	platformProps := platform.ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: plat}})
+	assert.Equal(t, "amd64", platformProps.Arch)
+}
+
+func TestParse_Pool(t *testing.T) {
+	for _, testCase := range []struct {
+		rawValue      string
+		expectedValue string
+	}{
+		{"", ""},
+		{"default", ""},
+		{"my-pool", "my-pool"},
+	} {
+		plat := &repb.Platform{Properties: []*repb.Platform_Property{
+			{Name: "Pool", Value: testCase.rawValue},
+		}}
+		platformProps := platform.ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: plat}})
+		assert.Equal(t, testCase.expectedValue, platformProps.Pool)
+	}
+
+	// Empty case
+	plat := &repb.Platform{Properties: []*repb.Platform_Property{}}
+	platformProps := platform.ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: plat}})
+	assert.Equal(t, "", platformProps.Pool)
+}
+
 func TestParse_ApplyOverrides(t *testing.T) {
 	for _, testCase := range []struct {
 		platformProps       []*repb.Platform_Property


### PR DESCRIPTION
This fixes that the issue with overriding `Pool` via remote header (`--remote_header=x-buildbuddy-platform.Pool=foo`)

The problem is that we weren't checking the lowercase version of the `Pool` property name, and the headers always seem to come through in lowercase even if they are specified in uppercase.

This PR uses `platform.ParseProperties` to get the canonical properties, allowing for lowercase -- which also lets us clean up `execution_server` a bit.

TODO in a future PR: Respect platform header overrides in the task router as well. The platform gets serialized and is part of the task routing key, but currently we only look at the platform from the `Command` (and not the combined platform from `task.Command` + `task.PlatformOverrides`). ~~This is not an immediate problem because it would only affect tasks with recycle-runner enabled and x-buildbuddy-platform headers, which is not very common scenario at the moment. In the worst case the runner just might not be recycled when using this header overrides feature.~~ Edit: This actually works just fine after all. Added tests in #1156

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
