### PR TITLE
Add file cache request count metric

### DIFF
--- a/enterprise/server/remote_execution/filecache/BUILD
+++ b/enterprise/server/remote_execution/filecache/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//server/util/lru",
         "//server/util/status",
         "//server/util/uuid",
+        "@com_github_prometheus_client_golang//prometheus",
     ],
 )
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -103,6 +103,9 @@ const (
 
 	/// PartitionID is the ID of the disk cache partition this event applied to.
 	PartitionID = "partition_id"
+
+	/// Status of the file cache request: `hit` if found in cache, `miss` otherwise.
+	FileCacheRequestStatusLabel = "status"
 )
 
 const (
@@ -554,6 +557,15 @@ var (
 		Subsystem: "remote_execution",
 		Name:      "runner_pool_disk_usage_bytes",
 		Help:      "Total disk usage of pooled command runners, in **bytes**.",
+	})
+
+	FileCacheRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "file_cache_requests",
+		Help:      "Number of local executor file cache requests.",
+	}, []string{
+		FileCacheRequestStatusLabel,
 	})
 
 	FileCacheLastEvictionAgeUsec = promauto.NewGauge(prometheus.GaugeOpts{


### PR DESCRIPTION
This will provide a straightforward way to observe the filecache hit rate.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1214
