### PR TITLE
Silence scanBrokenFiles noise.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -672,8 +672,9 @@ func (p *PebbleCache) scanForBrokenFiles(quitChan chan struct{}) error {
 		blobDir = p.blobDir(pathHasDupPartitionID, fileMetadata.GetFileRecord().GetIsolation().GetPartitionId())
 		_, err := p.fileStorer.NewReader(p.env.GetServerContext(), blobDir, fileMetadata.GetStorageMetadata(), 0, 0)
 		if err != nil {
-			p.handleMetadataMismatch(p.env.GetServerContext(), err, fileMetadataKey, fileMetadata)
-			mismatchCount += 1
+			if p.handleMetadataMismatch(p.env.GetServerContext(), err, fileMetadataKey, fileMetadata) {
+				mismatchCount += 1
+			}
 		}
 	}
 	log.Infof("Pebble Cache: scanForBrokenFiles fixed %d files", mismatchCount)
@@ -853,16 +854,23 @@ func readFileMetadata(reader pebble.Reader, fileMetadataKey []byte) (*rfpb.FileM
 	return fileMetadata, nil
 }
 
-func (p *PebbleCache) handleMetadataMismatch(ctx context.Context, err error, fileMetadataKey []byte, fileMetadata *rfpb.FileMetadata) {
+func (p *PebbleCache) handleMetadataMismatch(ctx context.Context, err error, fileMetadataKey []byte, fileMetadata *rfpb.FileMetadata) bool {
 	if !status.IsNotFoundError(err) && !os.IsNotExist(err) {
-		return
+		return false
 	}
 	if fileMetadata.GetStorageMetadata().GetFileMetadata() != nil {
-		log.Warningf("Metadata record %q was found but file (%+v) not found on disk: %s", fileMetadataKey, fileMetadata, err)
-		if err := p.deleteMetadataOnly(ctx, fileMetadataKey); err != nil {
-			log.Warningf("Error deleting metadata: %s", err)
+		err := p.deleteMetadataOnly(ctx, fileMetadataKey)
+		if err != nil && status.IsNotFoundError(err) {
+			return false
 		}
+		log.Warningf("Metadata record %q was found but file (%+v) not found on disk: %s", fileMetadataKey, fileMetadata, err)
+		if err != nil {
+			log.Warningf("Error deleting metadata: %s", err)
+			return false
+		}
+		return true
 	}
+	return false
 }
 
 func (p *PebbleCache) Contains(ctx context.Context, r *resource.ResourceName) (bool, error) {

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -854,8 +854,8 @@ func readFileMetadata(reader pebble.Reader, fileMetadataKey []byte) (*rfpb.FileM
 	return fileMetadata, nil
 }
 
-func (p *PebbleCache) handleMetadataMismatch(ctx context.Context, err error, fileMetadataKey []byte, fileMetadata *rfpb.FileMetadata) bool {
-	if !status.IsNotFoundError(err) && !os.IsNotExist(err) {
+func (p *PebbleCache) handleMetadataMismatch(ctx context.Context, causeErr error, fileMetadataKey []byte, fileMetadata *rfpb.FileMetadata) bool {
+	if !status.IsNotFoundError(causeErr) && !os.IsNotExist(causeErr) {
 		return false
 	}
 	if fileMetadata.GetStorageMetadata().GetFileMetadata() != nil {
@@ -863,7 +863,7 @@ func (p *PebbleCache) handleMetadataMismatch(ctx context.Context, err error, fil
 		if err != nil && status.IsNotFoundError(err) {
 			return false
 		}
-		log.Warningf("Metadata record %q was found but file (%+v) not found on disk: %s", fileMetadataKey, fileMetadata, err)
+		log.Warningf("Metadata record %q was found but file (%+v) not found on disk: %s", fileMetadataKey, fileMetadata, causeErr)
 		if err != nil {
 			log.Warningf("Error deleting metadata: %s", err)
 			return false


### PR DESCRIPTION
Don't log anything if the metadata key is already gone. There's a race between the scanner and the evictor.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
