### PR TITLE
Standardize cache delete method by returning NotFoundError for files that don't exist

### DIFF
--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -301,7 +301,7 @@ func (g *GCSCache) Delete(ctx context.Context, d *repb.Digest) error {
 	// Note, if we decide to retry deletions in the future, be sure to
 	// add a new metric for retry count.
 	if errors.Is(err, storage.ErrObjectNotExist) {
-		return status.NotFoundErrorf("Key %s not found in gcs_cache", d.GetHash())
+		return status.NotFoundErrorf("digest %s/%d not found in gcs_cache: %s", d.GetHash(), d.GetSizeBytes(), err.Error())
 	}
 	return err
 }

--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -2,6 +2,7 @@ package gcs_cache
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"io"
 	"io/ioutil"
@@ -299,6 +300,9 @@ func (g *GCSCache) Delete(ctx context.Context, d *repb.Digest) error {
 	timer.ObserveDelete(err)
 	// Note, if we decide to retry deletions in the future, be sure to
 	// add a new metric for retry count.
+	if errors.Is(err, storage.ErrObjectNotExist) {
+		return status.NotFoundErrorf("Key %s not found in gcs_cache", d.GetHash())
+	}
 	return err
 }
 

--- a/enterprise/server/backends/memcache/memcache.go
+++ b/enterprise/server/backends/memcache/memcache.go
@@ -3,6 +3,7 @@ package memcache
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"path/filepath"
 	"sync"
@@ -256,7 +257,11 @@ func (c *Cache) Delete(ctx context.Context, d *repb.Digest) error {
 	if err != nil {
 		return err
 	}
-	return c.mc.Delete(k)
+	err = c.mc.Delete(k)
+	if errors.Is(err, memcache.ErrCacheMiss) {
+		return status.NotFoundErrorf("Key %s not found in memcache", d.GetHash())
+	}
+	return err
 }
 
 // Low level interface used for seeking and stream-writing.

--- a/enterprise/server/backends/memcache/memcache.go
+++ b/enterprise/server/backends/memcache/memcache.go
@@ -259,7 +259,7 @@ func (c *Cache) Delete(ctx context.Context, d *repb.Digest) error {
 	}
 	err = c.mc.Delete(k)
 	if errors.Is(err, memcache.ErrCacheMiss) {
-		return status.NotFoundErrorf("Key %s not found in memcache", d.GetHash())
+		return status.NotFoundErrorf("digest %s/%d not found in memcache: %s", d.GetHash(), d.GetSizeBytes(), err.Error())
 	}
 	return err
 }

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -1063,7 +1063,10 @@ func (p *partition) delete(ctx context.Context, cacheType interfaces.CacheType, 
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.lru.Remove(k.FullPath())
+	removed := p.lru.Remove(k.FullPath())
+	if !removed {
+		return status.NotFoundErrorf("digest %s/%d not found in disk cache", d.GetHash(), d.GetSizeBytes())
+	}
 	return nil
 }
 

--- a/server/backends/memory_cache/memory_cache.go
+++ b/server/backends/memory_cache/memory_cache.go
@@ -204,8 +204,11 @@ func (m *MemoryCache) Delete(ctx context.Context, d *repb.Digest) error {
 		return err
 	}
 	m.lock.Lock()
-	m.l.Remove(k)
+	removed := m.l.Remove(k)
 	m.lock.Unlock()
+	if !removed {
+		return status.NotFoundErrorf("digest %s/%d not found in memory cache", d.GetHash(), d.GetSizeBytes())
+	}
 	return nil
 }
 


### PR DESCRIPTION
Standardize error type, so that it can be caught and ignored