### PR TITLE
Task sizing: Add isolation type label to sizer metrics

### DIFF
--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -122,6 +122,7 @@ func (s *taskSizer) Estimate(ctx context.Context, task *repb.ExecutionTask) *scp
 	defer func() {
 		metrics.RemoteExecutionTaskSizeReadRequests.With(prometheus.Labels{
 			metrics.TaskSizeReadStatusLabel: statusLabel,
+			metrics.IsolationTypeLabel:      props.WorkloadIsolationType,
 		}).Inc()
 	}()
 	recordedSize, err := s.lastRecordedSize(ctx, task)
@@ -149,8 +150,10 @@ func (s *taskSizer) Update(ctx context.Context, cmd *repb.Command, md *repb.Exec
 	}
 	statusLabel := "ok"
 	defer func() {
+		props := platform.ParseProperties(&repb.ExecutionTask{Command: cmd})
 		metrics.RemoteExecutionTaskSizeWriteRequests.With(prometheus.Labels{
 			metrics.TaskSizeWriteStatusLabel: statusLabel,
+			metrics.IsolationTypeLabel:       props.WorkloadIsolationType,
 		}).Inc()
 	}()
 	// If we are missing CPU/memory stats, do nothing. This is expected in some

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -465,6 +465,7 @@ var (
 		Help:      "Number of read requests to the task sizer, which estimates action resource usage based on historical execution stats.",
 	}, []string{
 		TaskSizeReadStatusLabel,
+		IsolationTypeLabel,
 	})
 
 	RemoteExecutionTaskSizeWriteRequests = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -474,6 +475,7 @@ var (
 		Help:      "Number of write requests to the task sizer, which estimates action resource usage based on historical execution stats.",
 	}, []string{
 		TaskSizeWriteStatusLabel,
+		IsolationTypeLabel,
 	})
 
 	RemoteExecutionWaitingExecutionResult = promauto.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
This will let us split the sizer charts by isolation type, so we can see how many of the hits/misses are coming from Mac vs Linux executors.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
