### PR TITLE
CLI: Remove banner for now

### DIFF
--- a/cli/tooltag/BUILD
+++ b/cli/tooltag/BUILD
@@ -5,8 +5,5 @@ go_library(
     srcs = ["tooltag.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/tooltag",
     visibility = ["//visibility:public"],
-    deps = [
-        "//cli/arg",
-        "//cli/log",
-    ],
+    deps = ["//cli/arg"],
 )

--- a/cli/tooltag/tooltag.go
+++ b/cli/tooltag/tooltag.go
@@ -2,11 +2,9 @@ package tooltag
 
 import (
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
-	"github.com/buildbuddy-io/buildbuddy/cli/log"
 )
 
 func ConfigureToolTag(args []string) []string {
-	log.Printf("🚀 \033[1mBUILT WITH BUILDBUDDY\033[0m 🚀")
 	if arg.GetCommand(args) != "" && !arg.Has(args, "tool_tag") {
 		return append(args, "--tool_tag=buildbuddy-cli")
 	}


### PR DESCRIPTION
The banner is a bit distracting so remove it for now; maybe we can show it at most once/week and also show a feedback link at the end of the invocation?

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
