### PR TITLE
Prevent disk cache race condition when cleaning up temp files

### DIFF
--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -58,6 +58,7 @@ var (
 	partitionsFlag        = flagutil.New("cache.disk.partitions", []disk.Partition{}, "")
 	partitionMappingsFlag = flagutil.New("cache.disk.partition_mappings", []disk.PartitionMapping{}, "")
 	useV2LayoutFlag       = flag.Bool("cache.disk.use_v2_layout", false, "If enabled, files will be stored using the v2 layout. See disk_cache.MigrateToV2Layout for a description.")
+	cleanupStaleFilesFlag = flag.Bool("cache.disk.cleanup_stale_files", true, "If enabled, stale files will be deleted during LRU initialization.")
 
 	migrateDiskCacheToV2AndExit = flag.Bool("migrate_disk_cache_to_v2_and_exit", false, "If true, attempt to migrate disk cache to v2 layout.")
 )
@@ -67,6 +68,7 @@ type Options struct {
 	Partitions        []disk.Partition
 	PartitionMappings []disk.PartitionMapping
 	UseV2Layout       bool
+	CleanupStaleFiles bool
 }
 
 // MigrateToV2Layout restructures the files under the root directory to conform to the "v2" layout.
@@ -173,6 +175,7 @@ func Register(env environment.Env) error {
 		Partitions:        *partitionsFlag,
 		PartitionMappings: *partitionMappingsFlag,
 		UseV2Layout:       *useV2LayoutFlag,
+		CleanupStaleFiles: *cleanupStaleFilesFlag,
 	}
 	c, err := NewDiskCache(env, dc, cache_config.MaxSizeBytes())
 	if err != nil {
@@ -217,7 +220,7 @@ func NewDiskCache(env environment.Env, opts *Options, defaultMaxSizeBytes int64)
 			rootDir = filepath.Join(rootDir, PartitionDirectoryPrefix+pc.ID)
 		}
 
-		p, err := newPartition(pc.ID, rootDir, pc.MaxSizeBytes, opts.UseV2Layout)
+		p, err := newPartition(pc.ID, rootDir, pc.MaxSizeBytes, opts.UseV2Layout, opts.CleanupStaleFiles)
 		if err != nil {
 			return nil, err
 		}
@@ -231,7 +234,7 @@ func NewDiskCache(env environment.Env, opts *Options, defaultMaxSizeBytes int64)
 		if opts.UseV2Layout {
 			rootDir = filepath.Join(rootDir, V2Dir, PartitionDirectoryPrefix+DefaultPartitionID)
 		}
-		p, err := newPartition(DefaultPartitionID, rootDir, defaultMaxSizeBytes, opts.UseV2Layout)
+		p, err := newPartition(DefaultPartitionID, rootDir, defaultMaxSizeBytes, opts.UseV2Layout, opts.CleanupStaleFiles)
 		if err != nil {
 			return nil, err
 		}
@@ -410,29 +413,31 @@ func (c *DiskCache) WaitUntilMapped() {
 // serialize this ledger, we regenerate it from scratch on startup by looking
 // at the filesystem.
 type partition struct {
-	id               string
-	useV2Layout      bool
-	mu               sync.RWMutex
-	rootDir          string
-	maxSizeBytes     int64
-	lru              interfaces.LRU
-	fileChannel      chan *fileRecord
-	diskIsMapped     bool
-	doneAsyncLoading chan struct{}
-	lastGCTime       time.Time
-	stringLock       sync.RWMutex
-	internedStrings  map[string]string
+	id                string
+	useV2Layout       bool
+	mu                sync.RWMutex
+	rootDir           string
+	maxSizeBytes      int64
+	lru               interfaces.LRU
+	fileChannel       chan *fileRecord
+	diskIsMapped      bool
+	doneAsyncLoading  chan struct{}
+	lastGCTime        time.Time
+	stringLock        sync.RWMutex
+	internedStrings   map[string]string
+	cleanupStaleFiles bool
 }
 
-func newPartition(id string, rootDir string, maxSizeBytes int64, useV2Layout bool) (*partition, error) {
+func newPartition(id string, rootDir string, maxSizeBytes int64, useV2Layout bool, cleanupStaleFiles bool) (*partition, error) {
 	p := &partition{
-		id:               id,
-		useV2Layout:      useV2Layout,
-		maxSizeBytes:     maxSizeBytes,
-		rootDir:          rootDir,
-		fileChannel:      make(chan *fileRecord),
-		internedStrings:  make(map[string]string, 0),
-		doneAsyncLoading: make(chan struct{}),
+		id:                id,
+		useV2Layout:       useV2Layout,
+		maxSizeBytes:      maxSizeBytes,
+		rootDir:           rootDir,
+		fileChannel:       make(chan *fileRecord),
+		internedStrings:   make(map[string]string, 0),
+		doneAsyncLoading:  make(chan struct{}),
+		cleanupStaleFiles: cleanupStaleFiles,
 	}
 	l, err := lru.NewLRU(&lru.Config{MaxSize: maxSizeBytes, OnEvict: p.evictFn, SizeFn: sizeFn})
 	if err != nil {
@@ -651,19 +656,23 @@ func (p *partition) initializeCache() error {
 				return err
 			}
 			if info.Size() == 0 {
-				log.Debugf("Deleting 0 length file: %q", path)
-				err = os.Remove(path)
-				if err != nil {
-					log.Warningf("Could not delete 0 length file %q: %s", path, err)
+				if p.cleanupStaleFiles {
+					log.Debugf("Deleting 0 length file: %q", path)
+					err = os.Remove(path)
+					if err != nil {
+						log.Warningf("Could not delete 0 length file %q: %s", path, err)
+					}
 				}
 				return nil
 			}
 			timestampedRecord, err := p.makeTimestampedRecordFromPathAndFileInfo(path, info)
 			if err != nil {
 				if disk.IsWriteTempFile(path) {
-					err = os.Remove(path)
-					if err != nil {
-						log.Warningf("Could not delete stale temp file %q (size %d): %s", path, info.Size(), err)
+					if p.cleanupStaleFiles {
+						err = os.Remove(path)
+						if err != nil {
+							log.Warningf("Could not delete stale temp file %q (size %d): %s", path, info.Size(), err)
+						}
 					}
 					return nil
 				}

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -677,7 +677,7 @@ func TestDeleteStaleTempFiles(t *testing.T) {
 	err = os.WriteFile(unexpectedFile, []byte("hello"), 0644)
 	require.NoError(t, err)
 
-	dc, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDir}, maxSizeBytes)
+	dc, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDir, CleanupStaleFiles: true}, maxSizeBytes)
 	require.NoError(t, err)
 
 	dc.WaitUntilMapped()

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -668,13 +668,18 @@ func TestDeleteStaleTempFiles(t *testing.T) {
 
 	// Create a temp file for a write that should be deleted.
 	badDigest, _ := testdigest.NewRandomDigestBuf(t, 1000)
+	yesterday := time.Now().AddDate(0, 0, -1)
 	writeTempFile := filepath.Join(anonPath, badDigest.GetHash()+".ababababab.tmp")
 	err = os.WriteFile(writeTempFile, []byte("hello"), 0644)
+	require.NoError(t, err)
+	err = os.Chtimes(writeTempFile, yesterday, yesterday)
 	require.NoError(t, err)
 
 	// Create an unexpected file that should not be deleted.
 	unexpectedFile := filepath.Join(anonPath, "some_other_file.txt")
 	err = os.WriteFile(unexpectedFile, []byte("hello"), 0644)
+	require.NoError(t, err)
+	err = os.Chtimes(unexpectedFile, yesterday, yesterday)
 	require.NoError(t, err)
 
 	dc, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDir}, maxSizeBytes)

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -677,7 +677,7 @@ func TestDeleteStaleTempFiles(t *testing.T) {
 	err = os.WriteFile(unexpectedFile, []byte("hello"), 0644)
 	require.NoError(t, err)
 
-	dc, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDir, CleanupStaleFiles: true}, maxSizeBytes)
+	dc, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDir}, maxSizeBytes)
 	require.NoError(t, err)
 
 	dc.WaitUntilMapped()


### PR DESCRIPTION
The disk cache tests have been really flaky for me due to a race condition where temp files are being deleted by the initialization function at the same time as when we're trying to [set data in unit tests](https://github.com/buildbuddy-io/buildbuddy/blob/master/server/util/disk/disk.go#L81)