### PR TITLE
Fix bug that we finalize invocations twice in some cases

### DIFF
--- a/server/build_event_protocol/build_event_server/build_event_server.go
+++ b/server/build_event_protocol/build_event_server/build_event_server.go
@@ -137,7 +137,7 @@ func (s *BuildEventProtocolServer) PublishBuildToolEventStream(stream pepb.Publi
 		}
 		if err := stream.Send(rsp); err != nil {
 			log.Warningf("Error sending ack stream for invocation %q: %s", streamID.InvocationId, err)
-			return disconnectWithErr(err)
+			return err
 		}
 	}
 	return nil

--- a/server/build_event_protocol/build_event_server/build_event_server.go
+++ b/server/build_event_protocol/build_event_server/build_event_server.go
@@ -125,7 +125,7 @@ func (s *BuildEventProtocolServer) PublishBuildToolEventStream(stream pepb.Publi
 	if channel != nil {
 		if err := channel.FinalizeInvocation(streamID.GetInvocationId()); err != nil {
 			log.Warningf("Error finalizing invocation %q: %s", streamID.GetInvocationId(), err)
-			return disconnectWithErr(err)
+			return err
 		}
 	}
 


### PR DESCRIPTION
This fixes at least one possible cause of the AlreadyExists error (https://github.com/buildbuddy-io/buildbuddy-internal/issues/951), although there may be others (still looking into it).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
