### PR TITLE
Make test grid extend to fill remainder of viewport vertically

### DIFF
--- a/enterprise/app/tap/tap.css
+++ b/enterprise/app/tap/tap.css
@@ -104,6 +104,7 @@
   /* Workaround to disable repaint-on-scroll for scrollable flex child,
      which causes bad scroll performance. */
   backface-visibility: hidden;
+  flex-grow: 1;
 }
 
 /* Workaround to add bottom padding to a scrollable flex child. */


### PR DESCRIPTION
This way, the horizontal scrollbar renders at the bottom of the page instead of awkwardly in the middle.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
