### PR TITLE
Allow running executor without any Xcode installed

### DIFF
--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -143,10 +143,7 @@ func GetConfiguredEnvironmentOrDie(configurator *config.Configurator, healthChec
 		log.Infof("No authentication will be configured: %s", err)
 	}
 
-	xl, err := xcode.NewXcodeLocator()
-	if err != nil {
-		log.Fatalf("Failed to set XcodeLocator: %s", err)
-	}
+	xl := xcode.NewXcodeLocator()
 	realEnv.SetXcodeLocator(xl)
 
 	if gcsCacheConfig := configurator.GetCacheGCSConfig(); gcsCacheConfig != nil {

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -589,10 +589,7 @@ func (r *Env) addExecutor(options *ExecutorOptions) *Executor {
 	env.SetRemoteExecutionClient(repb.NewExecutionClient(clientConn))
 	env.SetSchedulerClient(scpb.NewSchedulerClient(clientConn))
 	env.SetAuthenticator(r.newTestAuthenticator())
-	xl, err := xcode.NewXcodeLocator()
-	if err != nil {
-		assert.FailNowf(r.t, "Failed to set XcodeLocator: %s", err.Error())
-	}
+	xl := xcode.NewXcodeLocator()
 	env.SetXcodeLocator(xl)
 
 	bundleFS, err := bundle.Get()

--- a/server/xcode/xcode.go
+++ b/server/xcode/xcode.go
@@ -6,8 +6,8 @@ package xcode
 type xcodeLocator struct {
 }
 
-func NewXcodeLocator() (*xcodeLocator, error) {
-	return &xcodeLocator{}, nil
+func NewXcodeLocator() *xcodeLocator {
+	return &xcodeLocator{}
 }
 
 func (x *xcodeLocator) DeveloperDirForVersion(version string) (string, error) {


### PR DESCRIPTION
I forgot to make this change when adding support for the Command Line Tools. Technically it's not an error to not have any Xcodes installed, but we will still warn when this happens.

---

**Version bump**: Patch
