### PR TITLE
Benchmark interceptors

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -289,6 +289,11 @@ proto_library(
 )
 
 proto_library(
+    name = "ping_service_proto",
+    srcs = ["ping_service.proto"],
+)
+
+proto_library(
     name = "buildbuddy_service_proto",
     srcs = ["buildbuddy_service.proto"],
     deps = [
@@ -605,6 +610,13 @@ go_proto_library(
     deps = [
         ":raft_go_proto",
     ],
+)
+
+go_proto_library(
+    name = "ping_service_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/ping_service",
+    proto = ":ping_service_proto",
 )
 
 go_proto_library(

--- a/proto/ping_service.proto
+++ b/proto/ping_service.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package ping;
+
+message PingRequest {
+  uint64 tag = 1;
+}
+message PingResponse {
+  uint64 tag = 1;
+}
+
+service Api {
+  // Raft Meta-API.
+  rpc Ping(PingRequest) returns (PingResponse);
+}

--- a/proto/ping_service.proto
+++ b/proto/ping_service.proto
@@ -10,6 +10,5 @@ message PingResponse {
 }
 
 service Api {
-  // Raft Meta-API.
   rpc Ping(PingRequest) returns (PingResponse);
 }

--- a/server/rpc/filters/BUILD
+++ b/server/rpc/filters/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "filters",
@@ -16,5 +16,20 @@ go_library(
         "@io_opentelemetry_go_contrib_instrumentation_google_golang_org_grpc_otelgrpc//:otelgrpc",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//metadata",
+    ],
+)
+
+go_test(
+    name = "filters_test",
+    srcs = ["filters_test.go"],
+    deps = [
+        "//proto:ping_service_go_proto",
+        "//server/testutil/testenv",
+        "//server/testutil/testport",
+        "//server/util/grpc_client",
+        "//server/util/grpc_server",
+        "//server/util/log",
+        "//server/util/random",
+        "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/server/rpc/filters/filters_test.go
+++ b/server/rpc/filters/filters_test.go
@@ -1,0 +1,109 @@
+package filters_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/random"
+	"google.golang.org/grpc"
+
+	pspb "github.com/buildbuddy-io/buildbuddy/proto/ping_service"
+)
+
+type pingServer struct{}
+func (p *pingServer) Ping(ctx context.Context, req *pspb.PingRequest) (*pspb.PingResponse, error) {
+	return &pspb.PingResponse{
+		Tag: req.GetTag(),
+	}, nil
+}
+
+func BenchmarkBare(b *testing.B) {
+	ctx := context.Background()
+	listenAddr := fmt.Sprintf("localhost:%d", testport.FindFree(b))	
+	grpcServer := grpc.NewServer()
+	ps := &pingServer{}
+	pspb.RegisterApiServer(grpcServer, ps)
+
+	lis, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		b.Fatal(err)
+	}
+	go func() {
+		grpcServer.Serve(lis)
+	}()
+
+	conn, err := grpc.Dial(listenAddr, grpc.WithInsecure())
+	if err != nil {
+		b.Fatal(err)
+	}
+	client := pspb.NewApiClient(conn)
+
+	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+                req := &pspb.PingRequest{
+			Tag: random.RandUint64(),
+		}
+                b.StartTimer()
+		rsp, err := client.Ping(ctx, req)
+		if err != nil {
+                        b.Fatal(err)
+		}
+		if rsp.GetTag() != req.GetTag() {
+			b.Fatal("tag mismatch")
+		}
+        }
+	grpcServer.Stop()
+}
+
+
+func BenchmarkInstrumented(b *testing.B) {
+	*log.LogLevel = "error"
+	*log.IncludeShortFileName = true
+	log.Configure()
+
+	ctx := context.Background()
+	listenAddr := fmt.Sprintf("localhost:%d", testport.FindFree(b))	
+	
+	env := testenv.GetTestEnv(b)
+	grpcOptions := grpc_server.CommonGRPCServerOptions(env)
+	grpcServer := grpc.NewServer(grpcOptions...)
+	ps := &pingServer{}
+	pspb.RegisterApiServer(grpcServer, ps)
+
+	lis, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		b.Fatal(err)
+	}
+	go func() {
+		grpcServer.Serve(lis)
+	}()
+	conn, err := grpc_client.DialTarget("grpc://"+listenAddr)
+	if err != nil {
+		b.Fatal(err)
+	}
+	client := pspb.NewApiClient(conn)
+
+	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+                req := &pspb.PingRequest{
+			Tag: random.RandUint64(),
+		}
+                b.StartTimer()
+		rsp, err := client.Ping(ctx, req)
+		if err != nil {
+                        b.Fatal(err)
+		}
+		if rsp.GetTag() != req.GetTag() {
+			b.Fatal("tag mismatch")
+		}
+        }
+	grpcServer.Stop()
+}
+

--- a/server/rpc/filters/filters_test.go
+++ b/server/rpc/filters/filters_test.go
@@ -46,6 +46,7 @@ func BenchmarkBare(b *testing.B) {
 	}
 	client := pspb.NewApiClient(conn)
 
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		b.StopTimer()
 		req := &pspb.PingRequest{
@@ -63,7 +64,51 @@ func BenchmarkBare(b *testing.B) {
 	grpcServer.Stop()
 }
 
-func BenchmarkInstrumented(b *testing.B) {
+func BenchmarkInstrumentedClient(b *testing.B) {
+	*log.LogLevel = "error"
+	*log.IncludeShortFileName = true
+	log.Configure()
+
+	ctx := context.Background()
+	listenAddr := fmt.Sprintf("localhost:%d", testport.FindFree(b))
+
+	grpcServer := grpc.NewServer()
+	ps := &pingServer{}
+	pspb.RegisterApiServer(grpcServer, ps)
+
+	lis, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		b.Fatal(err)
+	}
+	go func() {
+		grpcServer.Serve(lis)
+	}()
+
+	conn, err := grpc_client.DialTarget("grpc://" + listenAddr)
+	if err != nil {
+		b.Fatal(err)
+	}
+	client := pspb.NewApiClient(conn)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		req := &pspb.PingRequest{
+			Tag: random.RandUint64(),
+		}
+		b.StartTimer()
+		rsp, err := client.Ping(ctx, req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if rsp.GetTag() != req.GetTag() {
+			b.Fatal("tag mismatch")
+		}
+	}
+	grpcServer.Stop()
+}
+
+func BenchmarkInstrumentedServer(b *testing.B) {
 	*log.LogLevel = "error"
 	*log.IncludeShortFileName = true
 	log.Configure()
@@ -84,12 +129,60 @@ func BenchmarkInstrumented(b *testing.B) {
 	go func() {
 		grpcServer.Serve(lis)
 	}()
+
+	conn, err := grpc.Dial(listenAddr, grpc.WithInsecure())
+	if err != nil {
+		b.Fatal(err)
+	}
+	client := pspb.NewApiClient(conn)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		req := &pspb.PingRequest{
+			Tag: random.RandUint64(),
+		}
+		b.StartTimer()
+		rsp, err := client.Ping(ctx, req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if rsp.GetTag() != req.GetTag() {
+			b.Fatal("tag mismatch")
+		}
+	}
+	grpcServer.Stop()
+}
+
+func BenchmarkInstrumentedAll(b *testing.B) {
+	*log.LogLevel = "error"
+	*log.IncludeShortFileName = true
+	log.Configure()
+
+	ctx := context.Background()
+	listenAddr := fmt.Sprintf("localhost:%d", testport.FindFree(b))
+
+	env := testenv.GetTestEnv(b)
+	grpcOptions := grpc_server.CommonGRPCServerOptions(env)
+	grpcServer := grpc.NewServer(grpcOptions...)
+	ps := &pingServer{}
+	pspb.RegisterApiServer(grpcServer, ps)
+
+	lis, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		b.Fatal(err)
+	}
+	go func() {
+		grpcServer.Serve(lis)
+	}()
+
 	conn, err := grpc_client.DialTarget("grpc://" + listenAddr)
 	if err != nil {
 		b.Fatal(err)
 	}
 	client := pspb.NewApiClient(conn)
 
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		b.StopTimer()
 		req := &pspb.PingRequest{

--- a/server/rpc/filters/filters_test.go
+++ b/server/rpc/filters/filters_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 type pingServer struct{}
+
 func (p *pingServer) Ping(ctx context.Context, req *pspb.PingRequest) (*pspb.PingResponse, error) {
 	return &pspb.PingResponse{
 		Tag: req.GetTag(),
@@ -26,7 +27,7 @@ func (p *pingServer) Ping(ctx context.Context, req *pspb.PingRequest) (*pspb.Pin
 
 func BenchmarkBare(b *testing.B) {
 	ctx := context.Background()
-	listenAddr := fmt.Sprintf("localhost:%d", testport.FindFree(b))	
+	listenAddr := fmt.Sprintf("localhost:%d", testport.FindFree(b))
 	grpcServer := grpc.NewServer()
 	ps := &pingServer{}
 	pspb.RegisterApiServer(grpcServer, ps)
@@ -47,21 +48,20 @@ func BenchmarkBare(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		b.StopTimer()
-                req := &pspb.PingRequest{
+		req := &pspb.PingRequest{
 			Tag: random.RandUint64(),
 		}
-                b.StartTimer()
+		b.StartTimer()
 		rsp, err := client.Ping(ctx, req)
 		if err != nil {
-                        b.Fatal(err)
+			b.Fatal(err)
 		}
 		if rsp.GetTag() != req.GetTag() {
 			b.Fatal("tag mismatch")
 		}
-        }
+	}
 	grpcServer.Stop()
 }
-
 
 func BenchmarkInstrumented(b *testing.B) {
 	*log.LogLevel = "error"
@@ -69,8 +69,8 @@ func BenchmarkInstrumented(b *testing.B) {
 	log.Configure()
 
 	ctx := context.Background()
-	listenAddr := fmt.Sprintf("localhost:%d", testport.FindFree(b))	
-	
+	listenAddr := fmt.Sprintf("localhost:%d", testport.FindFree(b))
+
 	env := testenv.GetTestEnv(b)
 	grpcOptions := grpc_server.CommonGRPCServerOptions(env)
 	grpcServer := grpc.NewServer(grpcOptions...)
@@ -84,7 +84,7 @@ func BenchmarkInstrumented(b *testing.B) {
 	go func() {
 		grpcServer.Serve(lis)
 	}()
-	conn, err := grpc_client.DialTarget("grpc://"+listenAddr)
+	conn, err := grpc_client.DialTarget("grpc://" + listenAddr)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -92,18 +92,17 @@ func BenchmarkInstrumented(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		b.StopTimer()
-                req := &pspb.PingRequest{
+		req := &pspb.PingRequest{
 			Tag: random.RandUint64(),
 		}
-                b.StartTimer()
+		b.StartTimer()
 		rsp, err := client.Ping(ctx, req)
 		if err != nil {
-                        b.Fatal(err)
+			b.Fatal(err)
 		}
 		if rsp.GetTag() != req.GetTag() {
 			b.Fatal("tag mismatch")
 		}
-        }
+	}
 	grpcServer.Stop()
 }
-


### PR DESCRIPTION
What I am seeing is that with client/server interceptors enabled (and logging at ERROR level), a simple server and client do 60% more allocations than a bare server.

goos: linux
goarch: amd64
cpu: AMD Ryzen 9 5950X 16-Core Processor
BenchmarkBare-32            	    9894	    102119 ns/op	    8681 B/op	     172 allocs/op
...
BenchmarkInstrumented-32    	    8373	    142681 ns/op	   15834 B/op	     277 allocs/op
PASS


