### PR TITLE
Set ActionResultCache in execution proto

### DIFF
--- a/enterprise/server/execution_service/BUILD
+++ b/enterprise/server/execution_service/BUILD
@@ -17,5 +17,7 @@ go_library(
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@go_googleapis//google/rpc:status_go_proto",
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_protobuf//proto",
     ],
 )

--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -12,13 +12,13 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/query_builder"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/proto"
 
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	timestamppb "github.com/golang/protobuf/ptypes/timestamp"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/protobuf/proto"
 )
 
 type ExecutionService struct {

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -341,6 +341,9 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, task *repb.E
 	actionResult.ExecutionMetadata = md
 
 	if !task.GetAction().GetDoNotCache() {
+		// If the action failed, upload information about the error via a failed ActionResult under
+		// an invocation-specific digest, which will not ever be seen by bazel but may be viewed
+		// via the Buildbuddy UI.
 		if cmdResult.Error != nil || cmdResult.ExitCode != 0 {
 			resultDigest, err := digest.AddInvocationIDToDigest(req.GetActionDigest(), task.GetInvocationId())
 			if err != nil {

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -115,6 +115,19 @@ func Compute(in io.Reader) (*repb.Digest, error) {
 	}, nil
 }
 
+func AddInvocationIDToDigest(digest *repb.Digest, invocationID string) (*repb.Digest, error) {
+	if digest == nil {
+		return nil, status.FailedPreconditionError("nil digest")
+	}
+	h := sha256.New()
+	h.Write([]byte(digest.Hash))
+	h.Write([]byte(invocationID))
+	return &repb.Digest{
+		Hash:      fmt.Sprintf("%x", h.Sum(nil)),
+		SizeBytes: digest.SizeBytes,
+	}, nil
+}
+
 func DownloadResourceName(d *repb.Digest, instanceName string) string {
 	// Haven't found docs on what a valid instance name looks like. But generally
 	// seems like a string, possibly separated by "/".

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -115,6 +115,8 @@ func Compute(in io.Reader) (*repb.Digest, error) {
 	}, nil
 }
 
+// AddInvocationIDToDigest combines the hash of the input digest and input invocationID and re-hash.
+// This is only to be used for failed action results.
 func AddInvocationIDToDigest(digest *repb.Digest, invocationID string) (*repb.Digest, error) {
 	if digest == nil {
 		return nil, status.FailedPreconditionError("nil digest")


### PR DESCRIPTION
1. When remote execution fails, compute action result digest based on
   the original action digest and the invocation id. When if succeeds,
   action result digest is the same as action digest. Upload the action
   result digest
2. When we convert Execution row from db to proto, set action result
   cache using the same logic as above.
