### PR TITLE
Move buildbuddy bazelrc to CI runner root dir

### DIFF
--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -94,8 +94,6 @@ func invokeRunner(t *testing.T, args []string, env []string, workDir string) *re
 	}
 	args = append(args, []string{
 		"--bazel_command=" + bazelPath,
-		// When running locally, /etc/bazel.bazelrc is not writable.
-		"--write_system_bazelrc=false",
 		"--bazel_startup_flags=--max_idle_secs=5 --noblock_for_lock",
 	}...)
 

--- a/enterprise/server/test/integration/workflow/workflow_test.go
+++ b/enterprise/server/test/integration/workflow/workflow_test.go
@@ -74,9 +74,6 @@ func setup(t *testing.T, gp interfaces.GitProvider) (*rbetest.Env, interfaces.Wo
 	// Use a pre-built bazel instead of invoking bazelisk, which significantly
 	// slows down the test.
 	flags.Set(t, "remote_execution.workflows_ci_runner_bazel_command", testbazel.BinaryPath(t))
-	// Don't write /etc/bazel.bazelrc in tests; it is not writable when running
-	// locally.
-	flags.Set(t, "remote_execution.workflows_ci_runner_disable_system_bazelrc", "true")
 	// Set events_api_url to point to the test BB app server (this gets
 	// propagated to the CI runner so it knows where to publish build events).
 	flags.Set(t, "app.events_api_url", fmt.Sprintf("grpc://localhost:%d", bbServer.GRPCPort()))

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -612,7 +612,6 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 			"--workflow_id=" + wf.WorkflowID,
 			"--trigger_event=" + wd.EventName,
 			"--bazel_command=" + ws.ciRunnerBazelCommand(),
-			"--write_system_bazelrc=" + fmt.Sprintf("%v", !conf.GetRemoteExecutionConfig().WorkflowsCIRunnerDisableSystemBazelrc),
 			"--debug=" + fmt.Sprintf("%v", ws.ciRunnerDebugMode()),
 		}, extraArgs...),
 		Platform: &repb.Platform{

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -263,23 +263,22 @@ type ShardedRedisConfig struct {
 }
 
 type RemoteExecutionConfig struct {
-	DefaultPoolName                       string             `yaml:"default_pool_name" usage:"The default executor pool to use if one is not specified."`
-	EnableWorkflows                       bool               `yaml:"enable_workflows" usage:"Whether to enable BuildBuddy workflows."`
-	WorkflowsPoolName                     string             `yaml:"workflows_pool_name" usage:"The executor pool to use for workflow actions. Defaults to the default executor pool if not specified."`
-	WorkflowsDefaultImage                 string             `yaml:"workflows_default_image" usage:"The default docker image to use for running workflows."`
-	WorkflowsCIRunnerDebug                bool               `yaml:"workflows_ci_runner_debug" usage:"Whether to run the CI runner in debug mode."`
-	WorkflowsCIRunnerBazelCommand         string             `yaml:"workflows_ci_runner_bazel_command" usage:"Bazel command to be used by the CI runner."`
-	WorkflowsCIRunnerDisableSystemBazelrc bool               `yaml:"workflows_ci_runner_disable_system_bazelrc" usage:"Whether the workflow runner should skip writing the system bazelrc."`
-	RedisTarget                           string             `yaml:"redis_target" usage:"A Redis target for storing remote execution state. Falls back to app.default_redis_target if unspecified. Required for remote execution. To ease migration, the redis target from the cache config will be used if neither this value nor app.default_redis_target are specified."`
-	ShardedRedis                          ShardedRedisConfig `yaml:"sharded_redis" usage:"Optional configuration for sharding execution data across multiple Redis instances. Mutually exclusive with the redis_target option."`
-	SharedExecutorPoolGroupID             string             `yaml:"shared_executor_pool_group_id" usage:"Group ID that owns the shared executor pool."`
-	RedisPubSubPoolSize                   int                `yaml:"redis_pubsub_pool_size" usage:"Maximum number of connections used for waiting for execution updates."`
-	EnableRemoteExec                      bool               `yaml:"enable_remote_exec" usage:"If true, enable remote-exec. ** Enterprise only **"`
-	RequireExecutorAuthorization          bool               `yaml:"require_executor_authorization" usage:"If true, executors connecting to this server must provide a valid executor API key."`
-	EnableUserOwnedExecutors              bool               `yaml:"enable_user_owned_executors" usage:"If enabled, users can register their own executors with the scheduler."`
-	ForceUserOwnedDarwinExecutors         bool               `yaml:"force_user_owned_darwin_executors" usage:"If enabled, darwin actions will always run on user-owned executors."`
-	EnableExecutorKeyCreation             bool               `yaml:"enable_executor_key_creation" usage:"If enabled, UI will allow executor keys to be created."`
-	EnableRedisAvailabilityMonitoring     bool               `yaml:"enable_redis_availability_monitoring" usage:"If enabled, the execution server will detect if Redis has lost state and will ask Bazel to retry executions."`
+	DefaultPoolName                   string             `yaml:"default_pool_name" usage:"The default executor pool to use if one is not specified."`
+	EnableWorkflows                   bool               `yaml:"enable_workflows" usage:"Whether to enable BuildBuddy workflows."`
+	WorkflowsPoolName                 string             `yaml:"workflows_pool_name" usage:"The executor pool to use for workflow actions. Defaults to the default executor pool if not specified."`
+	WorkflowsDefaultImage             string             `yaml:"workflows_default_image" usage:"The default docker image to use for running workflows."`
+	WorkflowsCIRunnerDebug            bool               `yaml:"workflows_ci_runner_debug" usage:"Whether to run the CI runner in debug mode."`
+	WorkflowsCIRunnerBazelCommand     string             `yaml:"workflows_ci_runner_bazel_command" usage:"Bazel command to be used by the CI runner."`
+	RedisTarget                       string             `yaml:"redis_target" usage:"A Redis target for storing remote execution state. Falls back to app.default_redis_target if unspecified. Required for remote execution. To ease migration, the redis target from the cache config will be used if neither this value nor app.default_redis_target are specified."`
+	ShardedRedis                      ShardedRedisConfig `yaml:"sharded_redis" usage:"Optional configuration for sharding execution data across multiple Redis instances. Mutually exclusive with the redis_target option."`
+	SharedExecutorPoolGroupID         string             `yaml:"shared_executor_pool_group_id" usage:"Group ID that owns the shared executor pool."`
+	RedisPubSubPoolSize               int                `yaml:"redis_pubsub_pool_size" usage:"Maximum number of connections used for waiting for execution updates."`
+	EnableRemoteExec                  bool               `yaml:"enable_remote_exec" usage:"If true, enable remote-exec. ** Enterprise only **"`
+	RequireExecutorAuthorization      bool               `yaml:"require_executor_authorization" usage:"If true, executors connecting to this server must provide a valid executor API key."`
+	EnableUserOwnedExecutors          bool               `yaml:"enable_user_owned_executors" usage:"If enabled, users can register their own executors with the scheduler."`
+	ForceUserOwnedDarwinExecutors     bool               `yaml:"force_user_owned_darwin_executors" usage:"If enabled, darwin actions will always run on user-owned executors."`
+	EnableExecutorKeyCreation         bool               `yaml:"enable_executor_key_creation" usage:"If enabled, UI will allow executor keys to be created."`
+	EnableRedisAvailabilityMonitoring bool               `yaml:"enable_redis_availability_monitoring" usage:"If enabled, the execution server will detect if Redis has lost state and will ask Bazel to retry executions."`
 }
 
 type ExecutorConfig struct {


### PR DESCRIPTION
The system bazelrc (`/etc/bazel.bazelrc`) is problematic both for Mac workflows and for workflow tests, since we don't have permission to write it.

Instead, write the bazelrc directly under the CI runner workspace dir an pass it as a `--bazelrc` flag. In order for it to be treated with lower precedence than the workspace `.bazelrc`, we also detect whether a workspace `.bazelrc` is present, and if so, pass in `--noworkspace_rc --bazelrc=.bazelrc` which causes the workspace rc to be treated with higher precedence than our bazelrc.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
