### PR TITLE
Fix another source of AlreadyExists errors

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -435,19 +435,18 @@ func (e *EventChannel) Close() {
 	e.onClose()
 }
 
-func (e *EventChannel) FinalizeInvocation(iid string) error {
+func (e *EventChannel) FinalizeInvocation(iid string, status inpb.Invocation_InvocationStatus) error {
 	ctx, cancel := background.ExtendContextForFinalization(e.ctx, 10*time.Second)
 	defer cancel()
 
 	invocation := &inpb.Invocation{
 		InvocationId:     iid,
-		InvocationStatus: inpb.Invocation_COMPLETE_INVOCATION_STATUS,
+		InvocationStatus: status,
 	}
 
-	if !e.beValues.BuildFinished() {
-		log.Warningf("Invocation %s lacks a BuildFinished event, marking as disconnected.", iid)
+	if status == inpb.Invocation_DISCONNECTED_INVOCATION_STATUS {
+		log.Warningf("Reporting disconnected status for invocation %s.", iid)
 		e.statusReporter.ReportDisconnect(ctx)
-		invocation.InvocationStatus = inpb.Invocation_DISCONNECTED_INVOCATION_STATUS
 	}
 
 	if err := e.pw.Flush(ctx); err != nil {
@@ -674,7 +673,8 @@ func (e *EventChannel) processSingleEvent(event *inpb.InvocationEvent, iid strin
 	}
 	e.statusReporter.ReportStatusForEvent(e.ctx, event.BuildEvent)
 
-	// For everything else, just save the event to our buffer and keep on chugging.
+	// For everything else, just save the event to our buffer and keep on
+	// chugging.
 	if err := e.pw.WriteProtoToStream(e.ctx, event); err != nil {
 		return err
 	}

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -673,8 +673,7 @@ func (e *EventChannel) processSingleEvent(event *inpb.InvocationEvent, iid strin
 	}
 	e.statusReporter.ReportStatusForEvent(e.ctx, event.BuildEvent)
 
-	// For everything else, just save the event to our buffer and keep on
-	// chugging.
+	// For everything else, just save the event to our buffer and keep on chugging.
 	if err := e.pw.WriteProtoToStream(e.ctx, event); err != nil {
 		return err
 	}

--- a/server/build_event_protocol/build_event_handler/build_event_handler_test.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler_test.go
@@ -353,7 +353,7 @@ func TestHandleEventWithWorkspaceStatusBeforeStarted(t *testing.T) {
 	assert.Equal(t, inpb.Invocation_PARTIAL_INVOCATION_STATUS, invocation.InvocationStatus)
 
 	// Finalize the invocation
-	err = channel.FinalizeInvocation("test-invocation-id")
+	err = channel.FinalizeInvocation("test-invocation-id", inpb.Invocation_COMPLETE_INVOCATION_STATUS)
 	assert.NoError(t, err)
 
 	// Make sure it gets finalized properly
@@ -481,7 +481,7 @@ func TestFinishedFinalizeWithCanceledContext(t *testing.T) {
 	cancel()
 
 	// Finalize the invocation
-	err = channel.FinalizeInvocation("test-invocation-id")
+	err = channel.FinalizeInvocation("test-invocation-id", inpb.Invocation_COMPLETE_INVOCATION_STATUS)
 	assert.NoError(t, err)
 	cancel()
 
@@ -524,7 +524,7 @@ func TestFinishedFinalize(t *testing.T) {
 	assert.Equal(t, inpb.Invocation_PARTIAL_INVOCATION_STATUS, invocation.InvocationStatus)
 
 	// Finalize the invocation
-	err = channel.FinalizeInvocation("test-invocation-id")
+	err = channel.FinalizeInvocation("test-invocation-id", inpb.Invocation_COMPLETE_INVOCATION_STATUS)
 	assert.NoError(t, err)
 	cancel()
 
@@ -565,7 +565,7 @@ func TestUnfinishedFinalizeWithCanceledContext(t *testing.T) {
 	cancel()
 
 	// Finalize the invocation
-	err = channel.FinalizeInvocation("test-invocation-id")
+	err = channel.FinalizeInvocation("test-invocation-id", inpb.Invocation_DISCONNECTED_INVOCATION_STATUS)
 	assert.NoError(t, err)
 	cancel()
 
@@ -603,7 +603,7 @@ func TestUnfinishedFinalize(t *testing.T) {
 	assert.Equal(t, inpb.Invocation_PARTIAL_INVOCATION_STATUS, invocation.InvocationStatus)
 
 	// Finalize the invocation
-	err = channel.FinalizeInvocation("test-invocation-id")
+	err = channel.FinalizeInvocation("test-invocation-id", inpb.Invocation_DISCONNECTED_INVOCATION_STATUS)
 	assert.NoError(t, err)
 	cancel()
 
@@ -651,7 +651,7 @@ func TestRetryOnComplete(t *testing.T) {
 	assert.Equal(t, inpb.Invocation_PARTIAL_INVOCATION_STATUS, invocation.InvocationStatus)
 
 	// Finalize the invocation
-	err = channel.FinalizeInvocation("test-invocation-id")
+	err = channel.FinalizeInvocation("test-invocation-id", inpb.Invocation_COMPLETE_INVOCATION_STATUS)
 	assert.NoError(t, err)
 
 	// Make sure it gets finalized properly
@@ -715,7 +715,7 @@ func TestRetryOnDisconnect(t *testing.T) {
 	assert.Equal(t, inpb.Invocation_PARTIAL_INVOCATION_STATUS, invocation.InvocationStatus)
 
 	// Finalize the invocation
-	err = channel.FinalizeInvocation("test-invocation-id")
+	err = channel.FinalizeInvocation("test-invocation-id", inpb.Invocation_DISCONNECTED_INVOCATION_STATUS)
 	assert.NoError(t, err)
 
 	// Make sure it gets finalized properly
@@ -765,7 +765,7 @@ func TestRetryOnDisconnect(t *testing.T) {
 	assert.Equal(t, inpb.Invocation_PARTIAL_INVOCATION_STATUS, invocation.InvocationStatus)
 
 	// Finalize the invocation
-	err = channel.FinalizeInvocation("test-invocation-id")
+	err = channel.FinalizeInvocation("test-invocation-id", inpb.Invocation_COMPLETE_INVOCATION_STATUS)
 	assert.NoError(t, err)
 
 	// Make sure it gets finalized properly
@@ -810,7 +810,7 @@ func TestRetryOnOldDisconnect(t *testing.T) {
 	assert.Equal(t, inpb.Invocation_PARTIAL_INVOCATION_STATUS, invocation.InvocationStatus)
 
 	// Finalize the invocation
-	err = channel.FinalizeInvocation("test-invocation-id")
+	err = channel.FinalizeInvocation("test-invocation-id", inpb.Invocation_DISCONNECTED_INVOCATION_STATUS)
 	assert.NoError(t, err)
 
 	// Make sure it gets finalized properly

--- a/server/build_event_protocol/build_event_server/BUILD
+++ b/server/build_event_protocol/build_event_server/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:build_events_go_proto",
+        "//proto:invocation_go_proto",
         "//proto:publish_build_event_go_proto",
         "//server/environment",
         "//server/interfaces",

--- a/server/build_event_protocol/build_event_server/build_event_server.go
+++ b/server/build_event_protocol/build_event_server/build_event_server.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc"
 
 	bepb "github.com/buildbuddy-io/buildbuddy/proto/build_events"
+	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 )
 
@@ -72,7 +73,7 @@ func (s *BuildEventProtocolServer) PublishBuildToolEventStream(stream pepb.Publi
 	disconnectWithErr := func(e error) error {
 		if channel != nil && streamID != nil {
 			log.Warningf("Disconnecting invocation %q: %s", streamID.InvocationId, e)
-			if err := channel.FinalizeInvocation(streamID.InvocationId); err != nil {
+			if err := channel.FinalizeInvocation(streamID.InvocationId, inpb.Invocation_DISCONNECTED_INVOCATION_STATUS); err != nil {
 				log.Warningf("Error finalizing invocation %q during disconnect: %s", streamID.InvocationId, err)
 			}
 		}
@@ -123,7 +124,7 @@ func (s *BuildEventProtocolServer) PublishBuildToolEventStream(stream pepb.Publi
 	}
 
 	if channel != nil {
-		if err := channel.FinalizeInvocation(streamID.GetInvocationId()); err != nil {
+		if err := channel.FinalizeInvocation(streamID.GetInvocationId(), inpb.Invocation_COMPLETE_INVOCATION_STATUS); err != nil {
 			log.Warningf("Error finalizing invocation %q: %s", streamID.GetInvocationId(), err)
 			return err
 		}

--- a/server/build_event_protocol/build_event_server/build_event_server.go
+++ b/server/build_event_protocol/build_event_server/build_event_server.go
@@ -137,7 +137,7 @@ func (s *BuildEventProtocolServer) PublishBuildToolEventStream(stream pepb.Publi
 		}
 		if err := stream.Send(rsp); err != nil {
 			log.Warningf("Error sending ack stream for invocation %q: %s", streamID.InvocationId, err)
-			return disconnectWithErr(err)
+			return err
 		}
 	}
 	return nil

--- a/server/build_event_protocol/build_event_server/build_event_server.go
+++ b/server/build_event_protocol/build_event_server/build_event_server.go
@@ -125,7 +125,7 @@ func (s *BuildEventProtocolServer) PublishBuildToolEventStream(stream pepb.Publi
 	if channel != nil {
 		if err := channel.FinalizeInvocation(streamID.GetInvocationId()); err != nil {
 			log.Warningf("Error finalizing invocation %q: %s", streamID.GetInvocationId(), err)
-			return disconnectWithErr(err)
+			return err
 		}
 	}
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -134,7 +134,7 @@ type Authenticator interface {
 }
 
 type BuildEventChannel interface {
-	FinalizeInvocation(iid string) error
+	FinalizeInvocation(iid string, status inpb.Invocation_InvocationStatus) error
 	HandleEvent(event *pepb.PublishBuildToolEventStreamRequest) error
 	Close()
 }


### PR DESCRIPTION
It's possible that once we call `beValues.AddEvent(BuildFinished)`, we encounter an error, which would cause the invocation to terminate early and be finalized. However, because we saw the `BuildFinished` event, we'd mark the invocation with COMPLETED status, which would cause AlreadyExists to be returned on the subsequent retry.

Instead of switching on whether we saw the BuildFinished event, we now pass the status directly, basing the status on whether we're invoking FinalizeInvocation as the result of `disconnectWithErr` or as the result of successfully receiving all build events from Bazel.

Future work: Should we only mark the invocation COMPLETED after sending back all of the ACKs to Bazel? (Will Bazel attempt to retry if we don't ACK everything?)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/951
