### PR TITLE
Add tracing around s3 and gcs cache network activity

### DIFF
--- a/enterprise/server/backends/gcs_cache/BUILD
+++ b/enterprise/server/backends/gcs_cache/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//server/util/cache_metrics",
         "//server/util/prefix",
         "//server/util/status",
+        "//server/util/tracing",
         "@com_google_cloud_go_storage//:storage",
         "@org_golang_google_api//googleapi:go_default_library",
         "@org_golang_google_api//option:go_default_library",

--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -81,6 +81,7 @@ func (g *GCSCache) createBucketIfNotExists(ctx context.Context, bucketName strin
 
 func (g *GCSCache) setBucketTTL(ctx context.Context, bucketName string, ageInDays int64) error {
 	traceCtx, spn := tracing.StartSpan(ctx)
+	spn.SetName("Attrs for GCSCache SetBucketTTL")
 	attrs, err := g.gcsClient.Bucket(bucketName).Attrs(traceCtx)
 	spn.End()
 	if err != nil {
@@ -105,6 +106,7 @@ func (g *GCSCache) setBucketTTL(ctx context.Context, bucketName string, ageInDay
 		},
 	}
 	traceCtx, spn = tracing.StartSpan(ctx)
+	spn.SetName("Update for GCSCache SetBucketTTL")
 	defer spn.End()
 	// Update the bucket TTL, regardless of whatever value is set.
 	_, err = g.gcsClient.Bucket(bucketName).Update(traceCtx, storage.BucketAttrsToUpdate{Lifecycle: &lc})

--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/cache_metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
@@ -60,10 +61,18 @@ func NewGCSCache(bucketName, projectID string, ageInDays int64, opts ...option.C
 	return g, nil
 }
 
+func (g *GCSCache) bucketExists(ctx context.Context, bucketName string) (bool, error) {
+	_, spn := tracing.StartSpan(ctx)
+	defer spn.End()
+	_, err := g.gcsClient.Bucket(bucketName).Attrs(ctx)
+	return err == nil, err
+}
 func (g *GCSCache) createBucketIfNotExists(ctx context.Context, bucketName string) error {
-	if _, err := g.gcsClient.Bucket(bucketName).Attrs(ctx); err != nil {
+	if exists, _ := g.bucketExists(ctx, bucketName); !exists {
 		log.Printf("Creating storage bucket: %s", bucketName)
 		g.bucketHandle = g.gcsClient.Bucket(bucketName)
+		_, spn := tracing.StartSpan(ctx)
+		defer spn.End()
 		return g.bucketHandle.Create(ctx, g.projectID, nil)
 	}
 	g.bucketHandle = g.gcsClient.Bucket(bucketName)
@@ -71,7 +80,9 @@ func (g *GCSCache) createBucketIfNotExists(ctx context.Context, bucketName strin
 }
 
 func (g *GCSCache) setBucketTTL(ctx context.Context, bucketName string, ageInDays int64) error {
+	_, spn := tracing.StartSpan(ctx)
 	attrs, err := g.gcsClient.Bucket(bucketName).Attrs(ctx)
+	spn.End()
 	if err != nil {
 		return err
 	}
@@ -93,6 +104,8 @@ func (g *GCSCache) setBucketTTL(ctx context.Context, bucketName string, ageInDay
 			},
 		},
 	}
+	_, spn = tracing.StartSpan(ctx)
+	defer spn.End()
 	// Update the bucket TTL, regardless of whatever value is set.
 	_, err = g.gcsClient.Bucket(bucketName).Update(ctx, storage.BucketAttrsToUpdate{Lifecycle: &lc})
 	return err
@@ -139,7 +152,9 @@ func (g *GCSCache) Get(ctx context.Context, d *repb.Digest) ([]byte, error) {
 		return nil, err
 	}
 	timer := cache_metrics.NewCacheTimer(cacheLabels)
+	_, spn := tracing.StartSpan(ctx)
 	b, err := ioutil.ReadAll(reader)
+	spn.End()
 	timer.ObserveGet(len(b), err)
 	// Note, if we decide to retry reads in the future, be sure to
 	// add a new metric for retry count.
@@ -207,7 +222,10 @@ func (g *GCSCache) Set(ctx context.Context, d *repb.Digest, data []byte) error {
 		writer := obj.If(storage.Conditions{DoesNotExist: true}).NewWriter(ctx)
 		setChunkSize(d, writer)
 		timer := cache_metrics.NewCacheTimer(cacheLabels)
-		if _, err = writer.Write(data); err == nil {
+		_, spn := tracing.StartSpan(ctx)
+		_, err = writer.Write(data)
+		spn.End()
+		if err == nil {
 			err = swallowGCSAlreadyExistsError(writer.Close())
 		}
 		timer.ObserveSet(len(data), err)
@@ -245,7 +263,9 @@ func (g *GCSCache) Delete(ctx context.Context, d *repb.Digest) error {
 		return err
 	}
 	timer := cache_metrics.NewCacheTimer(cacheLabels)
+	_, spn := tracing.StartSpan(ctx)
 	err = g.bucketHandle.Object(k).Delete(ctx)
+	spn.End()
 	timer.ObserveDelete(err)
 	// Note, if we decide to retry deletions in the future, be sure to
 	// add a new metric for retry count.
@@ -257,7 +277,9 @@ func (g *GCSCache) bumpTTLIfStale(ctx context.Context, key string, t time.Time) 
 		return true
 	}
 	obj := g.bucketHandle.Object(key)
+	_, spn := tracing.StartSpan(ctx)
 	_, err := obj.CopierFrom(obj).Run(ctx)
+	spn.End()
 	if err == storage.ErrObjectNotExist {
 		return false
 	}
@@ -276,7 +298,9 @@ func (g *GCSCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
 	numAttempts := 0
 	for {
 		timer := cache_metrics.NewCacheTimer(cacheLabels)
+		_, spn := tracing.StartSpan(ctx)
 		attrs, err := g.bucketHandle.Object(k).Attrs(ctx)
+		spn.End()
 		timer.ObserveContains(err)
 		numAttempts++
 		finalErr = err
@@ -329,7 +353,9 @@ func (g *GCSCache) Reader(ctx context.Context, d *repb.Digest, offset int64) (io
 	if err != nil {
 		return nil, err
 	}
+	_, spn := tracing.StartSpan(ctx)
 	reader, err := g.bucketHandle.Object(k).NewReader(ctx)
+	spn.End()
 	if err != nil {
 		if err == storage.ErrObjectNotExist {
 			return nil, status.NotFoundErrorf("Digest '%s/%d' not found in cache", d.GetHash(), d.GetSizeBytes())
@@ -337,6 +363,7 @@ func (g *GCSCache) Reader(ctx context.Context, d *repb.Digest, offset int64) (io
 		return nil, err
 	}
 	timer := cache_metrics.NewCacheTimer(cacheLabels)
+	// rely on google's internal tracing to capture read calls from the returned reader
 	return io.NopCloser(timer.NewInstrumentedReader(reader, d.GetSizeBytes())), nil
 }
 

--- a/enterprise/server/backends/s3_cache/BUILD
+++ b/enterprise/server/backends/s3_cache/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//server/util/cache_metrics",
         "//server/util/prefix",
         "//server/util/status",
+        "//server/util/tracing",
         "@com_github_aws_aws_sdk_go//aws",
         "@com_github_aws_aws_sdk_go//aws/awserr",
         "@com_github_aws_aws_sdk_go//aws/credentials",

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -109,8 +109,8 @@ func NewS3Cache(awsConfig *config.S3CacheConfig) (*S3Cache, error) {
 }
 
 func (s3c *S3Cache) bucketExists(ctx context.Context, bucketName string) (bool, error) {
-	_, spn := tracing.StartSpan(ctx)
-	_, err := s3c.s3.HeadBucketWithContext(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucketName)})
+	traceCtx, spn := tracing.StartSpan(ctx)
+	_, err := s3c.s3.HeadBucketWithContext(traceCtx, &s3.HeadBucketInput{Bucket: aws.String(bucketName)})
 	spn.End()
 	if err == nil {
 		return true, nil
@@ -130,12 +130,12 @@ func (s3c *S3Cache) createBucketIfNotExists(ctx context.Context, bucketName stri
 		return err
 	} else if !exists {
 		log.Printf("Creating storage bucket: %s", bucketName)
-		_, spn := tracing.StartSpan(ctx)
+		traceCtx, spn := tracing.StartSpan(ctx)
 		defer spn.End()
-		if _, err := s3c.s3.CreateBucketWithContext(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucketName)}); err != nil {
+		if _, err := s3c.s3.CreateBucketWithContext(traceCtx, &s3.CreateBucketInput{Bucket: aws.String(bucketName)}); err != nil {
 			return err
 		}
-		ctx, cancel := context.WithTimeout(ctx, bucketWaitTimeout)
+		ctx, cancel := context.WithTimeout(traceCtx, bucketWaitTimeout)
 		defer cancel()
 		return s3c.s3.WaitUntilBucketExistsWithContext(ctx, &s3.HeadBucketInput{
 			Bucket: aws.String(bucketName),
@@ -145,8 +145,8 @@ func (s3c *S3Cache) createBucketIfNotExists(ctx context.Context, bucketName stri
 }
 
 func (s3c *S3Cache) setBucketTTL(ctx context.Context, bucketName string, ageInDays int64) error {
-	_, spn := tracing.StartSpan(ctx)
-	attrs, err := s3c.s3.GetBucketLifecycleConfigurationWithContext(ctx, &s3.GetBucketLifecycleConfigurationInput{
+	traceCtx, spn := tracing.StartSpan(ctx)
+	attrs, err := s3c.s3.GetBucketLifecycleConfigurationWithContext(traceCtx, &s3.GetBucketLifecycleConfigurationInput{
 		Bucket: aws.String(bucketName),
 	})
 	spn.End()
@@ -169,9 +169,9 @@ func (s3c *S3Cache) setBucketTTL(ctx context.Context, bucketName string, ageInDa
 			return nil
 		}
 	}
-	_, spn = tracing.StartSpan(ctx)
+	traceCtx, spn = tracing.StartSpan(ctx)
 	defer spn.End()
-	_, err = s3c.s3.PutBucketLifecycleConfigurationWithContext(ctx, &s3.PutBucketLifecycleConfigurationInput{
+	_, err = s3c.s3.PutBucketLifecycleConfigurationWithContext(traceCtx, &s3.PutBucketLifecycleConfigurationInput{
 		Bucket: aws.String(bucketName),
 		LifecycleConfiguration: &s3.BucketLifecycleConfiguration{
 			Rules: []*s3.LifecycleRule{
@@ -244,8 +244,8 @@ func (s3c *S3Cache) Get(ctx context.Context, d *repb.Digest) ([]byte, error) {
 
 func (s3c *S3Cache) get(ctx context.Context, d *repb.Digest, key string) ([]byte, error) {
 	buff := &aws.WriteAtBuffer{}
-	_, spn := tracing.StartSpan(ctx)
-	_, err := s3c.downloader.DownloadWithContext(ctx, buff, &s3.GetObjectInput{
+	traceCtx, spn := tracing.StartSpan(ctx)
+	_, err := s3c.downloader.DownloadWithContext(traceCtx, buff, &s3.GetObjectInput{
 		Bucket: s3c.bucket,
 		Key:    aws.String(key),
 	})
@@ -294,8 +294,8 @@ func (s3c *S3Cache) Set(ctx context.Context, d *repb.Digest, data []byte) error 
 		Body:   bytes.NewReader(data),
 	}
 	timer := cache_metrics.NewCacheTimer(cacheLabels)
-	_, spn := tracing.StartSpan(ctx)
-	_, err = s3c.uploader.UploadWithContext(ctx, uploadParams)
+	traceCtx, spn := tracing.StartSpan(ctx)
+	_, err = s3c.uploader.UploadWithContext(traceCtx, uploadParams)
 	spn.End()
 	timer.ObserveSet(len(data), err)
 	return err
@@ -337,13 +337,13 @@ func (s3c *S3Cache) delete(ctx context.Context, key string) error {
 		Key:    aws.String(key),
 	}
 
-	_, spn := tracing.StartSpan(ctx)
+	traceCtx, spn := tracing.StartSpan(ctx)
 	defer spn.End()
-	if _, err := s3c.s3.DeleteObjectWithContext(ctx, deleteParams); err != nil {
+	if _, err := s3c.s3.DeleteObjectWithContext(traceCtx, deleteParams); err != nil {
 		return err
 	}
 
-	return s3c.s3.WaitUntilObjectNotExistsWithContext(ctx, &s3.HeadObjectInput{
+	return s3c.s3.WaitUntilObjectNotExistsWithContext(traceCtx, &s3.HeadObjectInput{
 		Bucket: s3c.bucket,
 		Key:    aws.String(key),
 	})
@@ -388,16 +388,16 @@ func (s3c *S3Cache) contains(ctx context.Context, key string) (bool, error) {
 		Key:    aws.String(key),
 	}
 
-	_, spn := tracing.StartSpan(ctx)
+	traceCtx, spn := tracing.StartSpan(ctx)
 	defer spn.End()
-	head, err := s3c.s3.HeadObjectWithContext(ctx, params)
+	head, err := s3c.s3.HeadObjectWithContext(traceCtx, params)
 	if err != nil {
 		if isNotFoundErr(err) {
 			return false, nil
 		}
 		return false, err
 	}
-	return s3c.bumpTTLIfStale(ctx, key, *head.LastModified), nil
+	return s3c.bumpTTLIfStale(traceCtx, key, *head.LastModified), nil
 }
 
 func (s3c *S3Cache) FindMissing(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error) {
@@ -435,10 +435,10 @@ func (s3c *S3Cache) Reader(ctx context.Context, d *repb.Digest, offset int64) (i
 	if err != nil {
 		return nil, err
 	}
-	_, spn := tracing.StartSpan(ctx)
+	traceCtx, spn := tracing.StartSpan(ctx)
 	// TODO(bduffany): track this as a contains() request, or find a way to
 	// track it as part of the read
-	result, err := s3c.s3.GetObjectWithContext(ctx, &s3.GetObjectInput{
+	result, err := s3c.s3.GetObjectWithContext(traceCtx, &s3.GetObjectInput{
 		Bucket: s3c.bucket,
 		Key:    aws.String(k),
 		Range:  aws.String(fmt.Sprintf("%d-", offset)),

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -25,6 +25,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/cache_metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"golang.org/x/sync/errgroup"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -107,17 +108,30 @@ func NewS3Cache(awsConfig *config.S3CacheConfig) (*S3Cache, error) {
 	return s3c, nil
 }
 
+func (s3c *S3Cache) bucketExists(ctx context.Context, bucketName string) (bool, error) {
+	_, spn := tracing.StartSpan(ctx)
+	_, err := s3c.s3.HeadBucketWithContext(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucketName)})
+	spn.End()
+	if err == nil {
+		return true, nil
+	}
+	aerr := err.(awserr.Error)
+	// AWS returns codes as strings
+	// https://github.com/aws/aws-sdk-go/blob/master/service/s3/s3manager/bucket_region_test.go#L70
+	if aerr.Code() != "NotFound" {
+		return false, err
+	}
+	return false, nil
+}
+
 func (s3c *S3Cache) createBucketIfNotExists(ctx context.Context, bucketName string) error {
 	// HeadBucket call will return 404 or 403
-	if _, err := s3c.s3.HeadBucketWithContext(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucketName)}); err != nil {
-		awsErr := err.(awserr.Error)
-		// AWS returns codes as strings
-		// https://github.com/aws/aws-sdk-go/blob/master/service/s3/s3manager/bucket_region_test.go#L70
-		if awsErr.Code() != "NotFound" {
-			return err
-		}
-
+	if exists, err := s3c.bucketExists(ctx, bucketName); err != nil {
+		return err
+	} else if !exists {
 		log.Printf("Creating storage bucket: %s", bucketName)
+		_, spn := tracing.StartSpan(ctx)
+		defer spn.End()
 		if _, err := s3c.s3.CreateBucketWithContext(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucketName)}); err != nil {
 			return err
 		}
@@ -131,9 +145,11 @@ func (s3c *S3Cache) createBucketIfNotExists(ctx context.Context, bucketName stri
 }
 
 func (s3c *S3Cache) setBucketTTL(ctx context.Context, bucketName string, ageInDays int64) error {
+	_, spn := tracing.StartSpan(ctx)
 	attrs, err := s3c.s3.GetBucketLifecycleConfigurationWithContext(ctx, &s3.GetBucketLifecycleConfigurationInput{
 		Bucket: aws.String(bucketName),
 	})
+	spn.End()
 	if err != nil {
 		awsErr, ok := err.(awserr.Error)
 		if ok && awsErr.Code() != "NoSuchLifecycleConfiguration" {
@@ -153,6 +169,8 @@ func (s3c *S3Cache) setBucketTTL(ctx context.Context, bucketName string, ageInDa
 			return nil
 		}
 	}
+	_, spn = tracing.StartSpan(ctx)
+	defer spn.End()
 	_, err = s3c.s3.PutBucketLifecycleConfigurationWithContext(ctx, &s3.PutBucketLifecycleConfigurationInput{
 		Bucket: aws.String(bucketName),
 		LifecycleConfiguration: &s3.BucketLifecycleConfiguration{
@@ -226,10 +244,12 @@ func (s3c *S3Cache) Get(ctx context.Context, d *repb.Digest) ([]byte, error) {
 
 func (s3c *S3Cache) get(ctx context.Context, d *repb.Digest, key string) ([]byte, error) {
 	buff := &aws.WriteAtBuffer{}
+	_, spn := tracing.StartSpan(ctx)
 	_, err := s3c.downloader.DownloadWithContext(ctx, buff, &s3.GetObjectInput{
 		Bucket: s3c.bucket,
 		Key:    aws.String(key),
 	})
+	spn.End()
 	if isNotFoundErr(err) {
 		return nil, status.NotFoundErrorf("Digest '%s/%d' not found in cache", d.GetHash(), d.GetSizeBytes())
 	}
@@ -274,7 +294,9 @@ func (s3c *S3Cache) Set(ctx context.Context, d *repb.Digest, data []byte) error 
 		Body:   bytes.NewReader(data),
 	}
 	timer := cache_metrics.NewCacheTimer(cacheLabels)
+	_, spn := tracing.StartSpan(ctx)
 	_, err = s3c.uploader.UploadWithContext(ctx, uploadParams)
+	spn.End()
 	timer.ObserveSet(len(data), err)
 	return err
 }
@@ -315,6 +337,8 @@ func (s3c *S3Cache) delete(ctx context.Context, key string) error {
 		Key:    aws.String(key),
 	}
 
+	_, spn := tracing.StartSpan(ctx)
+	defer spn.End()
 	if _, err := s3c.s3.DeleteObjectWithContext(ctx, deleteParams); err != nil {
 		return err
 	}
@@ -335,7 +359,9 @@ func (s3c *S3Cache) bumpTTLIfStale(ctx context.Context, key string, t time.Time)
 		Key:               aws.String(key),
 		MetadataDirective: aws.String(s3.MetadataDirectiveReplace),
 	}
+	_, spn := tracing.StartSpan(ctx)
 	_, err := s3c.s3.CopyObject(input)
+	spn.End()
 	if isNotFoundErr(err) {
 		return false
 	}
@@ -362,6 +388,8 @@ func (s3c *S3Cache) contains(ctx context.Context, key string) (bool, error) {
 		Key:    aws.String(key),
 	}
 
+	_, spn := tracing.StartSpan(ctx)
+	defer spn.End()
 	head, err := s3c.s3.HeadObjectWithContext(ctx, params)
 	if err != nil {
 		if isNotFoundErr(err) {
@@ -407,6 +435,7 @@ func (s3c *S3Cache) Reader(ctx context.Context, d *repb.Digest, offset int64) (i
 	if err != nil {
 		return nil, err
 	}
+	_, spn := tracing.StartSpan(ctx)
 	// TODO(bduffany): track this as a contains() request, or find a way to
 	// track it as part of the read
 	result, err := s3c.s3.GetObjectWithContext(ctx, &s3.GetObjectInput{
@@ -414,6 +443,7 @@ func (s3c *S3Cache) Reader(ctx context.Context, d *repb.Digest, offset int64) (i
 		Key:    aws.String(k),
 		Range:  aws.String(fmt.Sprintf("%d-", offset)),
 	})
+	spn.End()
 	if isNotFoundErr(err) {
 		return nil, status.NotFoundErrorf("Digest '%s/%d' not found in cache", d.GetHash(), d.GetSizeBytes())
 	}
@@ -423,9 +453,17 @@ func (s3c *S3Cache) Reader(ctx context.Context, d *repb.Digest, offset int64) (i
 
 type waitForUploadWriteCloser struct {
 	io.WriteCloser
+	ctx           context.Context
 	finishedWrite chan struct{}
 	timer         *cache_metrics.CacheTimer
 	size          int64
+}
+
+func (w *waitForUploadWriteCloser) Write(p []byte) (int, error) {
+	_, spn := tracing.StartSpan(w.ctx)
+	defer spn.End()
+	return w.WriteCloser.Write(p)
+
 }
 
 func (w *waitForUploadWriteCloser) Close() error {
@@ -442,6 +480,7 @@ func (s3c *S3Cache) Writer(ctx context.Context, d *repb.Digest) (io.WriteCloser,
 	if err != nil {
 		return nil, err
 	}
+	// TODO(tempoz): r is only closed in case of error
 	r, w := io.Pipe()
 	uploadParams := &s3manager.UploadInput{
 		Bucket: s3c.bucket,
@@ -451,6 +490,7 @@ func (s3c *S3Cache) Writer(ctx context.Context, d *repb.Digest) (io.WriteCloser,
 	timer := cache_metrics.NewCacheTimer(cacheLabels)
 	closer := &waitForUploadWriteCloser{
 		WriteCloser:   w,
+		ctx:           ctx,
 		finishedWrite: make(chan struct{}),
 		timer:         timer,
 		size:          d.GetSizeBytes(),

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -146,6 +146,7 @@ func (s3c *S3Cache) createBucketIfNotExists(ctx context.Context, bucketName stri
 
 func (s3c *S3Cache) setBucketTTL(ctx context.Context, bucketName string, ageInDays int64) error {
 	traceCtx, spn := tracing.StartSpan(ctx)
+	spn.SetName("GetBucketLifecycleConfigurationWithContext for S3Cache SetBucketTTL")
 	attrs, err := s3c.s3.GetBucketLifecycleConfigurationWithContext(traceCtx, &s3.GetBucketLifecycleConfigurationInput{
 		Bucket: aws.String(bucketName),
 	})
@@ -170,6 +171,7 @@ func (s3c *S3Cache) setBucketTTL(ctx context.Context, bucketName string, ageInDa
 		}
 	}
 	traceCtx, spn = tracing.StartSpan(ctx)
+	spn.SetName("PutBucketLifecycleConfigurationWithContext for S3Cache SetBucketTTL")
 	defer spn.End()
 	_, err = s3c.s3.PutBucketLifecycleConfigurationWithContext(traceCtx, &s3.PutBucketLifecycleConfigurationInput{
 		Bucket: aws.String(bucketName),


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Adds tracing for GCS and S3 caches. For reading from GCS with a reader, we depend on the tracing code
already present in google's GCS libs. An alternative strategy (that I am happy to switch to if it is 
desired) would be to wrap the returned reader with a bundled context so we can start a span on each
call to Read.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
