### PR TITLE
Disable telemetry in tests

### DIFF
--- a/enterprise/server/testutil/buildbuddy_enterprise/BUILD
+++ b/enterprise/server/testutil/buildbuddy_enterprise/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//proto:context_go_proto",
         "//proto:user_go_proto",
         "//server/testutil/app",
-        "//server/testutil/testport",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//proto",
     ],

--- a/enterprise/server/testutil/buildbuddy_enterprise/buildbuddy_enterprise.go
+++ b/enterprise/server/testutil/buildbuddy_enterprise/buildbuddy_enterprise.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/app"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
@@ -32,10 +31,9 @@ func Run(t *testing.T, args ...string) *app.App {
 func RunWithConfig(t *testing.T, configPath string, args ...string) *app.App {
 	redisTarget := testredis.Start(t).Target
 	commandArgs := []string{
-		fmt.Sprintf("--telemetry_port=%d", testport.FindFree(t)),
 		"--app_directory=/enterprise/app",
-		"--disable_telemetry",
 		"--app.default_redis_target=" + redisTarget,
+		"--telemetry_port=-1",
 	}
 	commandArgs = append(commandArgs, args...)
 	return app.Run(

--- a/server/testutil/app/app.go
+++ b/server/testutil/app/app.go
@@ -39,6 +39,7 @@ func Run(t *testing.T, commandPath string, commandArgs []string, configFilePath 
 	args := []string{
 		"--app.log_level=debug",
 		"--app.log_include_short_file_name",
+		"--disable_telemetry",
 		fmt.Sprintf("--config_file=%s", runfile(t, configFilePath)),
 		fmt.Sprintf("--port=%d", app.httpPort),
 		fmt.Sprintf("--grpc_port=%d", app.gRPCPort),


### PR DESCRIPTION
I can't repro this now, but earlier some tests were being slow (taking 20s longer than usual) since the telemetry client was timing out.

There's not much value in having telemetry enabled for tests (this probably just muddies our telemetry data) so this PR makes sure that telemetry is disabled in tests.

* Disable telemetry client for OSS app in tests, not just the enterprise app
* Disable telemetry server for enterprise app in tests

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
