### PR TITLE
CLI: Only run plugins on the `build` step in `bazel run` invocations

### DIFF
--- a/cli/bazelisk/BUILD
+++ b/cli/bazelisk/BUILD
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/bazelisk",
     visibility = ["//visibility:public"],
     deps = [
+        "//cli/arg",
         "//cli/log",
         "//cli/plugin",
         "//cli/workspace",


### PR DESCRIPTION
- Don't run bazel output handlers on the output of the `bazel run` binary
- Run post-bazel plugins after the bazel build and before the run

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1748
