### PR TITLE
CLI: Add a plugin to get notified when a build completes

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -55,5 +55,6 @@ actions:
 plugins:
   - path: cli/plugins/go_deps
   - path: cli/plugins/open_invocation
+  - path: cli/plugins/notify
   - path: cli/example_plugins/go_highlight
   - path: cli/example_plugins/ping_remote

--- a/cli/plugins/notify/README.md
+++ b/cli/plugins/notify/README.md
@@ -1,0 +1,14 @@
+# notify
+
+The notify plugin sends you desktop notifications when your build is
+complete. This is useful for long-running builds that you don't want to
+continually monitor, such as release builds.
+
+To use it, pass the `--notify` argument to the CLI or set the `BB_NOTIFY=1`
+environment variable.
+
+To enable sound (currently macOS only), set the environment variable
+`BB_NOTIFY_SOUND=1`. You can change the sound by setting
+`BB_NOTIFY_SOUND_NAME` to one of the sound file names from
+`/System/Library/Sounds`, excluding the file extension. Example:
+`BB_NOTIFY_SOUND_NAME=Funk`.

--- a/cli/plugins/notify/post_bazel.sh
+++ b/cli/plugins/notify/post_bazel.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -eu
+
+: "${BB_NOTIFY_SOUND=0}"
+: "${BB_NOTIFY_SOUND_NAME=Tink}"
+
+# Check for the file written by pre_bazel.
+if ! [[ -e "$PLUGIN_TEMPDIR/notify" ]]; then
+  exit 0
+fi
+
+STATUS_LINE=$(grep "Build" "$1" | grep "complete" | tail -n1 | perl -p -e 's@.*?(Build)@\1@')
+ELAPSED_TIME_LINE=$(grep "Elapsed time" "$1" | tail -n1 | perl -p -e 's@.*?(Elapsed)@\1@')
+
+TITLE="Bazel build finished"
+MESSAGE="${ELAPSED_TIME_LINE}\n${STATUS_LINE}"
+
+if [[ "$OSTYPE" == darwin* ]]; then
+  SCRIPT="display notification \"$MESSAGE\" with title \"$TITLE\""
+
+  if ((BB_NOTIFY_SOUND)); then
+    SCRIPT+=" sound name \"$BB_NOTIFY_SOUND_NAME\""
+  fi
+
+  osascript -e "$SCRIPT"
+  exit 0
+fi
+
+notify-send --expire-time 3000 "$TITLE" "$MESSAGE"

--- a/cli/plugins/notify/pre_bazel.py
+++ b/cli/plugins/notify/pre_bazel.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import time
+
+if __name__ == "__main__":
+    with open(sys.argv[1], 'r') as args_file:
+        arg_lines = args_file.readlines()
+
+    enabled_via_env_var = os.environ.get('BB_NOTIFY', '0') in ('1', 'true')
+    if '--notify\n' not in arg_lines and not enabled_via_env_var:
+        exit(0)
+    # Consume --notify arg if it exists
+    arg_lines = [line for line in arg_lines if line != '--notify\n']
+    with open(sys.argv[1], 'w') as args_file:
+        args_file.writelines(arg_lines)
+
+    # Create the file "${PLUGIN_TEMPDIR}/notify" to inform the post_bazel hook
+    # that notifications are enabled for this invocation.
+    with open(os.path.join(os.environ['PLUGIN_TEMPDIR'], 'notify'), 'w') as f:
+        pass

--- a/cli/plugins/notify/pre_bazel.sh
+++ b/cli/plugins/notify/pre_bazel.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+if ! which python3 &>/dev/null; then
+  echo -e "\x1b[33mWarning: notify plugin is disabled: missing 'python3' in \$PATH\x1b[m" >&2
+  exit 0
+fi
+if [[ "$OSTYPE" == darwin* ]] && ! which osascript &>/dev/null; then
+  echo -e "\x1b[33mWarning: notify plugin is disabled: missing 'osascript' in \$PATH\x1b[m" >&2
+  exit 0
+elif [[ "$OSTYPE" == linux* ]] && ! which notify-send &>/dev/null; then
+  echo -e "\x1b[33mWarning: notify plugin is disabled: missing 'notify-send' in \$PATH\x1b[m" >&2
+  exit 0
+fi
+
+exec python3 ./pre_bazel.py "$@"


### PR DESCRIPTION
Allows passing a `--notify` flag that shows a desktop notification when the build completes. On macOS, notifications can also optionally show a sound (by setting the env var `BB_NOTIFY_SOUND=1`).

![image (10)](https://user-images.githubusercontent.com/2414826/200632107-e03bcb52-3d93-412c-98fe-7a26979bae60.png)


---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
