### PR TITLE
Strip ANSI sequences when downloading logs

### DIFF
--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -10,17 +10,14 @@ interface TerminalState {
   wrap: boolean;
 }
 
-const wrapLocalStorageKey = "terminal-wrap";
-const wrapLocalStorageValue = "wrap";
+const WRAP_LOCAL_STORAGE_KEY = "terminal-wrap";
+const WRAP_LOCAL_STORAGE_VALUE = "wrap";
+const ANSI_STYLES_REGEX = /\x1b\[[\d;]+?m/g;
 
 export default class TerminalComponent extends React.Component<TerminalProps, TerminalState> {
-  state = { wrap: false };
+  state = { wrap: localStorage.getItem(WRAP_LOCAL_STORAGE_KEY) === WRAP_LOCAL_STORAGE_VALUE };
 
   terminalRef = React.createRef<HTMLDivElement>();
-
-  componentDidMount() {
-    this.setState({ wrap: localStorage.getItem(wrapLocalStorageKey) === wrapLocalStorageValue });
-  }
 
   render() {
     return (
@@ -66,14 +63,15 @@ export default class TerminalComponent extends React.Component<TerminalProps, Te
 
   handleWrapClicked() {
     let shouldWrap = !this.state.wrap;
-    localStorage.setItem(wrapLocalStorageKey, shouldWrap ? wrapLocalStorageValue : undefined);
+    localStorage.setItem(WRAP_LOCAL_STORAGE_KEY, shouldWrap ? WRAP_LOCAL_STORAGE_VALUE : undefined);
     this.setState({ wrap: shouldWrap });
   }
 
   handleDownloadClicked() {
     var element = document.createElement("a");
-    element.setAttribute("href", "data:text/plain;charset=utf-8," + encodeURIComponent(this.props.value));
-    element.setAttribute("download", "build_logs.txt");
+    const unstyledLogs = this.props.value.replace(ANSI_STYLES_REGEX, "");
+    element.setAttribute("href", "data:text/plain;charset=utf-8," + encodeURIComponent(unstyledLogs));
+    element.setAttribute("download", "build_logs.log");
     element.style.display = "none";
     document.body.appendChild(element);
     element.click();

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -71,7 +71,7 @@ export default class TerminalComponent extends React.Component<TerminalProps, Te
     var element = document.createElement("a");
     const unstyledLogs = this.props.value.replace(ANSI_STYLES_REGEX, "");
     element.setAttribute("href", "data:text/plain;charset=utf-8," + encodeURIComponent(unstyledLogs));
-    element.setAttribute("download", "build_logs.log");
+    element.setAttribute("download", "build.log");
     element.style.display = "none";
     document.body.appendChild(element);
     element.click();

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -75,7 +75,7 @@ export default class TerminalComponent extends React.Component<TerminalProps, Te
     var element = document.createElement("a");
     const unstyledLogs = this.props.value.replace(ANSI_STYLES_REGEX, "");
     element.setAttribute("href", "data:text/plain;charset=utf-8," + encodeURIComponent(unstyledLogs));
-    element.setAttribute("download", "build.log");
+    element.setAttribute("download", "build_logs.txt");
     element.style.display = "none";
     document.body.appendChild(element);
     element.click();

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -15,9 +15,13 @@ const WRAP_LOCAL_STORAGE_VALUE = "wrap";
 const ANSI_STYLES_REGEX = /\x1b\[[\d;]+?m/g;
 
 export default class TerminalComponent extends React.Component<TerminalProps, TerminalState> {
-  state = { wrap: localStorage.getItem(WRAP_LOCAL_STORAGE_KEY) === WRAP_LOCAL_STORAGE_VALUE };
+  state = { wrap: false };
 
   terminalRef = React.createRef<HTMLDivElement>();
+
+  componentDidMount() {
+    this.setState({ wrap: localStorage.getItem(WRAP_LOCAL_STORAGE_KEY) === WRAP_LOCAL_STORAGE_VALUE });
+  }
 
   render() {
     return (


### PR DESCRIPTION
Add a lightweight regex to strip ANSI styles, since they render as raw ANSI codes unless viewing the logs with `cat` or `less -r` (most people will probably use their editor or the default text viewer on their system)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
