### PR TITLE
Normalize repo URL for in-memory invocation proto

### DIFF
--- a/server/build_event_protocol/event_parser/BUILD
+++ b/server/build_event_protocol/event_parser/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//proto:build_event_stream_go_proto",
         "//proto:command_line_go_proto",
         "//proto:invocation_go_proto",
+        "//server/util/git",
         "//server/util/timeutil",
     ],
 )

--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	"github.com/buildbuddy-io/buildbuddy/proto/command_line"
+	"github.com/buildbuddy-io/buildbuddy/server/util/git"
 	"github.com/buildbuddy-io/buildbuddy/server/util/timeutil"
 
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
@@ -370,6 +371,9 @@ func (sep *StreamingEventParser) setReadPermission(value inpb.InvocationPermissi
 	}
 }
 func (sep *StreamingEventParser) setRepoUrl(value string, priority int) {
+	if norm, _ := git.NormalizeRepoURL(value); norm != nil {
+		value = norm.String()
+	}
 	if sep.priority.RepoUrl <= priority {
 		sep.priority.RepoUrl = priority
 		sep.invocation.RepoUrl = value

--- a/server/build_event_protocol/event_parser/event_parser_test.go
+++ b/server/build_event_protocol/event_parser/event_parser_test.go
@@ -163,7 +163,7 @@ func TestFillInvocation(t *testing.T) {
 		Metadata: map[string]string{
 			"ALLOW_ENV": "SHELL",
 			"ROLE":      "METADATA_CI",
-			"REPO_URL":  "https://github.com/buildbuddy-io/metadata_repo_url",
+			"REPO_URL":  "git@github.com:/buildbuddy-io/metadata_repo_url",
 		},
 	}
 	events = append(events, &build_event_stream.BuildEvent{
@@ -188,5 +188,5 @@ func TestFillInvocation(t *testing.T) {
 	assert.Equal(t, int64(1000), invocation.DurationUsec)
 	assert.Equal(t, "WORKSPACE_STATUS_BUILD_USER", invocation.User)
 	assert.Equal(t, "METADATA_CI", invocation.Role)
-	assert.Equal(t, "https://github.com/buildbuddy-io/metadata_repo_url", invocation.RepoUrl)
+	assert.Equal(t, "https://github.com/buildbuddy-io/metadata_repo_url", invocation.RepoUrl, "repo URL should be normalized")
 }


### PR DESCRIPTION
This fixes an issue that the logging added in https://github.com/buildbuddy-io/buildbuddy/pull/3123 is noisy, due to repo URLs mismatching between `Accumulator` and `EventParser`, even though the normalized values are the same.

The non-normalized URLs are never used directly (*), so we should only be comparing the normalized URLs when logging whether there is a mismatch.

It is also generally more sane to normalize the repo URL as soon as we can, to avoid possible bugs involving non-normalized repo URLs.

(*) Except when serving back to the UI for the invocation page, in the `GetInvocation` response. The UI does its own normalization though, so the approach in this PR of normalizing server-side before serving back to the UI should functionally be a NOP.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
