### PR TITLE
Don't assume nobody is uid/gid 65534 in firecracker_test.go

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"syscall"
 	"testing"
 	"time"
@@ -529,7 +530,7 @@ func TestFirecrackerNonRoot(t *testing.T) {
 	require.NoError(t, res.Error)
 	require.Empty(t, string(res.Stderr))
 	require.Equal(t, 0, res.ExitCode)
-	require.Equal(t, "uid=65534(nobody) gid=65534(nobody)\n", string(res.Stdout))
+	require.Regexp(t, regexp.MustCompile("uid=[0-9]+\\(nobody\\) gid=[0-9]+\\(nobody\\)"), string(res.Stdout))
 }
 
 func TestFirecrackerRunNOPWithZeroDisk(t *testing.T) {


### PR DESCRIPTION
Apparently this is not a safe assumption ([StackOverflow](https://stackoverflow.com/questions/34831861/can-i-assume-that-nobody-is-65534)) and running this on Tyler's machine the uid and gid are 99 so it fails.

**Version bump**: Patch