### PR TITLE
Fix symlink paths

### DIFF
--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -824,7 +824,8 @@ func DownloadTree(ctx context.Context, env environment.Env, instanceName string,
 			}
 		}
 		for _, symlinkNode := range dir.GetSymlinks() {
-			if err := os.Symlink(symlinkNode.GetTarget(), symlinkNode.GetName()); err != nil {
+			nodeAbsPath := filepath.Join(parentDir, symlinkNode.GetName())
+			if err := os.Symlink(symlinkNode.GetTarget(), nodeAbsPath); err != nil {
 				return err
 			}
 		}

--- a/enterprise/server/remote_execution/dirtools/dirtools_test.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools_test.go
@@ -36,6 +36,12 @@ func TestDownloadTree(t *testing.T) {
 				Digest: fileADigest,
 			},
 		},
+		Symlinks: []*repb.SymlinkNode{
+			&repb.SymlinkNode{
+				Name:   "fileA.symlink",
+				Target: "./fileA.txt",
+			},
+		},
 	}
 
 	childDigest, err := digest.ComputeForMessage(childDir)
@@ -71,6 +77,10 @@ func TestDownloadTree(t *testing.T) {
 	assert.DirExists(t, filepath.Join(tmpDir, "my-directory"), "my-directory should exist")
 	assert.FileExists(t, filepath.Join(tmpDir, "my-directory/fileA.txt"), "fileA.txt should exist")
 	assert.FileExists(t, filepath.Join(tmpDir, "fileB.txt"), "fileB.txt should exist")
+
+	target, err := os.Readlink(filepath.Join(tmpDir, "my-directory/fileA.symlink"))
+	assert.NoError(t, err, "should be able to read symlink")
+	assert.Equal(t, "./fileA.txt", target)
 }
 
 func TestDownloadTreeWithFileCache(t *testing.T) {

--- a/enterprise/server/remote_execution/dirtools/dirtools_test.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools_test.go
@@ -77,10 +77,12 @@ func TestDownloadTree(t *testing.T) {
 	assert.DirExists(t, filepath.Join(tmpDir, "my-directory"), "my-directory should exist")
 	assert.FileExists(t, filepath.Join(tmpDir, "my-directory/fileA.txt"), "fileA.txt should exist")
 	assert.FileExists(t, filepath.Join(tmpDir, "fileB.txt"), "fileB.txt should exist")
-
 	target, err := os.Readlink(filepath.Join(tmpDir, "my-directory/fileA.symlink"))
-	assert.NoError(t, err, "should be able to read symlink")
+	assert.NoError(t, err, "should be able to read symlink target")
 	assert.Equal(t, "./fileA.txt", target)
+	targetContents, err := os.ReadFile(filepath.Join(tmpDir, "my-directory/fileA.symlink"))
+	assert.NoError(t, err)
+	assert.Equal(t, "mytestdataA", string(targetContents), "symlinked file contents should match target file")
 }
 
 func TestDownloadTreeWithFileCache(t *testing.T) {


### PR DESCRIPTION
Symlinks were being created relative to the executor's working directory rather than relative to the parent `Directory` containing the `SymlinkNode`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
