### PR TITLE
Set pushed image tag using starlark flag

### DIFF
--- a/deployment/BUILD
+++ b/deployment/BUILD
@@ -1,7 +1,9 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
 load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
 load("@io_bazel_rules_docker//container:push.bzl", "container_push")
+load("//rules/flags:index.bzl", "write_flag_to_file")
 
 # TODO(tylerw): break depoloyment.yaml apart.
 # TODO(tylerw): do the etsy context thing to set dev/prod vars.
@@ -21,6 +23,22 @@ k8s_objects(
     ],
 )
 
+# Set --//deployment:image_tag to set the tag when running container_push
+# targets. If unset, defaults to "latest".
+#
+# Note that this tag is shared across all targets, which is fine since only one
+# container_push target can run at once.
+string_flag(
+    name = "image_tag",
+    build_setting_default = "latest",
+)
+
+write_flag_to_file(
+    name = "image_tag_file",
+    flag = ":image_tag",
+    visibility = ["//visibility:public"],
+)
+
 # Definition for uploading new releases of the on_prem docker image.
 # Running this? You may want to update the onprem image version configured in
 # deployment/buildbuddy-app.onprem.yaml so on-prem users actually get your
@@ -29,11 +47,9 @@ container_push(
     name = "release_onprem",
     format = "Docker",
     image = "//server:buildbuddy_image",
-
-    # Any of these components may have variables. They are set by passing
-    # --define version=1.2.3 as arguments to the bazel build command.
     registry = "gcr.io",
     repository = "flame-public/buildbuddy-app-onprem",
-    tag = "$(version)",
+    # Set the image tag with the bazel run flag "--//deployment:image_tag=TAG"
+    tag_file = "//deployment:image_tag_file",
     tags = ["manual"],  # Don't include this target in wildcard patterns
 )

--- a/deployment/BUILD
+++ b/deployment/BUILD
@@ -24,13 +24,13 @@ k8s_objects(
 )
 
 # Set --//deployment:image_tag to set the tag when running container_push
-# targets. If unset, defaults to "latest".
+# targets. If unset, defaults to "development".
 #
 # Note that this tag is shared across all targets, which is fine since only one
 # container_push target can run at once.
 string_flag(
     name = "image_tag",
-    build_setting_default = "latest",
+    build_setting_default = "development",
 )
 
 write_flag_to_file(

--- a/dockerfiles/run_script/BUILD
+++ b/dockerfiles/run_script/BUILD
@@ -4,11 +4,8 @@ container_push(
     name = "push_run_script",
     format = "Docker",
     image = "@run_script_image//image:dockerfile_image.tar",
-
-    # Any of these components may have variables. They are set by passing
-    # --define version=1.2.3 as arguments to the bazel build command.
     registry = "gcr.io",
     repository = "flame-build/run-script",  # Note flame-build, not flame-public.
-    tag = "$(version)",
+    tag_file = "//deployment:image_tag",
     tags = ["manual"],  # Don't include this target in wildcard patterns
 )

--- a/dockerfiles/test_images/BUILD
+++ b/dockerfiles/test_images/BUILD
@@ -16,11 +16,9 @@ container_push(
     name = "nonroot_user_push",
     format = "Docker",
     image = "//dockerfiles/test_images:nonroot_user_container_image",
-
-    # Any of these components may have variables. They are set by passing
-    # --define version=1.2.3 as arguments to the bazel build command.
     registry = "gcr.io",
     repository = "flame-build/test-nonroot-user",
-    tag = "$(version)",
+    # Set the image tag with the bazel run flag "--//deployment:image_tag=TAG"
+    tag_file = "//deployment:image_tag_file",
     tags = ["manual"],  # Don't include this target in wildcard patterns
 )

--- a/enterprise/deployment/BUILD
+++ b/enterprise/deployment/BUILD
@@ -8,12 +8,10 @@ container_push(
     name = "release_enterprise",
     format = "Docker",
     image = "//enterprise/server/cmd/server:buildbuddy_image",
-
-    # Any of these components may have variables. They are set by passing
-    # --define version=1.2.3 as arguments to the bazel build command.
     registry = "gcr.io",
     repository = "flame-public/buildbuddy-app-enterprise",
-    tag = "$(version)",
+    # Set the image tag with the bazel run flag "--//deployment:image_tag=TAG"
+    tag_file = "//deployment:image_tag_file",
     tags = ["manual"],  # Don't include this target in wildcard patterns
 )
 
@@ -23,12 +21,10 @@ container_push(
     name = "release_executor_enterprise",
     format = "Docker",
     image = "//enterprise/server/cmd/executor:executor_image",
-
-    # Any of these components may have variables. They are set by passing
-    # --define version=1.2.3 as arguments to the bazel build command.
     registry = "gcr.io",
     repository = "flame-public/buildbuddy-executor-enterprise",
-    tag = "$(version)",
+    # Set the image tag with the bazel run flag "--//deployment:image_tag=TAG"
+    tag_file = "//deployment:image_tag_file",
     tags = ["manual"],  # Don't include this target in wildcard patterns
 )
 
@@ -37,11 +33,9 @@ container_push(
     name = "executor_docker_default",
     format = "Docker",
     image = "//enterprise/server/cmd/executor:default_base_image",
-
-    # Any of these components may have variables. They are set by passing
-    # --define version=1.2.3 as arguments to the bazel build command.
     registry = "gcr.io",
     repository = "flame-public/executor-docker-default",  # Note flame-build, not flame-public.
-    tag = "$(version)",
+    # Set the image tag with the bazel run flag "--//deployment:image_tag=TAG"
+    tag_file = "//deployment:image_tag_file",
     tags = ["manual"],  # Don't include this target in wildcard patterns
 )

--- a/enterprise/server/deployment/BUILD
+++ b/enterprise/server/deployment/BUILD
@@ -6,11 +6,9 @@ container_push(
     name = "push_ci_runner",
     format = "Docker",
     image = "//enterprise/server/cmd/ci_runner:ci_runner_image",
-
-    # Any of these components may have variables. They are set by passing
-    # --define version=1.2.3 as arguments to the bazel build command.
     registry = "gcr.io",
     repository = "flame-public/buildbuddy-ci-runner",
-    tag = "$(version)",
+    # Set the image tag with the bazel run flag "--//deployment:image_tag=TAG"
+    tag_file = "//deployment:image_tag_file",
     tags = ["manual"],  # Don't include this target in wildcard patterns
 )

--- a/release.py
+++ b/release.py
@@ -80,14 +80,12 @@ def create_and_push_tag(old_version, new_version, release_notes=''):
     run_or_die(push_tag_cmd)
 
 def push_image(target, version_tag, image_tag):
-    # Note:
-    # The flag "--define=version=..." sets the Docker image tag.
-    # The flag "--//server/version:version_tag" sets the embedded
-    # git version tag which is printed on server startup.
+    # Note: The flag "--//server/version:version_tag" sets the embedded git
+    # version tag which is printed on server startup.
     command = (
         'bazel run -c opt --stamp '+
         '--define=release=true '+
-        '--define=version={image_tag} '+
+        '--//deployment:image_tag={image_tag} '+
         '--//server/version:version_tag={version_tag} '+
         '{target}'
     ).format(image_tag=image_tag, version_tag=version_tag, target=target)

--- a/tools/cacheload/BUILD
+++ b/tools/cacheload/BUILD
@@ -43,11 +43,9 @@ container_push(
     name = "push_cacheload_image",
     format = "Docker",
     image = ":cacheload_image",
-
-    # Any of these components may have variables. They are set by passing
-    # --define version=1.2.3 as arguments to the bazel build command.
     registry = "gcr.io",
     repository = "flame-build/cacheload",  # Note flame-build, not flame-public.
-    tag = "$(version)",
+    # Set the image tag with the bazel run flag "--//deployment:image_tag=TAG"
+    tag_file = "//deployment:image_tag_file",
     tags = ["manual"],  # Don't include this target in wildcard patterns
 )

--- a/tools/probers/BUILD
+++ b/tools/probers/BUILD
@@ -21,11 +21,9 @@ container_push(
     name = "push_probers_image",
     format = "Docker",
     image = ":probers_image",
-
-    # Any of these components may have variables. They are set by passing
-    # --define version=1.2.3 as arguments to the bazel build command.
     registry = "gcr.io",
     repository = "flame-build/probers",  # Note flame-build, not flame-public.
-    tag = "$(version)",
+    # Set the image tag with the bazel run flag "--//deployment:image_tag=TAG"
+    tag_file = "//deployment:image_tag_file",
     tags = ["manual"],  # Don't include this target in wildcard patterns
 )

--- a/tools/rbeperf/BUILD
+++ b/tools/rbeperf/BUILD
@@ -50,11 +50,9 @@ container_push(
     name = "push_rbeperf_image",
     format = "Docker",
     image = ":rbeperf_image",
-
-    # Any of these components may have variables. They are set by passing
-    # --define version=1.2.3 as arguments to the bazel build command.
     registry = "gcr.io",
     repository = "flame-build/rbeperf",  # Note flame-build, not flame-public.
-    tag = "$(version)",
+    # Set the image tag with the bazel run flag "--//deployment:image_tag=TAG"
+    tag_file = "//deployment:image_tag_file",
     tags = ["manual"],  # Don't include this target in wildcard patterns
 )

--- a/tools/tcpproxy/BUILD
+++ b/tools/tcpproxy/BUILD
@@ -29,11 +29,9 @@ container_push(
     name = "push_tcpproxy_image",
     format = "Docker",
     image = ":tcpproxy_image",
-
-    # Any of these components may have variables. They are set by passing
-    # --define version=1.2.3 as arguments to the bazel build command.
     registry = "gcr.io",
     repository = "flame-build/tcpproxy",  # Note flame-build, not flame-public.
-    tag = "$(version)",
+    # Set the image tag with the bazel run flag "--//deployment:image_tag=TAG"
+    tag_file = "//deployment:image_tag_file",
     tags = ["manual"],  # Don't include this target in wildcard patterns
 )


### PR DESCRIPTION
Migrate from setting the version with `--define=version=TAG` to `--//deployment:image_tag=TAG`.

Unfortunately the analysis cache is still discarded when changing starlark flags (see https://github.com/bazelbuild/bazel/issues/13591), but I figured since the docs say that "--define" is "legacy syntax" it's worth migrating to a starlark flag either way.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
