### PR TITLE
Only increment invocation usage after inserting a new invocation row

### DIFF
--- a/server/backends/invocationdb/invocationdb.go
+++ b/server/backends/invocationdb/invocationdb.go
@@ -66,9 +66,9 @@ func (d *InvocationDB) InsertOrUpdateInvocation(ctx context.Context, ti *tables.
 				return err
 			}
 			if err := d.createInvocation(tx, ctx, ti); err != nil {
-				created = true
 				return err
 			}
+			created = true
 			return nil
 		}
 		return tx.Model(&existing).Where("invocation_id = ?", ti.InvocationID).Updates(ti).Error

--- a/server/backends/invocationdb/invocationdb.go
+++ b/server/backends/invocationdb/invocationdb.go
@@ -53,17 +53,27 @@ func (d *InvocationDB) createInvocation(tx *db.DB, ctx context.Context, ti *tabl
 	return tx.Create(ti).Error
 }
 
-func (d *InvocationDB) InsertOrUpdateInvocation(ctx context.Context, ti *tables.Invocation) error {
-	return d.h.Transaction(ctx, func(tx *db.DB) error {
+// InsertOrUpdateInvocation checks whether an invocation with the same primary
+// key as the given invocation exists. If no such invocation exists, it will
+// create a new row with the given invocation properties. Otherwise, it will
+// update the existing invocation. It returns whether a new row was created.
+func (d *InvocationDB) InsertOrUpdateInvocation(ctx context.Context, ti *tables.Invocation) (bool, error) {
+	created := false
+	err := d.h.Transaction(ctx, func(tx *db.DB) error {
 		var existing tables.Invocation
 		if err := tx.Where("invocation_id = ?", ti.InvocationID).First(&existing).Error; err != nil {
 			if !db.IsRecordNotFound(err) {
 				return err
 			}
-			return d.createInvocation(tx, ctx, ti)
+			if err := d.createInvocation(tx, ctx, ti); err != nil {
+				created = true
+				return err
+			}
+			return nil
 		}
 		return tx.Model(&existing).Where("invocation_id = ?", ti.InvocationID).Updates(ti).Error
 	})
+	return created, err
 }
 
 func (d *InvocationDB) UpdateInvocationACL(ctx context.Context, authenticatedUser *interfaces.UserInfo, invocationID string, acl *aclpb.ACL) error {

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -211,7 +211,7 @@ func (r *statsRecorder) Start() {
 				if stats := hit_tracker.CollectCacheStats(ctx, r.env, task.invocationJWT.id); stats != nil {
 					fillInvocationFromCacheStats(stats, ti)
 				}
-				if err := r.env.GetInvocationDB().InsertOrUpdateInvocation(ctx, ti); err != nil {
+				if _, err := r.env.GetInvocationDB().InsertOrUpdateInvocation(ctx, ti); err != nil {
 					log.Errorf("Failed to write cache stats for invocation: %s", err)
 				}
 				// Cleanup regardless of whether the stats are flushed successfully to
@@ -466,7 +466,7 @@ func (e *EventChannel) FinalizeInvocation(iid string, status inpb.Invocation_Inv
 
 	ti := tableInvocationFromProto(invocation, iid)
 	recordInvocationMetrics(ti)
-	if err := e.env.GetInvocationDB().InsertOrUpdateInvocation(ctx, ti); err != nil {
+	if _, err := e.env.GetInvocationDB().InsertOrUpdateInvocation(ctx, ti); err != nil {
 		return err
 	}
 
@@ -615,14 +615,16 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 		if e.logWriter != nil {
 			ti.LastChunkId = e.logWriter.GetLastChunkId()
 		}
-		if err := e.env.GetInvocationDB().InsertOrUpdateInvocation(e.ctx, ti); err != nil {
+		created, err := e.env.GetInvocationDB().InsertOrUpdateInvocation(e.ctx, ti)
+		if err != nil {
 			return err
 		}
 
 		// Since this is the Started event and we just parsed the API key, now is
 		// a good time to record invocation usage for the group. Sanity check that
-		// this is the first started event (to safeguard against overcounting).
-		if ut := e.env.GetUsageTracker(); ut != nil && isFirstStartedEvent {
+		// we just inserted a new row into the DB, to guarantee that we don't
+		// increment the usage on invocation retries.
+		if ut := e.env.GetUsageTracker(); ut != nil && created {
 			if err := ut.Increment(e.ctx, &tables.UsageCounts{Invocations: 1}); err != nil {
 				log.Warningf("Failed to record invocation usage: %s", err)
 			}
@@ -713,7 +715,7 @@ func (e *EventChannel) writeBuildMetadata(ctx context.Context, invocationID stri
 		invocationProto.LastChunkId = e.logWriter.GetLastChunkId()
 	}
 	ti = tableInvocationFromProto(invocationProto, ti.BlobID)
-	if err := db.InsertOrUpdateInvocation(ctx, ti); err != nil {
+	if _, err := db.InsertOrUpdateInvocation(ctx, ti); err != nil {
 		return err
 	}
 	return nil

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -206,7 +206,7 @@ type Cache interface {
 
 type InvocationDB interface {
 	// Invocations API
-	InsertOrUpdateInvocation(ctx context.Context, in *tables.Invocation) error
+	InsertOrUpdateInvocation(ctx context.Context, in *tables.Invocation) (bool, error)
 	UpdateInvocationACL(ctx context.Context, authenticatedUser *UserInfo, invocationID string, acl *aclpb.ACL) error
 	LookupInvocation(ctx context.Context, invocationID string) (*tables.Invocation, error)
 	LookupGroupFromInvocation(ctx context.Context, invocationID string) (*tables.Group, error)


### PR DESCRIPTION
This should provide a stronger guarantee that the usage count does not exceed the number of rows inserted into the DB (modulo the possibility of deleting invocations via the UI).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
