### PR TITLE
Add metadata fields to cacheproxy

### DIFF
--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -426,7 +426,11 @@ func (c *CacheProxy) RemoteMetadata(ctx context.Context, peer string, isolation 
 	if err != nil {
 		return nil, err
 	}
-	return &interfaces.CacheMetadata{SizeBytes: md.GetSizeBytes()}, nil
+	return &interfaces.CacheMetadata{
+		SizeBytes:          md.GetSizeBytes(),
+		LastAccessTimeUsec: md.GetLastAccessUsec(),
+		LastModifyTimeUsec: md.GetLastModifyUsec(),
+	}, nil
 }
 
 func (c *CacheProxy) RemoteFindMissing(ctx context.Context, peer string, isolation *dcpb.Isolation, digests []*repb.Digest) ([]*repb.Digest, error) {


### PR DESCRIPTION
Fixes buildbuddy-io/buildbuddy-internal#1646