### PR TITLE
Fix GetAction API target filtering

### DIFF
--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -387,7 +387,7 @@ func targetMatchesTargetSelector(target *apipb.Target, selector *apipb.TargetSel
 
 // Returns true if a selector doesn't specify a particular id or matches the target's ID
 func actionMatchesActionSelector(id *apipb.Action_Id, selector *apipb.ActionSelector) bool {
-	return (selector.TargetId == "" || selector.TargetId == id.TargetId) ||
-		(selector.ConfigurationId == "" || selector.ConfigurationId == id.ConfigurationId) ||
+	return (selector.TargetId == "" || selector.TargetId == id.TargetId) &&
+		(selector.ConfigurationId == "" || selector.ConfigurationId == id.ConfigurationId) &&
 		(selector.ActionId == "" || selector.ActionId == id.ActionId)
 }


### PR DESCRIPTION
Currently if you make a `GetAction` API request with a target_id specified, we (incorrectly) return all targets.

This PR fixes that target id filtering logic and adds a test to verify this behavior. 

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
