### PR TITLE
Fix occasional pipe failure in fix_go_deps.sh

### DIFF
--- a/tools/fix_go_deps.sh
+++ b/tools/fix_go_deps.sh
@@ -59,7 +59,7 @@ fi
 # Note that all indirect imports are in the second block if and only if
 # we see two consecutive "require (" lines as the first 2 lines. So we just
 # check for that here.
-first_two_lines=$(grep -E '(^require \(|// indirect)' go.mod | head -n 2)
+first_two_lines=$( (grep -E '(^require \(|// indirect)' go.mod || true) | head -n 2)
 if [[ $(echo "$first_two_lines" | uniq) != 'require (' ]]; then
   echo "ERROR: Found direct and indirect imports mixed within the same require() block in go.mod" >&2
   echo "Please fix by manually merging all require() blocks into a single block, then running tools/fix_go_deps.sh" >&2


### PR DESCRIPTION
It appears that grep sometimes fails because `head -n 2` is closing the read end of the pipe before `grep` has a chance to write all of its output to the pipe.

Demo:

```bash
for i in $(seq 20); do
  (
    set -euo pipefail
    grep -E '(^require \(|// indirect)' go.mod | head -n 2
  ) &>/dev/null || echo "pipefail on attempt $i"
done
# Output:
pipefail on attempt 2
pipefail on attempt 6
pipefail on attempt 8
pipefail on attempt 13
pipefail on attempt 15
```

The fix is to change `grep ...` to `(grep ... || true)` so that the overall command doesn't fail if grep tries to write to a closed pipe.

```bash
for i in $(seq 1000); do
  (
    set -euo pipefail
    ( grep -E '(^require \(|// indirect)' go.mod || true ) | head -n 2
  ) &>/dev/null || echo "pipefail on attempt $i"
done
# No failures :)
```

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
