### PR TITLE
Add option to mount workspace ext4 fs instead of extracting contents.

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -37,6 +37,7 @@ go_library(
             "//proto:vmvfs_go_proto",
             "//server/environment",
             "//server/interfaces",
+            "//server/util/alert",
             "//server/util/disk",
             "//server/util/hash",
             "//server/util/log",

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -281,31 +281,32 @@ type RemoteExecutionConfig struct {
 }
 
 type ExecutorConfig struct {
-	AppTarget                string                    `yaml:"app_target" usage:"The GRPC url of a buildbuddy app server."`
-	Pool                     string                    `yaml:"pool" usage:"Executor pool name. Only one of this config option or the MY_POOL environment variable should be specified."`
-	RootDirectory            string                    `yaml:"root_directory" usage:"The root directory to use for build files."`
-	HostRootDirectory        string                    `yaml:"host_root_directory" usage:"Path on the host where the executor container root directory is mounted."`
-	LocalCacheDirectory      string                    `yaml:"local_cache_directory" usage:"A local on-disk cache directory. Must be on the same device (disk partition, Docker volume, etc.) as the configured root_directory, since files are hard-linked to this cache for performance reasons. Otherwise, 'Invalid cross-device link' errors may result."`
-	LocalCacheSizeBytes      int64                     `yaml:"local_cache_size_bytes" usage:"The maximum size, in bytes, to use for the local on-disk cache"`
-	DisableLocalCache        bool                      `yaml:"disable_local_cache" usage:"If true, a local file cache will not be used."`
-	DockerSocket             string                    `yaml:"docker_socket" usage:"If set, run execution commands in docker using the provided socket."`
-	APIKey                   string                    `yaml:"api_key" usage:"API Key used to authorize the executor with the BuildBuddy app server."`
-	DockerMountMode          string                    `yaml:"docker_mount_mode" usage:"Sets the mount mode of volumes mounted to docker images. Useful if running on SELinux https://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/"`
-	RunnerPool               RunnerPoolConfig          `yaml:"runner_pool"`
-	DockerNetHost            bool                      `yaml:"docker_net_host" usage:"Sets --net=host on the docker command. Intended for local development only."`
-	DockerSiblingContainers  bool                      `yaml:"docker_sibling_containers" usage:"If set, mount the configured Docker socket to containers spawned for each action, to enable Docker-out-of-Docker (DooD). Takes effect only if docker_socket is also set. Should not be set by executors that can run untrusted code."`
-	DockerInheritUserIDs     bool                      `yaml:"docker_inherit_user_ids" usage:"If set, run docker containers using the same uid and gid as the user running the executor process."`
-	DefaultXcodeVersion      string                    `yaml:"default_xcode_version" usage:"Sets the default Xcode version number to use if an action doesn't specify one. If not set, /Applications/Xcode.app/ is used."`
-	EnableBareRunner         bool                      `yaml:"enable_bare_runner" usage:"Enables running execution commands directly on the host without isolation."`
-	EnableFirecracker        bool                      `yaml:"enable_firecracker" usage:"Enables running execution commands inside of firecracker VMs"`
-	ContainerRegistries      []ContainerRegistryConfig `yaml:"container_registries"`
-	EnableVFS                bool                      `yaml:"enable_vfs" usage:"Whether FUSE based filesystem is enabled."`
-	DefaultImage             string                    `yaml:"default_image" usage:"The default docker image to use to warm up executors or if no platform property is set. Ex: gcr.io/flame-public/executor-docker-default:enterprise-v1.5.4"`
-	WarmupTimeoutSecs        int64                     `yaml:"warmup_timeout_secs" usage:"The default time (in seconds) to wait for an executor to warm up i.e. download the default docker image. Default is 120s"`
-	StartupWarmupMaxWaitSecs int64                     `yaml:"startup_warmup_max_wait_secs" usage:"Maximum time to block startup while waiting for default image to be pulled. Default is no wait."`
-	ExclusiveTaskScheduling  bool                      `yaml:"exclusive_task_scheduling" usage:"If true, only one task will be scheduled at a time. Default is false"`
-	MemoryBytes              int64                     `yaml:"memory_bytes" usage:"Optional maximum memory to allocate to execution tasks (approximate). Cannot set both this option and the SYS_MEMORY_BYTES env var."`
-	MilliCPU                 int64                     `yaml:"millicpu" usage:"Optional maximum CPU milliseconds to allocate to execution tasks (approximate). Cannot set both this option and the SYS_MILLICPU env var."`
+	AppTarget                     string                    `yaml:"app_target" usage:"The GRPC url of a buildbuddy app server."`
+	Pool                          string                    `yaml:"pool" usage:"Executor pool name. Only one of this config option or the MY_POOL environment variable should be specified."`
+	RootDirectory                 string                    `yaml:"root_directory" usage:"The root directory to use for build files."`
+	HostRootDirectory             string                    `yaml:"host_root_directory" usage:"Path on the host where the executor container root directory is mounted."`
+	LocalCacheDirectory           string                    `yaml:"local_cache_directory" usage:"A local on-disk cache directory. Must be on the same device (disk partition, Docker volume, etc.) as the configured root_directory, since files are hard-linked to this cache for performance reasons. Otherwise, 'Invalid cross-device link' errors may result."`
+	LocalCacheSizeBytes           int64                     `yaml:"local_cache_size_bytes" usage:"The maximum size, in bytes, to use for the local on-disk cache"`
+	DisableLocalCache             bool                      `yaml:"disable_local_cache" usage:"If true, a local file cache will not be used."`
+	DockerSocket                  string                    `yaml:"docker_socket" usage:"If set, run execution commands in docker using the provided socket."`
+	APIKey                        string                    `yaml:"api_key" usage:"API Key used to authorize the executor with the BuildBuddy app server."`
+	DockerMountMode               string                    `yaml:"docker_mount_mode" usage:"Sets the mount mode of volumes mounted to docker images. Useful if running on SELinux https://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/"`
+	RunnerPool                    RunnerPoolConfig          `yaml:"runner_pool"`
+	DockerNetHost                 bool                      `yaml:"docker_net_host" usage:"Sets --net=host on the docker command. Intended for local development only."`
+	DockerSiblingContainers       bool                      `yaml:"docker_sibling_containers" usage:"If set, mount the configured Docker socket to containers spawned for each action, to enable Docker-out-of-Docker (DooD). Takes effect only if docker_socket is also set. Should not be set by executors that can run untrusted code."`
+	DockerInheritUserIDs          bool                      `yaml:"docker_inherit_user_ids" usage:"If set, run docker containers using the same uid and gid as the user running the executor process."`
+	DefaultXcodeVersion           string                    `yaml:"default_xcode_version" usage:"Sets the default Xcode version number to use if an action doesn't specify one. If not set, /Applications/Xcode.app/ is used."`
+	EnableBareRunner              bool                      `yaml:"enable_bare_runner" usage:"Enables running execution commands directly on the host without isolation."`
+	EnableFirecracker             bool                      `yaml:"enable_firecracker" usage:"Enables running execution commands inside of firecracker VMs"`
+	FirecrackerMountWorkspaceFile bool                      `yaml:"firecracker_mount_workspace_file" usage:"Enables mounting workspace filesystem to improve performance of copying action outputs."`
+	ContainerRegistries           []ContainerRegistryConfig `yaml:"container_registries"`
+	EnableVFS                     bool                      `yaml:"enable_vfs" usage:"Whether FUSE based filesystem is enabled."`
+	DefaultImage                  string                    `yaml:"default_image" usage:"The default docker image to use to warm up executors or if no platform property is set. Ex: gcr.io/flame-public/executor-docker-default:enterprise-v1.5.4"`
+	WarmupTimeoutSecs             int64                     `yaml:"warmup_timeout_secs" usage:"The default time (in seconds) to wait for an executor to warm up i.e. download the default docker image. Default is 120s"`
+	StartupWarmupMaxWaitSecs      int64                     `yaml:"startup_warmup_max_wait_secs" usage:"Maximum time to block startup while waiting for default image to be pulled. Default is no wait."`
+	ExclusiveTaskScheduling       bool                      `yaml:"exclusive_task_scheduling" usage:"If true, only one task will be scheduled at a time. Default is false"`
+	MemoryBytes                   int64                     `yaml:"memory_bytes" usage:"Optional maximum memory to allocate to execution tasks (approximate). Cannot set both this option and the SYS_MEMORY_BYTES env var."`
+	MilliCPU                      int64                     `yaml:"millicpu" usage:"Optional maximum CPU milliseconds to allocate to execution tasks (approximate). Cannot set both this option and the SYS_MILLICPU env var."`
 }
 
 type ContainerRegistryConfig struct {


### PR DESCRIPTION
Mounting the filesystem file directly is significantly faster.

This is behind a flag for now because it doesn't work well locally due
to needing root. I tried using `udisksctl` to get around this
requirement but ran into the following issues:
   1) On local Ubuntu, at least on my
      installation, something automatically mounts the filesystem as soon as I
      set up the loop device even before I call "mount".
   2) On a deployed image, we would need to have DBus & udisk daemons
      installed and running for this to work.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
