### PR TITLE
Firecracker: Fix context deadline exceeded errors with docker-in-fc actions

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -52,7 +52,7 @@ const (
 	firecrackerSocketWaitTimeout = 3 * time.Second
 
 	// How long to wait when dialing the vmexec server inside the VM.
-	vSocketDialTimeout = 3 * time.Second
+	vSocketDialTimeout = 10 * time.Second
 
 	// How long to wait for the jailer directory to be created.
 	jailerDirectoryCreationTimeout = 1 * time.Second
@@ -661,7 +661,7 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 	vsockPath := filepath.Join(c.getChroot(), firecrackerVSockPath)
 	conn, err := vsock.SimpleGRPCDial(dialCtx, vsockPath, vsock.VMExecPort)
 	if err != nil {
-		return err
+		return status.InternalErrorf("Failed to dial firecracker VM exec port: %s", err)
 	}
 	defer conn.Close()
 
@@ -670,7 +670,10 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 		UnixTimestampNanoseconds: time.Now().UnixNano(),
 		ClearArpCache:            true,
 	})
-	return err
+	if err != nil {
+		return status.WrapError(err, "Failed to initialize firecracker VM exec client")
+	}
+	return nil
 }
 
 func nonCmdExit(err error) *interfaces.CommandResult {
@@ -1076,16 +1079,16 @@ func (c FirecrackerContainer) SendExecRequestToGuest(ctx context.Context, req *v
 	vsockPath := filepath.Join(c.getChroot(), firecrackerVSockPath)
 	conn, err := vsock.SimpleGRPCDial(dialCtx, vsockPath, vsock.VMExecPort)
 	if err != nil {
-		return nil, err
+		return nil, status.InternalErrorf("Firecracker exec failed: failed to dial VM exec port: %s", err)
 	}
 	defer conn.Close()
 
 	execClient := vmxpb.NewExecClient(conn)
 	rsp, err := execClient.Exec(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, status.WrapError(err, "Firecracker exec failed")
 	}
-	return rsp, err
+	return rsp, nil
 }
 
 func (c *FirecrackerContainer) SendPrepareFileSystemRequestToGuest(ctx context.Context, req *vmfspb.PrepareRequest) (*vmfspb.PrepareResponse, error) {


### PR DESCRIPTION
When testing docker-in-firecracker in dev, I found that dockerd takes a bit longer to init than it did when testing locally, causing the VM exec server connection timeout to be consistently hit (since we block on dockerd being available before starting the VM exec server). Fixed by bumping the timeout from 3s to 10s.

Also make the errors a bit more verbose, so we get a bit more visibility into where these "context deadline exceeded" errors are coming from in the future (it took me a bit of searching to pinpoint it to the VM exec startup timeout).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
