### PR TITLE
Implement UnlinkGitHubAccount

### DIFF
--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -362,6 +362,16 @@ func (d *UserDB) InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (stri
 	return groupID, err
 }
 
+func (d *UserDB) DeleteGroupGitHubToken(ctx context.Context, groupID string) error {
+	return d.h.DB(ctx).Exec(`
+		UPDATE `+"`Groups`"+`
+		SET github_token = ""
+		WHERE group_id = ?
+		`,
+		groupID,
+	).Error
+}
+
 func (d *UserDB) AddUserToGroup(ctx context.Context, userID string, groupID string) error {
 	return d.h.Transaction(ctx, func(tx *db.DB) error {
 		existing, err := getUserGroup(tx, userID, groupID)

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -363,13 +363,11 @@ func (d *UserDB) InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (stri
 }
 
 func (d *UserDB) DeleteGroupGitHubToken(ctx context.Context, groupID string) error {
-	return d.h.DB(ctx).Exec(`
-		UPDATE `+"`Groups`"+`
-		SET github_token = ""
-		WHERE group_id = ?
-		`,
-		groupID,
-	).Error
+	q, args := query_builder.
+		NewQuery(`UPDATE `+"`Groups`"+` SET github_token = ""`).
+		AddWhereClause("group_id = ?", groupID).
+		Build()
+	return d.h.DB(ctx).Exec(q, args...).Error
 }
 
 func (d *UserDB) AddUserToGroup(ctx context.Context, userID string, groupID string) error {

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -248,10 +248,11 @@ func (ws *workflowService) DeleteWorkflow(ctx context.Context, req *wfpb.DeleteW
 }
 
 func (ws *workflowService) GetLinkedWorkflows(ctx context.Context, accessToken string) ([]string, error) {
-	rows, err := ws.env.GetDBHandle().DB(ctx).Raw(
-		`SELECT workflow_id FROM Workflows WHERE access_token = ?`,
-		accessToken,
-	).Rows()
+	q, args := query_builder.
+		NewQuery("SELECT workflow_id FROM Workflows").
+		AddWhereClause("access_token = ?", accessToken).
+		Build()
+	rows, err := ws.env.GetDBHandle().DB(ctx).Raw(q, args...).Rows()
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -247,6 +247,25 @@ func (ws *workflowService) DeleteWorkflow(ctx context.Context, req *wfpb.DeleteW
 	return &wfpb.DeleteWorkflowResponse{}, nil
 }
 
+func (ws *workflowService) GetLinkedWorkflows(ctx context.Context, accessToken string) ([]string, error) {
+	rows, err := ws.env.GetDBHandle().DB(ctx).Raw(
+		`SELECT workflow_id FROM Workflows WHERE access_token = ?`,
+		accessToken,
+	).Rows()
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for rows.Next() {
+		id := ""
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
 func (ws *workflowService) providerForRepo(u *url.URL) (interfaces.GitProvider, error) {
 	for _, provider := range ws.env.GetGitProviders() {
 		if provider.MatchRepoURL(u) {

--- a/proto/github.proto
+++ b/proto/github.proto
@@ -12,4 +12,9 @@ message UnlinkGitHubAccountRequest {
 
 message UnlinkGitHubAccountResponse {
   context.ResponseContext response_context = 1;
+
+  // Warnings encountered while unlinking the account. For example, we may fail
+  // to delete webhooks if the linked GitHub token has already been revoked via
+  // the GitHub UI.
+  repeated string warning = 2;
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -297,6 +297,7 @@ type UserDB interface {
 	RequestToJoinGroup(ctx context.Context, userID string, groupID string) error
 	GetGroupUsers(ctx context.Context, groupID string, statuses []grpb.GroupMembershipStatus) ([]*grpb.GetGroupUsersResponse_GroupUser, error)
 	UpdateGroupUsers(ctx context.Context, groupID string, updates []*grpb.UpdateGroupUsersRequest_Update) error
+	DeleteGroupGitHubToken(ctx context.Context, groupID string) error
 
 	// API Keys API
 	GetAPIKey(ctx context.Context, apiKeyID string) (*tables.APIKey, error)
@@ -345,6 +346,10 @@ type WorkflowService interface {
 	ExecuteWorkflow(ctx context.Context, req *wfpb.ExecuteWorkflowRequest) (*wfpb.ExecuteWorkflowResponse, error)
 	GetRepos(ctx context.Context, req *wfpb.GetReposRequest) (*wfpb.GetReposResponse, error)
 	ServeHTTP(w http.ResponseWriter, r *http.Request)
+
+	// GetLinkedWorkflows returns any workflows linked with the given repo access
+	// token.
+	GetLinkedWorkflows(ctx context.Context, accessToken string) ([]string, error)
 }
 
 type RunnerService interface {


### PR DESCRIPTION
* Clear `Group.github_token`
* Delete workflows registered with the GitHub token, and report any issues unregistering webhooks as warnings

This does not actually revoke app access, but just clears our references to the access token. We instead advise the user to revoke access via GitHub's UI.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
