### PR TITLE
Fix a potential panic

### DIFF
--- a/enterprise/server/raft/rangelease/rangelease.go
+++ b/enterprise/server/raft/rangelease/rangelease.go
@@ -224,10 +224,12 @@ func (l *Lease) renewLease() error {
 		// This means another lease was active -- we should save it, so that
 		// we can correctly set the expected value with our next CAS request,
 		// and witness its epoch so that our next set request has a higher one.
-		err := proto.Unmarshal(kv.GetValue(), l.leaseRecord)
+		activeLease := &rfpb.RangeLeaseRecord{}
+		err := proto.Unmarshal(kv.GetValue(), activeLease)
 		if err != nil {
 			return err
 		}
+		l.leaseRecord = activeLease
 	} else {
 		return err
 	}


### PR DESCRIPTION
I saw this happen once during some testing:

```
12:49:48 app3 | panic: runtime error: invalid memory address or nil pointer dereference
12:49:48 app3 | [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xf92fb8]
12:49:48 app3 | goroutine 197358 [running]:
12:49:48 app3 | github.com/buildbuddy-io/buildbuddy/proto/raft.(*RangeLeaseRecord).Reset(0x1f912a0?)
12:49:48 app3 | 	bazel-out/k8-fastbuild/bin/proto/raft_go_proto_/github.com/buildbuddy-io/buildbuddy/proto/raft/raft.pb.go:2209 +0x18
12:49:48 app3 | google.golang.org/protobuf/proto.Reset({0x7145ac0, 0x0})
12:49:48 app3 | 	external/org_golang_google_protobuf/proto/reset.go:18 +0x3e
12:49:48 app3 | google.golang.org/protobuf/proto.UnmarshalOptions.unmarshal({{}, 0x0, 0x0, 0x0, {0x7152788, 0xc0000fac60}}, {0xc0003a5220, 0x1d, 0x20}, {0x7169978, ...})
12:49:48 app3 | 	external/org_golang_google_protobuf/proto/decode.go:77 +0xb9
12:49:48 app3 | google.golang.org/protobuf/proto.Unmarshal({0xc0003a5220, 0x1d, 0x20}, {0x7145ac0?, 0x0?})
12:49:48 app3 | 	external/org_golang_google_protobuf/proto/decode.go:50 +0x5d
12:49:48 app3 | github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rangelease.(*Lease).renewLease(0xc00046ea10)
12:49:48 app3 | 	enterprise/server/raft/rangelease/rangelease.go:227 +0x1fc
12:49:48 app3 | github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rangelease.(*Lease).ensureValidLease(0xc00046ea10, 0x0)
12:49:48 app3 | 	enterprise/server/raft/rangelease/rangelease.go:261 +0x13f
12:49:48 app3 | github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rangelease.(*Lease).Lease(...)
12:49:48 app3 | 	enterprise/server/raft/rangelease/rangelease.go:74
12:49:48 app3 | github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/store.(*Store).maybeAcquireRangeLease(0xc000065700, 0xc00331b600)
12:49:48 app3 | 	enterprise/server/raft/store/store.go:220 +0x371
12:49:48 app3 | created by github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/store.(*Store).AddRange
12:49:48 app3 | 	enterprise/server/raft/store/store.go:305 +0x52a
```