### PR TITLE
Add ability to override per-action properties internally

### DIFF
--- a/enterprise/server/remote_execution/platform/BUILD
+++ b/enterprise/server/remote_execution/platform/BUILD
@@ -6,8 +6,11 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/server/auth",
         "//proto:remote_execution_go_proto",
         "//server/environment",
+        "//server/interfaces",
+        "//server/util/bazel_request",
         "//server/util/log",
         "//server/util/status",
         "@org_golang_google_grpc//metadata",


### PR DESCRIPTION
When necessary, this lets us poke a key into redis like:

SET platform-override/ANON-TestRunner(//label:label_test) x-buildbuddy-platform.workload-isolation-type=podman

and have that override apply when that action is run.