### PR TITLE
Fix MySQL 8 syntax for BEP webhooks

### DIFF
--- a/server/build_event_protocol/webhooks/webhooks.go
+++ b/server/build_event_protocol/webhooks/webhooks.go
@@ -42,7 +42,7 @@ func (h *invocationUploadHook) NotifyComplete(ctx context.Context, in *inpb.Invo
 	db := h.env.GetDBHandle()
 	row := &struct{ InvocationWebhookURL string }{}
 	err := db.Raw(
-		`SELECT invocation_webhook_url FROM Groups WHERE group_id = ?`,
+		"SELECT invocation_webhook_url FROM `Groups` WHERE group_id = ?",
 		groupID,
 	).Take(row).Error
 	if err != nil {


### PR DESCRIPTION
The infamous `Groups` table quoting issue strikes once again. This is a problem in MySQL 8 but not 5.7

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
