### PR TITLE
Fix panic in rangemap.GetOverlapping

### DIFF
--- a/server/util/rangemap/rangemap.go
+++ b/server/util/rangemap/rangemap.go
@@ -126,7 +126,6 @@ func (rm *RangeMap) GetOverlapping(left, right []byte) []*Range {
 	if len(rm.ranges) == 0 {
 		return nil
 	}
-
 	// Search returns the smallest i for which func returns true.
 	// We want the smallest range that is bigger than this key
 	// aka, starts AFTER this key, and then we'll go one left of it
@@ -134,6 +133,10 @@ func (rm *RangeMap) GetOverlapping(left, right []byte) []*Range {
 		//  0 if a==b, -1 if a < b, and +1 if a > b
 		return bytes.Compare(rm.ranges[i].Left, left) > 0
 	})
+
+	if leftIndex > 0 && rm.ranges[leftIndex-1].Contains(left) {
+		leftIndex -= 1
+	}
 
 	// Search returns the smallest i for which func returns true.
 	// We want the smallest range that is bigger than this key
@@ -143,7 +146,10 @@ func (rm *RangeMap) GetOverlapping(left, right []byte) []*Range {
 		return bytes.Compare(rm.ranges[i].Left, right) > 0
 	})
 
-	return rm.ranges[leftIndex-1 : rightIndex]
+	if rightIndex > 0 {
+		rightIndex -= 1
+	}
+	return rm.ranges[leftIndex : rightIndex+1]
 }
 
 func (rm *RangeMap) Lookup(key []byte) interface{} {

--- a/server/util/rangemap/rangemap_test.go
+++ b/server/util/rangemap/rangemap_test.go
@@ -210,3 +210,40 @@ func TestClear(t *testing.T) {
 	r.Clear()
 	require.Equal(t, 0, len(r.Ranges()))
 }
+
+func TestGetOverlappingNPE(t *testing.T) {
+	r := rangemap.New()
+
+	addRange := func(left, right string, id int) {
+		_, err := r.Add([]byte(left), []byte(right), id)
+		require.Nil(t, err)
+	}
+
+	addRange("e", "z", 1)
+	overlap := r.GetOverlapping([]byte("d"), []byte("m"))
+	require.Equal(t, 1, overlap[0].Val)
+}
+
+func TestGetOverlappingMulti(t *testing.T) {
+	r := rangemap.New()
+
+	addRange := func(left, right string, id int) {
+		_, err := r.Add([]byte(left), []byte(right), id)
+		require.Nil(t, err)
+	}
+
+	addRange("a", "c", 1)
+	addRange("c", "e", 2)
+	addRange("e", "g", 3)
+	addRange("l", "n", 4)
+	addRange("n", "p", 5)
+
+	overlap := r.GetOverlapping([]byte("d"), []byte("m"))
+	require.Equal(t, 2, overlap[0].Val)
+	require.Equal(t, 3, overlap[1].Val)
+	require.Equal(t, 4, overlap[2].Val)
+
+	overlap2 := r.GetOverlapping([]byte("g"), []byte("z"))
+	require.Equal(t, 4, overlap2[0].Val)
+	require.Equal(t, 5, overlap2[1].Val)
+}


### PR DESCRIPTION
This fixes the panic in https://app.buildbuddy.io/invocation/b1b8a961-c498-4127-b0d0-90ee51d6eb9c?target=%2F%2Fenterprise%2Fserver%2Fraft%2Fstore%3Astore_test and adds a tests for this case.
