### PR TITLE
Allow downloading single file in zipped test outputs, behind a flag. (Revert 3153 revert 3101 split shard artifacts)

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1125,6 +1125,10 @@ code .comment {
   display: flex;
 }
 
+.artifact-line.sub-item {
+  padding-left: 16px;
+}
+
 .artifact-name {
   font-weight: 600;
   text-decoration: underline;

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -44,7 +44,7 @@ class RpcService {
     return false;
   }
 
-  getBytestreamUrl(bytestreamURL: string, invocationId: string, { filename = "" } = {}): string {
+  getBytestreamUrl(bytestreamURL: string, invocationId: string, { filename = "", zip = "" } = {}): string {
     const encodedRequestContext = uint8ArrayToBase64(context.RequestContext.encode(this.requestContext).finish());
     const params: Record<string, string> = {
       bytestream_url: bytestreamURL,
@@ -52,11 +52,16 @@ class RpcService {
       request_context: encodedRequestContext,
     };
     if (filename) params.filename = filename;
+    if (zip) params.z = zip;
     return `/file/download?${new URLSearchParams(params)}`;
   }
 
   downloadBytestreamFile(filename: string, bytestreamURL: string, invocationId: string) {
     window.open(this.getBytestreamUrl(bytestreamURL, invocationId, { filename }));
+  }
+
+  downloadBytestreamZipFile(filename: string, bytestreamURL: string, zip: string, invocationId: string) {
+    window.open(this.getBytestreamUrl(bytestreamURL, invocationId, { filename, zip }));
   }
 
   fetchBytestreamFile(

--- a/app/target/BUILD
+++ b/app/target/BUILD
@@ -18,6 +18,7 @@ ts_library(
         "//app/util:proto",
         "//proto:build_event_stream_ts_proto",
         "//proto:invocation_ts_proto",
+        "//proto:zip_ts_proto",
         "@npm//@types/react",
         "@npm//lucide-react",
         "@npm//react",

--- a/app/target/target_artifacts_card.tsx
+++ b/app/target/target_artifacts_card.tsx
@@ -1,15 +1,80 @@
 import { ArrowDownCircle, FileCode } from "lucide-react";
 import React from "react";
 
+import { zip } from "../../proto/zip_ts_proto";
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
 import rpcService from "../service/rpc_service";
 
 interface Props {
+  name: string;
   files: build_event_stream.File[];
   invocationId: string;
 }
 
-export default class TargetArtifactsCardComponent extends React.Component<Props> {
+interface State {
+  loading: boolean;
+  manifest: zip.IManifest;
+}
+
+export default class TargetArtifactsCardComponent extends React.Component<Props, State> {
+  static readonly ZIPPED_OUTPUTS_FILE: string = "test.outputs__outputs.zip";
+
+  state: State = {
+    loading: false,
+    manifest: null,
+  };
+
+  componentDidMount() {
+    this.maybeFetchOutputManifest();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.files !== prevProps.files) {
+      this.maybeFetchOutputManifest();
+    }
+  }
+
+  maybeFetchOutputManifest() {
+    let testOutputsUri = this.props.files.find(
+      (file: build_event_stream.File) => true && file.name === TargetArtifactsCardComponent.ZIPPED_OUTPUTS_FILE
+    )?.uri;
+
+    if (!testOutputsUri || !testOutputsUri.startsWith("bytestream://")) {
+      return;
+    }
+
+    this.setState({ ...this.state, loading: true });
+    const request = new zip.GetZipManifestRequest();
+    request.uri = testOutputsUri;
+    rpcService.service
+      .getZipManifest(request)
+      .then((response) => {
+        this.setState({ ...this.state, manifest: response.manifest, loading: false });
+      })
+      .catch(() => {
+        this.setState({
+          ...this.state,
+          loading: false,
+          manifest: null,
+        });
+      });
+  }
+
+  encodeManifestEntry(entry: zip.IManifestEntry): string {
+    return btoa(
+      zip.ManifestEntry.encode(entry)
+        .finish()
+        .reduce((str, b) => str + String.fromCharCode(b), "")
+    );
+  }
+
+  makeArtifactUri(baseUri: string, entry: zip.IManifestEntry): string {
+    return rpcService.getBytestreamUrl(baseUri, this.props.invocationId, {
+      filename: entry.name,
+      zip: this.encodeManifestEntry(entry),
+    });
+  }
+
   handleArtifactClicked(outputUri: string, outputFilename: string, event: MouseEvent) {
     event.preventDefault();
     if (!outputUri) return false;
@@ -22,33 +87,64 @@ export default class TargetArtifactsCardComponent extends React.Component<Props>
     return false;
   }
 
+  handleZipArtifactClicked(outputUri: string, outputFilename: string, entry: zip.IManifestEntry, event: MouseEvent) {
+    event.preventDefault();
+    if (!outputUri) return false;
+
+    if (outputUri.startsWith("file://")) {
+      window.prompt("Copy artifact path to clipboard: Cmd+C, Enter", outputUri);
+    } else if (outputUri.startsWith("bytestream://")) {
+      rpcService.downloadBytestreamZipFile(
+        outputFilename,
+        outputUri,
+        this.encodeManifestEntry(entry),
+        this.props.invocationId
+      );
+    }
+    return false;
+  }
+
   render() {
     return (
       <div className="card artifacts">
         <ArrowDownCircle className="icon brown" />
         <div className="content">
-          <div className="title">Artifacts</div>
+          <div className="title">Artifacts: {this.props.name}</div>
           <div className="details">
             {this.props.files.map((output) => (
-              <div className="artifact-line">
-                <a
-                  href={rpcService.getBytestreamUrl(output.uri, this.props.invocationId, {
-                    filename: output.name,
-                  })}
-                  className="artifact-name"
-                  onClick={this.handleArtifactClicked.bind(this, output.uri, output.name)}>
-                  {output.name}
-                </a>
-                {output.uri?.startsWith("bytestream://") && (
+              <>
+                <div className="artifact-line">
                   <a
-                    className="artifact-view"
-                    href={`/code/buildbuddy-io/buildbuddy/?bytestream_url=${encodeURIComponent(
-                      output.uri
-                    )}&invocation_id=${this.props.invocationId}&filename=${output.name}`}>
-                    <FileCode /> View
+                    href={rpcService.getBytestreamUrl(output.uri, this.props.invocationId, {
+                      filename: output.name,
+                    })}
+                    className="artifact-name"
+                    onClick={this.handleArtifactClicked.bind(this, output.uri, output.name)}>
+                    {output.name}
                   </a>
-                )}
-              </div>
+                  {output.uri?.startsWith("bytestream://") && (
+                    <a
+                      className="artifact-view"
+                      href={`/code/buildbuddy-io/buildbuddy/?bytestream_url=${encodeURIComponent(
+                        output.uri
+                      )}&invocation_id=${this.props.invocationId}&filename=${output.name}`}>
+                      <FileCode /> View
+                    </a>
+                  )}
+                </div>
+                {output.name === TargetArtifactsCardComponent.ZIPPED_OUTPUTS_FILE &&
+                  this.state.manifest &&
+                  this.state.manifest.entry?.map((entry) => (
+                    <div className="artifact-line sub-item">
+                      <a
+                        href={this.makeArtifactUri(output.uri, entry)}
+                        className="artifact-name"
+                        onClick={this.handleZipArtifactClicked.bind(this, output.uri, entry.name, entry)}>
+                        {entry.name}
+                      </a>
+                    </div>
+                  ))}
+              </>
             ))}
           </div>
           {this.props.files.length == 0 && <span>No artifacts</span>}

--- a/app/target/target_artifacts_card.tsx
+++ b/app/target/target_artifacts_card.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import { zip } from "../../proto/zip_ts_proto";
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
+import capabilities from "../capabilities/capabilities";
 import rpcService from "../service/rpc_service";
 
 interface Props {
@@ -35,6 +36,9 @@ export default class TargetArtifactsCardComponent extends React.Component<Props,
   }
 
   maybeFetchOutputManifest() {
+    if (!capabilities.config.testOutputManifestsEnabled) {
+      return;
+    }
     let testOutputsUri = this.props.files.find(
       (file: build_event_stream.File) => true && file.name === TargetArtifactsCardComponent.ZIPPED_OUTPUTS_FILE
     )?.uri;

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -367,6 +367,7 @@ proto_library(
         ":usage_proto",
         ":user_proto",
         ":workflow_proto",
+        ":zip_proto",
     ],
 )
 
@@ -471,6 +472,15 @@ proto_library(
 proto_library(
     name = "stored_invocation_proto",
     srcs = ["stored_invocation.proto"],
+)
+
+proto_library(
+    name = "zip_proto",
+    srcs = ["zip.proto"],
+    deps = [
+        ":context_proto",
+        ":remote_execution_proto",
+    ],
 )
 
 # Go proto rules below here
@@ -776,6 +786,7 @@ go_proto_library(
         ":usage_go_proto",
         ":user_go_proto",
         ":workflow_go_proto",
+        ":zip_go_proto",
     ],
 )
 
@@ -951,6 +962,16 @@ go_proto_library(
     proto = ":stored_invocation_proto",
 )
 
+go_proto_library(
+    name = "zip_go_proto",
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/zip",
+    proto = ":zip_proto",
+    deps = [
+        ":context_go_proto",
+        ":remote_execution_go_proto",
+    ],
+)
+
 # TypeScript proto rules below here
 
 ts_proto_library(
@@ -1091,4 +1112,9 @@ ts_proto_library(
 ts_proto_library(
     name = "runner_ts_proto",
     proto = ":runner_proto",
+)
+
+ts_proto_library(
+    name = "zip_ts_proto",
+    proto = ":zip_proto",
 )

--- a/proto/buildbuddy_service.proto
+++ b/proto/buildbuddy_service.proto
@@ -16,6 +16,7 @@ import "proto/usage.proto";
 import "proto/github.proto";
 import "proto/quota.proto";
 import "proto/secrets.proto";
+import "proto/zip.proto";
 
 package buildbuddy.service;
 
@@ -39,6 +40,10 @@ service BuildBuddyService {
       returns (invocation.GetTrendResponse);
   rpc GetInvocationOwner(invocation.GetInvocationOwnerRequest)
       returns (invocation.GetInvocationOwnerResponse);
+
+  // Zip manifest API
+  rpc GetZipManifest(zip.GetZipManifestRequest)
+      returns (zip.GetZipManifestResponse);
 
   // Bazel Config API
   rpc GetBazelConfig(bazel_config.GetBazelConfigRequest)

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -68,4 +68,7 @@ message FrontendConfig {
 
   // Whether to enable the secrets UI.
   bool secrets_enabled = 22;
+
+  // Whether to render test outputs.zip contents in the targets UI.
+  bool test_output_manifests_enabled = 23;
 }

--- a/proto/zip.proto
+++ b/proto/zip.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+import "proto/context.proto";
+
+package zip;
+
+message ManifestEntry {
+  // The full path of the file as specified in the archive.
+  string name = 1;
+
+  // The uncompressed size of the file in bytes.
+  int64 uncompressed_size = 2;
+
+  // The compressed size of the file in bytes.
+  int64 compressed_size = 3;
+
+  // The byte offset of the header for this file in the archive.
+  int64 header_offset = 4;
+
+  // The byte offset of the file content in the archive, as opposed to the file
+  // header--this lets us skip unneeded fields in the header and get right to
+  // decompressing.  This is an absolute position, NOT relative to the header.
+  int64 content_offset = 5;
+
+  // The type of compression used for this file.
+  enum CompressionType {
+    COMPRESSION_TYPE_UNKNOWN = 0;
+    COMPRESSION_TYPE_NONE = 1;
+    COMPRESSION_TYPE_FLATE = 2;
+  }
+  CompressionType compression = 6;
+
+  // Checksum (CRC32) for validating that the file contents have been
+  // decompressed properly.
+  uint32 crc32 = 7;
+}
+
+message Manifest {
+  // Individual summaries of the files in this archive.
+  repeated ManifestEntry entry = 1;
+}
+
+message GetZipManifestRequest {
+  context.RequestContext request_context = 1;
+
+  // Bytestream URI for the archive.
+  string uri = 2;
+}
+
+message GetZipManifestResponse {
+  context.ResponseContext response_context = 1;
+
+  optional Manifest manifest = 2;
+}

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//proto:user_go_proto",
         "//proto:user_id_go_proto",
         "//proto:workflow_go_proto",
+        "//proto:zip_go_proto",
         "//server/build_event_protocol/build_event_handler",
         "//server/bytestream",
         "//server/endpoint_urls/build_buddy_url",
@@ -47,6 +48,7 @@ go_library(
         "//server/util/status",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//proto",
     ],
 )
 

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -2,6 +2,7 @@ package buildbuddy_server
 
 import (
 	"context"
+	"encoding/base64"
 	"flag"
 	"fmt"
 	"net/http"
@@ -29,6 +30,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/role"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"google.golang.org/protobuf/proto"
 
 	remote_execution_config "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/config"
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
@@ -48,6 +50,7 @@ import (
 	uspb "github.com/buildbuddy-io/buildbuddy/proto/user"
 	uidpb "github.com/buildbuddy-io/buildbuddy/proto/user_id"
 	wfpb "github.com/buildbuddy-io/buildbuddy/proto/workflow"
+	zipb "github.com/buildbuddy-io/buildbuddy/proto/zip"
 	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
 	gcodes "google.golang.org/grpc/codes"
 	gstatus "google.golang.org/grpc/status"
@@ -143,6 +146,18 @@ func (s *BuildBuddyServer) DeleteInvocation(ctx context.Context, req *inpb.Delet
 	}
 
 	return &inpb.DeleteInvocationResponse{}, nil
+}
+
+func (s *BuildBuddyServer) GetZipManifest(ctx context.Context, req *zipb.GetZipManifestRequest) (*zipb.GetZipManifestResponse, error) {
+	u, err := url.Parse(req.GetUri())
+	if err != nil {
+		return nil, err
+	}
+	man, err := bytestream.FetchBytestreamZipManifest(ctx, s.env, u)
+	if err != nil {
+		return nil, err
+	}
+	return &zipb.GetZipManifestResponse{Manifest: man}, nil
 }
 
 func (s *BuildBuddyServer) CancelExecutions(ctx context.Context, req *inpb.CancelExecutionsRequest) (*inpb.CancelExecutionsResponse, error) {
@@ -1036,19 +1051,42 @@ func (s *BuildBuddyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// TODO(siggisim): Figure out why this JWT is overriding authority auth and remove.
+	ctx := context.WithValue(r.Context(), "x-buildbuddy-jwt", nil)
+
+	var zipReference = params.Get("z")
+	if len(zipReference) > 0 {
+		b, err := base64.StdEncoding.DecodeString(zipReference)
+		if err != nil {
+			log.Warningf("Error downloading file: %s", err)
+			http.Error(w, "File not found", http.StatusBadRequest)
+			return
+		}
+		entry := &zipb.ManifestEntry{}
+		if err := proto.Unmarshal(b, entry); err != nil {
+			log.Warningf("Failed to unmarshal ManifestEntry: %s", err)
+			http.Error(w, "File not found", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", entry.GetName()))
+		// TODO(jdhollen): Parse output mime type from bazel-generated MANIFEST file.
+		w.Header().Set("Content-Type", "application/octet-stream")
+		err = bytestream.StreamSingleFileFromBytestreamZip(ctx, s.env, lookup.URL, entry, w)
+		if err != nil {
+			log.Warningf("Error downloading zip file contents: %s", err)
+			http.Error(w, "File not found", http.StatusNotFound)
+		}
+		return
+	}
+
 	// Stream the file back to our client
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", lookup.Filename))
 	w.Header().Set("Content-Type", "application/octet-stream")
 
-	// TODO(siggisim): Figure out why this JWT is overriding authority auth and remove.
-	ctx := context.WithValue(r.Context(), "x-buildbuddy-jwt", nil)
-
-	err = bytestream.StreamBytestreamFile(ctx, s.env, lookup.URL, func(data []byte) {
-		w.Write(data)
-	})
+	err = bytestream.StreamBytestreamFile(ctx, s.env, lookup.URL, w)
 
 	if err != nil {
-		log.Warningf("Error downloading file: %s", err.Error())
+		log.Warningf("Error downloading file: %s", err)
 		http.Error(w, "File not found", http.StatusNotFound)
 		return
 	}

--- a/server/bytestream/BUILD
+++ b/server/bytestream/BUILD
@@ -7,11 +7,13 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
+        "//proto:zip_go_proto",
         "//server/environment",
         "//server/remote_cache/digest",
         "//server/util/flagutil",
         "//server/util/grpc_client",
         "//server/util/status",
+        "//server/util/ziputil",
         "@go_googleapis//google/bytestream:bytestream_go_proto",
         "@org_golang_google_protobuf//proto",
     ],

--- a/server/bytestream/bytestream.go
+++ b/server/bytestream/bytestream.go
@@ -1,6 +1,7 @@
 package bytestream
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/url"
@@ -12,13 +13,101 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/ziputil"
 	"google.golang.org/protobuf/proto"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	zipb "github.com/buildbuddy-io/buildbuddy/proto/zip"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
-func StreamBytestreamFile(ctx context.Context, env environment.Env, url *url.URL, callback func([]byte)) error {
+func FetchBytestreamZipManifest(ctx context.Context, env environment.Env, url *url.URL) (*zipb.Manifest, error) {
+	r, err := digest.ParseDownloadResourceName(strings.TrimPrefix(url.RequestURI(), "/"))
+	if err != nil {
+		return nil, err
+	}
+	// Let's just read 64K and see if we can find the central directory in there.
+	// We probably don't want to be in the business of rendering 3000-file zips'
+	// contents anyway.
+	offset := r.GetDigest().GetSizeBytes() - 65536
+	if offset < 0 {
+		offset = 0
+	}
+
+	var buf bytes.Buffer
+	err = StreamBytestreamFileChunk(ctx, env, url, offset, r.GetDigest().GetSizeBytes()-offset, &buf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Dump the full contents out into a buffer (should be 64K or less).
+	footer := buf.Bytes()
+
+	// Find and parse the End of Central Directory header or fail.
+	eocd, err := ziputil.ReadDirectoryEnd(footer, r.GetDigest().GetSizeBytes())
+	if err != nil {
+		return nil, err
+	}
+
+	cdStart := eocd.DirectoryOffset - offset
+	cdEnd := cdStart + eocd.DirectorySize
+
+	entries, err := ziputil.ReadDirectoryHeader(footer[cdStart:cdEnd], eocd)
+	if err != nil {
+		return nil, err
+	}
+
+	return &zipb.Manifest{Entry: entries}, nil
+}
+
+func validateLocalFileHeader(ctx context.Context, env environment.Env, url *url.URL, entry *zipb.ManifestEntry) (int, error) {
+	var buf bytes.Buffer
+	err := StreamBytestreamFileChunk(ctx, env, url, entry.GetHeaderOffset(), ziputil.FileHeaderLen, &buf)
+	if err != nil {
+		return -1, err
+	}
+	return ziputil.ValidateLocalFileHeader(buf.Bytes(), entry)
+}
+
+func StreamSingleFileFromBytestreamZip(ctx context.Context, env environment.Env, url *url.URL, entry *zipb.ManifestEntry, out io.Writer) error {
+	dynamicHeaderBytes, err := validateLocalFileHeader(ctx, env, url, entry)
+	if err != nil {
+		return err
+	}
+
+	// Stream the dynamic portion of the header and the compressed file as one read.
+	reader, writer := io.Pipe()
+	defer reader.Close()
+	go func() {
+		err := StreamBytestreamFileChunk(ctx, env, url, entry.GetHeaderOffset()+ziputil.FileHeaderLen, entry.GetCompressedSize()+int64(dynamicHeaderBytes), writer)
+		// StreamBytestreamFileChunk shouldn't return EOF, but let's just be safe.
+		if err != nil && err != io.EOF {
+			writer.CloseWithError(err)
+		}
+	}()
+
+	// Validate that the dynamic portion of the file header makes sense.
+	extras := make([]byte, dynamicHeaderBytes)
+	if _, err := io.ReadFull(reader, extras); err != nil {
+		return err
+	}
+	if err := ziputil.ValidateLocalFileNameAndExtras(extras, entry); err != nil {
+		return err
+	}
+
+	// And, finally, actually decompress.
+	if err := ziputil.DecompressAndStream(out, reader, entry); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func StreamBytestreamFile(ctx context.Context, env environment.Env, url *url.URL, writer io.Writer) error {
+	return StreamBytestreamFileChunk(ctx, env, url, 0, 0, writer)
+}
+
+func StreamBytestreamFileChunk(ctx context.Context, env environment.Env, url *url.URL, offset int64, limit int64, writer io.Writer) error {
 	if url.Scheme != "bytestream" && url.Scheme != "actioncache" {
 		return status.InvalidArgumentErrorf("Only bytestream:// uris are supported")
 	}
@@ -33,23 +122,23 @@ func StreamBytestreamFile(ctx context.Context, env environment.Env, url *url.URL
 			grpcPort = strconv.Itoa(p)
 		}
 		localURL.Host = "localhost:" + grpcPort
-		err = streamFromUrl(ctx, localURL, false, callback)
+		err = streamFromUrl(ctx, localURL, false, offset, limit, writer)
 	}
 
 	// If that fails, try to connect over grpcs
 	if err != nil || env.GetCache() == nil {
-		err = streamFromUrl(ctx, url, true, callback)
+		err = streamFromUrl(ctx, url, true, offset, limit, writer)
 	}
 
 	// If that fails, try grpc
 	if err != nil {
-		err = streamFromUrl(ctx, url, false, callback)
+		err = streamFromUrl(ctx, url, false, offset, limit, writer)
 	}
 
 	return err
 }
 
-func streamFromUrl(ctx context.Context, url *url.URL, grpcs bool, callback func([]byte)) error {
+func streamFromUrl(ctx context.Context, url *url.URL, grpcs bool, offset int64, limit int64, writer io.Writer) error {
 	if url.Port() == "" && grpcs {
 		url.Host = url.Hostname() + ":443"
 	} else if url.Port() == "" {
@@ -84,7 +173,9 @@ func streamFromUrl(ctx context.Context, url *url.URL, grpcs bool, callback func(
 		if err != nil {
 			return err
 		}
-		callback(buf)
+		if _, err := writer.Write(buf); err != nil {
+			return err
+		}
 		return nil
 	}
 	client := bspb.NewByteStreamClient(conn)
@@ -92,8 +183,8 @@ func streamFromUrl(ctx context.Context, url *url.URL, grpcs bool, callback func(
 	// Request the file bytestream
 	req := &bspb.ReadRequest{
 		ResourceName: strings.TrimPrefix(url.RequestURI(), "/"), // trim leading "/"
-		ReadOffset:   0,                                         // started from the bottom now we here
-		ReadLimit:    0,                                         // no limit
+		ReadOffset:   offset,                                    // started from the bottom now we here
+		ReadLimit:    limit,                                     // no limit
 	}
 	readClient, err := client.Read(ctx, req)
 	if err != nil {
@@ -108,7 +199,9 @@ func streamFromUrl(ctx context.Context, url *url.URL, grpcs bool, callback func(
 		if err != nil {
 			return err
 		}
-		callback(rsp.Data)
+		if _, err := writer.Write(rsp.Data); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/server/bytestream/bytestream.go
+++ b/server/bytestream/bytestream.go
@@ -52,6 +52,10 @@ func FetchBytestreamZipManifest(ctx context.Context, env environment.Env, url *u
 	cdStart := eocd.DirectoryOffset - offset
 	cdEnd := cdStart + eocd.DirectorySize
 
+	if cdStart < 0 {
+		return nil, status.UnimplementedError("directory size is very large.")
+	}
+
 	entries, err := ziputil.ReadDirectoryHeader(footer[cdStart:cdEnd], eocd)
 	if err != nil {
 		return nil, err

--- a/server/role_filter/role_filter.go
+++ b/server/role_filter/role_filter.go
@@ -34,6 +34,7 @@ var (
 		"GetCacheMetadata",
 		"GetTarget",
 		"GetExecution",
+		"GetZipManifest",
 		// Users do not need any particular role within their current group to be
 		// able to create another group or request to join an existing group.
 		"JoinGroup",

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -39,6 +39,7 @@ var (
 	expandedSuggestionsEnabled = flag.Bool("app.expanded_suggestions_enabled", false, "If set, enable more build suggestions in the UI.")
 	enableWorkflows            = flag.Bool("remote_execution.enable_workflows", false, "Whether to enable BuildBuddy workflows.")
 	enableExecutorKeyCreation  = flag.Bool("remote_execution.enable_executor_key_creation", false, "If enabled, UI will allow executor keys to be created.")
+	testOutputManifestsEnabled = flag.Bool("app.test_output_manifests_enabled", false, "If set, the target page will render the contents of test output zips.")
 
 	jsEntryPointPath = flag.String("js_entry_point_path", "/app/app_bundle/app.js?hash={APP_BUNDLE_HASH}", "Absolute URL path of the app JS entry point")
 	disableGA        = flag.Bool("disable_ga", false, "If true; ga will be disabled")
@@ -151,6 +152,7 @@ func serveIndexTemplate(env environment.Env, tpl *template.Template, version, js
 		ExpandedSuggestionsEnabled:    *expandedSuggestionsEnabled,
 		QuotaManagementEnabled:        env.GetQuotaManager() != nil,
 		SecretsEnabled:                env.GetSecretService() != nil,
+		TestOutputManifestsEnabled:    *testOutputManifestsEnabled,
 	}
 
 	configJSON, err := protojson.Marshal(&config)

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -39,7 +39,7 @@ var (
 	expandedSuggestionsEnabled = flag.Bool("app.expanded_suggestions_enabled", false, "If set, enable more build suggestions in the UI.")
 	enableWorkflows            = flag.Bool("remote_execution.enable_workflows", false, "Whether to enable BuildBuddy workflows.")
 	enableExecutorKeyCreation  = flag.Bool("remote_execution.enable_executor_key_creation", false, "If enabled, UI will allow executor keys to be created.")
-	testOutputManifestsEnabled = flag.Bool("app.test_output_manifests_enabled", false, "If set, the target page will render the contents of test output zips.")
+	testOutputManifestsEnabled = flag.Bool("app.test_output_manifests_enabled", true, "If set, the target page will render the contents of test output zips.")
 
 	jsEntryPointPath = flag.String("js_entry_point_path", "/app/app_bundle/app.js?hash={APP_BUNDLE_HASH}", "Absolute URL path of the app JS entry point")
 	disableGA        = flag.Bool("disable_ga", false, "If true; ga will be disabled")

--- a/server/util/ziputil/BUILD
+++ b/server/util/ziputil/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "ziputil",
+    srcs = ["ziputil.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/ziputil",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:zip_go_proto",
+        "//server/util/status",
+    ],
+)

--- a/server/util/ziputil/ziputil.go
+++ b/server/util/ziputil/ziputil.go
@@ -1,0 +1,246 @@
+// This file is primarily adapted from useful (unexported) functions from
+// the golang package 'archive/zip', slightly modified to match our use
+// cases.
+
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package ziputil
+
+import (
+	"compress/flate"
+	"encoding/binary"
+	"io"
+
+	zipb "github.com/buildbuddy-io/buildbuddy/proto/zip"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+)
+
+const (
+	FileHeaderSignature      = 0x04034b50
+	DirectoryHeaderSignature = 0x02014b50
+	DirectoryEndLen          = 22
+	DirectoryHeaderLen       = 46
+	FileHeaderLen            = 30
+)
+
+var (
+	errFormat    = status.FailedPreconditionError("zip: not a valid zip file")
+	errAlgorithm = status.UnimplementedError("zip: unsupported compression algorithm")
+	errZip64     = status.UnimplementedError("zip: zip64 not supported")
+)
+
+type DirectoryEnd struct {
+	DirectoryRecords int64
+	DirectorySize    int64
+	DirectoryOffset  int64
+	commentLen       uint16
+	comment          string
+}
+
+type readBuf []byte
+
+func (b *readBuf) uint16() uint16 {
+	v := binary.LittleEndian.Uint16(*b)
+	*b = (*b)[2:]
+	return v
+}
+
+func (b *readBuf) uint32() uint32 {
+	v := binary.LittleEndian.Uint32(*b)
+	*b = (*b)[4:]
+	return v
+}
+
+func findSignatureInBlock(b []byte) int {
+	if len(b) < DirectoryEndLen {
+		return -1
+	}
+	for i := len(b) - DirectoryEndLen; i >= 0; i-- {
+		// defined from directoryEndSignature in struct.go
+		if b[i] == 'P' && b[i+1] == 'K' && b[i+2] == 0x05 && b[i+3] == 0x06 {
+			// n is length of comment
+			n := int(b[i+DirectoryEndLen-2]) | int(b[i+DirectoryEndLen-1])<<8
+			if n+DirectoryEndLen+i <= len(b) {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func compressionTypeToEnum(compression uint16) zipb.ManifestEntry_CompressionType {
+	switch compression {
+	case 0:
+		return zipb.ManifestEntry_COMPRESSION_TYPE_NONE
+	case 8:
+		return zipb.ManifestEntry_COMPRESSION_TYPE_FLATE
+	default:
+		return zipb.ManifestEntry_COMPRESSION_TYPE_UNKNOWN
+	}
+}
+
+// The returned value is equal to the number of bytes that are expected in the
+// remaining (dynamically sized) header fields, or -1 if the header didn't validate.
+func ValidateLocalFileHeader(header []byte, entry *zipb.ManifestEntry) (int, error) {
+	buf := readBuf(header[:])
+	if sig := buf.uint32(); sig != FileHeaderSignature {
+		return 1, errFormat
+	}
+
+	buf = buf[4:] // Skip version, bitmap
+	compressionType := compressionTypeToEnum(buf.uint16())
+	if compressionType == zipb.ManifestEntry_COMPRESSION_TYPE_UNKNOWN {
+		return -1, errAlgorithm
+	}
+	buf = buf[4:] // Skip modification time, modification date.
+
+	crc32 := buf.uint32()
+	compsize := int64(buf.uint32())
+	uncompsize := int64(buf.uint32())
+	if entry.GetCompressedSize() == 0xffffffff || entry.GetUncompressedSize() == 0xffffffff {
+		// These values indicate zip64 format.
+		return -1, errZip64
+	}
+	if entry.GetCrc32() != crc32 || entry.GetCompressedSize() != compsize || entry.GetUncompressedSize() != uncompsize {
+		return -1, errFormat
+	}
+
+	filenameLen := int(buf.uint16())
+	extraLen := int(buf.uint16())
+
+	return filenameLen + extraLen, nil
+}
+
+func ValidateLocalFileNameAndExtras(input []byte, entry *zipb.ManifestEntry) error {
+	if string(input[:len(entry.GetName())]) != entry.GetName() {
+		return errFormat
+	}
+	return nil
+}
+
+func ReadDirectoryEnd(input []byte, trueSize int64) (dir *DirectoryEnd, err error) {
+	if int64(len(input)) > trueSize {
+		return nil, errFormat
+	}
+	if p := findSignatureInBlock(input); p >= 0 {
+		input = input[p:]
+	} else {
+		return nil, errFormat
+	}
+
+	b := readBuf(input[10:]) // skip signature, disk fields
+	d := &DirectoryEnd{
+		DirectoryRecords: int64(b.uint16()),
+		DirectorySize:    int64(b.uint32()),
+		DirectoryOffset:  int64(b.uint32()),
+		commentLen:       b.uint16(),
+	}
+	l := int(d.commentLen)
+	if l > len(b) {
+		return nil, status.FailedPreconditionError("zip: invalid comment length")
+	}
+	d.comment = string(b[:l])
+
+	// These values mean that the file can be a zip64 file
+	if d.DirectoryRecords == 0xffff || d.DirectorySize == 0xffff || d.DirectoryOffset == 0xffffffff {
+		return nil, errZip64
+	}
+
+	// Make sure directoryOffset points to somewhere in our file.
+	if d.DirectoryOffset < 0 || d.DirectoryOffset+d.DirectorySize > trueSize {
+		return nil, errFormat
+	}
+	return d, nil
+}
+
+// readDirectoryHeader attempts to read a directory header from r.
+// It returns io.ErrUnexpectedEOF if it cannot read a complete header,
+// and errFormat if it doesn't find a valid header signature.
+func ReadDirectoryHeader(buf []byte, d *DirectoryEnd) ([]*zipb.ManifestEntry, error) {
+	var headers []*zipb.ManifestEntry
+
+	b := readBuf(buf[:])
+	if len(b) < int(d.DirectorySize) {
+		return nil, errFormat
+	}
+
+	for i := 0; i < int(d.DirectoryRecords); i++ {
+		var h = &zipb.ManifestEntry{}
+		headers = append(headers, h)
+		if len(b) < DirectoryHeaderLen {
+			return nil, errFormat
+		}
+		if sig := b.uint32(); sig != DirectoryHeaderSignature {
+			return nil, errFormat
+		}
+		b = b[6:] // Skip CreatorVersion, ReaderVersion, Flags
+		var compressionType = compressionTypeToEnum(b.uint16())
+		if compressionType == zipb.ManifestEntry_COMPRESSION_TYPE_UNKNOWN {
+			return nil, errAlgorithm
+		}
+		h.Compression = compressionType
+		b = b[4:] // Skip ModifiedTime, ModifiedDate
+		h.Crc32 = b.uint32()
+		h.CompressedSize = int64(b.uint32())
+		h.UncompressedSize = int64(b.uint32())
+		if h.GetCompressedSize() == 0xffffffff || h.GetUncompressedSize() == 0xffffffff {
+			// These values indicate zip64 format.
+			return nil, errZip64
+		}
+		filenameLen := int(b.uint16())
+		extraLen := int(b.uint16())
+		commentLen := int(b.uint16())
+		b = b[8:] // Skip StartingDiskNumber, InternalAttrs, ExternalAttrs
+		h.HeaderOffset = int64(b.uint32())
+		if len(b) < filenameLen+extraLen+commentLen {
+			return nil, errFormat
+		}
+		h.Name = string(b[:filenameLen])
+		b = b[(filenameLen + extraLen + commentLen):]
+	}
+
+	return headers, nil
+}
+
+func DecompressAndStream(writer io.Writer, reader io.Reader, entry *zipb.ManifestEntry) error {
+	var outReader io.Reader
+	if entry.GetCompression() == zipb.ManifestEntry_COMPRESSION_TYPE_FLATE {
+		// TODO(jdhollen): maybe validate crc32?
+		outReader = flate.NewReader(io.LimitReader(reader, int64(entry.GetCompressedSize())))
+	} else if entry.GetCompression() == zipb.ManifestEntry_COMPRESSION_TYPE_NONE {
+		outReader = io.LimitReader(reader, int64(entry.GetCompressedSize()))
+	} else {
+		return errAlgorithm
+	}
+
+	if _, err := io.Copy(writer, outReader); err != nil {
+		return status.UnavailableError(err.Error())
+	}
+	return nil
+}


### PR DESCRIPTION
This addresses the error from #3153 where, for very large zip outputs with lots of files, we were panicking due to a negative index in the read files.

This also wraps everything in a flag (used from the client).