### PR TITLE
Don't assume CI role if CI env var is empty

### DIFF
--- a/server/build_event_protocol/accumulator/accumulator.go
+++ b/server/build_event_protocol/accumulator/accumulator.go
@@ -235,9 +235,13 @@ func (v *BEValues) populateWorkspaceInfoFromStructuredCommandLine(commandLine *c
 			case "CIRCLE_SHA1", "GITHUB_SHA", "BUILDKITE_COMMIT", "TRAVIS_COMMIT", "GIT_COMMIT", "CI_COMMIT_SHA", "COMMIT_SHA", "VOLATILE_GIT_COMMIT":
 				v.setStringValue(commitSHAFieldName, value)
 			case "CI":
-				v.setStringValue(roleFieldName, "CI")
+				if value != "" {
+					v.setStringValue(roleFieldName, "CI")
+				}
 			case "CI_RUNNER":
-				v.setStringValue(roleFieldName, "CI_RUNNER")
+				if value != "" {
+					v.setStringValue(roleFieldName, "CI_RUNNER")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This is part of the refactor to consolidate `Accumulator` and `EventParser`. Before fully consolidating those two, we need to resolve any discrepancies in the way that they compute invocation fields. This PR _partially_ resolves a discrepancy in the computation of the `role` field.

For some invocations, the env var `CI` is set to an empty string. With the current logic, the `Accumulator` sees this and sets `ROLE=CI`, but `EventParser` does not.

Since `Accumulator` is used for commit status reporting and target tracking, this means commit statuses _may_ be reported and targets _may_ be tracked, since both of those require `ROLE=CI`. But since `EventParser` is used for DB columns, this means the invocation will show in the UI as a non-CI invocation.

The change in this PR attempts to resolve this inconsistency by having the `Accumulator` treat `CI=<empty>` as though it is not set at all (same as what the `EventParser` does).

From the logs, only 1 org appears to be affected, and that org appears to be setting `CI=true` for their actual CI invocations, and `CI=` for some other invocations which look like they want to treat as local invocations. So overall, this change should be OK.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
