### PR TITLE
Send probes only to nodes that can fit a task

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -357,6 +357,11 @@ type executionNode struct {
 	handle *executorHandle
 }
 
+func (en *executionNode) CanFit(size *scpb.TaskSize) bool {
+	return int64(float64(en.assignableMemoryBytes)*tasksize.MaxResourceCapacityRatio) >= size.GetEstimatedMemoryBytes() &&
+		int64(float64(en.assignableMilliCpu)*tasksize.MaxResourceCapacityRatio) >= size.GetEstimatedMilliCpu()
+}
+
 func (en *executionNode) String() string {
 	if en.handle != nil {
 		return fmt.Sprintf("connected executor(%s)", en.executorID)
@@ -366,6 +371,16 @@ func (en *executionNode) String() string {
 
 func (en *executionNode) GetExecutorID() string {
 	return en.executorID
+}
+
+func nodesThatFit(nodes []*executionNode, taskSize *scpb.TaskSize) []*executionNode {
+	var out []*executionNode
+	for _, node := range nodes {
+		if node.CanFit(taskSize) {
+			out = append(out, node)
+		}
+	}
+	return out
 }
 
 // TODO(bduffany): Expand interfaces.ExecutionNode interface to include all
@@ -503,8 +518,7 @@ func (np *nodePool) NodeCount(ctx context.Context, taskSize *scpb.TaskSize) (int
 
 	fitCount := 0
 	for _, node := range np.nodes {
-		if int64(float64(node.assignableMemoryBytes)*tasksize.MaxResourceCapacityRatio) >= taskSize.GetEstimatedMemoryBytes() &&
-			int64(float64(node.assignableMilliCpu)*tasksize.MaxResourceCapacityRatio) >= taskSize.GetEstimatedMilliCpu() {
+		if node.CanFit(taskSize) {
 			fitCount++
 		}
 	}
@@ -1395,6 +1409,14 @@ func (s *SchedulerServer) enqueueTaskReservations(ctx context.Context, enqueueRe
 				nodes = nodeBalancer.GetNodes(opts.scheduleOnConnectedExecutors)
 				if len(nodes) == 0 {
 					return status.UnavailableErrorf("No registered executors in pool %q with os %q with arch %q.", pool, os, arch)
+				}
+				nodes = nodesThatFit(nodes, enqueueRequest.GetTaskSize())
+				if len(nodes) == 0 {
+					return status.UnavailableErrorf(
+						"No registered executors in pool %q with os %q with arch %q can fit a task with %d milli-cpu and %d bytes of memory.",
+						pool, os, arch,
+						enqueueRequest.GetTaskSize().GetEstimatedMilliCpu(),
+						enqueueRequest.GetTaskSize().GetEstimatedMemoryBytes())
 				}
 				rankedNodes := s.taskRouter.RankNodes(ctx, cmd, remoteInstanceName, toNodeInterfaces(nodes))
 				nodes, err = fromNodeInterfaces(rankedNodes)


### PR DESCRIPTION
Tested by running two executors locally, where the first one had the default resource limits and the second had `--executor.millicpu=50` (so small that it can't fit any task). Before this change, the second executor would get tasks enqueued, but never be able to dequeue. After the change, only the first executor (with the default resource limits) would get the task enqueued.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1467
