### PR TITLE
Fix some runner pool shutdown issues

### DIFF
--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -51,6 +51,7 @@ go_test(
         "//proto:remote_execution_go_proto",
         "//proto:worker_go_proto",
         "//server/config",
+        "//server/interfaces",
         "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/testutil/testfs",

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -51,7 +51,6 @@ go_test(
         "//proto:remote_execution_go_proto",
         "//proto:worker_go_proto",
         "//server/config",
-        "//server/interfaces",
         "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/testutil/testfs",

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -775,7 +775,7 @@ func (p *Pool) Get(ctx context.Context, task *repb.ExecutionTask) (*CommandRunne
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.isShuttingDown {
-		return nil, status.UnavailableErrorf("Could not get new task runner since executor is shutting down.")
+		return nil, status.UnavailableErrorf("Could not get a new task runner because the executor is shutting down.")
 	}
 	p.runners = append(p.runners, r)
 	return r, nil

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -227,6 +227,11 @@ func (r *CommandRunner) Run(ctx context.Context) *interfaces.CommandResult {
 	}
 
 	// Get the container to "ready" state so that we can exec commands in it.
+	//
+	// TODO(bduffany): Make this access to r.state thread-safe. The pool can be
+	// shutdown while this func is executing, which concurrently sets the runner
+	// state to "removed". This doesn't cause any known issues right now, but is
+	// error prone.
 	switch r.state {
 	case initial:
 		err := container.PullImageIfNecessary(
@@ -243,8 +248,10 @@ func (r *CommandRunner) Run(ctx context.Context) *interfaces.CommandResult {
 		break
 	case ready:
 		break
+	case removed:
+		return commandutil.ErrorResult(status.UnavailableErrorf("Not starting new task since executor is shutting down"))
 	default:
-		return commandutil.ErrorResult(status.FailedPreconditionErrorf("unexpected runner state %d; this should never happen", r.state))
+		return commandutil.ErrorResult(status.InternalErrorf("unexpected runner state %d; this should never happen", r.state))
 	}
 
 	if r.supportsPersistentWorkers(ctx, command) {
@@ -408,13 +415,9 @@ func NewPool(env environment.Env) (*Pool, error) {
 	return p, nil
 }
 
-func (p *Pool) shuttingDown() bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.isShuttingDown
-}
-
-// Add pauses the runner so that it may later be returned from Get.
+// Add pauses the runner and makes it available to be returned from the pool
+// via Get.
+//
 // If an error is returned, the runner was not successfully added to the pool,
 // and should be removed.
 func (p *Pool) Add(ctx context.Context, r *CommandRunner) error {
@@ -427,20 +430,32 @@ func (p *Pool) Add(ctx context.Context, r *CommandRunner) error {
 	return nil
 }
 
-func (p *Pool) add(ctx context.Context, r *CommandRunner) *labeledError {
-	if p.shuttingDown() {
+func (p *Pool) checkAddPreconditions(r *CommandRunner) *labeledError {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.isShuttingDown {
 		return &labeledError{
 			status.UnavailableError("pool is shutting down; new runners cannot be added."),
 			"pool_shutting_down",
 		}
 	}
-
+	// Note: shutdown can change the state to removed, so we need the lock to be
+	// held for this check.
 	if r.state != ready {
 		return &labeledError{
 			status.InternalErrorf("unexpected runner state %d; this should never happen", r.state),
 			"unexpected_runner_state",
 		}
 	}
+	return nil
+}
+
+func (p *Pool) add(ctx context.Context, r *CommandRunner) *labeledError {
+	if err := p.checkAddPreconditions(r); err != nil {
+		return err
+	}
+
 	if err := r.Container.Pause(ctx); err != nil {
 		return &labeledError{
 			status.WrapError(err, "failed to pause container before adding to the pool"),
@@ -484,6 +499,13 @@ func (p *Pool) add(ctx context.Context, r *CommandRunner) *labeledError {
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	// The pool might have shut down while we were pausing the container. We don't
+	// hold the lock while pausing since it is relatively slow, so need to re-check
+	// whether the pool shut down here.
+	if p.isShuttingDown {
+		r.RemoveInBackground()
+		return nil
+	}
 
 	if p.maxRunnerCount <= 0 {
 		return &labeledError{
@@ -749,6 +771,11 @@ func (p *Pool) Get(ctx context.Context, task *repb.ExecutionTask) (*CommandRunne
 		Workspace:          ws,
 		VFS:                fs,
 		VFSServer:          vfsServer,
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.isShuttingDown {
+		return nil, status.UnavailableErrorf("Could not get new task runner since executor is shutting down.")
 	}
 	p.runners = append(p.runners, r)
 	return r, nil


### PR DESCRIPTION
* Fix "unexpected runner state" errors in both Run and Add when the pool is shutdown mid-task
* Fix NPE due to unsynchronized concurrent access to `p.runners` when the pool is shutdown mid-task

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1158
