### PR TITLE
Add debug logging if pebble metadata size does not match size in cached digest - Move to lookups and writes

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1359,12 +1359,6 @@ func (p *PebbleCache) Writer(ctx context.Context, r *resource.ResourceName) (int
 			metrics.DiskCacheAddedFileSizeBytes.Observe(float64(bytesWritten))
 		}
 
-		fr := md.GetFileRecord()
-		if fr.GetCompressor() == repb.Compressor_IDENTITY &&
-			md.GetStoredSizeBytes() != fr.GetDigest().GetSizeBytes() {
-			log.CtxInfof(ctx, "Pebble write metadata size mismatch: %v", md)
-		}
-
 		return err
 	}
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -839,7 +839,9 @@ func lookupFileMetadata(ctx context.Context, iter *pebble.Iterator, fileMetadata
 		return nil, err
 	}
 
-	if fileMetadata.GetStoredSizeBytes() != fileMetadata.GetFileRecord().GetDigest().GetSizeBytes() {
+	fileRecord := fileMetadata.GetFileRecord()
+	if fileRecord.GetCompressor() == repb.Compressor_IDENTITY &&
+		fileMetadata.GetStoredSizeBytes() != fileRecord.GetDigest().GetSizeBytes() {
 		log.CtxInfof(ctx, "Pebble lookup metadata size mismatch: %v", fileMetadata)
 	}
 
@@ -856,7 +858,9 @@ func readFileMetadata(reader pebble.Reader, fileMetadataKey []byte) (*rfpb.FileM
 		return nil, err
 	}
 
-	if fileMetadata.GetStoredSizeBytes() != fileMetadata.GetFileRecord().GetDigest().GetSizeBytes() {
+	fileRecord := fileMetadata.GetFileRecord()
+	if fileRecord.GetCompressor() == repb.Compressor_IDENTITY &&
+		fileMetadata.GetStoredSizeBytes() != fileRecord.GetDigest().GetSizeBytes() {
 		log.Infof("Pebble read metadata size mismatch: %v", fileMetadata)
 	}
 
@@ -1355,7 +1359,9 @@ func (p *PebbleCache) Writer(ctx context.Context, r *resource.ResourceName) (int
 			metrics.DiskCacheAddedFileSizeBytes.Observe(float64(bytesWritten))
 		}
 
-		if md.GetStoredSizeBytes() != md.GetFileRecord().GetDigest().GetSizeBytes() {
+		fr := md.GetFileRecord()
+		if fr.GetCompressor() == repb.Compressor_IDENTITY &&
+			md.GetStoredSizeBytes() != fr.GetDigest().GetSizeBytes() {
 			log.CtxInfof(ctx, "Pebble write metadata size mismatch: %v", md)
 		}
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -595,7 +595,7 @@ func (p *PebbleCache) deleteOrphanedFiles(quitChan chan struct{}) error {
 			// Remove the second to last element which is the 4-char hash prefix.
 			parts = append(parts[:prefixIndex], parts[prefixIndex+1:]...)
 			fileMetadataKey := []byte(strings.Join(parts, sep))
-			if _, err := lookupFileMetadata(iter, fileMetadataKey); status.IsNotFoundError(err) {
+			if _, err := lookupFileMetadata(p.env.GetServerContext(), iter, fileMetadataKey); status.IsNotFoundError(err) {
 				if *orphanDeleteDryRun {
 					fi, err := d.Info()
 					if err != nil {
@@ -668,7 +668,7 @@ func (p *PebbleCache) scanForBrokenFiles(quitChan chan struct{}) error {
 		blobDir = p.blobDir(pathHasDupPartitionID, fileMetadata.GetFileRecord().GetIsolation().GetPartitionId())
 		_, err := p.fileStorer.NewReader(p.env.GetServerContext(), blobDir, fileMetadata.GetStorageMetadata(), 0, 0)
 		if err != nil {
-			p.handleMetadataMismatch(err, fileMetadataKey, fileMetadata)
+			p.handleMetadataMismatch(p.env.GetServerContext(), err, fileMetadataKey, fileMetadata)
 			mismatchCount += 1
 		}
 	}
@@ -833,11 +833,16 @@ func (p *PebbleCache) blobDir(shouldIncludePartition bool, partID string) string
 	return filePath
 }
 
-func lookupFileMetadata(iter *pebble.Iterator, fileMetadataKey []byte) (*rfpb.FileMetadata, error) {
+func lookupFileMetadata(ctx context.Context, iter *pebble.Iterator, fileMetadataKey []byte) (*rfpb.FileMetadata, error) {
 	fileMetadata := &rfpb.FileMetadata{}
 	if err := pebbleutil.LookupProto(iter, fileMetadataKey, fileMetadata); err != nil {
 		return nil, err
 	}
+
+	if fileMetadata.GetStoredSizeBytes() != fileMetadata.GetFileRecord().GetDigest().GetSizeBytes() {
+		log.CtxInfof(ctx, "Pebble lookup metadata size mismatch: %v", fileMetadata)
+	}
+
 	return fileMetadata, nil
 }
 
@@ -850,16 +855,21 @@ func readFileMetadata(reader pebble.Reader, fileMetadataKey []byte) (*rfpb.FileM
 	if err := proto.Unmarshal(buf, fileMetadata); err != nil {
 		return nil, err
 	}
+
+	if fileMetadata.GetStoredSizeBytes() != fileMetadata.GetFileRecord().GetDigest().GetSizeBytes() {
+		log.Infof("Pebble read metadata size mismatch: %v", fileMetadata)
+	}
+
 	return fileMetadata, nil
 }
 
-func (p *PebbleCache) handleMetadataMismatch(err error, fileMetadataKey []byte, fileMetadata *rfpb.FileMetadata) {
+func (p *PebbleCache) handleMetadataMismatch(ctx context.Context, err error, fileMetadataKey []byte, fileMetadata *rfpb.FileMetadata) {
 	if !status.IsNotFoundError(err) && !os.IsNotExist(err) {
 		return
 	}
 	if fileMetadata.GetStorageMetadata().GetFileMetadata() != nil {
 		log.Warningf("Metadata record %q was found but file (%+v) not found on disk: %s", fileMetadataKey, fileMetadata, err)
-		if err := p.deleteMetadataOnly(fileMetadataKey); err != nil {
+		if err := p.deleteMetadataOnly(ctx, fileMetadataKey); err != nil {
 			log.Warningf("Error deleting metadata: %s", err)
 		}
 	}
@@ -906,13 +916,9 @@ func (p *PebbleCache) Metadata(ctx context.Context, r *resource.ResourceName) (*
 	if err != nil {
 		return nil, err
 	}
-	md, err := lookupFileMetadata(iter, fileMetadataKey)
+	md, err := lookupFileMetadata(ctx, iter, fileMetadataKey)
 	if err != nil {
 		return nil, err
-	}
-
-	if md.GetStoredSizeBytes() != md.GetFileRecord().GetDigest().GetSizeBytes() {
-		log.CtxInfof(ctx, "Pebble metadata size mismatch: %v", md)
 	}
 
 	return &interfaces.CacheMetadata{
@@ -995,7 +1001,7 @@ func (p *PebbleCache) GetMulti(ctx context.Context, resources []*resource.Resour
 		blobDir := p.blobDir(!p.isolateByGroupIDs, partitionID)
 		rc, err := p.fileStorer.NewReader(ctx, blobDir, fileMetadata.GetStorageMetadata(), 0, 0)
 		if err != nil {
-			p.handleMetadataMismatch(err, fileMetadataKey, fileMetadata)
+			p.handleMetadataMismatch(ctx, err, fileMetadataKey, fileMetadata)
 			continue
 		}
 		sendAtimeUpdate(p.accesses, fileMetadataKey, fileMetadata, p.atimeUpdateThreshold, p.atimeBufferSize)
@@ -1073,7 +1079,7 @@ func sendAtimeUpdate(accesses chan<- *accessTimeUpdate, fileMetadataKey []byte, 
 	}
 }
 
-func (p *PebbleCache) deleteMetadataOnly(fileMetadataKey []byte) error {
+func (p *PebbleCache) deleteMetadataOnly(ctx context.Context, fileMetadataKey []byte) error {
 	db, err := p.leaser.DB()
 	if err != nil {
 		return err
@@ -1084,7 +1090,7 @@ func (p *PebbleCache) deleteMetadataOnly(fileMetadataKey []byte) error {
 	defer iter.Close()
 
 	// First, lookup the FileMetadata. If it's not found, we don't have the file.
-	fileMetadata, err := lookupFileMetadata(iter, fileMetadataKey)
+	fileMetadata, err := lookupFileMetadata(ctx, iter, fileMetadataKey)
 	if err != nil {
 		return err
 	}
@@ -1111,7 +1117,7 @@ func (p *PebbleCache) deleteRecord(ctx context.Context, fileRecord *rfpb.FileRec
 	if err != nil {
 		return err
 	}
-	fileMetadata, err := lookupFileMetadata(iter, fileMetadataKey)
+	fileMetadata, err := lookupFileMetadata(ctx, iter, fileMetadataKey)
 	if err != nil {
 		return err
 	}
@@ -1162,7 +1168,7 @@ func (p *PebbleCache) Reader(ctx context.Context, r *resource.ResourceName, offs
 	log.Debugf("Attempting pebble reader %s", string(fileMetadataKey))
 
 	// First, lookup the FileMetadata. If it's not found, we don't have the file.
-	fileMetadata, err := lookupFileMetadata(iter, fileMetadataKey)
+	fileMetadata, err := lookupFileMetadata(ctx, iter, fileMetadataKey)
 	if err != nil {
 		return nil, err
 	}
@@ -1173,7 +1179,7 @@ func (p *PebbleCache) Reader(ctx context.Context, r *resource.ResourceName, offs
 	if err == nil {
 		sendAtimeUpdate(p.accesses, fileMetadataKey, fileMetadata, p.atimeUpdateThreshold, p.atimeBufferSize)
 	} else if status.IsNotFoundError(err) || os.IsNotExist(err) {
-		p.handleMetadataMismatch(err, fileMetadataKey, fileMetadata)
+		p.handleMetadataMismatch(ctx, err, fileMetadataKey, fileMetadata)
 	}
 
 	if err != nil {
@@ -1348,6 +1354,11 @@ func (p *PebbleCache) Writer(ctx context.Context, r *resource.ResourceName) (int
 			p.sendSizeUpdate(partitionID, fileMetadataKey, bytesWritten)
 			metrics.DiskCacheAddedFileSizeBytes.Observe(float64(bytesWritten))
 		}
+
+		if md.GetStoredSizeBytes() != md.GetFileRecord().GetDigest().GetSizeBytes() {
+			log.CtxInfof(ctx, "Pebble write metadata size mismatch: %v", md)
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
Realized we'd get more hits on this log if we moved it to metadata lookups and writes, because the cache Metadata function doesn't get as much traffic