### PR TITLE
CI runner: Fix git clean to remove ignored directories

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1311,10 +1311,13 @@ func (ws *workspace) sync(ctx context.Context) error {
 	}
 
 	// Clean up in case a previous workflow made a mess.
-	if err := git(ctx, ws.log, "clean", "-d" /*directories*/, "--force"); err != nil {
-		return err
+	cleanArgs := []string{
+		"clean",
+		"-x", /* include ignored files */
+		"-d", /* recurse into directories */
+		"--force",
 	}
-	if err := git(ctx, ws.log, "clean", "-X" /*ignored files*/, "--force"); err != nil {
+	if err := git(ctx, ws.log, cleanArgs...); err != nil {
 		return err
 	}
 	// Create the branch if it doesn't already exist, then update it to point to


### PR DESCRIPTION
The original intent was to remove all untracked and ignored files and directories. The new implementation does this properly, while the old implementation did not properly delete ignored directories.

Test with:

```
#!/usr/bin/env bash
set -euo pipefail

cd $(mktemp -d)
git init

echo '
ignored_dir/
ignored_file.txt
' > .gitignore
git add .
git commit -m "Initial commit with .gitignore"

touch untracked_file.txt

mkdir untracked_dir
touch untracked_dir/file.txt

mkdir ignored_dir
touch ignored_dir/file.txt

touch ignored_file.txt

# INCORRECT CLEAN COMMANDS:
git clean -X --force
git clean -d --force
# CORRECT CLEAN COMMAND:
# git clean -x -d --force

echo "Paths remaining after clean (excluding .git/*):"
find . | grep -v './.git/'
```

Output before (with `git clean -X --force && git clean -d --force`); note `ignored_dir` is not removed (bug):

```
Paths remaining after clean (excluding .git/*):
.
./.git
./.gitignore
./ignored_dir
./ignored_dir/file.txt
```

Output after (with `git clean -x -d --force`); note the repo is back to a pristine state as expected:

```
Paths remaining after clean (excluding .git/*):
.
./.git
./.gitignore
```

This does mean that the convenience symlinks created by bazel (`bazel-out`, `bazel-bin` etc.) will need to be re-created on each run, but that's OK.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
