### PR TITLE
CLI: Fix version command

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -115,7 +115,7 @@ jobs:
           cd "${GITHUB_WORKSPACE}/buildbuddy"
           "${GITHUB_WORKSPACE}/bin/bazel" build //cli/cmd/bb \
               --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
-              --define version="$VERSION"
+              --//cli/version:cli_version="$VERSION"
 
           BINARY="bazel-${VERSION}-${OS}-${ARCH}"
           cp bazel-bin/cli/cmd/bb/bb_/bb "$BINARY"

--- a/cli/version/BUILD
+++ b/cli/version/BUILD
@@ -1,12 +1,33 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load(":defs.bzl", "write_version_src")
+
+string_flag(
+    name = "cli_version",
+    build_setting_default = "unknown",
+)
+
+# TODO(bduffany): This can be simplified a bit once go:embed supports
+# generated files: https://github.com/bazelbuild/rules_go/pull/3285
+write_version_src(
+    name = "version_src",
+    out = "version_flag.go",
+    flag = ":cli_version",
+)
+
+go_library(
+    name = "version_lib",
+    srcs = [":version_src"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/version",
+)
 
 go_library(
     name = "version",
-    srcs = ["version.go"],
+    srcs = ["version.go"],  # keep
+    embed = [":version_lib"],  # keep
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/version",
     visibility = ["//visibility:public"],
     deps = [
         "//cli/arg",
-        "//server/version",
     ],
 )

--- a/cli/version/defs.bzl
+++ b/cli/version/defs.bzl
@@ -1,0 +1,17 @@
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+
+def _write_version_src_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.out)
+    ctx.actions.write(out, """package version
+
+var cliVersionFlag = "%s"
+""" % ctx.attr.flag[BuildSettingInfo].value)
+    return DefaultInfo(files = depset([out]))
+
+write_version_src = rule(
+    implementation = _write_version_src_impl,
+    attrs = {
+        "out": attr.string(mandatory = True),
+        "flag": attr.label(providers = [BuildSettingInfo]),
+    },
+)

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
-	"github.com/buildbuddy-io/buildbuddy/server/version"
 )
 
 func HandleVersion(args []string) []string {
 	if arg.GetCommand(args) != "version" {
 		return args
 	}
-	fmt.Printf("bb %s\n", version.AppVersion())
+	// The "version" var is generated in this package according to the
+	// Bazel flag value --//cli/version:cli_version
+	fmt.Printf("bb %s\n", cliVersionFlag)
 	return args
 }


### PR DESCRIPTION
Adds a build flag `--//cli/version:cli_version` that lets us specify the CLI version, and sets this based on the git tag in the release workflow.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1746
