### PR TITLE
Allow clicking on percentile charts

### DIFF
--- a/enterprise/app/trends/percentile_chart.tsx
+++ b/enterprise/app/trends/percentile_chart.tsx
@@ -1,7 +1,17 @@
 import React from "react";
 
 import * as format from "../../../app/format/format";
-import { ResponsiveContainer, ComposedChart, CartesianGrid, XAxis, YAxis, Line, Legend, Tooltip } from "recharts";
+import {
+  ResponsiveContainer,
+  ComposedChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Line,
+  Legend,
+  Tooltip,
+  CurveProps,
+} from "recharts";
 
 export interface PercentilesChartProps {
   title: string;
@@ -13,15 +23,30 @@ export interface PercentilesChartProps {
   extractP90: (datum: string) => number;
   extractP95: (datum: string) => number;
   extractP99: (datum: string) => number;
+  onRowClicked?: (datum: string) => void;
 }
 
 export default class PercentilesChartComponent extends React.Component<PercentilesChartProps> {
+  private lastDataFromHover: string;
+
+  handleActiveDotClick() {
+    console.log(this.lastDataFromHover);
+    if (!this.props.onRowClicked || !this.lastDataFromHover) {
+      return;
+    }
+    this.props.onRowClicked(this.lastDataFromHover);
+  }
+
   render() {
     return (
       <div className="trend-chart">
         <div className="trend-chart-title">{this.props.title}</div>
         <ResponsiveContainer width="100%" height={300}>
-          <ComposedChart data={this.props.data}>
+          <ComposedChart
+            className={this.props.onRowClicked ? "trend-line-chart-interactive" : ""}
+            cursor="pointer"
+            data={this.props.data}
+            onClick={this.handleActiveDotClick.bind(this)}>
             <CartesianGrid strokeDasharray="3 3" />
             <Legend />
             <XAxis dataKey={this.props.extractLabel} />
@@ -35,6 +60,7 @@ export default class PercentilesChartComponent extends React.Component<Percentil
                   extractP90={this.props.extractP90}
                   extractP95={this.props.extractP95}
                   extractP99={this.props.extractP99}
+                  triggerCallback={(data) => (this.lastDataFromHover = data)}
                 />
               }
             />
@@ -89,6 +115,7 @@ interface PercentilesChartTooltipProps {
   extractP90: (datum: string) => number;
   extractP95: (datum: string) => number;
   extractP99: (datum: string) => number;
+  triggerCallback: (datum: string) => void;
 }
 
 function PercentilesChartTooltip({
@@ -100,9 +127,11 @@ function PercentilesChartTooltip({
   extractP90,
   extractP95,
   extractP99,
+  triggerCallback,
 }: PercentilesChartTooltipProps) {
   if (!active) return null;
   let data = payload[0].payload;
+  triggerCallback(data);
   return (
     <div className="trend-chart-hover">
       <div className="trend-chart-hover-label">{labelFormatter(data)}</div>
@@ -115,6 +144,4 @@ function PercentilesChartTooltip({
       </div>
     </div>
   );
-
-  return null;
 }

--- a/enterprise/app/trends/percentile_chart.tsx
+++ b/enterprise/app/trends/percentile_chart.tsx
@@ -1,7 +1,17 @@
 import React from "react";
 
 import * as format from "../../../app/format/format";
-import { ResponsiveContainer, ComposedChart, CartesianGrid, XAxis, YAxis, Line, Legend, Tooltip } from "recharts";
+import {
+  ResponsiveContainer,
+  ComposedChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Line,
+  Legend,
+  Tooltip,
+  TooltipProps,
+} from "recharts";
 
 export interface PercentilesChartProps {
   title: string;
@@ -94,9 +104,7 @@ export default class PercentilesChartComponent extends React.Component<Percentil
   }
 }
 
-interface PercentilesChartTooltipProps {
-  active?: boolean;
-  payload?: any[];
+interface PercentilesChartTooltipProps extends TooltipProps<any, any> {
   labelFormatter: (datum: string) => string;
   extractP50: (datum: string) => number;
   extractP75: (datum: string) => number;
@@ -106,30 +114,32 @@ interface PercentilesChartTooltipProps {
   triggerCallback: (datum: string) => void;
 }
 
-function PercentilesChartTooltip({
-  active,
-  payload,
-  labelFormatter,
-  extractP50,
-  extractP75,
-  extractP90,
-  extractP95,
-  extractP99,
-  triggerCallback,
-}: PercentilesChartTooltipProps) {
-  if (!active) return null;
-  let data = payload[0].payload;
-  triggerCallback(data);
-  return (
-    <div className="trend-chart-hover">
-      <div className="trend-chart-hover-label">{labelFormatter(data)}</div>
-      <div className="trend-chart-hover-value">
-        <div>p50: {format.durationSec(extractP50(data))}</div>
-        <div>p75: {format.durationSec(extractP75(data))}</div>
-        <div>p90: {format.durationSec(extractP90(data))}</div>
-        <div>p95: {format.durationSec(extractP95(data))}</div>
-        <div>p99: {format.durationSec(extractP99(data))}</div>
+class PercentilesChartTooltip extends React.Component<PercentilesChartTooltipProps> {
+  componentDidUpdate(prevProps: PercentilesChartTooltipProps) {
+    if (this.props.payload && this.props.payload.length > 0) {
+      this.props.triggerCallback(this.props.payload[0].payload);
+    }
+  }
+
+  render() {
+    if (!this.props.active || !this.props.payload || this.props.payload.length < 1) return null;
+
+    const data = this.props.payload[0].payload;
+    if (!data) {
+      return null;
+    }
+
+    return (
+      <div className="trend-chart-hover">
+        <div className="trend-chart-hover-label">{this.props.labelFormatter(data)}</div>
+        <div className="trend-chart-hover-value">
+          <div>p50: {format.durationSec(this.props.extractP50(data))}</div>
+          <div>p75: {format.durationSec(this.props.extractP75(data))}</div>
+          <div>p90: {format.durationSec(this.props.extractP90(data))}</div>
+          <div>p95: {format.durationSec(this.props.extractP95(data))}</div>
+          <div>p99: {format.durationSec(this.props.extractP99(data))}</div>
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
 }

--- a/enterprise/app/trends/percentile_chart.tsx
+++ b/enterprise/app/trends/percentile_chart.tsx
@@ -19,7 +19,7 @@ export interface PercentilesChartProps {
 export default class PercentilesChartComponent extends React.Component<PercentilesChartProps> {
   private lastDataFromHover: string;
 
-  handleActiveDotClick() {
+  handleRowClick() {
     if (!this.props.onRowClicked || !this.lastDataFromHover) {
       return;
     }
@@ -34,7 +34,7 @@ export default class PercentilesChartComponent extends React.Component<Percentil
           <ComposedChart
             data={this.props.data}
             cursor={this.props.onRowClicked ? "pointer" : ""}
-            onClick={this.handleActiveDotClick.bind(this)}>
+            onClick={this.handleRowClick.bind(this)}>
             <CartesianGrid strokeDasharray="3 3" />
             <Legend />
             <XAxis dataKey={this.props.extractLabel} />

--- a/enterprise/app/trends/percentile_chart.tsx
+++ b/enterprise/app/trends/percentile_chart.tsx
@@ -33,7 +33,7 @@ export default class PercentilesChartComponent extends React.Component<Percentil
         <ResponsiveContainer width="100%" height={300}>
           <ComposedChart
             data={this.props.data}
-            cursor={this.props.onRowClicked ? "pointer" : ""}
+            style={this.props.onRowClicked ? { cursor: "pointer" } : {}}
             onClick={this.handleRowClick.bind(this)}>
             <CartesianGrid strokeDasharray="3 3" />
             <Legend />

--- a/enterprise/app/trends/percentile_chart.tsx
+++ b/enterprise/app/trends/percentile_chart.tsx
@@ -1,17 +1,7 @@
 import React from "react";
 
 import * as format from "../../../app/format/format";
-import {
-  ResponsiveContainer,
-  ComposedChart,
-  CartesianGrid,
-  XAxis,
-  YAxis,
-  Line,
-  Legend,
-  Tooltip,
-  CurveProps,
-} from "recharts";
+import { ResponsiveContainer, ComposedChart, CartesianGrid, XAxis, YAxis, Line, Legend, Tooltip } from "recharts";
 
 export interface PercentilesChartProps {
   title: string;
@@ -30,7 +20,6 @@ export default class PercentilesChartComponent extends React.Component<Percentil
   private lastDataFromHover: string;
 
   handleActiveDotClick() {
-    console.log(this.lastDataFromHover);
     if (!this.props.onRowClicked || !this.lastDataFromHover) {
       return;
     }
@@ -43,9 +32,8 @@ export default class PercentilesChartComponent extends React.Component<Percentil
         <div className="trend-chart-title">{this.props.title}</div>
         <ResponsiveContainer width="100%" height={300}>
           <ComposedChart
-            className={this.props.onRowClicked ? "trend-line-chart-interactive" : ""}
-            cursor="pointer"
             data={this.props.data}
+            cursor={this.props.onRowClicked ? "pointer" : ""}
             onClick={this.handleActiveDotClick.bind(this)}>
             <CartesianGrid strokeDasharray="3 3" />
             <Legend />


### PR DESCRIPTION
I'll be using this on some charts for build times.

There isn't a concrete click handler for lines that provides the "closest" point, so I had to improvise a bit: this just uses the last date / x-axis value that we showed a tooltip for.  Since the percentile chart *always* shows a tooltip on hover, this seems alright to me--the user's click action will match the date that recharts thought they were hovering on.