### PR TITLE
Allow a lil docker tcp socket as a treat

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -544,8 +544,11 @@ func NewPool(env environment.Env, opts *PoolOptions) (*pool, error) {
 			return nil, status.FailedPreconditionErrorf("Docker socket %q not found", platform.DockerSocket())
 		}
 		dockerSocket := platform.DockerSocket()
+		if !strings.Contains(dockerSocket, "://") {
+			dockerSocket = fmt.Sprintf("unix://%s", dockerSocket)
+		}
 		dockerClient, err = dockerclient.NewClientWithOpts(
-			dockerclient.WithHost(fmt.Sprintf("unix://%s", dockerSocket)),
+			dockerclient.WithHost(dockerSocket),
 			dockerclient.WithAPIVersionNegotiation(),
 		)
 		if err != nil {


### PR DESCRIPTION
If folks want to run docker and connect to it over tcp, they will now be able to by setting

```
executor.docker_host=tcp://localhost:2375
```

in their config. Existing configs which set a file path should still have "unix://" prefixed to them and be unaffected.