### PR TITLE
Move QueryWriteStatus short-circuiting before the cache lookup

### DIFF
--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -423,6 +423,18 @@ func (s *ByteStreamServer) QueryWriteStatus(ctx context.Context, req *bspb.Query
 			Complete:      false,
 		}, nil
 	}
+	if rn.GetCompressor() != repb.Compressor_IDENTITY {
+		// When the upload is compressed, we don't know what value to return,
+		// since the committed size depends on how the client compressed the
+		// contents. So return 0 here and let it retry the upload.
+		// TODO(bduffany): For Bazel versions 5.1 and later, we can return
+		// {CommittedSize: -1, Complete: true}.
+		// See https://github.com/bazelbuild/bazel/issues/14654 for context.
+		return &bspb.QueryWriteStatusResponse{
+			CommittedSize: 0,
+			Complete:      false,
+		}, nil
+	}
 
 	ctx, err = prefix.AttachUserPrefixToContext(ctx, s.env)
 	if err != nil {
@@ -445,19 +457,6 @@ func (s *ByteStreamServer) QueryWriteStatus(ctx context.Context, req *bspb.Query
 			}, nil
 		}
 		return nil, err
-	}
-
-	if rn.GetCompressor() != repb.Compressor_IDENTITY {
-		// When the upload is compressed, we don't know what value to return,
-		// since the committed size depends on how the client compressed the
-		// contents. So return 0 here and let it retry the upload.
-		// TODO(bduffany): For Bazel versions 5.1 and later, we can return
-		// {CommittedSize: -1, Complete: true}.
-		// See https://github.com/bazelbuild/bazel/issues/14654 for context.
-		return &bspb.QueryWriteStatusResponse{
-			CommittedSize: 0,
-			Complete:      false,
-		}, nil
 	}
 
 	return &bspb.QueryWriteStatusResponse{


### PR DESCRIPTION
D'oh.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
