### PR TITLE
Fix NPM warnings in checkstyle

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -76,11 +76,11 @@ jobs:
         # NOTE: Only run prettier on files that differ from master, since
         # prettier can be slow.
         run: |
-          npm install --global prettier@2.2.1
+          npm install --location=global prettier@2.2.1
           git merge-base HEAD origin/master |
             xargs git diff --name-only --diff-filter=AMRCT |
             grep -P '(README|\.(js|jsx|ts|tsx|html|css|yaml|yml|json|md))$' |
-            ( xargs --no-run-if-empty --delimiter='\n' "$(npm bin --global)/prettier" --check 1>/dev/null || true ) &> prettier-errors.txt
+            ( xargs --no-run-if-empty --delimiter='\n' "$(npm bin --location=global)/prettier" --check 1>/dev/null || true ) &> prettier-errors.txt
           echo "prettier errors:"
           cat prettier-errors.txt
 


### PR DESCRIPTION
It warns that `--global` is deprecated in favor of `--location=global`, causing checkstyle to fail.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
