### PR TITLE
Record cache usage even if no invocation ID is set

### DIFF
--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -196,6 +196,10 @@ func (h *HitTracker) makeCloseFunc(d *repb.Digest, start time.Time, actionCounte
 			metrics.CacheTypeLabel: ct,
 		}).Observe(float64(dur.Microseconds()))
 
+		if err := h.recordCacheUsage(d, actionCounter); err != nil {
+			return err
+		}
+
 		if h.c == nil || h.iid == "" {
 			return nil
 		}
@@ -207,10 +211,6 @@ func (h *HitTracker) makeCloseFunc(d *repb.Digest, start time.Time, actionCounte
 			return err
 		}
 		if err := h.c.IncrementCount(h.ctx, h.counterKey(), h.counterField(timeCounter), dur.Microseconds()); err != nil {
-			return err
-		}
-
-		if err := h.recordCacheUsage(d, actionCounter); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This does not seem to be a problem for now (the executor seems to send along the invocation ID when it makes requests to the CAS, and so does Bazel), but it seems a unnecessary to depend on having an invocation ID to be able to track CAS usage.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
