### PR TITLE
Record pending execution before scheduling.

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -396,12 +396,14 @@ func (s *ExecutionServer) Dispatch(ctx context.Context, req *repb.ExecuteRequest
 		Metadata:       schedulingMetadata,
 		SerializedTask: serializedTask,
 	}
-	if _, err := scheduler.ScheduleTask(ctx, scheduleReq); err != nil {
-		return "", status.UnavailableErrorf("Error scheduling execution task %q: %s", executionID, err.Error())
-	}
 
 	if err := s.recordPendingExecution(ctx, executionID, r); err != nil {
 		log.Warningf("could not recording pending execution %q: %s", executionID, err)
+	}
+
+	if _, err := scheduler.ScheduleTask(ctx, scheduleReq); err != nil {
+		_ = s.deletePendingExecution(ctx, executionID)
+		return "", status.UnavailableErrorf("Error scheduling execution task %q: %s", executionID, err)
 	}
 
 	return executionID, nil


### PR DESCRIPTION
Executions can complete quickly before the ScheduleTask() call returns
causing us to not properly clean up the pending execution metadata.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
