### PR TITLE
Ensure remote_instance_name is respected in action cache

### DIFF
--- a/enterprise/server/raft/constants/constants.go
+++ b/enterprise/server/raft/constants/constants.go
@@ -133,7 +133,7 @@ func FileKey(r *rfpb.FileRecord) ([]byte, error) {
 	// filekeys look like this:
 	//   // {groupID}/{ac|cas}/{hashPrefix:4}/{hash}
 	//   // for example:
-	//   //   PART123/ac/abcd/abcd12345asdasdasd123123123asdasdasd
+	//   //   PART123/ac/44321/abcd/abcd12345asdasdasd123123123asdasdasd
 	//   //   PART123/cas/abcd/abcd12345asdasdasd123123123asdasdasd
 	partID, isolation, remoteInstanceHash, hash, err := fileRecordSegments(r)
 	if err != nil {
@@ -155,7 +155,7 @@ func FileDataKey(r *rfpb.FileRecord) ([]byte, error) {
 	// File Data keys look like this:
 	//   // {groupID}/{ac|cas}/{hash}-
 	//   // for example:
-	//   //   PART123/ac/abcd12345asdasdasd123123123asdasdasd-
+	//   //   PART123/ac/44321/abcd12345asdasdasd123123123asdasdasd-
 	//   //   PART123/cas/abcd12345asdasdasd123123123asdasdasd-
 	partID, isolation, remoteInstanceHash, hash, err := fileRecordSegments(r)
 	if err != nil {
@@ -174,7 +174,7 @@ func FileMetadataKey(r *rfpb.FileRecord) ([]byte, error) {
 	// Metadata keys look like this:
 	//   // {groupID}/{ac|cas}/{hash}
 	//   // for example:
-	//   //   PART123456/ac/abcd12345asdasdasd123123123asdasdasd
+	//   //   PART123456/ac/44321/abcd12345asdasdasd123123123asdasdasd
 	//   //   PART123456/cas/abcd12345asdasdasd123123123asdasdasd
 	partID, isolation, remoteInstanceHash, hash, err := fileRecordSegments(r)
 	if err != nil {

--- a/enterprise/server/raft/constants/constants.go
+++ b/enterprise/server/raft/constants/constants.go
@@ -1,8 +1,10 @@
 package constants
 
 import (
+	"hash/crc32"
 	"math"
 	"path/filepath"
+	"strconv"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -95,27 +97,32 @@ var (
 	RangeLeaseInvalidMsg = "Range lease invalid" // continue
 )
 
-func fileRecordSegments(r *rfpb.FileRecord) ([4]string, error) {
-	var segments [4]string
+// returns partitionID, isolation, hash or
+// returns partitionID, isolation, remote_instance_name, hahs
+func fileRecordSegments(r *rfpb.FileRecord) (partID string, isolation string, remoteInstanceHash string, digestHash string, err error) {
 	if r.GetIsolation().GetPartitionId() == "" {
-		return segments, status.FailedPreconditionError("Empty partition ID not allowed in filerecord.")
+		err = status.FailedPreconditionError("Empty partition ID not allowed in filerecord.")
+		return
 	}
-	segments[0] = r.GetIsolation().GetPartitionId()
+	partID = r.GetIsolation().GetPartitionId()
 
 	if r.GetIsolation().GetCacheType() == rfpb.Isolation_CAS_CACHE {
-		segments[1] = "cas"
+		isolation = "cas"
 	} else if r.GetIsolation().GetCacheType() == rfpb.Isolation_ACTION_CACHE {
-		segments[1] = "ac"
+		isolation = "ac"
+		if remoteInstanceName := r.GetIsolation().GetRemoteInstanceName(); remoteInstanceName != "" {
+			remoteInstanceHash = strconv.Itoa(int(crc32.ChecksumIEEE([]byte(remoteInstanceName))))
+		}
 	} else {
-		return segments, status.FailedPreconditionError("Isolation type must be explicitly set, not UNKNOWN.")
+		err = status.FailedPreconditionError("Isolation type must be explicitly set, not UNKNOWN.")
+		return
 	}
-	if len(r.GetDigest().GetHash()) > 4 {
-		segments[2] = r.GetDigest().GetHash()[:4]
-	} else {
-		return segments, status.FailedPreconditionError("Malformed digest; too short.")
+	if len(r.GetDigest().GetHash()) <= 4 {
+		err = status.FailedPreconditionError("Malformed digest; too short.")
+		return
 	}
-	segments[3] = r.GetDigest().GetHash()
-	return segments, nil
+	digestHash = r.GetDigest().GetHash()
+	return
 }
 
 // FileKey is the partial path where a file will be written.
@@ -128,11 +135,12 @@ func FileKey(r *rfpb.FileRecord) ([]byte, error) {
 	//   // for example:
 	//   //   PART123/ac/abcd/abcd12345asdasdasd123123123asdasdasd
 	//   //   PART123/cas/abcd/abcd12345asdasdasd123123123asdasdasd
-	s, err := fileRecordSegments(r)
+	partID, isolation, remoteInstanceHash, hash, err := fileRecordSegments(r)
 	if err != nil {
 		return nil, err
 	}
-	return []byte(filepath.Join(s[0], s[1], s[2], s[3])), nil
+
+	return []byte(filepath.Join(partID, isolation, remoteInstanceHash, hash[:4], hash)), nil
 }
 
 // FileDataKey is the partial key name where a file will be written if it is
@@ -149,11 +157,11 @@ func FileDataKey(r *rfpb.FileRecord) ([]byte, error) {
 	//   // for example:
 	//   //   PART123/ac/abcd12345asdasdasd123123123asdasdasd-
 	//   //   PART123/cas/abcd12345asdasdasd123123123asdasdasd-
-	s, err := fileRecordSegments(r)
+	partID, isolation, remoteInstanceHash, hash, err := fileRecordSegments(r)
 	if err != nil {
 		return nil, err
 	}
-	return []byte(filepath.Join(s[0], s[1], s[3]) + "-"), nil
+	return []byte(filepath.Join(partID, isolation, remoteInstanceHash, hash) + "-"), nil
 }
 
 // FileMetadataKey is the partial key name where a file's metadata will be
@@ -168,9 +176,9 @@ func FileMetadataKey(r *rfpb.FileRecord) ([]byte, error) {
 	//   // for example:
 	//   //   PART123456/ac/abcd12345asdasdasd123123123asdasdasd
 	//   //   PART123456/cas/abcd12345asdasdasd123123123asdasdasd
-	s, err := fileRecordSegments(r)
+	partID, isolation, remoteInstanceHash, hash, err := fileRecordSegments(r)
 	if err != nil {
 		return nil, err
 	}
-	return []byte(filepath.Join(s[0], s[1], s[3])), nil
+	return []byte(filepath.Join(partID, isolation, remoteInstanceHash, hash)), nil
 }


### PR DESCRIPTION
This segments AC files by remote_instance_name when it is set. The original remote_instance_name value is preserved in the file metadata (in pebble) but the file is stored under a subpath made from a hash of the remote_instance_name.