### PR TITLE
Only update meta if we are the leader

### DIFF
--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -296,7 +296,7 @@ func RunNodehostFn(ctx context.Context, nhf func(ctx context.Context) error) err
 		}
 		return nil
 	}
-	return status.DeadlineExceededErrorf("exceeded retry limit for node host function")
+	return status.DeadlineExceededErrorf("exceeded retries [ran %d/%d] for node host function", retrier.AttemptNumber(), retrier.MaxAttempts())
 }
 
 func getRequestState(ctx context.Context, rs *dragonboat.RequestState) (dbsm.Result, error) {
@@ -334,7 +334,7 @@ func SyncProposeLocal(ctx context.Context, nodehost *dragonboat.NodeHost, cluste
 	}
 	var raftResponse dbsm.Result
 	err = RunNodehostFn(ctx, func(ctx context.Context) error {
-		rs, err := nodehost.Propose(sesh, buf, time.Second)
+		rs, err := nodehost.Propose(sesh, buf, 1*time.Second)
 		if err != nil {
 			return err
 		}

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -47,6 +47,9 @@ func (fs *fakeStore) WithFileReadFn(fn fileReadFn) *fakeStore {
 	fs.fileReadFn = fn
 	return fs
 }
+func (fs *fakeStore) IsLeader(clusterID uint64) bool {
+	return false
+}
 
 func TestOpenCloseReplica(t *testing.T) {
 	rootDir := testfs.MakeTempDir(t)

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -408,6 +408,10 @@ func (s *Store) GetReplica(rangeID uint64) (*replica.Replica, error) {
 	return r, nil
 }
 
+func (s *Store) IsLeader(clusterID uint64) bool {
+	return s.isLeader(clusterID)
+}
+
 func (s *Store) isLeader(clusterID uint64) bool {
 	nodeHostInfo := s.nodeHost.GetNodeHostInfo(dragonboat.NodeHostInfoOption{
 		SkipLogInfo: true,

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -853,7 +853,6 @@ func TestPostFactoSplit(t *testing.T) {
 }
 
 func TestManySplits(t *testing.T) {
-	t.Skip()
 	sf := newStoreFactory(t)
 	s1, nh1 := sf.NewStore(t)
 	s2, nh2 := sf.NewStore(t)


### PR DESCRIPTION
This prevents deadlocks during split when a a node being split (so, in Update() command, which is guarded by a mutex) makes a request to update the metarange that happens to fall on the same worker blocked in Update().