### PR TITLE
Extend context before copying container logs

### DIFF
--- a/enterprise/server/remote_execution/containers/docker/BUILD
+++ b/enterprise/server/remote_execution/containers/docker/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//server/environment",
         "//server/interfaces",
+        "//server/util/background",
         "//server/util/log",
         "//server/util/random",
         "//server/util/status",

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -158,6 +158,8 @@ func (r *dockerCommandContainer) Run(ctx context.Context, command *repb.Command,
 		}()
 	}()
 
+	ctx, cancel := background.ExtendContextForFinalization(ctx, containerFinalizationTimeout)
+	defer cancel()
 	r.copyContainerLogs(ctx, cid, result)
 	if result.Error != nil {
 		return result

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/background"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"


### PR DESCRIPTION
I see quite a few of these errors in server logs:
```
Command execution returned error: rpc error: code = DeadlineExceeded desc = failed to read docker container logs: context deadline exceeded
```

This seems to indicate we're relying on test timeout context to uploads logs (which can be large), but we should probably give it some additional time.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
