### PR TITLE
Allow parsing resource names referring to zstd-compressed blobs

### DIFF
--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -325,9 +325,9 @@ func filesFromOutput(output []*build_event_stream.File) []*apipb.File {
 			Uri:  uri,
 		}
 		if u, err := url.Parse(uri); err == nil {
-			if _, d, err := digest.ExtractDigestFromDownloadResourceName(u.Path); err == nil {
-				f.Hash = d.GetHash()
-				f.SizeBytes = d.GetSizeBytes()
+			if r, err := digest.ParseDownloadResourceName(u.Path); err == nil {
+				f.Hash = r.GetHash()
+				f.SizeBytes = r.GetSizeBytes()
 			}
 		}
 		files = append(files, f)

--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -326,8 +326,8 @@ func filesFromOutput(output []*build_event_stream.File) []*apipb.File {
 		}
 		if u, err := url.Parse(uri); err == nil {
 			if r, err := digest.ParseDownloadResourceName(u.Path); err == nil {
-				f.Hash = r.GetHash()
-				f.SizeBytes = r.GetSizeBytes()
+				f.Hash = r.GetDigest().GetHash()
+				f.SizeBytes = r.GetDigest().GetSizeBytes()
 			}
 		}
 		files = append(files, f)

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -835,7 +835,7 @@ func (ws *workspace) applyPatch(ctx context.Context, bsClient bspb.ByteStreamCli
 	if err != nil {
 		return err
 	}
-	if err := cachetools.GetBlob(ctx, bsClient, digest.NewInstanceNameDigest(d, *remoteInstanceName), f); err != nil {
+	if err := cachetools.GetBlob(ctx, bsClient, digest.NewResourceName(d, *remoteInstanceName), f); err != nil {
 		_ = f.Close()
 		return err
 	}

--- a/enterprise/server/cmd/smash/smash.go
+++ b/enterprise/server/cmd/smash/smash.go
@@ -148,7 +148,7 @@ func newRandomDigestBuf(sizeBytes int64) (*repb.Digest, []byte) {
 
 func writeDataFunc(mtd *desc.MethodDescriptor, cd *runner.CallData) []byte {
 	d, buf := newRandomDigestBuf(randomBlobSize())
-	resourceName, err := digest.UploadResourceName(digest.NewInstanceNameDigest(d, *instanceName))
+	resourceName, err := digest.NewResourceName(d, *instanceName).UploadString()
 	if err != nil {
 		log.Fatalf("Error computing upload resource name: %s", err)
 	}
@@ -168,7 +168,7 @@ func writeDataFunc(mtd *desc.MethodDescriptor, cd *runner.CallData) []byte {
 func readDataFunc(mtd *desc.MethodDescriptor, cd *runner.CallData) []byte {
 	randomDigest := preWrittenDigests[rand.Intn(len(preWrittenDigests))]
 
-	resourceName := digest.DownloadResourceName(digest.NewInstanceNameDigest(randomDigest, *instanceName))
+	resourceName := digest.NewResourceName(randomDigest, *instanceName).DownloadString()
 	rr := &bspb.ReadRequest{
 		ResourceName: resourceName,
 		ReadOffset:   0,

--- a/enterprise/server/cmd/smash/smash.go
+++ b/enterprise/server/cmd/smash/smash.go
@@ -148,7 +148,7 @@ func newRandomDigestBuf(sizeBytes int64) (*repb.Digest, []byte) {
 
 func writeDataFunc(mtd *desc.MethodDescriptor, cd *runner.CallData) []byte {
 	d, buf := newRandomDigestBuf(randomBlobSize())
-	resourceName, err := digest.UploadResourceName(d, *instanceName)
+	resourceName, err := digest.UploadResourceName(digest.NewInstanceNameDigest(d, *instanceName))
 	if err != nil {
 		log.Fatalf("Error computing upload resource name: %s", err)
 	}
@@ -168,7 +168,7 @@ func writeDataFunc(mtd *desc.MethodDescriptor, cd *runner.CallData) []byte {
 func readDataFunc(mtd *desc.MethodDescriptor, cd *runner.CallData) []byte {
 	randomDigest := preWrittenDigests[rand.Intn(len(preWrittenDigests))]
 
-	resourceName := digest.DownloadResourceName(randomDigest, *instanceName)
+	resourceName := digest.DownloadResourceName(digest.NewInstanceNameDigest(randomDigest, *instanceName))
 	rr := &bspb.ReadRequest{
 		ResourceName: resourceName,
 		ReadOffset:   0,

--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -70,7 +70,7 @@ func timestampProto(timeInUsec int64) *timestamppb.Timestamp {
 }
 
 func tableExecToProto(in tables.Execution) (*espb.Execution, error) {
-	_, d, err := digest.ExtractDigestFromDownloadResourceName(in.ExecutionID)
+	r, err := digest.ParseDownloadResourceName(in.ExecutionID)
 	if err != nil {
 		return nil, err
 	}
@@ -79,16 +79,16 @@ func tableExecToProto(in tables.Execution) (*espb.Execution, error) {
 	if in.StatusCode == int32(codes.OK) && in.ExitCode == 0 {
 		// Action Result with unmodified action digest is only uploaded when there is no error
 		// from the CommandResult(i.e. status code is OK) and the exit code is zero.
-		actionResultDigest = proto.Clone(d).(*repb.Digest)
+		actionResultDigest = proto.Clone(r.Digest).(*repb.Digest)
 	} else {
-		actionResultDigest, err = digest.AddInvocationIDToDigest(d, in.InvocationID)
+		actionResultDigest, err = digest.AddInvocationIDToDigest(r.Digest, in.InvocationID)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	out := &espb.Execution{
-		ActionDigest:       d,
+		ActionDigest:       r.Digest,
 		ActionResultDigest: actionResultDigest,
 		Status: &statuspb.Status{
 			Code:    in.StatusCode,

--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -79,16 +79,16 @@ func tableExecToProto(in tables.Execution) (*espb.Execution, error) {
 	if in.StatusCode == int32(codes.OK) && in.ExitCode == 0 {
 		// Action Result with unmodified action digest is only uploaded when there is no error
 		// from the CommandResult(i.e. status code is OK) and the exit code is zero.
-		actionResultDigest = proto.Clone(r.Digest).(*repb.Digest)
+		actionResultDigest = proto.Clone(r.GetDigest()).(*repb.Digest)
 	} else {
-		actionResultDigest, err = digest.AddInvocationIDToDigest(r.Digest, in.InvocationID)
+		actionResultDigest, err = digest.AddInvocationIDToDigest(r.GetDigest(), in.InvocationID)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	out := &espb.Execution{
-		ActionDigest:       r.Digest,
+		ActionDigest:       r.GetDigest(),
 		ActionResultDigest: actionResultDigest,
 		Status: &statuspb.Status{
 			Code:    in.StatusCode,

--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -156,7 +156,7 @@ func trimPathPrefix(fullPath, prefix string) string {
 }
 
 type fileToUpload struct {
-	ad           *digest.InstanceNameDigest
+	ad           *digest.ResourceName
 	info         os.FileInfo
 	fullFilePath string
 
@@ -647,7 +647,7 @@ func (ff *BatchFileFetcher) bytestreamReadFiles(ctx context.Context, instanceNam
 	return nil
 }
 
-func fetchDir(ctx context.Context, bsClient bspb.ByteStreamClient, reqDigest *digest.InstanceNameDigest) (*repb.Directory, error) {
+func fetchDir(ctx context.Context, bsClient bspb.ByteStreamClient, reqDigest *digest.ResourceName) (*repb.Directory, error) {
 	dir := &repb.Directory{}
 	if err := cachetools.GetBlobAsProto(ctx, bsClient, reqDigest, dir); err != nil {
 		return nil, err
@@ -675,7 +675,7 @@ func DirMapFromTree(tree *repb.Tree) (rootDigest *repb.Digest, dirMap map[digest
 	return rootDigest, dirMap, nil
 }
 
-func GetTreeFromRootDirectoryDigest(ctx context.Context, casClient repb.ContentAddressableStorageClient, d *digest.InstanceNameDigest) (*repb.Tree, error) {
+func GetTreeFromRootDirectoryDigest(ctx context.Context, casClient repb.ContentAddressableStorageClient, d *digest.ResourceName) (*repb.Tree, error) {
 	var dirs []*repb.Directory
 	nextPageToken := ""
 	for {

--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -173,7 +173,7 @@ func newDirToUpload(instanceName, parentDir string, info os.FileInfo, dir *repb.
 		return nil, err
 	}
 	reader := bytes.NewReader(data)
-	ad, err := cachetools.ComputeDigest(reader, instanceName)
+	r, err := cachetools.ComputeDigest(reader, instanceName)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func newDirToUpload(instanceName, parentDir string, info os.FileInfo, dir *repb.
 	return &fileToUpload{
 		fullFilePath: filepath.Join(parentDir, info.Name()),
 		info:         info,
-		resourceName: ad,
+		resourceName: r,
 		data:         data,
 		dir:          dir,
 	}, nil

--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -627,7 +627,7 @@ func (ff *BatchFileFetcher) bytestreamReadFiles(ctx context.Context, instanceNam
 	if err != nil {
 		return err
 	}
-	if err := cachetools.GetBlob(ctx, ff.bsClient, digest.NewInstanceNameDigest(fp.FileNode.Digest, instanceName), f); err != nil {
+	if err := cachetools.GetBlob(ctx, ff.bsClient, digest.NewResourceName(fp.FileNode.Digest, instanceName), f); err != nil {
 		return err
 	}
 	if err := f.Close(); err != nil {

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -204,15 +204,15 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 // not validate it.
 // N.B. This should only be used if the calling code has already ensured the
 // action is valid and may be returned.
-func (s *ExecutionServer) getUnvalidatedActionResult(ctx context.Context, d *digest.ResourceName) (*repb.ActionResult, error) {
-	cache, err := namespace.ActionCache(ctx, s.cache, d.GetInstanceName())
+func (s *ExecutionServer) getUnvalidatedActionResult(ctx context.Context, r *digest.ResourceName) (*repb.ActionResult, error) {
+	cache, err := namespace.ActionCache(ctx, s.cache, r.GetInstanceName())
 	if err != nil {
 		return nil, err
 	}
-	data, err := cache.Get(ctx, d.Digest)
+	data, err := cache.Get(ctx, r.GetDigest())
 	if err != nil {
 		if status.IsNotFoundError(err) {
-			return nil, digest.MissingDigestError(d.Digest)
+			return nil, digest.MissingDigestError(r.GetDigest())
 		}
 		return nil, err
 	}

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -177,7 +177,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, task *repb.E
 
 	req := task.GetExecuteRequest()
 	taskID := task.GetExecutionId()
-	adInstanceDigest := digest.NewInstanceNameDigest(req.GetActionDigest(), req.GetInstanceName())
+	adInstanceDigest := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName())
 
 	acClient := s.env.GetActionCacheClient()
 
@@ -227,7 +227,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, task *repb.E
 
 	md.InputFetchStartTimestamp = ptypes.TimestampNow()
 
-	rootInstanceDigest := digest.NewInstanceNameDigest(
+	rootInstanceDigest := digest.NewResourceName(
 		task.GetAction().GetInputRootDigest(),
 		task.GetExecuteRequest().GetInstanceName(),
 	)
@@ -349,7 +349,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, task *repb.E
 			if err != nil {
 				return finishWithErrFn(status.UnavailableErrorf("Error uploading action result: %s", err.Error()))
 			}
-			adInstanceDigest = digest.NewInstanceNameDigest(resultDigest, req.GetInstanceName())
+			adInstanceDigest = digest.NewResourceName(resultDigest, req.GetInstanceName())
 		}
 		if err := cachetools.UploadActionResult(ctx, acClient, adInstanceDigest, actionResult); err != nil {
 			return finishWithErrFn(status.UnavailableErrorf("Error uploading action result: %s", err.Error()))

--- a/enterprise/server/remote_execution/operation/operation.go
+++ b/enterprise/server/remote_execution/operation/operation.go
@@ -18,13 +18,13 @@ import (
 	gstatus "google.golang.org/grpc/status"
 )
 
-func Assemble(stage repb.ExecutionStage_Value, name string, d *digest.ResourceName, er *repb.ExecuteResponse) (*longrunning.Operation, error) {
-	if d == nil || er == nil {
+func Assemble(stage repb.ExecutionStage_Value, name string, r *digest.ResourceName, er *repb.ExecuteResponse) (*longrunning.Operation, error) {
+	if r == nil || er == nil {
 		return nil, status.FailedPreconditionError("digest or execute response are both required to assemble operation")
 	}
 	metadata, err := ptypes.MarshalAny(&repb.ExecuteOperationMetadata{
 		Stage:        stage,
-		ActionDigest: d.Digest,
+		ActionDigest: r.GetDigest(),
 	})
 	if err != nil {
 		return nil, err

--- a/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
@@ -80,7 +80,7 @@ type Command struct {
 
 	gRPCClientSource GRPCClientSource
 
-	actionDigest *digest.InstanceNameDigest
+	actionDigest *digest.ResourceName
 
 	cancelExecutionRequest context.CancelFunc
 	accepted               chan string
@@ -101,7 +101,7 @@ func (c *Command) AcceptedChannel() <-chan string {
 	return c.accepted
 }
 
-func (c *Command) GetActionDigest() *digest.InstanceNameDigest {
+func (c *Command) GetActionDigest() *digest.ResourceName {
 	return c.actionDigest
 }
 

--- a/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
@@ -270,7 +270,7 @@ func (c *Client) PrepareCommand(ctx context.Context, instanceName string, name s
 	command := &Command{
 		gRPCClientSource: c.gRPClientSource,
 		Name:             name,
-		actionDigest:     digest.NewInstanceNameDigest(actionDigest, instanceName),
+		actionDigest:     digest.NewResourceName(actionDigest, instanceName),
 	}
 
 	return command, nil
@@ -282,7 +282,7 @@ func (c *Client) DownloadActionOutputs(ctx context.Context, env environment.Env,
 		if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
 			return err
 		}
-		d := digest.NewInstanceNameDigest(out.GetDigest(), res.InstanceName)
+		d := digest.NewResourceName(out.GetDigest(), res.InstanceName)
 		f, err := os.Create(path)
 		if err != nil {
 			return err
@@ -298,7 +298,7 @@ func (c *Client) DownloadActionOutputs(ctx context.Context, env environment.Env,
 		if err := os.MkdirAll(path, 0777); err != nil {
 			return err
 		}
-		treeDigest := digest.NewInstanceNameDigest(dir.GetTreeDigest(), res.InstanceName)
+		treeDigest := digest.NewResourceName(dir.GetTreeDigest(), res.InstanceName)
 		tree := &repb.Tree{}
 		if err := cachetools.GetBlobAsProto(ctx, c.gRPClientSource.GetByteStreamClient(), treeDigest, tree); err != nil {
 			return err

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -773,13 +773,13 @@ func (r *Env) DownloadOutputsToNewTempDir(res *CommandResult) string {
 }
 
 func (r *Env) GetActionResultForFailedAction(ctx context.Context, cmd *Command, invocationID string) (*repb.ActionResult, error) {
-	d := cmd.GetActionDigest().Digest
+	d := cmd.GetActionResourceName().GetDigest()
 	actionResultDigest, err := digest.AddInvocationIDToDigest(d, invocationID)
 	if err != nil {
 		assert.FailNow(r.t, fmt.Sprintf("unable to attach invocation ID %q to digest", invocationID))
 	}
 	req := &repb.GetActionResultRequest{
-		InstanceName: cmd.GetActionDigest().GetInstanceName(),
+		InstanceName: cmd.GetActionResourceName().GetInstanceName(),
 		ActionDigest: actionResultDigest,
 	}
 	acClient := r.GetActionResultStorageClient()
@@ -790,7 +790,7 @@ func (r *Env) GetStdoutAndStderr(ctx context.Context, actionResult *repb.ActionR
 	stdout := ""
 	if actionResult.GetStdoutDigest() != nil {
 		d := digest.NewResourceName(actionResult.GetStdoutDigest(), instanceName)
-		buf := bytes.NewBuffer(make([]byte, 0, d.GetSizeBytes()))
+		buf := bytes.NewBuffer(make([]byte, 0, d.GetDigest().GetSizeBytes()))
 		err := cachetools.GetBlob(ctx, r.GetByteStreamClient(), d, buf)
 		if err != nil {
 			return "", "", status.UnavailableErrorf("error retrieving stdout from CAS: %v", err)
@@ -801,7 +801,7 @@ func (r *Env) GetStdoutAndStderr(ctx context.Context, actionResult *repb.ActionR
 	stderr := ""
 	if actionResult.GetStderrDigest() != nil {
 		d := digest.NewResourceName(actionResult.GetStderrDigest(), instanceName)
-		buf := bytes.NewBuffer(make([]byte, 0, d.GetSizeBytes()))
+		buf := bytes.NewBuffer(make([]byte, 0, d.GetDigest().GetSizeBytes()))
 		err := cachetools.GetBlob(ctx, r.GetByteStreamClient(), d, buf)
 		if err != nil {
 			return "", "", status.InternalErrorf("error retrieving stderr from CAS: %v", err)

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -789,7 +789,7 @@ func (r *Env) GetActionResultForFailedAction(ctx context.Context, cmd *Command, 
 func (r *Env) GetStdoutAndStderr(ctx context.Context, actionResult *repb.ActionResult, instanceName string) (string, string, error) {
 	stdout := ""
 	if actionResult.GetStdoutDigest() != nil {
-		d := digest.NewInstanceNameDigest(actionResult.GetStdoutDigest(), instanceName)
+		d := digest.NewResourceName(actionResult.GetStdoutDigest(), instanceName)
 		buf := bytes.NewBuffer(make([]byte, 0, d.GetSizeBytes()))
 		err := cachetools.GetBlob(ctx, r.GetByteStreamClient(), d, buf)
 		if err != nil {
@@ -800,7 +800,7 @@ func (r *Env) GetStdoutAndStderr(ctx context.Context, actionResult *repb.ActionR
 
 	stderr := ""
 	if actionResult.GetStderrDigest() != nil {
-		d := digest.NewInstanceNameDigest(actionResult.GetStderrDigest(), instanceName)
+		d := digest.NewResourceName(actionResult.GetStderrDigest(), instanceName)
 		buf := bytes.NewBuffer(make([]byte, 0, d.GetSizeBytes()))
 		err := cachetools.GetBlob(ctx, r.GetByteStreamClient(), d, buf)
 		if err != nil {

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -98,7 +98,7 @@ func TestActionResultCacheWithFailedAction(t *testing.T) {
 
 	// Verify that it returns NotFound error when looking up action result with unmodified
 	// action digest when the action failed.
-	_, err = cachetools.GetActionResult(ctx, rbe.GetActionResultStorageClient(), cmd.GetActionDigest())
+	_, err = cachetools.GetActionResult(ctx, rbe.GetActionResultStorageClient(), cmd.GetActionResourceName())
 	assert.True(t, status.IsNotFoundError(err))
 }
 

--- a/server/bytestream/bytestream.go
+++ b/server/bytestream/bytestream.go
@@ -67,7 +67,7 @@ func streamFromUrl(ctx context.Context, url *url.URL, grpcs bool, callback func(
 		// Request the ActionResult
 		req := &repb.GetActionResultRequest{
 			InstanceName: r.GetInstanceName(),
-			ActionDigest: r.Digest,
+			ActionDigest: r.GetDigest(),
 		}
 		actionResult, err := acClient.GetActionResult(ctx, req)
 		if err != nil {

--- a/server/bytestream/bytestream.go
+++ b/server/bytestream/bytestream.go
@@ -59,15 +59,15 @@ func streamFromUrl(ctx context.Context, url *url.URL, grpcs bool, callback func(
 
 	if url.Scheme == "actioncache" {
 		acClient := repb.NewActionCacheClient(conn)
-		instanceName, d, err := digest.ExtractDigestFromActionCacheResourceName(strings.TrimPrefix(url.RequestURI(), "/"))
+		r, err := digest.ParseActionCacheResourceName(strings.TrimPrefix(url.RequestURI(), "/"))
 		if err != nil {
 			return err
 		}
 
 		// Request the ActionResult
 		req := &repb.GetActionResultRequest{
-			InstanceName: instanceName,
-			ActionDigest: d,
+			InstanceName: r.GetInstanceName(),
+			ActionDigest: r.Digest,
 		}
 		actionResult, err := acClient.GetActionResult(ctx, req)
 		if err != nil {

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -116,7 +116,7 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 	downloadTracker := ht.TrackDownload(r.Digest)
 
 	bufSize := int64(readBufSizeBytes)
-	if r.GetSizeBytes() > 0 && r.Digest.GetSizeBytes() < bufSize {
+	if r.GetSizeBytes() > 0 && r.GetSizeBytes() < bufSize {
 		bufSize = r.GetSizeBytes()
 	}
 	copyBuf := s.bufferPool.Get(bufSize)

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -43,9 +43,9 @@ func runByteStreamServer(ctx context.Context, env *testenv.TestEnv, t *testing.T
 	return clientConn
 }
 
-func readBlob(ctx context.Context, bsClient bspb.ByteStreamClient, d *digest.InstanceNameDigest, out io.Writer, offset int64) error {
+func readBlob(ctx context.Context, bsClient bspb.ByteStreamClient, d *digest.ResourceName, out io.Writer, offset int64) error {
 	req := &bspb.ReadRequest{
-		ResourceName: digest.DownloadResourceName(d.Digest, d.GetInstanceName()),
+		ResourceName: digest.DownloadResourceName(d),
 		ReadOffset:   offset,
 		ReadLimit:    d.GetSizeBytes(),
 	}
@@ -82,7 +82,7 @@ func TestRPCRead(t *testing.T) {
 	}
 	cases := []struct {
 		wantError          error
-		instanceNameDigest *digest.InstanceNameDigest
+		instanceNameDigest *digest.ResourceName
 		wantData           string
 		offset             int64
 	}{

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -43,11 +43,11 @@ func runByteStreamServer(ctx context.Context, env *testenv.TestEnv, t *testing.T
 	return clientConn
 }
 
-func readBlob(ctx context.Context, bsClient bspb.ByteStreamClient, d *digest.ResourceName, out io.Writer, offset int64) error {
+func readBlob(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.ResourceName, out io.Writer, offset int64) error {
 	req := &bspb.ReadRequest{
-		ResourceName: d.DownloadString(),
+		ResourceName: r.DownloadString(),
 		ReadOffset:   offset,
-		ReadLimit:    d.GetSizeBytes(),
+		ReadLimit:    r.GetDigest().GetSizeBytes(),
 	}
 	stream, err := bsClient.Read(ctx, req)
 	if err != nil {
@@ -140,7 +140,7 @@ func TestRPCRead(t *testing.T) {
 
 	for _, tc := range cases {
 		// Set the value in the cache.
-		if err := te.GetCache().Set(ctx, tc.instanceNameDigest.Digest, []byte(tc.wantData)); err != nil {
+		if err := te.GetCache().Set(ctx, tc.instanceNameDigest.GetDigest(), []byte(tc.wantData)); err != nil {
 			t.Fatal(err)
 		}
 

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -158,7 +158,7 @@ func UploadProto(ctx context.Context, bsClient bspb.ByteStreamClient, instanceNa
 		return nil, err
 	}
 	reader := bytes.NewReader(data)
-	ad, err := ComputeDigest(reader, instanceName)
+	resourceName, err := ComputeDigest(reader, instanceName)
 	if err != nil {
 		return nil, err
 	}
@@ -166,11 +166,11 @@ func UploadProto(ctx context.Context, bsClient bspb.ByteStreamClient, instanceNa
 	if _, err := reader.Seek(0, io.SeekStart); err != nil {
 		return nil, err
 	}
-	return UploadFromReader(ctx, bsClient, ad, reader)
+	return UploadFromReader(ctx, bsClient, resourceName, reader)
 }
 
 func UploadBlob(ctx context.Context, bsClient bspb.ByteStreamClient, instanceName string, in io.ReadSeeker) (*repb.Digest, error) {
-	ad, err := ComputeDigest(in, instanceName)
+	resourceName, err := ComputeDigest(in, instanceName)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func UploadBlob(ctx context.Context, bsClient bspb.ByteStreamClient, instanceNam
 	if _, err := in.Seek(0, io.SeekStart); err != nil {
 		return nil, err
 	}
-	return UploadFromReader(ctx, bsClient, ad, in)
+	return UploadFromReader(ctx, bsClient, resourceName, in)
 }
 
 func UploadFile(ctx context.Context, bsClient bspb.ByteStreamClient, instanceName, fullFilePath string) (*repb.Digest, error) {
@@ -187,7 +187,7 @@ func UploadFile(ctx context.Context, bsClient bspb.ByteStreamClient, instanceNam
 		return nil, err
 	}
 	defer f.Close()
-	ad, err := ComputeDigest(f, instanceName)
+	resourceName, err := ComputeDigest(f, instanceName)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func UploadFile(ctx context.Context, bsClient bspb.ByteStreamClient, instanceNam
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		return nil, err
 	}
-	return UploadFromReader(ctx, bsClient, ad, f)
+	return UploadFromReader(ctx, bsClient, resourceName, f)
 }
 
 func GetBlobAsProto(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest.ResourceName, out proto.Message) error {

--- a/server/remote_cache/digest/BUILD
+++ b/server/remote_cache/digest/BUILD
@@ -11,6 +11,7 @@ go_library(
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_uuid//:uuid",
         "@go_googleapis//google/rpc:errdetails_go_proto",
+        "@io_opentelemetry_go_otel_sdk//resource",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",

--- a/server/remote_cache/digest/BUILD
+++ b/server/remote_cache/digest/BUILD
@@ -11,7 +11,6 @@ go_library(
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_uuid//:uuid",
         "@go_googleapis//google/rpc:errdetails_go_proto",
-        "@io_opentelemetry_go_otel_sdk//resource",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -39,25 +39,35 @@ var (
 	// - "blobs/469db13020c60f8bdf9c89aa4e9a449914db23139b53a24d064f967a51057868/39120"
 	// - "blobs/ac/469db13020c60f8bdf9c89aa4e9a449914db23139b53a24d064f967a51057868/39120"
 	// - "uploads/2042a8f9-eade-4271-ae58-f5f6f5a32555/blobs/8afb02ca7aace3ae5cd8748ac589e2e33022b1a4bfd22d5d234c5887e270fe9c/17997850"
-	uploadRegex      = regexp.MustCompile("^(?:(?:(?P<instance_name>.*)/)?uploads/(?P<uuid>[a-f0-9-]{36})/)?blobs/(?P<hash>[a-f0-9]{64})/(?P<size>\\d+)")
-	downloadRegex    = regexp.MustCompile("^(?:(?P<instance_name>.*)/)?blobs/(?P<hash>[a-f0-9]{64})/(?P<size>\\d+)")
-	actionCacheRegex = regexp.MustCompile("^(?:(?P<instance_name>.*)/)?blobs/ac/(?P<hash>[a-f0-9]{64})/(?P<size>\\d+)")
+	uploadRegex      = regexp.MustCompile(`^(?:(?:(?P<instance_name>.*)/)?uploads/(?P<uuid>[a-f0-9-]{36})/)?(?P<blob_type>blobs|compressed-blobs/zstd)/(?P<hash>[a-f0-9]{64})/(?P<size>\d+)`)
+	downloadRegex    = regexp.MustCompile(`^(?:(?P<instance_name>.*)/)?(?P<blob_type>blobs|compressed-blobs/zstd)/(?P<hash>[a-f0-9]{64})/(?P<size>\d+)`)
+	actionCacheRegex = regexp.MustCompile(`^(?:(?P<instance_name>.*)/)?(?P<blob_type>blobs|compressed-blobs/zstd)/ac/(?P<hash>[a-f0-9]{64})/(?P<size>\d+)`)
 )
 
-type InstanceNameDigest struct {
+type ResourceName struct {
 	*repb.Digest
 	instanceName string
+	compressor   repb.Compressor_Value
 }
 
-func NewInstanceNameDigest(d *repb.Digest, instanceName string) *InstanceNameDigest {
-	return &InstanceNameDigest{
+func NewResourceName(d *repb.Digest, instanceName string, compressor repb.Compressor_Value) *ResourceName {
+	return &ResourceName{
 		Digest:       d,
 		instanceName: instanceName,
+		compressor:   compressor,
 	}
 }
 
-func (i *InstanceNameDigest) GetInstanceName() string {
-	return i.instanceName
+func NewInstanceNameDigest(d *repb.Digest, instanceName string) *ResourceName {
+	return NewResourceName(d, instanceName, repb.Compressor_IDENTITY)
+}
+
+func (r *ResourceName) GetInstanceName() string {
+	return r.instanceName
+}
+
+func (r *ResourceName) GetCompressor() repb.Compressor_Value {
+	return r.compressor
 }
 
 // Key is a representation of a digest that can be used as a map key.
@@ -130,30 +140,37 @@ func AddInvocationIDToDigest(digest *repb.Digest, invocationID string) (*repb.Di
 	}, nil
 }
 
-func DownloadResourceName(d *repb.Digest, instanceName string) string {
+func DownloadResourceName(resource *ResourceName) string {
 	// Haven't found docs on what a valid instance name looks like. But generally
 	// seems like a string, possibly separated by "/".
 
 	// Ensure there is no trailing slash and path has components.
-	instanceName = filepath.Join(filepath.SplitList(instanceName)...)
-	return fmt.Sprintf("%s/blobs/%s/%d", instanceName, d.GetHash(), d.GetSizeBytes())
+	instanceName := filepath.Join(filepath.SplitList(resource.GetInstanceName())...)
+	return fmt.Sprintf(
+		"%s/%s/%s/%d",
+		instanceName, blobTypeSegment(resource.GetCompressor()),
+		resource.GetHash(), resource.GetSizeBytes())
 }
 
-func UploadResourceName(d *repb.Digest, instanceName string) (string, error) {
+func UploadResourceName(resource *ResourceName) (string, error) {
 	// Haven't found docs on what a valid instance name looks like. But generally
 	// seems like a string, possibly separated by "/".
 
 	// Ensure there is no trailing slash and path has components.
-	instanceName = filepath.Join(filepath.SplitList(instanceName)...)
+	instanceName := filepath.Join(filepath.SplitList(resource.GetInstanceName())...)
 
 	u, err := guuid.NewRandom()
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s/uploads/%s/blobs/%s/%d", instanceName, u.String(), d.GetHash(), d.GetSizeBytes()), nil
+	return fmt.Sprintf(
+		"%s/uploads/%s/%s/%s/%d",
+		instanceName, u.String(), blobTypeSegment(resource.GetCompressor()),
+		resource.GetHash(), resource.GetSizeBytes(),
+	), nil
 }
 
-func extractDigest(resourceName string, matcher *regexp.Regexp) (string, *repb.Digest, error) {
+func parseResourceName(resourceName string, matcher *regexp.Regexp) (*ResourceName, error) {
 	match := matcher.FindStringSubmatch(resourceName)
 	result := make(map[string]string, len(match))
 	for i, name := range matcher.SubexpNames() {
@@ -164,14 +181,14 @@ func extractDigest(resourceName string, matcher *regexp.Regexp) (string, *repb.D
 	hash, hashOK := result["hash"]
 	sizeStr, sizeOK := result["size"]
 	if !hashOK || !sizeOK {
-		return "", nil, status.InvalidArgumentErrorf("Unparsable resource name: %s", resourceName)
+		return nil, status.InvalidArgumentErrorf("Unparsable resource name: %s", resourceName)
 	}
 	if hash == "" {
-		return "", nil, status.InvalidArgumentErrorf("Unparsable resource name (empty hash?): %s", resourceName)
+		return nil, status.InvalidArgumentErrorf("Unparsable resource name (empty hash?): %s", resourceName)
 	}
 	sizeBytes, err := strconv.ParseInt(sizeStr, 10, 0)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
 	// Set the instance name, if one was present.
@@ -180,22 +197,37 @@ func extractDigest(resourceName string, matcher *regexp.Regexp) (string, *repb.D
 		instanceName = in
 	}
 
-	return instanceName, &repb.Digest{
-		Hash:      hash,
-		SizeBytes: sizeBytes,
-	}, nil
+	// Determine compression level from blob type segment
+	blobTypeStr, sizeOK := result["blob_type"]
+	if !sizeOK {
+		// Should never happen since the regex would not match otherwise.
+		return nil, status.InvalidArgumentError(`Unparsable resource name: "/blobs" or "/compressed-blobs/zstd" missing or out of place`)
+	}
+	compressor := repb.Compressor_IDENTITY
+	if blobTypeStr == "compressed-blobs/zstd" {
+		compressor = repb.Compressor_ZSTD
+	}
+	d := &repb.Digest{Hash: hash, SizeBytes: sizeBytes}
+	return NewResourceName(d, instanceName, compressor), nil
 }
 
-func ExtractDigestFromUploadResourceName(resourceName string) (string, *repb.Digest, error) {
-	return extractDigest(resourceName, uploadRegex)
+func ParseUploadResourceName(resourceName string) (*ResourceName, error) {
+	return parseResourceName(resourceName, uploadRegex)
 }
 
-func ExtractDigestFromDownloadResourceName(resourceName string) (string, *repb.Digest, error) {
-	return extractDigest(resourceName, downloadRegex)
+func ParseDownloadResourceName(resourceName string) (*ResourceName, error) {
+	return parseResourceName(resourceName, downloadRegex)
 }
 
-func ExtractDigestFromActionCacheResourceName(resourceName string) (string, *repb.Digest, error) {
-	return extractDigest(resourceName, actionCacheRegex)
+func ParseActionCacheResourceName(resourceName string) (*ResourceName, error) {
+	return parseResourceName(resourceName, actionCacheRegex)
+}
+
+func blobTypeSegment(compressor repb.Compressor_Value) string {
+	if compressor == repb.Compressor_ZSTD {
+		return "compressed-blobs/zstd"
+	}
+	return "blobs"
 }
 
 func IsCacheDebuggingEnabled(ctx context.Context) bool {

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -45,17 +45,21 @@ var (
 )
 
 type ResourceName struct {
-	*repb.Digest
+	digest       *repb.Digest
 	instanceName string
 	compressor   repb.Compressor_Value
 }
 
 func NewResourceName(d *repb.Digest, instanceName string) *ResourceName {
 	return &ResourceName{
-		Digest:       d,
+		digest:       d,
 		instanceName: instanceName,
 		compressor:   repb.Compressor_IDENTITY,
 	}
+}
+
+func (r *ResourceName) GetDigest() *repb.Digest {
+	return r.digest
 }
 
 func (r *ResourceName) GetInstanceName() string {
@@ -78,7 +82,7 @@ func (r *ResourceName) DownloadString() string {
 	return fmt.Sprintf(
 		"%s/%s/%s/%d",
 		instanceName, blobTypeSegment(r.GetCompressor()),
-		r.GetHash(), r.GetSizeBytes())
+		r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes())
 }
 
 // UploadString returns a string representing the resource name for upload
@@ -93,7 +97,7 @@ func (r *ResourceName) UploadString() (string, error) {
 	return fmt.Sprintf(
 		"%s/uploads/%s/%s/%s/%d",
 		instanceName, u.String(), blobTypeSegment(r.GetCompressor()),
-		r.GetHash(), r.GetSizeBytes(),
+		r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes(),
 	), nil
 }
 

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -74,8 +74,8 @@ func TestParseResourceName(t *testing.T) {
 			continue
 		}
 		if tc.wantParsed != nil && (gotParsed == nil ||
-			gotParsed.GetHash() != tc.wantParsed.GetHash() ||
-			gotParsed.GetSizeBytes() != tc.wantParsed.GetSizeBytes() ||
+			gotParsed.GetDigest().GetHash() != tc.wantParsed.GetDigest().GetHash() ||
+			gotParsed.GetDigest().GetSizeBytes() != tc.wantParsed.GetDigest().GetSizeBytes() ||
 			gotParsed.GetInstanceName() != tc.wantParsed.GetInstanceName() ||
 			gotParsed.GetCompressor() != tc.wantParsed.GetCompressor()) {
 			t.Errorf("parseResourceName(%q): got %+v; want %+v", tc.resourceName, gotParsed, tc.wantParsed)

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -39,32 +39,32 @@ func TestParseResourceName(t *testing.T) {
 		{ // download, resource with instance name
 			resourceName: "my_instance_name/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			matcher:      downloadRegex,
-			wantParsed:   NewInstanceNameDigest(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "my_instance_name"),
+			wantParsed:   NewResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "my_instance_name"),
 		},
 		{ // download, resource with zstd compression
 			resourceName: "/compressed-blobs/zstd/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			matcher:      downloadRegex,
-			wantParsed:   NewResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "", repb.Compressor_ZSTD),
+			wantParsed:   newZstdResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, ""),
 		},
 		{ // download, resource with zstd compression and instance name
 			resourceName: "my_instance_name/compressed-blobs/zstd/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			matcher:      downloadRegex,
-			wantParsed:   NewResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "my_instance_name", repb.Compressor_ZSTD),
+			wantParsed:   newZstdResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "my_instance_name"),
 		},
 		{ // download, resource with digest only
 			resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			matcher:      downloadRegex,
-			wantParsed:   NewInstanceNameDigest(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, ""),
+			wantParsed:   NewResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, ""),
 		},
 		{ // upload, UUID and instance name
 			resourceName: "instance_name/uploads/2148e1f1-aacc-41eb-a31c-22b6da7c7ac1/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			matcher:      uploadRegex,
-			wantParsed:   NewInstanceNameDigest(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "instance_name"),
+			wantParsed:   NewResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "instance_name"),
 		},
 		{ // upload, UUID, instance name, and compression
 			resourceName: "instance_name/uploads/2148e1f1-aacc-41eb-a31c-22b6da7c7ac1/compressed-blobs/zstd/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			matcher:      uploadRegex,
-			wantParsed:   NewResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "instance_name", repb.Compressor_ZSTD),
+			wantParsed:   newZstdResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "instance_name"),
 		},
 	}
 	for _, tc := range cases {
@@ -81,4 +81,10 @@ func TestParseResourceName(t *testing.T) {
 			t.Errorf("parseResourceName(%q): got %+v; want %+v", tc.resourceName, gotParsed, tc.wantParsed)
 		}
 	}
+}
+
+func newZstdResourceName(d *repb.Digest, instanceName string) *ResourceName {
+	r := NewResourceName(d, instanceName)
+	r.SetCompressor(repb.Compressor_ZSTD)
+	return r
 }

--- a/tools/vmstart/vmstart.go
+++ b/tools/vmstart/vmstart.go
@@ -163,7 +163,7 @@ func main() {
 			log.Fatalf("Error parsing action digest %q: %s", *actionDigest, err)
 		}
 
-		actionInstanceDigest := digest.NewInstanceNameDigest(d, *remoteInstanceName)
+		actionInstanceDigest := digest.NewResourceName(d, *remoteInstanceName)
 
 		action, cmd, err := cachetools.GetActionAndCommand(ctx, env.GetByteStreamClient(), actionInstanceDigest)
 		if err != nil {
@@ -172,7 +172,7 @@ func main() {
 		log.Infof("Action:\n%s", proto.MarshalTextString(action))
 		log.Infof("Command:\n%s", proto.MarshalTextString(cmd))
 
-		tree, err := dirtools.GetTreeFromRootDirectoryDigest(ctx, env.GetContentAddressableStorageClient(), digest.NewInstanceNameDigest(action.GetInputRootDigest(), *remoteInstanceName))
+		tree, err := dirtools.GetTreeFromRootDirectoryDigest(ctx, env.GetContentAddressableStorageClient(), digest.NewResourceName(action.GetInputRootDigest(), *remoteInstanceName))
 		if err != nil {
 			log.Fatalf("Could not fetch input root structure: %s", err)
 		}


### PR DESCRIPTION
Allows the bytestream server to parse upload and download resource names for zstd-compressed blobs:
- Upload resource names follow the pattern `{instance_name}/uploads/{uuid}/compressed-blobs/{compressor}/{uncompressed_hash}/{uncompressed_size}{/optional_metadata}`
- Download resource names follow the pattern `{instance_name}/compressed-blobs/{compressor}/{uncompressed_hash}/{uncompressed_size}`

Changes:
* Expand `InstanceNameDigest` to include the blob compression type (either identity or zstd for now)
* Rename `InstanceNameDigest` to `ResourceName`
* Update string parsing methods to return `*ResourceName, error` instead of `string, *repb.Digest, error` and update regex matchers to recognize `compressed-blobs/zstd`
* Add tests

The only functional difference expected to be introduced by this PR is that we no longer immediately return `InvalidArgumentError` when we see Bytestream read/write requests for `compressed-blobs/zstd/DIGEST`. This should not matter to any clients that properly implement the RBE protocol, since we don't yet advertise zstd support via the capabilities API. But if we do happen do get zstd requests for some reason, the worst that can happen is:
* For writes, the checksum will fail upon write completion, since we don't yet decompress the incoming stream to compute the uncompressed digest
* For reads, we will return decompressed blobs even if zstd blobs are requested, and decompression will fail on the client

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
