### PR TITLE
Distinguish between key not set and empty key

### DIFF
--- a/enterprise/server/auth/BUILD
+++ b/enterprise/server/auth/BUILD
@@ -41,6 +41,7 @@ go_test(
         "//enterprise/server/testutil/enterprise_testenv",
         "//server/tables",
         "//server/util/status",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_oauth2//:oauth2",
     ],

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -651,12 +651,12 @@ func (a *OpenIDAuthenticator) ParseAPIKeyFromString(input string) (string, error
 		return "", nil
 	}
 	if len(matches) != 2 {
-		return "", status.FailedPreconditionError("invalid input")
+		return "", status.UnauthenticatedError("failed to parse API key: invalid input")
 	}
 	if apiKey := matches[1]; apiKey != "" {
 		return apiKey, nil
 	}
-	return "", status.FailedPreconditionError("missing API Key")
+	return "", status.UnauthenticatedError("failed to parse API key: missing API Key")
 }
 
 func (a *OpenIDAuthenticator) AuthContextFromAPIKey(ctx context.Context, apiKey string) context.Context {

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -89,7 +89,7 @@ const (
 
 var (
 	authCodeOption []oauth2.AuthCodeOption = []oauth2.AuthCodeOption{oauth2.AccessTypeOffline, oauth2.ApprovalForce}
-	apiKeyRegex                            = regexp.MustCompile(APIKeyHeader + "=([a-zA-Z0-9]+)")
+	apiKeyRegex                            = regexp.MustCompile(APIKeyHeader + "=([a-zA-Z0-9]*)")
 	jwtKey                                 = []byte("set_the_jwt_in_config") // set via config.
 )
 
@@ -644,12 +644,16 @@ func authContextFromClaims(ctx context.Context, claims *Claims, err error) conte
 	return ctx
 }
 
-func (a *OpenIDAuthenticator) ParseAPIKeyFromString(input string) string {
+func (a *OpenIDAuthenticator) ParseAPIKeyFromString(input string) *string {
+	stringPtr := func(str string) *string { return &str }
 	matches := apiKeyRegex.FindStringSubmatch(input)
-	if matches != nil && len(matches) > 1 {
-		return matches[1]
+	if len(matches) == 0 {
+		return nil
 	}
-	return ""
+	if len(matches) == 1 {
+		return stringPtr("")
+	}
+	return stringPtr(matches[1])
 }
 
 func (a *OpenIDAuthenticator) AuthContextFromAPIKey(ctx context.Context, apiKey string) context.Context {

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -644,16 +644,19 @@ func authContextFromClaims(ctx context.Context, claims *Claims, err error) conte
 	return ctx
 }
 
-func (a *OpenIDAuthenticator) ParseAPIKeyFromString(input string) *string {
-	stringPtr := func(str string) *string { return &str }
+func (a *OpenIDAuthenticator) ParseAPIKeyFromString(input string) (string, error) {
 	matches := apiKeyRegex.FindStringSubmatch(input)
 	if len(matches) == 0 {
-		return nil
+		// The api key header is not present
+		return "", nil
 	}
-	if len(matches) == 1 {
-		return stringPtr("")
+	if len(matches) != 2 {
+		return "", status.FailedPreconditionError("invalid input")
 	}
-	return stringPtr(matches[1])
+	if apiKey := matches[1]; apiKey != "" {
+		return apiKey, nil
+	}
+	return "", status.FailedPreconditionError("missing API Key")
 }
 
 func (a *OpenIDAuthenticator) AuthContextFromAPIKey(ctx context.Context, apiKey string) context.Context {

--- a/enterprise/server/auth/auth_test.go
+++ b/enterprise/server/auth/auth_test.go
@@ -151,7 +151,7 @@ func TestParseAPIKeyFromString(t *testing.T) {
 		},
 		{
 			name:    "empty key in the middle",
-			input:   "--bes_results_url=http://localhost:8080/invocation/ --remote_header='x-buildbuddy-api-key= --bes_backend=grpc://localhost:1985'",
+			input:   "--bes_results_url=http://localhost:8080/invocation/ --remote_header='x-buildbuddy-api-key=' --bes_backend=grpc://localhost:1985",
 			want:    "",
 			wantErr: true,
 		},

--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -71,7 +71,7 @@ func (d *AuthDB) GetAPIKeyGroupFromAPIKey(ctx context.Context, apiKey string) (i
 	})
 	if err != nil {
 		if db.IsRecordNotFound(err) {
-			return nil, status.UnauthenticatedErrorf("Invalid API key %s", apiKey)
+			return nil, status.UnauthenticatedErrorf("Invalid API key %q", apiKey)
 		}
 		return nil, err
 	}

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -155,7 +155,7 @@ func (a *SAMLAuthenticator) AuthenticateGRPCRequest(ctx context.Context) (interf
 	return a.fallback.AuthenticateGRPCRequest(ctx)
 }
 
-func (a *SAMLAuthenticator) ParseAPIKeyFromString(s string) *string {
+func (a *SAMLAuthenticator) ParseAPIKeyFromString(s string) (string, error) {
 	return a.fallback.ParseAPIKeyFromString(s)
 }
 

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -155,7 +155,7 @@ func (a *SAMLAuthenticator) AuthenticateGRPCRequest(ctx context.Context) (interf
 	return a.fallback.AuthenticateGRPCRequest(ctx)
 }
 
-func (a *SAMLAuthenticator) ParseAPIKeyFromString(s string) string {
+func (a *SAMLAuthenticator) ParseAPIKeyFromString(s string) *string {
 	return a.fallback.ParseAPIKeyFromString(s)
 }
 

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -616,8 +616,12 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 			if err != nil {
 				return err
 			}
-			if apiKey := auth.ParseAPIKeyFromString(options); apiKey != nil {
-				e.ctx = auth.AuthContextFromAPIKey(e.ctx, *apiKey)
+			apiKey, err := auth.ParseAPIKeyFromString(options)
+			if err != nil {
+				return status.UnauthenticatedErrorf("failed to parse API key: %s", err)
+			}
+			if apiKey != "" {
+				e.ctx = auth.AuthContextFromAPIKey(e.ctx, apiKey)
 				authError := e.ctx.Value(interfaces.AuthContextUserErrorKey)
 				if authError != nil {
 					if err, ok := authError.(error); ok {

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -618,7 +618,7 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 			}
 			apiKey, err := auth.ParseAPIKeyFromString(options)
 			if err != nil {
-				return status.UnauthenticatedErrorf("failed to parse API key: %s", err)
+				return err
 			}
 			if apiKey != "" {
 				e.ctx = auth.AuthContextFromAPIKey(e.ctx, apiKey)

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -616,8 +616,8 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 			if err != nil {
 				return err
 			}
-			if apiKey := auth.ParseAPIKeyFromString(options); apiKey != "" {
-				e.ctx = auth.AuthContextFromAPIKey(e.ctx, apiKey)
+			if apiKey := auth.ParseAPIKeyFromString(options); apiKey != nil {
+				e.ctx = auth.AuthContextFromAPIKey(e.ctx, *apiKey)
 				authError := e.ctx.Value(interfaces.AuthContextUserErrorKey)
 				if authError != nil {
 					if err, ok := authError.(error); ok {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -125,7 +125,7 @@ type Authenticator interface {
 	AuthenticatedUser(ctx context.Context) (UserInfo, error)
 
 	// Parses and returns a BuildBuddy API key from the given string.
-	ParseAPIKeyFromString(string) string
+	ParseAPIKeyFromString(string) *string
 
 	// Returns a context containing the given API key.
 	AuthContextFromAPIKey(ctx context.Context, apiKey string) context.Context

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -125,7 +125,7 @@ type Authenticator interface {
 	AuthenticatedUser(ctx context.Context) (UserInfo, error)
 
 	// Parses and returns a BuildBuddy API key from the given string.
-	ParseAPIKeyFromString(string) *string
+	ParseAPIKeyFromString(string) (string, error)
 
 	// Returns a context containing the given API key.
 	AuthContextFromAPIKey(ctx context.Context, apiKey string) context.Context

--- a/server/nullauth/nullauth.go
+++ b/server/nullauth/nullauth.go
@@ -39,8 +39,8 @@ func (a *NullAuthenticator) Logout(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 }
 
-func (a *NullAuthenticator) ParseAPIKeyFromString(input string) *string {
-	return nil
+func (a *NullAuthenticator) ParseAPIKeyFromString(input string) (string, error) {
+	return "", nil
 }
 
 func (a *NullAuthenticator) AuthContextFromAPIKey(ctx context.Context, apiKey string) context.Context {

--- a/server/nullauth/nullauth.go
+++ b/server/nullauth/nullauth.go
@@ -39,8 +39,8 @@ func (a *NullAuthenticator) Logout(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 }
 
-func (a *NullAuthenticator) ParseAPIKeyFromString(input string) string {
-	return ""
+func (a *NullAuthenticator) ParseAPIKeyFromString(input string) *string {
+	return nil
 }
 
 func (a *NullAuthenticator) AuthContextFromAPIKey(ctx context.Context, apiKey string) context.Context {

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -171,12 +171,12 @@ func (a *TestAuthenticator) Logout(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 }
 
-func (a *TestAuthenticator) ParseAPIKeyFromString(input string) string {
+func (a *TestAuthenticator) ParseAPIKeyFromString(input string) string* {
 	matches := testApiKeyRegex.FindStringSubmatch(input)
 	if matches != nil && len(matches) > 1 {
 		return matches[1]
 	}
-	return ""
+	return nil
 }
 
 func (a *TestAuthenticator) AuthContextFromAPIKey(ctx context.Context, apiKey string) context.Context {

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -171,12 +171,16 @@ func (a *TestAuthenticator) Logout(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 }
 
-func (a *TestAuthenticator) ParseAPIKeyFromString(input string) string* {
+func (a *TestAuthenticator) ParseAPIKeyFromString(input string) *string {
+	stringPtr := func(str string) *string { return &str }
 	matches := testApiKeyRegex.FindStringSubmatch(input)
-	if matches != nil && len(matches) > 1 {
-		return matches[1]
+	if len(matches) == 0 {
+		return nil
 	}
-	return nil
+	if len(matches) == 1 {
+		return stringPtr("")
+	}
+	return stringPtr(matches[1])
 }
 
 func (a *TestAuthenticator) AuthContextFromAPIKey(ctx context.Context, apiKey string) context.Context {


### PR DESCRIPTION
1. change ParseAPIKeyFromString to return a string pointer instead of
   a string; and thus allow us to distinguish between when the key is
   not set (i.e. 'x-buildbuddy-api-key=' is not present) vs empty key
   (i.e. the header is present)
2. also print quotes for "Invalid API Key" message, to make it more
   readable when the key is empty.
