### PR TITLE
add schema for quota configs

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -548,8 +548,12 @@ func (*Usage) TableName() string {
 
 type QuotaBucket struct {
 	Model
+	// The namespace indicates a single resource to be protected from abusive
+	// usage.
 	Namespace string `gorm:"primarykey"`
-	Name      string `gorm:"primarykey"`
+
+	// The name of the bucket, like "default", "banned", or "restricted".
+	Name string `gorm:"primarykey"`
 
 	// The maximum sustained rate of requests
 	NumRequests        int64
@@ -564,10 +568,13 @@ func (*QuotaBucket) TableName() string {
 	return "QuotaBucket"
 }
 
+// QuotaGroup defines the relationship between a QuotaBucket to a QuotaKey. For,
+// example, user:X is in bucket:restricted.
 type QuotaGroup struct {
 	Model
 	Namespace string `gorm:"primarykey"`
-	// GroupID or IP address
+	// GroupID or IP address (for anon clients). Used to count quota for a single
+	// user.
 	QuotaKey string `gorm:"primarykey"`
 
 	BucketName string

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -548,9 +548,8 @@ func (*Usage) TableName() string {
 
 type QuotaBucket struct {
 	Model
-	QuotaBucketID string `gorm:"primarykey"`
-	Namespace     string
-	Prefix        string
+	Namespace string `gorm:"primarykey"`
+	Name      string `gorm:"primarykey"`
 
 	// The maximum sustained rate of requests
 	NumRequests        int64
@@ -567,9 +566,11 @@ func (*QuotaBucket) TableName() string {
 
 type QuotaGroup struct {
 	Model
-	QuotaBucketID string `gorm:"primarykey"`
+	Namespace string `gorm:"primarykey"`
 	// GroupID or IP address
 	QuotaKey string `gorm:"primarykey"`
+
+	BucketName string
 }
 
 func (*QuotaGroup) TableName() string {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -546,6 +546,36 @@ func (*Usage) TableName() string {
 	return "Usages"
 }
 
+type QuotaBucket struct {
+	Model
+	QuotaBucketID string `gorm:"primarykey"`
+	Namespace     string
+	Prefix        string
+
+	// The maximum sustained rate of requests
+	NumRequests        int64
+	PeriodDurationUsec int64
+
+	// The number of requests that will be allowed to exceed the rate in a single
+	// burst and must be non-negative.
+	MaxBurst int64
+}
+
+func (*QuotaBucket) TableName() string {
+	return "QuotaBucket"
+}
+
+type QuotaGroup struct {
+	Model
+	QuotaBucketID string `gorm:"primarykey"`
+	// GroupID or IP address
+	QuotaKey string `gorm:"primarykey"`
+}
+
+func (*QuotaGroup) TableName() string {
+	return "QuotaGroup"
+}
+
 type PostAutoMigrateLogic func() error
 
 // Manual migration called before auto-migration.
@@ -946,4 +976,6 @@ func init() {
 	registerTable("TS", &TargetStatus{})
 	registerTable("WF", &Workflow{})
 	registerTable("UA", &Usage{})
+	registerTable("QB", &QuotaBucket{})
+	registerTable("QG", &QuotaGroup{})
 }

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -565,7 +565,7 @@ type QuotaBucket struct {
 }
 
 func (*QuotaBucket) TableName() string {
-	return "QuotaBucket"
+	return "QuotaBuckets"
 }
 
 // QuotaGroup defines the relationship between a QuotaBucket to a QuotaKey. For,
@@ -581,7 +581,7 @@ type QuotaGroup struct {
 }
 
 func (*QuotaGroup) TableName() string {
-	return "QuotaGroup"
+	return "QuotaGroups"
 }
 
 type PostAutoMigrateLogic func() error


### PR DESCRIPTION
QuotaBucket is to define the sustained rate and max burst.
QuotaGroup is to define the relationship between group ID / IP and the
QuotaBucket.

Note:
To save the space, for each namespace, we will define a default bucket. If a group id / ip is not in the QuotaGroup table, then quota manager will apply the default bucket.
