### PR TITLE
Skip expiry check in checkAccessToken

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -316,8 +316,10 @@ func (a *oidcAuthenticator) checkAccessToken(ctx context.Context, jwt, accessTok
 	if err != nil {
 		return err
 	}
-	conf := a.oidcConfig
-	validToken, err := provider.Verifier(conf).Verify(ctx, jwt)
+	conf := *a.oidcConfig // copy
+	// We're only checking the access token here, not checking for jwt expiry.
+	conf.SkipExpiryCheck = true
+	validToken, err := provider.Verifier(&conf).Verify(ctx, jwt)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Before https://github.com/buildbuddy-io/buildbuddy/pull/2165, we would set `SkipExpiryCheck = true` in the preceding call to `verifyTokenAndExtractUser(ctx, jwt, false /*=checkExpiry*/)`, which mutated the `oidcConfig`, and `checkAccessToken` was implicitly relying on that mutation. Now, we explicitly set `SkipExpiryCheck`, again making a copy to avoid data races across requests.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1489
