### PR TITLE
Pin podman and Skopeo versions in Dockerfile

### DIFF
--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y umoci iproute2
 # Install podman and skopeo
 RUN echo 'deb https://downloadcontent.opensuse.org/repositories/home:/alvistack/Debian_11/ /' >> /etc/apt/sources.list.d/home:alvistack.list && \
     curl -fsSL https://download.opensuse.org/repositories/home:/alvistack/Debian_11/Release.key | gpg --dearmor >> /etc/apt/trusted.gpg.d/home_alvistack_debian11.gpg && \
-    apt-get update && apt-get -y upgrade && apt-get install -y podman skopeo
+    apt-get update && apt-get -y upgrade && apt-get install -y podman=100:4.0.3-1 skopeo=100:1.7.0-1
 
 # Copy podman registries configuration.
 COPY data/registries.conf /etc/containers/registries.conf


### PR DESCRIPTION
The repo updated podman and skopeo very often. This might cause podman
to be upgraded in the production without enough testing.
