### PR TITLE
Allow configuring the OS for workflows in buildbuddy.yaml

### DIFF
--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -51,7 +51,8 @@ const (
 	enableVFSPropertyName            = "enable-vfs"
 
 	operatingSystemPropertyName = "OSFamily"
-	defaultOperatingSystemName  = "linux"
+	LinuxOperatingSystemName    = "linux"
+	defaultOperatingSystemName  = LinuxOperatingSystemName
 	darwinOperatingSystemName   = "darwin"
 
 	cpuArchitecturePropertyName = "Arch"

--- a/enterprise/server/test/integration/workflow/workflow_test.go
+++ b/enterprise/server/test/integration/workflow/workflow_test.go
@@ -208,6 +208,7 @@ func TestCreateAndTriggerViaWebhook(t *testing.T) {
 
 func TestCreateAndExecute(t *testing.T) {
 	fakeGitProvider := testgit.NewFakeProvider()
+	fakeGitProvider.FileContents = simpleRepoContents
 	env, _ := setup(t, fakeGitProvider)
 	bb := env.GetBuildBuddyServiceClient()
 	repoPath, commitSHA := testgit.MakeTempRepo(t, simpleRepoContents)

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -26,6 +26,7 @@ type BuildBuddyConfig struct {
 type Action struct {
 	Name          string    `yaml:"name"`
 	Triggers      *Triggers `yaml:"triggers"`
+	OS            string    `yaml:"os"`
 	BazelCommands []string  `yaml:"bazel_commands"`
 }
 


### PR DESCRIPTION
Also, don't set `container-image` unless the OS is `linux`.

This requires us to read the workflow config when calling `ExecuteWorkflow`, so a little bit of refactoring was needed. `executeWorkflow` now requires the `workflowAction` config from `buildbuddy.yaml`. Since we have that object, we no longer need to pass `--action_name=...` as an extra CI runner arg, and can always set it based on the passed in `workflowAction`.

Note that this does not make any changes to `pool` - that'll be a separate PR.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
