### PR TITLE
Populate scorecard field in invocation webhook payload with action cache misses

### DIFF
--- a/enterprise/server/test/integration/invocation_webhook/BUILD
+++ b/enterprise/server/test/integration/invocation_webhook/BUILD
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "invocation_webhook_test",
+    srcs = ["invocation_webhook_test.go"],
+    deps = [
+        "//enterprise/server/testutil/buildbuddy_enterprise",
+        "//proto:invocation_go_proto",
+        "//server/testutil/healthcheck",
+        "//server/testutil/testbazel",
+        "//server/testutil/testfs",
+        "//server/testutil/testhttp",
+        "//server/util/db",
+        "//server/util/testing/flags",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//encoding/protojson",
+    ],
+)

--- a/enterprise/server/test/integration/invocation_webhook/invocation_webhook_test.go
+++ b/enterprise/server/test/integration/invocation_webhook/invocation_webhook_test.go
@@ -1,0 +1,141 @@
+package invocation_webhook_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/buildbuddy_enterprise"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/healthcheck"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testbazel"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testhttp"
+	"github.com/buildbuddy-io/buildbuddy/server/util/db"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
+)
+
+func TestInvocationUploadWebhook(t *testing.T) {
+	tempDir := testfs.MakeTempDir(t)
+	dataSource := "sqlite3://" + filepath.Join(tempDir, "buildbuddy-test.db")
+	app := buildbuddy_enterprise.Run(t,
+		"--database.data_source="+dataSource,
+		"--integrations.invocation_upload.enabled=true",
+		"--cache.detailed_stats_enabled=true",
+		"--app.no_default_user_group=false",
+		"--api.api_key=TEST",
+	)
+
+	// Start our fake webhook server.
+	ws := NewWebhookServer(t)
+
+	// Connect directly to the DB and configure webhooks to point at the server.
+	// (For now, manual SQL is the only way to set up invocation webhooks.)
+	flags.Set(t, "database.data_source", dataSource)
+	hc := healthcheck.NewTestingHealthChecker()
+	dbh, err := db.GetConfiguredDatabase(hc)
+	require.NoError(t, err)
+	ctx := context.Background()
+	db := dbh.DB(ctx)
+	err = db.Exec("UPDATE `Groups` SET invocation_webhook_url = ?", ws.URL.String()).Error
+	require.NoError(t, err)
+
+	// Now run an invocation (with BES and remote cache) as the default group,
+	// expecting a cache miss.
+	wsDir := testbazel.MakeTempWorkspace(t, map[string]string{
+		"WORKSPACE": "",
+		"BUILD":     `genrule(name = "gen", outs = ["out"], cmd_bash = "touch $@")`,
+	})
+	buildFlags := []string{":gen", "--remote_header=x-buildbuddy-api-key=TEST"}
+	buildFlags = append(buildFlags, app.BESBazelFlags()...)
+	buildFlags = append(buildFlags, app.RemoteCacheBazelFlags()...)
+
+	result := testbazel.Invoke(ctx, t, wsDir, "build", buildFlags...)
+
+	require.NoError(t, result.Error)
+
+	// Wait up to 1s for the invocation to be published to the webhook.
+	end := time.Now().Add(1 * time.Second)
+	var invocations []*inpb.Invocation
+	for time.Now().Before(end) {
+		time.Sleep(25 * time.Millisecond)
+		invocations = ws.Invocations()
+		if len(invocations) != 0 {
+			break
+		}
+	}
+	if len(invocations) == 0 {
+		assert.FailNow(t, "no invocations were published to the test webhook server")
+	}
+	in := invocations[0]
+	require.Len(t, in.GetScoreCard().GetMisses(), 1, "should have 1 action cache miss")
+	require.Equal(t, "Genrule", in.GetScoreCard().GetMisses()[0].GetActionMnemonic())
+}
+
+// webhookServer collects invocations that are sent to it via HTTP and stores
+// them in a list.
+type webhookServer struct {
+	t   *testing.T
+	URL *url.URL
+
+	mu          sync.Mutex
+	invocations []*inpb.Invocation
+}
+
+func NewWebhookServer(t *testing.T) *webhookServer {
+	ws := &webhookServer{t: t}
+	handler := ws
+	url := testhttp.StartServer(t, handler)
+	ws.URL = url
+	return ws
+}
+
+func (ws *webhookServer) Invocations() []*inpb.Invocation {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	return append(make([]*inpb.Invocation, 0, len(ws.invocations)), ws.invocations...)
+}
+
+func (ws *webhookServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	in, err := ws.readInvocation(req)
+	if err != nil {
+		require.FailNow(ws.t, "failed to read invocation", "%s", err)
+	}
+	_, err = res.Write([]byte("OK"))
+	require.NoError(ws.t, err)
+
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	ws.invocations = append(ws.invocations, in)
+}
+
+func (ws *webhookServer) readInvocation(req *http.Request) (*inpb.Invocation, error) {
+	gzb, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	gzr, err := gzip.NewReader(bytes.NewReader(gzb))
+	if err != nil {
+		return nil, err
+	}
+	b, err := io.ReadAll(gzr)
+	if err != nil {
+		return nil, err
+	}
+	in := &inpb.Invocation{}
+	if err := protojson.Unmarshal(b, in); err != nil {
+		return nil, err
+	}
+	return in, nil
+}

--- a/server/build_event_protocol/build_event_handler/BUILD
+++ b/server/build_event_protocol/build_event_handler/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//proto:cache_go_proto",
         "//proto:command_line_go_proto",
         "//proto:invocation_go_proto",
+        "//proto:pagination_go_proto",
         "//proto:publish_build_event_go_proto",
         "//proto:user_id_go_proto",
         "//proto/api/v1:api_v1_go_proto",
@@ -34,6 +35,7 @@ go_library(
         "//server/util/capabilities",
         "//server/util/git",
         "//server/util/log",
+        "//server/util/paging",
         "//server/util/perms",
         "//server/util/protofile",
         "//server/util/redact",
@@ -43,6 +45,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//types/known/fieldmaskpb",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -42,6 +42,11 @@ const (
 	// detailed results from the metrics collector.
 	scorecardResultsExpiration = 3 * time.Hour
 
+	// CacheMissScoreCardLimit is the maximum number of results to return in
+	// the "cache misses" card (the card displayed when detailed stats are
+	// not enabled).
+	CacheMissScoreCardLimit = 1000
+
 	// Prometheus CacheEventTypeLabel values
 
 	hitLabel    = "hit"
@@ -512,8 +517,8 @@ func ScoreCard(ctx context.Context, env environment.Env, iid string) *capb.Score
 	// the number of cache misses to 1K if there are more than that. Too
 	// many are not useful in the UI and we don't want to pay the storage
 	// cost either.
-	if len(sortedKeys) > 1000 {
-		sortedKeys = sortedKeys[:1000]
+	if len(sortedKeys) > CacheMissScoreCardLimit {
+		sortedKeys = sortedKeys[:CacheMissScoreCardLimit]
 	}
 	sort.Strings(sortedKeys)
 

--- a/server/testutil/buildbuddy/buildbuddy.go
+++ b/server/testutil/buildbuddy/buildbuddy.go
@@ -7,11 +7,11 @@ import (
 )
 
 // Run a local BuildBuddy server for the scope of the given test case.
-func Run(t *testing.T) *app.App {
+func Run(t *testing.T, args ...string) *app.App {
 	return app.Run(
 		t,
 		/* commandPath= */ "server/cmd/buildbuddy/buildbuddy_/buildbuddy",
-		/* commandArgs= */ []string{},
+		/* commandArgs= */ args,
 		/* configPath= */ "config/buildbuddy.local.yaml",
 	)
 }


### PR DESCRIPTION
After enabling detailed stats, we no longer populate the `score_card` field in invocation webhook payloads. This PR restores that functionality and also adds an integration test for invocation webhooks.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
