### PR TITLE
Don't report commit statuses for inner workflow invocations

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1206,6 +1206,12 @@ func writeBazelrc(path string) error {
 
 	lines := []string{
 		"build --build_metadata=ROLE=CI",
+		// Don't report commit statuses for individual bazel commands, since the
+		// overall status of all bazel commands is reflected in the status reported
+		// for the workflow invocation. In addition, for PRs, we first merge with
+		// the target branch which causes the HEAD commit SHA to change, and this
+		// SHA won't actually exist on GitHub.
+		"build --build_metadata=DISABLE_COMMIT_STATUS_REPORTING=true",
 		"build --bes_backend=" + *besBackend,
 		"build --bes_results_url=" + *besResultsURL,
 	}

--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -113,6 +113,11 @@ func (r *BuildStatusReporter) flushPayloadsIfWorkspaceLoaded(ctx context.Context
 	if !r.buildEventAccumulator.WorkspaceIsLoaded() {
 		return // If we haven't loaded the workspace, we can't flush payloads yet.
 	}
+	// Don't flush payloads if explicitly disabled in build metadata, or if we
+	// don't yet have the metadata.
+	if !r.buildEventAccumulator.BuildMetadataIsLoaded() || r.buildEventAccumulator.DisableCommitStatusReporting() {
+		return
+	}
 	if r.githubClient == nil {
 		r.githubClient = r.initGHClient(ctx)
 	}

--- a/server/build_event_protocol/target_tracker/target_tracker_test.go
+++ b/server/build_event_protocol/target_tracker/target_tracker_test.go
@@ -116,6 +116,10 @@ func (a *fakeAccumulator) WorkspaceIsLoaded() bool {
 	return true
 }
 
+func (a *fakeAccumulator) BuildMetadataIsLoaded() bool {
+	return true
+}
+
 func (a *fakeAccumulator) BuildFinished() bool {
 	return true
 }

--- a/server/build_event_protocol/target_tracker/target_tracker_test.go
+++ b/server/build_event_protocol/target_tracker/target_tracker_test.go
@@ -100,6 +100,10 @@ func (a *fakeAccumulator) CommitSHA() string {
 	return ""
 }
 
+func (a *fakeAccumulator) DisableCommitStatusReporting() bool {
+	return false
+}
+
 func (a *fakeAccumulator) Pattern() string {
 	return ""
 }


### PR DESCRIPTION
This prevents the `bazel test //...` statuses from showing up, which are redundant with the action statuses (e.g. "Test all") and can be easily clobbered if multiple actions execute the same bazel command (e.g. "Test all" and "Test all (Mac)" which both run `bazel test //...`).

Tested locally.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1229
