### PR TITLE
Slightly increase build log height

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -992,7 +992,7 @@ code .comment {
 }
 
 .terminal {
-  height: 300px;
+  height: 360px;
   overflow: visible;
 }
 
@@ -1087,6 +1087,7 @@ code .comment {
 
 .build-logs-card {
   position: relative;
+  padding-bottom: 16px;
 }
 
 .build-logs-card .title {


### PR DESCRIPTION
* Add 3 more log lines worth of height (60px)
* Trim bottom padding from 32px -> 16px. The top padding is still at 32px so this introduces an asymmetry, but it's not really noticeable in practice because we add a blank line to the end of the logs. Tested in dense mode; no change because the bottom padding for dense mode is already 16px.

Before/after:

![image](https://user-images.githubusercontent.com/2414826/175325049-a6476907-12c1-4a58-8df9-e911ea945028.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1452
