### PR TITLE
Fix jankiness / network waterfall while loading SVGs during initial page load

### DIFF
--- a/app/alert/BUILD
+++ b/app/alert/BUILD
@@ -10,6 +10,7 @@ ts_library(
     ]),
     deps = [
         "@npm//@types/react",
+        "@npm//lucide-react",
         "@npm//react",
         "@npm//rxjs",
     ],

--- a/app/alert/alert.tsx
+++ b/app/alert/alert.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Subscription } from "rxjs";
 import alertService, { Alert, AlertType } from "./alert_service";
+import { XCircle, CheckCircle } from "lucide-react";
 
 interface State {
   alert?: Alert;
@@ -9,9 +10,9 @@ interface State {
 
 const DISPLAY_DURATION_MS = 4000;
 
-const ICON_URLS: Record<AlertType, string> = {
-  error: "/image/x-circle-regular.svg",
-  success: "/image/check-circle.svg",
+const ICONS: Record<AlertType, JSX.Element> = {
+  error: <XCircle className="red" />,
+  success: <CheckCircle className="green" />,
 };
 
 export default class AlertComponent extends React.Component<{}, State> {
@@ -48,7 +49,7 @@ export default class AlertComponent extends React.Component<{}, State> {
         className={`alert-banner alert-type-${this.state.alert?.type} ${this.state.isVisible ? "visible" : "hidden"}`}
         onMouseEnter={this.onMouseEnter.bind(this)}
         onMouseLeave={this.onMouseLeave.bind(this)}>
-        <img src={ICON_URLS[this.state.alert?.type]} />
+        {ICONS[this.state.alert?.type]}
         <span>{this.state.alert?.message}</span>
       </div>
     );

--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -46,6 +46,7 @@ ts_library(
         "@npm//@types/react",
         "@npm//dagre-d3-react",
         "@npm//long",
+        "@npm//lucide-react",
         "@npm//moment",
         "@npm//pako",
         "@npm//protobufjs",

--- a/app/invocation/invocation_error_card.tsx
+++ b/app/invocation/invocation_error_card.tsx
@@ -1,3 +1,4 @@
+import { AlertCircle } from "lucide-react";
 import React from "react";
 import InvocationModel from "./invocation_model";
 
@@ -11,7 +12,7 @@ export default class ErrorCardComponent extends React.Component {
   render() {
     return (
       <div className="card card-failure">
-        <img className="icon" src="/image/alert-circle.svg" />
+        <AlertCircle className="icon" />
         <div className="content">
           <div className="title">Error</div>
           <div className="details">{this.props.model.aborted.aborted.description}</div>

--- a/app/invocation/invocation_filter.tsx
+++ b/app/invocation/invocation_filter.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-
+import { Filter } from "lucide-react";
 import router from "../router/router";
 
 interface Props {
@@ -44,7 +44,7 @@ export default class InvocationFilterComponent extends React.Component {
   render() {
     return (
       <div className="filter">
-        <img src="/image/filter.svg" />
+        <Filter className="icon" />
         <input
           value={this.props.search.get(this.filterType())}
           className="filter-input"

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -1,3 +1,4 @@
+import { HelpCircle, PlayCircle, XCircle, CheckCircle } from "lucide-react";
 import moment from "moment";
 import React from "react";
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
@@ -136,8 +137,7 @@ export default class InvocationModel {
           model.buildToolLogs = buildEvent.buildToolLogs as build_event_stream.BuildToolLogs;
         }
         if (buildEvent.unstructuredCommandLine) {
-          model.unstructuredCommandLine =
-            buildEvent.unstructuredCommandLine as build_event_stream.UnstructuredCommandLine;
+          model.unstructuredCommandLine = buildEvent.unstructuredCommandLine as build_event_stream.UnstructuredCommandLine;
         }
       }
     }
@@ -456,19 +456,15 @@ export default class InvocationModel {
   getStatusIcon() {
     let invocationStatus = this.invocations.find(() => true)?.invocationStatus;
     if (invocationStatus == invocation.Invocation.InvocationStatus.DISCONNECTED_INVOCATION_STATUS) {
-      return <img className="icon status" src="/image/help-circle.svg" />;
+      return <HelpCircle className="icon" />;
     }
     if (!this.started) {
-      return <img className="icon status" src="/image/help-circle.svg" />;
+      return <HelpCircle className="icon" />;
     }
     if (!this.finished) {
-      return <img className="icon status" src="/image/play-circle.svg" />;
+      return <PlayCircle className="icon blue" />;
     }
-    return this.finished.exitCode.code == 0 ? (
-      <img className="icon status" src="/image/check-circle.svg" />
-    ) : (
-      <img className="icon status" src="/image/x-circle.svg" />
-    );
+    return this.finished.exitCode.code == 0 ? <CheckCircle className="icon green" /> : <XCircle className="icon red" />;
   }
 
   getCPU() {

--- a/app/invocation/invocation_overview.tsx
+++ b/app/invocation/invocation_overview.tsx
@@ -1,3 +1,22 @@
+import {
+  Activity,
+  Box,
+  Clock,
+  Cpu,
+  DownloadCloud,
+  Github,
+  GitBranch,
+  GitCommit,
+  Package,
+  Cloud,
+  HardDrive,
+  LayoutGrid,
+  Link,
+  Target,
+  User as UserIcon,
+  Wrench,
+  Zap,
+} from "lucide-react";
 import React from "react";
 import { User } from "../auth/auth_service";
 import format from "../format/format";
@@ -104,24 +123,24 @@ export default class InvocationOverviewComponent extends React.Component {
             {this.props.model.getStatus()}
           </div>
           <div className="detail" title={this.props.model.getDurationSeconds()}>
-            <img className="icon" src="/image/clock-regular.svg" />
+            <Clock className="icon" />
             {this.props.model.getTiming()}
           </div>
           <div className="detail clickable" onClick={this.handleUserClicked.bind(this)}>
-            <img className="icon" src="/image/user-regular.svg" />
+            <UserIcon className="icon" />
             {this.props.model.getUser(false)}
           </div>
           <div className="detail clickable" onClick={this.handleHostClicked.bind(this)}>
-            <img className="icon" src="/image/hard-drive-regular.svg" />
+            <HardDrive className="icon" />
             {this.props.model.getHost()}
           </div>
           <div className="detail">
-            <img className="icon" src="/image/tool-regular.svg" />
+            <Wrench className="icon" />
             {this.props.model.getTool()}
           </div>
           {isBazelInvocation && (
             <div className="detail" title={this.props.model.getAllPatterns()}>
-              <img className="icon" src="/image/grid-regular.svg" />
+              <LayoutGrid className="icon" />
               {this.props.model.getPattern()}
             </div>
           )}
@@ -129,19 +148,19 @@ export default class InvocationOverviewComponent extends React.Component {
             <div
               className="detail"
               title={`${this.props.model.buildMetrics?.targetMetrics.targetsConfigured} configured / ${this.props.model.buildMetrics?.targetMetrics.targetsLoaded} loaded`}>
-              <img className="icon" src="/image/target-regular.svg" />
+              <Target className="icon" />
               {this.props.model.targets.length} {this.props.model.targets.length == 1 ? "target" : "targets"}
             </div>
           )}
           {isBazelInvocation && (
             <div title={`${this.props.model.buildMetrics?.actionSummary.actionsCreated} created`} className="detail">
-              <img className="icon" src="/image/activity-regular.svg" />
+              <Activity className="icon" />
               {this.props.model.buildMetrics?.actionSummary.actionsExecuted} actions
             </div>
           )}
           {isBazelInvocation && (
             <div className="detail">
-              <img className="icon" src="/image/box-regular.svg" />
+              <Box className="icon" />
               {this.props.model.buildMetrics?.packageMetrics.packagesLoaded} packages
             </div>
           )}
@@ -149,49 +168,49 @@ export default class InvocationOverviewComponent extends React.Component {
             <div
               className={this.props.model.getFetchURLs().length ? "detail clickable" : "detail"}
               onClick={this.handleFetchesClicked.bind(this)}>
-              <img className="icon" src="/image/link.svg" />
+              <DownloadCloud className="icon" />
               {this.props.model.getFetchURLs().length} fetches
             </div>
           )}
           {isBazelInvocation && (
             <div className="detail">
-              <img className="icon" src="/image/cpu-regular.svg" />
+              <Cpu className="icon" />
               {this.props.model.getCPU()}
             </div>
           )}
           {isBazelInvocation && (
             <div className="detail">
-              <img className="icon" src="/image/zap-regular.svg" />
+              <Zap className="icon" />
               {this.props.model.getMode()}
             </div>
           )}
           {this.props.model.getRepo() && (
             <div className="detail clickable" onClick={this.handleRepoClicked.bind(this)}>
-              <img className="icon" src="/image/github-regular.svg" />
+              <Github className="icon" />
               {format.formatGitUrl(this.props.model.getRepo())}
             </div>
           )}
           {this.props.model.getBranchName() && (
             <div className="detail clickable" onClick={this.handleBranchClicked.bind(this)}>
-              <img className="icon" src="/image/git-branch-regular.svg" />
+              <GitBranch className="icon" />
               {this.props.model.getBranchName()}
             </div>
           )}
           {this.props.model.getCommit() && (
             <div className="detail clickable" onClick={this.handleCommitClicked.bind(this)}>
-              <img className="icon" src="/image/git-commit-regular.svg" />
+              <GitCommit className="icon" />
               {format.formatCommitHash(this.props.model.getCommit())}
             </div>
           )}
           {isBazelInvocation && (
             <div className="detail clickable" onClick={this.handleCacheClicked.bind(this)}>
-              <img className="icon" src="/image/package-regular.svg" />
+              <Package className="icon" />
               {this.props.model.getCache()}
             </div>
           )}
           {isBazelInvocation && (
             <div className="detail clickable" onClick={this.handleRBEClicked.bind(this)}>
-              <img className="icon" src="/image/cloud-regular.svg" />
+              <Cloud className="icon" />
               {this.props.model.getRBE()}
             </div>
           )}
@@ -203,7 +222,7 @@ export default class InvocationOverviewComponent extends React.Component {
           )}
           {this.props.model.getLinks().map((link) => (
             <a className="detail clickable" href={link.linkUrl} target="_blank">
-              <img className="icon" src="/image/link.svg" />
+              <Link className="icon" />
               {link.linkText}
             </a>
           ))}

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -256,18 +256,38 @@ button {
   margin-top: 8px;
 }
 
-.shelf .details img {
-  opacity: 0.5;
+.shelf .details .icon {
   margin-right: 8px;
-}
-
-.shelf .details img.buildkite,
-.shelf .details img.status {
-  opacity: 1;
 }
 
 .shelf .details img:first-of-type {
   margin-left: 0;
+}
+
+/* Default icon color is gray */
+.icon {
+  stroke: #616161;
+}
+
+.icon.gray,
+.icon.grey {
+  stroke: #616161;
+}
+
+.icon.green {
+  stroke: #8bc34a;
+}
+
+.icon.red {
+  stroke: #f44336;
+}
+
+.icon.blue {
+  stroke: #03a9f4;
+}
+
+.icon.white {
+  color: #fff;
 }
 
 .org-button {
@@ -384,7 +404,7 @@ button {
   overflow: hidden;
 }
 
-.filter img {
+.filter svg {
   width: 16px;
   height: 16px;
   opacity: 0.3;
@@ -852,12 +872,11 @@ code .comment {
   margin-top: 8px;
 }
 
-.history .details img {
-  opacity: 0.5;
+.history .details .icon {
   margin-right: 8px;
 }
 
-.history .details img:first-of-type {
+.history .details .icon:first-of-type {
   margin-left: 0;
 }
 

--- a/enterprise/app/api_keys/BUILD
+++ b/enterprise/app/api_keys/BUILD
@@ -19,6 +19,7 @@ ts_library(
         "//app/util:errors",
         "//proto:api_key_ts_proto",
         "@npm//@types/react",
+        "@npm//lucide-react",
         "@npm//react",
     ],
 )

--- a/enterprise/app/api_keys/api_keys.css
+++ b/enterprise/app/api_keys/api_keys.css
@@ -102,8 +102,8 @@
   overflow-x: hidden;
 }
 
-.api-keys .api-key-label img,
-.api-keys .api-key-value img {
+.api-keys .api-key-label svg,
+.api-keys .api-key-value svg {
   width: 16px;
   height: 16px;
   margin-right: 8px;

--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -1,5 +1,7 @@
+import { Key } from "lucide-react";
 import React from "react";
 import { User } from "../../../app/auth/auth_service";
+import capabilities from "../../../app/capabilities/capabilities";
 import FilledButton, { OutlinedButton } from "../../../app/components/button/button";
 import Dialog, {
   DialogBody,
@@ -8,7 +10,6 @@ import Dialog, {
   DialogHeader,
   DialogTitle,
 } from "../../../app/components/dialog/dialog";
-import capabilities from "../../../app/capabilities/capabilities";
 import TextInput from "../../../app/components/input/input";
 import Modal from "../../../app/components/modal/modal";
 import errorService from "../../../app/errors/error_service";
@@ -381,7 +382,7 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
                 <span>{describeCapabilities(key)}</span>
               </div>
               <div className="api-key-value">
-                <img src="/image/key.svg" />
+                <Key className="icon" />
                 <span>{key.value}</span>
               </div>
               {this.props.user.canCall("updateApiKey") && (

--- a/enterprise/app/filter/BUILD
+++ b/enterprise/app/filter/BUILD
@@ -20,6 +20,7 @@ ts_library(
         "@npm//@types/react",
         "@npm//@types/react-date-range",
         "@npm//date-fns",
+        "@npm//lucide-react",
         "@npm//moment",
         "@npm//react",
         "@npm//react-date-range",

--- a/enterprise/app/filter/filter.tsx
+++ b/enterprise/app/filter/filter.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { DateRangePicker, OnChangeProps, Range } from "react-date-range";
 import FilledButton, { OutlinedButton } from "../../../app/components/button/button";
 import Popup from "../../../app/components/popup/popup";
-import Radio from "../../../app/components/radio/radio";
+import { Filter, X, Calendar } from "lucide-react";
 import Checkbox from "../../../app/components/checkbox/checkbox";
 import { formatDateRange } from "../../../app/format/format";
 import router, {
@@ -188,14 +188,14 @@ export default class FilterComponent extends React.Component<FilterProps, State>
       <div className={`global-filter ${isFiltering ? "is-filtering" : ""}`}>
         {isFiltering && (
           <FilledButton className="square" title="Clear filters" onClick={this.onClickClearFilters.bind(this)}>
-            <img src="/image/x-white.svg" alt="" />
+            <X className="icon white" />
           </FilledButton>
         )}
         <div className="popup-wrapper">
           <OutlinedButton
             className={`filter-menu-button icon-text-button ${isFiltering ? "" : "square"}`}
             onClick={this.onOpenFilterMenu.bind(this)}>
-            <img className="subtle-icon" src="/image/filter.svg" alt="" />
+            <Filter className="icon" />
             {selectedStatuses.has(invocation.OverallStatus.SUCCESS) && <span className="status-block success" />}
             {selectedStatuses.has(invocation.OverallStatus.FAILURE) && <span className="status-block failure" />}
             {selectedStatuses.has(invocation.OverallStatus.IN_PROGRESS) && (
@@ -235,7 +235,7 @@ export default class FilterComponent extends React.Component<FilterProps, State>
         </div>
         <div className="popup-wrapper">
           <OutlinedButton className="date-picker-button icon-text-button" onClick={this.onOpenDatePicker.bind(this)}>
-            <img className="subtle-icon" src="/image/calendar.svg" alt="" />
+            <Calendar className="icon" />
             <span>{formatDateRange(startDate, endDate)}</span>
           </OutlinedButton>
           <Popup

--- a/enterprise/app/history/BUILD
+++ b/enterprise/app/history/BUILD
@@ -21,6 +21,7 @@ ts_library(
         "//proto:invocation_ts_proto",
         "//proto:user_ts_proto",
         "@npm//@types/react",
+        "@npm//lucide-react",
         "@npm//moment",
         "@npm//protobufjs",
         "@npm//react",

--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -14,6 +14,7 @@ import HistoryInvocationCardComponent from "./history_invocation_card";
 import HistoryInvocationStatCardComponent from "./history_invocation_stat_card";
 import { getProtoFilterParams } from "../filter/filter_util";
 import Spinner from "../../../app/components/spinner/spinner";
+import { CheckCircle, Clock, Hash, Percent, XCircle } from "lucide-react";
 
 interface State {
   /**
@@ -455,19 +456,19 @@ export default class HistoryComponent extends React.Component<Props, State> {
             {this.state.summaryStat && !hideSummaryStats && (
               <div className="details">
                 <div className="detail">
-                  <img className="icon" src="/image/hash.svg" />
+                  <Hash className="icon gray" />
                   {format.formatWithCommas(this.state.summaryStat.totalNumBuilds)} builds
                 </div>
                 <div className="detail">
-                  <img className="icon" src="/image/check-circle.svg" />
+                  <CheckCircle className="icon green" />
                   {format.formatWithCommas(this.state.summaryStat.totalNumSucessfulBuilds)} passed
                 </div>
                 <div className="detail">
-                  <img className="icon" src="/image/x-circle.svg" />
+                  <XCircle className="icon red" />
                   {format.formatWithCommas(this.state.summaryStat.totalNumFailingBuilds)} failed
                 </div>
                 <div className="detail">
-                  <img className="icon" src="/image/percent.svg" />
+                  <Percent className="icon grey" />
                   {format.percent(
                     Number(this.state.summaryStat.totalNumSucessfulBuilds) /
                       (Number(this.state.summaryStat.totalNumSucessfulBuilds) +
@@ -476,11 +477,11 @@ export default class HistoryComponent extends React.Component<Props, State> {
                   passed
                 </div>
                 <div className="detail">
-                  <img className="icon" src="/image/clock-regular.svg" />
+                  <Clock className="icon" />
                   {format.durationUsec(this.state.summaryStat.totalBuildTimeUsec)} total
                 </div>
                 <div className="detail">
-                  <img className="icon" src="/image/clock-regular.svg" />
+                  <Clock className="icon" />
                   {format.durationUsec(
                     Number(this.state.summaryStat.totalBuildTimeUsec) / Number(this.state.summaryStat.totalNumBuilds)
                   )}{" "}

--- a/enterprise/app/history/history_invocation_card.tsx
+++ b/enterprise/app/history/history_invocation_card.tsx
@@ -1,3 +1,15 @@
+import {
+  CheckCircle,
+  Clock,
+  Github,
+  HardDrive,
+  HelpCircle,
+  LayoutGrid,
+  PlayCircle,
+  User,
+  Wrench,
+  XCircle,
+} from "lucide-react";
 import React from "react";
 import format from "../../../app/format/format";
 import router from "../../../app/router/router";
@@ -102,16 +114,16 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
     return this.props.invocation.success ? "card-success" : "card-failure";
   }
 
-  getStatusIcon() {
+  renderStatusIcon() {
     if (this.isInProgress()) {
-      return "/image/play-circle.svg";
+      return <PlayCircle className="icon blue" />;
     }
 
     if (this.isDisconnected()) {
-      return "/image/help-circle.svg";
+      return <HelpCircle className="icon" />;
     }
 
-    return this.props.invocation.success ? "/image/check-circle.svg" : "/image/x-circle.svg";
+    return this.props.invocation.success ? <CheckCircle className="icon green" /> : <XCircle className="icon red" />;
   }
 
   getStatusLabel() {
@@ -192,11 +204,11 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
           {!this.props.hover && (
             <div className="details">
               <div className="detail">
-                <img className="icon" src={this.getStatusIcon()} />
+                {this.renderStatusIcon()}
                 {this.getStatusLabel()}
               </div>
               <div className="detail">
-                <img className="icon" src="/image/clock-regular.svg" />
+                <Clock className="icon" />
                 {this.getDuration()}
               </div>
               {this.props.invocation.user && (
@@ -205,7 +217,7 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
                   onClick={(e) => {
                     this.handleUserClicked(e, this.props.invocation);
                   }}>
-                  <img className="icon" src="/image/user-regular.svg" />
+                  <User className="icon" />
                   {this.props.invocation.user}
                 </div>
               )}
@@ -215,19 +227,19 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
                   onClick={(e) => {
                     this.handleHostClicked(e, this.props.invocation);
                   }}>
-                  <img className="icon" src="/image/hard-drive-regular.svg" />
+                  <HardDrive className="icon" />
                   {this.props.invocation.host}
                 </div>
               )}
               {this.props.invocation.command && (
                 <div className="detail">
-                  <img className="icon" src="/image/tool-regular.svg" />
+                  <Wrench className="icon" />
                   {this.props.invocation.command}
                 </div>
               )}
               {this.props.invocation.pattern && (
                 <div className="detail">
-                  <img className="icon" src="/image/grid-regular.svg" />
+                  <LayoutGrid className="icon" />
                   {format.truncateList(this.props.invocation.pattern)}
                 </div>
               )}
@@ -237,7 +249,7 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
                   onClick={(e) => {
                     this.handleRepoClicked(e, this.props.invocation);
                   }}>
-                  <img className="icon" src="/image/github-regular.svg" />
+                  <Github className="icon" />
                   {format.formatGitUrl(this.props.invocation.repoUrl)}
                 </div>
               )}

--- a/enterprise/app/history/history_invocation_stat_card.tsx
+++ b/enterprise/app/history/history_invocation_stat_card.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { invocation } from "../../../proto/invocation_ts_proto";
 import router from "../../../app/router/router";
 import format from "../../../app/format/format";
+import { Clock, Hash, XCircle, PlayCircle, CheckCircle, Activity } from "lucide-react";
 
 interface Props {
   invocationStat: invocation.IInvocationStat;
@@ -51,12 +52,14 @@ export default class HistoryInvocationStatCardComponent extends React.Component<
     return this.props.invocationStat.name || "Unknown";
   }
 
-  getIcon() {
-    if (this.props.invocationStat.lastGreenBuildUsec == this.props.invocationStat.latestBuildTimeUsec)
-      return "/image/check-circle.svg";
-    if (this.props.invocationStat.lastRedBuildUsec == this.props.invocationStat.latestBuildTimeUsec)
-      return "/image/x-circle.svg";
-    return "/image/play-circle.svg";
+  renderStatusIcon() {
+    if (this.props.invocationStat.lastGreenBuildUsec == this.props.invocationStat.latestBuildTimeUsec) {
+      return <CheckCircle className="icon green" />;
+    }
+    if (this.props.invocationStat.lastRedBuildUsec == this.props.invocationStat.latestBuildTimeUsec) {
+      return <XCircle className="icon red" />;
+    }
+    return <PlayCircle className="icon blue" />;
   }
 
   getStatus() {
@@ -87,19 +90,19 @@ export default class HistoryInvocationStatCardComponent extends React.Component<
           </div>
           <div className="details">
             <div className="detail">
-              <img className="icon" src={this.getIcon()} />
+              {this.renderStatusIcon()}
               {this.getStatus()}
             </div>
             <div className="detail">
-              <img className="icon" src="/image/hash.svg" />
+              <Hash className="icon" />
               {this.props.invocationStat.totalNumBuilds} total builds
             </div>
             <div className="detail">
-              <img className="icon" src="/image/clock-regular.svg" />
+              <Clock className="icon" />
               {format.durationUsec(this.props.invocationStat.totalBuildTimeUsec)} total
             </div>
             <div className="detail">
-              <img className="icon" src="/image/activity-regular.svg" />
+              <Activity className="icon" />
               {this.props.invocationStat.totalActions} total actions
             </div>
           </div>

--- a/enterprise/app/sidebar/BUILD
+++ b/enterprise/app/sidebar/BUILD
@@ -13,6 +13,7 @@ ts_library(
         "//app/router",
         "//app/service",
         "@npm//@types/react",
+        "@npm//lucide-react",
         "@npm//react",
     ],
 )

--- a/enterprise/app/sidebar/sidebar.css
+++ b/enterprise/app/sidebar/sidebar.css
@@ -16,7 +16,12 @@
 .sidebar .logo {
   width: 100%;
   max-width: 216px;
+  height: 36px;
   box-sizing: border-box;
+}
+
+.dense .sidebar .logo {
+  height: 24.7px;
 }
 
 .sidebar .sidebar-header {
@@ -80,7 +85,7 @@
   font-weight: 600;
   display: flex;
   align-items: center;
-  color: rgb(255, 255, 255, 0.8);
+  color: #90a4ae;
 }
 
 .sidebar .sidebar-item:hover,
@@ -88,16 +93,16 @@
   color: #fff;
 }
 
-.sidebar .sidebar-item img {
+.sidebar .sidebar-item svg {
   margin-right: 16px;
   width: 18px;
   height: 18px;
-  opacity: 0.5;
+  stroke: #90a4ae;
 }
 
-.sidebar .sidebar-item:hover img,
-.sidebar .sidebar-item.selected img {
-  opacity: 1;
+.sidebar .sidebar-item:hover svg,
+.sidebar .sidebar-item.selected svg {
+  stroke: white;
 }
 
 .sidebar .sidebar-footer {
@@ -123,7 +128,7 @@
 }
 
 .sidebar .sidebar-profile-arrow {
-  opacity: 0.7;
+  stroke: #90a4ae;
   margin-left: 4px;
 }
 
@@ -201,7 +206,7 @@
   padding: 16px 16px 0 16px;
 }
 
-.dense .sidebar .sidebar-item img {
+.dense .sidebar .sidebar-item svg {
   margin-right: 12px;
   width: 16px;
   height: 16px;

--- a/enterprise/app/sidebar/sidebar.tsx
+++ b/enterprise/app/sidebar/sidebar.tsx
@@ -1,3 +1,26 @@
+import {
+  BookOpen,
+  Gauge,
+  Settings,
+  Cloud,
+  PlayCircle,
+  Code,
+  HardDrive,
+  Users,
+  GitBranch,
+  Github,
+  BarChart2,
+  LayoutGrid,
+  CheckCircle,
+  Circle,
+  GitCommit,
+  ChevronUp,
+  ChevronDown,
+  List,
+  LogOut,
+  PlusCircle,
+  Sliders,
+} from "lucide-react";
 import React from "react";
 import authService, { User } from "../../../app/auth/auth_service";
 import capabilities from "../../../app/capabilities/capabilities";
@@ -155,80 +178,80 @@ export default class SidebarComponent extends React.Component {
           <div
             className={`sidebar-item ${this.isHomeSelected() ? "selected" : ""}`}
             onClick={this.navigateToAllBuilds.bind(this)}>
-            <img src="/image/list-white.svg" /> All builds
+            <List /> All builds
           </div>
           <div
             className={`sidebar-item ${this.isTrendsSelected() ? "selected" : ""}`}
             onClick={this.navigateToTrends.bind(this)}>
-            <img src="/image/bar-chart-white.svg" /> Trends
+            <BarChart2 /> Trends
           </div>
           {capabilities.test && (
             <div
               className={`sidebar-item ${this.isTapSelected() ? "selected" : ""}`}
               onClick={this.navigateToTap.bind(this)}>
-              <img src="/image/grid-white.svg" /> Tests
+              <LayoutGrid /> Tests
             </div>
           )}
           <div
             className={`sidebar-item ${this.isUsersSelected() ? "selected" : ""}`}
             onClick={this.navigateToUsers.bind(this)}>
-            <img src="/image/users-white.svg" /> Users
+            <Users /> Users
           </div>
           <div
             className={`sidebar-item ${this.isReposSelected() ? "selected" : ""}`}
             onClick={this.navigateToRepos.bind(this)}>
-            <img src="/image/github-white.svg" /> Repos
+            <Github /> Repos
           </div>
           <div
             className={`sidebar-item ${this.isBranchesSelected() ? "selected" : ""}`}
             onClick={this.navigateToBranches.bind(this)}>
-            <img src="/image/git-branch-white.svg" /> Branches
+            <GitBranch /> Branches
           </div>
           <div
             className={`sidebar-item ${this.isCommitsSelected() ? "selected" : ""}`}
             onClick={this.navigateToCommits.bind(this)}>
-            <img src="/image/git-commit-white.svg" /> Commits
+            <GitCommit /> Commits
           </div>
           <div
             className={`sidebar-item ${this.isHostsSelected() ? "selected" : ""}`}
             onClick={this.navigateToHosts.bind(this)}>
-            <img src="/image/hard-drive-white.svg" /> Hosts
+            <HardDrive /> Hosts
           </div>
           {router.canAccessExecutorsPage(this.props.user) && (
             <div
               className={`sidebar-item ${this.isExecutorsSelected() ? "selected" : ""}`}
               onClick={this.navigateToExecutors.bind(this)}>
-              <img src="/image/cloud-white.svg" /> Executors
+              <Cloud /> Executors
             </div>
           )}
           {router.canAccessWorkflowsPage(this.props.user) && (
             <div
               className={`sidebar-item ${this.isWorkflowsSelected() ? "selected" : ""}`}
               onClick={this.navigateToWorkflows.bind(this)}>
-              <img src="/image/play-circle-white.svg" /> Workflows
+              <PlayCircle /> Workflows
             </div>
           )}
           {capabilities.code && (
             <div
               className={`sidebar-item ${this.isCodeSelected() ? "selected" : ""}`}
               onClick={this.navigateToCode.bind(this)}>
-              <img src="/image/code-white.svg" /> Code
+              <Code /> Code
             </div>
           )}
           <div
             className={`sidebar-item ${this.isSettingsSelected() ? "selected" : ""}`}
             onClick={() => router.navigateToSetup()}>
-            <img src="/image/settings-white.svg" /> Setup
+            <Settings /> Setup
           </div>
           {router.canAccessUsagePage(this.props.user) && (
             <div
               className={`sidebar-item ${this.isUsageSelected() ? "selected" : ""}`}
               onClick={this.navigateToUsage.bind(this)}>
-              <img src="/image/gauge-white.svg" /> Usage
+              <Gauge /> Usage
             </div>
           )}
           <a className="sidebar-item" href="https://www.buildbuddy.io/docs/" target="_blank">
-            <img src="/image/book-open-white.svg" /> Docs
+            <BookOpen /> Docs
           </a>
         </div>
         <div className={`sidebar-footer ${this.state.profileExpanded ? "expanded" : ""}`}>
@@ -245,29 +268,23 @@ export default class SidebarComponent extends React.Component {
                         group.id === this.props.user.selectedGroup.id ? "selected" : ""
                       }`}
                       onClick={this.handleOrgClicked.bind(this, group.id)}>
-                      <img
-                        src={
-                          group.id === this.props.user.selectedGroup.id
-                            ? "/image/check-circle-white.svg"
-                            : "/image/circle-white.svg"
-                        }
-                      />{" "}
+                      {group.id === this.props.user.selectedGroup.id ? <CheckCircle /> : <Circle />}
                       <div className="org-picker-item-label">{group.name}</div>
                     </div>
                   ))}
                 </div>
                 {this.props.user && !this.props.user?.isInDefaultGroup() && (
                   <div className="sidebar-item create-organization" onClick={this.handleCreateOrgClicked.bind(this)}>
-                    <img src="/image/plus-circle-white.svg" />
+                    <PlusCircle />
                     Create org
                   </div>
                 )}
               </div>
               <div className="sidebar-item sidebar-logout-item" onClick={() => authService.logout()}>
-                <img src="/image/log-out-white.svg" /> Logout
+                <LogOut /> Logout
               </div>
               <div className="sidebar-item" onClick={() => router.navigateToSettings()}>
-                <img src="/image/sliders-white.svg" />
+                <Sliders />
                 Settings
               </div>
             </div>
@@ -286,10 +303,11 @@ export default class SidebarComponent extends React.Component {
                 </div>
                 <div className="sidebar-profile-org">{this.props.user?.selectedGroupName()}</div>
               </div>
-              <img
-                className="sidebar-profile-arrow"
-                src={this.state.profileExpanded ? "/image/chevron-down-white.svg" : "/image/chevron-up-white.svg"}
-              />
+              {this.state.profileExpanded ? (
+                <ChevronDown className="sidebar-profile-arrow" />
+              ) : (
+                <ChevronUp className="sidebar-profile-arrow" />
+              )}
             </div>
           )}
         </div>

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "jsdoc": "^3.6.2",
     "lint-staged": "^10.2.13",
     "long": "^4.0.0",
+    "lucide-react": "^0.16.19",
     "minimist": "^1.2.3",
     "moment": "^2.24.0",
     "monaco-editor": "^0.25.2",
@@ -70,8 +71,5 @@
     "typescript": "^3.4.5",
     "uglify-js": "^3.6.0",
     "uuid": "^8.3.0"
-  },
-  "dependencies": {
-    "lucide-react": "^0.16.19"
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,5 +70,8 @@
     "typescript": "^3.4.5",
     "uglify-js": "^3.6.0",
     "uuid": "^8.3.0"
+  },
+  "dependencies": {
+    "lucide-react": "^0.16.19"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1690,6 +1690,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lucide-react@^0.16.19:
+  version "0.16.19"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.16.19.tgz#c1a3ff65bbc562ccc02640657e12f0d4e385749a"
+  integrity sha512-x4PFAAxLjvrCisOdigDhF6Zh5OPNaLRalxkdvVoKI4xmEN7U7EoeYSZlZPTk8Cyp/RR048FRu8uyXu3yqAKNQA==
+
 magic-string@^0.25.2:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/2414826/143095274-c7eb8c8d-e651-4dc7-a8f5-534539a3d785.mp4

After:

https://user-images.githubusercontent.com/2414826/143095288-b6d295da-a034-4932-8f27-dbf58813ab28.mp4


We currently serve SVGs uncached which results in a waterfall of requests while the app is loading, causing jank and network congestion (each SVG request uses up a connection from the client's connection pool and has a fixed overhead due to HTTP headers etc.).

Rather than trying to cache these SVGs, the fix in this PR is to use icons as code (from the `lucide-react` package) rather than using `img` elements, where possible, effectively embedding them in the app bundle / chunks.

This approach has a few advantages compared to `img src`:
* No need to further slow down / complicate the bundling process/logic by including SVGs in the bundle and then figuring out how to append the resulting hash to all SVG URLs
* SVG elements can now be styled directly with CSS, with no need to create duplicate icons for each style variant (color, stroke width, etc.)
* Using a new icon is easier: just import it from `lucide-react` -- no need to download from lucide.dev
* Strong typing means it's not possible to reference an icon that doesn't exist

`lucide-react` is tree-shakeable so this only increases the bundle size according to the icons we actually use. With this PR, it increases the compressed bundle size by 4 KB (0.2% of the total compressed bundle size).

In follow-up PRs I can go through and update the rest of the icons; wanted to try this out as a POC and make sure we're happy with the overall approach here before going too crazy.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
