### PR TITLE
Set IsTargetRepoPublic field for PR events

### DIFF
--- a/enterprise/server/webhooks/github/github.go
+++ b/enterprise/server/webhooks/github/github.go
@@ -191,6 +191,7 @@ func parsePullRequestOrReview(event interface{}) (*interfaces.WebhookData, error
 		"Action",
 		"PullRequest.Base.Ref",
 		"PullRequest.Base.Repo.CloneURL",
+		"PullRequest.Base.Repo.Private",
 		"PullRequest.Head.Ref",
 		"PullRequest.Head.SHA",
 		"PullRequest.Head.Repo.CloneURL",
@@ -199,14 +200,16 @@ func parsePullRequestOrReview(event interface{}) (*interfaces.WebhookData, error
 		return nil, err
 	}
 	isFork := v["PullRequest.Base.Repo.CloneURL"] != v["PullRequest.Head.Repo.CloneURL"]
+	isTargetRepoPublic := v["PullRequest.Base.Repo.Private"] == "false"
 	return &interfaces.WebhookData{
-		EventName:     webhook_data.EventName.PullRequest,
-		PushedRepoURL: v["PullRequest.Head.Repo.CloneURL"],
-		PushedBranch:  v["PullRequest.Head.Ref"],
-		SHA:           v["PullRequest.Head.SHA"],
-		TargetRepoURL: v["PullRequest.Base.Repo.CloneURL"],
-		TargetBranch:  v["PullRequest.Base.Ref"],
-		IsTrusted:     !isFork,
+		EventName:          webhook_data.EventName.PullRequest,
+		PushedRepoURL:      v["PullRequest.Head.Repo.CloneURL"],
+		PushedBranch:       v["PullRequest.Head.Ref"],
+		SHA:                v["PullRequest.Head.SHA"],
+		TargetRepoURL:      v["PullRequest.Base.Repo.CloneURL"],
+		IsTargetRepoPublic: isTargetRepoPublic,
+		TargetBranch:       v["PullRequest.Base.Ref"],
+		IsTrusted:          !isFork,
 	}, nil
 }
 

--- a/enterprise/server/webhooks/github/github_test.go
+++ b/enterprise/server/webhooks/github/github_test.go
@@ -62,12 +62,13 @@ func TestParseRequest_ValidPullRequestReviewEvent_Success(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, &interfaces.WebhookData{
-		EventName:     "pull_request",
-		PushedRepoURL: "https://github.com/test2/bb-workflows-test.git",
-		PushedBranch:  "pr-test",
-		SHA:           "7d27db5443e48541a49693422c3b30fe6e8e3e9f",
-		TargetRepoURL: "https://github.com/test/bb-workflows-test.git",
-		TargetBranch:  "main",
+		EventName:          "pull_request",
+		PushedRepoURL:      "https://github.com/test2/bb-workflows-test.git",
+		PushedBranch:       "pr-test",
+		SHA:                "7d27db5443e48541a49693422c3b30fe6e8e3e9f",
+		TargetRepoURL:      "https://github.com/test/bb-workflows-test.git",
+		IsTargetRepoPublic: true,
+		TargetBranch:       "main",
 		// Even though the PR is from a fork, this should be trusted since the
 		// review is in "approved" state.
 		IsTrusted: true,


### PR DESCRIPTION
Accidentally reverted this logic in another PR. Fixed and updated the test

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1228
