### PR TITLE
Add basic support for macOS sandboxing.

### DIFF
--- a/enterprise/server/remote_execution/containers/sandbox/BUILD
+++ b/enterprise/server/remote_execution/containers/sandbox/BUILD
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "sandbox",
+    srcs = ["sandbox.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/sandbox",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//enterprise/server/remote_execution/commandutil",
+        "//enterprise/server/remote_execution/container",
+        "//proto:remote_execution_go_proto",
+        "//server/interfaces",
+        "//server/util/log",
+        "//server/util/status",
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "sandbox_test",
+    srcs = ["sandbox_test.go"],
+    deps = [
+        ":sandbox",
+        "//enterprise/server/remote_execution/container",
+        "//proto:remote_execution_go_proto",
+        "//server/config",
+        "//server/testutil/testfs",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/enterprise/server/remote_execution/containers/sandbox/BUILD
+++ b/enterprise/server/remote_execution/containers/sandbox/BUILD
@@ -19,6 +19,10 @@ go_library(
 go_test(
     name = "sandbox_test",
     srcs = ["sandbox_test.go"],
+    tags = [
+        "no-sandbox",  # sandbox-exec is not compatible with Bazel's sandbox environment
+    ],
+    target_compatible_with = ["@platforms//os:macos"],
     deps = [
         ":sandbox",
         "//enterprise/server/remote_execution/container",

--- a/enterprise/server/remote_execution/containers/sandbox/sandbox.go
+++ b/enterprise/server/remote_execution/containers/sandbox/sandbox.go
@@ -148,9 +148,9 @@ func resolveAlwaysWritableDirs(ctx context.Context) ([]sbxPath, error) {
 	dirs = append(dirs, darwinUserCache)
 
 	// Add some user specific dirs as well.
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
+	homeDir := "/"
+	if h, err := os.UserHomeDir(); err == nil {
+		homeDir = h
 	}
 	dirs = append(dirs, filepath.Join(homeDir, "Library/Caches"))
 	dirs = append(dirs, filepath.Join(homeDir, "Library/Logs"))
@@ -272,7 +272,7 @@ func (c *sandbox) runCmdInSandbox(ctx context.Context, command *repb.Command, wo
 	// slash, so make sure it does not!
 	inaccessiblePaths := []sbxPath{NewSubPath(filepath.Dir(strings.TrimRight(workDir, "/")))}
 	writablePaths := append(alwaysWritableDirs, NewSubPath(workDir))
-	
+
 	sandboxConfigPath := filepath.Join(workDir, "sandbox.sb")
 	sandboxConfigBuf := makeSandboxConfig(writablePaths, inaccessiblePaths, c.enableNetwork)
 	if err := os.WriteFile(sandboxConfigPath, sandboxConfigBuf, 0660); err != nil {

--- a/enterprise/server/remote_execution/containers/sandbox/sandbox.go
+++ b/enterprise/server/remote_execution/containers/sandbox/sandbox.go
@@ -1,0 +1,310 @@
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/golang/protobuf/proto"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+const (
+	getconfBinary     = "/usr/bin/getconf"
+	sandboxExecBinary = "/usr/bin/sandbox-exec"
+)
+
+var (
+	supportedOnce       sync.Once
+	sandboxingSupported bool
+
+	alwaysWritableDirsOnce sync.Once
+	alwaysWritableDirs     []sbxPath
+)
+
+// This functionality was inspired by DarwinSandboxedSpawnRunner.java (in bazel) and
+// Sandbox.swift (in apple/swift-package-manager).
+
+type sbxPathType int
+
+const (
+	// Three different modes are supported:
+	// 1) regular expression
+	// 2) literal
+	// 3) subpath
+	regexPath sbxPathType = iota
+	literalPath
+	subPath
+)
+
+type sbxPath struct {
+	expression string
+	pathType   sbxPathType
+}
+
+func (s *sbxPath) typeString() string {
+	switch s.pathType {
+	case regexPath:
+		return "regex"
+	case literalPath:
+		return "literal"
+	case subPath:
+		return "subpath"
+	default:
+		return "unknwon-sbx-path-type"
+	}
+}
+
+func (s *sbxPath) String() string {
+	return fmt.Sprintf(`(%s "%s")`, s.typeString(), s.expression)
+}
+
+func NewSubPath(expr string) sbxPath {
+	return sbxPath{expression: expr, pathType: subPath}
+}
+
+func NewRegexPath(expr string) sbxPath {
+	return sbxPath{expression: expr, pathType: regexPath}
+}
+
+func runSimpleCommand(ctx context.Context, command []string) *interfaces.CommandResult {
+	return commandutil.Run(ctx, &repb.Command{Arguments: command}, "" /*=workDir*/, nil /*=stdin*/, nil /*=stdout*/)
+}
+
+func computeSandboxingSupported(ctx context.Context) bool {
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+	command := []string{
+		sandboxExecBinary,
+		"-p",
+		"(version 1) (allow default)",
+		"/usr/bin/true",
+	}
+	result := runSimpleCommand(ctx, command)
+	return result.ExitCode == 0 && result.Error == nil
+}
+
+func getConfString(ctx context.Context, confVar string) (string, error) {
+	command := []string{getconfBinary, confVar}
+	result := runSimpleCommand(ctx, command)
+	if result.Error != nil {
+		return "", result.Error
+	}
+	return strings.TrimSpace(string(result.Stdout)), nil
+}
+
+func resolveSymlinks(path string, fileInfo os.FileInfo) string {
+	if fileInfo.Mode()&os.ModeSymlink != 0 {
+		if absPath, err := os.Readlink(path); err == nil {
+			return absPath
+		}
+	}
+	return path
+}
+
+func resolveAlwaysWritableDirs(ctx context.Context) ([]sbxPath, error) {
+	dirSet := make(map[string]struct{}, 0)
+	dirs := []string{
+		"/dev",
+		"/tmp",
+		"/private/tmp",
+		"/private/var/tmp",
+	}
+
+	// On macOS, processes may write to not only $TMPDIR but also to two other temporary
+	// directories. We have to get their location by calling "getconf".
+	darwinUserTmp, err := getConfString(ctx, "DARWIN_USER_TEMP_DIR")
+	if err != nil {
+		return nil, err
+	}
+	darwinUserCache, err := getConfString(ctx, "DARWIN_USER_CACHE_DIR")
+	if err != nil {
+		return nil, err
+	}
+	// These directories seem identical to their "/private" prefixed
+	// counterparts, but sandboxed commands will fail to write if they do
+	// not begin with "/private".
+	const privatePrefix = "/private"
+	if !strings.HasPrefix(darwinUserTmp, privatePrefix) {
+		darwinUserTmp = privatePrefix + darwinUserTmp
+	}
+	if !strings.HasPrefix(darwinUserCache, privatePrefix) {
+		darwinUserCache = privatePrefix + darwinUserCache
+	}
+	dirs = append(dirs, darwinUserTmp)
+	dirs = append(dirs, darwinUserCache)
+
+	// Add some user specific dirs as well.
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	dirs = append(dirs, filepath.Join(homeDir, "Library/Caches"))
+	dirs = append(dirs, filepath.Join(homeDir, "Library/Logs"))
+	dirs = append(dirs, filepath.Join(homeDir, "Library/Developer"))
+
+	for _, path := range dirs {
+		if fileInfo, err := os.Lstat(path); !os.IsNotExist(err) {
+			absPath := resolveSymlinks(path, fileInfo)
+			dirSet[absPath] = struct{}{}
+		}
+	}
+
+	alwaysWritable := make([]sbxPath, 0, len(dirSet))
+	for path := range dirSet {
+		alwaysWritable = append(alwaysWritable, NewSubPath(path))
+	}
+	return alwaysWritable, nil
+}
+
+// See https://reverse.put.as/wp-content/uploads/2011/09/Apple-Sandbox-Guide-v1.0.pdf for
+// docs on how sandboxing works.
+func makeSandboxConfig(writeable, inaccessible []sbxPath, enableNetworking bool) []byte {
+	buf := &bytes.Buffer{}
+	buf.WriteString("(version 1)\n")
+	buf.WriteString("(debug deny)\n")
+	buf.WriteString("(allow default)\n")
+	buf.WriteString("(allow process-exec (with no-sandbox) (literal \"/bin/ps\"))\n")
+
+	if !enableNetworking {
+		buf.WriteString("(deny network*)\n")
+		buf.WriteString("(allow network-inbound (local ip \"localhost:*\"))\n")
+		buf.WriteString("(allow network* (remote ip \"localhost:*\"))\n")
+		buf.WriteString("(allow network* (remote unix-socket))\n")
+	}
+
+	// Disallow reads from inaccessible paths.
+	buf.WriteString("(deny file-read*\n")
+	for _, path := range inaccessible {
+		buf.WriteString("    " + path.String() + "\n")
+	}
+	buf.WriteString(")\n")
+
+	// But allow reads for any of those paths found in writeable
+	buf.WriteString("(allow file-read*\n")
+	for _, denied := range inaccessible {
+		for _, path := range writeable {
+			if !strings.HasPrefix(path.expression, denied.expression) {
+				continue
+			}
+			buf.WriteString("    " + path.String() + "\n")
+		}
+	}
+	buf.WriteString(")\n")
+
+	// By default, deny all writes.
+	buf.WriteString("(deny file-write*)\n")
+
+	// But allow writes to our writeablePaths.
+	buf.WriteString("(allow file-write*\n")
+	for _, path := range writeable {
+		buf.WriteString("    " + path.String() + "\n")
+	}
+	buf.WriteString(")\n")
+
+	return buf.Bytes()
+}
+
+func sandboxPrereqs(ctx context.Context) error {
+	supportedOnce.Do(func() {
+		sandboxingSupported = computeSandboxingSupported(ctx)
+	})
+	if !sandboxingSupported {
+		return status.UnavailableError("sandboxing is not supported")
+	}
+
+	alwaysWritableDirsOnce.Do(func() {
+		if dirs, err := resolveAlwaysWritableDirs(ctx); err == nil {
+			alwaysWritableDirs = dirs
+		} else {
+			log.Warningf("Error resolving always writable dirs: %s", err)
+		}
+	})
+	if len(alwaysWritableDirs) == 0 {
+		return status.InternalError("error initializing sandbox")
+	}
+	return nil
+}
+
+// Options contains configuration options for the sandbox runner.
+type Options struct {
+	Network string
+}
+
+// sandbox executes commands using /usr/bin/sandbox-exec. This
+// functionality is only supported on mac os.
+type sandbox struct {
+	WorkDir       string
+	enableNetwork bool
+}
+
+func New(options *Options) container.CommandContainer {
+	return &sandbox{
+		enableNetwork: strings.ToLower(options.Network) != "off",
+	}
+}
+
+func (c *sandbox) runCmdInSandbox(ctx context.Context, command *repb.Command, workDir string, stdin io.Reader, stdout io.Writer) *interfaces.CommandResult {
+	result := &interfaces.CommandResult{
+		CommandDebugString: fmt.Sprintf("(sandbox) %s", command.GetArguments()),
+		ExitCode:           commandutil.NoExitCode,
+	}
+
+	if err := sandboxPrereqs(ctx); err != nil {
+		result.Error = err
+		return result
+	}
+
+	// filepath.Dir will return the parent dir if the arg does not contain a trailing
+	// slash, so make sure it does not!
+	inaccessiblePaths := []sbxPath{NewSubPath(filepath.Dir(strings.TrimRight(workDir, "/")))}
+	writablePaths := append(alwaysWritableDirs, NewSubPath(workDir))
+	
+	sandboxConfigPath := filepath.Join(workDir, "sandbox.sb")
+	sandboxConfigBuf := makeSandboxConfig(writablePaths, inaccessiblePaths, c.enableNetwork)
+	if err := os.WriteFile(sandboxConfigPath, sandboxConfigBuf, 0660); err != nil {
+		result.Error = err
+		return result
+	}
+
+	sandboxCmd := proto.Clone(command).(*repb.Command)
+	sandboxCmd.Arguments = append([]string{sandboxExecBinary, "-f", sandboxConfigPath}, command.Arguments...)
+	result = commandutil.Run(ctx, sandboxCmd, workDir, stdin, stdout)
+	return result
+}
+
+func (c *sandbox) Run(ctx context.Context, command *repb.Command, workDir string, _ container.PullCredentials) *interfaces.CommandResult {
+	return c.runCmdInSandbox(ctx, command, workDir, nil /*=stdin*/, nil /*=stdout*/)
+}
+
+func (c *sandbox) Create(ctx context.Context, workDir string) error {
+	c.WorkDir = workDir
+	return nil
+}
+
+func (c *sandbox) Exec(ctx context.Context, cmd *repb.Command, stdin io.Reader, stdout io.Writer) *interfaces.CommandResult {
+	return c.runCmdInSandbox(ctx, cmd, c.WorkDir, stdin, stdout)
+}
+
+func (c *sandbox) IsImageCached(ctx context.Context) (bool, error)                      { return false, nil }
+func (c *sandbox) PullImage(ctx context.Context, creds container.PullCredentials) error { return nil }
+func (c *sandbox) Start(ctx context.Context) error                                      { return nil }
+func (c *sandbox) Remove(ctx context.Context) error                                     { return nil }
+func (c *sandbox) Pause(ctx context.Context) error                                      { return nil }
+func (c *sandbox) Unpause(ctx context.Context) error                                    { return nil }
+func (c *sandbox) Stats(ctx context.Context) (*container.Stats, error) {
+	return &container.Stats{}, nil
+}

--- a/enterprise/server/remote_execution/containers/sandbox/sandbox.go
+++ b/enterprise/server/remote_execution/containers/sandbox/sandbox.go
@@ -106,7 +106,7 @@ func getConfString(ctx context.Context, confVar string) (string, error) {
 	return strings.TrimSpace(string(result.Stdout)), nil
 }
 
-func resolveSymlinks(path string, fileInfo os.FileInfo) string {
+func resolveSymlink(path string, fileInfo os.FileInfo) string {
 	if fileInfo.Mode()&os.ModeSymlink != 0 {
 		if absPath, err := os.Readlink(path); err == nil {
 			return absPath
@@ -124,8 +124,9 @@ func resolveAlwaysWritableDirs(ctx context.Context) ([]sbxPath, error) {
 		"/private/var/tmp",
 	}
 
-	// On macOS, processes may write to not only $TMPDIR but also to two other temporary
-	// directories. We have to get their location by calling "getconf".
+	// On macOS, processes may write to not only $TMPDIR but also to two
+	// other temporary directories. We have to get their location by calling
+	// "getconf".
 	darwinUserTmp, err := getConfString(ctx, "DARWIN_USER_TEMP_DIR")
 	if err != nil {
 		return nil, err
@@ -158,7 +159,7 @@ func resolveAlwaysWritableDirs(ctx context.Context) ([]sbxPath, error) {
 
 	for _, path := range dirs {
 		if fileInfo, err := os.Lstat(path); !os.IsNotExist(err) {
-			absPath := resolveSymlinks(path, fileInfo)
+			absPath := resolveSymlink(path, fileInfo)
 			dirSet[absPath] = struct{}{}
 		}
 	}
@@ -170,8 +171,8 @@ func resolveAlwaysWritableDirs(ctx context.Context) ([]sbxPath, error) {
 	return alwaysWritable, nil
 }
 
-// See https://reverse.put.as/wp-content/uploads/2011/09/Apple-Sandbox-Guide-v1.0.pdf for
-// docs on how sandboxing works.
+// See https://reverse.put.as/wp-content/uploads/2011/09/Apple-Sandbox-Guide-v1.0.pdf
+// for docs on how sandboxing works.
 func makeSandboxConfig(writeable, inaccessible []sbxPath, enableNetworking bool) []byte {
 	buf := &bytes.Buffer{}
 	buf.WriteString("(version 1)\n")
@@ -268,8 +269,8 @@ func (c *sandbox) runCmdInSandbox(ctx context.Context, command *repb.Command, wo
 		return result
 	}
 
-	// filepath.Dir will return the parent dir if the arg does not contain a trailing
-	// slash, so make sure it does not!
+	// filepath.Dir will return the parent dir if the arg does not contain a
+	// trailing slash, so make sure it does not!
 	inaccessiblePaths := []sbxPath{NewSubPath(filepath.Dir(strings.TrimRight(workDir, "/")))}
 	writablePaths := append(alwaysWritableDirs, NewSubPath(workDir))
 

--- a/enterprise/server/remote_execution/containers/sandbox/sandbox.go
+++ b/enterprise/server/remote_execution/containers/sandbox/sandbox.go
@@ -67,7 +67,7 @@ func (s *sbxPath) typeString() string {
 	case subPath:
 		return "subpath"
 	default:
-		return "unknwon-sbx-path-type"
+		return "unknown-sbx-path-type"
 	}
 }
 

--- a/enterprise/server/remote_execution/containers/sandbox/sandbox_test.go
+++ b/enterprise/server/remote_execution/containers/sandbox/sandbox_test.go
@@ -1,0 +1,101 @@
+package sandbox_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/sandbox"
+	"github.com/buildbuddy-io/buildbuddy/server/config"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/stretchr/testify/assert"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+func makeTempDirWithWorldTxt(t *testing.T) string {
+	rootDirFlag := flag.Lookup("executor.root_directory")
+	if rootDirFlag == nil {
+		t.Fatal("Missing --executor.root_directory flag.")
+	}
+	dir := testfs.MakeTempDir(t)
+
+	f, err := os.Create(fmt.Sprintf("%s/world.txt", dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	_, err = f.WriteString("world")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestSandboxedHelloWorld(t *testing.T) {
+	ctx := context.Background()
+	config.RegisterAndParseFlags()
+	tempDir := makeTempDirWithWorldTxt(t)
+	cmd := &repb.Command{
+		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+			&repb.Command_EnvironmentVariable{Name: "GREETING", Value: "Hello"},
+		},
+		Arguments: []string{"sh", "-c", fmt.Sprintf("printf \"$GREETING $(cat %s/world.txt)!\"", tempDir)},
+		Platform: &repb.Platform{
+			Properties: []*repb.Platform_Property{
+				&repb.Platform_Property{
+					Name:  "container-image",
+					Value: "none",
+				},
+			},
+		},
+	}
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+
+	sandboxContainer := sandbox.New(&sandbox.Options{})
+	result := sandboxContainer.Run(ctx, cmd, tempDir, container.PullCredentials{})
+
+	if result.Error != nil {
+		t.Fatal(result.Error)
+	}
+	assert.Regexp(t, "^(/usr)?/bin/sandbox-exec\\s", result.CommandDebugString, "sanity check: command should be run bare")
+	assert.Equal(t, "Hello world!", string(result.Stdout),
+		"stdout should equal 'Hello world!' ('$GREETING' env var should be replaced with 'Hello', and "+
+			"tempfile containing 'world' should be readable.)",
+	)
+	assert.Empty(t, string(result.Stderr), "stderr should be empty")
+	assert.Equal(t, 0, result.ExitCode, "should exit with success")
+}
+
+func TestCrossContainerReads(t *testing.T) {
+	ctx := context.Background()
+	config.RegisterAndParseFlags()
+	tempDir1 := makeTempDirWithWorldTxt(t)
+	goodCmd := &repb.Command{
+		Arguments: []string{"ls", tempDir1},
+	}
+
+	// Tries to read another actions directory.
+	tempDir2 := makeTempDirWithWorldTxt(t)
+	evilCmd := &repb.Command{
+		Arguments: []string{"ls", tempDir1},
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+
+	sandboxContainer := sandbox.New(&sandbox.Options{})
+	goodResult := sandboxContainer.Run(ctx, goodCmd, tempDir1, container.PullCredentials{})
+	evilResult := sandboxContainer.Run(ctx, evilCmd, tempDir2, container.PullCredentials{})
+
+	assert.Empty(t, string(goodResult.Stderr), "stderr should be empty")
+	assert.Equal(t, 0, goodResult.ExitCode, "should exit with success")
+
+	assert.Contains(t, string(evilResult.Stderr), "Operation not permitted")
+	assert.Equal(t, 1, evilResult.ExitCode, "should exit with error")
+}

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -22,6 +22,7 @@ var (
 	defaultIsolationType = flag.String("executor.default_isolation_type", "", "The default workload isolation type when no type is specified in an action. If not set, we use the first of the following that is set: docker, firecracker, podman, or barerunner")
 	enableBareRunner     = flag.Bool("executor.enable_bare_runner", false, "Enables running execution commands directly on the host without isolation.")
 	enablePodman         = flag.Bool("executor.enable_podman", false, "Enables running execution commands inside podman container.")
+	enableSandbox        = flag.Bool("executor.enable_sandbox", false, "Enables running execution commands inside of sandbox-exec.")
 	enableFirecracker    = flag.Bool("executor.enable_firecracker", false, "Enables running execution commands inside of firecracker VMs")
 	defaultImage         = flag.String("executor.default_image", "gcr.io/flame-public/executor-docker-default:enterprise-v1.6.0", "The default docker image to use to warm up executors or if no platform property is set. Ex: gcr.io/flame-public/executor-docker-default:enterprise-v1.5.4")
 	enableVFS            = flag.Bool("executor.enable_vfs", false, "Whether FUSE based filesystem is enabled.")
@@ -92,6 +93,7 @@ const (
 	PodmanContainerType      ContainerType = "podman"
 	DockerContainerType      ContainerType = "docker"
 	FirecrackerContainerType ContainerType = "firecracker"
+	SandboxContainerType     ContainerType = "sandbox"
 )
 
 // Properties represents the platform properties parsed from a command.
@@ -250,6 +252,14 @@ func GetExecutorProperties() *ExecutorProperties {
 			log.Warning("Podman was enabled, but is unsupported on darwin. Ignoring.")
 		} else {
 			p.SupportedIsolationTypes = append(p.SupportedIsolationTypes, PodmanContainerType)
+		}
+	}
+
+	if *enableSandbox {
+		if runtime.GOOS == "darwin" {
+			p.SupportedIsolationTypes = append(p.SupportedIsolationTypes, SandboxContainerType)
+		} else {
+			log.Warning("Sandbox was enabled, but is unsupported outside of darwin. Ignoring.")
 		}
 	}
 

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//enterprise/server/remote_execution/containers/docker",
         "//enterprise/server/remote_execution/containers/firecracker",
         "//enterprise/server/remote_execution/containers/podman",
+        "//enterprise/server/remote_execution/containers/sandbox",
         "//enterprise/server/remote_execution/dirtools",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/remote_execution/vfs",

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -25,6 +25,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/docker"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/firecracker"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/podman"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/sandbox"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/dirtools"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/vfs"
@@ -913,6 +914,11 @@ func (p *pool) newContainer(ctx context.Context, props *platform.Properties, tas
 			return nil, err
 		}
 		ctr = c
+	case platform.SandboxContainerType:
+		opts := &sandbox.Options{
+			Network: props.DockerNetwork,
+		}
+		ctr = sandbox.New(opts)
 	default:
 		ctr = bare.NewBareCommandContainer()
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -316,6 +316,7 @@ type ExecutorConfig struct {
 	EnableBareRunner              bool                      `yaml:"enable_bare_runner" usage:"Enables running execution commands directly on the host without isolation."`
 	EnablePodman                  bool                      `yaml:"enable_podman" usage:"Enables running execution commands inside podman container."`
 	PodmanRuntime                 string                    `yaml:"podman_runtime" usage:"Enables running podman with other runtimes, like gVisor (runsc)."`
+	EnableSandbox                 bool                      `yaml:"enable_sandbox" usage:"Enables running execution commands inside of sandbox-exec."`
 	EnableFirecracker             bool                      `yaml:"enable_firecracker" usage:"Enables running execution commands inside of firecracker VMs"`
 	FirecrackerMountWorkspaceFile bool                      `yaml:"firecracker_mount_workspace_file" usage:"Enables mounting workspace filesystem to improve performance of copying action outputs."`
 	ContainerRegistries           []ContainerRegistryConfig `yaml:"container_registries"`


### PR DESCRIPTION
This CL adds macOS sandboxing support for remotely executed actions by generating a sandbox-config file per-action and then executing the action using sandbox-exec.

A generated sandbox config looks like this:

```
(version 1)
(debug deny)
(allow default)
(allow process-exec (with no-sandbox) (literal "/bin/ps"))
(deny file-read*
    (subpath "/tmp/remote_build")
)
(allow file-read*
    (subpath "/tmp/remote_build/9d054f1d-26bd-4ba0-a203-e2925869b279")
)
(deny file-write*)
(allow file-write*
    (subpath "/Users/tylerw/Library/Caches")
    (subpath "/Users/tylerw/Library/Developer")
    (subpath "/Users/tylerw/Library/Logs")
    (subpath "/dev")
    (subpath "/private/tmp")
    (subpath "/private/var/folders/2f/wy_q59s572b5fsv3tryx38d00000gn/C")
    (subpath "/private/var/folders/2f/wy_q59s572b5fsv3tryx38d00000gn/T")
    (subpath "/private/var/tmp")
    (subpath "/tmp/remote_build/9d054f1d-26bd-4ba0-a203-e2925869b279")
)
```

The above profile:
 - allows reads from everywhere, except anything in the build root that is not the currently executing action
 - disallows writes everywhere except the remote action directory, tmp dirs, and some system locations needed by Xcode.

I've only tested this so far on a very simple project: //examples/macos/HelloWorld:HelloWorld from rules_apple.