### PR TITLE
Fix data race in RemoveConnectedExecutor

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -538,8 +538,7 @@ func (np *nodePool) RemoveConnectedExecutor(id string) bool {
 	defer np.mu.Unlock()
 	for i, e := range np.connectedExecutors {
 		if e.executorID == id {
-			np.connectedExecutors[i] = np.connectedExecutors[len(np.connectedExecutors)-1]
-			np.connectedExecutors = np.connectedExecutors[:len(np.connectedExecutors)-1]
+			np.connectedExecutors = append(np.connectedExecutors[:i], np.connectedExecutors[i+1:]...)
 			return true
 		}
 	}


### PR DESCRIPTION
`GetNodes()` returns a reference to `np.connectedExecutors` which is then read in `enqueueTaskReservations` (e.g. `toNodeInterfaces(nodes)`. `RemoveConnectedExecutor()` can concurrently mutate that slice though in order to remove an executor. The fix is to remove executors by creating a new slice, rather than mutating its contents.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
