### PR TITLE
Task sizing: Run tasks unsized if measurements haven't yet been recorded

### DIFF
--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -136,12 +136,7 @@ func TestSizer_Estimate_ShouldUseRecordedUsageStats(t *testing.T) {
 	}
 	ts := sizer.Estimate(ctx, task)
 
-	assert.Equal(
-		t, tasksize.DefaultMemEstimate, ts.EstimatedMemoryBytes,
-		"initial mem estimate should be the default estimate")
-	assert.Equal(
-		t, tasksize.DefaultCPUEstimate, ts.EstimatedMilliCpu,
-		"initial CPU estimate should be the default estimate")
+	assert.True(t, tasksize.IsUnsized(ts), "task should be unsized initially")
 
 	execStart := time.Now()
 	md := &repb.ExecutedActionMetadata{


### PR DESCRIPTION
When we haven't yet recorded a task size, run it with generous memory limits (up to the executor resource limits so that we can always give it a trial run on one of the registered executors).

Note, this is all still behind the flag `remote_execution.use_measured_task_sizes`.

Screenshot showing a task that consumes 4GB of memory first running in "unsized" mode, then running with a more accurate estimate once we know the size (ignore the spike in the second run -- a few extra test actions crept in):

![image](https://user-images.githubusercontent.com/2414826/176031045-3b4ea56c-a712-4758-af46-6d177c594115.png)


---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
