### PR TITLE
Task sizing: Support only soft task size limits for now

### DIFF
--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -126,7 +126,7 @@ func (s *taskSizer) Estimate(ctx context.Context, task *repb.ExecutionTask) *scp
 		return initialEstimate
 	}
 	return &scpb.TaskSize{
-		EstimatedMemoryBytes:   int64(float64(recordedSize.EstimatedMemoryBytes) * measuredSizeMemoryMultiplier),
+		EstimatedMemoryBytes:   recordedSize.EstimatedMemoryBytes,
 		EstimatedMilliCpu:      recordedSize.EstimatedMilliCpu,
 		EstimatedFreeDiskBytes: initialEstimate.EstimatedFreeDiskBytes,
 	}

--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -162,8 +162,8 @@ func TestSizer_Estimate_ShouldUseRecordedUsageStats(t *testing.T) {
 	ts = sizer.Estimate(ctx, task)
 
 	assert.Equal(
-		t, int64(917*1e6*1.10), ts.EstimatedMemoryBytes,
-		"subsequent mem estimate should equal recorded peak mem usage times a small multiplier")
+		t, int64(917*1e6), ts.EstimatedMemoryBytes,
+		"subsequent mem estimate should equal recorded peak mem usage")
 	assert.Equal(
 		t, int64(7.13/2*1000), ts.EstimatedMilliCpu,
 		"subsequent milliCPU estimate should equal recorded milliCPU")


### PR DESCRIPTION
* Don't use measured task sizes for Firecracker tasks (yet)
* Don't use a 1.10x multiplier for mem estimates, since the mem size estimate is just a soft limit and we have some wiggle room anyway (20% of the executor's memory is reserved in case we go over)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
