### PR TITLE
Update disk access by time with new metric name, add pretty visuals

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -2710,7 +2710,10 @@
           "type": "timeseries"
         },
         {
-          "cards": {},
+          "cards": {
+            "cardPadding": 0.25,
+            "cardRound": 2
+          },
           "color": {
             "cardColor": "#3274D9",
             "colorScale": "sqrt",
@@ -2766,15 +2769,18 @@
           "yBucketBound": "auto"
         },
         {
-          "cards": {},
+          "cards": {
+            "cardPadding": 0.75,
+            "cardRound": 2
+          },
           "color": {
-            "cardColor": "#FADE2A",
+            "cardColor": "#FF9830",
             "colorScale": "sqrt",
             "colorScheme": "interpolateOranges",
             "exponent": 0.5,
             "mode": "opacity"
           },
-          "dataFormat": "tsbuckets",
+          "dataFormat": "timeseries",
           "gridPos": {
             "h": 8,
             "w": 12,
@@ -2797,14 +2803,14 @@
                 "uid": "prom"
               },
               "exemplar": true,
-              "expr": "sum(increase(buildbuddy_remote_cache_disk_cache_seconds_since_last_access_bucket[$__interval])) by (le)",
+              "expr": "sum(increase(buildbuddy_remote_cache_disk_cache_usec_since_last_access_bucket[$__interval])) by (le)",
               "format": "heatmap",
               "interval": "",
               "legendFormat": "{{le}}",
               "refId": "A"
             }
           ],
-          "title": "Disk Cache by Seconds Since Last Access",
+          "title": "Disk Cache by Time Since Last Access",
           "tooltip": {
             "show": true,
             "showHistogram": true
@@ -2815,9 +2821,10 @@
           },
           "yAxis": {
             "decimals": -1,
-            "format": "s",
-            "logBase": 1,
-            "show": true
+            "format": "µs",
+            "logBase": 10,
+            "show": true,
+            "splitFactor": 4
           },
           "yBucketBound": "auto"
         }


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Metric name changed to `buildbuddy_remote_cache_disk_cache_usec_since_last_access_bucket` (and units changed to usec), so update histogram to reflect that. Also tweak graph settings so they look nicer and are easier to understand.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
