### PR TITLE
Allow executor to be started w/o a config file.

### DIFF
--- a/server/config/BUILD
+++ b/server/config/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//server/util/alert",
         "//server/util/flagutil",
         "//server/util/log",
+        "//server/util/status",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -12,13 +13,14 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"gopkg.in/yaml.v2"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 )
 
 var (
-	configFile = flag.String("config_file", "/config.yaml", "The path to a buildbuddy config file")
+	configFile = flag.String("config_file", "", "The path to a buildbuddy config file")
 )
 
 // When adding new storage fields, always be explicit about their yaml field
@@ -382,7 +384,7 @@ type OrgConfig struct {
 }
 
 var (
-	sharedConfigurator = &Configurator{}
+	sharedConfigurator = &Configurator{gc: &generalConfig{}}
 
 	// Contains the string slices originally defined by the flags
 	originalStringSlices = make(map[string][]string)
@@ -577,6 +579,14 @@ func ParseAndReconcileFlagsAndConfig(configFilePath string) (*Configurator, erro
 	RegisterAndParseFlags()
 	if configFilePath == "" {
 		configFilePath = *configFile
+	}
+	if configFilePath == "" {
+		_, err := os.Stat("/config.yaml")
+		if err == nil {
+			configFilePath = "/config.yaml"
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, status.UnknownErrorf("could not load config file: %s", err)
+		}
 	}
 	configurator, err := NewConfigurator(configFilePath)
 	if err != nil {


### PR DESCRIPTION
This was accidentally broken in
https://github.com/buildbuddy-io/buildbuddy/pull/1671.

Our docker BYOR instructions don't pass a config file.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
