### PR TITLE
Return OutOfRangeError if replica is not found.

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -407,7 +407,7 @@ func (s *Store) GetReplica(rangeID uint64) (*replica.Replica, error) {
 	// doing a split, so we do not check for range leases here.
 	rIface, ok := s.replicas.Load(rangeID)
 	if !ok {
-		return nil, status.NotFoundErrorf("Replica %d not found", rangeID)
+		return nil, status.OutOfRangeErrorf("%s: replica for range %d not found", constants.RangeNotFoundMsg, rangeID)
 	}
 	r, ok := rIface.(*replica.Replica)
 	if !ok {


### PR DESCRIPTION
I think the following is happening during moves:
A replica is removed from a range.  Other apps still have that replica in the cached range descriptor so they keep sending requests to that node. Since the node returns NotFound errors, the clients never refresh their range descriptors.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
