### PR TITLE
Allow viewing action results for actions marked with do_not_cache

### DIFF
--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -115,9 +115,10 @@ func tableExecToProto(in tables.Execution) (*espb.Execution, error) {
 	}
 
 	var actionResultDigest *repb.Digest
-	if in.StatusCode == int32(codes.OK) && in.ExitCode == 0 {
-		// Action Result with unmodified action digest is only uploaded when there is no error
-		// from the CommandResult(i.e. status code is OK) and the exit code is zero.
+	if in.StatusCode == int32(codes.OK) && in.ExitCode == 0 && !in.DoNotCache {
+		// Action Result with unmodified action digest is only uploaded when
+		// there is no error from the CommandResult(i.e. status code is OK) and
+		// the exit code is zero and the action was not marked with DoNotCache.
 		actionResultDigest = proto.Clone(r.GetDigest()).(*repb.Digest)
 	} else {
 		actionResultDigest, err = digest.AddInvocationIDToDigest(r.GetDigest(), in.InvocationID)

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -257,6 +257,7 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 			}
 		}
 		execution.CachedResult = executeResponse.GetCachedResult()
+		execution.DoNotCache = executeResponse.GetResult().GetExecutionMetadata().GetDoNotCache()
 
 		// Update stats if the operation has been completed.
 		if stage == repb.ExecutionStage_COMPLETED {

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -180,6 +180,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		ExecutorId:           s.id,
 		IoStats:              &repb.IOStats{},
 		EstimatedTaskSize:    st.GetSchedulingMetadata().GetTaskSize(),
+		DoNotCache:           task.GetAction().GetDoNotCache(),
 	}
 
 	if !req.GetSkipCacheLookup() {

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -907,6 +907,9 @@ message ExecutedActionMetadata {
 
   // Estimated task size that was used for scheduling purposes.
   scheduler.TaskSize estimated_task_size = 1003;
+
+  // Whether the executed Action was marked with `do_not_cache`.
+  bool do_not_cache = 1004;
 }
 
 // An ActionResult represents the result of an

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -382,6 +382,7 @@ type Execution struct {
 	StatusCode   int32
 	ExitCode     int32
 	CachedResult bool
+	DoNotCache   bool
 }
 
 func (t *Execution) TableName() string {


### PR DESCRIPTION
We were checking the conditions `ExitCode != 0 || Status != OK` to determine whether to use the invocationID-hashed action digest, but we also need `|| DoNotCache` since we add the invocation ID to the action result hash in that case as well.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
