### PR TITLE
Fix executor startup

### DIFF
--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -228,8 +228,7 @@ func main() {
 	// Clean up net namespaces in case vestiges remain from a previous executor.
 	if !networking.PreserveExistingNetNamespaces() {
 		if err := networking.DeleteNetNamespaces(rootContext); err != nil {
-			fmt.Printf("Error cleaning up old net namespaces:  %s", err)
-			os.Exit(1)
+			log.Debugf("Error cleaning up old net namespaces:  %s", err)
 		}
 	}
 	if err := networking.ConfigurePolicyBasedRoutingForSecondaryNetwork(rootContext); err != nil {

--- a/server/util/networking/networking.go
+++ b/server/util/networking/networking.go
@@ -63,9 +63,10 @@ func namespace(netNamespace string, args ...string) []string {
 }
 
 // Deletes all of the executor net namespaces. These can be left behind if the
-// executor doesn't exit gracefully. Unfortunately, "ip netns delete" doesn't
-// support patterns, so this runs a short shell for-loop.
+// executor doesn't exit gracefully.
 func DeleteNetNamespaces(ctx context.Context) error {
+	// "ip netns delete" doesn't support patterns, so we list all
+	// namespaces then delete the ones that match the bb executor pattern.
 	b, err := sudoCommand(ctx, "ip", "netns", "list")
 	if err != nil {
 		return err
@@ -78,7 +79,9 @@ func DeleteNetNamespaces(ctx context.Context) error {
 	for _, ns := range strings.Split(output, "\n") {
 		// Sometimes the output contains spaces, like
 		//     bb-executor-1
-		//     bb-executor-2 3fe4313e-eb76-4b6d-9d61-53caf12b87e6 (id: 344) 2ab15e85-d1c3-47bc-ad40-74e2941157a4 (id: 332)
+		//     bb-executor-2
+		//     3fe4313e-eb76-4b6d-9d61-53caf12b87e6 (id: 344)
+		//     2ab15e85-d1c3-47bc-ad40-74e2941157a4 (id: 332)
 		// So we get just the first column here.
 		fields := strings.Fields(ns)
 		if len(fields) > 0 {


### PR DESCRIPTION
- Use `sudo -A` to make sure the executor never gets stuck prompting for a sudo password.
- Instead of using `sudo sh -c '<script that invokes ip command>'` for ip netns cleanup, run `sudo ip` commands directly and process the intermediate results with Go, since `enable_local_firecracker.sh` only sets up passwordless sudo for the `ip` command, not the `sh` command.
- If the networking cleanup fails, log a debug message instead of `exit(1)`, since we don't want this to be a fatal err on Mac or if someone hasn't run `enable_local_firecracker.sh` on Linux.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
