### PR TITLE
Add error if we try to pass offset or limit to cache reader for compressed data

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1142,6 +1142,10 @@ func (p *PebbleCache) Delete(ctx context.Context, r *resource.ResourceName) erro
 }
 
 func (p *PebbleCache) Reader(ctx context.Context, r *resource.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+	if r.GetCompressor() != repb.Compressor_IDENTITY && (uncompressedOffset != 0 || limit != 0) {
+		return nil, status.InvalidArgumentError("offsets and limits apply to uncompressed data and cannot be passed to a compressed reader")
+	}
+
 	db, err := p.leaser.DB()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We added a check in the byte stream server to not use compression if we're using an offset or limit, but we should add an error in the cache itself so if we accidentally do this in the future it will be more clear what the problem is
