### PR TITLE
Fix raft split point logic.

### DIFF
--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -142,8 +142,7 @@ message CASResponse {
 message FindSplitPointRequest {}
 
 message FindSplitPointResponse {
-  bytes left = 1;
-  bytes right = 2;
+  bytes split = 1;
 
   int64 left_size_bytes = 3;
   int64 right_size_bytes = 4;


### PR DESCRIPTION
The split point should be a single key, otherwise there will be a gap in
the ranges.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
