### PR TITLE
Add method that parses .bazelrc files to a list of effective args

### DIFF
--- a/cli/logging/logging.go
+++ b/cli/logging/logging.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	verbose = flag.Bool("bb_verbose", true, "If true, enable verbose buildbuddy logging.")
+	verbose = flag.Bool("bb_verbose", false, "If true, enable verbose buildbuddy logging.")
 )
 
 func Printf(format string, v ...interface{}) {

--- a/cli/parser/BUILD
+++ b/cli/parser/BUILD
@@ -5,5 +5,8 @@ go_library(
     srcs = ["parser.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/parser",
     visibility = ["//visibility:public"],
-    deps = ["//cli/logging"],
+    deps = [
+        "//cli/arg",
+        "//cli/logging",
+    ],
 )

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
-	
+
 	bblog "github.com/buildbuddy-io/buildbuddy/cli/logging"
 )
 

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	"io"
 	"os"
+	"os/user"
 	"path/filepath"
 	"regexp"
 	"strings"
 
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	bblog "github.com/buildbuddy-io/buildbuddy/cli/logging"
 )
 
@@ -115,4 +117,53 @@ func GetFlagValue(options []*BazelOption, phase, config, flagName, commandLineOv
 		}
 	}
 	return ""
+}
+
+func GetArgsFromRCFiles(commandLineArgs []string) []string {
+	rcFiles := make([]string, 0)
+	if arg.Get(commandLineArgs, "system_rc") != "true" {
+		rcFiles = append(rcFiles, "/etc/bazel.bazelrc")
+		rcFiles = append(rcFiles, "%ProgramData%\bazel.bazelrc")
+	}
+	if arg.Get(commandLineArgs, "workspace_rc") != "true" {
+		rcFiles = append(rcFiles, ".bazelrc")
+	}
+	if arg.Get(commandLineArgs, "home_rc") != "true" {
+		usr, err := user.Current()
+		if err == nil {
+			rcFiles = append(rcFiles, filepath.Join(usr.HomeDir, ".bazelrc"))
+		}
+	}
+	if b := arg.Get(commandLineArgs, "bazelrc"); b != "" {
+		rcFiles = append(rcFiles, b)
+	}
+	opts, err := ParseRCFiles(rcFiles...)
+	if err != nil {
+		bblog.Printf("Error parsing .bazelrc file: %s", err.Error())
+		return nil
+	}
+
+	config := arg.Get(commandLineArgs, "config")
+	command := arg.GetCommand(commandLineArgs)
+
+	rcFileArgs := make([]string, 0)
+	rcFileArgs = appendArgsForConfig(opts, rcFileArgs, command, config)
+
+	bblog.Printf("rcFileArgs: %+v", rcFileArgs)
+
+	return rcFileArgs
+}
+
+func appendArgsForConfig(opts []*BazelOption, args []string, command, config string) []string {
+	for _, o := range opts {
+		if o.Phase != command || o.Config != config {
+			continue
+		}
+		if strings.HasPrefix(o.Option, "--config=") {
+			args = appendArgsForConfig(opts, args, command, strings.TrimPrefix(o.Option, "--config="))
+		} else {
+			args = append(args, o.Option)
+		}
+	}
+	return args
 }

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	
 	bblog "github.com/buildbuddy-io/buildbuddy/cli/logging"
 )
 
@@ -134,6 +135,7 @@ func GetArgsFromRCFiles(commandLineArgs []string) []string {
 			rcFiles = append(rcFiles, filepath.Join(usr.HomeDir, ".bazelrc"))
 		}
 	}
+	// TODO(siggisim): Handle multiple bazlerc params.
 	if b := arg.Get(commandLineArgs, "bazelrc"); b != "" {
 		rcFiles = append(rcFiles, b)
 	}


### PR DESCRIPTION
This is based on logic that currently lives here, but will be removed:
https://github.com/buildbuddy-io/buildbuddy/blob/master/cli/cmd/bb/bb.go#L61

Also makes logging non-verbose by default.

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
