### PR TITLE
CLI: Fix truncated bazel output

### DIFF
--- a/cli/bazelisk/BUILD
+++ b/cli/bazelisk/BUILD
@@ -12,10 +12,12 @@ go_library(
         "//cli/arg",
         "//cli/log",
         "//cli/plugin",
+        "//cli/terminal",
         "//cli/workspace",
         "//server/util/disk",
         "//server/util/status",
         "@com_github_bazelbuild_bazelisk//core:go_default_library",
         "@com_github_bazelbuild_bazelisk//repositories:go_default_library",
+        "@com_github_creack_pty//:pty",
     ],
 )

--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//cli/plugin",
         "//cli/remotebazel",
         "//cli/sidecar",
-        "//cli/terminal",
         "//cli/tooltag",
         "//cli/version",
         "//cli/watcher",

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -13,7 +13,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/plugin"
 	"github.com/buildbuddy-io/buildbuddy/cli/remotebazel"
 	"github.com/buildbuddy-io/buildbuddy/cli/sidecar"
-	"github.com/buildbuddy-io/buildbuddy/cli/terminal"
 	"github.com/buildbuddy-io/buildbuddy/cli/tooltag"
 	"github.com/buildbuddy-io/buildbuddy/cli/version"
 	"github.com/buildbuddy-io/buildbuddy/cli/watcher"
@@ -75,7 +74,6 @@ func run() (exitCode int, err error) {
 	args = tooltag.ConfigureToolTag(args)
 	args = sidecar.ConfigureSidecar(args)
 	args = login.ConfigureAPIKey(args)
-	args = terminal.ConfigureOutputMode(args)
 
 	// Prepare convenience env vars for plugins
 	if err := plugin.PrepareEnv(); err != nil {

--- a/cli/terminal/BUILD
+++ b/cli/terminal/BUILD
@@ -5,8 +5,4 @@ go_library(
     srcs = ["terminal.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/terminal",
     visibility = ["//visibility:public"],
-    deps = [
-        "//cli/arg",
-        "//cli/log",
-    ],
 )

--- a/cli/terminal/terminal.go
+++ b/cli/terminal/terminal.go
@@ -2,39 +2,13 @@ package terminal
 
 import (
 	"os"
-
-	"github.com/buildbuddy-io/buildbuddy/cli/arg"
-	"github.com/buildbuddy-io/buildbuddy/cli/log"
 )
 
-// ConfigureOutputMode makes sure that bazel produces fancy terminal output.
-// This is needed because we tee its output to a file, which makes bazel think
-// it is not writing to a terminal, causing it to disable fancy output (ANSI
-// colors, dynamic progress indicators, etc.) unless explicitly enabled.
-func ConfigureOutputMode(args []string) []string {
-	// If bb itself is not writing to a terminal, don't force color/curses.
-	o, err := os.Stdout.Stat()
+// IsTTY returns whether the given file descriptor is connected to a terminal.
+func IsTTY(f *os.File) (bool, error) {
+	stat, err := f.Stat()
 	if err != nil {
-		log.Printf("Could not stat stdout; fancy output will not be enabled: %s", err)
-		return args
+		return false, err
 	}
-	if (o.Mode() & os.ModeCharDevice) != os.ModeCharDevice {
-		return args
-	}
-	o, err = os.Stderr.Stat()
-	if err != nil {
-		log.Printf("Could not stat stderr; fancy output will not be enabled: %s", err)
-		return args
-	}
-	if (o.Mode() & os.ModeCharDevice) != os.ModeCharDevice {
-		return args
-	}
-
-	if !arg.Has(args, "curses") {
-		args = append(args, "--curses=yes")
-	}
-	if !arg.Has(args, "color") {
-		args = append(args, "--color=yes")
-	}
-	return args
+	return stat.Mode()&os.ModeCharDevice == os.ModeCharDevice, nil
 }


### PR DESCRIPTION
Write bazelisk's output to a pty whose size is inherited from the current terminal. This causes target names to be output with the correct length and also removes the need for passing `--curses=yes` and `--color=yes` since Bazel now sees that it's writing to a terminal and won't disable fancy output by default.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1758
