### PR TITLE
Fix persistent worker lifecycle

### DIFF
--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//server/remote_cache/digest",
         "//server/resources",
         "//server/util/alert",
+        "//server/util/background",
         "//server/util/flagutil",
         "//server/util/log",
         "//server/util/perms",


### PR DESCRIPTION
:point_right: Highly recommend disabling whitespace diff when reviewing: https://github.com/buildbuddy-io/buildbuddy/pull/2088/files?diff=split&w=1

The worker was getting killed after the first task it executed, due to the task context being canceled. The fix is to use the server context for the persistent worker instead of the task context.

Also fixed that the worker could stick around forever, since we were only ever canceling the worker context in the first task execution.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
