### PR TITLE
Add exit when ready flag

### DIFF
--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -67,6 +67,8 @@ var (
 	staticDirectory = flag.String("static_directory", "", "the directory containing static files to host")
 	appDirectory    = flag.String("app_directory", "", "the directory containing app binary files to host")
 
+	exitWhenReady = flag.Bool("exit_when_ready", false, "If set, the app will exit as soon as it becomes ready (useful for migrations)")
+
 	// URL path prefixes that should be handled by serving the app's HTML.
 	appRoutes = []string{
 		"/compare/",
@@ -378,6 +380,11 @@ func StartAndRunServices(env environment.Env) {
 		go func() {
 			server.ListenAndServe()
 		}()
+	}
+
+	if *exitWhenReady {
+		env.GetHealthChecker().Shutdown()
+		os.Exit(0)
 	}
 	env.GetHealthChecker().WaitForGracefulShutdown()
 }


### PR DESCRIPTION
Add an --exit_when_ready flag that can be used to kill the app after running migrations.

This will allow us to run other migrations as well as the DB ones (like, for instance, a disk cache migration). Currently setting --auto_migrate_db_and_exit causes the app to die before a disk migration would ever run.