### PR TITLE
Workflows: Allow sudo for non-root users

### DIFF
--- a/enterprise/dockerfiles/ci_runner_image/Dockerfile
+++ b/enterprise/dockerfiles/ci_runner_image/Dockerfile
@@ -13,6 +13,9 @@ RUN curl -Lo /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/rele
 # at least for CI runs on the BB repo itself.
 RUN USE_BAZEL_VERSION=5.3.1 bazelisk version
 
-# Provision a non-root user named "buildbuddy".
+# Provision a non-root user named "buildbuddy" and set up passwordless sudo.
 # Non-root users are needed for some bazel toolchains, such as hermetic python.
-RUN useradd --create-home buildbuddy
+RUN apt-get update && apt-get install -y sudo && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN useradd --create-home buildbuddy --groups sudo && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/enterprise/dockerfiles/rbe-ubuntu20-04-workflows/Dockerfile
+++ b/enterprise/dockerfiles/rbe-ubuntu20-04-workflows/Dockerfile
@@ -8,6 +8,9 @@ RUN curl -Lo /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/rele
 # at least for CI runs on the BB repo itself.
 RUN USE_BAZEL_VERSION=6.0.0 bazelisk version
 
-# Provision a non-root user named "buildbuddy".
+# Provision a non-root user named "buildbuddy" and set up passwordless sudo.
 # Non-root users are needed for some bazel toolchains, such as hermetic python.
-RUN useradd --create-home buildbuddy
+RUN apt-get update && apt-get install -y sudo && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN useradd --create-home buildbuddy --groups sudo && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -35,8 +35,8 @@ const (
 	Ubuntu16_04Image = "gcr.io/flame-public/executor-docker-default:enterprise-v1.6.0"
 	Ubuntu20_04Image = "gcr.io/flame-public/rbe-ubuntu20-04@sha256:036ae8c90876fa22da9ace6f8218e614f4cd500a154fc162973fff691e72d28e"
 
-	Ubuntu18_04WorkflowsImage = "gcr.io/flame-public/buildbuddy-ci-runner:v2.3.0"
-	Ubuntu20_04WorkflowsImage = "gcr.io/flame-public/rbe-ubuntu20-04-workflows@sha256:e74147369e5ff5c6c9d56f15ab10a894d54d4f45f14455ad418f70ddb59850e3"
+	Ubuntu18_04WorkflowsImage = "gcr.io/flame-public/buildbuddy-ci-runner@sha256:ba33bd1b3acdfe980b958baf7d05c2041c9d4183d15fdf665dd236289d777709"
+	Ubuntu20_04WorkflowsImage = "gcr.io/flame-public/rbe-ubuntu20-04-workflows@sha256:eb81189af1cec44b5348751f75ec7aea516d0de675b8461235f4cc4e553a34b5"
 
 	// overrideHeaderPrefix is a prefix used to override platform props via
 	// remote headers. The property name immediately follows the prefix in the


### PR DESCRIPTION
This is needed for rules_hermetic_python which needs to be run as a non-root user, but then sudo may be needed for certain other things (like installing dependencies with apt-get)

(If this is approved, then I will push the CI images and update the image digests in `platforms.go` before submitting.)

---

**Version bump**: Patch
