### PR TITLE
Upgrade Grafana to v8.3

### DIFF
--- a/tools/metrics/docker-compose.grafana.yml
+++ b/tools/metrics/docker-compose.grafana.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   grafana:
-    image: grafana/grafana:7.3.5
+    image: grafana/grafana:8.3.2
     environment:
       - GF_SERVER_HTTP_PORT=4500
       - GF_AUTH_ANONYMOUS_ENABLED=true
@@ -14,4 +14,3 @@ services:
       - "4500:4500"
     extra_hosts:
       - "host.docker.internal:host-gateway"
-

--- a/tools/metrics/grafana/provisioning/deploy/datasources/datasources.yml
+++ b/tools/metrics/grafana/provisioning/deploy/datasources/datasources.yml
@@ -2,10 +2,10 @@ apiVersion: 1
 
 datasources:
   - name: Prometheus
-  - type: prometheus
-  - access: proxy
-  - uid: prom
-  - isDefault: true
-  - url: http://prometheus-global-server.monitor-%{ENV}
-  - version: 1
-  - editable: false
+    type: prometheus
+    access: proxy
+    uid: prom
+    isDefault: true
+    url: http://prometheus-global-server.monitor-%{ENV}
+    version: 1
+    editable: false

--- a/tools/metrics/grafana/provisioning/local/datasources/datasources.yml
+++ b/tools/metrics/grafana/provisioning/local/datasources/datasources.yml
@@ -2,10 +2,10 @@ apiVersion: 1
 
 datasources:
   - name: Prometheus
-  - type: prometheus
-  - access: proxy
-  - uid: prom
-  - isDefault: true
-  - url: http://host.docker.internal:9100
-  - version: 1
-  - editable: false
+    type: prometheus
+    access: proxy
+    uid: prom
+    isDefault: true
+    url: http://host.docker.internal:9100
+    version: 1
+    editable: false

--- a/tools/metrics/run.sh
+++ b/tools/metrics/run.sh
@@ -12,7 +12,7 @@ START_BRANCH=$(git branch --show-current)
 : ${GRAFANA_ADMIN_PASSWORD:="admin"}
 : ${GRAFANA_DASHBOARD_ID:=1rsE5yoGz}
 GRAFANA_STARTUP_URL="http://localhost:$GRAFANA_PORT/d/$GRAFANA_DASHBOARD_ID?orgId=1&refresh=5s"
-GRAFANA_DASHBOARD_URL="http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/dashboards/db/buildbuddy-metrics"
+GRAFANA_DASHBOARD_URL="http://admin:$GRAFANA_ADMIN_PASSWORD@localhost:$GRAFANA_PORT/api/dashboards/uid/$GRAFANA_DASHBOARD_ID"
 GRAFANA_DASHBOARD_FILE_PATH="./grafana/dashboards/buildbuddy.json"
 
 : ${KUBE_CONTEXT:=""}


### PR DESCRIPTION
This will allow us to switch our charts over to the new "Time series" charts in Grafana which are based on the [uPlot](https://github.com/leeoniya/uPlot) libary, and are significantly more performant when viewing more than a few minutes of data. From my experience trying it out against dev, the new charts load much more quickly when a time range of 3+ hours is selected, and moving the mouse around the charts is a much smoother experience.

The high-performance charts are available starting from v7.4, but I found v7.4 to have a few small but very annoying bugs (the graph tooltip would rapidly flicker in some cases). v8.3 includes fixes for those bugs.

Confirmed that v8.3 is able to read our existing dashboard JSON, but the next time we make dashboard changes, it may export some JSON which is not compatible with v7.x -- so after this PR is merged, I'll immediately update our Grafana deployments to v8.x, in order to avoid running into scenarios where we're trying to consume a v8.x chart from a v7.x deployment.

Had to do a few misc fixes:
* The `/dashboards/db/{:name}` API endpoint (which allows getting a dashboard JSON config by dashboard name converted to slug) was removed, so this PR updates the `run.sh` script to no longer depend on that endpoint.
* Fixed incorrect YAML configuration due to copying and pasting from a bad example config. v7.3 could handle the bad config but v7.4+ reports it as an error. See https://github.com/grafana/grafana/issues/30999

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
