### PR TITLE
Add config flag for test grid v2

### DIFF
--- a/proto/config.proto
+++ b/proto/config.proto
@@ -53,4 +53,7 @@ message FrontendConfig {
 
   // Whether Darwin (macOS) executors must be self-hosted.
   bool force_user_owned_darwin_executors = 17;
+
+  // Whether test grid V2 is enabled.
+  bool test_grid_v2_enabled = 18;
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -59,6 +59,7 @@ type appConfig struct {
 	CodeEditorEnabled         bool     `yaml:"code_editor_enabled" usage:"If set, code editor functionality will be enabled."`
 	UserManagementEnabled     bool     `yaml:"user_management_enabled" usage:"If set, the user management page will be enabled in the UI."`
 	GlobalFilterEnabled       bool     `yaml:"global_filter_enabled" usage:"If set, the global filter will be enabled in the UI."`
+	TestGridV2Enabled         bool     `yaml:"test_grid_v2_enabled" usage:"Whether to enable test grid V2"`
 	UsageEnabled              bool     `yaml:"usage_enabled" usage:"If set, the usage page will be enabled in the UI."`
 	UsageStartDate            string   `yaml:"usage_start_date" usage:"If set, usage data will only be viewable on or after this timestamp. Specified in RFC3339 format, like 2021-10-01T00:00:00Z"`
 	UsageTrackingEnabled      bool     `yaml:"usage_tracking_enabled" usage:"If set, enable usage data collection."`
@@ -600,6 +601,10 @@ func (c *Configurator) GetAppGlobalFilterEnabled() bool {
 
 func (c *Configurator) GetAppUsageEnabled() bool {
 	return c.gc.App.UsageEnabled
+}
+
+func (c *Configurator) GetAppTestGridV2Enabled() bool {
+	return c.gc.App.TestGridV2Enabled
 }
 
 func (c *Configurator) GetAppUsageStartDate() string {

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -157,6 +157,7 @@ func serveIndexTemplate(env environment.Env, tpl *template.Template, version str
 		UsageEnabled:                  env.GetConfigurator().GetAppUsageEnabled(),
 		UserManagementEnabled:         env.GetConfigurator().GetAppUserManagementEnabled(),
 		ForceUserOwnedDarwinExecutors: forceUserOwnedDarwinExecutors,
+		TestGridV2Enabled:             env.GetConfigurator().GetAppTestGridV2Enabled(),
 	}
 
 	configJSON := &bytes.Buffer{}


### PR DESCRIPTION
Define a server flag that decides whether to enable the new V2 test grid query and pipe it up to the client.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
