### PR TITLE
Improve FinalizeInvocation logging

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -281,36 +281,39 @@ func (r *statsRecorder) handleTask(ctx context.Context, task *recordStatsTask) {
 	// unnecessarily throttled.
 	time.Sleep(time.Until(task.createdAt.Add(*cacheStatsFinalizationDelay)))
 	ti := &tables.Invocation{InvocationID: task.invocationJWT.id, Attempt: task.invocationJWT.attempt}
+	ctx = log.EnrichContext(ctx, log.InvocationIDKey, task.invocationJWT.id)
 	if stats := hit_tracker.CollectCacheStats(ctx, r.env, task.invocationJWT.id); stats != nil {
 		fillInvocationFromCacheStats(stats, ti)
+	} else {
+		log.CtxInfo(ctx, "cache stats is not available.")
 	}
 	if sc := hit_tracker.ScoreCard(ctx, r.env, task.invocationJWT.id); sc != nil {
 		scorecard.FillBESMetadata(sc, task.files)
 		if err := scorecard.Write(ctx, r.env, task.invocationJWT.id, task.invocationJWT.attempt, sc); err != nil {
-			log.Errorf("Error writing scorecard blob: %s", err)
+			log.CtxErrorf(ctx, "Error writing scorecard blob: %s", err)
 		}
 	}
 
 	updated, err := r.env.GetInvocationDB().UpdateInvocation(ctx, ti)
 	if err != nil {
-		log.Errorf("Failed to write cache stats for invocation %q to primaryDB: %s", ti.InvocationID, err)
+		log.CtxErrorf(ctx, "Failed to write cache stats to primaryDB: %s", err)
 	}
 
 	if task.invocationStatus == inpb.Invocation_COMPLETE_INVOCATION_STATUS {
 		// only flush complete invocation to clickhouse.
 		err = r.flushInvocationStatsToOLAPDB(ctx, task.invocationJWT)
 		if err != nil {
-			log.Errorf("Failed to flush stats for invocation %s to clickhouse: %s", ti.InvocationID, err)
+			log.CtxErrorf(ctx, "Failed to flush stats to clickhouse: %s", err)
 		}
 	} else {
-		log.Infof("skipped writing stats for invocation %s to clickhouse, invocationStatus = %s", ti.InvocationID, task.invocationStatus)
+		log.CtxInfof(ctx, "skipped writing stats to clickhouse, invocationStatus = %s", task.invocationStatus)
 	}
 	// Cleanup regardless of whether the stats are flushed successfully to
 	// the DB (since we won't retry the flush and we don't need these stats
 	// for any other purpose).
 	hit_tracker.CleanupCacheStats(ctx, r.env, task.invocationJWT.id)
 	if !updated {
-		log.Warningf("Attempt %d of invocation %s pre-empted by more recent attempt, no cache stats flushed.", task.invocationJWT.attempt, task.invocationJWT.id)
+		log.CtxWarningf(ctx, "Attempt %d of invocation pre-empted by more recent attempt, no cache stats flushed.", task.invocationJWT.attempt)
 		// Don't notify the webhook; the more recent attempt should trigger
 		// the notification when it is finalized.
 		return
@@ -623,6 +626,7 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 	}
 
 	ctx, cancel := background.ExtendContextForFinalization(e.ctx, 10*time.Second)
+	ctx = log.EnrichContext(ctx, log.InvocationIDKey, iid)
 	defer cancel()
 
 	invocationStatus := inpb.Invocation_DISCONNECTED_INVOCATION_STATUS
@@ -679,11 +683,12 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 	// This reduces the likelihood that the disconnected invocation's status
 	// will overwrite any statuses written by a more recent attempt.
 	if invocationStatus == inpb.Invocation_DISCONNECTED_INVOCATION_STATUS {
-		log.Warningf("Reporting disconnected status for invocation %s.", iid)
+		log.CtxWarning(ctx, "Reporting disconnected status for invocation")
 		e.statusReporter.ReportDisconnect(ctx)
 	}
 
 	e.statsRecorder.Enqueue(ctx, invocation)
+	log.CtxInfof(ctx, "Updated invocation to primaryDB and Enqueued invocation, invocation_status: %s", invocationStatus)
 	return nil
 }
 

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -120,6 +120,7 @@ func NewBuildEventHandler(env environment.Env) *BuildEventHandler {
 
 func (b *BuildEventHandler) OpenChannel(ctx context.Context, iid string) interfaces.BuildEventChannel {
 	buildEventAccumulator := accumulator.NewBEValues(iid)
+	ctx = log.EnrichContext(ctx, log.InvocationIDKey, iid)
 
 	b.openChannels.Add(1)
 	onClose := func() {
@@ -626,7 +627,6 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 	}
 
 	ctx, cancel := background.ExtendContextForFinalization(e.ctx, 10*time.Second)
-	ctx = log.EnrichContext(ctx, log.InvocationIDKey, iid)
 	defer cancel()
 
 	invocationStatus := inpb.Invocation_DISCONNECTED_INVOCATION_STATUS

--- a/server/build_event_protocol/build_event_server/build_event_server.go
+++ b/server/build_event_protocol/build_event_server/build_event_server.go
@@ -63,6 +63,7 @@ func (s *BuildEventProtocolServer) PublishLifecycleEvent(ctx context.Context, re
 // adds an OPEN_STREAM event.
 func (s *BuildEventProtocolServer) PublishBuildToolEventStream(stream pepb.PublishBuildEvent_PublishBuildToolEventStreamServer) error {
 	ctx := stream.Context()
+	log.CtxInfof("PublishBuildToolEventStream")
 	// Semantically, the protocol requires we ack events in order.
 	acks := make([]int, 0)
 	var streamID *bepb.StreamId

--- a/server/build_event_protocol/build_event_server/build_event_server.go
+++ b/server/build_event_protocol/build_event_server/build_event_server.go
@@ -63,7 +63,6 @@ func (s *BuildEventProtocolServer) PublishLifecycleEvent(ctx context.Context, re
 // adds an OPEN_STREAM event.
 func (s *BuildEventProtocolServer) PublishBuildToolEventStream(stream pepb.PublishBuildEvent_PublishBuildToolEventStreamServer) error {
 	ctx := stream.Context()
-	log.CtxInfof("PublishBuildToolEventStream")
 	// Semantically, the protocol requires we ack events in order.
 	acks := make([]int, 0)
 	var streamID *bepb.StreamId

--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -578,7 +578,7 @@ func CollectCacheStats(ctx context.Context, env environment.Env, iid string) *ca
 
 	counts, err := c.ReadCounts(ctx, counterKey(iid))
 	if err != nil {
-		log.Warningf("Failed to collect cache stats for invocation %s: %s", iid, err)
+		log.CtxWarningf(ctx, "Failed to collect cache stats for invocation %s: %s", iid, err)
 		return cs
 	}
 	if counts == nil {

--- a/server/rpc/filters/filters.go
+++ b/server/rpc/filters/filters.go
@@ -171,7 +171,7 @@ func requestIDUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 
 func addInvocationIdToLog(ctx context.Context) context.Context {
 	if iid := bazel_request.GetInvocationID(ctx); iid != "" {
-		return log.EnrichContext(ctx, "invocation_id", iid)
+		return log.EnrichContext(ctx, log.InvocationIDKey, iid)
 	}
 	return ctx
 }

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -283,6 +283,15 @@ func Debugf(format string, args ...interface{}) {
 	log.Debug().Msgf(format, args...)
 }
 
+// CtxDebug logs to the DEBUG log.
+// Logs are enriched with information from the context
+// (e.g. invocation_id, request_id)
+func CtxDebug(ctx context.Context, message string) {
+	e := log.Debug()
+	enrichEventFromContext(ctx, e)
+	e.Msg(message)
+}
+
 // CtxDebugf logs to the DEBUG log. Arguments are handled in the manner of
 // fmt.Printf.
 // Logs are enriched with information from the context
@@ -359,6 +368,15 @@ func Error(message string) {
 // Errorf logs to the ERROR log. Arguments are handled in the manner of fmt.Printf.
 func Errorf(format string, args ...interface{}) {
 	log.Error().Msgf(format, args...)
+}
+
+// CtxError logs to the ERROR log.
+// Logs are enriched with information from the context
+// (e.g. invocation_id, request_id)
+func CtxError(ctx context.Context, message string) {
+	e := log.Error()
+	enrichEventFromContext(ctx, e)
+	e.Msg(message)
 }
 
 // CtxErrorf logs to the ERROR log. Arguments are handled in the manner of

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -31,7 +31,8 @@ var (
 )
 
 const (
-	ExecutionIDKey = "execution_id"
+	ExecutionIDKey  = "execution_id"
+	InvocationIDKey = "invocation_id"
 
 	callerSkipFrameCount = 3
 )
@@ -302,6 +303,15 @@ func Infof(format string, args ...interface{}) {
 	log.Info().Msgf(format, args...)
 }
 
+// CtxInfo logs to the INFO log.
+// Logs are enriched with information from the context
+// (e.g. invocation_id, request_id)
+func CtxInfo(ctx context.Context, message string) {
+	e := log.Info()
+	enrichEventFromContext(ctx, e)
+	e.Msg(message)
+}
+
 // CtxInfof logs to the INFO log. Arguments are handled in the manner of
 // fmt.Printf.
 // Logs are enriched with information from the context
@@ -320,6 +330,15 @@ func Warning(message string) {
 // Warningf logs to the WARNING log. Arguments are handled in the manner of fmt.Printf.
 func Warningf(format string, args ...interface{}) {
 	log.Warn().Msgf(format, args...)
+}
+
+// CtxWarning logs to the WARNING log.
+// Logs are enriched with information from the context
+// (e.g. invocation_id, request_id)
+func CtxWarning(ctx context.Context, message string) {
+	e := log.Warn()
+	enrichEventFromContext(ctx, e)
+	e.Msg(message)
 }
 
 // CtxWarningf logs to the WARNING log. Arguments are handled in the manner of


### PR DESCRIPTION
1. Add CtxInfo and CtxWarning
2. Add invocation_id to the context and use log.Ctx*** for logging.
3. Add additional logging after we successfully enqueue stats recorder task.