### PR TITLE
Support dockerUser platform prop for firecracker

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/containeropts.go
+++ b/enterprise/server/remote_execution/containers/firecracker/containeropts.go
@@ -8,6 +8,9 @@ type ContainerOpts struct {
 	// The OCI container image. ex "alpine:latest".
 	ContainerImage string
 
+	// The "USER[:GROUP]" spec to run commands as (optional).
+	User string
+
 	// DockerClient can optionally be specified to pull container images via
 	// Docker. This is useful for de-duping in-flight image pull operations and
 	// making use of the local Docker cache for images. If not specified, images

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -272,6 +272,7 @@ type FirecrackerContainer struct {
 	workspaceGeneration int    // the number of times the workspace has been re-mounted into the guest VM
 	containerFSPath     string // the path to the container ext4 image
 	tempDir             string // path for writing disk images before the chroot is created
+	user                string // user to execute all commands as
 
 	rmOnce *sync.Once
 	rmErr  error
@@ -362,6 +363,7 @@ func NewContainer(env environment.Env, imageCacheAuth *container.ImageCacheAuthe
 		jailerRoot:         opts.JailerRoot,
 		dockerClient:       opts.DockerClient,
 		containerImage:     opts.ContainerImage,
+		user:               opts.User,
 		actionWorkingDir:   opts.ActionWorkingDirectory,
 		env:                env,
 		vmLog:              vmLog,
@@ -1302,7 +1304,7 @@ func (c *FirecrackerContainer) SendExecRequestToGuest(ctx context.Context, cmd *
 	statsListener := func(stats *repb.UsageStats) {
 		container.Metrics.Observe(c, stats)
 	}
-	return vmexec_client.Execute(ctx, client, cmd, workDir, statsListener, stdio)
+	return vmexec_client.Execute(ctx, client, cmd, workDir, c.user, statsListener, stdio)
 }
 
 func (c *FirecrackerContainer) dialVMExecServer(ctx context.Context) (*grpc.ClientConn, error) {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -883,6 +883,7 @@ func (p *pool) Get(ctx context.Context, st *repb.ScheduledTask) (interfaces.Runn
 		r, err := p.take(ctx, &query{
 			User:                   user,
 			ContainerImage:         props.ContainerImage,
+			CommandUser:            props.DockerUser,
 			WorkflowID:             props.WorkflowID,
 			WorkloadIsolationType:  platform.ContainerType(props.WorkloadIsolationType),
 			InitDockerd:            props.InitDockerd,
@@ -1000,6 +1001,7 @@ func (p *pool) newContainerImpl(ctx context.Context, props *platform.Properties,
 		sizeEstimate := task.GetSchedulingMetadata().GetTaskSize()
 		opts := firecracker.ContainerOpts{
 			ContainerImage:         props.ContainerImage,
+			User:                   props.DockerUser,
 			DockerClient:           p.dockerClient,
 			ActionWorkingDirectory: p.hostBuildRoot(),
 			NumCPUs:                int64(math.Max(1.0, float64(sizeEstimate.GetEstimatedMilliCpu())/1000)),
@@ -1041,6 +1043,8 @@ type query struct {
 	// container.
 	// Required; the zero-value "" matches bare runners.
 	ContainerImage string
+	// CommandUser is the username or ID to run commands as.
+	CommandUser string
 	// WorkflowID is the BuildBuddy workflow ID, if applicable.
 	// Required; the zero-value "" matches non-workflow runners.
 	WorkflowID string
@@ -1074,6 +1078,7 @@ func (p *pool) take(ctx context.Context, q *query) (*commandRunner, error) {
 		r := p.runners[i]
 		if r.state != paused ||
 			r.PlatformProperties.ContainerImage != q.ContainerImage ||
+			r.PlatformProperties.DockerUser != q.CommandUser ||
 			platform.ContainerType(r.PlatformProperties.WorkloadIsolationType) != q.WorkloadIsolationType ||
 			r.PlatformProperties.InitDockerd != q.InitDockerd ||
 			r.PlatformProperties.WorkflowID != q.WorkflowID ||

--- a/enterprise/server/remote_execution/vmexec_client/vmexec_client.go
+++ b/enterprise/server/remote_execution/vmexec_client/vmexec_client.go
@@ -26,7 +26,7 @@ const (
 )
 
 // Execute executes the command using the ExecStreamed API.
-func Execute(ctx context.Context, client vmxpb.ExecClient, cmd *repb.Command, workDir string, statsListener procstats.Listener, stdio *container.Stdio) *interfaces.CommandResult {
+func Execute(ctx context.Context, client vmxpb.ExecClient, cmd *repb.Command, workDir, user string, statsListener procstats.Listener, stdio *container.Stdio) *interfaces.CommandResult {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
@@ -44,6 +44,7 @@ func Execute(ctx context.Context, client vmxpb.ExecClient, cmd *repb.Command, wo
 	}
 	req := &vmxpb.ExecRequest{
 		WorkingDirectory: workDir,
+		User:             user,
 		Arguments:        cmd.GetArguments(),
 		OpenStdin:        stdio.Stdin != nil,
 	}

--- a/enterprise/server/vmexec/vmexec.go
+++ b/enterprise/server/vmexec/vmexec.go
@@ -263,6 +263,14 @@ func newCommand(start *vmxpb.ExecRequest, reapMutex *sync.RWMutex) (*command, er
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", envVar.GetName(), envVar.GetValue()))
 	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if start.GetUser() != "" {
+		cred, err := commandutil.LookupCredential(start.GetUser())
+		if err != nil {
+			return nil, err
+		}
+		cmd.SysProcAttr.Credential = cred
+	}
+
 	stdoutReader, stdoutWriter := io.Pipe()
 	cmd.Stdout = stdoutWriter
 	stderrReader, stderrWriter := io.Pipe()

--- a/enterprise/server/vmexec/vmexec_test.go
+++ b/enterprise/server/vmexec/vmexec_test.go
@@ -36,7 +36,7 @@ func TestExecStreamed_Simple(t *testing.T) {
 		`},
 	}
 
-	res := vmexec_client.Execute(context.Background(), client, cmd, ".", nil /*=statsListener*/, nil /*=stdio*/)
+	res := vmexec_client.Execute(context.Background(), client, cmd, ".", "" /*=user*/, nil /*=statsListener*/, nil /*=stdio*/)
 
 	require.NoError(t, res.Error)
 	assert.Equal(t, "foo-stdout\n", string(res.Stdout))
@@ -67,7 +67,7 @@ func TestExecStreamed_Stdio(t *testing.T) {
 		Stderr: &stderr,
 	}
 
-	res := vmexec_client.Execute(context.Background(), client, cmd, ".", nil /*=statsListener*/, stdio)
+	res := vmexec_client.Execute(context.Background(), client, cmd, ".", "" /*=user*/, nil /*=statsListener*/, stdio)
 
 	require.NoError(t, res.Error)
 	assert.Equal(t, "foo-stdout\n", stdout.String())
@@ -90,7 +90,7 @@ func TestExecStreamed_Stats(t *testing.T) {
 		`},
 	}
 
-	res := vmexec_client.Execute(context.Background(), client, cmd, wd, nil /*=statsListener*/, nil /*=stdio*/)
+	res := vmexec_client.Execute(context.Background(), client, cmd, wd, "" /*=user*/, nil /*=statsListener*/, nil /*=stdio*/)
 
 	require.NoError(t, res.Error)
 	require.NotNil(t, res.UsageStats)
@@ -113,7 +113,7 @@ func TestExecStreamed_Timeout(t *testing.T) {
 		`},
 	}
 
-	res := vmexec_client.Execute(ctx, client, cmd, ".", nil /*=statsListener*/, nil /*=stdio*/)
+	res := vmexec_client.Execute(ctx, client, cmd, ".", "" /*=user*/, nil /*=statsListener*/, nil /*=stdio*/)
 
 	assert.Error(t, res.Error)
 
@@ -144,7 +144,7 @@ func TestExecStreamed_Cancel(t *testing.T) {
 		cancel()
 	}()
 
-	res := vmexec_client.Execute(ctx, client, cmd, wd, nil /*=statsListener*/, nil /*=stdio*/)
+	res := vmexec_client.Execute(ctx, client, cmd, wd, "" /*=user*/, nil /*=statsListener*/, nil /*=stdio*/)
 
 	assert.Error(t, res.Error)
 

--- a/proto/vmexec.proto
+++ b/proto/vmexec.proto
@@ -64,7 +64,8 @@ message ExecRequest {
   // or not stdin is attached.
   bool open_stdin = 8;
 
-  // Optional user to run the command as.
+  // Optional user to run the command as. If unset, the command will run as
+  // root.
   string user = 9;
 }
 

--- a/proto/vmexec.proto
+++ b/proto/vmexec.proto
@@ -63,6 +63,9 @@ message ExecRequest {
   // the command, because commands can behave differently depending on whether
   // or not stdin is attached.
   bool open_stdin = 8;
+
+  // Optional user to run the command as.
+  string user = 9;
 }
 
 message ExecResponse {


### PR DESCRIPTION
Can be specified as `USER[:GROUP]`, where both USER and GROUP can be either names or IDs (same as Docker).

To be consistent with Docker, we do not create the user automatically. Instead the user is expected to be provisioned as part of the Docker image.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1643