### PR TITLE
Store transferred size in invocation table instead of only compressed sizes

### DIFF
--- a/app/invocation/invocation_cache_card.tsx
+++ b/app/invocation/invocation_cache_card.tsx
@@ -83,13 +83,13 @@ export default class CacheCardComponent extends React.Component<Props> {
                             "downloaded",
                             "download-color-swatch",
                             Number(cacheStat.totalDownloadSizeBytes),
-                            Number(cacheStat.totalCompressedDownloadSizeBytes)
+                            Number(cacheStat.totalDownloadTransferredSizeBytes)
                           )}
                           {this.renderVolumeChartLabel(
                             "uploaded",
                             "upload-color-swatch",
                             Number(cacheStat.totalUploadSizeBytes),
-                            Number(cacheStat.totalCompressedUploadSizeBytes)
+                            Number(cacheStat.totalUploadTransferredSizeBytes)
                           )}
                         </div>
                       </div>

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -21,12 +21,23 @@ message CacheStats {
   int64 cas_cache_misses = 5;
   int64 cas_cache_uploads = 6;
 
-  // Do not use these numbers to compute throughput, they are the sum total of
-  // many concurrent uploads.
+  // NOTE: Do not use size / time fields to compute throughput; use the
+  // throughput fields instead which are intended to be more accurate.
+
+  // Sum of digest sizes for all cache download requests.
   int64 total_download_size_bytes = 7;
+
+  // Sum of digest sizes for all cache upload requests.
   int64 total_upload_size_bytes = 8;
+
+  //  Sum of payload sizes (compressed, if applicable) for all cache download
+  // requests.
   int64 total_download_transferred_size_bytes = 14;
+
+  // Sum of payload sizes (compressed, if applicable) for all cache upload
+  // requests.
   int64 total_upload_transferred_size_bytes = 15;
+
   int64 total_download_usec = 9;
   int64 total_upload_usec = 10;
 

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -25,8 +25,8 @@ message CacheStats {
   // many concurrent uploads.
   int64 total_download_size_bytes = 7;
   int64 total_upload_size_bytes = 8;
-  int64 total_compressed_download_size_bytes = 14;
-  int64 total_compressed_upload_size_bytes = 15;
+  int64 total_download_transferred_size_bytes = 14;
+  int64 total_upload_transferred_size_bytes = 15;
   int64 total_download_usec = 9;
   int64 total_upload_usec = 10;
 

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -585,8 +585,8 @@ func fillInvocationFromCacheStats(cacheStats *capb.CacheStats, ti *tables.Invoca
 	ti.CasCacheUploads = cacheStats.GetCasCacheUploads()
 	ti.TotalDownloadSizeBytes = cacheStats.GetTotalDownloadSizeBytes()
 	ti.TotalUploadSizeBytes = cacheStats.GetTotalUploadSizeBytes()
-	ti.TotalCompressedDownloadSizeBytes = cacheStats.GetTotalCompressedDownloadSizeBytes()
-	ti.TotalCompressedUploadSizeBytes = cacheStats.GetTotalCompressedUploadSizeBytes()
+	ti.TotalDownloadTransferredSizeBytes = cacheStats.GetTotalDownloadTransferredSizeBytes()
+	ti.TotalUploadTransferredSizeBytes = cacheStats.GetTotalUploadTransferredSizeBytes()
 	ti.TotalDownloadUsec = cacheStats.GetTotalDownloadUsec()
 	ti.TotalUploadUsec = cacheStats.GetTotalUploadUsec()
 	ti.DownloadThroughputBytesPerSecond = cacheStats.GetDownloadThroughputBytesPerSecond()
@@ -1080,21 +1080,21 @@ func TableInvocationToProto(i *tables.Invocation) *inpb.Invocation {
 	}
 	out.Acl = perms.ToACLProto(&uidpb.UserId{Id: i.UserID}, i.GroupID, i.Perms)
 	out.CacheStats = &capb.CacheStats{
-		ActionCacheHits:                  i.ActionCacheHits,
-		ActionCacheMisses:                i.ActionCacheMisses,
-		ActionCacheUploads:               i.ActionCacheUploads,
-		CasCacheHits:                     i.CasCacheHits,
-		CasCacheMisses:                   i.CasCacheMisses,
-		CasCacheUploads:                  i.CasCacheUploads,
-		TotalDownloadSizeBytes:           i.TotalDownloadSizeBytes,
-		TotalCompressedDownloadSizeBytes: i.TotalCompressedDownloadSizeBytes,
-		TotalUploadSizeBytes:             i.TotalUploadSizeBytes,
-		TotalCompressedUploadSizeBytes:   i.TotalCompressedUploadSizeBytes,
-		TotalDownloadUsec:                i.TotalDownloadUsec,
-		TotalUploadUsec:                  i.TotalUploadUsec,
-		TotalCachedActionExecUsec:        i.TotalCachedActionExecUsec,
-		DownloadThroughputBytesPerSecond: i.DownloadThroughputBytesPerSecond,
-		UploadThroughputBytesPerSecond:   i.UploadThroughputBytesPerSecond,
+		ActionCacheHits:                   i.ActionCacheHits,
+		ActionCacheMisses:                 i.ActionCacheMisses,
+		ActionCacheUploads:                i.ActionCacheUploads,
+		CasCacheHits:                      i.CasCacheHits,
+		CasCacheMisses:                    i.CasCacheMisses,
+		CasCacheUploads:                   i.CasCacheUploads,
+		TotalDownloadSizeBytes:            i.TotalDownloadSizeBytes,
+		TotalDownloadTransferredSizeBytes: i.TotalDownloadTransferredSizeBytes,
+		TotalUploadSizeBytes:              i.TotalUploadSizeBytes,
+		TotalUploadTransferredSizeBytes:   i.TotalUploadTransferredSizeBytes,
+		TotalDownloadUsec:                 i.TotalDownloadUsec,
+		TotalUploadUsec:                   i.TotalUploadUsec,
+		TotalCachedActionExecUsec:         i.TotalCachedActionExecUsec,
+		DownloadThroughputBytesPerSecond:  i.DownloadThroughputBytesPerSecond,
+		UploadThroughputBytesPerSecond:    i.UploadThroughputBytesPerSecond,
 	}
 	out.LastChunkId = i.LastChunkId
 	if i.LastChunkId != "" {

--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -58,8 +58,8 @@ const (
 
 	DownloadSizeBytes
 	UploadSizeBytes
-	CompressedDownloadSizeBytes
-	CompressedUploadSizeBytes
+	DownloadTransferredSizeBytes
+	UploadTransferredSizeBytes
 
 	DownloadUsec
 	UploadUsec
@@ -111,9 +111,9 @@ func counterField(actionCache bool, ct counterType) string {
 		return "download-size-bytes"
 	case UploadSizeBytes:
 		return "upload-size-bytes"
-	case CompressedDownloadSizeBytes:
+	case DownloadTransferredSizeBytes:
 		return "compressed-download-size-bytes"
-	case CompressedUploadSizeBytes:
+	case UploadTransferredSizeBytes:
 		return "compressed-upload-size-bytes"
 	case DownloadUsec:
 		return "download-usec"
@@ -368,14 +368,12 @@ func (t *transferTimer) CloseWithBytesTransferred(transferredSizeBytes int64, co
 	if err := h.c.IncrementCount(h.ctx, h.counterKey(), h.counterField(t.sizeCounter), t.d.GetSizeBytes()); err != nil {
 		return err
 	}
-	if compressor != repb.Compressor_IDENTITY {
-		compressedSizeCounter := CompressedDownloadSizeBytes
-		if t.sizeCounter == UploadSizeBytes {
-			compressedSizeCounter = CompressedUploadSizeBytes
-		}
-		if err := h.c.IncrementCount(h.ctx, h.counterKey(), h.counterField(compressedSizeCounter), transferredSizeBytes); err != nil {
-			return err
-		}
+	compressedSizeCounter := DownloadTransferredSizeBytes
+	if t.sizeCounter == UploadSizeBytes {
+		compressedSizeCounter = UploadTransferredSizeBytes
+	}
+	if err := h.c.IncrementCount(h.ctx, h.counterKey(), h.counterField(compressedSizeCounter), transferredSizeBytes); err != nil {
+		return err
 	}
 	if err := h.c.IncrementCount(h.ctx, h.counterKey(), h.counterField(t.timeCounter), dur.Microseconds()); err != nil {
 		return err
@@ -578,8 +576,8 @@ func CollectCacheStats(ctx context.Context, env environment.Env, iid string) *ca
 
 	cs.TotalDownloadSizeBytes = counts[counterField(false, DownloadSizeBytes)]
 	cs.TotalUploadSizeBytes = counts[counterField(false, UploadSizeBytes)]
-	cs.TotalCompressedDownloadSizeBytes = counts[counterField(false, CompressedDownloadSizeBytes)]
-	cs.TotalCompressedUploadSizeBytes = counts[counterField(false, CompressedUploadSizeBytes)]
+	cs.TotalDownloadTransferredSizeBytes = counts[counterField(false, DownloadTransferredSizeBytes)]
+	cs.TotalUploadTransferredSizeBytes = counts[counterField(false, UploadTransferredSizeBytes)]
 	cs.TotalDownloadUsec = counts[counterField(false, DownloadUsec)]
 	cs.TotalUploadUsec = counts[counterField(false, UploadUsec)]
 

--- a/server/remote_cache/hit_tracker/hit_tracker_test.go
+++ b/server/remote_cache/hit_tracker/hit_tracker_test.go
@@ -62,10 +62,10 @@ func TestHitTracker_RecordsDetailedStats(t *testing.T) {
 	stats := hit_tracker.CollectCacheStats(ctx, env, iid)
 	assert.Equal(t, int64(1), stats.GetCasCacheHits())
 	assert.Equal(t, d.SizeBytes, stats.GetTotalDownloadSizeBytes())
-	assert.Equal(t, compressedSize, stats.GetTotalCompressedDownloadSizeBytes())
+	assert.Equal(t, compressedSize, stats.GetTotalDownloadTransferredSizeBytes())
 	assert.Equal(t, int64(0), stats.GetCasCacheUploads())
 	assert.Equal(t, int64(0), stats.GetTotalUploadSizeBytes())
-	assert.Equal(t, int64(0), stats.GetTotalCompressedUploadSizeBytes())
+	assert.Equal(t, int64(0), stats.GetTotalUploadTransferredSizeBytes())
 }
 
 // Note: Can't use bazel_request.WithRequestMetadata here since it sets the

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -111,29 +111,43 @@ type Invocation struct {
 	LastChunkId  string
 	BranchName   string `gorm:"index:branch_name_index"`
 	Model
-	DurationUsec                      int64
-	UploadThroughputBytesPerSecond    int64
-	ActionCount                       int64
-	Perms                             int `gorm:"index:perms"`
-	RedactionFlags                    int
-	InvocationStatus                  int64 `gorm:"index:invocation_status_idx"`
-	ActionCacheHits                   int64
-	ActionCacheMisses                 int64
-	ActionCacheUploads                int64
-	CasCacheHits                      int64
-	CasCacheMisses                    int64
-	CasCacheUploads                   int64
-	TotalDownloadSizeBytes            int64
-	TotalUploadSizeBytes              int64
+	DurationUsec                   int64
+	UploadThroughputBytesPerSecond int64
+	ActionCount                    int64
+	Perms                          int `gorm:"index:perms"`
+	RedactionFlags                 int
+	InvocationStatus               int64 `gorm:"index:invocation_status_idx"`
+	ActionCacheHits                int64
+	ActionCacheMisses              int64
+	ActionCacheUploads             int64
+	CasCacheHits                   int64
+	CasCacheMisses                 int64
+	CasCacheUploads                int64
+
+	// TotalDownloadSizeBytes is the sum of digest sizes for all cache download
+	// requests made by this invocation.
+	TotalDownloadSizeBytes int64
+
+	// TotalUploadSizeBytes is the sum of digest sizes for all cache upload
+	// requests made by this invocation.
+	TotalUploadSizeBytes int64
+
+	// TotalDownloadTransferredSizeBytes is the sum of payload sizes (compressed,
+	// if applicable) for all cache download requests made by this invocation.
 	TotalDownloadTransferredSizeBytes int64
-	TotalUploadTransferredSizeBytes   int64
-	TotalDownloadUsec                 int64
-	TotalUploadUsec                   int64
-	TotalCachedActionExecUsec         int64
-	DownloadThroughputBytesPerSecond  int64
-	InvocationUUID                    []byte `gorm:"size:16;uniqueIndex:invocation_invocation_uuid"`
-	Success                           bool
-	Attempt                           uint64 `gorm:"not null;default:0"`
+
+	// TotalUploadTransferredSizeBytes is the sum of payload sizes
+	// (compressed, if applicable) for all cache upload requests made by this
+	// invocation.
+	TotalUploadTransferredSizeBytes int64
+
+	TotalDownloadUsec                int64
+	TotalUploadUsec                  int64
+	TotalCachedActionExecUsec        int64
+	DownloadThroughputBytesPerSecond int64
+	InvocationUUID                   []byte `gorm:"size:16;uniqueIndex:invocation_invocation_uuid"`
+	Success                          bool
+	Attempt                          uint64 `gorm:"not null;default:0"`
 }
 
 func (i *Invocation) TableName() string {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -111,29 +111,29 @@ type Invocation struct {
 	LastChunkId  string
 	BranchName   string `gorm:"index:branch_name_index"`
 	Model
-	DurationUsec                     int64
-	UploadThroughputBytesPerSecond   int64
-	ActionCount                      int64
-	Perms                            int `gorm:"index:perms"`
-	RedactionFlags                   int
-	InvocationStatus                 int64 `gorm:"index:invocation_status_idx"`
-	ActionCacheHits                  int64
-	ActionCacheMisses                int64
-	ActionCacheUploads               int64
-	CasCacheHits                     int64
-	CasCacheMisses                   int64
-	CasCacheUploads                  int64
-	TotalDownloadSizeBytes           int64
-	TotalUploadSizeBytes             int64
-	TotalCompressedDownloadSizeBytes int64
-	TotalCompressedUploadSizeBytes   int64
-	TotalDownloadUsec                int64
-	TotalUploadUsec                  int64
-	TotalCachedActionExecUsec        int64
-	DownloadThroughputBytesPerSecond int64
-	InvocationUUID                   []byte `gorm:"size:16;uniqueIndex:invocation_invocation_uuid"`
-	Success                          bool
-	Attempt                          uint64 `gorm:"not null;default:0"`
+	DurationUsec                      int64
+	UploadThroughputBytesPerSecond    int64
+	ActionCount                       int64
+	Perms                             int `gorm:"index:perms"`
+	RedactionFlags                    int
+	InvocationStatus                  int64 `gorm:"index:invocation_status_idx"`
+	ActionCacheHits                   int64
+	ActionCacheMisses                 int64
+	ActionCacheUploads                int64
+	CasCacheHits                      int64
+	CasCacheMisses                    int64
+	CasCacheUploads                   int64
+	TotalDownloadSizeBytes            int64
+	TotalUploadSizeBytes              int64
+	TotalDownloadTransferredSizeBytes int64
+	TotalUploadTransferredSizeBytes   int64
+	TotalDownloadUsec                 int64
+	TotalUploadUsec                   int64
+	TotalCachedActionExecUsec         int64
+	DownloadThroughputBytesPerSecond  int64
+	InvocationUUID                    []byte `gorm:"size:16;uniqueIndex:invocation_invocation_uuid"`
+	Success                           bool
+	Attempt                           uint64 `gorm:"not null;default:0"`
 }
 
 func (i *Invocation) TableName() string {


### PR DESCRIPTION
Rename "compressed size" to "transferred size" and include IDENTITY requests in the total transferred size (e.g. AC requests) so that the total bytes transferred shown in the UI is more accurate. For example, if we have 1 AC request uncompressed @ 100KB and 1 CAS request @ 10KB compressed, 30KB uncompressed, we want to show it in the UI as 130KB downloaded (110KB w/ compression). But before this PR we'd show 130KB downloaded (10KB w/ compression) which is inaccurate and makes the compression ratio seem higher than it is.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
