### PR TITLE
Task sizing: Add initial impl of streaming vmexec API

### DIFF
--- a/enterprise/server/remote_execution/vmexec_client/BUILD
+++ b/enterprise/server/remote_execution/vmexec_client/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "vmexec_client",
+    srcs = ["vmexec_client.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/vmexec_client",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//enterprise/server/remote_execution/commandutil",
+        "//enterprise/server/remote_execution/container",
+        "//proto:remote_execution_go_proto",
+        "//proto:vmexec_go_proto",
+        "//server/interfaces",
+        "//server/util/status",
+        "@org_golang_x_sync//errgroup",
+    ],
+)

--- a/enterprise/server/remote_execution/vmexec_client/vmexec_client.go
+++ b/enterprise/server/remote_execution/vmexec_client/vmexec_client.go
@@ -1,0 +1,124 @@
+package vmexec_client
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"golang.org/x/sync/errgroup"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	vmxpb "github.com/buildbuddy-io/buildbuddy/proto/vmexec"
+)
+
+// Execute executes the command using the ExecStreamed API.
+func Execute(ctx context.Context, client vmxpb.ExecClient, cmd *repb.Command, workDir string, stdio *container.Stdio) *interfaces.CommandResult {
+	var stderr, stdout bytes.Buffer
+	if stdio == nil {
+		stdio = &container.Stdio{}
+	}
+	stdoutw := io.Writer(&stdout)
+	if stdio.Stdout != nil {
+		stdoutw = stdio.Stdout
+	}
+	stderrw := io.Writer(&stderr)
+	if stdio.Stderr != nil {
+		stderrw = stdio.Stderr
+	}
+	req := &vmxpb.ExecRequest{
+		WorkingDirectory: workDir,
+		Arguments:        cmd.GetArguments(),
+		OpenStdin:        stdio.Stdin != nil,
+	}
+	for _, ev := range cmd.GetEnvironmentVariables() {
+		req.EnvironmentVariables = append(req.EnvironmentVariables, &vmxpb.ExecRequest_EnvironmentVariable{
+			Name: ev.GetName(), Value: ev.GetValue(),
+		})
+	}
+
+	stream, err := client.ExecStreamed(ctx)
+	if err != nil {
+		return commandutil.ErrorResult(err)
+	}
+	startMsg := &vmxpb.ExecStreamedRequest{Start: req}
+	if err := stream.Send(startMsg); err != nil {
+		return commandutil.ErrorResult(err)
+	}
+	var res *vmxpb.ExecResponse
+	var stats *repb.UsageStats
+	eg, ctx := errgroup.WithContext(ctx)
+	if stdio.Stdin != nil {
+		eg.Go(func() error {
+			if _, err := io.Copy(&stdinWriter{stream}, stdio.Stdin); err != nil {
+				return status.InternalErrorf("failed to write stdin: %s", err)
+			}
+			if err := stream.CloseSend(); err != nil {
+				return status.InternalErrorf("failed to close send direction of stream: %s", err)
+			}
+			return nil
+		})
+	} else {
+		if err := stream.CloseSend(); err != nil {
+			return commandutil.ErrorResult(status.InternalErrorf("failed to close send direction of stream: %s", err))
+		}
+	}
+
+	eg.Go(func() error {
+		for {
+			msg, err := stream.Recv()
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				if ctx.Err() == context.DeadlineExceeded {
+					return status.DeadlineExceededError("context deadline exceeded")
+				}
+				if ctx.Err() == context.Canceled {
+					return status.CanceledError("context canceled")
+				}
+				return status.InternalErrorf("failed to receive from stream: %s", status.Message(err))
+			}
+			if _, err := stdoutw.Write(msg.Stdout); err != nil {
+				return status.InternalErrorf("failed to write stdout: %s", status.Message(err))
+			}
+			if _, err := stderrw.Write(msg.Stderr); err != nil {
+				return status.InternalErrorf("failed to write stderr: %s", status.Message(err))
+			}
+			if msg.Response != nil {
+				res = msg.Response
+			}
+			if msg.UsageStats != nil {
+				// TODO: update prometheus metrics
+				stats = msg.UsageStats
+			}
+		}
+	})
+
+	err = eg.Wait()
+	if res == nil {
+		res = &vmxpb.ExecResponse{ExitCode: commandutil.NoExitCode}
+	}
+	return &interfaces.CommandResult{
+		ExitCode:   int(res.ExitCode),
+		Stderr:     stderr.Bytes(),
+		Stdout:     stdout.Bytes(),
+		Error:      err,
+		UsageStats: stats,
+	}
+}
+
+type stdinWriter struct {
+	stream vmxpb.Exec_ExecStreamedClient
+}
+
+func (w *stdinWriter) Write(b []byte) (int, error) {
+	msg := &vmxpb.ExecStreamedRequest{Stdin: b}
+	if err := w.stream.Send(msg); err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}

--- a/enterprise/server/vmexec/BUILD
+++ b/enterprise/server/vmexec/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "vmexec",
@@ -7,11 +7,31 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/commandutil",
+        "//proto:remote_execution_go_proto",
         "//proto:vmexec_go_proto",
         "//server/util/log",
         "//server/util/status",
         "@com_github_vishvananda_netlink//:netlink",
         "@org_golang_google_grpc//status",
         "@org_golang_x_sys//unix",
+    ],
+)
+
+go_test(
+    name = "vmexec_test",
+    srcs = ["vmexec_test.go"],
+    deps = [
+        ":vmexec",
+        "//enterprise/server/remote_execution/commandutil",
+        "//enterprise/server/remote_execution/container",
+        "//enterprise/server/remote_execution/vmexec_client",
+        "//proto:remote_execution_go_proto",
+        "//proto:vmexec_go_proto",
+        "//server/testutil/testfs",
+        "//server/util/disk",
+        "//server/util/status",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/enterprise/server/vmexec/vmexec_test.go
+++ b/enterprise/server/vmexec/vmexec_test.go
@@ -1,0 +1,197 @@
+package vmexec_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"path"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/vmexec_client"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/vmexec"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	vmxpb "github.com/buildbuddy-io/buildbuddy/proto/vmexec"
+)
+
+func TestExecStreamed_Simple(t *testing.T) {
+	client := startExecService(t)
+	cmd := &repb.Command{
+		Arguments: []string{"bash", "-c", `
+			echo foo-stdout >&1
+			echo bar-stderr >&2
+			exit 7
+		`},
+	}
+
+	res := vmexec_client.Execute(context.Background(), client, cmd, ".", nil /*=stdio*/)
+
+	require.NoError(t, res.Error)
+	assert.Equal(t, "foo-stdout\n", string(res.Stdout))
+	assert.Equal(t, "bar-stderr\n", string(res.Stderr))
+	assert.Equal(t, 7, res.ExitCode)
+}
+
+func TestExecStreamed_Stdio(t *testing.T) {
+	client := startExecService(t)
+	cmd := &repb.Command{
+		Arguments: []string{"bash", "-c", `
+			in=$(cat)
+			if [[ "$in" != baz-stdin ]]; then
+			  echo "unexpected stdin: $in" >&2
+				exit 1
+			fi
+
+			echo foo-stdout >&1
+			echo bar-stderr >&2
+			exit 7
+		`},
+	}
+	var stdout, stderr bytes.Buffer
+	stdin := strings.NewReader("baz-stdin")
+	stdio := &container.Stdio{
+		Stdin:  stdin,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+
+	res := vmexec_client.Execute(context.Background(), client, cmd, ".", stdio)
+
+	require.NoError(t, res.Error)
+	assert.Equal(t, "foo-stdout\n", stdout.String())
+	assert.Equal(t, "bar-stderr\n", stderr.String())
+	assert.Equal(t, 7, res.ExitCode)
+}
+
+func TestExecStreamed_Stats(t *testing.T) {
+	wd := testfs.MakeTempDir(t)
+	testfs.WriteAllFileContents(t, wd, map[string]string{
+		"mem.py": useMemPythonScript(1e9, 1*time.Second),
+		"cpu.py": useCPUPythonScript(1 * time.Second),
+	})
+	client := startExecService(t)
+	cmd := &repb.Command{
+		Arguments: []string{"bash", "-c", `
+			python3 ./mem.py &
+			python3 ./cpu.py &
+			wait
+		`},
+	}
+
+	res := vmexec_client.Execute(context.Background(), client, cmd, wd, nil /*=stdio*/)
+
+	require.NoError(t, res.Error)
+	require.NotNil(t, res.UsageStats)
+	assert.GreaterOrEqual(t, res.UsageStats.GetCpuNanos(), int64(0.7e9), "should use around 1e9 CPU nanos")
+	assert.LessOrEqual(t, res.UsageStats.GetCpuNanos(), int64(1.6e9), "should use around 1e9 CPU nanos")
+	assert.GreaterOrEqual(t, res.UsageStats.GetMemoryBytes(), int64(1e9), "should use at least 1GB memory")
+	assert.LessOrEqual(t, res.UsageStats.GetMemoryBytes(), int64(1.6e9), "shouldn't use much more than 1GB memory")
+}
+
+func TestExecStreamed_Timeout(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	client := startExecService(t)
+	cmd := &repb.Command{
+		Arguments: []string{"bash", "-c", `
+			echo foo-stdout >&1
+			echo bar-stderr >&2
+			sleep 60
+		`},
+	}
+
+	res := vmexec_client.Execute(ctx, client, cmd, ".", nil /*=stdio*/)
+
+	assert.Error(t, res.Error)
+
+	assert.True(t, status.IsDeadlineExceededError(res.Error), "expected DeadlineExceeded but got %T: %s", res.Error, res.Error)
+	assert.Equal(t, "foo-stdout\n", string(res.Stdout), "should get partial stdout despite timeout")
+	assert.Equal(t, "bar-stderr\n", string(res.Stderr), "should get partial stderr despite timeout")
+	assert.Equal(t, commandutil.NoExitCode, res.ExitCode)
+}
+
+func TestExecStreamed_Cancel(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	client := startExecService(t)
+	wd := testfs.MakeTempDir(t)
+	cmd := &repb.Command{
+		Arguments: []string{"bash", "-c", `
+			echo foo-stdout >&1
+			echo bar-stderr >&2
+			touch cancel
+			sleep 60
+		`},
+	}
+
+	go func() {
+		err := disk.WaitUntilExists(ctx, path.Join(wd, "cancel"), disk.WaitOpts{})
+		require.NoError(t, err)
+		cancel()
+	}()
+
+	res := vmexec_client.Execute(ctx, client, cmd, wd, nil /*=stdio*/)
+
+	assert.Error(t, res.Error)
+
+	assert.True(t, status.IsCanceledError(res.Error), "expected Canceled but got %T: %s", res.Error, res.Error)
+	assert.Equal(t, "foo-stdout\n", string(res.Stdout), "should get partial stdout despite cancel")
+	assert.Equal(t, "bar-stderr\n", string(res.Stderr), "should get partial stderr despite cancel")
+	assert.Equal(t, commandutil.NoExitCode, res.ExitCode)
+}
+
+func startExecService(t *testing.T) vmxpb.ExecClient {
+	lis, err := net.Listen("tcp", "0.0.0.0:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		lis.Close()
+	})
+	server := grpc.NewServer()
+	execServer, err := vmexec.NewServer(&sync.RWMutex{})
+	require.NoError(t, err)
+	vmxpb.RegisterExecServer(server, execServer)
+	go server.Serve(lis)
+	t.Cleanup(func() {
+		server.Stop()
+	})
+
+	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithInsecure())
+	require.NoError(t, err)
+	client := vmxpb.NewExecClient(conn)
+	return client
+}
+
+// Returns a python script that consumes 1 CPU core continuously for the given
+// duration.
+func useCPUPythonScript(dur time.Duration) string {
+	return fmt.Sprintf(`
+import time
+end = time.time() + %f
+while time.time() < end:
+    pass
+`, dur.Seconds())
+}
+
+// Returns a python script that uses the given amount of resident memory and
+// holds onto that memory for the given duration.
+func useMemPythonScript(memBytes int64, dur time.Duration) string {
+	return fmt.Sprintf(`
+import time
+arr = b'1' * %d
+time.sleep(%f)
+`, memBytes, dur.Seconds())
+}


### PR DESCRIPTION
- Implement `ExecStreamed` RPC in `vmexec.go`
- Add a client library that correctly implements the client streaming protocol.
- A subsequent PR will replace our existing usage of `Exec()` in `firecracker.go` with `ExecStreamed()`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
