### PR TITLE
Make style.css cacheable

### DIFF
--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -76,5 +76,8 @@ genrule(
 
 sha(
     name = "sha",
-    srcs = ["//app:app_bundle"],
+    srcs = [
+        ":style.css",
+        "//app:app_bundle",
+    ],
 )

--- a/enterprise/app/BUILD.bazel
+++ b/enterprise/app/BUILD.bazel
@@ -82,5 +82,8 @@ genrule(
 
 sha(
     name = "sha",
-    srcs = ["//enterprise/app:app_bundle"],
+    srcs = [
+        ":style.css",
+        "//enterprise/app:app_bundle",
+    ],
 )

--- a/static/index.html
+++ b/static/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700,800&display=swap" rel="stylesheet" />
-    <link href="/app/style.css" rel="stylesheet" />
+    <link href="{{.StylePath}}" rel="stylesheet" />
     <link rel="apple-touch-icon" sizes="57x57" href="/favicon/apple-icon-57x57.png" />
     <link rel="apple-touch-icon" sizes="60x60" href="/favicon/apple-icon-60x60.png" />
     <link rel="apple-touch-icon" sizes="72x72" href="/favicon/apple-icon-72x72.png" />


### PR DESCRIPTION
This makes it so that `style.css` is cached in dev/prod, and also so that `style.css` caching is fixed during local development, so that we no longer need "Disable cache" ticked in devtools.

This should speed up initial page load time significantly, since there's a ~100ms gap where we aren't doing anything due to `style.css` being loaded:

![image](https://user-images.githubusercontent.com/2414826/164037599-ee643e45-10c4-4ad2-a2f0-f67cdbcc4793.png)

* Include styles in app bundle hash
* Append hash param to `style.css`

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
