### PR TITLE
Print stack trace for all errors

### DIFF
--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -86,10 +86,6 @@ func LogGRPCRequest(ctx context.Context, fullMethod string, dur time.Duration, e
 		Debugf("%s %s %s %s [%s]", "gRPC", reqID, shortPath, fmtErr(err), formatDuration(dur))
 	}
 	if *LogErrorStackTraces {
-		code := gstatus.Code(err)
-		if isExpectedGRPCError(code) {
-			return
-		}
 		if se, ok := err.(interface {
 			StackTrace() status.StackTrace
 		}); ok {


### PR DESCRIPTION
How do people feel about printing stack traces for all errors?
When debugging locally, I find stack traces helpful, even for common errors.
For example if a local service is unavailable or resource is exhausted,
it's helpful to have more information about where exactly it's failing.
