### PR TITLE
Fix error returned by uuid.GetHostID when running some tests locally

### DIFF
--- a/server/testutil/testenv/BUILD
+++ b/server/testutil/testenv/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//server/util/grpc_client",
         "//server/util/healthcheck",
         "//server/util/log",
-        "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//test/bufconn",
     ],

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io/ioutil"
 	"net"
-	"os"
 	"path/filepath"
 	"testing"
 	"text/template"
@@ -20,7 +19,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 
@@ -124,29 +122,11 @@ func writeTmpConfigFile(testRootDir string) (string, error) {
 	return configPath, nil
 }
 
-func ensureHomeDir(t testing.TB) {
-	// uuid.GetHostID (used in several places) requires either XDG_CONFIG_HOME or
-	// HOME to be set, otherwise it will return an error. So we initialize HOME to
-	// a test-scoped temp directory if neither of these are set. This is needed
-	// for tests where Bazel sandboxing is disabled.
-	home := os.Getenv("HOME")
-	if home == "" {
-		home = os.Getenv("XDG_CONFIG_HOME")
-	}
-	if home == "" {
-		home = testfs.MakeTempDir(t)
-		err := os.Setenv("HOME", home)
-		require.NoError(t, err)
-	}
-}
-
 // All instances of the configurator use the same config struct instance in order to support flag overrides.
 // We instantiate a single configurator per test to avoid triggering the race detector.
 var currentConfigurator *config.Configurator
 
 func GetTestEnv(t testing.TB) *TestEnv {
-	ensureHomeDir(t)
-
 	testRootDir := testfs.MakeTempDir(t)
 	tmpConfigFile, err := writeTmpConfigFile(testRootDir)
 	if err != nil {

--- a/server/util/uuid/uuid.go
+++ b/server/util/uuid/uuid.go
@@ -59,7 +59,12 @@ func StringToBytes(text string) ([]byte, error) {
 	return uuidBytes, nil
 }
 
-func getOrCreateHostId() (string, error) {
+func configDir() (string, error) {
+	// HOME and XDG_CONFIG_HOME may not be defined when running with `bazel test`.
+	if testTmpDir := os.Getenv("TEST_TMPDIR"); testTmpDir != "" {
+		return os.MkdirTemp(testTmpDir, "buildbuddy-config-*")
+	}
+
 	userConfigDir, err := os.UserConfigDir()
 	if err != nil {
 		// Home dir is not defined
@@ -67,6 +72,14 @@ func getOrCreateHostId() (string, error) {
 	}
 	configDirPath := path.Join(userConfigDir, configDirName)
 	err = os.MkdirAll(configDirPath, 0755)
+	if err != nil {
+		return "", err
+	}
+	return configDirPath, nil
+}
+
+func getOrCreateHostId() (string, error) {
+	configDirPath, err := configDir()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
For some reason, HOME and XDG_CONFIG_HOME don't seem to be defined when running `bazel test //...` locally, but they _are_ defined when running remotely, at least on my machine. So `os.UserConfigDir` returns an error. Fixed by detecting TEST_TMPDIR and using that instead.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
