### PR TITLE
CLI: Add an `analyze` command for dependency graph analysis

### DIFF
--- a/cli/analyze/BUILD
+++ b/cli/analyze/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "analyze",
+    srcs = ["analyze.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/analyze",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cli/arg",
+        "//cli/bazelisk",
+        "//cli/log",
+        "//cli/workspace",
+        "//proto:bazel_query_go_proto",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_x_sync//errgroup",
+    ],
+)

--- a/cli/analyze/analyze.go
+++ b/cli/analyze/analyze.go
@@ -1,0 +1,559 @@
+package analyze
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
+	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/proto"
+
+	bqpb "github.com/buildbuddy-io/buildbuddy/proto/bazel_query"
+)
+
+const (
+	fourWeeks   = 4 * 7 * 24 * time.Hour // 4 weeks
+	targetLimit = 20
+)
+
+var (
+	flags = flag.NewFlagSet("analyze", flag.ContinueOnError)
+
+	longestPathFlag = flags.Bool("longest_path", false, "Show the longest path in the build graph.")
+
+	costFlag  = flags.Bool("cost", false, "Analyze dependency costs for the target.")
+	sinceFlag = flags.Duration("since", fourWeeks, "How far back to look in git history to determine the number of edits.")
+
+	usage = `
+usage: bb ` + flags.Name() + ` [PATTERN]
+
+Analyzes the dependency graph for the given PATTERN, attempting to identify
+opportunities for restructuring your build in order to improve performance.
+
+The simplest usage is to run all analyses for all targets in the current repo,
+using the default //... as PATTERN argument:
+
+    bb ` + flags.Name() + `
+
+There are a few different analysis types available:
+
+    bb ` + flags.Name() + ` PATTERN --longest_path
+
+Shows the longest path in the dependency graph. Long dependency chains cannot
+be built in parallel, and slow down the whole build.
+
+    bb ` + flags.Name() + ` PATTERN --cost [--since=672h]
+
+Prints a cost metric for all transitive dependencies of a target in the current
+repository, based on the git change history of each dependency as well as the
+number of transitive dependencies.
+
+Targets with the highest cost are good candidates for splitting up into more
+granular targets. For example, it might make sense to split up a large,
+frequently changing utility library into smaller utilities, or split up a large
+piece of business logic into separate API and implementation targets.
+
+The cost of a target is computed roughly as the number of cache invalidations
+caused by changes to the target's source files. So if a target has 5 transitive
+dependents, and its sources were edited 10 times in the last month, its cost is
+5 * 10 = 50. The lookback duration defaults to 4 weeks, and can be modified
+using the --since flag.
+`
+)
+
+func HandleAnalyze(args []string) (int, error) {
+	cmd, idx := arg.GetCommandAndIndex(args)
+	if cmd != flags.Name() {
+		return -1, nil
+	}
+	if err := arg.ParseFlagSet(flags, args[idx+1:]); err != nil {
+		if err == flag.ErrHelp {
+			log.Print(usage)
+			return 1, nil
+		}
+		return -1, err
+	}
+
+	// TODO: Support more than one target
+	if len(flags.Args()) > 1 {
+		log.Print(usage)
+		return 1, nil
+	}
+
+	// Run all analyses if none are explicitly requested.
+	if !*costFlag && !*longestPathFlag {
+		log.Printf("No analysis flags were set. Enabling `--cost` and `--longest_path` analyses.")
+		*costFlag = true
+		*longestPathFlag = true
+	}
+
+	pattern := "//..."
+	if len(flags.Args()) > 0 {
+		pattern = flags.Args()[0]
+	}
+	log.Printf("Querying dependency graph for %q ...", pattern)
+	graph, err := queryGraph(pattern)
+	if err != nil {
+		log.Print(err)
+		return 1, nil
+	}
+
+	if *longestPathFlag {
+		// Compute the longest dependency path
+		longestPath := graph.LongestPath()
+		log.Printf("Longest dependency path (length %d):", len(longestPath)-1)
+		printRow("LENGTH", "TARGET")
+		for i, target := range longestPath {
+			printRow(i, target)
+		}
+	}
+
+	if *costFlag {
+		log.Printf("Computing target metrics...")
+		targetMetrics, err := computeTargetMetrics(graph)
+		if err != nil {
+			log.Printf("Failed to compute target metrics: %s", err)
+			return 1, nil
+		}
+
+		topTargets := make([]string, 0, len(targetMetrics))
+		for name := range targetMetrics {
+			topTargets = append(topTargets, name)
+		}
+		// Sort in decreasing order of cost.
+		sort.Slice(topTargets, func(i, j int) bool {
+			ci, cj := targetMetrics[topTargets[i]].Cost(), targetMetrics[topTargets[j]].Cost()
+			if ci != cj {
+				return ci > cj
+			}
+			// Break ties using lexicographical name ordering.
+			ni, nj := topTargets[i], topTargets[j]
+			return ni < nj
+		})
+		// Print top targets.
+		printRow("RANK", "CHANGED", "AFFECTS", "COST", "TARGET")
+		for i := 0; i < len(topTargets) && i < targetLimit; i++ {
+			t := topTargets[i]
+			m := targetMetrics[t]
+			printRow(i+1, m.SourceFileChangeCount, m.TransitiveDependentCount, m.Cost(), t)
+		}
+	}
+	return 0, nil
+}
+
+func printRow(values ...any) {
+	// NOTE: row data is printed to stdout, while all other output (log.Printf
+	// etc.) is printed to stderr. This allows redirecting stdout to a file
+	// and then processing it as a TSV (tab-separated value) file.
+	cols := make([]string, 0, len(values))
+	for _, v := range values {
+		cols = append(cols, fmt.Sprint(v))
+	}
+	fmt.Printf("%s\n", strings.Join(cols, "\t"))
+}
+
+type TargetMetrics struct {
+	SourceFileChangeCount    int
+	TransitiveDependentCount int
+}
+
+// Cost returns how expensive the target is, taking into account the number of
+// changes to the target as well as its number of transitive dependents.
+func (m *TargetMetrics) Cost() int {
+	return m.SourceFileChangeCount * m.TransitiveDependentCount
+}
+
+func computeTargetMetrics(graph *DependencyGraph) (map[string]*TargetMetrics, error) {
+	ws, err := workspace.Path()
+	if err != nil {
+		return nil, err
+	}
+
+	srcFilePaths, err := getAllSourceFilePaths(ws)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute source file paths: %s", err)
+	}
+
+	startTime := time.Now().Add(-*sinceFlag)
+
+	type targetResult struct {
+		RuleName      string
+		TargetMetrics *TargetMetrics
+
+		Err error
+	}
+	compute := func(rule *bqpb.Rule) *targetResult {
+		srcFileChangeCount := 0
+		for _, input := range rule.RuleInput {
+			srcPath := sourcePathFromLabel(input)
+			if !srcFilePaths[srcPath] {
+				continue
+			}
+			c, err := gitChangeCount(ws, srcPath, startTime)
+			if err != nil {
+				return &targetResult{Err: fmt.Errorf("failed to compute git change count for %q: %s", srcPath, err)}
+			}
+			srcFileChangeCount += c
+		}
+		transitiveDependentCount := graph.TransitiveDependentCount(*rule.Name)
+		return &targetResult{
+			RuleName: *rule.Name,
+			TargetMetrics: &TargetMetrics{
+				SourceFileChangeCount:    srcFileChangeCount,
+				TransitiveDependentCount: transitiveDependentCount,
+			},
+		}
+	}
+
+	// Start some workers in parallel to compute target results. The parallelism
+	// here lets us get more throughput for the `git log` calls for computing
+	// source file change history.
+	const numWorkers = 8
+	resultsCh := make(chan *targetResult, numWorkers)
+	eg := errgroup.Group{}
+	rulesCh := bufferedChanOf(mapValues(graph.Rules))
+	for i := 0; i < numWorkers; i++ {
+		eg.Go(func() error {
+			for rule := range rulesCh {
+				res := compute(rule)
+				if res.Err != nil {
+					return res.Err
+				}
+				resultsCh <- res
+			}
+			return nil
+		})
+	}
+
+	// Read results and populate them in a map.
+	metrics := map[string]*TargetMetrics{}
+	var metricsErr error
+	metricsDone := make(chan struct{})
+	go func() {
+		defer close(metricsDone)
+		for result := range resultsCh {
+			if result.Err != nil {
+				metricsErr = result.Err
+				return
+			}
+			metrics[result.RuleName] = result.TargetMetrics
+		}
+	}()
+
+	start := time.Now()
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	log.Debugf("Computed target metrics in %s", time.Since(start))
+	close(resultsCh)
+	<-metricsDone
+	if metricsErr != nil {
+		return nil, metricsErr
+	}
+
+	return metrics, nil
+}
+
+func sourcePathFromLabel(label string) string {
+	relTarget := strings.TrimPrefix(label, "//")
+	srcPath := strings.Replace(relTarget, ":", "/", 1)
+	return srcPath
+}
+
+func gitChangeCount(repoRoot, path string, since time.Time) (int, error) {
+	lines, err := getOutputLines(repoRoot, "git", "log", "--pretty=oneline", "--since="+since.Format(time.RFC3339Nano), "--", path)
+	if err != nil {
+		return 0, fmt.Errorf("git log failed: %s", err)
+	}
+	return len(lines), nil
+}
+
+// EdgeSet represents edges in a dependency graph.
+type EdgeSet struct {
+	// Outgoing represents all outgoing dependency edges.
+	// Outgoing[n][m] is true iff n depends on m.
+	Outgoing map[string]map[string]bool
+
+	// Incoming represents all incoming dependency edges.
+	// Incoming[m][n] is true iff n depends on m.
+	Incoming map[string]map[string]bool
+}
+
+// Remove removes an edge from n to m.
+func (s *EdgeSet) Remove(n, m string) bool {
+	if _, ok := s.Outgoing[n]; !ok {
+		return false
+	}
+	if _, ok := s.Incoming[m]; !ok {
+		return false
+	}
+	if !s.Outgoing[n][m] || !s.Incoming[m][n] {
+		return false
+	}
+	delete(s.Outgoing[n], m)
+	delete(s.Incoming[m], n)
+	return true
+}
+
+type DependencyGraph struct {
+	Query            *bqpb.QueryResult
+	Rules            map[string]*bqpb.Rule
+	DirectDependents map[string][]*bqpb.Rule
+	Sources          map[string]bool
+
+	transitiveDependentCount map[string]int
+}
+
+func queryGraph(target string) (*DependencyGraph, error) {
+	// Note, intersecting with //... limits us only to targets in the current
+	// workspace. Tracking changes to external repos is complicated, so we're
+	// excluding them for now.
+	q := fmt.Sprintf("deps(%s) intersect //...", target)
+	bazelArgs := []string{"query", "--output=proto", q}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	opts := &bazelisk.RunOpts{
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+	exitCode, err := bazelisk.Run(bazelArgs, opts)
+	if err != nil {
+		return nil, err
+	}
+	if exitCode != 0 {
+		fmt.Print(stderr.String())
+		return nil, fmt.Errorf("bazelisk query failed (exit code %d)", exitCode)
+	}
+
+	res := &bqpb.QueryResult{}
+	if err := proto.Unmarshal(stdout.Bytes(), res); err != nil {
+		return nil, err
+	}
+
+	graph := &DependencyGraph{
+		Query:            res,
+		Rules:            map[string]*bqpb.Rule{},
+		DirectDependents: map[string][]*bqpb.Rule{},
+		Sources:          map[string]bool{},
+
+		transitiveDependentCount: map[string]int{},
+	}
+	// Index rules by name.
+	for _, t := range graph.Query.Target {
+		r := t.Rule
+		// Ignore non-Rule messages.
+		if r == nil {
+			continue
+		}
+		graph.Rules[r.GetName()] = r
+	}
+	// Index direct dependents.
+	for _, r := range graph.Rules {
+		for _, input := range r.RuleInput {
+			// Don't index inputs from external repos.
+			if strings.HasPrefix(input, "@") {
+				continue
+			}
+			graph.DirectDependents[input] = append(graph.DirectDependents[input], r)
+		}
+	}
+	return graph, nil
+}
+
+// TransitiveDependentsCount returns the number of transitive dependents of a
+// given target, counting the target itself.
+func (g *DependencyGraph) TransitiveDependentCount(name string) int {
+	// Traverse the graph of transitive dependents, keeping track of nodes
+	// already visited.
+
+	// TODO: avoid a full graph traversal on each function call.
+	frontier := []string{name}
+	visited := map[string]bool{}
+	for len(frontier) > 0 {
+		name := frontier[len(frontier)-1]
+		frontier = frontier[:len(frontier)-1]
+		if visited[name] {
+			continue
+		}
+		visited[name] = true
+		for _, r := range g.DirectDependents[name] {
+			frontier = append(frontier, *r.Name)
+		}
+	}
+
+	return len(visited)
+}
+
+// LongestPath returns the longest dependency path from one node in the graph to
+// any other node.
+func (g *DependencyGraph) LongestPath() []string {
+	longestPathLength := 0
+	var longestPathEnd *string
+
+	length := map[string]int{}
+	pred := map[string]*string{}
+	e := g.EdgeSet()
+	for _, m := range g.TopologicalSort() {
+		for n := range e.Incoming[m] {
+			l := length[n] + 1
+			if l > length[m] {
+				length[m] = l
+				n := n
+				pred[m] = &n
+			}
+			if l > longestPathLength {
+				longestPathLength = l
+				m := m
+				longestPathEnd = &m
+			}
+		}
+	}
+	if longestPathEnd == nil {
+		return nil
+	}
+	path := []string{*longestPathEnd}
+	for {
+		p := pred[path[len(path)-1]]
+		if p == nil {
+			break
+		}
+		path = append(path, *p)
+	}
+	reverseSlice(path)
+	return path
+}
+
+// Roots returns all labels in the graph which have no direct dependents.
+func (g *DependencyGraph) Roots() []string {
+	var roots []string
+	for name := range g.Rules {
+		if len(g.DirectDependents[name]) == 0 {
+			roots = append(roots, name)
+		}
+	}
+	return roots
+}
+
+func (g *DependencyGraph) EdgeSet() *EdgeSet {
+	outgoing := map[string]map[string]bool{}
+	incoming := map[string]map[string]bool{}
+	s := g.Roots()
+	for len(s) > 0 {
+		n := s[len(s)-1]
+		s = s[:len(s)-1]
+		if _, ok := outgoing[n]; ok {
+			continue // already visited
+		}
+		rule := g.Rules[n]
+		if rule == nil {
+			continue
+		}
+		for _, m := range rule.RuleInput {
+			if outgoing[n] == nil {
+				outgoing[n] = map[string]bool{}
+			}
+			if incoming[m] == nil {
+				incoming[m] = map[string]bool{}
+			}
+			outgoing[n][m] = true
+			incoming[m][n] = true
+
+			s = append(s, m)
+		}
+	}
+	return &EdgeSet{Outgoing: outgoing, Incoming: incoming}
+}
+
+// TopologicalSort returns all node labels in the graph sorted so that each node
+// is sorted before any of its transitive deps.
+func (g *DependencyGraph) TopologicalSort() []string {
+	// https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm
+	var out []string
+	s := g.Roots()
+	e := g.EdgeSet()
+	for len(s) > 0 {
+		n := s[len(s)-1]
+		s = s[:len(s)-1]
+		out = append(out, n)
+		for m := anyKey(e.Outgoing[n]); m != nil; m = anyKey(e.Outgoing[n]) {
+			e.Remove(n, *m)
+			if len(e.Incoming[*m]) == 0 {
+				s = append(s, *m)
+			}
+		}
+	}
+	return out
+}
+
+func getAllSourceFilePaths(dir string) (map[string]bool, error) {
+	lines, err := getOutputLines(dir, "git", "ls-files", "--exclude-standard")
+	if err != nil {
+		return nil, fmt.Errorf("git ls-files failed: %s", err)
+	}
+	return makeSet(lines), nil
+}
+
+func getOutputLines(dir, executable string, args ...string) ([]string, error) {
+	cmd := exec.Command(executable, args...)
+	cmd.Dir = dir
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("%s", strings.TrimSpace(stderr.String()))
+	}
+	output := strings.TrimRight(stdout.String(), "\n")
+	if output == "" {
+		return nil, nil
+	}
+	return strings.Split(output, "\n"), nil
+}
+
+func anyKey[K comparable, V any](m map[K]V) *K {
+	for k := range m {
+		key := k
+		return &key
+	}
+	return nil
+}
+
+func makeSet[T comparable](values []T) map[T]bool {
+	set := map[T]bool{}
+	for _, v := range values {
+		set[v] = true
+	}
+	return set
+}
+
+func reverseSlice[T any](a []T) {
+	for i := 0; i < len(a)/2; i++ {
+		j := len(a) - i - 1
+		a[i], a[j] = a[j], a[i]
+	}
+}
+
+func bufferedChanOf[T any](slice []T) <-chan T {
+	ch := make(chan T, len(slice))
+	for _, val := range slice {
+		ch <- val
+	}
+	close(ch)
+	return ch
+}
+
+func mapValues[K comparable, V any](m map[K]V) []V {
+	var out []V
+	for _, v := range m {
+		out = append(out, v)
+	}
+	return out
+}

--- a/cli/bazelisk/BUILD
+++ b/cli/bazelisk/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//cli/plugin",
         "//cli/terminal",
         "//cli/workspace",
-        "//server/util/status",
         "@com_github_bazelbuild_bazelisk//core:go_default_library",
         "@com_github_bazelbuild_bazelisk//repositories:go_default_library",
         "@com_github_creack_pty//:pty",

--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/cmd/bb",
     visibility = ["//visibility:private"],
     deps = [
+        "//cli/analyze",
         "//cli/arg",
         "//cli/bazelisk",
         "//cli/cmd/sidecar",

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/buildbuddy-io/buildbuddy/cli/analyze"
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
 	"github.com/buildbuddy-io/buildbuddy/cli/help"
@@ -64,6 +65,10 @@ func run() (exitCode int, err error) {
 		return exitCode, err
 	}
 	exitCode, err = version.HandleVersion(args)
+	if err != nil || exitCode >= 0 {
+		return exitCode, err
+	}
+	exitCode, err = analyze.HandleAnalyze(args)
 	if err != nil || exitCode >= 0 {
 		return exitCode, err
 	}

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -59,7 +59,7 @@ func showHelp(subcommand string, modifiers []string) (exitCode int, err error) {
 	}
 	bazelArgs = append(bazelArgs, modifiers...)
 	buf := bytes.NewBuffer(nil)
-	exitCode, err = bazelisk.Run(bazelArgs, "/dev/null" /*=outputPath*/, buf)
+	exitCode, err = bazelisk.Run(bazelArgs, &bazelisk.RunOpts{Stdout: buf, Stderr: buf})
 	if err != nil {
 		io.Copy(os.Stdout, buf)
 		return exitCode, err
@@ -112,6 +112,7 @@ func printBBCommands() {
 	// TODO: Have commands add themselves to a registry and get the command
 	// names / descriptions from there.
 	columns := [][]string{
+		{"analyze", "Analyzes the dependency graph."},
 		{"install", "Installs a bb plugin (https://buildbuddy.io/plugins)."},
 		{"login", "Configures bb commands to use your BuildBuddy API key."},
 		{"print", "Displays various log file types written by bazel."},

--- a/cli/printlog/printlog.go
+++ b/cli/printlog/printlog.go
@@ -39,6 +39,10 @@ func HandlePrint(args []string) (int, error) {
 		return -1, nil
 	}
 	if err := arg.ParseFlagSet(flags, args[idx+1:]); err != nil {
+		if err == flag.ErrHelp {
+			log.Print(usage)
+			return 1, nil
+		}
 		return -1, err
 	}
 	if *grpcLog != "" {

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -21,6 +21,11 @@ proto_library(
 )
 
 proto_library(
+    name = "bazel_query_proto",
+    srcs = ["bazel_query.proto"],
+)
+
+proto_library(
     name = "build_status_proto",
     srcs = [
         "build_status.proto",
@@ -481,6 +486,12 @@ go_proto_library(
     deps = [
         ":context_go_proto",
     ],
+)
+
+go_proto_library(
+    name = "bazel_query_go_proto",
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/bazel_query",
+    proto = ":bazel_query_proto",
 )
 
 go_proto_library(

--- a/proto/bazel_query.proto
+++ b/proto/bazel_query.proto
@@ -1,0 +1,541 @@
+// Copyright 2014 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file contains the protocol buffer representation of a build
+// file or 'bazel query --output=proto' call.
+
+syntax = "proto2";
+
+package bazel_query;
+
+// option cc_api_version = 2;
+// option java_api_version = 1;
+option java_package = "com.google.devtools.build.lib.query2.proto.proto2api";
+
+message License {
+  repeated string license_type = 1;
+  repeated string exception = 2;
+}
+
+message StringDictEntry {
+  required string key = 1;
+  required string value = 2;
+}
+
+message LabelDictUnaryEntry {
+  required string key = 1;
+  required string value = 2;
+}
+
+message LabelListDictEntry {
+  required string key = 1;
+  repeated string value = 2;
+}
+
+message LabelKeyedStringDictEntry {
+  required string key = 1;
+  required string value = 2;
+}
+
+message StringListDictEntry {
+  required string key = 1;
+  repeated string value = 2;
+}
+
+// Represents an entry attribute of a Fileset rule in a build file.
+message FilesetEntry {
+  // Indicates what to do when a source file is actually a symlink.
+  enum SymlinkBehavior {
+    COPY = 1;
+    DEREFERENCE = 2;
+  }
+
+  // The label pointing to the source target where files are copied from.
+  required string source = 1;
+
+  // The relative path within the fileset rule where files will be mapped.
+  required string destination_directory = 2;
+
+  // Whether the files= attribute was specified. This is necessary because
+  // no files= attribute and files=[] mean different things.
+  optional bool files_present = 7;
+
+  // A list of file labels to include from the source directory.
+  repeated string file = 3;
+
+  // If this is a fileset entry representing files within the rule
+  // package, this lists relative paths to files that should be excluded from
+  // the set.  This cannot contain values if 'file' also has values.
+  repeated string exclude = 4;
+
+  // This field is optional because there will be some time when the new
+  // PB is used by tools depending on blaze query, but the new blaze version
+  // is not yet released.
+  // TODO(bazel-team): Make this field required once a version of Blaze is
+  // released that outputs this field.
+  optional SymlinkBehavior symlink_behavior = 5 [default = COPY];
+
+  // The prefix to strip from the path of the files in this FilesetEntry. Note
+  // that no value and the empty string as the value mean different things here.
+  optional string strip_prefix = 6;
+}
+
+// A rule attribute. Each attribute must have a type and one of the various
+// value fields populated - for the most part.
+//
+// Attributes of BOOLEAN and TRISTATE type may set all of the int, bool, and
+// string values for backwards compatibility with clients that expect them to
+// be set.
+//
+// Attributes of INTEGER, STRING, LABEL, LICENSE, BOOLEAN, and TRISTATE type
+// may set *none* of the values. This can happen if the Attribute message is
+// prepared for a client that doesn't support SELECTOR_LIST, but the rule has
+// a selector list value for the attribute. (Selector lists for attributes of
+// other types--the collection types--are handled differently when prepared
+// for such a client. The possible collection values are gathered together
+// and flattened.)
+//
+// By checking the type, the appropriate value can be extracted - see the
+// comments on each type for the associated value.  The order of lists comes
+// from the blaze parsing. If an attribute is of a list type, the associated
+// list should never be empty.
+message Attribute {
+  reserved 12, 16;
+
+  // Indicates the type of attribute.
+  enum Discriminator {
+    INTEGER = 1;              // int_value
+    STRING = 2;               // string_value
+    LABEL = 3;                // string_value
+    OUTPUT = 4;               // string_value
+    STRING_LIST = 5;          // string_list_value
+    LABEL_LIST = 6;           // string_list_value
+    OUTPUT_LIST = 7;          // string_list_value
+    DISTRIBUTION_SET = 8;     // string_list_value - order is unimportant
+    LICENSE = 9;              // license
+    STRING_DICT = 10;         // string_dict_value
+    FILESET_ENTRY_LIST = 11;  // fileset_list_value
+    LABEL_LIST_DICT = 12;     // label_list_dict_value
+    STRING_LIST_DICT = 13;    // string_list_dict_value
+    BOOLEAN = 14;             // int, bool and string value
+    TRISTATE = 15;            // tristate, int and string value
+    INTEGER_LIST = 16;        // int_list_value
+    UNKNOWN = 18;             // unknown type, use only for build extensions
+    LABEL_DICT_UNARY = 19;    // label_dict_unary_value
+    SELECTOR_LIST = 20;       // selector_list
+    LABEL_KEYED_STRING_DICT = 21;  // label_keyed_string_dict
+
+    DEPRECATED_STRING_DICT_UNARY = 17;
+  }
+
+  // Values for the TriState field type.
+  enum Tristate {
+    NO = 0;
+    YES = 1;
+    AUTO = 2;
+  }
+
+  message SelectorEntry {
+    reserved 12;
+
+    // The key of the selector entry. At this time, this is the label of a
+    // config_setting rule, or the pseudo-label "//conditions:default".
+    optional string label = 1;
+
+    // True if the entry's value is the default value for the type as a
+    // result of the condition value being specified as None (ie:
+    // {"//condition": None}).
+    optional bool is_default_value = 16;
+
+    // Exactly one of the following fields (except for glob_criteria) must be
+    // populated - note that the BOOLEAN and TRISTATE caveat in Attribute's
+    // comment does not apply here. The type field in the SelectorList
+    // containing this entry indicates which of these fields is populated,
+    // in accordance with the comments on Discriminator enum values above.
+    // (To be explicit: BOOLEAN populates the boolean_value field and TRISTATE
+    // populates the tristate_value field.)
+    optional int32 int_value = 2;
+    optional string string_value = 3;
+    optional bool boolean_value = 4;
+    optional Tristate tristate_value = 5;
+    repeated string string_list_value = 6;
+    optional License license = 7;
+    repeated StringDictEntry string_dict_value = 8;
+    repeated FilesetEntry fileset_list_value = 9;
+    repeated LabelListDictEntry label_list_dict_value = 10;
+    repeated StringListDictEntry string_list_dict_value = 11;
+    repeated int32 int_list_value = 13;
+    repeated LabelDictUnaryEntry label_dict_unary_value = 15;
+    repeated LabelKeyedStringDictEntry label_keyed_string_dict_value = 17;
+
+    repeated bytes DEPRECATED_string_dict_unary_value = 14;
+  }
+
+  message Selector {
+    // The list of (label, value) pairs in the map that defines the selector.
+    // At this time, this cannot be empty, i.e. a selector has at least one
+    // entry.
+    repeated SelectorEntry entries = 1;
+
+    // Whether or not this has any default values.
+    optional bool has_default_value = 2;
+
+    // The error message when no condition matches.
+    optional string no_match_error = 3;
+  }
+
+  message SelectorList {
+    // The type that this selector list evaluates to, and the type that each
+    // selector in the list evaluates to. At this time, this cannot be
+    // SELECTOR_LIST, i.e. selector lists do not nest.
+    optional Discriminator type = 1;
+
+    // The list of selector elements in this selector list. At this time, this
+    // cannot be empty, i.e. a selector list is never empty.
+    repeated Selector elements = 2;
+  }
+
+  // The name of the attribute
+  required string name = 1;
+
+  // Whether the attribute was explicitly specified
+  optional bool explicitly_specified = 13;
+
+  // If this attribute has a string value or a string list value, then this
+  // may be set to indicate that the value may be treated as a label that
+  // isn't a dependency of this attribute's rule.
+  optional bool nodep = 20;
+
+  // The type of attribute.  This message is used for all of the different
+  // attribute types so the discriminator helps for figuring out what is
+  // stored in the message.
+  required Discriminator type = 2;
+
+  // If this attribute has an integer value this will be populated.
+  // Boolean and TriState also use this field as [0,1] and [-1,0,1]
+  // for [false, true] and [auto, no, yes] respectively.
+  optional int32 int_value = 3;
+
+  // If the attribute has a string value this will be populated.  Label and
+  // path attributes use this field as the value even though the type may
+  // be LABEL or something else other than STRING.
+  optional string string_value = 5;
+
+  // If the attribute has a boolean value this will be populated.
+  optional bool boolean_value = 14;
+
+  // If the attribute is a Tristate value, this will be populated.
+  optional Tristate tristate_value = 15;
+
+  // The value of the attribute has a list of string values (label and path
+  // note from STRING applies here as well).
+  repeated string string_list_value = 6;
+
+  // If this is a license attribute, the license information is stored here.
+  optional License license = 7;
+
+  // If this is a string dict, each entry will be stored here.
+  repeated StringDictEntry string_dict_value = 8;
+
+  // If the attribute is part of a Fileset, the fileset entries are stored in
+  // this field.
+  repeated FilesetEntry fileset_list_value = 9;
+
+  // If this is a label list dict, each entry will be stored here.
+  repeated LabelListDictEntry label_list_dict_value = 10;
+
+  // If this is a string list dict, each entry will be stored here.
+  repeated StringListDictEntry string_list_dict_value = 11;
+
+  // The value of the attribute has a list of int32 values
+  repeated int32 int_list_value = 17;
+
+  // If this is a label dict unary, each entry will be stored here.
+  repeated LabelDictUnaryEntry label_dict_unary_value = 19;
+
+  // If this is a label-keyed string dict, each entry will be stored here.
+  repeated LabelKeyedStringDictEntry label_keyed_string_dict_value = 22;
+
+  // If this attribute's value is an expression containing one or more select
+  // expressions, then its type is SELECTOR_LIST and a SelectorList will be
+  // stored here.
+  optional SelectorList selector_list = 21;
+
+  repeated bytes DEPRECATED_string_dict_unary_value = 18;
+}
+
+// A rule instance (e.g., cc_library foo, java_binary bar).
+message Rule {
+  reserved 8, 11;
+
+  // The name of the rule (formatted as an absolute label, e.g. //foo/bar:baz).
+  required string name = 1;
+
+  // The rule class (e.g., java_library)
+  required string rule_class = 2;
+
+  // The BUILD file and line number of the location (formatted as
+  // <absolute_path>:<line_number>:<column_number>) in the rule's package's
+  // BUILD file where the rule instance was instantiated. The line number will
+  // be that of a rule invocation or macro call (that in turn invoked a
+  // rule). See
+  // https://bazel.build/rules/macros#macro-creation
+  optional string location = 3;
+
+  // All of the attributes that describe the rule.
+  repeated Attribute attribute = 4;
+
+  // All of the inputs to the rule (formatted as absolute labels). These are
+  // predecessors in the dependency graph.
+  repeated string rule_input = 5;
+
+  repeated ConfiguredRuleInput configured_rule_input = 15;
+
+  // All of the outputs of the rule (formatted as absolute labels). These are
+  // successors in the dependency graph.
+  repeated string rule_output = 6;
+
+  // The set of all "features" inherited from the rule's package declaration.
+  repeated string default_setting = 7;
+
+  // The rule's class's public by default value.
+  optional bool DEPRECATED_public_by_default = 9;
+
+  optional bool DEPRECATED_is_skylark = 10;
+
+  // Hash encapsulating the behavior of this Starlark rule. Any change to this
+  // rule's definition that could change its behavior will be reflected here.
+  optional string skylark_environment_hash_code = 12;
+
+  // The Starlark call stack at the moment the rule was instantiated.
+  // Each entry has the form "file:line:col: function".
+  // The outermost stack frame ("<toplevel>", the BUILD file) appears first;
+  // the frame for the rule function itself is omitted.
+  // The file name may be relative to package's source root directory.
+  //
+  // Requires --proto:instantiation_stack=true.
+  repeated string instantiation_stack = 13;
+
+  // The Starlark call stack for the definition of the rule class of this
+  // particular rule instance. If empty, either populating the field was not
+  // enabled on the command line with the --proto:definition_stack flag or the
+  // rule is a native one.
+  repeated string definition_stack = 14;
+}
+
+message ConfiguredRuleInput {
+  optional string label = 1;
+  optional string configuration_checksum = 2;
+  optional uint32 configuration_id = 3;
+}
+
+// Summary of all transitive dependencies of 'rule,' where each dependent
+// rule is included only once in the 'dependency' field.  Gives complete
+// information to analyze the single build target labeled rule.name,
+// including optional location of target in BUILD file.
+message RuleSummary {
+  required Rule rule = 1;
+  repeated Rule dependency = 2;
+  optional string location = 3;
+}
+
+// A package group. Aside from the name, it contains the list of packages
+// present in the group (as specified in the BUILD file).
+message PackageGroup {
+  reserved 4;
+
+  // The name of the package group
+  required string name = 1;
+
+  // The list of packages as specified in the BUILD file. Currently this is
+  // only a list of packages, but some time in the future, there might be
+  // some type of wildcard mechanism.
+  repeated string contained_package = 2;
+
+  // The list of sub package groups included in this one.
+  repeated string included_package_group = 3;
+}
+
+// An environment group.
+message EnvironmentGroup {
+  // The name of the environment group.
+  required string name = 1;
+
+  // The environments that belong to this group (as labels).
+  repeated string environment = 2;
+
+  // The member environments that rules implicitly support if not otherwise
+  // specified.
+  repeated string default = 3;
+}
+
+// A file that is an input into the build system.
+// Next-Id: 10
+message SourceFile {
+  reserved 7;
+
+  // The name of the source file (a label).
+  required string name = 1;
+
+  // The location of the source file.  This is a path with a line number and a
+  // column number not a label in the build system.
+  optional string location = 2;
+
+  // Labels of .bzl (Starlark) files that are transitively loaded in this BUILD
+  // file. This is present only when the SourceFile represents a BUILD file that
+  // loaded .bzl files.
+  // TODO(bazel-team): Rename this field.
+  repeated string subinclude = 3;
+
+  // Labels of package groups that are mentioned in the visibility declaration
+  // for this source file.
+  repeated string package_group = 4;
+
+  // Labels mentioned in the visibility declaration (including :__pkg__ and
+  // //visibility: ones)
+  repeated string visibility_label = 5;
+
+  // The package-level features enabled for this package. Only present if the
+  // SourceFile represents a BUILD file.
+  repeated string feature = 6;
+
+  // License attribute for the file.
+  optional License license = 8;
+
+  // True if the package contains an error. Only present if the SourceFile
+  // represents a BUILD file.
+  optional bool package_contains_errors = 9;
+}
+
+// A file that is the output of a build rule.
+message GeneratedFile {
+  // The name of the generated file (a label).
+  required string name = 1;
+
+  // The label of the target that generates the file.
+  required string generating_rule = 2;
+
+  // The path, line number, and column number of the output file (not a label).
+  optional string location = 3;
+}
+
+// A target from a blaze query execution.  Similar to the Attribute message,
+// the Discriminator is used to determine which field contains information.
+// For any given type, only one of these can be populated in a single Target.
+message Target {
+  enum Discriminator {
+    RULE = 1;
+    SOURCE_FILE = 2;
+    GENERATED_FILE = 3;
+    PACKAGE_GROUP = 4;
+    ENVIRONMENT_GROUP = 5;
+  }
+
+  // The type of target contained in the message.
+  required Discriminator type = 1;
+
+  // If this target represents a rule, the rule is stored here.
+  optional Rule rule = 2;
+
+  // A file that is not generated by the build system (version controlled
+  // or created by the test harness).
+  optional SourceFile source_file = 3;
+
+  // A generated file that is the output of a rule.
+  optional GeneratedFile generated_file = 4;
+
+  // A package group.
+  optional PackageGroup package_group = 5;
+
+  // An environment group.
+  optional EnvironmentGroup environment_group = 6;
+}
+
+// Container for all of the blaze query results.
+message QueryResult {
+  // All of the targets returned by the blaze query.
+  repeated Target target = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////
+// Messages dealing with querying the BUILD language itself. For now, this is
+// quite simplistic: Blaze can only tell the names of the rule classes, their
+// attributes with their type.
+
+// Information about allowed rule classes for a specific attribute of a rule.
+message AllowedRuleClassInfo {
+  enum AllowedRuleClasses {
+    ANY = 1;        // Any rule is allowed to be in this attribute
+    SPECIFIED = 2;  // Only the explicitly listed rules are allowed
+  }
+
+  required AllowedRuleClasses policy = 1;
+
+  // Rule class names of rules allowed in this attribute, e.g "cc_library",
+  // "py_binary". Only present if the allowed_rule_classes field is set to
+  // SPECIFIED.
+  repeated string allowed_rule_class = 2;
+}
+
+// This message represents a single attribute of a single rule.
+// See https://bazel.build/rules/lib/attr.
+message AttributeDefinition {
+  required string name = 1;  // e.g. "name", "srcs"
+  required Attribute.Discriminator type = 2;
+  optional bool mandatory = 3;
+  optional AllowedRuleClassInfo allowed_rule_classes = 4;  // type=label*
+  optional string documentation = 5;
+  optional bool allow_empty = 6;        // type=*_list|*_dict
+  optional bool allow_single_file = 7;  // type=label
+  optional AttributeValue default =
+      9;  // simple (not computed/late-bound) values only
+  optional bool executable = 10;  // type=label
+  optional bool configurable = 11;
+  optional bool nodep =
+      12;  // label-valued edge does not establish a dependency
+  optional bool cfg_is_host =
+      13;  // edge entails a transition to "host" configuration
+}
+
+// An AttributeValue represents the value of an attribute.
+// A single field, determined by the attribute type, is populated.
+//
+// It is used only for AttributeDefinition.default. Attribute and
+// SelectorEntry do their own thing for unfortunate historical reasons.
+message AttributeValue {
+  optional int32 int = 1;            // type=int|tristate
+  optional string string = 2;        // type=string|label|output
+  optional bool bool = 3;            // type=bool
+  repeated AttributeValue list = 4;  // type=*_list|distrib
+  repeated DictEntry dict = 5;       // type=*_dict
+
+  message DictEntry {
+    required string key = 1;
+    required AttributeValue value = 2;
+  }
+}
+
+message RuleDefinition {
+  required string name = 1;
+  // Only contains documented attributes
+  repeated AttributeDefinition attribute = 2;
+  optional string documentation = 3;
+  // Only for build extensions: label to file that defines the extension
+  optional string label = 4;
+}
+
+message BuildLanguage {
+  // Only contains documented rule definitions
+  repeated RuleDefinition rule = 1;
+}


### PR DESCRIPTION
* Add a `bb analyze` subcommand which accepts a PATTERN argument (defaulting to `//...`) and then analyzes the dependency graph for that pattern, using various analysis types. By default all analysis types are enabled, but specific analyses can be selected using flags.
* Add a "cost" analysis which takes into account the number of changes to a target's source files over a given time period (defaults to 4 weeks), as well as the number of transitive deps of a target. Roughly speaking it is the minimum number of invalidated actions that are caused by changes to a target's source files. (I say "roughly" and "minimum" because it only counts commits and not edits, doesn't account for historical changes to the build graph structure, and only counts the current branch, e.g. the main branch)
* Add a "longest path" analysis which shows the longest dependency path through the graph.

The analysis is pretty basic at the moment, but we can extend it in various ways by augmenting the nodes in the graph with "weights" corresponding to things like cache upload/download metrics, build times, etc., possibly using the BB API.

Example output (stderr logging output is omitted)

```
$ bb analyze //enterprise/server --cost
RANK    CHANGED AFFECTS COST    TARGET
1       12      126     1512    //server/interfaces:interfaces
2       2       258     516     //proto:remote_execution_proto
3       3       134     402     //proto:raft_proto
4       1       218     218     //proto:cache_proto
5       1       210     210     //proto:usage_proto
6       2       100     200     //server/util/alert:alert
7       1       171     171     //server/util/log:log
8       2       85      170     //server/util/flagutil/types:types
9       2       68      136     //server/util/query_builder:query_builder
10      1       127     127     //server/tables:tables
11      1       112     112     //proto:remote_asset_proto
12      1       112     112     //server/metrics:metrics
13      1       109     109     //server/environment:environment
14      14      7       98      //server/backends/disk_cache:disk_cache
15      4       22      88      //server/util/db:db
16      2       39      78      //server/remote_cache/digest:digest
17      3       22      66      //app/flame_chart:flame_chart_typings
18      3       20      60      //app/invocation:invocation_typings
19      10      5       50      //enterprise/server/backends/pebble_cache:pebble_cache
20      2       25      50      //server/util/retry:retry
```

```
$ bb analyze --longest_path
LENGTH  TARGET
0       //website:serve
1       //website:website
2       //enterprise/server/cmd/server/yaml_doc:generate_mdx
3       //enterprise/server/cmd/server/yaml_doc:generate_yaml
4       //enterprise/server/cmd/server/yaml_doc:yaml_doc
5       //enterprise/server/cmd/server/yaml_doc:yaml_doc_lib
6       //enterprise/server/cmd/server:server_lib
7       //server/libmain:libmain
8       //:bundle
9       //app:sha
10      //app:app_bundle
11      //app:app
12      //app:app_typings
13      //app/root:root
14      //app/root:root_typings
15      //app/invocation:invocation
16      //app/invocation:invocation_typings
17      //app/target:target
18      //app/target:target_typings
19      //app/docs:docs
20      //app/docs:docs_typings
21      //app/components/button:button
22      //app/components/button:button_typings
23      //app/components/link:link
24      //app/components/link:link_typings
25      //app/router:router
26      //app/router:router_typings
27      //app/auth:user
28      //app/auth:user_typings
29      //app/service:service
30      //app/service:service_typings
31      //proto:buildbuddy_service_ts_proto
32      //proto:_buildbuddy_service_ts_proto_pbts
33      //proto:_buildbuddy_service_ts_proto_pbjs
34      //proto:_buildbuddy_service_ts_proto_protos
35      //proto:buildbuddy_service_proto
36      //proto:invocation_proto
37      //proto:cache_proto
38      //proto:resource_proto
39      //proto:remote_execution_proto
40      //proto:scheduler_proto
41      //proto:context_proto
42      //proto:user_id_proto
43      //proto:user_id.proto
```

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
