### PR TITLE
Use default docker hostname behavior

### DIFF
--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -230,7 +230,6 @@ func (r *dockerCommandContainer) containerConfig(args, env []string, workDir str
 	}
 	return &dockercontainer.Config{
 		Image:      r.image,
-		Hostname:   "localhost",
 		Env:        env,
 		Cmd:        args,
 		WorkingDir: workDir,


### PR DESCRIPTION
By default, docker returns a container's ID when calling `hostname`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
