### PR TITLE
Add a 'strict' option to ts_library that runs TypeScript type checking in strict mode.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -71,6 +71,12 @@ ts_config(
     src = ":tsconfig.json",
 )
 
+ts_config(
+    name = "tsconfig_strict",
+    src = ":tsconfig_strict.json",
+    deps = [":tsconfig"],
+)
+
 filegroup(
     name = "config_files",
     srcs = select({

--- a/app/components/button/BUILD
+++ b/app/components/button/BUILD
@@ -10,6 +10,7 @@ ts_library(
         "*.ts",
         "*.tsx",
     ]),
+    strict = True,
     deps = [
         "//app/components/checkbox",
         "//app/components/link",

--- a/app/components/checkbox/BUILD
+++ b/app/components/checkbox/BUILD
@@ -7,6 +7,7 @@ exports_files(glob(["*.css"]))
 ts_library(
     name = "checkbox",
     srcs = glob(["*.tsx"]),
+    strict = True,
     deps = [
         "@npm//@types/react",
         "@npm//react",

--- a/app/components/dialog/BUILD
+++ b/app/components/dialog/BUILD
@@ -7,6 +7,7 @@ exports_files(glob(["*.css"]))
 ts_library(
     name = "dialog",
     srcs = ["dialog.tsx"],
+    strict = True,
     deps = [
         "@npm//@types/react",
         "@npm//react",
@@ -17,6 +18,7 @@ ts_library(
 ts_library(
     name = "simple_modal_dialog",
     srcs = ["simple_modal_dialog.tsx"],
+    strict = True,
     deps = [
         ":dialog",
         "//app/components/button",

--- a/app/components/filter_input/BUILD
+++ b/app/components/filter_input/BUILD
@@ -10,6 +10,7 @@ ts_library(
         "*.ts",
         "*.tsx",
     ]),
+    strict = True,
     deps = [
         "@npm//@types/react",
         "@npm//lucide-react",

--- a/app/components/input/BUILD
+++ b/app/components/input/BUILD
@@ -10,6 +10,7 @@ ts_library(
         "*.ts",
         "*.tsx",
     ]),
+    strict = True,
     deps = [
         "@npm//@types/react",
         "@npm//react",

--- a/app/components/menu/BUILD
+++ b/app/components/menu/BUILD
@@ -10,6 +10,7 @@ ts_library(
         "*.ts",
         "*.tsx",
     ]),
+    strict = True,
     deps = [
         "@npm//@types/react",
         "@npm//react",

--- a/app/components/modal/BUILD
+++ b/app/components/modal/BUILD
@@ -10,6 +10,7 @@ ts_library(
         "*.ts",
         "*.tsx",
     ]),
+    strict = True,
     deps = [
         "@npm//@types/react",
         "@npm//@types/react-modal",

--- a/app/components/popup/BUILD
+++ b/app/components/popup/BUILD
@@ -10,6 +10,7 @@ ts_library(
         "*.ts",
         "*.tsx",
     ]),
+    strict = True,
     deps = [
         "@npm//@types/react",
         "@npm//react",

--- a/app/components/radio/BUILD
+++ b/app/components/radio/BUILD
@@ -7,6 +7,7 @@ exports_files(glob(["*.css"]))
 ts_library(
     name = "radio",
     srcs = glob(["*.tsx"]),
+    strict = True,
     deps = [
         "@npm//@types/react",
         "@npm//react",

--- a/app/components/select/BUILD
+++ b/app/components/select/BUILD
@@ -10,6 +10,7 @@ ts_library(
         "*.ts",
         "*.tsx",
     ]),
+    strict = True,
     deps = [
         "@npm//@types/react",
         "@npm//lucide-react",

--- a/app/components/slider/BUILD
+++ b/app/components/slider/BUILD
@@ -7,6 +7,7 @@ exports_files(glob(["*.css"]))
 ts_library(
     name = "slider",
     srcs = glob(["*.tsx"]),
+    strict = True,
     deps = [
         "@npm//@types/react",
         "@npm//@types/react-slider",

--- a/app/components/spinner/BUILD
+++ b/app/components/spinner/BUILD
@@ -7,6 +7,7 @@ exports_files(glob(["*.css"]))
 ts_library(
     name = "spinner",
     srcs = glob(["*.tsx"]),
+    strict = True,
     deps = [
         "@npm//@types/react",
         "@npm//react",

--- a/app/components/tooltip/BUILD
+++ b/app/components/tooltip/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 ts_library(
     name = "tooltip",
     srcs = ["tooltip.tsx"],
+    strict = True,
     deps = [
         "//app/util:math",
         "@npm//@types/react",

--- a/app/errors/BUILD
+++ b/app/errors/BUILD
@@ -8,6 +8,7 @@ ts_library(
         "*.tsx",
         "*.ts",
     ]),
+    strict = True,
     deps = [
         "//app/alert",
         "//app/router",

--- a/app/favicon/BUILD.bazel
+++ b/app/favicon/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 ts_library(
     name = "favicon",
     srcs = glob(["*.ts"]),
+    strict = True,
     deps = [
     ],
 )

--- a/app/footer/BUILD
+++ b/app/footer/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 ts_library(
     name = "footer",
     srcs = glob(["*.tsx"]),
+    strict = True,
     deps = [
         "//app/capabilities",
         "@npm//@types/react",

--- a/app/preferences/BUILD
+++ b/app/preferences/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 ts_library(
     name = "preferences",
     srcs = glob(["*.ts"]),
+    strict = True,
     deps = [
         "//app/capabilities",
     ],

--- a/app/service/BUILD.bazel
+++ b/app/service/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 ts_library(
     name = "service",
     srcs = glob(["*.ts"]),
+    strict = True,
     deps = [
         "//app/util:async",
         "//proto:buildbuddy_service_ts_proto",

--- a/app/util/BUILD
+++ b/app/util/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 ts_library(
     name = "animated_value",
     srcs = ["animated_value.ts"],
+    strict = True,
     deps = [
         ":math",
         "@npm//tslib",
@@ -40,16 +41,19 @@ ts_jasmine_node_test(
 ts_library(
     name = "clipboard",
     srcs = ["clipboard.ts"],
+    strict = True,
 )
 
 ts_library(
     name = "color",
     srcs = ["color.ts"],
+    strict = True,
 )
 
 ts_library(
     name = "dom",
     srcs = ["dom.ts"],
+    strict = True,
     deps = [
         "@npm//tslib",
     ],
@@ -58,11 +62,13 @@ ts_library(
 ts_library(
     name = "errors",
     srcs = ["errors.ts"],
+    strict = True,
 )
 
 ts_library(
     name = "git",
     srcs = ["git.ts"],
+    strict = True,
 )
 
 ts_jasmine_node_test(
@@ -76,6 +82,7 @@ ts_jasmine_node_test(
 ts_library(
     name = "scroller",
     srcs = ["scroller.ts"],
+    strict = True,
     deps = [
         ":animated_value",
         ":animation_loop",
@@ -85,6 +92,7 @@ ts_library(
 ts_library(
     name = "time_delta",
     srcs = ["time_delta.ts"],
+    strict = True,
     deps = [
         "@npm//tslib",
     ],
@@ -93,6 +101,7 @@ ts_library(
 ts_library(
     name = "math",
     srcs = ["math.ts"],
+    strict = True,
     deps = [
         "@npm//tslib",
     ],
@@ -101,6 +110,7 @@ ts_library(
 ts_library(
     name = "memo",
     srcs = ["memo.ts"],
+    strict = True,
     deps = [
         "@npm//tslib",
     ],

--- a/enterprise/app/group_search/BUILD
+++ b/enterprise/app/group_search/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//enterprise:__subpackages__"])
 ts_library(
     name = "group_search",
     srcs = glob(["*.tsx"]),
+    strict = True,
     deps = [
         "//app/auth",
         "//app/components/dialog:simple_modal_dialog",

--- a/enterprise/app/sidebar/BUILD
+++ b/enterprise/app/sidebar/BUILD
@@ -7,6 +7,7 @@ exports_files(["sidebar.css"])
 ts_library(
     name = "sidebar",
     srcs = glob(["*.tsx"]),
+    strict = True,
     deps = [
         "//app/auth",
         "//app/capabilities",

--- a/rules/typescript/index.bzl
+++ b/rules/typescript/index.bzl
@@ -10,10 +10,13 @@ def _swc(**kwargs):
         **kwargs
     )
 
-def ts_library(name, srcs, **kwargs):
+def ts_library(name, srcs, strict = False, **kwargs):
+    tsconfig = "//:tsconfig"
+    if strict:
+        tsconfig = "//:tsconfig_strict"
     ts_project(
         name = name,
-        tsconfig = "//:tsconfig",
+        tsconfig = tsconfig,
         composite = True,
         transpiler = _swc,
         srcs = srcs,

--- a/tsconfig_strict.json
+++ b/tsconfig_strict.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strict": true
+  }
+}


### PR DESCRIPTION
I know that you both said you don't think we should do this but I took a closer look and:
1. There are a bunch of errors, like 100+ across 40+ files based on my sample and while most of them are straightforward, there are some that are kind of involved. So, it'll probably take a while to write, test, and deploy fixes for the entire repo.
2. This makes it easier to tackle bit by bit because at least you know which package you're working on.
3. This doesn't seem that bad to me?

Curious to hear what both of you think, though.

**Version bump**: None
**Related issues**: Unblocks https://github.com/buildbuddy-io/buildbuddy-internal/issues/936