### PR TITLE
Add utilities for bazel client version parsing and comparison

### DIFF
--- a/server/util/bazel_request/BUILD
+++ b/server/util/bazel_request/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "bazel_request",
@@ -8,6 +8,19 @@ go_library(
     deps = [
         "//proto:remote_execution_go_proto",
         "//server/util/status",
+        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_protobuf//proto",
+    ],
+)
+
+go_test(
+    name = "bazel_request_test",
+    srcs = ["bazel_request_test.go"],
+    deps = [
+        ":bazel_request",
+        "//proto:remote_execution_go_proto",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_protobuf//proto",
     ],

--- a/server/util/bazel_request/bazel_request.go
+++ b/server/util/bazel_request/bazel_request.go
@@ -2,12 +2,20 @@ package bazel_request
 
 import (
 	"context"
+	"regexp"
+	"strconv"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+var (
+	// Note: Using regexp instead of semver package for bazel version parsing,
+	// since semver doesn't support things like "5.0.0rc1"
+	bazelVersionPattern = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?(?P<suffix>.*)?`)
 )
 
 const RequestMetadataKey = "build.bazel.remote.execution.v2.requestmetadata-bin"
@@ -31,6 +39,89 @@ func GetInvocationID(ctx context.Context) string {
 		iid = rmd.GetToolInvocationId()
 	}
 	return iid
+}
+
+type Version struct {
+	// Major, Minor, Patch are the semver version parts. For Bazel versions like
+	// "0.X", the Major and Patch versions will be 0, and the Minor version will
+	// be "X".
+	Major, Minor, Patch int
+
+	// Suffix is the raw suffix occurring immediately after the version numbers.
+	// Example: "-pre.20221102.3"
+	Suffix string
+}
+
+// GetVersion returns the parsed Bazel version. It returns nil if no Bazel
+// version could be parsed, and in particular if the client is not bazel.
+func GetVersion(ctx context.Context) *Version {
+	rmd := GetRequestMetadata(ctx)
+	if rmd == nil {
+		return nil
+	}
+	if rmd.GetToolDetails().GetToolName() != "bazel" {
+		return nil
+	}
+	tv := rmd.GetToolDetails().GetToolVersion()
+	m := bazelVersionPattern.FindStringSubmatch(tv)
+	if len(m) == 0 {
+		return nil
+	}
+	var err error
+	b := &Version{}
+	b.Major, err = strconv.Atoi(m[bazelVersionPattern.SubexpIndex("major")])
+	if err != nil {
+		return nil
+	}
+	b.Minor, err = strconv.Atoi(m[bazelVersionPattern.SubexpIndex("minor")])
+	if err != nil {
+		return nil
+	}
+	if p := m[bazelVersionPattern.SubexpIndex("patch")]; p != "" {
+		b.Patch, err = strconv.Atoi(p)
+		if err != nil {
+			return nil
+		}
+	}
+	b.Suffix = m[bazelVersionPattern.SubexpIndex("suffix")]
+	return b
+}
+
+// IsAtLeast returns whether this bazel version is equal to or supercedes the
+// given version.
+func (v *Version) IsAtLeast(c *Version) bool {
+	if v.Major != c.Major {
+		return v.Major > c.Major
+	}
+	if v.Minor != c.Minor {
+		return v.Minor > c.Minor
+	}
+	if v.Patch != c.Patch {
+		return v.Patch > c.Patch
+	}
+	// If major, minor, and patch versions are all the same, compare the suffix.
+	// Make sure that release versions (which have an empty suffix) are
+	// considered greater than pre-release versions (which have a non-empty
+	// suffix).
+	vReleaseBit := boolToInt(v.Suffix == "")
+	cReleaseBit := boolToInt(c.Suffix == "")
+	if vReleaseBit != cReleaseBit {
+		return vReleaseBit > cReleaseBit
+	}
+	// If neither is a release version, compare pre-release suffixes
+	// lexicographically.
+	if v.Suffix != c.Suffix {
+		return v.Suffix > c.Suffix
+	}
+	// v is exactly equal to c, so it is at least c.
+	return true
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 func WithRequestMetadata(ctx context.Context, md *repb.RequestMetadata) (context.Context, error) {

--- a/server/util/bazel_request/bazel_request_test.go
+++ b/server/util/bazel_request/bazel_request_test.go
@@ -1,0 +1,90 @@
+package bazel_request_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+func TestParseBazelVersion(t *testing.T) {
+	for _, testCase := range []struct {
+		Tool, Version   string
+		ExpectedVersion *bazel_request.Version
+	}{
+		{"unknown-tool", "5.0.0", nil},
+		{"bazel", "INVALID", nil},
+		{"bazel", "", nil},
+		{"bazel", "0.23", v(0, 23, 0, "")},
+		{"bazel", "5.3.1", v(5, 3, 1, "")},
+		{"bazel", "7.0.0-pre.20221102.3", v(7, 0, 0, "-pre.20221102.3")},
+	} {
+		ctx := context.Background()
+		rmd := &repb.RequestMetadata{
+			ToolDetails: &repb.ToolDetails{
+				ToolName:    testCase.Tool,
+				ToolVersion: testCase.Version,
+			},
+		}
+		ctx = withIncomingMetadata(t, ctx, rmd)
+
+		actualVersion := bazel_request.GetVersion(ctx)
+
+		assert.Equal(t, testCase.ExpectedVersion, actualVersion)
+	}
+}
+
+func TestVersionIsAtLeast(t *testing.T) {
+	for _, testCase := range []struct {
+		V1, V2   *bazel_request.Version
+		Expected bool
+	}{
+		// Equal
+		{V1: v(1, 2, 3, ""), V2: v(1, 2, 3, ""), Expected: true},
+		// Pre-release vs. release
+		{V1: v(7, 0, 0, ""), V2: v(7, 0, 0, "-pre.20221026.2"), Expected: true},
+		{V1: v(7, 0, 0, "-pre.20221026.2"), V2: v(7, 0, 0, ""), Expected: false},
+		// Pre-release
+		{V1: v(7, 0, 0, "-pre.20221102.3"), V2: v(7, 0, 0, "-pre.20221026.2"), Expected: true},
+		{V1: v(7, 0, 0, "-pre.20221026.2"), V2: v(7, 0, 0, "-pre.20221102.3"), Expected: false},
+		// Patch
+		{V1: v(5, 3, 2, ""), V2: v(5, 3, 1, ""), Expected: true},
+		{V1: v(5, 3, 1, ""), V2: v(5, 3, 2, ""), Expected: false},
+		// Minor
+		{V1: v(5, 2, 0, ""), V2: v(5, 1, 0, ""), Expected: true},
+		{V1: v(5, 1, 0, ""), V2: v(5, 2, 0, ""), Expected: false},
+		// Major
+		{V1: v(6, 0, 0, ""), V2: v(5, 0, 0, ""), Expected: true},
+		{V1: v(5, 0, 0, ""), V2: v(6, 0, 0, ""), Expected: false},
+	} {
+		actual := testCase.V1.IsAtLeast(testCase.V2)
+
+		assert.Equal(
+			t, testCase.Expected, actual,
+			"expected %+v >= %+v", testCase.V1, testCase.V2)
+	}
+}
+
+func v(major, minor, patch int, suffix string) *bazel_request.Version {
+	return &bazel_request.Version{
+		Major:  major,
+		Minor:  minor,
+		Patch:  patch,
+		Suffix: suffix,
+	}
+}
+
+// Note: Can't use bazel_request.WithRequestMetadata here since it sets the
+// metadata on the outgoing context, not the incoming context.
+func withIncomingMetadata(t *testing.T, ctx context.Context, rmd *repb.RequestMetadata) context.Context {
+	b, err := proto.Marshal(rmd)
+	require.NoError(t, err)
+	md := metadata.Pairs(bazel_request.RequestMetadataKey, string(b))
+	return metadata.NewIncomingContext(ctx, md)
+}


### PR DESCRIPTION
Context: https://github.com/buildbuddy-io/buildbuddy/pull/2916#issuecomment-1314209533

This will also be useful to address https://github.com/buildbuddy-io/buildbuddy-internal/issues/1187

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
