### PR TITLE
For command types that don't populate OptionsDescription on the Started event (query, fetch), use OptionsParsed instead

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -233,11 +233,15 @@ func (r *buildEventReporter) Start(startTime time.Time) error {
 	}
 	r.startTime = startTime
 
-	optionsDescription := ""
+	options := []string{}
+	if *besBackend != "" {
+		options = append(options, fmt.Sprintf("--bes_backend=%s'", *besBackend))
+	}
 	if r.apiKey != "" {
-		optionsDescription = fmt.Sprintf("--remote_header='x-buildbuddy-api-key=%s'", r.apiKey)
+		options = append(options, fmt.Sprintf("--remote_header='x-buildbuddy-api-key=%s'", r.apiKey))
 	}
 
+	optionsDescription := strings.Join(options, " ")
 	cmd := ""
 	patterns := []string{}
 	if !r.isWorkflow {

--- a/enterprise/server/test/integration/build_logs/build_logs_test.go
+++ b/enterprise/server/test/integration/build_logs/build_logs_test.go
@@ -100,8 +100,9 @@ func publishStarted(t *testing.T, bep *build_event_publisher.Publisher) {
 	err := bep.Publish(&bespb.BuildEvent{
 		Payload: &bespb.BuildEvent_Started{
 			Started: &bespb.BuildStarted{
-				StartTimeMillis: startTime.UnixMilli(),
-				StartTime:       timestamppb.New(startTime),
+				StartTimeMillis:    startTime.UnixMilli(),
+				StartTime:          timestamppb.New(startTime),
+				OptionsDescription: "--bes_backend=foo",
 			},
 		},
 	})


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
