### PR TITLE
CLI: Rewrite bytestream:// URIs in BES to remote cache target

### DIFF
--- a/cli/cmd/sidecar/sidecar.go
+++ b/cli/cmd/sidecar/sidecar.go
@@ -158,7 +158,11 @@ func initializeGRPCServer(env *real_environment.RealEnv) (*grpc.Server, net.List
 func registerBESProxy(env *real_environment.RealEnv, grpcServer *grpc.Server) {
 	besTarget := normalizeGrpcTarget(*besBackend)
 	buildEventProxyClients := make([]pepb.PublishBuildEventClient, 0)
-	buildEventProxyClients = append(buildEventProxyClients, build_event_proxy.NewBuildEventProxyClient(env, besTarget))
+	bepProxyClient := build_event_proxy.NewBuildEventProxyClient(env, besTarget)
+	if *remoteCache != "" {
+		bepProxyClient.SetBytestreamURISubstitution(*listenAddr, *remoteCache)
+	}
+	buildEventProxyClients = append(buildEventProxyClients, bepProxyClient)
 	env.SetBuildEventProxyClients(buildEventProxyClients)
 
 	// Register to handle build event protocol messages.

--- a/server/build_event_protocol/build_event_proxy/BUILD
+++ b/server/build_event_protocol/build_event_proxy/BUILD
@@ -6,12 +6,16 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_proxy",
     visibility = ["//visibility:public"],
     deps = [
+        "//proto:build_event_stream_go_proto",
+        "//proto:build_events_go_proto",
         "//proto:publish_build_event_go_proto",
         "//server/environment",
+        "//server/util/besutil",
         "//server/util/flagutil",
         "//server/util/grpc_client",
         "//server/util/log",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_google_protobuf//types/known/emptypb",
     ],
 )

--- a/server/remote_cache/scorecard/BUILD
+++ b/server/remote_cache/scorecard/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//proto:invocation_go_proto",
         "//proto:pagination_go_proto",
         "//server/environment",
+        "//server/util/besutil",
         "//server/util/paging",
         "//server/util/status",
         "@org_golang_google_grpc//codes",

--- a/server/remote_cache/scorecard/scorecard.go
+++ b/server/remote_cache/scorecard/scorecard.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/util/besutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/paging"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"google.golang.org/grpc/codes"
@@ -302,27 +303,7 @@ func ExtractFiles(invocation *inpb.Invocation) map[string]*bespb.File {
 	}
 
 	for _, event := range invocation.Event {
-		switch p := event.BuildEvent.Payload.(type) {
-		case *bespb.BuildEvent_NamedSetOfFiles:
-			maybeAddToMap(p.NamedSetOfFiles.GetFiles()...)
-		case *bespb.BuildEvent_BuildToolLogs:
-			maybeAddToMap(p.BuildToolLogs.GetLog()...)
-		case *bespb.BuildEvent_TestResult:
-			maybeAddToMap(p.TestResult.GetTestActionOutput()...)
-		case *bespb.BuildEvent_TestSummary:
-			maybeAddToMap(p.TestSummary.GetPassed()...)
-			maybeAddToMap(p.TestSummary.GetFailed()...)
-		case *bespb.BuildEvent_RunTargetAnalyzed:
-			maybeAddToMap(p.RunTargetAnalyzed.GetRunfiles()...)
-		case *bespb.BuildEvent_Action:
-			maybeAddToMap(p.Action.GetStdout())
-			maybeAddToMap(p.Action.GetStderr())
-			maybeAddToMap(p.Action.GetPrimaryOutput())
-			maybeAddToMap(p.Action.GetActionMetadataLogs()...)
-		case *bespb.BuildEvent_Completed:
-			maybeAddToMap(p.Completed.GetImportantOutput()...)
-			maybeAddToMap(p.Completed.GetDirectoryOutput()...)
-		}
+		besutil.VisitFiles(event.BuildEvent, maybeAddToMap)
 	}
 
 	return out

--- a/server/util/besutil/BUILD
+++ b/server/util/besutil/BUILD
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "besutil",
+    srcs = ["besutil.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/besutil",
+    visibility = ["//visibility:public"],
+    deps = ["//proto:build_event_stream_go_proto"],
+)

--- a/server/util/besutil/besutil.go
+++ b/server/util/besutil/besutil.go
@@ -1,0 +1,32 @@
+package besutil
+
+import (
+	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
+)
+
+// VisitFiles calls the given func with each File message found in the given
+// build event. The visit function may be called more than once for a single
+// call of this function.
+func VisitFiles(event *bespb.BuildEvent, visit func(...*bespb.File)) {
+	switch p := event.Payload.(type) {
+	case *bespb.BuildEvent_NamedSetOfFiles:
+		visit(p.NamedSetOfFiles.GetFiles()...)
+	case *bespb.BuildEvent_BuildToolLogs:
+		visit(p.BuildToolLogs.GetLog()...)
+	case *bespb.BuildEvent_TestResult:
+		visit(p.TestResult.GetTestActionOutput()...)
+	case *bespb.BuildEvent_TestSummary:
+		visit(p.TestSummary.GetPassed()...)
+		visit(p.TestSummary.GetFailed()...)
+	case *bespb.BuildEvent_RunTargetAnalyzed:
+		visit(p.RunTargetAnalyzed.GetRunfiles()...)
+	case *bespb.BuildEvent_Action:
+		visit(p.Action.GetStdout())
+		visit(p.Action.GetStderr())
+		visit(p.Action.GetPrimaryOutput())
+		visit(p.Action.GetActionMetadataLogs()...)
+	case *bespb.BuildEvent_Completed:
+		visit(p.Completed.GetImportantOutput()...)
+		visit(p.Completed.GetDirectoryOutput()...)
+	}
+}


### PR DESCRIPTION
File URIs in BEP contained a string like `bytestream://///tmp/sidecar-12345.sock/PATH`, and so they could not be fetched via the BB UI (which doesn't know about the sidecar socket). This caused the timing profile to be missing.

This PR fixes that by rewriting all File URIs so that they reference the remote cache target, instead of the sidecar socket.

Will add an integration test in a follow-up PR.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1860
