### PR TITLE
Keep sidecar alive while CLI is running.

### DIFF
--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -15,6 +15,8 @@ go_library(
         "//cli/parser",
         "//cli/remotebazel",
         "//cli/sidecar",
+        "//proto:sidecar_go_proto",
+        "//server/util/grpc_client",
         "//server/version",
         "@com_github_bazelbuild_bazelisk//core:go_default_library",
         "@com_github_bazelbuild_bazelisk//repositories:go_default_library",

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -106,7 +106,7 @@ func keepaliveSidecar(ctx context.Context, sidecarSocket string) error {
 		for {
 			_, err := s.Ping(ctx, &scpb.PingRequest{})
 			if connectionValidated && err != nil {
-				fmt.Printf("sidecar did not response to ping request: %s\n", err)
+				bblog.Printf("sidecar did not respond to ping request: %s\n", err)
 				return
 			}
 			if !connectionValidated && err == nil {

--- a/cli/cmd/sidecar/BUILD
+++ b/cli/cmd/sidecar/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//cli/devnull",
         "//proto:publish_build_event_go_proto",
         "//proto:remote_execution_go_proto",
+        "//proto:sidecar_go_proto",
         "//server/backends/disk_cache",
         "//server/build_event_protocol/build_event_proxy",
         "//server/build_event_protocol/build_event_server",

--- a/cli/cmd/sidecar/sidecar.go
+++ b/cli/cmd/sidecar/sidecar.go
@@ -27,6 +27,7 @@ import (
 
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	scpb "github.com/buildbuddy-io/buildbuddy/proto/sidecar"
 	rpcfilters "github.com/buildbuddy-io/buildbuddy/server/rpc/filters"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
@@ -178,6 +179,17 @@ func registerCacheProxy(ctx context.Context, env *real_environment.RealEnv, grpc
 	repb.RegisterCapabilitiesServer(grpcServer, cacheProxy)
 }
 
+type sidecarService struct {
+}
+
+func (s *sidecarService) Ping(ctx context.Context, req *scpb.PingRequest) (*scpb.PingResponse, error) {
+	return &scpb.PingResponse{}, nil
+}
+
+func registerSidecarService(grpcServer *grpc.Server) {
+	scpb.RegisterSidecarServer(grpcServer, &sidecarService{})
+}
+
 func normalizeGrpcTarget(target string) string {
 	if strings.HasPrefix(target, "grpc://") || strings.HasPrefix(target, "grpcs://") {
 		return target
@@ -231,5 +243,8 @@ func main() {
 	if *besBackend == "" && *remoteCache == "" {
 		log.Fatal("No services configured. At least one of --bes_backend or --remote_cache must be provided!")
 	}
+
+	registerSidecarService(grpcServer)
+
 	grpcServer.Serve(lis)
 }

--- a/cli/cmd/sidecar/sidecar.go
+++ b/cli/cmd/sidecar/sidecar.go
@@ -179,15 +179,10 @@ func registerCacheProxy(ctx context.Context, env *real_environment.RealEnv, grpc
 	repb.RegisterCapabilitiesServer(grpcServer, cacheProxy)
 }
 
-type sidecarService struct {
-}
+type sidecarService struct{}
 
 func (s *sidecarService) Ping(ctx context.Context, req *scpb.PingRequest) (*scpb.PingResponse, error) {
 	return &scpb.PingResponse{}, nil
-}
-
-func registerSidecarService(grpcServer *grpc.Server) {
-	scpb.RegisterSidecarServer(grpcServer, &sidecarService{})
 }
 
 func normalizeGrpcTarget(target string) string {
@@ -244,7 +239,7 @@ func main() {
 		log.Fatal("No services configured. At least one of --bes_backend or --remote_cache must be provided!")
 	}
 
-	registerSidecarService(grpcServer)
+	scpb.RegisterSidecarServer(grpcServer, &sidecarService{})
 
 	grpcServer.Serve(lis)
 }

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -332,6 +332,11 @@ proto_library(
 )
 
 proto_library(
+    name = "sidecar_proto",
+    srcs = ["sidecar.proto"],
+)
+
+proto_library(
     name = "remote_asset_proto",
     srcs = ["remote_asset.proto"],
     deps = [
@@ -665,6 +670,13 @@ go_proto_library(
     name = "semver_go_proto",
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/semver",
     proto = ":semver_proto",
+)
+
+go_proto_library(
+    name = "sidecar_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/sidecar",
+    proto = ":sidecar_proto",
 )
 
 go_proto_library(

--- a/proto/sidecar.proto
+++ b/proto/sidecar.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package sidecar;
+
+message PingRequest {}
+message PingResponse {}
+
+service Sidecar {
+  // Checks if the sidecar is alive and resets the inactivity timer.
+  rpc Ping(PingRequest) returns (PingResponse);
+}


### PR DESCRIPTION
We lean on the sidecar in remote bazel for caching artifacts but the
sidecar can terminate due to inactivity during a long remote bazel
build.

This PR avoids this by continuously pinging the sidecar while the CLI is
running.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
