### PR TITLE
Add suggestions tab with support for multiple suggestions

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -15,7 +15,7 @@ import ScorecardCardComponent from "./scorecard_card";
 import FetchCardComponent from "./invocation_fetch_card";
 import InvocationDetailsCardComponent from "./invocation_details_card";
 import ErrorCardComponent from "./invocation_error_card";
-import SuggestionCardComponent from "./invocation_suggestion_card";
+import SuggestionCardComponent, { getSuggestions } from "./invocation_suggestion_card";
 import InvocationFilterComponent from "./invocation_filter";
 import InvocationInProgressComponent from "./invocation_in_progress";
 import InvocationModel from "./invocation_model";
@@ -220,6 +220,8 @@ export default class InvocationComponent extends React.Component<Props, State> {
         });
     };
 
+    const suggestions = getSuggestions({ model: this.state.model, buildLogs: this.getBuildLogs() });
+
     return (
       <div className="invocation">
         <div className={`shelf nopadding-dense ${this.state.model.getStatusClass()}`}>
@@ -243,6 +245,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
             denseMode={this.props.preferences.denseModeEnabled}
             role={this.state.model.getRole()}
             rbeEnabled={this.state.model.getIsRBEEnabled() ? true : false}
+            hasSuggestions={suggestions.length > 0}
           />
 
           {(activeTab === "targets" || activeTab === "artifacts" || activeTab === "execution") && (
@@ -269,8 +272,8 @@ export default class InvocationComponent extends React.Component<Props, State> {
             />
           )}
 
-          {(activeTab === "all" || activeTab == "log") && (
-            <SuggestionCardComponent model={this.state.model} buildLogs={this.getBuildLogs()} />
+          {(activeTab === "all" || activeTab == "log" || activeTab === "suggestions") && (
+            <SuggestionCardComponent suggestions={suggestions} overview={activeTab !== "suggestions"} />
           )}
 
           {(activeTab === "all" || activeTab == "log") && this.state.model.isQuery() && (

--- a/app/invocation/invocation_suggestion_card.tsx
+++ b/app/invocation/invocation_suggestion_card.tsx
@@ -1,13 +1,20 @@
 import React from "react";
-import { Radio } from "lucide-react";
+import { AlertCircle, HelpCircle } from "lucide-react";
+import { TextLink } from "../components/link/link";
 import InvocationModel from "./invocation_model";
 
 interface Props {
-  model: InvocationModel;
-  buildLogs: string;
+  suggestions: Suggestion[];
+  /**
+   * Whether this is being displayed from the overview page.
+   * Instead of showing all suggestions, this will show a summary
+   * and a link to the suggestions tab.
+   */
+  overview?: boolean;
 }
 
 interface Suggestion {
+  level: SuggestionLevel;
   message: React.ReactNode;
   reason: React.ReactNode;
 }
@@ -17,87 +24,135 @@ interface MatchParams {
   buildLogs: string;
 }
 
+export enum SuggestionLevel {
+  INFO,
+  ERROR,
+}
+
 /** Given some data about an invocation, optionally returns a suggestion. */
 type SuggestionMatcher = (params: MatchParams) => Suggestion | null;
 
-export default class SuggestionCardComponent extends React.Component<Props> {
-  shouldComponentUpdate(nextProps: Readonly<Props>): boolean {
-    return nextProps.buildLogs !== this.props.buildLogs || nextProps.model !== this.props.model;
+// TODO(siggisim): server side suggestion storing, parsing, and fetching.
+const matchers: SuggestionMatcher[] = [
+  buildLogRegex({
+    level: SuggestionLevel.ERROR,
+    regex: /stat \/usr\/bin\/gcc: no such file or directory/,
+    message: (
+      <>
+        It looks like the C toolchains aren't configured properly for this invocation, and remote build execution is
+        enabled. For more information about configuring toolchains, see the{" "}
+        <a href="https://www.buildbuddy.io/docs/rbe-setup" target="_blank">
+          BuildBuddy RBE Setup documentation
+        </a>
+        .
+      </>
+    ),
+  }),
+  buildLogRegex({
+    level: SuggestionLevel.ERROR,
+    regex: /exec user process caused "exec format error"/,
+    message: (
+      <>
+        It looks like the architecture of the host machine does not match the architecture of the remote execution
+        workers. This is likely because Bazel is running on a Mac, but only Linux remote executors are registered in the
+        remote execution cluster. Try running Bazel on a Linux host or in a Docker container.
+      </>
+    ),
+  }),
+  buildLogRegex({
+    level: SuggestionLevel.ERROR,
+    regex: /rpc error: code = Unavailable desc = No registered executors./,
+    message: (
+      <>
+        It looks like no executors are registered for the configured platform. This is likely because Bazel is running
+        on a Mac, but only Linux remote executors are registered in the remote execution cluster. Try running Bazel on a
+        Linux host or in a Docker container.
+      </>
+    ),
+  }),
+];
+
+export function getSuggestions({ model, buildLogs }: { model: InvocationModel; buildLogs: string }): Suggestion[] {
+  if (!buildLogs || !model) return [];
+
+  const suggestions: Suggestion[] = [];
+  for (let matcher of matchers) {
+    const suggestion = matcher({ buildLogs, model });
+    if (suggestion) suggestions.push(suggestion);
   }
+  return suggestions;
+}
 
-  // TODO(siggisim): server side suggestion storing, parsing, and fetching.
-  matchers: SuggestionMatcher[] = [
-    buildLogRegex({
-      regex: /stat \/usr\/bin\/gcc: no such file or directory/,
-      message: (
-        <>
-          It looks like the C toolchains aren't configured properly for this invocation, and remote build execution is
-          enabled. For more information about configuring toolchains, see the{" "}
-          <a href="https://www.buildbuddy.io/docs/rbe-setup" target="_blank">
-            BuildBuddy RBE Setup documentation
-          </a>
-          .
-        </>
-      ),
-    }),
-    buildLogRegex({
-      regex: /exec user process caused "exec format error"/,
-      message: (
-        <>
-          It looks like the architecture of the host machine does not match the architecture of the remote execution
-          workers. This is likely because Bazel is running on a Mac, but only Linux remote executors are registered in
-          the remote execution cluster. Try running Bazel on a Linux host or in a Docker container.
-        </>
-      ),
-    }),
-    buildLogRegex({
-      regex: /rpc error: code = Unavailable desc = No registered executors./,
-      message: (
-        <>
-          It looks like no executors are registered for the configured platform. This is likely because Bazel is running
-          on a Mac, but only Linux remote executors are registered in the remote execution cluster. Try running Bazel on
-          a Linux host or in a Docker container.
-        </>
-      ),
-    }),
-  ];
-
-  getSuggestion(): Suggestion | null {
-    if (!this.props.buildLogs || !this.props.model) return null;
-
-    for (let matcher of this.matchers) {
-      const suggestion = matcher({ buildLogs: this.props.buildLogs, model: this.props.model });
-      if (suggestion) return suggestion;
+export default class SuggestionCardComponent extends React.Component<Props> {
+  renderIcon(level: SuggestionLevel) {
+    switch (level) {
+      case SuggestionLevel.INFO:
+        return <HelpCircle className="icon" />;
+      case SuggestionLevel.ERROR:
+        return <AlertCircle className="icon red" />;
     }
-
-    return null;
   }
 
   render() {
-    const suggestion = this.getSuggestion();
-    if (!suggestion) return null;
+    const suggestions = this.props.suggestions;
+    if (!suggestions.length) return null;
 
-    return (
-      <div className="card card-suggestion">
-        <Radio className="icon white" />
-        <div className="content">
-          <div className="title">Suggestion from the BuildBuddy Team</div>
-          <div className="details">
-            <div className="card-suggestion-message">{suggestion.message}</div>
-            <div className="card-suggestion-reason">{suggestion.reason}</div>
+    // When rendering the overview, only show 1 up to one suggestion.
+    if (this.props.overview) {
+      const suggestion = suggestions[0];
+      const hiddenSuggestionsCount = suggestions.length - 1;
+      return (
+        <div className="card card-suggestion">
+          {this.renderIcon(suggestion.level)}
+          <div className="content">
+            <div className="title">Suggestion{suggestions.length === 1 ? "" : "s"} from the BuildBuddy Team</div>
+            <div className="details">
+              <div className="card-suggestion-message">{suggestion.message}</div>
+              {hiddenSuggestionsCount > 0 && (
+                <div className="suggestions-tab-link">
+                  <TextLink href="#suggestions">
+                    See {suggestions.length - 1} more suggestion{hiddenSuggestionsCount === 1 ? "" : "s"}
+                  </TextLink>
+                </div>
+              )}
+            </div>
           </div>
         </div>
+      );
+    }
+
+    return (
+      <div className="suggestions">
+        {suggestions.map((suggestion) => (
+          <div className="card card-suggestion">
+            {this.renderIcon(suggestion.level)}
+            <div className="content">
+              <div className="details">
+                <div className="card-suggestion-message">{suggestion.message}</div>
+                <div className="card-suggestion-reason">{suggestion.reason}</div>
+              </div>
+            </div>
+          </div>
+        ))}
       </div>
     );
   }
 }
 
 /** Returns the given suggestion message if the given regex matches the build logs. */
-function buildLogRegex({ regex, message }: { regex: RegExp; message: React.ReactNode }): SuggestionMatcher {
+function buildLogRegex({
+  level,
+  regex,
+  message,
+}: {
+  level: SuggestionLevel;
+  regex: RegExp;
+  message: React.ReactNode;
+}): SuggestionMatcher {
   return ({ buildLogs }) => {
     const matches = buildLogs.match(regex);
     if (!matches) return null;
     const reason = <>Shown because your build log contains "{matches[0]}"</>;
-    return { message, reason };
+    return { level, message, reason };
   };
 }

--- a/app/invocation/invocation_tabs.tsx
+++ b/app/invocation/invocation_tabs.tsx
@@ -12,6 +12,7 @@ export type TabsContext = {
   denseMode: boolean;
   role: string;
   rbeEnabled?: boolean;
+  hasSuggestions?: boolean;
 };
 
 export type TabId =
@@ -23,6 +24,7 @@ export type TabId =
   | "artifacts"
   | "timing"
   | "cache"
+  | "suggestions"
   | "raw"
   | "execution"
   | "fetches"
@@ -63,6 +65,7 @@ export default class InvocationTabsComponent extends React.Component<InvocationT
         {isBazelInvocation && this.renderTab("timing", { label: "Timing" })}
         {isBazelInvocation && this.renderTab("cache", { label: "Cache" })}
         {isBazelInvocation && this.props.rbeEnabled && this.renderTab("execution", { label: "Executions" })}
+        {this.props.hasSuggestions && this.renderTab("suggestions", { label: "Suggestions" })}
         {this.renderTab("raw", { label: "Raw" })}
       </div>
     );

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -473,8 +473,6 @@ svg.icon.orange {
 
 .card.card-suggestion {
   border-left: 6px solid transparent;
-  background-color: #ff5252;
-  color: #fff;
 }
 
 .card.dark {
@@ -603,6 +601,10 @@ svg.icon.orange {
   font-size: 0.8em;
   opacity: 0.7;
   max-width: 800px;
+}
+
+.card-suggestion .suggestions-tab-link {
+  margin-top: 8px;
 }
 
 /** Home **/

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -53,15 +53,15 @@ class Router {
   }
 
   /**
-   * Updates the URL relative to the origin. The new URL is formed by appending
-   * the given string onto `window.location.origin` verbatim.
+   * Updates the URL relative to the origin. The new URL is formed relative to
+   * the current href.
    *
    * - Creates a new browser history entry.
    * - Preserves global filter params.
    */
-  navigateTo(path: string) {
+  navigateTo(url: string) {
     const oldUrl = new URL(window.location.href);
-    const newUrl = new URL(window.location.origin + path);
+    const newUrl = new URL(url, window.location.href);
     // Preserve global filter params.
     for (const key of GLOBAL_FILTER_PARAM_NAMES) {
       if (!newUrl.searchParams.get(key) && oldUrl.searchParams.get(key)) {


### PR DESCRIPTION
* Add a suggestions tab if there is at least one suggestion
* In the overview page, link to "See {n} more suggestions" and also hide the suggestion reason to make it a bit more compact. The suggestion reason is now only visible in the suggestions tab.
* Support INFO-level suggestions instead of just errors.
* Remove red background and use a red icon instead, to make the styling more consistent for INFO-level suggestions.

---

Overview:

![image](https://user-images.githubusercontent.com/2414826/167939302-296df4c4-7bc9-423b-8d58-f3320a902b90.png)

---

Suggestions tab:

![image](https://user-images.githubusercontent.com/2414826/167939393-5923c21e-e3b6-4c91-ba65-be6d21c3bf5c.png)


---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
