### PR TITLE
old friend

### DIFF
--- a/server/util/consistent_hash/consistent_hash.go
+++ b/server/util/consistent_hash/consistent_hash.go
@@ -104,19 +104,20 @@ func (c *ConsistentHash) GetAllReplicas(key string) []string {
 	}
 	originalIndex := c.ring[c.keys[idx]]
 
-	seen := make(map[string]struct{}, len(c.items))
-	seen[c.items[originalIndex]] = struct{}{}
+	replicas := make([]string, 0, len(c.items))
+	replicas = append(replicas, c.items[originalIndex])
+
 	c.lookupReplicas(idx, func(replicaIndex uint8) bool {
 		replica := c.items[replicaIndex]
-		if _, ok := seen[replica]; !ok {
-			seen[replica] = struct{}{}
+		for _, r := range replicas {
+			if r == replica {
+				return false
+			}
 		}
-		return len(seen) == len(c.items)
-	})
-	replicas := make([]string, 0, len(seen))
-	for replica := range seen {
 		replicas = append(replicas, replica)
-	}
+		return len(replicas) == len(c.items)
+	})
+
 	return replicas
 
 }

--- a/server/util/consistent_hash/consistent_hash.go
+++ b/server/util/consistent_hash/consistent_hash.go
@@ -19,7 +19,6 @@ type ConsistentHash struct {
 	numReplicas int
 	mu          sync.RWMutex
 	replicaMu   sync.RWMutex
-	replicaSets map[uint32][]string
 }
 
 func NewConsistentHash() *ConsistentHash {
@@ -28,7 +27,6 @@ func NewConsistentHash() *ConsistentHash {
 		keys:        make([]int, 0),
 		ring:        make(map[int]uint8, 0),
 		items:       make([]string, 0),
-		replicaSets: make(map[uint32][]string, 0),
 	}
 }
 
@@ -50,7 +48,6 @@ func (c *ConsistentHash) Set(items ...string) error {
 	defer c.mu.Unlock()
 	c.keys = make([]int, 0)
 	c.ring = make(map[int]uint8, 0)
-	c.replicaSets = make(map[uint32][]string, 0)
 
 	c.items = items
 	sort.Strings(c.items)
@@ -80,13 +77,15 @@ func (c *ConsistentHash) Get(key string) string {
 	if idx == len(c.keys) {
 		idx = 0
 	}
-	return c.items[c.ring[c.keys[idx]]]
+	r := c.items[c.ring[c.keys[idx]]]
+	return r
 }
 
-func (c *ConsistentHash) lookupReplicas(idx int, fn func(replicaIndex uint8)) {
-	for offset := 1; offset < len(c.keys); offset += 1 {
+func (c *ConsistentHash) lookupReplicas(idx int, fn func(replicaIndex uint8) bool) {
+	done := false
+	for offset := 1; offset < len(c.keys) && !done; offset += 1 {
 		newIdx := (idx + offset) % len(c.keys)
-		fn(c.ring[c.keys[newIdx]])
+		done = fn(c.ring[c.keys[newIdx]])
 	}
 }
 
@@ -103,49 +102,23 @@ func (c *ConsistentHash) GetAllReplicas(key string) []string {
 	if idx == len(c.keys) {
 		idx = 0
 	}
-
-	// first, attempt to lookup the replicaset in our local cache, by
-	// computing a hash of the replicas in the set, and checking if this set
-	// has been returned before. If it has -- return that set.
 	originalIndex := c.ring[c.keys[idx]]
-	inputBuf := make([]byte, len(c.keys))
-	inputBuf[0] = originalIndex
-	inputIdx := 1
-	c.lookupReplicas(idx, func(replicaIndex uint8) {
-		inputBuf[inputIdx] = replicaIndex
-		inputIdx += 1
-	})
-	replicasKey := crc32.ChecksumIEEE(inputBuf)
 
-	c.replicaMu.RLock()
-	replicas, ok := c.replicaSets[replicasKey]
-	c.replicaMu.RUnlock()
-	if ok {
-		return replicas
-	}
-
-	// if no replicaset was found under the hash key, we'll go ahead and
-	// allocate a new replica set and cache it, then return it.
-	seen := make(map[uint8]struct{}, len(c.keys))
-	seen[originalIndex] = struct{}{}
-
-	replicas = make([]string, 0, len(c.keys))
-	replicas = append(replicas, c.items[originalIndex])
-
-	c.lookupReplicas(idx, func(replicaIndex uint8) {
-		if _, ok := seen[replicaIndex]; !ok {
-			replicas = append(replicas, c.items[replicaIndex])
-			seen[replicaIndex] = struct{}{}
+	seen := make(map[string]struct{}, len(c.items))
+	seen[c.items[originalIndex]] = struct{}{}
+	c.lookupReplicas(idx, func(replicaIndex uint8) bool {
+		replica := c.items[replicaIndex]
+		if _, ok := seen[replica]; !ok {
+			seen[replica] = struct{}{}
 		}
+		return len(seen) == len(c.items)
 	})
-
-	c.replicaMu.Lock()
-	if _, ok := c.replicaSets[replicasKey]; !ok {
-		c.replicaSets[replicasKey] = replicas
+	replicas := make([]string, 0, len(seen))
+	for replica := range seen {
+		replicas = append(replicas, replica)
 	}
-	c.replicaMu.Unlock()
-
 	return replicas
+
 }
 
 // GetNReplicas returns the N "items" responsible for the specified key, in

--- a/server/util/consistent_hash/consistent_hash_test.go
+++ b/server/util/consistent_hash/consistent_hash_test.go
@@ -88,6 +88,7 @@ func BenchmarkGetAllReplicas(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
 		b.StopTimer()
 		k, err := random.RandomString(64)


### PR DESCRIPTION
- Measure allocs
- Reduce cpu usage by doing less duplicate work

Before:
tylerw@lunchbox:~/buildbuddy$ blaze run server/util/consistent_hash:consistent_hash_test -- -test.bench=.
-----------------------------------------------------------------------------
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 5950X 16-Core Processor
BenchmarkGetAllReplicas-32    	  143203	      8215 ns/op	    1249 B/op	       2 allocs/op
PASS

After:
tylerw@lunchbox:~/buildbuddy$ blaze run server/util/consistent_hash:consistent_hash_test -- -test.bench=.
-----------------------------------------------------------------------------
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 5950X 16-Core Processor
BenchmarkGetAllReplicas-32    	  452287	      2711 ns/op	     224 B/op	       2 allocs/op
PASS
tylerw@lunchbox:~/buildbuddy$