### PR TITLE
Don't fail if a valid JWT doesn't contain (optional) at_hash

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -838,12 +838,12 @@ func (a *OpenIDAuthenticator) authenticateUser(w http.ResponseWriter, r *http.Re
 	// If the session is not found, bail.
 	sesh, err := authDB.ReadSession(ctx, sessionID)
 	if err != nil {
-		log.Debugf("Session not found: %s", err.Error())
+		log.Debugf("Session not found: %s", err)
 		return nil, ut, status.PermissionDeniedErrorf("%s: session not found", loggedOutMsg)
 	}
 
 	if err := auth.checkAccessToken(ctx, jwt, sesh.AccessToken); err != nil {
-		log.Debugf("Invalid token: %s", err.Error())
+		log.Debugf("Invalid token: %s", err)
 		return nil, ut, status.PermissionDeniedErrorf("%s: invalid token", loggedOutMsg)
 	}
 

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -838,11 +838,13 @@ func (a *OpenIDAuthenticator) authenticateUser(w http.ResponseWriter, r *http.Re
 	// If the session is not found, bail.
 	sesh, err := authDB.ReadSession(ctx, sessionID)
 	if err != nil {
-		return nil, ut, status.PermissionDeniedErrorf("%s: session not found: %s", loggedOutMsg, err.Error())
+		log.Debugf("Session not found: %s", err.Error())
+		return nil, ut, status.PermissionDeniedErrorf("%s: session not found", loggedOutMsg)
 	}
 
 	if err := auth.checkAccessToken(ctx, jwt, sesh.AccessToken); err != nil {
-		return nil, ut, status.PermissionDeniedErrorf("%s: invalid token: %s", loggedOutMsg, err.Error())
+		log.Debugf("Invalid token: %s", err.Error())
+		return nil, ut, status.PermissionDeniedErrorf("%s: invalid token", loggedOutMsg)
 	}
 
 	// Now try to verify the token again -- this time we check for expiry.


### PR DESCRIPTION
At this point the JWT has already been validated.

We undergo the extra step of making sure the token's at_hash matches - but the at_hash parameter is optional and not set by all auth providers: https://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken

The go-oidc library mentions: "It is the caller's responsibility to ensure that the optional access token hash is present for the ID token before calling this method":
https://github.com/coreos/go-oidc/blob/d42db69c79f2fa664fd4156e939bf27bba0d2f68/oidc/oidc.go#L371

Also improves error logging to help debug situations like these in the future.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
