### PR TITLE
Disable docker test workflow

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -29,14 +29,14 @@ actions:
       # TODO(http://go/b/958): See if we can remove --remote_download_outputs=toplevel
       - bazel --nosystem_rc test //... --config=workflows --remote_download_outputs=toplevel --test_tag_filters=+webdriver
   # TODO(bduffany): Move docker tests to the Test workflow when they are fast enough.
-  # TODO(http://go/b/1151): Switch from dev -> prod
-  - name: Docker tests
-    triggers:
-      push:
-        branches:
-          - "master"
-      pull_request:
-        branches:
-          - "master"
-    bazel_commands:
-      - bazel --nosystem_rc test //... --config=workflows --config=remote-dev --test_tag_filters=+docker --build_tag_filters=+docker
+  # TODO(http://go/b/1151): Switch from dev -> prod and re-enable
+  # - name: Docker tests
+  #   triggers:
+  #     push:
+  #       branches:
+  #         - "master"
+  #     pull_request:
+  #       branches:
+  #         - "master"
+  #   bazel_commands:
+  #     - bazel --nosystem_rc test //... --config=workflows --config=remote-dev --test_tag_filters=+docker --build_tag_filters=+docker


### PR DESCRIPTION
Can be re-enabled once docker-in-firecracker works in prod

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
