### PR TITLE
Make workflow invocations for public repos public

### DIFF
--- a/app/invocation/workflow_rerun_button.tsx
+++ b/app/invocation/workflow_rerun_button.tsx
@@ -66,6 +66,7 @@ export default class WorkflowRerunButton extends React.Component<WorkflowRerunBu
           targetRepoUrl: configuredEvent.targetRepoUrl,
           targetBranch: configuredEvent.targetBranch,
           clean,
+          visibility: this.props.model.buildMetadataMap.get("VISIBILITY") || "",
         })
       )
       .then((response) => router.navigateTo(`/invocation/${response.invocationId}`))

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -102,6 +102,7 @@ var (
 	workflowID                  = flag.String("workflow_id", "", "ID of the workflow associated with this CI run.")
 	actionName                  = flag.String("action_name", "", "If set, run the specified action and *only* that action, ignoring trigger conditions.")
 	invocationID                = flag.String("invocation_id", "", "If set, use the specified invocation ID for the workflow action. Ignored if action_name is not set.")
+	visibility                  = flag.String("visibility", "", "If set, use the specified value for VISIBILITY build metadata for the workflow invocation.")
 	bazelSubCommand             = flag.String("bazel_sub_command", "", "If set, run the bazel command specified by these args and ignore all triggering and configured actions.")
 	patchDigests                = flagutil.StringSlice("patch_digest", []string{}, "Digests of patches to apply to the repo after checkout. Can be specified multiple times to apply multiple patches.")
 	reportLiveRepoSetupProgress = flag.Bool("report_live_repo_setup_progress", false, "If set, repo setup output will be streamed live to the invocation instead of being postponed until the action is run.")
@@ -732,6 +733,9 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace, startTime time.T
 		buildMetadata.Metadata["ROLE"] = "CI_RUNNER"
 	} else {
 		buildMetadata.Metadata["ROLE"] = "HOSTED_BAZEL"
+	}
+	if *visibility != "" {
+		buildMetadata.Metadata["VISIBILITY"] = *visibility
 	}
 	buildMetadataEvent := &bespb.BuildEvent{
 		Id:      &bespb.BuildEventId{Id: &bespb.BuildEventId_BuildMetadata{BuildMetadata: &bespb.BuildEventId_BuildMetadataId{}}},

--- a/enterprise/server/webhooks/github/github.go
+++ b/enterprise/server/webhooks/github/github.go
@@ -119,18 +119,20 @@ func (*githubGitProvider) ParseWebhookData(r *http.Request) (*interfaces.Webhook
 			"HeadCommit.ID",
 			"Ref",
 			"Repo.CloneURL",
+			"Repo.Private",
 		)
 		if err != nil {
 			return nil, err
 		}
 		branch := strings.TrimPrefix(v["Ref"], "refs/heads/")
 		return &interfaces.WebhookData{
-			EventName:     webhook_data.EventName.Push,
-			PushedRepoURL: v["Repo.CloneURL"],
-			PushedBranch:  branch,
-			SHA:           v["HeadCommit.ID"],
-			TargetRepoURL: v["Repo.CloneURL"],
-			TargetBranch:  branch,
+			EventName:          webhook_data.EventName.Push,
+			PushedRepoURL:      v["Repo.CloneURL"],
+			PushedBranch:       branch,
+			SHA:                v["HeadCommit.ID"],
+			TargetRepoURL:      v["Repo.CloneURL"],
+			TargetBranch:       branch,
+			IsTargetRepoPublic: v["Repo.Private"] == "false",
 			// The push handler will not receive events from forked repositories,
 			// so if a commit was pushed to this repo then it is trusted.
 			IsTrusted: true,
@@ -140,11 +142,12 @@ func (*githubGitProvider) ParseWebhookData(r *http.Request) (*interfaces.Webhook
 		v, err := fieldgetter.ExtractValues(
 			event,
 			"Action",
-			"PullRequest.Base.Ref",
-			"PullRequest.Base.Repo.CloneURL",
+			"PullRequest.Head.Repo.CloneURL",
 			"PullRequest.Head.Ref",
 			"PullRequest.Head.SHA",
-			"PullRequest.Head.Repo.CloneURL",
+			"PullRequest.Base.Repo.CloneURL",
+			"PullRequest.Base.Ref",
+			"PullRequest.Base.Repo.Private",
 		)
 		if err != nil {
 			return nil, err
@@ -155,13 +158,14 @@ func (*githubGitProvider) ParseWebhookData(r *http.Request) (*interfaces.Webhook
 		}
 		isFork := v["PullRequest.Base.Repo.CloneURL"] != v["PullRequest.Head.Repo.CloneURL"]
 		return &interfaces.WebhookData{
-			EventName:     webhook_data.EventName.PullRequest,
-			PushedRepoURL: v["PullRequest.Head.Repo.CloneURL"],
-			PushedBranch:  v["PullRequest.Head.Ref"],
-			SHA:           v["PullRequest.Head.SHA"],
-			TargetRepoURL: v["PullRequest.Base.Repo.CloneURL"],
-			TargetBranch:  v["PullRequest.Base.Ref"],
-			IsTrusted:     !isFork,
+			EventName:          webhook_data.EventName.PullRequest,
+			PushedRepoURL:      v["PullRequest.Head.Repo.CloneURL"],
+			PushedBranch:       v["PullRequest.Head.Ref"],
+			SHA:                v["PullRequest.Head.SHA"],
+			TargetRepoURL:      v["PullRequest.Base.Repo.CloneURL"],
+			TargetBranch:       v["PullRequest.Base.Ref"],
+			IsTargetRepoPublic: v["PullRequest.Base.Private"] == "false",
+			IsTrusted:          !isFork,
 		}, nil
 
 	default:

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -388,6 +388,8 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 		TargetBranch:  req.GetTargetBranch(),
 		SHA:           req.GetCommitSha(),
 		IsTrusted:     req.GetTargetRepoUrl() == req.GetPushedRepoUrl(),
+		// Don't set IsTargetRepoPublic here; instead set visibility directly
+		// from build metadata.
 	}
 	invocationUUID, err := guuid.NewRandom()
 	if err != nil {
@@ -396,6 +398,7 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 	invocationID := invocationUUID.String()
 	extraCIRunnerArgs := []string{
 		fmt.Sprintf("--invocation_id=%s", invocationID),
+		fmt.Sprintf("--visibility=%s", req.GetVisibility()),
 	}
 	apiKey, err := ws.apiKeyForWorkflow(ctx, wf)
 	if err != nil {
@@ -601,6 +604,12 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 	if os == platform.DarwinOperatingSystemName && !wd.IsTrusted {
 		return nil, status.PermissionDeniedError("untrusted workflows are not supported on macOS")
 	}
+	// Make the "outer" workflow invocation public if the target repo is public,
+	// so that workflow commit status details can be seen by contributors.
+	visibility := ""
+	if wd.IsTargetRepoPublic {
+		visibility = "PUBLIC"
+	}
 	cmd := &repb.Command{
 		EnvironmentVariables: envVars,
 		Arguments: append([]string{
@@ -618,6 +627,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 			"--pushed_branch=" + wd.PushedBranch,
 			"--target_repo_url=" + wd.TargetRepoURL,
 			"--target_branch=" + wd.TargetBranch,
+			"--visibility=" + visibility,
 			"--workflow_id=" + wf.WorkflowID,
 			"--trigger_event=" + wd.EventName,
 			"--bazel_command=" + ws.ciRunnerBazelCommand(),

--- a/proto/workflow.proto
+++ b/proto/workflow.proto
@@ -154,6 +154,9 @@ message ExecuteWorkflowRequest {
   // existing workflow containers from being reused, so using this flag is not
   // encouraged.
   bool clean = 10;
+
+  // VISIBILITY build metadata used for the workflow invocation.
+  string visibility = 11;
 }
 
 message ExecuteWorkflowResponse {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -415,6 +415,10 @@ type WebhookData struct {
 	// Ex: "main"
 	TargetBranch string
 
+	// IsTargetRepoPublic reflects whether the target repo is publicly visible via
+	// the git provider.
+	IsTargetRepoPublic bool
+
 	// IsTrusted returns whether the committed code came from a trusted actor.
 	// For example, this will be true for members of the organization that owns
 	// the repo, and false for forked repositories sending pull requests to the


### PR DESCRIPTION
Set `VISIBILITY=PUBLIC` build metadata so that the "outer" workflow invocations are public for public repos.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1228
