### PR TITLE
Revert "A little locking goes a long way: prefer Rlock for contains checks."

### DIFF
--- a/enterprise/server/cmd/smash/smash.go
+++ b/enterprise/server/cmd/smash/smash.go
@@ -240,7 +240,7 @@ func main() {
 	if *method == byteStreamRead {
 		preWrittenDigests = writeBlobsForReading(ctx, int(*concurrency))
 	} else if *method == findMissingBlobs {
-		preWrittenDigests = writeBlobsForReading(ctx, 10000)
+		preWrittenDigests = writeBlobsForReading(ctx, 1000)
 	}
 
 	blobSizeDesc := fmt.Sprintf("size %d bytes", *blobSize)


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#2103

fixing. a. race. condition.