### PR TITLE
Tweak Mac workflows starter config

### DIFF
--- a/docs/workflows-config.md
+++ b/docs/workflows-config.md
@@ -134,24 +134,24 @@ executors.
    [Example config](#example-config) for a starting point.
 
 3. Set `os: "darwin"` on the workflow action that you would like to build
-   on macOS. For M1 Macs, add `arch: "arm64"` as well. Note: if you
-   copy another action as a starting point, be sure to give the new action
-   a unique name:
+   on macOS. For Apple silicon (ARM-based) Macs, add `arch: "arm64"` as
+   well. Note: if you copy another action as a starting point, be sure to
+   give the new action a unique name:
 
 ```yaml
 actions:
   - name: "Test all targets (Mac)"
     os: "darwin" # <-- add this line
-    arch: "arm64" # <-- add this line for M1 Macs only
+    arch: "arm64" # <-- add this line for Apple silicon (ARM-based) Macs only
     triggers:
       push:
         branches:
           - "main"
       pull_request:
         branches:
-          - "main"
+          - "*"
     bazel_commands:
-      - "test //... --build_metadata=ROLE=CI --bes_backend=grpcs://remote.buildbuddy.io --bes_results_url=https://app.buildbuddy.io/invocation/"
+      - "test //... --bes_backend=remote.buildbuddy.io --bes_results_url=https://app.buildbuddy.io/invocation/"
 ```
 
 That's it! Whenever any of the configured triggers are matched, one of
@@ -187,8 +187,8 @@ A named group of Bazel commands that run when triggered.
   `workflows` pool.
 - **`arch`** (`string`): The CPU architecture of the workflow runner.
   Defaults to `"amd64"`. `"arm64"` is also supported when running under
-  `os: "darwin"`, but requires using self-hosted M1 Mac executors running
-  on a dedicated `workflows` pool.
+  `os: "darwin"`, but requires using self-hosted Apple silicon (ARM-based)
+  Mac executors running on a dedicated `workflows` pool.
 - **`bazel_commands`** (`string` list): Bazel commands to be run in order.
   If a command fails, subsequent ones are not run, and the action is
   reported as failed. Otherwise, the action is reported as succeeded.


### PR DESCRIPTION
- Update `pull_request` trigger so that workflows trigger on stacked PRs (e.g. when pushing `frontend` in the chain `main <- backend <- frontend`)
- Remove `--build_metadata=ROLE=CI` since we apply this by default.
- Remove unnecessary `grpcs://` prefix
- Rename "M1" -> "Apple silicon (ARM-based)"

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
