### PR TITLE
Fix number formatting of test durations

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -509,7 +509,7 @@ export default class InvocationModel {
     let testResult = this.testSummaryMap.get(label)?.buildEvent.testSummary;
     if (testResult) {
       let durationMillis = durationToMillisWithFallback(testResult.totalRunDuration, testResult.totalRunDurationMillis);
-      return durationMillis / 1000 + " seconds";
+      return (durationMillis / 1000).toFixed(3) + " seconds";
     }
     return (
       this.getDuration(this.completedMap.get(label)?.eventTime, this.configuredMap.get(label)?.eventTime) + " seconds"


### PR DESCRIPTION
Use `toFixed(3)` for test times to be consistent with build times, and so that the decimal points line up and times can be more easily compared.

Before:
![image](https://user-images.githubusercontent.com/2414826/159731301-45593f9a-e733-450d-bfd1-432006fdcd34.png)

After:
![image](https://user-images.githubusercontent.com/2414826/159731395-67e7a2b7-d2bd-46da-bb56-ab59223df4ee.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->
