### PR TITLE
CLI: Use UserConfigDir for config files

### DIFF
--- a/cli/login/login.go
+++ b/cli/login/login.go
@@ -26,9 +26,9 @@ func HandleLogin(args []string) []string {
 
 	log.Printf("You are now logged in!")
 
-	dir, err := storage.Dir()
+	dir, err := storage.ConfigDir()
 	if err != nil {
-		log.Fatalf("error getting storage directory: %s", err)
+		log.Fatalf("error getting config directory: %s", err)
 	}
 	apiKeyFile := filepath.Join(dir, apiKeyFileName)
 	err = os.WriteFile(apiKeyFile, []byte(apiKey), 0644)
@@ -44,9 +44,9 @@ func ConfigureAPIKey(args []string) []string {
 		return args
 	}
 
-	dir, err := storage.Dir()
+	dir, err := storage.ConfigDir()
 	if err != nil {
-		log.Fatalf("error getting storage directory: %s", err)
+		log.Fatalf("error getting config directory: %s", err)
 	}
 	apiKeyFile := filepath.Join(dir, apiKeyFileName)
 	apiKeyBytes, err := os.ReadFile(apiKeyFile)

--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -351,7 +351,7 @@ func (p *Plugin) splitRepoRef() (string, string) {
 }
 
 func (p *Plugin) repoClonePath() (string, error) {
-	storagePath, err := storage.Dir()
+	storagePath, err := storage.CacheDir()
 	if err != nil {
 		return "", err
 	}

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -102,12 +102,12 @@ func restartSidecarIfNecessary(ctx context.Context, bbHomeDir string, args []str
 }
 
 func ConfigureSidecar(args []string) []string {
-	bbHome, err := storage.Dir()
+	cacheDir, err := storage.CacheDir()
 	ctx := context.Background()
 	if err != nil {
 		log.Printf("Sidecar could not be initialized, continuing without sidecar: %s", err)
 	}
-	if err := extractBundledSidecar(ctx, bbHome); err != nil {
+	if err := extractBundledSidecar(ctx, cacheDir); err != nil {
 		log.Printf("Error extracting sidecar: %s", err)
 	}
 
@@ -123,12 +123,12 @@ func ConfigureSidecar(args []string) []string {
 	if remoteCacheFlag != "" && remoteExecFlag == "" {
 		sidecarArgs = append(sidecarArgs, "--remote_cache="+remoteCacheFlag)
 		// Also specify as disk cache directory.
-		diskCacheDir := filepath.Join(bbHome, "filecache")
+		diskCacheDir := filepath.Join(cacheDir, "filecache")
 		sidecarArgs = append(sidecarArgs, fmt.Sprintf("--cache_dir=%s", diskCacheDir))
 	}
 
 	if len(sidecarArgs) > 0 {
-		sidecarSocket, err := restartSidecarIfNecessary(ctx, bbHome, sidecarArgs)
+		sidecarSocket, err := restartSidecarIfNecessary(ctx, cacheDir, sidecarArgs)
 		if err == nil {
 			err = keepaliveSidecar(ctx, sidecarSocket)
 		}

--- a/cli/storage/storage.go
+++ b/cli/storage/storage.go
@@ -5,18 +5,37 @@ import (
 	"path/filepath"
 )
 
-func Dir() (string, error) {
-	// Make sure we have a home directory to work in.
-	bbHome := os.Getenv("BUILDBUDDY_HOME")
-	if len(bbHome) == 0 {
+// ConfigDir returns a user-specific directory for storing BuildBuddy
+// configuration files.
+func ConfigDir() (string, error) {
+	configDir := os.Getenv("BUILDBUDDY_CONFIG_DIR")
+	if configDir == "" {
+		userConfigDir, err := os.UserConfigDir()
+		if err != nil {
+			return "", err
+		}
+		configDir = filepath.Join(userConfigDir, "buildbuddy")
+	}
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return "", err
+	}
+	return configDir, nil
+}
+
+// CacheDir returns a user-specific directory for storing results of expensive
+// computations. The user may clear this dir at any time (e.g. to free up disk
+// space), so longer-term data (like config files) should not be placed here.
+func CacheDir() (string, error) {
+	cacheDir := os.Getenv("BUILDBUDDY_CACHE_DIR")
+	if cacheDir == "" {
 		userCacheDir, err := os.UserCacheDir()
 		if err != nil {
 			return "", err
 		}
-		bbHome = filepath.Join(userCacheDir, "buildbuddy")
+		cacheDir = filepath.Join(userCacheDir, "buildbuddy")
 	}
-	if err := os.MkdirAll(bbHome, 0755); err != nil {
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
 		return "", err
 	}
-	return bbHome, nil
+	return cacheDir, nil
 }


### PR DESCRIPTION
UserCacheDir is meant as a temporary cache and may be cleaned up periodically (e.g. by disk cleanup utilities). This PR switches `bb login` to use UserConfigDir instead so that the user doesn't get logged out when they clear their cache.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
