### PR TITLE
Refactor: Move EventParser into accumulator

### DIFF
--- a/server/build_event_protocol/accumulator/BUILD
+++ b/server/build_event_protocol/accumulator/BUILD
@@ -8,6 +8,8 @@ go_library(
     deps = [
         "//proto:build_event_stream_go_proto",
         "//proto:command_line_go_proto",
+        "//proto:invocation_go_proto",
+        "//server/build_event_protocol/event_parser",
         "//server/build_event_protocol/invocation_format",
         "//server/util/git",
         "//server/util/timeutil",

--- a/server/build_event_protocol/build_event_handler/BUILD
+++ b/server/build_event_protocol/build_event_handler/BUILD
@@ -21,7 +21,6 @@ go_library(
         "//server/api/config",
         "//server/build_event_protocol/accumulator",
         "//server/build_event_protocol/build_status_reporter",
-        "//server/build_event_protocol/event_parser",
         "//server/build_event_protocol/invocation_format",
         "//server/build_event_protocol/target_tracker",
         "//server/environment",

--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -91,8 +91,8 @@ func (sep *StreamingEventParser) GetInvocation() *inpb.Invocation {
 	return sep.invocation
 }
 
-func (sep *StreamingEventParser) ParseEvent(event *inpb.InvocationEvent) {
-	switch p := event.BuildEvent.Payload.(type) {
+func (sep *StreamingEventParser) ParseEvent(event *build_event_stream.BuildEvent) {
+	switch p := event.Payload.(type) {
 	case *build_event_stream.BuildEvent_Progress:
 		{
 		}
@@ -104,7 +104,7 @@ func (sep *StreamingEventParser) ParseEvent(event *inpb.InvocationEvent) {
 			startTime := timeutil.GetTimeWithFallback(p.Started.StartTime, p.Started.StartTimeMillis)
 			sep.startTime = &startTime
 			sep.invocation.Command = p.Started.Command
-			for _, child := range event.BuildEvent.Children {
+			for _, child := range event.Children {
 				// Here we are then. Knee-deep.
 				switch c := child.Id.(type) {
 				case *build_event_stream.BuildEventId_Pattern:

--- a/server/build_event_protocol/event_parser/event_parser_test.go
+++ b/server/build_event_protocol/event_parser/event_parser_test.go
@@ -29,16 +29,14 @@ func singleFiles() []*build_event_stream.File {
 }
 
 func TestFillInvocation(t *testing.T) {
-	events := make([]*inpb.InvocationEvent, 0)
+	events := make([]*build_event_stream.BuildEvent, 0)
 
 	progress := &build_event_stream.Progress{
 		Stderr: "stderr",
 		Stdout: "stdout",
 	}
-	events = append(events, &inpb.InvocationEvent{
-		BuildEvent: &build_event_stream.BuildEvent{
-			Payload: &build_event_stream.BuildEvent_Progress{Progress: progress},
-		},
+	events = append(events, &build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_Progress{Progress: progress},
 	})
 
 	startTime := time.Now()
@@ -47,19 +45,15 @@ func TestFillInvocation(t *testing.T) {
 		Command:            "test",
 		OptionsDescription: "foo",
 	}
-	events = append(events, &inpb.InvocationEvent{
-		BuildEvent: &build_event_stream.BuildEvent{
-			Payload: &build_event_stream.BuildEvent_Started{Started: buildStarted},
-		},
+	events = append(events, &build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_Started{Started: buildStarted},
 	})
 
 	unstructuredCommandLine := &build_event_stream.UnstructuredCommandLine{
 		Args: []string{"foo", "bar", "baz"},
 	}
-	events = append(events, &inpb.InvocationEvent{
-		BuildEvent: &build_event_stream.BuildEvent{
-			Payload: &build_event_stream.BuildEvent_UnstructuredCommandLine{UnstructuredCommandLine: unstructuredCommandLine},
-		},
+	events = append(events, &build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_UnstructuredCommandLine{UnstructuredCommandLine: unstructuredCommandLine},
 	})
 
 	shellOption := &command_line.Option{
@@ -88,20 +82,16 @@ func TestFillInvocation(t *testing.T) {
 			},
 		},
 	}
-	events = append(events, &inpb.InvocationEvent{
-		BuildEvent: &build_event_stream.BuildEvent{
-			Payload: &build_event_stream.BuildEvent_StructuredCommandLine{StructuredCommandLine: structuredCommandLine},
-		},
+	events = append(events, &build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_StructuredCommandLine{StructuredCommandLine: structuredCommandLine},
 	})
 
 	optionsParsed := &build_event_stream.OptionsParsed{
 		CmdLine:         []string{"foo"},
 		ExplicitCmdLine: []string{"explicit"},
 	}
-	events = append(events, &inpb.InvocationEvent{
-		BuildEvent: &build_event_stream.BuildEvent{
-			Payload: &build_event_stream.BuildEvent_OptionsParsed{OptionsParsed: optionsParsed},
-		},
+	events = append(events, &build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_OptionsParsed{OptionsParsed: optionsParsed},
 	})
 
 	workspaceStatus := &build_event_stream.WorkspaceStatus{
@@ -112,10 +102,8 @@ func TestFillInvocation(t *testing.T) {
 			},
 		},
 	}
-	events = append(events, &inpb.InvocationEvent{
-		BuildEvent: &build_event_stream.BuildEvent{
-			Payload: &build_event_stream.BuildEvent_WorkspaceStatus{WorkspaceStatus: workspaceStatus},
-		},
+	events = append(events, &build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_WorkspaceStatus{WorkspaceStatus: workspaceStatus},
 	})
 
 	actionExecuted := &build_event_stream.ActionExecuted{
@@ -124,49 +112,39 @@ func TestFillInvocation(t *testing.T) {
 		PrimaryOutput:      singleFile(),
 		ActionMetadataLogs: singleFiles(),
 	}
-	events = append(events, &inpb.InvocationEvent{
-		BuildEvent: &build_event_stream.BuildEvent{
-			Payload: &build_event_stream.BuildEvent_Action{Action: actionExecuted},
-		},
+	events = append(events, &build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_Action{Action: actionExecuted},
 	})
 
 	namedSetOfFiles := &build_event_stream.NamedSetOfFiles{
 		Files: singleFiles(),
 	}
-	events = append(events, &inpb.InvocationEvent{
-		BuildEvent: &build_event_stream.BuildEvent{
-			Payload: &build_event_stream.BuildEvent_NamedSetOfFiles{NamedSetOfFiles: namedSetOfFiles},
-		},
+	events = append(events, &build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_NamedSetOfFiles{NamedSetOfFiles: namedSetOfFiles},
 	})
 
 	targetComplete := &build_event_stream.TargetComplete{
 		Success:         true,
 		DirectoryOutput: singleFiles(),
 	}
-	events = append(events, &inpb.InvocationEvent{
-		BuildEvent: &build_event_stream.BuildEvent{
-			Payload: &build_event_stream.BuildEvent_Completed{Completed: targetComplete},
-		},
+	events = append(events, &build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_Completed{Completed: targetComplete},
 	})
 
 	testResult := &build_event_stream.TestResult{
 		Status:           build_event_stream.TestStatus_PASSED,
 		TestActionOutput: singleFiles(),
 	}
-	events = append(events, &inpb.InvocationEvent{
-		BuildEvent: &build_event_stream.BuildEvent{
-			Payload: &build_event_stream.BuildEvent_TestResult{TestResult: testResult},
-		},
+	events = append(events, &build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_TestResult{TestResult: testResult},
 	})
 
 	testSummary := &build_event_stream.TestSummary{
 		Passed: singleFiles(),
 		Failed: singleFiles(),
 	}
-	events = append(events, &inpb.InvocationEvent{
-		BuildEvent: &build_event_stream.BuildEvent{
-			Payload: &build_event_stream.BuildEvent_TestSummary{TestSummary: testSummary},
-		},
+	events = append(events, &build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_TestSummary{TestSummary: testSummary},
 	})
 
 	finishTime := startTime.Add(time.Millisecond)
@@ -177,10 +155,8 @@ func TestFillInvocation(t *testing.T) {
 			Code: 0,
 		},
 	}
-	events = append(events, &inpb.InvocationEvent{
-		BuildEvent: &build_event_stream.BuildEvent{
-			Payload: &build_event_stream.BuildEvent_Finished{Finished: buildFinished},
-		},
+	events = append(events, &build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_Finished{Finished: buildFinished},
 	})
 
 	buildMetadata := &build_event_stream.BuildMetadata{
@@ -190,10 +166,8 @@ func TestFillInvocation(t *testing.T) {
 			"REPO_URL":  "https://github.com/buildbuddy-io/metadata_repo_url",
 		},
 	}
-	events = append(events, &inpb.InvocationEvent{
-		BuildEvent: &build_event_stream.BuildEvent{
-			Payload: &build_event_stream.BuildEvent_BuildMetadata{BuildMetadata: buildMetadata},
-		},
+	events = append(events, &build_event_stream.BuildEvent{
+		Payload: &build_event_stream.BuildEvent_BuildMetadata{BuildMetadata: buildMetadata},
 	})
 	invocation := &inpb.Invocation{
 		InvocationId:     "test-invocation",

--- a/server/build_event_protocol/target_tracker/BUILD
+++ b/server/build_event_protocol/target_tracker/BUILD
@@ -30,6 +30,7 @@ go_test(
     deps = [
         ":target_tracker",
         "//proto:build_event_stream_go_proto",
+        "//proto:invocation_go_proto",
         "//proto/api/v1:common_go_proto",
         "//server/testutil/testauth",
         "//server/testutil/testenv",

--- a/server/build_event_protocol/target_tracker/target_tracker_test.go
+++ b/server/build_event_protocol/target_tracker/target_tracker_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cmpb "github.com/buildbuddy-io/buildbuddy/proto/api/v1/common"
+	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
 )
 
 type Row struct {
@@ -71,6 +72,12 @@ type fakeAccumulator struct {
 	command      string
 	repoURL      string
 	invocationID string
+}
+
+func (a *fakeAccumulator) Invocation() *inpb.Invocation {
+	return &inpb.Invocation{
+		InvocationId: a.invocationID,
+	}
 }
 
 func (a *fakeAccumulator) Role() string {


### PR DESCRIPTION
This PR serves as step 1 of consolidating StreamingEventParser and Accumulator (AKA BEValues), which now serve basically the same purpose but (confusingly) provide slightly different values for things like RepoURL etc.

The remaining plan after this PR is the following:
- Replace all Accumulator methods (e.g. `RepoURL()`) with equivalent calls to invocation field getters (`acc.Invocation().GetRepoUrl()`) (We need to be careful about this part, since RepoURL() in particular has some normalization logic involved, and `BEValues` assigns different "priorities" to events than `parser` does)
- Get rid of StreamingEventParser and move all of its logic into `accumulator.go`
- (Maybe?) Rename `BEValues` to `accumulator` and replace `accumulator.NewBEValues()` with `accumulator.New()`

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
