### PR TITLE
Workflows: Fix argument handling for `bazel run` commands

### DIFF
--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -11,7 +11,7 @@ go_test(
     exec_properties = {
         "container-image": "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.2.8",
     },
-    shard_count = 8,
+    shard_count = 9,
     visibility = [
         "//enterprise:__subpackages__",
         "@buildbuddy_internal//enterprise:__subpackages__",


### PR DESCRIPTION
Properly handle the argument separator ("--") in `bazel run` commands.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
