### PR TITLE
CLI: Override explicit command line in the UI

### DIFF
--- a/app/invocation/invocation_details_card.tsx
+++ b/app/invocation/invocation_details_card.tsx
@@ -44,6 +44,25 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
       .join(" ");
   }
 
+  explicitCommandLine() {
+    // We allow overriding EXPLICIT_COMMAND_LINE to enable tools that wrap bazel
+    // to append bazel args but still preserve the appearance of the original
+    // command line. The effective command line can still be used to see the
+    // effective configuration used by bazel.
+    const overrideJSON = this.props.model.buildMetadataMap.get("EXPLICIT_COMMAND_LINE");
+    if (overrideJSON) {
+      try {
+        // TODO: Render these with something like shlex so that spaces are
+        // quoted as necessary.
+        return JSON.parse(overrideJSON).join(" ");
+      } catch (_) {
+        // Invalid JSON; fall back to showing BES event.
+      }
+    }
+
+    return this.bazelCommandAndPatternWithOptions(this.props.model.optionsParsed?.explicitCmdLine);
+  }
+
   render() {
     const isBazelInvocation = this.props.model.isBazelInvocation();
 
@@ -224,16 +243,11 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
                     explicit command line{" "}
                     <Copy
                       className="copy-icon"
-                      onClick={this.handleCopyClicked.bind(
-                        this,
-                        `${this.bazelCommandAndPatternWithOptions(this.props.model.optionsParsed?.explicitCmdLine)}`
-                      )}
+                      onClick={this.handleCopyClicked.bind(this, this.explicitCommandLine())}
                     />
                   </div>
                   <div className="invocation-section">
-                    <code className="wrap">
-                      {this.bazelCommandAndPatternWithOptions(this.props.model.optionsParsed?.explicitCmdLine)}
-                    </code>
+                    <code className="wrap">{this.explicitCommandLine()}</code>
                   </div>
                 </div>
 

--- a/cli/bazelisk/bazelisk.go
+++ b/cli/bazelisk/bazelisk.go
@@ -153,6 +153,13 @@ func InvokeRunScript(path string) (exitCode int, err error) {
 	panic("unreachable")
 }
 
+// IsInvokedByBazelisk returns whether the CLI was invoked by bazelisk itself.
+// This will return true when referencing a CLI release in .bazelversion such as
+// "buildbuddy-io/0.0.13" and then running `bazelisk`.
+func IsInvokedByBazelisk() bool {
+	return os.Getenv("BAZELISK_SKIP_WRAPPER") == "true"
+}
+
 // makePipeWriter adapts a writer to an *os.File by using an os.Pipe().
 // The returned file should not be closed; instead the returned closeFunc
 // should be called to ensure that all data from the pipe is flushed to the

--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//cli/help",
         "//cli/log",
         "//cli/login",
+        "//cli/metadata",
         "//cli/parser",
         "//cli/plugin",
         "//cli/remotebazel",

--- a/cli/metadata/BUILD
+++ b/cli/metadata/BUILD
@@ -5,4 +5,5 @@ go_library(
     srcs = ["metadata.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/metadata",
     visibility = ["//visibility:public"],
+    deps = ["//cli/bazelisk"],
 )

--- a/cli/metadata/BUILD
+++ b/cli/metadata/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "metadata",
+    srcs = ["metadata.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/metadata",
+    visibility = ["//visibility:public"],
+)

--- a/cli/metadata/metadata.go
+++ b/cli/metadata/metadata.go
@@ -1,0 +1,21 @@
+package metadata
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func AppendBuildMetadata(args, originalArgs []string) ([]string, error) {
+	// Ensure arg0 is "bb" (by default, it is an abs path)
+	originalArgs = append([]string{"bb"}, originalArgs[1:]...)
+
+	originalArgsJSON, err := json.Marshal(originalArgs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal original command arguments: %s", err)
+	}
+	// TODO: Add metadata to help understand how config files were expanded,
+	// and how plugins modified args (maybe not as build_metadata, but
+	// rather as some sort of artifact we attach to the invocation ID).
+	args = append(args, "--build_metadata=EXPLICIT_COMMAND_LINE="+string(originalArgsJSON))
+	return args, nil
+}

--- a/cli/metadata/metadata.go
+++ b/cli/metadata/metadata.go
@@ -3,11 +3,21 @@ package metadata
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
 )
 
+func getCommandLineToolName() string {
+	if bazelisk.IsInvokedByBazelisk() {
+		return "bazel"
+	}
+	return "bb"
+}
+
 func AppendBuildMetadata(args, originalArgs []string) ([]string, error) {
-	// Ensure arg0 is "bb" (by default, it is an abs path)
-	originalArgs = append([]string{"bb"}, originalArgs[1:]...)
+	originalArgs = append(
+		[]string{getCommandLineToolName()},
+		originalArgs[1:]...)
 
 	originalArgsJSON, err := json.Marshal(originalArgs)
 	if err != nil {


### PR DESCRIPTION
We expand `.bazelrc` default arguments and `--config` flags, causing the explicit command line to be super long. This PR lets us show the original `bb` tool command line under "explicit command line" instead of the expanded Bazel command line.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
