### PR TITLE
Add tests for replica

### DIFF
--- a/enterprise/server/raft/api/BUILD
+++ b/enterprise/server/raft/api/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//proto:raft_service_go_proto",
         "//server/util/disk",
         "//server/util/grpc_server",
-        "//server/util/log",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//reflection",
     ],

--- a/enterprise/server/raft/cache/BUILD
+++ b/enterprise/server/raft/cache/BUILD
@@ -47,6 +47,7 @@ go_test(
         "//server/testutil/testdigest",
         "//server/testutil/testenv",
         "//server/util/disk",
+        "//server/util/log",
         "//server/util/prefix",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/raft/cache/BUILD
+++ b/enterprise/server/raft/cache/BUILD
@@ -47,7 +47,6 @@ go_test(
         "//server/testutil/testdigest",
         "//server/testutil/testenv",
         "//server/util/disk",
-        "//server/util/log",
         "//server/util/prefix",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -311,7 +311,12 @@ func (rc *RaftCache) Reader(ctx context.Context, d *repb.Digest, offset int64) (
 
 	var readCloser io.ReadCloser
 	err = rc.sender.Run(ctx, fileKey, func(c rfspb.ApiClient, h *rfpb.Header) error {
-		r, err := rc.apiClient.RemoteReader(ctx, c, fileRecord, offset)
+		req := &rfpb.ReadRequest{
+			Header:     h,
+			FileRecord: fileRecord,
+			Offset:     offset,
+		}
+		r, err := rc.apiClient.RemoteReader(ctx, c, req)
 		if err != nil {
 			return err
 		}
@@ -414,10 +419,6 @@ func (rc *RaftCache) FindMissing(ctx context.Context, digests []*repb.Digest) ([
 		}
 		req := reqs[rangeDescriptor.GetRangeId()]
 		req.FileRecord = append(req.FileRecord, fileRecord)
-	}
-
-	for rangeID, reqs := range reqs {
-		log.Printf("cache.go: FindMissing: rangeID: %d: requests: %d", rangeID, len(reqs.FileRecord))
 	}
 
 	missingDigests := make([]*repb.Digest, 0)

--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -248,7 +248,7 @@ func (rc *RaftCache) Check(ctx context.Context) error {
 		return status.UnavailableError("node is still initializing")
 	}
 
-	key := constants.InitClusterSetupTimeKey
+	key := constants.ClusterSetupTimeKey
 	readReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectReadRequest{
 		Key: key,
 	}).ToProto()
@@ -414,6 +414,10 @@ func (rc *RaftCache) FindMissing(ctx context.Context, digests []*repb.Digest) ([
 		}
 		req := reqs[rangeDescriptor.GetRangeId()]
 		req.FileRecord = append(req.FileRecord, fileRecord)
+	}
+
+	for rangeID, reqs := range reqs {
+		log.Printf("cache.go: FindMissing: rangeID: %d: requests: %d", rangeID, len(reqs.FileRecord))
 	}
 
 	missingDigests := make([]*repb.Digest, 0)

--- a/enterprise/server/raft/cache/cache_test.go
+++ b/enterprise/server/raft/cache/cache_test.go
@@ -425,7 +425,6 @@ func TestFindMissingBlobs(t *testing.T) {
 	for _, d := range missing {
 		missingHashes = append(missingHashes, d.GetHash())
 	}
-	require.Equal(t, expectedMissingHashes, missingHashes)
-
+	require.ElementsMatch(t, expectedMissingHashes, missingHashes)
 	waitForShutdown(t, rc1, rc2, rc3)
 }

--- a/enterprise/server/raft/cache/cache_test.go
+++ b/enterprise/server/raft/cache/cache_test.go
@@ -274,7 +274,7 @@ func TestCacheShutdown(t *testing.T) {
 
 	cacheRPCTimeout := 5 * time.Second
 	digestsWritten := make([]*repb.Digest, 0)
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		ctx, cancel := context.WithTimeout(ctx, cacheRPCTimeout)
 		defer cancel()
 		d, buf := testdigest.NewRandomDigestBuf(t, 100)
@@ -285,7 +285,7 @@ func TestCacheShutdown(t *testing.T) {
 	// shutdown one node
 	waitForShutdown(t, rc3)
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		ctx, cancel := context.WithTimeout(ctx, cacheRPCTimeout)
 		defer cancel()
 		d, buf := testdigest.NewRandomDigestBuf(t, 100)

--- a/enterprise/server/raft/constants/constants.go
+++ b/enterprise/server/raft/constants/constants.go
@@ -64,16 +64,16 @@ var (
 	SystemPrefix    = keys.Key{systemPrefixByte}
 
 	// The last clusterID that was generated.
-	LastClusterIDKey = keys.MakeKey(MetaRangePrefix, []byte("last_cluster_id"))
+	LastClusterIDKey = keys.MakeKey(SystemPrefix, []byte("last_cluster_id"))
 
 	// The last nodeID that was generated.
-	LastNodeIDKey = keys.MakeKey(MetaRangePrefix, []byte("last_node_id"))
+	LastNodeIDKey = keys.MakeKey(SystemPrefix, []byte("last_node_id"))
 
 	// The last rangeID that was generated.
-	LastRangeIDKey = keys.MakeKey(MetaRangePrefix, []byte("last_range_id"))
+	LastRangeIDKey = keys.MakeKey(SystemPrefix, []byte("last_range_id"))
 
-	// When the first cluster was initially set up.
-	InitClusterSetupTimeKey = keys.MakeKey(MetaRangePrefix, []byte("initial_cluster_initialization_time"))
+	// When the cluster was created.
+	ClusterSetupTimeKey = keys.MakeKey(LocalPrefix, []byte("cluster_setup_time"))
 
 	// The last index that was applied by a statemachine.
 	LastAppliedIndexKey = keys.MakeKey(LocalPrefix, []byte("lastAppliedIndex"))

--- a/enterprise/server/raft/keys/keys.go
+++ b/enterprise/server/raft/keys/keys.go
@@ -21,6 +21,10 @@ func RangeMetaKey(key Key) Key {
 	return MakeKey([]byte{'\x02'}, key)
 }
 
+func SystemKey(key Key) Key {
+	return MakeKey([]byte{'\x03'}, key)
+}
+
 func IsLocalKey(key Key) bool {
 	if len(key) == 0 {
 		return false

--- a/enterprise/server/raft/replica/BUILD
+++ b/enterprise/server/raft/replica/BUILD
@@ -26,9 +26,14 @@ go_test(
     srcs = ["replica_test.go"],
     deps = [
         ":replica",
+        "//enterprise/server/raft/keys",
+        "//enterprise/server/raft/rbuilder",
+        "//proto:raft_go_proto",
         "//server/testutil/testdigest",
         "//server/util/disk",
+        "//server/util/status",
         "@com_github_cockroachdb_pebble//:pebble",
+        "@com_github_lni_dragonboat_v3//statemachine",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/raft/replica/BUILD
+++ b/enterprise/server/raft/replica/BUILD
@@ -6,12 +6,9 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/replica",
     visibility = ["//visibility:public"],
     deps = [
-        "//enterprise/server/raft/client",
         "//enterprise/server/raft/constants",
         "//enterprise/server/raft/keys",
-        "//enterprise/server/raft/sender",
         "//proto:raft_go_proto",
-        "//proto:raft_service_go_proto",
         "//server/util/disk",
         "//server/util/log",
         "//server/util/rangemap",

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -410,7 +410,7 @@ func (sm *Replica) cas(wb *pebble.Batch, req *rfpb.CASRequest) (*rfpb.CASRespons
 
 func (sm *Replica) scan(req *rfpb.ScanRequest) (*rfpb.ScanResponse, error) {
 	if len(req.GetLeft()) == 0 {
-		return nil, status.InvalidArgumentError("Increment requires a valid key.")
+		return nil, status.InvalidArgumentError("Scan requires a valid key.")
 	}
 
 	iterOpts := &pebble.IterOptions{}

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -9,11 +9,10 @@ import (
 	"io"
 	"path/filepath"
 	"sync"
+	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/client"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/rangemap"
@@ -22,15 +21,15 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
-	rfspb "github.com/buildbuddy-io/buildbuddy/proto/raft_service"
 	dbsm "github.com/lni/dragonboat/v3/statemachine"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	gstatus "google.golang.org/grpc/status"
 )
 
-type RangeTracker interface {
+type IStore interface {
 	AddRange(rd *rfpb.RangeDescriptor, r *Replica)
 	RemoveRange(rd *rfpb.RangeDescriptor, r *Replica)
+	ReadFileFromPeer(ctx context.Context, except *rfpb.ReplicaDescriptor, fileRecord *rfpb.FileRecord) (io.ReadCloser, error)
 }
 
 // KVs are stored directly in Pebble by the raft state machine, so the key and
@@ -86,9 +85,7 @@ type Replica struct {
 	clusterID uint64
 	nodeID    uint64
 
-	rangeTracker     RangeTracker
-	sender           *sender.Sender
-	apiClient        *client.APIClient
+	store            IStore
 	lastAppliedIndex uint64
 
 	log             log.Logger
@@ -167,7 +164,7 @@ func (sm *Replica) maybeSetRange(key, val []byte) error {
 			Left:  rangeDescriptor.GetLeft(),
 			Right: rangeDescriptor.GetRight(),
 		}
-		sm.rangeTracker.AddRange(sm.rangeDescriptor, sm)
+		sm.store.AddRange(sm.rangeDescriptor, sm)
 	}
 	sm.rangeMu.Unlock()
 	return nil
@@ -226,7 +223,8 @@ func (sm *Replica) getLastAppliedIndex() (uint64, error) {
 	if len(val) == 0 {
 		return 0, nil
 	}
-	return bytesToUint64(val), nil
+	i := bytesToUint64(val)
+	return i, nil
 }
 
 func (sm *Replica) getDBDir() string {
@@ -280,32 +278,30 @@ func (sm *Replica) checkAndSetRangeDescriptor() {
 }
 
 func (sm *Replica) readFileFromPeer(ctx context.Context, fileRecord *rfpb.FileRecord) error {
-	fileKey, err := constants.FileKey(fileRecord)
+	thisReplica := &rfpb.ReplicaDescriptor{
+		ClusterId: sm.clusterID,
+		NodeId:    sm.nodeID,
+	}
+	r, err := sm.store.ReadFileFromPeer(ctx, thisReplica, fileRecord)
 	if err != nil {
 		return err
 	}
-	err = sm.sender.Run(ctx, fileKey, func(c rfspb.ApiClient, h *rfpb.Header) error {
-		r, err := sm.apiClient.RemoteReader(ctx, c, fileRecord, 0 /*=offset*/)
-		if err != nil {
-			return err
-		}
-		file, err := constants.FilePath(sm.fileDir, fileRecord)
-		if err != nil {
-			return err
-		}
-		wc, err := disk.FileWriter(ctx, file)
-		if err != nil {
-			return err
-		}
-		if _, err := io.Copy(wc, r); err != nil {
-			return err
-		}
-		if err := wc.Close(); err != nil {
-			return err
-		}
-		return nil
-	})
-	return err
+	defer r.Close()
+	file, err := constants.FilePath(sm.fileDir, fileRecord)
+	if err != nil {
+		return err
+	}
+	wc, err := disk.FileWriter(ctx, file)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(wc, r); err != nil {
+		return err
+	}
+	if err := wc.Close(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (sm *Replica) fileWrite(wb *pebble.Batch, req *rfpb.FileWriteRequest) (*rfpb.FileWriteResponse, error) {
@@ -321,13 +317,13 @@ func (sm *Replica) fileWrite(wb *pebble.Batch, req *rfpb.FileWriteRequest) (*rfp
 	if err != nil {
 		return nil, err
 	}
-	ctx := context.Background()
-	if exists, err := disk.FileExists(ctx, f); err == nil && exists {
-		return &rfpb.FileWriteResponse{}, sm.rangeCheckedSet(wb, fileKey, protoBytes)
-	}
-	if err := sm.readFileFromPeer(ctx, req.GetFileRecord()); err != nil {
-		log.Errorf("ReadFileFromPeer failed: %s", err)
-		return nil, err
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if exists, err := disk.FileExists(ctx, f); err != nil || !exists {
+		if err := sm.readFileFromPeer(ctx, req.GetFileRecord()); err != nil {
+			log.Errorf("Error recovering file %q from peer: %s", f, err)
+			return nil, err
+		}
 	}
 	if exists, err := disk.FileExists(ctx, f); err == nil && exists {
 		return &rfpb.FileWriteResponse{}, sm.rangeCheckedSet(wb, fileKey, protoBytes)
@@ -859,8 +855,8 @@ func (sm *Replica) Close() error {
 	rangeDescriptor := sm.rangeDescriptor
 	sm.rangeMu.Unlock()
 
-	if sm.rangeTracker != nil && rangeDescriptor != nil {
-		sm.rangeTracker.RemoveRange(rangeDescriptor, sm)
+	if sm.store != nil && rangeDescriptor != nil {
+		sm.store.RemoveRange(rangeDescriptor, sm)
 	}
 	if sm.db != nil {
 		return sm.db.Close()
@@ -869,16 +865,14 @@ func (sm *Replica) Close() error {
 }
 
 // CreateReplica creates an ondisk statemachine.
-func New(rootDir, fileDir string, clusterID, nodeID uint64, rangeTracker RangeTracker, sender *sender.Sender, apiClient *client.APIClient) dbsm.IOnDiskStateMachine {
+func New(rootDir, fileDir string, clusterID, nodeID uint64, store IStore) dbsm.IOnDiskStateMachine {
 	return &Replica{
-		closedMu:     &sync.RWMutex{},
-		rootDir:      rootDir,
-		fileDir:      fileDir,
-		clusterID:    clusterID,
-		nodeID:       nodeID,
-		rangeTracker: rangeTracker,
-		sender:       sender,
-		apiClient:    apiClient,
-		log:          log.NamedSubLogger(fmt.Sprintf("c%dn%d", clusterID, nodeID)),
+		closedMu:  &sync.RWMutex{},
+		rootDir:   rootDir,
+		fileDir:   fileDir,
+		clusterID: clusterID,
+		nodeID:    nodeID,
+		store:     store,
+		log:       log.NamedSubLogger(fmt.Sprintf("c%dn%d", clusterID, nodeID)),
 	}
 }

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -865,7 +865,7 @@ func (sm *Replica) Close() error {
 }
 
 // CreateReplica creates an ondisk statemachine.
-func New(rootDir, fileDir string, clusterID, nodeID uint64, store IStore) dbsm.IOnDiskStateMachine {
+func New(rootDir, fileDir string, clusterID, nodeID uint64, store IStore) *Replica {
 	return &Replica{
 		closedMu:  &sync.RWMutex{},
 		rootDir:   rootDir,

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -1,15 +1,23 @@
 package replica_test
 
 import (
+	"context"
+	"io"
 	"io/ioutil"
 	"os"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/replica"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/cockroachdb/pebble"
 	"github.com/stretchr/testify/require"
+
+	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+	dbsm "github.com/lni/dragonboat/v3/statemachine"
 )
 
 func getTmpDir(t *testing.T) string {
@@ -27,6 +35,14 @@ func getTmpDir(t *testing.T) string {
 		}
 	})
 	return dir
+}
+
+type fakeStore struct{}
+
+func (fs *fakeStore) AddRange(rd *rfpb.RangeDescriptor, r *replica.Replica)    {}
+func (fs *fakeStore) RemoveRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {}
+func (fs *fakeStore) ReadFileFromPeer(ctx context.Context, except *rfpb.ReplicaDescriptor, fileRecord *rfpb.FileRecord) (io.ReadCloser, error) {
+	return nil, nil
 }
 
 func TestSnapshotAndRestore(t *testing.T) {
@@ -71,4 +87,292 @@ func TestSnapshotAndRestore(t *testing.T) {
 	}
 	require.Equal(t, 0, len(hashes))
 	db.Close()
+}
+
+func TestOpenCloseReplica(t *testing.T) {
+	rootDir := getTmpDir(t)
+	fileDir := getTmpDir(t)
+	store := &fakeStore{}
+	repl := replica.New(rootDir, fileDir, 1, 1, store)
+	require.NotNil(t, repl)
+
+	stopc := make(chan struct{})
+	lastAppliedIndex, err := repl.Open(stopc)
+	require.Nil(t, err)
+	require.Equal(t, uint64(0), lastAppliedIndex)
+
+	err = repl.Close()
+	require.Nil(t, err)
+}
+
+type entryMaker struct {
+	index uint64
+	t     *testing.T
+}
+
+func newEntryMaker(t *testing.T) *entryMaker {
+	return &entryMaker{
+		t: t,
+	}
+}
+func (em *entryMaker) makeEntry(batch *rbuilder.BatchBuilder) dbsm.Entry {
+	em.index += 1
+	buf, err := batch.ToBuf()
+	if err != nil {
+		em.t.Fatalf("Error making entry: %s", err)
+	}
+	return dbsm.Entry{Cmd: buf, Index: em.index}
+}
+
+func TestReplicaDirectReadWrite(t *testing.T) {
+	rootDir := getTmpDir(t)
+	fileDir := getTmpDir(t)
+	store := &fakeStore{}
+	repl := replica.New(rootDir, fileDir, 1, 1, store)
+	require.NotNil(t, repl)
+
+	stopc := make(chan struct{})
+	lastAppliedIndex, err := repl.Open(stopc)
+	require.Nil(t, err)
+	require.Equal(t, uint64(0), lastAppliedIndex)
+
+	// Do a DirectWrite.
+	em := newEntryMaker(t)
+	entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   []byte("key-name"),
+			Value: []byte("key-value"),
+		},
+	}))
+	entries := []dbsm.Entry{entry}
+	writeRsp, err := repl.Update(entries)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(writeRsp))
+
+	// Do a DirectRead and verify the value is was written.
+	buf, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectReadRequest{
+		Key: []byte("key-name"),
+	}).ToBuf()
+	readRsp, err := repl.Lookup(buf)
+	require.Nil(t, err)
+
+	readBatch := rbuilder.NewBatchResponse(readRsp)
+	directRead, err := readBatch.DirectReadResponse(0)
+	require.Nil(t, err)
+
+	require.Equal(t, []byte("key-value"), directRead.GetKv().GetValue())
+
+	err = repl.Close()
+	require.Nil(t, err)
+}
+
+func TestReplicaIncrement(t *testing.T) {
+	rootDir := getTmpDir(t)
+	fileDir := getTmpDir(t)
+	store := &fakeStore{}
+	repl := replica.New(rootDir, fileDir, 1, 1, store)
+	require.NotNil(t, repl)
+
+	stopc := make(chan struct{})
+	lastAppliedIndex, err := repl.Open(stopc)
+	require.Nil(t, err)
+	require.Equal(t, uint64(0), lastAppliedIndex)
+
+	// Do a DirectWrite.
+	em := newEntryMaker(t)
+	entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.IncrementRequest{
+		Key:   []byte("incr-key"),
+		Delta: 1,
+	}))
+	writeRsp, err := repl.Update([]dbsm.Entry{entry})
+	require.Nil(t, err)
+	require.Equal(t, 1, len(writeRsp))
+
+	// Make sure the response holds the new value.
+	incrBatch := rbuilder.NewBatchResponse(writeRsp[0].Result.Data)
+	incrRsp, err := incrBatch.IncrementResponse(0)
+	require.Nil(t, err)
+	require.Equal(t, uint64(1), incrRsp.GetValue())
+
+	// Increment the same key again by a different value.
+	entry = em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.IncrementRequest{
+		Key:   []byte("incr-key"),
+		Delta: 3,
+	}))
+	writeRsp, err = repl.Update([]dbsm.Entry{entry})
+	require.Nil(t, err)
+	require.Equal(t, 1, len(writeRsp))
+
+	// Make sure the response holds the new value.
+	incrBatch = rbuilder.NewBatchResponse(writeRsp[0].Result.Data)
+	incrRsp, err = incrBatch.IncrementResponse(0)
+	require.Nil(t, err)
+	require.Equal(t, uint64(4), incrRsp.GetValue())
+
+	err = repl.Close()
+	require.Nil(t, err)
+}
+
+func TestReplicaCAS(t *testing.T) {
+	rootDir := getTmpDir(t)
+	fileDir := getTmpDir(t)
+	store := &fakeStore{}
+	repl := replica.New(rootDir, fileDir, 1, 1, store)
+	require.NotNil(t, repl)
+
+	stopc := make(chan struct{})
+	lastAppliedIndex, err := repl.Open(stopc)
+	require.Nil(t, err)
+	require.Equal(t, uint64(0), lastAppliedIndex)
+
+	// Do a DirectWrite.
+	em := newEntryMaker(t)
+	entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   []byte("key-name"),
+			Value: []byte("key-value"),
+		},
+	}))
+	writeRsp, err := repl.Update([]dbsm.Entry{entry})
+	require.Nil(t, err)
+	require.Equal(t, 1, len(writeRsp))
+
+	// Do a CAS and verify:
+	//   1) the value is not set
+	//   2) the current value is returned.
+	entry = em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.CASRequest{
+		Kv: &rfpb.KV{
+			Key:   []byte("key-name"),
+			Value: []byte("new-key-value"),
+		},
+		ExpectedValue: []byte("bogus-expected-value"),
+	}))
+	writeRsp, err = repl.Update([]dbsm.Entry{entry})
+	require.Nil(t, err)
+
+	readBatch := rbuilder.NewBatchResponse(writeRsp[0].Result.Data)
+	casRsp, err := readBatch.CASResponse(0)
+	require.True(t, status.IsFailedPreconditionError(err))
+	require.Equal(t, []byte("key-value"), casRsp.GetKv().GetValue())
+
+	// Do a CAS with the correct expected value and ensure
+	// the value was written.
+	entry = em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.CASRequest{
+		Kv: &rfpb.KV{
+			Key:   []byte("key-name"),
+			Value: []byte("new-key-value"),
+		},
+		ExpectedValue: []byte("key-value"),
+	}))
+	writeRsp, err = repl.Update([]dbsm.Entry{entry})
+	require.Nil(t, err)
+
+	readBatch = rbuilder.NewBatchResponse(writeRsp[0].Result.Data)
+	casRsp, err = readBatch.CASResponse(0)
+	require.Nil(t, err)
+	require.Equal(t, []byte("new-key-value"), casRsp.GetKv().GetValue())
+
+	err = repl.Close()
+	require.Nil(t, err)
+}
+
+func TestReplicaScan(t *testing.T) {
+	rootDir := getTmpDir(t)
+	fileDir := getTmpDir(t)
+	store := &fakeStore{}
+	repl := replica.New(rootDir, fileDir, 1, 1, store)
+	require.NotNil(t, repl)
+
+	stopc := make(chan struct{})
+	lastAppliedIndex, err := repl.Open(stopc)
+	require.Nil(t, err)
+	require.Equal(t, uint64(0), lastAppliedIndex)
+
+	// Do a DirectWrite of some range descriptors.
+	em := newEntryMaker(t)
+	batch := rbuilder.NewBatchBuilder()
+	batch = batch.Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   keys.RangeMetaKey([]byte("b")),
+			Value: []byte("range-1"),
+		},
+	})
+	batch = batch.Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   keys.RangeMetaKey([]byte("c")),
+			Value: []byte("range-2"),
+		},
+	})
+	batch = batch.Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   keys.RangeMetaKey([]byte("d")),
+			Value: []byte("range-3"),
+		},
+	})
+	entry := em.makeEntry(batch)
+	writeRsp, err := repl.Update([]dbsm.Entry{entry})
+	require.Nil(t, err)
+	require.Equal(t, 1, len(writeRsp))
+
+	// Ensure that scan reads just the ranges we want.
+	// Scan b-c.
+	buf, err := rbuilder.NewBatchBuilder().Add(&rfpb.ScanRequest{
+		Left:     keys.RangeMetaKey([]byte("b")),
+		Right:    keys.RangeMetaKey([]byte("c")),
+		ScanType: rfpb.ScanRequest_SEEKGE_SCAN_TYPE,
+	}).ToBuf()
+	readRsp, err := repl.Lookup(buf)
+	require.Nil(t, err)
+
+	readBatch := rbuilder.NewBatchResponse(readRsp)
+	scanRsp, err := readBatch.ScanResponse(0)
+	require.Nil(t, err)
+	require.Equal(t, []byte("range-1"), scanRsp.GetKvs()[0].GetValue())
+
+	// Scan c-d.
+	buf, err = rbuilder.NewBatchBuilder().Add(&rfpb.ScanRequest{
+		Left:     keys.RangeMetaKey([]byte("c")),
+		Right:    keys.RangeMetaKey([]byte("d")),
+		ScanType: rfpb.ScanRequest_SEEKGE_SCAN_TYPE,
+	}).ToBuf()
+	readRsp, err = repl.Lookup(buf)
+	require.Nil(t, err)
+
+	readBatch = rbuilder.NewBatchResponse(readRsp)
+	scanRsp, err = readBatch.ScanResponse(0)
+	require.Nil(t, err)
+	require.Equal(t, []byte("range-2"), scanRsp.GetKvs()[0].GetValue())
+
+	// Scan d-*.
+	buf, err = rbuilder.NewBatchBuilder().Add(&rfpb.ScanRequest{
+		Left:     keys.RangeMetaKey([]byte("d")),
+		Right:    keys.RangeMetaKey([]byte("z")),
+		ScanType: rfpb.ScanRequest_SEEKGE_SCAN_TYPE,
+	}).ToBuf()
+	readRsp, err = repl.Lookup(buf)
+	require.Nil(t, err)
+
+	readBatch = rbuilder.NewBatchResponse(readRsp)
+	scanRsp, err = readBatch.ScanResponse(0)
+	require.Nil(t, err)
+	require.Equal(t, []byte("range-3"), scanRsp.GetKvs()[0].GetValue())
+
+	// Scan the full range.
+	buf, err = rbuilder.NewBatchBuilder().Add(&rfpb.ScanRequest{
+		Left:     keys.RangeMetaKey([]byte("a")),
+		Right:    keys.RangeMetaKey([]byte("z")),
+		ScanType: rfpb.ScanRequest_SEEKGE_SCAN_TYPE,
+	}).ToBuf()
+	readRsp, err = repl.Lookup(buf)
+	require.Nil(t, err)
+
+	readBatch = rbuilder.NewBatchResponse(readRsp)
+	scanRsp, err = readBatch.ScanResponse(0)
+	require.Nil(t, err)
+	require.Equal(t, []byte("range-1"), scanRsp.GetKvs()[0].GetValue())
+	require.Equal(t, []byte("range-2"), scanRsp.GetKvs()[1].GetValue())
+	require.Equal(t, []byte("range-3"), scanRsp.GetKvs()[2].GetValue())
+
+	err = repl.Close()
+	require.Nil(t, err)
 }

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -56,35 +56,40 @@ func (s *Sender) ConnectionForReplicaDesciptor(ctx context.Context, rd *rfpb.Rep
 }
 
 func (s *Sender) fetchRangeDescriptorFromMetaRange(ctx context.Context, key []byte) (*rfpb.RangeDescriptor, error) {
-	rangeDescriptor := s.rangeCache.Get(constants.MetaRangePrefix)
-	if rangeDescriptor == nil {
+	metaRangeDescriptor := s.rangeCache.Get(constants.MetaRangePrefix)
+	if metaRangeDescriptor == nil {
 		return nil, status.FailedPreconditionError("RangeCache did not have meta range. This should not happen")
 	}
 
-	for _, replica := range rangeDescriptor.GetReplicas() {
+	for _, replica := range metaRangeDescriptor.GetReplicas() {
 		client, err := s.ConnectionForReplicaDesciptor(ctx, replica)
 		if err != nil {
 			log.Errorf("Error getting api conn: %s", err)
 			continue
 		}
 		batchReq, err := rbuilder.NewBatchBuilder().Add(&rfpb.ScanRequest{
-			Left: keys.RangeMetaKey(key),
+			Left:     keys.RangeMetaKey(key),
+			Right:    constants.SystemPrefix,
+			ScanType: rfpb.ScanRequest_SEEKGE_SCAN_TYPE,
 		}).ToProto()
 		if err != nil {
 			return nil, err
 		}
 		header := &rfpb.Header{
 			Replica: replica,
-			RangeId: rangeDescriptor.GetRangeId(),
+			RangeId: metaRangeDescriptor.GetRangeId(),
 		}
 		rsp, err := client.SyncRead(ctx, &rfpb.SyncReadRequest{
 			Header: header,
 			Batch:  batchReq,
 		})
 		if err != nil {
-			continue
+			if status.IsOutOfRangeError(err) || status.IsUnavailableError(err) {
+				continue
+			}
+			return nil, err
 		}
-		scanRsp, err := rbuilder.NewBatchResponse(rsp).ScanResponse(0)
+		scanRsp, err := rbuilder.NewBatchResponseFromProto(rsp.GetBatch()).ScanResponse(0)
 		if err != nil {
 			log.Errorf("Error reading scan response: %s", err)
 			continue
@@ -119,6 +124,7 @@ func (s *Sender) LookupRangeDescriptor(ctx context.Context, key []byte) (*rfpb.R
 		if err := s.rangeCache.UpdateRange(rd); err != nil {
 			return nil, err
 		}
+		log.Debugf("Updated rangeCache with rd: %+v", rd)
 		rangeDescriptor = rd
 	}
 	return rangeDescriptor, nil
@@ -148,9 +154,9 @@ func (s *Sender) orderReplicas(rd *rfpb.RangeDescriptor) []*rfpb.ReplicaDescript
 	s.mu.RUnlock()
 
 	if !ok {
+		log.Warningf("No cached replica for range %d", rd.GetRangeId())
 		return rd.GetReplicas()
 	}
-
 	replicas := make([]*rfpb.ReplicaDescriptor, 0, len(rd.GetReplicas()))
 	replicas = append(replicas, cachedReplica)
 
@@ -173,6 +179,7 @@ func (s *Sender) Run(ctx context.Context, key []byte, fn func(c rfspb.ApiClient,
 			lastErr = err
 			continue
 		}
+		//log.Printf("Writing %s to range: %d", key, rangeDescriptor.GetRangeId())
 		replicas := s.orderReplicas(rangeDescriptor)
 		for _, replica := range replicas {
 			addr, _, err := s.nodeRegistry.ResolveGRPC(replica.GetClusterId(), replica.GetNodeId())
@@ -199,6 +206,11 @@ func (s *Sender) Run(ctx context.Context, key []byte, fn func(c rfspb.ApiClient,
 			lastErr = fn(client, header)
 			if lastErr != nil {
 				if status.IsOutOfRangeError(lastErr) || status.IsUnavailableError(lastErr) {
+					// TODO(tylerw): Make this lock free?
+					s.mu.Lock()
+					delete(s.cachedReplicas, rangeDescriptor.GetRangeId())
+					s.mu.Unlock()
+
 					log.Debugf("sender.Run got outOfRange or Unavailable on %+v, continuing to next replica", replica)
 					continue
 				}

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//enterprise/server/raft/replica",
         "//enterprise/server/raft/sender",
         "//proto:raft_go_proto",
+        "//proto:raft_service_go_proto",
         "//server/gossip",
         "//server/util/disk",
         "//server/util/log",

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -269,7 +269,6 @@ func (s *Store) RangeIsActive(rangeID uint64) bool {
 	s.leaseMu.RUnlock()
 
 	if !ok {
-		log.Debugf("%q did not have rangelease for range: %d", s.nodeHost.ID(), rangeID)
 		return false
 	}
 	valid := rl.Valid()
@@ -360,7 +359,6 @@ func (s *Store) RemoveData(ctx context.Context, req *rfpb.RemoveDataRequest) (*r
 func (s *Store) SyncPropose(ctx context.Context, req *rfpb.SyncProposeRequest) (*rfpb.SyncProposeResponse, error) {
 	if !s.RangeIsActive(req.GetHeader().GetRangeId()) {
 		err := status.OutOfRangeErrorf("Range %d not present", req.GetHeader().GetRangeId())
-		log.Debugf("Rangelease(%d) not held on %q, returning err: %s", req.GetHeader().GetRangeId(), s.nodeHost.ID(), err)
 		return nil, err
 	}
 	batchResponse, err := s.syncProposeLocal(ctx, req.GetHeader().GetReplica().GetClusterId(), req.GetBatch())
@@ -375,7 +373,6 @@ func (s *Store) SyncPropose(ctx context.Context, req *rfpb.SyncProposeRequest) (
 func (s *Store) SyncRead(ctx context.Context, req *rfpb.SyncReadRequest) (*rfpb.SyncReadResponse, error) {
 	if !s.RangeIsActive(req.GetHeader().GetRangeId()) {
 		err := status.OutOfRangeErrorf("Range %d not present", req.GetHeader().GetRangeId())
-		log.Debugf("Rangelease(%d) not held on %q, returning err: %s", req.GetHeader().GetRangeId(), s.nodeHost.ID(), err)
 		return nil, err
 	}
 	buf, err := proto.Marshal(req.GetBatch())
@@ -407,7 +404,6 @@ func (s *Store) FindMissing(ctx context.Context, req *rfpb.FindMissingRequest) (
 	defer s.replicaMu.RUnlock()
 	if !s.RangeIsActive(req.GetHeader().GetRangeId()) {
 		err := status.OutOfRangeErrorf("Range %d not present", req.GetHeader().GetRangeId())
-		log.Errorf("Range not active, returning err: %s", err)
 		return nil, err
 	}
 	r, ok := s.replicas[req.GetHeader().GetRangeId()]

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"bytes"
 	"context"
+	"io"
 	"sort"
 	"sync"
 	"time"
@@ -26,8 +27,11 @@ import (
 
 	raftConfig "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/config"
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+	rfspb "github.com/buildbuddy-io/buildbuddy/proto/raft_service"
 	dbsm "github.com/lni/dragonboat/v3/statemachine"
 )
+
+const readBufSizeBytes = 1000000 // 1MB
 
 type Store struct {
 	rootDir string
@@ -276,7 +280,37 @@ func (s *Store) RangeIsActive(rangeID uint64) bool {
 }
 
 func (s *Store) ReplicaFactoryFn(clusterID, nodeID uint64) dbsm.IOnDiskStateMachine {
-	return replica.New(s.rootDir, s.fileDir, clusterID, nodeID, s, s.sender, s.apiClient)
+	return replica.New(s.rootDir, s.fileDir, clusterID, nodeID, s)
+}
+
+func (s *Store) ReadFileFromPeer(ctx context.Context, except *rfpb.ReplicaDescriptor, fileRecord *rfpb.FileRecord) (io.ReadCloser, error) {
+	fileKey, err := constants.FileKey(fileRecord)
+	if err != nil {
+		return nil, err
+	}
+	var rc io.ReadCloser
+	err = s.sender.Run(ctx, fileKey, func(c rfspb.ApiClient, h *rfpb.Header) error {
+		log.Printf("in sender.Run, filekey: %q", fileKey)
+		if h.GetReplica().GetClusterId() == except.GetClusterId() &&
+			h.GetReplica().GetNodeId() == except.GetNodeId() {
+			log.Printf("NOT ATTEMPTING TO READ FROM SELF: +%v", h.GetReplica())
+			return status.OutOfRangeError("except node")
+		}
+		req := &rfpb.ReadRequest{
+			Header:     h,
+			FileRecord: fileRecord,
+			Offset:     0,
+		}
+		r, err := s.apiClient.RemoteReader(ctx, c, req)
+		if err != nil {
+			log.Printf("RemoteReader %+v err: %s", fileRecord, err)
+			return err
+		}
+		log.Printf("in sender.Run, filekey: %q, remoteReader returned r: %+v", fileKey, r)
+		rc = r
+		return nil
+	})
+	return rc, err
 }
 
 // TODO(check cluster has been added / dont care if it's published)
@@ -429,4 +463,46 @@ func (s *Store) FindMissing(ctx context.Context, req *rfpb.FindMissingRequest) (
 		}
 	}
 	return rsp, nil
+}
+
+type streamWriter struct {
+	stream rfspb.Api_ReadServer
+}
+
+func (w *streamWriter) Write(buf []byte) (int, error) {
+	err := w.stream.Send(&rfpb.ReadResponse{
+		Data: buf,
+	})
+	return len(buf), err
+}
+
+func (s *Store) Read(req *rfpb.ReadRequest, stream rfspb.Api_ReadServer) error {
+	s.replicaMu.RLock()
+	defer s.replicaMu.RUnlock()
+	if !s.RangeIsActive(req.GetHeader().GetRangeId()) {
+		err := status.OutOfRangeErrorf("Range %d not present", req.GetHeader().GetRangeId())
+		return err
+	}
+	_, ok := s.replicas[req.GetHeader().GetRangeId()]
+	if !ok {
+		return status.FailedPreconditionError("Range was active but replica not found; this should not happen")
+	}
+	file, err := constants.FilePath(s.fileDir, req.GetFileRecord())
+	if err != nil {
+		return err
+	}
+	reader, err := disk.FileReader(stream.Context(), file, req.GetOffset(), 0)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	bufSize := int64(readBufSizeBytes)
+	d := req.GetFileRecord().GetDigest()
+	if d.GetSizeBytes() > 0 && d.GetSizeBytes() < bufSize {
+		bufSize = d.GetSizeBytes()
+	}
+	copyBuf := make([]byte, bufSize)
+	_, err = io.CopyBuffer(&streamWriter{stream}, reader, copyBuf)
+	return err
 }

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -324,8 +324,9 @@ message Operation {
 ////////////////////////////////////////////////////////////////////////////////
 
 message ReadRequest {
-  FileRecord file_record = 1;
-  int64 offset = 2;
+  Header header = 1;
+  FileRecord file_record = 2;
+  int64 offset = 3;
 }
 
 message ReadResponse {

--- a/server/gossip/gossip.go
+++ b/server/gossip/gossip.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/network"
@@ -130,6 +131,7 @@ func NewGossipManager(listenAddress string, join []string) (*GossipManager, erro
 	serfConfig.LogOutput = &logWriter{subLog}
 	// this is the maximum value that serf supports.
 	serfConfig.UserEventSizeLimit = 9 * 1024
+	serfConfig.BroadcastTimeout = 300 * time.Millisecond
 
 	// spoiler: gossip girl was actually a:
 	gossipMan := &GossipManager{

--- a/server/gossip/gossip.go
+++ b/server/gossip/gossip.go
@@ -131,7 +131,7 @@ func NewGossipManager(listenAddress string, join []string) (*GossipManager, erro
 	serfConfig.LogOutput = &logWriter{subLog}
 	// this is the maximum value that serf supports.
 	serfConfig.UserEventSizeLimit = 9 * 1024
-	serfConfig.BroadcastTimeout = 300 * time.Millisecond
+	serfConfig.BroadcastTimeout = time.Second
 
 	// spoiler: gossip girl was actually a:
 	gossipMan := &GossipManager{


### PR DESCRIPTION
This CL fixes multi-range lookup, cleans up some interfaces, and adds tests for most of the raft operations performed by each replica. It also moves Read to store so that it correctly respects range leases, preventing a problem where a node could read stale or missing data from a replica that was restarted and is still catching up.