### PR TITLE
CLI: Fix some issues with watch mode

### DIFF
--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -91,7 +91,10 @@ func run() (exitCode int, err error) {
 
 	// If this is a `bazel run` command, add a --run_script arg so that
 	// we can execute post-bazel plugins between the build and the run step.
-	args, scriptPath = bazelisk.ConfigureRunScript(args, tempDir)
+	args, scriptPath, err = bazelisk.ConfigureRunScript(args)
+	if err != nil {
+		return -1, err
+	}
 
 	// Run bazelisk, capturing the original output in a file and allowing
 	// plugins to control how the output is rendered to the terminal.

--- a/cli/watcher/BUILD
+++ b/cli/watcher/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cli/arg",
+        "//cli/workspace",
         "//server/util/status",
         "@com_github_bduffany_godemon//:godemon",
         "@com_github_google_shlex//:shlex",

--- a/cli/watcher/watcher.go
+++ b/cli/watcher/watcher.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bduffany/godemon"
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/google/shlex"
 )
@@ -38,8 +39,13 @@ func Watch() (exitCode int, err error) {
 	// Notes on FS watcher solutions:
 	// https://docs.google.com/document/d/1tbe7lAX6OEYe5_1FRLG8RPG3lXGUrT4_Vv9UCx6_Vwo
 
+	workspaceDir, err := workspace.Path()
+	if err != nil {
+		return -1, err
+	}
+
 	_ = os.Setenv("GODEMON_LOG_PREFIX", "--- ")
-	argv := append([]string{"godemon"}, watcherFlags...)
+	argv := append([]string{"godemon", "--watch", workspaceDir}, watcherFlags...)
 	argv = append(argv, args...)
 
 	// Optionally invoke a specific godemon binary.

--- a/deps.bzl
+++ b/deps.bzl
@@ -317,8 +317,8 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "com_github_bduffany_godemon",
         importpath = "github.com/bduffany/godemon",
-        sum = "h1:BFwU6kr4ppuckKMtavYfk2pKTALlBtH6nEwBPX77LtQ=",
-        version = "v0.0.0-20221017142458-a1c682732be9",
+        sum = "h1:GTXHG34z1pHcS4rAM1H//o4KhZaGlE00rELhoHRNU7w=",
+        version = "v0.0.0-20221018141343-3bc43fa8b810",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/bazelbuild/bazelisk v1.11.0
 	github.com/bazelbuild/rules_go v0.29.0
 	github.com/bazelbuild/rules_webtesting v0.2.0
-	github.com/bduffany/godemon v0.0.0-20221017142458-a1c682732be9
+	github.com/bduffany/godemon v0.0.0-20221018141343-3bc43fa8b810
 	github.com/bojand/ghz v0.95.0
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/buildbuddy-io/tensorflow-proto v0.0.0-20220908151343-929b41ab4dc6

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/bazelbuild/rules_go v0.29.0 h1:SfxjyO/V68rVnzOHop92fB0gv/Aa75KNLAN0PM
 github.com/bazelbuild/rules_go v0.29.0/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=
 github.com/bazelbuild/rules_webtesting v0.2.0 h1:nhqjA2IslEOLViRBF5djQCiOD//7VyyHNKrqAZ1AuYA=
 github.com/bazelbuild/rules_webtesting v0.2.0/go.mod h1:M+vCvqp/1BViNuVL630BoiGqld9Q1vQzvf9bN/dWTeg=
-github.com/bduffany/godemon v0.0.0-20221017142458-a1c682732be9 h1:BFwU6kr4ppuckKMtavYfk2pKTALlBtH6nEwBPX77LtQ=
-github.com/bduffany/godemon v0.0.0-20221017142458-a1c682732be9/go.mod h1:ZgV2Qp9QIB1+SQmZYwrBfpWShscIYjlT/X39fhLl628=
+github.com/bduffany/godemon v0.0.0-20221018141343-3bc43fa8b810 h1:GTXHG34z1pHcS4rAM1H//o4KhZaGlE00rELhoHRNU7w=
+github.com/bduffany/godemon v0.0.0-20221018141343-3bc43fa8b810/go.mod h1:ZgV2Qp9QIB1+SQmZYwrBfpWShscIYjlT/X39fhLl628=
 github.com/bduffany/redsync/v4 v4.4.1-minimal h1:wyBDr+ApDWybbLGMSsepl30KzPAl+HlIQMhJSoLdRKg=
 github.com/bduffany/redsync/v4 v4.4.1-minimal/go.mod h1:9+8jiPGz2n9ZaN8znvOqjyeXP/acSo6VAFPaG5Xdb2M=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=


### PR DESCRIPTION
* Fix run script being deleted before it has a chance to run (since it was written to the cleaned up tempdir)
* Upgrade godemon to get better `.gitignore` behavior (it now respects `.gitignore` files anywhere in the repo, including nested dirs)
* Watch all files under the workspace root, not just the current directory (in the case where BB is invoked from a subdir in the bazel workspace)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
