### PR TITLE
Cleanup cache ContainsDeprecated method

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -584,15 +584,6 @@ func (c *Cache) Contains(ctx context.Context, r *resource.ResourceName) (bool, e
 	return false, nil
 }
 
-func (c *Cache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
-	return c.Contains(ctx, &resource.ResourceName{
-		Digest:       d,
-		InstanceName: c.isolation.GetRemoteInstanceName(),
-		Compressor:   repb.Compressor_IDENTITY,
-		CacheType:    c.isolation.GetCacheType(),
-	})
-}
-
 func (c *Cache) Metadata(ctx context.Context, r *resource.ResourceName) (*interfaces.CacheMetadata, error) {
 	d := r.GetDigest()
 	isolation := &dcpb.Isolation{

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -234,40 +234,20 @@ func TestContains_NotWritten(t *testing.T) {
 
 	// Data is not written - no nodes should contain it
 	d, _ := testdigest.NewRandomDigestBuf(t, 100)
+	r := &resource.ResourceName{
+		Digest:    d,
+		CacheType: resource.CacheType_CAS,
+	}
 
-	c, err := dc1.ContainsDeprecated(ctx, d)
-	require.NoError(t, err)
-	require.False(t, c)
-	c, err = dc1.Contains(ctx, &resource.ResourceName{
-		Digest:       d,
-		InstanceName: "",
-		Compressor:   repb.Compressor_IDENTITY,
-		CacheType:    resource.CacheType_CAS,
-	})
+	c, err := dc1.Contains(ctx, r)
 	require.NoError(t, err)
 	require.False(t, c)
 
-	c, err = dc2.ContainsDeprecated(ctx, d)
-	require.NoError(t, err)
-	require.False(t, c)
-	c, err = dc2.Contains(ctx, &resource.ResourceName{
-		Digest:       d,
-		InstanceName: "",
-		Compressor:   repb.Compressor_IDENTITY,
-		CacheType:    resource.CacheType_CAS,
-	})
+	c, err = dc2.Contains(ctx, r)
 	require.NoError(t, err)
 	require.False(t, c)
 
-	c, err = dc3.ContainsDeprecated(ctx, d)
-	require.NoError(t, err)
-	require.False(t, c)
-	c, err = dc3.Contains(ctx, &resource.ResourceName{
-		Digest:       d,
-		InstanceName: "",
-		Compressor:   repb.Compressor_IDENTITY,
-		CacheType:    resource.CacheType_CAS,
-	})
+	c, err = dc3.Contains(ctx, r)
 	require.NoError(t, err)
 	require.False(t, c)
 }

--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -396,15 +396,6 @@ func (g *GCSCache) Contains(ctx context.Context, r *resource.ResourceName) (bool
 	return false, nil
 }
 
-func (g *GCSCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
-	return g.Contains(ctx, &resource.ResourceName{
-		Digest:       d,
-		InstanceName: g.remoteInstanceName,
-		Compressor:   repb.Compressor_IDENTITY,
-		CacheType:    g.cacheType,
-	})
-}
-
 // TODO(buildbuddy-internal#1485) - Add last access time
 func (g *GCSCache) Metadata(ctx context.Context, r *resource.ResourceName) (*interfaces.CacheMetadata, error) {
 	metadata, err := g.metadata(ctx, r)

--- a/enterprise/server/backends/memcache/memcache.go
+++ b/enterprise/server/backends/memcache/memcache.go
@@ -133,15 +133,6 @@ func (c *Cache) Contains(ctx context.Context, r *resource.ResourceName) (bool, e
 	return false, err
 }
 
-func (c *Cache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
-	return c.Contains(ctx, &resource.ResourceName{
-		Digest:       d,
-		InstanceName: c.remoteInstanceName,
-		Compressor:   repb.Compressor_IDENTITY,
-		CacheType:    c.cacheType,
-	})
-}
-
 // TODO(buildbuddy-internal#1485) - Add last access and modify time
 func (c *Cache) Metadata(ctx context.Context, r *resource.ResourceName) (*interfaces.CacheMetadata, error) {
 	key, err := c.key(ctx, r)

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -222,15 +222,6 @@ func (mc *MigrationCache) Contains(ctx context.Context, r *resource.ResourceName
 	return srcContains, srcErr
 }
 
-func (mc *MigrationCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
-	return mc.Contains(ctx, &resource.ResourceName{
-		Digest:       d,
-		InstanceName: mc.remoteInstanceName,
-		Compressor:   repb.Compressor_IDENTITY,
-		CacheType:    mc.cacheType,
-	})
-}
-
 func (mc *MigrationCache) Metadata(ctx context.Context, r *resource.ResourceName) (*interfaces.CacheMetadata, error) {
 	eg, gctx := errgroup.WithContext(ctx)
 	var srcErr, dstErr error

--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -892,7 +892,7 @@ func TestContains_DestErr(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should return data from src cache without error
-	contains, err := mc.ContainsDeprecated(ctx, d)
+	contains, err := mc.Contains(ctx, r)
 	require.NoError(t, err)
 	require.True(t, contains)
 }

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -860,15 +860,6 @@ func (p *PebbleCache) Contains(ctx context.Context, r *resource.ResourceName) (b
 	return found, nil
 }
 
-func (p *PebbleCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
-	return p.Contains(ctx, &resource.ResourceName{
-		Digest:       d,
-		InstanceName: p.isolation.GetRemoteInstanceName(),
-		Compressor:   repb.Compressor_IDENTITY,
-		CacheType:    p.isolation.GetCacheType(),
-	})
-}
-
 func (p *PebbleCache) Metadata(ctx context.Context, r *resource.ResourceName) (*interfaces.CacheMetadata, error) {
 	db, err := p.leaser.DB()
 	if err != nil {

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -1183,14 +1183,14 @@ func BenchmarkContains1(b *testing.B) {
 	pc.Start()
 	defer pc.Stop()
 
-	digestKeys := make([]*repb.Digest, 0, 100000)
+	digestKeys := make([]*resource.ResourceName, 0, 100000)
 	for i := 0; i < 100; i++ {
 		d, buf := testdigest.NewRandomDigestBuf(b, 1000)
 		r := &resource.ResourceName{
 			Digest:    d,
 			CacheType: resource.CacheType_CAS,
 		}
-		digestKeys = append(digestKeys, d)
+		digestKeys = append(digestKeys, r)
 		if err := pc.Set(ctx, r, buf); err != nil {
 			b.Fatalf("Error setting %q in cache: %s", d.GetHash(), err.Error())
 		}
@@ -1200,7 +1200,7 @@ func BenchmarkContains1(b *testing.B) {
 	b.StopTimer()
 	for n := 0; n < b.N; n++ {
 		b.StartTimer()
-		found, err := pc.ContainsDeprecated(ctx, digestKeys[rand.Intn(len(digestKeys))])
+		found, err := pc.Contains(ctx, digestKeys[rand.Intn(len(digestKeys))])
 		b.StopTimer()
 		if err != nil {
 			b.Fatal(err)

--- a/enterprise/server/backends/redis_cache/redis_cache.go
+++ b/enterprise/server/backends/redis_cache/redis_cache.go
@@ -151,15 +151,6 @@ func (c *Cache) WithIsolation(ctx context.Context, cacheType resource.CacheType,
 	}, nil
 }
 
-func (c *Cache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
-	return c.Contains(ctx, &resource.ResourceName{
-		Digest:       d,
-		InstanceName: c.remoteInstanceName,
-		Compressor:   repb.Compressor_IDENTITY,
-		CacheType:    c.cacheType,
-	})
-}
-
 func (c *Cache) Contains(ctx context.Context, r *resource.ResourceName) (bool, error) {
 	key, err := c.key(ctx, r)
 	if err != nil {

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -452,15 +452,6 @@ func (s3c *S3Cache) Contains(ctx context.Context, r *resource.ResourceName) (boo
 	return false, err
 }
 
-func (s3c *S3Cache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
-	return s3c.Contains(ctx, &resource.ResourceName{
-		Digest:       d,
-		InstanceName: s3c.remoteInstanceName,
-		Compressor:   repb.Compressor_IDENTITY,
-		CacheType:    s3c.cacheType,
-	})
-}
-
 // TODO(buildbuddy-internal#1485) - Add last access time
 func (s3c *S3Cache) Metadata(ctx context.Context, r *resource.ResourceName) (*interfaces.CacheMetadata, error) {
 	metadata, err := s3c.metadata(ctx, r)

--- a/enterprise/server/composable_cache/composable_cache.go
+++ b/enterprise/server/composable_cache/composable_cache.go
@@ -58,15 +58,6 @@ func (c *ComposableCache) Contains(ctx context.Context, r *resource.ResourceName
 	return c.inner.Contains(ctx, r)
 }
 
-func (c *ComposableCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
-	outerExists, err := c.outer.ContainsDeprecated(ctx, d)
-	if err == nil && outerExists {
-		return outerExists, nil
-	}
-
-	return c.inner.ContainsDeprecated(ctx, d)
-}
-
 func (c *ComposableCache) Metadata(ctx context.Context, r *resource.ResourceName) (*interfaces.CacheMetadata, error) {
 	md, err := c.outer.Metadata(ctx, r)
 	if err == nil {

--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -482,15 +482,6 @@ func (rc *RaftCache) Contains(ctx context.Context, r *resource.ResourceName) (bo
 	return len(missing) == 0, nil
 }
 
-func (rc *RaftCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
-	return rc.Contains(ctx, &resource.ResourceName{
-		Digest:       d,
-		InstanceName: rc.isolation.GetRemoteInstanceName(),
-		Compressor:   repb.Compressor_IDENTITY,
-		CacheType:    rc.isolation.GetCacheType(),
-	})
-}
-
 func (rc *RaftCache) Metadata(ctx context.Context, r *resource.ResourceName) (*interfaces.CacheMetadata, error) {
 	return nil, status.UnimplementedError("not implemented")
 }

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -308,15 +308,6 @@ func (c *DiskCache) Contains(ctx context.Context, r *resource.ResourceName) (boo
 	return contains, err
 }
 
-func (c *DiskCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
-	return c.Contains(ctx, &resource.ResourceName{
-		Digest:       d,
-		InstanceName: c.remoteInstanceName,
-		Compressor:   repb.Compressor_IDENTITY,
-		CacheType:    c.cacheType,
-	})
-}
-
 func (c *DiskCache) Metadata(ctx context.Context, r *resource.ResourceName) (*interfaces.CacheMetadata, error) {
 	p, err := c.getPartition(ctx, r.GetInstanceName())
 	if err != nil {

--- a/server/backends/memory_cache/memory_cache.go
+++ b/server/backends/memory_cache/memory_cache.go
@@ -111,15 +111,6 @@ func (m *MemoryCache) Contains(ctx context.Context, r *resource.ResourceName) (b
 	return contains, nil
 }
 
-func (m *MemoryCache) ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error) {
-	return m.Contains(ctx, &resource.ResourceName{
-		Digest:       d,
-		InstanceName: m.remoteInstanceName,
-		Compressor:   repb.Compressor_IDENTITY,
-		CacheType:    m.cacheType,
-	})
-}
-
 // TODO(buildbuddy-internal#1485) - Add last access and modify time
 func (m *MemoryCache) Metadata(ctx context.Context, r *resource.ResourceName) (*interfaces.CacheMetadata, error) {
 	d := r.GetDigest()

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -219,7 +219,6 @@ type Cache interface {
 	WithIsolation(ctx context.Context, cacheType resource.CacheType, remoteInstanceName string) (Cache, error)
 
 	// [Deprecated] Normal cache-like operations that act in conjunction with WithIsolation
-	ContainsDeprecated(ctx context.Context, d *repb.Digest) (bool, error)
 	FindMissingDeprecated(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error)
 	GetMultiDeprecated(ctx context.Context, digests []*repb.Digest) (map[*repb.Digest][]byte, error)
 	SetMultiDeprecated(ctx context.Context, kvs map[*repb.Digest][]byte) error


### PR DESCRIPTION
See #2389 for more info

In cleaning up the WithIsolation method, I created duplicates of every cache method that take resource name objects instead of digests. Now I am cleaning up the deprecated old versions of the methods that take digests, and switching clients to use the new methods