### PR TITLE
Revert "Add `dockerUser` platform prop to control Docker user ID and output dir permissions (#1294)"

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -5,8 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -120,32 +118,6 @@ func PullImageIfNecessary(ctx context.Context, env environment.Env, cacheAuth *I
 	// expires.
 	cacheAuth.Refresh(cacheToken)
 	return nil
-}
-
-// ParseUser parses a user string, which may either be an empty string or a
-// string like `<uid>[:<gid>]` where uid and gid are numeric. If the user is
-// empty then (-1, -1) will be returned as the uid and gid, which correspond to
-// the current executor process owner.
-func ParseUser(user string) (int, int, error) {
-	parts := strings.Split(user, ":")
-	if len(parts) == 0 {
-		// empty string; inherit executor process owner.
-		return -1, -1, nil
-	}
-	uid, err := strconv.ParseInt(parts[0], 10, 32)
-	if err != nil || uid < 0 {
-		return 0, 0, status.UnimplementedError(
-			"unsupported container image user spec: currently only numeric <UID>[:<GID>] is supported")
-	}
-	gid := uid
-	if len(parts) > 1 {
-		gid, err = strconv.ParseInt(parts[1], 10, 32)
-		if err != nil || gid < 0 {
-			return 0, 0, status.UnimplementedError(
-				"unsupported container image user spec: currently only numeric <UID>[:<GID>] is supported")
-		}
-	}
-	return int(uid), int(gid), nil
 }
 
 type PullCredentials struct {

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -42,14 +42,9 @@ type DockerOptions struct {
 	Socket                  string
 	EnableSiblingContainers bool
 	UseHostNetwork          bool
+	ForceRoot               bool
 	DockerMountMode         string
-
-	// In order of precedence:
-	// ForceRoot, User, InheritUserIDs (from executor process)
-
-	ForceRoot      bool
-	User           string
-	InheritUserIDs bool
+	InheritUserIDs          bool
 }
 
 // dockerCommandContainer containerizes a command's execution using a Docker container.
@@ -192,9 +187,6 @@ func wrapDockerErr(err error, contextMsg string) error {
 func (r *dockerCommandContainer) getUser() (string, error) {
 	if r.options.ForceRoot {
 		return "root", nil
-	}
-	if r.options.User != "" {
-		return r.options.User, nil
 	}
 	if r.options.InheritUserIDs {
 		user, err := user.Current()

--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -61,11 +61,6 @@ type DirHelper struct {
 	dirsToCreate []string
 
 	outputDirs []string
-
-	// uid is the owner user ID for output directories created by this DirHelper.
-	uid int
-	// gid is the owner group ID for output directories created by this DirHelper.
-	gid int
 }
 
 func NewDirHelper(rootDir string, outputFiles, outputDirectories []string) *DirHelper {
@@ -75,10 +70,6 @@ func NewDirHelper(rootDir string, outputFiles, outputDirectories []string) *DirH
 		fullPaths:    make(map[string]struct{}, 0),
 		dirsToCreate: make([]string, 0),
 		outputDirs:   make([]string, 0),
-		// Inherit the user ID and group ID from the executor process unless
-		// otherwise specified.
-		uid: -1,
-		gid: -1,
 	}
 
 	for _, outputFile := range outputFiles {
@@ -110,68 +101,14 @@ func NewDirHelper(rootDir string, outputFiles, outputDirectories []string) *DirH
 	return c
 }
 
-// SetOwner sets the owner for all output directories, as well as parents of
-// those output directories, up to and including the workspace root. It
-// immediately changes the owner of the workspace root, but ownership of
-// output directories is only affected in subsequent calls to CreateOutputDirs.
-//
-// File ownership is not affected.
-//
-// TODO(bduffany): Figure out whether it makes sense to set ownership on all
-// directories created under the workspace root and not just output directories.
-// This would include ancestors of output directories up to the workspace root,
-// as well as ancestor directories of input files up to the workspace root.
-func (c *DirHelper) SetOwner(uid, gid int) error {
-	if c.uid != -1 && c.uid != uid {
-		return status.UnimplementedErrorf(
-			"Changing the owner user ID more than once on a workspace is not supported (tried to change from %d to %d)", c.uid, uid)
-	}
-	if c.gid != -1 && c.gid != gid {
-		return status.UnimplementedErrorf(
-			"Changing the owner group ID more than once on a workspace is not supported (tried to change from %d to %d)", c.gid, gid)
-	}
-
-	c.uid = uid
-	c.gid = gid
-	// Skip the syscall if the gid and uid will be inherited from the executor
-	// process, since that's the default behavior when creating directories.
-	if c.uid == -1 && c.gid == -1 {
-		return nil
-	}
-	return os.Chown(c.rootDir, c.uid, c.gid)
-}
-
 func (c *DirHelper) CreateOutputDirs() error {
 	for _, dir := range c.dirsToCreate {
 		if err := disk.EnsureDirectoryExists(dir); err != nil {
 			return err
 		}
-		// Need to chown output directories as well as their parent directories,
-		// since (unfortunately) certain actions will try to `unlinkat` their
-		// declared output directories, which requires permissions on the parent
-		// dir.
-		if err := c.chownUpToWorkspaceRoot(dir); err != nil {
-			return err
-		}
 	}
 	return nil
 }
-
-func (c *DirHelper) chownUpToWorkspaceRoot(path string) error {
-	// Skip syscalls if the gid and uid will be inherited from the executor
-	// process, since that's the default behavior when creating directories.
-	if c.uid == -1 && c.gid == -1 {
-		return nil
-	}
-	for path != c.rootDir {
-		if err := os.Chown(path, c.uid, c.gid); err != nil {
-			return err
-		}
-		path = filepath.Dir(path)
-	}
-	return nil
-}
-
 func (c *DirHelper) MatchesOutputDir(path string) (string, bool) {
 	for _, d := range c.outputDirs {
 		for p := path; p != filepath.Dir(p); p = filepath.Dir(p) {

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -59,17 +59,8 @@ const (
 	cpuArchitecturePropertyName = "Arch"
 	defaultCPUArchitecture      = "amd64"
 
-	// Property name that if set to "true" will cause Docker containers to be
-	// run as root. This takes precedence over the "dockerUser" property.
-	//
-	// This matches the property name defined here:
-	// https://github.com/bazelbuild/bazel-toolchains/blob/v5.1.0/rules/exec_properties/exec_properties.bzl#L164
+	// Using the property defined here: https://github.com/bazelbuild/bazel-toolchains/blob/v5.1.0/rules/exec_properties/exec_properties.bzl#L164
 	dockerRunAsRootPropertyName = "dockerRunAsRoot"
-	// Property name specifying the numeric <uid>[:<gid>] that the Docker
-	// container will run as. It takes precedence over the USER setting in the
-	// Dockerfile, and is required to run containerized actions that need to write
-	// output files. It is ignored for non-Docker actions.
-	dockerUserPropertyName = "dockerUser"
 
 	// A BuildBuddy Compute Unit is defined as 1 cpu and 2.5GB of memory.
 	EstimatedComputeUnitsPropertyName = "EstimatedComputeUnits"
@@ -99,7 +90,6 @@ type Properties struct {
 	ContainerRegistryPassword string
 	WorkloadIsolationType     string
 	DockerForceRoot           bool
-	DockerUser                string
 	RecycleRunner             bool
 	EnableVFS                 bool
 	// PreserveWorkspace specifies whether to delete all files in the workspace
@@ -152,7 +142,6 @@ func ParseProperties(task *repb.ExecutionTask) *Properties {
 		ContainerRegistryPassword: stringProp(m, containerRegistryPasswordPropertyName, ""),
 		WorkloadIsolationType:     stringProp(m, workloadIsolationPropertyName, ""),
 		DockerForceRoot:           boolProp(m, dockerRunAsRootPropertyName, false),
-		DockerUser:                stringProp(m, dockerUserPropertyName, ""),
 		RecycleRunner:             boolProp(m, RecycleRunnerPropertyName, false),
 		EnableVFS:                 boolProp(m, enableVFSPropertyName, false),
 		PreserveWorkspace:         boolProp(m, preserveWorkspacePropertyName, false),

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -186,9 +186,6 @@ func (r *CommandRunner) pullCredentials() container.PullCredentials {
 
 func (r *CommandRunner) PrepareForTask(ctx context.Context) error {
 	r.Workspace.SetTask(r.task)
-	if err := r.SetWorkspaceOwner(ctx); err != nil {
-		return err
-	}
 	// Clean outputs for the current task if applicable, in case
 	// those paths were written as read-only inputs in a previous action.
 	if r.PlatformProperties.RecycleRunner {
@@ -212,31 +209,6 @@ func (r *CommandRunner) PrepareForTask(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func (r *CommandRunner) SetWorkspaceOwner(ctx context.Context) error {
-	// Workspace owner will always match the executor process owner for the
-	// non-docker case.
-	if r.PlatformProperties.WorkloadIsolationType != string(platform.DockerContainerType) {
-		return nil
-	}
-
-	uid, gid := -1, -1 // inherit
-	var err error
-	if r.PlatformProperties.DockerForceRoot {
-		// Do nothing for now; if the docker container will run as root, then it
-		// most likely does not need to care about file permissions, and the
-		// executor is most likely already running as root -- otherwise, it would
-		// not be able to clean up files written by the container to the workspace,
-		// since they are owned by root. So, we can avoid chown syscalls here by
-		// keeping the workspace owner the same as the executor process.
-	} else if r.PlatformProperties.DockerUser != "" {
-		uid, gid, err = container.ParseUser(r.PlatformProperties.DockerUser)
-		if err != nil {
-			return err
-		}
-	}
-	return r.Workspace.SetOwner(uid, gid)
 }
 
 // Run runs the task that is currently bound to the command runner.
@@ -718,8 +690,6 @@ func (p *Pool) Get(ctx context.Context, task *repb.ExecutionTask) (*CommandRunne
 			User:             user,
 			ContainerImage:   props.ContainerImage,
 			WorkflowID:       props.WorkflowID,
-			DockerForceRoot:  props.DockerForceRoot,
-			DockerUser:       props.DockerUser,
 			InstanceName:     instanceName,
 			WorkerKey:        workerKey,
 			WorkspaceOptions: wsOpts,
@@ -793,7 +763,6 @@ func (p *Pool) newContainer(ctx context.Context, props *platform.Properties, tas
 	case platform.DockerContainerType:
 		opts := p.dockerOptions()
 		opts.ForceRoot = props.DockerForceRoot
-		opts.User = props.DockerUser
 		ctr = docker.NewDockerContainer(
 			p.env, p.imageCacheAuth, p.dockerClient, props.ContainerImage,
 			p.hostBuildRoot(), opts,
@@ -837,14 +806,6 @@ type query struct {
 	// WorkflowID is the BuildBuddy workflow ID, if applicable.
 	// Required; the zero-value "" matches non-workflow runners.
 	WorkflowID string
-	// DockerForceRoot is the value of the DockerForceRoot platform prop. This
-	// overrides the container image user and therefore the file permissions
-	// of files created by the container, so runners with different values of
-	// this property are incompatible.
-	// Required.
-	DockerForceRoot bool
-	// DockerUser is the value of the DockerUser platform prop.
-	DockerUser string
 	// WorkerKey is the key used to tell if a persistent worker can be reused.
 	// Required; the zero-value "" matches non-persistent-worker runners.
 	WorkerKey string
@@ -868,8 +829,6 @@ func (p *Pool) take(ctx context.Context, q *query) (*CommandRunner, error) {
 		if r.state != paused ||
 			r.PlatformProperties.ContainerImage != q.ContainerImage ||
 			r.PlatformProperties.WorkflowID != q.WorkflowID ||
-			r.PlatformProperties.DockerForceRoot != q.DockerForceRoot ||
-			r.PlatformProperties.DockerUser != q.DockerUser ||
 			r.WorkerKey != q.WorkerKey ||
 			r.InstanceName != q.InstanceName ||
 			*r.Workspace.Opts != *q.WorkspaceOptions {

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -91,15 +91,6 @@ func (ws *Workspace) SetTask(task *repb.ExecutionTask) {
 	ws.dirHelper = dirtools.NewDirHelper(ws.Path(), cmd.GetOutputFiles(), cmd.GetOutputDirectories())
 }
 
-func (ws *Workspace) SetOwner(uid, gid int) error {
-	ws.mu.Lock()
-	defer ws.mu.Unlock()
-	if ws.removing {
-		return WorkspaceMarkedForRemovalError
-	}
-	return ws.dirHelper.SetOwner(uid, gid)
-}
-
 // CommandWorkingDirectory returns the absolute path to the working directory
 // for the command to be executed. It assumes that any container executing the
 // task will have the workspace mounted at a path identical to its path on the


### PR DESCRIPTION
Decided to go with an alternate approach of specifying a platform prop that controls directory permissions directly.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
