### PR TITLE
Clean up logging in CLI

### DIFF
--- a/cli/bazelisk/BUILD
+++ b/cli/bazelisk/BUILD
@@ -9,7 +9,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/bazelisk",
     visibility = ["//visibility:public"],
     deps = [
-        "//cli/logging",
+        "//cli/log",
         "//cli/workspace",
         "//server/util/disk",
         "//server/util/status",

--- a/cli/bazelisk/bazelisk.go
+++ b/cli/bazelisk/bazelisk.go
@@ -2,18 +2,16 @@ package bazelisk
 
 import (
 	"context"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/bazelbuild/bazelisk/core"
 	"github.com/bazelbuild/bazelisk/repositories"
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-
-	bblog "github.com/buildbuddy-io/buildbuddy/cli/logging"
 )
 
 func Run(args []string) {
@@ -21,10 +19,10 @@ func Run(args []string) {
 	// the next version appearing in the .bazelversion file so that bazelisk
 	// doesn't just invoke us again (resulting in an infinite loop).
 	if err := setBazelVersion(); err != nil {
-		log.Fatal(err)
+		log.Fatalf("failed to set bazel version: %s", err)
 	}
 
-	bblog.Printf("Calling bazelisk with %+v", args)
+	log.Debugf("Calling bazelisk with %+v", args)
 
 	gcs := &repositories.GCSRepo{}
 	gitHub := repositories.CreateGitHubRepo(core.GetEnvOrConfig("BAZELISK_GITHUB_TOKEN"))
@@ -33,7 +31,7 @@ func Run(args []string) {
 
 	exitCode, err := core.RunBazelisk(args, repos)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("error running bazelisk: %s", err)
 	}
 
 	os.Exit(exitCode)

--- a/cli/cmd/sidecar/BUILD
+++ b/cli/cmd/sidecar/BUILD
@@ -8,7 +8,7 @@ go_library(
     deps = [
         "//cli/cache_proxy",
         "//cli/devnull",
-        "//cli/logging",
+        "//cli/log",
         "//proto:publish_build_event_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:sidecar_go_proto",

--- a/cli/cmd/sidecar/sidecar.go
+++ b/cli/cmd/sidecar/sidecar.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/cli/cache_proxy"
 	"github.com/buildbuddy-io/buildbuddy/cli/devnull"
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/disk_cache"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_proxy"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_server"
@@ -23,7 +24,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
-	bblog "github.com/buildbuddy-io/buildbuddy/cli/logging"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/sidecar"
@@ -132,9 +132,9 @@ func initializeGRPCServer(env *real_environment.RealEnv) (*grpc.Server, net.List
 		lis, err = net.Listen("tcp", *listenAddr)
 	}
 	if err != nil {
-		bblog.Fatalf("Failed to listen: %s", err.Error())
+		log.Fatalf("Failed to listen: %s", err.Error())
 	}
-	bblog.Printf("gRPC listening on %q", *listenAddr)
+	log.Debugf("gRPC listening on %q", *listenAddr)
 	grpcOptions := []grpc.ServerOption{
 		rpcfilters.GetUnaryInterceptor(env),
 		rpcfilters.GetStreamInterceptor(env),
@@ -151,13 +151,13 @@ func registerBESProxy(env *real_environment.RealEnv, grpcServer *grpc.Server) {
 	besTarget := normalizeGrpcTarget(*besBackend)
 	buildEventProxyClients := make([]pepb.PublishBuildEventClient, 0)
 	buildEventProxyClients = append(buildEventProxyClients, build_event_proxy.NewBuildEventProxyClient(env, besTarget))
-	bblog.Printf("Proxy: forwarding build events to: %q", besTarget)
+	log.Debugf("Proxy: forwarding build events to: %q", besTarget)
 	env.SetBuildEventProxyClients(buildEventProxyClients)
 
 	// Register to handle build event protocol messages.
 	buildEventServer, err := build_event_server.NewBuildEventProtocolServer(env)
 	if err != nil {
-		bblog.Fatalf("Error initializing BuildEventProtocolServer: %s", err.Error())
+		log.Fatalf("Error initializing BuildEventProtocolServer: %s", err.Error())
 	}
 	pepb.RegisterPublishBuildEventServer(grpcServer, buildEventServer)
 }
@@ -166,11 +166,11 @@ func registerCacheProxy(ctx context.Context, env *real_environment.RealEnv, grpc
 	cacheTarget := normalizeGrpcTarget(*remoteCache)
 	conn, err := grpc_client.DialTarget(cacheTarget)
 	if err != nil {
-		bblog.Fatalf("Error dialing remote cache: %s", err.Error())
+		log.Fatalf("Error dialing remote cache: %s", err.Error())
 	}
 	cacheProxy, err := cache_proxy.NewCacheProxy(ctx, env, conn)
 	if err != nil {
-		bblog.Fatalf("Error initializing cache proxy: %s", err.Error())
+		log.Fatalf("Error initializing cache proxy: %s", err.Error())
 	}
 	bspb.RegisterByteStreamServer(grpcServer, cacheProxy)
 	repb.RegisterActionCacheServer(grpcServer, cacheProxy)
@@ -198,7 +198,7 @@ func initializeDiskCache(env *real_environment.RealEnv) {
 	}
 	c, err := disk_cache.NewDiskCache(env, &disk_cache.Options{RootDirectory: *cacheDir}, maxSizeBytes)
 	if err != nil {
-		bblog.Fatalf("Error configuring cache: %s", err)
+		log.Fatalf("Error configuring cache: %s", err)
 	}
 	env.SetCache(c)
 }
@@ -228,7 +228,7 @@ func main() {
 		registerCacheProxy(ctx, env, grpcServer)
 	}
 	if *besBackend == "" && *remoteCache == "" {
-		bblog.Fatal("No services configured. At least one of --bes_backend or --remote_cache must be provided!")
+		log.Fatal("No services configured. At least one of --bes_backend or --remote_cache must be provided!")
 	}
 
 	scpb.RegisterSidecarServer(grpcServer, &sidecarService{})

--- a/cli/log/BUILD
+++ b/cli/log/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "log",
+    srcs = ["log.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/log",
+    visibility = ["//visibility:public"],
+)

--- a/cli/log/log.go
+++ b/cli/log/log.go
@@ -1,4 +1,4 @@
-package logging
+package log
 
 import (
 	"flag"
@@ -8,6 +8,13 @@ import (
 var (
 	verbose = flag.Bool("bb_verbose", false, "If true, enable verbose buildbuddy logging.")
 )
+
+func Debugf(format string, v ...interface{}) {
+	if !*verbose {
+		return
+	}
+	log.Printf(format, v...)
+}
 
 func Printf(format string, v ...interface{}) {
 	if !*verbose {

--- a/cli/log/log.go
+++ b/cli/log/log.go
@@ -17,9 +17,6 @@ func Debugf(format string, v ...interface{}) {
 }
 
 func Printf(format string, v ...interface{}) {
-	if !*verbose {
-		return
-	}
 	log.Printf(format, v...)
 }
 

--- a/cli/logging/BUILD
+++ b/cli/logging/BUILD
@@ -1,8 +1,0 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
-
-go_library(
-    name = "logging",
-    srcs = ["logging.go"],
-    importpath = "github.com/buildbuddy-io/buildbuddy/cli/logging",
-    visibility = ["//visibility:public"],
-)

--- a/cli/parser/BUILD
+++ b/cli/parser/BUILD
@@ -7,6 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cli/arg",
-        "//cli/logging",
+        "//cli/log",
     ],
 )

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -10,8 +10,7 @@ import (
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
-
-	bblog "github.com/buildbuddy-io/buildbuddy/cli/logging"
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
 )
 
 var (
@@ -73,7 +72,7 @@ func appendOptionsFromFile(in io.Reader, opts []*BazelOption) ([]*BazelOption, e
 			match := importMatcher.FindStringSubmatch(line)
 			opts, err = appendOptionsFromImport(match, opts)
 			if err != nil {
-				bblog.Printf("Error parsing import: %s", err.Error())
+				log.Debugf("Error parsing import: %s", err.Error())
 			}
 			continue
 		}
@@ -141,7 +140,7 @@ func GetArgsFromRCFiles(commandLineArgs []string) []string {
 	}
 	opts, err := ParseRCFiles(rcFiles...)
 	if err != nil {
-		bblog.Printf("Error parsing .bazelrc file: %s", err.Error())
+		log.Debugf("Error parsing .bazelrc file: %s", err.Error())
 		return nil
 	}
 
@@ -151,7 +150,7 @@ func GetArgsFromRCFiles(commandLineArgs []string) []string {
 	rcFileArgs := make([]string, 0)
 	rcFileArgs = appendArgsForConfig(opts, rcFileArgs, command, config)
 
-	bblog.Printf("rcFileArgs: %+v", rcFileArgs)
+	log.Debugf("rcFileArgs: %+v", rcFileArgs)
 
 	return rcFileArgs
 }

--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cli/arg",
-        "//cli/logging",
+        "//cli/log",
         "//enterprise/server/remote_execution/dirtools",
         "//proto:build_event_stream_go_proto",
         "//proto:buildbuddy_service_go_proto",

--- a/cli/sidecar/BUILD
+++ b/cli/sidecar/BUILD
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cli/arg",
-        "//cli/logging",
+        "//cli/log",
         "//cli/sidecar_bundle",
         "//cli/storage",
         "//proto:sidecar_go_proto",

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,7 +12,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
-	bblog "github.com/buildbuddy-io/buildbuddy/cli/logging"
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/sidecar_bundle"
 	"github.com/buildbuddy-io/buildbuddy/cli/storage"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
@@ -76,7 +75,7 @@ func pathExists(p string) bool {
 
 func startBackgroundProcess(cmd string, args []string) error {
 	c := exec.Command(cmd, args...)
-	bblog.Printf("running sidecar cmd: %s", c.String())
+	log.Debugf("running sidecar cmd: %s", c.String())
 	return c.Start()
 }
 
@@ -90,7 +89,7 @@ func restartSidecarIfNecessary(ctx context.Context, bbHomeDir string, args []str
 	// Check if a process is already running with this sock.
 	// If one is, we're all done!
 	if pathExists(sockPath) {
-		bblog.Printf("sidecar with args %s is already listening at %q.", args, sockPath)
+		log.Debugf("sidecar with args %s is already listening at %q.", args, sockPath)
 		return sockPath, nil
 	}
 
@@ -109,7 +108,7 @@ func ConfigureSidecar(args []string) []string {
 		log.Printf("Sidecar could not be initialized, continuing without sidecar: %s", err)
 	}
 	if err := extractBundledSidecar(ctx, bbHome); err != nil {
-		bblog.Printf("Error extracting sidecar: %s", err)
+		log.Printf("Error extracting sidecar: %s", err)
 	}
 
 	// Re(Start) the sidecar if the flags set don't match.
@@ -164,7 +163,7 @@ func keepaliveSidecar(ctx context.Context, sidecarSocket string) error {
 		for {
 			_, err := s.Ping(ctx, &scpb.PingRequest{})
 			if connectionValidated && err != nil {
-				bblog.Printf("sidecar did not respond to ping request: %s\n", err)
+				log.Debugf("sidecar did not respond to ping request: %s\n", err)
 				return
 			}
 			if !connectionValidated && err == nil {


### PR DESCRIPTION
Rename logging => log so we don't have to use bblog everywhere.

Differentiate between debug logs (that don't get printed unless verbose) and non-debug logs.

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
