### PR TITLE
Add one more line to ansi buffer

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -700,10 +700,10 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 			if e.env.GetConfigurator().GetStorageEnableChunkedEventLogs() {
 				numLinesToRetain := getNumActionsShownFromStartedBuildEvent(&bazelBuildEvent)
 				if numLinesToRetain != 0 {
-					// the number of lines curses can overwrite is 2 + the ui_actions shown:
-					// 1 for the progress tracker, 1 for each action, and 1 blank line.
+					// the number of lines curses can overwrite is 3 + the ui_actions shown:
+					// 1 for the progress tracker, 1 for each action, and 2 blank lines.
 					// 0 indicates that curses is not being used.
-					numLinesToRetain += 2
+					numLinesToRetain += 3
 				}
 				e.logWriter = eventlog.NewEventLogWriter(
 					e.ctx,


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Some invocations still indicate that the cursor is trying to move 1 line above the top of the
screen, so let's add 1 more line. I think this may be trying to erase a newline at the end of
the first line outside the buffer and not actually affecting the output display, since I
haven't seen malformed logs since we last incremented the ANSI buffer, but this should
silence complaints in the log.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
