### PR TITLE
Revert "RLock"

### DIFF
--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -718,9 +718,10 @@ func (p *partition) contains(ctx context.Context, cacheType interfaces.CacheType
 	// [ActionResult][build.bazel.remote.execution.v2.ActionResult] and will be
 	// for some period of time afterwards. The TTLs of the referenced blobs SHOULD be increased
 	// if necessary and applicable.
-	p.mu.RLock()
-	defer p.mu.RUnlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	ok := p.lru.Contains(k.FullPath())
+
 	if !ok && !p.diskIsMapped {
 		// OK if we're here it means the disk contents are still being loaded
 		// into the LRU. But we still need to return an answer! So we'll go


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#2105

Unfortunately this still triggers a data race.

==================
WARNING: DATA RACE
Read at 0x00c0014ce0f8 by goroutine 183:
  container/list.(*List).move()
      GOROOT/src/container/list/list.go:122 +0x1b8
  container/list.(*List).MoveToFront()
      GOROOT/src/container/list/list.go:185 +0x175
  github.com/buildbuddy-io/buildbuddy/server/util/lru.(*LRU).Contains()
      server/util/lru/lru.go:170 +0x10f
  github.com/buildbuddy-io/buildbuddy/server/backends/disk_cache.(*partition).contains()
      server/backends/disk_cache/disk_cache.go:723 +0x17a
  github.com/buildbuddy-io/buildbuddy/server/backends/disk_cache.(*partition).findMissing.func1.1()
      server/backends/disk_cache/disk_cache.go:771 +0xbe
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      external/org_golang_x_sync/errgroup/errgroup.go:74 +0x86

Previous write at 0x00c0014ce0f8 by goroutine 18:
  container/list.(*List).move()
      GOROOT/src/container/list/list.go:128 +0x346
  container/list.(*List).MoveToFront()
      GOROOT/src/container/list/list.go:185 +0x175
  github.com/buildbuddy-io/buildbuddy/server/util/lru.(*LRU).Contains()
      server/util/lru/lru.go:170 +0x10f
  github.com/buildbuddy-io/buildbuddy/server/backends/disk_cache.(*partition).contains()
      server/backends/disk_cache/disk_cache.go:723 +0x17a
  github.com/buildbuddy-io/buildbuddy/server/backends/disk_cache.(*partition).findMissing.func1.1()
      server/backends/disk_cache/disk_cache.go:771 +0xbe
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      external/org_golang_x_sync/errgroup/errgroup.go:74 +0x86
