### PR TITLE
Firecracker: Improve EOF handling in mergeDiffSnapshot

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -439,14 +439,15 @@ func mergeDiffSnapshot(ctx context.Context, baseSnapshotPath string, diffSnapsho
 				}
 
 				n, err := gin.ReadAt(buf, offset)
-				if err == io.EOF {
-					break
-				}
-				if err != nil {
+				eof := err == io.EOF
+				if err != nil && !eof {
 					return err
 				}
 				if _, err := out.WriteAt(buf[:n], offset); err != nil {
 					return err
+				}
+				if eof {
+					break
 				}
 				offset += int64(n)
 				if offset >= regionEnd {


### PR DESCRIPTION
Some data can be read when at EOF -- make sure to write the data before breaking out of the loop.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
