### PR TITLE
CLI: Fix more bazelrc parsing bugs

### DIFF
--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -81,7 +81,10 @@ func run() (exitCode int, err error) {
 	// UI. Need to find a way to override the explicit command line in the UI so
 	// that it reflects the args passed to the CLI, not the wrapped Bazel
 	// process.
-	args = parser.ExpandConfigs(bazelArgs)
+	args, err = parser.ExpandConfigs(bazelArgs)
+	if err != nil {
+		return -1, err
+	}
 
 	// Fiddle with args
 	// TODO(bduffany): model these as "built-in" plugins

--- a/cli/parser/BUILD
+++ b/cli/parser/BUILD
@@ -20,5 +20,6 @@ go_test(
         "//cli/log",
         "//server/testutil/testfs",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -15,12 +16,16 @@ func init() {
 func TestParseBazelrc_Basic(t *testing.T) {
 	ws := testfs.MakeTempDir(t)
 	testfs.WriteAllFileContents(t, ws, map[string]string{
-		"WORKSPACE": "",
+		"WORKSPACE":      "",
+		"import.bazelrc": "",
 		".bazelrc": `
 
 # COMMENT
 #ANOTHER COMMENT
 #
+
+startup --startup_flag_1
+startup:config --startup_configs_are_not_supported_so_this_flag_should_be_ignored
 
 # continuations are allowed \
 --this_is_not_a_flag_since_it_is_part_of_the_previous_line
@@ -42,6 +47,11 @@ build:foo --build_config_foo_multi_1 --build_config_foo_multi_2
 build:forward_ref --build_config_forward_ref_flag
 
 build:bar --build_config_bar_flag
+
+test --config=bar
+
+import     %workspace%/import.bazelrc
+try-import %workspace%/NONEXISTENT.bazelrc
 `,
 	})
 
@@ -52,6 +62,17 @@ build:bar --build_config_bar_flag
 		{
 			[]string{"query"},
 			[]string{
+				"--startup_flag_1",
+				"query",
+				"--common_global_flag_1",
+				"--common_global_flag_2",
+			},
+		},
+		{
+			[]string{"--explicit_startup_flag", "query"},
+			[]string{
+				"--startup_flag_1",
+				"--explicit_startup_flag",
 				"query",
 				"--common_global_flag_1",
 				"--common_global_flag_2",
@@ -60,6 +81,7 @@ build:bar --build_config_bar_flag
 		{
 			[]string{"build"},
 			[]string{
+				"--startup_flag_1",
 				"build",
 				"--common_global_flag_1",
 				"--common_global_flag_2",
@@ -69,6 +91,7 @@ build:bar --build_config_bar_flag
 		{
 			[]string{"build", "--explicit_flag"},
 			[]string{
+				"--startup_flag_1",
 				"build",
 				"--common_global_flag_1",
 				"--common_global_flag_2",
@@ -79,6 +102,7 @@ build:bar --build_config_bar_flag
 		{
 			[]string{"build", "--config=foo"},
 			[]string{
+				"--startup_flag_1",
 				"build",
 				"--common_global_flag_1",
 				"--common_global_flag_2",
@@ -93,6 +117,7 @@ build:bar --build_config_bar_flag
 		{
 			[]string{"build", "--config=foo", "--config", "bar"},
 			[]string{
+				"--startup_flag_1",
 				"build",
 				"--common_global_flag_1",
 				"--common_global_flag_2",
@@ -106,9 +131,62 @@ build:bar --build_config_bar_flag
 				"--build_config_bar_flag",
 			},
 		},
+		{
+			[]string{"test"},
+			[]string{
+				"--startup_flag_1",
+				"test",
+				"--common_global_flag_1",
+				"--common_global_flag_2",
+				"--build_flag_1",
+				"--config_bar_global_flag",
+				"--build_config_bar_flag",
+			},
+		},
 	} {
-		expandedArgs := expandConfigs(ws, tc.args)
+		expandedArgs, err := expandConfigs(ws, tc.args)
 
+		require.NoError(t, err, "error expanding %s", tc.args)
 		assert.Equal(t, tc.expectedExpandedArgs, expandedArgs)
 	}
+}
+
+func TestParseBazelrc_CircularConfigReference(t *testing.T) {
+	ws := testfs.MakeTempDir(t)
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		"WORKSPACE": "",
+		".bazelrc": `
+build:a --config=b
+build:b --config=c
+build:c --config=a
+
+build:d --config=d
+`,
+	})
+
+	_, err := expandConfigs(ws, []string{"build", "--config=a"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "circular --config reference detected: a -> b -> c -> a")
+
+	_, err = expandConfigs(ws, []string{"build", "--config=d"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "circular --config reference detected: d -> d")
+}
+
+func TestParseBazelrc_CircularImport(t *testing.T) {
+	ws := testfs.MakeTempDir(t)
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		"WORKSPACE": "",
+		".bazelrc":  `import %workspace%/a.bazelrc`,
+		"a.bazelrc": `import %workspace%/b.bazelrc`,
+		"b.bazelrc": `import %workspace%/a.bazelrc`,
+	})
+
+	_, err := expandConfigs(ws, []string{"build"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "circular import detected:")
+
+	_, err = expandConfigs(ws, []string{"build"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "circular import detected:")
 }


### PR DESCRIPTION
* Expand `startup` options
* Fix bug where `--config` flags specified in higher-precedence phases wouldn't expand configs defined for phases they inherit from.
  * Example: If bazelrc contains the lines `build:foo --some_flag` and `test --config=foo`, we now correctly get `--some_flag` when running `bazel test`
* Fix bug that `%workspace%` was resolved to the current working directory rather than the workspace directory
* Detect circular config file references instead of panicking with a stack overflow error
* Detect circular imports instead of panicking with a stack overflow error

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
