### PR TITLE
Respect executor host root dir flag when not running on k8s

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -541,6 +541,10 @@ func (p *Pool) add(ctx context.Context, r *CommandRunner) *labeledError {
 }
 
 func (p *Pool) hostBuildRoot() string {
+	// If host root dir is explicitly configured, prefer that.
+	if hd := p.env.GetConfigurator().GetExecutorConfig().HostExecutorRootDirectory; hd != "" {
+		return filepath.Join(hd, "remotebuilds")
+	}
 	if p.podID == "" {
 		// Probably running on bare metal -- return the build root directly.
 		return p.buildRoot
@@ -549,9 +553,6 @@ func (p *Pool) hostBuildRoot() string {
 	// TODO(bduffany): Make this configurable in YAML, populating {{.PodID}} via template.
 	// People might have conventions other than executor-data for the volume name + remotebuilds
 	// for the build root dir.
-	if hd := p.env.GetConfigurator().GetExecutorConfig().HostExecutorRootDirectory; hd != "" {
-		return filepath.Join(hd, "remotebuilds")
-	}
 	return fmt.Sprintf("/var/lib/kubelet/pods/%s/volumes/kubernetes.io~empty-dir/executor-data/remotebuilds", p.podID)
 }
 


### PR DESCRIPTION
The fix for https://github.com/buildbuddy-io/buildbuddy-internal/issues/1076 involves two parts:

1. Update our recommended command to the following:

```diff
 docker run \
+    --volume /tmp/buildbuddy:/buildbuddy \
     --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
     gcr.io/flame-public/buildbuddy-executor-enterprise:latest \
+    --executor.host_executor_root_directory=/tmp/buildbuddy \
     --executor.docker_socket=/var/run/docker.sock \
     --executor.app_target=grpcs://remote.buildbuddy.dev \
     --executor.api_key=XXXX
```

2. (This PR) Respect the `host_executor_root_directory` flag in environments other than k8s. The current behavior of only supporting this flag on k8s is most likely arbitrary (reviewers can correct me if I am wrong :sweat_smile: )

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
