### PR TITLE
Add cas tool option to get cache metadata

### DIFF
--- a/tools/cas/BUILD
+++ b/tools/cas/BUILD
@@ -6,7 +6,10 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/tools/cas",
     visibility = ["//visibility:private"],
     deps = [
+        "//proto:buildbuddy_service_go_proto",
+        "//proto:cache_go_proto",
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/util/grpc_client",


### PR DESCRIPTION
Pass `--metadata` to log the human-readable cache metadata just before fetching. Pass `--metadata_only` to fetch the cache metadata, print it as JSON to stdout, and exit -- useful for scripts that want to fetch the metadata and process it with something like `jq`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
