### PR TITLE
Clear login cookie if it's invalid

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -924,6 +924,10 @@ func (a *OpenIDAuthenticator) authenticateUser(w http.ResponseWriter, r *http.Re
 	sesh, err := authDB.ReadSession(ctx, sessionID)
 	if err != nil {
 		log.Debugf("Session not found: %s", err)
+		// Clear auth cookies if the session is not found. This allows the login
+		// flow to request a refresh token, since otherwise the login flow will
+		// assume (based on the existence of this cookie) that a valid session exists with a refresh token already set.
+		clearLoginCookie(a.env, w)
 		return nil, ut, status.PermissionDeniedErrorf("%s: session not found", loggedOutMsg)
 	}
 


### PR DESCRIPTION
If the session cookie is invalid (points to a row in the DB that does not exist), this can cause the auth logic to get into a bad state where going through the login oauth flow will not grant a refresh token, because the login flow assumes that if the session cookie is set at all (valid or not) then we don't need to re-request a refresh token.

This can happen if the DB gets cleared, e.g. during local development (which uses a DB under /tmp/). I'm not sure if there are other situations where it can happen.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
