### PR TITLE
CLI: Don't require hook scripts to be executable

### DIFF
--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -720,11 +720,9 @@ func (p *Plugin) PreBazel(args []string) ([]string, error) {
 		return args, nil
 	}
 	log.Debugf("Running pre-bazel hook for %s/%s", p.config.Repo, p.config.Path)
-	// TODO: if pre_bazel.sh is not executable and does not contain a shebang
-	// line, wrap it with "/usr/bin/env bash"
 	// TODO: support "pre_bazel.<any-extension>" as long as the file is
 	// executable and has a shebang line
-	cmd := exec.Command(scriptPath, argsFile.Name())
+	cmd := exec.Command("/usr/bin/env", "bash", scriptPath, argsFile.Name())
 	// TODO: Prefix output with "output from [plugin]" ?
 	cmd.Dir = path
 	cmd.Stderr = os.Stderr
@@ -764,7 +762,7 @@ func (p *Plugin) PostBazel(bazelOutputPath string) error {
 		return nil
 	}
 	log.Debugf("Running post-bazel hook for %s/%s", p.config.Repo, p.config.Path)
-	cmd := exec.Command(scriptPath, bazelOutputPath)
+	cmd := exec.Command("/usr/bin/env", "bash", scriptPath, bazelOutputPath)
 	// TODO: Prefix stderr output with "output from [plugin]" ?
 	cmd.Dir = path
 	cmd.Stderr = os.Stderr
@@ -799,7 +797,7 @@ func (p *Plugin) Pipe(r io.Reader) (io.Reader, error) {
 	if !exists {
 		return r, nil
 	}
-	cmd := exec.Command(scriptPath)
+	cmd := exec.Command("/usr/bin/env", "bash", scriptPath)
 	pr, pw := io.Pipe()
 	cmd.Dir = path
 	// Write command output to a pty to ensure line buffering.

--- a/docs/cli-plugins.md
+++ b/docs/cli-plugins.md
@@ -111,7 +111,7 @@ The `pre_bazel.sh` script will be called before Bazel is run. It is called with 
 The script will be called like this:
 
 ```bash
-/path/to/plugin/pre_bazel.sh /path/to/bazel-args
+/usr/bin/env bash /path/to/plugin/pre_bazel.sh /path/to/bazel-args
 ```
 
 Here's an example of what the Bazel args file might look like:
@@ -169,7 +169,7 @@ The `post_bazel.sh` script is called after Bazel completes. It is called with a 
 The script will be called like this:
 
 ```bash
-/path/to/plugin/post_bazel.sh /path/to/bazel-outputs
+/usr/bin/env bash /path/to/plugin/post_bazel.sh /path/to/bazel-outputs
 ```
 
 Here's an example of what the Bazel outputs file might look like:
@@ -303,11 +303,11 @@ This is a long-lived directory you can use to store user preferences, like wheth
 
 Here are some examples of plugins that can help you get started quickly:
 
-`pre-bazel.sh`
+`pre_bazel.sh`
 
 - ping_remote: https://github.com/buildbuddy-io/buildbuddy/tree/master/cli/example_plugins/ping_remote
 
-`post-bazel-sh`
+`post_bazel.sh`
 
 - open_invocation: https://github.com/buildbuddy-io/buildbuddy/tree/master/cli/plugins/open_invocation
 - notify: https://github.com/buildbuddy-io/buildbuddy/tree/master/cli/plugins/notify

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,9 +18,9 @@ The easiest way to install the BuildBuddy CLI is by running this simple bash scr
 curl -fsSL install.buildbuddy.io | bash
 ```
 
-If you're not comfortable executing random bash scripts from the internet (we totally get it!), you can take a look at what this script is doing under the hood, by visiting [install.buildbuddy.io](http://install.buildbuddy.io) in your browser.
+If you're not comfortable executing random bash scripts from the internet (we totally get it!), you can take a look at what this script is doing under the hood, by visiting [install.buildbuddy.io](https://install.buildbuddy.io) in your browser.
 
-It's downloading the latest BuildBuddy CLI binary for your OS and architecture from our Github repo [https://github.com/buildbuddy-io/bazel/releases](here) and moving it to `/usr/local/bin/bb`.
+It's downloading the latest BuildBuddy CLI binary for your OS and architecture from our Github repo [here](https://github.com/buildbuddy-io/bazel/releases) and moving it to `/usr/local/bin/bb`.
 
 You can perform those steps manually yourself if you'd like!
 


### PR DESCRIPTION
Instead of invoking plugins directly, we'll invoke with `/usr/bin/env bash` so that plugin authors don't have to remember to `chmod +x` each hook script.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
