### PR TITLE
Fix race in firecracker VMLog

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1680,5 +1680,8 @@ func (log *VMLog) Write(p []byte) (int, error) {
 func (log *VMLog) Tail() []byte {
 	log.mu.RLock()
 	defer log.mu.RUnlock()
-	return log.buf.Bytes()
+	b := log.buf.Bytes()
+	out := make([]byte, len(b))
+	copy(out, b)
+	return out
 }


### PR DESCRIPTION
`Tail()` should return a copy so that subsequent calls to `Write()` can't mutate the returned slice.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
