### PR TITLE
Task sizing: Fix measurements causing tasks to become unschedulable

### DIFF
--- a/enterprise/server/remote_execution/execution_server/BUILD
+++ b/enterprise/server/remote_execution/execution_server/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//enterprise/server/remote_execution/config",
         "//enterprise/server/remote_execution/operation",
         "//enterprise/server/remote_execution/platform",
+        "//enterprise/server/tasksize",
         "//proto:execution_stats_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -153,6 +153,7 @@ type executorHandle struct {
 	requireAuthorization bool
 	stream               scpb.Scheduler_RegisterAndStreamWorkServer
 	groupID              string
+	registration         *scpb.ExecutionNode
 
 	mu       sync.RWMutex
 	requests chan enqueueTaskReservationRequest
@@ -205,13 +206,12 @@ func (h *executorHandle) Serve(ctx context.Context) error {
 	}
 	h.groupID = groupID
 
-	var registeredNode *scpb.ExecutionNode
 	removeConnectedExecutor := func() {
-		if registeredNode == nil {
+		if h.registration == nil {
 			return
 		}
-		h.scheduler.RemoveConnectedExecutor(ctx, h, registeredNode)
-		registeredNode = nil
+		h.scheduler.RemoveConnectedExecutor(ctx, h, h.registration)
+		h.registration = nil
 	}
 	defer removeConnectedExecutor()
 
@@ -250,7 +250,7 @@ func (h *executorHandle) Serve(ctx context.Context) error {
 				if err := h.scheduler.AddConnectedExecutor(ctx, h, registration); err != nil {
 					return err
 				}
-				registeredNode = registration
+				h.registration = registration
 				executorID = registration.GetExecutorId()
 			} else if req.GetEnqueueTaskReservationResponse() != nil {
 				h.handleTaskReservationResponse(req.GetEnqueueTaskReservationResponse())
@@ -297,12 +297,20 @@ func (h *executorHandle) handleTaskReservationResponse(response *scpb.EnqueueTas
 func (h *executorHandle) EnqueueTaskReservation(ctx context.Context, req *scpb.EnqueueTaskReservationRequest) (*scpb.EnqueueTaskReservationResponse, error) {
 	// EnqueueTaskReservation may be called multiple times and OpenTelemetry doesn't have clear documentation as to
 	// whether it's safe to call Inject using a carrier that already has metadata so we clone the proto to be defensive.
+	// We also clone to avoid mutating the proto in applyMeasuredTaskSize below.
 	req, ok := proto.Clone(req).(*scpb.EnqueueTaskReservationRequest)
 	if !ok {
 		log.CtxErrorf(ctx, "could not clone reservation request")
 		return nil, status.InternalError("could not clone reservation request")
 	}
 	tracing.InjectProtoTraceMetadata(ctx, req.GetTraceMetadata(), func(m *tpb.Metadata) { req.TraceMetadata = m })
+
+	// Just before enqueueing, resize the task to match the measured task size,
+	// up to the executor's limits. This late-resizing approach ensures that we
+	// assign tasks to executors independently of any measured task sizes, to
+	// avoid issues where a task can't be rescheduled due to its measured size
+	// exceeding executor limits.
+	h.applyMeasuredTaskSize(req)
 
 	timeout := time.NewTimer(executorEnqueueTaskReservationTimeout)
 	rspCh := make(chan *scpb.EnqueueTaskReservationResponse, 1)
@@ -323,6 +331,34 @@ func (h *executorHandle) EnqueueTaskReservation(ctx context.Context, req *scpb.E
 		return nil, status.CanceledErrorf("could not enqueue task reservation %q", req.GetTaskId())
 	case rsp := <-rspCh:
 		return rsp, nil
+	}
+}
+
+func (h *executorHandle) applyMeasuredTaskSize(req *scpb.EnqueueTaskReservationRequest) {
+	if h.registration == nil {
+		return
+	}
+
+	size := req.GetTaskSize()
+	measuredSize := req.GetSchedulingMetadata().GetMeasuredTaskSize()
+	if measuredSize.GetEstimatedMemoryBytes() != 0 {
+		size.EstimatedMemoryBytes = measuredSize.GetEstimatedMemoryBytes()
+		executorMem := int64(float64(h.registration.GetAssignableMemoryBytes()) * tasksize.MaxResourceCapacityRatio)
+		if size.EstimatedMemoryBytes > executorMem {
+			size.EstimatedMemoryBytes = executorMem
+		}
+	}
+	if measuredSize.GetEstimatedMilliCpu() != 0 {
+		size.EstimatedMilliCpu = measuredSize.GetEstimatedMilliCpu()
+		executorMilliCPU := int64(float64(h.registration.GetAssignableMilliCpu()) * tasksize.MaxResourceCapacityRatio)
+		if size.EstimatedMilliCpu > executorMilliCPU {
+			size.EstimatedMilliCpu = executorMilliCPU
+		}
+	}
+
+	req.TaskSize = size
+	if req.SchedulingMetadata != nil {
+		req.SchedulingMetadata.TaskSize = size
 	}
 }
 
@@ -963,8 +999,9 @@ func (s *SchedulerServer) assignWorkToNode(ctx context.Context, handle *executor
 	var reqs []*scpb.EnqueueTaskReservationRequest
 	for _, task := range tasks {
 		req := &scpb.EnqueueTaskReservationRequest{
-			TaskId:   task.taskID,
-			TaskSize: task.metadata.GetTaskSize(),
+			TaskId:             task.taskID,
+			TaskSize:           task.metadata.GetTaskSize(),
+			SchedulingMetadata: task.metadata,
 		}
 		reqs = append(reqs, req)
 	}

--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -117,7 +117,7 @@ func TestEstimate_DiskSizePlatformProp_UsesPropValueForDiskSize(t *testing.T) {
 	assert.Equal(t, disk, ts.EstimatedFreeDiskBytes)
 }
 
-func TestSizer_Estimate_ShouldUseRecordedUsageStats(t *testing.T) {
+func TestSizer_Get_ShouldReturnRecordedUsageStats(t *testing.T) {
 	flags.Set(t, "remote_execution.use_measured_task_sizes", true)
 
 	env := testenv.GetTestEnv(t)
@@ -134,14 +134,9 @@ func TestSizer_Estimate_ShouldUseRecordedUsageStats(t *testing.T) {
 			Arguments: []string{"/usr/bin/clang", "foo.c", "-o", "foo.o"},
 		},
 	}
-	ts := sizer.Estimate(ctx, task)
+	ts := sizer.Get(ctx, task)
 
-	assert.Equal(
-		t, tasksize.DefaultMemEstimate, ts.EstimatedMemoryBytes,
-		"initial mem estimate should be the default estimate")
-	assert.Equal(
-		t, tasksize.DefaultCPUEstimate, ts.EstimatedMilliCpu,
-		"initial CPU estimate should be the default estimate")
+	require.Nil(t, ts, "should not return a task size initially")
 
 	execStart := time.Now()
 	md := &repb.ExecutedActionMetadata{
@@ -159,12 +154,12 @@ func TestSizer_Estimate_ShouldUseRecordedUsageStats(t *testing.T) {
 
 	require.NoError(t, err)
 
-	ts = sizer.Estimate(ctx, task)
+	ts = sizer.Get(ctx, task)
 
 	assert.Equal(
-		t, int64(917*1e6), ts.EstimatedMemoryBytes,
+		t, int64(917*1e6), ts.GetEstimatedMemoryBytes(),
 		"subsequent mem estimate should equal recorded peak mem usage")
 	assert.Equal(
-		t, int64(7.13/2*1000), ts.EstimatedMilliCpu,
+		t, int64(7.13/2*1000), ts.GetEstimatedMilliCpu(),
 		"subsequent milliCPU estimate should equal recorded milliCPU")
 }

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -60,23 +60,19 @@ message TaskSize {
 
 // Next ID: 8
 message SchedulingMetadata {
-  // Task size either explicitly requested via platform properties, or estimated
-  // by BuildBuddy (using basic heuristics).
-  //
-  // This field is used for scheduling purposes, when the app is deciding which
-  // executors (if any) may execute a task.
+  // Task size used for scheduling purposes, when the scheduler is deciding
+  // which executors (if any) may execute a task, and also when an executor is
+  // deciding which task to dequeue. Executors may see a different value of this
+  // field than what the scheduler sees, depending on measured_task_size. See
+  // documentation of that field for more info.
   TaskSize task_size = 1;
 
   // Task size measured from a previous task execution of a similar task, if
   // such data is available.
   //
-  // This field is purely intended for optimization purposes at the executor
-  // level and should have no effect on how a task is assigned to executors at
-  // the scheduler level. Executors may use this size to determine how many
-  // resources to allot for a task, but may not reject a task from being
-  // executed on the basis of this size being too large. Executors must respect
-  // the scheduler's original decision to enqueue the task, even if it requires
-  // allocating fewer resources than the measured task size.
+  // The scheduler may use this size to compute an adjusted `task_size` just
+  // before enqueueing a task onto an executor, but the adjusted size should not
+  // exceed the executor's limits.
   TaskSize measured_task_size = 7;
 
   string os = 2;

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -542,13 +542,13 @@ type TaskRouter interface {
 	MarkComplete(ctx context.Context, cmd *repb.Command, remoteInstanceName, executorInstanceID string)
 }
 
-// TaskSizer estimates task resource usage for scheduling purposes.
+// TaskSizer allows storing and retrieving task size measurements for a task.
 type TaskSizer interface {
-	// Estimate returns the resource usage for a task.
-	Estimate(ctx context.Context, task *repb.ExecutionTask) *scpb.TaskSize
+	// Get returns the previously measured size for a task, or nil if this data
+	// is not available.
+	Get(ctx context.Context, task *repb.ExecutionTask) *scpb.TaskSize
 
-	// Update updates future resource usage estimates based on a command's
-	// recorded execution stats.
+	// Update records a measured task size.
 	Update(ctx context.Context, cmd *repb.Command, md *repb.ExecutedActionMetadata) error
 }
 

--- a/tools/tasksize_stress/tasksize_stress_test.go
+++ b/tools/tasksize_stress/tasksize_stress_test.go
@@ -35,6 +35,10 @@ func TestCPU4(t *testing.T) {
 	fullyUtilizeCPUCores(4, *duration)
 }
 
+func TestCPU8(t *testing.T) {
+	fullyUtilizeCPUCores(8, *duration)
+}
+
 func fullyUtilizeCPUCores(numGoroutines int, dur time.Duration) {
 	var wg sync.WaitGroup
 	end := time.Now().Add(dur)


### PR DESCRIPTION
The scheduler will now apply task size measurements just before enqueueing a task onto an executor, limiting the task size to the executor's resource limits. This means that task sizing should no longer affect schedulability at all.

This approach is different than the original proposal in https://github.com/buildbuddy-io/buildbuddy/pull/2315, which was to have executors apply task size measurements locally. I found that it was cleaner to have the scheduler apply the task size measurements just before enqueueing a task onto the executor, because there were 3 different places where the executor was looking at the task_size field and we'd have to be careful to apply the measured task size in all 3 places as well as any future places. By having the scheduler apply the size adjustment, we don't have to make any changes to the executor behavior at all -- the executor can still just look at the task_size field. This keep's the executor's scheduling logic lightweight and keeps the scheduler doing most of the heavyweight scheduling logic.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
