### PR TITLE
CLI: Respect USE_BAZEL_VERSION env var

### DIFF
--- a/cli/bazelisk/bazelisk.go
+++ b/cli/bazelisk/bazelisk.go
@@ -106,6 +106,16 @@ func makePipeWriter(w io.Writer) (pw *os.File, closeFunc func(), err error) {
 }
 
 func setBazelVersion() error {
+	// If USE_BAZEL_VERSION is already set and not pointing to us (the BB CLI),
+	// preserve that value.
+	envVersion := os.Getenv("USE_BAZEL_VERSION")
+	if envVersion != "" && !strings.HasPrefix(envVersion, "buildbuddy-io/") {
+		return nil
+	}
+
+	// TODO: Handle the cases where we were invoked via .bazeliskrc
+	// or USE_BAZEL_FALLBACK_VERSION (less common).
+
 	ws, err := workspace.Path()
 	if err != nil {
 		return err
@@ -117,8 +127,6 @@ func setBazelVersion() error {
 		}
 	}
 	parts := strings.Split(string(b), "\n")
-	// TODO: Handle the cases where we were invoked via .bazeliskrc,
-	// USE_BAZEL_VERSION, or USE_BAZEL_FALLBACK_VERSION.
 
 	// Bazelisk probably chose us because we were specified first in
 	// .bazelversion. Delete the first line, if it exists.


### PR DESCRIPTION
USE_BAZEL_VERSION=5.0.0 wasn't working because our current logic would always set USE_BAZEL_VERSION=latest if `.bazelversion` doesn't point to `buildbuddy-io/`. This PR fixes that, so that we stay compatible with bazelisk.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
