### PR TITLE
CLI: Set USER_CACHE_DIR in plugin env

### DIFF
--- a/cli/plugin/plugin.go
+++ b/cli/plugin/plugin.go
@@ -479,6 +479,13 @@ func PrepareEnv() error {
 	if err := os.Setenv("USER_CONFIG_DIR", cfg); err != nil {
 		return err
 	}
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		return err
+	}
+	if err := os.Setenv("USER_CACHE_DIR", cache); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
This is useful for plugins to store build artifacts, e.g. via `go build`. Plugins should create their own plugin-specific dir under this cache dir. Per-version caches can be managed by the plugin if needed, e.g.  by creating a subdir like `$USER_CACHE_DIR/my-plugin-name/$(git rev-parse HEAD)`

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
