### PR TITLE
CLI: Temporarily disable bazel output handler plugins

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -54,6 +54,7 @@ actions:
 
 plugins:
   - path: cli/example_plugins/go_deps
-  - path: cli/example_plugins/go_highlight
+  # TODO(bduffany): Fix terminal IO for bazel output handling and re-enable.
+  # - path: cli/example_plugins/go_highlight
   - path: cli/example_plugins/open_invocation
   - path: cli/example_plugins/ping_remote


### PR DESCRIPTION
On macOS, we ran into an issue that bazelisk output is not properly getting line-buffered, so there is a long delay between when bazelisk prints a line of output and when we see it in the terminal.

The issue is that when we are using bazel output handler plugins, bazelisk no longer thinks that it's writing to a terminal, since we are using `io.Pipe()` to pass output to the bazel output handler pipeline. On macOS, line buffering apparently gets disabled when not writing to a terminal (this behavior doesn't seem to happen on Linux).

To fix this properly, we need to pipe via a `pty` so that bazelisk thinks it's writing to a terminal. But this is looking like a somewhat involved fix, so while the fix is in progress, I'm disabling the bazel output handler plugins that we have active in the BB repo.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
