### PR TITLE
Make gRPC health check appear at grpc.health.v1.Health

### DIFF
--- a/proto/health.proto
+++ b/proto/health.proto
@@ -17,7 +17,7 @@
 
 syntax = "proto3";
 
-package health;
+package grpc.health.v1;
 
 option go_package = "health";
 


### PR DESCRIPTION
I don't think anyone was using this yet, but lmk if you know of any.

The path / service name are both configurable in AWS so this is just as simple to use as before and now is at a more widely known path.

Related to https://github.com/buildbuddy-io/buildbuddy-internal/issues/1606