### PR TITLE
Ensure incomplete executions are retried

### DIFF
--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -329,7 +329,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, task *repb.E
 	// Exit codes < 0 mean that the command either never started or was killed.
 	// Make sure we return an error in this case.
 	if cmdResult.ExitCode < 0 {
-		cmdResult.Error = incompleteExecutionError(cmdResult.ExitCode, cmdResult.Error)
+		return finishWithErrFn(incompleteExecutionError(cmdResult.ExitCode, cmdResult.Error))
 	}
 
 	ctx, cancel = background.ExtendContextForFinalization(ctx, uploadDeadlineExtension)


### PR DESCRIPTION
**TODO**: This seems to revert #1292 since the condition `cmdResult.Error != nil` is intended to be equivalent to `cmdResult.ExitCode < 0` (if these conditions aren't equal, it is probably a bug). Need to gather more context for that PR and make sure this PR isn't undoing the intended fix.

---

Before, if an execution was incomplete (meaning that it can't be started or it doesn't return an exit code on its own) then we'd report a failing action result. This PR changes the logic to short-circuit and return an error so that the action can be retried.

This partially fixes an issue that workflow actions are not retried when executors restart (#1692 is the other part of the fix). I suspect this also might fix some other issues with actions not being retried when they are killed due to the executor being shut down during a rollout.

Will add tests in a follow-up PR, since a proper test will run the app and executors as subprocesses and send SIGTERM to the executor, which will require building out a bit of test infra.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1183
