### PR TITLE
Reuse MySQL server instances across tests

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -37,4 +37,6 @@ actions:
         branches:
           - "master"
     bazel_commands:
-      - test //... --config=workflows --test_tag_filters=+docker --build_tag_filters=+docker
+      # TODO(http://go/b/1249): Increase reliability of runner recycling when
+      # executing with high concurrency, and remove `--jobs=3`
+      - test //... --config=workflows --test_tag_filters=+docker --build_tag_filters=+docker --jobs=3

--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -42,10 +42,14 @@ go_test(
 go_test(
     name = "usage_test_mysql",
     srcs = ["usage_test.go"],
-    args = ["--testenv.use_mysql"],
+    args = [
+        "--testenv.use_mysql",
+        "--testmysql.reuse_server",
+    ],
     exec_properties = {
         "workload-isolation-type": "firecracker",
         "init-dockerd": "true",
+        "recycle-runner": "true",
     },
     shard_count = 7,
     tags = ["docker"],

--- a/server/testutil/testmysql/BUILD
+++ b/server/testutil/testmysql/BUILD
@@ -9,7 +9,6 @@ go_library(
     deps = [
         "//server/testutil/testport",
         "//server/util/log",
-        "//server/util/random",
         "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_stretchr_testify//require",
     ],

--- a/server/testutil/testmysql/testmysql.go
+++ b/server/testutil/testmysql/testmysql.go
@@ -1,22 +1,26 @@
 package testmysql
 
 import (
+	"context"
 	"database/sql"
+	"flag"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 )
 
 var (
 	targets = map[testing.TB]string{}
+
+	reuseServer = flag.Bool("testmysql.reuse_server", false, "If true, reuse mysql server between tests.")
 )
 
 // GetOrStart starts a new instance for the given test if one is not already
@@ -38,32 +42,57 @@ func GetOrStart(t testing.TB) string {
 //
 // Currently requires Docker to be available in the test execution environment.
 func Start(t testing.TB) string {
-	port := testport.FindFree(t)
-	containerNameSuffix, err := random.RandomString(8)
-	require.NoError(t, err)
-	containerName := "buildbuddy-test-mysql-" + containerNameSuffix
-
-	log.Debug("Starting mysql DB...")
-
 	const dbName = "buildbuddy-test"
-	cmd := exec.Command(
-		"docker", "run", "--rm", "--detach",
-		"--env", "MYSQL_ROOT_PASSWORD=root",
-		"--env", "MYSQL_DATABASE="+dbName,
-		"--publish", fmt.Sprintf("%d:3306", port),
-		"--name", containerName,
-		"mysql:8.0",
-	)
-	cmd.Stderr = &logWriter{"docker run mysql"}
-	err = cmd.Run()
-	require.NoError(t, err)
 
-	t.Cleanup(func() {
-		cmd := exec.Command("docker", "kill", containerName)
-		cmd.Stderr = &logWriter{"docker kill " + containerName}
+	var port int
+	if *reuseServer {
+		// List running server processes by name, and if we find one that looks
+		// like `buildbuddy-test-mysql-$PORT`, then return a connection directly
+		// to that port
+		cmd := exec.Command("docker", "ps", "--filter=name=buildbuddy-test-mysql-", "--format={{.Names}}")
+		b, err := cmd.CombinedOutput()
+		require.NoError(t, err)
+		lines := strings.Split(string(b), "\n")
+		for _, containerName := range lines {
+			if containerName == "" {
+				continue
+			}
+			var err error
+			port, err = strconv.Atoi(strings.TrimPrefix(containerName, "buildbuddy-test-mysql-"))
+			require.NoError(t, err, "failed to parse container port from %q", containerName)
+			log.Debugf("Reusing existing mysql DB container %s", containerName)
+			break
+		}
+	}
+
+	if port == 0 {
+		port = testport.FindFree(t)
+		containerName := fmt.Sprintf("buildbuddy-test-mysql-%d", port)
+
+		log.Debug("Starting mysql DB...")
+
+		cmd := exec.Command(
+			"docker", "run", "--rm", "--detach",
+			"--env", "MYSQL_ROOT_PASSWORD=root",
+			"--env", "MYSQL_DATABASE="+dbName,
+			"--publish", fmt.Sprintf("%d:3306", port),
+			"--name", containerName,
+			"mysql:8.0",
+		)
+		cmd.Stderr = &logWriter{"docker run mysql"}
 		err := cmd.Run()
 		require.NoError(t, err)
-	})
+	}
+
+	if !*reuseServer {
+		t.Cleanup(func() {
+			containerName := fmt.Sprintf("buildbuddy-test-mysql-%d", port)
+			cmd := exec.Command("docker", "kill", containerName)
+			cmd.Stderr = &logWriter{"docker kill " + containerName}
+			err := cmd.Run()
+			require.NoError(t, err)
+		})
+	}
 
 	// Wait for the DB to start up.
 	dsn := fmt.Sprintf("root:root@tcp(127.0.0.1:%d)/%s", port, dbName)
@@ -77,6 +106,20 @@ func Start(t testing.TB) string {
 			time.Sleep(100 * time.Millisecond)
 			continue
 		}
+
+		// Drop the DB from the old test and let it be re-created via GORM
+		// auto-migration.
+		if *reuseServer {
+			ctx := context.Background()
+			conn, err := db.Conn(ctx)
+			require.NoError(t, err)
+			defer conn.Close()
+			_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", dbName))
+			require.NoError(t, err)
+			_, err = conn.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE `%s`", dbName))
+			require.NoError(t, err)
+		}
+
 		return "mysql://" + dsn
 	}
 }


### PR DESCRIPTION
This gets `usage_test_mysql` running on CI in about ~6.6s total (for warm runs)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
