### PR TITLE
Remove usages of deprecated ioutil

### DIFF
--- a/cli/autoconfig/autoconfig.go
+++ b/cli/autoconfig/autoconfig.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -148,7 +147,7 @@ func Configure(ctx context.Context, bazelFlags *commandline.BazelFlags) (*BazelO
 }
 
 func addToolchainsToWorkspaceIfNotPresent(workspaceFilePath string) {
-	workspaceBytes, err := ioutil.ReadFile(workspaceFilePath)
+	workspaceBytes, err := os.ReadFile(workspaceFilePath)
 	if err != nil {
 		log.Println(err)
 		return

--- a/cli/cache_proxy/cache_proxy.go
+++ b/cli/cache_proxy/cache_proxy.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -196,7 +195,7 @@ func (p *CacheProxy) Read(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServ
 
 	var localFile *os.File
 	if *readThrough {
-		tmpFile, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%s%s-", instanceName, d.GetHash()))
+		tmpFile, err := os.CreateTemp("", fmt.Sprintf("%s%s-", instanceName, d.GetHash()))
 		if err == nil {
 			localFile = tmpFile
 			defer os.Remove(tmpFile.Name())
@@ -307,7 +306,7 @@ func (qw *queueWorker) handleWriteRequest(qreq queueReq) error {
 	}
 	d := resourceName.GetDigest()
 	instanceName := resourceName.GetInstanceName()
-	tmpFile, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%s%s-", instanceName, d.GetHash()))
+	tmpFile, err := os.CreateTemp("", fmt.Sprintf("%s%s-", instanceName, d.GetHash()))
 	if err != nil {
 		return err
 	}

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"hash/crc32"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -53,15 +52,15 @@ func getSidecarBinaryName() string {
 }
 
 func getLatestInstalledSidecarVersion(sidecarDir, sidecarName string) string {
-	files, err := ioutil.ReadDir(sidecarDir)
+	entries, err := os.ReadDir(sidecarDir)
 	if err != nil {
 		return ""
 	}
 	latestVersion := ""
-	for _, f := range files {
-		version := f.Name()
+	for _, entry := range entries {
+		version := entry.Name()
 		binPath := filepath.Join(sidecarDir, version, sidecarName)
-		if _, err := os.Stat(binPath); !os.IsNotExist(err) && f.IsDir() {
+		if _, err := os.Stat(binPath); !os.IsNotExist(err) && entry.IsDir() {
 			if semver.Compare(version, latestVersion) > 0 {
 				latestVersion = version
 			}
@@ -72,7 +71,7 @@ func getLatestInstalledSidecarVersion(sidecarDir, sidecarName string) string {
 
 func getlastUpdateCheck(bbHomeDir string) (time.Time, error) {
 	lastCheckedForUpdateFilePath := filepath.Join(bbHomeDir, lastCheckedForUpdateFileName)
-	content, err := ioutil.ReadFile(lastCheckedForUpdateFilePath)
+	content, err := os.ReadFile(lastCheckedForUpdateFilePath)
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path/filepath"
 	"sort"
 	"sync"
@@ -752,7 +751,7 @@ func (c *Cache) Get(ctx context.Context, d *repb.Digest) ([]byte, error) {
 		return nil, err
 	}
 	defer r.Close()
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 func (c *Cache) GetMulti(ctx context.Context, digests []*repb.Digest) (map[*repb.Digest][]byte, error) {

--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"sync"
@@ -184,7 +183,7 @@ func (g *GCSCache) Get(ctx context.Context, d *repb.Digest) ([]byte, error) {
 	}
 	timer := cache_metrics.NewCacheTimer(cacheLabels)
 	_, spn := tracing.StartSpan(ctx)
-	b, err := ioutil.ReadAll(reader)
+	b, err := io.ReadAll(reader)
 	spn.End()
 	timer.ObserveGet(len(b), err)
 	// Note, if we decide to retry reads in the future, be sure to

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -579,7 +578,7 @@ func (r *dockerCommandContainer) Stats(ctx context.Context) (*repb.UsageStats, e
 			log.Printf("error closing docker stats response body: %s", err)
 		}
 	}()
-	body, err := ioutil.ReadAll(stats.Body)
+	body, err := io.ReadAll(stats.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/remote_execution/containers/docker/docker_test.go
+++ b/enterprise/server/remote_execution/containers/docker/docker_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -26,7 +25,7 @@ import (
 
 func writeFile(t *testing.T, parentDir, fileName, content string) {
 	path := filepath.Join(parentDir, fileName)
-	if err := ioutil.WriteFile(path, []byte(content), 0660); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0660); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/enterprise/server/remote_execution/containers/docker/docker_test.go
+++ b/enterprise/server/remote_execution/containers/docker/docker_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -115,7 +114,7 @@ func TestFirecrackerRunSimple(t *testing.T) {
 	workDir := testfs.MakeDirAll(t, rootDir, "work")
 
 	path := filepath.Join(workDir, "world.txt")
-	if err := ioutil.WriteFile(path, []byte("world"), 0660); err != nil {
+	if err := os.WriteFile(path, []byte("world"), 0660); err != nil {
 		t.Fatal(err)
 	}
 	cmd := &repb.Command{
@@ -160,7 +159,7 @@ func TestFirecrackerLifecycle(t *testing.T) {
 	workDir := testfs.MakeDirAll(t, rootDir, "work")
 
 	path := filepath.Join(workDir, "world.txt")
-	if err := ioutil.WriteFile(path, []byte("world"), 0660); err != nil {
+	if err := os.WriteFile(path, []byte("world"), 0660); err != nil {
 		t.Fatal(err)
 	}
 	cmd := &repb.Command{
@@ -224,7 +223,7 @@ func TestFirecrackerSnapshotAndResume(t *testing.T) {
 	workDir := testfs.MakeDirAll(t, rootDir, "work")
 
 	path := filepath.Join(workDir, "world.txt")
-	if err := ioutil.WriteFile(path, []byte("world"), 0660); err != nil {
+	if err := os.WriteFile(path, []byte("world"), 0660); err != nil {
 		t.Fatal(err)
 	}
 	opts := firecracker.ContainerOpts{
@@ -301,7 +300,7 @@ func TestFirecrackerFileMapping(t *testing.T) {
 		}
 		d, buf := testdigest.NewRandomDigestBuf(t, fileSizeBytes)
 		fullPath := filepath.Join(parentDir, d.GetHash()+".txt")
-		if err := ioutil.WriteFile(fullPath, buf, 0660); err != nil {
+		if err := os.WriteFile(fullPath, buf, 0660); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -355,7 +354,7 @@ func TestFirecrackerRunStartFromSnapshot(t *testing.T) {
 	workDir := testfs.MakeDirAll(t, rootDir, "work1")
 
 	path := filepath.Join(workDir, "world.txt")
-	if err := ioutil.WriteFile(path, []byte("world"), 0660); err != nil {
+	if err := os.WriteFile(path, []byte("world"), 0660); err != nil {
 		t.Fatal(err)
 	}
 	cmd := &repb.Command{
@@ -402,7 +401,7 @@ func TestFirecrackerRunStartFromSnapshot(t *testing.T) {
 	opts.ActionWorkingDirectory = workDir
 
 	path = filepath.Join(workDir, "mars.txt")
-	if err := ioutil.WriteFile(path, []byte("mars"), 0660); err != nil {
+	if err := os.WriteFile(path, []byte("mars"), 0660); err != nil {
 		t.Fatal(err)
 	}
 	cmd = &repb.Command{
@@ -445,7 +444,7 @@ func TestFirecrackerRunWithNetwork(t *testing.T) {
 	workDir := testfs.MakeDirAll(t, rootDir, "work")
 
 	path := filepath.Join(workDir, "world.txt")
-	if err := ioutil.WriteFile(path, []byte("world"), 0660); err != nil {
+	if err := os.WriteFile(path, []byte("world"), 0660); err != nil {
 		t.Fatal(err)
 	}
 	// Make sure the container can at least send packets via the default route.
@@ -519,7 +518,7 @@ func TestFirecrackerRunWithDocker(t *testing.T) {
 	workDir := testfs.MakeDirAll(t, rootDir, "work")
 
 	path := filepath.Join(workDir, "world.txt")
-	if err := ioutil.WriteFile(path, []byte("world"), 0660); err != nil {
+	if err := os.WriteFile(path, []byte("world"), 0660); err != nil {
 		t.Fatal(err)
 	}
 	cmd := &repb.Command{

--- a/enterprise/server/remote_execution/containers/podman/podman_test.go
+++ b/enterprise/server/remote_execution/containers/podman/podman_test.go
@@ -3,7 +3,6 @@ package podman_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -26,7 +25,7 @@ import (
 
 func writeFile(t *testing.T, parentDir, fileName, content string) {
 	path := filepath.Join(parentDir, fileName)
-	if err := ioutil.WriteFile(path, []byte(content), 0660); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0660); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -301,11 +300,15 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 		if err != nil {
 			return nil, err
 		}
-		files, err := ioutil.ReadDir(fullPath)
+		entries, err := os.ReadDir(fullPath)
 		if err != nil {
 			return nil, err
 		}
-		for _, info := range files {
+		for _, entry := range entries {
+			info, err := entry.Info()
+			if err != nil {
+				return nil, err
+			}
 			fqfn := filepath.Join(fullPath, info.Name())
 			if info.Mode().IsDir() {
 				// Don't recurse on non-uploadable directories.

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -2,7 +2,6 @@ package filecache_test
 
 import (
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -28,7 +27,7 @@ func writeFile(t *testing.T, base string, path string, executable bool) {
 		t.Fatal(err)
 	}
 	log.Printf("Writing file %q", fullPath)
-	if err := ioutil.WriteFile(fullPath, []byte(path+suffix), mod); err != nil {
+	if err := os.WriteFile(fullPath, []byte(path+suffix), mod); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -84,7 +84,7 @@ func Test_Filecache(t *testing.T) {
 }
 
 func assertFileContents(t *testing.T, path, contents string) {
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/server/remote_execution/workspace/workspace_test.go
+++ b/enterprise/server/remote_execution/workspace/workspace_test.go
@@ -2,7 +2,6 @@ package workspace_test
 
 import (
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,7 +32,7 @@ func writeEmptyFiles(t *testing.T, ws *workspace.Workspace, paths []string) {
 		if err := os.MkdirAll(filepath.Dir(fullPath), 0777); err != nil {
 			t.Fatal(err)
 		}
-		if err := ioutil.WriteFile(fullPath, []byte{}, 0777); err != nil {
+		if err := os.WriteFile(fullPath, []byte{}, 0777); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/enterprise/server/webhooks/bitbucket/bitbucket.go
+++ b/enterprise/server/webhooks/bitbucket/bitbucket.go
@@ -3,7 +3,7 @@ package bitbucket
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -115,7 +115,7 @@ func (*bitbucketGitProvider) IsTrusted(ctx context.Context, accessToken, repoURL
 }
 
 func unmarshalBody(r *http.Request, payload interface{}) error {
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/webhooks/github/github.go
+++ b/enterprise/server/webhooks/github/github.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime"
 	"net/http"
 	"net/url"
@@ -237,13 +237,13 @@ func webhookJSONPayload(r *http.Request) ([]byte, error) {
 	}
 	switch contentType {
 	case "application/json":
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			return nil, status.InternalErrorf("failed to read request body: %s", err)
 		}
 		return body, nil
 	case "application/x-www-form-urlencoded":
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			return nil, status.InternalErrorf("failed to read request body: %s", err)
 		}

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"io"
-	"io/ioutil"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/webhook_data"
 	"gopkg.in/yaml.v2"
@@ -46,7 +45,7 @@ type PullRequestTrigger struct {
 }
 
 func NewConfig(r io.Reader) (*BuildBuddyConfig, error) {
-	byt, err := ioutil.ReadAll(r)
+	byt, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/server/backends/blobstore/blobstore.go
+++ b/server/backends/blobstore/blobstore.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -195,7 +195,7 @@ func decompress(in []byte, err error) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	rsp, err := ioutil.ReadAll(zr)
+	rsp, err := io.ReadAll(zr)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func compress(in []byte) ([]byte, error) {
 	if err := zr.Close(); err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(&buf)
+	return io.ReadAll(&buf)
 }
 
 func (d *DiskBlobStore) blobPath(blobName string) (string, error) {
@@ -334,7 +334,7 @@ func (g *GCSBlobStore) ReadBlob(ctx context.Context, blobName string) ([]byte, e
 	}
 	start := time.Now()
 	ctx, spn := tracing.StartSpan(ctx)
-	b, err := ioutil.ReadAll(reader)
+	b, err := io.ReadAll(reader)
 	spn.End()
 	recordReadMetrics(gcsLabel, start, b, err)
 	return decompress(b, err)
@@ -666,7 +666,7 @@ func (z *AzureBlobStore) ReadBlob(ctx context.Context, blobName string) ([]byte,
 	readCloser := response.Body(azblob.RetryReaderOptions{})
 	defer readCloser.Close()
 	ctx, spn := tracing.StartSpan(ctx)
-	b, err := ioutil.ReadAll(readCloser)
+	b, err := io.ReadAll(readCloser)
 	spn.End()
 	if err != nil {
 		return nil, err

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -178,7 +178,7 @@ func (c *GithubClient) Link(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		redirectWithError(w, r, status.PermissionDeniedErrorf("Error reading GitHub response: %s", err.Error()))
 		return

--- a/server/http/filters/filters.go
+++ b/server/http/filters/filters.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"flag"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -59,7 +58,7 @@ func RedirectIfNotForwardedHTTPS(env environment.Env, next http.Handler) http.Ha
 // gzip, courtesy of https://gist.github.com/CJEnright/bc2d8b8dc0c1389a9feeddb110f822d7
 var gzPool = sync.Pool{
 	New: func() interface{} {
-		w := gzip.NewWriter(ioutil.Discard)
+		w := gzip.NewWriter(io.Discard)
 		return w
 	},
 }

--- a/server/http/protolet/protolet.go
+++ b/server/http/protolet/protolet.go
@@ -3,7 +3,7 @@ package protolet
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 
@@ -44,7 +44,7 @@ func isRPCMethod(m reflect.Method) bool {
 }
 
 func ReadRequestToProto(r *http.Request, req proto.Message) error {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}

--- a/server/remote_asset/fetch_server/fetch_server.go
+++ b/server/remote_asset/fetch_server/fetch_server.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -135,7 +135,7 @@ func (p *FetchServer) FetchBlob(ctx context.Context, req *rapb.FetchBlobRequest)
 		if err != nil {
 			return nil, status.AbortedErrorf("Error fetching URI  %q: %s", uri, err.Error())
 		}
-		data, err := ioutil.ReadAll(rsp.Body)
+		data, err := io.ReadAll(rsp.Body)
 		if err != nil {
 			log.Warningf("Error reading object bytes: %s", err.Error())
 			continue

--- a/server/ssl/ssl.go
+++ b/server/ssl/ssl.go
@@ -10,9 +10,9 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"flag"
-	"io/ioutil"
 	"math/big"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
@@ -318,12 +318,12 @@ func (s *SSLService) GenerateCerts(apiKey string) (string, string, error) {
 }
 
 func loadX509KeyPair(certFile, keyFile string) (*x509.Certificate, *rsa.PrivateKey, error) {
-	cf, err := ioutil.ReadFile(certFile)
+	cf, err := os.ReadFile(certFile)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	kf, err := ioutil.ReadFile(keyFile)
+	kf, err := os.ReadFile(keyFile)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/telemetry/telemetry_client.go
+++ b/server/telemetry/telemetry_client.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -146,7 +145,7 @@ func getAppVersion() string {
 		log.Debugf("Error reading getting version file path: %s", err)
 		return unknownFieldValue
 	}
-	versionBytes, err := ioutil.ReadFile(filepath.Join(rfp, versionFilename))
+	versionBytes, err := os.ReadFile(filepath.Join(rfp, versionFilename))
 	if err != nil {
 		log.Debugf("Error reading version file: %s", err)
 		return unknownFieldValue

--- a/server/testutil/testbazel/testbazel.go
+++ b/server/testutil/testbazel/testbazel.go
@@ -2,7 +2,6 @@ package testbazel
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -64,7 +63,7 @@ func MakeTempWorkspace(t *testing.T, contents map[string]string) string {
 		fullPath := filepath.Join(workspaceDir, path)
 		err := os.MkdirAll(filepath.Dir(fullPath), 0777)
 		require.NoError(t, err, "failed to create bazel workspace contents")
-		err = ioutil.WriteFile(fullPath, []byte(fileContents), 0777)
+		err = os.WriteFile(fullPath, []byte(fileContents), 0777)
 		require.NoError(t, err, "failed to create bazel workspace contents")
 	}
 	return workspaceDir

--- a/server/testutil/testserver/testserver.go
+++ b/server/testutil/testserver/testserver.go
@@ -2,7 +2,7 @@ package testserver
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -77,7 +77,7 @@ func Run(t *testing.T, opts *Opts) *Server {
 
 func isOK(resp *http.Response) (bool, error) {
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, err
 	}

--- a/server/util/compression/compression.go
+++ b/server/util/compression/compression.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/flate"
 	"io"
-	"io/ioutil"
 	"runtime"
 	"sync"
 
@@ -227,7 +226,7 @@ func DecompressFlate(data []byte) ([]byte, error) {
 	dataReader := bytes.NewReader(data)
 	rc := flate.NewReader(dataReader)
 
-	buf, err := ioutil.ReadAll(rc)
+	buf, err := io.ReadAll(rc)
 	if err != nil {
 		return nil, err
 	}

--- a/server/util/devnull/devnull.go
+++ b/server/util/devnull/devnull.go
@@ -2,7 +2,6 @@ package devnull
 
 import (
 	"io"
-	"io/ioutil"
 )
 
 // A writer that drops anything written to it.
@@ -16,7 +15,7 @@ type discardWriteCloser struct {
 // dropping any bytes written to it and returning nil on Close.
 func NewWriteCloser() io.WriteCloser {
 	return &discardWriteCloser{
-		ioutil.Discard,
+		io.Discard,
 	}
 }
 

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -71,7 +70,7 @@ func WriteFile(ctx context.Context, fullPath string, data []byte) (int, error) {
 	// still remove the tmp file.
 	defer DeleteLocalFileIfExists(tmpFileName)
 
-	if err := ioutil.WriteFile(tmpFileName, data, 0644); err != nil {
+	if err := os.WriteFile(tmpFileName, data, 0644); err != nil {
 		return 0, err
 	}
 	return len(data), os.Rename(tmpFileName, fullPath)

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -80,7 +80,7 @@ func WriteFile(ctx context.Context, fullPath string, data []byte) (int, error) {
 func ReadFile(ctx context.Context, fullPath string) ([]byte, error) {
 	ctx, spn := tracing.StartSpan(ctx)
 	defer spn.End()
-	data, err := ioutil.ReadFile(fullPath)
+	data, err := os.ReadFile(fullPath)
 	if os.IsNotExist(err) {
 		return nil, status.NotFoundError(err.Error())
 	}


### PR DESCRIPTION
- Replace usages of ioutil.ReadDir with os.ReadDir
- Replace usages of ioutil.ReadFile with os.ReadFile
- Replace usages of ioutil.ReadAll with io.ReadAll
- Replace usages of ioutil.WriteFile with os.WriteFile
- Replace ioutil.TempFile, ioutil.Discard with non-deprecated equivalents
