### PR TITLE
Fix data race in healthchecker

### DIFF
--- a/server/util/healthcheck/healthcheck.go
+++ b/server/util/healthcheck/healthcheck.go
@@ -160,7 +160,10 @@ func (h *HealthChecker) runHealthChecks(ctx context.Context) {
 	statusDataMu := sync.Mutex{}
 
 	h.checkersMu.Lock()
-	checkers := h.checkers
+	checkers := make(map[string]interfaces.Checker, len(h.checkers))
+	for k, v := range h.checkers {
+		checkers[k] = v
+	}
 	h.checkersMu.Unlock()
 
 	eg, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
The checker still picks up a race even though we have a lock around the map, because we are still using an unprotected ref to the map: https://app.buildbuddy.io/invocation/8ccdc88f-f820-43fc-9d79-7fd06985f202?target=%2F%2Fenterprise%2Fserver%2Fusage%3Ausage_test_mysql

Fixed by making a copy of the map.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
