### PR TITLE
Refactor flag handling to allow config flags to be explicitly defined in code

### DIFF
--- a/cli/cmd/sidecar/sidecar.go
+++ b/cli/cmd/sidecar/sidecar.go
@@ -179,11 +179,14 @@ func initializeDiskCache(env *real_environment.RealEnv) {
 }
 
 func main() {
-	flag.Parse()
-	configurator, err := config.NewConfigurator("")
+	// Can remove all this configurator stuff once all flags the sidecar uses are
+	// defined outside the configurator.
+	config.RegisterAndParseFlags()
+	configurator, err := config.NewConfiguratorFromData([]byte{})
 	if err != nil {
 		log.Fatalf("Error initializing Configurator: %s", err.Error())
 	}
+	configurator.ReconcileFlagsAndConfig()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"net"
@@ -58,7 +57,6 @@ var (
 	port           = flag.Int("port", 8080, "The port to listen for HTTP traffic on")
 	monitoringPort = flag.Int("monitoring_port", 9090, "The port to listen for monitoring traffic on")
 	gRPCPort       = flag.Int("grpc_port", 1987, "The port to listen for gRPC traffic on")
-	configFile     = flag.String("config_file", "", "The path to a buildbuddy config file")
 	serverType     = flag.String("server_type", "prod-buildbuddy-executor", "The server type to match on health checks")
 )
 
@@ -239,21 +237,9 @@ func main() {
 	// here to allow group-write and others-write permissions.
 	syscall.Umask(0)
 
-	// Parse all flags, once and for all.
-	flag.Parse()
 	rootContext := context.Background()
 
-	configFilePath := *configFile
-	if configFilePath == "" {
-		_, err := os.Stat("/config.yaml")
-		if err == nil {
-			configFilePath = "/config.yaml"
-		} else if !errors.Is(err, os.ErrNotExist) {
-			log.Fatalf("Error loading config file from file: %s", err)
-		}
-	}
-
-	configurator, err := config.NewConfigurator(configFilePath)
+	configurator, err := config.ParseAndReconcileFlagsAndConfig("")
 	if err != nil {
 		log.Fatalf("Error loading config from file: %s", err)
 	}

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -61,7 +61,6 @@ import (
 )
 
 var (
-	configFile = flag.String("config_file", "/config.yaml", "The path to a buildbuddy config file")
 	serverType = flag.String("server_type", "buildbuddy-server", "The server type to match on health checks")
 )
 
@@ -169,11 +168,10 @@ func convertToProdOrDie(ctx context.Context, env *real_environment.RealEnv) {
 }
 
 func main() {
-	flag.Parse()
 	rootContext := context.Background()
 	version.Print()
 
-	configurator, err := config.NewConfigurator(*configFile)
+	configurator, err := config.ParseAndReconcileFlagsAndConfig("")
 	if err != nil {
 		log.Fatalf("Error loading config from file: %s", err)
 	}

--- a/enterprise/server/remote_execution/containers/bare/BUILD
+++ b/enterprise/server/remote_execution/containers/bare/BUILD
@@ -20,6 +20,7 @@ go_test(
         ":bare",
         "//enterprise/server/remote_execution/container",
         "//proto:remote_execution_go_proto",
+        "//server/config",
         "//server/testutil/testfs",
         "@com_github_stretchr_testify//assert",
     ],

--- a/enterprise/server/remote_execution/containers/bare/bare_test.go
+++ b/enterprise/server/remote_execution/containers/bare/bare_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/bare"
+	"github.com/buildbuddy-io/buildbuddy/server/config"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/stretchr/testify/assert"
 
@@ -37,6 +38,7 @@ func makeTempDirWithWorldTxt(t *testing.T) string {
 
 func TestHelloWorldOnBareMetal(t *testing.T) {
 	ctx := context.Background()
+	config.RegisterAndParseFlags()
 	tempDir := makeTempDirWithWorldTxt(t)
 	cmd := &repb.Command{
 		EnvironmentVariables: []*repb.Command_EnvironmentVariable{

--- a/enterprise/server/test/integration/remote_execution/rbetest/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbetest/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//server/build_event_protocol/build_event_handler",
         "//server/build_event_protocol/build_event_server",
         "//server/buildbuddy_server",
+        "//server/config",
         "//server/interfaces",
         "//server/remote_cache/action_cache_server",
         "//server/remote_cache/byte_stream_server",

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -34,6 +34,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_handler"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_server"
 	"github.com/buildbuddy-io/buildbuddy/server/buildbuddy_server"
+	"github.com/buildbuddy-io/buildbuddy/server/config"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/action_cache_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/byte_stream_server"
@@ -127,6 +128,10 @@ func (r *Env) GetContentAddressableStorageClient() repb.ContentAddressableStorag
 
 func (r *Env) GetActionResultStorageClient() repb.ActionCacheClient {
 	return r.buildBuddyServers[rand.Intn(len(r.buildBuddyServers))].acClient
+}
+
+func (r *Env) GetConfigurator() *config.Configurator {
+	return r.testEnv.GetConfigurator()
 }
 
 func (r *Env) uploadInputRoot(ctx context.Context, rootDir string) *repb.Digest {

--- a/enterprise/server/test/integration/workflow/workflow_test.go
+++ b/enterprise/server/test/integration/workflow/workflow_test.go
@@ -63,6 +63,7 @@ func setup(t *testing.T, gp interfaces.GitProvider) (*rbetest.Env, interfaces.Wo
 			env.SetInvocationSearchService(iss)
 		},
 	})
+
 	// Configure executors so that we can run at least one workflow task.
 	// Workflow tasks require 8Gi to schedule, but all of our workflow test cases
 	// typically use far less RAM. To enable this test to run on machines smaller
@@ -80,6 +81,8 @@ func setup(t *testing.T, gp interfaces.GitProvider) (*rbetest.Env, interfaces.Wo
 	// Set events_api_url to point to the test BB app server (this gets
 	// propagated to the CI runner so it knows where to publish build events).
 	flags.Set(t, "app.events_api_url", fmt.Sprintf("grpc://localhost:%d", bbServer.GRPCPort()))
+
+	env.GetConfigurator().ReconcileFlagsAndConfig()
 
 	env.AddExecutors(10)
 	return env, workflowService

--- a/server/cmd/buildbuddy/main.go
+++ b/server/cmd/buildbuddy/main.go
@@ -13,7 +13,6 @@ import (
 )
 
 var (
-	configFile = flag.String("config_file", "/config.yaml", "The path to a buildbuddy config file")
 	serverType = flag.String("server_type", "buildbuddy-server", "The server type to match on health checks")
 )
 
@@ -23,9 +22,8 @@ var (
 // which import from libmain.go.
 
 func main() {
-	flag.Parse()
 	version.Print()
-	configurator, err := config.NewConfigurator(*configFile)
+	configurator, err := config.ParseAndReconcileFlagsAndConfig("")
 	if err != nil {
 		log.Fatalf("Error loading config from file: %s", err)
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -382,10 +382,12 @@ type OrgConfig struct {
 	Domain string `yaml:"domain" usage:"Your organization's email domain. If this is set, only users with email addresses in this domain will be able to register for a BuildBuddy account."`
 }
 
-var sharedGeneralConfig = &generalConfig{}
-var originalStringSlices = make(map[string][]string)
-var defineFlagsOnce sync.Once
-var originalSetFlags = make(map[string]bool)
+var (
+	sharedGeneralConfig = &generalConfig{}
+	originalStringSlices = make(map[string][]string)
+	defineFlagsOnce sync.Once
+	originalSetFlags = make(map[string]bool)
+)
 
 func RegisterAndParseFlags() {
 	defineFlagsOnce.Do(func() {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -390,7 +390,7 @@ var (
 	defineFlagsOnce      sync.Once
 
 	// Set of the flags that were explicitly set on the command line
-	originalSetFlags     = make(map[string]struct{})
+	originalSetFlags = make(map[string]struct{})
 )
 
 func RegisterAndParseFlags() {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -383,10 +383,10 @@ type OrgConfig struct {
 }
 
 var (
-	sharedGeneralConfig = &generalConfig{}
+	sharedGeneralConfig  = &generalConfig{}
 	originalStringSlices = make(map[string][]string)
-	defineFlagsOnce sync.Once
-	originalSetFlags = make(map[string]bool)
+	defineFlagsOnce      sync.Once
+	originalSetFlags     = make(map[string]bool)
 )
 
 func RegisterAndParseFlags() {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -623,7 +623,6 @@ func ParseAndReconcileFlagsAndConfig(configFilePath string) (*Configurator, erro
 		return nil, err
 	}
 	configurator.ReconcileFlagsAndConfig()
-	log.Infof("log_queries: %v", configurator.gc.Database.LogQueries)
 	return configurator, nil
 }
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -550,6 +550,8 @@ func parseConfig(fileBytes []byte, presenceMap map[string]bool) (*generalConfig,
 	if err := yaml.Unmarshal([]byte(expandedFileBytes), gc); err != nil {
 		return nil, fmt.Errorf("Error parsing config file: %s", err)
 	}
+	// The shared config caches the last config parsed from a file so that a call to
+	// `readConfig` with an empty `configFile` can return the cached config.
 	sharedGeneralConfig = gc
 
 	generalConfigMap := make(map[interface{}]interface{})

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -547,20 +547,20 @@ func NewConfiguratorFromData(data []byte) (*Configurator, error) {
 	return sharedConfigurator, nil
 }
 
-func readConfig(fullConfigPath string) (*Configurator, error) {
-	if fullConfigPath == "" {
+func NewConfigurator(configFilePath string) (*Configurator, error) {
+	if configFilePath == "" {
 		return sharedConfigurator, nil
 	}
-	log.Infof("Reading buildbuddy config from '%s'", fullConfigPath)
+	log.Infof("Reading buildbuddy config from '%s'", configFilePath)
 
-	_, err := os.Stat(fullConfigPath)
+	_, err := os.Stat(configFilePath)
 
 	// If the file does not exist then we are SOL.
 	if os.IsNotExist(err) {
-		return nil, fmt.Errorf("Config file %s not found", fullConfigPath)
+		return nil, fmt.Errorf("Config file %s not found", configFilePath)
 	}
 
-	fileBytes, err := os.ReadFile(fullConfigPath)
+	fileBytes, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading config file: %s", err)
 	}
@@ -568,15 +568,11 @@ func readConfig(fullConfigPath string) (*Configurator, error) {
 	return NewConfiguratorFromData(fileBytes)
 }
 
-func NewConfigurator(configFilePath string) (*Configurator, error) {
+func ParseAndReconcileFlagsAndConfig(configFilePath string) (*Configurator, error) {
+	RegisterAndParseFlags()
 	if configFilePath == "" {
 		configFilePath = *configFile
 	}
-	return readConfig(configFilePath)
-}
-
-func ParseAndReconcileFlagsAndConfig(configFilePath string) (*Configurator, error) {
-	RegisterAndParseFlags()
 	configurator, err := NewConfigurator(configFilePath)
 	if err != nil {
 		return nil, err

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -142,7 +142,7 @@ func GetTestEnv(t testing.TB) *TestEnv {
 		t.Fatal(err)
 	}
 	if currentConfigurator == nil {
-		configurator, err := config.NewConfigurator(tmpConfigFile)
+		configurator, err := config.ParseAndReconcileFlagsAndConfig(tmpConfigFile)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server/util/capabilities/capabilities_test.go
+++ b/server/util/capabilities/capabilities_test.go
@@ -63,6 +63,7 @@ func TestIsGranted_AnonymousUsageDisabled_AnonymousUser_False(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	flags.Set(t, "auth.enable_anonymous_usage", "false")
 	anonCtx := context.Background()
+	te.GetConfigurator().ReconcileFlagsAndConfig()
 
 	canWrite, err := capabilities.IsGranted(anonCtx, te, akpb.ApiKey_CACHE_WRITE_CAPABILITY)
 
@@ -74,6 +75,7 @@ func TestIsGranted_AnonymousUsageEnabled_AnonymousUser_True(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	flags.Set(t, "auth.enable_anonymous_usage", "true")
 	anonCtx := context.Background()
+	te.GetConfigurator().ReconcileFlagsAndConfig()
 
 	canWrite, err := capabilities.IsGranted(anonCtx, te, akpb.ApiKey_CACHE_WRITE_CAPABILITY)
 

--- a/server/util/testing/flags/BUILD
+++ b/server/util/testing/flags/BUILD
@@ -2,7 +2,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "flags",
+    testonly = 1,
     srcs = ["flags.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/testing/flags",
     visibility = ["//visibility:public"],
+    deps = ["//server/config"],
 )

--- a/server/util/testing/flags/flags.go
+++ b/server/util/testing/flags/flags.go
@@ -16,14 +16,10 @@ func Set(t testing.TB, name, value string) {
 		t.Fatalf("Undefined flag: %s", name)
 	}
 	original := f.Value.String()
-	originalSetMap := config.GetOriginalSetFlags()
-	_, inOriginalSet := originalSetMap[name]
-	originalSetMap[name] = struct{}{}
 	flag.Set(name, value)
+	wasSet := config.TestOnlySetFlag(name, true)
 	t.Cleanup(func() {
 		flag.Set(name, original)
-		if !inOriginalSet {
-			delete(originalSetMap, name)
-		}
+		config.TestOnlySetFlag(name, wasSet)
 	})
 }

--- a/server/util/testing/flags/flags.go
+++ b/server/util/testing/flags/flags.go
@@ -17,11 +17,13 @@ func Set(t testing.TB, name, value string) {
 	}
 	original := f.Value.String()
 	originalSetMap := config.GetOriginalSetFlags()
-	originalSet := originalSetMap[name]
-	originalSetMap[name] = true
+	_, inOriginalSet := originalSetMap[name]
+	originalSetMap[name] = struct{}{}
 	flag.Set(name, value)
 	t.Cleanup(func() {
 		flag.Set(name, original)
-		originalSetMap[name] = originalSet
+		if !inOriginalSet {
+			delete(originalSetMap, name)
+		}
 	})
 }

--- a/server/util/testing/flags/flags.go
+++ b/server/util/testing/flags/flags.go
@@ -3,18 +3,25 @@ package flags
 import (
 	"flag"
 	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/config"
 )
 
 // Set a flag value and register a cleanup function to restore the flag
 // to its original value after the given test is complete.
 func Set(t testing.TB, name, value string) {
+	config.RegisterAndParseFlags()
 	f := flag.Lookup(name)
 	if f == nil {
 		t.Fatalf("Undefined flag: %s", name)
 	}
 	original := f.Value.String()
+	originalSetMap := config.GetOriginalSetFlags()
+	originalSet := originalSetMap[name]
+	originalSetMap[name] = true
 	flag.Set(name, value)
 	t.Cleanup(func() {
 		flag.Set(name, original)
+		originalSetMap[name] = originalSet
 	})
 }

--- a/server/util/url/url_test.go
+++ b/server/util/url/url_test.go
@@ -12,10 +12,12 @@ import (
 )
 
 func envWithAppURL(t *testing.T, appUrl string) environment.Env {
+	config.RegisterAndParseFlags()
 	c, err := config.NewConfiguratorFromData([]byte(fmt.Sprintf("app:\n  build_buddy_url: %s\n", appUrl)))
 	if err != nil {
 		t.Fatal(err)
 	}
+	c.ReconcileFlagsAndConfig()
 	healthChecker := healthcheck.NewHealthChecker("test")
 	return real_environment.NewRealEnv(c, healthChecker)
 }


### PR DESCRIPTION
- app changes for moving config into flags defined in code
- update tests for change to flag handling

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

`config.go` now registers only missing flags, and thus can no longer register them in its `init` function,
as not all flags can be guaranteed to be defined when config is imported. The code which was pointing
the default FlagSet at the `sharedGeneralConfig` has been repurposed to allow us to define missing flags
or define flags whose values point to a given `generalConfig` for ease of assignment to and from the
default flags. Explicitly defined flags take precedence over explicitly defined config values, which
in turn take precedence over default flag values. On the initial flag parse, the explicitly set flags
are saved so that they may be referenced for that precedence later. The string slices are also saved,
to prevent any future config reconciliation from receiving values contained in a past config. A map
version of the yaml config file is used to distinguish between zero values in the config and absent values
in the config in order to determine the aforementioned precedence.

The `ParseAndReconcileFlagsAndConfig` function is meant to be the new way to get a configurator in most
cases, and it will parse the flags, parse the config file, and use the flag > config > default precedence to
resolve conflicts and render the resulting `Configurator` and the default FlagSet consistent.

The `config_file` flag was moved into `config.go`, since the flag would otherwise need to be parsed before calling `ParseAndReconcileFlagsAndConfig` in order to dereference it to pass it in, complicating the construction of a configurator.

The PR is split into two commits for ease of viewing: first the changes to the production code, and then
the test changes. It was unfortunately not realistic to split across multiple PRs, as the tests would not
pass until all the code changes were complete.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
