### PR TITLE
Add user-specific github token

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -78,6 +78,7 @@ export class AuthService {
     user.displayUser = response.displayUser as user_id.DisplayUser;
     user.groups = response.userGroup as grp.Group[];
     user.selectedGroup = response.userGroup.find((group) => group.id === response.selectedGroupId) as grp.Group;
+    user.githubToken = response.githubToken;
     user.allowedRpcs = new Set(
       response.allowedRpc.map(
         // Ensure RPC names are lowerCamelCase so that they match the RPC names

--- a/app/auth/user.ts
+++ b/app/auth/user.ts
@@ -7,6 +7,7 @@ export class User {
   groups: grp.Group[];
   selectedGroup: grp.Group;
   allowedRpcs: Set<BuildBuddyServiceRpcName>;
+  githubToken: string;
 
   selectedGroupName() {
     if (this.selectedGroup?.name == "DEFAULT_GROUP") return "Organization";

--- a/app/menu/menu.tsx
+++ b/app/menu/menu.tsx
@@ -61,6 +61,7 @@ export default class MenuComponent extends React.Component {
   private gitHubLinkUrl(): string {
     const params = new URLSearchParams({
       group_id: this.props.user?.selectedGroup?.id,
+      user_id: this.props.user?.displayUser.userId.id,
       redirect_url: window.location.href,
     });
     return `/auth/github/link/?${params}`;

--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -90,7 +90,7 @@ export default class CodeComponent extends React.Component<Props> {
 
   updateUser() {
     this.octokit = new Octokit({
-      auth: this.props.user.selectedGroup.githubToken,
+      auth: this.props.user.githubToken,
     });
   }
 
@@ -304,6 +304,11 @@ export default class CodeComponent extends React.Component<Props> {
   }
 
   async handleReviewClicked() {
+    if (!this.props.user.githubToken) {
+      this.handleGitHubClicked();
+      return;
+    }
+
     this.setState({ requestingReview: true });
 
     let filteredEntries = Array.from(this.state.changes.entries()).filter(
@@ -388,13 +393,18 @@ export default class CodeComponent extends React.Component<Props> {
 
   handleGitHubClicked() {
     const params = new URLSearchParams({
-      group_id: this.props.user?.selectedGroup?.id,
+      user_id: this.props.user?.displayUser?.userId.id,
       redirect_url: window.location.href,
     });
     window.location.href = `/auth/github/link/?${params}`;
   }
 
   handleUpdatePR() {
+    if (!this.props.user.githubToken) {
+      this.handleGitHubClicked();
+      return;
+    }
+
     let filteredEntries = Array.from(this.state.changes.entries()).filter(
       ([key, value]) => this.state.pathToIncludeChanges.get(key) // Only include checked changes
     );
@@ -520,7 +530,7 @@ export default class CodeComponent extends React.Component<Props> {
                   ))}
             </div>
             <div className="code-sidebar-actions">
-              {!this.props.user.selectedGroup.githubToken && (
+              {!this.props.user.githubToken && (
                 <button onClick={this.handleGitHubClicked.bind(this)}>
                   <Link className="icon" /> Link GitHub
                 </button>

--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -54,6 +54,7 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
   private gitHubLinkUrl(): string {
     const params = new URLSearchParams({
       group_id: this.props.user?.selectedGroup?.id,
+      user_id: this.props.user?.displayUser.userId.id,
       redirect_url: window.location.href,
     });
     return `/auth/github/link/?${params}`;

--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -8,6 +8,8 @@ package grp;
 // Group represents a group that a user is a member of.
 // Next tag: 10
 message Group {
+  reserved 8;
+
   // The unique ID of this group.
   // Ex. "GR4576963743584254779"
   string id = 1;
@@ -22,9 +24,6 @@ message Group {
 
   // True if this group has linked a Github token.
   bool github_linked = 4;
-
-  // The organization's GitHub token, if linked.
-  string github_token = 8;
 
   // The unique URL segment for this group which is used
   // to construct nice-looking URLs for this group, such as

--- a/proto/user.proto
+++ b/proto/user.proto
@@ -30,6 +30,9 @@ message GetUserResponse {
   // List of BuildBuddyService RPC names that the user is allowed to perform
   // for their currently selected group.
   repeated string allowed_rpc = 4;
+
+  // User-specific Github token (if linked).
+  string github_token = 5;
 }
 
 message CreateUserRequest {

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -32,7 +32,7 @@ const (
 	stateCookieName    = "Github-State-Token"
 	redirectCookieName = "Github-Redirect-Url"
 	groupIDCookieName  = "Github-Linked-Group-ID"
-	userIDCookieName  = "Github-Linked-User-ID"
+	userIDCookieName   = "Github-Linked-User-ID"
 )
 
 // State represents a status value that GitHub's statuses API understands.
@@ -165,7 +165,7 @@ func (c *GithubClient) Link(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			redirectWithError(w, r, status.PermissionDeniedErrorf("Error linking github account to group: %v", err))
 			return
-		}	
+		}
 	}
 
 	// Restore user ID from cookie.
@@ -180,7 +180,7 @@ func (c *GithubClient) Link(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			redirectWithError(w, r, status.PermissionDeniedErrorf("Error linking github account to user: %v", err))
 			return
-		}	
+		}
 	}
 
 	redirectUrl := getCookie(r, redirectCookieName)

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -138,7 +138,6 @@ func makeGroups(groupRoles []*tables.GroupRole) []*grpb.Group {
 			Name:                   g.Name,
 			OwnedDomain:            g.OwnedDomain,
 			GithubLinked:           githubToken != "",
-			GithubToken:            githubToken,
 			UrlIdentifier:          urlIdentifier,
 			SharingEnabled:         g.SharingEnabled,
 			UseGroupOwnedExecutors: g.UseGroupOwnedExecutors != nil && *g.UseGroupOwnedExecutors,
@@ -179,6 +178,7 @@ func (s *BuildBuddyServer) GetUser(ctx context.Context, req *uspb.GetUserRequest
 		UserGroup:       makeGroups(tu.Groups),
 		SelectedGroupId: selectedGroupID,
 		AllowedRpc:      allowedRPCs,
+		GithubToken: 	 tu.GithubToken,
 	}, nil
 }
 

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -178,7 +178,7 @@ func (s *BuildBuddyServer) GetUser(ctx context.Context, req *uspb.GetUserRequest
 		UserGroup:       makeGroups(tu.Groups),
 		SelectedGroupId: selectedGroupID,
 		AllowedRpc:      allowedRPCs,
-		GithubToken: 	 tu.GithubToken,
+		GithubToken:     tu.GithubToken,
 	}, nil
 }
 

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -220,6 +220,7 @@ type User struct {
 	Email     string
 	ImageURL  string
 
+	// User-specific Github token (if linked).
 	GithubToken string
 
 	// Group roles are used to determine read/write permissions

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -220,6 +220,8 @@ type User struct {
 	Email     string
 	ImageURL  string
 
+	GithubToken string
+
 	// Group roles are used to determine read/write permissions
 	// for everything.
 	Groups []*GroupRole `gorm:"-"`


### PR DESCRIPTION
This allows the user to link a user-specific Github token for use in the Code UI instead of using the org-wide one.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
