### PR TITLE
Use new Ubuntu 20.04 image for workflows

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -1,5 +1,6 @@
 actions:
   - name: Test
+    container_image: ubuntu-20.04
     triggers:
       push:
         branches:
@@ -23,6 +24,7 @@ actions:
       - build //enterprise/server/cmd/executor //enterprise/server //server //cli/cmd/bb --config=mac-workflows
       - test //cli/... --config=mac-workflows --test_tag_filters=-performance,-webdriver,-docker
   - name: Benchmark
+    container_image: ubuntu-20.04
     triggers:
       push:
         branches:
@@ -30,6 +32,7 @@ actions:
     bazel_commands:
       - test //... --config=workflows --test_tag_filters=+performance
   - name: Browser tests
+    container_image: ubuntu-20.04
     triggers:
       push:
         branches:
@@ -42,6 +45,7 @@ actions:
       - test //... --config=workflows --remote_download_outputs=toplevel --test_tag_filters=+webdriver
   # TODO(bduffany): Move docker tests to the Test workflow when they are fast enough.
   - name: Docker tests
+    container_image: ubuntu-20.04
     triggers:
       push:
         branches:

--- a/enterprise/server/workflow/config/test_data/basic.yaml
+++ b/enterprise/server/workflow/config/test_data/basic.yaml
@@ -1,5 +1,9 @@
 actions:
   - name: "Build and test"
+    # Unrecognized YAML keys should not cause problems
+    # (e.g. using a config option in dev before it is available in prod,
+    # or specifying a deprecated option which no longer has any effect)
+    unknown_key: "foo"
     triggers:
       push:
         branches: [main]


### PR DESCRIPTION
Also add a test case to make sure we can parse the config successfully even though the `container_image` prop is not yet recognized in prod. (Also note that the "Test" workflow in this PR is able to run even though `container_image` hasn't reached prod yet)

Verified using the workflow task ID that the `container-image` platform prop is set correctly:

```
      {
        "name":  "container-image",
        "value":  "docker://gcr.io/flame-public/rbe-ubuntu20-04-workflows@sha256:e74147369e5ff5c6c9d56f15ab10a894d54d4f45f14455ad418f70ddb59850e3"
      },
```

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
