### PR TITLE
local split

### DIFF
--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -51,7 +51,7 @@ var (
 	join                = flagutil.New("cache.raft.join", []string{}, "The list of nodes to use when joining clusters Ex. '1.2.3.4:1991,2.3.4.5:1991...'")
 	httpAddr            = flag.String("cache.raft.http_addr", "", "The address to listen for HTTP raft traffic. Ex. '1992'")
 	gRPCAddr            = flag.String("cache.raft.grpc_addr", "", "The address to listen for internal API traffic on. Ex. '1993'")
-	clearCacheOnStartup = flag.Bool("cache.raft.clear_cache_on_startup", true, "If set, remove all raft + cache data on start")
+	clearCacheOnStartup = flag.Bool("cache.raft.clear_cache_on_startup", false, "If set, remove all raft + cache data on start")
 	testMode            = flag.Bool("cache.raft.test_mode", true, "If set, use driver TestingOpts to split sooner / faster")
 )
 

--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -51,8 +51,8 @@ var (
 	join                = flagutil.New("cache.raft.join", []string{}, "The list of nodes to use when joining clusters Ex. '1.2.3.4:1991,2.3.4.5:1991...'")
 	httpAddr            = flag.String("cache.raft.http_addr", "", "The address to listen for HTTP raft traffic. Ex. '1992'")
 	gRPCAddr            = flag.String("cache.raft.grpc_addr", "", "The address to listen for internal API traffic on. Ex. '1993'")
-	clearCacheOnStartup = flag.Bool("cache.raft.clear_cache_on_startup", false, "If set, remove all raft + cache data on start")
-	testMode            = flag.Bool("cache.raft.test_mode", false, "If set, use driver TestingOpts to split sooner / faster")
+	clearCacheOnStartup = flag.Bool("cache.raft.clear_cache_on_startup", true, "If set, remove all raft + cache data on start")
+	testMode            = flag.Bool("cache.raft.test_mode", true, "If set, use driver TestingOpts to split sooner / faster")
 )
 
 const (

--- a/enterprise/server/raft/driver/driver.go
+++ b/enterprise/server/raft/driver/driver.go
@@ -24,7 +24,6 @@ import (
 )
 
 var (
-	enableSplittingReplicas = flag.Bool("cache.raft.enable_splitting_replicas", true, "If set, allow splitting oversize replicas")
 	enableMovingReplicas    = flag.Bool("cache.raft.enable_moving_replicas", false, "If set, allow moving replicas between nodes")
 	enableReplacingReplicas = flag.Bool("cache.raft.enable_replacing_replicas", false, "If set, allow replacing dead / down replicas")
 )
@@ -39,9 +38,6 @@ const (
 
 	// Attempt to reconcile / manage clusters after this period.
 	defaultManagePeriod = 60 * time.Second
-
-	// Split replicas after they reach this size.
-	defaultMaxReplicaSizeBytes = 1e9 // 1GB
 
 	// A node must have this * idealReplicaCount number of replicas to be
 	// eligible for moving a replica to another node.
@@ -60,10 +56,6 @@ type Opts struct {
 	// ManagePeriod is how often to attempt to re-spawn, clean-up, or
 	// split dead or oversize replicas / clusters.
 	ManagePeriod time.Duration
-
-	// The maximum size a replica may be before it's considered overloaded
-	// and is split.
-	MaxReplicaSizeBytes int64
 }
 
 // make a replica struct that can be used as a map key because protos cannot be.
@@ -248,28 +240,6 @@ func (cm *clusterMap) DeadReplicas(myClusters uint64Set, timeout time.Duration) 
 	return dead
 }
 
-// OverloadedReplicas returns a slice of replicaStructs that:
-//   - Are members of clusters this node manages
-//   - Report sizes greater than `maxSizeBytes`
-func (cm *clusterMap) OverloadedReplicas(myClusters uint64Set, maxSizeBytes int64) replicaSet {
-	cm.mu.RLock()
-	defer cm.mu.RUnlock()
-
-	overloaded := make(replicaSet, 0)
-	for rs, observation := range cm.observations {
-		if !myClusters.Contains(rs.clusterID) {
-			// Skip clusters that this node does not hold the lease
-			// for.
-			continue
-		}
-		if observation.sizeBytes > maxSizeBytes {
-			overloaded.Add(rs)
-		}
-		// TODO(tylerw): also split if QPS > 1000.
-	}
-	return overloaded
-}
-
 func (cm *clusterMap) idealReplicaCount() float64 {
 	totalNumReplicas := len(cm.observations)
 	numNodes := len(cm.nodeReplicas)
@@ -384,19 +354,17 @@ func (cm *clusterMap) FitScore(potentialMoves ...moveInstruction) float64 {
 
 func DefaultOpts() Opts {
 	return Opts{
-		ReplicaTimeout:      defaultReplicaTimeout,
-		BroadcastPeriod:     defaultBroadcastPeriod,
-		ManagePeriod:        defaultManagePeriod,
-		MaxReplicaSizeBytes: defaultMaxReplicaSizeBytes,
+		ReplicaTimeout:  defaultReplicaTimeout,
+		BroadcastPeriod: defaultBroadcastPeriod,
+		ManagePeriod:    defaultManagePeriod,
 	}
 }
 
 func TestingOpts() Opts {
 	return Opts{
-		ReplicaTimeout:      5 * time.Second,
-		BroadcastPeriod:     2 * time.Second,
-		ManagePeriod:        5 * time.Second,
-		MaxReplicaSizeBytes: 10 * 1e6, // 10MB
+		ReplicaTimeout:  5 * time.Second,
+		BroadcastPeriod: 2 * time.Second,
+		ManagePeriod:    5 * time.Second,
 	}
 }
 
@@ -631,9 +599,6 @@ func (d *Driver) computeState(ctx context.Context) (*clusterState, error) {
 }
 
 type clusterChanges struct {
-	// split these
-	overloadedReplicas replicaSet
-
 	// replace these
 	deadReplicas replicaSet
 
@@ -643,9 +608,8 @@ type clusterChanges struct {
 
 func (d *Driver) proposeChanges(state *clusterState) *clusterChanges {
 	changes := &clusterChanges{
-		overloadedReplicas: d.clusterMap.OverloadedReplicas(state.myClusters, d.opts.MaxReplicaSizeBytes),
-		deadReplicas:       d.clusterMap.DeadReplicas(state.myClusters, d.opts.ReplicaTimeout),
-		moveableReplicas:   d.clusterMap.MoveableReplicas(state.myClusters, state.myNodes, state.node.GetNhid()),
+		deadReplicas:     d.clusterMap.DeadReplicas(state.myClusters, d.opts.ReplicaTimeout),
+		moveableReplicas: d.clusterMap.MoveableReplicas(state.myClusters, state.myNodes, state.node.GetNhid()),
 	}
 	return changes
 }
@@ -717,33 +681,6 @@ func (d *Driver) applyMove(ctx context.Context, move moveInstruction, state *clu
 
 // modifyCluster applies `changes` to the cluster when possible.
 func (d *Driver) modifyCluster(ctx context.Context, state *clusterState, changes *clusterChanges) error {
-	// Splits are going to happen before anything else.
-	if *enableSplittingReplicas {
-		overloadedClusters := make(map[uint64]struct{})
-		for rs, _ := range changes.overloadedReplicas {
-			overloadedClusters[rs.clusterID] = struct{}{}
-		}
-		for clusterID := range overloadedClusters {
-			rd, ok := state.managedRanges[clusterID]
-			if !ok {
-				continue
-			}
-			_, err := d.store.SplitCluster(ctx, &rfpb.SplitClusterRequest{
-				Header: state.GetHeader(clusterID),
-				Range:  rd,
-			})
-			if err != nil {
-				log.Warningf("Error splitting cluster: %s", err)
-			} else {
-				log.Infof("Successfully split %+v", rd)
-			}
-			time.Sleep(10 * time.Second)
-			if err := d.updateState(ctx, state); err != nil {
-				return err
-			}
-		}
-	}
-
 	if *enableReplacingReplicas {
 		requiredMoves := d.makeMoveInstructions(changes.deadReplicas)
 		for _, move := range requiredMoves {
@@ -802,7 +739,7 @@ func (d *Driver) manageClusters() error {
 	log.Printf("cluster map:\n%s", d.clusterMap.String())
 
 	changes := d.proposeChanges(state)
-	s := len(changes.overloadedReplicas) + len(changes.deadReplicas) + len(changes.moveableReplicas)
+	s := len(changes.deadReplicas) + len(changes.moveableReplicas)
 	if s == 0 {
 		return nil
 	}
@@ -825,12 +762,6 @@ func (d *Driver) Statusz(ctx context.Context) string {
 	buf += fmt.Sprintf("cluster map:\n%s\n", d.clusterMap.String())
 	changes := d.proposeChanges(state)
 
-	if len(changes.overloadedReplicas) > 0 {
-		buf += "Overloaded Replicas:\n"
-		for rep, _ := range changes.overloadedReplicas {
-			buf += fmt.Sprintf("\tc%dn%d\n", rep.clusterID, rep.nodeID)
-		}
-	}
 	if len(changes.deadReplicas) > 0 {
 		buf += "Dead Replicas:\n"
 		for rep, _ := range changes.deadReplicas {

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1226,7 +1226,6 @@ func (sm *Replica) Update(entries []dbsm.Entry) ([]dbsm.Entry, error) {
 			sm.log.Warningf("Error computing usage: %s", err)
 		} else {
 			if usage.GetEstimatedDiskBytesUsed() > *replicaSplitSizeBytes {
-				sm.log.Warningf("Requesting split")
 				sm.store.RequestSplit(sm.ClusterID)
 			}
 			sm.lastUsageCheckIndex = sm.lastAppliedIndex

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -48,6 +48,7 @@ func (fs *fakeStore) GetReplica(rangeID uint64) (*replica.Replica, error) {
 func (fs *fakeStore) Sender() *sender.Sender {
 	return nil
 }
+func (fs *fakeStore) RequestSplit(clusterID uint64) {}
 func (fs *fakeStore) WithFileReadFn(fn fileReadFn) *fakeStore {
 	fs.fileReadFn = fn
 	return fs

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -41,6 +41,7 @@ go_library(
         "@org_golang_google_grpc//reflection",
         "@org_golang_google_protobuf//encoding/prototext",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -216,8 +216,6 @@ func (s *Store) handleSplits(quitChan <-chan struct{}) error {
 			cancel()
 			if err != nil {
 				s.log.Warningf("Error splitting cluster: %s", err)
-			} else {
-				s.log.Infof("Split cluster succeeded: %+v", rsp)
 			}
 		}
 	}

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -212,7 +212,7 @@ func (s *Store) handleSplits(quitChan <-chan struct{}) error {
 				Range: rd,
 			}
 			ctx, cancel := context.WithTimeout(context.TODO(), 60*time.Second)
-			rsp, err := s.SplitCluster(ctx, req)
+			_, err := s.SplitCluster(ctx, req)
 			cancel()
 			if err != nil {
 				s.log.Warningf("Error splitting cluster: %s", err)

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"net"
@@ -35,6 +36,7 @@ import (
 	"github.com/hashicorp/serf/serf"
 	"github.com/lni/dragonboat/v3"
 	"github.com/lni/dragonboat/v3/raftio"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/protobuf/encoding/prototext"
@@ -53,6 +55,12 @@ const (
 	// If a node's disk is fuller than this (by percentage), it is not
 	// eligible to receive ranges moved from other nodes.
 	maximumDiskCapacity = .95
+
+	splitQueueSize = 100
+)
+
+var (
+	enableSplittingReplicas = flag.Bool("cache.raft.enable_splitting_replicas", true, "If set, allow splitting oversize replicas")
 )
 
 type Store struct {
@@ -79,6 +87,9 @@ type Store struct {
 
 	fileStorer filestore.Store
 	splitMu    sync.Mutex
+	splitQueue chan *rfpb.RangeDescriptor
+	eg         *errgroup.Group
+	quitChan   chan struct{}
 }
 
 func New(rootDir string, nodeHost *dragonboat.NodeHost, gossipManager *gossip.GossipManager, sender *sender.Sender, registry registry.NodeRegistry, apiClient *client.APIClient) *Store {
@@ -103,7 +114,9 @@ func New(rootDir string, nodeHost *dragonboat.NodeHost, gossipManager *gossip.Go
 			IsolateByGroupIDs:           true,
 			PrioritizeHashInMetadataKey: true,
 		}),
-		splitMu: sync.Mutex{},
+		splitMu:    sync.Mutex{},
+		splitQueue: make(chan *rfpb.RangeDescriptor, splitQueueSize),
+		eg:         &errgroup.Group{},
 	}
 	s.leaderUpdatedCB = listener.LeaderCB(s.onLeaderUpdated)
 	gossipManager.AddListener(s)
@@ -165,7 +178,54 @@ func (s *Store) onLeaderUpdated(info raftio.LeaderInfo) {
 	go s.maybeAcquireRangeLease(rd)
 }
 
+func (s *Store) RequestSplit(clusterID uint64) {
+	rd := s.lookupRange(clusterID)
+	if rd == nil {
+		return
+	}
+	header := &rfpb.Header{
+		RangeId:    rd.GetRangeId(),
+		Generation: rd.GetGeneration(),
+	}
+	if _, err := s.LeasedRange(header); err != nil {
+		return
+	}
+	select {
+	case s.splitQueue <- rd:
+		break
+	default:
+		s.log.Warningf("Split queue was full; dropping request to split cluster %d.", clusterID)
+	}
+}
+
+func (s *Store) handleSplits(quitChan <-chan struct{}) error {
+	for {
+		select {
+		case <-quitChan:
+			return nil
+		case rd := <-s.splitQueue:
+			req := &rfpb.SplitClusterRequest{
+				Header: &rfpb.Header{
+					RangeId:    rd.GetRangeId(),
+					Generation: rd.GetGeneration(),
+				},
+				Range: rd,
+			}
+			ctx, cancel := context.WithTimeout(context.TODO(), 60*time.Second)
+			rsp, err := s.SplitCluster(ctx, req)
+			cancel()
+			if err != nil {
+				s.log.Warningf("Error splitting cluster: %s", err)
+			} else {
+				s.log.Infof("Split cluster succeeded: %+v", rsp)
+			}
+		}
+	}
+}
+
 func (s *Store) Start(grpcAddress string) error {
+	s.quitChan = make(chan struct{}, 0)
+
 	// A grpcServer is run which is responsible for presenting a meta API
 	// to manage raft nodes on each host, as well as an API to shuffle data
 	// around between nodes, outside of raft.
@@ -182,10 +242,21 @@ func (s *Store) Start(grpcAddress string) error {
 		s.grpcServer.Serve(lis)
 	}()
 	s.grpcAddr = grpcAddress
+
+	s.eg.Go(func() error {
+		return s.handleSplits(s.quitChan)
+	})
+
 	return nil
 }
 
 func (s *Store) Stop(ctx context.Context) error {
+	close(s.quitChan)
+	if err := s.eg.Wait(); err != nil {
+		return err
+	}
+	s.log.Info("Store: waitgroups finished")
+
 	listener.DefaultListener().UnregisterLeaderUpdatedCB(&s.leaderUpdatedCB)
 	return grpc_server.GRPCShutdown(ctx, s.grpcServer)
 }
@@ -884,6 +955,10 @@ func casRevert(cas *rfpb.CASRequest) *rfpb.CASRequest {
 //   new endpoints.
 // 6) The split range is unlocked.
 func (s *Store) SplitCluster(ctx context.Context, req *rfpb.SplitClusterRequest) (*rfpb.SplitClusterResponse, error) {
+	if !*enableSplittingReplicas {
+		return nil, status.FailedPreconditionError("Splitting not enabled")
+	}
+
 	s.splitMu.Lock()
 	defer s.splitMu.Unlock()
 

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -452,6 +452,7 @@ message SplitClusterRequest {
   Header header = 1;
   RangeDescriptor range = 2;
 }
+
 message SplitClusterResponse {
   RangeDescriptor left = 1;
   RangeDescriptor right = 2;


### PR DESCRIPTION
This change moves the split triggering logic out of the driver and into the store + replica. Replicas periodically check their own usage and when it is over a certain size, they request a split from the store. This change simplifies things and also reduces the time it takes for a range to split when over size. It also reduces the load on the gossip network since the store no longer needs to "poll" so aggressively to catch size changes, instead they are driven by replicas increasing in size. 

