### PR TITLE
Record the last evicted item age so we can monitor cachet eviction

### DIFF
--- a/server/backends/disk_cache/BUILD
+++ b/server/backends/disk_cache/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//server/config",
         "//server/environment",
         "//server/interfaces",
+        "//server/metrics",
         "//server/remote_cache/digest",
         "//server/util/alert",
         "//server/util/disk",
@@ -18,6 +19,7 @@ go_library(
         "//server/util/prefix",
         "//server/util/status",
         "//server/util/statusz",
+        "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/config"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
@@ -27,6 +28,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/statusz"
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -309,25 +311,25 @@ type partition struct {
 }
 
 func newPartition(id string, rootDir string, maxSizeBytes int64, useV2Layout bool) (*partition, error) {
-	l, err := lru.NewLRU(&lru.Config{MaxSize: maxSizeBytes, OnEvict: evictFn, SizeFn: sizeFn})
-	if err != nil {
-		return nil, err
-	}
-	c := &partition{
+	p := &partition{
 		id:               id,
 		useV2Layout:      useV2Layout,
 		maxSizeBytes:     maxSizeBytes,
-		lru:              l,
 		rootDir:          rootDir,
 		fileChannel:      make(chan *fileRecord),
 		internedStrings:  make(map[string]string, 0),
 		doneAsyncLoading: make(chan struct{}),
 	}
-	if err := c.initializeCache(); err != nil {
+	l, err := lru.NewLRU(&lru.Config{MaxSize: maxSizeBytes, OnEvict: p.evictFn, SizeFn: sizeFn})
+	if err != nil {
 		return nil, err
 	}
-	c.startJanitor()
-	return c, nil
+	p.lru = l
+	if err := p.initializeCache(); err != nil {
+		return nil, err
+	}
+	p.startJanitor()
+	return p, nil
 }
 
 type fileRecord struct {
@@ -348,12 +350,6 @@ func sizeFn(value interface{}) int64 {
 	return size
 }
 
-func evictFn(value interface{}) {
-	if v, ok := value.(*fileRecord); ok {
-		disk.DeleteFile(context.TODO(), v.FullPath())
-	}
-}
-
 func getLastUse(info os.FileInfo) int64 {
 	stat := info.Sys().(*syscall.Stat_t)
 	// Super Gross! https://github.com/golang/go/issues/31735
@@ -367,6 +363,18 @@ func getLastUse(info os.FileInfo) int64 {
 		ts = syscall.Timespec{}
 	}
 	return time.Unix(ts.Sec, ts.Nsec).UnixNano()
+}
+
+func (p *partition) evictFn(value interface{}) {
+	if v, ok := value.(*fileRecord); ok {
+		i, err := os.Stat(v.FullPath())
+		if err == nil {
+			lastUse := time.Unix(0, getLastUse(i))
+			ageUsec := float64(time.Now().Sub(lastUse).Microseconds())
+			metrics.DiskCacheLastEvictionAgeUsec.With(prometheus.Labels{metrics.PartitionID: p.id}).Set(ageUsec)
+		}
+		disk.DeleteFile(context.TODO(), v.FullPath())
+	}
 }
 
 func (p *partition) internString(s string) string {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -94,6 +94,9 @@ const (
 
 	/// EventName is the name used to identify the type of an unexpected event.
 	EventName = "name"
+
+	/// PartitionID is the ID of the disk cache partition this event applied to.
+	PartitionID = "partition_id"
 )
 
 const (
@@ -257,6 +260,15 @@ var (
 	///   sum(rate(buildbuddy_remote_cache_upload_duration_usec{cache_type="cas"}[5m])) by (le)
 	/// )
 	/// ```
+
+	DiskCacheLastEvictionAgeUsec = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "disk_cache_last_eviction_age_usec",
+		Help:      "The age (in usec) of the item most recently evicted from the cache",
+	}, []string{
+		PartitionID,
+	})
 
 	/// ## Remote execution metrics
 


### PR DESCRIPTION
Keep a prom counter with the last evicted item's age (in usec), per partition, and update it when items are evicted.