### PR TITLE
Have Hosted Bazel runs be displayed more naturally in the UI.

### DIFF
--- a/app/invocation/child_invocation_card.tsx
+++ b/app/invocation/child_invocation_card.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import format from "../format/format";
 import router from "../router/router";
-import { BazelCommandResult } from "./workflow_commands";
+import { BazelCommandResult } from "./child_invocations";
 
-export type WorkflowCommandsCardProps = {
+export type ChildInvocationCardProps = {
   status: string;
   results: BazelCommandResult[];
   className: string;
@@ -11,7 +11,7 @@ export type WorkflowCommandsCardProps = {
   linksDisabled?: boolean;
 };
 
-export default class WorkflowCommandsCard extends React.Component<WorkflowCommandsCardProps> {
+export default class ChildInvocationCard extends React.Component<ChildInvocationCardProps> {
   private handleCommandClicked(invocationId: string, e: React.MouseEvent) {
     e.preventDefault();
     router.navigateTo(`/invocation/${invocationId}`);

--- a/app/invocation/child_invocations.tsx
+++ b/app/invocation/child_invocations.tsx
@@ -1,22 +1,28 @@
 import React from "react";
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
 import InvocationModel from "./invocation_model";
-import WorkflowCommandsCard from "./workflow_commands_card";
+import ChildInvocationCard from "./child_invocation_card";
 import { CheckCircle, PlayCircle, XCircle } from "lucide-react";
 
-export type WorkflowCommandsProps = {
+export type ChildInvocationProps = {
   model: InvocationModel;
 };
 
 export type BazelCommandResult = {
-  invocation: build_event_stream.WorkflowConfigured.IInvocationMetadata;
+  invocation:
+    | build_event_stream.WorkflowConfigured.IInvocationMetadata
+    | build_event_stream.ChildInvocationsConfigured.IInvocationMetadata;
   durationMillis?: number;
 };
 
-export default class WorkflowCommands extends React.Component<WorkflowCommandsProps> {
+export default class ChildInvocations extends React.Component<ChildInvocationProps> {
   render() {
-    const configuredEvent = this.props.model.workflowConfigured!;
-    const completedEventsById = this.props.model.workflowCommandCompletedByInvocationId;
+    const workflowConfiguredEvent = this.props.model.workflowConfigured!;
+    const childInvocationsConfiguredEvent = this.props.model.childInvocationsConfigured;
+    const invocations = childInvocationsConfiguredEvent
+      ? childInvocationsConfiguredEvent.invocation
+      : workflowConfiguredEvent.invocation;
+    const completedEventsById = this.props.model.childInvocationCompletedByInvocationId;
 
     const isInProgress = !this.props.model.finished;
 
@@ -26,7 +32,7 @@ export default class WorkflowCommands extends React.Component<WorkflowCommandsPr
     const inProgress: BazelCommandResult[] = [];
     const queued: BazelCommandResult[] = [];
 
-    for (const invocation of configuredEvent.invocation) {
+    for (const invocation of invocations) {
       const completedEvent = completedEventsById.get(invocation.invocationId);
       if (!completedEvent) {
         if (isInProgress) {
@@ -53,7 +59,7 @@ export default class WorkflowCommands extends React.Component<WorkflowCommandsPr
     return (
       <>
         {failed.length > 0 && (
-          <WorkflowCommandsCard
+          <ChildInvocationCard
             status="failed"
             results={failed}
             className="card-failure"
@@ -61,7 +67,7 @@ export default class WorkflowCommands extends React.Component<WorkflowCommandsPr
           />
         )}
         {inProgress.length > 0 && (
-          <WorkflowCommandsCard
+          <ChildInvocationCard
             status="in progress"
             results={inProgress}
             className="card-in-progress"
@@ -69,7 +75,7 @@ export default class WorkflowCommands extends React.Component<WorkflowCommandsPr
           />
         )}
         {queued.length > 0 && (
-          <WorkflowCommandsCard
+          <ChildInvocationCard
             status="queued"
             results={queued}
             className="card-neutral"
@@ -78,7 +84,7 @@ export default class WorkflowCommands extends React.Component<WorkflowCommandsPr
           />
         )}
         {notRun.length > 0 && (
-          <WorkflowCommandsCard
+          <ChildInvocationCard
             status="not run"
             results={notRun}
             className="card-neutral"
@@ -87,7 +93,7 @@ export default class WorkflowCommands extends React.Component<WorkflowCommandsPr
           />
         )}
         {succeeded.length > 0 && (
-          <WorkflowCommandsCard
+          <ChildInvocationCard
             status="succeeded"
             results={succeeded}
             className="card-success"

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -20,7 +20,7 @@ import InvocationFilterComponent from "./invocation_filter";
 import InvocationInProgressComponent from "./invocation_in_progress";
 import InvocationModel from "./invocation_model";
 import InvocationLogsModel from "./invocation_logs_model";
-import WorkflowCommands from "./workflow_commands";
+import ChildInvocations from "./child_invocations";
 import InvocationNotFoundComponent from "./invocation_not_found";
 import InvocationOverviewComponent from "./invocation_overview";
 import RawLogsCardComponent from "./invocation_raw_logs_card";
@@ -253,9 +253,8 @@ export default class InvocationComponent extends React.Component<Props, State> {
             <ErrorCardComponent model={this.state.model} />
           )}
 
-          {this.state.model.workflowConfigured && (activeTab === "all" || activeTab === "commands") && (
-            <WorkflowCommands model={this.state.model} />
-          )}
+          {(this.state.model.workflowConfigured || this.state.model.childInvocationsConfigured) &&
+            (activeTab === "all" || activeTab === "commands") && <ChildInvocations model={this.state.model} />}
 
           {isBazelInvocation && (activeTab === "all" || activeTab == "targets") && (
             <TargetsComponent

--- a/app/invocation/invocation_overview.tsx
+++ b/app/invocation/invocation_overview.tsx
@@ -103,7 +103,7 @@ export default class InvocationOverviewComponent extends React.Component {
           <InvocationButtons invocationId={this.props.invocationId} model={this.props.model} user={this.props.user} />
         </div>
         <div className="titles">
-          {isBazelInvocation && (
+          {(this.props.model.isBazelInvocation() || this.props.model.isHostedBazelInvocation()) && (
             <div className="title" title={this.props.model.getAllPatterns()}>
               {this.props.model.getUser(/*possessive=*/ true)} {this.props.model.getCommand()}{" "}
               {this.props.model.getPattern()}

--- a/app/invocation/invocation_tabs.tsx
+++ b/app/invocation/invocation_tabs.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CI_RUNNER_ROLE } from "./invocation_model";
+import { CI_RUNNER_ROLE, HOSTED_BAZEL_ROLE } from "./invocation_model";
 
 export type InvocationTabsProps = TabsContext;
 
@@ -50,7 +50,7 @@ export default class InvocationTabsComponent extends React.Component<InvocationT
   }
 
   render() {
-    const isBazelInvocation = this.props.role !== CI_RUNNER_ROLE;
+    const isBazelInvocation = this.props.role !== CI_RUNNER_ROLE && this.props.role !== HOSTED_BAZEL_ROLE;
 
     return (
       <div className="tabs">

--- a/enterprise/app/history/history_invocation_card.tsx
+++ b/enterprise/app/history/history_invocation_card.tsx
@@ -239,7 +239,7 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
                   {this.props.invocation.command}
                 </div>
               )}
-              {this.props.invocation.pattern && (
+              {this.props.invocation.pattern.length > 0 && (
                 <div className="detail">
                   <LayoutGrid className="icon" />
                   {format.truncateList(this.props.invocation.pattern)}

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -211,6 +211,17 @@ message BuildEventId {
     string invocation_id = 1;
   }
 
+  // Identifier of an event providing a list of commands that are
+  // run as children of this invocation.
+  message ChildInvocationsConfiguredId {}
+
+  // Identifier of an event providing the status of a completed child
+  // invocation.
+  message ChildInvocationCompletedId {
+    // Invocation ID of the command that was completed.
+    string invocation_id = 1;
+  }
+
   oneof id {
     UnknownBuildEventId unknown = 1;
     ProgressId progress = 2;
@@ -244,6 +255,8 @@ message BuildEventId {
 
     WorkflowConfiguredId workflow_configured = 1000;
     WorkflowCommandCompletedId workflow_command_completed = 1001;
+    ChildInvocationsConfiguredId child_invocations_configured = 1002;
+    ChildInvocationCompletedId child_invocation_completed = 1003;
   }
 }
 
@@ -861,6 +874,37 @@ message WorkflowCommandCompleted {
   int64 duration_millis = 3;
 }
 
+message ChildInvocationsConfigured {
+  // Metadata for a child Bazel invocation spawned from the current invocation.
+  message InvocationMetadata {
+    // Bazel invocation ID (UUIDV4) for a sub-invocation.
+    // Should not be set for bazel commands that do not create invocations, such
+    // as `bazel version`. Example: "86083af6-4699-4957-a0a3-d6a806104bb3"
+    string invocation_id = 1;
+
+    // Bazel command.
+    // Example: "test //..."
+    string bazel_command = 2;
+  }
+
+  // Child Bazel invocations.
+  repeated InvocationMetadata invocation = 1;
+}
+
+// Event describing completion of a child invocation.
+// Note: the event ID holds the invocation ID that identifies the command.
+message ChildInvocationCompleted {
+  // The overall status of the command. A command was successful if and only if
+  // this value is equal to 0.
+  int32 exit_code = 1;
+
+  // Start time of the invocation, in milliseconds since epoch.
+  int64 start_time_millis = 2;
+
+  // How long it took for the invocation to complete, in milliseconds.
+  int64 duration_millis = 3;
+}
+
 // Message describing a build event. Events will have an identifier that
 // is unique within a given build invocation; they also announce follow-up
 // events as children. More details, which are specific to the kind of event
@@ -901,5 +945,7 @@ message BuildEvent {
 
     WorkflowConfigured workflow_configured = 1000;
     WorkflowCommandCompleted workflow_command_completed = 1001;
+    ChildInvocationsConfigured child_invocations_configured = 1002;
+    ChildInvocationCompleted child_invocation_completed = 1003;
   }
 }


### PR DESCRIPTION
The runner will report child invocation information via the new
`ChildInvocationsConfigured` and `ChildInvocationCompleted` events that
can be used for both workflows & hosted bazel invocations.

Invocation history:
![invocation_history](https://user-images.githubusercontent.com/1335358/150206911-b39570c0-8868-4ec0-ac98-3cf19525823c.png)

Invocation details:
![invocation_details](https://user-images.githubusercontent.com/1335358/150206936-f50046bb-3139-4122-a15b-8b5afa99666c.png)


<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
