### PR TITLE
Use `ui_actions_shown` to determine number of log lines to buffer for ANSI

### DIFF
--- a/server/build_event_protocol/build_event_handler/BUILD
+++ b/server/build_event_protocol/build_event_handler/BUILD
@@ -35,6 +35,7 @@ go_library(
         "//server/util/status",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
+        "@com_github_google_shlex//:shlex",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_grpc//status",
         "@org_golang_x_sync//errgroup",

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -839,15 +839,15 @@ func getValuesForOptionNameFromOptions(options, value string) ([]string, error) 
 		return values, err
 	}
 	flag := "--" + value
-	for i, option := range(optionsList) {
+	for i, option := range optionsList {
 		if option == "--" {
 			break
 		}
-		if strings.HasPrefix(option, flag + "=") {
-			values = append(values, strings.TrimPrefix(option, flag + "="))
+		if strings.HasPrefix(option, flag+"=") {
+			values = append(values, strings.TrimPrefix(option, flag+"="))
 		} else if option == flag {
-			if i < len(optionsList) - 1 {
-				values = append(values, optionsList[i + 1])
+			if i < len(optionsList)-1 {
+				values = append(values, optionsList[i+1])
 			} else {
 				values = append(values, "")
 			}


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->
Approximates flag parsing by shlex splitting and assuming no options have values of `--curses`
or `--ui_actions_shown`. Actually correct parsing would require reproducing the entirety of all
possible bazel flags in go, which is too much. If we decide correctly parsed options are necessary,
we can instead buffer events until the OptionsParsed event arrives and use the values in that, but
that, too, is cumbersome.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
