### PR TITLE
Add Raft metric for evicted item age.

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1572,6 +1572,16 @@ var (
 	}, []string{
 		RaftRangeIDLabel,
 	})
+
+	RaftEvictionAgeUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "raft",
+		Name:      "eviction_age_usec",
+		Buckets:   durationUsecBuckets(1*time.Hour, 30*24*time.Hour, 2),
+		Help:      "Age of items evicted from the cache, in **microseconds**.",
+	}, []string{
+		PartitionID,
+	})
 )
 
 // exponentialBucketRange returns prometheus.ExponentialBuckets specified in


### PR DESCRIPTION
I updated the sampling key to remove extranerous information, mainly to avoid confusion between the atime timestamp in the sample key and the atime maintained by the LRU. Now the full sample is passed on eviction to access the atime in the LRU.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
