### PR TITLE
Performance: Optimize API key redaction

### DIFF
--- a/server/util/redact/BUILD
+++ b/server/util/redact/BUILD
@@ -26,5 +26,6 @@ go_test(
         "//server/testutil/testenv",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//encoding/protojson",
     ],
 )

--- a/server/util/redact/redact.go
+++ b/server/util/redact/redact.go
@@ -2,6 +2,7 @@ package redact
 
 import (
 	"context"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -457,19 +458,84 @@ func (r *StreamingRedactor) RedactMetadata(event *bespb.BuildEvent) {
 
 func (r *StreamingRedactor) RedactAPIKey(ctx context.Context, event *bespb.BuildEvent) error {
 	apiKey, ok := ctx.Value("x-buildbuddy-api-key").(string)
-	if !ok {
+	if !ok || apiKey == "" {
 		return nil
 	}
+	// Traverse the event with reflection and redact any values that may contain
+	// an API key.
+	// Note: a find-and-replace on the prototext representation would be a much
+	// simpler option, but it also has much higher CPU/memory overhead.
+	reflectRedactAPIKey(reflect.ValueOf(event), apiKey)
+	return nil
+}
 
-	txt, err := prototext.Marshal(event)
-	if err != nil {
-		return err
+func reflectRedactAPIKey(value reflect.Value, apiKey string) *reflect.Value {
+	switch value.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		if !value.IsValid() {
+			return nil
+		}
+		redactedValue := reflectRedactAPIKey(value.Elem(), apiKey)
+		if redactedValue != nil {
+			value.Elem().Set(*redactedValue)
+		}
+		return nil
+	case reflect.Struct:
+		for i := 0; i < value.NumField(); i += 1 {
+			f := value.Field(i)
+			if !f.CanSet() {
+				// Skip private fields
+				continue
+			}
+			redactedValue := reflectRedactAPIKey(f, apiKey)
+			if redactedValue != nil {
+				f.Set(*redactedValue)
+			}
+		}
+		return nil
+	case reflect.Slice:
+		for i := 0; i < value.Len(); i += 1 {
+			f := value.Index(i)
+			redactedValue := reflectRedactAPIKey(f, apiKey)
+			if redactedValue != nil {
+				f.Set(*redactedValue)
+			}
+		}
+		return nil
+	case reflect.Map:
+		type replacement struct{ originalKey, redactedKey, redactedValue reflect.Value }
+		var replacements []replacement
+		for _, key := range value.MapKeys() {
+			redactedKey := reflectRedactAPIKey(key, apiKey)
+			redactedValue := reflectRedactAPIKey(value.MapIndex(key), apiKey)
+			if redactedValue != nil {
+				value.SetMapIndex(key, *redactedValue)
+			}
+			if redactedKey != nil {
+				replacements = append(replacements, replacement{key, *redactedKey, value.MapIndex(key)})
+			}
+		}
+		for _, r := range replacements {
+			// Delete old key
+			value.SetMapIndex(r.originalKey, reflect.Value{})
+			// Replace with redacted entry
+			value.SetMapIndex(r.redactedKey, r.redactedValue)
+		}
+		return nil
+	case reflect.String:
+		s := value.String()
+		if !strings.Contains(s, apiKey) {
+			return nil
+		}
+		redacted := strings.ReplaceAll(s, apiKey, "<REDACTED>")
+		redactedValue := reflect.ValueOf(redacted)
+		// Return the redacted string back to the caller so that it can update
+		// the containing element with the redacted string.
+		return &redactedValue
+	default:
+		// Not a string or a type that can contain a string; nothing to redact.
+		return nil
 	}
-	// TODO: Show the display label of the API key that was redacted, if we can
-	// get that info efficiently.
-	txt = []byte(strings.ReplaceAll(string(txt), apiKey, "<REDACTED>"))
-
-	return prototext.Unmarshal(txt, event)
 }
 
 func (r *StreamingRedactor) RedactAPIKeysWithSlowRegexp(ctx context.Context, event *bespb.BuildEvent) error {

--- a/server/util/redact/redact_test.go
+++ b/server/util/redact/redact_test.go
@@ -1,6 +1,7 @@
 package redact_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/redact"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	clpb "github.com/buildbuddy-io/buildbuddy/proto/command_line"
@@ -292,4 +294,58 @@ func TestRedactMetadata_WorkspaceStatus_StripsRepoURLCredentials(t *testing.T) {
 
 	require.Equal(t, 1, len(workspaceStatus.Item))
 	assert.Equal(t, "https://github.com/buildbuddy-io/metadata_repo_url", workspaceStatus.Item[0].Value)
+}
+
+func TestRedactAPIKey(t *testing.T) {
+	apiKey := "abc123"
+	notAPIKey := "Hello world!"
+
+	// Declare a list of events to be redacted, where each event contains an
+	// API key and a string not containing an API key.
+	events := []*bespb.BuildEvent{
+		// API key appearing as struct field value
+		{Payload: &bespb.BuildEvent_Progress{Progress: &bespb.Progress{
+			Stdout: notAPIKey,
+			Stderr: apiKey,
+		}}},
+		// API key appearing as repeated field value
+		{Payload: &bespb.BuildEvent_UnstructuredCommandLine{UnstructuredCommandLine: &bespb.UnstructuredCommandLine{
+			Args: []string{notAPIKey, apiKey},
+		}}},
+		// API key appearing as map value
+		{Payload: &bespb.BuildEvent_BuildMetadata{BuildMetadata: &bespb.BuildMetadata{
+			Metadata: map[string]string{
+				"FOO": apiKey,
+				"BAR": notAPIKey,
+			},
+		}}},
+		// API key appearing as map key
+		{Payload: &bespb.BuildEvent_BuildMetadata{BuildMetadata: &bespb.BuildMetadata{
+			Metadata: map[string]string{
+				apiKey: notAPIKey,
+			},
+		}}},
+		// API key appearing as a string nested inside a list of structs
+		{Payload: &bespb.BuildEvent_Expanded{Expanded: &bespb.PatternExpanded{
+			TestSuiteExpansions: []*bespb.PatternExpanded_TestSuiteExpansion{
+				{
+					SuiteLabel: apiKey + "_" + notAPIKey,
+					TestLabels: []string{apiKey, notAPIKey},
+				},
+			},
+		}}},
+	}
+	redactor := redact.NewStreamingRedactor(testenv.GetTestEnv(t))
+	ctx := context.WithValue(context.Background(), "x-buildbuddy-api-key", apiKey)
+
+	for _, e := range events {
+		err := redactor.RedactAPIKey(ctx, e)
+
+		require.NoError(t, err)
+		b, err := protojson.MarshalOptions{Multiline: true}.Marshal(e)
+		json := string(b)
+		require.NotContains(t, json, apiKey)
+		require.Contains(t, json, "<REDACTED>")
+		require.Contains(t, json, notAPIKey)
+	}
 }


### PR DESCRIPTION
(Credit to @vadimberezniker for suggesting this optimization)

Instead of Marshaling/Unmarshaling each build event to redact API keys, redact by traversing the object structure with reflection and redacting any strings encountered. This should save about 1% of total CPU usage in prod.

For a stream of 1800 build events (`bb build //...` in the buildbuddy repo), saves 600K allocations totaling 44MB, and has 20X lower CPU overhead.

```
BenchmarkRedact_MarshalUnmarshal-8            16          69822699 ns/op        44800414 B/op     603938 allocs/op
BenchmarkRedact_Reflect-8                    357           3166731 ns/op             784 B/op         31 allocs/op
```

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
