### PR TITLE
add seperate flags for reading and writing from clickhouse

### DIFF
--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -3,6 +3,7 @@ package invocation_stat_service
 import (
 	"context"
 	"database/sql"
+	"flag"
 	"fmt"
 	"sort"
 	"time"
@@ -18,6 +19,10 @@ import (
 
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
+)
+
+var (
+	readFromOLAPDBEnabled = flag.Bool("app.enable_read_from_olap_db", false, "If enabled, complete invocations will be flushed to OLAP DB")
 )
 
 type InvocationStatService struct {
@@ -58,7 +63,7 @@ func (i *InvocationStatService) getAggColumn(reqCtx *ctxpb.RequestContext, aggTy
 
 func (i *InvocationStatService) GetTrendBasicQuery(timezoneOffsetMinutes int32) string {
 	q := ""
-	if i.olapdbh == nil {
+	if i.olapdbh == nil || !*readFromOLAPDBEnabled {
 		q = fmt.Sprintf("SELECT %s as name,", i.dbh.DateFromUsecTimestamp("updated_at_usec", timezoneOffsetMinutes)) + `
 	    SUM(CASE WHEN duration_usec > 0 THEN duration_usec END) as total_build_time_usec,`
 	} else {
@@ -162,7 +167,7 @@ func (i *InvocationStatService) GetTrend(ctx context.Context, req *inpb.GetTrend
 	qStr, qArgs := q.Build()
 	var rows *sql.Rows
 	var err error
-	if i.olapdbh == nil {
+	if i.olapdbh == nil || !*readFromOLAPDBEnabled {
 		rows, err = i.dbh.RawWithOptions(ctx, db.Opts().WithQueryName("query_invocation_trends"), qStr, qArgs...).Rows()
 	} else {
 		rows, err = i.olapdbh.DB(ctx).Raw(qStr, qArgs...).Rows()
@@ -177,7 +182,7 @@ func (i *InvocationStatService) GetTrend(ctx context.Context, req *inpb.GetTrend
 
 	for rows.Next() {
 		stat := &inpb.TrendStat{}
-		if i.olapdbh == nil {
+		if i.olapdbh == nil || !*readFromOLAPDBEnabled {
 			if err := i.dbh.DB(ctx).ScanRows(rows, &stat); err != nil {
 				return nil, err
 			}
@@ -198,7 +203,7 @@ func (i *InvocationStatService) GetTrend(ctx context.Context, req *inpb.GetTrend
 
 func (i *InvocationStatService) GetInvocationStatBaseQuery(aggColumn string) string {
 	q := fmt.Sprintf("SELECT %s as name,", aggColumn)
-	if i.olapdbh == nil {
+	if i.olapdbh == nil || !*readFromOLAPDBEnabled {
 		q = q + `
 	    SUM(CASE WHEN duration_usec > 0 THEN duration_usec END) as total_build_time_usec,`
 	} else {
@@ -295,7 +300,7 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 	qStr, qArgs := q.Build()
 	var rows *sql.Rows
 	var err error
-	if i.olapdbh == nil {
+	if i.olapdbh == nil || !*readFromOLAPDBEnabled {
 		rows, err = i.dbh.RawWithOptions(ctx, db.Opts().WithQueryName("query_invocation_stats"), qStr, qArgs...).Rows()
 	} else {
 		rows, err = i.olapdbh.DB(ctx).Raw(qStr, qArgs...).Rows()
@@ -310,7 +315,7 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 
 	for rows.Next() {
 		stat := &inpb.InvocationStat{}
-		if i.olapdbh == nil {
+		if i.olapdbh == nil || !*readFromOLAPDBEnabled {
 			if err := i.dbh.DB(ctx).ScanRows(rows, &stat); err != nil {
 				return nil, err
 			}

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -79,6 +79,7 @@ var (
 	chunkFileSizeBytes                = flag.Int("storage.chunk_file_size_bytes", 3_000_000 /* 3 MB */, "How many bytes to buffer in memory before flushing a chunk of build protocol data to disk.")
 	enableChunkedEventLogs            = flag.Bool("storage.enable_chunked_event_logs", false, "If true, Event logs will be stored separately from the invocation proto in chunks.")
 	requireInvocationEventParseOnRead = flag.Bool("app.require_invocation_event_parse_on_read", false, "If true, invocation responses will be filled from database values and then by parsing the events on read.")
+	flushToOLAPDBEnabled              = flag.Bool("app.enable_flush_to_olap_db", false, "If enabled, complete invocations will be flushed to OLAP DB")
 
 	cacheStatsFinalizationDelay = flag.Duration(
 		"cache_stats_finalization_delay", 500*time.Millisecond,
@@ -249,7 +250,7 @@ func (r *statsRecorder) lookupInvocation(ctx context.Context, ij *invocationJWT)
 }
 
 func (r *statsRecorder) flushInvocationStatsToOLAPDB(ctx context.Context, ij *invocationJWT, ti *tables.Invocation) error {
-	if r.env.GetOLAPDBHandle() == nil {
+	if r.env.GetOLAPDBHandle() == nil || !*flushToOLAPDBEnabled {
 		return nil
 	}
 	inv, err := r.lookupInvocation(ctx, ij)

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -79,7 +79,7 @@ var (
 	chunkFileSizeBytes                = flag.Int("storage.chunk_file_size_bytes", 3_000_000 /* 3 MB */, "How many bytes to buffer in memory before flushing a chunk of build protocol data to disk.")
 	enableChunkedEventLogs            = flag.Bool("storage.enable_chunked_event_logs", false, "If true, Event logs will be stored separately from the invocation proto in chunks.")
 	requireInvocationEventParseOnRead = flag.Bool("app.require_invocation_event_parse_on_read", false, "If true, invocation responses will be filled from database values and then by parsing the events on read.")
-	flushToOLAPDBEnabled              = flag.Bool("app.enable_flush_to_olap_db", false, "If enabled, complete invocations will be flushed to OLAP DB")
+	writeToOLAPDBEnabled              = flag.Bool("app.enable_write_to_olap_db", false, "If enabled, complete invocations will be flushed to OLAP DB")
 
 	cacheStatsFinalizationDelay = flag.Duration(
 		"cache_stats_finalization_delay", 500*time.Millisecond,
@@ -250,7 +250,7 @@ func (r *statsRecorder) lookupInvocation(ctx context.Context, ij *invocationJWT)
 }
 
 func (r *statsRecorder) flushInvocationStatsToOLAPDB(ctx context.Context, ij *invocationJWT, ti *tables.Invocation) error {
-	if r.env.GetOLAPDBHandle() == nil || !*flushToOLAPDBEnabled {
+	if r.env.GetOLAPDBHandle() == nil || !*writeToOLAPDBEnabled {
 		return nil
 	}
 	inv, err := r.lookupInvocation(ctx, ij)


### PR DESCRIPTION
So that we can enable double write first; then enable reading from
clickhouse after the data is backfilled.
