### PR TITLE
Support HostID usecases when we have no permissions

### DIFF
--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -81,7 +81,12 @@ func NewExecutor(env environment.Env, id string, options *Options) (*Executor, e
 	}
 	hostID := options.NameOverride
 	if hostID == "" {
-		hostID = uuid.GetHostIDOrUUID()
+		if h, err := uuid.GetHostID(); err == nil {
+			hostID = h
+		} else {
+			log.Warning("Unable to get stable BuildBuddy HostID. Falling back to temp UUID. %s", err)
+			hostID = uuid.GetFailsafeHostID()
+		}
 	}
 	runnerPool, err := runner.NewPool(env)
 	if err != nil {

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -81,7 +81,6 @@ func NewExecutor(env environment.Env, id string, options *Options) (*Executor, e
 	}
 	hostID := options.NameOverride
 	if hostID == "" {
-		var err error
 		hostID = uuid.GetHostIDOrUUID()
 	}
 	runnerPool, err := runner.NewPool(env)

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -82,10 +82,7 @@ func NewExecutor(env environment.Env, id string, options *Options) (*Executor, e
 	hostID := options.NameOverride
 	if hostID == "" {
 		var err error
-		hostID, err = uuid.GetHostID()
-		if err != nil {
-			return nil, err
-		}
+		hostID = uuid.GetHostIDOrUUID()
 	}
 	runnerPool, err := runner.NewPool(env)
 	if err != nil {

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -84,7 +84,7 @@ func NewExecutor(env environment.Env, id string, options *Options) (*Executor, e
 		if h, err := uuid.GetHostID(); err == nil {
 			hostID = h
 		} else {
-			log.Warning("Unable to get stable BuildBuddy HostID. Falling back to temp UUID. %s", err)
+			log.Warningf("Unable to get stable BuildBuddy HostID. Falling back to failsafe ID. %s", err)
 			hostID = uuid.GetFailsafeHostID()
 		}
 	}

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -96,10 +96,7 @@ func NewFileCache(rootDir string, maxSizeBytes int64) (*fileCache, error) {
 	if maxSizeBytes <= 0 {
 		return nil, errors.New("Must provide a positive size")
 	}
-	hostID, err := uuid.GetHostID()
-	if err != nil {
-		return nil, err
-	}
+	hostID := uuid.GetHostIDOrUUID()
 	rootDir = filepath.Join(rootDir, hostID)
 	if err := disk.EnsureDirectoryExists(rootDir); err != nil {
 		return nil, err

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -96,7 +96,7 @@ func NewFileCache(rootDir string, maxSizeBytes int64) (*fileCache, error) {
 	if maxSizeBytes <= 0 {
 		return nil, errors.New("Must provide a positive size")
 	}
-	hostID := uuid.GetHostIDOrUUID()
+	hostID := uuid.GetFailsafeHostID()
 	rootDir = filepath.Join(rootDir, hostID)
 	if err := disk.EnsureDirectoryExists(rootDir); err != nil {
 		return nil, err

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -96,7 +96,11 @@ func NewFileCache(rootDir string, maxSizeBytes int64) (*fileCache, error) {
 	if maxSizeBytes <= 0 {
 		return nil, errors.New("Must provide a positive size")
 	}
-	hostID := uuid.GetFailsafeHostID()
+	hostID, err := uuid.GetHostID()
+	if err != nil {
+		log.Warning("Unable to get stable BuildBuddy HostID; filecache will not be reused across process restarts.")
+		hostID = uuid.GetFailsafeHostID()
+	}
 	rootDir = filepath.Join(rootDir, hostID)
 	if err := disk.EnsureDirectoryExists(rootDir); err != nil {
 		return nil, err

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -95,6 +95,11 @@ func ValidateActionResult(ctx context.Context, cache interfaces.Cache, r *repb.A
 func setWorkerMetadata(ar *repb.ActionResult) error {
 	if ar.ExecutionMetadata == nil {
 		ar.ExecutionMetadata = &repb.ExecutedActionMetadata{
+			// This will return the Host ID in the normal case and
+			// fall back to a safe ID if permissions don't allow a
+			// Host ID. Don't warn in that case because this func is
+			// called on every UpdateActionResult, and the
+			// consequences of this ID changing are none.
 			Worker: uuid.GetFailsafeHostID(),
 		}
 	}

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -94,11 +94,9 @@ func ValidateActionResult(ctx context.Context, cache interfaces.Cache, r *repb.A
 
 func setWorkerMetadata(ar *repb.ActionResult) error {
 	if ar.ExecutionMetadata == nil {
-		hostID, err := uuid.GetHostID()
-		if err != nil {
-			return err
+		ar.ExecutionMetadata = &repb.ExecutedActionMetadata{
+			Worker: uuid.GetHostIDOrUUID(),
 		}
-		ar.ExecutionMetadata = &repb.ExecutedActionMetadata{Worker: hostID}
 	}
 	return nil
 }

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -95,7 +95,7 @@ func ValidateActionResult(ctx context.Context, cache interfaces.Cache, r *repb.A
 func setWorkerMetadata(ar *repb.ActionResult) error {
 	if ar.ExecutionMetadata == nil {
 		ar.ExecutionMetadata = &repb.ExecutedActionMetadata{
-			Worker: uuid.GetHostIDOrUUID(),
+			Worker: uuid.GetFailsafeHostID(),
 		}
 	}
 	return nil

--- a/server/util/uuid/uuid.go
+++ b/server/util/uuid/uuid.go
@@ -24,7 +24,7 @@ var (
 	hostIDError error
 	hostIDOnce  sync.Once
 
-	failsafeID   string
+	failsafeID     string
 	failsafeIDOnce sync.Once
 )
 

--- a/server/util/uuid/uuid.go
+++ b/server/util/uuid/uuid.go
@@ -122,3 +122,23 @@ func GetHostID() (string, error) {
 	)
 	return hostID, hostIDError
 }
+
+// GetHostIDOrUUID is the "failsafe" version of GetHostID. In most cases it will
+// return the output of GetHostID, but if an error is encountered, another UUID
+// will be generated.
+func GetHostIDOrUUID() string {
+	hostID, err := GetHostID()
+	if err == nil {
+		return hostID
+	}
+
+	// In practice this should never error, but check err anyway and provide
+	// a fallback (that will never be used).
+	uuid, err := guuid.NewRandom()
+	if err != nil {
+		return uuid.String()
+	}
+
+	failsafe := guuid.New()
+	return string(failsafe.NodeID())
+}


### PR DESCRIPTION
Several customers now have bumped into this when attempting to run BuildBuddy in very-locked-down environments (no write perms for config dir) or in unusual configurations (no config dir set?).

This prevent an error in that case, at the cost of generating a less sticky ID.