### PR TITLE
Enable runner recycling for mysql test

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -37,4 +37,5 @@ actions:
         branches:
           - "master"
     bazel_commands:
-      - test //... --config=workflows --test_tag_filters=+docker --build_tag_filters=+docker
+      # TODO(http://go/b/1249): remove --jobs=3
+      - test //... --config=workflows --test_tag_filters=+docker --build_tag_filters=+docker --jobs=3

--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -46,6 +46,7 @@ go_test(
     exec_properties = {
         "workload-isolation-type": "firecracker",
         "init-dockerd": "true",
+        "recycle-runner": "true",
     },
     shard_count = 7,
     tags = ["docker"],


### PR DESCRIPTION
This allows test actions to execute against a VM snapshot with the docker daemon already up and running, as well as the mysql image being cached, which significantly speeds up test execution.

Example cold run (1m24s) -- note the `docker pull` output in the logs :
https://app.buildbuddy.dev/invocation/739e3966-ceed-4fd9-9a35-52a978ea8253?target=%2F%2Fenterprise%2Fserver%2Fusage%3Ausage_test_mysql#2

Example warm run (30.6s; ~2.7X improvement) -- note that the `docker pull` output is not in the logs, because the mysql image is cached:
https://app.buildbuddy.dev/invocation/77e2b82e-2ef2-43ab-bb21-032d17442850?target=%2F%2Fenterprise%2Fserver%2Fusage%3Ausage_test_mysql#2 

This is still pretty slow, because the mysql server takes quite some time to start. If we allow the test to reuse the MySQL DB, we can get this down to about 3.5s -- see results from this experimental change: https://app.buildbuddy.dev/invocation/3fd28a9e-39e8-4f68-bf10-9b9e4262047c?target=%2F%2Fenterprise%2Fserver%2Fusage%3Ausage_test_mysql#2

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
