### PR TITLE
Expose zstd capabilities

### DIFF
--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -286,7 +286,11 @@ func StartBuildEventServicesOrDie(env environment.Env, grpcServer *grpc.Server) 
 	}
 	// Register to handle GetCapabilities messages, which tell the client
 	// that this server supports CAS functionality.
-	capabilitiesServer := capabilities_server.NewCapabilitiesServer( /*supportCAS=*/ enableCache /*supportRemoteExec=*/, enableRemoteExec)
+	capabilitiesServer := capabilities_server.NewCapabilitiesServer(
+		/*supportCAS=*/ enableCache,
+		/*supportRemoteExec=*/ enableRemoteExec,
+		/*supportZstd=*/ env.GetConfigurator().GetCacheZstdTranscodingEnabled(),
+	)
 	repb.RegisterCapabilitiesServer(grpcServer, capabilitiesServer)
 }
 


### PR DESCRIPTION
To be pushed in a subsequent release after the `--cache.zstd_transcoding_enabled` flag is live on all servers.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
