### PR TITLE
Fix firecracker goroutine leak

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -305,6 +305,9 @@ type FirecrackerContainer struct {
 	externalJailerCmd *exec.Cmd
 
 	cleanupVethPair func(context.Context) error
+	// cancelVmCtx cancels the Machine context, stopping the VMM if it hasn't
+	// already been stopped manually.
+	cancelVmCtx context.CancelFunc
 }
 
 // ConfigurationHash returns a digest that can be used to look up or save a
@@ -373,6 +376,7 @@ func NewContainer(env environment.Env, imageCacheAuth *container.ImageCacheAuthe
 		imageCacheAuth:     imageCacheAuth,
 		allowSnapshotStart: opts.AllowSnapshotStart,
 		mountWorkspaceFile: *firecrackerMountWorkspaceFile,
+		cancelVmCtx:        func() {},
 	}
 
 	if err := c.newID(); err != nil {
@@ -642,7 +646,8 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 		return err
 	}
 
-	vmCtx := context.Background()
+	vmCtx, cancel := context.WithCancel(context.Background())
+	c.cancelVmCtx = cancel
 	machineOpts := []fcclient.Opt{
 		fcclient.WithLogger(getLogrusLogger(c.constants.DebugMode)),
 		fcclient.WithSnapshot(fullMemSnapshotName, vmStateSnapshotName),
@@ -1268,7 +1273,8 @@ func (c *FirecrackerContainer) Create(ctx context.Context, actionWorkingDir stri
 		return err
 	}
 
-	vmCtx := context.Background()
+	vmCtx, cancel := context.WithCancel(context.Background())
+	c.cancelVmCtx = cancel
 
 	machineOpts := []fcclient.Opt{
 		fcclient.WithLogger(getLogrusLogger(c.constants.DebugMode)),
@@ -1511,6 +1517,8 @@ func (c *FirecrackerContainer) Remove(ctx context.Context) error {
 }
 
 func (c *FirecrackerContainer) remove(ctx context.Context) error {
+	defer c.cancelVmCtx()
+
 	var lastErr error
 
 	if err := c.machine.Shutdown(ctx); err != nil {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -503,7 +503,7 @@ func TestFirecrackerNonRoot(t *testing.T) {
 		`},
 		OutputDirectories: []string{"outputs", "nested/outputs"},
 	}
-	ws.SetTask(&repb.ExecutionTask{Command: cmd})
+	ws.SetTask(ctx, &repb.ExecutionTask{Command: cmd})
 	err = ws.CreateOutputDirs()
 	require.NoError(t, err)
 


### PR DESCRIPTION
Context: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1764

Upstream mitigation: https://github.com/firecracker-microvm/firecracker-go-sdk/pull/458

Tested: `firecracker_test` still passes; runner recycling still works locally.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
