### PR TITLE
Speed up remote bazel checkouts when base commit doesn't change.

### DIFF
--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -297,10 +297,6 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) error {
 			return status.UnknownErrorf("error streaming logs: %s", err)
 		}
 
-		if l.GetNextChunkId() == "" {
-			break
-		}
-
 		chunks = append(chunks, l)
 		// If the current chunk was live but is no longer then delay redraw
 		// until the next chunk is retrieved. The "volatile" part of the
@@ -315,6 +311,10 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) error {
 			chunks = nil
 		}
 		wasLive = l.GetLive()
+
+		if l.GetNextChunkId() == "" {
+			break
+		}
 
 		if l.GetNextChunkId() == chunkID {
 			time.Sleep(1 * time.Second)

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -99,6 +99,7 @@ var (
 	commitSHA          = flag.String("commit_sha", "", "Commit SHA to report statuses for.")
 	targetRepoURL      = flag.String("target_repo_url", "", "URL of the target repo.")
 	targetBranch       = flag.String("target_branch", "", "Branch to check action triggers against.")
+	targetCommitSHA    = flag.String("target_commit_sha", "", "If set, target repo URL is checked out at the given commit instead of the tip of the branch.")
 	workflowID         = flag.String("workflow_id", "", "ID of the workflow associated with this CI run.")
 	actionName         = flag.String("action_name", "", "If set, run the specified action and *only* that action, ignoring trigger conditions.")
 	invocationID       = flag.String("invocation_id", "", "If set, use the specified invocation ID for the workflow action. Ignored if action_name is not set.")
@@ -989,22 +990,43 @@ func (ws *workspace) sync(ctx context.Context) error {
 	// "base" here is referring to the repo on which the workflow is configured.
 	// "fork" is referring to the forked repo, if the runner was triggered by a
 	// PR from a fork (forkBranches will be empty otherwise).
-	baseBranches := []string{*targetBranch}
+	baseRefs := []string{}
+	if *targetBranch != "" {
+		baseRefs = append(baseRefs, *targetBranch)
+	}
 	forkBranches := []string{}
 	// Add the pushed branch to the appropriate list corresponding to the remote
 	// to be fetched (base or fork).
-	if isPushedBranchInFork := *pushedRepoURL != *targetRepoURL; isPushedBranchInFork {
-		forkBranches = append(forkBranches, *pushedBranch)
-	} else if *pushedBranch != *targetBranch {
-		baseBranches = append(baseBranches, *pushedBranch)
+	if *pushedRepoURL != "" {
+		if isPushedBranchInFork := *pushedRepoURL != *targetRepoURL; isPushedBranchInFork {
+			forkBranches = append(forkBranches, *pushedBranch)
+		} else if *pushedBranch != *targetBranch {
+			baseRefs = append(baseRefs, *pushedBranch)
+		}
 	}
 	// TODO: Fetch from remotes in parallel
-	if err := ws.fetch(ctx, *targetRepoURL, baseBranches); err != nil {
-		return err
-	}
 	if err := ws.fetch(ctx, *pushedRepoURL, forkBranches); err != nil {
 		return err
 	}
+	if err := ws.fetch(ctx, *targetRepoURL, baseRefs); err != nil {
+		return err
+	}
+
+	checkoutRef := ""
+	checkoutLocalBranchName := ""
+	if *pushedRepoURL != "" {
+		checkoutRef = fmt.Sprintf("%s/%s", gitRemoteName(*pushedRepoURL), *pushedBranch)
+		checkoutLocalBranchName = *pushedBranch
+	} else {
+		if *targetBranch != "" {
+			checkoutRef = fmt.Sprintf("%s/%s", gitRemoteName(*targetRepoURL), *targetBranch)
+			checkoutLocalBranchName = *targetBranch
+		} else {
+			checkoutRef = *targetCommitSHA
+			checkoutLocalBranchName = "local"
+		}
+	}
+
 	// Clean up in case a previous workflow made a mess.
 	if err := git(ctx, ws.log, "clean", "-d" /*directories*/, "--force"); err != nil {
 		return err
@@ -1014,13 +1036,12 @@ func (ws *workspace) sync(ctx context.Context) error {
 	}
 	// Create the branch if it doesn't already exist, then update it to point to
 	// the pushed branch tip.
-	remotePushedBranchRef := fmt.Sprintf("%s/%s", gitRemoteName(*pushedRepoURL), *pushedBranch)
-	if err := git(ctx, ws.log, "checkout", "--force", "-B", *pushedBranch, remotePushedBranchRef); err != nil {
+	if err := git(ctx, ws.log, "checkout", "--force", "-B", checkoutLocalBranchName, checkoutRef); err != nil {
 		return err
 	}
 	// Merge the target branch (if different from the pushed branch) so that the
 	// workflow can pick up any changes not yet incorporated into the pushed branch.
-	if *pushedRepoURL != *targetRepoURL || *pushedBranch != *targetBranch {
+	if *pushedRepoURL != "" && (*pushedRepoURL != *targetRepoURL || *pushedBranch != *targetBranch) {
 		targetRef := fmt.Sprintf("%s/%s", gitRemoteName(*targetRepoURL), *targetBranch)
 		if err := git(ctx, ws.log, "merge", "--no-edit", targetRef); err != nil && !isAlreadyUpToDate(err) {
 			errMsg := err.Output

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1005,10 +1005,10 @@ func (ws *workspace) sync(ctx context.Context) error {
 		}
 	}
 	// TODO: Fetch from remotes in parallel
-	if err := ws.fetch(ctx, *pushedRepoURL, forkBranches); err != nil {
+	if err := ws.fetch(ctx, *targetRepoURL, baseRefs); err != nil {
 		return err
 	}
-	if err := ws.fetch(ctx, *targetRepoURL, baseRefs); err != nil {
+	if err := ws.fetch(ctx, *pushedRepoURL, forkBranches); err != nil {
 		return err
 	}
 

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -132,14 +132,14 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		"--bes_backend=" + conf.GetAppEventsAPIURL(),
 		"--cache_backend=" + conf.GetAppCacheAPIURL(),
 		"--bes_results_url=" + conf.GetAppBuildBuddyURL() + "/invocation/",
-		"--commit_sha=" + req.GetRepoState().GetCommitSha(),
-		"--pushed_repo_url=" + repoURL.String(),
 		"--target_repo_url=" + repoURL.String(),
 		"--bazel_sub_command=" + req.GetBazelCommand(),
-		"--pushed_branch=master",
-		"--target_branch=master",
 		"--invocation_id=" + invocationID,
-		"--report_live_repo_setup_progress",
+	}
+	if req.GetRepoState().GetCommitSha() != "" {
+		args = append(args, "--target_commit_sha="+req.GetRepoState().GetCommitSha())
+	} else {
+		args = append(args, "--target_branch=master")
 	}
 	if req.GetInstanceName() != "" {
 		args = append(args, "--remote_instance_name="+req.GetInstanceName())


### PR DESCRIPTION
ci_runner arg changes:
  --target_commit_sha can be specified instead of --target_branch to
checkout the target at a specific commit
  --push_repo_* args can be omitted

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
