### PR TITLE
Show file names for BES uploads in cache scorecard

### DIFF
--- a/app/invocation/cache_requests_card.tsx
+++ b/app/invocation/cache_requests_card.tsx
@@ -339,7 +339,7 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
                 {groupActionId === null && result.actionMnemonic}
               </TextLink>
             ) : (
-              result.actionId
+              <>{result.name ? result.name : result.actionId}</>
             )}
           </div>
         )}
@@ -378,6 +378,15 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
         {result.actionMnemonic && (
           <>
             <b>Action</b> <span>{result.actionMnemonic}</span>
+          </>
+        )}
+        {result.name && (
+          <>
+            <b>File</b>{" "}
+            <span>
+              {result.pathPrefix ? result.pathPrefix + "/" : ""}
+              {result.name}
+            </span>
           </>
         )}
         <>
@@ -441,7 +450,7 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
         <div className="results-table">
           <div className="row column-headers">
             {this.getGroupBy() !== cache.GetCacheScoreCardRequest.GroupBy.GROUP_BY_ACTION && (
-              <div className="name-column">Action</div>
+              <div className="name-column">Name</div>
             )}
             <div className="cache-type-column">Cache</div>
             <div className="status-column">Status</div>

--- a/app/invocation/cache_requests_card.tsx
+++ b/app/invocation/cache_requests_card.tsx
@@ -375,9 +375,9 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
             <b>Target</b> <span>{result.targetId}</span>
           </>
         )}
-        {result.actionMnemonic && (
+        {(result.actionMnemonic || result.actionId) && (
           <>
-            <b>Action</b> <span>{result.actionMnemonic}</span>
+            <b>Action</b> <span>{result.actionMnemonic || result.actionId}</span>
           </>
         )}
         {result.name && (

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -204,6 +204,16 @@ message ScoreCard {
     // request was unsuccessful, this represents the number of bytes
     // transferred before the failure, if any.
     int64 transferred_size_bytes = 11;
+
+    // The file name of the cache artifact, if known.
+    // Ex: "server/util/url/url.a"
+    string name = 12;
+
+    // The file's path prefix, if known. This is part of the full file path, so
+    // it is important, but it can be "noisy" for display purposes, so it is
+    // kept separate.
+    // Ex: "bazel-out/k8-fastbuild/bin"
+    string path_prefix = 13;
   }
 
   // In the interest of saving space, we only show cache misses.

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -148,6 +148,9 @@ type recordStatsTask struct {
 	*invocationJWT
 	// createdAt is the time at which this task was created.
 	createdAt time.Time
+	// files contains a mapping of file digests to file name metadata for files
+	// referenced in the BEP.
+	files map[string]*build_event_stream.File
 }
 
 // statsRecorder listens for finalized invocations and copies cache stats from
@@ -198,6 +201,7 @@ func (r *statsRecorder) Enqueue(ctx context.Context, invocation *inpb.Invocation
 			attempt: invocation.Attempt,
 			jwt:     jwt,
 		},
+		files:     scorecard.ExtractFiles(invocation),
 		createdAt: time.Now(),
 	}
 	select {
@@ -238,8 +242,9 @@ func (r *statsRecorder) handleTask(ctx context.Context, task *recordStatsTask) {
 	if stats := hit_tracker.CollectCacheStats(ctx, r.env, task.invocationJWT.id); stats != nil {
 		fillInvocationFromCacheStats(stats, ti)
 	}
-	if scoreCard := hit_tracker.ScoreCard(ctx, r.env, task.invocationJWT.id); scoreCard != nil {
-		if err := scorecard.Write(ctx, r.env, task.invocationJWT.id, scoreCard); err != nil {
+	if sc := hit_tracker.ScoreCard(ctx, r.env, task.invocationJWT.id); sc != nil {
+		scorecard.FillBESMetadata(sc, task.files)
+		if err := scorecard.Write(ctx, r.env, task.invocationJWT.id, sc); err != nil {
 			log.Errorf("Error writing scorecard blob: %s", err)
 		}
 	}

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -201,8 +201,8 @@ func (r *statsRecorder) Enqueue(ctx context.Context, invocation *inpb.Invocation
 			attempt: invocation.Attempt,
 			jwt:     jwt,
 		},
-		files:     scorecard.ExtractFiles(invocation),
 		createdAt: time.Now(),
+		files:     scorecard.ExtractFiles(invocation),
 	}
 	select {
 	case r.tasks <- req:

--- a/server/remote_cache/scorecard/BUILD
+++ b/server/remote_cache/scorecard/BUILD
@@ -6,7 +6,9 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/remote_cache/scorecard",
     visibility = ["//visibility:public"],
     deps = [
+        "//proto:build_event_stream_go_proto",
         "//proto:cache_go_proto",
+        "//proto:invocation_go_proto",
         "//proto:pagination_go_proto",
         "//server/environment",
         "//server/util/paging",

--- a/server/remote_cache/scorecard/scorecard.go
+++ b/server/remote_cache/scorecard/scorecard.go
@@ -131,7 +131,7 @@ func filterResults(results []*capb.ScoreCard_Result, req *capb.GetCacheScoreCard
 		case "search":
 			s := strings.ToLower(req.GetFilter().GetSearch())
 			predicates = append(predicates, func(result *capb.ScoreCard_Result) bool {
-				filePath := strings.Join([]string{result.GetPathPrefix(), result.GetName()}, "/")
+				filePath := filepath.Join(result.GetPathPrefix(), result.GetName())
 				return strings.Contains(strings.ToLower(result.GetActionId()), s) ||
 					strings.Contains(strings.ToLower(result.GetActionMnemonic()), s) ||
 					strings.Contains(strings.ToLower(result.GetTargetId()), s) ||
@@ -266,8 +266,10 @@ func blobName(invocationID string) string {
 	return filepath.Join(invocationID, blobFileName)
 }
 
-// ExtractFiles extracts files from invocation BES events, returning a mapping
-// of digest to file.
+// ExtractFiles extracts any files from invocation BES events which may be
+// associated with bes-upload cache requests, such as the timing profile or
+// other uploads that weren't directly tied to an action execution. The returned
+// mapping is keyed by digest hash.
 func ExtractFiles(invocation *inpb.Invocation) map[string]*bespb.File {
 	out := map[string]*bespb.File{}
 
@@ -309,7 +311,7 @@ func FillBESMetadata(sc *capb.ScoreCard, files map[string]*bespb.File) {
 			continue
 		}
 		result.Name = f.Name
-		result.PathPrefix = strings.Join(f.PathPrefix, "/")
+		result.PathPrefix = filepath.Join(f.PathPrefix...)
 	}
 }
 

--- a/server/remote_cache/scorecard/scorecard.go
+++ b/server/remote_cache/scorecard/scorecard.go
@@ -3,6 +3,7 @@ package scorecard
 import (
 	"context"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -12,7 +13,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
 
+	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
+	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
 	pgpb "github.com/buildbuddy-io/buildbuddy/proto/pagination"
 )
 
@@ -20,6 +23,10 @@ const (
 	// Default page size for the scorecard when a page token is not included in
 	// the request.
 	defaultScoreCardPageSize = 100
+)
+
+var (
+	bytestreamURIPattern = regexp.MustCompile(`^bytestream://.*/blobs/([a-z0-9]{64})/\d+$`)
 )
 
 // GetCacheScoreCard returns a list of detailed, per-request cache stats.
@@ -124,10 +131,12 @@ func filterResults(results []*capb.ScoreCard_Result, req *capb.GetCacheScoreCard
 		case "search":
 			s := strings.ToLower(req.GetFilter().GetSearch())
 			predicates = append(predicates, func(result *capb.ScoreCard_Result) bool {
+				filePath := strings.Join([]string{result.GetPathPrefix(), result.GetName()}, "/")
 				return strings.Contains(strings.ToLower(result.GetActionId()), s) ||
 					strings.Contains(strings.ToLower(result.GetActionMnemonic()), s) ||
 					strings.Contains(strings.ToLower(result.GetTargetId()), s) ||
-					strings.Contains(strings.ToLower(result.GetDigest().GetHash()), s)
+					strings.Contains(strings.ToLower(result.GetDigest().GetHash()), s) ||
+					strings.Contains(strings.ToLower(filePath), s)
 			})
 		default:
 			return nil, status.InvalidArgumentErrorf("invalid field path %q", path)
@@ -255,6 +264,53 @@ func blobName(invocationID string) string {
 	// to lookup data from historical invocations.
 	blobFileName := invocationID + "-scorecard.pb"
 	return filepath.Join(invocationID, blobFileName)
+}
+
+// ExtractFiles extracts files from invocation BES events, returning a mapping
+// of digest to file.
+func ExtractFiles(invocation *inpb.Invocation) map[string]*bespb.File {
+	out := map[string]*bespb.File{}
+
+	maybeAddToMap := func(file *bespb.File) {
+		if uri, ok := file.File.(*bespb.File_Uri); ok {
+			m := bytestreamURIPattern.FindStringSubmatch(uri.Uri)
+			if len(m) >= 1 {
+				digestHash := m[1]
+				out[digestHash] = file
+			}
+		}
+	}
+
+	for _, event := range invocation.Event {
+		switch p := event.BuildEvent.Payload.(type) {
+		case *bespb.BuildEvent_NamedSetOfFiles:
+			for _, f := range p.NamedSetOfFiles.Files {
+				maybeAddToMap(f)
+			}
+		case *bespb.BuildEvent_BuildToolLogs:
+			for _, f := range p.BuildToolLogs.Log {
+				maybeAddToMap(f)
+			}
+		}
+	}
+
+	return out
+}
+
+// FillBESMetadata populates file metadata in the scorecard results for files
+// uploaded via BEP.
+func FillBESMetadata(sc *capb.ScoreCard, files map[string]*bespb.File) {
+	for _, result := range sc.Results {
+		if result.ActionId != "bes-upload" {
+			continue
+		}
+		f := files[result.Digest.GetHash()]
+		if f == nil {
+			continue
+		}
+		result.Name = f.Name
+		result.PathPrefix = strings.Join(f.PathPrefix, "/")
+	}
 }
 
 // Read reads the invocation cache scorecard from the configured blobstore.


### PR DESCRIPTION
Instead of showing "bes-upload" for all of these names, show the actual file name by cross-referencing File metadata that we have readily available in the BEP.

Computing these on the server side rather than client side, and storing them in the scorecard proto so that they are searchable.

The server side implementation extracts file metadata from the buffered BES events that we already have in memory during FinalizeInvocation. The downside is that this metadata sits in memory for 500ms for each invocation while we wait for stats buffers across apps to be flushed. This will slightly increase memory usage, but to a very small degree. Also, the alternatives seemed a bit overkill (either storing this metadata in Redis or re-reading the full invocation in the stats recorder just to get file name metadata).

![image](https://user-images.githubusercontent.com/2414826/169354568-763ed42a-7233-4ba1-967f-95a9e6f1bbf5.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
