### PR TITLE
Add more executor error handling tests

### DIFF
--- a/enterprise/server/test/integration/remote_execution/bazel_rbe/BUILD
+++ b/enterprise/server/test/integration/remote_execution/bazel_rbe/BUILD
@@ -3,13 +3,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "bazel_rbe_test",
     srcs = ["bazel_rbe_test.go"],
-    shard_count = 6,
+    shard_count = 11,
     deps = [
+        "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/test/integration/remote_execution/rbetest",
         "//server/metrics",
         "//server/testutil/testbazel",
         "//server/testutil/testmetrics",
         "//server/util/bazel",
+        "//server/util/status",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
+++ b/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
@@ -4,15 +4,33 @@ package bazel_rbe_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/test/integration/remote_execution/rbetest"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testbazel"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testmetrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	// The max number of bazel retries; passed as the --remote_retries flag to
+	// bazel. The default is 5, but we set it to 2 to reduce test execution time
+	// since bazel does exponential backoff between retries. We don't use 1 here
+	// so that we can distinguish between cases where bazel allows exactly 1
+	// retry in certain error scenarios; particularly, when refreshing after
+	// UNAUTHENTICATED errors:
+	// https://cs.github.com/bazelbuild/bazel/blob/93677c68f0bc688dbfa75484688160cdbdae7328/src/main/java/com/google/devtools/build/lib/remote/util/Utils.java#L519
+	bazelRemoteRetries = 2
+
+	// The number of times that the scheduler will retry. This should match
+	// the const with the same name in scheduler_server.go
+	schedulerMaxTaskAttemptCount = 5
 )
 
 func TestSimpleAction_Exit0(t *testing.T) {
@@ -49,8 +67,7 @@ func TestSimpleAction_TerminateWithSIGKILL(t *testing.T) {
 	// SIGKILL usually happens due to OOM, so make sure these are retried
 	assert.Contains(t, res.Stderr, "Resource Exhausted")
 	assert.Contains(t, res.Stderr, "signal: killed")
-	// 1 initial attempt + 5 scheduler retries
-	assert.Equal(t, 6, tasksStarted(t))
+	assert.Equal(t, 1+bazelRemoteRetries, tasksStarted(t))
 }
 
 func TestSimpleAction_TerminateWithSIGABRT(t *testing.T) {
@@ -64,8 +81,119 @@ func TestSimpleAction_TerminateWithSIGABRT(t *testing.T) {
 	assert.Contains(
 		t, res.Stderr, "Aborting test action",
 		"Error message logged before aborting should be visible in bazel stderr")
-	// 1 initial attempt + 5 scheduler retries
-	assert.Equal(t, 6, tasksStarted(t))
+	assert.Equal(t, 1+bazelRemoteRetries, tasksStarted(t))
+}
+
+func TestPersistentUnavailableError_Retried(t *testing.T) {
+	env := rbetest.NewRBETestEnv(t)
+	env.AddBuildBuddyServer()
+	const errMsg = "error injected by test"
+	errResult := commandutil.ErrorResult(status.UnavailableError(errMsg))
+	env.AddExecutorWithOptions(&rbetest.ExecutorOptions{
+		RunInterceptor: rbetest.AlwaysReturn(errResult),
+	})
+	// observe initial count so that we can get the diff at the end of the test
+	_ = tasksStarted(t)
+	ctx := context.Background()
+
+	res := runRemoteShellActionViaBazel(t, ctx, env, "exit 0")
+
+	require.Error(t, res.Error)
+	assert.Contains(t, res.Stderr, "Unavailable")
+	assert.Contains(t, res.Stderr, errMsg)
+	assert.Equal(t, 1+bazelRemoteRetries, tasksStarted(t))
+}
+
+func TestTransientUnavailableError_Retried(t *testing.T) {
+	env := rbetest.NewRBETestEnv(t)
+	env.AddBuildBuddyServer()
+	const errMsg = "error injected by test"
+	errResult := commandutil.ErrorResult(status.UnavailableError(errMsg))
+	env.AddExecutorWithOptions(&rbetest.ExecutorOptions{
+		RunInterceptor: rbetest.ReturnForFirstAttempt(errResult),
+	})
+	// observe initial count so that we can get the diff at the end of the test
+	_ = tasksStarted(t)
+	ctx := context.Background()
+
+	res := runRemoteShellActionViaBazel(t, ctx, env, "exit 0")
+
+	require.NoError(t, res.Error)
+	assert.NotContains(t, res.Stderr, errMsg)
+	// 1 failed attempt due to transient error + 1 successful attempt
+	assert.Equal(t, 2, tasksStarted(t), "unexpected number of retries")
+}
+
+func TestTransientInternalError_Retried(t *testing.T) {
+	env := rbetest.NewRBETestEnv(t)
+	env.AddBuildBuddyServer()
+	const errMsg = "error injected by test"
+	errResult := commandutil.ErrorResult(status.InternalError(errMsg))
+	env.AddExecutorWithOptions(&rbetest.ExecutorOptions{
+		RunInterceptor: rbetest.ReturnForFirstAttempt(errResult),
+	})
+	// observe initial count so that we can get the diff at the end of the test
+	_ = tasksStarted(t)
+	ctx := context.Background()
+
+	res := runRemoteShellActionViaBazel(t, ctx, env, "exit 0")
+
+	require.NoError(t, res.Error)
+	assert.NotContains(t, res.Stderr, errMsg)
+	// 1 failed attempt due to transient error + 1 successful attempt
+	assert.Equal(t, 2, tasksStarted(t))
+}
+
+func TestUnauthenticatedError_RetriedOnce(t *testing.T) {
+	env := rbetest.NewRBETestEnv(t)
+	env.AddBuildBuddyServer()
+	const errMsg = "error injected by test"
+	errResult := commandutil.ErrorResult(status.UnauthenticatedError(errMsg))
+	env.AddExecutorWithOptions(&rbetest.ExecutorOptions{
+		RunInterceptor: rbetest.AlwaysReturn(errResult),
+	})
+	// observe initial count so that we can get the diff at the end of the test
+	_ = tasksStarted(t)
+	ctx := context.Background()
+
+	res := runRemoteShellActionViaBazel(t, ctx, env, "exit 0")
+
+	require.Error(t, res.Error)
+	assert.Contains(t, res.Stderr, errMsg)
+	// Bazel allows a single retry for Unauthenticated errors via to allow for
+	// refreshing stale auth credentials. See:
+	// https://cs.github.com/bazelbuild/bazel/blob/93677c68f0bc688dbfa75484688160cdbdae7328/src/main/java/com/google/devtools/build/lib/remote/GrpcRemoteExecutor.java#L138
+	assert.Equal(t, 2, tasksStarted(t))
+}
+
+func TestExecutorShutdown_Retried(t *testing.T) {
+	env := rbetest.NewRBETestEnv(t)
+	env.AddBuildBuddyServer()
+	// TODO(bduffany): Simplify executor shutdown logic across runner types and
+	// remove reliance on ErrSIGKILL here
+	errResult := commandutil.ErrorResult(commandutil.ErrSIGKILL)
+	env.AddExecutorWithOptions(&rbetest.ExecutorOptions{
+		RunInterceptor: rbetest.AlwaysReturn(errResult),
+	})
+	// observe initial count so that we can get the diff at the end of the test
+	_ = tasksStarted(t)
+	ctx := context.Background()
+
+	res := runRemoteShellActionViaBazel(t, ctx, env, `
+		echo THIS_MSG_SHOULD_APPEAR_IN_BAZEL_STDERR >&2
+		exit 0
+	`)
+
+	require.Error(t, res.Error)
+	assert.Contains(
+		t, res.Stderr,
+		"command was terminated by SIGKILL, likely due to executor shutdown or OOM")
+	// TODO(bduffany): Fail faster. Currently, these get retried by both the
+	// scheduler and Bazel, where each bazel attempt results in 5 scheduler
+	// attempts.
+	assert.Equal(t, (1+bazelRemoteRetries)*schedulerMaxTaskAttemptCount, tasksStarted(t))
+	// TODO(bduffany): Ensure that we get partial debug output in this case
+	// assert.Contains(t, res.Stderr, "THIS_MSG_SHOULD_APPEAR_IN_BAZEL_STDERR")
 }
 
 func TestActionWithContainerImage_InvalidArgument(t *testing.T) {
@@ -79,10 +207,9 @@ func TestActionWithContainerImage_InvalidArgument(t *testing.T) {
 	require.Error(t, res.Error)
 	assert.Contains(t, res.Stderr, "InvalidArgument")
 	// TODO(bduffany): Fail faster. Currently, these get retried by both the
-	// scheduler and Bazel, causing 5 bazel attempts, each of which results in
-	// 6 attempts by the scheduler, with exponential backoff between each bazel
-	// attempt.
-	assert.Equal(t, 30, tasksStarted(t))
+	// scheduler and Bazel, where each bazel attempt results in 5 scheduler
+	// attempts.
+	assert.Equal(t, (1+bazelRemoteRetries)*(schedulerMaxTaskAttemptCount), tasksStarted(t))
 }
 
 func TestActionWithRunnerRecycling_Unauthenticated(t *testing.T) {
@@ -100,10 +227,9 @@ func TestActionWithRunnerRecycling_Unauthenticated(t *testing.T) {
 	assert.Contains(t, res.Stderr, "Unavailable")
 	assert.Contains(t, res.Stderr, "runner recycling is not supported for anonymous builds")
 	// TODO(bduffany): Fail faster. Currently, these get retried by both the
-	// scheduler and Bazel, causing 5 bazel attempts, each of which results in
-	// 6 attempts by the scheduler, with exponential backoff between each bazel
-	// attempt.
-	assert.Equal(t, 30, tasksStarted(t))
+	// scheduler and Bazel, where each bazel attempt results in 5 scheduler
+	// attempts.
+	assert.Equal(t, (1+bazelRemoteRetries)*(schedulerMaxTaskAttemptCount), tasksStarted(t))
 }
 
 func setup(t *testing.T) *rbetest.Env {
@@ -158,7 +284,11 @@ exec(name = "exec", command = """` + shCommand + `""")
 `,
 	})
 	// Execute just the test action remotely.
-	buildArgs := []string{":exec", "--remote_executor=" + env.GetRemoteExecutionTarget()}
+	buildArgs := []string{
+		":exec",
+		"--remote_executor=" + env.GetRemoteExecutionTarget(),
+		"--remote_retries=" + fmt.Sprintf("%d", bazelRemoteRetries),
+	}
 	buildArgs = append(buildArgs, extraBazelArgs...)
 	return testbazel.Invoke(ctx, t, ws, "build", buildArgs...)
 }

--- a/enterprise/server/test/integration/remote_execution/rbetest/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbetest/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//server/build_event_protocol/build_event_server",
         "//server/buildbuddy_server",
         "//server/config",
+        "//server/environment",
         "//server/interfaces",
         "//server/metrics",
         "//server/remote_cache/action_cache_server",


### PR DESCRIPTION
:point_right: This depends on the runner refactoring in https://github.com/buildbuddy-io/buildbuddy/pull/1877 since we need to be able to stub in a test runner impl that returns arbitrary error results.

---

Add more RBE error handling tests now that we have more flexibility on how we inject errors.

This is in preparation for implementing the changes described here: https://docs.google.com/document/d/1fIC4gt4sZBH89-NkcQn6EEGRhU2rMwV6d0QiJpLw7d8/edit#heading=h.6u7iifm7d5cn

Some of the test assertions added in this PR demonstrate some of the issues that should be corrected as part of these changes.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
