### PR TITLE
CLI: Make help commands and flags work

### DIFF
--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -52,7 +52,7 @@ func GetCommand(args []string) string {
 // Returns the first non-option found in the list of args (doesn't begin with "-") and the index at which it was found
 func GetCommandAndIndex(args []string) (string, int) {
 	for i, arg := range args {
-		if strings.HasPrefix("-", arg) {
+		if strings.HasPrefix(arg, "-") {
 			continue
 		}
 		return arg, i
@@ -114,4 +114,15 @@ func RemoveExistingArgs(args []string, existingArgs []string) []string {
 		}
 	}
 	return diff
+}
+
+// ContainsExact returns whether the slice `args` contains the literal string
+// `value`.
+func ContainsExact(args []string, value string) bool {
+	for _, v := range args {
+		if v == value {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//cli/arg",
         "//cli/bazelisk",
+        "//cli/help",
         "//cli/log",
         "//cli/login",
         "//cli/parser",

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
+	"github.com/buildbuddy-io/buildbuddy/cli/help"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/login"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
@@ -28,6 +29,12 @@ func main() {
 }
 
 func run() (exitCode int, err error) {
+	// Show help if applicable.
+	exitCode, err = help.HandleHelp(os.Args[1:])
+	if err != nil || exitCode >= 0 {
+		return exitCode, err
+	}
+
 	// Maybe run interactively (watching for changes to files).
 	if exitCode, err := watcher.Watch(); exitCode >= 0 || err != nil {
 		return exitCode, err

--- a/cli/help/BUILD
+++ b/cli/help/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "help",
+    srcs = ["help.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/help",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cli/arg",
+        "//cli/bazelisk",
+        "//cli/version",
+    ],
+)

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -1,0 +1,111 @@
+package help
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
+	"github.com/buildbuddy-io/buildbuddy/cli/version"
+)
+
+const (
+	cliName = "bb"
+)
+
+var (
+	// helpModifiers are flags that affect how the help output is displayed.
+	helpModifiers = map[string]struct{}{
+		"--long":  {},
+		"--short": {},
+	}
+)
+
+func HandleHelp(args []string) (exitCode int, err error) {
+	args, _ = arg.SplitPassthroughArgs(args)
+
+	cmd, idx := arg.GetCommandAndIndex(args)
+	// If no command is specified, show general help.
+	// TODO: Allow configuring a "default command" that is run when
+	// no args are passed? Like `build //...`
+	if idx == -1 {
+		return showHelp("", getHelpModifiers(args))
+	}
+	if cmd == "help" {
+		// Get the subcommand (the string "build" in "bazel help build")
+		subcommand, _ := arg.GetCommandAndIndex(args[idx+1:])
+		return showHelp(subcommand, getHelpModifiers(args))
+	}
+	if arg.ContainsExact(args, "-h") || arg.ContainsExact(args, "--help") {
+		// Assume cmd is the bazel subcommand if set.
+		// Bazel will show "ERROR: 'foo' is not a known command" if the
+		// subcommand is invalid.
+		return showHelp(cmd, getHelpModifiers(args))
+	}
+	return -1, nil
+}
+
+func showHelp(subcommand string, modifiers []string) (exitCode int, err error) {
+	bazelArgs := []string{"help"}
+	if subcommand != "" {
+		bazelArgs = append(bazelArgs, subcommand)
+	}
+	bazelArgs = append(bazelArgs, modifiers...)
+	buf := bytes.NewBuffer(nil)
+	exitCode, err = bazelisk.Run(bazelArgs, "/dev/null" /*=outputPath*/, buf)
+	if err != nil {
+		io.Copy(os.Stdout, buf)
+		return exitCode, err
+	}
+	if exitCode != 0 {
+		io.Copy(os.Stdout, buf)
+		return exitCode, nil
+	}
+	// Match "Usage: bazel <command> <options> ..."
+	usagePattern := regexp.MustCompile(`^(.*?Usage:\s+)bazel(\s+.*)$`)
+	// Match example "bazel help ..." commands in "Getting more help" section
+	moreHelpPattern := regexp.MustCompile(`^(\s*)bazel( help\s+.*)$`)
+	// Get help output lines with trailing newlines removed
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	for _, line := range lines {
+		// Bazel shows its release version at the top of the help output;
+		// show ours too.
+		if strings.Contains(line, "[bazel release") {
+			releaseTag := fmt.Sprintf("[%s release %v]", cliName, version.String())
+			fmt.Println(padStart(releaseTag, len(line)))
+			fmt.Println(line)
+			continue
+		}
+		if m := usagePattern.FindStringSubmatch(line); m != nil {
+			fmt.Println(m[1] + cliName + m[2])
+			continue
+		}
+		if m := moreHelpPattern.FindStringSubmatch(line); m != nil {
+			fmt.Println(m[1] + cliName + m[2])
+			continue
+		}
+		fmt.Println(line)
+	}
+	return exitCode, nil
+}
+
+func getHelpModifiers(args []string) []string {
+	var out []string
+	for _, arg := range args {
+		if _, ok := helpModifiers[arg]; ok {
+			out = append(out, arg)
+		}
+	}
+	return out
+}
+
+func padStart(value string, targetLength int) string {
+	for len(value) < targetLength {
+		value = " " + value
+	}
+	return value
+}

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -15,3 +15,7 @@ func HandleVersion(args []string) []string {
 	fmt.Printf("bb %s\n", cliVersionFlag)
 	return args
 }
+
+func String() string {
+	return cliVersionFlag
+}


### PR DESCRIPTION
* Running `bb` without subcommand: shows top-level help
* Running `bb help <command>` or `bb <command>` with `-h` or `--help` appearing anywhere in the args: shows help for `<command>`
* Supports `--short` and `--long` options that bazel supports
* Replaces occurrences of `bazel` with `bb` in a few cases
* Shows CLI version info above Bazel version info

Example output

<details>
<summary>bb help</summary>

```
                                                            [bb release unknown]
                                                           [bazel release 5.3.1]
Usage: bb <command> <options> ...

Available commands:
  analyze-profile     Analyzes build profile data.
  aquery              Analyzes the given targets and queries the action graph.
  build               Builds the specified targets.
  canonicalize-flags  Canonicalizes a list of bazel options.
  clean               Removes output files and optionally stops the server.
  coverage            Generates code coverage report for specified test targets.
  cquery              Loads, analyzes, and queries the specified targets w/ configurations.
  dump                Dumps the internal state of the bazel server process.
  fetch               Fetches external repositories that are prerequisites to the targets.
  help                Prints help for commands, or the index.
  info                Displays runtime info about the bazel server.
  license             Prints the license of this software.
  mobile-install      Installs targets to mobile devices.
  print_action        Prints the command line args for compiling a file.
  query               Executes a dependency graph query.
  run                 Runs the specified target.
  shutdown            Stops the bazel server.
  sync                Syncs all repositories specified in the workspace file
  test                Builds and runs the specified test targets.
  version             Prints version information for bazel.

Getting more help:
  bb help <command>
                   Prints help and options for <command>.
  bb help startup_options
                   Options for the JVM hosting bazel.
  bb help target-syntax
                   Explains the syntax for specifying targets.
  bb help info-keys
                   Displays a list of keys used by the info command.
```

</details>

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
