### PR TITLE
Cleanup EnableZstdCompression flag

### DIFF
--- a/enterprise/server/backends/migration_cache/config.go
+++ b/enterprise/server/backends/migration_cache/config.go
@@ -33,20 +33,18 @@ type DiskCacheConfig struct {
 }
 
 type PebbleCacheConfig struct {
-	Name                   string                  `yaml:"name"`
-	RootDirectory          string                  `yaml:"root_directory"`
-	Partitions             []disk.Partition        `yaml:"partitions"`
-	PartitionMappings      []disk.PartitionMapping `yaml:"partition_mappings"`
-	MaxSizeBytes           int64                   `yaml:"max_size_bytes"`
-	BlockCacheSizeBytes    int64                   `yaml:"block_cache_size_bytes"`
-	MaxInlineFileSizeBytes int64                   `yaml:"max_inline_file_size_bytes"`
-	AtimeUpdateThreshold   *time.Duration          `yaml:"atime_update_threshold"`
-	AtimeWriteBatchSize    int                     `yaml:"atime_write_batch_size"`
-	AtimeBufferSize        *int                    `yaml:"atime_buffer_size"`
-	MinEvictionAge         *time.Duration          `yaml:"min_eviction_age"`
-
-	EnableZstdCompression       bool  `yaml:"enable_zstd_compression"`
-	MinBytesAutoZstdCompression int64 `yaml:"min_bytes_auto_zstd_compression"`
+	Name                        string                  `yaml:"name"`
+	RootDirectory               string                  `yaml:"root_directory"`
+	Partitions                  []disk.Partition        `yaml:"partitions"`
+	PartitionMappings           []disk.PartitionMapping `yaml:"partition_mappings"`
+	MaxSizeBytes                int64                   `yaml:"max_size_bytes"`
+	BlockCacheSizeBytes         int64                   `yaml:"block_cache_size_bytes"`
+	MaxInlineFileSizeBytes      int64                   `yaml:"max_inline_file_size_bytes"`
+	AtimeUpdateThreshold        *time.Duration          `yaml:"atime_update_threshold"`
+	AtimeWriteBatchSize         int                     `yaml:"atime_write_batch_size"`
+	AtimeBufferSize             *int                    `yaml:"atime_buffer_size"`
+	MinEvictionAge              *time.Duration          `yaml:"min_eviction_age"`
+	MinBytesAutoZstdCompression int64                   `yaml:"min_bytes_auto_zstd_compression"`
 }
 
 func (cfg *MigrationConfig) SetConfigDefaults() {

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -148,7 +148,6 @@ func pebbleCacheFromConfig(env environment.Env, cfg *PebbleCacheConfig) (*pebble
 		AtimeWriteBatchSize:         cfg.AtimeWriteBatchSize,
 		AtimeBufferSize:             cfg.AtimeBufferSize,
 		MinEvictionAge:              cfg.MinEvictionAge,
-		EnableZstdCompression:       cfg.EnableZstdCompression,
 	}
 	c, err := pebble_cache.NewPebbleCache(env, opts)
 	if err != nil {

--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"io/ioutil"
 	"sync"
 	"testing"
 	"time"
@@ -1327,10 +1328,9 @@ func TestReadWrite(t *testing.T) {
 		srcReader, err := srcCache.Reader(ctx, r, 0, 0)
 		require.NoError(t, err)
 
-		actualBuf = make([]byte, len(buf))
-		n, err = srcReader.Read(actualBuf)
+		actualBuf, err = ioutil.ReadAll(srcReader)
 		require.NoError(t, err)
-		require.Equal(t, int(testSize), n)
+		require.Equal(t, int(testSize), len(actualBuf))
 		require.True(t, bytes.Equal(buf, actualBuf))
 
 		err = srcReader.Close()
@@ -1339,10 +1339,9 @@ func TestReadWrite(t *testing.T) {
 		destReader, err := destCache.Reader(ctx, r, 0, 0)
 		require.NoError(t, err)
 
-		actualBuf = make([]byte, len(buf))
-		n, err = destReader.Read(actualBuf)
+		actualBuf, err = ioutil.ReadAll(destReader)
 		require.NoError(t, err)
-		require.Equal(t, int(testSize), n)
+		require.Equal(t, int(testSize), len(actualBuf))
 		require.True(t, bytes.Equal(buf, actualBuf))
 
 		err = destReader.Close()

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -378,7 +378,6 @@ func TestMetadata(t *testing.T) {
 	options := &pebble_cache.Options{
 		RootDirectory:               testfs.MakeTempDir(t),
 		MaxSizeBytes:                maxSizeBytes,
-		EnableZstdCompression:       true,
 		MinBytesAutoZstdCompression: math.MaxInt64, // Turn off automatic compression
 	}
 	pc, err := pebble_cache.NewPebbleCache(te, options)
@@ -741,9 +740,8 @@ func TestCompression(t *testing.T) {
 
 			maxSizeBytes := int64(1_000_000_000) // 1GB
 			opts := &pebble_cache.Options{
-				RootDirectory:         testfs.MakeTempDir(t),
-				MaxSizeBytes:          maxSizeBytes,
-				EnableZstdCompression: true,
+				RootDirectory: testfs.MakeTempDir(t),
+				MaxSizeBytes:  maxSizeBytes,
 			}
 			pc, err := pebble_cache.NewPebbleCache(te, opts)
 			if err != nil {
@@ -785,9 +783,8 @@ func TestCompression_BufferPoolReuse(t *testing.T) {
 
 	maxSizeBytes := int64(1000)
 	opts := &pebble_cache.Options{
-		RootDirectory:         testfs.MakeTempDir(t),
-		MaxSizeBytes:          maxSizeBytes,
-		EnableZstdCompression: true,
+		RootDirectory: testfs.MakeTempDir(t),
+		MaxSizeBytes:  maxSizeBytes,
 	}
 	pc, err := pebble_cache.NewPebbleCache(te, opts)
 	if err != nil {
@@ -843,9 +840,8 @@ func TestCompression_ParallelRequests(t *testing.T) {
 
 	maxSizeBytes := int64(1000)
 	opts := &pebble_cache.Options{
-		RootDirectory:         testfs.MakeTempDir(t),
-		MaxSizeBytes:          maxSizeBytes,
-		EnableZstdCompression: true,
+		RootDirectory: testfs.MakeTempDir(t),
+		MaxSizeBytes:  maxSizeBytes,
 	}
 	pc, err := pebble_cache.NewPebbleCache(te, opts)
 	if err != nil {
@@ -924,10 +920,9 @@ func TestCompression_NoEarlyEviction(t *testing.T) {
 			float64(totalSizeCompresedData) *
 				(1 / pebble_cache.JanitorCutoffThreshold))) // account for .9 evictor cutoff
 	opts := &pebble_cache.Options{
-		RootDirectory:         testfs.MakeTempDir(t),
-		MaxSizeBytes:          maxSizeBytes,
-		EnableZstdCompression: true,
-		MinEvictionAge:        &minEvictionAge,
+		RootDirectory:  testfs.MakeTempDir(t),
+		MaxSizeBytes:   maxSizeBytes,
+		MinEvictionAge: &minEvictionAge,
 	}
 	pc, err := pebble_cache.NewPebbleCache(te, opts)
 	require.NoError(t, err)
@@ -986,9 +981,8 @@ func TestCompressionOffset(t *testing.T) {
 
 	maxSizeBytes := int64(1_000_000_000) // 1GB
 	opts := &pebble_cache.Options{
-		RootDirectory:         testfs.MakeTempDir(t),
-		MaxSizeBytes:          maxSizeBytes,
-		EnableZstdCompression: true,
+		RootDirectory: testfs.MakeTempDir(t),
+		MaxSizeBytes:  maxSizeBytes,
 	}
 	pc, err := pebble_cache.NewPebbleCache(te, opts)
 	require.NoError(t, err)


### PR DESCRIPTION
Now that we've validated that zstd compression is stable, we can remove this flag
