### PR TITLE
Add utils for downloading CAS/AC artifacts via the UI

### DIFF
--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -40,6 +40,8 @@ class RpcService {
       filename,
       bytestream_url: bytestreamURL,
       invocation_id: invocationId,
+      group_id: this.requestContext.groupId || "",
+      impersonating_group_id: this.requestContext.impersonatingGroupId || "",
     })}`;
   }
 
@@ -52,13 +54,8 @@ class RpcService {
     invocationId: string,
     responseType?: "arraybuffer" | "json" | "text" | undefined
   ) {
-    return this.fetchFile(
-      `/file/download?${new URLSearchParams({
-        bytestream_url: bytestreamURL,
-        invocation_id: invocationId,
-      })}`,
-      responseType || ""
-    );
+    const url = this.getBytestreamFileUrl(/*filename=*/ "", bytestreamURL, invocationId);
+    return this.fetchFile(url, responseType || "");
   }
 
   fetchFile(fileURL: string, responseType: "arraybuffer" | "json" | "text" | "") {

--- a/app/terminal/BUILD
+++ b/app/terminal/BUILD
@@ -9,6 +9,7 @@ ts_library(
         "//app/components/spinner",
         "//app/errors",
         "//app/service",
+        "//app/util:download",
         "//proto:eventlog_ts_proto",
         "@npm//@types/react",
         "@npm//@types/react-lazylog",

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { LazyLog } from "react-lazylog";
 import errorService from "../errors/error_service";
 import Spinner from "../components/spinner/spinner";
+import { downloadString } from "../util/download";
 
 export interface TerminalProps {
   value?: string;
@@ -82,14 +83,8 @@ export default class TerminalComponent extends React.Component<TerminalProps, Te
 
   handleDownloadClicked() {
     const serveLog = (log: string) => {
-      const element = document.createElement("a");
       const unstyledLogs = log.replace(ANSI_STYLES_REGEX, "");
-      element.setAttribute("href", "data:text/plain;charset=utf-8," + encodeURIComponent(unstyledLogs));
-      element.setAttribute("download", "build_logs.txt");
-      element.style.display = "none";
-      document.body.appendChild(element);
-      element.click();
-      element.remove();
+      downloadString(unstyledLogs, "build_logs.txt");
     };
     if (this.props.fullLogsFetcher) {
       this.setState({ isLoadingFullLog: true });

--- a/app/util/BUILD
+++ b/app/util/BUILD
@@ -46,6 +46,17 @@ jasmine_node_test(
 )
 
 ts_library(
+    name = "cache",
+    srcs = ["cache.ts"],
+    deps = [
+        ":download",
+        "//app/capabilities",
+        "//app/service",
+        "//proto:remote_execution_ts_proto",
+    ],
+)
+
+ts_library(
     name = "clipboard",
     srcs = ["clipboard.ts"],
 )
@@ -53,6 +64,14 @@ ts_library(
 ts_library(
     name = "dom",
     srcs = ["dom.ts"],
+    deps = [
+        "@npm//tslib",
+    ],
+)
+
+ts_library(
+    name = "download",
+    srcs = ["download.ts"],
     deps = [
         "@npm//tslib",
     ],

--- a/app/util/cache.ts
+++ b/app/util/cache.ts
@@ -1,0 +1,49 @@
+import rpcService from "../service/rpc_service";
+import capabilities from "../capabilities/capabilities";
+import { build } from "../../proto/remote_execution_ts_proto";
+import { downloadString } from "./download";
+
+/**
+ * Downloads an ActionResult from the Action Cache by Action digest and optional
+ * instance name, in JSON proto format.
+ */
+export function downloadActionResultJSON(hash: string, sizeBytes: number, instanceName = "") {
+  const prefix = cachePrefix(capabilities.config.cacheApiUrl, instanceName);
+  const actionResultUrl = `actioncache://${prefix}/blobs/ac/${hash}/${sizeBytes}`;
+  rpcService
+    .fetchBytestreamFile(actionResultUrl, /*invocationId=*/ "", "arraybuffer")
+    .then((buffer: any) => {
+      const actionResult = build.bazel.remote.execution.v2.ActionResult.decode(new Uint8Array(buffer));
+      const formattedResult = JSON.stringify(actionResult, null, 2);
+      downloadString(formattedResult, `ActionResult_${hash}_${sizeBytes}.json`, { mimeType: "application/json" });
+    })
+    .catch((e) => console.error("Failed to fetch action result:", e));
+}
+
+/**
+ * Downloads a blob from the Content Addressable Storage (CAS) by digest and
+ * optional instance name.
+ */
+export function downloadBlob(hash: string, sizeBytes: number, instanceName = "") {
+  const prefix = cachePrefix(capabilities.config.cacheApiUrl, instanceName);
+  const blobUrl = `bytestream://${prefix}/blobs/${hash}/${sizeBytes}`;
+  rpcService.downloadBytestreamFile(`Blob_${hash}_${sizeBytes}.bin`, blobUrl, /*invocationId=*/ "");
+}
+
+/**
+ * Returns the cache prefix suitable for bytestream:// or actioncache:// URLs.
+ */
+export function cachePrefix(address: string, instanceName: string) {
+  address = address.replace(/^grpcs?:\/\//, "");
+  if (!instanceName) return address;
+  return `${address}/${instanceName}`;
+}
+
+/**
+ * Makes the download utils available in the global scope so that they can
+ * invoked via devtools.
+ */
+export function registerConsoleUtils() {
+  (window as any)._downloadActionResultJSON = downloadActionResultJSON;
+  (window as any)._downloadBlob = downloadBlob;
+}

--- a/app/util/download.ts
+++ b/app/util/download.ts
@@ -1,0 +1,10 @@
+/** Downloads a string as a text file to the user's downloads directory. */
+export function downloadString(content: string, fileName: string, { mimeType = "text/plain" } = {}) {
+  const link = document.createElement("a");
+  link.style.display = "none";
+  link.setAttribute("href", `data:${mimeType};charset=utf-8,${encodeURIComponent(content)}`);
+  link.setAttribute("download", fileName);
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+}

--- a/enterprise/app/root/BUILD.bazel
+++ b/enterprise/app/root/BUILD.bazel
@@ -22,6 +22,7 @@ ts_library(
         "//app/preferences",
         "//app/router",
         "//app/service",
+        "//app/util:cache",
         "//enterprise/app/code",
         "//enterprise/app/executors",
         "//enterprise/app/history",

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -27,6 +27,7 @@ const CodeComponent = React.lazy(() => import("../code/code"));
 
 import ExecutorsComponent from "../executors/executors";
 import UserPreferences from "../../../app/preferences/preferences";
+import * as cache from "../../../app/util/cache";
 
 interface State {
   user: User;
@@ -51,6 +52,8 @@ capabilities.register("BuildBuddy Enterprise", true, [
   Path.tapPath,
   Path.codePath,
 ]);
+
+cache.registerConsoleUtils();
 
 export default class EnterpriseRootComponent extends React.Component {
   state: State = {

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -53,4 +53,7 @@ message FrontendConfig {
 
   // Whether Darwin (macOS) executors must be self-hosted.
   bool force_user_owned_darwin_executors = 17;
+
+  // The configured gRPC endpoint for the remote cache.
+  string cache_api_url = 18;
 }

--- a/server/http/filters/BUILD
+++ b/server/http/filters/BUILD
@@ -6,11 +6,13 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/http/filters",
     visibility = ["//visibility:public"],
     deps = [
+        "//proto:context_go_proto",
         "//server/environment",
         "//server/http/protolet",
         "//server/metrics",
         "//server/role_filter",
         "//server/util/log",
+        "//server/util/request_context",
         "//server/util/status",
         "//server/util/uuid",
         "@com_github_prometheus_client_golang//prometheus",

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -157,6 +157,7 @@ func serveIndexTemplate(env environment.Env, tpl *template.Template, version str
 		UsageEnabled:                  env.GetConfigurator().GetAppUsageEnabled(),
 		UserManagementEnabled:         env.GetConfigurator().GetAppUserManagementEnabled(),
 		ForceUserOwnedDarwinExecutors: forceUserOwnedDarwinExecutors,
+		CacheApiUrl:                   env.GetConfigurator().GetAppCacheAPIURL(),
 	}
 
 	configJSON := &bytes.Buffer{}


### PR DESCRIPTION
* Make the `invocation_id` param _optional_ in the `/file/download` endpoint, to avoid needing to know the invocation ID just to download a blob from CAS / AC.
  * Before, we would use the `invocation_id` to fetch an API key for the invocation owner. That API key then determines the group ID prefix for the cache.
  * But the group ID prefix comes from AuthenticatedUser, which doesn't care whether it comes from an API key or a JWT. Since Web requests are authenticated with a JWT, it should be possible to use only the JWT and avoid the need for the API key.
  * The only issue is that that we don't properly set `Claims.GroupID` for plain HTTP requests, because that field comes from `RequestContext.selected_group_id`, which is only populated for _protolet_ HTTP requests.
  * To work around this, we can pass the `RequestContext` via URL params, and set the `RequestContext` in the `ctx` via middleware. This way, both plain-HTTP and protolet requests will have the `RequestContext` available in the HTTP authentication path.
  * This also buys us proper impersonation support, since impersonation is based on `impersonating_group_id` in the request context. Specifically, it will allow us to know whether the authenticated user fetching the CAS blobs is an impersonator, to avoid incrementing usage counts when calling these debug endpoints.
* Add util functions for downloading objects from AC (as JSON) and CAS (as raw binary)
  * Expose these in global scope as `_downloadActionResultJSON` and `_downloadBlob` so they can be invoked via devtools. This is a temporary solution until we implement a full UI.

---

Usage:

* Open devtools console (F12)
* To download an action result: `_downloadActionResultJSON(hash: string, size: number, instanceName: string)`
* To download a blob from CAS: `_downloadBlob(hash: string, size: number, instanceName: string)`
* Instance name is optional and defaults to `""`
* Size is required, but you can pass `1` if you don't know it, and it should technically work. (I'm not sure if the server-side behavior will change in the future, but for now this will work).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
