### PR TITLE
Add output_paths fields to remote_execution.proto

### DIFF
--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -586,6 +586,8 @@ message Command {
   //
   // Directories leading up to the output files are created by the worker prior
   // to execution, even if they are not explicitly part of the input root.
+  //
+  // DEPRECATED since v2.1: Use `output_paths` instead.
   repeated string output_files = 3;
 
   // A list of the output directories that the client expects to retrieve from
@@ -615,7 +617,39 @@ message Command {
   // Directories leading up to the output directories (but not the output
   // directories themselves) are created by the worker prior to execution, even
   // if they are not explicitly part of the input root.
+  //
+  // DEPRECATED since 2.1: Use `output_paths` instead.
   repeated string output_directories = 4;
+
+  // A list of the output paths that the client expects to retrieve from the
+  // action. Only the listed paths will be returned to the client as output.
+  // The type of the output (file or directory) is not specified, and will be
+  // determined by the server after action execution. If the resulting path is
+  // a file, it will be returned in an
+  // [OutputFile][build.bazel.remote.execution.v2.OutputFile] typed field.
+  // If the path is a directory, the entire directory structure will be returned
+  // as a [Tree][build.bazel.remote.execution.v2.Tree] message digest, see
+  // [OutputDirectory][build.bazel.remote.execution.v2.OutputDirectory]
+  // Other files or directories that may be created during command execution
+  // are discarded.
+  //
+  // The paths are relative to the working directory of the action execution.
+  // The paths are specified using a single forward slash (`/`) as a path
+  // separator, even if the execution platform natively uses a different
+  // separator. The path MUST NOT include a trailing slash, nor a leading slash,
+  // being a relative path.
+  //
+  // In order to ensure consistent hashing of the same Action, the output paths
+  // MUST be deduplicated and sorted lexicographically by code point (or,
+  // equivalently, by UTF-8 bytes).
+  //
+  // Directories leading up to the output paths are created by the worker prior
+  // to execution, even if they are not explicitly part of the input root.
+  //
+  // New in v2.1: this field supersedes the DEPRECATED `output_files` and
+  // `output_directories` fields. If `output_paths` is used, `output_files` and
+  // `output_directories` will be ignored!
+  repeated string output_paths = 7;
 
   // The platform requirements for the execution environment. The server MAY
   // choose to execute the action on any worker satisfying the requirements, so
@@ -918,12 +952,12 @@ message ActionResult {
   reserved 1;  // Reserved for use as the resource name.
 
   // The output files of the action. For each output file requested in the
-  // `output_files` field of the Action, if the corresponding file existed after
-  // the action completed, a single entry will be present either in this field,
-  // or the `output_file_symlinks` field if the file was a symbolic link to
-  // another file.
+  // `output_files` or `output_paths` field of the Action, if the corresponding
+  // file existed after the action completed, a single entry will be present
+  // either in this field, or the `output_file_symlinks` field if the file was
+  // a symbolic link to another file (`output_symlinks` field after v2.1).
   //
-  // If an output of the same name was found, but was a directory rather
+  // If an output listed in `output_files` was found, but was a directory rather
   // than a regular file, the server will return a FAILED_PRECONDITION.
   // If the action does not produce the requested output, then that output
   // will be omitted from the list. The server is free to arrange the output
@@ -934,22 +968,42 @@ message ActionResult {
   // Those may be links to other output files, or input files, or even absolute
   // paths outside of the working directory, if the server supports
   // [SymlinkAbsolutePathStrategy.ALLOWED][build.bazel.remote.execution.v2.CacheCapabilities.SymlinkAbsolutePathStrategy].
-  // For each output file requested in the `output_files` field of the Action,
-  // if the corresponding file existed after
+  // For each output file requested in the `output_files` or `output_paths`
+  // field of the Action, if the corresponding file existed after
   // the action completed, a single entry will be present either in this field,
   // or in the `output_files` field, if the file was not a symbolic link.
   //
-  // If an output symbolic link of the same name was found, but its target
-  // type was not a regular file, the server will return a FAILED_PRECONDITION.
+  // If an output symbolic link of the same name as listed in `output_files` of
+  // the Command was found, but its target type was not a regular file, the
+  // server will return a FAILED_PRECONDITION.
   // If the action does not produce the requested output, then that output
   // will be omitted from the list. The server is free to arrange the output
   // list as desired; clients MUST NOT assume that the output list is sorted.
+  //
+  // DEPRECATED as of v2.1. Servers that wish to be compatible with v2.0 API
+  // should still populate this field in addition to `output_symlinks`.
   repeated OutputSymlink output_file_symlinks = 10;
 
+  // New in v2.1: this field will only be populated if the command
+  // `output_paths` field was used, and not the pre v2.1 `output_files` or
+  // `output_directories` fields.
+  // The output paths of the action that are symbolic links to other paths.
+  // Those may be links to other outputs, or inputs, or even absolute paths
+  // outside of the working directory, if the server supports
+  // [SymlinkAbsolutePathStrategy.ALLOWED][build.bazel.remote.execution.v2.CacheCapabilities.SymlinkAbsolutePathStrategy].
+  // A single entry for each output requested in `output_paths`
+  // field of the Action, if the corresponding path existed after
+  // the action completed and was a symbolic link.
+  //
+  // If the action does not produce a requested output, then that output
+  // will be omitted from the list. The server is free to arrange the output
+  // list as desired; clients MUST NOT assume that the output list is sorted.
+  repeated OutputSymlink output_symlinks = 12;
+
   // The output directories of the action. For each output directory requested
-  // in the `output_directories` field of the Action, if the corresponding
-  // directory existed after the action completed, a single entry will be
-  // present in the output list, which will contain the digest of a
+  // in the `output_directories` or `output_paths` field of the Action, if the
+  // corresponding directory existed after the action completed, a single entry
+  // will be present in the output list, which will contain the digest of a
   // [Tree][build.bazel.remote.execution.v2.Tree] message containing the
   // directory tree, and the path equal exactly to the corresponding Action
   // output_directories member.
@@ -1005,7 +1059,8 @@ message ActionResult {
   //   }
   // }
   // ```
-  // If an output of the same name was found, but was not a directory, the
+  // If an output of the same name as listed in `output_files` of
+  // the Command was found in `output_directories`, but was not a directory, the
   // server will return a FAILED_PRECONDITION.
   repeated OutputDirectory output_directories = 3;
 
@@ -1024,6 +1079,9 @@ message ActionResult {
   // If the action does not produce the requested output, then that output
   // will be omitted from the list. The server is free to arrange the output
   // list as desired; clients MUST NOT assume that the output list is sorted.
+  //
+  // DEPRECATED as of v2.1. Servers that wish to be compatible with v2.0 API
+  // should still populate this field in addition to `output_symlinks`.
   repeated OutputSymlink output_directory_symlinks = 11;
 
   // The exit code of the command.
@@ -1349,7 +1407,8 @@ message GetActionResultRequest {
   bool inline_stderr = 4;
 
   // A hint to the server to inline the contents of the listed output files.
-  // Each path needs to exactly match one path in `output_files` in the
+  // Each path needs to exactly match one file path in either `output_paths` or
+  // `output_files` (DEPRECATED since v2.1) in the
   // [Command][build.bazel.remote.execution.v2.Command] message.
   repeated string inline_output_files = 5;
 }


### PR DESCRIPTION
I also pulled in the latest comments on the other output_* fields to lessen the diff between this and the remote version, though buildfix reformatted some of the comments because they're too too long in the remote version.

**Version bump**: Minor

**Related issues**: Unblocks https://github.com/buildbuddy-io/buildbuddy-internal/issues/1766