### PR TITLE
Remove runner pool memory restrictions for Firecracker

### DIFF
--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -253,7 +253,7 @@ func main() {
 	}
 	executorID := executorUUID.String()
 
-	runnerPool, err := runner.NewPool(env)
+	runnerPool, err := runner.NewPool(env, &runner.PoolOptions{})
 	if err != nil {
 		log.Fatalf("Failed to initialize runner pool: %s", err)
 	}

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -190,6 +190,12 @@ type CommandContainer interface {
 	Remove(ctx context.Context) error
 
 	// Stats returns the current resource usage of this container.
+	//
+	// A `nil` value may be returned if the resource usage is unknown.
+	//
+	// Implementations may assume that this will only be called when the
+	// container is paused, for the purposes of computing resources used for
+	// pooled runners.
 	Stats(ctx context.Context) (*repb.UsageStats, error)
 }
 

--- a/enterprise/server/remote_execution/containers/bare/bare.go
+++ b/enterprise/server/remote_execution/containers/bare/bare.go
@@ -62,5 +62,5 @@ func (c *bareCommandContainer) Pause(ctx context.Context) error   { return nil }
 func (c *bareCommandContainer) Unpause(ctx context.Context) error { return nil }
 
 func (c *bareCommandContainer) Stats(ctx context.Context) (*repb.UsageStats, error) {
-	return &repb.UsageStats{}, nil
+	return nil, nil
 }

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1588,6 +1588,9 @@ func (c *FirecrackerContainer) Wait(ctx context.Context) error {
 }
 
 func (c *FirecrackerContainer) Stats(ctx context.Context) (*repb.UsageStats, error) {
+	// Note: We return a non-nil value here since paused Firecracker containers
+	// only exist on disk and legitimately consume 0 memory / CPU resources when
+	// paused.
 	return &repb.UsageStats{}, nil
 }
 

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -779,7 +779,7 @@ func (c *podmanCommandContainer) readRawStats(ctx context.Context) (*repb.UsageS
 
 func (c *podmanCommandContainer) Stats(ctx context.Context) (*repb.UsageStats, error) {
 	if !c.options.EnableStats {
-		return &repb.UsageStats{}, nil
+		return nil, nil
 	}
 
 	current, err := c.readRawStats(ctx)

--- a/enterprise/server/remote_execution/containers/sandbox/sandbox.go
+++ b/enterprise/server/remote_execution/containers/sandbox/sandbox.go
@@ -325,5 +325,5 @@ func (c *sandbox) Remove(ctx context.Context) error                             
 func (c *sandbox) Pause(ctx context.Context) error                                      { return nil }
 func (c *sandbox) Unpause(ctx context.Context) error                                    { return nil }
 func (c *sandbox) Stats(ctx context.Context) (*repb.UsageStats, error) {
-	return &repb.UsageStats{}, nil
+	return nil, nil
 }

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -56,6 +56,8 @@ go_test(
     data = ["//enterprise/server/remote_execution/runner/testworker"],
     embed = [":runner"],
     deps = [
+        "//enterprise/server/remote_execution/container",
+        "//enterprise/server/remote_execution/containers/bare",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/remote_execution/workspace",
         "//enterprise/server/tasksize",

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -627,7 +627,8 @@ func (p *pool) add(ctx context.Context, r *commandRunner) *labeledError {
 	}
 	// If memory usage stats are not implemented, fall back to the default task
 	// size estimate.
-	if stats.MemoryBytes == 0 {
+	if stats == nil {
+		stats = &repb.UsageStats{}
 		stats.MemoryBytes = int64(float64(tasksize.DefaultMemEstimate) * runnerMemUsageEstimateMultiplierBytes)
 	}
 

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -497,6 +497,14 @@ func ACLForUser(user interfaces.UserInfo) *aclpb.ACL {
 	return perms.ToACLProto(userID, groupID, permBits)
 }
 
+type ContainerProvider func(context.Context, *platform.Properties, *repb.ScheduledTask) (*container.TracedCommandContainer, error)
+
+type PoolOptions struct {
+	// ContainerProvider is an optional implementation overriding
+	// newContainerImpl.
+	ContainerProvider ContainerProvider
+}
+
 type pool struct {
 	env            environment.Env
 	imageCacheAuth *container.ImageCacheAuthenticator
@@ -504,6 +512,7 @@ type pool struct {
 	buildRoot      string
 	dockerClient   *dockerclient.Client
 	podmanProvider *podman.Provider
+	newContainer   ContainerProvider
 
 	maxRunnerCount            int
 	maxRunnerMemoryUsageBytes int64
@@ -518,7 +527,7 @@ type pool struct {
 	runners []*commandRunner
 }
 
-func NewPool(env environment.Env) (*pool, error) {
+func NewPool(env environment.Env, opts *PoolOptions) (*pool, error) {
 	hc := env.GetHealthChecker()
 	if hc == nil {
 		return nil, status.FailedPreconditionError("Missing health checker")
@@ -560,6 +569,10 @@ func NewPool(env environment.Env) (*pool, error) {
 		buildRoot:      *rootDirectory,
 		imageCacheAuth: imageCacheAuth,
 		runners:        []*commandRunner{},
+	}
+	p.newContainer = p.newContainerImpl
+	if opts.ContainerProvider != nil {
+		p.newContainer = opts.ContainerProvider
 	}
 	p.setLimits()
 	hc.RegisterShutdownFunction(p.Shutdown)
@@ -957,7 +970,7 @@ func (p *pool) Get(ctx context.Context, st *repb.ScheduledTask) (interfaces.Runn
 	return r, nil
 }
 
-func (p *pool) newContainer(ctx context.Context, props *platform.Properties, task *repb.ScheduledTask) (*container.TracedCommandContainer, error) {
+func (p *pool) newContainerImpl(ctx context.Context, props *platform.Properties, task *repb.ScheduledTask) (*container.TracedCommandContainer, error) {
 	var ctr container.CommandContainer
 	switch platform.ContainerType(props.WorkloadIsolationType) {
 	case platform.DockerContainerType:

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -1262,7 +1262,7 @@ type testRunnerPool struct {
 }
 
 func NewTestRunnerPool(t testing.TB, env environment.Env, runInterceptor RunInterceptor) interfaces.RunnerPool {
-	realPool, err := runner.NewPool(env)
+	realPool, err := runner.NewPool(env, &runner.PoolOptions{})
 	require.NoError(t, err)
 	return &testRunnerPool{realPool, runInterceptor}
 }


### PR DESCRIPTION
- Update the runner pool logic and `container.Stats()` API to allow returning 0 as a valid memory usage value, and to allow returning `nil` to represent "not implemented, use an estimate instead"
- Update all container implementations so that only Firecracker returns 0 memory from `Stats()`, and all the other impls which don't yet implement `Stats()` (or have it disabled) return `nil` instead.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
