### PR TITLE
Firecracker: Add support for hot-swapping workspaces

### DIFF
--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -199,15 +199,16 @@ func main() {
 
 	// The following devices are provided by our firecracker implementation:
 	//
-	// - /dev/vda: The container disk image generated from the docker/OCI image
-	// - /dev/vdb: A "scratch" disk image which is initially empty, and persists
+	// - /dev/vda: The read-only container disk image generated from the docker/OCI image
+	// - /dev/vdb: A read-write "scratch" disk image which is initially empty, and persists
 	//   for the lifetime of the container.
-	// - /dev/vdc: The workspace disk image, which is replaced by the host when
+	// - /dev/vdc: A read-write workspace disk image, which is replaced by the host when
 	//   each action is run.
 	//
 	// We mount the scratch disk as an overlay on top of the container disk, so
 	// that if actions want to write files outside of the workspace directory,
-	// they can do so without modifying the container image.
+	// they can do so, and the container disk image will remain untouched (and
+	// safe for re-use across multiple VMs).
 	//
 	// We additionally mount the action working directory to /workspace within the
 	// chroot.

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -83,6 +83,7 @@ go_test(
         "//server/testutil/testfs",
         "//server/util/disk",
         "//server/util/fileresolver",
+        "//server/util/log",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@go_googleapis//google/bytestream:bytestream_go_proto",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -162,6 +162,7 @@ func openFile(ctx context.Context, env environment.Env, fileName string) (io.Rea
 
 // putFileIntoDir finds "fileName" on the local filesystem, in runfiles, or
 // in the bundle. It then puts that file into destdir (via hardlink or copying)
+// and returns a path to the file in the new location. Files are written in
 // a content-addressable-storage-based location, so when files are updated they
 // will be put into new paths.
 func putFileIntoDir(ctx context.Context, env environment.Env, fileName, destDir string, mode fs.FileMode) (string, error) {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -711,6 +711,9 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 // createWorkspaceImage creates a new ext4 image from the action working dir
 // and returns the chroot-relative path to the created image.
 func (c *FirecrackerContainer) createWorkspaceImage(ctx context.Context, workspacePath string) (string, error) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
 	c.workspaceGeneration++
 	relativePath := fmt.Sprintf("%s.gen_%d.ext4", workspaceFSName, c.workspaceGeneration)
 	hostPath := filepath.Join(c.getChroot(), relativePath)
@@ -729,7 +732,9 @@ func (c *FirecrackerContainer) createWorkspaceImage(ctx context.Context, workspa
 // container, updates the workspace block device to an ext4 image pointed to
 // by chrootRelativeImagePath, and re-mounts the drive.
 func (c *FirecrackerContainer) hotSwapWorkspace(ctx context.Context, execClient vmxpb.ExecClient, chrootRelativeImagePath string) error {
-	log.Infof("Hot-swapping guest workspace drive")
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
 	if _, err := execClient.UnmountWorkspace(ctx, &vmxpb.UnmountWorkspaceRequest{}); err != nil {
 		return status.WrapError(err, "Failed to unmount workspace")
 	}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -91,6 +91,12 @@ const (
 	workspaceFSName  = "workspacefs.ext4"
 	workspaceDriveID = "workspacefs"
 
+	// The scratchfs image name and drive ID.
+	scratchFSName  = "scratchfs.ext4"
+	scratchDriveID = "scratchfs"
+	// TODO(bduffany): Make this configurable
+	scratchDiskSizeBytes = 2e9
+
 	// The containerfs drive ID.
 	containerFSName  = "containerfs.ext4"
 	containerDriveID = "containerfs"
@@ -156,7 +162,6 @@ func openFile(ctx context.Context, env environment.Env, fileName string) (io.Rea
 
 // putFileIntoDir finds "fileName" on the local filesystem, in runfiles, or
 // in the bundle. It then puts that file into destdir (via hardlink or copying)
-// and returns a path to the file in the new location. Files are written in
 // a content-addressable-storage-based location, so when files are updated they
 // will be put into new paths.
 func putFileIntoDir(ctx context.Context, env environment.Env, fileName, destDir string, mode fs.FileMode) (string, error) {
@@ -277,11 +282,13 @@ type FirecrackerContainer struct {
 	id    string // a random GUID, unique per-run of firecracker
 	vmIdx int    // the index of this vm on the host machine
 
-	constants        Constants
-	containerImage   string // the OCI container image. ex "alpine:latest"
-	actionWorkingDir string // the action directory with inputs / outputs
-	workspaceFSPath  string // the path to the workspace ext4 image
-	containerFSPath  string // the path to the container ext4 image
+	constants           Constants
+	containerImage      string // the OCI container image. ex "alpine:latest"
+	actionWorkingDir    string // the action directory with inputs / outputs
+	workspaceFSPath     string // the path to the workspace ext4 image
+	workspaceGeneration int    // the number of times the workspace has been re-mounted into the guest VM
+	scratchFSPath       string // the path fo the scratch ext4 image
+	containerFSPath     string // the path to the container ext4 image
 
 	rmOnce *sync.Once
 	rmErr  error
@@ -544,7 +551,8 @@ func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context, instanceName st
 		KernelImagePath:     kernelImagePath,
 		InitrdImagePath:     initrdImagePath,
 		ContainerFSPath:     filepath.Join(c.getChroot(), containerFSName),
-		WorkspaceFSPath:     filepath.Join(c.getChroot(), workspaceFSName),
+		ScratchFSPath:       filepath.Join(c.getChroot(), scratchFSName),
+		WorkspaceFSPath:     c.workspaceFSPath,
 		ForceSnapshotDigest: d,
 	}
 
@@ -564,7 +572,10 @@ func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context, instanceName st
 	return snapshotDigest, nil
 }
 
-func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOverride, instanceName string, snapshotDigest *repb.Digest) error {
+// LoadSnapshot loads a VM snapshot from the given snapshot digest and resumes
+// the VM. If workspaceDirOverride is set, it will also hot-swap the workspace
+// drive; otherwise, the workspace will be loaded as-is from the snapshot.
+func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOverride string, instanceName string, snapshotDigest *repb.Digest) error {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
@@ -644,18 +655,12 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 		return err
 	}
 
-	workspaceFileInChroot := filepath.Join(c.getChroot(), workspaceFSName)
+	wsImgRelPath := ""
 	if workspaceDirOverride != "" {
-		// Put the filesystem in place
-		workspaceSizeBytes, err := disk.DirSize(workspaceDirOverride)
-		if err != nil {
-			return err
-		}
-		if err := ext4.DirectoryToImage(ctx, workspaceDirOverride, workspaceFileInChroot, workspaceSizeBytes+(c.constants.DiskSlackSpaceMB*1e6)); err != nil {
+		if wsImgRelPath, err = c.createWorkspaceImage(ctx, workspaceDirOverride); err != nil {
 			return err
 		}
 	}
-	c.workspaceFSPath = workspaceFileInChroot
 
 	machine, err := fcclient.NewMachine(vmCtx, cfg, machineOpts...)
 	if err != nil {
@@ -675,13 +680,6 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 	if err := c.machine.LoadSnapshot(ctx, fullMemSnapshotName, vmStateSnapshotName, enableDiffSnapshotsOpt); err != nil {
 		return status.InternalErrorf("error loading snapshot: %s", err)
 	}
-	if workspaceDirOverride != "" {
-		// If the snapshot is being loaded with a different workspaceFS
-		// then handle that now.
-		if err := c.machine.UpdateGuestDrive(ctx, workspaceDriveID, workspaceFSName); err != nil {
-			return status.InternalErrorf("error updating workspace drive attached to snapshot: %s", err)
-		}
-	}
 	if err := c.machine.ResumeVM(ctx); err != nil {
 		return status.InternalErrorf("error resuming VM: %s", err)
 	}
@@ -699,6 +697,49 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 	})
 	if err != nil {
 		return status.WrapError(err, "Failed to initialize firecracker VM exec client")
+	}
+
+	if workspaceDirOverride != "" {
+		// If the snapshot is being loaded with a different workspaceFS
+		// then handle that now.
+		if err := c.hotSwapWorkspace(ctx, execClient, wsImgRelPath); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// createWorkspaceImage creates a new ext4 image from the action working dir
+// and returns the chroot-relative path to the created image.
+func (c *FirecrackerContainer) createWorkspaceImage(ctx context.Context, workspacePath string) (string, error) {
+	c.workspaceGeneration++
+	relativePath := fmt.Sprintf("%s.gen_%d.ext4", workspaceFSName, c.workspaceGeneration)
+	hostPath := filepath.Join(c.getChroot(), relativePath)
+	sizeBytes, err := disk.DirSize(workspacePath)
+	if err != nil {
+		return "", err
+	}
+	if err := ext4.DirectoryToImage(ctx, workspacePath, hostPath, sizeBytes+c.constants.DiskSlackSpaceMB*1e6); err != nil {
+		return "", err
+	}
+	c.workspaceFSPath = hostPath
+	return relativePath, nil
+}
+
+// hotSwapWorkspace unmounts the workspace drive from a running firecracker
+// container, updates the workspace block device to an ext4 image pointed to
+// by chrootRelativeImagePath, and re-mounts the drive.
+func (c *FirecrackerContainer) hotSwapWorkspace(ctx context.Context, execClient vmxpb.ExecClient, chrootRelativeImagePath string) error {
+	log.Infof("Hot-swapping guest workspace drive")
+	if _, err := execClient.UnmountWorkspace(ctx, &vmxpb.UnmountWorkspaceRequest{}); err != nil {
+		return status.WrapError(err, "Failed to unmount workspace")
+	}
+	if err := c.machine.UpdateGuestDrive(ctx, workspaceDriveID, chrootRelativeImagePath); err != nil {
+		return status.InternalErrorf("error updating workspace drive attached to snapshot: %s", err)
+	}
+	if _, err := execClient.MountWorkspace(ctx, &vmxpb.MountWorkspaceRequest{}); err != nil {
+		return status.WrapError(err, "Failed to remount workspace after update")
 	}
 	return nil
 }
@@ -767,7 +808,7 @@ func (c *FirecrackerContainer) getJailerCommand(ctx context.Context) *exec.Cmd {
 	return builder.Build(ctx)
 }
 
-func (c *FirecrackerContainer) getConfig(ctx context.Context, containerFS, workspaceFS string) (*fcclient.Config, error) {
+func (c *FirecrackerContainer) getConfig(ctx context.Context, containerFS, scratchFS, workspaceFS string) (*fcclient.Config, error) {
 	bootArgs := "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules=1 random.trust_cpu=on i8042.noaux=1 tsc=reliable ipv6.disable=1"
 	if c.constants.EnableNetworking {
 		bootArgs += " " + machineIPBootArgs
@@ -795,12 +836,20 @@ func (c *FirecrackerContainer) getConfig(ctx context.Context, containerFS, works
 		InitrdPath:      initrdImagePath,
 		KernelArgs:      bootArgs,
 		ForwardSignals:  make([]os.Signal, 0),
+		// Note: ordering in this list determines the device lettering
+		// (/dev/vda, /dev/vdb, /dev/vdc, ...)
 		Drives: []fcmodels.Drive{
 			fcmodels.Drive{
 				DriveID:      fcclient.String(containerDriveID),
 				PathOnHost:   &containerFS,
 				IsRootDevice: fcclient.Bool(false),
 				IsReadOnly:   fcclient.Bool(true),
+			},
+			fcmodels.Drive{
+				DriveID:      fcclient.String(scratchDriveID),
+				PathOnHost:   &scratchFS,
+				IsRootDevice: fcclient.Bool(false),
+				IsReadOnly:   fcclient.Bool(false),
 			},
 			fcmodels.Drive{
 				DriveID:      fcclient.String(workspaceDriveID),
@@ -1179,6 +1228,11 @@ func (c *FirecrackerContainer) Create(ctx context.Context, actionWorkingDir stri
 	if err != nil {
 		return err
 	}
+	scratchPath := filepath.Join(containerHome, scratchFSName)
+	if err := ext4.MakeEmptyImage(ctx, scratchPath, scratchDiskSizeBytes); err != nil {
+		return err
+	}
+	c.scratchFSPath = scratchPath
 	wsPath := filepath.Join(containerHome, workspaceFSName)
 	if err := ext4.DirectoryToImage(ctx, c.actionWorkingDir, wsPath, workspaceSizeBytes+(c.constants.DiskSlackSpaceMB*1e6)); err != nil {
 		return err
@@ -1186,9 +1240,10 @@ func (c *FirecrackerContainer) Create(ctx context.Context, actionWorkingDir stri
 	c.workspaceFSPath = wsPath
 
 	log.Debugf("c.containerFSPath: %q", c.containerFSPath)
+	log.Debugf("c.scratchFSPath: %q", c.scratchFSPath)
 	log.Debugf("c.workspaceFSPath: %q", c.workspaceFSPath)
 	log.Debugf("getChroot() is %q", c.getChroot())
-	fcCfg, err := c.getConfig(ctx, c.containerFSPath, c.workspaceFSPath)
+	fcCfg, err := c.getConfig(ctx, c.containerFSPath, c.scratchFSPath, c.workspaceFSPath)
 	if err != nil {
 		return err
 	}
@@ -1229,6 +1284,7 @@ func (c *FirecrackerContainer) SendExecRequestToGuest(ctx context.Context, req *
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
+	// TODO(bduffany): Reuse connection from Unpause(), if applicable
 	conn, err := c.dialVMExecServer(ctx)
 	if err != nil {
 		return nil, status.InternalErrorf("Firecracker exec failed: failed to dial VM exec port: %s", err)
@@ -1497,7 +1553,29 @@ func (c *FirecrackerContainer) Unpause(ctx context.Context) error {
 		log.Debugf("Unpause took %s", time.Since(start))
 	}()
 
+	// Don't hot-swap the workspace into the VM since we haven't yet downloaded inputs.
 	return c.LoadSnapshot(ctx, "" /*=workspaceOverride*/, "" /*=instanceName*/, c.pausedSnapshotDigest)
+}
+
+// SyncWorkspace creates a new disk image from the given working directory
+// and hot-swaps the currently mounted workspace drive in the guest.
+//
+// This is intended to be called just before Exec, so that the inputs to
+// the executed action will be made available to the VM.
+func (c *FirecrackerContainer) SyncWorkspace(ctx context.Context) error {
+	// TODO(bduffany): reuse the connection created in Unpause(), if applicable
+	conn, err := c.dialVMExecServer(ctx)
+	if err != nil {
+		return err
+	}
+	execClient := vmxpb.NewExecClient(conn)
+
+	chrootRelativeImagePath, err := c.createWorkspaceImage(ctx, c.actionWorkingDir)
+	if err != nil {
+		return err
+	}
+
+	return c.hotSwapWorkspace(ctx, execClient, chrootRelativeImagePath)
 }
 
 // Wait waits until the underlying VM exits. It returns an error if one is

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -655,13 +655,6 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 		return err
 	}
 
-	wsImgRelPath := ""
-	if workspaceDirOverride != "" {
-		if wsImgRelPath, err = c.createWorkspaceImage(ctx, workspaceDirOverride); err != nil {
-			return err
-		}
-	}
-
 	machine, err := fcclient.NewMachine(vmCtx, cfg, machineOpts...)
 	if err != nil {
 		return status.InternalErrorf("Failed creating machine: %s", err)
@@ -702,6 +695,10 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 	if workspaceDirOverride != "" {
 		// If the snapshot is being loaded with a different workspaceFS
 		// then handle that now.
+		wsImgRelPath, err := c.createWorkspaceImage(ctx, workspaceDirOverride)
+		if err != nil {
+			return err
+		}
 		if err := c.hotSwapWorkspace(ctx, execClient, wsImgRelPath); err != nil {
 			return err
 		}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -736,13 +736,13 @@ func (c *FirecrackerContainer) hotSwapWorkspace(ctx context.Context, execClient 
 	defer span.End()
 
 	if _, err := execClient.UnmountWorkspace(ctx, &vmxpb.UnmountWorkspaceRequest{}); err != nil {
-		return status.WrapError(err, "Failed to unmount workspace")
+		return status.WrapError(err, "failed to unmount workspace")
 	}
 	if err := c.machine.UpdateGuestDrive(ctx, workspaceDriveID, chrootRelativeImagePath); err != nil {
 		return status.InternalErrorf("error updating workspace drive attached to snapshot: %s", err)
 	}
 	if _, err := execClient.MountWorkspace(ctx, &vmxpb.MountWorkspaceRequest{}); err != nil {
-		return status.WrapError(err, "Failed to remount workspace after update")
+		return status.WrapError(err, "failed to remount workspace after update")
 	}
 	return nil
 }

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -31,6 +31,10 @@ type LoadSnapshotOptions struct {
 	InitrdImagePath     string
 	ContainerFSPath     string
 
+	// This field is optional -- a snapshot may have a scratch filesystem
+	// attached or it may have on attached at runtime.
+	ScratchFSPath string
+
 	// This field is optional -- a snapshot may have a filesystem
 	// stored with it or it may have one attached at runtime.
 	WorkspaceFSPath string
@@ -81,6 +85,9 @@ func extractFiles(snapOpts *LoadSnapshotOptions) []string {
 		snapOpts.KernelImagePath,
 		snapOpts.InitrdImagePath,
 		snapOpts.ContainerFSPath,
+	}
+	if snapOpts.ScratchFSPath != "" {
+		files = append(files, snapOpts.ScratchFSPath)
 	}
 	if snapOpts.WorkspaceFSPath != "" {
 		files = append(files, snapOpts.WorkspaceFSPath)

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -32,7 +32,7 @@ type LoadSnapshotOptions struct {
 	ContainerFSPath     string
 
 	// This field is optional -- a snapshot may have a scratch filesystem
-	// attached or it may have on attached at runtime.
+	// attached or it may have one attached at runtime.
 	ScratchFSPath string
 
 	// This field is optional -- a snapshot may have a filesystem

--- a/enterprise/server/vmexec/vmexec.go
+++ b/enterprise/server/vmexec/vmexec.go
@@ -18,11 +18,16 @@ import (
 )
 
 const (
+<<<<<<< HEAD
 	// NOTE: These must match the values in enterprise/server/cmd/goinit/main.go
 
 	// workspaceDevice is the path to the hot-swappable workspace block device.
 	workspaceDevice = "/dev/vdc"
 
+=======
+	// workspaceDevice is the path to the hot-swappable workspace block device.
+	workspaceDevice = "/dev/vdc"
+>>>>>>> Use consts
 	// workspaceMountPath is the path where the hot-swappable workspace block
 	// device is mounted.
 	workspaceMountPath = "/workspace"

--- a/enterprise/server/vmexec/vmexec.go
+++ b/enterprise/server/vmexec/vmexec.go
@@ -18,16 +18,11 @@ import (
 )
 
 const (
-<<<<<<< HEAD
 	// NOTE: These must match the values in enterprise/server/cmd/goinit/main.go
 
 	// workspaceDevice is the path to the hot-swappable workspace block device.
 	workspaceDevice = "/dev/vdc"
 
-=======
-	// workspaceDevice is the path to the hot-swappable workspace block device.
-	workspaceDevice = "/dev/vdc"
->>>>>>> Use consts
 	// workspaceMountPath is the path where the hot-swappable workspace block
 	// device is mounted.
 	workspaceMountPath = "/workspace"


### PR DESCRIPTION
- Split the mounted RW drive into 2 drives: `scratchfs` (persists across container reuse, not hot-swapped for now) and `workspacefs` (hot-swappable)
- Add a `SyncWorkspace` function to allow hot-swapping the workspace device

The `SyncWorkspace` function is not actually called yet because it would wind up doing unnecessary extra work in the hosted bazel case, since hosted bazel actions have no explicit inputs or outputs that they care about. Specifically, we'd unnecessarily nuke the workspace and then re-create an ext4 image with the same contents. Workspaces can be rather large since they can contain an entire git repo, so this would likely slow down hosted bazel too much.

PRs to follow:
* Update the CI runner to write its contents to the scratch disk (at `/root`) instead of the workspace disk.
* Add a config option to specify the `EstimatedFreeDisk` fraction that gets allocated to the scratch disk vs. workspace disk.
* Call `SyncWorkspace` after `DownloadInputs` to get firecracker working for regular bazel actions that want to use runner recycling (specifically, docker-in-firecracker test actions).
* Once that's done, runner-recycling will work for docker-in-firecracker actions, speeding them up significantly since they can reuse the docker image cache from previous tasks and not have to restart the Docker daemon. We'll be able to set `recycle-runner=true` on our Docker workflow actions to make Docker test workflows faster.

Future optimizations to be made:
* Reuse the vmexec client instead of dialing it every time

TODO before submitting:
- [x] Rebuild `initrd.cpio`

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1188
