### PR TITLE
Fix a few minor compression issues

### DIFF
--- a/server/remote_cache/byte_stream_server/BUILD
+++ b/server/remote_cache/byte_stream_server/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//server/environment",
         "//server/interfaces",
+        "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/remote_cache/hit_tracker",
         "//server/remote_cache/namespace",

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -1,6 +1,7 @@
 package byte_stream_server
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"github.com/DataDog/zstd"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/hit_tracker"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/namespace"
@@ -119,7 +121,10 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 	defer reader.Close()
 
 	if r.GetCompressor() == repb.Compressor_ZSTD {
-		reader = NewZstdCompressor(reader)
+		reader, err = NewZstdCompressor(reader, r.GetDigest().GetSizeBytes())
+		if err != nil {
+			return status.InternalErrorf("Failed to compress blob: %s", err)
+		}
 		defer reader.Close()
 	}
 
@@ -481,7 +486,22 @@ func (d *zstdDecompressor) Close() error {
 	return lastErr
 }
 
-func NewZstdCompressor(reader io.Reader) io.ReadCloser {
+func NewZstdCompressor(reader io.Reader, decompressedLength int64) (io.ReadCloser, error) {
+	// Optimization: If we can send the whole response in one message,
+	// decompress all at once, instead of Read() then Close(), which may issue two
+	// separate responses since Close() may flush some buffered data.
+	if decompressedLength <= readBufSizeBytes {
+		buf := &bytes.Buffer{}
+		if _, err := io.Copy(buf, reader); err != nil {
+			return nil, err
+		}
+		out, err := zstd.Compress(make([]byte, 0, int(decompressedLength)), buf.Bytes())
+		if err != nil {
+			return nil, err
+		}
+		return cachetools.NewBytesReadSeekCloser(out), nil
+	}
+
 	pr, pw := io.Pipe()
 	go func() {
 		compressor := zstd.NewWriter(pw)
@@ -492,8 +512,15 @@ func NewZstdCompressor(reader io.Reader) io.ReadCloser {
 			pw.CloseWithError(err)
 		}(err)
 		if err := compressor.Close(); err != nil {
-			log.Errorf("Failed to close zstd writer; some zstd resources may not be cleaned up properly: %s", err)
+			// ErrClosePipe means the compressor tried to flush its remaining data to
+			// the pipe, but the pipe was closed since the client canceled their
+			// request or some other error occurred. This can be safely ignored;
+			// the compressor will still clean up properly in this case.
+			if err == io.ErrClosedPipe {
+				return
+			}
+			log.Errorf("Failed to close zstd writer: %s", err)
 		}
 	}()
-	return pr
+	return pr, nil
 }


### PR DESCRIPTION
* For very small blobs, fix an issue that we often issue multiple separate responses unnecessarily when the fully compressed blob could have been sent in a single response.
  * More generally, for streaming compression responses, each Read() from the compressor returns some number of bytes that is very different from our desired 1MB read buffer size. Since we directly pipe the compressor to the stream writer, this means we'll write smaller buffers with varying sizes depending on compression ratio as well as the compressor's window size, which determines how often it flushes. We can fix this by staging through an intermediate buffer that we only flush when it reaches 1MB. But the small fix in this PR should fix this issue for 99+% of blobs, and we will still want to keep this optimization anyway to avoid creating a streaming compressor+goroutine for the 99% case.
* Fix an error logged when the compressor tries to write its compressed output to a closed pipe, which just means that the client disconnected, so it can be safely ignored.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
