### PR TITLE
Fetch file from peer if key is missing on write.

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -348,24 +348,22 @@ func (sm *Replica) fileWrite(wb *pebble.Batch, req *rfpb.FileWriteRequest) (*rfp
 
 	found := iter.SeekGE(fileMetadataKey)
 	if !found || bytes.Compare(fileMetadataKey, iter.Key()) != 0 {
-		return nil, status.NotFoundErrorf("file data for %v was not found in replica", req.GetFileRecord())
-	}
-
-	fileMetadata := &rfpb.FileMetadata{}
-	if err := proto.Unmarshal(iter.Value(), fileMetadata); err != nil {
-		return nil, err
-	}
-
-	// Check that we have the actual file, if not, try to read it from a peer.
-	ctx := context.TODO()
-	if !sm.fileStorer.FileExists(ctx, sm.fileDir, fileMetadata.GetStorageMetadata()) {
-		if err := sm.fetchFileToLocalStorage(ctx, fileMetadata); err != nil {
+		ctx := context.TODO()
+		md, err := sm.fetchFileToLocalStorage(ctx, req.GetFileRecord())
+		if err != nil {
 			return nil, err
-		} else {
-			d := req.GetFileRecord().GetDigest()
-			sm.log.Debugf("fileWrite: fetched file %q/%d to local storage", d.GetHash(), d.GetSizeBytes())
+		}
+		d := req.GetFileRecord().GetDigest()
+		sm.log.Debugf("fileWrite: fetched file %q/%d to local storage", d.GetHash(), d.GetSizeBytes())
+		protoBytes, err := proto.Marshal(md)
+		if err != nil {
+			return nil, err
+		}
+		if err := sm.rangeCheckedSet(wb, fileMetadataKey, protoBytes); err != nil {
+			return nil, err
 		}
 	}
+
 	return &rfpb.FileWriteResponse{}, nil
 }
 
@@ -1377,32 +1375,28 @@ func (sm *Replica) SaveSnapshotToWriter(w io.Writer, snap *pebble.Snapshot) erro
 	return nil
 }
 
-func (sm *Replica) fetchFileToLocalStorage(ctx context.Context, fileMetadata *rfpb.FileMetadata) error {
+func (sm *Replica) fetchFileToLocalStorage(ctx context.Context, fileRecord *rfpb.FileRecord) (*rfpb.StorageMetadata, error) {
 	rd := &rfpb.ReplicaDescriptor{
 		ClusterId: sm.clusterID,
 		NodeId:    sm.nodeID,
 	}
-	writeCloserMetadata, err := sm.fileStorer.NewWriter(ctx, sm.fileDir, fileMetadata.GetFileRecord())
+	writeCloserMetadata, err := sm.fileStorer.NewWriter(ctx, sm.fileDir, fileRecord)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	readCloser, err := sm.store.ReadFileFromPeer(ctx, rd, fileMetadata.GetFileRecord())
+	readCloser, err := sm.store.ReadFileFromPeer(ctx, rd, fileRecord)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer readCloser.Close()
 	n, err := io.Copy(writeCloserMetadata, readCloser)
-	if n != fileMetadata.GetSizeBytes() {
-		return status.FailedPreconditionErrorf("read %d bytes but expected %d", n, fileMetadata.GetSizeBytes())
+	if n != fileRecord.GetDigest().GetSizeBytes() {
+		return nil, status.FailedPreconditionErrorf("read %d bytes but expected %d", n, fileRecord.GetDigest().GetSizeBytes())
 	}
 	if err := writeCloserMetadata.Close(); err != nil {
-		return err
+		return nil, err
 	}
-	if !proto.Equal(writeCloserMetadata.Metadata(), fileMetadata.GetStorageMetadata()) {
-		log.Errorf("Stored metadata differs after fetching file locally. Before %+v, after: %+v", fileMetadata.GetStorageMetadata(), writeCloserMetadata.Metadata())
-		return status.FailedPreconditionError("stored metadata changed when fetching file")
-	}
-	return nil
+	return writeCloserMetadata.Metadata(), nil
 }
 
 func (sm *Replica) ApplySnapshotFromReader(r io.Reader, db ReplicaWriter) error {
@@ -1444,7 +1438,7 @@ func (sm *Replica) ApplySnapshotFromReader(r io.Reader, db ReplicaWriter) error 
 			if err := proto.Unmarshal(kv.GetValue(), fileMetadata); err != nil {
 				return err
 			}
-			if err := sm.fetchFileToLocalStorage(ctx, fileMetadata); err != nil {
+			if _, err := sm.fetchFileToLocalStorage(ctx, fileMetadata.GetFileRecord()); err != nil {
 				return err
 			}
 		}

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -35,7 +35,7 @@ func (fs *fakeStore) ReadFileFromPeer(ctx context.Context, except *rfpb.ReplicaD
 	if fs.fileReadFn != nil {
 		return fs.fileReadFn(fileRecord)
 	}
-	return nil, nil
+	return nil, status.NotFoundErrorf("file not found")
 }
 func (fs *fakeStore) GetReplica(rangeID uint64) (*replica.Replica, error) {
 	return nil, nil


### PR DESCRIPTION
On a new node, the keys for existing files won't be present because the
file writes are not part of the raft log.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
