### PR TITLE
Revert Primary Key Migration

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -687,6 +687,7 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 		}
 		ti := &tables.Invocation{
 			InvocationID:     iid,
+			InvocationPK:     md5Int64(iid),
 			InvocationUUID:   invocationUUID,
 			InvocationStatus: int64(inpb.Invocation_PARTIAL_INVOCATION_STATUS),
 			RedactionFlags:   redact.RedactionFlagStandardRedactions,
@@ -940,6 +941,7 @@ func tableInvocationFromProto(p *inpb.Invocation, blobID string) (*tables.Invoca
 
 	i := &tables.Invocation{}
 	i.InvocationID = p.InvocationId // Required.
+	i.InvocationPK = md5Int64(p.InvocationId)
 	i.InvocationUUID = uuid
 	i.Success = p.Success
 	i.User = p.User

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -224,6 +224,7 @@ func (t *TargetTracker) writeTestTargets(ctx context.Context, permissions *perms
 
 func (t *TargetTracker) writeTestTargetStatuses(ctx context.Context, permissions *perms.UserGroupPerm) error {
 	repoURL := t.buildEventAccumulator.RepoURL()
+	invocationPK := md5Int64(t.buildEventAccumulator.InvocationID())
 	invocationUUID, err := uuid.StringToBytes(t.buildEventAccumulator.InvocationID())
 	if err != nil {
 		return err
@@ -235,6 +236,7 @@ func (t *TargetTracker) writeTestTargetStatuses(ctx context.Context, permissions
 		}
 		newTargetStatuses = append(newTargetStatuses, &tables.TargetStatus{
 			TargetID:       md5Int64(repoURL + target.label),
+			InvocationPK:   invocationPK,
 			InvocationUUID: invocationUUID,
 			TargetType:     int32(target.targetType),
 			TestSize:       int32(target.testSize),
@@ -457,8 +459,9 @@ func insertOrUpdateTargetStatuses(ctx context.Context, env environment.Env, stat
 		valueArgs := []interface{}{}
 		for _, t := range chunk {
 			nowUsec := time.Now().UnixMicro()
-			valueStrings = append(valueStrings, "(?, ?, ?, ?, ?, ?, ?, ?, ?)")
+			valueStrings = append(valueStrings, "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 			valueArgs = append(valueArgs, t.TargetID)
+			valueArgs = append(valueArgs, t.InvocationPK)
 			valueArgs = append(valueArgs, t.InvocationUUID)
 			valueArgs = append(valueArgs, t.TargetType)
 			valueArgs = append(valueArgs, t.TestSize)
@@ -469,7 +472,7 @@ func insertOrUpdateTargetStatuses(ctx context.Context, env environment.Env, stat
 			valueArgs = append(valueArgs, nowUsec)
 		}
 		err := env.GetDBHandle().TransactionWithOptions(ctx, db.Opts().WithQueryName("target_tracker_insert_target_statuses"), func(tx *db.DB) error {
-			stmt := fmt.Sprintf("INSERT INTO TargetStatuses (target_id, invocation_uuid, target_type, test_size, status, start_time_usec, duration_usec, created_at_usec, updated_at_usec) VALUES %s", strings.Join(valueStrings, ","))
+			stmt := fmt.Sprintf("INSERT INTO TargetStatuses (target_id, invocation_pk, invocation_uuid, target_type, test_size, status, start_time_usec, duration_usec, created_at_usec, updated_at_usec) VALUES %s", strings.Join(valueStrings, ","))
 			return tx.Exec(stmt, valueArgs...).Error
 		})
 		if err != nil {


### PR DESCRIPTION
Revert "Fix TargetStatuses Insert Statement"

This reverts commit bfe6dfd9273cc778984e0e68e96d4a51f37e2b22.

Revert "address comments"

This reverts commit 106ef207090913079d9aa25f6cb327e593ab7a52.

Revert "Use INPLACE and LOCK=NONE"

This reverts commit 67f6c59b4cc3c23f595ed1afae113932753ee666.

Revert "Drop Invocation PK Column"

This reverts commit c488d640e201dcab982476adb60f776c31af99ec.
