### PR TITLE
CLI: Fix subcommand help

### DIFF
--- a/cli/help/BUILD
+++ b/cli/help/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//cli/arg",
         "//cli/bazelisk",
+        "//cli/parser",
         "//cli/version",
     ],
 )

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
+	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 	"github.com/buildbuddy-io/buildbuddy/cli/version"
 )
 
@@ -36,15 +37,17 @@ func HandleHelp(args []string) (exitCode int, err error) {
 		return showHelp("", getHelpModifiers(args))
 	}
 	if cmd == "help" {
-		// Get the subcommand (the string "build" in "bazel help build")
-		subcommand, _ := arg.GetCommandAndIndex(args[idx+1:])
-		return showHelp(subcommand, getHelpModifiers(args))
+		bazelCommand, _ := parser.GetBazelCommandAndIndex(args[idx+1:])
+		return showHelp(bazelCommand, getHelpModifiers(args))
 	}
 	if arg.ContainsExact(args, "-h") || arg.ContainsExact(args, "--help") {
-		// Assume cmd is the bazel subcommand if set.
-		// Bazel will show "ERROR: 'foo' is not a known command" if the
-		// subcommand is invalid.
-		return showHelp(cmd, getHelpModifiers(args))
+		bazelCommand, _ := parser.GetBazelCommandAndIndex(args)
+		// Sanity check to work around potential issues with
+		// GetBazelCommandAndIndex (see TODOs on that func).
+		if cmd != bazelCommand {
+			return -1, nil
+		}
+		return showHelp(bazelCommand, getHelpModifiers(args))
 	}
 	return -1, nil
 }

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -250,7 +250,7 @@ func expandConfigs(workspaceDir string, args []string) ([]string, error) {
 	}
 	args = append(startupArgs, args...)
 
-	command, commandIndex := getBazelCommandAndIndex(args)
+	command, commandIndex := GetBazelCommandAndIndex(args)
 	if commandIndex == -1 {
 		return args, nil
 	}
@@ -361,7 +361,7 @@ func isConfigDefined(rules *Rules, config string, phases []string) bool {
 }
 
 func consumeRCFileArgs(args []string, workspaceDir string) (newArgs []string, rcFiles []string, err error) {
-	_, idx := getBazelCommandAndIndex(args)
+	_, idx := GetBazelCommandAndIndex(args)
 	if idx == -1 {
 		return nil, nil, fmt.Errorf(`no command provided (run "%s help" to see available commands)`, os.Args[0])
 	}
@@ -458,7 +458,13 @@ func asStartupBoolFlag(arg, name string) (value, ok bool) {
 	return false, false
 }
 
-func getBazelCommandAndIndex(args []string) (string, int) {
+// TODO: Return an empty string if the subcommand happens to come after
+// a bb-specific command. For example, `bb install --path test` should
+// return an empty string, not "test".
+// TODO: More robust parsing of startup options. For example, this has a bug
+// that passing `bazel --output_base build test ...` returns "build" as the
+// bazel command, even though "build" is the argument to --output_base.
+func GetBazelCommandAndIndex(args []string) (string, int) {
 	for i, a := range args {
 		if _, ok := bazelCommands[a]; ok {
 			return a, i


### PR DESCRIPTION
Fix `bb install --help` not working.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
