### PR TITLE
CLI: Add a timeout to sidecar

### DIFF
--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -134,7 +134,7 @@ func main() {
 		sidecarArgs = append(sidecarArgs, remoteCacheFlag)
 		// Also specify as disk cache directory.
 		diskCacheDir := filepath.Join(bbHome, "filecache")
-		sidecarArgs = append(sidecarArgs, fmt.Sprintf("--cache_directory=%s", diskCacheDir))
+		sidecarArgs = append(sidecarArgs, fmt.Sprintf("--cache_dir=%s", diskCacheDir))
 	}
 
 	if len(sidecarArgs) > 0 {


### PR DESCRIPTION
[Longstanding bug, felt like a distraction last night so added this] 5 mins (configurable) after recieving the last RPC, the sidecar will gracefully terminate itself