### PR TITLE
Make artifacts viewable in code editor

### DIFF
--- a/app/invocation/invocation_artifacts_card.tsx
+++ b/app/invocation/invocation_artifacts_card.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import InvocationModel from "./invocation_model";
 import rpcService from "../service/rpc_service";
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
-import { ArrowDownCircle } from "lucide-react";
+import { ArrowDownCircle, FileCode } from "lucide-react";
 
 interface Props {
   model: InvocationModel;
@@ -85,14 +85,23 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
                 <div className="artifact-section-title">{target.label}</div>
                 <div className="artifact-list">
                   {target.outputs.map((output) => (
-                    <a
-                      href={rpcService.getBytestreamUrl(output.uri, this.props.model.getId(), {
-                        filename: output.name,
-                      })}
-                      className="artifact-name"
-                      onClick={this.handleArtifactClicked.bind(this, output.uri, output.name)}>
-                      {output.name}
-                    </a>
+                    <div className="artifact-line">
+                      <a
+                        href={rpcService.getBytestreamUrl(output.uri, this.props.model.getId(), {
+                          filename: output.name,
+                        })}
+                        className="artifact-name"
+                        onClick={this.handleArtifactClicked.bind(this, output.uri, output.name)}>
+                        {output.name}
+                      </a>
+                      <a
+                        className="artifact-view"
+                        href={`/code/buildbuddy-io/buildbuddy/?bytestream_url=${encodeURIComponent(
+                          output.uri
+                        )}&invocation_id=${this.props.model.getId()}&filename=${output.name}`}>
+                        <FileCode /> View
+                      </a>
+                    </div>
                   ))}
                   {target.hiddenOutputCount > 0 && (
                     <div className="artifact-hidden-count">

--- a/app/invocation/invocation_artifacts_card.tsx
+++ b/app/invocation/invocation_artifacts_card.tsx
@@ -94,13 +94,15 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
                         onClick={this.handleArtifactClicked.bind(this, output.uri, output.name)}>
                         {output.name}
                       </a>
-                      <a
-                        className="artifact-view"
-                        href={`/code/buildbuddy-io/buildbuddy/?bytestream_url=${encodeURIComponent(
-                          output.uri
-                        )}&invocation_id=${this.props.model.getId()}&filename=${output.name}`}>
-                        <FileCode /> View
-                      </a>
+                      {output.uri?.startsWith("bytestream://") && (
+                        <a
+                          className="artifact-view"
+                          href={`/code/buildbuddy-io/buildbuddy/?bytestream_url=${encodeURIComponent(
+                            output.uri
+                          )}&invocation_id=${this.props.model.getId()}&filename=${output.name}`}>
+                          <FileCode /> View
+                        </a>
+                      )}
                     </div>
                   ))}
                   {target.hiddenOutputCount > 0 && (

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1138,7 +1138,6 @@ code .comment {
   justify-content: center;
   padding: 0 8px;
   color: #888;
-  margin-top: 4px;
   white-space: nowrap;
 }
 
@@ -1156,7 +1155,7 @@ code .comment {
   padding-left: 32px;
 }
 
-.artifacts :is(.artifact-name, .artifact-hidden-count) {
+.artifacts :is(.artifact-line, .artifact-hidden-count) {
   margin-top: 4px;
 }
 

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1138,10 +1138,13 @@ code .comment {
   justify-content: center;
   padding: 0 8px;
   color: #888;
+  margin-top: 4px;
+  white-space: nowrap;
 }
 
 .artifact-view svg {
   width: 16px;
+  height: 16px;
 }
 
 .artifact-section-title {

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1121,11 +1121,27 @@ code .comment {
   cursor: pointer;
 }
 
+.artifact-line {
+  display: flex;
+}
+
 .artifact-name {
   font-weight: 600;
   text-decoration: underline;
   cursor: pointer;
-  display: block;
+}
+
+.artifact-view {
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 8px;
+  color: #888;
+}
+
+.artifact-view svg {
+  width: 16px;
 }
 
 .artifact-section-title {

--- a/app/target/target_artifacts_card.tsx
+++ b/app/target/target_artifacts_card.tsx
@@ -1,4 +1,4 @@
-import { ArrowDownCircle } from "lucide-react";
+import { ArrowDownCircle, FileCode } from "lucide-react";
 import React from "react";
 
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
@@ -29,13 +29,24 @@ export default class TargetArtifactsCardComponent extends React.Component<Props>
         <div className="content">
           <div className="title">Artifacts</div>
           <div className="details">
-            {this.props.files.map((file) => (
-              <a
-                href={rpcService.getBytestreamUrl(file.uri, this.props.invocationId, { filename: file.name })}
-                className="artifact-name"
-                onClick={this.handleArtifactClicked.bind(this, file.uri, file.name)}>
-                {file.name}
-              </a>
+            {this.props.files.map((output) => (
+              <div className="artifact-line">
+                <a
+                  href={rpcService.getBytestreamUrl(output.uri, this.props.invocationId, {
+                    filename: output.name,
+                  })}
+                  className="artifact-name"
+                  onClick={this.handleArtifactClicked.bind(this, output.uri, output.name)}>
+                  {output.name}
+                </a>
+                <a
+                  className="artifact-view"
+                  href={`/code/buildbuddy-io/buildbuddy/?bytestream_url=${encodeURIComponent(
+                    output.uri
+                  )}&invocation_id=${this.props.invocationId}&filename=${output.name}`}>
+                  <FileCode /> View
+                </a>
+              </div>
             ))}
           </div>
           {this.props.files.length == 0 && <span>No artifacts</span>}

--- a/app/target/target_artifacts_card.tsx
+++ b/app/target/target_artifacts_card.tsx
@@ -39,13 +39,15 @@ export default class TargetArtifactsCardComponent extends React.Component<Props>
                   onClick={this.handleArtifactClicked.bind(this, output.uri, output.name)}>
                   {output.name}
                 </a>
-                <a
-                  className="artifact-view"
-                  href={`/code/buildbuddy-io/buildbuddy/?bytestream_url=${encodeURIComponent(
-                    output.uri
-                  )}&invocation_id=${this.props.invocationId}&filename=${output.name}`}>
-                  <FileCode /> View
-                </a>
+                {output.uri?.startsWith("bytestream://") && (
+                  <a
+                    className="artifact-view"
+                    href={`/code/buildbuddy-io/buildbuddy/?bytestream_url=${encodeURIComponent(
+                      output.uri
+                    )}&invocation_id=${this.props.invocationId}&filename=${output.name}`}>
+                    <FileCode /> View
+                  </a>
+                )}
               </div>
             ))}
           </div>

--- a/enterprise/app/code/code.css
+++ b/enterprise/app/code/code.css
@@ -25,6 +25,9 @@
   font-family: monospace;
   flex-shrink: 0;
   margin-right: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .code-menu-logo .logo {
@@ -44,11 +47,20 @@
   justify-content: center;
 }
 
+.code-menu-back {
+  margin-right: 16px;
+  color: #000;
+}
+
 .code-menu-actions {
   min-width: 1px;
   white-space: nowrap;
   display: flex;
   align-items: center;
+}
+
+.code-menu-download-button {
+  gap: 8px;
 }
 
 .code-menu-breadcrumbs {

--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -9,7 +9,7 @@ import * as diff from "diff";
 import { runner } from "../../../proto/runner_ts_proto";
 import CodeBuildButton from "./code_build_button";
 import CodeEmptyStateComponent from "./code_empty";
-import { ArrowUpCircle, Code, Link, PlusCircle, Send, XCircle } from "lucide-react";
+import { ArrowLeft, ArrowUpCircle, Code, Download, Link, PlusCircle, Send, XCircle } from "lucide-react";
 import Spinner from "../../../app/components/spinner/spinner";
 import { OutlinedButton, FilledButton } from "../../../app/components/button/button";
 import { createPullRequest, updatePullRequest } from "./code_pull_request";
@@ -115,16 +115,34 @@ export default class CodeComponent extends React.Component<Props, State> {
     this.diffEditor?.layout();
   }
 
+  isSingleFile() {
+    return Boolean(this.props.search.get("bytestream_url"));
+  }
+
   componentDidMount() {
-    if (!this.currentRepo()) {
+    if (!this.currentRepo() && !this.isSingleFile()) {
       return;
     }
 
     window.addEventListener("resize", () => this.handleWindowResize());
+
     this.editor = monaco.editor.create(this.codeViewer.current, {
       value: ["// Welcome to BuildBuddy Code!", "", "// Click on a file to the left to get start editing."].join("\n"),
       theme: "vs",
     });
+
+    let bytestreamURL = this.props.search.get("bytestream_url");
+    let invocationID = this.props.search.get("invocation_id");
+    let filename = this.props.search.get("filename");
+    if (this.isSingleFile()) {
+      rpcService.fetchBytestreamFile(bytestreamURL, invocationID, "text").then((result: any) => {
+        this.editor.setModel(monaco.editor.createModel(result, undefined, monaco.Uri.file(filename || "file")));
+      });
+    }
+
+    if (!this.isSingleFile()) {
+      return;
+    }
 
     if (this.currentPath()) {
       if (this.state.mergeConflicts.has(this.currentPath())) {
@@ -630,7 +648,7 @@ export default class CodeComponent extends React.Component<Props, State> {
   // TODO(siggisim): Make sidebar look nice
   // TODO(siggisim): Make the diff view look nicer
   render() {
-    if (!this.currentRepo()) {
+    if (!this.currentRepo() && !this.isSingleFile()) {
       return <CodeEmptyStateComponent />;
     }
 
@@ -643,110 +661,145 @@ export default class CodeComponent extends React.Component<Props, State> {
       <div className="code-editor">
         <div className="code-menu">
           <div className="code-menu-logo">
+            {this.isSingleFile() && (
+              <a href="javascript:history.back()">
+                <ArrowLeft className="code-menu-back" />
+              </a>
+            )}
             <a href="/">
               <img alt="BuildBuddy Code" src="/image/logo_dark.svg" className="logo" /> Code{" "}
               <Code className="icon code-logo" />
             </a>
           </div>
           <div className="code-menu-breadcrumbs">
-            <div className="code-menu-breadcrumbs-environment">
-              {/* <a href="#">my-workspace</a> /{" "} TODO: add workspace to breadcrumb */}
-              <a target="_blank" href={`http://github.com/${this.currentOwner()}`}>
-                {this.currentOwner()}
-              </a>{" "}
-              /{" "}
-              <a target="_blank" href={`http://github.com/${this.currentOwner()}/${this.currentRepo()}`}>
-                {this.currentRepo()}
-              </a>{" "}
-              {/* <a href="#">master</a> / TODO: add branch to breadcrumb  */}@{" "}
-              <a
-                target="_blank"
-                title={this.state.commitSHA}
-                href={`http://github.com/${this.currentOwner()}/${this.currentRepo()}/commit/${this.state.commitSHA}`}>
-                {this.state.commitSHA?.slice(0, 7)}
-              </a>{" "}
-              <span onClick={this.handleUpdateCommitSha.bind(this, undefined)}>
-                <ArrowUpCircle className="code-update-commit" />
-              </span>{" "}
-            </div>
-            <div className="code-menu-breadcrumbs-filename">
-              {this.currentPath() ? (
-                <>
-                  <a href="#">{this.currentPath()}</a>
-                </>
-              ) : undefined}
-            </div>
-          </div>
-          <div className="code-menu-actions">
-            {this.state.changes.size > 0 && !this.state.prBranch && (
-              <OutlinedButton
-                disabled={this.state.requestingReview}
-                className="request-review-button"
-                onClick={this.handleShowReviewModalClicked.bind(this)}>
-                {this.state.requestingReview ? (
-                  <>
-                    <Spinner className="icon" /> Requesting...
-                  </>
-                ) : (
-                  <>
-                    <Send className="icon blue" /> Request Review
-                  </>
-                )}
-              </OutlinedButton>
+            {this.isSingleFile() && (
+              <div className="code-menu-breadcrumbs-filename">{this.props.search.get("filename")}</div>
+              // todo show hash and size
+              // todo show warning message for files larger than ~50mb
             )}
-            {this.state.changes.size > 0 && this.state.prBranch && (
-              <OutlinedButton
-                disabled={this.state.updatingPR}
-                className="request-review-button"
-                onClick={this.handleUpdatePR.bind(this)}>
-                {this.state.updatingPR ? (
-                  <>
-                    <Spinner className="icon" /> Updating...
-                  </>
-                ) : (
-                  <>
-                    <Send className="icon blue" /> Update PR
-                  </>
-                )}
-              </OutlinedButton>
+            {!this.isSingleFile() && (
+              <>
+                <div className="code-menu-breadcrumbs-environment">
+                  {/* <a href="#">my-workspace</a> /{" "} TODO: add workspace to breadcrumb */}
+                  <a target="_blank" href={`http://github.com/${this.currentOwner()}`}>
+                    {this.currentOwner()}
+                  </a>{" "}
+                  /{" "}
+                  <a target="_blank" href={`http://github.com/${this.currentOwner()}/${this.currentRepo()}`}>
+                    {this.currentRepo()}
+                  </a>{" "}
+                  {/* <a href="#">master</a> / TODO: add branch to breadcrumb  */}@{" "}
+                  <a
+                    target="_blank"
+                    title={this.state.commitSHA}
+                    href={`http://github.com/${this.currentOwner()}/${this.currentRepo()}/commit/${
+                      this.state.commitSHA
+                    }`}>
+                    {this.state.commitSHA?.slice(0, 7)}
+                  </a>{" "}
+                  <span onClick={this.handleUpdateCommitSha.bind(this, undefined)}>
+                    <ArrowUpCircle className="code-update-commit" />
+                  </span>{" "}
+                </div>
+                <div className="code-menu-breadcrumbs-filename">
+                  {this.currentPath() ? (
+                    <>
+                      <a href="#">{this.currentPath()}</a>
+                    </>
+                  ) : undefined}
+                </div>
+              </>
             )}
-            <CodeBuildButton
-              onCommandClicked={this.handleBuildClicked.bind(this)}
-              isLoading={this.state.isBuilding}
-              project={`${this.currentOwner()}/${this.currentRepo()}}`}
-            />
           </div>
+          {this.isSingleFile() && (
+            <div className="code-menu-actions">
+              <OutlinedButton
+                className="code-menu-download-button"
+                onClick={() =>
+                  rpcService.downloadBytestreamFile(
+                    this.props.search.get("filename"),
+                    this.props.search.get("bytestream_url"),
+                    this.props.search.get("invocation_id")
+                  )
+                }>
+                <Download /> Download File
+              </OutlinedButton>
+            </div>
+          )}
+          {!this.isSingleFile() && (
+            <div className="code-menu-actions">
+              {this.state.changes.size > 0 && !this.state.prBranch && (
+                <OutlinedButton
+                  disabled={this.state.requestingReview}
+                  className="request-review-button"
+                  onClick={this.handleShowReviewModalClicked.bind(this)}>
+                  {this.state.requestingReview ? (
+                    <>
+                      <Spinner className="icon" /> Requesting...
+                    </>
+                  ) : (
+                    <>
+                      <Send className="icon blue" /> Request Review
+                    </>
+                  )}
+                </OutlinedButton>
+              )}
+              {this.state.changes.size > 0 && this.state.prBranch && (
+                <OutlinedButton
+                  disabled={this.state.updatingPR}
+                  className="request-review-button"
+                  onClick={this.handleUpdatePR.bind(this)}>
+                  {this.state.updatingPR ? (
+                    <>
+                      <Spinner className="icon" /> Updating...
+                    </>
+                  ) : (
+                    <>
+                      <Send className="icon blue" /> Update PR
+                    </>
+                  )}
+                </OutlinedButton>
+              )}
+              <CodeBuildButton
+                onCommandClicked={this.handleBuildClicked.bind(this)}
+                isLoading={this.state.isBuilding}
+                project={`${this.currentOwner()}/${this.currentRepo()}}`}
+              />
+            </div>
+          )}
         </div>
         <div className="code-main">
-          <div className="code-sidebar">
-            <div className="code-sidebar-tree">
-              {this.state.repoResponse &&
-                this.state.repoResponse.data.tree
-                  .sort(compareNodes)
-                  .map((node: any) => (
-                    <SidebarNodeComponent
-                      node={node}
-                      treeShaToExpanded={this.state.treeShaToExpanded}
-                      treeShaToChildrenMap={this.state.treeShaToChildrenMap}
-                      handleFileClicked={this.handleFileClicked.bind(this)}
-                      fullPath={node.path}
-                    />
-                  ))}
-            </div>
-            <div className="code-sidebar-actions">
-              {!this.props.user.githubToken && (
-                <button onClick={this.handleGitHubClicked.bind(this)}>
-                  <Link className="icon" /> Link GitHub
+          {!this.isSingleFile() && (
+            <div className="code-sidebar">
+              <div className="code-sidebar-tree">
+                {this.state.repoResponse &&
+                  this.state.repoResponse.data.tree
+                    .sort(compareNodes)
+                    .map((node: any) => (
+                      <SidebarNodeComponent
+                        node={node}
+                        treeShaToExpanded={this.state.treeShaToExpanded}
+                        treeShaToChildrenMap={this.state.treeShaToChildrenMap}
+                        handleFileClicked={this.handleFileClicked.bind(this)}
+                        fullPath={node.path}
+                      />
+                    ))}
+              </div>
+              <div className="code-sidebar-actions">
+                {!this.props.user.githubToken && (
+                  <button onClick={this.handleGitHubClicked.bind(this)}>
+                    <Link className="icon" /> Link GitHub
+                  </button>
+                )}
+                <button onClick={this.handleNewFileClicked.bind(this)}>
+                  <PlusCircle className="icon green" /> New
                 </button>
-              )}
-              <button onClick={this.handleNewFileClicked.bind(this)}>
-                <PlusCircle className="icon green" /> New
-              </button>
-              <button onClick={this.handleDeleteClicked.bind(this)}>
-                <XCircle className="icon red" /> Delete
-              </button>
+                <button onClick={this.handleDeleteClicked.bind(this)}>
+                  <XCircle className="icon red" /> Delete
+                </button>
+              </div>
             </div>
-          </div>
+          )}
           <div className="code-container">
             <div className="code-viewer-container">
               <div className={`code-viewer ${showDiffView ? "hidden-viewer" : ""}`} ref={this.codeViewer} />


### PR DESCRIPTION
Screenshot of view button next to artifacts:
<img width="1495" alt="Screen Shot 2022-11-28 at 5 04 39 PM" src="https://user-images.githubusercontent.com/1704556/204413209-9602d6c3-c171-40da-a974-54cd03d3b5db.png">

Screenshot of single file code editor view:
<img width="1495" alt="Screen Shot 2022-11-28 at 5 04 44 PM" src="https://user-images.githubusercontent.com/1704556/204413259-8a3ecd8a-d8b2-4164-b555-ef87581ea7b3.png">


---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
