### PR TITLE
Include cache.Reader() call time in CAS download time

### DIFF
--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -105,6 +105,7 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 		ht.TrackEmptyHit()
 		return nil
 	}
+	downloadTracker := ht.TrackDownload(r.GetDigest())
 
 	cacheRN := digest.NewCASResourceName(r.GetDigest(), r.GetInstanceName())
 	passthroughCompressionEnabled := s.cache.SupportsCompressor(r.GetCompressor()) && req.ReadOffset == 0 && req.ReadLimit == 0
@@ -140,8 +141,6 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 		}
 		defer reader.Close()
 	}
-
-	downloadTracker := ht.TrackDownload(r.GetDigest())
 
 	copyBuf := s.bufferPool.Get(bufSize)
 	defer s.bufferPool.Put(copyBuf)


### PR DESCRIPTION
These numbers looked way too small to me: I was seeing 37usec read times but our prom metrics show a p50 of a ms or so. 

I think we're omitting some of the read time by creating the download tracker after calling Reader(). This change moves download tracker creation to before that call so the numbers are correct.