### PR TITLE
Fix overlap check.

### DIFF
--- a/server/util/rangemap/rangemap.go
+++ b/server/util/rangemap/rangemap.go
@@ -146,10 +146,10 @@ func (rm *RangeMap) GetOverlapping(left, right []byte) []*Range {
 		return bytes.Compare(rm.ranges[i].Left, right) >= 0
 	})
 
-	if rightIndex > 0 {
-		rightIndex -= 1
+	if rightIndex == 0 {
+		return nil
 	}
-	return rm.ranges[leftIndex : rightIndex+1]
+	return rm.ranges[leftIndex:rightIndex]
 }
 
 func (rm *RangeMap) Lookup(key []byte) interface{} {

--- a/server/util/rangemap/rangemap_test.go
+++ b/server/util/rangemap/rangemap_test.go
@@ -167,7 +167,7 @@ func TestGetOverlapping(t *testing.T) {
 		require.Nil(t, err)
 	}
 
-	addRange("a", "e", 1)
+	addRange("b", "e", 1)
 	addRange("e", "i", 2)
 	addRange("m", "q", 3)
 
@@ -179,10 +179,12 @@ func TestGetOverlapping(t *testing.T) {
 		return ids
 	}
 
-	require.Equal(t, overlappingRangeIDs("d", "m"), []int{1, 2})
-	require.Equal(t, overlappingRangeIDs("d", "n"), []int{1, 2, 3})
-	require.Equal(t, overlappingRangeIDs("d", "q"), []int{1, 2, 3})
-	require.Equal(t, overlappingRangeIDs("a", "q"), []int{1, 2, 3})
+	require.Equal(t, []int{1, 2}, overlappingRangeIDs("d", "m"))
+	require.Equal(t, []int{1, 2, 3}, overlappingRangeIDs("d", "n"))
+	require.Equal(t, []int{1, 2, 3}, overlappingRangeIDs("d", "q"))
+	require.Equal(t, []int{1, 2, 3}, overlappingRangeIDs("b", "q"))
+	require.Empty(t, overlappingRangeIDs("a", "b"))
+	require.Empty(t, overlappingRangeIDs("q", "z"))
 }
 
 func TestRemove(t *testing.T) {


### PR DESCRIPTION
For the right index, we find the first range that does *not* overlap the
range being tested. If the right index is 0 then it means there are no
ranges that overlap.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
