### PR TITLE
Fix another source of 'broken pipe' errors in fix_go_deps

### DIFF
--- a/tools/fix_go_deps.sh
+++ b/tools/fix_go_deps.sh
@@ -59,7 +59,7 @@ fi
 # Note that all indirect imports are in the second block if and only if
 # we see two consecutive "require (" lines as the first 2 lines. So we just
 # check for that here.
-first_two_lines=$( (grep -E '(^require \(|// indirect)' go.mod || true) | head -n 2)
+first_two_lines=$( (grep -E '(^require \(|// indirect)' go.mod 2>/dev/null || true) | head -n 2)
 if [[ $(echo "$first_two_lines" | uniq) != 'require (' ]]; then
   echo "ERROR: Found direct and indirect imports mixed within the same require() block in go.mod" >&2
   echo "Please fix by manually merging all require() blocks into a single block, then running tools/fix_go_deps.sh" >&2


### PR DESCRIPTION
When grep terminates early (due to "head -n2") it occasionally prints "grep: broken pipe" for some reason. Silence this output to prevent it from showing up in the diff.

I can't repro this locally, so this PR is just an attempt to fix.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
