### PR TITLE
Add workaround for Bazel committed_size check when uploading compressed blobs

### DIFF
--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -323,11 +323,11 @@ func (s *ByteStreamServer) Write(stream bspb.ByteStream_WriteServer) error {
 
 			// If the API key is read-only, pretend the object already exists.
 			if !canWrite {
-				return handleAlreadyExists(stream, req)
+				return s.handleAlreadyExists(ctx, stream, req)
 			}
 			streamState, err = s.initStreamState(ctx, req)
 			if status.IsAlreadyExistsError(err) {
-				return handleAlreadyExists(stream, req)
+				return s.handleAlreadyExists(ctx, stream, req)
 			}
 			if err != nil {
 				return err

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -296,7 +296,7 @@ func TestRPCWriteCompressedReadUncompressed(t *testing.T) {
 	clientConn := runByteStreamServer(ctx, te, t)
 	bsClient := bspb.NewByteStreamClient(clientConn)
 
-	for _, blobSize := range []int{1, 1e2, 1e4, 1e6, 8e6} {
+	for _, blobSize := range []int{1, 1e2, 1e4, 1e6, 8e6, 16e6} {
 		blob := compressibleBlobOfSize(blobSize)
 
 		compressedBlob := compression.CompressZstd(nil, blob)
@@ -324,6 +324,25 @@ func TestRPCWriteCompressedReadUncompressed(t *testing.T) {
 		downloadResourceName := fmt.Sprintf("blobs/%s/%d", d.Hash, d.SizeBytes)
 		downloadBuf := []byte{}
 		downloadStream, err := bsClient.Read(ctx, &bspb.ReadRequest{
+			ResourceName: downloadResourceName,
+		})
+		require.NoError(t, err)
+		for {
+			res, err := downloadStream.Recv()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			downloadBuf = append(downloadBuf, res.Data...)
+		}
+		require.Equal(t, blob, downloadBuf)
+
+		// Now try uploading a duplicate. The duplicate upload should not fail,
+		// and we should still be able to read the blob.
+		mustUploadChunked(t, ctx, bsClient, uploadResourceName, compressedBlob)
+
+		downloadBuf = []byte{}
+		downloadStream, err = bsClient.Read(ctx, &bspb.ReadRequest{
 			ResourceName: downloadResourceName,
 		})
 		require.NoError(t, err)
@@ -413,14 +432,24 @@ func mustUploadChunked(t *testing.T, ctx context.Context, bsClient bspb.ByteStre
 			Data:         remaining[:chunkSize],
 			FinishWrite:  chunkSize == len(remaining),
 		})
-		require.NoError(t, err)
+		if err != io.EOF {
+			require.NoError(t, err)
+		}
 		remaining = remaining[chunkSize:]
+		if err == io.EOF {
+			break
+		}
 	}
 	res, err := uploadStream.CloseAndRecv()
 	require.NoError(t, err)
-	// NOTE: If the blob already exists, this assertion will fail if the blob is
-	// compressed.
+
+	// Note: REAPI clients are not advised to perform this committed_size check
+	// for compressed blobs, but we do this check to mimic what Bazel 5.0.0 does
+	// in practice. We also assert that we successfully sent all chunks, since the
+	// server needs all chunks in order to know the committed size. See
+	// https://github.com/bazelbuild/bazel/issues/14654
 	require.Equal(t, int64(len(blob)), res.CommittedSize)
+	require.Len(t, remaining, 0, "upload was unexpectedly short-circuited")
 }
 
 func zstdDecompress(t *testing.T, b []byte) []byte {

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -442,10 +442,10 @@ func mustUploadChunked(t *testing.T, ctx context.Context, bsClient bspb.ByteStre
 		remaining = remaining[chunkSize:]
 		if err == io.EOF {
 			// Server sent back a WriteResponse, which we will receive in the
-			// following CloseAndRecv call. Note that this response may have been
-			// sent in response to a WriteRequest sent in a previous loop iteration,
-			// since the gRPC client does not wait for the server to process each
-			// request before sending subsequent requests.
+			// following CloseAndRecv call. Note that this response may have been sent
+			// in response to a WriteRequest sent in a previous loop iteration, since
+			// the gRPC client does not wait for the server to process each request
+			// before sending subsequent requests.
 			break
 		}
 	}

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -296,6 +296,10 @@ func TestRPCWriteCompressedReadUncompressed(t *testing.T) {
 	clientConn := runByteStreamServer(ctx, te, t)
 	bsClient := bspb.NewByteStreamClient(clientConn)
 
+	// Note: Some larger blob sizes are included here so that we have a better
+	// chance of exercising the scenario where the gRPC client sends a burst of
+	// write requests at once without waiting to see if the server sends back
+	// a response (this is a common scenario in client-streaming uploads).
 	for _, blobSize := range []int{1, 1e2, 1e4, 1e6, 8e6, 16e6} {
 		blob := compressibleBlobOfSize(blobSize)
 

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -441,6 +441,11 @@ func mustUploadChunked(t *testing.T, ctx context.Context, bsClient bspb.ByteStre
 		}
 		remaining = remaining[chunkSize:]
 		if err == io.EOF {
+			// Server sent back a WriteResponse, which we will receive in the
+			// following CloseAndRecv call. Note that this response may have been
+			// sent in response to a WriteRequest sent in a previous loop iteration,
+			// since the gRPC client does not wait for the server to process each
+			// request before sending subsequent requests.
 			break
 		}
 	}


### PR DESCRIPTION
Context: https://github.com/bazelbuild/bazel/issues/14654

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
