### PR TITLE
Upgrade all checkout actions to v3

### DIFF
--- a/.github/workflows/buildbuddy-foss.yaml
+++ b/.github/workflows/buildbuddy-foss.yaml
@@ -19,7 +19,7 @@ jobs:
           destination_repo: "https://${{ secrets.BUILDBUDDY_GITHUB_USER_TOKEN }}@github.com/buildbuddy-io/buildbuddy-foss.git"
           destination_branch: "master"
       - name: Checkout buildbuddy-foss
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: "buildbuddy-io/buildbuddy-foss"
           ref: master

--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Setup go
         uses: actions/setup-go@v2

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Checkout internal
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           repository: "buildbuddy-io/buildbuddy-internal"
           ref: "master"

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           repository: "buildbuddy-io/buildbuddy-helm"
           ref: "master"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Mount Bazel cache
         uses: actions/cache@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install bazelisk
         run: |

--- a/.github/workflows/release-m1.yaml
+++ b/.github/workflows/release-m1.yaml
@@ -14,7 +14,7 @@ jobs:
         shell: "/usr/bin/arch -arch arm64e /bin/bash --noprofile --norc -eo pipefail {0}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install bazelisk
         run: |

--- a/.github/workflows/release-mac.yaml
+++ b/.github/workflows/release-mac.yaml
@@ -11,7 +11,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'release skip')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install bazelisk
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'release skip')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install bazelisk
         run: |

--- a/.github/workflows/website-pr.yaml
+++ b/.github/workflows/website-pr.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Build Website
         run: bazel build //website:website

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Build Website
         run: |

--- a/docs/rbe-github-actions.md
+++ b/docs/rbe-github-actions.md
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Install bazelisk
       run: |


### PR DESCRIPTION
I'm running into some weird issues like "reference is not a tree" with checkout v1, which appears to be fixed in v3 ([issue](https://github.com/actions/checkout/issues/23)).

Upgrading all actions to checkout v3 so that we get this fix everywhere, and also because I noticed some issues on m1 which were only fixed by clearing out the _work dir on the runner. I suspect this might be due to some incompatibility between v1 and v3 across different action runs. Either way, upgrading everything to v3 shouldn't hurt, and will rule out version incompatibility as an issue.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
