### PR TITLE
Fix "unavailable" alert logic for target URLs containing params

### DIFF
--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -405,11 +405,12 @@ function getMatchedPath(urlPath: string): string | null {
     urlPath += "/";
   }
   let curMatch: string | null = null;
-  for (let path of Object.values(Path)) {
-    if (!path.endsWith("/")) {
-      path += "/";
+  for (const path of Object.values(Path)) {
+    let prefix = path;
+    if (!prefix.endsWith("/")) {
+      prefix += "/";
     }
-    if (urlPath.startsWith(path) && (curMatch === null || curMatch.length < path)) {
+    if (urlPath.startsWith(prefix) && (curMatch === null || curMatch.length < path)) {
       curMatch = path;
     }
   }

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -63,14 +63,16 @@ class Router {
    * - Preserves global filter params.
    */
   navigateTo(url: string) {
-    const unavailableMsg = getUnavailableMessage(url);
-    if (unavailableMsg && !capabilities.canNavigateToPath(url)) {
+    const oldUrl = new URL(window.location.href);
+    const newUrl = new URL(url, window.location.href);
+
+    const matchedPath = getMatchedPath(newUrl.pathname);
+    const unavailableMsg = getUnavailableMessage(matchedPath);
+    if (unavailableMsg && !capabilities.canNavigateToPath(matchedPath)) {
       alert(unavailableMsg);
       return;
     }
 
-    const oldUrl = new URL(window.location.href);
-    const newUrl = new URL(url, window.location.href);
     // Preserve global filter params.
     for (const key of GLOBAL_FILTER_PARAM_NAMES) {
       if (!newUrl.searchParams.get(key) && oldUrl.searchParams.get(key)) {
@@ -397,11 +399,25 @@ export class Path {
   static codePath = "/code/";
 }
 
-function getUnavailableMessage(href: string) {
-  let path = new URL(href, window.location.href).pathname;
-  if (!path.endsWith("/")) path += "/";
+/** Returns the longest path value in `Path` matching the given URL path. */
+function getMatchedPath(urlPath: string): string | null {
+  if (!urlPath.endsWith("/")) {
+    urlPath += "/";
+  }
+  let curMatch: string | null = null;
+  for (let path of Object.values(Path)) {
+    if (!path.endsWith("/")) {
+      path += "/";
+    }
+    if (urlPath.startsWith(path) && (curMatch === null || curMatch.length < path)) {
+      curMatch = path;
+    }
+  }
+  return curMatch;
+}
 
-  switch (path) {
+function getUnavailableMessage(matchedPath: string) {
+  switch (matchedPath) {
     case Path.workflowsPath:
     case Path.codePath:
     case Path.settingsPath:


### PR DESCRIPTION
`getUnavailableMessage()` was looking at the pathname of the target URL, but `capabilities.canNavigateToPath()` was looking at the whole URL including params, which caused it to incorrectly return `false` in some cases.

This PR updates the logic so that we only pass in the matched `Path` string to both functions.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
