### PR TITLE
Use background context to record executions

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -305,10 +305,9 @@ func (s *ExecutionServer) recordExecution(ctx context.Context, executionID strin
 	}
 	var executionPrimaryDB tables.Execution
 
-	// Don't use the stream context since we still want to write executions into
-	// clickhouse when stream context is cancelled.
-	ctx, cancel := context.WithTimeout(context.Background(), recordExecutionsTimeout)
-	ctx = log.EnrichContext(ctx, log.ExecutionIDKey, executionID)
+	// we need more time to want write executions into clickhouse when stream
+	// context is cancelled.
+	ctx, cancel := background.ExtendContextForFinalization(ctx, recordExecutionsTimeout)
 	defer cancel()
 
 	if err := s.env.GetDBHandle().DB(ctx).Where("execution_id = ?", executionID).First(&executionPrimaryDB).Error; err != nil {

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -49,7 +49,8 @@ import (
 
 const (
 	// TTL for keys used to track pending executions for action merging.
-	pendingExecutionTTL = 8 * time.Hour
+	pendingExecutionTTL     = 8 * time.Hour
+	recordExecutionsTimeout = 15 * time.Second
 )
 
 var (
@@ -292,7 +293,7 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 
 	if stage == repb.ExecutionStage_COMPLETED {
 		if err := s.recordExecution(ctx, executionID); err != nil {
-			log.CtxErrorf(ctx, "failed to record execution: %s", err)
+			log.CtxErrorf(ctx, "failed to record execution %q: %s", executionID, err)
 		}
 	}
 	return dbErr
@@ -303,12 +304,19 @@ func (s *ExecutionServer) recordExecution(ctx context.Context, executionID strin
 		return nil
 	}
 	var executionPrimaryDB tables.Execution
+
+	// Don't use the stream context since we still want to write executions into
+	// clickhouse when stream context is cancelled.
+	ctx, cancel := context.WithTimeout(context.Background(), recordExecutionsTimeout)
+	ctx = log.EnrichContext(ctx, log.ExecutionIDKey, executionID)
+	defer cancel()
+
 	if err := s.env.GetDBHandle().DB(ctx).Where("execution_id = ?", executionID).First(&executionPrimaryDB).Error; err != nil {
-		return status.InternalErrorf("failed to look up execution: %s", err)
+		return status.InternalErrorf("failed to look up execution %q: %s", executionID, err)
 	}
 	links, err := s.getInvocationLinks(ctx, executionID)
 	if err != nil {
-		return status.InternalErrorf("failed to get invocations for execution: %s", err)
+		return status.InternalErrorf("failed to get invocations for execution %q: %s", executionID, err)
 	}
 
 	for _, link := range links {


### PR DESCRIPTION
We still want to record cancelled executions in clickhouse.
Also, add execution id in logging message b/c we didn't enrich context for
PublishOperation.
