### PR TITLE
Don't return runners to the pool after unclean execution

### DIFF
--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -417,7 +417,9 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, task *repb.E
 		logActionResult(taskID, md)
 		return finishWithErrFn(err) // CHECK (these errors should not happen).
 	}
-	finishedCleanly = true
+	if cmdResult.Error == nil {
+		finishedCleanly = true
+	}
 	return false, nil
 }
 


### PR DESCRIPTION
In the firecracker case, an unclean execution can mean that the VM can be in an unexpected state when we next try to resume it (e.g. if we failed to pause the VM, then there's a good chance unpausing will fail). So for now we can avoid these scenarios by avoid adding containers to the pool if there was an error.

It's difficult to test this codepath with our current setup, so in a separate PR I'm planning on defining interfaces for `runner.Pool` and `runner.CommandRunner` so that we can have `runner.Run()` directly return an error like `InternalError`, which can't be easily triggered otherwise.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
