### PR TITLE
Fix docker command for running the executor

### DIFF
--- a/enterprise/app/executors/executors.tsx
+++ b/enterprise/app/executors/executors.tsx
@@ -60,9 +60,12 @@ class ExecutorDeploy extends React.Component<ExecutorDeployProps, ExecutorDeploy
         </Select>
         <code>
           <pre>
-            {`docker run --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \\
+            {`docker run \\
+    --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \\
+    --volume /tmp/buildbuddy:/buildbuddy \\
     gcr.io/flame-public/buildbuddy-executor-enterprise:latest \\
     --executor.docker_socket=/var/run/docker.sock \\
+    --executor.host_root_directory=/tmp/buildbuddy \\
     --executor.app_target=${this.props.schedulerUri} \\
     --executor.api_key=${this.props.executorKeys[this.state.selectedExecutorKeyIdx]?.value}`}
           </pre>

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -542,7 +542,7 @@ func (p *Pool) add(ctx context.Context, r *CommandRunner) *labeledError {
 
 func (p *Pool) hostBuildRoot() string {
 	// If host root dir is explicitly configured, prefer that.
-	if hd := p.env.GetConfigurator().GetExecutorConfig().HostExecutorRootDirectory; hd != "" {
+	if hd := p.env.GetConfigurator().GetExecutorConfig().HostRootDirectory; hd != "" {
 		return filepath.Join(hd, "remotebuilds")
 	}
 	if p.podID == "" {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -262,6 +262,7 @@ type ExecutorConfig struct {
 	AppTarget                      string                    `yaml:"app_target" usage:"The GRPC url of a buildbuddy app server."`
 	Pool                           string                    `yaml:"pool" usage:"Executor pool name. Only one of this config option or the MY_POOL environment variable should be specified."`
 	RootDirectory                  string                    `yaml:"root_directory" usage:"The root directory to use for build files."`
+	HostRootDirectory              string                    `yaml:"host_root_directory" usage:"Path on the host where the executor container root directory is mounted."`
 	LocalCacheDirectory            string                    `yaml:"local_cache_directory" usage:"A local on-disk cache directory. Must be on the same device (disk partition, Docker volume, etc.) as the configured root_directory, since files are hard-linked to this cache for performance reasons. Otherwise, 'Invalid cross-device link' errors may result."`
 	LocalCacheSizeBytes            int64                     `yaml:"local_cache_size_bytes" usage:"The maximum size, in bytes, to use for the local on-disk cache"`
 	DisableLocalCache              bool                      `yaml:"disable_local_cache" usage:"If true, a local file cache will not be used."`
@@ -276,7 +277,6 @@ type ExecutorConfig struct {
 	EnableBareRunner               bool                      `yaml:"enable_bare_runner" usage:"Enables running execution commands directly on the host without isolation."`
 	EnableFirecracker              bool                      `yaml:"enable_firecracker" usage:"Enables running execution commands inside of firecracker VMs"`
 	EnableFirecrackerDiffSnapshots bool                      `yaml:"enable_firecracker_diff_snapshots" usage:"Enables incremental memory snapshots for firecracker VMs."`
-	HostExecutorRootDirectory      string                    `yaml:"host_executor_root_directory" usage:"Path on the host where the executor container root directory is mounted."`
 	ContainerRegistries            []ContainerRegistryConfig `yaml:"container_registries"`
 	EnableVFS                      bool                      `yaml:"enable_vfs" usage:"Whether FUSE based filesystem is enabled."`
 	DefaultImage                   string                    `yaml:"default_image" usage:"The default docker image to use to warm up executors or if no platform property is set. Ex: gcr.io/flame-public/executor-docker-default:enterprise-v1.5.4"`


### PR DESCRIPTION
Also rename `executor.host_executor_root_directory` to `executor.host_root_directory` while we still can (it's unlikely that anyone is using this flag yet, since we haven't documented it anywhere, and it previously wasn't working as intended -- see https://github.com/buildbuddy-io/buildbuddy/pull/1445)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
