### PR TITLE
Remove blobstore reads from BES handler

### DIFF
--- a/server/build_event_protocol/event_parser/BUILD
+++ b/server/build_event_protocol/event_parser/BUILD
@@ -9,7 +9,6 @@ go_library(
         "//proto:build_event_stream_go_proto",
         "//proto:command_line_go_proto",
         "//proto:invocation_go_proto",
-        "//server/util/terminal",
         "//server/util/timeutil",
     ],
 )

--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -197,145 +197,149 @@ func (sep *StreamingEventParser) ParseEvent(event *inpb.InvocationEvent) {
 }
 
 func (sep *StreamingEventParser) fillInvocationFromStructuredCommandLine(commandLine *command_line.CommandLine) {
+	priority := envPriority
 	envVarMap := parseEnv(commandLine)
 	if user, ok := envVarMap["USER"]; ok && user != "" {
-		sep.setUser(user, envPriority)
+		sep.setUser(user, priority)
 	}
 	if url, ok := envVarMap["TRAVIS_REPO_SLUG"]; ok && url != "" {
-		sep.setRepoUrl(url, envPriority)
+		sep.setRepoUrl(url, priority)
 	}
 	if url, ok := envVarMap["GIT_URL"]; ok && url != "" {
-		sep.setRepoUrl(url, envPriority)
+		sep.setRepoUrl(url, priority)
 	}
 	if url, ok := envVarMap["BUILDKITE_REPO"]; ok && url != "" {
-		sep.setRepoUrl(url, envPriority)
+		sep.setRepoUrl(url, priority)
 	}
 	if url, ok := envVarMap["REPO_URL"]; ok && url != "" {
-		sep.setRepoUrl(url, envPriority)
+		sep.setRepoUrl(url, priority)
 	}
 	if url, ok := envVarMap["CIRCLE_REPOSITORY_URL"]; ok && url != "" {
-		sep.setRepoUrl(url, envPriority)
+		sep.setRepoUrl(url, priority)
 	}
 	if url, ok := envVarMap["GITHUB_REPOSITORY"]; ok && url != "" {
-		sep.setRepoUrl(url, envPriority)
+		sep.setRepoUrl(url, priority)
 	}
 	if branch, ok := envVarMap["TRAVIS_BRANCH"]; ok && branch != "" {
-		sep.setBranchName(branch, envPriority)
+		sep.setBranchName(branch, priority)
 	}
 	if branch, ok := envVarMap["GIT_BRANCH"]; ok && branch != "" {
-		sep.setBranchName(branch, envPriority)
+		sep.setBranchName(branch, priority)
 	}
 	if branch, ok := envVarMap["BUILDKITE_BRANCH"]; ok && branch != "" {
-		sep.setBranchName(branch, envPriority)
+		sep.setBranchName(branch, priority)
 	}
 	if branch, ok := envVarMap["CIRCLE_BRANCH"]; ok && branch != "" {
-		sep.setBranchName(branch, envPriority)
+		sep.setBranchName(branch, priority)
 	}
 	if branch, ok := envVarMap["GITHUB_REF"]; ok && strings.HasPrefix(branch, "refs/heads/") {
-		sep.setBranchName(strings.TrimPrefix(branch, "refs/heads/"), envPriority)
+		sep.setBranchName(strings.TrimPrefix(branch, "refs/heads/"), priority)
 	}
 	if branch, ok := envVarMap["GITHUB_HEAD_REF"]; ok && branch != "" {
-		sep.setBranchName(branch, envPriority)
+		sep.setBranchName(branch, priority)
 	}
 	if sha, ok := envVarMap["TRAVIS_COMMIT"]; ok && sha != "" {
-		sep.setCommitSha(sha, envPriority)
+		sep.setCommitSha(sha, priority)
 	}
 	if sha, ok := envVarMap["GIT_COMMIT"]; ok && sha != "" {
-		sep.setCommitSha(sha, envPriority)
+		sep.setCommitSha(sha, priority)
 	}
 	if sha, ok := envVarMap["BUILDKITE_COMMIT"]; ok && sha != "" {
-		sep.setCommitSha(sha, envPriority)
+		sep.setCommitSha(sha, priority)
 	}
 	if sha, ok := envVarMap["CIRCLE_SHA1"]; ok && sha != "" {
-		sep.setCommitSha(sha, envPriority)
+		sep.setCommitSha(sha, priority)
 	}
 	if sha, ok := envVarMap["GITHUB_SHA"]; ok && sha != "" {
-		sep.setCommitSha(sha, envPriority)
+		sep.setCommitSha(sha, priority)
 	}
 	if sha, ok := envVarMap["COMMIT_SHA"]; ok && sha != "" {
-		sep.setCommitSha(sha, envPriority)
+		sep.setCommitSha(sha, priority)
 	}
 	if sha, ok := envVarMap["VOLATILE_GIT_COMMIT"]; ok && sha != "" {
-		sep.setCommitSha(sha, envPriority)
+		sep.setCommitSha(sha, priority)
 	}
 	if ci, ok := envVarMap["CI"]; ok && ci != "" {
-		sep.setRole("CI", envPriority)
+		sep.setRole("CI", priority)
 	}
 	if ciRunner, ok := envVarMap["CI_RUNNER"]; ok && ciRunner != "" {
-		sep.setRole("CI_RUNNER", envPriority)
+		sep.setRole("CI_RUNNER", priority)
 	}
 
 	// Gitlab CI Environment Variables
 	// https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
 	if url, ok := envVarMap["CI_REPOSITORY_URL"]; ok && url != "" {
-		sep.setRepoUrl(url, envPriority)
+		sep.setRepoUrl(url, priority)
 	}
 	if branch, ok := envVarMap["CI_COMMIT_BRANCH"]; ok && branch != "" {
-		sep.setBranchName(branch, envPriority)
+		sep.setBranchName(branch, priority)
 	}
 	if sha, ok := envVarMap["CI_COMMIT_SHA"]; ok && sha != "" {
-		sep.setCommitSha(sha, envPriority)
+		sep.setCommitSha(sha, priority)
 	}
 }
 
 func (sep *StreamingEventParser) fillInvocationFromWorkspaceStatus(workspaceStatus *build_event_stream.WorkspaceStatus) {
+	priority := workspaceStatusPriority
 	for _, item := range workspaceStatus.Item {
 		if item.Value == "" {
 			continue
 		}
 		switch item.Key {
 		case "BUILD_USER":
-			sep.setUser(item.Value, workspaceStatusPriority)
+			sep.setUser(item.Value, priority)
 		case "USER":
-			sep.setUser(item.Value, workspaceStatusPriority)
+			sep.setUser(item.Value, priority)
 		case "BUILD_HOST":
-			sep.setHost(item.Value, workspaceStatusPriority)
+			sep.setHost(item.Value, priority)
 		case "HOST":
-			sep.setHost(item.Value, workspaceStatusPriority)
+			sep.setHost(item.Value, priority)
 		case "PATTERN":
-			sep.setPattern(strings.Split(item.Value, " "), workspaceStatusPriority)
+			sep.setPattern(strings.Split(item.Value, " "), priority)
 		case "ROLE":
-			sep.setRole(item.Value, workspaceStatusPriority)
+			sep.setRole(item.Value, priority)
 		case "REPO_URL":
-			sep.setRepoUrl(item.Value, workspaceStatusPriority)
+			sep.setRepoUrl(item.Value, priority)
 		case "GIT_BRANCH":
-			sep.setBranchName(item.Value, workspaceStatusPriority)
+			sep.setBranchName(item.Value, priority)
 		case "COMMIT_SHA":
-			sep.setCommitSha(item.Value, workspaceStatusPriority)
+			sep.setCommitSha(item.Value, priority)
 		}
 	}
 }
 
 func (sep *StreamingEventParser) fillInvocationFromBuildMetadata(metadata map[string]string) {
+	priority := buildMetadataPriority
 	if sha, ok := metadata["COMMIT_SHA"]; ok && sha != "" {
-		sep.setCommitSha(sha, buildMetadataPriority)
+		sep.setCommitSha(sha, priority)
 	}
 	if branch, ok := metadata["BRANCH_NAME"]; ok && branch != "" {
-		sep.setBranchName(branch, buildMetadataPriority)
+		sep.setBranchName(branch, priority)
 	}
 	if url, ok := metadata["REPO_URL"]; ok && url != "" {
-		sep.setRepoUrl(url, buildMetadataPriority)
+		sep.setRepoUrl(url, priority)
 	}
 	if user, ok := metadata["USER"]; ok && user != "" {
-		sep.setUser(user, buildMetadataPriority)
+		sep.setUser(user, priority)
 	}
 	if host, ok := metadata["HOST"]; ok && host != "" {
-		sep.setHost(host, buildMetadataPriority)
+		sep.setHost(host, priority)
 	}
 	if pattern, ok := metadata["PATTERN"]; ok && pattern != "" {
-		sep.setPattern(strings.Split(pattern, " "), buildMetadataPriority)
+		sep.setPattern(strings.Split(pattern, " "), priority)
 	}
 	if role, ok := metadata["ROLE"]; ok && role != "" {
-		sep.setRole(role, buildMetadataPriority)
+		sep.setRole(role, priority)
 	}
 	if visibility, ok := metadata["VISIBILITY"]; ok && visibility == "PUBLIC" {
-		sep.setReadPermission(inpb.InvocationPermission_PUBLIC, buildMetadataPriority)
+		sep.setReadPermission(inpb.InvocationPermission_PUBLIC, priority)
 	}
 }
 
 func (sep *StreamingEventParser) fillInvocationFromWorkflowConfigured(workflowConfigured *build_event_stream.WorkflowConfigured) {
-	sep.setCommand("workflow run", workflowConfiguredPriority)
-	sep.setPattern([]string{workflowConfigured.ActionName}, workflowConfiguredPriority)
+	priority := workflowConfiguredPriority
+	sep.setCommand("workflow run", priority)
+	sep.setPattern([]string{workflowConfigured.ActionName}, priority)
 }
 
 // All the funcs below set invocation fields only if they haven't already been

--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	"github.com/buildbuddy-io/buildbuddy/proto/command_line"
-	"github.com/buildbuddy-io/buildbuddy/server/util/terminal"
 	"github.com/buildbuddy-io/buildbuddy/server/util/timeutil"
 
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
@@ -15,6 +14,19 @@ import (
 const (
 	envVarOptionName = "client_env"
 	envVarSeparator  = "="
+)
+
+// eventPriority represents the priority of an invocation event
+// when setting invocation fields. For example, if the build USER is set in
+// build metadata, that always overrides the USER value from workspace status,
+// even if the workspace status event came later in the stream.
+type eventPriority int
+
+const (
+	envPriority                eventPriority = 1
+	workspaceStatusPriority    eventPriority = 2
+	buildMetadataPriority      eventPriority = 3
+	workflowConfiguredPriority eventPriority = 4
 )
 
 func parseEnv(commandLine *command_line.CommandLine) map[string]string {
@@ -40,48 +52,37 @@ func parseEnv(commandLine *command_line.CommandLine) map[string]string {
 	return envVarMap
 }
 
+// StreamingEventParser consumes a stream of build events and populates an
+// invocation proto as it does so.
+//
+// To save memory, only the "summary" fields (like success, duration, etc.) in
+// the invocation are recorded by default, and any variable-length lists such as
+// events, console buffer etc. are not saved.
 type StreamingEventParser struct {
-	terminalWriter         *terminal.ScreenWriter
-	command                string
-	buildMetadata          []map[string]string
-	events                 []*inpb.InvocationEvent
-	structuredCommandLines []*command_line.CommandLine
-	workspaceStatuses      []*build_event_stream.WorkspaceStatus
-	workflowConfigurations []*build_event_stream.WorkflowConfigured
-	pattern                []string
-	startTime              *time.Time
-	endTime                *time.Time
-	actionCount            int64
-	success                bool
+	invocation *inpb.Invocation
+	startTime  *time.Time
+
+	// fieldPriority maps invocation field pointers to the priority of the event
+	// which set the field. This allows us to set invocation fields only if a
+	// previous event of higher priority hasn't already set the field.
+	fieldPriority map[any]eventPriority
 }
 
-func NewStreamingEventParser(screenWriter *terminal.ScreenWriter) *StreamingEventParser {
+func NewStreamingEventParser(invocation *inpb.Invocation) *StreamingEventParser {
 	return &StreamingEventParser{
-		startTime:              nil,
-		endTime:                nil,
-		terminalWriter:         screenWriter,
-		structuredCommandLines: make([]*command_line.CommandLine, 0),
-		workspaceStatuses:      make([]*build_event_stream.WorkspaceStatus, 0),
-		workflowConfigurations: make([]*build_event_stream.WorkflowConfigured, 0),
-		buildMetadata:          make([]map[string]string, 0),
-		events:                 make([]*inpb.InvocationEvent, 0),
+		invocation:    invocation,
+		fieldPriority: make(map[any]eventPriority, 0),
 	}
 }
 
+func (sep *StreamingEventParser) GetInvocation() *inpb.Invocation {
+	return sep.invocation
+}
+
 func (sep *StreamingEventParser) ParseEvent(event *inpb.InvocationEvent) {
-	sep.events = append(sep.events, event)
 	switch p := event.BuildEvent.Payload.(type) {
 	case *build_event_stream.BuildEvent_Progress:
 		{
-			if sep.terminalWriter != nil {
-				sep.terminalWriter.Write([]byte(p.Progress.Stderr))
-				sep.terminalWriter.Write([]byte(p.Progress.Stdout))
-			}
-			// Now that we've updated our screenwriter, zero out
-			// progress output in the event so they don't eat up
-			// memory.
-			p.Progress.Stderr = ""
-			p.Progress.Stdout = ""
 		}
 	case *build_event_stream.BuildEvent_Aborted:
 		{
@@ -90,13 +91,13 @@ func (sep *StreamingEventParser) ParseEvent(event *inpb.InvocationEvent) {
 		{
 			startTime := timeutil.GetTimeWithFallback(p.Started.StartTime, p.Started.StartTimeMillis)
 			sep.startTime = &startTime
-			sep.command = p.Started.Command
+			sep.invocation.Command = p.Started.Command
 			for _, child := range event.BuildEvent.Children {
 				// Here we are then. Knee-deep.
 				switch c := child.Id.(type) {
 				case *build_event_stream.BuildEventId_Pattern:
 					{
-						sep.pattern = c.Pattern.Pattern
+						sep.invocation.Pattern = c.Pattern.Pattern
 					}
 				}
 			}
@@ -106,14 +107,14 @@ func (sep *StreamingEventParser) ParseEvent(event *inpb.InvocationEvent) {
 		}
 	case *build_event_stream.BuildEvent_StructuredCommandLine:
 		{
-			sep.structuredCommandLines = append(sep.structuredCommandLines, p.StructuredCommandLine)
+			sep.fillInvocationFromStructuredCommandLine(p.StructuredCommandLine)
 		}
 	case *build_event_stream.BuildEvent_OptionsParsed:
 		{
 		}
 	case *build_event_stream.BuildEvent_WorkspaceStatus:
 		{
-			sep.workspaceStatuses = append(sep.workspaceStatuses, p.WorkspaceStatus)
+			sep.fillInvocationFromWorkspaceStatus(p.WorkspaceStatus)
 		}
 	case *build_event_stream.BuildEvent_Fetch:
 		{
@@ -145,15 +146,18 @@ func (sep *StreamingEventParser) ParseEvent(event *inpb.InvocationEvent) {
 	case *build_event_stream.BuildEvent_Finished:
 		{
 			endTime := timeutil.GetTimeWithFallback(p.Finished.FinishTime, p.Finished.FinishTimeMillis)
-			sep.endTime = &endTime
-			sep.success = p.Finished.ExitCode.Code == 0
+			if sep.startTime != nil {
+				duration := endTime.Sub(*sep.startTime)
+				sep.invocation.DurationUsec = duration.Microseconds()
+			}
+			sep.invocation.Success = p.Finished.ExitCode.Code == 0
 		}
 	case *build_event_stream.BuildEvent_BuildToolLogs:
 		{
 		}
 	case *build_event_stream.BuildEvent_BuildMetrics:
 		{
-			sep.actionCount = p.BuildMetrics.ActionSummary.ActionsExecuted
+			sep.invocation.ActionCount = p.BuildMetrics.ActionSummary.ActionsExecuted
 		}
 	case *build_event_stream.BuildEvent_WorkspaceInfo:
 		{
@@ -164,7 +168,7 @@ func (sep *StreamingEventParser) ParseEvent(event *inpb.InvocationEvent) {
 			if metadata == nil {
 				return
 			}
-			sep.buildMetadata = append(sep.buildMetadata, metadata)
+			sep.fillInvocationFromBuildMetadata(metadata)
 		}
 	case *build_event_stream.BuildEvent_ConvenienceSymlinksIdentified:
 		{
@@ -175,188 +179,165 @@ func (sep *StreamingEventParser) ParseEvent(event *inpb.InvocationEvent) {
 			if wfc == nil {
 				return
 			}
-			sep.workflowConfigurations = append(sep.workflowConfigurations, wfc)
+			sep.fillInvocationFromWorkflowConfigured(wfc)
 		}
 	}
 }
 
-func (sep *StreamingEventParser) FillInvocation(invocation *inpb.Invocation) {
-	invocation.Command = sep.command
-	invocation.Pattern = sep.pattern
-	invocation.Event = sep.events
-	invocation.Success = sep.success
-	invocation.ActionCount = sep.actionCount
-
-	// Fill invocation in a deterministic order:
-	// - Environment variables
-	// - Workspace status
-	// - Build metadata
-
-	for _, commandLine := range sep.structuredCommandLines {
-		fillInvocationFromStructuredCommandLine(commandLine, invocation)
+// setField sets an invocation field from a build event, but only if the current
+// field value was not already set by an event of higher priority (note, if the
+// field was already set by an event with the *same* priority, then the field is
+// overridden).
+func setField[T any](sep *StreamingEventParser, priority eventPriority, field *T, value T) {
+	if sep.fieldPriority[field] > priority {
+		return
 	}
-	for _, workspaceStatus := range sep.workspaceStatuses {
-		fillInvocationFromWorkspaceStatus(workspaceStatus, invocation)
-	}
-	for _, buildMetadatum := range sep.buildMetadata {
-		fillInvocationFromBuildMetadata(buildMetadatum, invocation)
-	}
-	for _, workflowConfigured := range sep.workflowConfigurations {
-		fillInvocationFromWorkflowConfigured(workflowConfigured, invocation)
-	}
-
-	buildDuration := time.Duration(int64(0))
-	if sep.endTime != nil && sep.startTime != nil {
-		buildDuration = sep.endTime.Sub(*sep.startTime)
-	}
-	invocation.DurationUsec = buildDuration.Microseconds()
-	if sep.terminalWriter != nil {
-		// TODO(siggisim): Do this rendering once on write, rather than on every read.
-		invocation.ConsoleBuffer = string(sep.terminalWriter.Render())
-	}
+	*field = value
+	sep.fieldPriority[field] = priority
 }
 
-func fillInvocationFromStructuredCommandLine(commandLine *command_line.CommandLine, invocation *inpb.Invocation) {
+func (sep *StreamingEventParser) fillInvocationFromStructuredCommandLine(commandLine *command_line.CommandLine) {
 	envVarMap := parseEnv(commandLine)
-	if commandLine != nil {
-		invocation.StructuredCommandLine = append(invocation.StructuredCommandLine, commandLine)
-	}
+	invocation := sep.invocation
 	if user, ok := envVarMap["USER"]; ok && user != "" {
-		invocation.User = user
+		setField(sep, envPriority, &invocation.User, user)
 	}
 	if url, ok := envVarMap["TRAVIS_REPO_SLUG"]; ok && url != "" {
-		invocation.RepoUrl = url
+		setField(sep, envPriority, &invocation.RepoUrl, url)
 	}
 	if url, ok := envVarMap["GIT_URL"]; ok && url != "" {
-		invocation.RepoUrl = url
+		setField(sep, envPriority, &invocation.RepoUrl, url)
 	}
 	if url, ok := envVarMap["BUILDKITE_REPO"]; ok && url != "" {
-		invocation.RepoUrl = url
+		setField(sep, envPriority, &invocation.RepoUrl, url)
 	}
 	if url, ok := envVarMap["REPO_URL"]; ok && url != "" {
-		invocation.RepoUrl = url
+		setField(sep, envPriority, &invocation.RepoUrl, url)
 	}
 	if url, ok := envVarMap["CIRCLE_REPOSITORY_URL"]; ok && url != "" {
-		invocation.RepoUrl = url
+		setField(sep, envPriority, &invocation.RepoUrl, url)
 	}
 	if url, ok := envVarMap["GITHUB_REPOSITORY"]; ok && url != "" {
-		invocation.RepoUrl = url
+		setField(sep, envPriority, &invocation.RepoUrl, url)
 	}
 	if branch, ok := envVarMap["TRAVIS_BRANCH"]; ok && branch != "" {
-		invocation.BranchName = branch
+		setField(sep, envPriority, &invocation.BranchName, branch)
 	}
 	if branch, ok := envVarMap["GIT_BRANCH"]; ok && branch != "" {
-		invocation.BranchName = branch
+		setField(sep, envPriority, &invocation.BranchName, branch)
 	}
 	if branch, ok := envVarMap["BUILDKITE_BRANCH"]; ok && branch != "" {
-		invocation.BranchName = branch
+		setField(sep, envPriority, &invocation.BranchName, branch)
 	}
 	if branch, ok := envVarMap["CIRCLE_BRANCH"]; ok && branch != "" {
-		invocation.BranchName = branch
+		setField(sep, envPriority, &invocation.BranchName, branch)
 	}
 	if branch, ok := envVarMap["GITHUB_REF"]; ok && strings.HasPrefix(branch, "refs/heads/") {
-		invocation.BranchName = strings.TrimPrefix(branch, "refs/heads/")
+		setField(sep, envPriority, &invocation.BranchName, strings.TrimPrefix(branch, "refs/heads/"))
 	}
 	if branch, ok := envVarMap["GITHUB_HEAD_REF"]; ok && branch != "" {
-		invocation.BranchName = branch
+		setField(sep, envPriority, &invocation.BranchName, branch)
 	}
 	if sha, ok := envVarMap["TRAVIS_COMMIT"]; ok && sha != "" {
-		invocation.CommitSha = sha
+		setField(sep, envPriority, &invocation.CommitSha, sha)
 	}
 	if sha, ok := envVarMap["GIT_COMMIT"]; ok && sha != "" {
-		invocation.CommitSha = sha
+		setField(sep, envPriority, &invocation.CommitSha, sha)
 	}
 	if sha, ok := envVarMap["BUILDKITE_COMMIT"]; ok && sha != "" {
-		invocation.CommitSha = sha
+		setField(sep, envPriority, &invocation.CommitSha, sha)
 	}
 	if sha, ok := envVarMap["CIRCLE_SHA1"]; ok && sha != "" {
-		invocation.CommitSha = sha
+		setField(sep, envPriority, &invocation.CommitSha, sha)
 	}
 	if sha, ok := envVarMap["GITHUB_SHA"]; ok && sha != "" {
-		invocation.CommitSha = sha
+		setField(sep, envPriority, &invocation.CommitSha, sha)
 	}
 	if sha, ok := envVarMap["COMMIT_SHA"]; ok && sha != "" {
-		invocation.CommitSha = sha
+		setField(sep, envPriority, &invocation.CommitSha, sha)
 	}
 	if sha, ok := envVarMap["VOLATILE_GIT_COMMIT"]; ok && sha != "" {
-		invocation.CommitSha = sha
+		setField(sep, envPriority, &invocation.CommitSha, sha)
 	}
 	if ci, ok := envVarMap["CI"]; ok && ci != "" {
-		invocation.Role = "CI"
+		setField(sep, envPriority, &invocation.Role, "CI")
 	}
 	if ciRunner, ok := envVarMap["CI_RUNNER"]; ok && ciRunner != "" {
-		invocation.Role = "CI_RUNNER"
+		setField(sep, envPriority, &invocation.Role, "CI_RUNNER")
 	}
 
 	// Gitlab CI Environment Variables
 	// https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
 	if url, ok := envVarMap["CI_REPOSITORY_URL"]; ok && url != "" {
-		invocation.RepoUrl = url
+		setField(sep, envPriority, &invocation.RepoUrl, url)
 	}
 	if branch, ok := envVarMap["CI_COMMIT_BRANCH"]; ok && branch != "" {
-		invocation.BranchName = branch
+		setField(sep, envPriority, &invocation.BranchName, branch)
 	}
 	if sha, ok := envVarMap["CI_COMMIT_SHA"]; ok && sha != "" {
-		invocation.CommitSha = sha
+		setField(sep, envPriority, &invocation.CommitSha, sha)
 	}
 }
 
-func fillInvocationFromWorkspaceStatus(workspaceStatus *build_event_stream.WorkspaceStatus, invocation *inpb.Invocation) {
+func (sep *StreamingEventParser) fillInvocationFromWorkspaceStatus(workspaceStatus *build_event_stream.WorkspaceStatus) {
+	invocation := sep.invocation
 	for _, item := range workspaceStatus.Item {
 		if item.Value == "" {
 			continue
 		}
 		switch item.Key {
 		case "BUILD_USER":
-			invocation.User = item.Value
+			setField(sep, workspaceStatusPriority, &invocation.User, item.Value)
 		case "USER":
-			invocation.User = item.Value
+			setField(sep, workspaceStatusPriority, &invocation.User, item.Value)
 		case "BUILD_HOST":
-			invocation.Host = item.Value
+			setField(sep, workspaceStatusPriority, &invocation.Host, item.Value)
 		case "HOST":
-			invocation.Host = item.Value
+			setField(sep, workspaceStatusPriority, &invocation.Host, item.Value)
 		case "PATTERN":
-			invocation.Pattern = strings.Split(item.Value, " ")
+			setField(sep, workspaceStatusPriority, &invocation.Pattern, strings.Split(item.Value, " "))
 		case "ROLE":
-			invocation.Role = item.Value
+			setField(sep, workspaceStatusPriority, &invocation.Role, item.Value)
 		case "REPO_URL":
-			invocation.RepoUrl = item.Value
+			setField(sep, workspaceStatusPriority, &invocation.RepoUrl, item.Value)
 		case "GIT_BRANCH":
-			invocation.BranchName = item.Value
+			setField(sep, workspaceStatusPriority, &invocation.BranchName, item.Value)
 		case "COMMIT_SHA":
-			invocation.CommitSha = item.Value
+			setField(sep, workspaceStatusPriority, &invocation.CommitSha, item.Value)
 		}
 	}
 }
 
-func fillInvocationFromBuildMetadata(metadata map[string]string, invocation *inpb.Invocation) {
+func (sep *StreamingEventParser) fillInvocationFromBuildMetadata(metadata map[string]string) {
+	invocation := sep.invocation
 	if sha, ok := metadata["COMMIT_SHA"]; ok && sha != "" {
-		invocation.CommitSha = sha
+		setField(sep, buildMetadataPriority, &invocation.CommitSha, sha)
 	}
 	if branch, ok := metadata["BRANCH_NAME"]; ok && branch != "" {
-		invocation.BranchName = branch
+		setField(sep, buildMetadataPriority, &invocation.BranchName, branch)
 	}
 	if url, ok := metadata["REPO_URL"]; ok && url != "" {
-		invocation.RepoUrl = url
+		setField(sep, buildMetadataPriority, &invocation.RepoUrl, url)
 	}
 	if user, ok := metadata["USER"]; ok && user != "" {
-		invocation.User = user
+		setField(sep, buildMetadataPriority, &invocation.User, user)
 	}
 	if host, ok := metadata["HOST"]; ok && host != "" {
-		invocation.Host = host
+		setField(sep, buildMetadataPriority, &invocation.Host, host)
 	}
 	if pattern, ok := metadata["PATTERN"]; ok && pattern != "" {
-		invocation.Pattern = strings.Split(pattern, " ")
+		setField(sep, buildMetadataPriority, &invocation.Pattern, strings.Split(pattern, " "))
 	}
 	if role, ok := metadata["ROLE"]; ok && role != "" {
-		invocation.Role = role
+		setField(sep, buildMetadataPriority, &invocation.Role, role)
 	}
 	if visibility, ok := metadata["VISIBILITY"]; ok && visibility == "PUBLIC" {
-		invocation.ReadPermission = inpb.InvocationPermission_PUBLIC
+		setField(sep, buildMetadataPriority, &invocation.ReadPermission, inpb.InvocationPermission_PUBLIC)
 	}
 }
 
-func fillInvocationFromWorkflowConfigured(workflowConfigured *build_event_stream.WorkflowConfigured, invocation *inpb.Invocation) {
-	invocation.Command = "workflow run"
-	invocation.Pattern = []string{workflowConfigured.ActionName}
+func (sep *StreamingEventParser) fillInvocationFromWorkflowConfigured(workflowConfigured *build_event_stream.WorkflowConfigured) {
+	invocation := sep.invocation
+	setField(sep, workflowConfiguredPriority, &invocation.Command, "workflow run")
+	setField(sep, workflowConfiguredPriority, &invocation.Pattern, []string{workflowConfigured.ActionName})
 }

--- a/server/build_event_protocol/event_parser/event_parser_test.go
+++ b/server/build_event_protocol/event_parser/event_parser_test.go
@@ -199,50 +199,19 @@ func TestFillInvocation(t *testing.T) {
 		InvocationId:     "test-invocation",
 		InvocationStatus: inpb.Invocation_COMPLETE_INVOCATION_STATUS,
 	}
-	parser := event_parser.NewStreamingEventParser(nil)
+	parser := event_parser.NewStreamingEventParser(invocation)
 	for _, event := range events {
 		parser.ParseEvent(event)
 	}
-	parser.FillInvocation(invocation)
 
-	assert.Equal(t, "test-invocation", invocation.InvocationId)
-	assert.Equal(t, inpb.Invocation_COMPLETE_INVOCATION_STATUS, invocation.InvocationStatus)
+	assert.Empty(t, invocation.Event, "parser should not keep the full events list in memory")
+	assert.Empty(t, invocation.StructuredCommandLine, "parser should not keep the full events list in memory")
 
-	assert.Equal(t, "", invocation.Event[0].BuildEvent.GetProgress().Stderr)
-	assert.Equal(t, "", invocation.Event[0].BuildEvent.GetProgress().Stdout)
-	assert.Equal(t, "", invocation.ConsoleBuffer)
+	assert.Equal(t, "test-invocation", invocation.InvocationId, "parser should keep original invocation properties")
+	assert.Equal(t, inpb.Invocation_COMPLETE_INVOCATION_STATUS, invocation.InvocationStatus, "parser should keep original invocation properties")
 
 	assert.Equal(t, "test", invocation.Command)
-	assert.Equal(t, "foo", invocation.Event[1].BuildEvent.GetStarted().OptionsDescription)
-
-	assert.Equal(t, []string{"foo"}, invocation.Event[4].BuildEvent.GetOptionsParsed().CmdLine)
-	assert.Equal(t, []string{"explicit"}, invocation.Event[4].BuildEvent.GetOptionsParsed().ExplicitCmdLine)
-
-	assert.Equal(t, "uri", invocation.Event[6].BuildEvent.GetAction().Stdout.GetUri())
-	assert.Equal(t, "uri", invocation.Event[6].BuildEvent.GetAction().Stderr.GetUri())
-	assert.Equal(t, "uri", invocation.Event[6].BuildEvent.GetAction().PrimaryOutput.GetUri())
-	assert.Equal(t, 1, len(invocation.Event[6].BuildEvent.GetAction().ActionMetadataLogs))
-	assert.Equal(t, "uri", invocation.Event[6].BuildEvent.GetAction().ActionMetadataLogs[0].GetUri())
-
-	assert.Equal(t, 1, len(invocation.Event[7].BuildEvent.GetNamedSetOfFiles().Files))
-	assert.Equal(t, "uri", invocation.Event[7].BuildEvent.GetNamedSetOfFiles().Files[0].GetUri())
-
-	assert.Equal(t, 1, len(invocation.Event[8].BuildEvent.GetCompleted().DirectoryOutput))
-	assert.Equal(t, "uri", invocation.Event[8].BuildEvent.GetCompleted().DirectoryOutput[0].GetUri())
-
-	assert.Equal(t, 1, len(invocation.Event[9].BuildEvent.GetTestResult().TestActionOutput))
-	assert.Equal(t, "uri", invocation.Event[9].BuildEvent.GetTestResult().TestActionOutput[0].GetUri())
-
-	assert.Equal(t, 1, len(invocation.Event[10].BuildEvent.GetTestSummary().Passed))
-	assert.Equal(t, 1, len(invocation.Event[10].BuildEvent.GetTestSummary().Failed))
-	assert.Equal(t, "uri", invocation.Event[10].BuildEvent.GetTestSummary().Passed[0].GetUri())
-	assert.Equal(t, "uri", invocation.Event[10].BuildEvent.GetTestSummary().Failed[0].GetUri())
-
 	assert.Equal(t, int64(1000), invocation.DurationUsec)
-
-	assert.Equal(t, "SHELL=/bin/bash", invocation.StructuredCommandLine[0].Sections[0].GetOptionList().Option[0].OptionValue)
-	assert.Equal(t, "SECRET=<REDACTED>", invocation.StructuredCommandLine[0].Sections[0].GetOptionList().Option[1].OptionValue)
-
 	assert.Equal(t, "WORKSPACE_STATUS_BUILD_USER", invocation.User)
 	assert.Equal(t, "METADATA_CI", invocation.Role)
 	assert.Equal(t, "https://github.com/buildbuddy-io/metadata_repo_url", invocation.RepoUrl)


### PR DESCRIPTION
The high level approach in this PR is to remove all calls to `fillInvocationFromEvents()`, since it reads all the invocation protos from blobstore. The reason we call `fillInvocationFromEvents` in the first place is to determine the values of certain Invocation table fields before we update invocation rows in the DB (when flushing post-workspace-status, and in FinalizeInvocation). Instead of reading the full list of events, we can just accumulate the necessary DB fields in memory throughout the invocation.

---

More details:

`fillInvocationFromEvents()` was calling `StreamingEventParser.ParseEvent()` for each build event, which has some important business logic that we want to preserve; namely populating certain invocation proto fields based on the events before we write those fields to the DB (via `tableInvocationFromProto`).

Ideally, we'd just remove `StreamingEventParser` and populate all the invocation DB fields based on `accumulator.BEValues`, since it serves a similar purpose (keeping track of a subset of invocation fields).

However, `StreamingEventParser` and `BEValues` have subtly different logic, unfortunately. For example, different events have effectively different "priorities" -- `StreamingEventParser` gives BuildMetadata events the highest priority, while `BEValues` assigns arbitrary priority depending on which order the event came in. So the value of `BEValues.RepoURL()` _might_ be different than the `invocation.RepoUrl` field computed by `StreamingEventParser`.

Ideally, we should consolidate these two, but it feels like a large and risky change that I would rather handle in a later PR to avoid complicating this one.

So, instead, the approach in this PR is to remove all event buffering from `StreamingEventParser`, so that it is a lightweight object similar to `accumulator.BEValues` that sits in memory while the invocation is in progress. We construct a parser once at the beginning of the invocation, and update it in real time as events come in, keeping only a subset of Invocation fields in memory.

Then, in all the places where we were previously calling `parser.FillInvocation`, we now call `parser.GetInvocation` to retrieve the invocation proto it has written so far.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
