### PR TITLE
Don't change open file limit if current limit is already larger than the target

### DIFF
--- a/server/util/rlimit/rlimit.go
+++ b/server/util/rlimit/rlimit.go
@@ -19,7 +19,7 @@ func MaxRLimit() error {
 		// This is OPEN_MAX in sys/syslimits.h.
 		limit.Max = 10240
 	}
-	if limit.Cur != limit.Max {
+	if limit.Cur < limit.Max {
 		log.Infof("Increasing open files limit %d => %d", limit.Cur, limit.Max)
 		limit.Cur = limit.Max
 		if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {


### PR DESCRIPTION
Inspired by https://github.com/buildbuddy-io/buildbuddy/issues/3269

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
