### PR TITLE
Improve/fix CI runner development script

### DIFF
--- a/enterprise/server/cmd/ci_runner/run_local.sh
+++ b/enterprise/server/cmd/ci_runner/run_local.sh
@@ -87,7 +87,6 @@ docker exec \
   --trigger_event=pull_request \
   --bes_backend=grpc://localhost:1985 \
   --bes_results_url=http://localhost:8080/invocation/ \
-  --debug \
   --workflow_id=WF1234 \
   "$@"
 

--- a/enterprise/server/cmd/ci_runner/run_local.sh
+++ b/enterprise/server/cmd/ci_runner/run_local.sh
@@ -47,23 +47,38 @@ TEMPDIR=$(mktemp --dry-run | xargs dirname)
 : "${CI_RUNNER_BAZEL_CACHE_DIR:=$TEMPDIR/buildbuddy_ci_runner_bazel_cache}"
 
 : "${REPO_PATH:=$PWD}"
+: "${PERSISTENT:=true}"
+: "${BUILDBUDDY_API_KEY:=}"
 
 bazel build //enterprise/server/cmd/ci_runner:buildbuddy_ci_runner
 RUNNER_PATH="$PWD/bazel-bin/enterprise/server/cmd/ci_runner/buildbuddy_ci_runner"
-echo "$RUNNER_PATH"
+RUNNER_DATA_DIR="$TEMPDIR/buildbuddy_ci_runner_data"
+mkdir -p "$RUNNER_DATA_DIR"
+rm -f "$RUNNER_DATA_DIR/ci_runner"
+cp "$RUNNER_PATH" "$RUNNER_DATA_DIR/ci_runner"
+echo "Copied ci_runner to $RUNNER_DATA_DIR/ci_runner"
 
 mkdir -p "$CI_RUNNER_BAZEL_CACHE_DIR"
 
-docker run \
-  --volume "$RUNNER_PATH:/bin/ci_runner" \
-  --volume "$CI_RUNNER_BAZEL_CACHE_DIR:/root/.cache/bazel" \
-  --volume "$(dir_abspath "$REPO_PATH"):/root/mounted_repo" \
-  --net host \
-  --interactive \
-  --tty \
-  --rm \
-  gcr.io/flame-public/buildbuddy-ci-runner:v2.2.8 \
-  ci_runner \
+if ! docker inspect buildbuddy-ci-runner-local &>/dev/null; then
+  # Initialize container
+  docker run \
+    --volume "$RUNNER_DATA_DIR:/runner-data" \
+    --volume "$CI_RUNNER_BAZEL_CACHE_DIR:/root/.cache/bazel" \
+    --volume "$(dir_abspath "$REPO_PATH"):/root/mounted_repo" \
+    --net host \
+    --detach \
+    --rm \
+    --name buildbuddy-ci-runner-local \
+    gcr.io/flame-public/buildbuddy-ci-runner:v2.2.8 \
+    sleep infinity
+fi
+
+docker exec \
+  --interactive --tty \
+  --env BUILDBUDDY_API_KEY="$BUILDBUDDY_API_KEY" \
+  buildbuddy-ci-runner-local \
+  /runner-data/ci_runner \
   --pushed_repo_url="file:///root/mounted_repo" \
   --target_repo_url="file:///root/mounted_repo" \
   --commit_sha="$(cd "$REPO_PATH" && git rev-parse HEAD)" \
@@ -72,4 +87,10 @@ docker run \
   --trigger_event=pull_request \
   --bes_backend=grpc://localhost:1985 \
   --bes_results_url=http://localhost:8080/invocation/ \
+  --debug \
+  --workflow_id=WF1234 \
   "$@"
+
+if [[ "$PERSISTENT" != true ]]; then
+  docker rm -f buildbuddy-ci-runner-local
+fi


### PR DESCRIPTION
- Pass a fake `workflow_id` arg so that workflow testing works again.
- Add a `PERSISTENT` option for easier testing of repo sync behavior (rather than fresh clone), while still allowing the locally built CI runner to be swapped into the persistent container. This avoids needing to re-clone the repo each time the CI runner is changed
- Forward `BUILDBUDDY_API_KEY` env var to the CI runner

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
