### PR TITLE
Retrieve ACKs from build event proxy

### DIFF
--- a/server/build_event_protocol/build_event_proxy/build_event_proxy.go
+++ b/server/build_event_protocol/build_event_proxy/build_event_proxy.go
@@ -2,7 +2,7 @@ package build_event_proxy
 
 import (
 	"context"
-    "io"
+	"io"
 	"sync"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -82,20 +82,20 @@ func (c *BuildEventProxyClient) newAsyncStreamProxy(ctx context.Context, opts ..
 		}
 		asp.PublishBuildEvent_PublishBuildToolEventStreamClient = stream
 
-        // Receive all responses (ACKs) from the proxy, but ignore those.
-        // Without this step the channel maybe blocked with outstanding messages.
-        go func() {
-            for {
-                _, err := stream.Recv()
-                if err == io.EOF {
-                    break
-                }
-                if err != nil {
-                    log.Warningf("Got error while getting response from proxy: %s", err.Error())
-                    break
-                }
-            }
-        }()
+		// Receive all responses (ACKs) from the proxy, but ignore those.
+		// Without this step the channel maybe blocked with outstanding messages.
+		go func() {
+			for {
+				_, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					log.Warningf("Got error while getting response from proxy: %s", err.Error())
+					break
+				}
+			}
+		}()
 
 		// `range` *copies* the values it returns into the loopvar, and
 		// copies of protos are not permitted, so rather than range over the

--- a/server/build_event_protocol/build_event_proxy/build_event_proxy.go
+++ b/server/build_event_protocol/build_event_proxy/build_event_proxy.go
@@ -2,6 +2,7 @@ package build_event_proxy
 
 import (
 	"context"
+    "io"
 	"sync"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -80,6 +81,21 @@ func (c *BuildEventProxyClient) newAsyncStreamProxy(ctx context.Context, opts ..
 			return
 		}
 		asp.PublishBuildEvent_PublishBuildToolEventStreamClient = stream
+
+        // Receive all responses (ACKs) from the proxy, but ignore those.
+        // Without this step the channel maybe blocked with outstanding messages.
+        go func() {
+            for {
+                _, err := stream.Recv()
+                if err == io.EOF {
+                    break
+                }
+                if err != nil {
+                    log.Warningf("Got error while getting response from proxy: %s", err.Error())
+                    break
+                }
+            }
+        }()
 
 		// `range` *copies* the values it returns into the loopvar, and
 		// copies of protos are not permitted, so rather than range over the


### PR DESCRIPTION
Found out that when using proxy some streams were not complete. It's
because the build event server to which traffic was proxied was sending
ACKs messages along the way, but buildbuddy was not retrieving it,
so those were accumulated till some buffers were filled up.

---

**Version bump**: Patch