### PR TITLE
Remove empty commit_shas from test grid query

### DIFF
--- a/server/target/target.go
+++ b/server/target/target.go
@@ -283,6 +283,7 @@ func readPaginatedTargets(ctx context.Context, env environment.Env, req *trpb.Ge
 	}
 	commitQuery.AddWhereClause("role = ?", ciRole)
 	commitQuery.AddWhereClause("command = ?", testCommand)
+	commitQuery.AddWhereClause("commit_sha != ''")
 	paginationToken, err := NewTokenFromRequest(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When we have a problem parsing commit_shas and there are tons of
invocations with empty commit_shas. The test grid performance will
degrade since the limit clause on the commit inner-query doesn't really
prune the number of invocations down.
