### PR TITLE
More fixes for firecracker timeout handling

### DIFF
--- a/enterprise/server/remote_execution/commandutil/BUILD
+++ b/enterprise/server/remote_execution/commandutil/BUILD
@@ -8,13 +8,16 @@ go_library(
     deps = [
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
+        "//server/util/log",
         "//server/util/status",
+        "@com_github_mitchellh_go_ps//:go-ps",
     ],
 )
 
 go_test(
     name = "commandutil_test",
     srcs = ["commandutil_test.go"],
+    data = ["//enterprise/server/remote_execution/commandutil/test_binary"],
     deps = [
         ":commandutil",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/remote_execution/commandutil/test_binary/BUILD
+++ b/enterprise/server/remote_execution/commandutil/test_binary/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+package(
+    default_testonly = 1,
+    default_visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "lib",
+    srcs = ["test_binary.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil/test_binary",
+)
+
+go_binary(
+    name = "test_binary",
+    embed = [":lib"],
+)

--- a/enterprise/server/remote_execution/commandutil/test_binary/test_binary.go
+++ b/enterprise/server/remote_execution/commandutil/test_binary/test_binary.go
@@ -1,0 +1,26 @@
+// Test binary for commandutil_test
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+func main() {
+	// Have this binary become its own process group leader
+	check(syscall.Setpgid(0, os.Getpid()))
+	_, err := os.Stdout.Write([]byte("stdout\n"))
+	check(err)
+	_, err = os.Stderr.Write([]byte("stderr\n"))
+	check(err)
+	time.Sleep(100 * time.Second)
+}
+
+func check(err error) {
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+}

--- a/enterprise/server/vmexec/vmexec.go
+++ b/enterprise/server/vmexec/vmexec.go
@@ -148,7 +148,7 @@ func (x *execServer) Exec(ctx context.Context, req *vmxpb.ExecRequest) (*vmxpb.E
 	defer x.reapMutex.RUnlock()
 
 	log.Debugf("Running command in VM: %q", cmd.String())
-	err := commandutil.RunWithProcessGroupCleanup(ctx, cmd)
+	err := commandutil.RunWithProcessTreeCleanup(ctx, cmd)
 	exitCode, err := commandutil.ExitCode(ctx, cmd, err)
 	rsp := &vmxpb.ExecResponse{}
 	rsp.ExitCode = int32(exitCode)

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.11
 	github.com/mattn/go-sqlite3 v1.14.11
 	github.com/mdlayher/vsock v0.0.0-20210303205602-10d591861736
+	github.com/mitchellh/go-ps v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1058,6 +1058,7 @@ github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXx
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=

--- a/server/testutil/testfs/BUILD
+++ b/server/testutil/testfs/BUILD
@@ -9,5 +9,6 @@ go_library(
         "//server/util/random",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/server/testutil/testfs/testfs.go
+++ b/server/testutil/testfs/testfs.go
@@ -8,10 +8,18 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// RunfilePath returns the path to the given bazel runfile.
+func RunfilePath(t testing.TB, path string) string {
+	path, err := bazel.Runfile(path)
+	require.NoError(t, err)
+	return path
+}
 
 // MakeTempDir creates and returns an empty directory that exists for the scope
 // of a test.


### PR DESCRIPTION
* We fail to collect stdout/stderr from certain bazel tests because the bazel `test-setup.sh` script runs the test child process as its own process group leader. So, [the fix in the last PR to kill processes by pgid](https://github.com/buildbuddy-io/buildbuddy/pull/1822/files#diff-ce918767a53b70309881b30d88900177b4791e488cee8d4449e1c1a01cab920aR113) was not sufficient. Fix this by explicitly killing the process tree by recursively inspecting child pids of the root command process. This fix also benefits the bare runner impl, not just firecracker.
* Move the action timeout calculation closer to when we actually send the exec request (after dialing the exec server), since dialing the exec server can eat up a significant amount of the timeout that would otherwise be allocated to collecting outputs.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
