### PR TITLE
Add more fields to clickhouse.Invocation

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -1362,6 +1362,12 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         sum = "h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=",
         version = "v1.0.1",
     )
+    go_repository(
+        name = "com_github_go_faker_faker_v4",
+        importpath = "github.com/go-faker/faker/v4",
+        sum = "h1:zjTxJMHn7Po7OCPKY+VjO6mNQ4ZzE7PoBjb2sUNHVPs=",
+        version = "v4.0.0-beta.3",
+    )
 
     go_repository(
         name = "com_github_go_git_gcfg",

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/docker/go-units v0.4.0
 	github.com/elastic/gosigar v0.11.0
 	github.com/firecracker-microvm/firecracker-go-sdk v0.22.1-0.20220812215434-490e3369bc97
+	github.com/go-faker/faker/v4 v4.0.0-beta.3
 	github.com/go-git/go-git/v5 v5.2.0
 	github.com/go-redis/redis/extra/redisotel/v8 v8.10.0
 	github.com/go-redis/redis/v8 v8.10.0
@@ -135,7 +136,6 @@ require (
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/getsentry/sentry-go v0.12.0 // indirect
-	github.com/go-faker/faker/v4 v4.0.0-beta.3 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.0.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -135,6 +135,7 @@ require (
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/getsentry/sentry-go v0.12.0 // indirect
+	github.com/go-faker/faker/v4 v4.0.0-beta.3 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.0.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -555,6 +555,8 @@ github.com/go-critic/go-critic v0.5.2/go.mod h1:cc0+HvdE3lFpqLecgqMaJcvWWH77sLdB
 github.com/go-critic/go-critic v0.6.1/go.mod h1:SdNCfU0yF3UBjtaZGw6586/WocupMOJuiqgom5DsQxM=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-faker/faker/v4 v4.0.0-beta.3 h1:zjTxJMHn7Po7OCPKY+VjO6mNQ4ZzE7PoBjb2sUNHVPs=
+github.com/go-faker/faker/v4 v4.0.0-beta.3/go.mod h1:uuNc0PSRxF8nMgjGrrrU4Nw5cF30Jc6Kd0/FUTTYbhg=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
 github.com/go-git/go-billy/v5 v5.0.0 h1:7NQHvd9FVid8VL4qVUMm8XifBK+2xCoZ2lSk0agRrHM=

--- a/server/util/clickhouse/BUILD
+++ b/server/util/clickhouse/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "clickhouse",
@@ -13,5 +13,17 @@ go_library(
         "@com_github_clickhouse_clickhouse_go_v2//:clickhouse-go",
         "@io_gorm_driver_clickhouse//:clickhouse",
         "@io_gorm_gorm//:gorm",
+    ],
+)
+
+go_test(
+    name = "clickhouse_test",
+    srcs = ["clickhouse_test.go"],
+    deps = [
+        ":clickhouse",
+        "//server/tables",
+        "@com_github_go_faker_faker_v4//:faker",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/util/clickhouse/clickhouse_test.go
+++ b/server/util/clickhouse/clickhouse_test.go
@@ -1,0 +1,84 @@
+package clickhouse_test
+
+import (
+	"encoding/hex"
+	"reflect"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/util/clickhouse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-faker/faker/v4"
+)
+
+func isExcluded(fieldName string, excludedFields []string) bool {
+	for _, fn := range excludedFields {
+		if fn == fieldName {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSchemaInSync(t *testing.T) {
+	chInvType := reflect.TypeOf(clickhouse.Invocation{})
+	primaryInvType := reflect.TypeOf(tables.Invocation{})
+
+	chInvFields := reflect.VisibleFields(chInvType)
+	primaryInvFields := reflect.VisibleFields(primaryInvType)
+
+	for _, chField := range chInvFields {
+		_, found := primaryInvType.FieldByName(chField.Name)
+		assert.True(t, found, "Field %q is not found in tables.Invocation", chField.Name)
+	}
+
+	excludedFields := (&clickhouse.Invocation{}).ExcludedFields()
+	for _, primaryField := range primaryInvFields {
+		if primaryField.Anonymous {
+			continue
+		}
+
+		_, found := chInvType.FieldByName(primaryField.Name)
+		isExcluded := isExcluded(primaryField.Name, excludedFields)
+		if isExcluded {
+			assert.False(t, found, "Field %q is found in clickhouse.Invocation, but it's marked as excluded", primaryField.Name)
+		} else {
+			assert.True(t, found, "Field %q is not found in clickhouse.Invocation", primaryField.Name)
+		}
+		assert.NotEqual(t, found, isExcluded, "Field %q is not found in clickhouse.Invocation", primaryField.Name)
+	}
+}
+
+func TestToInvocationFromPrimaryDB(t *testing.T) {
+	src := &tables.Invocation{}
+	err := faker.FakeData(src)
+	require.NoError(t, err)
+	dest := clickhouse.ToInvocationFromPrimaryDB(src)
+
+	primaryInvType := reflect.TypeOf(*src)
+	primaryInvFields := reflect.VisibleFields(primaryInvType)
+	srcValue := reflect.ValueOf(*src)
+	destValue := reflect.ValueOf(*dest)
+	excludedFields := (&clickhouse.Invocation{}).ExcludedFields()
+
+	expectedUUID := hex.EncodeToString(src.InvocationUUID)
+	assert.Equal(t, dest.InvocationUUID, expectedUUID, "src and dest have different values for field 'InvocationUUID'. src = %v, dest = %v", src.InvocationUUID, expectedUUID)
+
+	for _, primaryField := range primaryInvFields {
+		if isExcluded(primaryField.Name, excludedFields) || primaryField.Anonymous || primaryField.Name == "InvocationUUID" {
+			// check InvocationUUID field seperately
+			continue
+		}
+		srcFieldValue := srcValue.FieldByName(primaryField.Name)
+		destFieldValue := destValue.FieldByName(primaryField.Name)
+		require.True(t, srcFieldValue.IsValid())
+		if destFieldValue.IsValid() {
+			assert.Equal(t, srcFieldValue.Interface(), destFieldValue.Interface(), "src and dest have different values for field %q. src = %v, dest = %v", primaryField.Name, srcFieldValue, destFieldValue)
+		} else {
+			assert.Failf(t, "dest has invalid field %q", primaryField.Name)
+		}
+	}
+
+}


### PR DESCRIPTION
It's difficult to migrate additional existing columns to clickhouse after initial migration.
In this PR,
- add all the columns from Invocation to clickhouse if i think there is
a slight possibility in the future we need it in clickhouse.
- add a method "ExcludedFields", where we need to explicitly call out
the fields we don't want to store in clickhouse.
- add tests to catch future bugs where we forget to add a field in
clickhouse when we add them in Invocation.
