### PR TITLE
Refactor SDKROOT calculation

### DIFF
--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -303,20 +303,15 @@ func ApplyOverrides(env environment.Env, executorProps *ExecutorProperties, plat
 			}
 		}
 
-		developerDir, err := env.GetXcodeLocator().DeveloperDirForVersion(xcodeVersion)
+		sdk := fmt.Sprintf("%s%s", appleSDKPlatform, appleSDKVersion)
+		developerDir, sdkRoot, err := env.GetXcodeLocator().PathsForVersionAndSDK(xcodeVersion, sdk)
 		if err != nil {
 			return err
 		}
 
-		sdkPath := fmt.Sprintf("Platforms/%s.platform/Developer/SDKs/%s%s.sdk", appleSDKPlatform, appleSDKPlatform, appleSDKVersion)
-		if !env.GetXcodeLocator().IsSDKPathPresentForVersion(sdkPath, xcodeVersion) {
-			sdkPath = fmt.Sprintf("Platforms/%s.platform/Developer/SDKs/%s.sdk", appleSDKPlatform, appleSDKPlatform)
-		}
-
-		sdkRoot := fmt.Sprintf("%s/%s", developerDir, sdkPath)
 		command.EnvironmentVariables = append(command.EnvironmentVariables, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: sdkRoot},
 			{Name: "DEVELOPER_DIR", Value: developerDir},
+			{Name: "SDKROOT", Value: sdkRoot},
 		}...)
 	}
 	return nil

--- a/enterprise/server/remote_execution/platform/platform_test.go
+++ b/enterprise/server/remote_execution/platform/platform_test.go
@@ -1,6 +1,7 @@
 package platform_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -189,31 +190,31 @@ func TestParse_ApplyOverrides(t *testing.T) {
 		platformProps       []*repb.Platform_Property
 		startingEnvVars     []*repb.Command_EnvironmentVariable
 		expectedEnvVars     []*repb.Command_EnvironmentVariable
+		errorExpected       bool
 		defaultXcodeVersion string
 	}{
 		// Default darwin platform
 		{[]*repb.Platform_Property{
 			{Name: "osfamily", Value: "darwin"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "11.1"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
+		}, []*repb.Command_EnvironmentVariable{
+			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"},
+			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 		},
-			[]*repb.Command_EnvironmentVariable{
-				{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"},
-				{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
-			},
+			false,
 			"12.2",
 		},
 		// Case insensitive darwin platform
 		{[]*repb.Platform_Property{
 			{Name: "OSFAMILY", Value: "dArWiN"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "11.1"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{
 			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 		},
+			false,
 			"12.2",
 		},
 		// Darwin with no overrides
@@ -223,32 +224,32 @@ func TestParse_ApplyOverrides(t *testing.T) {
 			{Name: "SDKROOT", Value: "/Applications/Xcode_12.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.2.app/Contents/Developer"},
 		},
+			false,
 			"12.2",
 		},
-		// Darwin with sdk platform
+		// Darwin with invalid sdk platform
 		{[]*repb.Platform_Property{
 			{Name: "OSFamily", Value: "Darwin"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "11.1"},
+			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "14.1"},
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
-		}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone.sdk"},
-			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
-		},
+		}, []*repb.Command_EnvironmentVariable{},
+			true,
 			"12.2",
 		},
 		// Darwin with valid sdk platform
 		{[]*repb.Platform_Property{
 			{Name: "OSFamily", Value: "Darwin"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "ACTUALLY_EXISTS_11.1"},
+			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "14.3"},
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhoneACTUALLY_EXISTS_11.1.sdk"},
+			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone14.3.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 		},
+			false,
 			"12.2",
 		},
 		// Darwin with xcode override but no sdk version
@@ -262,45 +263,60 @@ func TestParse_ApplyOverrides(t *testing.T) {
 			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 		},
+			false,
+			"12.2",
+		},
+		// Darwin with xcode override but invalid sdk version
+		{[]*repb.Platform_Property{
+			{Name: "OSFamily", Value: "Darwin"},
+			{Name: "enablexcodeoverride", Value: "true"},
+		}, []*repb.Command_EnvironmentVariable{
+			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "14.2"},
+			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
+			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
+		}, []*repb.Command_EnvironmentVariable{},
+			true,
 			"12.2",
 		},
 		// Case insensitive darwin with xcode override
 		{[]*repb.Platform_Property{
 			{Name: "OSFAMILY", Value: "dArWiN"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "ACTUALLY_EXISTS_11.1"},
+			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "14.3"},
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhoneACTUALLY_EXISTS_11.1.sdk"},
+			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone14.3.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 		},
+			false,
 			"12.2",
 		},
 		// Case insensitive darwin with no default xcode version
 		{[]*repb.Platform_Property{
 			{Name: "OSFAMILY", Value: "dArWiN"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "11.1"},
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.5.123"},
 		}, []*repb.Command_EnvironmentVariable{
 			{Name: "SDKROOT", Value: "/Applications/Xcode.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode.app/Contents/Developer"},
 		},
+			false,
 			"",
 		},
 		// Case insensitive darwin with no default xcode version and existing sdk
 		{[]*repb.Platform_Property{
 			{Name: "OSFAMILY", Value: "dArWiN"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "ACTUALLY_EXISTS_11.1"},
+			{Name: "APPLE_SDK_VERSION_OVERRIDE", Value: "14.3"},
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{
-			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhoneACTUALLY_EXISTS_11.1.sdk"},
+			{Name: "SDKROOT", Value: "/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhone.platform/Developer/SDKs/iPhone14.3.sdk"},
 			{Name: "DEVELOPER_DIR", Value: "/Applications/Xcode_12.4.app/Contents/Developer"},
 		},
+			false,
 			"",
 		},
 		// Default linux
@@ -311,6 +327,7 @@ func TestParse_ApplyOverrides(t *testing.T) {
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{},
+			false,
 			"12.2",
 		},
 		// Default case-insensitive linux
@@ -321,6 +338,7 @@ func TestParse_ApplyOverrides(t *testing.T) {
 			{Name: "APPLE_SDK_PLATFORM", Value: "iPhone"},
 			{Name: "XCODE_VERSION_OVERRIDE", Value: "12.4.123"},
 		}, []*repb.Command_EnvironmentVariable{},
+			false,
 			"12.2",
 		},
 	} {
@@ -330,26 +348,58 @@ func TestParse_ApplyOverrides(t *testing.T) {
 		execProps.DefaultXcodeVersion = testCase.defaultXcodeVersion
 		command := &repb.Command{EnvironmentVariables: testCase.startingEnvVars}
 		env := testenv.GetTestEnv(t)
-		env.RealEnv.SetXcodeLocator(&xcodeLocator{})
+		env.RealEnv.SetXcodeLocator(&xcodeLocator{
+			sdks12_2: map[string]string{
+				"iPhone":     "Platforms/iPhone.platform/Developer/SDKs/iPhone.sdk",
+				"iPhone14.2": "Platforms/iPhone.platform/Developer/SDKs/iPhone14.2.sdk",
+				"MacOSX":     "Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk",
+				"MacOSX11.0": "Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk",
+			},
+			sdks12_4: map[string]string{
+				"iPhone":     "Platforms/iPhone.platform/Developer/SDKs/iPhone.sdk",
+				"iPhone14.3": "Platforms/iPhone.platform/Developer/SDKs/iPhone14.3.sdk",
+				"MacOSX":     "Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk",
+				"MacOSX11.1": "Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk",
+			},
+			sdksDefault: map[string]string{
+				"iPhone":     "Platforms/iPhone.platform/Developer/SDKs/iPhone.sdk",
+				"iPhone14.4": "Platforms/iPhone.platform/Developer/SDKs/iPhone14.4.sdk",
+				"MacOSX":     "Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk",
+				"MacOSX11.3": "Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk",
+			},
+		})
 		err := platform.ApplyOverrides(env, execProps, platformProps, command)
-		require.NoError(t, err)
+		if testCase.errorExpected {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+		}
 		assert.ElementsMatch(t, command.EnvironmentVariables, append(testCase.startingEnvVars, testCase.expectedEnvVars...))
 	}
 }
 
 type xcodeLocator struct {
+	sdks12_2    map[string]string
+	sdks12_4    map[string]string
+	sdksDefault map[string]string
 }
 
-func (x *xcodeLocator) DeveloperDirForVersion(version string) (string, error) {
-	if strings.HasPrefix(version, "12.4") {
-		return "/Applications/Xcode_12.4.app/Contents/Developer", nil
+func (x *xcodeLocator) PathsForVersionAndSDK(xcodeVersion string, sdk string) (string, string, error) {
+	var developerDir string
+	var sdkPath string
+	if strings.HasPrefix(xcodeVersion, "12.2") {
+		developerDir = "/Applications/Xcode_12.2.app/Contents/Developer"
+		sdkPath, _ = x.sdks12_2[sdk]
+	} else if strings.HasPrefix(xcodeVersion, "12.4") {
+		developerDir = "/Applications/Xcode_12.4.app/Contents/Developer"
+		sdkPath, _ = x.sdks12_4[sdk]
+	} else {
+		developerDir = "/Applications/Xcode.app/Contents/Developer"
+		sdkPath, _ = x.sdksDefault[sdk]
 	}
-	if strings.HasPrefix(version, "12.2") {
-		return "/Applications/Xcode_12.2.app/Contents/Developer", nil
+	if sdkPath == "" {
+		return "", "", fmt.Errorf("Invalid SDK '%s' for Xcode '%s'", sdk, xcodeVersion)
 	}
-	return "/Applications/Xcode.app/Contents/Developer", nil
-}
-
-func (x *xcodeLocator) IsSDKPathPresentForVersion(sdkPath, version string) bool {
-	return strings.Contains(sdkPath, "ACTUALLY_EXISTS")
+	sdkRoot := fmt.Sprintf("%s/%s", developerDir, sdkPath)
+	return developerDir, sdkRoot, nil
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -572,11 +572,9 @@ type HealthChecker interface {
 
 // Locates all Xcode versions installed on the host system.
 type XcodeLocator interface {
-	// Returns the developer directory and SDKs for the given Xcode version.
-	DeveloperDirForVersion(version string) (string, error)
-
-	// Returns true if the given SDK path is present in the given Xcode version.
-	IsSDKPathPresentForVersion(sdkPath, version string) bool
+	// Finds the Xcode that matches the given Xcode version.
+	// Returns the developer directory for that Xcode and the SDK root for the given SDK.
+	PathsForVersionAndSDK(xcodeVersion string, sdk string) (string, string, error)
 }
 
 // LRU implements a Least Recently Used cache.

--- a/server/xcode/xcode.go
+++ b/server/xcode/xcode.go
@@ -14,6 +14,6 @@ func (x *xcodeLocator) DeveloperDirForVersion(version string) (string, error) {
 	return "", nil
 }
 
-func (x *xcodeLocator) IsSDKPathPresentForVersion(sdkPath, version string) bool {
-	return false
+func (x *xcodeLocator) PathsForVersionAndSDK(xcodeVersion string, sdk string) (string, string, error) {
+	return "", "", nil
 }

--- a/server/xcode/xcode_darwin.go
+++ b/server/xcode/xcode_darwin.go
@@ -10,8 +10,11 @@ package xcode
 import "C"
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 	"unsafe"
 
@@ -32,7 +35,7 @@ type xcodeLocator struct {
 type xcodeVersion struct {
 	version          string
 	developerDirPath string
-	sdks             []string
+	sdks             map[string]string
 }
 
 func NewXcodeLocator() (*xcodeLocator, error) {
@@ -41,27 +44,20 @@ func NewXcodeLocator() (*xcodeLocator, error) {
 	return xl, err
 }
 
-// Finds the Xcode developer directory that most closely matches the given Xcode version.
-func (x *xcodeLocator) DeveloperDirForVersion(version string) (string, error) {
-	xv := x.xcodeVersionForVersionString(version)
+// Finds the Xcode that matches the given Xcode version.
+// Returns the developer directory for that Xcode and the SDK root for the given SDK.
+func (x *xcodeLocator) PathsForVersionAndSDK(xcodeVersion string, sdk string) (string, string, error) {
+	xv := x.xcodeVersionForVersionString(xcodeVersion)
 	if xv == nil {
-		return "", status.FailedPreconditionErrorf("Xcode version %s not installed on remote executor. Available Xcode versions are %+v", version, x.versions)
-	}
-	return xv.developerDirPath, nil
-}
 
-// Return true if the given SDK path is present in the given Xcode version.
-func (x *xcodeLocator) IsSDKPathPresentForVersion(sdkPath, version string) bool {
-	xv := x.xcodeVersionForVersionString(version)
-	if xv == nil {
-		return false
+		return "", "", status.FailedPreconditionErrorf("Xcode version %s not installed on remote executor. Available Xcode versions are %s", xcodeVersion, versionsString(x.versions))
 	}
-	for _, sdk := range xv.sdks {
-		if sdk == sdkPath {
-			return true
-		}
+	sdkPath, ok := xv.sdks[sdk]
+	if !ok {
+		return "", "", status.FailedPreconditionErrorf("SDK %s not available for Xcode %s. Available SDKs are %s", sdk, xcodeVersion, sdksString(xv.sdks))
 	}
-	return false
+	sdkRoot := fmt.Sprintf("%s/%s", xv.developerDirPath, sdkPath)
+	return xv.developerDirPath, sdkRoot, nil
 }
 
 // Returns the xcodeVersion most closely matching the version string.
@@ -76,7 +72,7 @@ func (x *xcodeLocator) xcodeVersionForVersionString(version string) *xcodeVersio
 	return nil
 }
 
-// Locates all all Xcode versions installed on the host machine.
+// Locates all Xcode versions installed on the host machine.
 // Very losely based on https://github.com/bazelbuild/bazel/blob/master/tools/osx/xcode_locator.m
 func (x *xcodeLocator) locate() error {
 	bundleID := stringToCFString(xcodeBundleID)
@@ -113,10 +109,14 @@ func (x *xcodeLocator) locate() error {
 			continue
 		}
 		developerDirPath := path + developerDirectoryPath
-		sdks, err := fs.Glob(os.DirFS(developerDirPath), "Platforms/*.platform/Developer/SDKs/*")
+		sdkPaths, err := fs.Glob(os.DirFS(developerDirPath), "Platforms/*.platform/Developer/SDKs/*")
 		if err != nil {
 			log.Warningf("Error reading Xcode SDKs from %s: %s", path, err.Error())
 			continue
+		}
+		sdks := make(map[string]string)
+		for _, sdkPath := range sdkPaths {
+			sdks[strings.TrimSuffix(filepath.Base(sdkPath), ".sdk")] = sdkPath
 		}
 		log.Infof("Found Xcode version %s (%s) at path %s", xcodePlist.CFBundleShortVersionString, xcodePlist.ProductBuildVersion, path)
 		versions := expandXcodeVersions(xcodePlist.CFBundleShortVersionString, xcodePlist.ProductBuildVersion)
@@ -167,4 +167,22 @@ func stringToCFString(gostr string) C.CFStringRef {
 // Converts a CFStringRef into a go string.
 func stringFromCFString(cfStr C.CFStringRef) string {
 	return C.GoString(C.CFStringGetCStringPtr(cfStr, C.kCFStringEncodingUTF8))
+}
+
+func sdksString(sdks map[string]string) string {
+	availableSDKs := make([]string, 0, len(sdks))
+	for sdk, _ := range sdks {
+		availableSDKs = append(availableSDKs, sdk)
+	}
+	sort.Strings(availableSDKs)
+	return strings.Join(availableSDKs, ", ")
+}
+
+func versionsString(versions map[string]*xcodeVersion) string {
+	availableVersions := make([]string, 0, len(versions))
+	for version, _ := range versions {
+		availableVersions = append(availableVersions, version)
+	}
+	sort.Strings(availableVersions)
+	return strings.Join(availableVersions, ", ")
 }


### PR DESCRIPTION
We now store a map of sdk -> sdkPath (e.g. `iPhoneSimulator15.2` -> `Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator15.2.sdk`, `MacOSX.sdk` -> `SDKs/MacOSX.sdk`). We now also return an error if we can't find the desired SDK in the desired Xcode version, which is more correct than falling back to a version-less SDK.

This change is more performant, with a map lookup instead of iterating over an array. But more importantly, it is needed for a future change to support using the Xcode Command Line Tools as the default "Xcode" version.

---

**Version bump**: Patch
