### PR TITLE
Remote asset: Determine digest size using Metadata API

### DIFF
--- a/server/remote_asset/fetch_server/BUILD
+++ b/server/remote_asset/fetch_server/BUILD
@@ -11,7 +11,6 @@ go_library(
         "//server/environment",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
-        "//server/util/ioutil",
         "//server/util/log",
         "//server/util/prefix",
         "//server/util/scratchspace",

--- a/server/remote_asset/fetch_server/fetch_server.go
+++ b/server/remote_asset/fetch_server/fetch_server.go
@@ -15,7 +15,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
-	"github.com/buildbuddy-io/buildbuddy/server/util/ioutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/scratchspace"
@@ -30,10 +29,9 @@ import (
 )
 
 const (
-	checksumQualifier     = "checksum.sri"
-	sha256Prefix          = "sha256-"
-	maxHTTPTimeout        = 60 * time.Minute
-	bytestreamReadBufSize = 4e6 // 4 MB
+	checksumQualifier = "checksum.sri"
+	sha256Prefix      = "sha256-"
+	maxHTTPTimeout    = 60 * time.Minute
 )
 
 type FetchServer struct {
@@ -42,7 +40,7 @@ type FetchServer struct {
 
 func Register(env environment.Env) error {
 	// OPTIONAL CACHE API -- only enable if configured.
-	if env.GetByteStreamClient() == nil {
+	if err := checkPreconditions(env); err != nil {
 		return nil
 	}
 	fetchServer, err := NewFetchServer(env)
@@ -54,11 +52,20 @@ func Register(env environment.Env) error {
 }
 
 func NewFetchServer(env environment.Env) (*FetchServer, error) {
-	cache := env.GetCache()
-	if cache == nil {
-		return nil, status.FailedPreconditionError("A cache is required to enable the ByteStreamServer")
+	if err := checkPreconditions(env); err != nil {
+		return nil, err
 	}
 	return &FetchServer{env: env}, nil
+}
+
+func checkPreconditions(env environment.Env) error {
+	if env.GetCache() == nil {
+		return status.FailedPreconditionError("missing Cache")
+	}
+	if env.GetByteStreamClient() == nil {
+		return status.FailedPreconditionError("missing ByteStreamClient")
+	}
+	return nil
 }
 
 func timeoutFromContext(ctx context.Context) (time.Duration, bool) {
@@ -111,31 +118,40 @@ func (p *FetchServer) FetchBlob(ctx context.Context, req *rapb.FetchBlobRequest)
 			}
 			blobDigest := &repb.Digest{
 				Hash: fmt.Sprintf("%x", sha256),
-				// We don't know the digest size (yet), but we have to specify
-				// something here or the bytestream API will return an
-				// InvalidArgument error. The bytestream server doesn't actually
-				// check this value; it just needs something greater than 0.
-				//
-				// Note, the value we specify here is used as the max size of
-				// each chunk sent back in the stream, so want something
-				// relatively large here or else the streaming will be too slow.
-				SizeBytes: bytestreamReadBufSize,
+				// The digest size is unknown since the client only sends up
+				// the hash. We can look up the size using the Metadata API,
+				// which looks up only using the hash, so the size we pass here
+				// doesn't matter.
+				SizeBytes: -1,
 			}
 			expectedSHA256 = blobDigest.Hash
 			cacheRN := digest.NewCASResourceName(blobDigest, req.GetInstanceName())
 
-			// TODO: Find a way to get the correct digest size without
-			// downloading the full blob from cache.
 			log.CtxInfof(ctx, "Looking up %s in cache", blobDigest.Hash)
-			c := &ioutil.Counter{}
 
-			if err := cachetools.GetBlob(ctx, p.env.GetByteStreamClient(), cacheRN, c); err != nil {
-				log.CtxInfof(ctx, "FetchServer failed to get %s from cache: %s", expectedSHA256, err)
+			// Lookup metadata to get the correct digest size to be returned to
+			// the client.
+			cache := p.env.GetCache()
+			md, err := cache.Metadata(ctx, cacheRN.ToProto())
+			if err != nil {
+				log.CtxInfof(ctx, "FetchServer failed to get metadata for %s: %s", expectedSHA256, err)
 				continue
 			}
-
-			blobDigest.SizeBytes = c.Count() // set the actual correct size.
-			log.CtxInfof(ctx, "FetchServer successfully read %s from cache", digest.String(blobDigest))
+			blobDigest.SizeBytes = md.SizeBytes
+			// Even though we successfully fetched metadata, we need to renew
+			// the cache entry (using Contains()) to ensure that it doesn't
+			// expire by the time the client requests it from cache.
+			cacheRN = digest.NewCASResourceName(blobDigest, req.GetInstanceName())
+			exists, err := cache.Contains(ctx, cacheRN.ToProto())
+			if err != nil {
+				log.CtxErrorf(ctx, "Failed to renew %s: %s", digest.String(blobDigest), err)
+				continue
+			}
+			if !exists {
+				log.CtxInfof(ctx, "Blob %s expired before we could renew it", digest.String(blobDigest))
+				continue
+			}
+			log.CtxInfof(ctx, "FetchServer found %s in cache", digest.String(blobDigest))
 			return &rapb.FetchBlobResponse{
 				Status:     &statuspb.Status{Code: int32(gcodes.OK)},
 				BlobDigest: blobDigest,


### PR DESCRIPTION
Speeds up fetches (and reduces load on the cache) by checking Metadata and renewing the cache entry with FindMissingBlobs instead of downloading the full asset using the ByteStream API.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
