### PR TITLE
Link workflow invocation from inner invocations

### DIFF
--- a/app/components/link/link.tsx
+++ b/app/components/link/link.tsx
@@ -34,7 +34,7 @@ export const Link = React.forwardRef((props: LinkProps, ref: React.Ref<HTMLAncho
   return (
     <a
       ref={ref}
-      className={`link-wrapper ${className}`}
+      className={`link-wrapper ${className || ""}`}
       onClick={onClickWrapped}
       href={href}
       {...externalProps}

--- a/app/invocation/invocation_overview.tsx
+++ b/app/invocation/invocation_overview.tsx
@@ -11,7 +11,7 @@ import {
   Cloud,
   HardDrive,
   LayoutGrid,
-  Link,
+  Link as LinkIcon,
   Target,
   User as UserIcon,
   Wrench,
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import React from "react";
 import { User } from "../auth/auth_service";
+import { Link } from "../components/link/link";
 import format from "../format/format";
 import router from "../router/router";
 import InvocationButtons from "./invocation_buttons";
@@ -30,10 +31,6 @@ interface Props {
   user?: User;
 }
 export default class InvocationOverviewComponent extends React.Component<Props> {
-  handleOrganizationClicked() {
-    router.navigateHome();
-  }
-
   handleUserClicked() {
     router.navigateToUserHistory(this.props.model.getUser(false));
   }
@@ -81,6 +78,8 @@ export default class InvocationOverviewComponent extends React.Component<Props> 
     const ownerGroup = this.props.model.findOwnerGroup(this.props.user?.groups);
     const isBazelInvocation = this.props.model.isBazelInvocation();
     const roleLabel = format.formatRole(this.props.model.getRole());
+    const parentInvocationId = this.props.model.buildMetadataMap.get("PARENT_INVOCATION_ID");
+    const parentWorkflowId = this.props.model.buildMetadataMap.get("WORKFLOW_ID");
 
     return (
       <div className="container">
@@ -88,13 +87,14 @@ export default class InvocationOverviewComponent extends React.Component<Props> 
           <div className="breadcrumbs">
             {this.props.user && ownerGroup && (
               <>
-                <span onClick={this.handleOrganizationClicked.bind(this)} className="clickable">
-                  {ownerGroup.name}
-                </span>
-                <span onClick={this.handleOrganizationClicked.bind(this)} className="clickable">
-                  Builds
-                </span>
+                <Link href="/">{ownerGroup.name}</Link>
+                <Link href="/">Builds</Link>
               </>
+            )}
+            {parentInvocationId && (
+              <Link href={`/invocation/${parentInvocationId}`}>
+                {parentWorkflowId ? "Workflow" : "Bazel invocation"} {parentInvocationId}
+              </Link>
             )}
             <span>Invocation {this.props.invocationId}</span>
           </div>
@@ -218,7 +218,7 @@ export default class InvocationOverviewComponent extends React.Component<Props> 
           )}
           {this.props.model.getLinks().map((link) => (
             <a className="detail clickable" href={link.linkUrl} target="_blank">
-              <Link className="icon" />
+              <LinkIcon className="icon" />
               {link.linkText}
             </a>
           ))}

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -229,15 +229,11 @@ button {
   margin-bottom: 8px;
 }
 
-.breadcrumbs span:after {
+.breadcrumbs > :not(:last-child)::after {
   content: "›";
   padding: 0 8px;
   color: #ccc;
   font-weight: 600;
-}
-
-.breadcrumbs span:last-of-type:after {
-  content: "";
 }
 
 .shelf .details {

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -451,7 +451,7 @@ func run() error {
 		return status.WrapError(err, "ensure PATH")
 	}
 	// Write default bazelrc
-	if err := writeBazelrc(buildbuddyBazelrcPath); err != nil {
+	if err := writeBazelrc(buildbuddyBazelrcPath, buildEventReporter.invocationID); err != nil {
 		return status.WrapError(err, "write "+buildbuddyBazelrcPath)
 	}
 	// Delete bazelrc before exiting. Use abs path since we might cd after this
@@ -1385,7 +1385,7 @@ func invocationURL(invocationID string) string {
 	return urlPrefix + invocationID
 }
 
-func writeBazelrc(path string) error {
+func writeBazelrc(path, invocationID string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
@@ -1397,6 +1397,7 @@ func writeBazelrc(path string) error {
 
 	lines := []string{
 		"build --build_metadata=ROLE=CI",
+		"build --build_metadata=PARENT_INVOCATION_ID=" + invocationID,
 		// Don't report commit statuses for individual bazel commands, since the
 		// overall status of all bazel commands is reflected in the status reported
 		// for the workflow invocation. In addition, for PRs, we first merge with
@@ -1405,6 +1406,9 @@ func writeBazelrc(path string) error {
 		"build --build_metadata=DISABLE_COMMIT_STATUS_REPORTING=true",
 		"build --bes_backend=" + *besBackend,
 		"build --bes_results_url=" + *besResultsURL,
+	}
+	if *workflowID != "" {
+		lines = append(lines, "build --build_metadata=WORKFLOW_ID="+*workflowID)
 	}
 	if apiKey := os.Getenv(buildbuddyAPIKeyEnvVarName); apiKey != "" {
 		lines = append(lines, "build --remote_header=x-buildbuddy-api-key="+apiKey)


### PR DESCRIPTION
* Add PARENT_INVOCATION_ID and WORKFLOW_ID as build metadata to child invocations, so that we know the parent invocation ID as well as whether it's a workflow (vs hosted bazel)
* Show "Workflow <workflow_invocation_id>" in the breadcrumb (or "Bazel invocation <hostedbazel_invocation_id>" for hosted bazel)

![image](https://user-images.githubusercontent.com/2414826/164777921-8cbc8fbc-4704-43a3-bf90-52b4b83abd13.png)

Wraps more or less as expected:

![image](https://user-images.githubusercontent.com/2414826/164779682-f4344527-97d5-4bd9-80e6-bdb2a5624f5a.png)


---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
