### PR TITLE
Show peak VM disk usage in UI

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -9,7 +9,6 @@ import DigestComponent, { parseDigest } from "../components/digest/digest";
 import { TextLink } from "../components/link/link";
 import TerminalComponent from "../terminal/terminal";
 import UserPreferences from "../preferences/preferences";
-import router from "../router/router";
 
 interface Props {
   model: InvocationModel;
@@ -489,6 +488,14 @@ export default class InvocationActionCardComponent extends React.Component<Props
                                     {format.bytes(this.state.actionResult.executionMetadata.usageStats.peakMemoryBytes)}
                                   </div>
                                   <div>MilliCPU: {computeMilliCpu(this.state.actionResult)}</div>
+                                  {this.state.actionResult.executionMetadata.usageStats.peakFileSystemUsage?.map(
+                                    (fs) => (
+                                      <div>
+                                        Peak disk usage: {fs.target} ({fs.fstype}): {format.bytes(fs.usedBytes)} of{" "}
+                                        {format.bytes(fs.totalBytes)}
+                                      </div>
+                                    )
+                                  )}
                                 </div>
                               </>
                             )}


### PR DESCRIPTION
Currently only works for regular firecracker actions, not workflows. (Some extra work is needed to properly display the CI runner action in the UI)

Screenshot:

---

![image](https://user-images.githubusercontent.com/2414826/214395723-6d0d8b1d-7cae-4816-8916-58fd76d09452.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
