### PR TITLE
remove CommandBuffer in execution collector

### DIFF
--- a/enterprise/server/backends/redis_execution_collector/BUILD
+++ b/enterprise/server/backends/redis_execution_collector/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_execution_collector",
     visibility = ["//visibility:public"],
     deps = [
-        "//enterprise/server/util/redisutil",
         "//proto:remote_execution_go_proto",
         "//proto:stored_invocation_go_proto",
         "//server/environment",

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -323,6 +323,8 @@ func (s *ExecutionServer) recordExecution(ctx context.Context, executionID strin
 			// the invocation is complete
 			if err := s.env.GetExecutionCollector().Append(ctx, link.InvocationID, executionProto); err != nil {
 				log.CtxErrorf(ctx, "failed to append execution %q to invocation %q: %s", executionID, link.InvocationID, err)
+			} else {
+				log.CtxInfof(ctx, "appended execution %q to invocation %q in redis", executionID, link.InvocationID)
 			}
 		} else {
 			err = s.env.GetOLAPDBHandle().FlushExecutionStats(ctx, inv, []*repb.StoredExecution{executionProto})

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -319,8 +319,7 @@ func (r *statsRecorder) flushInvocationStatsToOLAPDB(ctx context.Context, ij *in
 	if err = r.env.GetExecutionCollector().AddInvocation(ctx, storedInv); err != nil {
 		log.CtxErrorf(ctx, "failed to write the complete Invocation to redis: %s", err)
 	} else {
-		// Temporary logging for debugging clickhouse missing data.
-		log.CtxDebug(ctx, "Successfully wrote invocation to redis")
+		log.CtxInfo(ctx, "Successfully wrote invocation to redis")
 	}
 
 	for {

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -318,6 +318,9 @@ func (r *statsRecorder) flushInvocationStatsToOLAPDB(ctx context.Context, ij *in
 	storedInv := toStoredInvocation(inv)
 	if err = r.env.GetExecutionCollector().AddInvocation(ctx, storedInv); err != nil {
 		log.CtxErrorf(ctx, "failed to write the complete Invocation to redis: %s", err)
+	} else {
+		// Temporary logging for debugging clickhouse missing data.
+		log.CtxDebug(ctx, "Successfully wrote invocation to redis")
 	}
 
 	for {


### PR DESCRIPTION
The CommandBuffer flushes every 250 ms by default. This can cause an
issue where execution server appends the execution is reids, but when build event
handler tries to fetch the executions from redis, the execution was still in the
buffer and not in redis.

Also, added some logging to help debugging. 
