### PR TITLE
Executor: Warm up new Ubuntu 20.04 images

### DIFF
--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	runnerPath           = "enterprise/server/cmd/ci_runner/buildbuddy_ci_runner"
-	RunnerContainerImage = "docker://gcr.io/flame-public/buildbuddy-ci-runner@sha256:fbff6d1e88e9e1085c7e46bd0c5de4f478e97b630246631e5f9d7c720c968e2e"
+	RunnerContainerImage = "docker://" + platform.Ubuntu18_04WorkflowsImage
 )
 
 type runnerService struct {

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -26,12 +26,18 @@ var (
 	enablePodman         = flag.Bool("executor.enable_podman", false, "Enables running execution commands inside podman container.")
 	enableSandbox        = flag.Bool("executor.enable_sandbox", false, "Enables running execution commands inside of sandbox-exec.")
 	enableFirecracker    = flag.Bool("executor.enable_firecracker", false, "Enables running execution commands inside of firecracker VMs")
-	defaultImage         = flag.String("executor.default_image", "gcr.io/flame-public/executor-docker-default:enterprise-v1.6.0", "The default docker image to use to warm up executors or if no platform property is set. Ex: gcr.io/flame-public/executor-docker-default:enterprise-v1.5.4")
+	defaultImage         = flag.String("executor.default_image", Ubuntu16_04Image, "The default docker image to use to warm up executors or if no platform property is set. Ex: gcr.io/flame-public/executor-docker-default:enterprise-v1.5.4")
 	enableVFS            = flag.Bool("executor.enable_vfs", false, "Whether FUSE based filesystem is enabled.")
 	extraEnvVars         = flagutil.New("executor.extra_env_vars", []string{}, "Additional environment variables to pass to remotely executed actions. i.e. MY_ENV_VAR=foo")
 )
 
 const (
+	Ubuntu16_04Image = "gcr.io/flame-public/executor-docker-default:enterprise-v1.6.0"
+	Ubuntu20_04Image = "gcr.io/flame-public/rbe-ubuntu20-04@sha256:036ae8c90876fa22da9ace6f8218e614f4cd500a154fc162973fff691e72d28e"
+
+	Ubuntu18_04WorkflowsImage = "gcr.io/flame-public/buildbuddy-ci-runner:v2.3.0"
+	Ubuntu20_04WorkflowsImage = "gcr.io/flame-public/rbe-ubuntu20-04-workflows@sha256:e74147369e5ff5c6c9d56f15ab10a894d54d4f45f14455ad418f70ddb59850e3"
+
 	// overrideHeaderPrefix is a prefix used to override platform props via
 	// remote headers. The property name immediately follows the prefix in the
 	// header key, and the header value is used as the property value.

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -8,7 +8,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/runner",
     deps = [
         "//enterprise/server/auth",
-        "//enterprise/server/hostedrunner",
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/containers/bare",

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -52,10 +52,6 @@ import (
 	guuid "github.com/google/uuid"
 )
 
-const (
-	workflowsImage = "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.3.0"
-)
-
 var (
 	enableFirecracker             = flag.Bool("remote_execution.workflows_enable_firecracker", false, "Whether to enable firecracker for Linux workflow actions.")
 	workflowsPoolName             = flag.String("remote_execution.workflows_pool_name", "", "The executor pool to use for workflow actions. Defaults to the default executor pool if not specified.")
@@ -752,7 +748,7 @@ func (ws *workflowService) workflowsImage() string {
 	if remote_execution_config.RemoteExecutionEnabled() && *workflowsDefaultImage != "" {
 		return *workflowsDefaultImage
 	}
-	return workflowsImage
+	return platform.DockerPrefix + platform.Ubuntu18_04WorkflowsImage
 }
 
 func (ws *workflowService) ciRunnerDebugMode() bool {


### PR DESCRIPTION
- Add the Ubuntu 20.04 RBE image and Ubuntu 20.04 CI image to the set of images to be warmed up.
- Move the workflow image warmup behind a flag, so that we don't have to warm up as many Firecracker images during scale up of the "normal" (non-workflow) executor pool. (I plan to enable this new flag only for the workflow executors)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
