### PR TITLE
Roll forward #1696: Add command to test grid query

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -637,11 +637,6 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 			return nil
 		})
 	}
-	if db.Migrator().HasIndex("Invocations", "invocations_test_grid_query_index") {
-		postMigrate = append(postMigrate, func() error {
-			return db.Migrator().DropIndex("TargetStatuses", "invocations_test_grid_query_index")
-		})
-	}
 	return postMigrate, nil
 }
 
@@ -806,6 +801,13 @@ func PostAutoMigrate(db *gorm.DB) error {
 			err := db.Exec(fmt.Sprintf("CREATE INDEX `%s` ON `Invocations`%s", indexName, cols)).Error
 			if err != nil {
 				log.Errorf("Error creating %s: %s", indexName, err)
+			}
+		}
+
+		// Drop deprecated invocation indexes
+		if db.Migrator().HasIndex("Invocations", "invocations_test_grid_query_index") {
+			if err := db.Migrator().DropIndex("Invocations", "invocations_test_grid_query_index"); err != nil {
+				log.Errorf("Error dropping deprecated index: %s", err)
 			}
 		}
 	}

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -637,6 +637,11 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 			return nil
 		})
 	}
+	if db.Migrator().HasIndex("Invocations", "invocations_test_grid_query_index") {
+		postMigrate = append(postMigrate, func() error {
+			return db.Migrator().DropIndex("TargetStatuses", "invocations_test_grid_query_index")
+		})
+	}
 	return postMigrate, nil
 }
 
@@ -776,8 +781,22 @@ func PostAutoMigrate(db *gorm.DB) error {
 		"invocations_stats_branch_index":      "(`group_id`, `branch_name`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
 		"invocations_stats_commit_index":      "(`group_id`, `commit_sha`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
 		"invocations_stats_role_index":        "(`group_id`, `role`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_test_grid_query_index":   "(`group_id`, `role`, `repo_url`, `created_at_usec` DESC)",
 	}
+	prefixIndicesByDialect := map[string]map[string]string{
+		mysqlDialect: map[string]string{
+			"invocations_test_grid_query_command_index": "(`group_id` (25), `role` (10), `repo_url`, `command` (10), `created_at_usec` DESC)",
+		},
+		sqliteDialect: map[string]string{
+			"invocations_test_grid_query_command_index": "(`group_id`, `role`, `repo_url`, `command` , `created_at_usec` DESC)",
+		},
+	}
+	prefixIndexes, ok := prefixIndicesByDialect[db.Dialector.Name()]
+	if ok {
+		for name, cols := range prefixIndexes {
+			indexes[name] = cols
+		}
+	}
+
 	m := db.Migrator()
 	if m.HasTable("Invocations") {
 		for indexName, cols := range indexes {

--- a/server/target/target.go
+++ b/server/target/target.go
@@ -24,6 +24,7 @@ import (
 const (
 	sqlite3Dialect = "sqlite3"
 	ciRole         = "CI"
+	testCommand    = "test"
 
 	// The number of distinct commits returned in GetTargetResponse.
 	targetPageSize = 20
@@ -280,6 +281,7 @@ func readPaginatedTargets(ctx context.Context, env environment.Env, req *trpb.Ge
 		commitQuery.AddWhereClause("repo_url = ?", repo)
 	}
 	commitQuery.AddWhereClause("role = ?", ciRole)
+	commitQuery.AddWhereClause("command = ?", testCommand)
 	paginationToken, err := NewTokenFromRequest(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Commit containing just the fixes (tested locally): https://github.com/buildbuddy-io/buildbuddy/pull/1719/commits/38bea110281ff7d4373fb7de9b062f063bb7671e

* Fix erroneous reference to "TargetStatuses" instead of "Invocations"
* Fix sqlite migration bug that occurs because we check existence of the index pre-migration but defer the drop statement execution until post-automigration. The deferred DROP INDEX fails because the index gets dropped automatically as part of GORM auto-migration (more accurately, GORM recreates the entire table from scratch, copying values from the old table). This behavior only appears to happen for sqlite and not mysql.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
