### PR TITLE
Update generated TF repo with required c++ libs

### DIFF
--- a/enterprise/tools/tensorflow/BUILD.lib.bzl
+++ b/enterprise/tools/tensorflow/BUILD.lib.bzl
@@ -1,7 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+
 cc_library(
     name = "libtensorflow",
     srcs = glob(["tensorflow/**/*.h"]) + [
         "@libtensorflow-cpu-linux-x86_64-${TENSORFLOW_VERSION}//:libtensorflow",
     ],
-    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "libstdc++",
+    srcs = ["libstdc++.so.6"],
+)
+
+cc_library(
+    name = "libgcc_s",
+    srcs = ["libgcc_s.so.1"],
 )

--- a/enterprise/tools/tensorflow/Dockerfile
+++ b/enterprise/tools/tensorflow/Dockerfile
@@ -81,12 +81,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends gettext-base &&
     cat /tmp/BUILD | envsubst > BUILD && \
     cat /tmp/deps.bzl | envsubst > deps.bzl
 
+# Copy the system libgcc and libstdc++ into the repo since TF depends on them.
+# We don't want to rely on these being available on the host system -- for
+# example, distroless images will not have these available. Together they are
+# ~2 MB so copying into the repo should be OK.
+RUN apt-get update && apt-get install --no-install-recommends -y libgcc-s1 && \
+    cp /lib/x86_64-linux-gnu/libgcc_s.so.1 . && \
+    cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 .
+
 # Make some adjustments to gazelle's default output to link against the TF
 # release libraries and headers, and add a "keep" comment to prevent gazelle
 # from modifying it.
 RUN buildozer 'remove clinkopts' //tensorflow/go && \
     buildozer 'remove copts' //tensorflow/go && \
-    buildozer 'add cdeps //:libtensorflow' //tensorflow/go && \
+    buildozer 'add cdeps //:libtensorflow //:libstdc++ //:libgcc_s' //tensorflow/go && \
     buildozer 'comment keep' //tensorflow/go
 
 # Remove the system install of TF to ensure those aren't used in the test build.


### PR DESCRIPTION
TF doesn't work unless `libstdc++.so.6` and `libgcc_s.so.1` are available at runtime. I didn't catch this until trying to run BB as a Docker container (which is based on the distroless image), since when running as a regular go_binary, my system copies of these libs were used.

We could also switch to the `distroless/cc-debian11` base image (instead of `distroless/debian11`) but I figured it's more portable to include the libs in the generated repo.

Generated repo diff: https://github.com/bduffany/go-tensorflow/commit/35855b13822d37e8e9e77ec74bf8582e5d656d90

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
