### PR TITLE
Get docker_test running in CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -96,6 +96,9 @@ build --workspace_status_command=$(pwd)/workspace_status.sh
 # Use a static PATH variable to prevent unnecessary rebuilds of dependencies like protobuf.
 build --incompatible_strict_action_env
 
+# Don't include Docker tests by default when running `bazel test //...`, to avoid
+# a hard dependency on Docker for development.
+test --test_tag_filters=-docker
 
 # Try importing a user specific .bazelrc
 # You can create your own by copying and editing the template-user.bazelrc template:

--- a/.bazelrc
+++ b/.bazelrc
@@ -30,6 +30,8 @@ build:remote-shared --remote_download_minimal
 build:remote-shared --experimental_repo_remote_exec
 build:remote-shared --jobs=100
 build:remote-shared --verbose_failures
+# TODO(bduffany): Remove this once firecracker is enabled in prod.
+build:remote-shared --build_tag_filters=-docker
 
 # Build with --config=remote to use BuildBuddy RBE.
 build:remote --config=remote-shared

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -7,8 +7,7 @@ actions:
       pull_request:
         branches:
           - "master"
-    # TODO(https://github.com/buildbuddy-io/buildbuddy-internal/issues/1140): Re-enable
-    # system bazelrc
+    # TODO(http://go/b/1140): Re-enable system bazelrc
     bazel_commands:
       - bazel --nosystem_rc test //... --config=workflows --test_tag_filters=-performance,-webdriver,-docker
   - name: Benchmark
@@ -27,10 +26,10 @@ actions:
         branches:
           - "master"
     bazel_commands:
-      # TODO(https://github.com/buildbuddy-io/buildbuddy-internal/issues/958):
-      # See if we can remove --remote_download_outputs=toplevel
+      # TODO(http://go/b/958): See if we can remove --remote_download_outputs=toplevel
       - bazel --nosystem_rc test //... --config=workflows --remote_download_outputs=toplevel --test_tag_filters=+webdriver
-  # TODO(bduffany): Move these to the Test workflow when they are fast enough.
+  # TODO(bduffany): Move docker tests to the Test workflow when they are fast enough.
+  # TODO(http://go/b/1151): Switch from dev -> prod
   - name: Docker tests
     triggers:
       push:
@@ -40,4 +39,4 @@ actions:
         branches:
           - "master"
     bazel_commands:
-      - bazel --nosystem_rc test //... --config=workflows --test_tag_filters=+docker
+      - bazel --nosystem_rc test //... --config=workflows --config=remote-dev --test_tag_filters=+docker

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -30,3 +30,14 @@ actions:
       # TODO(https://github.com/buildbuddy-io/buildbuddy-internal/issues/958):
       # See if we can remove --remote_download_outputs=toplevel
       - bazel --nosystem_rc test //... --config=workflows --remote_download_outputs=toplevel --test_tag_filters=+webdriver
+  # TODO(bduffany): Move these to the Test workflow when they are fast enough.
+  - name: Docker tests
+    triggers:
+      push:
+        branches:
+          - "master"
+      pull_request:
+        branches:
+          - "master"
+      bazel_commands:
+        - bazel --nosystem_rc test //... --test_tag_filters=+docker

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -40,4 +40,4 @@ actions:
         branches:
           - "master"
       bazel_commands:
-        - bazel --nosystem_rc test //... --test_tag_filters=+docker
+        - bazel --nosystem_rc test //... --config=workflows --test_tag_filters=+docker

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -39,5 +39,5 @@ actions:
       pull_request:
         branches:
           - "master"
-      bazel_commands:
-        - bazel --nosystem_rc test //... --config=workflows --test_tag_filters=+docker
+    bazel_commands:
+      - bazel --nosystem_rc test //... --config=workflows --test_tag_filters=+docker

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -39,4 +39,4 @@ actions:
         branches:
           - "master"
     bazel_commands:
-      - bazel --nosystem_rc test //... --config=workflows --config=remote-dev --test_tag_filters=+docker
+      - bazel --nosystem_rc test //... --config=workflows --config=remote-dev --test_tag_filters=+docker --build_tag_filters=+docker

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -10,7 +10,7 @@ actions:
     # TODO(https://github.com/buildbuddy-io/buildbuddy-internal/issues/1140): Re-enable
     # system bazelrc
     bazel_commands:
-      - bazel --nosystem_rc test //... --config=workflows --test_tag_filters=-performance,-webdriver
+      - bazel --nosystem_rc test //... --config=workflows --test_tag_filters=-performance,-webdriver,-docker
   - name: Benchmark
     triggers:
       push:

--- a/enterprise/server/remote_execution/containers/docker/BUILD
+++ b/enterprise/server/remote_execution/containers/docker/BUILD
@@ -32,9 +32,8 @@ go_test(
         # TODO(https://github.com/buildbuddy-io/buildbuddy-internal/issues/1094): Require less manual configuration here.
         "workload-isolation-type": "firecracker",
         "init-dockerd": "true",
-        "EstimatedComputeUnits": "1",
-        "EstimatedFreeDiskBytes": "1000000000",  # 1 GB
     },
+    shard_count = 2,
     tags = ["docker"],
     deps = [
         ":docker",

--- a/enterprise/server/remote_execution/containers/docker/BUILD
+++ b/enterprise/server/remote_execution/containers/docker/BUILD
@@ -28,7 +28,14 @@ go_library(
 go_test(
     name = "docker_test",
     srcs = ["docker_test.go"],
-    tags = ["manual"],
+    exec_properties = {
+        # TODO(https://github.com/buildbuddy-io/buildbuddy-internal/issues/1094): Require less manual configuration here.
+        "workload-isolation-type": "firecracker",
+        "init-dockerd": "true",
+        "EstimatedComputeUnits": "1",
+        "EstimatedFreeDiskBytes": "1000000000",  # 1 GB
+    },
+    tags = ["docker"],
     deps = [
         ":docker",
         "//enterprise/server/remote_execution/container",

--- a/enterprise/server/remote_execution/containers/docker/docker_test.go
+++ b/enterprise/server/remote_execution/containers/docker/docker_test.go
@@ -109,6 +109,12 @@ func TestDockerLifecycleControl(t *testing.T) {
 		}
 	})
 
+	err = container.PullImageIfNecessary(
+		ctx, env, cacheAuth, c, container.PullCredentials{},
+		"docker.io/library/busybox",
+	)
+	require.NoError(t, err)
+
 	err = c.Create(ctx, workDir)
 
 	require.NoError(t, err)


### PR DESCRIPTION
Using the new docker-in-firecracker support to run `docker_test` on CI.

WIP: Blocked on https://github.com/buildbuddy-io/buildbuddy-internal/issues/1151

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
