### PR TITLE
Fix s3 range reads

### DIFF
--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -469,10 +469,11 @@ func (s3c *S3Cache) Reader(ctx context.Context, d *repb.Digest, offset, limit in
 	// TODO(bduffany): track this as a contains() request, or find a way to
 	// track it as part of the read
 
-	readRange := aws.String(fmt.Sprintf("%d-", offset))
+	// This range follows the format specified here: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
+	readRange := aws.String(fmt.Sprintf("bytes=%d-", offset))
 	if limit != 0 {
 		// range bounds are inclusive
-		readRange = aws.String(fmt.Sprintf("%d-%d", offset, offset+limit-1))
+		readRange = aws.String(fmt.Sprintf("bytes=%d-%d", offset, offset+limit-1))
 	}
 
 	result, err := s3c.s3.GetObjectWithContext(ctx, &s3.GetObjectInput{


### PR DESCRIPTION
This fixes an issue where (when using an s3 backing cache) we get a SHA mismatch if the context is cancelled during a large download.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
