### PR TITLE
Allow specifying--dev flag for exec containers

### DIFF
--- a/enterprise/server/remote_execution/containers/docker/BUILD
+++ b/enterprise/server/remote_execution/containers/docker/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//proto:remote_execution_go_proto",
+        "//server/config",
         "//server/environment",
         "//server/interfaces",
         "//server/util/log",

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -25,8 +25,8 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"google.golang.org/grpc/codes"
 
-	config "github.com/buildbuddy-io/buildbuddy/server/config"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	config "github.com/buildbuddy-io/buildbuddy/server/config"
 	dockertypes "github.com/docker/docker/api/types"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	dockerclient "github.com/docker/docker/client"
@@ -252,8 +252,8 @@ func (r *dockerCommandContainer) hostConfig(workDir string) *dockercontainer.Hos
 	devices := make([]dockercontainer.DeviceMapping, 0)
 	for _, device := range r.options.DockerDevices {
 		devices = append(devices, dockercontainer.DeviceMapping{
-			PathOnHost: device.PathOnHost,
-			PathInContainer: device.PathInContainer,
+			PathOnHost:        device.PathOnHost,
+			PathInContainer:   device.PathInContainer,
 			CgroupPermissions: device.CgroupPermissions,
 		})
 	}

--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//proto:remote_execution_go_proto",
+        "//server/config",
         "//server/environment",
         "//server/interfaces",
         "//server/util/background",

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -18,6 +18,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
+	config "github.com/buildbuddy-io/buildbuddy/server/config"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
@@ -38,6 +39,7 @@ type PodmanOptions struct {
 	ForceRoot bool
 	Network   string
 	CapAdd    string
+	Devices   []config.DockerDeviceMapping
 	Runtime   string
 }
 
@@ -95,6 +97,9 @@ func (c *podmanCommandContainer) getPodmanRunArgs(workDir string) []string {
 	}
 	if c.options.CapAdd != "" {
 		args = append(args, "--cap-add="+c.options.CapAdd)
+	}
+	for _, device := range c.options.Devices {
+		args = append(args, "--device="+device.PathOnHost)
 	}
 	if c.options.Runtime != "" {
 		args = append(args, "--runtime="+c.options.Runtime)

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -18,8 +18,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
-	config "github.com/buildbuddy-io/buildbuddy/server/config"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	config "github.com/buildbuddy-io/buildbuddy/server/config"
 )
 
 var (
@@ -99,7 +99,17 @@ func (c *podmanCommandContainer) getPodmanRunArgs(workDir string) []string {
 		args = append(args, "--cap-add="+c.options.CapAdd)
 	}
 	for _, device := range c.options.Devices {
-		args = append(args, "--device="+device.PathOnHost)
+		deviceSpecs := make([]string, 0)
+		if device.PathOnHost != "" {
+			deviceSpecs = append(deviceSpecs, device.PathOnHost)
+		}
+		if device.PathInContainer != "" {
+			deviceSpecs = append(deviceSpecs, device.PathInContainer)
+		}
+		if device.CgroupPermissions != "" {
+			deviceSpecs = append(deviceSpecs, device.CgroupPermissions)
+		}
+		args = append(args, "--device="+strings.Join(deviceSpecs, ":"))
 	}
 	if c.options.Runtime != "" {
 		args = append(args, "--runtime="+c.options.Runtime)

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -662,6 +662,7 @@ func (p *pool) dockerOptions() *docker.DockerOptions {
 		UseHostNetwork:          cfg.DockerNetHost,
 		DockerMountMode:         cfg.DockerMountMode,
 		DockerCapAdd:            cfg.DockerCapAdd,
+		DockerDevices:           cfg.DockerDevices,
 		InheritUserIDs:          cfg.DockerInheritUserIDs,
 	}
 }
@@ -875,6 +876,7 @@ func (p *pool) newContainer(ctx context.Context, props *platform.Properties, tas
 			ForceRoot: props.DockerForceRoot,
 			Network:   props.DockerNetwork,
 			CapAdd:    cfg.DockerCapAdd,
+			Devices:   cfg.DockerDevices,
 			Runtime:   cfg.PodmanRuntime,
 		}
 		ctr = podman.NewPodmanCommandContainer(p.env, p.imageCacheAuth, props.ContainerImage, p.buildRoot, opts)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -288,6 +288,12 @@ type RemoteExecutionConfig struct {
 	EnableRedisAvailabilityMonitoring bool               `yaml:"enable_redis_availability_monitoring" usage:"If enabled, the execution server will detect if Redis has lost state and will ask Bazel to retry executions."`
 }
 
+type DockerDeviceMapping struct {
+	PathOnHost         string  `yaml:"path_on_host" usage:"path to device that should be mapped from the host."`
+	PathInContainer    string  `yaml:"path_in_container" usage:"path under which the device will be present in container."`
+	CgroupPermissions  string  `yaml:"cgroup_permissions" usage:"cgroup permissions that should be assinged to device."`
+}
+
 type ExecutorConfig struct {
 	AppTarget                     string                    `yaml:"app_target" usage:"The GRPC url of a buildbuddy app server."`
 	Pool                          string                    `yaml:"pool" usage:"Executor pool name. Only one of this config option or the MY_POOL environment variable should be specified."`
@@ -302,6 +308,7 @@ type ExecutorConfig struct {
 	RunnerPool                    RunnerPoolConfig          `yaml:"runner_pool"`
 	DockerNetHost                 bool                      `yaml:"docker_net_host" usage:"Sets --net=host on the docker command. Intended for local development only."`
 	DockerCapAdd                  string                    `yaml:"docker_cap_add" usage:"Sets --cap-add= on the docker command. Comma separated."`
+	DockerDevices                 []DockerDeviceMapping     `yaml:"docker_devices" usage:"Sets --device= on the docker command."`
 	DockerSiblingContainers       bool                      `yaml:"docker_sibling_containers" usage:"If set, mount the configured Docker socket to containers spawned for each action, to enable Docker-out-of-Docker (DooD). Takes effect only if docker_socket is also set. Should not be set by executors that can run untrusted code."`
 	DockerInheritUserIDs          bool                      `yaml:"docker_inherit_user_ids" usage:"If set, run docker containers using the same uid and gid as the user running the executor process."`
 	DefaultXcodeVersion           string                    `yaml:"default_xcode_version" usage:"Sets the default Xcode version number to use if an action doesn't specify one. If not set, /Applications/Xcode.app/ is used."`

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -289,9 +289,9 @@ type RemoteExecutionConfig struct {
 }
 
 type DockerDeviceMapping struct {
-	PathOnHost         string  `yaml:"path_on_host" usage:"path to device that should be mapped from the host."`
-	PathInContainer    string  `yaml:"path_in_container" usage:"path under which the device will be present in container."`
-	CgroupPermissions  string  `yaml:"cgroup_permissions" usage:"cgroup permissions that should be assigned to device."`
+	PathOnHost        string `yaml:"path_on_host" usage:"path to device that should be mapped from the host."`
+	PathInContainer   string `yaml:"path_in_container" usage:"path under which the device will be present in container."`
+	CgroupPermissions string `yaml:"cgroup_permissions" usage:"cgroup permissions that should be assigned to device."`
 }
 
 type ExecutorConfig struct {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -291,7 +291,7 @@ type RemoteExecutionConfig struct {
 type DockerDeviceMapping struct {
 	PathOnHost         string  `yaml:"path_on_host" usage:"path to device that should be mapped from the host."`
 	PathInContainer    string  `yaml:"path_in_container" usage:"path under which the device will be present in container."`
-	CgroupPermissions  string  `yaml:"cgroup_permissions" usage:"cgroup permissions that should be assinged to device."`
+	CgroupPermissions  string  `yaml:"cgroup_permissions" usage:"cgroup permissions that should be assigned to device."`
 }
 
 type ExecutorConfig struct {


### PR DESCRIPTION
This change introduces the capability to pass devices from host machine to execution containers, which are being spawned by the build-buddy.

The rationale: adding support for `/dev/fuse` or any other host-bound devices during Bazel RBE execution.

---

**Version bump**: Minor