### PR TITLE
Small raft cleanup

### DIFF
--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -450,7 +450,6 @@ func SendStartClusterRequests(ctx context.Context, nodeHost *dragonboat.NodeHost
 			return err
 		}
 		clusterID = clusterIncrResponse.GetValue()
-		log.Printf("clusterID is now: %d", clusterID)
 		nodeIncrResponse, err := rsp.IncrementResponse(1)
 		if err != nil {
 			return err

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1280,6 +1280,7 @@ func (sm *Replica) Update(entries []dbsm.Entry) ([]dbsm.Entry, error) {
 						log.Warningf("mid-split, dropping rangelease cmd: %+v", union)
 						continue
 					}
+					log.Errorf("Range locked but got request: %+v", union)
 					return nil, err
 				}
 				defer db.Close()

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -708,8 +708,11 @@ func (s *Store) SyncWriter(stream rfspb.Api_SyncWriterServer) error {
 					return err
 				}
 				clusterID := req.GetHeader().GetReplica().GetClusterId()
-				_, err = client.SyncProposeLocal(ctx, s.nodeHost, clusterID, writeReq)
-				return err
+				writeRsp, err := client.SyncProposeLocal(ctx, s.nodeHost, clusterID, writeReq)
+				if err != nil {
+					return err
+				}
+				return rbuilder.NewBatchResponseFromProto(writeRsp).AnyError()
 			}}
 			writeCloser = rwc
 		} else {


### PR DESCRIPTION
- Log spurious reqs received during split
- Check SyncPropose error
- Remove spurious log
