### PR TITLE
Fix prometheus scrape configs for local executor

### DIFF
--- a/tools/metrics/prometheus/prometheus.yml
+++ b/tools/metrics/prometheus/prometheus.yml
@@ -6,7 +6,7 @@ scrape_configs:
   - job_name: buildbuddy-app
     static_configs:
       - targets: ["host.docker.internal:9090"]
-  - job_name: buildbuddy-executor
+  - job_name: executor
     static_configs:
       - targets: ["host.docker.internal:9091"]
   - job_name: redis


### PR DESCRIPTION
The grafana `pool` variable values are determined using the `executor*` regex, so update the local job name to match this regex.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
