### PR TITLE
Stream logs instead of loading entire logs into memory

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -31,7 +31,6 @@ import InvocationActionCardComponent from "./invocation_action_card";
 import TargetsComponent from "./invocation_targets";
 import { BuildBuddyError } from "../util/errors";
 import UserPreferences from "../preferences/preferences";
-import Long from "long";
 import capabilities from "../capabilities/capabilities";
 import CacheRequestsCardComponent from "./cache_requests_card";
 import rpc_service from "../service/rpc_service";
@@ -42,7 +41,6 @@ interface State {
   error: BuildBuddyError | null;
 
   model: InvocationModel;
-  attempt: Long;
 }
 
 interface Props {
@@ -55,7 +53,6 @@ interface Props {
 
 const largePageSize = 100;
 const smallPageSize = 10;
-const maxInt32 = 2147483647;
 
 export default class InvocationComponent extends React.Component<Props, State> {
   state: State = {
@@ -64,7 +61,6 @@ export default class InvocationComponent extends React.Component<Props, State> {
     error: null,
 
     model: new InvocationModel(),
-    attempt: new Long(0),
   };
 
   private timeoutRef: number;
@@ -112,7 +108,6 @@ export default class InvocationComponent extends React.Component<Props, State> {
           inProgress: showInProgressScreen,
           model: InvocationModel.modelFromInvocations(response.invocation as invocation.Invocation[]),
           loading: false,
-          attempt: response.invocation[0].attempt,
         });
         document.title = `${this.state.model.getUser(
           true
@@ -214,7 +209,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
     const isBazelInvocation = this.state.model.isBazelInvocation();
     const fetchBuildLogs = () => {
       rpc_service.downloadBytestreamFile("//buildlog", "bytestream://", this.props.invocationId, {
-        attempt: this.state.attempt.toString(),
+        attempt: Number(this.state.model.invocations[0]?.attempt ?? 0).toString()
       });
     };
 

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -208,9 +208,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
     });
     const isBazelInvocation = this.state.model.isBazelInvocation();
     const fetchBuildLogs = () => {
-      rpc_service.downloadBytestreamFile("//buildlog", "bytestream://", this.props.invocationId, {
-        attempt: Number(this.state.model.invocations[0]?.attempt ?? 0).toString()
-      });
+      rpc_service.downloadLog(this.props.invocationId, Number(this.state.model.invocations[0]?.attempt ?? 0));
     };
 
     const suggestions = getSuggestions({

--- a/app/invocation/invocation_build_logs_card.tsx
+++ b/app/invocation/invocation_build_logs_card.tsx
@@ -7,7 +7,7 @@ interface Props {
   loading: boolean;
   expanded: boolean;
   dark: boolean;
-  fullLogsFetcher: () => Promise<string>;
+  fullLogsFetcher: () => void;
 }
 
 export default class BuildLogsCardComponent extends React.Component<Props> {

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -44,6 +44,10 @@ class RpcService {
     return false;
   }
 
+  getDownloadUrl(params: Record<string, string>): string {
+    return `/file/download?${new URLSearchParams(params)}`;
+  }
+
   getBytestreamUrl(
     bytestreamURL: string,
     invocationId: string,
@@ -63,7 +67,16 @@ class RpcService {
         params[k] = additionalParams[k];
       }
     }
-    return `/file/download?${new URLSearchParams(params)}`;
+    return this.getDownloadUrl(params);
+  }
+
+  downloadLog(invocationId: string, attempt: number) {
+    const params: Record<string, string> = {
+      invocation_id: invocationId,
+      attempt: attempt.toString(),
+      artifact: "buildlog",
+    };
+    window.open(this.getDownloadUrl(params));
   }
 
   downloadBytestreamFile(

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -44,7 +44,12 @@ class RpcService {
     return false;
   }
 
-  getBytestreamUrl(bytestreamURL: string, invocationId: string, { filename = "", zip = "" } = {}): string {
+  getBytestreamUrl(
+    bytestreamURL: string,
+    invocationId: string,
+    { filename = "", zip = "" } = {},
+    additionalParams?: Record<string, string>
+  ): string {
     const encodedRequestContext = uint8ArrayToBase64(context.RequestContext.encode(this.requestContext).finish());
     const params: Record<string, string> = {
       bytestream_url: bytestreamURL,
@@ -53,15 +58,31 @@ class RpcService {
     };
     if (filename) params.filename = filename;
     if (zip) params.z = zip;
+    if (typeof additionalParams !== undefined) {
+      for (const k in additionalParams) {
+        params[k] = additionalParams[k];
+      }
+    }
     return `/file/download?${new URLSearchParams(params)}`;
   }
 
-  downloadBytestreamFile(filename: string, bytestreamURL: string, invocationId: string) {
-    window.open(this.getBytestreamUrl(bytestreamURL, invocationId, { filename }));
+  downloadBytestreamFile(
+    filename: string,
+    bytestreamURL: string,
+    invocationId: string,
+    additionalParams?: Record<string, string>
+  ) {
+    window.open(this.getBytestreamUrl(bytestreamURL, invocationId, { filename }, additionalParams));
   }
 
-  downloadBytestreamZipFile(filename: string, bytestreamURL: string, zip: string, invocationId: string) {
-    window.open(this.getBytestreamUrl(bytestreamURL, invocationId, { filename, zip }));
+  downloadBytestreamZipFile(
+    filename: string,
+    bytestreamURL: string,
+    zip: string,
+    invocationId: string,
+    additionalParams?: Record<string, string>
+  ) {
+    window.open(this.getBytestreamUrl(bytestreamURL, invocationId, { filename, zip }, additionalParams));
   }
 
   fetchBytestreamFile(

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -48,12 +48,7 @@ class RpcService {
     return `/file/download?${new URLSearchParams(params)}`;
   }
 
-  getBytestreamUrl(
-    bytestreamURL: string,
-    invocationId: string,
-    { filename = "", zip = "" } = {},
-    additionalParams?: Record<string, string>
-  ): string {
+  getBytestreamUrl(bytestreamURL: string, invocationId: string, { filename = "", zip = "" } = {}): string {
     const encodedRequestContext = uint8ArrayToBase64(context.RequestContext.encode(this.requestContext).finish());
     const params: Record<string, string> = {
       bytestream_url: bytestreamURL,
@@ -62,11 +57,6 @@ class RpcService {
     };
     if (filename) params.filename = filename;
     if (zip) params.z = zip;
-    if (typeof additionalParams !== undefined) {
-      for (const k in additionalParams) {
-        params[k] = additionalParams[k];
-      }
-    }
     return this.getDownloadUrl(params);
   }
 
@@ -79,23 +69,12 @@ class RpcService {
     window.open(this.getDownloadUrl(params));
   }
 
-  downloadBytestreamFile(
-    filename: string,
-    bytestreamURL: string,
-    invocationId: string,
-    additionalParams?: Record<string, string>
-  ) {
-    window.open(this.getBytestreamUrl(bytestreamURL, invocationId, { filename }, additionalParams));
+  downloadBytestreamFile(filename: string, bytestreamURL: string, invocationId: string) {
+    window.open(this.getBytestreamUrl(bytestreamURL, invocationId, { filename }));
   }
 
-  downloadBytestreamZipFile(
-    filename: string,
-    bytestreamURL: string,
-    zip: string,
-    invocationId: string,
-    additionalParams?: Record<string, string>
-  ) {
-    window.open(this.getBytestreamUrl(bytestreamURL, invocationId, { filename, zip }, additionalParams));
+  downloadBytestreamZipFile(filename: string, bytestreamURL: string, zip: string, invocationId: string) {
+    window.open(this.getBytestreamUrl(bytestreamURL, invocationId, { filename, zip }));
   }
 
   fetchBytestreamFile(

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -27,7 +27,7 @@ export interface TerminalProps {
   title?: JSX.Element;
 
   lightTheme?: boolean;
-  fullLogsFetcher?: () => Promise<string>;
+  fullLogsFetcher?: () => void;
 }
 
 interface State {
@@ -296,25 +296,8 @@ export default class TerminalComponent extends React.Component<TerminalProps, St
     this.updateLineLengthLimit();
   }
   private onDownloadClick() {
-    const serveLog = (log: string) => {
-      const element = document.createElement("a");
-      const plaintext = toPlainText(log);
-      element.setAttribute("href", "data:text/plain;charset=utf-8," + encodeURIComponent(plaintext));
-      element.setAttribute("download", "build_logs.txt");
-      element.click();
-    };
-    if (this.props.fullLogsFetcher) {
-      this.setState({ isLoadingFullLog: true });
-      this.props
-        .fullLogsFetcher()
-        .then(serveLog)
-        .catch((e) => errorService.handleError(e))
-        .finally(() => {
-          this.setState({ isLoadingFullLog: false });
-        });
-      return;
-    }
-    serveLog(this.props.value);
+    event.preventDefault();
+    this.props.fullLogsFetcher();
   }
 
   render() {

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -296,7 +296,15 @@ export default class TerminalComponent extends React.Component<TerminalProps, St
     this.updateLineLengthLimit();
   }
   private onDownloadClick() {
-    this.props.fullLogsFetcher();
+		if (this.props.fullLogsFetcher) {
+			this.props.fullLogsFetcher();
+			return
+		} 
+		const element = document.createElement("a");
+		const plaintext = toPlainText(this.props.value);
+		element.setAttribute("href", "data:text/plain;charset=utf-8," + encodeURIComponent(plaintext));
+		element.setAttribute("download", "build_logs.txt");
+		element.click();
   }
 
   render() {

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -296,7 +296,6 @@ export default class TerminalComponent extends React.Component<TerminalProps, St
     this.updateLineLengthLimit();
   }
   private onDownloadClick() {
-    event.preventDefault();
     this.props.fullLogsFetcher();
   }
 

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -296,15 +296,15 @@ export default class TerminalComponent extends React.Component<TerminalProps, St
     this.updateLineLengthLimit();
   }
   private onDownloadClick() {
-		if (this.props.fullLogsFetcher) {
-			this.props.fullLogsFetcher();
-			return
-		} 
-		const element = document.createElement("a");
-		const plaintext = toPlainText(this.props.value);
-		element.setAttribute("href", "data:text/plain;charset=utf-8," + encodeURIComponent(plaintext));
-		element.setAttribute("download", "build_logs.txt");
-		element.click();
+    if (this.props.fullLogsFetcher) {
+      this.props.fullLogsFetcher();
+      return;
+    }
+    const element = document.createElement("a");
+    const plaintext = toPlainText(this.props.value);
+    element.setAttribute("href", "data:text/plain;charset=utf-8," + encodeURIComponent(plaintext));
+    element.setAttribute("download", "build_logs.txt");
+    element.click();
   }
 
   render() {

--- a/server/backends/chunkstore/chunkstore.go
+++ b/server/backends/chunkstore/chunkstore.go
@@ -251,6 +251,10 @@ func (r *chunkstoreReader) shiftToFront(p []byte, bytesRead *int) {
 }
 
 func (r *chunkstoreReader) Read(p []byte) (int, error) {
+	return r.read(p)
+}
+
+func (r *chunkstoreReader) read(p []byte) (int, error) {
 	bytesRead := r.copyToReadBuffer(p)
 	if r.reverse {
 		defer r.shiftToFront(p, &bytesRead)

--- a/server/backends/chunkstore/chunkstore.go
+++ b/server/backends/chunkstore/chunkstore.go
@@ -251,10 +251,6 @@ func (r *chunkstoreReader) shiftToFront(p []byte, bytesRead *int) {
 }
 
 func (r *chunkstoreReader) Read(p []byte) (int, error) {
-	return r.read(p)
-}
-
-func (r *chunkstoreReader) read(p []byte) (int, error) {
 	bytesRead := r.copyToReadBuffer(p)
 	if r.reverse {
 		defer r.shiftToFront(p, &bytesRead)

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//proto:user_id_go_proto",
         "//proto:workflow_go_proto",
         "//proto:zip_go_proto",
+        "//server/backends/chunkstore",
         "//server/build_event_protocol/build_event_handler",
         "//server/bytestream",
         "//server/endpoint_urls/build_buddy_url",

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1046,16 +1046,13 @@ func (s *BuildBuddyServer) getAnyAPIKeyForInvocation(ctx context.Context, invoca
 func (s *BuildBuddyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	params := r.URL.Query()
 
-	// TODO(siggisim): Figure out why this JWT is overriding authority auth and remove.
-	ctx := context.WithValue(r.Context(), "x-buildbuddy-jwt", nil)
-
 	if params.Get("artifact") != "" {
-		s.serveArtifact(ctx, w, params)
+		s.serveArtifact(r.Context(), w, params)
 		return
 	}
 	if params.Get("bytestream_url") != "" {
 		// bytestream request
-		s.serveBytestream(ctx, w, params)
+		s.serveBytestream(r.Context(), w, params)
 		return
 	}
 	http.Error(w, `One of "artifact" or "bytestream_url" query param is required`, http.StatusBadRequest)
@@ -1125,6 +1122,9 @@ func (s *BuildBuddyServer) serveBytestream(ctx context.Context, w http.ResponseW
 			lookup.URL.User = url.User(apiKey.Value)
 		}
 	}
+
+	// TODO(siggisim): Figure out why this JWT is overriding authority auth and remove.
+	ctx = context.WithValue(ctx, "x-buildbuddy-jwt", nil)
 
 	var zipReference = params.Get("z")
 	if len(zipReference) > 0 {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1066,6 +1066,7 @@ func (s *BuildBuddyServer) serveArtifact(ctx context.Context, w http.ResponseWri
 		if iid == "" {
 			log.Warningf("Build log requested with empty invocation id.")
 			http.Error(w, "File not found", http.StatusNotFound)
+			return
 		}
 		if _, err := s.env.GetInvocationDB().LookupInvocation(ctx, iid); err != nil {
 			if status.IsPermissionDeniedError(err) {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -992,10 +992,6 @@ type bsLookup struct {
 }
 
 func getBestFilename(filename, blobname string) string {
-	if strings.HasPrefix(filename, "//") && !strings.HasPrefix(filename, "///") {
-		// This is not a normal file path, let the implementation handle it
-		return filename
-	}
 	// First try to use the filename parameter
 	parts := strings.Split(filename, "/")
 	name := parts[len(parts)-1]

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1058,6 +1058,7 @@ func (s *BuildBuddyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.serveBytestream(ctx, w, params)
 		return
 	}
+	http.Error(w, `One of "artifact" or "bytestream_url" query param is required`, http.StatusBadRequest)
 }
 
 // serveArtifact handles requests that specify particular build artifacts


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Logs were being loaded into memory on both the client and the server, which would be a problem
for very large logs. Instead, we now stream the logs from the blobstore chunks on the server
side and download the stream to disk on the client side.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
