### PR TITLE
Firecracker: Sync workspace after downloading inputs

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1397,7 +1397,7 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 	}
 
 	if c.fsLayout == nil {
-		if err := c.SyncWorkspace(ctx); err != nil {
+		if err := c.syncWorkspace(ctx); err != nil {
 			result.Error = err
 			return result
 		}
@@ -1583,12 +1583,12 @@ func (c *FirecrackerContainer) Unpause(ctx context.Context) error {
 	return c.LoadSnapshot(ctx, "" /*=workspaceOverride*/, "" /*=instanceName*/, c.pausedSnapshotDigest)
 }
 
-// SyncWorkspace creates a new disk image from the given working directory
+// syncWorkspace creates a new disk image from the given working directory
 // and hot-swaps the currently mounted workspace drive in the guest.
 //
 // This is intended to be called just before Exec, so that the inputs to
 // the executed action will be made available to the VM.
-func (c *FirecrackerContainer) SyncWorkspace(ctx context.Context) error {
+func (c *FirecrackerContainer) syncWorkspace(ctx context.Context) error {
 	// TODO(bduffany): reuse the connection created in Unpause(), if applicable
 	conn, err := c.dialVMExecServer(ctx)
 	if err != nil {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -619,8 +619,6 @@ func TestFirecrackerExecWithRecycledWorkspaceWithNewContents(t *testing.T) {
 
 	err = c.Unpause(ctx)
 	require.NoError(t, err)
-	err = c.SyncWorkspace(ctx)
-	require.NoError(t, err)
 
 	res = c.Exec(ctx, &repb.Command{Arguments: []string{"sh", "test2.sh"}}, nil, nil)
 
@@ -640,8 +638,6 @@ func TestFirecrackerExecWithRecycledWorkspaceWithNewContents(t *testing.T) {
 	})
 
 	err = c.Unpause(ctx)
-	require.NoError(t, err)
-	err = c.SyncWorkspace(ctx)
 	require.NoError(t, err)
 
 	res = c.Exec(ctx, &repb.Command{Arguments: []string{"sh", "test3.sh"}}, nil, nil)
@@ -738,8 +734,6 @@ func TestFirecrackerExecWithRecycledWorkspaceWithDocker(t *testing.T) {
 
 	start := time.Now()
 	err = c.Unpause(ctx)
-	require.NoError(t, err)
-	err = c.SyncWorkspace(ctx)
 	require.NoError(t, err)
 
 	res = c.Exec(ctx, &repb.Command{Arguments: []string{"sh", "test2.sh"}}, nil, nil)

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -246,9 +246,12 @@ func (r *CommandRunner) Run(ctx context.Context) *interfaces.CommandResult {
 			return commandutil.ErrorResult(err)
 		}
 		r.state = ready
-		break
 	case ready:
-		break
+		// When re-using a container, need to synchronize workspace contents before
+		// executing.
+		if err := r.syncWorkspace(ctx); err != nil {
+			return commandutil.ErrorResult(err)
+		}
 	case removed:
 		return commandutil.ErrorResult(status.UnavailableErrorf("Not starting new task since executor is shutting down"))
 	default:
@@ -260,6 +263,26 @@ func (r *CommandRunner) Run(ctx context.Context) *interfaces.CommandResult {
 	}
 
 	return r.Container.Exec(ctx, command, nil, nil)
+}
+
+// syncWorkspace synchronizes the action workspace directory to the container.
+// It should be called after downloading inputs and before executing the action.
+//
+// This should only be called when using runner recycling, since the Run() API
+// is responsible for making the workspace available to the container, and
+// inputs have already been downloaded by the time Run() is called.
+//
+// This is also an NOP for configurations in which the runner shares the same
+// view of the workspace as the host, such as the workspace is mounted to a
+// container or made directly accessible to a bare runner.
+func (r *CommandRunner) syncWorkspace(ctx context.Context) error {
+	if r.VFS != nil {
+		return nil
+	}
+	if fc, ok := r.Container.Delegate.(*firecracker.FirecrackerContainer); ok {
+		return fc.SyncWorkspace(ctx)
+	}
+	return nil
 }
 
 // shutdown runs any manual cleanup required to clean up processes before


### PR DESCRIPTION
This allows firecracker actions that deal with inputs/outputs to work properly when using runner recyling.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1188
