### PR TITLE
Add statusz option to serve just the version string

### DIFF
--- a/server/util/statusz/statusz.go
+++ b/server/util/statusz/statusz.go
@@ -132,6 +132,12 @@ type renderedSection struct {
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// When "?version" is set, just serve the server version in plain text.
+	if r.URL.Query().Has("version") {
+		w.Write([]byte(version.AppVersion()))
+		return
+	}
+
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 


### PR DESCRIPTION
This lets us avoid using a hacky regex to extract the version from the /statusz response.

e.g. for a local server:

```
$ curl http://localhost:9090/statusz?version
unknown
```

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/1964