### PR TITLE
Prevent flag names in combined form from getting stripped out

### DIFF
--- a/server/util/redact/redact.go
+++ b/server/util/redact/redact.go
@@ -129,6 +129,14 @@ func filterCommandLineOptions(options []*clpb.Option) []*clpb.Option {
 	return filtered
 }
 
+func splitCombinedForm(cf string) (string, string) {
+	i := strings.Index(cf, "=")
+	if i < 0 {
+		return cf, ""
+	}
+	return cf[:i], cf[i+1:]
+}
+
 func redactStructuredCommandLine(commandLine *clpb.CommandLine, allowedEnvVars []string) {
 	for _, section := range commandLine.Sections {
 		p, ok := section.SectionType.(*clpb.CommandLineSection_OptionList)
@@ -142,7 +150,9 @@ func redactStructuredCommandLine(commandLine *clpb.CommandLine, allowedEnvVars [
 			// regex-based stripping.
 			stripRepoURLCredentialsFromCommandLineOption(option)
 			option.OptionValue = stripURLSecrets(option.OptionValue)
-			option.CombinedForm = stripURLSecrets(option.CombinedForm)
+			ck, cv := splitCombinedForm(option.CombinedForm)
+			cv = stripURLSecrets(cv)
+			option.CombinedForm = ck + "=" + cv
 
 			// Redact remote header values
 			if option.OptionName == "remote_header" || option.OptionName == "remote_cache_header" || option.OptionName == "remote_exec_header" || option.OptionName == "bes_header" || option.OptionName == "remote_downloader_header" {

--- a/server/util/redact/redact_test.go
+++ b/server/util/redact/redact_test.go
@@ -141,16 +141,16 @@ func TestRedactMetadata_StructuredCommandLine(t *testing.T) {
 func TestRedactMetadata_OptionsParsed_StripsURLSecrets(t *testing.T) {
 	redactor := redact.NewStreamingRedactor(testenv.GetTestEnv(t))
 	optionsParsed := &bespb.OptionsParsed{
-		CmdLine:         []string{"213wZJyTUyhXkj381312@foo"},
-		ExplicitCmdLine: []string{"213wZJyTUyhXkj381312@explicit"},
+		CmdLine:         []string{"213wZJyTUyhXkj381312@foo", "--flag=@repo//package"},
+		ExplicitCmdLine: []string{"213wZJyTUyhXkj381312@explicit", "--flag=@repo//package"},
 	}
 
 	redactor.RedactMetadata(&bespb.BuildEvent{
 		Payload: &bespb.BuildEvent_OptionsParsed{OptionsParsed: optionsParsed},
 	})
 
-	assert.Equal(t, []string{"foo"}, optionsParsed.CmdLine)
-	assert.Equal(t, []string{"explicit"}, optionsParsed.ExplicitCmdLine)
+	assert.Equal(t, []string{"foo", "--flag=@repo//package"}, optionsParsed.CmdLine)
+	assert.Equal(t, []string{"explicit", "--flag=@repo//package"}, optionsParsed.ExplicitCmdLine)
 }
 
 func TestRedactMetadata_ActionExecuted_StripsURLSecrets(t *testing.T) {

--- a/server/util/redact/redact_test.go
+++ b/server/util/redact/redact_test.go
@@ -108,7 +108,7 @@ func TestRedactMetadata_StructuredCommandLine(t *testing.T) {
 		{"some_url", "https://token@foo.com", "https://foo.com"},
 		{"remote_default_exec_properties", "container-registry-username=SECRET_USERNAME", "container-registry-username=<REDACTED>"},
 		{"remote_default_exec_properties", "container-registry-password=SECRET_PASSWORD", "container-registry-password=<REDACTED>"},
-		{"host_platform", "@buildbuddy_toolchain//:platform", "host_platform=@buildbuddy_toolchain//:platform"},
+		{"host_platform", "@buildbuddy_toolchain//:platform", "@buildbuddy_toolchain//:platform"},
 	} {
 		option := &clpb.Option{
 			OptionName:   testCase.optionName,

--- a/server/util/redact/redact_test.go
+++ b/server/util/redact/redact_test.go
@@ -108,6 +108,7 @@ func TestRedactMetadata_StructuredCommandLine(t *testing.T) {
 		{"some_url", "https://token@foo.com", "https://foo.com"},
 		{"remote_default_exec_properties", "container-registry-username=SECRET_USERNAME", "container-registry-username=<REDACTED>"},
 		{"remote_default_exec_properties", "container-registry-password=SECRET_PASSWORD", "container-registry-password=<REDACTED>"},
+		{"host_platform", "@buildbuddy_toolchain//:platform", "host_platform=@buildbuddy_toolchain//:platform"},
 	} {
 		option := &clpb.Option{
 			OptionName:   testCase.optionName,


### PR DESCRIPTION
The URL secret regex was redacting `--flag_name=@repo//some/package` since it matches `--flag_name=@`. The fix is to split this up into two parts (flag name and flag value), so that the flag value `@repo//some/package` is redacted on its own -- the regex does not match this.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1197
