### PR TITLE
Apply a timeout to VM removal

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1517,6 +1517,10 @@ func (c *FirecrackerContainer) Remove(ctx context.Context) error {
 }
 
 func (c *FirecrackerContainer) remove(ctx context.Context) error {
+	// Make sure we don't get stuck for too long trying to remove.
+	ctx, cancel := context.WithTimeout(ctx, finalizationTimeout)
+	defer cancel()
+
 	defer c.cancelVmCtx()
 
 	var lastErr error


### PR DESCRIPTION
We usually call `Remove(ctx)` with a `ctx` returned from `context.ExtendContextForFinalization(ctx, 10s)`. The problem is that `ExtendContextForFinalization` extends the context by up to 10s, but doesn't limit it to 10s. So if an action doesn't have a timeout, it can be blocked in `Remove()` for up to 7 days (our default timeout for actions that don't specify one).

This PR makes it so we only spend up to 10 seconds when trying to remove. Failing to remove is not ideal, but it's also not the end of the world since it happens very rarely.

There's an existing TODO to make this removal happen in the background instead of blocking execution, but a proper fix for that is a bit involved.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1790
