### PR TITLE
Add better cache miss debugging

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -12,6 +12,7 @@ import ArtifactsCardComponent from "./invocation_artifacts_card";
 import BuildLogsCardComponent from "./invocation_build_logs_card";
 import QueryGraphCardComponent from "./invocation_query_graph_card";
 import CacheCardComponent from "./invocation_cache_card";
+import ScorecardCardComponent from "./scorecard_card";
 import FetchCardComponent from "./invocation_fetch_card";
 import InvocationDetailsCardComponent from "./invocation_details_card";
 import ErrorCardComponent from "./invocation_error_card";
@@ -281,6 +282,9 @@ export default class InvocationComponent extends React.Component<Props, State> {
 
           {isBazelInvocation && (activeTab === "all" || activeTab == "cache") && (
             <CacheCardComponent model={this.state.model} />
+          )}
+          {isBazelInvocation && (activeTab === "all" || activeTab == "cache") && (
+            <ScorecardCardComponent model={this.state.model} />
           )}
 
           {isBazelInvocation && (activeTab === "all" || activeTab == "artifacts") && (

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -15,6 +15,7 @@ export const InvocationStatus = invocation.Invocation.InvocationStatus;
 export default class InvocationModel {
   invocations: invocation.Invocation[] = [];
   cacheStats: cache.CacheStats[] = [];
+  scoreCard: cache.IScoreCard;
 
   consoleBuffer: string;
   targets: build_event_stream.BuildEvent[] = [];
@@ -62,8 +63,10 @@ export default class InvocationModel {
     model.cacheStats = invocations
       .map((invocation) => invocation.cacheStats)
       .filter((cacheStat) => !!cacheStat) as cache.CacheStats[];
+
     for (let invocation of invocations) {
       if (invocation.consoleBuffer) model.consoleBuffer = invocation.consoleBuffer;
+      if (invocation.scoreCard) model.scoreCard = invocation.scoreCard;
       for (let cl of invocation.structuredCommandLine) {
         model.structuredCommandLine.push(cl as command_line.CommandLine);
       }
@@ -133,7 +136,8 @@ export default class InvocationModel {
           model.buildToolLogs = buildEvent.buildToolLogs as build_event_stream.BuildToolLogs;
         }
         if (buildEvent.unstructuredCommandLine) {
-          model.unstructuredCommandLine = buildEvent.unstructuredCommandLine as build_event_stream.UnstructuredCommandLine;
+          model.unstructuredCommandLine =
+            buildEvent.unstructuredCommandLine as build_event_stream.UnstructuredCommandLine;
         }
       }
     }

--- a/app/invocation/scorecard_card.tsx
+++ b/app/invocation/scorecard_card.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import InvocationModel from "./invocation_model";
+import rpcService from "../service/rpc_service";
+
+interface Props {
+  model: InvocationModel;
+}
+
+export default class ScorecardCardComponent extends React.Component {
+  props: Props;
+
+  getCacheAddress() {
+    let address = this.props.model.optionsMap.get("remote_cache").replace("grpc://", "");
+    address = address.replace("grpcs://", "");
+    if (this.props.model.optionsMap.get("remote_cache")) {
+      address = this.props.model.optionsMap.get("remote_cache").replace("grpc://", "");
+      address = address.replace("grpcs://", "");
+    }
+    if (this.props.model.optionsMap.get("remote_instance_name")) {
+      address = address + "/" + this.props.model.optionsMap.get("remote_instance_name");
+    }
+    return address;
+  }
+
+  getActionDownloadURL(actionId: string) {
+    let actionResultURI = "actioncache://" + this.getCacheAddress() + "/blobs/ac/" + actionId + "/141";
+    return rpcService.getBytestreamFileUrl(actionId, actionResultURI, this.props.model.getId());
+  }
+
+  render() {
+    return (
+      <div className="card scorecard">
+        <img className="icon" src="/image/x-circle-regular.svg" />
+        <div className="content">
+          <div className="title">Cache Misses</div>
+          <div className="details">
+            {this.props.model.scoreCard.misses.map((result) => (
+              <div>
+                <div className="scorecard-target-name">{result.targetId}</div>
+                <div className="scorecard-action-id-list">
+                  <a href={this.getActionDownloadURL(result.actionId)} className="scorecard-action-id">
+                    {result.actionId}
+                  </a>
+                </div>
+              </div>
+            ))}
+          </div>
+          {this.props.model.scoreCard.misses.length == 0 && <span>No artifacts</span>}
+        </div>
+      </div>
+    );
+  }
+}

--- a/app/invocation/scorecard_card.tsx
+++ b/app/invocation/scorecard_card.tsx
@@ -25,6 +25,7 @@ export default class ScorecardCardComponent extends React.Component {
   }
 
   render() {
+    if (!this.props.model.scoreCard) return null;
     return (
       <div className="card scorecard">
         <img className="icon" src="/image/x-circle-regular.svg" />

--- a/app/invocation/scorecard_card.tsx
+++ b/app/invocation/scorecard_card.tsx
@@ -12,10 +12,7 @@ export default class ScorecardCardComponent extends React.Component {
   getCacheAddress() {
     let address = this.props.model.optionsMap.get("remote_cache").replace("grpc://", "");
     address = address.replace("grpcs://", "");
-    if (this.props.model.optionsMap.get("remote_cache")) {
-      address = this.props.model.optionsMap.get("remote_cache").replace("grpc://", "");
-      address = address.replace("grpcs://", "");
-    }
+
     if (this.props.model.optionsMap.get("remote_instance_name")) {
       address = address + "/" + this.props.model.optionsMap.get("remote_instance_name");
     }
@@ -45,7 +42,7 @@ export default class ScorecardCardComponent extends React.Component {
               </div>
             ))}
           </div>
-          {this.props.model.scoreCard.misses.length == 0 && <span>No artifacts</span>}
+          {this.props.model.scoreCard.misses.length == 0 && <span>No Misses</span>}
         </div>
       </div>
     );

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1167,6 +1167,22 @@ code .comment {
   margin-bottom: 8px;
 }
 
+.scorecard-target-name {
+  font-weight: 600;
+  text-decoration: underline;
+  cursor: pointer;
+  display: block;
+}
+
+.scorecard-action-id {
+  color: #757575;
+  margin-top: 8px;
+}
+
+.scorecard-action-id-list {
+  padding-left: 32px;
+}
+
 .stat-cards {
   display: flex;
   flex-wrap: wrap;

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -29,3 +29,14 @@ message CacheStats {
   // the sum of execution time of cached objects.
   int64 total_cached_action_exec_usec = 11;
 }
+
+message ScoreCard {
+  message Result {
+    string action_mnemonic = 1;
+    string target_id = 2;
+    string action_id = 3;
+  }
+
+  // In the interest of saving space, we only show cache misses.
+  repeated Result misses = 1;
+}

--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -9,6 +9,7 @@ import "google/protobuf/timestamp.proto";
 
 package invocation;
 
+// Next tag: 25
 message Invocation {
   // The invocation identifier itself.
   string invocation_id = 1;
@@ -74,6 +75,10 @@ message Invocation {
   // Any cache stats that were captured during this invocation.
   // May not be present if the buildbuddy cache was not used.
   cache.CacheStats cache_stats = 18;
+
+  // The scorecard, indicating any action cache misses.
+  // May not be present if the buildbuddy cache was not used.
+  cache.ScoreCard score_card = 24;
 
   // The role played by this invocation. Ex: "CI"
   string role = 19;

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -1595,6 +1595,23 @@ message RequestMetadata {
   // An identifier to tie multiple tool invocations together. For example,
   // runs of foo_test, bar_test and baz_test on a post-submit of a given patch.
   string correlated_invocations_id = 4;
+
+  // A brief description of the kind of action, for example, CppCompile or
+  // GoLink. There is no standard agreed set of values for this, and they are
+  // expected to vary between different client tools.
+  string action_mnemonic = 5;
+
+  // An identifier for the target which produced this action.
+  // No guarantees are made around how many actions may relate to a single
+  // target.
+  string target_id = 6;
+
+  // An identifier for the configuration in which the target was built,
+  // e.g. for differentiating building host tools or different target platforms.
+  // There is no expectation that this value will have any particular structure,
+  // or equality across invocations, though some client tools may offer these
+  // guarantees.
+  string configuration_id = 7;
 }
 
 message SizedDirectory {

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -199,7 +199,7 @@ func (r *statsRecorder) Enqueue(ctx context.Context, invocation *inpb.Invocation
 }
 
 func scoreCardBlobName(invocationID string) string {
-	blobFileName := invocationID + "-scorecard.chunk"
+	blobFileName := invocationID + "-scorecard.pb"
 	return filepath.Join(invocationID, blobFileName)
 }
 

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -211,6 +211,10 @@ func (r *statsRecorder) Start() {
 				if stats := hit_tracker.CollectCacheStats(ctx, r.env, task.invocationJWT.id); stats != nil {
 					fillInvocationFromCacheStats(stats, ti)
 				}
+				if scorecard := hit_tracker.ScoreCard(ctx, r.env, task.invocationJWT.id); scorecard != nil {
+					//log.Printf("Collected scorecard: %+v", scorecard)
+				}
+
 				if _, err := r.env.GetInvocationDB().InsertOrUpdateInvocation(ctx, ti); err != nil {
 					log.Errorf("Failed to write cache stats for invocation: %s", err)
 				}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -489,7 +489,7 @@ type PubSub interface {
 //
 // No guarantees are made about durability of MetricsCollectors -- they may be
 // evicted from the backing store that maintains them (usually memcache or
-// redis), so they should *not* be used in critical path code.
+// redis), so they should *not* be used for data that requires durability.
 type MetricsCollector interface {
 	IncrementCount(ctx context.Context, key, field string, n int64) error
 	ReadCounts(ctx context.Context, key string) (map[string]int64, error)

--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -345,7 +345,15 @@ func ScoreCard(ctx context.Context, env environment.Env, iid string) *capb.Score
 	for targetField, _ := range misses {
 		sortedKeys = append(sortedKeys, targetField)
 	}
+	// TODO(tylerw): figure out pagination or something? For now, truncate
+	// the number of cache misses to 1K if there are more than that. Too
+	// many are not useful in the UI and we don't want to pay the storage
+	// cost either.
+	if len(sortedKeys) > 1000 {
+		sortedKeys = sortedKeys[:1000]
+	}
 	sort.Strings(sortedKeys)
+
 	for _, targetField := range sortedKeys {
 		mnemonic, targetID, actionID := parseTargetField(targetField)
 		if mnemonic == "" || targetID == "" || actionID == "" {

--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -2,6 +2,9 @@ package hit_tracker
 
 import (
 	"context"
+	"fmt"
+	"regexp"
+	"sort"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -15,6 +18,9 @@ import (
 	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
+
+// Example: "GoLink(//merger:merger_test)/16f1152b7b260f690ea06f8b938a1b60712b5ee41a1c125ecad8ed9416481fbb"
+var actionRegexp = regexp.MustCompile("^(?P<action_mnemonic>[[:alnum:]]*)\\((?P<target_id>.+)\\)/(?P<action_id>[[:alnum:]]+)$")
 
 type CacheMode int
 type counterType int
@@ -57,8 +63,16 @@ func cacheTypePrefix(actionCache bool, name string) string {
 	}
 }
 
+// counterKey returns a string key under which general invocation  metrics can
+// be accounted.
 func counterKey(iid string) string {
 	return "hit_tracker/" + iid
+}
+
+// targetMissesKey returns a string key under which target level hit metrics can
+// be accounted.
+func targetMissesKey(iid string) string {
+	return "hit_tracker/" + iid + "/misses"
 }
 
 func counterField(actionCache bool, ct counterType) string {
@@ -90,20 +104,36 @@ type HitTracker struct {
 	ctx         context.Context
 	iid         string
 	actionCache bool
+
+	// The request metadata, may be nil or incomplete.
+	requestMetadata *repb.RequestMetadata
 }
 
 func NewHitTracker(ctx context.Context, env environment.Env, actionCache bool) *HitTracker {
 	return &HitTracker{
-		c:           env.GetMetricsCollector(),
-		usage:       env.GetUsageTracker(),
-		ctx:         ctx,
-		iid:         bazel_request.GetInvocationID(ctx),
-		actionCache: actionCache,
+		c:               env.GetMetricsCollector(),
+		usage:           env.GetUsageTracker(),
+		ctx:             ctx,
+		iid:             bazel_request.GetInvocationID(ctx),
+		actionCache:     actionCache,
+		requestMetadata: bazel_request.GetRequestMetadata(ctx),
 	}
 }
 
 func (h *HitTracker) counterKey() string {
 	return counterKey(h.iid)
+}
+
+func (h *HitTracker) targetMissesKey() string {
+	return targetMissesKey(h.iid)
+}
+
+func (h *HitTracker) targetField() string {
+	if h.requestMetadata == nil {
+		return ""
+	}
+	rmd := h.requestMetadata
+	return makeTargetField(rmd.GetActionMnemonic(), rmd.GetTargetId(), rmd.GetActionId())
 }
 
 func (h *HitTracker) counterField(ct counterType) string {
@@ -117,6 +147,10 @@ func (h *HitTracker) cacheTypeLabel() string {
 	return casLabel
 }
 
+func makeTargetField(actionMnemonic, targetID, actionID string) string {
+	return fmt.Sprintf("%s(%s)/%s", actionMnemonic, targetID, actionID)
+}
+
 // Example Usage:
 //
 // ht := NewHitTracker(env, invocationID, false /*=actionCache*/)
@@ -124,14 +158,22 @@ func (h *HitTracker) cacheTypeLabel() string {
 //   log.Printf("Error counting cache miss.")
 // }
 func (h *HitTracker) TrackMiss(d *repb.Digest) error {
-	if h.c == nil || h.iid == "" {
-		return nil
-	}
 	metrics.CacheEvents.With(prometheus.Labels{
 		metrics.CacheTypeLabel:      h.cacheTypeLabel(),
 		metrics.CacheEventTypeLabel: missLabel,
 	}).Inc()
-	return h.c.IncrementCount(h.ctx, h.counterKey(), h.counterField(Miss), 1)
+	if h.c == nil || h.iid == "" {
+		return nil
+	}
+	if err := h.c.IncrementCount(h.ctx, h.counterKey(), h.counterField(Miss), 1); err != nil {
+		return err
+	}
+	if h.actionCache {
+		if err := h.c.IncrementCount(h.ctx, h.targetMissesKey(), h.targetField(), 1); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (h *HitTracker) TrackEmptyHit() error {
@@ -142,7 +184,10 @@ func (h *HitTracker) TrackEmptyHit() error {
 	if h.c == nil || h.iid == "" {
 		return nil
 	}
-	return h.c.IncrementCount(h.ctx, h.counterKey(), h.counterField(Hit), 1)
+	if err := h.c.IncrementCount(h.ctx, h.counterKey(), h.counterField(Hit), 1); err != nil {
+		return err
+	}
+	return nil
 }
 
 type closeFunction func() error
@@ -213,7 +258,11 @@ func (h *HitTracker) makeCloseFunc(d *repb.Digest, start time.Time, actionCounte
 		if err := h.c.IncrementCount(h.ctx, h.counterKey(), h.counterField(timeCounter), dur.Microseconds()); err != nil {
 			return err
 		}
-
+		if h.actionCache && actionCounter == Miss {
+			if err := h.c.IncrementCount(h.ctx, h.targetMissesKey(), h.targetField(), 1); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 }
@@ -265,6 +314,50 @@ func computeThroughputBytesPerSecond(sizeBytes, durationUsec int64) int64 {
 	}
 	dur := time.Duration(durationUsec * int64(time.Microsecond))
 	return int64(float64(sizeBytes) / dur.Seconds())
+}
+
+func parseTargetField(f string) (string, string, string) {
+	// parses a string like this:
+	// "GoLink(//merger:merger_test)/16f1152b7b260f690ea06f8b938a1b60712b5ee41a1c125ecad8ed9416481fbb"
+	match := actionRegexp.FindStringSubmatch(f)
+	if len(match) != 4 {
+		return "", "", ""
+	}
+	return match[1], match[2], match[3]
+}
+
+func ScoreCard(ctx context.Context, env environment.Env, iid string) *capb.ScoreCard {
+	c := env.GetMetricsCollector()
+	if c == nil || iid == "" {
+		return nil
+	}
+	sc := &capb.ScoreCard{}
+
+	misses, err := c.ReadCounts(ctx, targetMissesKey(iid))
+	if err != nil {
+		log.Warningf("Failed to collect score card: %s", err)
+		return sc
+	}
+	if misses == nil {
+		misses = make(map[string]int64)
+	}
+	sortedKeys := make([]string, 0, len(misses))
+	for targetField, _ := range misses {
+		sortedKeys = append(sortedKeys, targetField)
+	}
+	sort.Strings(sortedKeys)
+	for _, targetField := range sortedKeys {
+		mnemonic, targetID, actionID := parseTargetField(targetField)
+		if mnemonic == "" || targetID == "" || actionID == "" {
+			continue
+		}
+		sc.Misses = append(sc.Misses, &capb.ScoreCard_Result{
+			ActionMnemonic: mnemonic,
+			TargetId:       targetID,
+			ActionId:       actionID,
+		})
+	}
+	return sc
 }
 
 func CollectCacheStats(ctx context.Context, env environment.Env, iid string) *capb.CacheStats {


### PR DESCRIPTION
This CL adds support for an ActionCache miss scorecard, basically a list of targets and their associated action ids that were cache misses during a build. The data is collected using deferred counters in redis|memory, and finalized to blobstore at the same time the cache stats are finalized.

This adds a card to the cache tab that shows the items that were missing from the action cache, like this:

![image](https://user-images.githubusercontent.com/141737/141842022-9b3ade6c-1b2b-4253-9b9f-e01e7295b80b.png)

Future improvements (maybe someone more UI handy than me can help with):
 - pagination, in case the scorecard is large (it can be)
 - linking to a card to display the action, rather than downloading it, so users can debug a cache miss entirely in the UI