### PR TITLE
Implement debug stream command outputs flag for bare executors

### DIFF
--- a/enterprise/server/remote_execution/commandutil/commandutil.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil.go
@@ -47,7 +47,7 @@ func constructExecCommand(ctx context.Context, command *repb.Command, workDir st
 	if in != nil {
 		cmd.Stdin = in
 	}
-	if *debugStreamCommandOutputs {
+	if *DebugStreamCommandOutputs {
 		cmd.Stdout = io.MultiWriter(cmd.Stdout, os.Stdout)
 		cmd.Stderr = io.MultiWriter(cmd.Stderr, os.Stderr)
 	}

--- a/enterprise/server/remote_execution/commandutil/commandutil.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil.go
@@ -3,8 +3,10 @@ package commandutil
 import (
 	"bytes"
 	"context"
+	"flag"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -26,6 +28,10 @@ const (
 	NoExitCode = -2
 )
 
+var (
+	DebugStreamCommandOutputs = flag.Bool("debug_stream_command_outputs", false, "If true, stream command outputs to the terminal. Intended for debugging purposes only and should not be used in production.")
+)
+
 func constructExecCommand(ctx context.Context, command *repb.Command, workDir string, in io.Reader, out io.Writer) (*exec.Cmd, *bytes.Buffer, *bytes.Buffer) {
 	executable, args := splitExecutableArgs(command.GetArguments())
 	cmd := exec.CommandContext(ctx, executable, args...)
@@ -40,6 +46,10 @@ func constructExecCommand(ctx context.Context, command *repb.Command, workDir st
 	cmd.Stderr = &stderr
 	if in != nil {
 		cmd.Stdin = in
+	}
+	if *debugStreamCommandOutputs {
+		cmd.Stdout = io.MultiWriter(cmd.Stdout, os.Stdout)
+		cmd.Stderr = io.MultiWriter(cmd.Stderr, os.Stderr)
 	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	for _, envVar := range command.GetEnvironmentVariables() {

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -37,8 +37,6 @@ var (
 	dockerDaemonErrorCode        = 125
 	containerFinalizationTimeout = 10 * time.Second
 	defaultDockerUlimit          = int64(65535)
-
-	debugStreamCommandOutputs = flag.Bool("docker_debug_stream_command_outputs", false, "If true, stream command outputs to the terminal. Intended for debugging purposes only and should not be used in production.")
 )
 
 type DockerOptions struct {
@@ -254,7 +252,7 @@ func copyOutputs(reader io.Reader, result *interfaces.CommandResult) error {
 	var stdoutBuf, stderrBuf bytes.Buffer
 
 	stdout, stderr := io.Writer(&stdoutBuf), io.Writer(&stderrBuf)
-	if *debugStreamCommandOutputs {
+	if *commandutil.DebugStreamCommandOutputs {
 		stdout, stderr = io.MultiWriter(stdout, os.Stdout), io.MultiWriter(stderr, os.Stderr)
 	}
 

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"


### PR DESCRIPTION
`docker_debug_stream_command_outputs` allows sending stdout / stderr of Docker commands directly to the terminal. This PR renames the flag to a more generic `debug_stream_command_outputs` and gets it working for bare executors too.

Using this for debugging Mac workflows.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
