### PR TITLE
Use log.Debug for missing API key file error

### DIFF
--- a/cli/login/login.go
+++ b/cli/login/login.go
@@ -51,7 +51,7 @@ func ConfigureAPIKey(args []string) []string {
 	apiKeyFile := filepath.Join(dir, apiKeyFileName)
 	apiKeyBytes, err := os.ReadFile(apiKeyFile)
 	if err != nil {
-		fmt.Print(err)
+		log.Debug(err)
 		return args
 	}
 


### PR DESCRIPTION
This error was being printed every time since I haven't run bb login yet - log it as a debug msg instead

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
