### PR TITLE
Workflows: Make container image configurable

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -694,6 +695,9 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 		CommitSha:          *commitSHA,
 		TargetRepoUrl:      *targetRepoURL,
 		TargetBranch:       *targetBranch,
+		Os:                 runtime.GOOS,
+		Arch:               runtime.GOARCH,
+		ContainerImage:     ar.action.ContainerImage,
 	}
 	wfcEvent := &bespb.BuildEvent{
 		Id:      &bespb.BuildEventId{Id: &bespb.BuildEventId_WorkflowConfigured{WorkflowConfigured: &bespb.BuildEventId_WorkflowConfiguredId{}}},

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -27,6 +27,7 @@ type Action struct {
 	Triggers          *Triggers         `yaml:"triggers"`
 	OS                string            `yaml:"os"`
 	Arch              string            `yaml:"arch"`
+	ContainerImage    string            `yaml:"container_image"`
 	ResourceRequests  ResourceRequests  `yaml:"resource_requests"`
 	User              string            `yaml:"user"`
 	GitCleanExclude   []string          `yaml:"git_clean_exclude"`

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -1191,6 +1191,17 @@ message WorkflowConfigured {
   // The branch into which the pushed branch is being merged (for PRs),
   // or the pushed_branch (for push events).
   string target_branch = 10;
+
+  // The OS on which the workflow is running.
+  // Adheres to the same naming convention as GOOS in golang.
+  string os = 11;
+
+  // The CPU architecture on which the workflow is running.
+  // Adheres to the same naming convention as GOARCH in golang.
+  string arch = 12;
+
+  // Container image spec for the workflow, if applicable.
+  string container_image = 13;
 }
 
 // Event describing a workflow command that completed.


### PR DESCRIPTION
- Add a `container_image` setting to workflow actions, which maps to the "container-image" platform prop and works mostly the same way as regular RBE actions.
  - Let people use `ubuntu-18.04` / `ubuntu-20.04` as aliases for our Ubuntu workflow images, similar to GitHub actions' `runs-on` prop.
- Send up the `container_image` value in the `WorkflowConfigured` event so that we can show deprecation/migration warnings in the UI if needed (for example, if it's blank, we can encourage people to upgrade from the default 18.04 image to 20.04). Also set `OS` and `Arch` since the UI needs to know whether the OS is Linux to decide whether to show any warnings about `container_image`, and arch is just extra "nice to have" info which we can show in the invocation details bar just like we do for regular invocations.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1830
