### PR TITLE
Remove in-memory atimes map, which is not used

### DIFF
--- a/enterprise/server/backends/pebble_cache/BUILD
+++ b/enterprise/server/backends/pebble_cache/BUILD
@@ -22,7 +22,6 @@ go_library(
         "//server/util/log",
         "//server/util/status",
         "//server/util/statusz",
-        "@com_github_cespare_xxhash_v2//:xxhash",
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_prometheus_client_golang//prometheus",


### PR DESCRIPTION
This cleanup CL just removes the old atimes map since now we are relying on an atime written in the record.