### PR TITLE
Allow running workflows as a non-root user

### DIFF
--- a/enterprise/dockerfiles/ci_runner_image/Dockerfile
+++ b/enterprise/dockerfiles/ci_runner_image/Dockerfile
@@ -10,3 +10,7 @@ RUN curl -Lo /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/rele
 # Pre-install bazel 4.1.0 to avoid bazelisk downloading & installing bazel on every
 # CI run, at least for CI runs on the BuildBuddy repo itself.
 RUN USE_BAZEL_VERSION=4.1.0 bazelisk version
+
+# Provision a non-root user named "buildbuddy".
+# Non-root users are needed for some bazel toolchains, such as hermetic python.
+RUN useradd --create-home buildbuddy

--- a/enterprise/server/cmd/ci_runner/run_local.sh
+++ b/enterprise/server/cmd/ci_runner/run_local.sh
@@ -70,7 +70,7 @@ if ! docker inspect buildbuddy-ci-runner-local &>/dev/null; then
     --detach \
     --rm \
     --name buildbuddy-ci-runner-local \
-    gcr.io/flame-public/buildbuddy-ci-runner:v2.2.8 \
+    gcr.io/flame-public/buildbuddy-ci-runner:v2.2.9 \
     sleep infinity
 fi
 

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -81,7 +81,7 @@ const (
 	CPUArchitecturePropertyName = "Arch"
 	defaultCPUArchitecture      = "amd64"
 
-	dockerUserPropertyName = "dockerUser"
+	DockerUserPropertyName = "dockerUser"
 	// Using the property defined here: https://github.com/bazelbuild/bazel-toolchains/blob/v5.1.0/rules/exec_properties/exec_properties.bzl#L164
 	dockerRunAsRootPropertyName = "dockerRunAsRoot"
 	// Using the property defined here: https://github.com/bazelbuild/bazel-toolchains/blob/v5.1.0/rules/exec_properties/exec_properties.bzl#L156
@@ -207,7 +207,7 @@ func ParseProperties(task *repb.ExecutionTask) *Properties {
 		WorkloadIsolationType:      stringProp(m, workloadIsolationPropertyName, ""),
 		InitDockerd:                boolProp(m, initDockerdPropertyName, false),
 		DockerForceRoot:            boolProp(m, dockerRunAsRootPropertyName, false),
-		DockerUser:                 stringProp(m, dockerUserPropertyName, ""),
+		DockerUser:                 stringProp(m, DockerUserPropertyName, ""),
 		DockerNetwork:              stringProp(m, dockerNetworkPropertyName, ""),
 		RecycleRunner:              boolProp(m, RecycleRunnerPropertyName, false),
 		EnableVFS:                  vfsEnabled,

--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -10,7 +10,7 @@ go_test(
     # Run the ci_runner_test in the same environment that the CI runner uses in prod,
     # since we invoke the ci runner binary directly.
     exec_properties = {
-        "container-image": "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.2.8",
+        "container-image": "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.2.9",
     },
     shard_count = 11,
     visibility = [

--- a/enterprise/server/test/integration/workflow/BUILD
+++ b/enterprise/server/test/integration/workflow/BUILD
@@ -8,7 +8,7 @@ go_test(
     # currently does not support dockerized execution of commands. So for now we
     # run the whole test using the CI runner image.
     exec_properties = {
-        "container-image": "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.2.8",
+        "container-image": "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.2.9",
     },
     shard_count = 2,
     deps = [

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -26,6 +26,7 @@ type Action struct {
 	Triggers          *Triggers `yaml:"triggers"`
 	OS                string    `yaml:"os"`
 	Arch              string    `yaml:"arch"`
+	User              string    `yaml:"user"`
 	GitCleanExclude   []string  `yaml:"git_clean_exclude"`
 	BazelWorkspaceDir string    `yaml:"bazel_workspace_dir"`
 	BazelCommands     []string  `yaml:"bazel_commands"`


### PR DESCRIPTION
* Add a `buildbuddy` user to the CI runner image
* Allow setting `user:` in the workflow config, which directly sets the `dockerUser` platform prop. For now, we will only support the "buildbuddy" user (users can explicitly specify "root" if they want, but this will have no effect). This way we're consistent with how users are provisioned for Docker/Podman -- we expect them to be provisioned in the Dockerfile, rather than creating them ourselves.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1643
