### PR TITLE
Increase the number of fallback peers we attempt to use for handoff.

### DIFF
--- a/server/util/peerset/peerset.go
+++ b/server/util/peerset/peerset.go
@@ -4,19 +4,23 @@ import (
 	"math/rand"
 )
 
+const maxFailedFallbackPeers = 3
+
 type PeerSet struct {
-	PreferredPeers []string
-	FallbackPeers  []string
-	FailedPeers    []string
-	i              int // next peer index
+	PreferredPeers      []string
+	FallbackPeers       []string
+	FailedPeers         []string
+	FailedFallbackPeers []string
+	i                   int // next peer index
 }
 
 func New(preferredPeers, fallbackPeers []string) *PeerSet {
 	return &PeerSet{
-		i:              0,
-		PreferredPeers: preferredPeers,
-		FallbackPeers:  fallbackPeers,
-		FailedPeers:    nil,
+		i:                   0,
+		PreferredPeers:      preferredPeers,
+		FallbackPeers:       fallbackPeers,
+		FailedPeers:         nil,
+		FailedFallbackPeers: nil,
 	}
 }
 
@@ -43,6 +47,7 @@ func (p *PeerSet) MarkPeerAsFailed(failedPeer string) {
 			return
 		}
 	}
+	p.FailedFallbackPeers = append(p.FailedFallbackPeers, failedPeer)
 }
 
 // GetNextPeerAndHandoff returns the next available peer and a handoff peer
@@ -62,11 +67,26 @@ func (p *PeerSet) GetNextPeerAndHandoff() (string, string) {
 		defer increment()
 		return p.PreferredPeers[i], ""
 	}
+
+	// Give up if we have already tried enough fallback peers.
+	if len(p.FailedFallbackPeers) > maxFailedFallbackPeers {
+		return "", ""
+	}
+
+	// Once we're out of preferred peers, start going through the fallback
+	// peers.
 	i -= numPreferred
 
-	if i < len(p.FallbackPeers) && i < len(p.FailedPeers) {
+	fallbackIdx := i
+	// If a fallback peer is marked as failed after this function returns, it
+	// will be added to the list of failed fallback peers. We use this fact to
+	// prevent failedIdx from advancing to the next failed peer until we find a
+	// good fallback peer.
+	failedIdx := i - len(p.FailedFallbackPeers)
+
+	if fallbackIdx < len(p.FallbackPeers) && failedIdx < len(p.FailedPeers) {
 		defer increment()
-		return p.FallbackPeers[i], p.FailedPeers[i]
+		return p.FallbackPeers[fallbackIdx], p.FailedPeers[failedIdx]
 	}
 	return "", ""
 }

--- a/server/util/peerset/peerset_test.go
+++ b/server/util/peerset/peerset_test.go
@@ -58,6 +58,32 @@ func TestGetNextPeer(t *testing.T) {
 				{"", ""},
 			},
 		},
+		{
+			peerset.New([]string{"a", "b", "c"}, []string{"d", "e", "f", "g"}),
+			[]string{"c", "d"},
+			[]wantPeerHandoff{
+				{"a", ""},
+				{"b", ""},
+				{"c", ""},
+				{"d", "c"},
+				{"e", "c"},
+				{"", ""},
+			},
+		},
+		{
+			peerset.New([]string{"a", "b", "c"}, []string{"d", "e", "f", "g"}),
+			[]string{"b", "c", "d", "e"},
+			[]wantPeerHandoff{
+				{"a", ""},
+				{"b", ""},
+				{"c", ""},
+				{"d", "b"},
+				{"e", "b"},
+				{"f", "b"},
+				{"g", "c"},
+				{"", ""},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Prior to this change, the number of fallback peers we attempted to use
was equal to the number of failed preferred peers. In the most common
case of 1 failed peer, we would only try one fallback peer. If that peer
was also down, we would give up and this would typically lead to a
failed write.

This change returns up to 3 fallback peers before giving up.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
