### PR TITLE
Change URLFlag so that its underlying type is URL, not string

### DIFF
--- a/enterprise/server/test/integration/workflow/workflow_test.go
+++ b/enterprise/server/test/integration/workflow/workflow_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -77,7 +78,9 @@ func setup(t *testing.T, gp interfaces.GitProvider) (*rbetest.Env, interfaces.Wo
 	flags.Set(t, "remote_execution.workflows_ci_runner_bazel_command", testbazel.BinaryPath(t))
 	// Set events_api_url to point to the test BB app server (this gets
 	// propagated to the CI runner so it knows where to publish build events).
-	flags.Set(t, "app.events_api_url", fmt.Sprintf("grpc://localhost:%d", bbServer.GRPCPort()))
+	u, err := url.Parse(fmt.Sprintf("grpc://localhost:%d", bbServer.GRPCPort()))
+	require.NoError(t, err)
+	flags.Set(t, "app.events_api_url", *u)
 
 	env.AddExecutors(t, 10)
 	return env, workflowService

--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/userdb"
@@ -300,10 +299,7 @@ func TestWebhook_UntrustedPullRequest_StartsUntrustedWorkflow(t *testing.T) {
 	execClient := &fakeExecutionClient{}
 	te.SetRemoteExecutionClient(execClient)
 	ws := te.GetWorkflowService()
-	appUrl := testhttp.StartServer(t, ws)
-	u, err := url.Parse(appUrl)
-	require.NoError(t, err)
-	flags.Set(t, "app.build_buddy_url", *u)
+	flags.Set(t, "app.build_buddy_url", *testhttp.StartServer(t, ws))
 	flags.Set(t, "remote_execution.enable_remote_exec", true)
 	provider := setupFakeGitProvider(t, te)
 	repoURL := makeTempRepo(t)
@@ -345,10 +341,7 @@ func TestWebhook_TrustedPullRequest_StartsTrustedWorkflow(t *testing.T) {
 	execClient := &fakeExecutionClient{}
 	te.SetRemoteExecutionClient(execClient)
 	ws := te.GetWorkflowService()
-	appUrl := testhttp.StartServer(t, ws)
-	u, err := url.Parse(appUrl)
-	require.NoError(t, err)
-	flags.Set(t, "app.build_buddy_url", *u)
+	flags.Set(t, "app.build_buddy_url", *testhttp.StartServer(t, ws))
 	flags.Set(t, "remote_execution.enable_remote_exec", true)
 	provider := setupFakeGitProvider(t, te)
 	repoURL := makeTempRepo(t)
@@ -390,10 +383,7 @@ func TestWebhook_TrustedApprovalOnUntrustedPullRequest_StartsTrustedWorkflow(t *
 	execClient := &fakeExecutionClient{}
 	te.SetRemoteExecutionClient(execClient)
 	ws := te.GetWorkflowService()
-	appUrl := testhttp.StartServer(t, ws)
-	u, err := url.Parse(appUrl)
-	require.NoError(t, err)
-	flags.Set(t, "app.build_buddy_url", *u)
+	flags.Set(t, "app.build_buddy_url", *testhttp.StartServer(t, ws))
 	flags.Set(t, "remote_execution.enable_remote_exec", true)
 	provider := setupFakeGitProvider(t, te)
 	repoURL := makeTempRepo(t)
@@ -436,10 +426,7 @@ func TestWebhook_TrustedApprovalOnAlreadyTrustedPullRequest_NOP(t *testing.T) {
 	execClient := &fakeExecutionClient{}
 	te.SetRemoteExecutionClient(execClient)
 	ws := te.GetWorkflowService()
-	appUrl := testhttp.StartServer(t, ws)
-	u, err := url.Parse(appUrl)
-	require.NoError(t, err)
-	flags.Set(t, "app.build_buddy_url", *u)
+	flags.Set(t, "app.build_buddy_url", *testhttp.StartServer(t, ws))
 	flags.Set(t, "remote_execution.enable_remote_exec", true)
 	provider := setupFakeGitProvider(t, te)
 	repoURL := makeTempRepo(t)
@@ -478,10 +465,7 @@ func TestWebhook_UntrustedApprovalOnUntrustedPullRequest_NOP(t *testing.T) {
 	execClient := &fakeExecutionClient{}
 	te.SetRemoteExecutionClient(execClient)
 	ws := te.GetWorkflowService()
-	appUrl := testhttp.StartServer(t, ws)
-	u, err := url.Parse(appUrl)
-	require.NoError(t, err)
-	flags.Set(t, "app.build_buddy_url", *u)
+	flags.Set(t, "app.build_buddy_url", *testhttp.StartServer(t, ws))
 	flags.Set(t, "remote_execution.enable_remote_exec", true)
 	provider := setupFakeGitProvider(t, te)
 	repoURL := makeTempRepo(t)
@@ -520,10 +504,7 @@ func TestWebhook_TrustedPush_StartsTrustedWorkflow(t *testing.T) {
 	execClient := &fakeExecutionClient{}
 	te.SetRemoteExecutionClient(execClient)
 	ws := te.GetWorkflowService()
-	appUrl := testhttp.StartServer(t, ws)
-	u, err := url.Parse(appUrl)
-	require.NoError(t, err)
-	flags.Set(t, "app.build_buddy_url", *u)
+	flags.Set(t, "app.build_buddy_url", *testhttp.StartServer(t, ws))
 	flags.Set(t, "remote_execution.enable_remote_exec", true)
 	provider := setupFakeGitProvider(t, te)
 	repoURL := makeTempRepo(t)

--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/userdb"
@@ -299,8 +300,10 @@ func TestWebhook_UntrustedPullRequest_StartsUntrustedWorkflow(t *testing.T) {
 	execClient := &fakeExecutionClient{}
 	te.SetRemoteExecutionClient(execClient)
 	ws := te.GetWorkflowService()
-	url := testhttp.StartServer(t, ws)
-	flags.Set(t, "app.build_buddy_url", url)
+	appUrl := testhttp.StartServer(t, ws)
+	u, err := url.Parse(appUrl)
+	require.NoError(t, err)
+	flags.Set(t, "app.build_buddy_url", *u)
 	flags.Set(t, "remote_execution.enable_remote_exec", true)
 	provider := setupFakeGitProvider(t, te)
 	repoURL := makeTempRepo(t)
@@ -342,8 +345,10 @@ func TestWebhook_TrustedPullRequest_StartsTrustedWorkflow(t *testing.T) {
 	execClient := &fakeExecutionClient{}
 	te.SetRemoteExecutionClient(execClient)
 	ws := te.GetWorkflowService()
-	url := testhttp.StartServer(t, ws)
-	flags.Set(t, "app.build_buddy_url", url)
+	appUrl := testhttp.StartServer(t, ws)
+	u, err := url.Parse(appUrl)
+	require.NoError(t, err)
+	flags.Set(t, "app.build_buddy_url", *u)
 	flags.Set(t, "remote_execution.enable_remote_exec", true)
 	provider := setupFakeGitProvider(t, te)
 	repoURL := makeTempRepo(t)
@@ -385,8 +390,10 @@ func TestWebhook_TrustedApprovalOnUntrustedPullRequest_StartsTrustedWorkflow(t *
 	execClient := &fakeExecutionClient{}
 	te.SetRemoteExecutionClient(execClient)
 	ws := te.GetWorkflowService()
-	url := testhttp.StartServer(t, ws)
-	flags.Set(t, "app.build_buddy_url", url)
+	appUrl := testhttp.StartServer(t, ws)
+	u, err := url.Parse(appUrl)
+	require.NoError(t, err)
+	flags.Set(t, "app.build_buddy_url", *u)
 	flags.Set(t, "remote_execution.enable_remote_exec", true)
 	provider := setupFakeGitProvider(t, te)
 	repoURL := makeTempRepo(t)
@@ -429,8 +436,10 @@ func TestWebhook_TrustedApprovalOnAlreadyTrustedPullRequest_NOP(t *testing.T) {
 	execClient := &fakeExecutionClient{}
 	te.SetRemoteExecutionClient(execClient)
 	ws := te.GetWorkflowService()
-	url := testhttp.StartServer(t, ws)
-	flags.Set(t, "app.build_buddy_url", url)
+	appUrl := testhttp.StartServer(t, ws)
+	u, err := url.Parse(appUrl)
+	require.NoError(t, err)
+	flags.Set(t, "app.build_buddy_url", *u)
 	flags.Set(t, "remote_execution.enable_remote_exec", true)
 	provider := setupFakeGitProvider(t, te)
 	repoURL := makeTempRepo(t)
@@ -469,8 +478,10 @@ func TestWebhook_UntrustedApprovalOnUntrustedPullRequest_NOP(t *testing.T) {
 	execClient := &fakeExecutionClient{}
 	te.SetRemoteExecutionClient(execClient)
 	ws := te.GetWorkflowService()
-	url := testhttp.StartServer(t, ws)
-	flags.Set(t, "app.build_buddy_url", url)
+	appUrl := testhttp.StartServer(t, ws)
+	u, err := url.Parse(appUrl)
+	require.NoError(t, err)
+	flags.Set(t, "app.build_buddy_url", *u)
 	flags.Set(t, "remote_execution.enable_remote_exec", true)
 	provider := setupFakeGitProvider(t, te)
 	repoURL := makeTempRepo(t)
@@ -509,8 +520,10 @@ func TestWebhook_TrustedPush_StartsTrustedWorkflow(t *testing.T) {
 	execClient := &fakeExecutionClient{}
 	te.SetRemoteExecutionClient(execClient)
 	ws := te.GetWorkflowService()
-	url := testhttp.StartServer(t, ws)
-	flags.Set(t, "app.build_buddy_url", url)
+	appUrl := testhttp.StartServer(t, ws)
+	u, err := url.Parse(appUrl)
+	require.NoError(t, err)
+	flags.Set(t, "app.build_buddy_url", *u)
 	flags.Set(t, "remote_execution.enable_remote_exec", true)
 	provider := setupFakeGitProvider(t, te)
 	repoURL := makeTempRepo(t)

--- a/server/endpoint_urls/build_buddy_url/BUILD
+++ b/server/endpoint_urls/build_buddy_url/BUILD
@@ -5,8 +5,5 @@ go_library(
     srcs = ["build_buddy_url.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url",
     visibility = ["//visibility:public"],
-    deps = [
-        "//server/util/alert",
-        "//server/util/flagutil",
-    ],
+    deps = ["//server/util/flagutil"],
 )

--- a/server/endpoint_urls/build_buddy_url/build_buddy_url.go
+++ b/server/endpoint_urls/build_buddy_url/build_buddy_url.go
@@ -3,24 +3,15 @@ package build_buddy_url
 import (
 	"net/url"
 
-	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 )
 
-var buildBuddyURL = flagutil.URLString("app.build_buddy_url", "http://localhost:8080", "The external URL where your BuildBuddy instance can be found.")
+var buildBuddyURL = flagutil.URLFromString("app.build_buddy_url", "http://localhost:8080", "The external URL where your BuildBuddy instance can be found.")
 
 func WithPath(path string) *url.URL {
-	u, err := url.Parse(*buildBuddyURL)
-	if err != nil {
-		// Shouldn't happen, URLFlag should validate it.
-		alert.UnexpectedEvent("flag app.build_buddy_url was not a parseable URL: %v", err)
-	}
-	if path == "" {
-		return u
-	}
-	return u.ResolveReference(&url.URL{Path: path})
+	return buildBuddyURL.ResolveReference(&url.URL{Path: path})
 }
 
 func String() string {
-	return *buildBuddyURL
+	return buildBuddyURL.String()
 }

--- a/server/endpoint_urls/cache_api_url/BUILD
+++ b/server/endpoint_urls/cache_api_url/BUILD
@@ -5,8 +5,5 @@ go_library(
     srcs = ["cache_api_url.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/cache_api_url",
     visibility = ["//visibility:public"],
-    deps = [
-        "//server/util/alert",
-        "//server/util/flagutil",
-    ],
+    deps = ["//server/util/flagutil"],
 )

--- a/server/endpoint_urls/cache_api_url/cache_api_url.go
+++ b/server/endpoint_urls/cache_api_url/cache_api_url.go
@@ -3,24 +3,15 @@ package cache_api_url
 import (
 	"net/url"
 
-	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 )
 
-var cacheAPIURL = flagutil.URLString("app.cache_api_url", "", "Overrides the default remote cache protocol gRPC address shown by BuildBuddy on the configuration screen.")
+var cacheAPIURL = flagutil.URLFromString("app.cache_api_url", "", "Overrides the default remote cache protocol gRPC address shown by BuildBuddy on the configuration screen.")
 
 func WithPath(path string) *url.URL {
-	u, err := url.Parse(*cacheAPIURL)
-	if err != nil {
-		// Shouldn't happen, URLFlag should validate it.
-		alert.UnexpectedEvent("flag app.cache_api_url was not a parseable URL: %v", err)
-	}
-	if path == "" {
-		return u
-	}
-	return u.ResolveReference(&url.URL{Path: path})
+	return cacheAPIURL.ResolveReference(&url.URL{Path: path})
 }
 
 func String() string {
-	return *cacheAPIURL
+	return cacheAPIURL.String()
 }

--- a/server/endpoint_urls/events_api_url/BUILD
+++ b/server/endpoint_urls/events_api_url/BUILD
@@ -5,8 +5,5 @@ go_library(
     srcs = ["events_api_url.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/events_api_url",
     visibility = ["//visibility:public"],
-    deps = [
-        "//server/util/alert",
-        "//server/util/flagutil",
-    ],
+    deps = ["//server/util/flagutil"],
 )

--- a/server/endpoint_urls/events_api_url/events_api_url.go
+++ b/server/endpoint_urls/events_api_url/events_api_url.go
@@ -3,24 +3,15 @@ package events_api_url
 import (
 	"net/url"
 
-	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 )
 
-var eventsAPIURL = flagutil.URLString("app.events_api_url", "", "Overrides the default build event protocol gRPC address shown by BuildBuddy on the configuration screen.")
+var eventsAPIURL = flagutil.URLFromString("app.events_api_url", "", "Overrides the default build event protocol gRPC address shown by BuildBuddy on the configuration screen.")
 
 func WithPath(path string) *url.URL {
-	u, err := url.Parse(*eventsAPIURL)
-	if err != nil {
-		// Shouldn't happen, URLFlag should validate it.
-		alert.UnexpectedEvent("flag app.events_api_url was not a parseable URL: %v", err)
-	}
-	if path == "" {
-		return u
-	}
-	return u.ResolveReference(&url.URL{Path: path})
+	return eventsAPIURL.ResolveReference(&url.URL{Path: path})
 }
 
 func String() string {
-	return *eventsAPIURL
+	return eventsAPIURL.String()
 }

--- a/server/endpoint_urls/remote_exec_api_url/BUILD
+++ b/server/endpoint_urls/remote_exec_api_url/BUILD
@@ -5,8 +5,5 @@ go_library(
     srcs = ["remote_exec_api_url.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/remote_exec_api_url",
     visibility = ["//visibility:public"],
-    deps = [
-        "//server/util/alert",
-        "//server/util/flagutil",
-    ],
+    deps = ["//server/util/flagutil"],
 )

--- a/server/endpoint_urls/remote_exec_api_url/remote_exec_api_url.go
+++ b/server/endpoint_urls/remote_exec_api_url/remote_exec_api_url.go
@@ -3,24 +3,15 @@ package remote_exec_api_url
 import (
 	"net/url"
 
-	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 )
 
-var remoteExecAPIURL = flagutil.URLString("app.remote_execution_api_url", "", "Overrides the default remote execution protocol gRPC address shown by BuildBuddy on the configuration screen.")
+var remoteExecAPIURL = flagutil.URLFromString("app.remote_execution_api_url", "", "Overrides the default remote execution protocol gRPC address shown by BuildBuddy on the configuration screen.")
 
 func WithPath(path string) *url.URL {
-	u, err := url.Parse(*remoteExecAPIURL)
-	if err != nil {
-		// Shouldn't happen, URLFlag should validate it.
-		alert.UnexpectedEvent("flag app.remote_execution_api_url was not a parseable URL: %v", err)
-	}
-	if path == "" {
-		return u
-	}
-	return u.ResolveReference(&url.URL{Path: path})
+	return remoteExecAPIURL.ResolveReference(&url.URL{Path: path})
 }
 
 func String() string {
-	return *remoteExecAPIURL
+	return remoteExecAPIURL.String()
 }

--- a/server/testutil/testhttp/testhttp.go
+++ b/server/testutil/testhttp/testhttp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
@@ -13,7 +14,7 @@ import (
 
 // StartServer runs a test-scoped HTTP server and returns the base server URL
 // in the format "http://localhost:PORT"
-func StartServer(t *testing.T, handler http.Handler) string {
+func StartServer(t *testing.T, handler http.Handler) *url.URL {
 	port := testport.FindFree(t)
 
 	addr := fmt.Sprintf("localhost:%d", port)
@@ -27,5 +28,5 @@ func StartServer(t *testing.T, handler http.Handler) string {
 		err := lis.Close()
 		require.NoError(t, err)
 	})
-	return "http://" + addr
+	return &url.URL{Scheme: "http", Host: addr}
 }

--- a/server/util/flagutil/flagutil.go
+++ b/server/util/flagutil/flagutil.go
@@ -170,8 +170,7 @@ func (f *URLFlag) Set(value string) error {
 	if err != nil {
 		return err
 	}
-	v := (*url.URL)(f)
-	*v = *u
+	*(*url.URL)(f) = *u
 	return nil
 }
 
@@ -179,18 +178,12 @@ func (f *URLFlag) String() string {
 	return (*url.URL)(f).String()
 }
 
-func (f *URLFlag) UnmarshalYAML(unmarshal func(any) error) error {
-	var s string
-	err := unmarshal(&s)
+func (f *URLFlag) UnmarshalYAML(value *yaml.Node) error {
+	u, err := url.Parse(value.Value)
 	if err != nil {
-		return err
+		return &yaml.TypeError{Errors: []string{err.Error()}}
 	}
-	u, err := url.Parse(s)
-	if err != nil {
-		return err
-	}
-	v := (*url.URL)(f)
-	*v = *u
+	*(*url.URL)(f) = *u
 	return nil
 }
 

--- a/server/util/flagutil/flagutil.go
+++ b/server/util/flagutil/flagutil.go
@@ -64,15 +64,6 @@ type Appendable interface {
 	AppendSlice(any) error
 }
 
-// String flag that gets validated as a URL
-// TODO: just use the URL directly (not the string) once we can generate the
-// YAML map from the flags instead of the other way around.
-func URLString(name, value, usage string) *string {
-	u := NewURLFlag(&value)
-	defaultFlagSet.Var(u, name, usage)
-	return &value
-}
-
 type SliceFlag[T any] []T
 
 func NewSliceFlag[T any](slice *[]T) *SliceFlag[T] {
@@ -153,41 +144,58 @@ func (f *SliceFlag[T]) YAMLTypeAlias() reflect.Type {
 	return f.AliasedType()
 }
 
-type URLFlag string
+type URLFlag url.URL
 
-func NewURLFlag(s *string) *URLFlag {
-	_, err := url.Parse(*s)
+func URL(name string, value url.URL, usage string) *url.URL {
+	u := &value
+	defaultFlagSet.Var((*URLFlag)(u), name, usage)
+	return u
+}
+
+func URLVar(value *url.URL, name string, usage string) {
+	defaultFlagSet.Var((*URLFlag)(value), name, usage)
+}
+
+func URLFromString(name, value, usage string) *url.URL {
+	u, err := url.Parse(value)
 	if err != nil {
-		log.Fatalf("Error parsing default URL value '%s' for flag: %v", *s, err)
+		log.Fatalf("Error parsing default URL value '%s' for flag: %v", value, err)
 		return nil
 	}
-	return (*URLFlag)(s)
+	return URL(name, *u, usage)
 }
 
 func (f *URLFlag) Set(value string) error {
-	*f = URLFlag(value)
-	_, err := url.Parse(value)
+	u, err := url.Parse(value)
 	if err != nil {
 		return err
 	}
+	v := (*url.URL)(f)
+	*v = *u
 	return nil
 }
 
 func (f *URLFlag) String() string {
-	return string(*f)
+	return (*url.URL)(f).String()
 }
 
 func (f *URLFlag) UnmarshalYAML(unmarshal func(any) error) error {
-	err := unmarshal((*string)(f))
+	var s string
+	err := unmarshal(&s)
 	if err != nil {
 		return err
 	}
-	_, err = url.Parse(string(*f))
-	return err
+	u, err := url.Parse(s)
+	if err != nil {
+		return err
+	}
+	v := (*url.URL)(f)
+	*v = *u
+	return nil
 }
 
 func (f *URLFlag) AliasedType() reflect.Type {
-	return reflect.TypeOf((*string)(nil))
+	return reflect.TypeOf((*url.URL)(nil))
 }
 
 func (f *URLFlag) YAMLTypeAlias() reflect.Type {

--- a/server/util/flagutil/flagutil_test.go
+++ b/server/util/flagutil/flagutil_test.go
@@ -2,6 +2,7 @@ package flagutil
 
 import (
 	"flag"
+	"net/url"
 	"reflect"
 	"testing"
 
@@ -125,7 +126,7 @@ func TestGenerateYAMLTypeMapFromFlags(t *testing.T) {
 	flags.Float64("one.two.two_and_a_half.float64", 5.2, "")
 	Slice("one.two.three.struct_slice", []testStruct{{Field: 4, Meadow: "Great"}}, "")
 	flags.String("a.b.string", "xxx", "")
-	URLString("a.b.url", "https://www.example.com", "")
+	URLFromString("a.b.url", "https://www.example.com", "")
 	actual, err := GenerateYAMLTypeMapFromFlags()
 	require.NoError(t, err)
 	expected := map[string]any{
@@ -145,7 +146,7 @@ func TestGenerateYAMLTypeMapFromFlags(t *testing.T) {
 		"a": map[string]any{
 			"b": map[string]any{
 				"string": reflect.TypeOf(""),
-				"url":    reflect.TypeOf(URLFlag("")),
+				"url":    reflect.TypeOf(URLFlag(url.URL{})),
 			},
 		},
 	}
@@ -195,7 +196,7 @@ func TestRetypeAndFilterYAMLMap(t *testing.T) {
 		"a": map[string]any{
 			"b": map[string]any{
 				"string": reflect.TypeOf(""),
-				"url":    reflect.TypeOf(URLFlag("")),
+				"url":    reflect.TypeOf(URLFlag(url.URL{})),
 			},
 		},
 		"foo": map[string]any{
@@ -219,7 +220,7 @@ one:
         - field: 5
 a:
   b:
-    url: "www.example.com"
+    url: "http://www.example.com"
 foo: 7
 first:
   second:
@@ -247,7 +248,7 @@ first:
 		},
 		"a": map[string]any{
 			"b": map[string]any{
-				"url": URLFlag("www.example.com"),
+				"url": URLFlag(url.URL{Scheme: "http", Host: "www.example.com"}),
 			},
 		},
 	}
@@ -294,7 +295,7 @@ func TestPopulateFlagsFromData(t *testing.T) {
 	flagABString := flags.String("a.b.string", "xxx", "")
 	flagABStructSlice := []testStruct{{Field: 7, Meadow: "Chimney"}}
 	SliceVar(&flagABStructSlice, "a.b.struct_slice", "")
-	flagABURL := URLString("a.b.url", "https://www.example.com", "")
+	flagABURL := URLFromString("a.b.url", "https://www.example.com", "")
 	yamlData := `
 bool: true
 one:
@@ -312,7 +313,7 @@ one:
         - field: 5
 a:
   b:
-    url: "www.example.com:8080"
+    url: "http://www.example.com:8080"
 foo: 7
 first:
   second:
@@ -328,7 +329,7 @@ first:
 	assert.Equal(t, []testStruct{{Field: 4, Meadow: "Great"}, {Field: 9, Meadow: "Eternal"}, {Field: 5}}, flagOneTwoThreeStructSlice)
 	assert.Equal(t, "xxx", *flagABString)
 	assert.Equal(t, []testStruct{{Field: 7, Meadow: "Chimney"}}, flagABStructSlice)
-	assert.Equal(t, "www.example.com:8080", *flagABURL)
+	assert.Equal(t, url.URL{Scheme:"http", Host: "www.example.com:8080"}, *flagABURL)
 }
 
 func TestBadPopulateFlagsFromData(t *testing.T) {
@@ -368,7 +369,7 @@ func TestPopulateFlagsFromYAML(t *testing.T) {
 	flagABString := flags.String("a.b.string", "xxx", "")
 	flagABStructSlice := []testStruct{{Field: 7, Meadow: "Chimney"}}
 	SliceVar(&flagABStructSlice, "a.b.struct_slice", "")
-	flagABURL := URLString("a.b.url", "https://www.example.com", "")
+	flagABURL := URLFromString("a.b.url", "https://www.example.com", "")
 	input := map[string]any{
 		"bool": false,
 		"one": map[string]any{
@@ -386,7 +387,7 @@ func TestPopulateFlagsFromYAML(t *testing.T) {
 			"b": map[string]any{
 				"string":       "",
 				"struct_slice": []testStruct{{Field: 9}},
-				"url":          URLFlag("https://www.example.com:8080"),
+				"url":          URLFlag(url.URL{Scheme: "https", Host: "www.example.com:8080"}),
 			},
 		},
 		"undefined": struct{}{}, // keys without with no corresponding flag name should be ignored.
@@ -401,7 +402,7 @@ func TestPopulateFlagsFromYAML(t *testing.T) {
 	assert.Equal(t, []testStruct{{Field: 4, Meadow: "Great"}}, flagOneTwoThreeStructSlice)
 	assert.Equal(t, "", *flagABString)
 	assert.Equal(t, []testStruct{{Field: 7, Meadow: "Chimney"}, {Field: 9}}, flagABStructSlice)
-	assert.Equal(t, "https://www.example.com:8080", *flagABURL)
+	assert.Equal(t, url.URL{Scheme: "https", Host: "www.example.com:8080"}, *flagABURL)
 }
 
 func TestBadPopulateFlagsFromYAML(t *testing.T) {
@@ -526,16 +527,20 @@ func TestSetValueForFlagName(t *testing.T) {
 	assert.Equal(t, "2", *flagString)
 
 	flags = replaceFlagsForTesting(t)
-	flagURL := URLString("url", "https://www.example.com", "")
-	err = SetValueForFlagName("url", "https://www.example.com:8080", map[string]struct{}{}, true, true)
+	flagURL := URLFromString("url", "https://www.example.com", "")
+	u, err := url.Parse("https://www.example.com:8080")
 	require.NoError(t, err)
-	assert.Equal(t, "https://www.example.com:8080", *flagURL)
+	err = SetValueForFlagName("url", *u, map[string]struct{}{}, true, true)
+	require.NoError(t, err)
+	assert.Equal(t, url.URL{Scheme: "https", Host: "www.example.com:8080"}, *flagURL)
 
 	flags = replaceFlagsForTesting(t)
-	flagURL = URLString("url", "https://www.example.com", "")
-	err = SetValueForFlagName("url", "https://www.example.com:8080", map[string]struct{}{"url": struct{}{}}, true, true)
+	flagURL = URLFromString("url", "https://www.example.com", "")
+	u, err = url.Parse("https://www.example.com:8080")
 	require.NoError(t, err)
-	assert.Equal(t, "https://www.example.com", *flagURL)
+	err = SetValueForFlagName("url", *u, map[string]struct{}{"url": struct{}{}}, true, true)
+	require.NoError(t, err)
+	assert.Equal(t, url.URL{Scheme: "https", Host: "www.example.com"}, *flagURL)
 
 	flags = replaceFlagsForTesting(t)
 	string_slice := make([]string, 2)

--- a/server/util/flagutil/flagutil_test.go
+++ b/server/util/flagutil/flagutil_test.go
@@ -329,7 +329,7 @@ first:
 	assert.Equal(t, []testStruct{{Field: 4, Meadow: "Great"}, {Field: 9, Meadow: "Eternal"}, {Field: 5}}, flagOneTwoThreeStructSlice)
 	assert.Equal(t, "xxx", *flagABString)
 	assert.Equal(t, []testStruct{{Field: 7, Meadow: "Chimney"}}, flagABStructSlice)
-	assert.Equal(t, url.URL{Scheme:"http", Host: "www.example.com:8080"}, *flagABURL)
+	assert.Equal(t, url.URL{Scheme: "http", Host: "www.example.com:8080"}, *flagABURL)
 }
 
 func TestBadPopulateFlagsFromData(t *testing.T) {

--- a/server/util/url/BUILD
+++ b/server/util/url/BUILD
@@ -21,5 +21,6 @@ go_test(
         "//server/real_environment",
         "//server/util/healthcheck",
         "//server/util/testing/flags",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/util/url/url_test.go
+++ b/server/util/url/url_test.go
@@ -2,13 +2,16 @@ package url_test
 
 import (
 	"flag"
+	"net/url"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
-	"github.com/buildbuddy-io/buildbuddy/server/util/url"
+	"github.com/stretchr/testify/require"
+
+	bburl "github.com/buildbuddy-io/buildbuddy/server/util/url"
 )
 
 func init() {
@@ -16,7 +19,9 @@ func init() {
 }
 
 func envWithAppURL(t *testing.T, appUrl string) environment.Env {
-	flags.Set(t, "app.build_buddy_url", appUrl)
+	u, err := url.Parse(appUrl)
+	require.NoError(t, err)
+	flags.Set(t, "app.build_buddy_url", *u)
 	healthChecker := healthcheck.NewHealthChecker("test")
 	return real_environment.NewRealEnv(healthChecker)
 }
@@ -56,7 +61,7 @@ func TestValidateRedirect(t *testing.T) {
 
 	for _, tc := range testCases {
 		te := envWithAppURL(t, tc.AppURL)
-		err := url.ValidateRedirect(te, tc.RedirURL)
+		err := bburl.ValidateRedirect(te, tc.RedirURL)
 		gotErr := err != nil
 		if gotErr != tc.WantErr {
 			t.Fatalf("ValidateRedir(%q, %q) returned %s, wantErr: %t", tc.AppURL, tc.RedirURL, err, tc.WantErr)


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

The motivation for this is mainly to stop having to re-parse a URL over and over again, as well
as to remove the associated error handling code, which was needlessly complicating.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
