### PR TITLE
Bundle the sidecar instead of downloading it

### DIFF
--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -6,6 +6,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "bb_lib",
     srcs = ["bb.go"],
+    data = [
+        "//cli/cmd/sidecar",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/cmd/bb",
     visibility = ["//visibility:private"],
     deps = [

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -179,15 +179,9 @@ func main() {
 	bblog.Printf("--remote_cache was %q", remoteCacheFlag)
 	bblog.Printf("--remote_executor was %q", remoteExecFlag)
 
-	// Maybe update the sidecar? If we haven't recently.
-	updated, err := sidecar.MaybeUpdateSidecar(ctx, bbHome)
-	if err != nil {
-		bblog.Printf("Error updating sidecar: %s", err.Error())
+	if err := sidecar.ExtractBundledSidecar(ctx, bbHome); err != nil {
+		bblog.Printf("Error extracting sidecar: %s", err)
 	}
-	if updated {
-		bblog.Printf("Updated sidecar: %t", updated)
-	}
-
 	// Re(Start) the sidecar if the flags set don't match.
 	sidecarArgs := make([]string, 0)
 	if besBackendFlag != "" {

--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//cli/commandline",
         "//cli/logging",
-        "//enterprise/server/remote_execution/dirtools",
         "//proto:build_event_stream_go_proto",
         "//proto:buildbuddy_service_go_proto",
         "//proto:eventlog_go_proto",

--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//cli/commandline",
         "//cli/logging",
+        "//enterprise/server/remote_execution/dirtools",
         "//proto:build_event_stream_go_proto",
         "//proto:buildbuddy_service_go_proto",
         "//proto:eventlog_go_proto",

--- a/cli/sidecar/BUILD
+++ b/cli/sidecar/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//cli/download",
         "//cli/logging",
+        "//cli/sidecar_bundle",
         "@org_golang_x_mod//semver",
     ],
 )

--- a/cli/sidecar_bundle/BUILD
+++ b/cli/sidecar_bundle/BUILD
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+genrule(
+    name = "sidecar_crossplatform",
+    srcs = select({
+        "@bazel_tools//src/conditions:darwin_x86_64": ["//cli/cmd/sidecar:sidecar-darwin-amd64"],
+        "@bazel_tools//src/conditions:darwin_arm64": ["//cli/cmd/sidecar:sidecar-darwin-arm64"],
+        "//conditions:default": ["//cli/cmd/sidecar:sidecar-linux-amd64"],
+    }),
+    outs = ["sidecar-binary"],
+    cmd_bash = "cp $(SRCS) $@",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "sidecar_bundle",
+    srcs = ["sidecar_bundle.go"],
+    embedsrcs = [":sidecar-binary"],  # keep
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/sidecar_bundle",
+    visibility = ["//visibility:public"],
+)

--- a/cli/sidecar_bundle/sidecar_bundle.go
+++ b/cli/sidecar_bundle/sidecar_bundle.go
@@ -1,0 +1,13 @@
+package sidecar_bundle
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed *
+var embedFS embed.FS
+
+func Open() (fs.File, error) {
+	return embedFS.Open("sidecar-binary")
+}


### PR DESCRIPTION
Really basic -- just in the spirit of making things build again. This bundles the sidecar into the CLI rather than trying to do anything fancy like downloading it.

Tested: it works.