### PR TITLE
Make random digest generator usable outside of tests.

### DIFF
--- a/server/testutil/testdigest/testdigest.go
+++ b/server/testutil/testdigest/testdigest.go
@@ -1,94 +1,34 @@
 package testdigest
 
 import (
-	"bytes"
 	"io"
-	"math/rand"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	realdigest "github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 )
 
 var (
 	randomSeedOnce sync.Once
-	randomGen      *Generator
+	randomGen      *digest.Generator
 )
 
-type randomDataMaker struct {
-	src rand.Source
-}
-
-func (r *randomDataMaker) Read(p []byte) (n int, err error) {
-	todo := len(p)
-	offset := 0
-	for {
-		val := int64(r.src.Int63())
-		for i := 0; i < 8; i++ {
-			p[offset] = byte(val & 0xff)
-			todo--
-			if todo == 0 {
-				return len(p), nil
-			}
-			offset++
-			val >>= 8
-		}
-	}
-}
-
-type Generator struct {
-	randMaker *randomDataMaker
-}
-
-func NewGenerator(seed int64) *Generator {
-	return &Generator{randMaker: &randomDataMaker{rand.NewSource(seed)}}
-}
-
-func (g *Generator) RandomDigestReader(sizeBytes int64) (*repb.Digest, io.ReadSeeker, error) {
-	// Read some random bytes.
-	buf := new(bytes.Buffer)
-	if _, err := io.CopyN(buf, g.randMaker, sizeBytes); err != nil {
-		return nil, nil, err
-	}
-	readSeeker := bytes.NewReader(buf.Bytes())
-
-	// Compute a digest for the random bytes.
-	d, err := realdigest.Compute(readSeeker)
-	if err != nil {
-		return nil, nil, err
-	}
-	if _, err := readSeeker.Seek(0, 0); err != nil {
-		return nil, nil, err
-	}
-	return d, readSeeker, nil
-}
-
-func (g *Generator) RandomDigestBuf(sizeBytes int64) (*repb.Digest, []byte, error) {
-	d, rs, err := g.RandomDigestReader(sizeBytes)
-	if err != nil {
-		return nil, nil, err
-	}
-	buf, err := io.ReadAll(rs)
-	if err != nil {
-		return nil, nil, err
-	}
-	return d, buf, nil
-}
-
-func NewRandomDigestReader(t *testing.T, sizeBytes int64) (*repb.Digest, io.ReadSeeker, error) {
+func NewRandomDigestReader(t testing.TB, sizeBytes int64) (*repb.Digest, io.ReadSeeker) {
 	randomSeedOnce.Do(func() {
-		randomGen = NewGenerator(time.Now().UnixNano())
+		randomGen = digest.RandomGenerator(time.Now().Unix())
 	})
-	return randomGen.RandomDigestReader(sizeBytes)
-}
-
-func NewRandomDigestBuf(t *testing.T, sizeBytes int64) (*repb.Digest, []byte) {
-	d, rs, err := NewRandomDigestReader(t, sizeBytes)
+	d, r, err := randomGen.RandomDigestReader(sizeBytes)
 	if err != nil {
 		t.Fatal(err)
 	}
+	return d, r
+}
+
+func NewRandomDigestBuf(t testing.TB, sizeBytes int64) (*repb.Digest, []byte) {
+	d, rs := NewRandomDigestReader(t, sizeBytes)
 	buf, err := io.ReadAll(rs)
 	if err != nil {
 		t.Fatal(err)
@@ -98,8 +38,7 @@ func NewRandomDigestBuf(t *testing.T, sizeBytes int64) (*repb.Digest, []byte) {
 
 func ReadDigestAndClose(t *testing.T, r io.ReadCloser) *repb.Digest {
 	defer r.Close()
-
-	d, err := realdigest.Compute(r)
+	d, err := digest.Compute(r)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Once in a while I need to generate random digests in a one-off testing
tool and it'd be nice to have this functionality easily accessible.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
