### PR TITLE
CLI: Add support for remote plugins

### DIFF
--- a/cli/plugin/BUILD
+++ b/cli/plugin/BUILD
@@ -6,8 +6,11 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/plugin",
     visibility = ["//visibility:public"],
     deps = [
+        "//cli/log",
+        "//cli/storage",
         "//cli/workspace",
         "//server/util/disk",
+        "//server/util/git",
         "//server/util/status",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -3,13 +3,18 @@ package plugin
 import (
 	"bytes"
 	"context"
+	"io"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
+	"github.com/buildbuddy-io/buildbuddy/cli/storage"
 	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
+	"github.com/buildbuddy-io/buildbuddy/server/util/git"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"gopkg.in/yaml.v2"
 )
@@ -18,6 +23,9 @@ const (
 	// Path where we expect to find the plugin configuration, relative to the
 	// root of the Bazel workspace in which the CLI is invoked.
 	configPath = "buildbuddy.yaml"
+
+	// Path under the CLI storage dir where plugins are saved.
+	pluginsStorageDirName = "plugins"
 )
 
 type BuildBuddyConfig struct {
@@ -42,12 +50,14 @@ func readConfig() (*BuildBuddyConfig, error) {
 	f, err := os.Open(filepath.Join(ws, configPath))
 	if err != nil {
 		if os.IsNotExist(err) {
+			log.Debugf("%s not found in %s", configPath, ws)
 			return nil, nil
 		}
 		return nil, err
 	}
 	defer f.Close()
 
+	log.Debugf("Reading %s", f.Name())
 	cfg := &BuildBuddyConfig{}
 	if err := yaml.NewDecoder(f).Decode(cfg); err != nil {
 		return nil, status.UnknownErrorf("failed to parse %s: %s", f.Name(), err)
@@ -74,9 +84,61 @@ func LoadAll() ([]*Plugin, error) {
 		if err := plugin.load(); err != nil {
 			return nil, err
 		}
+		if err := plugin.validate(); err != nil {
+			return nil, err
+		}
 		plugins = append(plugins, plugin)
 	}
 	return plugins, nil
+}
+
+// RepoURL returns the normalized repo URL. It does not include the ref part of
+// the URL. For example, a "repo" spec of "foo/bar@abc123" returns
+// "https://github.com/foo/bar".
+func (p *Plugin) RepoURL() string {
+	if p.config.Repo == "" {
+		return ""
+	}
+	repo, _ := p.splitRepoRef()
+	segments := strings.Split(repo, "/")
+	// Auto-convert owner/repo to https://github.com/owner/repo
+	if len(segments) == 2 {
+		repo = "https://github.com/" + repo
+	}
+	u, err := git.NormalizeRepoURL(repo)
+	if err != nil {
+		return ""
+	}
+	return u.String()
+}
+
+func (p *Plugin) splitRepoRef() (string, string) {
+	refParts := strings.Split(p.config.Repo, "@")
+	if len(refParts) == 2 {
+		return refParts[0], refParts[1]
+	}
+	if len(refParts) > 0 {
+		return refParts[0], ""
+	}
+	return "", ""
+}
+
+func (p *Plugin) repoClonePath() (string, error) {
+	storagePath, err := storage.Dir()
+	if err != nil {
+		return "", err
+	}
+	u, err := url.Parse(p.RepoURL())
+	if err != nil {
+		return "", err
+	}
+	_, ref := p.splitRepoRef()
+	refSubdir := "latest"
+	if ref != "" {
+		refSubdir = filepath.Join("ref", ref)
+	}
+	fullPath := filepath.Join(storagePath, pluginsStorageDirName, u.Host, u.Path, refSubdir)
+	return fullPath, nil
 }
 
 // load downloads the plugin from the specified repo, if applicable.
@@ -84,13 +146,80 @@ func (p *Plugin) load() error {
 	if p.config.Repo == "" {
 		return nil
 	}
-	return status.UnimplementedError("repository plugins are not yet implemented")
+
+	if p.RepoURL() == "" {
+		return status.InvalidArgumentErrorf(`could not parse plugin repo URL %q: expecting "[HOST/]OWNER/REPO[@REVISION]"`, p.config.Repo)
+	}
+	path, err := p.repoClonePath()
+	if err != nil {
+		return err
+	}
+	exists, err := disk.FileExists(context.TODO(), filepath.Join(path, ".git"))
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	log.Printf("Downloading %q", p.RepoURL())
+	stderr := &bytes.Buffer{}
+	clone := exec.Command("git", "clone", p.RepoURL(), path)
+	clone.Stderr = stderr
+	clone.Stdout = io.Discard
+	if err := clone.Run(); err != nil {
+		log.Printf("%s", stderr.String())
+		return err
+	}
+	_, ref := p.splitRepoRef()
+	if ref != "" {
+		stderr := &bytes.Buffer{}
+		checkout := exec.Command("git", "checkout", ref)
+		checkout.Stderr = stderr
+		checkout.Stdout = io.Discard
+		if err := checkout.Run(); err != nil {
+			log.Printf("%s", stderr.String())
+			return err
+		}
+	}
+	return nil
 }
 
-// Path returns the root path of the plugin.
-func (p *Plugin) Path() string {
-	// TODO: If remote, join config path with fetched repo path.
-	return p.config.Path
+// validate makes sure the plugin's path spec points to a valid path within the
+// source repository.
+func (p *Plugin) validate() error {
+	path, err := p.Path()
+	if err != nil {
+		return err
+	}
+	exists, err := disk.FileExists(context.TODO(), path)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		if p.config.Repo != "" {
+			return status.FailedPreconditionErrorf("plugin path %q does not exist in %s", p.config.Path, p.config.Repo)
+		}
+		return status.FailedPreconditionErrorf("plugin path %q was not found in this workspace", p.config.Path)
+	}
+	return nil
+}
+
+// Path returns the absolute root path of the plugin.
+func (p *Plugin) Path() (string, error) {
+	if p.config.Repo != "" {
+		repoPath, err := p.repoClonePath()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(repoPath, p.config.Path), nil
+	}
+
+	ws, err := workspace.Path()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(ws, p.config.Path), nil
 }
 
 // PreBazel executes the plugin's pre-bazel hook if it exists, allowing the
@@ -109,19 +238,27 @@ func (p *Plugin) Path() string {
 //       for arg in "$@"; do
 //         echo "$arg"
 //       done
-//       if ! timeout 1 ping -c1 remote.buildbuddy.io; then
+//       # Note: redirect ping stdout to stderr, to avoid adding ping output to
+//       # bazel args.
+//       if ! timeout 1 ping -c1 remote.buildbuddy.io >&2; then
 //           # Network is spotty; don't use cache
 //           echo "--remote_cache="
 //       fi
 func (p *Plugin) PreBazel(args []string) ([]string, error) {
-	scriptPath := filepath.Join(p.Path(), "pre_bazel.sh")
+	path, err := p.Path()
+	if err != nil {
+		return nil, err
+	}
+	scriptPath := filepath.Join(path, "pre_bazel.sh")
 	exists, err := disk.FileExists(context.TODO(), scriptPath)
 	if err != nil {
 		return nil, err
 	}
 	if !exists {
+		log.Debugf("Bazel hook not found at %s", scriptPath)
 		return args, nil
 	}
+	log.Debugf("Running pre-bazel hook for %s/%s", p.config.Repo, p.config.Path)
 	// TODO: if pre_bazel.sh is not executable and does not contain a shebang
 	// line, wrap it with "/usr/bin/env bash"
 	// TODO: support "pre_bazel.<any-extension>" as long as the file is
@@ -134,7 +271,14 @@ func (p *Plugin) PreBazel(args []string) ([]string, error) {
 	if err := cmd.Run(); err != nil {
 		return nil, err
 	}
-	return strings.Split(buf.String(), "\n"), nil
+	out := buf.String()
+	// For convenience, allow output to end with a trailing newline.
+	if len(out) > 0 && out[len(out)-1] == '\n' {
+		out = out[:len(out)-1]
+	}
+	newArgs := strings.Split(out, "\n")
+	log.Debugf("New bazel args: %s", newArgs)
+	return newArgs, nil
 }
 
 // PostBazel executes the plugin's post-bazel hook if it exists, allowing it to
@@ -153,7 +297,11 @@ func (p *Plugin) PreBazel(args []string) ([]string, error) {
 //         print "\x1b[33m" . $1 . "\x1b[m" . $2
 //       }' < "$1"
 func (p *Plugin) PostBazel(bazelOutputPath string) error {
-	scriptPath := filepath.Join(p.Path(), "post_bazel.sh")
+	path, err := p.Path()
+	if err != nil {
+		return err
+	}
+	scriptPath := filepath.Join(path, "post_bazel.sh")
 	exists, err := disk.FileExists(context.TODO(), scriptPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
Support the "repo" parameter in the plugin spec.

Repos are cloned to the storage dir, under `~/.cache/buildbuddy/`, then under `plugins/HOST/OWNER/REPO`, then in a ref-specific subdir: either `latest` if no ref is specified or `ref/REF` if `@<branch,sha,etc>` is specified (the `ref/` is needed so that we can distinguish between "latest commit from the default branch" and "an actual branch named 'latest'")

Also fix a few bugs found when testing.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
