### PR TITLE
Fix `--verbose` flag

### DIFF
--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"os"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
@@ -17,7 +16,7 @@ func main() {
 	flag.Parse()
 
 	// Parse args
-	commandLineArgs := os.Args[1:]
+	commandLineArgs := flag.Args()
 	rcFileArgs := parser.GetArgsFromRCFiles(commandLineArgs)
 	args := append(commandLineArgs, rcFileArgs...)
 

--- a/cli/log/log.go
+++ b/cli/log/log.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	verbose = flag.Bool("bb_verbose", false, "If true, enable verbose buildbuddy logging.")
+	verbose = flag.Bool("verbose", false, "If true, enable verbose buildbuddy logging.")
 )
 
 func Debugf(format string, v ...interface{}) {


### PR DESCRIPTION
For now, this has to come before any other args i.e.
```
bb --verbose build foo
```

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
