### PR TITLE
CLI: Fix Ctrl+C not working when bazel output handlers are active

### DIFF
--- a/cli/bazelisk/bazelisk.go
+++ b/cli/bazelisk/bazelisk.go
@@ -78,7 +78,7 @@ func Run(args []string, outputPath string, w io.Writer) (int, error) {
 
 	exitCode, err := core.RunBazelisk(args, repos)
 	if err != nil {
-		log.Fatalf("error running bazelisk: %s", err)
+		return -1, status.InternalErrorf("failed to run bazelisk: %s", err)
 	}
 	return exitCode, nil
 }

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -82,6 +82,11 @@ func run() (exitCode int, err error) {
 		return -1, err
 	}
 
+	// If the build was interrupted (Ctrl+C), don't run post-bazel plugins.
+	if exitCode == 8 /*interrupted*/ {
+		return exitCode, nil
+	}
+
 	// Run plugin post-bazel hooks
 	for _, p := range plugins {
 		if err := p.PostBazel(outputPath); err != nil {


### PR DESCRIPTION
- [x] Tested on Linux
- [x] Tested on macOS

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1747
