### PR TITLE
Add histogram metric for item eviction age.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1869,6 +1869,8 @@ func (e *partitionEvictor) evict(count int) (*evictionPoolEntry, error) {
 			}
 			lbls := prometheus.Labels{metrics.PartitionID: e.part.ID, metrics.CacheNameLabel: e.cacheName}
 			metrics.DiskCacheNumEvictions.With(lbls).Inc()
+			age := time.Since(time.Unix(0, sample.timestamp))
+			metrics.DiskCacheEvictionAgeUsec.With(lbls).Observe(float64(age.Microseconds()))
 			evicted += 1
 			lastEvicted = sample
 			e.samplePool = append(e.samplePool[:i], e.samplePool[i+1:]...)

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -387,6 +387,17 @@ var (
 		CacheNameLabel,
 	})
 
+	DiskCacheEvictionAgeUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "disk_cache_eviction_age_usec",
+		Buckets:   durationUsecBuckets(1*time.Hour, 30*24*time.Hour, 2),
+		Help:      "Age of items evicted from the cache, in **microseconds**.",
+	}, []string{
+		PartitionID,
+		CacheNameLabel,
+	})
+
 	DiskCacheNumEvictions = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",
@@ -435,14 +446,6 @@ var (
 		Help:      "Number of writes for digests that already exist.",
 	}, []string{
 		CacheNameLabel,
-	})
-
-	DiskCacheUsecSinceLastAccess = promauto.NewHistogram(prometheus.HistogramOpts{
-		Namespace: bbNamespace,
-		Subsystem: "remote_cache",
-		Name:      "disk_cache_usec_since_last_access",
-		Help:      "Time since last digest access, in **microseconds**.",
-		Buckets:   durationUsecBuckets(1*time.Microsecond, 30*day, 10),
 	})
 
 	DiskCacheAddedFileSizeBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION
It's like a last evicted gauge, but better.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
