### PR TITLE
use base image explicitly for smarter-device-manager

### DIFF
--- a/tools/smarter_device_manager/BUILD
+++ b/tools/smarter_device_manager/BUILD
@@ -3,17 +3,17 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 
 go_image(
     name = "smarter_device_manager_image",
+    base = "@buildbuddy_go_image_base//image",
     binary = "@com_gitlab_arm_research_smarter_device_manager//:smarter-device-manager",
-		base = "@buildbuddy_go_image_base//image",
     tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 
 container_push(
-   name = "push_image",
-   image = ":smarter_device_manager_image",
-   format = "Docker",
-   registry = "gcr.io",
-   repository = "flame-build/smarter-device-manager",
-   tag = "server_image",
+    name = "push_image",
+    format = "Docker",
+    image = ":smarter_device_manager_image",
+    registry = "gcr.io",
+    repository = "flame-build/smarter-device-manager",
+    tag = "server_image",
 )

--- a/tools/smarter_device_manager/BUILD
+++ b/tools/smarter_device_manager/BUILD
@@ -1,8 +1,19 @@
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 
 go_image(
     name = "smarter_device_manager_image",
     binary = "@com_gitlab_arm_research_smarter_device_manager//:smarter-device-manager",
+		base = "@buildbuddy_go_image_base//image",
     tags = ["manual"],
     visibility = ["//visibility:public"],
+)
+
+container_push(
+   name = "push_image",
+   image = ":smarter_device_manager_image",
+   format = "Docker",
+   registry = "gcr.io",
+   repository = "flame-build/smarter-device-manager",
+   tag = "server_image",
 )


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

rules_docker is using a base image that is out of date and has vulnerabilities, so we explicitly set the base image.
also adds container_push target to ease deployment of images.

---

**Version bump**: TODO <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
