### PR TITLE
Build up `trailingNonWhitespaceCharacters` in correct order

### DIFF
--- a/app/flame_chart/profile_model.ts
+++ b/app/flame_chart/profile_model.ts
@@ -50,7 +50,7 @@ export function parseProfile(data: string): Profile {
 function trailingNonWhitespaceCharacters(text: string, numTrailingChars: number) {
   let out = "";
   for (let i = text.length - 1; i >= 0; i--) {
-    if (text[i].trim() !== "") out += text[i];
+    if (text[i].trim() !== "") out = text[i] + out;
 
     if (out.length >= numTrailingChars) break;
   }


### PR DESCRIPTION
Right now these get built up in the wrong order, which breaks timing profile that have the correct closing sequence.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
