### PR TITLE
Fix implicit any error for internal build

### DIFF
--- a/enterprise/app/settings/github_link.tsx
+++ b/enterprise/app/settings/github_link.tsx
@@ -59,14 +59,14 @@ export default class GitHubLink extends React.Component<Props, State> {
         this.setState({ deleteModalVisible: false });
         this.refreshUser();
       })
-      .catch((e) => errorService.handleError(e))
+      .catch((e: any) => errorService.handleError(e))
       .finally(() => this.setState({ isDeleting: false }));
   }
   private refreshUser() {
     this.setState({ isRefreshingUser: true });
     authService
       .refreshUser()
-      .catch((e) => errorService.handleError(e))
+      .catch((e: any) => errorService.handleError(e))
       .finally(() => this.setState({ isRefreshingUser: false }));
   }
 


### PR DESCRIPTION
For some reason, this library fails to build with `Parameter 'e' implicitly has an 'any' type.`, but only when building from the internal repo. Need to dig into why this is happening, but in the meantime this fixes the internal build.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
