### PR TITLE
invocation: avoid crash when render query profiles

### DIFF
--- a/app/invocation/invocation_breakdown_card.tsx
+++ b/app/invocation/invocation_breakdown_card.tsx
@@ -71,8 +71,9 @@ export default class InvocationBreakdownCardComponent extends React.Component<Pr
           <div className="title">Timing Breakdown</div>
           <div className="details">
             <div className="cache-sections">
-              {renderBreakdown(phaseData, "Phase breakdown", "Breakdown of build phases")}
-              {renderBreakdown(executionData, "Execution breakdown", "Breakdown totals across all threads")}
+              {phaseData.length > 0 && renderBreakdown(phaseData, "Phase breakdown", "Breakdown of build phases")}
+              {executionData.length > 0 &&
+                renderBreakdown(executionData, "Execution breakdown", "Breakdown totals across all threads")}
             </div>
           </div>
         </div>


### PR DESCRIPTION
When a profile is generated from `bazel query` or `bazel cquery`, it would contains no executionData and thus, causes a crash in rendering "Timing" tab on the Invocation page.

Fix it by skipping the Breakdown section when the data is empty.

---

**Version bump**: TODO
