### PR TITLE
Add debug logging if pebble metadata size does not match size in cached digest

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -898,7 +898,7 @@ func (p *PebbleCache) Metadata(ctx context.Context, r *resource.ResourceName) (*
 	}
 
 	if md.GetStoredSizeBytes() != md.GetFileRecord().GetDigest().GetSizeBytes() {
-		log.Debugf("Pebble metadata size mismatch: %v", md)
+		log.CtxInfof(ctx, "Pebble metadata size mismatch: %v", md)
 	}
 
 	return &interfaces.CacheMetadata{

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -897,6 +897,10 @@ func (p *PebbleCache) Metadata(ctx context.Context, r *resource.ResourceName) (*
 		return nil, err
 	}
 
+	if md.GetStoredSizeBytes() != md.GetFileRecord().GetDigest().GetSizeBytes() {
+		log.Debugf("Pebble metadata size mismatch: %v", md)
+	}
+
 	return &interfaces.CacheMetadata{
 		SizeBytes:          md.GetStoredSizeBytes(),
 		LastModifyTimeUsec: md.GetLastModifyUsec(),


### PR DESCRIPTION
This logging will have some false positive rate, because on dev compression is on and in those cases we'd expect the sizes to be different. 