### PR TITLE
Terminal V2: Fix missing newlines in copied-and-pasted text

### DIFF
--- a/app/terminal/row.tsx
+++ b/app/terminal/row.tsx
@@ -30,6 +30,7 @@ export function Row({ data, index, style }: ListChildComponentProps<ListData>) {
       {row.map((part, i) => (
         <RowSpan key={i} {...part} isActiveMatch={part.matchIndex === data.activeMatchIndex} />
       ))}
+      {row === rowsForLine[rowsForLine.length - 1] && "\n"}
     </div>
   );
 }


### PR DESCRIPTION
When copying and pasting text, lines would be concatenated together in a single line. The fix is to append a newline to the last row in each wrapped line. (These newlines are lost when we split by `\n` originally)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
