### PR TITLE
Fix changes view in code editor and make single file view read-only

### DIFF
--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -129,6 +129,7 @@ export default class CodeComponent extends React.Component<Props, State> {
     this.editor = monaco.editor.create(this.codeViewer.current, {
       value: ["// Welcome to BuildBuddy Code!", "", "// Click on a file to the left to get start editing."].join("\n"),
       theme: "vs",
+      readOnly: this.isSingleFile(),
     });
 
     let bytestreamURL = this.props.search.get("bytestream_url");
@@ -138,9 +139,6 @@ export default class CodeComponent extends React.Component<Props, State> {
       rpcService.fetchBytestreamFile(bytestreamURL, invocationID, "text").then((result: any) => {
         this.editor.setModel(monaco.editor.createModel(result, undefined, monaco.Uri.file(filename || "file")));
       });
-    }
-
-    if (!this.isSingleFile()) {
       return;
     }
 


### PR DESCRIPTION
This fixes an issue with displaying changes introduced by the artifact viewer change and makes the artifact viewer mode read-only.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
