### PR TITLE
Add styles for invocation action card terminal

### DIFF
--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -51,7 +51,7 @@
 }
 
 .invocation-action-card .terminal-container {
-  padding: 8px;
+  padding: 8px 32px;
   border-radius: 8px;
 }
 

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -50,6 +50,11 @@
   height: 18px;
 }
 
+.invocation-action-card .terminal-container {
+  padding: 8px;
+  border-radius: 8px;
+}
+
 .file-name {
   display: flex;
   align-items: flex-start;

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1033,11 +1033,11 @@ code .comment {
   opacity: 0.7;
 }
 
-.terminal {
+.terminal-container {
   background: #222;
 }
 
-.light-terminal .terminal {
+.terminal-container.light-terminal {
   background: #fafafa;
 }
 

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -972,7 +972,7 @@ code .comment {
 
 /** Misc **/
 
-.terminal-container {
+.terminal-content {
   position: relative;
 }
 

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -39,51 +39,53 @@ export default class TerminalComponent extends React.Component<TerminalProps, Te
         className={`terminal-container ${this.props.lightTheme ? "light-terminal" : ""} ${
           this.props.subtitle ? "has-subtitle" : ""
         }`}>
-        <div className="terminal-top-bar">
-          {this.props.title && (
-            <div className="terminal-titles">
-              {this.props.title}
-              {this.props.subtitle}
-            </div>
-          )}
-          {/* Search bar is actually rendered by react-lazylog.
+        <div className="terminal-content">
+          <div className="terminal-top-bar">
+            {this.props.title && (
+              <div className="terminal-titles">
+                {this.props.title}
+                {this.props.subtitle}
+              </div>
+            )}
+            {/* Search bar is actually rendered by react-lazylog.
               This div is just a placeholder for layout purposes. */}
-          <div className="terminal-search-placeholder" />
-          <div className="terminal-actions">
-            <button
-              title="Wrap"
-              onClick={this.handleWrapClicked.bind(this)}
-              className={`terminal-action ${this.state.wrap ? "active" : ""}`}>
-              <WrapText className="icon white" />
-            </button>
-            {this.state.isLoadingFullLog ? (
-              <Spinner />
-            ) : (
-              <button title="Download" onClick={this.handleDownloadClicked.bind(this)} className="terminal-action">
-                <Download className="icon white" />
+            <div className="terminal-search-placeholder" />
+            <div className="terminal-actions">
+              <button
+                title="Wrap"
+                onClick={this.handleWrapClicked.bind(this)}
+                className={`terminal-action ${this.state.wrap ? "active" : ""}`}>
+                <WrapText className="icon white" />
               </button>
+              {this.state.isLoadingFullLog ? (
+                <Spinner />
+              ) : (
+                <button title="Download" onClick={this.handleDownloadClicked.bind(this)} className="terminal-action">
+                  <Download className="icon white" />
+                </button>
+              )}
+            </div>
+          </div>
+          <div className="terminal" ref={this.terminalRef}>
+            {this.props.loading ? (
+              <div className={`loading ${this.props.lightTheme ? "" : "loading-dark"}`} />
+            ) : (
+              <LazyLog
+                selectableLines={true}
+                caseInsensitive={true}
+                rowHeight={20}
+                enableSearch={true}
+                lineClassName="terminal-line"
+                follow={true}
+                // Ensure a trailing blank line to prevent the horizontal scrollbar
+                // from covering up the last line of logs.
+                text={(this.wrapText(this.props.value) || "No build logs...") + "\n\n"}
+                // This spread works around lightTheme not being included in @types/react-lazylog
+                // (it's a custom prop we added in our fork).
+                {...{ lightTheme: this.props.lightTheme }}
+              />
             )}
           </div>
-        </div>
-        <div className="terminal" ref={this.terminalRef}>
-          {this.props.loading ? (
-            <div className={`loading ${this.props.lightTheme ? "" : "loading-dark"}`} />
-          ) : (
-            <LazyLog
-              selectableLines={true}
-              caseInsensitive={true}
-              rowHeight={20}
-              enableSearch={true}
-              lineClassName="terminal-line"
-              follow={true}
-              // Ensure a trailing blank line to prevent the horizontal scrollbar
-              // from covering up the last line of logs.
-              text={(this.wrapText(this.props.value) || "No build logs...") + "\n\n"}
-              // This spread works around lightTheme not being included in @types/react-lazylog
-              // (it's a custom prop we added in our fork).
-              {...{ lightTheme: this.props.lightTheme }}
-            />
-          )}
         </div>
       </div>
     );


### PR DESCRIPTION
Just adding padding and border-radius to the `.terminal-container`. Moved the background color to `.terminal-container` instead of `.terminal` so that the padding gets the color as well.

![image](https://user-images.githubusercontent.com/2414826/147970793-b5a1e3b6-8278-4c28-8244-0b5ce77737ca.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
