### PR TITLE
Rename release workflows from 'Upload Artifacts' to 'Build and Upload Artifacts' if they build stuff

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -146,7 +146,7 @@ jobs:
           mv bazelisk "${GITHUB_WORKSPACE}/bin/bazel"
           chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
 
-      - name: Build artifacts
+      - name: Build Artifacts
         id: build
         run: |
           set -x  # print executed commands
@@ -169,7 +169,7 @@ jobs:
           shasum -a 256 "$BINARY" > "${BINARY}.sha256"
           echo "BINARY=${BINARY}" >> "$GITHUB_OUTPUT"
 
-      - name: Upload artifacts
+      - name: Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.BUILDBUDDY_GITHUB_USER_TOKEN }}
         run: |

--- a/.github/workflows/release-m1.yaml
+++ b/.github/workflows/release-m1.yaml
@@ -35,7 +35,7 @@ jobs:
         id: tag
         run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
 
-      - name: Upload Artifacts
+      - name: Build and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/release-mac.yaml
+++ b/.github/workflows/release-mac.yaml
@@ -24,7 +24,7 @@ jobs:
         id: tag
         run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
 
-      - name: Upload Artifacts
+      - name: Build and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
         id: tag
         run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
 
-      - name: Upload Artifacts
+      - name: Build and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
I also capitalized 'Artifacts' in all the titles for consistency.

---

**Version bump**: None
