### PR TITLE
Add some tests for RBE signal handling

### DIFF
--- a/enterprise/server/remote_execution/commandutil/BUILD
+++ b/enterprise/server/remote_execution/commandutil/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "commandutil",
@@ -9,5 +9,19 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/util/status",
+    ],
+)
+
+go_test(
+    name = "commandutil_test",
+    srcs = ["commandutil_test.go"],
+    deps = [
+        ":commandutil",
+        "//proto:remote_execution_go_proto",
+        "//server/interfaces",
+        "//server/testutil/testfs",
+        "//server/util/status",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/remote_execution/commandutil/commandutil_test.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_test.go
@@ -1,0 +1,127 @@
+package commandutil_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+func TestRun_NormalExit_NoError(t *testing.T) {
+	ctx := context.Background()
+
+	{
+		res := runSh(ctx, "exit 0")
+
+		assert.NoError(t, res.Error)
+		assert.Equal(t, 0, res.ExitCode)
+	}
+	{
+		res := runSh(ctx, "exit 1")
+
+		assert.NoError(t, res.Error)
+		assert.Equal(t, 1, res.ExitCode)
+	}
+	{
+		res := runSh(ctx, "exit 137")
+
+		assert.NoError(t, res.Error)
+		assert.Equal(t, 137, res.ExitCode)
+	}
+}
+
+// TODO(bduffany): Treat SIGABRT as a normal exit rather than an unexpected
+// termination, and ensure that unexpected terminations are retried rather than
+// immediately reporting them to Bazel.
+
+func TestRun_Killed_ErrorResult(t *testing.T) {
+	ctx := context.Background()
+
+	{
+		res := runSh(ctx, "kill -ABRT $$")
+
+		require.Error(t, res.Error)
+		assert.Contains(t, res.Error.Error(), "signal: aborted")
+		assert.Equal(t, -1, res.ExitCode)
+	}
+	{
+		res := runSh(ctx, "kill -INT $$")
+
+		require.Error(t, res.Error)
+		assert.Contains(t, res.Error.Error(), "signal: interrupt")
+		assert.Equal(t, -1, res.ExitCode)
+	}
+	{
+		res := runSh(ctx, "kill -TERM $$")
+
+		require.Error(t, res.Error)
+		assert.Contains(t, res.Error.Error(), "signal: terminated")
+		assert.Equal(t, -1, res.ExitCode)
+	}
+	{
+		res := runSh(ctx, "kill -KILL $$")
+
+		require.Error(t, res.Error)
+		assert.Contains(t, res.Error.Error(), "signal: killed")
+		assert.Equal(t, -1, res.ExitCode)
+	}
+}
+
+// TODO(bduffany): All the error codes when the command is not found or not
+// executable should probably have the same error code, instead of a mix of
+// NOT_FOUND / UNAVAILABLE. Also we should probably ensure that Bazel doesn't
+// retry these errors at the executor level, since retrying is unlikely to
+// help (these errors are most likely due to an incorrect input specification or
+// container-image that doesn't contain the executable in PATH)
+
+func TestRun_CommandNotFound_ErrorResult(t *testing.T) {
+	ctx := context.Background()
+
+	{
+		cmd := &repb.Command{Arguments: []string{"./command_not_found_in_working_dir"}}
+		res := commandutil.Run(ctx, cmd, ".", nil /*=stdin*/, nil /*=stdout*/)
+
+		assert.Error(t, res.Error)
+		assert.True(
+			t, status.IsUnavailableError(res.Error),
+			"expecting UNAVAILABLE when executable file is missing, got: %s", res.Error)
+		assert.Equal(t, -2, res.ExitCode)
+	}
+	{
+		cmd := &repb.Command{Arguments: []string{"command_not_found_in_PATH"}}
+		res := commandutil.Run(ctx, cmd, ".", nil /*=stdin*/, nil /*=stdout*/)
+
+		assert.Error(t, res.Error)
+		assert.True(
+			t, status.IsNotFoundError(res.Error),
+			"expecting NOT_FOUND when executable is not found in $PATH, got: %s", res.Error)
+		assert.Equal(t, -2, res.ExitCode)
+	}
+}
+
+func TestRun_CommandNotExecutable_ErrorResult(t *testing.T) {
+	ctx := context.Background()
+	wd := testfs.MakeTempDir(t)
+	testfs.WriteAllFileContents(t, wd, map[string]string{"non_executable_file": ""})
+
+	cmd := &repb.Command{Arguments: []string{"./non_executable_file"}}
+	res := commandutil.Run(ctx, cmd, wd, nil /*=stdin*/, nil /*=stdout*/)
+
+	assert.Error(t, res.Error)
+	assert.True(
+		t, status.IsUnavailableError(res.Error),
+		"expecting UNAVAILABLE when command is not executable, got: %s", res.Error)
+	assert.Equal(t, -2, res.ExitCode)
+}
+
+func runSh(ctx context.Context, script string) *interfaces.CommandResult {
+	cmd := &repb.Command{Arguments: []string{"sh", "-c", script}}
+	return commandutil.Run(ctx, cmd, ".", nil /*=stdin*/, nil /*=stdout*/)
+}


### PR DESCRIPTION
I plan on changing some of the error handling logic in RBE so that we can retry errors caused by failing to unpause runners, and make sure we don't return runners back to the pool.

The purpose of this PR is to add some tests to demonstrate and solidify the current behavior of the system, so that it will be more clear what behavior is changing as part of this upcoming error handling PR.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
