### PR TITLE
Performance: Remove unused syscall in disk.FileReader

### DIFF
--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -205,12 +205,12 @@ func FileReader(ctx context.Context, fullPath string, offset, length int64) (io.
 	if err != nil {
 		return nil, err
 	}
+	if length > 0 {
+		return &readCloser{io.NewSectionReader(f, offset, length), f, ctx}, nil
+	}
 	info, err := f.Stat()
 	if err != nil {
 		return nil, err
-	}
-	if length > 0 {
-		return &readCloser{io.NewSectionReader(f, offset, length), f, ctx}, nil
 	}
 	return &readCloser{io.NewSectionReader(f, offset, info.Size()-offset), f, ctx}, nil
 }


### PR DESCRIPTION
When `length > 0`, we make a `stat` syscall and discard the result. This PR removes the unnecessary `stat`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
