### PR TITLE
Firecracker: Add vmexec RPCs for mounting/unmounting a workspace

### DIFF
--- a/enterprise/server/vmexec/vmexec.go
+++ b/enterprise/server/vmexec/vmexec.go
@@ -76,6 +76,20 @@ func (x *execServer) Initialize(ctx context.Context, req *vmxpb.InitializeReques
 	return &vmxpb.InitializeResponse{}, nil
 }
 
+func (x *execServer) UnmountWorkspace(ctx context.Context, req *vmxpb.UnmountWorkspaceRequest) (*vmxpb.UnmountWorkspaceResponse, error) {
+	if err := syscall.Unmount("/workspace", 0); err != nil {
+		return nil, status.InternalErrorf("unmount failed: %s", err)
+	}
+	return &vmxpb.UnmountWorkspaceResponse{}, nil
+}
+
+func (x *execServer) MountWorkspace(ctx context.Context, req *vmxpb.MountWorkspaceRequest) (*vmxpb.MountWorkspaceResponse, error) {
+	if err := syscall.Mount("/dev/vdc", "/workspace", "ext4", syscall.MS_RELATIME, ""); err != nil {
+		return nil, err
+	}
+	return &vmxpb.MountWorkspaceResponse{}, nil
+}
+
 func (x *execServer) Exec(ctx context.Context, req *vmxpb.ExecRequest) (*vmxpb.ExecResponse, error) {
 	if len(req.GetArguments()) < 1 {
 		return nil, status.InvalidArgumentError("Arguments not specified")

--- a/proto/vmexec.proto
+++ b/proto/vmexec.proto
@@ -46,9 +46,18 @@ message InitializeResponse {
   // This page intentionally left empty.
 }
 
+message UnmountWorkspaceRequest {}
+message UnmountWorkspaceResponse {}
+
+message MountWorkspaceRequest {}
+message MountWorkspaceResponse {}
+
 // This service is run inside of a VM. It executes commands sent to it over
 // gRPC in the local environment and returns the results.
 service Exec {
   rpc Exec(ExecRequest) returns (ExecResponse);
   rpc Initialize(InitializeRequest) returns (InitializeResponse);
+  rpc UnmountWorkspace(UnmountWorkspaceRequest)
+      returns (UnmountWorkspaceResponse);
+  rpc MountWorkspace(MountWorkspaceRequest) returns (MountWorkspaceResponse);
 }


### PR DESCRIPTION
These will be used for workspace hot-swap support, which is needed to get firecracker working for normal bazel actions that want to use runner recycling.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1188
