### PR TITLE
Remove terminal subtitles

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -2151,6 +2151,11 @@ code .comment {
   background: #263238;
 }
 
-.loading.loading-dark:before {
+.loading.loading-dark-terminal {
+  background: #222;
+}
+
+.loading.loading-dark:before,
+.loading.loading-dark-terminal:before {
   background-image: url("/image/loader-white.svg");
 }

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -570,7 +570,7 @@ svg.icon.orange {
 
 .card .icon {
   margin-right: 16px;
-  padding-top: 2px;
+  padding-top: 1px;
 }
 
 .card .title {

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1004,13 +1004,7 @@ code .comment {
 
   display: flex;
   align-items: start;
-}
-
-.terminal-search-placeholder {
-  margin-left: auto;
-  width: 290px;
-  flex-shrink: 0;
-  align-self: stretch;
+  justify-content: space-between;
 }
 
 .terminal-actions {
@@ -1066,6 +1060,7 @@ code .comment {
   background-color: transparent;
   cursor: pointer;
   padding: 12px;
+  margin: -12px 0;
   opacity: 0.6;
 }
 
@@ -1087,6 +1082,7 @@ code .comment {
 .react-lazylog-searchbar.react-lazylog-searchbar {
   margin-right: 80px;
   background-color: transparent;
+  padding: 1px 0 16px 0;
 }
 
 .terminal-container.has-subtitle .react-lazylog-searchbar {
@@ -1106,9 +1102,6 @@ code .comment {
   .terminal .react-lazylog-searchbar-matches {
     display: none;
   }
-  .terminal-search-placeholder {
-    width: 170px;
-  }
 }
 
 @media (max-width: 525px) {
@@ -1116,7 +1109,7 @@ code .comment {
     margin-top: 0;
   }
   .react-lazylog-searchbar {
-    display: none !important;
+    opacity: 0;
   }
 }
 

--- a/app/target/action_card.tsx
+++ b/app/target/action_card.tsx
@@ -110,9 +110,6 @@ export default class ActionCardComponent extends React.Component {
 
   render() {
     const title = <div className="title">Error Log</div>;
-    const subtitle = (
-      <div className="test-subtitle">{this.getStatusTitle(this.props.action.buildEvent.action.success)}</div>
-    );
     return (
       <div className="target-action-card">
         {this.props.action?.buildEvent?.action?.stderr?.uri && (
@@ -125,7 +122,6 @@ export default class ActionCardComponent extends React.Component {
               {!this.state.cacheEnabled && (
                 <>
                   {title}
-                  {subtitle}
                   <div className="empty-state">
                     Log uploading isn't enabled for this invocation.
                     <br />
@@ -140,7 +136,6 @@ export default class ActionCardComponent extends React.Component {
               {this.state.cacheEnabled && (
                 <TerminalComponent
                   title={title}
-                  subtitle={subtitle}
                   loading={this.state.loadingStderr}
                   value={this.state.stdErr || "Empty log"}
                   lightTheme={!this.props.dark}

--- a/app/target/target_log_card.tsx
+++ b/app/target/target_log_card.tsx
@@ -4,7 +4,6 @@ import { TerminalComponent } from "../terminal/terminal";
 
 interface Props {
   title: string;
-  subtitle: string;
   contents: string;
   dark: boolean;
 }
@@ -20,7 +19,6 @@ export default class TargetLogCardComponent extends React.Component {
           <div className="test-log">
             <TerminalComponent
               title={<div className="title">{this.props.title}</div>}
-              subtitle={<div className="test-subtitle">{this.props.subtitle}</div>}
               value={this.props.contents}
               lightTheme={!this.props.dark}
             />

--- a/app/target/target_test_document_card.tsx
+++ b/app/target/target_test_document_card.tsx
@@ -137,8 +137,7 @@ export default class TargetTestDocumentCardComponent extends React.Component {
                   .map((child) => (
                     <TargetLogCardComponent
                       contents={child.textContent}
-                      title={testSuite.getAttribute("name")}
-                      subtitle={`${child.tagName}`}
+                      title={`${testSuite.getAttribute("name")} ${child.tagName}`}
                       dark={this.props.dark}
                     />
                   ))}

--- a/app/target/target_test_log_card.tsx
+++ b/app/target/target_test_log_card.tsx
@@ -125,8 +125,10 @@ export default class TargetTestLogCardComponent extends React.Component {
           <div className="content">
             <div className="title">
               {this.getStatusTitle(this.props.testResult.buildEvent.testResult.status)} in{" "}
-              {format.durationMillis(this.props.testResult.buildEvent.testResult.testAttemptDurationMillis)} on Shard{" "}
-              {this.props.testResult.buildEvent.id.testResult.shard} (Run{" "}
+              {format.durationMillis(this.props.testResult.buildEvent.testResult.testAttemptDurationMillis)}
+            </div>
+            <div className="subtitle">
+              On Shard {this.props.testResult.buildEvent.id.testResult.shard} (Run{" "}
               {this.props.testResult.buildEvent.id.testResult.run}, Attempt{" "}
               {this.props.testResult.buildEvent.id.testResult.attempt})
             </div>

--- a/app/target/target_test_log_card.tsx
+++ b/app/target/target_test_log_card.tsx
@@ -5,7 +5,7 @@ import { invocation } from "../../proto/invocation_ts_proto";
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
 import { TerminalComponent } from "../terminal/terminal";
 import rpcService from "../service/rpc_service";
-import { PauseCircle } from "lucide-react";
+import { CheckCircle, Clock, HelpCircle, PauseCircle, XCircle } from "lucide-react";
 
 interface Props {
   testResult: invocation.InvocationEvent;
@@ -102,49 +102,66 @@ export default class TargetTestLogCardComponent extends React.Component {
         return "card-failure";
     }
   }
+
+  getStatusIcon(status: build_event_stream.TestStatus) {
+    switch (status) {
+      case build_event_stream.TestStatus.PASSED:
+        return <CheckCircle className="icon green" />;
+      case build_event_stream.TestStatus.FLAKY:
+        return <HelpCircle className="icon orange" />;
+      case build_event_stream.TestStatus.TIMEOUT:
+        return <Clock className="icon" />;
+      default:
+        return <XCircle className="icon red" />;
+    }
+  }
+
   render() {
     const title = <div className="title">Test log</div>;
-    const subtitle = (
-      <div className="test-subtitle">
-        {this.getStatusTitle(this.props.testResult.buildEvent.testResult.status)} in{" "}
-        {format.durationMillis(this.props.testResult.buildEvent.testResult.testAttemptDurationMillis)} on Shard{" "}
-        {this.props.testResult.buildEvent.id.testResult.shard} (Run {this.props.testResult.buildEvent.id.testResult.run}
-        , Attempt {this.props.testResult.buildEvent.id.testResult.attempt})
-      </div>
-    );
-
     return (
-      <div
-        className={`card ${
-          this.state.cacheEnabled && (this.props.dark ? "dark" : "light-terminal")
-        } ${this.getStatusClass(this.props.testResult.buildEvent.testResult.status)}`}>
-        <PauseCircle className={`icon rotate-90 ${this.props.dark ? "white" : ""}`} />
-        <div className="content">
-          {!this.state.cacheEnabled && (
-            <div className="empty-state">
-              {title}
-              {subtitle}
-              Test log uploading isn't enabled for this invocation.
-              <br />
-              <br />
-              To enable test log uploading you must add GRPC remote caching. You can do so by checking{" "}
-              <b>Enable cache</b> below, updating your <b>.bazelrc</b> accordingly, and re-running your invocation:
-              <SetupCodeComponent />
+      <>
+        <div className={`card ${this.getStatusClass(this.props.testResult.buildEvent.testResult.status)}`}>
+          {this.getStatusIcon(this.props.testResult.buildEvent.testResult.status)}
+          <div className="content">
+            <div className="title">
+              {this.getStatusTitle(this.props.testResult.buildEvent.testResult.status)} in{" "}
+              {format.durationMillis(this.props.testResult.buildEvent.testResult.testAttemptDurationMillis)} on Shard{" "}
+              {this.props.testResult.buildEvent.id.testResult.shard} (Run{" "}
+              {this.props.testResult.buildEvent.id.testResult.run}, Attempt{" "}
+              {this.props.testResult.buildEvent.id.testResult.attempt})
             </div>
-          )}
-          {this.state.cacheEnabled && (
-            <div className="test-log">
-              <TerminalComponent
-                title={title}
-                subtitle={subtitle}
-                value={this.state.testLog || "Empty log"}
-                loading={this.state.loading}
-                lightTheme={!this.props.dark}
-              />
-            </div>
-          )}
+          </div>
         </div>
-      </div>
+        <div
+          className={`card ${
+            this.state.cacheEnabled && (this.props.dark ? "dark" : "light-terminal")
+          } ${this.getStatusClass(this.props.testResult.buildEvent.testResult.status)}`}>
+          <PauseCircle className={`icon rotate-90 ${this.props.dark ? "white" : ""}`} />
+          <div className="content">
+            {!this.state.cacheEnabled && (
+              <div className="empty-state">
+                {title}
+                Test log uploading isn't enabled for this invocation.
+                <br />
+                <br />
+                To enable test log uploading you must add GRPC remote caching. You can do so by checking{" "}
+                <b>Enable cache</b> below, updating your <b>.bazelrc</b> accordingly, and re-running your invocation:
+                <SetupCodeComponent />
+              </div>
+            )}
+            {this.state.cacheEnabled && (
+              <div className="test-log">
+                <TerminalComponent
+                  title={title}
+                  value={this.state.testLog || "Empty log"}
+                  loading={this.state.loading}
+                  lightTheme={!this.props.dark}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </>
     );
   }
 }

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -56,7 +56,7 @@ export default class TerminalComponent extends React.Component<TerminalProps, Te
           </div>
           <div className="terminal" ref={this.terminalRef}>
             {this.props.loading ? (
-              <div className={`loading ${this.props.lightTheme ? "" : "loading-dark"}`} />
+              <div className={`loading ${this.props.lightTheme ? "" : "loading-dark-terminal"}`} />
             ) : (
               <LazyLog
                 selectableLines={true}

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -9,7 +9,6 @@ export interface TerminalProps {
   loading?: boolean;
 
   title?: JSX.Element;
-  subtitle?: JSX.Element;
 
   lightTheme?: boolean;
   fullLogsFetcher?: () => Promise<string>;
@@ -35,21 +34,10 @@ export default class TerminalComponent extends React.Component<TerminalProps, Te
 
   render() {
     return (
-      <div
-        className={`terminal-container ${this.props.lightTheme ? "light-terminal" : ""} ${
-          this.props.subtitle ? "has-subtitle" : ""
-        }`}>
+      <div className={`terminal-container ${this.props.lightTheme ? "light-terminal" : ""}`}>
         <div className="terminal-content">
           <div className="terminal-top-bar">
-            {this.props.title && (
-              <div className="terminal-titles">
-                {this.props.title}
-                {this.props.subtitle}
-              </div>
-            )}
-            {/* Search bar is actually rendered by react-lazylog.
-              This div is just a placeholder for layout purposes. */}
-            <div className="terminal-search-placeholder" />
+            {this.props.title && <div className="terminal-titles">{this.props.title}</div>}
             <div className="terminal-actions">
               <button
                 title="Wrap"


### PR DESCRIPTION
They're not really compatible with the way we render the terminal search box.

On small screens they would wrap and overlap with terminal content.

This PR removes/combines useless subtitles and breaks out useful ones into their own card.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
