### PR TITLE
Fix a potential panic in Close

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1562,6 +1562,10 @@ func (sm *Replica) RecoverFromSnapshot(r io.Reader, quit <-chan struct{}) error 
 // IOnDiskStateMachine instance has been closed, the Close method is not
 // allowed to update the state of IOnDiskStateMachine visible to the outside.
 func (sm *Replica) Close() error {
+	if sm.leaser == nil {
+		return nil
+	}
+
 	sm.leaser.Close()
 
 	sm.rangeMu.Lock()


### PR DESCRIPTION
Try to fix a weird panic I saw during testing:

```
15:21:27 app4 | panic: runtime error: invalid memory address or nil pointer dereference
15:21:27 app4 | [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x196d185]
15:21:27 app4 | goroutine 1004 [running]:
15:21:27 app4 | github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/replica.(*Replica).Close(0xc0001519e0)
15:21:27 app4 | 	enterprise/server/raft/replica/replica.go:1578 +0x25
15:21:27 app4 | github.com/lni/dragonboat/v3/internal/rsm.(*OnDiskStateMachine).Close(0x0?)
15:21:27 app4 | 	external/com_github_lni_dragonboat_v3/internal/rsm/adapter.go:343 +0x25
15:21:27 app4 | github.com/lni/dragonboat/v3/internal/rsm.(*NativeSM).Close(0xc005a7ed00)
15:21:27 app4 | 	external/com_github_lni_dragonboat_v3/internal/rsm/managed.go:151 +0x29
15:21:27 app4 | github.com/lni/dragonboat/v3/internal/rsm.(*StateMachine).Close(...)
15:21:27 app4 | 	external/com_github_lni_dragonboat_v3/internal/rsm/statemachine.go:235
15:21:27 app4 | github.com/lni/dragonboat/v3.(*node).destroy(...)
15:21:27 app4 | 	external/com_github_lni_dragonboat_v3/node.go:531
15:21:27 app4 | github.com/lni/dragonboat/v3.(*closeWorker).handle(0xc001117718?, {0xc001117700?})
15:21:27 app4 | 	external/com_github_lni_dragonboat_v3/engine.go:786 +0x51
15:21:27 app4 | github.com/lni/dragonboat/v3.(*closeWorker).workerMain(0xc00083d720)
15:21:27 app4 | 	external/com_github_lni_dragonboat_v3/engine.go:770 +0xaa
15:21:27 app4 | github.com/lni/dragonboat/v3.newCloseWorker.func1()
15:21:27 app4 | 	external/com_github_lni_dragonboat_v3/engine.go:759 +0x1d
15:21:27 app4 | github.com/lni/goutils/syncutil.(*Stopper).runWorker.func1()
15:21:27 app4 | 	external/com_github_lni_goutils/syncutil/stopper.go:79 +0xc5
15:21:27 app4 | created by github.com/lni/goutils/syncutil.(*Stopper).runWorker
15:21:27 app4 | 	external/com_github_lni_goutils/syncutil/stopper.go:74 +0xea
15:21:27 app4 | Terminating app4
```