### PR TITLE
Handle stale write attempts.

### DIFF
--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -117,10 +117,10 @@ func (c *APIClient) RemoteReader(ctx context.Context, client rfspb.ApiClient, re
 }
 
 type streamWriteCloser struct {
-	stream        rfspb.Api_WriteClient
-	header        *rfpb.Header
-	fileRecord    *rfpb.FileRecord
-	bytesUploaded int64
+	stream         rfspb.Api_WriteClient
+	header         *rfpb.Header
+	fileRecord     *rfpb.FileRecord
+	firstWriteDone bool
 }
 
 func (wc *streamWriteCloser) Write(data []byte) (int, error) {
@@ -130,8 +130,19 @@ func (wc *streamWriteCloser) Write(data []byte) (int, error) {
 		Data:        data,
 		FinishWrite: false,
 	}
-	err := wc.stream.Send(req)
-	return len(data), err
+	if err := wc.stream.Send(req); err != nil {
+		return 0, err
+	}
+	// On the first write, the peer will send us an empty response to indicate
+	// that it has accepted the write so we wait here to make sure the write
+	// was not rejected.
+	if !wc.firstWriteDone {
+		if _, err := wc.stream.Recv(); err != nil {
+			return 0, err
+		}
+		wc.firstWriteDone = true
+	}
+	return len(data), nil
 }
 
 func (wc *streamWriteCloser) Close() error {
@@ -143,7 +154,10 @@ func (wc *streamWriteCloser) Close() error {
 	if err := wc.stream.Send(req); err != nil {
 		return err
 	}
-	_, err := wc.stream.CloseAndRecv()
+	if err := wc.stream.CloseSend(); err != nil {
+		return err
+	}
+	_, err := wc.stream.Recv()
 	return err
 }
 
@@ -153,10 +167,9 @@ func RemoteWriter(ctx context.Context, client rfspb.ApiClient, header *rfpb.Head
 		return nil, err
 	}
 	wc := &streamWriteCloser{
-		header:        header,
-		fileRecord:    fileRecord,
-		bytesUploaded: 0,
-		stream:        stream,
+		header:     header,
+		fileRecord: fileRecord,
+		stream:     stream,
 	}
 	return wc, nil
 }
@@ -167,20 +180,11 @@ func RemoteSyncWriter(ctx context.Context, client rfspb.ApiClient, header *rfpb.
 		return nil, err
 	}
 	wc := &streamWriteCloser{
-		header:        header,
-		fileRecord:    fileRecord,
-		bytesUploaded: 0,
-		stream:        stream,
+		header:     header,
+		fileRecord: fileRecord,
+		stream:     stream,
 	}
 	return wc, nil
-}
-
-func (c *APIClient) RemoteWriter(ctx context.Context, peerHeader *PeerHeader, fileRecord *rfpb.FileRecord) (io.WriteCloser, error) {
-	client, err := c.getClient(ctx, peerHeader.GRPCAddr)
-	if err != nil {
-		return nil, err
-	}
-	return RemoteWriter(ctx, client, peerHeader.Header, fileRecord)
 }
 
 type multiWriteCloser struct {

--- a/proto/raft_service.proto
+++ b/proto/raft_service.proto
@@ -23,7 +23,21 @@ service Api {
 
   // Data API.
   rpc Read(ReadRequest) returns (stream ReadResponse);
-  rpc Write(stream WriteRequest) returns (WriteResponse);
-  rpc SyncWriter(stream WriteRequest) returns (WriteResponse);
   rpc FindMissing(FindMissingRequest) returns (FindMissingResponse);
+
+  // Write semantics:
+  //
+  // After creating the stream, the client will send an initial WriteRequest
+  // containing the metadata and the first (and possibly only) chunk of data to
+  // be written.
+  //
+  // If the server is able to accept the write, it will send an
+  // empty WriteResponse, otherwise it will close the stream with an error.
+  //
+  // After the initial WriteResponse, the server will not send another
+  // WriteResponse until the client sends a WriteRequest with finish_write set
+  // to true at which point it will indicate how many bytes were written on the
+  // server.
+  rpc Write(stream WriteRequest) returns (stream WriteResponse);
+  rpc SyncWriter(stream WriteRequest) returns (stream WriteResponse);
 }


### PR DESCRIPTION
When attempting to write to peers, send the first request and wait for a
response from the peer to indicate whether it has accepted the write. If
the write fails (for example due to stale range information), we can
retry with fresh information.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
