### PR TITLE
Clean up cache FindMissingDeprecated method

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -740,11 +740,6 @@ func getIsolation(resources []*resource.ResourceName) *dcpb.Isolation {
 	}
 }
 
-func (c *Cache) FindMissingDeprecated(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error) {
-	rns := digest.ResourceNames(c.isolation.GetCacheType(), c.isolation.GetRemoteInstanceName(), digests)
-	return c.FindMissing(ctx, rns)
-}
-
 // The first reader with a non-empty value will be returned. If all potential
 // peers for the digest are exhausted, then return a NotFoundError.
 //

--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -442,11 +442,6 @@ func (g *GCSCache) FindMissing(ctx context.Context, resources []*resource.Resour
 	return missing, nil
 }
 
-func (g *GCSCache) FindMissingDeprecated(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error) {
-	rns := digest.ResourceNames(g.cacheType, g.remoteInstanceName, digests)
-	return g.FindMissing(ctx, rns)
-}
-
 func (g *GCSCache) Reader(ctx context.Context, r *resource.ResourceName, offset, limit int64) (io.ReadCloser, error) {
 	k, err := g.key(ctx, r)
 	if err != nil {

--- a/enterprise/server/backends/memcache/memcache.go
+++ b/enterprise/server/backends/memcache/memcache.go
@@ -181,11 +181,6 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*resource.ResourceN
 	return missing, nil
 }
 
-func (c *Cache) FindMissingDeprecated(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error) {
-	rns := digest.ResourceNames(c.cacheType, c.remoteInstanceName, digests)
-	return c.FindMissing(ctx, rns)
-}
-
 func (c *Cache) Get(ctx context.Context, r *resource.ResourceName) ([]byte, error) {
 	d := r.GetDigest()
 	if !eligibleForMc(d) {

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -315,11 +315,6 @@ func (mc *MigrationCache) FindMissing(ctx context.Context, resources []*resource
 	return srcMissing, srcErr
 }
 
-func (mc *MigrationCache) FindMissingDeprecated(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error) {
-	rns := digest.ResourceNames(mc.cacheType, mc.remoteInstanceName, digests)
-	return mc.FindMissing(ctx, rns)
-}
-
 func (mc *MigrationCache) GetMulti(ctx context.Context, resources []*resource.ResourceName) (map[*repb.Digest][]byte, error) {
 	eg, gctx := errgroup.WithContext(ctx)
 	var srcErr, dstErr error

--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -93,10 +93,6 @@ func (c *errorCache) Metadata(ctx context.Context, r *resource.ResourceName) (*i
 	return nil, errors.New("error cache metadata err")
 }
 
-func (c *errorCache) FindMissingDeprecated(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error) {
-	return nil, errors.New("error cache findmissing err")
-}
-
 func (c *errorCache) Writer(ctx context.Context, r *resource.ResourceName) (interfaces.CommittedWriteCloser, error) {
 	return nil, errors.New("error cache writer err")
 }
@@ -981,20 +977,12 @@ func TestFindMissing(t *testing.T) {
 	require.NoError(t, err)
 
 	digests := []*repb.Digest{d, notSetD1, notSetD2}
-	missing, err := mc.FindMissingDeprecated(ctx, digests)
-	require.NoError(t, err)
-	require.ElementsMatch(t, []*repb.Digest{notSetD1, notSetD2}, missing)
-
 	rns := digest.ResourceNames(resource.CacheType_CAS, "", digests)
-	missing, err = mc.FindMissing(ctx, rns)
+	missing, err := mc.FindMissing(ctx, rns)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []*repb.Digest{notSetD1, notSetD2}, missing)
 
 	digests = []*repb.Digest{d}
-	missing, err = mc.FindMissingDeprecated(ctx, digests)
-	require.NoError(t, err)
-	require.Empty(t, missing)
-
 	rns = digest.ResourceNames(resource.CacheType_CAS, "", digests)
 	missing, err = mc.FindMissing(ctx, rns)
 	require.NoError(t, err)
@@ -1069,7 +1057,8 @@ func TestFindMissing_DestErr(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should return data from src cache without error
-	missing, err := mc.FindMissingDeprecated(ctx, []*repb.Digest{d, notSetD1, notSetD2})
+	rns := digest.ResourceNames(resource.CacheType_CAS, "", []*repb.Digest{d, notSetD1, notSetD2})
+	missing, err := mc.FindMissing(ctx, rns)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []*repb.Digest{notSetD1, notSetD2}, missing)
 }

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -920,11 +920,6 @@ func (p *PebbleCache) FindMissing(ctx context.Context, resources []*resource.Res
 	return missing, nil
 }
 
-func (p *PebbleCache) FindMissingDeprecated(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error) {
-	rns := digest.ResourceNames(p.isolation.GetCacheType(), p.isolation.GetRemoteInstanceName(), digests)
-	return p.FindMissing(ctx, rns)
-}
-
 func (p *PebbleCache) Get(ctx context.Context, r *resource.ResourceName) ([]byte, error) {
 	rc, err := p.Reader(ctx, r, 0, 0)
 	if err != nil {

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -1130,21 +1130,21 @@ func BenchmarkFindMissing(b *testing.B) {
 	pc.Start()
 	defer pc.Stop()
 
-	digestKeys := make([]*repb.Digest, 0, 100000)
+	digestKeys := make([]*resource.ResourceName, 0, 100000)
 	for i := 0; i < 100; i++ {
 		d, buf := testdigest.NewRandomDigestBuf(b, 1000)
 		r := &resource.ResourceName{
 			Digest:    d,
 			CacheType: resource.CacheType_CAS,
 		}
-		digestKeys = append(digestKeys, d)
+		digestKeys = append(digestKeys, r)
 		if err := pc.Set(ctx, r, buf); err != nil {
 			b.Fatalf("Error setting %q in cache: %s", d.GetHash(), err.Error())
 		}
 	}
 
-	randomDigests := func(n int) []*repb.Digest {
-		r := make([]*repb.Digest, 0, n)
+	randomDigests := func(n int) []*resource.ResourceName {
+		r := make([]*resource.ResourceName, 0, n)
 		offset := rand.Intn(len(digestKeys))
 		for i := 0; i < n; i++ {
 			r = append(r, digestKeys[(i+offset)%len(digestKeys)])
@@ -1158,7 +1158,7 @@ func BenchmarkFindMissing(b *testing.B) {
 		keys := randomDigests(100)
 
 		b.StartTimer()
-		missing, err := pc.FindMissingDeprecated(ctx, keys)
+		missing, err := pc.FindMissing(ctx, keys)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/enterprise/server/backends/redis_cache/redis_cache.go
+++ b/enterprise/server/backends/redis_cache/redis_cache.go
@@ -220,11 +220,6 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*resource.ResourceN
 	return missing, nil
 }
 
-func (c *Cache) FindMissingDeprecated(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error) {
-	rns := digest.ResourceNames(c.cacheType, c.remoteInstanceName, digests)
-	return c.FindMissing(ctx, rns)
-}
-
 func (c *Cache) Get(ctx context.Context, r *resource.ResourceName) ([]byte, error) {
 	if !c.eligibleForCache(r.GetDigest()) {
 		return nil, status.ResourceExhaustedErrorf("Get: Digest %v too big for redis", r.GetDigest())

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -521,11 +521,6 @@ func (s3c *S3Cache) FindMissing(ctx context.Context, resources []*resource.Resou
 	return missing, nil
 }
 
-func (s3c *S3Cache) FindMissingDeprecated(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error) {
-	rns := digest.ResourceNames(s3c.cacheType, s3c.remoteInstanceName, digests)
-	return s3c.FindMissing(ctx, rns)
-}
-
 func (s3c *S3Cache) Reader(ctx context.Context, r *resource.ResourceName, offset, limit int64) (io.ReadCloser, error) {
 	k, err := s3c.key(ctx, r)
 	if err != nil {

--- a/enterprise/server/composable_cache/composable_cache.go
+++ b/enterprise/server/composable_cache/composable_cache.go
@@ -84,17 +84,6 @@ func (c *ComposableCache) FindMissing(ctx context.Context, resources []*resource
 	return c.inner.FindMissing(ctx, missingResources)
 }
 
-func (c *ComposableCache) FindMissingDeprecated(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error) {
-	missing, err := c.outer.FindMissingDeprecated(ctx, digests)
-	if err != nil {
-		missing = digests
-	}
-	if len(missing) == 0 {
-		return nil, nil
-	}
-	return c.inner.FindMissingDeprecated(ctx, missing)
-}
-
 func (c *ComposableCache) Get(ctx context.Context, r *resource.ResourceName) ([]byte, error) {
 	outerRsp, err := c.outer.Get(ctx, r)
 	if err == nil {

--- a/enterprise/server/raft/cache/BUILD
+++ b/enterprise/server/raft/cache/BUILD
@@ -50,6 +50,7 @@ go_test(
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/interfaces",
+        "//server/remote_cache/digest",
         "//server/testutil/testauth",
         "//server/testutil/testdigest",
         "//server/testutil/testenv",

--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -541,11 +541,6 @@ func (rc *RaftCache) FindMissing(ctx context.Context, resources []*resource.Reso
 	return rc.findMissingResourceNames(ctx, resources)
 }
 
-func (rc *RaftCache) FindMissingDeprecated(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error) {
-	resourceNames := digest.ResourceNames(rc.isolation.GetCacheType(), rc.isolation.GetRemoteInstanceName(), digests)
-	return rc.findMissingResourceNames(ctx, resourceNames)
-}
-
 func (rc *RaftCache) Get(ctx context.Context, rn *resource.ResourceName) ([]byte, error) {
 	r, err := rc.Reader(ctx, rn, 0, 0)
 	if err != nil {

--- a/enterprise/server/raft/cache/cache_test.go
+++ b/enterprise/server/raft/cache/cache_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
@@ -402,7 +403,8 @@ func TestFindMissingBlobs(t *testing.T) {
 		expectedMissingHashes = append(expectedMissingHashes, d.GetHash())
 	}
 
-	missing, err := cache.FindMissingDeprecated(ctx, append(digestsWritten, missingDigests...))
+	rns := digest.ResourceNames(resource.CacheType_CAS, "remote/instance/name", append(digestsWritten, missingDigests...))
+	missing, err := cache.FindMissing(ctx, rns)
 	require.NoError(t, err)
 
 	missingHashes := make([]string, 0)

--- a/enterprise/server/registry/registry.go
+++ b/enterprise/server/registry/registry.go
@@ -91,8 +91,8 @@ func (r *registry) writeManifest(ctx context.Context, oldDigest string, newManif
 	return nil
 }
 
-func (r *registry) getCachedManifest(ctx context.Context, digest string) (*rgpb.Manifest, error) {
-	mfBytes, err := r.manifestStore.ReadBlob(ctx, blobKey(digest))
+func (r *registry) getCachedManifest(ctx context.Context, d string) (*rgpb.Manifest, error) {
+	mfBytes, err := r.manifestStore.ReadBlob(ctx, blobKey(d))
 	if err != nil {
 		if status.IsNotFoundError(err) {
 			return nil, nil
@@ -101,14 +101,11 @@ func (r *registry) getCachedManifest(ctx context.Context, digest string) (*rgpb.
 	}
 	mfProto := &rgpb.Manifest{}
 	if err := proto.Unmarshal(mfBytes, mfProto); err != nil {
-		return nil, status.UnknownErrorf("could not unmarshal manifest proto %s: %s", digest, err)
+		return nil, status.UnknownErrorf("could not unmarshal manifest proto %s: %s", d, err)
 	}
 
-	c, err := r.cache.WithIsolation(ctx, resource.CacheType_CAS, registryInstanceName)
-	if err != nil {
-		return nil, err
-	}
-	missing, err := c.FindMissingDeprecated(ctx, mfProto.CasDependencies)
+	cacheResources := digest.ResourceNames(resource.CacheType_CAS, registryInstanceName, mfProto.CasDependencies)
+	missing, err := r.cache.FindMissing(ctx, cacheResources)
 	if err != nil {
 		return nil, status.UnavailableErrorf("could not check blob existence in CAS: %s", err)
 	}
@@ -116,7 +113,7 @@ func (r *registry) getCachedManifest(ctx context.Context, digest string) (*rgpb.
 	// manifest so that we trigger a new conversion and repopulate the data in
 	// the CAS.
 	if len(missing) > 0 {
-		log.CtxInfof(ctx, "Some blobs are missing from CAS for manifest %q, ignoring cached manifest", digest)
+		log.CtxInfof(ctx, "Some blobs are missing from CAS for manifest %q, ignoring cached manifest", d)
 		return nil, nil
 	}
 	return mfProto, nil

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -179,15 +179,16 @@ func (c *CacheProxy) FindMissing(ctx context.Context, req *dcpb.FindMissingReque
 	if err != nil {
 		return nil, err
 	}
-	digests := make([]*repb.Digest, 0)
+
+	instanceName := req.GetIsolation().GetRemoteInstanceName()
+	cacheType := req.GetIsolation().GetCacheType()
+	digests := make([]*resource.ResourceName, 0)
 	for _, k := range req.GetKey() {
-		digests = append(digests, digestFromKey(k))
+		d := digestFromKey(k)
+		rn := digest.NewCacheResourceName(d, instanceName, cacheType).ToProto()
+		digests = append(digests, rn)
 	}
-	cache, err := c.getCache(ctx, req.GetIsolation())
-	if err != nil {
-		return nil, err
-	}
-	missing, err := cache.FindMissingDeprecated(ctx, digests)
+	missing, err := c.cache.FindMissing(ctx, digests)
 	if err != nil {
 		return nil, err
 	}

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -352,11 +352,6 @@ func (c *DiskCache) FindMissing(ctx context.Context, resources []*resource.Resou
 	return p.findMissing(ctx, resources)
 }
 
-func (c *DiskCache) FindMissingDeprecated(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error) {
-	rns := digest.ResourceNames(c.cacheType, c.remoteInstanceName, digests)
-	return c.FindMissing(ctx, rns)
-}
-
 func (c *DiskCache) Get(ctx context.Context, r *resource.ResourceName) ([]byte, error) {
 	p, err := c.getPartition(ctx, r.GetInstanceName())
 	if err != nil {

--- a/server/backends/memory_cache/memory_cache.go
+++ b/server/backends/memory_cache/memory_cache.go
@@ -148,11 +148,6 @@ func (m *MemoryCache) FindMissing(ctx context.Context, resources []*resource.Res
 	return missing, nil
 }
 
-func (m *MemoryCache) FindMissingDeprecated(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error) {
-	rns := digest.ResourceNames(m.cacheType, m.remoteInstanceName, digests)
-	return m.FindMissing(ctx, rns)
-}
-
 func (m *MemoryCache) Get(ctx context.Context, r *resource.ResourceName) ([]byte, error) {
 	k, err := m.key(ctx, r)
 	if err != nil {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -219,7 +219,6 @@ type Cache interface {
 	WithIsolation(ctx context.Context, cacheType resource.CacheType, remoteInstanceName string) (Cache, error)
 
 	// [Deprecated] Normal cache-like operations that act in conjunction with WithIsolation
-	FindMissingDeprecated(ctx context.Context, digests []*repb.Digest) ([]*repb.Digest, error)
 	GetMultiDeprecated(ctx context.Context, digests []*repb.Digest) (map[*repb.Digest][]byte, error)
 	SetMultiDeprecated(ctx context.Context, kvs map[*repb.Digest][]byte) error
 	DeleteDeprecated(ctx context.Context, d *repb.Digest) error

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -100,11 +100,7 @@ func (s *ContentAddressableStorageServer) FindMissingBlobs(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	cache, err := s.getCache(ctx, req.GetInstanceName())
-	if err != nil {
-		return nil, err
-	}
-	digestsToLookup := make([]*repb.Digest, 0, len(req.GetBlobDigests()))
+	digestsToLookup := make([]*resource.ResourceName, 0, len(req.GetBlobDigests()))
 	for _, d := range req.GetBlobDigests() {
 		if d.GetHash() == digest.EmptySha256 {
 			continue
@@ -112,9 +108,10 @@ func (s *ContentAddressableStorageServer) FindMissingBlobs(ctx context.Context, 
 		if d.GetHash() == digest.EmptyHash {
 			continue
 		}
-		digestsToLookup = append(digestsToLookup, d)
+		rn := digest.NewCASResourceName(d, req.GetInstanceName()).ToProto()
+		digestsToLookup = append(digestsToLookup, rn)
 	}
-	missing, err := cache.FindMissingDeprecated(ctx, digestsToLookup)
+	missing, err := s.cache.FindMissing(ctx, digestsToLookup)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
See https://github.com/buildbuddy-io/buildbuddy/pull/2389 for more info

In cleaning up the WithIsolation method, I created duplicates of every cache method that take resource name objects instead of digests. Now I am cleaning up the deprecated old versions of the methods that take digests, and switching clients to use the new methods