### PR TITLE
Switch the ordering of the resource.proto CacheType enum

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -48,6 +48,7 @@ ts_library(
         "//proto:grpc_code_ts_proto",
         "//proto:invocation_ts_proto",
         "//proto:remote_execution_ts_proto",
+        "//proto:resource_ts_proto",
         "//proto:user_ts_proto",
         "//proto:workflow_ts_proto",
         "@npm//@types/dagre-d3",

--- a/app/invocation/cache_requests_card.tsx
+++ b/app/invocation/cache_requests_card.tsx
@@ -4,6 +4,7 @@ import InvocationModel from "./invocation_model";
 import { X, ArrowUp, ArrowDown, ArrowLeftRight, ChevronRight, Check, SortAsc, SortDesc } from "lucide-react";
 import { cache } from "../../proto/cache_ts_proto";
 import { invocation } from "../../proto/invocation_ts_proto";
+import { resource } from "../../proto/resource_ts_proto";
 import rpc_service from "../service/rpc_service";
 import DigestComponent from "../components/digest/digest";
 import Link, { TextLink } from "../components/link/link";
@@ -374,6 +375,7 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
   private getCacheMetadata(scorecardResult: cache.ScoreCard.IResult) {
     const digest = scorecardResult.digest;
     const remoteInstanceName = this.props.model.getRemoteInstanceName();
+    const ct = toResourceCacheType(scorecardResult.cacheType);
 
     // Set an empty struct in the map so the FE doesn't fire duplicate requests while the first request is in progress
     // or if there is an invalid result
@@ -383,7 +385,7 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
       .getCacheMetadata({
         resourceName: {
           digest: digest,
-          cacheType: scorecardResult.cacheType,
+          cacheType: ct,
           instanceName: remoteInstanceName,
         },
       })
@@ -710,4 +712,15 @@ function groupResults(
  */
 function looksLikeDigest(actionId: string) {
   return actionId.length === 64;
+}
+
+function toResourceCacheType(ct: cache.CacheType) {
+  switch(ct) {
+    case cache.CacheType.CAS:
+      return resource.CacheType.CAS;
+    case cache.CacheType.AC:
+      return resource.CacheType.AC;
+    default:
+      return resource.CacheType.UNKNOWN_CACHE_TYPE;
+  }
 }

--- a/app/invocation/cache_requests_card.tsx
+++ b/app/invocation/cache_requests_card.tsx
@@ -375,7 +375,7 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
   private getCacheMetadata(scorecardResult: cache.ScoreCard.IResult) {
     const digest = scorecardResult.digest;
     const remoteInstanceName = this.props.model.getRemoteInstanceName();
-    const ct = toResourceCacheType(scorecardResult.cacheType);
+    const cacheType = toResourceCacheType(scorecardResult.cacheType);
 
     // Set an empty struct in the map so the FE doesn't fire duplicate requests while the first request is in progress
     // or if there is an invalid result
@@ -385,7 +385,7 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
       .getCacheMetadata({
         resourceName: {
           digest: digest,
-          cacheType: ct,
+          cacheType: cacheType,
           instanceName: remoteInstanceName,
         },
       })
@@ -714,8 +714,8 @@ function looksLikeDigest(actionId: string) {
   return actionId.length === 64;
 }
 
-function toResourceCacheType(ct: cache.CacheType) {
-  switch(ct) {
+function toResourceCacheType(cacheType: cache.CacheType) {
+  switch(cacheType) {
     case cache.CacheType.CAS:
       return resource.CacheType.CAS;
     case cache.CacheType.AC:

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -922,6 +922,11 @@ ts_proto_library(
 )
 
 ts_proto_library(
+    name = "resource_ts_proto",
+    proto = ":resource_proto",
+)
+
+ts_proto_library(
     name = "target_ts_proto",
     proto = ":target_proto",
 )

--- a/proto/resource.proto
+++ b/proto/resource.proto
@@ -32,8 +32,8 @@ message ResourceName {
 // CacheType represents the type of cache being written to.
 enum CacheType {
   UNKNOWN_CACHE_TYPE = 0;
-  // Content addressable storage (CAS) cache.
-  CAS = 1;
   // Action cache (AC).
-  AC = 2;
+  AC = 1;
+  // Content addressable storage (CAS) cache.
+  CAS = 2;
 }


### PR DESCRIPTION
See motivation for this change here:
https://github.com/buildbuddy-io/buildbuddy/pull/2649#discussion_r987289928
