### PR TITLE
Switch hostedbazel to workflows pool

### DIFF
--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -168,7 +168,7 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		Arguments: args,
 		Platform: &repb.Platform{
 			Properties: []*repb.Platform_Property{
-				{Name: "Pool", Value: "hostedbazel"},
+				{Name: "Pool", Value: "workflows"},
 				{Name: platform.HostedBazelAffinityKeyPropertyName, Value: affinityKey},
 				{Name: "container-image", Value: RunnerContainerImage},
 				{Name: "recycle-runner", Value: "true"},


### PR DESCRIPTION
Verified that the workflows pool is able to run firecracker actions: https://app.buildbuddy.dev/invocation/b1836c88-9f7a-4641-bf23-c0ee0e57c225?actionDigest=4eacb2fbfe20c81826474112eb2471794ec360524e010601010f908b7424b72e/208&actionResultDigest=4eacb2fbfe20c81826474112eb2471794ec360524e010601010f908b7424b72e/208#action

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
