### PR TITLE
Delete old network namespaces in enable_local_firecracker.sh so people can use it to clean up after old Firecracker runs that didn't exit cleanly.

### DIFF
--- a/tools/enable_local_firecracker.sh
+++ b/tools/enable_local_firecracker.sh
@@ -79,5 +79,9 @@ if [ "$FOUND_ENTRY" != "$IP_ENTRY" ]; then
     echo "$IP_ENTRY" | EDITOR='tee -a' visudo >/dev/null
 fi
 
+# Clean up vestigial network namespaces, these can be left around if firecracker
+# doesn't exit cleanly and interfere with subsequent VM startup.
+ip --all netns delete
+
 echo "All done! You should be ready to run the executor as your user now."
 echo "You will need to run this program again if you restart or update the jailer binary"


### PR DESCRIPTION
**Version bump**: None