### PR TITLE
CLI: Wire up plugins in `main`

### DIFF
--- a/cli/bazelisk/bazelisk.go
+++ b/cli/bazelisk/bazelisk.go
@@ -2,6 +2,7 @@ package bazelisk
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,7 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
 
-func Run(args []string) {
+func Run(args []string, output io.Writer) (int, error) {
 	// If we were already invoked via bazelisk, then set the bazel version to
 	// the next version appearing in the .bazelversion file so that bazelisk
 	// doesn't just invoke us again (resulting in an infinite loop).
@@ -29,12 +30,57 @@ func Run(args []string) {
 	// Fetch releases, release candidates and Bazel-at-commits from GCS, forks from GitHub
 	repos := core.CreateRepositories(gcs, gcs, gitHub, gcs, gitHub, true)
 
+	// Temporarily redirect stdout/stderr so that we can capture the bazelisk
+	// output.
+	// Note, we might be able to use Bazel's "command.log" file instead, but
+	// would need to find a way to avoid a race condition if another Bazel
+	// command is run concurrently (since it will clear out command.log as
+	// soon as our bazelisk invocation below is complete and it is able to
+	// grap the workspace lock).
+	originalStdout, originalStderr := os.Stdout, os.Stderr
+	defer func() {
+		os.Stdout, os.Stderr = originalStdout, originalStderr
+	}()
+	stdoutPipe, closeStdoutPipe, err := makePipeWriter(io.MultiWriter(output, os.Stdout))
+	if err != nil {
+		return 0, err
+	}
+	defer closeStdoutPipe()
+	os.Stdout = stdoutPipe
+	stderrPipe, closeStderrPipe, err := makePipeWriter(io.MultiWriter(output, os.Stderr))
+	if err != nil {
+		return 0, err
+	}
+	defer closeStderrPipe()
+	os.Stderr = stderrPipe
+
 	exitCode, err := core.RunBazelisk(args, repos)
 	if err != nil {
 		log.Fatalf("error running bazelisk: %s", err)
 	}
+	return exitCode, nil
+}
 
-	os.Exit(exitCode)
+// makePipeWriter adapts a writer to an *os.File by using an os.Pipe().
+// The returned file should not be closed; instead the returned closeFunc
+// should be called to ensure that all data from the pipe is flushed to the
+// underlying writer.
+func makePipeWriter(w io.Writer) (pw *os.File, closeFunc func(), err error) {
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		return
+	}
+	done := make(chan struct{}, 1)
+	go func() {
+		io.Copy(w, pr)
+		close(done)
+	}()
+	closeFunc = func() {
+		pw.Close()
+		// Wait until the pipe contents are flushed to w.
+		<-done
+	}
+	return
 }
 
 func setBazelVersion() error {

--- a/cli/bazelisk/bazelisk.go
+++ b/cli/bazelisk/bazelisk.go
@@ -15,7 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
 
-func Run(args []string, output io.Writer) (int, error) {
+func Run(args []string) (int, *Output, error) {
 	// If we were already invoked via bazelisk, then set the bazel version to
 	// the next version appearing in the .bazelversion file so that bazelisk
 	// doesn't just invoke us again (resulting in an infinite loop).
@@ -30,26 +30,31 @@ func Run(args []string, output io.Writer) (int, error) {
 	// Fetch releases, release candidates and Bazel-at-commits from GCS, forks from GitHub
 	repos := core.CreateRepositories(gcs, gcs, gitHub, gcs, gitHub, true)
 
+	output, err := os.CreateTemp("", "bazelisk-output-*")
+	if err != nil {
+		return 0, nil, status.FailedPreconditionErrorf("failed to create output file: %s", err)
+	}
+
 	// Temporarily redirect stdout/stderr so that we can capture the bazelisk
 	// output.
 	// Note, we might be able to use Bazel's "command.log" file instead, but
 	// would need to find a way to avoid a race condition if another Bazel
 	// command is run concurrently (since it will clear out command.log as
 	// soon as our bazelisk invocation below is complete and it is able to
-	// grap the workspace lock).
+	// grab the workspace lock).
 	originalStdout, originalStderr := os.Stdout, os.Stderr
 	defer func() {
 		os.Stdout, os.Stderr = originalStdout, originalStderr
 	}()
 	stdoutPipe, closeStdoutPipe, err := makePipeWriter(io.MultiWriter(output, os.Stdout))
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 	defer closeStdoutPipe()
 	os.Stdout = stdoutPipe
 	stderrPipe, closeStderrPipe, err := makePipeWriter(io.MultiWriter(output, os.Stderr))
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 	defer closeStderrPipe()
 	os.Stderr = stderrPipe
@@ -58,7 +63,7 @@ func Run(args []string, output io.Writer) (int, error) {
 	if err != nil {
 		log.Fatalf("error running bazelisk: %s", err)
 	}
-	return exitCode, nil
+	return exitCode, &Output{output}, nil
 }
 
 // makePipeWriter adapts a writer to an *os.File by using an os.Pipe().
@@ -70,7 +75,7 @@ func makePipeWriter(w io.Writer) (pw *os.File, closeFunc func(), err error) {
 	if err != nil {
 		return
 	}
-	done := make(chan struct{}, 1)
+	done := make(chan struct{})
 	go func() {
 		io.Copy(w, pr)
 		close(done)
@@ -110,4 +115,14 @@ func setBazelVersion() error {
 	}
 
 	return os.Setenv("USE_BAZEL_VERSION", parts[0])
+}
+
+// Output points to the stdout/stderr written by bazelisk. It is like a regular
+// file, but the Close() method also deletes the file to avoid accumulating too
+// many logs on disk.
+type Output struct{ *os.File }
+
+func (o *Output) Close() error {
+	o.File.Close()
+	return os.Remove(o.File.Name())
 }

--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -11,10 +11,13 @@ go_library(
     deps = [
         "//cli/arg",
         "//cli/bazelisk",
+        "//cli/log",
         "//cli/login",
         "//cli/parser",
+        "//cli/plugin",
         "//cli/remotebazel",
         "//cli/sidecar",
+        "//cli/terminal",
         "//cli/tooltag",
         "//cli/version",
     ],

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -30,7 +30,7 @@ func run() (exitCode int, err error) {
 	// Load plugins
 	plugins, err := plugin.LoadAll()
 	if err != nil {
-		return 0, err
+		return -1, err
 	}
 
 	// Parse args
@@ -49,7 +49,7 @@ func run() (exitCode int, err error) {
 	for _, p := range plugins {
 		args, err = p.PreBazel(args)
 		if err != nil {
-			return 0, err
+			return -1, err
 		}
 	}
 
@@ -64,14 +64,14 @@ func run() (exitCode int, err error) {
 	// Actually run bazel
 	exitCode, output, err := bazelisk.Run(args)
 	if err != nil {
-		return 0, err
+		return -1, err
 	}
 	defer output.Close()
 
 	// Run plugin post-bazel hooks
 	for _, p := range plugins {
 		if err := p.PostBazel(output.Name()); err != nil {
-			return 0, err
+			return -1, err
 		}
 	}
 

--- a/cli/log/log.go
+++ b/cli/log/log.go
@@ -9,11 +9,8 @@ var (
 	verbose = flag.Bool("verbose", false, "If true, enable verbose buildbuddy logging.")
 )
 
-func Debug(v ...any) {
-	if !*verbose {
-		return
-	}
-	log.Print(v...)
+func init() {
+	log.SetFlags(0)
 }
 
 func Debug(v ...any) {

--- a/cli/log/log.go
+++ b/cli/log/log.go
@@ -9,8 +9,11 @@ var (
 	verbose = flag.Bool("verbose", false, "If true, enable verbose buildbuddy logging.")
 )
 
-func init() {
-	log.SetFlags(0)
+func Debug(v ...any) {
+	if !*verbose {
+		return
+	}
+	log.Print(v...)
 }
 
 func Debug(v ...any) {

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -309,6 +309,7 @@ func (p *Plugin) PostBazel(bazelOutputPath string) error {
 	if !exists {
 		return nil
 	}
+	log.Debugf("Running post-bazel hook for %s/%s", p.config.Repo, p.config.Path)
 	cmd := exec.Command(scriptPath, bazelOutputPath)
 	// TODO: Prefix stderr output with "output from [plugin]" ?
 	cmd.Stderr = os.Stderr

--- a/cli/terminal/BUILD
+++ b/cli/terminal/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "terminal",
+    srcs = ["terminal.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/terminal",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cli/arg",
+        "//cli/log",
+    ],
+)

--- a/cli/terminal/terminal.go
+++ b/cli/terminal/terminal.go
@@ -1,0 +1,40 @@
+package terminal
+
+import (
+	"os"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
+)
+
+// ConfigureOutputMode makes sure that bazel produces fancy terminal output.
+// This is needed because we tee its output to a file, which makes bazel think
+// it is not writing to a terminal, causing it to disable fancy output (ANSI
+// colors, dynamic progress indicators, etc.) unless explicitly enabled.
+func ConfigureOutputMode(args []string) []string {
+	// If bb itself is not writing to a terminal, don't force color/curses.
+	o, err := os.Stdout.Stat()
+	if err != nil {
+		log.Printf("Could not stat stdout; fancy output will not be enabled: %s", err)
+		return args
+	}
+	if (o.Mode() & os.ModeCharDevice) != os.ModeCharDevice {
+		return args
+	}
+	o, err = os.Stderr.Stat()
+	if err != nil {
+		log.Printf("Could not stat stderr; fancy output will not be enabled: %s", err)
+		return args
+	}
+	if (o.Mode() & os.ModeCharDevice) != os.ModeCharDevice {
+		return args
+	}
+
+	if !arg.Has(args, "curses") {
+		args = append(args, "--curses=yes")
+	}
+	if !arg.Has(args, "color") {
+		args = append(args, "--color=yes")
+	}
+	return args
+}


### PR DESCRIPTION
Actually load plugins in `main()` and run their pre/post-bazel plugin hooks.

Tested with both pre- and post-bazel hooks, with both local and remote plugins.

(Note, I haven't made the change to the pre-bazel API yet so that it operates on a single file passed as $1; will do that in a follow-up PR)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
