### PR TITLE
Fix for lag in build logs

### DIFF
--- a/server/backends/chunkstore/chunkstore.go
+++ b/server/backends/chunkstore/chunkstore.go
@@ -502,7 +502,7 @@ func (l *writeLoop) run(ctx context.Context) {
 					// flushes and no-op writes (to get updated chunkIndex from potential
 					// automatic flushes).
 					if string(req.VolatileTail) == string(volatileTail) {
-						// We did not chanhge the tail, update the request to reflect this.
+						// We did not change the tail, update the request to reflect this.
 						req.VolatileTail = nil
 					} else {
 						volatileTail = req.VolatileTail

--- a/server/backends/chunkstore/chunkstore.go
+++ b/server/backends/chunkstore/chunkstore.go
@@ -369,6 +369,10 @@ type WriteRequest struct {
 	Close        bool
 }
 
+func (w *WriteRequest) IsEmpty() bool {
+	return w == nil || ((w.Chunk == nil || len(w.Chunk) == 0) && w.VolatileTail == nil && !w.Close)
+}
+
 type WriteResult struct {
 	Err            error
 	Size           int
@@ -582,7 +586,7 @@ func (l *writeLoop) run(ctx context.Context) {
 		l.writeResultChannel <- result
 
 		if l.writeHook != nil {
-			if bytesFlushed != 0 || !open || (req != nil && ((req.Chunk != nil && len(req.Chunk) != 0) || req.VolatileTail != nil)) {
+			if bytesFlushed != 0 || !open || !req.IsEmpty() {
 				// Only call the writeHook if a state change has occurred.
 
 				// All work has been done for this write; trigger the writeHook.


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

The actual bug was that the volatile tail would get wiped out by last chunk id
checks sometimes, but while debugging I also noticed we were calling the
writeHook way more often than we should be, so I also fixed that.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
