### PR TITLE
Allow setting role via workspace_status

### DIFF
--- a/server/build_event_protocol/accumulator/accumulator.go
+++ b/server/build_event_protocol/accumulator/accumulator.go
@@ -263,6 +263,9 @@ func (v *BEValues) populateWorkspaceInfoFromWorkspaceStatus(workspace *build_eve
 		if item.Key == "COMMIT_SHA" {
 			v.setStringValue(commitSHAFieldName, item.Value)
 		}
+		if item.Key == "ROLE" {
+			v.setStringValue(roleFieldName, item.Value)
+		}
 	}
 }
 


### PR DESCRIPTION
This is part of the refactor to consolidate Accumulator and EventParser. Before fully consolidating those two, we need to resolve any discrepancies in the way that they compute invocation fields. This PR partially resolves a discrepancy in the computation of the role field.

Currently, `EventParser` allows setting ROLE via workspace_status.sh (although we don't document this in the metadata guide), which means that the ROLE returned from workspace_status.sh will propagate to the invocation DB.

However, `Accumulator` doesn't respect ROLE in workspace_status.sh, so the ROLE set there will not be observed by build_status_reporter or target_tracker. This means that the invocation will show up in the UI with the "CI" label, but will not appear in the Test grid or in GitHub statuses.

This PR resolves the discrepancy by allowing build statuses to be reported and targets to be tracked if ROLE is only set via workspace_status.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
