### PR TITLE
CLI: Fixes for ping-remote example plugin

### DIFF
--- a/cli/example_plugins/ping-remote/pre_bazel.sh
+++ b/cli/example_plugins/ping-remote/pre_bazel.sh
@@ -1,12 +1,25 @@
 #!/usr/bin/env bash
 
-if ! grep -E '^--remote_executor=.*\.buildbuddy\.io$' "$1" &>/dev/null; then
-  # BB remote execution is not enabled; do nothing.
+# Look for the effective (last) "--remote_executor" flag value,
+# converting "--remote_executor\n<value>" to "--remote_executor=<value>".
+REMOTE_EXECUTOR=$(
+  perl -p -e 's@^--remote_executor\n@--remote_executor=@' "$1" |
+    grep -E '^--remote_executor=' |
+    perl -p -e 's@^--remote_executor=(grpcs?://)?(.*?)(:\d+)?$@\2@' |
+    tail -n 1
+)
+if ! [[ "$REMOTE_EXECUTOR" ]]; then
+  # Remote execution is not enabled; do nothing.
   exit 0
 fi
 
+function timeout() {
+  perl -e 'alarm shift; exec @ARGV' "$@"
+}
+
 # Make sure we can ping the remote execution service in 500ms.
-if ! timeout 0.5 ping -c 1 remote.buildbuddy.io &>/dev/null; then
+if ! timeout 0.5 ping -c 1 "$REMOTE_EXECUTOR" &>/dev/null; then
   # Network is spotty; disable remote execution.
   echo "--remote_executor=" >>"$1"
+  echo >&2 -e "\x1b[33mWarning: failed to reach $REMOTE_EXECUTOR. Disabling remote execution.\x1b[m"
 fi


### PR DESCRIPTION
* Correctly parse args by looking only at the last `remote_executor` flag, and handling both `--remote_executor <value>` and `--remote_executor=<value>`.
* Pull in the `timeout` function from `siggisim/ping-remote`
* Handle any remote, not just `remote.buildbuddy.io`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
