### PR TITLE
For public invocations, add (as opposed to replace) others_read permissions

### DIFF
--- a/server/backends/invocationdb/BUILD
+++ b/server/backends/invocationdb/BUILD
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:acl_go_proto",
-        "//proto:api_key_go_proto",
         "//proto:invocation_go_proto",
         "//proto:telemetry_go_proto",
         "//proto:user_id_go_proto",

--- a/server/backends/invocationdb/BUILD
+++ b/server/backends/invocationdb/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:acl_go_proto",
+        "//proto:api_key_go_proto",
         "//proto:invocation_go_proto",
         "//proto:telemetry_go_proto",
         "//proto:user_id_go_proto",

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -1253,11 +1253,13 @@ func (e *EventChannel) tableInvocationFromProto(p *inpb.Invocation, blobID strin
 	i.Attempt = p.Attempt
 	i.BazelExitCode = p.BazelExitCode
 
-	userGroupPerms, err := perms.GetFromContext(e.ctx, e.env)
+	userGroupPerms, err := perms.ForAuthenticatedGroup(e.ctx, e.env)
 	if err != nil {
-		return nil, err
+		// TODO(Maggie): Return the error here once we're confident this is stable
+		log.Warningf("Error fetching group perms for invocation %v", p.InvocationId)
+	} else {
+		i.Perms = userGroupPerms.Perms
 	}
-	i.Perms = userGroupPerms.Perms
 	if p.ReadPermission == inpb.InvocationPermission_PUBLIC {
 		i.Perms |= perms.OTHERS_READ
 	}

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -625,7 +625,7 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 		invocation.LastChunkId = e.logWriter.GetLastChunkId(ctx)
 	}
 
-	ti, err := tableInvocationFromProto(invocation, iid)
+	ti, err := e.tableInvocationFromProto(invocation, iid)
 	if err != nil {
 		return err
 	}
@@ -1024,7 +1024,7 @@ func (e *EventChannel) writeBuildMetadata(ctx context.Context, invocationID stri
 	if e.logWriter != nil {
 		invocationProto.LastChunkId = e.logWriter.GetLastChunkId(ctx)
 	}
-	ti, err = tableInvocationFromProto(invocationProto, ti.BlobID)
+	ti, err = e.tableInvocationFromProto(invocationProto, ti.BlobID)
 	if err != nil {
 		return err
 	}
@@ -1221,7 +1221,7 @@ func LookupInvocation(env environment.Env, ctx context.Context, iid string) (*in
 	return invocation, nil
 }
 
-func tableInvocationFromProto(p *inpb.Invocation, blobID string) (*tables.Invocation, error) {
+func (e *EventChannel) tableInvocationFromProto(p *inpb.Invocation, blobID string) (*tables.Invocation, error) {
 	uuid, err := uuid.StringToBytes(p.InvocationId)
 	if err != nil {
 		return nil, err
@@ -1248,13 +1248,19 @@ func tableInvocationFromProto(p *inpb.Invocation, blobID string) (*tables.Invoca
 	i.ActionCount = p.ActionCount
 	i.BlobID = blobID
 	i.InvocationStatus = int64(p.InvocationStatus)
-	if p.ReadPermission == inpb.InvocationPermission_PUBLIC {
-		i.Perms |= perms.OTHERS_READ
-	}
 	i.LastChunkId = p.LastChunkId
 	i.RedactionFlags = redact.RedactionFlagStandardRedactions
 	i.Attempt = p.Attempt
 	i.BazelExitCode = p.BazelExitCode
+
+	userGroupPerms, err := perms.GetFromContext(e.ctx, e.env)
+	if err != nil {
+		return nil, err
+	}
+	i.Perms = userGroupPerms.Perms
+	if p.ReadPermission == inpb.InvocationPermission_PUBLIC {
+		i.Perms |= perms.OTHERS_READ
+	}
 	return i, nil
 }
 

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -1249,7 +1249,7 @@ func tableInvocationFromProto(p *inpb.Invocation, blobID string) (*tables.Invoca
 	i.BlobID = blobID
 	i.InvocationStatus = int64(p.InvocationStatus)
 	if p.ReadPermission == inpb.InvocationPermission_PUBLIC {
-		i.Perms = perms.OTHERS_READ
+		i.Perms |= perms.OTHERS_READ
 	}
 	i.LastChunkId = p.LastChunkId
 	i.RedactionFlags = redact.RedactionFlagStandardRedactions

--- a/server/util/capabilities/BUILD
+++ b/server/util/capabilities/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//proto:api_key_go_proto",
         "//server/environment",
         "//server/util/perms",
+        "//server/util/status",
     ],
 )
 

--- a/server/util/capabilities/capabilities.go
+++ b/server/util/capabilities/capabilities.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
 )
@@ -58,18 +59,17 @@ func IsGranted(ctx context.Context, env environment.Env, cap akpb.ApiKey_Capabil
 	return user.HasCapability(cap), nil
 }
 
-func GetFromContext(ctx context.Context, env environment.Env) ([]akpb.ApiKey_Capability, error) {
-	var caps []akpb.ApiKey_Capability
-	if auth := env.GetAuthenticator(); auth != nil {
-		u, err := auth.AuthenticatedUser(ctx)
-		if err == nil {
-			caps = u.GetCapabilities()
-		} else {
-			if perms.IsAnonymousUserError(err) && auth.AnonymousUsageEnabled() {
-				caps = DefaultAuthenticatedUserCapabilities
-			}
-		}
+func ForAuthenticatedUser(ctx context.Context, env environment.Env) ([]akpb.ApiKey_Capability, error) {
+	auth := env.GetAuthenticator()
+	if auth == nil {
+		return nil, status.UnimplementedError("Auth is not configured")
 	}
-
-	return caps, nil
+	u, err := auth.AuthenticatedUser(ctx)
+	if err != nil {
+		if perms.IsAnonymousUserError(err) && auth.AnonymousUsageEnabled() {
+			return DefaultAuthenticatedUserCapabilities, nil
+		}
+		return nil, err
+	}
+	return u.GetCapabilities(), nil
 }

--- a/server/util/capabilities/capabilities.go
+++ b/server/util/capabilities/capabilities.go
@@ -57,3 +57,19 @@ func IsGranted(ctx context.Context, env environment.Env, cap akpb.ApiKey_Capabil
 	}
 	return user.HasCapability(cap), nil
 }
+
+func GetFromContext(ctx context.Context, env environment.Env) ([]akpb.ApiKey_Capability, error) {
+	var caps []akpb.ApiKey_Capability
+	if auth := env.GetAuthenticator(); auth != nil {
+		u, err := auth.AuthenticatedUser(ctx)
+		if err == nil {
+			caps = u.GetCapabilities()
+		} else {
+			if perms.IsAnonymousUserError(err) && auth.AnonymousUsageEnabled() {
+				caps = DefaultAuthenticatedUserCapabilities
+			}
+		}
+	}
+
+	return caps, nil
+}


### PR DESCRIPTION
Fixes buildbuddy-io/buildbuddy-internal#1589
   
When we create an invocation, we are setting the permissions based on the context (https://github.com/buildbuddy-io/buildbuddy/blob/master/server/backends/invocationdb/invocationdb.go#L91). These are
being overwritten for workflows for public repos. This may
incorrectly restrict the invocation, if we had previously set additional permissions on it
