### PR TITLE
Clean up detailed stats after reading

### DIFF
--- a/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector.go
+++ b/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector.go
@@ -118,6 +118,18 @@ func (c *collector) GetAll(ctx context.Context, keys ...string) ([]string, error
 	return values, nil
 }
 
+func (c *collector) ListAppend(ctx context.Context, key string, values ...string) error {
+	ifaces := make([]interface{}, 0, len(values))
+	for _, value := range values {
+		ifaces = append(ifaces, value)
+	}
+	return c.rbuf.RPush(ctx, key, ifaces...)
+}
+
+func (c *collector) ListRange(ctx context.Context, key string, start, stop int64) ([]string, error) {
+	return c.rdb.LRange(ctx, key, start, stop).Result()
+}
+
 func (c *collector) ReadCounts(ctx context.Context, key string) (map[string]int64, error) {
 	h, err := c.rdb.HGetAll(ctx, key).Result()
 	if err != nil {
@@ -140,6 +152,10 @@ func (c *collector) ReadCounts(ctx context.Context, key string) (map[string]int6
 
 func (c *collector) Delete(ctx context.Context, key string) error {
 	return c.rdb.Del(ctx, key).Err()
+}
+
+func (c *collector) Expire(ctx context.Context, key string, duration time.Duration) error {
+	return c.rbuf.Expire(ctx, key, duration)
 }
 
 func (c *collector) Flush(ctx context.Context) error {

--- a/enterprise/server/util/redisutil/redisutil_test.go
+++ b/enterprise/server/util/redisutil/redisutil_test.go
@@ -318,6 +318,13 @@ func TestCommandBuffer(t *testing.T) {
 	err = buf.SAdd(ctx, "set2", "1")
 	require.NoError(t, err)
 
+	err = buf.RPush(ctx, "list1", "1", "2")
+	require.NoError(t, err)
+	err = buf.RPush(ctx, "list1", "3")
+	require.NoError(t, err)
+	err = buf.RPush(ctx, "list2", "A")
+	require.NoError(t, err)
+
 	// Create 2 keys that don't expire (initially).
 	_, err = rdb.Set(ctx, "expiring1", "value1", 0).Result()
 	require.NoError(t, err)
@@ -368,6 +375,13 @@ func TestCommandBuffer(t *testing.T) {
 	s2, err := rdb.SMembers(ctx, "set2").Result()
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"1"}, s2, "SAdd not working as expected")
+
+	list1, err := rdb.LRange(ctx, "list1", 0, -1).Result()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"1", "2", "3"}, list1)
+	list2, err := rdb.LRange(ctx, "list2", 0, -1).Result()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"A"}, list2)
 
 	_, err = rdb.Get(ctx, "expiring1").Result()
 	assert.Equal(t, redis.Nil, err)

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -664,8 +664,11 @@ type MetricsCollector interface {
 	SetGetMembers(ctx context.Context, key string) ([]string, error)
 	Set(ctx context.Context, key, value string, expiration time.Duration) error
 	GetAll(ctx context.Context, key ...string) ([]string, error)
+	ListAppend(ctx context.Context, key string, values ...string) error
+	ListRange(ctx context.Context, key string, start, stop int64) ([]string, error)
 	ReadCounts(ctx context.Context, key string) (map[string]int64, error)
 	Delete(ctx context.Context, key string) error
+	Expire(ctx context.Context, key string, duration time.Duration) error
 	Flush(ctx context.Context) error
 }
 

--- a/server/remote_cache/hit_tracker/BUILD
+++ b/server/remote_cache/hit_tracker/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//server/tables",
         "//server/util/bazel_request",
         "//server/util/log",
-        "@com_github_google_uuid//:uuid",
         "@com_github_prometheus_client_golang//prometheus",
         "@go_googleapis//google/rpc:status_go_proto",
         "@org_golang_google_grpc//codes",


### PR DESCRIPTION
:point_right: depends on https://github.com/buildbuddy-io/buildbuddy/pull/2027

* Switch to using a list to store results, to simplify retrieval and cleanup
* Delete the list in `CleanupCacheStats`
* Set a 3h expiration for the list in case we fail to clean up for whatever reason. The expiration is reset on each list push, so as long as an invocation makes cache requests at least once every few hours, we should still be able to handle long running invocations.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
