### PR TITLE
smaller leases

### DIFF
--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -396,7 +396,7 @@ type raftWriteCloser struct {
 
 func (rwc *raftWriteCloser) Commit() error {
 	if err := rwc.WriteCloser.Close(); err != nil {
-		return err
+		return status.UnavailableError(err.Error())
 	}
 	return rwc.closeFn()
 }

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1237,6 +1237,12 @@ func (sm *Replica) Writer(ctx context.Context, header *rfpb.Header, fileRecord *
 		}
 		defer db.Close()
 
+		// Re-validate the header to ensure the range did not split before
+		// we got to Commit().
+		if err := sm.validateRange(header); err != nil {
+			return err
+		}
+
 		batch := db.NewBatch()
 		now := time.Now()
 		md := &rfpb.FileMetadata{

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -19,7 +19,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/pebbleutil"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
-	"github.com/buildbuddy-io/buildbuddy/server/util/canary"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/ioutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"


### PR DESCRIPTION
- Lease DB only for metadata changes
- Return unavailable so it can be retried
- Remove unused import


Note: I still see see split lease times over a second. I believe this is because scanning (and proto deserializing) so many files that have inline metadata content is slow. 