### PR TITLE
Performance: Optimize `bazel_request.GetInvocationID`

### DIFF
--- a/server/util/bazel_request/BUILD
+++ b/server/util/bazel_request/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//server/util/status",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_google_protobuf//encoding/protowire",
         "@org_golang_google_protobuf//proto",
     ],
 )

--- a/server/util/bazel_request/bazel_request_test.go
+++ b/server/util/bazel_request/bazel_request_test.go
@@ -13,6 +13,31 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
+func TestGetInvocationID(t *testing.T) {
+	for _, rmd := range []*repb.RequestMetadata{
+		{
+			ToolInvocationId: "455385a4-7773-4044-96b3-9fd0556ca5cd",
+		},
+		{
+			ToolDetails:             &repb.ToolDetails{ToolName: "bazel", ToolVersion: "6.0.0"},
+			ToolInvocationId:        "455385a4-7773-4044-96b3-9fd0556ca5cd",
+			CorrelatedInvocationsId: "1e24dd4a-8d5e-40c3-9be3-4ae250d3535e",
+		},
+		{
+			ToolDetails:             &repb.ToolDetails{ToolName: "bazel", ToolVersion: "6.0.0"},
+			ToolInvocationId:        "455385a4-7773-4044-96b3-9fd0556ca5cd",
+			CorrelatedInvocationsId: "1e24dd4a-8d5e-40c3-9be3-4ae250d3535e",
+			ActionMnemonic:          "CppCompile",
+			ActionId:                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			TargetId:                "//foo/bar/baz:baz",
+			ConfigurationId:         "5e8679d0116818e43799a512d0deb1a83982abbe3699eba0e69a85241d0a695a",
+		},
+	} {
+		ctx := withIncomingMetadata(t, context.Background(), rmd)
+		assert.Equal(t, rmd.GetToolInvocationId(), bazel_request.GetInvocationID(ctx))
+	}
+}
+
 func TestParseBazelVersion(t *testing.T) {
 	for _, testCase := range []struct {
 		Tool, Version   string


### PR DESCRIPTION
This should save ~1-3% on app CPU based on current profiling data, and also save ~0.9KB worth of allocations per request.

```
BenchmarkGetInvocationID-8              10000000               964.0 ns/op          1184 B/op         14 allocs/op
BenchmarkFastGetInvocationID-8          10000000               128.4 ns/op           320 B/op          3 allocs/op
```

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
