### PR TITLE
Rename Contains to ContainsDeprecated to prepare for ResourceName refactor

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -400,7 +400,7 @@ func (c *Cache) readPeers(d *repb.Digest) *peerset.PeerSet {
 func (c *Cache) remoteContains(ctx context.Context, peer string, isolation *dcpb.Isolation, d *repb.Digest) (bool, error) {
 	if !c.config.DisableLocalLookup && peer == c.config.ListenAddr {
 		// No prefix necessary -- it's already set on the local cache.
-		return c.local.Contains(ctx, d)
+		return c.local.ContainsDeprecated(ctx, d)
 	}
 	return c.cacheProxy.RemoteContains(ctx, peer, isolation, d)
 }
@@ -553,7 +553,7 @@ func (c *Cache) getBackfillOrders(d *repb.Digest, ps *peerset.PeerSet) []*backfi
 // This is like setting READ_CONSISTENCY = ONE.
 //
 // Values found on a non-primary replica will be backfilled to the primary.
-func (c *Cache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (c *Cache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	ps := c.readPeers(d)
 	backfill := func() {
 		if err := c.backfillPeers(ctx, c.getBackfillOrders(d, ps)); err != nil {

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -130,7 +130,7 @@ func TestBasicReadWrite(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err)
 			assert.True(t, exists)
 			readAndCompareDigest(t, ctx, baseCache, d)
@@ -297,7 +297,7 @@ func TestReadWriteWithFailedNode(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err)
 			assert.True(t, exists)
 			readAndCompareDigest(t, ctx, baseCache, d)
@@ -367,7 +367,7 @@ func TestReadWriteWithFailedAndRestoredNode(t *testing.T) {
 		}
 		digestsWritten = append(digestsWritten, d)
 		for _, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err)
 			assert.True(t, exists)
 			readAndCompareDigest(t, ctx, baseCache, d)
@@ -380,7 +380,7 @@ func TestReadWriteWithFailedAndRestoredNode(t *testing.T) {
 	waitForReady(t, config3.ListenAddr)
 	for _, d := range digestsWritten {
 		for _, distributedCache := range distributedCaches {
-			exists, err := distributedCache.Contains(ctx, d)
+			exists, err := distributedCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err)
 			assert.True(t, exists)
 			readAndCompareDigest(t, ctx, distributedCache, d)
@@ -434,7 +434,7 @@ func TestBackfill(t *testing.T) {
 		}
 		digestsWritten = append(digestsWritten, d)
 		for _, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err)
 			assert.True(t, exists)
 			readAndCompareDigest(t, ctx, baseCache, d)
@@ -453,13 +453,13 @@ func TestBackfill(t *testing.T) {
 	// because it has been backfilled.
 	for _, d := range digestsWritten {
 		for _, distributedCache := range distributedCaches {
-			exists, err := distributedCache.Contains(ctx, d)
+			exists, err := distributedCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err)
 			assert.True(t, exists)
 			readAndCompareDigest(t, ctx, distributedCache, d)
 		}
 		for i, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err, fmt.Sprintf("basecache %dmissing digest", i))
 			assert.True(t, exists, fmt.Sprintf("basecache %dmissing digest", i))
 			readAndCompareDigest(t, ctx, baseCache, d)
@@ -799,7 +799,7 @@ func TestHintedHandoff(t *testing.T) {
 		}
 		digestsWritten = append(digestsWritten, d)
 		for _, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err)
 			assert.True(t, exists)
 			readAndCompareDigest(t, ctx, baseCache, d)
@@ -840,7 +840,7 @@ func TestHintedHandoff(t *testing.T) {
 
 	// Ensure that dc3 successfully received all the hinted handoffs.
 	for _, d := range hintedHandoffs {
-		exists, err := memoryCache3.Contains(ctx, d)
+		exists, err := memoryCache3.ContainsDeprecated(ctx, d)
 		assert.Nil(t, err)
 		assert.True(t, exists)
 		readAndCompareDigest(t, ctx, dc3, d)
@@ -893,7 +893,7 @@ func TestDelete(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.NoError(t, err)
 			assert.True(t, exists)
 		}
@@ -903,7 +903,7 @@ func TestDelete(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.NoError(t, err)
 			assert.False(t, exists)
 		}

--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -351,7 +351,7 @@ func (g *GCSCache) metadata(ctx context.Context, d *repb.Digest) (*storage.Objec
 	return nil, finalErr
 }
 
-func (g *GCSCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (g *GCSCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	metadata, err := g.metadata(ctx, d)
 	if err != nil || metadata == nil {
 		return false, err
@@ -393,7 +393,7 @@ func (g *GCSCache) FindMissing(ctx context.Context, digests []*repb.Digest) ([]*
 	for _, d := range digests {
 		fetchFn := func(d *repb.Digest) {
 			eg.Go(func() error {
-				exists, err := g.Contains(ctx, d)
+				exists, err := g.ContainsDeprecated(ctx, d)
 				if err != nil {
 					return err
 				}

--- a/enterprise/server/backends/memcache/memcache.go
+++ b/enterprise/server/backends/memcache/memcache.go
@@ -112,7 +112,7 @@ func (c *Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheTyp
 	}, nil
 }
 
-func (c *Cache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (c *Cache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	key, err := c.key(ctx, d)
 	if err != nil {
 		return false, err
@@ -159,7 +159,7 @@ func (c *Cache) FindMissing(ctx context.Context, digests []*repb.Digest) ([]*rep
 	for _, d := range digests {
 		fetchFn := func(d *repb.Digest) {
 			eg.Go(func() error {
-				exists, err := c.Contains(ctx, d)
+				exists, err := c.ContainsDeprecated(ctx, d)
 				if err != nil {
 					return err
 				}

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -174,20 +174,20 @@ func (mc *MigrationCache) WithIsolation(ctx context.Context, cacheType interface
 	return &clone, nil
 }
 
-func (mc *MigrationCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (mc *MigrationCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	eg, gctx := errgroup.WithContext(ctx)
 	var srcErr, dstErr error
 	var srcContains, dstContains bool
 
 	eg.Go(func() error {
-		srcContains, srcErr = mc.src.Contains(gctx, d)
+		srcContains, srcErr = mc.src.ContainsDeprecated(gctx, d)
 		return srcErr
 	})
 
 	doubleRead := rand.Float64() <= mc.doubleReadPercentage
 	if doubleRead {
 		eg.Go(func() error {
-			dstContains, dstErr = mc.dest.Contains(gctx, d)
+			dstContains, dstErr = mc.dest.ContainsDeprecated(gctx, d)
 			return nil // we don't care about the return error from this cache
 		})
 	}
@@ -595,7 +595,7 @@ func (mc *MigrationCache) Get(ctx context.Context, d *repb.Digest) ([]byte, erro
 }
 
 func (mc *MigrationCache) sendNonBlockingCopy(ctx context.Context, d *repb.Digest) {
-	alreadyCopied, err := mc.dest.Contains(ctx, d)
+	alreadyCopied, err := mc.dest.ContainsDeprecated(ctx, d)
 	if err != nil {
 		log.Warningf("Migration copy err, could not call Contains on dest cache: %s", err)
 		return

--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -47,7 +47,7 @@ func getAnonContext(t *testing.T, env environment.Env) context.Context {
 // copied the given digest over
 func waitForCopy(t *testing.T, ctx context.Context, destCache interfaces.Cache, digest *repb.Digest) {
 	for delay := 50 * time.Millisecond; delay < 1*time.Minute; delay *= 2 {
-		contains, err := destCache.Contains(ctx, digest)
+		contains, err := destCache.ContainsDeprecated(ctx, digest)
 		require.NoError(t, err, "error calling contains on dest cache")
 
 		if contains {
@@ -78,7 +78,7 @@ func (c *errorCache) Delete(ctx context.Context, d *repb.Digest) error {
 	return errors.New("error cache delete err")
 }
 
-func (c *errorCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (c *errorCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	return false, errors.New("error cache contains err")
 }
 
@@ -518,12 +518,12 @@ func TestContains(t *testing.T) {
 	err = mc.Set(ctx, d, buf)
 	require.NoError(t, err)
 
-	contains, err := mc.Contains(ctx, d)
+	contains, err := mc.ContainsDeprecated(ctx, d)
 	require.NoError(t, err)
 	require.True(t, contains)
 
 	notWrittenDigest, _ := testdigest.NewRandomDigestBuf(t, 100)
-	contains, err = mc.Contains(ctx, notWrittenDigest)
+	contains, err = mc.ContainsDeprecated(ctx, notWrittenDigest)
 	require.NoError(t, err)
 	require.False(t, contains)
 }
@@ -544,7 +544,7 @@ func TestContains_DestErr(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should return data from src cache without error
-	contains, err := mc.Contains(ctx, d)
+	contains, err := mc.ContainsDeprecated(ctx, d)
 	require.NoError(t, err)
 	require.True(t, contains)
 }

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -873,7 +873,7 @@ func (p *PebbleCache) handleMetadataMismatch(err error, fileMetadataKey []byte, 
 	}
 }
 
-func (p *PebbleCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (p *PebbleCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	db, err := p.leaser.DB()
 	if err != nil {
 		return false, err

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -447,7 +447,7 @@ func TestSizeLimit(t *testing.T) {
 	// size bytes.
 	containedDigestsSize := int64(0)
 	for _, d := range digestKeys {
-		if ok, err := pc.Contains(ctx, d); err == nil && ok {
+		if ok, err := pc.ContainsDeprecated(ctx, d); err == nil && ok {
 			containedDigestsSize += d.GetSizeBytes()
 		}
 	}
@@ -583,7 +583,7 @@ func TestLRU(t *testing.T) {
 
 	evictionsByQuartile := make([][]*repb.Digest, 5)
 	for i, d := range digestKeys {
-		ok, err := pc.Contains(ctx, d)
+		ok, err := pc.ContainsDeprecated(ctx, d)
 		evicted := err != nil || !ok
 		q := i / quartile
 		if evicted {
@@ -1093,7 +1093,7 @@ func BenchmarkContains1(b *testing.B) {
 	b.StopTimer()
 	for n := 0; n < b.N; n++ {
 		b.StartTimer()
-		found, err := pc.Contains(ctx, digestKeys[rand.Intn(len(digestKeys))])
+		found, err := pc.ContainsDeprecated(ctx, digestKeys[rand.Intn(len(digestKeys))])
 		b.StopTimer()
 		if err != nil {
 			b.Fatal(err)

--- a/enterprise/server/backends/redis_cache/redis_cache.go
+++ b/enterprise/server/backends/redis_cache/redis_cache.go
@@ -146,7 +146,7 @@ func (c *Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheTyp
 	}, nil
 }
 
-func (c *Cache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (c *Cache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	key, err := c.key(ctx, d)
 	if err != nil {
 		return false, err

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -405,7 +405,7 @@ func (s3c *S3Cache) bumpTTLIfStale(ctx context.Context, key string, t time.Time)
 	return true
 }
 
-func (s3c *S3Cache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (s3c *S3Cache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	timer := cache_metrics.NewCacheTimer(cacheLabels)
 	var err error
 	defer timer.ObserveContains(err)
@@ -474,7 +474,7 @@ func (s3c *S3Cache) FindMissing(ctx context.Context, digests []*repb.Digest) ([]
 	for _, d := range digests {
 		fetchFn := func(d *repb.Digest) {
 			eg.Go(func() error {
-				exists, err := s3c.Contains(ctx, d)
+				exists, err := s3c.ContainsDeprecated(ctx, d)
 				if err != nil {
 					return err
 				}

--- a/enterprise/server/composable_cache/composable_cache.go
+++ b/enterprise/server/composable_cache/composable_cache.go
@@ -47,13 +47,13 @@ func (c *ComposableCache) WithIsolation(ctx context.Context, cacheType interface
 	}, nil
 }
 
-func (c *ComposableCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
-	outerExists, err := c.outer.Contains(ctx, d)
+func (c *ComposableCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
+	outerExists, err := c.outer.ContainsDeprecated(ctx, d)
 	if err == nil && outerExists {
 		return outerExists, nil
 	}
 
-	return c.inner.Contains(ctx, d)
+	return c.inner.ContainsDeprecated(ctx, d)
 }
 
 func (c *ComposableCache) Metadata(ctx context.Context, d *repb.Digest) (*interfaces.CacheMetadata, error) {

--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -445,7 +445,7 @@ func (rc *RaftCache) Stop() error {
 	return nil
 }
 
-func (rc *RaftCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (rc *RaftCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	missing, err := rc.FindMissing(ctx, []*repb.Digest{d})
 	if err != nil {
 		return false, err

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -314,7 +314,7 @@ func (c *DiskCache) Statusz(ctx context.Context) string {
 	return buf
 }
 
-func (c *DiskCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (c *DiskCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	record, err := c.partition.lruGet(ctx, c.cacheType, c.remoteInstanceName, d)
 	contains := record != nil
 	return contains, err

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -367,7 +367,7 @@ func TestLRU(t *testing.T) {
 		digestKeys = append(digestKeys, d)
 	}
 	// Now "use" the first digest written so it is most recently used.
-	ok, err := dc.Contains(ctx, digestKeys[0])
+	ok, err := dc.ContainsDeprecated(ctx, digestKeys[0])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -464,7 +464,7 @@ func TestAsyncLoading(t *testing.T) {
 	// Ensure that files on disk exist *immediately*, even though
 	// they may not have been async processed yet.
 	for _, d := range digests {
-		exists, err := dc.Contains(ctx, d)
+		exists, err := dc.ContainsDeprecated(ctx, d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -485,7 +485,7 @@ func TestAsyncLoading(t *testing.T) {
 
 	// Check that everything still exists.
 	for _, d := range digests {
-		exists, err := dc.Contains(ctx, d)
+		exists, err := dc.ContainsDeprecated(ctx, d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -527,7 +527,7 @@ func TestJanitorThread(t *testing.T) {
 		if i > 500 {
 			break
 		}
-		contains, err := dc.Contains(ctx, d)
+		contains, err := dc.ContainsDeprecated(ctx, d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -568,7 +568,7 @@ func TestZeroLengthFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Ensure that the goodDigest exists and the zero length one does not.
-	exists, err := dc.Contains(ctx, badDigest)
+	exists, err := dc.ContainsDeprecated(ctx, badDigest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -576,7 +576,7 @@ func TestZeroLengthFiles(t *testing.T) {
 		t.Fatalf("%q (empty file) should not be mapped in cache.", badDigest.GetHash())
 	}
 
-	exists, err = dc.Contains(ctx, goodDigest)
+	exists, err = dc.ContainsDeprecated(ctx, goodDigest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -748,7 +748,7 @@ func TestV2Layout(t *testing.T) {
 	dPath := filepath.Join(userRoot, d.GetHash()[0:disk_cache.HashPrefixDirPrefixLen], d.GetHash())
 	require.FileExists(t, dPath)
 
-	ok, err := dc.Contains(ctx, d)
+	ok, err := dc.ContainsDeprecated(ctx, d)
 	require.NoError(t, err)
 	require.Truef(t, ok, "digest should be in the cache")
 
@@ -845,7 +845,7 @@ func TestV2LayoutMigration(t *testing.T) {
 		require.NoError(t, err)
 
 		d := &repb.Digest{Hash: testHash, SizeBytes: 5}
-		ok, err := ic.Contains(ctx, d)
+		ok, err := ic.ContainsDeprecated(ctx, d)
 		require.NoError(t, err)
 		require.True(t, ok, "digest should be in the cache")
 
@@ -861,7 +861,7 @@ func TestV2LayoutMigration(t *testing.T) {
 		ic, err := dc.WithIsolation(ctx, interfaces.CASCacheType, "" /*=instanceName*/)
 
 		d := &repb.Digest{Hash: testHash, SizeBytes: 5}
-		ok, err := ic.Contains(ctx, d)
+		ok, err := ic.ContainsDeprecated(ctx, d)
 		require.NoError(t, err)
 		require.True(t, ok, "digest should be in the cache")
 
@@ -878,7 +878,7 @@ func TestV2LayoutMigration(t *testing.T) {
 		require.NoError(t, err)
 
 		d := &repb.Digest{Hash: testHash, SizeBytes: 5}
-		ok, err := ic.Contains(ctx, d)
+		ok, err := ic.ContainsDeprecated(ctx, d)
 		require.NoError(t, err)
 		require.True(t, ok, "digest should be in the cache")
 

--- a/server/backends/memory_cache/memory_cache.go
+++ b/server/backends/memory_cache/memory_cache.go
@@ -97,7 +97,7 @@ func (m *MemoryCache) WithIsolation(ctx context.Context, cacheType interfaces.Ca
 	}, nil
 }
 
-func (m *MemoryCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (m *MemoryCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	k, err := m.key(ctx, d)
 	if err != nil {
 		return false, err
@@ -134,7 +134,7 @@ func (m *MemoryCache) FindMissing(ctx context.Context, digests []*repb.Digest) (
 	var missing []*repb.Digest
 	// No parallelism here either. Not necessary for an in-memory cache.
 	for _, d := range digests {
-		ok, err := m.Contains(ctx, d)
+		ok, err := m.ContainsDeprecated(ctx, d)
 		if err != nil {
 			return nil, err
 		}

--- a/server/backends/memory_cache/memory_cache_test.go
+++ b/server/backends/memory_cache/memory_cache_test.go
@@ -302,7 +302,7 @@ func TestLRU(t *testing.T) {
 		digestKeys = append(digestKeys, d)
 	}
 	// Now "use" the first digest written so it is most recently used.
-	ok, err := mc.Contains(ctx, digestKeys[0])
+	ok, err := mc.ContainsDeprecated(ctx, digestKeys[0])
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -236,7 +236,7 @@ type Cache interface {
 	WithIsolation(ctx context.Context, cacheType CacheType, remoteInstanceName string) (Cache, error)
 
 	// Normal cache-like operations.
-	Contains(ctx context.Context, d *repb.Digest) (bool, error)
+	ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error)
 	Metadata(ctx context.Context, d *repb.Digest) (*CacheMetadata, error)
 	FindMissing(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error)
 	Get(ctx context.Context, d *repb.Digest) ([]byte, error)

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -251,7 +251,7 @@ func (s *ByteStreamServer) initStreamState(ctx context.Context, req *bspb.WriteR
 	// Protocol does say that if another parallel write had finished while
 	// this one was ongoing, we can immediately return a response with the
 	// committed size, so we'll just do that.
-	exists, err := cache.Contains(ctx, r.GetDigest())
+	exists, err := cache.ContainsDeprecated(ctx, r.GetDigest())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
More details about ResourceName refactor in #2389 

Plan is to create a new Contains method that takes a ResourceName instead of a digest (Ex. https://github.com/buildbuddy-io/buildbuddy/pull/2638)
