### PR TITLE
Remove storage global options for podman

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -137,8 +137,6 @@ func runPodman(ctx context.Context, subCommand string, workDir string, stdin io.
 		"podman",
 		"--events-backend=file",
 		"--cgroup-manager=cgroupfs",
-		"--storage-driver=overlay",
-		"--storage-opt=overlay.mount_program=/usr/bin/fuse-overlayfs",
 		subCommand,
 	}
 


### PR DESCRIPTION
Once we mounted /var/lib/containers, we don't need to use /fuse/overlay
mount program.
