### PR TITLE
Implement SupportsCompressor for migration cache

### DIFF
--- a/enterprise/server/backends/migration_cache/config.go
+++ b/enterprise/server/backends/migration_cache/config.go
@@ -44,6 +44,7 @@ type PebbleCacheConfig struct {
 	AtimeBufferSize        *int                    `yaml:"atime_buffer_size"`
 	MinEvictionAge         *time.Duration          `yaml:"min_eviction_age"`
 	IsolateByGroupIDs      bool                    `yaml:"isolate_by_group_ids"`
+	EnableZstdCompression  bool                    `yaml:"enable_zstd_compression"`
 }
 
 func (cfg *MigrationConfig) SetConfigDefaults() {


### PR DESCRIPTION
* Also fix a bug in FindMissing where we were hardcoding "Compressor: repb.Compressor_IDENTITY" when queuing the data to be copied. FindMissing is always called with resources with the identity compressor anyway, so this shouldn't matter. But it's technically incorrect and could cause a subtle bug later