### PR TITLE
Fix some sidebar styling issues and clean up sidebar styles

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -264,9 +264,11 @@ button {
   margin-left: 0;
 }
 
-/* Default icon color is gray */
 svg.icon {
+  /* Default icon color is gray */
   stroke: #616161;
+  /* By default, icons should not get squished */
+  flex-shrink: 0;
 }
 
 svg.icon.white {

--- a/enterprise/app/root/root.css
+++ b/enterprise/app/root/root.css
@@ -39,7 +39,7 @@ body {
 
   .left .page {
     max-height: initial;
-  }  
+  }
 
   .dense .page,
   .page {
@@ -52,34 +52,30 @@ body {
     width: 100%;
   }
 
-  .dense .sidebar-body,
-  .sidebar-body {
-    display: flex;
+  .dense .sidebar .sidebar-body,
+  .sidebar .sidebar-body {
     flex-wrap: wrap;
-    margin-bottom: -16px;
+    flex-direction: row;
+    margin-bottom: var(--sidebar-padding);
   }
 
-  .dense .sidebar .sidebar-item,
-  .sidebar .sidebar-item {
-    margin-right: 32px;
+  .dense .sidebar .logo {
+    height: 36px;
   }
 
-  .sidebar .sidebar-footer.expanded {
-    margin: 32px -32px -32px -32px;
-    padding-bottom: 16px;
+  .sidebar .sidebar-footer:not(.expanded) {
+    background-color: transparent;
   }
 
-  .dense .sidebar .sidebar-footer.expanded {
-    margin: 12px -12px -12px -12px;
-    padding-bottom: 8px;
+  .sidebar .sidebar-expanded-profile {
+    margin-bottom: 0;
   }
 
-  .dense .sidebar .sidebar-footer .sidebar-profile,
   .sidebar .sidebar-footer .sidebar-profile {
     position: absolute;
     top: 0;
     right: 0;
-    background-color: transparent !important;
+    padding: 24px;
   }
 
   .dense .sidebar .sidebar-profile-photo {

--- a/enterprise/app/root/root.css
+++ b/enterprise/app/root/root.css
@@ -46,17 +46,17 @@ body {
     flex-direction: column;
     max-height: initial;
   }
-  .dense .sidebar,
-  .sidebar {
+
+  /* Duplicate selector for increased specificity. */
+  .sidebar.sidebar {
     height: auto;
     width: 100%;
   }
 
-  .dense .sidebar .sidebar-body,
   .sidebar .sidebar-body {
     flex-wrap: wrap;
     flex-direction: row;
-    margin-bottom: var(--sidebar-padding);
+    padding-bottom: 16px;
   }
 
   .dense .sidebar .logo {

--- a/enterprise/app/sidebar/sidebar.css
+++ b/enterprise/app/sidebar/sidebar.css
@@ -211,10 +211,6 @@
   opacity: 1;
 }
 
-.sidebar .org-picker-item svg {
-  flex-shrink: 0;
-}
-
 /** Dense **/
 
 .dense .sidebar {

--- a/enterprise/app/sidebar/sidebar.css
+++ b/enterprise/app/sidebar/sidebar.css
@@ -6,15 +6,40 @@
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
-  padding: 32px;
   overflow: auto;
   overflow-x: hidden;
   font-size: 18px;
   user-select: none;
 }
 
+.sidebar {
+  --sidebar-padding: 32px;
+  color: #fff;
+}
+
+.dense .sidebar {
+  --sidebar-padding: 16px;
+}
+
+/* Applying border padding to children so that background colors can extend to the sidebar edges. */
+
+.sidebar > * {
+  padding: 0 var(--sidebar-padding);
+}
+
+.sidebar > :first-child {
+  padding-top: var(--sidebar-padding);
+}
+
+.sidebar > :last-child {
+  padding-bottom: var(--sidebar-padding);
+}
+
+.sidebar .sidebar-footer {
+  padding: 0;
+}
+
 .sidebar .logo {
-  width: 100%;
   max-width: 216px;
   height: 36px;
   box-sizing: border-box;
@@ -32,13 +57,7 @@
   display: flex;
   align-items: center;
   cursor: pointer;
-  padding: 24px 24px 24px 32px;
-  margin: 0 0 -32px 0;
   font-size: 16px;
-}
-
-.sidebar .sidebar-profile:hover {
-  background-color: #455a64;
 }
 
 .sidebar .sidebar-profile-photo {
@@ -73,6 +92,10 @@
 .sidebar .sidebar-body {
   flex-grow: 1;
   overflow: auto;
+
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .sidebar .sidebar-body::-webkit-scrollbar {
@@ -80,7 +103,6 @@
 }
 
 .sidebar .sidebar-item {
-  margin-bottom: 16px;
   cursor: pointer;
   font-weight: 600;
   display: flex;
@@ -105,21 +127,29 @@
   stroke: white;
 }
 
-.sidebar .sidebar-footer {
-  margin: 0 -32px 0 -32px;
-}
-
+.sidebar .sidebar-footer:hover,
 .sidebar .sidebar-footer.expanded {
   background-color: #455a64;
 }
 
+.sidebar .sidebar-profile,
 .sidebar .sidebar-expanded-profile {
-  padding: 24px 32px 0 32px;
-  color: #fff;
+  padding: 24px var(--sidebar-padding);
 }
 
-.sidebar .sidebar-footer.expanded .sidebar-profile {
-  background-color: #455a64;
+.dense .sidebar .sidebar-profile,
+.dense .sidebar .sidebar-expanded-profile {
+  padding: 16px var(--sidebar-padding);
+}
+
+.sidebar .sidebar-expanded-profile {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sidebar .sidebar-expanded-profile {
+  margin-bottom: -8px;
 }
 
 .sidebar .default-photo {
@@ -130,9 +160,16 @@
 .sidebar .sidebar-profile-arrow {
   stroke: #90a4ae;
   margin-left: 4px;
+  margin-right: -4px;
 }
 
 /** Org picker */
+
+.sidebar .org-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
 
 .sidebar .org-picker-header {
   font-size: 15px;
@@ -142,12 +179,14 @@
 }
 
 .sidebar .org-list {
-  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
-.sidebar .create-organization {
-  margin-bottom: 16px;
-  padding-bottom: 16px;
+.sidebar hr {
+  margin: 0;
+  border: 0;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
 
@@ -172,11 +211,14 @@
   opacity: 1;
 }
 
+.sidebar .org-picker-item svg {
+  flex-shrink: 0;
+}
+
 /** Dense **/
 
 .dense .sidebar {
   width: 180px;
-  padding: 16px;
   font-size: 15px;
 }
 
@@ -185,25 +227,12 @@
   font-size: 16px;
 }
 
-.dense .sidebar .sidebar-footer {
-  margin: 0 -16px 0 -16px;
-}
-
-.dense .sidebar .sidebar-profile {
-  padding: 16px;
-  margin: 0 0 -12px 0;
-}
-
 .dense .sidebar .sidebar-profile-photo {
   display: none;
 }
 
 .dense .sidebar .sidebar-profile-name {
   margin-left: 0;
-}
-
-.dense .sidebar .sidebar-expanded-profile {
-  padding: 16px 16px 0 16px;
 }
 
 .dense .sidebar .sidebar-item svg {

--- a/enterprise/app/sidebar/sidebar.tsx
+++ b/enterprise/app/sidebar/sidebar.tsx
@@ -280,6 +280,7 @@ export default class SidebarComponent extends React.Component {
                   </div>
                 )}
               </div>
+              <hr />
               <div className="sidebar-item sidebar-logout-item" onClick={() => authService.logout()}>
                 <LogOut /> Logout
               </div>


### PR DESCRIPTION
Fixes:
* Fix bottom spacing between profile picker (at bottom) and the bottom edge of the sidebar, which was reproducible in dense mode only
* Fix issue that icons in the group picker become squished when the group name is too long

Refactor:
* Avoid specifying margins where possible and instead use the `gap` property which now has full support in all major browsers: https://caniuse.com/gap. The gap property is cleaner than margins because it allows setting a single CSS property on the parent, rather than having to awkwardly apply margins to all children except the last child.
* Avoid specifying negative margins where possible.
* Avoid non-symmetric padding and margins where possible -- make it so that the top padding almost always matches the bottom padding and left padding almost always matches the right padding.
* Remove `.dense` specific styles where possible in favor of setting a CSS variable that controls the base padding.

Tested in Linux/Chrome, macOS/Chrome, macOS/Safari, across all combinations of {mobile, dense mode, sidebar footer expanded}.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
