### PR TITLE
Fix AddUserToGroup logic when user previously requested access

### DIFF
--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -396,6 +396,18 @@ func (d *UserDB) AddUserToGroup(ctx context.Context, userID string, groupID stri
 			return err
 		}
 		if existing != nil {
+			if existing.MembershipStatus == int32(grpb.GroupMembershipStatus_REQUESTED) {
+				return tx.Exec(`
+					UPDATE UserGroups
+					SET membership_status = ?
+					WHERE user_user_id = ?
+					AND group_group_id = ?
+					`,
+					grpb.GroupMembershipStatus_MEMBER,
+					userID,
+					groupID,
+				).Error
+			}
 			return status.AlreadyExistsError("You're already in this organization.")
 		}
 		row := &struct{ Count int64 }{}


### PR DESCRIPTION
Bug:
1. User US1 with email `@foo.com` requests access to a group GR1
2. An admin of GR1 (US2) then switches on "Automatically add anyone with an **@foo.com** email to this group"
3. User US1 attempts to join the group again, but they get the error "You're already in this organization."

This error message is incorrect because they're not actually in the organization yet. They just have a membership request, which has not been approved.

The expected behavior is that the join attempt in step 3 should automatically succeed, since GR1 has set `@foo.com` as their owned domain, and US1 has an `@foo.com` email.

In a future PR, we might consider changing this behavior so that Step (2) results in the membership request in step (1) being accepted automatically. But I figure this might be a bit too aggressive (having a setting toggle suddenly result in a bunch of new users being added to the org).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
