### PR TITLE
Add protos for stream-based Firecracker execution

### DIFF
--- a/enterprise/server/vmexec/vmexec.go
+++ b/enterprise/server/vmexec/vmexec.go
@@ -117,17 +117,6 @@ func (x *execServer) Exec(ctx context.Context, req *vmxpb.ExecRequest) (*vmxpb.E
 		cmd.Dir = req.GetWorkingDirectory()
 	}
 
-	// TODO(tylerw): implement this.
-	if req.GetStdinVsockPort() != 0 {
-		return nil, status.UnimplementedError("Vsock stdin not implemented")
-	}
-	if req.GetStdoutVsockPort() != 0 {
-		return nil, status.UnimplementedError("Vsock stdout not implemented")
-	}
-	if req.GetStderrVsockPort() != 0 {
-		return nil, status.UnimplementedError("Vsock stderr not implemented")
-	}
-
 	// TODO(tylerw): use syncfs or something better here.
 	defer unix.Sync()
 
@@ -151,4 +140,8 @@ func (x *execServer) Exec(ctx context.Context, req *vmxpb.ExecRequest) (*vmxpb.E
 	rsp.Stdout = stdoutBuf.Bytes()
 	rsp.Stderr = stderrBuf.Bytes()
 	return rsp, nil
+}
+
+func (x *execServer) ExecStreamed(stream vmxpb.Exec_ExecStreamedServer) error {
+	return status.UnimplementedError("not implemented")
 }

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -209,6 +209,7 @@ proto_library(
     name = "vmexec_proto",
     srcs = ["vmexec.proto"],
     deps = [
+        ":remote_execution_proto",
         "@com_google_protobuf//:duration_proto",
         "@go_googleapis//google/rpc:status_proto",
     ],
@@ -573,6 +574,7 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/vmexec",
     proto = ":vmexec_proto",
     deps = [
+        ":remote_execution_go_proto",
         "@go_googleapis//google/rpc:status_go_proto",
     ],
 )

--- a/proto/vmexec.proto
+++ b/proto/vmexec.proto
@@ -4,12 +4,19 @@ package vmexec;
 
 import "google/protobuf/duration.proto";
 import "google/rpc/status.proto";
+import "proto/remote_execution.proto";
 
 // The exec service is run from inside a VM. The host uses this service to
 // execute commands as well as prepare the VM for command execution.
 service Exec {
   // Executes a command in the VM and returns the result of execution.
   rpc Exec(ExecRequest) returns (ExecResponse);
+
+  // Executes a command in the VM and streams back command progress.
+  // TODO(bduffany): Once this is implemented, rename this to Exec
+  // and delete the old Exec() function.
+  rpc ExecStreamed(stream ExecStreamedRequest)
+      returns (stream ExecStreamedResponse);
 
   // Prepares the VM for command execution after a fresh start or a resume.
   rpc Initialize(InitializeRequest) returns (InitializeResponse);
@@ -42,17 +49,17 @@ message ExecRequest {
   // executable.
   repeated string arguments = 3;
 
-  // Optional. Ports are vsock ports where the host will read/write stdin,
-  // stdout, and stderr. If unset, or set to 0, input will be ignored and
-  // output will be buffered and returned in the ExecResponse.
-  int32 stdin_vsock_port = 4;
-  int32 stdout_vsock_port = 5;
-  int32 stderr_vsock_port = 6;
+  reserved 4, 5, 6;
 
   // An explicit timeout for the action. This is used instead of a request
   // context deadline so that we can return partial command outputs in the
   // ExecResponse.
   google.protobuf.Duration timeout = 7;
+
+  // Whether to open a pipe for stdin. This needs to be specified when starting
+  // the command, because commands can behave differently depending on whether
+  // or not stdin is attached.
+  bool open_stdin = 8;
 }
 
 message ExecResponse {
@@ -60,6 +67,52 @@ message ExecResponse {
   bytes stdout = 2;
   bytes stderr = 3;
   google.rpc.Status status = 4;
+}
+
+message ExecStreamedRequest {
+  // Only one of these fields should be set. oneof is not used due to awkward Go
+  // APIs.
+
+  // Begins command execution. When there is no stdin to be sent, clients
+  // should close their end of the stream after sending this message.
+  ExecRequest start = 1;
+
+  // Bytes to be written to stdin of the executed process. In order to use
+  // this field, `open_stdin` must be set in the initial start request,
+  // otherwise execution will be canceled and an INTERNAL error will be
+  // returned. Clients should close their end of the stream once there is no
+  // more input to be sent (this will close the stdin pipe).
+  bytes stdin = 2;
+}
+
+message ExecStreamedResponse {
+  // Only one of these fields should be set. oneof is not used due to awkward Go
+  // APIs.
+
+  // Overall result of the command's execution. This is not guaranteed to be
+  // the last message in the stream, so clients should continue to receive
+  // from the stream until it is closed, even after receiving this message.
+  // For example, the server may send this immediately when the process is
+  // closed, and send any remaining buffered stdout or stderr afterwards.
+  ExecResponse response = 1;
+
+  // Incremental bytes received from stdout of the executed process. This will
+  // be delivered in the same order in which it was received from the executed
+  // process' stdout stream. The relative ordering of stdout vs. stderr is not
+  // guaranteed.
+  bytes stdout = 2;
+
+  // Incremental bytes received from the stderr of the executed process. This
+  // will be delivered in the same order in which it was received from the
+  // executed process' stderr stream. The relative ordering of stdout vs.
+  // stderr is not guaranteed.
+  bytes stderr = 3;
+
+  // Latest sampled usage stats from the command being executed. This may be
+  // delivered multiple times, and is **not** guaranteed to be delivered at
+  // least once (for example, if the command completes execution too quickly
+  // to collect meaningful stats, this may not be delivered).
+  build.bazel.remote.execution.v2.UsageStats usage_stats = 4;
 }
 
 message InitializeRequest {


### PR DESCRIPTION
This will be useful for:
- Stats (immediate use case): allows us to stream stats and live-update prometheus metrics while the task is running.
- Stdio: allows us to stream stdin and stdout/stderr, so we no longer have to worry about grpc max size restricting the amount of stdout/stderr we can receive.
- Persistent workers: firecracker-based persistent workers require stdin streaming, since we need to stream tasks one-by-one as each task comes in.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
