### PR TITLE
Fix time formatting for target test cases card

### DIFF
--- a/app/target/target_test_cases_card.tsx
+++ b/app/target/target_test_cases_card.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import format from "../format/format";
 import { AlertCircle, XCircle, PlayCircle, CheckCircle } from "lucide-react";
 import { invocation } from "../../proto/invocation_ts_proto";
+import { durationToMillisWithFallback } from "../util/proto";
 
 interface Props {
   testResult: invocation.InvocationEvent;
@@ -63,7 +64,12 @@ export default class TargetTestCasesCardComponent extends React.Component<Props>
             <div className="title">{this.props.testSuite.getAttribute("name")}</div>
             <div className="test-subtitle">
               {testCases.length} {testCases.length == 1 ? "test" : "tests"} {this.getStatusTitle()} in{" "}
-              {format.durationSec(this.props.testResult.buildEvent.testResult.testAttemptDuration.seconds)}
+              {format.durationMillis(
+                durationToMillisWithFallback(
+                  this.props.testResult.buildEvent.testResult.testAttemptDuration,
+                  this.props.testResult.buildEvent.testResult.testAttemptDurationMillis
+                )
+              )}
             </div>
             <div className="test-document">
               <div className="test-suite">


### PR DESCRIPTION
Uses the `durationToMillisWithFallback` util to be backwards-compatible with old versions of Bazel that return time values as millis instead of duration protos.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
