### PR TITLE
Add a router-aware Link component

### DIFF
--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -53,6 +53,7 @@ genrule(
         "//app/components/dialog:dialog.css",
         "//app/components/digest:digest.css",
         "//app/components/input:input.css",
+        "//app/components/link:link.css",
         "//app/components/menu:menu.css",
         "//app/components/modal:modal.css",
         "//app/components/popup:popup.css",

--- a/app/components/link/BUILD
+++ b/app/components/link/BUILD
@@ -1,0 +1,16 @@
+load("@npm//@bazel/typescript:index.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "link",
+    srcs = ["link.tsx"],
+    deps = [
+        "//app/router",
+        "@npm//@types/react",
+        "@npm//react",
+        "@npm//tslib",
+    ],
+)
+
+exports_files(["link.css"])

--- a/app/components/link/link.css
+++ b/app/components/link/link.css
@@ -1,0 +1,9 @@
+.text-link {
+  text-decoration: underline;
+  cursor: pointer;
+  color: #546e7a;
+}
+
+.text-link:hover {
+  color: #78909c;
+}

--- a/app/components/link/link.tsx
+++ b/app/components/link/link.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import router from "../../router/router";
+
+export type LinkProps = React.HTMLProps<HTMLAnchorElement>;
+
+/**
+ * `Link` renders an unstyled, router-aware `<a>` element.
+ *
+ * It handles app-internal navigation via the router, to avoid full page
+ * reloads.
+ *
+ * External links are opened in a new tab, but this behavior can be overridden
+ * by explicitly setting a `target`.
+ *
+ * It respects any `onClick` handlers registered, and invokes them before
+ * navigation. If `e.preventDefault()` is called from the registered `onClick`
+ * handler, navigation is canceled, as is the case for normal `<a>` elements.
+ */
+export const Link = React.forwardRef((props: LinkProps, ref: React.Ref<HTMLAnchorElement>) => {
+  const { className, href, onClick, ...rest } = props;
+  const isExternal = href.startsWith("http://") || href.startsWith("https://");
+  const onClickWrapped = isExternal
+    ? onClick
+    : (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+        if (onClick) {
+          onClick(e);
+          if (e.defaultPrevented) return;
+        }
+
+        e.preventDefault();
+        router.navigateTo(href);
+      };
+  const externalProps: React.HTMLProps<HTMLAnchorElement> = isExternal ? { target: "_blank" } : {};
+  return (
+    <a
+      ref={ref}
+      className={`link-wrapper ${className}`}
+      onClick={onClickWrapped}
+      href={href}
+      {...externalProps}
+      {...rest}
+    />
+  );
+});
+
+export type TextLinkProps = React.HTMLAttributes<HTMLAnchorElement>;
+
+/**
+ * TextLink renders an inline text `<Link>` with underline styling.
+ */
+export const TextLink = React.forwardRef((props: TextLinkProps, ref: React.Ref<HTMLAnchorElement>) => {
+  const { className, ...rest } = props;
+  return <Link ref={ref} className={`text-link ${className}`} {...rest} />;
+});
+
+export default Link;


### PR DESCRIPTION
Also add an inline `TextLink` component that works exactly like `<a>` but has underline styling:

![image](https://user-images.githubusercontent.com/2414826/159053261-3a486788-3add-4ee0-91a7-c3fdfefad85f.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
