### PR TITLE
Write cache scorecard under attempt-specific directory

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -250,7 +250,7 @@ func (r *statsRecorder) handleTask(ctx context.Context, task *recordStatsTask) {
 	}
 	if sc := hit_tracker.ScoreCard(ctx, r.env, task.invocationJWT.id); sc != nil {
 		scorecard.FillBESMetadata(sc, task.files)
-		if err := scorecard.Write(ctx, r.env, task.invocationJWT.id, sc); err != nil {
+		if err := scorecard.Write(ctx, r.env, task.invocationJWT.id, task.invocationJWT.attempt, sc); err != nil {
 			log.Errorf("Error writing scorecard blob: %s", err)
 		}
 	}
@@ -1045,7 +1045,7 @@ func LookupInvocation(env environment.Env, ctx context.Context, iid string) (*in
 			if ti.InvocationStatus == int64(inpb.Invocation_PARTIAL_INVOCATION_STATUS) {
 				scoreCard = hit_tracker.ScoreCard(ctx, env, iid)
 			} else {
-				sc, err := scorecard.Read(ctx, env, iid)
+				sc, err := scorecard.Read(ctx, env, iid, ti.Attempt)
 				if err != nil {
 					log.Warningf("Failed to read scorecard for invocation %s: %s", iid, err)
 				} else {

--- a/server/remote_cache/scorecard/scorecard.go
+++ b/server/remote_cache/scorecard/scorecard.go
@@ -324,9 +324,7 @@ func FillBESMetadata(sc *capb.ScoreCard, files map[string]*bespb.File) {
 }
 
 // Read reads the invocation cache scorecard from the configured blobstore.
-func Read(
-	ctx context.Context, env environment.Env, invocationID string, invocationAttempt uint64,
-) (*capb.ScoreCard, error) {
+func Read(ctx context.Context, env environment.Env, invocationID string, invocationAttempt uint64) (*capb.ScoreCard, error) {
 	blobStore := env.GetBlobstore()
 	buf, err := blobStore.ReadBlob(ctx, blobName(invocationID, invocationAttempt))
 	if err != nil && status.IsNotFoundError(err) {
@@ -347,13 +345,7 @@ func Read(
 }
 
 // Write writes the invocation cache scorecard to the configured blobstore.
-func Write(
-	ctx context.Context,
-	env environment.Env,
-	invocationID string,
-	invocationAttempt uint64,
-	scoreCard *capb.ScoreCard,
-) error {
+func Write(ctx context.Context, env environment.Env, invocationID string, invocationAttempt uint64, scoreCard *capb.ScoreCard) error {
 	scoreCardBuf, err := proto.Marshal(scoreCard)
 	if err != nil {
 		return err

--- a/server/remote_cache/scorecard/scorecard.go
+++ b/server/remote_cache/scorecard/scorecard.go
@@ -2,6 +2,7 @@ package scorecard
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -32,7 +33,7 @@ var (
 // GetCacheScoreCard returns a list of detailed, per-request cache stats.
 func GetCacheScoreCard(ctx context.Context, env environment.Env, req *capb.GetCacheScoreCardRequest) (*capb.GetCacheScoreCardResponse, error) {
 	// Authorize access to the requested invocation
-	_, err := env.GetInvocationDB().LookupInvocation(ctx, req.GetInvocationId())
+	invocation, err := env.GetInvocationDB().LookupInvocation(ctx, req.GetInvocationId())
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +50,7 @@ func GetCacheScoreCard(ctx context.Context, env environment.Env, req *capb.GetCa
 		return nil, status.InvalidArgumentError("invalid page token")
 	}
 
-	scorecard, err := Read(ctx, env, req.InvocationId)
+	scorecard, err := Read(ctx, env, req.InvocationId, invocation.Attempt)
 	if err != nil {
 		return nil, err
 	}
@@ -259,9 +260,16 @@ func sortResults(results []*capb.ScoreCard_Result, opts *sortOpts) {
 	})
 }
 
-func blobName(invocationID string) string {
+func blobName(invocationID string, invocationAttempt uint64) string {
 	// WARNING: Things will break if this is changed, because we use this name
 	// to lookup data from historical invocations.
+	blobFileName := "scorecard.pb"
+	return filepath.Join(invocationID, fmt.Sprint(invocationAttempt), blobFileName)
+}
+
+// blobNameDeprecated returns a deprecated cache scorecard file name
+// This may be needed to lookup data from historical invocations that used the deprecated naming
+func blobNameDeprecated(invocationID string) string {
 	blobFileName := invocationID + "-scorecard.pb"
 	return filepath.Join(invocationID, blobFileName)
 }
@@ -316,12 +324,21 @@ func FillBESMetadata(sc *capb.ScoreCard, files map[string]*bespb.File) {
 }
 
 // Read reads the invocation cache scorecard from the configured blobstore.
-func Read(ctx context.Context, env environment.Env, invocationID string) (*capb.ScoreCard, error) {
+func Read(
+	ctx context.Context, env environment.Env, invocationID string, invocationAttempt uint64,
+) (*capb.ScoreCard, error) {
 	blobStore := env.GetBlobstore()
-	buf, err := blobStore.ReadBlob(ctx, blobName(invocationID))
-	if err != nil {
+	buf, err := blobStore.ReadBlob(ctx, blobName(invocationID, invocationAttempt))
+	if err != nil && status.IsNotFoundError(err) {
+		// Try reading from deprecated file name for older files that were written before the naming changed
+		buf, err = blobStore.ReadBlob(ctx, blobNameDeprecated(invocationID))
+		if err != nil {
+			return nil, err
+		}
+	} else if err != nil {
 		return nil, err
 	}
+
 	sc := &capb.ScoreCard{}
 	if err := proto.Unmarshal(buf, sc); err != nil {
 		return nil, err
@@ -330,12 +347,18 @@ func Read(ctx context.Context, env environment.Env, invocationID string) (*capb.
 }
 
 // Write writes the invocation cache scorecard to the configured blobstore.
-func Write(ctx context.Context, env environment.Env, invocationID string, scoreCard *capb.ScoreCard) error {
+func Write(
+	ctx context.Context,
+	env environment.Env,
+	invocationID string,
+	invocationAttempt uint64,
+	scoreCard *capb.ScoreCard,
+) error {
 	scoreCardBuf, err := proto.Marshal(scoreCard)
 	if err != nil {
 		return err
 	}
 	blobStore := env.GetBlobstore()
-	_, err = blobStore.WriteBlob(ctx, blobName(invocationID), scoreCardBuf)
+	_, err = blobStore.WriteBlob(ctx, blobName(invocationID, invocationAttempt), scoreCardBuf)
 	return err
 }


### PR DESCRIPTION
Fixes buildbuddy-io/buildbuddy-internal#1287