### PR TITLE
Use nodejs version from WORKSPACE

### DIFF
--- a/rules/yarn/index.bzl
+++ b/rules/yarn/index.bzl
@@ -8,7 +8,7 @@ def yarn(name, srcs, package, command = "build", deps = [], yarn = "@yarn//:yarn
     cmd = """
         export ROOTDIR=$$(pwd) && 
         export PACKAGEDIR=$$(dirname $(location %s)) && 
-        export PATH=$$PATH:$$ROOTDIR/$$(dirname $(location %s)):$$ROOTDIR/$$(dirname $(location %s)) && 
+        export PATH=$$ROOTDIR/$$(dirname $(location %s)):$$ROOTDIR/$$(dirname $(location %s)):$$PATH && 
         cd $$PACKAGEDIR && 
         yarn install && 
         yarn %s && 


### PR DESCRIPTION
The original code was setting `PATH=$PATH:/path/containing/bazel/provisioned/node` but that logic still causes the system nodejs to take precedence. The `$PATH` needs to go at the end to make the WORKSPACE version take precedence, not the beginning

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
