### PR TITLE
Reduce allocations for migration double reads

### DIFF
--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -412,6 +412,7 @@ type doubleReader struct {
 	dest io.ReadCloser
 
 	r             *resource.ResourceName
+	doubleReadBuf []byte
 	bytesReadSrc  int
 	bytesReadDest int
 }
@@ -422,9 +423,12 @@ func (d *doubleReader) Read(p []byte) (n int, err error) {
 
 	if d.dest != nil {
 		eg.Go(func() error {
-			pCopy := make([]byte, len(p))
+			if d.doubleReadBuf == nil || len(d.doubleReadBuf) != len(p) {
+				d.doubleReadBuf = make([]byte, len(p))
+			}
+
 			var dstN int
-			dstN, dstErr = d.dest.Read(pCopy)
+			dstN, dstErr = d.dest.Read(d.doubleReadBuf)
 			d.bytesReadDest += dstN
 			return nil
 		})


### PR DESCRIPTION
Fixes buildbuddy-io/buildbuddy-internal#1912
