### PR TITLE
Fix error propagation in dsingleflight util.

### DIFF
--- a/server/util/dsingleflight/BUILD
+++ b/server/util/dsingleflight/BUILD
@@ -22,6 +22,7 @@ go_test(
     embed = [":dsingleflight"],
     deps = [
         "//enterprise/server/testutil/testredis",
+        "//server/util/status",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_sync//errgroup",
     ],

--- a/server/util/dsingleflight/dsingleflight.go
+++ b/server/util/dsingleflight/dsingleflight.go
@@ -67,8 +67,8 @@ func redisResultKey(workKey string) string {
 // doWork executes the work function and publishes the result to redis as well
 // as returning it to teh caller.
 func (c *Coordinator) doWork(ctx context.Context, workKey string, work Work) ([]byte, error) {
-	r, err := work()
-	errStatus := gstatus.Convert(err)
+	r, workErr := work()
+	errStatus := gstatus.Convert(workErr)
 	errStatusBytes, err := proto.Marshal(errStatus.Proto())
 	if err != nil {
 		return nil, status.UnknownErrorf("could not marshal status: %s", err)
@@ -91,7 +91,7 @@ func (c *Coordinator) doWork(ctx context.Context, workKey string, work Work) ([]
 		return nil, status.UnavailableErrorf("could not store result: %s", err)
 	}
 
-	return r, nil
+	return r, workErr
 }
 
 // claimWork loops trying to lock the workKey. If locking succeeds, the passed


### PR DESCRIPTION
We were not propagating the error from the work function. If a worker
got the result from the redis stream, they would see the correct error
but the worker that owns the work could incorrectly return a nil error.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
