### PR TITLE
Add install script for CLI

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+install_buildbuddy_cli() (
+  set -eo pipefail
+
+  arch=$(uname -m) # x86_64 | arm64
+  os=$(uname -s)   # Linux | Darwin
+  os=$(tr '[:upper:]' '[:lower:]' <<<"$os")
+  tempfile=$(mktemp buildbuddy.XXXXX)
+  cleanup() { rm -f "$tempfile"; }
+  trap cleanup EXIT
+
+  # Look for the line matching
+  #   "browser_download_url": "https://github.com/buildbuddy-io/bazel/releases/.../bazel-...-${os}-${arch}"
+  # and extract the URL.
+  latest_binary_url=$(
+    curl -fsSL https://api.github.com/repos/buildbuddy-io/bazel/releases/latest |
+      perl -nle 'if (/"browser_download_url":\s*"(.*?-'"${os}-${arch}"')"/) { print $1 }'
+  )
+
+  if [[ ! "$latest_binary_url" ]]; then
+    echo >&2 "Could not find a CLI release for os '$os', arch '$arch'"
+    exit 1
+  fi
+
+  echo >&2 "Downloading $latest_binary_url"
+  curl -fSL "$latest_binary_url" -o "$tempfile"
+  chmod 0755 "$tempfile"
+  echo >&2 "Will write the CLI to /usr/local/bin - this may ask for your password."
+  sudo mv "$tempfile" /usr/local/bin/bb
+)
+
+install_buildbuddy_cli


### PR DESCRIPTION
Adapted from https://github.com/buildbuddy-io/buildbuddy-cli/tree/master/install.sh but works with the new releases over in https://github.com/buildbuddy-io/bazel/releases

Tested linux-amd64 and darwin-arm64

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
