### PR TITLE
CLI: Make bazel startup flags work

### DIFF
--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"os"
 	"path/filepath"
 
@@ -20,7 +19,6 @@ import (
 )
 
 func main() {
-	flag.Parse()
 	exitCode, err := run()
 	if err != nil {
 		log.Fatal(status.Message(err))
@@ -43,12 +41,13 @@ func run() (exitCode int, err error) {
 	}
 
 	// Parse args
-	commandLineArgs := flag.Args()
+	commandLineArgs := os.Args[1:]
 	rcFileArgs := parser.GetArgsFromRCFiles(commandLineArgs)
 	args := append(commandLineArgs, rcFileArgs...)
 
 	// Fiddle with args
 	// TODO(bduffany): model these as "built-in" plugins
+	args = log.Configure(args)
 	args = tooltag.ConfigureToolTag(args)
 	args = sidecar.ConfigureSidecar(args)
 	args = login.ConfigureAPIKey(args)

--- a/cli/log/BUILD
+++ b/cli/log/BUILD
@@ -5,4 +5,5 @@ go_library(
     srcs = ["log.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/log",
     visibility = ["//visibility:public"],
+    deps = ["//cli/arg"],
 )

--- a/cli/log/log.go
+++ b/cli/log/log.go
@@ -1,27 +1,29 @@
 package log
 
 import (
-	"flag"
 	"log"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 )
 
-var (
-	verbose = flag.Bool("verbose", false, "If true, enable verbose buildbuddy logging.")
-)
+var verbose bool
 
-func init() {
+func Configure(args []string) []string {
+	verboseFlagVal, args := arg.Pop(args, "verbose")
+	verbose = verboseFlagVal == "1" || verboseFlagVal == "true"
 	log.SetFlags(0)
+	return args
 }
 
 func Debug(v ...any) {
-	if !*verbose {
+	if !verbose {
 		return
 	}
 	log.Print(v...)
 }
 
 func Debugf(format string, v ...interface{}) {
-	if !*verbose {
+	if !verbose {
 		return
 	}
 	log.Printf(format, v...)


### PR DESCRIPTION
- Remove call to `flag.Parse()`
- Make `--verbose` a manually parsed flag. For now it has to be set to either `--verbose=1` or `--verbose=true`.
- TODO in future PR: Need to figure out an alternate flag parsing strategy so that we can still use the standard Go `flag` library for anything that depends on it. We might want to consider something like requiring all bb flags to be prefixed with `bb`, then call `flag.Parse()` only with those prefixed flags (by temporarily overriding `os.Args`). We could alternatively require startup flags to be passed via `--startup_flag=--foo=bar` but that would break compatibility with `bazel` -- not sure if we want to do that.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
