### PR TITLE
CLI: Try bazel clean to fix release

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -160,6 +160,7 @@ jobs:
 
           export DEVELOPER_DIR=/Applications/Xcode_12.4.app/Contents/Developer
           cd "${GITHUB_WORKSPACE}/buildbuddy"
+          "${GITHUB_WORKSPACE}/bin/bazel" clean --expunge
           "${GITHUB_WORKSPACE}/bin/bazel" build //cli/cmd/bb \
               --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
               --//cli/version:cli_version="$VERSION"


### PR DESCRIPTION
Getting `clang: unknown argument: -fnocanonical-system-headers` for the macos-latest release ([logs](https://github.com/buildbuddy-io/buildbuddy/actions/runs/3313987715/jobs/5472802736)). [This article](https://zpjiang.me/2019/03/23/bazel-unknown-argument-fno-canonical-system-headers/) suggests `bazel clean --expunge` might fix it.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
