### PR TITLE
Refactor disk cache to use resource.CacheType instead of interfaces.CacheType

### DIFF
--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -360,7 +360,7 @@ func (s *APIServer) DeleteFile(ctx context.Context, req *apipb.DeleteFileRequest
 	urlStr := strings.TrimPrefix(parsedURL.RequestURI(), "/")
 
 	var parsedResourceName *digest.ResourceName
-	var cacheType interfaces.CacheType
+	var cacheType interfaces.CacheTypeDeprecated
 	if digest.IsActionCacheResourceName(urlStr) {
 		parsedResourceName, err = digest.ParseActionCacheResourceName(urlStr)
 		if err != nil {

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -323,7 +323,7 @@ func (c *Cache) Shutdown(ctx context.Context) error {
 	return c.cacheProxy.Shutdown(ctx)
 }
 
-func toProtoCacheType(cacheType interfaces.CacheType) (dcpb.Isolation_CacheType, error) {
+func toProtoCacheType(cacheType interfaces.CacheTypeDeprecated) (dcpb.Isolation_CacheType, error) {
 	switch cacheType {
 	case interfaces.CASCacheType:
 		return dcpb.Isolation_CAS_CACHE, nil
@@ -334,7 +334,7 @@ func toProtoCacheType(cacheType interfaces.CacheType) (dcpb.Isolation_CacheType,
 	}
 }
 
-func (c *Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+func (c *Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheTypeDeprecated, remoteInstanceName string) (interfaces.Cache, error) {
 	newLocal, err := c.local.WithIsolation(ctx, cacheType, remoteInstanceName)
 	if err != nil {
 		return nil, err

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -400,7 +400,7 @@ func (c *Cache) readPeers(d *repb.Digest) *peerset.PeerSet {
 func (c *Cache) remoteContains(ctx context.Context, peer string, isolation *dcpb.Isolation, d *repb.Digest) (bool, error) {
 	if !c.config.DisableLocalLookup && peer == c.config.ListenAddr {
 		// No prefix necessary -- it's already set on the local cache.
-		return c.local.Contains(ctx, d)
+		return c.local.ContainsDeprecated(ctx, d)
 	}
 	return c.cacheProxy.RemoteContains(ctx, peer, isolation, d)
 }
@@ -553,7 +553,7 @@ func (c *Cache) getBackfillOrders(d *repb.Digest, ps *peerset.PeerSet) []*backfi
 // This is like setting READ_CONSISTENCY = ONE.
 //
 // Values found on a non-primary replica will be backfilled to the primary.
-func (c *Cache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (c *Cache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	ps := c.readPeers(d)
 	backfill := func() {
 		if err := c.backfillPeers(ctx, c.getBackfillOrders(d, ps)); err != nil {

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -130,7 +130,7 @@ func TestBasicReadWrite(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err)
 			assert.True(t, exists)
 			readAndCompareDigest(t, ctx, baseCache, d)
@@ -297,7 +297,7 @@ func TestReadWriteWithFailedNode(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err)
 			assert.True(t, exists)
 			readAndCompareDigest(t, ctx, baseCache, d)
@@ -367,7 +367,7 @@ func TestReadWriteWithFailedAndRestoredNode(t *testing.T) {
 		}
 		digestsWritten = append(digestsWritten, d)
 		for _, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err)
 			assert.True(t, exists)
 			readAndCompareDigest(t, ctx, baseCache, d)
@@ -380,7 +380,7 @@ func TestReadWriteWithFailedAndRestoredNode(t *testing.T) {
 	waitForReady(t, config3.ListenAddr)
 	for _, d := range digestsWritten {
 		for _, distributedCache := range distributedCaches {
-			exists, err := distributedCache.Contains(ctx, d)
+			exists, err := distributedCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err)
 			assert.True(t, exists)
 			readAndCompareDigest(t, ctx, distributedCache, d)
@@ -434,7 +434,7 @@ func TestBackfill(t *testing.T) {
 		}
 		digestsWritten = append(digestsWritten, d)
 		for _, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err)
 			assert.True(t, exists)
 			readAndCompareDigest(t, ctx, baseCache, d)
@@ -453,13 +453,13 @@ func TestBackfill(t *testing.T) {
 	// because it has been backfilled.
 	for _, d := range digestsWritten {
 		for _, distributedCache := range distributedCaches {
-			exists, err := distributedCache.Contains(ctx, d)
+			exists, err := distributedCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err)
 			assert.True(t, exists)
 			readAndCompareDigest(t, ctx, distributedCache, d)
 		}
 		for i, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err, fmt.Sprintf("basecache %dmissing digest", i))
 			assert.True(t, exists, fmt.Sprintf("basecache %dmissing digest", i))
 			readAndCompareDigest(t, ctx, baseCache, d)
@@ -799,7 +799,7 @@ func TestHintedHandoff(t *testing.T) {
 		}
 		digestsWritten = append(digestsWritten, d)
 		for _, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.Nil(t, err)
 			assert.True(t, exists)
 			readAndCompareDigest(t, ctx, baseCache, d)
@@ -840,7 +840,7 @@ func TestHintedHandoff(t *testing.T) {
 
 	// Ensure that dc3 successfully received all the hinted handoffs.
 	for _, d := range hintedHandoffs {
-		exists, err := memoryCache3.Contains(ctx, d)
+		exists, err := memoryCache3.ContainsDeprecated(ctx, d)
 		assert.Nil(t, err)
 		assert.True(t, exists)
 		readAndCompareDigest(t, ctx, dc3, d)
@@ -893,7 +893,7 @@ func TestDelete(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.NoError(t, err)
 			assert.True(t, exists)
 		}
@@ -903,7 +903,7 @@ func TestDelete(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, baseCache := range baseCaches {
-			exists, err := baseCache.Contains(ctx, d)
+			exists, err := baseCache.ContainsDeprecated(ctx, d)
 			assert.NoError(t, err)
 			assert.False(t, exists)
 		}

--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -153,7 +153,7 @@ func (g *GCSCache) key(ctx context.Context, d *repb.Digest) (string, error) {
 	return userPrefix + g.prefix + hash, nil
 }
 
-func (g *GCSCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+func (g *GCSCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheTypeDeprecated, remoteInstanceName string) (interfaces.Cache, error) {
 	newPrefix := filepath.Join(remoteInstanceName, cacheType.Prefix())
 	if len(newPrefix) > 0 && newPrefix[len(newPrefix)-1] != '/' {
 		newPrefix += "/"

--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -351,7 +351,7 @@ func (g *GCSCache) metadata(ctx context.Context, d *repb.Digest) (*storage.Objec
 	return nil, finalErr
 }
 
-func (g *GCSCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (g *GCSCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	metadata, err := g.metadata(ctx, d)
 	if err != nil || metadata == nil {
 		return false, err
@@ -393,7 +393,7 @@ func (g *GCSCache) FindMissing(ctx context.Context, digests []*repb.Digest) ([]*
 	for _, d := range digests {
 		fetchFn := func(d *repb.Digest) {
 			eg.Go(func() error {
-				exists, err := g.Contains(ctx, d)
+				exists, err := g.ContainsDeprecated(ctx, d)
 				if err != nil {
 					return err
 				}

--- a/enterprise/server/backends/memcache/memcache.go
+++ b/enterprise/server/backends/memcache/memcache.go
@@ -101,7 +101,7 @@ func (c *Cache) mcSet(key string, data []byte) error {
 	return c.mc.Set(makeItem(key, data))
 }
 
-func (c *Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+func (c *Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheTypeDeprecated, remoteInstanceName string) (interfaces.Cache, error) {
 	newPrefix := filepath.Join(remoteInstanceName, cacheType.Prefix())
 	if len(newPrefix) > 0 && newPrefix[len(newPrefix)-1] != '/' {
 		newPrefix += "/"

--- a/enterprise/server/backends/memcache/memcache.go
+++ b/enterprise/server/backends/memcache/memcache.go
@@ -112,7 +112,7 @@ func (c *Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheTyp
 	}, nil
 }
 
-func (c *Cache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (c *Cache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	key, err := c.key(ctx, d)
 	if err != nil {
 		return false, err
@@ -159,7 +159,7 @@ func (c *Cache) FindMissing(ctx context.Context, digests []*repb.Digest) ([]*rep
 	for _, d := range digests {
 		fetchFn := func(d *repb.Digest) {
 			eg.Go(func() error {
-				exists, err := c.Contains(ctx, d)
+				exists, err := c.ContainsDeprecated(ctx, d)
 				if err != nil {
 					return err
 				}

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -157,7 +157,7 @@ func pebbleCacheFromConfig(env environment.Env, cfg *PebbleCacheConfig) (*pebble
 	return c, nil
 }
 
-func (mc *MigrationCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+func (mc *MigrationCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheTypeDeprecated, remoteInstanceName string) (interfaces.Cache, error) {
 	srcCache, err := mc.src.WithIsolation(ctx, cacheType, remoteInstanceName)
 	if err != nil {
 		return nil, errors.WithMessage(err, "cannot get src cache with isolation")

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -174,20 +174,20 @@ func (mc *MigrationCache) WithIsolation(ctx context.Context, cacheType interface
 	return &clone, nil
 }
 
-func (mc *MigrationCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (mc *MigrationCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	eg, gctx := errgroup.WithContext(ctx)
 	var srcErr, dstErr error
 	var srcContains, dstContains bool
 
 	eg.Go(func() error {
-		srcContains, srcErr = mc.src.Contains(gctx, d)
+		srcContains, srcErr = mc.src.ContainsDeprecated(gctx, d)
 		return srcErr
 	})
 
 	doubleRead := rand.Float64() <= mc.doubleReadPercentage
 	if doubleRead {
 		eg.Go(func() error {
-			dstContains, dstErr = mc.dest.Contains(gctx, d)
+			dstContains, dstErr = mc.dest.ContainsDeprecated(gctx, d)
 			return nil // we don't care about the return error from this cache
 		})
 	}
@@ -595,7 +595,7 @@ func (mc *MigrationCache) Get(ctx context.Context, d *repb.Digest) ([]byte, erro
 }
 
 func (mc *MigrationCache) sendNonBlockingCopy(ctx context.Context, d *repb.Digest) {
-	alreadyCopied, err := mc.dest.Contains(ctx, d)
+	alreadyCopied, err := mc.dest.ContainsDeprecated(ctx, d)
 	if err != nil {
 		log.Warningf("Migration copy err, could not call Contains on dest cache: %s", err)
 		return

--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -47,7 +47,7 @@ func getAnonContext(t *testing.T, env environment.Env) context.Context {
 // copied the given digest over
 func waitForCopy(t *testing.T, ctx context.Context, destCache interfaces.Cache, digest *repb.Digest) {
 	for delay := 50 * time.Millisecond; delay < 1*time.Minute; delay *= 2 {
-		contains, err := destCache.Contains(ctx, digest)
+		contains, err := destCache.ContainsDeprecated(ctx, digest)
 		require.NoError(t, err, "error calling contains on dest cache")
 
 		if contains {
@@ -78,7 +78,7 @@ func (c *errorCache) Delete(ctx context.Context, d *repb.Digest) error {
 	return errors.New("error cache delete err")
 }
 
-func (c *errorCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (c *errorCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	return false, errors.New("error cache contains err")
 }
 
@@ -518,12 +518,12 @@ func TestContains(t *testing.T) {
 	err = mc.Set(ctx, d, buf)
 	require.NoError(t, err)
 
-	contains, err := mc.Contains(ctx, d)
+	contains, err := mc.ContainsDeprecated(ctx, d)
 	require.NoError(t, err)
 	require.True(t, contains)
 
 	notWrittenDigest, _ := testdigest.NewRandomDigestBuf(t, 100)
-	contains, err = mc.Contains(ctx, notWrittenDigest)
+	contains, err = mc.ContainsDeprecated(ctx, notWrittenDigest)
 	require.NoError(t, err)
 	require.False(t, contains)
 }
@@ -544,7 +544,7 @@ func TestContains_DestErr(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should return data from src cache without error
-	contains, err := mc.Contains(ctx, d)
+	contains, err := mc.ContainsDeprecated(ctx, d)
 	require.NoError(t, err)
 	require.True(t, contains)
 }

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -795,7 +795,7 @@ func (p *PebbleCache) lookupGroupAndPartitionID(ctx context.Context, remoteInsta
 	return user.GetGroupID(), defaultPartitionID, nil
 }
 
-func (p *PebbleCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+func (p *PebbleCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheTypeDeprecated, remoteInstanceName string) (interfaces.Cache, error) {
 	groupID, partID, err := p.lookupGroupAndPartitionID(ctx, remoteInstanceName)
 	if err != nil {
 		return nil, err

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -873,7 +873,7 @@ func (p *PebbleCache) handleMetadataMismatch(err error, fileMetadataKey []byte, 
 	}
 }
 
-func (p *PebbleCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (p *PebbleCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	db, err := p.leaser.DB()
 	if err != nil {
 		return false, err

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -157,7 +157,7 @@ func TestIsolation(t *testing.T) {
 		cache2         interfaces.Cache
 		shouldBeShared bool
 	}
-	mustIsolate := func(cacheType interfaces.CacheType, remoteInstanceName string) interfaces.Cache {
+	mustIsolate := func(cacheType interfaces.CacheTypeDeprecated, remoteInstanceName string) interfaces.Cache {
 		c, err := pc.WithIsolation(ctx, cacheType, remoteInstanceName)
 		if err != nil {
 			t.Fatalf("Error isolating cache: %s", err)
@@ -787,7 +787,7 @@ func TestStartupScan(t *testing.T) {
 }
 
 type digestAndType struct {
-	cacheType interfaces.CacheType
+	cacheType interfaces.CacheTypeDeprecated
 	digest    *repb.Digest
 }
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -447,7 +447,7 @@ func TestSizeLimit(t *testing.T) {
 	// size bytes.
 	containedDigestsSize := int64(0)
 	for _, d := range digestKeys {
-		if ok, err := pc.Contains(ctx, d); err == nil && ok {
+		if ok, err := pc.ContainsDeprecated(ctx, d); err == nil && ok {
 			containedDigestsSize += d.GetSizeBytes()
 		}
 	}
@@ -583,7 +583,7 @@ func TestLRU(t *testing.T) {
 
 	evictionsByQuartile := make([][]*repb.Digest, 5)
 	for i, d := range digestKeys {
-		ok, err := pc.Contains(ctx, d)
+		ok, err := pc.ContainsDeprecated(ctx, d)
 		evicted := err != nil || !ok
 		q := i / quartile
 		if evicted {
@@ -1093,7 +1093,7 @@ func BenchmarkContains1(b *testing.B) {
 	b.StopTimer()
 	for n := 0; n < b.N; n++ {
 		b.StartTimer()
-		found, err := pc.Contains(ctx, digestKeys[rand.Intn(len(digestKeys))])
+		found, err := pc.ContainsDeprecated(ctx, digestKeys[rand.Intn(len(digestKeys))])
 		b.StopTimer()
 		if err != nil {
 			b.Fatal(err)

--- a/enterprise/server/backends/redis_cache/redis_cache.go
+++ b/enterprise/server/backends/redis_cache/redis_cache.go
@@ -134,7 +134,7 @@ func (c *Cache) rdbSet(ctx context.Context, key string, data []byte) error {
 	return err
 }
 
-func (c *Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+func (c *Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheTypeDeprecated, remoteInstanceName string) (interfaces.Cache, error) {
 	newPrefix := filepath.Join(remoteInstanceName, cacheType.Prefix())
 	if len(newPrefix) > 0 && newPrefix[len(newPrefix)-1] != '/' {
 		newPrefix += "/"

--- a/enterprise/server/backends/redis_cache/redis_cache.go
+++ b/enterprise/server/backends/redis_cache/redis_cache.go
@@ -146,7 +146,7 @@ func (c *Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheTyp
 	}, nil
 }
 
-func (c *Cache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (c *Cache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	key, err := c.key(ctx, d)
 	if err != nil {
 		return false, err

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -250,7 +250,7 @@ func isNotFoundErr(err error) bool {
 	}
 }
 
-func (s3c *S3Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+func (s3c *S3Cache) WithIsolation(ctx context.Context, cacheType interfaces.CacheTypeDeprecated, remoteInstanceName string) (interfaces.Cache, error) {
 	newPrefix := filepath.Join(remoteInstanceName, cacheType.Prefix())
 	if len(newPrefix) > 0 && newPrefix[len(newPrefix)-1] != '/' {
 		newPrefix += "/"

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -405,7 +405,7 @@ func (s3c *S3Cache) bumpTTLIfStale(ctx context.Context, key string, t time.Time)
 	return true
 }
 
-func (s3c *S3Cache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (s3c *S3Cache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	timer := cache_metrics.NewCacheTimer(cacheLabels)
 	var err error
 	defer timer.ObserveContains(err)
@@ -474,7 +474,7 @@ func (s3c *S3Cache) FindMissing(ctx context.Context, digests []*repb.Digest) ([]
 	for _, d := range digests {
 		fetchFn := func(d *repb.Digest) {
 			eg.Go(func() error {
-				exists, err := s3c.Contains(ctx, d)
+				exists, err := s3c.ContainsDeprecated(ctx, d)
 				if err != nil {
 					return err
 				}

--- a/enterprise/server/composable_cache/composable_cache.go
+++ b/enterprise/server/composable_cache/composable_cache.go
@@ -31,7 +31,7 @@ func NewComposableCache(outer, inner interfaces.Cache, mode CacheMode) interface
 	}
 }
 
-func (c *ComposableCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+func (c *ComposableCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheTypeDeprecated, remoteInstanceName string) (interfaces.Cache, error) {
 	newInner, err := c.inner.WithIsolation(ctx, cacheType, remoteInstanceName)
 	if err != nil {
 		return nil, status.WrapError(err, "WithIsolation failed on inner cache")

--- a/enterprise/server/composable_cache/composable_cache.go
+++ b/enterprise/server/composable_cache/composable_cache.go
@@ -47,13 +47,13 @@ func (c *ComposableCache) WithIsolation(ctx context.Context, cacheType interface
 	}, nil
 }
 
-func (c *ComposableCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
-	outerExists, err := c.outer.Contains(ctx, d)
+func (c *ComposableCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
+	outerExists, err := c.outer.ContainsDeprecated(ctx, d)
 	if err == nil && outerExists {
 		return outerExists, nil
 	}
 
-	return c.inner.Contains(ctx, d)
+	return c.inner.ContainsDeprecated(ctx, d)
 }
 
 func (c *ComposableCache) Metadata(ctx context.Context, d *repb.Digest) (*interfaces.CacheMetadata, error) {

--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -311,7 +311,7 @@ func (rc *RaftCache) lookupPartitionID(ctx context.Context, remoteInstanceName s
 	return DefaultPartitionID, nil
 }
 
-func (rc *RaftCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+func (rc *RaftCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheTypeDeprecated, remoteInstanceName string) (interfaces.Cache, error) {
 	partID, err := rc.lookupPartitionID(ctx, remoteInstanceName)
 	if err != nil {
 		return nil, err

--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -445,7 +445,7 @@ func (rc *RaftCache) Stop() error {
 	return nil
 }
 
-func (rc *RaftCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (rc *RaftCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	missing, err := rc.FindMissing(ctx, []*repb.Digest{d})
 	if err != nil {
 		return false, err

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -154,7 +154,7 @@ func (c *CacheProxy) getClient(ctx context.Context, peer string) (dcpb.Distribut
 	return client, nil
 }
 
-func ProtoCacheTypeToCacheType(cacheType dcpb.Isolation_CacheType) (interfaces.CacheType, error) {
+func ProtoCacheTypeToCacheType(cacheType dcpb.Isolation_CacheType) (interfaces.CacheTypeDeprecated, error) {
 	switch cacheType {
 	case dcpb.Isolation_CAS_CACHE:
 		return interfaces.CASCacheType, nil

--- a/enterprise/server/util/cacheproxy/cacheproxy_test.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy_test.go
@@ -137,7 +137,7 @@ type snitchCache struct {
 	writeCount map[string]int
 }
 
-func (s *snitchCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+func (s *snitchCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheTypeDeprecated, remoteInstanceName string) (interfaces.Cache, error) {
 	c, err := s.Cache.WithIsolation(ctx, cacheType, remoteInstanceName)
 	if err != nil {
 		return nil, err

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -819,7 +819,6 @@ func ScanDiskDirectory(scanDir string) <-chan *rfpb.FileMetadata {
 	return scanned
 }
 
-// TODO: Make sure they map to the same numbers
 type fileKey struct {
 	part               *partition
 	cacheType          resource.CacheType

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -314,7 +314,7 @@ func (c *DiskCache) Statusz(ctx context.Context) string {
 	return buf
 }
 
-func (c *DiskCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (c *DiskCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	record, err := c.partition.lruGet(ctx, c.cacheType, c.remoteInstanceName, d)
 	contains := record != nil
 	return contains, err

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -927,7 +927,7 @@ func TestScanDiskDirectoryV1(t *testing.T) {
 
 	tests := []struct {
 		remoteInstanceName string
-		cacheType          interfaces.CacheType
+		cacheType          interfaces.CacheTypeDeprecated
 		apiKey             string
 		expectedPartition  string
 	}{
@@ -1049,7 +1049,7 @@ func TestScanDiskDirectoryV2(t *testing.T) {
 
 	tests := []struct {
 		remoteInstanceName string
-		cacheType          interfaces.CacheType
+		cacheType          interfaces.CacheTypeDeprecated
 		apiKey             string
 		expectedPartition  string
 	}{

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -367,7 +367,7 @@ func TestLRU(t *testing.T) {
 		digestKeys = append(digestKeys, d)
 	}
 	// Now "use" the first digest written so it is most recently used.
-	ok, err := dc.Contains(ctx, digestKeys[0])
+	ok, err := dc.ContainsDeprecated(ctx, digestKeys[0])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -464,7 +464,7 @@ func TestAsyncLoading(t *testing.T) {
 	// Ensure that files on disk exist *immediately*, even though
 	// they may not have been async processed yet.
 	for _, d := range digests {
-		exists, err := dc.Contains(ctx, d)
+		exists, err := dc.ContainsDeprecated(ctx, d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -485,7 +485,7 @@ func TestAsyncLoading(t *testing.T) {
 
 	// Check that everything still exists.
 	for _, d := range digests {
-		exists, err := dc.Contains(ctx, d)
+		exists, err := dc.ContainsDeprecated(ctx, d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -527,7 +527,7 @@ func TestJanitorThread(t *testing.T) {
 		if i > 500 {
 			break
 		}
-		contains, err := dc.Contains(ctx, d)
+		contains, err := dc.ContainsDeprecated(ctx, d)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -568,7 +568,7 @@ func TestZeroLengthFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Ensure that the goodDigest exists and the zero length one does not.
-	exists, err := dc.Contains(ctx, badDigest)
+	exists, err := dc.ContainsDeprecated(ctx, badDigest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -576,7 +576,7 @@ func TestZeroLengthFiles(t *testing.T) {
 		t.Fatalf("%q (empty file) should not be mapped in cache.", badDigest.GetHash())
 	}
 
-	exists, err = dc.Contains(ctx, goodDigest)
+	exists, err = dc.ContainsDeprecated(ctx, goodDigest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -748,7 +748,7 @@ func TestV2Layout(t *testing.T) {
 	dPath := filepath.Join(userRoot, d.GetHash()[0:disk_cache.HashPrefixDirPrefixLen], d.GetHash())
 	require.FileExists(t, dPath)
 
-	ok, err := dc.Contains(ctx, d)
+	ok, err := dc.ContainsDeprecated(ctx, d)
 	require.NoError(t, err)
 	require.Truef(t, ok, "digest should be in the cache")
 
@@ -845,7 +845,7 @@ func TestV2LayoutMigration(t *testing.T) {
 		require.NoError(t, err)
 
 		d := &repb.Digest{Hash: testHash, SizeBytes: 5}
-		ok, err := ic.Contains(ctx, d)
+		ok, err := ic.ContainsDeprecated(ctx, d)
 		require.NoError(t, err)
 		require.True(t, ok, "digest should be in the cache")
 
@@ -861,7 +861,7 @@ func TestV2LayoutMigration(t *testing.T) {
 		ic, err := dc.WithIsolation(ctx, interfaces.CASCacheType, "" /*=instanceName*/)
 
 		d := &repb.Digest{Hash: testHash, SizeBytes: 5}
-		ok, err := ic.Contains(ctx, d)
+		ok, err := ic.ContainsDeprecated(ctx, d)
 		require.NoError(t, err)
 		require.True(t, ok, "digest should be in the cache")
 
@@ -878,7 +878,7 @@ func TestV2LayoutMigration(t *testing.T) {
 		require.NoError(t, err)
 
 		d := &repb.Digest{Hash: testHash, SizeBytes: 5}
-		ok, err := ic.Contains(ctx, d)
+		ok, err := ic.ContainsDeprecated(ctx, d)
 		require.NoError(t, err)
 		require.True(t, ok, "digest should be in the cache")
 

--- a/server/backends/memory_cache/memory_cache.go
+++ b/server/backends/memory_cache/memory_cache.go
@@ -25,7 +25,7 @@ var cacheInMemory = flag.Bool("cache.in_memory", false, "Whether or not to use t
 type MemoryCache struct {
 	l                  interfaces.LRU
 	lock               *sync.RWMutex
-	cacheType          interfaces.CacheType
+	cacheType          interfaces.CacheTypeDeprecated
 	remoteInstanceName string
 }
 
@@ -88,7 +88,7 @@ func (m *MemoryCache) key(ctx context.Context, d *repb.Digest) (string, error) {
 	return key, nil
 }
 
-func (m *MemoryCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheType, remoteInstanceName string) (interfaces.Cache, error) {
+func (m *MemoryCache) WithIsolation(ctx context.Context, cacheType interfaces.CacheTypeDeprecated, remoteInstanceName string) (interfaces.Cache, error) {
 	return &MemoryCache{
 		l:                  m.l,
 		lock:               m.lock,

--- a/server/backends/memory_cache/memory_cache.go
+++ b/server/backends/memory_cache/memory_cache.go
@@ -97,7 +97,7 @@ func (m *MemoryCache) WithIsolation(ctx context.Context, cacheType interfaces.Ca
 	}, nil
 }
 
-func (m *MemoryCache) Contains(ctx context.Context, d *repb.Digest) (bool, error) {
+func (m *MemoryCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
 	k, err := m.key(ctx, d)
 	if err != nil {
 		return false, err
@@ -134,7 +134,7 @@ func (m *MemoryCache) FindMissing(ctx context.Context, digests []*repb.Digest) (
 	var missing []*repb.Digest
 	// No parallelism here either. Not necessary for an in-memory cache.
 	for _, d := range digests {
-		ok, err := m.Contains(ctx, d)
+		ok, err := m.ContainsDeprecated(ctx, d)
 		if err != nil {
 			return nil, err
 		}

--- a/server/backends/memory_cache/memory_cache_test.go
+++ b/server/backends/memory_cache/memory_cache_test.go
@@ -49,7 +49,7 @@ func TestIsolation(t *testing.T) {
 		cache2         interfaces.Cache
 		shouldBeShared bool
 	}
-	mustIsolate := func(cacheType interfaces.CacheType, remoteInstanceName string) interfaces.Cache {
+	mustIsolate := func(cacheType interfaces.CacheTypeDeprecated, remoteInstanceName string) interfaces.Cache {
 		c, err := mc.WithIsolation(ctx, cacheType, remoteInstanceName)
 		if err != nil {
 			t.Fatalf("Error isolating cache: %s", err)

--- a/server/backends/memory_cache/memory_cache_test.go
+++ b/server/backends/memory_cache/memory_cache_test.go
@@ -302,7 +302,7 @@ func TestLRU(t *testing.T) {
 		digestKeys = append(digestKeys, d)
 	}
 	// Now "use" the first digest written so it is most recently used.
-	ok, err := mc.Contains(ctx, digestKeys[0])
+	ok, err := mc.ContainsDeprecated(ctx, digestKeys[0])
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -919,7 +919,7 @@ func (s *BuildBuddyServer) GetCacheMetadata(ctx context.Context, req *capb.GetCa
 	}, nil
 }
 
-func ProtoCacheTypeToCacheType(cacheType resource.CacheType) (interfaces.CacheType, error) {
+func ProtoCacheTypeToCacheType(cacheType resource.CacheType) (interfaces.CacheTypeDeprecated, error) {
 	switch cacheType {
 	case resource.CacheType_AC:
 		return interfaces.ActionCacheType, nil

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -26,6 +26,7 @@ import (
 	qpb "github.com/buildbuddy-io/buildbuddy/proto/quota"
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 	telpb "github.com/buildbuddy-io/buildbuddy/proto/telemetry"
@@ -215,6 +216,18 @@ func (t CacheTypeDeprecated) Prefix() string {
 	default:
 		alert.UnexpectedEvent("unknown_cache_type", "type: %v", t)
 		return "unknown"
+	}
+}
+
+func (t CacheTypeDeprecated) ToResourceNameCacheType() rspb.CacheType {
+	switch t {
+	case ActionCacheType:
+		return rspb.CacheType_AC
+	case CASCacheType:
+		return rspb.CacheType_AC
+	default:
+		alert.UnexpectedEvent("unknown_cache_type", "type: %v", t)
+		return rspb.CacheType_UNKNOWN_CACHE_TYPE
 	}
 }
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -224,7 +224,7 @@ func (t CacheTypeDeprecated) ToResourceNameCacheType() rspb.CacheType {
 	case ActionCacheType:
 		return rspb.CacheType_AC
 	case CASCacheType:
-		return rspb.CacheType_AC
+		return rspb.CacheType_CAS
 	default:
 		alert.UnexpectedEvent("unknown_cache_type", "type: %v", t)
 		return rspb.CacheType_UNKNOWN_CACHE_TYPE

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -198,15 +198,15 @@ type Blobstore interface {
 	DeleteBlob(ctx context.Context, blobName string) error
 }
 
-type CacheType int
+type CacheTypeDeprecated int
 
 const (
-	UnknownCacheType CacheType = iota
+	UnknownCacheType CacheTypeDeprecated = iota
 	ActionCacheType
 	CASCacheType
 )
 
-func (t CacheType) Prefix() string {
+func (t CacheTypeDeprecated) Prefix() string {
 	switch t {
 	case ActionCacheType:
 		return "ac"
@@ -233,7 +233,7 @@ type CacheMetadata struct {
 type Cache interface {
 	// WithIsolation returns a cache accessor that guarantees that data for a given cacheType and
 	// remoteInstanceCombination is isolated from any other cacheType and remoteInstanceName combination.
-	WithIsolation(ctx context.Context, cacheType CacheType, remoteInstanceName string) (Cache, error)
+	WithIsolation(ctx context.Context, cacheType CacheTypeDeprecated, remoteInstanceName string) (Cache, error)
 
 	// Normal cache-like operations.
 	ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error)

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -236,7 +236,7 @@ type Cache interface {
 	WithIsolation(ctx context.Context, cacheType CacheType, remoteInstanceName string) (Cache, error)
 
 	// Normal cache-like operations.
-	Contains(ctx context.Context, d *repb.Digest) (bool, error)
+	ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error)
 	Metadata(ctx context.Context, d *repb.Digest) (*CacheMetadata, error)
 	FindMissing(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error)
 	Get(ctx context.Context, d *repb.Digest) ([]byte, error)

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"flag"
 	"fmt"
+	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"hash"
 	"io"
 
@@ -251,7 +252,12 @@ func (s *ByteStreamServer) initStreamState(ctx context.Context, req *bspb.WriteR
 	// Protocol does say that if another parallel write had finished while
 	// this one was ongoing, we can immediately return a response with the
 	// committed size, so we'll just do that.
-	exists, err := cache.ContainsDeprecated(ctx, r.GetDigest())
+	exists, err := s.cache.Contains(ctx, &resource.ResourceName{
+		Digest:       r.GetDigest(),
+		InstanceName: r.GetInstanceName(),
+		Compressor:   repb.Compressor_IDENTITY,
+		CacheType:    resource.CacheType_CAS,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"flag"
 	"fmt"
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"hash"
 	"io"
 
@@ -252,12 +251,7 @@ func (s *ByteStreamServer) initStreamState(ctx context.Context, req *bspb.WriteR
 	// Protocol does say that if another parallel write had finished while
 	// this one was ongoing, we can immediately return a response with the
 	// committed size, so we'll just do that.
-	exists, err := s.cache.Contains(ctx, &resource.ResourceName{
-		Digest:       r.GetDigest(),
-		InstanceName: r.GetInstanceName(),
-		Compressor:   repb.Compressor_IDENTITY,
-		CacheType:    resource.CacheType_CAS,
-	})
+	exists, err := cache.ContainsDeprecated(ctx, r.GetDigest())
 	if err != nil {
 		return nil, err
 	}

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -251,7 +251,7 @@ func (s *ByteStreamServer) initStreamState(ctx context.Context, req *bspb.WriteR
 	// Protocol does say that if another parallel write had finished while
 	// this one was ongoing, we can immediately return a response with the
 	// committed size, so we'll just do that.
-	exists, err := cache.Contains(ctx, r.GetDigest())
+	exists, err := cache.ContainsDeprecated(ctx, r.GetDigest())
 	if err != nil {
 		return nil, err
 	}

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/protobuf/proto"
@@ -102,6 +103,18 @@ func (r *ResourceName) UploadString() (string, error) {
 		instanceName, u.String(), blobTypeSegment(r.GetCompressor()),
 		r.GetDigest().GetHash(), r.GetDigest().GetSizeBytes(),
 	), nil
+}
+
+func CacheTypeToPrefix(cacheType rspb.CacheType) string {
+	switch cacheType {
+	case rspb.CacheType_CAS:
+		return ""
+	case rspb.CacheType_AC:
+		return "ac"
+	default:
+		alert.UnexpectedEvent("unknown_cache_type", "type: %v", cacheType)
+		return "unknown"
+	}
 }
 
 // Key is a representation of a digest that can be used as a map key.


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: TODO <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
