### PR TITLE
Add support for displaying artifacts populated via namedSetOfFiles

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -183,6 +183,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
         <TargetComponent
           invocationId={this.props.invocationId}
           hash={this.props.hash}
+          files={this.state.model.getFiles(completed.buildEvent)}
           configuredEvent={this.state.model.configuredMap.get(targetLabel)}
           skippedEvent={this.state.model.skippedMap.get(targetLabel)}
           completedEvent={completed}

--- a/app/invocation/invocation_artifacts_card.tsx
+++ b/app/invocation/invocation_artifacts_card.tsx
@@ -44,12 +44,14 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
     const filteredTargets = this.props.model.succeeded
       .map((event) => ({
         label: event.id.targetCompleted.label,
-        outputs: event.completed.importantOutput.filter(
-          (output) =>
-            !this.props.filter ||
-            event.id.targetCompleted.label.toLowerCase().includes(this.props.filter.toLowerCase()) ||
-            output.name.toLowerCase().includes(this.props.filter.toLowerCase())
-        ),
+        outputs: this.props.model
+          .getFiles(event)
+          .filter(
+            (output) =>
+              !this.props.filter ||
+              event.id.targetCompleted.label.toLowerCase().includes(this.props.filter.toLowerCase()) ||
+              output.name.toLowerCase().includes(this.props.filter.toLowerCase())
+          ),
       }))
       .filter((target) => target.outputs.length);
 

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -57,7 +57,7 @@ export default class InvocationModel {
   testSummaryMap: Map<string, invocation.InvocationEvent> = new Map<string, invocation.InvocationEvent>();
   actionMap: Map<string, invocation.InvocationEvent[]> = new Map<string, invocation.InvocationEvent[]>();
 
-  private fileSetNameToFilesMap: Map<string, build_event_stream.IFile[]> = new Map();
+  private fileSetIDToFilesMap: Map<string, build_event_stream.IFile[]> = new Map();
 
   static modelFromInvocations(invocations: invocation.Invocation[]) {
     let model = new InvocationModel();
@@ -76,7 +76,7 @@ export default class InvocationModel {
       for (let event of invocation.event) {
         let buildEvent = event.buildEvent;
         if (buildEvent.namedSetOfFiles) {
-          model.fileSetNameToFilesMap.set(buildEvent.id.namedSet.id, buildEvent.namedSetOfFiles.files);
+          model.fileSetIDToFilesMap.set(buildEvent.id.namedSet.id, buildEvent.namedSetOfFiles.files);
         }
         if (buildEvent.configured) model.targets.push(buildEvent as build_event_stream.BuildEvent);
         if (buildEvent.configured) {
@@ -526,7 +526,7 @@ export default class InvocationModel {
     return (
       event.completed.outputGroup
         ?.flatMap((group) => group.fileSets)
-        .flatMap((set) => this.fileSetNameToFilesMap.get(set.id)) || []
+        .flatMap((set) => this.fileSetIDToFilesMap.get(set.id)) || []
     );
   }
 

--- a/app/target/target.tsx
+++ b/app/target/target.tsx
@@ -17,6 +17,7 @@ interface Props {
   targetLabel: string;
   hash: string;
 
+  files: build_event_stream.IFile[];
   configuredEvent: invocation.InvocationEvent;
   completedEvent: invocation.InvocationEvent;
   skippedEvent: invocation.InvocationEvent;
@@ -161,7 +162,7 @@ export default class TargetComponent extends React.Component {
   render() {
     let resultEvents = this.props.testResultEvents?.sort(this.resultSort) || [];
     let actionEvents = this.props.actionEvents?.sort(this.actionSort) || [];
-    let files = this.props?.completedEvent?.buildEvent?.completed.importantOutput || [];
+    let files = this.props.files || [];
     for (const resultEvent of resultEvents) {
       files = files.concat(resultEvent?.buildEvent?.testResult?.testActionOutput || []);
     }


### PR DESCRIPTION
This prepares us for the impending flip of the `--legacy_important_outputs` flag in future bazel versions: https://github.com/bazelbuild/bazel/pull/14353

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
