### PR TITLE
Workflows: Allow excluding paths from git clean

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -117,6 +117,7 @@ var (
 	bazelSubCommand    = flag.String("bazel_sub_command", "", "If set, run the bazel command specified by these args and ignore all triggering and configured actions.")
 	patchDigests       = flagtypes.Slice("patch_digest", []string{}, "Digests of patches to apply to the repo after checkout. Can be specified multiple times to apply multiple patches.")
 	recordRunMetadata  = flag.Bool("record_run_metadata", false, "Instead of running a target, extract metadata about it and report it in the build event stream.")
+	gitCleanExclude    = flagtypes.Slice("git_clean_exclude", []string{}, "Directories to exclude from `git clean` while setting up the repo.")
 
 	shutdownAndExit = flag.Bool("shutdown_and_exit", false, "If set, runs bazel shutdown with the configured bazel_command, and exits. No other commands are run.")
 
@@ -1316,6 +1317,9 @@ func (ws *workspace) sync(ctx context.Context) error {
 		"-x", /* include ignored files */
 		"-d", /* recurse into directories */
 		"--force",
+	}
+	for _, path := range *gitCleanExclude {
+		cleanArgs = append(cleanArgs, "-e", path)
 	}
 	if err := git(ctx, ws.log, cleanArgs...); err != nil {
 		return err

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -23,11 +23,12 @@ type BuildBuddyConfig struct {
 }
 
 type Action struct {
-	Name          string    `yaml:"name"`
-	Triggers      *Triggers `yaml:"triggers"`
-	OS            string    `yaml:"os"`
-	Arch          string    `yaml:"arch"`
-	BazelCommands []string  `yaml:"bazel_commands"`
+	Name            string    `yaml:"name"`
+	Triggers        *Triggers `yaml:"triggers"`
+	OS              string    `yaml:"os"`
+	Arch            string    `yaml:"arch"`
+	GitCleanExclude []string  `yaml:"git_clean_exclude"`
+	BazelCommands   []string  `yaml:"bazel_commands"`
 }
 
 type Triggers struct {

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -81,15 +81,24 @@ func generateWebhookID() (string, error) {
 	return strings.ToLower(u.String()), nil
 }
 
-func instanceName(wf *tables.Workflow, wd *interfaces.WebhookData, workflowActionName string) string {
+func instanceName(wf *tables.Workflow, wd *interfaces.WebhookData, workflowActionName string, gitCleanExclude []string) string {
 	// Use a unique remote instance name per repo URL and workflow action name, to help
 	// route workflow tasks to runners which previously executed the same workflow
 	// action.
 	//
+	// git_clean_exclude is also included in this key so that if a PR is
+	// modifying git_clean_exclude, it sees a consistent view of the excluded
+	// directories throughout the PR.
+	//
 	// Instance name suffix is additionally used to effectively invalidate all
 	// existing runners for the workflow and cause subsequent workflows to be run
 	// from a clean runner.
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(wd.PushedRepoURL+workflowActionName+wf.InstanceNameSuffix)))
+	keys := append([]string{
+		wd.PushedRepoURL,
+		workflowActionName,
+		wf.InstanceNameSuffix,
+	}, gitCleanExclude...)
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(keys, "|"))))
 }
 
 type workflowService struct {
@@ -705,6 +714,9 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 				{Name: platform.EstimatedFreeDiskPropertyName, Value: "20000000000"}, // 20GB
 			},
 		},
+	}
+	for _, path := range workflowAction.GitCleanExclude {
+		cmd.Arguments = append(cmd.Arguments, "--git_clean_exclude="+path)
 	}
 	cmdDigest, err := cachetools.UploadProtoToCAS(ctx, cache, instanceName, cmd)
 	if err != nil {

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -913,7 +913,7 @@ func (ws *workflowService) executeWorkflow(ctx context.Context, key *tables.APIK
 	if err != nil {
 		return "", err
 	}
-	in := instanceName(wf, wd, workflowAction.Name)
+	in := instanceName(wf, wd, workflowAction.Name, workflowAction.GitCleanExclude)
 	ad, err := ws.createActionForWorkflow(ctx, wf, wd, isTrusted, key, in, workflowAction, invocationID, extraCIRunnerArgs)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Adds a new `git_clean_exclude` list to the workflow action config, which will be passed as extra `-e` flags to `git clean`.

Context: This is needed for `rules_xcodeproj` which needs a bazel output base that is in-repo. (Creating a symlink to the existing output base will not work.) This dir will be added to `.gitignore` so it will be cleaned by our usual `git clean` logic, so we need a way to explicitly exclude it from `git clean`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
