### PR TITLE
Let there be UsageStats in the result returned to TestFirecrackerFileMapping.

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -339,6 +339,12 @@ func TestFirecrackerFileMapping(t *testing.T) {
 	if res.Error != nil {
 		t.Fatalf("error: %s", res.Error)
 	}
+
+	// Check that the result has usage stats, but don't perform equality checks
+	// on them.
+	assert.True(res.UsageStats != nil)
+	res.UsageStats = nil
+
 	assert.Equal(t, expectedResult, res)
 
 	for _, fullPath := range files {


### PR DESCRIPTION
This PR just asserts that they're there and then clears them for the proto comparison with the expected result.

**Version bump**: Patch