### PR TITLE
Bump timeout in TestRedisRestart test.

### DIFF
--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -1180,7 +1180,7 @@ func TestRedisRestart(t *testing.T) {
 
 	// Wait for the remote execution to start by looking for the presence of a
 	// redis task key on one of the shards. This shard will become the victim.
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(30 * time.Second)
 	var victimShard *testredis.Handle
 	for time.Now().Before(deadline) && victimShard == nil {
 		for _, shard := range redisShards {


### PR DESCRIPTION
In the failing cases seen so far, it takes Bazel more than 10 seconds to
send any remote execution requests causing us to fail to find the remote
execution task information.

Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1324

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
