### PR TITLE
Use "partial clones" to speed up git checkouts.

### DIFF
--- a/enterprise/dockerfiles/ci_runner_image/Dockerfile
+++ b/enterprise/dockerfiles/ci_runner_image/Dockerfile
@@ -1,6 +1,7 @@
 FROM gcr.io/cloud-marketplace/google/rbe-ubuntu18-04@sha256:48b67b41118dbcdfc265e7335f454fbefa62681ab8d47200971fc7a52fb32054
 
-RUN apt-get update && apt-get install -y build-essential
+RUN add-apt-repository ppa:git-core/ppa
+RUN apt-get update && apt-get install -y build-essential git
 
 # Install bazelisk
 RUN curl -Lo /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.5/bazelisk-linux-amd64 && \

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -815,11 +815,10 @@ func (ws *workspace) setup(ctx context.Context, reporter *buildEventReporter) er
 	if err := os.Chdir(repoDirName); err != nil {
 		return status.WrapErrorf(err, "cd %q", repoDirName)
 	}
-	if err := git(ctx, ws.log, "init"); err != nil {
+	if err := ws.clone(ctx, *targetRepoURL); err != nil {
 		return err
 	}
-	// Don't use a credential helper since we always use explicit credentials.
-	if err := git(ctx, ws.log, "config", "--local", "credential.helper", ""); err != nil {
+	if err := ws.config(ctx); err != nil {
 		return err
 	}
 	return ws.sync(ctx)
@@ -847,11 +846,6 @@ func (ws *workspace) applyPatch(ctx context.Context, bsClient bspb.ByteStreamCli
 }
 
 func (ws *workspace) sync(ctx context.Context) error {
-	// Setup config before we do anything.
-	if err := ws.config(ctx); err != nil {
-		return err
-	}
-
 	// Fetch the pushed and target branches from their respective remotes.
 	// "base" here is referring to the repo on which the workflow is configured.
 	// "fork" is referring to the forked repo, if the runner was triggered by a
@@ -881,11 +875,8 @@ func (ws *workspace) sync(ctx context.Context) error {
 	}
 	// Create the branch if it doesn't already exist, then update it to point to
 	// the pushed branch tip.
-	if err := git(ctx, ws.log, "checkout", "-B", *pushedBranch); err != nil {
-		return err
-	}
 	remotePushedBranchRef := fmt.Sprintf("%s/%s", gitRemoteName(*pushedRepoURL), *pushedBranch)
-	if err := git(ctx, ws.log, "reset", "--hard", remotePushedBranchRef); err != nil {
+	if err := git(ctx, ws.log, "checkout", "-B", *pushedBranch, remotePushedBranchRef); err != nil {
 		return err
 	}
 	// Merge the target branch (if different from the pushed branch) so that the
@@ -938,6 +929,20 @@ func (ws *workspace) config(ctx context.Context) error {
 	return nil
 }
 
+func (ws *workspace) clone(ctx context.Context, remoteURL string) error {
+	authURL, err := gitutil.AuthRepoURL(remoteURL, os.Getenv(repoUserEnvVarName), os.Getenv(repoTokenEnvVarName))
+	if err != nil {
+		return err
+	}
+	writeCommandSummary(ws.log, "Cloning target repo...")
+	// Don't show command since the URL may contain the repo access token.
+	args := []string{"clone", "--config=credential.helper=", "--filter=blob:none", "--no-checkout", authURL, "."}
+	if err := runCommand(ctx, "git", args, map[string]string{}, ws.log); err != nil {
+		return status.UnknownError("Command `git clone --filter=blob:none --no-checkout <url>` failed.")
+	}
+	return nil
+}
+
 func (ws *workspace) fetch(ctx context.Context, remoteURL string, branches []string) error {
 	if len(branches) == 0 {
 		return nil
@@ -953,7 +958,7 @@ func (ws *workspace) fetch(ctx context.Context, remoteURL string, branches []str
 	if err := git(ctx, io.Discard, "remote", "add", remoteName, authURL); err != nil && !isRemoteAlreadyExists(err) {
 		return status.UnknownErrorf("Command `git remote add %q <url>` failed.", remoteName)
 	}
-	fetchArgs := append([]string{"fetch", "--force", remoteName}, branches...)
+	fetchArgs := append([]string{"fetch", "--filter=blob:none", "--force", remoteName}, branches...)
 	if err := git(ctx, ws.log, fetchArgs...); err != nil {
 		return err
 	}

--- a/enterprise/server/cmd/ci_runner/run_local.sh
+++ b/enterprise/server/cmd/ci_runner/run_local.sh
@@ -62,7 +62,7 @@ docker run \
   --interactive \
   --tty \
   --rm \
-  gcr.io/flame-public/buildbuddy-ci-runner:v2.2.7 \
+  gcr.io/flame-public/buildbuddy-ci-runner:v2.2.8 \
   ci_runner \
   --pushed_repo_url="file:///root/mounted_repo" \
   --target_repo_url="file:///root/mounted_repo" \

--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -9,7 +9,7 @@ go_test(
     # Run the ci_runner_test in the same environment that the CI runner uses in prod,
     # since we invoke the ci runner binary directly.
     exec_properties = {
-        "container-image": "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.2.7",
+        "container-image": "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.2.8",
     },
     shard_count = 6,
     visibility = [

--- a/enterprise/server/test/integration/workflow/BUILD
+++ b/enterprise/server/test/integration/workflow/BUILD
@@ -7,7 +7,7 @@ go_test(
     # currently does not support dockerized execution of commands. So for now we
     # run the whole test using the CI runner image.
     exec_properties = {
-        "container-image": "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.2.7",
+        "container-image": "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.2.8",
     },
     shard_count = 2,
     deps = [

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -44,7 +44,7 @@ import (
 )
 
 const (
-	workflowsImage = "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.2.7"
+	workflowsImage = "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.2.8"
 )
 
 var (


### PR DESCRIPTION
Use "partial clones" to speed up git checkouts.

The partial clone feature allows delaying fetching relevant blobs until they are
actually needed (e.g. when checking out a branch).

This is particularly useful for cold Hosted Bazel instances.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
