### PR TITLE
Refactor invocation finalization workers and add prometheus metrics

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -261,7 +261,7 @@ func (r *statsRecorder) Start() {
 				// for any other purpose).
 				hit_tracker.CleanupCacheStats(ctx, r.env, task.invocationJWT.id)
 				if !updated {
-					log.Debugf("Attempt %d of invocation %s pre-empted by more recent attempt, no cache stats flushed.", task.invocationJWT.attempt, task.invocationJWT.id)
+					log.Warningf("Attempt %d of invocation %s pre-empted by more recent attempt, no cache stats flushed.", task.invocationJWT.attempt, task.invocationJWT.id)
 					// Don't notify the webhook; the more recent attempt should trigger
 					// the notification when it is finalized.
 					continue

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -199,7 +199,7 @@ func (r *statsRecorder) Enqueue(ctx context.Context, invocation *inpb.Invocation
 		break
 	default:
 		alert.UnexpectedEvent(
-			"stats_recorder_workers_overloaded",
+			"stats_recorder_channel_buffer_full",
 			"Failed to write cache stats: stats recorder task buffer is full")
 	}
 }
@@ -274,7 +274,7 @@ func (r *statsRecorder) Start() {
 					break
 				default:
 					alert.UnexpectedEvent(
-						"webhook_workers_overloaded",
+						"webhook_channel_buffer_full",
 						"Failed to notify webhook: channel buffer is full")
 				}
 			}

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -60,8 +60,11 @@ const (
 	// How many workers to spin up for writing cache stats to the DB.
 	numStatsRecorderWorkers = 8
 
+	// How many workers to spin up for looking up invocations before webhooks are
+	// notified.
+	numWebhookNotifierLookupWorkers = 8
 	// How many workers to spin up for notifying webhooks.
-	numWebhookNotifierWorkers = 16
+	numWebhookNotifierNotifyWorkers = 16
 
 	// How long to wait before giving up on webhook requests.
 	webhookNotifyTimeout = 1 * time.Minute
@@ -233,53 +236,64 @@ func readScoreCard(ctx context.Context, env environment.Env, invocationID string
 }
 
 func (r *statsRecorder) Start() {
-	r.eg = errgroup.Group{}
 	ctx := context.Background()
 	for i := 0; i < numStatsRecorderWorkers; i++ {
-		r.eg.Go(func() error {
+		metrics.StatsRecorderWorkers.Inc()
+		go func() {
+			defer metrics.StatsRecorderWorkers.Dec()
 			for task := range r.tasks {
-				// Apply the finalization delay relative to when the invocation was marked
-				// finalized, rather than relative to now. Otherwise each worker would be
-				// unnecessarily throttled.
-				time.Sleep(time.Until(task.createdAt.Add(cacheStatsFinalizationDelay)))
-				ti := &tables.Invocation{InvocationID: task.invocationJWT.id, Attempt: task.invocationJWT.attempt}
-				if stats := hit_tracker.CollectCacheStats(ctx, r.env, task.invocationJWT.id); stats != nil {
-					fillInvocationFromCacheStats(stats, ti)
-				}
-				if scoreCard := hit_tracker.ScoreCard(ctx, r.env, task.invocationJWT.id); scoreCard != nil {
-					if err := writeScoreCard(ctx, r.env, task.invocationJWT.id, scoreCard); err != nil {
-						log.Errorf("Error writing scorecard blob: %s", err)
-					}
-				}
-
-				updated, err := r.env.GetInvocationDB().UpdateInvocation(ctx, ti)
-				if err != nil {
-					log.Errorf("Failed to write cache stats for invocation: %s", err)
-				}
-				// Cleanup regardless of whether the stats are flushed successfully to
-				// the DB (since we won't retry the flush and we don't need these stats
-				// for any other purpose).
-				hit_tracker.CleanupCacheStats(ctx, r.env, task.invocationJWT.id)
-				if !updated {
-					log.Warningf("Attempt %d of invocation %s pre-empted by more recent attempt, no cache stats flushed.", task.invocationJWT.attempt, task.invocationJWT.id)
-					// Don't notify the webhook; the more recent attempt should trigger
-					// the notification when it is finalized.
-					continue
-				}
-
-				// Once cache stats are populated, notify the onStatsRecorded channel in
-				// a non-blocking fashion.
-				select {
-				case r.onStatsRecorded <- task.invocationJWT:
-					break
-				default:
-					alert.UnexpectedEvent(
-						"webhook_channel_buffer_full",
-						"Failed to notify webhook: channel buffer is full")
-				}
+				r.handleTask(ctx, task)
 			}
-			return nil
-		})
+		}()
+	}
+}
+
+func (r *statsRecorder) handleTask(ctx context.Context, task *recordStatsTask) {
+	log.Infof("Recording stats")
+
+	start := time.Now()
+	defer func() {
+		metrics.StatsRecorderDuration.Observe(float64(time.Since(start).Microseconds()))
+	}()
+
+	// Apply the finalization delay relative to when the invocation was marked
+	// finalized, rather than relative to now. Otherwise each worker would be
+	// unnecessarily throttled.
+	time.Sleep(time.Until(task.createdAt.Add(cacheStatsFinalizationDelay)))
+	ti := &tables.Invocation{InvocationID: task.invocationJWT.id, Attempt: task.invocationJWT.attempt}
+	if stats := hit_tracker.CollectCacheStats(ctx, r.env, task.invocationJWT.id); stats != nil {
+		fillInvocationFromCacheStats(stats, ti)
+	}
+	if scoreCard := hit_tracker.ScoreCard(ctx, r.env, task.invocationJWT.id); scoreCard != nil {
+		if err := writeScoreCard(ctx, r.env, task.invocationJWT.id, scoreCard); err != nil {
+			log.Errorf("Error writing scorecard blob: %s", err)
+		}
+	}
+
+	updated, err := r.env.GetInvocationDB().UpdateInvocation(ctx, ti)
+	if err != nil {
+		log.Errorf("Failed to write cache stats for invocation: %s", err)
+	}
+	// Cleanup regardless of whether the stats are flushed successfully to
+	// the DB (since we won't retry the flush and we don't need these stats
+	// for any other purpose).
+	hit_tracker.CleanupCacheStats(ctx, r.env, task.invocationJWT.id)
+	if !updated {
+		log.Warningf("Attempt %d of invocation %s pre-empted by more recent attempt, no cache stats flushed.", task.invocationJWT.attempt, task.invocationJWT.id)
+		// Don't notify the webhook; the more recent attempt should trigger
+		// the notification when it is finalized.
+		return
+	}
+
+	// Once cache stats are populated, notify the onStatsRecorded channel in
+	// a non-blocking fashion.
+	select {
+	case r.onStatsRecorded <- task.invocationJWT:
+		break
+	default:
+		alert.UnexpectedEvent(
+			"webhook_channel_buffer_full",
+			"Failed to notify webhook: channel buffer is full")
 	}
 }
 
@@ -310,6 +324,11 @@ type notifyWebhookTask struct {
 }
 
 func notifyWithTimeout(ctx context.Context, env environment.Env, t *notifyWebhookTask) error {
+	start := time.Now()
+	defer func() {
+		metrics.WebhookNotifyDuration.Observe(float64(time.Since(start).Microseconds()))
+	}()
+
 	ctx, cancel := context.WithTimeout(ctx, webhookNotifyTimeout)
 	defer cancel()
 	// Run the webhook using the authenticated user from the build event stream.
@@ -349,43 +368,59 @@ func (w *webhookNotifier) Start() {
 	w.eg = errgroup.Group{}
 	ctx := context.Background()
 
-	w.eg.Go(func() error {
-		// Listen for invocations that have been finalized and start a notify
-		// webhook task for each webhook.
-		for ij := range w.invocations {
-			invocation, err := w.lookupInvocation(ctx, ij)
-			if err != nil {
-				log.Warningf("Failed to lookup invocation before notifying webhook: %s", err)
-				continue
-			}
-
-			// Don't call webhooks for disconnected invocations.
-			if invocation.GetInvocationStatus() == inpb.Invocation_DISCONNECTED_INVOCATION_STATUS {
-				continue
-			}
-
-			for _, hook := range w.env.GetWebhooks() {
-				w.tasks <- &notifyWebhookTask{
-					hook:          hook,
-					invocationJWT: ij,
-					invocation:    invocation,
+	for i := 0; i < numWebhookNotifierLookupWorkers; i++ {
+		metrics.WebhookInvocationLookupWorkers.Inc()
+		go func() {
+			defer metrics.WebhookInvocationLookupWorkers.Dec()
+			// Listen for invocations that have been finalized and start a notify
+			// webhook task for each webhook.
+			for ij := range w.invocations {
+				if err := w.lookupAndCreateTask(ctx, ij); err != nil {
+					log.Warningf("Failed to lookup invocation before notifying webhook: %s", err)
 				}
 			}
-		}
-		w.doneSendingTasks <- struct{}{}
-		return nil
-	})
+			w.doneSendingTasks <- struct{}{}
+		}()
+	}
 
-	for i := 0; i < numWebhookNotifierWorkers; i++ {
-		w.eg.Go(func() error {
+	for i := 0; i < numWebhookNotifierNotifyWorkers; i++ {
+		metrics.WebhookNotifyWorkers.Inc()
+		go func() {
+			defer metrics.WebhookNotifyWorkers.Dec()
 			for task := range w.tasks {
 				if err := notifyWithTimeout(ctx, w.env, task); err != nil {
 					log.Warningf("Failed to notify webhook for invocation %s: %s", task.invocation.GetInvocationId(), err)
 				}
 			}
-			return nil
-		})
+		}()
 	}
+}
+
+func (w *webhookNotifier) lookupAndCreateTask(ctx context.Context, ij *invocationJWT) error {
+	start := time.Now()
+	defer func() {
+		metrics.WebhookInvocationLookupDuration.Observe(float64(time.Since(start).Microseconds()))
+	}()
+
+	invocation, err := w.lookupInvocation(ctx, ij)
+	if err != nil {
+		return err
+	}
+
+	// Don't call webhooks for disconnected invocations.
+	if invocation.GetInvocationStatus() == inpb.Invocation_DISCONNECTED_INVOCATION_STATUS {
+		return nil
+	}
+
+	for _, hook := range w.env.GetWebhooks() {
+		w.tasks <- &notifyWebhookTask{
+			hook:          hook,
+			invocationJWT: ij,
+			invocation:    invocation,
+		}
+	}
+
+	return nil
 }
 
 func (w *webhookNotifier) Stop() {

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -62,9 +62,9 @@ const (
 
 	// How many workers to spin up for looking up invocations before webhooks are
 	// notified.
-	numWebhookNotifierLookupWorkers = 8
+	numWebhookInvocationLookupWorkers = 8
 	// How many workers to spin up for notifying webhooks.
-	numWebhookNotifierNotifyWorkers = 16
+	numWebhookNotifyWorkers = 16
 
 	// How long to wait before giving up on webhook requests.
 	webhookNotifyTimeout = 1 * time.Minute
@@ -366,7 +366,7 @@ func (w *webhookNotifier) Start() {
 	w.eg = errgroup.Group{}
 	ctx := context.Background()
 
-	for i := 0; i < numWebhookNotifierLookupWorkers; i++ {
+	for i := 0; i < numWebhookInvocationLookupWorkers; i++ {
 		metrics.WebhookInvocationLookupWorkers.Inc()
 		go func() {
 			defer metrics.WebhookInvocationLookupWorkers.Dec()
@@ -381,7 +381,7 @@ func (w *webhookNotifier) Start() {
 		}()
 	}
 
-	for i := 0; i < numWebhookNotifierNotifyWorkers; i++ {
+	for i := 0; i < numWebhookNotifyWorkers; i++ {
 		metrics.WebhookNotifyWorkers.Inc()
 		go func() {
 			defer metrics.WebhookNotifyWorkers.Dec()

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -110,9 +110,9 @@ const (
 )
 
 var (
-	/// ## Build event handler metrics
+	/// ## Invocation build event metrics
 	///
-	/// All metrics are recorded at the _end_ of each invocation.
+	/// All invocation metrics are recorded at the _end_ of each invocation.
 
 	InvocationCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -110,9 +110,9 @@ const (
 )
 
 var (
-	/// ## Invocation log uploads
+	/// ## Build event handler metrics
 	///
-	/// All invocation metrics are recorded at the _end_ of each invocation.
+	/// All metrics are recorded at the _end_ of each invocation.
 
 	InvocationCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
@@ -177,6 +177,51 @@ var (
 	///   /
 	/// sum(rate(buildbuddy_invocation_build_event_count[5m]))
 	/// ```
+
+	StatsRecorderWorkers = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "invocation",
+		Name:      "stats_recorder_workers",
+		Help:      "Number of invocation stats recorder workers currently running.",
+	})
+
+	StatsRecorderDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "invocation",
+		Name:      "stats_recorder_duration_usec",
+		Buckets:   prometheus.ExponentialBuckets(1, 10, 9),
+		Help:      "How long it took to finalize an invocation's stats. This includes the time required to wait for all BuildBuddy apps to flush their local metrics to Redis (if applicable) and then record the metrics to the DB.",
+	})
+
+	WebhookInvocationLookupWorkers = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "invocation",
+		Name:      "webhook_invocation_lookup_workers",
+		Help:      "Number of webhook invocation lookup workers currently running.",
+	})
+
+	WebhookInvocationLookupDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "invocation",
+		Name:      "webhook_invocation_lookup_duration_usec",
+		Buckets:   prometheus.ExponentialBuckets(1, 10, 9),
+		Help:      "How long it took to lookup an invocation before posting to the webhook.",
+	})
+
+	WebhookNotifyWorkers = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "invocation",
+		Name:      "webhook_notify_workers",
+		Help:      "Number of webhook notify workers currently running.",
+	})
+
+	WebhookNotifyDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "invocation",
+		Name:      "webhook_notify_duration_usec",
+		Buckets:   prometheus.ExponentialBuckets(1, 10, 9),
+		Help:      "How long it took to post an invocation proto to the webhook.",
+	})
 
 	/// ## Remote cache metrics
 	///


### PR DESCRIPTION
* Refactor workers so that it's more obvious that they should run forever, so we don't accidentally terminate them.
* Add metrics so we can monitor/alert on the status of these finalizers.
* Use more than one invocation lookup worker for webhook notifications (previously all webhook notifications were blocked on a single worker looking up invocations in serial).

![image](https://user-images.githubusercontent.com/2414826/154573319-cf478aed-f959-4790-8bed-069b78e2e2cf.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
