### PR TITLE
CLI: Increase the sidecar's default local cache size

### DIFF
--- a/cli/cmd/sidecar/sidecar.go
+++ b/cli/cmd/sidecar/sidecar.go
@@ -34,6 +34,11 @@ import (
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
+const (
+	// Default max size for the sidecar's local cache.
+	defaultMaxCacheSizeBytes = 10_000_000_000 // 10 GB
+)
+
 var (
 	serverType = flag.String("server_type", "sidecar", "The server type to match on health checks")
 
@@ -196,7 +201,7 @@ func normalizeGrpcTarget(target string) string {
 }
 
 func initializeDiskCache(env *real_environment.RealEnv) {
-	maxSizeBytes := int64(1e9) // 1 GB
+	maxSizeBytes := int64(defaultMaxCacheSizeBytes)
 	if *cacheMaxSizeBytes != 0 {
 		maxSizeBytes = *cacheMaxSizeBytes
 	}


### PR DESCRIPTION
I was seeing some behavior where `bb` builds were spending a few seconds in "Waiting for build events upload" at the end of each build. The specific command I was testing was `bb build //enterprise/server --config=cache`.

While waiting for BES uploads, the sidecar logs show that it's serving lots of `FindMissingBlobs` requests that need to be forwarded to the remote, since the blobs aren't available in the sidecar's local disk cache. The logs also show lots of cache evictions happening, which seems to be due to the small cache size.

By bumping the cache size, we can fit more BES uploads across builds in the local cache, making it so that most of the `FindMissingBlobs` requests can be served locally, so the build doesn't need to spend as long at the end.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
