### PR TITLE
Terminal V2: Fix handling of tab characters

### DIFF
--- a/app/terminal/BUILD
+++ b/app/terminal/BUILD
@@ -1,4 +1,4 @@
-load("//rules/typescript:index.bzl", "ts_library")
+load("//rules/typescript:index.bzl", "ts_jasmine_node_test", "ts_library")
 load(":defs.bzl", "TERMINAL_V2_ENABLED")
 
 package(default_visibility = ["//visibility:public"])
@@ -47,7 +47,7 @@ ts_library(
     name = "terminal2",
     srcs = glob(
         ["*.tsx"],
-        exclude = ["terminal1.tsx"],
+        exclude = ["terminal1.tsx"] + glob(["*_test.ts"]),
     ),
     deps = [
         "//app/components/input",
@@ -66,4 +66,10 @@ ts_library(
         "@npm//react-virtualized-auto-sizer",
         "@npm//react-window",
     ],
+)
+
+ts_jasmine_node_test(
+    name = "text_test",
+    srcs = ["text_test.ts"],
+    deps = [":terminal2"],
 )

--- a/app/terminal/ansi.tsx
+++ b/app/terminal/ansi.tsx
@@ -1,3 +1,5 @@
+const ANSI_CODES_REGEX = /\x1b\[[\d;]*?m/g;
+
 export type AnsiTextSpan = {
   /** Text in this span, with ANSI escape sequences removed. */
   text: string;
@@ -86,7 +88,7 @@ function applyCode(span: AnsiTextSpan, code: number) {
   }
 }
 
-export default function parse(text: string): AnsiTextSpan[] {
+export default function parseAnsi(text: string): AnsiTextSpan[] {
   let span = { text: "", style: {} };
   const spans: AnsiTextSpan[] = [];
   let code = "";
@@ -143,4 +145,9 @@ export default function parse(text: string): AnsiTextSpan[] {
     }
   }
   return spans;
+}
+
+/** Strips ANSI codes from text. */
+export function stripAnsiCodes(text: string): string {
+  return text.replace(ANSI_CODES_REGEX, "");
 }

--- a/app/terminal/row.tsx
+++ b/app/terminal/row.tsx
@@ -14,6 +14,10 @@ export function Row({ data, index, style }: ListChildComponentProps<ListData>) {
   // quick succession when rendering each row of a wrapped line.
   const rowsForLine = computeRows(rowData.line, data.rowLength, data.search, rowData.matchStartIndex);
   const row = rowsForLine[rowData.wrapOffset];
+  if (!row) {
+    console.error("Row mismatch:", { rowData, rowsForLine });
+    return null;
+  }
   return (
     <div
       style={{

--- a/app/terminal/text.tsx
+++ b/app/terminal/text.tsx
@@ -14,10 +14,8 @@
  *   multiple rows.
  */
 
-import parseAnsi, { AnsiTextSpan } from "./ansi";
+import parseAnsi, { stripAnsiCodes, AnsiTextSpan } from "./ansi";
 import memoizeOne from "memoize-one";
-
-const ANSI_CODES_REGEX = /\x1b\[[\d;]*?m/g;
 
 /**
  * Rounding errors start messing with row positioning when there are this many
@@ -201,10 +199,6 @@ export function normalizeSpace(text: string) {
     visibleLineLength++;
   }
   return out;
-}
-
-function stripAnsiCodes(text: string) {
-  return text.replace(ANSI_CODES_REGEX, "");
 }
 
 export function toPlainText(text: string) {

--- a/app/terminal/text_test.ts
+++ b/app/terminal/text_test.ts
@@ -1,20 +1,25 @@
-import { normalizeSpace } from "./text";
+import { normalizeSpace, computeRows } from "./text";
 
 describe("normalizeSpace", () => {
-  it("should apply tab stops", () => {
-    // Single tabstop
+  it("should handle a single tabstop in a single line of plaintext", () => {
     expect(normalizeSpace("\t1234")).toEqual("        1234");
     expect(normalizeSpace("1234\t")).toEqual("1234    ");
     expect(normalizeSpace("1234\t1234")).toEqual("1234    1234");
     expect(normalizeSpace("1234567\t1234")).toEqual("1234567 1234");
     expect(normalizeSpace("12345678\t1234")).toEqual("12345678        1234");
+  });
 
-    // Multiple tabstops
+  it("should handle multiple tabstops in a single line of plaintext", () => {
     expect(normalizeSpace("1234\t\t1234")).toEqual("1234            1234");
     expect(normalizeSpace("\t1234\t1234\t")).toEqual("        1234    1234    ");
+  });
 
-    // Multiple tabstops with newlines
+  it("should handle multiple tabstops across multiple lines of plaintext", () => {
     expect(normalizeSpace("1234567\t123\nab\tcdefg")).toEqual("1234567 123\nab      cdefg");
     expect(normalizeSpace("\n\t1234567\t123\nab\tcdefg")).toEqual("\n        1234567 123\nab      cdefg");
+  });
+
+  it("should handle tabstops in lines containing ANSI codes", () => {
+    expect(normalizeSpace("\x1b[33m\t12345\x1b[0m\t12345")).toEqual("\x1b[33m        12345\x1b[0m   12345");
   });
 });

--- a/app/terminal/text_test.ts
+++ b/app/terminal/text_test.ts
@@ -1,0 +1,20 @@
+import { normalizeSpace } from "./text";
+
+describe("normalizeSpace", () => {
+  it("should apply tab stops", () => {
+    // Single tabstop
+    expect(normalizeSpace("\t1234")).toEqual("        1234");
+    expect(normalizeSpace("1234\t")).toEqual("1234    ");
+    expect(normalizeSpace("1234\t1234")).toEqual("1234    1234");
+    expect(normalizeSpace("1234567\t1234")).toEqual("1234567 1234");
+    expect(normalizeSpace("12345678\t1234")).toEqual("12345678        1234");
+
+    // Multiple tabstops
+    expect(normalizeSpace("1234\t\t1234")).toEqual("1234            1234");
+    expect(normalizeSpace("\t1234\t1234\t")).toEqual("        1234    1234    ");
+
+    // Multiple tabstops with newlines
+    expect(normalizeSpace("1234567\t123\nab\tcdefg")).toEqual("1234567 123\nab      cdefg");
+    expect(normalizeSpace("\n\t1234567\t123\nab\tcdefg")).toEqual("\n        1234567 123\nab      cdefg");
+  });
+});


### PR DESCRIPTION
* Fix bug that we were only expanding at most 1 tab to the equivalent spacing, causing a crash due to incorrect wrapping calculations if a line has multiple tabs.
* Add a safeguard to render a blank line instead of crashing if wrapping calculations are off for any other reason in the future.
* Properly handle tabs by converting each tab to the number of spaces required to reach the next tab stop position.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
