### PR TITLE
Dedupe firecracker disk image conversion

### DIFF
--- a/enterprise/server/util/container/BUILD
+++ b/enterprise/server/util/container/BUILD
@@ -11,8 +11,10 @@ go_library(
         "//enterprise/server/remote_execution/containers/docker",
         "//enterprise/server/util/ext4",
         "//server/util/disk",
+        "//server/util/hash",
         "//server/util/log",
         "//server/util/status",
         "@com_github_docker_docker//client",
+        "@org_golang_x_sync//singleflight",
     ],
 )


### PR DESCRIPTION
This is mostly experimental -- if we don't see a lot of successful de-dupes logged in practice, we can revert this code.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/1906
