### PR TITLE
Make Xcode matching more percise

### DIFF
--- a/server/xcode/xcode_darwin.go
+++ b/server/xcode/xcode_darwin.go
@@ -59,8 +59,8 @@ func (x *xcodeLocator) PathsForVersionAndSDK(xcodeVersion string, sdk string) (s
 		xcodeVersion = defaultXcodeVersion
 	}
 
-	xv := x.xcodeVersionForVersionString(xcodeVersion)
-	if xv == nil {
+	xv, ok := x.versions[xcodeVersion]
+	if !ok {
 		var err error
 		if xcodeVersion == defaultXcodeVersion {
 			err = status.FailedPreconditionErrorf("Default Xcode version not set on remote executor and xcode-select set to an invalid path. Available Xcode versions are %s", versionsString(x.versions))
@@ -75,18 +75,6 @@ func (x *xcodeLocator) PathsForVersionAndSDK(xcodeVersion string, sdk string) (s
 	}
 	sdkRoot := fmt.Sprintf("%s/%s", xv.developerDirPath, sdkPath)
 	return xv.developerDirPath, sdkRoot, nil
-}
-
-// Returns the xcodeVersion most closely matching the version string.
-func (x *xcodeLocator) xcodeVersionForVersionString(version string) *xcodeVersion {
-	versionComponents := strings.Split(version, ".")
-	for i := range versionComponents {
-		subVersion := strings.Join(versionComponents[0:len(versionComponents)-i], ".")
-		if xcodeVersion, ok := x.versions[subVersion]; ok {
-			return xcodeVersion
-		}
-	}
-	return nil
 }
 
 // Locates all Xcode versions installed on the host machine.


### PR DESCRIPTION
If the following Xcode versions are installed:

- 12.0.0.12A7209
- 12.1.0.12A7403
- 12.1.1.12A7605b
- 12.2.0.12B45b

Then we map these input versions to these output versions:

- 12 - > 12.2.0.12B45b
- 12.0 -> 12.0.0.12A7209
- 12.0.0 -> 12.0.0.12A7209
- 12.0.0.12A7209 -> 12.0.0.12A7209
- 12.1 -> 12.1.1.12A7605b
- 12.1.0 -> 12.1.0.12A7403
- 12.1.0.12A7403 -> 12.1.0.12A7403
- 12.1.1 -> 12.1.1.12A7605b
- 12.1.1.12A7605b -> 12.1.1.12A7605b
- 12.2 -> 12.2.0.12B45b
- 12.2.0 -> 12.2.0.12B45b
- 12.2.0.12B45b -> 12.2.0.12B45b

To summarize, we map a less percise version to the highest available version it could match. This is good.

We _also_ currently take a fully qualified version, such as  12.5.0.12E262 and if it doesn't match one of the inputs available above, we make it less percise until it potentially matches: 12.5.0, 12.5, and finally 12. This means that 12.5.0.12E262 -> 12 - > 12.2.0.12B45b, which is invalid.

This commit removes that final step, meaning in the example above, 12.5.0.12E262 will return an error saying that Xcode version isn't available.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch