### PR TITLE
Support partial reads in ByteStream API.

### DIFF
--- a/enterprise/server/backends/memcache/memcache.go
+++ b/enterprise/server/backends/memcache/memcache.go
@@ -244,7 +244,7 @@ func (c *Cache) Delete(ctx context.Context, d *repb.Digest) error {
 }
 
 // Low level interface used for seeking and stream-writing.
-func (c *Cache) Reader(ctx context.Context, d *repb.Digest, offset int64) (io.ReadCloser, error) {
+func (c *Cache) Reader(ctx context.Context, d *repb.Digest, offset, limit int64) (io.ReadCloser, error) {
 	if !eligibleForMc(d) {
 		return nil, status.ResourceExhaustedErrorf("Reader: Digest %v too big for memcache", d)
 	}
@@ -260,6 +260,9 @@ func (c *Cache) Reader(ctx context.Context, d *repb.Digest, offset int64) (io.Re
 	r := bytes.NewReader(buf)
 	r.Seek(offset, 0)
 	length := d.GetSizeBytes()
+	if limit != 0 && limit < length {
+		length = limit
+	}
 	if length > 0 {
 		return io.NopCloser(io.LimitReader(r, length)), nil
 	}

--- a/enterprise/server/composable_cache/composable_cache.go
+++ b/enterprise/server/composable_cache/composable_cache.go
@@ -170,12 +170,12 @@ func (m *MultiCloser) Close() error {
 	return nil
 }
 
-func (c *ComposableCache) Reader(ctx context.Context, d *repb.Digest, offset int64) (io.ReadCloser, error) {
-	if outerReader, err := c.outer.Reader(ctx, d, offset); err == nil {
+func (c *ComposableCache) Reader(ctx context.Context, d *repb.Digest, offset, limit int64) (io.ReadCloser, error) {
+	if outerReader, err := c.outer.Reader(ctx, d, offset, limit); err == nil {
 		return outerReader, nil
 	}
 
-	innerReader, err := c.inner.Reader(ctx, d, offset)
+	innerReader, err := c.inner.Reader(ctx, d, offset, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -300,7 +300,7 @@ func (rc *RaftCache) makeFileRecord(ctx context.Context, d *repb.Digest) (*rfpb.
 	}, nil
 }
 
-func (rc *RaftCache) Reader(ctx context.Context, d *repb.Digest, offset int64) (io.ReadCloser, error) {
+func (rc *RaftCache) Reader(ctx context.Context, d *repb.Digest, offset, limit int64) (io.ReadCloser, error) {
 	fileRecord, err := rc.makeFileRecord(ctx, d)
 	if err != nil {
 		return nil, err
@@ -316,6 +316,7 @@ func (rc *RaftCache) Reader(ctx context.Context, d *repb.Digest, offset int64) (
 			Header:     h,
 			FileRecord: fileRecord,
 			Offset:     offset,
+			Limit:      limit,
 		}
 		r, err := rc.apiClient.RemoteReader(ctx, c, req)
 		if err != nil {
@@ -416,7 +417,7 @@ func (rc *RaftCache) FindMissing(ctx context.Context, digests []*repb.Digest) ([
 }
 
 func (rc *RaftCache) Get(ctx context.Context, d *repb.Digest) ([]byte, error) {
-	r, err := rc.Reader(ctx, d, 0)
+	r, err := rc.Reader(ctx, d, 0, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -313,6 +313,7 @@ func (s *Store) ReadFileFromPeer(ctx context.Context, except *rfpb.ReplicaDescri
 			Header:     h,
 			FileRecord: fileRecord,
 			Offset:     0,
+			Limit:      0,
 		}
 		r, err := s.apiClient.RemoteReader(ctx, c, req)
 		if err != nil {

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -278,7 +278,7 @@ func (c *CacheProxy) Read(req *dcpb.ReadRequest, stream dcpb.DistributedCache_Re
 	if err != nil {
 		return err
 	}
-	reader, err := cache.Reader(ctx, d, req.GetOffset())
+	reader, err := cache.Reader(ctx, d, req.GetOffset(), req.GetLimit())
 	if err != nil {
 		c.log.Debugf("Read(%q) failed (user prefix: %s), err: %s", IsolationToString(req.GetIsolation())+d.GetHash(), up, err)
 		return err
@@ -430,11 +430,12 @@ func (c *CacheProxy) RemoteGetMulti(ctx context.Context, peer string, isolation 
 	return resultMap, nil
 }
 
-func (c *CacheProxy) RemoteReader(ctx context.Context, peer string, isolation *dcpb.Isolation, d *repb.Digest, offset int64) (io.ReadCloser, error) {
+func (c *CacheProxy) RemoteReader(ctx context.Context, peer string, isolation *dcpb.Isolation, d *repb.Digest, offset, limit int64) (io.ReadCloser, error) {
 	req := &dcpb.ReadRequest{
 		Isolation: isolation,
 		Key:       digestToKey(d),
 		Offset:    offset,
+		Limit:     limit,
 	}
 	client, err := c.getClient(ctx, peer)
 	if err != nil {

--- a/enterprise/server/util/cacheproxy/cacheproxy_test.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy_test.go
@@ -120,7 +120,7 @@ func TestReaderMaxOffset(t *testing.T) {
 	}
 
 	// Remote-read the random bytes back.
-	r, err := c.RemoteReader(ctx, peer, isolation, d, d.GetSizeBytes())
+	r, err := c.RemoteReader(ctx, peer, isolation, d, d.GetSizeBytes(), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +311,7 @@ func TestReader(t *testing.T) {
 		}
 
 		// Remote-read the random bytes back.
-		r, err := c.RemoteReader(ctx, peer, isolation, d, 0)
+		r, err := c.RemoteReader(ctx, peer, isolation, d, 0, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -373,7 +373,7 @@ func TestWriter(t *testing.T) {
 		// they match..
 		cache, err := te.GetCache().WithIsolation(ctx, interfaces.CASCacheType, remoteInstanceName)
 		require.NoError(t, err)
-		r, err := cache.Reader(ctx, d, 0)
+		r, err := cache.Reader(ctx, d, 0, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -567,7 +567,7 @@ func TestOversizeBlobs(t *testing.T) {
 		}
 
 		// Remote-read the random bytes back.
-		r, err := c.RemoteReader(ctx, peer, isolation, d, 0)
+		r, err := c.RemoteReader(ctx, peer, isolation, d, 0, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -735,7 +735,7 @@ func TestEmptyRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := c.RemoteReader(ctx, peer, isolation, d, 0)
+	r, err := c.RemoteReader(ctx, peer, isolation, d, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -22,6 +22,7 @@ message ReadRequest {
   reserved 1;
   Key key = 2;
   int64 offset = 3;
+  int64 limit = 5;
 }
 
 message ReadResponse {

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -410,6 +410,7 @@ message ReadRequest {
   Header header = 1;
   FileRecord file_record = 2;
   int64 offset = 3;
+  int64 limit = 4;
 }
 
 message ReadResponse {

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -313,8 +313,8 @@ func (c *DiskCache) Delete(ctx context.Context, d *repb.Digest) error {
 	return c.partition.delete(ctx, c.cacheType, c.remoteInstanceName, d)
 }
 
-func (c *DiskCache) Reader(ctx context.Context, d *repb.Digest, offset int64) (io.ReadCloser, error) {
-	return c.partition.reader(ctx, c.cacheType, c.remoteInstanceName, d, offset)
+func (c *DiskCache) Reader(ctx context.Context, d *repb.Digest, offset, limit int64) (io.ReadCloser, error) {
+	return c.partition.reader(ctx, c.cacheType, c.remoteInstanceName, d, offset, limit)
 }
 
 func (c *DiskCache) Writer(ctx context.Context, d *repb.Digest) (io.WriteCloser, error) {
@@ -888,13 +888,13 @@ func (p *partition) delete(ctx context.Context, cacheType interfaces.CacheType, 
 	return nil
 }
 
-func (p *partition) reader(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string, d *repb.Digest, offset int64) (io.ReadCloser, error) {
+func (p *partition) reader(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string, d *repb.Digest, offset, limit int64) (io.ReadCloser, error) {
 	k, err := p.key(ctx, cacheType, remoteInstanceName, d)
 	if err != nil {
 		return nil, err
 	}
 	// Can't specify length because this might be ActionCache
-	r, err := disk.FileReader(ctx, k.FullPath(), offset, 0)
+	r, err := disk.FileReader(ctx, k.FullPath(), offset, limit)
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if err != nil {

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -152,7 +152,7 @@ func TestReadWrite(t *testing.T) {
 			t.Fatalf("Error closing writer: %s", err.Error())
 		}
 		// Use Reader() to get the bytes from the cache.
-		reader, err := dc.Reader(ctx, d, 0)
+		reader, err := dc.Reader(ctx, d, 0, 0)
 		if err != nil {
 			t.Fatalf("Error getting %q reader: %s", d.GetHash(), err.Error())
 		}
@@ -185,7 +185,7 @@ func TestReadOffset(t *testing.T) {
 		t.Fatalf("Error closing writer: %s", err.Error())
 	}
 	// Use Reader() to get the bytes from the cache.
-	reader, err := dc.Reader(ctx, d, d.GetSizeBytes())
+	reader, err := dc.Reader(ctx, d, d.GetSizeBytes(), 0)
 	if err != nil {
 		t.Fatalf("Error getting %q reader: %s", d.GetHash(), err.Error())
 	}

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -196,6 +196,29 @@ func TestReadOffset(t *testing.T) {
 
 }
 
+func TestReadOffsetLimit(t *testing.T) {
+	rootDir := testfs.MakeTempDir(t)
+	te := getTestEnv(t, emptyUserMap)
+	dc, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDir}, 1000)
+	require.NoError(t, err)
+
+	ctx := getAnonContext(t, te)
+	size := int64(10)
+	d, buf := testdigest.NewRandomDigestBuf(t, size)
+	err = dc.Set(ctx, d, buf)
+	require.NoError(t, err)
+
+	offset := int64(2)
+	limit := int64(3)
+	reader, err := dc.Reader(ctx, d, offset, limit)
+	require.NoError(t, err)
+
+	readBuf := make([]byte, size)
+	n, err := reader.Read(readBuf)
+	require.EqualValues(t, limit, n)
+	require.Equal(t, buf[offset:offset+limit], readBuf[:limit])
+}
+
 func TestSizeLimit(t *testing.T) {
 	maxSizeBytes := int64(1000) // 1000 bytes
 	rootDir := testfs.MakeTempDir(t)

--- a/server/backends/memory_cache/BUILD
+++ b/server/backends/memory_cache/BUILD
@@ -30,5 +30,6 @@ go_test(
         "//server/testutil/testdigest",
         "//server/testutil/testenv",
         "//server/util/prefix",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/backends/memory_cache/memory_cache.go
+++ b/server/backends/memory_cache/memory_cache.go
@@ -190,7 +190,7 @@ func (m *MemoryCache) Delete(ctx context.Context, d *repb.Digest) error {
 }
 
 // Low level interface used for seeking and stream-writing.
-func (m *MemoryCache) Reader(ctx context.Context, d *repb.Digest, offset int64) (io.ReadCloser, error) {
+func (m *MemoryCache) Reader(ctx context.Context, d *repb.Digest, offset, limit int64) (io.ReadCloser, error) {
 	// Locking and key prefixing are handled in Get.
 	buf, err := m.Get(ctx, d)
 	if err != nil {
@@ -199,6 +199,9 @@ func (m *MemoryCache) Reader(ctx context.Context, d *repb.Digest, offset int64) 
 	r := bytes.NewReader(buf)
 	r.Seek(offset, 0)
 	length := int64(len(buf))
+	if limit != 0 && limit < length {
+		length = limit
+	}
 	if length > 0 {
 		return io.NopCloser(io.LimitReader(r, length)), nil
 	}

--- a/server/backends/memory_cache/memory_cache_test.go
+++ b/server/backends/memory_cache/memory_cache_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"testing"
 
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/memory_cache"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
@@ -13,8 +14,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
-
-	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
 var (
@@ -218,7 +217,7 @@ func TestReadWrite(t *testing.T) {
 			t.Fatalf("Error closing writer: %s", err.Error())
 		}
 		// Use Reader() to get the bytes from the cache.
-		reader, err := mc.Reader(ctx, d, 0)
+		reader, err := mc.Reader(ctx, d, 0, 0)
 		if err != nil {
 			t.Fatalf("Error getting %q reader: %s", d.GetHash(), err.Error())
 		}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -233,7 +233,7 @@ type Cache interface {
 	Delete(ctx context.Context, d *repb.Digest) error
 
 	// Low level interface used for seeking and stream-writing.
-	Reader(ctx context.Context, d *repb.Digest, offset int64) (io.ReadCloser, error)
+	Reader(ctx context.Context, d *repb.Digest, offset, limit int64) (io.ReadCloser, error)
 	Writer(ctx context.Context, d *repb.Digest) (io.WriteCloser, error)
 }
 

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -125,7 +125,7 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 		ht.TrackEmptyHit()
 		return nil
 	}
-	reader, err := cache.Reader(ctx, r.GetDigest(), req.ReadOffset)
+	reader, err := cache.Reader(ctx, r.GetDigest(), req.ReadOffset, req.ReadLimit)
 	if err != nil {
 		ht.TrackMiss(r.GetDigest())
 		return err


### PR DESCRIPTION
Used to serve container layer ranges.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
