### PR TITLE
Firecracker: Improve default task sizing

### DIFF
--- a/enterprise/server/tasksize/BUILD
+++ b/enterprise/server/tasksize/BUILD
@@ -21,6 +21,7 @@ go_test(
     srcs = ["tasksize_test.go"],
     deps = [
         ":tasksize",
+        "//enterprise/server/remote_execution/platform",
         "//proto:remote_execution_go_proto",
         "@com_github_stretchr_testify//assert",
     ],

--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -26,8 +26,8 @@ const (
 	// Additional resources needed depending on task characteristics
 
 	FirecrackerAdditionalMemEstimateBytes = int64(150 * 1e6) // 150 MB
-	DockerAdditionalMemEstimateBytes      = int64(400 * 1e6) // 400 MB
-	DockerAdditionalDiskEstimateBytes     = int64(3 * 1e9)   // 3 GB
+	DockerAdditionalMemEstimateBytes      = int64(800 * 1e6) // 800 MB
+	DockerAdditionalDiskEstimateBytes     = int64(12 * 1e9)  // 12 GB
 
 	MaxEstimatedFreeDisk = int64(20 * 1e9) // 20GB
 
@@ -82,7 +82,7 @@ func Estimate(task *repb.ExecutionTask) *scpb.TaskSize {
 		// Note: props.InitDockerd is only supported for docker-in-firecracker.
 		if props.InitDockerd {
 			freeDiskEstimate += DockerAdditionalDiskEstimateBytes
-			memEstimate += DockerAdditionalDiskEstimateBytes
+			memEstimate += DockerAdditionalMemEstimateBytes
 		}
 	}
 

--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -25,9 +25,23 @@ const (
 
 	// Additional resources needed depending on task characteristics
 
+	// FirecrackerAdditionalMemEstimateBytes represents the overhead incurred by
+	// the firecracker runtime. It was computed as the minimum memory needed to
+	// execute a trivial task (i.e. pwd) in Firecracker, multiplied by ~1.5x so
+	// that we have some wiggle room.
 	FirecrackerAdditionalMemEstimateBytes = int64(150 * 1e6) // 150 MB
-	DockerAdditionalMemEstimateBytes      = int64(800 * 1e6) // 800 MB
-	DockerAdditionalDiskEstimateBytes     = int64(12 * 1e9)  // 12 GB
+
+	// DockerInFirecrackerAdditionalMemEstimateBytes is an additional memory
+	// estimate added for docker-in-firecracker actions. It was computed as the
+	// minimum additional memory needed to run a mysql:8.0 container inside
+	// a firecracker VM, multiplied by ~2X.
+	DockerInFirecrackerAdditionalMemEstimateBytes = int64(800 * 1e6) // 800 MB
+
+	// DockerInFirecrackerAdditionalDiskEstimateBytes is an additional memory
+	// estimate added for docker-in-firecracker actions. It was computed as the
+	// minimum additional disk needed to run a mysql:8.0 container inside
+	// a firecracker VM, multiplied by ~3X.
+	DockerInFirecrackerAdditionalDiskEstimateBytes = int64(12 * 1e9) // 12 GB
 
 	MaxEstimatedFreeDisk = int64(20 * 1e9) // 20GB
 
@@ -81,8 +95,8 @@ func Estimate(task *repb.ExecutionTask) *scpb.TaskSize {
 		memEstimate += FirecrackerAdditionalMemEstimateBytes
 		// Note: props.InitDockerd is only supported for docker-in-firecracker.
 		if props.InitDockerd {
-			freeDiskEstimate += DockerAdditionalDiskEstimateBytes
-			memEstimate += DockerAdditionalMemEstimateBytes
+			freeDiskEstimate += DockerInFirecrackerAdditionalDiskEstimateBytes
+			memEstimate += DockerInFirecrackerAdditionalMemEstimateBytes
 		}
 	}
 

--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/tasksize"
 	"github.com/stretchr/testify/assert"
 
@@ -38,6 +39,41 @@ func TestEstimate_TestTask_RespectsTestSize(t *testing.T) {
 		assert.Equal(t, testCase.expectedMilliCPU, ts.EstimatedMilliCpu)
 		assert.Equal(t, tasksize.DefaultFreeDiskEstimate, ts.EstimatedFreeDiskBytes)
 	}
+}
+
+func TestEstimate_TestTask_Firecracker_AddsAdditionalResources(t *testing.T) {
+	for _, testCase := range []struct {
+		size                string
+		isolationType       platform.ContainerType
+		initDockerd         bool
+		expectedMemoryBytes int64
+		expectedMilliCPU    int64
+		expectedDiskBytes   int64
+	}{
+		{"small", platform.BareContainerType, false /*=initDockerd*/, 20 * 1e6, 600, tasksize.DefaultFreeDiskEstimate},
+		{"enormous", platform.BareContainerType, false /*=initDockerd*/, 800 * 1e6, 1000, tasksize.DefaultFreeDiskEstimate},
+		{"small", platform.FirecrackerContainerType, false /*=initDockerd*/, 20*1e6 + tasksize.FirecrackerAdditionalMemEstimateBytes, 600, tasksize.DefaultFreeDiskEstimate},
+		{"enormous", platform.FirecrackerContainerType, true /*=initDockerd*/, 800*1e6 + tasksize.FirecrackerAdditionalMemEstimateBytes + tasksize.DockerAdditionalMemEstimateBytes, 1000, tasksize.DefaultFreeDiskEstimate + tasksize.DockerAdditionalDiskEstimateBytes},
+	} {
+		ts := tasksize.Estimate(&repb.ExecutionTask{
+			Command: &repb.Command{
+				Platform: &repb.Platform{
+					Properties: []*repb.Platform_Property{
+						{Name: "workload-isolation-type", Value: string(testCase.isolationType)},
+						{Name: "init-dockerd", Value: fmt.Sprintf("%v", testCase.initDockerd)},
+					},
+				},
+				EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+					{Name: "TEST_SIZE", Value: testCase.size},
+				},
+			},
+		})
+
+		assert.Equal(t, testCase.expectedMemoryBytes, ts.EstimatedMemoryBytes)
+		assert.Equal(t, testCase.expectedMilliCPU, ts.EstimatedMilliCpu)
+		assert.Equal(t, testCase.expectedDiskBytes, ts.EstimatedFreeDiskBytes)
+	}
+
 }
 
 func TestEstimate_BCUPlatformProps_ConvertsBCUToTaskSize(t *testing.T) {

--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -53,7 +53,7 @@ func TestEstimate_TestTask_Firecracker_AddsAdditionalResources(t *testing.T) {
 		{"small", platform.BareContainerType, false /*=initDockerd*/, 20 * 1e6, 600, tasksize.DefaultFreeDiskEstimate},
 		{"enormous", platform.BareContainerType, false /*=initDockerd*/, 800 * 1e6, 1000, tasksize.DefaultFreeDiskEstimate},
 		{"small", platform.FirecrackerContainerType, false /*=initDockerd*/, 20*1e6 + tasksize.FirecrackerAdditionalMemEstimateBytes, 600, tasksize.DefaultFreeDiskEstimate},
-		{"enormous", platform.FirecrackerContainerType, true /*=initDockerd*/, 800*1e6 + tasksize.FirecrackerAdditionalMemEstimateBytes + tasksize.DockerAdditionalMemEstimateBytes, 1000, tasksize.DefaultFreeDiskEstimate + tasksize.DockerAdditionalDiskEstimateBytes},
+		{"enormous", platform.FirecrackerContainerType, true /*=initDockerd*/, 800*1e6 + tasksize.FirecrackerAdditionalMemEstimateBytes + tasksize.DockerInFirecrackerAdditionalMemEstimateBytes, 1000, tasksize.DefaultFreeDiskEstimate + tasksize.DockerInFirecrackerAdditionalDiskEstimateBytes},
 	} {
 		ts := tasksize.Estimate(&repb.ExecutionTask{
 			Command: &repb.Command{


### PR DESCRIPTION
- Account for firecracker VM memory overhead in memory estimate. Experimentally, I found that firecracker needs at least 104 MB of memory to be able to run a trivial task (`pwd`). This PR sets the overhead to 150MB to give us some wiggle room. I think this might depend on the size of `initrd.cpio` + `vmlinux` since those get loaded into memory (?) so in the future we might want to calculate the sizes of those files at build time and derive the estimate from those sizes.
- Increase memory and disk estimates when using docker-in-firecracker. I found that running a `mysql:8.0` image inside a test requires at least 400MB additional memory (on top of the default estimate for a `small` test) and about 4GB additional disk space. I derived the estimate values by multiplying those by 2x and 3x, respectively, since customers may run more images / heavier images in their tests.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1094