### PR TITLE
Catch non-specific errors too

### DIFF
--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -156,6 +156,8 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 			if err := stream.Send(&bspb.ReadResponse{Data: buf[:n]}); err != nil {
 				return err
 			}
+		} else if err != nil {
+			return err
 		} else {
 			if err := stream.Send(&bspb.ReadResponse{Data: buf}); err != nil {
 				return err


### PR DESCRIPTION
When encountering a bad magic number we were continuing forever attempting to read which lead to the client hanging. By catching all non-nil errors here we avoid this.