### PR TITLE
Revert #3272: Firecracker: Monitor peak FS usage

### DIFF
--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -323,7 +323,6 @@ func main() {
 	}
 	die(os.WriteFile("/etc/hosts", []byte(strings.Join(hosts, "\n")), 0755))
 	die(os.WriteFile("/etc/resolv.conf", []byte("nameserver 8.8.8.8"), 0755))
-	die(syscall.Symlink("/proc/mounts", "/etc/mtab"))
 
 	if *setDefaultRoute {
 		die(configureDefaultRoute("eth0", "192.168.241.1"))

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -80,7 +80,6 @@ go_test(
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/filecache",
         "//enterprise/server/remote_execution/workspace",
-        "//enterprise/server/util/ext4",
         "//proto:remote_execution_go_proto",
         "//server/backends/disk_cache",
         "//server/interfaces",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/firecracker"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/workspace"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ext4"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/disk_cache"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/action_cache_server"
@@ -297,8 +296,7 @@ func TestFirecrackerSnapshotAndResume(t *testing.T) {
 
 func TestFirecrackerFileMapping(t *testing.T) {
 	numFiles := 100
-	fileSizeBytes := int64(1_000_000)
-	scratchTestFileSizeBytes := int64(50_000_000)
+	fileSizeBytes := int64(1000)
 	ctx := context.Background()
 	env := getTestEnv(ctx, t)
 
@@ -322,16 +320,8 @@ func TestFirecrackerFileMapping(t *testing.T) {
 		}
 	}
 
-	workspaceDirSize, err := disk.DirSize(rootDir)
-	require.NoError(t, err)
-
 	cmd := &repb.Command{
-		Arguments: []string{"sh", "-c", `
-			find -name '*.txt' -exec cp {} {}.out \;
-			</dev/zero head -c ` + fmt.Sprint(scratchTestFileSizeBytes) + ` > ~/scratch_file.txt
-			# Sleep a bit to ensure we get a good disk usage sample.
-			sleep 1
-		`},
+		Arguments: []string{"sh", "-c", `find -name '*.txt' -exec cp {} {}.out \;`},
 	}
 	expectedResult := &interfaces.CommandResult{
 		ExitCode: 0,
@@ -358,53 +348,9 @@ func TestFirecrackerFileMapping(t *testing.T) {
 		t.Fatalf("error: %s", res.Error)
 	}
 
-	// Check that the result has the expected disk usage stats.
+	// Check that the result has usage stats, but don't perform equality checks
+	// on them.
 	assert.True(t, res.UsageStats != nil)
-	var workspaceFSU, scratchFSU *repb.UsageStats_FileSystemUsage
-	for _, fsu := range res.UsageStats.PeakFileSystemUsage {
-		if fsu.Target == "/workspace" {
-			workspaceFSU = fsu
-		} else if fsu.Target == "/" {
-			scratchFSU = fsu
-		}
-	}
-
-	const workspaceDiskSlackSpaceBytes = 2_000_000_000
-	if workspaceFSU == nil {
-		assert.Fail(t, "/workspace disk usage was not reported")
-	} else {
-		assert.Equal(t, "ext4", workspaceFSU.GetFstype())
-		assert.Equal(t, "/dev/vdc", workspaceFSU.GetSource())
-		assert.InDelta(
-			t, workspaceFSU.GetUsedBytes(),
-			// Expected size is twice the input size, since we duplicate the inputs.
-			2*workspaceDirSize,
-			10_000_000,
-			"used workspace disk size")
-		expectedTotalSize := ext4.MinDiskImageSizeBytes + workspaceDirSize + workspaceDiskSlackSpaceBytes
-		assert.InDelta(
-			t, expectedTotalSize, workspaceFSU.GetTotalBytes(),
-			60_000_000,
-			"total workspace disk size")
-	}
-	if scratchFSU == nil {
-		assert.Fail(t, "scratch (/) disk usage was not reported")
-	} else {
-		assert.Equal(t, "overlay", scratchFSU.GetFstype())
-		assert.Equal(t, "overlayfs:/scratch/bbvmroot", scratchFSU.GetSource())
-		const approxInitialScratchDiskSizeBytes = 60e6
-		assert.InDelta(
-			t, approxInitialScratchDiskSizeBytes+scratchTestFileSizeBytes,
-			scratchFSU.GetUsedBytes(),
-			20_000_000,
-			"used scratch disk size")
-		assert.InDelta(
-			t, 1_000_000*opts.ScratchDiskSizeMB+ext4.MinDiskImageSizeBytes+approxInitialScratchDiskSizeBytes,
-			scratchFSU.GetTotalBytes(),
-			20_000_000,
-			"total scratch disk size")
-	}
-
 	res.UsageStats = nil
 
 	assert.Equal(t, expectedResult, res)

--- a/enterprise/server/vmexec/BUILD
+++ b/enterprise/server/vmexec/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//proto:vmexec_go_proto",
         "//server/util/log",
         "//server/util/status",
-        "@com_github_elastic_gosigar//:gosigar",
         "@com_github_vishvananda_netlink//:netlink",
         "@org_golang_google_grpc//status",
         "@org_golang_x_sys//unix",

--- a/enterprise/server/vmexec/vmexec_test.go
+++ b/enterprise/server/vmexec/vmexec_test.go
@@ -97,7 +97,6 @@ func TestExecStreamed_Stats(t *testing.T) {
 	assert.LessOrEqual(t, res.UsageStats.GetCpuNanos(), int64(1.6e9), "should use around 1e9 CPU nanos")
 	assert.GreaterOrEqual(t, res.UsageStats.GetMemoryBytes(), int64(1e9), "should use at least 1GB memory")
 	assert.LessOrEqual(t, res.UsageStats.GetMemoryBytes(), int64(1.6e9), "shouldn't use much more than 1GB memory")
-	assert.NotEmpty(t, res.UsageStats.GetPeakFileSystemUsage(), "file system usage should not be empty")
 }
 
 func TestExecStreamed_Timeout(t *testing.T) {


### PR DESCRIPTION
This PR causes actions to crash due to `syscall.Symlink` failing if `/etc/mtab` already exists.

I'm not sure why it doesn't reproduce in `firecracker_test`, but does reproduce when running actions. Need more time to understand the issue. Reverting for now to unblock the release.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
