### PR TITLE
Fix button wrapping issue in dialog footer

### DIFF
--- a/app/components/button/button.css
+++ b/app/components/button/button.css
@@ -55,6 +55,7 @@
   background: transparent;
   border: 1px solid rgba(20, 20, 20, 0.1);
   transition: 200ms ease;
+  flex-shrink: 1;
   overflow: hidden;
 }
 

--- a/app/components/button/button.css
+++ b/app/components/button/button.css
@@ -55,7 +55,6 @@
   background: transparent;
   border: 1px solid rgba(20, 20, 20, 0.1);
   transition: 200ms ease;
-  flex-shrink: 1;
   overflow: hidden;
 }
 

--- a/app/invocation/invocation_menu.tsx
+++ b/app/invocation/invocation_menu.tsx
@@ -4,6 +4,7 @@ import { invocation } from "../../proto/invocation_ts_proto";
 import { User } from "../auth/auth_service";
 import capabilities from "../capabilities/capabilities";
 import FilledButton, { OutlinedButton } from "../components/button/button";
+import Spinner from "../components/spinner/spinner";
 import Dialog, {
   DialogBody,
   DialogFooter,
@@ -112,7 +113,7 @@ export default class InvocationMenuComponent extends React.Component<InvocationM
             </DialogBody>
             <DialogFooter>
               <DialogFooterButtons>
-                {this.state.isDeleteModalLoading && <div className="loading" />}
+                {this.state.isDeleteModalLoading && <Spinner />}
                 <OutlinedButton disabled={this.state.isDeleteModalLoading} onClick={this.onCloseDeleteModal.bind(this)}>
                   Cancel
                 </OutlinedButton>

--- a/app/invocation/invocation_share_button.tsx
+++ b/app/invocation/invocation_share_button.tsx
@@ -14,6 +14,7 @@ import Dialog, {
 } from "../components/dialog/dialog";
 import Input from "../components/input/input";
 import Modal from "../components/modal/modal";
+import Spinner from "../components/spinner/spinner";
 import Select, { Option } from "../components/select/select";
 import rpcService from "../service/rpc_service";
 import InvocationModel from "./invocation_model";
@@ -155,7 +156,7 @@ export default class InvocationShareButtonComponent extends React.Component<
               <DialogFooterButtons>
                 {this.state.isLoading && (
                   <>
-                    <div className="loading" />
+                    <Spinner />
                     <span className="loading-message">Saving...</span>
                   </>
                 )}

--- a/enterprise/app/api_keys/BUILD
+++ b/enterprise/app/api_keys/BUILD
@@ -14,6 +14,7 @@ ts_library(
         "//app/components/dialog",
         "//app/components/input",
         "//app/components/modal",
+        "//app/components/spinner",
         "//app/errors",
         "//app/service",
         "//app/util:errors",

--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -11,6 +11,7 @@ import Dialog, {
   DialogTitle,
 } from "../../../app/components/dialog/dialog";
 import TextInput from "../../../app/components/input/input";
+import Spinner from "../../../app/components/spinner/spinner";
 import Modal from "../../../app/components/modal/modal";
 import errorService from "../../../app/errors/error_service";
 import rpcService from "../../../app/service/rpc_service";
@@ -167,6 +168,7 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
 
     try {
       this.setState({ updateForm: { ...this.state.updateForm, isSubmitting: true } });
+      return;
       await rpcService.service.updateApiKey(
         new api_key.CreateApiKeyRequest({
           ...this.state.updateForm.request,
@@ -307,7 +309,7 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
             </DialogBody>
             <DialogFooter>
               <DialogFooterButtons>
-                {isSubmitting && <div className="loading"></div>}
+                {isSubmitting && <Spinner />}
                 <OutlinedButton type="button" onClick={onRequestClose}>
                   Cancel
                 </OutlinedButton>

--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -423,7 +423,7 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
             </DialogBody>
             <DialogFooter>
               <DialogFooterButtons>
-                {this.state.isDeleteModalSubmitting && <div className="loading" />}
+                {this.state.isDeleteModalSubmitting && <Spinner />}
                 <OutlinedButton
                   disabled={this.state.isDeleteModalSubmitting}
                   onClick={this.onCloseDeleteModal.bind(this)}>

--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -168,7 +168,6 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
 
     try {
       this.setState({ updateForm: { ...this.state.updateForm, isSubmitting: true } });
-      return;
       await rpcService.service.updateApiKey(
         new api_key.CreateApiKeyRequest({
           ...this.state.updateForm.request,

--- a/enterprise/app/workflows/BUILD
+++ b/enterprise/app/workflows/BUILD
@@ -16,6 +16,7 @@ ts_library(
         "//app/components/menu",
         "//app/components/modal",
         "//app/components/popup",
+        "//app/components/spinner",
         "//app/errors",
         "//app/router",
         "//app/service",

--- a/enterprise/app/workflows/workflows.tsx
+++ b/enterprise/app/workflows/workflows.tsx
@@ -13,6 +13,7 @@ import Dialog, {
 import Menu, { MenuItem } from "../../../app/components/menu/menu";
 import Modal from "../../../app/components/modal/modal";
 import Popup from "../../../app/components/popup/popup";
+import Spinner from "../../../app/components/spinner/spinner";
 import router from "../../../app/router/router";
 import rpcService from "../../../app/service/rpc_service";
 import { copyToClipboard } from "../../../app/util/clipboard";
@@ -202,7 +203,7 @@ class ListWorkflowsComponent extends React.Component<ListWorkflowsProps, State> 
                   </DialogBody>
                   <DialogFooter>
                     <DialogFooterButtons>
-                      {this.state.isDeleting && <div className="loading" />}
+                      {this.state.isDeleting && <Spinner />}
                       <Button className="destructive" onClick={this.onClickUnlink.bind(this)} disabled={isDeleting}>
                         Unlink
                       </Button>

--- a/enterprise/app/workflows/workflows.tsx
+++ b/enterprise/app/workflows/workflows.tsx
@@ -105,6 +105,7 @@ class ListWorkflowsComponent extends React.Component<ListWorkflowsProps, State> 
   }
 
   private async onClickUnlink() {
+    this.setState({ isDeleting: true });
     try {
       await rpcService.service.deleteWorkflow(
         new workflow.DeleteWorkflowRequest({ id: this.state.workflowToDelete.id })


### PR DESCRIPTION
The `<div className="loading" />` would take up the full width of the `<DialogFooterButtons>`, and since `.outlined-button` was recently updated to have `flex-shrink: 1;`, the outlined button would get squished by the loading div. Fixed by using the `<Spinner />` component instead, which does not try to render at 100% width.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
