### PR TITLE
Allow faster refresh rate for local Grafana development

### DIFF
--- a/tools/metrics/docker-compose.grafana.yml
+++ b/tools/metrics/docker-compose.grafana.yml
@@ -7,6 +7,7 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Editor
       - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/buildbuddy.json
+      - GF_DASHBOARDS_MIN_REFRESH_INTERVAL=1s
     volumes:
       - ./grafana/provisioning/local:/etc/grafana/provisioning
       - ./grafana/dashboards:/var/lib/grafana/dashboards

--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -8517,6 +8517,7 @@
   },
   "timepicker": {
     "refresh_intervals": [
+      "1s",
       "5s",
       "10s",
       "15s",

--- a/tools/metrics/grafana/provisioning/local/datasources/datasources.yml
+++ b/tools/metrics/grafana/provisioning/local/datasources/datasources.yml
@@ -9,3 +9,5 @@ datasources:
     url: http://host.docker.internal:9100
     version: 1
     editable: false
+    jsonData:
+      timeInterval: 1s


### PR DESCRIPTION
Reduce the min refresh rate from 5s -> 1s for local development only. This helps visualize metrics which change very quickly, such as executor memory and CPU.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
