### PR TITLE
Fix sidebar links again

### DIFF
--- a/enterprise/app/sidebar/sidebar.tsx
+++ b/enterprise/app/sidebar/sidebar.tsx
@@ -137,19 +137,19 @@ export default class SidebarComponent extends React.Component<Props, State> {
               <LayoutGrid className="icon" /> Tests
             </SidebarLink>
           )}
-          <SidebarLink selected={this.isUsersSelected()} href="#users">
+          <SidebarLink selected={this.isUsersSelected()} href="/#users">
             <Users className="icon" /> Users
           </SidebarLink>
-          <SidebarLink selected={this.isReposSelected()} href="#repos">
+          <SidebarLink selected={this.isReposSelected()} href="/#repos">
             <Github className="icon" /> Repos
           </SidebarLink>
-          <SidebarLink selected={this.isBranchesSelected()} href="#branches">
+          <SidebarLink selected={this.isBranchesSelected()} href="/#branches">
             <GitBranch className="icon" /> Branches
           </SidebarLink>
-          <SidebarLink selected={this.isCommitsSelected()} href="#commits">
+          <SidebarLink selected={this.isCommitsSelected()} href="/#commits">
             <GitCommit className="icon" /> Commits
           </SidebarLink>
-          <SidebarLink selected={this.isHostsSelected()} href="#hosts">
+          <SidebarLink selected={this.isHostsSelected()} href="/#hosts">
             <HardDrive className="icon" /> Hosts
           </SidebarLink>
           {router.canAccessExecutorsPage(this.props.user) && (


### PR DESCRIPTION
The hash is relative to the current path, so if you're currently on the tests page and click one of these links then you'll get navigated to `/tests/#users`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
