### PR TITLE
Fix visibility of //enterprise/.../vfs stuff to fix buildbuddy-internal

### DIFF
--- a/enterprise/server/remote_execution/vfs/BUILD
+++ b/enterprise/server/remote_execution/vfs/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-package(default_visibility = ["//enterprise:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 go_library(
     name = "vfs",

--- a/enterprise/server/util/vfs_server/BUILD
+++ b/enterprise/server/util/vfs_server/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-package(default_visibility = ["//enterprise:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 go_library(
     name = "vfs_server",


### PR DESCRIPTION
//tools/mountv_vfs:mount_vfs_lib in there depends on some of the vfs stuff in //enterprise, so that needs to be public for the dependency to work.

---

**Version bump**: Patch