### PR TITLE
Fix memory leak in fastcopy_darwin

### DIFF
--- a/server/util/fastcopy/fastcopy_darwin.go
+++ b/server/util/fastcopy/fastcopy_darwin.go
@@ -5,16 +5,23 @@ package fastcopy
 
 /*
 #include <stdint.h> // for uint32_t
+#include <stdlib.h> // for free
 #include <sys/clonefile.h>
 */
 import "C"
 
 import (
 	"syscall"
+	"unsafe"
 )
 
 func FastCopy(source, destination string) error {
-	ret, err := C.clonefile(C.CString(source), C.CString(destination), C.uint32_t(0))
+	src := C.CString(source)
+	defer C.free(unsafe.Pointer(src))
+	dst := C.CString(destination)
+	defer C.free(unsafe.Pointer(dst))
+
+	ret, err := C.clonefile(src, dst, C.uint32_t(0))
 	if errno, ok := err.(syscall.Errno); ret == -1 && ok && errno != syscall.EEXIST {
 		return err
 	}


### PR DESCRIPTION
Documentation of `C.CString`:

```
// Go string to C string
// The C string is allocated in the C heap using malloc.
// It is the caller's responsibility to arrange for it to be
// freed, such as by calling C.free (be sure to include stdlib.h
// if C.free is needed).
func C.CString(string) *C.char
```

Verified locally using a bazel build that runs a nop sh_test, with `--runs_per_test=100000`. Before, the executor's memory would start at 27MB then climb steadily up to 80 MB or so. After, the executor's memory usage stays at 27MB while the tests are executing.

Interestingly, there's a lot of code in the wild that creates a `C.CString` without freeing it - seems like a Go static analyzer would be able to catch this: https://cs.github.com/?scopeName=All+repos&scope=&q=%22%2C+C.CString%22

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
