### PR TITLE
Enable `auth.oauth_providers` flag

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -240,10 +240,10 @@ type authConfig struct {
 }
 
 type OauthProvider struct {
-	IssuerURL    string `yaml:"issuer_url" usage:"The issuer URL of this OIDC Provider."`
-	ClientID     string `yaml:"client_id" usage:"The oauth client ID."`
-	ClientSecret string `yaml:"client_secret" usage:"The oauth client secret."`
-	Slug         string `yaml:"slug" usage:"The slug of this OIDC Provider."`
+	IssuerURL    string `yaml:"issuer_url" json:"issuer_url" usage:"The issuer URL of this OIDC Provider."`
+	ClientID     string `yaml:"client_id" json:"client_id" usage:"The oauth client ID."`
+	ClientSecret string `yaml:"client_secret" json:"client_secret" usage:"The oauth client secret."`
+	Slug         string `yaml:"slug" json:"slug" usage:"The slug of this OIDC Provider."`
 }
 type SAMLConfig struct {
 	CertFile string `yaml:"cert_file" usage:"Path to a PEM encoded certificate file used for SAML auth."`
@@ -449,11 +449,6 @@ func defineFlagsForMembers(parentStructNames []string, T reflect.Value, flagSet 
 				}
 				fallthrough
 			default:
-				// We know this is not flag compatible and it's here for
-				// long-term support reasons, so don't warn about it.
-				if fqFieldName == "auth.oauth_providers" {
-					continue
-				}
 				log.Warningf("Skipping flag: --%s, kind: %s", fqFieldName, f.Type().Kind())
 			}
 		}


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Now that struct slice flags work, `auth.oauth_providers` is a valid flag as long as we give its
fields json tags, as done in this PR.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
