### PR TITLE
Be more flexible about choosing a split point; add tests

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -615,11 +615,11 @@ type splitPoint struct {
 	rightSize int64
 }
 
-func absInt(a, b int64) int64 {
-	if a < b {
-		return b - a
+func absInt(i int64) int64 {
+	if i < 0 {
+		return -1 * i
 	}
-	return a - b
+	return i
 }
 
 func (sm *Replica) findSplitPoint(req *rfpb.FindSplitPointRequest) (*rfpb.FindSplitPointResponse, error) {
@@ -650,8 +650,8 @@ func (sm *Replica) findSplitPoint(req *rfpb.FindSplitPointRequest) (*rfpb.FindSp
 
 	for iter.First(); iter.Valid(); iter.Next() {
 		if canSplitKeys(lastKey, iter.Key()) {
-			splitDistance := absInt(optimalSplitSize, leftSize)
-			bestSplitDistance := absInt(optimalSplitSize, splitSize)
+			splitDistance := absInt(optimalSplitSize - leftSize)
+			bestSplitDistance := absInt(optimalSplitSize - splitSize)
 			if splitDistance < bestSplitDistance {
 				if len(splitKey) != len(lastKey) {
 					splitKey = make([]byte, len(lastKey))

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -615,6 +615,13 @@ type splitPoint struct {
 	rightSize int64
 }
 
+func absInt(a, b int64) int64 {
+	if a < b {
+		return b - a
+	}
+	return a - b
+}
+
 func (sm *Replica) findSplitPoint(req *rfpb.FindSplitPointRequest) (*rfpb.FindSplitPointResponse, error) {
 	iterOpts := &pebble.IterOptions{
 		LowerBound: keys.Key([]byte{constants.MinByte}),
@@ -633,30 +640,46 @@ func (sm *Replica) findSplitPoint(req *rfpb.FindSplitPointRequest) (*rfpb.FindSp
 		totalSize += sizeBytes
 	}
 
-	leftSplitSize := int64(0)
+	optimalSplitSize := totalSize / 2
+
+	leftSize := int64(0)
 	var lastKey []byte
+
+	splitSize := int64(0)
+	var splitKey []byte
+
 	for iter.First(); iter.Valid(); iter.Next() {
-		if leftSplitSize >= totalSize/2 && canSplitKeys(lastKey, iter.Key()) {
-			sp := &rfpb.FindSplitPointResponse{
-				Split:          make([]byte, len(iter.Key())),
-				LeftSizeBytes:  leftSplitSize,
-				RightSizeBytes: totalSize - leftSplitSize,
+		if canSplitKeys(lastKey, iter.Key()) {
+			splitDistance := absInt(optimalSplitSize, leftSize)
+			bestSplitDistance := absInt(optimalSplitSize, splitSize)
+			if splitDistance < bestSplitDistance {
+				if len(splitKey) != len(lastKey) {
+					splitKey = make([]byte, len(lastKey))
+				}
+				copy(splitKey, lastKey)
+				splitSize = leftSize
 			}
-			copy(sp.Split, iter.Key())
-			log.Debugf("Found split point: %+v", sp)
-			return sp, nil
 		}
 		size, err := sizeOf(iter.Key(), iter.Value())
 		if err != nil {
 			return nil, err
 		}
-		leftSplitSize += size
+		leftSize += size
 		if len(lastKey) != len(iter.Key()) {
 			lastKey = make([]byte, len(iter.Key()))
 		}
 		copy(lastKey, iter.Key())
 	}
-	return nil, status.NotFoundErrorf("Could not find split point. (Total size: %d, left split size: %d", totalSize, leftSplitSize)
+
+	if splitKey == nil {
+		sm.printRange(sm.db, "unsplittable range")
+		return nil, status.NotFoundErrorf("Could not find split point. (Total size: %d, left split size: %d", totalSize, leftSize)
+	}
+	return &rfpb.FindSplitPointResponse{
+		Split:          splitKey,
+		LeftSizeBytes:  splitSize,
+		RightSizeBytes: totalSize - splitSize,
+	}, nil
 }
 
 func canSplitKeys(leftKey, rightKey []byte) bool {
@@ -683,12 +706,20 @@ func canSplitKeys(leftKey, rightKey []byte) bool {
 	return true
 }
 
-func printRange(wb *pebble.Batch, tag string) {
-	iter := wb.NewIter(&pebble.IterOptions{})
-	for iter.First(); iter.Valid(); iter.Next() {
-		log.Printf("%q: key: %q", tag, iter.Key())
-	}
+func (sm *Replica) printRange(r pebble.Reader, tag string) {
+	iter := r.NewIter(&pebble.IterOptions{})
 	defer iter.Close()
+
+	totalSize := int64(0)
+	for iter.First(); iter.Valid(); iter.Next() {
+		size, err := sizeOf(iter.Key(), iter.Value())
+		if err != nil {
+			sm.log.Errorf("Error computing size of %s: %s", iter.Key(), err)
+			continue
+		}
+		totalSize += size
+		sm.log.Infof("%q: key: %q (%d)", tag, iter.Key(), totalSize)
+	}
 }
 
 func (sm *Replica) deleteStoredFiles(start, end []byte) error {

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -85,7 +85,7 @@ func (em *entryMaker) makeEntry(batch *rbuilder.BatchBuilder) dbsm.Entry {
 func writeDefaultRangeDescriptor(t *testing.T, em *entryMaker, r *replica.Replica) {
 	// Do a direct write of the range local range.
 	rdBuf, err := proto.Marshal(&rfpb.RangeDescriptor{
-		Left:       []byte{constants.MinByte},
+		Left:       []byte("a"),
 		Right:      []byte("z"),
 		RangeId:    1,
 		Generation: 1,
@@ -670,4 +670,87 @@ func TestReplicaSplitLease(t *testing.T) {
 
 	err = repl.Close()
 	require.NoError(t, err)
+}
+
+func TestFindSplitPoint(t *testing.T) {
+	ctx := context.Background()
+	rootDir := testfs.MakeTempDir(t)
+	store := &fakeStore{}
+	repl := replica.New(rootDir, 1, 1, store)
+	require.NotNil(t, repl)
+
+	stopc := make(chan struct{})
+	lastAppliedIndex, err := repl.Open(stopc)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), lastAppliedIndex)
+	em := newEntryMaker(t)
+	writeDefaultRangeDescriptor(t, em, repl)
+
+	writeFiles := func(partitionID string, count int, sizeBytes int64) {
+		for i := 0; i < count; i++ {
+			// Write a file to the replica's data dir.
+			d, buf := testdigest.NewRandomDigestBuf(t, sizeBytes)
+			fileRecord := &rfpb.FileRecord{
+				Isolation: &rfpb.Isolation{
+					CacheType:   rfpb.Isolation_CAS_CACHE,
+					PartitionId: partitionID,
+					GroupId:     interfaces.AuthAnonymousUser,
+				},
+				Digest: d,
+			}
+			header := &rfpb.Header{RangeId: 1, Generation: 1}
+			writeCommitter, err := repl.Writer(ctx, header, fileRecord)
+			require.NoError(t, err)
+			_, err = writeCommitter.Write(buf)
+			require.NoError(t, err)
+			require.Nil(t, writeCommitter.Commit())
+			require.Nil(t, writeCommitter.Close())
+
+			entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.FileWriteRequest{
+				FileRecord: fileRecord,
+			}))
+			entries := []dbsm.Entry{entry}
+			writeRsp, err := repl.Update(entries)
+			require.NoError(t, err)
+			require.Equal(t, 1, len(writeRsp))
+		}
+	}
+
+	{
+		// No data: findSplitPoint should return error.
+		entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.FindSplitPointRequest{}))
+		rsp, err := repl.Update([]dbsm.Entry{entry})
+		require.NoError(t, err)
+		require.Error(t, rbuilder.NewBatchResponse(rsp[0].Result.Data).AnyError())
+	}
+	{
+		// 1000 digests of the same size, split point should be half way between
+		writeFiles("default", 10, 100000)
+		entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.FindSplitPointRequest{}))
+		rsp, err := repl.Update([]dbsm.Entry{entry})
+		require.NoError(t, err)
+
+		splitRsp, err := rbuilder.NewBatchResponse(rsp[0].Result.Data).FindSplitPointResponse(0)
+		require.NoError(t, err)
+		require.NotNil(t, splitRsp)
+
+		// Left and right side of split should both be approximately 50%
+		require.Equal(t, splitRsp.GetLeftSizeBytes()/100000, int64(5))
+		require.Equal(t, splitRsp.GetRightSizeBytes()/100000, int64(5))
+	}
+	{
+		// Write one more big blob; expect split point to be right before it.
+		writeFiles("default2", 1, 1000000)
+		entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.FindSplitPointRequest{}))
+		rsp, err := repl.Update([]dbsm.Entry{entry})
+		require.NoError(t, err)
+
+		splitRsp, err := rbuilder.NewBatchResponse(rsp[0].Result.Data).FindSplitPointResponse(0)
+		require.NoError(t, err)
+		require.NotNil(t, splitRsp)
+
+		// Left and right side of split should both be approximately 50%
+		require.Equal(t, splitRsp.GetLeftSizeBytes()/100000, int64(10))
+		require.Equal(t, splitRsp.GetRightSizeBytes()/100000, int64(10))
+	}
 }


### PR DESCRIPTION
This change makes the splitting more flexible: any splittable point in a range is valid. The algorithm searches through the entire range for a split point, and determines the best split point by how closely it approximates splitting the range into two even halves.

If a split point cannot be found for some reason, the range's keys are printed (so we can debug better).

We can tweak it if we want so it only ever splits in the middle third or something, but figured I'd start here. Open to feedback!