### PR TITLE
secret service

### DIFF
--- a/enterprise/server/backends/kms/BUILD
+++ b/enterprise/server/backends/kms/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/kms",
     visibility = [
         "//enterprise:__subpackages__",
+        "//tools:__subpackages__",
         "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [

--- a/enterprise/server/backends/userdb/BUILD
+++ b/enterprise/server/backends/userdb/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/userdb",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/server/util/keystore",
         "//proto:api_key_go_proto",
         "//proto:group_go_proto",
         "//proto:telemetry_go_proto",

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//enterprise/server/saml",
         "//enterprise/server/scheduling/scheduler_server",
         "//enterprise/server/scheduling/task_router",
+        "//enterprise/server/secrets",
         "//enterprise/server/selfauth",
         "//enterprise/server/splash",
         "//enterprise/server/tasksize",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/saml"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/scheduler_server"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_router"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/secrets"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/selfauth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/splash"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/tasksize"
@@ -250,6 +251,9 @@ func main() {
 	}
 
 	if err := kms.Register(realEnv); err != nil {
+		log.Fatalf("%v", err)
+	}
+	if err := secrets.Register(realEnv); err != nil {
 		log.Fatalf("%v", err)
 	}
 

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -400,8 +400,10 @@ func (s *ExecutionServer) Dispatch(ctx context.Context, req *repb.ExecuteRequest
 	props := platform.ParseProperties(executionTask)
 
 	// Add in secrets for any action explicitly requesting secrets, and all workflows.
-	if props.IncludeSecrets || props.WorkflowID != "" {
-		secretService := s.env.GetSecretService()
+	// TODO(tylerw): once secrets service is launched, remove the
+	// '&& secretService != nil' part of the check below.
+	secretService := s.env.GetSecretService()
+	if props.IncludeSecrets || (props.WorkflowID != "" && secretService != nil) {
 		if secretService == nil {
 			return "", status.FailedPreconditionError("Secrets requested but secret service not available")
 		}

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -72,6 +72,7 @@ const (
 	extraArgsPropertyName                = "extra-args"
 	envOverridesPropertyName             = "env-overrides"
 	podmanImageStreamingPropertyName     = "podman-enable-image-streaming"
+	includeSecretsPropertyName           = "include-secrets"
 
 	OperatingSystemPropertyName = "OSFamily"
 	LinuxOperatingSystemName    = "linux"
@@ -121,15 +122,19 @@ type Properties struct {
 	RecycleRunner              bool
 	EnableVFS                  bool
 	EnablePodmanImageStreaming bool
+	IncludeSecrets             bool
+
 	// InitDockerd specifies whether to initialize dockerd within the execution
 	// environment if it is available in the execution image, allowing Docker
 	// containers to be spawned by actions. Only available with
 	// `workload-isolation-type=firecracker`.
 	InitDockerd bool
+
 	// PreserveWorkspace specifies whether to delete all files in the workspace
 	// before running each action. If true, all files are kept except for output
 	// files and directories.
 	PreserveWorkspace bool
+
 	// NonrootWorkspace specifies whether workspace directories should be made
 	// writable by users other than the executor user (which is the root user for
 	// production workloads). This is required to be set when running actions
@@ -146,6 +151,7 @@ type Properties struct {
 	WorkflowID               string
 	HostedBazelAffinityKey   string
 	UseSelfHostedExecutors   bool
+
 	// DisableMeasuredTaskSize disables measurement-based task sizing, even if
 	// it is enabled via flag, and instead uses the default / platform based
 	// sizing. Intended for debugging purposes only and should not generally
@@ -153,12 +159,15 @@ type Properties struct {
 	// TODO(bduffany): remove this once measured task sizing is battle-tested
 	// and this is no longer needed for debugging
 	DisableMeasuredTaskSize bool
+
 	// DisablePredictedTaskSize disables model-based task sizing, even if it
 	// is enabled via flag, and instead uses the default / platform based
 	// sizing.
 	DisablePredictedTaskSize bool
+
 	// ExtraArgs contains arguments to append to the action.
 	ExtraArgs []string
+
 	// EnvOverrides contains environment variables in the form NAME=VALUE to be
 	// applied as overrides to the action.
 	EnvOverrides []string
@@ -212,6 +221,7 @@ func ParseProperties(task *repb.ExecutionTask) *Properties {
 		RecycleRunner:              boolProp(m, RecycleRunnerPropertyName, false),
 		EnableVFS:                  vfsEnabled,
 		EnablePodmanImageStreaming: boolProp(m, podmanImageStreamingPropertyName, false),
+		IncludeSecrets:             boolProp(m, includeSecretsPropertyName, false),
 		PreserveWorkspace:          boolProp(m, preserveWorkspacePropertyName, false),
 		NonrootWorkspace:           boolProp(m, nonrootWorkspacePropertyName, false),
 		CleanWorkspaceInputs:       stringProp(m, cleanWorkspaceInputsPropertyName, ""),

--- a/enterprise/server/secrets/BUILD
+++ b/enterprise/server/secrets/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "secrets",
@@ -15,18 +15,5 @@ go_library(
         "//server/util/perms",
         "//server/util/query_builder",
         "//server/util/status",
-    ],
-)
-
-go_test(
-    name = "secrets_test",
-    srcs = ["secrets_test.go"],
-    deps = [
-        ":secrets",
-        "//enterprise/server/backends/userdb",
-        "//proto:secrets_go_proto",
-        "//server/tables",
-        "//server/testutil/testenv",
-        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/secrets/BUILD
+++ b/enterprise/server/secrets/BUILD
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "secrets",
+    srcs = ["secrets.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/secrets",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//enterprise/server/util/keystore",
+        "//proto:remote_execution_go_proto",
+        "//proto:secrets_go_proto",
+        "//server/environment",
+        "//server/tables",
+        "//server/util/hash",
+        "//server/util/perms",
+        "//server/util/query_builder",
+        "//server/util/status",
+    ],
+)
+
+go_test(
+    name = "secrets_test",
+    srcs = ["secrets_test.go"],
+    deps = [
+        ":secrets",
+        "//enterprise/server/backends/userdb",
+        "//proto:secrets_go_proto",
+        "//server/tables",
+        "//server/testutil/testenv",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/secrets/secrets.go
+++ b/enterprise/server/secrets/secrets.go
@@ -1,0 +1,210 @@
+package secrets
+
+import (
+	"context"
+	"flag"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/keystore"
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/util/hash"
+	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
+	"github.com/buildbuddy-io/buildbuddy/server/util/query_builder"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	skpb "github.com/buildbuddy-io/buildbuddy/proto/secrets"
+)
+
+var (
+	enableSecretService = flag.Bool("app.enable_secret_service", false, "If set, secret service will be enabled")
+)
+
+type SecretService struct {
+	env environment.Env
+}
+
+func New(env environment.Env) *SecretService {
+	return &SecretService{
+		env: env,
+	}
+}
+
+func Register(env environment.Env) error {
+	if !*enableSecretService {
+		return nil
+	}
+	if env.GetKMS() == nil {
+		return status.FailedPreconditionError("KMS is required by secret service")
+	}
+	env.SetSecretService(New(env))
+	return nil
+}
+
+func (s *SecretService) GetPublicKey(ctx context.Context, req *skpb.GetPublicKeyRequest) (*skpb.GetPublicKeyResponse, error) {
+	u, err := perms.AuthenticatedUser(ctx, s.env)
+	if err != nil {
+		return nil, err
+	}
+	udb := s.env.GetUserDB()
+	if udb == nil {
+		return nil, status.FailedPreconditionError("No UserDB configured")
+	}
+	pubKey, err := udb.GetOrCreatePublicKey(ctx, u.GetGroupID())
+	if err != nil {
+		return nil, err
+	}
+	rsp := &skpb.GetPublicKeyResponse{
+		PublicKey: &skpb.PublicKey{
+			Id:    hash.String(u.GetGroupID() + pubKey),
+			Value: pubKey,
+		},
+	}
+	return rsp, nil
+}
+
+func (s *SecretService) ListSecrets(ctx context.Context, req *skpb.ListSecretsRequest) (*skpb.ListSecretsResponse, error) {
+	u, err := perms.AuthenticatedUser(ctx, s.env)
+	if err != nil {
+		return nil, err
+	}
+	dbHandle := s.env.GetDBHandle()
+	if err != nil {
+		return nil, status.FailedPreconditionError("A database is required")
+	}
+
+	q := query_builder.NewQuery(`SELECT name, value FROM Secrets`)
+	q.AddWhereClause("group_id = ?", u.GetGroupID())
+	q.SetOrderBy("name", true /*ascending*/)
+	queryStr, args := q.Build()
+	query := dbHandle.DB(ctx).Raw(queryStr, args...)
+	rows, err := query.Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	rsp := &skpb.ListSecretsResponse{}
+
+	for rows.Next() {
+		k := &tables.Secret{}
+		if err := dbHandle.DB(ctx).ScanRows(rows, k); err != nil {
+			return nil, err
+		}
+		rsp.Secret = append(rsp.Secret, &skpb.Secret{
+			Name:  k.Name,
+			Value: k.Value,
+		})
+	}
+	return rsp, nil
+}
+
+func (s *SecretService) UpdateSecret(ctx context.Context, req *skpb.UpdateSecretRequest) (*skpb.UpdateSecretResponse, error) {
+	u, err := perms.AuthenticatedUser(ctx, s.env)
+	if err != nil {
+		return nil, err
+	}
+	dbHandle := s.env.GetDBHandle()
+	if err != nil {
+		return nil, status.FailedPreconditionError("A database is required")
+	}
+
+	if req.GetSecret().GetName() == "" {
+		return nil, status.InvalidArgumentError("A non-empty secret name is required")
+	}
+	if req.GetSecret().GetValue() == "" {
+		return nil, status.InvalidArgumentError("A non-empty secret value is required")
+	}
+
+	udb := s.env.GetUserDB()
+	if udb == nil {
+		return nil, status.FailedPreconditionError("No UserDB configured")
+	}
+	grp, err := udb.GetGroupByID(ctx, u.GetGroupID())
+	if err != nil {
+		return nil, err
+	}
+
+	secretPerms := perms.GroupAuthPermissions(u.GetGroupID())
+
+	// Before writing the secret to the database, verify that we can open
+	// the secret box using this group's public key.
+	_, err = keystore.OpenAnonymousSealedBox(s.env, grp.PublicKey, grp.EncryptedPrivateKey, req.GetSecret().GetValue())
+	if err != nil {
+		return nil, err
+	}
+	err = dbHandle.DB(ctx).Exec(`REPLACE INTO Secrets (user_id, group_id, name, value, perms) VALUES (?, ?, ?, ?, ?)`,
+		u.GetUserID(), u.GetGroupID(), req.GetSecret().GetName(), req.GetSecret().GetValue(), secretPerms.Perms).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return &skpb.UpdateSecretResponse{}, nil
+}
+
+func (s *SecretService) DeleteSecret(ctx context.Context, req *skpb.DeleteSecretRequest) (*skpb.DeleteSecretResponse, error) {
+	u, err := perms.AuthenticatedUser(ctx, s.env)
+	if err != nil {
+		return nil, err
+	}
+	dbHandle := s.env.GetDBHandle()
+	if err != nil {
+		return nil, status.FailedPreconditionError("A database is required")
+	}
+
+	if req.GetSecret().GetName() == "" {
+		return nil, status.InvalidArgumentError("A non-empty secret name is required")
+	}
+
+	err = dbHandle.DB(ctx).Exec(`DELETE FROM Secrets WHERE group_id = ? AND name = ?`, u.GetGroupID(), req.GetSecret().GetName()).Error
+	if err != nil {
+		return nil, err
+	}
+	return &skpb.DeleteSecretResponse{}, nil
+}
+
+func (s *SecretService) GetSecretEnvVars(ctx context.Context, groupID string) ([]*repb.Command_EnvironmentVariable, error) {
+	if err := perms.AuthorizeGroupAccess(ctx, s.env, groupID); err != nil {
+		return nil, err
+	}
+
+	udb := s.env.GetUserDB()
+	if udb == nil {
+		return nil, status.FailedPreconditionError("No UserDB configured")
+	}
+
+	grp, err := udb.GetGroupByID(ctx, groupID)
+	if err != nil {
+		return nil, err
+	}
+
+	rsp, err := s.ListSecrets(ctx, &skpb.ListSecretsRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(rsp.GetSecret()) == 0 {
+		return []*repb.Command_EnvironmentVariable{}, nil
+	}
+
+	names := make([]string, 0, len(rsp.GetSecret()))
+	encValues := make([]string, 0, len(rsp.GetSecret()))
+	for _, nameAndEncValue := range rsp.GetSecret() {
+		names = append(names, nameAndEncValue.GetName())
+		encValues = append(encValues, nameAndEncValue.GetValue())
+	}
+
+	values, err := keystore.OpenAnonymousSealedBoxes(s.env, grp.PublicKey, grp.EncryptedPrivateKey, encValues)
+	if err != nil {
+		return nil, err
+	}
+
+	envVars := make([]*repb.Command_EnvironmentVariable, len(values))
+	for i := 0; i < len(values); i++ {
+		envVars[i] = &repb.Command_EnvironmentVariable{
+			Name:  names[i],
+			Value: values[i],
+		}
+	}
+	return envVars, nil
+}

--- a/enterprise/server/secrets/secrets.go
+++ b/enterprise/server/secrets/secrets.go
@@ -183,7 +183,9 @@ func (s *SecretService) GetSecretEnvVars(ctx context.Context, groupID string) ([
 		return nil, err
 	}
 
-	if len(rsp.GetSecret()) == 0 {
+	// No secrets, or public key not set up? Let's exit early instead of throwing
+	// an error later.
+	if len(rsp.GetSecret()) == 0 || grp.PublicKey == "" {
 		return []*repb.Command_EnvironmentVariable{}, nil
 	}
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -345,6 +345,9 @@ type UserDB interface {
 	CreateAPIKey(ctx context.Context, groupID string, label string, capabilities []akpb.ApiKey_Capability, visibleToDevelopers bool) (*tables.APIKey, error)
 	UpdateAPIKey(ctx context.Context, key *tables.APIKey) error
 	DeleteAPIKey(ctx context.Context, apiKeyID string) error
+
+	// To support secrets API
+	GetOrCreatePublicKey(ctx context.Context, groupID string) (string, error)
 }
 
 // A webhook can be called when a build is completed.
@@ -920,4 +923,7 @@ type SecretService interface {
 	ListSecrets(ctx context.Context, req *skpb.ListSecretsRequest) (*skpb.ListSecretsResponse, error)
 	UpdateSecret(ctx context.Context, req *skpb.UpdateSecretRequest) (*skpb.UpdateSecretResponse, error)
 	DeleteSecret(ctx context.Context, req *skpb.DeleteSecretRequest) (*skpb.DeleteSecretResponse, error)
+
+	// Internal use only -- fetches decoded secrets for use in running a command.
+	GetSecretEnvVars(ctx context.Context, groupID string) ([]*repb.Command_EnvironmentVariable, error)
 }

--- a/server/role_filter/role_filter.go
+++ b/server/role_filter/role_filter.go
@@ -64,6 +64,11 @@ var (
 		"ExecuteWorkflow",
 		// Setup
 		"GetApiKeys",
+		// Secret management
+		"GetPublicKey",
+		"ListSecrets",
+		"UpdateSecret",
+		"DeleteSecret",
 		// Remote Bazel
 		"Run",
 	}
@@ -86,11 +91,6 @@ var (
 		"DeleteWorkflow",
 		"GetWorkflows",
 		"GetRepos",
-		// Secret management
-		"GetPublicKey",
-		"ListSecrets",
-		"UpdateSecret",
-		"DeleteSecret",
 		// RBE deployment view
 		"GetExecutionNodes",
 		// BuildBuddy usage data

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -211,6 +211,10 @@ type Group struct {
 	InvocationWebhookURL string `gorm:"not null;default:''"`
 
 	SuggestionPreference grpb.SuggestionPreference `gorm:"not null;default:1"`
+
+	// The public key and encrypted private key. Used to upload secrets.
+	PublicKey           string
+	EncryptedPrivateKey string
 }
 
 func (g *Group) TableName() string {
@@ -331,6 +335,18 @@ type APIKey struct {
 
 func (k *APIKey) TableName() string {
 	return "APIKeys"
+}
+
+type Secret struct {
+	UserID  string `gorm:"primaryKey"`
+	GroupID string `gorm:"primaryKey"`
+	Name    string `gorm:"primaryKey"`
+	Value   string
+	Perms   int `gorm:"type:int(11);default:NULL"`
+}
+
+func (s *Secret) TableName() string {
+	return "Secrets"
 }
 
 type Execution struct {
@@ -992,6 +1008,7 @@ func init() {
 	registerTable("IE", &InvocationExecution{})
 	registerTable("TL", &TelemetryLog{})
 	registerTable("CL", &CacheLog{})
+	registerTable("SK", &Secret{})
 	registerTable("TA", &Target{})
 	registerTable("TS", &TargetStatus{})
 	registerTable("WF", &Workflow{})


### PR DESCRIPTION
Add basic secrets support
 - Secrets are available to workflows by default
 - They can be made available to any action by setting the property "include-secrets" = "true" in the action's execution properties. (There is a small performance penalty, 2 extra mysql reads, so this is opt-in)
 - Secrets are decoded using a master key from the KMS *in the app* and passed to the executor over the grpcs channel -- so they should work with BYOR
 - They are appended to the environment variables of the deserialized command included in the ExecutionTask, so they are not visible in the command proto that is stored in the cache
 - Secrets can be created exactly like github secrets, multi-language examples here: https://docs.github.com/en/rest/actions/secrets#example-encrypting-a-secret-using-python. There is also a go example in our own code, in keystore.go (NewAnonymousSealedBox)
 

