### PR TITLE
Task sizing: Add an option to enable cgroup-based podman stats

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -46,13 +46,16 @@ type DockerDeviceMapping struct {
 	CgroupPermissions string `yaml:"cgroup_permissions" usage:"cgroup permissions that should be assigned to device."`
 }
 
-// Stats holds represents a container's held resources.
+// Stats represents a container's resource usage.
 type Stats struct {
+	// MemoryUsageBytes is the most recent memory usage value sampled from the
+	// container, in bytes.
 	MemoryUsageBytes int64
-
-	// TODO: add CPU usage once we have a reliable way to measure it.
-	// CPU only applies to bare execution, since Docker containers
-	// are frozen when not in use, reducing their CPU usage to 0.
+	// CPUNanos is the total CPU usage used by a task, in CPU-nanoseconds.
+	CPUNanos int64
+	// PeakMemoryUsageBytes is the highest memory usage sampled during the
+	// execution of a task, in bytes.
+	PeakMemoryUsageBytes int64
 }
 
 type FileSystemLayout struct {

--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -13,9 +13,11 @@ go_library(
         "//server/interfaces",
         "//server/util/alert",
         "//server/util/background",
+        "//server/util/disk",
         "//server/util/log",
         "//server/util/networking",
         "//server/util/random",
+        "//server/util/retry",
         "//server/util/status",
     ],
 )
@@ -23,6 +25,13 @@ go_library(
 go_test(
     name = "podman_test",
     srcs = ["podman_test.go"],
+    args = [
+        # Note: these are used only for the Stats tests, which require running as root.
+        # These paths were tested on Ubuntu 20.04 + podman 3.4.2, but may be different for other setups.
+        # See the comment in podman.go for more info.
+        "--executor.podman.memory_usage_path_template=/sys/fs/cgroup/memory/machine.slice/libpod-{{.ContainerID}}.scope/memory.usage_in_bytes",
+        "--executor.podman.cpu_usage_path_template=/sys/fs/cgroup/cpu,cpuacct/machine.slice/libpod-{{.ContainerID}}.scope/cpuacct.usage",
+    ],
     tags = [
         "manual",
         "no-sandbox",

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -89,6 +89,7 @@ type podmanCommandContainer struct {
 
 	image     string
 	buildRoot string
+	workDir   string
 
 	options *PodmanOptions
 
@@ -172,6 +173,7 @@ func (c *podmanCommandContainer) getPodmanRunArgs(workDir string) []string {
 }
 
 func (c *podmanCommandContainer) Run(ctx context.Context, command *repb.Command, workDir string, creds container.PullCredentials) *interfaces.CommandResult {
+	c.workDir = workDir
 	defer os.RemoveAll(c.cidFilePath())
 	result := &interfaces.CommandResult{
 		CommandDebugString: fmt.Sprintf("(podman) %s", command.GetArguments()),
@@ -223,6 +225,7 @@ func (c *podmanCommandContainer) Create(ctx context.Context, workDir string) err
 		return status.UnavailableErrorf("failed to generate podman container name: %s", err)
 	}
 	c.name = containerName
+	c.workDir = workDir
 
 	podmanRunArgs := c.getPodmanRunArgs(workDir)
 	podmanRunArgs = append(podmanRunArgs, c.image)
@@ -344,7 +347,7 @@ func (c *podmanCommandContainer) PullImage(ctx context.Context, creds container.
 // ".cid" extension, such as "/tmp/remote_build/{{WORKSPACE_ID}}.cid". Note:
 // this logic depends on the workspace parent directory already existing.
 func (c *podmanCommandContainer) cidFilePath() string {
-	return c.buildRoot + ".cid"
+	return c.workDir + ".cid"
 }
 
 // monitor starts a goroutine to monitor the container's resource usage. The

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -641,6 +641,13 @@ type CommandResult struct {
 	// * -2 (NoExitCode) if the exit code could not be determined because it returned
 	//   an error other than exec.ExitError. This case typically means it failed to start.
 	ExitCode int
+
+	// PeakMemoryUsageBytes is the approximate maximum memory usage (in bytes)
+	// used by the command throughout its execution, or 0 if unknown.
+	PeakMemoryUsageBytes int64
+	// CPUNanos is the approximate CPU usage of the command (measured in
+	// CPU-nanoseconds), or 0 if unknown.
+	CPUNanos int64
 }
 
 type Subscriber interface {


### PR DESCRIPTION
Adds an option `EnableStats` to the podman API that periodically collects CPU usage (nanos) and mem usage (bytes) while the container is running, and reports these in the `CommandResult` (both for `Run` and `Exec`). It also allows the `Stats()` func to work properly, which is used for runner pool resource management.

The implementation is based on polling the cgroupfs. Locally, each cgroupfs read takes ~10 microseconds, so we should be able to sample these stats at a fairly high rate.

Alternatives considered:
* Using the `getrusage` system call - I found this to be unreliable. In particular, `maxrss` only reports the max resident set size amongst all child processes individually, as in `max(child1_maxrss, ..., childN_maxrss)` and doesn't represent the max total memory usage across all child processes. This is problematic for any actions that use process-based concurrency. It also would introduce complexity and performance overhead since we'd have to add a wrapper binary for every task which calls `getrusage(RUSAGE_CHILDREN)` and writes it to a file.
* Using `podman stats` - I found `podman stats` to yield an error in dev - I haven't yet dug in as to why, but also `podman stats` requires some overhead of spinning up a process and parsing JSON output (the output uses human-readable abbreviations so the parsing would be pretty ugly and imprecise). We would also be limited to a 1s polling interval since the podman CLI throws an error if you try to specify anything less than that.
 
Overall I figured since `podman stats` is getting its data from the cgroupfs anyway, it's not too bad to read from the cgroup files directly, save for the configuration hairiness.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
