### PR TITLE
CLI: bump version in docs to 5.0.0

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,13 +45,13 @@ bb version
 If you're already using Bazelisk, you can easily install the BuildBuddy CLI for your entire project by running:
 
 ```bash
-echo "$(echo "buildbuddy-io/0.1.4"; cat .bazelversion)" > .bazelversion
+echo "$(echo "buildbuddy-io/5.0.0"; cat .bazelversion)" > .bazelversion
 ```
 
-This will simply prepend `buildbuddy-io/0.1.4` on a new line above your `.bazelversion` file like so:
+This will simply prepend `buildbuddy-io/5.0.0` on a new line above your `.bazelversion` file like so:
 
 ```title=".bazelversion"
-buildbuddy-io/0.1.4
+buildbuddy-io/5.0.0
 5.3.2
 ```
 

--- a/website/src/pages/cli.tsx
+++ b/website/src/pages/cli.tsx
@@ -331,13 +331,13 @@ function Component() {
                 <>
                   <div>
                     <Prompt />
-                    <span>{`echo "$(echo "buildbuddy-io/0.1.4"; cat .bazelversion)" > .bazelversion`}</span>
+                    <span>{`echo "$(echo "buildbuddy-io/5.0.0"; cat .bazelversion)" > .bazelversion`}</span>
                   </div>
                 </>,
                 <>
                   <div>
                     <Prompt />
-                    <span>{`echo "$(echo "buildbuddy-io/0.1.4"; cat .bazelversion)" > .bazelversion`}</span>
+                    <span>{`echo "$(echo "buildbuddy-io/5.0.0"; cat .bazelversion)" > .bazelversion`}</span>
                   </div>
                   <div>
                     <Prompt />
@@ -346,7 +346,7 @@ function Component() {
                 <>
                   <div>
                     <Prompt />
-                    <span>{`echo "$(echo "buildbuddy-io/0.1.4"; cat .bazelversion)" > .bazelversion`}</span>
+                    <span>{`echo "$(echo "buildbuddy-io/5.0.0"; cat .bazelversion)" > .bazelversion`}</span>
                   </div>
                   <div>
                     <Prompt />
@@ -356,7 +356,7 @@ function Component() {
                 <>
                   <div>
                     <Prompt />
-                    <span>{`echo "$(echo "buildbuddy-io/0.1.4"; cat .bazelversion)" > .bazelversion`}</span>
+                    <span>{`echo "$(echo "buildbuddy-io/5.0.0"; cat .bazelversion)" > .bazelversion`}</span>
                   </div>
                   <div>
                     <Prompt />
@@ -370,7 +370,7 @@ function Component() {
           bigImage={true}
           lessPadding={true}
           flipped={false}
-          snippet={`echo "$(echo "buildbuddy-io/0.1.4"; cat .bazelversion)" > .bazelversion`}
+          snippet={`echo "$(echo "buildbuddy-io/5.0.0"; cat .bazelversion)" > .bazelversion`}
           primaryButtonText=""
           secondaryButtonText=""
         />


### PR DESCRIPTION
Bumping to 5.0.0 to skirt around an issue that Bazelisk refuses to download the arm64 version of `bb` on M1 Macs, because Bazelisk has some hard-coded logic that arm64 releases of "bazel" are only available starting with 4.1.0.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
