### PR TITLE
Misc number formatting fixes

### DIFF
--- a/app/format/format.tsx
+++ b/app/format/format.tsx
@@ -20,27 +20,39 @@ export function durationMillis(duration: number | Long) {
 export function durationSec(duration: number | Long) {
   let seconds = +duration;
   if (!seconds || seconds < 0) {
-    return "0 s";
+    return "0s";
   }
-  if (seconds > 60 * 60 * 24 * 365) {
+
+  if (seconds >= 60 * 60 * 24 * 365) {
     return `${(seconds / (60 * 60 * 24 * 365)).toPrecision(3)} years`;
   }
-  if (seconds > 60 * 60 * 24 * 30) {
+  if (seconds >= 60 * 60 * 24 * 30) {
     return `${(seconds / (60 * 60 * 24 * 30)).toPrecision(3)} months`;
   }
-  if (seconds > 60 * 60 * 24 * 7) {
+  if (seconds >= 60 * 60 * 24 * 7) {
     return `${(seconds / (60 * 60 * 24 * 7)).toPrecision(3)} weeks`;
   }
-  if (seconds > 60 * 60 * 24) {
-    return `${(seconds / (60 * 60 * 24)).toPrecision(3)} d`;
+  if (seconds >= 60 * 60 * 24) {
+    const hours = seconds / (60 * 60);
+    const d = Math.floor(hours / 24);
+    const h = Math.floor(hours - d * 24);
+    return `${d}d ${h}h`;
   }
-  if (seconds > 60 * 60) {
-    return `${(seconds / (60 * 60)).toPrecision(3)} h`;
+  if (seconds >= 60 * 60) {
+    const minutes = seconds / 60;
+    const h = Math.floor(minutes / 60);
+    const m = Math.floor(minutes - h * 60);
+    return `${h}h ${m}m`;
   }
-  if (seconds > 60) {
-    return `${(seconds / 60).toPrecision(3)} m`;
+  if (seconds >= 60) {
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds - m * 60);
+    return `${m}m ${s}s`;
   }
-  return `${seconds.toPrecision(3)} s`;
+  if (seconds >= 1) {
+    return `${seconds.toPrecision(3)}s`;
+  }
+  return `${(seconds * 1000).toPrecision(3)}ms`;
 }
 
 export function compactDurationSec(duration: number | Long) {
@@ -48,22 +60,22 @@ export function compactDurationSec(duration: number | Long) {
   if (!seconds || seconds < 0) {
     return "0s";
   }
-  if (seconds > 60 * 60 * 24 * 365) {
+  if (seconds >= 60 * 60 * 24 * 365) {
     return `${(seconds / (60 * 60 * 24 * 365)).toFixed(0)}y`;
   }
-  if (seconds > 60 * 60 * 24 * 30) {
+  if (seconds >= 60 * 60 * 24 * 30) {
     return `${(seconds / (60 * 60 * 24 * 30)).toFixed(0)}m`;
   }
-  if (seconds > 60 * 60 * 24 * 7) {
+  if (seconds >= 60 * 60 * 24 * 7) {
     return `${(seconds / (60 * 60 * 24 * 7)).toFixed(0)}w`;
   }
-  if (seconds > 60 * 60 * 24) {
+  if (seconds >= 60 * 60 * 24) {
     return `${(seconds / (60 * 60 * 24)).toFixed(0)}d`;
   }
-  if (seconds > 60 * 60) {
+  if (seconds >= 60 * 60) {
     return `${(seconds / (60 * 60)).toFixed(0)}h`;
   }
-  if (seconds > 60) {
+  if (seconds >= 60) {
     return `${(seconds / 60).toFixed(0)}m`;
   }
   if (seconds >= 1) {
@@ -72,58 +84,67 @@ export function compactDurationSec(duration: number | Long) {
   return `${(seconds * 1000).toFixed(0)}ms`;
 }
 
-export function bytes(bytes: number | Long, fractionDigits = 2) {
+/**
+ * Removes any trailing zeroes after the decimal point,
+ * including the decimal point itself if there are only
+ * trailing zeroes.
+ */
+function truncateDecimalZeroes(numString: string): string {
+  return numString.replace(/\.(.+?)0+$/, ".$1").replace(/\.0+$/, "");
+}
+
+export function bytes(bytes: number | Long) {
   bytes = +bytes;
   if (bytes < 100) {
     return bytes + "B";
   }
   if (bytes < 1e6) {
-    return (bytes / 1e3).toFixed(fractionDigits) + "KB";
+    return truncateDecimalZeroes((bytes / 1e3).toPrecision(4)) + "KB";
   }
   if (bytes < 1e9) {
-    return (bytes / 1e6).toFixed(fractionDigits) + "MB";
+    return truncateDecimalZeroes((bytes / 1e6).toPrecision(4)) + "MB";
   }
   if (bytes < 1e12) {
-    return (bytes / 1e9).toFixed(fractionDigits) + "GB";
+    return truncateDecimalZeroes((bytes / 1e9).toPrecision(4)) + "GB";
   }
   if (bytes < 1e15) {
-    return (bytes / 1e12).toFixed(fractionDigits) + "TB";
+    return truncateDecimalZeroes((bytes / 1e12).toPrecision(4)) + "TB";
   }
-  return (bytes / 1e15).toFixed(fractionDigits) + "PB";
+  return truncateDecimalZeroes((bytes / 1e15).toPrecision(4)) + "PB";
 }
 
-export function bitsPerSecond(bitsPerSecond: number | Long, fractionDigits = 2) {
+export function bitsPerSecond(bitsPerSecond: number | Long) {
   bitsPerSecond = Number(bitsPerSecond);
   if (bitsPerSecond < 1e3) {
     return bitsPerSecond + "bps";
   }
   if (bitsPerSecond < 1e6) {
-    return (bitsPerSecond / 1e3).toFixed(fractionDigits) + "Kbps";
+    return truncateDecimalZeroes((bitsPerSecond / 1e3).toPrecision(4)) + "Kbps";
   }
   if (bitsPerSecond < 1e9) {
-    return (bitsPerSecond / 1e6).toFixed(fractionDigits) + "Mbps";
+    return truncateDecimalZeroes((bitsPerSecond / 1e6).toPrecision(4)) + "Mbps";
   }
   if (bitsPerSecond < 1e12) {
-    return (bitsPerSecond / 1e9).toFixed(fractionDigits) + "Gbps";
+    return truncateDecimalZeroes((bitsPerSecond / 1e9).toPrecision(4)) + "Gbps";
   }
   if (bitsPerSecond < 1e15) {
-    return (bitsPerSecond / 1e12).toFixed(fractionDigits) + "Tbps";
+    return truncateDecimalZeroes((bitsPerSecond / 1e12).toPrecision(4)) + "Tbps";
   }
-  return (bitsPerSecond / 1e15).toFixed(fractionDigits) + "Pbps";
+  return truncateDecimalZeroes((bitsPerSecond / 1e15).toPrecision(4)) + "Pbps";
 }
 
-export function count(value: number | Long, fractionDigits = 2): string {
+export function count(value: number | Long): string {
   value = Number(value);
   if (value < 1e3) {
     return String(value);
   }
   if (value < 1e6) {
-    return (value / 1e3).toFixed(fractionDigits) + "K";
+    return truncateDecimalZeroes((value / 1e3).toPrecision(4)) + "K";
   }
   if (value < 1e9) {
-    return (value / 1e6).toFixed(fractionDigits) + "M";
+    return truncateDecimalZeroes((value / 1e6).toPrecision(4)) + "M";
   }
-  return (value / 1e9).toFixed(fractionDigits) + "B";
+  return truncateDecimalZeroes((value / 1e9).toPrecision(4)) + "B";
 }
 
 export function sentenceCase(string: string) {

--- a/app/format/format_test.ts
+++ b/app/format/format_test.ts
@@ -37,6 +37,56 @@ describe("sentenceCase", () => {
   });
 });
 
+describe("durationSec", () => {
+  it("should format 0 as 0s", () => {
+    expect(format.durationSec(null)).toEqual("0s");
+    expect(format.durationSec(0)).toEqual("0s");
+  });
+  it("should format < 1 second as ms", () => {
+    expect(format.durationSec(0.0001)).toEqual("0.100ms");
+    expect(format.durationSec(0.001)).toEqual("1.00ms");
+    expect(format.durationSec(0.999)).toEqual("999ms");
+  });
+  it("should format < 1 minute as fractional seconds", () => {
+    expect(format.durationSec(7.42)).toEqual("7.42s");
+    expect(format.durationSec(59.94999)).toEqual("59.9s");
+    expect(format.durationSec(59.95)).toEqual("60.0s");
+    expect(format.durationSec(59.99999)).toEqual("60.0s");
+  });
+
+  // Convenience to-second conversions to make the following tests more readable.
+  const second = 1;
+  const minute = 60;
+  const hour = 60 * 60;
+  const day = 60 * 60 * 24;
+
+  it("should format < 1 hour as m/s", () => {
+    expect(format.durationSec(1 * minute)).toEqual("1m 0s");
+    expect(format.durationSec(59 * minute + 59.499 * second)).toEqual("59m 59s");
+    expect(format.durationSec(59 * minute + 59.5 * second)).toEqual("59m 59s");
+    expect(format.durationSec(59 * minute + 59.999 * second)).toEqual("59m 59s");
+  });
+  it("should format < 1 day as h/m", () => {
+    expect(format.durationSec(1 * hour)).toEqual("1h 0m");
+    expect(format.durationSec(23 * hour + 59 * minute)).toEqual("23h 59m");
+    expect(format.durationSec(23 * hour + 59 * minute + 29.999 * second)).toEqual("23h 59m");
+    expect(format.durationSec(23 * hour + 59 * minute + 30 * second)).toEqual("23h 59m");
+    expect(format.durationSec(23 * hour + 59 * minute + 59.999 * second)).toEqual("23h 59m");
+  });
+  it("should format < 1 week as d/h", () => {
+    expect(format.durationSec(1 * day)).toEqual("1d 0h");
+    expect(format.durationSec(6 * day + 23 * hour)).toEqual("6d 23h");
+    expect(format.durationSec(6 * day + 23 * hour + 29 * minute + 59.999 * second)).toEqual("6d 23h");
+    expect(format.durationSec(6 * day + 23 * hour + 30 * minute)).toEqual("6d 23h");
+    expect(format.durationSec(6 * day + 23 * hour + 59 * minute + 59.999 * second)).toEqual("6d 23h");
+  });
+  it("should format larger timespans with decimals", () => {
+    expect(format.durationSec(14 * day)).toEqual("2.00 weeks");
+    expect(format.durationSec(30 * day)).toEqual("1.00 months");
+    expect(format.durationSec(365 * day)).toEqual("1.00 years");
+  });
+});
+
 describe("formatWithCommas", () => {
   it("should handle 0", () => {
     expect(format.formatWithCommas(new Long(0, 0))).toEqual("0");
@@ -56,14 +106,31 @@ describe("bytes", () => {
   it("should abbreviate large numbers", () => {
     expect(format.bytes(0)).toEqual("0B");
     expect(format.bytes(99)).toEqual("99B");
-    expect(format.bytes(100)).toEqual("0.10KB");
-    expect(format.bytes(1e6 - 1)).toEqual("1000.00KB");
-    expect(format.bytes(1e6)).toEqual("1.00MB");
-    expect(format.bytes(1e9 - 1)).toEqual("1000.00MB");
-    expect(format.bytes(1e9)).toEqual("1.00GB");
-    expect(format.bytes(1e12 - 1)).toEqual("1000.00GB");
-    expect(format.bytes(1e12)).toEqual("1.00TB");
-    expect(format.bytes(1e15 - 1)).toEqual("1000.00TB");
-    expect(format.bytes(1e15)).toEqual("1.00PB");
+    expect(format.bytes(100)).toEqual("0.1KB");
+    expect(format.bytes(1020)).toEqual("1.02KB");
+    expect(format.bytes(1023)).toEqual("1.023KB");
+    expect(format.bytes(1e6 - 1)).toEqual("1000KB");
+    expect(format.bytes(1e6)).toEqual("1MB");
+    expect(format.bytes(1e9 - 1)).toEqual("1000MB");
+    expect(format.bytes(1e9)).toEqual("1GB");
+    expect(format.bytes(1e12 - 1)).toEqual("1000GB");
+    expect(format.bytes(1e12)).toEqual("1TB");
+    expect(format.bytes(1e15 - 1)).toEqual("1000TB");
+    expect(format.bytes(1e15)).toEqual("1PB");
+  });
+});
+
+describe("count", () => {
+  it("should abbreviate large numbers", () => {
+    expect(format.count(0)).toEqual("0");
+    expect(format.count(99)).toEqual("99");
+    expect(format.count(100)).toEqual("100");
+    expect(format.count(1020)).toEqual("1.02K");
+    expect(format.count(1023)).toEqual("1.023K");
+    expect(format.count(1e6 - 1)).toEqual("1000K");
+    expect(format.count(1e6)).toEqual("1M");
+    expect(format.count(1.5e6)).toEqual("1.5M");
+    expect(format.count(1e9 - 1)).toEqual("1000M");
+    expect(format.count(1e9)).toEqual("1B");
   });
 });

--- a/enterprise/app/trends/cache_chart.tsx
+++ b/enterprise/app/trends/cache_chart.tsx
@@ -13,8 +13,6 @@ interface Props {
   extractWrites?: (datum: any) => number;
 }
 
-const countTickFormatter = (value: number) => format.count(value, /*fractionDigits=*/ 0);
-
 const CacheChartTooltip = ({ active, payload, labelFormatter, extractHits, extractMisses, extractWrites }: any) => {
   if (active) {
     let data = payload[0].payload;
@@ -52,7 +50,7 @@ export default class CacheChartComponent extends React.Component {
             <CartesianGrid strokeDasharray="3 3" />
             <Legend />
             <XAxis dataKey={this.props.extractLabel} />
-            <YAxis yAxisId="hits" tickFormatter={countTickFormatter} />
+            <YAxis yAxisId="hits" tickFormatter={format.count} allowDecimals={false} />
             <YAxis
               domain={[0, 100]}
               yAxisId="percent"

--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -32,16 +32,6 @@ interface State {
 
 const SECONDS_PER_MICROSECOND = 1e-6;
 
-const countTickFormatter = (value: number) => {
-  // Don't show fractional counts ("1.5 builds", "0.5 users" etc.)
-  // This case will only ever be reached for very small numbers, because
-  // tick values should be large, whole numbers when counts are high.
-  if (Math.floor(Number(value)) !== Number(value)) return "";
-  return format.count(value, /*fractionDigits=*/ 0);
-};
-const bytesTickFormatter = (value: number) => format.bytes(value, /*fractionDigits=*/ 0);
-const bitsPerSecondTickFormatter = (value: number) => format.bitsPerSecond(value, /*=fractionDigits=*/ 0);
-
 export default class TrendsComponent extends React.Component<Props, State> {
   props: Props;
 
@@ -229,11 +219,12 @@ export default class TrendsComponent extends React.Component<Props, State> {
                   return (+stat?.totalBuildTimeUsec * SECONDS_PER_MICROSECOND) / +stat?.completedInvocationCount;
                 }}
                 extractLabel={this.formatShortDate}
-                formatTickValue={countTickFormatter}
+                formatTickValue={format.count}
+                allowDecimals={false}
                 formatHoverLabel={this.formatLongDate}
                 formatHoverValue={(value) => (value || 0) + " builds"}
                 formatSecondaryHoverValue={(value) => `${format.durationSec(value)} average`}
-                formatSecondaryTickValue={format.compactDurationSec}
+                formatSecondaryTickValue={format.durationSec}
                 name="builds"
                 secondaryName="average build duration"
                 secondaryLine={true}
@@ -249,7 +240,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 }}
                 extractSecondaryValue={(date) => +this.state.dateToStatMap.get(date)?.maxDurationUsec / 1000000}
                 extractLabel={this.formatShortDate}
-                formatTickValue={format.compactDurationSec}
+                formatTickValue={format.durationSec}
                 formatHoverLabel={this.formatLongDate}
                 formatHoverValue={(value) => `${format.durationSec(value || 0)} average`}
                 formatSecondaryHoverValue={(value) => `${format.durationSec(value || 0)} slowest`}
@@ -284,8 +275,9 @@ export default class TrendsComponent extends React.Component<Props, State> {
                   (+this.state.dateToStatMap.get(date)?.totalDownloadUsec * SECONDS_PER_MICROSECOND)
                 }
                 extractLabel={this.formatShortDate}
-                formatTickValue={bytesTickFormatter}
-                formatSecondaryTickValue={bitsPerSecondTickFormatter}
+                formatTickValue={format.bytes}
+                allowDecimals={false}
+                formatSecondaryTickValue={format.bitsPerSecond}
                 formatHoverLabel={this.formatLongDate}
                 formatHoverValue={(value) => `${format.bytes(value || 0)} downloaded`}
                 formatSecondaryHoverValue={(value) => format.bitsPerSecond(value || 0)}
@@ -304,8 +296,8 @@ export default class TrendsComponent extends React.Component<Props, State> {
                   (+this.state.dateToStatMap.get(date)?.totalUploadUsec * SECONDS_PER_MICROSECOND)
                 }
                 extractLabel={this.formatShortDate}
-                formatTickValue={bytesTickFormatter}
-                formatSecondaryTickValue={bitsPerSecondTickFormatter}
+                formatTickValue={format.bytes}
+                formatSecondaryTickValue={format.bitsPerSecond}
                 formatHoverLabel={this.formatLongDate}
                 formatHoverValue={(value) => `${format.bytes(value || 0)} uploaded`}
                 formatSecondaryHoverValue={(value) => format.bitsPerSecond(value || 0)}
@@ -320,7 +312,8 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 data={this.state.dates}
                 extractValue={(date) => +this.state.dateToStatMap.get(date)?.userCount}
                 extractLabel={this.formatShortDate}
-                formatTickValue={countTickFormatter}
+                formatTickValue={format.count}
+                allowDecimals={false}
                 formatHoverLabel={this.formatLongDate}
                 formatHoverValue={(value) => (value || 0) + " users"}
                 name="users with builds"
@@ -331,7 +324,8 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 data={this.state.dates}
                 extractValue={(date) => +this.state.dateToStatMap.get(date)?.commitCount}
                 extractLabel={this.formatShortDate}
-                formatTickValue={countTickFormatter}
+                formatTickValue={format.count}
+                allowDecimals={false}
                 formatHoverLabel={this.formatLongDate}
                 formatHoverValue={(value) => (value || 0) + " commits"}
                 name="commits with builds"
@@ -342,7 +336,8 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 data={this.state.dates}
                 extractValue={(date) => +this.state.dateToStatMap.get(date)?.branchCount}
                 extractLabel={this.formatShortDate}
-                formatTickValue={countTickFormatter}
+                formatTickValue={format.count}
+                allowDecimals={false}
                 formatHoverLabel={this.formatLongDate}
                 formatHoverValue={(value) => (value || 0) + " branches"}
                 name="branches with builds"
@@ -352,7 +347,8 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 data={this.state.dates}
                 extractValue={(date) => +this.state.dateToStatMap.get(date)?.hostCount}
                 extractLabel={this.formatShortDate}
-                formatTickValue={countTickFormatter}
+                formatTickValue={format.count}
+                allowDecimals={false}
                 formatHoverLabel={this.formatLongDate}
                 formatHoverValue={(value) => (value || 0) + " hosts"}
                 name="hosts with builds"
@@ -363,7 +359,8 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 data={this.state.dates}
                 extractValue={(date) => +this.state.dateToStatMap.get(date)?.repoCount}
                 extractLabel={this.formatShortDate}
-                formatTickValue={countTickFormatter}
+                formatTickValue={format.count}
+                allowDecimals={false}
                 formatHoverLabel={this.formatLongDate}
                 formatHoverValue={(value) => (value || 0) + " repos"}
                 name="repos with builds"

--- a/enterprise/app/trends/trends_chart.tsx
+++ b/enterprise/app/trends/trends_chart.tsx
@@ -11,6 +11,7 @@ import {
   Legend,
   Tooltip,
   Cell,
+  YAxisProps,
 } from "recharts";
 
 interface Props {
@@ -22,11 +23,13 @@ interface Props {
   formatHoverValue?: (datum: number) => string;
   formatTickValue?: (datum: number, index: number) => string;
   extractValue: (datum: any) => number;
+  allowDecimals?: boolean;
   name: string;
 
   extractSecondaryValue?: (datum: any) => number;
   formatSecondaryHoverValue?: (datum: number) => string;
   formatSecondaryTickValue?: (datum: number, index: number) => string;
+  secondaryAllowDecimals?: boolean;
   secondaryName?: string;
   secondaryLine?: boolean;
   separateAxis?: boolean;
@@ -76,7 +79,11 @@ export default class TrendsChartComponent extends React.Component {
             <CartesianGrid strokeDasharray="3 3" />
             <Legend />
             <XAxis dataKey={this.props.extractLabel} />
-            <YAxis yAxisId="primary" tickFormatter={this.props.formatTickValue} />
+            <YAxis
+              yAxisId="primary"
+              tickFormatter={this.props.formatTickValue}
+              allowDecimals={this.props.allowDecimals}
+            />
             {/* If no secondary axis should be shown, render an invisible one
                 by setting height="0" so that right-padding is consistent across
                 all charts. */}
@@ -85,6 +92,7 @@ export default class TrendsChartComponent extends React.Component {
               orientation="right"
               height={hasSecondaryAxis ? undefined : 0}
               tickFormatter={this.props.formatSecondaryTickValue}
+              allowDecimals={this.props.secondaryAllowDecimals}
             />
             <Tooltip
               content={


### PR DESCRIPTION
* More natural time formatting (1m 15s instead of 1.25m)
* Fix y-axis precision in trends charts. Sometimes, two Y-axis ticks would have the same formatted values (see screenshot) since they weren't being rendered with high enough precision.
* Prevent y-axis in trends charts from showing fractional values for whole-number charts, such as users, branches, etc, to prevent showing ticks representing "1.5 users" etc.

BEFORE (History card shows 1.31m)

![image](https://user-images.githubusercontent.com/2414826/152833942-7a99df17-3aa9-4e52-9315-d383535cfae7.png)

AFTER

![image](https://user-images.githubusercontent.com/2414826/152834210-9cb33b6a-ee5c-4899-b682-40d5243ff3b9.png)

BEFORE (2M is shown twice in trends chart y-axis)

![image](https://user-images.githubusercontent.com/2414826/152833585-be8f355f-d905-495a-975c-5ebef0402a3e.png)

AFTER

![image](https://user-images.githubusercontent.com/2414826/152833086-f012e274-9d02-4245-96eb-57c7261a6ca8.png)

BEFORE (each tick in trends chart y-axis represents 0.75 branches -- nonsensical)

![image](https://user-images.githubusercontent.com/2414826/152833684-174ac304-77fc-481c-8983-85fa728651b6.png)

AFTER

![image](https://user-images.githubusercontent.com/2414826/152833212-5e1d54de-ac03-429a-95a4-34d679f2295f.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1100
