### PR TITLE
Add Ubuntu 20.04 workflows image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -268,6 +268,12 @@ dockerfile_image(
 )
 
 dockerfile_image(
+    name = "rbe-ubuntu20-04-workflows_image",
+    dockerfile = "//enterprise/dockerfiles/rbe-ubuntu20-04-workflows:Dockerfile",
+    visibility = ["//visibility:public"],
+)
+
+dockerfile_image(
     name = "run_script_image",
     dockerfile = "//dockerfiles/run_script:Dockerfile",
     visibility = ["//visibility:public"],

--- a/enterprise/dockerfiles/rbe-ubuntu20-04-workflows/Dockerfile
+++ b/enterprise/dockerfiles/rbe-ubuntu20-04-workflows/Dockerfile
@@ -1,0 +1,13 @@
+FROM gcr.io/flame-public/rbe-ubuntu20-04@sha256:036ae8c90876fa22da9ace6f8218e614f4cd500a154fc162973fff691e72d28e
+
+# Install bazelisk
+RUN curl -Lo /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-amd64 && \
+    chmod +x /usr/local/bin/bazelisk
+
+# Pre-download/extract bazel so that Bazel can skip that work on first run,
+# at least for CI runs on the BB repo itself.
+RUN USE_BAZEL_VERSION=6.0.0 bazelisk version
+
+# Provision a non-root user named "buildbuddy".
+# Non-root users are needed for some bazel toolchains, such as hermetic python.
+RUN useradd --create-home buildbuddy

--- a/enterprise/server/deployment/BUILD
+++ b/enterprise/server/deployment/BUILD
@@ -12,3 +12,14 @@ container_push(
     tag_file = "//deployment:image_tag_file",
     tags = ["manual"],  # Don't include this target in wildcard patterns
 )
+
+container_push(
+    name = "push_rbe-ubuntu20-04-workflows",
+    format = "Docker",
+    image = "@rbe-ubuntu20-04-workflows_image//image:dockerfile_image.tar",
+    registry = "gcr.io",
+    repository = "flame-public/rbe-ubuntu20-04-workflows",
+    # Set the image tag with the bazel run flag "--//deployment:image_tag=TAG"
+    tag_file = "//deployment:image_tag_file",
+    tags = ["manual"],  # Don't include this target in wildcard patterns
+)


### PR DESCRIPTION
Note, unlike the 18.04-based image, this image does not have a step that installs `build-essential`, `git 2.38.1` (from ppa), and `python3.6-dev`, because:

- `build-essential` is already installed in the new rbe-ubuntu20-04 image
- The `git` version in the rbe-ubuntu20-04 base image is sufficiently high for `git clone --filter=blob:none --no-checkout` to work (`git 2.25.1`). The version in the ppa (and in the current CI runner image) is 2.38.1, so we're downgrading the git version relative to the 18.04 image, but I figure it's worth the downgrade since we're reducing the complexity of the image. If people need a newer version for whatever reason, we can either upgrade the image later, or tell people they can use a custom image which installs git from the ppa.
- We install `python3-dev` in the new rbe-ubuntu20-04 image, which should cover the use cases for the `python3.6-dev` package in the 18.04-based image (I think it was the python gRPC package which just needs the dev package to be available for whatever python3 version is installed.)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1830

