### PR TITLE
Fix UI displayed when the user is not part of any orgs

### DIFF
--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -328,6 +328,12 @@ class Router {
   }
 
   private getFallbackPath(user: User | null): string | null {
+    // Require the user to create an org if they are logged in but not part of
+    // an org.
+    if (user !== null && !user.groups?.length) {
+      return Path.createOrgPath;
+    }
+
     const path = window.location.pathname;
 
     if (path === Path.executorsPath && !this.canAccessExecutorsPage(user)) {

--- a/enterprise/app/org/create_org.tsx
+++ b/enterprise/app/org/create_org.tsx
@@ -39,6 +39,9 @@ export default class CreateOrgComponent extends OrgForm<grp.CreateGroupRequest> 
       <div className="organization-page">
         <div className="container">
           <div className="organization-page-title">Create organization</div>
+          {this.props.user && !Boolean(this.props.user.groups?.length) && (
+            <p className="callout">You are logged in, but not part of any organization. Create one to continue.</p>
+          )}
           <form autoComplete="off" className="organization-form" onSubmit={this.onSubmit.bind(this)}>
             {this.renderFields()}
             <FilledButton

--- a/enterprise/app/org/org.css
+++ b/enterprise/app/org/org.css
@@ -10,6 +10,12 @@
   margin-bottom: 32px;
 }
 
+.organization-page .callout {
+  background-color: #ffe082;
+  padding: 16px 32px;
+  border-radius: 8px;
+}
+
 .organization-form {
   max-width: 600px;
 }

--- a/enterprise/app/org/org_members.tsx
+++ b/enterprise/app/org/org_members.tsx
@@ -174,6 +174,12 @@ export default class OrgMembersComponent extends React.Component<OrgMembersProps
         })
       )
       .then(() => {
+        // After removing yourself from an org, refresh the page to trigger
+        // group reselection or login page as appropriate.
+        if (this.state.selectedUserIds.has(this.props.user.displayUser.userId.id)) {
+          window.location.reload();
+          return;
+        }
         alertService.success("Changes applied successfully.");
         this.setState({
           isRemoveModalVisible: false,

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -137,7 +137,7 @@ export default class EnterpriseRootComponent extends React.Component {
       (fallback && !capabilities.auth);
     let login = fallback && !setup && !this.state.loading && !this.state.user;
     let home = fallback && !setup && !this.state.loading && this.state.user;
-    let sidebar = !!this.state.user && !code;
+    let sidebar = Boolean(this.state.user) && Boolean(this.state.user.groups?.length) && !code;
     let menu = !sidebar && !code && !this.state.loading;
 
     return (


### PR DESCRIPTION
* If the user is logged in but not part of an org, show the create org page to have them create a new org. Went with an explicit URL redirect to `/org/create` to avoid adding more complexity to `root.tsx` (the boolean logic there is getting hard to follow and I didn't want to add more complexity to handle this edge case)
* When a user removes themselves from the last org they're a part of, reload the page to re-trigger the initial auth flow and router redirects

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/942

