### PR TITLE
Gossip node partition usages when size delta is bigger than threshold.

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"net"
 	"os"
@@ -69,16 +70,23 @@ const (
 	// considered to be full and eviction will kick in.
 	evictionCutoffThreshold = .90
 
-	// How often nodes wil gossip about their partition usage.
-	nodePartitionUsageGossipInterval = 15 * time.Second
+	// How often nodes wil check whether to gossip usage data if it is
+	// sufficiently different from the last broadcast.
+	nodePartitionUsageCheckInterval = 15 * time.Second
+
+	// How often nodes can go without broadcasting usage information.
+	// Usage data will be gosipped after this time if no updated were triggered
+	// based on data changes.
+	nodePartitionUsageMaxAge = 15 * time.Minute
 
 	// How old node partition usage data can be before we consider it invalid.
-	nodePartitionStalenessLimit = 30 * time.Second
+	nodePartitionStalenessLimit = nodePartitionUsageMaxAge * 2
 )
 
 var (
-	enableSplittingReplicas = flag.Bool("cache.raft.enable_splitting_replicas", true, "If set, allow splitting oversize replicas")
-	replicaSplitSizeBytes   = flag.Int64("cache.raft.replica_split_size_bytes", 2e7, "Split replicas after they reach this size")
+	enableSplittingReplicas            = flag.Bool("cache.raft.enable_splitting_replicas", true, "If set, allow splitting oversize replicas")
+	replicaSplitSizeBytes              = flag.Int64("cache.raft.replica_split_size_bytes", 2e7, "Split replicas after they reach this size")
+	partitionUsageDeltaGossipThreshold = flag.Int("cache.raft.partition_usage_delta_bytes_threshold", 100e6, "Gossip partition usage information if it has changed by more than this amount since the last gossip.")
 )
 
 type nodePartitionUsage struct {
@@ -120,6 +128,7 @@ func (pu *partitionUsage) GlobalSizeBytes() int64 {
 
 func (pu *partitionUsage) RemoteUpdate(nhid string, update *rfpb.PartitionMetadata) {
 	pu.mu.Lock()
+	defer pu.mu.Unlock()
 	n, ok := pu.nodes[nhid]
 	if !ok {
 		n = &nodePartitionUsage{}
@@ -134,7 +143,6 @@ func (pu *partitionUsage) RemoteUpdate(nhid string, update *rfpb.PartitionMetada
 			delete(pu.nodes, id)
 		}
 	}
-	pu.mu.Unlock()
 }
 
 func (pu *partitionUsage) evict(ctx context.Context, key *ReplicaSample) (skip bool, err error) {
@@ -153,7 +161,12 @@ func (pu *partitionUsage) evict(ctx context.Context, key *ReplicaSample) (skip b
 		return false, status.InternalErrorf("eviction request failed: %s", rsp.AnyError())
 	}
 
+	globalSizeBytes := pu.GlobalSizeBytes()
+
 	pu.mu.Lock()
+	defer pu.mu.Unlock()
+	// Update local replica information to reflect the eviction. Don't need
+	// to wait for a proactive update from the replica.
 	u, ok := pu.replicas[key.header.GetRangeId()]
 	if ok {
 		u.SizeBytes -= key.metadata.GetStoredSizeBytes()
@@ -161,7 +174,18 @@ func (pu *partitionUsage) evict(ctx context.Context, key *ReplicaSample) (skip b
 	} else {
 		log.Warningf("eviction succeeded but range %d wasn't found", key.header.GetRangeId())
 	}
-	pu.mu.Unlock()
+
+	// Assume eviction on all nodes is happening at a similar rate as on the
+	// current node and update the usage information speculatively since we
+	// don't know when we'll receive the next usage update from remote nodes.
+	// When we do receive updates from other nodes they will overwrite our
+	// speculative numbers.
+	for _, npu := range pu.nodes {
+		npu.sizeBytes -= int64(float64(key.metadata.GetStoredSizeBytes()) * float64(globalSizeBytes) / float64(npu.sizeBytes))
+		if npu.sizeBytes < 0 {
+			npu.sizeBytes = 0
+		}
+	}
 
 	return false, nil
 }
@@ -223,10 +247,11 @@ type usageTracker struct {
 	gossipManager *gossip.GossipManager
 	partitions    []disk.Partition
 
-	quitChan    chan struct{}
-	mu          sync.Mutex
-	byRange     map[uint64]*rfpb.ReplicaUsage
-	byPartition map[string]*partitionUsage
+	quitChan      chan struct{}
+	mu            sync.Mutex
+	byRange       map[uint64]*rfpb.ReplicaUsage
+	byPartition   map[string]*partitionUsage
+	lastBroadcast map[string]*rfpb.PartitionMetadata
 }
 
 func newUsageTracker(store *Store, gossipManager *gossip.GossipManager, partitions []disk.Partition) (*usageTracker, error) {
@@ -237,6 +262,7 @@ func newUsageTracker(store *Store, gossipManager *gossip.GossipManager, partitio
 		quitChan:      make(chan struct{}),
 		byRange:       make(map[uint64]*rfpb.ReplicaUsage),
 		byPartition:   make(map[string]*partitionUsage),
+		lastBroadcast: make(map[string]*rfpb.PartitionMetadata),
 	}
 
 	for _, p := range partitions {
@@ -291,19 +317,41 @@ func (ut *usageTracker) Statusz(ctx context.Context) string {
 		}
 
 		globalSizeBytes := u.GlobalSizeBytes()
-		for _, nu := range u.nodes {
-			globalSizeBytes += nu.sizeBytes
-		}
-		percentFull := float64(globalSizeBytes) / float64(p.MaxSizeBytes)
+		percentFull := (float64(globalSizeBytes) / float64(p.MaxSizeBytes)) * 100
 
 		buf += fmt.Sprintf("\t\tCapacity: %s / %s (%2.2f%% full)\n", units.BytesSize(float64(globalSizeBytes)), units.BytesSize(float64(p.MaxSizeBytes)), percentFull)
 		buf += "\t\tLocal Ranges:\n"
+
 		u.mu.Lock()
-		for rid, pu := range u.replicas {
+		// Show ranges in a consistent order so that they don't jump around when
+		// refreshing the statusz page.
+		var rids []uint64
+		for rid := range u.replicas {
+			rids = append(rids, rid)
+		}
+		sort.Slice(rids, func(i, j int) bool { return rids[i] < rids[j] })
+
+		for _, rid := range rids {
+			pu, ok := u.replicas[rid]
+			if !ok {
+				continue
+			}
 			buf += fmt.Sprintf("\t\t\t%d: %s, %d records\n", rid, units.BytesSize(float64(pu.GetSizeBytes())), pu.GetTotalCount())
 		}
+
+		// Show nodes in a consistent order so that they don't jump around when
+		// refreshing the statusz page.
+		var nhids []string
+		for nhid := range u.nodes {
+			nhids = append(nhids, nhid)
+		}
+		sort.Strings(nhids)
 		buf += "\t\tGlobal Usage:\n"
-		for nhid, nu := range u.nodes {
+		for _, nhid := range nhids {
+			nu, ok := u.nodes[nhid]
+			if !ok {
+				continue
+			}
 			buf += fmt.Sprintf("\t\t\t%s: %s\n", nhid, units.BytesSize(float64(nu.sizeBytes)))
 		}
 		u.mu.Unlock()
@@ -408,6 +456,11 @@ func (ut *usageTracker) RangeUsages() []*rfpb.ReplicaUsage {
 }
 
 func (ut *usageTracker) computeUsage() *rfpb.NodePartitionUsage {
+	usages := ut.store.RefreshReplicaUsages()
+	for _, u := range usages {
+		ut.LocalUpdate(u.GetRangeId(), u)
+	}
+
 	ut.mu.Lock()
 	defer ut.mu.Unlock()
 	nu := &rfpb.NodePartitionUsage{
@@ -432,21 +485,47 @@ func (ut *usageTracker) computeUsage() *rfpb.NodePartitionUsage {
 }
 
 func (ut *usageTracker) broadcastLoop() {
+	idleTimer := time.NewTimer(nodePartitionUsageMaxAge)
+
 	for {
-		if err := ut.broadcast(); err != nil {
-			log.Warningf("could not gossip node partition usage info: %s", err)
-		}
 		select {
 		case <-ut.quitChan:
 			return
-		case <-time.After(nodePartitionUsageGossipInterval):
-			break
+		case <-time.After(nodePartitionUsageCheckInterval):
+			if !idleTimer.Stop() {
+				<-idleTimer.C
+			}
+			idleTimer.Reset(nodePartitionUsageMaxAge)
+			if err := ut.broadcast(false /*=force*/); err != nil {
+				log.Warningf("could not gossip node partition usage info: %s", err)
+			}
+		case <-idleTimer.C:
+			if err := ut.broadcast(true /*=force*/); err != nil {
+				log.Warningf("could not gossip node partition usage info: %s", err)
+			}
 		}
 	}
 }
 
-func (ut *usageTracker) broadcast() error {
+func (ut *usageTracker) broadcast(force bool) error {
 	usage := ut.computeUsage()
+
+	// If not forced, check whether there's enough changes to force a broadcast.
+	if !force {
+		significantChange := false
+		ut.mu.Lock()
+		for _, u := range usage.GetPartitionUsage() {
+			lb, ok := ut.lastBroadcast[u.GetPartitionId()]
+			if !ok || math.Abs(float64(u.GetSizeBytes()-lb.GetSizeBytes())) > float64(*partitionUsageDeltaGossipThreshold) {
+				significantChange = true
+				break
+			}
+		}
+		ut.mu.Unlock()
+		if !significantChange {
+			return nil
+		}
+	}
 
 	buf, err := proto.Marshal(usage)
 	if err != nil {
@@ -455,6 +534,12 @@ func (ut *usageTracker) broadcast() error {
 
 	if err := ut.gossipManager.SendUserEvent(constants.NodePartitionUsageEvent, buf, false /*coalesce*/); err != nil {
 		return err
+	}
+
+	ut.mu.Lock()
+	defer ut.mu.Unlock()
+	for _, u := range usage.GetPartitionUsage() {
+		ut.lastBroadcast[u.GetPartitionId()] = u
 	}
 
 	return nil
@@ -592,12 +677,6 @@ func (s *Store) NotifyUsage(usage *rfpb.ReplicaUsage) {
 	if usage.GetEstimatedDiskBytesUsed() > *replicaSplitSizeBytes {
 		s.RequestSplit(clusterID)
 	}
-
-	rd := s.lookupRange(clusterID)
-	if rd == nil {
-		return
-	}
-	s.usages.LocalUpdate(rd.GetRangeId(), usage)
 }
 
 func (s *Store) RequestSplit(clusterID uint64) {
@@ -1333,6 +1412,31 @@ func (s *Store) Usage() *rfpb.StoreUsage {
 		su.TotalBytesUsed += ru.GetEstimatedDiskBytesUsed()
 	}
 	return su
+}
+
+func (s *Store) RefreshReplicaUsages() []*rfpb.ReplicaUsage {
+	s.rangeMu.RLock()
+	openRanges := make([]*rfpb.RangeDescriptor, 0, len(s.openRanges))
+	for _, rd := range s.openRanges {
+		openRanges = append(openRanges, rd)
+	}
+	s.rangeMu.RUnlock()
+
+	var usages []*rfpb.ReplicaUsage
+	for _, rd := range openRanges {
+		r, err := s.GetReplica(rd.GetRangeId())
+		if err != nil {
+			log.Warningf("could not get replica %d to refresh usage: %s", rd.GetRangeId(), err)
+			continue
+		}
+		u, err := r.Usage()
+		if err != nil {
+			log.Warningf("could not refresh usage for replica %d: %s", rd.GetRangeId(), err)
+			continue
+		}
+		usages = append(usages, u)
+	}
+	return usages
 }
 
 func (s *Store) updateTags() error {


### PR DESCRIPTION
If node usage has not reached the threshold, force an update to be sent after 15 minutes to make the usage information reasonably up to date across the cache nodes.

Other changes:
 - Proactively refresh replica usages every 15 seconds instead of relying on periodic updates from replicas. This makes the usage information more accurate and there's no performance hit as replica Usage() is now a cheap operation.
 - When evicting data locally, speculatively update usage for remote nodes assuming they are evicting at a similar rate to avoid evicting more data from nodes that are getting more write requests.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: TODO <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
