### PR TITLE
Update blog posts to point to new images and fix a few jumbled release notes

### DIFF
--- a/website/blog/buildBuddy-achieves-soc-2-certification.md
+++ b/website/blog/buildBuddy-achieves-soc-2-certification.md
@@ -6,7 +6,7 @@ author_title: Head of Sales @ BuildBuddy
 date: 2021-04-28:12:00:00
 author_url: https://www.linkedin.com/in/gli/
 author_image_url: https://avatars.githubusercontent.com/u/27219306?v=4
-image: https://uploads-ssl.webflow.com/5eeba6a68ba54530ffd09006/606de9e9765e01d812105cf7_socforserviceorganizationslogosos.jpeg
+image: /img/blog/soc2.jpg
 tags: [company, security]
 ---
 
@@ -15,7 +15,7 @@ Our mission at BuildBuddy is to help developers be more productive. It's our hig
 Today, we’re excited to share that BuildBuddy has achieved SOC 2 certification.
 
 <p align="center">
-  <img src="https://uploads-ssl.webflow.com/5eeba6a68ba54530ffd09006/606de9e9765e01d812105cf7_socforserviceorganizationslogosos.jpeg" />
+  <img src="/img/blog/soc2.jpg" />
 </p>
 
 The audit was conducted by [The Cadence Group](https://thecadencegroup.com/), compliance specialists who have performed SOC reporting examinations for some of the largest software companies in the world. Our certification means that we adhere to the highest standards of security, processing integrity, and risk management.

--- a/website/blog/buildbuddy-joins-y-combinator.md
+++ b/website/blog/buildbuddy-joins-y-combinator.md
@@ -7,12 +7,13 @@ date: 2020-03-16:12:00:00
 author_url: https://www.linkedin.com/in/siggisim/
 author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
 tags: [company]
+image: /img/blog/xkcd.png
 ---
 
 If you've hung out around developers for any extended period --- you've probably heard "my code is compiling" as an excuse from them when they're slacking off and browsing Hacker News.
 
-<figure class="image">
-  <img src="https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5eed4e21d97fc3603e86efdc_1*J-1MC3QGbIuwq4tb-yr-iA.png" />
+<figure className="image">
+  <img src="/img/blog/xkcd.png" />
   <figcaption>"Compiling" via <a href="https://xkcd.com/303/">XKCD</a></figcaption>
 </figure>
 
@@ -22,9 +23,9 @@ Slow, flaky builds waste hours of developer time --- leading to slow dev refresh
 
 We're excited to share that we've been accepted into [Y Combinator](https://www.ycombinator.com/) and have been participating in their Winter 2020 batch. Here's a photo from our first batch dinner where the founders of Airbnb (YC Winter 2009) told us stories about their YC experience:
 
-<figure class="image">
-  <img src="https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5eed4e212a1f37493d85f9ee_1*ktcdbtOw6h_-hxMmR2VU2g.jpeg" />
+<figure className="image">
+  <img src="/img/blog/yc-dinner.jpg" />
   <figcaption>Airbnb founders speak at our first batch dinner via <a href="https://twitter.com/gustaf/status/1215039947356270594">Gustaf Alstromer</a></figcaption>
 </figure>
 
-We're excited to share more about BuildBuddy in the coming months. If you intrigued and want to learn more --- feel free to shoot us an email at <hello@buildbuddy.io>.
+We're excited to share more about BuildBuddy in the coming months. If you intrigued and want to learn more - feel free to shoot us an email at <hello@buildbuddy.io>.

--- a/website/blog/buildbuddy-v1-1-0-release-notes.md
+++ b/website/blog/buildbuddy-v1-1-0-release-notes.md
@@ -1,62 +1,75 @@
 ---
-slug: buildbuddy-v1-2-1-release-notes
-title: BuildBuddy v1.2.1 Release Notes
+slug: buildbuddy-v1-1-0-release-notes
+title: BuildBuddy v1.1.0 Release Notes
 author: Siggi Simonarson
 author_title: Co-founder @ BuildBuddy
 date: 2020-07-15:12:00:00
 author_url: https://www.linkedin.com/in/siggisim/
 author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
-tags: [product, release-notes, team]
+tags: [product, release-notes]
 ---
 
-Excited to share that v1.2.1 of BuildBuddy is live on both [Cloud Hosted BuildBuddy](https://app.buildbuddy.io/) and open source via [Github](https://github.com/buildbuddy-io/buildbuddy) and [Docker](https://github.com/buildbuddy-io/buildbuddy/blob/master/docs/on-prem.md#docker-image)!
+Excited to share that v1.1.0 of BuildBuddy is live on both [Cloud Hosted BuildBuddy](https://app.buildbuddy.io/) and open source via [Github](https://github.com/buildbuddy-io/buildbuddy) and [Docker](https://github.com/buildbuddy-io/buildbuddy/blob/master/SETUP.md#docker-image)!
 
 Thanks to everyone that has tested open source and cloud-hosted BuildBuddy. We've made lots of improvements in this release based on your feedback.
 
-A special welcome to our newest contributor and **team member**:
+A special thank you to our new contributors:
 
-- [Brandon Duffany](https://github.com/bduffany) - Brandon is an ex-Googler and Cornell alumn who's worked as a software engineer on Google Assistant and Google Ads. He'll start off focused on surfacing better profiling and timing information to help users track down and fix slow builds!
+- [Sergio Rodriguez Orellana](https://github.com/SrodriguezO) who contributed support for making dense mode the default view mode.
+- [Tim Glaser](https://twitter.com/timgl?lang=en) who made some major improvements to our documentation.
 
-Our focus for this release was on expanding access to BuildBuddy as well as improving scalability and performance.
+Our focus for this release was on our new Remote Build Execution platform. This release marks a huge step in fulfilling our mission of making developers more productive by supporting the Bazel ecosystem.
 
-We're also excited to announce that we're expanding the BuildBuddy Cloud free tier. BuildBuddy Cloud is now **free for teams of up to 3 engineers** in addition to being free for individuals open source projects of any size.
+BuildBuddy's Remote Build Execution platform supports executing your Bazel build and tests in parallel across thousands of machines with automatic scaling, support for custom Docker images, and more. We've been iterating on and testing BuildBuddy RBE for months with companies of different sizes, and are excited to now make it available to everyone.
+
+While BuildBuddy RBE is not yet fully open source, we're offering Cloud RBE for free to individuals and open source projects to show our appreciation to the open source community.
+
+We'll be adding more documentation on getting started with BuildBuddy RBE in the coming weeks, but in the meantime feel free to email us at <rbe@buildbuddy.io> or ping us in the [BuildBuddy Slack](https://join.slack.com/t/buildbuddy/shared_invite/zt-e0cugoo1-GiHaFuzzOYBPQzl9rkUR_g) and we'll be happy to help you get started.
 
 ## **New to Open Source BuildBuddy**
 
-- **Official BuildBuddy Helm charts** - thanks to a [request](https://github.com/buildbuddy-io/buildbuddy/issues/35) from [Nathan Leung](https://github.com/nathanhleung) we've created official [BuildBuddy Helm Charts](https://github.com/buildbuddy-io/buildbuddy-helm) that are available for both [Open Source](https://github.com/buildbuddy-io/buildbuddy-helm/tree/master/charts/buildbuddy) and [Enterprise](https://github.com/buildbuddy-io/buildbuddy-helm/tree/master/charts/buildbuddy-enterprise) deployments. [Helm](https://helm.sh/) enables you to deploy BuildBuddy to a Kubernetes cluster with a single command, and makes configuration a breeze. The charts can optionally take care of provisioning a MySQL instance, an Nginx ingress, and even Memcached.**‍**
+- **Cache & remote execution badges - **BuildBuddy invocations pages now show badges that indicate whether or not caching and remote execution are enabled. Clicking on these badges takes you to instructions on how to configure these if they're enabled for your BuildBuddy instance.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f5044fa08c11ed1be6b7ddb_Screen%20Shot%202020-09-02%20at%206.19.37%20PM.png)
+![](../static/img/blog/cache-badge.png)
 
-- **Build metadata** - a frequent request from users is the ability to associate a BuildBuddy invocation with a particular git commit and repo. To support this, we've added optional build metadata including repo URL, commit SHA, and CI role that can be passed up with your build. This metadata can be passed up using the **--build_metadata** flag, using a **--workspace_status_command** script, or using environment variables commonly set by CI providers like CircleCI, BuildKite, GitHub Actions, and others. More information on how to configure your metadata can be found in our [build metadata guide.](https://www.buildbuddy.io/docs/guide-metadata)
+- **Remote build execution configuration options** - the BuildBuddy configuration widget has now been updated to enable configuring of remote build execution if it's enabled for your BuildBuddy instance.
 
-- **GitHub commit status publishing** - now that you can configure build metadata to associate invocations with a GitHub repo and commit, we've added the ability to publish commit statuses straight to GitHub when you've set your metadata role to **CI**. To enable this feature, simply click **Link GitHub Account** in your BuildBuddy profile dropdown (if you're using self hosted BuildBuddy, you'll need to [create a Github OAuth app](https://www.buildbuddy.io/docs/config-github) and add it to your config.yaml file).
+![](../static/img/blog/config-options.png)
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f5044c5bc9cf35e30ca6fb2_Screen%20Shot%202020-09-02%20at%206.19.15%20PM.png)
+- **Better build status support** - BuildBuddy now better distinguishes between in-progress, failed, passed, and cancelled builds with new colorful status indicators, favicons, and more.
 
-BuildBuddy links directly on GitHub
+![](../static/img/blog/favicon.png)
 
-- **Improved cache hit rate** - we've made improvement to our Action Cache validation logic that should result in higher cache hit rates.
+- **Improved documentation and new website** - we've completely revamped the BuildBuddy documentation, and it's now sync'd between GitHub and [buildbuddy.io/docs/](https://buildbuddy.io/docs/), so your docs will be fresh regardless of where you're reading them. We'll be adding new sections on configuring RBE in the coming weeks. We've also completely revamped the BuildBuddy website to make it easier to navigate and perform actions like requesting a quote, or subscribing to our [newsletter](#wf-form-Newsletter-Form).
 
-- **New guides** - we've added new guides to our documentation, including our [Authentication Guide](https://www.buildbuddy.io/docs/guide-auth), [Build Metadata Guide](https://www.buildbuddy.io/docs/guide-metadata), [Remote Build Execution with Github Actions Guide](https://www.buildbuddy.io/docs/rbe-github-actions), with more coming soon. We've also started collecting troubleshooting documentation for common errors including [RBE Failures](https://www.buildbuddy.io/docs/troubleshooting-rbe), and [Slow Uploads](https://www.buildbuddy.io/docs/troubleshooting-slow-upload). Contributions [welcome](https://github.com/buildbuddy-io/buildbuddy/tree/master/docs)!
+![](../static/img/blog/docs.png)
 
-- **Target information in timing tab** - in Bazel 3.4.0, the experimental [flag](https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_profile_include_target_label) **--experimental_profile_include_target_label** was introduced which adds target information to profiling events. When this flag is enabled, this target information is now displayed in the BuildBuddy Timing tab.
+- **Test run grid** - BuildBuddy will now automatically display test runs as a grid when a single test target is run more than 10 times. This supports the use case of finding and fixing flaky tests by running them with **--runs_per_test=100**.
+
+![](../static/img/blog/test-runs.png)
+
+- **Performance and reliability improvements** - we put a lot of work into improving performance and reliability in this release. This includes changes like better event flushing (no more getting stuck on 15 build events), better shutdown behavior, speed improvements and optimizations in build artifact uploading and downloading, and more.
+
+‍
 
 ## New to Cloud & Enterprise BuildBuddy
 
-- **BuildBuddy Cloud is now free for teams of up to 3** - we want to make BuildBuddy available to every team - regardless of size. BuildBuddy has always been free for individuals and open source projects and today we're expanding this to teams of up to 3 engineers. As your team continues to grow, we have reasonably priced plans that scale from startups to the largest enterprises.
+- **Remote Build Execution** - BuildBuddy Cloud and enterprise on-prem now support Remote Build Execution. Features include custom Docker image support, automatic scaling, multiple caching layers, and more. Additional features like Mac support, viewing of remote build actions in BuildBuddy, and more are coming soon.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f50458c4b4e4668b318e974_Screen%20Shot%202020-09-02%20at%206.23.09%20PM.png)
+![](../static/img/blog/rbe.png)
 
-- **Distributed scheduler** - the scheduler is a core component of any remote execution platform. In many cases, it is a single point of failure that turns an otherwise robust system into a fragile, stateful service that's hard to scale. In BuildBuddy 1.2.1, we rewrote our **distributed** Remote Build Execution scheduler from the ground up based on many learnings and best practices from state-of-the-art systems like Apache Spark. This enables BuildBuddy to scale to handle the largest workloads with no single point of failure, single digit millisecond queue wait times, and fault tolerance that enables execution on preemptible nodes. This allows for more cost effective high availability configurations, and allows you to deploy new BuildBuddy releases without a blip in ongoing executions.
+- **Invocation grouping** - BuildBuddy invocations can now be grouped by commit and by repo. These can be populated in one of three ways:
 
-- **Remote asset API ** - in Bazel 3.0.0 the Remote Asset API was introduced along with the --experimental_remote_downloader [flag](https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_remote_downloader). In this release, we've added basic support for this experimental API.
+1.  automatically by common CI environments like CircleCI and GitHub actions
+2.  manually by using build flags **--build_metadata=REPO_URL=** and **--build_metadata=COMMIT_SHA=**‍
+3.  by using a **--workspace_status_command** script like [this one](https://github.com/buildbuddy-io/buildbuddy/blob/master/workspace_status.sh)
 
-- **Organization configuration** - we've added configuration options for on-prem installs that allow you to configure an organization's name and limit signups to emails from a specific domain. More information in the [org config documentation](https://www.buildbuddy.io/docs/config-org).
+![](../static/img/blog/commits.png)
 
-- **Configurable anonymous access** - we've added a configuration option that allows organizations with authentication configured to choose whether or not anonymous access should be enabled. Anonymous access is off by default when auth is configured. More information in the [auth config documentation](https://www.buildbuddy.io/docs/config-auth).
+- **New cloud endpoint** - BuildBuddy now exposes a L7 load balanced gRPCS cloud endpoint at **cloud.buildbuddy.io** which can be used for BES, cache, and remote execution (see our [.bazelrc](https://github.com/buildbuddy-io/buildbuddy/blob/master/.bazelrc#L25) for an example). We'll gradually be migrating users to this from the old events.buildbuddy.io, and cache.buildbuddy.io endpoints with port numbers.
 
-- **S3 cache support** - BuildBuddy [previously](https://github.com/buildbuddy-io/buildbuddy/pull/12) had support for using Amazon S3 as a backing store for build events. In this release, we've added Amazon S3 support for as a backing store for caching as well, with support for streaming, ContainsMulti, and more.
+- **Easier enterprise deployment** - deploying enterprise BuildBuddy is now just as easy as deploying open source BuildBuddy, with a one line install script that deploys to your Kubernetes cluster. It takes your [BuildBuddy configuration file](https://www.buildbuddy.io/docs/config) as a parameter so you can easily configure things to your needs.
 
 That's it for this release. Stay tuned for more updates coming soon!
 
-As always, we love your feedback - join our [Slack channel](https://slack.buildbuddy.io) or email us at <hello@buildbuddy.io> with any questions, comments, or thoughts.
+As always, we love your feedback - email us at <hello@buildbuddy.io> with any questions, comments, or thoughts.

--- a/website/blog/buildbuddy-v1-2-1-release-notes.md
+++ b/website/blog/buildbuddy-v1-2-1-release-notes.md
@@ -1,75 +1,62 @@
 ---
-slug: buildbuddy-v1-1-0-release-notes
-title: BuildBuddy v1.1.0 Release Notes
+slug: buildbuddy-v1-2-1-release-notes
+title: BuildBuddy v1.2.1 Release Notes
 author: Siggi Simonarson
 author_title: Co-founder @ BuildBuddy
 date: 2020-09-03:12:00:00
 author_url: https://www.linkedin.com/in/siggisim/
 author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
-tags: [product, release-notes]
+tags: [product, release-notes, team]
 ---
 
-Excited to share that v1.1.0 of BuildBuddy is live on both [Cloud Hosted BuildBuddy](https://app.buildbuddy.io/) and open source via [Github](https://github.com/buildbuddy-io/buildbuddy) and [Docker](https://github.com/buildbuddy-io/buildbuddy/blob/master/SETUP.md#docker-image)!
+Excited to share that v1.2.1 of BuildBuddy is live on both [Cloud Hosted BuildBuddy](https://app.buildbuddy.io/) and open source via [Github](https://github.com/buildbuddy-io/buildbuddy) and [Docker](https://github.com/buildbuddy-io/buildbuddy/blob/master/docs/on-prem.md#docker-image)!
 
 Thanks to everyone that has tested open source and cloud-hosted BuildBuddy. We've made lots of improvements in this release based on your feedback.
 
-A special thank you to our new contributors:
+A special welcome to our newest contributor and **team member**:
 
-- [Sergio Rodriguez Orellana](https://github.com/SrodriguezO) who contributed support for making dense mode the default view mode.
-- [Tim Glaser](https://twitter.com/timgl?lang=en) who made some major improvements to our documentation.
+- [Brandon Duffany](https://github.com/bduffany) - Brandon is an ex-Googler and Cornell alumn who's worked as a software engineer on Google Assistant and Google Ads. He'll start off focused on surfacing better profiling and timing information to help users track down and fix slow builds!
 
-Our focus for this release was on our new Remote Build Execution platform. This release marks a huge step in fulfilling our mission of making developers more productive by supporting the Bazel ecosystem.
+Our focus for this release was on expanding access to BuildBuddy as well as improving scalability and performance.
 
-BuildBuddy's Remote Build Execution platform supports executing your Bazel build and tests in parallel across thousands of machines with automatic scaling, support for custom Docker images, and more. We've been iterating on and testing BuildBuddy RBE for months with companies of different sizes, and are excited to now make it available to everyone.
-
-While BuildBuddy RBE is not yet fully open source, we're offering Cloud RBE for free to individuals and open source projects to show our appreciation to the open source community.
-
-We'll be adding more documentation on getting started with BuildBuddy RBE in the coming weeks, but in the meantime feel free to email us at <rbe@buildbuddy.io> or ping us in the [BuildBuddy Slack](https://join.slack.com/t/buildbuddy/shared_invite/zt-e0cugoo1-GiHaFuzzOYBPQzl9rkUR_g) and we'll be happy to help you get started.
+We're also excited to announce that we're expanding the BuildBuddy Cloud free tier. BuildBuddy Cloud is now **free for teams of up to 3 engineers** in addition to being free for individuals open source projects of any size.
 
 ## **New to Open Source BuildBuddy**
 
-- **Cache & remote execution badges - **BuildBuddy invocations pages now show badges that indicate whether or not caching and remote execution are enabled. Clicking on these badges takes you to instructions on how to configure these if they're enabled for your BuildBuddy instance.
+- **Official BuildBuddy Helm charts** - thanks to a [request](https://github.com/buildbuddy-io/buildbuddy/issues/35) from [Nathan Leung](https://github.com/nathanhleung) we've created official [BuildBuddy Helm Charts](https://github.com/buildbuddy-io/buildbuddy-helm) that are available for both [Open Source](https://github.com/buildbuddy-io/buildbuddy-helm/tree/master/charts/buildbuddy) and [Enterprise](https://github.com/buildbuddy-io/buildbuddy-helm/tree/master/charts/buildbuddy-enterprise) deployments. [Helm](https://helm.sh/) enables you to deploy BuildBuddy to a Kubernetes cluster with a single command, and makes configuration a breeze. The charts can optionally take care of provisioning a MySQL instance, an Nginx ingress, and even Memcached.**‍**
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f46c467b18b5b9b9a054e_Screen%20Shot%202020-07-15%20at%2011.10.53%20AM.png)
+![](../static/img/blog/helm.png)
 
-- **Remote build execution configuration options** - the BuildBuddy configuration widget has now been updated to enable configuring of remote build execution if it's enabled for your BuildBuddy instance.
+- **Build metadata** - a frequent request from users is the ability to associate a BuildBuddy invocation with a particular git commit and repo. To support this, we've added optional build metadata including repo URL, commit SHA, and CI role that can be passed up with your build. This metadata can be passed up using the **--build_metadata** flag, using a **--workspace_status_command** script, or using environment variables commonly set by CI providers like CircleCI, BuildKite, GitHub Actions, and others. More information on how to configure your metadata can be found in our [build metadata guide.](https://www.buildbuddy.io/docs/guide-metadata)
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f5044fdd7a1168e60f04d_Screen%20Shot%202020-07-15%20at%2011.51.30%20AM.png)
+- **GitHub commit status publishing** - now that you can configure build metadata to associate invocations with a GitHub repo and commit, we've added the ability to publish commit statuses straight to GitHub when you've set your metadata role to **CI**. To enable this feature, simply click **Link GitHub Account** in your BuildBuddy profile dropdown (if you're using self hosted BuildBuddy, you'll need to [create a Github OAuth app](https://www.buildbuddy.io/docs/config-github) and add it to your config.yaml file).
 
-- **Better build status support** - BuildBuddy now better distinguishes between in-progress, failed, passed, and cancelled builds with new colorful status indicators, favicons, and more.
+![](../static/img/blog/commit-status.png)
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f482df789bfe48429ccdd_Screen%20Shot%202020-07-15%20at%2011.16.56%20AM.png)
+BuildBuddy links directly on GitHub
 
-- **Improved documentation and new website** - we've completely revamped the BuildBuddy documentation, and it's now sync'd between GitHub and [buildbuddy.io/docs/](https://buildbuddy.io/docs/), so your docs will be fresh regardless of where you're reading them. We'll be adding new sections on configuring RBE in the coming weeks. We've also completely revamped the BuildBuddy website to make it easier to navigate and perform actions like requesting a quote, or subscribing to our [newsletter](#wf-form-Newsletter-Form).
+- **Improved cache hit rate** - we've made improvement to our Action Cache validation logic that should result in higher cache hit rates.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f4c7722c95645285c77bc_Screen%20Shot%202020-07-15%20at%2011.35.08%20AM.png)
+- **New guides** - we've added new guides to our documentation, including our [Authentication Guide](https://www.buildbuddy.io/docs/guide-auth), [Build Metadata Guide](https://www.buildbuddy.io/docs/guide-metadata), [Remote Build Execution with Github Actions Guide](https://www.buildbuddy.io/docs/rbe-github-actions), with more coming soon. We've also started collecting troubleshooting documentation for common errors including [RBE Failures](https://www.buildbuddy.io/docs/troubleshooting-rbe), and [Slow Uploads](https://www.buildbuddy.io/docs/troubleshooting-slow-upload). Contributions [welcome](https://github.com/buildbuddy-io/buildbuddy/tree/master/docs)!
 
-- **Test run grid** - BuildBuddy will now automatically display test runs as a grid when a single test target is run more than 10 times. This supports the use case of finding and fixing flaky tests by running them with **--runs_per_test=100**.
-
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f4d62b65ec8097cb159df_Screen%20Shot%202020-07-15%20at%2011.38.57%20AM.png)
-
-- **Performance and reliability improvements** - we put a lot of work into improving performance and reliability in this release. This includes changes like better event flushing (no more getting stuck on 15 build events), better shutdown behavior, speed improvements and optimizations in build artifact uploading and downloading, and more.
-
-‍
+- **Target information in timing tab** - in Bazel 3.4.0, the experimental [flag](https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_profile_include_target_label) **--experimental_profile_include_target_label** was introduced which adds target information to profiling events. When this flag is enabled, this target information is now displayed in the BuildBuddy Timing tab.
 
 ## New to Cloud & Enterprise BuildBuddy
 
-- **Remote Build Execution** - BuildBuddy Cloud and enterprise on-prem now support Remote Build Execution. Features include custom Docker image support, automatic scaling, multiple caching layers, and more. Additional features like Mac support, viewing of remote build actions in BuildBuddy, and more are coming soon.
+- **BuildBuddy Cloud is now free for teams of up to 3** - we want to make BuildBuddy available to every team - regardless of size. BuildBuddy has always been free for individuals and open source projects and today we're expanding this to teams of up to 3 engineers. As your team continues to grow, we have reasonably priced plans that scale from startups to the largest enterprises.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f463422c9562d965c6e96_Screen%20Shot%202020-07-15%20at%2011.08.27%20AM.png)
+![](../static/img/blog/pricing.png)
 
-- **Invocation grouping** - BuildBuddy invocations can now be grouped by commit and by repo. These can be populated in one of three ways:
+- **Distributed scheduler** - the scheduler is a core component of any remote execution platform. In many cases, it is a single point of failure that turns an otherwise robust system into a fragile, stateful service that's hard to scale. In BuildBuddy 1.2.1, we rewrote our **distributed** Remote Build Execution scheduler from the ground up based on many learnings and best practices from state-of-the-art systems like Apache Spark. This enables BuildBuddy to scale to handle the largest workloads with no single point of failure, single digit millisecond queue wait times, and fault tolerance that enables execution on preemptible nodes. This allows for more cost effective high availability configurations, and allows you to deploy new BuildBuddy releases without a blip in ongoing executions.
 
-1.  automatically by common CI environments like CircleCI and GitHub actions
-2.  manually by using build flags **--build_metadata=REPO_URL=** and **--build_metadata=COMMIT_SHA=**‍
-3.  by using a **--workspace_status_command** script like [this one](https://github.com/buildbuddy-io/buildbuddy/blob/master/workspace_status.sh)
+- **Remote asset API ** - in Bazel 3.0.0 the Remote Asset API was introduced along with the --experimental_remote_downloader [flag](https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_remote_downloader). In this release, we've added basic support for this experimental API.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f4f1e86a5cb635333d937_Screen%20Shot%202020-07-15%20at%2011.46.30%20AM.png)
+- **Organization configuration** - we've added configuration options for on-prem installs that allow you to configure an organization's name and limit signups to emails from a specific domain. More information in the [org config documentation](https://www.buildbuddy.io/docs/config-org).
 
-- **New cloud endpoint** - BuildBuddy now exposes a L7 load balanced gRPCS cloud endpoint at **cloud.buildbuddy.io** which can be used for BES, cache, and remote execution (see our [.bazelrc](https://github.com/buildbuddy-io/buildbuddy/blob/master/.bazelrc#L25) for an example). We'll gradually be migrating users to this from the old events.buildbuddy.io, and cache.buildbuddy.io endpoints with port numbers.
+- **Configurable anonymous access** - we've added a configuration option that allows organizations with authentication configured to choose whether or not anonymous access should be enabled. Anonymous access is off by default when auth is configured. More information in the [auth config documentation](https://www.buildbuddy.io/docs/config-auth).
 
-- **Easier enterprise deployment** - deploying enterprise BuildBuddy is now just as easy as deploying open source BuildBuddy, with a one line install script that deploys to your Kubernetes cluster. It takes your [BuildBuddy configuration file](https://www.buildbuddy.io/docs/config) as a parameter so you can easily configure things to your needs.
+- **S3 cache support** - BuildBuddy [previously](https://github.com/buildbuddy-io/buildbuddy/pull/12) had support for using Amazon S3 as a backing store for build events. In this release, we've added Amazon S3 support for as a backing store for caching as well, with support for streaming, ContainsMulti, and more.
 
 That's it for this release. Stay tuned for more updates coming soon!
 
-As always, we love your feedback - email us at <hello@buildbuddy.io> with any questions, comments, or thoughts.
+As always, we love your feedback - join our [Slack channel](https://slack.buildbuddy.io) or email us at <hello@buildbuddy.io> with any questions, comments, or thoughts.

--- a/website/blog/buildbuddy-v1-3-0-release-notes.md
+++ b/website/blog/buildbuddy-v1-3-0-release-notes.md
@@ -9,67 +9,42 @@ author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
 tags: [product, release-notes]
 ---
 
-Excited to share that v1.1.0 of BuildBuddy is live on both [Cloud Hosted BuildBuddy](https://app.buildbuddy.io/) and open source via [Github](https://github.com/buildbuddy-io/buildbuddy) and [Docker](https://github.com/buildbuddy-io/buildbuddy/blob/master/SETUP.md#docker-image)!
+We're excited to share that v1.3.0 of BuildBuddy is live on both[ Cloud Hosted BuildBuddy](https://app.buildbuddy.io/) and open-source via[ Github](https://github.com/buildbuddy-io/buildbuddy) and[ Docker](https://github.com/buildbuddy-io/buildbuddy/blob/master/docs/on-prem.md#docker-image)!
 
-Thanks to everyone that has tested open source and cloud-hosted BuildBuddy. We've made lots of improvements in this release based on your feedback.
+Thanks to everyone using open source and cloud-hosted BuildBuddy. We’ve made lots of improvements in this release based on your feedback.
 
-A special thank you to our new contributors:
-
-- [Sergio Rodriguez Orellana](https://github.com/SrodriguezO) who contributed support for making dense mode the default view mode.
-- [Tim Glaser](https://twitter.com/timgl?lang=en) who made some major improvements to our documentation.
-
-Our focus for this release was on our new Remote Build Execution platform. This release marks a huge step in fulfilling our mission of making developers more productive by supporting the Bazel ecosystem.
-
-BuildBuddy's Remote Build Execution platform supports executing your Bazel build and tests in parallel across thousands of machines with automatic scaling, support for custom Docker images, and more. We've been iterating on and testing BuildBuddy RBE for months with companies of different sizes, and are excited to now make it available to everyone.
-
-While BuildBuddy RBE is not yet fully open source, we're offering Cloud RBE for free to individuals and open source projects to show our appreciation to the open source community.
-
-We'll be adding more documentation on getting started with BuildBuddy RBE in the coming weeks, but in the meantime feel free to email us at <rbe@buildbuddy.io> or ping us in the [BuildBuddy Slack](https://join.slack.com/t/buildbuddy/shared_invite/zt-e0cugoo1-GiHaFuzzOYBPQzl9rkUR_g) and we'll be happy to help you get started.
+Our focus for this release was on giving users new tools to improve build performance, debug cache hits, and a completely redesigned Cloud & Enterprise experience.
 
 ## **New to Open Source BuildBuddy**
 
-- **Cache & remote execution badges - **BuildBuddy invocations pages now show badges that indicate whether or not caching and remote execution are enabled. Clicking on these badges takes you to instructions on how to configure these if they're enabled for your BuildBuddy instance.
+- **Timing profile explorer **- Bazel's timing profile is the best way to get detailed insights into where to spend your time optimizing your build. Unfortunately, extracting useful information out of the thousands of events can be challenging without using something like Chrome's profiling tools. Now we've built these tools right into the BuildBuddy timing tab so you can explore this info for any build. See which actions dominate your build's critical path or find out how much time is spent downloading outputs - now with a single click.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f46c467b18b5b9b9a054e_Screen%20Shot%202020-07-15%20at%2011.10.53%20AM.png)
+![](../static/img/blog/timing-profile.png)
 
-- **Remote build execution configuration options** - the BuildBuddy configuration widget has now been updated to enable configuring of remote build execution if it's enabled for your BuildBuddy instance.
+Dive into the timing for every action, critical path information, and more.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f5044fdd7a1168e60f04d_Screen%20Shot%202020-07-15%20at%2011.51.30%20AM.png)
+- **Cache stats **- one of the feature requests we get most frequently is for more information on cache hits and misses. This data can be tricky to get a hold of because it's not made easily available by Bazel's build event protocol. That's why we've introduced BuildBuddy's new cache tab. It gives you a view into cache hits, misses, and writes for every invocation that uses BuildBuddy's gRPC cache. It breaks these numbers down by action cache (AC) and content addressable store (CAS). BuildBuddy also tracks the volume and throughput of cache requests so you can see how much data is moving in and out of the cache - and at what speed.
 
-- **Better build status support** - BuildBuddy now better distinguishes between in-progress, failed, passed, and cancelled builds with new colorful status indicators, favicons, and more.
+![](../static/img/blog/cache-stats.png)
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f482df789bfe48429ccdd_Screen%20Shot%202020-07-15%20at%2011.16.56%20AM.png)
+Get a view into cache performance for every invocation.
 
-- **Improved documentation and new website** - we've completely revamped the BuildBuddy documentation, and it's now sync'd between GitHub and [buildbuddy.io/docs/](https://buildbuddy.io/docs/), so your docs will be fresh regardless of where you're reading them. We'll be adding new sections on configuring RBE in the coming weeks. We've also completely revamped the BuildBuddy website to make it easier to navigate and perform actions like requesting a quote, or subscribing to our [newsletter](#wf-form-Newsletter-Form).
+- **Environment variable redaction controls** - when debugging cache hits, it can be useful to get a full picture of the inputs that are affecting a particular build - like the PATH environment variable. By default, BuildBuddy redacts nearly all environment variables passed into Bazel. We've added controls per invocation that allow you to optionally allow environment variables of your choice to skip redaction. Information on configuring this can be found in our[ build metadata docs](https://www.buildbuddy.io/docs/guide-metadata#environment-variable-redacting).
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f4c7722c95645285c77bc_Screen%20Shot%202020-07-15%20at%2011.35.08%20AM.png)
+## **New to Cloud & Enterprise BuildBuddy**
 
-- **Test run grid** - BuildBuddy will now automatically display test runs as a grid when a single test target is run more than 10 times. This supports the use case of finding and fixing flaky tests by running them with **--runs_per_test=100**.
+- **Redesigned navigation **- as BuildBuddy has grown from a debugging tool to a fully-featured platform to debug, analyze, monitor, and share builds across your organization, we've outgrown the minimal navigation setup that has gotten us this far. In Cloud and Enterprise BuildBuddy, we've replaced the top menu bar with a more fully-featured left-nav. This gives us room to add new features like Trends and provides easier access to critical pages like Setup & Docs.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f4d62b65ec8097cb159df_Screen%20Shot%202020-07-15%20at%2011.38.57%20AM.png)
+![](../static/img/blog/navigation.png)
 
-- **Performance and reliability improvements** - we put a lot of work into improving performance and reliability in this release. This includes changes like better event flushing (no more getting stuck on 15 build events), better shutdown behavior, speed improvements and optimizations in build artifact uploading and downloading, and more.
+The new navigation makes room for new features.
 
-‍
+- **Trends **- BuildBuddy has lots of information about every invocation that it collects. Now with Trends, you can follow how your builds are changing over time. Have all of the cache improvements you've been working on decreased average build time over the last month? Has the addition of a new external dependency significantly increased the length of your slowest builds? Answering these questions is easy with BuildBuddy Trends.
 
-## New to Cloud & Enterprise BuildBuddy
+![](../static/img/blog/trends-v0.png)
 
-- **Remote Build Execution** - BuildBuddy Cloud and enterprise on-prem now support Remote Build Execution. Features include custom Docker image support, automatic scaling, multiple caching layers, and more. Additional features like Mac support, viewing of remote build actions in BuildBuddy, and more are coming soon.
+- **Redis Pub/Sub support **- we've added support for Redis Pub/Sub to significantly improve remote build execution performance. It's completely optional for on-prem deployments, but in our testing it's improved performance for builds with lots of small actions by a factor of 2x. No change is required for Cloud users - just enjoy the faster builds!
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f463422c9562d965c6e96_Screen%20Shot%202020-07-15%20at%2011.08.27%20AM.png)
+That’s it for this release. Stay tuned for more updates coming soon!
 
-- **Invocation grouping** - BuildBuddy invocations can now be grouped by commit and by repo. These can be populated in one of three ways:
-
-1.  automatically by common CI environments like CircleCI and GitHub actions
-2.  manually by using build flags **--build_metadata=REPO_URL=** and **--build_metadata=COMMIT_SHA=**‍
-3.  by using a **--workspace_status_command** script like [this one](https://github.com/buildbuddy-io/buildbuddy/blob/master/workspace_status.sh)
-
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5f0f4f1e86a5cb635333d937_Screen%20Shot%202020-07-15%20at%2011.46.30%20AM.png)
-
-- **New cloud endpoint** - BuildBuddy now exposes a L7 load balanced gRPCS cloud endpoint at **cloud.buildbuddy.io** which can be used for BES, cache, and remote execution (see our [.bazelrc](https://github.com/buildbuddy-io/buildbuddy/blob/master/.bazelrc#L25) for an example). We'll gradually be migrating users to this from the old events.buildbuddy.io, and cache.buildbuddy.io endpoints with port numbers.
-
-- **Easier enterprise deployment** - deploying enterprise BuildBuddy is now just as easy as deploying open source BuildBuddy, with a one line install script that deploys to your Kubernetes cluster. It takes your [BuildBuddy configuration file](https://www.buildbuddy.io/docs/config) as a parameter so you can easily configure things to your needs.
-
-That's it for this release. Stay tuned for more updates coming soon!
-
-As always, we love your feedback - email us at <hello@buildbuddy.io> with any questions, comments, or thoughts.
+As always, we love your feedback - join our[ Slack channel](https://slack.buildbuddy.io) or email us at hello@buildbuddy.io with any questions, comments, or thoughts.

--- a/website/blog/buildbuddy-v1-4-0-release-notes.md
+++ b/website/blog/buildbuddy-v1-4-0-release-notes.md
@@ -27,33 +27,33 @@ We're also excited to share that over the coming weeks and months, we'll be open
 
 - **Invocation sharing & visibility controls** - while you've always been able to share BuildBuddy links with members of your organization, it's been difficult to share invocations more broadly (in GitHub issues or on StackOverflow). Now that working from home is the new norm, sharing links to your build logs or invocations details and artifacts has become more important than ever. To support this, we've added a **Share** button on the invocation page that allows you to control visibility of your invocations (this can be disabled at the organization level). We've also disabled the expiration of invocations and build logs for everyone on BuildBuddy Cloud - so you can share BuildBuddy links with confidence.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5fad7e7e02aaaabf670ca163_Screen%20Shot%202020-11-12%20at%2010.25.43%20AM.png)
+![](../static/img/blog/share.png)
 
 - **Invocation diffing** - we've all run into the problem where a build works on your machine, but not on your coworker's machine. To support debugging these kinds of issues, we've added the ability to diff builds straight from the invocations page. This allows you to quickly find any flags or invocation details that may have changed between builds. Stay tuned for more diffing features here, including cache hit debugging and more.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5fad7f9eb7782df7e6d2ec76_Screen%20Shot%202020-11-12%20at%2010.31.25%20AM.png)
+![](../static/img/blog/compare.png)
 
 - **Suggested fixes** - as software engineers, we often find ourselves bumping into errors and issues that many others have bumped into before. A tool like BuildBuddy provides the perfect way to quickly surface these suggested fixes to developers quickly, without even so much as a Google search. We've started by adding suggestions for common issues that BuildBuddy users run into, but stay tuned for the ability to add your own custom fix suggestions and share them with your organization and beyond!
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5fad86d1f58677c468250e2c_Screen%20Shot%202020-11-12%20at%2011.01.13%20AM.png)
+![](../static/img/blog/suggested-fixes.png)
 
 - **Easy invocation deletion** - you can now delete your BuildBuddy invocations directly from the invocation page "three dot" menu in case you want to share an invocation and delete it when you're done.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5fad85c7ae39b0100858c2b8_Screen%20Shot%202020-11-12%20at%2010.56.53%20AM.png)
+![](../static/img/blog/deletion.png)
 
 ## New to Cloud & Enterprise BuildBuddy
 
 - **Cache stats & filters** - our trends page now allows you to see trends in caching performance broken down by the Action Cache (AC) and the Content Addressable Store (CAS). The trends page is now also filterable by CI vs non-CI builds, and by user, repo, commit, or host.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5fad8533a1566a7bd6c70deb_Screen%20Shot%202020-11-06%20at%2011.54.19%20AM.png)
+![](../static/img/blog/filtered-trends.png)
 
 - **Simplified API key header auth** - previously if you wanted to authenticate your BuildBuddy invocations using an API key (instead of using certificated based mTLS), you had to place your API key in each BuildBuddy flag that connected to BuildBuddy with YOUR_API_KEY@cloud.buildbuddy.io. This has been greatly simplified in this release with the support for the --remote_header flag, which allows you to more easily separate auth credentials into a separate .bazelrc file.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5fad8825c75ffe49d07e8b46_Screen%20Shot%202020-11-12%20at%2011.06.29%20AM.png)
+![](../static/img/blog/api-header.png)
 
 - **Organization creation and invitations** - you can now create organizations and send invitation links to others.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/5fad85aabb83d90aa2813edf_Screen%20Shot%202020-11-12%20at%2010.57.26%20AM.png)
+![](../static/img/blog/org-invites.png)
 
 - **Remote build execution performance and reliability improvements** - we've made a whole host of changes to our remote build execution executors and schedulers to make them more fault tolerant, easier to scale, and faster. We've also exposed support for executor pools on BuildBuddy Enterprise which allow you to route remote execution traffic based on OS, CPU architecture, GPU requirements, CPU/memory requirements, and more. Routing can be configured at both the platform and individual target level. Finally, we've added improved documentation to help get up and running with RBE more quickly.
 

--- a/website/blog/buildbuddy-v1-5-0-release-notes.md
+++ b/website/blog/buildbuddy-v1-5-0-release-notes.md
@@ -23,15 +23,15 @@ Our focus for this release was on giving users more visibility into test flakin
 
 - **Test flakiness dashboard** - one of the feature requests we get most frequently from BuildBuddy users is the ability to collect target-level data and analyze it across invocations. Today we're taking the first step in the direction with our new test dashboard. The test dashboard allows you to monitor per-target test statuses by commit - so you can quickly identify and fix flaky test targets that slow down developer velocity. It also has a timing view that gives you a heat-map to quickly identify slow targets. This is just the first step we're taking in exposing more target-level data and are excited to build additional features based on your feedback!
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/6010c6df601bb5e1c1e16a78_Screen%20Shot%202021-01-26%20at%205.49.46%20PM.png)
+![](../static/img/blog/test-grid.png)
 
 - **Prometheus metrics** - we've added a ton of new Prometheus metrics to BuildBuddy that allow open-source and Enterprise users to monitor not only BuildBuddy's performance, but the overall health of their developer productivity efforts. This allows you to hook into existing monitoring and alerting tools like Grafana to analyze and get notified when your developers are experiencing issues. Metrics include build duration, cache hit & miss rates, remote execution queue length, and more. For a full list of the new metrics we now expose, see our [Prometheus metric documentation](https://www.buildbuddy.io/docs/prometheus-metrics). Interested in some metrics that aren't on this list? Let us know!
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/6010ccfb707b665aa637bb30_Screen%20Shot%202021-01-26%20at%206.16.10%20PM.png)
+![](../static/img/blog/prometheus.png)
 
 - **Auto-scaling** - with the addition of our new Prometheus metrics, we've also made improvements to the autoscaling capabilities of BuildBuddy executors. Now in addition to scaling off of raw compute metrics like CPU and RAM, BuildBuddy executors can also be configured to scale based on executor queue length and other custom metrics. This allows you to achieve better performance under heavy load while also managing your compute resources more efficiently and cost-effectively.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/6010cd9f28a90e7c5a1dd1b4_Screen%20Shot%202021-01-26%20at%206.18.49%20PM.png)
+![](../static/img/blog/autoscaling-prometheus.png)
 
 - **Security hardening** - as part of our SOC 2 compliance controls, BuildBuddy undergoes regularly scheduled penetration tests by paid security professionals. This release contains fixes for all three non-critical findings from our January 2021 pen-test.
 

--- a/website/blog/buildbuddy-v1-8-0-release-notes.md
+++ b/website/blog/buildbuddy-v1-8-0-release-notes.md
@@ -31,11 +31,11 @@ Our focus for this release was on reliability, performance, improved documentati
 
 - **Read-only API keys** - when using Bazel remote caching, teams often need to configure which machines have write access to the cache. While Bazel has some flags to control cache writes, using these can be error prone and insecure. BuildBuddy now makes this easy by introducing the ability to create both read-only and read+write api keys on your organization settings page. You can create as many API keys (and certificates) as you'd like and distribute them to your CI machines, workstations, and other endpoints.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/60529f08fe396cda68cb1499_Screen%20Shot%202021-03-17%20at%205.29.09%20PM.png)
+![](../static/img/blog/read-only.png)
 
 - **Improved docs** - we've completely revamped [our documentation](https://docs.buildbuddy.io/) and added support for tables of contents, syntax highlighting, better navigation, dark mode (!!), interactive widgets, and an "Edit this page" button that links directly to the correct file in our [GitHub docs directory](https://github.com/buildbuddy-io/buildbuddy/tree/master/docs) for submitting pull requests. With these great new features, we'll be ramping up documentation on both new and existing BuildBuddy features to make the lives of BuildBuddy users easier.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/60529f3ecbd5bf1d4ccb635b_Screen%20Shot%202021-03-17%20at%205.30.45%20PM.png)
+![](../static/img/blog/docsv2.png)
 
 - **Testing improvements** - we've invested heavily in our testing infrastructure, adding new integration tests and test fixtures that make testing BuildBuddy's interactions with Bazel easier. This will lead to more stable releases and faster iteration cycles going forward.
 
@@ -43,11 +43,11 @@ Our focus for this release was on reliability, performance, improved documentati
 
 - **Buildkite integration -** invocations that are kicked off from Buildkite now link back to the Buildkite job that triggered them.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/6052a05f32acfea7cc471cbb_Screen%20Shot%202021-03-17%20at%205.35.16%20PM.png)
+![](../static/img/blog/buildkite.png)
 
 - **Grafana** - our [Helm charts](https://github.com/buildbuddy-io/buildbuddy-helm) make deploying BuildBuddy to Kubernetess cluster a breeze. One thing that's been tricky for many users has been accessing the Prometheus data that BuildBuddy exports in an easily digestible format. To fix this, we made it easy to [deploy Grafana and Prometheus](https://github.com/buildbuddy-io/buildbuddy-helm/tree/master/charts/buildbuddy-enterprise#example-with-prometheus--grafana) via our Helm charts with just a couple lines of configuration. It comes out of the box with a default dashboard that shows popular BuildBuddy metrics and can be easily extended to add more graphs.
 
-![](https://uploads-ssl.webflow.com/5eeba6a6c5230ea3d1a60d83/6052a1f479e3910be45d5c1f_Screen%20Shot%202021-03-17%20at%205.42.10%20PM.png)
+![](../static/img/blog/grafana.png)
 
 - **More to come** - we've been laying the groundwork for two major projects that will go live in the coming weeks to make building and testing your Bazel projects even faster.
 

--- a/website/blog/buildbuddy-v2-5-0-release-notes.md
+++ b/website/blog/buildbuddy-v2-5-0-release-notes.md
@@ -18,43 +18,43 @@ Thanks to everyone using open source, cloud-hosted, and enterprise BuildBuddy. W
 
 - **The new global filter** - BuildBuddy collects lots of build information across CI and local builds. In order to make navigating these builds easier, we've introduced a new global filter. The global filter allows you to filter by status and role on any page - with more options including user, repo, and branch coming soon.
 
-![](images/global_filter.png)
+![](../static/img/blog/global_filter.png)
 
 - **Date picker** - To complement the new global filter, we've also added a date picker. The date picker allows you to select a time range and see builds, trends, etc. for exactly the time period you're interested in.
 
-![](images/date_picker.png)
+![](../static/img/blog/date_picker.png)
 
 - **Clickable trends** - Now that you can filter any view by date, we've added a feature to the Trends page that allows you to click on a data point and be taken to a filtered view of builds from just that time period. As part of this change, the trends page now also respects your local time zone.
 
-![](images/trends.png)
+![](../static/img/blog/trends.png)
 
 - **Branch information** - BuildBuddy now collects information about a build's git branch in addition to the repo and commit info already collected. This makes it even easier to navigate your builds.
 
-![](images/branch.png)
+![](../static/img/blog/branch.png)
 
 - **Light terminal theme** - For those of you who suffer from eye strain when reading light text on dark backgrounds: we've heard your feedback. We've added a new light terminal theme that can be enabled in your personal settings.
 
-![](images/light_terminal.png)
+![](../static/img/blog/light_terminal.png)
 
 - **Improved flaky test support** - Flaky tests can destroy developer productivity. To make them easier to deal with, we've added a new feature that calls out flaky tests & timeouts more explicitly. We've also improved the behavior of our RBE to reduce flakes due to timeouts when caused by external factors like Docker image pulls.
 
-![](images/flaky_test.png)
+![](../static/img/blog/flaky_test.png)
 
 - **Remote executions tab** - We've had a hidden feature for a while that allowed you to click on the `Remote execution on` label to see an overview of remotely executed actions for RBE builds. We've now promoted this feature to its own `Executions` tab. With this change come new features like search and filtering.
 
-![](images/executions_tab.png)
+![](../static/img/blog/executions_tab.png)
 
 - **Action input & output files** - When clicking on an individual remotely executed actions, we now have a new file viewer that allows you to navigate the input files of the action. You can click on any of these files (as well as any output files the action has) to download them from the remote cache.
 
-![](images/file_tree.png)
+![](../static/img/blog/file_tree.png)
 
 - **Action timing** - The timing tab gives you a breakdown of execution timing from Bazel's point of view, but there's another story to tell from the remote executor's point of view. Action pages now show a visual breakdown of time spent in queue, downloading inputs, executing, and uploading outputs for each remotely executed action.
 
-![](images/action_timeline.png)
+![](../static/img/blog/action_timeline.png)
 
 - **Revamped settings page** - We've revamped the settings page to make it easier to manage your BuildBuddy account.
 
-![](images/settings.png)
+![](../static/img/blog/settings.png)
 
 - **And much much more** - Every release comes packed with so many new features, performance improvements and bug fixes that we can't get to them all. Here are some more highlights:
   - Support for serving static files from a CDN

--- a/website/blog/buildbuddy-v2-7-0-release-notes.md
+++ b/website/blog/buildbuddy-v2-7-0-release-notes.md
@@ -22,18 +22,18 @@ Thanks to everyone using open source, cloud-hosted, and enterprise BuildBuddy. W
 
 - **Build log improvements** - the build log viewer is core to the BuildBuddy experience. We've made a ton of improvements in this release to make this log viewing experience even better. Build logs are now **live** and update much more frequently. You can also now **search** build logs with a built-in search bar, **download** the raw build log text, and even **wrap** long lines.
 
-![](images/build_logs.png)
+![](../static/img/blog/build_logs.png)
 
 - **Cache miss debugging UI** - one of the requests we get most frequently is for help debugging remote cache misses. There's a [guide](https://docs.bazel.build/versions/main/remote-execution-caching-debug.html) in the Bazel documentation, but it can be cumbersome to follow. We've made this process easier by surfacing individual action cache misses directly on the BuildBuddy cache tab. This allows you to quickly dive into which targets and actions missed cache and compare them against previous builds. You can click on any of these action hashes to explore the action's input files, environment variables, and command arguments. This is just the first step in making cache misses easier to debug - we're working on making this process even easier.
 
-![](images/cache_misses.png)
+![](../static/img/blog/cache_misses.png)
 
 - **Member management & roles** - we've heard from many of the large organizations that we work with that they'd like to be able to limit which members of their organization are able to access certain BuildBuddy functionality - like editing organization settings. In order to support this, we've added a new member management UI on the BuildBuddy organization settings page. Here you can assign either `Admin` or `Developer` roles to members of your BuildBuddy organization.
 
-![](images/members.png)
+![](../static/img/blog/members.png)
 
 - **Usage page** - while our Trends page gives users great insight into how their build metrics are trending over time, it's less useful for getting a sense of your total BuildBuddy usage for the current month (and previous months). We've introduced a new Usage page that allows you to get a quick glance of the metrics that are important for billing.
-  ![](images/usage.png)
+  ![](../static/img/blog/usage.png)
 
 - **And much much more** - Every release comes packed with so many new features, performance improvements and bug fixes that we can't get to them all. Here are some more highlights:
   - Mac support for remote persistent workers


### PR DESCRIPTION
Some of the release notes blog post file names / contents got jumbled in the old blog migration.

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
