### PR TITLE
Add direct group navigation (admin-only)

### DIFF
--- a/app/auth/user.ts
+++ b/app/auth/user.ts
@@ -19,4 +19,8 @@ export class User {
   canCall(rpc: BuildBuddyServiceRpcName) {
     return this.allowedRpcs.has(rpc);
   }
+
+  canImpersonate() {
+    return this.allowedRpcs.has("getInvocationOwner");
+  }
 }

--- a/enterprise/app/group_search/BUILD
+++ b/enterprise/app/group_search/BUILD
@@ -1,0 +1,17 @@
+load("//rules/typescript:index.bzl", "ts_library")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+ts_library(
+    name = "group_search",
+    srcs = glob(["*.tsx"]),
+    deps = [
+        "//app/auth",
+        "//app/components/dialog:simple_modal_dialog",
+        "//app/components/input",
+        "//app/errors",
+        "//app/service",
+        "@npm//@types/react",
+        "@npm//react",
+    ],
+)

--- a/enterprise/app/group_search/group_search.tsx
+++ b/enterprise/app/group_search/group_search.tsx
@@ -32,11 +32,19 @@ export default class GroupSearchComponent extends React.Component<{}, State> {
   }
 
   private onSearch() {
+    const query = this.state.query.trim();
+
+    // If the query looks like a group ID, navigate directly to it.
+    if (query.startsWith("GR")) {
+      const groupId = query;
+      auth_service.enterImpersonationMode(groupId);
+      return;
+    }
+
+    // Otherwise try to look up the group by its exact URL identifier.
     this.setState({ loading: true });
-    // Only support exact match on URL identifier for now.
-    const urlIdentifier = this.state.query.trim();
     rpc_service.service
-      .getGroup({ urlIdentifier })
+      .getGroup({ urlIdentifier: query })
       .then((response) => auth_service.enterImpersonationMode(response.id))
       .catch((e) => error_service.handleError(e))
       .finally(() => this.setState({ loading: false }));
@@ -45,7 +53,7 @@ export default class GroupSearchComponent extends React.Component<{}, State> {
   render() {
     return (
       <SimpleModalDialog
-        title="Find org"
+        title="Go to org"
         submitLabel="Search"
         isOpen={this.state.visible}
         onRequestClose={this.onClose.bind(this)}
@@ -54,7 +62,7 @@ export default class GroupSearchComponent extends React.Component<{}, State> {
         <TextInput
           value={this.state.query}
           onChange={this.onChangeQuery.bind(this)}
-          placeholder="URL identifier (example: 'acme-inc')"
+          placeholder="Group ID ('GR1234...') or URL identifier ('acme-inc')"
           style={{ width: "100%" }}
           autoFocus
         />

--- a/enterprise/app/root/BUILD.bazel
+++ b/enterprise/app/root/BUILD.bazel
@@ -24,6 +24,7 @@ ts_library(
         "//app/service",
         "//enterprise/app/code",
         "//enterprise/app/executors",
+        "//enterprise/app/group_search",
         "//enterprise/app/history",
         "//enterprise/app/login",
         "//enterprise/app/org",

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -20,6 +20,7 @@ import SidebarComponent from "../sidebar/sidebar";
 import TapComponent from "../tap/tap";
 import TrendsComponent from "../trends/trends";
 import UsageComponent from "../usage/usage";
+import GroupSearchComponent from "../group_search/group_search";
 import { AlertCircle, LogOut } from "lucide-react";
 import { OutlinedButton } from "../../../app/components/button/button";
 const CodeComponent = React.lazy(() => import("../code/code"));
@@ -153,7 +154,8 @@ export default class EnterpriseRootComponent extends React.Component {
           <div className="impersonation-toolbar">
             <AlertCircle className="icon black" />
             <span>
-              Authenticated as a member of <b>{this.state.user.selectedGroupName()}</b>. Proceed with caution.
+              Authenticated as a member of <b>{this.state.user.selectedGroupName()}</b> (
+              {this.state.user.selectedGroup?.id}). Proceed with caution.
             </span>
             <OutlinedButton onClick={this.handleExitImpersonationModeClicked.bind(this)}>
               <span>Exit</span>
@@ -309,6 +311,7 @@ export default class EnterpriseRootComponent extends React.Component {
               {this.state.loading && <div className="loading loading-dark"></div>}
             </div>
           </div>
+          <GroupSearchComponent />
           <AlertComponent />
         </div>
       </>

--- a/enterprise/app/sidebar/sidebar.css
+++ b/enterprise/app/sidebar/sidebar.css
@@ -109,6 +109,10 @@
   color: #90a4ae;
 }
 
+.sidebar .sidebar-item.admin-only {
+  color: #ffc107;
+}
+
 .sidebar .sidebar-item:hover,
 .sidebar .sidebar-item.selected {
   color: #fff;

--- a/enterprise/app/sidebar/sidebar.tsx
+++ b/enterprise/app/sidebar/sidebar.tsx
@@ -18,6 +18,7 @@ import {
   List,
   LogOut,
   PlusCircle,
+  Search,
   Sliders,
   Terminal,
 } from "lucide-react";
@@ -49,6 +50,10 @@ export default class SidebarComponent extends React.Component<Props, State> {
 
   handleCreateOrgClicked(e: React.MouseEvent) {
     router.navigateToCreateOrg();
+  }
+
+  handleSearchGroupsClicked() {
+    window.dispatchEvent(new CustomEvent("groupSearchClick"));
   }
 
   async handleOrgClicked(groupId: string) {
@@ -211,6 +216,12 @@ export default class SidebarComponent extends React.Component<Props, State> {
                   <div className="sidebar-item create-organization" onClick={this.handleCreateOrgClicked.bind(this)}>
                     <PlusCircle className="icon" />
                     Create org
+                  </div>
+                )}
+                {Boolean(this.props.user?.canImpersonate()) && (
+                  <div className="sidebar-item admin-only" onClick={this.handleSearchGroupsClicked.bind(this)}>
+                    <Search className="icon" />
+                    Find org
                   </div>
                 )}
               </div>

--- a/enterprise/app/sidebar/sidebar.tsx
+++ b/enterprise/app/sidebar/sidebar.tsx
@@ -18,7 +18,7 @@ import {
   List,
   LogOut,
   PlusCircle,
-  Search,
+  ArrowRightCircle,
   Sliders,
   Terminal,
 } from "lucide-react";
@@ -220,8 +220,8 @@ export default class SidebarComponent extends React.Component<Props, State> {
                 )}
                 {Boolean(this.props.user?.canImpersonate()) && (
                   <div className="sidebar-item admin-only" onClick={this.handleSearchGroupsClicked.bind(this)}>
-                    <Search className="icon" />
-                    Find org
+                    <ArrowRightCircle className="icon" />
+                    Go to org
                   </div>
                 )}
               </div>


### PR DESCRIPTION
This allows impersonating a group directly (by group ID or slug), rather than needing an invocation ID (which is often inconvenient).

https://user-images.githubusercontent.com/2414826/210277974-d76a5494-e792-49d6-900b-bce15c143603.mp4

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
