### PR TITLE
Fixup option name broken on refactor

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -79,7 +79,8 @@ var (
 )
 
 func init() {
-	flagutil.StructSliceVar(&dockerDevices, "docker_devices", "Sets --device= on the docker command.")
+	flagutil.StructSliceVar(&dockerDevices, "executor.docker_devices", `Configure (docker) devices that will be available inside the sandbox container. Format is --executor.docker_devices='[{"PathOnHost":"/dev/foo","PathInContaine
+r":"/some/dest","CgroupPermissions":"see,docker,docs"}]'`)
 }
 
 const (

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -311,7 +311,7 @@ type ExecutorConfig struct {
 	RunnerPool                    RunnerPoolConfig          `yaml:"runner_pool"`
 	DockerNetHost                 bool                      `yaml:"docker_net_host" usage:"Sets --net=host on the docker command. Intended for local development only."`
 	DockerCapAdd                  string                    `yaml:"docker_cap_add" usage:"Sets --cap-add= on the docker command. Comma separated."`
-	DockerDevices                 []DockerDeviceMapping     `yaml:"docker_devices" usage:"Sets --device= on the docker command."`
+	DockerDevices                 []DockerDeviceMapping     `yaml:"docker_devices" usage:"Configure (docker) devices that will be available inside the sandbox container. Format is --executor.docker_devices='[{\"PathOnHost\":\"/dev/foo\",\"PathInContaine\nr\":\"/some/dest\",\"CgroupPermissions\":\"see,docker,docs\"}]'"`
 	DockerSiblingContainers       bool                      `yaml:"docker_sibling_containers" usage:"If set, mount the configured Docker socket to containers spawned for each action, to enable Docker-out-of-Docker (DooD). Takes effect only if docker_socket is also set. Should not be set by executors that can run untrusted code."`
 	DockerInheritUserIDs          bool                      `yaml:"docker_inherit_user_ids" usage:"If set, run docker containers using the same uid and gid as the user running the executor process."`
 	DefaultXcodeVersion           string                    `yaml:"default_xcode_version" usage:"Sets the default Xcode version number to use if an action doesn't specify one. If not set, /Applications/Xcode.app/ is used."`


### PR DESCRIPTION
s/--docker_devices/--executor.docker_devices/

The old code had all the options unprefixed, this one instance must have been missed.

Also, added some hints about the right format. Took me an insane amount of time to figure out, so I hope it will help others.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)TODO <!-- Required. Choose from: Major, Minor, Patch, None -->
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
