### PR TITLE
Enable web tracing

### DIFF
--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -35,6 +35,21 @@ class RpcService {
     (window as any)._rpcService = this;
   }
 
+  debuggingEnabled(): boolean {
+    const url = new URL(window.location.href);
+    let sp = url.searchParams.get("debug");
+    if (sp == null) {
+      let match = url.hash.match("debug=(.*)");
+      if (match != null) {
+        sp = match[1];
+      }
+    }
+    if (sp == "1" || sp == "true" || sp == "True") {
+      return true;
+    }
+    return false;
+  }
+
   getBytestreamUrl(bytestreamURL: string, invocationId: string, { filename = "" } = {}): string {
     const encodedRequestContext = uint8ArrayToBase64(context.RequestContext.encode(this.requestContext).finish());
     const params: Record<string, string> = {
@@ -86,6 +101,9 @@ class RpcService {
   rpc(method: any, requestData: any, callback: any) {
     var request = new XMLHttpRequest();
     request.open("POST", `/rpc/BuildBuddyService/${method.name}`, true);
+    if (this.debuggingEnabled()) {
+      request.setRequestHeader("x-buildbuddy-trace", "force");
+    }
 
     request.setRequestHeader("Content-Type", method.contentType || "application/proto");
     request.responseType = "arraybuffer";

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -38,12 +38,6 @@ class RpcService {
   debuggingEnabled(): boolean {
     const url = new URL(window.location.href);
     let sp = url.searchParams.get("debug");
-    if (sp === null) {
-      let match = url.hash.match("debug=(.*)");
-      if (match !== null) {
-        sp = match[1];
-      }
-    }
     if (sp === "1" || sp === "true" || sp === "True") {
       return true;
     }

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -38,13 +38,13 @@ class RpcService {
   debuggingEnabled(): boolean {
     const url = new URL(window.location.href);
     let sp = url.searchParams.get("debug");
-    if (sp == null) {
+    if (sp === null) {
       let match = url.hash.match("debug=(.*)");
-      if (match != null) {
+      if (match !== null) {
         sp = match[1];
       }
     }
-    if (sp == "1" || sp == "true" || sp == "True") {
+    if (sp === "1" || sp === "true" || sp === "True") {
       return true;
     }
     return false;

--- a/server/http/protolet/BUILD
+++ b/server/http/protolet/BUILD
@@ -10,5 +10,6 @@ go_library(
         "//server/util/request_context",
         "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@org_golang_google_grpc//metadata",
     ],
 )

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -376,7 +376,7 @@ func StartAndRunServices(env environment.Env) {
 
 	// Generate HTTP (protolet) handlers for the BuildBuddy API, so it
 	// can be called over HTTP(s).
-	buildBuddyProtoHandlers, err := protolet.GenerateHTTPHandlers(buildBuddyServer)
+	protoletHandler, err := protolet.GenerateHTTPHandlers(buildBuddyServer)
 	if err != nil {
 		log.Fatalf("Error initializing RPC over HTTP handlers for BuildBuddy server: %s", err)
 	}
@@ -402,7 +402,7 @@ func StartAndRunServices(env environment.Env) {
 		mux.Handle(appRoute, httpfilters.WrapExternalHandler(env, staticFileServer))
 	}
 	mux.Handle("/app/", httpfilters.WrapExternalHandler(env, http.StripPrefix("/app", afs)))
-	mux.Handle("/rpc/BuildBuddyService/", httpfilters.WrapAuthenticatedExternalProtoletHandler(env, "/rpc/BuildBuddyService/", buildBuddyProtoHandlers))
+	mux.Handle("/rpc/BuildBuddyService/", httpfilters.WrapAuthenticatedExternalProtoletHandler(env, "/rpc/BuildBuddyService/", protoletHandler))
 	mux.Handle("/file/download", httpfilters.WrapAuthenticatedExternalHandler(env, buildBuddyServer))
 	mux.Handle("/healthz", env.GetHealthChecker().LivenessHandler())
 	mux.Handle("/readyz", env.GetHealthChecker().ReadinessHandler())


### PR DESCRIPTION
This CL allows appending "debug=1" or "debug=true" to a URL in the UI to request the backend to force tracing.

My intent with this CL is to make it easier to debug performance issues in prod: currently it's very difficult to see why queries are slow for a particular page load without setting up a mirror environment and running the same request with debug logging on. After this change, it should only require loading the page with debug=1 and then fishing around in jaeger.

The app enables this functionality by setting an HTTP header in requests to the backend when the debug=1 flag is present in the URL. For simplicity, the header is only set on RPC (via protolet) requests.

The backend protolet previously did not set any gRPC metadata before calling handler implementations -- now it does. Only whitelisted headers are put into the metadata.
