### PR TITLE
Firecracker: Move hosted bazel working dir to scratch disk

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -419,6 +419,16 @@ func run() error {
 		ctx = metadata.AppendToOutgoingContext(ctx, auth.APIKeyHeader, ws.buildbuddyAPIKey)
 	}
 
+	// Change the current working directory to respect WORKDIR_OVERRIDE, if set.
+	if wd := os.Getenv("WORKDIR_OVERRIDE"); wd != "" {
+		if err := os.MkdirAll(wd, 0755); err != nil {
+			return status.WrapError(err, "create WORKDIR_OVERRIDE directory")
+		}
+		if err := os.Chdir(wd); err != nil {
+			return err
+		}
+	}
+
 	// Bazel needs a HOME dir; ensure that one is set.
 	if err := ensureHomeDir(); err != nil {
 		return status.WrapError(err, "ensure HOME")

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -151,6 +151,9 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 			{Name: "BUILDBUDDY_API_KEY", Value: apiKey},
 			{Name: "REPO_USER", Value: req.GetGitRepo().GetUsername()},
 			{Name: "REPO_TOKEN", Value: req.GetGitRepo().GetAccessToken()},
+			// Run from the scratch disk, since the workspace disk is hot-swapped
+			// between runs, which may not be very Bazel-friendly.
+			{Name: "WORKDIR_OVERRIDE", Value: "/root/workspace"},
 		},
 		Arguments: args,
 		Platform: &repb.Platform{


### PR DESCRIPTION
Depends on https://github.com/buildbuddy-io/buildbuddy/pull/1680

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1188
