### PR TITLE
Firecracker: Monitor peak FS usage

### DIFF
--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -312,6 +312,7 @@ func main() {
 	}
 	die(os.WriteFile("/etc/hosts", []byte(strings.Join(hosts, "\n")), 0755))
 	die(os.WriteFile("/etc/resolv.conf", []byte("nameserver 8.8.8.8"), 0755))
+	die(syscall.Symlink("/proc/mounts", "/etc/mtab"))
 
 	if *setDefaultRoute {
 		die(configureDefaultRoute("eth0", "192.168.241.1"))

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -80,6 +80,7 @@ go_test(
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/filecache",
         "//enterprise/server/remote_execution/workspace",
+        "//enterprise/server/util/ext4",
         "//proto:remote_execution_go_proto",
         "//server/backends/disk_cache",
         "//server/interfaces",

--- a/enterprise/server/vmexec/BUILD
+++ b/enterprise/server/vmexec/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//proto:vmexec_go_proto",
         "//server/util/log",
         "//server/util/status",
+        "@com_github_elastic_gosigar//:gosigar",
         "@com_github_vishvananda_netlink//:netlink",
         "@org_golang_google_grpc//status",
         "@org_golang_x_sys//unix",

--- a/enterprise/server/vmexec/vmexec.go
+++ b/enterprise/server/vmexec/vmexec.go
@@ -7,12 +7,14 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sort"
 	"sync"
 	"syscall"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/elastic/gosigar"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
@@ -320,9 +322,16 @@ func (c *command) Run(ctx context.Context, msgs chan *message) (*vmxpb.ExecStrea
 		_, err := io.Copy(&stderrWriter{msgs}, c.stderrReader)
 		stderrErrCh <- err
 	}()
-	// TODO(bduffany): monitor stats from the whole VM, not just
+	// TODO(bduffany): report memory/CPU stats from the whole VM, not just
 	// the process being executed.
+	var peakFSU []*repb.UsageStats_FileSystemUsage
 	statsListener := func(stats *repb.UsageStats) {
+		// Update the stats with disk usage.
+		if fsu := getFileSystemUsage(); fsu != nil {
+			peakFSU = updatePeakFileSystemUsage(peakFSU, fsu)
+		}
+		stats.PeakFileSystemUsage = peakFSU
+
 		msgs <- &message{Response: &vmxpb.ExecStreamedResponse{UsageStats: stats}}
 	}
 	_, err := commandutil.RunWithProcessTreeCleanup(ctx, c.cmd, statsListener)
@@ -354,4 +363,73 @@ type stderrWriter struct{ msgs chan *message }
 func (w *stderrWriter) Write(b []byte) (int, error) {
 	w.msgs <- &message{Response: &vmxpb.ExecStreamedResponse{Stderr: b}}
 	return len(b), nil
+}
+
+func getFileSystemUsage() []*repb.UsageStats_FileSystemUsage {
+	fsl := &gosigar.FileSystemList{}
+	if err := fsl.Get(); err != nil {
+		log.Errorf("Failed to get filesystem usage: %s", err)
+		return nil
+	}
+	out := make([]*repb.UsageStats_FileSystemUsage, 0, len(fsl.List))
+	for _, fs := range fsl.List {
+		// Only consider the root FS and the workspace FS.
+		// Otherwise the list is really messy, containing things like
+		// tmpfs, udev, cgroup, etc. which aren't very interesting.
+		if !(fs.DirName == "/" || fs.DirName == "/workspace") {
+			continue
+		}
+
+		fsu := &gosigar.FileSystemUsage{}
+		if err := fsu.Get(fs.DirName); err != nil {
+			log.Errorf("Failed to get filesystem usage for %s: %s", fs.DevName, err)
+			continue
+		}
+		out = append(out, &repb.UsageStats_FileSystemUsage{
+			Source:     fs.DevName,
+			Target:     fs.DirName,
+			Fstype:     fs.SysTypeName,
+			UsedBytes:  int64(fsu.Used),
+			TotalBytes: int64(fsu.Total),
+		})
+	}
+	return out
+}
+
+func updatePeakFileSystemUsage(peak, current []*repb.UsageStats_FileSystemUsage) []*repb.UsageStats_FileSystemUsage {
+	// Keep track of which indexes in the `current` list that we have merged
+	// into the `peak` list.
+	observed := map[int]bool{}
+
+	for _, p := range peak {
+		var cur *repb.UsageStats_FileSystemUsage
+		for i, c := range current {
+			if p.Target == c.Target {
+				cur = c
+				observed[i] = true
+				break
+			}
+		}
+		if cur == nil {
+			// The FS disappeared somehow.
+			// Keep it in the `peak` list with its last observed value.
+			continue
+		}
+		if cur.UsedBytes > p.UsedBytes {
+			p.UsedBytes = cur.UsedBytes
+		}
+	}
+	for i, c := range current {
+		// If we see an FS that we haven't previously observed in the `peak`
+		// list then append it to the end.
+		if !observed[i] {
+			peak = append(peak, c)
+		}
+	}
+	// Sort to ensure deterministic ordering.
+	sort.Slice(peak, func(i, j int) bool {
+		return peak[i].Target < peak[j].Target
+	})
+
+	return peak
 }

--- a/enterprise/server/vmexec/vmexec_test.go
+++ b/enterprise/server/vmexec/vmexec_test.go
@@ -98,6 +98,7 @@ func TestExecStreamed_Stats(t *testing.T) {
 	assert.LessOrEqual(t, res.UsageStats.GetCpuNanos(), int64(1.6e9), "should use around 1e9 CPU nanos")
 	assert.GreaterOrEqual(t, res.UsageStats.GetMemoryBytes(), int64(1e9), "should use at least 1GB memory")
 	assert.LessOrEqual(t, res.UsageStats.GetMemoryBytes(), int64(1.6e9), "shouldn't use much more than 1GB memory")
+	assert.NotEmpty(t, res.UsageStats.GetPeakFileSystemUsage(), "file system usage should not be empty")
 }
 
 func TestExecStreamed_Timeout(t *testing.T) {

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2044,6 +2044,33 @@ message UsageStats {
   // used for real-time metrics and shouldn't be used as a "summary" metric for
   // the task (peak_memory_bytes is a more useful summary metric).
   int64 memory_bytes = 3;
+
+  // File system usage counts.
+  //
+  // Field names follow the df naming convention:
+  // https://github.com/coreutils/coreutils/blob/d5868df0d0a6bd09387ece41b62b873fd7c201f9/src/df.c#L1580-L1582
+  message FileSystemUsage {
+    // Filesystem mount source device name.
+    // Example: "/dev/sda1"
+    string source = 1;
+
+    // Filesystem mount target path.
+    // Example: "/"
+    string target = 2;
+
+    // Filesystem type.
+    // Example: "ext4"
+    string fstype = 3;
+
+    // Filesystem used bytes.
+    int64 used_bytes = 4;
+
+    // Filesystem total size in bytes.
+    int64 total_bytes = 5;
+  }
+
+  // Peak file system usage, for each mounted file system.
+  repeated FileSystemUsage peak_file_system_usage = 4;
 }
 
 // Proto representation of the Execution stored in OLAP DB. Only used in


### PR DESCRIPTION
Monitor peak disk usage (for scratch and workspace disks separately) throughout VM action execution and report in ExecutedActionMetadata.

This will let us (and users) confirm whether certain errors are due to the VM running out of disk space.

---

**Version bump**: Patch
