### PR TITLE
Normalize hosted bazel args in runner.

### DIFF
--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -90,6 +90,7 @@ func invokeRunner(t *testing.T, args []string, env []string, workDir string) *re
 	args = append(args, []string{
 		"--bazel_command=" + bazelPath,
 		"--bazel_startup_flags=--max_idle_secs=5 --noblock_for_lock",
+		"--workflow_id=test-workflow",
 	}...)
 
 	cmd := exec.Command(binPath, args...)


### PR DESCRIPTION
This makes the synthetic hosted bazel invocation look more like a
regular invocation in the UI.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
