### PR TITLE
raft: cleanup / small fixes

### DIFF
--- a/enterprise/server/cmd/smash/BUILD
+++ b/enterprise/server/cmd/smash/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//server/remote_cache/digest",
         "//server/util/grpc_client",
         "//server/util/log",
-        "//server/util/monitoring",
         "@com_github_bojand_ghz//printer",
         "@com_github_bojand_ghz//runner",
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/enterprise/server/cmd/smash/smash.go
+++ b/enterprise/server/cmd/smash/smash.go
@@ -19,7 +19,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/buildbuddy-io/buildbuddy/server/util/monitoring"
 	"github.com/golang/protobuf/proto"
 	"github.com/jhump/protoreflect/desc"
 	"google.golang.org/grpc/metadata"
@@ -194,7 +193,6 @@ func dataFunc(mtd *desc.MethodDescriptor, cd *runner.CallData) []byte {
 }
 func main() {
 	flag.Parse()
-	monitoring.StartMonitoringHandler("localhost:8888")
 
 	seed := *randomSeed
 	if seed == 0 {

--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -25,7 +25,7 @@ import (
 
 // If a request is received that will result in a nodehost.Sync{Propose/Read},
 // but not deadline is set, defaultContextTimeout will be applied.
-const defaultContextTimeout = 60 * time.Second
+const DefaultContextTimeout = 60 * time.Second
 
 type apiClientAndConn struct {
 	rfspb.ApiClient
@@ -239,7 +239,7 @@ func (c *APIClient) MultiWriter(ctx context.Context, peers []string, fileRecord 
 
 func SyncProposeLocal(ctx context.Context, nodehost *dragonboat.NodeHost, clusterID uint64, batch *rfpb.BatchCmdRequest) (*rfpb.BatchCmdResponse, error) {
 	if _, ok := ctx.Deadline(); !ok {
-		c, cancel := context.WithTimeout(ctx, defaultContextTimeout)
+		c, cancel := context.WithTimeout(ctx, DefaultContextTimeout)
 		defer cancel()
 		ctx = c
 	}
@@ -270,7 +270,7 @@ func SyncProposeLocal(ctx context.Context, nodehost *dragonboat.NodeHost, cluste
 
 func SyncReadLocal(ctx context.Context, nodehost *dragonboat.NodeHost, clusterID uint64, batch *rfpb.BatchCmdRequest) (*rfpb.BatchCmdResponse, error) {
 	if _, ok := ctx.Deadline(); !ok {
-		c, cancel := context.WithTimeout(ctx, defaultContextTimeout)
+		c, cancel := context.WithTimeout(ctx, DefaultContextTimeout)
 		defer cancel()
 		ctx = c
 	}

--- a/enterprise/server/raft/rangelease/rangelease.go
+++ b/enterprise/server/raft/rangelease/rangelease.go
@@ -28,8 +28,7 @@ const (
 	defaultGracePeriod = 4 * time.Second
 )
 
-// TODO(tylerw): Maybe this belongs in keys?
-func containsMetaRange(rd *rfpb.RangeDescriptor) bool {
+func ContainsMetaRange(rd *rfpb.RangeDescriptor) bool {
 	r := rangemap.Range{Left: rd.Left, Right: rd.Right}
 	return r.Contains([]byte{constants.MinByte}) && r.Contains([]byte{constants.UnsplittableMaxByte - 1})
 }
@@ -185,7 +184,7 @@ func (l *Lease) assembleLeaseRequest() (*rfpb.RangeLeaseRecord, error) {
 	// any range that includes the metarange will be leased with a
 	// time-based lease, rather than a node epoch based one.
 	leaseRecord := &rfpb.RangeLeaseRecord{}
-	if containsMetaRange(l.rangeDescriptor) {
+	if ContainsMetaRange(l.rangeDescriptor) {
 		leaseRecord.Value = &rfpb.RangeLeaseRecord_Expiration{
 			Expiration: time.Now().Add(l.leaseDuration).UnixNano(),
 		}

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//server/gossip",
         "//server/util/disk",
         "//server/util/log",
-        "//server/util/rangemap",
         "//server/util/status",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_lni_dragonboat_v3//:dragonboat",

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -407,6 +407,11 @@ func (s *Store) SyncRead(ctx context.Context, req *rfpb.SyncReadRequest) (*rfpb.
 	if err != nil {
 		return nil, err
 	}
+	if _, ok := ctx.Deadline(); !ok {
+		c, cancel := context.WithTimeout(ctx, client.DefaultContextTimeout)
+		defer cancel()
+		ctx = c
+	}
 	raftResponseIface, err := s.nodeHost.SyncRead(ctx, req.GetHeader().GetReplica().GetClusterId(), buf)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- Stop monitoring smash
- Smarter logic around cache/uncaching a replica
- Dedupe containsMetaRange function
- Ensure default context is set before interacting with nodehost.
