### PR TITLE
Switch over fully to flag-based configuration

### DIFF
--- a/cli/cmd/sidecar/sidecar.go
+++ b/cli/cmd/sidecar/sidecar.go
@@ -205,12 +205,7 @@ func initializeDiskCache(env *real_environment.RealEnv) {
 }
 
 func main() {
-	// Can remove all this configurator stuff once all flags the sidecar uses are
-	// defined outside the configurator.
 	flag.Parse()
-	if err := config.PopulateFlagsFromData([]byte{}); err != nil {
-		log.Fatalf("Error initializing Configurator: %s", err.Error())
-	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -358,7 +358,7 @@ type apiKeyGroupCache struct {
 	mu  sync.RWMutex
 }
 
-func newAPIKeyGroupCache(configurator *config.Configurator) (*apiKeyGroupCache, error) {
+func newAPIKeyGroupCache() (*apiKeyGroupCache, error) {
 	config := &lru.Config{
 		MaxSize: apiKeyGroupCacheSize,
 		SizeFn:  func(v interface{}) int64 { return 1 },
@@ -481,7 +481,7 @@ func newOpenIDAuthenticator(ctx context.Context, env environment.Env, oauthProvi
 	// Initialize API Key -> Group cache unless it's disabled by config.
 	var akgCache *apiKeyGroupCache
 	if *apiKeyGroupCacheTTL != time.Duration(0) {
-		akgCache, err = newAPIKeyGroupCache(env.GetConfigurator())
+		akgCache, err = newAPIKeyGroupCache()
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -108,8 +108,8 @@ func InitializeCacheClientsOrDie(cacheTarget string, realEnv *real_environment.R
 	realEnv.SetActionCacheClient(repb.NewActionCacheClient(conn))
 }
 
-func GetConfiguredEnvironmentOrDie(configurator *config.Configurator, healthChecker *healthcheck.HealthChecker) environment.Env {
-	realEnv := real_environment.NewRealEnv(configurator, healthChecker)
+func GetConfiguredEnvironmentOrDie(healthChecker *healthcheck.HealthChecker) environment.Env {
+	realEnv := real_environment.NewRealEnv(healthChecker)
 
 	if err := resources.Configure(); err != nil {
 		log.Fatal(status.Message(err))
@@ -196,8 +196,8 @@ func main() {
 
 	rootContext := context.Background()
 
-	configurator, err := config.ParseAndReconcileFlagsAndConfig("")
-	if err != nil {
+	flag.Parse()
+	if err := config.PopulateFlagsFromFile(); err != nil {
 		log.Fatalf("Error loading config from file: %s", err)
 	}
 
@@ -209,7 +209,7 @@ func main() {
 	healthChecker := healthcheck.NewHealthChecker(*serverType)
 	localListener = bufconn.Listen(1024 * 1024 * 10 /* 10MB buffer? Seems ok. */)
 
-	env := GetConfiguredEnvironmentOrDie(configurator, healthChecker)
+	env := GetConfiguredEnvironmentOrDie(healthChecker)
 
 	if err := tracing.Configure(env); err != nil {
 		log.Fatalf("Could not configure tracing: %s", err)

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -151,12 +151,12 @@ func main() {
 	rootContext := context.Background()
 	version.Print()
 
-	configurator, err := config.ParseAndReconcileFlagsAndConfig("")
-	if err != nil {
+	flag.Parse()
+	if err := config.PopulateFlagsFromFile(); err != nil {
 		log.Fatalf("Error loading config from file: %s", err)
 	}
 	healthChecker := healthcheck.NewHealthChecker(*serverType)
-	realEnv := libmain.GetConfiguredEnvironmentOrDie(configurator, healthChecker)
+	realEnv := libmain.GetConfiguredEnvironmentOrDie(healthChecker)
 	if err := tracing.Configure(realEnv); err != nil {
 		log.Fatalf("Could not configure tracing: %s", err)
 	}
@@ -180,7 +180,7 @@ func main() {
 	if err := redis_metrics_collector.Register(realEnv); err != nil {
 		log.Fatalf("%v", err)
 	}
-	if err = usage.RegisterTracker(realEnv); err != nil {
+	if err := usage.RegisterTracker(realEnv); err != nil {
 		log.Fatalf("%v", err)
 	}
 

--- a/server/cmd/buildbuddy/main.go
+++ b/server/cmd/buildbuddy/main.go
@@ -23,12 +23,13 @@ var (
 
 func main() {
 	version.Print()
-	configurator, err := config.ParseAndReconcileFlagsAndConfig("")
-	if err != nil {
+
+	flag.Parse()
+	if err := config.PopulateFlagsFromFile(); err != nil {
 		log.Fatalf("Error loading config from file: %s", err)
 	}
 	healthChecker := healthcheck.NewHealthChecker(*serverType)
-	env := libmain.GetConfiguredEnvironmentOrDie(configurator, healthChecker)
+	env := libmain.GetConfiguredEnvironmentOrDie(healthChecker)
 
 	telemetryClient := telemetry.NewTelemetryClient(env)
 	telemetryClient.Start()

--- a/server/config/BUILD
+++ b/server/config/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//server/util/flagutil",
         "//server/util/log",
-        "//server/util/status",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )

--- a/server/config/BUILD
+++ b/server/config/BUILD
@@ -8,6 +8,5 @@ go_library(
     deps = [
         "//server/util/flagutil",
         "//server/util/log",
-        "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
-	"gopkg.in/yaml.v2"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 )
@@ -360,25 +359,7 @@ type OrgConfig struct {
 }
 
 func PopulateFlagsFromData(data []byte) error {
-	// expand environment variables
-	expandedData := []byte(os.ExpandEnv(string(data)))
-
-	strictMap, err := flagutil.GenerateYAMLMapFromFlags()
-	if err != nil {
-		return err
-	}
-
-	// Unmarshal in strict mode once and warn about invalid fields.
-	if err := yaml.UnmarshalStrict([]byte(expandedData), strictMap); err != nil {
-		log.Warningf("Unknown fields in config: %s", err)
-	}
-
-	permissiveMap := make(map[interface{}]interface{})
-	if err := yaml.Unmarshal([]byte(expandedData), permissiveMap); err != nil {
-		return fmt.Errorf("Error parsing config file: %s", err)
-	}
-
-	return flagutil.PopulateFlagsFromYAMLMap(permissiveMap)
+	return flagutil.PopulateFlagsFromData(data)
 }
 
 func PopulateFlagsFromFile() error {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1,24 +1,20 @@
 package config
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"os"
-	"reflect"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
-	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"gopkg.in/yaml.v2"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 )
 
 var (
-	configFile = flag.String("config_file", "", "The path to a buildbuddy config file")
+	configFile = flag.String("config_file", "/config.yaml", "The path to a buildbuddy config file")
 )
 
 // When adding new storage fields, always be explicit about their yaml field
@@ -363,176 +359,45 @@ type OrgConfig struct {
 	Domain string `yaml:"domain" usage:"Your organization's email domain. If this is set, only users with email addresses in this domain will be able to register for a BuildBuddy account."`
 }
 
-var (
-	sharedConfigurator = &Configurator{gc: &generalConfig{}}
-
-	// Contains the string slices originally defined by the flags
-	originalSliceLens = make(map[string]int)
-	defineFlagsOnce   sync.Once
-
-	// Set of the flags that were explicitly set on the command line
-	originalSetFlags = make(map[string]struct{})
-)
-
-func RegisterAndParseFlags() {
-	defineFlagsOnce.Do(func() {
-		defineFlagsForMembers([]string{}, reflect.ValueOf(&generalConfig{}).Elem(), flag.CommandLine)
-		flag.Parse()
-		flag.Visit(func(flg *flag.Flag) {
-			originalSetFlags[flg.Name] = struct{}{}
-		})
-	})
-}
-
-// FOR TESTING PURPOSES ONLY!!!
-func TestOnlySetFlag(flagName string, set bool) bool {
-	_, wasSet := originalSetFlags[flagName]
-	if set {
-		originalSetFlags[flagName] = struct{}{}
-	} else {
-		delete(originalSetFlags, flagName)
-	}
-	return wasSet
-}
-
-// If configSet is nil, defines all global flags present in the config that have
-// not been elsewhere defined. If configSet isn't nil, defines flags in the
-// provided FlagSet for the config.
-func defineFlagsForMembers(parentStructNames []string, T reflect.Value, flagSet *flag.FlagSet) {
-	typeOfT := T.Type()
-	for i := 0; i < T.NumField(); i++ {
-		f := T.Field(i)
-		fieldName := typeOfT.Field(i).Tag.Get("yaml")
-		fqFieldName := strings.ToLower(strings.Join(append(parentStructNames, fieldName), "."))
-		docString := typeOfT.Field(i).Tag.Get("usage")
-
-		// Only define missing flags
-		if flagSet.Lookup(fqFieldName) == nil {
-			switch f.Type().Kind() {
-			case reflect.Ptr:
-				log.Fatal("The config should not contain pointers!")
-			case reflect.Struct:
-				defineFlagsForMembers(append(parentStructNames, fieldName), f, flagSet)
-			case reflect.Bool:
-				flagSet.BoolVar(f.Addr().Convert(reflect.TypeOf((*bool)(nil))).Interface().(*bool), fqFieldName, f.Bool(), docString)
-			case reflect.String:
-				flagSet.StringVar(f.Addr().Convert(reflect.TypeOf((*string)(nil))).Interface().(*string), fqFieldName, f.String(), docString)
-			case reflect.Int:
-				flagSet.IntVar(f.Addr().Convert(reflect.TypeOf((*int)(nil))).Interface().(*int), fqFieldName, int(f.Int()), docString)
-			case reflect.Int64:
-				if f.Addr().Type() == reflect.TypeOf((*time.Duration)(nil)) {
-					flagSet.DurationVar(f.Addr().Interface().(*time.Duration), fqFieldName, time.Duration(f.Int()), docString)
-					continue
-				}
-				flagSet.Int64Var(f.Addr().Convert(reflect.TypeOf((*int64)(nil))).Interface().(*int64), fqFieldName, int64(f.Int()), docString)
-			case reflect.Float64:
-				flagSet.Float64Var(f.Addr().Convert(reflect.TypeOf((*float64)(nil))).Interface().(*float64), fqFieldName, f.Float(), docString)
-			case reflect.Slice:
-				if sf, err := flagutil.NewSliceFlag(f.Addr().Interface()); err == nil {
-					flagSet.Var(sf, fqFieldName, docString)
-					continue
-				}
-				fallthrough
-			default:
-				log.Warningf("Skipping flag: --%s, kind: %s", fqFieldName, f.Type().Kind())
-			}
-		}
-	}
-}
-
-func populateYamlPresenceMap(yamlMap map[interface{}]interface{}) map[string]struct{} {
-	var check func(key []string, value interface{})
-	presenceMap := make(map[string]struct{})
-	check = func(key []string, value interface{}) {
-		if m, ok := value.(map[interface{}]interface{}); ok {
-			for k, v := range m {
-				if newKey, ok := k.(string); ok {
-					check(append(key, strings.ToLower(newKey)), v)
-					continue
-				}
-				log.Warningf("Non-string key encountered in yaml map in field: %s", key)
-			}
-			return
-		}
-		presenceMap[strings.Join(key, ".")] = struct{}{}
-	}
-	check([]string{}, yamlMap)
-	return presenceMap
-}
-
-type Configurator struct {
-	gc          *generalConfig
-	presenceMap map[string]struct{}
-	reconciled  bool
-}
-
-func NewConfiguratorFromData(data []byte) (*Configurator, error) {
+func PopulateFlagsFromData(data []byte) error {
 	// expand environment variables
 	expandedData := []byte(os.ExpandEnv(string(data)))
 
+	strictMap, err := flagutil.GenerateYAMLMapFromFlags()
+	if err != nil {
+		return err
+	}
+
 	// Unmarshal in strict mode once and warn about invalid fields.
-	var syntaxValidationConfig generalConfig
-	if err := yaml.UnmarshalStrict([]byte(expandedData), &syntaxValidationConfig); err != nil {
+	if err := yaml.UnmarshalStrict([]byte(expandedData), strictMap); err != nil {
 		log.Warningf("Unknown fields in config: %s", err)
 	}
 
-	gc := &generalConfig{}
-	if err := yaml.Unmarshal([]byte(expandedData), gc); err != nil {
-		return nil, fmt.Errorf("Error parsing config file: %s", err)
+	permissiveMap := make(map[interface{}]interface{})
+	if err := yaml.Unmarshal([]byte(expandedData), permissiveMap); err != nil {
+		return fmt.Errorf("Error parsing config file: %s", err)
 	}
 
-	generalConfigMap := make(map[interface{}]interface{})
-	if err := yaml.Unmarshal([]byte(expandedData), &generalConfigMap); err != nil {
-		return nil, fmt.Errorf("Error parsing config file: %s", err)
-	}
-
-	// The shared config caches the last config parsed from a file so that a call to
-	// `readConfig` with an empty `configFile` can return the cached config.
-	sharedConfigurator = &Configurator{gc, populateYamlPresenceMap(generalConfigMap), false}
-
-	return sharedConfigurator, nil
+	return flagutil.PopulateFlagsFromYAMLMap(permissiveMap)
 }
 
-func NewConfigurator(configFilePath string) (*Configurator, error) {
-	if configFilePath == "" {
-		return sharedConfigurator, nil
-	}
-	log.Infof("Reading buildbuddy config from '%s'", configFilePath)
+func PopulateFlagsFromFile() error {
+	log.Infof("Reading buildbuddy config from '%s'", *configFile)
 
-	_, err := os.Stat(configFilePath)
+	_, err := os.Stat(*configFile)
 
-	// If the file does not exist then we are SOL.
+	// If the file does not exist then skip it.
 	if os.IsNotExist(err) {
-		return nil, fmt.Errorf("Config file %s not found", configFilePath)
+		log.Warningf("No config file found at %s.", *configFile)
+		return nil
 	}
 
-	fileBytes, err := os.ReadFile(configFilePath)
+	fileBytes, err := os.ReadFile(*configFile)
 	if err != nil {
-		return nil, fmt.Errorf("Error reading config file: %s", err)
+		return fmt.Errorf("Error reading config file: %s", err)
 	}
 
-	return NewConfiguratorFromData(fileBytes)
-}
-
-func ParseAndReconcileFlagsAndConfig(configFilePath string) (*Configurator, error) {
-	RegisterAndParseFlags()
-	if configFilePath == "" {
-		configFilePath = *configFile
-	}
-	if configFilePath == "" {
-		_, err := os.Stat("/config.yaml")
-		if err == nil {
-			configFilePath = "/config.yaml"
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return nil, status.UnknownErrorf("could not load config file: %s", err)
-		}
-	}
-	configurator, err := NewConfigurator(configFilePath)
-	if err != nil {
-		return nil, err
-	}
-	configurator.ReconcileFlagsAndConfig()
-	return configurator, nil
+	return PopulateFlagsFromData(fileBytes)
 }
 
 type RedisClientConfig struct {
@@ -545,65 +410,4 @@ func (cc *RedisClientConfig) String() string {
 		return "sharded across " + strings.Join(cc.ShardedConfig.Shards, ", ")
 	}
 	return cc.SimpleTarget
-}
-
-// After calling this function, the generalConfig in the Configurator and the
-// flags in the default flag set (flag.Commandline) with a corresponding config
-// value will be consistent.
-func (c *Configurator) ReconcileFlagsAndConfig() {
-	c.GenerateFlagSet().VisitAll(func(flg *flag.Flag) {
-		if flag.Lookup(flg.Name) == nil {
-			// If a flag exists in the config but not in the flags, skip it. This can
-			// easily happen when the same config is used with different buildbuddy
-			// binaries (e. g. the free server and the enterprise server)
-			return
-		}
-		if configSlice, ok := flg.Value.(flagutil.SliceFlag); ok {
-			if flagSlice, ok := flag.Lookup(flg.Name).Value.(flagutil.SliceFlag); ok {
-				if originalSliceLen, ok := originalSliceLens[flg.Name]; ok {
-					// reset flagSlice if it has been modified
-					// in this case, flagSliceLen is the sum of the length of the slices
-					// defined in the config and those defined on the command line, and
-					// the config slice comes first.
-					flagSlice.SetTo(flagSlice.Slice(flagSlice.Len()-originalSliceLen, flagSlice.Len()))
-					if c.reconciled {
-						// reset configSlice if it has been modified
-						configSlice.SetTo(configSlice.Slice(0, configSlice.Len()-originalSliceLen))
-					}
-				} else {
-					originalSliceLens[flg.Name] = flagSlice.Len()
-				}
-				// Slices from flags are appended to the values in the config, as
-				// opposed to one overriding the other, so no conflict check is needed.
-				concatSlice := configSlice.AppendSlice(flagSlice.UnderlyingSlice())
-				configSlice.SetTo(concatSlice)
-				flagSlice.SetTo(concatSlice)
-				return
-			}
-			log.Warningf("yaml defines %s as %T, but flags do not.", flg.Name, configSlice.UnderlyingSlice())
-		}
-		_, setInFlags := originalSetFlags[flg.Name]
-		_, presentInYaml := c.presenceMap[flg.Name]
-		if !setInFlags {
-			// reset flag to default value if it was not initially set
-			flag.Set(flg.Name, flag.Lookup(flg.Name).DefValue)
-		}
-		// If the flag was set on the command line or there is no value specified in
-		// the config, we use the value defined by the flags and update the config
-		// with that value. Otherwise (which is to say, if there was no flag
-		// explicitly set on the command line and there is a value present in the
-		// config), use the config value and update the flags with that value.
-		if setInFlags || !presentInYaml {
-			flg.Value.Set(flag.Lookup(flg.Name).Value.String())
-			return
-		}
-		flag.Set(flg.Name, flg.Value.String())
-	})
-	c.reconciled = true
-}
-
-func (c *Configurator) GenerateFlagSet() *flag.FlagSet {
-	flagSet := flag.NewFlagSet("", flag.ContinueOnError)
-	defineFlagsForMembers([]string{}, reflect.ValueOf(c.gc).Elem(), flagSet)
-	return flagSet
 }

--- a/server/environment/BUILD
+++ b/server/environment/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//proto:remote_asset_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",
-        "//server/config",
         "//server/interfaces",
         "@com_github_go_redis_redis_v8//:redis",
         "@go_googleapis//google/bytestream:bytestream_go_proto",

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io/fs"
 
-	"github.com/buildbuddy-io/buildbuddy/server/config"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/go-redis/redis/v8"
 	"google.golang.org/grpc"
@@ -32,7 +31,6 @@ import (
 
 type Env interface {
 	// The following dependencies are required.
-	GetConfigurator() *config.Configurator
 	GetServerContext() context.Context
 
 	// Optional dependencies below here. For example: enterprise-only things,

--- a/server/libmain/BUILD
+++ b/server/libmain/BUILD
@@ -22,7 +22,6 @@ go_library(
         "//server/build_event_protocol/build_event_server",
         "//server/build_event_protocol/webhooks",
         "//server/buildbuddy_server",
-        "//server/config",
         "//server/environment",
         "//server/http/filters",
         "//server/http/protolet",

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -22,7 +22,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_server"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/webhooks"
 	"github.com/buildbuddy-io/buildbuddy/server/buildbuddy_server"
-	"github.com/buildbuddy-io/buildbuddy/server/config"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/http/protolet"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -128,12 +127,12 @@ func configureFilesystemsOrDie(realEnv *real_environment.RealEnv) {
 // the environments used by the open-core version and the enterprise version are
 // not substantially different enough yet to warrant the extra complexity of
 // always updating both main files.
-func GetConfiguredEnvironmentOrDie(configurator *config.Configurator, healthChecker *healthcheck.HealthChecker) *real_environment.RealEnv {
+func GetConfiguredEnvironmentOrDie(healthChecker *healthcheck.HealthChecker) *real_environment.RealEnv {
 	if err := log.Configure(); err != nil {
 		fmt.Printf("Error configuring logging: %s", err)
 		os.Exit(1)
 	}
-	realEnv := real_environment.NewRealEnv(configurator, healthChecker)
+	realEnv := real_environment.NewRealEnv(healthChecker)
 	realEnv.SetMux(tracing.NewHttpServeMux(http.NewServeMux()))
 	realEnv.SetAuthenticator(&nullauth.NullAuthenticator{})
 	configureFilesystemsOrDie(realEnv)

--- a/server/real_environment/BUILD
+++ b/server/real_environment/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//proto:remote_asset_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",
-        "//server/config",
         "//server/interfaces",
         "@com_github_go_redis_redis_v8//:redis",
         "@go_googleapis//google/bytestream:bytestream_go_proto",

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-redis/redis/v8"
 
-	"github.com/buildbuddy-io/buildbuddy/server/config"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 
 	bspb "google.golang.org/genproto/googleapis/bytestream"
@@ -69,7 +68,6 @@ type RealEnv struct {
 	APIService                       interfaces.ApiService
 	fileCache                        interfaces.FileCache
 	remoteExecutionService           interfaces.RemoteExecutionService
-	configurator                     *config.Configurator
 	executionClients                 map[string]*executionClientConfig
 	cacheRedisClient                 redis.UniversalClient
 	defaultRedisClient               redis.UniversalClient
@@ -95,9 +93,8 @@ type RealEnv struct {
 	grpcsServer                      *grpc.Server
 }
 
-func NewRealEnv(c *config.Configurator, h interfaces.HealthChecker) *RealEnv {
+func NewRealEnv(h interfaces.HealthChecker) *RealEnv {
 	return &RealEnv{
-		configurator:     c,
 		healthChecker:    h,
 		serverContext:    context.Background(),
 		executionClients: make(map[string]*executionClientConfig, 0),
@@ -105,10 +102,6 @@ func NewRealEnv(c *config.Configurator, h interfaces.HealthChecker) *RealEnv {
 }
 
 // Required -- no SETTERs for these.
-func (r *RealEnv) GetConfigurator() *config.Configurator {
-	return r.configurator
-}
-
 func (r *RealEnv) GetHealthChecker() interfaces.HealthChecker {
 	return r.healthChecker
 }

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -126,7 +126,7 @@ func GetTestEnv(t testing.TB) *TestEnv {
 
 	healthChecker := healthcheck.NewHealthChecker("test")
 	te := &TestEnv{
-		RealEnv: real_environment.NewRealEnv(nil, healthChecker),
+		RealEnv: real_environment.NewRealEnv(healthChecker),
 	}
 	c, err := memory_cache.NewMemoryCache(1000 * 1000 * 1000 /* 1GB */)
 	if err != nil {

--- a/server/util/url/url_test.go
+++ b/server/util/url/url_test.go
@@ -18,7 +18,7 @@ func init() {
 func envWithAppURL(t *testing.T, appUrl string) environment.Env {
 	flags.Set(t, "app.build_buddy_url", appUrl)
 	healthChecker := healthcheck.NewHealthChecker("test")
-	return real_environment.NewRealEnv(nil, healthChecker)
+	return real_environment.NewRealEnv(healthChecker)
 }
 
 func TestValidateRedirect(t *testing.T) {

--- a/tools/vmstart/BUILD
+++ b/tools/vmstart/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//enterprise/server/remote_execution/filecache",
         "//proto:remote_execution_go_proto",
         "//proto:vmvfs_go_proto",
-        "//server/config",
         "//server/real_environment",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",

--- a/tools/vmstart/vmstart.go
+++ b/tools/vmstart/vmstart.go
@@ -15,7 +15,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/firecracker"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/dirtools"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
-	"github.com/buildbuddy-io/buildbuddy/server/config"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
@@ -45,12 +44,8 @@ var (
 )
 
 func getToolEnv() *real_environment.RealEnv {
-	configurator, err := config.NewConfigurator("")
-	if err != nil {
-		log.Fatalf("This should never happen.")
-	}
 	healthChecker := healthcheck.NewHealthChecker("tool")
-	re := real_environment.NewRealEnv(configurator, healthChecker)
+	re := real_environment.NewRealEnv(healthChecker)
 
 	fc, err := filecache.NewFileCache(*snapshotDir, *snapshotDirMaxBytes)
 	if err != nil {


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Removes the configurator entirely, as it is no longer a relevant structure. `flags.Parse`
can now be called safely directly from a main function without "registering" flags first.
We now only need to populate the flags from a given YAML config, as opposed to reconciling,
and the new flagutils way of populating the flags means that we don't need to externally
keep track of which flags were set initially via the command line.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
