### PR TITLE
Add filecache last evicted age metric

### DIFF
--- a/enterprise/server/remote_execution/filecache/BUILD
+++ b/enterprise/server/remote_execution/filecache/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
+        "//server/metrics",
         "//server/util/disk",
         "//server/util/fastcopy",
         "//server/util/log",

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -560,7 +560,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",
 		Name:      "file_cache_last_eviction_age_usec",
-		Help:      "Age of the last entry evicted from the executor's local file cache, in **microseconds**.",
+		Help:      "Age of the last entry evicted from the executor's local file cache (relative to when it was added to the cache), in **microseconds**.",
 	})
 
 	/// ## Blobstore metrics

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -556,6 +556,13 @@ var (
 		Help:      "Total disk usage of pooled command runners, in **bytes**.",
 	})
 
+	FileCacheLastEvictionAgeUsec = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "file_cache_last_eviction_age_usec",
+		Help:      "Age of the last entry evicted from the executor's local file cache, in **microseconds**.",
+	})
+
 	/// ## Blobstore metrics
 	///
 	/// "Blobstore" refers to the backing storage that BuildBuddy uses to


### PR DESCRIPTION
This will help us monitor the health of the filecache as we roll out firecracker, which adds large artifacts to the filecache and depends on the filecache for restoring VMs from snapshot.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1214
