### PR TITLE
CLI: Fix release script

### DIFF
--- a/cli/release.py
+++ b/cli/release.py
@@ -25,7 +25,7 @@ def _main(version):
     p = sh("git fetch --tags")
 
     # Get latest tag
-    p = sh("git tag -l 'cli-*' | tail -n1", stream_stdout=False)
+    p = sh("git tag -l 'cli-*' --sort=creatordate | tail -n1", stream_stdout=False)
     latest_tag = p.stdout.strip()
 
     # If version is unset, bump the latest patch version


### PR DESCRIPTION
Getting "tag already exists" because `git tag -l` sorts alphabetically, and `0.0.10` doesn't get sorted after `0.0.9` when sorting alphabetically.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
