### PR TITLE
Bump default TTL of pubsub streams.

### DIFF
--- a/enterprise/server/backends/pubsub/pubsub.go
+++ b/enterprise/server/backends/pubsub/pubsub.go
@@ -69,7 +69,7 @@ func (s *Subscriber) Chan() <-chan string {
 }
 
 const (
-	listTTL = 15 * time.Minute
+	listTTL = 8 * time.Hour
 )
 
 type ListPubSub struct {


### PR DESCRIPTION
There are no updates published while an execution is queued which can
cause the stream to disappear prematurely.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
