### PR TITLE
Fix log redraw issues when lines are longer than the terminal width.

### DIFF
--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -15,5 +15,6 @@ go_library(
         "@com_github_go_git_go_git_v5//:go-git",
         "@com_github_go_git_go_git_v5//plumbing",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_x_sys//unix",
     ],
 )

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/metadata"
 
 	bblog "github.com/buildbuddy-io/buildbuddy/cli/logging"
@@ -185,6 +186,28 @@ func Config(path string) (*RepoConfig, error) {
 	return repoConfig, nil
 }
 
+func getTermWidth() int {
+	size, err := unix.IoctlGetWinsize(int(os.Stdout.Fd()), unix.TIOCGWINSZ)
+	if err != nil {
+		return 80
+	}
+	return int(size.Col)
+}
+
+func splitLogBuffer(buf []byte) []string {
+	var lines []string
+
+	termWidth := getTermWidth()
+	for _, line := range strings.Split(string(buf), "\n") {
+		for len(line) > termWidth {
+			lines = append(lines, line[0:termWidth])
+			line = line[termWidth:]
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
 func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) error {
 	conn, err := grpc_client.DialTarget(opts.Server)
 	if err != nil {
@@ -237,22 +260,22 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) error {
 
 		// Are we redrawing the current chunk?
 		if moveBack > 0 {
-			// TODO(vadim): fix handling of long lines
-			// we move the cursor up by the number of lines in the buffer,
-			// which may be different from the # of lines in the terminal
-			// due to wrapping.
 			consoleCursorMoveUp(moveBack)
 			consoleCursorMoveBeginningLine()
 			consoleDeleteLines(moveBack)
 		}
+
+		logLines := splitLogBuffer(l.GetBuffer())
 		if !l.GetLive() {
 			moveBack = 0
 		} else {
-			moveBack = len(strings.Split(string(l.GetBuffer()), "\n"))
+			moveBack = len(logLines)
 		}
 
-		_, _ = os.Stdout.Write(l.GetBuffer())
-		_, _ = os.Stdout.Write([]byte("\n"))
+		for _, l := range logLines {
+			_, _ = os.Stdout.Write([]byte(l))
+			_, _ = os.Stdout.Write([]byte("\n"))
+		}
 
 		if l.GetNextChunkId() == chunkID {
 			time.Sleep(1 * time.Second)


### PR DESCRIPTION
We were redrawing log chunks using the physical number of lines which
did not account for any wrapping that occurrs on the local terminal.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
