### PR TITLE
Allow SSL to be used for monitoring endpoint on executor

### DIFF
--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//server/remote_cache/byte_stream_server",
         "//server/remote_cache/content_addressable_storage_server",
         "//server/resources",
+        "//server/ssl",
         "//server/util/fileresolver",
         "//server/util/flagutil/yaml",
         "//server/util/grpc_client",

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -33,6 +33,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/byte_stream_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/content_addressable_storage_server"
 	"github.com/buildbuddy-io/buildbuddy/server/resources"
+	"github.com/buildbuddy-io/buildbuddy/server/ssl"
 	"github.com/buildbuddy-io/buildbuddy/server/util/fileresolver"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
@@ -64,10 +65,11 @@ var (
 	localCacheSizeBytes      = flag.Int64("executor.local_cache_size_bytes", 1_000_000_000 /* 1 GB */, "The maximum size, in bytes, to use for the local on-disk cache")
 	startupWarmupMaxWaitSecs = flag.Int64("executor.startup_warmup_max_wait_secs", 0, "Maximum time to block startup while waiting for default image to be pulled. Default is no wait.")
 
-	listen         = flag.String("listen", "0.0.0.0", "The interface to listen on (default: 0.0.0.0)")
-	port           = flag.Int("port", 8080, "The port to listen for HTTP traffic on")
-	monitoringPort = flag.Int("monitoring_port", 9090, "The port to listen for monitoring traffic on")
-	serverType     = flag.String("server_type", "prod-buildbuddy-executor", "The server type to match on health checks")
+	listen            = flag.String("listen", "0.0.0.0", "The interface to listen on (default: 0.0.0.0)")
+	port              = flag.Int("port", 8080, "The port to listen for HTTP traffic on")
+	monitoringPort    = flag.Int("monitoring_port", 9090, "The port to listen for monitoring traffic on")
+	monitoringSSLPort = flag.Int("monitoring.ssl_port", -1, "If non-negative, the SSL port to listen for monitoring traffic on. `ssl` config must have `ssl_enabled: true` and be properly configured.")
+	serverType        = flag.String("server_type", "prod-buildbuddy-executor", "The server type to match on health checks")
 )
 
 var localListener *bufconn.Listener
@@ -294,8 +296,18 @@ func main() {
 		repb.RegisterActionCacheServer(localServer, actionCacheServer)
 	}
 
+	// Setup SSL for monitoring endpoints (optional).
+	if err := ssl.Register(env); err != nil {
+		log.Fatal(err.Error())
+	}
+
 	container.Metrics.Start(rootContext)
 	monitoring.StartMonitoringHandler(fmt.Sprintf("%s:%d", *listen, *monitoringPort))
+	if *monitoringSSLPort >= 0 {
+		if err := monitoring.StartSSLMonitoringHandler(env, fmt.Sprintf("%s:%d", *listen, *monitoringSSLPort)); err != nil {
+			log.Fatal(err.Error())
+		}
+	}
 
 	http.Handle("/healthz", env.GetHealthChecker().LivenessHandler())
 	http.Handle("/readyz", env.GetHealthChecker().ReadinessHandler())

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -296,14 +296,14 @@ func main() {
 		repb.RegisterActionCacheServer(localServer, actionCacheServer)
 	}
 
-	// Setup SSL for monitoring endpoints (optional).
-	if err := ssl.Register(env); err != nil {
-		log.Fatal(err.Error())
-	}
-
 	container.Metrics.Start(rootContext)
 	monitoring.StartMonitoringHandler(fmt.Sprintf("%s:%d", *listen, *monitoringPort))
+
+	// Setup SSL for monitoring endpoints (optional).
 	if *monitoringSSLPort >= 0 {
+		if err := ssl.Register(env); err != nil {
+			log.Fatal(err.Error())
+		}
 		if err := monitoring.StartSSLMonitoringHandler(env, fmt.Sprintf("%s:%d", *listen, *monitoringSSLPort)); err != nil {
 			log.Fatal(err.Error())
 		}

--- a/server/util/monitoring/BUILD
+++ b/server/util/monitoring/BUILD
@@ -6,8 +6,10 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/monitoring",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/environment",
         "//server/util/basicauth",
         "//server/util/log",
+        "//server/util/status",
         "//server/util/statusz",
         "@com_github_prometheus_client_golang//prometheus/promhttp",
     ],

--- a/server/util/monitoring/monitoring.go
+++ b/server/util/monitoring/monitoring.go
@@ -5,8 +5,10 @@ import (
 	"net/http"
 	"net/http/pprof"
 
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/basicauth"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/statusz"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -58,4 +60,25 @@ func StartMonitoringHandler(hostPort string) {
 			log.Fatal(err.Error())
 		}
 	}()
+}
+
+func StartSSLMonitoringHandler(env environment.Env, hostPort string) error {
+	ssl := env.GetSSLService()
+	if !ssl.IsEnabled() {
+		return status.InvalidArgumentError("ssl must be enabled in config to use SSL monitoring")
+	}
+	mux := http.NewServeMux()
+	RegisterMonitoringHandlers(mux)
+	tlsConfig, _ := ssl.ConfigureTLS(mux)
+	s := &http.Server{
+		Addr:      hostPort,
+		Handler:   mux,
+		TLSConfig: tlsConfig,
+	}
+
+	go func() {
+		log.Infof("Enabling monitoring (pprof/prometheus) interface with SSL on https://%s", hostPort)
+		s.ListenAndServeTLS("", "")
+	}()
+	return nil
 }


### PR DESCRIPTION
When `--monitoring.ssl_port` >= 0, use the SSL config to serve the monitoring handler with HTTPS on that port.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
