### PR TITLE
split3

### DIFF
--- a/enterprise/server/raft/nodeliveness/nodeliveness.go
+++ b/enterprise/server/raft/nodeliveness/nodeliveness.go
@@ -161,9 +161,7 @@ func (h *Liveness) ensureValidLease(forceRenewal bool) (*rfpb.NodeLivenessRecord
 		}
 	}
 
-	if alreadyValid {
-		log.Debugf("Renewed %s", h.String())
-	} else {
+	if !alreadyValid {
 		log.Debugf("Acquired %s", h.String())
 	}
 

--- a/enterprise/server/raft/rangecache/rangecache.go
+++ b/enterprise/server/raft/rangecache/rangecache.go
@@ -37,13 +37,6 @@ func (rc *RangeCache) updateRange(rangeDescriptor *rfpb.RangeDescriptor) error {
 
 	r := rc.rangeMap.Get(left, right)
 	if r == nil {
-		// Easy add, there were no overlaps.
-		_, err := rc.rangeMap.Add(left, right, newDescriptor)
-		if err == nil {
-			log.Debugf("rangeCache easy-add of [%q, %q) %+v", left, right, newDescriptor)
-			return nil
-		}
-
 		// If this range overlaps, we'll check it against the overlapping
 		// ranges and possibly delete them or if they are newer, then we'll
 		// ignore this update.
@@ -65,7 +58,7 @@ func (rc *RangeCache) updateRange(rangeDescriptor *rfpb.RangeDescriptor) error {
 			rc.rangeMap.Remove(overlappingRange.Left, overlappingRange.Right)
 		}
 		log.Debugf("Adding new range: %d [%q, %q)", newDescriptor.GetRangeId(), left, right)
-		_, err = rc.rangeMap.Add(left, right, newDescriptor)
+		_, err := rc.rangeMap.Add(left, right, newDescriptor)
 		return err
 	} else {
 		v, ok := r.Val.(*rfpb.RangeDescriptor)
@@ -74,8 +67,6 @@ func (rc *RangeCache) updateRange(rangeDescriptor *rfpb.RangeDescriptor) error {
 		}
 		if newDescriptor.GetGeneration() > v.GetGeneration() {
 			r.Val = newDescriptor
-		} else {
-			log.Debugf("Ignoring rangeDescriptor %+v, because current has same or later generation: %+v", newDescriptor, v)
 		}
 	}
 	return nil

--- a/enterprise/server/raft/rangelease/rangelease.go
+++ b/enterprise/server/raft/rangelease/rangelease.go
@@ -266,9 +266,7 @@ func (l *Lease) ensureValidLease(forceRenewal bool) (*rfpb.RangeLeaseRecord, err
 		}
 	}
 
-	if alreadyValid {
-		log.Debugf("Renewed %s", l.String())
-	} else {
+	if !alreadyValid {
 		log.Debugf("Acquired %s", l.String())
 	}
 

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -31,6 +31,7 @@ go_library(
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_hashicorp_serf//serf",
         "@com_github_lni_dragonboat_v3//:dragonboat",
+        "@com_github_lni_dragonboat_v3//raftio",
         "@com_github_lni_dragonboat_v3//statemachine",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//reflection",

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -158,7 +158,6 @@ func (s *Store) maybeAcquireRangeLease(rd *rfpb.RangeDescriptor) {
 		return
 	}
 
-	start := time.Now()
 	rangeID := rd.GetRangeId()
 	rlIface, _ := s.leases.LoadOrStore(rangeID, rangelease.New(s.sender, s.liveness, rd))
 	rl, ok := rlIface.(*rangelease.Lease)

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -31,6 +31,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/serf/serf"
 	"github.com/lni/dragonboat/v3"
+	"github.com/lni/dragonboat/v3/raftio"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
@@ -68,6 +69,7 @@ type Store struct {
 	replicas sync.Map // map of uint64 rangeID -> *replica.Replica
 
 	metaRangeData string
+	leaderUpdatedCB listener.LeaderCB
 }
 
 func New(rootDir, fileDir string, nodeHost *dragonboat.NodeHost, gossipManager *gossip.GossipManager, sender *sender.Sender, registry registry.NodeRegistry, apiClient *client.APIClient) *Store {
@@ -89,9 +91,20 @@ func New(rootDir, fileDir string, nodeHost *dragonboat.NodeHost, gossipManager *
 
 		metaRangeData: "",
 	}
+	s.leaderUpdatedCB = listener.LeaderCB(s.onLeaderUpdated)
 	gossipManager.AddListener(s)
 	s.gossipUsage()
+
+	listener.DefaultListener().RegisterLeaderUpdatedCB(&s.leaderUpdatedCB)
 	return s
+}
+
+func (s *Store) onLeaderUpdated(info raftio.LeaderInfo) {
+	rd := s.lookupRange(info.ClusterID)
+	if rd == nil {
+		return
+	}
+	go s.maybeAcquireRangeLease(rd)
 }
 
 func (s *Store) Start(grpcAddress string) error {
@@ -114,6 +127,7 @@ func (s *Store) Start(grpcAddress string) error {
 }
 
 func (s *Store) Stop(ctx context.Context) error {
+	listener.DefaultListener().UnregisterLeaderUpdatedCB(&s.leaderUpdatedCB)
 	return grpc_server.GRPCShutdown(ctx, s.grpcServer)
 }
 
@@ -159,7 +173,6 @@ func (s *Store) maybeAcquireRangeLease(rd *rfpb.RangeDescriptor) {
 		}
 		err := rl.Lease()
 		if err == nil {
-			log.Debugf("Succesfully leased range: %s in %s", rl, time.Since(start))
 			break
 		}
 		log.Warningf("Error leasing range: %s: %s, will try again.", rl, err)
@@ -249,6 +262,8 @@ func (s *Store) AddRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 		}
 		go s.gossipManager.SetTags(map[string]string{constants.MetaRangeTag: string(buf)})
 	}
+
+	// Start goroutines for these so that Adding ranges is quick.
 	go s.maybeAcquireRangeLease(rd)
 	go s.gossipUsage()
 }
@@ -266,6 +281,7 @@ func (s *Store) RemoveRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 		return
 	}
 
+	// Start goroutines for these so that Removing ranges is quick.
 	go s.releaseRangeLease(rd.GetRangeId())
 	go s.gossipUsage()
 }
@@ -660,7 +676,6 @@ func (s *Store) renewNodeLiveness() {
 		}
 		err := s.liveness.Lease()
 		if err == nil {
-			log.Printf("Node is now live: %s", s.liveness.String())
 			return
 		}
 		log.Errorf("Error leasing node liveness record: %s", err)

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -68,7 +68,7 @@ type Store struct {
 	leases   sync.Map // map of uint64 rangeID -> *rangelease.Lease
 	replicas sync.Map // map of uint64 rangeID -> *replica.Replica
 
-	metaRangeData string
+	metaRangeData   string
 	leaderUpdatedCB listener.LeaderCB
 }
 


### PR DESCRIPTION
- Simplify rangecache logic
- Allow populating rangecache with the 0th replica
- Clean up logging
- Bring back functionality to get rangelease when leader changes
- Buildfix
