### PR TITLE
CLI: Add bb update command to update the CLI itself

### DIFF
--- a/cli/BUILD
+++ b/cli/BUILD
@@ -2,3 +2,8 @@ alias(
     name = "cli",
     actual = "//cli/cmd/bb",
 )
+
+exports_files(
+    srcs = ["install.sh"],
+    visibility = ["//visibility:public"],
+)

--- a/cli/bazelisk/BUILD
+++ b/cli/bazelisk/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//cli/plugin",
         "//cli/terminal",
         "//cli/workspace",
-        "//server/util/disk",
         "//server/util/status",
         "@com_github_bazelbuild_bazelisk//core:go_default_library",
         "@com_github_bazelbuild_bazelisk//repositories:go_default_library",

--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//cli/remotebazel",
         "//cli/sidecar",
         "//cli/tooltag",
+        "//cli/update",
         "//cli/version",
         "//cli/watcher",
         "//server/util/status",

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/remotebazel"
 	"github.com/buildbuddy-io/buildbuddy/cli/sidecar"
 	"github.com/buildbuddy-io/buildbuddy/cli/tooltag"
+	"github.com/buildbuddy-io/buildbuddy/cli/update"
 	"github.com/buildbuddy-io/buildbuddy/cli/version"
 	"github.com/buildbuddy-io/buildbuddy/cli/watcher"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -49,8 +50,11 @@ func run() (exitCode int, err error) {
 	}
 
 	// Handle CLI-specific subcommands.
-	// TODO: Refactor so that logging is configured earlier.
 	exitCode, err = plugin.HandleInstall(args)
+	if err != nil || exitCode >= 0 {
+		return exitCode, err
+	}
+	exitCode, err = update.HandleUpdate(args)
 	if err != nil || exitCode >= 0 {
 		return exitCode, err
 	}
@@ -117,8 +121,11 @@ func run() (exitCode int, err error) {
 
 	// Handle commands
 	args = remotebazel.HandleRemoteBazel(args, passthroughArgs)
-	args = version.HandleVersion(args)
 	args = login.HandleLogin(args)
+	exitCode, err = version.HandleVersion(args)
+	if err != nil || exitCode >= 0 {
+		return exitCode, err
+	}
 
 	// If this is a `bazel run` command, add a --run_script arg so that
 	// we can execute post-bazel plugins between the build and the run step.

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -115,6 +115,7 @@ func printBBCommands() {
 		{"install", "Installs a bb plugin (https://buildbuddy.io/plugins)."},
 		{"login", "Configures bb commands to use your BuildBuddy API key."},
 		{"remote", "Runs a bazel command in the cloud with BuildBuddy's hosted bazel service."},
+		{"update", "Updates the bb CLI to the latest version."},
 	}
 	fmt.Println("bb commands:")
 	for _, row := range columns {

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -13,8 +13,9 @@ install_buildbuddy_cli() (
   # Look for the line matching
   #   "browser_download_url": "https://github.com/buildbuddy-io/bazel/releases/.../bazel-...-${os}-${arch}"
   # and extract the URL.
+  release="${1:-latest}"
   latest_binary_url=$(
-    curl -fsSL https://api.github.com/repos/buildbuddy-io/bazel/releases/latest |
+    curl -fsSL https://api.github.com/repos/buildbuddy-io/bazel/releases/"$release" |
       perl -nle 'if (/"browser_download_url":\s*"(.*?-'"${os}-${arch}"')"/) { print $1 }'
   )
 
@@ -30,4 +31,4 @@ install_buildbuddy_cli() (
   sudo mv "$tempfile" /usr/local/bin/bb
 )
 
-install_buildbuddy_cli
+install_buildbuddy_cli "$@"

--- a/cli/log/log.go
+++ b/cli/log/log.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	debugPrefix = "\x1b[33m[bb-debug]\x1b[m "
+	debugPrefix   = "\x1b[33m[bb-debug]\x1b[m "
+	warningPrefix = "\x1b[33mWarning:\x1b[m "
 )
 
 var verbose bool
@@ -39,6 +40,14 @@ func Print(v ...any) {
 
 func Printf(format string, v ...interface{}) {
 	log.Printf(format, v...)
+}
+
+func Warn(v ...any) {
+	log.Print(append([]any{warningPrefix}, v...)...)
+}
+
+func Warnf(format string, v ...interface{}) {
+	log.Printf(warningPrefix+format, v...)
 }
 
 func Fatalf(format string, v ...interface{}) {

--- a/cli/update/BUILD
+++ b/cli/update/BUILD
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+genrule(
+    name = "copy_install",
+    srcs = ["//cli:install.sh"],
+    outs = ["install.sh"],
+    cmd_bash = "cp $(SRCS) $@",
+)
+
+go_library(
+    name = "update",
+    srcs = ["update.go"],
+    embedsrcs = ["install.sh"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/update",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cli/arg",
+        "//cli/bazelisk",
+        "//cli/log",
+        "//cli/workspace",
+    ],
+)

--- a/cli/update/update.go
+++ b/cli/update/update.go
@@ -1,0 +1,190 @@
+package update
+
+import (
+	_ "embed"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
+	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
+)
+
+//go:embed install.sh
+var installScript string
+
+var (
+	flags         = flag.NewFlagSet("update", flag.ContinueOnError)
+	workspaceFlag = flags.Bool("workspace", false, "")
+	systemFlag    = flags.Bool("system", false, "")
+)
+
+const (
+	installPath      = "/usr/local/bin/bb"
+	latestVersionURL = "https://api.github.com/repos/buildbuddy-io/bazel/releases/latest"
+
+	usage = `
+usage: bb update
+
+Updates bb to the latest version.
+
+If --workspace is set, it updates (or adds) bb in your .bazelversion file
+so that collaborators will see the new version when running with bazel.
+
+If --system is set, it downloads the latest version to ` + installPath + `
+on your system.
+
+By default, --workspace or --system will be inferred based on whether
+bb is already running under bazelisk or directly via ` + installPath + `,
+respectively.
+`
+)
+
+func HandleUpdate(args []string) (exitCode int, err error) {
+	cmd, idx := arg.GetCommandAndIndex(args)
+	if cmd != flags.Name() {
+		return -1, nil
+	}
+	if err := arg.ParseFlagSet(flags, args[idx+1:]); err != nil {
+		log.Print(err.Error())
+		log.Print(usage)
+		return -1, nil
+	}
+	if !*workspaceFlag && !*systemFlag {
+		if bazelisk.IsInvokedByBazelisk() {
+			*workspaceFlag = true
+		} else {
+			*systemFlag = true
+		}
+	}
+
+	latestVersion, err := fetchLatestVersion()
+	if err != nil {
+		log.Printf("Failed to fetch latest version: %s", err)
+		return 1, nil
+	}
+
+	if *workspaceFlag {
+		if err := updateWorkspaceVersion(latestVersion); err != nil {
+			log.Printf("Failed to update .bazelversion: %s", err)
+			return 1, nil
+		}
+	}
+	if *systemFlag {
+		if err := updateSystemInstall(latestVersion); err != nil {
+			log.Printf("Failed to update system bb version: %s", err)
+			return 1, nil
+		}
+	}
+	return 0, nil
+}
+
+func fetchLatestVersion() (string, error) {
+	res, err := http.Get(latestVersionURL)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+	m := map[string]any{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return "", err
+	}
+	vi := m["tag_name"]
+	v, ok := vi.(string)
+	if !ok {
+		return "", fmt.Errorf("unexpected type %T for 'tag_name' in response from %s", vi, latestVersionURL)
+	}
+	if v == "" {
+		return "", fmt.Errorf("missing 'tag_name' key in response from %s", latestVersionURL)
+	}
+	return v, nil
+}
+
+// Attempts to update .bazelversion with the installed CLI version.
+func updateWorkspaceVersion(version string) error {
+	ws, err := workspace.Path()
+	if err != nil {
+		return err
+	}
+	bazelversionPath := filepath.Join(ws, ".bazelversion")
+	versions, err := bazelisk.ParseVersionDotfile(bazelversionPath)
+	if err != nil {
+		return err
+	}
+
+	versionLine := "buildbuddy-io/" + version
+	if len(versions) > 0 && strings.HasPrefix(versions[0], "buildbuddy-io/") {
+		if versions[0] == versionLine {
+			log.Printf(".bazelversion already includes %s", versionLine)
+			return nil
+		}
+		versions[0] = versionLine
+	} else {
+		versions = append([]string{versionLine}, versions...)
+	}
+	stat, err := os.Stat(bazelversionPath)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(bazelversionPath, os.O_TRUNC|os.O_WRONLY, stat.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Write([]byte(strings.Join(versions, "\n") + "\n")); err != nil {
+		return err
+	}
+	log.Printf("Successfully updated .bazelversion with %s", versionLine)
+	return nil
+}
+
+func getInstalledVersion() (string, error) {
+	_, err := os.Stat(installPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	b, err := exec.Command(installPath, "version", "--cli").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+func updateSystemInstall(version string) error {
+	installedVersion, err := getInstalledVersion()
+	if err != nil {
+		log.Warnf("Failed to determine installed version: %s.", err)
+	}
+	if installedVersion == version {
+		log.Printf("Version %s is already installed at %s", version, installPath)
+		return nil
+	}
+	log.Printf("Downloading latest version.")
+	if err := bash(installScript, "tags/"+version); err != nil {
+		return fmt.Errorf("failed to run install script: %s", err)
+	}
+	return nil
+}
+
+func bash(scriptContent string, args ...string) error {
+	bashArgs := append([]string{"-c", scriptContent}, args...)
+	cmd := exec.Command("bash", bashArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -6,14 +6,18 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 )
 
-func HandleVersion(args []string) []string {
+func HandleVersion(args []string) (exitCode int, err error) {
 	if arg.GetCommand(args) != "version" {
-		return args
+		return -1, nil
+	}
+	if arg.ContainsExact(args, "--cli") {
+		fmt.Println(cliVersionFlag)
+		return 0, nil
 	}
 	// The "version" var is generated in this package according to the
 	// Bazel flag value --//cli/version:cli_version
 	fmt.Printf("bb %s\n", cliVersionFlag)
-	return args
+	return -1, nil
 }
 
 func String() string {


### PR DESCRIPTION
This PR lets users update their CLI version to the latest version with `bb update`.

The command tries to be smart -- if bb is run via the `.bazelversion` trick, then it just updates the `.bazelversion` line to reference the new version. Otherwise it updates `/usr/local/bin/bb`. Users can override this default behavior by specifying `--workspace` and/or `--system`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
