### PR TITLE
Make remote_Execution_test pass on darwin arm64

### DIFF
--- a/enterprise/server/test/integration/remote_execution/rbetest/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbetest/BUILD
@@ -47,6 +47,7 @@ go_library(
         "//server/util/log",
         "//server/util/prefix",
         "//server/util/role",
+        "//server/xcode",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_uuid//:uuid",
         "@com_github_stretchr_testify//assert",

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -581,7 +581,7 @@ func (r *Env) addExecutor(options *ExecutorOptions) *Executor {
 	env.SetAuthenticator(r.newTestAuthenticator())
 	xl, err := xcode.NewXcodeLocator()
 	if err != nil {
-		assert.FailNowf(r.t, "Failed to set XCodeLocator: %s", err.Error())
+		assert.FailNowf(r.t, "Failed to set XcodeLocator: %s", err.Error())
 	}
 	env.SetXcodeLocator(xl)
 

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -49,6 +50,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/role"
+	"github.com/buildbuddy-io/buildbuddy/server/xcode"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -577,6 +579,11 @@ func (r *Env) addExecutor(options *ExecutorOptions) *Executor {
 	env.SetRemoteExecutionClient(repb.NewExecutionClient(clientConn))
 	env.SetSchedulerClient(scpb.NewSchedulerClient(clientConn))
 	env.SetAuthenticator(r.newTestAuthenticator())
+	xl, err := xcode.NewXcodeLocator()
+	if err != nil {
+		assert.FailNowf(r.t, "Failed to set XCodeLocator: %s", err.Error())
+	}
+	env.SetXCodeLocator(xl)
 
 	bundleFS, err := bundle.Get()
 	require.NoError(r.t, err)
@@ -965,6 +972,8 @@ func minimalCommand(args ...string) *repb.Command {
 		Platform: &repb.Platform{
 			Properties: []*repb.Platform_Property{
 				{Name: "container-image", Value: "none"},
+				{Name: "OSFamily", Value: runtime.GOOS},
+				{Name: "Arch", Value: runtime.GOARCH},
 			},
 		},
 	}

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -583,7 +583,7 @@ func (r *Env) addExecutor(options *ExecutorOptions) *Executor {
 	if err != nil {
 		assert.FailNowf(r.t, "Failed to set XCodeLocator: %s", err.Error())
 	}
-	env.SetXCodeLocator(xl)
+	env.SetXcodeLocator(xl)
 
 	bundleFS, err := bundle.Get()
 	require.NoError(r.t, err)

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -56,6 +56,7 @@ executor:
   app_target: "grpc://localhost:1985"
   local_cache_directory: "{{.TestRootDir}}/remote_execution/cache"
   local_cache_size_bytes: 1000000000  # 1GB
+  default_xcode_version: "13.1"
 auth:
   oauth_providers:
     - issuer_url: 'https://auth.test.buildbuddy.io'


### PR DESCRIPTION
1. Pass the runtime os and arch to Command.Platform.Properties
2. Set XcodeLocator in test env
3. set default_xcode_version in executor test config
