### PR TITLE
CLI: Increase cache proxy write queue size

### DIFF
--- a/cli/cache_proxy/cache_proxy.go
+++ b/cli/cache_proxy/cache_proxy.go
@@ -31,7 +31,7 @@ var (
 )
 
 const (
-	queueBufferSize = 100
+	queueBufferSize = 10_000
 )
 
 // CacheProxy implements a local GRPC cache that proxies a remote GRPC cache.


### PR DESCRIPTION
Lots of remote writes are getting dropped due to the small queue capacity. Increasing the queue length so that the sidecar can better utilize upload bandwidth once the invocation is complete.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
