### PR TITLE
Migrate set-output commands to GITHUB_OUTPUT files

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -16,7 +16,7 @@ jobs:
         id: version
         # Strip "cli-v" prefix from the tag to get the CLI version.
         # e.g. cli-v1.2.3 sets VERSION to 1.2.3
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/cli-v/}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\/cli-v/}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout buildbuddy-io/bazel
         uses: actions/checkout@v3
@@ -167,7 +167,7 @@ jobs:
           BINARY="bazel-${VERSION}-${OS}-${ARCH}"
           cp bazel-bin/cli/cmd/bb/bb_/bb "$BINARY"
           shasum -a 256 "$BINARY" > "${BINARY}.sha256"
-          echo ::set-output name=BINARY::"${BINARY}"
+          echo "BINARY=${BINARY}" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifacts
         env:

--- a/.github/workflows/release-m1.yaml
+++ b/.github/workflows/release-m1.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get Tag
         id: tag
-        run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+        run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
 
       - name: Upload Artifacts
         env:

--- a/.github/workflows/release-mac.yaml
+++ b/.github/workflows/release-mac.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get Tag
         id: tag
-        run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+        run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
 
       - name: Upload Artifacts
         env:


### PR DESCRIPTION
`set-output` is deprecated: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
