### PR TITLE
Patch sha rule to not depend on config paths

### DIFF
--- a/rules/sha/index.bzl
+++ b/rules/sha/index.bzl
@@ -4,7 +4,16 @@ def sha(name, srcs, **kwargs):
         name = name,
         srcs = srcs,
         outs = [name + ".sum"],
-        cmd = "find $(SRCS) -type f | sort | xargs shasum | shasum | awk '{ print $$1 }' > $@",
+        # TODO(bduffany): Upgrade rules_nodejs and set `metafile=False` on the app bundle
+        # rule, and remove the `grep -v _metadata.json` part below.
+        cmd_bash = """
+        # Replaces host config paths like "bazel-out/{k8-opt,k8-fastbuild,k8-opt-ST-abc123}" etc.
+        # with just "bazel-out/CONFIG"
+        normalize_config_paths() {
+            perl -p -e 's@ bazel-out/.*?/@ bazel-out/CONFIG/@'
+        }
+        find $(SRCS) -type f | grep -v _metadata.json | sort | xargs shasum | normalize_config_paths | shasum | awk '{ print $$1 }' > $@
+        """,
         local = 1,
         **kwargs
     )


### PR DESCRIPTION
I'm running into trouble upgrading rules_nodejs, so using `grep -v _metadata.json` to avoid including the generated metadata.json files in the SHA for now.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
