### PR TITLE
Add types for ChangeEvent handlers

### DIFF
--- a/app/docs/setup_code.tsx
+++ b/app/docs/setup_code.tsx
@@ -69,16 +69,16 @@ export default class SetupCodeComponent extends React.Component<Props, State> {
     return response.credential[index] || null;
   }
 
-  handleInputChange(event: React.ChangeEvent) {
-    const target = event.target as HTMLInputElement;
+  handleInputChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const target = event.target;
     const name = target.name;
     this.setState({
       [name]: target.value,
     } as Record<keyof State, any>);
   }
 
-  handleCheckboxChange(event: React.ChangeEvent) {
-    const target = event.target as HTMLInputElement;
+  handleCheckboxChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const target = event.target;
     const name = target.name;
     this.setState({
       [name]: target.checked,

--- a/app/invocation/invocation_execution_card.tsx
+++ b/app/invocation/invocation_execution_card.tsx
@@ -216,23 +216,23 @@ export default class ExecutionCardComponent extends React.Component<Props, State
     }
   }
 
-  handleInputChange(event: React.ChangeEvent) {
-    const target = event.target as HTMLInputElement;
+  handleInputChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const target = event.target;
     const name = target.name;
     this.setState({
       [name]: target.value,
     } as Record<keyof State, any>);
   }
 
-  handleSortChange(event: React.ChangeEvent) {
+  handleSortChange(event: React.ChangeEvent<HTMLInputElement>) {
     this.setState({
-      sort: (event.target as HTMLInputElement).value,
+      sort: event.target.value,
     });
   }
 
-  handleStatusFilterChange(event: React.ChangeEvent) {
+  handleStatusFilterChange(event: React.ChangeEvent<HTMLInputElement>) {
     this.setState({
-      statusFilter: (event.target as HTMLInputElement).value,
+      statusFilter: event.target.value,
     });
   }
 

--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -557,13 +557,13 @@ export default class CodeComponent extends React.Component<Props, State> {
       });
   }
 
-  onTitleChange(e: React.ChangeEvent) {
-    const input = e.target as HTMLInputElement;
+  onTitleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const input = e.target;
     this.updateState({ prTitle: input.value });
   }
 
-  onBodyChange(e: React.ChangeEvent) {
-    const input = e.target as HTMLInputElement;
+  onBodyChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const input = e.target;
     this.updateState({ prBody: input.value });
   }
 

--- a/enterprise/app/org/create_org.tsx
+++ b/enterprise/app/org/create_org.tsx
@@ -23,7 +23,7 @@ export default class CreateOrgComponent extends OrgForm<grp.CreateGroupRequest> 
     router.navigateTo(Path.settingsPath);
   }
 
-  onChangeName(e: React.ChangeEvent) {
+  onChangeName(e: React.ChangeEvent<HTMLInputElement>) {
     const { name, value } = getChangedFormState(e);
     // Auto-populate the slug field from the opg name if the slug field
     // hasn't yet been touched (we don't want to modify any existing input

--- a/enterprise/app/org/org_form.tsx
+++ b/enterprise/app/org/org_form.tsx
@@ -58,14 +58,14 @@ export default abstract class OrgForm<T extends GroupRequest> extends React.Comp
     const name = (e.target as HTMLInputElement).name;
     this.setState({ touched: new Set([...this.state.touched, name]) });
   }
-  onChange(e: React.ChangeEvent) {
+  onChange(e: React.ChangeEvent<HTMLInputElement>) {
     const { name, value } = getChangedFormState(e);
     this.setFieldValue(name, value);
   }
-  onChangeName(e: React.ChangeEvent) {
+  onChangeName(e: React.ChangeEvent<HTMLInputElement>) {
     return this.onChange(e);
   }
-  onChangeUrlIdentifier(e: React.ChangeEvent) {
+  onChangeUrlIdentifier(e: React.ChangeEvent<HTMLInputElement>) {
     const { name, value } = getChangedFormState(e);
     this.setFieldValue(name, makeSlug(value as string));
   }
@@ -178,8 +178,8 @@ export default abstract class OrgForm<T extends GroupRequest> extends React.Comp
   }
 }
 
-export function getChangedFormState(changeEvent: React.ChangeEvent) {
-  const input = changeEvent.target as HTMLInputElement;
+export function getChangedFormState(changeEvent: React.ChangeEvent<HTMLInputElement>) {
+  const input = changeEvent.target;
 
   const name = input.name;
   const value = input.type === "checkbox" ? input.checked : input.value;

--- a/enterprise/app/org/org_members.tsx
+++ b/enterprise/app/org/org_members.tsx
@@ -117,8 +117,8 @@ export default class OrgMembersComponent extends React.Component<OrgMembersProps
 
     this.setState({ isEditRoleModalVisible: false });
   }
-  private onChangeRoleToApply(event: React.ChangeEvent) {
-    const roleToApply = Number((event.target as HTMLSelectElement).value) as grp.Group.Role;
+  private onChangeRoleToApply(event: React.ChangeEvent<HTMLSelectElement>) {
+    const roleToApply = Number(event.target.value) as grp.Group.Role;
     this.setState({ roleToApply });
   }
   private onClickApplyRoleEdits() {

--- a/enterprise/app/usage/usage.tsx
+++ b/enterprise/app/usage/usage.tsx
@@ -35,8 +35,8 @@ export default class UsageComponent extends React.Component<UsageProps, State> {
       .finally(() => this.setState({ loading: false }));
   }
 
-  private onChangePeriod(e: React.ChangeEvent) {
-    const selectedPeriod = (e.target as HTMLOptionElement).value;
+  private onChangePeriod(e: React.ChangeEvent<HTMLSelectElement>) {
+    const selectedPeriod = e.target.value;
     this.setState({ selectedPeriod });
   }
 


### PR DESCRIPTION
My commit to address feedback in https://github.com/buildbuddy-io/buildbuddy/pull/1753 didn't make it through since GitHub was having issues, and I didn't notice that the push failed :sweat_smile: 

Fixing other `ChangeEvent` instances in this PR as well 

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
