### PR TITLE
Don't return from stats recorder goroutine when invocations are retried

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -261,7 +261,7 @@ func (r *statsRecorder) Start() {
 				// for any other purpose).
 				hit_tracker.CleanupCacheStats(ctx, r.env, task.invocationJWT.id)
 				if !updated {
-					log.Debugf("Attempt %d of invocation %s pre-empted by more recent attempt, no cache stats flushed.", task.invocationJWT.attempt, task.invocationJWT.id)
+					log.Warningf("Attempt %d of invocation %s pre-empted by more recent attempt, no cache stats flushed.", task.invocationJWT.attempt, task.invocationJWT.id)
 					// Don't notify the webhook; the more recent attempt should trigger
 					// the notification when it is finalized.
 					continue

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -199,7 +199,7 @@ func (r *statsRecorder) Enqueue(ctx context.Context, invocation *inpb.Invocation
 		break
 	default:
 		alert.UnexpectedEvent(
-			"stats_recorder_workers_overloaded",
+			"stats_recorder_channel_buffer_full",
 			"Failed to write cache stats: stats recorder task buffer is full")
 	}
 }
@@ -274,7 +274,7 @@ func (r *statsRecorder) Start() {
 					break
 				default:
 					alert.UnexpectedEvent(
-						"webhook_workers_overloaded",
+						"webhook_channel_buffer_full",
 						"Failed to notify webhook: channel buffer is full")
 				}
 			}


### PR DESCRIPTION
Attempt at fixing the error: `"Failed to write cache stats: stats recorder task buffer is full"`, which we believe is happening when all stats recorder workers have returned.

Also replace some `log.Errorf` occurrences with `alert.UnexpectedEvent` so we can be alerted of this more quickly in the future.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
