### PR TITLE
Bug fixes / improvements for FetchBlob

### DIFF
--- a/server/remote_asset/fetch_server/fetch_server.go
+++ b/server/remote_asset/fetch_server/fetch_server.go
@@ -132,43 +132,17 @@ func (p *FetchServer) FetchBlob(ctx context.Context, req *rapb.FetchBlobRequest)
 
 	// Keep track of the last fetch error so that if we fail to fetch, we at
 	// least have something we can return to the client.
-	var fetchErr error
-	setFetchErr := func(err error) {
-		fetchErr = err
-		log.Warning(status.Message(err))
-	}
+	var lastFetchErr error
 
 	for _, uri := range req.GetUris() {
 		_, err := url.Parse(uri)
 		if err != nil {
 			return nil, status.InvalidArgumentErrorf("unparsable URI: %q", uri)
 		}
-		rsp, err := httpClient.Get(uri)
+		blobDigest, err := mirrorToCache(ctx, cache, httpClient, uri, expectedSHA256)
 		if err != nil {
-			setFetchErr(status.UnavailableErrorf("failed to fetch %q: HTTP GET failed: %s", uri, err))
-			continue
-		}
-		defer rsp.Body.Close()
-		if rsp.StatusCode < 200 || rsp.StatusCode >= 400 {
-			setFetchErr(status.UnavailableErrorf("failed to fetch %q: HTTP %s", uri, err))
-			continue
-		}
-		data, err := io.ReadAll(rsp.Body)
-		if err != nil {
-			setFetchErr(status.UnavailableErrorf("failed to read response body from %q: %s", uri, err))
-			continue
-		}
-		blobDigest, err := digest.Compute(bytes.NewReader(data))
-		if err != nil {
-			setFetchErr(status.InternalErrorf("failed to compute digest: %s", err))
-			continue
-		}
-		if expectedSHA256 != "" && blobDigest.Hash != expectedSHA256 {
-			setFetchErr(status.InvalidArgumentErrorf("response body checksum for %q was %q but wanted %q", uri, blobDigest.Hash, expectedSHA256))
-			continue
-		}
-		if err := cache.Set(ctx, blobDigest, data); err != nil {
-			setFetchErr(status.InternalErrorf("failed to add object to cache: %s", err))
+			lastFetchErr = err
+			log.Warningf("Failed to mirror %q to cache: %s", uri, err)
 			continue
 		}
 		return &rapb.FetchBlobResponse{
@@ -186,11 +160,41 @@ func (p *FetchServer) FetchBlob(ctx context.Context, req *rapb.FetchBlobRequest)
 			// make sense in some cases, but it's unclear at the moment whether
 			// there is any benefit to using those.)
 			Code:    int32(gcodes.NotFound),
-			Message: status.Message(fetchErr),
+			Message: status.Message(lastFetchErr),
 		},
 	}, nil
 }
 
 func (p *FetchServer) FetchDirectory(ctx context.Context, req *rapb.FetchDirectoryRequest) (*rapb.FetchDirectoryResponse, error) {
 	return nil, status.UnimplementedError("FetchDirectory is not yet implemented")
+}
+
+// mirrorToCache uploads the contents at the given URI to the given cache,
+// returning the digest. The fetched contents are checked against the given
+// expectedSHA256 (if non-empty), and if there is a mismatch then an error is
+// returned.
+func mirrorToCache(ctx context.Context, cache interfaces.Cache, httpClient *http.Client, uri, expectedSHA256 string) (*repb.Digest, error) {
+	rsp, err := httpClient.Get(uri)
+	if err != nil {
+		return nil, status.UnavailableErrorf("failed to fetch %q: HTTP GET failed: %s", uri, err)
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode < 200 || rsp.StatusCode >= 400 {
+		return nil, status.UnavailableErrorf("failed to fetch %q: HTTP %s", uri, err)
+	}
+	data, err := io.ReadAll(rsp.Body)
+	if err != nil {
+		return nil, status.UnavailableErrorf("failed to read response body from %q: %s", uri, err)
+	}
+	blobDigest, err := digest.Compute(bytes.NewReader(data))
+	if err != nil {
+		return nil, status.InternalErrorf("failed to compute digest: %s", err)
+	}
+	if expectedSHA256 != "" && blobDigest.Hash != expectedSHA256 {
+		return nil, status.InvalidArgumentErrorf("response body checksum for %q was %q but wanted %q", uri, blobDigest.Hash, expectedSHA256)
+	}
+	if err := cache.Set(ctx, blobDigest, data); err != nil {
+		return nil, status.InternalErrorf("failed to add object to cache: %s", err)
+	}
+	return blobDigest, nil
 }

--- a/server/remote_asset/fetch_server/fetch_server.go
+++ b/server/remote_asset/fetch_server/fetch_server.go
@@ -105,6 +105,8 @@ func (p *FetchServer) FetchBlob(ctx context.Context, req *rapb.FetchBlobRequest)
 		return nil, err
 	}
 
+	var expectedSHA256 string
+
 	for _, qualifier := range req.GetQualifiers() {
 		if qualifier.GetName() == checksumQualifier && strings.HasPrefix(qualifier.GetValue(), sha256Prefix) {
 			b64sha256 := strings.TrimPrefix(qualifier.GetValue(), sha256Prefix)
@@ -116,6 +118,7 @@ func (p *FetchServer) FetchBlob(ctx context.Context, req *rapb.FetchBlobRequest)
 				Hash:      fmt.Sprintf("%x", sha256),
 				SizeBytes: int64(-1),
 			}
+			expectedSHA256 = blobDigest.Hash
 			if data, err := cache.Get(ctx, blobDigest); err == nil {
 				blobDigest.SizeBytes = int64(len(data)) // set the actual correct size.
 				return &rapb.FetchBlobResponse{
@@ -126,28 +129,46 @@ func (p *FetchServer) FetchBlob(ctx context.Context, req *rapb.FetchBlobRequest)
 		}
 	}
 	httpClient := timeoutHTTPClient(ctx, req.GetTimeout())
+
+	// Keep track of the last fetch error so that if we fail to fetch, we at
+	// least have something we can return to the client.
+	var fetchErr error
+	setFetchErr := func(err error) {
+		fetchErr = err
+		log.Warning(status.Message(err))
+	}
+
 	for _, uri := range req.GetUris() {
 		_, err := url.Parse(uri)
 		if err != nil {
-			return nil, status.InvalidArgumentErrorf("Unparsable URI: %q", uri)
+			return nil, status.InvalidArgumentErrorf("unparsable URI: %q", uri)
 		}
 		rsp, err := httpClient.Get(uri)
 		if err != nil {
-			return nil, status.AbortedErrorf("Error fetching URI  %q: %s", uri, err.Error())
+			setFetchErr(status.UnavailableErrorf("failed to fetch %q: HTTP GET failed: %s", uri, err))
+			continue
+		}
+		defer rsp.Body.Close()
+		if rsp.StatusCode < 200 || rsp.StatusCode >= 400 {
+			setFetchErr(status.UnavailableErrorf("failed to fetch %q: HTTP %s", uri, err))
+			continue
 		}
 		data, err := io.ReadAll(rsp.Body)
 		if err != nil {
-			log.Warningf("Error reading object bytes: %s", err.Error())
+			setFetchErr(status.UnavailableErrorf("failed to read response body from %q: %s", uri, err))
 			continue
 		}
-		reader := bytes.NewReader(data)
-		blobDigest, err := digest.Compute(reader)
+		blobDigest, err := digest.Compute(bytes.NewReader(data))
 		if err != nil {
-			log.Warningf("Error computing object digest: %s", err.Error())
+			setFetchErr(status.InternalErrorf("failed to compute digest: %s", err))
+			continue
+		}
+		if expectedSHA256 != "" && blobDigest.Hash != expectedSHA256 {
+			setFetchErr(status.InvalidArgumentErrorf("response body checksum for %q was %q but wanted %q", uri, blobDigest.Hash, expectedSHA256))
 			continue
 		}
 		if err := cache.Set(ctx, blobDigest, data); err != nil {
-			log.Warningf("Error inserting object into cache: %s", err.Error())
+			setFetchErr(status.InternalErrorf("failed to add object to cache: %s", err))
 			continue
 		}
 		return &rapb.FetchBlobResponse{
@@ -158,7 +179,10 @@ func (p *FetchServer) FetchBlob(ctx context.Context, req *rapb.FetchBlobRequest)
 	}
 
 	return &rapb.FetchBlobResponse{
-		Status: &statuspb.Status{Code: int32(gcodes.NotFound)},
+		Status: &statuspb.Status{
+			Code:    int32(gcodes.NotFound),
+			Message: status.Message(fetchErr),
+		},
 	}, nil
 }
 

--- a/server/remote_asset/fetch_server/fetch_server.go
+++ b/server/remote_asset/fetch_server/fetch_server.go
@@ -180,6 +180,11 @@ func (p *FetchServer) FetchBlob(ctx context.Context, req *rapb.FetchBlobRequest)
 
 	return &rapb.FetchBlobResponse{
 		Status: &statuspb.Status{
+			// Note: returning NotFound here because the other error codes in
+			// the proto documentation for FetchBlobResponse.status don't really
+			// apply when we fail to fetch. (PermissionDenied and Aborted might
+			// make sense in some cases, but it's unclear at the moment whether
+			// there is any benefit to using those.)
 			Code:    int32(gcodes.NotFound),
 			Message: status.Message(fetchErr),
 		},


### PR DESCRIPTION
Bug fixes:
* If the remote URI returns an HTTP error status, return an error instead of reading the response body. This can cause empty responses to be returned.
* If we fail to fetch a particular URI, continue to the next URI instead of returning `Aborted`.
* Make sure we call `Close()` on the response body (documentation says the caller is responsible for calling `Close()`).

Improvements:
* Record the last fetch error and return it in the status message, in addition to logging. (We still return a gRPC code of NotFound so this should functionally be a NOP, but improve debuggability.)
* Make sure all logged error messages include the URI.
* Do a checksum on our side (since it's simple enough to do) so that we don't store useless blobs into the cache and so that the client doesn't have to download a bad payload only to fail the checksum on their side.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
