### PR TITLE
Add paging for cache scorecard and link to action results

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -120,7 +120,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
   }
 
   getCacheAddress() {
-    let address = this.props.model.optionsMap.get("remote_executor").replace("grpc://", "");
+    let address = (this.props.model.optionsMap.get("remote_executor") || "").replace("grpc://", "");
     address = address.replace("grpcs://", "");
     if (this.props.model.optionsMap.get("remote_cache")) {
       address = this.props.model.optionsMap.get("remote_cache").replace("grpc://", "");

--- a/app/invocation/scorecard_card.tsx
+++ b/app/invocation/scorecard_card.tsx
@@ -1,51 +1,128 @@
 import React from "react";
 import InvocationModel from "./invocation_model";
-import rpcService from "../service/rpc_service";
+import { cache } from "../../proto/cache_ts_proto";
+import router from "../router/router";
 
 interface Props {
   model: InvocationModel;
 }
 
-export default class ScorecardCardComponent extends React.Component {
-  props: Props;
+interface State {
+  resultsLimit: number | null;
+}
 
-  getCacheAddress() {
-    let address = this.props.model.optionsMap.get("remote_cache").replace("grpc://", "");
-    address = address.replace("grpcs://", "");
+// How many cache misses to show initially.
+const INITIAL_RESULTS_LIMIT = 64;
 
-    if (this.props.model.optionsMap.get("remote_instance_name")) {
-      address = address + "/" + this.props.model.optionsMap.get("remote_instance_name");
-    }
-    return address;
+export default class ScorecardCardComponent extends React.Component<Props, State> {
+  state: State = {
+    resultsLimit: INITIAL_RESULTS_LIMIT,
+  };
+
+  getActionUrl(digestHash: string) {
+    // TODO(bduffany): Pass the correct digest size here, or update the action page to make the size optional.
+    const digestSizeBytes = 141;
+    return `/invocation/${this.props.model.getId()}?actionDigest=${digestHash}/${digestSizeBytes}#action`;
   }
 
-  getActionDownloadURL(actionId: string) {
-    let actionResultURI = "actioncache://" + this.getCacheAddress() + "/blobs/ac/" + actionId + "/141";
-    return rpcService.getBytestreamFileUrl(actionId, actionResultURI, this.props.model.getId());
+  onClickShowAll() {
+    this.setState({ resultsLimit: null });
+  }
+
+  onClickAction(e: React.MouseEvent) {
+    e.preventDefault();
+    const url = (e.target as HTMLAnchorElement).getAttribute("href");
+    router.navigateTo(url);
   }
 
   render() {
     if (!this.props.model.scoreCard) return null;
+
+    const groups = groupResultsByTargetId(this.props.model.scoreCard.misses);
+    const visibleGroups = limitResults(groups, this.state.resultsLimit);
+    const hiddenGroupsCount = groups.length - visibleGroups.length;
+
     return (
       <div className="card scorecard">
         <img className="icon" src="/image/x-circle-regular.svg" />
         <div className="content">
           <div className="title">Cache Misses</div>
           <div className="details">
-            {this.props.model.scoreCard.misses.map((result) => (
-              <div>
-                <div className="scorecard-target-name">{result.targetId}</div>
+            {visibleGroups.map((group) => (
+              <div key={group.targetId}>
+                <div className="scorecard-target-name">{group.targetId}</div>
                 <div className="scorecard-action-id-list">
-                  <a href={this.getActionDownloadURL(result.actionId)} className="scorecard-action-id">
-                    {result.actionId}
-                  </a>
+                  {group.results.map((result) => (
+                    <a
+                      key={result.actionId}
+                      href={this.getActionUrl(result.actionId)}
+                      onClick={this.onClickAction.bind(this)}
+                      className="scorecard-action-id">
+                      {result.actionId}
+                      {result.actionMnemonic ? ` (${result.actionMnemonic})` : ""}
+                    </a>
+                  ))}
+                  {group.hiddenResultsCount ? (
+                    <div className="scorecard-hidden-count">
+                      {group.hiddenResultsCount} more {group.hiddenResultsCount === 1 ? "cache miss" : "misses"} for
+                      this target
+                    </div>
+                  ) : null}
                 </div>
               </div>
             ))}
+            {hiddenGroupsCount > 0 ? (
+              <>
+                <div className="scorecard-hidden-count">
+                  {hiddenGroupsCount} more {hiddenGroupsCount === 1 ? "target" : "targets"} with cache misses
+                </div>
+                <div className="more" onClick={this.onClickShowAll.bind(this)}>
+                  See all cache misses
+                </div>
+              </>
+            ) : null}
           </div>
           {this.props.model.scoreCard.misses.length == 0 && <span>No Misses</span>}
         </div>
       </div>
     );
   }
+}
+
+type ResultGroup = {
+  targetId: string;
+  results: cache.ScoreCard.IResult[];
+  hiddenResultsCount?: number;
+};
+
+function groupResultsByTargetId(results: cache.ScoreCard.IResult[]): ResultGroup[] {
+  const resultsByTarget = new Map<string, cache.ScoreCard.IResult[]>();
+  for (const result of results) {
+    const resultsForTarget = resultsByTarget.get(result.targetId) || [];
+    resultsForTarget.push(result);
+    resultsByTarget.set(result.targetId, resultsForTarget);
+  }
+  return [...resultsByTarget.entries()]
+    .map(([targetId, results]) => ({ targetId, results }))
+    .sort((a, b) => a.targetId.localeCompare(b.targetId));
+}
+
+function limitResults(groups: ResultGroup[], limit: number | null): ResultGroup[] {
+  if (limit === null) {
+    return groups;
+  }
+  const limitedGroups = [];
+  let remaining = limit;
+  for (let group of groups) {
+    if (remaining === 0) break;
+
+    group = { ...group }; // shallow clone
+    limitedGroups.push(group);
+    if (group.results.length > remaining) {
+      group.hiddenResultsCount = group.results.length - remaining;
+      group.results = group.results.slice(0, remaining);
+    }
+    remaining -= group.results.length;
+  }
+  return limitedGroups;
 }

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1168,19 +1168,27 @@ code .comment {
 }
 
 .scorecard-target-name {
-  font-weight: 600;
-  text-decoration: underline;
-  cursor: pointer;
+  margin-top: 8px;
+  color: #757575;
   display: block;
 }
 
 .scorecard-action-id {
-  color: #757575;
-  margin-top: 8px;
+  display: block;
+  margin-top: 4px;
+  font-weight: 600;
+  text-decoration: underline;
 }
 
 .scorecard-action-id-list {
   padding-left: 32px;
+  margin-bottom: 8px;
+}
+
+.scorecard-hidden-count {
+  color: #bdbdbd;
+  margin-top: 4px;
+  margin-bottom: 8px;
 }
 
 .stat-cards {


### PR DESCRIPTION
* Implement client-side paging (the same way we do for artifacts)
* Link to action results page
* Add action mnemonic to links
* Make the styling consistent with the test artifacts list

![image](https://user-images.githubusercontent.com/2414826/142078555-a5745ebb-204d-4020-8046-08b1e92273f9.png)

TODO in future PRs:
- Don't hard-code the action digest size as 141: either don't require a size to be able to view the action page, or find a way to use the actual digest size
- If the action is not found, show a help message with the list of potential reasons: `--noremote_upload_local_results` was set; a read-only API key was used; action expired or was manually deleted from CAS; ...?

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
