### PR TITLE
Allocate pseudo-tty in CI runner when executing commands.

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -621,8 +621,8 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "com_github_creack_pty",
         importpath = "github.com/creack/pty",
-        sum = "h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=",
-        version = "v1.1.11",
+        sum = "h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=",
+        version = "v1.1.17",
     )
     go_repository(
         name = "com_github_crewjam_httperr",

--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//server/util/lockingbuffer",
         "//server/util/log",
         "//server/util/status",
+        "@com_github_creack_pty//:pty",
         "@com_github_google_shlex//:shlex",
         "@com_github_google_uuid//:uuid",
         "@com_github_logrusorgru_aurora//:aurora",

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -898,7 +898,7 @@ func (ws *workspace) sync(ctx context.Context) error {
 	// workflow can pick up any changes not yet incorporated into the pushed branch.
 	if *pushedRepoURL != *targetRepoURL || *pushedBranch != *targetBranch {
 		targetRef := fmt.Sprintf("%s/%s", gitRemoteName(*targetRepoURL), *targetBranch)
-		if err := git(ctx, ws.log, "merge", targetRef); err != nil && !isAlreadyUpToDate(err) {
+		if err := git(ctx, ws.log, "merge", "--no-edit", targetRef); err != nil && !isAlreadyUpToDate(err) {
 			errMsg := err.Output
 			if err := git(ctx, ws.log, "merge", "--abort"); err != nil {
 				errMsg += "\n" + err.Output

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -208,8 +208,18 @@ func TestCIRunner_Push_WorkspaceWithDefaultTestAllConfig_RunsAndUploadsResultsTo
 	runnerInvocation := singleInvocation(t, app, result)
 	assert.Contains(
 		t, runnerInvocation.ConsoleBuffer,
-		"Executed 2 out of 2 tests: 1 test passes and 1 fails locally.",
-		"pass.sh test should have passed and fail.sh should have failed.",
+		"Executed 2 out of 2 tests",
+		"2 tests should have been executed",
+	)
+	assert.Contains(
+		t, runnerInvocation.ConsoleBuffer,
+		"1 test passes",
+		"1 test should have passed",
+	)
+	assert.Contains(
+		t, runnerInvocation.ConsoleBuffer,
+		"1 fails locally",
+		"1 test should have failed",
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -106,6 +106,7 @@ require (
 	github.com/containerd/fifo v1.0.0 // indirect
 	github.com/containernetworking/cni v0.8.1 // indirect
 	github.com/containernetworking/plugins v0.9.1 // indirect
+	github.com/creack/pty v1.1.17 // indirect
 	github.com/crewjam/httperr v0.0.0-20190612203328-a946449404da // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d // indirect

--- a/go.sum
+++ b/go.sum
@@ -326,6 +326,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
+github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/crewjam/httperr v0.0.0-20190612203328-a946449404da h1:WXnT88cFG2davqSFqvaFfzkSMC0lqh/8/rKZ+z7tYvI=
 github.com/crewjam/httperr v0.0.0-20190612203328-a946449404da/go.mod h1:+rmNIXRvYMqLQeR4DHyTvs6y0MEMymTz4vyFpFkKTPs=
 github.com/crewjam/saml v0.4.5 h1:H9u+6CZAESUKHxMyxUbVn0IawYvKZn4nt3d4ccV4O/M=

--- a/tools/remotebazel/remotebazel.go
+++ b/tools/remotebazel/remotebazel.go
@@ -68,10 +68,6 @@ func main() {
 
 	ctx := metadata.AppendToOutgoingContext(context.Background(), "x-buildbuddy-api-key", *apiKey)
 
-	// --isatty=1 makes Bazel think it's running in an interactive terminal which enables nicer UI output
-	// TODO(vadim): propagate terminal width
-	cmd := flag.Args()[0] + " --isatty=1 " + strings.Join(flag.Args()[1:], " ")
-
 	log.Infof("Sending request...")
 
 	req := &rnpb.RunRequest{
@@ -79,7 +75,7 @@ func main() {
 			RepoUrl: *repo,
 		},
 		RepoState:          &rnpb.RunRequest_RepoState{},
-		BazelCommand:       cmd,
+		BazelCommand:       strings.Join(flag.Args(), " "),
 		InstanceName:       *remoteInstanceName,
 		SessionAffinityKey: *affinityKey,
 	}


### PR DESCRIPTION
This allows us to show interactive git & bazel progress without hacks.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
