### PR TITLE
Fix error handling for github import page

### DIFF
--- a/app/components/link/link.tsx
+++ b/app/components/link/link.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import router from "../../router/router";
 
-export type LinkProps = React.HTMLProps<HTMLAnchorElement>;
+export type LinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
 /**
  * `Link` renders an unstyled, router-aware `<a>` element.
@@ -43,7 +43,7 @@ export const Link = React.forwardRef((props: LinkProps, ref: React.Ref<HTMLAncho
   );
 });
 
-export type TextLinkProps = React.HTMLAttributes<HTMLAnchorElement>;
+export type TextLinkProps = LinkProps;
 
 /**
  * TextLink renders an inline text `<Link>` with underline styling.

--- a/enterprise/app/workflows/BUILD
+++ b/enterprise/app/workflows/BUILD
@@ -13,6 +13,7 @@ ts_library(
         "//app/components/button",
         "//app/components/dialog",
         "//app/components/input",
+        "//app/components/link",
         "//app/components/menu",
         "//app/components/modal",
         "//app/components/popup",

--- a/enterprise/app/workflows/github_import.tsx
+++ b/enterprise/app/workflows/github_import.tsx
@@ -7,6 +7,7 @@ import rpcService from "../../../app/service/rpc_service";
 import { BuildBuddyError } from "../../../app/util/errors";
 import { workflow } from "../../../proto/workflow_ts_proto";
 import { ArrowRight, Check, ChevronsDown } from "lucide-react";
+import { TextLink } from "../../../app/components/link/link";
 
 type GitHubRepoPickerProps = {};
 
@@ -79,7 +80,23 @@ export default class GitHubImport extends React.Component<GitHubRepoPickerProps,
 
   render() {
     if (this.state.error) {
-      return <div className="error">{this.state.error}</div>;
+      return (
+        <div className="workflows-github-import">
+          <div className="container">
+            <div className="card card-failure">
+              <div className="content">
+                <p>Error: {this.state.error.message}</p>
+                {this.state.error.code === "PermissionDenied" && (
+                  <p>
+                    You may be able to fix this error by{" "}
+                    <TextLink href="/settings/org/github">re-linking a GitHub account to your organization</TextLink>.
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      );
     }
     if (!this.state.reposResponse || !this.state.workflowsResponse) {
       return <div className="loading"></div>;


### PR DESCRIPTION
Instead of crashing the app, show this error instead:

![image](https://user-images.githubusercontent.com/2414826/159075047-32be9d89-9f92-4858-a4c4-c089044023d1.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1234
