### PR TITLE
Fix tools/enable_local_firecracker.sh to allow cgroup2 mounted on /sys/fs/cgroup/unified

### DIFF
--- a/tools/enable_local_firecracker.sh
+++ b/tools/enable_local_firecracker.sh
@@ -5,63 +5,62 @@ set -euo pipefail
 # user to run firecracker (via the jailer), without being root.
 
 # this script must be run as root, so check that first.
-if [ $(id -u) -ne 0 ]; then
+if [ "$(id -u)" -ne 0 ]; then
     echo "This script must be run as root (use sudo)."
     echo "sudo $0"
     exit 1
 fi
 
-if ! command -v jailer &> /dev/null
-then
+if ! command -v jailer &>/dev/null; then
     echo "jailer could not be found (install firecracker + jailer?)"
     exit 1
 fi
 
-if ! command -v ip &> /dev/null
-then
+if ! command -v ip &>/dev/null; then
     echo "ip could not be found (install iproute2?)"
     exit 1
 fi
 
-if ! command -v iptables &> /dev/null
-then
+if ! command -v iptables &>/dev/null; then
     echo "iptables could not be found"
+    exit 1
+fi
+
+CGROUP2_PATH=$( (mount | grep -E -m1 '^cgroup2 on ' | awk '{print $3}') || true)
+if [[ ! "$CGROUP2_PATH" ]]; then
+    echo "missing cgroup2 mount"
     exit 1
 fi
 
 groupadd -f -r cgroups
 usermod -a -G cgroups root
-usermod -a -G cgroups $SUDO_USER
+usermod -a -G cgroups "$SUDO_USER"
 
 # jailer will create stuff here; ensure the dir exists and owner is user.
-mkdir -p /sys/fs/cgroup/cpuset/firecracker
-chown -R $SUDO_USER:cgroups /sys/fs/cgroup/cpuset/firecracker
-chmod -R g+rw /sys/fs/cgroup/cpuset/firecracker
+mkdir -p "$CGROUP2_PATH"/firecracker
+chown -R "$SUDO_USER":cgroups "$CGROUP2_PATH"/firecracker
+chmod -R g+rw "$CGROUP2_PATH"/firecracker
 
-mkdir -p /sys/fs/cgroup/firecracker
-chown -R $SUDO_USER:cgroups /sys/fs/cgroup/firecracker
-chmod -R g+rw /sys/fs/cgroup/firecracker
+chown -R root:cgroups "$CGROUP2_PATH"/cgroup.subtree_control
+chmod -R g+rw "$CGROUP2_PATH"/cgroup.subtree_control
+chown -R root:cgroups "$CGROUP2_PATH"/cgroup.procs
+chmod -R g+rw "$CGROUP2_PATH"/cgroup.procs
 
-chown -R root:cgroups /sys/fs/cgroup/cgroup.subtree_control
-chmod -R g+rw /sys/fs/cgroup/cgroup.subtree_control
-chown -R root:cgroups /sys/fs/cgroup/cgroup.procs
-chmod -R g+rw /sys/fs/cgroup/cgroup.procs
-
-setfacl -m u:${SUDO_USER}:rw /dev/kvm
+setfacl -m u:"${SUDO_USER}":rw /dev/kvm
 
 # enable IP forwarding.
-echo 1 > /proc/sys/net/ipv4/ip_forward
+echo 1 >/proc/sys/net/ipv4/ip_forward
 
 PRIMARY_DEVICE=$(route | grep default | awk '{print $8}')
-iptables -t nat -A POSTROUTING -o $PRIMARY_DEVICE -j MASQUERADE
+iptables -t nat -A POSTROUTING -o "$PRIMARY_DEVICE" -j MASQUERADE
 iptables -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 
 # allow the jailer to run without root by setting capabilities on the binary.
 JAILER_PATH=$(which jailer)
-JAILER_PERMS="$(getcap $JAILER_PATH | awk '{print $3}')"
+JAILER_PERMS="$(getcap "$JAILER_PATH" | awk '{print $3}')"
 if [ "$JAILER_PERMS" != "cap_net_admin,cap_sys_admin,cap_mknod+eip" ]; then
     echo "Running setcap CAP_MKNOD,CAP_SYS_ADMIN,CAP_NET_ADMIN+eip $JAILER_PATH"
-    setcap CAP_MKNOD,CAP_SYS_ADMIN,CAP_NET_ADMIN+eip $JAILER_PATH
+    setcap CAP_MKNOD,CAP_SYS_ADMIN,CAP_NET_ADMIN+eip "$JAILER_PATH"
 fi
 
 IP_PATH=$(which ip)

--- a/tools/enable_local_firecracker.sh
+++ b/tools/enable_local_firecracker.sh
@@ -41,9 +41,9 @@ mkdir -p "$CGROUP2_PATH"/firecracker
 chown -R "$SUDO_USER":cgroups "$CGROUP2_PATH"/firecracker
 chmod -R g+rw "$CGROUP2_PATH"/firecracker
 
-chown -R root:cgroups "$CGROUP2_PATH"/cgroup.subtree_control
+chown -R "$SUDO_USER":cgroups "$CGROUP2_PATH"/cgroup.subtree_control
 chmod -R g+rw "$CGROUP2_PATH"/cgroup.subtree_control
-chown -R root:cgroups "$CGROUP2_PATH"/cgroup.procs
+chown -R "$SUDO_USER":cgroups "$CGROUP2_PATH"/cgroup.procs
 chmod -R g+rw "$CGROUP2_PATH"/cgroup.procs
 
 setfacl -m u:"${SUDO_USER}":rw /dev/kvm


### PR DESCRIPTION
In Ubuntu 20.04.1, cgroup2 is mounted on `/sys/fs/cgroup/unified`, not `/sys/fs/cgroup`. Update the script to read the cgroup2 path using `mount | grep cgroup2`. Also delete the old cgroup v1 stuff (cpuset), and fix a few shellcheck lints.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
