### PR TITLE
Embed version info using stamping instead of starlark flag

### DIFF
--- a/.github/workflows/release-m1.yaml
+++ b/.github/workflows/release-m1.yaml
@@ -40,6 +40,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export DEVELOPER_DIR=/Applications/Xcode_12.4.app/Contents/Developer
-          "${GITHUB_WORKSPACE}/bin/bazel" build --config=release-m1 --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} --//server/version:version_tag=${{ steps.tag.outputs.TAG }} //enterprise/server/cmd/executor:executor
+          "${GITHUB_WORKSPACE}/bin/bazel" build --config=release-m1 --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-darwin-arm64
           gh release upload ${{ steps.tag.outputs.TAG }} executor-enterprise-darwin-arm64 --clobber

--- a/.github/workflows/release-mac.yaml
+++ b/.github/workflows/release-mac.yaml
@@ -29,7 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export DEVELOPER_DIR=/Applications/Xcode_12.4.app/Contents/Developer
-          "${GITHUB_WORKSPACE}/bin/bazel" build --config=release --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} --//server/version:version_tag=${{ steps.tag.outputs.TAG }} //server/cmd/buildbuddy:buildbuddy //enterprise/server/cmd/server:buildbuddy //enterprise/server/cmd/executor:executor
+          "${GITHUB_WORKSPACE}/bin/bazel" build --config=release --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //server/cmd/buildbuddy:buildbuddy //enterprise/server/cmd/server:buildbuddy //enterprise/server/cmd/executor:executor
           cp bazel-bin/server/cmd/**/**/buildbuddy buildbuddy-darwin-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/buildbuddy buildbuddy-enterprise-darwin-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-darwin-amd64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" build --config=release --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} --//server/version:version_tag=${{ steps.tag.outputs.TAG }} //server/cmd/buildbuddy:buildbuddy //enterprise/server/cmd/server:buildbuddy //enterprise/server/cmd/executor:executor
+          "${GITHUB_WORKSPACE}/bin/bazel" build --config=release --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //server/cmd/buildbuddy:buildbuddy //enterprise/server/cmd/server:buildbuddy //enterprise/server/cmd/executor:executor
           cp bazel-bin/server/cmd/**/**/buildbuddy buildbuddy-linux-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/buildbuddy buildbuddy-enterprise-linux-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-linux-amd64

--- a/server/version/BUILD
+++ b/server/version/BUILD
@@ -1,42 +1,16 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//rules/flags:index.bzl", "write_flag_to_file")
-
-# Define a build flag that sets the embedded version tag:
-#
-#     bazel build server --//server/version:version_tag=v1.2.3
-string_flag(
-    name = "version_tag",
-    build_setting_default = "",
-)
 
 go_library(
     name = "version",
-    srcs = ["version.go"],  # keep
-    embed = [":version_tag_lib"],  # keep
+    srcs = ["version.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/version",
     visibility = ["//visibility:public"],
     x_defs = {
-        "commitSha": "{COMMIT_SHA}",
+        "commitSha": "{STABLE_COMMIT_SHA}",
+        "versionTag": "{STABLE_VERSION_TAG}",
     },
     deps = [
         "//server/util/log",
     ],
-)
-
-go_library(
-    name = "version_tag_lib",
-    srcs = [":version_tag.go"],
-    importpath = "github.com/buildbuddy-io/buildbuddy/server/version",
-)
-
-# TODO(bduffany): Use go:embed instead of a generated go library once generated
-# files can be embedded: https://github.com/bazelbuild/rules_go/pull/3285
-write_flag_to_file(
-    name = "version_tag.go",
-    flag = ":version_tag",
-    template = """package version
-
-var versionTag = "%s"
-""",
 )

--- a/server/version/version.go
+++ b/server/version/version.go
@@ -12,11 +12,8 @@ const (
 )
 
 // This is set by x_defs in the BUILD file.
-//
-//	x_defs = {
-//	    "commitSha": "{COMMIT_SHA}",
-//	},
 var commitSha string
+var versionTag string
 
 func Print() {
 	appVersion := fmt.Sprintf("BuildBuddy %s", AppVersion())
@@ -27,7 +24,7 @@ func Print() {
 }
 
 func AppVersion() string {
-	if versionTag != "" {
+	if versionTag != "" && versionTag != "{STABLE_VERSION_TAG}" {
 		return versionTag
 	}
 	return unknownValue
@@ -38,7 +35,7 @@ func GoVersion() string {
 }
 
 func Commit() string {
-	if commitSha != "" && commitSha != "{COMMIT_SHA}" {
+	if commitSha != "" && commitSha != "{STABLE_COMMIT_SHA}" {
 		return commitSha
 	}
 	return unknownValue

--- a/tools/latest_version_tag.sh
+++ b/tools/latest_version_tag.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+# Prints the latest BuildBuddy version tag, like "v2.12.8"
+git tag -l 'v*' --sort=creatordate |
+    perl -nle 'if (/^v\d+\.\d+\.\d+$/) { print $_ }' |
+    tail -n1
+

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -28,3 +28,9 @@ echo "GIT_BRANCH $git_branch"
 git_tree_status=$(git diff-index --quiet HEAD -- && echo 'Clean' || echo 'Modified')
 echo "GIT_TREE_STATUS $git_tree_status"
 
+# Note: the "STABLE_" suffix causes these to be part of the "stable" workspace
+# status, which may trigger rebuilds of certain targets if these values change
+# and you're building with the "--stamp" flag.
+latest_version_tag=$(./tools/latest_version_tag.sh)
+echo "STABLE_VERSION_TAG $latest_version_tag"
+echo "STABLE_COMMIT_SHA $commit_sha"


### PR DESCRIPTION
Instead of a starlark flag (which we could potentially forget to set), embed the version info using `workspace_status.sh`.

Also fix the way that we were embedding the commit SHA. The commit SHA could potentially be stale since it was part of the "volatile" status, which means it doesn't trigger rebuilds if changed. Prefixing it with "STABLE_" fixes this.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
