### PR TITLE
Raise open file descriptor limit for VMs.

### DIFF
--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -291,8 +291,8 @@ func main() {
 	die(mkdirp("/sys/fs/cgroup/cpuset", 0555))
 	die(mount("cgroup", "/sys/fs/cgroup/cpuset", "cgroup", cgroupMountFlags, "cpuset"))
 
-	if err := rlimit.MaxRLimit(); err != nil {
-		log.Errorf("Unable to increase rlimit: %s", err)
+	if err := rlimit.SetOpenFileDescriptorLimit(16384); err != nil {
+		log.Errorf("Unable to increase file open descriptor limit: %s", err)
 	}
 
 	die(mkdirp("/etc", 0755))

--- a/server/util/rlimit/rlimit.go
+++ b/server/util/rlimit/rlimit.go
@@ -28,3 +28,11 @@ func MaxRLimit() error {
 	}
 	return nil
 }
+
+func SetOpenFileDescriptorLimit(n uint64) error {
+	log.Infof("Increasing open file descriptor limit to %d", n)
+	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &syscall.Rlimit{Cur: n, Max: n}); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
The current limit (4096) is not sufficient for large Bazel builds.

The default process hard limit in the kernel is 4096, but it is modifiable by any
privileged process. The system hard limit is much higher.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
