### PR TITLE
CLI: More fixes for go deps plugin

### DIFF
--- a/cli/example_plugins/go_deps/post_bazel.py
+++ b/cli/example_plugins/go_deps/post_bazel.py
@@ -10,7 +10,7 @@ AUTO_RUN_GAZELLE_PREFERENCE_KEY = "autoRunGazelle"
 
 def main():
     # If not running in an interactive terminal session, don't do anything.
-    if not sys.stdin.isatty():
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
         return
 
     bazel_output_path = sys.argv[1]
@@ -146,7 +146,7 @@ def get_preference(key, default_value=None):
 def set_preference(key, value):
     preferences = read_preferences()
     preferences[key] = value
-    os.makedirs(os.path.dirname(preferences_path()))
+    os.makedirs(os.path.dirname(preferences_path()), exist_ok=True)
     with open(preferences_path(), "w") as f:
         json.dump(preferences, f)
 


### PR DESCRIPTION
* Pass `exist_ok` to `makedirs` (unlike `mkdir -p` it returns an error if the dir already exists :confused:)
* Make sure stdout is a tty before showing prompts, otherwise if the bb output is being redirected to a file then the command might hang and it won't be clear why

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
