### PR TITLE
Use material colors for timing breakdown

### DIFF
--- a/app/flame_chart/BUILD
+++ b/app/flame_chart/BUILD
@@ -15,6 +15,7 @@ ts_library(
         "//app/components/scrollbar",
         "//app/util:animated_value",
         "//app/util:animation_loop",
+        "//app/util:color",
         "//app/util:dom",
         "//app/util:math",
         "@npm//@types/react",

--- a/app/flame_chart/flame_chart_model.ts
+++ b/app/flame_chart/flame_chart_model.ts
@@ -1,4 +1,4 @@
-import getColor from "./colors";
+import { getUniformBrightnessColor } from "../util/color";
 import { buildThreadTimelines, ThreadEvent, TraceEvent } from "./profile_model";
 import {
   BLOCK_HEIGHT,
@@ -51,7 +51,7 @@ export function buildFlameChartModel(events: TraceEvent[], { visibilityThreshold
             width: dur / MICROSECONDS_PER_SECOND,
             y:
               currentThreadY + depth * (BLOCK_HEIGHT + BLOCK_VERTICAL_GAP) + SECTION_LABEL_HEIGHT + SECTION_PADDING_TOP,
-            fill: getColor(`${cat}#${name}`),
+            fill: getUniformBrightnessColor(`${cat}#${name}`),
           },
           event,
         };

--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -35,6 +35,7 @@ ts_library(
         "//app/target",
         "//app/terminal",
         "//app/util:clipboard",
+        "//app/util:color",
         "//app/util:errors",
         "//app/util:proto",
         "//proto:acl_ts_proto",

--- a/app/invocation/invocation_breakdown_card.tsx
+++ b/app/invocation/invocation_breakdown_card.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { PieChart as PieChartIcon } from "lucide-react";
 import { ResponsiveContainer, PieChart, Pie, Cell } from "recharts";
 import format from "../format/format";
-import getColor from "../flame_chart/colors";
+import { getChartColor } from "../util/color";
 
 interface Props {
   durationMap: Map<string, number>;
@@ -60,10 +60,6 @@ export default class InvocationBreakdownCardComponent extends React.Component<Pr
 
     executionData = executionData.sort((a, b) => (b?.value || 0) - (a?.value || 0)).filter((entry) => entry.value > 0);
 
-    let executionSum = executionData.reduce((prev, current) => {
-      return { name: "Sum", value: (prev.value || 0) + (current.value || 0) };
-    });
-
     return (
       <div className="card">
         <PieChartIcon className="icon" />
@@ -94,8 +90,8 @@ function renderBreakdown(data: Datum[], title: string, subtitle: string) {
         <ResponsiveContainer width={100} height={100}>
           <PieChart>
             <Pie data={data} dataKey="value" outerRadius={40} innerRadius={20}>
-              {data.map((entry, index) => (
-                <Cell key={`cell-${index}`} fill={getColor(entry.name)} />
+              {data.map((_, index) => (
+                <Cell key={`cell-${index}`} fill={getChartColor(index)} />
               ))}
             </Pie>
           </PieChart>
@@ -105,7 +101,7 @@ function renderBreakdown(data: Datum[], title: string, subtitle: string) {
             <div className="cache-chart-label">
               <span
                 className="color-swatch cache-hit-color-swatch"
-                style={{ backgroundColor: getColor(entry.name) }}></span>
+                style={{ backgroundColor: getChartColor(index) }}></span>
               <span className="cache-stat">
                 <span className="cache-stat-duration">{format.durationUsec(entry.value)}</span>{" "}
                 <span className="cache-stat-description">

--- a/app/util/BUILD
+++ b/app/util/BUILD
@@ -43,6 +43,11 @@ ts_library(
 )
 
 ts_library(
+    name = "color",
+    srcs = ["color.ts"],
+)
+
+ts_library(
     name = "dom",
     srcs = ["dom.ts"],
     deps = [

--- a/app/util/color.ts
+++ b/app/util/color.ts
@@ -1,8 +1,39 @@
+/**
+ * A subset of material colors arranged so that adjacent colors in the list are
+ * visually distinct.
+ */
+const MATERIAL_CHART_COLORS = [
+  "#4CAF50", // green-500
+  "#03A9F4", // blue-500
+  "#FF9800", // orange-500
+  "#9C27B0", // purple-500
+  "#F44336", // red-500
+  "#009688", // teal-500
+  "#3F51B5", // indigo-500
+];
+
+/**
+ * Returns a color suitable for use in charts. The input parameter is an index
+ * representing the color's position relative to other chart elements, starting
+ * from 0. Indexes that are one apart from each other will have visually
+ * distinct colors.
+ *
+ * If the index exceeds the number of pre-configured material colors, the
+ * returned color falls back to a less pretty set of colors but with uniform
+ * perceived brightness.
+ */
+export function getChartColor(index: number) {
+  if (index < 0 || index >= MATERIAL_CHART_COLORS.length) {
+    return getUniformBrightnessColor(String(index));
+  }
+  return MATERIAL_CHART_COLORS[index];
+}
+
 // See https://perceived-brightness.vercel.app/
 // These colors were generated using a perceived brightness of 156 +/- 3
 // We want the perceived brightness to be constant so that text always
 // displays consistently against flame chart colors.
-const colors = [
+const UNIFORM_BRIGHTNESS_COLORS = [
   "#17b51a",
   "#36a9c5",
   "#64ad02",
@@ -141,7 +172,9 @@ const colors = [
  * All colors returned have the same approximate perceived brightness
  * to avoid issues with color contrast.
  */
-const getColor = (id: string) => colors[Math.abs(hash(id) % colors.length)];
+export function getUniformBrightnessColor(id: string) {
+  return UNIFORM_BRIGHTNESS_COLORS[Math.abs(hash(id) % UNIFORM_BRIGHTNESS_COLORS.length)];
+}
 
 function hash(value: string) {
   let hash = 0;
@@ -150,5 +183,3 @@ function hash(value: string) {
   }
   return hash;
 }
-
-export default getColor;


### PR DESCRIPTION
The colors were randomly generated so they looked a bit drab and some colors were hard to tell apart.

**Before**

![image](https://user-images.githubusercontent.com/2414826/204389792-b65d0563-28c5-4f09-ae1a-68e00a84708b.png)

**After**

![image](https://user-images.githubusercontent.com/2414826/204389721-61863c92-d9a7-49ef-896e-bba014979e53.png)


---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
