### PR TITLE
Validate directory has contents before returning it in GetTree

### DIFF
--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -500,6 +500,10 @@ func (s *ContentAddressableStorageServer) fetchDirectory(ctx context.Context, ca
 		if err := proto.Unmarshal(blob, subDir); err != nil {
 			return nil, err
 		}
+		if len(subDir.Directories) == 0 && len(subDir.Files) == 0 {
+			log.Warningf("Found empty directory for digest: %s blob: [%+v]", d.GetHash(), blob)
+			return nil, status.NotFoundErrorf("Found empty directory for digest %s.", d.GetHash())
+		}
 		children = append(children, &repb.DirectoryWithDigest{Directory: subDir, Digest: d})
 	}
 	return children, nil


### PR DESCRIPTION
Haven't managed to trigger this case in testing yet (only artificially by randomly setting a blob in `rspMap` to empty bytes / empty proto) - but this would fix a hypothetical issue that would cause a cached:
```
Failed Precondition: Digest hash:"60430d8c02074632d6ca79aa65d7b261dce5b87798c5424fe061625bae630644" size_bytes:157 not found
  Precondition Failure:
    (MISSING) blobs/60430d8c02074632d6ca79aa65d7b261dce5b87798c5424fe061625bae630644/157:
```

Investigating further to see if I can figure out how to convince GetMulti to return empty bytes (searched server logs for "returned a zero-length response for" but got no hits).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
