### PR TITLE
Firecracker: Enable debug mode when --debug_stream_command_outputs is set

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -804,6 +804,7 @@ func (p *Pool) newContainer(ctx context.Context, props *platform.Properties, tas
 			InitDockerd:            props.InitDockerd,
 			JailerRoot:             p.buildRoot,
 			AllowSnapshotStart:     false,
+			DebugMode:              *commandutil.DebugStreamCommandOutputs,
 		}
 		c, err := firecracker.NewContainer(p.env, p.imageCacheAuth, opts)
 		if err != nil {


### PR DESCRIPTION
This will allow seeing the firecracker VM output without having to make a code change.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
