### PR TITLE
Add flag to allow using local images during development

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"sync"
@@ -25,6 +26,10 @@ const (
 	// Default TTL for tokens granting access to locally cached images, before
 	// re-authentication with the remote registry is required.
 	defaultImageCacheTokenTTL = 15 * time.Minute
+)
+
+var (
+	debugUseLocalImagesOnly = flag.Bool("debug_use_local_images_only", false, "Do not pull OCI images and only used locally cached images. This can be set to test local image builds during development without needing to push to a container registry. Not intended for production use.")
 )
 
 // Stats holds represents a container's held resources.
@@ -89,6 +94,9 @@ type CommandContainer interface {
 // PullImageIfNecessary pulls the image configured for the container if it
 // is not cached locally.
 func PullImageIfNecessary(ctx context.Context, env environment.Env, cacheAuth *ImageCacheAuthenticator, ctr CommandContainer, creds PullCredentials, imageRef string) error {
+	if *debugUseLocalImagesOnly {
+		return nil
+	}
 	isCached, err := ctr.IsImageCached(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
This allows quickly testing local image builds without needing to push to a remote registry.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
