### PR TITLE
Fix flaky invocation page test

### DIFF
--- a/server/test/webdriver/invocation/invocation_test.go
+++ b/server/test/webdriver/invocation/invocation_test.go
@@ -47,7 +47,7 @@ func TestInvocationPage_FailedInvocation_BESOnly(t *testing.T) {
 		"WORKSPACE": "",
 		"BUILD":     `genrule(name = "a", outs = ["a.sh"], cmd_bash = "exit 1")`,
 	})
-	buildArgs := append([]string{"//:a"}, app.BESBazelFlags()...)
+	buildArgs := append([]string{"//:a", "--show_progress=0"}, app.BESBazelFlags()...)
 	result := testbazel.Invoke(context.Background(), t, workspacePath, "build", buildArgs...)
 	require.NotEmpty(t, result.InvocationID)
 
@@ -66,5 +66,5 @@ func TestInvocationPage_FailedInvocation_BESOnly(t *testing.T) {
 	logs := wt.Find(".terminal").Text()
 
 	assert.Contains(t, logs, "Streaming build results to:")
-	assert.Contains(t, logs, "Build did NOT complete successfully")
+	assert.Contains(t, logs, "ERROR:")
 }

--- a/server/test/webdriver/invocation/invocation_test.go
+++ b/server/test/webdriver/invocation/invocation_test.go
@@ -37,7 +37,7 @@ func TestInvocationPage_SuccessfulInvocation_BESOnly(t *testing.T) {
 	logs := wt.Find(".terminal").Text()
 
 	assert.Contains(t, logs, "Streaming build results to:")
-	assert.Contains(t, logs, "Build completed successfully")
+	assert.Contains(t, logs, "Target //:a up-to-date:")
 }
 
 func TestInvocationPage_FailedInvocation_BESOnly(t *testing.T) {
@@ -66,5 +66,5 @@ func TestInvocationPage_FailedInvocation_BESOnly(t *testing.T) {
 	logs := wt.Find(".terminal").Text()
 
 	assert.Contains(t, logs, "Streaming build results to:")
-	assert.Contains(t, logs, "Build did NOT complete successfully")
+	assert.Contains(t, logs, "Target //:a failed to build")
 }

--- a/server/test/webdriver/invocation/invocation_test.go
+++ b/server/test/webdriver/invocation/invocation_test.go
@@ -18,7 +18,7 @@ func TestInvocationPage_SuccessfulInvocation_BESOnly(t *testing.T) {
 		"WORKSPACE": "",
 		"BUILD":     `genrule(name = "a", outs = ["a.sh"], cmd_bash = "touch $@")`,
 	})
-	buildArgs := append([]string{"//:a"}, app.BESBazelFlags()...)
+	buildArgs := append([]string{"//:a", "--show_progress=0"}, app.BESBazelFlags()...)
 	result := testbazel.Invoke(context.Background(), t, workspacePath, "build", buildArgs...)
 	require.NotEmpty(t, result.InvocationID)
 
@@ -66,5 +66,5 @@ func TestInvocationPage_FailedInvocation_BESOnly(t *testing.T) {
 	logs := wt.Find(".terminal").Text()
 
 	assert.Contains(t, logs, "Streaming build results to:")
-	assert.Contains(t, logs, "ERROR:")
+	assert.Contains(t, logs, "Build did NOT complete successfully")
 }


### PR DESCRIPTION
Adding `--show_progress=0` prevents the logs from being as variable in length for invocations that happen to take longer to run (so we can do assertions more reliably on what is shown in the logs viewport).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
