### PR TITLE
2/6 Reduce db dependencies

### DIFF
--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -73,7 +73,7 @@ func (s *APIServer) GetInvocation(ctx context.Context, req *apipb.GetInvocationR
 	}
 	queryStr, args := q.Build()
 
-	rows, err := s.env.GetDBHandle().Raw(queryStr, args...).Rows()
+	rows, err := s.env.GetDBHandle().DB().Raw(queryStr, args...).Rows()
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -53,7 +53,7 @@ func (d *AuthDB) InsertOrUpdateUserToken(ctx context.Context, subID string, toke
 
 func (d *AuthDB) ReadToken(ctx context.Context, subID string) (*tables.Token, error) {
 	ti := &tables.Token{}
-	existingRow := d.h.Raw(`SELECT * FROM Tokens as t
+	existingRow := d.h.DB().Raw(`SELECT * FROM Tokens as t
                                WHERE t.sub_id = ?`, subID)
 	if err := existingRow.Take(ti).Error; err != nil {
 		return nil, err

--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -63,7 +63,7 @@ func (d *AuthDB) ReadToken(ctx context.Context, subID string) (*tables.Token, er
 
 func (d *AuthDB) GetAPIKeyGroupFromAPIKey(ctx context.Context, apiKey string) (interfaces.APIKeyGroup, error) {
 	akg := &apiKeyGroup{}
-	err := d.h.TransactionWithOptions(ctx, db.Opts().WithStaleReads(), func(tx *db.DB) error {
+	err := d.h.TransactionWithOptions(ctx, d.h.NewOpts().WithStaleReads(), func(tx *db.DB) error {
 		existingRow := tx.Raw(`
 			SELECT ak.capabilities, g.group_id, g.use_group_owned_executors
 			FROM `+"`Groups`"+` AS g, APIKeys AS ak
@@ -82,7 +82,7 @@ func (d *AuthDB) GetAPIKeyGroupFromAPIKey(ctx context.Context, apiKey string) (i
 
 func (d *AuthDB) GetAPIKeyGroupFromBasicAuth(ctx context.Context, login, pass string) (interfaces.APIKeyGroup, error) {
 	akg := &apiKeyGroup{}
-	err := d.h.TransactionWithOptions(ctx, db.Opts().WithStaleReads(), func(tx *db.DB) error {
+	err := d.h.TransactionWithOptions(ctx, d.h.NewOpts().WithStaleReads(), func(tx *db.DB) error {
 		existingRow := tx.Raw(`
 			SELECT ak.capabilities, g.group_id, g.use_group_owned_executors
 			FROM `+"`Groups`"+` AS g, APIKeys AS ak
@@ -102,7 +102,7 @@ func (d *AuthDB) GetAPIKeyGroupFromBasicAuth(ctx context.Context, login, pass st
 
 func (d *AuthDB) LookupUserFromSubID(ctx context.Context, subID string) (*tables.User, error) {
 	user := &tables.User{}
-	err := d.h.TransactionWithOptions(ctx, db.Opts().WithStaleReads(), func(tx *db.DB) error {
+	err := d.h.TransactionWithOptions(ctx, d.h.NewOpts().WithStaleReads(), func(tx *db.DB) error {
 		userRow := tx.Raw(`SELECT * FROM Users WHERE sub_id = ? ORDER BY user_id ASC`, subID)
 		if err := userRow.Take(user).Error; err != nil {
 			return err

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -96,7 +96,7 @@ func (d *UserDB) GetGroupByID(ctx context.Context, groupID string) (*tables.Grou
 	if groupID == "" {
 		return nil, status.InvalidArgumentError("Group ID cannot be empty.")
 	}
-	query := d.h.Raw(`SELECT * FROM `+"`Groups`"+` AS g WHERE g.group_id = ?`, groupID)
+	query := d.h.DB().Raw(`SELECT * FROM `+"`Groups`"+` AS g WHERE g.group_id = ?`, groupID)
 	group := &tables.Group{}
 	if err := query.Take(group).Error; err != nil {
 		if db.IsRecordNotFound(err) {
@@ -139,7 +139,7 @@ func (d *UserDB) GetAPIKey(ctx context.Context, apiKeyID string) (*tables.APIKey
 	if apiKeyID == "" {
 		return nil, status.InvalidArgumentError("API key cannot be empty.")
 	}
-	query := d.h.Raw(`SELECT * FROM APIKeys WHERE api_key_id = ?`, apiKeyID)
+	query := d.h.DB().Raw(`SELECT * FROM APIKeys WHERE api_key_id = ?`, apiKeyID)
 	key := &tables.APIKey{}
 	if err := query.Take(key).Error; err != nil {
 		if db.IsRecordNotFound(err) {
@@ -155,7 +155,7 @@ func (d *UserDB) GetAPIKeys(ctx context.Context, groupID string) ([]*tables.APIK
 		return nil, status.InvalidArgumentError("Group ID cannot be empty.")
 	}
 
-	query := d.h.Raw(`
+	query := d.h.DB().Raw(`
 		SELECT api_key_id, value, label, perms, capabilities
 		FROM APIKeys
 		WHERE group_id = ?
@@ -251,7 +251,7 @@ func (d *UserDB) GetAuthGroup(ctx context.Context) (*tables.Group, error) {
 	}
 
 	tg := &tables.Group{}
-	existingRow := d.h.Raw(`SELECT * FROM `+"`Groups`"+` as g WHERE g.group_id = ?`, u.GetGroupID())
+	existingRow := d.h.DB().Raw(`SELECT * FROM `+"`Groups`"+` as g WHERE g.group_id = ?`, u.GetGroupID())
 	if err := existingRow.Take(tg).Error; err != nil {
 		if db.IsRecordNotFound(err) {
 			return nil, status.UnauthenticatedErrorf("Group not found: %q", u.GetGroupID())
@@ -428,7 +428,7 @@ func (d *UserDB) GetGroupUsers(ctx context.Context, groupID string, statuses []g
 	q.SetOrderBy(`u.email`, true /*=ascending*/)
 
 	qString, qArgs := q.Build()
-	rows, err := d.h.Raw(qString, qArgs...).Rows()
+	rows, err := d.h.DB().Raw(qString, qArgs...).Rows()
 	if err != nil {
 		return nil, err
 	}
@@ -786,7 +786,7 @@ func (d *UserDB) GetImpersonatedUser(ctx context.Context) (*tables.User, error) 
 }
 
 func (d *UserDB) FillCounts(ctx context.Context, stat *telpb.TelemetryStat) error {
-	counts := d.h.Raw(`
+	counts := d.h.DB().Raw(`
 		SELECT 
 			COUNT(DISTINCT user_id) as registered_user_count
 		FROM Users as u

--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -39,14 +39,14 @@ func checkPreconditions(req *espb.GetExecutionRequest) error {
 }
 
 func (es *ExecutionService) getInvocationExecutions(ctx context.Context, invocationID string) ([]tables.Execution, error) {
-	db := es.env.GetDBHandle()
+	dbh := es.env.GetDBHandle()
 	q := query_builder.NewQuery(`SELECT * FROM Executions as e`)
 	q = q.AddWhereClause(`e.invocation_id = ?`, invocationID)
 	if err := perms.AddPermissionsCheckToQueryWithTableAlias(ctx, es.env, q, "e"); err != nil {
 		return nil, err
 	}
 	queryStr, args := q.Build()
-	rows, err := db.Raw(queryStr, args...).Rows()
+	rows, err := dbh.DB().Raw(queryStr, args...).Rows()
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (es *ExecutionService) getInvocationExecutions(ctx context.Context, invocat
 	executions := make([]tables.Execution, 0)
 	for rows.Next() {
 		var exec tables.Execution
-		if err := db.ScanRows(rows, &exec); err != nil {
+		if err := dbh.ScanRows(rows, &exec); err != nil {
 			return nil, err
 		}
 		executions = append(executions, exec)

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -59,7 +59,7 @@ func (r *runnerService) lookupAPIKey(ctx context.Context) (string, error) {
 	q.AddWhereClause("group_id = ?", u.GetGroupID())
 	qStr, qArgs := q.Build()
 	k := &tables.APIKey{}
-	if err := r.env.GetDBHandle().Raw(qStr, qArgs...).Take(&k).Error; err != nil {
+	if err := r.env.GetDBHandle().DB().Raw(qStr, qArgs...).Take(&k).Error; err != nil {
 		return "", err
 	}
 	return k.Value, nil

--- a/enterprise/server/invocation_search_service/BUILD
+++ b/enterprise/server/invocation_search_service/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//server/tables",
         "//server/util/alert",
         "//server/util/blocklist",
-        "//server/util/db",
         "//server/util/perms",
         "//server/util/query_builder",
         "//server/util/status",

--- a/enterprise/server/invocation_search_service/invocation_search_service.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service.go
@@ -12,7 +12,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/blocklist"
-	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/query_builder"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -46,7 +45,7 @@ func defaultSortParams() *inpb.InvocationSort {
 }
 
 func (s *InvocationSearchService) rawQueryInvocations(ctx context.Context, sql string, values ...interface{}) ([]*tables.Invocation, error) {
-	rows, err := s.h.RawWithOptions(ctx, db.Opts().WithQueryName("search_invocations"), sql, values...).Rows()
+	rows, err := s.h.RawWithOptions(ctx, s.h.NewOpts().WithQueryName("search_invocations"), sql, values...).Rows()
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/invocation_stat_service/BUILD
+++ b/enterprise/server/invocation_stat_service/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//server/environment",
         "//server/interfaces",
         "//server/util/blocklist",
-        "//server/util/db",
         "//server/util/log",
         "//server/util/perms",
         "//server/util/query_builder",

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -8,7 +8,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/blocklist"
-	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/query_builder"
@@ -143,7 +142,7 @@ func (i *InvocationStatService) GetTrend(ctx context.Context, req *inpb.GetTrend
 	q.SetOrderBy("MAX(updated_at_usec)" /*ascending=*/, false)
 
 	qStr, qArgs := q.Build()
-	rows, err := i.h.RawWithOptions(ctx, db.Opts().WithQueryName("query_invocation_trends"), qStr, qArgs...).Rows()
+	rows, err := i.h.RawWithOptions(ctx, i.h.NewOpts().WithQueryName("query_invocation_trends"), qStr, qArgs...).Rows()
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +246,7 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 	q.SetLimit(int64(limit))
 
 	qStr, qArgs := q.Build()
-	rows, err := i.h.RawWithOptions(ctx, db.Opts().WithQueryName("query_invocation_stats"), qStr, qArgs...).Rows()
+	rows, err := i.h.RawWithOptions(ctx, i.h.NewOpts().WithQueryName("query_invocation_stats"), qStr, qArgs...).Rows()
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -186,7 +186,8 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 		}
 	}
 
-	return s.env.GetDBHandle().TransactionWithOptions(ctx, db.Opts().WithQueryName("upsert_execution"), func(tx *db.DB) error {
+	dbh := s.env.GetDBHandle()
+	return dbh.TransactionWithOptions(ctx, dbh.NewOpts().WithQueryName("upsert_execution"), func(tx *db.DB) error {
 		var existing tables.Execution
 		if err := tx.Where("execution_id = ?", executionID).First(&existing).Error; err != nil {
 			return err

--- a/enterprise/server/usage/usage_test.go
+++ b/enterprise/server/usage/usage_test.go
@@ -61,7 +61,7 @@ func timeStr(t time.Time) string {
 func queryAllUsages(t *testing.T, te *testenv.TestEnv) []*tables.Usage {
 	usages := []*tables.Usage{}
 	dbh := te.GetDBHandle()
-	rows, err := dbh.Raw(`
+	rows, err := dbh.DB().Raw(`
 		SELECT * From Usages
 		ORDER BY group_id, period_start_usec, region ASC;
 	`).Rows()

--- a/enterprise/server/usage_service/usage_service.go
+++ b/enterprise/server/usage_service/usage_service.go
@@ -82,9 +82,9 @@ func (s *usageService) GetUsage(ctx context.Context, req *usagepb.GetUsageReques
 }
 
 func (s *usageService) scanUsages(ctx context.Context, groupID string, start, end time.Time) ([]*usagepb.Usage, error) {
-	db := s.env.GetDBHandle()
-	rows, err := db.Raw(`
-		SELECT `+db.UTCMonthFromUsecTimestamp("period_start_usec")+` AS period,
+	dbh := s.env.GetDBHandle()
+	rows, err := dbh.DB().Raw(`
+		SELECT `+dbh.UTCMonthFromUsecTimestamp("period_start_usec")+` AS period,
 		SUM(invocations) AS invocations,
 		SUM(action_cache_hits) AS action_cache_hits,
 		SUM(cas_cache_hits) AS cas_cache_hits,
@@ -103,7 +103,7 @@ func (s *usageService) scanUsages(ctx context.Context, groupID string, start, en
 	usages := []*usagepb.Usage{}
 	for rows.Next() {
 		usage := &usagepb.Usage{}
-		if err := db.ScanRows(rows, usage); err != nil {
+		if err := dbh.ScanRows(rows, usage); err != nil {
 			return nil, err
 		}
 		usages = append(usages, usage)

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -339,7 +339,7 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 
 	// Lookup workflow
 	wf := &tables.Workflow{}
-	err = ws.env.GetDBHandle().Raw(
+	err = ws.env.GetDBHandle().DB().Raw(
 		`SELECT * FROM Workflows WHERE workflow_id = ?`,
 		req.GetWorkflowId(),
 	).Take(wf).Error
@@ -687,7 +687,7 @@ func (ws *workflowService) apiKeyForWorkflow(ctx context.Context, wf *tables.Wor
 	q.AddWhereClause("group_id = ?", wf.GroupID)
 	qStr, qArgs := q.Build()
 	k := &tables.APIKey{}
-	if err := ws.env.GetDBHandle().Raw(qStr, qArgs...).Take(&k).Error; err != nil {
+	if err := ws.env.GetDBHandle().DB().Raw(qStr, qArgs...).Take(&k).Error; err != nil {
 		return nil, err
 	}
 	return k, nil

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -249,7 +249,7 @@ func (c *GithubClient) populateTokenIfNecessary(ctx context.Context) error {
 	}
 
 	var group tables.Group
-	err = dbHandle.Raw(`SELECT github_token FROM `+"`Groups`"+` WHERE group_id = ?`,
+	err = dbHandle.DB().Raw(`SELECT github_token FROM `+"`Groups`"+` WHERE group_id = ?`,
 		userInfo.GetGroupID()).First(&group).Error
 	if err != nil {
 		return err

--- a/server/backends/invocationdb/invocationdb.go
+++ b/server/backends/invocationdb/invocationdb.go
@@ -39,7 +39,7 @@ func getACL(i *tables.Invocation) *aclpb.ACL {
 func (d *InvocationDB) registerInvocationAttempt(ctx context.Context, ti *tables.Invocation) (bool, error) {
 	ti.Attempt = 1
 	created := false
-	err := d.h.TransactionWithOptions(ctx, db.Opts().WithQueryName("upsert_invocation"), func(tx *db.DB) error {
+	err := d.h.TransactionWithOptions(ctx, d.h.NewOpts().WithQueryName("upsert_invocation"), func(tx *db.DB) error {
 		// First, try inserting the invocation. This will work for first attempts.
 		err := tx.Create(ti).Error
 		if err == nil {
@@ -108,7 +108,7 @@ func (d *InvocationDB) CreateInvocation(ctx context.Context, ti *tables.Invocati
 // id and attempt number. It returns whether a row was updated.
 func (d *InvocationDB) UpdateInvocation(ctx context.Context, ti *tables.Invocation) (bool, error) {
 	updated := false
-	err := d.h.TransactionWithOptions(ctx, db.Opts().WithQueryName("update_invocation"), func(tx *db.DB) error {
+	err := d.h.TransactionWithOptions(ctx, d.h.NewOpts().WithQueryName("update_invocation"), func(tx *db.DB) error {
 		result := tx.Where("`invocation_id` = ? AND `attempt` = ?", ti.InvocationID, ti.Attempt).Updates(ti)
 		updated = result.RowsAffected > 0
 		return result.Error

--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -60,9 +60,9 @@ func NewBuildStatusReporter(env environment.Env, buildEventAccumulator *accumula
 
 func (r *BuildStatusReporter) initGHClient(ctx context.Context) *github.GithubClient {
 	if workflowID := r.buildEventAccumulator.WorkflowID(); workflowID != "" {
-		if db := r.env.GetDBHandle(); db != nil {
+		if dbh := r.env.GetDBHandle(); dbh != nil {
 			workflow := &tables.Workflow{}
-			if err := db.Raw(`SELECT * from Workflows WHERE workflow_id = ?`, workflowID).Take(workflow).Error; err == nil {
+			if err := dbh.DB().Raw(`SELECT * from Workflows WHERE workflow_id = ?`, workflowID).Take(workflow).Error; err == nil {
 				return github.NewGithubClient(r.env, workflow.AccessToken)
 			}
 		}

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -448,7 +448,8 @@ func insertTargets(ctx context.Context, env environment.Env, targets []*tables.T
 			valueArgs = append(valueArgs, nowUsec)
 			valueArgs = append(valueArgs, nowUsec)
 		}
-		err := env.GetDBHandle().TransactionWithOptions(ctx, db.Opts().WithQueryName("target_tracker_insert_targets"), func(tx *db.DB) error {
+		dbh := env.GetDBHandle()
+		err := dbh.TransactionWithOptions(ctx, dbh.NewOpts().WithQueryName("target_tracker_insert_targets"), func(tx *db.DB) error {
 			stmt := fmt.Sprintf("INSERT INTO Targets (repo_url, target_id, user_id, group_id, perms, label, rule_type, created_at_usec, updated_at_usec) VALUES %s", strings.Join(valueStrings, ","))
 			return tx.Exec(stmt, valueArgs...).Error
 		})
@@ -490,7 +491,8 @@ func insertOrUpdateTargetStatuses(ctx context.Context, env environment.Env, stat
 			valueArgs = append(valueArgs, nowUsec)
 			valueArgs = append(valueArgs, nowUsec)
 		}
-		err := env.GetDBHandle().TransactionWithOptions(ctx, db.Opts().WithQueryName("target_tracker_insert_target_statuses"), func(tx *db.DB) error {
+		dbh := env.GetDBHandle()
+		err := dbh.TransactionWithOptions(ctx, dbh.NewOpts().WithQueryName("target_tracker_insert_target_statuses"), func(tx *db.DB) error {
 			stmt := fmt.Sprintf("INSERT INTO TargetStatuses (target_id, invocation_uuid, target_type, test_size, status, start_time_usec, duration_usec, created_at_usec, updated_at_usec) VALUES %s", strings.Join(valueStrings, ","))
 			return tx.Exec(stmt, valueArgs...).Error
 		})

--- a/server/build_event_protocol/webhooks/webhooks.go
+++ b/server/build_event_protocol/webhooks/webhooks.go
@@ -39,9 +39,9 @@ func (h *invocationUploadHook) NotifyComplete(ctx context.Context, in *inpb.Invo
 	if groupID == "" {
 		return nil
 	}
-	db := h.env.GetDBHandle()
+	dbh := h.env.GetDBHandle()
 	row := &struct{ InvocationWebhookURL string }{}
-	err := db.Raw(
+	err := dbh.DB().Raw(
 		"SELECT invocation_webhook_url FROM `Groups` WHERE group_id = ?",
 		groupID,
 	).Take(row).Error

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -226,7 +226,6 @@ type DBOptions interface {
 
 type DBHandle interface {
 	// TODO(zoey): Remove these methods from the interface using new DB method
-	Raw(sql string, values ...interface{}) *gorm.DB
 	Exec(sql string, values ...interface{}) *gorm.DB
 	ScanRows(rows *sql.Rows, dest interface{}) error
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -230,6 +230,7 @@ type DBHandle interface {
 	ScanRows(rows *sql.Rows, dest interface{}) error
 
 	DB() *gorm.DB
+	NewOpts() DBOptions
 	RawWithOptions(ctx context.Context, opts DBOptions, sql string, values ...interface{}) *gorm.DB
 	TransactionWithOptions(ctx context.Context, opts DBOptions, txn TxRunner) error
 	Transaction(ctx context.Context, txn TxRunner) error

--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -92,10 +92,6 @@ func (o *Options) QueryName() string {
 
 type DB = gorm.DB
 
-func (dbh *DBHandle) Raw(sql string, values ...interface{}) *gorm.DB {
-	return dbh.db.Raw(sql, values...)
-}
-
 func (dbh *DBHandle) Exec(sql string, values ...interface{}) *gorm.DB {
 	return dbh.db.Exec(sql, values...)
 }

--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -56,37 +56,33 @@ type DBHandle struct {
 	dialect       string
 }
 
-type Options struct {
+type options struct {
 	readOnly        bool
 	allowStaleReads bool
 	queryName       string
 }
 
-func Opts() interfaces.DBOptions {
-	return &Options{}
-}
-
-func (o *Options) WithStaleReads() interfaces.DBOptions {
+func (o *options) WithStaleReads() interfaces.DBOptions {
 	o.readOnly = true
 	o.allowStaleReads = true
 	return o
 }
 
 // WithQueryName specifies the query label to use in exported metrics.
-func (o *Options) WithQueryName(queryName string) interfaces.DBOptions {
+func (o *options) WithQueryName(queryName string) interfaces.DBOptions {
 	o.queryName = queryName
 	return o
 }
 
-func (o *Options) ReadOnly() bool {
+func (o *options) ReadOnly() bool {
 	return o.readOnly
 }
 
-func (o *Options) AllowStaleReads() bool {
+func (o *options) AllowStaleReads() bool {
 	return o.allowStaleReads
 }
 
-func (o *Options) QueryName() string {
+func (o *options) QueryName() string {
 	return o.queryName
 }
 
@@ -102,6 +98,10 @@ func (dbh *DBHandle) ScanRows(rows *sql.Rows, dest interface{}) error {
 
 func (dbh *DBHandle) DB() *DB {
 	return dbh.db
+}
+
+func (dbh *DBHandle) NewOpts() interfaces.DBOptions {
+	return &options{}
 }
 
 func (dbh *DBHandle) gormHandleForOpts(ctx context.Context, opts interfaces.DBOptions) *DB {


### PR DESCRIPTION
- Remove `Raw` from DBHandle interface
- Let the DBHandle determine the type of Options

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

This CL moves the function call for DBOptions into the DBHandle interface to reduce
dependencies on the `db.go` file.

The motivation for reducing depencies on the `db.go` file is that that file is forced to
use structs from an external library containing cgo, and that was breaking when we built
the executor. To avoid a recurrence of that extremely puzzling error, only files that
absolutely *must* depend on `db.go` will do so (`libmain.go` and `testenv.go`).

---

**Version bump**: TODO <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
