### PR TITLE
Add BUILD file to the marketing website so it can be built and developed with Bazel

### DIFF
--- a/rules/yarn/index.bzl
+++ b/rules/yarn/index.bzl
@@ -1,0 +1,33 @@
+def yarn(name, srcs, package, command = "build", deps = [], yarn = "@nodejs//:yarn_bin", node = "@nodejs//:node_bin", **kwargs):
+    extension = ".tar"
+    executable = False
+    if command != "build":
+        extension = ".sh"
+        executable = True
+
+    cmd = """
+        export ROOTDIR=$$(pwd) && 
+        export PACKAGEDIR=$$(dirname $(location %s)) && 
+        export PATH=$$PATH:$$ROOTDIR/$$(dirname $(location %s)):$$ROOTDIR/$$(dirname $(location %s)) && 
+        cd $$PACKAGEDIR && 
+        yarn install && 
+        yarn %s && 
+        cd build && 
+        tar -cvf ../build.tar * && 
+        cd $$ROOTDIR && 
+        mv $$PACKAGEDIR/build.tar $@
+    """ % (package, yarn, node, command)
+
+    if executable:
+        cmd = "echo \"cd $$(dirname $(location %s)) && yarn install && yarn %s\" > $@" % (package, command)
+
+    native.genrule(
+        name = name,
+        srcs = srcs + [package] + deps,
+        outs = [name + extension],
+        cmd_bash = cmd,
+        executable = executable,
+        exec_tools = [yarn, node],
+        local = 1,
+        **kwargs
+    )

--- a/website/BUILD.bazel
+++ b/website/BUILD.bazel
@@ -1,0 +1,42 @@
+load("//rules/yarn:index.bzl", "yarn")
+
+package(default_visibility = ["//visibility:public"])
+
+SRCS = glob([
+    "src/**",
+    "static/**",
+    "docs/**",
+]) + [
+    "docusaurus.config.js",
+    "yarn.lock",
+    "sidebars.js",
+]
+
+# Builds and bundles static marketing website into a .tar
+yarn(
+    name = "website",
+    srcs = SRCS,
+    package = "package.json",
+    tags = ["manual"],
+)
+
+# Starts marketing website server in development mode
+yarn(
+    name = "start",
+    srcs = SRCS,
+    command = "start",
+    package = "package.json",
+    tags = ["manual"],
+)
+
+# Serves production marketing website bundle
+yarn(
+    name = "serve",
+    srcs = SRCS,
+    command = "serve",
+    package = "package.json",
+    tags = ["manual"],
+    deps = [
+        ":website",
+    ],
+)

--- a/website/README.md
+++ b/website/README.md
@@ -2,7 +2,7 @@
 
 ## Development
 
-To run the marketing website locally, run:
+To run the marketing website locally for development, run:
 
 ```bash
 bazel run website:start
@@ -10,7 +10,7 @@ bazel run website:start
 
 View the marketing site at http://localhost:3000/
 
-This page will live reload as you make and save changes.
+This page will live reload as you make and save changes. Perfect for iterating quickly.
 
 # Production preview
 
@@ -22,7 +22,7 @@ bazel run website:serve
 
 View the marketing site at http://localhost:3000/
 
-You'll need to rebuild this target for it to pick up any changes.
+Instead of using the live reloading dev server, this will serve the website out of the production static bundle. This means you'll get optimized images, minified js/css, and all of the production-ready bells and whistles. You'll need to rebuild this target for it to pick up any changes.
 
 # Bundle
 

--- a/website/README.md
+++ b/website/README.md
@@ -1,13 +1,37 @@
-# BuildBuddy's docs/blog website
+# buildbuddy.io marketing website
 
-To run the docs/blog website locally, run:
+## Development
+
+To run the marketing website locally, run:
 
 ```bash
-cd website
-yarn install
-yarn start
+bazel run website:start
 ```
 
-View the docs site at http://localhost:3000/docs/introduction
+View the marketing site at http://localhost:3000/
 
-To deploy the docs/blog website, just commit your changes.
+This page will live reload as you make and save changes.
+
+# Production preview
+
+To preview a static production build locally, run:
+
+```bash
+bazel run website:serve
+```
+
+View the marketing site at http://localhost:3000/
+
+You'll need to rebuild this target for it to pick up any changes.
+
+# Bundle
+
+To generate a static `.tar` archive of the marketing website.
+
+```bash
+bazel build website
+```
+
+## Deployment
+
+To deploy the marketing website, just commit your changes.


### PR DESCRIPTION
Adds a really dumb Yarn rule that runs a yarn command or bundles the `build` directory into a tar.

Updated website README to document the 3 workflows:
- Development with live reload
- Previewing production build locally
- Bundling static tar
---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
