### PR TITLE
Fix dev_qa script

### DIFF
--- a/tools/dev_qa.sh
+++ b/tools/dev_qa.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-: "${QA_ROOT:=~/buildbuddy-qa}"
+: "${QA_ROOT:=$HOME/buildbuddy-qa}"
 
 mkdir -p "$QA_ROOT"
 cd "$QA_ROOT"


### PR DESCRIPTION
The `~` wasn't being expanded due to being inside quotes, causing the QA repos to be cloned into the literal path `./~/buildbuddy-qa`.

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
