### PR TITLE
Refactor: Trim Accumulator interface

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -683,7 +683,6 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 	invocation := e.beValues.Invocation()
 	invocation.Attempt = e.attempt
 	invocation.HasChunkedEventLogs = e.logWriter != nil
-	invocation.BazelExitCode = e.beValues.BuildExitCode()
 
 	if e.pw != nil {
 		if err := e.pw.Flush(ctx); err != nil {

--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -241,23 +241,27 @@ func (r *BuildStatusReporter) invocationLabel() string {
 		return r.buildEventAccumulator.ActionName()
 	}
 
-	command := r.buildEventAccumulator.Command()
+	command := r.buildEventAccumulator.Invocation().GetCommand()
 	pattern := r.buildEventAccumulator.Pattern()
 	return fmt.Sprintf("bazel %s %s", command, pattern)
 }
 
+func (r *BuildStatusReporter) invocationID() string {
+	return r.buildEventAccumulator.Invocation().GetInvocationId()
+}
+
 func (r *BuildStatusReporter) invocationURL() string {
-	return build_buddy_url.WithPath(fmt.Sprintf("/invocation/%s", r.buildEventAccumulator.InvocationID())).String()
+	return build_buddy_url.WithPath(fmt.Sprintf("/invocation/%s", r.invocationID())).String()
 }
 
 func (r *BuildStatusReporter) groupURL(label string) string {
-	u := build_buddy_url.WithPath(fmt.Sprintf("/invocation/%s", r.buildEventAccumulator.InvocationID()))
+	u := build_buddy_url.WithPath(fmt.Sprintf("/invocation/%s", r.invocationID()))
 	u.RawQuery = fmt.Sprintf("targetFilter=%s", label)
 	return u.String()
 }
 
 func (r *BuildStatusReporter) targetURL(label string) string {
-	u := build_buddy_url.WithPath(fmt.Sprintf("/invocation/%s", r.buildEventAccumulator.InvocationID()))
+	u := build_buddy_url.WithPath(fmt.Sprintf("/invocation/%s", r.invocationID()))
 	u.RawQuery = fmt.Sprintf("target=%s", label)
 	return u.String()
 }

--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -165,7 +165,8 @@ func (sep *StreamingEventParser) ParseEvent(event *build_event_stream.BuildEvent
 				duration := endTime.Sub(*sep.startTime)
 				sep.invocation.DurationUsec = duration.Microseconds()
 			}
-			sep.invocation.Success = p.Finished.ExitCode.Code == 0
+			sep.invocation.Success = p.Finished.ExitCode.GetCode() == 0
+			sep.invocation.BazelExitCode = p.Finished.ExitCode.GetName()
 		}
 	case *build_event_stream.BuildEvent_BuildToolLogs:
 		{

--- a/server/build_event_protocol/target_tracker/target_tracker_test.go
+++ b/server/build_event_protocol/target_tracker/target_tracker_test.go
@@ -76,6 +76,9 @@ type fakeAccumulator struct {
 
 func (a *fakeAccumulator) Invocation() *inpb.Invocation {
 	return &inpb.Invocation{
+		Role:         a.role,
+		Command:      a.command,
+		RepoUrl:      a.repoURL,
 		InvocationId: a.invocationID,
 	}
 }
@@ -84,24 +87,12 @@ func (a *fakeAccumulator) Role() string {
 	return a.role
 }
 
-func (a *fakeAccumulator) Command() string {
-	return a.command
-}
-
 func (a *fakeAccumulator) RepoURL() string {
 	return a.repoURL
 }
 
-func (a *fakeAccumulator) InvocationID() string {
-	return a.invocationID
-}
-
 func (a *fakeAccumulator) StartTime() time.Time {
 	return time.Now()
-}
-
-func (a *fakeAccumulator) BranchName() string {
-	return ""
 }
 
 func (a *fakeAccumulator) CommitSHA() string {


### PR DESCRIPTION
This PR aims to remove some methods from the `Accumulator` interface. It should be a NOP -- for any methods where the accumulator and EventParser would return different values, I left those in tact (but I still plan to consolidate those in a later PR).

- Remove `BuildExitCode()` and set the `BuildExitCode` on the invocation instead when handling the `Finished` event.
- Remove `InvocationID()` and update callers to use `Invocation().GetInvocationId()` instead.
- Remove `Command()` and update callers to use `Invocation().GetCommand()` instead.
- Remove `BranchName()` which was unused.
- Reorganize methods so it's clearer which fields we are trying to remove as the end goal of the refactoring.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
