### PR TITLE
Use a regular mutex for APIKeyGroupCache

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -373,7 +373,7 @@ type apiKeyGroupCache struct {
 	// time to force a refresh of the underlying data.
 	lru interfaces.LRU
 	ttl time.Duration
-	mu  sync.RWMutex
+	mu  sync.Mutex
 }
 
 func newAPIKeyGroupCache() (*apiKeyGroupCache, error) {
@@ -389,9 +389,9 @@ func newAPIKeyGroupCache() (*apiKeyGroupCache, error) {
 }
 
 func (c *apiKeyGroupCache) Get(apiKey string) (akg interfaces.APIKeyGroup, ok bool) {
-	c.mu.RLock()
+	c.mu.Lock()
 	v, ok := c.lru.Get(apiKey)
-	c.mu.RUnlock()
+	c.mu.Unlock()
 	if !ok {
 		return nil, ok
 	}


### PR DESCRIPTION
`lru.Get` mutates the LRU.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
