### PR TITLE
Gossip: Set multiple tags at once by default

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -233,8 +233,10 @@ func (s *Store) gossipUsage() {
 	}
 	usage.DiskBytesTotal = int64(du.TotalBytes)
 	usage.DiskBytesUsed = int64(du.UsedBytes)
-	s.gossipManager.SetTag(constants.NodeHostIDTag, string(s.nodeHost.ID()))
-	s.gossipManager.SetTag(constants.NodeUsageTag, proto.MarshalTextString(usage))
+	s.gossipManager.SetTags(map[string]string{
+		constants.NodeHostIDTag: string(s.nodeHost.ID()),
+		constants.NodeUsageTag:  proto.MarshalTextString(usage),
+	})
 }
 
 // We need to implement the RangeTracker interface so that stores opened and
@@ -264,7 +266,7 @@ func (s *Store) AddRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 			log.Errorf("Error marshaling metarange descriptor: %s", err)
 			return
 		}
-		go s.gossipManager.SetTag(constants.MetaRangeTag, string(buf))
+		go s.gossipManager.SetTags(map[string]string{constants.MetaRangeTag: string(buf)})
 	}
 	go s.maybeAcquireRangeLease(rd)
 	go s.gossipUsage()

--- a/server/gossip/gossip.go
+++ b/server/gossip/gossip.go
@@ -72,14 +72,15 @@ func (gm *GossipManager) Leave() error {
 func (gm *GossipManager) Shutdown() error {
 	return gm.serfInstance.Shutdown()
 }
-func (gm *GossipManager) SetTag(tagName, tagValue string) error {
+func (gm *GossipManager) SetTags(tags map[string]string) error {
 	gm.tagMu.Lock()
 	defer gm.tagMu.Unlock()
-	log.Debugf("Setting tag %q = %q", tagName, tagValue)
-	if tagValue == "" {
-		delete(gm.tags, tagName)
-	} else {
-		gm.tags[tagName] = tagValue
+	for tagName, tagValue := range tags {
+		if tagValue == "" {
+			delete(gm.tags, tagName)
+		} else {
+			gm.tags[tagName] = tagValue
+		}
 	}
 	return gm.serfInstance.SetTags(gm.tags)
 }
@@ -100,10 +101,12 @@ type logWriter struct {
 
 func (lw *logWriter) Write(d []byte) (int, error) {
 	s := strings.TrimSuffix(string(d), "\n")
+	// Gossip logs are very verbose and there is
+	// very little useful info in DEBUG/INFO level logs.
 	if strings.Contains(s, "[DEBUG]") {
-		log.Debug(s)
+		//		log.Debug(s)
 	} else if strings.Contains(s, "[INFO]") {
-		log.Info(s)
+		//		log.Info(s)
 	} else {
 		log.Warning(s)
 	}

--- a/server/gossip/gossip_test.go
+++ b/server/gossip/gossip_test.go
@@ -90,7 +90,7 @@ func TestSendTag(t *testing.T) {
 	node2 := newGossipManager(t, localAddr(t), []string{node1Addr}, &testBroker{onEvent: eventCB})
 	defer node2.Shutdown()
 
-	err := node1.SetTag("testTagName", "testTagValue")
+	err := node1.SetTags(map[string]string{"testTagName": "testTagValue"})
 	require.Nil(t, err)
 
 	select {


### PR DESCRIPTION
Because currently setting tags is synchronous (waits for gossip to broadcast the tag before returning) this makes setting multiple tags much faster (which we do a lot in our store tests).