### PR TITLE
Add initrd.cpio to build using pure Go cpio lib

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -403,6 +403,12 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         sum = "h1:4ZrkT/RzpnROylmoQL57iVUL57wGKTR5O6KpVnbm2tA=",
         version = "v0.0.0-20160919175755-f7c97cef3b4e",
     )
+    go_repository(
+        name = "com_github_cavaliergopher_cpio",
+        importpath = "github.com/cavaliergopher/cpio",
+        sum = "h1:KQFSeKmZhv0cr+kawA3a0xTQCU4QxXF1vhU7P7av2KM=",
+        version = "v1.0.1",
+    )
 
     go_repository(
         name = "com_github_census_instrumentation_opencensus_proto",

--- a/enterprise/tools/cpio/BUILD
+++ b/enterprise/tools/cpio/BUILD
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+package(default_visibility = ["//visibility:public"])
+
+go_library(
+    name = "cpio_lib",
+    srcs = ["cpio.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/tools/cpio",
+    deps = [
+        "//server/util/log",
+        "@com_github_cavaliergopher_cpio//:cpio",
+    ],
+)
+
+go_binary(
+    name = "cpio",
+    embed = [":cpio_lib"],
+)

--- a/enterprise/tools/cpio/cpio.go
+++ b/enterprise/tools/cpio/cpio.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"os"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/cavaliergopher/cpio"
+)
+
+// This tool allows creating cpio archives in SVR4 (newc) format.
+// Example:
+//   cpio -out initrd.cpio -- goinit vmvfs
+
+var (
+	outPath = flag.String("out", "", "Path to the output cpio file.")
+)
+
+func check(err error) {
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+}
+
+func main() {
+	flag.Parse()
+	inputPaths := flag.Args()
+	if *outPath == "" {
+		log.Fatalf("Missing -out path")
+	}
+	out, err := os.Create(*outPath)
+	check(err)
+	defer out.Close()
+
+	w := cpio.NewWriter(out)
+	defer func() {
+		err := w.Close()
+		check(err)
+
+		s, err := os.Stat(*outPath)
+		check(err)
+		log.Infof("Wrote %s (%.2f MB)", *outPath, float64(s.Size())/1e6)
+	}()
+
+	for _, path := range inputPaths {
+		s, err := os.Stat(path)
+		check(err)
+		hdr := &cpio.Header{Name: path, Mode: cpio.FileMode(s.Mode()), Size: s.Size()}
+		err = w.WriteHeader(hdr)
+		check(err)
+		f, err := os.Open(path)
+		check(err)
+		defer f.Close()
+		_, err = io.Copy(w, f)
+		check(err)
+	}
+}

--- a/enterprise/vmsupport/bin/BUILD
+++ b/enterprise/vmsupport/bin/BUILD
@@ -1,18 +1,6 @@
-load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
-
 exports_files([
     "vmlinux",
-    "initrd.cpio",
 ])
-
-configure_make(
-    name = "cpio",
-    configure_in_place = False,
-    lib_source = "@org_gnu_cpio//:all",
-    out_binaries = ["cpio"],
-    tags = ["manual"],
-)
 
 genrule(
     name = "mkinitrd",
@@ -20,17 +8,18 @@ genrule(
         "//enterprise/server/cmd/goinit",
         "//enterprise/server/vmvfs",
     ],
-    outs = ["initrd-latest.cpio"],
+    outs = ["initrd.cpio"],
     cmd_bash = """
-        ./$(location mkinitrd.sh) \
-            $(location //enterprise/server/cmd/goinit:goinit) \
-            $(location //enterprise/server/vmvfs) \
-            \"$@\"
+        env \
+            GOINIT=$(location //enterprise/server/cmd/goinit:goinit) \
+            VMVFS=$(location //enterprise/server/vmvfs) \
+            CPIO=$(location //enterprise/tools/cpio) \
+            ./$(location mkinitrd.sh) \
+            "$@"
     """,
-    tags = ["manual"],
     tools = [
         "mkinitrd.sh",
-        ":cpio",
+        "//enterprise/tools/cpio",
     ],
     visibility = ["//visibility:public"],
 )

--- a/enterprise/vmsupport/bin/mkinitrd.sh
+++ b/enterprise/vmsupport/bin/mkinitrd.sh
@@ -1,21 +1,26 @@
 #!/bin/bash
 set -e
 
-GOINIT=$1  # path to goinit binary
-VMVFS=$2 # path to vmvfs binary
-FSPATH=$3  # path to write output filesytem to
+RANDOM_STR=$(
+  tr -dc A-Za-z0-9 </dev/urandom | head -c 13
+  echo ''
+)-init
+ROOT_DIR="${RANDOM_STR}"
+mkdir -p "${ROOT_DIR}"
+cp "${GOINIT}" "${ROOT_DIR}/init"
+cp "${VMVFS}" "${ROOT_DIR}/vmvfs"
 
-RANDOM_STR=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13 ; echo '')-init
-ROOT_DIR=${RANDOM_STR}
+abspath() {
+  if ! [[ "$1" =~ ^/ ]]; then
+    echo "$PWD/$1"
+  else
+    echo "$1"
+  fi
+}
 
-mkdir -p ${ROOT_DIR}
-cp ${GOINIT} ${ROOT_DIR}/init
-cp ${VMVFS} ${ROOT_DIR}/vmvfs
-IMAGE_FILE=${RANDOM_STR}.cpio
-
-pushd ${ROOT_DIR}
-find "./" | cpio --create --format=newc -O /tmp/initrd.cpio
-popd
-
-cp /tmp/initrd.cpio "${FSPATH}"
-echo "Created initrd: ${FSPATH}"
+FSPATH="$(abspath "$1")"
+CPIO="$(abspath "$CPIO")"
+(
+  cd "$ROOT_DIR"
+  "$CPIO" -out "$FSPATH" -- init vmvfs
+)

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/bazelbuild/rules_webtesting v0.2.0
 	github.com/bojand/ghz v0.95.0
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
+	github.com/cavaliergopher/cpio v1.0.1
 	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/cockroachdb/pebble v0.0.0-20210406181039-e3809b89b488
 	github.com/coreos/go-oidc v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/cavaliergopher/cpio v1.0.1 h1:KQFSeKmZhv0cr+kawA3a0xTQCU4QxXF1vhU7P7av2KM=
+github.com/cavaliergopher/cpio v1.0.1/go.mod h1:pBdaqQjnvXxdS/6CvNDwIANIFSP0xRKI16PX4xejRQc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=


### PR DESCRIPTION
This keeps initrd.cpio in sync with its transitive deps, and avoids adding 40MB to the repo history on each update.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
