### PR TITLE
blog: update correct author's url

### DIFF
--- a/website/blog/welcoming-son-luong-ngoc.md
+++ b/website/blog/welcoming-son-luong-ngoc.md
@@ -4,7 +4,7 @@ title: Welcoming Son Luong Ngoc
 author: Siggi Simonarson
 author_title: Co-founder @ BuildBuddy
 date: 2023-1-10 12:00:00
-author_url: https://www.linkedin.com/in/luongngocson/
+author_url: https://www.linkedin.com/in/siggisim/
 author_image_url: https://avatars.githubusercontent.com/u/1704556?v=4
 image: /img/welcome_son.png
 tags: [company, team]


### PR DESCRIPTION
A friend of mine said he was confused when clicking on the blog post author would show my profile page instead. Let's fix that.

---

**Version bump**: None