### PR TITLE
Fix error message when attempting to use a server-admin only endpoint with no server-admin group ID defined

### DIFF
--- a/server/role_filter/role_filter.go
+++ b/server/role_filter/role_filter.go
@@ -126,8 +126,11 @@ func AuthorizeRPC(ctx context.Context, env environment.Env, rpcName string) erro
 		return nil
 	}
 
-	serverAdminGID := env.GetAuthenticator().AdminGroupID()
-	if serverAdminGID != "" && stringSliceContains(ServerAdminOnlyRPCs, rpcName) {
+	if stringSliceContains(ServerAdminOnlyRPCs, rpcName) {
+		serverAdminGID := env.GetAuthenticator().AdminGroupID()
+		if serverAdminGID == "" {
+			return status.PermissionDeniedError("Permission Denied.")
+		}
 		for _, m := range u.GetGroupMemberships() {
 			if m.GroupID == serverAdminGID && m.Role == role.Admin {
 				return nil


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Previously this would output the confusing message `Could not determine authenticated group ID from request`, when in fact the server admin group was simply not defined.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
