### PR TITLE
Fix impl of WriteResponse.committed_size field

### DIFF
--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -392,7 +392,8 @@ func mustUploadChunked(t *testing.T, ctx context.Context, bsClient bspb.ByteStre
 	require.NoError(t, err)
 	res, err := uploadStream.CloseAndRecv()
 	require.NoError(t, err)
-	// NOTE: If the blob already exists, this assertion will fail.
+	// NOTE: If the blob already exists, this assertion will fail if the blob is
+	// compressed.
 	require.Equal(t, len(blob), res.CommittedSize)
 }
 

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -390,8 +390,10 @@ func mustUploadChunked(t *testing.T, ctx context.Context, bsClient bspb.ByteStre
 		FinishWrite: true,
 	})
 	require.NoError(t, err)
-	_, err = uploadStream.CloseAndRecv()
+	res, err := uploadStream.CloseAndRecv()
 	require.NoError(t, err)
+	// NOTE: If the blob already exists, this assertion will fail.
+	require.Equal(t, len(blob), res.CommittedSize)
 }
 
 func zstdCompress(t *testing.T, b []byte) []byte {

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -394,7 +394,7 @@ func mustUploadChunked(t *testing.T, ctx context.Context, bsClient bspb.ByteStre
 	require.NoError(t, err)
 	// NOTE: If the blob already exists, this assertion will fail if the blob is
 	// compressed.
-	require.Equal(t, len(blob), res.CommittedSize)
+	require.Equal(t, int64(len(blob)), res.CommittedSize)
 }
 
 func zstdCompress(t *testing.T, b []byte) []byte {


### PR DESCRIPTION
When Bazel actually completes the upload (as opposed to the upload immediately returning because the digest already exists) -- it will check whether the committed_size matches the _raw_ size of the stream written. The previous impl of committed_size returned the number of _uncompressed_ bytes written.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
