### PR TITLE
Run ci_runner_test and workflow_test using CI runner image

### DIFF
--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -6,6 +6,11 @@ go_test(
     data = [
         "//enterprise/server/cmd/ci_runner",
     ],
+    # Run the ci_runner_test in the same environment that the CI runner uses in prod,
+    # since we invoke the ci runner binary directly.
+    exec_properties = {
+        "container-image": "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.2.7",
+    },
     shard_count = 6,
     visibility = [
         "//enterprise:__subpackages__",

--- a/enterprise/server/test/integration/workflow/BUILD
+++ b/enterprise/server/test/integration/workflow/BUILD
@@ -3,6 +3,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "workflow_test",
     srcs = ["workflow_test.go"],
+    # ci_runner gets invoked directly by this test since the RBE test framework
+    # currently does not support dockerized execution of commands. So for now we
+    # run the whole test using the CI runner image.
+    exec_properties = {
+        "container-image": "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.2.7",
+    },
     shard_count = 2,
     deps = [
         "//enterprise/server/invocation_search_service",


### PR DESCRIPTION
This ensures that the `ci_runner`, when invoked in these tests, runs in the same environment that it would in production. In particular, this ensures it is using the same version of `git` that we use in prod.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
