### PR TITLE
Always use group id as cache prefix

### DIFF
--- a/server/util/prefix/BUILD
+++ b/server/util/prefix/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//server/environment",
         "//server/interfaces",
+        "//server/util/authutil",
         "//server/util/log",
         "//server/util/status",
     ],

--- a/server/util/prefix/prefix.go
+++ b/server/util/prefix/prefix.go
@@ -21,10 +21,8 @@ func addPrefix(prefix, key string) string {
 func userPrefixCacheKey(ctx context.Context, env environment.Env, key string) (string, error) {
 	if auth := env.GetAuthenticator(); auth != nil {
 		if u, err := auth.AuthenticatedUser(ctx); err == nil {
-			if u.GetGroupID() != "" {
-				return addPrefix(u.GetGroupID(), key), nil
-			} else if u.GetUserID() != "" {
-				return addPrefix(u.GetUserID(), key), nil
+			if gm, err := authutil.EffectiveGroup(ctx, u); err == nil {
+				return addPrefix(gm.GroupID, key), nil
 			}
 		}
 	}

--- a/server/util/prefix/prefix.go
+++ b/server/util/prefix/prefix.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )


### PR DESCRIPTION
Currently if you do a write authenticated as a user - it will write to the cache with a user prefix (rather than a group prefix).

We don't ever want to write to the cache with a user prefix (we want to write it as the group).

This currently isn't an issue, but became an issue when we started writing patch files while authenticating as a user in the web UI.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
