### PR TITLE
Use type parameters for component props and state

### DIFF
--- a/app/docs/setup_code.tsx
+++ b/app/docs/setup_code.tsx
@@ -8,11 +8,11 @@ import rpcService from "../service/rpc_service";
 import router from "../router/router";
 
 interface Props {
-  bazelConfigResponse?: bazel_config.GetBazelConfigResponse;
+  bazelConfigResponse?: bazel_config.IGetBazelConfigResponse;
 }
 
 interface State {
-  bazelConfigResponse: bazel_config.GetBazelConfigResponse;
+  bazelConfigResponse: bazel_config.IGetBazelConfigResponse;
   user: User;
   selectedCredentialIndex: number;
 
@@ -23,8 +23,7 @@ interface State {
   executionChecked: boolean;
 }
 
-export default class SetupCodeComponent extends React.Component {
-  props: Props;
+export default class SetupCodeComponent extends React.Component<Props, State> {
   state: State = {
     bazelConfigResponse: null,
     selectedCredentialIndex: 0,
@@ -59,7 +58,7 @@ export default class SetupCodeComponent extends React.Component {
     }
   }
 
-  setConfigResponse(response: bazel_config.GetBazelConfigResponse) {
+  setConfigResponse(response: bazel_config.IGetBazelConfigResponse) {
     this.setState({ bazelConfigResponse: response, selectedCredentialIndex: 0 });
   }
 
@@ -70,33 +69,38 @@ export default class SetupCodeComponent extends React.Component {
     return response.credential[index] || null;
   }
 
-  handleInputChange(event: any) {
-    const target = event.target;
+  handleInputChange(event: React.ChangeEvent) {
+    const target = event.target as HTMLInputElement;
     const name = target.name;
     this.setState({
       [name]: target.value,
-    });
+    } as Record<keyof State, any>);
   }
 
-  handleCheckboxChange(event: any) {
-    const target = event.target;
+  handleCheckboxChange(event: React.ChangeEvent) {
+    const target = event.target as HTMLInputElement;
     const name = target.name;
     this.setState({
       [name]: target.checked,
-    });
+    } as Record<keyof State, any>);
   }
 
   getResultsUrl() {
-    return this.state.bazelConfigResponse?.configOption.find((option: any) => option.flagName == "bes_results_url")
-      ?.body;
+    return this.state.bazelConfigResponse?.configOption.find(
+      (option: bazel_config.IConfigOption) => option.flagName == "bes_results_url"
+    )?.body;
   }
 
   getEventStream() {
-    return this.state.bazelConfigResponse?.configOption.find((option: any) => option.flagName == "bes_backend")?.body;
+    return this.state.bazelConfigResponse?.configOption.find(
+      (option: bazel_config.IConfigOption) => option.flagName == "bes_backend"
+    )?.body;
   }
 
   getCache() {
-    return this.state.bazelConfigResponse?.configOption.find((option: any) => option.flagName == "remote_cache")?.body;
+    return this.state.bazelConfigResponse?.configOption.find(
+      (option: bazel_config.IConfigOption) => option.flagName == "remote_cache"
+    )?.body;
   }
 
   getCacheOptions() {
@@ -122,8 +126,9 @@ export default class SetupCodeComponent extends React.Component {
   }
 
   getRemoteExecution() {
-    return this.state.bazelConfigResponse?.configOption?.find((option: any) => option.flagName == "remote_executor")
-      ?.body;
+    return this.state.bazelConfigResponse?.configOption?.find(
+      (option: bazel_config.IConfigOption) => option.flagName == "remote_executor"
+    )?.body;
   }
 
   getCredentials() {
@@ -156,14 +161,20 @@ export default class SetupCodeComponent extends React.Component {
 
   isCacheEnabled() {
     return Boolean(
-      this.state.bazelConfigResponse?.configOption.find((option: any) => option.flagName == "remote_cache")
+      this.state.bazelConfigResponse?.configOption.find(
+        (option: bazel_config.IConfigOption) => option.flagName == "remote_cache"
+      )
     );
   }
 
   isExecutionEnabled() {
     return (
       (this.isAuthenticated() || !capabilities.auth) &&
-      Boolean(this.state.bazelConfigResponse?.configOption.find((option: any) => option.flagName == "remote_executor"))
+      Boolean(
+        this.state.bazelConfigResponse?.configOption.find(
+          (option: bazel_config.IConfigOption) => option.flagName == "remote_executor"
+        )
+      )
     );
   }
 

--- a/app/invocation/dense/dense_invocation_overview.tsx
+++ b/app/invocation/dense/dense_invocation_overview.tsx
@@ -9,9 +9,7 @@ interface Props {
   model: InvocationModel;
   invocationId: string;
 }
-export default class DenseInvocationOverviewComponent extends React.Component {
-  props: Props;
-
+export default class DenseInvocationOverviewComponent extends React.Component<Props> {
   handleUserClicked() {
     router.navigateToUserHistory(this.props.model.getUser(false));
   }

--- a/app/invocation/invocation_cache_card.tsx
+++ b/app/invocation/invocation_cache_card.tsx
@@ -10,9 +10,7 @@ interface Props {
 
 const BITS_PER_BYTE = 8;
 
-export default class CacheCardComponent extends React.Component {
-  props: Props;
-
+export default class CacheCardComponent extends React.Component<Props> {
   render() {
     return (
       <div className="card">

--- a/app/invocation/invocation_details_card.tsx
+++ b/app/invocation/invocation_details_card.tsx
@@ -16,9 +16,7 @@ interface State {
 
 const defaultPageSize = 1;
 
-export default class ArtifactsCardComponent extends React.Component {
-  props: Props;
-
+export default class ArtifactsCardComponent extends React.Component<Props, State> {
   state: State = {
     limit: defaultPageSize,
   };

--- a/app/invocation/invocation_error_card.tsx
+++ b/app/invocation/invocation_error_card.tsx
@@ -6,9 +6,7 @@ interface Props {
   model: InvocationModel;
 }
 
-export default class ErrorCardComponent extends React.Component {
-  props: Props;
-
+export default class ErrorCardComponent extends React.Component<Props> {
   render() {
     return (
       <div className="card card-failure">

--- a/app/invocation/invocation_execution_card.tsx
+++ b/app/invocation/invocation_execution_card.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 interface State {
   loading: boolean;
-  executions: execution_stats.Execution[];
+  executions: execution_stats.IExecution[];
   sort: string;
   direction: "asc" | "desc";
   statusFilter: string;
@@ -45,7 +45,7 @@ const GRPC_STATUS_LABEL_BY_CODE: Record<number, string> = Object.fromEntries(
   Object.entries(google.rpc.Code).map(([name, value]) => [value, name])
 );
 
-function getExecutionStatus(execution: execution_stats.Execution): ExecutionStatus {
+function getExecutionStatus(execution: execution_stats.IExecution): ExecutionStatus {
   if (execution.stage === ExecutionStage.Value.COMPLETED) {
     if (execution.status.code !== 0) {
       return {
@@ -65,9 +65,7 @@ function getExecutionStatus(execution: execution_stats.Execution): ExecutionStat
   return STATUSES_BY_STAGE[execution.stage];
 }
 
-export default class ExecutionCardComponent extends React.Component {
-  props: Props;
-
+export default class ExecutionCardComponent extends React.Component<Props, State> {
   state: State = {
     executions: [],
     loading: true,
@@ -126,42 +124,42 @@ export default class ExecutionCardComponent extends React.Component {
     return microsA - microsB;
   }
 
-  totalDuration(execution: execution_stats.Execution) {
+  totalDuration(execution: execution_stats.IExecution) {
     return this.subtractTimestamp(
       execution?.executedActionMetadata?.workerCompletedTimestamp,
       execution?.executedActionMetadata?.queuedTimestamp
     );
   }
 
-  queuedDuration(execution: execution_stats.Execution) {
+  queuedDuration(execution: execution_stats.IExecution) {
     return this.subtractTimestamp(
       execution?.executedActionMetadata?.workerStartTimestamp,
       execution?.executedActionMetadata?.queuedTimestamp
     );
   }
 
-  downloadDuration(execution: execution_stats.Execution) {
+  downloadDuration(execution: execution_stats.IExecution) {
     return this.subtractTimestamp(
       execution?.executedActionMetadata?.inputFetchCompletedTimestamp,
       execution?.executedActionMetadata?.inputFetchStartTimestamp
     );
   }
 
-  executionDuration(execution: execution_stats.Execution) {
+  executionDuration(execution: execution_stats.IExecution) {
     return this.subtractTimestamp(
       execution?.executedActionMetadata?.executionCompletedTimestamp,
       execution?.executedActionMetadata?.executionStartTimestamp
     );
   }
 
-  uploadDuration(execution: execution_stats.Execution) {
+  uploadDuration(execution: execution_stats.IExecution) {
     return this.subtractTimestamp(
       execution?.executedActionMetadata?.outputUploadCompletedTimestamp,
       execution?.executedActionMetadata?.outputUploadStartTimestamp
     );
   }
 
-  sort(a: execution_stats.Execution, b: execution_stats.Execution) {
+  sort(a: execution_stats.IExecution, b: execution_stats.IExecution) {
     let first = this.state.direction == "asc" ? a : b;
     let second = this.state.direction == "asc" ? b : a;
 
@@ -218,27 +216,27 @@ export default class ExecutionCardComponent extends React.Component {
     }
   }
 
-  handleInputChange(event: any) {
-    const target = event.target;
+  handleInputChange(event: React.ChangeEvent) {
+    const target = event.target as HTMLInputElement;
     const name = target.name;
     this.setState({
       [name]: target.value,
-    });
+    } as Record<keyof State, any>);
   }
 
-  handleSortChange(event: any) {
+  handleSortChange(event: React.ChangeEvent) {
     this.setState({
-      sort: event.target.value,
+      sort: (event.target as HTMLInputElement).value,
     });
   }
 
-  handleStatusFilterChange(event: any) {
+  handleStatusFilterChange(event: React.ChangeEvent) {
     this.setState({
-      statusFilter: event.target.value,
+      statusFilter: (event.target as HTMLInputElement).value,
     });
   }
 
-  handleActionDigestClick(execution: execution_stats.Execution) {
+  handleActionDigestClick(execution: execution_stats.IExecution) {
     let path =
       "/invocation/" +
       this.props.model.getId() +

--- a/app/invocation/invocation_fetch_card.tsx
+++ b/app/invocation/invocation_fetch_card.tsx
@@ -11,9 +11,7 @@ interface State {
   loading: boolean;
 }
 
-export default class FetchCardComponent extends React.Component {
-  props: Props;
-
+export default class FetchCardComponent extends React.Component<Props, State> {
   state: State = {
     loading: false,
   };

--- a/app/invocation/invocation_filter.tsx
+++ b/app/invocation/invocation_filter.tsx
@@ -8,9 +8,7 @@ interface Props {
   placeholder?: string;
 }
 
-export default class InvocationFilterComponent extends React.Component {
-  props: Props;
-
+export default class InvocationFilterComponent extends React.Component<Props> {
   handleFilterChange(event: any) {
     let value = event.target.value;
     let params = {};

--- a/app/invocation/invocation_in_progress.tsx
+++ b/app/invocation/invocation_in_progress.tsx
@@ -4,9 +4,7 @@ interface Props {
   invocationId: string;
 }
 
-export default class InvocationInProgressComponent extends React.Component {
-  props: Props;
-
+export default class InvocationInProgressComponent extends React.Component<Props> {
   render() {
     return (
       <div className="state-page">

--- a/app/invocation/invocation_not_found.tsx
+++ b/app/invocation/invocation_not_found.tsx
@@ -13,9 +13,7 @@ interface Props {
   user?: User;
 }
 
-export default class InvocationNotFoundComponent extends React.Component {
-  props: Props;
-
+export default class InvocationNotFoundComponent extends React.Component<Props> {
   handleLoginClicked() {
     authService.login();
   }

--- a/app/invocation/invocation_overview.tsx
+++ b/app/invocation/invocation_overview.tsx
@@ -29,9 +29,7 @@ interface Props {
   invocationId: string;
   user?: User;
 }
-export default class InvocationOverviewComponent extends React.Component {
-  props: Props;
-
+export default class InvocationOverviewComponent extends React.Component<Props> {
   handleOrganizationClicked() {
     router.navigateHome();
   }

--- a/app/invocation/invocation_raw_logs_card.tsx
+++ b/app/invocation/invocation_raw_logs_card.tsx
@@ -14,9 +14,7 @@ interface State {
   filterString: string;
 }
 
-export default class RawLogsCardComponent extends React.Component {
-  props: Props;
-
+export default class RawLogsCardComponent extends React.Component<Props, State> {
   state: State = {
     expandedMap: new Map<Long, boolean>(),
     numPages: 1,

--- a/app/invocation/invocation_targets.tsx
+++ b/app/invocation/invocation_targets.tsx
@@ -11,9 +11,7 @@ interface Props {
   mode: string;
 }
 
-export default class TargetsComponent extends React.Component {
-  props: Props;
-
+export default class TargetsComponent extends React.Component<Props> {
   render() {
     return (
       <div>

--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -45,9 +45,7 @@ const sortByDurationDescStorageValue = "duration-desc";
 const groupByThreadStorageValue = "thread";
 const groupByAllStorageValue = "all";
 
-export default class InvocationTimingCardComponent extends React.Component {
-  props: Props;
-
+export default class InvocationTimingCardComponent extends React.Component<Props, State> {
   state: State = {
     threadNumPages: 1,
     threadToNumEventPagesMap: new Map<number, number>(),
@@ -78,7 +76,7 @@ export default class InvocationTimingCardComponent extends React.Component {
     let profileFile = this.props.model.buildToolLogs?.log.find((log: any) => log.uri);
 
     if (!profileFile?.uri) {
-      const hasBuildToolLogs = this.props.model.buildToolLogs;
+      const hasBuildToolLogs = Boolean(this.props.model.buildToolLogs);
       this.setState({
         ...this.state,
         buildInProgress: !hasBuildToolLogs,

--- a/app/menu/menu.tsx
+++ b/app/menu/menu.tsx
@@ -15,9 +15,7 @@ interface State {
   menuExpanded: boolean;
 }
 
-export default class MenuComponent extends React.Component {
-  props: Props;
-
+export default class MenuComponent extends React.Component<Props, State> {
   state: State = {
     menuExpanded: false,
   };

--- a/app/target/action_card.tsx
+++ b/app/target/action_card.tsx
@@ -20,9 +20,7 @@ interface State {
   loadingStderr: boolean;
 }
 
-export default class ActionCardComponent extends React.Component {
-  props: Props;
-
+export default class ActionCardComponent extends React.Component<Props, State> {
   state: State = {
     stdErr: "",
     stdOut: "",
@@ -69,7 +67,7 @@ export default class ActionCardComponent extends React.Component {
       .catch(() => {
         this.setState({
           ...this.state,
-          testLog: "Error loading bytestream stderr!",
+          stdErr: "Error loading bytestream stderr!",
         });
       });
   }
@@ -92,14 +90,14 @@ export default class ActionCardComponent extends React.Component {
       .then((contents: string) => {
         this.setState({
           ...this.state,
-          stdout: contents,
+          stdOut: contents,
           loadingStdout: false,
         });
       })
       .catch(() => {
         this.setState({
           ...this.state,
-          testLog: "Error loading bytestream stdout!",
+          stdErr: "Error loading bytestream stdout!",
         });
       });
   }

--- a/app/target/target.tsx
+++ b/app/target/target.tsx
@@ -30,9 +30,7 @@ interface Props {
   dark: boolean;
 }
 
-export default class TargetComponent extends React.Component {
-  props: Props;
-
+export default class TargetComponent extends React.Component<Props> {
   componentWillMount() {
     document.title = `Target ${this.props.invocationId} | BuildBuddy`;
   }

--- a/app/target/target_artifacts_card.tsx
+++ b/app/target/target_artifacts_card.tsx
@@ -9,9 +9,7 @@ interface Props {
   invocationId: string;
 }
 
-export default class TargetArtifactsCardComponent extends React.Component {
-  props: Props;
-
+export default class TargetArtifactsCardComponent extends React.Component<Props> {
   handleArtifactClicked(outputUri: string, outputFilename: string, event: MouseEvent) {
     event.preventDefault();
     if (!outputUri) return false;

--- a/app/target/target_log_card.tsx
+++ b/app/target/target_log_card.tsx
@@ -8,9 +8,7 @@ interface Props {
   dark: boolean;
 }
 
-export default class TargetLogCardComponent extends React.Component {
-  props: Props;
-
+export default class TargetLogCardComponent extends React.Component<Props> {
   render() {
     return (
       <div className={`card ${this.props.dark ? "dark" : "light-terminal"}`}>

--- a/app/target/target_test_cases_card.tsx
+++ b/app/target/target_test_cases_card.tsx
@@ -9,9 +9,7 @@ interface Props {
   tagName?: string;
 }
 
-export default class TargetTestCasesCardComponent extends React.Component {
-  props: Props;
-
+export default class TargetTestCasesCardComponent extends React.Component<Props> {
   getStatusTitle() {
     switch (this.props.tagName) {
       case "failure":

--- a/app/target/target_test_document_card.tsx
+++ b/app/target/target_test_document_card.tsx
@@ -17,9 +17,7 @@ interface State {
   cacheEnabled: boolean;
 }
 
-export default class TargetTestDocumentCardComponent extends React.Component {
-  props: Props;
-
+export default class TargetTestDocumentCardComponent extends React.Component<Props> {
   state: State = {
     testLog: "",
     testDocument: null,

--- a/app/target/target_test_log_card.tsx
+++ b/app/target/target_test_log_card.tsx
@@ -19,9 +19,7 @@ interface State {
   loading: boolean;
 }
 
-export default class TargetTestLogCardComponent extends React.Component {
-  props: Props;
-
+export default class TargetTestLogCardComponent extends React.Component<Props, State> {
   state: State = {
     testLog: "",
     cacheEnabled: true,

--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -58,9 +58,7 @@ const LOCAL_STORAGE_STATE_KEY = "code-state-v1";
 // TODO(siggisim): Add links to the code editor from anywhere we reference a repo
 // TODO(siggisim): Add branch / workspace selection
 // TODO(siggisim): Add some form of search
-export default class CodeComponent extends React.Component<Props> {
-  props: Props;
-
+export default class CodeComponent extends React.Component<Props, State> {
   state: State = {
     commitSHA: "",
     repoResponse: undefined,
@@ -617,7 +615,7 @@ export default class CodeComponent extends React.Component<Props> {
   }
 
   updateState(newState: Partial<State>, callback?: VoidFunction) {
-    this.setState(newState, () => {
+    this.setState(newState as State, () => {
       this.saveState();
       if (callback) {
         callback();

--- a/enterprise/app/history/history_tabs.tsx
+++ b/enterprise/app/history/history_tabs.tsx
@@ -4,9 +4,7 @@ interface Props {
   hash: string;
 }
 
-export default class HistoryTabsComponent extends React.Component {
-  props: Props;
-
+export default class HistoryTabsComponent extends React.Component<Props> {
   render() {
     return (
       <div className="tabs">

--- a/enterprise/app/login/login.tsx
+++ b/enterprise/app/login/login.tsx
@@ -19,8 +19,6 @@ interface Props {
 }
 
 export default class LoginComponent extends React.Component<Props, State> {
-  props: Props;
-
   state: State = {
     showSSO: false,
     defaultToSSO: false,

--- a/enterprise/app/sidebar/sidebar.tsx
+++ b/enterprise/app/sidebar/sidebar.tsx
@@ -37,9 +37,7 @@ interface State {
   profileExpanded: boolean;
 }
 
-export default class SidebarComponent extends React.Component {
-  props: Props;
-
+export default class SidebarComponent extends React.Component<Props, State> {
   state: State = {
     profileExpanded: false,
   };

--- a/enterprise/app/trends/cache_chart.tsx
+++ b/enterprise/app/trends/cache_chart.tsx
@@ -38,9 +38,7 @@ const CacheChartTooltip = ({ active, payload, labelFormatter, extractHits, extra
   return null;
 };
 
-export default class CacheChartComponent extends React.Component {
-  props: Props;
-
+export default class CacheChartComponent extends React.Component<Props> {
   render() {
     return (
       <div className="trend-chart">

--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -33,8 +33,6 @@ interface State {
 const SECONDS_PER_MICROSECOND = 1e-6;
 
 export default class TrendsComponent extends React.Component<Props, State> {
-  props: Props;
-
   state: State = {
     stats: [],
     loading: true,

--- a/enterprise/app/trends/trends_chart.tsx
+++ b/enterprise/app/trends/trends_chart.tsx
@@ -66,9 +66,7 @@ const TrendsChartTooltip = ({
   return null;
 };
 
-export default class TrendsChartComponent extends React.Component {
-  props: Props;
-
+export default class TrendsChartComponent extends React.Component<Props> {
   render() {
     const hasSecondaryAxis = this.props.extractSecondaryValue && this.props.separateAxis;
     return (


### PR DESCRIPTION
Motivation:
* Specifying `props: Props` instead of `React.Component<Props>` prevents the compiler from understanding the expected types of `shouldComponentUpdate` and other lifecycle methods, which can be helpful for catching certain types of bugs. See https://codesandbox.io/s/withered-fog-pq8o3x?file=/src/App.tsx
* Specifying `props: Props` is also incompatible with TS `strict` mode, which would be nice to enable at some point (for better null-safety, etc.)
* When not using type parameters for `State`, the compiler is unable to detect issues with `this.setState`. See https://codesandbox.io/s/dazzling-taussig-0r4s1y?file=/src/App.tsx:0-339

This PR refactors

```
class Foo extends React.Component {
  props: Props;
  state: State = { ... };
}
```

to

```
class Foo extends React.Component<Props, State> {
  state: State = { ... }
}
```

and fix any compile-time errors that result from the change.

The only real bugs caught by this refactoring were in `action_card.tsx`, and the remaining build errors are fixed by fiddling with types to make the compiler happy.

Unfortunately `this.setState` requires some awkward casting in a few places, and there is not really a good workaround -- https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365 has more context

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
