### PR TITLE
Make `bazel-*` exclude more specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ tramp
 .\#*
 
 # Bazel directories
-bazel-*
+/bazel-*
 
 # Generated protos
 **/proto/**/*.pb.go


### PR DESCRIPTION
Otherwise we can't have blog posts files start with `bazel-`.

---

**Version bump**: None