### PR TITLE
CLI: Support interactive rebuilding with `-w` or `--watch` flag.

### DIFF
--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//cli/terminal",
         "//cli/tooltag",
         "//cli/version",
+        "//cli/watcher",
         "//server/util/status",
     ],
 )

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/terminal"
 	"github.com/buildbuddy-io/buildbuddy/cli/tooltag"
 	"github.com/buildbuddy-io/buildbuddy/cli/version"
+	"github.com/buildbuddy-io/buildbuddy/cli/watcher"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
 
@@ -27,12 +28,26 @@ func main() {
 }
 
 func run() (exitCode int, err error) {
+	// Maybe run interactively (watching for changes to files).
+	if exitCode, err := watcher.Watch(); exitCode >= 0 || err != nil {
+		return exitCode, err
+	}
+
+	var scriptPath string
 	// Prepare a dir for temporary files created by this CLI run
 	tempDir, err := os.MkdirTemp("", "buildbuddy-cli-*")
 	if err != nil {
 		return -1, err
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		// Remove tempdir. Need to do this before invoking the run script
+		// (if applicable), since the run script will replace this process.
+		os.RemoveAll(tempDir)
+
+		if scriptPath != "" {
+			exitCode, err = bazelisk.InvokeRunScript(scriptPath)
+		}
+	}()
 
 	// Load plugins
 	plugins, err := plugin.LoadAll(tempDir)
@@ -76,7 +91,7 @@ func run() (exitCode int, err error) {
 
 	// If this is a `bazel run` command, add a --run_script arg so that
 	// we can execute post-bazel plugins between the build and the run step.
-	args, scriptPath := bazelisk.ConfigureRunScript(args, tempDir)
+	args, scriptPath = bazelisk.ConfigureRunScript(args, tempDir)
 
 	// Run bazelisk, capturing the original output in a file and allowing
 	// plugins to control how the output is rendered to the terminal.
@@ -94,14 +109,6 @@ func run() (exitCode int, err error) {
 	// Run plugin post-bazel hooks
 	for _, p := range plugins {
 		if err := p.PostBazel(outputPath); err != nil {
-			return -1, err
-		}
-	}
-
-	// If this is a `bazel run` command, invoke the run script.
-	if scriptPath != "" {
-		exitCode, err = bazelisk.InvokeRunScript(scriptPath)
-		if err != nil {
 			return -1, err
 		}
 	}

--- a/cli/watcher/BUILD
+++ b/cli/watcher/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "watcher",
+    srcs = ["watcher.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/watcher",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cli/arg",
+        "//server/util/status",
+        "@com_github_bduffany_godemon//:godemon",
+        "@com_github_google_shlex//:shlex",
+    ],
+)

--- a/cli/watcher/watcher.go
+++ b/cli/watcher/watcher.go
@@ -1,0 +1,58 @@
+package watcher
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/bduffany/godemon"
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/google/shlex"
+)
+
+// Watch looks for the -w or --watch flag, and if present it reinvokes the
+// CLI as a subprocess on changes to source files.
+func Watch() (exitCode int, err error) {
+	args := os.Args
+
+	idx := -1
+	for i, arg := range args {
+		if arg == "-w" || arg == "--watch" {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return -1, nil
+	}
+	args = append(args[:idx], args[idx+1:]...)
+
+	// Allow specifying --watcher_flags to forward args to the watcher.
+	// Mostly useful for debugging, e.g. --watcher_flags='--verbose'
+	watcherFlagsRaw, args := arg.Pop(args, "watcher_flags")
+	watcherFlags, err := shlex.Split(watcherFlagsRaw)
+	if err != nil {
+		return -1, status.InvalidArgumentErrorf("failed to parse --watcher_flags: %s", err)
+	}
+
+	// Notes on FS watcher solutions:
+	// https://docs.google.com/document/d/1tbe7lAX6OEYe5_1FRLG8RPG3lXGUrT4_Vv9UCx6_Vwo
+
+	_ = os.Setenv("GODEMON_LOG_PREFIX", "--- ")
+	argv := append([]string{"godemon"}, watcherFlags...)
+	argv = append(argv, args...)
+
+	// Optionally invoke a specific godemon binary.
+	// Especially useful for development but can also be used to pull in newer
+	// godemon features.
+	if bin := os.Getenv("GODEMON_BINARY_PATH"); bin != "" {
+		if err := syscall.Exec(bin, argv, os.Environ()); err != nil {
+			return -1, err
+		}
+		panic("unreachable")
+	}
+
+	godemon.Main(argv)
+
+	return 0, nil
+}

--- a/deps.bzl
+++ b/deps.bzl
@@ -314,6 +314,12 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         sum = "h1:nhqjA2IslEOLViRBF5djQCiOD//7VyyHNKrqAZ1AuYA=",
         version = "v0.2.0",
     )
+    go_repository(
+        name = "com_github_bduffany_godemon",
+        importpath = "github.com/bduffany/godemon",
+        sum = "h1:BFwU6kr4ppuckKMtavYfk2pKTALlBtH6nEwBPX77LtQ=",
+        version = "v0.0.0-20221017142458-a1c682732be9",
+    )
 
     go_repository(
         name = "com_github_beevik_etree",
@@ -378,6 +384,12 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         importpath = "github.com/blizzy78/varnamelen",
         sum = "h1:80mYO7Y5ppeEefg1Jzu+NBg16iwToOQVnDnNIoWSShs=",
         version = "v0.3.0",
+    )
+    go_repository(
+        name = "com_github_bmatcuk_doublestar_v4",
+        importpath = "github.com/bmatcuk/doublestar/v4",
+        sum = "h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=",
+        version = "v4.0.2",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/bazelbuild/bazelisk v1.11.0
 	github.com/bazelbuild/rules_go v0.29.0
 	github.com/bazelbuild/rules_webtesting v0.2.0
+	github.com/bduffany/godemon v0.0.0-20221017142458-a1c682732be9
 	github.com/bojand/ghz v0.95.0
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/buildbuddy-io/tensorflow-proto v0.0.0-20220908151343-929b41ab4dc6
@@ -116,6 +117,7 @@ require (
 	github.com/beevik/etree v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
 	github.com/cilium/ebpf v0.7.0 // indirect
 	github.com/cockroachdb/errors v1.9.0 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f // indirect
@@ -132,6 +134,7 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/getsentry/sentry-go v0.12.0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,8 @@ github.com/bazelbuild/rules_go v0.29.0 h1:SfxjyO/V68rVnzOHop92fB0gv/Aa75KNLAN0PM
 github.com/bazelbuild/rules_go v0.29.0/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=
 github.com/bazelbuild/rules_webtesting v0.2.0 h1:nhqjA2IslEOLViRBF5djQCiOD//7VyyHNKrqAZ1AuYA=
 github.com/bazelbuild/rules_webtesting v0.2.0/go.mod h1:M+vCvqp/1BViNuVL630BoiGqld9Q1vQzvf9bN/dWTeg=
+github.com/bduffany/godemon v0.0.0-20221017142458-a1c682732be9 h1:BFwU6kr4ppuckKMtavYfk2pKTALlBtH6nEwBPX77LtQ=
+github.com/bduffany/godemon v0.0.0-20221017142458-a1c682732be9/go.mod h1:ZgV2Qp9QIB1+SQmZYwrBfpWShscIYjlT/X39fhLl628=
 github.com/bduffany/redsync/v4 v4.4.1-minimal h1:wyBDr+ApDWybbLGMSsepl30KzPAl+HlIQMhJSoLdRKg=
 github.com/bduffany/redsync/v4 v4.4.1-minimal/go.mod h1:9+8jiPGz2n9ZaN8znvOqjyeXP/acSo6VAFPaG5Xdb2M=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
@@ -240,6 +242,8 @@ github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blizzy78/varnamelen v0.3.0/go.mod h1:hbwRdBvoBqxk34XyQ6HA0UH3G0/1TKuv5AC4eaBT0Ec=
+github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
+github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bojand/ghz v0.95.0 h1:5KxpUb69n2m07388In4xQKIucbsjCwsG6yoBPN8vVvg=
 github.com/bojand/ghz v0.95.0/go.mod h1:3axvM646bgxnmBRH25t6+Bg/ekazoAy+UltIGziQS1o=


### PR DESCRIPTION
Using [godemon](https://github.com/bduffany/godemon) as the file watcher for now since it embeds easily in Go. We might consider switching to [ibazel](https://github.com/bazelbuild/bazel-watcher) in the future, but we might want to either fork or contribute some upstream patches since it has some undesired behavior, e.g. https://github.com/bazelbuild/bazel-watcher/issues/305. We'd also need to figure out how to embed it in our app, since the Go API currently isn't visible externally.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
