### PR TITLE
Fix goroutine leak in zstd decoder pool

### DIFF
--- a/server/util/compression/compression.go
+++ b/server/util/compression/compression.go
@@ -152,6 +152,12 @@ func NewZstdChunkingCompressor(reader io.Reader, readBuf []byte, compressBuf []b
 	return pr, nil
 }
 
+// DecoderRef wraps a *zstd.Decoder. Since it does not directly start any
+// goroutines, it can be garbage collected before the wrapped decoder can.
+// When garbage collected, a finalizer automatically closes the wrapped decoder,
+// thus allowing the decoder to be garbage collected as well.
+type DecoderRef struct{ *zstd.Decoder }
+
 // ZstdDecoderPool allows reusing zstd decoders to avoid excessive allocations.
 type ZstdDecoderPool struct {
 	pool sync.Pool
@@ -165,8 +171,11 @@ func NewZstdDecoderPool() *ZstdDecoderPool {
 				if err != nil {
 					return err
 				}
-				runtime.SetFinalizer(dc, (*zstd.Decoder).Close)
-				return dc
+				ref := &DecoderRef{dc}
+				runtime.SetFinalizer(ref, func(ref *DecoderRef) {
+					ref.Decoder.Close()
+				})
+				return ref
 			},
 		},
 	}
@@ -177,25 +186,25 @@ func NewZstdDecoderPool() *ZstdDecoderPool {
 //
 // If the returned decoder will only be used to decode chunks via DecodeAll, a
 // nil reader can be passed.
-func (p *ZstdDecoderPool) Get(reader io.Reader) (*zstd.Decoder, error) {
+func (p *ZstdDecoderPool) Get(reader io.Reader) (*DecoderRef, error) {
 	val := p.pool.Get()
 	if err, ok := val.(error); ok {
 		return nil, err
 	}
 	// No need to check this type assertion since Put can only accept decoders.
-	decoder := val.(*zstd.Decoder)
+	decoder := val.(*DecoderRef)
 	if err := decoder.Reset(reader); err != nil {
 		return nil, err
 	}
 	return decoder, nil
 }
 
-func (p *ZstdDecoderPool) Put(decoder *zstd.Decoder) error {
+func (p *ZstdDecoderPool) Put(ref *DecoderRef) error {
 	// Release reference to enclosed reader before adding back to the pool.
-	if err := decoder.Reset(nil); err != nil {
+	if err := ref.Reset(nil); err != nil {
 		return err
 	}
-	p.pool.Put(decoder)
+	p.pool.Put(ref)
 	return nil
 }
 

--- a/server/util/compression/compression.go
+++ b/server/util/compression/compression.go
@@ -167,7 +167,7 @@ func NewZstdDecoderPool() *ZstdDecoderPool {
 	return &ZstdDecoderPool{
 		pool: sync.Pool{
 			New: func() interface{} {
-				dc, err := zstd.NewReader(nil)
+				dc, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(1))
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
The problem is that the pool waits for decoders to be garbage collected before calling `Close`, but decoders can't be garbage collected until `Close` is called (circular logic).

Fixed by adding a lightweight reference around the decoder that can be garbage collected before the decoder can (since it doesn't start any goroutines itself), and when finalized it closes the underlying decoder.

Before (running a bazel build in a loop that uploads a bunch of compressed artifacts to cache, clearing the local cache in between runs and uploading via a new remote instance name):

![image](https://user-images.githubusercontent.com/2414826/152024140-16d7e1ff-80d3-4c99-9eff-4546c7dbef7e.png)

After (same scenario as above):

![image](https://user-images.githubusercontent.com/2414826/152023144-f8f4076e-00db-44ed-a266-dcb6148e1f53.png)

Also, save even more memory by setting `WithDecoderConcurrency(1)` -- we don't need the default concurrency of GOMAXPROCS because we don't use these decoders concurrently (yet at least). Each decoder compresses one stream at a time (or one chunk, in the `DecodeAll` case). By setting concurrency=1 we're effectively using 8X fewer goroutines.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1131
