### PR TITLE
Executor: Force-remove workspace directories

### DIFF
--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -285,7 +285,16 @@ func (ws *Workspace) Remove() error {
 	// immediately fail since we've set the removing bit.
 	ws.mu.Unlock()
 
-	return os.RemoveAll(ws.rootDir)
+	if err := os.RemoveAll(ws.rootDir); err != nil {
+		// Sometimes removal fails if badly-behaved actions write their
+		// directories read-only. Retry with force-removal in this case.
+		log.Debugf("Failed to remove %s - attempting force-removal.", ws.rootDir)
+		if err := forceRemove(ws.rootDir); err != nil {
+			return status.InternalErrorf("failed to force-remove workspace directory %q: %s", ws.rootDir, err)
+		}
+		return nil
+	}
+	return nil
 }
 
 // Size computes the current workspace size in bytes.
@@ -352,6 +361,28 @@ func (ws *Workspace) Clean() error {
 		return status.UnavailableErrorf("Failed to clean workspace: %s", err)
 	}
 	return nil
+}
+
+// forceRemove attempts to remove a directory by first making the entire tree
+// writable. Before calling this function, it's recommended to first try
+// os.RemoveAll, since this function is expensive (it incurs a system call for
+// each permissions change).
+func forceRemove(path string) error {
+	err := filepath.WalkDir(path, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			// In order to remove dir entries and make sure we can further
+			// recurse into the dir, we need all bits set (RWX).
+			return os.Chmod(path, 0770)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return os.RemoveAll(path)
 }
 
 func removeChildren(dirPath string) error {

--- a/enterprise/server/remote_execution/workspace/workspace_test.go
+++ b/enterprise/server/remote_execution/workspace/workspace_test.go
@@ -67,6 +67,23 @@ func actualFilePaths(t *testing.T, ws *workspace.Workspace) map[string]struct{} 
 	return paths
 }
 
+func TestWorkspaceRemove_ReadOnlyTree_DeletesEntireTree(t *testing.T) {
+	ws := newWorkspace(t, &workspace.Opts{})
+	writeEmptyFiles(t, ws, []string{
+		"READONLY",
+		"dir/READONLY",
+	})
+	err := os.Chmod(filepath.Join(ws.Path(), "READONLY"), 0400)
+	require.NoError(t, err)
+	err = os.Chmod(filepath.Join(ws.Path(), "dir/READONLY"), 0400)
+	require.NoError(t, err)
+	err = os.Chmod(filepath.Join(ws.Path(), "dir"), 0400)
+	require.NoError(t, err)
+
+	err = ws.Remove()
+	require.NoError(t, err)
+}
+
 func TestWorkspaceCleanup_NoPreserveWorkspace_DeletesAllFiles(t *testing.T) {
 	filePaths := []string{
 		"some_output_directory/DELETEME",


### PR DESCRIPTION
If we fail to delete a workspace directory, fall back to force-removal (golang equivalent of `chmod -R +w workspace && rm -rf workspace`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
