### PR TITLE
Allow specifying CPU architecture in workflow config

### DIFF
--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -27,6 +27,7 @@ type Action struct {
 	Name          string    `yaml:"name"`
 	Triggers      *Triggers `yaml:"triggers"`
 	OS            string    `yaml:"os"`
+	Arch          string    `yaml:"arch"`
 	BazelCommands []string  `yaml:"bazel_commands"`
 }
 

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -616,6 +616,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 			Properties: []*repb.Platform_Property{
 				{Name: "Pool", Value: ws.workflowsPoolName()},
 				{Name: "OSFamily", Value: os},
+				{Name: "Arch", Value: workflowAction.Arch},
 				{Name: "container-image", Value: containerImage},
 				// Reuse the docker container for the CI runner across executions if
 				// possible, and also keep the git repo around so it doesn't need to be


### PR DESCRIPTION
This lets us support M1 Macs (by setting `os: darwin, arch: arm64`)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
