### PR TITLE
Embed bazelisk into the CI runner to simplify Mac workflow executor provisioning

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -3519,6 +3519,24 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         urls = ["https://github.com/bazelbuild/bazel/releases/download/4.1.0/bazel-4.1.0-linux-x86_64"],
         executable = True,
     )
+    http_file(
+        name = "io_bazel_bazelisk-1.10.1-darwin-amd64",
+        sha256 = "e485bbf84532d02a60b0eb23c702610b5408df3a199087a4f2b5e0995bbf2d5a",
+        urls = ["https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-darwin-amd64"],
+        executable = True,
+    )
+    http_file(
+        name = "io_bazel_bazelisk-1.10.1-darwin-arm64",
+        sha256 = "c22d48601466d9d3b043ccd74051f2f4230f9b9f4509f097017c97303aa88d13",
+        urls = ["https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-darwin-arm64"],
+        executable = True,
+    )
+    http_file(
+        name = "io_bazel_bazelisk-1.10.1-linux-amd64",
+        sha256 = "4cb534c52cdd47a6223d4596d530e7c9c785438ab3b0a49ff347e991c210b2cd",
+        urls = ["https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-linux-amd64"],
+        executable = True,
+    )
 
     go_repository(
         name = "io_etcd_go_bbolt",

--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//proto:build_event_stream_go_proto",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
+        "//server/util/bazelisk",
         "//server/util/flagutil",
         "//server/util/git",
         "//server/util/grpc_client",

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -20,6 +21,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/config"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/bazelisk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lockingbuffer"
@@ -93,7 +95,7 @@ var (
 	patchDigests                flagutil.StringSliceFlag
 	reportLiveRepoSetupProgress = flag.Bool("report_live_repo_setup_progress", false, "If set, repo setup output will be streamed live to the invocation instead of being postponed until the action is run.")
 
-	bazelCommand      = flag.String("bazel_command", bazeliskBinaryName, "Bazel command to use.")
+	bazelCommand      = flag.String("bazel_command", "", "Bazel command to use.")
 	bazelStartupFlags = flag.String("bazel_startup_flags", "", "Startup flags to pass to bazel. The value can include spaces and will be properly tokenized.")
 	debug             = flag.Bool("debug", false, "Print additional debug information in the action logs.")
 
@@ -331,10 +333,6 @@ func main() {
 	ws.log = io.MultiWriter(os.Stderr, &ws.logBuf)
 	ws.hostname, ws.username = getHostAndUserName()
 
-	if *bazelCommand == "" {
-		*bazelCommand = bazeliskBinaryName
-	}
-
 	ctx := context.Background()
 	if ws.buildbuddyAPIKey != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, auth.APIKeyHeader, ws.buildbuddyAPIKey)
@@ -347,6 +345,14 @@ func main() {
 	// Make sure PATH is set.
 	if err := ensurePath(); err != nil {
 		fatal(status.WrapError(err, "ensure PATH"))
+	}
+	// Make sure we have a bazel / bazelisk binary available.
+	if *bazelCommand == "" {
+		cmd, err := getBazeliskCommand()
+		if err != nil {
+			fatal(status.WrapError(err, "get bazel command"))
+		}
+		*bazelCommand = cmd
 	}
 
 	var buildEventReporter *buildEventReporter
@@ -609,7 +615,7 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace, startTime time.T
 		if err != nil {
 			return status.InvalidArgumentErrorf("failed to parse bazel command: %s", err)
 		}
-		printCommandLine(ar.reporter, bazeliskBinaryName, args...)
+		printCommandLine(ar.reporter, *bazelCommand, args...)
 		// Transparently set the invocation ID from the one we computed ahead of
 		// time. The UI is expecting this invocation ID so that it can render a
 		// BuildBuddy invocation URL for each bazel_command that is executed.
@@ -695,6 +701,39 @@ func ensurePath() error {
 		return nil
 	}
 	return os.Setenv("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+}
+
+func getBazeliskCommand() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	// If bazelisk is already in the workspace root, use that.
+	if _, err := os.Stat(bazeliskBinaryName); err != nil {
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+	} else {
+		return filepath.Join(wd, bazeliskBinaryName), nil
+	}
+	// If bazelisk is embedded, copy it to the workspace root, and use that.
+	if f, err := bazelisk.Open(); err == nil {
+		defer f.Close()
+		dst, err := os.OpenFile(bazeliskBinaryName, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0555)
+		if err != nil {
+			return "", err
+		}
+		defer dst.Close()
+		if _, err := io.Copy(dst, f); err != nil {
+			return "", err
+		}
+		return filepath.Join(wd, bazeliskBinaryName), nil
+	}
+	// If bazelisk is in PATH, use that.
+	if _, err := exec.LookPath(bazeliskBinaryName); err != nil {
+		return "", err
+	}
+	return bazeliskBinaryName, nil
 }
 
 func getHostAndUserName() (string, string) {

--- a/server/util/bazelisk/BUILD
+++ b/server/util/bazelisk/BUILD
@@ -15,10 +15,7 @@ genrule(
 go_library(
     name = "bazelisk",
     srcs = ["bazelisk.go"],
-    embedsrcs = select({
-        "//:fastbuild": [":empty"],  # Need at least one file to embed
-        "//conditions:default": [":bazelisk-1.10.1"],
-    }),
+    embedsrcs = [":bazelisk-1.10.1"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/bazelisk",
     visibility = ["//visibility:public"],
 )

--- a/server/util/bazelisk/BUILD
+++ b/server/util/bazelisk/BUILD
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+genrule(
+    name = "bazelisk-1.10.1_crossplatform",
+    srcs = select({
+        "@bazel_tools//src/conditions:darwin_x86_64": ["@io_bazel_bazelisk-1.10.1-darwin-amd64//file:downloaded"],
+        "@bazel_tools//src/conditions:darwin_arm64": ["@io_bazel_bazelisk-1.10.1-darwin-arm64//file:downloaded"],
+        "//conditions:default": ["@io_bazel_bazelisk-1.10.1-linux-amd64//file:downloaded"],
+    }),
+    outs = ["bazelisk-1.10.1"],
+    cmd_bash = "cp $(SRCS) $@",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "bazelisk",
+    srcs = ["bazelisk.go"],
+    embedsrcs = select({
+        "//:fastbuild": [":empty"],  # Need at least one file to embed
+        "//conditions:default": [":bazelisk-1.10.1"],
+    }),
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/bazelisk",
+    visibility = ["//visibility:public"],
+)

--- a/server/util/bazelisk/BUILD
+++ b/server/util/bazelisk/BUILD
@@ -15,7 +15,7 @@ genrule(
 go_library(
     name = "bazelisk",
     srcs = ["bazelisk.go"],
-    embedsrcs = [":bazelisk-1.10.1"],
+    embedsrcs = [":bazelisk-1.10.1"],  # keep
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/bazelisk",
     visibility = ["//visibility:public"],
 )

--- a/server/util/bazelisk/bazelisk.go
+++ b/server/util/bazelisk/bazelisk.go
@@ -1,0 +1,13 @@
+package bazelisk
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed *
+var embedFS embed.FS
+
+func Open() (fs.File, error) {
+	return embedFS.Open("bazelisk-1.10.1")
+}


### PR DESCRIPTION
Increases the size of the standalone CI runner binary by about 5MB (bringing the total size to 25MB).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
