### PR TITLE
Workflows: Gracefully handle webhook registration failures

### DIFF
--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -203,8 +203,8 @@ func (ws *workflowService) CreateWorkflow(ctx context.Context, req *wfpb.CreateW
 	rsp := &wfpb.CreateWorkflowResponse{}
 
 	providerWebhookID, err := provider.RegisterWebhook(ctx, accessToken, repoURL, webhookURL)
-	if err != nil && !status.IsUnimplementedError(err) {
-		return nil, err
+	if err != nil {
+		log.CtxWarningf(ctx, "Failed to register webhook with git provider: %s", err)
 	}
 	rsp.WebhookRegistered = (providerWebhookID != "")
 

--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -165,7 +165,7 @@ func (*fakeExecuteStream) Recv() (*longrunning.Operation, error) {
 	return &longrunning.Operation{Name: "fake-operation-name"}, nil
 }
 
-func TestCreate(t *testing.T) {
+func TestCreate_SuccessfullyRegisterWebhook(t *testing.T) {
 	ctx := context.Background()
 	te := newTestEnv(t)
 	provider := setupFakeGitProvider(t, te)
@@ -196,8 +196,42 @@ func TestCreate(t *testing.T) {
 		t, testgit.FakeWebhookID, row.GitProviderWebhookID,
 		"inserted table workflow git provider webhook ID should be set based on git provider response",
 	)
-
+	assert.NotEmpty(t, row.WebhookID, "webhook ID in DB should be nonempty")
+	assert.Contains(t, rsp.GetWebhookUrl(), row.WebhookID, "webhook ID in DB should match the URL")
 	assert.Equal(t, rsp.GetWebhookUrl(), provider.RegisteredWebhookURL, "returned webhook URL should be registered to the provider")
+}
+
+func TestCreate_NoWebhookPermissions(t *testing.T) {
+	ctx := context.Background()
+	te := newTestEnv(t)
+	provider := setupFakeGitProvider(t, te)
+	provider.RegisterWebhookError = fmt.Errorf("(fake error) You do not have permissions to register webhooks!")
+	repoURL := makeTempRepo(t)
+	clientConn := runBBServer(ctx, te, t)
+	bbClient := bbspb.NewBuildBuddyServiceClient(clientConn)
+
+	req := &wfpb.CreateWorkflowRequest{
+		RequestContext: testauth.RequestContext("USER1", "GROUP1"),
+		Name:           "BuildBuddy OS Workflow",
+		GitRepo:        &wfpb.CreateWorkflowRequest_GitRepo{RepoUrl: repoURL},
+	}
+	ctx = metadata.AppendToOutgoingContext(ctx, testauth.APIKeyHeader, "USER1")
+	rsp, err := bbClient.CreateWorkflow(ctx, req)
+
+	assert.NoError(t, err)
+	assert.Regexp(t, "^WF.*", rsp.GetId(), "workflow ID should exist and match WF.*")
+	assert.Regexp(t, "^.*/webhooks/workflow/.*", rsp.GetWebhookUrl(), "workflow webhook URL should exist and match /webhooks/workflow/.*")
+	assert.False(t, rsp.GetWebhookRegistered(), "webhook should have failed to register")
+
+	var row tables.Workflow
+	err = te.GetDBHandle().DB(ctx).First(&row).Error
+	assert.NoError(t, err)
+	assert.Equal(t, rsp.GetId(), row.WorkflowID, "inserted table workflow ID should match create response")
+	assert.Equal(t, "GROUP1", row.UserID, "inserted table workflow user should match auth")
+	assert.Equal(t, "GROUP1", row.GroupID, "inserted table workflow group should match auth")
+	assert.NotEmpty(t, row.WebhookID, "webhook ID in DB should be nonempty")
+	assert.Contains(t, rsp.GetWebhookUrl(), row.WebhookID, "webhook ID in DB should match the URL")
+	assert.Equal(t, "", row.GitProviderWebhookID, "git provider should not have returned a webhook ID")
 }
 
 func TestDelete(t *testing.T) {

--- a/server/testutil/testgit/testgit.go
+++ b/server/testutil/testgit/testgit.go
@@ -24,11 +24,17 @@ const (
 
 // FakeProvider implements the git provider interface for tests.
 type FakeProvider struct {
+	// Captured values
+
 	RegisteredWebhookURL  string
 	UnregisteredWebhookID string
-	WebhookData           *interfaces.WebhookData
-	FileContents          map[string]string
-	TrustedUsers          []string
+
+	// Faked values
+
+	RegisterWebhookError error
+	WebhookData          *interfaces.WebhookData
+	FileContents         map[string]string
+	TrustedUsers         []string
 }
 
 func NewFakeProvider() *FakeProvider {
@@ -48,6 +54,9 @@ func (p *FakeProvider) ParseWebhookData(req *http.Request) (*interfaces.WebhookD
 	return p.WebhookData, nil
 }
 func (p *FakeProvider) RegisterWebhook(ctx context.Context, accessToken, repoURL, webhookURL string) (string, error) {
+	if p.RegisterWebhookError != nil {
+		return "", p.RegisterWebhookError
+	}
 	p.RegisteredWebhookURL = webhookURL
 	return FakeWebhookID, nil
 }


### PR DESCRIPTION
The client handles missing webhook permissions gracefully by showing a dialog with the webhook URL, asking the user to register it with the git provider manually (based on `registered_webhook: false` being set in the response). However, the server side logic for populating this field was broken at some point. This PR fixes it.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
