### PR TITLE
Use "raw unpack" when generating Firecracker container fs.

### DIFF
--- a/enterprise/server/util/container/container.go
+++ b/enterprise/server/util/container/container.go
@@ -168,16 +168,15 @@ func convertContainerToExt4FS(ctx context.Context, workspaceDir, containerImage 
 	}
 
 	// Make a directory to unpack the bundle to.
-	bundleOutputDir := filepath.Join(rootUnpackDir, "bundle")
-	if err := disk.EnsureDirectoryExists(bundleOutputDir); err != nil {
+	rootFSDir := filepath.Join(rootUnpackDir, "rootfs")
+	if err := disk.EnsureDirectoryExists(rootFSDir); err != nil {
 		return "", err
 	}
-	if out, err := exec.CommandContext(ctx, "umoci", "raw", "unpack", "--rootless", "--image", ociImageDir, bundleOutputDir).CombinedOutput(); err != nil {
+	if out, err := exec.CommandContext(ctx, "umoci", "raw", "unpack", "--rootless", "--image", ociImageDir, rootFSDir).CombinedOutput(); err != nil {
 		return "", status.InternalErrorf("umoci unpack error: %q: %s", string(out), err)
 	}
 
 	// Take the rootfs and write it into an ext4 image.
-	rootFSDir := filepath.Join(bundleOutputDir, "rootfs")
 	f, err := os.CreateTemp(workspaceDir, "containerfs-*.ext4")
 	if err != nil {
 		return "", err

--- a/enterprise/server/util/container/container.go
+++ b/enterprise/server/util/container/container.go
@@ -172,7 +172,7 @@ func convertContainerToExt4FS(ctx context.Context, workspaceDir, containerImage 
 	if err := disk.EnsureDirectoryExists(bundleOutputDir); err != nil {
 		return "", err
 	}
-	if out, err := exec.CommandContext(ctx, "umoci", "unpack", "--rootless", "--image", ociImageDir, bundleOutputDir).CombinedOutput(); err != nil {
+	if out, err := exec.CommandContext(ctx, "umoci", "raw", "unpack", "--rootless", "--image", ociImageDir, bundleOutputDir).CombinedOutput(); err != nil {
 		return "", status.InternalErrorf("umoci unpack error: %q: %s", string(out), err)
 	}
 


### PR DESCRIPTION
The regular unpack command generates some extra data that is only
necessary for creating new layers which we don't need.

Verified that the Docker executor image we are building already pull the
latest version of umoci.

This is about 30% faster for the buildbuddy image.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
