### PR TITLE
Take compression into account for cache upload/download byte metrics

### DIFF
--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -161,7 +161,7 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 		}
 	}
 	bytesFromCache := bytesTransferredToClient
-	compressedReader, isCompressedReader := reader.(compression.ZstdCompressor)
+	compressedReader, isCompressedReader := reader.(*compression.ZstdCompressor)
 	if isCompressedReader {
 		bytesFromCache = compressedReader.NumDecompressedBytes()
 	}

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -125,22 +125,20 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 
 	// If the cache doesn't support the requested compression, it will cache decompressed bytes and the server
 	// is in charge of compressing it
-	var bytesFromCache int64
+	var counter *ioutil.Counter
 	if r.GetCompressor() == repb.Compressor_ZSTD && !passthroughCompressionEnabled {
 		rbuf := s.bufferPool.Get(bufSize)
 		defer s.bufferPool.Put(rbuf)
 		cbuf := s.bufferPool.Get(bufSize)
 		defer s.bufferPool.Put(cbuf)
 
-		counter := &ioutil.Counter{}
+		// Counter for the number of bytes from the original reader containing decompressed bytes
+		counter = &ioutil.Counter{}
 		reader, err = compression.NewZstdCompressingReader(io.TeeReader(reader, counter), rbuf[:bufSize], cbuf[:bufSize])
 		if err != nil {
 			return status.InternalErrorf("Failed to compress blob: %s", err)
 		}
 		defer reader.Close()
-
-		// Count the number of bytes from the original reader containing decompressed bytes
-		bytesFromCache = counter.Count()
 	}
 
 	downloadTracker := ht.TrackDownload(r.GetDigest())
@@ -166,10 +164,11 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 			continue
 		}
 	}
-	// If the reader was not passed through the compressor above and bytesFromCache is not set, the data will be sent
+	// If the reader was not passed through the compressor above, the data will be sent
 	// as is from the cache to the client, and the number of bytes will be equal
-	if bytesFromCache == 0 {
-		bytesFromCache = int64(bytesTransferredToClient)
+	bytesFromCache := int64(bytesTransferredToClient)
+	if counter != nil {
+		bytesFromCache = counter.Count()
 	}
 
 	downloadTracker.CloseWithBytesTransferred(bytesFromCache, int64(bytesTransferredToClient), r.GetCompressor())

--- a/server/remote_cache/hit_tracker/hit_tracker_test.go
+++ b/server/remote_cache/hit_tracker/hit_tracker_test.go
@@ -46,7 +46,7 @@ func TestHitTracker_RecordsDetailedStats(t *testing.T) {
 	ht := hit_tracker.NewHitTracker(ctx, env, actionCache)
 
 	dl := ht.TrackDownload(d)
-	dl.CloseWithBytesTransferred(compressedSize, repb.Compressor_ZSTD)
+	dl.CloseWithBytesTransferred(compressedSize, compressedSize, repb.Compressor_ZSTD)
 
 	sc := hit_tracker.ScoreCard(ctx, env, iid)
 	require.Len(t, sc.Results, 1, "expected exactly one cache result")
@@ -101,7 +101,7 @@ func TestHitTracker_RecordsUsage(t *testing.T) {
 		ht := hit_tracker.NewHitTracker(ctx, env, actionCache)
 
 		dl := ht.TrackDownload(d)
-		dl.CloseWithBytesTransferred(compressedSize, repb.Compressor_ZSTD)
+		dl.CloseWithBytesTransferred(compressedSize, compressedSize, repb.Compressor_ZSTD)
 
 		require.Len(t, ut.Increments, 1)
 		assert.Equal(t, []*tables.UsageCounts{{
@@ -130,7 +130,7 @@ func TestHitTracker_RecordsUsage(t *testing.T) {
 		ht := hit_tracker.NewHitTracker(ctx, env, actionCache)
 
 		dl := ht.TrackDownload(d)
-		dl.CloseWithBytesTransferred(compressedSize, repb.Compressor_ZSTD)
+		dl.CloseWithBytesTransferred(compressedSize, compressedSize, repb.Compressor_ZSTD)
 
 		assert.Equal(t, []*tables.UsageCounts{{
 			CASCacheHits:           1,
@@ -156,7 +156,7 @@ func TestHitTracker_RecordsUsage(t *testing.T) {
 		ht := hit_tracker.NewHitTracker(ctx, env, actionCache)
 
 		dl := ht.TrackDownload(d)
-		dl.CloseWithBytesTransferred(d.SizeBytes, repb.Compressor_IDENTITY)
+		dl.CloseWithBytesTransferred(d.SizeBytes, d.SizeBytes, repb.Compressor_IDENTITY)
 
 		assert.Equal(t, []*tables.UsageCounts{{
 			ActionCacheHits:        1,


### PR DESCRIPTION
Before, we always read/wrote decompressed bytes from the cache, so we could use the digest size as the number of bytes uploaded/downloaded from the cache. Now that the cache can read/write decompressed bytes, we need to modify the metric to use the actual number of bytes transferred.
