### PR TITLE
Disable stargzstore background fetching.

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -136,6 +136,13 @@ func NewProvider(env environment.Env, imageCacheAuthenticator *container.ImageCa
 
 	imageStreamingEnabled := *imageStreamingRegistryHTTPTarget != "" && *imageStreamingRegistryGRPCTarget != ""
 	if imageStreamingEnabled {
+		storeConf := `
+no_background_fetch = true
+`
+		if _, err := disk.WriteFile(env.GetServerContext(), "/etc/stargz-store/config.toml", []byte(storeConf)); err != nil {
+			return nil, status.UnavailableErrorf("could not write stargzstore config: %s", err)
+		}
+
 		log.Infof("Starting stargz store")
 		cmd := exec.CommandContext(env.GetServerContext(), "stargz-store", "/var/lib/stargz-store/store")
 		logWriter := log.Writer("[stargzstore] ")


### PR DESCRIPTION
This appears to avoid the failures seen in TF builds, though it's hard
to say with 100% certainty.

We can try turning image streaming again in dev after tomorrow's
release.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
