### PR TITLE
cacheload: Fix logic for `--blob_size=0`

### DIFF
--- a/tools/cacheload/cacheload.go
+++ b/tools/cacheload/cacheload.go
@@ -85,7 +85,7 @@ func randRange(low, high int) int64 {
 }
 
 func randomBlobSize() int64 {
-	if *blobSize > 0 {
+	if *blobSize >= 0 {
 		return *blobSize
 	}
 	n := rand.Intn(histCountsTotal)


### PR DESCRIPTION
The existing flag defaults to -1 (meaning "use realistic blob sizes") so that we can support 0 as a valid value, but the impl doesn't handle 0 properly. This PR fixes that.

Ran into this bug while trying to use `--blob_size=0` to measure the maximum possible read QPS independent of disk I/O, since the bytestream server handles 0 as a special case and returns immediately.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
