### PR TITLE
More CSS fixes for build logs

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -927,8 +927,6 @@ code .comment {
 .terminal {
   height: 300px;
   margin-top: -49px;
-  /* overflow-x: auto;
-  overflow-y: hidden; */
   overflow: visible;
 }
 

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -920,11 +920,16 @@ code .comment {
 
 /** Misc **/
 
+.terminal-container {
+  position: relative;
+}
+
 .terminal {
   height: 300px;
   margin-top: -49px;
-  overflow-x: auto;
-  overflow-y: hidden;
+  /* overflow-x: auto;
+  overflow-y: hidden; */
+  overflow: visible;
 }
 
 .terminal a {
@@ -938,14 +943,23 @@ code .comment {
 }
 
 .terminal-actions {
-  right: 32px;
-  top: 22px;
+  right: 0;
   position: absolute;
   z-index: 1;
 }
 
-.dense .terminal-actions {
-  top: 4px;
+.light-terminal .terminal-actions {
+  filter: invert();
+}
+
+.light-terminal .react-lazylog-searchbar-input {
+  background-color: white;
+  border: 1px solid #eee;
+  color: black;
+}
+
+.light-terminal .react-lazylog-searchbar-input::placeholder {
+  color: #aaa;
 }
 
 .terminal-actions img {
@@ -974,9 +988,10 @@ code .comment {
   pointer-events: none;
 }
 
-.react-lazylog-searchbar {
-  margin-bottom: 8px;
+/* Duplicate class selector here is used to increase specificity */
+.react-lazylog-searchbar.react-lazylog-searchbar {
   margin-right: 80px;
+  background-color: transparent;
 }
 
 .dense .react-lazylog-searchbar {

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -25,7 +25,7 @@ export default class TerminalComponent extends React.Component<TerminalProps, Te
 
   render() {
     return (
-      <>
+      <div className={`terminal-container ${this.props.lightTheme ? "light-terminal" : ""}`}>
         <div className="terminal-actions">
           <button
             title="Wrap"
@@ -53,7 +53,7 @@ export default class TerminalComponent extends React.Component<TerminalProps, Te
             {...{ lightTheme: this.props.lightTheme }}
           />
         </div>
-      </>
+      </div>
     );
   }
 


### PR DESCRIPTION
Tested in Chrome (both Linux and macOS) and Safari.

Test log (light / non-dense)

![image](https://user-images.githubusercontent.com/2414826/142458055-46c241a9-8fba-4594-97d7-29c78f8b476e.png)

Build log (dark / dense)

![image](https://user-images.githubusercontent.com/2414826/142458167-9737a81f-85ca-40b5-8f46-a24860ceb464.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
