### PR TITLE
Add full request metadata to executor cache requests

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -305,11 +305,12 @@ func (s *ExecutionServer) Dispatch(ctx context.Context, req *repb.ExecuteRequest
 	}
 
 	executionTask := &repb.ExecutionTask{
-		ExecuteRequest: req,
-		InvocationId:   invocationID,
-		ExecutionId:    executionID,
-		Action:         action,
-		Command:        command,
+		ExecuteRequest:  req,
+		InvocationId:    invocationID,
+		ExecutionId:     executionID,
+		Action:          action,
+		Command:         command,
+		RequestMetadata: bazel_request.GetRequestMetadata(ctx),
 	}
 	// Allow execution worker to auth to cache (if necessary).
 	if jwt, ok := ctx.Value("x-buildbuddy-jwt").(string); ok {

--- a/enterprise/server/scheduling/priority_task_scheduler/BUILD
+++ b/enterprise/server/scheduling/priority_task_scheduler/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//server/metrics",
         "//server/resources",
         "//server/util/alert",
+        "//server/util/bazel_request",
         "//server/util/log",
         "//server/util/status",
         "//server/util/tracing",

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -262,8 +262,6 @@ func (q *PriorityTaskScheduler) EnqueueTaskReservation(ctx context.Context, req 
 func (q *PriorityTaskScheduler) propagateExecutionTaskValuesToContext(ctx context.Context, execTask *repb.ExecutionTask) context.Context {
 	ctx = context.WithValue(ctx, "x-buildbuddy-jwt", execTask.GetJwt())
 	rmd := execTask.GetRequestMetadata()
-	// TODO(bduffany): remove this fallback once all apps populate request
-	// metadata in each ExecutionTask.
 	if rmd == nil {
 		rmd = &repb.RequestMetadata{ToolInvocationId: execTask.GetInvocationId()}
 	}

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/resources"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
+	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
@@ -258,13 +259,16 @@ func (q *PriorityTaskScheduler) EnqueueTaskReservation(ctx context.Context, req 
 	return &scpb.EnqueueTaskReservationResponse{}, nil
 }
 
-func propagateExecutionTaskValuesToContext(ctx context.Context, execTask *repb.ExecutionTask) context.Context {
+func (q *PriorityTaskScheduler) propagateExecutionTaskValuesToContext(ctx context.Context, execTask *repb.ExecutionTask) context.Context {
 	ctx = context.WithValue(ctx, "x-buildbuddy-jwt", execTask.GetJwt())
-	rmd := &repb.RequestMetadata{
-		ToolInvocationId: execTask.GetInvocationId(),
+	rmd := execTask.GetRequestMetadata()
+	// TODO(bduffany): remove this fallback once all apps populate request
+	// metadata in each ExecutionTask.
+	if rmd == nil {
+		rmd = &repb.RequestMetadata{ToolInvocationId: execTask.GetInvocationId()}
 	}
 	if data, err := proto.Marshal(rmd); err == nil {
-		ctx = context.WithValue(ctx, "build.bazel.remote.execution.v2.requestmetadata-bin", string(data))
+		ctx = context.WithValue(ctx, bazel_request.RequestMetadataKey, string(data))
 	}
 	return ctx
 }
@@ -274,7 +278,7 @@ func (q *PriorityTaskScheduler) runTask(ctx context.Context, execTask *repb.Exec
 		return false, status.FailedPreconditionError("Execution client not configured")
 	}
 
-	ctx = propagateExecutionTaskValuesToContext(ctx, execTask)
+	ctx = q.propagateExecutionTaskValuesToContext(ctx, execTask)
 	clientStream, err := q.env.GetRemoteExecutionClient().PublishOperation(ctx)
 	if err != nil {
 		q.log.Warningf("Error opening publish operation stream: %s", err)

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -1748,4 +1748,5 @@ message ExecutionTask {
   string invocation_id = 3;
   google.protobuf.Timestamp queued_timestamp = 7;
   Platform platform_overrides = 8;
+  RequestMetadata request_metadata = 9;
 }


### PR DESCRIPTION
Forward the complete request metadata proto with requests from executor -> cache, not just the invocation ID metadata.

This fixes an issue that the scorecard is missing the target ID, action ID, and action mnemonic for RBE requests.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
