### PR TITLE
Make yaml autodocs give examples for null fields

### DIFF
--- a/server/util/flagutil/yaml/yaml.go
+++ b/server/util/flagutil/yaml/yaml.go
@@ -232,7 +232,6 @@ func DocumentNode(in any, n *yaml.Node, opts ...common.DocumentNodeOption) error
 						return err
 					}
 					replacedExample := string(StartOfLine.ReplaceAll(example, []byte("    ")))
-					// log.Infof("example:\n%s\n\nreplacedExample:\n%s", string(example), string(replacedExample))
 					n.FootComment = fmt.Sprintf("For example:\n%s", string(replacedExample))
 				}
 				return DocumentNode(reflect.New(t.Elem()).Elem().Interface(), n, opts...)

--- a/server/util/flagutil/yaml/yaml.go
+++ b/server/util/flagutil/yaml/yaml.go
@@ -38,6 +38,8 @@ var (
 	AppendTypeToLineComment = &appendTypeToLineComment{}
 
 	WordWrapForIndentationLevel = generateWordWrapRegexByIndentationLevel(76, 3)
+
+	StartOfLine = regexp.MustCompile("(?m)^")
 )
 
 func generateWordWrapRegexByIndentationLevel(targetLineLength, minWrapLength int) []*regexp.Regexp {
@@ -154,7 +156,7 @@ func (f *appendTypeToLineComment) Transform(in any, n *yaml.Node) {
 	n.LineComment += "(type: " + typeString + ")"
 }
 
-func (f *appendTypeToLineComment) Passthrough() bool { return true }
+func (f *appendTypeToLineComment) Passthrough() bool { return false }
 
 func filterPassthrough(opts []common.DocumentNodeOption) []common.DocumentNodeOption {
 	ptOpts := []common.DocumentNodeOption{}
@@ -220,7 +222,20 @@ func DocumentNode(in any, n *yaml.Node, opts ...common.DocumentNodeOption) error
 			if !v.IsNil() {
 				return DocumentNode(v.Elem().Interface(), n, opts...)
 			} else {
-				return DocumentNode(reflect.New(reflect.TypeOf(t).Elem()).Elem().Interface(), n, opts...)
+				exampleNode, err := DocumentedNode(reflect.Indirect(reflect.New(t.Elem())).Interface(), append(filterPassthrough(opts), AppendTypeToLineComment)...)
+				if err != nil {
+					return err
+				}
+				if exampleNode.Kind != yaml.ScalarNode {
+					example, err := yaml.Marshal(exampleNode)
+					if err != nil {
+						return err
+					}
+					replacedExample := string(StartOfLine.ReplaceAll(example, []byte("    ")))
+					// log.Infof("example:\n%s\n\nreplacedExample:\n%s", string(example), string(replacedExample))
+					n.FootComment = fmt.Sprintf("For example:\n%s", string(replacedExample))
+				}
+				return DocumentNode(reflect.New(t.Elem()).Elem().Interface(), n, opts...)
 			}
 		case reflect.Struct:
 			// yaml.Node stores mappings in Content as [key1, value1, key2, value2...]
@@ -243,7 +258,10 @@ func DocumentNode(in any, n *yaml.Node, opts ...common.DocumentNodeOption) error
 					v.FieldByIndex([]int{i}).Interface(),
 					n.Content[idx],
 					append(
-						[]common.DocumentNodeOption{NewLineComment(ft.Tag.Get("usage"))},
+						append(
+							[]common.DocumentNodeOption{NewLineComment(ft.Tag.Get("usage"))},
+							AppendTypeToLineComment,
+						),
 						filterPassthrough(opts)...,
 					)...,
 				); err != nil {


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

- Fixes a bug where an instance of the type of the type, as opposed to the type, was being default-constructed for pointers.
- Adds indentation to allow uncommenting the examples to work properly with sub-examples.
- Changes `AppendTypeToLineComment` to not pass through so it doesn't double (or triple, or quadruple, etc) up types at the end of lines.
---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
