### PR TITLE
Fix recursive cloning issue with CLI release

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -68,6 +68,14 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
     steps:
+      - name: Clean workspace
+        run: |
+          set -x
+          ls -la ./
+          rm -rf ./* || true
+          rm -rf ./.??* || true
+          ls -la ./
+
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/release-m1.yaml
+++ b/.github/workflows/release-m1.yaml
@@ -13,6 +13,14 @@ jobs:
       run:
         shell: "/usr/bin/arch -arch arm64e /bin/bash --noprofile --norc -eo pipefail {0}"
     steps:
+      - name: Clean workspace
+        run: |
+          set -x
+          ls -la ./
+          rm -rf ./* || true
+          rm -rf ./.??* || true
+          ls -la ./
+
       - name: Checkout
         uses: actions/checkout@v3
 


### PR DESCRIPTION
The GitHub Actions workspace dir doesn't seem to get properly cleaned up before/after workflows on our self-hosted M1 runner. (I noticed that the cloned BB repo as well as the built executor binary from the `release-m1` workflow was present in the workspace during the `release-cli` workflow.)

Temporarily fix this by explicitly cleaning up before running workflows. Do the same on the release-m1 workflow so we always run from a clean workspace on the M1 runner. Longer term, we should figure out why this is happening, but I couldn't find any obvious reasons after searching online and inspecting the permissions on the workspace files.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
