### PR TITLE
Fix startup scan

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -972,11 +972,11 @@ func (e *partitionEvictor) computeSize() (int64, int64, int64, error) {
 	}
 
 	acPrefixRange := func(start, end []byte) ([]byte, []byte) {
-		left := make([]byte, 0)
+		left := make([]byte, 0, len(e.acPrefix)+len(start))
 		left = append(left, e.acPrefix...)
 		left = append(left, start...)
 
-		right := make([]byte, 0)
+		right := make([]byte, 0, len(e.acPrefix)+len(end))
 		right = append(right, e.acPrefix...)
 		right = append(right, end...)
 		return left, right
@@ -984,10 +984,13 @@ func (e *partitionEvictor) computeSize() (int64, int64, int64, error) {
 
 	// Start scanning the AC.
 	// AC keys look like /partitionID/ac/12312312313(crc-32)/digesthash
+	// Start scanning at 10 because crc32s do not begin with 0.
 	for i := 10; i < 99; i++ {
 		left, right := acPrefixRange([]byte(fmt.Sprintf("%d", i)), []byte(fmt.Sprintf("%d", i+1)))
 		goScanRange(left, right)
 	}
+	// Additionally scan from 99-> max byte to ensure we cover the full
+	// range.
 	left, right := acPrefixRange([]byte("99"), []byte{constants.MaxByte})
 	goScanRange(left, right)
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -919,7 +919,7 @@ func (e *partitionEvictor) computeSizeInRange(start, end []byte) (int64, int64, 
 		LowerBound: start,
 		UpperBound: end,
 	})
-	iter.SeekGE(start)
+	iter.SeekLT(start)
 
 	casCount := int64(0)
 	acCount := int64(0)
@@ -971,13 +971,25 @@ func (e *partitionEvictor) computeSize() (int64, int64, int64, error) {
 		})
 	}
 
+	acPrefixRange := func(start, end []byte) ([]byte, []byte) {
+		left := make([]byte, 0)
+		left = append(left, e.acPrefix...)
+		left = append(left, start...)
+
+		right := make([]byte, 0)
+		right = append(right, e.acPrefix...)
+		right = append(right, end...)
+		return left, right
+	}
+
 	// Start scanning the AC.
 	// AC keys look like /partitionID/ac/12312312313(crc-32)/digesthash
-	for i := 0; i < 100; i++ {
-		kr := append(e.acPrefix, []byte(fmt.Sprintf("%.2d", i))...)
-		start, end := keyRange(kr)
-		goScanRange(start, end)
+	for i := 10; i < 99; i++ {
+		left, right := acPrefixRange([]byte(fmt.Sprintf("%d", i)), []byte(fmt.Sprintf("%d", i+1)))
+		goScanRange(left, right)
 	}
+	left, right := acPrefixRange([]byte("99"), []byte{constants.MaxByte})
+	goScanRange(left, right)
 
 	// Start scanning the CAS.
 	// CAS keys look like /partitionID/cas/digesthash(sha-256)
@@ -1277,5 +1289,8 @@ func (p *PebbleCache) Stop() error {
 	if err := p.eg.Wait(); err != nil {
 		return err
 	}
-	return p.db.Flush()
+	if err := p.db.Flush(); err != nil {
+		return err
+	}
+	return p.db.Close()
 }

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -565,6 +565,59 @@ func TestMigrationFromDiskV2(t *testing.T) {
 	}
 }
 
+func TestStartupScan(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
+	ctx := getAnonContext(t, te)
+	rootDir := testfs.MakeTempDir(t)
+	maxSizeBytes := int64(1_000_000_000) // 1GB
+	options := &pebble_cache.Options{RootDirectory: rootDir, MaxSizeBytes: maxSizeBytes}
+	pc, err := pebble_cache.NewPebbleCache(te, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc.Start()
+	digests := make([]*repb.Digest, 0)
+	for i := 0; i < 1000; i++ {
+		remoteInstanceName := fmt.Sprintf("remote-instance-%d", i)
+		c, err := pc.WithIsolation(ctx, interfaces.ActionCacheType, remoteInstanceName)
+		require.Nil(t, err)
+		d, buf := testdigest.NewRandomDigestBuf(t, 1000)
+		err = c.Set(ctx, d, buf)
+		require.Nil(t, err)
+		digests = append(digests, d)
+
+		err = pc.Set(ctx, d, buf)
+		require.Nil(t, err)
+	}
+	log.Printf("Wrote %d digests", len(digests))
+	log.Printf("Statusz: %s", pc.Statusz(ctx))
+	time.Sleep(pebble_cache.JanitorCheckPeriod)
+	pc.TestingWaitForGC()
+	pc.Stop()
+
+	pc2, err := pebble_cache.NewPebbleCache(te, options)
+	require.Nil(t, err, err)
+
+	pc2.Start()
+	defer pc2.Stop()
+	for i, d := range digests {
+		remoteInstanceName := fmt.Sprintf("remote-instance-%d", i)
+		c, err := pc2.WithIsolation(ctx, interfaces.ActionCacheType, remoteInstanceName)
+		require.Nil(t, err)
+		rbuf, err := c.Get(ctx, d)
+		if err != nil {
+			t.Fatalf("Error getting %q from cache: %s", d.GetHash(), err.Error())
+		}
+
+		// Compute a digest for the bytes returned.
+		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		if d.GetHash() != d2.GetHash() {
+			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), d.GetHash())
+		}
+	}
+}
+
 func BenchmarkGetMulti(b *testing.B) {
 	te := testenv.GetTestEnv(b)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -591,7 +591,7 @@ func TestStartupScan(t *testing.T) {
 		require.Nil(t, err)
 	}
 	log.Printf("Wrote %d digests", len(digests))
-	log.Printf("Statusz: %s", pc.Statusz(ctx))
+
 	time.Sleep(pebble_cache.JanitorCheckPeriod)
 	pc.TestingWaitForGC()
 	pc.Stop()


### PR DESCRIPTION
Previously we were skipping some records when scanning the AC ranges on startup.