### PR TITLE
Utility to dedupe expensive work across servers.

### DIFF
--- a/enterprise/server/testutil/testredis/testredis.go
+++ b/enterprise/server/testutil/testredis/testredis.go
@@ -106,8 +106,12 @@ func (h *Handle) Restart() {
 	waitUntilHealthy(h.t, h.Target)
 }
 
+func (h *Handle) Client() redis.UniversalClient {
+	return redis.NewClient(redisutil.TargetToOptions(h.Target))
+}
+
 func (h *Handle) KeyCount(pattern string) int {
-	keys, err := redis.NewClient(redisutil.TargetToOptions(h.Target)).Keys(context.Background(), pattern).Result()
+	keys, err := h.Client().Keys(context.Background(), pattern).Result()
 	require.NoError(h.t, err)
 	return len(keys)
 }

--- a/server/util/dsingleflight/BUILD
+++ b/server/util/dsingleflight/BUILD
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "dsingleflight",
+    srcs = ["dsingleflight.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/dsingleflight",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/util/log",
+        "//server/util/status",
+        "@com_github_go_redis_redis_v8//:redis",
+        "@go_googleapis//google/rpc:status_go_proto",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//proto",
+    ],
+)
+
+go_test(
+    name = "dsingleflight_test",
+    srcs = ["dsingleflight_test.go"],
+    embed = [":dsingleflight"],
+    deps = [
+        "//enterprise/server/testutil/testredis",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_x_sync//errgroup",
+    ],
+)

--- a/server/util/dsingleflight/dsingleflight.go
+++ b/server/util/dsingleflight/dsingleflight.go
@@ -1,0 +1,195 @@
+// Package dsingleflight is a distributed version of the singleflight package.
+// Work is coordinated across servers using Redis.
+package dsingleflight
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/go-redis/redis/v8"
+	"google.golang.org/protobuf/proto"
+
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	gstatus "google.golang.org/grpc/status"
+)
+
+const (
+	resultStatusField = "status"
+	resultDataField   = "data"
+
+	lockTTL   = 5 * time.Second
+	resultTTL = 30 * time.Second
+)
+
+type Coordinator struct {
+	rdb redis.UniversalClient
+}
+
+func New(rdb redis.UniversalClient) *Coordinator {
+	return &Coordinator{rdb: rdb}
+}
+
+type result struct {
+	data []byte
+	err  error
+}
+
+type Work func() ([]byte, error)
+
+func redisLockKey(workKey string) string {
+	return fmt.Sprintf("singleflightLock/{%s}", workKey)
+}
+
+func redisResultKey(workKey string) string {
+	return fmt.Sprintf("singleflightResult/{%s}", workKey)
+}
+
+// doWork executes the work function and publishes the result to redis as well
+// as returning it to teh caller.
+func (c *Coordinator) doWork(ctx context.Context, workKey string, work Work) ([]byte, error) {
+	r, err := work()
+	errStatus := gstatus.Convert(err)
+	errStatusBytes, err := proto.Marshal(errStatus.Proto())
+	if err != nil {
+		return nil, status.UnknownErrorf("could not marshal status: %s", err)
+	}
+
+	resultKey := redisResultKey(workKey)
+	if err := c.rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: resultKey,
+		Values: []string{resultStatusField, string(errStatusBytes), resultDataField, string(r)},
+	}).Err(); err != nil {
+		return nil, status.UnavailableErrorf("could not publish result: %s", err)
+	}
+
+	if err := c.rdb.Expire(ctx, resultKey, resultTTL); err != nil {
+		return nil, status.UnavailableErrorf("could not update result ttl: %s", err)
+	}
+
+	return r, nil
+}
+
+// claimWork loops trying to lock the workKey. If locking succeeds, the passed
+// work function is executed and its result returned. While the
+// work function is executing, the TTL on the lock is extended to prevent
+// anyone else from claiming the work.
+func (c *Coordinator) claimWork(ctx context.Context, workKey string, work Work) ([]byte, error) {
+	workResult := make(chan *result, 1)
+
+	firstCheck := true
+	isOwner := false
+	lockKey := redisLockKey(workKey)
+	for {
+		if !isOwner {
+			claimed, err := c.rdb.SetNX(ctx, lockKey, "meow", lockTTL).Result()
+			if err != nil {
+				return nil, status.UnavailableErrorf("could not lock work: %s, ", err)
+			}
+			if claimed {
+				log.CtxInfof(ctx, "dsingleflight: we claimed %q, starting work", workKey)
+				isOwner = true
+				go func() {
+					data, err := c.doWork(ctx, workKey, work)
+					workResult <- &result{data: data, err: err}
+				}()
+			} else if firstCheck {
+				firstCheck = false
+				log.CtxInfof(ctx, "dsingleflight: waiting for result for %q", workKey)
+			}
+		} else {
+			if err := c.rdb.Expire(ctx, lockKey, lockTTL).Err(); err != nil {
+				return nil, status.UnavailableErrorf("could not update lock expiry: %s", err)
+			}
+		}
+
+		select {
+		case result := <-workResult:
+			log.CtxInfof(ctx, "dsingleflight: work completed for %q", workKey)
+			return result.data, result.err
+		case <-time.After(1 * time.Second):
+		}
+	}
+}
+
+// waitResult blocks until result is retrieved from redis or the context is
+// cancelled.
+func (c *Coordinator) waitResult(ctx context.Context, workKey string) ([]byte, error) {
+	resultKey := redisResultKey(workKey)
+	data, err := c.rdb.XRead(ctx, &redis.XReadArgs{
+		Streams: []string{resultKey, "0"},
+		Count:   1,
+		Block:   0, // Block indefinitely
+	}).Result()
+	if err != nil {
+		return nil, status.UnavailableErrorf("could not read from stream: %s", err)
+	}
+
+	if len(data) != 1 {
+		return nil, status.FailedPreconditionErrorf("expected exactly one stream")
+	}
+	if len(data[0].Messages) != 1 {
+		return nil, status.FailedPreconditionErrorf("expected exactly one message")
+	}
+
+	log.CtxInfof(ctx, "dsingleflight: got result for %q", workKey)
+
+	vals := data[0].Messages[0].Values
+	if s, ok := vals[resultStatusField].(string); ok {
+		var statusProto spb.Status
+		if err := proto.Unmarshal([]byte(s), &statusProto); err != nil {
+			return nil, status.UnknownErrorf("could not unmarshal status: %s", err)
+		}
+		if err := gstatus.ErrorProto(&statusProto); err != nil {
+			return nil, err
+		}
+	}
+
+	if data, ok := vals[resultDataField].(string); ok {
+		return []byte(data), nil
+	} else {
+		return nil, status.UnknownErrorf("result did not contain error or data")
+	}
+}
+
+// Do executes the given function, making a best effort attempt to only execute
+// the work once amongst concurrent callers for the same key.
+func (c *Coordinator) Do(ctx context.Context, key string, work Work) ([]byte, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	workResultCh := make(chan *result, 1)
+	waitResultCh := make(chan *result, 1)
+
+	go func() {
+		data, err := c.claimWork(ctx, key, work)
+		workResultCh <- &result{data: data, err: err}
+	}()
+	go func() {
+		data, err := c.waitResult(ctx, key)
+		waitResultCh <- &result{data: data, err: err}
+	}()
+
+	select {
+	case result := <-workResultCh:
+		return result.data, result.err
+	case result := <-waitResultCh:
+		return result.data, result.err
+	}
+}
+
+func (c *Coordinator) DoProto(ctx context.Context, key string, work func() (proto.Message, error), out proto.Message) error {
+	bs, err := c.Do(ctx, key, func() ([]byte, error) {
+		m, err := work()
+		if err != nil {
+			return nil, err
+		}
+		return proto.Marshal(m)
+	})
+	if err != nil {
+		return err
+	}
+	return proto.Unmarshal(bs, out)
+}

--- a/server/util/dsingleflight/dsingleflight.go
+++ b/server/util/dsingleflight/dsingleflight.go
@@ -1,5 +1,22 @@
 // Package dsingleflight is a distributed version of the singleflight package.
 // Work is coordinated across servers using Redis.
+//
+// Usage:
+//     sf := dsingleflight.New(rdb)
+//     result, err := df.Do(ctx, "executor-large-compute-CBF43926", func() ([]byte, error) {
+// 		   return expensiveCalculation()
+//     })
+//
+// Considerations:
+//  - Deduplication is best-effort and depends on redis availability. There's a
+//    possibility that a task may be executed more than once.
+//  - Task keys are not namespaced. Choose keys that will be unique across all
+//    servers connected to the Redis instance/cluster and that appropriately
+//    differentiate different types of tasks.
+//    An example key might be servertype-subsystem-taskhash
+//  - The result is temporarily stored in Redis, so it must be serializable to
+//    a slice of bytes.
+
 package dsingleflight
 
 import (

--- a/server/util/dsingleflight/dsingleflight_test.go
+++ b/server/util/dsingleflight/dsingleflight_test.go
@@ -1,0 +1,62 @@
+package dsingleflight
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestDo(t *testing.T) {
+	rdb := testredis.Start(t).Client()
+	c := New(rdb)
+	ctx := context.Background()
+
+	rand.Seed(time.Now().UnixNano())
+	key := fmt.Sprintf("key-%d", rand.Int())
+
+	wg, ctx := errgroup.WithContext(ctx)
+
+	numWorkers := 20
+	results := make(chan []byte, numWorkers)
+
+	var mu sync.Mutex
+	numExecutions := 0
+	usedWorker := ""
+
+	for i := 0; i < numWorkers; i++ {
+		i := i
+		worker := fmt.Sprintf("worker_%d", i)
+		wg.Go(func() error {
+			res, err := c.Do(ctx, key, func() ([]byte, error) {
+				mu.Lock()
+				numExecutions++
+				usedWorker = worker
+				mu.Unlock()
+				time.Sleep(2 * time.Second)
+				return []byte(worker), nil
+			})
+			if err != nil {
+				return err
+			}
+			results <- res
+			return nil
+		})
+	}
+
+	err := wg.Wait()
+	require.NoError(t, err)
+
+	require.Equal(t, 1, numExecutions, "expected work to be done only once")
+	// all callers should have gotten the same result
+	close(results)
+	for result := range results {
+		require.Equal(t, usedWorker, string(result))
+	}
+}


### PR DESCRIPTION
Every client for a given work key will try to obtain a lock in Redis.
The first client to get the lock will perform the work and publish the
result to a stream. If the owner does not refresh the lock within 5
seconds, another worker will have a chance to claim the lock and do the
work.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
