### PR TITLE
Disable telemetry when running buildbuddy_enterprise in tests

### DIFF
--- a/enterprise/server/testutil/buildbuddy_enterprise/buildbuddy_enterprise.go
+++ b/enterprise/server/testutil/buildbuddy_enterprise/buildbuddy_enterprise.go
@@ -34,6 +34,7 @@ func RunWithConfig(t *testing.T, configPath string, args ...string) *app.App {
 	commandArgs := []string{
 		fmt.Sprintf("--telemetry_port=%d", testport.FindFree(t)),
 		"--app_directory=/enterprise/app",
+		"--disable_telemetry",
 		"--app.default_redis_target=" + redisTarget,
 	}
 	commandArgs = append(commandArgs, args...)


### PR DESCRIPTION
I noticed in some of the tests that timeout there is a gap that seems to be due to telemetry client timeout:

```
2022/08/10 16:15:05.538 INF                        healthcheck.go:204 > HealthChecker transitioning from ready: false => ready: true
2022/08/10 16:15:22.643 DBG                   telemetry_client.go:129 > Error posting telemetry data: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 34.82.173.239:443: i/o timeout"
```
(source: https://app.buildbuddy.io/invocation/08ae1234-9397-4da8-8dba-ac9df2a98839?target=%2F%2Fenterprise%2Fserver%2Ftest%2Fintegration%2Fremote_cache%3Aremote_cache_test)