### PR TITLE
Add SetMembers, Set, and GetAll methods to MetricsCollector

### DIFF
--- a/enterprise/server/backends/redis_metrics_collector/BUILD
+++ b/enterprise/server/backends/redis_metrics_collector/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "redis_metrics_collector",
@@ -12,5 +12,17 @@ go_library(
         "//enterprise/server/util/redisutil",
         "//server/environment",
         "@com_github_go_redis_redis_v8//:redis",
+    ],
+)
+
+go_test(
+    name = "redis_metrics_collector_test",
+    srcs = ["redis_metrics_collector_test.go"],
+    deps = [
+        ":redis_metrics_collector",
+        "//enterprise/server/testutil/testredis",
+        "//enterprise/server/util/redisutil",
+        "@com_github_go_redis_redis_v8//:redis",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector.go
+++ b/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector.go
@@ -88,7 +88,7 @@ func (c *collector) SetAdd(ctx context.Context, key string, members ...string) e
 	return c.SetAddWithExpiry(ctx, key, countExpiration, members...)
 }
 
-func (c *collector) SetMembers(ctx context.Context, key string) ([]string, error) {
+func (c *collector) SetGetMembers(ctx context.Context, key string) ([]string, error) {
 	return c.rdb.SMembers(ctx, key).Result()
 }
 

--- a/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector_test.go
+++ b/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector_test.go
@@ -1,0 +1,48 @@
+package redis_metrics_collector_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_metrics_collector"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redisutil"
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// noExpiration is a special expiration value indicating that no expiration
+	// should be set.
+	noExpiration time.Duration = 0
+)
+
+func TestSetAndGetAll(t *testing.T) {
+	target := testredis.Start(t).Target
+	rdb := redis.NewClient(redisutil.TargetToOptions(target))
+	rbuf := redisutil.NewCommandBuffer(rdb)
+	mc := redis_metrics_collector.New(rdb, rbuf)
+	ctx := context.Background()
+	const nKeys = 100_000
+
+	// Do a bunch of Set() operations
+	keys := make([]string, 0, nKeys)
+	expectedValues := make([]string, 0, nKeys)
+	for i := 0; i < nKeys; i++ {
+		key := fmt.Sprintf("key_%d", i)
+		keys = append(keys, key)
+		val := fmt.Sprintf("val_%d", i)
+		expectedValues = append(expectedValues, val)
+		err := mc.Set(ctx, key, val, noExpiration)
+		require.NoError(t, err)
+	}
+	err := rbuf.Flush(ctx)
+	require.NoError(t, err)
+
+	// Read back the values written via Set()
+	values, err := mc.GetAll(ctx, keys...)
+	require.NoError(t, err)
+	require.Equal(t, expectedValues, values)
+}

--- a/server/backends/memory_metrics_collector/BUILD
+++ b/server/backends/memory_metrics_collector/BUILD
@@ -5,7 +5,10 @@ go_library(
     srcs = ["memory_metrics_collector.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/backends/memory_metrics_collector",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_hashicorp_golang_lru//:golang-lru"],
+    deps = [
+        "//server/util/status",
+        "@com_github_hashicorp_golang_lru//:golang-lru",
+    ],
 )
 
 go_test(

--- a/server/backends/memory_metrics_collector/memory_metrics_collector.go
+++ b/server/backends/memory_metrics_collector/memory_metrics_collector.go
@@ -110,7 +110,7 @@ func (m *MemoryMetricsCollector) SetAddWithExpiry(ctx context.Context, key strin
 	return m.SetAdd(ctx, key, members...)
 }
 
-func (m *MemoryMetricsCollector) SetMembers(ctx context.Context, key string) ([]string, error) {
+func (m *MemoryMetricsCollector) SetGetMembers(ctx context.Context, key string) ([]string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/server/backends/memory_metrics_collector/memory_metrics_collector_test.go
+++ b/server/backends/memory_metrics_collector/memory_metrics_collector_test.go
@@ -2,9 +2,17 @@ package memory_metrics_collector
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	// noExpiration is a special expiration value indicating that no expiration
+	// should be set.
+	noExpiration time.Duration = 0
 )
 
 func TestIncrementCounts(t *testing.T) {
@@ -41,4 +49,28 @@ func TestIncrementCounts(t *testing.T) {
 	read, err = m.ReadCounts(context.Background(), "key2")
 	require.NoError(t, err)
 	require.Equal(t, counts1, read)
+}
+
+func TestSetAndGetAll(t *testing.T) {
+	mc, err := NewMemoryMetricsCollector()
+	require.NoError(t, err)
+	ctx := context.Background()
+	const nKeys = 50_000
+
+	// Do a bunch of Set() operations
+	keys := make([]string, 0, nKeys)
+	expectedValues := make([]string, 0, nKeys)
+	for i := 0; i < nKeys; i++ {
+		key := fmt.Sprintf("key_%d", i)
+		keys = append(keys, key)
+		val := fmt.Sprintf("val_%d", i)
+		expectedValues = append(expectedValues, val)
+		err := mc.Set(ctx, key, val, noExpiration)
+		require.NoError(t, err)
+	}
+
+	// Read back the values written via Set()
+	values, err := mc.GetAll(ctx, keys...)
+	require.NoError(t, err)
+	require.Equal(t, expectedValues, values)
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -649,6 +649,9 @@ type MetricsCollector interface {
 	IncrementCount(ctx context.Context, key, field string, n int64) error
 	SetAddWithExpiry(ctx context.Context, key string, expiry time.Duration, members ...string) error
 	SetAdd(ctx context.Context, key string, members ...string) error
+	SetMembers(ctx context.Context, key string) ([]string, error)
+	Set(ctx context.Context, key, value string, expiration time.Duration) error
+	GetAll(ctx context.Context, key ...string) ([]string, error)
 	ReadCounts(ctx context.Context, key string) (map[string]int64, error)
 	Delete(ctx context.Context, key string) error
 	Flush(ctx context.Context) error

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -649,7 +649,7 @@ type MetricsCollector interface {
 	IncrementCount(ctx context.Context, key, field string, n int64) error
 	SetAddWithExpiry(ctx context.Context, key string, expiry time.Duration, members ...string) error
 	SetAdd(ctx context.Context, key string, members ...string) error
-	SetMembers(ctx context.Context, key string) ([]string, error)
+	SetGetMembers(ctx context.Context, key string) ([]string, error)
 	Set(ctx context.Context, key, value string, expiration time.Duration) error
 	GetAll(ctx context.Context, key ...string) ([]string, error)
 	ReadCounts(ctx context.Context, key string) (map[string]int64, error)


### PR DESCRIPTION
These will be used for the new cache scorecard. `GetAll` is used instead of individual `Get` operations for better performance in the Redis case.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
