### PR TITLE
Run trusted workflows on events from trusted forks

### DIFF
--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -634,12 +634,15 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 	}
 	if os == platform.DarwinOperatingSystemName && !wd.IsTrusted {
 		return nil, ApprovalRequired
+<<<<<<< HEAD
 	}
 	// Make the "outer" workflow invocation public if the target repo is public,
 	// so that workflow commit status details can be seen by contributors.
 	visibility := ""
 	if wd.IsTargetRepoPublic {
 		visibility = "PUBLIC"
+=======
+>>>>>>> Treat approved commit as trusted
 	}
 	cmd := &repb.Command{
 		EnvironmentVariables: envVars,

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -634,15 +634,12 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 	}
 	if os == platform.DarwinOperatingSystemName && !wd.IsTrusted {
 		return nil, ApprovalRequired
-<<<<<<< HEAD
 	}
 	// Make the "outer" workflow invocation public if the target repo is public,
 	// so that workflow commit status details can be seen by contributors.
 	visibility := ""
 	if wd.IsTargetRepoPublic {
 		visibility = "PUBLIC"
-=======
->>>>>>> Treat approved commit as trusted
 	}
 	cmd := &repb.Command{
 		EnvironmentVariables: envVars,


### PR DESCRIPTION
Run workflows as trusted whenever the PR author is a trusted member of the organization, even if the repo is a fork.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1232
