### PR TITLE
Document Prometheus metrics path and port

### DIFF
--- a/docs/config-flags.md
+++ b/docs/config-flags.md
@@ -10,6 +10,7 @@ There are several configuration options that are not in the BuildBuddy configura
 - `--listen` The interface that BuildBuddy will listen on. Defaults to 0.0.0.0 (all interfaces)
 - `--port` The port to listen for HTTP traffic on. Defaults to 8080.
 - `--grpc_port` The port to listen for gRPC traffic on. Defaults to 1985.
+- `--monitoring_port` The port to listen for Prometheus metrics requests on. Defaults to 9090.
 
 ## Configuration options as flags
 

--- a/docs/prometheus-metrics.mdx
+++ b/docs/prometheus-metrics.mdx
@@ -10,6 +10,8 @@ BuildBuddy exposes [Prometheus](https://prometheus.io) metrics that allow monito
 [four golden signals](https://landing.google.com/sre/sre-book/chapters/monitoring-distributed-systems/):
 latency, traffic, errors, and saturation.
 
+Prometheus metrics are exposed under the path `metrics/` on port `9090` by default.
+
 To view these metrics in a live-updating dashboard, we recommend using a tool
 like [Grafana](https://grafana.com).
 


### PR DESCRIPTION
Added a line noting the path and port that Prometheus metrics are configured with. Also documented the `--monitoring_port` config flag.

**Version bump**: None
