### PR TITLE
Revert "Allow passing 0 as a port value to pick an unassigned port"

### DIFF
--- a/enterprise/server/image_converter/image_converter.go
+++ b/enterprise/server/image_converter/image_converter.go
@@ -459,10 +459,10 @@ func (c *imageConverter) Start(hc interfaces.HealthChecker, env environment.Env)
 		rgpb.RegisterImageConverterServer(server, c)
 	}
 
-	if _, err := grpc_server.RegisterGRPCServer(env, regRegistryServices); err != nil {
+	if err := grpc_server.RegisterGRPCServer(env, regRegistryServices); err != nil {
 		log.Fatalf("Could not setup GRPC server: %s", err)
 	}
-	if _, err := grpc_server.RegisterGRPCSServer(env, regRegistryServices); err != nil {
+	if err := grpc_server.RegisterGRPCSServer(env, regRegistryServices); err != nil {
 		log.Fatalf("Could not setup GRPCS server: %s", err)
 	}
 

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -331,20 +331,16 @@ func StartAndRunServices(env environment.Env) {
 		log.Fatalf("%v", err)
 	}
 
-	_, err = grpc_server.RegisterInternalGRPCServer(env, registerInternalGRPCServices)
-	if err != nil {
+	if err := grpc_server.RegisterInternalGRPCServer(env, registerInternalGRPCServices); err != nil {
 		log.Fatalf("%v", err)
 	}
-	_, err = grpc_server.RegisterInternalGRPCSServer(env, registerInternalGRPCServices)
-	if err != nil {
+	if err := grpc_server.RegisterInternalGRPCSServer(env, registerInternalGRPCServices); err != nil {
 		log.Fatalf("%v", err)
 	}
-	gRPCPort, err := grpc_server.RegisterGRPCServer(env, registerGRPCServices)
-	if err != nil {
+	if err := grpc_server.RegisterGRPCServer(env, registerGRPCServices); err != nil {
 		log.Fatalf("%v", err)
 	}
-	_, err = grpc_server.RegisterGRPCSServer(env, registerGRPCServices)
-	if err != nil {
+	if err := grpc_server.RegisterGRPCSServer(env, registerGRPCServices); err != nil {
 		log.Fatalf("%v", err)
 	}
 
@@ -386,12 +382,12 @@ func StartAndRunServices(env environment.Env) {
 		mux.Handle("/webhooks/workflow/", httpfilters.WrapExternalHandler(env, wfs))
 	}
 
-	httpServerAddr := fmt.Sprintf("%s:%d", *listen, *port)
-	httpListener, err := net.Listen("tcp", httpServerAddr)
-	if err != nil {
-		log.Fatalf("could not listen on HTTP port: %s", err)
+	if sp := env.GetSplashPrinter(); sp != nil {
+		sp.PrintSplashScreen(bburl.WithPath("").Hostname(), *port, grpc_server.GRPCPort())
 	}
+
 	server := &http.Server{
+		Addr:    fmt.Sprintf("%s:%d", *listen, *port),
 		Handler: env.GetMux(),
 	}
 
@@ -439,12 +435,8 @@ func StartAndRunServices(env environment.Env) {
 	} else {
 		// If no SSL is enabled, we'll just serve things as-is.
 		go func() {
-			server.Serve(httpListener)
+			server.ListenAndServe()
 		}()
-	}
-
-	if sp := env.GetSplashPrinter(); sp != nil {
-		sp.PrintSplashScreen(bburl.WithPath("").Hostname(), httpListener.Addr().(*net.TCPAddr).Port, gRPCPort)
 	}
 
 	if *exitWhenReady {

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -47,10 +47,10 @@ func Port() int {
 
 type RegisterServices func(server *grpc.Server, env environment.Env)
 
-func RegisterGRPCServer(env environment.Env, regServices RegisterServices) (int, error) {
-	grpcServer, port, err := NewGRPCServer(env, *gRPCPort, nil, regServices)
+func RegisterGRPCServer(env environment.Env, regServices RegisterServices) error {
+	grpcServer, err := NewGRPCServer(env, *gRPCPort, nil, regServices)
 	if err != nil {
-		return -1, err
+		return err
 	}
 	env.SetGRPCServer(grpcServer)
 	if *gRPCOverHTTPPortEnabled {
@@ -59,75 +59,73 @@ func RegisterGRPCServer(env environment.Env, regServices RegisterServices) (int,
 			grpcServer,
 		})
 	}
-	return port, nil
+	return nil
 }
 
-func RegisterGRPCSServer(env environment.Env, regServices RegisterServices) (int, error) {
+func RegisterGRPCSServer(env environment.Env, regServices RegisterServices) error {
 	if !env.GetSSLService().IsEnabled() {
-		return -1, nil
+		return nil
 	}
 	creds, err := env.GetSSLService().GetGRPCSTLSCreds()
 	if err != nil {
-		return -1, status.InternalErrorf("Error getting SSL creds: %s", err)
+		return status.InternalErrorf("Error getting SSL creds: %s", err)
 	}
-	grpcsServer, port, err := NewGRPCServer(env, *gRPCSPort, grpc.Creds(creds), regServices)
+	grpcsServer, err := NewGRPCServer(env, *gRPCSPort, grpc.Creds(creds), regServices)
 	if err != nil {
-		return -1, err
+		return err
 	}
 	env.SetGRPCSServer(grpcsServer)
-	return port, nil
+	return nil
 }
 
-func RegisterInternalGRPCServer(env environment.Env, regServices RegisterServices) (int, error) {
-	if *internalGRPCPort == -1 {
-		return -1, nil
+func RegisterInternalGRPCServer(env environment.Env, regServices RegisterServices) error {
+	if *internalGRPCPort == 0 {
+		return nil
 	}
 
-	grpcServer, port, err := NewGRPCServer(env, *internalGRPCPort, nil, regServices)
+	grpcServer, err := NewGRPCServer(env, *internalGRPCPort, nil, regServices)
 	if err != nil {
-		return -1, err
+		return err
 	}
 	env.SetInternalGRPCServer(grpcServer)
-	return port, nil
+	return nil
 }
 
-func RegisterInternalGRPCSServer(env environment.Env, regServices RegisterServices) (int, error) {
-	if *internalGRPCSPort == -1 {
-		return -1, nil
+func RegisterInternalGRPCSServer(env environment.Env, regServices RegisterServices) error {
+	if *internalGRPCSPort == 0 {
+		return nil
 	}
 
 	if !env.GetSSLService().IsEnabled() {
-		return -1, nil
+		return nil
 	}
 	creds, err := env.GetSSLService().GetGRPCSTLSCreds()
 	if err != nil {
-		return -1, status.InternalErrorf("Error getting SSL creds: %s", err)
+		return status.InternalErrorf("Error getting SSL creds: %s", err)
 	}
-	grpcsServer, port, err := NewGRPCServer(env, *internalGRPCSPort, grpc.Creds(creds), regServices)
+	grpcsServer, err := NewGRPCServer(env, *internalGRPCSPort, grpc.Creds(creds), regServices)
 	if err != nil {
-		return -1, err
+		return err
 	}
 	env.SetInternalGRPCSServer(grpcsServer)
-	return port, nil
+	return nil
 }
 
-func NewGRPCServer(env environment.Env, port int, credentialOption grpc.ServerOption, regServices RegisterServices) (*grpc.Server, int, error) {
+func NewGRPCServer(env environment.Env, port int, credentialOption grpc.ServerOption, regServices RegisterServices) (*grpc.Server, error) {
 	// Initialize our gRPC server (and fail early if that doesn't happen).
 	hostAndPort := fmt.Sprintf("%s:%d", env.GetListenAddr(), port)
 
 	lis, err := net.Listen("tcp", hostAndPort)
 	if err != nil {
-		return nil, -1, status.InternalErrorf("Failed to listen: %s", err)
+		return nil, status.InternalErrorf("Failed to listen: %s", err)
 	}
-
-	listeningPort := lis.Addr().(*net.TCPAddr).Port
 
 	grpcOptions := CommonGRPCServerOptions(env)
 	if credentialOption != nil {
 		grpcOptions = append(grpcOptions, credentialOption)
-		log.Infof("gRPCS listening on %s:%d", env.GetListenAddr(), listeningPort)
+		log.Infof("gRPCS listening on %s", hostAndPort)
 	} else {
-		log.Infof("gRPC listening on %s:%d", env.GetListenAddr(), listeningPort)
+		log.Infof("gRPC listening on %s", hostAndPort)
 	}
 
 	grpcServer := grpc.NewServer(grpcOptions...)
@@ -152,7 +150,7 @@ func NewGRPCServer(env environment.Env, port int, credentialOption grpc.ServerOp
 		_ = grpcServer.Serve(lis)
 	}()
 	env.GetHealthChecker().RegisterShutdownFunction(GRPCShutdownFunc(grpcServer))
-	return grpcServer, lis.Addr().(*net.TCPAddr).Port, nil
+	return grpcServer, nil
 }
 
 func GRPCShutdown(ctx context.Context, grpcServer *grpc.Server) error {

--- a/server/util/monitoring/monitoring.go
+++ b/server/util/monitoring/monitoring.go
@@ -2,7 +2,6 @@ package monitoring
 
 import (
 	"flag"
-	"net"
 	"net/http"
 	"net/http/pprof"
 
@@ -55,18 +54,14 @@ func RegisterMonitoringHandlers(mux *http.ServeMux) {
 func StartMonitoringHandler(hostPort string) {
 	mux := http.NewServeMux()
 	RegisterMonitoringHandlers(mux)
-	httpListener, err := net.Listen("tcp", hostPort)
-	if err != nil {
-		log.Fatalf("could not listen on HTTP port: %s", err)
-	}
-	httpPort := httpListener.Addr().(*net.TCPAddr).Port
 	s := &http.Server{
+		Addr:    hostPort,
 		Handler: http.Handler(mux),
 	}
 
 	go func() {
-		log.Infof("Enabling monitoring (pprof/prometheus) interface on http://localhost:%d", httpPort)
-		if err := s.Serve(httpListener); err != nil {
+		log.Infof("Enabling monitoring (pprof/prometheus) interface on http://%s", hostPort)
+		if err := s.ListenAndServe(); err != nil {
 			log.Fatal(err.Error())
 		}
 	}()


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#2855

My guess is this is related to dev breaking b/c readiness check never passes. Not sure why yet.