### PR TITLE
Improve error logging in markTaskComplete

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -817,7 +817,7 @@ func (s *ExecutionServer) PublishOperation(stream repb.Execution_PublishOperatio
 			if response != nil {
 				if err := s.markTaskComplete(ctx, taskID, response); err != nil {
 					// Errors updating the router or recording usage are non-fatal.
-					log.CtxErrorf(ctx, "Could not update task router: %s", err)
+					log.CtxErrorf(ctx, "Could not update post-completion metadata for task %q: %s", taskID, err)
 				}
 			}
 		}
@@ -876,7 +876,11 @@ func (s *ExecutionServer) markTaskComplete(ctx context.Context, taskID string, e
 		}
 	}
 
-	return s.updateUsage(ctx, cmd, executeResponse)
+	if err := s.updateUsage(ctx, cmd, executeResponse); err != nil {
+		log.CtxWarningf(ctx, "Failed to update usage for ExecuteResponse %+v: %s", executeResponse, err)
+	}
+
+	return nil
 }
 
 func (s *ExecutionServer) updateUsage(ctx context.Context, cmd *repb.Command, executeResponse *repb.ExecuteResponse) error {


### PR DESCRIPTION
- Fix inaccurate "could not update task router" logging since the error wasn't necessarily with the task router.
- Add more logging when `updateUsage` fails due to a nil timestamp. I suspect it's because the ExecuteResponse has an error, but this logging will let us confirm.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1508

