### PR TITLE
workround for podman readlink error

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -308,6 +308,7 @@ func (c *podmanCommandContainer) maybeCleanupCorruptedImages(ctx context.Context
 		return nil
 	}
 	result.Error = status.UnavailableError("a storage corruption occurred for podman")
+	result.ExitCode = commandutil.NoExitCode
 	return removeImage(ctx, c.image)
 }
 

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -307,7 +307,7 @@ func (c *podmanCommandContainer) maybeCleanupCorruptedImages(ctx context.Context
 	if !storageErrorRegex.MatchString(string(result.Stderr)) {
 		return nil
 	}
-	result.Error = status.UnavailableError("a storage corruption occurred for podman")
+	result.Error = status.UnavailableError("a storage corruption occurred")
 	result.ExitCode = commandutil.NoExitCode
 	return removeImage(ctx, c.image)
 }


### PR DESCRIPTION
When we detect that podman failed with the storage corruption warning
and readlink no such file error, we will remove the image and set the
command result to unavailable error to trigger a retry.