### PR TITLE
Add tooling for generating a Bazel repository with minimal Tensorflow Go bindings

### DIFF
--- a/enterprise/tools/tensorflow/BUILD.lib.bzl
+++ b/enterprise/tools/tensorflow/BUILD.lib.bzl
@@ -1,0 +1,7 @@
+cc_library(
+    name = "libtensorflow",
+    srcs = glob(["tensorflow/**/*.h"]) + [
+        "@libtensorflow-cpu-linux-x86_64-${TENSORFLOW_VERSION}//:libtensorflow",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/enterprise/tools/tensorflow/Dockerfile
+++ b/enterprise/tools/tensorflow/Dockerfile
@@ -1,0 +1,95 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+
+# This Dockerfile is derived from
+# https://github.com/tensorflow/build/blob/776c02aad97ac75c59306b721bf5a70edad2c9c6/golang_install_guide/example-program/Dockerfile
+
+FROM golang:1.18-bullseye
+
+ARG TENSORFLOW_VERSION
+
+# Install proto deps needed to generate go srcs.
+RUN apt-get update && apt-get -y install --no-install-recommends \
+    libprotobuf-dev \
+    protobuf-compiler
+
+# Clone the TF repo, which includes the Go API package.
+# Note: the generation scripts rely on the repo being in GOPATH,
+# which is why we clone under /go/src/...
+RUN git clone --branch=v${TENSORFLOW_VERSION} https://github.com/tensorflow/tensorflow.git \
+   /go/src/github.com/tensorflow/tensorflow
+
+# Install the TensorFlow shared library (required for generating go srcs)
+RUN curl -L https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-$(uname -m)-${TENSORFLOW_VERSION}.tar.gz \
+    | tee /tensorflow.tar.gz \
+    | tar xz --directory /usr/local \
+    && ldconfig
+
+# Generate go srcs (mainly protos)
+RUN cd /go/src/github.com/tensorflow/tensorflow \
+    && go mod init github.com/tensorflow/tensorflow \
+    && (cd tensorflow/go/op && go generate) \
+    && go mod tidy \
+    && go test ./...
+
+# Create a new repo under /tensorflow, with only the go sources.
+# We don't need the rest of the TF repo since it includes a lot of deps we don't need.
+RUN mkdir -p /tensorflow/tensorflow && \
+    cd /go/src/github.com/tensorflow/tensorflow && \
+    cp -r tensorflow/go /tensorflow/tensorflow/ && \
+    rm /tensorflow/tensorflow/go/BUILD && \
+    cp LICENSE .gitignore .bazelversion go.mod go.sum /tensorflow/
+
+WORKDIR /tensorflow
+COPY WORKSPACE .
+
+# Install bazel tools.
+RUN go install github.com/bazelbuild/bazelisk@latest && \
+    ln -s $(which bazelisk) /usr/bin/bazel && \
+    bazel version && \
+    go install github.com/bazelbuild/buildtools/buildozer@latest && \
+    go install github.com/bazelbuild/bazel-gazelle/cmd/gazelle@latest
+
+# Generate BUILD files with gazelle.
+# Note: disabling proto target generation since `go generate` already generates protos for us.
+RUN gazelle -go_prefix github.com/tensorflow/tensorflow -proto=disable .
+
+# Vendor the TF header files so that the cgo include directives
+# can find the headers.
+RUN cp -r /usr/local/include/tensorflow/* ./tensorflow/
+# Add a BUILD file declaring a cc_library referencing the vendored TF headers
+# and lazily downloaded .so (via http_archive - see deps.bzl). Populate
+# TF version and TF release sha256 sum.
+COPY BUILD.lib.bzl /tmp/BUILD
+COPY deps.bzl /tmp/deps.bzl
+RUN apt-get update && apt-get install -y --no-install-recommends gettext-base && \
+    export TENSORFLOW_VERSION=${TENSORFLOW_VERSION} && \
+    export TENSORFLOW_SHA256=$(sha256sum /tensorflow.tar.gz | awk '{print $1}') && \
+    cat /tmp/BUILD | envsubst > BUILD && \
+    cat /tmp/deps.bzl | envsubst > deps.bzl
+
+# Make some adjustments to gazelle's default output to link against the TF
+# release libraries and headers, and add a "keep" comment to prevent gazelle
+# from modifying it.
+RUN buildozer 'remove clinkopts' //tensorflow/go && \
+    buildozer 'remove copts' //tensorflow/go && \
+    buildozer 'add cdeps //:libtensorflow' //tensorflow/go && \
+    buildozer 'comment keep' //tensorflow/go
+
+# Remove the system install of TF to ensure those aren't used in the test build.
+RUN rm -rf /usr/local/lib/libtensorflow* /usr/local/include/tensorflow
+# Make sure we can build the Go lib.
+RUN bazel build //tensorflow/go && rm bazel-*

--- a/enterprise/tools/tensorflow/WORKSPACE
+++ b/enterprise/tools/tensorflow/WORKSPACE
@@ -1,0 +1,56 @@
+# NOTE: This WORKSPACE file is used to allow running test builds of
+# the generated Tensorflow bazel repo. It is not actually needed
+# in practice.
+
+workspace(name = "com_github_tensorflow_tensorflow_tensorflow_go")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# Go
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+    ],
+)
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "5982e5463f171da99e3bdaeff8c0f48283a7a5f396ec5282910b9e8a49c0dd7e",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
+    ],
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_download_sdk(
+    name = "go_sdk_linux",
+    goarch = "amd64",
+    goos = "linux",
+    version = "1.18.1",  # Keep in sync with .github/workflows/checkstyle.yaml
+)
+
+go_register_toolchains()
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "7c9731ff49ebe1cc4a0650a21d40acc099043f4d584b24632bafc0f5328bc3ff",
+    strip_prefix = "protobuf-3.19.0",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.19.0/protobuf-all-3.19.0.zip"],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+load(":deps.bzl", "tensorflow_cgo_deps")
+
+tensorflow_cgo_deps()

--- a/enterprise/tools/tensorflow/deps.bzl
+++ b/enterprise/tools/tensorflow/deps.bzl
@@ -1,0 +1,11 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def tensorflow_cgo_deps():
+    http_archive(
+        name = "libtensorflow-cpu-linux-x86_64-${TENSORFLOW_VERSION}",
+        sha256 = "${TENSORFLOW_SHA256}",
+        urls = [
+            "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-${TENSORFLOW_VERSION}.tar.gz",
+        ],
+        build_file_content = "filegroup(name = \"libtensorflow\", srcs = glob([\"lib/*\"]), visibility = [\"//visibility:public\"])",
+    )

--- a/enterprise/tools/tensorflow/generate_repository.sh
+++ b/enterprise/tools/tensorflow/generate_repository.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# This script generates a Bazel-compatible repository for Tensorflow. Currently
+# the repository contents are uploaded to a blank-slate git repo to avoid
+# pulling in the entire history and unnecessary sources from tensorflow proper.
+# The repo is hosted at github.com/bduffany/go-tensorflow currently, but this
+# can be forked as needed.
+#
+# Usage:
+#
+# enterprise/tools/tensorflow/create_repository.sh ~/local/clone/of/github.com/bduffany/go-tensorflow
+
+set -e
+
+: "${TENSORFLOW_VERSION:=2.9.0}"
+REPO_DIR="${1:?}"
+
+if ! (cd "$REPO_DIR" && git status &>/dev/null); then
+  echo "$REPO_DIR is not a git repo"
+fi
+
+docker build \
+  --tag tensorflow/generate \
+  --build-arg="TENSORFLOW_VERSION=$TENSORFLOW_VERSION" \
+  enterprise/tools/tensorflow
+
+echo "Will generate new, bazel-compatible repo contents under $REPO_DIR based on v$TENSORFLOW_VERSION"
+(
+  cd "$REPO_DIR"
+  if ! git diff --quiet; then
+    echo >&2 "Working tree is dirty; exiting."
+    exit 1
+  fi
+  # TODO: Allow basing on a previous version, so repo doesn't get bloated
+  # from having independent branches for each version.
+  git checkout main
+  git checkout -b "v$TENSORFLOW_VERSION" || git checkout "v$TENSORFLOW_VERSION"
+  # Clear the current branch contents; we'll re-populate it from the Docker build.
+  find . -not -path "./.git/*" -not -name ".git" -delete
+)
+
+docker run \
+  --rm \
+  --volume="$REPO_DIR:/out" \
+  --workdir=/tensorflow \
+  --user="$(id -u):$(id -g)" \
+  tensorflow/generate \
+  sh -c 'cp -r ./* /out/'
+
+(
+  cd "$REPO_DIR"
+  git add .
+  git commit -m "Generate v$TENSORFLOW_VERSION"
+  git push --set-upstream origin --force "$(git branch --show-current)"
+)


### PR DESCRIPTION
Adds a script `enterprise/tools/tensorflow/generate_repository.sh` that can be run to generate a Bazel-compatible Tensorflow repo. The generated repo contains only the files needed to build the Go bindings:
* The original go sources from the `tensorflow/go` subdirectory in TF proper
* Gazelle-generated BUILD files (with `-proto=disable` since it gets confused when trying to generate the protos). The `tensorflow/go/BUILD` file is modified to properly link against `libtensorflow`
* The generated code produced via `(cd tensorflow/go/op && go generate)`, which generates Go protos among other things
* The C headers under `tensorflow/c/` (these are taken from the release archive, rather than the original repo, since we link against the release shared object)
* A `deps.bzl` file containing an `http_archive` rule to download the release archive of TF. The release files are too big to be checked in (340MB, and GitHub's per-file limit is 100MB)
* A BUILD file defining a `cc_library` for the release archive

The repo is currently hosted at https://github.com/bduffany/go-tensorflow and the generated branch for v2.9.0 is at https://github.com/bduffany/go-tensorflow/tree/v2.9.0 but we can move this elsewhere as needed (it can probably even just be a tar file that we host on GCS, just not sure if that is compatible with the go.mod replace directive)

We can't just use a vanilla `go_repository` to generate the repo because:

* The Tensorflow repo is huge (1GB+) and the pre-existing BUILD/WORKSPACE files have tons of misc deps that we don't want to inherit.
* Gazelle gets confused when trying to generate protos for TF, so we'd still need another way to generate the protos. The official docs for TF recommend running a `go generate` command which itself depends on having `libtensorflow` available to the linker, and also relies on being run from `GOPATH`. This PR does this setup and code generation within a Docker container to avoid polluting the local machine.
* We want to apply a few tweaks to the Gazelle-generated rules to get the cgo deps working, and maintaining patch files is a pain. Instead, this tooling runs a few `buildozer` commands to tweak the build file programatically so that we can link against libtensorflow.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
