### PR TITLE
Add flag type registry

### DIFF
--- a/server/util/flagutil/BUILD
+++ b/server/util/flagutil/BUILD
@@ -5,5 +5,8 @@ go_library(
     srcs = ["flagutil.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/flagutil",
     visibility = ["//visibility:public"],
-    deps = ["//server/util/flagutil/common"],
+    deps = [
+        "//server/util/flagutil/common",
+        "//server/util/flagutil/types/autoflags",
+    ],
 )

--- a/server/util/flagutil/flagutil.go
+++ b/server/util/flagutil/flagutil.go
@@ -2,6 +2,7 @@ package flagutil
 
 import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types/autoflags"
 )
 
 // SetValueForFlagName sets the value for a flag by name. setFlags is the set of
@@ -17,4 +18,33 @@ var SetValueForFlagName = common.SetValueForFlagName
 // a given flag name.
 func GetDereferencedValue[T any](name string) (T, error) {
 	return common.GetDereferencedValue[T](name)
+}
+
+// New declares a new flag named `name` with the specified value `defaultValue`
+// of type `T` and the help text `usage`. It returns a pointer to where the
+// value is stored.
+func New[T any](name string, defaultValue T, usage string) *T {
+	return autoflags.New(name, defaultValue, usage)
+}
+
+// Var declares a new flag named `name` with the specified value `defaultValue`
+// of type `T` stored at the pointer `value` and the help text `usage`.
+func Var[T any](value *T, name string, defaultValue T, usage string) {
+	autoflags.Var(value, name, defaultValue, usage)
+}
+
+// Deprecated declares a new deprecated flag named `name` with the specified
+// value `defaultValue` of type `T`, the help text `usage`, and a
+// `migrationPlan` explaining to the user how to migrate from the deprecated
+// functionality. It returns a pointer to where the value is stored.
+func Deprecated[T any](name string, defaultValue T, usage string, migrationPlan string) *T {
+	return autoflags.Deprecated(name, defaultValue, usage, migrationPlan)
+}
+
+// DeprecatedVar declares a new deprecated flag named `name` with the specified
+// value `defaultValue` of type `T` stored at the pointer `value`, the help text
+// `usage`, and a `migrationPlan` explaining to the user how to migrate from the
+// deprecated functionality.
+func DeprecatedVar[T any](value *T, name string, defaultValue T, usage string, migrationPlan string) {
+	autoflags.DeprecatedVar(value, name, defaultValue, usage, migrationPlan)
 }

--- a/server/util/flagutil/types/autoflags/BUILD
+++ b/server/util/flagutil/types/autoflags/BUILD
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "autoflags",
+    srcs = ["autoflags.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types/autoflags",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/util/flagutil/common",
+        "//server/util/flagutil/types",
+    ],
+)
+
+go_test(
+    name = "autoflags_test",
+    srcs = ["autoflags_test.go"],
+    embed = [":autoflags"],
+    deps = [
+        "//server/util/flagutil/common",
+        "//server/util/flagutil/types",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/util/flagutil/types/autoflags/BUILD
+++ b/server/util/flagutil/types/autoflags/BUILD
@@ -4,7 +4,9 @@ go_library(
     name = "autoflags",
     srcs = ["autoflags.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types/autoflags",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//server/util/flagutil:__subpackages__",
+    ],
     deps = [
         "//server/util/flagutil/common",
         "//server/util/flagutil/types",

--- a/server/util/flagutil/types/autoflags/autoflags.go
+++ b/server/util/flagutil/types/autoflags/autoflags.go
@@ -1,0 +1,73 @@
+package autoflags
+
+import (
+	"log"
+	"net/url"
+	"reflect"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
+
+	flagtypes "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types"
+)
+
+// New declares a new flag named `name` with the specified value `defaultValue`
+// of type `T` and the help text `usage`. It returns a pointer to where the
+// value is stored.
+func New[T any](name string, defaultValue T, usage string) *T {
+	value := reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Interface().(*T)
+	Var(value, name, defaultValue, usage)
+	return value
+}
+
+// Var declares a new flag named `name` with the specified value `defaultValue`
+// of type `T` stored at the pointer `value` and the help text `usage`.
+func Var[T any](value *T, name string, defaultValue T, usage string) {
+	switch v := any(value).(type) {
+	case *bool:
+		common.DefaultFlagSet.BoolVar(v, name, any(defaultValue).(bool), usage)
+	case *time.Duration:
+		common.DefaultFlagSet.DurationVar(v, name, any(defaultValue).(time.Duration), usage)
+	case *float64:
+		common.DefaultFlagSet.Float64Var(v, name, any(defaultValue).(float64), usage)
+	case *int:
+		common.DefaultFlagSet.IntVar(v, name, any(defaultValue).(int), usage)
+	case *int64:
+		common.DefaultFlagSet.Int64Var(v, name, any(defaultValue).(int64), usage)
+	case *uint:
+		common.DefaultFlagSet.UintVar(v, name, any(defaultValue).(uint), usage)
+	case *uint64:
+		common.DefaultFlagSet.Uint64Var(v, name, any(defaultValue).(uint64), usage)
+	case *string:
+		common.DefaultFlagSet.StringVar(v, name, any(defaultValue).(string), usage)
+	case *[]string:
+		flagtypes.StringSliceVar(v, name, any(defaultValue).([]string), usage)
+	case *url.URL:
+		flagtypes.URLVar(v, name, any(defaultValue).(url.URL), usage)
+	default:
+		if reflect.TypeOf(value).Elem().Kind() == reflect.Slice {
+			flagtypes.JSONSliceVar(value, name, defaultValue, usage)
+			return
+		}
+		log.Fatalf("Var was called from flag registry for flag %s with value %v of unrecognized type %T.", name, defaultValue, defaultValue)
+	}
+}
+
+// Deprecated declares a new deprecated flag named `name` with the specified
+// value `defaultValue` of type `T`, the help text `usage`, and a
+// `migrationPlan` explaining to the user how to migrate from the deprecated
+// functionality. It returns a pointer to where the value is stored.
+func Deprecated[T any](name string, defaultValue T, usage string, migrationPlan string) *T {
+	value := New(name, defaultValue, usage)
+	flagtypes.Deprecate[T](name, migrationPlan)
+	return value
+}
+
+// DeprecatedVar declares a new deprecated flag named `name` with the specified
+// value `defaultValue` of type `T` stored at the pointer `value`, the help text
+// `usage`, and a `migrationPlan` explaining to the user how to migrate from the
+// deprecated functionality.
+func DeprecatedVar[T any](value *T, name string, defaultValue T, usage string, migrationPlan string) {
+	Var(value, name, defaultValue, usage)
+	flagtypes.Deprecate[T](name, migrationPlan)
+}

--- a/server/util/flagutil/types/autoflags/autoflags_test.go
+++ b/server/util/flagutil/types/autoflags/autoflags_test.go
@@ -1,4 +1,4 @@
-package common_test
+package autoflags
 
 import (
 	"flag"
@@ -33,101 +33,103 @@ func replaceFlagsForTesting(t *testing.T) *flag.FlagSet {
 	return flags
 }
 
-func TestSetValueForFlagName(t *testing.T) {
+func TestNew(t *testing.T) {
 	flags := replaceFlagsForTesting(t)
-	flagBool := flags.Bool("bool", false, "")
+	flagBool := New("bool", false, "")
 	err := common.SetValueForFlagName("bool", true, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, true, *flagBool)
 
 	flags = replaceFlagsForTesting(t)
-	flagBool = flags.Bool("bool", false, "")
+	flagBool = New("bool", false, "")
 	err = common.SetValueForFlagName("bool", true, map[string]struct{}{"bool": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, false, *flagBool)
 
 	flags = replaceFlagsForTesting(t)
-	flagInt := flags.Int("int", 2, "")
+	flagInt := New("int", 2, "")
 	err = common.SetValueForFlagName("int", 1, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, 1, *flagInt)
 
 	flags = replaceFlagsForTesting(t)
-	flagInt = flags.Int("int", 2, "")
+	flagInt = New("int", 2, "")
 	err = common.SetValueForFlagName("int", 1, map[string]struct{}{"int": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, 2, *flagInt)
 
 	flags = replaceFlagsForTesting(t)
-	flagInt64 := flags.Int64("int64", 2, "")
+	flagInt64 := New("int64", int64(2), "")
 	err = common.SetValueForFlagName("int64", 1, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), *flagInt64)
 
 	flags = replaceFlagsForTesting(t)
-	flagInt64 = flags.Int64("int64", 2, "")
+	flagInt64 = New("int64", int64(2), "")
 	err = common.SetValueForFlagName("int64", 1, map[string]struct{}{"int64": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), *flagInt64)
 
 	flags = replaceFlagsForTesting(t)
-	flagUint := flags.Uint("uint", 2, "")
+	flagUint := New("uint", uint(2), "")
 	err = common.SetValueForFlagName("uint", 1, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, uint(1), *flagUint)
 
 	flags = replaceFlagsForTesting(t)
-	flagUint = flags.Uint("uint", 2, "")
+	flagUint = New("uint", uint(2), "")
 	err = common.SetValueForFlagName("uint", 1, map[string]struct{}{"uint": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, uint(2), *flagUint)
 
 	flags = replaceFlagsForTesting(t)
-	flagUint64 := flags.Uint64("uint64", 2, "")
+	flagUint64 := New("uint64", uint64(2), "")
 	err = common.SetValueForFlagName("uint64", 1, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1), *flagUint64)
 
 	flags = replaceFlagsForTesting(t)
-	flagUint64 = flags.Uint64("uint64", 2, "")
+	flagUint64 = New("uint64", uint64(2), "")
 	err = common.SetValueForFlagName("uint64", 1, map[string]struct{}{"uint64": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(2), *flagUint64)
 
 	flags = replaceFlagsForTesting(t)
-	flagFloat64 := flags.Float64("float64", 2, "")
+	flagFloat64 := New("float64", float64(2), "")
 	err = common.SetValueForFlagName("float64", 1, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, float64(1), *flagFloat64)
 
 	flags = replaceFlagsForTesting(t)
-	flagFloat64 = flags.Float64("float64", 2, "")
+	flagFloat64 = New("float64", float64(2), "")
 	err = common.SetValueForFlagName("float64", 1, map[string]struct{}{"float64": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, float64(2), *flagFloat64)
 
 	flags = replaceFlagsForTesting(t)
-	flagString := flags.String("string", "2", "")
+	flagString := New("string", "2", "")
 	err = common.SetValueForFlagName("string", "1", map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, "1", *flagString)
 
 	flags = replaceFlagsForTesting(t)
-	flagString = flags.String("string", "2", "")
+	flagString = New("string", "2", "")
 	err = common.SetValueForFlagName("string", "1", map[string]struct{}{"string": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, "2", *flagString)
 
 	flags = replaceFlagsForTesting(t)
-	flagURL := flagtypes.URLFromString("url", "https://www.example.com", "")
+	defaultURL := url.URL{Scheme: "https", Host: "www.example.com"}
+	flagURL := New("url", defaultURL, "")
 	u, err := url.Parse("https://www.example.com:8080")
 	require.NoError(t, err)
 	err = common.SetValueForFlagName("url", *u, map[string]struct{}{}, true)
 	require.NoError(t, err)
+	assert.Equal(t, url.URL{Scheme: "https", Host: "www.example.com"}, defaultURL)
 	assert.Equal(t, url.URL{Scheme: "https", Host: "www.example.com:8080"}, *flagURL)
 
 	flags = replaceFlagsForTesting(t)
-	flagURL = flagtypes.URLFromString("url", "https://www.example.com", "")
+	flagURL = New("url", url.URL{Scheme: "https", Host: "www.example.com"}, "")
 	u, err = url.Parse("https://www.example.com:8080")
 	require.NoError(t, err)
 	err = common.SetValueForFlagName("url", *u, map[string]struct{}{"url": {}}, true)
@@ -135,122 +137,58 @@ func TestSetValueForFlagName(t *testing.T) {
 	assert.Equal(t, url.URL{Scheme: "https", Host: "www.example.com"}, *flagURL)
 
 	flags = replaceFlagsForTesting(t)
-	stringSlice := make([]string, 2)
-	stringSlice[0] = "1"
-	stringSlice[1] = "2"
-	flagtypes.SliceVar(&stringSlice, "string_slice", stringSlice, "")
+	defaultStringSlice := []string{"1", "2"}
+	stringSlice := New("string_slice", defaultStringSlice, "")
 	err = common.SetValueForFlagName("string_slice", []string{"3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, map[string]struct{}{}, true)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, stringSlice)
+	assert.Equal(t, []string{"1", "2"}, defaultStringSlice)
+	assert.Equal(t, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, *stringSlice)
 
 	flags = replaceFlagsForTesting(t)
-	flagStringSlice := flagtypes.Slice("string_slice", []string{"1", "2"}, "")
+	stringSlice = New("string_slice", defaultStringSlice, "")
 	err = common.SetValueForFlagName("string_slice", []string{"3"}, map[string]struct{}{"string_slice": {}}, true)
 	require.NoError(t, err)
+	assert.Equal(t, []string{"1", "2"}, defaultStringSlice)
 	assert.Equal(t, []string{"1", "2", "3"}, *(*[]string)(flags.Lookup("string_slice").Value.(*flagtypes.StringSliceFlag)))
-	assert.Equal(t, []string{"1", "2", "3"}, *flagStringSlice)
+	assert.Equal(t, []string{"1", "2", "3"}, *stringSlice)
 
 	flags = replaceFlagsForTesting(t)
-	flagStringSlice = flagtypes.Slice("string_slice", []string{"1", "2"}, "")
+	stringSlice = New("string_slice", defaultStringSlice, "")
 	err = common.SetValueForFlagName("string_slice", []string{"3"}, map[string]struct{}{}, false)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"3"}, *flagStringSlice)
+	assert.Equal(t, []string{"1", "2"}, defaultStringSlice)
+	assert.Equal(t, []string{"3"}, *stringSlice)
 
 	flags = replaceFlagsForTesting(t)
-	flagStringSlice = flagtypes.Slice("string_slice", []string{"1", "2"}, "")
+	stringSlice = New("string_slice", defaultStringSlice, "")
 	err = common.SetValueForFlagName("string_slice", []string{"3"}, map[string]struct{}{"string_slice": {}}, false)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"1", "2"}, *flagStringSlice)
+	assert.Equal(t, []string{"1", "2"}, defaultStringSlice)
+	assert.Equal(t, []string{"1", "2"}, *stringSlice)
 
 	flags = replaceFlagsForTesting(t)
-	flagStructSlice := []testStruct{{Field: 1}, {Field: 2}}
-	flagtypes.SliceVar(&flagStructSlice, "struct_slice", flagStructSlice, "")
+	defaultStructSlice := []testStruct{{Field: 1}, {Field: 2}}
+	structSlice := New("struct_slice", defaultStructSlice, "")
 	err = common.SetValueForFlagName("struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{}, true)
 	require.NoError(t, err)
-	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}, {Field: 3}}, flagStructSlice)
+	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}, {Field: 3}}, *structSlice)
 
 	flags = replaceFlagsForTesting(t)
-	flagStructSlice = []testStruct{{Field: 1}, {Field: 2}}
-	flagtypes.SliceVar(&flagStructSlice, "struct_slice", flagStructSlice, "")
+	structSlice = New("struct_slice", defaultStructSlice, "")
 	err = common.SetValueForFlagName("struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{"struct_slice": {}}, true)
 	require.NoError(t, err)
-	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}, {Field: 3}}, flagStructSlice)
+	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}}, defaultStructSlice)
+	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}, {Field: 3}}, *structSlice)
 
 	flags = replaceFlagsForTesting(t)
-	flagStructSlice = []testStruct{{Field: 1}, {Field: 2}}
-	flagtypes.SliceVar(&flagStructSlice, "struct_slice", flagStructSlice, "")
+	structSlice = New("struct_slice", defaultStructSlice, "")
 	err = common.SetValueForFlagName("struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{}, false)
 	require.NoError(t, err)
-	assert.Equal(t, []testStruct{{Field: 3}}, flagStructSlice)
+	assert.Equal(t, []testStruct{{Field: 3}}, *structSlice)
 
 	flags = replaceFlagsForTesting(t)
-	flagStructSlice = []testStruct{{Field: 1}, {Field: 2}}
-	flagtypes.SliceVar(&flagStructSlice, "struct_slice", flagStructSlice, "")
+	structSlice = New("struct_slice", defaultStructSlice, "")
 	err = common.SetValueForFlagName("struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{"struct_slice": {}}, false)
 	require.NoError(t, err)
-	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}}, flagStructSlice)
-}
-
-func TestBadSetValueForFlagName(t *testing.T) {
-	flags := replaceFlagsForTesting(t)
-	_ = flags.Bool("bool", false, "")
-	err := common.SetValueForFlagName("bool", 0, map[string]struct{}{}, true)
-	require.Error(t, err)
-
-	flags = replaceFlagsForTesting(t)
-	err = common.SetValueForFlagName("bool", false, map[string]struct{}{}, true)
-	require.Error(t, err)
-
-	flags = replaceFlagsForTesting(t)
-	_ = flagtypes.Slice("string_slice", []string{"1", "2"}, "")
-	err = common.SetValueForFlagName("string_slice", "3", map[string]struct{}{}, true)
-	require.Error(t, err)
-
-	flags = replaceFlagsForTesting(t)
-	_ = flagtypes.Slice("string_slice", []string{"1", "2"}, "")
-	err = common.SetValueForFlagName("string_slice", "3", map[string]struct{}{}, false)
-	require.Error(t, err)
-
-	flags = replaceFlagsForTesting(t)
-	flagStructSlice := []testStruct{{Field: 1}, {Field: 2}}
-	flagtypes.SliceVar(&flagStructSlice, "struct_slice", flagStructSlice, "")
-	err = common.SetValueForFlagName("struct_slice", testStruct{Field: 3}, map[string]struct{}{}, true)
-	require.Error(t, err)
-
-	flags = replaceFlagsForTesting(t)
-	flagStructSlice = []testStruct{{Field: 1}, {Field: 2}}
-	flagtypes.SliceVar(&flagStructSlice, "struct_slice", flagStructSlice, "")
-	err = common.SetValueForFlagName("struct_slice", testStruct{Field: 3}, map[string]struct{}{}, false)
-	require.Error(t, err)
-}
-
-func TestDereferencedValueFromFlagName(t *testing.T) {
-	flags := replaceFlagsForTesting(t)
-	_ = flags.Bool("bool", false, "")
-	v, err := common.GetDereferencedValue[bool]("bool")
-	require.NoError(t, err)
-	assert.Equal(t, false, v)
-
-	flags = replaceFlagsForTesting(t)
-	_ = flags.Bool("bool", true, "")
-	v, err = common.GetDereferencedValue[bool]("bool")
-	require.NoError(t, err)
-	assert.Equal(t, true, v)
-
-	flags = replaceFlagsForTesting(t)
-	_ = flagtypes.Slice("string_slice", []string{"1", "2"}, "")
-	stringSlice, err := common.GetDereferencedValue[[]string]("string_slice")
-	require.NoError(t, err)
-	assert.Equal(t, []string{"1", "2"}, stringSlice)
-
-	flags = replaceFlagsForTesting(t)
-	structSlice := flagtypes.Slice("struct_slice", []testStruct{{Field: 1}, {Field: 2}}, "")
-	require.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}}, *structSlice)
-}
-
-func TestBadDereferencedValueFromFlagName(t *testing.T) {
-	_ = replaceFlagsForTesting(t)
-	_, err := common.GetDereferencedValue[any]("unknown_flag")
-	require.Error(t, err)
 }

--- a/server/util/flagutil/types/types.go
+++ b/server/util/flagutil/types/types.go
@@ -1,5 +1,14 @@
 package types
 
+// For user-defined flag value types. New flag value types should be declared
+// either as a type definition of the type they contain (see `StringSliceFlag`
+// for an example) or a type definition of a `reflect.Value` which will itself
+// wrap the desired value (see `JSONSliceFlag` for an example). Any new type
+// should also be added to the `Var` function in the `autoflags` subpackage of
+// this package.
+//
+// New flag value types should implement `common.TypeAliased` and `flag.Value`.
+
 import (
 	"encoding/json"
 	"flag"
@@ -45,95 +54,156 @@ func NewPrimitiveFlag[T bool | time.Duration | float64 | int | int64 | uint | ui
 	return NewPrimitiveFlagVar(&value)
 }
 
-type SliceFlag[T any] []T
-
-func NewSliceFlag[T any](slice *[]T) *SliceFlag[T] {
-	return (*SliceFlag[T])(slice)
-}
-
 func Slice[T any](name string, defaultValue []T, usage string) *[]T {
-	slice := make([]T, len(defaultValue))
-	copy(slice, defaultValue)
-	common.DefaultFlagSet.Var(NewSliceFlag(&slice), name, usage)
-	return &slice
+	slice := &[]T{}
+	SliceVar(slice, name, defaultValue, usage)
+	return slice
 }
 
-func SliceVar[T any](slice *[]T, name, usage string) {
-	common.DefaultFlagSet.Var(NewSliceFlag(slice), name, usage)
-}
-
-func (f *SliceFlag[T]) String() string {
-	switch v := any((*[]T)(f)).(type) {
+func SliceVar[T any](slice *[]T, name string, defaultSlice []T, usage string) {
+	switch s := any(slice).(type) {
 	case *[]string:
-		return strings.Join(*v, ",")
+		StringSliceVar(s, name, any(defaultSlice).([]string), usage)
 	default:
-		b, err := json.Marshal(f)
-		if err != nil {
-			alert.UnexpectedEvent("config_cannot_marshal_struct", "err: %s", err)
-			return "[]"
-		}
-		return string(b)
+		JSONSliceVar(slice, name, defaultSlice, usage)
 	}
 }
 
-func (f *SliceFlag[T]) Set(values string) error {
-	if v, ok := any((*[]T)(f)).(*[]string); ok {
-		for _, val := range strings.Split(values, ",") {
-			*v = append(*v, val)
-		}
-		return nil
+type JSONSliceFlag[T any] reflect.Value
+
+func NewJSONSliceFlag[T any](slice *T) *JSONSliceFlag[T] {
+	v := (JSONSliceFlag[T])(reflect.ValueOf(slice))
+	return &v
+}
+
+func JSONSlice[T any](name string, defaultValue T, usage string) *T {
+	value := reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Interface().(*T)
+	JSONSliceVar(value, name, defaultValue, usage)
+	return value
+}
+
+func JSONSliceVar[T any](value *T, name string, defaultValue T, usage string) {
+	src := reflect.ValueOf(defaultValue)
+	if src.Kind() != reflect.Slice {
+		log.Fatalf("JSONSliceVar called for flag %s with non-slice value %v of type %T.", name, defaultValue, defaultValue)
 	}
-	v := (*[]T)(f)
+	v := reflect.ValueOf(value)
+	if src.IsNil() && !v.Elem().IsNil() {
+		v.Elem().Set(reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Elem())
+	} else if v.Elem().Len() != src.Len() || v.Elem().IsNil() {
+		v.Elem().Set(reflect.MakeSlice(reflect.TypeOf((*T)(nil)).Elem(), src.Len(), src.Len()))
+	}
+	reflect.Copy(v.Elem(), src)
+	common.DefaultFlagSet.Var((*JSONSliceFlag[T])(&v), name, usage)
+}
+
+func (f *JSONSliceFlag[T]) String() string {
+	b, err := json.Marshal((*reflect.Value)(f).Interface())
+	if err != nil {
+		alert.UnexpectedEvent("config_cannot_marshal_struct", "err: %s", err)
+		return "[]"
+	}
+	return string(b)
+}
+
+func (f *JSONSliceFlag[T]) Set(values string) error {
 	var a any
 	if err := json.Unmarshal([]byte(values), &a); err != nil {
 		return err
 	}
+	v := (reflect.Value)(*f).Elem()
 	if _, ok := a.([]any); ok {
-		var dst []T
-		if err := json.Unmarshal([]byte(values), &dst); err != nil {
+		dst := reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Interface()
+		if err := json.Unmarshal([]byte(values), dst); err != nil {
 			return err
 		}
-		*v = append(*v, dst...)
+		v.Set(reflect.AppendSlice(v, reflect.ValueOf(dst).Elem()))
 		return nil
 	}
 	if _, ok := a.(map[string]any); ok {
-		var dst T
-		if err := json.Unmarshal([]byte(values), &dst); err != nil {
+		dst := reflect.New(reflect.TypeOf((*T)(nil)).Elem().Elem()).Interface()
+		if err := json.Unmarshal([]byte(values), dst); err != nil {
 			return err
 		}
-		*v = append(*v, dst)
+		v.Set(reflect.Append(v, reflect.ValueOf(dst).Elem()))
 		return nil
 	}
 	return fmt.Errorf("Default Set for SliceFlag can only accept JSON objects or arrays, but type was %T", a)
 }
 
-func (f *SliceFlag[T]) AppendSlice(slice any) error {
-	s, ok := slice.([]T)
-	if !ok {
-		return status.FailedPreconditionErrorf("Cannot append value %v of type %T to flag of type %T.", slice, slice, ([]T)(nil))
+func (f *JSONSliceFlag[T]) AppendSlice(slice any) error {
+	v := (reflect.Value)(*f)
+	if _, ok := slice.(T); !ok {
+		return status.FailedPreconditionErrorf("Cannot append value %v of type %T to flag of type %s.", slice, slice, v.Type().Elem())
 	}
-	v := (*[]T)(f)
-	*v = append(*v, s...)
+	v.Elem().Set(reflect.AppendSlice(v.Elem(), reflect.ValueOf(slice)))
 	return nil
 }
 
-func (f *SliceFlag[T]) AliasedType() reflect.Type {
-	return reflect.TypeOf((*[]T)(nil))
+func (f *JSONSliceFlag[T]) AliasedType() reflect.Type {
+	return reflect.TypeOf((*T)(nil))
 }
 
-func (f *SliceFlag[T]) YAMLTypeAlias() reflect.Type {
-	return f.AliasedType()
+func (f *JSONSliceFlag[T]) Slice() T {
+	return *(reflect.Value)(*f).Interface().(*T)
+}
+
+type StringSliceFlag []string
+
+func NewStringSliceFlag(slice *[]string) *StringSliceFlag {
+	return (*StringSliceFlag)(slice)
+}
+
+func StringSlice(name string, defaultValue []string, usage string) *[]string {
+	value := &[]string{}
+	StringSliceVar(value, name, defaultValue, usage)
+	return value
+}
+
+func StringSliceVar(value *[]string, name string, defaultValue []string, usage string) {
+	if defaultValue == nil && *value != nil {
+		*value = nil
+	} else if len(*value) != len(defaultValue) || *value == nil {
+		*value = make([]string, len(defaultValue))
+	}
+	copy(*value, defaultValue)
+	common.DefaultFlagSet.Var((*StringSliceFlag)(value), name, usage)
+}
+
+func (f *StringSliceFlag) String() string {
+	return strings.Join(*f, ",")
+}
+
+func (f *StringSliceFlag) Set(values string) error {
+	for _, val := range strings.Split(values, ",") {
+		*f = append(*f, val)
+	}
+	return nil
+}
+
+func (f *StringSliceFlag) AppendSlice(slice any) error {
+	s, ok := slice.([]string)
+	if !ok {
+		return status.FailedPreconditionErrorf("Cannot append value %v of type %T to flag of type []string.", slice, slice)
+	}
+	*f = append(*f, s...)
+	return nil
+}
+
+func (f *StringSliceFlag) AliasedType() reflect.Type {
+	return reflect.TypeOf((*[]string)(nil))
 }
 
 type URLFlag url.URL
 
-func URL(name string, value url.URL, usage string) *url.URL {
-	u := &value
-	common.DefaultFlagSet.Var((*URLFlag)(u), name, usage)
-	return u
+func URL(name string, defaultValue url.URL, usage string) *url.URL {
+	value := &url.URL{}
+	URLVar(value, name, defaultValue, usage)
+	return value
 }
 
-func URLVar(value *url.URL, name string, usage string) {
+func URLVar(value *url.URL, name string, defaultValue url.URL, usage string) {
+	*value = *defaultValue.ResolveReference(&url.URL{})
 	common.DefaultFlagSet.Var((*URLFlag)(value), name, usage)
 }
 
@@ -218,8 +288,8 @@ func (f *FlagAlias[T]) Set(value string) error {
 }
 
 func (f *FlagAlias[T]) String() string {
-	if f.name == "" && f.WrappedValue() == nil {
-		return fmt.Sprint(*common.Zero[T]())
+	if f == nil || (f.name == "" && f.WrappedValue() == nil) {
+		return fmt.Sprint(common.Zero[T]())
 	}
 	return f.WrappedValue().String()
 }
@@ -239,7 +309,7 @@ func (f *FlagAlias[T]) WrappedValue() flag.Value {
 type DeprecatedFlag[T any] struct {
 	flag.Value
 	name          string
-	migrationPlan string
+	MigrationPlan string
 }
 
 // DeprecatedVar takes a flag.Value (which can be obtained for primitive types
@@ -258,16 +328,40 @@ type DeprecatedFlag[T any] struct {
 //   "All of our foos were destroyed in a fire, please specify a bar instead.",
 // )
 func DeprecatedVar[T any](value flag.Value, name string, usage, migrationPlan string) *T {
-	common.DefaultFlagSet.Var(&DeprecatedFlag[T]{value, name, migrationPlan}, name, usage+" **DEPRECATED** "+migrationPlan)
+	common.DefaultFlagSet.Var(value, name, usage)
+	Deprecate[T](name, migrationPlan)
 	converted, err := common.ConvertFlagValue(value)
 	if err != nil {
 		log.Fatalf("Error creating deprecated flag %s: %v", name, err)
 	}
-	return converted.(*T)
+	c, ok := converted.(*T)
+	if !ok {
+		log.Fatalf("Error creating deprecated flag %s: could not coerce flag of type %T to type %T.", name, converted, (*T)(nil))
+	}
+	return c
+}
+
+// Deprecate deprecates an existing flag by name; generally this should be
+// called in an init func. While simpler to use than DeprecatedVar, it does
+// decouple the flag declaration from the flag deprecation.
+func Deprecate[T any](name, migrationPlan string) {
+	flg := common.DefaultFlagSet.Lookup(name)
+	converted, err := common.ConvertFlagValue(flg.Value)
+	if err != nil {
+		log.Fatalf("Error creating deprecated flag %s: %v", name, err)
+	} else if _, ok := converted.(*T); !ok {
+		log.Fatalf("Error creating deprecated flag %s: could not coerce flag of type %T to type %T.", name, converted, (*T)(nil))
+	}
+	flg.Value = &DeprecatedFlag[T]{
+		Value:         flg.Value,
+		name:          flg.Name,
+		MigrationPlan: migrationPlan,
+	}
+	flg.Usage = flg.Usage + " **DEPRECATED** " + migrationPlan
 }
 
 func (d *DeprecatedFlag[T]) Set(value string) error {
-	log.Warningf("Flag \"%s\" was set on the command line but has been deprecated: %s", d.name, d.migrationPlan)
+	log.Warningf("Flag \"%s\" was set on the command line but has been deprecated: %s", d.name, d.MigrationPlan)
 	return d.Value.Set(value)
 }
 
@@ -276,16 +370,16 @@ func (d *DeprecatedFlag[T]) WrappedValue() flag.Value {
 }
 
 func (d *DeprecatedFlag[T]) SetValueForFlagNameHook() {
-	log.Warningf("Flag \"%s\" was set programmatically by name but has been deprecated: %s", d.name, d.migrationPlan)
+	log.Warningf("Flag \"%s\" was set programmatically by name but has been deprecated: %s", d.name, d.MigrationPlan)
 }
 
 func (d *DeprecatedFlag[T]) YAMLSetValueHook() {
-	log.Warningf("Flag \"%s\" was set through the YAML config but has been deprecated: %s", d.name, d.migrationPlan)
+	log.Warningf("Flag \"%s\" was set through the YAML config but has been deprecated: %s", d.name, d.MigrationPlan)
 }
 
 func (d *DeprecatedFlag[T]) String() string {
-	if d.Value == nil {
-		return fmt.Sprint(*common.Zero[T]())
+	if d == nil || d.Value == nil {
+		return fmt.Sprint(common.Zero[T]())
 	}
 	return d.Value.String()
 }

--- a/server/util/flagutil/types/types_test.go
+++ b/server/util/flagutil/types/types_test.go
@@ -36,7 +36,7 @@ func TestStringSliceFlag(t *testing.T) {
 
 	foo := Slice("foo", []string{}, "A list of foos")
 	assert.Equal(t, []string{}, *foo)
-	assert.Equal(t, []string{}, *(*[]string)(flags.Lookup("foo").Value.(*SliceFlag[string])))
+	assert.Equal(t, []string{}, *(*[]string)(flags.Lookup("foo").Value.(*StringSliceFlag)))
 	err = flags.Set("foo", "foo0,foo1")
 	assert.NoError(t, err)
 	err = flags.Set("foo", "foo2")
@@ -44,17 +44,17 @@ func TestStringSliceFlag(t *testing.T) {
 	err = flags.Set("foo", "foo3,foo4,foo5")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"foo0", "foo1", "foo2", "foo3", "foo4", "foo5"}, *foo)
-	assert.Equal(t, []string{"foo0", "foo1", "foo2", "foo3", "foo4", "foo5"}, *(*[]string)(flags.Lookup("foo").Value.(*SliceFlag[string])))
+	assert.Equal(t, []string{"foo0", "foo1", "foo2", "foo3", "foo4", "foo5"}, *(*[]string)(flags.Lookup("foo").Value.(*StringSliceFlag)))
 
 	bar := Slice("bar", []string{"bar0", "bar1"}, "A list of bars")
 	assert.Equal(t, []string{"bar0", "bar1"}, *bar)
-	assert.Equal(t, []string{"bar0", "bar1"}, *(*[]string)(flags.Lookup("bar").Value.(*SliceFlag[string])))
+	assert.Equal(t, []string{"bar0", "bar1"}, *(*[]string)(flags.Lookup("bar").Value.(*StringSliceFlag)))
 	err = flags.Set("bar", "bar2")
 	assert.NoError(t, err)
 	err = flags.Set("bar", "bar3,bar4,bar5")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"bar0", "bar1", "bar2", "bar3", "bar4", "bar5"}, *bar)
-	assert.Equal(t, []string{"bar0", "bar1", "bar2", "bar3", "bar4", "bar5"}, *(*[]string)(flags.Lookup("bar").Value.(*SliceFlag[string])))
+	assert.Equal(t, []string{"bar0", "bar1", "bar2", "bar3", "bar4", "bar5"}, *(*[]string)(flags.Lookup("bar").Value.(*StringSliceFlag)))
 
 	baz := Slice("baz", []string{}, "A list of bazs")
 	err = flags.Set("baz", flags.Lookup("bar").Value.String())
@@ -62,8 +62,8 @@ func TestStringSliceFlag(t *testing.T) {
 	assert.Equal(t, *bar, *baz)
 
 	testSlice := []string{"yes", "si", "hai"}
-	testFlag := NewSliceFlag(&testSlice)
-	testFlag.AppendSlice(*(*[]string)(testFlag))
+	testFlag := NewJSONSliceFlag(&testSlice)
+	testFlag.AppendSlice(testFlag.Slice())
 	assert.Equal(t, []string{"yes", "si", "hai", "yes", "si", "hai"}, testSlice)
 }
 
@@ -74,42 +74,42 @@ func TestStructSliceFlag(t *testing.T) {
 
 	fooFlag := Slice("foo", []testStruct{}, "A list of foos")
 	assert.Equal(t, []testStruct{}, *fooFlag)
-	assert.Equal(t, []testStruct{}, *(*[]testStruct)(flags.Lookup("foo").Value.(*SliceFlag[testStruct])))
+	assert.Equal(t, []testStruct{}, ([]testStruct)(flags.Lookup("foo").Value.(*JSONSliceFlag[[]testStruct]).Slice()))
 	err = flags.Set("foo", `[{"field":3,"meadow":"watership down"}]`)
 	assert.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 3, Meadow: "watership down"}}, *fooFlag)
-	assert.Equal(t, []testStruct{{Field: 3, Meadow: "watership down"}}, *(*[]testStruct)(flags.Lookup("foo").Value.(*SliceFlag[testStruct])))
+	assert.Equal(t, []testStruct{{Field: 3, Meadow: "watership down"}}, ([]testStruct)(flags.Lookup("foo").Value.(*JSONSliceFlag[[]testStruct]).Slice()))
 	err = flags.Set("foo", `{"field":5,"meadow":"runnymede"}`)
 	assert.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 3, Meadow: "watership down"}, {Field: 5, Meadow: "runnymede"}}, *fooFlag)
-	assert.Equal(t, []testStruct{{Field: 3, Meadow: "watership down"}, {Field: 5, Meadow: "runnymede"}}, *(*[]testStruct)(flags.Lookup("foo").Value.(*SliceFlag[testStruct])))
+	assert.Equal(t, []testStruct{{Field: 3, Meadow: "watership down"}, {Field: 5, Meadow: "runnymede"}}, ([]testStruct)(flags.Lookup("foo").Value.(*JSONSliceFlag[[]testStruct]).Slice()))
 
 	barFlag := []testStruct{{Field: 11, Meadow: "arcadia"}, {Field: 13, Meadow: "kingcombe"}}
-	SliceVar(&barFlag, "bar", "A list of bars")
+	SliceVar(&barFlag, "bar", barFlag, "A list of bars")
 	assert.Equal(t, []testStruct{{Field: 11, Meadow: "arcadia"}, {Field: 13, Meadow: "kingcombe"}}, barFlag)
-	assert.Equal(t, []testStruct{{Field: 11, Meadow: "arcadia"}, {Field: 13, Meadow: "kingcombe"}}, *(*[]testStruct)(flags.Lookup("bar").Value.(*SliceFlag[testStruct])))
+	assert.Equal(t, []testStruct{{Field: 11, Meadow: "arcadia"}, {Field: 13, Meadow: "kingcombe"}}, ([]testStruct)(flags.Lookup("bar").Value.(*JSONSliceFlag[[]testStruct]).Slice()))
 
 	fooxFlag := Slice("foox", []testStruct{}, "A list of fooxes")
 	assert.Equal(t, []testStruct{}, *fooxFlag)
-	assert.Equal(t, []testStruct{}, *(*[]testStruct)(flags.Lookup("foox").Value.(*SliceFlag[testStruct])))
+	assert.Equal(t, []testStruct{}, ([]testStruct)(flags.Lookup("foox").Value.(*JSONSliceFlag[[]testStruct]).Slice()))
 	err = flags.Set("foox", `[{"field":13,"meadow":"cors y llyn"},{},{"field":15}]`)
 	assert.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 13, Meadow: "cors y llyn"}, {}, {Field: 15}}, *fooxFlag)
-	assert.Equal(t, []testStruct{{Field: 13, Meadow: "cors y llyn"}, {}, {Field: 15}}, *(*[]testStruct)(flags.Lookup("foox").Value.(*SliceFlag[testStruct])))
+	assert.Equal(t, []testStruct{{Field: 13, Meadow: "cors y llyn"}, {}, {Field: 15}}, ([]testStruct)(flags.Lookup("foox").Value.(*JSONSliceFlag[[]testStruct]).Slice()))
 	err = flags.Set("foox", `[{"field":17,"meadow":"red hill"},{},{"field":19}]`)
 	assert.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 13, Meadow: "cors y llyn"}, {}, {Field: 15}, {Field: 17, Meadow: "red hill"}, {}, {Field: 19}}, *fooxFlag)
-	assert.Equal(t, []testStruct{{Field: 13, Meadow: "cors y llyn"}, {}, {Field: 15}, {Field: 17, Meadow: "red hill"}, {}, {Field: 19}}, *(*[]testStruct)(flags.Lookup("foox").Value.(*SliceFlag[testStruct])))
+	assert.Equal(t, []testStruct{{Field: 13, Meadow: "cors y llyn"}, {}, {Field: 15}, {Field: 17, Meadow: "red hill"}, {}, {Field: 19}}, ([]testStruct)(flags.Lookup("foox").Value.(*JSONSliceFlag[[]testStruct]).Slice()))
 
 	bazFlag := []testStruct{}
-	SliceVar(&bazFlag, "baz", "A list of bazs")
+	SliceVar(&bazFlag, "baz", bazFlag, "A list of bazs")
 	err = flags.Set("baz", flags.Lookup("bar").Value.String())
 	assert.NoError(t, err)
 	assert.Equal(t, barFlag, bazFlag)
 
 	testSlice := []testStruct{{}, {Field: 1}, {Meadow: "Paradise"}}
-	testFlag := NewSliceFlag(&testSlice)
-	testFlag.AppendSlice(*(*[]testStruct)(testFlag))
+	testFlag := NewJSONSliceFlag(&testSlice)
+	testFlag.AppendSlice(testFlag.Slice())
 	assert.Equal(t, []testStruct{{}, {Field: 1}, {Meadow: "Paradise"}, {}, {Field: 1}, {Meadow: "Paradise"}}, testSlice)
 }
 
@@ -120,42 +120,42 @@ func TestProtoSliceFlag(t *testing.T) {
 
 	fooFlag := Slice("foo", []*timestamppb.Timestamp{}, "A list of foos")
 	assert.Equal(t, []*timestamppb.Timestamp{}, *fooFlag)
-	assert.Equal(t, []*timestamppb.Timestamp{}, *(*[]*timestamppb.Timestamp)(flags.Lookup("foo").Value.(*SliceFlag[*timestamppb.Timestamp])))
+	assert.Equal(t, []*timestamppb.Timestamp{}, ([]*timestamppb.Timestamp)(flags.Lookup("foo").Value.(*JSONSliceFlag[[]*timestamppb.Timestamp]).Slice()))
 	err = flags.Set("foo", `[{"seconds":3,"nanos":5}]`)
 	assert.NoError(t, err)
 	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 3, Nanos: 5}}, *fooFlag)
-	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 3, Nanos: 5}}, *(*[]*timestamppb.Timestamp)(flags.Lookup("foo").Value.(*SliceFlag[*timestamppb.Timestamp])))
+	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 3, Nanos: 5}}, ([]*timestamppb.Timestamp)(flags.Lookup("foo").Value.(*JSONSliceFlag[[]*timestamppb.Timestamp]).Slice()))
 	err = flags.Set("foo", `{"seconds":5,"nanos":9}`)
 	assert.NoError(t, err)
 	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 3, Nanos: 5}, {Seconds: 5, Nanos: 9}}, *fooFlag)
-	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 3, Nanos: 5}, {Seconds: 5, Nanos: 9}}, *(*[]*timestamppb.Timestamp)(flags.Lookup("foo").Value.(*SliceFlag[*timestamppb.Timestamp])))
+	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 3, Nanos: 5}, {Seconds: 5, Nanos: 9}}, ([]*timestamppb.Timestamp)(flags.Lookup("foo").Value.(*JSONSliceFlag[[]*timestamppb.Timestamp]).Slice()))
 
 	barFlag := []*timestamppb.Timestamp{{Seconds: 11, Nanos: 100}, {Seconds: 13, Nanos: 256}}
-	SliceVar(&barFlag, "bar", "A list of bars")
+	SliceVar(&barFlag, "bar", barFlag, "A list of bars")
 	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 11, Nanos: 100}, {Seconds: 13, Nanos: 256}}, barFlag)
-	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 11, Nanos: 100}, {Seconds: 13, Nanos: 256}}, *(*[]*timestamppb.Timestamp)(flags.Lookup("bar").Value.(*SliceFlag[*timestamppb.Timestamp])))
+	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 11, Nanos: 100}, {Seconds: 13, Nanos: 256}}, ([]*timestamppb.Timestamp)(flags.Lookup("bar").Value.(*JSONSliceFlag[[]*timestamppb.Timestamp]).Slice()))
 
 	fooxFlag := Slice("foox", []*timestamppb.Timestamp{}, "A list of fooxes")
 	assert.Equal(t, []*timestamppb.Timestamp{}, *fooxFlag)
-	assert.Equal(t, []*timestamppb.Timestamp{}, *(*[]*timestamppb.Timestamp)(flags.Lookup("foox").Value.(*SliceFlag[*timestamppb.Timestamp])))
+	assert.Equal(t, []*timestamppb.Timestamp{}, ([]*timestamppb.Timestamp)(flags.Lookup("foox").Value.(*JSONSliceFlag[[]*timestamppb.Timestamp]).Slice()))
 	err = flags.Set("foox", `[{"seconds":13,"nanos":64},{},{"seconds":15}]`)
 	assert.NoError(t, err)
 	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 13, Nanos: 64}, {}, {Seconds: 15}}, *fooxFlag)
-	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 13, Nanos: 64}, {}, {Seconds: 15}}, *(*[]*timestamppb.Timestamp)(flags.Lookup("foox").Value.(*SliceFlag[*timestamppb.Timestamp])))
+	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 13, Nanos: 64}, {}, {Seconds: 15}}, ([]*timestamppb.Timestamp)(flags.Lookup("foox").Value.(*JSONSliceFlag[[]*timestamppb.Timestamp]).Slice()))
 	err = flags.Set("foox", `[{"seconds":17,"nanos":9001},{},{"seconds":19}]`)
 	assert.NoError(t, err)
 	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 13, Nanos: 64}, {}, {Seconds: 15}, {Seconds: 17, Nanos: 9001}, {}, {Seconds: 19}}, *fooxFlag)
-	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 13, Nanos: 64}, {}, {Seconds: 15}, {Seconds: 17, Nanos: 9001}, {}, {Seconds: 19}}, *(*[]*timestamppb.Timestamp)(flags.Lookup("foox").Value.(*SliceFlag[*timestamppb.Timestamp])))
+	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 13, Nanos: 64}, {}, {Seconds: 15}, {Seconds: 17, Nanos: 9001}, {}, {Seconds: 19}}, ([]*timestamppb.Timestamp)(flags.Lookup("foox").Value.(*JSONSliceFlag[[]*timestamppb.Timestamp]).Slice()))
 
 	bazFlag := []*timestamppb.Timestamp{}
-	SliceVar(&bazFlag, "baz", "A list of bazs")
+	SliceVar(&bazFlag, "baz", bazFlag, "A list of bazs")
 	err = flags.Set("baz", flags.Lookup("bar").Value.String())
 	assert.NoError(t, err)
 	assert.Equal(t, barFlag, bazFlag)
 
 	testSlice := []*timestamppb.Timestamp{{}, {Seconds: 1}, {Nanos: 99}}
-	testFlag := NewSliceFlag(&testSlice)
-	testFlag.AppendSlice(*(*[]*timestamppb.Timestamp)(testFlag))
+	testFlag := NewJSONSliceFlag(&testSlice)
+	testFlag.AppendSlice(testFlag.Slice())
 	assert.Equal(t, []*timestamppb.Timestamp{{}, {Seconds: 1}, {Nanos: 99}, {}, {Seconds: 1}, {Nanos: 99}}, testSlice)
 
 }
@@ -301,7 +301,7 @@ string_alias: "meow"
 	string_slice := make([]string, 2)
 	string_slice[0] = "1"
 	string_slice[1] = "2"
-	SliceVar(&string_slice, "string_slice", "")
+	SliceVar(&string_slice, "string_slice", string_slice, "")
 	Alias[[]string]("string_slice", "string_slice_alias")
 	err = common.SetValueForFlagName("string_slice_alias", []string{"3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, map[string]struct{}{}, true)
 	require.NoError(t, err)
@@ -332,7 +332,7 @@ string_alias: "meow"
 	string_slice = make([]string, 2)
 	string_slice[0] = "1"
 	string_slice[1] = "2"
-	SliceVar(&string_slice, "string_slice", "")
+	SliceVar(&string_slice, "string_slice", string_slice, "")
 	Alias[[]string]("string_slice", "string_slice_alias")
 	Alias[[]string]("string_slice_alias", "string_slice_alias_alias")
 	err = common.SetValueForFlagName("string_slice_alias_alias", []string{"3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, map[string]struct{}{}, true)
@@ -380,16 +380,16 @@ string_alias: "meow"
 	assert.Equal(t, []string{"1", "2"}, stringSliceAliasAlias)
 
 	flags = replaceFlagsForTesting(t)
-	SliceVar(&[]testStruct{{Field: 1}, {Field: 2}}, "struct_slice", "")
+	Slice("struct_slice", []testStruct{{Field: 1}, {Field: 2}}, "")
 	structSlice, err := common.GetDereferencedValue[[]testStruct]("struct_slice")
 	require.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}}, structSlice)
 }
 
-func TestDeprecateFlag(t *testing.T) {
+func TestDeprecatedVar(t *testing.T) {
 	flags := replaceFlagsForTesting(t)
 	flagInt := DeprecatedVar[int](NewPrimitiveFlag(5), "deprecated_int", "", "migration plan")
-	flagStringSlice := DeprecatedVar[[]string](NewSliceFlag(&[]string{"hi"}), "deprecated_string_slice", "", "migration plan")
+	flagStringSlice := DeprecatedVar[[]string](NewStringSliceFlag(&[]string{"hi"}), "deprecated_string_slice", "", "migration plan")
 	assert.Equal(t, *flagInt, 5)
 	assert.Equal(t, *flagStringSlice, []string{"hi"})
 	flags.Set("deprecated_int", "7")
@@ -407,7 +407,7 @@ func TestDeprecateFlag(t *testing.T) {
 
 	flagInt = DeprecatedVar[int](NewPrimitiveFlag(5), "deprecated_int", "", "migration plan")
 	flagString := DeprecatedVar[string](NewPrimitiveFlag(""), "deprecated_string", "", "migration plan")
-	flagStringSlice = DeprecatedVar[[]string](NewSliceFlag(&[]string{"hi"}), "deprecated_string_slice", "", "migration plan")
+	flagStringSlice = DeprecatedVar[[]string](NewStringSliceFlag(&[]string{"hi"}), "deprecated_string_slice", "", "migration plan")
 	flags.Set("deprecated_int", "7")
 	flags.Set("deprecated_string_slice", "hello")
 	yamlData := `
@@ -432,6 +432,67 @@ deprecated_string_slice:
 	assert.Equal(t, testStringSlice, []string{"hi", "hello", "hey"})
 
 	d := any(&DeprecatedFlag[struct{}]{})
+	_, ok := d.(common.WrappingValue)
+	assert.True(t, ok)
+	_, ok = d.(common.SetValueForFlagNameHooked)
+	assert.True(t, ok)
+	_, ok = d.(flagyaml.YAMLSetValueHooked)
+	assert.True(t, ok)
+
+}
+
+func TestDeprecate(t *testing.T) {
+	flags := replaceFlagsForTesting(t)
+	flagInt := flags.Int("deprecated_int", 5, "some usage text")
+	Deprecate[int]("deprecated_int", "migration plan")
+	flagStringSlice := StringSlice("deprecated_string_slice", []string{"hi"}, "")
+	Deprecate[[]string]("deprecated_string_slice", "migration plan")
+	assert.Equal(t, *flagInt, 5)
+	assert.Equal(t, *flagStringSlice, []string{"hi"})
+	flags.Set("deprecated_int", "7")
+	flags.Set("deprecated_string_slice", "hello")
+	assert.Equal(t, *flagStringSlice, []string{"hi", "hello"})
+	assert.Equal(t, *flagInt, 7)
+	testInt, err := common.GetDereferencedValue[int]("deprecated_int")
+	require.NoError(t, err)
+	assert.Equal(t, testInt, 7)
+	testStringSlice, err := common.GetDereferencedValue[[]string]("deprecated_string_slice")
+	require.NoError(t, err)
+	assert.Equal(t, testStringSlice, []string{"hi", "hello"})
+	assert.Equal(t, "some usage text **DEPRECATED** migration plan", flags.Lookup("deprecated_int").Usage)
+
+	flags = replaceFlagsForTesting(t)
+
+	flagInt = flags.Int("deprecated_int", 5, "some usage text")
+	Deprecate[int]("deprecated_int", "migration plan")
+	flagString := flags.String("deprecated_string", "", "")
+	Deprecate[string]("deprecated_string", "migration plan")
+	flagStringSlice = DeprecatedVar[[]string](NewStringSliceFlag(&[]string{"hi"}), "deprecated_string_slice", "", "migration plan")
+	flags.Set("deprecated_int", "7")
+	flags.Set("deprecated_string_slice", "hello")
+	yamlData := `
+deprecated_int: 9
+deprecated_string: "moo"
+deprecated_string_slice:
+  - "hey"
+`
+	err = flagyaml.PopulateFlagsFromData([]byte(yamlData))
+	require.NoError(t, err)
+	assert.Equal(t, *flagInt, 7)
+	assert.Equal(t, *flagString, "moo")
+	assert.Equal(t, *flagStringSlice, []string{"hi", "hello", "hey"})
+	testInt, err = common.GetDereferencedValue[int]("deprecated_int")
+	require.NoError(t, err)
+	assert.Equal(t, testInt, 7)
+	testString, err := common.GetDereferencedValue[string]("deprecated_string")
+	require.NoError(t, err)
+	assert.Equal(t, testString, "moo")
+	testStringSlice, err = common.GetDereferencedValue[[]string]("deprecated_string_slice")
+	require.NoError(t, err)
+	assert.Equal(t, testStringSlice, []string{"hi", "hello", "hey"})
+	assert.Equal(t, "some usage text **DEPRECATED** migration plan", flags.Lookup("deprecated_int").Usage)
+
+	d := any(flags.Lookup("deprecated_int").Value)
 	_, ok := d.(common.WrappingValue)
 	assert.True(t, ok)
 	_, ok = d.(common.SetValueForFlagNameHooked)

--- a/server/util/flagutil/yaml/yaml.go
+++ b/server/util/flagutil/yaml/yaml.go
@@ -67,6 +67,8 @@ func IgnoreFilter(flg *flag.Flag) bool {
 
 type YAMLTypeAliasable interface {
 	// YAMLTypeAlias returns the type alias we use in YAML for this flag.Value.
+	// Only necessary if the type used for YAML is not the type returned by
+	// AliasedType.
 	YAMLTypeAlias() reflect.Type
 }
 

--- a/server/util/flagutil/yaml/yaml_test.go
+++ b/server/util/flagutil/yaml/yaml_test.go
@@ -231,10 +231,10 @@ func TestPopulateFlagsFromData(t *testing.T) {
 	flagOneTwoStringSlice := flagtypes.Slice("one.two.string_slice", []string{"hi", "hello"}, "")
 	flagOneTwoTwoAndAHalfFloat := flags.Float64("one.two.two_and_a_half.float64", 5.2, "")
 	flagOneTwoThreeStructSlice := []testStruct{{Field: 4, Meadow: "Great"}}
-	flagtypes.SliceVar(&flagOneTwoThreeStructSlice, "one.two.three.struct_slice", "")
+	flagtypes.SliceVar(&flagOneTwoThreeStructSlice, "one.two.three.struct_slice", flagOneTwoThreeStructSlice, "")
 	flagABString := flags.String("a.b.string", "xxx", "")
 	flagABStructSlice := []testStruct{{Field: 7, Meadow: "Chimney"}}
-	flagtypes.SliceVar(&flagABStructSlice, "a.b.struct_slice", "")
+	flagtypes.SliceVar(&flagABStructSlice, "a.b.struct_slice", flagABStructSlice, "")
 	flagABURL := flagtypes.URLFromString("a.b.url", "https://www.example.com", "")
 	yamlData := `
 bool: true
@@ -305,10 +305,10 @@ func TestPopulateFlagsFromYAML(t *testing.T) {
 	flagOneTwoStringSlice := flagtypes.Slice("one.two.string_slice", []string{"hi", "hello"}, "")
 	flagOneTwoTwoAndAHalfFloat := flags.Float64("one.two.two_and_a_half.float64", 5.2, "")
 	flagOneTwoThreeStructSlice := []testStruct{{Field: 4, Meadow: "Great"}}
-	flagtypes.SliceVar(&flagOneTwoThreeStructSlice, "one.two.three.struct_slice", "")
+	flagtypes.SliceVar(&flagOneTwoThreeStructSlice, "one.two.three.struct_slice", flagOneTwoThreeStructSlice, "")
 	flagABString := flags.String("a.b.string", "xxx", "")
 	flagABStructSlice := []testStruct{{Field: 7, Meadow: "Chimney"}}
-	flagtypes.SliceVar(&flagABStructSlice, "a.b.struct_slice", "")
+	flagtypes.SliceVar(&flagABStructSlice, "a.b.struct_slice", flagABStructSlice, "")
 	flagABURL := flagtypes.URLFromString("a.b.url", "https://www.example.com", "")
 	input := map[string]any{
 		"bool": false,


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

This introduces `autoflags`, which greatly simplifies the use of `DeprecatedFlag`s. It also allows us to disambiguate the special case of string-based slice flags from the general JSON-based slice flags, which were previously fairly muddled together, while still not requiring the user of the library to make the distinction themselves. Finally, it allows for easy extension of our flag types. `autoflags.New` and `autoflags.Deprecated` can be used anywhere a normal `flag`-style flag declaration, like `flag.Bool` is used, and `autoflags.Var` and `autoflags.DeprecatedVar` can be used anywhere a `flag`-style `Var` flag declaration is used, like `flag.BoolVar`.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
