### PR TITLE
Fix CLI RBE autoconfig

### DIFF
--- a/cli/autoconfig/autoconfig.go
+++ b/cli/autoconfig/autoconfig.go
@@ -157,23 +157,27 @@ func addToolchainsToWorkspaceIfNotPresent(workspaceFilePath string) {
 		return
 	}
 
+	httpArchive := `
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+`
+
 	buildbuddyToolchain := `
-		# BuildBuddy Toolchain
-		
-		http_archive(
-				name = "io_buildbuddy_buildbuddy_toolchain",
-				sha256 = "a2a5cccec251211e2221b1587af2ce43c36d32a42f5d881737db3b546a536510",
-				strip_prefix = "buildbuddy-toolchain-829c8a574f706de5c96c54ca310f139f4acda7dd",
-				urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/829c8a574f706de5c96c54ca310f139f4acda7dd.tar.gz"],
-		)
-		
-		load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
-		
-		buildbuddy_deps()
-		
-		load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "buildbuddy")
-		
-		buildbuddy(name = "buildbuddy_toolchain")
+# BuildBuddy Toolchain
+
+http_archive(
+    name = "io_buildbuddy_buildbuddy_toolchain",
+    sha256 = "a2a5cccec251211e2221b1587af2ce43c36d32a42f5d881737db3b546a536510",
+    strip_prefix = "buildbuddy-toolchain-829c8a574f706de5c96c54ca310f139f4acda7dd",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/829c8a574f706de5c96c54ca310f139f4acda7dd.tar.gz"],
+)
+
+load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
+
+buildbuddy_deps()
+
+load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "buildbuddy")
+
+buildbuddy(name = "buildbuddy_toolchain")
 `
 
 	workspaceFile, err := os.OpenFile(workspaceFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -182,6 +186,13 @@ func addToolchainsToWorkspaceIfNotPresent(workspaceFilePath string) {
 		return
 	}
 	defer workspaceFile.Close()
+
+	if !strings.Contains(string(workspaceBytes), "http_archive") {
+		if _, err := workspaceFile.WriteString(httpArchive); err != nil {
+			log.Println(err)
+		}
+	}
+
 	if _, err := workspaceFile.WriteString(buildbuddyToolchain); err != nil {
 		log.Println(err)
 	}


### PR DESCRIPTION
* Fix indentation (bazel fails to build w/ the current indentation)
* Import http_archive if not already imported

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
