### PR TITLE
remove new timing fields when comparing invocations

### DIFF
--- a/app/compare/BUILD
+++ b/app/compare/BUILD
@@ -16,6 +16,7 @@ ts_library(
         "//app/router",
         "//app/service",
         "//app/util:errors",
+        "//proto:build_event_stream_ts_proto",
         "//proto:command_line_ts_proto",
         "//proto:invocation_ts_proto",
         "@npm//@types/diff-match-patch",

--- a/app/compare/diff_preprocessing.tsx
+++ b/app/compare/diff_preprocessing.tsx
@@ -1,5 +1,6 @@
 import { invocation as invocation_proto } from "../../proto/invocation_ts_proto";
 import { command_line } from "../../proto/command_line_ts_proto";
+import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
 
 export type PreProcessingOptions = {
   sortEvents?: boolean;
@@ -83,10 +84,13 @@ export function prepareForDiff(
         removeTimingData(buildEvent.structuredCommandLine);
       } else if (id?.buildMetrics) {
         delete buildEvent.buildMetrics.timingMetrics;
+        removeTimingDataInActionSummary(buildEvent.buildMetrics.actionSummary);
       } else if (id?.started) {
         delete buildEvent.started.startTimeMillis;
+        delete buildEvent.started.startTime;
       } else if (id?.buildFinished) {
         delete buildEvent.finished.finishTimeMillis;
+        delete buildEvent.finished.finishTime;
       }
     }
 
@@ -106,6 +110,13 @@ function removeTimingData(commandLine: command_line.ICommandLine) {
   for (const section of commandLine.sections) {
     if (!section?.optionList?.option) continue;
     section.optionList.option = section.optionList.option.filter((option) => option.optionName !== "startup_time");
+  }
+}
+
+function removeTimingDataInActionSummary(actionSummary: build_event_stream.BuildMetrics.IActionSummary) {
+  for (const actionData of actionSummary.actionData) {
+    delete actionData.firstStartedMs;
+    delete actionData.lastEndedMs;
   }
 }
 

--- a/app/compare/diff_preprocessing.tsx
+++ b/app/compare/diff_preprocessing.tsx
@@ -114,7 +114,7 @@ function removeTimingData(commandLine: command_line.ICommandLine) {
 }
 
 function removeTimingDataInActionSummary(actionSummary: build_event_stream.BuildMetrics.IActionSummary) {
-  for (const actionData of actionSummary.actionData) {
+  for (const actionData of actionSummary?.actionData || []) {
     delete actionData.firstStartedMs;
     delete actionData.lastEndedMs;
   }


### PR DESCRIPTION
- delete first_started_ms and last_ended_ms in
BuildMetrics.ActionSummary.ActionData
- delete BuildStarted.StartTime and BuildFinished.FinishTime

https://github.com/buildbuddy-io/buildbuddy-internal/issues/1162
