### PR TITLE
Delete unused files after splitting

### DIFF
--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -211,20 +211,9 @@ func NewRaftCache(env environment.Env, conf *Config) (*RaftCache, error) {
 	}
 	rc.nodeHost = nodeHost
 
-	// PebbleLogDir is a parent directory for pebble data. Within this
-	// directory, subdirs will be created per raft (cluster_id, node_id).
-	pebbleLogDir := filepath.Join(conf.RootDir, "pebble")
-
-	// FileDir is a parent directory where files will be stored. This data
-	// is managed entirely by the raft statemachine.
-	fileDir := filepath.Join(conf.RootDir, "files")
-	if err := disk.EnsureDirectoryExists(fileDir); err != nil {
-		return nil, err
-	}
-
 	rc.apiClient = client.NewAPIClient(env, rc.nodeHost.ID())
 	rc.sender = sender.New(rc.rangeCache, rc.registry, rc.apiClient)
-	rc.store = store.New(pebbleLogDir, fileDir, rc.nodeHost, rc.gossipManager, rc.sender, rc.registry, rc.apiClient)
+	rc.store = store.New(conf.RootDir, rc.nodeHost, rc.gossipManager, rc.sender, rc.registry, rc.apiClient)
 	if err := rc.store.Start(rc.grpcAddress); err != nil {
 		return nil, err
 	}

--- a/enterprise/server/raft/filestore/filestore.go
+++ b/enterprise/server/raft/filestore/filestore.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"hash/crc32"
 	"io"
+	"os"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -75,6 +76,8 @@ type Store interface {
 
 	FileReader(ctx context.Context, fileDir string, f *rfpb.StorageMetadata_FileMetadata, offset, limit int64) (io.ReadCloser, error)
 	FileWriter(ctx context.Context, fileDir string, fileRecord *rfpb.FileRecord) (WriteCloserMetadata, error)
+
+	DeleteStoredFile(ctx context.Context, fileDir string, md *rfpb.StorageMetadata) error
 }
 
 type fileStorer struct {
@@ -222,4 +225,13 @@ func (fs *fileStorer) FileWriter(ctx context.Context, fileDir string, fileRecord
 		WriteCloser: wc,
 		fileName:    string(file),
 	}, nil
+}
+
+func (fs *fileStorer) DeleteStoredFile(ctx context.Context, fileDir string, md *rfpb.StorageMetadata) error {
+	switch {
+	case md.GetFileMetadata() != nil:
+		return os.Remove(fs.FilePath(fileDir, md.GetFileMetadata()))
+	default:
+		return nil
+	}
 }

--- a/enterprise/server/raft/replica/BUILD
+++ b/enterprise/server/raft/replica/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//enterprise/server/raft/rbuilder",
         "//enterprise/server/raft/sender",
         "//proto:raft_go_proto",
+        "//server/util/disk",
         "//server/util/log",
         "//server/util/rangemap",
         "//server/util/status",
@@ -31,7 +32,6 @@ go_test(
     deps = [
         ":replica",
         "//enterprise/server/raft/constants",
-        "//enterprise/server/raft/filestore",
         "//enterprise/server/raft/keys",
         "//enterprise/server/raft/rbuilder",
         "//enterprise/server/raft/sender",
@@ -40,7 +40,6 @@ go_test(
         "//server/testutil/testdigest",
         "//server/testutil/testfs",
         "//server/util/status",
-        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_lni_dragonboat_v3//statemachine",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//proto",

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -51,7 +51,6 @@ const (
 
 type Store struct {
 	rootDir  string
-	fileDir  string
 	grpcAddr string
 
 	nodeHost      *dragonboat.NodeHost
@@ -74,10 +73,9 @@ type Store struct {
 	fileStorer filestore.Store
 }
 
-func New(rootDir, fileDir string, nodeHost *dragonboat.NodeHost, gossipManager *gossip.GossipManager, sender *sender.Sender, registry registry.NodeRegistry, apiClient *client.APIClient) *Store {
+func New(rootDir string, nodeHost *dragonboat.NodeHost, gossipManager *gossip.GossipManager, sender *sender.Sender, registry registry.NodeRegistry, apiClient *client.APIClient) *Store {
 	s := &Store{
 		rootDir:       rootDir,
-		fileDir:       fileDir,
 		nodeHost:      nodeHost,
 		gossipManager: gossipManager,
 		sender:        sender,
@@ -360,7 +358,7 @@ func (s *Store) RangeIsActive(header *rfpb.Header) error {
 }
 
 func (s *Store) ReplicaFactoryFn(clusterID, nodeID uint64) dbsm.IOnDiskStateMachine {
-	return replica.New(s.rootDir, s.fileDir, clusterID, nodeID, s)
+	return replica.New(s.rootDir, clusterID, nodeID, s)
 }
 
 func (s *Store) Sender() *sender.Sender {


### PR DESCRIPTION
- Simplify replica construction by only requiring a single dir, rootDir, in New().
- Clean up replica tests to use the replica Writer directly.
- Add a DeleteStoredData method to fileStorer
- Add a function to delete stored files based on k/v ranges, and call it from split().