### PR TITLE
Bump default execution image version

### DIFF
--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -31,7 +31,7 @@ const (
 	DefaultPoolValue = "default"
 
 	containerImagePropertyName = "container-image"
-	DefaultContainerImage      = "gcr.io/flame-public/executor-docker-default:enterprise-v1.5.4"
+	DefaultContainerImage      = "gcr.io/flame-public/executor-docker-default:enterprise-v1.6.0"
 	DockerPrefix               = "docker://"
 
 	containerRegistryUsernamePropertyName = "container-registry-username"


### PR DESCRIPTION
The new image version has `docker-ce` installed. Compressed size is about 90MB increased from the previous image (8.6%)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
