### PR TITLE
Add some utils to help with bazel 5 proto timestamp/duration migration

### DIFF
--- a/app/format/format.tsx
+++ b/app/format/format.tsx
@@ -178,6 +178,10 @@ export function formatTimestamp(timestamp: { seconds?: number | Long; nanos?: nu
     .padStart(3, "0")} ${moment(+timestamp.seconds * 1000).format("A")}`;
 }
 
+export function formatDate(date: Date): string {
+  return formatTimestampMillis(date.getTime());
+}
+
 const DATE_RANGE_SEPARATOR = "\u2013";
 
 export function formatDateRange(startDate: Date, endDate: Date, { now = new Date() } = {}) {
@@ -264,6 +268,7 @@ export default {
   bitsPerSecond,
   count,
   truncateList,
+  formatDate,
   formatTimestampUsec,
   formatTimestampMillis,
   formatTimestamp,

--- a/app/util/BUILD
+++ b/app/util/BUILD
@@ -91,6 +91,9 @@ ts_library(
     name = "proto",
     srcs = ["proto.ts"],
     deps = [
+        "//proto:duration_ts_proto",
         "//proto:timestamp_ts_proto",
+        "@npm//@types/long",
+        "@npm//long",
     ],
 )

--- a/app/util/proto.ts
+++ b/app/util/proto.ts
@@ -1,15 +1,51 @@
-import { google } from "../../proto/timestamp_ts_proto";
+import Long from "long";
+import { google as google_timestamp } from "../../proto/timestamp_ts_proto";
+import { google as google_duration } from "../../proto/duration_ts_proto";
 
-export function dateToTimestamp(date: Date): google.protobuf.Timestamp {
+export function dateToTimestamp(date: Date): google_timestamp.protobuf.Timestamp {
   const timestampMillis = date.getTime();
-  return new google.protobuf.Timestamp({
+  return new google_timestamp.protobuf.Timestamp({
     seconds: Math.floor(timestampMillis / 1e3) as any,
     nanos: (timestampMillis % 1e3) * 1e6,
   });
 }
 
 /** Converts a proto timestamp to a local date. */
-export function timestampToDate(timestamp: google.protobuf.ITimestamp) {
+export function timestampToDate(timestamp: google_timestamp.protobuf.ITimestamp): Date {
   const timestampMillis = Math.floor(((timestamp.seconds as any) + timestamp.nanos / 1e9) * 1e3);
   return new Date(timestampMillis);
+}
+
+/** Converts a proto duration to a number of millis. */
+export function durationToMillis(duration: google_duration.protobuf.IDuration): number {
+  const seconds = Number(duration.seconds) + Number(duration.nanos) / 1e9;
+  return seconds * 1e3;
+}
+
+/**
+ * Converts a proto timestamp to a local `Date`, with an optional
+ * millis-since-epoch fallback. This is useful for extracting `Date`s from
+ * protos that have been migrated to use the `Timestamp` API.
+ */
+export function timestampToDateWithFallback(
+  timestamp: google_timestamp.protobuf.ITimestamp,
+  timestampMillisFallback: number | Long
+): Date {
+  if (timestamp) return timestampToDate(timestamp);
+
+  return new Date(Number(timestampMillisFallback));
+}
+
+/**
+ * Converts a proto duration to a number of millis, with an optional millis
+ * fallback. This is useful for extracting millis from protos that have been
+ * migrated to use the `Duration` API.
+ */
+export function durationToMillisWithFallback(
+  duration: google_duration.protobuf.IDuration,
+  fallbackMillis: number | Long
+): number {
+  if (duration) return durationToMillis(duration);
+
+  return Number(fallbackMillis);
 }

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -824,6 +824,11 @@ ts_proto_library(
 )
 
 ts_proto_library(
+    name = "duration_ts_proto",
+    proto = "@com_google_protobuf//:duration_proto",
+)
+
+ts_proto_library(
     name = "cache_ts_proto",
     proto = ":cache_proto",
 )


### PR DESCRIPTION
Usage:
- Instead of `format.formatDateMillis(someProto.someTimestampMillis)`, call `format.formatDate(proto.timestampToDateWithFallback(someProto.someTimestamp, someProto.someTimestampMillis))`
- Instead of `format.durationMillis(someProto.someDurationMillis)`, call `format.durationMillis(proto.durationToMillisWithFallback(someProto.duration, someProto.durationMillis))`

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
