### PR TITLE
Hide explicit + effective command lines for workflow invocations

### DIFF
--- a/app/invocation/invocation_details_card.tsx
+++ b/app/invocation/invocation_details_card.tsx
@@ -204,47 +204,51 @@ export default class ArtifactsCardComponent extends React.Component {
               </div>
             )}
 
-            <div className="invocation-command-line">
-              <div className="invocation-command-line-title">
-                explicit command line{" "}
-                <Copy
-                  className="copy-icon"
-                  onClick={this.handleCopyClicked.bind(
-                    this,
-                    `bazel ${this.props.model.started?.command} ${
-                      this.props.model.expanded?.id?.pattern?.pattern
-                    } ${this.props.model.optionsParsed?.explicitCmdLine.join(" ")}`
-                  )}
-                />
-              </div>
-              <div className="invocation-section">
-                <code className="wrap">
-                  bazel {this.props.model.started?.command} {this.props.model.expanded?.id?.pattern?.pattern}{" "}
-                  {this.props.model.optionsParsed?.explicitCmdLine.join(" ")}
-                </code>
-              </div>
-            </div>
+            {this.props.model.isBazelInvocation() && (
+              <>
+                <div className="invocation-command-line">
+                  <div className="invocation-command-line-title">
+                    explicit command line{" "}
+                    <Copy
+                      className="copy-icon"
+                      onClick={this.handleCopyClicked.bind(
+                        this,
+                        `bazel ${this.props.model.started?.command} ${
+                          this.props.model.expanded?.id?.pattern?.pattern
+                        } ${this.props.model.optionsParsed?.explicitCmdLine.join(" ")}`
+                      )}
+                    />
+                  </div>
+                  <div className="invocation-section">
+                    <code className="wrap">
+                      bazel {this.props.model.started?.command} {this.props.model.expanded?.id?.pattern?.pattern}{" "}
+                      {this.props.model.optionsParsed?.explicitCmdLine.join(" ")}
+                    </code>
+                  </div>
+                </div>
 
-            <div className="invocation-command-line">
-              <div className="invocation-command-line-title">
-                effective command line{" "}
-                <Copy
-                  className="copy-icon"
-                  onClick={this.handleCopyClicked.bind(
-                    this,
-                    `bazel ${this.props.model.started?.command} ${
-                      this.props.model.expanded?.id?.pattern?.pattern
-                    } ${this.props.model.optionsParsed?.cmdLine.join(" ")}`
-                  )}
-                />
-              </div>
-              <div className="invocation-section">
-                <code className="wrap">
-                  bazel {this.props.model.started?.command} {this.props.model.expanded?.id?.pattern?.pattern}{" "}
-                  {this.props.model.optionsParsed?.cmdLine.join(" ")}
-                </code>
-              </div>
-            </div>
+                <div className="invocation-command-line">
+                  <div className="invocation-command-line-title">
+                    effective command line{" "}
+                    <Copy
+                      className="copy-icon"
+                      onClick={this.handleCopyClicked.bind(
+                        this,
+                        `bazel ${this.props.model.started?.command} ${
+                          this.props.model.expanded?.id?.pattern?.pattern
+                        } ${this.props.model.optionsParsed?.cmdLine.join(" ")}`
+                      )}
+                    />
+                  </div>
+                  <div className="invocation-section">
+                    <code className="wrap">
+                      bazel {this.props.model.started?.command} {this.props.model.expanded?.id?.pattern?.pattern}{" "}
+                      {this.props.model.optionsParsed?.cmdLine.join(" ")}
+                    </code>
+                  </div>
+                </div>
+              </>
+            )}
 
             {this.props.model.structuredCommandLine
               .filter((commandLine) => commandLine.commandLineLabel && commandLine.commandLineLabel.length)


### PR DESCRIPTION
For workflows, these wind up just showing `bazel`.

At some point we might want to show the CI runner command line, but that will require a few BES changes, so for now just hide these.

Review is easier with whitespace diff disabled: https://github.com/buildbuddy-io/buildbuddy/pull/1667/files?diff=split&w=1

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
