### PR TITLE
CLI: Allow specifying repo subdir with :path suffix

### DIFF
--- a/cli/plugin/BUILD
+++ b/cli/plugin/BUILD
@@ -26,6 +26,7 @@ go_test(
         "//cli/log",
         "//cli/workspace",
         "//server/testutil/testfs",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
Instead of `bb install buildbuddy-io/plugins --path=go_deps`, users can run `bb install buildbuddy-io/plugins:go_deps`

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
