### PR TITLE
remote bazel: handle runfile directory dependencies.

### DIFF
--- a/cli/commandline/commandline.go
+++ b/cli/commandline/commandline.go
@@ -67,7 +67,14 @@ func ParseFlagsAndRewriteArgs(args []string) *BazelArgs {
 	})
 	ourArgs := make([]string, 0, len(ourFlagNames))
 	newArgs := make([]string, 0, len(args))
-	for _, arg := range args {
+	for i, arg := range args {
+		// Don't remove anything after "--" delimiter, even if it looks like one
+		// of our flags.
+		if arg == "--" {
+			newArgs = append(newArgs, args[i:]...)
+			break
+		}
+
 		wasOurs := false
 		for _, flagName := range ourFlagNames {
 			if strings.HasPrefix(arg, flagName+"=") || arg == flagName {

--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -8,10 +8,12 @@ go_library(
     deps = [
         "//cli/commandline",
         "//cli/logging",
+        "//enterprise/server/remote_execution/dirtools",
         "//proto:build_event_stream_go_proto",
         "//proto:buildbuddy_service_go_proto",
         "//proto:eventlog_go_proto",
         "//proto:invocation_go_proto",
+        "//proto:remote_execution_go_proto",
         "//proto:runner_go_proto",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",

--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -38,6 +38,7 @@ go_library(
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//types/known/durationpb",
         "@org_golang_google_protobuf//types/known/timestamppb",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/enterprise/server/remote_execution/dirtools/dirtools_test.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools_test.go
@@ -59,7 +59,7 @@ func TestDownloadTree(t *testing.T) {
 			childDir,
 		},
 	}
-	info, err := dirtools.DownloadTree(ctx, env, "", directory, tmpDir, &dirtools.DownloadTreeOpts{})
+	info, err := dirtools.DownloadTree(ctx, env.GetByteStreamClient(), env.GetContentAddressableStorageClient(), nil /*=fileCache*/, "", directory, tmpDir, &dirtools.DownloadTreeOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestDownloadTreeEmptyDigest(t *testing.T) {
 			childDir,
 		},
 	}
-	info, err := dirtools.DownloadTree(ctx, env, "foo", directory, tmpDir, &dirtools.DownloadTreeOpts{})
+	info, err := dirtools.DownloadTree(ctx, env.GetByteStreamClient(), env.GetContentAddressableStorageClient(), nil /*=fileCache*/, "foo", directory, tmpDir, &dirtools.DownloadTreeOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -148,7 +148,10 @@ func (ws *Workspace) DownloadInputs(ctx context.Context, tree *repb.Tree) (*dirt
 		opts.Skip = ws.Inputs
 		opts.TrackTransfers = true
 	}
-	txInfo, err := dirtools.DownloadTree(ctx, ws.env, ws.task.GetExecuteRequest().GetInstanceName(), tree, ws.rootDir, opts)
+	bsClient := ws.env.GetByteStreamClient()
+	casClient := ws.env.GetContentAddressableStorageClient()
+	fileCache := ws.env.GetFileCache()
+	txInfo, err := dirtools.DownloadTree(ctx, bsClient, casClient, fileCache, ws.task.GetExecuteRequest().GetInstanceName(), tree, ws.rootDir, opts)
 	if err == nil {
 		if err := ws.CleanInputsIfNecessary(txInfo.Exists); err != nil {
 			return txInfo, err

--- a/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
@@ -300,7 +300,9 @@ func (c *Client) DownloadActionOutputs(ctx context.Context, env environment.Env,
 		if err := cachetools.GetBlobAsProto(ctx, c.gRPClientSource.GetByteStreamClient(), treeDigest, tree); err != nil {
 			return err
 		}
-		if _, err := dirtools.DownloadTree(ctx, env, res.InstanceName, tree, path, &dirtools.DownloadTreeOpts{}); err != nil {
+		bsClient := env.GetByteStreamClient()
+		casClient := env.GetContentAddressableStorageClient()
+		if _, err := dirtools.DownloadTree(ctx, bsClient, casClient, nil /*=fileCache*/, res.InstanceName, tree, path, &dirtools.DownloadTreeOpts{}); err != nil {
 			return err
 		}
 	}

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -148,10 +148,9 @@ func (r *Env) GetConfigurator() *config.Configurator {
 }
 
 func (r *Env) uploadInputRoot(ctx context.Context, rootDir string) *repb.Digest {
-	r.testEnv.SetByteStreamClient(r.GetByteStreamClient())
-	r.testEnv.SetContentAddressableStorageClient(r.GetContentAddressableStorageClient())
-
-	digest, _, err := cachetools.UploadDirectoryToCAS(ctx, r.testEnv, "" /*=instanceName*/, rootDir)
+	bsClient := r.GetByteStreamClient()
+	casClient := r.GetContentAddressableStorageClient()
+	digest, _, err := cachetools.UploadDirectoryToCAS(ctx, bsClient, casClient, nil /*=fileCache*/, "" /*=instanceName*/, rootDir)
 	if err != nil {
 		assert.FailNow(r.t, err.Error())
 	}

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -524,6 +524,13 @@ message File {
   }
 }
 
+message Tree {
+  // Where the tree is to be planted.
+  string name = 1;
+  // Bytestream URI for the tree digest.
+  string uri = 2;
+}
+
 // Payload of a message to describe a set of files, usually build artifacts, to
 // be referred to later by their name. In this way, files that occur identically
 // as outputs of several targets have to be named only once.
@@ -1260,8 +1267,10 @@ message RunTargetAnalyzed {
   repeated string arguments = 1;
   // Path to the root of the runfiles directory.
   string runfiles_root = 2;
-  // Any runtime dependencies for the runnable target.
+  // Any runtime file dependencies for the runnable target.
   repeated File runfiles = 3;
+  // Any runtime directory dependencies for the runnable target.
+  repeated Tree runfileDirectories = 4;
 }
 
 // Message describing a build event. Events will have an identifier that

--- a/server/remote_cache/cachetools/BUILD
+++ b/server/remote_cache/cachetools/BUILD
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
-        "//server/environment",
         "//server/interfaces",
         "//server/remote_cache/digest",
         "//server/remote_cache/namespace",

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/namespace"
@@ -457,8 +456,8 @@ func (*bytesReadSeekCloser) Close() error { return nil }
 // UploadDirectoryToCAS uploads all the files in a given directory to the CAS
 // as well as the directory structure, and returns the digest of the root
 // Directory proto that can be used to fetch the uploaded contents.
-func UploadDirectoryToCAS(ctx context.Context, env environment.Env, instanceName, rootDirPath string) (*repb.Digest, *repb.Digest, error) {
-	ul, err := NewBatchCASUploader(ctx, env.GetByteStreamClient(), env.GetContentAddressableStorageClient(), env.GetFileCache(), instanceName)
+func UploadDirectoryToCAS(ctx context.Context, bsClient bspb.ByteStreamClient, casClient repb.ContentAddressableStorageClient, fileCache interfaces.FileCache, instanceName, rootDirPath string) (*repb.Digest, *repb.Digest, error) {
+	ul, err := NewBatchCASUploader(ctx, bsClient, casClient, fileCache, instanceName)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
runner: all symlinked runfile directories are uploaded and returned as
Tree objects via BES.
cli: download and plant all trees referenced in the BES event.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
