### PR TITLE
CLI: Fix handling of sidecar backend args

### DIFF
--- a/cli/arg/BUILD
+++ b/cli/arg/BUILD
@@ -1,8 +1,15 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "arg",
     srcs = ["arg.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/arg",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "arg_test",
+    srcs = ["arg_test.go"],
+    embed = [":arg"],
+    deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -15,7 +15,7 @@ func Has(args []string, desiredArg string) bool {
 
 // Returns the value of the given desiredArg if contained in args
 func Get(args []string, desiredArg string) string {
-	arg, _, _ := Find(args, desiredArg)
+	arg, _, _ := FindLast(args, desiredArg)
 	return arg
 }
 
@@ -63,6 +63,22 @@ func Find(args []string, desiredArg string) (value string, index int, length int
 		}
 	}
 	return "", -1, 0
+}
+
+// FindLast returns the value corresponding to the last occurrence of the given
+// argument.
+func FindLast(args []string, desiredArg string) (value string, index int, length int) {
+	start := 0
+	lastValue, lastIndex, lastLength := "", -1, 0
+	for start < len(args) {
+		value, index, length := Find(args[start:], desiredArg)
+		if index == -1 {
+			break
+		}
+		lastValue, lastIndex, lastLength = value, start+index, length
+		start = start + index + length
+	}
+	return lastValue, lastIndex, lastLength
 }
 
 // Returns the first non-option found in the list of args (doesn't begin with "-")

--- a/cli/arg/arg_test.go
+++ b/cli/arg/arg_test.go
@@ -1,0 +1,46 @@
+package arg
+
+import (
+	"fmt"
+
+	"github.com/stretchr/testify/assert"
+)
+
+import "testing"
+
+func TestFindLast(t *testing.T) {
+	repr := func(val string, idx, length int) string {
+		return fmt.Sprintf("val=%q, idx=%d, len=%d", val, idx, length)
+	}
+
+	for _, tc := range []struct {
+		Args                          []string
+		ExpectedValue                 string
+		ExpectedIndex, ExpectedLength int
+	}{
+		{
+			[]string{"--foo=bar"},
+			"bar", 0, 1,
+		},
+		{
+			[]string{"--foo", "bar"},
+			"bar", 0, 2,
+		},
+		{
+			[]string{"--foo=bar", "--foo=baz"},
+			"baz", 1, 1,
+		},
+		{
+			[]string{"--foo=bar", "--foo", "baz"},
+			"baz", 1, 2,
+		},
+	} {
+		val, idx, length := FindLast(tc.Args, "foo")
+		assert.Equal(
+			t,
+			repr(tc.ExpectedValue, tc.ExpectedIndex, tc.ExpectedLength),
+			repr(val, idx, length),
+			"incorrect return value for %s", tc.Args,
+		)
+	}
+}

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -158,12 +158,10 @@ func ConfigureSidecar(args []string) []string {
 		return args
 	}
 	if besBackendFlag != "" {
-		_, rest := arg.Pop(args, "bes_backend")
-		args = append(rest, fmt.Sprintf("--bes_backend=unix://%s", sidecarSocket))
+		args = append(args, fmt.Sprintf("--bes_backend=unix://%s", sidecarSocket))
 	}
 	if remoteCacheFlag != "" && remoteExecFlag == "" {
-		_, rest := arg.Pop(args, "remote_cache")
-		args = append(rest, fmt.Sprintf("--remote_cache=unix://%s", sidecarSocket))
+		args = append(args, fmt.Sprintf("--remote_cache=unix://%s", sidecarSocket))
 	}
 	return args
 }


### PR DESCRIPTION
If there are multiple argument values of `bes_backend`, `remote_cache` etc, the last one should win.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
