### PR TITLE
Add timing breakdown card to timing profile

### DIFF
--- a/app/flame_chart/colors.ts
+++ b/app/flame_chart/colors.ts
@@ -2,7 +2,7 @@
 // These colors were generated using a perceived brightness of 156 +/- 3
 // We want the perceived brightness to be constant so that text always
 // displays consistently against flame chart colors.
-export default [
+const colors =  [
   "#17b51a",
   "#36a9c5",
   "#64ad02",
@@ -132,3 +132,24 @@ export default [
   "#21a3fb",
   "#1cacb8",
 ];
+
+/**
+ * Returns a random color for the given ID.
+ *
+ * Calls for the same ID will return the same color.
+ *
+ * All colors returned have the same approximate perceived brightness
+ * to avoid issues with color contrast.
+ */
+ const getColor = (id: string) => colors[Math.abs(hash(id) % colors.length)];
+
+ function hash(value: string) {
+   let hash = 0;
+   for (let i = 0; i < value?.length; i++) {
+     hash = ((hash << 5) - hash + value.charCodeAt(i)) | 0;
+   }
+   return hash;
+ }
+ 
+
+ export default getColor;

--- a/app/flame_chart/colors.ts
+++ b/app/flame_chart/colors.ts
@@ -2,7 +2,7 @@
 // These colors were generated using a perceived brightness of 156 +/- 3
 // We want the perceived brightness to be constant so that text always
 // displays consistently against flame chart colors.
-const colors =  [
+const colors = [
   "#17b51a",
   "#36a9c5",
   "#64ad02",
@@ -141,15 +141,14 @@ const colors =  [
  * All colors returned have the same approximate perceived brightness
  * to avoid issues with color contrast.
  */
- const getColor = (id: string) => colors[Math.abs(hash(id) % colors.length)];
+const getColor = (id: string) => colors[Math.abs(hash(id) % colors.length)];
 
- function hash(value: string) {
-   let hash = 0;
-   for (let i = 0; i < value?.length; i++) {
-     hash = ((hash << 5) - hash + value.charCodeAt(i)) | 0;
-   }
-   return hash;
- }
- 
+function hash(value: string) {
+  let hash = 0;
+  for (let i = 0; i < value?.length; i++) {
+    hash = ((hash << 5) - hash + value.charCodeAt(i)) | 0;
+  }
+  return hash;
+}
 
- export default getColor;
+export default getColor;

--- a/app/flame_chart/flame_chart_model.ts
+++ b/app/flame_chart/flame_chart_model.ts
@@ -1,4 +1,4 @@
-import colors from "./colors";
+import getColor from "./colors";
 import { buildThreadTimelines, ThreadEvent, TraceEvent } from "./profile_model";
 import {
   BLOCK_HEIGHT,
@@ -30,24 +30,6 @@ export type BlockModel = {
   };
   event: ThreadEvent;
 };
-
-/**
- * Returns a random color for the given ID.
- *
- * Calls for the same ID will return the same color.
- *
- * All colors returned have the same approximate perceived brightness
- * to avoid issues with color contrast.
- */
-const getColor = (id: string) => colors[Math.abs(hash(id) % colors.length)];
-
-function hash(value: string) {
-  let hash = 0;
-  for (let i = 0; i < value.length; i++) {
-    hash = ((hash << 5) - hash + value.charCodeAt(i)) | 0;
-  }
-  return hash;
-}
 
 export function buildFlameChartModel(events: TraceEvent[], { visibilityThreshold = 0 } = {}): FlameChartModel {
   let currentThreadY = 0;

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -538,6 +538,15 @@
   font-weight: 20px;
 }
 
+.cache-stat-duration {
+  min-width: 60px;
+  display: inline-block;
+}
+
+.cache-stat-description {
+  font-weight: normal;
+}
+
 .cache-chart-label {
   display: flex;
 }

--- a/app/invocation/invocation_breakdown_card.tsx
+++ b/app/invocation/invocation_breakdown_card.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { PieChart as PieChartIcon } from "lucide-react";
 import { ResponsiveContainer, PieChart, Pie, Cell } from "recharts";
-import format from "app/format/format";
-import getColor from "app/flame_chart/colors";
+import format from "../format/format";
+import getColor from "../flame_chart/colors";
 
 interface Props {
   durationMap: Map<string, number>;

--- a/app/invocation/invocation_breakdown_card.tsx
+++ b/app/invocation/invocation_breakdown_card.tsx
@@ -8,6 +8,11 @@ interface Props {
   durationMap: Map<string, number>;
 }
 
+interface Datum {
+  name: string;
+  value: number;
+}
+
 export default class InvocationBreakdownCardComponent extends React.Component<Props> {
   render() {
     let launching = this.props.durationMap.get("Launch Blaze");
@@ -38,10 +43,6 @@ export default class InvocationBreakdownCardComponent extends React.Component<Pr
 
     phaseData = phaseData.sort((a, b) => b.value - a.value).filter((entry) => entry.value > 0);
 
-    let phaseSum = phaseData.reduce((prev, current) => {
-      return { name: "Sum", value: prev.value + current.value };
-    });
-
     let executionData = [
       { value: runningProcess, name: "Executing locally" },
       { value: inputMapping, name: "Input mapping" },
@@ -70,71 +71,51 @@ export default class InvocationBreakdownCardComponent extends React.Component<Pr
           <div className="title">Timing Breakdown</div>
           <div className="details">
             <div className="cache-sections">
-              <div className="cache-section">
-                <div className="cache-title">Phase breakdown</div>
-                <div className="cache-subtitle">Breakdown of build phases</div>
-                <div className="cache-chart">
-                  <ResponsiveContainer width={100} height={100}>
-                    <PieChart>
-                      <Pie data={phaseData} dataKey="value" outerRadius={40} innerRadius={20}>
-                        {phaseData.map((entry, index) => (
-                          <Cell key={`cell-${index}`} fill={getColor(entry.name)} />
-                        ))}
-                      </Pie>
-                    </PieChart>
-                  </ResponsiveContainer>
-                  <div>
-                    {phaseData.map((entry, index) => (
-                      <div className="cache-chart-label">
-                        <span
-                          className="color-swatch cache-hit-color-swatch"
-                          style={{ backgroundColor: getColor(entry.name) }}></span>
-                        <span className="cache-stat">
-                          <span className="cache-stat-duration">{format.durationUsec(entry.value)}</span>{" "}
-                          <span className="cache-stat-description">
-                            {entry.name} ({format.percent(entry.value / phaseSum.value)}%)
-                          </span>
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
-
-              <div className="cache-section">
-                <div className="cache-title">Execution breakdown</div>
-                <div className="cache-subtitle">Breakdown totals across all threads</div>
-                <div className="cache-chart">
-                  <ResponsiveContainer width={100} height={100}>
-                    <PieChart>
-                      <Pie data={executionData} dataKey="value" outerRadius={40} innerRadius={20}>
-                        {executionData.map((entry, index) => (
-                          <Cell key={`cell-${index}`} fill={getColor(entry.name)} />
-                        ))}
-                      </Pie>
-                    </PieChart>
-                  </ResponsiveContainer>
-                  <div>
-                    {executionData.map((entry, index) => (
-                      <div className="cache-chart-label">
-                        <span
-                          className="color-swatch cache-hit-color-swatch"
-                          style={{ backgroundColor: getColor(entry.name) }}></span>
-                        <span className="cache-stat">
-                          <span className="cache-stat-duration">{format.durationUsec(entry.value)}</span>{" "}
-                          <span className="cache-stat-description">
-                            {entry.name} ({format.percent(entry.value / executionSum.value)}%)
-                          </span>
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
+              {renderBreakdown(phaseData)}
+              {renderBreakdown(executionData)}
             </div>
           </div>
         </div>
       </div>
     );
   }
+}
+
+function renderBreakdown(data: Datum[]) {
+  let sum = data.reduce((prev, current) => {
+    return { name: "Sum", value: prev.value + current.value };
+  });
+
+  return (
+    <div className="cache-section">
+      <div className="cache-title">Phase breakdown</div>
+      <div className="cache-subtitle">Breakdown of build phases</div>
+      <div className="cache-chart">
+        <ResponsiveContainer width={100} height={100}>
+          <PieChart>
+            <Pie data={data} dataKey="value" outerRadius={40} innerRadius={20}>
+              {data.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={getColor(entry.name)} />
+              ))}
+            </Pie>
+          </PieChart>
+        </ResponsiveContainer>
+        <div>
+          {data.map((entry, index) => (
+            <div className="cache-chart-label">
+              <span
+                className="color-swatch cache-hit-color-swatch"
+                style={{ backgroundColor: getColor(entry.name) }}></span>
+              <span className="cache-stat">
+                <span className="cache-stat-duration">{format.durationUsec(entry.value)}</span>{" "}
+                <span className="cache-stat-description">
+                  {entry.name} ({format.percent(entry.value / sum.value)}%)
+                </span>
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/app/invocation/invocation_breakdown_card.tsx
+++ b/app/invocation/invocation_breakdown_card.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { PieChart as PieChartIcon } from "lucide-react";
+import { ResponsiveContainer, PieChart, Pie, Cell } from "recharts";
+import format from "app/format/format";
+import getColor from "app/flame_chart/colors";
+
+interface Props {
+  durationMap: Map<string, number>;
+}
+
+export default class InvocationBreakdownCardComponent extends React.Component<Props> {
+  render() {
+    let launching = this.props.durationMap.get("Launch Blaze");
+    let total = this.props.durationMap.get("buildTargets");
+    let targets = this.props.durationMap.get("evaluateTargetPatterns");
+    let analysis = this.props.durationMap.get("runAnalysisPhase");
+    let building = total - analysis - targets;
+
+    let runningProcess = this.props.durationMap.get("subprocess.run");
+    let executingRemotely = this.props.durationMap.get("execute remotely");
+    let sandboxSetup = this.props.durationMap.get("sandbox.createFileSystem");
+    let sandboxTeardown = this.props.durationMap.get("sandbox.delete");
+    let inputMapping = this.props.durationMap.get("AbstractSpawnStrategy.getInputMapping");
+    let merkleTree = this.props.durationMap.get("MerkleTree.build(ActionInput)");
+    let downloadOuputs = this.props.durationMap.get("download outputs");
+    let uploadMissing = this.props.durationMap.get("upload missing inputs");
+    let uploadOutputs = this.props.durationMap.get("upload outputs");
+    let checkCache = this.props.durationMap.get("check cache hit");
+    let detectModifiedOutput = this.props.durationMap.get("detectModifiedOutputFiles");
+    let stableStatus = this.props.durationMap.get("BazelWorkspaceStatusAction stable-status.txt");
+
+    let phaseData = [
+      { value: launching, name: "Launch" },
+      { value: targets, name: "Evaluation" },
+      { value: analysis, name: "Analysis" },
+      { value: building, name: "Execution" },
+    ];
+
+    phaseData = phaseData.sort((a, b) => b.value - a.value).filter((entry) => entry.value > 0);
+
+    let phaseSum = phaseData.reduce((prev, current) => {
+      return { name: "Sum", value: prev.value + current.value };
+    });
+
+    let executionData = [
+      { value: runningProcess, name: "Executing locally" },
+      { value: inputMapping, name: "Input mapping" },
+      { value: merkleTree, name: "Merkle tree building" },
+      { value: sandboxSetup, name: "Local sandbox creation" },
+      { value: sandboxTeardown, name: "Local sandbox teardown" },
+      { value: executingRemotely, name: "Executing remotely" },
+      { value: checkCache, name: "Checking cache hits" },
+      { value: uploadMissing, name: "Uploading missing inputs" },
+      { value: downloadOuputs, name: "Downloading outputs" },
+      { value: uploadOutputs, name: "Uploading inputs" },
+      { value: detectModifiedOutput, name: "Detect modified output files" },
+      { value: stableStatus, name: "Generating stable-status.txt" },
+    ];
+
+    executionData = executionData.sort((a, b) => (b?.value || 0) - (a?.value || 0)).filter((entry) => entry.value > 0);
+
+    let executionSum = executionData.reduce((prev, current) => {
+      return { name: "Sum", value: (prev.value || 0) + (current.value || 0) };
+    });
+
+    return (
+      <div className="card">
+        <PieChartIcon className="icon" />
+        <div className="content">
+          <div className="title">Timing Breakdown</div>
+          <div className="details">
+            <div className="cache-sections">
+              <div className="cache-section">
+                <div className="cache-title">Phase breakdown</div>
+                <div className="cache-subtitle">Breakdown of build phases</div>
+                <div className="cache-chart">
+                  <ResponsiveContainer width={100} height={100}>
+                    <PieChart>
+                      <Pie data={phaseData} dataKey="value" outerRadius={40} innerRadius={20}>
+                        {phaseData.map((entry, index) => (
+                          <Cell key={`cell-${index}`} fill={getColor(entry.name)} />
+                        ))}
+                      </Pie>
+                    </PieChart>
+                  </ResponsiveContainer>
+                  <div>
+                    {phaseData.map((entry, index) => (
+                      <div className="cache-chart-label">
+                        <span
+                          className="color-swatch cache-hit-color-swatch"
+                          style={{ backgroundColor: getColor(entry.name) }}></span>
+                        <span className="cache-stat">
+                          <span className="cache-stat-duration">{format.durationUsec(entry.value)}</span>{" "}
+                          <span className="cache-stat-description">
+                            {entry.name} ({format.percent(entry.value / phaseSum.value)}%)
+                          </span>
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="cache-section">
+                <div className="cache-title">Execution breakdown</div>
+                <div className="cache-subtitle">Breakdown totals across all threads</div>
+                <div className="cache-chart">
+                  <ResponsiveContainer width={100} height={100}>
+                    <PieChart>
+                      <Pie data={executionData} dataKey="value" outerRadius={40} innerRadius={20}>
+                        {executionData.map((entry, index) => (
+                          <Cell key={`cell-${index}`} fill={getColor(entry.name)} />
+                        ))}
+                      </Pie>
+                    </PieChart>
+                  </ResponsiveContainer>
+                  <div>
+                    {executionData.map((entry, index) => (
+                      <div className="cache-chart-label">
+                        <span
+                          className="color-swatch cache-hit-color-swatch"
+                          style={{ backgroundColor: getColor(entry.name) }}></span>
+                        <span className="cache-stat">
+                          <span className="cache-stat-duration">{format.durationUsec(entry.value)}</span>{" "}
+                          <span className="cache-stat-description">
+                            {entry.name} ({format.percent(entry.value / executionSum.value)}%)
+                          </span>
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -6,8 +6,10 @@ import { Profile, parseProfile } from "../flame_chart/profile_model";
 import rpcService from "../service/rpc_service";
 import InvocationModel from "./invocation_model";
 import Button from "../components/button/button";
-import { Clock } from "lucide-react";
+import { Clock, HelpCircle } from "lucide-react";
 import errorService from "../errors/error_service";
+import format from "app/format/format";
+import InvocationBreakdownCardComponent from "./invocation_breakdown_card";
 
 interface Props {
   model: InvocationModel;
@@ -19,6 +21,7 @@ interface State {
   threadNumPages: number;
   threadToNumEventPagesMap: Map<number, number>;
   threadMap: Map<number, Thread>;
+  durationMap: Map<string, number>;
   sortBy: string;
   groupBy: string;
   threadPageSize: number;
@@ -48,6 +51,7 @@ export default class InvocationTimingCardComponent extends React.Component<Props
     threadNumPages: 1,
     threadToNumEventPagesMap: new Map<number, number>(),
     threadMap: new Map<number, Thread>(),
+    durationMap: new Map<string, number>(),
     sortBy: window.localStorage[sortByStorageKey] || sortByTimeAscStorageValue,
     groupBy: window.localStorage[groupByStorageKey] || groupByThreadStorageValue,
     threadPageSize: window.localStorage[threadPageSizeStorageKey] || 10,
@@ -115,6 +119,14 @@ export default class InvocationTimingCardComponent extends React.Component<Props
         events: [] as any[],
       };
 
+      if (event.dur) {
+        if (this.state.durationMap.get(event.name)) {
+          this.state.durationMap.set(event.name, this.state.durationMap.get(event.name) + event.dur);
+        } else {
+          this.state.durationMap.set(event.name, event.dur);
+        }
+      }
+
       if (event.ph == "X") {
         // Duration events
         thread.events.push(event);
@@ -178,14 +190,6 @@ export default class InvocationTimingCardComponent extends React.Component<Props
     return this.state.threadToNumEventPagesMap.get(threadId) || 1;
   }
 
-  formatDuration(durationMicros: number) {
-    let durationSeconds = durationMicros / 1000000;
-    if (durationSeconds < 100) {
-      return durationSeconds.toPrecision(3);
-    }
-    return durationSeconds.toFixed(0);
-  }
-
   renderEmptyState() {
     if (this.state.loading) {
       return <div className="loading" />;
@@ -207,7 +211,6 @@ export default class InvocationTimingCardComponent extends React.Component<Props
       );
     }
 
-    console.assert(!this.isTimingEnabled());
     return (
       <>
         <p>Profiling isn't enabled for this invocation.</p>
@@ -240,6 +243,24 @@ export default class InvocationTimingCardComponent extends React.Component<Props
     return (
       <>
         <FlameChart profile={this.state.profile} />
+        <InvocationBreakdownCardComponent durationMap={this.state.durationMap} />
+
+        <div className="card card-suggestion">
+          <HelpCircle className="icon" />
+          <div className="content">
+            <div className="title">Want better timing data?</div>
+            <div className="details">
+              <div className="suggestions-tab-link">
+                For a more detailed timing profile, try using these flags:{" "}
+                <span className="inline-code bazel-flag">--noslim_profile</span>{" "}
+                <span className="inline-code bazel-flag">--experimental_profile_include_target_label</span>{" "}
+                <span className="inline-code bazel-flag">--experimental_profile_include_primary_output</span>{" "}
+                {/* <TextLink href="#suggestions">Click here to view suggestions</TextLink> based on your timing profile! */}
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div className="card timing">
           <Clock className="icon" />
           <div className="content">
@@ -355,7 +376,7 @@ export default class InvocationTimingCardComponent extends React.Component<Props
                                 <div>
                                   {event.name} {event.args?.target}
                                 </div>
-                                <div>{this.formatDuration(event.dur)} seconds</div>
+                                <div>{format.durationUsec(event.dur)}</div>
                               </div>
                               <div
                                 className="list-percent"
@@ -395,7 +416,7 @@ export default class InvocationTimingCardComponent extends React.Component<Props
                         <li>
                           <div className="list-grid">
                             <div>{event.name}</div>
-                            <div>{this.formatDuration(event.dur)} seconds</div>
+                            <div>{format.durationUsec(event.dur)}</div>
                           </div>
                           <div
                             className="list-percent"

--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -8,7 +8,7 @@ import InvocationModel from "./invocation_model";
 import Button from "../components/button/button";
 import { Clock, HelpCircle } from "lucide-react";
 import errorService from "../errors/error_service";
-import format from "app/format/format";
+import format from "../format/format";
 import InvocationBreakdownCardComponent from "./invocation_breakdown_card";
 
 interface Props {


### PR DESCRIPTION
Also:
- Pulls getColor out of flame chart so we can use it in other places to get stable colors
- Formats durations nicely on timing page
- Adds hints for how to get better information out of your timing profile
- Adds (commented out for now) link to view suggestions based on timing profile

Screenshot:

<img width="1546" alt="Screen Shot 2022-11-22 at 3 53 20 PM" src="https://user-images.githubusercontent.com/1704556/203444274-6a27bab6-3740-472b-ac41-afee0bfe618b.png">


---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
