### PR TITLE
Remove polling from task scheduling loop

### DIFF
--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -31,8 +31,8 @@ const (
 
 	// Definitions for BCU ("BuildBuddy Compute Unit")
 
-	computeUnitsToMilliCPU = 1000      // 1 BCU = 1000 milli-CPU
-	computeUnitsToRAMBytes = 2.5 * 1e9 // 1 BCU = 2.5GB of memory
+	ComputeUnitsToMilliCPU = 1000      // 1 BCU = 1000 milli-CPU
+	ComputeUnitsToRAMBytes = 2.5 * 1e9 // 1 BCU = 2.5GB of memory
 
 	// Default resource estimates
 
@@ -323,8 +323,8 @@ func Estimate(task *repb.ExecutionTask) *scpb.TaskSize {
 	}
 
 	if props.EstimatedComputeUnits > 0 {
-		cpuEstimate = props.EstimatedComputeUnits * computeUnitsToMilliCPU
-		memEstimate = props.EstimatedComputeUnits * computeUnitsToRAMBytes
+		cpuEstimate = props.EstimatedComputeUnits * ComputeUnitsToMilliCPU
+		memEstimate = props.EstimatedComputeUnits * ComputeUnitsToRAMBytes
 	}
 	if props.EstimatedFreeDiskBytes > 0 {
 		freeDiskEstimate = props.EstimatedFreeDiskBytes

--- a/enterprise/server/test/integration/remote_execution/BUILD
+++ b/enterprise/server/test/integration/remote_execution/BUILD
@@ -13,6 +13,7 @@ go_test(
         "//enterprise/server/build_event_publisher",
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/scheduling/scheduler_server",
+        "//enterprise/server/tasksize",
         "//enterprise/server/test/integration/remote_execution/rbetest",
         "//enterprise/server/testutil/buildbuddy_enterprise",
         "//enterprise/server/testutil/testexecutor",


### PR DESCRIPTION
This fixes two problems:

- (main issue) the 10ms polling was causing constant CPU usage of a few % even while the executor was idle. In dev, the executor always consumes around 4.5% CPU. Locally, the CPU usage is always around 1.7% and this change brings it to 0%.
- (minor issue) the 10ms poll rate was artificially throttling the queue draw-down rate to one task per 10ms.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
