### PR TITLE
Fix local ci_runner_test

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -111,6 +111,7 @@ var (
 
 	// Test-only flags
 	fallbackToCleanCheckout = flag.Bool("fallback_to_clean_checkout", true, "Fallback to cloning the repo from scratch if sync fails (for testing purposes only).")
+	writeSystemBazelrc      = flag.Bool("write_system_bazelrc", true, "Whether to write /etc/bazel.bazelrc.")
 
 	shellCharsRequiringQuote = regexp.MustCompile(`[^\w@%+=:,./-]`)
 )
@@ -410,8 +411,10 @@ func main() {
 		fatal(status.WrapError(err, "ensure PATH"))
 	}
 	// Write default bazelrc
-	if err := writeBazelrc(systemBazelrcPath); err != nil {
-		fatal(status.WrapError(err, "write "+systemBazelrcPath))
+	if *writeSystemBazelrc {
+		if err := writeBazelrc(systemBazelrcPath); err != nil {
+			fatal(status.WrapError(err, "write "+systemBazelrcPath))
+		}
 	}
 	// Configure TERM to get prettier output from executed commands.
 	if err := os.Setenv("TERM", "xterm-256color"); err != nil {

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -89,6 +89,8 @@ func invokeRunner(t *testing.T, args []string, env []string, workDir string) *re
 	}
 	args = append(args, []string{
 		"--bazel_command=" + bazelPath,
+		// When running locally, /etc/bazel.bazelrc is not writable.
+		"--write_system_bazelrc=false",
 		"--bazel_startup_flags=--max_idle_secs=5 --noblock_for_lock",
 		"--workflow_id=test-workflow",
 	}...)


### PR DESCRIPTION
`/etc/bazel.bazelrc` is not writable when running the test locally in the bazel sandbox, so the CI runner encounters a fatal error.

The fix in this PR is to disable writing this file only in tests. This is not ideal because then this logic won't be exercised. But the other options I considered seem worse:

- Revert the /etc/bazel.bazelrc behavior. Not a good option IMO because the benefits of this approach outweigh the downsides in terms of testability.
- Make failed writes to /etc/bazel.bazelrc non-fatal: this is not great because the test would then behave differently locally vs. on CI (where it is run inside a docker container with /etc writable), making it difficult to debug.
- If /etc is not writable, write ~/.bazelrc instead: this is also not great because ~/.bazelrc overrides the repo .bazelrc, while /etc/bazel.bazelrc does not
- If /etc is not writable, then append to bazel args just after the `test` subcommand instead: aside from being complex, this has the same problem as writing ~/.bazelrc: it overrides the workspace .bazelrc.

Other things I looked into:
- Seeing whether its possible to configure the system bazelrc path -- I could not find any way to do this. When looking at the bazel source code, it appears that the system path is baked in at compile time and not overridable by any means.
- I also tried to see if we could configure the sandbox to make /etc or at least /etc/bazel.bazelrc writable by adding some sort of test tag or build arg -- this also doesn't seem possible, even with `--sandbox_add_mount_pair` which only allows mounting directories (can't mount /etc since other stuff needs to be written there), or `--sandbox_writeable_path` since that makes a path writable on the host system, which is not desired.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
