### PR TITLE
Use ts.created_at_usec instead of ts.start_time_usec

### DIFF
--- a/server/target/target.go
+++ b/server/target/target.go
@@ -92,8 +92,8 @@ func readTargets(ctx context.Context, env environment.Env, req *trpb.GetTargetRe
 	if err := perms.AddPermissionsCheckToQueryWithTableAlias(ctx, env, q, "i"); err != nil {
 		return nil, err
 	}
-	q.AddWhereClause("ts.start_time_usec > ?", startUsec)
-	q.AddWhereClause("ts.start_time_usec < ?", endUsec)
+	q.AddWhereClause("ts.created_at_usec > ?", startUsec)
+	q.AddWhereClause("ts.created_at_usec < ?", endUsec)
 
 	tq := req.GetQuery()
 	if repo := tq.GetRepoUrl(); repo != "" {


### PR DESCRIPTION
ts.start_time_usec is the time when the test is first ran. If a test is
cached; then it would be earlier than the created_at_usec.
