### PR TITLE
Use `Timer` instead of `time.After` so we can drain channels and avoid a memory leak

### DIFF
--- a/server/backends/chunkstore/BUILD
+++ b/server/backends/chunkstore/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//server/interfaces",
         "//server/util/background",
         "//server/util/status",
+        "//server/util/timeutil",
     ],
 )
 

--- a/server/util/timeutil/timeutil.go
+++ b/server/util/timeutil/timeutil.go
@@ -63,3 +63,12 @@ func (*clock) Now() time.Time {
 func NewClock() Clock {
 	return &clock{}
 }
+
+func StopAndDrainTimer(t *time.Timer) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+}


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Addresses buildbuddy-io/buildbuddy-internal#1806

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
