### PR TITLE
Workflows: Support setting static env vars in config

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -820,7 +820,7 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 			args = appendBazelSubcommandArgs(args, "--script_path="+runScript)
 		}
 
-		runErr := runCommand(ctx, *bazelCommand, expandEnv(args), nil /*=env*/, ar.action.BazelWorkspaceDir, ar.reporter)
+		runErr := runCommand(ctx, *bazelCommand, expandEnv(args), ar.action.Env, ar.action.BazelWorkspaceDir, ar.reporter)
 		exitCode := getExitCode(runErr)
 		if exitCode != noExitCode {
 			ar.reporter.Printf("%s(command exited with code %d)%s\n", ansiGray, exitCode, ansiReset)

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -23,15 +23,16 @@ type BuildBuddyConfig struct {
 }
 
 type Action struct {
-	Name              string           `yaml:"name"`
-	Triggers          *Triggers        `yaml:"triggers"`
-	OS                string           `yaml:"os"`
-	Arch              string           `yaml:"arch"`
-	ResourceRequests  ResourceRequests `yaml:"resource_requests"`
-	User              string           `yaml:"user"`
-	GitCleanExclude   []string         `yaml:"git_clean_exclude"`
-	BazelWorkspaceDir string           `yaml:"bazel_workspace_dir"`
-	BazelCommands     []string         `yaml:"bazel_commands"`
+	Name              string            `yaml:"name"`
+	Triggers          *Triggers         `yaml:"triggers"`
+	OS                string            `yaml:"os"`
+	Arch              string            `yaml:"arch"`
+	ResourceRequests  ResourceRequests  `yaml:"resource_requests"`
+	User              string            `yaml:"user"`
+	GitCleanExclude   []string          `yaml:"git_clean_exclude"`
+	BazelWorkspaceDir string            `yaml:"bazel_workspace_dir"`
+	Env               map[string]string `yaml:"env"`
+	BazelCommands     []string          `yaml:"bazel_commands"`
 }
 
 type Triggers struct {


### PR DESCRIPTION
This can be used e.g. to set `USE_BAZEL_VERSION` to allow conveniently testing multiple bazel versions.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1935
