### PR TITLE
Fix usages of time.Ticker

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -75,10 +75,10 @@ func NewContainerMetrics() *ContainerMetrics {
 // Start kicks off a goroutine that periodically updates the CPU gauge.
 func (m *ContainerMetrics) Start(ctx context.Context) {
 	go func() {
+		t := time.NewTicker(cpuUsageUpdateInterval)
+		defer t.Stop()
+		lastTick := time.Now()
 		for {
-			t := time.NewTicker(cpuUsageUpdateInterval)
-			defer t.Stop()
-			lastTick := time.Now()
 			select {
 			case <-ctx.Done():
 				return

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -245,6 +245,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	// Run a timer that periodically sends update messages back
 	// to our caller while execution is ongoing.
 	updateTicker := time.NewTicker(execProgressCallbackPeriod)
+	defer updateTicker.Stop()
 	var cmdResult *interfaces.CommandResult
 	for cmdResult == nil {
 		select {

--- a/enterprise/server/scheduling/scheduler_client/scheduler_client.go
+++ b/enterprise/server/scheduling/scheduler_client/scheduler_client.go
@@ -171,6 +171,9 @@ func (r *Registration) maintainRegistrationAndStreamWork(ctx context.Context) {
 
 	defer r.setConnected(false)
 
+	registrationTicker := time.NewTicker(schedulerCheckInInterval)
+	defer registrationTicker.Stop()
+
 	for {
 		stream, err := r.schedulerClient.RegisterAndStreamWork(ctx)
 		if err != nil {
@@ -204,7 +207,6 @@ func (r *Registration) maintainRegistrationAndStreamWork(ctx context.Context) {
 			}
 		}()
 
-		registrationTicker := time.NewTicker(schedulerCheckInInterval)
 		for {
 			done, err := r.processWorkStream(ctx, stream, schedulerMsgs, registrationTicker)
 			if err != nil {

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -260,6 +260,7 @@ func (h *executorHandle) Serve(ctx context.Context) error {
 	}()
 
 	checkCredentialsTicker := time.NewTicker(checkRegistrationCredentialsInterval)
+	defer checkCredentialsTicker.Stop()
 
 	executorID := "unknown"
 	for {


### PR DESCRIPTION
* Audit all usages of `time.Ticker` and make sure we `defer ticker.Stop()`.
  * Some exceptions are made in cases where we create a ticker in a func like `foo.Start()` and then destroy it in a symmetric call to `foo.Stop()`. Note, it is safe to call `ticker.Stop()` twice.
* In any cases where we call `defer ticker.Stop()`, make sure the `defer` is not inside a `for` loop. Otherwise, the ticker will be kept running until the for loop terminates (potentially never, in some cases), incurring high CPU load. (Note, a ticker will run even if nobody is receiving from ticker.C)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
