### PR TITLE
Revert change to default workflow config

### DIFF
--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -56,15 +56,21 @@ func NewConfig(r io.Reader) (*BuildBuddyConfig, error) {
 }
 
 // GetDefault returns the default workflow config, which tests all targets
-// when pushing or sending pull requests to merge into to any branch.
+// when pushing any branch.
 func GetDefault() *BuildBuddyConfig {
 	return &BuildBuddyConfig{
 		Actions: []*Action{
 			{
 				Name: "Test all targets",
 				Triggers: &Triggers{
-					Push:        &PushTrigger{Branches: []string{"*"}},
-					PullRequest: &PullRequestTrigger{Branches: []string{"*"}},
+					Push: &PushTrigger{Branches: []string{"*"}},
+
+					// TODO(bduffany): Add a PullRequest trigger to the default config
+					// once we figure out a way to prevent workflows from being run twice
+					// on each push to a PR branch. If this were enabled as-is, then we'd
+					// get one "push" event associated with the push to the PR branch, and
+					// one "pull_request" event with a "synchronized" action associated
+					// with the PR.
 				},
 				// Note: default Bazel flags are written by the runner to ~/.bazelrc
 				BazelCommands: []string{"test //..."},


### PR DESCRIPTION
Deleting a line added in https://github.com/buildbuddy-io/buildbuddy/pull/1742/files#diff-c616e5fe98c2a3744d73f798d03567de0daebc665a72adef67300c334560d748R67 because I remembered the reason why we didn't have a `PullRequest` trigger in the default config (it causes workflow actions to be triggered twice on each push to a PR branch). Reverted the change and added an explanatory comment

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
