### PR TITLE
Update disk cache usage to be calculated based on block size.

### DIFF
--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -28,6 +28,12 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
+const (
+	// All files on disk will be a multiple of this block size, assuming a
+	// filesystem with default settings.
+	defaultExt4BlockSize = 4096
+)
+
 var (
 	emptyUserMap = testauth.TestUsers()
 )
@@ -102,7 +108,7 @@ func (c *errorCache) Reader(ctx context.Context, d *repb.Digest, offset, limit i
 func TestACIsolation(t *testing.T) {
 	te := testenv.GetTestEnv(t)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(1000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 1)
 	rootDirSrc := testfs.MakeTempDir(t)
 	rootDirDest := testfs.MakeTempDir(t)
 
@@ -133,7 +139,7 @@ func TestACIsolation(t *testing.T) {
 func TestACIsolation_RemoteInstanceName(t *testing.T) {
 	te := testenv.GetTestEnv(t)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(1000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 1)
 	rootDirSrc := testfs.MakeTempDir(t)
 	rootDirDest := testfs.MakeTempDir(t)
 
@@ -162,7 +168,7 @@ func TestACIsolation_RemoteInstanceName(t *testing.T) {
 func TestSet_DoubleWrite(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(1000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 10)
 	rootDirSrc := testfs.MakeTempDir(t)
 	rootDirDest := testfs.MakeTempDir(t)
 
@@ -193,7 +199,7 @@ func TestSet_DestWriteErr(t *testing.T) {
 	ctx := getAnonContext(t, te)
 	rootDirSrc := testfs.MakeTempDir(t)
 
-	srcCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirSrc}, int64(1000))
+	srcCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirSrc}, int64(defaultExt4BlockSize*10))
 	require.NoError(t, err)
 	destCache := &errorCache{}
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
@@ -276,7 +282,7 @@ func TestGetSet(t *testing.T) {
 func TestGet_DoubleRead(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(1000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 10)
 	rootDirSrc := testfs.MakeTempDir(t)
 	rootDirDest := testfs.MakeTempDir(t)
 
@@ -299,7 +305,7 @@ func TestGet_DoubleRead(t *testing.T) {
 func TestGet_DestReadErr(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(1000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 1)
 	rootDirSrc := testfs.MakeTempDir(t)
 
 	srcCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirSrc}, maxSizeBytes)
@@ -455,7 +461,7 @@ func TestCopyDataInBackground_ExceedsCopyChannelSize(t *testing.T) {
 func TestCopyDataInBackground_RateLimit(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(1000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 10)
 	rootDirSrc := testfs.MakeTempDir(t)
 	rootDirDest := testfs.MakeTempDir(t)
 
@@ -508,7 +514,7 @@ func TestCopyDataInBackground_AuthenticatedUser(t *testing.T) {
 	testUsers := testauth.TestUsers(testAPIKey, testGroup)
 
 	te := getTestEnv(t, testUsers)
-	maxSizeBytes := int64(1000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 10)
 	rootDirSrc := testfs.MakeTempDir(t)
 	rootDirDest := testfs.MakeTempDir(t)
 
@@ -584,7 +590,7 @@ func TestCopyDataInBackground_MultipleIsolations(t *testing.T) {
 
 	te := getTestEnv(t, testUsers)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(1000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 10)
 	rootDirSrc := testfs.MakeTempDir(t)
 	rootDirDest := testfs.MakeTempDir(t)
 
@@ -652,7 +658,7 @@ func TestCopyDataInBackground_MultipleIsolations(t *testing.T) {
 func TestContains(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(1000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 1)
 	rootDirSrc := testfs.MakeTempDir(t)
 	rootDirDest := testfs.MakeTempDir(t)
 
@@ -679,7 +685,7 @@ func TestContains(t *testing.T) {
 func TestContains_DestErr(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(1000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 1)
 	rootDirSrc := testfs.MakeTempDir(t)
 
 	srcCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirSrc}, maxSizeBytes)
@@ -700,7 +706,7 @@ func TestContains_DestErr(t *testing.T) {
 func TestMetadata(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(1000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 10)
 	rootDirSrc := testfs.MakeTempDir(t)
 	rootDirDest := testfs.MakeTempDir(t)
 
@@ -727,7 +733,7 @@ func TestMetadata(t *testing.T) {
 func TestMetadata_DestErr(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(1000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 10)
 	rootDirSrc := testfs.MakeTempDir(t)
 
 	srcCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirSrc}, maxSizeBytes)
@@ -748,7 +754,7 @@ func TestMetadata_DestErr(t *testing.T) {
 func TestFindMissing(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(1000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 10)
 	rootDirSrc := testfs.MakeTempDir(t)
 	rootDirDest := testfs.MakeTempDir(t)
 
@@ -777,7 +783,7 @@ func TestFindMissing(t *testing.T) {
 func TestFindMissing_DestErr(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(1000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 10)
 	rootDirSrc := testfs.MakeTempDir(t)
 
 	srcCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirSrc}, maxSizeBytes)
@@ -801,7 +807,7 @@ func TestFindMissing_DestErr(t *testing.T) {
 func TestGetMultiWithCopying(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(10000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 100)
 	rootDirSrc := testfs.MakeTempDir(t)
 	rootDirDest := testfs.MakeTempDir(t)
 
@@ -847,7 +853,7 @@ func TestGetMultiWithCopying(t *testing.T) {
 func TestSetMulti(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(10000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 100)
 	rootDirSrc := testfs.MakeTempDir(t)
 	rootDirDest := testfs.MakeTempDir(t)
 
@@ -895,7 +901,7 @@ func TestSetMulti(t *testing.T) {
 func TestDelete(t *testing.T) {
 	te := getTestEnv(t, emptyUserMap)
 	ctx := getAnonContext(t, te)
-	maxSizeBytes := int64(1000)
+	maxSizeBytes := int64(defaultExt4BlockSize * 10)
 	rootDirSrc := testfs.MakeTempDir(t)
 	rootDirDest := testfs.MakeTempDir(t)
 

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -33,6 +33,12 @@ var (
 	emptyUserMap = testauth.TestUsers()
 )
 
+const (
+	// All files on disk will be a multiple of this block size, assuming a
+	// filesystem with default settings.
+	defaultExt4BlockSize = 4096
+)
+
 func getTestEnv(t *testing.T, users map[string]interfaces.UserInfo) *testenv.TestEnv {
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(users))
@@ -296,7 +302,7 @@ func TestReadOffset(t *testing.T) {
 func TestReadOffsetLimit(t *testing.T) {
 	rootDir := testfs.MakeTempDir(t)
 	te := getTestEnv(t, emptyUserMap)
-	dc, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDir}, 1000)
+	dc, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDir}, defaultExt4BlockSize)
 	require.NoError(t, err)
 
 	ctx := getAnonContext(t, te)
@@ -317,7 +323,8 @@ func TestReadOffsetLimit(t *testing.T) {
 }
 
 func TestSizeLimit(t *testing.T) {
-	maxSizeBytes := int64(1000) // 1000 bytes
+	// Enough space for 2 small digests.
+	maxSizeBytes := int64(defaultExt4BlockSize * 2)
 	rootDir := testfs.MakeTempDir(t)
 	te := getTestEnv(t, emptyUserMap)
 	dc, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDir}, maxSizeBytes)
@@ -356,7 +363,8 @@ func TestSizeLimit(t *testing.T) {
 }
 
 func TestLRU(t *testing.T) {
-	maxSizeBytes := int64(1000) // 1000 bytes
+	// Enough room for two small digests.
+	maxSizeBytes := int64(defaultExt4BlockSize * 2)
 	rootDir := testfs.MakeTempDir(t)
 	te := getTestEnv(t, emptyUserMap)
 	dc, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDir}, maxSizeBytes)


### PR DESCRIPTION
Using the file size underestimates the real usage since each file is stored as multiples of the filesystem block size.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
