### PR TITLE
Dedupe image conversions across registry instances.

### DIFF
--- a/enterprise/server/registry/BUILD
+++ b/enterprise/server/registry/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/registry",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/server/backends/redis_client",
         "//proto:registry_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/backends/blobstore",
@@ -19,6 +20,7 @@ go_library(
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/ssl",
+        "//server/util/dsingleflight",
         "//server/util/flagutil/yaml",
         "//server/util/grpc_client",
         "//server/util/grpc_server",
@@ -41,7 +43,6 @@ go_library(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_protobuf//proto",
         "@org_golang_x_sync//errgroup",
-        "@org_golang_x_sync//singleflight",
     ],
 )
 


### PR DESCRIPTION
This will allow us to run multiple replicas of the registry.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
