### PR TITLE
Fix dropdown appearance in Safari

### DIFF
--- a/app/components/input/input.css
+++ b/app/components/input/input.css
@@ -5,6 +5,7 @@
   padding: 8px 16px;
   box-sizing: border-box;
   appearance: none;
+  -webkit-appearance: none;
   border: 1px solid gray;
   border-radius: 2px;
 }

--- a/app/components/select/select.css
+++ b/app/components/select/select.css
@@ -14,6 +14,7 @@
   transition: border 200ms ease;
   background-color: transparent;
   appearance: none;
+  -webkit-appearance: none;
   padding-right: 40px;
   cursor: pointer;
 }

--- a/enterprise/app/org/org.css
+++ b/enterprise/app/org/org.css
@@ -55,6 +55,7 @@
   padding: 16px;
   box-sizing: border-box;
   appearance: none;
+  -webkit-appearance: none;
   border: 1px solid gray;
   border-radius: 2px;
 }


### PR DESCRIPTION
* Add `-webkit-appearance` vendor prefix, since Safari doesn't yet support `appearance`
* Make `appearance` settings consistent in a few other places

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/963
