### PR TITLE
Improve dashboard JSON normalization

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -22,7 +22,6 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": 1,
-  "iteration": 1663168571049,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -8551,8 +8550,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -8715,8 +8713,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",

--- a/tools/metrics/process_dashboard.py
+++ b/tools/metrics/process_dashboard.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Prepares the input Grafana dashboard JSON for storage in Git.
+
+Its purpose is to reduce unnecessary diffs, normalizing the dashboard and
+reverting changes which are most likely unintended.
+"""
+
+import collections
+import json
+import sys
+
+DASHBOARD_REFRESH_INTERVAL = "1m"
+
+
+def main():
+    dashboard = json.load(sys.stdin)["dashboard"]
+
+    # Remove volatile versioning info since we use Git for versioning.
+    if "version" in dashboard:
+        del dashboard["version"]
+    if "iteration" in dashboard:
+        del dashboard["iteration"]
+
+    # Sometimes null values creep into the dashboard JSON and cause unnecessary
+    # diffs. Strip these out since the resulting dashboard is equivalent.
+    #
+    # Related: https://github.com/grafana/grafana/issues/54126
+    remove_dict_none_values(dashboard)
+
+    dashboard = with_ordered_dicts(dashboard)
+
+    # Grafana updates the refresh interval in the JSON when changing it in the
+    # UI. Hard-code it here to prevent accidental updates.
+    dashboard["refresh"] = DASHBOARD_REFRESH_INTERVAL
+
+    # Grafana updates "collapsed" state when expanding panels in the UI. Ensure
+    # all panels are collapsed to prevent accidental updates.
+    for panel in dashboard["panels"]:
+        panel["collapsed"] = True
+
+    # Note: ensure_ascii=False keeps strings like "µs" as-is.
+    json.dump(dashboard, sys.stdout, indent=2, ensure_ascii=False)
+
+
+def with_ordered_dicts(obj):
+    if isinstance(obj, list):
+        return [with_ordered_dicts(item) for item in obj]
+    elif isinstance(obj, dict):
+        new_items = [(k, with_ordered_dicts(v)) for (k, v) in obj.items()]
+        return collections.OrderedDict(sorted(new_items))
+    else:
+        return obj
+
+
+def remove_dict_none_values(obj):
+    if isinstance(obj, list):
+        for item in obj:
+            remove_dict_none_values(item)
+    elif isinstance(obj, dict):
+        keys_to_remove = []
+        for k, v in obj.items():
+            if v is None:
+                keys_to_remove.append(k)
+            else:
+                remove_dict_none_values(v)
+        for k in keys_to_remove:
+            del obj[k]
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/metrics/run.sh
+++ b/tools/metrics/run.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-set -e -o pipefail
-__file__=$(realpath "$0")
-__dir__=$(dirname "$__file__")
+set -eo pipefail
+__dir__=$(dirname "$0")
 
 cd "$__dir__"
 
@@ -43,8 +42,9 @@ function sync() {
     return
   fi
 
-  json=$(echo "$json" | jq -M -r '.dashboard | del(.version)')
-  current=$(cat "$GRAFANA_DASHBOARD_FILE_PATH" | jq -M -r 'del(.version)')
+  json=$(echo "$json" | ./process_dashboard.py)
+  if [[ -z "$json" ]]; then return 1; fi
+  current=$(cat "$GRAFANA_DASHBOARD_FILE_PATH")
   # If the dashboard hasn't changed, don't write a new JSON file, to avoid
   # updating the file timestamp (causing Grafana to show "someone else updated
   # this dashboard")
@@ -65,7 +65,7 @@ function sync() {
 (
   while true; do
     sleep 3
-    sync
+    sync || true
   done
 ) &
 


### PR DESCRIPTION
Some changes to prevent unnecessary diffs and make it less painful to deal with concurrent changes to the dashboard JSON across multiple branches:
- Remove null values (I see these show up in diffs sometimes, not sure why, but the dashboard seems to work the same with or without these)
- Prevent accidentally modifying the refresh interval (happens to me all the time, since locally I find a short refresh interval like 5s more useful)
- Prevent accidentally updating the "collapsed" bit, leaving panels expanded unnecessarily (also happens often)
- Remove "iteration" key which is unnecessary versioning info

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
