### PR TITLE
Make partition evictor use db leases too

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -302,7 +302,7 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 			if err := disk.EnsureDirectoryExists(blobDir); err != nil {
 				return err
 			}
-			pe, err := newPartitionEvictor(part, blobDir, pc.db, pc.accesses)
+			pe, err := newPartitionEvictor(part, blobDir, pc, pc.accesses)
 			if err != nil {
 				return err
 			}
@@ -1627,7 +1627,7 @@ func (e *partitionEvictor) resampleK(k int) error {
 	}
 	defer db.Close()
 
-	start, end := partitionLimits(e.part.ID)
+	start, end := keyRange([]byte(e.part.ID + "/"))
 	iter := db.NewIter(&pebble.IterOptions{
 		LowerBound: start,
 		UpperBound: end,

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -358,7 +358,6 @@ type dbInterface interface {
 	pebble.Writer
 	io.Closer
 
-	Compact(start, end []byte, parallelize bool) error
 	EstimateDiskUsage(start, end []byte) (uint64, error)
 	Flush() error
 	Metrics() *pebble.Metrics


### PR DESCRIPTION
This is to prevent potential panics / race conditions.

Also, compute some simple summary stats across all partitions by summing the cas, ac, and bytes totals and showing them in /Statusz. (I find myself adding these often when debugging things, so I figured I'd let a computer do it)