### PR TITLE
Support wider range of auth providers

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -59,7 +59,7 @@ export class AuthService {
   }
 
   getCookie(name: string) {
-    var match = document.cookie.match(new RegExp("(^| )" + name + "=([^;]+)"));
+    let match = document.cookie.match(new RegExp("(^| )" + name + "=([^;]+)"));
     if (match) return match[2];
   }
 

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -14,7 +14,7 @@ export { User };
 const SELECTED_GROUP_ID_LOCAL_STORAGE_KEY = "selected_group_id";
 const IMPERSONATING_GROUP_ID_SESSION_STORAGE_KEY = "impersonating_group_id";
 const AUTO_LOGIN_ATTEMPTED_STORAGE_KEY = "auto_login_attempted";
-const TOKEN_REFRESH_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+const TOKEN_REFRESH_INTERVAL_SECONDS = 30 * 60; // 30 minutes
 
 export class AuthService {
   user: User = null;
@@ -50,11 +50,24 @@ export class AuthService {
         } else {
           this.onUserRpcError(error);
         }
+      }).finally(() => {
+        setTimeout(() => {
+          this.startRefreshTimer()
+        }, 1000); // Wait a second before starting the refresh timer so we can grab the session duration.
       });
+  }
 
+  getCookie(name: string) {
+    var match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+    if (match) return match[2];  
+  }
+
+  startRefreshTimer() {
+    let refreshFrequencySeconds = parseInt(this.getCookie("Session-Duration-Seconds")) / 2 || TOKEN_REFRESH_INTERVAL_SECONDS;
+    console.info(`Refreshing access token every ${refreshFrequencySeconds} seconds.`)
     setInterval(() => {
       if (this.user) this.refreshToken();
-    }, TOKEN_REFRESH_INTERVAL_MS);
+    }, refreshFrequencySeconds * 1000);    
   }
 
   refreshToken() {

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -50,24 +50,26 @@ export class AuthService {
         } else {
           this.onUserRpcError(error);
         }
-      }).finally(() => {
+      })
+      .finally(() => {
         setTimeout(() => {
-          this.startRefreshTimer()
+          this.startRefreshTimer();
         }, 1000); // Wait a second before starting the refresh timer so we can grab the session duration.
       });
   }
 
   getCookie(name: string) {
-    var match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
-    if (match) return match[2];  
+    var match = document.cookie.match(new RegExp("(^| )" + name + "=([^;]+)"));
+    if (match) return match[2];
   }
 
   startRefreshTimer() {
-    let refreshFrequencySeconds = parseInt(this.getCookie("Session-Duration-Seconds")) / 2 || TOKEN_REFRESH_INTERVAL_SECONDS;
-    console.info(`Refreshing access token every ${refreshFrequencySeconds} seconds.`)
+    let refreshFrequencySeconds =
+      parseInt(this.getCookie("Session-Duration-Seconds")) / 2 || TOKEN_REFRESH_INTERVAL_SECONDS;
+    console.info(`Refreshing access token every ${refreshFrequencySeconds} seconds.`);
     setInterval(() => {
       if (this.user) this.refreshToken();
-    }, refreshFrequencySeconds * 1000);    
+    }, refreshFrequencySeconds * 1000);
   }
 
   refreshToken() {

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -46,6 +46,7 @@ var (
 	apiKeyGroupCacheTTL  = flag.Duration("auth.api_key_group_cache_ttl", 5*time.Minute, "TTL for API Key to Group caching. Set to '0' to disable cache.")
 	httpsOnlyCookies     = flag.Bool("auth.https_only_cookies", false, "If true, cookies will only be set over https connections.")
 	disableRefreshToken  = flag.Bool("auth.disable_refresh_token", false, "If true, the offline_access scope which requests refresh tokens will not be requested.")
+	forceApproval  		 = flag.Bool("auth.force_approval", false, "If true, when a user doesn't have a session (first time logging in, or manually logged out) force the auth provider to show the consent screen allowing the user to select an account if they have multiple. This isn't supported by all auth providers.")
 )
 
 type OauthProvider struct {
@@ -79,6 +80,9 @@ const (
 	authorityHeader          = ":authority"
 	basicAuthHeader          = "authorization"
 
+	// The key that the current access token expiration time is stored under in the context.
+	contextTokenExpiryKey = "auth.tokenExpiry"
+
 	contextAPIKeyKey = "api.key"
 	APIKeyHeader     = "x-buildbuddy-api-key"
 
@@ -91,11 +95,12 @@ const (
 
 	// The name of the auth cookies used to authenticate the
 	// client.
-	jwtCookie        = "Authorization"
-	sessionIDCookie  = "Session-ID"
-	authIssuerCookie = "Authorization-Issuer"
-	stateCookie      = "State-Token"
-	redirCookie      = "Redirect-Url"
+	jwtCookie        	   = "Authorization"
+	sessionIDCookie  	   = "Session-ID"
+	sessionDurationCookie  = "Session-Duration-Seconds"
+	authIssuerCookie 	   = "Authorization-Issuer"
+	stateCookie      	   = "State-Token"
+	redirCookie            = "Redirect-Url"
 
 	// How long certain cookies last
 	tempCookieDuration  = 24 * time.Hour
@@ -187,12 +192,12 @@ func assembleJWT(ctx context.Context, claims *Claims) (string, error) {
 	return tokenString, err
 }
 
-func SetCookie(env environment.Env, w http.ResponseWriter, name, value string, expiry time.Time) {
+func SetCookie(env environment.Env, w http.ResponseWriter, name, value string, expiry time.Time, httpOnly bool) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     name,
 		Value:    value,
 		Expires:  expiry,
-		HttpOnly: true,
+		HttpOnly: httpOnly,
 		SameSite: http.SameSiteLaxMode,
 		Path:     "/",
 		Secure:   *httpsOnlyCookies,
@@ -200,7 +205,7 @@ func SetCookie(env environment.Env, w http.ResponseWriter, name, value string, e
 }
 
 func ClearCookie(env environment.Env, w http.ResponseWriter, name string) {
-	SetCookie(env, w, name, "", time.Now())
+	SetCookie(env, w, name, "", time.Now(), true /* httpOnly= */)
 }
 
 func GetCookie(r *http.Request, name string) string {
@@ -210,11 +215,13 @@ func GetCookie(r *http.Request, name string) string {
 	return ""
 }
 
-func setLoginCookie(env environment.Env, w http.ResponseWriter, jwt, issuer, sessionID string) {
+func setLoginCookie(env environment.Env, w http.ResponseWriter, jwt, issuer, sessionID string, sessionExpireTime int64) {
 	expiry := time.Now().Add(loginCookieDuration)
-	SetCookie(env, w, jwtCookie, jwt, expiry)
-	SetCookie(env, w, authIssuerCookie, issuer, expiry)
-	SetCookie(env, w, sessionIDCookie, sessionID, expiry)
+	SetCookie(env, w, jwtCookie, jwt, expiry, true /* httpOnly= */)
+	SetCookie(env, w, authIssuerCookie, issuer, expiry, true /* httpOnly= */)
+	SetCookie(env, w, sessionIDCookie, sessionID, expiry, true /* httpOnly= */)
+	// Don't make the session duration cookie httpOnly so the front end knows how frequently it needs to refresh tokens.
+	SetCookie(env, w, sessionDurationCookie, fmt.Sprintf("%d", sessionExpireTime - time.Now().Unix()), expiry, false /* httpOnly= */)
 }
 
 func clearLoginCookie(env environment.Env, w http.ResponseWriter) {
@@ -626,8 +633,8 @@ func (a *OpenIDAuthenticator) getAuthCodeOptions(r *http.Request) []oauth2.AuthC
 		options = append(options, oauth2.AccessTypeOffline)
 	}
 	sessionID := GetCookie(r, sessionIDCookie)
-	// If a session doesn't already exist, force a consent screen.
-	if sessionID == "" {
+	// If a session doesn't already exist, force a consent screen (so the user can select between multiple accounts) if enabled.
+	if sessionID == "" && *forceApproval {
 		options = append(options, oauth2.ApprovalForce)
 	}
 	return options
@@ -957,16 +964,23 @@ func (a *OpenIDAuthenticator) authenticateUser(w http.ResponseWriter, r *http.Re
 
 	sesh.ExpiryUsec = time.Unix(0, newToken.Expiry.UnixNano()).UnixMicro()
 	sesh.AccessToken = newToken.AccessToken
+	
+	// If token renewal returns a new refresh token, update it on the session
+	if refreshToken, ok := newToken.Extra("refresh_token").(string); ok {
+		sesh.RefreshToken = refreshToken
+	}
 
 	if err := authDB.InsertOrUpdateUserSession(ctx, sessionID, sesh); err != nil {
 		return nil, nil, err
 	}
-	if jwt, ok := newToken.Extra("id_token").(string); ok {
-		setLoginCookie(a.env, w, jwt, issuer, sessionID)
-		claims, err := ClaimsFromSubID(a.env, ctx, a, ut.GetSubID())
-		return claims, ut, err
+	// If token renewal returns a new id token, update it on the login cookie
+	if newJWT, ok := newToken.Extra("id_token").(string); ok {
+		jwt = newJWT
 	}
-	return nil, nil, status.PermissionDeniedErrorf("%s: could not refresh token", loggedOutMsg)
+
+	setLoginCookie(a.env, w, jwt, issuer, sessionID, newToken.Expiry.Unix())
+	claims, err := ClaimsFromSubID(a.env, ctx, a, ut.GetSubID())
+	return claims, ut, err
 }
 
 func (a *OpenIDAuthenticator) authenticatedUser(ctx context.Context) (*Claims, error) {
@@ -1065,7 +1079,7 @@ func (a *OpenIDAuthenticator) Login(w http.ResponseWriter, r *http.Request) {
 	// Set the "state" cookie which will be returned to us by tha authentication
 	// provider in the URL. We verify that it matches.
 	state := fmt.Sprintf("%d", random.RandUint64())
-	SetCookie(a.env, w, stateCookie, state, time.Now().Add(tempCookieDuration))
+	SetCookie(a.env, w, stateCookie, state, time.Now().Add(tempCookieDuration), true /* httpOnly= */)
 
 	redirectURL := r.URL.Query().Get(authRedirectParam)
 	if err := a.validateRedirectURL(redirectURL); err != nil {
@@ -1082,11 +1096,11 @@ func (a *OpenIDAuthenticator) Login(w http.ResponseWriter, r *http.Request) {
 
 	// Set the redirection URL in a cookie so we can use it after validating
 	// the user in our /auth callback.
-	SetCookie(a.env, w, redirCookie, redirectURL, time.Now().Add(tempCookieDuration))
+	SetCookie(a.env, w, redirCookie, redirectURL, time.Now().Add(tempCookieDuration), true /* httpOnly= */)
 
 	// Set the issuer cookie so we remember which issuer to use when exchanging
 	// a token later in our /auth callback.
-	SetCookie(a.env, w, authIssuerCookie, issuer, time.Now().Add(tempCookieDuration))
+	SetCookie(a.env, w, authIssuerCookie, issuer, time.Now().Add(tempCookieDuration), true /* httpOnly= */)
 
 	http.Redirect(w, r, u, http.StatusTemporaryRedirect)
 }
@@ -1178,7 +1192,7 @@ func (a *OpenIDAuthenticator) Auth(w http.ResponseWriter, r *http.Request) {
 
 	// OK, the token is valid so we will: store the token in our DB for
 	// later & set the login cookie so we know this user is logged in.
-	setLoginCookie(a.env, w, jwt, issuer, sessionID)
+	setLoginCookie(a.env, w, jwt, issuer, sessionID, oauth2Token.Expiry.Unix())
 
 	expireTime := time.Unix(0, oauth2Token.Expiry.UnixNano())
 	sesh := &tables.Session{

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -46,7 +46,7 @@ var (
 	apiKeyGroupCacheTTL  = flag.Duration("auth.api_key_group_cache_ttl", 5*time.Minute, "TTL for API Key to Group caching. Set to '0' to disable cache.")
 	httpsOnlyCookies     = flag.Bool("auth.https_only_cookies", false, "If true, cookies will only be set over https connections.")
 	disableRefreshToken  = flag.Bool("auth.disable_refresh_token", false, "If true, the offline_access scope which requests refresh tokens will not be requested.")
-	forceApproval  		 = flag.Bool("auth.force_approval", false, "If true, when a user doesn't have a session (first time logging in, or manually logged out) force the auth provider to show the consent screen allowing the user to select an account if they have multiple. This isn't supported by all auth providers.")
+	forceApproval        = flag.Bool("auth.force_approval", false, "If true, when a user doesn't have a session (first time logging in, or manually logged out) force the auth provider to show the consent screen allowing the user to select an account if they have multiple. This isn't supported by all auth providers.")
 )
 
 type OauthProvider struct {
@@ -95,12 +95,12 @@ const (
 
 	// The name of the auth cookies used to authenticate the
 	// client.
-	jwtCookie        	   = "Authorization"
-	sessionIDCookie  	   = "Session-ID"
-	sessionDurationCookie  = "Session-Duration-Seconds"
-	authIssuerCookie 	   = "Authorization-Issuer"
-	stateCookie      	   = "State-Token"
-	redirCookie            = "Redirect-Url"
+	jwtCookie             = "Authorization"
+	sessionIDCookie       = "Session-ID"
+	sessionDurationCookie = "Session-Duration-Seconds"
+	authIssuerCookie      = "Authorization-Issuer"
+	stateCookie           = "State-Token"
+	redirCookie           = "Redirect-Url"
 
 	// How long certain cookies last
 	tempCookieDuration  = 24 * time.Hour
@@ -221,7 +221,7 @@ func setLoginCookie(env environment.Env, w http.ResponseWriter, jwt, issuer, ses
 	SetCookie(env, w, authIssuerCookie, issuer, expiry, true /* httpOnly= */)
 	SetCookie(env, w, sessionIDCookie, sessionID, expiry, true /* httpOnly= */)
 	// Don't make the session duration cookie httpOnly so the front end knows how frequently it needs to refresh tokens.
-	SetCookie(env, w, sessionDurationCookie, fmt.Sprintf("%d", sessionExpireTime - time.Now().Unix()), expiry, false /* httpOnly= */)
+	SetCookie(env, w, sessionDurationCookie, fmt.Sprintf("%d", sessionExpireTime-time.Now().Unix()), expiry, false /* httpOnly= */)
 }
 
 func clearLoginCookie(env environment.Env, w http.ResponseWriter) {
@@ -964,7 +964,7 @@ func (a *OpenIDAuthenticator) authenticateUser(w http.ResponseWriter, r *http.Re
 
 	sesh.ExpiryUsec = time.Unix(0, newToken.Expiry.UnixNano()).UnixMicro()
 	sesh.AccessToken = newToken.AccessToken
-	
+
 	// If token renewal returns a new refresh token, update it on the session
 	if refreshToken, ok := newToken.Extra("refresh_token").(string); ok {
 		sesh.RefreshToken = refreshToken

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -102,7 +102,7 @@ func (a *SAMLAuthenticator) Login(w http.ResponseWriter, r *http.Request) {
 		a.fallback.Login(w, r)
 		return
 	}
-	auth.SetCookie(a.env, w, slugCookie, slug, time.Now().Add(cookieDuration))
+	auth.SetCookie(a.env, w, slugCookie, slug, time.Now().Add(cookieDuration), true /* httpOnly= */)
 	session, err := sp.Session.GetSession(r)
 	if session != nil {
 		redirectURL := r.URL.Query().Get(authRedirectParam)
@@ -187,7 +187,7 @@ func (a *SAMLAuthenticator) Auth(w http.ResponseWriter, r *http.Request) {
 	}
 	// Store slug as a cookie to enable logins directly from the /acs page.
 	slug := r.URL.Query().Get(slugParam)
-	auth.SetCookie(a.env, w, slugCookie, slug, time.Now().Add(cookieDuration))
+	auth.SetCookie(a.env, w, slugCookie, slug, time.Now().Add(cookieDuration), true /* httpOnly= */)
 
 	sp.ServeHTTP(w, r)
 }


### PR DESCRIPTION
Improvements that make our auth library work better with a wider variety of auth providers.
- Don't assume auth token refresh interval on the front-end (different providers issue access tokens with a 5 minute lifespan). Instead set a cookie that the frontend can read when we set the login cookies.
- Don't assume all auth providers support `consent=prompt` (some don't) and put this behind a flag.
- If an auth provider gives us a new refresh token in the token refresh response, update the session so we use that one going forward (some auth providers will "roll" the refresh token, so old tokens become invalid once they're used once).
- Don't assume that refresh tokens contain an "id_token" (some providers don't set this). If they don't, preserve the original id token.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
