### PR TITLE
CLI: bump version in docs to 0.1.2

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,13 +45,13 @@ bb version
 If you're already using Bazelisk, you can easily install the BuildBuddy CLI for your entire project by running:
 
 ```bash
-echo "$(echo "buildbuddy-io/0.1.1"; cat .bazelversion)" > .bazelversion
+echo "$(echo "buildbuddy-io/0.1.2"; cat .bazelversion)" > .bazelversion
 ```
 
-This will simply prepend `buildbuddy-io/0.1.1` on a new line above your `.bazelversion` file like so:
+This will simply prepend `buildbuddy-io/0.1.2` on a new line above your `.bazelversion` file like so:
 
 ```title=".bazelversion"
-buildbuddy-io/0.1.1
+buildbuddy-io/0.1.2
 5.3.2
 ```
 

--- a/website/src/pages/cli.tsx
+++ b/website/src/pages/cli.tsx
@@ -331,13 +331,13 @@ function Component() {
                 <>
                   <div>
                     <Prompt />
-                    <span>{`echo "$(echo "buildbuddy-io/0.1.1"; cat .bazelversion)" > .bazelversion`}</span>
+                    <span>{`echo "$(echo "buildbuddy-io/0.1.2"; cat .bazelversion)" > .bazelversion`}</span>
                   </div>
                 </>,
                 <>
                   <div>
                     <Prompt />
-                    <span>{`echo "$(echo "buildbuddy-io/0.1.1"; cat .bazelversion)" > .bazelversion`}</span>
+                    <span>{`echo "$(echo "buildbuddy-io/0.1.2"; cat .bazelversion)" > .bazelversion`}</span>
                   </div>
                   <div>
                     <Prompt />
@@ -346,7 +346,7 @@ function Component() {
                 <>
                   <div>
                     <Prompt />
-                    <span>{`echo "$(echo "buildbuddy-io/0.1.1"; cat .bazelversion)" > .bazelversion`}</span>
+                    <span>{`echo "$(echo "buildbuddy-io/0.1.2"; cat .bazelversion)" > .bazelversion`}</span>
                   </div>
                   <div>
                     <Prompt />
@@ -356,7 +356,7 @@ function Component() {
                 <>
                   <div>
                     <Prompt />
-                    <span>{`echo "$(echo "buildbuddy-io/0.1.1"; cat .bazelversion)" > .bazelversion`}</span>
+                    <span>{`echo "$(echo "buildbuddy-io/0.1.2"; cat .bazelversion)" > .bazelversion`}</span>
                   </div>
                   <div>
                     <Prompt />
@@ -370,7 +370,7 @@ function Component() {
           bigImage={true}
           lessPadding={true}
           flipped={false}
-          snippet={`echo "$(echo "buildbuddy-io/0.1.1"; cat .bazelversion)" > .bazelversion`}
+          snippet={`echo "$(echo "buildbuddy-io/0.1.2"; cat .bazelversion)" > .bazelversion`}
           primaryButtonText=""
           secondaryButtonText=""
         />


### PR DESCRIPTION
* Fixes `Ctrl+C` handling (don't forward Ctrl+C to sidecar)
* Increases the cache proxy upload buffer size so that more Write requests can occur in the background

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
