### PR TITLE
Fix explicit/effective command lines with multiple pattern components

### DIFF
--- a/app/invocation/invocation_details_card.tsx
+++ b/app/invocation/invocation_details_card.tsx
@@ -215,15 +215,18 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
                       className="copy-icon"
                       onClick={this.handleCopyClicked.bind(
                         this,
-                        `bazel ${this.props.model.started?.command} ${
-                          this.props.model.expanded?.id?.pattern?.pattern
-                        } ${this.props.model.optionsParsed?.explicitCmdLine.join(" ")}`
+                        `bazel ${
+                          this.props.model.started?.command
+                        } ${this.props.model.expanded?.id?.pattern?.pattern.join(
+                          " "
+                        )} ${this.props.model.optionsParsed?.explicitCmdLine.join(" ")}`
                       )}
                     />
                   </div>
                   <div className="invocation-section">
                     <code className="wrap">
-                      bazel {this.props.model.started?.command} {this.props.model.expanded?.id?.pattern?.pattern}{" "}
+                      bazel {this.props.model.started?.command}{" "}
+                      {this.props.model.expanded?.id?.pattern?.pattern?.join(" ")}{" "}
                       {this.props.model.optionsParsed?.explicitCmdLine.join(" ")}
                     </code>
                   </div>
@@ -236,15 +239,18 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
                       className="copy-icon"
                       onClick={this.handleCopyClicked.bind(
                         this,
-                        `bazel ${this.props.model.started?.command} ${
-                          this.props.model.expanded?.id?.pattern?.pattern
-                        } ${this.props.model.optionsParsed?.cmdLine.join(" ")}`
+                        `bazel ${
+                          this.props.model.started?.command
+                        } ${this.props.model.expanded?.id?.pattern?.pattern.join(
+                          " "
+                        )} ${this.props.model.optionsParsed?.cmdLine.join(" ")}`
                       )}
                     />
                   </div>
                   <div className="invocation-section">
                     <code className="wrap">
-                      bazel {this.props.model.started?.command} {this.props.model.expanded?.id?.pattern?.pattern}{" "}
+                      bazel {this.props.model.started?.command}{" "}
+                      {this.props.model.expanded?.id?.pattern?.pattern.join(" ")}{" "}
                       {this.props.model.optionsParsed?.cmdLine.join(" ")}
                     </code>
                   </div>

--- a/app/invocation/invocation_details_card.tsx
+++ b/app/invocation/invocation_details_card.tsx
@@ -33,8 +33,13 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
     alert_service.success("Command line copied to clipboard!");
   }
 
-  bazelCommandAndPattern() {
-    return `bazel ${this.props.model.started?.command} ${this.props.model.expanded?.id?.pattern?.pattern.join(" ")}`;
+  bazelCommandAndPatternWithOptions(options: string[]) {
+    return [
+      "bazel",
+      this.props.model.started?.command,
+      ...this.props.model.expanded?.id?.pattern?.pattern,
+      ...options,
+    ].join(" ");
   }
 
   render() {
@@ -219,13 +224,13 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
                       className="copy-icon"
                       onClick={this.handleCopyClicked.bind(
                         this,
-                        `${this.bazelCommandAndPattern()} ${this.props.model.optionsParsed?.explicitCmdLine.join(" ")}`
+                        `${this.bazelCommandAndPatternWithOptions(this.props.model.optionsParsed?.explicitCmdLine)}`
                       )}
                     />
                   </div>
                   <div className="invocation-section">
                     <code className="wrap">
-                      {this.bazelCommandAndPattern()} {this.props.model.optionsParsed?.explicitCmdLine.join(" ")}
+                      {this.bazelCommandAndPatternWithOptions(this.props.model.optionsParsed?.explicitCmdLine)}
                     </code>
                   </div>
                 </div>
@@ -237,13 +242,13 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
                       className="copy-icon"
                       onClick={this.handleCopyClicked.bind(
                         this,
-                        `${this.bazelCommandAndPattern()} ${this.props.model.optionsParsed?.cmdLine.join(" ")}`
+                        `${this.bazelCommandAndPatternWithOptions(this.props.model.optionsParsed?.cmdLine)}`
                       )}
                     />
                   </div>
                   <div className="invocation-section">
                     <code className="wrap">
-                      {this.bazelCommandAndPattern()} {this.props.model.optionsParsed?.cmdLine.join(" ")}
+                      {this.bazelCommandAndPatternWithOptions(this.props.model.optionsParsed?.cmdLine)}
                     </code>
                   </div>
                 </div>

--- a/app/invocation/invocation_details_card.tsx
+++ b/app/invocation/invocation_details_card.tsx
@@ -33,6 +33,10 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
     alert_service.success("Command line copied to clipboard!");
   }
 
+  bazelCommandAndPattern() {
+    return `bazel ${this.props.model.started?.command} ${this.props.model.expanded?.id?.pattern?.pattern.join(" ")}`;
+  }
+
   render() {
     const isBazelInvocation = this.props.model.isBazelInvocation();
 
@@ -215,19 +219,13 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
                       className="copy-icon"
                       onClick={this.handleCopyClicked.bind(
                         this,
-                        `bazel ${
-                          this.props.model.started?.command
-                        } ${this.props.model.expanded?.id?.pattern?.pattern.join(
-                          " "
-                        )} ${this.props.model.optionsParsed?.explicitCmdLine.join(" ")}`
+                        `${this.bazelCommandAndPattern()} ${this.props.model.optionsParsed?.explicitCmdLine.join(" ")}`
                       )}
                     />
                   </div>
                   <div className="invocation-section">
                     <code className="wrap">
-                      bazel {this.props.model.started?.command}{" "}
-                      {this.props.model.expanded?.id?.pattern?.pattern?.join(" ")}{" "}
-                      {this.props.model.optionsParsed?.explicitCmdLine.join(" ")}
+                      {this.bazelCommandAndPattern()} {this.props.model.optionsParsed?.explicitCmdLine.join(" ")}
                     </code>
                   </div>
                 </div>
@@ -239,19 +237,13 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
                       className="copy-icon"
                       onClick={this.handleCopyClicked.bind(
                         this,
-                        `bazel ${
-                          this.props.model.started?.command
-                        } ${this.props.model.expanded?.id?.pattern?.pattern.join(
-                          " "
-                        )} ${this.props.model.optionsParsed?.cmdLine.join(" ")}`
+                        `${this.bazelCommandAndPattern()} ${this.props.model.optionsParsed?.cmdLine.join(" ")}`
                       )}
                     />
                   </div>
                   <div className="invocation-section">
                     <code className="wrap">
-                      bazel {this.props.model.started?.command}{" "}
-                      {this.props.model.expanded?.id?.pattern?.pattern.join(" ")}{" "}
-                      {this.props.model.optionsParsed?.cmdLine.join(" ")}
+                      {this.bazelCommandAndPattern()} {this.props.model.optionsParsed?.cmdLine.join(" ")}
                     </code>
                   </div>
                 </div>


### PR DESCRIPTION
Currently these render without spaces, i.e.
```
bazel build targetonetargettwotargetthree --config=local
```

With this change we join the pattern components with spaces, i.e.
```
bazel build targetone targettwo targetthree --config=local
```


<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
