### PR TITLE
Clean up CLI main

### DIFF
--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -9,17 +9,13 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/cmd/bb",
     visibility = ["//visibility:private"],
     deps = [
-        "//cli/autoconfig",
+        "//cli/arg",
         "//cli/bazelisk",
-        "//cli/commandline",
-        "//cli/logging",
         "//cli/parser",
         "//cli/remotebazel",
         "//cli/sidecar",
-        "//cli/storage",
-        "//proto:sidecar_go_proto",
-        "//server/util/grpc_client",
-        "//server/version",
+        "//cli/tooltag",
+        "//cli/version",
     ],
 )
 

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -1,208 +1,37 @@
 package main
 
 import (
-	"context"
 	"flag"
-	"fmt"
-	"log"
 	"os"
-	"os/user"
-	"path/filepath"
-	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/cli/autoconfig"
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
-	"github.com/buildbuddy-io/buildbuddy/cli/commandline"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 	"github.com/buildbuddy-io/buildbuddy/cli/remotebazel"
 	"github.com/buildbuddy-io/buildbuddy/cli/sidecar"
-	"github.com/buildbuddy-io/buildbuddy/cli/storage"
-	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
-	"github.com/buildbuddy-io/buildbuddy/server/version"
-
-	bblog "github.com/buildbuddy-io/buildbuddy/cli/logging"
-	scpb "github.com/buildbuddy-io/buildbuddy/proto/sidecar"
+	"github.com/buildbuddy-io/buildbuddy/cli/tooltag"
+	"github.com/buildbuddy-io/buildbuddy/cli/version"
 )
-
-var (
-	disable = flag.Bool("disable_buildbuddy", false, "If true, disable buildbuddy functionality and just run bazel.")
-)
-
-func die(exitCode int, err error) {
-	if err != nil {
-		log.Fatal(err)
-	}
-	os.Exit(exitCode)
-}
-
-func runBazelAndDie(ctx context.Context, bazelArgs *commandline.BazelArgs, opts *autoconfig.BazelOpts) {
-	if opts.EnableRemoteBazel {
-		repoConfig, err := remotebazel.Config(".")
-		if err != nil {
-			log.Fatalf("config err: %s", err)
-		}
-
-		exitCode, err := remotebazel.Run(ctx, remotebazel.RunOpts{
-			Server:            opts.BuildBuddyEndpoint,
-			APIKey:            opts.APIKey,
-			Args:              bazelArgs,
-			WorkspaceFilePath: opts.WorkspaceFilePath,
-			SidecarSocket:     opts.SidecarSocket,
-		}, repoConfig)
-		if err != nil {
-			die(1, err)
-		}
-		die(exitCode, nil)
-	}
-
-	bazelisk.Run(bazelArgs.ExecArgs())
-}
-
-func parseBazelRCs(bazelFlags *commandline.BazelFlags) []*parser.BazelOption {
-	rcFiles := make([]string, 0)
-	if !bazelFlags.NoSystemRC {
-		rcFiles = append(rcFiles, "/etc/bazel.bazelrc")
-		rcFiles = append(rcFiles, "%ProgramData%\bazel.bazelrc")
-	}
-	if !bazelFlags.NoWorkspaceRC {
-		rcFiles = append(rcFiles, ".bazelrc")
-	}
-	if !bazelFlags.NoHomeRC {
-		usr, err := user.Current()
-		if err == nil {
-			rcFiles = append(rcFiles, filepath.Join(usr.HomeDir, ".bazelrc"))
-		}
-	}
-	if bazelFlags.BazelRC != "" {
-		rcFiles = append(rcFiles, bazelFlags.BazelRC)
-	}
-	opts, err := parser.ParseRCFiles(rcFiles...)
-	if err != nil {
-		bblog.Printf("Error parsing .bazelrc file: %s", err.Error())
-		return nil
-	}
-	return opts
-
-}
-
-// keepaliveSidecar validates the connection to the sidecar and keeps the
-// sidecar alive as long as this process is alive by issuing background ping
-// requests.
-func keepaliveSidecar(ctx context.Context, sidecarSocket string) error {
-	conn, err := grpc_client.DialTarget("unix://" + sidecarSocket)
-	if err != nil {
-		return err
-	}
-	s := scpb.NewSidecarClient(conn)
-	connected := make(chan struct{})
-	go func() {
-		connectionValidated := false
-		for {
-			_, err := s.Ping(ctx, &scpb.PingRequest{})
-			if connectionValidated && err != nil {
-				bblog.Printf("sidecar did not respond to ping request: %s\n", err)
-				return
-			}
-			if !connectionValidated && err == nil {
-				close(connected)
-				connectionValidated = true
-			}
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(1 * time.Second):
-			}
-		}
-	}()
-	select {
-	case <-connected:
-		return nil
-	case <-time.After(5 * time.Second):
-		return fmt.Errorf("could not connect to sidecar")
-	}
-}
 
 func main() {
-	// Parse any flags (and remove them so bazel isn't confused).
-	bazelArgs := commandline.ParseFlagsAndRewriteArgs(os.Args[1:])
+	flag.Parse()
 
-	ctx := context.Background()
+	// Parse args
+	commandLineArgs := os.Args[1:]
+	rcFileArgs := parser.GetArgsFromRCFiles(commandLineArgs)
+	args := append(commandLineArgs, rcFileArgs...)
 
-	if *disable {
-		bblog.Printf("Buildbuddy was disabled, just running bazel.")
-		runBazelAndDie(ctx, bazelArgs, &autoconfig.BazelOpts{})
-	}
+	// Fiddle with args
+	args = tooltag.ConfigureToolTag(args)
+	args = sidecar.ConfigureSidecar(args)
 
-	// Make sure we have a home directory to work in.
-	bbHome, err := storage.Dir()
-	if err != nil {
-		die(-1, err)
-	}
+	// Handle commands
+	args = remotebazel.HandleRemoteBazel(args)
+	args = version.HandleVersion(args)
 
-	bazelFlags := commandline.ExtractBazelFlags(bazelArgs.Filtered)
-	autoconfOpts, err := autoconfig.Configure(ctx, bazelFlags)
-	if err != nil {
-		die(-1, err)
-	}
-	bazelArgs.Add(autoconfOpts.ExtraArgs...)
-	opts := parseBazelRCs(bazelFlags)
+	// Remove any args that don't need to be on the command line
+	args = arg.RemoveExistingArgs(args, rcFileArgs)
 
-	// Determine if cache or BES options are set.
-	subcommand := commandline.GetSubCommand(bazelArgs.Filtered)
-	besBackendFlag := parser.GetFlagValue(opts, subcommand, bazelFlags.Config, "--bes_backend", autoconfOpts.BESBackendOverride)
-	remoteCacheFlag := parser.GetFlagValue(opts, subcommand, bazelFlags.Config, "--remote_cache", autoconfOpts.RemoteCacheOverride)
-	remoteExecFlag := parser.GetFlagValue(opts, subcommand, bazelFlags.Config, "--remote_executor", autoconfOpts.RemoteExecutorOverride)
-
-	bazelArgs.Add("--tool_tag=buildbuddy-cli")
-
-	if subcommand == "version" {
-		fmt.Printf("bb %s\n", version.AppVersion())
-	}
-	if besBackendFlag == "" && remoteCacheFlag == "" {
-		runBazelAndDie(ctx, bazelArgs, autoconfOpts)
-	}
-
-	bblog.Printf("--bes_backend was %q", besBackendFlag)
-	bblog.Printf("--remote_cache was %q", remoteCacheFlag)
-	bblog.Printf("--remote_executor was %q", remoteExecFlag)
-
-	if err := sidecar.ExtractBundledSidecar(ctx, bbHome); err != nil {
-		bblog.Printf("Error extracting sidecar: %s", err)
-	}
-	// Re(Start) the sidecar if the flags set don't match.
-	sidecarArgs := make([]string, 0)
-	if besBackendFlag != "" {
-		sidecarArgs = append(sidecarArgs, besBackendFlag)
-	}
-	if remoteCacheFlag != "" && remoteExecFlag == "" {
-		sidecarArgs = append(sidecarArgs, remoteCacheFlag)
-		// Also specify as disk cache directory.
-		diskCacheDir := filepath.Join(bbHome, "filecache")
-		sidecarArgs = append(sidecarArgs, fmt.Sprintf("--cache_dir=%s", diskCacheDir))
-	}
-
-	if len(sidecarArgs) > 0 {
-		sidecarSocket, err := sidecar.RestartSidecarIfNecessary(ctx, bbHome, sidecarArgs)
-		if err == nil {
-			err = keepaliveSidecar(ctx, sidecarSocket)
-		}
-		if err == nil {
-			if !autoconfOpts.EnableRemoteBazel {
-				if besBackendFlag != "" {
-					bazelArgs.Add(fmt.Sprintf("--bes_backend=unix://%s", sidecarSocket))
-				}
-				if remoteCacheFlag != "" && remoteExecFlag == "" {
-					bazelArgs.Add(fmt.Sprintf("--remote_cache=unix://%s", sidecarSocket))
-				}
-				if remoteExecFlag != "" {
-					bazelArgs.Add(remoteExecFlag)
-				}
-			}
-			autoconfOpts.SidecarSocket = sidecarSocket
-		} else {
-			log.Printf("Sidecar could not be initialized, continuing without sidecar: %s", err)
-		}
-	}
-	bblog.Printf("Rewrote bazel command line to: %s", bazelArgs)
-	runBazelAndDie(ctx, bazelArgs, autoconfOpts)
+	// Actually run bazel
+	bazelisk.Run(args)
 }

--- a/cli/cmd/sidecar/BUILD
+++ b/cli/cmd/sidecar/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//cli/cache_proxy",
         "//cli/devnull",
+        "//cli/logging",
         "//proto:publish_build_event_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:sidecar_go_proto",

--- a/cli/logging/logging.go
+++ b/cli/logging/logging.go
@@ -15,3 +15,11 @@ func Printf(format string, v ...interface{}) {
 	}
 	log.Printf(format, v...)
 }
+
+func Fatalf(format string, v ...interface{}) {
+	log.Fatalf(format, v...)
+}
+
+func Fatal(format string) {
+	log.Fatal(format)
+}

--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/remotebazel",
     visibility = ["//visibility:public"],
     deps = [
-        "//cli/commandline",
+        "//cli/arg",
         "//cli/logging",
         "//enterprise/server/remote_execution/dirtools",
         "//proto:build_event_stream_go_proto",
@@ -19,6 +19,7 @@ go_library(
         "//server/real_environment",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
+        "//server/util/bazel",
         "//server/util/grpc_client",
         "//server/util/healthcheck",
         "//server/util/status",

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"flag"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"os/exec"
@@ -16,12 +17,13 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/buildbuddy-io/buildbuddy/cli/commandline"
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/dirtools"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/bazel"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -47,6 +49,7 @@ const (
 	escapeSeq                  = "\u001B["
 	gitConfigSection           = "buildbuddy"
 	gitConfigRemoteBazelRemote = "remote-bazel-remote-name"
+	defaultRemoteExecutionURL  = "remote.buildbuddy.io"
 )
 
 var (
@@ -70,7 +73,7 @@ func consoleDeleteLines(n int) {
 type RunOpts struct {
 	Server            string
 	APIKey            string
-	Args              *commandline.BazelArgs
+	Args              []string
 	WorkspaceFilePath string
 	SidecarSocket     string
 }
@@ -502,9 +505,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 
 	fetchOutputs := false
 	runOutput := false
-	var bazelArgs []string
-	bazelArgs = append(bazelArgs, opts.Args.Filtered...)
-	bazelArgs = append(bazelArgs, opts.Args.Added...)
+	bazelArgs := arg.GetNonPassthroughArgs(opts.Args)
 	if len(bazelArgs) > 0 && (bazelArgs[0] == "build" || bazelArgs[0] == "run") {
 		fetchOutputs = true
 		if bazelArgs[0] == "run" {
@@ -576,7 +577,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 	}
 
 	if fetchOutputs && exitCode == 0 {
-		conn, err := grpc_client.DialTarget("unix://" + opts.SidecarSocket)
+		conn, err := grpc_client.DialTarget(opts.SidecarSocket)
 		if err != nil {
 			return 0, fmt.Errorf("could not communicate with sidecar: %s", err)
 		}
@@ -603,7 +604,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 			}
 			execArgs := defaultRunArgs
 			// Pass through extra arguments (-- --foo=bar) from the command line.
-			execArgs = append(execArgs, opts.Args.Passthrough...)
+			execArgs = append(execArgs, arg.GetPassthroughArgs(opts.Args)...)
 			bblog.Printf("Executing %q with arguments %s", binPath, execArgs)
 			cmd := exec.CommandContext(ctx, binPath, execArgs...)
 			cmd.Dir = filepath.Join(outputsBaseDir, buildBuddyArtifactDir, runfilesRoot)
@@ -618,4 +619,53 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 	}
 
 	return exitCode, nil
+}
+
+func handleRemoteBazel(args []string) []string {
+	sidecarSocket := arg.Get(args, "bes_backend")
+
+	args = arg.Remove(args, "bes_backend")
+	args = arg.Remove(args, "remote_cache")
+	args = arg.Remove(args, "remote_executor")
+	args = arg.Remove(args, "jobs")
+
+	args = append(args, "--bes_backend="+defaultRemoteExecutionURL)
+	args = append(args, "--remote_cache="+defaultRemoteExecutionURL)
+	args = append(args, "--remote_executor="+defaultRemoteExecutionURL)
+	args = append(args, "--jobs=100")
+
+	ctx := context.Background()
+	repoConfig, err := Config(".")
+	if err != nil {
+		log.Fatalf("config err: %s", err)
+	}
+
+	wsFilePath, err := bazel.FindWorkspaceFile(".")
+	if err != nil {
+		log.Fatalf("error finding workspace: %s", err)
+	}
+	exitCode, err := Run(ctx, RunOpts{
+		Server:            "grpcs://"+defaultRemoteExecutionURL,
+		APIKey:            arg.Get(args, "remote_header=x-buildbuddy-api-key"),
+		Args:              args,
+		WorkspaceFilePath: wsFilePath,
+		SidecarSocket:     sidecarSocket,
+	}, repoConfig)
+	if err != nil {
+		log.Fatalf("error running remote bazel: %s", err)
+	}
+
+	os.Exit(exitCode)
+	return args
+}
+
+
+func HandleRemoteBazel(args []string) []string {
+	if c, i := arg.GetCommandAndIndex(args); c == "remote" {
+		return handleRemoteBazel(args[i+1:])
+	}
+	if arg, rest := arg.Pop(args, "remote"); arg == "true" {
+		return handleRemoteBazel(rest)
+	}
+	return args
 }

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -645,7 +645,7 @@ func handleRemoteBazel(args []string) []string {
 		log.Fatalf("error finding workspace: %s", err)
 	}
 	exitCode, err := Run(ctx, RunOpts{
-		Server:            "grpcs://"+defaultRemoteExecutionURL,
+		Server:            "grpcs://" + defaultRemoteExecutionURL,
 		APIKey:            arg.Get(args, "remote_header=x-buildbuddy-api-key"),
 		Args:              args,
 		WorkspaceFilePath: wsFilePath,
@@ -658,7 +658,6 @@ func handleRemoteBazel(args []string) []string {
 	os.Exit(exitCode)
 	return args
 }
-
 
 func HandleRemoteBazel(args []string) []string {
 	if c, i := arg.GetCommandAndIndex(args); c == "remote" {

--- a/cli/sidecar/BUILD
+++ b/cli/sidecar/BUILD
@@ -6,9 +6,13 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/sidecar",
     visibility = ["//visibility:public"],
     deps = [
+        "//cli/arg",
         "//cli/download",
         "//cli/logging",
         "//cli/sidecar_bundle",
+        "//cli/storage",
+        "//proto:sidecar_go_proto",
+        "//server/util/grpc_client",
         "@org_golang_x_mod//semver",
     ],
 )

--- a/cli/tooltag/BUILD
+++ b/cli/tooltag/BUILD
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "tooltag",
+    srcs = ["tooltag.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/tooltag",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cli/arg",
+    ],
+)

--- a/cli/tooltag/tooltag.go
+++ b/cli/tooltag/tooltag.go
@@ -1,0 +1,12 @@
+package tooltag
+
+import (
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+)
+
+func ConfigureToolTag(args []string) []string {
+	if !arg.Has(args, "tool_tag") {
+		return append(args, "--tool_tag=buildbuddy-cli")
+	}
+	return args
+}

--- a/cli/version/BUILD
+++ b/cli/version/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "version",
+    srcs = ["version.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/version",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cli/arg",
+        "//server/version",
+    ],
+)

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -1,0 +1,16 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/server/version"
+)
+
+func HandleVersion(args []string) []string {
+	if arg.GetCommand(args) != "version" {
+		return args
+	}
+	fmt.Printf("bb %s\n", version.AppVersion())
+	return args
+}


### PR DESCRIPTION
This makes the main of CLI only responsible for manipulating args.
- Moves sidecar configuration into sidecar
- Moves remote bazel configuration into remotebazel
- Pulls `bazel version` handling into its own package
- Pulls tooltag setting into its own package

This drops any RBE / remote cache / BES autoconfiguration, which I think we should think about more carefully before adding back.

Will delete code that this makes obsolete in a separate PR.

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
