### PR TITLE
Use first_start_time and total_run_duration

### DIFF
--- a/server/build_event_protocol/target_tracker/BUILD
+++ b/server/build_event_protocol/target_tracker/BUILD
@@ -18,6 +18,8 @@ go_library(
         "//server/util/status",
         "//server/util/uuid",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//types/known/durationpb",
+        "@org_golang_google_protobuf//types/known/timestamppb",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/server/build_event_protocol/target_tracker/BUILD
+++ b/server/build_event_protocol/target_tracker/BUILD
@@ -16,10 +16,9 @@ go_library(
         "//server/util/perms",
         "//server/util/query_builder",
         "//server/util/status",
+        "//server/util/timeutil",
         "//server/util/uuid",
         "@com_github_golang_protobuf//proto:go_default_library",
-        "@org_golang_google_protobuf//types/known/durationpb",
-        "@org_golang_google_protobuf//types/known/timestamppb",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -89,8 +89,8 @@ func (t *target) updateFromEvent(event *build_event_stream.BuildEvent) {
 	case *build_event_stream.BuildEvent_TestSummary:
 		ts := p.TestSummary
 		t.overallStatus = ts.GetOverallStatus()
-		t.firstStartTime = timeutil.GetTime(ts.GetFirstStartTime(), ts.GetFirstStartTimeMillis())
-		t.totalDuration = timeutil.GetDuration(ts.GetTotalRunDuration(), ts.GetTotalRunDurationMillis())
+		t.firstStartTime = timeutil.GetTimeWithFallback(ts.GetFirstStartTime(), ts.GetFirstStartTimeMillis())
+		t.totalDuration = timeutil.GetDurationWithFallback(ts.GetTotalRunDuration(), ts.GetTotalRunDurationMillis())
 		t.state = targetStateSummary
 	case *build_event_stream.BuildEvent_Aborted:
 		t.buildSuccess = false

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -17,11 +17,10 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/query_builder"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/timeutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/uuid"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cmpb "github.com/buildbuddy-io/buildbuddy/proto/api/v1/common"
 )
@@ -72,22 +71,6 @@ func getTestStatus(aborted *build_event_stream.Aborted) build_event_stream.TestS
 	}
 }
 
-// Converts a timestamp proto field to time.Time. When ts is nil, use fallbackMillis.
-func convertTimestamp(ts *timestamppb.Timestamp, fallbackMillis int64) time.Time {
-	if ts != nil {
-		return ts.AsTime()
-	}
-
-	return time.UnixMilli(fallbackMillis)
-}
-
-func convertDuration(duration *durationpb.Duration, fallbackMillis int64) time.Duration {
-	if duration != nil {
-		return duration.AsDuration()
-	}
-	return time.Duration(fallbackMillis) * time.Microsecond
-}
-
 func (t *target) updateFromEvent(event *build_event_stream.BuildEvent) {
 	switch p := event.Payload.(type) {
 	case *build_event_stream.BuildEvent_Configured:
@@ -106,8 +89,8 @@ func (t *target) updateFromEvent(event *build_event_stream.BuildEvent) {
 	case *build_event_stream.BuildEvent_TestSummary:
 		ts := p.TestSummary
 		t.overallStatus = ts.GetOverallStatus()
-		t.firstStartTime = convertTimestamp(ts.GetFirstStartTime(), ts.GetFirstStartTimeMillis())
-		t.totalDuration = convertDuration(ts.GetTotalRunDuration(), ts.GetTotalRunDurationMillis())
+		t.firstStartTime = timeutil.GetTime(ts.GetFirstStartTime(), ts.GetFirstStartTimeMillis())
+		t.totalDuration = timeutil.GetDuration(ts.GetTotalRunDuration(), ts.GetTotalRunDurationMillis())
 		t.state = targetStateSummary
 	case *build_event_stream.BuildEvent_Aborted:
 		t.buildSuccess = false

--- a/server/util/timeutil/BUILD
+++ b/server/util/timeutil/BUILD
@@ -5,4 +5,8 @@ go_library(
     srcs = ["timeutil.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/timeutil",
     visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_google_protobuf//types/known/durationpb",
+        "@org_golang_google_protobuf//types/known/timestamppb",
+    ],
 )

--- a/server/util/timeutil/timeutil.go
+++ b/server/util/timeutil/timeutil.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Returns time.Time from a timestamp proto field. When the given ts is nil, uses fallbackMillis
-func GetTime(ts *timestamppb.Timestamp, fallbackMillis int64) time.Time {
+func GetTimeWithFallback(ts *timestamppb.Timestamp, fallbackMillis int64) time.Time {
 	if ts != nil {
 		return ts.AsTime()
 	}
@@ -19,7 +19,7 @@ func GetTime(ts *timestamppb.Timestamp, fallbackMillis int64) time.Time {
 
 // Returns time.Duration from a duration proto field. When the given duration is nil,
 // uses fallbackMillis
-func GetDuration(duration *durationpb.Duration, fallbackMillis int64) time.Duration {
+func GetDurationWithFallback(duration *durationpb.Duration, fallbackMillis int64) time.Duration {
 	if duration != nil {
 		return duration.AsDuration()
 	}

--- a/server/util/timeutil/timeutil.go
+++ b/server/util/timeutil/timeutil.go
@@ -3,7 +3,28 @@ package timeutil
 import (
 	"fmt"
 	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// Returns time.Time from a timestamp proto field. When the given ts is nil, uses fallbackMillis
+func GetTime(ts *timestamppb.Timestamp, fallbackMillis int64) time.Time {
+	if ts != nil {
+		return ts.AsTime()
+	}
+
+	return time.UnixMilli(fallbackMillis)
+}
+
+// Returns time.Duration from a duration proto field. When the given duration is nil,
+// uses fallbackMillis
+func GetDuration(duration *durationpb.Duration, fallbackMillis int64) time.Duration {
+	if duration != nil {
+		return duration.AsDuration()
+	}
+	return time.Duration(fallbackMillis) * time.Microsecond
+}
 
 // ShortFormatDuration returns a human-readable, short, and approximate
 // representation of the given duration.


### PR DESCRIPTION
1. only use deprecated fields as a fallback
2. remove result struct -- it's set but not used. As a result,
   deprecated fields: test_attempt_start_millis_epoch and
   test_attempt_duration_millis are removed

https://github.com/buildbuddy-io/buildbuddy-internal/issues/1162
