### PR TITLE
CI runner image improvements

### DIFF
--- a/enterprise/dockerfiles/ci_runner_image/Dockerfile
+++ b/enterprise/dockerfiles/ci_runner_image/Dockerfile
@@ -1,15 +1,17 @@
 FROM gcr.io/cloud-marketplace/google/rbe-ubuntu18-04@sha256:48b67b41118dbcdfc265e7335f454fbefa62681ab8d47200971fc7a52fb32054
 
-RUN add-apt-repository ppa:git-core/ppa
-RUN apt-get update && apt-get install -y build-essential git
+RUN add-apt-repository ppa:git-core/ppa && \
+    apt-get update && \
+    apt-get install -y build-essential git python3.6-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install bazelisk
 RUN curl -Lo /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.5/bazelisk-linux-amd64 && \
     chmod +x /usr/local/bin/bazelisk
 
-# Pre-install bazel 4.1.0 to avoid bazelisk downloading & installing bazel on every
-# CI run, at least for CI runs on the BuildBuddy repo itself.
-RUN USE_BAZEL_VERSION=4.1.0 bazelisk version
+# Pre-download/extract bazel so that Bazel can skip that work on first run,
+# at least for CI runs on the BB repo itself.
+RUN USE_BAZEL_VERSION=5.3.1 bazelisk version
 
 # Provision a non-root user named "buildbuddy".
 # Non-root users are needed for some bazel toolchains, such as hermetic python.


### PR DESCRIPTION
- Install `python3.6-dev` apt package to satisfy python gRPC system deps. Context: https://buildbuddy.slack.com/archives/CUHBFVATU/p1668434604090649?thread_ts=1668434529.712729&cid=CUHBFVATU
- Pre-download/extract bazel 5.3.1 by default, instead of 4.0.0
- Clean up `apt-get` artifacts to reduce image size.

Overall, uncompressed image size is reduced by 282 MB.

```
                Before    After
Compressed      942M      863M
Uncompressed    2.427GB   2.145GB
```

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
