### PR TITLE
Re-enable systemrc for workflows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -63,12 +63,17 @@ build:untrusted-ci --repository_cache=/home/runner/repo-cache/untrusted/
 build:untrusted-ci --disk_cache=
 
 # Configuration used for BuildBuddy workflows
-build:workflows --config=remote
+build:workflows --config=remote-shared
 build:workflows --build_metadata=ROLE=CI
 build:workflows --build_metadata=VISIBILITY=PUBLIC
 build:workflows --remote_instance_name=buildbuddy-io/buildbuddy/workflows
 build:workflows --color=yes
 build:workflows --disk_cache=
+# Use BuildBuddy endpoints from the CI runner systemrc.
+build:workflows --config=buildbuddy_bes_backend
+build:workflows --config=buildbuddy_bes_results_url
+build:workflows --config=buildbuddy_remote_cache
+build:workflows --config=buildbuddy_remote_executor
 
 # Configuration used for BuildBuddy release workflow
 build:release --config=remote

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -7,7 +7,6 @@ actions:
       pull_request:
         branches:
           - "master"
-    # TODO(http://go/b/1140): Re-enable system bazelrc
     bazel_commands:
       - test //... --config=workflows --test_tag_filters=-performance,-webdriver,-docker
   - name: Benchmark

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -9,14 +9,14 @@ actions:
           - "master"
     # TODO(http://go/b/1140): Re-enable system bazelrc
     bazel_commands:
-      - bazel --nosystem_rc test //... --config=workflows --test_tag_filters=-performance,-webdriver,-docker
+      - test //... --config=workflows --test_tag_filters=-performance,-webdriver,-docker
   - name: Benchmark
     triggers:
       push:
         branches:
           - "master"
     bazel_commands:
-      - bazel --nosystem_rc test //... --config=workflows --test_tag_filters=+performance
+      - test //... --config=workflows --test_tag_filters=+performance
   - name: Browser tests
     triggers:
       push:
@@ -27,7 +27,7 @@ actions:
           - "master"
     bazel_commands:
       # TODO(http://go/b/958): See if we can remove --remote_download_outputs=toplevel
-      - bazel --nosystem_rc test //... --config=workflows --remote_download_outputs=toplevel --test_tag_filters=+webdriver
+      - test //... --config=workflows --remote_download_outputs=toplevel --test_tag_filters=+webdriver
   # TODO(bduffany): Move docker tests to the Test workflow when they are fast enough.
   # TODO(http://go/b/1151): Switch from dev -> prod and re-enable
   # - name: Docker tests
@@ -39,4 +39,4 @@ actions:
   #       branches:
   #         - "master"
   #   bazel_commands:
-  #     - bazel --nosystem_rc test //... --config=workflows --config=remote-dev --test_tag_filters=+docker --build_tag_filters=+docker
+  #     - test //... --config=workflows --config=remote-dev --test_tag_filters=+docker --build_tag_filters=+docker


### PR DESCRIPTION
This will allow us to re-enable workflows in dev, with dev CI runner actions pointing at dev BB endpoints.

Here are the new systemrc configs in action (screenshot from the command line displayed in the UI):

![image](https://user-images.githubusercontent.com/2414826/154357883-c5bbf203-a767-44ad-8d8c-69318ab67e3b.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1140
