### PR TITLE
Fix data races in runner_test

### DIFF
--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -393,14 +393,13 @@ func TestRunnerPool_ExceedMaxRunnerCount_OldestRunnerEvicted(t *testing.T) {
 		MaxRunnerDiskSizeBytes:    unlimited,
 		MaxRunnerMemoryUsageBytes: unlimited,
 	})
-	task := newTask()
 	ctxUser1 := withAuthenticatedUser(t, context.Background(), "US1")
 	ctxUser2 := withAuthenticatedUser(t, context.Background(), "US2")
 	ctxUser3 := withAuthenticatedUser(t, context.Background(), "US3")
 
-	r1 := mustGetNewRunner(t, ctxUser1, pool, task)
-	r2 := mustGetNewRunner(t, ctxUser2, pool, task)
-	r3 := mustGetNewRunner(t, ctxUser3, pool, task)
+	r1 := mustGetNewRunner(t, ctxUser1, pool, newTask())
+	r2 := mustGetNewRunner(t, ctxUser2, pool, newTask())
+	r3 := mustGetNewRunner(t, ctxUser3, pool, newTask())
 
 	// Limit is 2, so r1 and r2 should be added with no problem.
 
@@ -411,9 +410,9 @@ func TestRunnerPool_ExceedMaxRunnerCount_OldestRunnerEvicted(t *testing.T) {
 	// Should be able to get r1 and r3 back from the pool. r2 should have been
 	// evicted since it's the oldest (least recently added back to the pool).
 
-	mustGetPausedRunner(t, ctxUser1, pool, task)
-	mustGetPausedRunner(t, ctxUser3, pool, task)
-	mustGetNewRunner(t, ctxUser2, pool, task)
+	mustGetPausedRunner(t, ctxUser1, pool, newTask())
+	mustGetPausedRunner(t, ctxUser3, pool, newTask())
+	mustGetNewRunner(t, ctxUser2, pool, newTask())
 }
 
 func TestRunnerPool_DiskLimitExceeded_CannotAdd(t *testing.T) {


### PR DESCRIPTION
Adding even more locking to the runner pool (to protect `r.state`, `r.PlatformProperties`, and `r.task`) ... we can remove the need for locking once we have a proper fix for https://github.com/buildbuddy-io/buildbuddy-internal/issues/1159 (e.g., canceling the context on shutdown, instead of doing a concurrent call to `r.Remove()` while the task is executing)

I chose to lock around the runner pool's lock, rather than introducing per-runner locks, for (a) simplicity, and (b) to avoid introducing the possibility of deadlocks (i.e., having to worry about acquiring `p.mu` and `r.mu` in a consistent order)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
