### PR TITLE
Revert "Support Command.output_paths"

### DIFF
--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -65,31 +65,41 @@ type DirHelper struct {
 	// commands. (Parent dirs of requested outputs)
 	dirsToCreate []string
 
-	// The output paths that the client requested. Stored as a map for fast
-	// lookup.
-	outputPaths map[string]struct{}
+	outputDirs []string
 
 	// dirPerms are the permissions used when creating output directories.
 	dirPerms fs.FileMode
 }
 
-func NewDirHelper(rootDir string, outputPaths []string, dirPerms fs.FileMode) *DirHelper {
+func NewDirHelper(rootDir string, outputFiles, outputDirectories []string, dirPerms fs.FileMode) *DirHelper {
 	c := &DirHelper{
 		rootDir:      rootDir,
 		prefixes:     make(map[string]struct{}, 0),
 		fullPaths:    make(map[string]struct{}, 0),
 		dirsToCreate: make([]string, 0),
-		outputPaths:  make(map[string]struct{}, 0),
+		outputDirs:   make([]string, 0),
 		dirPerms:     dirPerms,
 	}
 
-	for _, outputPath := range outputPaths {
-		fullPath := filepath.Join(c.rootDir, outputPath)
+	for _, outputFile := range outputFiles {
+		fullPath := filepath.Join(c.rootDir, outputFile)
 		c.fullPaths[fullPath] = struct{}{}
 		c.dirsToCreate = append(c.dirsToCreate, filepath.Dir(fullPath))
-		c.outputPaths[fullPath] = struct{}{}
-		c.prefixes[fullPath] = struct{}{}
 	}
+	for _, outputDir := range outputDirectories {
+		fullPath := filepath.Join(c.rootDir, outputDir)
+		c.fullPaths[fullPath] = struct{}{}
+		c.dirsToCreate = append(c.dirsToCreate, fullPath)
+		c.outputDirs = append(c.outputDirs, fullPath)
+	}
+
+	// STOPSHIP(tylerw): Do we need an updated copy of the remote APIs proto?
+	// if outputPaths := command.GetOutputPaths(); len(outputPaths) > 0 {
+	// 	c.dirsToCreate = make([]string, 0)
+	// 	for _, outputPath :=  range outputPaths {
+	// 		c.dirsToCreate = append(c.dirsToCreate, filepath.Join(rootDir, filepath.Dir(outputPath)))
+	// 	}
+	// }
 
 	for _, dir := range c.dirsToCreate {
 		for p := dir; p != filepath.Dir(p); p = filepath.Dir(p) {
@@ -108,47 +118,38 @@ func (c *DirHelper) CreateOutputDirs() error {
 	}
 	return nil
 }
-
-func (c *DirHelper) IsOutputPath(path string) bool {
-	_, ok := c.outputPaths[path]
-	return ok
-}
-
-// If the provided path is a descendant of any of the output_paths, this
-// function returns which output_path it is a descendent of and true, otherwise
-// it returns an unspecified string and false.
-func (c *DirHelper) FindParentOutputPath(path string) (string, bool) {
-	for p := filepath.Dir(path); p != filepath.Dir(p); p = filepath.Dir(p) {
-		if c.IsOutputPath(p) {
-			return p, true
+func (c *DirHelper) MatchesOutputDir(path string) (string, bool) {
+	for _, d := range c.outputDirs {
+		for p := path; p != filepath.Dir(p); p = filepath.Dir(p) {
+			if p == d {
+				return d, true
+			}
 		}
 	}
 	return "", false
 }
-
-func (c *DirHelper) ShouldUploadAnythingInDir(path string) bool {
-	// Upload something in this directory if:
-	// 1. it is in output_paths
-	// 2. any of its children are in output_paths
-	// 3. it is a child of anything in output_paths
-	if c.IsOutputPath(path) {
+func (c *DirHelper) ShouldBeUploaded(path string) bool {
+	// a file is an output file
+	// a file is a prefix of an output file
+	// a file is an output directory or inside of one
+	if c.MatchesOutputFile(path) {
 		return true
 	}
-	_, ok := c.prefixes[path]
-	if ok {
+	if c.MatchesOutputFilePrefix(path) {
 		return true
 	}
-	return c.ShouldUploadFile(path)
-}
-
-func (c *DirHelper) ShouldUploadFile(path string) bool {
-	// Upload the file if it is a child of anything in output_paths
-	for p := path; p != filepath.Dir(p); p = filepath.Dir(p) {
-		if c.IsOutputPath(p) {
-			return true
-		}
+	if _, ok := c.MatchesOutputDir(path); ok {
+		return true
 	}
 	return false
+}
+func (c *DirHelper) MatchesOutputFilePrefix(path string) bool {
+	_, ok := c.prefixes[path]
+	return ok
+}
+func (c *DirHelper) MatchesOutputFile(path string) bool {
+	_, ok := c.fullPaths[path]
+	return ok
 }
 
 func trimPathPrefix(fullPath, prefix string) string {
@@ -273,7 +274,6 @@ func uploadFiles(ctx context.Context, env environment.Env, instanceName string, 
 func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, instanceName, rootDir string, actionResult *repb.ActionResult) (*TransferInfo, error) {
 	txInfo := &TransferInfo{}
 	startTime := time.Now()
-	treesToUpload := make([]string, 0)
 	filesToUpload := make([]*fileToUpload, 0)
 	uploadFileFn := func(parentDir string, info os.FileInfo) (*repb.FileNode, error) {
 		uploadableFile, err := newFileToUpload(instanceName, parentDir, info)
@@ -282,8 +282,8 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 		}
 		filesToUpload = append(filesToUpload, uploadableFile)
 		fqfn := filepath.Join(parentDir, info.Name())
-		if _, ok := dirHelper.FindParentOutputPath(fqfn); !ok {
-			// If this file is *not* a descendant of any output_path but wasn't
+		if _, ok := dirHelper.MatchesOutputDir(fqfn); !ok {
+			// If this file does *not* match an output dir but wasn't
 			// skipped before the call to uploadFileFn, then it must be
 			// appended to OutputFiles.
 			actionResult.OutputFiles = append(actionResult.OutputFiles, uploadableFile.OutputFile(rootDir))
@@ -312,11 +312,8 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 			fqfn := filepath.Join(fullPath, info.Name())
 			if info.Mode().IsDir() {
 				// Don't recurse on non-uploadable directories.
-				if !dirHelper.ShouldUploadAnythingInDir(fqfn) {
+				if !dirHelper.ShouldBeUploaded(fqfn) {
 					continue
-				}
-				if dirHelper.IsOutputPath(fqfn) {
-					treesToUpload = append(treesToUpload, fqfn)
 				}
 				dirNode, err := uploadDirFn(fullPath, info.Name())
 				if err != nil {
@@ -326,7 +323,7 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 				txInfo.BytesTransferred += dirNode.GetDigest().GetSizeBytes()
 				directory.Directories = append(directory.Directories, dirNode)
 			} else if info.Mode().IsRegular() {
-				if !dirHelper.ShouldUploadFile(fqfn) {
+				if !dirHelper.ShouldBeUploaded(fqfn) {
 					continue
 				}
 				fileNode, err := uploadFileFn(fullPath, info)
@@ -363,15 +360,11 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 		return nil, err
 	}
 
-	// Make Trees of all of the paths specified in output_paths which were
-	// directories (which we noted in the filesystem walk above).
 	trees := make(map[string]*repb.Tree, 0)
-	for _, treeToUpload := range treesToUpload {
-		trees[treeToUpload] = &repb.Tree{}
+	for _, outputDir := range dirHelper.outputDirs {
+		trees[outputDir] = &repb.Tree{}
 	}
 
-	// For each of the filesToUpload, determine which Tree (if any) it is a part
-	// of and add it.
 	for _, f := range filesToUpload {
 		if f.dir == nil {
 			continue
@@ -379,9 +372,11 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 		fqfn := f.fullFilePath
 		if tree, ok := trees[fqfn]; ok {
 			tree.Root = f.dir
-		} else if treePath, ok := dirHelper.FindParentOutputPath(fqfn); ok {
-			tree = trees[treePath]
-			tree.Children = append(tree.Children, f.dir)
+		} else {
+			if treePath, ok := dirHelper.MatchesOutputDir(fqfn); ok {
+				tree = trees[treePath]
+				tree.Children = append(tree.Children, f.dir)
+			}
 		}
 	}
 

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -102,11 +102,7 @@ func (ws *Workspace) SetTask(ctx context.Context, task *repb.ExecutionTask) {
 	log.CtxDebugf(ctx, "Assigned task %s to workspace at %q", task.GetExecutionId(), ws.rootDir)
 	ws.task = task
 	cmd := task.GetCommand()
-	outputPaths := cmd.GetOutputPaths()
-	if len(outputPaths) == 0 {
-		outputPaths = append(cmd.GetOutputFiles(), cmd.GetOutputDirectories()...)
-	}
-	ws.dirHelper = dirtools.NewDirHelper(ws.Path(), outputPaths, ws.dirPerms)
+	ws.dirHelper = dirtools.NewDirHelper(ws.Path(), cmd.GetOutputFiles(), cmd.GetOutputDirectories(), ws.dirPerms)
 }
 
 // CommandWorkingDirectory returns the absolute path to the working directory

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -548,10 +548,9 @@ func TestSimpleCommandWithPoolSelectionViaPlatformProp_Success(t *testing.T) {
 	opts := &rbetest.ExecuteOpts{}
 
 	cmd := rbe.Execute(&repb.Command{
-		Arguments: []string{"sh", "-c", strings.Join([]string{
-			`mkdir output_dir`,
-			`touch output.txt undeclared_output.txt output_dir/output.txt`,
-		}, "\n")},
+		Arguments: []string{
+			"touch", "output.txt", "undeclared_output.txt", "output_dir/output.txt",
+		},
 		Platform:          platform,
 		OutputDirectories: []string{"output_dir"},
 		OutputFiles:       []string{"output.txt"},
@@ -610,10 +609,9 @@ func TestSimpleCommandWithPoolSelectionViaHeader(t *testing.T) {
 	}
 
 	cmd := rbe.Execute(&repb.Command{
-		Arguments: []string{"sh", "-c", strings.Join([]string{
-			`mkdir output_dir`,
-			`touch output.txt undeclared_output.txt output_dir/output.txt`,
-		}, "\n")},
+		Arguments: []string{
+			"touch", "output.txt", "undeclared_output.txt", "output_dir/output.txt",
+		},
 		Platform:          platform,
 		OutputDirectories: []string{"output_dir"},
 		OutputFiles:       []string{"output.txt"},
@@ -675,10 +673,10 @@ func TestSimpleCommand_DefaultWorkspacePermissions(t *testing.T) {
 	}, &rbetest.ExecuteOpts{InputRootDir: inputRoot})
 	res := cmd.Wait()
 
-	expected_dirs := []string{
-		".", "output_dir_parent", "output_file_parent", "input_dir",
+	expectedOutput := ""
+	for _, dir := range dirs {
+		expectedOutput += "755 " + dir + "\n"
 	}
-	expectedOutput := "755 " + strings.Join(expected_dirs[:], "\n755 ") + "\n"
 
 	require.Equal(t, expectedOutput, res.Stdout)
 }
@@ -719,10 +717,10 @@ func TestSimpleCommand_NonrootWorkspacePermissions(t *testing.T) {
 	}, &rbetest.ExecuteOpts{InputRootDir: inputRoot})
 	res := cmd.Wait()
 
-	expected_dirs := []string{
-		".", "output_dir_parent", "output_file_parent", "input_dir",
+	expectedOutput := ""
+	for _, dir := range dirs {
+		expectedOutput += "777 " + dir + "\n"
 	}
-	expectedOutput := "777 " + strings.Join(expected_dirs[:], "\n777 ") + "\n"
 
 	require.Equal(t, expectedOutput, res.Stdout)
 }
@@ -789,14 +787,15 @@ func TestBasicActionIO(t *testing.T) {
 		Arguments: []string{
 			"sh", "-c", strings.Join([]string{
 				`set -e`,
-				// Make the output directory -- even though it's declared in
-				// OutputDirectories, it's the Command's responsibility to
-				// create it (the executor creates parent directories though)
-				`mkdir out_dir`,
 				// Create a file in the output directory.
+				// No need to create the output directory itself; executor is
+				// responsible for that.
 				`cp greeting.input out_dir/hello_world.output`,
 				`printf 'world' >> out_dir/hello_world.output`,
 				// Create a file in a child dir of the output directory.
+				// Need to create the child directory ourselves since it's not a declared
+				// output directory. Note that the executor should still upload it as
+				// part of the output dir tree.
 				`mkdir out_dir/child`,
 				`cp child/farewell.input out_dir/child/goodbye_world.output`,
 				`printf 'world' >> out_dir/child/goodbye_world.output`,
@@ -804,8 +803,7 @@ func TestBasicActionIO(t *testing.T) {
 				`cp greeting.input out_files_dir/hello_bb.output`,
 				`printf 'BB' >> out_files_dir/hello_bb.output`,
 				// Create another explicitly declared output.
-				// Because this is an OutputFile, its parent is created by the
-				// executor.
+				// No need to create out_files_dir/child; executor is responsible for that.
 				`cp child/farewell.input out_files_dir/child/goodbye_bb.output`,
 				`printf 'BB' >> out_files_dir/child/goodbye_bb.output`,
 			}, "\n"),
@@ -880,19 +878,19 @@ func TestComplexActionIO(t *testing.T) {
 		Arguments: []string{"sh", "-c", strings.Join([]string{
 			`set -e`,
 			`input_paths=$(find . -type f)`,
-			// Mirror the input tree to out_files_dir, skipping the first byte
-			// so that the output digests are different. Note that we don't
-			// create directories here since the executor is responsible for
-			// creating parent dirs of output files.
+			// Mirror the input tree to out_files_dir, skipping the first byte so that
+			// the output digests are different. Note that we don't create directories
+			// here since the executor is responsible for creating parent dirs of
+			// output files.
 			`
 			for path in $input_paths; do
-				opath="out_files_dir/$(echo "$path" | sed 's/.input/.output/')"
-				cat "$path" | tail -c +2 > "$opath"
+				output_path="out_files_dir/$(echo "$path" | sed 's/.input/.output/')"
+				cat "$path" | tail -c +2 > "$output_path"
 			done
 			`,
-			// Mirror the input tree to out_dir, skipping the first 2 bytes this
-			// time. We *do* need to create parent dirs since the executor is
-			// only responsible for creating the top-level out_dir.
+			// Mirror the input tree to out_dir, skipping the first 2 bytes this time.
+			// We *do* need to create parent dirs since the executor is only
+			// responsible for creating the top-level out_dir.
 			`
 			for path in $input_paths; do
 				output_path="out_dir/$(echo "$path" | sed 's/.input/.output/')"
@@ -940,195 +938,6 @@ func TestComplexActionIO(t *testing.T) {
 		}
 	}
 	assert.Empty(t, missing)
-}
-
-func TestOutputDirectoriesAndFiles(t *testing.T) {
-	tmpDir := testfs.MakeTempDir(t)
-	dirLayout := []string{
-		"", "a", "a/a", "a/b", "b", "b/a", "b/b", "c", "c/a", "c/b", "d", "d/a",
-		"d/b", "e", "e/a", "e/b",
-	}
-	files := []string{"a.txt", "b.txt"}
-	for _, dir := range dirLayout {
-		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0777); err != nil {
-			assert.FailNow(t, err.Error())
-		}
-		for _, fname := range files {
-			relPath := filepath.Join(dir, fname)
-			testfs.WriteRandomString(t, tmpDir, relPath /* size= */, 10)
-		}
-	}
-
-	rbe := rbetest.NewRBETestEnv(t)
-	rbe.AddBuildBuddyServer()
-	rbe.AddExecutor(t)
-
-	opts := &rbetest.ExecuteOpts{InputRootDir: tmpDir}
-
-	platform := &repb.Platform{
-		Properties: []*repb.Platform_Property{
-			{Name: "OSFamily", Value: runtime.GOOS},
-			{Name: "Arch", Value: runtime.GOARCH},
-		},
-	}
-	cmd := rbe.Execute(&repb.Command{
-		Arguments: []string{
-			"sh", "-c", "cp -r " + filepath.Join(tmpDir, "*") + " output",
-		},
-		Platform:          platform,
-		OutputDirectories: []string{"output/a", "output/b/a", "output/c/a"},
-		OutputFiles: []string{
-			"output/c/b/a.txt", "output/d/a.txt", "output/d/a/a.txt",
-		},
-	}, opts)
-	res := cmd.Wait()
-
-	require.Equal(t, 0, res.ExitCode)
-	require.Empty(t, res.Stderr)
-
-	outDir := rbe.DownloadOutputsToNewTempDir(res)
-
-	expectedFiles := []string{
-		"a/a/a.txt", "a/a/b.txt", "a/b/a.txt", "a/b/b.txt", "b/a/a.txt",
-		"b/a/b.txt", "c/a/a.txt", "c/a/b.txt", "c/b/a.txt", "d/a.txt",
-		"d/a/a.txt",
-	}
-	unexpectedFiles := []string{
-		"a.txt", "b.txt", "b/b", "c/b/b.txt", "d/a/b.txt", "d/b", "e",
-	}
-	for _, expectedFile := range expectedFiles {
-		expectedOutputFile := filepath.Join("output", expectedFile)
-		assert.Truef(t, testfs.Exists(t, outDir, expectedOutputFile),
-			"expected file to exist: %s", expectedOutputFile)
-	}
-	for _, unexpectedFile := range unexpectedFiles {
-		unexpectedOutputFile := filepath.Join("output", unexpectedFile)
-		assert.Falsef(t, testfs.Exists(t, outDir, unexpectedOutputFile),
-			"expected file to not exist: %s", unexpectedOutputFile)
-	}
-}
-
-func TestOutputPaths(t *testing.T) {
-	tmpDir := testfs.MakeTempDir(t)
-	dirLayout := []string{
-		"", "a", "a/a", "a/b", "b", "b/a", "b/b", "c", "c/a", "c/b", "d", "d/a",
-		"d/b", "e", "e/a", "e/b",
-	}
-	files := []string{"a.txt", "b.txt"}
-	for _, dir := range dirLayout {
-		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0777); err != nil {
-			assert.FailNow(t, err.Error())
-		}
-		for _, fname := range files {
-			relPath := filepath.Join(dir, fname)
-			testfs.WriteRandomString(t, tmpDir, relPath /* size= */, 10)
-		}
-	}
-
-	rbe := rbetest.NewRBETestEnv(t)
-	rbe.AddBuildBuddyServer()
-	rbe.AddExecutor(t)
-
-	opts := &rbetest.ExecuteOpts{InputRootDir: tmpDir}
-
-	platform := &repb.Platform{
-		Properties: []*repb.Platform_Property{
-			{Name: "OSFamily", Value: runtime.GOOS},
-			{Name: "Arch", Value: runtime.GOARCH},
-		},
-	}
-	cmd := rbe.Execute(&repb.Command{
-		Arguments: []string{
-			"sh", "-c", "cp -r " + filepath.Join(tmpDir, "*") + " output",
-		},
-		Platform: platform,
-		OutputPaths: []string{
-			"output/a", "output/b/a", "output/c/a", "output/c/b/a.txt",
-			"output/d/a.txt", "output/d/a/a.txt",
-		},
-	}, opts)
-	res := cmd.Wait()
-
-	require.Equal(t, 0, res.ExitCode)
-	require.Empty(t, res.Stderr)
-
-	outDir := rbe.DownloadOutputsToNewTempDir(res)
-
-	expectedFiles := []string{
-		"a/a/a.txt", "a/a/b.txt", "a/b/a.txt", "a/b/b.txt", "b/a/a.txt",
-		"b/a/b.txt", "c/a/a.txt", "c/a/b.txt", "c/b/a.txt", "d/a.txt",
-		"d/a/a.txt",
-	}
-	unexpectedFiles := []string{
-		"a.txt", "b.txt", "b/b", "c/b/b.txt", "d/a/b.txt", "d/b", "e",
-	}
-	for _, expectedFile := range expectedFiles {
-		expectedOutputFile := filepath.Join("output", expectedFile)
-		assert.Truef(t, testfs.Exists(t, outDir, expectedOutputFile),
-			"expected file to exist: %s", expectedOutputFile)
-	}
-	for _, unexpectedFile := range unexpectedFiles {
-		unexpectedOutputFile := filepath.Join("output", unexpectedFile)
-		assert.Falsef(t, testfs.Exists(t, outDir, unexpectedOutputFile),
-			"expected file to not exist: %s", unexpectedOutputFile)
-	}
-}
-
-func TestOuputPathsDirectoriesAndFiles(t *testing.T) {
-	tmpDir := testfs.MakeTempDir(t)
-	dirLayout := []string{"", "a", "b", "c"}
-	files := []string{"a.txt", "b.txt"}
-	for _, dir := range dirLayout {
-		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0777); err != nil {
-			assert.FailNow(t, err.Error())
-		}
-		for _, fname := range files {
-			relPath := filepath.Join(dir, fname)
-			testfs.WriteRandomString(t, tmpDir, relPath /* size= */, 10)
-		}
-	}
-
-	rbe := rbetest.NewRBETestEnv(t)
-	rbe.AddBuildBuddyServer()
-	rbe.AddExecutor(t)
-
-	opts := &rbetest.ExecuteOpts{InputRootDir: tmpDir}
-
-	platform := &repb.Platform{
-		Properties: []*repb.Platform_Property{
-			{Name: "OSFamily", Value: runtime.GOOS},
-			{Name: "Arch", Value: runtime.GOARCH},
-		},
-	}
-	cmd := rbe.Execute(&repb.Command{
-		Arguments: []string{
-			"sh", "-c", "cp -r " + filepath.Join(tmpDir, "*") + " output",
-		},
-		Platform:          platform,
-		OutputFiles:       []string{"output/a/a.txt"},
-		OutputDirectories: []string{"output/b"},
-		OutputPaths:       []string{"output/c"},
-	}, opts)
-	res := cmd.Wait()
-
-	require.Equal(t, 0, res.ExitCode)
-	require.Empty(t, res.Stderr)
-
-	outDir := rbe.DownloadOutputsToNewTempDir(res)
-
-	// output_paths should supersede output_files and output_directories.
-	expectedFiles := []string{"c/a.txt", "c/b.txt"}
-	unexpectedFiles := []string{"a", "b"}
-	for _, expectedFile := range expectedFiles {
-		expectedOutputFile := filepath.Join("output", expectedFile)
-		assert.Truef(t, testfs.Exists(t, outDir, expectedOutputFile),
-			"expected file to exist: %s", expectedOutputFile)
-	}
-	for _, unexpectedFile := range unexpectedFiles {
-		unexpectedOutputFile := filepath.Join("output", unexpectedFile)
-		assert.Falsef(t, testfs.Exists(t, outDir, unexpectedOutputFile),
-			"expected file to not exist: %s", unexpectedOutputFile)
-	}
 }
 
 func TestComplexActionIOWithCompression(t *testing.T) {


### PR DESCRIPTION
rules_kotlin doesn't respect the behavior described here: https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto#L589 so this change breaks clients using those rules.