### PR TITLE
Move Reader, Writer, and FindMissing to the replica

### DIFF
--- a/enterprise/server/raft/filestore/BUILD
+++ b/enterprise/server/raft/filestore/BUILD
@@ -9,6 +9,5 @@ go_library(
         "//proto:raft_go_proto",
         "//server/util/disk",
         "//server/util/status",
-        "@com_github_cockroachdb_pebble//:pebble",
     ],
 )

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -27,7 +27,6 @@ go_library(
         "//server/util/log",
         "//server/util/status",
         "//server/util/statusz",
-        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_hashicorp_serf//serf",
         "@com_github_lni_dragonboat_v3//:dragonboat",
         "@com_github_lni_dragonboat_v3//raftio",

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -28,7 +27,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/statusz"
-	"github.com/cockroachdb/pebble"
 	"github.com/hashicorp/serf/serf"
 	"github.com/lni/dragonboat/v3"
 	"github.com/lni/dragonboat/v3/raftio"
@@ -541,25 +539,13 @@ func (s *Store) FindMissing(ctx context.Context, req *rfpb.FindMissingRequest) (
 	if err != nil {
 		return nil, err
 	}
-	reader, err := r.Reader()
+	missing, err := r.FindMissing(ctx, req.GetFileRecord())
 	if err != nil {
 		return nil, err
 	}
-	defer reader.Close()
-	iter := reader.NewIter(nil /*default iterOptions*/)
-	defer iter.Close()
-
-	rsp := &rfpb.FindMissingResponse{}
-	for _, fileRecord := range req.GetFileRecord() {
-		fileMetadaKey, err := s.fileStorer.FileMetadataKey(fileRecord)
-		if err != nil {
-			return nil, err
-		}
-		if !iter.SeekGE(fileMetadaKey) || bytes.Compare(iter.Key(), fileMetadaKey) != 0 {
-			rsp.FileRecord = append(rsp.FileRecord, fileRecord)
-		}
-	}
-	return rsp, nil
+	return &rfpb.FindMissingResponse{
+		FileRecord: missing,
+	}, nil
 }
 
 type streamWriter struct {
@@ -582,32 +568,7 @@ func (s *Store) Read(req *rfpb.ReadRequest, stream rfspb.Api_ReadServer) error {
 		return err
 	}
 
-	db, err := r.Reader()
-	if err != nil {
-		return err
-	}
-	defer db.Close()
-
-	iter := db.NewIter(nil /*default iterOptions*/)
-	defer iter.Close()
-
-	fileMetadataKey, err := s.fileStorer.FileMetadataKey(req.GetFileRecord())
-	if err != nil {
-		return err
-	}
-
-	// First, lookup the FileMetadata. If it's not found, we don't have the file.
-	found := iter.SeekGE(fileMetadataKey)
-	if !found || bytes.Compare(fileMetadataKey, iter.Key()) != 0 {
-		return status.NotFoundErrorf("file %q not found", fileMetadataKey)
-	}
-	fileMetadata := &rfpb.FileMetadata{}
-	if err := proto.Unmarshal(iter.Value(), fileMetadata); err != nil {
-		return status.InternalErrorf("error reading file %q metadata", fileMetadataKey)
-	}
-	offset := req.GetOffset()
-	limit := req.GetLimit()
-	readCloser, err := s.fileStorer.NewReader(stream.Context(), s.fileDir, fileMetadata.GetStorageMetadata(), offset, limit)
+	readCloser, err := r.Reader(stream.Context(), req.GetFileRecord(), req.GetOffset(), req.GetLimit())
 	if err != nil {
 		return err
 	}
@@ -623,11 +584,9 @@ func (s *Store) Read(req *rfpb.ReadRequest, stream rfspb.Api_ReadServer) error {
 	return err
 }
 
-func (s *Store) handleWrite(stream rfspb.Api_WriteServer) error {
+func (s *Store) Write(stream rfspb.Api_WriteServer) error {
 	var bytesWritten int64
-	var fileMetadataKey []byte
-	var writeCloser filestore.WriteCloserMetadata
-	var batch *pebble.Batch
+	var writeCloser filestore.CommittedWriter
 	for {
 		req, err := stream.Recv()
 		if err == io.EOF {
@@ -648,20 +607,11 @@ func (s *Store) handleWrite(stream rfspb.Api_WriteServer) error {
 			if err != nil {
 				return err
 			}
-			db, err := r.DB()
+			writeCloser, err = r.Writer(stream.Context(), req.GetFileRecord())
 			if err != nil {
 				return err
 			}
-			defer db.Close()
-			batch = db.NewBatch()
-			fileMetadataKey, err = s.fileStorer.FileMetadataKey(req.GetFileRecord())
-			if err != nil {
-				return err
-			}
-			writeCloser, err = s.fileStorer.NewWriter(stream.Context(), s.fileDir, batch, req.GetFileRecord())
-			if err != nil {
-				return err
-			}
+			defer writeCloser.Close()
 		}
 		n, err := writeCloser.Write(req.Data)
 		if err != nil {
@@ -669,22 +619,7 @@ func (s *Store) handleWrite(stream rfspb.Api_WriteServer) error {
 		}
 		bytesWritten += int64(n)
 		if req.FinishWrite {
-			if err := writeCloser.Close(); err != nil {
-				return err
-			}
-			md := &rfpb.FileMetadata{
-				FileRecord:      req.GetFileRecord(),
-				StorageMetadata: writeCloser.Metadata(),
-				SizeBytes:       bytesWritten,
-			}
-			protoBytes, err := proto.Marshal(md)
-			if err != nil {
-				return err
-			}
-			if err := batch.Set(fileMetadataKey, protoBytes, nil /*ignored write options*/); err != nil {
-				return err
-			}
-			if err := batch.Commit(&pebble.WriteOptions{Sync: true}); err != nil {
+			if err := writeCloser.Commit(); err != nil {
 				return err
 			}
 			return stream.SendAndClose(&rfpb.WriteResponse{
@@ -693,10 +628,6 @@ func (s *Store) handleWrite(stream rfspb.Api_WriteServer) error {
 		}
 	}
 	return nil
-}
-
-func (s *Store) Write(stream rfspb.Api_WriteServer) error {
-	return s.handleWrite(stream)
 }
 
 type raftWriteCloser struct {


### PR DESCRIPTION
This keeps ownership of the DB inside the replica.

[It's also a prerequisite for tests (coming in another CL) that test file writes to the replica.]