### PR TITLE
Fix py3 incompatibility in release script.

### DIFF
--- a/release.py
+++ b/release.py
@@ -96,7 +96,7 @@ def create_and_push_tag(old_version, new_version, release_notes=''):
     if len(release_notes) > 0:
         commit_message = "\n".join([commit_message, release_notes])
 
-    commit_msg_file = tempfile.NamedTemporaryFile(delete=False)
+    commit_msg_file = tempfile.NamedTemporaryFile(mode='w+', delete=False)
     commit_msg_file_name = commit_msg_file.name
     commit_msg_file.write(commit_message)
     commit_msg_file.close()


### PR DESCRIPTION
NamedTemporaryFile by default opens file in binary mode but we are
writing a string which py3 is not happy about.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
