### PR TITLE
Rename ExecOpts to Stdio

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -194,7 +194,7 @@ type CommandContainer interface {
 	// stdin of the executed process. If stdout is non-nil, the stdout of the
 	// executed process will be written to the stdout writer rather than being
 	// written to the command result's stdout field (same for stderr).
-	Exec(ctx context.Context, command *repb.Command, opts *ExecOpts) *interfaces.CommandResult
+	Exec(ctx context.Context, command *repb.Command, stdio *Stdio) *interfaces.CommandResult
 	// Unpause un-freezes a container so that it can be used to execute commands.
 	Unpause(ctx context.Context) error
 	// Pause freezes a container so that it no longer consumes CPU resources.
@@ -207,8 +207,8 @@ type CommandContainer interface {
 	Stats(ctx context.Context) (*Stats, error)
 }
 
-// ExecOpts specifies options for executing a task.
-type ExecOpts struct {
+// Stdio specifies standard input / output readers for a command.
+type Stdio struct {
 	// Stdin is an optional stdin source for the executed process.
 	Stdin io.Reader
 	// Stdout is an optional stdout sink for the executed process.
@@ -406,7 +406,7 @@ func (t *TracedCommandContainer) Create(ctx context.Context, workingDir string) 
 	return t.Delegate.Create(ctx, workingDir)
 }
 
-func (t *TracedCommandContainer) Exec(ctx context.Context, command *repb.Command, opts *ExecOpts) *interfaces.CommandResult {
+func (t *TracedCommandContainer) Exec(ctx context.Context, command *repb.Command, opts *Stdio) *interfaces.CommandResult {
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
 	return t.Delegate.Exec(ctx, command, opts)

--- a/enterprise/server/remote_execution/container/container_test.go
+++ b/enterprise/server/remote_execution/container/container_test.go
@@ -37,7 +37,7 @@ func (c *FakeContainer) PullImage(ctx context.Context, creds container.PullCrede
 	return nil
 }
 func (c *FakeContainer) Create(context.Context, string) error { return nil }
-func (c *FakeContainer) Exec(context.Context, *repb.Command, *container.ExecOpts) *interfaces.CommandResult {
+func (c *FakeContainer) Exec(context.Context, *repb.Command, *container.Stdio) *interfaces.CommandResult {
 	return nil
 }
 func (c *FakeContainer) Remove(ctx context.Context) error  { return nil }

--- a/enterprise/server/remote_execution/containers/bare/bare.go
+++ b/enterprise/server/remote_execution/containers/bare/bare.go
@@ -21,7 +21,7 @@ func NewBareCommandContainer() container.CommandContainer {
 }
 
 func (c *bareCommandContainer) Run(ctx context.Context, command *repb.Command, workDir string, creds container.PullCredentials) *interfaces.CommandResult {
-	return commandutil.Run(ctx, command, workDir, &container.ExecOpts{})
+	return commandutil.Run(ctx, command, workDir, &container.Stdio{})
 }
 
 func (c *bareCommandContainer) Create(ctx context.Context, workDir string) error {
@@ -29,8 +29,8 @@ func (c *bareCommandContainer) Create(ctx context.Context, workDir string) error
 	return nil
 }
 
-func (c *bareCommandContainer) Exec(ctx context.Context, cmd *repb.Command, opts *container.ExecOpts) *interfaces.CommandResult {
-	return commandutil.Run(ctx, cmd, c.WorkDir, opts)
+func (c *bareCommandContainer) Exec(ctx context.Context, cmd *repb.Command, stdio *container.Stdio) *interfaces.CommandResult {
+	return commandutil.Run(ctx, cmd, c.WorkDir, stdio)
 }
 
 func (c *bareCommandContainer) IsImageCached(ctx context.Context) (bool, error) { return false, nil }

--- a/enterprise/server/remote_execution/containers/docker/docker_test.go
+++ b/enterprise/server/remote_execution/containers/docker/docker_test.go
@@ -127,7 +127,7 @@ func TestDockerLifecycleControl(t *testing.T) {
 	// the docker container.
 	isContainerRunning = true
 
-	res := c.Exec(ctx, cmd, &container.ExecOpts{})
+	res := c.Exec(ctx, cmd, &container.Stdio{})
 
 	require.NoError(t, res.Error)
 	assert.Equal(t, res, expectedResult)
@@ -146,7 +146,7 @@ func TestDockerLifecycleControl(t *testing.T) {
 	assert.Greater(t, stats.MemoryUsageBytes, int64(0))
 
 	// Try executing the same command again after unpausing.
-	res = c.Exec(ctx, cmd, &container.ExecOpts{})
+	res = c.Exec(ctx, cmd, &container.Stdio{})
 
 	require.NoError(t, res.Error)
 	assert.Equal(t, res, expectedResult)
@@ -254,7 +254,7 @@ func TestDockerExec_Timeout_StdoutStderrStillVisible(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
-	res := c.Exec(ctx, cmd, &container.ExecOpts{})
+	res := c.Exec(ctx, cmd, &container.Stdio{})
 
 	assert.True(
 		t, status.IsDeadlineExceededError(res.Error),
@@ -309,7 +309,7 @@ func TestDockerExec_Stdio(t *testing.T) {
 	require.NoError(t, err)
 
 	var stdout, stderr bytes.Buffer
-	res := c.Exec(ctx, cmd, &container.ExecOpts{
+	res := c.Exec(ctx, cmd, &container.Stdio{
 		Stdin:  strings.NewReader("TestInput\n"),
 		Stdout: &stdout,
 		Stderr: &stderr,

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1226,7 +1226,7 @@ func (c *FirecrackerContainer) Run(ctx context.Context, command *repb.Command, a
 		}
 	}()
 
-	cmdResult := c.Exec(ctx, command, &container.ExecOpts{})
+	cmdResult := c.Exec(ctx, command, &container.Stdio{})
 	return cmdResult
 }
 
@@ -1398,9 +1398,9 @@ func (c *FirecrackerContainer) SendPrepareFileSystemRequestToGuest(ctx context.C
 // the executed process.
 // If stdout is non-nil, the stdout of the executed process will be written to the
 // stdout writer.
-func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, opts *container.ExecOpts) *interfaces.CommandResult {
+func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdio *container.Stdio) *interfaces.CommandResult {
 	// TODO(bduffany): Wire up stdin/stdout/stderr from ExecOpts
-	if opts.Stderr != nil || opts.Stdout != nil || opts.Stdin != nil {
+	if stdio.Stderr != nil || stdio.Stdout != nil || stdio.Stdin != nil {
 		return commandutil.ErrorResult(status.FailedPreconditionError("firecracker does not yet support remote persistent workers"))
 	}
 

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_darwin.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_darwin.go
@@ -29,7 +29,7 @@ func (c *FirecrackerContainer) Create(ctx context.Context, actionWorkingDir stri
 	return status.UnimplementedError("Not yet implemented.")
 }
 
-func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, opts *container.ExecOpts) *interfaces.CommandResult {
+func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdio *container.Stdio) *interfaces.CommandResult {
 	return &interfaces.CommandResult{}
 }
 

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -330,7 +330,7 @@ func (c *podmanCommandContainer) Run(ctx context.Context, command *repb.Command,
 	}
 	podmanRunArgs = append(podmanRunArgs, image)
 	podmanRunArgs = append(podmanRunArgs, command.Arguments...)
-	result = runPodman(ctx, "run", &container.ExecOpts{}, podmanRunArgs...)
+	result = runPodman(ctx, "run", &container.Stdio{}, podmanRunArgs...)
 
 	// Stop monitoring so that we can get stats.
 	stopMonitoring()
@@ -435,7 +435,7 @@ func (c *podmanCommandContainer) Create(ctx context.Context, workDir string) err
 	}
 	podmanRunArgs = append(podmanRunArgs, image)
 	podmanRunArgs = append(podmanRunArgs, "sleep", "infinity")
-	createResult := runPodman(ctx, "create", &container.ExecOpts{}, podmanRunArgs...)
+	createResult := runPodman(ctx, "create", &container.Stdio{}, podmanRunArgs...)
 	if err := c.maybeCleanupCorruptedImages(ctx, createResult); err != nil {
 		log.Warningf("Failed to remove corrupted image: %s", err)
 	}
@@ -448,7 +448,7 @@ func (c *podmanCommandContainer) Create(ctx context.Context, workDir string) err
 		return status.UnknownErrorf("podman create failed: exit code %d, stderr: %s", createResult.ExitCode, createResult.Stderr)
 	}
 
-	startResult := runPodman(ctx, "start", &container.ExecOpts{}, c.name)
+	startResult := runPodman(ctx, "start", &container.Stdio{}, c.name)
 	if startResult.Error != nil {
 		return startResult.Error
 	}
@@ -458,7 +458,7 @@ func (c *podmanCommandContainer) Create(ctx context.Context, workDir string) err
 	return nil
 }
 
-func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, opts *container.ExecOpts) *interfaces.CommandResult {
+func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, stdio *container.Stdio) *interfaces.CommandResult {
 	// Reset usage stats since we're running a new task. Note: This throws away
 	// any resource usage between the initial "Create" call and now, but that's
 	// probably fine for our needs right now.
@@ -477,7 +477,7 @@ func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, op
 	if strings.ToLower(c.options.Network) == "off" {
 		podmanRunArgs = append(podmanRunArgs, "--network=none")
 	}
-	if opts.Stdin != nil {
+	if stdio.Stdin != nil {
 		podmanRunArgs = append(podmanRunArgs, "--interactive")
 	}
 	podmanRunArgs = append(podmanRunArgs, c.name)
@@ -488,7 +488,7 @@ func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, op
 	// during a normal execution, so we are overly cautious here and only
 	// interpret this code specially when the container was removed and we are
 	// expecting a SIGKILL as a result.
-	res := runPodman(ctx, "exec", opts, podmanRunArgs...)
+	res := runPodman(ctx, "exec", stdio, podmanRunArgs...)
 	stopMonitoring()
 	if stats := <-statsCh; stats != nil {
 		res.UsageStats = stats.ToProto()
@@ -509,7 +509,7 @@ func (c *podmanCommandContainer) IsImageCached(ctx context.Context) (bool, error
 	}
 
 	// Try to avoid the `pull` command which results in a network roundtrip.
-	listResult := runPodman(ctx, "image", &container.ExecOpts{}, "inspect", "--format={{.ID}}", c.image)
+	listResult := runPodman(ctx, "image", &container.Stdio{}, "inspect", "--format={{.ID}}", c.image)
 	if listResult.ExitCode == podmanInternalExitCode {
 		return false, nil
 	} else if listResult.Error != nil {
@@ -672,7 +672,7 @@ func (c *podmanCommandContainer) pullImage(ctx context.Context, creds container.
 	// Use server context instead of ctx to make sure that "podman pull" is not killed when the context
 	// is cancelled. If "podman pull" is killed when copying a parent layer, it will result in
 	// corrupted storage.  More details see https://github.com/containers/storage/issues/1136.
-	pullResult := runPodman(c.env.GetServerContext(), "pull", &container.ExecOpts{}, podmanArgs...)
+	pullResult := runPodman(c.env.GetServerContext(), "pull", &container.Stdio{}, podmanArgs...)
 	if pullResult.Error != nil {
 		return pullResult.Error
 	}
@@ -687,7 +687,7 @@ func (c *podmanCommandContainer) Remove(ctx context.Context) error {
 	c.removed = true
 	c.mu.Unlock()
 	os.RemoveAll(c.cidFilePath()) // intentionally ignoring error.
-	res := runPodman(ctx, "kill", &container.ExecOpts{}, "--signal=KILL", c.name)
+	res := runPodman(ctx, "kill", &container.Stdio{}, "--signal=KILL", c.name)
 	if res.Error != nil {
 		return res.Error
 	}
@@ -698,7 +698,7 @@ func (c *podmanCommandContainer) Remove(ctx context.Context) error {
 }
 
 func (c *podmanCommandContainer) Pause(ctx context.Context) error {
-	res := runPodman(ctx, "pause", &container.ExecOpts{}, c.name)
+	res := runPodman(ctx, "pause", &container.Stdio{}, c.name)
 	if res.ExitCode != 0 {
 		return status.UnknownErrorf("podman pause failed: exit code %d, stderr: %s", res.ExitCode, string(res.Stderr))
 	}
@@ -706,7 +706,7 @@ func (c *podmanCommandContainer) Pause(ctx context.Context) error {
 }
 
 func (c *podmanCommandContainer) Unpause(ctx context.Context) error {
-	res := runPodman(ctx, "unpause", &container.ExecOpts{}, c.name)
+	res := runPodman(ctx, "unpause", &container.Stdio{}, c.name)
 	if res.Error != nil {
 		return res.Error
 	}
@@ -763,14 +763,14 @@ func (c *podmanCommandContainer) Stats(ctx context.Context) (*container.Stats, e
 	return &stats, nil
 }
 
-func runPodman(ctx context.Context, subCommand string, opts *container.ExecOpts, args ...string) *interfaces.CommandResult {
+func runPodman(ctx context.Context, subCommand string, stdio *container.Stdio, args ...string) *interfaces.CommandResult {
 	command := []string{
 		"podman",
 		subCommand,
 	}
 
 	command = append(command, args...)
-	result := commandutil.Run(ctx, &repb.Command{Arguments: command}, "" /*=workDir*/, opts)
+	result := commandutil.Run(ctx, &repb.Command{Arguments: command}, "" /*=workDir*/, stdio)
 	return result
 }
 
@@ -813,7 +813,7 @@ func removeImage(ctx context.Context, imageName string) error {
 	ctx, cancel := background.ExtendContextForFinalization(ctx, containerFinalizationTimeout)
 	defer cancel()
 
-	result := runPodman(ctx, "rmi", &container.ExecOpts{}, imageName)
+	result := runPodman(ctx, "rmi", &container.Stdio{}, imageName)
 	if result.Error != nil {
 		return result.Error
 	}
@@ -833,7 +833,7 @@ func ConfigureSecondaryNetwork(ctx context.Context) error {
 	// Hack: run a dummy podman container to setup default podman bridge network in ip route.
 	// "podman run --rm busybox sh". This should setup the following in ip route:
 	// "10.88.0.0/16 dev cni-podman0 proto kernel scope link src 10.88.0.1 linkdown"
-	result := runPodman(ctx, "run", &container.ExecOpts{}, "--rm", "busybox", "sh")
+	result := runPodman(ctx, "run", &container.Stdio{}, "--rm", "busybox", "sh")
 	if result.Error != nil {
 		return result.Error
 	}

--- a/enterprise/server/remote_execution/containers/podman/podman_test.go
+++ b/enterprise/server/remote_execution/containers/podman/podman_test.go
@@ -90,7 +90,7 @@ func TestHelloWorldExec(t *testing.T) {
 	err := podman.Create(ctx, "/work")
 	require.NoError(t, err)
 
-	result := podman.Exec(ctx, cmd, &container.ExecOpts{})
+	result := podman.Exec(ctx, cmd, &container.Stdio{})
 	assert.NoError(t, result.Error)
 
 	assert.Regexp(t, "^(/usr)?/bin/podman\\s", result.CommandDebugString, "sanity check: command should be run bare")
@@ -133,7 +133,7 @@ func TestExecStdio(t *testing.T) {
 	require.NoError(t, err)
 
 	var stdout, stderr bytes.Buffer
-	res := podman.Exec(ctx, cmd, &container.ExecOpts{
+	res := podman.Exec(ctx, cmd, &container.Stdio{
 		Stdin:  strings.NewReader("TestInput\n"),
 		Stdout: &stdout,
 		Stderr: &stderr,

--- a/enterprise/server/remote_execution/containers/sandbox/sandbox.go
+++ b/enterprise/server/remote_execution/containers/sandbox/sandbox.go
@@ -83,7 +83,7 @@ func NewRegexPath(expr string) sbxPath {
 }
 
 func runSimpleCommand(ctx context.Context, command []string) *interfaces.CommandResult {
-	return commandutil.Run(ctx, &repb.Command{Arguments: command}, "" /*=workDir*/, &container.ExecOpts{})
+	return commandutil.Run(ctx, &repb.Command{Arguments: command}, "" /*=workDir*/, &container.Stdio{})
 }
 
 func computeSandboxingSupported(ctx context.Context) bool {
@@ -276,7 +276,7 @@ func New(options *Options) container.CommandContainer {
 	}
 }
 
-func (c *sandbox) runCmdInSandbox(ctx context.Context, command *repb.Command, workDir string, opts *container.ExecOpts) *interfaces.CommandResult {
+func (c *sandbox) runCmdInSandbox(ctx context.Context, command *repb.Command, workDir string, stdio *container.Stdio) *interfaces.CommandResult {
 	result := &interfaces.CommandResult{
 		CommandDebugString: fmt.Sprintf("(sandbox) %s", command.GetArguments()),
 		ExitCode:           commandutil.NoExitCode,
@@ -301,12 +301,12 @@ func (c *sandbox) runCmdInSandbox(ctx context.Context, command *repb.Command, wo
 
 	sandboxCmd := proto.Clone(command).(*repb.Command)
 	sandboxCmd.Arguments = append([]string{sandboxExecBinary, "-f", sandboxConfigPath}, command.Arguments...)
-	result = commandutil.Run(ctx, sandboxCmd, workDir, opts)
+	result = commandutil.Run(ctx, sandboxCmd, workDir, stdio)
 	return result
 }
 
 func (c *sandbox) Run(ctx context.Context, command *repb.Command, workDir string, _ container.PullCredentials) *interfaces.CommandResult {
-	return c.runCmdInSandbox(ctx, command, workDir, &container.ExecOpts{})
+	return c.runCmdInSandbox(ctx, command, workDir, &container.Stdio{})
 }
 
 func (c *sandbox) Create(ctx context.Context, workDir string) error {
@@ -314,8 +314,8 @@ func (c *sandbox) Create(ctx context.Context, workDir string) error {
 	return nil
 }
 
-func (c *sandbox) Exec(ctx context.Context, cmd *repb.Command, opts *container.ExecOpts) *interfaces.CommandResult {
-	return c.runCmdInSandbox(ctx, cmd, c.WorkDir, opts)
+func (c *sandbox) Exec(ctx context.Context, cmd *repb.Command, stdio *container.Stdio) *interfaces.CommandResult {
+	return c.runCmdInSandbox(ctx, cmd, c.WorkDir, stdio)
 }
 
 func (c *sandbox) IsImageCached(ctx context.Context) (bool, error)                      { return false, nil }

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -370,7 +370,7 @@ func (r *commandRunner) Run(ctx context.Context) *interfaces.CommandResult {
 		return r.sendPersistentWorkRequest(ctx, command)
 	}
 
-	return r.Container.Exec(ctx, command, &container.ExecOpts{})
+	return r.Container.Exec(ctx, command, &container.Stdio{})
 }
 
 func (r *commandRunner) UploadOutputs(ctx context.Context, ioStats *repb.IOStats, actionResult *repb.ActionResult, cmdResult *interfaces.CommandResult) error {
@@ -488,7 +488,7 @@ func (r *commandRunner) cleanupCIRunner(ctx context.Context) error {
 	cleanupCmd := proto.Clone(r.task.GetCommand()).(*repb.Command)
 	cleanupCmd.Arguments = append(cleanupCmd.Arguments, "--shutdown_and_exit")
 
-	res := commandutil.Run(ctx, cleanupCmd, r.Workspace.Path(), &container.ExecOpts{})
+	res := commandutil.Run(ctx, cleanupCmd, r.Workspace.Path(), &container.Stdio{})
 	return res.Error
 }
 
@@ -1377,12 +1377,12 @@ func (r *commandRunner) startPersistentWorker(command *repb.Command, workerArgs,
 		defer stdinReader.Close()
 		defer stdoutWriter.Close()
 
-		opts := &container.ExecOpts{
+		stdio := &container.Stdio{
 			Stdin:  stdinReader,
 			Stdout: stdoutWriter,
 			Stderr: &r.stderr,
 		}
-		res := r.Container.Exec(ctx, command, opts)
+		res := r.Container.Exec(ctx, command, stdio)
 		log.Debugf("Persistent worker exited with response: %+v, flagFiles: %+v, workerArgs: %+v", res, flagFiles, workerArgs)
 	}()
 }


### PR DESCRIPTION
The original intent was just to hold 3 input/output streams, and this rename makes the intent more clear and will prevent more options creeping into this struct.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
