### PR TITLE
Attempt to auto-relogin when sessions expire

### DIFF
--- a/app/auth/BUILD
+++ b/app/auth/BUILD
@@ -7,7 +7,6 @@ ts_library(
     srcs = ["auth_service.ts"],
     deps = [
         ":user",
-        "//app/alert",
         "//app/capabilities",
         "//app/errors",
         "//app/router",

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -8,12 +8,12 @@ import errorService from "../errors/error_service";
 import { BuildBuddyError } from "../../app/util/errors";
 import router from "../router/router";
 import { User } from "./user";
-import alert_service from "../alert/alert_service";
 
 export { User };
 
 const SELECTED_GROUP_ID_LOCAL_STORAGE_KEY = "selected_group_id";
 const IMPERSONATING_GROUP_ID_SESSION_STORAGE_KEY = "impersonating_group_id";
+const AUTO_LOGIN_ATTEMPTED_STORAGE_KEY = "auto_login_attempted";
 const TOKEN_REFRESH_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 
 export class AuthService {
@@ -35,11 +35,13 @@ export class AuthService {
     let request = new user.GetUserRequest();
     this.getUser(request)
       .then((response: user.GetUserResponse) => {
-        this.emitUser(this.userFromResponse(response));
+        this.handleLoggedIn(response);
       })
       .catch((error: any) => {
         if (BuildBuddyError.parse(error).code == "PermissionDenied" && String(error).includes("logged out")) {
           this.emitUser(null);
+        } else if (BuildBuddyError.parse(error).code == "PermissionDenied" && String(error).includes("session expired")) {
+          this.refreshToken();
         } else if (BuildBuddyError.parse(error).code == "Unauthenticated" || String(error).includes("not found")) {
           this.createUser();
         } else {
@@ -57,16 +59,33 @@ export class AuthService {
       let parsedError = BuildBuddyError.parse(error);
       console.warn(parsedError);
       if (parsedError?.code == "Unauthenticated" || parsedError?.code == "PermissionDenied") {
-        alert_service.warning("Logged out");
-        this.emitUser(null);
+        this.handleTokenRefreshError()
       }
     });
+  }
+
+  handleLoggedIn(response: user.GetUserResponse) {
+    localStorage.removeItem(AUTO_LOGIN_ATTEMPTED_STORAGE_KEY);
+    this.emitUser(this.userFromResponse(response));
+  }
+
+  handleTokenRefreshError() {
+    // If we've already tried to auto-relogin and it didn't work, just log the user out.
+    if (localStorage.getItem(AUTO_LOGIN_ATTEMPTED_STORAGE_KEY)) {
+      this.emitUser(null);
+      return;
+    }
+    // If we haven't tried to auto-relogin already, try it.
+    localStorage.setItem(AUTO_LOGIN_ATTEMPTED_STORAGE_KEY, "true");
+    window.location.href = `/login/?${new URLSearchParams({
+      redirect_url: window.location.href
+    })}`;  
   }
 
   refreshUser() {
     return this.getUser(new user.GetUserRequest())
       .then((response: user.GetUserResponse) => {
-        this.emitUser(this.userFromResponse(response));
+        this.handleLoggedIn(response);
       })
       .catch((error: any) => {
         this.onUserRpcError(error);

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -40,7 +40,10 @@ export class AuthService {
       .catch((error: any) => {
         if (BuildBuddyError.parse(error).code == "PermissionDenied" && String(error).includes("logged out")) {
           this.emitUser(null);
-        } else if (BuildBuddyError.parse(error).code == "PermissionDenied" && String(error).includes("session expired")) {
+        } else if (
+          BuildBuddyError.parse(error).code == "PermissionDenied" &&
+          String(error).includes("session expired")
+        ) {
           this.refreshToken();
         } else if (BuildBuddyError.parse(error).code == "Unauthenticated" || String(error).includes("not found")) {
           this.createUser();
@@ -59,7 +62,7 @@ export class AuthService {
       let parsedError = BuildBuddyError.parse(error);
       console.warn(parsedError);
       if (parsedError?.code == "Unauthenticated" || parsedError?.code == "PermissionDenied") {
-        this.handleTokenRefreshError()
+        this.handleTokenRefreshError();
       }
     });
   }
@@ -78,8 +81,8 @@ export class AuthService {
     // If we haven't tried to auto-relogin already, try it.
     localStorage.setItem(AUTO_LOGIN_ATTEMPTED_STORAGE_KEY, "true");
     window.location.href = `/login/?${new URLSearchParams({
-      redirect_url: window.location.href
-    })}`;  
+      redirect_url: window.location.href,
+    })}`;
   }
 
   refreshUser() {

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -89,14 +89,14 @@ const (
 	apiKeyGroupCacheSize = 10000
 
 	// WARNING: app/auth/auth_service.ts depends on these messages matching.
-	userNotFoundMsg = "User not found"
-	loggedOutMsg    = "User logged out"
+	userNotFoundMsg   = "User not found"
+	loggedOutMsg      = "User logged out"
 	ExpiredSessionMsg = "User session expired"
 )
 
 var (
-	apiKeyRegex                            = regexp.MustCompile(APIKeyHeader + "=([a-zA-Z0-9]*)")
-	jwtKey                                 = []byte("set_the_jwt_in_config") // set via config.
+	apiKeyRegex = regexp.MustCompile(APIKeyHeader + "=([a-zA-Z0-9]*)")
+	jwtKey      = []byte("set_the_jwt_in_config") // set via config.
 )
 
 func jwtKeyFunc(token *jwt.Token) (interface{}, error) {
@@ -543,7 +543,7 @@ func (a *OpenIDAuthenticator) getAuthCodeOptions(r *http.Request) []oauth2.AuthC
 	}
 	sessionID := GetCookie(r, sessionIDCookie)
 	// If a session doesn't already exist, force a consent screen.
-	if (sessionID == "") {
+	if sessionID == "" {
 		options = append(options, oauth2.ApprovalForce)
 	}
 	return options
@@ -795,7 +795,7 @@ func (a *OpenIDAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r 
 	}
 	if err != nil {
 		return AuthContextWithError(ctx, err)
-}
+	}
 	return authContextFromClaims(ctx, claims, err)
 }
 
@@ -977,7 +977,7 @@ func (a *OpenIDAuthenticator) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Redirect to the login provider (and ask for a refresh token).
-	u, err:= auth.authCodeURL(state, a.getAuthCodeOptions(r)...)
+	u, err := auth.authCodeURL(state, a.getAuthCodeOptions(r)...)
 	if err != nil {
 		redirectWithError(w, r, err)
 		return

--- a/enterprise/server/auth/auth_test.go
+++ b/enterprise/server/auth/auth_test.go
@@ -47,8 +47,8 @@ func (f fakeOidcAuthenticator) getSlug() string {
 	return testSlug
 }
 
-func (f fakeOidcAuthenticator) authCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
-	return "https://auth.test"
+func (f fakeOidcAuthenticator) authCodeURL(state string, opts ...oauth2.AuthCodeOption) (string, error) {
+	return "https://auth.test", nil
 }
 
 func (f fakeOidcAuthenticator) exchange(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -80,7 +80,7 @@ func (a *SAMLAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r *h
 	ctx := r.Context()
 	sp, err := a.serviceProviderFromRequest(r)
 	if err == nil {
-		session, err := sp.Session.GetSession(r) 
+		session, err := sp.Session.GetSession(r)
 		if err != nil {
 			return auth.AuthContextWithError(ctx, status.PermissionDeniedErrorf("%s: %s", auth.ExpiredSessionMsg, err.Error()))
 		}

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -94,7 +94,6 @@ func (a *SAMLAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r *h
 	} else if slug := auth.GetCookie(r, slugCookie); slug != "" {
 		return auth.AuthContextWithError(ctx, status.PermissionDeniedErrorf("Error getting service provider for slug %s: %s", slug, err.Error()))
 	}
-
 	return a.fallback.AuthenticatedHTTPContext(w, r)
 }
 

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -91,9 +91,7 @@ func (a *SAMLAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r *h
 			ctx = context.WithValue(ctx, contextSamlSlugKey, a.getSlugFromRequest(r))
 			return ctx
 		}
-	}
-
-	if slug := auth.GetCookie(r, slugCookie); err != nil && slug != "" {
+	} else if slug := auth.GetCookie(r, slugCookie); slug != "" {
 		return auth.AuthContextWithError(ctx, status.PermissionDeniedErrorf("Error getting service provider for slug %s: %s", slug, err.Error()))
 	}
 

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -78,8 +78,7 @@ func (a *SAMLAuthenticator) Login(w http.ResponseWriter, r *http.Request) {
 
 func (a *SAMLAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r *http.Request) context.Context {
 	ctx := r.Context()
-	sp, err := a.serviceProviderFromRequest(r)
-	if err == nil {
+	if sp, err := a.serviceProviderFromRequest(r); err == nil {
 		session, err := sp.Session.GetSession(r)
 		if err != nil {
 			return auth.AuthContextWithError(ctx, status.PermissionDeniedErrorf("%s: %s", auth.ExpiredSessionMsg, err.Error()))

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -53,7 +53,7 @@ func NewSAMLAuthenticator(env environment.Env, fallback interfaces.Authenticator
 }
 
 func (a *SAMLAuthenticator) Login(w http.ResponseWriter, r *http.Request) {
-	slug := r.URL.Query().Get(slugParam)
+	slug := a.getSlugFromRequest(r)
 	if slug == "" {
 		a.fallback.Login(w, r)
 		return
@@ -78,8 +78,12 @@ func (a *SAMLAuthenticator) Login(w http.ResponseWriter, r *http.Request) {
 
 func (a *SAMLAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r *http.Request) context.Context {
 	ctx := r.Context()
-	if sp, err := a.serviceProviderFromRequest(r); err == nil {
-		session, _ := sp.Session.GetSession(r)
+	sp, err := a.serviceProviderFromRequest(r)
+	if err == nil {
+		session, err := sp.Session.GetSession(r) 
+		if err != nil {
+			return auth.AuthContextWithError(ctx, status.PermissionDeniedErrorf("%s: %s", auth.ExpiredSessionMsg, err.Error()))
+		}
 		sa, ok := session.(samlsp.SessionWithAttributes)
 		if ok {
 			ctx = context.WithValue(ctx, contextSamlSessionKey, sa)
@@ -88,6 +92,11 @@ func (a *SAMLAuthenticator) AuthenticatedHTTPContext(w http.ResponseWriter, r *h
 			return ctx
 		}
 	}
+
+	if slug := auth.GetCookie(r, slugCookie); err != nil && slug != "" {
+		return auth.AuthContextWithError(ctx, status.PermissionDeniedErrorf("Error getting service provider for slug %s: %s", slug, err.Error()))
+	}
+
 	return a.fallback.AuthenticatedHTTPContext(w, r)
 }
 
@@ -137,7 +146,8 @@ func (a *SAMLAuthenticator) Auth(w http.ResponseWriter, r *http.Request) {
 	sp, err := a.serviceProviderFromRequest(r)
 	if err != nil {
 		log.Warningf("SAML Auth Failed: %s", err)
-		a.fallback.Auth(w, r)
+		auth.ClearCookie(a.env, w, slugCookie)
+		http.Redirect(w, r, "/?error="+url.QueryEscape(err.Error()), http.StatusTemporaryRedirect)
 		return
 	}
 	// Store slug as a cookie to enable logins directly from the /acs page.


### PR DESCRIPTION
This should greatly reduce the frequency that users with {no refresh token, short-lived refresh tokens, SAML auth} see the login screen. It should now only ever be shown if they manually log out or if access is revoked on the auth provider side.

On the client side: 
 - Attempt to refresh the token if we get a "session expired" error message on the initial page load
 - If token refresh fails, try to auto-relogin once by redirecting to the /login/ page

On the server side:
- Return a "session expired" error message:
  - if we are attempting to refresh the OIDC token, and the refresh fails
  - if the slug cookie is set, but we don't have a valid SAML session
- Only force the OIDC consent screen to be showed if a session ID isn't set (i.e. the user has logged out).
- Fallback to cookies for issuer / slug on the `/login/` page if no url params are set. 
- Plumb through some error message that were previously being swallowed

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
