### PR TITLE
Fix error "intermediate value is not iterable" from rendering bazel command in invocation details

### DIFF
--- a/app/invocation/invocation_details_card.tsx
+++ b/app/invocation/invocation_details_card.tsx
@@ -37,9 +37,11 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
     return [
       "bazel",
       this.props.model.started?.command,
-      ...this.props.model.expanded?.id?.pattern?.pattern,
-      ...options,
-    ].join(" ");
+      ...(this.props.model.expanded?.id?.pattern?.pattern || []),
+      ...(options || []),
+    ]
+      .filter((value) => value)
+      .join(" ");
   }
 
   render() {


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
