### PR TITLE
CLI: Set `--remote_bytestream_uri_prefix`

### DIFF
--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -124,7 +124,6 @@ func run() (exitCode int, err error) {
 	// Fiddle with Bazel args
 	// TODO(bduffany): model these as "built-in" plugins
 	args = tooltag.ConfigureToolTag(args)
-	args = sidecar.ConfigureSidecar(args)
 	args = login.ConfigureAPIKey(args)
 
 	// Prepare convenience env vars for plugins
@@ -143,6 +142,11 @@ func run() (exitCode int, err error) {
 			return -1, err
 		}
 	}
+
+	// Note: sidecar is configured after pre-bazel plugins, since pre-bazel
+	// plugins may change the value of bes_backend, remote_cache,
+	// remote_instance_name, etc.
+	args = sidecar.ConfigureSidecar(args)
 
 	// Handle remote bazel. Note, pre-bazel hooks apply to remote bazel, but not
 	// output handlers or post-bazel hooks.

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -163,11 +164,32 @@ func ConfigureSidecar(args []string) []string {
 		}
 		if remoteCacheFlag != "" && remoteExecFlag == "" {
 			args = append(args, fmt.Sprintf("--remote_cache=unix://%s", sidecarSocket))
+			// Set bytestream URI prefix to match the actual remote cache
+			// backend, rather than the sidecar socket.
+			instanceName := arg.Get(args, "remote_instance_name")
+			args = append(args, fmt.Sprintf("--remote_bytestream_uri_prefix=%s", bytestreamURIPrefix(remoteCacheFlag, instanceName)))
 		}
 		return args
 	}
 	log.Warnf("Could not connect to sidecar, continuing without sidecar: %s", connectionErr)
 	return args
+}
+
+func bytestreamURIPrefix(cacheTarget, instanceName string) string {
+	prefix := stripProtocol(cacheTarget)
+	if instanceName != "" {
+		prefix += "/" + instanceName
+	}
+	return prefix
+}
+
+func stripProtocol(target string) string {
+	for _, protocol := range []string{"grpc://", "grpcs://", "http://", "https://"} {
+		if strings.HasPrefix(target, protocol) {
+			return strings.TrimPrefix(target, protocol)
+		}
+	}
+	return target
 }
 
 // keepaliveSidecar validates the connection to the sidecar and keeps the


### PR DESCRIPTION
This makes `bytestream://` URIs in the BEP point to the remote cache backend rather than the local sidecar socket (which the BB UI can't fetch from).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1860
