### PR TITLE
Allow passing an stderr reader to container.Exec

### DIFF
--- a/enterprise/server/remote_execution/commandutil/BUILD
+++ b/enterprise/server/remote_execution/commandutil/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/server/remote_execution/container",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/util/log",
@@ -20,6 +21,7 @@ go_test(
     data = ["//enterprise/server/remote_execution/commandutil/test_binary"],
     deps = [
         ":commandutil",
+        "//enterprise/server/remote_execution/container",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/testutil/testfs",

--- a/enterprise/server/remote_execution/container/container_test.go
+++ b/enterprise/server/remote_execution/container/container_test.go
@@ -2,7 +2,6 @@ package container_test
 
 import (
 	"context"
-	"io"
 	"testing"
 	"time"
 
@@ -38,7 +37,7 @@ func (c *FakeContainer) PullImage(ctx context.Context, creds container.PullCrede
 	return nil
 }
 func (c *FakeContainer) Create(context.Context, string) error { return nil }
-func (c *FakeContainer) Exec(context.Context, *repb.Command, io.Reader, io.Writer) *interfaces.CommandResult {
+func (c *FakeContainer) Exec(context.Context, *repb.Command, *container.ExecOpts) *interfaces.CommandResult {
 	return nil
 }
 func (c *FakeContainer) Remove(ctx context.Context) error  { return nil }

--- a/enterprise/server/remote_execution/containers/bare/bare.go
+++ b/enterprise/server/remote_execution/containers/bare/bare.go
@@ -2,7 +2,6 @@ package bare
 
 import (
 	"context"
-	"io"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
@@ -22,7 +21,7 @@ func NewBareCommandContainer() container.CommandContainer {
 }
 
 func (c *bareCommandContainer) Run(ctx context.Context, command *repb.Command, workDir string, creds container.PullCredentials) *interfaces.CommandResult {
-	return commandutil.Run(ctx, command, workDir, nil, nil)
+	return commandutil.Run(ctx, command, workDir, &container.ExecOpts{})
 }
 
 func (c *bareCommandContainer) Create(ctx context.Context, workDir string) error {
@@ -30,8 +29,8 @@ func (c *bareCommandContainer) Create(ctx context.Context, workDir string) error
 	return nil
 }
 
-func (c *bareCommandContainer) Exec(ctx context.Context, cmd *repb.Command, stdin io.Reader, stdout io.Writer) *interfaces.CommandResult {
-	return commandutil.Run(ctx, cmd, c.WorkDir, stdin, stdout)
+func (c *bareCommandContainer) Exec(ctx context.Context, cmd *repb.Command, opts *container.ExecOpts) *interfaces.CommandResult {
+	return commandutil.Run(ctx, cmd, c.WorkDir, opts)
 }
 
 func (c *bareCommandContainer) IsImageCached(ctx context.Context) (bool, error) { return false, nil }

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1226,7 +1226,7 @@ func (c *FirecrackerContainer) Run(ctx context.Context, command *repb.Command, a
 		}
 	}()
 
-	cmdResult := c.Exec(ctx, command, nil /*=stdin*/, nil /*=stdout*/)
+	cmdResult := c.Exec(ctx, command, &container.ExecOpts{})
 	return cmdResult
 }
 
@@ -1398,7 +1398,12 @@ func (c *FirecrackerContainer) SendPrepareFileSystemRequestToGuest(ctx context.C
 // the executed process.
 // If stdout is non-nil, the stdout of the executed process will be written to the
 // stdout writer.
-func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdin io.Reader, stdout io.Writer) *interfaces.CommandResult {
+func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, opts *container.ExecOpts) *interfaces.CommandResult {
+	// TODO(bduffany): Wire up stdin/stdout/stderr from ExecOpts
+	if opts.Stderr != nil || opts.Stdout != nil || opts.Stdin != nil {
+		return commandutil.ErrorResult(status.FailedPreconditionError("firecracker does not yet support remote persistent workers"))
+	}
+
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_darwin.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_darwin.go
@@ -5,7 +5,6 @@ package firecracker
 
 import (
 	"context"
-	"io"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -30,7 +29,7 @@ func (c *FirecrackerContainer) Create(ctx context.Context, actionWorkingDir stri
 	return status.UnimplementedError("Not yet implemented.")
 }
 
-func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdin io.Reader, stdout io.Writer) *interfaces.CommandResult {
+func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, opts *container.ExecOpts) *interfaces.CommandResult {
 	return &interfaces.CommandResult{}
 }
 

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -3,7 +3,6 @@ package podman
 import (
 	"context"
 	"fmt"
-	"io"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -167,7 +166,7 @@ func (c *podmanCommandContainer) Run(ctx context.Context, command *repb.Command,
 	}
 	podmanRunArgs = append(podmanRunArgs, c.image)
 	podmanRunArgs = append(podmanRunArgs, command.Arguments...)
-	result = runPodman(ctx, "run", nil, nil, podmanRunArgs...)
+	result = runPodman(ctx, "run", &container.ExecOpts{}, podmanRunArgs...)
 	if err := c.maybeCleanupCorruptedImages(ctx, result); err != nil {
 		log.Warningf("Failed to remove corrupted image: %s", err)
 	}
@@ -189,7 +188,7 @@ func (c *podmanCommandContainer) Create(ctx context.Context, workDir string) err
 	podmanRunArgs := c.getPodmanRunArgs(workDir)
 	podmanRunArgs = append(podmanRunArgs, c.image)
 	podmanRunArgs = append(podmanRunArgs, "sleep", "infinity")
-	createResult := runPodman(ctx, "create", nil, nil, podmanRunArgs...)
+	createResult := runPodman(ctx, "create", &container.ExecOpts{}, podmanRunArgs...)
 	if err := c.maybeCleanupCorruptedImages(ctx, createResult); err != nil {
 		log.Warningf("Failed to remove corrupted image: %s", err)
 	}
@@ -202,7 +201,7 @@ func (c *podmanCommandContainer) Create(ctx context.Context, workDir string) err
 		return status.UnknownErrorf("podman create failed: exit code %d, stderr: %s", createResult.ExitCode, createResult.Stderr)
 	}
 
-	startResult := runPodman(ctx, "start", nil, nil, c.name)
+	startResult := runPodman(ctx, "start", &container.ExecOpts{}, c.name)
 	if startResult.Error != nil {
 		return startResult.Error
 	}
@@ -212,7 +211,7 @@ func (c *podmanCommandContainer) Create(ctx context.Context, workDir string) err
 	return nil
 }
 
-func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, stdin io.Reader, stdout io.Writer) *interfaces.CommandResult {
+func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, opts *container.ExecOpts) *interfaces.CommandResult {
 	podmanRunArgs := make([]string, 0, 2*len(cmd.GetEnvironmentVariables())+len(cmd.Arguments)+1)
 	for _, envVar := range cmd.GetEnvironmentVariables() {
 		podmanRunArgs = append(podmanRunArgs, "--env", fmt.Sprintf("%s=%s", envVar.GetName(), envVar.GetValue()))
@@ -225,6 +224,9 @@ func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, st
 	if strings.ToLower(c.options.Network) == "off" {
 		podmanRunArgs = append(podmanRunArgs, "--network=none")
 	}
+	if opts.Stdin != nil {
+		podmanRunArgs = append(podmanRunArgs, "--interactive")
+	}
 	podmanRunArgs = append(podmanRunArgs, c.name)
 	podmanRunArgs = append(podmanRunArgs, cmd.Arguments...)
 	// Podman doesn't provide a way to find out whether an exec process was
@@ -233,7 +235,7 @@ func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, st
 	// during a normal execution, so we are overly cautious here and only
 	// interpret this code specially when the container was removed and we are
 	// expecting a SIGKILL as a result.
-	res := runPodman(ctx, "exec", stdin, stdout, podmanRunArgs...)
+	res := runPodman(ctx, "exec", opts, podmanRunArgs...)
 	c.mu.Lock()
 	removed := c.removed
 	c.mu.Unlock()
@@ -246,7 +248,7 @@ func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, st
 
 func (c *podmanCommandContainer) IsImageCached(ctx context.Context) (bool, error) {
 	// Try to avoid the `pull` command which results in a network roundtrip.
-	listResult := runPodman(ctx, "image", nil /*=stdin*/, nil /*=stdout*/, "inspect", "--format={{.ID}}", c.image)
+	listResult := runPodman(ctx, "image", &container.ExecOpts{}, "inspect", "--format={{.ID}}", c.image)
 	if listResult.ExitCode == podmanInternalExitCode {
 		return false, nil
 	} else if listResult.Error != nil {
@@ -299,7 +301,7 @@ func (c *podmanCommandContainer) pullImage(creds container.PullCredentials) erro
 	// Use server context instead of ctx to make sure that "podman pull" is not killed when the context
 	// is cancelled. If "podman pull" is killed when copying a parent layer, it will result in
 	// corrupted storage.  More details see https://github.com/containers/storage/issues/1136.
-	pullResult := runPodman(c.env.GetServerContext(), "pull", nil /*=stdin*/, nil /*=stdout*/, podmanArgs...)
+	pullResult := runPodman(c.env.GetServerContext(), "pull", &container.ExecOpts{}, podmanArgs...)
 	if pullResult.Error != nil {
 		return pullResult.Error
 	}
@@ -313,7 +315,7 @@ func (c *podmanCommandContainer) Remove(ctx context.Context) error {
 	c.mu.Lock()
 	c.removed = true
 	c.mu.Unlock()
-	res := runPodman(ctx, "kill", nil /*=stdin*/, nil /*=stdout*/, "--signal=KILL", c.name)
+	res := runPodman(ctx, "kill", &container.ExecOpts{}, "--signal=KILL", c.name)
 	if res.Error != nil {
 		return res.Error
 	}
@@ -324,7 +326,7 @@ func (c *podmanCommandContainer) Remove(ctx context.Context) error {
 }
 
 func (c *podmanCommandContainer) Pause(ctx context.Context) error {
-	res := runPodman(ctx, "pause", nil /*=stdin*/, nil /*=stdout*/, c.name)
+	res := runPodman(ctx, "pause", &container.ExecOpts{}, c.name)
 	if res.ExitCode != 0 {
 		return status.UnknownErrorf("podman pause failed: exit code %d, stderr: %s", res.ExitCode, string(res.Stderr))
 	}
@@ -332,7 +334,7 @@ func (c *podmanCommandContainer) Pause(ctx context.Context) error {
 }
 
 func (c *podmanCommandContainer) Unpause(ctx context.Context) error {
-	res := runPodman(ctx, "unpause", nil /*=stdin*/, nil /*=stdout*/, c.name)
+	res := runPodman(ctx, "unpause", &container.ExecOpts{}, c.name)
 	if res.Error != nil {
 		return res.Error
 	}
@@ -346,14 +348,14 @@ func (c *podmanCommandContainer) Stats(ctx context.Context) (*container.Stats, e
 	return &container.Stats{}, nil
 }
 
-func runPodman(ctx context.Context, subCommand string, stdin io.Reader, stdout io.Writer, args ...string) *interfaces.CommandResult {
+func runPodman(ctx context.Context, subCommand string, opts *container.ExecOpts, args ...string) *interfaces.CommandResult {
 	command := []string{
 		"podman",
 		subCommand,
 	}
 
 	command = append(command, args...)
-	result := commandutil.Run(ctx, &repb.Command{Arguments: command}, "" /*=workDir*/, stdin, stdout)
+	result := commandutil.Run(ctx, &repb.Command{Arguments: command}, "" /*=workDir*/, opts)
 	return result
 }
 
@@ -396,7 +398,7 @@ func removeImage(ctx context.Context, imageName string) error {
 	ctx, cancel := background.ExtendContextForFinalization(ctx, containerFinalizationTimeout)
 	defer cancel()
 
-	result := runPodman(ctx, "rmi", nil, nil, imageName)
+	result := runPodman(ctx, "rmi", &container.ExecOpts{}, imageName)
 	if result.Error != nil {
 		return result.Error
 	}
@@ -416,7 +418,7 @@ func ConfigureSecondaryNetwork(ctx context.Context) error {
 	// Hack: run a dummy podman container to setup default podman bridge network in ip route.
 	// "podman run --rm busybox sh". This should setup the following in ip route:
 	// "10.88.0.0/16 dev cni-podman0 proto kernel scope link src 10.88.0.1 linkdown"
-	result := runPodman(ctx, "run", nil, nil, "--rm", "busybox", "sh")
+	result := runPodman(ctx, "run", &container.ExecOpts{}, "--rm", "busybox", "sh")
 	if result.Error != nil {
 		return result.Error
 	}


### PR DESCRIPTION
This will let us read stderr from the persistent worker process and expose errors from the worker in command error messages, rather than the vague error `io: read/write on closed pipe`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
