### PR TITLE
Migrate finish_time_millis and start_time_millis

### DIFF
--- a/enterprise/server/test/integration/build_logs/BUILD
+++ b/enterprise/server/test/integration/build_logs/BUILD
@@ -13,5 +13,6 @@ go_test(
         "//server/util/status",
         "@com_github_google_uuid//:uuid",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )

--- a/enterprise/server/test/integration/build_logs/build_logs_test.go
+++ b/enterprise/server/test/integration/build_logs/build_logs_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
@@ -95,10 +96,12 @@ func newUUID(t *testing.T) string {
 }
 
 func publishStarted(t *testing.T, bep *build_event_publisher.Publisher) {
+	startTime := time.Now()
 	err := bep.Publish(&bespb.BuildEvent{
 		Payload: &bespb.BuildEvent_Started{
 			Started: &bespb.BuildStarted{
-				StartTimeMillis: time.Now().UnixMilli(),
+				StartTimeMillis: startTime.UnixMilli(),
+				StartTime:       timestamppb.New(startTime),
 			},
 		},
 	})
@@ -118,11 +121,13 @@ func publishProgress(t *testing.T, bep *build_event_publisher.Publisher, stdout,
 }
 
 func publishFinished(t *testing.T, bep *build_event_publisher.Publisher) {
+	finishTime := time.Now()
 	err := bep.Publish(&bespb.BuildEvent{
 		Payload: &bespb.BuildEvent_Finished{
 			Finished: &bespb.BuildFinished{
 				ExitCode:         &bespb.BuildFinished_ExitCode{Name: "OK", Code: 0},
-				FinishTimeMillis: time.Now().UnixMilli(),
+				FinishTimeMillis: finishTime.UnixMilli(),
+				FinishTime:       timestamppb.New(finishTime),
 			},
 		},
 	})

--- a/server/build_event_protocol/accumulator/BUILD
+++ b/server/build_event_protocol/accumulator/BUILD
@@ -10,5 +10,6 @@ go_library(
         "//proto:command_line_go_proto",
         "//server/build_event_protocol/invocation_format",
         "//server/util/git",
+        "//server/util/timeutil",
     ],
 )

--- a/server/build_event_protocol/accumulator/accumulator.go
+++ b/server/build_event_protocol/accumulator/accumulator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/invocation_format"
 
 	gitutil "github.com/buildbuddy-io/buildbuddy/server/util/git"
+	"github.com/buildbuddy-io/buildbuddy/server/util/timeutil"
 )
 
 const (
@@ -157,7 +158,7 @@ func (v *BEValues) setStringValue(fieldName, proposedValue string) bool {
 func (v *BEValues) handleStartedEvent(event *build_event_stream.BuildEvent) {
 	v.setStringValue(commandFieldName, event.GetStarted().Command)
 	v.setStringValue(patternFieldName, patternFromEvent(event))
-	v.buildStartTime = time.UnixMilli(event.GetStarted().GetStartTimeMillis())
+	v.buildStartTime = timeutil.GetTimeWithFallback(event.GetStarted().GetStartTime(), event.GetStarted().GetStartTimeMillis())
 }
 
 func (v *BEValues) populateWorkspaceInfoFromStructuredCommandLine(commandLine *command_line.CommandLine) {

--- a/server/build_event_protocol/event_parser/BUILD
+++ b/server/build_event_protocol/event_parser/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//proto:command_line_go_proto",
         "//proto:invocation_go_proto",
         "//server/terminal",
+        "//server/util/timeutil",
     ],
 )
 
@@ -22,5 +23,6 @@ go_test(
         "//proto:command_line_go_proto",
         "//proto:invocation_go_proto",
         "@com_github_stretchr_testify//assert",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )

--- a/server/build_event_protocol/event_parser/event_parser_test.go
+++ b/server/build_event_protocol/event_parser/event_parser_test.go
@@ -2,11 +2,13 @@ package event_parser_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	"github.com/buildbuddy-io/buildbuddy/proto/command_line"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/event_parser"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
 )
@@ -39,8 +41,10 @@ func TestFillInvocation(t *testing.T) {
 		},
 	})
 
+	startTime := time.Now()
 	buildStarted := &build_event_stream.BuildStarted{
-		StartTimeMillis:    0,
+		StartTimeMillis:    startTime.UnixMilli(),
+		StartTime:          timestamppb.New(startTime),
 		Command:            "test",
 		OptionsDescription: "foo",
 	}
@@ -166,8 +170,10 @@ func TestFillInvocation(t *testing.T) {
 		},
 	})
 
+	finishTime := startTime.Add(time.Millisecond)
 	buildFinished := &build_event_stream.BuildFinished{
-		FinishTimeMillis: 1,
+		FinishTimeMillis: finishTime.UnixMilli(),
+		FinishTime:       timestamppb.New(finishTime),
 		ExitCode: &build_event_stream.BuildFinished_ExitCode{
 			Name: "Success",
 			Code: 0,


### PR DESCRIPTION
Migrate finish_time_millis and start_time_millis from event_parser, and
build_logs_test

https://github.com/buildbuddy-io/buildbuddy-internal/issues/1162
