### PR TITLE
Disable esbuild metafile generation

### DIFF
--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -21,6 +21,7 @@ esbuild(
     },
     define = {"process.env.NODE_ENV": '"production"'},
     entry_points = ["app.tsx"],
+    metafile = False,
     minify = select({
         ":fastbuild": False,
         "//conditions:default": True,

--- a/enterprise/app/BUILD.bazel
+++ b/enterprise/app/BUILD.bazel
@@ -28,6 +28,7 @@ esbuild(
     entry_points = [
         "app.tsx",
     ],
+    metafile = False,
     minify = select({
         ":fastbuild": False,
         "//conditions:default": True,

--- a/rules/sha/index.bzl
+++ b/rules/sha/index.bzl
@@ -4,15 +4,13 @@ def sha(name, srcs, **kwargs):
         name = name,
         srcs = srcs,
         outs = [name + ".sum"],
-        # TODO(bduffany): Upgrade rules_nodejs and set `metafile=False` on the app bundle
-        # rule, and remove the `grep -v _metadata.json` part below.
         cmd_bash = """
         # Replaces host config paths like "bazel-out/{k8-opt,k8-fastbuild,k8-opt-ST-abc123}" etc.
         # with just "bazel-out/CONFIG"
         normalize_config_paths() {
             perl -p -e 's@ bazel-out/.*?/@ bazel-out/CONFIG/@'
         }
-        find $(SRCS) -type f | grep -v _metadata.json | sort | xargs shasum | normalize_config_paths | shasum | awk '{ print $$1 }' > $@
+        find $(SRCS) -type f | sort | xargs shasum | normalize_config_paths | shasum | awk '{ print $$1 }' > $@
         """,
         local = 1,
         **kwargs


### PR DESCRIPTION
Verified that the metadata.json file is not included in the SHA (by adding a debug print to //rules/sha/index.bzl).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
