### PR TITLE
Add --executor.firecracker_kill_host_on_failure flag that kills the host executor process if there's a problem with Firecracker.

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -59,7 +59,7 @@ import (
 
 var firecrackerMountWorkspaceFile = flag.Bool("executor.firecracker_mount_workspace_file", false, "Enables mounting workspace filesystem to improve performance of copying action outputs.")
 var firecrackerCgroupVersion = flag.String("executor.firecracker_cgroup_version", "1", "Specifies the cgroup version for firecracker to use.")
-var firecrackerKillHostOnFailure = flag.Bool("executor.firecracker_kill_host_on_failure", false, "Kills the host executor process if any command orchestrating or running Firecracker fails. Useful for capturing failures preemptively. WARNING: using this option MAY leave the host machine in an unhealthy state on Firecracker failure; some post-hoc cleanup may be necessary.")
+var dieOnFirecrackerFailure = flag.Bool("executor.die_on_firecracker_failure", false, "Makes the host executor process die if any command orchestrating or running Firecracker fails. Useful for capturing failures preemptively. WARNING: using this option MAY leave the host machine in an unhealthy state on Firecracker failure; some post-hoc cleanup may be necessary.")
 
 const (
 	// How long to wait for the VMM to listen on the firecracker socket.
@@ -748,8 +748,8 @@ func (c *FirecrackerContainer) hotSwapWorkspace(ctx context.Context, execClient 
 
 func nonCmdExit(err error) *interfaces.CommandResult {
 	log.Errorf("nonCmdExit returning error: %s", err)
-	if *firecrackerKillHostOnFailure {
-		log.Errorf("--executor.firecracker_kill_host_on_failure=true killing executor now")
+	if *dieOnFirecrackerFailure {
+		log.Errorf("--executor.die_on_firecracker_failure=true executor is dying now")
 		os.Exit(1)
 	}
 	return &interfaces.CommandResult{

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -59,6 +59,7 @@ import (
 
 var firecrackerMountWorkspaceFile = flag.Bool("executor.firecracker_mount_workspace_file", false, "Enables mounting workspace filesystem to improve performance of copying action outputs.")
 var firecrackerCgroupVersion = flag.String("executor.firecracker_cgroup_version", "1", "Specifies the cgroup version for firecracker to use.")
+var firecrackerKillHostOnFailure = flag.Bool("executor.firecracker_kill_host_on_failure", false, "Kills the host executor process if any command orchestrating or running Firecracker fails. Useful for capturing failures preemptively. WARNING: using this option MAY leave the host machine in an unhealthy state on Firecracker failure; some post-hoc cleanup may be necessary.")
 
 const (
 	// How long to wait for the VMM to listen on the firecracker socket.
@@ -747,6 +748,10 @@ func (c *FirecrackerContainer) hotSwapWorkspace(ctx context.Context, execClient 
 
 func nonCmdExit(err error) *interfaces.CommandResult {
 	log.Errorf("nonCmdExit returning error: %s", err)
+	if *firecrackerKillHostOnFailure {
+		log.Errorf("--executor.firecracker_kill_host_on_failure=true killing executor now")
+		os.Exit(1)
+	}
 	return &interfaces.CommandResult{
 		Error:    err,
 		ExitCode: -2,

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -747,10 +747,10 @@ func (c *FirecrackerContainer) hotSwapWorkspace(ctx context.Context, execClient 
 }
 
 func nonCmdExit(err error) *interfaces.CommandResult {
-	log.Errorf("nonCmdExit returning error: %s", err)
 	if *dieOnFirecrackerFailure {
-		log.Errorf("--executor.die_on_firecracker_failure=true executor is dying now")
-		os.Exit(1)
+		log.Fatalf("dying on firecracker error: %s", err)
+	} else {
+		log.Errorf("nonCmdExit returning error: %s", err)
 	}
 	return &interfaces.CommandResult{
 		Error:    err,


### PR DESCRIPTION
**Version bump**: Patch