### PR TITLE
Add bazel RBE integration tests

### DIFF
--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -181,6 +181,8 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, task *repb.E
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
+	metrics.RemoteExecutionTasksStartedCount.Inc()
+
 	req := task.GetExecuteRequest()
 	taskID := task.GetExecutionId()
 	adInstanceDigest := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName())

--- a/enterprise/server/test/integration/remote_execution/bazel_rbe/BUILD
+++ b/enterprise/server/test/integration/remote_execution/bazel_rbe/BUILD
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "bazel_rbe_test",
+    srcs = ["bazel_rbe_test.go"],
+    shard_count = 6,
+    deps = [
+        "//enterprise/server/test/integration/remote_execution/rbetest",
+        "//server/metrics",
+        "//server/testutil/testbazel",
+        "//server/testutil/testmetrics",
+        "//server/util/bazel",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
+++ b/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
@@ -1,0 +1,164 @@
+// package rbe_retry_test contains end-to-end tests for the remote execution
+// service using Bazel as the client.
+package bazel_rbe_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/test/integration/remote_execution/rbetest"
+	"github.com/buildbuddy-io/buildbuddy/server/metrics"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testbazel"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testmetrics"
+	"github.com/buildbuddy-io/buildbuddy/server/util/bazel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimpleAction_Exit0(t *testing.T) {
+	env := setup(t)
+	ctx := context.Background()
+
+	res := runRemoteShellActionViaBazel(t, ctx, env, "echo Success; exit 0")
+
+	require.NoError(t, res.Error)
+	assert.Contains(t, res.Stdout, "Success\n")
+	assert.Equal(t, 1, tasksStarted(t))
+}
+
+func TestSimpleAction_Exit1(t *testing.T) {
+	env := setup(t)
+	ctx := context.Background()
+
+	res := runRemoteShellActionViaBazel(t, ctx, env, "echo >&2 stderr output; exit 1")
+
+	require.Error(t, res.Error)
+	assert.Equal(t, 1, tasksStarted(t))
+}
+
+func TestSimpleAction_TerminateWithSIGKILL(t *testing.T) {
+	env := setup(t)
+	ctx := context.Background()
+
+	res := runRemoteShellActionViaBazel(
+		t, ctx, env,
+		"echo >&2 'User debug message to help diagnose OOM'; kill -KILL $$")
+
+	require.Error(t, res.Error)
+	assert.Contains(t, res.Stderr, "User debug message to help diagnose OOM")
+	// SIGKILL usually happens due to OOM, so make sure these are retried
+	assert.Contains(t, res.Stderr, "Resource Exhausted")
+	assert.Contains(t, res.Stderr, "signal: killed")
+	// 1 initial attempt + 5 scheduler retries
+	assert.Equal(t, 6, tasksStarted(t))
+}
+
+func TestSimpleAction_TerminateWithSIGABRT(t *testing.T) {
+	env := setup(t)
+	ctx := context.Background()
+
+	res := runRemoteShellActionViaBazel(
+		t, ctx, env,
+		"echo >&2 'Aborting test action'; kill -ABRT $$")
+
+	assert.Contains(
+		t, res.Stderr, "Aborting test action",
+		"Error message logged before aborting should be visible in bazel stderr")
+	// 1 initial attempt + 5 scheduler retries
+	assert.Equal(t, 6, tasksStarted(t))
+}
+
+func TestActionWithContainerImage_InvalidArgument(t *testing.T) {
+	env := setup(t)
+	ctx := context.Background()
+
+	res := runRemoteShellActionViaBazel(
+		t, ctx, env, "exit 0",
+		"--remote_default_exec_properties=container-image=INVALID")
+
+	require.Error(t, res.Error)
+	assert.Contains(t, res.Stderr, "InvalidArgument")
+	// TODO(bduffany): Fail faster. Currently, these get retried by both the
+	// scheduler and Bazel, causing 5 bazel attempts, each of which results in
+	// 6 attempts by the scheduler, with exponential backoff between each bazel
+	// attempt.
+	assert.Equal(t, 30, tasksStarted(t))
+}
+
+func TestActionWithRunnerRecycling_Unauthenticated(t *testing.T) {
+	env := setup(t)
+	ctx := context.Background()
+
+	res := runRemoteShellActionViaBazel(
+		t, ctx, env, "exit 0",
+		// runner recycling requires authentication, but this build doesn't specify
+		// an API key
+		"--remote_default_exec_properties=recycle-runner=true")
+
+	require.Error(t, res.Error)
+	// TODO(bduffany): return Unauthenticated here, not Unavailable
+	assert.Contains(t, res.Stderr, "Unavailable")
+	assert.Contains(t, res.Stderr, "runner recycling is not supported for anonymous builds")
+	// TODO(bduffany): Fail faster. Currently, these get retried by both the
+	// scheduler and Bazel, causing 5 bazel attempts, each of which results in
+	// 6 attempts by the scheduler, with exponential backoff between each bazel
+	// attempt.
+	assert.Equal(t, 30, tasksStarted(t))
+}
+
+func setup(t *testing.T) *rbetest.Env {
+	env := rbetest.NewRBETestEnv(t)
+	env.AddBuildBuddyServer()
+	env.AddExecutor()
+	// observe initial count so that we can get the diff at the end of the test
+	_ = tasksStarted(t)
+	return env
+}
+
+var previousTasksStarted = 0
+
+// tasksStarted returns the change in the tasks started count since this func
+// was last called.
+func tasksStarted(t testing.TB) int {
+	counterValue := int(testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount))
+	diff := counterValue - previousTasksStarted
+	previousTasksStarted = counterValue
+	return diff
+}
+
+func runRemoteShellActionViaBazel(t *testing.T, ctx context.Context, env *rbetest.Env, shCommand string, extraBazelArgs ...string) *bazel.InvocationResult {
+	ws := testbazel.MakeTempWorkspace(t, map[string]string{
+		"WORKSPACE": "",
+		// Define a bazel rule that runs exactly one action, which creates a dummy
+		// file (because Bazel requires actions to have outputs) then executes our
+		// test command.
+		//
+		// This approach is used instead of using built-in rules like `sh_test` or
+		// `genrule` because those rules have expensive/inconvenient CC deps, and
+		// also wind up executing more than one action, so test assertions are less
+		// intuitive.
+		"defs.bzl": `
+def _exec_impl(ctx):
+  out = ctx.actions.declare_file(ctx.label.name)
+  ctx.actions.run_shell(
+    outputs = [out],
+    command = """
+      set -e
+      touch "%s"
+      %s
+		""" % (out.path, ctx.attr.command),
+  )
+  return [DefaultInfo(files = depset([out]))]
+
+exec = rule(implementation = _exec_impl, attrs = {"command": attr.string()})
+`,
+		"BUILD": `
+load(":defs.bzl", "exec")
+exec(name = "exec", command = """` + shCommand + `""")
+`,
+	})
+	// Execute just the test action remotely.
+	buildArgs := []string{":exec", "--remote_executor=" + env.GetRemoteExecutionTarget()}
+	buildArgs = append(buildArgs, extraBazelArgs...)
+	return testbazel.Invoke(ctx, t, ws, "build", buildArgs...)
+}

--- a/enterprise/server/test/integration/remote_execution/rbetest/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbetest/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//server/remote_cache/action_cache_server",
         "//server/remote_cache/byte_stream_server",
         "//server/remote_cache/cachetools",
+        "//server/remote_cache/capabilities_server",
         "//server/remote_cache/content_addressable_storage_server",
         "//server/remote_cache/digest",
         "//server/resources",

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -342,6 +342,13 @@ var (
 	/// sum(rate(buildbuddy_remote_execution_count[5m]))
 	/// ```
 
+	RemoteExecutionTasksStartedCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "tasks_started_count",
+		Help:      "Number of tasks started remotely, but not necessarily completed. Includes retry attempts of the same task.",
+	})
+
 	RemoteExecutionExecutedActionMetadataDurationsUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",

--- a/server/testutil/testmetrics/testmetrics.go
+++ b/server/testutil/testmetrics/testmetrics.go
@@ -16,3 +16,14 @@ func GaugeValue(t testing.TB, metric prometheus.Gauge) float64 {
 	require.NoError(t, err)
 	return m.Gauge.GetValue()
 }
+
+// CounterValue returns the current value of a counter metric.
+//
+// Note: counter values can persist across tests, so be sure to only make
+// assertions on *changes* to counter values.
+func CounterValue(t testing.TB, metric prometheus.Counter) float64 {
+	m := &dto.Metric{}
+	err := metric.Write(m)
+	require.NoError(t, err)
+	return m.Counter.GetValue()
+}


### PR DESCRIPTION
Motivation: This will give us greater confidence that any proposed changes to address https://github.com/buildbuddy-io/buildbuddy-internal/issues/1279 won't break the existing retry behavior.

This also buys us test coverage for the following Bazel <-> RBE integrations:
* Bazel's retry behavior based on the error codes that we are returning
* Bazel's stdout/stderr output displayed to the user based on the status codes that we return

Since these two behaviors are directly visible when using bazel with BB RBE, it seems worthwhile to have integration tests in place to enforce that these are working as intended.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
