### PR TITLE
gitignore generated protos under all dirs, not just /proto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,11 @@ tramp
 # Bazel directories
 bazel-*
 
+# Generated protos
+**/proto/**/*.pb.go
+**/proto/**/*_ts_proto.d.ts
+**/proto/**/*_ts_proto.js
+
 # Node dependencies
 node_modules
 

--- a/proto/.gitignore
+++ b/proto/.gitignore
@@ -1,4 +1,0 @@
-# Proto symlinks
-*_ts_proto.js
-*.d.ts
-*.pb.go


### PR DESCRIPTION
This new pattern matches `enterprise/server/test/integration/remote_execution/proto/**/*.pb.go`

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
