### PR TITLE
Add repo picker for test grid V2

### DIFF
--- a/app/components/select/select.css
+++ b/app/components/select/select.css
@@ -17,6 +17,8 @@
   -webkit-appearance: none;
   padding-right: 40px;
   cursor: pointer;
+  text-overflow: ellipsis;
+  overflow: clip;
 }
 
 .select:focus {
@@ -34,7 +36,6 @@
 }
 
 .select-wrapper .dropdown-icon-wrapper {
-  display: block;
   position: absolute;
   top: 0;
   right: 0;
@@ -42,6 +43,7 @@
   width: 40px;
   height: 100%;
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   justify-content: center;
   z-index: 1;

--- a/enterprise/app/tap/BUILD
+++ b/enterprise/app/tap/BUILD
@@ -12,6 +12,7 @@ ts_library(
         "//app/capabilities",
         "//app/components/button",
         "//app/components/select",
+        "//app/errors",
         "//app/format",
         "//app/router",
         "//app/service",

--- a/enterprise/app/tap/tap.css
+++ b/enterprise/app/tap/tap.css
@@ -12,14 +12,26 @@
   top: 0;
 }
 
+.tap .tap-header-left-section {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.tap .tap-header-left-section > * {
+  flex-shrink: 0;
+}
+
 .tap .target-controls {
   display: flex;
   gap: 16px;
   align-items: center;
 }
 
-.tap-header {
+.tap .tap-header {
   display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 16px;


### PR DESCRIPTION
- Add repo picker pinned just to the right edge of the page title
  - Another option was to place it with the other dropdowns, but this placement prevents it from jumping around when switching between empty and nonempty repos
- Repo picker selection defaults to the value in the URL, or the last selected repo (stored in localStorage)
- When the page loads, fetch the list of repos in the background, in parallel with test targets.
- If no repo is selected, wait for the repos to be fetched before fetching targets so that we have some repo to filter by.

https://user-images.githubusercontent.com/2414826/153500304-4c3a4f3e-9697-45ad-88c7-2418e14b3e17.mp4

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
