### PR TITLE
Move go deps fix before gazelle

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -35,14 +35,6 @@ jobs:
           echo "buildifier diff:"
           cat buildifier-diff.txt
 
-      - name: gazelle
-        # Keep Gazelle version in sync with WORKSPACE
-        run: |
-          go install github.com/bazelbuild/bazel-gazelle/cmd/gazelle@v0.23.0
-          "$(go env GOPATH)/bin/gazelle" -mode diff > gazelle-diff.txt || true
-          echo "gazelle diff:"
-          cat gazelle-diff.txt
-
       - name: go deps
         # Keep Gazelle version in sync with WORKSPACE
         run: |
@@ -50,6 +42,14 @@ jobs:
           GAZELLE_PATH="$(go env GOPATH)/bin/gazelle" tools/fix_go_deps.sh --diff &> go-deps-diff.txt || true
           echo "go deps diff:"
           cat go-deps-diff.txt
+
+      - name: gazelle
+        # Keep Gazelle version in sync with WORKSPACE
+        run: |
+          go install github.com/bazelbuild/bazel-gazelle/cmd/gazelle@v0.23.0
+          "$(go env GOPATH)/bin/gazelle" -mode diff > gazelle-diff.txt || true
+          echo "gazelle diff:"
+          cat gazelle-diff.txt
 
       - name: clang-format
         run: |

--- a/buildfix.sh
+++ b/buildfix.sh
@@ -55,6 +55,11 @@ else
   bazel run //tools/prettier:fix
 fi
 
+if ((GO_DEPS)); then
+  echo "Fixing go.mod, go.sum, and deps.bzl..."
+  GAZELLE_PATH=$(which gazelle || true) ./tools/fix_go_deps.sh
+fi
+
 if ((GAZELLE)); then
   echo "Fixing BUILD deps with gazelle..."
   if which gazelle &>/dev/null; then
@@ -62,11 +67,6 @@ if ((GAZELLE)); then
   else
     bazel run //:gazelle
   fi
-fi
-
-if ((GO_DEPS)); then
-  echo "Fixing go.mod, go.sum, and deps.bzl..."
-  GAZELLE_PATH=$(which gazelle || true) ./tools/fix_go_deps.sh
 fi
 
 echo 'All done!'


### PR DESCRIPTION
This makes sure that `deps.bzl` is up to date before running Gazelle, which updates BUILD files that can reference the repositories in `deps.bzl`.

The checkstyle change isn't strictly needed, but this applies the same ordering there just to keep things consistent.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
