### PR TITLE
Add metadata timestamps for cache types that already expose it

### DIFF
--- a/enterprise/server/backends/memcache/memcache.go
+++ b/enterprise/server/backends/memcache/memcache.go
@@ -128,6 +128,7 @@ func (c *Cache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
 	return false, err
 }
 
+// TODO(buildbuddy-internal#1485) - Add last access and modify time
 func (c *Cache) Metadata(ctx context.Context, d *repb.Digest) (*interfaces.CacheMetadata, error) {
 	key, err := c.key(ctx, d)
 	if err != nil {

--- a/enterprise/server/backends/redis_cache/redis_cache.go
+++ b/enterprise/server/backends/redis_cache/redis_cache.go
@@ -157,7 +157,7 @@ func (c *Cache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
 	return found, err
 }
 
-// TODO(buildbuddy-internal#1485) - Add last access time
+// TODO(buildbuddy-internal#1485) - Add last access and modify time
 // Note: Can't use rdb.ObjectIdleTime to calculate last access time, because rdb.StrLen resets the idle time to 0,
 // so this API will always incorrectly set the last access time to the current time
 func (c *Cache) Metadata(ctx context.Context, d *repb.Digest) (*interfaces.CacheMetadata, error) {
@@ -177,14 +177,8 @@ func (c *Cache) Metadata(ctx context.Context, d *repb.Digest) (*interfaces.Cache
 		return nil, err
 	}
 
-	lastModifyTimeSec, err := c.rdb.LastSave(ctx).Result()
-	if err != nil {
-		return nil, err
-	}
-
 	return &interfaces.CacheMetadata{
-		SizeBytes:          blobLen,
-		LastModifyTimeUsec: lastModifyTimeSec * 1e6,
+		SizeBytes: blobLen,
 	}, nil
 }
 

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -406,26 +406,31 @@ func (s3c *S3Cache) bumpTTLIfStale(ctx context.Context, key string, t time.Time)
 
 func (s3c *S3Cache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
 	timer := cache_metrics.NewCacheTimer(cacheLabels)
-	c, _, err := s3c.contains(ctx, d)
+	metadata, err := s3c.metadata(ctx, d)
 	timer.ObserveContains(err)
-	return c, err
+	contains := metadata != nil
+	return contains, err
 }
 
+// TODO(buildbuddy-internal#1485) - Add last access time
 func (s3c *S3Cache) Metadata(ctx context.Context, d *repb.Digest) (*interfaces.CacheMetadata, error) {
-	ok, size, err := s3c.contains(ctx, d)
+	metadata, err := s3c.metadata(ctx, d)
 	if err != nil {
 		return nil, err
 	}
-	if !ok {
+	if metadata == nil {
 		return nil, status.NotFoundErrorf("Digest '%s/%d' not found in cache", d.GetHash(), d.GetSizeBytes())
 	}
-	return &interfaces.CacheMetadata{SizeBytes: size}, nil
+	return &interfaces.CacheMetadata{
+		SizeBytes:          *metadata.ContentLength,
+		LastModifyTimeUsec: metadata.LastModified.UnixMicro(),
+	}, nil
 }
 
-func (s3c *S3Cache) contains(ctx context.Context, d *repb.Digest) (bool, int64, error) {
+func (s3c *S3Cache) metadata(ctx context.Context, d *repb.Digest) (*s3.HeadObjectOutput, error) {
 	key, err := s3c.key(ctx, d)
 	if err != nil {
-		return false, 0, err
+		return nil, err
 	}
 	params := &s3.HeadObjectInput{
 		Bucket: s3c.bucket,
@@ -437,15 +442,15 @@ func (s3c *S3Cache) contains(ctx context.Context, d *repb.Digest) (bool, int64, 
 	head, err := s3c.s3.HeadObjectWithContext(ctx, params)
 	if err != nil {
 		if isNotFoundErr(err) {
-			return false, 0, nil
+			return nil, nil
 		}
-		return false, 0, err
+		return nil, err
 	}
 	bumped := s3c.bumpTTLIfStale(ctx, key, *head.LastModified)
 	if bumped {
-		return true, *head.ContentLength, nil
+		return head, nil
 	}
-	return false, 0, nil
+	return nil, nil
 }
 
 func (s3c *S3Cache) FindMissing(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error) {

--- a/server/backends/memory_cache/memory_cache.go
+++ b/server/backends/memory_cache/memory_cache.go
@@ -109,6 +109,7 @@ func (m *MemoryCache) Contains(ctx context.Context, d *repb.Digest) (bool, error
 	return contains, nil
 }
 
+// TODO(buildbuddy-internal#1485) - Add last access and modify time
 func (m *MemoryCache) Metadata(ctx context.Context, d *repb.Digest) (*interfaces.CacheMetadata, error) {
 	k, err := m.key(ctx, d)
 	if err != nil {


### PR DESCRIPTION
buildbuddy-io/buildbuddy-internal#1485

Some cache types automatically expose last access / modify time. Add this lowhanging fruit to the metadata API.
For those that don't, a little more work will be required to buffer access time updates, so add in a separate PR
