### PR TITLE
add click behavior to duration percentile chart (clicking will show the slowest builds).

### DIFF
--- a/enterprise/app/trends/percentile_chart.tsx
+++ b/enterprise/app/trends/percentile_chart.tsx
@@ -23,17 +23,17 @@ export interface PercentilesChartProps {
   extractP90: (datum: string) => number;
   extractP95: (datum: string) => number;
   extractP99: (datum: string) => number;
-  onRowClicked?: (datum: string) => void;
+  onColumnClicked?: (datum: string) => void;
 }
 
 export default class PercentilesChartComponent extends React.Component<PercentilesChartProps> {
   private lastDataFromHover: string;
 
   handleRowClick() {
-    if (!this.props.onRowClicked || !this.lastDataFromHover) {
+    if (!this.props.onColumnClicked || !this.lastDataFromHover) {
       return;
     }
-    this.props.onRowClicked(this.lastDataFromHover);
+    this.props.onColumnClicked(this.lastDataFromHover);
   }
 
   render() {
@@ -43,7 +43,7 @@ export default class PercentilesChartComponent extends React.Component<Percentil
         <ResponsiveContainer width="100%" height={300}>
           <ComposedChart
             data={this.props.data}
-            style={this.props.onRowClicked ? { cursor: "pointer" } : {}}
+            style={this.props.onColumnClicked ? { cursor: "pointer" } : {}}
             onClick={this.handleRowClick.bind(this)}>
             <CartesianGrid strokeDasharray="3 3" />
             <Legend />

--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -273,6 +273,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                   extractP90={(date) => +(this.getStat(date).buildTimeUsecP90 ?? 0) * SECONDS_PER_MICROSECOND}
                   extractP95={(date) => +(this.getStat(date).buildTimeUsecP95 ?? 0) * SECONDS_PER_MICROSECOND}
                   extractP99={(date) => +(this.getStat(date).buildTimeUsecP99 ?? 0) * SECONDS_PER_MICROSECOND}
+                  onColumnClicked={capabilities.globalFilter ? this.onBarClicked.bind(this, "", "duration") : null}
                 />
               )}
               {!this.state.enableInvocationPercentileCharts && (


### PR DESCRIPTION
rename "onRowClicked" to "onColumnClicked", too, because that's what it actually is.  Oops.