### PR TITLE
Fix error code returned when snaploader artifacts expire

### DIFF
--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -133,7 +133,7 @@ func (l *Loader) unpackManifest() error {
 
 	manifestPath := filepath.Join(tmpDir, ManifestFileName)
 	if !l.env.GetFileCache().FastLinkFile(fileNodeFromDigest(manifestDigest), manifestPath) {
-		return status.FailedPreconditionErrorf("No manifest file found for snapshot: %s/%d", l.snapshotDigest.GetHash(), l.snapshotDigest.GetSizeBytes())
+		return status.UnavailableErrorf("snapshot manifest not found in local cache (digest: %s/%d)", l.snapshotDigest.GetHash(), l.snapshotDigest.GetSizeBytes())
 	}
 	buf, err := os.ReadFile(manifestPath)
 	if err != nil {
@@ -162,7 +162,7 @@ func (l *Loader) UnpackSnapshot(outputDirectory string) error {
 	}
 	for filename, dk := range l.manifest.CachedFiles {
 		if !l.env.GetFileCache().FastLinkFile(fileNodeFromDigest(dk.ToDigest()), filepath.Join(outputDirectory, filename)) {
-			return status.FailedPreconditionErrorf("File %q missing from snapshot.", filename)
+			return status.UnavailableErrorf("snapshot artifact %q not found in local cache", filename)
 		}
 	}
 	return nil


### PR DESCRIPTION
Make sure these errors are retryable. (We used to convert all runner errors to Unavailable errors, but now we respect the returned error codes, so this error is no longer retried.)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
