### PR TITLE
Expand cache scorecard proto and add dedicated RPC for cache scorecard

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -48,6 +48,7 @@ proto_library(
         "cache.proto",
     ],
     deps = [
+        ":context_proto",
         ":remote_execution_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:timestamp_proto",
@@ -305,6 +306,7 @@ proto_library(
     deps = [
         ":api_key_proto",
         ":bazel_config_proto",
+        ":cache_proto",
         ":eventlog_proto",
         ":execution_stats_proto",
         ":github_proto",
@@ -633,6 +635,7 @@ go_proto_library(
     deps = [
         ":api_key_go_proto",
         ":bazel_config_go_proto",
+        ":cache_go_proto",
         ":eventlog_go_proto",
         ":execution_stats_go_proto",
         ":github_go_proto",
@@ -685,6 +688,7 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/cache",
     proto = ":cache_proto",
     deps = [
+        ":context_go_proto",
         ":remote_execution_go_proto",
         "@go_googleapis//google/rpc:status_go_proto",
     ],

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -108,6 +108,11 @@ proto_library(
 )
 
 proto_library(
+    name = "pagination_proto",
+    srcs = [":pagination.proto"],
+)
+
+proto_library(
     name = "publish_build_event_proto",
     srcs = [
         "publish_build_event.proto",

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -47,6 +47,12 @@ proto_library(
     srcs = [
         "cache.proto",
     ],
+    deps = [
+        ":remote_execution_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@go_googleapis//google/rpc:status_proto",
+    ],
 )
 
 proto_library(
@@ -678,6 +684,10 @@ go_proto_library(
     name = "cache_go_proto",
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/cache",
     proto = ":cache_proto",
+    deps = [
+        ":remote_execution_go_proto",
+        "@go_googleapis//google/rpc:status_go_proto",
+    ],
 )
 
 go_proto_library(

--- a/proto/buildbuddy_service.proto
+++ b/proto/buildbuddy_service.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "proto/api_key.proto";
 import "proto/bazel_config.proto";
+import "proto/cache.proto";
 import "proto/eventlog.proto";
 import "proto/execution_stats.proto";
 import "proto/grp.proto";
@@ -69,6 +70,10 @@ service BuildBuddyService {
       returns (execution_stats.GetExecutionResponse);
   rpc GetExecutionNodes(scheduler.GetExecutionNodesRequest)
       returns (scheduler.GetExecutionNodesResponse);
+
+  // Cache API
+  rpc GetCacheScoreCard(cache.GetCacheScoreCardRequest)
+      returns (cache.GetCacheScoreCardResponse);
 
   // Target API
   rpc GetTarget(target.GetTargetRequest) returns (target.GetTargetResponse);

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -42,6 +42,8 @@ message GetCacheScoreCardRequest {
 
   // The invocation ID for which to look up cache stats.
   string invocation_id = 2;
+
+  // TODO(bduffany): Add paging
 }
 
 message GetCacheScoreCardResponse {

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -2,6 +2,11 @@ syntax = "proto3";
 
 package cache;
 
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+import "google/rpc/status.proto";
+import "proto/remote_execution.proto";
+
 // Next Tag: 14
 message CacheStats {
   // Server-side Action-cache stats.
@@ -32,11 +37,57 @@ message CacheStats {
 
 message ScoreCard {
   message Result {
+    enum CacheType {
+      UNKNOWN_CACHE_TYPE = 0;
+      // Content addressable storage (CAS) cache
+      CAS = 1;
+      // Action cache (AC)
+      AC = 2;
+    }
+
+    enum ResultType {
+      UNKNOWN_RESULT_TYPE = 0;
+      // CAS or AC read.
+      HIT = 1;
+      // AC miss.
+      MISS = 2;
+      // CAS or AC write.
+      UPLOAD = 3;
+    }
+
+    // The short action name of the action relevant to the transfer,
+    // such as "GoCompile".
     string action_mnemonic = 1;
+
+    // The Bazel target label relevant to the transfer, such as "//foo:bar".
     string target_id = 2;
+
+    // Action digest hash for the action relevant to the transfer.
     string action_id = 3;
+
+    // The digest of the requested contents.
+    build.bazel.remote.execution.v2.Digest digest = 4;
+
+    // The timestamp at which the server received the request from the client.
+    google.protobuf.Timestamp start_time = 5;
+
+    // The time needed for the transfer to complete, starting from start_time.
+    google.protobuf.Duration duration = 6;
+
+    // Whether the transferred payload was compressed.
+    bool compressed = 7;
+
+    // The compressed size of the transferred payload. Should be ignored if
+    // `compressed` is false.
+    int64 compressed_size_bytes = 8;
+
+    // Response status of the cache request.
+    google.rpc.Status status = 9;
   }
 
   // In the interest of saving space, we only show cache misses.
+  // TODO(bduffany): use flat `results` list and deprecate this
   repeated Result misses = 1;
+
+  repeated Result results = 2;
 }

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -5,6 +5,7 @@ package cache;
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
+import "proto/context.proto";
 import "proto/remote_execution.proto";
 
 // Next Tag: 14
@@ -35,24 +36,43 @@ message CacheStats {
   int64 total_cached_action_exec_usec = 11;
 }
 
+// Request to retrieve detailed per-request cache stats.
+message GetCacheScoreCardRequest {
+  context.RequestContext request_context = 1;
+
+  // The invocation ID for which to look up cache stats.
+  string invocation_id = 2;
+}
+
+message GetCacheScoreCardResponse {
+  context.ResponseContext response_context = 1;
+
+  // The cache scorecard containing detailed per-request stats.
+  ScoreCard scorecard = 2;
+}
+
+// CacheType represents the type of cache being written to.
+enum CacheType {
+  UNKNOWN_CACHE_TYPE = 0;
+  // Content addressable storage (CAS) cache.
+  CAS = 1;
+  // Action cache (AC).
+  AC = 2;
+}
+
+// RequestType represents the type of cache request being performed: read or
+// write.
+enum RequestType {
+  UNKNOWN_REQUEST_TYPE = 0;
+  // Cache read.
+  READ = 1;
+  // Cache write.
+  WRITE = 2;
+}
+
 message ScoreCard {
+  // Result holds details about the result of a single cache request.
   message Result {
-    enum CacheType {
-      UNKNOWN_CACHE_TYPE = 0;
-      // Content addressable storage (CAS) cache.
-      CAS = 1;
-      // Action cache (AC).
-      AC = 2;
-    }
-
-    enum RequestType {
-      UNKNOWN_RESULT_TYPE = 0;
-      // Cache read.
-      READ = 1;
-      // Cache write.
-      WRITE = 2;
-    }
-
     // The short action name of the action relevant to the transfer,
     // such as "GoCompile".
     string action_mnemonic = 1;

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -39,20 +39,18 @@ message ScoreCard {
   message Result {
     enum CacheType {
       UNKNOWN_CACHE_TYPE = 0;
-      // Content addressable storage (CAS) cache
+      // Content addressable storage (CAS) cache.
       CAS = 1;
-      // Action cache (AC)
+      // Action cache (AC).
       AC = 2;
     }
 
-    enum ResultType {
+    enum RequestType {
       UNKNOWN_RESULT_TYPE = 0;
-      // CAS or AC read.
-      HIT = 1;
-      // AC miss.
-      MISS = 2;
-      // CAS or AC write.
-      UPLOAD = 3;
+      // Cache read.
+      READ = 1;
+      // Cache write.
+      WRITE = 2;
     }
 
     // The short action name of the action relevant to the transfer,
@@ -65,24 +63,31 @@ message ScoreCard {
     // Action digest hash for the action relevant to the transfer.
     string action_id = 3;
 
+    // The type of cache relevant to this result.
+    CacheType cache_type = 4;
+
+    // The type of cache request described by this result (read or write).
+    RequestType request_type = 5;
+
+    // Response status of the cache request. For example, a cache miss is
+    // represented by a READ request_type with a NotFound status code.
+    google.rpc.Status status = 6;
+
     // The digest of the requested contents.
-    build.bazel.remote.execution.v2.Digest digest = 4;
+    build.bazel.remote.execution.v2.Digest digest = 7;
 
     // The timestamp at which the server received the request from the client.
-    google.protobuf.Timestamp start_time = 5;
+    google.protobuf.Timestamp start_time = 8;
 
     // The time needed for the transfer to complete, starting from start_time.
-    google.protobuf.Duration duration = 6;
+    google.protobuf.Duration duration = 9;
 
     // Whether the transferred payload was compressed.
-    bool compressed = 7;
+    bool compressed = 10;
 
     // The compressed size of the transferred payload. Should be ignored if
     // `compressed` is false.
-    int64 compressed_size_bytes = 8;
-
-    // Response status of the cache request.
-    google.rpc.Status status = 9;
+    int64 compressed_size_bytes = 11;
   }
 
   // In the interest of saving space, we only show cache misses.

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -51,9 +51,9 @@ message GetCacheScoreCardRequest {
     int64 index = 1;
   }
 
-  // A string representation of the page token, which must be a value returned
-  // by a previous response.
-  string page_token = 3;
+  // A string representation of the next page token, which must be a value
+  // returned by a previous response.
+  string next_page_token = 3;
 
   // TODO(bduffany): add sorting/filtering options
 }

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -43,14 +43,30 @@ message GetCacheScoreCardRequest {
   // The invocation ID for which to look up cache stats.
   string invocation_id = 2;
 
-  // TODO(bduffany): Add paging
+  // Pagination token. Not intended for direct client usage.
+  message PageToken {
+    // The start index in the scorecard results list, after sorting and
+    // filtering results. Number of results to fetch is determined by the
+    // server.
+    int64 index = 1;
+  }
+
+  // A string representation of the page token, which must be a value returned
+  // by a previous response.
+  string page_token = 3;
+
+  // TODO(bduffany): add sorting/filtering options
 }
 
 message GetCacheScoreCardResponse {
   context.ResponseContext response_context = 1;
 
-  // The cache scorecard containing detailed per-request stats.
-  ScoreCard scorecard = 2;
+  // The cache results for the current page.
+  repeated ScoreCard.Result results = 2;
+
+  // A token used to fetch more results. If empty, there are no results
+  // remaining.
+  string page_token = 3;
 }
 
 // CacheType represents the type of cache being written to.
@@ -113,8 +129,5 @@ message ScoreCard {
   }
 
   // In the interest of saving space, we only show cache misses.
-  // TODO(bduffany): use flat `results` list and deprecate this
   repeated Result misses = 1;
-
-  repeated Result results = 2;
 }

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -38,34 +38,26 @@ message CacheStats {
 
 // Request to retrieve detailed per-request cache stats.
 message GetCacheScoreCardRequest {
+  // The request context, including the page token from the previous response.
   context.RequestContext request_context = 1;
 
   // The invocation ID for which to look up cache stats.
   string invocation_id = 2;
 
-  // Pagination token. Not intended for direct client usage.
-  message PageToken {
-    // The start index in the scorecard results list, after sorting and
-    // filtering results. Number of results to fetch is determined by the
-    // server.
-    int64 index = 1;
-  }
-
-  // A string representation of the next page token, which must be a value
-  // returned by a previous response.
+  // A page token returned from the previous response, or an empty string
+  // initially.
   string page_token = 3;
-
-  // TODO(bduffany): add sorting/filtering options
 }
 
 message GetCacheScoreCardResponse {
+  // The response context, including the next_page_token.
   context.ResponseContext response_context = 1;
 
   // The cache results for the current page.
   repeated ScoreCard.Result results = 2;
 
-  // A token used to fetch more results. If empty, there are no results
-  // remaining.
+  // An opaque token that can be included in a subsequent request to fetch more
+  // results from the server. If empty, there are no more results available.
   string next_page_token = 3;
 }
 

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -53,7 +53,7 @@ message GetCacheScoreCardRequest {
 
   // A string representation of the next page token, which must be a value
   // returned by a previous response.
-  string next_page_token = 3;
+  string page_token = 3;
 
   // TODO(bduffany): add sorting/filtering options
 }
@@ -66,7 +66,7 @@ message GetCacheScoreCardResponse {
 
   // A token used to fetch more results. If empty, there are no results
   // remaining.
-  string page_token = 3;
+  string next_page_token = 3;
 }
 
 // CacheType represents the type of cache being written to.

--- a/proto/pagination.proto
+++ b/proto/pagination.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+// This package contains internal pagination protos for use on the server. It is
+// not intended for client usage, and clients should not assume any relationship
+// between these protos and page tokens returned by the server.
+package pagination;
+
+// OffsetLimit represents an offset into a collection of results along with a
+// maximum number of results to return starting at the offset.
+message OffsetLimit {
+  // The offset into the ordered list of results from the original request.
+  int64 offset = 1;
+
+  // The maximum number of results to return, starting at the offset.
+  int64 limit = 2;
+}

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//proto:api_key_go_proto",
         "//proto:bazel_config_go_proto",
+        "//proto:cache_go_proto",
         "//proto:eventlog_go_proto",
         "//proto:execution_stats_go_proto",
         "//proto:github_go_proto",

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -31,18 +31,18 @@ import (
 	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
 	elpb "github.com/buildbuddy-io/buildbuddy/proto/eventlog"
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
-	gcodes "google.golang.org/grpc/codes"
 	ghpb "github.com/buildbuddy-io/buildbuddy/proto/github"
 	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
-	gstatus "google.golang.org/grpc/status"
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
-	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
 	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 	trpb "github.com/buildbuddy-io/buildbuddy/proto/target"
 	usagepb "github.com/buildbuddy-io/buildbuddy/proto/usage"
 	uspb "github.com/buildbuddy-io/buildbuddy/proto/user"
 	wfpb "github.com/buildbuddy-io/buildbuddy/proto/workflow"
+	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
+	gcodes "google.golang.org/grpc/codes"
+	gstatus "google.golang.org/grpc/status"
 )
 
 var (

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -28,20 +28,21 @@ import (
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
 	bzpb "github.com/buildbuddy-io/buildbuddy/proto/bazel_config"
+	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
 	elpb "github.com/buildbuddy-io/buildbuddy/proto/eventlog"
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
+	gcodes "google.golang.org/grpc/codes"
 	ghpb "github.com/buildbuddy-io/buildbuddy/proto/github"
 	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
+	gstatus "google.golang.org/grpc/status"
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
+	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
 	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 	trpb "github.com/buildbuddy-io/buildbuddy/proto/target"
 	usagepb "github.com/buildbuddy-io/buildbuddy/proto/usage"
 	uspb "github.com/buildbuddy-io/buildbuddy/proto/user"
 	wfpb "github.com/buildbuddy-io/buildbuddy/proto/workflow"
-	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
-	gcodes "google.golang.org/grpc/codes"
-	gstatus "google.golang.org/grpc/status"
 )
 
 var (
@@ -838,6 +839,10 @@ func (s *BuildBuddyServer) GetUsage(ctx context.Context, req *usagepb.GetUsageRe
 	if us := s.env.GetUsageService(); us != nil {
 		return us.GetUsage(ctx, req)
 	}
+	return nil, status.UnimplementedError("Not implemented")
+}
+
+func (s *BuildBuddyServer) GetCacheScoreCard(ctx context.Context, req *capb.GetCacheScoreCardRequest) (*capb.GetCacheScoreCardResponse, error) {
 	return nil, status.UnimplementedError("Not implemented")
 }
 

--- a/server/role_filter/role_filter.go
+++ b/server/role_filter/role_filter.go
@@ -27,6 +27,7 @@ var (
 		// done purely using perms bits attached to each row.
 		"GetInvocation",
 		"GetEventLogChunk",
+		"GetCacheScoreCard",
 		"GetTarget",
 		"GetExecution",
 		// Users do not need any particular role within their current group to be


### PR DESCRIPTION
Expanding the cache scorecard result message with more details, and adding a new field `result` which will contain a flat results list. This flattened list is easiest for the client to slice and dice.

Might need to iterate on this in subsequent PRs if we see that this approach doesn't scale well, but this flat list works well for development purposes. The plan is to only populate the new fields behind a flag.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
