### PR TITLE
CLI: Have the highlight plugin handle TypeScript errors too.

### DIFF
--- a/cli/example_plugins/go-highlight/handle_bazel_output.py
+++ b/cli/example_plugins/go-highlight/handle_bazel_output.py
@@ -6,5 +6,15 @@ if __name__ == "__main__":
         m = re.search(r"^(.*?\.go:\d+:\d+:)(.*)", line)
         if m:
             print("\x1b[33m" + m.group(1) + "\x1b[0m" + m.group(2))
-        else:
-            print(line, end="")
+            continue
+
+        # TypeScript formats line numbers like "path.tsx(line,col)". In addition
+        # to highlighting, reformat as "path:line:col:" since VSCode allows
+        # Ctrl+Clicking to jump to that exact location in the code when it's
+        # formatted that way.
+        m = re.search(r"^(.*?\.tsx?)\((\d+),(\d+)\)(:)(.*)", line)
+        if m:
+            print("\x1b[33m%s:%s:%s%s\x1b[m%s" % m.groups())
+            continue
+
+        print(line, end="")


### PR DESCRIPTION
Also reformat the errors so that they're Ctrl+Clickable in VSCode. In VSCode you can Ctrl+Click things like `enterprise/app/root/root.tsx:100:50: some error` and it will jump to that exact code location. Ctrl+Click does not work when it's formatted w/ parens, like `enterprise/app/root/root.tsx(100,50): some error`.

![image](https://user-images.githubusercontent.com/2414826/212150949-95af2b30-f534-414d-8490-15269c6eba56.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
