### PR TITLE
CLI: Disable the sidecar for CI builds

### DIFF
--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
@@ -102,6 +103,12 @@ func restartSidecarIfNecessary(ctx context.Context, bbHomeDir string, args []str
 }
 
 func ConfigureSidecar(args []string) []string {
+	// Don't enable the sidecar on CI for now, since the runner may terminate
+	// before events have a chance to upload.
+	if strings.ToLower(os.Getenv("CI")) == "true" {
+		return args
+	}
+
 	bbHome, err := storage.Dir()
 	ctx := context.Background()
 	if err != nil {

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -445,6 +445,8 @@ func run() error {
 		forcedInvocationID: *invocationID,
 	}
 
+	os.Setenv("CI", "true")
+
 	ctx := context.Background()
 	if ws.buildbuddyAPIKey != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, auth.APIKeyHeader, ws.buildbuddyAPIKey)


### PR DESCRIPTION
The CI runner (either our CI runner, or other runners like GitHub Actions) might cause disconnected invocations if the runner terminates before the sidecar has a chance to upload BES events / artifacts. Disable the sidecar on CI for now.

Also set `CI=true` in the BB CI runner so that we don't forget to do it later once we start using `bb` as the bazelisk wrapper for workflows :)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
