### PR TITLE
Add example "go_highlight" plugin

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -51,3 +51,6 @@ actions:
       # TODO(http://go/b/1249): Increase reliability of runner recycling when
       # executing with high concurrency, and remove `--jobs=3`
       - test //... --config=workflows --test_tag_filters=+docker --build_tag_filters=+docker --jobs=3
+
+plugins:
+  - path: cli/example_plugins/go_highlight

--- a/cli/example_plugins/go_highlight/README.md
+++ b/cli/example_plugins/go_highlight/README.md
@@ -1,0 +1,5 @@
+# go_highlight
+
+go_highlight is a BuildBuddy CLI plugin that makes syntax errors in Go
+programs easier to spot, by highlighting them and placing them at the very
+end of the build output, after all of Bazel's output.

--- a/cli/example_plugins/go_highlight/post_bazel.sh
+++ b/cli/example_plugins/go_highlight/post_bazel.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+# Look for lines like:
+#     foo/bar/baz.go:10:15: syntax error: blah
+# And highlight the "path:line:column" part in orange.
+python3 -c '
+import re
+import sys
+
+for line in sys.stdin:
+    m = re.search(r"^(.*?\.go:\d+:\d+:)(.*)", line)
+    if m:
+        print("\x1b[33m" + m.group(1) + "\x1b[0m" + m.group(2))
+' <"$1" >&2

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -287,15 +287,7 @@ func (p *Plugin) PreBazel(args []string) ([]string, error) {
 // Currently the invocation data is fed as plain text via a file. The file path
 // is passed as the first argument.
 //
-// Example plugin that highlights lines containing source locations (like
-// "/path/to/foo.go:23:42: undefined variable") so they are easier to visually
-// spot in the build output:
-//
-//     post_bazel.sh
-//       #!/usr/bin/env bash
-//       perl -nle 'if (/^(.*\.\w+:\d+:\d+:)(.*)/) {
-//         print "\x1b[33m" . $1 . "\x1b[m" . $2
-//       }' < "$1"
+// See cli/example_plugins/go_highlight/post_bazel.sh for an example.
 func (p *Plugin) PostBazel(bazelOutputPath string) error {
 	path, err := p.Path()
 	if err != nil {


### PR DESCRIPTION
This example plugin looks for go source lines and outputs them at the end of the build with the file names highlighted, like this:

![image](https://user-images.githubusercontent.com/2414826/193329583-62678469-d562-415a-a7a7-d808e034ad7d.png)

I have been using my own Bazel wrapper for a while which does something similar (it highlights the errors inline, instead of at the end of the build). I've found it useful for more quickly spotting errors in Go code, since Go's errors are in plain text and hard to distinguish from other output lines.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
