### PR TITLE
Always use shared executors for Linux workflows

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -476,7 +476,7 @@ func (s *ExecutionServer) Dispatch(ctx context.Context, req *repb.ExecuteRequest
 		predictedSize = sizer.Predict(ctx, executionTask)
 	}
 
-	pool, err := s.env.GetSchedulerService().GetPoolInfo(ctx, props.OS, props.Pool, props.UseSelfHostedExecutors)
+	pool, err := s.env.GetSchedulerService().GetPoolInfo(ctx, props.OS, props.Pool, props.WorkflowID, props.UseSelfHostedExecutors)
 	if err != nil {
 		return "", err
 	}
@@ -978,7 +978,7 @@ func (s *ExecutionServer) updateUsage(ctx context.Context, cmd *repb.Command, ex
 	// TODO: Incorporate remote-header overrides here.
 	plat := platform.ParseProperties(&repb.ExecutionTask{Command: cmd})
 
-	pool, err := s.env.GetSchedulerService().GetPoolInfo(ctx, plat.OS, plat.Pool, plat.UseSelfHostedExecutors)
+	pool, err := s.env.GetSchedulerService().GetPoolInfo(ctx, plat.OS, plat.Pool, plat.WorkflowID, plat.UseSelfHostedExecutors)
 	if err != nil {
 		return status.InternalErrorf("failed to determine executor pool: %s", err)
 	}

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -887,7 +887,7 @@ func NewSchedulerServerWithOptions(env environment.Env, options *Options) (*Sche
 	return s, nil
 }
 
-func (s *SchedulerServer) GetPoolInfo(ctx context.Context, os, requestedPool string, useSelfHosted bool) (*interfaces.PoolInfo, error) {
+func (s *SchedulerServer) GetPoolInfo(ctx context.Context, os, requestedPool, workflowID string, useSelfHosted bool) (*interfaces.PoolInfo, error) {
 	// Note: The defaultPoolName flag only applies to the shared executor pool.
 	// The pool name for self-hosted pools is always determined directly from
 	// platform props.
@@ -904,6 +904,12 @@ func (s *SchedulerServer) GetPoolInfo(ctx context.Context, os, requestedPool str
 		GroupID: *sharedExecutorPoolGroupID,
 		Name:    sharedPoolName,
 	}
+
+	// Linux workflows are currently only supported on shared executors.
+	if os == platform.LinuxOperatingSystemName && workflowID != "" {
+		return sharedPool, nil
+	}
+
 	user, err := perms.AuthenticatedUser(ctx, s.env)
 	if err != nil {
 		if s.env.GetAuthenticator().AnonymousUsageEnabled() {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -509,7 +509,7 @@ type SchedulerService interface {
 	EnqueueTaskReservation(ctx context.Context, req *scpb.EnqueueTaskReservationRequest) (*scpb.EnqueueTaskReservationResponse, error)
 	ReEnqueueTask(ctx context.Context, req *scpb.ReEnqueueTaskRequest) (*scpb.ReEnqueueTaskResponse, error)
 	GetExecutionNodes(ctx context.Context, req *scpb.GetExecutionNodesRequest) (*scpb.GetExecutionNodesResponse, error)
-	GetPoolInfo(ctx context.Context, os, requestedPool string, useSelfHosted bool) (*PoolInfo, error)
+	GetPoolInfo(ctx context.Context, os, requestedPool, workflowID string, useSelfHosted bool) (*PoolInfo, error)
 }
 
 // PoolInfo holds high level metadata for an executor pool.


### PR DESCRIPTION
Even if the group has selected "default to self hosted executors", schedule workflow actions on shared executors, since we currently don't support self-hosted Linux workflows.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
