### PR TITLE
Ensure docker exec commands are retried during executor shut down

### DIFF
--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/auth",
+        "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/containers/firecracker",
         "//enterprise/server/remote_execution/dirtools",


### PR DESCRIPTION
This fixes one of the causes for workflows not being retried when the executor shuts down. Workflow actions go through the `Exec` code path (due to runner recycling), and the `ContainerExecInspect` API returns a clean exit code (137) when killed as part of `Remove()`, which is called when the executor shuts down.

The fix is to translate this exit condition to `ErrSIGKILL` and explicitly retry `ErrSIGKILL` errors.

Future work: look into ensuring that all commands are retried whenever they receive SIGKILL (due to OOM), as well as ensure that the `Run()` codepath is well-behaved as well.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1183
