### PR TITLE
Firecracker: Bump vsock dial timeout (again)

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -55,7 +55,11 @@ const (
 	firecrackerSocketWaitTimeout = 3 * time.Second
 
 	// How long to wait when dialing the vmexec server inside the VM.
-	vSocketDialTimeout = 10 * time.Second
+	// TODO(bduffany): This timeout is long mostly to allow Docker to be
+	// initialized. Should probably wait for Docker separately and give it its own
+	// timeout, rather than blocking execserver initialization on Docker
+	// initialization.
+	vSocketDialTimeout = 15 * time.Second
 
 	// How long to wait for the jailer directory to be created.
 	jailerDirectoryCreationTimeout = 1 * time.Second


### PR DESCRIPTION
Running `firecracker_test` locally with `--runs_per_test=20 --test_filter=Docker` consistently fails at least once with the current timeout. Bumping an additional 5 sec so that the test will at least pass consistently. In prod, timeouts will be retried, so we probably shouldn't bump this much further.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
