### PR TITLE
Update task sizing semantics in scheduling API

### DIFF
--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -58,8 +58,27 @@ message TaskSize {
   int64 estimated_free_disk_bytes = 3;
 }
 
+// Next ID: 8
 message SchedulingMetadata {
+  // Task size either explicitly requested via platform properties, or estimated
+  // by BuildBuddy (using basic heuristics).
+  //
+  // This field is used for scheduling purposes, when the app is deciding which
+  // executors (if any) may execute a task.
   TaskSize task_size = 1;
+
+  // Task size measured from a previous task execution of a similar task, if
+  // such data is available.
+  //
+  // This field is purely intended for optimization purposes at the executor
+  // level and should have no effect on how a task is assigned to executors at
+  // the scheduler level. Executors may use this size to determine how many
+  // resources to allot for a task, but may not reject a task from being
+  // executed on the basis of this size being too large. Executors must respect
+  // the scheduler's original decision to enqueue the task, even if it requires
+  // allocating fewer resources than the measured task size.
+  TaskSize measured_task_size = 7;
+
   string os = 2;
   string arch = 3;
   string pool = 4;


### PR DESCRIPTION
This PR is just adding new fields / comments as a proposal for addressing a scheduling issue with task sizing.

With the current task sizing implementation, there's an issue in which, after an executor has executed a task, the task may no longer be schedulable on that executor due to the measured task size exceeding the executor's resource limits. This is not an intended outcome at least with this first iteration of task sizing, since it breaks a lot of tasks that currently schedule and execute just fine.

The proposed fix is to never use measured task sizes for scheduler -> executor probing, and instead always use the "original" task size estimate (either the one from platform props, or the one based on our heuristics). Then, on the executor, we can use the measured_task_size, but capped to the limits of the priority_task_scheduler.

This way, we still get most of the benefits of task sizing, while still using the scheduler's current scheduling decisions.

If this proposal sounds good then I plan to implement it as follow-up PRs to the scheduler & executor.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
