### PR TITLE
Add go-tensorflow to deps.bzl

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -4233,6 +4233,16 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         version = "v0.0.0-20200319021203-7eef512accb3",
     )
 
+    # keep
+    go_repository(
+        name = "com_github_tensorflow_tensorflow",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/tensorflow/tensorflow",
+        replace = "github.com/bduffany/go-tensorflow",
+        sum = "h1:3WU8fhrz/8ucFejgXUdGwo08YgIB1NHFfySLLKJrNZ0=",
+        version = "v0.0.0-20220829154158-35855b13822d",
+    )
+
     go_repository(
         name = "com_github_tetafro_godot",
         importpath = "github.com/tetafro/godot",


### PR DESCRIPTION
To add the cgo deps without breaking the internal repo, we need to first add the TF go_repository to deps.bzl, then let the repo auto-sync complete, then import the cgo deps from the go_repository within the internal repo WORKSPACE. Then, we can use tensorflow safely in the OSS repo without the internal repo breaking.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
