### PR TITLE
Implement podman lifecycle methods

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -33,5 +33,6 @@ go_test(
         "//server/testutil/testenv",
         "//server/testutil/testfs",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -123,7 +123,7 @@ func (c *podmanCommandContainer) Create(ctx context.Context, workDir string) err
 }
 
 func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, stdin io.Reader, stdout io.Writer) *interfaces.CommandResult {
-	podmanRunArgs := make([]string, 0, len(2*cmd.GetEnvironmentVariables())+len(cmd.Arguments)+1)
+	podmanRunArgs := make([]string, 0, 2*len(cmd.GetEnvironmentVariables())+len(cmd.Arguments)+1)
 	for _, envVar := range cmd.GetEnvironmentVariables() {
 		podmanRunArgs = append(podmanRunArgs, "--env", fmt.Sprintf("%s=%s", envVar.GetName(), envVar.GetValue()))
 	}

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -123,7 +123,7 @@ func (c *podmanCommandContainer) Create(ctx context.Context, workDir string) err
 }
 
 func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, stdin io.Reader, stdout io.Writer) *interfaces.CommandResult {
-	podmanRunArgs := make([]string, 0, len(cmd.GetEnvironmentVariables())+len(cmd.Arguments)+1)
+	podmanRunArgs := make([]string, 0, len(2*cmd.GetEnvironmentVariables())+len(cmd.Arguments)+1)
 	for _, envVar := range cmd.GetEnvironmentVariables() {
 		podmanRunArgs = append(podmanRunArgs, "--env", fmt.Sprintf("%s=%s", envVar.GetName(), envVar.GetValue()))
 	}

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -33,8 +33,9 @@ type podmanCommandContainer struct {
 
 	image     string
 	buildRoot string
-	// workDir is the path to the workspace directory mounted to the container.
-	workDir string
+
+	// name is the container name.
+	name string
 }
 
 func NewPodmanCommandContainer(env environment.Env, imageCacheAuth *container.ImageCacheAuthenticator, image, buildRoot string) container.CommandContainer {
@@ -46,12 +47,34 @@ func NewPodmanCommandContainer(env environment.Env, imageCacheAuth *container.Im
 	}
 }
 
+func (c *podmanCommandContainer) getPodmanRunArgs(workDir string, autoRemove bool) []string {
+	args := []string{
+		"--hostname",
+		"localhost",
+		"--workdir",
+		workDir,
+		"--name",
+		c.name,
+		"--volume",
+		fmt.Sprintf(
+			"%s:%s",
+			filepath.Join(c.buildRoot, filepath.Base(workDir)),
+			workDir,
+		),
+	}
+	if autoRemove {
+		args = append(args, "--rm")
+	}
+	return args
+}
+
 func (c *podmanCommandContainer) Run(ctx context.Context, command *repb.Command, workDir string, creds container.PullCredentials) *interfaces.CommandResult {
 	result := &interfaces.CommandResult{
 		CommandDebugString: fmt.Sprintf("(podman) %s", command.GetArguments()),
 		ExitCode:           commandutil.NoExitCode,
 	}
 	containerName, err := generateContainerName()
+	c.name = containerName
 	if err != nil {
 		result.Error = status.UnavailableErrorf("failed to generate podman container name: %s", err)
 		return result
@@ -61,28 +84,14 @@ func (c *podmanCommandContainer) Run(ctx context.Context, command *repb.Command,
 		return result
 	}
 
-	podmanRunArgs := []string{
-		"--hostname",
-		"localhost",
-		"--workdir",
-		workDir,
-		"--name",
-		containerName,
-		"--rm",
-		"--volume",
-		fmt.Sprintf(
-			"%s:%s",
-			filepath.Join(c.buildRoot, filepath.Base(workDir)),
-			workDir,
-		),
-	}
+	podmanRunArgs := c.getPodmanRunArgs(workDir, true /*=autoRemove*/)
 
 	for _, envVar := range command.GetEnvironmentVariables() {
 		podmanRunArgs = append(podmanRunArgs, "--env", fmt.Sprintf("%s=%s", envVar.GetName(), envVar.GetValue()))
 	}
 	podmanRunArgs = append(podmanRunArgs, c.image)
 	podmanRunArgs = append(podmanRunArgs, command.Arguments...)
-	result = runPodman(ctx, "run", "", nil, nil, podmanRunArgs...)
+	result = runPodman(ctx, "run", nil, nil, podmanRunArgs...)
 	if exitedCleanly := result.ExitCode >= 0; !exitedCleanly {
 		err = killContainerIfRunning(ctx, containerName)
 	}
@@ -93,17 +102,37 @@ func (c *podmanCommandContainer) Run(ctx context.Context, command *repb.Command,
 }
 
 func (c *podmanCommandContainer) Create(ctx context.Context, workDir string) error {
-	c.workDir = workDir
-	return nil
+	containerName, err := generateContainerName()
+	if err != nil {
+		return status.UnavailableErrorf("failed to generate podman container name: %s", err)
+	}
+	c.name = containerName
+
+	podmanRunArgs := c.getPodmanRunArgs(workDir, false /*=autoRemove*/)
+	podmanRunArgs = append(podmanRunArgs, c.image)
+	podmanRunArgs = append(podmanRunArgs, "sleep", "infinity")
+	createResult := runPodman(ctx, "create", nil, nil, podmanRunArgs...)
+	if err = createResult.Error; err != nil {
+		return status.UnavailableErrorf("failed to create container: %s", err)
+	}
+
+	startResult := runPodman(ctx, "start", nil, nil, c.name)
+	return startResult.Error
 }
 
 func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, stdin io.Reader, stdout io.Writer) *interfaces.CommandResult {
-	return runPodman(ctx, "run" /*workDir=*/, "", stdin, stdout, cmd.Arguments...)
+	podmanRunArgs := []string{}
+	for _, envVar := range cmd.GetEnvironmentVariables() {
+		podmanRunArgs = append(podmanRunArgs, "--env", fmt.Sprintf("%s=%s", envVar.GetName(), envVar.GetValue()))
+	}
+	podmanRunArgs = append(podmanRunArgs, c.name)
+	podmanRunArgs = append(podmanRunArgs, cmd.Arguments...)
+	return runPodman(ctx, "exec", stdin, stdout, podmanRunArgs...)
 }
 
 func (c *podmanCommandContainer) IsImageCached(ctx context.Context) (bool, error) {
 	// Try to avoid the `pull` command which results in a network roundtrip.
-	listResult := runPodman(ctx, "images", "", nil, nil, "--filter=reference="+c.image, "--format={{.ID}}")
+	listResult := runPodman(ctx, "images", nil, nil, "--filter=reference="+c.image, "--format={{.ID}}")
 	if listResult.Error != nil {
 		return false, listResult.Error
 	}
@@ -116,31 +145,40 @@ func (c *podmanCommandContainer) IsImageCached(ctx context.Context) (bool, error
 }
 
 func (c *podmanCommandContainer) PullImage(ctx context.Context, creds container.PullCredentials) error {
-	pullResult := runPodman(ctx, "pull", "", nil, nil, c.image)
+	pullResult := runPodman(ctx, "pull", nil, nil, c.image)
 	if pullResult.Error != nil {
 		return pullResult.Error
 	}
 	return nil
 }
-func (c *podmanCommandContainer) Start(ctx context.Context) error   { return nil }
-func (c *podmanCommandContainer) Remove(ctx context.Context) error  { return nil }
-func (c *podmanCommandContainer) Pause(ctx context.Context) error   { return nil }
-func (c *podmanCommandContainer) Unpause(ctx context.Context) error { return nil }
+
+func (c *podmanCommandContainer) Remove(ctx context.Context) error {
+	res := runPodman(ctx, "rm", nil, nil, "--force", c.name)
+	return res.Error
+}
+
+func (c *podmanCommandContainer) Pause(ctx context.Context) error {
+	res := runPodman(ctx, "pause", nil, nil, c.name)
+	return res.Error
+}
+
+func (c *podmanCommandContainer) Unpause(ctx context.Context) error {
+	res := runPodman(ctx, "unpause", nil, nil, c.name)
+	return res.Error
+}
 
 func (c *podmanCommandContainer) Stats(ctx context.Context) (*container.Stats, error) {
 	return &container.Stats{}, nil
 }
 
-func runPodman(ctx context.Context, subCommand string, workDir string, stdin io.Reader, stdout io.Writer, args ...string) *interfaces.CommandResult {
+func runPodman(ctx context.Context, subCommand string, stdin io.Reader, stdout io.Writer, args ...string) *interfaces.CommandResult {
 	command := []string{
 		"podman",
-		"--events-backend=file",
-		"--cgroup-manager=cgroupfs",
 		subCommand,
 	}
 
 	command = append(command, args...)
-	result := commandutil.Run(ctx, &repb.Command{Arguments: command}, workDir, stdin, stdout)
+	result := commandutil.Run(ctx, &repb.Command{Arguments: command}, "" /*=workDir*/, stdin, stdout)
 	return result
 }
 
@@ -156,7 +194,7 @@ func killContainerIfRunning(ctx context.Context, containerName string) error {
 	ctx, cancel := background.ExtendContextForFinalization(ctx, containerFinalizationTimeout)
 	defer cancel()
 
-	result := runPodman(ctx, "kill", "", nil, nil, containerName)
+	result := runPodman(ctx, "kill", nil, nil, containerName)
 	if result.Error != nil {
 		return result.Error
 	}

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -25,6 +25,10 @@ var (
 	containerFinalizationTimeout = 10 * time.Second
 )
 
+const (
+	podmanInternalExitCode = 125
+)
+
 // podmanCommandContainer containerizes a command's execution using a Podman container.
 // between containers.
 type podmanCommandContainer struct {
@@ -47,7 +51,7 @@ func NewPodmanCommandContainer(env environment.Env, imageCacheAuth *container.Im
 	}
 }
 
-func (c *podmanCommandContainer) getPodmanRunArgs(workDir string, autoRemove bool) []string {
+func (c *podmanCommandContainer) getPodmanRunArgs(workDir string) []string {
 	args := []string{
 		"--hostname",
 		"localhost",
@@ -55,15 +59,13 @@ func (c *podmanCommandContainer) getPodmanRunArgs(workDir string, autoRemove boo
 		workDir,
 		"--name",
 		c.name,
+		"--rm",
 		"--volume",
 		fmt.Sprintf(
 			"%s:%s",
 			filepath.Join(c.buildRoot, filepath.Base(workDir)),
 			workDir,
 		),
-	}
-	if autoRemove {
-		args = append(args, "--rm")
 	}
 	return args
 }
@@ -84,7 +86,7 @@ func (c *podmanCommandContainer) Run(ctx context.Context, command *repb.Command,
 		return result
 	}
 
-	podmanRunArgs := c.getPodmanRunArgs(workDir, true /*=autoRemove*/)
+	podmanRunArgs := c.getPodmanRunArgs(workDir)
 
 	for _, envVar := range command.GetEnvironmentVariables() {
 		podmanRunArgs = append(podmanRunArgs, "--env", fmt.Sprintf("%s=%s", envVar.GetName(), envVar.GetValue()))
@@ -108,7 +110,7 @@ func (c *podmanCommandContainer) Create(ctx context.Context, workDir string) err
 	}
 	c.name = containerName
 
-	podmanRunArgs := c.getPodmanRunArgs(workDir, false /*=autoRemove*/)
+	podmanRunArgs := c.getPodmanRunArgs(workDir)
 	podmanRunArgs = append(podmanRunArgs, c.image)
 	podmanRunArgs = append(podmanRunArgs, "sleep", "infinity")
 	createResult := runPodman(ctx, "create", nil, nil, podmanRunArgs...)
@@ -121,7 +123,7 @@ func (c *podmanCommandContainer) Create(ctx context.Context, workDir string) err
 }
 
 func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, stdin io.Reader, stdout io.Writer) *interfaces.CommandResult {
-	podmanRunArgs := []string{}
+	podmanRunArgs := make([]string, 0, len(cmd.GetEnvironmentVariables())+len(cmd.Arguments)+1)
 	for _, envVar := range cmd.GetEnvironmentVariables() {
 		podmanRunArgs = append(podmanRunArgs, "--env", fmt.Sprintf("%s=%s", envVar.GetName(), envVar.GetValue()))
 	}
@@ -132,10 +134,13 @@ func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, st
 
 func (c *podmanCommandContainer) IsImageCached(ctx context.Context) (bool, error) {
 	// Try to avoid the `pull` command which results in a network roundtrip.
-	listResult := runPodman(ctx, "images", nil, nil, "--filter=reference="+c.image, "--format={{.ID}}")
-	if listResult.Error != nil {
+	listResult := runPodman(ctx, "image", nil /*=stdin*/, nil /*=stdout*/, "inspect", "--format={{.ID}}", c.image)
+	if listResult.ExitCode == podmanInternalExitCode {
+		return false, nil
+	} else if listResult.Error != nil {
 		return false, listResult.Error
 	}
+
 	if strings.TrimSpace(string(listResult.Stdout)) != "" {
 		// Found at least one image matching the ref; `docker run` should succeed
 		// without pulling the image.
@@ -145,7 +150,7 @@ func (c *podmanCommandContainer) IsImageCached(ctx context.Context) (bool, error
 }
 
 func (c *podmanCommandContainer) PullImage(ctx context.Context, creds container.PullCredentials) error {
-	pullResult := runPodman(ctx, "pull", nil, nil, c.image)
+	pullResult := runPodman(ctx, "pull", nil /*=stdin*/, nil /*=stdout*/, c.image)
 	if pullResult.Error != nil {
 		return pullResult.Error
 	}
@@ -153,17 +158,17 @@ func (c *podmanCommandContainer) PullImage(ctx context.Context, creds container.
 }
 
 func (c *podmanCommandContainer) Remove(ctx context.Context) error {
-	res := runPodman(ctx, "rm", nil, nil, "--force", c.name)
+	res := runPodman(ctx, "rm", nil /*=stdin*/, nil /*=stdout*/, "--force", c.name)
 	return res.Error
 }
 
 func (c *podmanCommandContainer) Pause(ctx context.Context) error {
-	res := runPodman(ctx, "pause", nil, nil, c.name)
+	res := runPodman(ctx, "pause", nil /*=stdin*/, nil /*=stdout*/, c.name)
 	return res.Error
 }
 
 func (c *podmanCommandContainer) Unpause(ctx context.Context) error {
-	res := runPodman(ctx, "unpause", nil, nil, c.name)
+	res := runPodman(ctx, "unpause", nil /*=stdin*/, nil /*=stdout*/, c.name)
 	return res.Error
 }
 

--- a/enterprise/server/remote_execution/containers/podman/podman_test.go
+++ b/enterprise/server/remote_execution/containers/podman/podman_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
@@ -31,7 +32,7 @@ func makeTempDirWithWorldTxt(t *testing.T) string {
 	return dir
 }
 
-func TestHelloWorld(t *testing.T) {
+func TestRunHelloWorld(t *testing.T) {
 	ctx := context.Background()
 	rootDir := makeTempDirWithWorldTxt(t)
 	cmd := &repb.Command{
@@ -51,9 +52,7 @@ func TestHelloWorld(t *testing.T) {
 	podman := podman.NewPodmanCommandContainer(env, cacheAuth, "docker.io/library/busybox", rootDir)
 	result := podman.Run(ctx, cmd, "/work", container.PullCredentials{})
 
-	if result.Error != nil {
-		t.Fatal(result.Error)
-	}
+	require.NoError(t, result.Error)
 	assert.Regexp(t, "^(/usr)?/bin/podman\\s", result.CommandDebugString, "sanity check: command should be run bare")
 	assert.Equal(t, "Hello world!", string(result.Stdout),
 		"stdout should equal 'Hello world!' ('$GREETING' env var should be replaced with 'Hello', and "+
@@ -61,4 +60,41 @@ func TestHelloWorld(t *testing.T) {
 	)
 	assert.Empty(t, string(result.Stderr), "stderr should be empty")
 	assert.Equal(t, 0, result.ExitCode, "should exit with success")
+}
+
+func TestHelloWorldExec(t *testing.T) {
+	ctx := context.Background()
+	rootDir := makeTempDirWithWorldTxt(t)
+	cmd := &repb.Command{
+		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+			&repb.Command_EnvironmentVariable{Name: "GREETING", Value: "Hello"},
+		},
+		Arguments: []string{"sh", "-c", `printf "$GREETING $(cat world.txt)!"`},
+	}
+	// Need to give enough time to download the Docker image.
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	env := testenv.GetTestEnv(t)
+	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
+	cacheAuth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
+
+	podman := podman.NewPodmanCommandContainer(env, cacheAuth, "docker.io/library/busybox", rootDir)
+
+	err := podman.Create(ctx, "/work")
+	require.NoError(t, err)
+
+	result := podman.Exec(ctx, cmd, nil, nil)
+	assert.NoError(t, result.Error)
+
+	assert.Regexp(t, "^(/usr)?/bin/podman\\s", result.CommandDebugString, "sanity check: command should be run bare")
+	assert.Equal(t, "Hello world!", string(result.Stdout),
+		"stdout should equal 'Hello world!' ('$GREETING' env var should be replaced with 'Hello', and "+
+			"tempfile containing 'world' should be readable.)",
+	)
+	assert.Empty(t, string(result.Stderr), "stderr should be empty")
+	assert.Equal(t, 0, result.ExitCode, "should exit with success")
+
+	err = podman.Remove(ctx)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Also remove two global options "--events-backend=file", "--cgroup-manager=cgroupfs". They are no longer needed in podman 3.4. 