### PR TITLE
Retry timeout error

### DIFF
--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"strings"
 	"syscall"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -187,16 +188,22 @@ func ToInvocationFromPrimaryDB(ti *tables.Invocation) *Invocation {
 	}
 }
 
+func isTimeout(err error) bool {
+	return strings.Contains(err.Error(), "i/o timeout")
+}
+
 func (h *DBHandle) FlushInvocationStats(ctx context.Context, ti *tables.Invocation) error {
 	inv := ToInvocationFromPrimaryDB(ti)
 	retrier := retry.DefaultWithContext(ctx)
 	var lastError error
+	attempt := 0
 	for retrier.Next() {
+		attempt++
 		res := h.DB(ctx).Create(inv)
 		lastError = res.Error
-		if errors.Is(res.Error, syscall.ECONNRESET) || errors.Is(res.Error, syscall.ECONNREFUSED) || errors.Is(res.Error, context.DeadlineExceeded) {
+		if errors.Is(res.Error, syscall.ECONNRESET) || errors.Is(res.Error, syscall.ECONNREFUSED) || isTimeout(res.Error) {
 			// Retry since it's an transient error.
-			log.CtxInfof(ctx, "attempt to write invocation to clickhouse failed: %s", res.Error)
+			log.CtxInfof(ctx, "attempt (n=%d) to write invocation to clickhouse failed: %s", attempt, res.Error)
 			continue
 		}
 		break
@@ -210,7 +217,7 @@ func (h *DBHandle) FlushInvocationStats(ctx context.Context, ti *tables.Invocati
 		metrics.ClickhouseStatusLabel: statusLabel,
 	}).Inc()
 	if lastError != nil {
-		return status.UnavailableErrorf("clickhouse.FlushInvocationStats exceeded retries for invocation id %q, err: %s", ti.InvocationID, lastError)
+		return status.UnavailableErrorf("clickhouse.FlushInvocationStats exceeded retries (n=%d) for invocation id %q, err: %s", attempt, ti.InvocationID, lastError)
 	}
 	return nil
 }

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -196,14 +196,12 @@ func (h *DBHandle) FlushInvocationStats(ctx context.Context, ti *tables.Invocati
 	inv := ToInvocationFromPrimaryDB(ti)
 	retrier := retry.DefaultWithContext(ctx)
 	var lastError error
-	attempt := 0
 	for retrier.Next() {
-		attempt++
 		res := h.DB(ctx).Create(inv)
 		lastError = res.Error
 		if errors.Is(res.Error, syscall.ECONNRESET) || errors.Is(res.Error, syscall.ECONNREFUSED) || isTimeout(res.Error) {
 			// Retry since it's an transient error.
-			log.CtxInfof(ctx, "attempt (n=%d) to write invocation to clickhouse failed: %s", attempt, res.Error)
+			log.CtxInfof(ctx, "attempt (n=%d) to write invocation to clickhouse failed: %s", retrier.AttemptNumber(), res.Error)
 			continue
 		}
 		break
@@ -217,7 +215,7 @@ func (h *DBHandle) FlushInvocationStats(ctx context.Context, ti *tables.Invocati
 		metrics.ClickhouseStatusLabel: statusLabel,
 	}).Inc()
 	if lastError != nil {
-		return status.UnavailableErrorf("clickhouse.FlushInvocationStats exceeded retries (n=%d) for invocation id %q, err: %s", attempt, ti.InvocationID, lastError)
+		return status.UnavailableErrorf("clickhouse.FlushInvocationStats exceeded retries (n=%d) for invocation id %q, err: %s", retrier.AttemptNumber(), ti.InvocationID, lastError)
 	}
 	return nil
 }


### PR DESCRIPTION
There are 2 cases last week invocations were missing due to i/o timeout.
Further invetigation shows that they were not retried. Use
strings.Contains to check the error.
