### PR TITLE
Allow passing 0 as a port value to pick an unassigned port

### DIFF
--- a/enterprise/server/image_converter/image_converter.go
+++ b/enterprise/server/image_converter/image_converter.go
@@ -459,10 +459,10 @@ func (c *imageConverter) Start(hc interfaces.HealthChecker, env environment.Env)
 		rgpb.RegisterImageConverterServer(server, c)
 	}
 
-	if err := grpc_server.RegisterGRPCServer(env, regRegistryServices); err != nil {
+	if _, err := grpc_server.RegisterGRPCServer(env, regRegistryServices); err != nil {
 		log.Fatalf("Could not setup GRPC server: %s", err)
 	}
-	if err := grpc_server.RegisterGRPCSServer(env, regRegistryServices); err != nil {
+	if _, err := grpc_server.RegisterGRPCSServer(env, regRegistryServices); err != nil {
 		log.Fatalf("Could not setup GRPCS server: %s", err)
 	}
 


### PR DESCRIPTION
This allows passing "0" as a port value to let the OS auto-assign a random available port. If running on a shared machine it is useful for avoiding port collisions.

Example usage:

```
tylerw@lunchbox:~/buildbuddy$ blaze run enterprise/server -- -grpc_port=0 -grpcs_port=0 -internal_grpc_port=0 -internal_grpcs_port=0 -internal_http_port=0 -monitoring_port=0 -port=0 -ssl_port=0 -telemetry_port=0
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/cc24b289-3e25-448b-83c0-4e3c784b5812
INFO: Analyzed target //enterprise/server:server (416 packages loaded, 8433 targets configured).
INFO: Found 1 target...
Target //enterprise/server/cmd/server:buildbuddy up-to-date:
  bazel-bin/enterprise/server/cmd/server/buildbuddy_/buildbuddy
INFO: Elapsed time: 8.852s, Critical Path: 7.12s
INFO: 91 processes: 1 internal, 89 linux-sandbox, 1 local.
INFO: Running command line: bazel-bin/enterprise/server/cmd/server/buildbuddy_/buildbuddy '--config_file=enterprise/config/buildbuddy.local.yaml' '--max_shutdown_duration=3s' '--static_directory=static' '--app_directory=/enterprise/app' '-grpc_port=0' '-grpcs_port=0' '-internal_grpc_port=0' '-internal_grpcs_port=0' '-internal_http_port=0' '-monitoring_port=0' '-port=0' '-ssl_port=0' '-telemetry_port=0'
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/cc24b289-3e25-448b-83c0-4e3c784b5812
INFO: Build completed successfully, 91 total actions
2022/11/03 15:18:56.511 INF BuildBuddy v2.12.2 compiled with go1.18.1
2022/11/03 15:18:56.511 INF Reading buildbuddy config from 'enterprise/config/buildbuddy.local.yaml'
2022/11/03 15:18:56.515 INF Auto-migrating DB
2022/11/03 15:18:56.559 INF Cache: BuildBuddy cache API enabled!
2022/11/03 15:18:56.559 INF DiskCache partition "default": loaded 0 files in 96.53µs
2022/11/03 15:18:56.559 INF Finished initializing disk cache partition "default" at "/tmp/tylerw-buildbuddy-enterprise-cache". Current size: 0 (max: 10000000000) bytes
2022/11/03 15:18:56.686 INF Enabling monitoring (pprof/prometheus) interface on http://localhost:33403
2022/11/03 15:18:56.686 INF gRPC listening on 0.0.0.0:33743
2022/11/03 15:18:56.686 INF gRPC listening on 0.0.0.0:40437
2022/11/03 15:18:56.687 INF
2022/11/03 15:18:56.687 INF ╔════════════════════════════════════════════════════════════════════╗
2022/11/03 15:18:56.687 INF ║                                                                    ║
2022/11/03 15:18:56.687 INF ║   Your BuildBuddy Enterprise Server is up and running!             ║
2022/11/03 15:18:56.687 INF ║                                                                    ║
2022/11/03 15:18:56.687 INF ║   Need help? Email us anytime at support@buildbuddy.io             ║
2022/11/03 15:18:56.687 INF ║   Thanks for using BuildBuddy!                                     ║
2022/11/03 15:18:56.687 INF ║                                                                    ║
2022/11/03 15:18:56.687 INF ║   Add the following lines to your .bazelrc to start sending build  ║
2022/11/03 15:18:56.687 INF ║   events to your local server:                                     ║
2022/11/03 15:18:56.687 INF ║        build --bes_results_url=http://localhost:44599/invocation/  ║
2022/11/03 15:18:56.687 INF ║        build --bes_backend=grpc://localhost:40437                  ║
2022/11/03 15:18:56.687 INF ║                                                                    ║
2022/11/03 15:18:56.687 INF ║   You can now view Buildbuddy in the browser:                      ║
2022/11/03 15:18:56.687 INF ║        http://localhost:44599/                                     ║
2022/11/03 15:18:56.687 INF ║                                                                    ║
2022/11/03 15:18:56.687 INF ╚════════════════════════════════════════════════════════════════════╝
2022/11/03 15:18:56.687 INF
2022/11/03 15:18:56.688 INF HealthChecker transitioning from ready: false => ready: true
^CCaught interrupt signal; shutting down...
2022/11/03 15:18:57.801 INF StatsRecorder: waiting for EventChannels to be closed before shutting down
2022/11/03 15:18:57.801 INF StatsRecorder: shutting down
2022/11/03 15:18:57.801 INF Graceful stop of GRPC server succeeded.
2022/11/03 15:18:57.801 INF Graceful stop of GRPC server succeeded.
Server "buildbuddy-server" stopped.
tylerw@lunchbox:~/buildbuddy$
```