### PR TITLE
Firecracker: Use correct context when cleaning up forwarding rule

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -304,7 +304,7 @@ type FirecrackerContainer struct {
 	// to finish, rather than calling "Wait()" on the sdk machine object.
 	externalJailerCmd *exec.Cmd
 
-	cleanupVethPair func() error
+	cleanupVethPair func(context.Context) error
 }
 
 // ConfigurationHash returns a digest that can be used to look up or save a
@@ -982,7 +982,7 @@ func (c *FirecrackerContainer) cleanupNetworking(ctx context.Context) error {
 	// up everything and return the last error if there is one.
 	var lastErr error
 	if c.cleanupVethPair != nil {
-		if err := c.cleanupVethPair(); err != nil {
+		if err := c.cleanupVethPair(ctx); err != nil {
 			lastErr = err
 		}
 	}

--- a/enterprise/server/util/networking/networking.go
+++ b/enterprise/server/util/networking/networking.go
@@ -178,7 +178,7 @@ func DeleteRoute(ctx context.Context, vmIdx int) error {
 //
 //  # add a route in the root namespace so that traffic to 192.168.0.3 hits 10.0.0.2, the veth0 end of the pair
 //  $ sudo ip route add 192.168.0.3 via 10.0.0.2
-func SetupVethPair(ctx context.Context, netNamespace, vmIP string, vmIdx int) (func() error, error) {
+func SetupVethPair(ctx context.Context, netNamespace, vmIP string, vmIdx int) (func(context.Context) error, error) {
 	defaultDevice, err := findDefaultDevice(ctx)
 	if err != nil {
 		return nil, err
@@ -249,7 +249,7 @@ func SetupVethPair(ctx context.Context, netNamespace, vmIP string, vmIdx int) (f
 		return nil, err
 	}
 
-	return func() error {
+	return func(ctx context.Context) error {
 		return removeForwardAcceptRule(ctx, veth1, defaultDevice)
 	}, nil
 }


### PR DESCRIPTION
This was preventing the firecracker container from being cleaned up properly (it was failing with "context canceled")

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
