### PR TITLE
Disable orphan file scan by default

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -730,6 +730,7 @@ type digestAndType struct {
 }
 
 func TestDeleteOrphans(t *testing.T) {
+	flags.Set(t, "cache.pebble.scan_for_orphaned_files", true)
 	flags.Set(t, "cache.pebble.orphan_delete_dry_run", false)
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))


### PR DESCRIPTION
Based on logs, it seems we're orphaning files when the apps restart. I disabled the orphan deletion already, but this disables the scan as well because it hammers the disk and the logs for no real reason.