### PR TITLE
Task sizing: Define sizer interface

### DIFF
--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -34,6 +34,7 @@ go_library(
         "//enterprise/server/scheduling/task_router",
         "//enterprise/server/selfauth",
         "//enterprise/server/splash",
+        "//enterprise/server/tasksize",
         "//enterprise/server/telemetry",
         "//enterprise/server/usage",
         "//enterprise/server/usage_service",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_router"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/selfauth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/splash"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/tasksize"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/usage"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/usage_service"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/bitbucket"
@@ -192,6 +193,9 @@ func main() {
 	}
 	if err := task_router.Register(realEnv); err != nil {
 		log.Fatalf("%v", err)
+	}
+	if err := tasksize.Register(realEnv); err != nil {
+		log.Fatal(err.Error())
 	}
 
 	if err := remote_execution_redis_client.RegisterRemoteExecutionClient(realEnv); err != nil {

--- a/enterprise/server/remote_execution/execution_server/BUILD
+++ b/enterprise/server/remote_execution/execution_server/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//enterprise/server/remote_execution/config",
         "//enterprise/server/remote_execution/operation",
         "//enterprise/server/remote_execution/platform",
-        "//enterprise/server/tasksize",
         "//proto:execution_stats_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",

--- a/enterprise/server/tasksize/BUILD
+++ b/enterprise/server/tasksize/BUILD
@@ -10,9 +10,12 @@ go_library(
     ],
     deps = [
         "//enterprise/server/remote_execution/platform",
+        "//proto:execution_stats_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",
+        "//server/environment",
         "//server/util/log",
+        "//server/util/status",
     ],
 )
 

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -289,6 +289,8 @@ func newBuildBuddyServer(t *testing.T, env *buildBuddyServerEnv, opts *BuildBudd
 	router, err := task_router.New(env)
 	require.NoError(t, err, "could not set up TaskRouter")
 	env.SetTaskRouter(router)
+	err = tasksize.Register(env)
+	require.NoError(t, err, "could not set up TaskSizer")
 	executionServer, err := execution_server.NewExecutionServer(env)
 	require.NoError(t, err, "could not set up ExecutionServer")
 	env.SetRemoteExecutionService(executionServer)

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -75,6 +75,8 @@ type Env interface {
 	SetSchedulerService(interfaces.SchedulerService)
 	GetTaskRouter() interfaces.TaskRouter
 	SetTaskRouter(interfaces.TaskRouter)
+	GetTaskSizer() interfaces.TaskSizer
+	SetTaskSizer(interfaces.TaskSizer)
 	GetDefaultRedisClient() redis.UniversalClient
 	SetDefaultRedisClient(redis.UniversalClient)
 	GetRemoteExecutionRedisClient() redis.UniversalClient

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -532,6 +532,16 @@ type TaskRouter interface {
 	MarkComplete(ctx context.Context, cmd *repb.Command, remoteInstanceName, executorInstanceID string)
 }
 
+// TaskSizer estimates task resource usage for scheduling purposes.
+type TaskSizer interface {
+	// Estimate returns the resource usage for a task.
+	Estimate(ctx context.Context, task *repb.ExecutionTask) *scpb.TaskSize
+
+	// Update updates future resource usage estimates based on a command's
+	// recorded execution stats.
+	Update(ctx context.Context, cmd *repb.Command, summary *espb.ExecutionSummary) error
+}
+
 // ScheduledTask represents an execution task along with its scheduling metadata
 // computed by the execution service.
 type ScheduledTask struct {

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -37,6 +37,7 @@ func (cc *executionClientConfig) DisableStreaming() bool {
 type RealEnv struct {
 	schedulerService                 interfaces.SchedulerService
 	taskRouter                       interfaces.TaskRouter
+	taskSizer                        interfaces.TaskSizer
 	healthChecker                    interfaces.HealthChecker
 	serverContext                    context.Context
 	workflowService                  interfaces.WorkflowService
@@ -294,6 +295,12 @@ func (r *RealEnv) SetTaskRouter(tr interfaces.TaskRouter) {
 }
 func (r *RealEnv) GetTaskRouter() interfaces.TaskRouter {
 	return r.taskRouter
+}
+func (r *RealEnv) GetTaskSizer() interfaces.TaskSizer {
+	return r.taskSizer
+}
+func (r *RealEnv) SetTaskSizer(val interfaces.TaskSizer) {
+	r.taskSizer = val
 }
 func (r *RealEnv) SetMetricsCollector(c interfaces.MetricsCollector) {
 	r.metricsCollector = c


### PR DESCRIPTION
This will let us fail at server startup (in `Register()`) if no Redis client is configured in the env. It also generally makes sense to make an interface that has the same look and feel as TaskRouter, since the usage of those two things is very similar (they both will use Redis, and they both will be called after each task execution in MarkComplete).

* Add task sizer interface definition
* Add env plumbing
* Use the new `Estimate()` method in `ExecutionServer` (just passes through to the existing impl)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
