### PR TITLE
Lower internal jwt lifespan from 24h=>6h and always use that

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -81,7 +81,7 @@ const (
 	loginCookieDuration = 365 * 24 * time.Hour
 
 	// BuildBuddy JWT duration maximum.
-	defaultBuildBuddyJWTDuration = 24 * time.Hour
+	defaultBuildBuddyJWTDuration = 6 * time.Hour
 
 	// Maximum amount of time we will cache Group information for an API key.
 	defaultAPIKeyGroupCacheTTL = 5 * time.Minute
@@ -159,10 +159,6 @@ func (c *Claims) GetUseGroupOwnedExecutors() bool {
 
 func assembleJWT(ctx context.Context, claims *Claims) (string, error) {
 	expirationTime := time.Now().Add(defaultBuildBuddyJWTDuration)
-	deadline, ok := ctx.Deadline()
-	if ok {
-		expirationTime = deadline
-	}
 	claims.StandardClaims = jwt.StandardClaims{ExpiresAt: expirationTime.Unix()}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	tokenString, err := token.SignedString(jwtKey)


### PR DESCRIPTION
Should decouple max execution duration from --remote_timeout when using --experimental_remote_execution_keepalive

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
