### PR TITLE
Add metrics for bytes sent to/from server and for ac_server

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -139,6 +139,9 @@ const (
 	// Describes the type of cache request
 	CacheRequestType = "type"
 
+	// Describes the name of the server that handles a client request, such as "byte_stream_server" or "cas_server"
+	ServerName = "server_name"
+
 	// Describes the type of compression
 	CompressionType = "compression"
 
@@ -311,6 +314,7 @@ var (
 		Help:      "Number of bytes downloaded from the remote cache in each download. Use the **`_sum`** suffix to get the total downloaded bytes and the **`_count`** suffix to get the number of downloaded files.",
 	}, []string{
 		CacheTypeLabel,
+		ServerName,
 	})
 
 	/// #### Examples
@@ -348,6 +352,7 @@ var (
 		Help:      "Number of bytes uploaded to the remote cache in each upload. Use the **`_sum`** suffix to get the total uploaded bytes and the **`_count`** suffix to get the number of uploaded files.",
 	}, []string{
 		CacheTypeLabel,
+		ServerName,
 	})
 
 	/// #### Examples
@@ -1536,6 +1541,50 @@ var (
 	}, []string{
 		CacheNameLabel,
 		CompressionType,
+	})
+
+	ServerUploadSizeBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "server",
+		Name:      "upload_size_bytes",
+		Buckets:   prometheus.ExponentialBuckets(1, 10, 9),
+		Help:      "Number of bytes uploaded to the server in each upload. Use the **`_sum`** suffix to get the total uploaded bytes and the **`_count`** suffix to get the number of uploaded files.",
+	}, []string{
+		CacheTypeLabel,
+		ServerName,
+	})
+
+	ServerDownloadSizeBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "server",
+		Name:      "download_size_bytes",
+		Buckets:   prometheus.ExponentialBuckets(1, 10, 9),
+		Help:      "Number of bytes downloaded from the server in each download. Use the **`_sum`** suffix to get the total downloaded bytes and the **`_count`** suffix to get the number of downloaded files.",
+	}, []string{
+		CacheTypeLabel,
+		ServerName,
+	})
+
+	DigestUploadSizeBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "server",
+		Name:      "digest_upload_size_bytes",
+		Buckets:   prometheus.ExponentialBuckets(1, 10, 9),
+		Help:      "Digest size uploaded to the server in each upload. This does not always match the actual size uploaded to the server, if the client sends compressed bytes. Use the **`_sum`** suffix to get the total uploaded bytes and the **`_count`** suffix to get the number of uploaded files.",
+	}, []string{
+		CacheTypeLabel,
+		ServerName,
+	})
+
+	DigestDownloadSizeBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "server",
+		Name:      "digest_download_size_bytes",
+		Buckets:   prometheus.ExponentialBuckets(1, 10, 9),
+		Help:      "Digest size downloaded from the server in each download. This does not always match the actual size downloaded to the server, if the client requests compressed bytes. Use the **`_sum`** suffix to get the total downloaded bytes and the **`_count`** suffix to get the number of downloaded files.",
+	}, []string{
+		CacheTypeLabel,
+		ServerName,
 	})
 
 	/// #### Examples

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -159,7 +159,7 @@ func (s *ActionCacheServer) GetActionResult(ctx context.Context, req *repb.GetAc
 		ht.TrackMiss(d)
 		return nil, status.NotFoundErrorf("ActionResult (%s) not found: %s", d, err)
 	}
-	defer downloadTracker.Close()
+	defer downloadTracker.CloseWithBytesTransferred(int64(len(blob)), int64(len(blob)), repb.Compressor_IDENTITY, "ac_server")
 
 	rsp := &repb.ActionResult{}
 	if err := proto.Unmarshal(blob, rsp); err != nil {
@@ -231,6 +231,6 @@ func (s *ActionCacheServer) UpdateActionResult(ctx context.Context, req *repb.Up
 	if err := s.cache.Set(ctx, acResource.ToProto(), blob); err != nil {
 		return nil, err
 	}
-	uploadTracker.Close()
+	uploadTracker.CloseWithBytesTransferred(int64(len(blob)), int64(len(blob)), repb.Compressor_IDENTITY, "ac_server")
 	return req.ActionResult, nil
 }

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -171,7 +171,7 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 		bytesFromCache = counter.Count()
 	}
 
-	downloadTracker.CloseWithBytesTransferred(bytesFromCache, int64(bytesTransferredToClient), r.GetCompressor())
+	downloadTracker.CloseWithBytesTransferred(bytesFromCache, int64(bytesTransferredToClient), r.GetCompressor(), "byte_stream_server")
 	return err
 }
 
@@ -394,7 +394,7 @@ func (s *ByteStreamServer) Write(stream bspb.ByteStream_WriteServer) error {
 			ht := hit_tracker.NewHitTracker(ctx, s.env, false)
 			uploadTracker := ht.TrackUpload(streamState.resourceName.GetDigest())
 			defer func() {
-				uploadTracker.CloseWithBytesTransferred(streamState.offset, int64(bytesUploadedFromClient), streamState.resourceName.GetCompressor())
+				uploadTracker.CloseWithBytesTransferred(streamState.offset, int64(bytesUploadedFromClient), streamState.resourceName.GetCompressor(), "byte_stream_server")
 			}()
 		} else { // Subsequent messages
 			if err := checkSubsequentPreconditions(req, streamState); err != nil {
@@ -472,7 +472,7 @@ func (s *ByteStreamServer) handleAlreadyExists(ctx context.Context, stream bspb.
 			ht := hit_tracker.NewHitTracker(ctx, s.env, false)
 			uploadTracker := ht.TrackUpload(r.GetDigest())
 			remainingSize, err = s.recvAll(stream)
-			uploadTracker.CloseWithBytesTransferred(0, int64(len(firstRequest.Data))+remainingSize, r.GetCompressor())
+			uploadTracker.CloseWithBytesTransferred(0, int64(len(firstRequest.Data))+remainingSize, r.GetCompressor(), "byte_stream_server")
 			if err != nil {
 				return err
 			}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -174,7 +174,7 @@ func (s *ContentAddressableStorageServer) BatchUpdateBlobs(ctx context.Context, 
 		bytesWrittenToCache := 0
 		bytesFromClient := len(uploadRequest.GetData())
 		defer func() {
-			uploadTracker.CloseWithBytesTransferred(int64(bytesWrittenToCache), int64(bytesFromClient), uploadRequest.GetCompressor())
+			uploadTracker.CloseWithBytesTransferred(int64(bytesWrittenToCache), int64(bytesFromClient), uploadRequest.GetCompressor(), "cas_server")
 		}()
 
 		if uploadDigest.GetHash() == digest.EmptySha256 {
@@ -299,7 +299,7 @@ func (s *ContentAddressableStorageServer) BatchReadBlobs(ctx context.Context, re
 		}
 		downloadTracker := ht.TrackDownload(readDigest)
 		closeTrackerFuncs = append(closeTrackerFuncs, func(data downloadTrackerData) {
-			downloadTracker.CloseWithBytesTransferred(int64(data.bytesReadFromCache), int64(data.bytesDownloadedToClient), data.compressor)
+			downloadTracker.CloseWithBytesTransferred(int64(data.bytesReadFromCache), int64(data.bytesDownloadedToClient), data.compressor, "cas_server")
 		})
 
 		if readDigest.GetHash() != digest.EmptySha256 {

--- a/server/remote_cache/hit_tracker/hit_tracker_test.go
+++ b/server/remote_cache/hit_tracker/hit_tracker_test.go
@@ -46,7 +46,7 @@ func TestHitTracker_RecordsDetailedStats(t *testing.T) {
 	ht := hit_tracker.NewHitTracker(ctx, env, actionCache)
 
 	dl := ht.TrackDownload(d)
-	dl.CloseWithBytesTransferred(compressedSize, compressedSize, repb.Compressor_ZSTD)
+	dl.CloseWithBytesTransferred(compressedSize, compressedSize, repb.Compressor_ZSTD, "test")
 
 	sc := hit_tracker.ScoreCard(ctx, env, iid)
 	require.Len(t, sc.Results, 1, "expected exactly one cache result")
@@ -101,7 +101,7 @@ func TestHitTracker_RecordsUsage(t *testing.T) {
 		ht := hit_tracker.NewHitTracker(ctx, env, actionCache)
 
 		dl := ht.TrackDownload(d)
-		dl.CloseWithBytesTransferred(compressedSize, compressedSize, repb.Compressor_ZSTD)
+		dl.CloseWithBytesTransferred(compressedSize, compressedSize, repb.Compressor_ZSTD, "test")
 
 		require.Len(t, ut.Increments, 1)
 		assert.Equal(t, []*tables.UsageCounts{{
@@ -130,7 +130,7 @@ func TestHitTracker_RecordsUsage(t *testing.T) {
 		ht := hit_tracker.NewHitTracker(ctx, env, actionCache)
 
 		dl := ht.TrackDownload(d)
-		dl.CloseWithBytesTransferred(compressedSize, compressedSize, repb.Compressor_ZSTD)
+		dl.CloseWithBytesTransferred(compressedSize, compressedSize, repb.Compressor_ZSTD, "test")
 
 		assert.Equal(t, []*tables.UsageCounts{{
 			CASCacheHits:           1,
@@ -156,7 +156,7 @@ func TestHitTracker_RecordsUsage(t *testing.T) {
 		ht := hit_tracker.NewHitTracker(ctx, env, actionCache)
 
 		dl := ht.TrackDownload(d)
-		dl.CloseWithBytesTransferred(d.SizeBytes, d.SizeBytes, repb.Compressor_IDENTITY)
+		dl.CloseWithBytesTransferred(d.SizeBytes, d.SizeBytes, repb.Compressor_IDENTITY, "test")
 
 		assert.Equal(t, []*tables.UsageCounts{{
 			ActionCacheHits:        1,


### PR DESCRIPTION
In prod, the number of bytes downloaded/uploaded from the cache don't seem to have gone down after turning on compression in the executors. Add additional metrics to look into this more and a server label to help break down where our cache requests are originating from. Also start emitting cache metrics from the action cache server.
