### PR TITLE
Check err != nil before using

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -358,7 +358,7 @@ func (c *podmanCommandContainer) killContainerIfRunning(ctx context.Context) err
 	defer cancel()
 
 	err := c.Remove(ctx)
-	if strings.Contains(err.Error(), "Error: can only kill running containers.") {
+	if err != nil && strings.Contains(err.Error(), "Error: can only kill running containers.") {
 		// This is expected.
 		return nil
 	}


### PR DESCRIPTION
h/t @bduffany 

Address error:
```
runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1129c17]

at go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End·dwrap·11 ( [external/io_opentelemetry_go_otel_sdk/trace/span.go:244](https://console.cloud.google.com/debug?referrer=fromlog&file=external%2Fio_opentelemetry_go_otel_sdk%2Ftrace%2Fspan.go&line=244&project=flame-build) )
at go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End ( [external/io_opentelemetry_go_otel_sdk/trace/span.go:283](https://console.cloud.google.com/debug?referrer=fromlog&file=external%2Fio_opentelemetry_go_otel_sdk%2Ftrace%2Fspan.go&line=283&project=flame-build) )
at github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/podman.(*podmanCommandContainer).killContainerIfRunning ( [external/com_github_buildbuddy_io_buildbuddy/enterprise/server/remote_execution/containers/podman/podman.go:361](https://console.cloud.google.com/debug?referrer=fromlog&file=external%2Fcom_github_buildbuddy_io_buildbuddy%2Fenterprise%2Fserver%2Fremote_execution%2Fcontainers%2Fpodman%2Fpodman.go&line=361&project=flame-build) )
at github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/podman.(*podmanCommandContainer).Run ( [external/com_github_buildbuddy_io_buildbuddy/enterprise/server/remote_execution/containers/podman/podman.go:163](https://console.cloud.google.com/debug?referrer=fromlog&file=external%2Fcom_github_buildbuddy_io_buildbuddy%2Fenterprise%2Fserver%2Fremote_execution%2Fcontainers%2Fpodman%2Fpodman.go&line=163&project=flame-build) )
at github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container.(*TracedCommandContainer).Run ( [external/com_github_buildbuddy_io_buildbuddy/enterprise/server/remote_execution/container/container.go:269](https://console.cloud.google.com/debug?referrer=fromlog&file=external%2Fcom_github_buildbuddy_io_buildbuddy%2Fenterprise%2Fserver%2Fremote_execution%2Fcontainer%2Fcontainer.go&line=269&project=flame-build) )
at github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/runner.(*commandRunner).Run ( [external/com_github_buildbuddy_io_buildbuddy/enterprise/server/remote_execution/runner/runner.go:314](https://console.cloud.google.com/debug?referrer=fromlog&file=external%2Fcom_github_buildbuddy_io_buildbuddy%2Fenterprise%2Fserver%2Fremote_execution%2Frunner%2Frunner.go&line=314&project=flame-build) )
at github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor.(*Executor).ExecuteTaskAndStreamResults.func3 ( [external/com_github_buildbuddy_io_buildbuddy/enterprise/server/remote_execution/executor/executor.go:235](https://console.cloud.google.com/debug?referrer=fromlog&file=external%2Fcom_github_buildbuddy_io_buildbuddy%2Fenterprise%2Fserver%2Fremote_execution%2Fexecutor%2Fexecutor.go&line=235&project=flame-build) )
```

(from https://console.cloud.google.com/errors/detail/COP81fS23K34hwE;time=P30D?project=flame-build&utm_source=error-reporting-notification&utm_medium=email&utm_content=new-error)