### PR TITLE
Add support for CAS-only API keys

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -254,7 +254,9 @@ export default class InvocationModel {
     return this.invocations
       .find(() => true)
       ?.createdWithCapabilities?.some(
-        (existingCapability) => existingCapability == api_key.ApiKey.Capability.CACHE_WRITE_CAPABILITY
+        (existingCapability) =>
+          existingCapability == api_key.ApiKey.Capability.CACHE_WRITE_CAPABILITY ||
+          existingCapability == api_key.ApiKey.Capability.CAS_WRITE_CAPABILITY
       );
   }
 

--- a/enterprise/app/api_keys/api_keys.css
+++ b/enterprise/app/api_keys/api_keys.css
@@ -150,7 +150,8 @@
   user-select: none;
 }
 
-.api-keys-form input[type="checkbox"] {
+.api-keys-form input[type="checkbox"],
+.api-keys-form input[type="radio"] {
   width: 20px;
   height: 20px;
   flex-shrink: 0;

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -168,7 +168,7 @@ func (c *Claims) IsAdmin() bool {
 
 func (c *Claims) HasCapability(cap akpb.ApiKey_Capability) bool {
 	for _, cc := range c.Capabilities {
-		if cap & cc > 0 {
+		if cap&cc > 0 {
 			return true
 		}
 	}

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -168,7 +168,7 @@ func (c *Claims) IsAdmin() bool {
 
 func (c *Claims) HasCapability(cap akpb.ApiKey_Capability) bool {
 	for _, cc := range c.Capabilities {
-		if cap == cc {
+		if cap & cc > 0 {
 			return true
 		}
 	}

--- a/proto/api_key.proto
+++ b/proto/api_key.proto
@@ -27,6 +27,8 @@ message ApiKey {
     CACHE_WRITE_CAPABILITY = 1;  // 2^0
     // Allows registering an executor with the scheduler.
     REGISTER_EXECUTOR_CAPABILITY = 2;  // 2^1
+    // Allows writing to the content-addressable store only.
+    CAS_WRITE_CAPABILITY = 4;  // 2^2
   }
 
   // Capabilities associated with this API key.

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -318,11 +318,7 @@ func (w *writeState) Commit() error {
 func (s *ByteStreamServer) Write(stream bspb.ByteStream_WriteServer) error {
 	ctx := stream.Context()
 
-	canWriteAll, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CACHE_WRITE_CAPABILITY)
-	if err != nil {
-		return err
-	}
-	canWriteCAS, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CAS_WRITE_CAPABILITY)
+	canWrite, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CACHE_WRITE_CAPABILITY | akpb.ApiKey_CAS_WRITE_CAPABILITY)
 	if err != nil {
 		return err
 	}
@@ -343,7 +339,7 @@ func (s *ByteStreamServer) Write(stream bspb.ByteStream_WriteServer) error {
 			}
 
 			// If the API key is read-only, pretend the object already exists.
-			if !canWriteAll && !canWriteCAS {
+			if !canWrite {
 				return s.handleAlreadyExists(ctx, stream, req)
 			}
 			streamState, err = s.initStreamState(ctx, req)

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -318,7 +318,11 @@ func (w *writeState) Commit() error {
 func (s *ByteStreamServer) Write(stream bspb.ByteStream_WriteServer) error {
 	ctx := stream.Context()
 
-	canWrite, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CACHE_WRITE_CAPABILITY)
+	canWriteAll, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CACHE_WRITE_CAPABILITY)
+	if err != nil {
+		return err
+	}
+	canWriteCAS, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CAS_WRITE_CAPABILITY)
 	if err != nil {
 		return err
 	}
@@ -339,7 +343,7 @@ func (s *ByteStreamServer) Write(stream bspb.ByteStream_WriteServer) error {
 			}
 
 			// If the API key is read-only, pretend the object already exists.
-			if !canWrite {
+			if !canWriteAll && !canWriteCAS {
 				return s.handleAlreadyExists(ctx, stream, req)
 			}
 			streamState, err = s.initStreamState(ctx, req)

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -318,7 +318,7 @@ func (w *writeState) Commit() error {
 func (s *ByteStreamServer) Write(stream bspb.ByteStream_WriteServer) error {
 	ctx := stream.Context()
 
-	canWrite, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CACHE_WRITE_CAPABILITY | akpb.ApiKey_CAS_WRITE_CAPABILITY)
+	canWrite, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CACHE_WRITE_CAPABILITY|akpb.ApiKey_CAS_WRITE_CAPABILITY)
 	if err != nil {
 		return err
 	}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -154,7 +154,7 @@ func (s *ContentAddressableStorageServer) BatchUpdateBlobs(ctx context.Context, 
 		return nil, err
 	}
 
-	canWrite, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CACHE_WRITE_CAPABILITY | akpb.ApiKey_CAS_WRITE_CAPABILITY)
+	canWrite, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CACHE_WRITE_CAPABILITY|akpb.ApiKey_CAS_WRITE_CAPABILITY)
 	if err != nil {
 		return nil, err
 	}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -154,11 +154,15 @@ func (s *ContentAddressableStorageServer) BatchUpdateBlobs(ctx context.Context, 
 		return nil, err
 	}
 
-	canWrite, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CACHE_WRITE_CAPABILITY)
+	canWriteAll, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CACHE_WRITE_CAPABILITY)
 	if err != nil {
 		return nil, err
 	}
-	if !canWrite {
+	canWriteCAS, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CAS_WRITE_CAPABILITY)
+	if err != nil {
+		return nil, err
+	}
+	if !canWriteAll && !canWriteCAS {
 		// For read-only API keys, pretend the write succeeded.
 		for _, uploadRequest := range req.Requests {
 			rsp.Responses = append(rsp.Responses, &repb.BatchUpdateBlobsResponse_Response{

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -154,15 +154,11 @@ func (s *ContentAddressableStorageServer) BatchUpdateBlobs(ctx context.Context, 
 		return nil, err
 	}
 
-	canWriteAll, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CACHE_WRITE_CAPABILITY)
+	canWrite, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CACHE_WRITE_CAPABILITY | akpb.ApiKey_CAS_WRITE_CAPABILITY)
 	if err != nil {
 		return nil, err
 	}
-	canWriteCAS, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CAS_WRITE_CAPABILITY)
-	if err != nil {
-		return nil, err
-	}
-	if !canWriteAll && !canWriteCAS {
+	if !canWrite {
 		// For read-only API keys, pretend the write succeeded.
 		for _, uploadRequest := range req.Requests {
 			rsp.Responses = append(rsp.Responses, &repb.BatchUpdateBlobsResponse_Response{

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -61,7 +61,7 @@ func (c *TestUser) GetCapabilities() []akpb.ApiKey_Capability          { return 
 func (c *TestUser) IsAdmin() bool                                      { return false }
 func (c *TestUser) HasCapability(cap akpb.ApiKey_Capability) bool {
 	for _, cc := range c.Capabilities {
-		if cap == cc {
+		if cap & cc > 0 {
 			return true
 		}
 	}

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -61,7 +61,7 @@ func (c *TestUser) GetCapabilities() []akpb.ApiKey_Capability          { return 
 func (c *TestUser) IsAdmin() bool                                      { return false }
 func (c *TestUser) HasCapability(cap akpb.ApiKey_Capability) bool {
 	for _, cc := range c.Capabilities {
-		if cap & cc > 0 {
+		if cap&cc > 0 {
 			return true
 		}
 	}


### PR DESCRIPTION
This API key type allows users of this key to upload to the CAS, but not the Action Cache.

This allows users to use an API key that restricts them from poisoning / tampering with the remote cache via the Action Cache, but allows them to still upload timing profiles and test logs. CAS uploading is less prone to issues because we validate the SHAs of the content on upload, and artifacts are stored keyed on their SHA.

This also pairs nicely with remote execution, where users can upload inputs to the CAS (where again their SHAs are validated) - but only the trusted remote executors can populate the AC. 

<img width="595" alt="Screen Shot 2022-07-12 at 2 52 18 PM" src="https://user-images.githubusercontent.com/1704556/178601874-de5832e7-3797-4df2-b833-3784fee0c0c0.png">

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
