### PR TITLE
Add command to test grid query

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -772,17 +772,31 @@ func postMigrateInvocationUUIDForSQLite(db *gorm.DB) error {
 // Manual migration called after auto-migration.
 func PostAutoMigrate(db *gorm.DB) error {
 	indexes := map[string]string{
-		"invocations_trends_query_index":            "(`group_id`, `updated_at_usec`)",
-		"invocations_trends_query_role_index":       "(`group_id`, `role`, `updated_at_usec`)",
-		"invocations_stats_group_id_index":          "(`group_id`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_user_index":              "(`group_id`, `user`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_host_index":              "(`group_id`, `host`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_repo_index":              "(`group_id`, `repo_url`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_branch_index":            "(`group_id`, `branch_name`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_commit_index":            "(`group_id`, `commit_sha`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_role_index":              "(`group_id`, `role`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_test_grid_query_command_index": "(`group_id` (25), `role` (10), `repo_url`, `command` (10), `created_at_usec` DESC)",
+		"invocations_trends_query_index":      "(`group_id`, `updated_at_usec`)",
+		"invocations_trends_query_role_index": "(`group_id`, `role`, `updated_at_usec`)",
+		"invocations_stats_group_id_index":    "(`group_id`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_user_index":        "(`group_id`, `user`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_host_index":        "(`group_id`, `host`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_repo_index":        "(`group_id`, `repo_url`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_branch_index":      "(`group_id`, `branch_name`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_commit_index":      "(`group_id`, `commit_sha`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_role_index":        "(`group_id`, `role`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
 	}
+	prefixIndicesByDialect := map[string]map[string]string{
+		mysqlDialect: map[string]string{
+			"invocations_test_grid_query_command_index": "(`group_id` (25), `role` (10), `repo_url`, `command` (10), `created_at_usec` DESC)",
+		},
+		sqliteDialect: map[string]string{
+			"invocations_test_grid_query_command_index": "(`group_id`, `role`, `repo_url`, `command` , `created_at_usec` DESC)",
+		},
+	}
+	prefixIndexes, ok := prefixIndicesByDialect[db.Dialector.Name()]
+	if ok {
+		for name, cols := range prefixIndexes {
+			indexes[name] = cols
+		}
+	}
+
 	m := db.Migrator()
 	if m.HasTable("Invocations") {
 		for indexName, cols := range indexes {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -637,6 +637,11 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 			return nil
 		})
 	}
+	if db.Migrator().HasIndex("Invocations", "invocations_test_grid_query_index") {
+		postMigrate = append(postMigrate, func() error {
+			return db.Migrator().DropIndex("TargetStatuses", "invocations_test_grid_query_index")
+		})
+	}
 	return postMigrate, nil
 }
 
@@ -767,16 +772,16 @@ func postMigrateInvocationUUIDForSQLite(db *gorm.DB) error {
 // Manual migration called after auto-migration.
 func PostAutoMigrate(db *gorm.DB) error {
 	indexes := map[string]string{
-		"invocations_trends_query_index":      "(`group_id`, `updated_at_usec`)",
-		"invocations_trends_query_role_index": "(`group_id`, `role`, `updated_at_usec`)",
-		"invocations_stats_group_id_index":    "(`group_id`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_user_index":        "(`group_id`, `user`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_host_index":        "(`group_id`, `host`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_repo_index":        "(`group_id`, `repo_url`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_branch_index":      "(`group_id`, `branch_name`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_commit_index":      "(`group_id`, `commit_sha`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_role_index":        "(`group_id`, `role`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_test_grid_query_index":   "(`group_id`, `role`, `repo_url`, `created_at_usec` DESC)",
+		"invocations_trends_query_index":            "(`group_id`, `updated_at_usec`)",
+		"invocations_trends_query_role_index":       "(`group_id`, `role`, `updated_at_usec`)",
+		"invocations_stats_group_id_index":          "(`group_id`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_user_index":              "(`group_id`, `user`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_host_index":              "(`group_id`, `host`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_repo_index":              "(`group_id`, `repo_url`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_branch_index":            "(`group_id`, `branch_name`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_commit_index":            "(`group_id`, `commit_sha`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_stats_role_index":              "(`group_id`, `role`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_test_grid_query_command_index": "(`group_id` (25), `role` (10), `repo_url`, `command` (10), `created_at_usec` DESC)",
 	}
 	m := db.Migrator()
 	if m.HasTable("Invocations") {

--- a/server/target/target.go
+++ b/server/target/target.go
@@ -24,6 +24,7 @@ import (
 const (
 	sqlite3Dialect = "sqlite3"
 	ciRole         = "CI"
+	testCommand    = "test"
 
 	// The number of distinct commits returned in GetTargetResponse.
 	targetPageSize = 20
@@ -280,6 +281,7 @@ func readPaginatedTargets(ctx context.Context, env environment.Env, req *trpb.Ge
 		commitQuery.AddWhereClause("repo_url = ?", repo)
 	}
 	commitQuery.AddWhereClause("role = ?", ciRole)
+	commitQuery.AddWhereClause("command = ?", testCommand)
 	paginationToken, err := NewTokenFromRequest(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add command to the index. 
Need to use prefix indices on VARCHAR(255) 
columns on Mysql, otherwise it returns an error with "Specified key was too long;
max key length is 3072 bytes"
Unfortunately, prefix indexes are not supported on SQLite. Therefore, the index are different based on the dialect. 

Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1212
