### PR TITLE
Don't use a git credential helper for the workflow repo

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -767,6 +767,10 @@ func (ws *workspace) setup(ctx context.Context, reporter *buildEventReporter) er
 	if err := git(ctx, ws.log, "init"); err != nil {
 		return err
 	}
+	// Don't use a credential helper since we always use explicit credentials.
+	if err := git(ctx, ws.log, "config", "--local", "credential.helper", ""); err != nil {
+		return err
+	}
 	return ws.sync(ctx)
 }
 

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -767,6 +767,10 @@ func (ws *workspace) setup(ctx context.Context, reporter *buildEventReporter) er
 	if err := git(ctx, ws.log, "init"); err != nil {
 		return err
 	}
+	// Don't use a credential helper since we always use explicit credentials.
+	if err := git(ctx, ws.log, "config", "--local", "credential.helper", ""); err != nil {
+		return err
+	}
 	return ws.sync(ctx)
 }
 
@@ -898,11 +902,7 @@ func (ws *workspace) fetch(ctx context.Context, remoteURL string, branches []str
 	if err := git(ctx, io.Discard, "remote", "add", remoteName, authURL); err != nil && !isRemoteAlreadyExists(err) {
 		return status.UnknownErrorf("Command `git remote add %q <url>` failed.", remoteName)
 	}
-	// Don't use a credential helper when fetching -- it's unnecessary since we've
-	// already configured credentials on the remote explicitly, and some
-	// credential helpers require user input in order to proceed, which is
-	// undesired.
-	fetchArgs := append([]string{"-c", "credential.helper=", "fetch", "--force", remoteName}, branches...)
+	fetchArgs := append([]string{"fetch", "--force", remoteName}, branches...)
 	if err := git(ctx, ws.log, fetchArgs...); err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes an issue with Mac workflows that the osxkeychain credential helper shows an interactive dialog which blocks the `git fetch` until the dialog is clicked through.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
