### PR TITLE
Make workflows compute units configurable

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -277,6 +277,8 @@ type RemoteExecutionConfig struct {
 	WorkflowsCIRunnerDebug            bool               `yaml:"workflows_ci_runner_debug" usage:"Whether to run the CI runner in debug mode."`
 	WorkflowsCIRunnerBazelCommand     string             `yaml:"workflows_ci_runner_bazel_command" usage:"Bazel command to be used by the CI runner."`
 	WorkflowsEnableFirecracker        bool               `yaml:"workflows_enable_firecracker" usage:"Whether to enable firecracker for Linux workflow actions."`
+	WorkflowsLinuxComputeUnits        int                `yaml:"workflows_linux_compute_units" usage:"Number of BuildBuddy compute units (BCU) to reserve for Linux workflow actions."`
+	WorkflowsMacComputeUnits          int                `yaml:"workflows_mac_compute_units" usage:"Number of BuildBuddy compute units (BCU) to reserve for Mac workflow actions."`
 	RedisTarget                       string             `yaml:"redis_target" usage:"A Redis target for storing remote execution state. Falls back to app.default_redis_target if unspecified. Required for remote execution. To ease migration, the redis target from the cache config will be used if neither this value nor app.default_redis_target are specified."`
 	ShardedRedis                      ShardedRedisConfig `yaml:"sharded_redis" usage:"Optional configuration for sharding execution data across multiple Redis instances. Mutually exclusive with the redis_target option."`
 	SharedExecutorPoolGroupID         string             `yaml:"shared_executor_pool_group_id" usage:"Group ID that owns the shared executor pool."`


### PR DESCRIPTION
Make the config separate for Linux vs Mac, so that we can bump the BCUs for Linux workflows without affecting Mac workflows.

Also bump the current default value from 2 -> 3 (3 CPU cores + 7.5GB RAM), to reduce the chance of hitting OOM errors.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
