### PR TITLE
Require a deadline; use it

### DIFF
--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -324,7 +324,11 @@ func SyncProposeLocal(ctx context.Context, nodehost *dragonboat.NodeHost, cluste
 	}
 	var raftResponse dbsm.Result
 	err = RunNodehostFn(ctx, func(ctx context.Context) error {
-		rs, err := nodehost.Propose(sesh, buf, time.Second)
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			return status.FailedPreconditionError("nodehost.Propose *requires* a context deadline be set")
+		}
+		rs, err := nodehost.Propose(sesh, buf, time.Until(deadline))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Proposing something via raft requires a deadline. Previously this was hardcoded to 1 second, which can cause issues if the raft command being applied takes longer than that.

I noticed this when debugging a split issue -- acquiring the split lock requires waiting for existing reads/writes to finish, and this can take longer than a second. 