### PR TITLE
Always use workspace version of gazelle for buildfix.sh

### DIFF
--- a/buildfix.sh
+++ b/buildfix.sh
@@ -27,7 +27,10 @@ done
 c_yellow="\x1b[33m"
 c_reset="\x1b[0m"
 
-BAZEL_QUIET_FLAGS=(--ui_event_filters=-info,-stdout,-stderr --noshow_progress)
+BAZEL_QUIET_FLAGS=(
+  "--ui_event_filters=-info,-stdout,-stderr"
+  "--noshow_progress"
+)
 
 # buildifier format all BUILD files
 echo "Formatting WORKSPACE/BUILD files..."
@@ -54,16 +57,12 @@ echo "Formatting frontend and markup files with prettier..."
 
 if ((GO_DEPS)); then
   echo "Fixing go.mod, go.sum, and deps.bzl..."
-  GAZELLE_PATH=$(which gazelle || true) ./tools/fix_go_deps.sh
+  ./tools/fix_go_deps.sh
 fi
 
 if ((GAZELLE)); then
   echo "Fixing BUILD deps with gazelle..."
-  if which gazelle &>/dev/null; then
-    gazelle
-  else
-    bazel run //:gazelle
-  fi
+  bazel run "${BAZEL_QUIET_FLAGS[@]}" //:gazelle
 fi
 
 echo 'All done!'


### PR DESCRIPTION
Instead of using the gazelle binary in `$PATH`, always invoke Gazelle using `bazel run //:gazelle`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
