### PR TITLE
Expand Firecracker scratchfs size from 30MB to 32MB

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -108,7 +108,7 @@ const (
 	scratchDriveID = "scratchfs"
 	// minScratchDiskSizeBytes is the minimum size needed for the scratch disk.
 	// This is needed because the init binary needs some space to copy files around.
-	minScratchDiskSizeBytes = 30e6
+	minScratchDiskSizeBytes = 32e6
 
 	// The containerfs drive ID.
 	containerFSName  = "containerfs.ext4"


### PR DESCRIPTION
This makes the `TestFirecrackerRunNOPWithZeroDisk` test pass (`bazel test --config=cache-dev //enterprise/server/remote_execution/containers/firecracker:firecracker_test --test_filter=TestFirecrackerRunNOPWithZeroDisk`) -- it is currently failing. I played around with it a bit and it looks like it only needs about 80KB-90KB more, but I figured we could give it a little bit of headroom.

**Version bump**: Patch