### PR TITLE
Don't build docker tests by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,8 +30,6 @@ build:remote-shared --remote_download_minimal
 build:remote-shared --experimental_repo_remote_exec
 build:remote-shared --jobs=100
 build:remote-shared --verbose_failures
-# TODO(bduffany): Remove this once firecracker is enabled in prod.
-build:remote-shared --build_tag_filters=-docker
 
 # Build with --config=remote to use BuildBuddy RBE.
 build:remote --config=remote-shared
@@ -98,9 +96,10 @@ build --workspace_status_command=$(pwd)/workspace_status.sh
 # Use a static PATH variable to prevent unnecessary rebuilds of dependencies like protobuf.
 build --incompatible_strict_action_env
 
-# Don't include Docker tests by default when running `bazel test //...`, to avoid
-# a hard dependency on Docker for development.
+# Don't build or run Docker tests by default, to avoid a hard dependency
+# on Docker for development.
 test --test_tag_filters=-docker
+build --build_tag_filters=-docker
 
 # Try importing a user specific .bazelrc
 # You can create your own by copying and editing the template-user.bazelrc template:


### PR DESCRIPTION
This causes problems for BB code, which wants to use the `buildbuddy-ci-runner` image for the RBE image (so that the target platform matches the host platform), but the CI runner image doesn't (yet?) have Docker installed.

Example failure:

https://app.buildbuddy.dev/invocation/0255ebea-bafb-43fe-b0e2-fea27ec6d6fd?actionDigest=1fa103e9af0da4afabefe962260b88007243a10a1cf96d01489d423fda36703e/284&actionResultDigest=d020edebebf3c2ca9a0d4531a76cad4ec7526f443a0fbd14df49146c7e85a4f1/284#

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
