### PR TITLE
CLI: Add `--open` plugin

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -55,4 +55,5 @@ actions:
 plugins:
   - path: cli/example_plugins/go_deps
   - path: cli/example_plugins/go_highlight
+  - path: cli/example_plugins/open_invocation
   - path: cli/example_plugins/ping_remote

--- a/cli/bazelisk/BUILD
+++ b/cli/bazelisk/BUILD
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cli/log",
+        "//cli/plugin",
         "//cli/workspace",
         "//server/util/disk",
         "//server/util/status",

--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//cli/terminal",
         "//cli/tooltag",
         "//cli/version",
+        "//server/util/status",
     ],
 )
 

--- a/cli/example_plugins/open_invocation/README.md
+++ b/cli/example_plugins/open_invocation/README.md
@@ -1,0 +1,5 @@
+# open_invocation
+
+open_invocation adds a flag "--open" to bazel commands which causes the
+`bes_results_url` to be opened automatically in the Web browser after the
+invocation is complete.

--- a/cli/example_plugins/open_invocation/post_bazel.sh
+++ b/cli/example_plugins/open_invocation/post_bazel.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# If the "invocation_url.txt" file was written by the pre-bazel hook,
+# open the URL in that file.
+
+[[ ! -e "$PLUGIN_TEMPDIR/invocation_url.txt" ]] && exit 0
+
+_gray="\x1b[90m"
+_underline="\x1b[4m"
+_normal="\x1b[m"
+
+invocation_url=$(cat "$PLUGIN_TEMPDIR/invocation_url.txt")
+
+echo -e "${_gray}> Opening ${_underline}${invocation_url}${_normal}"
+open_command=$(which xdg-open open | head -n1)
+"$open_command" "$invocation_url" &>/dev/null

--- a/cli/example_plugins/open_invocation/pre_bazel.py
+++ b/cli/example_plugins/open_invocation/pre_bazel.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import uuid
+
+def main():
+    args_file_path = sys.argv[1]
+
+    with open(args_file_path, 'r') as f:
+        args = f.read().split('\n')
+
+    bes_results_url = get_flag_value(args, 'bes_results_url')
+
+    # TODO: More robust parsing (handle --open false, --noopen, --open=1 etc.)
+    if '--open' not in args or not bes_results_url:
+        return
+
+    args.remove('--open')
+
+    # Add --invocation_id flag if not already set.
+    invocation_id = get_flag_value(args, 'invocation_id')
+    if not invocation_id:
+        invocation_id = str(uuid.uuid4())
+        args.append('--invocation_id=' + invocation_id)
+
+    # Write a temp file with the invocation URL so that the post-bazel hook
+    # knows which URL to open.
+    url_file_path = os.path.join(os.environ['PLUGIN_TEMPDIR'], 'invocation_url.txt')
+    with open(url_file_path, 'w') as f:
+        f.write(bes_results_url + invocation_id)
+
+    # Write the new args.
+    with open(args_file_path, 'w') as f:
+        f.write('\n'.join(args))
+
+
+# TODO: Provide a library function for this?
+def get_flag_value(flags, name):
+    for flag in flags:
+        if flag.startswith('--' + name + '='):
+            return '='.join(flag.split('=')[1:])
+    return None
+
+
+if __name__ == "__main__":
+    main()

--- a/cli/example_plugins/open_invocation/pre_bazel.sh
+++ b/cli/example_plugins/open_invocation/pre_bazel.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec python3 ./pre_bazel.py "$@"


### PR DESCRIPTION
Adds a plugin which accepts the flag `--open`. When set, it automatically opens the invocation in the browser, if `bes_results_url` is also set.

This plugin needs to pass data between `pre_bazel.sh` and `post_bazel.sh`, so we now provision a temp dir for each plugin where they can write whatever data they want. The dir path is available via the `PLUGIN_TEMPDIR` env var.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
