### PR TITLE
CLI: Improve bazelrc parsing logic

### DIFF
--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -77,8 +77,11 @@ func run() (exitCode int, err error) {
 	// Split out passthrough args and don't let plugins modify them,
 	// since those are intended to be passed to the built binary as-is.
 	bazelArgs, passthroughArgs := arg.SplitPassthroughArgs(args)
-	rcFileArgs := parser.GetArgsFromRCFiles(bazelArgs)
-	args = append(bazelArgs, rcFileArgs...)
+	// TODO: Expanding configs results in a long explicit command line in the BB
+	// UI. Need to find a way to override the explicit command line in the UI so
+	// that it reflects the args passed to the CLI, not the wrapped Bazel
+	// process.
+	args = parser.ExpandConfigs(bazelArgs)
 
 	// Fiddle with args
 	// TODO(bduffany): model these as "built-in" plugins
@@ -103,9 +106,6 @@ func run() (exitCode int, err error) {
 	args = remotebazel.HandleRemoteBazel(args, passthroughArgs)
 	args = version.HandleVersion(args)
 	args = login.HandleLogin(args)
-
-	// Remove any args that don't need to be on the command line
-	args = arg.RemoveExistingArgs(args, rcFileArgs)
 
 	// If this is a `bazel run` command, add a --run_script arg so that
 	// we can execute post-bazel plugins between the build and the run step.

--- a/cli/parser/BUILD
+++ b/cli/parser/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "parser",
@@ -8,5 +8,17 @@ go_library(
     deps = [
         "//cli/arg",
         "//cli/log",
+        "//cli/workspace",
+    ],
+)
+
+go_test(
+    name = "parser_test",
+    srcs = ["parser_test.go"],
+    embed = [":parser"],
+    deps = [
+        "//cli/log",
+        "//server/testutil/testfs",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 	"os/user"
@@ -11,20 +12,66 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
+	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
 )
 
 var (
-	optionMatcher = regexp.MustCompile("(?P<phase>[^:]*):?(?P<config>.*)?\\s+(?P<option>.*)")
 	importMatcher = regexp.MustCompile("(import|try-import)\\s+(?P<relative>\\%workspace\\%)?(?P<path>.*)")
+
+	// Inheritance hierarchy: https://bazel.build/run/bazelrc#option-defaults
+	// All commands inherit from "common".
+	parentCommand = map[string]string{
+		"test":           "build",
+		"run":            "build",
+		"clean":          "build",
+		"mobile-install": "build",
+		"info":           "build",
+		"print_action":   "build",
+		"config":         "build",
+		"cquery":         "build",
+		"aquery":         "build",
+
+		"coverage": "test",
+	}
 )
 
-type BazelOption struct {
-	Phase  string
-	Config string
-	Option string
+type Rules struct {
+	All              []*RcRule
+	ByPhaseAndConfig map[string]map[string][]*RcRule
 }
 
-func appendOptionsFromImport(match []string, opts []*BazelOption) ([]*BazelOption, error) {
+func StructureRules(rules []*RcRule) *Rules {
+	r := &Rules{
+		All:              rules,
+		ByPhaseAndConfig: map[string]map[string][]*RcRule{},
+	}
+	for _, rule := range rules {
+		byConfig := r.ByPhaseAndConfig[rule.Phase]
+		if byConfig == nil {
+			byConfig = map[string][]*RcRule{}
+			r.ByPhaseAndConfig[rule.Phase] = byConfig
+		}
+		byConfig[rule.Config] = append(byConfig[rule.Config], rule)
+	}
+	return r
+}
+
+func (r *Rules) ForPhaseAndConfig(phase, config string) []*RcRule {
+	byConfig := r.ByPhaseAndConfig[phase]
+	if byConfig == nil {
+		return nil
+	}
+	return byConfig[config]
+}
+
+// RcRule is a rule parsed from a bazelrc file.
+type RcRule struct {
+	Phase   string
+	Config  string
+	Options []string
+}
+
+func appendRcRulesFromImport(match []string, opts []*RcRule) ([]*RcRule, error) {
 	importPath := ""
 	for i, name := range importMatcher.SubexpNames() {
 		switch name {
@@ -41,59 +88,95 @@ func appendOptionsFromImport(match []string, opts []*BazelOption) ([]*BazelOptio
 		return opts, err
 	}
 	defer file.Close()
-	return appendOptionsFromFile(file, opts)
+	return appendRcRulesFromFile(file, opts)
 }
 
-func optionFromMatch(match []string) *BazelOption {
-	o := &BazelOption{}
-	for i, name := range optionMatcher.SubexpNames() {
-		switch name {
-		case "phase":
-			o.Phase = match[i]
-		case "config":
-			o.Config = match[i]
-		case "option":
-			o.Option = match[i]
-		}
-	}
-	return o
-}
-
-func appendOptionsFromFile(in io.Reader, opts []*BazelOption) ([]*BazelOption, error) {
+func appendRcRulesFromFile(in io.Reader, opts []*RcRule) ([]*RcRule, error) {
 	scanner := bufio.NewScanner(in)
 	var err error
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix(line, "#") {
+		// Handle line continuations (lines can end with "\" to effectively
+		// continue the same line)
+		for strings.HasSuffix(line, `\`) && scanner.Scan() {
+			line = line[:len(line)-1] + scanner.Text()
+		}
+
+		line = stripCommentsAndWhitespace(line)
+		if strings.TrimSpace(line) == "" {
 			continue
 		}
 
 		if importMatcher.MatchString(line) {
 			match := importMatcher.FindStringSubmatch(line)
-			opts, err = appendOptionsFromImport(match, opts)
+			// TODO: Prevent import cycles
+			opts, err = appendRcRulesFromImport(match, opts)
 			if err != nil {
 				log.Debugf("Error parsing import: %s", err.Error())
 			}
 			continue
 		}
 
-		if optionMatcher.MatchString(line) {
-			match := optionMatcher.FindStringSubmatch(line)
-			opts = append(opts, optionFromMatch(match))
+		opt, err := parseRcRule(line)
+		if err != nil {
+			log.Debugf("Error parsing bazelrc option: %s", err.Error())
+			continue
 		}
+		// Bazel doesn't support configs for startup options and ignores them if
+		// they appear in a bazelrc: https://bazel.build/run/bazelrc#config
+		if opt.Phase == "startup" && opt.Config != "" {
+			continue
+		}
+		opts = append(opts, opt)
 	}
 	return opts, scanner.Err()
 }
 
-func ParseRCFiles(filePaths ...string) ([]*BazelOption, error) {
-	options := make([]*BazelOption, 0)
+func stripCommentsAndWhitespace(line string) string {
+	index := strings.Index(line, "#")
+	if index >= 0 {
+		line = line[:index]
+	}
+	return strings.TrimSpace(line)
+}
+
+func parseRcRule(line string) (*RcRule, error) {
+	tokens := strings.Fields(line)
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("unexpected empty line")
+	}
+	if strings.HasPrefix(tokens[0], "-") {
+		return &RcRule{
+			Phase:   "common",
+			Options: tokens,
+		}, nil
+	}
+	if !strings.Contains(tokens[0], ":") {
+		return &RcRule{
+			Phase:   tokens[0],
+			Options: tokens[1:],
+		}, nil
+	}
+	phaseConfig := strings.Split(tokens[0], ":")
+	if len(phaseConfig) != 2 {
+		return nil, fmt.Errorf("invalid bazelrc syntax: %s", phaseConfig)
+	}
+	return &RcRule{
+		Phase:   phaseConfig[0],
+		Config:  phaseConfig[1],
+		Options: tokens[1:],
+	}, nil
+}
+
+func ParseRCFiles(filePaths ...string) ([]*RcRule, error) {
+	options := make([]*RcRule, 0)
 	for _, filePath := range filePaths {
 		file, err := os.Open(filePath)
 		if err != nil {
 			continue
 		}
 		defer file.Close()
-		options, err = appendOptionsFromFile(file, options)
+		options, err = appendRcRulesFromFile(file, options)
 		if err != nil {
 			continue
 		}
@@ -101,70 +184,136 @@ func ParseRCFiles(filePaths ...string) ([]*BazelOption, error) {
 	return options, nil
 }
 
-func GetFlagValue(options []*BazelOption, phase, config, flagName, commandLineOverride string) string {
-	if commandLineOverride != "" {
-		return flagName + "=" + commandLineOverride
+func ExpandConfigs(args []string) []string {
+	ws, err := workspace.Path()
+	if err != nil {
+		log.Debugf("Could not determine workspace dir: %s", err)
 	}
-	for _, opt := range options {
-		if opt.Phase != phase {
-			continue
-		}
-		if opt.Config != config && opt.Config != "" {
-			continue
-		}
-		if strings.HasPrefix(opt.Option, flagName) {
-			return opt.Option
-		}
-	}
-	return ""
+	return expandConfigs(ws, args)
 }
 
-func GetArgsFromRCFiles(commandLineArgs []string) []string {
+func expandConfigs(workspaceDir string, args []string) []string {
 	rcFiles := make([]string, 0)
-	if arg.Get(commandLineArgs, "system_rc") != "true" {
+	// TODO: handle --nosystem_rc, --system_rc no, --system_rc=0, etc.
+	if arg.Get(args, "system_rc") != "no" {
 		rcFiles = append(rcFiles, "/etc/bazel.bazelrc")
-		rcFiles = append(rcFiles, "%ProgramData%\bazel.bazelrc")
+		rcFiles = append(rcFiles, `%ProgramData%\bazel.bazelrc`)
 	}
-	if arg.Get(commandLineArgs, "workspace_rc") != "true" {
-		rcFiles = append(rcFiles, ".bazelrc")
+	if workspaceDir != "" && arg.Get(args, "workspace_rc") != "no" {
+		rcFiles = append(rcFiles, filepath.Join(workspaceDir, ".bazelrc"))
 	}
-	if arg.Get(commandLineArgs, "home_rc") != "true" {
+	if arg.Get(args, "home_rc") != "no" {
 		usr, err := user.Current()
 		if err == nil {
 			rcFiles = append(rcFiles, filepath.Join(usr.HomeDir, ".bazelrc"))
 		}
 	}
-	// TODO(siggisim): Handle multiple bazlerc params.
-	if b := arg.Get(commandLineArgs, "bazelrc"); b != "" {
+	// TODO(siggisim): Handle multiple bazelrc params.
+	if b := arg.Get(args, "bazelrc"); b != "" {
 		rcFiles = append(rcFiles, b)
 	}
-	opts, err := ParseRCFiles(rcFiles...)
+	r, err := ParseRCFiles(rcFiles...)
 	if err != nil {
 		log.Debugf("Error parsing .bazelrc file: %s", err.Error())
 		return nil
 	}
+	rules := StructureRules(r)
 
-	config := arg.Get(commandLineArgs, "config")
-	command := arg.GetCommand(commandLineArgs)
+	command, commandIndex := arg.GetCommandAndIndex(args)
 
-	rcFileArgs := make([]string, 0)
-	rcFileArgs = appendArgsForConfig(opts, rcFileArgs, command, config)
+	// Always apply bazelrc rules in order of the precedence hierarchy. For
+	// example, for the "test" command, apply options in order of "common", then
+	// "build", then "test".
+	phases := getPhases(command)
 
-	log.Debugf("rcFileArgs: %+v", rcFileArgs)
+	// We'll refer to args in bazelrc which aren't expanded from a --config
+	// option as "default" args, like a .bazelrc line that just says "-c dbg" or
+	// "build -c dbg" as opposed to something qualified like "build:dbg -c dbg".
+	//
+	// These default args take lower precedence than explicit command line args
+	// so we expand those first just after the command.
+	var defaultArgs []string
+	for _, phase := range phases {
+		defaultArgs = appendArgsForConfig(rules, defaultArgs, phase, "" /*=config*/)
+	}
+	args = concat(args[:commandIndex+1], defaultArgs, args[commandIndex+1:])
 
-	return rcFileArgs
+	for {
+		config, i, length := arg.Find(args, "config")
+		if i < 0 {
+			break
+		}
+
+		var configArgs []string
+		for _, phase := range phases {
+			configArgs = appendArgsForConfig(rules, configArgs, phase, config)
+		}
+
+		args = concat(args[:i], configArgs, args[i+length:])
+	}
+
+	log.Debugf("expanded args: %+v", args)
+
+	return args
 }
 
-func appendArgsForConfig(opts []*BazelOption, args []string, command, config string) []string {
-	for _, o := range opts {
-		if o.Phase != command || o.Config != config {
-			continue
-		}
-		if strings.HasPrefix(o.Option, "--config=") {
-			args = appendArgsForConfig(opts, args, command, strings.TrimPrefix(o.Option, "--config="))
-		} else {
-			args = append(args, o.Option)
+func appendArgsForConfig(rules *Rules, args []string, phase, config string) []string {
+	// TODO: Detect cycles in --config definitions, like
+	// build:foo --config=bar, build:bar --config=foo
+	for _, rule := range rules.ForPhaseAndConfig(phase, config) {
+		for i := 0; i < len(rule.Options); i++ {
+			opt := rule.Options[i]
+			if strings.HasPrefix(opt, "--config=") {
+				config := strings.TrimPrefix(opt, "--config=")
+				args = appendArgsForConfig(rules, args, phase, config)
+			} else if opt == "--config" && i+1 < len(rule.Options) {
+				config := rule.Options[i+1]
+				args = appendArgsForConfig(rules, args, phase, config)
+				// Consume the following argument in this iteration too
+				i++
+			} else {
+				args = append(args, opt)
+			}
 		}
 	}
 	return args
+}
+
+// getPhases returns the command's inheritance hierarchy in increasing order of
+// precedence.
+//
+// Examples:
+//
+//     getPhases("run")      // {"common", "build", "run"}
+//     getPhases("coverage") // {"common", "build", "test", "coverage"}
+func getPhases(command string) (out []string) {
+	for {
+		if command == "" {
+			out = append(out, "common")
+			break
+		}
+		out = append(out, command)
+		command = parentCommand[command]
+	}
+	reverse(out)
+	return
+}
+
+func reverse(a []string) {
+	for i := 0; i < len(a)/2; i++ {
+		j := len(a) - i - 1
+		a[i], a[j] = a[j], a[i]
+	}
+}
+
+func concat(slices ...[]string) []string {
+	length := 0
+	for _, s := range slices {
+		length += len(s)
+	}
+	out := make([]string, 0, length)
+	for _, s := range slices {
+		out = append(out, s...)
+	}
+	return out
 }

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -1,0 +1,114 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	log.Configure([]string{"--verbose=1"})
+}
+
+func TestParseBazelrc_Basic(t *testing.T) {
+	ws := testfs.MakeTempDir(t)
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		"WORKSPACE": "",
+		".bazelrc": `
+
+# COMMENT
+#ANOTHER COMMENT
+#
+
+# continuations are allowed \
+--this_is_not_a_flag_since_it_is_part_of_the_previous_line
+
+--common_global_flag_1          # trailing comments are allowed
+common --common_global_flag_2
+common:foo --config_foo_global_flag
+common:bar --config_bar_global_flag
+
+build --build_flag_1
+build:foo --build_config_foo_flag
+
+# Should be able to refer to the "forward_ref" config even though
+# it comes later on in the file
+build:foo --config=forward_ref
+
+build:foo --build_config_foo_multi_1 --build_config_foo_multi_2
+
+build:forward_ref --build_config_forward_ref_flag
+
+build:bar --build_config_bar_flag
+`,
+	})
+
+	for _, tc := range []struct {
+		args                 []string
+		expectedExpandedArgs []string
+	}{
+		{
+			[]string{"query"},
+			[]string{
+				"query",
+				"--common_global_flag_1",
+				"--common_global_flag_2",
+			},
+		},
+		{
+			[]string{"build"},
+			[]string{
+				"build",
+				"--common_global_flag_1",
+				"--common_global_flag_2",
+				"--build_flag_1",
+			},
+		},
+		{
+			[]string{"build", "--explicit_flag"},
+			[]string{
+				"build",
+				"--common_global_flag_1",
+				"--common_global_flag_2",
+				"--build_flag_1",
+				"--explicit_flag",
+			},
+		},
+		{
+			[]string{"build", "--config=foo"},
+			[]string{
+				"build",
+				"--common_global_flag_1",
+				"--common_global_flag_2",
+				"--build_flag_1",
+				"--config_foo_global_flag",
+				"--build_config_foo_flag",
+				"--build_config_forward_ref_flag",
+				"--build_config_foo_multi_1",
+				"--build_config_foo_multi_2",
+			},
+		},
+		{
+			[]string{"build", "--config=foo", "--config", "bar"},
+			[]string{
+				"build",
+				"--common_global_flag_1",
+				"--common_global_flag_2",
+				"--build_flag_1",
+				"--config_foo_global_flag",
+				"--build_config_foo_flag",
+				"--build_config_forward_ref_flag",
+				"--build_config_foo_multi_1",
+				"--build_config_foo_multi_2",
+				"--config_bar_global_flag",
+				"--build_config_bar_flag",
+			},
+		},
+	} {
+		expandedArgs := expandConfigs(ws, tc.args)
+
+		assert.Equal(t, tc.expectedExpandedArgs, expandedArgs)
+	}
+}


### PR DESCRIPTION
* Expand --config args in place instead of appending them and then later trying to remove the args which were expanded from those configs
* Fix various bugs w/ bazelrc parsing logic, precedence etc.
* TODO in a future PR: add some build_metadata (maybe?) that tells BB what the original command line was before we expanded configs in place, so we can show a nicer "explicit command line" in the UI

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
