### PR TITLE
Stop reading deprecated cache type field from cache scorecards

### DIFF
--- a/app/invocation/cache_requests_card.tsx
+++ b/app/invocation/cache_requests_card.tsx
@@ -349,8 +349,8 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
             )}
           </div>
         )}
-        <div className="cache-type-column" title={cacheTypeTitle(getCacheType(result))}>
-          {renderCacheType(getCacheType(result))}
+        <div className="cache-type-column" title={cacheTypeTitle(result.cacheType)}>
+          {renderCacheType(result.cacheType)}
         </div>
         <div className="status-column column-with-icon">{renderStatus(result)}</div>
         <div>
@@ -376,7 +376,6 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
   private getCacheMetadata(scorecardResult: cache.ScoreCard.IResult) {
     const digest = scorecardResult.digest;
     const remoteInstanceName = this.props.model.getRemoteInstanceName();
-    const cacheType = toResourceCacheType(scorecardResult.cacheTypeDeprecated);
 
     // Set an empty struct in the map so the FE doesn't fire duplicate requests while the first request is in progress
     // or if there is an invalid result
@@ -386,7 +385,7 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
       .getCacheMetadata({
         resourceName: {
           digest: digest,
-          cacheType: cacheType,
+          cacheType: scorecardResult.cacheType,
           instanceName: remoteInstanceName,
         },
       })
@@ -627,7 +626,6 @@ function renderCompressionSavings(result: cache.ScoreCard.IResult) {
 }
 
 function renderStatus(result: cache.ScoreCard.IResult): React.ReactNode {
-  const cacheType = getCacheType(result);
   if (result.requestType === cache.RequestType.READ) {
     if (result.status.code !== 0 /*=OK*/) {
       return (
@@ -640,7 +638,7 @@ function renderStatus(result: cache.ScoreCard.IResult): React.ReactNode {
     }
     return (
       <>
-        {cacheType === resource.CacheType.AC ? <Check className="icon green" /> : <ArrowDown className="icon green" />}
+        {result.cacheType === resource.CacheType.AC ? <Check className="icon green" /> : <ArrowDown className="icon green" />}
         <span>Hit</span>
       </>
     );

--- a/app/invocation/cache_requests_card.tsx
+++ b/app/invocation/cache_requests_card.tsx
@@ -638,7 +638,11 @@ function renderStatus(result: cache.ScoreCard.IResult): React.ReactNode {
     }
     return (
       <>
-        {result.cacheType === resource.CacheType.AC ? <Check className="icon green" /> : <ArrowDown className="icon green" />}
+        {result.cacheType === resource.CacheType.AC ? (
+          <Check className="icon green" />
+        ) : (
+          <ArrowDown className="icon green" />
+        )}
         <span>Hit</span>
       </>
     );

--- a/app/invocation/cache_requests_card.tsx
+++ b/app/invocation/cache_requests_card.tsx
@@ -711,27 +711,6 @@ function looksLikeDigest(actionId: string) {
   return actionId.length === 64;
 }
 
-function getCacheType(result: cache.ScoreCard.IResult): resource.CacheType {
-  const cacheType = result.cacheType;
-  // If the cacheType field is not set, try reading data from the older cacheTypeDeprecated field
-  // for scorecard results that were written before we added the new cacheType field
-  if (!cacheType) {
-    return toResourceCacheType(result.cacheTypeDeprecated);
-  }
-  return cacheType;
-}
-
-function toResourceCacheType(cacheType: cache.CacheType): resource.CacheType {
-  switch (cacheType) {
-    case cache.CacheType.CAS:
-      return resource.CacheType.CAS;
-    case cache.CacheType.AC:
-      return resource.CacheType.AC;
-    default:
-      return resource.CacheType.UNKNOWN_CACHE_TYPE;
-  }
-}
-
 function toCacheProtoCacheType(cacheType: resource.CacheType): cache.CacheType {
   switch (cacheType) {
     case resource.CacheType.CAS:

--- a/server/remote_cache/scorecard/scorecard.go
+++ b/server/remote_cache/scorecard/scorecard.go
@@ -106,20 +106,8 @@ func filterResults(results []*capb.ScoreCard_Result, req *capb.GetCacheScoreCard
 		switch path {
 		case "cache_type":
 			predicates = append(predicates, func(result *capb.ScoreCard_Result) bool {
-				// If the cacheType fields are not set, try reading data from the older cacheTypeDeprecated field
-				// for requests that were made before we added the new cacheType field
 				filterCacheType := req.GetFilter().GetCacheType()
-				if filterCacheType == resource.CacheType_UNKNOWN_CACHE_TYPE {
-					deprecatedCacheType := req.GetFilter().GetCacheTypeDeprecated()
-					filterCacheType = toResourceCacheType(deprecatedCacheType)
-				}
-
 				resultCacheType := result.GetCacheType()
-				if resultCacheType == resource.CacheType_UNKNOWN_CACHE_TYPE {
-					deprecatedCacheType := result.GetCacheTypeDeprecated()
-					resultCacheType = toResourceCacheType(deprecatedCacheType)
-				}
-
 				return resultCacheType == filterCacheType
 			})
 		case "request_type":


### PR DESCRIPTION
buildbuddy-io/buildbuddy-internal#1733

Note: After this change, old cache scorecards won’t show on the UI

For scorecards created over 15 days ago - when we merged the change to write the new cacheType field - that cacheType field will be 0 UNKNOWN_CACHE_TYPE. All these scorecard results will be filtered out [here](https://github.com/buildbuddy-io/buildbuddy/blob/master/server/remote_cache/scorecard/scorecard.go#L108).