### PR TITLE
pebble lease fix

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -817,29 +817,9 @@ func (p *PebbleCache) blobDir() string {
 	return p.partitionBlobDir(p.isolation.GetPartitionId())
 }
 
-// hasFileMetadata returns a bool indicating if the provided iterator has the
-// key specified by fileMetadataKey.
-func hasFileMetadata(iter *pebble.Iterator, fileMetadataKey []byte) bool {
-	if iter.SeekGE(fileMetadataKey) && bytes.Compare(iter.Key(), fileMetadataKey) == 0 {
-		return true
-	}
-	return false
-}
-
-func lookupAndSetFileMetadata(iter *pebble.Iterator, fileMetadataKey []byte, fileMetadata *rfpb.FileMetadata) error {
-	found := iter.SeekGE(fileMetadataKey)
-	if !found || bytes.Compare(fileMetadataKey, iter.Key()) != 0 {
-		return status.NotFoundErrorf("record %q not found", fileMetadataKey)
-	}
-	if err := proto.Unmarshal(iter.Value(), fileMetadata); err != nil {
-		return status.InternalErrorf("error reading record %q metadata", fileMetadataKey)
-	}
-	return nil
-}
-
 func lookupFileMetadata(iter *pebble.Iterator, fileMetadataKey []byte) (*rfpb.FileMetadata, error) {
 	fileMetadata := &rfpb.FileMetadata{}
-	if err := lookupAndSetFileMetadata(iter, fileMetadataKey, fileMetadata); err != nil {
+	if err := pebbleutil.LookupProto(iter, fileMetadataKey, fileMetadata); err != nil {
 		return nil, err
 	}
 	return fileMetadata, nil
@@ -847,14 +827,12 @@ func lookupFileMetadata(iter *pebble.Iterator, fileMetadataKey []byte) (*rfpb.Fi
 
 func readFileMetadata(reader pebble.Reader, fileMetadataKey []byte) (*rfpb.FileMetadata, error) {
 	fileMetadata := &rfpb.FileMetadata{}
-	buf, closer, err := reader.Get(fileMetadataKey)
-	if err == pebble.ErrNotFound {
-		return nil, status.NotFoundErrorf("record %q not found", fileMetadataKey)
-	}
-	err = proto.Unmarshal(buf, fileMetadata)
-	closer.Close()
+	buf, err := pebbleutil.GetCopy(reader, fileMetadataKey)
 	if err != nil {
-		return nil, status.InternalErrorf("error reading record %q metadata", fileMetadataKey)
+		return nil, err
+	}
+	if err := proto.Unmarshal(buf, fileMetadata); err != nil {
+		return nil, err
 	}
 	return fileMetadata, nil
 }
@@ -889,7 +867,7 @@ func (p *PebbleCache) Contains(ctx context.Context, d *repb.Digest) (bool, error
 	if err != nil {
 		return false, err
 	}
-	found := hasFileMetadata(iter, fileMetadataKey)
+	found := pebbleutil.IterHasKey(iter, fileMetadataKey)
 	return found, nil
 }
 
@@ -946,7 +924,7 @@ func (p *PebbleCache) FindMissing(ctx context.Context, digests []*repb.Digest) (
 		if err != nil {
 			return nil, err
 		}
-		if !hasFileMetadata(iter, fileMetadataKey) {
+		if !pebbleutil.IterHasKey(iter, fileMetadataKey) {
 			missing = append(missing, d)
 		}
 	}
@@ -989,7 +967,7 @@ func (p *PebbleCache) GetMulti(ctx context.Context, digests []*repb.Digest) (map
 			return nil, err
 		}
 		fileMetadata := &rfpb.FileMetadata{}
-		if err := lookupAndSetFileMetadata(iter, fileMetadataKey, fileMetadata); err != nil {
+		if err := pebbleutil.LookupProto(iter, fileMetadataKey, fileMetadata); err != nil {
 			continue
 		}
 		rc, err := p.fileStorer.NewReader(ctx, blobDir, fileMetadata.GetStorageMetadata(), 0, 0)
@@ -1137,7 +1115,11 @@ func (p *PebbleCache) Reader(ctx context.Context, d *repb.Digest, offset, limit 
 	if err != nil {
 		return nil, err
 	}
-	defer db.Close()
+
+	// The deferred function will close the db in the case where an error
+	// is encountered before returning the reader below.
+	closeFn := db.SingletonCloseFunc()
+	defer closeFn()
 
 	iter := db.NewIter(nil /*default iterOptions*/)
 	defer iter.Close()
@@ -1163,24 +1145,33 @@ func (p *PebbleCache) Reader(ctx context.Context, d *repb.Digest, offset, limit 
 	} else if status.IsNotFoundError(err) || os.IsNotExist(err) {
 		p.handleMetadataMismatch(err, fileMetadataKey, fileMetadata)
 	}
-	return rc, err
+
+	if err != nil {
+		return nil, err
+	}
+
+	// This function will be called when the reader is closed. Because only
+	// one close function is active at a time, the previously deferred
+	// function will be a no-op.
+	readerLeaseClose := db.SingletonCloseFunc()
+	return pebbleutil.ReadCloserWithFunc(rc, readerLeaseClose), nil
 }
 
 type writeCloser struct {
-	filestore.WriteCloserMetadata
+	interfaces.MetadataWriteCloser
 	closeFn      func(n int64) error
 	bytesWritten int64
 }
 
 func (dc *writeCloser) Close() error {
-	if err := dc.WriteCloserMetadata.Close(); err != nil {
+	if err := dc.MetadataWriteCloser.Close(); err != nil {
 		return err
 	}
 	return dc.closeFn(dc.bytesWritten)
 }
 
 func (dc *writeCloser) Write(p []byte) (int, error) {
-	n, err := dc.WriteCloserMetadata.Write(p)
+	n, err := dc.MetadataWriteCloser.Write(p)
 	if err != nil {
 		return 0, err
 	}
@@ -1206,13 +1197,13 @@ func (p *PebbleCache) Writer(ctx context.Context, d *repb.Digest) (io.WriteClose
 
 	iter := db.NewIter(nil /*default iterOptions*/)
 	defer iter.Close()
-	alreadyExists := hasFileMetadata(iter, fileMetadataKey)
+	alreadyExists := pebbleutil.IterHasKey(iter, fileMetadataKey)
 	if alreadyExists {
 		metrics.DiskCacheDuplicateWrites.Inc()
 		metrics.DiskCacheDuplicateWritesBytes.Add(float64(d.GetSizeBytes()))
 	}
 
-	var wcm filestore.WriteCloserMetadata
+	var wcm interfaces.MetadataWriteCloser
 	if d.GetSizeBytes() < p.maxInlineFileSizeBytes {
 		wcm = p.fileStorer.InlineWriter(ctx, d.GetSizeBytes())
 	} else {
@@ -1222,7 +1213,9 @@ func (p *PebbleCache) Writer(ctx context.Context, d *repb.Digest) (io.WriteClose
 		}
 		wcm = fw
 	}
-	dc := &writeCloser{WriteCloserMetadata: wcm, closeFn: func(bytesWritten int64) error {
+	writerLeaseClose := db.SingletonCloseFunc()
+	dc := &writeCloser{MetadataWriteCloser: wcm, closeFn: func(bytesWritten int64) error {
+		defer writerLeaseClose()
 		now := time.Now().UnixMicro()
 		md := &rfpb.FileMetadata{
 			FileRecord:      fileRecord,
@@ -1243,6 +1236,7 @@ func (p *PebbleCache) Writer(ctx context.Context, d *repb.Digest) (io.WriteClose
 		return err
 	}}
 	return dc, nil
+
 }
 
 func (p *PebbleCache) DoneScanning() bool {

--- a/enterprise/server/raft/filestore/BUILD
+++ b/enterprise/server/raft/filestore/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:raft_go_proto",
+        "//server/interfaces",
         "//server/util/disk",
         "//server/util/status",
     ],

--- a/enterprise/server/raft/replica/BUILD
+++ b/enterprise/server/raft/replica/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//enterprise/server/raft/sender",
         "//enterprise/server/util/pebbleutil",
         "//proto:raft_go_proto",
+        "//server/interfaces",
         "//server/util/disk",
         "//server/util/log",
         "//server/util/rangemap",

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//proto:raft_go_proto",
         "//proto:raft_service_go_proto",
         "//server/gossip",
+        "//server/interfaces",
         "//server/util/alert",
         "//server/util/grpc_server",
         "//server/util/log",

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -22,6 +22,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/replica"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
 	"github.com/buildbuddy-io/buildbuddy/server/gossip"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -584,7 +585,7 @@ func (s *Store) Read(req *rfpb.ReadRequest, stream rfspb.Api_ReadServer) error {
 
 func (s *Store) Write(stream rfspb.Api_WriteServer) error {
 	var bytesWritten int64
-	var writeCloser filestore.CommittedWriter
+	var writeCloser interfaces.CommittedMetadataWriteCloser
 	for {
 		req, err := stream.Recv()
 		if err == io.EOF {

--- a/enterprise/server/util/pebbleutil/BUILD
+++ b/enterprise/server/util/pebbleutil/BUILD
@@ -6,9 +6,11 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/pebbleutil",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/interfaces",
         "//server/util/log",
         "//server/util/status",
         "@com_github_cockroachdb_pebble//:pebble",
+        "@org_golang_google_protobuf//proto",
     ],
 )
 

--- a/server/interfaces/BUILD
+++ b/server/interfaces/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//proto:invocation_go_proto",
         "//proto:publish_build_event_go_proto",
         "//proto:quota_go_proto",
+        "//proto:raft_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:runner_go_proto",
         "//proto:scheduler_go_proto",

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -24,6 +24,7 @@ import (
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 	qpb "github.com/buildbuddy-io/buildbuddy/proto/quota"
+	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
@@ -855,4 +856,32 @@ type QuotaManager interface {
 	RemoveNamespace(ctx context.Context, req *qpb.RemoveNamespaceRequest) (*qpb.RemoveNamespaceResponse, error)
 	ApplyBucket(ctx context.Context, req *qpb.ApplyBucketRequest) (*qpb.ApplyBucketResponse, error)
 	ModifyNamespace(ctx context.Context, req *qpb.ModifyNamespaceRequest) (*qpb.ModifyNamespaceResponse, error)
+}
+
+// A Metadater implements the Metadata() method and returns a StorageMetadata
+// proto representing the stored data. The result is only valid if Close has
+// already been called. This is only used with MetadataWriteCloser.
+type Metadater interface {
+	Metadata() *rfpb.StorageMetadata
+}
+
+// A Committer implements the Commit method, to finalize a write.
+// If this returns successfully, the caller is assured that the data has
+// been successfully written to disk and any metadata stores.
+// This is only used with CommittedMetadataWriteCloser.
+type Committer interface {
+	Commit() error
+}
+
+type MetadataWriteCloser interface {
+	io.Writer
+	io.Closer
+	Metadater
+}
+
+type CommittedMetadataWriteCloser interface {
+	io.Writer
+	io.Closer
+	Metadater
+	Committer
 }


### PR DESCRIPTION
- Move important writer ifaces to interfaces and fix names
- Refactor to account for interface move
- Move lots of shared pebble utils to pebbleutil
- Use new interfaces and utils in replica and pebble_cache
