### PR TITLE
Use new ExecutedActionMetadata for task sizing

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -870,10 +870,9 @@ func (s *ExecutionServer) markTaskComplete(ctx context.Context, taskID string, e
 	}
 
 	if sizer := s.env.GetTaskSizer(); sizer != nil {
-		if md, _ := decodeMetadataFromExecutionSummary(executeResponse); md != nil {
-			if err := sizer.Update(ctx, cmd, md); err != nil {
-				log.CtxWarningf(ctx, "Failed to update task size: %s", err)
-			}
+		md := executeResponse.GetResult().GetExecutionMetadata()
+		if err := sizer.Update(ctx, cmd, md); err != nil {
+			log.CtxWarningf(ctx, "Failed to update task size: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Not using the ExecutionSummary at all for task sizing, since UsageStats was only just implemented, and other metadata fields aren't needed for task sizing.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
