### PR TITLE
Avoid panic when Xcode is not installed

### DIFF
--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -142,7 +142,11 @@ func GetConfiguredEnvironmentOrDie(configurator *config.Configurator, healthChec
 		log.Infof("No authentication will be configured: %s", err)
 	}
 
-	realEnv.SetXCodeLocator(xcode.NewXcodeLocator())
+	xl, err := xcode.NewXcodeLocator()
+	realEnv.SetXCodeLocator(xl)
+	if err != nil {
+		log.Fatalf("Failed to set XCodeLocator: %s", err)
+	}
 
 	if gcsCacheConfig := configurator.GetCacheGCSConfig(); gcsCacheConfig != nil {
 		opts := make([]option.ClientOption, 0)

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -143,10 +143,10 @@ func GetConfiguredEnvironmentOrDie(configurator *config.Configurator, healthChec
 	}
 
 	xl, err := xcode.NewXcodeLocator()
-	realEnv.SetXCodeLocator(xl)
 	if err != nil {
 		log.Fatalf("Failed to set XCodeLocator: %s", err)
 	}
+	realEnv.SetXCodeLocator(xl)
 
 	if gcsCacheConfig := configurator.GetCacheGCSConfig(); gcsCacheConfig != nil {
 		opts := make([]option.ClientOption, 0)

--- a/server/xcode/xcode.go
+++ b/server/xcode/xcode.go
@@ -6,7 +6,7 @@ package xcode
 type xcodeLocator struct {
 }
 
-func NewXcodeLocator() *xcodeLocator {
+func NewXcodeLocator() (*xcodeLocator, error) {
 	return &xcodeLocator{}
 }
 

--- a/server/xcode/xcode.go
+++ b/server/xcode/xcode.go
@@ -7,7 +7,7 @@ type xcodeLocator struct {
 }
 
 func NewXcodeLocator() (*xcodeLocator, error) {
-	return &xcodeLocator{}
+	return &xcodeLocator{}, nil
 }
 
 func (x *xcodeLocator) DeveloperDirForVersion(version string) (string, error) {

--- a/server/xcode/xcode_darwin.go
+++ b/server/xcode/xcode_darwin.go
@@ -10,7 +10,6 @@ package xcode
 import "C"
 
 import (
-	"fmt"
 	"io/fs"
 	"os"
 	"strings"
@@ -86,7 +85,7 @@ func (x *xcodeLocator) locate() error {
 	urlsPointer := C.LSCopyApplicationURLsForBundleIdentifier(bundleID, nil)
 
 	if urlsPointer == C.CFArrayRef(unsafe.Pointer(nil)) {
-		return fmt.Errorf("cannot find XCode bundle: %q", xcodeBundleID)
+		return status.FailedPreconditionErrorf("cannot find Xcode bundle: %q. Make sure Xcode is installed.", xcodeBundleID)
 	}
 	defer C.CFRelease(C.CFTypeRef(urlsPointer))
 


### PR DESCRIPTION
Return error for NewXCodeLocator when Xcode cannot be found.
If NewXCodeLocator returns an error log.Fatal
