### PR TITLE
Add prefixes to match git apply's filename expectations

### DIFF
--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -237,7 +237,7 @@ export default class CodeComponent extends React.Component<Props> {
     let state = new runner.RunRequest.RepoState();
     // TODO(siggisim): add commit sha
     for (let path of this.state.changes.keys()) {
-      state.patch.push(diff.createPatch(path, this.state.originalFileContents.get(path), this.state.changes.get(path)));
+      state.patch.push(diff.createTwoFilesPatch(`a/${path}`, `b/${path}`, this.state.originalFileContents.get(path), this.state.changes.get(path)));
     }
     return state;
   }


### PR DESCRIPTION
Git seems to strip the first directory from filenames when git applying (likely because `git diff` uses `a/filename` and `b/filename` when rendering diffs.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
