### PR TITLE
Remove flag to register self-auth handlers

### DIFF
--- a/enterprise/server/selfauth/selfauth.go
+++ b/enterprise/server/selfauth/selfauth.go
@@ -95,9 +95,6 @@ type tokenJSON struct {
 }
 
 func Register(env environment.Env) error {
-	if !Enabled() {
-		return nil
-	}
 	oauth, err := NewSelfAuth()
 	if err != nil {
 		return status.InternalErrorf("Error initializing self auth: %s", err)


### PR DESCRIPTION
We want our webdriver tests to self-auth because google oauth has bot-prevention measures. Remove this check so that the self-auth handlers are always registered. Self-auth will still only be automatically added as an oauth provider if the flag is on. Only organization slugs that have explicitly added self-auth as an auth provider in the config will be able to use it. 
