### PR TITLE
Temporarily revert bazel cleanup logic causing workflow_test to be flaky

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -267,9 +267,11 @@ func (r *CommandRunner) Remove(ctx context.Context) error {
 	errs := []error{}
 	if s := r.state; s != initial && s != removed {
 		r.state = removed
-		if err := r.shutdown(ctx); err != nil {
-			errs = append(errs, err)
-		}
+		// TODO(bduffany): Figure out why this causes workflow_test to be flaky,
+		// and re-enable.
+		// if err := r.shutdown(ctx); err != nil {
+		// 	errs = append(errs, err)
+		// }
 		if err := r.Container.Remove(ctx); err != nil {
 			errs = append(errs, err)
 		}


### PR DESCRIPTION
This was added in #1237 which is not in prod yet so it's safe to revert. Occasionally, it causes workflow_test to fail.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
