### PR TITLE
Remote asset: Remove extraneous digest check after mirroring to cache

### DIFF
--- a/server/remote_asset/fetch_server/fetch_server.go
+++ b/server/remote_asset/fetch_server/fetch_server.go
@@ -211,12 +211,8 @@ func mirrorToCache(ctx context.Context, bsClient bspb.ByteStreamClient, remoteIn
 		return nil, status.InvalidArgumentErrorf("response body checksum for %q was %q but wanted %q", uri, blobDigest.Hash, expectedSHA256)
 	}
 	cacheRN := digest.NewCASResourceName(blobDigest, remoteInstanceName)
-	uploadDigest, err := cachetools.UploadFromReader(ctx, bsClient, cacheRN, bytes.NewReader(data))
-	if err != nil {
+	if _, err := cachetools.UploadFromReader(ctx, bsClient, cacheRN, bytes.NewReader(data)); err != nil {
 		return nil, status.UnavailableErrorf("failed to add object to cache: %s", err)
-	}
-	if uploadDigest.Hash != expectedSHA256 {
-		return nil, status.UnavailableErrorf("unexpected hash mismatch: expected %s, got %s", expectedSHA256, uploadDigest.Hash)
 	}
 	log.CtxInfof(ctx, "Mirrored %s to cache (digest: %s/%d)", uri, blobDigest.Hash, blobDigest.SizeBytes)
 	return blobDigest, nil


### PR DESCRIPTION
We don't need to check the digest after uploading to cache, since the cache should return an error if the uploaded digest doesn't match the resource name.

This behavior was introduced here: https://github.com/buildbuddy-io/buildbuddy/pull/2826/files#diff-acc021802981fe69ea4087d3e20feb202744d3783a040b04993fb6b89d9d2ee6R218

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
