### PR TITLE
Increase max length of secret values

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -341,8 +341,8 @@ type Secret struct {
 	UserID  string `gorm:"primaryKey"`
 	GroupID string `gorm:"primaryKey"`
 	Name    string `gorm:"primaryKey"`
-	Value   string
-	Perms   int `gorm:"type:int(11);default:NULL"`
+	Value   string `gorm:"type:text"`
+	Perms   int    `gorm:"type:int(11);default:NULL"`
 }
 
 func (s *Secret) TableName() string {


### PR DESCRIPTION
The current type of the secret `value` column is VARCHAR(255) which is too short. This PR changes the type to `text` which has a longer max length.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
