### PR TITLE
Allow Alias to do a no-op to the flags

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -51,7 +51,7 @@ var (
 	migrateFromDiskDir        = flag.String("cache.pebble.migrate_from_disk_dir", "", "If set, attempt to migrate this disk dir to a new pebble cache")
 	forceAllowMigration       = flag.Bool("cache.pebble.force_allow_migration", false, "If set, allow migrating into an existing pebble cache")
 	clearCacheBeforeMigration = flag.Bool("cache.pebble.clear_cache_before_migration", false, "If set, clear any existing cache content before migrating")
-	mirrorActiveDiskCache     = flagtypes.Alias[bool]("cache.pebble.mirror_active_disk_cache", "cache.disk.enable_live_updates")
+	mirrorActiveDiskCache     = flagtypes.Alias[bool]("cache.disk.enable_live_updates", "cache.pebble.mirror_active_disk_cache")
 )
 
 const (

--- a/server/util/flagutil/types/types.go
+++ b/server/util/flagutil/types/types.go
@@ -188,26 +188,31 @@ type FlagAlias struct {
 	name string
 }
 
-func Alias[T any](newName, name string) *T {
+// Alias defines a new name or names for the existing flag at the passed name
+// and returns a pointer to the data backing it. If no new names are passed,
+// Alias simply returns said pointer without creating any new alias flags.
+func Alias[T any](name string, newNames ...string) *T {
 	f := &FlagAlias{name: name}
 	var flg *flag.Flag
 	for aliaser, ok := common.IsNameAliasing(f), true; ok; aliaser, ok = flg.Value.(common.IsNameAliasing) {
 		if flg = common.DefaultFlagSet.Lookup(aliaser.AliasedName()); flg == nil {
-			log.Fatalf("Error aliasing flag %s as %s: flag %s does not exist.", name, newName, aliaser.AliasedName())
+			log.Fatalf("Error aliasing flag %s as %s: flag %s does not exist.", name, strings.Join(newNames, ", "), aliaser.AliasedName())
 		}
 	}
 	addr := reflect.ValueOf(flg.Value)
 	if t, err := common.GetTypeForFlagValue(flg.Value); err == nil {
 		if !addr.CanConvert(t) {
-			log.Fatalf("Error aliasing flag %s as %s: Flag %s of type %T could not be converted to %s.", name, newName, flg.Name, flg.Value, t)
+			log.Fatalf("Error aliasing flag %s as %s: Flag %s of type %T could not be converted to %s.", name, strings.Join(newNames, ", "), flg.Name, flg.Value, t)
 		}
 		addr = addr.Convert(t)
 	}
 	value, ok := addr.Interface().(*T)
 	if !ok {
-		log.Fatalf("Error aliasing flag %s as %s: Failed to assert flag %s of type %T as type %T.", name, newName, flg.Name, flg.Value, (*T)(nil))
+		log.Fatalf("Error aliasing flag %s as %s: Failed to assert flag %s of type %T as type %T.", name, strings.Join(newNames, ", "), flg.Name, flg.Value, (*T)(nil))
 	}
-	common.DefaultFlagSet.Var(f, newName, "Alias for "+name)
+	for _, newName := range newNames {
+		common.DefaultFlagSet.Var(f, newName, "Alias for "+name)
+	}
 	return value
 }
 

--- a/server/util/flagutil/types/types_test.go
+++ b/server/util/flagutil/types/types_test.go
@@ -163,8 +163,8 @@ func TestProtoSliceFlag(t *testing.T) {
 func TestFlagAlias(t *testing.T) {
 	flags := replaceFlagsForTesting(t)
 	s := flags.String("string", "test", "")
-	as := Alias[string]("string_alias", "string")
-	aas := Alias[string]("string_alias_alias", "string_alias")
+	as := Alias[string]("string", "string_alias")
+	aas := Alias[string]("string_alias", "string_alias_alias")
 	assert.Equal(t, *s, "test")
 	assert.Equal(t, s, as)
 	assert.Equal(t, as, aas)
@@ -195,12 +195,15 @@ func TestFlagAlias(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, reflect.TypeOf((*string)(nil)), aasfYAMLType)
 
+	p := Alias[string]("string_alias_alias")
+	assert.Equal(t, aas, p)
+
 	flags = replaceFlagsForTesting(t)
 
 	flagString := flags.String("string", "test", "")
-	Alias[string]("string_alias", "string")
-	Alias[string]("string_alias2", "string")
-	Alias[string]("string_alias3", "string")
+	Alias[string]("string", "string_alias")
+	Alias[string]("string", "string_alias2")
+	Alias[string]("string", "string_alias3")
 	yamlData := `
 string: "woof"
 string_alias2: "moo"
@@ -214,9 +217,9 @@ string_alias: "meow"
 	flags = replaceFlagsForTesting(t)
 
 	flagStringSlice := Slice("string_slice", []string{"test"}, "")
-	Alias[[]string]("string_slice_alias", "string_slice")
-	Alias[[]string]("string_slice_alias2", "string_slice")
-	Alias[[]string]("string_slice_alias3", "string_slice")
+	Alias[[]string]("string_slice", "string_slice_alias")
+	Alias[[]string]("string_slice", "string_slice_alias2")
+	Alias[[]string]("string_slice", "string_slice_alias3")
 	flags.Set("string_slice", "squeak")
 	yamlData = `
 string_slice:
@@ -236,7 +239,7 @@ string_slice_alias:
 	flags = replaceFlagsForTesting(t)
 
 	flagString = flags.String("string", "test", "")
-	Alias[string]("string_alias", "string")
+	Alias[string]("string", "string_alias")
 	yamlData = `
 string_alias: "meow"
 `
@@ -247,7 +250,7 @@ string_alias: "meow"
 	flags = replaceFlagsForTesting(t)
 
 	flagString = flags.String("string", "test", "")
-	Alias[string]("string_alias", "string")
+	Alias[string]("string", "string_alias")
 	flags.Set("string", "moo")
 	yamlData = `
 string_alias: "meow"
@@ -259,7 +262,7 @@ string_alias: "meow"
 	flags = replaceFlagsForTesting(t)
 
 	flagString = flags.String("string", "test", "")
-	Alias[string]("string_alias", "string")
+	Alias[string]("string", "string_alias")
 	flags.Set("string_alias", "moo")
 	yamlData = `
 string: "meow"
@@ -271,7 +274,7 @@ string: "meow"
 	flags = replaceFlagsForTesting(t)
 
 	flagString = flags.String("string", "test", "")
-	Alias[string]("string_alias", "string")
+	Alias[string]("string", "string_alias")
 	flags.Set("string_alias", "moo")
 	yamlData = `
 string_alias: "meow"
@@ -282,14 +285,14 @@ string_alias: "meow"
 
 	flags = replaceFlagsForTesting(t)
 	flagString = flags.String("string", "2", "")
-	Alias[string]("string_alias", "string")
+	Alias[string]("string", "string_alias")
 	err = common.SetValueForFlagName("string_alias", "1", map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, "1", *flagString)
 
 	flags = replaceFlagsForTesting(t)
 	flagString = flags.String("string", "2", "")
-	Alias[string]("string_alias", "string")
+	Alias[string]("string", "string_alias")
 	err = common.SetValueForFlagName("string_alias", "1", map[string]struct{}{"string": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, "2", *flagString)
@@ -299,28 +302,28 @@ string_alias: "meow"
 	string_slice[0] = "1"
 	string_slice[1] = "2"
 	SliceVar(&string_slice, "string_slice", "")
-	Alias[[]string]("string_slice_alias", "string_slice")
+	Alias[[]string]("string_slice", "string_slice_alias")
 	err = common.SetValueForFlagName("string_slice_alias", []string{"3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, string_slice)
 
 	flags = replaceFlagsForTesting(t)
 	flagStringSlice = Slice("string_slice", []string{"1", "2"}, "")
-	Alias[[]string]("string_slice_alias", "string_slice")
+	Alias[[]string]("string_slice", "string_slice_alias")
 	err = common.SetValueForFlagName("string_slice_alias", []string{"3"}, map[string]struct{}{"string_slice": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2", "3"}, *flagStringSlice)
 
 	flags = replaceFlagsForTesting(t)
 	flagStringSlice = Slice("string_slice", []string{"1", "2"}, "")
-	Alias[[]string]("string_slice_alias", "string_slice")
+	Alias[[]string]("string_slice", "string_slice_alias")
 	err = common.SetValueForFlagName("string_slice_alias", []string{"3"}, map[string]struct{}{}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"3"}, *flagStringSlice)
 
 	flags = replaceFlagsForTesting(t)
 	flagStringSlice = Slice("string_slice", []string{"1", "2"}, "")
-	Alias[[]string]("string_slice_alias", "string_slice")
+	Alias[[]string]("string_slice", "string_slice_alias")
 	err = common.SetValueForFlagName("string_slice_alias", []string{"3"}, map[string]struct{}{"string_slice": {}}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, *flagStringSlice)
@@ -330,32 +333,32 @@ string_alias: "meow"
 	string_slice[0] = "1"
 	string_slice[1] = "2"
 	SliceVar(&string_slice, "string_slice", "")
-	Alias[[]string]("string_slice_alias", "string_slice")
-	Alias[[]string]("string_slice_alias_alias", "string_slice_alias")
+	Alias[[]string]("string_slice", "string_slice_alias")
+	Alias[[]string]("string_slice_alias", "string_slice_alias_alias")
 	err = common.SetValueForFlagName("string_slice_alias_alias", []string{"3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, string_slice)
 
 	flags = replaceFlagsForTesting(t)
 	flagStringSlice = Slice("string_slice", []string{"1", "2"}, "")
-	Alias[[]string]("string_slice_alias", "string_slice")
-	Alias[[]string]("string_slice_alias_alias", "string_slice_alias")
+	Alias[[]string]("string_slice", "string_slice_alias")
+	Alias[[]string]("string_slice_alias", "string_slice_alias_alias")
 	err = common.SetValueForFlagName("string_slice_alias_alias", []string{"3"}, map[string]struct{}{"string_slice": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2", "3"}, *flagStringSlice)
 
 	flags = replaceFlagsForTesting(t)
 	flagStringSlice = Slice("string_slice", []string{"1", "2"}, "")
-	Alias[[]string]("string_slice_alias", "string_slice")
-	Alias[[]string]("string_slice_alias_alias", "string_slice_alias")
+	Alias[[]string]("string_slice", "string_slice_alias")
+	Alias[[]string]("string_slice_alias", "string_slice_alias_alias")
 	err = common.SetValueForFlagName("string_slice_alias_alias", []string{"3"}, map[string]struct{}{}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"3"}, *flagStringSlice)
 
 	flags = replaceFlagsForTesting(t)
 	flagStringSlice = Slice("string_slice", []string{"1", "2"}, "")
-	Alias[[]string]("string_slice_alias", "string_slice")
-	Alias[[]string]("string_slice_alias_alias", "string_slice_alias")
+	Alias[[]string]("string_slice", "string_slice_alias")
+	Alias[[]string]("string_slice_alias", "string_slice_alias_alias")
 	err = common.SetValueForFlagName("string_slice_alias_alias", []string{"3"}, map[string]struct{}{"string_slice": {}}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, *flagStringSlice)
@@ -366,12 +369,12 @@ string_alias: "meow"
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, stringSlice)
 
-	_ = Alias[[]string]("string_slice_alias", "string_slice")
+	_ = Alias[[]string]("string_slice", "string_slice_alias")
 	stringSliceAlias, err := common.GetDereferencedValue[[]string]("string_slice_alias")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, stringSliceAlias)
 
-	_ = Alias[[]string]("string_slice_alias_alias", "string_slice_alias")
+	_ = Alias[[]string]("string_slice_alias", "string_slice_alias_alias")
 	stringSliceAliasAlias, err := common.GetDereferencedValue[[]string]("string_slice_alias_alias")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, stringSliceAliasAlias)


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Now if someone wants to use the Alias function to access a flag in a place that it isn't defined, they are no longer forced to declare a new alias for the flag.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
