### PR TITLE
Clarify executor task queue resource logging

### DIFF
--- a/enterprise/server/scheduling/priority_task_scheduler/BUILD
+++ b/enterprise/server/scheduling/priority_task_scheduler/BUILD
@@ -25,6 +25,8 @@ go_library(
         "//server/util/tracing",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_x_text//language",
+        "@org_golang_x_text//message",
     ],
 )
 


### PR DESCRIPTION
With the current logging, it's unclear whether the information logged represents the queue state before the task is scheduled or after the task is scheduled.

This PR updates the logging so that it happens whenever the queue's resource capacity changes, and adds a prefix that indicates whether the change was due to a task being scheduled or being completed. It also adds additional useful info and improves the number formatting to make it more readable.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
