### PR TITLE
cacheload: Support compressed reads/writes

### DIFF
--- a/server/remote_cache/digest/BUILD
+++ b/server/remote_cache/digest/BUILD
@@ -26,7 +26,9 @@ go_test(
     embed = [":digest"],
     deps = [
         "//proto:remote_execution_go_proto",
+        "//server/util/compression",
         "//server/util/status",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//status",
     ],

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -4,7 +4,9 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/compression"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -196,5 +198,19 @@ func TestDiff(t *testing.T) {
 		got1, got2 := Diff(tc.s1, tc.s2)
 		require.ElementsMatch(t, tc.expectedMissingFromS1, got1)
 		require.ElementsMatch(t, tc.expectedMissingFromS2, got2)
+	}
+}
+
+func TestRandomGenerator(t *testing.T) {
+	const expectedCompression = 0.3
+	gen := RandomGenerator(0)
+
+	for _, size := range []int64{1_000, 10_000, 100_000} {
+		d, b, err := gen.RandomDigestBuf(size)
+		cb := compression.CompressZstd(nil, b)
+
+		require.NoError(t, err)
+		require.Equal(t, size, d.SizeBytes)
+		assert.InDelta(t, int(float64(size)*expectedCompression), len(cb), float64(size)*0.20, "should get approximately 0.3 compression ratio")
 	}
 }


### PR DESCRIPTION
- Allow passing `--read_compressed` or `--write_compressed` to compress reads/writes, respectively.
- Update random digest generator so that it generates blobs that are approximately 70% compressible.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
