### PR TITLE
Show group-owned connected executors even if "use self-owned Linux executors" is not enabled

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -330,19 +330,27 @@ svg.icon.orange {
 }
 
 .tab {
-  box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.15);
   border-radius: 50px;
+  border: 1px solid #eee;
   margin-right: 8px;
   padding: 12px 32px;
   cursor: pointer;
   margin-top: 8px;
-  color: #aaa;
+  color: #9e9e9e;
   text-align: center;
   flex-shrink: 0;
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
   user-select: none;
+}
+
+.tab:hover {
+  background: #fafafa;
+}
+
+.tab:active {
+  background: #f5f5f5;
 }
 
 .tab.selected {

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -342,6 +342,7 @@ svg.icon.orange {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
+  user-select: none;
 }
 
 .tab.selected {

--- a/enterprise/app/executors/executor_card.tsx
+++ b/enterprise/app/executors/executor_card.tsx
@@ -4,36 +4,43 @@ import format from "../../../app/format/format";
 import { Cloud } from "lucide-react";
 
 interface Props {
-  node: scheduler.IExecutionNode;
+  executor: scheduler.GetExecutionNodesResponse.IExecutor;
 }
 
 export default class ExecutorCardComponent extends React.Component<Props> {
   render() {
+    const node = this.props.executor.node;
+    const enabled = this.props.executor.enabled;
+
     return (
-      <div className="card">
+      <div className={`card ${enabled ? "card-success" : "card-failure"}`}>
         <Cloud className="icon" />
         <div className="details">
           <div className="executor-section">
             <div className="executor-section-title">Address:</div>
             <div>
-              {this.props.node.host}:{this.props.node.port}
+              {node.host}:{node.port}
             </div>
           </div>
           <div className="executor-section">
             <div className="executor-section-title">ID:</div>
-            <div>{this.props.node.executorId}</div>
+            <div>{node.executorId}</div>
           </div>
           <div className="executor-section">
             <div className="executor-section-title">Assignable Memory:</div>
-            <div>{format.bytes(+this.props.node.assignableMemoryBytes)}</div>
+            <div>{format.bytes(+node.assignableMemoryBytes)}</div>
           </div>
           <div className="executor-section">
             <div className="executor-section-title">Assignable Milli CPU:</div>
-            <div>{this.props.node.assignableMilliCpu}</div>
+            <div>{node.assignableMilliCpu}</div>
           </div>
           <div className="executor-section">
             <div className="executor-section-title">Version:</div>
-            <div>{this.props.node.version}</div>
+            <div>{node.version}</div>
+          </div>
+          <div className="executor-section">
+            <div className="executor-section-title">Status:</div>
+            <div>{enabled ? "Enabled" : "Disabled"}</div>
           </div>
         </div>
       </div>

--- a/enterprise/app/executors/executors.css
+++ b/enterprise/app/executors/executors.css
@@ -7,8 +7,8 @@
 
 .executors-page .card {
   box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.1), 0px 1px 6px rgba(0, 0, 0, 0.05);
-  margin-left: 32px;
-  margin-right: 32px;
+  margin-left: 0;
+  margin-right: 0;
   padding: 32px;
   border-radius: 8px;
   font-size: 14px;

--- a/enterprise/app/executors/executors.css
+++ b/enterprise/app/executors/executors.css
@@ -78,3 +78,21 @@
 .executors-page .organization-settings-button {
   margin-top: 16px;
 }
+
+.executors-page .callout {
+  margin-top: 32px;
+  margin-bottom: 32px;
+  padding: 16px;
+  max-width: 600px;
+  border-radius: 8px;
+  display: flex;
+  gap: 16px;
+}
+
+.executors-page .callout .icon {
+  flex-shrink: 0;
+}
+
+.executors-page .warning-callout {
+  background: #ffecb3;
+}

--- a/enterprise/app/executors/executors.tsx
+++ b/enterprise/app/executors/executors.tsx
@@ -10,6 +10,7 @@ import { bazel_config } from "../../../proto/bazel_config_ts_proto";
 import { FilledButton } from "../../../app/components/button/button";
 import router from "../../../app/router/router";
 import Select, { Option } from "../../../app/components/select/select";
+import { AlertCircle } from "lucide-react";
 
 enum FetchType {
   Executors,
@@ -17,9 +18,11 @@ enum FetchType {
   BazelConfig,
 }
 
-function onClickLink(href: string, e: React.MouseEvent<HTMLAnchorElement>) {
-  e.preventDefault();
-  router.navigateTo(href);
+function linkHandler(href: string) {
+  return (e: React.MouseEvent) => {
+    e.preventDefault();
+    router.navigateTo(href);
+  };
 }
 
 interface ExecutorDeployProps {
@@ -80,8 +83,19 @@ class ExecutorSetup extends React.Component<ExecutorSetupProps> {
   state = { selectedExecutorKeyIdx: 0 };
 
   render() {
+    // If the user already has executors running, show the "short" version of the setup.
+    if (this.props.user.selectedGroup.useGroupOwnedExecutors && this.props.executors.length) {
+      return (
+        <>
+          <h2>Deploy additional executors</h2>
+          <ExecutorDeploy executorKeys={this.props.executorKeys} schedulerUri={this.props.schedulerUri} />
+        </>
+      );
+    }
+
     return (
       <>
+        <h1>Set up self-hosted executors</h1>
         <hr />
         <h2>1. Create an API key for executor registration</h2>
         {this.props.executorKeys.length == 0 && (
@@ -90,7 +104,7 @@ class ExecutorSetup extends React.Component<ExecutorSetupProps> {
             <p>API keys are used to authorize self-hosted executors.</p>
             {this.props.user.canCall("createApiKey") && (
               <FilledButton className="manage-keys-button">
-                <a href="/settings/org/api-keys" onClick={onClickLink.bind("/settings/org/api-keys")}>
+                <a href="/settings/org/api-keys" onClick={linkHandler("/settings/org/api-keys")}>
                   Manage keys
                 </a>
               </FilledButton>
@@ -108,14 +122,10 @@ class ExecutorSetup extends React.Component<ExecutorSetupProps> {
             </div>
             <h2>2. Deploy executors</h2>
             <ExecutorDeploy executorKeys={this.props.executorKeys} schedulerUri={this.props.schedulerUri} />
-            {this.props.executors.length == 1 && <p>You have 1 self-hosted executor connected.</p>}
-            {this.props.executors.length != 1 && (
-              <p>You have {this.props.executors.length} self-hosted executors connected.</p>
-            )}
             <h2>3. Switch to self-hosted executors in organization settings</h2>
             <p>Enable "Use self-hosted executors" on the Organization Settings page.</p>
             <FilledButton className="organization-settings-button">
-              <a href="/settings/" onClick={onClickLink.bind("/settings")}>
+              <a href="/settings/" onClick={linkHandler("/settings")}>
                 Open settings
               </a>
             </FilledButton>
@@ -127,6 +137,7 @@ class ExecutorSetup extends React.Component<ExecutorSetupProps> {
 }
 
 interface ExecutorsListProps {
+  user: User;
   executors: scheduler.IExecutionNode[];
 }
 
@@ -169,10 +180,11 @@ class ExecutorsList extends React.Component<ExecutorsListProps> {
   }
 }
 
+type TabId = "status" | "setup";
+
 interface Props {
   user: User;
-  hash: string;
-  search: URLSearchParams;
+  path: string;
 }
 
 interface State {
@@ -209,12 +221,6 @@ export default class ExecutorsComponent extends React.Component<Props, State> {
 
   componentWillUnmount() {
     this.subscription?.unsubscribe();
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    if (this.props.hash !== prevProps.hash || this.props.search != prevProps.search) {
-      this.fetch();
-    }
   }
 
   async fetchApiKeys() {
@@ -288,47 +294,76 @@ export default class ExecutorsComponent extends React.Component<Props, State> {
     this.fetchExecutors();
   }
 
+  onClickTab(tabId: TabId) {
+    router.navigateTo(`/executors/${tabId}`);
+  }
+
   // "bring your own runners" is enabled for the installation (i.e. BuildBuddy Cloud deployment).
   renderWithGroupOwnedExecutorsEnabled() {
-    if (this.props.user?.selectedGroup?.useGroupOwnedExecutors) {
-      if (this.state.nodes.length == 0) {
-        return (
-          <div className="empty-state">
-            <h1>No self-hosted executors connected.</h1>
-            <p>Self-hosted executors are enabled, but there are no executors connected.</p>
-            <p>Follow the instructions below to deploy your executors.</p>
-            <ExecutorSetup
-              user={this.props.user}
-              executorKeys={this.state.executorKeys}
-              executors={this.state.nodes}
-              schedulerUri={this.state.schedulerUri}
-            />
+    const linuxNodes = this.state.nodes.filter((node) => node.os.toLowerCase() === "linux");
+
+    const defaultTabId = this.state.nodes.length > 0 ? "status" : "setup";
+    const activeTab = (this.props.path.substring("/executors/".length) || defaultTabId) as TabId;
+
+    return (
+      <>
+        <div className="tabs">
+          <div
+            className={`tab ${activeTab === "status" ? "selected" : ""}`}
+            onClick={this.onClickTab.bind(this, "status")}>
+            Status
           </div>
-        );
-      }
-      return (
-        <>
-          <h1>Self-hosted executors</h1>
-          <ExecutorsList executors={this.state.nodes} />
-          <hr />
-          <h1>Deploying additional executors</h1>
-          <ExecutorDeploy executorKeys={this.state.executorKeys} schedulerUri={this.state.schedulerUri} />
-        </>
-      );
-    } else {
-      return (
-        <div className="empty-state">
-          <h1>You're currently using BuildBuddy Cloud executors.</h1>
-          <p>See the instructions below if you'd like to use self-hosted executors.</p>
+          <div
+            className={`tab ${activeTab === "setup" ? "selected" : ""}`}
+            onClick={this.onClickTab.bind(this, "setup")}>
+            Setup
+          </div>
+        </div>
+        {activeTab === "status" && (
+          <>
+            {linuxNodes.length > 0 && !this.props.user.selectedGroup.useGroupOwnedExecutors && (
+              <div className="callout warning-callout">
+                <AlertCircle className="icon orange" />
+                <div className="callout-content">
+                  <div>
+                    Linux executors are connected, but will not be used to execute tasks since your organization is
+                    using BuildBuddy Cloud executors. To fix this, enable "use self-hosted Linux executors" in settings.
+                  </div>
+                  <div>
+                    <FilledButton className="organization-settings-button">
+                      <a href="/settings/" onClick={linkHandler("/settings")}>
+                        Open settings
+                      </a>
+                    </FilledButton>
+                  </div>
+                </div>
+              </div>
+            )}
+            <ExecutorsList user={this.props.user} executors={this.state.nodes} />
+            {!this.state.nodes.length && this.props.user.selectedGroup.useGroupOwnedExecutors && (
+              <div className="empty-state">
+                <h1>No self-hosted Linux executors are connected.</h1>
+                <p>Click the "setup" tab to deploy your executors.</p>
+              </div>
+            )}
+            {!this.state.nodes.length && !this.props.user.selectedGroup.useGroupOwnedExecutors && (
+              <div className="empty-state">
+                <h1>You're currently using BuildBuddy cloud executors.</h1>
+                <p>Click the "setup" tab for instructions on self-hosting executors.</p>
+              </div>
+            )}
+          </>
+        )}
+        {activeTab === "setup" && (
           <ExecutorSetup
             user={this.props.user}
             executorKeys={this.state.executorKeys}
             executors={this.state.nodes}
             schedulerUri={this.state.schedulerUri}
           />
-        </div>
-      );
-    }
+        )}
+      </>
+    );
   }
 
   // "bring your own runners" is not enabled for the installation (i.e. onprem deployment)
@@ -348,7 +383,7 @@ export default class ExecutorsComponent extends React.Component<Props, State> {
         </div>
       );
     } else {
-      return <ExecutorsList executors={this.state.nodes} />;
+      return <ExecutorsList user={this.props.user} executors={this.state.nodes} />;
     }
   }
 

--- a/enterprise/app/executors/executors.tsx
+++ b/enterprise/app/executors/executors.tsx
@@ -137,7 +137,6 @@ class ExecutorSetup extends React.Component<ExecutorSetupProps> {
 }
 
 interface ExecutorsListProps {
-  user: User;
   executors: scheduler.IExecutionNode[];
 }
 
@@ -156,7 +155,6 @@ class ExecutorsList extends React.Component<ExecutorsListProps> {
     return (
       <>
         <div className="executor-cards">
-          {}
           {keys
             .map((key) => executorsByPool.get(key))
             .map((executors) => (
@@ -339,7 +337,7 @@ export default class ExecutorsComponent extends React.Component<Props, State> {
                 </div>
               </div>
             )}
-            <ExecutorsList user={this.props.user} executors={this.state.nodes} />
+            <ExecutorsList executors={this.state.nodes} />
             {!this.state.nodes.length && this.props.user.selectedGroup.useGroupOwnedExecutors && (
               <div className="empty-state">
                 <h1>No self-hosted Linux executors are connected.</h1>
@@ -383,7 +381,7 @@ export default class ExecutorsComponent extends React.Component<Props, State> {
         </div>
       );
     } else {
-      return <ExecutorsList user={this.props.user} executors={this.state.nodes} />;
+      return <ExecutorsList executors={this.state.nodes} />;
     }
   }
 

--- a/enterprise/app/executors/executors.tsx
+++ b/enterprise/app/executors/executors.tsx
@@ -338,7 +338,7 @@ export default class ExecutorsComponent extends React.Component<Props, State> {
             <ExecutorsList executors={this.state.nodes} />
             {!this.state.nodes.length && this.props.user.selectedGroup.useGroupOwnedExecutors && (
               <div className="empty-state">
-                <h1>No self-hosted Linux executors are connected.</h1>
+                <h1>No self-hosted executors are connected.</h1>
                 <p>Click the "setup" tab to deploy your executors.</p>
               </div>
             )}

--- a/enterprise/app/org/org.css
+++ b/enterprise/app/org/org.css
@@ -60,6 +60,11 @@
   border-radius: 2px;
 }
 
+.organization-form .input-label-subtitle {
+  font-size: 14px;
+  color: #9e9e9e;
+}
+
 .organization-form .url-input-row {
   display: flex;
   flex-wrap: wrap;

--- a/enterprise/app/org/org_form.tsx
+++ b/enterprise/app/org/org_form.tsx
@@ -170,7 +170,11 @@ export default abstract class OrgForm<T extends GroupRequest> extends React.Comp
               name="useGroupOwnedExecutors"
               checked={request.useGroupOwnedExecutors}
             />
-            <span>Use self-hosted Linux executors</span>
+            {capabilities.config.forceUserOwnedDarwinExecutors ? (
+              <span>Use self-hosted Linux executors</span>
+            ) : (
+              <span>Use self-hosted executors</span>
+            )}
           </label>
         )}
       </>

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -249,9 +249,7 @@ export default class EnterpriseRootComponent extends React.Component {
                   </Suspense>
                 )}
                 {usage && <UsageComponent user={this.state.user} />}
-                {executors && (
-                  <ExecutorsComponent user={this.state.user} search={this.state.search} hash={this.state.hash} />
-                )}
+                {executors && <ExecutorsComponent path={this.state.path} user={this.state.user} />}
                 {home && <HistoryComponent user={this.state.user} hash={this.state.hash} search={this.state.search} />}
                 {workflows && <WorkflowsComponent path={this.state.path} user={this.state.user} />}
                 {code && (

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -54,7 +54,7 @@ const (
 	operatingSystemPropertyName = "OSFamily"
 	LinuxOperatingSystemName    = "linux"
 	defaultOperatingSystemName  = LinuxOperatingSystemName
-	darwinOperatingSystemName   = "darwin"
+	DarwinOperatingSystemName   = "darwin"
 
 	cpuArchitecturePropertyName = "Arch"
 	defaultCPUArchitecture      = "amd64"
@@ -275,7 +275,7 @@ func ApplyOverrides(env environment.Env, executorProps *ExecutorProperties, plat
 		platformProps.ContainerImage = strings.TrimPrefix(platformProps.ContainerImage, DockerPrefix)
 	}
 
-	if strings.EqualFold(platformProps.OS, darwinOperatingSystemName) {
+	if strings.EqualFold(platformProps.OS, DarwinOperatingSystemName) {
 		appleSDKVersion := ""
 		appleSDKPlatform := "MacOSX"
 		xcodeVersion := executorProps.DefaultXCodeVersion

--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/scheduler_server",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/server/remote_execution/platform",
         "//enterprise/server/tasksize",
         "//proto:api_key_go_proto",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1528,6 +1528,7 @@ func (s *SchedulerServer) GetExecutionNodes(ctx context.Context, req *scpb.GetEx
 	if err != nil {
 		return nil, err
 	}
+	useGroupOwnedExecutors := g.UseGroupOwnedExecutors != nil && *g.UseGroupOwnedExecutors
 
 	executors := make([]*scpb.GetExecutionNodesResponse_Executor, len(executionNodes))
 	for i, node := range executionNodes {
@@ -1536,7 +1537,7 @@ func (s *SchedulerServer) GetExecutionNodes(ctx context.Context, req *scpb.GetEx
 			Node: node,
 			Enabled: !s.requireExecutorAuthorization ||
 				(s.enableUserOwnedExecutors &&
-					((g.UseGroupOwnedExecutors != nil && *g.UseGroupOwnedExecutors) || (s.forceUserOwnedDarwinExecutors && isDarwinExecutor))),
+					(useGroupOwnedExecutors || (s.forceUserOwnedDarwinExecutors && isDarwinExecutor))),
 		}
 	}
 

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -68,7 +68,6 @@ import (
 
 const (
 	ExecutorAPIKey = "EXECUTOR_API_KEY"
-	ExecutorGroup  = "GR123"
 
 	testCommandBinaryRunfilePath = "enterprise/server/test/integration/remote_execution/command/testcommand_/testcommand"
 	testCommandBinaryName        = "testcommand"
@@ -93,8 +92,9 @@ type Env struct {
 	executorNameCounter uint64
 	envOpts             *enterprise_testenv.Options
 
-	UserID1  string
-	GroupID1 string
+	UserID1         string
+	GroupID1        string
+	ExecutorGroupID string
 }
 
 func (r *Env) GetBuildBuddyServiceClient() bbspb.BuildBuddyServiceClient {
@@ -169,19 +169,27 @@ func NewRBETestEnv(t *testing.T) *Env {
 	err = testEnv.GetDBHandle().Exec(
 		`UPDATE APIKeys SET value = ? WHERE group_id = ?`, userID, groupID).Error
 	require.NoError(t, err)
+	// Create executor group
+	execGroupSlug := "executor-group"
+	executorGroupID, err := testEnv.GetUserDB().InsertOrUpdateGroup(ctx, &tables.Group{
+		URLIdentifier: &execGroupSlug,
+		UserID:        userID,
+	})
+	require.NoError(t, err)
 	// Note: This root data dir (under which all executors' data is placed) does
 	// not get cleaned up until after all executors are shutdown (in the cleanup
 	// func below), since test cleanup funcs are run in LIFO order.
 	rootDataDir := testfs.MakeTempDir(t)
 	rbe := &Env{
-		testEnv:     testEnv,
-		t:           t,
-		redisTarget: redisTarget,
-		executors:   make(map[string]*Executor),
-		envOpts:     envOpts,
-		GroupID1:    groupID,
-		UserID1:     userID,
-		rootDataDir: rootDataDir,
+		testEnv:         testEnv,
+		t:               t,
+		redisTarget:     redisTarget,
+		executors:       make(map[string]*Executor),
+		envOpts:         envOpts,
+		GroupID1:        groupID,
+		UserID1:         userID,
+		ExecutorGroupID: executorGroupID,
+		rootDataDir:     rootDataDir,
 	}
 	testEnv.SetAuthenticator(rbe.newTestAuthenticator())
 	rbe.testCommandController = newTestCommandController(t)
@@ -666,15 +674,15 @@ func (r *Env) addExecutor(options *ExecutorOptions) *Executor {
 func (r *Env) newTestAuthenticator() *testauth.TestAuthenticator {
 	users := testauth.TestUsers(r.UserID1, r.GroupID1)
 	users[ExecutorAPIKey] = &testauth.TestUser{
-		GroupID:       ExecutorGroup,
-		AllowedGroups: []string{ExecutorGroup},
+		GroupID:       r.ExecutorGroupID,
+		AllowedGroups: []string{r.ExecutorGroupID},
 		// TODO(bduffany): Replace `role.Admin` below with `role.Default` since API
 		// keys cannot have admin rights in practice. This is needed because some
 		// tests perform some RPCs which require admin rights, and we'll need to
 		// either (a) refactor those tests to authenticate as an admin user, or (b)
 		// make it legitimately possible for an API key to have admin role.
 		GroupMemberships: []*interfaces.GroupMembership{
-			{GroupID: ExecutorGroup, Role: role.Admin},
+			{GroupID: r.ExecutorGroupID, Role: role.Admin},
 		},
 		Capabilities: []akpb.ApiKey_Capability{akpb.ApiKey_REGISTER_EXECUTOR_CAPABILITY},
 	}
@@ -710,13 +718,13 @@ func (r *Env) waitForExecutorRegistration() {
 		client := r.GetBuildBuddyServiceClient()
 		req := &scpb.GetExecutionNodesRequest{
 			RequestContext: &ctxpb.RequestContext{
-				GroupId: ExecutorGroup,
+				GroupId: r.ExecutorGroupID,
 			},
 		}
-		nodes, err := client.GetExecutionNodes(ctx, req)
+		rsp, err := client.GetExecutionNodes(ctx, req)
 		require.NoError(r.t, err)
-		for _, node := range nodes.GetExecutionNode() {
-			nodesByHostIp[fmt.Sprintf("%s:%d", node.Host, node.Port)] = true
+		for _, e := range rsp.GetExecutor() {
+			nodesByHostIp[fmt.Sprintf("%s:%d", e.Node.Host, e.Node.Port)] = true
 		}
 		if reflect.DeepEqual(expectedNodesByHostIp, nodesByHostIp) {
 			return

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -50,4 +50,7 @@ message FrontendConfig {
 
   // Whether or not user management is enabled.
   bool user_management_enabled = 16;
+
+  // Whether Darwin (macOS) executors must be self-hosted.
+  bool force_user_owned_darwin_executors = 17;
 }

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -212,7 +212,16 @@ message GetExecutionNodesRequest {
 message GetExecutionNodesResponse {
   context.ResponseContext response_context = 1;
 
-  repeated ExecutionNode execution_node = 2;
+  repeated Executor executor = 2;
+
+  message Executor {
+    ExecutionNode node = 1;
+
+    // Whether tasks can be routed to this node. If this is false, it is likely
+    // due to a misconfiguration.
+    bool enabled = 2;
+  }
+
   bool user_owned_executors_supported = 3;
 }
 

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -132,10 +132,12 @@ func serveIndexTemplate(env environment.Env, tpl *template.Template, version str
 	userOwnedExecutorsEnabled := false
 	executorKeyCreationEnabled := false
 	workflowsEnabled := false
+	forceUserOwnedDarwinExecutors := false
 	if reConf := env.GetConfigurator().GetRemoteExecutionConfig(); reConf != nil {
 		userOwnedExecutorsEnabled = reConf.EnableUserOwnedExecutors
 		executorKeyCreationEnabled = reConf.EnableExecutorKeyCreation
 		workflowsEnabled = reConf.EnableWorkflows
+		forceUserOwnedDarwinExecutors = reConf.ForceUserOwnedDarwinExecutors
 	}
 
 	config := cfgpb.FrontendConfig{
@@ -154,7 +156,7 @@ func serveIndexTemplate(env environment.Env, tpl *template.Template, version str
 		GlobalFilterEnabled:           env.GetConfigurator().GetAppGlobalFilterEnabled(),
 		UsageEnabled:                  env.GetConfigurator().GetAppUsageEnabled(),
 		UserManagementEnabled:         env.GetConfigurator().GetAppUserManagementEnabled(),
-		ForceUserOwnedDarwinExecutors: env.GetConfigurator().GetRemoteExecutionConfig().ForceUserOwnedDarwinExecutors,
+		ForceUserOwnedDarwinExecutors: forceUserOwnedDarwinExecutors,
 	}
 
 	configJSON := &bytes.Buffer{}

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -139,21 +139,22 @@ func serveIndexTemplate(env environment.Env, tpl *template.Template, version str
 	}
 
 	config := cfgpb.FrontendConfig{
-		Version:                    version,
-		ConfiguredIssuers:          issuers,
-		DefaultToDenseMode:         env.GetConfigurator().GetDefaultToDenseMode(),
-		GithubEnabled:              env.GetConfigurator().GetGithubConfig() != nil,
-		AnonymousUsageEnabled:      env.GetConfigurator().GetAnonymousUsageEnabled(),
-		TestDashboardEnabled:       env.GetConfigurator().EnableTargetTracking(),
-		UserOwnedExecutorsEnabled:  userOwnedExecutorsEnabled,
-		ExecutorKeyCreationEnabled: executorKeyCreationEnabled,
-		WorkflowsEnabled:           workflowsEnabled,
-		CodeEditorEnabled:          env.GetConfigurator().GetCodeEditorEnabled(),
-		RemoteExecutionEnabled:     env.GetConfigurator().GetRemoteExecutionConfig() != nil,
-		SsoEnabled:                 ssoEnabled,
-		GlobalFilterEnabled:        env.GetConfigurator().GetAppGlobalFilterEnabled(),
-		UsageEnabled:               env.GetConfigurator().GetAppUsageEnabled(),
-		UserManagementEnabled:      env.GetConfigurator().GetAppUserManagementEnabled(),
+		Version:                       version,
+		ConfiguredIssuers:             issuers,
+		DefaultToDenseMode:            env.GetConfigurator().GetDefaultToDenseMode(),
+		GithubEnabled:                 env.GetConfigurator().GetGithubConfig() != nil,
+		AnonymousUsageEnabled:         env.GetConfigurator().GetAnonymousUsageEnabled(),
+		TestDashboardEnabled:          env.GetConfigurator().EnableTargetTracking(),
+		UserOwnedExecutorsEnabled:     userOwnedExecutorsEnabled,
+		ExecutorKeyCreationEnabled:    executorKeyCreationEnabled,
+		WorkflowsEnabled:              workflowsEnabled,
+		CodeEditorEnabled:             env.GetConfigurator().GetCodeEditorEnabled(),
+		RemoteExecutionEnabled:        env.GetConfigurator().GetRemoteExecutionConfig() != nil,
+		SsoEnabled:                    ssoEnabled,
+		GlobalFilterEnabled:           env.GetConfigurator().GetAppGlobalFilterEnabled(),
+		UsageEnabled:                  env.GetConfigurator().GetAppUsageEnabled(),
+		UserManagementEnabled:         env.GetConfigurator().GetAppUserManagementEnabled(),
+		ForceUserOwnedDarwinExecutors: env.GetConfigurator().GetRemoteExecutionConfig().ForceUserOwnedDarwinExecutors,
 	}
 
 	configJSON := &bytes.Buffer{}


### PR DESCRIPTION
* Always show all connected executors, even if "use self-owned Linux executors" is not enabled in settings. This fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/980.
* To avoid confusion while also simplifying the UX in the case where you have Linux executors registered, but haven't enabled "use self-owned Linux executors", show an explicit callout in this case to go to the settings page and enable self-hosted executors.
* The page was starting to get noisy and crowded showing both the full executors list and full setup instructions below it -- so this PR also splits the page into separate "Status" and "Setup" tabs. The tabbed UX should not result in any unnecessary extra clicks in most cases, since we default to the "setup" tab if no executors are currently registered.

Misc:
* Fix link handling on executors page (links were causing a full page load instead of router navigation)
* Improve contrast ratio on tabs (text is hard to read) and add stronger signifiers that they are clickable

Screenshots:

---

![image](https://user-images.githubusercontent.com/2414826/144926642-863bebb3-51fa-4398-b092-d94fd04e0f2a.png)

---

![image](https://user-images.githubusercontent.com/2414826/144926474-1cc6291e-9b75-4213-89e2-72f32ce406fb.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/980
