### PR TITLE
Don't check visibility when pulling any available api key for invocation

### DIFF
--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -151,7 +151,7 @@ func (d *UserDB) GetAPIKey(ctx context.Context, apiKeyID string) (*tables.APIKey
 	return key, nil
 }
 
-func (d *UserDB) GetAPIKeys(ctx context.Context, groupID string) ([]*tables.APIKey, error) {
+func (d *UserDB) GetAPIKeys(ctx context.Context, groupID string, checkVisibility bool) ([]*tables.APIKey, error) {
 	if groupID == "" {
 		return nil, status.InvalidArgumentError("Group ID cannot be empty.")
 	}
@@ -163,7 +163,7 @@ func (d *UserDB) GetAPIKeys(ctx context.Context, groupID string) ([]*tables.APIK
 
 	q := query_builder.NewQuery(`SELECT api_key_id, value, label, perms, capabilities, visible_to_developers FROM APIKeys`)
 	q.AddWhereClause("group_id = ?", groupID)
-	if err := authutil.AuthorizeGroupRole(u, groupID, role.Admin); err != nil {
+	if err := authutil.AuthorizeGroupRole(u, groupID, role.Admin); err != nil && checkVisibility {
 		q.AddWhereClause("visible_to_developers = ?", true)
 	}
 	q.SetOrderBy("label", true /*ascending*/)

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -420,7 +420,7 @@ func (s *BuildBuddyServer) GetApiKeys(ctx context.Context, req *akpb.GetApiKeysR
 	if err := perms.AuthorizeGroupAccess(ctx, s.env, groupID); err != nil {
 		return nil, err
 	}
-	tableKeys, err := userDB.GetAPIKeys(ctx, groupID)
+	tableKeys, err := userDB.GetAPIKeys(ctx, groupID, true /*checkVisibility*/)
 	if err != nil {
 		return nil, err
 	}
@@ -610,7 +610,7 @@ func (s *BuildBuddyServer) getAPIKeysForAuthorizedGroup(ctx context.Context) ([]
 	}
 	for _, allowedGroupID := range authenticatedUser.GetAllowedGroups() {
 		if allowedGroupID == groupID {
-			tableKeys, err := userDB.GetAPIKeys(ctx, groupID)
+			tableKeys, err := userDB.GetAPIKeys(ctx, groupID, true /*checkVisibility*/)
 			if err != nil {
 				return nil, err
 			}
@@ -870,7 +870,7 @@ func (s *BuildBuddyServer) getAnyAPIKeyForInvocation(ctx context.Context, invoca
 	if userDB == nil {
 		return nil, status.UnimplementedError("Not Implemented")
 	}
-	apiKeys, err := userDB.GetAPIKeys(ctx, in.GroupID)
+	apiKeys, err := userDB.GetAPIKeys(ctx, in.GroupID, false /*checkVisibility*/)
 	if err != nil {
 		return nil, err
 	}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -301,7 +301,7 @@ type UserDB interface {
 
 	// API Keys API
 	GetAPIKey(ctx context.Context, apiKeyID string) (*tables.APIKey, error)
-	GetAPIKeys(ctx context.Context, groupID string) ([]*tables.APIKey, error)
+	GetAPIKeys(ctx context.Context, groupID string, checkVisibility bool) ([]*tables.APIKey, error)
 	CreateAPIKey(ctx context.Context, groupID string, label string, capabilities []akpb.ApiKey_Capability, visibleToDevelopers bool) (*tables.APIKey, error)
 	UpdateAPIKey(ctx context.Context, key *tables.APIKey) error
 	DeleteAPIKey(ctx context.Context, apiKeyID string) error


### PR DESCRIPTION
Fixes issue where developers can't view timing profiles.

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
