### PR TITLE
Render node's textContent rather than innerHTML when rendering test logs

### DIFF
--- a/app/target/target_test_cases_card.tsx
+++ b/app/target/target_test_cases_card.tsx
@@ -86,9 +86,7 @@ export default class TargetTestCasesCardComponent extends React.Component {
                           <div className="test-case-message">
                             {child.getAttribute("message")} {child.getAttribute("type")}
                           </div>
-                          <div className="test-case-contents">
-                            {child.innerHTML.replace("<![CDATA[", "").replace("--]]>", "")}
-                          </div>
+                          <div className="test-case-contents">{child.textContent}</div>
                         </div>
                       ))}
                     </div>

--- a/app/target/target_test_document_card.tsx
+++ b/app/target/target_test_document_card.tsx
@@ -136,7 +136,7 @@ export default class TargetTestDocumentCardComponent extends React.Component {
                   )
                   .map((child) => (
                     <TargetLogCardComponent
-                      contents={child.innerHTML.replace("<![CDATA[", "").replace("--]]>", "")}
+                      contents={child.textContent}
                       title={testSuite.getAttribute("name")}
                       subtitle={`${child.tagName}`}
                       dark={this.props.dark}


### PR DESCRIPTION
This fixes https://github.com/buildbuddy-io/buildbuddy/issues/231

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
