### PR TITLE
Check range generation in replica.

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -493,7 +493,7 @@ func (s *Store) FindMissing(ctx context.Context, req *rfpb.FindMissingRequest) (
 	if err != nil {
 		return nil, err
 	}
-	missing, err := r.FindMissing(ctx, req.GetFileRecord())
+	missing, err := r.FindMissing(ctx, req.GetHeader(), req.GetFileRecord())
 	if err != nil {
 		return nil, err
 	}
@@ -522,7 +522,7 @@ func (s *Store) Read(req *rfpb.ReadRequest, stream rfspb.Api_ReadServer) error {
 		return err
 	}
 
-	readCloser, err := r.Reader(stream.Context(), req.GetFileRecord(), req.GetOffset(), req.GetLimit())
+	readCloser, err := r.Reader(stream.Context(), req.GetHeader(), req.GetFileRecord(), req.GetOffset(), req.GetLimit())
 	if err != nil {
 		return err
 	}
@@ -561,7 +561,7 @@ func (s *Store) Write(stream rfspb.Api_WriteServer) error {
 			if err != nil {
 				return err
 			}
-			writeCloser, err = r.Writer(stream.Context(), req.GetFileRecord())
+			writeCloser, err = r.Writer(stream.Context(), req.GetHeader(), req.GetFileRecord())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Although we already validate the generation in the store, the generation
in the replica might change due to a concurrent split so we need to
revalidate the generation after split lock is acquired to make sure the
generation hasn't changed.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
