### PR TITLE
Revert cgroup v1 change in tools/enable_local_firecracker

### DIFF
--- a/tools/enable_local_firecracker.sh
+++ b/tools/enable_local_firecracker.sh
@@ -37,6 +37,10 @@ usermod -a -G cgroups root
 usermod -a -G cgroups "$SUDO_USER"
 
 # jailer will create stuff here; ensure the dir exists and owner is user.
+mkdir -p /sys/fs/cgroup/cpuset/firecracker
+chown -R "$SUDO_USER":cgroups /sys/fs/cgroup/cpuset/firecracker
+chmod -R g+rw /sys/fs/cgroup/cpuset/firecracker
+
 mkdir -p "$CGROUP2_PATH"/firecracker
 chown -R "$SUDO_USER":cgroups "$CGROUP2_PATH"/firecracker
 chmod -R g+rw "$CGROUP2_PATH"/firecracker


### PR DESCRIPTION
I removed these in the last PR, but turns out we do need these.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
