### PR TITLE
Add per-OS execution duration to usage table

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -649,23 +649,19 @@ func (s *ExecutionServer) markTaskComplete(ctx context.Context, taskID string, e
 		router.MarkComplete(ctx, cmd, actionResourceName.GetInstanceName(), nodeID)
 	}
 
-	if err := s.updateUsage(ctx, actionResourceName, executeResponse); err != nil {
+	if err := s.updateUsage(ctx, cmd, executeResponse); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (s *ExecutionServer) updateUsage(ctx context.Context, actionResourceName *digest.ResourceName, executeResponse *repb.ExecuteResponse) error {
+func (s *ExecutionServer) updateUsage(ctx context.Context, cmd *repb.Command, executeResponse *repb.ExecuteResponse) error {
 	ut := s.env.GetUsageTracker()
 	if ut == nil {
 		return nil
 	}
 	dur, err := executionDuration(executeResponse.GetResult().GetExecutionMetadata())
-	if err != nil {
-		return err
-	}
-	cmd, err := s.fetchCommandForTask(ctx, actionResourceName)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -595,26 +595,24 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 		if stage == repb.ExecutionStage_COMPLETED {
 			response := operation.ExtractExecuteResponse(op)
 			if response != nil {
-				actionResourceName, err := digest.ParseUploadResourceName(taskID)
-				if err != nil {
+				if err := s.markTaskComplete(ctx, taskID, response); err != nil {
 					log.Error(err.Error())
-				} else {
-					// Before publishing the COMPLETED operation, update the task router
-					// so that subsequent tasks with similar routing properties can get
-					// routed back to the same executor.
-					if err := s.updateRouter(ctx, actionResourceName, response); err != nil {
-						// Errors from updating the router should not be fatal.
-						log.Errorf("Failed to update task router for task %s: %s", taskID, err)
-					}
-					// Also update usage, but it can wait until we're done handling the
-					// operation.
-					defer func() {
-						if err := s.updateUsage(ctx, actionResourceName, response); err != nil {
-							// Errors from updating usage should not be fatal.
-							log.Errorf("Failed to update usage for task %s: %s", taskID, err)
-						}
-					}()
 				}
+				// Before publishing the COMPLETED operation, update the task router
+				// so that subsequent tasks with similar routing properties can get
+				// routed back to the same executor.
+				if err := s.updateRouter(ctx, actionResourceName, response); err != nil {
+					// Errors from updating the router should not be fatal.
+					log.Errorf("Failed to update task router for task %s: %s", taskID, err)
+				}
+				// Also update usage, but it can wait until we're done handling the
+				// operation.
+				defer func() {
+					if err := s.updateUsage(ctx, actionResourceName, response); err != nil {
+						// Errors from updating usage should not be fatal.
+						log.Errorf("Failed to update usage for task %s: %s", taskID, err)
+					}
+				}()
 			}
 		}
 
@@ -646,22 +644,25 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 	}
 }
 
-func (s *ExecutionServer) updateRouter(ctx context.Context, actionResourceName *digest.ResourceName, executeResponse *repb.ExecuteResponse) error {
-	router := s.env.GetTaskRouter()
-	if router == nil {
-		return nil
-	}
-	// If the result was served from cache, nothing was actually executed, so no
-	// need to update the task router.
-	if executeResponse.GetCachedResult() {
-		return nil
+// markTaskComplete contains logic to be run when the task is complete but
+// before letting the client know that the task has completed.
+func (s *ExecutionServer) markTaskComplete(ctx context.Context, taskID string, executeResponse *repb.ExecuteResponse) error {
+	actionResourceName, err := digest.ParseUploadResourceName(taskID)
+	if err != nil {
+		return err
 	}
 	cmd, err := s.fetchCommandForTask(ctx, actionResourceName)
 	if err != nil {
 		return err
 	}
-	nodeID := executeResponse.GetResult().GetExecutionMetadata().GetExecutorId()
-	router.MarkComplete(ctx, cmd, actionResourceName.GetInstanceName(), nodeID)
+
+	router := s.env.GetTaskRouter()
+	// Only update the router if a task was actually executed
+	if router != nil && !executeResponse.GetCachedResult() {
+		nodeID := executeResponse.GetResult().GetExecutionMetadata().GetExecutorId()
+		router.MarkComplete(ctx, cmd, actionResourceName.GetInstanceName(), nodeID)
+	}
+
 	return nil
 }
 

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -649,11 +649,7 @@ func (s *ExecutionServer) markTaskComplete(ctx context.Context, taskID string, e
 		router.MarkComplete(ctx, cmd, actionResourceName.GetInstanceName(), nodeID)
 	}
 
-	if err := s.updateUsage(ctx, cmd, executeResponse); err != nil {
-		return err
-	}
-
-	return nil
+	return s.updateUsage(ctx, cmd, executeResponse)
 }
 
 func (s *ExecutionServer) updateUsage(ctx context.Context, cmd *repb.Command, executeResponse *repb.ExecuteResponse) error {

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -267,8 +267,10 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, c collection
 				invocations,
 				cas_cache_hits,
 				action_cache_hits,
-				total_download_size_bytes
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+				total_download_size_bytes,
+				linux_execution_duration_usec,
+				mac_execution_duration_usec
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			`,
 			pk.GroupID,
 			pk.PeriodStartUsec,
@@ -278,6 +280,8 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, c collection
 			counts.CASCacheHits,
 			counts.ActionCacheHits,
 			counts.TotalDownloadSizeBytes,
+			counts.LinuxExecutionDurationUsec,
+			counts.MacExecutionDurationUsec,
 		)
 		if err := res.Error; err != nil {
 			return err
@@ -296,7 +300,9 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, c collection
 				invocations = invocations + ?,
 				cas_cache_hits = cas_cache_hits + ?,
 				action_cache_hits = action_cache_hits + ?,
-				total_download_size_bytes = total_download_size_bytes + ?
+				total_download_size_bytes = total_download_size_bytes + ?,
+				linux_execution_duration_usec = linux_execution_duration_usec + ?,
+				mac_execution_duration_usec = mac_execution_duration_usec + ?
 			WHERE
 				group_id = ?
 				AND period_start_usec = ?
@@ -308,6 +314,8 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, c collection
 			counts.CASCacheHits,
 			counts.ActionCacheHits,
 			counts.TotalDownloadSizeBytes,
+			counts.LinuxExecutionDurationUsec,
+			counts.MacExecutionDurationUsec,
 			pk.GroupID,
 			pk.PeriodStartUsec,
 			pk.Region,
@@ -417,6 +425,12 @@ func countsToMap(tu *tables.UsageCounts) (map[string]int64, error) {
 	if tu.TotalDownloadSizeBytes > 0 {
 		counts["total_download_size_bytes"] = tu.TotalDownloadSizeBytes
 	}
+	if tu.LinuxExecutionDurationUsec > 0 {
+		counts["linux_execution_duration_usec"] = tu.LinuxExecutionDurationUsec
+	}
+	if tu.MacExecutionDurationUsec > 0 {
+		counts["mac_execution_duration_usec"] = tu.MacExecutionDurationUsec
+	}
 	return counts, nil
 }
 
@@ -432,9 +446,11 @@ func stringMapToCounts(h map[string]string) (*tables.UsageCounts, error) {
 		hInt64[k] = count
 	}
 	return &tables.UsageCounts{
-		Invocations:            hInt64["invocations"],
-		CASCacheHits:           hInt64["cas_cache_hits"],
-		ActionCacheHits:        hInt64["action_cache_hits"],
-		TotalDownloadSizeBytes: hInt64["total_download_size_bytes"],
+		Invocations:                hInt64["invocations"],
+		CASCacheHits:               hInt64["cas_cache_hits"],
+		ActionCacheHits:            hInt64["action_cache_hits"],
+		TotalDownloadSizeBytes:     hInt64["total_download_size_bytes"],
+		LinuxExecutionDurationUsec: hInt64["linux_execution_duration_usec"],
+		MacExecutionDurationUsec:   hInt64["mac_execution_duration_usec"],
 	}, nil
 }

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -432,7 +432,7 @@ type UsageCounts struct {
 	ActionCacheHits        int64
 	TotalDownloadSizeBytes int64
 
-	// NOTE: New fields should added here should be annotated with
+	// NOTE: New fields added here should be annotated with
 	// `gorm:"not null;default:0"`
 
 	LinuxExecutionDurationUsec int64 `gorm:"not null;default:0"`

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -427,10 +427,12 @@ func (wf *Workflow) TableName() string {
 }
 
 type UsageCounts struct {
-	Invocations            int64
-	CASCacheHits           int64
-	ActionCacheHits        int64
-	TotalDownloadSizeBytes int64
+	Invocations                int64
+	CASCacheHits               int64
+	ActionCacheHits            int64
+	TotalDownloadSizeBytes     int64
+	LinuxExecutionDurationUsec int64
+	MacExecutionDurationUsec   int64
 }
 
 // Usage holds usage counter values for a group during a particular time period.

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -427,12 +427,16 @@ func (wf *Workflow) TableName() string {
 }
 
 type UsageCounts struct {
-	Invocations                int64
-	CASCacheHits               int64
-	ActionCacheHits            int64
-	TotalDownloadSizeBytes     int64
-	LinuxExecutionDurationUsec int64
-	MacExecutionDurationUsec   int64
+	Invocations            int64
+	CASCacheHits           int64
+	ActionCacheHits        int64
+	TotalDownloadSizeBytes int64
+
+	// NOTE: New fields should added here should be annotated with
+	// `gorm:"not null;default:0"`
+
+	LinuxExecutionDurationUsec int64 `gorm:"not null;default:0"`
+	MacExecutionDurationUsec   int64 `gorm:"not null;default:0"`
 }
 
 // Usage holds usage counter values for a group during a particular time period.


### PR DESCRIPTION
Also add tests that make it ~impossible to forget to update the usage tracker when new UsageCounts fields are added.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1063
