### PR TITLE
Don't return an error if an AWS blob is NotFound in the BlobExists method

### DIFF
--- a/server/backends/blobstore/blobstore.go
+++ b/server/backends/blobstore/blobstore.go
@@ -578,11 +578,11 @@ func (a *AwsS3BlobStore) BlobExists(ctx context.Context, blobName string) (bool,
 
 	ctx, spn := tracing.StartSpan(ctx)
 	defer spn.End()
-	_, err := a.s3.HeadObjectWithContext(ctx, params); 
+	_, err := a.s3.HeadObjectWithContext(ctx, params)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "NotFound" {
 			return false, nil
-		}	
+		}
 		return false, err
 	}
 

--- a/server/backends/blobstore/blobstore.go
+++ b/server/backends/blobstore/blobstore.go
@@ -578,7 +578,11 @@ func (a *AwsS3BlobStore) BlobExists(ctx context.Context, blobName string) (bool,
 
 	ctx, spn := tracing.StartSpan(ctx)
 	defer spn.End()
-	if _, err := a.s3.HeadObjectWithContext(ctx, params); err != nil {
+	_, err := a.s3.HeadObjectWithContext(ctx, params); 
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "NotFound" {
+			return false, nil
+		}	
 		return false, err
 	}
 


### PR DESCRIPTION
This should fix the issue with chunked logs on AWS.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
