### PR TITLE
Make repo build with bazel 6

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -135,8 +135,8 @@ go_library(
 platform(
     name = "firecracker",
     constraint_values = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:linux",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
     ],
     exec_properties = {
         "workload-isolation-type": "firecracker",
@@ -146,8 +146,8 @@ platform(
 platform(
     name = "firecracker_vfs",
     constraint_values = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:linux",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
     ],
     exec_properties = {
         "workload-isolation-type": "firecracker",
@@ -158,8 +158,8 @@ platform(
 platform(
     name = "vfs",
     constraint_values = [
-        "@bazel_tools//platforms:x86_64",
-        "@bazel_tools//platforms:linux",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
     ],
     exec_properties = {
         "enable-vfs": "true",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -182,9 +182,9 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_k8s",
-    sha256 = "51f0977294699cd547e139ceff2396c32588575588678d2054da167691a227ef",
-    strip_prefix = "rules_k8s-0.6",
-    urls = ["https://github.com/bazelbuild/rules_k8s/archive/v0.6.tar.gz"],
+    sha256 = "ce5b9bc0926681e2e7f2147b49096f143e6cbc783e71bc1d4f36ca76b00e6f4a",
+    strip_prefix = "rules_k8s-0.7",
+    urls = ["https://github.com/bazelbuild/rules_k8s/archive/refs/tags/v0.7.tar.gz"],
 )
 
 load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_defaults", "k8s_repositories")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,11 +9,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 http_archive(
     name = "platforms",
+    sha256 = "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
         "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
     ],
-    sha256 = "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
 )
 
 # Go

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,6 +5,17 @@ workspace(
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
+# Bazel platforms
+
+http_archive(
+    name = "platforms",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+    ],
+    sha256 = "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
+)
+
 # Go
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -115,7 +115,7 @@ yarn_install(
     name = "npm",
     exports_directories_only = False,
     package_json = "//:package.json",
-    symlink_node_modules = True,
+    symlink_node_modules = False,
     yarn_lock = "//:yarn.lock",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -193,7 +193,7 @@ k8s_repositories()
 
 load("@io_bazel_rules_k8s//k8s:k8s_go_deps.bzl", k8s_go_deps = "deps")
 
-k8s_go_deps()
+k8s_go_deps(go_version = "")
 
 k8s_defaults(
     name = "k8s_deploy",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,5 @@
 workspace(
     name = "buildbuddy",
-    managed_directories = {"@npm": ["node_modules"]},
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")


### PR DESCRIPTION
I had to do a few things to make this work:
- Remove the managed_directories directive from our WORKSPACE file and set symlink_node_modules to False in the yarn_install directive.
- Migrate to platform definitions from https://github.com/bazelbuild/platforms.
- Upgrade to version 0.7 of rules_k8s (which switches to use the platform definitions above).
- Clear the go_version passed into k8s_go_deps, otherwise it specifies a version which conflicts with ours. I thought about changing our version to match theirs but that didn't work out of the box and I thought it'd be better to have ours be the only go version definition.

You can test this yourself by running (change version & checksum for different platforms):
`wget -O /tmp/bazel-6.0.0-pre.20221020.1-linux-x86_64 https://github.com/bazelbuild/bazel/releases/download/6.0.0-pre.20221020.1/bazel-6.0.0-pre.20221020.1-linux-x86_64 && echo "b8bf93fc9fd780c2e3e5fe7222de70edc019076a8f53c8f67ce0054d955a5ede  /tmp/bazel-6.0.0-pre.20221020.1-linux-x86_64" | sha256sum --check --status && chmod +x /tmp/bazel-6.0.0-pre.20221020.1-linux-x86_64 && git clone https://github.com/buildbuddy-io/buildbuddy /tmp/bb && cd /tmp/bb && git checkout bazel_6_its_one_bigger_isnt_it && /tmp/bazel-6.0.0-pre.20221020.1-linux-x86_64 build //...`

**Version bump**: Minor
**Related issues**: Partially fixes #1810