### PR TITLE
github action: ensure git user name and email are in quotes

### DIFF
--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -39,8 +39,8 @@ jobs:
       - name: Commit
         run: |
           cd "$GITHUB_WORKSPACE"/buildbuddy-internal
-          git config --local user.email ${{ github.event.head_commit.author.email }}
-          git config --local user.name ${{ github.event.head_commit.author.name }}
+          git config --local user.email '${{ github.event.head_commit.author.email }}'
+          git config --local user.name '${{ github.event.head_commit.author.name }}'
           git add WORKSPACE
           git add deps.bzl
           cat <<EOF > message.txt


### PR DESCRIPTION
Username could contain spaces in the middle and without quotes, git-config would not be able to parse it and throw error with exit code 129.

Fix by adding quotes between the Github Action expressions.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: TODO <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
