### PR TITLE
Support Command.output_paths (attempt #2)

### DIFF
--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -102,7 +102,13 @@ func (ws *Workspace) SetTask(ctx context.Context, task *repb.ExecutionTask) {
 	log.CtxDebugf(ctx, "Assigned task %s to workspace at %q", task.GetExecutionId(), ws.rootDir)
 	ws.task = task
 	cmd := task.GetCommand()
-	ws.dirHelper = dirtools.NewDirHelper(ws.Path(), cmd.GetOutputFiles(), cmd.GetOutputDirectories(), ws.dirPerms)
+	outputDirs := make([]string, 0)
+	outputPaths := cmd.GetOutputPaths()
+	if len(outputPaths) == 0 {
+		outputDirs = cmd.GetOutputDirectories()
+		outputPaths = append(cmd.GetOutputFiles(), cmd.GetOutputDirectories()...)
+	}
+	ws.dirHelper = dirtools.NewDirHelper(ws.Path(), outputDirs, outputPaths, ws.dirPerms)
 }
 
 // CommandWorkingDirectory returns the absolute path to the working directory

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -787,15 +787,12 @@ func TestBasicActionIO(t *testing.T) {
 		Arguments: []string{
 			"sh", "-c", strings.Join([]string{
 				`set -e`,
-				// Create a file in the output directory.
-				// No need to create the output directory itself; executor is
-				// responsible for that.
+                // No need to create the output directory itself; executor is
+                // responsible for that because it's specified as an
+                // OutputDirectory.
 				`cp greeting.input out_dir/hello_world.output`,
 				`printf 'world' >> out_dir/hello_world.output`,
 				// Create a file in a child dir of the output directory.
-				// Need to create the child directory ourselves since it's not a declared
-				// output directory. Note that the executor should still upload it as
-				// part of the output dir tree.
 				`mkdir out_dir/child`,
 				`cp child/farewell.input out_dir/child/goodbye_world.output`,
 				`printf 'world' >> out_dir/child/goodbye_world.output`,
@@ -803,7 +800,8 @@ func TestBasicActionIO(t *testing.T) {
 				`cp greeting.input out_files_dir/hello_bb.output`,
 				`printf 'BB' >> out_files_dir/hello_bb.output`,
 				// Create another explicitly declared output.
-				// No need to create out_files_dir/child; executor is responsible for that.
+				// Because this is an OutputFile, its parent is created by the
+				// executor.
 				`cp child/farewell.input out_files_dir/child/goodbye_bb.output`,
 				`printf 'BB' >> out_files_dir/child/goodbye_bb.output`,
 			}, "\n"),
@@ -878,19 +876,19 @@ func TestComplexActionIO(t *testing.T) {
 		Arguments: []string{"sh", "-c", strings.Join([]string{
 			`set -e`,
 			`input_paths=$(find . -type f)`,
-			// Mirror the input tree to out_files_dir, skipping the first byte so that
-			// the output digests are different. Note that we don't create directories
-			// here since the executor is responsible for creating parent dirs of
-			// output files.
+			// Mirror the input tree to out_files_dir, skipping the first byte
+			// so that the output digests are different. Note that we don't
+			// create directories here since the executor is responsible for
+			// creating parent dirs of output files.
 			`
 			for path in $input_paths; do
-				output_path="out_files_dir/$(echo "$path" | sed 's/.input/.output/')"
-				cat "$path" | tail -c +2 > "$output_path"
+				opath="out_files_dir/$(echo "$path" | sed 's/.input/.output/')"
+				cat "$path" | tail -c +2 > "$opath"
 			done
 			`,
-			// Mirror the input tree to out_dir, skipping the first 2 bytes this time.
-			// We *do* need to create parent dirs since the executor is only
-			// responsible for creating the top-level out_dir.
+			// Mirror the input tree to out_dir, skipping the first 2 bytes this
+			// time. We *do* need to create parent dirs since the executor is
+			// only responsible for creating the top-level out_dir.
 			`
 			for path in $input_paths; do
 				output_path="out_dir/$(echo "$path" | sed 's/.input/.output/')"
@@ -938,6 +936,195 @@ func TestComplexActionIO(t *testing.T) {
 		}
 	}
 	assert.Empty(t, missing)
+}
+
+func TestOutputDirectoriesAndFiles(t *testing.T) {
+	tmpDir := testfs.MakeTempDir(t)
+	dirLayout := []string{
+		"", "a", "a/a", "a/b", "b", "b/a", "b/b", "c", "c/a", "c/b", "d", "d/a",
+		"d/b", "e", "e/a", "e/b",
+	}
+	files := []string{"a.txt", "b.txt"}
+	for _, dir := range dirLayout {
+		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0777); err != nil {
+			assert.FailNow(t, err.Error())
+		}
+		for _, fname := range files {
+			relPath := filepath.Join(dir, fname)
+			testfs.WriteRandomString(t, tmpDir, relPath /* size= */, 10)
+		}
+	}
+
+	rbe := rbetest.NewRBETestEnv(t)
+	rbe.AddBuildBuddyServer()
+	rbe.AddExecutor(t)
+
+	opts := &rbetest.ExecuteOpts{InputRootDir: tmpDir}
+
+	platform := &repb.Platform{
+		Properties: []*repb.Platform_Property{
+			{Name: "OSFamily", Value: runtime.GOOS},
+			{Name: "Arch", Value: runtime.GOARCH},
+		},
+	}
+	cmd := rbe.Execute(&repb.Command{
+		Arguments: []string{
+			"sh", "-c", "cp -r " + filepath.Join(tmpDir, "*") + " output",
+		},
+		Platform:          platform,
+		OutputDirectories: []string{"output/a", "output/b/a", "output/c/a"},
+		OutputFiles: []string{
+			"output/c/b/a.txt", "output/d/a.txt", "output/d/a/a.txt",
+		},
+	}, opts)
+	res := cmd.Wait()
+
+	require.Equal(t, 0, res.ExitCode)
+	require.Empty(t, res.Stderr)
+
+	outDir := rbe.DownloadOutputsToNewTempDir(res)
+
+	expectedFiles := []string{
+		"a/a/a.txt", "a/a/b.txt", "a/b/a.txt", "a/b/b.txt", "b/a/a.txt",
+		"b/a/b.txt", "c/a/a.txt", "c/a/b.txt", "c/b/a.txt", "d/a.txt",
+		"d/a/a.txt",
+	}
+	unexpectedFiles := []string{
+		"a.txt", "b.txt", "b/b", "c/b/b.txt", "d/a/b.txt", "d/b", "e",
+	}
+	for _, expectedFile := range expectedFiles {
+		expectedOutputFile := filepath.Join("output", expectedFile)
+		assert.Truef(t, testfs.Exists(t, outDir, expectedOutputFile),
+			"expected file to exist: %s", expectedOutputFile)
+	}
+	for _, unexpectedFile := range unexpectedFiles {
+		unexpectedOutputFile := filepath.Join("output", unexpectedFile)
+		assert.Falsef(t, testfs.Exists(t, outDir, unexpectedOutputFile),
+			"expected file to not exist: %s", unexpectedOutputFile)
+	}
+}
+
+func TestOutputPaths(t *testing.T) {
+	tmpDir := testfs.MakeTempDir(t)
+	dirLayout := []string{
+		"", "a", "a/a", "a/b", "b", "b/a", "b/b", "c", "c/a", "c/b", "d", "d/a",
+		"d/b", "e", "e/a", "e/b",
+	}
+	files := []string{"a.txt", "b.txt"}
+	for _, dir := range dirLayout {
+		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0777); err != nil {
+			assert.FailNow(t, err.Error())
+		}
+		for _, fname := range files {
+			relPath := filepath.Join(dir, fname)
+			testfs.WriteRandomString(t, tmpDir, relPath /* size= */, 10)
+		}
+	}
+
+	rbe := rbetest.NewRBETestEnv(t)
+	rbe.AddBuildBuddyServer()
+	rbe.AddExecutor(t)
+
+	opts := &rbetest.ExecuteOpts{InputRootDir: tmpDir}
+
+	platform := &repb.Platform{
+		Properties: []*repb.Platform_Property{
+			{Name: "OSFamily", Value: runtime.GOOS},
+			{Name: "Arch", Value: runtime.GOARCH},
+		},
+	}
+	cmd := rbe.Execute(&repb.Command{
+		Arguments: []string{
+			"sh", "-c", "cp -r " + filepath.Join(tmpDir, "*") + " output",
+		},
+		Platform: platform,
+		OutputPaths: []string{
+			"output/a", "output/b/a", "output/c/a", "output/c/b/a.txt",
+			"output/d/a.txt", "output/d/a/a.txt",
+		},
+	}, opts)
+	res := cmd.Wait()
+
+	require.Equal(t, 0, res.ExitCode)
+	require.Empty(t, res.Stderr)
+
+	outDir := rbe.DownloadOutputsToNewTempDir(res)
+
+	expectedFiles := []string{
+		"a/a/a.txt", "a/a/b.txt", "a/b/a.txt", "a/b/b.txt", "b/a/a.txt",
+		"b/a/b.txt", "c/a/a.txt", "c/a/b.txt", "c/b/a.txt", "d/a.txt",
+		"d/a/a.txt",
+	}
+	unexpectedFiles := []string{
+		"a.txt", "b.txt", "b/b", "c/b/b.txt", "d/a/b.txt", "d/b", "e",
+	}
+	for _, expectedFile := range expectedFiles {
+		expectedOutputFile := filepath.Join("output", expectedFile)
+		assert.Truef(t, testfs.Exists(t, outDir, expectedOutputFile),
+			"expected file to exist: %s", expectedOutputFile)
+	}
+	for _, unexpectedFile := range unexpectedFiles {
+		unexpectedOutputFile := filepath.Join("output", unexpectedFile)
+		assert.Falsef(t, testfs.Exists(t, outDir, unexpectedOutputFile),
+			"expected file to not exist: %s", unexpectedOutputFile)
+	}
+}
+
+func TestOuputPathsDirectoriesAndFiles(t *testing.T) {
+	tmpDir := testfs.MakeTempDir(t)
+	dirLayout := []string{"", "a", "b", "c"}
+	files := []string{"a.txt", "b.txt"}
+	for _, dir := range dirLayout {
+		if err := os.MkdirAll(filepath.Join(tmpDir, dir), 0777); err != nil {
+			assert.FailNow(t, err.Error())
+		}
+		for _, fname := range files {
+			relPath := filepath.Join(dir, fname)
+			testfs.WriteRandomString(t, tmpDir, relPath /* size= */, 10)
+		}
+	}
+
+	rbe := rbetest.NewRBETestEnv(t)
+	rbe.AddBuildBuddyServer()
+	rbe.AddExecutor(t)
+
+	opts := &rbetest.ExecuteOpts{InputRootDir: tmpDir}
+
+	platform := &repb.Platform{
+		Properties: []*repb.Platform_Property{
+			{Name: "OSFamily", Value: runtime.GOOS},
+			{Name: "Arch", Value: runtime.GOARCH},
+		},
+	}
+	cmd := rbe.Execute(&repb.Command{
+		Arguments: []string{
+			"sh", "-c", "cp -r " + filepath.Join(tmpDir, "*") + " output",
+		},
+		Platform:          platform,
+		OutputFiles:       []string{"output/a/a.txt"},
+		OutputDirectories: []string{"output/b"},
+		OutputPaths:       []string{"output/c"},
+	}, opts)
+	res := cmd.Wait()
+
+	require.Equal(t, 0, res.ExitCode)
+	require.Empty(t, res.Stderr)
+
+	outDir := rbe.DownloadOutputsToNewTempDir(res)
+
+	// output_paths should supersede output_files and output_directories.
+	expectedFiles := []string{"c/a.txt", "c/b.txt"}
+	unexpectedFiles := []string{"a", "b"}
+	for _, expectedFile := range expectedFiles {
+		expectedOutputFile := filepath.Join("output", expectedFile)
+		assert.Truef(t, testfs.Exists(t, outDir, expectedOutputFile),
+			"expected file to exist: %s", expectedOutputFile)
+	}
+	for _, unexpectedFile := range unexpectedFiles {
+		unexpectedOutputFile := filepath.Join("output", unexpectedFile)
+		assert.Falsef(t, testfs.Exists(t, outDir, unexpectedOutputFile),
+			"expected file to not exist: %s", unexpectedOutputFile)
+	}
 }
 
 func TestComplexActionIOWithCompression(t *testing.T) {


### PR DESCRIPTION
This is a rollforward (with fixes) of https://github.com/buildbuddy-io/buildbuddy/pull/2879 which was reverted in https://github.com/buildbuddy-io/buildbuddy/pull/2903 because some rules_kotlin rules expected the previous behavior of output_directories.

This PR does a few things:

Adds a more complex test for the various kinds of outputs (output_directories, output_files, and output_paths)
Supports output_paths instead of output_files and output_directories, when specified. Otherwise, falls back to output_files and output_directories. N.B. that the behavior of output_paths is slightly different than the behavior of output_files and output_directories: the executor will only create the parents of all of the specified output_paths, not the paths themselves.
Does not change the behavior when output_files and output_directories are used -- all specified output_directories will still be created and uploaded by the executor, and parents of output_files will be created and the files uploaded, just like before.
Version bump: Minor

Related issues: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1766