### PR TITLE
Fix rare panic in ContainerMetrics.Observe

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -118,8 +118,13 @@ func (m *ContainerMetrics) Observe(c CommandContainer, s *repb.UsageStats) {
 			cpuNanos += stats.CpuNanos
 		}
 		diffCPUNanos := cpuNanos - prevCPUNanos
-		metrics.RemoteExecutionUsedMilliCPU.Add(float64(diffCPUNanos) / 1e6)
-		m.intervalCPUNanos += diffCPUNanos
+		// Note: This > 0 check is here to avoid panicking in case there are
+		// issues with process stats returning non-monotonically-increasing
+		// values for CPU usage.
+		if diffCPUNanos > 0 {
+			metrics.RemoteExecutionUsedMilliCPU.Add(float64(diffCPUNanos) / 1e6)
+			m.intervalCPUNanos += diffCPUNanos
+		}
 	}
 	var totalMemBytes, totalPeakMemBytes int64
 	for _, stats := range m.latest {


### PR DESCRIPTION
The `.Add()` method for a Prometheus counter metric panics if called with a negative value (:cry:)

I am only seeing this on Mac executors, and very rarely (once every few days). Presumably it's some issue with the system clock, or some imprecision with the process stats API being used.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
