### PR TITLE
Improve error handling for InsertOrUpdateInvocation

### DIFF
--- a/server/backends/invocationdb/BUILD
+++ b/server/backends/invocationdb/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//server/interfaces",
         "//server/tables",
         "//server/util/db",
-        "//server/util/log",
         "//server/util/perms",
         "//server/util/query_builder",
         "//server/util/status",


### PR DESCRIPTION
Verified that Bazel does a retry in case we return an error here, so this should not negatively affect any existing cases where we return an error for whatever reason (e.g. due to context deadline exceeded).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
