### PR TITLE
Add PebbleKey with versions

### DIFF
--- a/enterprise/server/raft/filestore/BUILD
+++ b/enterprise/server/raft/filestore/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -13,5 +13,18 @@ go_library(
         "//server/util/disk",
         "//server/util/log",
         "//server/util/status",
+    ],
+)
+
+go_test(
+    name = "filestore_test",
+    srcs = ["filestore_test.go"],
+    deps = [
+        ":filestore",
+        "//proto:raft_go_proto",
+        "//proto:resource_go_proto",
+        "//server/testutil/testdigest",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/raft/filestore/filestore.go
+++ b/enterprise/server/raft/filestore/filestore.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/proto/resource"
@@ -55,10 +56,147 @@ func fileRecordSegments(r *rfpb.FileRecord) (partID string, groupID string, isol
 	return
 }
 
+type PebbleKeyVersion int
+
+const (
+	// UndefinedKeyVersion is the version of all keys in the database
+	// that have not yet been versioned.
+	UndefinedKeyVersion PebbleKeyVersion = 0
+
+	// Version1 is the first key version that includes a version in the
+	// key path, to disambiguate reading old keys.
+	Version1 = 1
+
+	// Version2 is the same as Version1, plus a change that moves the
+	// remote instance name hash to the end of the key rather than the
+	// beginning. This allows for even sampling across the keyspace,
+	// regardless of remote instance name.
+	Version2 = 2
+)
+
+type PebbleKey struct {
+	partID             string
+	groupID            string
+	isolation          string
+	remoteInstanceHash string
+	hash               string
+
+	prioritizeHashInMetadataKey bool
+}
+
+func (pmk *PebbleKey) String() string {
+	fmk, err := pmk.Bytes(UndefinedKeyVersion)
+	if err != nil {
+		return err.Error()
+	}
+	return string(fmk)
+}
+
+func (pmk *PebbleKey) Bytes(version PebbleKeyVersion) ([]byte, error) {
+	switch version {
+	case UndefinedKeyVersion:
+		filePath := filepath.Join(pmk.isolation, pmk.remoteInstanceHash, pmk.hash)
+		if pmk.isolation == "ac" {
+			filePath = filepath.Join(pmk.groupID, filePath)
+		}
+		partDir := PartitionDirectoryPrefix + pmk.partID
+		filePath = filepath.Join(partDir, filePath)
+
+		return []byte(filePath), nil
+	case Version1:
+		filePath := filepath.Join(pmk.isolation, pmk.remoteInstanceHash, pmk.hash)
+		if pmk.isolation == "ac" {
+			filePath = filepath.Join(pmk.groupID, filePath)
+		}
+		partDir := "/v1/" + PartitionDirectoryPrefix + pmk.partID
+		filePath = filepath.Join(partDir, filePath)
+		return []byte(filePath), nil
+	case Version2:
+		filePath := filepath.Join(pmk.hash, pmk.isolation, pmk.remoteInstanceHash)
+		if pmk.isolation == "ac" {
+			filePath = filepath.Join(pmk.groupID, filePath)
+		}
+		partDir := "/v3/" + PartitionDirectoryPrefix + pmk.partID
+		filePath = filepath.Join(partDir, filePath)
+		return []byte(filePath), nil
+	default:
+		return nil, status.FailedPreconditionErrorf("Unknown key version: %v", version)
+	}
+}
+
+func (pmk *PebbleKey) parseUndefinedVersion(parts [][]byte) error {
+	switch len(parts) {
+	case 3:
+		pmk.partID, pmk.isolation, pmk.hash = string(parts[0]), string(parts[1]), string(parts[2])
+	case 5:
+		pmk.partID, pmk.groupID, pmk.isolation, pmk.remoteInstanceHash, pmk.hash = string(parts[0]), string(parts[1]), string(parts[2]), string(parts[3]), string(parts[4])
+	default:
+		return status.InvalidArgumentErrorf("Unable to parse %v to pebble key", parts)
+	}
+	pmk.partID = strings.TrimPrefix(pmk.partID, PartitionDirectoryPrefix)
+	return nil
+}
+
+func (pmk *PebbleKey) parseVersion1(parts [][]byte) error {
+	switch len(parts) {
+	case 4:
+		pmk.partID, pmk.isolation, pmk.hash = string(parts[1]), string(parts[2]), string(parts[3])
+	case 6:
+		pmk.partID, pmk.groupID, pmk.isolation, pmk.remoteInstanceHash, pmk.hash = string(parts[1]), string(parts[2]), string(parts[3]), string(parts[4]), string(parts[5])
+	default:
+		return status.InvalidArgumentErrorf("Unable to parse %v to pebble key", parts)
+	}
+	pmk.partID = strings.TrimPrefix(pmk.partID, PartitionDirectoryPrefix)
+	return nil
+}
+
+func (pmk *PebbleKey) parseVersion2(parts [][]byte) error {
+	switch len(parts) {
+	case 4:
+		pmk.partID, pmk.hash, pmk.isolation = string(parts[1]), string(parts[2]), string(parts[3])
+	case 6:
+		pmk.partID, pmk.groupID, pmk.hash, pmk.isolation, pmk.remoteInstanceHash = string(parts[1]), string(parts[2]), string(parts[3]), string(parts[4]), string(parts[5])
+	default:
+		return status.InvalidArgumentErrorf("Unable to parse %v to pebble key", parts)
+	}
+	pmk.partID = strings.TrimPrefix(pmk.partID, PartitionDirectoryPrefix)
+	return nil
+}
+
+func (pmk *PebbleKey) FromBytes(in []byte) (PebbleKeyVersion, error) {
+	version := UndefinedKeyVersion
+	parts := bytes.Split(in, []byte{filepath.Separator})
+
+	if len(parts) == 0 {
+		return -1, status.InvalidArgumentErrorf("Unable to parse %q to pebble key", in)
+	}
+
+	// Attempt to read the key version, if one is present. This allows for much
+	// simpler parsing because we can restrict the set of valid parse inputs
+	// instead of having to possibly parse any/all versions at once.
+	if len(parts[0]) > 1 && parts[0][0] == byte('v') {
+		if s, err := strconv.ParseUint(string(parts[0][1:]), 10, 32); err == nil {
+			version = PebbleKeyVersion(s)
+		}
+	}
+
+	switch version {
+	case UndefinedKeyVersion:
+		return UndefinedKeyVersion, pmk.parseUndefinedVersion(parts)
+	case Version1:
+		return Version1, pmk.parseVersion1(parts)
+	case Version2:
+		return Version2, pmk.parseVersion2(parts)
+	default:
+		return -1, status.InvalidArgumentErrorf("Unable to parse %q to pebble key", in)
+	}
+}
+
 type Store interface {
 	FileKey(r *rfpb.FileRecord) ([]byte, error)
 	FilePath(fileDir string, f *rfpb.StorageMetadata_FileMetadata) string
 	FileMetadataKey(r *rfpb.FileRecord) ([]byte, error)
+	PebbleKey(r *rfpb.FileRecord) (*PebbleKey, error)
 
 	NewReader(ctx context.Context, fileDir string, md *rfpb.StorageMetadata, offset, limit int64) (io.ReadCloser, error)
 	NewWriter(ctx context.Context, fileDir string, fileRecord *rfpb.FileRecord) (interfaces.CommittedMetadataWriteCloser, error)
@@ -142,25 +280,26 @@ func (fs *fileStorer) FileMetadataKey(r *rfpb.FileRecord) ([]byte, error) {
 	//    for example:
 	//      PART123456/GR123/abcd12345asdasdasd123123123asdasdasd/ac/44321
 	//      PART123456/GR123/abcd12345asdasdasd123123123asdasdasd/cas
+	pmk, err := fs.PebbleKey(r)
+	if err != nil {
+		return nil, err
+	}
+	return pmk.Bytes(UndefinedKeyVersion)
+}
+
+func (fs *fileStorer) PebbleKey(r *rfpb.FileRecord) (*PebbleKey, error) {
 	partID, groupID, isolation, remoteInstanceHash, hash, err := fileRecordSegments(r)
 	if err != nil {
 		return nil, err
 	}
-
-	var filePath string
-	if fs.prioritizeHashInMetadataKey {
-		filePath = filepath.Join(hash, isolation, remoteInstanceHash)
-	} else {
-		filePath = filepath.Join(isolation, remoteInstanceHash, hash)
-	}
-
-	if r.GetIsolation().GetCacheType() == resource.CacheType_AC {
-		filePath = filepath.Join(groupID, filePath)
-	}
-	partDir := PartitionDirectoryPrefix + partID
-	filePath = filepath.Join(partDir, filePath)
-
-	return []byte(filePath), nil
+	return &PebbleKey{
+		partID:                      partID,
+		groupID:                     groupID,
+		isolation:                   isolation,
+		remoteInstanceHash:          remoteInstanceHash,
+		hash:                        hash,
+		prioritizeHashInMetadataKey: fs.prioritizeHashInMetadataKey,
+	}, nil
 }
 
 func (fs *fileStorer) NewWriter(ctx context.Context, fileDir string, fileRecord *rfpb.FileRecord) (interfaces.CommittedMetadataWriteCloser, error) {

--- a/enterprise/server/raft/filestore/filestore_test.go
+++ b/enterprise/server/raft/filestore/filestore_test.go
@@ -31,6 +31,9 @@ func TestKeyVersionCrossCompatibility(t *testing.T) {
 			},
 			Digest: d,
 		}
+		if i%2 == 0 {
+			fr.Isolation.CacheType = resource.CacheType_CAS
+		}
 		sourceKey, err := fs.PebbleKey(fr)
 		require.NoError(t, err)
 
@@ -43,7 +46,7 @@ func TestKeyVersionCrossCompatibility(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, i, parsedVersion)
-			assert.Equal(t, sourceKey, parsedKey)
+			assert.Equal(t, sourceKey.String(), parsedKey.String())
 
 			_, err = parsedKey.Bytes(j)
 			require.NoError(t, err)

--- a/enterprise/server/raft/filestore/filestore_test.go
+++ b/enterprise/server/raft/filestore/filestore_test.go
@@ -1,0 +1,52 @@
+package filestore_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/filestore"
+	"github.com/buildbuddy-io/buildbuddy/proto/resource"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+)
+
+func TestKeyVersionCrossCompatibility(t *testing.T) {
+	testGroupID := "GR7890"
+	partitionID := "FOO"
+	fs := filestore.New(filestore.Opts{})
+
+	// What we are testing here is that for every version a key can be
+	// written at, it can also be re-read and rewritten at every other version.
+	for i := filestore.UndefinedKeyVersion; i < filestore.TestingMaxKeyVersion; i++ {
+		d, _ := testdigest.NewRandomDigestBuf(t, 100)
+		fr := &rfpb.FileRecord{
+			Isolation: &rfpb.Isolation{
+				CacheType:          resource.CacheType_AC,
+				RemoteInstanceName: "remote_instance_name",
+				PartitionId:        partitionID,
+				GroupId:            testGroupID,
+			},
+			Digest: d,
+		}
+		sourceKey, err := fs.PebbleKey(fr)
+		require.NoError(t, err)
+
+		keyBytes, err := sourceKey.Bytes(i)
+		require.NoError(t, err)
+
+		for j := filestore.UndefinedKeyVersion; j < filestore.TestingMaxKeyVersion; j++ {
+			parsedKey := &filestore.PebbleKey{}
+			parsedVersion, err := parsedKey.FromBytes(keyBytes)
+
+			assert.NoError(t, err)
+			assert.Equal(t, i, parsedVersion)
+			assert.Equal(t, sourceKey, parsedKey)
+
+			_, err = parsedKey.Bytes(j)
+			require.NoError(t, err)
+		}
+	}
+}


### PR DESCRIPTION
Principles of Migration:
 - you must always be able to read and write multiple versions of the data
 	- this ensures the DB is "rollback-safe"
	- first ship a code change that speaks the new version, then, once you're sure it won't be rolled back, flip the flag to change current-version
 - switch to the new version then once everything is migrated, bump db version so multi-version reads are no longer necessary

A **PebbleKey** is version agnostic -- it can be read or written at any version
	- this is enforced by unit tests that read and write keys at all versions from min-to-max and ensure they are compatible

A **Migrator** is responsible for reading keys *and values* at one version and writing them at another
	- this allows us to upgrade values if we desire

When you write a new key to the DB, it's written at currentVersion (flag controlled)
When you read a key from the DB, it's looked for between (dbVersion, latestVersion)

- currently, everything in the DB is of undefined version
- our first migration will do nothing but store the version in the key
- we'll then migrate everything to version 2 which reorders keys

For simplicity, we'll only ever do one migration at a time.
