### PR TITLE
Restrict visibility of (most of) //enterprise to //enterprise:__subpackages

### DIFF
--- a/enterprise/BUILD
+++ b/enterprise/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-package(default_visibility = [":__subpackages__"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 filegroup(
     name = "config_files",
@@ -58,7 +58,6 @@ go_library(
         "//conditions:default": [],
     }),
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise",
-    visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//server/util/fileresolver",
     ],

--- a/enterprise/app/BUILD.bazel
+++ b/enterprise/app/BUILD.bazel
@@ -2,7 +2,7 @@ load("//rules/typescript:index.bzl", "ts_library")
 load("@npm//@bazel/esbuild:index.bzl", "esbuild", "esbuild_config")
 load("//rules/sha:index.bzl", "sha")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 config_setting(
     name = "fastbuild",

--- a/enterprise/app/api_keys/BUILD
+++ b/enterprise/app/api_keys/BUILD
@@ -1,6 +1,6 @@
 load("//rules/typescript:index.bzl", "ts_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 exports_files(glob(["*.css"]))
 

--- a/enterprise/app/code/BUILD
+++ b/enterprise/app/code/BUILD
@@ -1,6 +1,6 @@
 load("//rules/typescript:index.bzl", "ts_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 exports_files([
     "code.css",

--- a/enterprise/app/executors/BUILD
+++ b/enterprise/app/executors/BUILD
@@ -1,6 +1,6 @@
 load("//rules/typescript:index.bzl", "ts_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 exports_files(["executors.css"])
 

--- a/enterprise/app/history/BUILD
+++ b/enterprise/app/history/BUILD
@@ -1,6 +1,6 @@
 load("//rules/typescript:index.bzl", "ts_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 exports_files(glob(["*.css"]))
 

--- a/enterprise/app/login/BUILD
+++ b/enterprise/app/login/BUILD
@@ -1,6 +1,6 @@
 load("//rules/typescript:index.bzl", "ts_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 ts_library(
     name = "login",

--- a/enterprise/app/org/BUILD
+++ b/enterprise/app/org/BUILD
@@ -1,6 +1,6 @@
 load("//rules/typescript:index.bzl", "ts_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 exports_files(glob(["*.css"]))
 

--- a/enterprise/app/quota/BUILD
+++ b/enterprise/app/quota/BUILD
@@ -1,6 +1,6 @@
 load("//rules/typescript:index.bzl", "ts_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 exports_files(glob(["*.css"]))
 

--- a/enterprise/app/root/BUILD.bazel
+++ b/enterprise/app/root/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//rules/typescript:index.bzl", "ts_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 exports_files(["root.css"])
 

--- a/enterprise/app/secrets/BUILD
+++ b/enterprise/app/secrets/BUILD
@@ -1,11 +1,12 @@
 load("//rules/typescript:index.bzl", "ts_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 exports_files(["secrets.css"])
 
 ts_library(
     name = "secrets",
     srcs = glob(["*.tsx"]),
-    visibility = ["//visibility:public"],
     deps = [
         "//app/alert",
         "//app/components/button",

--- a/enterprise/app/settings/BUILD
+++ b/enterprise/app/settings/BUILD
@@ -1,6 +1,6 @@
 load("//rules/typescript:index.bzl", "ts_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 exports_files(["settings.css"])
 

--- a/enterprise/app/sidebar/BUILD
+++ b/enterprise/app/sidebar/BUILD
@@ -1,6 +1,6 @@
 load("//rules/typescript:index.bzl", "ts_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 exports_files(["sidebar.css"])
 

--- a/enterprise/app/tap/BUILD
+++ b/enterprise/app/tap/BUILD
@@ -1,6 +1,6 @@
 load("//rules/typescript:index.bzl", "ts_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 exports_files(["tap.css"])
 

--- a/enterprise/app/trends/BUILD
+++ b/enterprise/app/trends/BUILD
@@ -1,6 +1,6 @@
 load("//rules/typescript:index.bzl", "ts_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 exports_files(["trends.css"])
 

--- a/enterprise/app/usage/BUILD
+++ b/enterprise/app/usage/BUILD
@@ -1,6 +1,6 @@
 load("//rules/typescript:index.bzl", "ts_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 exports_files(["usage.css"])
 

--- a/enterprise/app/workflows/BUILD
+++ b/enterprise/app/workflows/BUILD
@@ -1,6 +1,6 @@
 load("//rules/typescript:index.bzl", "ts_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 exports_files(["workflows.css"])
 

--- a/enterprise/dockerfiles/ci_runner_image/BUILD
+++ b/enterprise/dockerfiles/ci_runner_image/BUILD
@@ -1,4 +1,3 @@
 package(default_visibility = [
     "//enterprise:__subpackages__",
-    "@buildbuddy_internal//enterprise:__subpackages__",
 ])

--- a/enterprise/server/api/BUILD
+++ b/enterprise/server/api/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "api",
     srcs = ["api_server.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/api",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:api_key_go_proto",
         "//proto:eventlog_go_proto",

--- a/enterprise/server/auth/BUILD
+++ b/enterprise/server/auth/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/auth",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//enterprise/server/selfauth",

--- a/enterprise/server/backends/authdb/BUILD
+++ b/enterprise/server/backends/authdb/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "authdb",
     srcs = ["authdb.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/authdb",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:group_go_proto",
         "//server/interfaces",

--- a/enterprise/server/backends/distributed/BUILD
+++ b/enterprise/server/backends/distributed/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/distributed",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//enterprise/server/backends/pubsub",
@@ -39,7 +38,6 @@ go_test(
     shard_count = 10,
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/backends/gcs_cache/BUILD
+++ b/enterprise/server/backends/gcs_cache/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/gcs_cache",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/backends/kms/BUILD
+++ b/enterprise/server/backends/kms/BUILD
@@ -7,7 +7,6 @@ go_library(
     visibility = [
         "//enterprise:__subpackages__",
         "//tools:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//server/environment",

--- a/enterprise/server/backends/memcache/BUILD
+++ b/enterprise/server/backends/memcache/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/memcache",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//enterprise/server/composable_cache",

--- a/enterprise/server/backends/migration_cache/BUILD
+++ b/enterprise/server/backends/migration_cache/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "migration_cache",
     srcs = [
@@ -7,7 +9,6 @@ go_library(
         "migration_cache.go",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/migration_cache",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/backends/pebble_cache",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/backends/pebble_cache/BUILD
+++ b/enterprise/server/backends/pebble_cache/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pebble_cache",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//enterprise/server/raft/constants",

--- a/enterprise/server/backends/pubsub/BUILD
+++ b/enterprise/server/backends/pubsub/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pubsub",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//server/interfaces",

--- a/enterprise/server/backends/redis_cache/BUILD
+++ b/enterprise/server/backends/redis_cache/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_cache",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//enterprise/server/backends/redis_client",

--- a/enterprise/server/backends/redis_client/BUILD
+++ b/enterprise/server/backends/redis_client/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "redis_client",
     srcs = ["redis_client.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_client",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/config",
         "//enterprise/server/util/redisutil",

--- a/enterprise/server/backends/redis_kvstore/BUILD
+++ b/enterprise/server/backends/redis_kvstore/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_kvstore",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//server/environment",

--- a/enterprise/server/backends/redis_metrics_collector/BUILD
+++ b/enterprise/server/backends/redis_metrics_collector/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_metrics_collector",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//enterprise/server/util/redisutil",

--- a/enterprise/server/backends/s3_cache/BUILD
+++ b/enterprise/server/backends/s3_cache/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/s3_cache",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/backends/userdb/BUILD
+++ b/enterprise/server/backends/userdb/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "userdb",
     srcs = ["userdb.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/userdb",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/util/keystore",
         "//proto:api_key_go_proto",

--- a/enterprise/server/build_event_publisher/BUILD
+++ b/enterprise/server/build_event_publisher/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "build_event_publisher",
     srcs = ["build_event_publisher.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/build_event_publisher",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/auth",
         "//proto:build_event_stream_go_proto",

--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -4,7 +4,6 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 package(
     default_visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
 )
 

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -2,11 +2,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "executor_lib",
     srcs = ["executor.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/executor",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise:bundle",
         "//enterprise/server/auth",
@@ -67,7 +68,6 @@ go_binary(
         "//enterprise:licenses",
     ],
     embed = [":executor_lib"],
-    visibility = ["//visibility:public"],
 )
 
 container_image(
@@ -77,7 +77,6 @@ container_image(
         "config.yaml": "app/enterprise/server/cmd/executor/executor.runfiles/buildbuddy/enterprise/config/executor.release.yaml",
     },
     tags = ["manual"],
-    visibility = ["//visibility:public"],
 )
 
 # Build a docker image similar to the go_binary above, but use the "go_image"
@@ -87,7 +86,6 @@ go_image(
     base = ":base_image",
     binary = ":executor",
     tags = ["manual"],
-    visibility = ["//visibility:public"],
 )
 
 # This image is the docker image used by the executor to run actions that do not
@@ -96,5 +94,4 @@ container_image(
     name = "default_base_image",
     base = "@default_execution_image//image:dockerfile_image.tar",
     tags = ["manual"],
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/cmd/executor/yaml_doc/BUILD
+++ b/enterprise/server/cmd/executor/yaml_doc/BUILD
@@ -1,9 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_binary(
     name = "yaml_doc",
     embed = [":yaml_doc_lib"],
-    visibility = ["//visibility:public"],
 )
 
 go_library(
@@ -33,5 +34,4 @@ genrule(
         cat $(location :generate_yaml) >> "$@" &&
         echo "\\`\\`\\`" >> "$@"
     """,
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/cmd/goinit/BUILD
+++ b/enterprise/server/cmd/goinit/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "goinit_lib",
     srcs = ["main.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/goinit",
-    visibility = ["//visibility:private"],
     deps = [
         "//enterprise/server/util/vsock",
         "//enterprise/server/vmexec",
@@ -25,5 +26,4 @@ go_binary(
     embed = [":goinit_lib"],
     pure = "on",
     static = "on",
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -2,11 +2,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "server_lib",
     srcs = ["main.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/server",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise:bundle",
         "//enterprise/server/api",
@@ -81,7 +82,6 @@ go_binary(
         "//static",
     ],
     embed = [":server_lib"],
-    visibility = ["//visibility:public"],
 )
 
 container_image(
@@ -92,7 +92,6 @@ container_image(
         "buildbuddy": "tmp",
     },
     tags = ["manual"],
-    visibility = ["//visibility:public"],
 )
 
 # Build a docker image similar to the go_binary above, but use the "go_image"
@@ -102,5 +101,4 @@ go_image(
     base = ":base_image",
     binary = ":buildbuddy",
     tags = ["manual"],
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/cmd/server/yaml_doc/BUILD
+++ b/enterprise/server/cmd/server/yaml_doc/BUILD
@@ -1,9 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_binary(
     name = "yaml_doc",
     embed = [":yaml_doc_lib"],
-    visibility = ["//visibility:public"],
 )
 
 go_library(
@@ -33,5 +34,4 @@ genrule(
         cat $(location :generate_yaml) >> "$@" &&
         echo "\\`\\`\\`" >> "$@"
     """,
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/cmd/smash/BUILD
+++ b/enterprise/server/cmd/smash/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "smash_lib",
     srcs = ["smash.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/smash",
-    visibility = ["//visibility:private"],
     deps = [
         "//proto:remote_execution_go_proto",
         "//server/remote_cache/cachetools",
@@ -24,5 +25,4 @@ go_library(
 go_binary(
     name = "smash",
     embed = [":smash_lib"],
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/composable_cache/BUILD
+++ b/enterprise/server/composable_cache/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "composable_cache",
     srcs = ["composable_cache.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/composable_cache",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",

--- a/enterprise/server/deployment/BUILD
+++ b/enterprise/server/deployment/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_docker//container:push.bzl", "container_push")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 container_push(
     name = "push_ci_runner",
     format = "Docker",
@@ -11,9 +13,6 @@ container_push(
     repository = "flame-public/buildbuddy-ci-runner",
     tag = "$(version)",
     tags = ["manual"],  # Don't include this target in wildcard patterns
-    visibility = [
-        "//enterprise:__subpackages__",
-    ],
 )
 
 container_push(
@@ -24,7 +23,4 @@ container_push(
     repository = "flame-public/buildbuddy-ci-runner",
     tag = "debug",
     tags = ["manual"],  # Don't include this target in wildcard patterns
-    visibility = [
-        "//enterprise:__subpackages__",
-    ],
 )

--- a/enterprise/server/deployment/BUILD
+++ b/enterprise/server/deployment/BUILD
@@ -13,7 +13,6 @@ container_push(
     tags = ["manual"],  # Don't include this target in wildcard patterns
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
 )
 
@@ -27,6 +26,5 @@ container_push(
     tags = ["manual"],  # Don't include this target in wildcard patterns
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
 )

--- a/enterprise/server/execution_service/BUILD
+++ b/enterprise/server/execution_service/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "execution_service",
     srcs = ["execution_service.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/execution_service",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:execution_stats_go_proto",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/hostedrunner/BUILD
+++ b/enterprise/server/hostedrunner/BUILD
@@ -1,11 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "hostedrunner",
     srcs = ["hostedrunner.go"],
     data = ["//enterprise/server/cmd/ci_runner:buildbuddy_ci_runner"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/hostedrunner",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/operation",
         "//enterprise/server/remote_execution/platform",

--- a/enterprise/server/image_converter/BUILD
+++ b/enterprise/server/image_converter/BUILD
@@ -2,11 +2,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "image_converter_lib",
     srcs = ["image_converter.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/image_converter",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/backends/redis_client",
         "//proto:registry_go_proto",
@@ -43,14 +44,12 @@ go_library(
 go_binary(
     name = "image_converter",
     embed = [":image_converter_lib"],
-    visibility = ["//visibility:public"],
 )
 
 container_image(
     name = "base_image",
     base = "@buildbuddy_go_image_base//image",
     tags = ["manual"],
-    visibility = ["//visibility:public"],
 )
 
 # Build a docker image similar to the go_binary above, but use the "go_image"
@@ -60,5 +59,4 @@ go_image(
     base = ":base_image",
     binary = ":image_converter",
     tags = ["manual"],
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/invocation_search_service/BUILD
+++ b/enterprise/server/invocation_search_service/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/invocation_search_service",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//proto:invocation_go_proto",

--- a/enterprise/server/invocation_stat_service/BUILD
+++ b/enterprise/server/invocation_stat_service/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/invocation_stat_service",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//proto:context_go_proto",

--- a/enterprise/server/quota/BUILD
+++ b/enterprise/server/quota/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "quota",
     srcs = ["quota_manager.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/quota",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/backends/pubsub",
         "//proto:quota_go_proto",

--- a/enterprise/server/raft/bringup/BUILD
+++ b/enterprise/server/raft/bringup/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "bringup",
     srcs = ["bringup.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/bringup",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/raft/client",
         "//enterprise/server/raft/config",

--- a/enterprise/server/raft/cache/BUILD
+++ b/enterprise/server/raft/cache/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "cache",
     srcs = ["cache.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/cache",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/raft/bringup",
         "//enterprise/server/raft/client",

--- a/enterprise/server/raft/client/BUILD
+++ b/enterprise/server/raft/client/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "client",
     srcs = ["client.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/client",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/raft/filestore",
         "//enterprise/server/raft/rbuilder",

--- a/enterprise/server/raft/config/BUILD
+++ b/enterprise/server/raft/config/BUILD
@@ -1,9 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "config",
     srcs = ["config.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/config",
-    visibility = ["//visibility:public"],
     deps = ["@com_github_lni_dragonboat_v3//config"],
 )

--- a/enterprise/server/raft/constants/BUILD
+++ b/enterprise/server/raft/constants/BUILD
@@ -1,9 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "constants",
     srcs = ["constants.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants",
-    visibility = ["//visibility:public"],
     deps = ["//enterprise/server/raft/keys"],
 )

--- a/enterprise/server/raft/driver/BUILD
+++ b/enterprise/server/raft/driver/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "driver",
     srcs = ["driver.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/driver",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/raft/constants",
         "//proto:raft_go_proto",

--- a/enterprise/server/raft/filestore/BUILD
+++ b/enterprise/server/raft/filestore/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "filestore",
     srcs = ["filestore.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/filestore",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:raft_go_proto",
         "//proto:resource_go_proto",

--- a/enterprise/server/raft/keys/BUILD
+++ b/enterprise/server/raft/keys/BUILD
@@ -1,8 +1,9 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "keys",
     srcs = ["keys.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys",
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/raft/listener/BUILD
+++ b/enterprise/server/raft/listener/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "listener",
     srcs = ["listener.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/listener",
-    visibility = ["//visibility:public"],
     deps = [
         "//server/util/log",
         "@com_github_lni_dragonboat_v3//raftio",

--- a/enterprise/server/raft/logger/BUILD
+++ b/enterprise/server/raft/logger/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "logger",
     srcs = ["logger.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/logger",
-    visibility = ["//visibility:public"],
     deps = [
         "//server/util/log",
         "@com_github_lni_dragonboat_v3//logger",

--- a/enterprise/server/raft/nodeliveness/BUILD
+++ b/enterprise/server/raft/nodeliveness/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "nodeliveness",
     srcs = ["nodeliveness.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/nodeliveness",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/raft/constants",
         "//enterprise/server/raft/keys",

--- a/enterprise/server/raft/rangecache/BUILD
+++ b/enterprise/server/raft/rangecache/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "rangecache",
     srcs = ["rangecache.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rangecache",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/raft/constants",
         "//proto:raft_go_proto",

--- a/enterprise/server/raft/rangelease/BUILD
+++ b/enterprise/server/raft/rangelease/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "rangelease",
     srcs = ["rangelease.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rangelease",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/raft/constants",
         "//enterprise/server/raft/nodeliveness",

--- a/enterprise/server/raft/rbuilder/BUILD
+++ b/enterprise/server/raft/rbuilder/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "rbuilder",
     srcs = ["rbuilder.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:raft_go_proto",
         "//server/util/status",

--- a/enterprise/server/raft/registry/BUILD
+++ b/enterprise/server/raft/registry/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "registry",
     srcs = ["registry.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/registry",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/raft/constants",
         "//proto:raft_go_proto",

--- a/enterprise/server/raft/replica/BUILD
+++ b/enterprise/server/raft/replica/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "replica",
     srcs = ["replica.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/replica",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/raft/constants",
         "//enterprise/server/raft/filestore",

--- a/enterprise/server/raft/sender/BUILD
+++ b/enterprise/server/raft/sender/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "sender",
     srcs = ["sender.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/raft/client",
         "//enterprise/server/raft/constants",

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "store",
     srcs = ["store.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/store",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/raft/bringup",
         "//enterprise/server/raft/client",

--- a/enterprise/server/registry/BUILD
+++ b/enterprise/server/registry/BUILD
@@ -2,11 +2,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "registry_lib",
     srcs = ["registry.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/registry",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:registry_go_proto",
         "//proto:remote_execution_go_proto",
@@ -37,7 +38,6 @@ container_image(
     name = "base_image",
     base = "@buildbuddy_go_image_base//image",
     tags = ["manual"],
-    visibility = ["//visibility:public"],
 )
 
 # Build a docker image similar to the go_binary above, but use the "go_image"
@@ -47,5 +47,4 @@ go_image(
     base = ":base_image",
     binary = ":registry",
     tags = ["manual"],
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/remote_execution/commandutil/BUILD
+++ b/enterprise/server/remote_execution/commandutil/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "commandutil",
     srcs = ["commandutil.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/util/procstats",

--- a/enterprise/server/remote_execution/commandutil/test_binary/BUILD
+++ b/enterprise/server/remote_execution/commandutil/test_binary/BUILD
@@ -2,7 +2,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 package(
     default_testonly = 1,
-    default_visibility = ["//visibility:public"],
+    default_visibility = ["//enterprise:__subpackages__"],
+
 )
 
 go_library(

--- a/enterprise/server/remote_execution/config/BUILD
+++ b/enterprise/server/remote_execution/config/BUILD
@@ -1,8 +1,9 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__", "//server/buildbuddy_server:__pkg__", "//server/telemetry:__pkg__", "//server/static:__pkg__"])
+
 go_library(
     name = "config",
     srcs = ["config.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/config",
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/remote_execution/container/BUILD
+++ b/enterprise/server/remote_execution/container/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "container",
     srcs = ["container.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/platform",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/remote_execution/containers/bare/BUILD
+++ b/enterprise/server/remote_execution/containers/bare/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "bare",
     srcs = ["bare.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/bare",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",

--- a/enterprise/server/remote_execution/containers/docker/BUILD
+++ b/enterprise/server/remote_execution/containers/docker/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "docker",
     srcs = ["docker.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/docker",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "firecracker",
     srcs = [
@@ -15,7 +17,6 @@ go_library(
         "//conditions:default": [],
     }),
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/firecracker",
-    visibility = ["//visibility:public"],
     deps = [
         "@com_github_docker_docker//client",
     ] + select({

--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "podman",
     srcs = ["podman.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/podman",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",

--- a/enterprise/server/remote_execution/containers/sandbox/BUILD
+++ b/enterprise/server/remote_execution/containers/sandbox/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "sandbox",
     srcs = ["sandbox.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/sandbox",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",

--- a/enterprise/server/remote_execution/dirtools/BUILD
+++ b/enterprise/server/remote_execution/dirtools/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "dirtools",
     srcs = ["dirtools.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/dirtools",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
         "//server/environment",

--- a/enterprise/server/remote_execution/execution_server/BUILD
+++ b/enterprise/server/remote_execution/execution_server/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "execution_server",
     srcs = ["execution_server.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/execution_server",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/backends/pubsub",
         "//enterprise/server/remote_execution/config",

--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "executor",
     srcs = ["executor.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/auth",
         "//enterprise/server/remote_execution/operation",

--- a/enterprise/server/remote_execution/filecache/BUILD
+++ b/enterprise/server/remote_execution/filecache/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "filecache",
     srcs = ["filecache.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
         "//server/interfaces",

--- a/enterprise/server/remote_execution/operation/BUILD
+++ b/enterprise/server/remote_execution/operation/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "operation",
     srcs = ["operation.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/operation",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
         "//server/remote_cache/digest",

--- a/enterprise/server/remote_execution/platform/BUILD
+++ b/enterprise/server/remote_execution/platform/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "platform",
     srcs = ["platform.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
         "//server/environment",

--- a/enterprise/server/remote_execution/redis_client/BUILD
+++ b/enterprise/server/remote_execution/redis_client/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "redis_client",
     srcs = ["redis_client.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/redis_client",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/backends/redis_client",
         "//enterprise/server/remote_execution/config",

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "runner",
     srcs = ["runner.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/runner",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/auth",
         "//enterprise/server/hostedrunner",

--- a/enterprise/server/remote_execution/runner/testworker/BUILD
+++ b/enterprise/server/remote_execution/runner/testworker/BUILD
@@ -6,7 +6,6 @@ go_library(
     name = "testworker_lib",
     srcs = ["testworker.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/runner/testworker",
-    visibility = ["//visibility:public"],
     deps = ["//server/util/log"],
 )
 

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "snaploader",
     srcs = ["snaploader.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaploader",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
         "//server/environment",

--- a/enterprise/server/remote_execution/vfs/BUILD
+++ b/enterprise/server/remote_execution/vfs/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "vfs",
     srcs = ["vfs.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/vfs",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:vfs_go_proto",
         "//server/util/log",

--- a/enterprise/server/remote_execution/vmexec_client/BUILD
+++ b/enterprise/server/remote_execution/vmexec_client/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "vmexec_client",
     srcs = ["vmexec_client.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/vmexec_client",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",

--- a/enterprise/server/remote_execution/workspace/BUILD
+++ b/enterprise/server/remote_execution/workspace/BUILD
@@ -1,11 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "workspace",
     srcs = ["workspace.go"],
     data = ["//enterprise/server/cmd/ci_runner:buildbuddy_ci_runner"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/workspace",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/dirtools",
         "//enterprise/server/remote_execution/vfs",

--- a/enterprise/server/saml/BUILD
+++ b/enterprise/server/saml/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/saml",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//enterprise/server/auth",

--- a/enterprise/server/scheduling/priority_queue/BUILD
+++ b/enterprise/server/scheduling/priority_queue/BUILD
@@ -1,9 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "priority_queue",
     srcs = ["priority_queue.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/priority_queue",
-    visibility = ["//visibility:public"],
     deps = ["//proto:scheduler_go_proto"],
 )

--- a/enterprise/server/scheduling/priority_task_scheduler/BUILD
+++ b/enterprise/server/scheduling/priority_task_scheduler/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "priority_task_scheduler",
     srcs = ["priority_task_scheduler.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/priority_task_scheduler",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/executor",
         "//enterprise/server/remote_execution/runner",

--- a/enterprise/server/scheduling/scheduler_client/BUILD
+++ b/enterprise/server/scheduling/scheduler_client/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "scheduler_client",
     srcs = ["scheduler_client.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/scheduler_client",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/auth",
         "//enterprise/server/scheduling/priority_task_scheduler",

--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "scheduler_server",
     srcs = ["scheduler_server.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/scheduler_server",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/config",
         "//enterprise/server/remote_execution/platform",

--- a/enterprise/server/scheduling/scheduler_server/config/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/config/BUILD
@@ -1,8 +1,9 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__", "//server/static:__pkg__"])
+
 go_library(
     name = "config",
     srcs = ["config.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/scheduler_server/config",
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/scheduling/task_leaser/BUILD
+++ b/enterprise/server/scheduling/task_leaser/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "task_leaser",
     srcs = ["task_leaser.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_leaser",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/auth",
         "//proto:scheduler_go_proto",

--- a/enterprise/server/scheduling/task_router/BUILD
+++ b/enterprise/server/scheduling/task_router/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "task_router",
     srcs = ["task_router.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_router",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/platform",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/secrets/BUILD
+++ b/enterprise/server/secrets/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "secrets",
     srcs = ["secrets.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/secrets",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/util/keystore",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/selfauth/BUILD
+++ b/enterprise/server/selfauth/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/selfauth",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//server/endpoint_urls/build_buddy_url",

--- a/enterprise/server/splash/BUILD
+++ b/enterprise/server/splash/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/splash",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//server/util/log",

--- a/enterprise/server/tasksize/BUILD
+++ b/enterprise/server/tasksize/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/tasksize",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//enterprise/server/remote_execution/platform",

--- a/enterprise/server/tasksize/BUILD
+++ b/enterprise/server/tasksize/BUILD
@@ -1,12 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "tasksize",
     srcs = ["tasksize.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/tasksize",
-    visibility = [
-        "//enterprise:__subpackages__",
-    ],
     deps = [
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/tasksize_model",

--- a/enterprise/server/tasksize_model/BUILD
+++ b/enterprise/server/tasksize_model/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/tasksize_model",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//enterprise/server/remote_execution/platform",

--- a/enterprise/server/tasksize_model/BUILD
+++ b/enterprise/server/tasksize_model/BUILD
@@ -1,12 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "tasksize_model",
     srcs = ["tasksize_model.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/tasksize_model",
-    visibility = [
-        "//enterprise:__subpackages__",
-    ],
     deps = [
         "//enterprise/server/remote_execution/platform",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/telemetry/BUILD
+++ b/enterprise/server/telemetry/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "telemetry",
     srcs = ["telemetry_server.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/telemetry",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:telemetry_go_proto",
         "//server/environment",

--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -15,7 +15,6 @@ go_test(
     shard_count = 11,
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//enterprise/server/testutil/testgit",

--- a/enterprise/server/test/integration/remote_execution/command/BUILD
+++ b/enterprise/server/test/integration/remote_execution/command/BUILD
@@ -1,16 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_binary(
     name = "testcommand",
     embed = [":command_lib"],
-    visibility = ["//visibility:public"],
 )
 
 go_library(
     name = "command_lib",
     srcs = ["testcommand.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/test/integration/remote_execution/command",
-    visibility = ["//visibility:private"],
     deps = [
         "//enterprise/server/test/integration/remote_execution/proto:remoteexecutiontest_go_proto",
         "//server/util/log",

--- a/enterprise/server/test/integration/remote_execution/rbeclient/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "rbeclient",
     srcs = ["rbeclient.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/test/integration/remote_execution/rbeclient",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/dirtools",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/test/integration/remote_execution/rbetest/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbetest/BUILD
@@ -1,11 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "rbetest",
     testonly = 1,
     srcs = ["rbetest.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/test/integration/remote_execution/rbetest",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise:bundle",
         "//enterprise/server/remote_execution/execution_server",

--- a/enterprise/server/test/integration/task_router/BUILD
+++ b/enterprise/server/test/integration/task_router/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_test(
     name = "task_router_test",
     size = "small",
     srcs = ["task_router_test.go"],
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/scheduling/task_router",
         "//enterprise/server/testutil/enterprise_testenv",

--- a/enterprise/server/testutil/buildbuddy_enterprise/BUILD
+++ b/enterprise/server/testutil/buildbuddy_enterprise/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "buildbuddy_enterprise",
     testonly = 1,
@@ -9,7 +11,6 @@ go_library(
         "//enterprise/server/cmd/server:buildbuddy",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/buildbuddy_enterprise",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/testutil/testredis",
         "//proto:context_go_proto",

--- a/enterprise/server/testutil/enterprise_testenv/BUILD
+++ b/enterprise/server/testutil/enterprise_testenv/BUILD
@@ -1,11 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "enterprise_testenv",
     testonly = 1,
     srcs = ["enterprise_testenv.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/backends/authdb",
         "//enterprise/server/backends/redis_cache",

--- a/enterprise/server/testutil/testcontext/BUILD
+++ b/enterprise/server/testutil/testcontext/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "testcontext",
     srcs = ["test_context.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testcontext",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
         "//server/util/bazel_request",

--- a/enterprise/server/testutil/testexecutor/BUILD
+++ b/enterprise/server/testutil/testexecutor/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "testexecutor",
     srcs = ["testexecutor.go"],
@@ -7,7 +9,6 @@ go_library(
         "//enterprise/server/cmd/executor",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testexecutor",
-    visibility = ["//visibility:public"],
     deps = [
         "//server/testutil/testport",
         "//server/testutil/testserver",

--- a/enterprise/server/testutil/testgit/BUILD
+++ b/enterprise/server/testutil/testgit/BUILD
@@ -1,11 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "testgit",
     testonly = 1,
     srcs = ["testgit.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testgit",
-    visibility = ["//visibility:public"],
     deps = [
         "//server/interfaces",
         "//server/testutil/testfs",

--- a/enterprise/server/testutil/testredis/BUILD
+++ b/enterprise/server/testutil/testredis/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "testredis",
     testonly = 1,
@@ -9,7 +11,6 @@ go_library(
         "//enterprise/server/test/bin/redis:redis-server-linux-x86_64",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/util/redisutil",
         "//server/testutil/testfs",

--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "usage",
     srcs = ["usage.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/usage",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/usage/config",
         "//enterprise/server/util/redisutil",

--- a/enterprise/server/usage/config/BUILD
+++ b/enterprise/server/usage/config/BUILD
@@ -1,8 +1,9 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "config",
     srcs = ["config.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/usage/config",
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/usage_service/BUILD
+++ b/enterprise/server/usage_service/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "usage_service",
     srcs = ["usage_service.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/usage_service",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/usage/config",
         "//proto:usage_go_proto",

--- a/enterprise/server/util/cacheproxy/BUILD
+++ b/enterprise/server/util/cacheproxy/BUILD
@@ -1,12 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "cacheproxy",
     srcs = ["cacheproxy.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/cacheproxy",
-    visibility = [
-        "//enterprise:__subpackages__",
-    ],
     deps = [
         "//proto:distributed_cache_go_proto",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/util/cacheproxy/BUILD
+++ b/enterprise/server/util/cacheproxy/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/cacheproxy",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//proto:distributed_cache_go_proto",

--- a/enterprise/server/util/container/BUILD
+++ b/enterprise/server/util/container/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "container",
     srcs = ["container.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/container",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/containers/docker",

--- a/enterprise/server/util/ext4/BUILD
+++ b/enterprise/server/util/ext4/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "ext4",
     srcs = ["ext4.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ext4",
-    visibility = ["//visibility:public"],
     deps = [
         "//server/util/log",
         "//server/util/status",

--- a/enterprise/server/util/fieldgetter/BUILD
+++ b/enterprise/server/util/fieldgetter/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/fieldgetter",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
 )
 

--- a/enterprise/server/util/fieldgetter/BUILD
+++ b/enterprise/server/util/fieldgetter/BUILD
@@ -1,12 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "fieldgetter",
     srcs = ["fieldgetter.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/fieldgetter",
-    visibility = [
-        "//enterprise:__subpackages__",
-    ],
 )
 
 go_test(

--- a/enterprise/server/util/heartbeat/BUILD
+++ b/enterprise/server/util/heartbeat/BUILD
@@ -1,12 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "heartbeat",
     srcs = ["heartbeat.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/heartbeat",
-    visibility = [
-        "//enterprise:__subpackages__",
-    ],
     deps = [
         "//server/interfaces",
         "//server/util/log",

--- a/enterprise/server/util/heartbeat/BUILD
+++ b/enterprise/server/util/heartbeat/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/heartbeat",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//server/interfaces",

--- a/enterprise/server/util/keystore/BUILD
+++ b/enterprise/server/util/keystore/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "keystore",
     srcs = ["keystore.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/keystore",
-    visibility = ["//visibility:public"],
     deps = [
         "//server/environment",
         "//server/util/status",

--- a/enterprise/server/util/pebbleutil/BUILD
+++ b/enterprise/server/util/pebbleutil/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "pebbleutil",
     srcs = ["pebbleutil.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/pebbleutil",
-    visibility = ["//visibility:public"],
     deps = [
         "//server/interfaces",
         "//server/util/log",

--- a/enterprise/server/util/procstats/BUILD
+++ b/enterprise/server/util/procstats/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "procstats",
     srcs = ["procstats.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/procstats",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
         "@com_github_mitchellh_go_ps//:go-ps",

--- a/enterprise/server/util/rbeutil/BUILD
+++ b/enterprise/server/util/rbeutil/BUILD
@@ -1,8 +1,9 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "rbeutil",
     srcs = ["rbeutil.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/rbeutil",
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/util/redisutil/BUILD
+++ b/enterprise/server/util/redisutil/BUILD
@@ -1,12 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "redisutil",
     srcs = ["redisutil.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redisutil",
-    visibility = [
-        "//enterprise:__subpackages__",
-    ],
     deps = [
         "//server/interfaces",
         "//server/util/log",
@@ -22,9 +21,6 @@ go_test(
     name = "redisutil_test",
     size = "small",
     srcs = ["redisutil_test.go"],
-    visibility = [
-        "//enterprise:__subpackages__",
-    ],
     deps = [
         ":redisutil",
         "//enterprise/server/testutil/testredis",

--- a/enterprise/server/util/redisutil/BUILD
+++ b/enterprise/server/util/redisutil/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redisutil",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//server/interfaces",
@@ -25,7 +24,6 @@ go_test(
     srcs = ["redisutil_test.go"],
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         ":redisutil",

--- a/enterprise/server/util/vfs_server/BUILD
+++ b/enterprise/server/util/vfs_server/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "vfs_server",
     srcs = [
@@ -8,7 +10,6 @@ go_library(
         "vfs_server_linux.go",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/vfs_server",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/dirtools",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/util/vsock/BUILD
+++ b/enterprise/server/util/vsock/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "vsock",
     srcs = ["vsock.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/vsock",
-    visibility = ["//visibility:public"],
     deps = [
         "//server/util/log",
         "//server/util/status",

--- a/enterprise/server/vmexec/BUILD
+++ b/enterprise/server/vmexec/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "vmexec",
     srcs = ["vmexec.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/vmexec",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/remote_execution/commandutil",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/vmvfs/BUILD
+++ b/enterprise/server/vmvfs/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "vmvfs_lib",
     srcs = ["vmvfs.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/vmvfs",
-    visibility = ["//visibility:private"],
     deps = [
         "//enterprise/server/remote_execution/vfs",
         "//enterprise/server/util/vsock",
@@ -22,5 +23,4 @@ go_binary(
     embed = [":vmvfs_lib"],
     pure = "on",
     static = "on",
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/webhooks/bitbucket/BUILD
+++ b/enterprise/server/webhooks/bitbucket/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/bitbucket",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//enterprise/server/util/fieldgetter",

--- a/enterprise/server/webhooks/github/BUILD
+++ b/enterprise/server/webhooks/github/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/github",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//enterprise/server/util/fieldgetter",
@@ -25,7 +24,6 @@ go_test(
     srcs = ["github_test.go"],
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         ":github",

--- a/enterprise/server/webhooks/webhook_data/BUILD
+++ b/enterprise/server/webhooks/webhook_data/BUILD
@@ -6,6 +6,5 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/webhook_data",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
 )

--- a/enterprise/server/workflow/config/BUILD
+++ b/enterprise/server/workflow/config/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/config",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//enterprise/server/webhooks/webhook_data",

--- a/enterprise/server/workflow/service/BUILD
+++ b/enterprise/server/workflow/service/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/service",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//enterprise/server/remote_execution/config",

--- a/enterprise/tools/cpio/BUILD
+++ b/enterprise/tools/cpio/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(
     name = "cpio_lib",

--- a/enterprise/tools/tensorflow/BUILD.lib.bzl
+++ b/enterprise/tools/tensorflow/BUILD.lib.bzl
@@ -1,4 +1,4 @@
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 cc_library(
     name = "libtensorflow",

--- a/enterprise/tools/tensorflow/deps.bzl
+++ b/enterprise/tools/tensorflow/deps.bzl
@@ -7,5 +7,5 @@ def tensorflow_cgo_deps():
         urls = [
             "https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-${TENSORFLOW_VERSION}.tar.gz",
         ],
-        build_file_content = "filegroup(name = \"libtensorflow\", srcs = glob([\"lib/*\"]), visibility = [\"//visibility:public\"])",
+        build_file_content = "filegroup(name = \"libtensorflow\", srcs = glob([\"lib/*\"]), visibility = [\"//enterprise:__subpackages__\"])",
     )

--- a/enterprise/vmsupport/bin/BUILD
+++ b/enterprise/vmsupport/bin/BUILD
@@ -1,3 +1,5 @@
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 exports_files([
     "vmlinux",
 ])
@@ -21,5 +23,4 @@ genrule(
         "mkinitrd.sh",
         "//enterprise/tools/cpio",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/server/resources/BUILD
+++ b/server/resources/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/resources",
     visibility = [
         "//enterprise:__subpackages__",
-        "@buildbuddy_internal//enterprise:__subpackages__",
     ],
     deps = [
         "//server/util/flagutil",


### PR DESCRIPTION
This PR removes the unnecessary @buildbuddy_internal//enterprise:__subpackages__ visibility and restricts the visibility of most packages in //enterprise to //enterprise:__subpackages. There are a few that are referenced outside of //enterprise, so I just made exceptions for those and we can clean 'em up later if necessary, but at least they're easier to find now.

---

**Version bump**: Patch