### PR TITLE
add a test for zip file downloads and drop a bit of validation.

### DIFF
--- a/server/bytestream/BUILD
+++ b/server/bytestream/BUILD
@@ -32,7 +32,6 @@ go_test(
     deps = [
         "//proto:zip_go_proto",
         "//server/environment",
-        "@com_github_stretchr_testify//assert",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/server/bytestream/BUILD
+++ b/server/bytestream/BUILD
@@ -33,5 +33,6 @@ go_test(
         "//proto:zip_go_proto",
         "//server/environment",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+        "@org_golang_google_protobuf//proto",
     ],
 )

--- a/server/bytestream/BUILD
+++ b/server/bytestream/BUILD
@@ -31,6 +31,7 @@ go_test(
     embed = [":bytestream"],
     deps = [
         "//proto:zip_go_proto",
+        "//server/environment",
         "@com_github_stretchr_testify//assert",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],

--- a/server/bytestream/bytestream_test.go
+++ b/server/bytestream/bytestream_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"google.golang.org/protobuf/proto"
 
 	zipb "github.com/buildbuddy-io/buildbuddy/proto/zip"
 )
@@ -46,7 +47,7 @@ func TestManifest_SomeFilesZip(t *testing.T) {
 	path, _ := bazel.Runfile("some_files.zip")
 	bytes, _ := os.ReadFile(path)
 	manifest, _ := parseZipManifestFooter(bytes, 0, int64(len(bytes)))
-	if expected != manifest {
+	if !proto.Equal(expected, manifest) {
 		t.Fatalf("Incorrect manifest. Expected: %v\n Actual: %v", expected, manifest)
 	}
 }
@@ -56,7 +57,7 @@ func TestManifest_NoFilesZip(t *testing.T) {
 	path, _ := bazel.Runfile("no_files.zip")
 	bytes, _ := os.ReadFile(path)
 	manifest, _ := parseZipManifestFooter(bytes, 0, int64(len(bytes)))
-	if expected != manifest {
+	if !proto.Equal(expected, manifest) {
 		t.Fatalf("Incorrect manifest. Expected: %v\n Actual: %v", expected, manifest)
 	}
 }


### PR DESCRIPTION
As commented in the code, this validation isn't actually performed in the golang zip utils--it's something i wrote myself, and it turns out trying to perform it actually makes your life harder because it's sometimes not present.