### PR TITLE
Write bazel output base under CI runner workspace dir

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -79,7 +79,7 @@ const (
 	defaultRunnerMemoryLimitBytes = tasksize.WorkflowMemEstimate
 	// Memory usage estimate multiplier for pooled runners, relative to the
 	// default memory estimate for execution tasks.
-	runnerMemUsageEstimateMultiplierBytes = 6.5
+	runnerMemUsageEstimateMultiplierBytes = 2
 
 	// Label assigned to runner pool request count metric for fulfilled requests.
 	hitStatusLabel = "hit"
@@ -471,11 +471,10 @@ func (p *Pool) add(ctx context.Context, r *CommandRunner) *labeledError {
 			"stats_failed",
 		}
 	}
-	// If memory usage stats are not implemented, fall back to the task size
-	// estimate.
+	// If memory usage stats are not implemented, fall back to the default task
+	// size estimate.
 	if stats.MemoryUsageBytes == 0 {
-		estimate := tasksize.Estimate(r.task)
-		stats.MemoryUsageBytes = estimate.GetEstimatedMemoryBytes()
+		stats.MemoryUsageBytes = int64(float64(tasksize.DefaultMemEstimate) * runnerMemUsageEstimateMultiplierBytes)
 	}
 
 	if stats.MemoryUsageBytes > p.maxRunnerMemoryUsageBytes {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -79,7 +79,7 @@ const (
 	defaultRunnerMemoryLimitBytes = tasksize.WorkflowMemEstimate
 	// Memory usage estimate multiplier for pooled runners, relative to the
 	// default memory estimate for execution tasks.
-	runnerMemUsageEstimateMultiplierBytes = 2
+	runnerMemUsageEstimateMultiplierBytes = 6.5
 
 	// Label assigned to runner pool request count metric for fulfilled requests.
 	hitStatusLabel = "hit"

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -418,7 +418,7 @@ func TestRunnerPool_ExceedMemoryLimit_OldestRunnerEvicted(t *testing.T) {
 	env := newTestEnv(t)
 	pool := newRunnerPool(t, env, &config.RunnerPoolConfig{
 		MaxRunnerCount:            unlimited,
-		MaxRunnerMemoryUsageBytes: 16 * 1e9,
+		MaxRunnerMemoryUsageBytes: 5200e6,
 		MaxRunnerDiskSizeBytes:    unlimited,
 	})
 	ctx := withAuthenticatedUser(t, context.Background(), "US1")
@@ -429,8 +429,8 @@ func TestRunnerPool_ExceedMemoryLimit_OldestRunnerEvicted(t *testing.T) {
 	r3 := mustGetNewRunner(t, ctx, pool, newWorkflowTask())
 
 	// Try adding all of them to the pool. 3rd runner should result in eviction,
-	// since the estimated memory usage for bare runners is 8GB, and the pool can
-	// only fit 2 * 8GB = 16GB worth of runners.
+	// since the estimated memory usage for paused bare runners is 2.6GB, and the
+	// pool can only fit 2 * 2.6GB = 5.2GB worth of runners.
 	mustAddWithoutEviction(t, ctx, pool, r1)
 	mustAddWithoutEviction(t, ctx, pool, r2)
 	mustAddWithEviction(t, ctx, pool, r3)


### PR DESCRIPTION
This allows the bazel output base to get cleaned up along with the workspace to prevent it from being "orphaned" when the executor restarts or if runners are evicted from the pool.

See https://github.com/buildbuddy-io/buildbuddy-internal/issues/1277#issuecomment-1087604511

---

**Version bump**: Patch

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1277
