### PR TITLE
Misc tweaks for cache misses card and action page

### DIFF
--- a/app/components/digest/digest.css
+++ b/app/components/digest/digest.css
@@ -2,12 +2,12 @@
   display: flex;
   align-items: center;
   color: #000;
+  border-radius: 4px;
+  overflow: hidden;
 }
 
 .digest-component-hash {
   padding: 0 8px;
-  border-top-left-radius: 4px;
-  border-bottom-left-radius: 4px;
   max-width: 64px;
   min-width: 24px;
   overflow: hidden;
@@ -15,7 +15,6 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   font-size: 0.6em;
-  margin-left: 8px;
   transition: all 0.5s ease;
 }
 
@@ -25,7 +24,6 @@
 
 .digest-component.expanded .digest-component-hash {
   max-width: initial;
-  margin-left: 0;
   font-size: 0.8em;
 }
 
@@ -35,8 +33,6 @@
 
 .digest-component-size {
   padding: 0 8px;
-  border-top-right-radius: 4px;
-  border-bottom-right-radius: 4px;
   display: inline-block;
   white-space: nowrap;
   font-size: 0.6em;

--- a/app/components/digest/digest.tsx
+++ b/app/components/digest/digest.tsx
@@ -2,7 +2,15 @@ import format from "../../format/format";
 import React from "react";
 import Long from "long";
 
-export type DigestProps = { digest: { hash?: string; sizeBytes?: number | Long }; expanded?: boolean };
+export type Digest = {
+  hash?: string;
+  sizeBytes?: number | Long | null;
+};
+
+export type DigestProps = {
+  digest: Digest;
+  expanded?: boolean;
+};
 
 export const DigestComponent = React.forwardRef((props: DigestProps, ref: React.Ref<HTMLInputElement>) => {
   return (
@@ -13,10 +21,21 @@ export const DigestComponent = React.forwardRef((props: DigestProps, ref: React.
         style={{ backgroundColor: format.colorHash(props.digest.hash) }}>
         {props.digest.hash}
       </span>
-      <span title={`${props.digest.sizeBytes}`} className="digest-component-size">
-        {format.bytes(props.digest.sizeBytes)}
-      </span>
+      {props.digest.sizeBytes !== null && props.digest.sizeBytes !== undefined && (
+        <span title={`${props.digest.sizeBytes}`} className="digest-component-size">
+          {format.bytes(props.digest.sizeBytes)}
+        </span>
+      )}
     </span>
   );
 });
+
+export function parseDigest(value: string): Digest {
+  const parts = value.split("/");
+  return {
+    hash: parts[0],
+    sizeBytes: parts.length > 1 ? Number(parts[1]) : null,
+  };
+}
+
 export default DigestComponent;

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -13,6 +13,11 @@
   cursor: pointer;
   user-select: none;
 }
+
+.input-tree-node-name .digest-component {
+  margin-left: 8px;
+}
+
 .input-tree-node-name .icon {
   opacity: 0.7;
 }
@@ -52,6 +57,10 @@
 
 .file-name:hover {
   color: #888;
+}
+
+.file-name .digest-component {
+  margin-left: 8px;
 }
 
 .action-timeline {

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -5,7 +5,7 @@ import { Download, Info } from "lucide-react";
 import { build } from "../../proto/remote_execution_ts_proto";
 import InputNodeComponent, { InputNode } from "./invocation_action_input_node";
 import rpcService from "../service/rpc_service";
-import DigestComponent from "../components/digest/digest";
+import DigestComponent, { parseDigest } from "../components/digest/digest";
 
 interface Props {
   model: InvocationModel;
@@ -29,15 +29,17 @@ export default class InvocationActionCardComponent extends React.Component<Props
     treeShaToChildrenMap: new Map<string, InputNode[]>(),
     inputDirs: [],
   };
+
   componentDidMount() {
     this.fetchAction();
     this.fetchActionResult();
   }
 
   fetchAction() {
-    let actionFile = "bytestream://" + this.getCacheAddress() + "/blobs/" + this.props.search.get("actionDigest");
+    const digest = parseDigest(this.props.search.get("actionDigest"));
+    const actionUrl = `bytestream://${this.getCacheAddress()}/blobs/${digest.hash}/${digest.sizeBytes ?? 1}`;
     rpcService
-      .fetchBytestreamFile(actionFile, this.props.model.getId(), "arraybuffer")
+      .fetchBytestreamFile(actionUrl, this.props.model.getId(), "arraybuffer")
       .then((buffer: any) => {
         let action = build.bazel.remote.execution.v2.Action.decode(new Uint8Array(buffer));
         this.setState({
@@ -46,7 +48,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
         this.fetchCommand(action);
         this.fetchInputRoot(action.inputRootDigest);
       })
-      .catch((e) => console.log(e));
+      .catch((e) => console.error("Failed to fetch action:", e));
   }
 
   fetchInputRoot(rootDigest: build.bazel.remote.execution.v2.IDigest) {
@@ -68,20 +70,20 @@ export default class InvocationActionCardComponent extends React.Component<Props
           inputDirs: inputDirs,
         });
       })
-      .catch((e) => console.log(e));
+      .catch((e) => console.error("Failed to fetch input root:", e));
   }
 
   fetchActionResult() {
-    let actionResultFile =
-      "actioncache://" + this.getCacheAddress() + "/blobs/ac/" + this.props.search.get("actionDigest");
+    const digest = parseDigest(this.props.search.get("actionDigest"));
+    const actionResultUrl = `actioncache://${this.getCacheAddress()}/blobs/ac/${digest.hash}/${digest.sizeBytes ?? 1}`;
     rpcService
-      .fetchBytestreamFile(actionResultFile, this.props.model.getId(), "arraybuffer")
+      .fetchBytestreamFile(actionResultUrl, this.props.model.getId(), "arraybuffer")
       .then((buffer: any) => {
         this.setState({
           actionResult: build.bazel.remote.execution.v2.ActionResult.decode(new Uint8Array(buffer)),
         });
       })
-      .catch((e) => console.log(e));
+      .catch((e) => console.error("Failed to fetch action result:", e));
   }
 
   fetchCommand(action: build.bazel.remote.execution.v2.Action) {
@@ -99,7 +101,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
           command: build.bazel.remote.execution.v2.Command.decode(new Uint8Array(buffer)),
         });
       })
-      .catch((e) => console.log(e));
+      .catch((e) => console.error("Failed to fetch command:", e));
   }
 
   displayList(list: string[]) {
@@ -268,7 +270,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
   }
 
   render() {
-    let digest = this.props.search.get("actionDigest").split("/");
+    const digest = parseDigest(this.props.search.get("actionDigest"));
     return (
       <div className="invocation-action-card">
         <div className="card">
@@ -279,15 +281,15 @@ export default class InvocationActionCardComponent extends React.Component<Props
               {this.state.action ? (
                 <div>
                   <div className="action-section">
-                    <div className="action-property-title">Digest hash/size</div>
-                    <DigestComponent digest={{ hash: digest[0], sizeBytes: parseInt(digest[1]) }} expanded={true} />
+                    <div className="action-property-title">Digest</div>
+                    <DigestComponent digest={digest} expanded={true} />
                   </div>
                   <div className="action-section">
                     <div className="action-property-title">Cacheable</div>
                     <div>{!this.state.action.doNotCache ? "True" : "False"}</div>
                   </div>
                   <div className="action-section">
-                    <div className="action-property-title">Input root digest hash/size</div>
+                    <div className="action-property-title">Input root digest</div>
                     <div>
                       <DigestComponent digest={this.state.action.inputRootDigest} expanded={true} />
                     </div>
@@ -310,7 +312,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
                   </div>
                   <div className="action-section">
                     <div className="action-property-title">Input files</div>
-                    {this.state.inputDirs.length && (
+                    {this.state.inputDirs.length ? (
                       <div className="input-tree">
                         {this.state.inputDirs.map((node) => (
                           <InputNodeComponent
@@ -321,6 +323,8 @@ export default class InvocationActionCardComponent extends React.Component<Props
                           />
                         ))}
                       </div>
+                    ) : (
+                      <div>None found</div>
                     )}
                   </div>
                 </div>

--- a/app/invocation/scorecard_card.tsx
+++ b/app/invocation/scorecard_card.tsx
@@ -21,9 +21,7 @@ export default class ScorecardCardComponent extends React.Component<Props, State
   };
 
   getActionUrl(digestHash: string) {
-    // TODO(bduffany): Pass the correct digest size here, or update the action page to make the size optional.
-    const digestSizeBytes = 141;
-    return `/invocation/${this.props.model.getId()}?actionDigest=${digestHash}/${digestSizeBytes}#action`;
+    return `/invocation/${this.props.model.getId()}?actionDigest=${digestHash}#action`;
   }
 
   onClickShowAll() {

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -70,11 +70,17 @@ class RpcService {
         if (this.status >= 200 && this.status < 400) {
           resolve(this.response);
         } else {
-          reject("Error loading file");
+          let message: String;
+          if (this.response instanceof ArrayBuffer) {
+            message = new TextDecoder().decode(this.response);
+          } else {
+            message = String(this.response);
+          }
+          reject("Error loading file: " + message);
         }
       };
       request.onerror = function () {
-        reject("Error loading file");
+        reject("Error loading file (unknown error)");
       };
       request.send();
     });


### PR DESCRIPTION
* Don't show an incorrect digest size in the UI / URL if we don't know the digest size (last outstanding issue from buildbuddy-io/buildbuddy-internal#982)
* Don't show `Input files: 0` and instead show "None found" -- in some cases there were input files but we just don't have them available on our side, particularly when not using RBE.
* Misc
  * Make the DigestComponent size optional since we don't know it in some cases
  * Simplify DigestComponent border-radius to encompass the outer component
  * Refactor so that the DigestComponent doesn't specify its own external margins, which makes it less composable; instead specify margin via parents

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/982
