### PR TITLE
Retry failed workflow invocation streams

### DIFF
--- a/enterprise/server/build_event_publisher/BUILD
+++ b/enterprise/server/build_event_publisher/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//proto:publish_build_event_go_proto",
         "//server/util/grpc_client",
         "//server/util/log",
+        "//server/util/retry",
         "//server/util/status",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_google_uuid//:uuid",

--- a/enterprise/server/build_event_publisher/build_event_publisher.go
+++ b/enterprise/server/build_event_publisher/build_event_publisher.go
@@ -210,10 +210,15 @@ func (b *EventBuffer) Subscribe() (<-chan *pepb.OrderedBuildEvent, func()) {
 			// Send all events which haven't been sent yet
 			for i < len(buffer) {
 				buildEvent := buffer[i]
-				events <- &pepb.OrderedBuildEvent{
+				obe := &pepb.OrderedBuildEvent{
 					StreamId:       b.streamID,
 					SequenceNumber: int64(i) + 1,
 					Event:          buildEvent,
+				}
+				select {
+				case <-cancel:
+					return
+				case events <- obe:
 				}
 				if _, ok := buildEvent.Event.(*bepb.BuildEvent_ComponentStreamFinished); ok {
 					return

--- a/enterprise/server/build_event_publisher/build_event_publisher.go
+++ b/enterprise/server/build_event_publisher/build_event_publisher.go
@@ -119,18 +119,12 @@ func (p *Publisher) run(ctx context.Context) error {
 		if err := stream.Send(req); err != nil {
 			return status.UnavailableErrorf("send failed: %s", err)
 		}
-		_, finished := obe.Event.Event.(*bepb.BuildEvent_ComponentStreamFinished)
-		if !finished {
-			continue
-		}
-		// After successfully transmitting all events, close our side of the stream
-		// and wait for server ACKs before closing the connection.
-		if err := stream.CloseSend(); err != nil {
-			return status.UnavailableErrorf("close send failed: %s", err)
-		}
-		break
 	}
-
+	// After successfully transmitting all events, close our side of the stream
+	// and wait for server ACKs before closing the connection.
+	if err := stream.CloseSend(); err != nil {
+		return status.UnavailableErrorf("close send failed: %s", err)
+	}
 	// Return any error from receiving ACKs
 	return <-doneReceiving
 }

--- a/enterprise/server/build_event_publisher/build_event_publisher.go
+++ b/enterprise/server/build_event_publisher/build_event_publisher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/auth"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/retry"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/uuid"
@@ -19,16 +20,21 @@ import (
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 )
 
-// buildEventPublisher publishes Bazel build events for a single build event stream.
+const (
+	// numStreamRetries is the max number of retries to allow for publishing
+	// a build event stream.
+	numStreamRetries = 5
+)
+
+// Publisher publishes Bazel build events for a single build event stream.
+// It retries the stream if it gets disconnected.
 type Publisher struct {
 	streamID   *bepb.StreamId
 	apiKey     string
 	besBackend string
 
-	mu     sync.Mutex // PROTECTS(err, events)
-	err    error
-	events chan *bespb.BuildEvent
-	done   chan struct{}
+	events *EventBuffer
+	done   chan error
 }
 
 func New(besBackend, apiKey, invocationID string) (*Publisher, error) {
@@ -43,43 +49,42 @@ func New(besBackend, apiKey, invocationID string) (*Publisher, error) {
 		},
 		apiKey:     apiKey,
 		besBackend: besBackend,
-
-		// We probably won't ever saturate this buffer since we only need to
-		// publish a few events for the actions themselves and progress events
-		// are rate-limited. Also, events are sent to the server with low
-		// latency compared to the rate limiting interval.
-		events: make(chan *bespb.BuildEvent, 256),
-		done:   make(chan struct{}, 1),
+		events:     NewEventBuffer(),
+		done:       make(chan error, 1),
 	}, nil
-}
-
-func (p *Publisher) getError() error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.err
-}
-
-func (p *Publisher) setError(err error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.err = err
 }
 
 // Start the event publishing loop in the background. Stops handling new events
 // as soon as the first call to `Wait()` occurs.
 func (p *Publisher) Start(ctx context.Context) {
-	go p.run(ctx)
+	go func() {
+		defer close(p.done)
+		r := retry.New(ctx, &retry.Options{
+			MaxRetries:     numStreamRetries,
+			InitialBackoff: 300 * time.Millisecond,
+			MaxBackoff:     1 * time.Second,
+			Multiplier:     2,
+		})
+		var err error
+		for r.Next() {
+			if err != nil {
+				log.Debugf("Retrying build event stream due to error: %s", err)
+			}
+			err = p.run(ctx)
+			if err == nil {
+				return
+			}
+		}
+		p.done <- err
+	}()
 }
 
-func (p *Publisher) run(ctx context.Context) {
-	defer func() {
-		p.done <- struct{}{}
-	}()
-
+// run performs a single attempt to stream any currently buffered events
+// as well as all subsequently published events to the BES backend.
+func (p *Publisher) run(ctx context.Context) error {
 	conn, err := grpc_client.DialTarget(p.besBackend)
 	if err != nil {
-		p.setError(status.WrapError(err, "error dialing bes_backend"))
-		return
+		return status.WrapError(err, "error dialing bes_backend")
 	}
 	defer conn.Close()
 	besClient := pepb.NewPublishBuildEventClient(conn)
@@ -88,98 +93,133 @@ func (p *Publisher) run(ctx context.Context) {
 	}
 	stream, err := besClient.PublishBuildToolEventStream(ctx)
 	if err != nil {
-		p.setError(status.WrapError(err, "error opening build event stream"))
-		return
+		return status.WrapError(err, "error dialing bes_backend")
 	}
 
-	doneReceiving := make(chan struct{}, 1)
+	doneReceiving := make(chan error, 1)
 	go func() {
+		defer close(doneReceiving)
 		for {
 			_, err := stream.Recv()
 			if err == nil {
 				continue
 			}
 			if err == io.EOF {
-				log.Debug("Received all acks from server.")
-			} else {
-				log.Errorf("Error receiving acks from the server: %s", err)
-				p.setError(err)
+				return
 			}
-			doneReceiving <- struct{}{}
+			doneReceiving <- status.UnavailableErrorf("recv failed: %s", err)
 			return
 		}
 	}()
 
-	for seqNo := int64(1); ; seqNo++ {
-		event := <-p.events
-		if event == nil {
-			// Wait() was called, meaning no more events to publish.
-			// Send ComponentStreamFinished event before closing the stream.
-			start := time.Now()
-			err = stream.Send(&pepb.PublishBuildToolEventStreamRequest{
+	i := int64(0)
+	finished := false
+	for {
+		buffer := p.events.Get()
+		// Send all events which haven't been sent yet
+		for i < int64(len(buffer)) {
+			event := buffer[i]
+			req := &pepb.PublishBuildToolEventStreamRequest{
 				OrderedBuildEvent: &pepb.OrderedBuildEvent{
 					StreamId:       p.streamID,
-					SequenceNumber: seqNo,
-					Event: &bepb.BuildEvent{
-						EventTime: ptypes.TimestampNow(),
-						Event: &bepb.BuildEvent_ComponentStreamFinished{ComponentStreamFinished: &bepb.BuildEvent_BuildComponentStreamFinished{
-							Type: bepb.BuildEvent_BuildComponentStreamFinished_FINISHED,
-						}},
-					},
+					SequenceNumber: i + 1,
+					Event:          event,
 				},
-			})
-			log.Debugf("BEP: published FINISHED event (#%d) in %s", seqNo, time.Since(start))
-
-			if err != nil {
-				p.setError(err)
-				return
 			}
+			i++
+			if err := stream.Send(req); err != nil {
+				return status.UnavailableErrorf("send failed: %s", err)
+			}
+			// After successfully transmitting all events, close our side of the stream
+			// and wait for server ACKs before closing the connection.
+			if _, ok := event.Event.(*bepb.BuildEvent_ComponentStreamFinished); ok {
+				if err := stream.CloseSend(); err != nil {
+					return status.UnavailableErrorf("close send failed: %s", err)
+				}
+				finished = true
+			}
+		}
+		if finished {
 			break
 		}
+		// Wait until another event has been added to the buffer since we called
+		// Get(), then rinse and repeat.
+		p.events.Wait()
+	}
 
-		bazelEvent, err := ptypes.MarshalAny(event)
-		if err != nil {
-			p.setError(status.WrapError(err, "failed to marshal bazel event"))
-			return
-		}
-		start := time.Now()
-		err = stream.Send(&pepb.PublishBuildToolEventStreamRequest{
-			OrderedBuildEvent: &pepb.OrderedBuildEvent{
-				StreamId:       p.streamID,
-				SequenceNumber: seqNo,
-				Event: &bepb.BuildEvent{
-					EventTime: ptypes.TimestampNow(),
-					Event:     &bepb.BuildEvent_BazelEvent{BazelEvent: bazelEvent},
-				},
-			},
-		})
-		log.Debugf("BEP: published event (#%d) in %s", seqNo, time.Since(start))
-		if err != nil {
-			p.setError(err)
-			return
-		}
-	}
-	// After successfully transmitting all events, close our side of the stream
-	// and wait for server ACKs before closing the connection.
-	if err := stream.CloseSend(); err != nil {
-		p.setError(status.WrapError(err, "failed to close build event stream"))
-		return
-	}
-	<-doneReceiving
+	// Return any error from receiving ACKs
+	return <-doneReceiving
 }
 
-func (p *Publisher) Publish(e *bespb.BuildEvent) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.err != nil {
-		return status.WrapError(p.err, "cannot publish event due to previous error")
+func (p *Publisher) Publish(event *bespb.BuildEvent) error {
+	be := &bepb.BuildEvent{EventTime: ptypes.TimestampNow()}
+	if event == nil {
+		be.Event = &bepb.BuildEvent_ComponentStreamFinished{ComponentStreamFinished: &bepb.BuildEvent_BuildComponentStreamFinished{
+			Type: bepb.BuildEvent_BuildComponentStreamFinished_FINISHED,
+		}}
+	} else {
+		bazelEvent, err := ptypes.MarshalAny(event)
+		if err != nil {
+			return err
+		}
+		be.Event = &bepb.BuildEvent_BazelEvent{BazelEvent: bazelEvent}
 	}
-	p.events <- e
+
+	p.events.Add(be)
 	return nil
 }
 
+// Wait publishes the Finished event and then waits for the server to ACK
+// all published events.
 func (p *Publisher) Wait() error {
-	p.events <- nil
-	<-p.done
-	return p.err
+	if err := p.Publish(nil); err != nil {
+		return err
+	}
+	if err := <-p.done; err != nil {
+		return status.UnavailableErrorf("failed to publish build event stream after multiple attempts: %s", err)
+	}
+	return nil
+}
+
+// EventBuffer holds build events that have not been ack'd by the server.
+//
+// It supports a single consumer and multiple producers: multiple goroutines
+// can call Add(), and a single goroutine can call Get() and Wait() in a loop
+// to observe added events. The consumer keeps track of which events it has
+// already processed.
+type EventBuffer struct {
+	mu sync.Mutex
+	// TODO(bduffany): Store these on disk since the buffer can get quite large if
+	// there is a lot of log output.
+	items []*bepb.BuildEvent
+	// notify is used to signal that an event has been added to the buffer.
+	notify chan struct{}
+}
+
+func NewEventBuffer() *EventBuffer {
+	return &EventBuffer{notify: make(chan struct{}, 1)}
+}
+
+// Get returns the currently buffered items.
+func (b *EventBuffer) Get() []*bepb.BuildEvent {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.items
+}
+
+// Add adds an item to the event buffer and unblocks a Wait() caller.
+func (b *EventBuffer) Add(event *bepb.BuildEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.items = append(b.items, event)
+	// Set a notification if one is not already set
+	select {
+	case b.notify <- struct{}{}:
+	default:
+	}
+}
+
+// Wait waits until the next call to Add().
+func (b *EventBuffer) Wait() {
+	<-b.notify
 }

--- a/enterprise/server/build_event_publisher/build_event_publisher.go
+++ b/enterprise/server/build_event_publisher/build_event_publisher.go
@@ -42,20 +42,21 @@ func New(besBackend, apiKey, invocationID string) (*Publisher, error) {
 	if err != nil {
 		return nil, err
 	}
+	streamID := &bepb.StreamId{
+		InvocationId: invocationID,
+		BuildId:      id.String(),
+	}
 	return &Publisher{
-		streamID: &bepb.StreamId{
-			InvocationId: invocationID,
-			BuildId:      id.String(),
-		},
+		streamID:   streamID,
 		apiKey:     apiKey,
 		besBackend: besBackend,
-		events:     NewEventBuffer(),
+		events:     NewEventBuffer(streamID),
 		done:       make(chan error, 1),
 	}, nil
 }
 
 // Start the event publishing loop in the background. Stops handling new events
-// as soon as the first call to `Wait()` occurs.
+// as soon as the first call to Finish() occurs.
 func (p *Publisher) Start(ctx context.Context) {
 	go func() {
 		defer close(p.done)
@@ -67,13 +68,11 @@ func (p *Publisher) Start(ctx context.Context) {
 		})
 		var err error
 		for r.Next() {
-			if err != nil {
-				log.Debugf("Retrying build event stream due to error: %s", err)
-			}
 			err = p.run(ctx)
 			if err == nil {
 				return
 			}
+			log.Debugf("Retrying build event stream due to error: %s", err)
 		}
 		p.done <- err
 	}()
@@ -112,69 +111,55 @@ func (p *Publisher) run(ctx context.Context) error {
 		}
 	}()
 
-	i := int64(0)
-	finished := false
-	for {
-		buffer := p.events.Get()
-		// Send all events which haven't been sent yet
-		for i < int64(len(buffer)) {
-			event := buffer[i]
-			req := &pepb.PublishBuildToolEventStreamRequest{
-				OrderedBuildEvent: &pepb.OrderedBuildEvent{
-					StreamId:       p.streamID,
-					SequenceNumber: i + 1,
-					Event:          event,
-				},
-			}
-			i++
-			if err := stream.Send(req); err != nil {
-				return status.UnavailableErrorf("send failed: %s", err)
-			}
-			// After successfully transmitting all events, close our side of the stream
-			// and wait for server ACKs before closing the connection.
-			if _, ok := event.Event.(*bepb.BuildEvent_ComponentStreamFinished); ok {
-				if err := stream.CloseSend(); err != nil {
-					return status.UnavailableErrorf("close send failed: %s", err)
-				}
-				finished = true
-			}
+	events, cancel := p.events.Subscribe()
+	defer cancel()
+
+	for obe := range events {
+		req := &pepb.PublishBuildToolEventStreamRequest{OrderedBuildEvent: obe}
+		if err := stream.Send(req); err != nil {
+			return status.UnavailableErrorf("send failed: %s", err)
 		}
-		if finished {
-			break
+		_, finished := obe.Event.Event.(*bepb.BuildEvent_ComponentStreamFinished)
+		if !finished {
+			continue
 		}
-		// Wait until another event has been added to the buffer since we called
-		// Get(), then rinse and repeat.
-		p.events.Wait()
+		// After successfully transmitting all events, close our side of the stream
+		// and wait for server ACKs before closing the connection.
+		if err := stream.CloseSend(); err != nil {
+			return status.UnavailableErrorf("close send failed: %s", err)
+		}
+		break
 	}
 
 	// Return any error from receiving ACKs
 	return <-doneReceiving
 }
 
-func (p *Publisher) Publish(event *bespb.BuildEvent) error {
-	be := &bepb.BuildEvent{EventTime: ptypes.TimestampNow()}
-	if event == nil {
-		be.Event = &bepb.BuildEvent_ComponentStreamFinished{ComponentStreamFinished: &bepb.BuildEvent_BuildComponentStreamFinished{
-			Type: bepb.BuildEvent_BuildComponentStreamFinished_FINISHED,
-		}}
-	} else {
-		bazelEvent, err := ptypes.MarshalAny(event)
-		if err != nil {
-			return err
-		}
-		be.Event = &bepb.BuildEvent_BazelEvent{BazelEvent: bazelEvent}
+func (p *Publisher) Publish(bazelEvent *bespb.BuildEvent) error {
+	bazelEventAny, err := ptypes.MarshalAny(bazelEvent)
+	if err != nil {
+		return err
 	}
-
+	be := &bepb.BuildEvent{
+		EventTime: ptypes.TimestampNow(),
+		Event:     &bepb.BuildEvent_BazelEvent{BazelEvent: bazelEventAny},
+	}
 	p.events.Add(be)
 	return nil
 }
 
-// Wait publishes the Finished event and then waits for the server to ACK
+// Finish publishes the final stream event and then waits for the server to ACK
 // all published events.
-func (p *Publisher) Wait() error {
-	if err := p.Publish(nil); err != nil {
-		return err
+func (p *Publisher) Finish() error {
+	be := &bepb.BuildEvent{
+		EventTime: ptypes.TimestampNow(),
+		Event: &bepb.BuildEvent_ComponentStreamFinished{
+			ComponentStreamFinished: &bepb.BuildEvent_BuildComponentStreamFinished{
+				Type: bepb.BuildEvent_BuildComponentStreamFinished_FINISHED,
+			},
+		},
 	}
+	p.events.Add(be)
 	if err := <-p.done; err != nil {
 		return status.UnavailableErrorf("failed to publish build event stream after multiple attempts: %s", err)
 	}
@@ -183,11 +168,12 @@ func (p *Publisher) Wait() error {
 
 // EventBuffer holds build events that have not been ack'd by the server.
 //
-// It supports a single consumer and multiple producers: multiple goroutines
-// can call Add(), and a single goroutine can call Get() and Wait() in a loop
-// to observe added events. The consumer keeps track of which events it has
-// already processed.
+// It supports a single consumer and multiple producers: multiple goroutines can
+// call Add(), and a single goroutine can call Subscribe() to get the currently
+// buffered events and subsequently added events.
 type EventBuffer struct {
+	streamID *bepb.StreamId
+
 	mu sync.Mutex
 	// TODO(bduffany): Store these on disk since the buffer can get quite large if
 	// there is a lot of log output.
@@ -196,18 +182,57 @@ type EventBuffer struct {
 	notify chan struct{}
 }
 
-func NewEventBuffer() *EventBuffer {
-	return &EventBuffer{notify: make(chan struct{}, 1)}
+func NewEventBuffer(streamID *bepb.StreamId) *EventBuffer {
+	return &EventBuffer{
+		streamID: streamID,
+		notify:   make(chan struct{}, 1),
+	}
 }
 
-// Get returns the currently buffered items.
-func (b *EventBuffer) Get() []*bepb.BuildEvent {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.items
+// Subscribe returns a channel that streams the currently buffered events as
+// well as any subsequently added events, up until the ComponentStreamFinished
+// event.
+//
+// The returned callback function cancels the subscription. It must be called,
+// or else a goroutine leak may occur. Once cancel is called, it is safe for
+// another goroutine to call Subscribe() again.
+func (b *EventBuffer) Subscribe() (<-chan *pepb.OrderedBuildEvent, func()) {
+	events := make(chan *pepb.OrderedBuildEvent)
+	cancel := make(chan struct{})
+	go func() {
+		defer close(events)
+		i := 0
+		for {
+			b.mu.Lock()
+			buffer := b.items
+			b.mu.Unlock()
+
+			// Send all events which haven't been sent yet
+			for i < len(buffer) {
+				buildEvent := buffer[i]
+				events <- &pepb.OrderedBuildEvent{
+					StreamId:       b.streamID,
+					SequenceNumber: int64(i) + 1,
+					Event:          buildEvent,
+				}
+				if _, ok := buildEvent.Event.(*bepb.BuildEvent_ComponentStreamFinished); ok {
+					return
+				}
+				i++
+			}
+			// Wait until another event has been added to the buffer, then rinse and
+			// repeat.
+			select {
+			case <-cancel:
+				return
+			case <-b.notify:
+			}
+		}
+	}()
+	return events, func() { close(cancel) }
 }
 
-// Add adds an item to the event buffer and unblocks a Wait() caller.
+// Add adds an item to the event buffer, making it available to the subscriber.
 func (b *EventBuffer) Add(event *bepb.BuildEvent) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -217,9 +242,4 @@ func (b *EventBuffer) Add(event *bepb.BuildEvent) {
 	case b.notify <- struct{}{}:
 	default:
 	}
-}
-
-// Wait waits until the next call to Add().
-func (b *EventBuffer) Wait() {
-	<-b.notify
 }

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -280,7 +280,7 @@ func (r *buildEventReporter) Start(startTime time.Time) error {
 	// Flush whenever the log buffer fills past a certain threshold.
 	r.log.writeListener = func() {
 		if size := r.log.Len(); size >= progressFlushThresholdBytes {
-			r.FlushProgress() // ignore error; it will surface in `bep.Wait()`
+			r.FlushProgress() // ignore error; it will surface in `bep.Finish()`
 		}
 	}
 	stopFlushingProgress := r.startBackgroundProgressFlush()
@@ -325,7 +325,7 @@ func (r *buildEventReporter) Stop(exitCode int, exitCodeName string) error {
 		LastMessage: true,
 	})
 
-	if err := r.bep.Wait(); err != nil {
+	if err := r.bep.Finish(); err != nil {
 		// If we don't publish a build event successfully, then the status may not be
 		// reported to the Git provider successfully. Terminate with a code indicating
 		// that the executor can retry the action, so that we have another chance.
@@ -796,7 +796,7 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace, startTime time.T
 		}
 
 		// Publish the status of each command as well as the finish time.
-		// Stop execution early on BEP failure, but ignore error -- it will surface in `bep.Wait()`.
+		// Stop execution early on BEP failure, but ignore error -- it will surface in `bep.Finish()`.
 		duration := time.Since(cmdStartTime)
 		completedEvent := &bespb.BuildEvent{
 			Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_WorkflowCommandCompleted{WorkflowCommandCompleted: &bespb.BuildEventId_WorkflowCommandCompletedId{
@@ -838,7 +838,7 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace, startTime time.T
 		}
 
 		// Flush progress after every command.
-		// Stop execution early on BEP failure, but ignore error -- it will surface in `bep.Wait()`.
+		// Stop execution early on BEP failure, but ignore error -- it will surface in `bep.Finish()`.
 		if err := ar.reporter.FlushProgress(); err != nil {
 			break
 		}

--- a/enterprise/server/test/integration/build_logs/build_logs_test.go
+++ b/enterprise/server/test/integration/build_logs/build_logs_test.go
@@ -183,7 +183,7 @@ func TestBuildLogs_CompletedInvocation(t *testing.T) {
 		// Close the build event publisher in case the test failed before we made it
 		// to the part where the stream is closed.
 		if !bepClosed {
-			err := bep.Wait()
+			err := bep.Finish()
 			require.NoError(t, err)
 		}
 	}()
@@ -214,7 +214,7 @@ func TestBuildLogs_CompletedInvocation(t *testing.T) {
 	// Close the BEP stream -- this should not return until all events are ACK'd
 	// by the server. The server sends ACKs only after all events are processed,
 	// so the logs should be available when this returns.
-	err = bep.Wait()
+	err = bep.Finish()
 	bepClosed = true
 	require.NoError(t, err)
 
@@ -235,7 +235,7 @@ func TestBuildLogs_InProgressInvocation(t *testing.T) {
 	defer func() {
 		// Close the BEP stream during cleanup since we keep it open for the
 		// duration of the test (since we are testing "in progress" invocations)
-		err := bep.Wait()
+		err := bep.Finish()
 		require.NoError(t, err)
 	}()
 	log := NewInvocationLog(bbClient, iid)


### PR DESCRIPTION
This fixes an issue that a workflow invocation can be disconnected if the build event stream client is connected to a BB app that is shut down while the stream is in progress and the workflow invocation takes longer than the grace period.

Tested locally.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1183
