### PR TITLE
Remove unhelpful compression metric

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1269,9 +1269,6 @@ func (z *zstdCompressor) Close() error {
 	metrics.CompressionRatio.
 		With(prometheus.Labels{metrics.CompressionType: "zstd"}).
 		Observe(float64(z.numCompressedBytes) / float64(z.numDecompressedBytes))
-	if z.numCompressedBytes > z.numDecompressedBytes {
-		metrics.BadCompressionStreamSize.With(prometheus.Labels{metrics.CompressionType: "zstd"}).Observe(float64(z.numDecompressedBytes))
-	}
 
 	z.bufferPool.Put(z.compressBuf)
 	return z.CustomCommitWriteCloser.Close()

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1439,25 +1439,6 @@ var (
 		CompressionType,
 	})
 
-	BadCompressionStreamSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: bbNamespace,
-		Subsystem: "compressor",
-		Name:      "bad_compression_stream_size",
-		Buckets:   exponentialBucketRange(1, 1_000_000_000, 10),
-		Help:      "The size of data streams that increased in size when compressed",
-	}, []string{
-		CompressionType,
-	})
-
-	/// #### Examples
-	///
-	/// ```promql
-	/// # Histogram with the count of elements in each bucket
-	/// # Visualize with the Bar Gauge type
-	/// # Legend: {{le}}
-	/// sum(buildbuddy_compressor_bad_compression_buffer_size) by(le)
-	/// ```
-
 	CompressionRatio = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "pebble",
@@ -1475,7 +1456,12 @@ var (
 	/// # Histogram buckets with the count of elements in each compression ratio bucket
 	/// # Visualize with the Bar Gauge type
 	/// # Legend: {{le}}
+	/// # Format: Heatmap
 	/// sum(buildbuddy_pebble_compression_ratio_bucket) by(le)
+	///
+	/// # Percentage of elements that increased in size when compressed (compression ratio > 1)
+	/// # Visualize with the Stat type
+	/// (sum(buildbuddy_pebble_compression_ratio_count) - sum(buildbuddy_pebble_compression_ratio_bucket{le="1.0"})) / sum(buildbuddy_pebble_compression_ratio_count)
 	/// ```
 
 	/// ### Raft cache metrics


### PR DESCRIPTION
In prod, the majority of blobs with a bad compression ratio (increased in size when compressed) were between 10,000B and 100,000B. This metric was added to see if there was a clear size cutoff above which compression was helpful in the majority of cases so we could use it as our minimum compression size. That doesn't seem to hold true, so the metric isn't really useful. 
