### PR TITLE
EnrichCtx before we call OpenChannel

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -125,7 +125,6 @@ func NewBuildEventHandler(env environment.Env) *BuildEventHandler {
 
 func (b *BuildEventHandler) OpenChannel(ctx context.Context, iid string) interfaces.BuildEventChannel {
 	buildEventAccumulator := accumulator.NewBEValues(iid)
-	ctx = log.EnrichContext(ctx, log.InvocationIDKey, iid)
 	val, ok := b.cancelFnsByInvID.Load(iid)
 	if ok {
 		cancelFn := val.(context.CancelFunc)


### PR DESCRIPTION
I accidentally reverted some of the changes made in
https://github.com/buildbuddy-io/buildbuddy/pull/2813 in my PR
https://github.com/buildbuddy-io/buildbuddy/pull/2837

When we call `postProcessStream`, the `ctx` was from `stream.Context()`. We didn't set the IID from the `streamID.InvocationId` explicitly. This might cause the inconsistent iid in the logs. https://github.com/buildbuddy-io/buildbuddy-internal/issues/1863
