### PR TITLE
Clean apt cache after installing deps in default RBE image

### DIFF
--- a/dockerfiles/default_execution_image/Dockerfile
+++ b/dockerfiles/default_execution_image/Dockerfile
@@ -1,4 +1,4 @@
 FROM gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:5464e3e83dc656fc6e4eae6a01f5c2645f1f7e95854b3802b85e86484132d90e
 
-RUN apt-get update && apt-get install -y rpm build-essential
+RUN apt-get update && apt-get install -y rpm build-essential && apt-get clean
 RUN curl -Lo /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 && chmod +x /usr/local/bin/bazelisk && /usr/local/bin/bazelisk

--- a/dockerfiles/default_execution_image/Dockerfile
+++ b/dockerfiles/default_execution_image/Dockerfile
@@ -1,4 +1,4 @@
 FROM gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:5464e3e83dc656fc6e4eae6a01f5c2645f1f7e95854b3802b85e86484132d90e
 
-RUN apt-get update && apt-get install -y rpm build-essential && apt-get clean
+RUN apt-get update && apt-get install -y rpm build-essential && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN curl -Lo /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 && chmod +x /usr/local/bin/bazelisk && /usr/local/bin/bazelisk


### PR DESCRIPTION
According to https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run

* It's always recommended to run `rm -rf /var/lib/apt/lists/*` (shaves off about 100MB)
* The official Ubuntu/Debian images should run `apt-get clean` automatically, but I found that there are things in the apt cache that could be cleaned (shaving off around another 100 MB). The explicit `apt-get clean` might be needed because we are on an older ubuntu version (16.04) or because Google's RBE image doesn't do this automatically for some reason.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
