### PR TITLE
Scan inter + intra partition in parallel

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -884,7 +884,6 @@ func (e *partitionEvictor) computeSize() (int64, int64, int64, error) {
 	totalAcCount := int64(0)
 
 	goScanRange := func(start, end []byte) {
-		log.Printf("Scanning from %q to %q", start, end)
 		eg.Go(func() error {
 			blobSizeBytes, casCount, acCount, err := e.computeSizeInRange(start, end)
 			if err != nil {

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -901,6 +901,7 @@ func (e *partitionEvictor) computeSize() (int64, int64, int64, error) {
 	}
 
 	// Start scanning the AC.
+	// AC keys look like /partitionID/ac/12312312313(crc-32)/digesthash
 	for i := 0; i < 10; i++ {
 		kr := append(e.acPrefix, []byte(fmt.Sprintf("%d", i))...)
 		start, end := keyRange(kr)
@@ -908,6 +909,7 @@ func (e *partitionEvictor) computeSize() (int64, int64, int64, error) {
 	}
 
 	// Start scanning the CAS.
+	// CAS keys look like /partitionID/cas/digesthash(sha-256)
 	for i := 0; i < 16; i++ {
 		kr := append(e.casPrefix, []byte(fmt.Sprintf("%x", i))...)
 		start, end := keyRange(kr)


### PR DESCRIPTION
I went for something simple to start with.

The difference, when running locally:
```
2022/06/30 15:41:08.627 INF Pebble Cache: Initialized cache partition "default" AC: 15331, CAS: 1732768, Size: 7012901198 [bytes] in 424.877198ms
2022/06/30 15:41:29.414 INF Pebble Cache: Initialized cache partition "default" AC: 15508, CAS: 1732784, Size: 7013263634 [bytes] in 2.488654371s
```