### PR TITLE
When creating / editing API keys allow admins to chose whether they're visible to developers

### DIFF
--- a/app/docs/setup_code.tsx
+++ b/app/docs/setup_code.tsx
@@ -206,6 +206,7 @@ export default class SetupCodeComponent extends React.Component {
             ) : (
               <>This BuildBuddy installation requires authentication, but no API keys are set up.</>
             )}
+            {!this.state.user.canCall("createApiKey") && <> Only organization administrators can create API keys.</>}
           </div>
           {this.state.user.canCall("createApiKey") && (
             <div>

--- a/app/docs/setup_code.tsx
+++ b/app/docs/setup_code.tsx
@@ -202,7 +202,7 @@ export default class SetupCodeComponent extends React.Component {
         <div className="no-api-keys-content">
           <div>
             {capabilities.anonymous ? (
-              <>Looks like your organization doesn't have any API keys.</>
+              <>Looks like your organization doesn't have any API keys that are visible to you.</>
             ) : (
               <>This BuildBuddy installation requires authentication, but no API keys are set up.</>
             )}

--- a/enterprise/app/api_keys/api_keys.css
+++ b/enterprise/app/api_keys/api_keys.css
@@ -169,3 +169,9 @@
   padding: 4px 8px;
   border-radius: 4px;
 }
+
+.api-keys .no-api-keys-message {
+  background: #e1f5fe;
+  padding: 16px;
+  border-radius: 8px;
+}

--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -241,8 +241,7 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
     onChange: (name: string, value: any) => any,
     e: React.ChangeEvent<HTMLInputElement>
   ) {
-    request.visibleToDevelopers = e.target.checked;
-    onChange("visibleToDevelopers", request.visibleToDevelopers);
+    onChange("visibleToDevelopers", e.target.checked);
   }
 
   private onChangeRegisterExecutor<T extends ApiKeyFields>(
@@ -489,7 +488,7 @@ function describeCapabilities<T extends ApiKeyFields>(apiKey: T | null) {
     capabilities += "+Executor";
   }
   if (isVisibleToDevelopers(apiKey)) {
-    capabilities += " [Devs]";
+    capabilities += " [D]";
   }
   return capabilities;
 }

--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -144,6 +144,7 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
           id: apiKey.id,
           label: apiKey.label,
           capability: [...apiKey.capability],
+          visibleToDevelopers: apiKey.visibleToDevelopers,
         }),
       },
     });
@@ -235,6 +236,15 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
     this.onChangeCapability(request, api_key.ApiKey.Capability.CACHE_WRITE_CAPABILITY, !e.target.checked, onChange);
   }
 
+  private onChangeVisibility<T extends ApiKeyFields>(
+    request: T,
+    onChange: (name: string, value: any) => any,
+    e: React.ChangeEvent<HTMLInputElement>
+  ) {
+    request.visibleToDevelopers = e.target.checked;
+    onChange("visibleToDevelopers", request.visibleToDevelopers);
+  }
+
   private onChangeRegisterExecutor<T extends ApiKeyFields>(
     request: T,
     onChange: (name: string, value: any) => any,
@@ -305,6 +315,18 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
                   </label>
                 </div>
               )}
+              <div className="field-container">
+                <label className="checkbox-row">
+                  <input
+                    type="checkbox"
+                    onChange={this.onChangeVisibility.bind(this, request, onChange)}
+                    checked={isVisibleToDevelopers(request)}
+                  />
+                  <span>
+                    Visible to developers <span className="field-description">(users with the role Developer)</span>
+                  </span>
+                </label>
+              </div>
             </DialogBody>
             <DialogFooter>
               <DialogFooterButtons>
@@ -370,6 +392,11 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
         })}
 
         <div className="api-keys-list">
+          {getApiKeysResponse.apiKey.length == 0 && !this.props.user.canCall("createApiKey") && (
+            <div className="no-api-keys-message">
+              No API keys have been made visible to developers. Only organization admins can create API keys.
+            </div>
+          )}
           {getApiKeysResponse.apiKey.map((key) => (
             <div key={key.id} className="api-key-list-item">
               <div className="api-key-label">
@@ -450,6 +477,10 @@ function hasCapability<T extends ApiKeyFields>(apiKey: T | null, capability: api
 
 function isReadOnly<T extends ApiKeyFields>(apiKey: T | null) {
   return !hasCapability(apiKey, api_key.ApiKey.Capability.CACHE_WRITE_CAPABILITY);
+}
+
+function isVisibleToDevelopers<T extends ApiKeyFields>(apiKey: T | null) {
+  return apiKey?.visibleToDevelopers;
 }
 
 function describeCapabilities<T extends ApiKeyFields>(apiKey: T | null) {

--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -488,5 +488,8 @@ function describeCapabilities<T extends ApiKeyFields>(apiKey: T | null) {
   if (hasCapability(apiKey, api_key.ApiKey.Capability.REGISTER_EXECUTOR_CAPABILITY)) {
     capabilities += "+Executor";
   }
+  if (isVisibleToDevelopers(apiKey)) {
+    capabilities += " [Devs]";
+  }
   return capabilities;
 }

--- a/enterprise/server/backends/userdb/BUILD
+++ b/enterprise/server/backends/userdb/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//server/environment",
         "//server/interfaces",
         "//server/tables",
+        "//server/util/authutil",
         "//server/util/capabilities",
         "//server/util/db",
         "//server/util/log",

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/capabilities"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -155,10 +156,21 @@ func (d *UserDB) GetAPIKeys(ctx context.Context, groupID string) ([]*tables.APIK
 		return nil, status.InvalidArgumentError("Group ID cannot be empty.")
 	}
 
+	u, err := perms.AuthenticatedUser(ctx, d.env)
+	if err != nil {
+		return nil, err
+	}
+
+	filter := "AND visible_to_developers = true"
+	if err := authutil.AuthorizeGroupRole(u, groupID, role.Admin); err == nil {
+		filter = ""
+	}
+
 	query := d.h.DB(ctx).Raw(`
-		SELECT api_key_id, value, label, perms, capabilities
+		SELECT api_key_id, value, label, perms, capabilities, visible_to_developers
 		FROM APIKeys
 		WHERE group_id = ?
+		`+filter+`
 		ORDER BY label ASC
 	`, groupID)
 	rows, err := query.Rows()
@@ -178,32 +190,33 @@ func (d *UserDB) GetAPIKeys(ctx context.Context, groupID string) ([]*tables.APIK
 	return keys, nil
 }
 
-func (d *UserDB) CreateAPIKey(ctx context.Context, groupID string, label string, caps []akpb.ApiKey_Capability) (*tables.APIKey, error) {
+func (d *UserDB) CreateAPIKey(ctx context.Context, groupID string, label string, caps []akpb.ApiKey_Capability, visibleToDevelopers bool) (*tables.APIKey, error) {
 	if groupID == "" {
 		return nil, status.InvalidArgumentError("Group ID cannot be nil.")
 	}
 
-	return createAPIKey(d.h.DB(ctx), groupID, newAPIKeyToken(), label, caps)
+	return createAPIKey(d.h.DB(ctx), groupID, newAPIKeyToken(), label, caps, visibleToDevelopers)
 }
 
-func createAPIKey(db *db.DB, groupID, value, label string, caps []akpb.ApiKey_Capability) (*tables.APIKey, error) {
+func createAPIKey(db *db.DB, groupID, value, label string, caps []akpb.ApiKey_Capability, visibleToDevelopers bool) (*tables.APIKey, error) {
 	pk, err := tables.PrimaryKeyForTable("APIKeys")
 	if err != nil {
 		return nil, err
 	}
 	keyPerms := perms.GROUP_READ | perms.GROUP_WRITE
 	if err := db.Exec(
-		`INSERT INTO APIKeys (api_key_id, group_id, perms, capabilities, value, label) VALUES (?, ?, ?, ?, ?, ?)`,
-		pk, groupID, keyPerms, capabilities.ToInt(caps), value, label).Error; err != nil {
+		`INSERT INTO APIKeys (api_key_id, group_id, perms, capabilities, value, label, visible_to_developers) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		pk, groupID, keyPerms, capabilities.ToInt(caps), value, label, visibleToDevelopers).Error; err != nil {
 		return nil, err
 	}
 	return &tables.APIKey{
-		APIKeyID:     pk,
-		GroupID:      groupID,
-		Value:        value,
-		Label:        label,
-		Perms:        keyPerms,
-		Capabilities: capabilities.ToInt(caps),
+		APIKeyID:            pk,
+		GroupID:             groupID,
+		Value:               value,
+		Label:               label,
+		Perms:               keyPerms,
+		Capabilities:        capabilities.ToInt(caps),
+		VisibleToDevelopers: visibleToDevelopers,
 	}, nil
 }
 
@@ -216,9 +229,10 @@ func (d *UserDB) UpdateAPIKey(ctx context.Context, key *tables.APIKey) error {
 	}
 
 	err := d.h.DB(ctx).Exec(
-		`UPDATE APIKeys SET label = ?, capabilities = ? WHERE api_key_id = ?`,
+		`UPDATE APIKeys SET label = ?, capabilities = ?, visible_to_developers = ? WHERE api_key_id = ?`,
 		key.Label,
 		key.Capabilities,
+		key.VisibleToDevelopers,
 		key.APIKeyID,
 	).Error
 	if err != nil {
@@ -330,7 +344,7 @@ func (d *UserDB) InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (stri
 			if err := tx.Create(&newGroup).Error; err != nil {
 				return err
 			}
-			_, err = createAPIKey(tx, groupID, newAPIKeyToken(), defaultAPIKeyLabel, defaultAPIKeyCapabilities)
+			_, err = createAPIKey(tx, groupID, newAPIKeyToken(), defaultAPIKeyLabel, defaultAPIKeyCapabilities, false)
 			return err
 		}
 
@@ -512,7 +526,7 @@ func (d *UserDB) CreateDefaultGroup(ctx context.Context) error {
 				if err := tx.Create(&c.group).Error; err != nil {
 					return err
 				}
-				if _, err := createAPIKey(tx, DefaultGroupID, c.apiKeyValue, defaultAPIKeyLabel, defaultAPIKeyCapabilities); err != nil {
+				if _, err := createAPIKey(tx, DefaultGroupID, c.apiKeyValue, defaultAPIKeyLabel, defaultAPIKeyCapabilities, false); err != nil {
 					return err
 				}
 				return nil
@@ -592,7 +606,7 @@ func (d *UserDB) createUser(ctx context.Context, tx *db.DB, u *tables.User) erro
 		if err := tx.Create(&sug).Error; err != nil {
 			return err
 		}
-		if _, err := createAPIKey(tx, sug.GroupID, newAPIKeyToken(), defaultAPIKeyLabel, defaultAPIKeyCapabilities); err != nil {
+		if _, err := createAPIKey(tx, sug.GroupID, newAPIKeyToken(), defaultAPIKeyLabel, defaultAPIKeyCapabilities, false); err != nil {
 			return err
 		}
 		groupIDs = append(groupIDs, sug.GroupID)

--- a/proto/api_key.proto
+++ b/proto/api_key.proto
@@ -31,6 +31,9 @@ message ApiKey {
 
   // Capabilities associated with this API key.
   repeated Capability capability = 4;
+
+  // True if this API key is visible to developers.
+  bool visible_to_developers = 5;
 }
 
 message CreateApiKeyRequest {
@@ -46,6 +49,9 @@ message CreateApiKeyRequest {
 
   // Optional. Capabilities granted to this API key.
   repeated ApiKey.Capability capability = 4;
+
+  // True if this API key should be visible to developers.
+  bool visible_to_developers = 5;
 }
 
 message CreateApiKeyResponse {
@@ -88,6 +94,9 @@ message UpdateApiKeyRequest {
   // NOTE: If this is empty, all capabilities will be removed as part of
   // this update.
   repeated ApiKey.Capability capability = 4;
+
+  // True if this API key should be visible to developers.
+  bool visible_to_developers = 5;
 }
 
 message UpdateApiKeyResponse {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -428,10 +428,11 @@ func (s *BuildBuddyServer) GetApiKeys(ctx context.Context, req *akpb.GetApiKeysR
 	}
 	for _, k := range tableKeys {
 		rsp.ApiKey = append(rsp.ApiKey, &akpb.ApiKey{
-			Id:         k.APIKeyID,
-			Value:      k.Value,
-			Label:      k.Label,
-			Capability: capabilities.FromInt(k.Capabilities),
+			Id:                  k.APIKeyID,
+			Value:               k.Value,
+			Label:               k.Label,
+			Capability:          capabilities.FromInt(k.Capabilities),
+			VisibleToDevelopers: k.VisibleToDevelopers,
 		})
 	}
 	return rsp, nil
@@ -446,16 +447,17 @@ func (s *BuildBuddyServer) CreateApiKey(ctx context.Context, req *akpb.CreateApi
 	if err := perms.AuthorizeGroupAccess(ctx, s.env, groupID); err != nil {
 		return nil, err
 	}
-	k, err := userDB.CreateAPIKey(ctx, groupID, req.GetLabel(), req.GetCapability())
+	k, err := userDB.CreateAPIKey(ctx, groupID, req.GetLabel(), req.GetCapability(), req.GetVisibleToDevelopers())
 	if err != nil {
 		return nil, err
 	}
 	return &akpb.CreateApiKeyResponse{
 		ApiKey: &akpb.ApiKey{
-			Id:         k.APIKeyID,
-			Value:      k.Value,
-			Label:      k.Label,
-			Capability: capabilities.FromInt(k.Capabilities),
+			Id:                  k.APIKeyID,
+			Value:               k.Value,
+			Label:               k.Label,
+			Capability:          capabilities.FromInt(k.Capabilities),
+			VisibleToDevelopers: k.VisibleToDevelopers,
 		},
 	}, nil
 }
@@ -490,9 +492,10 @@ func (s *BuildBuddyServer) UpdateApiKey(ctx context.Context, req *akpb.UpdateApi
 		return nil, err
 	}
 	tk := &tables.APIKey{
-		APIKeyID:     req.GetId(),
-		Label:        req.GetLabel(),
-		Capabilities: capabilities.ToInt(req.GetCapability()),
+		APIKeyID:            req.GetId(),
+		Label:               req.GetLabel(),
+		Capabilities:        capabilities.ToInt(req.GetCapability()),
+		VisibleToDevelopers: req.GetVisibleToDevelopers(),
 	}
 	if err := userDB.UpdateAPIKey(ctx, tk); err != nil {
 		return nil, err
@@ -572,9 +575,10 @@ func toProtoAPIKeys(tableKeys []*tables.APIKey) []*akpb.ApiKey {
 	protoKeys := make([]*akpb.ApiKey, len(tableKeys))
 	for i, k := range tableKeys {
 		protoKeys[i] = &akpb.ApiKey{
-			Id:    k.APIKeyID,
-			Value: k.Value,
-			Label: k.Label,
+			Id:                  k.APIKeyID,
+			Value:               k.Value,
+			Label:               k.Label,
+			VisibleToDevelopers: k.VisibleToDevelopers,
 		}
 	}
 	return protoKeys

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -301,7 +301,7 @@ type UserDB interface {
 	// API Keys API
 	GetAPIKey(ctx context.Context, apiKeyID string) (*tables.APIKey, error)
 	GetAPIKeys(ctx context.Context, groupID string) ([]*tables.APIKey, error)
-	CreateAPIKey(ctx context.Context, groupID string, label string, capabilities []akpb.ApiKey_Capability) (*tables.APIKey, error)
+	CreateAPIKey(ctx context.Context, groupID string, label string, capabilities []akpb.ApiKey_Capability, visibleToDevelopers bool) (*tables.APIKey, error)
 	UpdateAPIKey(ctx context.Context, key *tables.APIKey) error
 	DeleteAPIKey(ctx context.Context, apiKeyID string) error
 }

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -306,7 +306,7 @@ type APIKey struct {
 	// NOTE: If the default is changed, a DB migration may be required to
 	// migrate old DB rows to reflect the new default.
 	Capabilities        int32 `gorm:"default:1"`
-	VisibleToDevelopers bool
+	VisibleToDevelopers bool  `gorm:"not null;default:false"`
 }
 
 func (k *APIKey) TableName() string {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -305,7 +305,8 @@ type APIKey struct {
 	//
 	// NOTE: If the default is changed, a DB migration may be required to
 	// migrate old DB rows to reflect the new default.
-	Capabilities int32 `gorm:"default:1"`
+	Capabilities        int32 `gorm:"default:1"`
+	VisibleToDevelopers bool
 }
 
 func (k *APIKey) TableName() string {


### PR DESCRIPTION
This allows admins to choose whether or not individual API keys are visible to developers when creating / updating keys.

All existing API keys will only be visible to Admins.

Admin:
<img width="712" alt="Screen Shot 2022-03-15 at 5 08 30 PM" src="https://user-images.githubusercontent.com/1704556/158492073-74fdbf34-251e-431f-8c31-036317299f33.png">

User:
<img width="558" alt="Screen Shot 2022-03-15 at 5 09 02 PM" src="https://user-images.githubusercontent.com/1704556/158492113-11ab7895-5010-428f-a054-e81185d86cb1.png">


**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
