### PR TITLE
Add bazel-5.3.2 and bazel-6.0.0 to //server/util/bazel:bazel_binaries_tar

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6053,6 +6053,18 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         executable = True,
     )
     http_file(
+        name = "io_bazel_bazel-6.0.0-darwin-x86_64",
+        sha256 = "8e543c5c9f1c8c91df945cd2fb4c3b43587929a43044a0ed87d13da0d19f96e8",
+        urls = ["https://github.com/bazelbuild/bazel/releases/download/6.0.0/bazel-6.0.0-darwin-x86_64"],
+        executable = True,
+    )
+    http_file(
+        name = "io_bazel_bazel-6.0.0-linux-x86_64",
+        sha256 = "f03d44ecaac3878e3d19489e37caa4ca1dc57427b686a78a85065ea3c27ebe68",
+        urls = ["https://github.com/bazelbuild/bazel/releases/download/6.0.0/bazel-6.0.0-linux-x86_64"],
+        executable = True,
+    )
+    http_file(
         name = "io_bazel_bazelisk-1.10.1-darwin-amd64",
         sha256 = "e485bbf84532d02a60b0eb23c702610b5408df3a199087a4f2b5e0995bbf2d5a",
         urls = ["https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-darwin-amd64"],

--- a/server/util/bazel/BUILD
+++ b/server/util/bazel/BUILD
@@ -45,11 +45,32 @@ extract_bazel_installation(
     visibility = ["//visibility:public"],
 )
 
+genrule(
+    name = "bazel-6.0.0_crossplatform",
+    srcs = select({
+        "@bazel_tools//src/conditions:darwin": ["@io_bazel_bazel-6.0.0-darwin-x86_64//file:downloaded"],
+        "//conditions:default": ["@io_bazel_bazel-6.0.0-linux-x86_64//file:downloaded"],
+    }),
+    outs = ["bazel-6.0.0"],
+    cmd_bash = "cp $(SRCS) $@",
+    executable = True,
+    visibility = ["//visibility:public"],
+)
+
+extract_bazel_installation(
+    name = "bazel-6.0.0_extract_installation",
+    bazel = ":bazel-6.0.0_crossplatform",
+    out_dir = "bazel-6.0.0_install",
+    visibility = ["//visibility:public"],
+)
+
 pkg_tar(
     name = "bazel_binaries_tar",
     srcs = [
         ":bazel-3.7_crossplatform",
         ":bazel-4.1_crossplatform",
+        ":bazel-5.3.2_crossplatform",
+        ":bazel-6.0.0_crossplatform",
     ],
     package_dir = "/bazel",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
I thiiiiink this will make them available to call from the probers.

**Version bump**: None
**Related issues**: Unblocks https://github.com/buildbuddy-io/buildbuddy-internal/issues/1904