### PR TITLE
CLI: prevent watcher from interrupting post-bazel plugins

### DIFF
--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -148,7 +148,12 @@ func run() (exitCode int, err error) {
 		return exitCode, nil
 	}
 
-	// Run plugin post-bazel hooks
+	// Run plugin post-bazel hooks.
+	// Pause the file watcher while these are in progress, so that plugins can
+	// apply fixes to files in the workspace without the watcher immediately
+	// restarting.
+	watcher.Pause()
+	defer watcher.Unpause()
 	for _, p := range plugins {
 		if err := p.PostBazel(outputPath); err != nil {
 			return -1, err

--- a/cli/watcher/BUILD
+++ b/cli/watcher/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cli/arg",
+        "//cli/log",
         "//cli/workspace",
         "//server/util/status",
         "@com_github_bduffany_godemon//:godemon",

--- a/deps.bzl
+++ b/deps.bzl
@@ -317,8 +317,8 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "com_github_bduffany_godemon",
         importpath = "github.com/bduffany/godemon",
-        sum = "h1:swhDsEzgaYy2dKQ9FCrbmYrGvk7+dZRvvHOUu2rZvR0=",
-        version = "v0.0.0-20221022171016-b1a022d2f9c2",
+        sum = "h1:Th4pNly+xoH2szOq4aA+uAFmg5h37BCyq3pFqnZGJ70=",
+        version = "v0.0.0-20221115232931-09721d48e30e",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/bazelbuild/bazelisk v1.11.0
 	github.com/bazelbuild/rules_go v0.29.0
 	github.com/bazelbuild/rules_webtesting v0.2.0
-	github.com/bduffany/godemon v0.0.0-20221022171016-b1a022d2f9c2
+	github.com/bduffany/godemon v0.0.0-20221115232931-09721d48e30e
 	github.com/bojand/ghz v0.95.0
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/buildbuddy-io/tensorflow-proto v0.0.0-20220908151343-929b41ab4dc6

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,8 @@ github.com/bazelbuild/rules_go v0.29.0 h1:SfxjyO/V68rVnzOHop92fB0gv/Aa75KNLAN0PM
 github.com/bazelbuild/rules_go v0.29.0/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=
 github.com/bazelbuild/rules_webtesting v0.2.0 h1:nhqjA2IslEOLViRBF5djQCiOD//7VyyHNKrqAZ1AuYA=
 github.com/bazelbuild/rules_webtesting v0.2.0/go.mod h1:M+vCvqp/1BViNuVL630BoiGqld9Q1vQzvf9bN/dWTeg=
-github.com/bduffany/godemon v0.0.0-20221022171016-b1a022d2f9c2 h1:swhDsEzgaYy2dKQ9FCrbmYrGvk7+dZRvvHOUu2rZvR0=
-github.com/bduffany/godemon v0.0.0-20221022171016-b1a022d2f9c2/go.mod h1:led5f4NrGeXrUKOlQA36mgNtNs7gVo86eZUOX42q5+8=
+github.com/bduffany/godemon v0.0.0-20221115232931-09721d48e30e h1:Th4pNly+xoH2szOq4aA+uAFmg5h37BCyq3pFqnZGJ70=
+github.com/bduffany/godemon v0.0.0-20221115232931-09721d48e30e/go.mod h1:led5f4NrGeXrUKOlQA36mgNtNs7gVo86eZUOX42q5+8=
 github.com/bduffany/redsync/v4 v4.4.1-minimal h1:wyBDr+ApDWybbLGMSsepl30KzPAl+HlIQMhJSoLdRKg=
 github.com/bduffany/redsync/v4 v4.4.1-minimal/go.mod h1:9+8jiPGz2n9ZaN8znvOqjyeXP/acSo6VAFPaG5Xdb2M=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=


### PR DESCRIPTION
If a post-bazel plugin (like `go-deps`) writes a file, it causes the file watcher to immediately kick in and restart the `bb` command, clobbering the console output and preventing other fixes from running. This PR pauses the watcher while post-bazel plugins are running, so that the plugins can run to completion before the `bb` command gets restarted.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
