### PR TITLE
Add bazel "command" as an advanced filter

### DIFF
--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -16,6 +16,7 @@ export const REPO_PARAM_NAME = "repo";
 export const BRANCH_PARAM_NAME = "branch";
 export const COMMIT_PARAM_NAME = "commit";
 export const HOST_PARAM_NAME = "host";
+export const COMMAND_PARAM_NAME = "command";
 
 const GLOBAL_FILTER_PARAM_NAMES = [
   ROLE_PARAM_NAME,
@@ -29,6 +30,7 @@ const GLOBAL_FILTER_PARAM_NAMES = [
   BRANCH_PARAM_NAME,
   COMMIT_PARAM_NAME,
   HOST_PARAM_NAME,
+  COMMAND_PARAM_NAME,
 ];
 
 class Router {

--- a/enterprise/app/filter/filter.tsx
+++ b/enterprise/app/filter/filter.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { DateRangePicker, OnChangeProps, Range } from "react-date-range";
 import FilledButton, { OutlinedButton } from "../../../app/components/button/button";
 import Popup from "../../../app/components/popup/popup";
-import { Filter, X, Calendar, User, Github, GitBranch, GitCommit, HardDrive } from "lucide-react";
+import { Filter, X, Calendar, User, Github, GitBranch, GitCommit, HardDrive, Wrench } from "lucide-react";
 import Checkbox from "../../../app/components/checkbox/checkbox";
 import { formatDateRange } from "../../../app/format/format";
 import router, {
@@ -17,6 +17,7 @@ import router, {
   BRANCH_PARAM_NAME,
   COMMIT_PARAM_NAME,
   HOST_PARAM_NAME,
+  COMMAND_PARAM_NAME,
 } from "../../../app/router/router";
 import { invocation } from "../../../proto/invocation_ts_proto";
 import {
@@ -47,6 +48,7 @@ interface State {
   branch?: string;
   commit?: string;
   host?: string;
+  command?: string;
 }
 
 type PresetRange = {
@@ -84,13 +86,15 @@ export default class FilterComponent extends React.Component<FilterProps, State>
           search.get(REPO_PARAM_NAME) ||
           search.get(BRANCH_PARAM_NAME) ||
           search.get(COMMIT_PARAM_NAME) ||
-          search.get(HOST_PARAM_NAME)
+          search.get(HOST_PARAM_NAME) ||
+          search.get(COMMAND_PARAM_NAME)
       ),
       user: search.get(USER_PARAM_NAME),
       repo: search.get(REPO_PARAM_NAME),
       branch: search.get(BRANCH_PARAM_NAME),
       commit: search.get(COMMIT_PARAM_NAME),
       host: search.get(HOST_PARAM_NAME),
+      command: search.get(COMMAND_PARAM_NAME),
     };
   }
 
@@ -135,6 +139,7 @@ export default class FilterComponent extends React.Component<FilterProps, State>
       [BRANCH_PARAM_NAME]: "",
       [COMMIT_PARAM_NAME]: "",
       [HOST_PARAM_NAME]: "",
+      [COMMAND_PARAM_NAME]: "",
     });
   }
 
@@ -195,6 +200,7 @@ export default class FilterComponent extends React.Component<FilterProps, State>
       [BRANCH_PARAM_NAME]: this.state.branch,
       [COMMIT_PARAM_NAME]: this.state.commit,
       [HOST_PARAM_NAME]: this.state.host,
+      [COMMAND_PARAM_NAME]: this.state.command,
     });
   }
 
@@ -215,9 +221,10 @@ export default class FilterComponent extends React.Component<FilterProps, State>
     const branchValue = this.props.search.get(BRANCH_PARAM_NAME) || "";
     const commitValue = this.props.search.get(COMMIT_PARAM_NAME) || "";
     const hostValue = this.props.search.get(HOST_PARAM_NAME) || "";
+    const commandValue = this.props.search.get(COMMAND_PARAM_NAME) || "";
 
     const isFiltering = Boolean(
-      roleValue || statusValue || userValue || repoValue || branchValue || commitValue || hostValue
+      roleValue || statusValue || userValue || repoValue || branchValue || commitValue || hostValue || commandValue
     );
     const selectedRoles = new Set(parseRoleParam(roleValue));
     const selectedStatuses = new Set(parseStatusParam(statusValue));
@@ -292,6 +299,11 @@ export default class FilterComponent extends React.Component<FilterProps, State>
                 <HardDrive /> {hostValue}
               </span>
             )}
+            {commandValue && (
+              <span className="advanced-badge">
+                <Wrench /> {commandValue}
+              </span>
+            )}
           </OutlinedButton>
           <Popup
             isOpen={this.state.isFilterMenuOpen}
@@ -362,6 +374,14 @@ export default class FilterComponent extends React.Component<FilterProps, State>
                       placeholder={"e.g. lunchbox"}
                       value={this.state.host}
                       onChange={(e) => this.setState({ host: e.target.value })}
+                    />
+                  </div>
+                  <div className="option-group-title">Command</div>
+                  <div className="option-group-input">
+                    <TextInput
+                      placeholder={"e.g. test"}
+                      value={this.state.command}
+                      onChange={(e) => this.setState({ command: e.target.value })}
                     />
                   </div>
                   <div className="option-group-input">

--- a/enterprise/app/filter/filter_util.tsx
+++ b/enterprise/app/filter/filter_util.tsx
@@ -13,6 +13,7 @@ import {
   BRANCH_PARAM_NAME,
   COMMIT_PARAM_NAME,
   HOST_PARAM_NAME,
+  COMMAND_PARAM_NAME,
 } from "../../../app/router/router";
 
 // URL param value representing the empty role (""), which is the default.
@@ -33,6 +34,7 @@ export interface ProtoFilterParams {
   branch: string;
   commit: string;
   host: string;
+  command: string;
 }
 
 export const LAST_N_DAYS_OPTIONS = [7, 30, 90, 180, 365];
@@ -50,6 +52,7 @@ export function getProtoFilterParams(search: URLSearchParams): ProtoFilterParams
     branch: search.get(BRANCH_PARAM_NAME),
     commit: search.get(COMMIT_PARAM_NAME),
     host: search.get(HOST_PARAM_NAME),
+    command: search.get(COMMAND_PARAM_NAME),
   };
 }
 

--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -94,6 +94,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
         repoUrl: this.props.repo || filterParams.repo,
         branchName: this.props.branch || filterParams.branch,
         commitSha: this.props.commit || filterParams.commit,
+        command: filterParams.command,
         groupId: this.props.user?.selectedGroup?.id,
       }),
       pageToken: nextPage ? this.state.pageToken : "",
@@ -134,6 +135,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
         repoUrl: this.props.repo || filterParams.repo,
         branchName: this.props.branch || filterParams.branch,
         commitSha: this.props.commit || filterParams.commit,
+        command: filterParams.command,
 
         role: filterParams.role,
         updatedBefore: filterParams.updatedBefore,
@@ -165,6 +167,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
         repoUrl: this.props.repo || filterParams.repo,
         branchName: this.props.branch || filterParams.branch,
         commitSha: this.props.commit || filterParams.commit,
+        command: filterParams.command,
 
         role: filterParams.role,
         updatedAfter: filterParams.updatedAfter,

--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -92,6 +92,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
       request.query.repoUrl = filterParams.repo;
       request.query.branchName = filterParams.branch;
       request.query.commitSha = filterParams.commit;
+      request.query.command = filterParams.command;
 
       request.query.updatedBefore = filterParams.updatedBefore;
       request.query.updatedAfter = filterParams.updatedAfter;
@@ -124,6 +125,10 @@ export default class TrendsComponent extends React.Component<Props, State> {
 
     if (this.props.search.get("repo")) {
       request.query.repoUrl = this.props.search.get("repo");
+    }
+
+    if (this.props.search.get("command")) {
+      request.query.command = this.props.search.get("command");
     }
 
     this.setState({ ...this.state, loading: true });

--- a/enterprise/server/invocation_search_service/invocation_search_service.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service.go
@@ -126,6 +126,9 @@ func (s *InvocationSearchService) QueryInvocations(ctx context.Context, req *inp
 	if branch := req.GetQuery().GetBranchName(); branch != "" {
 		q.AddWhereClause("i.branch_name = ?", branch)
 	}
+	if command := req.GetQuery().GetCommand(); command != "" {
+		q.AddWhereClause("i.command = ?", command)
+	}
 	if sha := req.GetQuery().GetCommitSha(); sha != "" {
 		q.AddWhereClause("i.commit_sha = ?", sha)
 	}

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -123,6 +123,10 @@ func (i *InvocationStatService) GetTrend(ctx context.Context, req *inpb.GetTrend
 		q.AddWhereClause("branch_name = ?", branchName)
 	}
 
+	if command := req.GetQuery().GetCommand(); command != "" {
+		q.AddWhereClause("command = ?", command)
+	}
+
 	if commitSHA := req.GetQuery().GetCommitSha(); commitSHA != "" {
 		q.AddWhereClause("commit_sha = ?", commitSHA)
 	}
@@ -264,6 +268,10 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 
 	if branchName := req.GetQuery().GetBranchName(); branchName != "" {
 		q.AddWhereClause("branch_name = ?", branchName)
+	}
+
+	if command := req.GetQuery().GetCommand(); command != "" {
+		q.AddWhereClause("command = ?", command)
 	}
 
 	if commitSHA := req.GetQuery().GetCommitSha(); commitSHA != "" {

--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -227,6 +227,9 @@ message InvocationQuery {
 
   // The git branch used for the build.
   string branch_name = 10;
+
+  // The bazel command that was used. Ex: "build", "test", "run"
+  string command = 11;
 }
 
 // OverallStatus is a status representing both the completion status and
@@ -366,6 +369,9 @@ message InvocationStatQuery {
 
   // The git branch used for the build.
   string branch_name = 10;
+
+  // The bazel command that was used. Ex: "build", "test", "run"
+  string command = 11;
 }
 
 message GetInvocationStatRequest {
@@ -469,6 +475,9 @@ message TrendQuery {
 
   // The git branch used for the build.
   string branch_name = 10;
+
+  // The bazel command that was used. Ex: "build", "test", "run"
+  string command = 11;
 }
 
 message GetTrendRequest {

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -119,7 +119,7 @@ func ToInvocationFromPrimaryDB(ti *tables.Invocation) *Invocation {
 		Host:                             ti.Host,
 		CommitSHA:                        ti.CommitSHA,
 		BranchName:                       ti.BranchName,
-		Command:                       	  ti.Command,
+		Command:                          ti.Command,
 		ActionCount:                      ti.ActionCount,
 		InvocationStatus:                 ti.InvocationStatus,
 		RepoURL:                          ti.RepoURL,

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -56,6 +56,7 @@ type Invocation struct {
 	Host                             string
 	CommitSHA                        string
 	BranchName                       string
+	Command                          string
 	ActionCount                      int64
 	InvocationStatus                 int64
 	RepoURL                          string
@@ -118,6 +119,7 @@ func ToInvocationFromPrimaryDB(ti *tables.Invocation) *Invocation {
 		Host:                             ti.Host,
 		CommitSHA:                        ti.CommitSHA,
 		BranchName:                       ti.BranchName,
+		Command:                       	  ti.Command,
 		ActionCount:                      ti.ActionCount,
 		InvocationStatus:                 ti.InvocationStatus,
 		RepoURL:                          ti.RepoURL,


### PR DESCRIPTION
This column doesn't (yet) have an index, but this is under advanced filter - so we can worry about that if we get any negative performance feedback. 

Not sure if there's anything I need to do on the clickhouse side of things of whether this will "just work". cc @luluz66 

I can verify clickhouse compatibility when this goes to dev.

<img width="454" alt="Screen Shot 2022-09-22 at 2 13 17 PM" src="https://user-images.githubusercontent.com/1704556/191852019-0fb3c6ce-4443-43f5-859b-0a2252e680a6.png">

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
