### PR TITLE
CLI: Fix handling of passthrough args

### DIFF
--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -64,20 +64,41 @@ func GetCommandAndIndex(args []string) (string, int) {
 func GetPassthroughArgs(args []string) []string {
 	for i, arg := range args {
 		if arg == "--" {
-			return args[i+1:]
+			return append([]string{}, args[i+1:]...)
 		}
 	}
-	return []string{}
+	return nil
 }
 
 // Returns any non "passthrough" arugments in args (those to the left of the first " -- ", if any)
 func GetNonPassthroughArgs(args []string) []string {
+	splitIndex := len(args)
 	for i, arg := range args {
 		if arg == "--" {
-			return args[:i]
+			splitIndex = i
+			break
 		}
 	}
-	return args
+	return append([]string{}, args[:splitIndex]...)
+}
+
+// Splits bazel args and passthrough args into two separate lists. The first
+// "--" separator is dropped if it exists.
+func SplitPassthroughArgs(args []string) (bazel []string, passthrough []string) {
+	return GetNonPassthroughArgs(args), GetPassthroughArgs(args)
+}
+
+// JoinPassthroughArgs joins the given args and passthrough args with a "--"
+// separator, if the passthrough args are non-empty. Otherwise it returns
+// the original non-passthrough args.
+func JoinPassthroughArgs(args, passthroughArgs []string) []string {
+	out := append([]string{}, args...)
+	if len(passthroughArgs) == 0 {
+		return out
+	}
+	out = append(out, "--")
+	out = append(out, passthroughArgs...)
+	return out
 }
 
 // Returns args with any arguments also found in existingArgs removed

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -619,7 +619,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 	return exitCode, nil
 }
 
-func handleRemoteBazel(args []string) []string {
+func handleRemoteBazel(args, passthroughArgs []string) []string {
 	args = arg.Remove(args, "bes_backend")
 	args = arg.Remove(args, "remote_cache")
 	args = arg.Remove(args, "remote_executor")
@@ -643,7 +643,7 @@ func handleRemoteBazel(args []string) []string {
 	exitCode, err := Run(ctx, RunOpts{
 		Server:            "grpcs://" + defaultRemoteExecutionURL,
 		APIKey:            arg.Get(args, "remote_header=x-buildbuddy-api-key"),
-		Args:              args,
+		Args:              arg.JoinPassthroughArgs(args, passthroughArgs),
 		WorkspaceFilePath: wsFilePath,
 	}, repoConfig)
 	if err != nil {
@@ -654,12 +654,12 @@ func handleRemoteBazel(args []string) []string {
 	return args
 }
 
-func HandleRemoteBazel(args []string) []string {
+func HandleRemoteBazel(args, passthroughArgs []string) []string {
 	if c, i := arg.GetCommandAndIndex(args); c == "remote" {
-		return handleRemoteBazel(args[i+1:])
+		return handleRemoteBazel(args[i+1:], passthroughArgs)
 	}
 	if arg, rest := arg.Pop(args, "remote"); arg == "true" {
-		return handleRemoteBazel(rest)
+		return handleRemoteBazel(rest, passthroughArgs)
 	}
 	return args
 }


### PR DESCRIPTION
Fixes things like `bb run enterprise/server -- --config_file=foo/bar.yaml`. This was broken because some of the arg handling was appending to the args list irrespective of the passthrough args.

* Plugins no longer are allowed to mutate the passthrough args.
* `GetPassthroughArgs` and `GetNonPassthroughArgs` now always return a copy, to prevent accidental mutation of the underlying array.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
