### PR TITLE
Add Mac build to workflows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,15 +21,18 @@ build:cache --remote_cache=grpcs://remote.buildbuddy.io
 build:cache --remote_upload_local_results
 
 # Flags shared across remote configs
+build:remote-shared --enable_platform_specific_config
 build:remote-shared --remote_upload_local_results
-build:remote-shared --host_platform=@buildbuddy_toolchain//:platform
-build:remote-shared --platforms=@buildbuddy_toolchain//:platform
-build:remote-shared --crosstool_top=@buildbuddy_toolchain//:toolchain
 build:remote-shared --remote_timeout=600
 build:remote-shared --remote_download_minimal
 build:remote-shared --experimental_repo_remote_exec
 build:remote-shared --jobs=100
 build:remote-shared --verbose_failures
+
+# Flags used for Linux remote builds (via --enable_platform_specific_config)
+build:linux --host_platform=@buildbuddy_toolchain//:platform
+build:linux --platforms=@buildbuddy_toolchain//:platform
+build:linux --crosstool_top=@buildbuddy_toolchain//:toolchain
 
 # Build with --config=remote to use BuildBuddy RBE.
 build:remote --config=remote-shared
@@ -75,9 +78,6 @@ build:workflows --config=buildbuddy_bes_backend
 build:workflows --config=buildbuddy_bes_results_url
 build:workflows --config=buildbuddy_remote_cache
 build:workflows --config=buildbuddy_remote_executor
-
-build:workflows-darwin-amd64 --config=workflows
-build:workflows-darwin-amd64 --remote_executor=
 
 # Configuration used for BuildBuddy release workflow
 build:release --config=remote

--- a/.bazelrc
+++ b/.bazelrc
@@ -76,6 +76,9 @@ build:workflows --config=buildbuddy_bes_results_url
 build:workflows --config=buildbuddy_remote_cache
 build:workflows --config=buildbuddy_remote_executor
 
+build:workflows-darwin-amd64 --config=workflows
+build:workflows-darwin-amd64 --remote_executor=
+
 # Configuration used for BuildBuddy release workflow
 build:release --config=remote
 build:release --remote_instance_name=buildbuddy-io/buildbuddy/release

--- a/.bazelrc
+++ b/.bazelrc
@@ -64,6 +64,8 @@ build:untrusted-ci --flaky_test_attempts=2
 
 # Configuration used for BuildBuddy workflows
 build:workflows --config=remote-shared
+build:workflows --build_metadata=ROLE=CI
+build:workflows --build_metadata=VISIBILITY=PUBLIC
 build:workflows --remote_instance_name=buildbuddy-io/buildbuddy/workflows
 build:workflows --color=yes
 build:workflows --disk_cache=

--- a/.bazelrc
+++ b/.bazelrc
@@ -21,18 +21,15 @@ build:cache --remote_cache=grpcs://remote.buildbuddy.io
 build:cache --remote_upload_local_results
 
 # Flags shared across remote configs
-build:remote-shared --enable_platform_specific_config
 build:remote-shared --remote_upload_local_results
+build:remote-shared --host_platform=@buildbuddy_toolchain//:platform
+build:remote-shared --platforms=@buildbuddy_toolchain//:platform
+build:remote-shared --crosstool_top=@buildbuddy_toolchain//:toolchain
 build:remote-shared --remote_timeout=600
 build:remote-shared --remote_download_minimal
 build:remote-shared --experimental_repo_remote_exec
 build:remote-shared --jobs=100
 build:remote-shared --verbose_failures
-
-# Flags used for Linux remote builds (via --enable_platform_specific_config)
-build:linux --host_platform=@buildbuddy_toolchain//:platform
-build:linux --platforms=@buildbuddy_toolchain//:platform
-build:linux --crosstool_top=@buildbuddy_toolchain//:toolchain
 
 # Build with --config=remote to use BuildBuddy RBE.
 build:remote --config=remote-shared
@@ -67,8 +64,6 @@ build:untrusted-ci --flaky_test_attempts=2
 
 # Configuration used for BuildBuddy workflows
 build:workflows --config=remote-shared
-build:workflows --build_metadata=ROLE=CI
-build:workflows --build_metadata=VISIBILITY=PUBLIC
 build:workflows --remote_instance_name=buildbuddy-io/buildbuddy/workflows
 build:workflows --color=yes
 build:workflows --disk_cache=
@@ -78,6 +73,15 @@ build:workflows --config=buildbuddy_bes_backend
 build:workflows --config=buildbuddy_bes_results_url
 build:workflows --config=buildbuddy_remote_cache
 build:workflows --config=buildbuddy_remote_executor
+
+# TODO(bduffany): Enable RBE for Mac workflows, and reconcile this with other configs
+build:mac-workflows --config=cache
+build:mac-workflows --remote_instance_name=buildbuddy-io/buildbuddy/workflows
+build:mac-workflows --experimental_remote_cache_compression
+build:mac-workflows --color=yes
+build:mac-workflows --config=buildbuddy_bes_backend
+build:mac-workflows --config=buildbuddy_bes_results_url
+build:mac-workflows --config=buildbuddy_remote_cache
 
 # Configuration used for BuildBuddy release workflow
 build:release --config=remote

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -19,7 +19,7 @@ actions:
         branches:
           - "master"
     bazel_commands:
-      - build //... --config=workflows
+      - build //enterprise/server/cmd/executor //enterprise/server //server --config=mac-workflows
   - name: Benchmark
     triggers:
       push:

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -9,6 +9,17 @@ actions:
           - "master"
     bazel_commands:
       - test //... --config=workflows --test_tag_filters=-performance,-webdriver,-docker
+  - name: Build (darwin_amd64)
+    os: "darwin"
+    triggers:
+      push:
+        branches:
+          - "master"
+      pull_request:
+        branches:
+          - "master"
+    bazel_commands:
+      - build //... --config=workflows
   - name: Benchmark
     triggers:
       push:

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -19,7 +19,7 @@ actions:
         branches:
           - "master"
     bazel_commands:
-      - build //... --config=workflows-darwin-amd64
+      - build //... --config=workflows
   - name: Benchmark
     triggers:
       push:

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -19,7 +19,7 @@ actions:
         branches:
           - "master"
     bazel_commands:
-      - build //... --config=workflows
+      - build //... --config=workflows-darwin-amd64
   - name: Benchmark
     triggers:
       push:


### PR DESCRIPTION
Building only with remote cache for now since I ran into toolchain issues with RBE. Also just building specific targets, since building `//...` also resulted in toolchain issues, even without RBE. I would like to revisit the RBE build at some point, but this should at least make sure we can build our binaries on Mac, to avoid blocking releases.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
