### PR TITLE
Make terminal component more self-contained so it can be used to show action outputs

### DIFF
--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -117,12 +117,12 @@
   color: #222;
 }
 
-.action-section div {
+.action-section > div {
   flex-grow: 1;
   font-size: 13px;
 }
 
-.action-section div.action-property-title {
+.action-section .action-property-title {
   width: 20%;
   flex-grow: 0;
   flex-shrink: 0;

--- a/app/invocation/invocation_build_logs_card.tsx
+++ b/app/invocation/invocation_build_logs_card.tsx
@@ -19,21 +19,14 @@ export default class BuildLogsCardComponent extends React.Component<Props> {
         }`}>
         <PauseCircle className={`icon rotate-90 ${this.props.dark ? "white" : ""}`} />
         <div className="content">
-          <div className="title">Build logs </div>
           <div className="details">
-            {this.props.loading ? (
-              // "terminal" class makes sure the loading container's size
-              // is the same as the terminal that will take its place.
-              <div className="terminal">
-                <div className={`loading ${this.props.dark ? "loading-dark" : ""}`} />
-              </div>
-            ) : (
-              <TerminalComponent
-                value={this.props.value}
-                lightTheme={!this.props.dark}
-                fullLogsFetcher={this.props.fullLogsFetcher}
-              />
-            )}
+            <TerminalComponent
+              title={<div className="title">Build logs</div>}
+              loading={this.props.loading}
+              value={this.props.value}
+              lightTheme={!this.props.dark}
+              fullLogsFetcher={this.props.fullLogsFetcher}
+            />
           </div>
         </div>
       </div>

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -585,9 +585,12 @@ svg.icon.orange {
 
 .card .details {
   line-height: 1.6em;
-  margin-top: 16px;
   word-break: break-all;
   white-space: pre-wrap;
+}
+
+.card .details:not(:first-child) {
+  margin-top: 16px;
 }
 
 .card .more {
@@ -975,8 +978,11 @@ code .comment {
 
 .terminal {
   height: 300px;
-  margin-top: -49px;
   overflow: visible;
+}
+
+.terminal-search-placholder {
+  min-width: 278px;
 }
 
 .terminal .ReactVirtualized__Grid {
@@ -994,18 +1000,49 @@ code .comment {
   color: #fff;
 }
 
-.terminal-actions {
-  right: 0;
+.terminal-top-bar {
   position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+
+  display: flex;
+  align-items: start;
+}
+
+.terminal-search-placeholder {
+  margin-left: auto;
+  width: 290px;
+  flex-shrink: 0;
+  align-self: stretch;
+}
+
+.terminal-actions {
   display: flex;
   align-items: center;
+}
+
+.terminal-actions,
+.terminal-titles {
   z-index: 1;
+}
+
+.dense .terminal-actions .icon.icon {
+  display: initial;
 }
 
 .terminal-actions .spinner {
   --size: 18px;
   padding: 12px;
   opacity: 0.7;
+}
+
+.terminal {
+  background: #222;
+}
+
+.light-terminal .terminal {
+  background: #fafafa;
 }
 
 .light-terminal .terminal-actions {
@@ -1056,10 +1093,9 @@ code .comment {
   background-color: transparent;
 }
 
-.dense .react-lazylog-searchbar {
-  margin-bottom: 0;
-  margin-right: 96px;
-  margin-top: 14px;
+.terminal-container.has-subtitle .react-lazylog-searchbar {
+  /* Add some extra margin so the subtitle isn't so close to the terminal contents. */
+  margin-bottom: 8px;
 }
 
 .react-lazylog-searchbar-filter {
@@ -1073,6 +1109,9 @@ code .comment {
   }
   .terminal .react-lazylog-searchbar-matches {
     display: none;
+  }
+  .terminal-search-placeholder {
+    width: 150px;
   }
 }
 
@@ -1302,11 +1341,6 @@ code .comment {
 /** Tests **/
 
 .test-log {
-  white-space: pre-wrap;
-  font-family: "Source Code Pro", monospace;
-  line-height: 1.4em;
-  margin-top: 16px;
-  word-break: break-word;
   height: calc(100vh - 160px);
   box-sizing: border-box;
 }

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -981,10 +981,6 @@ code .comment {
   overflow: visible;
 }
 
-.terminal-search-placholder {
-  min-width: 278px;
-}
-
 .terminal .ReactVirtualized__Grid {
   /* !important is needed here to override react-virtualized inline style attribute */
   overflow-x: scroll !important;
@@ -1111,7 +1107,7 @@ code .comment {
     display: none;
   }
   .terminal-search-placeholder {
-    width: 150px;
+    width: 170px;
   }
 }
 

--- a/app/target/action_card.tsx
+++ b/app/target/action_card.tsx
@@ -109,6 +109,10 @@ export default class ActionCardComponent extends React.Component {
   }
 
   render() {
+    const title = <div className="title">Error Log</div>;
+    const subtitle = (
+      <div className="test-subtitle">{this.getStatusTitle(this.props.action.buildEvent.action.success)}</div>
+    );
     return (
       <div className="target-action-card">
         {this.props.action?.buildEvent?.action?.stderr?.uri && (
@@ -118,34 +122,29 @@ export default class ActionCardComponent extends React.Component {
             }`}>
             <PauseCircle className={`icon rotate-90 ${this.props.dark ? "white" : ""}`} />
             <div className="content">
-              <div className="title">Error Log</div>
-              <div className="test-subtitle">{this.getStatusTitle(this.props.action.buildEvent.action.success)}</div>
               {!this.state.cacheEnabled && (
-                <div className="empty-state">
-                  Log uploading isn't enabled for this invocation.
-                  <br />
-                  <br />
-                  To enable action log uploading you must add GRPC remote caching. You can do so by checking{" "}
-                  <b>Enable cache</b> below, updating your <b>.bazelrc</b> accordingly, and re-running your invocation:
-                  <SetupCodeComponent />
-                </div>
+                <>
+                  {title}
+                  {subtitle}
+                  <div className="empty-state">
+                    Log uploading isn't enabled for this invocation.
+                    <br />
+                    <br />
+                    To enable action log uploading you must add GRPC remote caching. You can do so by checking{" "}
+                    <b>Enable cache</b> below, updating your <b>.bazelrc</b> accordingly, and re-running your
+                    invocation:
+                    <SetupCodeComponent />
+                  </div>
+                </>
               )}
-              {this.state.cacheEnabled && this.state.stdErr && (
-                <div className="error-log">
-                  <TerminalComponent value={this.state.stdErr} lightTheme={!this.props.dark} />
-                </div>
-              )}
-              {this.state.cacheEnabled && this.state.loadingStderr && (
-                <span>
-                  <br />
-                  Loading...
-                </span>
-              )}
-              {this.state.cacheEnabled && !this.state.loadingStderr && !this.state.stdErr && (
-                <span>
-                  <br />
-                  Empty log
-                </span>
+              {this.state.cacheEnabled && (
+                <TerminalComponent
+                  title={title}
+                  subtitle={subtitle}
+                  loading={this.state.loadingStderr}
+                  value={this.state.stdErr || "Empty log"}
+                  lightTheme={!this.props.dark}
+                />
               )}
             </div>
           </div>
@@ -153,35 +152,29 @@ export default class ActionCardComponent extends React.Component {
 
         {this.props.action?.buildEvent?.action?.stdout?.uri && (
           <div className={`card ${this.state.cacheEnabled && (this.props.dark ? "dark" : "light-terminal")}`}>
-            <PauseCircle className={`rotate-90 ${this.props.dark ? "white" : ""}`} />
+            <PauseCircle className={`icon rotate-90 ${this.props.dark ? "white" : ""}`} />
             <div className="content">
-              <div className="title">Log</div>
               {!this.state.cacheEnabled && (
-                <div className="empty-state">
-                  Log uploading isn't enabled for this invocation.
-                  <br />
-                  <br />
-                  To enable action log uploading you must add GRPC remote caching. You can do so by checking{" "}
-                  <b>Enable cache</b> below, updating your <b>.bazelrc</b> accordingly, and re-running your invocation:
-                  <SetupCodeComponent />
-                </div>
+                <>
+                  <div className="title">Log</div>
+                  <div className="empty-state">
+                    Log uploading isn't enabled for this invocation.
+                    <br />
+                    <br />
+                    To enable action log uploading you must add GRPC remote caching. You can do so by checking{" "}
+                    <b>Enable cache</b> below, updating your <b>.bazelrc</b> accordingly, and re-running your
+                    invocation:
+                    <SetupCodeComponent />
+                  </div>
+                </>
               )}
-              {this.state.cacheEnabled && this.state.stdOut && (
-                <div className="error-log">
-                  <TerminalComponent value={this.state.stdOut} lightTheme={!this.props.dark} />
-                </div>
-              )}
-              {this.state.cacheEnabled && this.state.loadingStdout && (
-                <span>
-                  <br />
-                  Loading...
-                </span>
-              )}
-              {this.state.cacheEnabled && !this.state.loadingStdout && !this.state.stdOut && (
-                <span>
-                  <br />
-                  Empty log
-                </span>
+              {this.state.cacheEnabled && (
+                <TerminalComponent
+                  title={<div className="title">Log</div>}
+                  loading={this.state.loadingStdout}
+                  value={this.state.stdOut || "Empty log"}
+                  lightTheme={!this.props.dark}
+                />
               )}
             </div>
           </div>

--- a/app/target/target_log_card.tsx
+++ b/app/target/target_log_card.tsx
@@ -17,13 +17,14 @@ export default class TargetLogCardComponent extends React.Component {
       <div className={`card ${this.props.dark ? "dark" : "light-terminal"}`}>
         <PauseCircle className={`icon rotate-90 ${this.props.dark ? "white" : ""}`} />
         <div className="content">
-          <div className="title">{this.props.title}</div>
-          <div className="test-subtitle">{this.props.subtitle}</div>
-          {this.props.contents && (
-            <div className="test-log">
-              <TerminalComponent value={this.props.contents} lightTheme={!this.props.dark} />
-            </div>
-          )}
+          <div className="test-log">
+            <TerminalComponent
+              title={<div className="title">{this.props.title}</div>}
+              subtitle={<div className="test-subtitle">{this.props.subtitle}</div>}
+              value={this.props.contents}
+              lightTheme={!this.props.dark}
+            />
+          </div>
         </div>
       </div>
     );

--- a/app/target/target_test_log_card.tsx
+++ b/app/target/target_test_log_card.tsx
@@ -103,6 +103,16 @@ export default class TargetTestLogCardComponent extends React.Component {
     }
   }
   render() {
+    const title = <div className="title">Test log</div>;
+    const subtitle = (
+      <div className="test-subtitle">
+        {this.getStatusTitle(this.props.testResult.buildEvent.testResult.status)} in{" "}
+        {format.durationMillis(this.props.testResult.buildEvent.testResult.testAttemptDurationMillis)} on Shard{" "}
+        {this.props.testResult.buildEvent.id.testResult.shard} (Run {this.props.testResult.buildEvent.id.testResult.run}
+        , Attempt {this.props.testResult.buildEvent.id.testResult.attempt})
+      </div>
+    );
+
     return (
       <div
         className={`card ${
@@ -110,16 +120,10 @@ export default class TargetTestLogCardComponent extends React.Component {
         } ${this.getStatusClass(this.props.testResult.buildEvent.testResult.status)}`}>
         <PauseCircle className={`icon rotate-90 ${this.props.dark ? "white" : ""}`} />
         <div className="content">
-          <div className="title">Test log</div>
-          <div className="test-subtitle">
-            {this.getStatusTitle(this.props.testResult.buildEvent.testResult.status)} in{" "}
-            {format.durationMillis(this.props.testResult.buildEvent.testResult.testAttemptDurationMillis)} on Shard{" "}
-            {this.props.testResult.buildEvent.id.testResult.shard} (Run{" "}
-            {this.props.testResult.buildEvent.id.testResult.run}, Attempt{" "}
-            {this.props.testResult.buildEvent.id.testResult.attempt})
-          </div>
           {!this.state.cacheEnabled && (
             <div className="empty-state">
+              {title}
+              {subtitle}
               Test log uploading isn't enabled for this invocation.
               <br />
               <br />
@@ -128,22 +132,16 @@ export default class TargetTestLogCardComponent extends React.Component {
               <SetupCodeComponent />
             </div>
           )}
-          {this.state.cacheEnabled && this.state.testLog && (
+          {this.state.cacheEnabled && (
             <div className="test-log">
-              <TerminalComponent value={this.state.testLog} lightTheme={!this.props.dark} />
+              <TerminalComponent
+                title={title}
+                subtitle={subtitle}
+                value={this.state.testLog || "Empty log"}
+                loading={this.state.loading}
+                lightTheme={!this.props.dark}
+              />
             </div>
-          )}
-          {this.state.cacheEnabled && this.state.loading && (
-            <span>
-              <br />
-              Loading...
-            </span>
-          )}
-          {this.state.cacheEnabled && !this.state.loading && !this.state.testLog && (
-            <span>
-              <br />
-              Empty log
-            </span>
           )}
         </div>
       </div>

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -6,6 +6,11 @@ import Spinner from "../components/spinner/spinner";
 
 export interface TerminalProps {
   value?: string;
+  loading?: boolean;
+
+  title?: JSX.Element;
+  subtitle?: JSX.Element;
+
   lightTheme?: boolean;
   fullLogsFetcher?: () => Promise<string>;
 }
@@ -30,37 +35,55 @@ export default class TerminalComponent extends React.Component<TerminalProps, Te
 
   render() {
     return (
-      <div className={`terminal-container ${this.props.lightTheme ? "light-terminal" : ""}`}>
-        <div className="terminal-actions">
-          <button
-            title="Wrap"
-            onClick={this.handleWrapClicked.bind(this)}
-            className={`terminal-action ${this.state.wrap ? "active" : ""}`}>
-            <WrapText className="icon white" />
-          </button>
-          {this.state.isLoadingFullLog ? (
-            <Spinner />
-          ) : (
-            <button title="Download" onClick={this.handleDownloadClicked.bind(this)} className="terminal-action">
-              <Download className="icon white" />
-            </button>
+      <div
+        className={`terminal-container ${this.props.lightTheme ? "light-terminal" : ""} ${
+          this.props.subtitle ? "has-subtitle" : ""
+        }`}>
+        <div className="terminal-top-bar">
+          {this.props.title && (
+            <div className="terminal-titles">
+              {this.props.title}
+              {this.props.subtitle}
+            </div>
           )}
+          {/* Search bar is actually rendered by react-lazylog.
+              This div is just a placeholder for layout purposes. */}
+          <div className="terminal-search-placeholder" />
+          <div className="terminal-actions">
+            <button
+              title="Wrap"
+              onClick={this.handleWrapClicked.bind(this)}
+              className={`terminal-action ${this.state.wrap ? "active" : ""}`}>
+              <WrapText className="icon white" />
+            </button>
+            {this.state.isLoadingFullLog ? (
+              <Spinner />
+            ) : (
+              <button title="Download" onClick={this.handleDownloadClicked.bind(this)} className="terminal-action">
+                <Download className="icon white" />
+              </button>
+            )}
+          </div>
         </div>
         <div className="terminal" ref={this.terminalRef}>
-          <LazyLog
-            selectableLines={true}
-            caseInsensitive={true}
-            rowHeight={20}
-            enableSearch={true}
-            lineClassName="terminal-line"
-            follow={true}
-            // Ensure a trailing blank line to prevent the horizontal scrollbar
-            // from covering up the last line of logs.
-            text={(this.wrapText(this.props.value) || "No build logs...") + "\n\n"}
-            // This spread works around lightTheme not being included in @types/react-lazylog
-            // (it's a custom prop we added in our fork).
-            {...{ lightTheme: this.props.lightTheme }}
-          />
+          {this.props.loading ? (
+            <div className={`loading ${this.props.lightTheme ? "" : "loading-dark"}`} />
+          ) : (
+            <LazyLog
+              selectableLines={true}
+              caseInsensitive={true}
+              rowHeight={20}
+              enableSearch={true}
+              lineClassName="terminal-line"
+              follow={true}
+              // Ensure a trailing blank line to prevent the horizontal scrollbar
+              // from covering up the last line of logs.
+              text={(this.wrapText(this.props.value) || "No build logs...") + "\n\n"}
+              // This spread works around lightTheme not being included in @types/react-lazylog
+              // (it's a custom prop we added in our fork).
+              {...{ lightTheme: this.props.lightTheme }}
+            />
+          )}
         </div>
       </div>
     );


### PR DESCRIPTION
Updates the terminal component to be more self-contained so that it can render in places other than `.card`.

* Remove external negative margins to avoid unexpected layout shifts
* Give it ownership of the title and subtitle, so that it can manage the layout more directly, without relying on negative margins
* Add a placeholder div which is empty but has the same dimensions as the search bar, so that the title and actions are laid out more naturally and wrap properly on different screen sizes.

Before (layout is shifted upwards, top bar does not have the correct BG color, wrap/download icons are not visible):

![image](https://user-images.githubusercontent.com/2414826/146844495-ad216b42-a695-492c-904d-2293d822c897.png)

After (different invocation, so output is not expected to be the same):

![image](https://user-images.githubusercontent.com/2414826/146844722-e5af37db-0bd3-43e9-8626-dbee73c2b7d3.png)

The terminal could use a bit of padding in this screenshot, but I think that should be managed by a separate tiny helper component, e.g. `TerminalFrame` component which applies padding with the correct color depending on the theme, + slightly rounded borders.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
