### PR TITLE
Add CI runner option to override bazel args

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -119,6 +119,7 @@ var (
 
 	bazelCommand      = flag.String("bazel_command", "", "Bazel command to use.")
 	bazelStartupFlags = flag.String("bazel_startup_flags", "", "Startup flags to pass to bazel. The value can include spaces and will be properly tokenized.")
+	extraBazelArgs    = flag.String("extra_bazel_args", "", "Extra flags to pass to the bazel command. The value can include spaces and will be properly tokenized.")
 	debug             = flag.Bool("debug", false, "Print additional debug information in the action logs.")
 
 	// Test-only flags
@@ -1050,6 +1051,13 @@ func bazelArgs(cmd string) ([]string, error) {
 	}
 	if exists := (err == nil); exists {
 		startupFlags = append(startupFlags, "--noworkspace_rc", "--bazelrc=.bazelrc")
+	}
+	if *extraBazelArgs != "" {
+		extras, err := shlex.Split(*extraBazelArgs)
+		if err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, extras...)
 	}
 	return append(startupFlags, tokens...), nil
 }


### PR DESCRIPTION
This is to support replaying workflows against a particular env, without affecting the env in which the workflow was originally created.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
