### PR TITLE
Use resource.ResourceName in distributed cache function

### DIFF
--- a/enterprise/server/backends/distributed/BUILD
+++ b/enterprise/server/backends/distributed/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//proto:resource_go_proto",
         "//server/environment",
         "//server/interfaces",
-        "//server/remote_cache/digest",
         "//server/resources",
         "//server/util/background",
         "//server/util/consistent_hash",

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -16,7 +16,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
-	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/resources"
 	"github.com/buildbuddy-io/buildbuddy/server/util/background"
 	"github.com/buildbuddy-io/buildbuddy/server/util/consistent_hash"
@@ -61,13 +60,17 @@ type CacheConfig struct {
 }
 
 type hintedHandoffOrder struct {
-	ctx       context.Context
-	d         *repb.Digest
-	isolation *dcpb.Isolation
+	ctx context.Context
+	r   *resource.ResourceName
 }
 
 func (o *hintedHandoffOrder) String() string {
-	return fmt.Sprintf("{digest:%q isolation:{%s}}", o.d.GetHash(), o.isolation)
+	hash := o.r.GetDigest().GetHash()
+	isolation := &dcpb.Isolation{
+		CacheType:          o.r.GetCacheType(),
+		RemoteInstanceName: o.r.GetInstanceName(),
+	}
+	return fmt.Sprintf("{digest:%q isolation:{%s}}", hash, isolation)
 }
 
 type peerInfo struct {
@@ -221,7 +224,7 @@ func (c *Cache) recvHeartbeatCallback(ctx context.Context, peer string) {
 	c.heartbeatMu.Unlock()
 }
 
-func (c *Cache) recvHintedHandoffCallback(ctx context.Context, peer string, isolation *dcpb.Isolation, d *repb.Digest) {
+func (c *Cache) recvHintedHandoffCallback(ctx context.Context, peer string, r *resource.ResourceName) {
 	c.hintedHandoffsMu.Lock()
 	defer c.hintedHandoffsMu.Unlock()
 	if _, ok := c.hintedHandoffsByPeer[peer]; !ok {
@@ -230,9 +233,8 @@ func (c *Cache) recvHintedHandoffCallback(ctx context.Context, peer string, isol
 		c.hintedHandoffsByPeer[peer] = make(chan *hintedHandoffOrder, maxHintedHandoffsPerPeer)
 	}
 	order := &hintedHandoffOrder{
-		ctx:       ctx,
-		isolation: isolation,
-		d:         d,
+		ctx: ctx,
+		r:   r,
 	}
 	select {
 	case c.hintedHandoffsByPeer[peer] <- order:
@@ -250,7 +252,7 @@ func (c *Cache) handleHintedHandoffs(peer string) {
 		select {
 		case handoffOrder := <-c.hintedHandoffsByPeer[peer]:
 			ctx, cancel := background.ExtendContextForFinalization(handoffOrder.ctx, 10*time.Second)
-			err := c.sendFile(ctx, handoffOrder.d, handoffOrder.isolation, peer)
+			err := c.sendFile(ctx, handoffOrder.r, peer)
 			if err != nil {
 				c.log.Warningf("unable to complete hinted handoff to peer: %q: %s (order %s)", peer, err, handoffOrder)
 				return
@@ -362,17 +364,11 @@ func (c *Cache) readPeers(d *repb.Digest) *peerset.PeerSet {
 	return peerset.New(primaryPeers, secondaryPeers)
 }
 
-func (c *Cache) remoteContains(ctx context.Context, peer string, isolation *dcpb.Isolation, d *repb.Digest) (bool, error) {
+func (c *Cache) remoteContains(ctx context.Context, peer string, r *resource.ResourceName) (bool, error) {
 	if !c.config.DisableLocalLookup && peer == c.config.ListenAddr {
-		// No prefix necessary -- it's already set on the local cache.
-		return c.local.Contains(ctx, &resource.ResourceName{
-			Digest:       d,
-			InstanceName: isolation.GetRemoteInstanceName(),
-			Compressor:   repb.Compressor_IDENTITY,
-			CacheType:    isolation.GetCacheType(),
-		})
+		return c.local.Contains(ctx, r)
 	}
-	return c.cacheProxy.RemoteContains(ctx, peer, isolation, d)
+	return c.cacheProxy.RemoteContains(ctx, peer, r)
 }
 
 func (c *Cache) remoteMetadata(ctx context.Context, peer string, isolation *dcpb.Isolation, d *repb.Digest) (*interfaces.CacheMetadata, error) {
@@ -387,42 +383,30 @@ func (c *Cache) remoteMetadata(ctx context.Context, peer string, isolation *dcpb
 	return c.cacheProxy.RemoteMetadata(ctx, peer, isolation, d)
 }
 
-func (c *Cache) remoteFindMissing(ctx context.Context, peer string, isolation *dcpb.Isolation, digests []*repb.Digest) ([]*repb.Digest, error) {
+func (c *Cache) remoteFindMissing(ctx context.Context, peer string, isolation *dcpb.Isolation, rns []*resource.ResourceName) ([]*repb.Digest, error) {
 	if !c.config.DisableLocalLookup && peer == c.config.ListenAddr {
-		rns := digest.ResourceNames(isolation.GetCacheType(), isolation.GetRemoteInstanceName(), digests)
 		return c.local.FindMissing(ctx, rns)
 	}
-	return c.cacheProxy.RemoteFindMissing(ctx, peer, isolation, digests)
+	return c.cacheProxy.RemoteFindMissing(ctx, peer, isolation, rns)
 }
 
-func (c *Cache) remoteGetMulti(ctx context.Context, peer string, isolation *dcpb.Isolation, digests []*repb.Digest) (map[*repb.Digest][]byte, error) {
+func (c *Cache) remoteGetMulti(ctx context.Context, peer string, isolation *dcpb.Isolation, rns []*resource.ResourceName) (map[*repb.Digest][]byte, error) {
 	if !c.config.DisableLocalLookup && peer == c.config.ListenAddr {
-		rns := digest.ResourceNames(isolation.GetCacheType(), isolation.GetRemoteInstanceName(), digests)
 		return c.local.GetMulti(ctx, rns)
 	}
-	return c.cacheProxy.RemoteGetMulti(ctx, peer, isolation, digests)
+	return c.cacheProxy.RemoteGetMulti(ctx, peer, isolation, rns)
 }
-func (c *Cache) remoteReader(ctx context.Context, peer string, isolation *dcpb.Isolation, d *repb.Digest, offset, limit int64) (io.ReadCloser, error) {
+func (c *Cache) remoteReader(ctx context.Context, peer string, r *resource.ResourceName, offset, limit int64) (io.ReadCloser, error) {
 	if !c.config.DisableLocalLookup && peer == c.config.ListenAddr {
-		r := &resource.ResourceName{
-			Digest:       d,
-			InstanceName: isolation.GetRemoteInstanceName(),
-			CacheType:    isolation.GetCacheType(),
-		}
 		return c.local.Reader(ctx, r, offset, limit)
 	}
-	return c.cacheProxy.RemoteReader(ctx, peer, isolation, d, offset, limit)
+	return c.cacheProxy.RemoteReader(ctx, peer, r, offset, limit)
 }
-func (c *Cache) remoteWriter(ctx context.Context, peer, handoffPeer string, isolation *dcpb.Isolation, d *repb.Digest) (interfaces.CommittedWriteCloser, error) {
+func (c *Cache) remoteWriter(ctx context.Context, peer, handoffPeer string, r *resource.ResourceName) (interfaces.CommittedWriteCloser, error) {
 	if c.config.EnableLocalWrites && peer == c.config.ListenAddr {
-		r := &resource.ResourceName{
-			Digest:       d,
-			InstanceName: isolation.GetRemoteInstanceName(),
-			CacheType:    isolation.GetCacheType(),
-		}
 		return c.local.Writer(ctx, r)
 	}
-	return c.cacheProxy.RemoteWriter(ctx, peer, handoffPeer, isolation, d)
+	return c.cacheProxy.RemoteWriter(ctx, peer, handoffPeer, r)
 }
 func (c *Cache) remoteDelete(ctx context.Context, peer string, r *resource.ResourceName) error {
 	if !c.config.DisableLocalLookup && peer == c.config.ListenAddr {
@@ -434,22 +418,18 @@ func (c *Cache) remoteDelete(ctx context.Context, peer string, r *resource.Resou
 	}
 	return c.cacheProxy.RemoteDelete(ctx, peer, isolation, r.GetDigest())
 }
-func (c *Cache) sendFile(ctx context.Context, d *repb.Digest, isolation *dcpb.Isolation, dest string) error {
-	if exists, err := c.cacheProxy.RemoteContains(ctx, dest, isolation, d); err == nil && exists {
+
+func (c *Cache) sendFile(ctx context.Context, rn *resource.ResourceName, dest string) error {
+	if exists, err := c.cacheProxy.RemoteContains(ctx, dest, rn); err == nil && exists {
 		return nil
 	}
 
-	rn := &resource.ResourceName{
-		Digest:       d,
-		InstanceName: isolation.GetRemoteInstanceName(),
-		CacheType:    isolation.GetCacheType(),
-	}
 	r, err := c.local.Reader(ctx, rn, 0, 0)
 	if err != nil {
 		return err
 	}
 	defer r.Close()
-	rwc, err := c.cacheProxy.RemoteWriter(ctx, dest, "", isolation, d)
+	rwc, err := c.cacheProxy.RemoteWriter(ctx, dest, "", rn)
 	if err != nil {
 		return err
 	}
@@ -460,16 +440,16 @@ func (c *Cache) sendFile(ctx context.Context, d *repb.Digest, isolation *dcpb.Is
 	return rwc.Commit()
 }
 
-func (c *Cache) copyFile(ctx context.Context, d *repb.Digest, source string, isolation *dcpb.Isolation, dest string) error {
-	if exists, err := c.remoteContains(ctx, dest, isolation, d); err == nil && exists {
+func (c *Cache) copyFile(ctx context.Context, rn *resource.ResourceName, source string, dest string) error {
+	if exists, err := c.remoteContains(ctx, dest, rn); err == nil && exists {
 		return nil
 	}
-	r, err := c.remoteReader(ctx, source, isolation, d, 0, 0)
+	r, err := c.remoteReader(ctx, source, rn, 0, 0)
 	if err != nil {
 		return err
 	}
 	defer r.Close()
-	rwc, err := c.remoteWriter(ctx, dest, "", isolation, d)
+	rwc, err := c.remoteWriter(ctx, dest, "", rn)
 	if err != nil {
 		return err
 	}
@@ -481,7 +461,7 @@ func (c *Cache) copyFile(ctx context.Context, d *repb.Digest, source string, iso
 }
 
 type backfillOrder struct {
-	d      *repb.Digest
+	r      *resource.ResourceName
 	source string
 	dest   string
 }
@@ -490,16 +470,17 @@ func dedupeBackfills(backfills []*backfillOrder) []*backfillOrder {
 	deduped := make([]*backfillOrder, 0, len(backfills))
 	seen := make(map[string]struct{}, len(backfills))
 	for _, bf := range backfills {
-		if _, ok := seen[bf.d.GetHash()]; ok {
+		d := bf.r.GetDigest()
+		if _, ok := seen[d.GetHash()]; ok {
 			continue
 		}
-		seen[bf.d.GetHash()] = struct{}{}
+		seen[d.GetHash()] = struct{}{}
 		deduped = append(deduped, bf)
 	}
 	return deduped
 }
 
-func (c *Cache) backfillPeers(ctx context.Context, isolation *dcpb.Isolation, backfills []*backfillOrder) error {
+func (c *Cache) backfillPeers(ctx context.Context, backfills []*backfillOrder) error {
 	if len(backfills) == 0 {
 		return nil
 	}
@@ -508,13 +489,13 @@ func (c *Cache) backfillPeers(ctx context.Context, isolation *dcpb.Isolation, ba
 	for _, bf := range backfills {
 		bf := bf
 		eg.Go(func() error {
-			return c.copyFile(gCtx, bf.d, bf.source, isolation, bf.dest)
+			return c.copyFile(gCtx, bf.r, bf.source, bf.dest)
 		})
 	}
 	return eg.Wait()
 }
 
-func (c *Cache) getBackfillOrders(d *repb.Digest, ps *peerset.PeerSet) []*backfillOrder {
+func (c *Cache) getBackfillOrders(r *resource.ResourceName, ps *peerset.PeerSet) []*backfillOrder {
 	source, targets := ps.GetBackfillTargets()
 	if len(targets) == 0 {
 		return nil
@@ -525,7 +506,7 @@ func (c *Cache) getBackfillOrders(d *repb.Digest, ps *peerset.PeerSet) []*backfi
 		orders = append(orders, &backfillOrder{
 			source: source,
 			dest:   target,
-			d:      d,
+			r:      r,
 		})
 	}
 	return orders
@@ -538,19 +519,15 @@ func (c *Cache) getBackfillOrders(d *repb.Digest, ps *peerset.PeerSet) []*backfi
 //
 // Values found on a non-primary replica will be backfilled to the primary.
 func (c *Cache) Contains(ctx context.Context, r *resource.ResourceName) (bool, error) {
-	isolation := &dcpb.Isolation{
-		CacheType:          r.GetCacheType(),
-		RemoteInstanceName: r.GetInstanceName(),
-	}
 	ps := c.readPeers(r.GetDigest())
 	backfill := func() {
-		if err := c.backfillPeers(ctx, isolation, c.getBackfillOrders(r.GetDigest(), ps)); err != nil {
+		if err := c.backfillPeers(ctx, c.getBackfillOrders(r, ps)); err != nil {
 			c.log.Debugf("Error backfilling peers: %s", err)
 		}
 	}
 
 	for peer := ps.GetNextPeer(); peer != ""; peer = ps.GetNextPeer() {
-		exists, err := c.remoteContains(ctx, peer, isolation, r.GetDigest())
+		exists, err := c.remoteContains(ctx, peer, r)
 		if err == nil {
 			if exists {
 				c.log.Debugf("Contains(%q) found on peer %q", r.GetDigest(), peer)
@@ -575,7 +552,7 @@ func (c *Cache) Metadata(ctx context.Context, r *resource.ResourceName) (*interf
 	}
 	ps := c.readPeers(d)
 	backfill := func() {
-		if err := c.backfillPeers(ctx, isolation, c.getBackfillOrders(d, ps)); err != nil {
+		if err := c.backfillPeers(ctx, c.getBackfillOrders(r, ps)); err != nil {
 			c.log.Debugf("Error backfilling peers: %s", err)
 		}
 	}
@@ -606,15 +583,14 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*resource.ResourceN
 	}
 
 	mu := sync.RWMutex{} // protects(foundMap)
-	hashDigests := make(map[string][]*repb.Digest, 0)
+	hashResources := make(map[string][]*resource.ResourceName, 0)
 	foundMap := make(map[string]struct{}, len(resources))
 	peerMap := make(map[string]*peerset.PeerSet, len(resources))
 	for _, r := range resources {
-		d := r.GetDigest()
-		hash := d.GetHash()
-		hashDigests[hash] = append(hashDigests[hash], d)
+		hash := r.GetDigest().GetHash()
+		hashResources[hash] = append(hashResources[hash], r)
 		if _, ok := peerMap[hash]; !ok {
-			peerMap[hash] = c.readPeers(d)
+			peerMap[hash] = c.readPeers(r.GetDigest())
 		}
 	}
 
@@ -622,8 +598,8 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*resource.ResourceN
 		// Each iteration through this outer loop sends a "batch" of requests in
 		// parallel, until all digests have been found or we have exhausted all
 		// peers.
-		peerRequests := make(map[string][]*repb.Digest, 0)
-		for h, perHashDigests := range hashDigests {
+		peerRequests := make(map[string][]*resource.ResourceName, 0)
+		for h, perHashResources := range hashResources {
 			// If a previous request has already found this digest, skip it.
 			if _, ok := foundMap[h]; ok {
 				continue
@@ -636,11 +612,11 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*resource.ResourceN
 				c.log.Debugf("Exhausted all peers for %q. Peerset: %+v", h, ps)
 				continue
 			}
-			peerRequests[peer] = append(peerRequests[peer], perHashDigests[0])
+			peerRequests[peer] = append(peerRequests[peer], perHashResources[0])
 		}
 		if len(peerRequests) == 0 {
 			stillMissing := make([]string, 0)
-			for h := range hashDigests {
+			for h := range hashResources {
 				if _, ok := foundMap[h]; !ok {
 					stillMissing = append(stillMissing, h)
 				}
@@ -651,11 +627,11 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*resource.ResourceN
 			break
 		}
 		eg, gCtx := errgroup.WithContext(ctx)
-		for peer, digests := range peerRequests {
+		for peer, resources := range peerRequests {
 			peer := peer
-			digests := digests
+			resources := resources
 			eg.Go(func() error {
-				peerRsp, err := c.remoteFindMissing(gCtx, peer, isolation, digests)
+				peerRsp, err := c.remoteFindMissing(gCtx, peer, isolation, resources)
 				peerMissingHashes := make(map[string]struct{})
 				for _, d := range peerRsp {
 					peerMissingHashes[d.GetHash()] = struct{}{}
@@ -663,14 +639,16 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*resource.ResourceN
 				mu.Lock()
 				defer mu.Unlock()
 				if err != nil {
-					for _, d := range digests {
-						peerMap[d.GetHash()].MarkPeerAsFailed(peer)
+					for _, r := range resources {
+						hash := r.GetDigest().GetHash()
+						peerMap[hash].MarkPeerAsFailed(peer)
 					}
 					return nil
 				}
-				for _, d := range digests {
-					if _, ok := peerMissingHashes[d.GetHash()]; !ok {
-						foundMap[d.GetHash()] = struct{}{}
+				for _, r := range resources {
+					hash := r.GetDigest().GetHash()
+					if _, ok := peerMissingHashes[hash]; !ok {
+						foundMap[hash] = struct{}{}
 					}
 				}
 				return nil
@@ -684,7 +662,7 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*resource.ResourceN
 			}
 			continue
 		}
-		if len(foundMap) == len(hashDigests) {
+		if len(foundMap) == len(hashResources) {
 			// If we've found everything, we can exit now.
 			break
 		}
@@ -694,11 +672,11 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*resource.ResourceN
 	// on the first peer in our list, we want to backfill it.
 	backfills := make([]*backfillOrder, 0)
 	for h := range foundMap {
-		d := hashDigests[h][0]
+		r := hashResources[h][0]
 		ps := peerMap[h]
-		backfills = append(backfills, c.getBackfillOrders(d, ps)...)
+		backfills = append(backfills, c.getBackfillOrders(r, ps)...)
 	}
-	if err := c.backfillPeers(ctx, isolation, backfills); err != nil {
+	if err := c.backfillPeers(ctx, backfills); err != nil {
 		c.log.Debugf("Error backfilling peers: %s", err)
 	}
 
@@ -729,29 +707,23 @@ func getIsolation(resources []*resource.ResourceName) *dcpb.Isolation {
 // This is like setting READ_CONSISTENCY = ONE.
 //
 // Values found on a non-primary replica will be backfilled to the primary.
-func (c *Cache) distributedReader(ctx context.Context, r *resource.ResourceName, offset, limit int64) (io.ReadCloser, error) {
-	isolation := &dcpb.Isolation{
-		CacheType:          r.GetCacheType(),
-		RemoteInstanceName: r.GetInstanceName(),
-	}
-	d := r.GetDigest()
-
-	ps := c.readPeers(r.GetDigest())
+func (c *Cache) distributedReader(ctx context.Context, rn *resource.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+	ps := c.readPeers(rn.GetDigest())
 	backfill := func() {
-		if err := c.backfillPeers(ctx, isolation, c.getBackfillOrders(d, ps)); err != nil {
+		if err := c.backfillPeers(ctx, c.getBackfillOrders(rn, ps)); err != nil {
 			c.log.Debugf("Error backfilling peers: %s", err)
 		}
 	}
 
 	for peer := ps.GetNextPeer(); peer != ""; peer = ps.GetNextPeer() {
-		r, err := c.remoteReader(ctx, peer, isolation, d, offset, limit)
+		r, err := c.remoteReader(ctx, peer, rn, offset, limit)
 		if err == nil {
-			c.log.Debugf("Reader(%q) found on peer %s", cacheproxy.IsolationToString(isolation)+d.GetHash(), peer)
+			c.log.Debugf("Reader(%q) found on peer %s", cacheproxy.ResourceIsolationString(rn), peer)
 			backfill()
 			return r, err
 		}
 		if status.IsNotFoundError(err) {
-			c.log.Debugf("Reader(%q) not found on peer %s", cacheproxy.IsolationToString(isolation)+d.GetHash(), peer)
+			c.log.Debugf("Reader(%q) not found on peer %s", cacheproxy.ResourceIsolationString(rn), peer)
 			continue
 		}
 
@@ -759,7 +731,7 @@ func (c *Cache) distributedReader(ctx context.Context, r *resource.ResourceName,
 		ps.MarkPeerAsFailed(peer)
 
 	}
-	return nil, status.NotFoundErrorf("Exhausted all peers attempting to read %q, peerset: %v", d.GetHash(), ps)
+	return nil, status.NotFoundErrorf("Exhausted all peers attempting to read %q, peerset: %v", rn.GetDigest().GetHash(), ps)
 }
 
 func (c *Cache) Get(ctx context.Context, rn *resource.ResourceName) ([]byte, error) {
@@ -778,15 +750,14 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*resource.ResourceName
 	}
 
 	mu := sync.RWMutex{} // protects(gotMap)
-	hashDigests := make(map[string][]*repb.Digest, 0)
+	hashResources := make(map[string][]*resource.ResourceName, 0)
 	gotMap := make(map[string][]byte, len(resources))
 	peerMap := make(map[string]*peerset.PeerSet, len(resources))
 	for _, r := range resources {
-		d := r.GetDigest()
-		hash := d.GetHash()
-		hashDigests[hash] = append(hashDigests[hash], d)
+		hash := r.GetDigest().GetHash()
+		hashResources[hash] = append(hashResources[hash], r)
 		if _, ok := peerMap[hash]; !ok {
-			peerMap[hash] = c.readPeers(d)
+			peerMap[hash] = c.readPeers(r.GetDigest())
 		}
 	}
 
@@ -794,8 +765,8 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*resource.ResourceName
 		// Each iteration through this outer loop sends a "batch" of requests in
 		// parallel, until all digests have been found or we have exhausted all
 		// peers.
-		peerRequests := make(map[string][]*repb.Digest, 0)
-		for h, perHashDigests := range hashDigests {
+		peerRequests := make(map[string][]*resource.ResourceName, 0)
+		for h, perHashResources := range hashResources {
 			// If a previous request has already found this digest, skip it.
 			if _, ok := gotMap[h]; ok {
 				continue
@@ -808,11 +779,11 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*resource.ResourceName
 				c.log.Debugf("Exhausted all peers for %q. Peerset: %+v", h, ps)
 				continue
 			}
-			peerRequests[peer] = append(peerRequests[peer], perHashDigests[0])
+			peerRequests[peer] = append(peerRequests[peer], perHashResources[0])
 		}
 		if len(peerRequests) == 0 {
 			stillMissing := make([]string, 0)
-			for h := range hashDigests {
+			for h := range hashResources {
 				if _, ok := gotMap[h]; !ok {
 					stillMissing = append(stillMissing, h)
 				}
@@ -822,17 +793,18 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*resource.ResourceName
 			break
 		}
 		eg, gCtx := errgroup.WithContext(ctx)
-		for peer, digests := range peerRequests {
+		for peer, resources := range peerRequests {
 			peer := peer
-			digests := digests
+			resources := resources
 			eg.Go(func() error {
-				peerRsp, err := c.remoteGetMulti(gCtx, peer, isolation, digests)
+				peerRsp, err := c.remoteGetMulti(gCtx, peer, isolation, resources)
 				mu.Lock()
 				defer mu.Unlock()
 				if err != nil {
 					c.log.Debugf("GetMulti: peer %q returned err: %s", peer, err)
-					for _, d := range digests {
-						peerMap[d.GetHash()].MarkPeerAsFailed(peer)
+					for _, r := range resources {
+						hash := r.GetDigest().GetHash()
+						peerMap[hash].MarkPeerAsFailed(peer)
 					}
 					return nil
 				}
@@ -850,7 +822,7 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*resource.ResourceName
 			}
 			continue
 		}
-		if len(gotMap) == len(hashDigests) {
+		if len(gotMap) == len(hashResources) {
 			// If we've found everything, we can exit now.
 			break
 		}
@@ -862,11 +834,11 @@ func (c *Cache) GetMulti(ctx context.Context, resources []*resource.ResourceName
 	for h, buf := range gotMap {
 		if len(buf) > 0 {
 			ps := peerMap[h]
-			d := hashDigests[h][0]
-			backfills = append(backfills, c.getBackfillOrders(d, ps)...)
+			r := hashResources[h][0]
+			backfills = append(backfills, c.getBackfillOrders(r, ps)...)
 		}
 	}
-	if err := c.backfillPeers(ctx, isolation, backfills); err != nil {
+	if err := c.backfillPeers(ctx, backfills); err != nil {
 		c.log.Debugf("Error backfilling peers: %s", err)
 	}
 
@@ -971,7 +943,7 @@ func (c *Cache) multiWriter(ctx context.Context, r *resource.ResourceName) (inte
 		isolation:   isolation,
 	}
 	for peer, hintedHandoff := ps.GetNextPeerAndHandoff(); peer != ""; peer, hintedHandoff = ps.GetNextPeerAndHandoff() {
-		rwc, err := c.remoteWriter(ctx, peer, hintedHandoff, isolation, r.GetDigest())
+		rwc, err := c.remoteWriter(ctx, peer, hintedHandoff, r)
 		if err != nil {
 			ps.MarkPeerAsFailed(peer)
 			log.Infof("Error opening remote writer for %q to peer %q: %s", r.GetDigest().GetHash(), peer, err)

--- a/enterprise/server/util/cacheproxy/BUILD
+++ b/enterprise/server/util/cacheproxy/BUILD
@@ -43,11 +43,9 @@ go_test(
         "//server/testutil/testdigest",
         "//server/testutil/testenv",
         "//server/testutil/testport",
-        "//server/util/log",
         "//server/util/prefix",
         "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//require",
-        "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//testing/protocmp",
     ],
 )

--- a/enterprise/server/util/cacheproxy/BUILD
+++ b/enterprise/server/util/cacheproxy/BUILD
@@ -43,7 +43,11 @@ go_test(
         "//server/testutil/testdigest",
         "//server/testutil/testenv",
         "//server/testutil/testport",
+        "//server/util/log",
         "//server/util/prefix",
+        "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//testing/protocmp",
     ],
 )

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -176,11 +176,7 @@ func (c *CacheProxy) FindMissing(ctx context.Context, req *dcpb.FindMissingReque
 		return nil, err
 	}
 
-	digests := make([]*resource.ResourceName, 0)
-	for _, r := range req.GetResources() {
-		digests = append(digests, r)
-	}
-	missing, err := c.cache.FindMissing(ctx, digests)
+	missing, err := c.cache.FindMissing(ctx, req.GetResources())
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/util/cacheproxy/cacheproxy_test.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy_test.go
@@ -19,7 +19,9 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	dcpb "github.com/buildbuddy-io/buildbuddy/proto/distributed_cache"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -110,10 +112,6 @@ func TestReaderMaxOffset(t *testing.T) {
 	readSeeker.Seek(0, 0)
 
 	instanceName := "foo"
-	isolation := &dcpb.Isolation{
-		RemoteInstanceName: instanceName,
-		CacheType:          resource.CacheType_CAS,
-	}
 	rn := &resource.ResourceName{
 		Digest:       d,
 		CacheType:    resource.CacheType_CAS,
@@ -126,7 +124,7 @@ func TestReaderMaxOffset(t *testing.T) {
 	}
 
 	// Remote-read the random bytes back.
-	r, err := c.RemoteReader(ctx, peer, isolation, d, d.GetSizeBytes(), 0)
+	r, err := c.RemoteReader(ctx, peer, rn, d.GetSizeBytes(), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,12 +172,13 @@ func TestWriteAlreadyExistsCAS(t *testing.T) {
 
 	testSize := int64(10000000)
 	d, readSeeker := testdigest.NewRandomDigestReader(t, testSize)
-	isolation := &dcpb.Isolation{
+	rn := &resource.ResourceName{
+		Digest:    d,
 		CacheType: resource.CacheType_CAS,
 	}
 
 	// Remote-write the random bytes to the cache (with a prefix).
-	wc, err := c.RemoteWriter(ctx, peer, noHandoff, isolation, d)
+	wc, err := c.RemoteWriter(ctx, peer, noHandoff, rn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +192,7 @@ func TestWriteAlreadyExistsCAS(t *testing.T) {
 
 	// Reset readSeeker.
 	readSeeker.Seek(0, 0)
-	wc, err = c.RemoteWriter(ctx, peer, noHandoff, isolation, d)
+	wc, err = c.RemoteWriter(ctx, peer, noHandoff, rn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -228,13 +227,13 @@ func TestWriteAlreadyExistsAC(t *testing.T) {
 
 	testSize := int64(10000000)
 	d, readSeeker := testdigest.NewRandomDigestReader(t, testSize)
-
-	isolation := &dcpb.Isolation{
+	rn := &resource.ResourceName{
+		Digest:    d,
 		CacheType: resource.CacheType_AC,
 	}
 
 	// Remote-write the random bytes to the cache (with a prefix).
-	wc, err := c.RemoteWriter(ctx, peer, noHandoff, isolation, d)
+	wc, err := c.RemoteWriter(ctx, peer, noHandoff, rn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -248,7 +247,7 @@ func TestWriteAlreadyExistsAC(t *testing.T) {
 
 	// Reset readSeeker.
 	readSeeker.Seek(0, 0)
-	wc, err = c.RemoteWriter(ctx, peer, noHandoff, isolation, d)
+	wc, err = c.RemoteWriter(ctx, peer, noHandoff, rn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -284,7 +283,6 @@ func TestReader(t *testing.T) {
 
 	for _, testSize := range testSizes {
 		remoteInstanceName := fmt.Sprintf("prefix/%d", testSize)
-		isolation := &dcpb.Isolation{CacheType: resource.CacheType_CAS, RemoteInstanceName: remoteInstanceName}
 
 		// Read some random bytes.
 		buf := new(bytes.Buffer)
@@ -310,7 +308,7 @@ func TestReader(t *testing.T) {
 		}
 
 		// Remote-read the random bytes back.
-		r, err := c.RemoteReader(ctx, peer, isolation, d, 0, 0)
+		r, err := c.RemoteReader(ctx, peer, rn, 0, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -346,8 +344,7 @@ func TestReadOffsetLimit(t *testing.T) {
 
 	offset := int64(2)
 	limit := int64(3)
-	isolation := &dcpb.Isolation{CacheType: resource.CacheType_CAS}
-	reader, err := c.RemoteReader(ctx, peer, isolation, d, offset, limit)
+	reader, err := c.RemoteReader(ctx, peer, r, offset, limit)
 	require.NoError(t, err)
 
 	readBuf := make([]byte, size)
@@ -380,7 +377,6 @@ func TestWriter(t *testing.T) {
 
 	for _, testSize := range testSizes {
 		remoteInstanceName := fmt.Sprintf("prefix/%d", testSize)
-		isolation := &dcpb.Isolation{CacheType: resource.CacheType_CAS, RemoteInstanceName: remoteInstanceName}
 
 		// Read some random bytes.
 		buf := new(bytes.Buffer)
@@ -400,7 +396,7 @@ func TestWriter(t *testing.T) {
 		readSeeker.Seek(0, 0)
 
 		// Remote-write the random bytes to the cache (with a prefix).
-		wc, err := c.RemoteWriter(ctx, peer, noHandoff, isolation, d)
+		wc, err := c.RemoteWriter(ctx, peer, noHandoff, rn)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -443,11 +439,13 @@ func TestWriteAlreadyExists(t *testing.T) {
 
 	testSize := int64(10000000)
 	d, readSeeker := testdigest.NewRandomDigestReader(t, testSize)
-	remoteInstanceName := ""
-	isolation := &dcpb.Isolation{CacheType: resource.CacheType_CAS, RemoteInstanceName: remoteInstanceName}
+	rn := &resource.ResourceName{
+		Digest:    d,
+		CacheType: resource.CacheType_CAS,
+	}
 
 	// Remote-write the random bytes to the cache (with a prefix).
-	wc, err := c.RemoteWriter(ctx, peer, noHandoff, isolation, d)
+	wc, err := c.RemoteWriter(ctx, peer, noHandoff, rn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -461,7 +459,7 @@ func TestWriteAlreadyExists(t *testing.T) {
 
 	// Reset readSeeker.
 	readSeeker.Seek(0, 0)
-	wc, err = c.RemoteWriter(ctx, peer, noHandoff, isolation, d)
+	wc, err = c.RemoteWriter(ctx, peer, noHandoff, rn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -497,7 +495,6 @@ func TestContains(t *testing.T) {
 
 	for _, testSize := range testSizes {
 		remoteInstanceName := fmt.Sprintf("prefix/%d", testSize)
-		isolation := &dcpb.Isolation{CacheType: resource.CacheType_CAS, RemoteInstanceName: remoteInstanceName}
 
 		// Read some random bytes.
 		buf := new(bytes.Buffer)
@@ -522,7 +519,7 @@ func TestContains(t *testing.T) {
 		}
 
 		// Ensure key exists.
-		ok, err := c.RemoteContains(ctx, peer, isolation, d)
+		ok, err := c.RemoteContains(ctx, peer, r)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -537,7 +534,7 @@ func TestContains(t *testing.T) {
 		}
 
 		// Ensure it no longer exists.
-		ok, err = c.RemoteContains(ctx, peer, isolation, d)
+		ok, err = c.RemoteContains(ctx, peer, r)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -571,7 +568,6 @@ func TestOversizeBlobs(t *testing.T) {
 
 	for _, testSize := range testSizes {
 		remoteInstanceName := fmt.Sprintf("prefix/%d", testSize)
-		isolation := &dcpb.Isolation{CacheType: resource.CacheType_CAS, RemoteInstanceName: remoteInstanceName}
 
 		// Read some random bytes.
 		buf := new(bytes.Buffer)
@@ -583,13 +579,18 @@ func TestOversizeBlobs(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		rn := &resource.ResourceName{
+			Digest:       d,
+			CacheType:    resource.CacheType_CAS,
+			InstanceName: remoteInstanceName,
+		}
 
 		// Now tack on a little bit of "extra" data.
 		buf.Write([]byte("overload"))
 		readSeeker = bytes.NewReader(buf.Bytes())
 
 		// Remote-write the random bytes to the cache (with a prefix).
-		wc, err := c.RemoteWriter(ctx, peer, noHandoff, isolation, d)
+		wc, err := c.RemoteWriter(ctx, peer, noHandoff, rn)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -607,7 +608,7 @@ func TestOversizeBlobs(t *testing.T) {
 		}
 
 		// Remote-read the random bytes back.
-		r, err := c.RemoteReader(ctx, peer, isolation, d, 0, 0)
+		r, err := c.RemoteReader(ctx, peer, rn, 0, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -651,7 +652,7 @@ func TestFindMissing(t *testing.T) {
 		remoteInstanceName := fmt.Sprintf("prefix/%d", tc.numExistingDigests)
 		isolation := &dcpb.Isolation{CacheType: resource.CacheType_CAS, RemoteInstanceName: remoteInstanceName}
 
-		existingDigests := make([]*repb.Digest, 0, tc.numExistingDigests)
+		existingDigests := make([]*resource.ResourceName, 0, tc.numExistingDigests)
 		for i := 0; i < tc.numExistingDigests; i++ {
 			// Read some random bytes.
 			buf := new(bytes.Buffer)
@@ -668,7 +669,7 @@ func TestFindMissing(t *testing.T) {
 				CacheType:    resource.CacheType_CAS,
 				InstanceName: remoteInstanceName,
 			}
-			existingDigests = append(existingDigests, d)
+			existingDigests = append(existingDigests, r)
 			// Set the random bytes in the cache (with a prefix)
 			err = te.GetCache().Set(ctx, r, buf.Bytes())
 			if err != nil {
@@ -676,15 +677,22 @@ func TestFindMissing(t *testing.T) {
 			}
 		}
 
+		var missingResources []*resource.ResourceName
 		var missingDigests []*repb.Digest
 		for i := 0; i < tc.numMissingDigests; i++ {
 			d, _ := testdigest.NewRandomDigestBuf(t, 1000)
+			r := &resource.ResourceName{
+				Digest:       d,
+				CacheType:    resource.CacheType_CAS,
+				InstanceName: remoteInstanceName,
+			}
+			missingResources = append(missingResources, r)
 			missingDigests = append(missingDigests, d)
 		}
 
-		remoteMissing, err := c.RemoteFindMissing(ctx, peer, isolation, append(existingDigests, missingDigests...))
+		remoteMissing, err := c.RemoteFindMissing(ctx, peer, isolation, append(existingDigests, missingResources...))
 		require.NoError(t, err)
-		require.ElementsMatch(t, remoteMissing, missingDigests)
+		require.Empty(t, cmp.Diff(missingDigests, remoteMissing, protocmp.Transform()))
 	}
 }
 
@@ -713,7 +721,7 @@ func TestGetMulti(t *testing.T) {
 		remoteInstanceName := fmt.Sprintf("prefix/%d", numDigests)
 		isolation := &dcpb.Isolation{CacheType: resource.CacheType_CAS, RemoteInstanceName: remoteInstanceName}
 
-		digests := make([]*repb.Digest, 0, numDigests)
+		digests := make([]*resource.ResourceName, 0, numDigests)
 		for i := 0; i < numDigests; i++ {
 			// Read some random bytes.
 			buf := new(bytes.Buffer)
@@ -730,7 +738,7 @@ func TestGetMulti(t *testing.T) {
 				CacheType:    resource.CacheType_CAS,
 				InstanceName: remoteInstanceName,
 			}
-			digests = append(digests, d)
+			digests = append(digests, r)
 			// Set the random bytes in the cache (with a prefix)
 			err = te.GetCache().Set(ctx, r, buf.Bytes())
 			if err != nil {
@@ -744,9 +752,9 @@ func TestGetMulti(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, d := range digests {
-			buf, ok := gotMap[d]
-			if !ok || int64(len(buf)) != d.GetSizeBytes() {
-				t.Fatalf("Digest %q was uploaded but is not contained in cache", d.GetHash())
+			buf, ok := gotMap[d.GetDigest()]
+			if !ok || int64(len(buf)) != d.GetDigest().GetSizeBytes() {
+				t.Fatalf("Digest %q was uploaded but is not contained in cache", d.GetDigest().GetHash())
 			}
 		}
 	}
@@ -769,7 +777,6 @@ func TestEmptyRead(t *testing.T) {
 	waitUntilServerIsAlive(peer)
 
 	remoteInstanceName := "null"
-	isolation := &dcpb.Isolation{CacheType: resource.CacheType_CAS, RemoteInstanceName: remoteInstanceName}
 	d := &repb.Digest{
 		Hash:      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 		SizeBytes: 0,
@@ -784,7 +791,7 @@ func TestEmptyRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := c.RemoteReader(ctx, peer, isolation, d, 0, 0)
+	r, err := c.RemoteReader(ctx, peer, rn, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -826,7 +833,7 @@ func TestDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	exists, err := c.RemoteContains(ctx, peer, isolation, d)
+	exists, err := c.RemoteContains(ctx, peer, r)
 	require.NoError(t, err)
 	require.True(t, exists)
 
@@ -834,7 +841,7 @@ func TestDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	// Ensure it no longer exists
-	exists, err = c.RemoteContains(ctx, peer, isolation, d)
+	exists, err = c.RemoteContains(ctx, peer, r)
 	require.NoError(t, err)
 	require.False(t, exists)
 }

--- a/enterprise/server/util/cacheproxy/cacheproxy_test.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy_test.go
@@ -820,7 +820,6 @@ func TestDelete(t *testing.T) {
 	waitUntilServerIsAlive(peer)
 
 	remoteInstanceName := "remote/instance"
-	isolation := &dcpb.Isolation{CacheType: resource.CacheType_CAS, RemoteInstanceName: remoteInstanceName}
 
 	// Write to the cache (with a prefix)
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
@@ -837,7 +836,7 @@ func TestDelete(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, exists)
 
-	err = c.RemoteDelete(ctx, peer, isolation, d)
+	err = c.RemoteDelete(ctx, peer, r)
 	require.NoError(t, err)
 
 	// Ensure it no longer exists
@@ -887,6 +886,7 @@ func TestMetadata(t *testing.T) {
 			Key:       d.GetHash(),
 			SizeBytes: d.GetSizeBytes(),
 		},
+		Resource: r,
 	})
 	if err != nil {
 		t.Fatalf("Error fetching metadata from cacheproxy: %s", err)

--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -14,7 +14,8 @@ message Key {
   int64 size_bytes = 2;
 }
 
-// TODO: Delete key and isolation fields once PR to stop reading them has been rolled out
+// TODO: Delete key and isolation fields once PR to stop reading them has been
+// rolled out
 message ReadRequest {
   Isolation isolation = 4;
   reserved 1;
@@ -28,7 +29,8 @@ message ReadResponse {
   bytes data = 1;
 }
 
-// TODO: Delete key and isolation fields once PR to stop reading them has been rolled out
+// TODO: Delete key and isolation fields once PR to stop reading them has been
+// rolled out
 message WriteRequest {
   Isolation isolation = 6;
   reserved 1;
@@ -53,7 +55,8 @@ message DeleteRequest {
 
 message DeleteResponse {}
 
-// TODO: Delete key and isolation fields once PR to stop reading them has been rolled out
+// TODO: Delete key and isolation fields once PR to stop reading them has been
+// rolled out
 message FindMissingRequest {
   Isolation isolation = 1;
   repeated Key key = 2;

--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -14,68 +14,68 @@ message Key {
   int64 size_bytes = 2;
 }
 
-// TODO: Delete key and isolation fields once PR to stop reading them has been
-// rolled out
 message ReadRequest {
-  Isolation isolation = 4;
   reserved 1;
-  Key key = 2;
   int64 offset = 3;
   int64 limit = 5;
   resource.ResourceName resource = 6;
+
+  // Deprecated fields - use resource field instead
+  Isolation isolation = 4;
+  Key key = 2;
 }
 
 message ReadResponse {
   bytes data = 1;
 }
 
-// TODO: Delete key and isolation fields once PR to stop reading them has been
-// rolled out
 message WriteRequest {
-  Isolation isolation = 6;
   reserved 1;
-  Key key = 2;
   bool finish_write = 3;
   bytes data = 4;
+  resource.ResourceName resource = 7;
 
   // A node that this data should eventually be handed off to.
   // Clients should attempt to replicate this data when possible.
   string handoff_peer = 5;
-  resource.ResourceName resource = 7;
+
+  // Deprecated fields - use resource field instead
+  Isolation isolation = 6;
+  Key key = 2;
 }
 
 message WriteResponse {
   int64 committed_size = 1;
 }
 
-// TODO: Delete key and isolation fields once PR to stop reading them has been
-// rolled out
 message DeleteRequest {
+  resource.ResourceName resource = 3;
+
+  // Deprecated fields - use resource field instead
   Isolation isolation = 1;
   Key key = 2;
-  resource.ResourceName resource = 3;
 }
 
 message DeleteResponse {}
 
-// TODO: Delete key and isolation fields once PR to stop reading them has been
-// rolled out
 message FindMissingRequest {
+  repeated resource.ResourceName resources = 3;
+
+  // Deprecated fields - use resource field instead
   Isolation isolation = 1;
   repeated Key key = 2;
-  repeated resource.ResourceName resources = 3;
 }
 
 message FindMissingResponse {
   repeated Key missing = 1;
 }
 
-// TODO: Delete key and isolation fields once PR to stop reading them has been
-// rolled out
 message MetadataRequest {
+  resource.ResourceName resource = 3;
+
+  // Deprecated fields - use resource field instead
   Isolation isolation = 1;
   Key key = 2;
-  resource.ResourceName resource = 3;
 }
 
 message MetadataResponse {
@@ -89,12 +89,13 @@ message KV {
   bytes value = 2;
 }
 
-// TODO: Delete key field once PR to stop reading them has been rolled out
 message GetMultiRequest {
-  Isolation isolation = 3;
   reserved 1;
-  repeated Key key = 2;
   repeated resource.ResourceName resources = 4;
+
+  // Deprecated fields - use resource field instead
+  Isolation isolation = 3;
+  repeated Key key = 2;
 }
 
 message GetMultiResponse {

--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -48,9 +48,12 @@ message WriteResponse {
   int64 committed_size = 1;
 }
 
+// TODO: Delete key and isolation fields once PR to stop reading them has been
+// rolled out
 message DeleteRequest {
   Isolation isolation = 1;
   Key key = 2;
+  resource.ResourceName resource = 3;
 }
 
 message DeleteResponse {}
@@ -67,9 +70,12 @@ message FindMissingResponse {
   repeated Key missing = 1;
 }
 
+// TODO: Delete key and isolation fields once PR to stop reading them has been
+// rolled out
 message MetadataRequest {
   Isolation isolation = 1;
   Key key = 2;
+  resource.ResourceName resource = 3;
 }
 
 message MetadataResponse {

--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -14,18 +14,21 @@ message Key {
   int64 size_bytes = 2;
 }
 
+// TODO: Delete key and isolation fields once PR to stop reading them has been rolled out
 message ReadRequest {
   Isolation isolation = 4;
   reserved 1;
   Key key = 2;
   int64 offset = 3;
   int64 limit = 5;
+  resource.ResourceName resource = 6;
 }
 
 message ReadResponse {
   bytes data = 1;
 }
 
+// TODO: Delete key and isolation fields once PR to stop reading them has been rolled out
 message WriteRequest {
   Isolation isolation = 6;
   reserved 1;
@@ -36,6 +39,7 @@ message WriteRequest {
   // A node that this data should eventually be handed off to.
   // Clients should attempt to replicate this data when possible.
   string handoff_peer = 5;
+  resource.ResourceName resource = 7;
 }
 
 message WriteResponse {
@@ -49,9 +53,11 @@ message DeleteRequest {
 
 message DeleteResponse {}
 
+// TODO: Delete key and isolation fields once PR to stop reading them has been rolled out
 message FindMissingRequest {
   Isolation isolation = 1;
   repeated Key key = 2;
+  repeated resource.ResourceName resources = 3;
 }
 
 message FindMissingResponse {
@@ -74,10 +80,12 @@ message KV {
   bytes value = 2;
 }
 
+// TODO: Delete key field once PR to stop reading them has been rolled out
 message GetMultiRequest {
   Isolation isolation = 3;
   reserved 1;
   repeated Key key = 2;
+  repeated resource.ResourceName resources = 4;
 }
 
 message GetMultiResponse {


### PR DESCRIPTION
We need this change in order to pass a resource's compression type to distributed cache methods
