### PR TITLE
Fix double JanitorCutoffThreshold multiplication in pebble cache

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1261,7 +1261,7 @@ func (p *PebbleCache) TestingWaitForGC() error {
 			totalSizeBytes := e.sizeBytes
 			e.mu.Unlock()
 
-			if totalSizeBytes < int64(float64(maxAllowedSize)*.90) {
+			if totalSizeBytes <= maxAllowedSize {
 				done += 1
 			}
 		}
@@ -1676,6 +1676,7 @@ func (e *partitionEvictor) resampleK(k int) error {
 	return nil
 }
 
+// evict is based off the Redis approximated LRU algorithm
 func (e *partitionEvictor) evict(count int) (*evictionPoolEntry, error) {
 	db, err := e.dbGetter.DB()
 	if err != nil {
@@ -1736,7 +1737,7 @@ func (e *partitionEvictor) ttl(quitChan chan struct{}) error {
 		totalCount := e.casCount + e.acCount
 		e.mu.Unlock()
 
-		if sizeBytes < int64(float64(maxAllowedSize)*.90) {
+		if sizeBytes <= maxAllowedSize {
 			break
 		}
 


### PR DESCRIPTION
- Bug was causing items to be evicted prematurely
- Fix flaky unit tests due to truncating floats instead of rounding up. Was also causing items to be evicted prematurely, causing test failures
- Fix TestingWaitForGC. If the cache held exactly the max number of bytes, the test would wait forever and timeout