### PR TITLE
Request `offline_access` scope from non-Google OIDC providers in order to retrieve refresh token

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -387,7 +387,8 @@ func createAuthenticatorsFromConfig(ctx context.Context, authConfigs []config.Oa
 				if provider, err = authenticator.provider(); err == nil {
 					// "openid" is a required scope for OpenID Connect flows.
 					scopes := []string{oidc.ScopeOpenID, "profile", "email"}
-					// Google reject the offline_access scope in favor of access_type=offline url param.
+					// Google reject the offline_access scope in favor of access_type=offline url param which already gets 
+					// set in our auth flow thanks to the oauth2.AccessTypeOffline authCodeOption at the top of this file.
 					// https://github.com/coreos/go-oidc/blob/v2.2.1/oidc.go#L30
 					if authConfig.IssuerURL != "https://accounts.google.com" {
 						scopes = append(scopes, oidc.ScopeOfflineAccess)

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -385,14 +385,20 @@ func createAuthenticatorsFromConfig(ctx context.Context, authConfigs []config.Oa
 			if authenticator.cachedOauth2Config == nil {
 				var provider *oidc.Provider
 				if provider, err = authenticator.provider(); err == nil {
+					// "openid" is a required scope for OpenID Connect flows.
+					scopes := []string{oidc.ScopeOpenID, "profile", "email"}
+					// Google reject the offline_access scope in favor of access_type=offline url param.
+					// https://github.com/coreos/go-oidc/blob/v2.2.1/oidc.go#L30
+					if authConfig.IssuerURL != "https://accounts.google.com" {
+						scopes = append(scopes, oidc.ScopeOfflineAccess)
+					}
 					// Configure an OpenID Connect aware OAuth2 client.
 					authenticator.cachedOauth2Config = &oauth2.Config{
 						ClientID:     authConfig.ClientID,
 						ClientSecret: authConfig.ClientSecret,
 						RedirectURL:  authURL.String(),
 						Endpoint:     provider.Endpoint(),
-						// "openid" is a required scope for OpenID Connect flows.
-						Scopes: []string{oidc.ScopeOpenID, "profile", "email"},
+						Scopes: 	  scopes,
 					}
 				}
 			}

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -387,7 +387,7 @@ func createAuthenticatorsFromConfig(ctx context.Context, authConfigs []config.Oa
 				if provider, err = authenticator.provider(); err == nil {
 					// "openid" is a required scope for OpenID Connect flows.
 					scopes := []string{oidc.ScopeOpenID, "profile", "email"}
-					// Google reject the offline_access scope in favor of access_type=offline url param which already gets 
+					// Google reject the offline_access scope in favor of access_type=offline url param which already gets
 					// set in our auth flow thanks to the oauth2.AccessTypeOffline authCodeOption at the top of this file.
 					// https://github.com/coreos/go-oidc/blob/v2.2.1/oidc.go#L30
 					if authConfig.IssuerURL != "https://accounts.google.com" {
@@ -399,7 +399,7 @@ func createAuthenticatorsFromConfig(ctx context.Context, authConfigs []config.Oa
 						ClientSecret: authConfig.ClientSecret,
 						RedirectURL:  authURL.String(),
 						Endpoint:     provider.Endpoint(),
-						Scopes: 	  scopes,
+						Scopes:       scopes,
 					}
 				}
 			}


### PR DESCRIPTION
This fixes the issue where Okta users registered through OIDC will be logged out every 60 minutes.

Without this scope, Okta does not send a refresh_token with the authorize response.

Google auth does not support this scope, but instead uses a url parameter `access_type=offline` which we already set thanks to oauth2.AccessTypeOffline on line 91 of auth.go:
https://github.com/coreos/go-oidc/blob/v2.2.1/oidc.go#L30

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
