### PR TITLE
Firecracker: Move slack space allocation to scratch disk

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/containeropts.go
+++ b/enterprise/server/remote_execution/containers/firecracker/containeropts.go
@@ -24,10 +24,6 @@ type ContainerOpts struct {
 	// The amount of RAM, in MB, to allocate to this VM.
 	MemSizeMB int64
 
-	// The amount of slack space to allocate to the workspace drive (for writing
-	// action outputs, test temp files, etc.)
-	WorkspaceDiskSlackSpaceMB int64
-
 	// The size of the scratch disk to allocate (for writing files anywhere
 	// outside of the workspace directory, such as /tmp or ~/.cache).
 	ScratchDiskSizeMB int64

--- a/enterprise/server/remote_execution/containers/firecracker/containeropts.go
+++ b/enterprise/server/remote_execution/containers/firecracker/containeropts.go
@@ -24,8 +24,13 @@ type ContainerOpts struct {
 	// The amount of RAM, in MB, to allocate to this VM.
 	MemSizeMB int64
 
-	// The amount of slack space to allocate on disk when the VM is created.
-	DiskSlackSpaceMB int64
+	// The amount of slack space to allocate to the workspace drive (for writing
+	// action outputs, test temp files, etc.)
+	WorkspaceDiskSlackSpaceMB int64
+
+	// The size of the scratch disk to allocate (for writing files anywhere
+	// outside of the workspace directory, such as /tmp or ~/.cache).
+	ScratchDiskSizeMB int64
 
 	// Whether or not to enable networking.
 	EnableNetworking bool

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -90,6 +90,10 @@ const (
 	// The workspacefs image name and drive ID.
 	workspaceFSName  = "workspacefs.ext4"
 	workspaceDriveID = "workspacefs"
+	// workspaceDiskSlackSpaceMB is the amount of additional storage allocated to
+	// the workspace disk for writing action outputs, test tempfiles, etc.
+	// TODO(bduffany): Consider making this configurable
+	workspaceDiskSlackSpaceMB = 2_000 // 2 GB
 
 	// The scratchfs image name and drive ID.
 	scratchFSName  = "scratchfs.ext4"
@@ -271,13 +275,12 @@ func checkIfFilesExist(targetDir string, files ...string) bool {
 // changing this algorithm will invalidate all existing cached snapshots. Be
 // careful!
 type Constants struct {
-	NumCPUs                   int64
-	MemSizeMB                 int64
-	ScratchDiskSizeMB         int64
-	WorkspaceDiskSlackSpaceMB int64
-	EnableNetworking          bool
-	InitDockerd               bool
-	DebugMode                 bool
+	NumCPUs           int64
+	MemSizeMB         int64
+	ScratchDiskSizeMB int64
+	EnableNetworking  bool
+	InitDockerd       bool
+	DebugMode         bool
 }
 
 // FirecrackerContainer executes commands inside of a firecracker VM.
@@ -328,6 +331,7 @@ func (c *FirecrackerContainer) ConfigurationHash() *repb.Digest {
 	params := []string{
 		fmt.Sprintf("cpus=%d", c.constants.NumCPUs),
 		fmt.Sprintf("mb=%d", c.constants.MemSizeMB),
+		fmt.Sprintf("scratch=%d", c.constants.ScratchDiskSizeMB),
 		fmt.Sprintf("net=%t", c.constants.EnableNetworking),
 		fmt.Sprintf("dockerd=%t", c.constants.InitDockerd),
 		fmt.Sprintf("debug=%t", c.constants.DebugMode),
@@ -370,13 +374,12 @@ func NewContainer(env environment.Env, imageCacheAuth *container.ImageCacheAuthe
 
 	c := &FirecrackerContainer{
 		constants: Constants{
-			NumCPUs:                   opts.NumCPUs,
-			MemSizeMB:                 opts.MemSizeMB,
-			ScratchDiskSizeMB:         opts.ScratchDiskSizeMB,
-			WorkspaceDiskSlackSpaceMB: opts.WorkspaceDiskSlackSpaceMB,
-			EnableNetworking:          opts.EnableNetworking,
-			InitDockerd:               opts.InitDockerd,
-			DebugMode:                 opts.DebugMode,
+			NumCPUs:           opts.NumCPUs,
+			MemSizeMB:         opts.MemSizeMB,
+			ScratchDiskSizeMB: opts.ScratchDiskSizeMB,
+			EnableNetworking:  opts.EnableNetworking,
+			InitDockerd:       opts.InitDockerd,
+			DebugMode:         opts.DebugMode,
 		},
 		jailerRoot:         opts.JailerRoot,
 		dockerClient:       opts.DockerClient,
@@ -719,7 +722,7 @@ func (c *FirecrackerContainer) createWorkspaceImage(ctx context.Context, workspa
 	if err != nil {
 		return err
 	}
-	workspaceDiskSizeBytes := ext4.MinDiskImageSizeBytes + workspaceSizeBytes + c.constants.WorkspaceDiskSlackSpaceMB*1e6
+	workspaceDiskSizeBytes := ext4.MinDiskImageSizeBytes + workspaceSizeBytes + workspaceDiskSlackSpaceMB*1e6
 	if err := ext4.DirectoryToImage(ctx, workspacePath, c.workspaceFSPath(), workspaceDiskSizeBytes); err != nil {
 		return err
 	}
@@ -1253,7 +1256,7 @@ func (c *FirecrackerContainer) Create(ctx context.Context, actionWorkingDir stri
 		return err
 	}
 	workspaceFSPath := filepath.Join(c.tempDir, workspaceFSName)
-	workspaceDiskSizeBytes := ext4.MinDiskImageSizeBytes + workspaceSizeBytes + c.constants.WorkspaceDiskSlackSpaceMB*1e6
+	workspaceDiskSizeBytes := ext4.MinDiskImageSizeBytes + workspaceSizeBytes + workspaceDiskSlackSpaceMB*1e6
 	if err := ext4.DirectoryToImage(ctx, c.actionWorkingDir, workspaceFSPath, workspaceDiskSizeBytes); err != nil {
 		return err
 	}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -94,8 +94,9 @@ const (
 	// The scratchfs image name and drive ID.
 	scratchFSName  = "scratchfs.ext4"
 	scratchDriveID = "scratchfs"
-	// TODO(bduffany): Make this configurable
-	scratchDiskSizeBytes = 2e9
+	// minScratchDiskSizeBytes is the minimum size needed for the scratch disk.
+	// This is needed because the init binary needs some space to copy files around.
+	minScratchDiskSizeBytes = 25e6
 
 	// The containerfs drive ID.
 	containerFSName  = "containerfs.ext4"
@@ -270,12 +271,13 @@ func checkIfFilesExist(targetDir string, files ...string) bool {
 // changing this algorithm will invalidate all existing cached snapshots. Be
 // careful!
 type Constants struct {
-	NumCPUs          int64
-	MemSizeMB        int64
-	DiskSlackSpaceMB int64
-	EnableNetworking bool
-	InitDockerd      bool
-	DebugMode        bool
+	NumCPUs                   int64
+	MemSizeMB                 int64
+	ScratchDiskSizeMB         int64
+	WorkspaceDiskSlackSpaceMB int64
+	EnableNetworking          bool
+	InitDockerd               bool
+	DebugMode                 bool
 }
 
 // FirecrackerContainer executes commands inside of a firecracker VM.
@@ -368,12 +370,13 @@ func NewContainer(env environment.Env, imageCacheAuth *container.ImageCacheAuthe
 
 	c := &FirecrackerContainer{
 		constants: Constants{
-			NumCPUs:          opts.NumCPUs,
-			MemSizeMB:        opts.MemSizeMB,
-			DiskSlackSpaceMB: opts.DiskSlackSpaceMB,
-			EnableNetworking: opts.EnableNetworking,
-			InitDockerd:      opts.InitDockerd,
-			DebugMode:        opts.DebugMode,
+			NumCPUs:                   opts.NumCPUs,
+			MemSizeMB:                 opts.MemSizeMB,
+			ScratchDiskSizeMB:         opts.ScratchDiskSizeMB,
+			WorkspaceDiskSlackSpaceMB: opts.WorkspaceDiskSlackSpaceMB,
+			EnableNetworking:          opts.EnableNetworking,
+			InitDockerd:               opts.InitDockerd,
+			DebugMode:                 opts.DebugMode,
 		},
 		jailerRoot:         opts.JailerRoot,
 		dockerClient:       opts.DockerClient,
@@ -712,11 +715,12 @@ func (c *FirecrackerContainer) createWorkspaceImage(ctx context.Context, workspa
 	defer span.End()
 
 	c.workspaceGeneration++
-	sizeBytes, err := disk.DirSize(workspacePath)
+	workspaceSizeBytes, err := disk.DirSize(workspacePath)
 	if err != nil {
 		return err
 	}
-	if err := ext4.DirectoryToImage(ctx, workspacePath, c.workspaceFSPath(), sizeBytes+c.constants.DiskSlackSpaceMB*1e6); err != nil {
+	workspaceDiskSizeBytes := ext4.MinDiskImageSizeBytes + workspaceSizeBytes + c.constants.WorkspaceDiskSlackSpaceMB*1e6
+	if err := ext4.DirectoryToImage(ctx, workspacePath, c.workspaceFSPath(), workspaceDiskSizeBytes); err != nil {
 		return err
 	}
 	return nil
@@ -1244,11 +1248,13 @@ func (c *FirecrackerContainer) Create(ctx context.Context, actionWorkingDir stri
 		return err
 	}
 	scratchFSPath := filepath.Join(c.tempDir, scratchFSName)
+	scratchDiskSizeBytes := ext4.MinDiskImageSizeBytes + minScratchDiskSizeBytes + c.constants.ScratchDiskSizeMB*1e6
 	if err := ext4.MakeEmptyImage(ctx, scratchFSPath, scratchDiskSizeBytes); err != nil {
 		return err
 	}
 	workspaceFSPath := filepath.Join(c.tempDir, workspaceFSName)
-	if err := ext4.DirectoryToImage(ctx, c.actionWorkingDir, workspaceFSPath, workspaceSizeBytes+(c.constants.DiskSlackSpaceMB*1e6)); err != nil {
+	workspaceDiskSizeBytes := ext4.MinDiskImageSizeBytes + workspaceSizeBytes + c.constants.WorkspaceDiskSlackSpaceMB*1e6
+	if err := ext4.DirectoryToImage(ctx, c.actionWorkingDir, workspaceFSPath, workspaceDiskSizeBytes); err != nil {
 		return err
 	}
 	log.Debugf("Scratch and workspace disk images written to %q", c.tempDir)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -135,13 +135,14 @@ func TestFirecrackerRunSimple(t *testing.T) {
 	}
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:         busyboxImage,
-		ActionWorkingDirectory: workDir,
-		NumCPUs:                1,
-		MemSizeMB:              2500,
-		EnableNetworking:       false,
-		DiskSlackSpaceMB:       100,
-		JailerRoot:             tempJailerRoot(t),
+		ContainerImage:            busyboxImage,
+		ActionWorkingDirectory:    workDir,
+		NumCPUs:                   1,
+		MemSizeMB:                 2500,
+		EnableNetworking:          false,
+		ScratchDiskSizeMB:         100,
+		WorkspaceDiskSlackSpaceMB: 100,
+		JailerRoot:                tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	c, err := firecracker.NewContainer(env, auth, opts)
@@ -181,13 +182,14 @@ func TestFirecrackerLifecycle(t *testing.T) {
 	}
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:         busyboxImage,
-		ActionWorkingDirectory: workDir,
-		NumCPUs:                1,
-		MemSizeMB:              2500,
-		EnableNetworking:       false,
-		DiskSlackSpaceMB:       100,
-		JailerRoot:             tempJailerRoot(t),
+		ContainerImage:            busyboxImage,
+		ActionWorkingDirectory:    workDir,
+		NumCPUs:                   1,
+		MemSizeMB:                 2500,
+		EnableNetworking:          false,
+		ScratchDiskSizeMB:         100,
+		WorkspaceDiskSlackSpaceMB: 100,
+		JailerRoot:                tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	c, err := firecracker.NewContainer(env, auth, opts)
@@ -232,13 +234,14 @@ func TestFirecrackerSnapshotAndResume(t *testing.T) {
 		t.Fatal(err)
 	}
 	opts := firecracker.ContainerOpts{
-		ContainerImage:         busyboxImage,
-		ActionWorkingDirectory: workDir,
-		NumCPUs:                1,
-		MemSizeMB:              minMemSizeMB, // small to make snapshotting faster.
-		EnableNetworking:       false,
-		DiskSlackSpaceMB:       100,
-		JailerRoot:             tempJailerRoot(t),
+		ContainerImage:            busyboxImage,
+		ActionWorkingDirectory:    workDir,
+		NumCPUs:                   1,
+		MemSizeMB:                 minMemSizeMB, // small to make snapshotting faster.
+		EnableNetworking:          false,
+		ScratchDiskSizeMB:         100,
+		WorkspaceDiskSlackSpaceMB: 100,
+		JailerRoot:                tempJailerRoot(t),
 	}
 	c, err := firecracker.NewContainer(env, cacheAuth, opts)
 	if err != nil {
@@ -321,13 +324,14 @@ func TestFirecrackerFileMapping(t *testing.T) {
 		CommandDebugString: `(firecracker) [sh -c find -name '*.txt' -exec cp {} {}.out \;]`,
 	}
 	opts := firecracker.ContainerOpts{
-		ContainerImage:         busyboxImage,
-		ActionWorkingDirectory: rootDir,
-		NumCPUs:                1,
-		MemSizeMB:              minMemSizeMB,
-		EnableNetworking:       false,
-		DiskSlackSpaceMB:       100,
-		JailerRoot:             tempJailerRoot(t),
+		ContainerImage:            busyboxImage,
+		ActionWorkingDirectory:    rootDir,
+		NumCPUs:                   1,
+		MemSizeMB:                 minMemSizeMB,
+		EnableNetworking:          false,
+		ScratchDiskSizeMB:         100,
+		WorkspaceDiskSlackSpaceMB: 100,
+		JailerRoot:                tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	c, err := firecracker.NewContainer(env, auth, opts)
@@ -378,15 +382,16 @@ func TestFirecrackerRunStartFromSnapshot(t *testing.T) {
 	}
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:         busyboxImage,
-		ActionWorkingDirectory: workDir,
-		NumCPUs:                1,
-		MemSizeMB:              minMemSizeMB,
-		EnableNetworking:       false,
-		AllowSnapshotStart:     true,
-		DiskSlackSpaceMB:       100,
-		JailerRoot:             tempJailerRoot(t),
-		DebugMode:              true,
+		ContainerImage:            busyboxImage,
+		ActionWorkingDirectory:    workDir,
+		NumCPUs:                   1,
+		MemSizeMB:                 minMemSizeMB,
+		EnableNetworking:          false,
+		AllowSnapshotStart:        true,
+		ScratchDiskSizeMB:         100,
+		WorkspaceDiskSlackSpaceMB: 100,
+		JailerRoot:                tempJailerRoot(t),
+		DebugMode:                 true,
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	c, err := firecracker.NewContainer(env, auth, opts)
@@ -462,13 +467,14 @@ func TestFirecrackerRunWithNetwork(t *testing.T) {
 	cmd := &repb.Command{Arguments: []string{"ping", "-c1", defaultRouteIP}}
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:         busyboxImage,
-		ActionWorkingDirectory: workDir,
-		NumCPUs:                1,
-		MemSizeMB:              2500,
-		EnableNetworking:       true,
-		DiskSlackSpaceMB:       100,
-		JailerRoot:             tempJailerRoot(t),
+		ContainerImage:            busyboxImage,
+		ActionWorkingDirectory:    workDir,
+		NumCPUs:                   1,
+		MemSizeMB:                 2500,
+		EnableNetworking:          true,
+		ScratchDiskSizeMB:         100,
+		WorkspaceDiskSlackSpaceMB: 100,
+		JailerRoot:                tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	c, err := firecracker.NewContainer(env, auth, opts)
@@ -484,6 +490,37 @@ func TestFirecrackerRunWithNetwork(t *testing.T) {
 
 	assert.Equal(t, 0, res.ExitCode)
 	assert.Contains(t, string(res.Stdout), "64 bytes from "+defaultRouteIP)
+}
+
+func TestFirecrackerRunNOPWithZeroDisk(t *testing.T) {
+	ctx := context.Background()
+	env := getTestEnv(ctx, t)
+	rootDir := testfs.MakeTempDir(t)
+	workDir := testfs.MakeDirAll(t, rootDir, "work")
+	cmd := &repb.Command{Arguments: []string{"pwd"}}
+	opts := firecracker.ContainerOpts{
+		ContainerImage:         busyboxImage,
+		ActionWorkingDirectory: workDir,
+		NumCPUs:                1,
+		MemSizeMB:              2500,
+		EnableNetworking:       false,
+		JailerRoot:             tempJailerRoot(t),
+		// Request 0 disk; implementation should ensure the disk is at least as big
+		// as is required to run a NOP command. Otherwise, users might have to
+		// keep on top of our min disk requirements which is not really feasible.
+		ScratchDiskSizeMB:         0,
+		WorkspaceDiskSlackSpaceMB: 0,
+	}
+	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
+	c, err := firecracker.NewContainer(env, auth, opts)
+	require.NoError(t, err)
+
+	// Run will handle the full lifecycle: no need to call Remove() here.
+	res := c.Run(ctx, cmd, opts.ActionWorkingDirectory, container.PullCredentials{})
+	require.NoError(t, res.Error)
+	assert.Equal(t, 0, res.ExitCode)
+	assert.Equal(t, "", string(res.Stderr))
+	assert.Equal(t, "/workspace\n", string(res.Stdout))
 }
 
 func TestFirecrackerRunWithDocker(t *testing.T) {
@@ -513,14 +550,15 @@ func TestFirecrackerRunWithDocker(t *testing.T) {
 	}
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:         imageWithDockerInstalled,
-		ActionWorkingDirectory: workDir,
-		NumCPUs:                1,
-		MemSizeMB:              2500,
-		EnableNetworking:       true,
-		InitDockerd:            true,
-		DiskSlackSpaceMB:       100,
-		JailerRoot:             tempJailerRoot(t),
+		ContainerImage:            imageWithDockerInstalled,
+		ActionWorkingDirectory:    workDir,
+		NumCPUs:                   1,
+		MemSizeMB:                 2500,
+		EnableNetworking:          true,
+		InitDockerd:               true,
+		ScratchDiskSizeMB:         100,
+		WorkspaceDiskSlackSpaceMB: 100,
+		JailerRoot:                tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	c, err := firecracker.NewContainer(env, auth, opts)
@@ -553,12 +591,13 @@ func TestFirecrackerExecWithRecycledWorkspaceWithNewContents(t *testing.T) {
 	})
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:         busyboxImage,
-		ActionWorkingDirectory: workDir,
-		NumCPUs:                1,
-		MemSizeMB:              2500,
-		DiskSlackSpaceMB:       2000,
-		JailerRoot:             tempJailerRoot(t),
+		ContainerImage:            busyboxImage,
+		ActionWorkingDirectory:    workDir,
+		NumCPUs:                   1,
+		MemSizeMB:                 2500,
+		ScratchDiskSizeMB:         2000,
+		WorkspaceDiskSlackSpaceMB: 100,
+		JailerRoot:                tempJailerRoot(t),
 	}
 	c, err := firecracker.NewContainer(env, cacheAuth, opts)
 	require.NoError(t, err)
@@ -641,14 +680,15 @@ func TestFirecrackerExecWithRecycledWorkspaceWithDocker(t *testing.T) {
 	})
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:         imageWithDockerInstalled,
-		ActionWorkingDirectory: workDir,
-		NumCPUs:                1,
-		MemSizeMB:              2500,
-		DiskSlackSpaceMB:       4000, // 4 GB
-		JailerRoot:             tempJailerRoot(t),
-		EnableNetworking:       true,
-		InitDockerd:            true,
+		ContainerImage:            imageWithDockerInstalled,
+		ActionWorkingDirectory:    workDir,
+		NumCPUs:                   1,
+		MemSizeMB:                 2500,
+		ScratchDiskSizeMB:         4000, // 4 GB
+		WorkspaceDiskSlackSpaceMB: 100,
+		JailerRoot:                tempJailerRoot(t),
+		EnableNetworking:          true,
+		InitDockerd:               true,
 	}
 	c, err := firecracker.NewContainer(env, cacheAuth, opts)
 	require.NoError(t, err)
@@ -737,14 +777,15 @@ func TestFirecrackerExecWithDockerFromSnapshot(t *testing.T) {
 	workDir := testfs.MakeDirAll(t, rootDir, "work")
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:         imageWithDockerInstalled,
-		ActionWorkingDirectory: workDir,
-		NumCPUs:                1,
-		MemSizeMB:              2500,
-		InitDockerd:            true,
-		EnableNetworking:       true,
-		DiskSlackSpaceMB:       100,
-		JailerRoot:             tempJailerRoot(t),
+		ContainerImage:            imageWithDockerInstalled,
+		ActionWorkingDirectory:    workDir,
+		NumCPUs:                   1,
+		MemSizeMB:                 2500,
+		InitDockerd:               true,
+		EnableNetworking:          true,
+		ScratchDiskSizeMB:         1000,
+		WorkspaceDiskSlackSpaceMB: 100,
+		JailerRoot:                tempJailerRoot(t),
 	}
 	c, err := firecracker.NewContainer(env, cacheAuth, opts)
 	if err != nil {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -135,14 +135,13 @@ func TestFirecrackerRunSimple(t *testing.T) {
 	}
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:            busyboxImage,
-		ActionWorkingDirectory:    workDir,
-		NumCPUs:                   1,
-		MemSizeMB:                 2500,
-		EnableNetworking:          false,
-		ScratchDiskSizeMB:         100,
-		WorkspaceDiskSlackSpaceMB: 100,
-		JailerRoot:                tempJailerRoot(t),
+		ContainerImage:         busyboxImage,
+		ActionWorkingDirectory: workDir,
+		NumCPUs:                1,
+		MemSizeMB:              2500,
+		EnableNetworking:       false,
+		ScratchDiskSizeMB:      100,
+		JailerRoot:             tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	c, err := firecracker.NewContainer(env, auth, opts)
@@ -182,14 +181,13 @@ func TestFirecrackerLifecycle(t *testing.T) {
 	}
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:            busyboxImage,
-		ActionWorkingDirectory:    workDir,
-		NumCPUs:                   1,
-		MemSizeMB:                 2500,
-		EnableNetworking:          false,
-		ScratchDiskSizeMB:         100,
-		WorkspaceDiskSlackSpaceMB: 100,
-		JailerRoot:                tempJailerRoot(t),
+		ContainerImage:         busyboxImage,
+		ActionWorkingDirectory: workDir,
+		NumCPUs:                1,
+		MemSizeMB:              2500,
+		EnableNetworking:       false,
+		ScratchDiskSizeMB:      100,
+		JailerRoot:             tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	c, err := firecracker.NewContainer(env, auth, opts)
@@ -210,6 +208,7 @@ func TestFirecrackerLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
+		log.Debugf("Cleaning up...")
 		if err := c.Remove(ctx); err != nil {
 			t.Fatal(err)
 		}
@@ -234,14 +233,13 @@ func TestFirecrackerSnapshotAndResume(t *testing.T) {
 		t.Fatal(err)
 	}
 	opts := firecracker.ContainerOpts{
-		ContainerImage:            busyboxImage,
-		ActionWorkingDirectory:    workDir,
-		NumCPUs:                   1,
-		MemSizeMB:                 minMemSizeMB, // small to make snapshotting faster.
-		EnableNetworking:          false,
-		ScratchDiskSizeMB:         100,
-		WorkspaceDiskSlackSpaceMB: 100,
-		JailerRoot:                tempJailerRoot(t),
+		ContainerImage:         busyboxImage,
+		ActionWorkingDirectory: workDir,
+		NumCPUs:                1,
+		MemSizeMB:              minMemSizeMB, // small to make snapshotting faster.
+		EnableNetworking:       false,
+		ScratchDiskSizeMB:      100,
+		JailerRoot:             tempJailerRoot(t),
 	}
 	c, err := firecracker.NewContainer(env, cacheAuth, opts)
 	if err != nil {
@@ -324,14 +322,13 @@ func TestFirecrackerFileMapping(t *testing.T) {
 		CommandDebugString: `(firecracker) [sh -c find -name '*.txt' -exec cp {} {}.out \;]`,
 	}
 	opts := firecracker.ContainerOpts{
-		ContainerImage:            busyboxImage,
-		ActionWorkingDirectory:    rootDir,
-		NumCPUs:                   1,
-		MemSizeMB:                 minMemSizeMB,
-		EnableNetworking:          false,
-		ScratchDiskSizeMB:         100,
-		WorkspaceDiskSlackSpaceMB: 100,
-		JailerRoot:                tempJailerRoot(t),
+		ContainerImage:         busyboxImage,
+		ActionWorkingDirectory: rootDir,
+		NumCPUs:                1,
+		MemSizeMB:              minMemSizeMB,
+		EnableNetworking:       false,
+		ScratchDiskSizeMB:      100,
+		JailerRoot:             tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	c, err := firecracker.NewContainer(env, auth, opts)
@@ -382,16 +379,15 @@ func TestFirecrackerRunStartFromSnapshot(t *testing.T) {
 	}
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:            busyboxImage,
-		ActionWorkingDirectory:    workDir,
-		NumCPUs:                   1,
-		MemSizeMB:                 minMemSizeMB,
-		EnableNetworking:          false,
-		AllowSnapshotStart:        true,
-		ScratchDiskSizeMB:         100,
-		WorkspaceDiskSlackSpaceMB: 100,
-		JailerRoot:                tempJailerRoot(t),
-		DebugMode:                 true,
+		ContainerImage:         busyboxImage,
+		ActionWorkingDirectory: workDir,
+		NumCPUs:                1,
+		MemSizeMB:              minMemSizeMB,
+		EnableNetworking:       false,
+		AllowSnapshotStart:     true,
+		ScratchDiskSizeMB:      100,
+		JailerRoot:             tempJailerRoot(t),
+		DebugMode:              true,
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	c, err := firecracker.NewContainer(env, auth, opts)
@@ -467,14 +463,13 @@ func TestFirecrackerRunWithNetwork(t *testing.T) {
 	cmd := &repb.Command{Arguments: []string{"ping", "-c1", defaultRouteIP}}
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:            busyboxImage,
-		ActionWorkingDirectory:    workDir,
-		NumCPUs:                   1,
-		MemSizeMB:                 2500,
-		EnableNetworking:          true,
-		ScratchDiskSizeMB:         100,
-		WorkspaceDiskSlackSpaceMB: 100,
-		JailerRoot:                tempJailerRoot(t),
+		ContainerImage:         busyboxImage,
+		ActionWorkingDirectory: workDir,
+		NumCPUs:                1,
+		MemSizeMB:              2500,
+		EnableNetworking:       true,
+		ScratchDiskSizeMB:      100,
+		JailerRoot:             tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	c, err := firecracker.NewContainer(env, auth, opts)
@@ -508,8 +503,7 @@ func TestFirecrackerRunNOPWithZeroDisk(t *testing.T) {
 		// Request 0 disk; implementation should ensure the disk is at least as big
 		// as is required to run a NOP command. Otherwise, users might have to
 		// keep on top of our min disk requirements which is not really feasible.
-		ScratchDiskSizeMB:         0,
-		WorkspaceDiskSlackSpaceMB: 0,
+		ScratchDiskSizeMB: 0,
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	c, err := firecracker.NewContainer(env, auth, opts)
@@ -550,15 +544,14 @@ func TestFirecrackerRunWithDocker(t *testing.T) {
 	}
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:            imageWithDockerInstalled,
-		ActionWorkingDirectory:    workDir,
-		NumCPUs:                   1,
-		MemSizeMB:                 2500,
-		EnableNetworking:          true,
-		InitDockerd:               true,
-		ScratchDiskSizeMB:         100,
-		WorkspaceDiskSlackSpaceMB: 100,
-		JailerRoot:                tempJailerRoot(t),
+		ContainerImage:         imageWithDockerInstalled,
+		ActionWorkingDirectory: workDir,
+		NumCPUs:                1,
+		MemSizeMB:              2500,
+		EnableNetworking:       true,
+		InitDockerd:            true,
+		ScratchDiskSizeMB:      100,
+		JailerRoot:             tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	c, err := firecracker.NewContainer(env, auth, opts)
@@ -591,13 +584,12 @@ func TestFirecrackerExecWithRecycledWorkspaceWithNewContents(t *testing.T) {
 	})
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:            busyboxImage,
-		ActionWorkingDirectory:    workDir,
-		NumCPUs:                   1,
-		MemSizeMB:                 2500,
-		ScratchDiskSizeMB:         2000,
-		WorkspaceDiskSlackSpaceMB: 100,
-		JailerRoot:                tempJailerRoot(t),
+		ContainerImage:         busyboxImage,
+		ActionWorkingDirectory: workDir,
+		NumCPUs:                1,
+		MemSizeMB:              2500,
+		ScratchDiskSizeMB:      2000,
+		JailerRoot:             tempJailerRoot(t),
 	}
 	c, err := firecracker.NewContainer(env, cacheAuth, opts)
 	require.NoError(t, err)
@@ -680,15 +672,14 @@ func TestFirecrackerExecWithRecycledWorkspaceWithDocker(t *testing.T) {
 	})
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:            imageWithDockerInstalled,
-		ActionWorkingDirectory:    workDir,
-		NumCPUs:                   1,
-		MemSizeMB:                 2500,
-		ScratchDiskSizeMB:         4000, // 4 GB
-		WorkspaceDiskSlackSpaceMB: 100,
-		JailerRoot:                tempJailerRoot(t),
-		EnableNetworking:          true,
-		InitDockerd:               true,
+		ContainerImage:         imageWithDockerInstalled,
+		ActionWorkingDirectory: workDir,
+		NumCPUs:                1,
+		MemSizeMB:              2500,
+		ScratchDiskSizeMB:      4000, // 4 GB
+		JailerRoot:             tempJailerRoot(t),
+		EnableNetworking:       true,
+		InitDockerd:            true,
 	}
 	c, err := firecracker.NewContainer(env, cacheAuth, opts)
 	require.NoError(t, err)
@@ -777,15 +768,14 @@ func TestFirecrackerExecWithDockerFromSnapshot(t *testing.T) {
 	workDir := testfs.MakeDirAll(t, rootDir, "work")
 
 	opts := firecracker.ContainerOpts{
-		ContainerImage:            imageWithDockerInstalled,
-		ActionWorkingDirectory:    workDir,
-		NumCPUs:                   1,
-		MemSizeMB:                 2500,
-		InitDockerd:               true,
-		EnableNetworking:          true,
-		ScratchDiskSizeMB:         1000,
-		WorkspaceDiskSlackSpaceMB: 100,
-		JailerRoot:                tempJailerRoot(t),
+		ContainerImage:         imageWithDockerInstalled,
+		ActionWorkingDirectory: workDir,
+		NumCPUs:                1,
+		MemSizeMB:              2500,
+		InitDockerd:            true,
+		EnableNetworking:       true,
+		ScratchDiskSizeMB:      1000,
+		JailerRoot:             tempJailerRoot(t),
 	}
 	c, err := firecracker.NewContainer(env, cacheAuth, opts)
 	if err != nil {

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -69,26 +69,12 @@ const (
 	// A BuildBuddy Compute Unit is defined as 1 cpu and 2.5GB of memory.
 	EstimatedComputeUnitsPropertyName = "EstimatedComputeUnits"
 
-	// EstimatedFreeDiskPropertyName specifies how much space beyond the input
-	// files a task requires to be able to function.
-	//
-	// This is required for Firecracker VMs since disks need to be allocated
-	// ahead of time.
+	// EstimatedFreeDiskPropertyName specifies how much "scratch space" beyond the
+	// input files a task requires to be able to function. This is useful for
+	// managed Bazel + Firecracker because for Firecracker we need to decide ahead
+	// of time how big the workspace filesystem is going to be, and managed Bazel
+	// requires a relatively large amount of free space compared to typical actions.
 	EstimatedFreeDiskPropertyName = "EstimatedFreeDiskBytes"
-
-	// VMScratchDiskAllocationPropertyName specifies how much of the estimated
-	// free disk should be allocated to the "scratch" (root) FS within a
-	// firecracker VM. It is specified as a decimal number between 0 and 1,
-	// ex: "0.5".
-	//
-	// For firecracker VMs, there are 2 disks mounted: the "scratch" disk mounted
-	// at "/", and the "workspace" disk mounted at "/workspace", in which the
-	// action inputs are available and outputs are written. This platform property
-	// specifies how much is allocated to the scratch disk.
-	VMScratchDiskAllocationPropertyName = "VMScratchDiskAllocation"
-	// DefaultVMScratchDiskAllocation is the default fraction of estimated
-	// free disk that is allocated to the scratch disk.
-	DefaultVMScratchDiskAllocation = 0.2
 
 	BareContainerType        ContainerType = "none"
 	PodmanContainerType      ContainerType = "podman"
@@ -103,7 +89,6 @@ type Properties struct {
 	Pool                      string
 	EstimatedComputeUnits     int64
 	EstimatedFreeDiskBytes    int64
-	VMScratchDiskAllocation   float64
 	ContainerImage            string
 	ContainerRegistryUsername string
 	ContainerRegistryPassword string
@@ -166,20 +151,12 @@ func ParseProperties(task *repb.ExecutionTask) *Properties {
 		pool = ""
 	}
 
-	vmScratchDiskAllocation := float64Prop(m, VMScratchDiskAllocationPropertyName, DefaultVMScratchDiskAllocation)
-	if vmScratchDiskAllocation < 0 {
-		vmScratchDiskAllocation = 0
-	} else if vmScratchDiskAllocation > 1 {
-		vmScratchDiskAllocation = 1
-	}
-
 	return &Properties{
 		OS:                        strings.ToLower(stringProp(m, operatingSystemPropertyName, defaultOperatingSystemName)),
 		Arch:                      strings.ToLower(stringProp(m, cpuArchitecturePropertyName, defaultCPUArchitecture)),
 		Pool:                      strings.ToLower(pool),
 		EstimatedComputeUnits:     int64Prop(m, EstimatedComputeUnitsPropertyName, 0),
 		EstimatedFreeDiskBytes:    int64Prop(m, EstimatedFreeDiskPropertyName, 0),
-		VMScratchDiskAllocation:   vmScratchDiskAllocation,
 		ContainerImage:            stringProp(m, containerImagePropertyName, ""),
 		ContainerRegistryUsername: stringProp(m, containerRegistryUsernamePropertyName, ""),
 		ContainerRegistryPassword: stringProp(m, containerRegistryPasswordPropertyName, ""),
@@ -381,19 +358,6 @@ func int64Prop(props map[string]string, name string, defaultValue int64) int64 {
 		return defaultValue
 	}
 	return i
-}
-
-func float64Prop(props map[string]string, name string, defaultValue float64) float64 {
-	val := props[strings.ToLower(name)]
-	if val == "" {
-		return defaultValue
-	}
-	f, err := strconv.ParseFloat(val, 64)
-	if err != nil {
-		log.Warningf("Could not parse platform property %q as float64: %s", name, err)
-		return f
-	}
-	return f
 }
 
 func stringListProp(props map[string]string, name string) []string {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -797,22 +797,18 @@ func (p *Pool) newContainer(ctx context.Context, props *platform.Properties, tas
 		ctr = podman.NewPodmanCommandContainer(p.env, p.imageCacheAuth, props.ContainerImage, p.buildRoot, opts)
 	case platform.FirecrackerContainerType:
 		sizeEstimate := tasksize.Estimate(task)
-		totalDiskSizeMB := int64(float64(sizeEstimate.GetEstimatedFreeDiskBytes()) / 1e6)
-		scratchDiskSizeMB := int64(float64(totalDiskSizeMB) * props.VMScratchDiskAllocation)
-		workspaceDiskSlackSpaceMB := totalDiskSizeMB - scratchDiskSizeMB
 		opts := firecracker.ContainerOpts{
-			ContainerImage:            props.ContainerImage,
-			DockerClient:              p.dockerClient,
-			ActionWorkingDirectory:    p.hostBuildRoot(),
-			NumCPUs:                   int64(math.Max(1.0, float64(sizeEstimate.GetEstimatedMilliCpu())/1000)),
-			MemSizeMB:                 int64(math.Max(1.0, float64(sizeEstimate.GetEstimatedMemoryBytes())/1e6)),
-			ScratchDiskSizeMB:         scratchDiskSizeMB,
-			WorkspaceDiskSlackSpaceMB: workspaceDiskSlackSpaceMB,
-			EnableNetworking:          true,
-			InitDockerd:               props.InitDockerd,
-			JailerRoot:                p.buildRoot,
-			AllowSnapshotStart:        false,
-			DebugMode:                 *commandutil.DebugStreamCommandOutputs,
+			ContainerImage:         props.ContainerImage,
+			DockerClient:           p.dockerClient,
+			ActionWorkingDirectory: p.hostBuildRoot(),
+			NumCPUs:                int64(math.Max(1.0, float64(sizeEstimate.GetEstimatedMilliCpu())/1000)),
+			MemSizeMB:              int64(math.Max(1.0, float64(sizeEstimate.GetEstimatedMemoryBytes())/1e6)),
+			ScratchDiskSizeMB:      int64(float64(sizeEstimate.GetEstimatedFreeDiskBytes()) / 1e6),
+			EnableNetworking:       true,
+			InitDockerd:            props.InitDockerd,
+			JailerRoot:             p.buildRoot,
+			AllowSnapshotStart:     false,
+			DebugMode:              *commandutil.DebugStreamCommandOutputs,
 		}
 		c, err := firecracker.NewContainer(p.env, p.imageCacheAuth, opts)
 		if err != nil {

--- a/enterprise/server/util/ext4/ext4.go
+++ b/enterprise/server/util/ext4/ext4.go
@@ -14,6 +14,13 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 )
 
+const (
+	// MinDiskImageSizeBytes is the approximate minimum size needed for an ext4
+	// image. The functions in this package which create disk images will fail
+	// if the provided size is any smaller.
+	MinDiskImageSizeBytes = 220e3
+)
+
 // DirectoryToImage creates an ext4 image of the specified size from inputDir
 // and writes it to outputFile.
 func DirectoryToImage(ctx context.Context, inputDir, outputFile string, sizeBytes int64) error {

--- a/tools/vmstart/vmstart.go
+++ b/tools/vmstart/vmstart.go
@@ -109,16 +109,15 @@ func main() {
 		vmIdx = *forceVMIdx
 	}
 	opts := firecracker.ContainerOpts{
-		ContainerImage:            *image,
-		ActionWorkingDirectory:    emptyActionDir,
-		NumCPUs:                   1,
-		MemSizeMB:                 2500,
-		ScratchDiskSizeMB:         100,
-		WorkspaceDiskSlackSpaceMB: 100,
-		EnableNetworking:          true,
-		DebugMode:                 true,
-		ForceVMIdx:                vmIdx,
-		JailerRoot:                "/tmp/remote_build/",
+		ContainerImage:         *image,
+		ActionWorkingDirectory: emptyActionDir,
+		NumCPUs:                1,
+		MemSizeMB:              2500,
+		ScratchDiskSizeMB:      100,
+		EnableNetworking:       true,
+		DebugMode:              true,
+		ForceVMIdx:             vmIdx,
+		JailerRoot:             "/tmp/remote_build/",
 	}
 
 	var c *firecracker.FirecrackerContainer

--- a/tools/vmstart/vmstart.go
+++ b/tools/vmstart/vmstart.go
@@ -109,15 +109,16 @@ func main() {
 		vmIdx = *forceVMIdx
 	}
 	opts := firecracker.ContainerOpts{
-		ContainerImage:         *image,
-		ActionWorkingDirectory: emptyActionDir,
-		NumCPUs:                1,
-		MemSizeMB:              2500,
-		DiskSlackSpaceMB:       100,
-		EnableNetworking:       true,
-		DebugMode:              true,
-		ForceVMIdx:             vmIdx,
-		JailerRoot:             "/tmp/remote_build/",
+		ContainerImage:            *image,
+		ActionWorkingDirectory:    emptyActionDir,
+		NumCPUs:                   1,
+		MemSizeMB:                 2500,
+		ScratchDiskSizeMB:         100,
+		WorkspaceDiskSlackSpaceMB: 100,
+		EnableNetworking:          true,
+		DebugMode:                 true,
+		ForceVMIdx:                vmIdx,
+		JailerRoot:                "/tmp/remote_build/",
 	}
 
 	var c *firecracker.FirecrackerContainer


### PR DESCRIPTION
Instead of hard-coding the scratch disk size as 2GB, hard-code the workspace size as 2GB and allocate the EstimatedFreeDiskBytes to scratch space instead. This makes sense both for hosted bazel (once we move its working directory to the scratch disk) and for docker-in-firecracker tests (which need most of the disk space for cached image layers).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1188
