### PR TITLE
CLI: Add a `print` command to view serialized bazel log files

### DIFF
--- a/cli/bazelisk/bazelisk.go
+++ b/cli/bazelisk/bazelisk.go
@@ -199,10 +199,12 @@ func setBazelVersion() error {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	// Bazelisk probably chose us because we were specified first in
-	// .bazelversion. Delete the first line, if it exists.
-	if len(parts) > 0 {
-		parts = parts[1:]
+	// If we appear first in .bazelversion, ignore that version to prevent
+	// bazelisk from invoking us recursively.
+	if IsInvokedByBazelisk() {
+		for len(parts) > 0 && strings.HasPrefix(parts[0], "buildbuddy-io/") {
+			parts = parts[1:]
+		}
 	}
 	// If we couldn't find a non-BB bazel version in .bazelversion at this
 	// point, default to "latest".

--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//cli/metadata",
         "//cli/parser",
         "//cli/plugin",
+        "//cli/printlog",
         "//cli/remotebazel",
         "//cli/sidecar",
         "//cli/tooltag",

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/metadata"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 	"github.com/buildbuddy-io/buildbuddy/cli/plugin"
+	"github.com/buildbuddy-io/buildbuddy/cli/printlog"
 	"github.com/buildbuddy-io/buildbuddy/cli/remotebazel"
 	"github.com/buildbuddy-io/buildbuddy/cli/sidecar"
 	"github.com/buildbuddy-io/buildbuddy/cli/tooltag"
@@ -54,10 +55,23 @@ func run() (exitCode int, err error) {
 	if err != nil || exitCode >= 0 {
 		return exitCode, err
 	}
+	exitCode, err = printlog.HandlePrint(args)
+	if err != nil || exitCode >= 0 {
+		return exitCode, err
+	}
 	exitCode, err = update.HandleUpdate(args)
 	if err != nil || exitCode >= 0 {
 		return exitCode, err
 	}
+	exitCode, err = version.HandleVersion(args)
+	if err != nil || exitCode >= 0 {
+		return exitCode, err
+	}
+	// TODO: Convert this to (exitCode, err) convention
+	args = login.HandleLogin(args)
+
+	// If none of the CLI subcommand handlers were triggered, assume we have a
+	// bazel invocation.
 
 	// Maybe run interactively (watching for changes to files).
 	if exitCode, err := watcher.Watch(); exitCode >= 0 || err != nil {
@@ -100,7 +114,7 @@ func run() (exitCode int, err error) {
 		return -1, err
 	}
 
-	// Fiddle with args
+	// Fiddle with Bazel args
 	// TODO(bduffany): model these as "built-in" plugins
 	args = tooltag.ConfigureToolTag(args)
 	args = sidecar.ConfigureSidecar(args)
@@ -119,13 +133,9 @@ func run() (exitCode int, err error) {
 		}
 	}
 
-	// Handle commands
+	// Handle remote bazel. Note, pre-bazel hooks apply to remote bazel, but not
+	// output handlers or post-bazel hooks.
 	args = remotebazel.HandleRemoteBazel(args, passthroughArgs)
-	args = login.HandleLogin(args)
-	exitCode, err = version.HandleVersion(args)
-	if err != nil || exitCode >= 0 {
-		return exitCode, err
-	}
 
 	// If this is a `bazel run` command, add a --run_script arg so that
 	// we can execute post-bazel plugins between the build and the run step.

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -114,6 +114,7 @@ func printBBCommands() {
 	columns := [][]string{
 		{"install", "Installs a bb plugin (https://buildbuddy.io/plugins)."},
 		{"login", "Configures bb commands to use your BuildBuddy API key."},
+		{"print", "Displays various log file types written by bazel."},
 		{"remote", "Runs a bazel command in the cloud with BuildBuddy's hosted bazel service."},
 		{"update", "Updates the bb CLI to the latest version."},
 	}

--- a/cli/printlog/BUILD
+++ b/cli/printlog/BUILD
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "printlog",
+    srcs = ["printlog.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/printlog",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cli/arg",
+        "//cli/log",
+        "//proto:remote_execution_log_go_proto",
+        "@org_golang_google_protobuf//encoding/protojson",
+        "@org_golang_google_protobuf//proto",
+    ],
+)

--- a/cli/printlog/printlog.go
+++ b/cli/printlog/printlog.go
@@ -1,0 +1,108 @@
+package printlog
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	rlpb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution_log"
+)
+
+const (
+	usage = `
+usage: bb print --grpc_log=PATH
+
+Prints a human-readable representation of log files output by Bazel.
+
+Currently supported log types:
+  --grpc_log: Path to a file saved with --experimental_remote_grpc_log.
+`
+)
+
+var (
+	flags   = flag.NewFlagSet("print", flag.ContinueOnError)
+	grpcLog = flags.String("grpc_log", "", "gRPC log path.")
+)
+
+func HandlePrint(args []string) (int, error) {
+	cmd, idx := arg.GetCommandAndIndex(args)
+	if cmd != flags.Name() {
+		return -1, nil
+	}
+	if err := arg.ParseFlagSet(flags, args[idx+1:]); err != nil {
+		return -1, err
+	}
+	if *grpcLog != "" {
+		if err := printLog(*grpcLog, &rlpb.LogEntry{}); err != nil {
+			return -1, err
+		}
+		return 0, nil
+	}
+	log.Print(usage)
+	return 1, nil
+}
+
+func printLog(path string, m proto.Message) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := copyUnmarshaled(os.Stdout, f, m); err != nil {
+		return err
+	}
+	return nil
+}
+
+func copyUnmarshaled(w io.Writer, grpcLog io.Reader, m proto.Message) error {
+	pr := NewDelimitedProtoReader(grpcLog)
+	for {
+		err := pr.Unmarshal(m)
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read LogEntry: %s", err)
+		}
+		b, err := protojson.MarshalOptions{Multiline: true}.Marshal(m)
+		if err != nil {
+			return fmt.Errorf("failed to marshal remote gRPC log entry: %s", err)
+		}
+		if _, err := w.Write(b); err != nil {
+			return err
+		}
+		if _, err := w.Write([]byte{'\n'}); err != nil {
+			return err
+		}
+	}
+}
+
+type DelimitedProtoReader struct {
+	buf bytes.Buffer
+	r   *bufio.Reader
+}
+
+func NewDelimitedProtoReader(r io.Reader) *DelimitedProtoReader {
+	return &DelimitedProtoReader{r: bufio.NewReader(r)}
+}
+
+func (p *DelimitedProtoReader) Unmarshal(m proto.Message) error {
+	size, err := binary.ReadUvarint(p.r)
+	if err != nil {
+		return err
+	}
+	p.buf.Reset()
+	if _, err := io.CopyN(&p.buf, p.r, int64(size)); err != nil {
+		return err
+	}
+	return proto.Unmarshal(p.buf.Bytes(), m)
+}

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -396,6 +396,20 @@ proto_library(
 )
 
 proto_library(
+    name = "remote_execution_log_proto",
+    srcs = ["remote_execution_log.proto"],
+    deps = [
+        ":remote_execution_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@go_googleapis//google/api:annotations_proto",
+        "@go_googleapis//google/bytestream:bytestream_proto",
+        "@go_googleapis//google/longrunning:longrunning_proto",
+        "@go_googleapis//google/rpc:status_proto",
+    ],
+)
+
+proto_library(
     name = "remote_execution_proto",
     srcs = ["remote_execution.proto"],
     deps = [
@@ -845,6 +859,19 @@ go_proto_library(
         ":remote_execution_go_proto",
         ":semver_go_proto",
         "@go_googleapis//google/api:annotations_go_proto",
+        "@go_googleapis//google/longrunning:longrunning_go_proto",
+        "@go_googleapis//google/rpc:status_go_proto",
+    ],
+)
+
+go_proto_library(
+    name = "remote_execution_log_go_proto",
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/remote_execution_log",
+    proto = ":remote_execution_log_proto",
+    deps = [
+        ":remote_execution_go_proto",
+        "@go_googleapis//google/api:annotations_go_proto",
+        "@go_googleapis//google/bytestream:bytestream_go_proto",
         "@go_googleapis//google/longrunning:longrunning_go_proto",
         "@go_googleapis//google/rpc:status_go_proto",
     ],

--- a/proto/remote_execution_log.proto
+++ b/proto/remote_execution_log.proto
@@ -1,0 +1,184 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package remote_logging;
+
+import "proto/remote_execution.proto";
+import "google/protobuf/timestamp.proto";
+import "google/bytestream/bytestream.proto";
+import "google/longrunning/operations.proto";
+import "google/rpc/status.proto";
+
+option java_package = "com.google.devtools.build.lib.remote.logging";
+
+// A single log entry for gRPC calls related to remote execution.
+message LogEntry {
+  // Request metadata included in call.
+  build.bazel.remote.execution.v2.RequestMetadata metadata = 1;
+
+  // Status of the call on close.
+  google.rpc.Status status = 2;
+
+  // Full method name of the method called as returned from
+  // io.grpc.MethodDescriptor.getFullMethodName() (i.e. in format
+  // $FULL_SERVICE_NAME/$METHOD_NAME).
+  string method_name = 3;
+
+  // Method specific details for this call.
+  RpcCallDetails details = 4;
+
+  // Time the call started.
+  google.protobuf.Timestamp start_time = 5;
+
+  // Time the call closed.
+  google.protobuf.Timestamp end_time = 6;
+}
+
+// Details for a call to
+// build.bazel.remote.execution.v2.Execution.Execute.
+message ExecuteDetails {
+  // The build.bazel.remote.execution.v2.ExecuteRequest sent by the
+  // call.
+  build.bazel.remote.execution.v2.ExecuteRequest request = 1;
+
+  // Each google.longrunning.Operation received by the Execute call in order.
+  repeated google.longrunning.Operation responses = 2;
+}
+
+// Details for a call to
+// build.bazel.remote.execution.v2.ActionCache.GetCapabilities.
+message GetCapabilitiesDetails {
+  // The build.bazel.remote.execution.v2.GetCapabilitiesRequest sent by
+  // the call.
+  build.bazel.remote.execution.v2.GetCapabilitiesRequest request = 1;
+
+  // The received build.bazel.remote.execution.v2.ServerCapabilities.
+  build.bazel.remote.execution.v2.ServerCapabilities response = 2;
+}
+
+// Details for a call to
+// build.bazel.remote.execution.v2.ActionCache.GetActionResult.
+message GetActionResultDetails {
+  // The build.bazel.remote.execution.v2.GetActionResultRequest sent by
+  // the call.
+  build.bazel.remote.execution.v2.GetActionResultRequest request = 1;
+
+  // The received build.bazel.remote.execution.v2.ActionResult.
+  build.bazel.remote.execution.v2.ActionResult response = 2;
+}
+
+// Details for a call to
+// build.bazel.remote.execution.v2.ActionCache.UpdateActionResult.
+message UpdateActionResultDetails {
+  // The build.bazel.remote.execution.v2.GetActionResultRequest sent by
+  // the call.
+  build.bazel.remote.execution.v2.UpdateActionResultRequest request = 1;
+
+  // The received build.bazel.remote.execution.v2.ActionResult.
+  build.bazel.remote.execution.v2.ActionResult response = 2;
+}
+
+// Details for a call to build.bazel.remote.execution.v2.WaitExecution.
+message WaitExecutionDetails {
+  // The google.watcher.v1.Request sent by the Watch call.
+  build.bazel.remote.execution.v2.WaitExecutionRequest request = 1;
+
+  // Each google.longrunning.Operation received by the call in order.
+  repeated google.longrunning.Operation responses = 2;
+}
+
+// Details for a call to
+// build.bazel.remote.execution.v2.ContentAddressableStorage.FindMissingBlobs.
+message FindMissingBlobsDetails {
+  // The build.bazel.remote.execution.v2.FindMissingBlobsRequest request
+  // sent.
+  build.bazel.remote.execution.v2.FindMissingBlobsRequest request = 1;
+
+  // The build.bazel.remote.execution.v2.FindMissingBlobsResponse
+  // received.
+  build.bazel.remote.execution.v2.FindMissingBlobsResponse response = 2;
+}
+
+// Details for a call to google.bytestream.Read.
+message ReadDetails {
+  // The google.bytestream.ReadRequest sent.
+  google.bytestream.ReadRequest request = 1;
+
+  // The number of reads performed in this call.
+  int64 num_reads = 2;
+
+  // The total number of bytes read totalled over all stream responses.
+  int64 bytes_read = 3;
+}
+
+// Details for a call to google.bytestream.Write.
+message WriteDetails {
+  // The names of resources requested to be written to in this call in the order
+  // they were first requested in. If the ByteStream protocol is followed
+  // according to specification, this should contain at most two elements:
+  // The resource name specified in the first message of the stream, and an
+  // empty string specified in each successive request if num_writes > 1.
+  repeated string resource_names = 1;
+
+  // The offsets sent for the initial request and any non-sequential offsets
+  // specified over the course of the call. If the ByteStream protocol is
+  // followed according to specification, this should contain a single element
+  // which is the starting point for the write call.
+  repeated int64 offsets = 5;
+
+  // The effective final size for each request sent with finish_write true
+  // specified over the course of the call. If the ByteStream protocol is
+  // followed according to specification, this should contain a single element
+  // which is the total size of the written resource, including the initial
+  // offset.
+  repeated int64 finish_writes = 6;
+
+  // The number of writes performed in this call.
+  int64 num_writes = 2;
+
+  // The total number of bytes sent over the stream.
+  int64 bytes_sent = 3;
+
+  // The received google.bytestream.WriteResponse.
+  google.bytestream.WriteResponse response = 4;
+}
+
+// Details for a call to google.bytestream.QueryWriteStatus.
+message QueryWriteStatusDetails {
+  // The google.bytestream.QueryWriteStatusRequest sent by the call.
+  google.bytestream.QueryWriteStatusRequest request = 1;
+
+  // The received google.bytestream.QueryWriteStatusResponse.
+  google.bytestream.QueryWriteStatusResponse response = 2;
+}
+
+// Contains details for specific types of calls.
+message RpcCallDetails {
+  oneof details {
+    ExecuteDetails execute = 7;
+    GetActionResultDetails get_action_result = 8;
+    WaitExecutionDetails wait_execution = 9;
+    FindMissingBlobsDetails find_missing_blobs = 10;
+    ReadDetails read = 5;
+    WriteDetails write = 6;
+    GetCapabilitiesDetails get_capabilities = 12;
+    UpdateActionResultDetails update_action_result = 13;
+    QueryWriteStatusDetails query_write_status = 14;
+  }
+
+  // Reserved fields for V1 remote APIs, which BuildBuddy doesn't support.
+  reserved 1, 2, 3, 4;
+}


### PR DESCRIPTION
Adds a command `bb print --grpc_log=PATH` which prints a sequence of JSON-serialized LogEntry protos.

This is effectively the same as `remote_client --grpc_log` (from https://github.com/bazelbuild/tools_remote) except the output is easier to parse with something like `jq`, and also the BuildBuddy extensions to REAPI V2 are rendered with their correct names, instead of tag numbers (such as ExecutedActionMetadata.usage_stats).

Will add website docs in a separate PR.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
