### PR TITLE
Include workflow action name in runner routing key

### DIFF
--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -60,15 +60,15 @@ func generateWebhookID() (string, error) {
 	return strings.ToLower(u.String()), nil
 }
 
-func instanceName(wf *tables.Workflow, wd *interfaces.WebhookData, actionName string) string {
-	// Use a unique remote instance name per repo URL and action name, to help
+func instanceName(wf *tables.Workflow, wd *interfaces.WebhookData, workflowActionName string) string {
+	// Use a unique remote instance name per repo URL and workflow action name, to help
 	// route workflow tasks to runners which previously executed the same workflow
 	// action.
 	//
 	// Instance name suffix is additionally used to effectively invalidate all
 	// existing runners for the workflow and cause subsequent workflows to be run
 	// from a clean runner.
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(wd.PushedRepoURL+actionName+wf.InstanceNameSuffix)))
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(wd.PushedRepoURL+workflowActionName+wf.InstanceNameSuffix)))
 }
 
 type workflowService struct {


### PR DESCRIPTION
This allows workflow actions to use different build configurations (e.g. `--define` flags) without discarding the analysis cache for other workflow actions. It also allows actions to run `bazel clean` as the first `bazel_command` without affecting the bazel cache from other actions.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1251
