### PR TITLE
CLI: Support user-level plugins

### DIFF
--- a/cli/plugin/BUILD
+++ b/cli/plugin/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "plugin",
@@ -15,5 +15,17 @@ go_library(
         "//server/util/status",
         "@com_github_creack_pty//:pty",
         "@in_gopkg_yaml_v2//:yaml_v2",
+    ],
+)
+
+go_test(
+    name = "plugin_test",
+    srcs = ["plugin_test.go"],
+    embed = [":plugin"],
+    deps = [
+        "//cli/log",
+        "//cli/workspace",
+        "//server/testutil/testfs",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/cli/plugin/plugin_test.go
+++ b/cli/plugin/plugin_test.go
@@ -1,0 +1,173 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
+	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	log.Configure([]string{"--verbose=1"})
+}
+
+func TestGetConfiguredPlugins_CombinesUserAndWorkspaceConfigs(t *testing.T) {
+	ws, home := setup(t)
+	testfs.WriteAllFileContents(t, home, map[string]string{
+		"a/.empty": "",
+		"b/.empty": "",
+		"buildbuddy.yaml": `
+plugins:
+  - path: ./a
+  - path: ./b
+  - repo: foo/bar@v1.0
+  - repo: foo/bar@v1.0
+    path: ./foobar_subdir1
+`,
+	})
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		"a/.empty": "",
+		"b/.empty": "",
+		"buildbuddy.yaml": `
+plugins:
+  - path: ./a
+  - path: ./b
+  - repo: foo/bar@v2.0
+  - repo: foo/bar@v2.0
+    path: foobar_subdir2
+`,
+	})
+	setTestHomeDir(t, home)
+
+	plugins, err := getConfiguredPlugins(ws)
+
+	require.NoError(t, err)
+	var ids []string
+	for _, p := range plugins {
+		id, err := p.VersionedID()
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
+	expectedIDs := []string{
+		filepath.Join(home, "a"),
+		filepath.Join(home, "b"),
+		// Note: foo/bar@v1.0 should not be included since the workspace
+		// buildbuddy.yaml includes a version override with v2.0
+
+		// repo_subdir1 should be included since the home buildbuddy.yaml
+		// doesn't include a specific override for that path:
+		"https://github.com/foo/bar@v1.0:foobar_subdir1",
+		filepath.Join(ws, "a"),
+		filepath.Join(ws, "b"),
+		"https://github.com/foo/bar@v2.0",
+		"https://github.com/foo/bar@v2.0:foobar_subdir2",
+	}
+	require.Equal(t, expectedIDs, ids)
+}
+
+func TestInstall_ToWorkspaceConfig_LocalAbsolutePath_CreateNewConfig(t *testing.T) {
+	ws, _ := setup(t)
+	pluginDir := testfs.MakeDirAll(t, ws, "test-plugin")
+
+	exitCode, err := HandleInstall([]string{"install", "--path=" + pluginDir})
+
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+
+	config := testfs.ReadFileAsString(t, ws, "buildbuddy.yaml")
+	expectedConfig := `plugins:
+  - path: ` + pluginDir + `
+`
+	require.Equal(t, expectedConfig, config)
+}
+
+func TestInstall_ToWorkspaceConfig_LocalRelativePath_CreateNewConfig(t *testing.T) {
+	ws, _ := setup(t)
+	testfs.MakeDirAll(t, ws, "test-plugin")
+
+	exitCode, err := HandleInstall([]string{"install", "--path=./test-plugin"})
+
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+
+	config := testfs.ReadFileAsString(t, ws, "buildbuddy.yaml")
+	expectedConfig := `plugins:
+  - path: ./test-plugin
+`
+	require.Equal(t, expectedConfig, config)
+}
+
+func TestInstall_ToWorkspaceConfig_OverwriteExistingConfig(t *testing.T) {
+	ws, _ := setup(t)
+	testfs.MakeDirAll(t, ws, "test-plugin-1")
+	testfs.MakeDirAll(t, ws, "test-plugin-2")
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		"buildbuddy.yaml": `plugins:
+  - path: ./test-plugin-1
+`,
+	})
+
+	exitCode, err := HandleInstall([]string{"install", "--path=./test-plugin-2"})
+
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+
+	config := testfs.ReadFileAsString(t, ws, "buildbuddy.yaml")
+	expectedConfig := `plugins:
+  - path: ./test-plugin-1
+  - path: ./test-plugin-2
+`
+	require.Equal(t, expectedConfig, config)
+}
+
+func TestInstall_ToUserConfig_CreateNewConfig(t *testing.T) {
+	_, home := setup(t)
+	testfs.MakeDirAll(t, home, "test-plugin")
+
+	exitCode, err := HandleInstall([]string{"install", "--path=./test-plugin", "--user"})
+
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+
+	config := testfs.ReadFileAsString(t, home, "buildbuddy.yaml")
+	expectedConfig := `plugins:
+  - path: ./test-plugin
+`
+	require.Equal(t, expectedConfig, config)
+}
+
+func setup(t *testing.T) (ws, home string) {
+	root := testfs.MakeTempDir(t)
+	ws = testfs.MakeDirAll(t, root, "workspace")
+	testfs.WriteAllFileContents(t, ws, map[string]string{"WORKSPACE": ""})
+	home = testfs.MakeDirAll(t, root, "home")
+
+	setTestHomeDir(t, home)
+	setTestWorkDir(t, ws)
+	workspace.SetForTest(ws)
+
+	return ws, home
+}
+
+func setTestWorkDir(t *testing.T, path string) {
+	original, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := os.Chdir(original)
+		require.NoError(t, err)
+	})
+}
+
+func setTestHomeDir(t *testing.T, path string) {
+	original := os.Getenv("HOME")
+	err := os.Setenv("HOME", path)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := os.Setenv("HOME", original)
+		require.NoError(t, err)
+	})
+}

--- a/cli/workspace/BUILD
+++ b/cli/workspace/BUILD
@@ -5,8 +5,5 @@ go_library(
     srcs = ["workspace.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/workspace",
     visibility = ["//visibility:public"],
-    deps = [
-        "//server/util/disk",
-        "//server/util/status",
-    ],
+    deps = ["//server/util/disk"],
 )

--- a/cli/workspace/workspace.go
+++ b/cli/workspace/workspace.go
@@ -2,12 +2,12 @@ package workspace
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
-	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
 
 var (
@@ -43,8 +43,14 @@ func path() (string, error) {
 		next := filepath.Dir(dir)
 		if dir == next {
 			// We've reached the root dir without finding a WORKSPACE file
-			return "", status.FailedPreconditionError("not within a bazel workspace (could not find WORKSPACE or WORKSPACE.bazel file)")
+			return "", fmt.Errorf("not within a bazel workspace (could not find WORKSPACE or WORKSPACE.bazel file)")
 		}
 		dir = next
 	}
+}
+
+// TODO: Take workspace dir as a param everywhere so that this isn't needed.
+func SetForTest(path string) {
+	_, _ = Path()
+	pathVal, pathErr = path, nil
 }


### PR DESCRIPTION
Adds support for a `--user` flag to `bb install` which installs plugins to `~/buildbuddy.yaml` instead of `./buildbuddy.yaml`.

We now also load plugins from both `~/buildbuddy.yaml` and `%workspace%/buildbuddy.yaml`. If there are duplicate plugins (same repo and path, but potentially different versions), we prefer the one in the workspace `buildbuddy.yaml`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
