### PR TITLE
Reduce bucket granularity for duration metrics

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -137,15 +137,13 @@ const (
 const (
 	bbNamespace = "buildbuddy"
 
-	thirtyDaysDuration = 30 * 24 * time.Hour
+	day = 24 * time.Hour
 )
 
 var (
 	// Bucket constants.
 
-	// durationUsecBuckets is a reasonable bucket setting for microsecond-valued
-	// duration metrics (1 usec to 30 days).
-	durationUsecBuckets = exponentialBucketRange(1, float64(thirtyDaysDuration.Microseconds()), 2)
+	coarseMicrosecondToHour = durationUsecBuckets(1*time.Microsecond, 1*time.Hour, 10)
 )
 
 var (
@@ -180,7 +178,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "invocation",
 		Name:      "duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   durationUsecBuckets(1*time.Millisecond, 1*day, 10),
 		Help:      "The total duration of each invocation, in **microseconds**.",
 	}, []string{
 		InvocationStatusLabel,
@@ -229,7 +227,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "invocation",
 		Name:      "stats_recorder_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "How long it took to finalize an invocation's stats, in **microseconds**. This includes the time required to wait for all BuildBuddy apps to flush their local metrics to Redis (if applicable) and then record the metrics to the DB.",
 	})
 
@@ -244,7 +242,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "invocation",
 		Name:      "webhook_invocation_lookup_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "How long it took to lookup an invocation before posting to the webhook, in **microseconds**.",
 	})
 
@@ -259,7 +257,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "invocation",
 		Name:      "webhook_notify_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "How long it took to post an invocation proto to the webhook, in **microseconds**.",
 	})
 
@@ -299,7 +297,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",
 		Name:      "download_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   durationUsecBuckets(1*time.Microsecond, 1*time.Hour, 5),
 		Help:      "Download duration for each file downloaded from the remote cache, in **microseconds**.",
 	}, []string{
 		CacheTypeLabel,
@@ -336,7 +334,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",
 		Name:      "upload_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   durationUsecBuckets(1*time.Microsecond, 1*time.Hour, 5),
 		Help:      "Upload duration for each file uploaded to the remote cache, in **microseconds**.",
 	}, []string{
 		CacheTypeLabel,
@@ -373,6 +371,7 @@ var (
 		Subsystem: "remote_cache",
 		Name:      "disk_cache_usec_since_last_access",
 		Help:      "Time since last digest access, in **microseconds**.",
+		Buckets:   durationUsecBuckets(1*time.Microsecond, 30*day, 10),
 	})
 
 	DiskCacheAddedFileSizeBytes = promauto.NewHistogram(prometheus.HistogramOpts{
@@ -435,7 +434,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",
 		Name:      "executed_action_metadata_durations_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   durationUsecBuckets(1*time.Microsecond, 1*day, 5),
 		Help:      "Time spent in each stage of action execution, in **microseconds**. Queries should filter or group by the `stage` label, taking care not to aggregate different stages.",
 	}, []string{
 		ExecutedActionStageLabel,
@@ -679,7 +678,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",
 		Name:      "file_upload_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "Per-file upload duration during remote execution, in **microseconds**.",
 	})
 
@@ -788,7 +787,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "blobstore",
 		Name:      "read_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "Duration per blobstore file read, in **microseconds**.",
 	}, []string{
 		BlobstoreTypeLabel,
@@ -823,7 +822,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "blobstore",
 		Name:      "write_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "Duration per blobstore file write, in **microseconds**.",
 	}, []string{
 		BlobstoreTypeLabel,
@@ -843,7 +842,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "blobstore",
 		Name:      "delete_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "Delete duration per blobstore file deletion, in **microseconds**.",
 	}, []string{
 		BlobstoreTypeLabel,
@@ -879,7 +878,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "sql",
 		Name:      "query_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "SQL query duration, in **microseconds**.",
 	}, []string{
 		SQLQueryTemplateLabel,
@@ -1011,7 +1010,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "http",
 		Name:      "request_handler_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "Time taken to handle each HTTP request in **microseconds**.",
 	}, []string{
 		HTTPRouteLabel,
@@ -1066,7 +1065,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "build_event_handler",
 		Name:      "duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "The time spent handling each build event in **microseconds**.",
 	}, []string{
 		StatusLabel,
@@ -1117,7 +1116,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "cache",
 		Name:      "get_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "The time spent retrieving each entry from the cache, in **microseconds**. This is recorded only for successful gets.",
 	}, []string{
 		CacheTierLabel,
@@ -1154,7 +1153,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "cache",
 		Name:      "read_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "The total time spent for each read stream, in **microseconds**. This is recorded only for successful reads, and measures the entire read stream (not just individual chunks).",
 	}, []string{
 		CacheTierLabel,
@@ -1192,7 +1191,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "cache",
 		Name:      "set_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "The time spent writing each entry to the cache, in **microseconds**. This is recorded only for successful sets.",
 	}, []string{
 		CacheTierLabel,
@@ -1240,7 +1239,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "cache",
 		Name:      "write_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "The time spent for each streamed write to the cache, in **microseconds**. This is recorded only on success, and measures the entire stream (not just individual chunks).",
 	}, []string{
 		CacheTierLabel,
@@ -1286,7 +1285,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "cache",
 		Name:      "delete_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "Duration of each cache deletion, in **microseconds**.",
 	}, []string{
 		CacheTierLabel,
@@ -1308,7 +1307,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "cache",
 		Name:      "contains_duration_usec",
-		Buckets:   durationUsecBuckets,
+		Buckets:   coarseMicrosecondToHour,
 		Help:      "Duration of each each `contains(key)` request, in **microseconds**.",
 	}, []string{
 		CacheTierLabel,
@@ -1359,4 +1358,8 @@ func exponentialBucketRange(min, max, factor float64) []float64 {
 		current *= factor
 	}
 	return buckets
+}
+
+func durationUsecBuckets(min, max time.Duration, factor float64) []float64 {
+	return exponentialBucketRange(float64(min.Microseconds()), float64(max.Microseconds()), factor)
 }


### PR DESCRIPTION
* For most metrics, change the buckets from `(min=1us, max=30d, factor=2)` (~37 buckets) to `(min=1us, max=1h, factor=10)` (~10 buckets)
* For some metrics, use a custom bucket range, with reasonable cardinality.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
