### PR TITLE
Fix workflow_test flakiness and re-enable bare workflow runner shutdown logic

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -267,11 +267,9 @@ func (r *CommandRunner) Remove(ctx context.Context) error {
 	errs := []error{}
 	if s := r.state; s != initial && s != removed {
 		r.state = removed
-		// TODO(bduffany): Figure out why this causes workflow_test to be flaky,
-		// and re-enable.
-		// if err := r.shutdown(ctx); err != nil {
-		// 	errs = append(errs, err)
-		// }
+		if err := r.shutdown(ctx); err != nil {
+			errs = append(errs, err)
+		}
 		if err := r.Container.Remove(ctx); err != nil {
 			errs = append(errs, err)
 		}

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -189,6 +189,7 @@ func NewRBETestEnv(t *testing.T) *Env {
 		log.Warningf("Shutting down executors...")
 		var wg sync.WaitGroup
 		for id, e := range rbe.executors {
+			id, e := id, e
 			e.env.GetHealthChecker().Shutdown()
 			wg.Add(1)
 			go func() {


### PR DESCRIPTION
The root cause is that we weren't properly waiting for all executors to shut down before removing the test root workspace containing the data for all the executors.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
