### PR TITLE
Enable zstd transcoding by default

### DIFF
--- a/server/remote_cache/config/config.go
+++ b/server/remote_cache/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import "flag"
 
-var zstdTranscodingEnabled = flag.Bool("cache.zstd_transcoding_enabled", false, "Whether to accept requests to read/write zstd-compressed blobs, compressing/decompressing outgoing/incoming blobs on the fly.")
+var zstdTranscodingEnabled = flag.Bool("cache.zstd_transcoding_enabled", true, "Whether to accept requests to read/write zstd-compressed blobs, compressing/decompressing outgoing/incoming blobs on the fly.")
 
 func ZstdTranscodingEnabled() bool {
 	return *zstdTranscodingEnabled


### PR DESCRIPTION
I've seen multiple customers run into this and I think it's safe to enable by default. 