### PR TITLE
Redis unavailability handling.

### DIFF
--- a/enterprise/server/backends/pubsub/BUILD
+++ b/enterprise/server/backends/pubsub/BUILD
@@ -10,7 +10,9 @@ go_library(
     ],
     deps = [
         "//server/interfaces",
+        "//server/util/alert",
         "//server/util/log",
+        "//server/util/status",
         "@com_github_go_redis_redis_v8//:redis",
     ],
 )
@@ -22,7 +24,7 @@ go_test(
     deps = [
         "//enterprise/server/testutil/testredis",
         "//enterprise/server/util/redisutil",
-        "//server/interfaces",
+        "//server/util/status",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/backends/pubsub/pubsub.go
+++ b/enterprise/server/backends/pubsub/pubsub.go
@@ -2,9 +2,12 @@ package pubsub
 
 import (
 	"context"
+	"strings"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/go-redis/redis/v8"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -123,7 +126,7 @@ func (p *ListPubSub) Subscribe(ctx context.Context, channelName string) interfac
 
 			// Should not happen.
 			if vals == nil || len(vals) != 2 {
-				log.Errorf("Wrong number of elemenents returned from BLPop: %v", vals)
+				log.Errorf("Wrong number of elements returned from BLPop: %v", vals)
 				return
 			}
 			// ... and neither should this.
@@ -144,8 +147,15 @@ func (p *ListPubSub) Subscribe(ctx context.Context, channelName string) interfac
 	}
 }
 
-// To keep things simple for now, we maintain streams with a single value per element stored under the following key.
-const streamDataField = "data"
+const (
+	// To keep things simple for now, we maintain streams with a single value per element stored under the following key.
+	streamDataField = "data"
+	// Key prefix to identify monitored channels.
+	monitoredKeyPrefix = "monitoredPubSub/"
+	// For "monitored" channels, we publish a dummy message at channel creation time so we have a means to verify
+	// whether the object still exists in Redis.
+	dummyExistenceVerificationMessage = "this is a dummy message to verify existence of stream"
+)
 
 type StreamPubSub struct {
 	rdb redis.UniversalClient
@@ -156,32 +166,135 @@ func NewStreamPubSub(redisClient redis.UniversalClient) *StreamPubSub {
 	return &StreamPubSub{rdb: redisClient}
 }
 
-func (p *StreamPubSub) subscribe(ctx context.Context, channelName string, startFromTail bool) interfaces.Subscriber {
-	ch := make(chan string)
-	ctx, cancel := context.WithCancel(ctx)
+type Channel struct {
+	name string
+}
 
-	deliverMsg := func(msg *redis.XMessage) bool {
-		data, ok := msg.Values[streamDataField]
-		if !ok {
-			log.Errorf("Message %q on stream %q missing data field", msg.ID, channelName)
-			return false
-		}
-		str, ok := data.(string)
-		if !ok {
-			log.Errorf("Message %q on stream %q is of type %T, wanted string", msg.ID, channelName, data)
-			return false
-		}
+func (c *Channel) String() string {
+	return c.name
+}
 
-		select {
-		case ch <- str:
-			return true
-		case <-ctx.Done():
-			return false
-		}
+func (p *StreamPubSub) CreateMonitoredChannel(ctx context.Context, name string) error {
+	channelName := monitoredKeyPrefix + name
+	channel := &Channel{name: channelName}
+	if err := p.Publish(ctx, channel, dummyExistenceVerificationMessage); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *StreamPubSub) MonitoredChannel(name string) *Channel {
+	return &Channel{name: monitoredKeyPrefix + name}
+}
+
+func (p *StreamPubSub) UnmonitoredChannel(name string) *Channel {
+	return &Channel{name: name}
+}
+
+type Message struct {
+	Err  error
+	Data string
+}
+
+type StreamSubscription struct {
+	cancel context.CancelFunc
+	ch     <-chan *Message
+}
+
+func (s *StreamSubscription) Close() error {
+	s.cancel()
+	return nil
+}
+
+func (s *StreamSubscription) Chan() <-chan *Message {
+	return s.ch
+}
+
+func (p *StreamPubSub) extractMsgData(channel *Channel, msg *redis.XMessage) (string, error) {
+	data, ok := msg.Values[streamDataField]
+	if !ok {
+		return "", status.FailedPreconditionErrorf("Message %q on stream %q missing data field", msg.ID, channel.name)
+	}
+	str, ok := data.(string)
+	if !ok {
+		return "", status.FailedPreconditionErrorf("Message %q on stream %q is of type %T, wanted string", msg.ID, channel.name, data)
 	}
 
+	return str, nil
+}
+
+func (p *StreamPubSub) deliverMsg(ctx context.Context, psChannel *Channel, outCh chan *Message, msg *redis.XMessage) bool {
+	data, err := p.extractMsgData(psChannel, msg)
+	if err != nil {
+		alert.UnexpectedEvent("could not extract PubSub message contents", "error: %s", err)
+		return false
+	}
+	if data == dummyExistenceVerificationMessage {
+		return true
+	}
+
+	select {
+	case outCh <- &Message{Data: data}:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (p *StreamPubSub) checkMonitoredChannelExists(ctx context.Context, channel *Channel) error {
+	result, err := p.rdb.XRead(ctx, &redis.XReadArgs{
+		Streams: []string{channel.name, "0"},
+		Block:   -1, // No blocking.
+	}).Result()
+	if err == redis.Nil {
+		return status.UnavailableErrorf("PubSub channel %q disappeared", channel.name)
+	}
+	if err != nil {
+		return status.UnavailableErrorf("unable to check existence of PubSub channel %q: %s", channel.name, err)
+	}
+	if len(result) != 1 {
+		return status.UnknownErrorf("invalid xread return for channel %q", channel.name)
+	}
+	stream := result[0]
+	if len(stream.Messages) == 0 {
+		return status.UnavailableErrorf("PubSub channel %q disappeared", channel.name)
+	}
+	data, err := p.extractMsgData(channel, &stream.Messages[0])
+	if err != nil {
+		return status.UnavailableErrorf("unable to check existence of PubSub channel %q", channel.name)
+	}
+	if data != dummyExistenceVerificationMessage {
+		return status.UnavailableErrorf("PubSub channel %q does not start with verification message", channel.name)
+	}
+	return nil
+}
+
+func (p *StreamPubSub) subscribe(ctx context.Context, psChannel *Channel, startFromTail bool) *StreamSubscription {
+	ctx, cancel := context.WithCancel(ctx)
+
+	// If this is a monitored channel, start a goroutine that will periodically check that the stream still exists or
+	// publish an error if it does not.
+	monChan := make(chan *Message)
+	if strings.HasPrefix(psChannel.name, monitoredKeyPrefix) {
+		go func() {
+			defer close(monChan)
+			for {
+				if err := p.checkMonitoredChannelExists(ctx, psChannel); err != nil {
+					monChan <- &Message{Err: err}
+					return
+				}
+				select {
+				case <-time.After(1 * time.Second):
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	msgChan := make(chan *Message)
 	go func() {
-		defer close(ch)
+		defer close(msgChan)
 
 		// Start from beginning of stream.
 		streamID := "0"
@@ -189,15 +302,16 @@ func (p *StreamPubSub) subscribe(ctx context.Context, channelName string, startF
 		// If starting from tail, check if the stream has any elements.
 		// If it does then publish the last element and subscribe to messages following that element.
 		if startFromTail {
-			msgs, err := p.rdb.XRevRangeN(ctx, channelName, "+", "-", 1).Result()
+			msgs, err := p.rdb.XRevRangeN(ctx, psChannel.name, "+", "-", 1).Result()
 			if err != nil {
-				log.Errorf("Unable to retrieve last element of stream %q: %s", channelName, err)
+				log.Errorf("Unable to retrieve last element of stream!!! %q: %s", psChannel.name, err)
+				msgChan <- &Message{Err: err}
 				return
 			}
 			if len(msgs) == 1 {
 				msg := msgs[0]
 				streamID = msg.ID
-				if !deliverMsg(&msg) {
+				if !p.deliverMsg(ctx, psChannel, msgChan, &msg) {
 					return
 				}
 			}
@@ -205,55 +319,77 @@ func (p *StreamPubSub) subscribe(ctx context.Context, channelName string, startF
 
 		for {
 			result, err := p.rdb.XRead(ctx, &redis.XReadArgs{
-				Streams: []string{channelName, streamID},
-				Block:   0, // Block indefinitely.
+				Streams: []string{psChannel.name, streamID},
+				Block:   0, // Block indefinitely
 			}).Result()
 			if err != nil {
 				if err != context.Canceled {
-					log.Errorf("Error reading from stream %q: %s", channelName, err)
+					log.Errorf("Error reading from stream %q: %s", psChannel.name, err)
+					msgChan <- &Message{Err: err}
 				}
 				return
 			}
-
 			// We are subscribing to a single stream so there should be exactly one response.
 			if len(result) != 1 {
-				log.Errorf("Did not receive exactly one result for channel %q, got %d", channelName, len(result))
+				log.Errorf("Did not receive exactly one result for channel %q, got %d", psChannel.name, len(result))
 				return
 			}
-
 			for _, msg := range result[0].Messages {
-				if !deliverMsg(&msg) {
+				if !p.deliverMsg(ctx, psChannel, msgChan, &msg) {
 					return
 				}
 				streamID = msg.ID
 			}
 		}
 	}()
-	return &channelSubscriber{
+
+	ch := make(chan *Message)
+	go func() {
+		defer cancel()
+		defer close(ch)
+		for {
+			select {
+			case msg, ok := <-monChan:
+				if !ok {
+					return
+				}
+				ch <- msg
+			case msg, ok := <-msgChan:
+				if !ok {
+					return
+				}
+				ch <- msg
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return &StreamSubscription{
 		cancel: cancel,
 		ch:     ch,
 	}
 }
 
 // SubscribeHead returns a subscription for all previous and future message on the stream.
-func (p *StreamPubSub) SubscribeHead(ctx context.Context, channelName string) interfaces.Subscriber {
+func (p *StreamPubSub) SubscribeHead(ctx context.Context, channel *Channel) *StreamSubscription {
 	// Subscribe from the beginning of the stream.
-	return p.subscribe(ctx, channelName, false /*startFromTail=*/)
+	return p.subscribe(ctx, channel, false /*startFromTail=*/)
 }
 
 // SubscribeTail returns a subscription for messages starting from the last message already on the stream, if any.
-func (p *StreamPubSub) SubscribeTail(ctx context.Context, channelName string) interfaces.Subscriber {
+func (p *StreamPubSub) SubscribeTail(ctx context.Context, channel *Channel) *StreamSubscription {
 	// Subscribe from the last elements of the stream, if any.
-	return p.subscribe(ctx, channelName, true /*startFromTail=*/)
+	return p.subscribe(ctx, channel, true /*startFromTail=*/)
 }
 
-func (p *StreamPubSub) Publish(ctx context.Context, channelName string, message string) error {
+func (p *StreamPubSub) Publish(ctx context.Context, channel *Channel, message string) error {
 	pipe := p.rdb.TxPipeline()
 	pipe.XAdd(ctx, &redis.XAddArgs{
-		Stream: channelName,
+		Stream: channel.name,
 		Values: map[string]interface{}{streamDataField: message},
 	})
-	pipe.Expire(ctx, channelName, listTTL)
+	pipe.Expire(ctx, channel.name, listTTL)
 	_, err := pipe.Exec(ctx)
 	return err
 }

--- a/enterprise/server/backends/pubsub/pubsub_test.go
+++ b/enterprise/server/backends/pubsub/pubsub_test.go
@@ -7,24 +7,26 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redisutil"
-	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 const (
-	channel1 = "testChannelName"
-	message1 = "msg1"
-	message2 = "msg2"
-	message3 = "msg3"
+	channel1Name = "testChannelName"
+	message1     = "msg1"
+	message2     = "msg2"
+	message3     = "msg3"
 )
 
 func TestPubSub(t *testing.T) {
-	target := testredis.Start(t).Target
-	pubSub := NewStreamPubSub(redis.NewClient(redisutil.TargetToOptions(target)))
+	redisHandle := testredis.Start(t)
+	pubSub := NewStreamPubSub(redis.NewClient(redisutil.TargetToOptions(redisHandle.Target)))
 
 	ctx := context.Background()
+
+	channel1 := pubSub.UnmonitoredChannel(channel1Name)
 
 	subscriber := pubSub.SubscribeHead(ctx, channel1)
 	defer subscriber.Close()
@@ -58,7 +60,33 @@ func TestPubSub(t *testing.T) {
 	requireMessages(t, tailSubscriber, message3)
 }
 
-func requireNoMessages(t *testing.T, subscriber interfaces.Subscriber) {
+func TestMonitoredPubSub(t *testing.T) {
+	redisHandle := testredis.Start(t)
+	pubSub := NewStreamPubSub(redis.NewClient(redisutil.TargetToOptions(redisHandle.Target)))
+
+	ctx := context.Background()
+
+	err := pubSub.CreateMonitoredChannel(ctx, channel1Name)
+	require.NoError(t, err)
+	channel1 := pubSub.MonitoredChannel(channel1Name)
+
+	subscriber := pubSub.SubscribeHead(ctx, channel1)
+	defer subscriber.Close()
+	requireNoMessages(t, subscriber)
+
+	// Publish a message and it should be immediately available to the subscriber.
+	err = pubSub.Publish(ctx, channel1, message1)
+	require.NoError(t, err)
+	requireMessages(t, subscriber, message1)
+
+	redisHandle.Restart()
+
+	err = requireError(t, subscriber)
+	require.True(t, status.IsUnavailableError(err), "expected UNAVAILABLE error but got %s", err)
+	require.Contains(t, err.Error(), "disappeared")
+}
+
+func requireNoMessages(t *testing.T, subscriber *StreamSubscription) {
 	select {
 	case msg, ok := <-subscriber.Chan():
 		if !ok {
@@ -70,18 +98,22 @@ func requireNoMessages(t *testing.T, subscriber interfaces.Subscriber) {
 	}
 }
 
-func requireMessages(t *testing.T, subscriber interfaces.Subscriber, expectedMessages ...string) {
-	timedOut := false
+func requireMessages(t *testing.T, subscriber *StreamSubscription, expectedMessages ...string) {
+	done := false
 	var receivedMsgs []string
-	for !timedOut {
+	for !done {
 		select {
 		case msg, ok := <-subscriber.Chan():
 			if !ok {
 				assert.FailNow(t, "subscriber channel closed prematurely")
 			}
-			receivedMsgs = append(receivedMsgs, msg)
-		case <-time.After(500 * time.Millisecond):
-			timedOut = true
+			require.NoError(t, msg.Err, "expected message, but got error")
+			receivedMsgs = append(receivedMsgs, msg.Data)
+			if len(receivedMsgs) == len(expectedMessages) {
+				done = true
+			}
+		case <-time.After(2 * time.Second):
+			done = true
 		}
 	}
 
@@ -90,4 +122,18 @@ func requireMessages(t *testing.T, subscriber interfaces.Subscriber, expectedMes
 	}
 
 	require.Equal(t, expectedMessages, receivedMsgs, "received PubSub messages did not match expected messages")
+}
+
+func requireError(t *testing.T, subscriber *StreamSubscription) error {
+	select {
+	case msg, ok := <-subscriber.Chan():
+		if !ok {
+			assert.FailNow(t, "subscriber channel closed prematurely")
+		}
+		require.Error(t, msg.Err, "subscriber should have returned an error")
+		return msg.Err
+	case <-time.After(2 * time.Second):
+		assert.FailNow(t, "expected to receive an error but none received")
+	}
+	return nil
 }

--- a/enterprise/server/remote_execution/execution_server/BUILD
+++ b/enterprise/server/remote_execution/execution_server/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//enterprise/server/remote_execution/operation",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/tasksize",
+        "//enterprise/server/util/rbeutil",
         "//proto:execution_stats_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",

--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/tasksize",
+        "//enterprise/server/util/rbeutil",
         "//proto:api_key_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/tasksize"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/rbeutil"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/resources"
@@ -905,7 +906,13 @@ func (s *SchedulerServer) assignWorkToNode(ctx context.Context, handle *executor
 }
 
 func redisKeyForTask(taskID string) string {
-	return "task/" + taskID
+	if rbeutil.IsV2ExecutionID(taskID) {
+		// Use the taskID as the input to the Redis consistent hash function so that task information and pubsub
+		// channels end up on the same Redis shard.
+		return fmt.Sprintf("task/{%s}", taskID)
+	} else {
+		return fmt.Sprintf("task/%s", taskID)
+	}
 }
 
 func (s *SchedulerServer) insertTask(ctx context.Context, taskID string, metadata *scpb.SchedulingMetadata, serializedTask []byte) error {

--- a/enterprise/server/test/integration/remote_execution/BUILD
+++ b/enterprise/server/test/integration/remote_execution/BUILD
@@ -17,6 +17,7 @@ go_test(
         "//server/testutil/testenv",
         "//server/testutil/testfs",
         "//server/util/status",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/server/util/rbeutil/BUILD
+++ b/enterprise/server/util/rbeutil/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "rbeutil",
+    srcs = ["rbeutil.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/rbeutil",
+    visibility = ["//visibility:public"],
+)

--- a/enterprise/server/util/rbeutil/rbeutil.go
+++ b/enterprise/server/util/rbeutil/rbeutil.go
@@ -1,0 +1,18 @@
+package rbeutil
+
+import "strings"
+
+const (
+	// Certain RBE features rely on predictable names for resources so that different apps can co-operate
+	// without needing any direct communication or shared state. For example, a client may be waiting for execution
+	// progress updates on one app and updates may be published by other apps. This co-operation is possible because
+	// all the apps generate the same PubSub channel name based on the execution ID.
+	// Occasionally we need to introduce changes that affect these shared resources. To be able to roll out these
+	// changes safely, we encode the scheme being used as part of the execution ID. This allows apps to determine which
+	// naming/protocol they should for a given execution without knowing anything about other apps.
+	V2ExecutionIDPrefix = "v2/"
+)
+
+func IsV2ExecutionID(executionID string) bool {
+	return strings.HasPrefix(executionID, V2ExecutionIDPrefix)
+}

--- a/enterprise/server/util/rbeutil/rbeutil.go
+++ b/enterprise/server/util/rbeutil/rbeutil.go
@@ -10,6 +10,13 @@ const (
 	// Occasionally we need to introduce changes that affect these shared resources. To be able to roll out these
 	// changes safely, we encode the scheme being used as part of the execution ID. This allows apps to determine which
 	// naming/protocol they should for a given execution without knowing anything about other apps.
+
+	// V2ExecutionIDPrefix is used for rolling out changes to the Redis PubSub stream keys used for remote execution
+	// status updates and for task key updates. Notably under the new scheme both the PubSub stream keys and the task
+	// keys use the task ID as the hash for the ring client to ensure that PubSub channel and task metadata for a single
+	// task are placed on the same Redis shard. The other change is that we publish a dummy marker message to the PubSub
+	// stream when the PubSub channel is created so that we can properly detect whether the PubSub stream has
+	// disappeared from redis.
 	V2ExecutionIDPrefix = "v2/"
 )
 


### PR DESCRIPTION
This PR adds the ability to detect if execution related data has disappeared
because Redis restarted and lost data or because a Redis shard went
away. The detection is built into the PubSub subscription. The PubSub
subscriber monitors the state of the PubSub stream in the background
and publishes an error to the subscription client if the PubSub stream
disappears.

If we detect that a PubSub stream has gone away, we generate a synthetic
operation failure message to Bazel and rely on Bazel to retry execution
of the action.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
