### PR TITLE
Allow mixing of self-hosted and cloud-hosted executors

### DIFF
--- a/enterprise/app/executors/executor_card.tsx
+++ b/enterprise/app/executors/executor_card.tsx
@@ -10,10 +10,10 @@ interface Props {
 export default class ExecutorCardComponent extends React.Component<Props> {
   render() {
     const node = this.props.executor.node;
-    const enabled = this.props.executor.enabled;
+    const isDefault = this.props.executor.isDefault;
 
     return (
-      <div className={`card ${enabled ? "card-success" : "card-failure"}`}>
+      <div className={`card ${isDefault ? "card-success" : "card-neutral"}`}>
         <Cloud className="icon" />
         <div className="details">
           <div className="executor-section">
@@ -39,8 +39,8 @@ export default class ExecutorCardComponent extends React.Component<Props> {
             <div>{node.version}</div>
           </div>
           <div className="executor-section">
-            <div className="executor-section-title">Status:</div>
-            <div>{enabled ? "Enabled" : "Disabled"}</div>
+            <div className="executor-section-title">Default:</div>
+            <div>{isDefault ? "True" : "False"}</div>
           </div>
         </div>
       </div>

--- a/enterprise/app/executors/executors.tsx
+++ b/enterprise/app/executors/executors.tsx
@@ -122,8 +122,8 @@ class ExecutorSetup extends React.Component<ExecutorSetupProps> {
             </div>
             <h2>2. Deploy executors</h2>
             <ExecutorDeploy executorKeys={this.props.executorKeys} schedulerUri={this.props.schedulerUri} />
-            <h2>3. Switch to self-hosted executors in organization settings</h2>
-            <p>Enable "Use self-hosted executors" on the Organization Settings page.</p>
+            <h2>3. Default to self-hosted executors in organization settings</h2>
+            <p>Enable "Default to self-hosted executors" on the Organization Settings page.</p>
             <FilledButton className="organization-settings-button">
               <a href="/settings/" onClick={linkHandler("/settings")}>
                 Open settings
@@ -317,13 +317,13 @@ export default class ExecutorsComponent extends React.Component<Props, State> {
         </div>
         {activeTab === "status" && (
           <>
-            {this.state.nodes.some((node) => !node.enabled) && (
+            {this.state.nodes.some((node) => !node.isDefault) && (
               <div className="callout warning-callout">
                 <AlertCircle className="icon orange" />
                 <div className="callout-content">
                   <div>
-                    Some executors are disabled since your organization is using BuildBuddy Cloud executors. To fix
-                    this, enable self-hosted executors in settings.
+                    Self-hosted executors are not the default for this organization. To change this, enable "Default to
+                    self-hosted executors" in your organization settings.
                   </div>
                   <div>
                     <FilledButton className="organization-settings-button">

--- a/enterprise/app/org/org_form.tsx
+++ b/enterprise/app/org/org_form.tsx
@@ -170,11 +170,7 @@ export default abstract class OrgForm<T extends GroupRequest> extends React.Comp
               name="useGroupOwnedExecutors"
               checked={request.useGroupOwnedExecutors}
             />
-            {capabilities.config.forceUserOwnedDarwinExecutors ? (
-              <span>Use self-hosted Linux executors</span>
-            ) : (
-              <span>Use self-hosted executors</span>
-            )}
+            <span>Default to self-hosted executors</span>
           </label>
         )}
       </>

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -307,7 +307,7 @@ func (s *ExecutionServer) Dispatch(ctx context.Context, req *repb.ExecuteRequest
 
 	props := platform.ParseProperties(executionTask)
 
-	executorGroupID, defaultPool, err := s.env.GetSchedulerService().GetGroupIDAndDefaultPoolForUser(ctx, props.OS)
+	executorGroupID, defaultPool, err := s.env.GetSchedulerService().GetGroupIDAndDefaultPoolForUser(ctx, props.OS, props.UseSelfHostedExecutors)
 	if err != nil {
 		return "", err
 	}

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -52,6 +52,7 @@ const (
 	workloadIsolationPropertyName        = "workload-isolation-type"
 	enableVFSPropertyName                = "enable-vfs"
 	HostedBazelAffinityKeyPropertyName   = "hosted-bazel-affinity-key"
+	useSelfHostedExecutorsPropertyName   = "use-self-hosted-executors"
 
 	operatingSystemPropertyName = "OSFamily"
 	LinuxOperatingSystemName    = "linux"
@@ -112,6 +113,7 @@ type Properties struct {
 	PersistentWorkerProtocol string
 	WorkflowID               string
 	HostedBazelAffinityKey   string
+	UseSelfHostedExecutors   bool
 }
 
 // ContainerType indicates the type of containerization required by an executor.
@@ -163,6 +165,7 @@ func ParseProperties(task *repb.ExecutionTask) *Properties {
 		PersistentWorkerProtocol:  stringProp(m, persistentWorkerProtocolPropertyName, ""),
 		WorkflowID:                stringProp(m, WorkflowIDPropertyName, ""),
 		HostedBazelAffinityKey:    stringProp(m, HostedBazelAffinityKeyPropertyName, ""),
+		UseSelfHostedExecutors:    boolProp(m, useSelfHostedExecutorsPropertyName, false),
 	}
 }
 

--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "scheduler_server",
@@ -26,5 +26,18 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//peer",
+    ],
+)
+
+go_test(
+    name = "scheduler_server_test",
+    srcs = ["scheduler_server_test.go"],
+    embed = [":scheduler_server"],
+    deps = [
+        "//enterprise/server/testutil/enterprise_testenv",
+        "//enterprise/server/testutil/testredis",
+        "//server/interfaces",
+        "//server/testutil/testauth",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -35,7 +35,6 @@ go_test(
     embed = [":scheduler_server"],
     deps = [
         "//enterprise/server/testutil/enterprise_testenv",
-        "//enterprise/server/testutil/testredis",
         "//server/interfaces",
         "//server/testutil/testauth",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -1,0 +1,118 @@
+package scheduler_server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
+
+	"github.com/stretchr/testify/require"
+)
+
+func getScheduleServer(t *testing.T, userOwnedEnabled, groupOwnedEnabled bool, user string) (*SchedulerServer, context.Context) {
+	env := enterprise_testenv.GetCustomTestEnv(t, &enterprise_testenv.Options{})
+	env.GetConfigurator().GetRemoteExecutionConfig().DefaultPoolName = "defaultPoolName"
+	env.GetConfigurator().GetRemoteExecutionConfig().SharedExecutorPoolGroupID = "sharedGroupID"
+
+	s := &SchedulerServer{env: env}
+
+	testUsers := make(map[string]interfaces.UserInfo, 0)
+	testUsers["user1"] = &testauth.TestUser{UserID: "user1", GroupID: "group1", UseGroupOwnedExecutors: groupOwnedEnabled}
+
+	ta := testauth.NewTestAuthenticator(testUsers)
+	env.SetAuthenticator(ta)
+	s.enableUserOwnedExecutors = userOwnedEnabled
+
+	ctx := context.Background()
+	if user != "" {
+		authenticatedCtx, err := ta.WithAuthenticatedUser(context.Background(), user)
+		require.NoError(t, err)
+		ctx = authenticatedCtx
+	}
+	return s, ctx
+}
+
+func TestSchedulerServerGetGroupIDAndDefaultPoolForUserUserOwnedDisabled(t *testing.T) {
+	s, ctx := getScheduleServer(t, false, false, "")
+	g, p, err := s.GetGroupIDAndDefaultPoolForUser(ctx, "linux", false)
+	require.NoError(t, err)
+	require.Equal(t, "", g)
+	require.Equal(t, "defaultPoolName", p)
+}
+
+func TestSchedulerServerGetGroupIDAndDefaultPoolForUserNoAuth(t *testing.T) {
+	s, ctx := getScheduleServer(t, true, false, "")
+	g, p, err := s.GetGroupIDAndDefaultPoolForUser(ctx, "linux", false)
+	require.NoError(t, err)
+	require.Equal(t, "sharedGroupID", g)
+	require.Equal(t, "defaultPoolName", p)
+}
+
+func TestSchedulerServerGetGroupIDAndDefaultPoolForUserWithOS(t *testing.T) {
+	s, ctx := getScheduleServer(t, true, false, "user1")
+	s.forceUserOwnedDarwinExecutors = false
+	g, p, err := s.GetGroupIDAndDefaultPoolForUser(ctx, "linux", false)
+	require.NoError(t, err)
+	require.Equal(t, "sharedGroupID", g)
+	require.Equal(t, "defaultPoolName", p)
+
+	g, p, err = s.GetGroupIDAndDefaultPoolForUser(ctx, "darwin", false)
+	require.NoError(t, err)
+	require.Equal(t, "sharedGroupID", g)
+	require.Equal(t, "defaultPoolName", p)
+
+	s.forceUserOwnedDarwinExecutors = true
+	g, p, err = s.GetGroupIDAndDefaultPoolForUser(ctx, "linux", false)
+	require.NoError(t, err)
+	require.Equal(t, "sharedGroupID", g)
+	require.Equal(t, "defaultPoolName", p)
+
+	g, p, err = s.GetGroupIDAndDefaultPoolForUser(ctx, "darwin", false)
+	require.NoError(t, err)
+	require.Equal(t, "group1", g)
+	require.Equal(t, "", p)
+}
+
+func TestSchedulerServerGetGroupIDAndDefaultPoolForUserDarwin(t *testing.T) {
+	s, ctx := getScheduleServer(t, true, false, "")
+	g, p, err := s.GetGroupIDAndDefaultPoolForUser(ctx, "linux", false)
+	require.NoError(t, err)
+	require.Equal(t, "sharedGroupID", g)
+	require.Equal(t, "defaultPoolName", p)
+}
+
+func TestSchedulerServerGetGroupIDAndDefaultPoolForUserDarwinNoAuth(t *testing.T) {
+	s, ctx := getScheduleServer(t, true, false, "")
+	s.forceUserOwnedDarwinExecutors = true
+	_, _, err := s.GetGroupIDAndDefaultPoolForUser(ctx, "darwin", false)
+	require.Error(t, err)
+}
+
+func TestSchedulerServerGetGroupIDAndDefaultPoolForUserSelfHostedNoAuth(t *testing.T) {
+	s, ctx := getScheduleServer(t, true, false, "")
+	_, _, err := s.GetGroupIDAndDefaultPoolForUser(ctx, "linux", true)
+	require.Error(t, err)
+}
+
+func TestSchedulerServerGetGroupIDAndDefaultPoolForUserSelfHosted(t *testing.T) {
+	s, ctx := getScheduleServer(t, true, false, "user1")
+	g, p, err := s.GetGroupIDAndDefaultPoolForUser(ctx, "linux", true)
+	require.NoError(t, err)
+	require.Equal(t, "group1", g)
+	require.Equal(t, "", p)
+}
+
+func TestSchedulerServerGetGroupIDAndDefaultPoolForUserSelfHostedByDefault(t *testing.T) {
+	s, ctx := getScheduleServer(t, true, true, "user1")
+	g, p, err := s.GetGroupIDAndDefaultPoolForUser(ctx, "linux", false)
+	require.NoError(t, err)
+	require.Equal(t, "group1", g)
+	require.Equal(t, "", p)
+
+	g, p, err = s.GetGroupIDAndDefaultPoolForUser(ctx, "linux", true)
+	require.NoError(t, err)
+	require.Equal(t, "group1", g)
+	require.Equal(t, "", p)
+}

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -217,9 +217,8 @@ message GetExecutionNodesResponse {
   message Executor {
     ExecutionNode node = 1;
 
-    // Whether tasks can be routed to this node. If this is false, it is likely
-    // due to a misconfiguration.
-    bool enabled = 2;
+    // Whether tasks will be routed to this node by default.
+    bool is_default = 2;
   }
 
   bool user_owned_executors_supported = 3;

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -418,7 +418,7 @@ type SchedulerService interface {
 	EnqueueTaskReservation(ctx context.Context, req *scpb.EnqueueTaskReservationRequest) (*scpb.EnqueueTaskReservationResponse, error)
 	ReEnqueueTask(ctx context.Context, req *scpb.ReEnqueueTaskRequest) (*scpb.ReEnqueueTaskResponse, error)
 	GetExecutionNodes(ctx context.Context, req *scpb.GetExecutionNodesRequest) (*scpb.GetExecutionNodesResponse, error)
-	GetGroupIDAndDefaultPoolForUser(ctx context.Context, os string) (string, string, error)
+	GetGroupIDAndDefaultPoolForUser(ctx context.Context, os string, useSelfHosted bool) (string, string, error)
 }
 
 type ExecutionService interface {


### PR DESCRIPTION
This PR enables users to choose whether or not to use self-hosted executors at the action level.

It does so by introducing a new platform property called `use-self-hosted-executors`.

For folks that only want to use self-hosted executors, there is still an organization-level switch that defaults all invocations to self-hosted executors, and disallows the use of cloud-hosted executors.

The wording of this switch updated slightly to `Use self-hosted executors ` => `Default to self-hosted executors` but the functionality effectively remains the same for existing users.

Also updated the "Enabled" language for executors to "Default" to match this behavior.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
