### PR TITLE
Support --prober_name in bazelrbe

### DIFF
--- a/tools/probers/bazelrbe/bazelrbe.go
+++ b/tools/probers/bazelrbe/bazelrbe.go
@@ -20,7 +20,7 @@ import (
 var (
 	bazelBinary = flag.String("bazel_binary", "", "Path to bazel binary")
 	bazelArgs   = flag.String("bazel_args", "", "Space separated list of args to pass to Bazel")
-	proberName  = flag.String("prober_name", "", "Short, human-readable name of this prober")
+	proberName  = flag.String("prober_name", "", "Short, human-readable name of this prober. This name must be a valid bazel package name (only '.', '@', '-', '_' and alphanumeric characters allowed).")
 
 	numTargets         = flag.Int("num_targets", 10, "Number targets to generate")
 	numInputsPerTarget = flag.Int("num_inputs_per_target", 10, "Number of inputs each generated target will have")
@@ -66,7 +66,7 @@ func createWorkspace(dir string, numTargets, numInputsPerTarget, inputSizeBytes 
 
 	if *proberName != "" {
 		dir = dir + "/" + *proberName
-		err := os.Mkdir(dir, 0777)
+		err := os.Mkdir(dir, 0755)
 		if err != nil {
 			return err
 		}

--- a/tools/probers/bazelrbe/bazelrbe.go
+++ b/tools/probers/bazelrbe/bazelrbe.go
@@ -20,6 +20,7 @@ import (
 var (
 	bazelBinary = flag.String("bazel_binary", "", "Path to bazel binary")
 	bazelArgs   = flag.String("bazel_args", "", "Space separated list of args to pass to Bazel")
+	proberName  = flag.String("prober_name", "", "Short, human-readable name of this prober")
 
 	numTargets         = flag.Int("num_targets", 10, "Number targets to generate")
 	numInputsPerTarget = flag.Int("num_inputs_per_target", 10, "Number of inputs each generated target will have")
@@ -61,6 +62,14 @@ func createWorkspace(dir string, numTargets, numInputsPerTarget, inputSizeBytes 
 	err := os.WriteFile(filepath.Join(dir, "WORKSPACE"), []byte(""), 0644)
 	if err != nil {
 		return err
+	}
+
+	if *proberName != "" {
+		dir = dir + "/" + *proberName
+		err := os.Mkdir(dir, 0777)
+		if err != nil {
+			return err
+		}
 	}
 
 	buildFile, err := os.Create(filepath.Join(dir, "BUILD"))
@@ -114,7 +123,7 @@ func runProbe() error {
 		return status.UnknownErrorf("Could not populate workspace: %s", err)
 	}
 
-	args := []string{"//:all"}
+	args := []string{"//" + *proberName + ":all"}
 	if *bazelArgs != "" {
 		for _, extraArg := range strings.Split(*bazelArgs, " ") {
 			args = append(args, extraArg)


### PR DESCRIPTION
When set, this option creates and builds the probed target under '//name' instead of '//' which should make it easier to idenfy prober invocations. When the option is unset, the default behavior is the same as today.

**Version bump**: None
**Related issues**: Unblocks https://github.com/buildbuddy-io/buildbuddy-internal/issues/1905