### PR TITLE
Firecracker: Fix error when passing more than one init flag

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -750,13 +750,13 @@ func (c *FirecrackerContainer) getConfig(ctx context.Context, containerFS, works
 
 	// Pass some flags to the init script.
 	if c.constants.DebugMode {
-		bootArgs = "--debug_mode " + bootArgs
+		bootArgs = "-debug_mode " + bootArgs
 	}
 	if c.constants.EnableNetworking {
-		bootArgs = "--set_default_route " + bootArgs
+		bootArgs = "-set_default_route " + bootArgs
 	}
 	if c.constants.InitDockerd {
-		bootArgs = "--init_dockerd " + bootArgs
+		bootArgs = "-init_dockerd " + bootArgs
 	}
 	cfg := &fcclient.Config{
 		VMID:            c.id,


### PR DESCRIPTION
It looks like as of firecracker v0.25, passing more than one `--` to bootArgs is not allowed, even if `--` is used as a prefix rather than a standalone arg. It causes the error

```
Internal: Failed starting machine: [PUT /actions][400] createSyncActionBadRequest  &{FaultMessage:Invalid kernel command line: Too many `--` in kernel cmdline.}
```

Was able to repro the error locally after upgrading from v0.24 -> v0.25, and verified that passing the args with a single `-` instead of `--` fixes the issue.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
