### PR TITLE
Don't return NO_STATUS rows from TargetStatuses table

### DIFF
--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -234,7 +234,7 @@ func (t *TargetTracker) writeTestTargetStatuses(ctx context.Context, permissions
 	}
 	newTargetStatuses := make([]*tables.TargetStatus, 0)
 	for _, target := range t.targets {
-		if !isTest(target) || target.overallStatus == build_event_stream.TestStatus_NO_STATUS {
+		if !isTest(target) {
 			continue
 		}
 		newTargetStatuses = append(newTargetStatuses, &tables.TargetStatus{

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -234,7 +234,7 @@ func (t *TargetTracker) writeTestTargetStatuses(ctx context.Context, permissions
 	}
 	newTargetStatuses := make([]*tables.TargetStatus, 0)
 	for _, target := range t.targets {
-		if !isTest(target) {
+		if !isTest(target) || target.overallStatus == build_event_stream.TestStatus_NO_STATUS {
 			continue
 		}
 		newTargetStatuses = append(newTargetStatuses, &tables.TargetStatus{

--- a/server/target/target.go
+++ b/server/target/target.go
@@ -127,6 +127,7 @@ func readTargets(ctx context.Context, env environment.Env, req *trpb.GetTargetRe
                                      JOIN Invocations AS i ON ts.invocation_uuid = i.invocation_uuid`)
 	q.AddWhereClause("i.group_id = ?", req.GetRequestContext().GetGroupId())
 	q.AddWhereClause("t.group_id = ?", req.GetRequestContext().GetGroupId())
+	q.AddWhereClause("ts.status != 0")
 	// Adds user / permissions to targets (t) table.
 	if err := perms.AddPermissionsCheckToQueryWithTableAlias(ctx, env, q, "t"); err != nil {
 		return nil, err
@@ -318,5 +319,6 @@ func readPaginatedTargets(ctx context.Context, env environment.Env, req *trpb.Ge
 		FROM Targets as t
 		JOIN TargetStatuses as ts ON ts.target_id = t.target_id`)
 	q.AddJoinClause(joinQuery, "i", "ts.invocation_uuid = i.invocation_uuid")
+	q.AddWhereClause(`ts.status != 0`)
 	return fetchTargetsFromDB(ctx, env, q, repo)
 }


### PR DESCRIPTION
These NO_STATUS rows are stored when running a test with `--test_tag_filters` and test targets are matched by the pattern (e.g. `//...`) but excluded by the tag filters. For example, when running our "Docker tests" workflow we see that a NO_STATUS gets reported for all targets which aren't tagged with `docker`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1244
