### PR TITLE
Trim whitespace before normalizing/parsing repo urls

### DIFF
--- a/server/util/git/git.go
+++ b/server/util/git/git.go
@@ -68,6 +68,7 @@ func OwnerRepoFromRepoURL(repoURL string) (string, error) {
 }
 
 func ParseRepoURL(repo string) (*url.URL, error) {
+	repo = strings.TrimSpace(repo)
 	// We assume https:// when scheme is missing for all domains except localhost,
 	// which in most cases uses http:// since most people forgo the hassle of
 	// setting up HTTPS locally. We assume "github.com" if no scheme or domain is
@@ -138,6 +139,7 @@ func ParseRepoURL(repo string) (*url.URL, error) {
 }
 
 func NormalizeRepoURL(repo string) (*url.URL, error) {
+	repo = strings.TrimSpace(repo)
 	// We coerce https scheme for all domains except localhost. We remove the user
 	// info. We strip the ".git" suffix, if it exists.
 	repoURL, err := ParseRepoURL(repo)

--- a/server/util/git/git_test.go
+++ b/server/util/git/git_test.go
@@ -33,6 +33,7 @@ func TestStripRepoURLCredentials(t *testing.T) {
 		expected string
 	}{
 		{"https://github.com/org/repo.git", "https://github.com/org/repo.git"},
+		{" \r\n\t https://USER:PASS@github.com/org/repo.git\r\n\t  ", "https://github.com/org/repo.git"},
 		{"https://USER:PASS@github.com/org/repo.git", "https://github.com/org/repo.git"},
 		{"https://PASS:@github.com/org/repo.git", "https://github.com/org/repo.git"},
 		{"https://:PASS@gitlab.com/org/repo", "https://gitlab.com/org/repo"},
@@ -57,6 +58,7 @@ func TestOwnerRepoFromRepoURL(t *testing.T) {
 	for _, url := range []string{
 		"https://github.com/org/repo.git",
 		"https://USER:PASS@github.com/org/repo.git",
+		"  https://USER:PASS@github.com/org/repo.git \r\n",
 		"https://PASS:@github.com/org/repo.git",
 		"https://:PASS@gitlab.com/org/repo",
 		"http://USER:PASS@github.com/org/repo.git",
@@ -78,6 +80,7 @@ func TestNormalizeRepoURL(t *testing.T) {
 		"ssh://github.com/buildbuddy-io/buildbuddy",
 		"ssh://github.com/buildbuddy-io/buildbuddy.git",
 		"git://github.com/buildbuddy-io/buildbuddy",
+		"   git://github.com/buildbuddy-io/buildbuddy \r\n\t  ",
 		"git://github.com/buildbuddy-io/buildbuddy.git",
 		"git@github.com:buildbuddy-io/buildbuddy.git",
 		"https://NOTREALTOKEN:@github.com/buildbuddy-io/buildbuddy",


### PR DESCRIPTION
Should fix some issues with repo parsing we're seeing in prod

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
