### PR TITLE
Pin actions to macos-11 for now

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -104,7 +104,7 @@ jobs:
         include:
           - os: ubuntu-latest
             shell: bash
-          - os: macos-latest
+          - os: macos-11
             shell: bash
           - os: m1
             # TODO: Can we remove this if we upgrade our m1 runner to native arm64?
@@ -160,7 +160,6 @@ jobs:
 
           export DEVELOPER_DIR=/Applications/Xcode_12.4.app/Contents/Developer
           cd "${GITHUB_WORKSPACE}/buildbuddy"
-          "${GITHUB_WORKSPACE}/bin/bazel" clean --expunge
           "${GITHUB_WORKSPACE}/bin/bazel" build //cli/cmd/bb \
               --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
               --//cli/version:cli_version="$VERSION"

--- a/.github/workflows/release-mac.yaml
+++ b/.github/workflows/release-mac.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-11
     if: "!contains(github.event.head_commit.message, 'release skip')"
     steps:
       - name: Checkout


### PR DESCRIPTION
GitHub is slowly migrating `macos-latest` jobs to macOS 12, and it breaks us. This PR pins us to macOS 11 until we can find a fix.

Context https://bazelbuild.slack.com/archives/CA31HN1T3/p1666632009661389

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
