### PR TITLE
Add a fileresolver util to locate bundled files with runfiles fallback

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -127,7 +127,7 @@ go_library(
     }),
     importpath = "github.com/buildbuddy-io/buildbuddy",
     deps = [
-        "//server/util/log",
+        "//server/util/fileresolver",
     ],
 )
 

--- a/bundle.go
+++ b/bundle.go
@@ -3,9 +3,8 @@ package buildbuddy
 import (
 	"embed"
 	"io/fs"
-	"strings"
 
-	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/fileresolver"
 )
 
 // NB: We cannot embed "static", "bazel-out", etc here, because when this
@@ -16,57 +15,6 @@ import (
 //go:embed *
 var all embed.FS
 
-type aliasFS struct {
-	FS            embed.FS
-	remappedPaths map[string]string
-}
-
-func (a *aliasFS) Open(name string) (fs.File, error) {
-	fileAlias, ok := a.remappedPaths[name]
-	if ok {
-		return a.FS.Open(fileAlias)
-	}
-	return a.FS.Open(name)
-}
-
 func Get() (fs.FS, error) {
-	afs := &aliasFS{
-		FS:            all,
-		remappedPaths: make(map[string]string, 0),
-	}
-	// This is annoying but necessary -- we bundle some binary files that
-	// end up in a bazel-out/$arch/bin directory. Rather than try to read
-	// them by their full name, which is $arch dependent, we glob them
-	// and alias them under a path that does not contain the $arch
-	// component. This path also matches what is present in the os.FS,
-	// so callsites that read these files do not need to change at all.
-	pathsToAlias := []string{
-		"bazel-out/*/bin",
-	}
-	for _, p := range pathsToAlias {
-		matches, err := fs.Glob(all, p)
-		if err != nil {
-			return nil, err
-		}
-		for _, match := range matches {
-			fs.WalkDir(all, match, func(path string, d fs.DirEntry, err error) error {
-				if path == match {
-					return nil
-				}
-				// This basically takes a path like:
-				//   'bazel-out/k8-fastbuild/bin/app/app_bundle.js'
-				// and aliases it under the new name:
-				//   'bin/app/app_bundle.js'
-				// complaining if anything was already aliased there.
-				unaliasedPath := strings.TrimPrefix(path, match+"/")
-				if _, ok := afs.remappedPaths[unaliasedPath]; ok {
-					log.Warningf("Named collision in bundled files: %q => %q", path, unaliasedPath)
-					return nil
-				}
-				afs.remappedPaths[unaliasedPath] = path
-				return nil
-			})
-		}
-	}
-	return afs, nil
+	return fileresolver.GetBundleFS(all)
 }

--- a/enterprise/BUILD
+++ b/enterprise/BUILD
@@ -42,7 +42,6 @@ go_library(
         "//enterprise:licenses",
         "//:config_files",
         "//static",
-        "//enterprise/server/cmd/ci_runner:buildbuddy_ci_runner",
         "//enterprise/vmsupport/bin:vmlinux",
         "//enterprise/vmsupport/bin:initrd.cpio",
     ] + select({
@@ -51,6 +50,7 @@ go_library(
             "//enterprise/app:app_bundle",
             "//enterprise/app:style",
             "//enterprise/app:sha",
+            "//enterprise/server/cmd/ci_runner:buildbuddy_ci_runner",
         ],
     }),
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise",

--- a/enterprise/BUILD
+++ b/enterprise/BUILD
@@ -42,6 +42,7 @@ go_library(
         "//enterprise:licenses",
         "//:config_files",
         "//static",
+        "//enterprise/server/cmd/ci_runner:buildbuddy_ci_runner",
         "//enterprise/vmsupport/bin:vmlinux",
         "//enterprise/vmsupport/bin:initrd.cpio",
     ] + select({

--- a/enterprise/BUILD
+++ b/enterprise/BUILD
@@ -1,6 +1,6 @@
-package(default_visibility = [":__subpackages__"])
-
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = [":__subpackages__"])
 
 filegroup(
     name = "config_files",
@@ -56,6 +56,5 @@ go_library(
     visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//server/util/fileresolver",
-        "//server/util/log",
     ],
 )

--- a/enterprise/BUILD
+++ b/enterprise/BUILD
@@ -55,6 +55,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise",
     visibility = ["//enterprise:__subpackages__"],
     deps = [
+        "//server/util/fileresolver",
         "//server/util/log",
     ],
 )

--- a/enterprise/bundle.go
+++ b/enterprise/bundle.go
@@ -3,9 +3,8 @@ package enterprise
 import (
 	"embed"
 	"io/fs"
-	"strings"
 
-	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/fileresolver"
 )
 
 // NB: We cannot embed "static", "bazel-out", etc here, because when this
@@ -16,57 +15,6 @@ import (
 //go:embed *
 var all embed.FS
 
-type aliasFS struct {
-	embed.FS
-	remappedPaths map[string]string
-}
-
-func (a *aliasFS) Open(name string) (fs.File, error) {
-	fileAlias, ok := a.remappedPaths[name]
-	if ok {
-		return a.FS.Open(fileAlias)
-	}
-	return a.FS.Open(name)
-}
-
 func Get() (fs.FS, error) {
-	afs := &aliasFS{
-		FS:            all,
-		remappedPaths: make(map[string]string, 0),
-	}
-	// This is annoying but necesary -- we bundle some binary files that
-	// end up in a bazel-out/$arch/bin directory. Rather than try to read
-	// them by their full name, which is $arch dependent, we glob them
-	// and alias them under a path that does not contain the $arch
-	// component. This path also matches what is present in the os.FS,
-	// so callsites that read these files do not need to change at all.
-	pathsToAlias := []string{
-		"bazel-out/*/bin",
-	}
-	for _, p := range pathsToAlias {
-		matches, err := fs.Glob(all, p)
-		if err != nil {
-			return nil, err
-		}
-		for _, match := range matches {
-			fs.WalkDir(all, match, func(path string, d fs.DirEntry, err error) error {
-				if path == match {
-					return nil
-				}
-				// This basically takes a path like:
-				//   'bazel-out/k8-fastbuild/bin/app/app_bundle.js'
-				// and aliases it under the new name:
-				//   'bin/app/app_bundle.js'
-				// complaining if anything was already aliased there.
-				unaliasedPath := strings.TrimPrefix(path, match+"/")
-				if _, ok := afs.remappedPaths[unaliasedPath]; ok {
-					log.Warningf("Named collision in bundled files: %q => %q", path, unaliasedPath)
-					return nil
-				}
-				afs.remappedPaths[unaliasedPath] = path
-				return nil
-			})
-		}
-	}
-	return afs, nil
+	return fileresolver.GetBundleFS(all)
 }

--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -1,14 +1,17 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
+package(
+    default_visibility = [
+        "//enterprise:__subpackages__",
+        "@buildbuddy_internal//enterprise:__subpackages__",
+    ],
+)
+
 go_library(
     name = "main",
     srcs = ["main.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/ci_runner",
-    visibility = [
-        "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
-    ],
     deps = [
         "//enterprise/server/build_event_publisher",
         "//enterprise/server/workflow/config",
@@ -30,10 +33,13 @@ go_binary(
     embed = [":main"],
     pure = "on",
     static = "on",
-    visibility = [
-        "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
-    ],
+)
+
+genrule(
+    name = "embedsrcs_compatible_ci_runner",
+    srcs = [":ci_runner"],
+    outs = ["buildbuddy_ci_runner"],
+    cmd_bash = "cp $(SRCS) $@",
 )
 
 # Note: the CI runner image only includes the setup needed for the CI runner;
@@ -43,18 +49,10 @@ container_image(
     name = "ci_runner_image",
     base = "@ci_runner_image//image:dockerfile_image.tar",
     tags = ["manual"],
-    visibility = [
-        "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
-    ],
 )
 
 container_image(
     name = "ci_runner_debug_image",
     base = "@ci_runner_debug_image//image:dockerfile_image.tar",
     tags = ["manual"],
-    visibility = [
-        "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
-    ],
 )

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/executor",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise:bundle",
         "//enterprise/server/auth",
         "//enterprise/server/backends/gcs_cache",
         "//enterprise/server/backends/memcache",

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//server/remote_cache/byte_stream_server",
         "//server/remote_cache/content_addressable_storage_server",
         "//server/resources",
+        "//server/util/fileresolver",
         "//server/util/grpc_client",
         "//server/util/grpc_server",
         "//server/util/healthcheck",

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -42,6 +42,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/test/bufconn"
 
+	bundle "github.com/buildbuddy-io/buildbuddy/enterprise"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
@@ -114,6 +115,12 @@ func GetConfiguredEnvironmentOrDie(configurator *config.Configurator, healthChec
 	if executorConfig.Pool != "" && resources.GetPoolName() != "" {
 		log.Fatal("Only one of the `MY_POOL` environment variable and `executor.pool` config option may be set")
 	}
+
+	bundleFS, err := bundle.Get()
+	if err != nil {
+		log.Fatalf("Failed to initialize bundle: %s", err)
+	}
+	realEnv.SetFileResolver(fileresolver.New(bundleFS, "enterprise"))
 
 	authenticator, err := auth.NewOpenIDAuthenticator(context.Background(), realEnv)
 	if err == nil {

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/byte_stream_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/content_addressable_storage_server"
 	"github.com/buildbuddy-io/buildbuddy/server/resources"
+	"github.com/buildbuddy-io/buildbuddy/server/util/fileresolver"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
 	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -46,6 +46,7 @@ go_library(
         "//server/real_environment",
         "//server/static",
         "//server/telemetry",
+        "//server/util/fileresolver",
         "//server/util/grpc_client",
         "//server/util/healthcheck",
         "//server/util/log",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/static"
 	"github.com/buildbuddy-io/buildbuddy/server/telemetry"
+	"github.com/buildbuddy-io/buildbuddy/server/util/fileresolver"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -84,11 +85,12 @@ func configureFilesystemsOrDie(realEnv *real_environment.RealEnv) {
 			realEnv.SetAppFilesystem(appFS)
 		}
 	}
+	bundleFS, err := bundle.Get()
+	if err != nil {
+		log.Fatalf("Error getting bundle FS: %s", err)
+	}
+	realEnv.SetFileResolver(fileresolver.New(bundleFS, "enterprise"))
 	if realEnv.GetAppFilesystem() == nil {
-		bundleFS, err := bundle.Get()
-		if err != nil {
-			log.Fatalf("Error getting bundle FS: %s", err)
-		}
 		if realEnv.GetAppFilesystem() == nil {
 			appFS, err := fs.Sub(bundleFS, "app")
 			if err != nil {

--- a/enterprise/server/hostedrunner/BUILD
+++ b/enterprise/server/hostedrunner/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//server/util/status",
         "@com_github_google_uuid//:uuid",
         "@go_googleapis//google/longrunning:longrunning_go_proto",
-        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
         "@org_golang_google_grpc//status",
     ],
 )

--- a/enterprise/server/hostedrunner/BUILD
+++ b/enterprise/server/hostedrunner/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "hostedrunner",
     srcs = ["hostedrunner.go"],
+    data = ["//enterprise/server/cmd/ci_runner:buildbuddy_ci_runner"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/hostedrunner",
     visibility = ["//visibility:public"],
     deps = [

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -3,11 +3,10 @@ package hostedrunner
 import (
 	"context"
 	"io"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"time"
 
-	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/operation"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/tasksize"
@@ -27,23 +26,22 @@ import (
 )
 
 const (
-	runnerBinaryRunfile  = "enterprise/server/cmd/ci_runner/ci_runner_/ci_runner"
+	runnerPath           = "enterprise/server/cmd/ci_runner/buildbuddy_ci_runner"
 	runnerContainerImage = "docker://gcr.io/flame-public/buildbuddy-ci-runner@sha256:fbff6d1e88e9e1085c7e46bd0c5de4f478e97b630246631e5f9d7c720c968e2e"
 )
 
 type runnerService struct {
-	env              environment.Env
-	runnerBinaryPath string
+	env environment.Env
 }
 
 func New(env environment.Env) (*runnerService, error) {
-	runnerPath, err := bazel.Runfile(runnerBinaryRunfile)
+	f, err := env.GetFileResolver().Open(runnerPath)
 	if err != nil {
-		return nil, status.FailedPreconditionErrorf("could not find runner binary runfile: %s", err)
+		return nil, status.FailedPreconditionErrorf("could not open runner binary runfile: %s", err)
 	}
+	defer f.Close()
 	return &runnerService{
-		env:              env,
-		runnerBinaryPath: runnerPath,
+		env: env,
 	}, nil
 }
 
@@ -100,7 +98,7 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 	if err != nil {
 		return nil, err
 	}
-	binaryBlob, err := os.ReadFile(r.runnerBinaryPath)
+	binaryBlob, err := fs.ReadFile(r.env.GetFileResolver(), runnerPath)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +107,7 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		return nil, err
 	}
 	// Save this to use when constructing the command to run below.
-	runnerName := filepath.Base(r.runnerBinaryPath)
+	runnerName := filepath.Base(runnerPath)
 	dir := &repb.Directory{
 		Files: []*repb.FileNode{{
 			Name:         runnerName,

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -22,7 +22,6 @@ go_library(
             "//server/util/status",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
-            "//enterprise:bundle",
             "//enterprise/server/remote_execution/commandutil",
             "//enterprise/server/remote_execution/container",
             "//enterprise/server/remote_execution/snaploader",
@@ -44,7 +43,6 @@ go_library(
             "@com_github_firecracker_microvm_firecracker_go_sdk//client/models",
             "@com_github_google_uuid//:uuid",
             "@com_github_sirupsen_logrus//:logrus",
-            "@io_bazel_rules_go//go/tools/bazel:go_default_library",
             "@org_golang_x_sys//unix",
         ],
         "//conditions:default": [],

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaploader"
@@ -36,7 +35,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
-	bundle "github.com/buildbuddy-io/buildbuddy/enterprise"
 	containerutil "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/container"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	vmxpb "github.com/buildbuddy-io/buildbuddy/proto/vmexec"

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -140,11 +140,11 @@ func putFileIntoDir(ctx context.Context, env environment.Env, fileName, destDir 
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
 	// If fileReader is still nil, the file was not found, so return an error.
 	if f == nil {
 		return "", status.NotFoundErrorf("File %q not found on fs, in runfiles or in bundle.", fileName)
 	}
+	defer f.Close()
 
 	// Compute the file hash to determine the new location where it should be written.
 	h := sha256.New()

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -119,43 +119,15 @@ var (
 	vmIdxMu sync.Mutex
 )
 
-func getFileReader(ctx context.Context, fileName string) (io.Reader, error) {
-	sourcePath := ""
-
+func openFile(ctx context.Context, env environment.Env, fileName string) (io.ReadCloser, error) {
 	// If the file exists on the filesystem, use that.
-	if fp, err := exec.LookPath(fileName); err == nil {
-		log.Debugf("Located %q at %s", fileName, fp)
-		sourcePath = fp
+	if path, err := exec.LookPath(fileName); err == nil {
+		log.Debugf("Located %q at %s", fileName, path)
+		return os.Open(path)
 	}
 
-	// If the file exists in the binary runfiles, that works too.
-	if rfp, err := bazel.RunfilesPath(); err == nil {
-		targetFile := filepath.Join(rfp, "enterprise", fileName)
-		if exists, err := disk.FileExists(targetFile); err == nil && exists {
-			log.Debugf("Located %q at %s", fileName, targetFile)
-			sourcePath = targetFile
-		}
-	}
-
-	var fileReader io.Reader
-	if sourcePath != "" {
-		reader, err := disk.FileReader(ctx, sourcePath, 0, 0)
-		if err != nil {
-			return nil, err
-		}
-		fileReader = reader
-	}
-
-	// If file wasn't found, check the bundle, it may be available there.
-	if fileReader == nil {
-		if bundleFS, err := bundle.Get(); err == nil {
-			if f, err := bundleFS.Open(fileName); err == nil {
-				log.Debugf("Located %q in bundle", fileName)
-				fileReader = f
-			}
-		}
-	}
-	return fileReader, nil
+	// Otherwise try to find it in the bundle or runfiles.
+	return env.GetFileResolver().Open(fileName)
 }
 
 // putFileIntoDir finds "fileName" on the local filesystem, in runfiles, or
@@ -163,19 +135,20 @@ func getFileReader(ctx context.Context, fileName string) (io.Reader, error) {
 // and returns a path to the file in the new location. Files are written in
 // a content-addressable-storage-based location, so when files are updated they
 // will be put into new paths.
-func putFileIntoDir(ctx context.Context, fileName, destDir string, mode fs.FileMode) (string, error) {
-	fileReader, err := getFileReader(ctx, fileName)
+func putFileIntoDir(ctx context.Context, env environment.Env, fileName, destDir string, mode fs.FileMode) (string, error) {
+	f, err := openFile(ctx, env, fileName)
 	if err != nil {
 		return "", err
 	}
+	defer f.Close()
 	// If fileReader is still nil, the file was not found, so return an error.
-	if fileReader == nil {
+	if f == nil {
 		return "", status.NotFoundErrorf("File %q not found on fs, in runfiles or in bundle.", fileName)
 	}
 
 	// Compute the file hash to determine the new location where it should be written.
 	h := sha256.New()
-	if _, err := io.Copy(h, fileReader); err != nil {
+	if _, err := io.Copy(h, f); err != nil {
 		return "", err
 	}
 	fileHash := fmt.Sprintf("%x", h.Sum(nil))
@@ -189,15 +162,16 @@ func putFileIntoDir(ctx context.Context, fileName, destDir string, mode fs.FileM
 		return casPath, nil
 	}
 	// Write the file to the new location if it does not exist there already.
-	fileReader, err = getFileReader(ctx, fileName)
+	f, err = openFile(ctx, env, fileName)
 	if err != nil {
 		return "", err
 	}
+	defer f.Close()
 	writer, err := disk.FileWriter(ctx, casPath)
 	if err != nil {
 		return "", err
 	}
-	if _, err := io.Copy(writer, fileReader); err != nil {
+	if _, err := io.Copy(writer, f); err != nil {
 		return "", err
 	}
 	if err := writer.Close(); err != nil {
@@ -336,7 +310,7 @@ func NewContainer(env environment.Env, imageCacheAuth *container.ImageCacheAuthe
 	// Ensure our kernel and initrd exist on the same filesystem where we'll
 	// be jailing containers. This allows us to hardlink these files rather
 	// than copying them around over and over again.
-	if err := copyStaticFiles(context.Background(), opts.JailerRoot); err != nil {
+	if err := copyStaticFiles(context.Background(), env, opts.JailerRoot); err != nil {
 		return nil, err
 	}
 
@@ -689,13 +663,13 @@ func (c *FirecrackerContainer) getConfig(ctx context.Context, containerFS, works
 	return cfg, nil
 }
 
-func copyStaticFiles(ctx context.Context, workingDir string) error {
+func copyStaticFiles(ctx context.Context, env environment.Env, workingDir string) error {
 	locateBinariesOnce.Do(func() {
-		initrdImagePath, locateBinariesError = putFileIntoDir(ctx, "vmsupport/bin/initrd.cpio", workingDir, 0755)
+		initrdImagePath, locateBinariesError = putFileIntoDir(ctx, env, "enterprise/vmsupport/bin/initrd.cpio", workingDir, 0755)
 		if locateBinariesError != nil {
 			return
 		}
-		kernelImagePath, locateBinariesError = putFileIntoDir(ctx, "vmsupport/bin/vmlinux", workingDir, 0755)
+		kernelImagePath, locateBinariesError = putFileIntoDir(ctx, env, "enterprise/vmsupport/bin/vmlinux", workingDir, 0755)
 		if locateBinariesError != nil {
 			return
 		}

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -76,4 +76,5 @@ type Env interface {
 	GetUsageService() interfaces.UsageService
 	GetUsageTracker() interfaces.UsageTracker
 	GetXCodeLocator() interfaces.XcodeLocator
+	GetFileResolver() fs.FS
 }

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -36,7 +36,11 @@ type Env interface {
 	// Optional dependencies below here. For example: enterprise-only things,
 	// or services that may not always be configured, like webhooks.
 	GetDBHandle() *db.DBHandle
+	// GetStaticFilesystem returns the FS that is used to serve from the /static
+	// directory.
 	GetStaticFilesystem() fs.FS
+	// GetAppFilesystem returns the FS used to serve JS and CSS resources needed
+	// by the app, including the app bundle and any lazily loaded JS chunks.
 	GetAppFilesystem() fs.FS
 	GetBlobstore() interfaces.Blobstore
 	GetInvocationDB() interfaces.InvocationDB
@@ -76,5 +80,10 @@ type Env interface {
 	GetUsageService() interfaces.UsageService
 	GetUsageTracker() interfaces.UsageTracker
 	GetXCodeLocator() interfaces.XcodeLocator
+	// GetFileResolver returns an FS that can be used to read server-side
+	// resources that aren't intended to be directly served to end users. It first
+	// consults the bundle and falls back to runfiles.
+	//
+	// See server/util/fileresolver/fileresolver.go
 	GetFileResolver() fs.FS
 }

--- a/server/libmain/BUILD
+++ b/server/libmain/BUILD
@@ -44,6 +44,7 @@ go_library(
         "//server/ssl",
         "//server/static",
         "//server/util/db",
+        "//server/util/fileresolver",
         "//server/util/grpc_server",
         "//server/util/healthcheck",
         "//server/util/log",

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -39,6 +39,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/ssl"
 	"github.com/buildbuddy-io/buildbuddy/server/static"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
+	"github.com/buildbuddy-io/buildbuddy/server/util/fileresolver"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
 	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -110,11 +111,12 @@ func configureFilesystemsOrDie(realEnv *real_environment.RealEnv) {
 		}
 		realEnv.SetAppFilesystem(appFS)
 	}
+	bundleFS, err := bundle.Get()
+	if err != nil {
+		log.Fatalf("Error getting bundle FS: %s", err)
+	}
+	realEnv.SetFileResolver(fileresolver.New(bundleFS, ""))
 	if realEnv.GetStaticFilesystem() == nil || realEnv.GetAppFilesystem() == nil {
-		bundleFS, err := bundle.Get()
-		if err != nil {
-			log.Fatalf("Error getting bundle FS: %s", err)
-		}
 		if realEnv.GetStaticFilesystem() == nil {
 			staticFS, err := fs.Sub(bundleFS, "static")
 			if err != nil {

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -76,6 +76,7 @@ type RealEnv struct {
 	buildEventProxyClients           []pepb.PublishBuildEventClient
 	webhooks                         []interfaces.Webhook
 	xcodeLocator                     interfaces.XcodeLocator
+	fileResolver                     fs.FS
 }
 
 func NewRealEnv(c *config.Configurator, h interfaces.HealthChecker) *RealEnv {
@@ -360,4 +361,12 @@ func (r *RealEnv) SetRemoteExecutionRedisPubSubClient(client *redis.Client) {
 
 func (r *RealEnv) GetRemoteExecutionRedisPubSubClient() *redis.Client {
 	return r.remoteExecutionRedisPubSubClient
+}
+
+func (r *RealEnv) GetFileResolver() fs.FS {
+	return r.fileResolver
+}
+
+func (r *RealEnv) SetFileResolver(fr fs.FS) {
+	r.fileResolver = fr
 }

--- a/server/util/fileresolver/BUILD
+++ b/server/util/fileresolver/BUILD
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "fileresolver",
+    srcs = ["fileresolver.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/fileresolver",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/util/log",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+    ],
+)
+
+go_test(
+    name = "fileresolver_test",
+    srcs = ["fileresolver_test.go"],
+    deps = [
+        ":fileresolver",
+        "//server/util/fileresolver/test_data:bundle",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/util/fileresolver/fileresolver.go
+++ b/server/util/fileresolver/fileresolver.go
@@ -1,0 +1,117 @@
+package fileresolver
+
+import (
+	"embed"
+	"io/fs"
+	"os"
+	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+
+	bazelgo "github.com/bazelbuild/rules_go/go/tools/bazel"
+)
+
+type aliasFS struct {
+	FS            embed.FS
+	remappedPaths map[string]string
+}
+
+// GetBundleFS returns an FS that reads files directly from the given embed.FS,
+// aliasing any paths like "bazel-out/$arch/bin/$path" to "bin/$path" to provide
+// a simpler interface for dealing with architecture-specific paths.
+func GetBundleFS(bundle embed.FS) (fs.FS, error) {
+	afs := &aliasFS{
+		FS:            bundle,
+		remappedPaths: make(map[string]string, 0),
+	}
+	// This is annoying but necessary -- we bundle some binary files that
+	// end up in a bazel-out/$arch/bin directory. Rather than try to read
+	// them by their full name, which is $arch dependent, we glob them
+	// and alias them under a path that does not contain the $arch
+	// component. This path also matches what is present in the os.FS,
+	// so callsites that read these files do not need to change at all.
+	pathsToAlias := []string{
+		"bazel-out/*/bin",
+	}
+	for _, p := range pathsToAlias {
+		matches, err := fs.Glob(bundle, p)
+		if err != nil {
+			return nil, err
+		}
+		for _, match := range matches {
+			fs.WalkDir(bundle, match, func(path string, d fs.DirEntry, err error) error {
+				if path == match {
+					return nil
+				}
+				// This basically takes a path like:
+				//   'bazel-out/k8-fastbuild/bin/app/app_bundle.js'
+				// and aliases it under the new name:
+				//   'bin/app/app_bundle.js'
+				// complaining if anything was already aliased there.
+				unaliasedPath := strings.TrimPrefix(path, match+"/")
+				if _, ok := afs.remappedPaths[unaliasedPath]; ok {
+					log.Warningf("Named collision in bundled files: %q => %q", path, unaliasedPath)
+					return nil
+				}
+				afs.remappedPaths[unaliasedPath] = path
+				return nil
+			})
+		}
+	}
+	return afs, nil
+}
+
+func (a *aliasFS) Open(name string) (fs.File, error) {
+	fileAlias, ok := a.remappedPaths[name]
+	if ok {
+		return a.FS.Open(fileAlias)
+	}
+	return a.FS.Open(name)
+}
+
+type fileResolver struct {
+	bundleFS     fs.FS
+	bundlePrefix string
+}
+
+// Open resolves a logical path to a local file, where the path is relative to
+// the Bazel workspace root. It first consults the bundle, then Bazel runfiles.
+//
+// `os.NotExists` can be used to check whether the file does not exist, if an
+// error is returned. The caller is responsible for closing the returned file.
+func (r *fileResolver) Open(name string) (fs.File, error) {
+	if strings.HasPrefix(name, r.bundlePrefix) {
+		f, err := r.bundleFS.Open(strings.TrimPrefix(name, r.bundlePrefix))
+		if err == nil {
+			return f, nil
+		}
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+
+	runfilePath, err := bazelgo.Runfile(name)
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(runfilePath)
+}
+
+// New returns an FS that looks up files first from the bundle, then from
+// bazel runfiles.
+//
+// The bundleRoot specifies the parent directory of the bundle FS, relative
+// to the workspace root. For example, if the bundle is located at
+// foo/bar/bundle.go, bundleRoot should be set to foo/bar. Files will only
+// be looked up from the bundle if they start with this prefix. We will always
+// consult runfiles regardless of whether they begin with this prefix.
+func New(bundleFS fs.FS, bundleRoot string) fs.FS {
+	bundlePrefix := ""
+	if bundleRoot != "" && !strings.HasSuffix(bundleRoot, string(os.PathSeparator)) {
+		bundlePrefix = bundleRoot + string(os.PathSeparator)
+	}
+	return &fileResolver{
+		bundleFS:     bundleFS,
+		bundlePrefix: bundlePrefix,
+	}
+}

--- a/server/util/fileresolver/fileresolver_test.go
+++ b/server/util/fileresolver/fileresolver_test.go
@@ -1,0 +1,25 @@
+package fileresolver_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/fileresolver"
+	"github.com/stretchr/testify/require"
+
+	bundle "github.com/buildbuddy-io/buildbuddy/server/util/fileresolver/test_data"
+)
+
+func TestFileResolver(t *testing.T) {
+	paths := []string{
+		"server/util/fileresolver/test_data/embedded_dir/embedded_child.txt",
+		"server/util/fileresolver/test_data/embedded_file.txt",
+		"server/util/fileresolver/test_data/runfile.txt",
+	}
+
+	resolver := fileresolver.New(bundle.FS, "server/util/fileresolver/test_data")
+	for _, path := range paths {
+		f, err := resolver.Open(path)
+		require.NoError(t, err)
+		f.Close()
+	}
+}

--- a/server/util/fileresolver/test_data/BUILD
+++ b/server/util/fileresolver/test_data/BUILD
@@ -22,7 +22,13 @@ go_library(
     name = "bundle",
     srcs = ["bundle.go"],
     data = [":runfiles"],
-    embedsrcs = [":embedsrcs"],
+    embedsrcs = [
+        "BUILD",
+        "bundle.go",
+        "embedded_dir/embedded_child.txt",
+        "embedded_file.txt",
+        "runfile.txt",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/fileresolver/test_data",
     visibility = ["//visibility:public"],
 )

--- a/server/util/fileresolver/test_data/BUILD
+++ b/server/util/fileresolver/test_data/BUILD
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(
+    default_testonly = 1,
+    default_visibility = ["//server/util/fileresolver:__subpackages__"],
+)
+
+filegroup(
+    name = "embedsrcs",
+    srcs = [
+        "embedded_dir/embedded_child.txt",
+        "embedded_file.txt",
+    ],
+)
+
+filegroup(
+    name = "runfiles",
+    srcs = ["runfile.txt"],
+)
+
+go_library(
+    name = "bundle",
+    srcs = ["bundle.go"],
+    data = [":runfiles"],
+    embedsrcs = [":embedsrcs"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/fileresolver/test_data",
+    visibility = ["//visibility:public"],
+)

--- a/server/util/fileresolver/test_data/bundle.go
+++ b/server/util/fileresolver/test_data/bundle.go
@@ -1,4 +1,4 @@
-package bundle_and_runfiles
+package bundle
 
 import "embed"
 

--- a/server/util/fileresolver/test_data/bundle.go
+++ b/server/util/fileresolver/test_data/bundle.go
@@ -1,0 +1,6 @@
+package bundle_and_runfiles
+
+import "embed"
+
+//go:embed *
+var FS embed.FS

--- a/server/util/fileresolver/test_data/embedded_file.txt
+++ b/server/util/fileresolver/test_data/embedded_file.txt
@@ -1,0 +1,1 @@
+Hello from embed_file

--- a/server/util/fileresolver/test_data/embedded_file.txt
+++ b/server/util/fileresolver/test_data/embedded_file.txt
@@ -1,1 +1,0 @@
-Hello from embed_file


### PR DESCRIPTION
Also use the fileresolver in a few places:
* firecracker.go (simplifies the logic for resolving paths to vmlinux, etc.)
* hostedrunner.go (fixes a bug that the server fails to start because we don't have runfiles available when running the enterprise app as a standalone binary)

This will also be useful for https://github.com/buildbuddy-io/buildbuddy/pull/1193

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
