### PR TITLE
Enable network for podman

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -69,7 +69,6 @@ func (c *podmanCommandContainer) Run(ctx context.Context, command *repb.Command,
 		"--name",
 		containerName,
 		"--rm",
-		"--network=none",
 		"--volume",
 		fmt.Sprintf(
 			"%s:%s",


### PR DESCRIPTION
Use the default network mode: bridge for podman

Tested with a sh_test that curl www.google.com
