### PR TITLE
Remove restrictions on double compressing inlined data in pebble

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -298,10 +298,6 @@ func validateOpts(opts *Options) error {
 		}
 	}
 
-	if opts.MinBytesAutoZstdCompression < opts.MaxInlineFileSizeBytes {
-		return status.FailedPreconditionError("pebble cache should not compress inlined data because it is already compressed")
-	}
-
 	return nil
 }
 
@@ -318,9 +314,6 @@ func SetOptionDefaults(opts *Options) {
 	}
 	if opts.MaxInlineFileSizeBytes == 0 {
 		opts.MaxInlineFileSizeBytes = DefaultMaxInlineFileSizeBytes
-	}
-	if opts.MinBytesAutoZstdCompression == 0 {
-		opts.MinBytesAutoZstdCompression = DefaultMaxInlineFileSizeBytes
 	}
 	if opts.AtimeUpdateThreshold == nil {
 		opts.AtimeUpdateThreshold = &DefaultAtimeUpdateThreshold


### PR DESCRIPTION
Our estimated cache size is larger than the actual disk usage numbers, meaning we aren't utilizing the full availability of our allocated disk space. A hypothesis is that the actual size on our disks is smaller because Pebble compresses the data that we inline, so it's smaller than we expect. Before we had added checks to not double compress data. To more accurately get the size that's actually written, we want to compress all data, because then it will approximate the compressed size that Pebble is writing to disk, even if this means that inlined data will be compressed again by Pebble. 