### PR TITLE
Disable race detection for GH action builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -53,7 +53,7 @@ build:ci --repository_cache=/home/runner/repo-cache/
 build:ci --flaky_test_attempts=2
 build:ci --color=yes
 build:ci --disk_cache=
-build:ci --@io_bazel_rules_go//go/config:race
+# build:ci --@io_bazel_rules_go//go/config:race
 
 # Configuration used for untrusted GitHub actions-based CI
 build:untrusted-ci --config=remote


### PR DESCRIPTION
Looks like these are failing on GH actions too, not just BB workflows -- probably because the default execution image (ubuntu 16.04) has an outdated gcc version.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
