### PR TITLE
Change the way IDs (invocation, request) are propagated to the logger.

### DIFF
--- a/server/rpc/filters/BUILD
+++ b/server/rpc/filters/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//server/environment",
         "//server/metrics",
         "//server/role_filter",
+        "//server/util/bazel_request",
         "//server/util/log",
         "//server/util/quota",
         "//server/util/request_context",

--- a/server/util/log/BUILD
+++ b/server/util/log/BUILD
@@ -6,9 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/log",
     visibility = ["//visibility:public"],
     deps = [
-        "//server/util/bazel_request",
         "//server/util/status",
-        "//server/util/uuid",
         "@com_github_rs_zerolog//:zerolog",
         "@com_github_rs_zerolog//log",
         "@org_golang_google_grpc//codes",

--- a/server/util/uuid/BUILD
+++ b/server/util/uuid/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/uuid",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/util/log",
         "//server/util/status",
         "@com_github_google_uuid//:uuid",
     ],

--- a/server/util/uuid/uuid.go
+++ b/server/util/uuid/uuid.go
@@ -2,12 +2,12 @@ package uuid
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"path"
 	"sync"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	guuid "github.com/google/uuid"
 )
@@ -16,7 +16,6 @@ const (
 	// Name of the configuration directory in os.UserConfigDir
 	configDirName  = "buildbuddy"
 	hostIDFilename = "host_id"
-	uuidContextKey = "uuid"
 )
 
 var (
@@ -28,24 +27,12 @@ var (
 	failsafeIDOnce sync.Once
 )
 
-func GetFromContext(ctx context.Context) (string, error) {
-	u, ok := ctx.Value(uuidContextKey).(string)
-	if ok {
-		return u, nil
-	}
-	return "", fmt.Errorf("UUID not present in context")
-}
-
 func SetInContext(ctx context.Context) (context.Context, error) {
 	u, err := guuid.NewRandom()
 	if err != nil {
 		return nil, err
 	}
-	ou, ok := ctx.Value(uuidContextKey).(string)
-	if ok {
-		return nil, fmt.Errorf("UUID %q already set in context!", ou)
-	}
-	return context.WithValue(ctx, uuidContextKey, u.String()), nil
+	return log.EnrichContext(ctx, "request_id", u.String()), nil
 }
 
 func StringToBytes(text string) ([]byte, error) {


### PR DESCRIPTION
Instead of extracting a hardcoded set of IDs at log time, allow identifiers to be added to the context.

This will enable us to enrich log events with execution_id, raft replica id, etc.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
