### PR TITLE
Add //cli build target alias

### DIFF
--- a/cli/BUILD
+++ b/cli/BUILD
@@ -1,0 +1,4 @@
+alias(
+    name = "cli",
+    actual = "//cli/cmd/bb",
+)


### PR DESCRIPTION
Lets us build/run the CLI with `bazel run cli` instead of `bazel run cli/cmd/bb`. Similar to how we can run the server with `bazel run server`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
