### PR TITLE
Auto-generate YAML docs

### DIFF
--- a/enterprise/server/cmd/executor/yaml_doc/BUILD
+++ b/enterprise/server/cmd/executor/yaml_doc/BUILD
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_binary(
+    name = "yaml_doc",
+    embed = [":yaml_doc_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "yaml_doc_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/executor/yaml_doc",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//enterprise/server/cmd/executor:executor_lib",
+        "//server/util/flagutil",
+    ],
+)
+
+genrule(
+    name = "generate",
+    outs = ["buildbuddy_executor_documented_defaults.yaml"],
+    cmd = "./$(location :yaml_doc) -yaml_documented_defaults_out_file=\"$@\"",
+    tools = [":yaml_doc"],
+)

--- a/enterprise/server/cmd/executor/yaml_doc/main.go
+++ b/enterprise/server/cmd/executor/yaml_doc/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	_ "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/executor"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
+)
+
+const flagName = "yaml_documented_defaults_out_file"
+
+var yamlDefaultsOutFile = flag.String(flagName, "buildbuddy_executor_documented_defaults.yaml", "Path to a file to write the default YAML config (with docs) to.")
+
+func init() {
+	flagutil.IgnoreFlagForYAML(flagName)
+}
+
+func main() {
+	flag.Parse()
+
+	b, err := flagutil.SplitDocumentedDefaultYAMLFromFlags()
+	if err != nil {
+		log.Fatalf("Encountered error generating documented default YAML file: %s", err)
+	}
+
+	if err := os.WriteFile(*yamlDefaultsOutFile, b, 0644); err != nil {
+		log.Fatalf("Encountered error writing the documented default YAML file: %s", err)
+	}
+}

--- a/enterprise/server/cmd/executor/yaml_doc/main.go
+++ b/enterprise/server/cmd/executor/yaml_doc/main.go
@@ -20,7 +20,7 @@ func init() {
 func main() {
 	flag.Parse()
 
-	b, err := flagutil.SplitDocumentedDefaultYAMLFromFlags()
+	b, err := flagutil.SplitDocumentedYAMLFromFlags()
 	if err != nil {
 		log.Fatalf("Encountered error generating documented default YAML file: %s", err)
 	}

--- a/enterprise/server/cmd/server/yaml_doc/BUILD
+++ b/enterprise/server/cmd/server/yaml_doc/BUILD
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_binary(
+    name = "yaml_doc",
+    embed = [":yaml_doc_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "yaml_doc_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/server/yaml_doc",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//enterprise/server/cmd/server:server_lib",
+        "//server/util/flagutil",
+    ],
+)
+
+genrule(
+    name = "generate",
+    outs = ["buildbuddy_enterprise_server_documented_defaults.yaml"],
+    cmd = "./$(location :yaml_doc) -yaml_documented_defaults_out_file=\"$@\"",
+    tools = [":yaml_doc"],
+)

--- a/enterprise/server/cmd/server/yaml_doc/main.go
+++ b/enterprise/server/cmd/server/yaml_doc/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	_ "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/server"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
+)
+
+const flagName = "yaml_documented_defaults_out_file"
+
+var yamlDefaultsOutFile = flag.String(flagName, "buildbuddy_enterprise_server_documented_defaults.yaml", "Path to a file to write the default YAML config (with docs) to.")
+
+func init() {
+	flagutil.IgnoreFlagForYAML(flagName)
+}
+
+func main() {
+	flag.Parse()
+
+	b, err := flagutil.SplitDocumentedDefaultYAMLFromFlags()
+	if err != nil {
+		log.Fatalf("Encountered error generating documented default YAML file: %s", err)
+	}
+
+	if err := os.WriteFile(*yamlDefaultsOutFile, b, 0644); err != nil {
+		log.Fatalf("Encountered error writing the documented default YAML file: %s", err)
+	}
+}

--- a/enterprise/server/cmd/server/yaml_doc/main.go
+++ b/enterprise/server/cmd/server/yaml_doc/main.go
@@ -20,7 +20,7 @@ func init() {
 func main() {
 	flag.Parse()
 
-	b, err := flagutil.SplitDocumentedDefaultYAMLFromFlags()
+	b, err := flagutil.SplitDocumentedYAMLFromFlags()
 	if err != nil {
 		log.Fatalf("Encountered error generating documented default YAML file: %s", err)
 	}

--- a/server/cmd/buildbuddy/BUILD
+++ b/server/cmd/buildbuddy/BUILD
@@ -47,7 +47,7 @@ go_library(
     name = "buildbuddy_lib",
     srcs = ["main.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/cmd/buildbuddy",
-    visibility = ["//visibility:private"],
+    visibility = [":__subpackages__"],
     deps = [
         "//server/config",
         "//server/janitor",

--- a/server/cmd/buildbuddy/yaml_doc/BUILD
+++ b/server/cmd/buildbuddy/yaml_doc/BUILD
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_binary(
+    name = "yaml_doc",
+    embed = [":yaml_doc_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "yaml_doc_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/cmd/buildbuddy/yaml_doc",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//server/cmd/buildbuddy:buildbuddy_lib",
+        "//server/util/flagutil",
+    ],
+)
+
+genrule(
+    name = "generate",
+    outs = ["buildbuddy_server_documented_defaults.yaml"],
+    cmd = "./$(location :yaml_doc) -yaml_documented_defaults_out_file=\"$@\"",
+    tools = [":yaml_doc"],
+)

--- a/server/cmd/buildbuddy/yaml_doc/main.go
+++ b/server/cmd/buildbuddy/yaml_doc/main.go
@@ -20,7 +20,7 @@ func init() {
 func main() {
 	flag.Parse()
 
-	b, err := flagutil.SplitDocumentedDefaultYAMLFromFlags()
+	b, err := flagutil.SplitDocumentedYAMLFromFlags()
 	if err != nil {
 		log.Fatalf("Encountered error generating documented default YAML file: %s", err)
 	}

--- a/server/cmd/buildbuddy/yaml_doc/main.go
+++ b/server/cmd/buildbuddy/yaml_doc/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	_ "github.com/buildbuddy-io/buildbuddy/server/cmd/buildbuddy"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
+)
+
+const flagName = "yaml_documented_defaults_out_file"
+
+var yamlDefaultsOutFile = flag.String(flagName, "buildbuddy_server_documented_defaults.yaml", "Path to a file to write the default YAML config (with docs) to.")
+
+func init() {
+	flagutil.IgnoreFlagForYAML(flagName)
+}
+
+func main() {
+	flag.Parse()
+
+	b, err := flagutil.SplitDocumentedDefaultYAMLFromFlags()
+	if err != nil {
+		log.Fatalf("Encountered error generating documented default YAML file: %s", err)
+	}
+
+	if err := os.WriteFile(*yamlDefaultsOutFile, b, 0644); err != nil {
+		log.Fatalf("Encountered error writing the documented default YAML file: %s", err)
+	}
+}

--- a/server/util/flagutil/flagutil.go
+++ b/server/util/flagutil/flagutil.go
@@ -1,6 +1,7 @@
 package flagutil
 
 import (
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -35,6 +36,15 @@ var (
 	// Flag names to ignore when generating a YAML map or populating flags (e. g.,
 	// the flag specifying the path to the config file)
 	ignoreSet = make(map[string]struct{})
+
+	nilableKinds = map[reflect.Kind]struct{}{
+		reflect.Chan:      {},
+		reflect.Func:      {},
+		reflect.Interface: {},
+		reflect.Map:       {},
+		reflect.Ptr:       {},
+		reflect.Slice:     {},
+	}
 )
 
 func flagTypeFromFlagFuncName(name string) reflect.Type {
@@ -46,6 +56,16 @@ func flagTypeFromFlagFuncName(name string) reflect.Type {
 	}
 	ff.Call(in)
 	return reflect.TypeOf(fs.Lookup("").Value)
+}
+
+func IgnoreFilter(flg *flag.Flag) bool {
+	keys := strings.Split(flg.Name, ".")
+	for i := range keys {
+		if _, ok := ignoreSet[strings.Join(keys[:i+1], ".")]; ok {
+			return false
+		}
+	}
+	return true
 }
 
 type YAMLTypeAliasable interface {
@@ -62,6 +82,10 @@ type isNameAliasing interface {
 
 type Appendable interface {
 	AppendSlice(any) error
+}
+
+type DocumentedMarshaler interface {
+	DocumentNode(n *yaml.Node, opts ...DocumentNodeOption) error
 }
 
 type SliceFlag[T any] []T
@@ -187,6 +211,10 @@ func (f *URLFlag) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
+func (f *URLFlag) MarshalYAML() (any, error) {
+	return f.String(), nil
+}
+
 func (f *URLFlag) AliasedType() reflect.Type {
 	return reflect.TypeOf((*url.URL)(nil))
 }
@@ -276,18 +304,211 @@ func getYAMLTypeForFlag(flg *flag.Flag) (reflect.Type, error) {
 	return nil, status.UnimplementedErrorf("Unsupported flag type at %s: %T", flg.Name, flg.Value)
 }
 
-// GenerateYAMLTypeMapFromFlags generates a map of the type that should be
-// marshaled from YAML for each flag name at the corresponding nested map index.
-func GenerateYAMLTypeMapFromFlags() (map[string]any, error) {
+type DocumentNodeOption interface {
+	Transform(in any, n *yaml.Node)
+	Passthrough() bool
+}
+
+type headComment string
+
+func (h *headComment) Transform(in any, n *yaml.Node) { n.HeadComment = string(*h) }
+func (h *headComment) Passthrough() bool              { return false }
+func HeadComment(s string) *headComment               { return (*headComment)(&s) }
+
+type lineComment string
+
+func (l *lineComment) Transform(in any, n *yaml.Node) { n.LineComment = string(*l) }
+func (l *lineComment) Passthrough() bool              { return false }
+func LineComment(s string) *lineComment               { return (*lineComment)(&s) }
+
+type footComment string
+
+func (f *footComment) Transform(in any, n *yaml.Node) { n.FootComment = string(*f) }
+func (f *footComment) Passthrough() bool              { return false }
+func FootComment(s string) *footComment               { return (*footComment)(&s) }
+
+type addTypeToLineComment struct{}
+
+func (f *addTypeToLineComment) Transform(in any, n *yaml.Node) {
+	if n.LineComment != "" {
+		n.LineComment = fmt.Sprintf("%s type: %T", n.LineComment, in)
+	} else {
+		n.LineComment = fmt.Sprintf("type: %T", in)
+	}
+}
+
+func (f *addTypeToLineComment) Passthrough() bool { return true }
+func AddTypeToLineComment() *addTypeToLineComment { return (*addTypeToLineComment)(&struct{}{}) }
+
+func FilterPassthrough(opts []DocumentNodeOption) []DocumentNodeOption {
+	ptOpts := []DocumentNodeOption{}
+	for _, opt := range opts {
+		if opt.Passthrough() {
+			ptOpts = append(ptOpts, opt)
+		}
+	}
+	return ptOpts
+}
+
+func DocumentedNode(in any, opts ...DocumentNodeOption) (*yaml.Node, error) {
+	n := &yaml.Node{}
+	if err := n.Encode(in); err != nil {
+		return nil, err
+	}
+	if err := DocumentNode(in, n, opts...); err != nil {
+		return nil, err
+	}
+	return n, nil
+}
+
+func DocumentNode(in any, n *yaml.Node, opts ...DocumentNodeOption) error {
+	switch m := in.(type) {
+	case DocumentedMarshaler:
+		return m.DocumentNode(n, opts...)
+	case yaml.Marshaler:
+		// pass
+	default:
+		v := reflect.ValueOf(in)
+		t := v.Type()
+		switch t.Kind() {
+		case reflect.Ptr:
+			if !v.IsNil() {
+				return DocumentNode(v.Elem().Interface(), n, opts...)
+			} else {
+				return DocumentNode(reflect.New(reflect.TypeOf(t).Elem()).Elem().Interface(), n, opts...)
+			}
+		case reflect.Struct:
+			contentIndex := make(map[string]int, len(n.Content)/2)
+			for i := 0; i < len(n.Content)/2; i++ {
+				contentIndex[n.Content[2*i].Value] = 2*i + 1
+			}
+			for i := 0; i < t.NumField(); i++ {
+				ft := t.FieldByIndex([]int{i})
+				name := strings.Split(ft.Tag.Get("yaml"), ",")[0]
+				if name == "" {
+					name = strings.ToLower(ft.Name)
+				}
+				idx, ok := contentIndex[name]
+				if !ok {
+					// field is not encoded by yaml
+					continue
+				}
+				if err := DocumentNode(
+					v.FieldByIndex([]int{i}).Interface(),
+					n.Content[idx],
+					append(
+						[]DocumentNodeOption{LineComment(ft.Tag.Get("usage"))},
+						FilterPassthrough(opts)...,
+					)...,
+				); err != nil {
+					return err
+				}
+			}
+		case reflect.Slice:
+			for i := range n.Content {
+				var err error
+				if err = DocumentNode(v.Index(i).Interface(), n.Content[i], FilterPassthrough(opts)...); err != nil {
+					return err
+				}
+			}
+			if len(n.Content) == 0 {
+				exampleNode, err := DocumentedNode(reflect.MakeSlice(t, 1, 1).Interface(), FilterPassthrough(opts)...)
+				if err != nil {
+					return err
+				}
+				if exampleNode.Content[0].Kind != yaml.ScalarNode {
+					example, err := yaml.Marshal(exampleNode)
+					if err != nil {
+						return err
+					}
+					n.FootComment = fmt.Sprintf("e.g.,\n%s", string(example))
+				}
+			}
+		case reflect.Map:
+			for i := 0; i < len(n.Content)/2; i++ {
+				k := reflect.ValueOf(n.Content[2*i].Value)
+				if err := DocumentNode(
+					v.MapIndex(k).Interface(),
+					n.Content[2*i+1],
+					FilterPassthrough(opts)...,
+				); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	for _, opt := range opts {
+		opt.Transform(in, n)
+	}
+	return nil
+}
+
+func GenerateDocumentedDefaultYAMLNodeFromFlag(flg *flag.Flag) (*yaml.Node, error) {
+	t, err := getYAMLTypeForFlag(flg)
+	if err != nil {
+		return nil, status.InternalErrorf("Error encountered generating default YAML from flags: %s", err)
+	}
+	value := reflect.ValueOf(flg.Value)
+	if !value.CanConvert(t) {
+		return nil, status.FailedPreconditionErrorf("Cannot convert value %v of type %T into type %v for flag %s.", flg.Value, flg.Value, t, flg.Name)
+	}
+	return DocumentedNode(value.Convert(t).Interface(), LineComment(flg.Usage), AddTypeToLineComment())
+}
+
+func SplitDocumentedDefaultYAMLFromFlags() ([]byte, error) {
+	b := bytes.NewBuffer([]byte{})
+
+	if _, err := b.Write([]byte("# Unstructured settings\n\n")); err != nil {
+		return nil, err
+	}
+	um, err := GenerateYAMLMapWithValuesFromFlags(
+		GenerateDocumentedDefaultYAMLNodeFromFlag,
+		func(flg *flag.Flag) bool { return !strings.Contains(flg.Name, ".") },
+		IgnoreFilter,
+	)
+	if err != nil {
+		return nil, err
+	}
+	ub, err := yaml.Marshal(um)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := b.Write(ub); err != nil {
+		return nil, err
+	}
+
+	if _, err := b.Write([]byte("\n# Structured settings\n\n")); err != nil {
+		return nil, err
+	}
+	sm, err := GenerateYAMLMapWithValuesFromFlags(
+		GenerateDocumentedDefaultYAMLNodeFromFlag,
+		func(flg *flag.Flag) bool { return strings.Contains(flg.Name, ".") },
+		IgnoreFilter,
+	)
+	if err != nil {
+		return nil, err
+	}
+	sb, err := yaml.Marshal(sm)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := b.Write(sb); err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}
+
+func GenerateYAMLMapWithValuesFromFlags[T any](generateValue func(*flag.Flag) (T, error), filters ...func(*flag.Flag) bool) (map[string]any, error) {
 	yamlMap := make(map[string]any)
 	var errors []error
 	defaultFlagSet.VisitAll(func(flg *flag.Flag) {
-		keys := strings.Split(flg.Name, ".")
-		for i := range keys {
-			if _, ok := ignoreSet[strings.Join(keys[:i+1], ".")]; ok {
+		for _, f := range filters {
+			if !f(flg) {
 				return
 			}
 		}
+		keys := strings.Split(flg.Name, ".")
 		m := yamlMap
 		for i, k := range keys[:len(keys)-1] {
 			v, ok := m[k]
@@ -298,26 +519,47 @@ func GenerateYAMLTypeMapFromFlags() (map[string]any, error) {
 			}
 			m, ok = v.(map[string]any)
 			if !ok {
-				errors = append(errors, status.FailedPreconditionErrorf("When trying to create YAML type map hierarchy for %s, encountered non-map value of type %T at %s", flg.Name, v, strings.Join(keys[:i+1], ".")))
+				errors = append(errors, status.FailedPreconditionErrorf("When trying to create YAML map hierarchy for %s, encountered non-map value %s of type %T at %s", flg.Name, v, v, strings.Join(keys[:i+1], ".")))
 				return
 			}
 		}
 		k := keys[len(keys)-1]
 		if v, ok := m[k]; ok {
-			errors = append(errors, status.FailedPreconditionErrorf("When trying to create type for %s for YAML type map, encountered pre-existing value of type %T.", flg.Name, v))
+			errors = append(errors, status.FailedPreconditionErrorf("When generating value for %s for YAML map, encountered pre-existing value %s of type %T.", flg.Name, v, v))
 			return
 		}
-		t, err := getYAMLTypeForFlag(flg)
+		v, err := generateValue(flg)
 		if err != nil {
 			errors = append(errors, err)
 			return
 		}
-		m[k] = t.Elem()
+		value := reflect.ValueOf(v)
+		if _, ok := nilableKinds[value.Kind()]; ok && value.IsNil() {
+			return
+		}
+		m[k] = v
 	})
 	if errors != nil {
-		return nil, status.InternalErrorf("Errors encountered when converting flags to YAML map: %v", errors)
+		return nil, status.InternalErrorf("Errors encountered when generating YAML map from flags: %v", errors)
 	}
-	return yamlMap, nil
+
+	return RemoveEmptyMapsFromYAMLMap(yamlMap), nil
+}
+
+func RemoveEmptyMapsFromYAMLMap(m map[string]any) map[string]any {
+	for k, v := range m {
+		mv, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m[k] = RemoveEmptyMapsFromYAMLMap(mv); m[k] == nil {
+			delete(m, k)
+		}
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }
 
 // RetypeAndFilterYAMLMap un-marshals yaml from the input yamlMap and then
@@ -340,13 +582,13 @@ func RetypeAndFilterYAMLMap(yamlMap map[string]any, typeMap map[string]any, pref
 			if err != nil {
 				return status.InternalErrorf("Encountered error marshaling %v to YAML at %s: %s", yamlMap[k], strings.Join(label, "."), err)
 			}
-			v := reflect.New(t).Elem()
+			v := reflect.New(t.Elem()).Elem()
 			err = yaml.Unmarshal(yamlData, v.Addr().Interface())
 			if err != nil {
 				return status.InternalErrorf("Encountered error marshaling %s to YAML for type %v at %s: %s", string(yamlData), v.Type(), strings.Join(label, "."), err)
 			}
-			if v.Type() != t {
-				return status.InternalErrorf("Failed to unmarshal YAML to the specified type at %s: wanted %v, got %T", strings.Join(label, "."), t, v.Type())
+			if v.Type() != t.Elem() {
+				return status.InternalErrorf("Failed to unmarshal YAML to the specified type at %s: wanted %v, got %T", strings.Join(label, "."), t.Elem(), v.Type())
 			}
 			yamlMap[k] = v.Interface()
 		case map[string]any:
@@ -387,7 +629,7 @@ func PopulateFlagsFromData(data []byte) error {
 	} else {
 		node = nil
 	}
-	typeMap, err := GenerateYAMLTypeMapFromFlags()
+	typeMap, err := GenerateYAMLMapWithValuesFromFlags(getYAMLTypeForFlag, IgnoreFilter)
 	if err != nil {
 		return err
 	}

--- a/server/util/flagutil/flagutil_test.go
+++ b/server/util/flagutil/flagutil_test.go
@@ -127,26 +127,26 @@ func TestGenerateYAMLTypeMapFromFlags(t *testing.T) {
 	Slice("one.two.three.struct_slice", []testStruct{{Field: 4, Meadow: "Great"}}, "")
 	flags.String("a.b.string", "xxx", "")
 	URLFromString("a.b.url", "https://www.example.com", "")
-	actual, err := GenerateYAMLTypeMapFromFlags()
+	actual, err := GenerateYAMLMapWithValuesFromFlags(getYAMLTypeForFlag, IgnoreFilter)
 	require.NoError(t, err)
 	expected := map[string]any{
-		"bool": reflect.TypeOf(false),
+		"bool": reflect.TypeOf((*bool)(nil)),
 		"one": map[string]any{
 			"two": map[string]any{
-				"int":          reflect.TypeOf(int(0)),
-				"string_slice": reflect.TypeOf(([]string)(nil)),
+				"int":          reflect.TypeOf((*int)(nil)),
+				"string_slice": reflect.TypeOf((*[]string)(nil)),
 				"two_and_a_half": map[string]any{
-					"float64": reflect.TypeOf(float64(0)),
+					"float64": reflect.TypeOf((*float64)(nil)),
 				},
 				"three": map[string]any{
-					"struct_slice": reflect.TypeOf(([]testStruct)(nil)),
+					"struct_slice": reflect.TypeOf((*[]testStruct)(nil)),
 				},
 			},
 		},
 		"a": map[string]any{
 			"b": map[string]any{
-				"string": reflect.TypeOf(""),
-				"url":    reflect.TypeOf(URLFlag(url.URL{})),
+				"string": reflect.TypeOf((*string)(nil)),
+				"url":    reflect.TypeOf((*URLFlag)(nil)),
 			},
 		},
 	}
@@ -160,47 +160,47 @@ func TestBadGenerateYAMLTypeMapFromFlags(t *testing.T) {
 
 	flags.Int("one.two.int", 10, "")
 	flags.Int("one.two", 10, "")
-	_, err := GenerateYAMLTypeMapFromFlags()
+	_, err := GenerateYAMLMapWithValuesFromFlags(getYAMLTypeForFlag, IgnoreFilter)
 	require.Error(t, err)
 
 	flags = replaceFlagsForTesting(t)
 
 	flags.Int("one.two", 10, "")
 	flags.Int("one.two.int", 10, "")
-	_, err = GenerateYAMLTypeMapFromFlags()
+	_, err = GenerateYAMLMapWithValuesFromFlags(getYAMLTypeForFlag, IgnoreFilter)
 	require.Error(t, err)
 
 	flags = replaceFlagsForTesting(t)
 
 	flags.Var(&unsupportedFlagValue{}, "unsupported", "")
-	_, err = GenerateYAMLTypeMapFromFlags()
+	_, err = GenerateYAMLMapWithValuesFromFlags(getYAMLTypeForFlag, IgnoreFilter)
 	require.Error(t, err)
 
 }
 
 func TestRetypeAndFilterYAMLMap(t *testing.T) {
 	typeMap := map[string]any{
-		"bool": reflect.TypeOf(false),
+		"bool": reflect.TypeOf((*bool)(nil)),
 		"one": map[string]any{
 			"two": map[string]any{
-				"int":          reflect.TypeOf(int(0)),
-				"string_slice": reflect.TypeOf(([]string)(nil)),
+				"int":          reflect.TypeOf((*int)(nil)),
+				"string_slice": reflect.TypeOf((*[]string)(nil)),
 				"two_and_a_half": map[string]any{
-					"float64": reflect.TypeOf(float64(0)),
+					"float64": reflect.TypeOf((*float64)(nil)),
 				},
 				"three": map[string]any{
-					"struct_slice": reflect.TypeOf(([]testStruct)(nil)),
+					"struct_slice": reflect.TypeOf((*[]testStruct)(nil)),
 				},
 			},
 		},
 		"a": map[string]any{
 			"b": map[string]any{
-				"string": reflect.TypeOf(""),
-				"url":    reflect.TypeOf(URLFlag(url.URL{})),
+				"string": reflect.TypeOf((*string)(nil)),
+				"url":    reflect.TypeOf((*URLFlag)(nil)),
 			},
 		},
 		"foo": map[string]any{
-			"bar": reflect.TypeOf(int64(0)),
+			"bar": reflect.TypeOf((*int64)(nil)),
 		},
 	}
 	yamlData := `
@@ -259,7 +259,7 @@ first:
 
 func TestBadRetypeAndFilterYAMLMap(t *testing.T) {
 	typeMap := map[string]any{
-		"bool": reflect.TypeOf(false),
+		"bool": reflect.TypeOf((*bool)(nil)),
 	}
 	yamlData := `
 bool: 7


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Add functionality to `flagutil` that allows us to auto-generate documented YAML files
from the flag definitions.

- Refactor the way we generate types from flags to allow for code reuse in generating YAML from flags
    * Generate map structure for YAML from flag names
    * Use a function that has been passed in as a parameter to generate value to be stored in the YAML map for a given flag, don't store anything if nil
    * Use filter functions that have been passed in to determine if a given flag should be ignored when generating YAML
    * Recursively remove all empty maps from the YAML
- Add ability to generate documented YAML node from flag definition
- Separate "structured" and "unstructured" settings for readability purposes
- Update tests to reflect changes to yaml type map generation
- Add `yaml_doc` genrules for server, enterprise server, and executor

Note that due to the YAML implementation using a `textless` `parser` when using the exported `Encode` functions, we have to construct the full `yaml.Node` structure from anywhere we want a comment to appear down. That is to say, it is not possible to simply implement the `MarshalYAML` function for any interface we want documented and then depend on calling `Encode` inside that function to get commented Nodes for any nested structures, as the resulting `Node`s would be stripped of comments. Also, the `HeadComment` is currently broken when marshalling YAML, and is thus not used.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
