### PR TITLE
Fix version definition in CLI release

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -115,7 +115,7 @@ jobs:
           cd "${GITHUB_WORKSPACE}/buildbuddy"
           "${GITHUB_WORKSPACE}/bin/bazel" build //cli/cmd/bb \
               --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
-              --define version=${{ steps.tag.outputs.TAG }}
+              --define version="$VERSION"
 
           BINARY="bazel-${VERSION}-${OS}-${ARCH}"
           cp bazel-bin/cli/cmd/bb/bb_/bb "$BINARY"


### PR DESCRIPTION
I don't think this actually fixes the output of `bb version`, but it at least prevents an undefined variable reference in the workflow.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
