### PR TITLE
Disable prometheus handling time histogram

### DIFF
--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -96,7 +96,6 @@ func NewGRPCServer(env environment.Env, port int, credentialOption grpc.ServerOp
 	// Support prometheus grpc metrics.
 	grpc_prometheus.Register(grpcServer)
 
-
 	// DISABLED in prod: enabling these causes unnecessary allocations
 	// that substantially (50%+ QPS) impact performance.
 	// grpc_prometheus.EnableHandlingTimeHistogram()


### PR DESCRIPTION
I'd like to try disabling this in an attempt to reduce allocations (and associated CPU use) in prod.

When testing locally, this allowed a single buildbuddy server to handle substantially more bytestream/Read QPS (32K -> 50K) and go_grpc_prometheus/server_metrics.go no longer shows up near the top of a pprof heap profile.