### PR TITLE
Add support for specifying an "session affinity key" in the Run API.

### DIFF
--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -141,6 +141,11 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		args = append(args, "--patch_digest="+patchDigest)
 	}
 
+	affinityKey := req.GetSessionAffinityKey()
+	if affinityKey == "" {
+		affinityKey = req.GetGitRepo().GetRepoUrl()
+	}
+
 	cmd := &repb.Command{
 		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
 			{Name: "BUILDBUDDY_API_KEY", Value: apiKey},
@@ -150,7 +155,7 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		Arguments: args,
 		Platform: &repb.Platform{
 			Properties: []*repb.Platform_Property{
-				{Name: platform.WorkflowIDPropertyName, Value: "hostedrunner-" + req.GetGitRepo().GetRepoUrl()},
+				{Name: platform.HostedBazelAffinityKeyPropertyName, Value: affinityKey},
 				{Name: "container-image", Value: RunnerContainerImage},
 				{Name: "recycle-runner", Value: "true"},
 				{Name: "workload-isolation-type", Value: "firecracker"},

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -51,6 +51,7 @@ const (
 	WorkflowIDPropertyName               = "workflow-id"
 	workloadIsolationPropertyName        = "workload-isolation-type"
 	enableVFSPropertyName                = "enable-vfs"
+	HostedBazelAffinityKeyPropertyName   = "hosted-bazel-affinity-key"
 
 	operatingSystemPropertyName = "OSFamily"
 	LinuxOperatingSystemName    = "linux"
@@ -110,6 +111,7 @@ type Properties struct {
 	PersistentWorkerKey      string
 	PersistentWorkerProtocol string
 	WorkflowID               string
+	HostedBazelAffinityKey   string
 }
 
 // ContainerType indicates the type of containerization required by an executor.
@@ -160,6 +162,7 @@ func ParseProperties(task *repb.ExecutionTask) *Properties {
 		PersistentWorkerKey:       stringProp(m, persistentWorkerKeyPropertyName, ""),
 		PersistentWorkerProtocol:  stringProp(m, persistentWorkerProtocolPropertyName, ""),
 		WorkflowID:                stringProp(m, WorkflowIDPropertyName, ""),
+		HostedBazelAffinityKey:    stringProp(m, HostedBazelAffinityKeyPropertyName, ""),
 	}
 }
 

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -677,12 +677,13 @@ func (p *Pool) Get(ctx context.Context, task *repb.ExecutionTask) (*CommandRunne
 	}
 	if props.RecycleRunner {
 		r, err := p.take(ctx, &query{
-			User:             user,
-			ContainerImage:   props.ContainerImage,
-			WorkflowID:       props.WorkflowID,
-			InstanceName:     instanceName,
-			WorkerKey:        workerKey,
-			WorkspaceOptions: wsOpts,
+			User:                   user,
+			ContainerImage:         props.ContainerImage,
+			WorkflowID:             props.WorkflowID,
+			HostedBazelAffinityKey: props.HostedBazelAffinityKey,
+			InstanceName:           instanceName,
+			WorkerKey:              workerKey,
+			WorkspaceOptions:       wsOpts,
 		})
 		if err != nil {
 			return nil, err
@@ -797,6 +798,9 @@ type query struct {
 	// WorkerKey is the key used to tell if a persistent worker can be reused.
 	// Required; the zero-value "" matches non-persistent-worker runners.
 	WorkerKey string
+	// HostedBazelAffinityKey is used to route hosted Bazel requests to different
+	// bazel instances.
+	HostedBazelAffinityKey string
 	// InstanceName is the remote instance name that must have been used when
 	// creating the runner.
 	// Required; the zero-value "" corresponds to the default instance name.
@@ -817,6 +821,7 @@ func (p *Pool) take(ctx context.Context, q *query) (*CommandRunner, error) {
 		if r.state != paused ||
 			r.PlatformProperties.ContainerImage != q.ContainerImage ||
 			r.PlatformProperties.WorkflowID != q.WorkflowID ||
+			r.PlatformProperties.HostedBazelAffinityKey != q.HostedBazelAffinityKey ||
 			r.WorkerKey != q.WorkerKey ||
 			r.InstanceName != q.InstanceName ||
 			*r.Workspace.Opts != *q.WorkspaceOptions {

--- a/proto/runner.proto
+++ b/proto/runner.proto
@@ -62,6 +62,10 @@ message RunRequest {
   // changing this key will mean hitting a different cache and remote executor.
   // Optional.
   string instance_name = 5;
+
+  // Key used to indicate preference to which Bazel instance the request should
+  // be routed to.
+  string session_affinity_key = 6;
 }
 
 message RunResponse {

--- a/tools/remotebazel/remotebazel.go
+++ b/tools/remotebazel/remotebazel.go
@@ -24,6 +24,7 @@ var (
 	remoteInstanceName = flag.String("remote_instance_name", "", "The remote instance name, if one should be used.")
 	repo               = flag.String("repo", "", "git repo URL")
 	patch              = flag.String("patch", "", "Optional patch to apply after checking out the repo")
+	affinityKey        = flag.String("affinity_key", "", "Preference for which Bazel instance the request is routed to")
 )
 
 const (
@@ -77,9 +78,10 @@ func main() {
 		GitRepo: &rnpb.RunRequest_GitRepo{
 			RepoUrl: *repo,
 		},
-		RepoState:    &rnpb.RunRequest_RepoState{},
-		BazelCommand: cmd,
-		InstanceName: *remoteInstanceName,
+		RepoState:          &rnpb.RunRequest_RepoState{},
+		BazelCommand:       cmd,
+		InstanceName:       *remoteInstanceName,
+		SessionAffinityKey: *affinityKey,
 	}
 	if *patch != "" {
 		patchContents, err := os.ReadFile(*patch)


### PR DESCRIPTION
This allows clients to specify preference as to which Bazel instance
their requests get routed.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
