### PR TITLE
Use math.big to evenly scan ranges on startup with more goroutines

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1392,7 +1392,6 @@ func (e *partitionEvictor) computeSizeInRange(start, end []byte) (int64, int64, 
 }
 
 func splitRange(left, right []byte, count int) ([][]byte, error) {
-	log.Printf("Splitting between %q and %q", left, right)
 	leftInt := big.NewInt(0).SetBytes(left)
 	rightInt := big.NewInt(0).SetBytes(right)
 	delta := new(big.Int).Sub(rightInt, leftInt)


### PR DESCRIPTION
Use math.big to evenly divide the CAS and AC keyspace and scan the CAS keyspace with more goroutines (160) than before (16).