### PR TITLE
CLI: Allow viewing sidecar debug logs

### DIFF
--- a/cli/sidecar/BUILD
+++ b/cli/sidecar/BUILD
@@ -12,5 +12,6 @@ go_library(
         "//cli/storage",
         "//proto:sidecar_go_proto",
         "//server/util/grpc_client",
+        "@com_github_google_shlex//:shlex",
     ],
 )


### PR DESCRIPTION
* The sidecar will now write its logs to a `.log` file next to its `.sock` file.
* Log level can be figured by running the CLI like `BB_SIDECAR_ARGS='--app.log_level=debug' bb run ...`

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
