### PR TITLE
Fix broken github commit URL

### DIFF
--- a/app/invocation/invocation_details_card.tsx
+++ b/app/invocation/invocation_details_card.tsx
@@ -162,7 +162,10 @@ export default class ArtifactsCardComponent extends React.Component {
               <div className="invocation-section">
                 <div className="invocation-section-title">GitHub commit</div>
                 <div>
-                  <a href={`${this.props.model.getGithubRepo()}/commit/${this.props.model.getGithubSHA()}`}>
+                  <a
+                    href={`${this.props.model
+                      .getGithubRepo()
+                      .replace(/\.git$/, "")}/commit/${this.props.model.getGithubSHA()}`}>
                     {this.props.model.getGithubSHA()}
                   </a>
                 </div>


### PR DESCRIPTION
Before, this would link to something like:
[https://github.com/buildbuddy-io/buildbuddy.git/commit/6c69b8c55cbd6ff2518c877611d2c993f236c444](https://github.com/buildbuddy-io/buildbuddy.git/commit/6c69b8c55cbd6ff2518c877611d2c993f236c444)

This link doesn't work -- stripping the `.git` suffix fixes it:

https://github.com/buildbuddy-io/buildbuddy/commit/6c69b8c55cbd6ff2518c877611d2c993f236c444


---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
