### PR TITLE
Support a simple wildcard specifier in workflow config to match any branch

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1242,7 +1242,7 @@ func readConfig() (*config.BuildBuddyConfig, error) {
 	f, err := os.Open(config.FilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return config.GetDefault(*targetBranch), nil
+			return config.GetDefault(), nil
 		}
 		return nil, status.FailedPreconditionErrorf("open %q: %s", config.FilePath, err)
 	}

--- a/enterprise/server/workflow/config/BUILD
+++ b/enterprise/server/workflow/config/BUILD
@@ -10,7 +10,6 @@ go_library(
     ],
     deps = [
         "//enterprise/server/webhooks/webhook_data",
-        "@com_github_gobwas_glob//:glob",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )

--- a/enterprise/server/workflow/config/BUILD
+++ b/enterprise/server/workflow/config/BUILD
@@ -10,6 +10,7 @@ go_library(
     ],
     deps = [
         "//enterprise/server/webhooks/webhook_data",
+        "@com_github_gobwas_glob//:glob",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -56,14 +56,15 @@ func NewConfig(r io.Reader) (*BuildBuddyConfig, error) {
 }
 
 // GetDefault returns the default workflow config, which tests all targets
-// when pushing to the given target branch, sending build events to BuildBuddy.
-func GetDefault(targetBranch string) *BuildBuddyConfig {
+// when pushing or sending pull requests to merge into to any branch.
+func GetDefault() *BuildBuddyConfig {
 	return &BuildBuddyConfig{
 		Actions: []*Action{
 			{
 				Name: "Test all targets",
 				Triggers: &Triggers{
-					Push: &PushTrigger{Branches: []string{targetBranch}},
+					Push:        &PushTrigger{Branches: []string{"*"}},
+					PullRequest: &PullRequestTrigger{Branches: []string{"*"}},
 				},
 				// Note: default Bazel flags are written by the runner to ~/.bazelrc
 				BazelCommands: []string{"test //..."},
@@ -90,6 +91,9 @@ func MatchesAnyTrigger(action *Action, event, branch string) bool {
 
 func matchesAnyBranch(branches []string, branch string) bool {
 	for _, b := range branches {
+		if b == "*" {
+			return true
+		}
 		if b == branch {
 			return true
 		}

--- a/enterprise/server/workflow/config/config_test.go
+++ b/enterprise/server/workflow/config/config_test.go
@@ -34,3 +34,26 @@ func TestWorkflowConf_Parse_BasicConfig_Valid(t *testing.T) {
 		},
 	}, conf)
 }
+
+func TestMatchesAnyTrigger_SupportsBasicWildcard(t *testing.T) {
+	for _, testCase := range []struct {
+		pattern, branchName string
+		shouldMatch         bool
+	}{
+		{"main", "main", true},
+		{"main", "other", false},
+		{"*", "main", true},
+		{"*", "other", true},
+	} {
+		action := &config.Action{
+			Triggers: &config.Triggers{
+				Push: &config.PushTrigger{Branches: []string{testCase.pattern}},
+			},
+		}
+		event := "push"
+
+		match := config.MatchesAnyTrigger(action, event, testCase.branchName)
+
+		assert.Equal(t, testCase.shouldMatch, match, "expected match(%q, %q) => %v", testCase.branchName, testCase.pattern, testCase.shouldMatch)
+	}
+}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -732,7 +732,7 @@ func (ws *workflowService) fetchWorkflowConfig(ctx context.Context, gitProvider 
 	b, err := gitProvider.GetFileContents(ctx, workflow.AccessToken, webhookData.PushedRepoURL, config.FilePath, webhookData.SHA)
 	if err != nil {
 		if status.IsNotFoundError(err) {
-			return config.GetDefault(webhookData.TargetBranch), nil
+			return config.GetDefault(), nil
 		}
 		return nil, err
 	}


### PR DESCRIPTION
Support a simple wildcard character ( `*` ) to match any branch. Not supporting full regex or glob for now to avoid having to worry about performance.

This wildcard support also lets us simplify the default workflow config. Now, it can be fully static, instead of depending on the base branch.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1235
