### PR TITLE
CLI: Allow local plugins to be specified as :PATH

### DIFF
--- a/cli/plugin/plugin_test.go
+++ b/cli/plugin/plugin_test.go
@@ -141,11 +141,15 @@ func TestInstall_ToUserConfig_CreateNewConfig(t *testing.T) {
 	require.Equal(t, expectedConfig, config)
 }
 
-func TestParseRepoInstallSpec(t *testing.T) {
+func TestParsePluginSpec(t *testing.T) {
 	for _, tc := range []struct {
 		Repo, PathArg  string
 		ExpectedConfig *PluginConfig
 	}{
+		{
+			":/local/path", "",
+			&PluginConfig{Path: "/local/path"},
+		},
 		{
 			"foo/bar", "",
 			&PluginConfig{Repo: "foo/bar"},
@@ -179,7 +183,7 @@ func TestParseRepoInstallSpec(t *testing.T) {
 			&PluginConfig{Repo: "example.com/foo/bar@v1", Path: "/nested/subdir"},
 		},
 	} {
-		cfg, err := parseRepoInstallSpec(tc.Repo, tc.PathArg)
+		cfg, err := parsePluginSpec(tc.Repo, tc.PathArg)
 
 		require.NoError(t, err)
 		assert.Equal(t, tc.ExpectedConfig, cfg)


### PR DESCRIPTION
I kept around the `--path` arg because of the nice ergonomics (e.g. tab completion, easier to pass to something like `xargs`, etc.)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
