### PR TITLE
Bring back dapper sql tracing; sans the gorm upgrade.

### DIFF
--- a/server/http/protolet/BUILD
+++ b/server/http/protolet/BUILD
@@ -10,6 +10,6 @@ go_library(
         "//server/util/request_context",
         "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
-        "@org_golang_google_grpc//metadata",
+        "@io_opentelemetry_go_otel_trace//:trace",
     ],
 )

--- a/server/http/protolet/protolet.go
+++ b/server/http/protolet/protolet.go
@@ -7,37 +7,17 @@ import (
 	"io/ioutil"
 	"net/http"
 	"reflect"
-	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/request_context"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
-	"google.golang.org/grpc/metadata"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
 	contextProtoMessageKey = "protolet.requestMessage"
 )
-
-func copyHeader(m metadata.MD, h http.Header, k string) {
-	if _, ok := h[k]; !ok {
-		return
-	}
-	m[k] = make([]string, len(h[k]))
-	copy(m[k], h[k])
-}
-
-func headersToContext(h http.Header) metadata.MD {
-	m := make(metadata.MD, 0)
-	for key, _ := range h {
-		switch strings.ToLower(key) {
-		case "x-buildbuddy-trace":
-			copyHeader(m, h, key)
-		}
-	}
-	return m
-}
 
 func isRPCMethod(m reflect.Method) bool {
 	t := m.Type
@@ -160,9 +140,14 @@ func GenerateHTTPHandlers(server interface{}) (*HTTPHandlers, error) {
 			return
 		}
 
-		// Filter and convert any HTTP headers to grpc MD, and attach
-		// that metadata to the context.
-		ctx := metadata.NewIncomingContext(r.Context(), headersToContext(r.Header))
+		// If we know this is a protolet request and we expect to handle it,
+		// override the span name to something legible instead of the generic
+		// handled-path name. This means instead of the span appearing with a
+		// name like "POST /rpc/BuildBuddyService/", it will instead appear
+		// with the name: "POST /rpc/BuildBuddyService/GetUser".
+		ctx := r.Context()
+		span := trace.SpanFromContext(ctx)
+		span.SetName(fmt.Sprintf("%s %s", r.Method, r.RequestURI))
 
 		reqVal := reflect.ValueOf(ctx.Value(contextProtoMessageKey).(proto.Message))
 		args := []reflect.Value{reflect.ValueOf(server), reflect.ValueOf(ctx), reqVal}

--- a/server/util/db/BUILD
+++ b/server/util/db/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//server/tables",
         "//server/util/log",
         "//server/util/status",
+        "//server/util/tracing",
         "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_googlecloudplatform_cloudsql_proxy//proxy/dialers/mysql",
         "@com_github_mattn_go_sqlite3//:go-sqlite3",
@@ -20,5 +21,8 @@ go_library(
         "@io_gorm_driver_sqlite//:sqlite",
         "@io_gorm_gorm//:gorm",
         "@io_gorm_gorm//logger",
+        "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel//codes",
+        "@io_opentelemetry_go_otel_trace//:trace",
     ],
 )


### PR DESCRIPTION
Example traces look like this:

<img width="1471" alt="image" src="https://user-images.githubusercontent.com/141737/160213651-816c4fa7-c17f-4085-aefe-6636eeb3d437.png">
