### PR TITLE
Support detecting cgroup version from system

### DIFF
--- a/enterprise/config/executor.local.yaml
+++ b/enterprise/config/executor.local.yaml
@@ -3,7 +3,6 @@ executor:
   docker_socket: /var/run/docker.sock
   docker_inherit_user_ids: true
   enable_firecracker: true
-  firecracker_cgroup_version: 2
   app_target: "grpc://localhost:1985"
   local_cache_directory: "/tmp/filecache"
   local_cache_size_bytes: 10000000000 # 10GB

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -190,8 +190,7 @@ func getCgroupVersion() (string, error) {
 	}
 	b, err := exec.Command("stat", "-fc", "%T", "/sys/fs/cgroup/").Output()
 	if err != nil {
-		log.Debugf("Error determining system cgroup version: %s", err.Error())
-		return "", err
+		return "", status.UnavailableErrorf("Error determining system cgroup version: %v", err)
 	}
 	v := strings.TrimSpace(string(b))
 	if v == "cgroup2fs" {
@@ -199,7 +198,6 @@ func getCgroupVersion() (string, error) {
 	} else if v == "tmpfs" {
 		return "1", nil
 	} else {
-		log.Debugf("Error determining system cgroup version. System-reported version: %s", v)
 		return "", status.InternalErrorf("No cgroup version found (system reported %s)", v)
 	}
 }


### PR DESCRIPTION
This PR:
- Detects the cgroup version from the system (by running `stat -fc %T /sys/fs/cgroup/` and searching for `cgroup2fs` or `tmpfs`) when `--executor.firecracker_cgroup_version` is an empty string. Otherwise, the value from `--executor.firecracker_cgroup_version` is used.
- Switches the default value of `--executor.firecracker_cgroup_version` to be an empty string, enabled the behavior above.

**Version bump**: Patch