### PR TITLE
Scan and delete

### DIFF
--- a/enterprise/server/backends/pebble_cache/BUILD
+++ b/enterprise/server/backends/pebble_cache/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//server/interfaces",
         "//server/metrics",
         "//server/remote_cache/digest",
+        "//server/util/alert",
         "//server/util/disk",
         "//server/util/flagutil/types",
         "//server/util/log",
@@ -36,6 +37,8 @@ go_test(
     shard_count = 8,
     deps = [
         ":pebble_cache",
+        "//enterprise/server/raft/constants",
+        "//proto:raft_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/backends/disk_cache",
         "//server/environment",
@@ -48,6 +51,9 @@ go_test(
         "//server/util/disk",
         "//server/util/log",
         "//server/util/prefix",
+        "//server/util/status",
+        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//proto",
     ],
 )

--- a/enterprise/server/backends/pebble_cache/BUILD
+++ b/enterprise/server/backends/pebble_cache/BUILD
@@ -52,6 +52,7 @@ go_test(
         "//server/util/log",
         "//server/util/prefix",
         "//server/util/status",
+        "//server/util/testing/flags",
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//proto",

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -378,7 +378,7 @@ func (p *PebbleCache) deleteOrphanedFiles(quitChan chan struct{}) {
 					if err != nil {
 						return err
 					}
-					log.Printf("Would delete orphaned file: %s (last modified: %s) which is not in cache", path, fi.ModTime())
+					log.Infof("Would delete orphaned file: %s (last modified: %s) which is not in cache", path, fi.ModTime())
 				} else {
 					if err := os.Remove(path); err == nil {
 						log.Infof("Removed orphaned file: %q", path)

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1464,7 +1464,5 @@ func (p *PebbleCache) Stop() error {
 		return err
 	}
 
-	// TODO(tylerw) re-enable this once shutdown race is debugged.
 	return p.db.Close()
-	//return nil
 }

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -54,7 +54,7 @@ var (
 	forceAllowMigration       = flag.Bool("cache.pebble.force_allow_migration", false, "If set, allow migrating into an existing pebble cache")
 	clearCacheBeforeMigration = flag.Bool("cache.pebble.clear_cache_before_migration", false, "If set, clear any existing cache content before migrating")
 	mirrorActiveDiskCache     = flagtypes.Alias[bool]("cache.disk.enable_live_updates", "cache.pebble.mirror_active_disk_cache")
-	orphanDeleteDryRun        = flag.Bool("cache.disk.orphan_delete_dry_run", true, "If set, log orphaned files instead of deleting them")
+	orphanDeleteDryRun        = flag.Bool("cache.pebble.orphan_delete_dry_run", true, "If set, log orphaned files instead of deleting them")
 )
 
 const (

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -23,6 +24,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -103,13 +105,17 @@ type PebbleCache struct {
 	db        *pebble.DB
 	isolation *rfpb.Isolation
 
-	statusMu *sync.Mutex // PROTECTS(evictors)
-	atimes   *sync.Map
-	edits    chan *sizeUpdate
+	atimes *sync.Map
+	edits  chan *sizeUpdate
 
 	quitChan chan struct{}
 	eg       *errgroup.Group
+
+	statusMu *sync.Mutex // PROTECTS(evictors)
 	evictors []*partitionEvictor
+
+	brokenFilesDone   chan struct{}
+	orphanedFilesDone chan struct{}
 }
 
 // Register creates a new PebbleCache from the configured flags and sets it in
@@ -249,15 +255,17 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 		return nil, err
 	}
 	pc := &PebbleCache{
-		opts:     opts,
-		env:      env,
-		db:       db,
-		quitChan: make(chan struct{}),
-		eg:       &errgroup.Group{},
-		statusMu: &sync.Mutex{},
-		atimes:   &sync.Map{},
-		edits:    make(chan *sizeUpdate, 1000),
-		evictors: make([]*partitionEvictor, len(opts.Partitions)),
+		opts:              opts,
+		env:               env,
+		db:                db,
+		quitChan:          make(chan struct{}),
+		brokenFilesDone:   make(chan struct{}),
+		orphanedFilesDone: make(chan struct{}),
+		eg:                &errgroup.Group{},
+		statusMu:          &sync.Mutex{},
+		atimes:            &sync.Map{},
+		edits:             make(chan *sizeUpdate, 1000),
+		evictors:          make([]*partitionEvictor, len(opts.Partitions)),
 		isolation: &rfpb.Isolation{
 			CacheType:   rfpb.Isolation_CAS_CACHE,
 			PartitionId: defaultPartitionID,
@@ -324,6 +332,62 @@ func (p *PebbleCache) processSizeUpdates(quitChan chan struct{}) {
 	}
 }
 
+func (p *PebbleCache) deleteOrphanedFiles(quitChan chan struct{}) {
+	const sep = "/"
+	iter := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte{constants.MinByte},
+		UpperBound: []byte{constants.MaxByte},
+	})
+	defer iter.Close()
+
+	orphanCount := 0
+	fileMetadata := &rfpb.FileMetadata{}
+	for _, part := range p.opts.Partitions {
+		blobDir := p.partitionBlobDir(part.ID)
+		walkFn := func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+
+			// Check if we're shutting down; exit if so.
+			select {
+			case <-quitChan:
+				return status.CanceledErrorf("cache shutting down")
+			default:
+			}
+
+			relPath, err := filepath.Rel(blobDir, path)
+			if err != nil {
+				return err
+			}
+			parts := strings.Split(relPath, sep)
+			if len(parts) < 3 {
+				log.Warningf("Skipping orphaned file: %q", path)
+				return nil
+			}
+			prefixIndex := len(parts) - 2
+			// Remove the second to last element which is the 4-char hash prefix.
+			parts = append(parts[:prefixIndex], parts[prefixIndex+1:]...)
+			fileMetadataKey := []byte(strings.Join(parts, sep))
+			if err := lookupAndSetFileMetadata(iter, fileMetadataKey, fileMetadata); err != nil {
+				if err := os.Remove(path); err == nil {
+					log.Infof("Removed orphaned file: %q", path)
+					orphanCount += 1
+				}
+			}
+			return nil
+		}
+		if err := filepath.WalkDir(blobDir, walkFn); err != nil {
+			alert.UnexpectedEvent("pebble_cache_error_deleting_orphans", "err: %s", err)
+		}
+	}
+	log.Infof("Pebble Cache: deleteOrphanedFiles removed %d files", orphanCount)
+	close(p.orphanedFilesDone)
+}
+
 func (p *PebbleCache) scanForBrokenFiles(quitChan chan struct{}) {
 	iter := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte{constants.MinByte},
@@ -335,6 +399,7 @@ func (p *PebbleCache) scanForBrokenFiles(quitChan chan struct{}) {
 	fileMetadata := &rfpb.FileMetadata{}
 	blobDir := ""
 
+	mismatchCount := 0
 	for iter.Next() {
 		// Check if we're shutting down; exit if so.
 		select {
@@ -353,8 +418,11 @@ func (p *PebbleCache) scanForBrokenFiles(quitChan chan struct{}) {
 		_, err := filestore.NewReader(p.env.GetServerContext(), blobDir, fileMetadata.GetStorageMetadata(), 0, 0)
 		if err != nil {
 			p.handleMetadataMismatch(err, fileMetadataKey, fileMetadata)
+			mismatchCount += 1
 		}
 	}
+	log.Infof("Pebble Cache: scanForBrokenFiles fixed %d files", mismatchCount)
+	close(p.brokenFilesDone)
 }
 
 func (p *PebbleCache) MigrateFromDiskDir(diskDir string) error {
@@ -874,6 +942,26 @@ func (p *PebbleCache) Writer(ctx context.Context, d *repb.Digest) (io.WriteClose
 	return dc, nil
 }
 
+func (p *PebbleCache) DoneScanning() bool {
+	var brokenFilesDone, orphanedFilesDone bool
+
+	select {
+	case <-p.brokenFilesDone:
+		brokenFilesDone = true
+	default:
+		break
+	}
+
+	select {
+	case <-p.orphanedFilesDone:
+		orphanedFilesDone = true
+	default:
+		break
+	}
+
+	return brokenFilesDone && orphanedFilesDone
+}
+
 // TestingWaitForGC should be used by tests only.
 // This function waits until any active file deletion has finished.
 func (p *PebbleCache) TestingWaitForGC() error {
@@ -1360,6 +1448,10 @@ func (p *PebbleCache) Start() error {
 		p.scanForBrokenFiles(p.quitChan)
 		return nil
 	})
+	p.eg.Go(func() error {
+		p.deleteOrphanedFiles(p.quitChan)
+		return nil
+	})
 	return nil
 }
 
@@ -1373,6 +1465,6 @@ func (p *PebbleCache) Stop() error {
 	}
 
 	// TODO(tylerw) re-enable this once shutdown race is debugged.
-	// return p.db.Close()
-	return nil
+	return p.db.Close()
+	//return nil
 }

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -710,14 +710,15 @@ func TestDeleteOrphans(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
+	// Check that all of the deleted digests are not in the cache.
 	for _, dt := range deletedDigests {
-		// we don't know if this is an action cache or cas digest, so check both
 		if c, err := pc2.WithIsolation(ctx, dt.cacheType, "remoteInstanceName"); err == nil {
 			_, err := c.Get(ctx, dt.digest)
 			require.True(t, status.IsNotFoundError(err))
 		}
 	}
 
+	// Check that all of the non-deleted items are still fetchable.
 	for _, dt := range digests {
 		c, err := pc2.WithIsolation(ctx, dt.cacheType, "remoteInstanceName")
 		require.Nil(t, err)

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -571,7 +571,6 @@ func TestMigrationFromDiskV2(t *testing.T) {
 }
 
 func TestStartupScan(t *testing.T) {
-	t.Skip()
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
 	ctx := getAnonContext(t, te)

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -632,7 +632,7 @@ type digestAndType struct {
 }
 
 func TestDeleteOrphans(t *testing.T) {
-	flags.Set(t, "cache.disk.orphan_delete_dry_run", false)
+	flags.Set(t, "cache.pebble.orphan_delete_dry_run", false)
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
 	ctx := getAnonContext(t, te)


### PR DESCRIPTION
Add code to pebble_cache which will scan and delete files from the blobDir which do not have corresponding records in the pebble DB. This is to remove corrupted data which is effectively invisible and taking up space on the partition but not being used.