### PR TITLE
CLI: Don't initialize sidecar if it won't proxy any requests

### DIFF
--- a/cli/log/log.go
+++ b/cli/log/log.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	debugPrefix   = "\x1b[33m[bb-debug]\x1b[m "
-	warningPrefix = "\x1b[33mWarning:\x1b[m "
+	WarningPrefix = "\x1b[33mWarning:\x1b[m "
 )
 
 var verbose bool
@@ -43,11 +43,11 @@ func Printf(format string, v ...interface{}) {
 }
 
 func Warn(v ...any) {
-	log.Print(append([]any{warningPrefix}, v...)...)
+	log.Print(append([]any{WarningPrefix}, v...)...)
 }
 
 func Warnf(format string, v ...interface{}) {
-	log.Printf(warningPrefix+format, v...)
+	log.Printf(WarningPrefix+format, v...)
 }
 
 func Fatalf(format string, v ...interface{}) {

--- a/cli/test/integration/cli/BUILD
+++ b/cli/test/integration/cli/BUILD
@@ -4,6 +4,7 @@ go_test(
     name = "cli_test",
     srcs = ["cli_test.go"],
     deps = [
+        "//cli/log",
         "//cli/testutil/testcli",
         "//server/testutil/testbazel",
         "//server/testutil/testfs",

--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/testutil/testcli"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testbazel"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
@@ -15,9 +16,12 @@ func TestBazelVersion(t *testing.T) {
 	cmd := testcli.Command(t, ws, "version")
 
 	b, err := testcli.CombinedOutput(cmd)
+	output := string(b)
 	require.NoError(t, err, "output: %s", string(b))
 
-	require.Contains(t, string(b), "Build label: "+testbazel.Version)
+	require.Contains(t, output, "Build label: "+testbazel.Version)
+	// Make sure we don't print any warnings.
+	require.NotContains(t, output, log.WarningPrefix)
 }
 
 func TestBazelBuildWithLocalPlugin(t *testing.T) {
@@ -56,4 +60,6 @@ func TestBazelBuildWithLocalPlugin(t *testing.T) {
 	require.Contains(t, output, "--build_metadata FOO=bar was canonicalized as expected!")
 	require.Contains(t, output, "Hello from handle_bazel_output.sh! Build was successful.")
 	require.Contains(t, output, "Hello from post_bazel.sh!")
+	// Make sure we don't print any warnings.
+	require.NotContains(t, output, log.WarningPrefix)
 }


### PR DESCRIPTION
The sidecar shouldn't be initialized unless there is a bes_backend or remote_cache set. This logic broke in an earlier PR, and this PR fixes it.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
