### PR TITLE
Parse Aborted build events

### DIFF
--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -567,6 +567,10 @@ enum TestStatus {
   REMOTE_FAILURE = 6;
   FAILED_TO_BUILD = 7;
   TOOL_HALTED_BEFORE_TESTING = 8;
+
+  // Buildbuddy-specific enum
+  // The test is cancelled by the user
+  CANCELLED = 1000;
 }
 
 // Payload on events reporting about individual test action.

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -567,10 +567,6 @@ enum TestStatus {
   REMOTE_FAILURE = 6;
   FAILED_TO_BUILD = 7;
   TOOL_HALTED_BEFORE_TESTING = 8;
-
-  // Buildbuddy-specific enum
-  // The test is cancelled by the user
-  CANCELLED = 1000;
 }
 
 // Payload on events reporting about individual test action.

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -72,7 +72,7 @@ func newTarget(label string) *target {
 func getTestStatus(aborted *build_event_stream.Aborted) build_event_stream.TestStatus {
 	switch aborted.GetReason() {
 	case build_event_stream.Aborted_USER_INTERRUPTED:
-		return build_event_stream.TestStatus_CANCELLED
+		return build_event_stream.TestStatus_TOOL_HALTED_BEFORE_TESTING
 	default:
 		return build_event_stream.TestStatus_FAILED_TO_BUILD
 	}

--- a/server/target/target.go
+++ b/server/target/target.go
@@ -48,8 +48,6 @@ func convertToCommonStatus(in build_event_stream.TestStatus) cmpb.Status {
 	case build_event_stream.TestStatus_FAILED_TO_BUILD:
 		return cmpb.Status_FAILED_TO_BUILD
 	case build_event_stream.TestStatus_TOOL_HALTED_BEFORE_TESTING:
-		return cmpb.Status_INCOMPLETE
-	case build_event_stream.TestStatus_CANCELLED:
 		return cmpb.Status_CANCELLED
 	default:
 		return cmpb.Status_STATUS_UNSPECIFIED

--- a/server/target/target.go
+++ b/server/target/target.go
@@ -49,6 +49,8 @@ func convertToCommonStatus(in build_event_stream.TestStatus) cmpb.Status {
 		return cmpb.Status_FAILED_TO_BUILD
 	case build_event_stream.TestStatus_TOOL_HALTED_BEFORE_TESTING:
 		return cmpb.Status_INCOMPLETE
+	case build_event_stream.TestStatus_CANCELLED:
+		return cmpb.Status_CANCELLED
 	default:
 		return cmpb.Status_STATUS_UNSPECIFIED
 	}


### PR DESCRIPTION
1. Parse Aborted events and set appropriate test statues for the target
   statuses.
2. Write the target statuses when we process the last messages instead
   of when we receive the Finished event. Otherwise, we will skip many Aborted events.

https://github.com/buildbuddy-io/buildbuddy-internal/issues/1160
