### PR TITLE
Add bazel symlinks to .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,1 +1,5 @@
+bazel-bin
+bazel-buildbuddy
+bazel-out
+bazel-testlogs
 node_modules


### PR DESCRIPTION
Occasionally I get weird errors due to bazel trying to build targets under `bazel-bin`, `bazel-buildbuddy` etc. when running things like `bazel test //...`. Example:

`ERROR: error loading package 'bazel-bin/server/test/webdriver/invocation/invocation_test_chromium-local.sh.runfiles/buildbuddy/server/util/bazel/bazel-5.3.0_install/embedded_tools/src/conditions': Label '//tools/windows:windows_config.bzl' is invalid because 'tools/windows' is not a package; perhaps you meant to put the colon here: '//tools:windows/windows_config.bzl'?`

Seems like bazel should never traverse these symlinks when expanding `//...` so this is probably a weird Bazel bug, but adding the bazel convenience symlinks to `.bazelignore` seems to fix it.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
