### PR TITLE
Support parsing objects from config yaml

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1285,9 +1285,8 @@ type partitionEvictor struct {
 	lastRun     time.Time
 	lastEvicted *evictionPoolEntry
 
-	atimeUpdateThreshold time.Duration
-	atimeBufferSize      int
-	minEvictionAge       time.Duration
+	atimeBufferSize int
+	minEvictionAge  time.Duration
 }
 
 func newPartitionEvictor(part disk.Partition, fileStorer filestore.Store, blobDir string, dbg pebbleutil.Leaser, accesses chan<- *accessTimeUpdate, atimeBufferSize int, minEvictionAge time.Duration) (*partitionEvictor, error) {
@@ -1511,7 +1510,7 @@ func (e *partitionEvictor) randomKey(n int) []byte {
 
 func (e *partitionEvictor) refreshAtime(s *evictionPoolEntry) error {
 	if s.fileMetadata.GetLastAccessUsec() == 0 {
-		sendAtimeUpdate(e.accesses, s.fileMetadataKey, s.fileMetadata /* force an update */, 0, e.atimeBufferSize)
+		sendAtimeUpdate(e.accesses, s.fileMetadataKey, s.fileMetadata, 0 /*force an update*/, e.atimeBufferSize)
 		return status.FailedPreconditionErrorf("File %q had no atime set", s.fileMetadataKey)
 	}
 	atime := time.UnixMicro(s.fileMetadata.GetLastAccessUsec())

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -213,7 +213,7 @@ func main() {
 	rootContext := context.Background()
 
 	flag.Parse()
-	if err := flagyaml.PopulateFlagsFromFile(config.Path()); err != nil {
+	if err := flagyaml.PopulateFlagsFromFileWithReread(config.Path()); err != nil {
 		log.Fatalf("Error loading config from file: %s", err)
 	}
 

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -53,7 +53,6 @@ go_library(
         "//server/util/clickhouse",
         "//server/util/fileresolver",
         "//server/util/flagutil",
-        "//server/util/flagutil/yaml",
         "//server/util/healthcheck",
         "//server/util/log",
         "//server/util/tracing",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -55,7 +55,6 @@ import (
 	remote_execution_redis_client "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/redis_client"
 	telserver "github.com/buildbuddy-io/buildbuddy/enterprise/server/telemetry"
 	workflow "github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/service"
-	flagyaml "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/yaml"
 )
 
 var serverType = flag.String("server_type", "buildbuddy-server", "The server type to match on health checks")
@@ -159,11 +158,13 @@ func main() {
 	version.Print()
 
 	flag.Parse()
-	if err := flagyaml.PopulateFlagsFromFile(config.Path()); err != nil {
-		log.Fatalf("Error loading config from file: %s", err)
+	cfg, err := config.ParseConfig(config.Path())
+	if err != nil {
+		log.Fatalf(err.Error())
 	}
+
 	healthChecker := healthcheck.NewHealthChecker(*serverType)
-	realEnv := libmain.GetConfiguredEnvironmentOrDie(healthChecker)
+	realEnv := libmain.GetConfiguredEnvironmentOrDie(healthChecker, cfg)
 	if err := tracing.Configure(realEnv); err != nil {
 		log.Fatalf("Could not configure tracing: %s", err)
 	}

--- a/enterprise/server/image_converter/image_converter.go
+++ b/enterprise/server/image_converter/image_converter.go
@@ -487,7 +487,7 @@ func (c *imageConverter) Start(hc interfaces.HealthChecker, env environment.Env)
 func main() {
 	flag.Parse()
 
-	if err := flagyaml.PopulateFlagsFromFile(config.Path()); err != nil {
+	if err := flagyaml.PopulateFlagsFromFileWithReread(config.Path()); err != nil {
 		log.Fatalf("Error loading config from file: %s", err)
 	}
 

--- a/server/cmd/buildbuddy/BUILD
+++ b/server/cmd/buildbuddy/BUILD
@@ -53,7 +53,6 @@ go_library(
         "//server/janitor",
         "//server/libmain",
         "//server/telemetry",
-        "//server/util/flagutil/yaml",
         "//server/util/healthcheck",
         "//server/util/log",
         "//server/version",

--- a/server/cmd/buildbuddy/main.go
+++ b/server/cmd/buildbuddy/main.go
@@ -10,8 +10,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/version"
-
-	flag_yaml "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/yaml"
 )
 
 var (
@@ -27,11 +25,13 @@ func main() {
 	version.Print()
 
 	flag.Parse()
-	if err := flag_yaml.PopulateFlagsFromFile(config.Path()); err != nil {
-		log.Fatalf("Error loading config from file: %s", err)
+	cfg, err := config.ParseConfig(config.Path())
+	if err != nil {
+		log.Fatalf(err.Error())
 	}
+
 	healthChecker := healthcheck.NewHealthChecker(*serverType)
-	env := libmain.GetConfiguredEnvironmentOrDie(healthChecker)
+	env := libmain.GetConfiguredEnvironmentOrDie(healthChecker, cfg)
 
 	telemetryClient := telemetry.NewTelemetryClient(env)
 	telemetryClient.Start()

--- a/server/config/BUILD
+++ b/server/config/BUILD
@@ -2,8 +2,19 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "config",
-    srcs = ["config.go"],
+    srcs = [
+        "config.go",
+        "migration_config.go",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/config",
     visibility = ["//visibility:public"],
-    deps = ["//server/util/flagutil/yaml"],
+    deps = [
+        "//server/util/disk",
+        "//server/util/file",
+        "//server/util/flagutil/yaml",
+        "//server/util/log",
+        "//server/util/status",
+        "@com_github_pkg_errors//:errors",
+        "@in_gopkg_yaml_v3//:yaml_v3",
+    ],
 )

--- a/server/config/BUILD
+++ b/server/config/BUILD
@@ -2,14 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "config",
-    srcs = [
-        "config.go",
-        "migration_config.go",
-    ],
+    srcs = ["config.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/config",
     visibility = ["//visibility:public"],
     deps = [
-        "//server/util/disk",
         "//server/util/file",
         "//server/util/flagutil/yaml",
         "//server/util/log",

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -20,16 +20,10 @@ var (
 	// If you wish to extract a section of the config to the Config struct as opposed to parsing into flags:
 	// 1. Set the section name in configKeysToExtract so the flag parser will know to ignore it
 	// 2. Define the section in the Config struct using `yaml` tags
-	configKeysToExtract = []string{"migration"}
+	configKeysToExtract []string
 )
 
-type Config struct {
-	CacheBlock *CacheBlock `yaml:"cache"`
-}
-
-type CacheBlock struct {
-	MigrationConfig *MigrationConfig `yaml:"migration"`
-}
+type Config struct{}
 
 func init() {
 	// As this flag determines the YAML file we read the config from, it can't

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -3,19 +3,72 @@ package config
 import (
 	"flag"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/file"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+
 	flagyaml "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/yaml"
 )
 
 const pathFlagName = "config_file"
 
-var configPath = flag.String(pathFlagName, "/config.yaml", "The path to a buildbuddy config file")
+var (
+	configPath = flag.String(pathFlagName, "/config.yaml", "The path to a buildbuddy config file")
+
+	// If you wish to extract a section of the config to the Config struct as opposed to parsing into flags:
+	// 1. Set the section name in configKeysToExtract so the flag parser will know to ignore it
+	// 2. Define the section in the Config struct using `yaml` tags
+	configKeysToExtract = []string{"migration"}
+)
+
+type Config struct {
+	CacheBlock *CacheBlock `yaml:"cache"`
+}
+
+type CacheBlock struct {
+	MigrationConfig *MigrationConfig `yaml:"migration"`
+}
 
 func init() {
 	// As this flag determines the YAML file we read the config from, it can't
 	// meaningfully be specified in the YAML config file.
 	flagyaml.IgnoreFlagForYAML(pathFlagName)
+
+	for _, key := range configKeysToExtract {
+		flagyaml.IgnoreKeyForYAML(key)
+	}
 }
 
 func Path() string {
 	return *configPath
+}
+
+// ParseConfig parses a config file
+// There are two ways to extract data from the config file:
+// 1. By default, this function populates flags with the config data
+// 2. For fields defined in the Config struct, it also returns a parsed Config object
+func ParseConfig(configPath string) (*Config, error) {
+	log.Infof("Reading buildbuddy config from '%s'", configPath)
+	fileBytes, err := file.ReadFile(configPath)
+	if err != nil {
+		// If the file does not exist then skip it.
+		if status.IsNotFoundError(err) {
+			log.Warningf("No config file found at %s.", configPath)
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	if err := flagyaml.PopulateFlagsFromData(fileBytes); err != nil {
+		return nil, errors.WithMessagef(err, "error populating flags from config file %s", configPath)
+	}
+	flagyaml.RereadFlagsOnDisconnect(configPath)
+
+	cfg := &Config{}
+	if err = yaml.Unmarshal(fileBytes, cfg); err != nil {
+		return nil, errors.WithMessagef(err, "error unmarshaling config file %s to config struct", configPath)
+	}
+	return cfg, nil
 }

--- a/server/libmain/BUILD
+++ b/server/libmain/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//server/build_event_protocol/build_event_server",
         "//server/build_event_protocol/webhooks",
         "//server/buildbuddy_server",
+        "//server/config",
         "//server/endpoint_urls/build_buddy_url",
         "//server/environment",
         "//server/http/filters",

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -23,6 +23,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_server"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/webhooks"
 	"github.com/buildbuddy-io/buildbuddy/server/buildbuddy_server"
+	"github.com/buildbuddy-io/buildbuddy/server/config"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/http/protolet"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -139,7 +140,7 @@ func configureFilesystemsOrDie(realEnv *real_environment.RealEnv) {
 // the environments used by the open-core version and the enterprise version are
 // not substantially different enough yet to warrant the extra complexity of
 // always updating both main files.
-func GetConfiguredEnvironmentOrDie(healthChecker *healthcheck.HealthChecker) *real_environment.RealEnv {
+func GetConfiguredEnvironmentOrDie(healthChecker *healthcheck.HealthChecker, cfg *config.Config) *real_environment.RealEnv {
 	if err := log.Configure(); err != nil {
 		fmt.Printf("Error configuring logging: %s", err)
 		os.Exit(1)

--- a/server/util/file/BUILD
+++ b/server/util/file/BUILD
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "file",
+    srcs = ["file.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/file",
+    visibility = ["//visibility:public"],
+    deps = ["//server/util/status"],
+)

--- a/server/util/file/file.go
+++ b/server/util/file/file.go
@@ -1,0 +1,21 @@
+package file
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+)
+
+func ReadFile(configFile string) ([]byte, error) {
+	_, err := os.Stat(configFile)
+	if os.IsNotExist(err) {
+		return nil, status.NotFoundErrorf("no file found at %s", configFile)
+	}
+
+	fileBytes, err := os.ReadFile(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("error reading file: %s", err)
+	}
+	return fileBytes, nil
+}

--- a/server/util/flagutil/yaml/BUILD
+++ b/server/util/flagutil/yaml/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/util/alert",
+        "//server/util/file",
         "//server/util/flagutil/common",
         "//server/util/log",
         "//server/util/status",


### PR DESCRIPTION
For cache migrations, I thought it would be cleaner if:
1. We nested all migration cache config under the migration block.

i.e. 
Normally if you had a pebble cache, the config would look like:
cache
++ pebble

With a migration, it would look like:
cache
++migration
++++src
++++++pebble
++++dest
++++++pebble

Because we will now support migrating from two of the same cache type, nesting under the migration block lets us add another layer of `src` and `dest` keys to be more explicit about the direction of the migration. 

2. We parsed the cache config yaml as an object, as opposed to flags

Now that we have a new migration section of the config, it's kind of a pain to create a complete new set of flags for every cache type that's eligible for migration. 

i.e. 
Before, if we have the option rootDir for pebble cache, we'd have the flag cache.pebble.rootDir

Now we would need
- cache.pebble.RootDir for pebble caches not in a migration
- cache.migration.src.pebble.RootDir for source pebble caches in a migration
- cache.migration.dest.pebble.RootDir for dest pebble caches in a migration
- ... etc. for all cache options

It feels more readable and less complex to me to parse this new migration config as an object

Here's an example of how we would then use this new config object to initialize a migration_cache: https://github.com/buildbuddy-io/buildbuddy/pull/2486/files#diff-3c25189bbd67311458979d8b7dcacba95332e9afd3754e23966df0388287be9cL23
