### PR TITLE
Define metrics for GRPC by group id.

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -121,6 +121,12 @@ const (
 
 	/// Status of the task size write request: `ok`, `missing_stats` or `error`.
 	TaskSizeWriteStatusLabel = "status"
+
+	// The full name of the grpc method: /<service>/<method>
+	GRPCFullMethodLabel = "grpc_full_method"
+
+	// The key used for quota accounting. It's either a group ID or an ip address.
+	QuotaKey = "quota_key"
 )
 
 const (
@@ -1308,5 +1314,15 @@ var (
 		Help:      "Counter for unexpected events.",
 	}, []string{
 		EventName,
+	})
+
+	RPCsHandledTotalByQuotaKey = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "quota",
+		Name:      "rpcs_handled_total_by_quota_key",
+		Help:      "Total number of RPCs completed on the server by quota_key, regardless of success or failure.",
+	}, []string{
+		GRPCFullMethodLabel,
+		QuotaKey,
 	})
 )

--- a/server/rpc/filters/BUILD
+++ b/server/rpc/filters/BUILD
@@ -7,8 +7,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/environment",
+        "//server/metrics",
         "//server/role_filter",
         "//server/util/log",
+        "//server/util/quota",
         "//server/util/request_context",
         "//server/util/uuid",
         "@com_github_grpc_ecosystem_go_grpc_prometheus//:go-grpc-prometheus",


### PR DESCRIPTION
This allows us to figure out a sensible default quota.

Add rpc intercepters to record the metrics.
