### PR TITLE
CLI: Write plugin pipeline outputs to a pty

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -54,7 +54,6 @@ actions:
 
 plugins:
   - path: cli/example_plugins/go_deps
-  # TODO(bduffany): Fix terminal IO for bazel output handling and re-enable.
-  # - path: cli/example_plugins/go_highlight
+  - path: cli/example_plugins/go_highlight
   - path: cli/example_plugins/open_invocation
   - path: cli/example_plugins/ping_remote

--- a/cli/plugin/BUILD
+++ b/cli/plugin/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//server/util/disk",
         "//server/util/git",
         "//server/util/status",
+        "@com_github_creack_pty//:pty",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )


### PR DESCRIPTION
This fixes the bazel output buffering issue since it tricks plugins into thinking they are writing to a terminal.

Tested on macOS and Linux.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
