### PR TITLE
Add `Banner` component

### DIFF
--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -51,6 +51,7 @@ genrule(
         "//app/compare:compare.css",
         "//app/invocation:invocation.css",
         "//app/terminal:terminal.css",
+        "//app/components/banner:banner.css",
         "//app/components/button:button.css",
         "//app/components/dialog:dialog.css",
         "//app/components/digest:digest.css",

--- a/app/alert/alert.css
+++ b/app/alert/alert.css
@@ -6,23 +6,6 @@
   margin-top: 32px;
 
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.27), 0 3px 5px rgba(0, 0, 0, 0.12);
-  border-radius: 8px;
-  padding: 16px;
-
-  display: flex;
-  align-items: start;
-}
-
-.alert-banner.alert-type-error {
-  background: #ffcdd2;
-}
-
-.alert-banner.alert-type-success {
-  background: #c8e6c9;
-}
-
-.alert-banner.alert-type-warning {
-  background: #fffde7;
 }
 
 .alert-banner.hidden {

--- a/app/alert/alert.tsx
+++ b/app/alert/alert.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Subscription } from "rxjs";
-import alertService, { Alert, AlertType } from "./alert_service";
-import { XCircle, CheckCircle, AlertCircle } from "lucide-react";
+import Banner from "../components/banner/banner";
+import alertService, { Alert } from "./alert_service";
 
 interface State {
   alert?: Alert;
@@ -9,12 +9,6 @@ interface State {
 }
 
 const DISPLAY_DURATION_MS = 4000;
-
-const ICONS: Record<AlertType, JSX.Element> = {
-  error: <XCircle className="icon red" />,
-  success: <CheckCircle className="icon green" />,
-  warning: <AlertCircle className="icon orange" />,
-};
 
 export default class AlertComponent extends React.Component<{}, State> {
   state: State = {};
@@ -46,13 +40,13 @@ export default class AlertComponent extends React.Component<{}, State> {
 
   render() {
     return (
-      <div
-        className={`alert-banner alert-type-${this.state.alert?.type} ${this.state.isVisible ? "visible" : "hidden"}`}
+      <Banner
+        type={this.state.alert?.type || "info"}
+        className={`alert-banner ${this.state.isVisible ? "visible" : "hidden"}`}
         onMouseEnter={this.onMouseEnter.bind(this)}
         onMouseLeave={this.onMouseLeave.bind(this)}>
-        {ICONS[this.state.alert?.type]}
-        <span>{this.state.alert?.message}</span>
-      </div>
+        {this.state.alert?.message}
+      </Banner>
     );
   }
 }

--- a/app/components/banner/BUILD
+++ b/app/components/banner/BUILD
@@ -2,19 +2,19 @@ load("//rules/typescript:index.bzl", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(glob(["*.css"]))
+
 ts_library(
-    name = "alert",
+    name = "banner",
     srcs = glob([
-        "*.tsx",
         "*.ts",
+        "*.tsx",
     ]),
     strict = True,
     deps = [
-        "//app/components/banner",
         "@npm//@types/react",
+        "@npm//lucide-react",
         "@npm//react",
-        "@npm//rxjs",
+        "@npm//tslib",
     ],
 )
-
-exports_files(srcs = glob(["*.css"]))

--- a/app/components/banner/banner.css
+++ b/app/components/banner/banner.css
@@ -1,0 +1,27 @@
+.banner {
+  border-radius: 8px;
+  padding: 16px;
+
+  display: flex;
+  align-items: start;
+}
+
+.banner.banner-info {
+  background: #e3f2fd;
+}
+
+.banner.banner-success {
+  background: #c8e6c9;
+}
+
+.banner.banner-warning {
+  background: #fffde7;
+}
+
+.banner.banner-error {
+  background: #ffcdd2;
+}
+
+.banner > :not(:last-child) {
+  margin-right: 8px;
+}

--- a/app/components/banner/banner.tsx
+++ b/app/components/banner/banner.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { XCircle, CheckCircle, AlertCircle, Info } from "lucide-react";
+
+const ICONS = {
+  info: <Info className="icon blue" />,
+  success: <CheckCircle className="icon green" />,
+  warning: <AlertCircle className="icon orange" />,
+  error: <XCircle className="icon red" />,
+} as const;
+
+type BannerType = keyof typeof ICONS;
+
+export type BannerProps = JSX.IntrinsicElements["div"] & {
+  /** The banner type. */
+  type: BannerType;
+};
+
+/**
+ * A banner shows a message that draws the attention of the user, using a
+ * colorful icon and background.
+ */
+export const Banner = React.forwardRef((props: BannerProps, ref: React.Ref<HTMLDivElement>) => {
+  const { type = "info", className, children, ...rest } = props;
+  return (
+    <div className={`banner banner-${type} ${className || ""}`} {...rest} ref={ref}>
+      {ICONS[type]}
+      <div>{children}</div>
+    </div>
+  );
+});
+
+export default Banner;

--- a/enterprise/app/executors/BUILD
+++ b/enterprise/app/executors/BUILD
@@ -10,6 +10,7 @@ ts_library(
     deps = [
         "//app/auth",
         "//app/capabilities",
+        "//app/components/banner",
         "//app/components/button",
         "//app/components/select",
         "//app/format",

--- a/enterprise/app/executors/executors.css
+++ b/enterprise/app/executors/executors.css
@@ -49,20 +49,8 @@
   margin-top: 16px;
 }
 
-.executors-page .callout {
+.executors-page .banner {
   margin-top: 32px;
   margin-bottom: 32px;
-  padding: 16px;
   max-width: 600px;
-  border-radius: 8px;
-  display: flex;
-  gap: 16px;
-}
-
-.executors-page .callout .icon {
-  flex-shrink: 0;
-}
-
-.executors-page .warning-callout {
-  background: #ffecb3;
 }

--- a/enterprise/app/executors/executors.tsx
+++ b/enterprise/app/executors/executors.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Banner from "../../../app/components/banner/banner";
 import rpcService from "../../../app/service/rpc_service";
 import { BuildBuddyError } from "../../../app/util/errors";
 import { User } from "../../../app/auth/auth_service";
@@ -10,7 +11,6 @@ import { bazel_config } from "../../../proto/bazel_config_ts_proto";
 import { FilledButton } from "../../../app/components/button/button";
 import router from "../../../app/router/router";
 import Select, { Option } from "../../../app/components/select/select";
-import { AlertCircle } from "lucide-react";
 
 enum FetchType {
   Executors,
@@ -323,22 +323,19 @@ export default class ExecutorsComponent extends React.Component<Props, State> {
         {activeTab === "status" && (
           <>
             {this.state.nodes.some((node) => !node.isDefault) && (
-              <div className="callout warning-callout">
-                <AlertCircle className="icon orange" />
-                <div className="callout-content">
-                  <div>
-                    Self-hosted executors are not the default for this organization. To change this, enable "Default to
-                    self-hosted executors" in your organization settings.
-                  </div>
-                  <div>
-                    <FilledButton className="organization-settings-button">
-                      <a href="/settings/" onClick={linkHandler("/settings")}>
-                        Open settings
-                      </a>
-                    </FilledButton>
-                  </div>
+              <Banner type="warning">
+                <div>
+                  Self-hosted executors are not the default for this organization. To change this, enable "Default to
+                  self-hosted executors" in your organization settings.
                 </div>
-              </div>
+                <div>
+                  <FilledButton className="organization-settings-button">
+                    <a href="/settings/" onClick={linkHandler("/settings")}>
+                      Open settings
+                    </a>
+                  </FilledButton>
+                </div>
+              </Banner>
             )}
             <ExecutorsList executors={this.state.nodes} />
             {!this.state.nodes.length && this.props.user.selectedGroup.useGroupOwnedExecutors && (

--- a/enterprise/app/org/BUILD
+++ b/enterprise/app/org/BUILD
@@ -12,6 +12,7 @@ ts_library(
         "//app/alert",
         "//app/auth",
         "//app/capabilities",
+        "//app/components/banner",
         "//app/components/button",
         "//app/components/checkbox",
         "//app/components/dialog",
@@ -25,7 +26,6 @@ ts_library(
         "//proto:group_ts_proto",
         "//proto:user_id_ts_proto",
         "@npm//@types/react",
-        "@npm//lucide-react",
         "@npm//react",
     ],
 )

--- a/enterprise/app/org/create_org.tsx
+++ b/enterprise/app/org/create_org.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import authService from "../../../app/auth/auth_service";
+import Banner from "../../../app/components/banner/banner";
 import FilledButton from "../../../app/components/button/button";
 import router, { Path } from "../../../app/router/router";
 import rpcService from "../../../app/service/rpc_service";
@@ -44,7 +45,7 @@ export default class CreateOrgComponent extends OrgForm<grp.CreateGroupRequest> 
         <div className="container">
           <div className="organization-page-title">Create organization</div>
           {this.props.user && !Boolean(this.props.user.groups?.length) && (
-            <p className="callout">You are logged in, but not part of any organization. Create one to continue.</p>
+            <Banner type="info">You are logged in, but not part of any organization. Create one to continue.</Banner>
           )}
           <form autoComplete="off" className="organization-form" onSubmit={this.onSubmit.bind(this)}>
             {this.renderFields()}

--- a/enterprise/app/org/org.css
+++ b/enterprise/app/org/org.css
@@ -10,10 +10,8 @@
   margin-bottom: 32px;
 }
 
-.organization-page .callout {
-  background-color: #ffe082;
-  padding: 16px 32px;
-  border-radius: 8px;
+.organization-page .banner {
+  margin: 16px 0;
 }
 
 .organization-form {
@@ -154,22 +152,6 @@
 .organization-invite-link-container .invite-link {
   color: #263238;
   font-weight: 600;
-}
-
-.organization-form .warning {
-  display: inline-flex;
-  align-self: flex-start;
-  margin-top: 8px;
-  background: #ffcdd2;
-  padding: 16px;
-  border-radius: 8px;
-}
-
-.organization-form .warning svg {
-  width: 24px;
-  height: 24px;
-  margin-right: 16px;
-  padding-top: 2px;
 }
 
 .organization-join-page {

--- a/enterprise/app/org/org_form.tsx
+++ b/enterprise/app/org/org_form.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import capabilities from "../../../app/capabilities/capabilities";
+import Banner from "../../../app/components/banner/banner";
 import { User } from "../../../app/auth/auth_service";
 import { grp } from "../../../proto/group_ts_proto";
 import { BuildBuddyError } from "../../../app/util/errors";
-import { AlertCircle } from "lucide-react";
 import Select, { Option } from "../../../app/components/select/select";
 
 export type FormProps = {
@@ -131,13 +131,10 @@ export default abstract class OrgForm<T extends GroupRequest> extends React.Comp
             />
           </div>
           {initialRequest.urlIdentifier && initialRequest.urlIdentifier !== request.urlIdentifier && (
-            <div className="warning">
-              <AlertCircle className="icon red" />
-              <div>
-                This change will deactivate the old URL. <br />
-                Be sure to update any links in docs, bookmarks, etc.
-              </div>
-            </div>
+            <Banner type="warning">
+              This change will deactivate the old URL. <br />
+              Be sure to update any links in docs, bookmarks, etc.
+            </Banner>
           )}
         </div>
         {this.showSuggestionPreference() && (


### PR DESCRIPTION
We have a bunch of these components which have an icon on the left-hand side, rounded corners, and light background color:

![image](https://user-images.githubusercontent.com/2414826/214434906-b320e2e8-f579-4e95-88cc-17ded3770623.png)

![image](https://user-images.githubusercontent.com/2414826/214435665-7ce94058-e223-4dee-9c08-dfda40cb5e42.png)

![image](https://user-images.githubusercontent.com/2414826/214435943-4385c6ee-6912-4744-a601-efee492fb18d.png)

This next one doesn't have an icon, but an info-level note would make sense here:

![image](https://user-images.githubusercontent.com/2414826/214436362-3a375954-0bd4-4fe2-a6e0-ce4689faea2f.png)

Extracting a `Banner` component so we can reuse these more easily and make them more consistent.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
