### PR TITLE
Use milliseconds for eviction age histogram.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1870,7 +1870,7 @@ func (e *partitionEvictor) evict(count int) (*evictionPoolEntry, error) {
 			lbls := prometheus.Labels{metrics.PartitionID: e.part.ID, metrics.CacheNameLabel: e.cacheName}
 			metrics.DiskCacheNumEvictions.With(lbls).Inc()
 			age := time.Since(time.Unix(0, sample.timestamp))
-			metrics.DiskCacheEvictionAgeUsec.With(lbls).Observe(float64(age.Microseconds()))
+			metrics.DiskCacheEvictionAgeMsec.With(lbls).Observe(float64(age.Milliseconds()))
 			evicted += 1
 			lastEvicted = sample
 			e.samplePool = append(e.samplePool[:i], e.samplePool[i+1:]...)

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -161,8 +161,8 @@ func (pu *partitionUsage) evict(ctx context.Context, sample *approxlru.Sample[*R
 		return false, status.InternalErrorf("eviction request failed: %s", rsp.AnyError())
 	}
 
-	ageUsec := float64(time.Since(sample.Timestamp).Microseconds())
-	metrics.RaftEvictionAgeUsec.With(prometheus.Labels{metrics.PartitionID: pu.id}).Observe(ageUsec)
+	ageMillis := float64(time.Since(sample.Timestamp).Milliseconds())
+	metrics.RaftEvictionAgeMsec.With(prometheus.Labels{metrics.PartitionID: pu.id}).Observe(ageMillis)
 
 	globalSizeBytes := pu.GlobalSizeBytes()
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -387,12 +387,14 @@ var (
 		CacheNameLabel,
 	})
 
-	DiskCacheEvictionAgeUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	// This metric is in milliseconds because Grafana heatmaps don't display
+	// microsecond durations nicely when they can contain large durations.
+	DiskCacheEvictionAgeMsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",
-		Name:      "disk_cache_eviction_age_usec",
-		Buckets:   durationUsecBuckets(1*time.Hour, 30*24*time.Hour, 2),
-		Help:      "Age of items evicted from the cache, in **microseconds**.",
+		Name:      "disk_cache_eviction_age_msec",
+		Buckets:   exponentialBucketRange(float64(1*time.Hour.Milliseconds()), float64(30*24*time.Hour.Milliseconds()), 2),
+		Help:      "Age of items evicted from the cache, in **milliseconds**.",
 	}, []string{
 		PartitionID,
 		CacheNameLabel,
@@ -1626,12 +1628,14 @@ var (
 		RaftRangeIDLabel,
 	})
 
-	RaftEvictionAgeUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	// This metric is in milliseconds because Grafana heatmaps don't display
+	// microsecond durations nicely when they can contain large durations.
+	RaftEvictionAgeMsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "raft",
-		Name:      "eviction_age_usec",
-		Buckets:   durationUsecBuckets(1*time.Hour, 30*24*time.Hour, 2),
-		Help:      "Age of items evicted from the cache, in **microseconds**.",
+		Name:      "eviction_age_msec",
+		Buckets:   exponentialBucketRange(float64(1*time.Hour.Milliseconds()), float64(30*24*time.Hour.Milliseconds()), 2),
+		Help:      "Age of items evicted from the cache, in **milliseconds**.",
 	}, []string{
 		PartitionID,
 	})


### PR DESCRIPTION
Unfortunately Grafana heatmaps don't display units nicely if they're in microseconds, only in milliseconds.

When the values are large, Grafana displays them in seconds instead of more friendlier units like hours, days, or weeks. This is not a problem for other metrics that don't typically contain such large durations. 

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
