### PR TITLE
Update DB schema for user-level API keys

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -199,7 +199,8 @@ type Group struct {
 	GithubToken *string
 	Model
 
-	SharingEnabled bool `gorm:"default:1;type:tinyint(1)"`
+	SharingEnabled       bool `gorm:"default:1;type:tinyint(1)"`
+	UserOwnedKeysEnabled bool `gorm:"not null;default:false;type:tinyint(1)"`
 
 	// If enabled, builds for this group will always use their own executors instead of the installation-wide shared
 	// executors.


### PR DESCRIPTION
This just adds the org-level preference for enabling/disabling user-level keys.

As for the `APIKeys` table, turns out that it already has a `user_id` column, which is always empty. Also, we always set `perms = GROUP_READ|GROUP_WRITE`. So, we can introduce user-level keys without needing a migration! :four_leaf_clover: We just have to populate `user_id` with the authenticated user ID (for user-level keys only) and set `perms = OWNER_READ|OWNER_WRITE`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
