### PR TITLE
Faster find replicas.

### DIFF
--- a/server/util/consistent_hash/consistent_hash.go
+++ b/server/util/consistent_hash/consistent_hash.go
@@ -108,14 +108,14 @@ func (c *ConsistentHash) GetAllReplicas(key string) []string {
 	// computing a hash of the replicas in the set, and checking if this set
 	// has been returned before. If it has -- return that set.
 	originalIndex := c.ring[c.keys[idx]]
-
-	replicasHash := crc32.NewIEEE()
-	replicasHash.Write([]byte{originalIndex})
+	inputBuf := make([]byte, len(c.keys))
+	inputBuf[0] = originalIndex
+	inputIdx := 1
 	c.lookupReplicas(idx, func(replicaIndex uint8) {
-		replicasHash.Write([]byte{replicaIndex})
+		inputBuf[inputIdx] = replicaIndex
+		inputIdx += 1
 	})
-
-	replicasKey := replicasHash.Sum32()
+	replicasKey := crc32.ChecksumIEEE(inputBuf)
 
 	c.replicaMu.RLock()
 	replicas, ok := c.replicaSets[replicasKey]


### PR DESCRIPTION
Before:

goos: linux
goarch: amd64
cpu: AMD Ryzen 9 5950X 16-Core Processor
BenchmarkGetAllReplicas-32    	   32829	     31928 ns/op
PASS


After:

goos: linux
goarch: amd64
cpu: AMD Ryzen 9 5950X 16-Core Processor
BenchmarkGetAllReplicas-32    	  129259	      8693 ns/op
PASS

(so roughly a 4x improvement)