### PR TITLE
Fix action results not showing in UI for EU invocations

### DIFF
--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -57,7 +57,7 @@ func newMemoryCache(t *testing.T, maxSizeBytes int64) interfaces.Cache {
 }
 
 func waitForReady(t *testing.T, addr string) {
-	conn, err := grpc_client.DialTargetWithOptions("grpc://"+addr, false, grpc.WithBlock(), grpc.WithTimeout(maxWaitForReadyDuration))
+	conn, err := grpc_client.DialTarget("grpc://"+addr, grpc.WithBlock(), grpc.WithTimeout(maxWaitForReadyDuration))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/bytestream/bytestream.go
+++ b/server/bytestream/bytestream.go
@@ -150,6 +150,14 @@ func StreamBytestreamFileChunk(ctx context.Context, env environment.Env, url *ur
 	return err
 }
 
+func grpcTargetForFileURL(u *url.URL, grpcs bool) string {
+	target := url.URL{Scheme: "grpc", User: u.User, Host: u.Host}
+	if grpcs {
+		target.Scheme = "grpcs"
+	}
+	return target.String()
+}
+
 func streamFromUrl(ctx context.Context, url *url.URL, grpcs bool, offset int64, limit int64, writer io.Writer) error {
 	if url.Port() == "" && grpcs {
 		url.Host = url.Hostname() + ":443"
@@ -157,7 +165,7 @@ func streamFromUrl(ctx context.Context, url *url.URL, grpcs bool, offset int64, 
 		url.Host = url.Hostname() + ":80"
 	}
 
-	conn, err := grpc_client.DialTargetWithOptions(url.String(), grpcs)
+	conn, err := grpc_client.DialTarget(grpcTargetForFileURL(url, grpcs))
 	if err != nil {
 		return err
 	}

--- a/server/util/grpc_client/grpc_client.go
+++ b/server/util/grpc_client/grpc_client.go
@@ -14,11 +14,7 @@ import (
 
 // DialTarget handles some of the logic around detecting the correct GRPC
 // connection type and applying relevant options when connecting.
-func DialTarget(target string) (*grpc.ClientConn, error) {
-	return DialTargetWithOptions(target, true)
-}
-
-func DialTargetWithOptions(target string, grpcsBytestream bool, extraOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
+func DialTarget(target string, extraOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
 	dialOptions := CommonGRPCClientOptions()
 	dialOptions = append(dialOptions, extraOptions...)
 	u, err := url.Parse(target)
@@ -26,7 +22,7 @@ func DialTargetWithOptions(target string, grpcsBytestream bool, extraOptions ...
 		if u.User != nil {
 			dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(newRPCCredentials(u.User.String())))
 		}
-		if u.Scheme == "grpcs" || (u.Scheme == "bytestream" && grpcsBytestream) {
+		if u.Scheme == "grpcs" {
 			dialOptions = append(dialOptions, grpc.WithTransportCredentials(google.NewDefaultCredentials().TransportCredentials()))
 		} else {
 			dialOptions = append(dialOptions, grpc.WithInsecure())

--- a/tools/cacheload/cacheload.go
+++ b/tools/cacheload/cacheload.go
@@ -181,7 +181,7 @@ func main() {
 		monitoring.StartMonitoringHandler(fmt.Sprintf("%s:%d", *listen, *monitoringPort))
 	}
 
-	conn, err := grpc_client.DialTargetWithOptions(*cacheTarget, false, grpc.WithBlock(), grpc.WithTimeout(*timeout))
+	conn, err := grpc_client.DialTarget(*cacheTarget, grpc.WithBlock(), grpc.WithTimeout(*timeout))
 	if err != nil {
 		log.Fatalf("Unable to connect to target '%s': %s", *cacheTarget, err)
 	}

--- a/tools/rbeperf/rbeperf.go
+++ b/tools/rbeperf/rbeperf.go
@@ -821,7 +821,7 @@ func main() {
 		}
 	}
 
-	clientConn, err := grpc_client.DialTargetWithOptions(*server, true, grpc.WithBlock(), grpc.WithTimeout(5*time.Second))
+	clientConn, err := grpc_client.DialTarget(*server, grpc.WithBlock(), grpc.WithTimeout(5*time.Second))
 	if err != nil {
 		log.Fatalf("Could not connect to server %q: %s", *server, err)
 	}


### PR DESCRIPTION
This PR fixes a long-standing bug that action results are not showing up in the UI for invocations that use `--remote_executor=europe.remote.buildbuddy.io`, even though the results are present in AC (as they can be fetched using `tools/cas`).

The root cause turned out to be that we were calling `DialTargetWithOptions` with the URL `actioncache://europe.remote.buildbuddy.io`, and `DialTargetWithOptions` parses that URL to the target+options `("europe.remote.buildbuddy.io", grpc.WithInsecure())`. The request fails with the error "connection closed before server preface received" because the `europe.remote.buildbuddy.io` target requires TLS.

This bug does not reproduce in the US because we first attempt to download the file from `localhost` before we attempt to download using the gRPC target (`remote.buildbuddy.io` for US), and the localhost target does not require TLS, so the first request succeeds and we don't continue on to the "fallback" path of requesting via the `remote.buildbuddy.io` target.

The bug also doesn't reproduce for bytestream URLs in EU, because `DialTargetWithOptions` has special handling for the `"bytestream"` URL scheme, but not the `"actioncache"` scheme. So our first request to localhost fails because the file is not hosted in the US, but then the request to EU succeeds only because there's special handling for `bytestream://`.

An alternative fix would have been to change the `DialTargetWithOptions` scheme handling to `(u.Scheme == "bytestream" || u.Scheme == "actioncache")`, but I figured this is error prone and complex. For example, there are a few call sites which use that `DialTargetWithOptions` func, setting `grpcsBytestream` to either `true` or `false`, when in fact both call sites do not need to be setting that param and could instead just call `DialTarget`. So the bytestream:// support is adding complexity to the API of `DialTarget` which is used in a lot of places, but there's really only one caller which needs bytestream:// support (the HTTP handler).

Instead of having `DialTargetWithOptions` be aware of bytestream:// and actioncache:// URLs, we can instead just pass in a `grpcs://` target directly. This also allows us to remove `DialTargetWithOptions` in favor of just `DialTarget`.

I checked all the call sites of both `DialTargetWithOptions` and `DialTarget` and verified that the `/file/download/` handler is the only call site which attempts to call that function with a `bytestream://` URL, so this change should be safe.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
