### PR TITLE
Add a webdriver test for authenticated invocations (via self-auth)

### DIFF
--- a/enterprise/app/login/login.tsx
+++ b/enterprise/app/login/login.tsx
@@ -118,7 +118,9 @@ export default class LoginComponent extends React.Component<Props, State> {
                     Happier Developers.
                   </>
                 )}
-                {!redirecting && this.isJoiningOrg() && this.state.orgName && <>Join {this.state.orgName} on BuildBuddy</>}
+                {!redirecting && this.isJoiningOrg() && this.state.orgName && (
+                  <>Join {this.state.orgName} on BuildBuddy</>
+                )}
                 {redirecting && <>Login to continue</>}
               </div>
               <div className="hide-on-mobile">
@@ -127,8 +129,12 @@ export default class LoginComponent extends React.Component<Props, State> {
               </div>
             </div>
             <div className="login-buttons">
-              <button onClick={this.handleLoginClicked.bind(this)}>Sign up for BuildBuddy</button>
-              <button onClick={this.handleLoginClicked.bind(this)}>Log in to BuildBuddy</button>
+              <button className="signup-button" onClick={this.handleLoginClicked.bind(this)}>
+                Sign up for BuildBuddy
+              </button>
+              <button className="login-button" onClick={this.handleLoginClicked.bind(this)}>
+                Log in to BuildBuddy
+              </button>
               {capabilities.anonymous && (
                 <button onClick={this.handleSetupClicked.bind(this)}>Use BuildBuddy without an account</button>
               )}

--- a/enterprise/app/sidebar/sidebar.tsx
+++ b/enterprise/app/sidebar/sidebar.tsx
@@ -263,7 +263,7 @@ export default class SidebarComponent extends React.Component {
                   </div>
                 )}
               </div>
-              <div className="sidebar-item" onClick={() => authService.logout()}>
+              <div className="sidebar-item sidebar-logout-item" onClick={() => authService.logout()}>
                 <img src="/image/log-out-white.svg" /> Logout
               </div>
               <div className="sidebar-item" onClick={() => router.navigateToSettings()}>

--- a/enterprise/server/test/webdriver/BUILD
+++ b/enterprise/server/test/webdriver/BUILD
@@ -1,0 +1,4 @@
+# Instruct Gazelle to generate go_web_test_suite rules for newly added tests,
+# and let it manage deps for existing go_web_test_suite rules.
+
+# gazelle:map_kind go_test go_web_test_suite //rules/webdriver:index.bzl

--- a/enterprise/server/test/webdriver/invocation/BUILD
+++ b/enterprise/server/test/webdriver/invocation/BUILD
@@ -1,0 +1,14 @@
+load("//rules/webdriver:index.bzl", "go_web_test_suite")
+
+go_web_test_suite(
+    name = "invocation_test",
+    srcs = ["invocation_test.go"],
+    shard_count = 1,
+    deps = [
+        "//enterprise/server/testutil/buildbuddy_enterprise",
+        "//server/testutil/testbazel",
+        "//server/testutil/webtester",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/test/webdriver/invocation/invocation_test.go
+++ b/enterprise/server/test/webdriver/invocation/invocation_test.go
@@ -1,0 +1,63 @@
+package invocation_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/buildbuddy_enterprise"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testbazel"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/webtester"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthenticatedInvocation_LogUploadEnabled(t *testing.T) {
+	wt := webtester.New(t)
+	app := buildbuddy_enterprise.Run(t)
+
+	workspacePath := testbazel.MakeTempWorkspace(t, map[string]string{
+		"WORKSPACE": "",
+		"BUILD":     `genrule(name = "a", outs = ["a.sh"], cmd_bash = "touch $@")`,
+	})
+	buildArgs := append([]string{"//:a", "--show_progress=0"}, app.BESBazelFlags()...)
+
+	// Log in and get the build flags needed for BuildBuddy, including API key
+	webtester.Login(wt, app.HTTPURL())
+	buildbuddyBuildFlags := webtester.GetBazelBuildFlags(wt, app.HTTPURL(), webtester.WithEnableCache)
+	t.Log(buildbuddyBuildFlags)
+	buildArgs = append(buildArgs, buildbuddyBuildFlags...)
+
+	result := testbazel.Invoke(context.Background(), t, workspacePath, "build", buildArgs...)
+	require.NotEmpty(t, result.InvocationID)
+
+	// Make sure we can view the invocation while logged in
+	wt.Get(app.HTTPURL() + "/invocation/" + result.InvocationID)
+
+	details := wt.Find(".details").Text()
+
+	assert.Contains(t, details, "Succeeded")
+	assert.NotContains(t, details, "Failed")
+	assert.Contains(t, details, "//:a")
+	assert.Contains(t, details, "Log upload on")
+	assert.Contains(t, details, "Remote execution off")
+
+	// Sanity check that the login button is not present while logged in,
+	// since we rely on this to check whether we're logged out
+	require.Empty(
+		t, wt.FindAll(".login-button"),
+		"login button is not expected to be visible if logged in",
+	)
+
+	// Log out and make sure we see only the login page when attempting to view
+	// the invocation again
+
+	webtester.Logout(wt)
+
+	wt.Get(app.HTTPURL() + "/invocation/" + result.InvocationID)
+
+	wt.Find(".login-button")
+
+	// TODO(bduffany): Log in as a different self-auth user that is not in the
+	// default BB org, and make sure we get PermissionDenied instead of the
+	// login page
+}

--- a/enterprise/server/testutil/buildbuddy_enterprise/buildbuddy_enterprise.go
+++ b/enterprise/server/testutil/buildbuddy_enterprise/buildbuddy_enterprise.go
@@ -23,6 +23,7 @@ func RunWithConfig(t *testing.T, configPath string, args ...string) *app.App {
 		fmt.Sprintf("--telemetry_port=%d", app.FreePort(t)),
 		"--app_directory=/enterprise/app",
 		"--app.default_redis_target=" + redisTarget,
+		"--auth.enable_self_auth=true",
 	}
 	commandArgs = append(commandArgs, args...)
 	return app.Run(

--- a/server/testutil/webtester/webtester.go
+++ b/server/testutil/webtester/webtester.go
@@ -3,6 +3,7 @@ package webtester
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/bazelbuild/rules_webtesting/go/webtest"
@@ -64,6 +65,17 @@ func (wt *WebTester) Find(cssSelector string) *Element {
 	return &Element{wt.t, el}
 }
 
+// FindAll returns all elements matching the given CSS selector.
+func (wt *WebTester) FindAll(cssSelector string) []*Element {
+	els, err := wt.driver.FindElements(selenium.ByCSSSelector, cssSelector)
+	require.NoError(wt.t, err)
+	out := make([]*Element, len(els))
+	for i, el := range els {
+		out[i] = &Element{wt.t, el}
+	}
+	return out
+}
+
 // Screenshot takes a screenshot and saves it in the test outputs directory. The
 // given tag is used to disambiguate between other screenhots taken in the test.
 func (wt *WebTester) Screenshot(tag string) {
@@ -110,4 +122,101 @@ func (el *Element) Text() string {
 	txt, err := el.webElement.Text()
 	require.NoError(el.t, err)
 	return txt
+}
+
+// IsSelected returns whether the element is selected.
+func (el *Element) IsSelected() bool {
+	val, err := el.webElement.IsSelected()
+	require.NoError(el.t, err)
+	return val
+}
+
+// GetAttribute returns the named attribute of the element.
+func (el *Element) GetAttribute(name string) string {
+	val, err := el.webElement.GetAttribute(name)
+	require.NoError(el.t, err)
+	return val
+}
+
+// ===
+// Utility functions that don't directly correspond with WebElement APIs
+// ===
+
+// HasClass returns whether an element has the given class name.
+func HasClass(el *Element, class string) bool {
+	classes := strings.Split(el.GetAttribute("class"), " ")
+	for _, c := range classes {
+		if c == class {
+			return true
+		}
+	}
+	return false
+}
+
+// ===
+// BuildBuddy-specific functionality
+// ===
+
+// Login uses the Web app to log into BuildBuddy as the default self-auth user.
+// It expects that no user is currently logged in, and that self-auth is
+// enabled.
+func Login(wt *WebTester, appBaseURL string) {
+	wt.Get(appBaseURL)
+	wt.Find(".login-button").Click()
+}
+
+// Logout logs out of the app. It expects that a user is currently logged in,
+// with the sidebar visible in the UI.
+func Logout(wt *WebTester) {
+	ExpandSidebarOptions(wt)
+	wt.Find(".sidebar-logout-item").Click()
+}
+
+// ExpandSidebarOptions expands the sidebar options, exposing the section
+// containing links to Logout, Settings, etc.
+func ExpandSidebarOptions(wt *WebTester) {
+	toggle := wt.Find(".sidebar-footer")
+	if HasClass(toggle, "expanded") {
+		return
+	}
+	toggle.Click()
+}
+
+// SetupPageOption applies a desired setting to the setup page.
+type SetupPageOption func(wt *WebTester)
+
+var (
+	// WithEnableCache is a setup page option that checks the "enable cache"
+	// checkbox.
+	WithEnableCache SetupPageOption = func(wt *WebTester) {
+		checkbox := wt.Find("#cache")
+		if !checkbox.IsSelected() {
+			checkbox.Click()
+		}
+	}
+)
+
+// GetBazelBuildFlags uses the Web app to navigate to the setup page and get the
+// Bazel config flags recommended by BuildBuddy. Options can be passed to select
+// config options via the UI.
+func GetBazelBuildFlags(wt *WebTester, appBaseURL string, opts ...SetupPageOption) []string {
+	wt.Get(appBaseURL + "/docs/setup/")
+	for _, fn := range opts {
+		fn(wt)
+	}
+	rawBazelrc := wt.Find(`[data-header=".bazelrc"] .contents`).Text()
+	lines := strings.Split(strings.TrimSpace(rawBazelrc), "\n")
+	buildFlags := make([]string, 0, len(lines))
+	for _, line := range lines {
+		// Remove comments
+		parts := strings.Split(line, "#")
+		if len(parts) > 1 {
+			line = parts[0]
+		}
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "build ") {
+			buildFlags = append(buildFlags, strings.TrimPrefix(line, "build "))
+		}
+	}
+	return buildFlags
 }


### PR DESCRIPTION
Uses the new self-auth to log in to the app, gets the bazelrc contents (including the API key) from the setup page, then runs a bazel invocation using those recommended bazelrc flags. Asserts that we can view the invocation if we're still logged in, and that if we're logged out, we see the login page instead.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
