### PR TITLE
Add compression support to GetFile API

### DIFF
--- a/proto/api/v1/file.proto
+++ b/proto/api/v1/file.proto
@@ -6,12 +6,25 @@ package api.v1;
 message GetFileRequest {
   // This corresponds to the uri field in the File message.
   string uri = 1;
+
+  // Compression formats supported by the client. The server treats this list as
+  // though IDENTITY is implicitly appended, so it does not need to be
+  // explicitly specified by clients here. The server may return the response
+  // payload in one of these compression formats, if supported. Clients should
+  // list this in their preferred order, and the server will use the first
+  // value that is supported.
+  repeated Compressor.Value acceptable_compressors = 2;
 }
 
 // Response object for GetFile
 message GetFileResponse {
   // The file data.
   bytes data = 1;
+
+  // The compression format of `data`. This will be one of the
+  // `acceptable_compressors` specified in the request, or the IDENTITY
+  // compressor for uncompressed payloads.
+  Compressor.Value compressor = 2;
 }
 
 // A file associated with a BuildBuddy build.
@@ -48,3 +61,17 @@ message DeleteFileRequest {
 
 // Response object for DeleteFile
 message DeleteFileResponse {}
+
+// Compression formats which may be supported.
+//
+// Note: this matches the Compressor proto from Bazel's remote APIs
+// (proto/remote_execution.proto).
+message Compressor {
+  enum Value {
+    // No compression.
+    IDENTITY = 0;
+
+    // Zstandard compression.
+    ZSTD = 1;
+  }
+}


### PR DESCRIPTION
The proto is copied from the remote execution proto, so that we can easily cast between the two types of protos. The field names are also the same, just for consistency (`acceptable_compressors` / `compressor`)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
