### PR TITLE
Move default workflow args to /etc/bazel.bazelrc

### DIFF
--- a/docs/workflows-config.md
+++ b/docs/workflows-config.md
@@ -29,19 +29,14 @@ actions:
         branches:
           - "main"
     bazel_commands:
-      - "test //... --build_metadata=ROLE=CI --bes_backend=grpcs://cloud.buildbuddy.io --bes_results_url=https://app.buildbuddy.io/invocation/"
+      - "test //..."
 ```
 
 This config is equivalent to the default config that we use if you do
-not have a `buildbuddy.yaml`, with some exceptions:
-
-- This example uses `"main"` for the branch name -- if you copy this config,
-  be sure to replace that with the name of your main branch. By default, we
-  run the above bazel command when any branch is pushed.
-- By default, we also pass `--remote_header=x-buildbuddy-api-key=<YOUR_API_KEY>`,
-  so that workflow builds show up in your BuildBuddy org. For security reasons,
-  we do not pass these flags when running workflows on pull request
-  branches from forked repos.
+not have a `buildbuddy.yaml`, with one exception: this example uses `"main"`
+for the branch name -- if you copy this config, be sure to replace that with
+the name of your main branch. By default, we run the above bazel command
+when any branch is pushed.
 
 Other points to note:
 
@@ -57,6 +52,8 @@ Other points to note:
   always recommend including a `.bazelversion` in your repo to prevent
   problems caused by using conflicting versions of Bazel in different
   build environments.
+
+<!-- TODO(bduffany): Document ~/.bazelrc -->
 
 ## Mac configuration
 

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 
@@ -58,7 +57,7 @@ func NewConfig(r io.Reader) (*BuildBuddyConfig, error) {
 
 // GetDefault returns the default workflow config, which tests all targets
 // when pushing to the given target branch, sending build events to BuildBuddy.
-func GetDefault(targetBranch, besBackend, besResultsURL, apiKey string) *BuildBuddyConfig {
+func GetDefault(targetBranch string) *BuildBuddyConfig {
 	return &BuildBuddyConfig{
 		Actions: []*Action{
 			{
@@ -66,16 +65,8 @@ func GetDefault(targetBranch, besBackend, besResultsURL, apiKey string) *BuildBu
 				Triggers: &Triggers{
 					Push: &PushTrigger{Branches: []string{targetBranch}},
 				},
-				BazelCommands: []string{
-					fmt.Sprintf(
-						"test //... "+
-							"--build_metadata=ROLE=CI "+
-							"--bes_backend=%s --bes_results_url=%s "+
-							"--remote_header=x-buildbuddy-api-key=%s",
-						besBackend, besResultsURL,
-						apiKey,
-					),
-				},
+				// Note: default Bazel flags are written by the runner to ~/.bazelrc
+				BazelCommands: []string{"test //..."},
 			},
 		},
 	}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -411,7 +411,7 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 	if err != nil {
 		return nil, err
 	}
-	cfg, err := ws.fetchWorkflowConfig(ctx, apiKey, gitProvider, wf, wd)
+	cfg, err := ws.fetchWorkflowConfig(ctx, gitProvider, wf, wd)
 	if err != nil {
 		return nil, err
 	}
@@ -717,7 +717,7 @@ func (ws *workflowService) checkStartWorkflowPreconditions(ctx context.Context) 
 
 // fetchWorkflowConfig returns the BuildBuddyConfig from the repo, or the
 // default BuildBuddyConfig if one is not set up.
-func (ws *workflowService) fetchWorkflowConfig(ctx context.Context, key *tables.APIKey, gitProvider interfaces.GitProvider, workflow *tables.Workflow, webhookData *interfaces.WebhookData) (*config.BuildBuddyConfig, error) {
+func (ws *workflowService) fetchWorkflowConfig(ctx context.Context, gitProvider interfaces.GitProvider, workflow *tables.Workflow, webhookData *interfaces.WebhookData) (*config.BuildBuddyConfig, error) {
 	b, err := gitProvider.GetFileContents(ctx, workflow.AccessToken, webhookData.PushedRepoURL, config.FilePath, webhookData.SHA)
 	if err != nil {
 		if status.IsNotFoundError(err) {
@@ -754,7 +754,7 @@ func (ws *workflowService) startWorkflow(webhookID string, r *http.Request) erro
 	}
 	// Fetch the workflow config (buildbuddy.yaml) and start a CI runner execution
 	// for each action matching the webhook event.
-	cfg, err := ws.fetchWorkflowConfig(ctx, apiKey, gitProvider, wf, webhookData)
+	cfg, err := ws.fetchWorkflowConfig(ctx, gitProvider, wf, webhookData)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -721,11 +721,7 @@ func (ws *workflowService) fetchWorkflowConfig(ctx context.Context, key *tables.
 	b, err := gitProvider.GetFileContents(ctx, workflow.AccessToken, webhookData.PushedRepoURL, config.FilePath, webhookData.SHA)
 	if err != nil {
 		if status.IsNotFoundError(err) {
-			appConf := ws.env.GetConfigurator()
-			return config.GetDefault(
-				webhookData.TargetBranch, appConf.GetAppEventsAPIURL(),
-				appConf.GetAppBuildBuddyURL()+"/invocation/", key.Value,
-			), nil
+			return config.GetDefault(webhookData.TargetBranch), nil
 		}
 		return nil, err
 	}


### PR DESCRIPTION
Makes the config story consistent between default and non-default (i.e. `buildbuddy.yaml`-configured) workflows, and makes the command line rendered in the UI for the default workflow a bit less messy.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/835
