### PR TITLE
Roll-forward #3272: Firecracker: Monitor peak FS usage

### DIFF
--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -323,7 +323,13 @@ func main() {
 	}
 	die(os.WriteFile("/etc/hosts", []byte(strings.Join(hosts, "\n")), 0755))
 	die(os.WriteFile("/etc/resolv.conf", []byte("nameserver 8.8.8.8"), 0755))
-	die(syscall.Symlink("/proc/mounts", "/etc/mtab"))
+	if _, err := os.Stat("/etc/mtab"); err != nil {
+		if os.IsNotExist(err) {
+			die(syscall.Symlink("/proc/mounts", "/etc/mtab"))
+		} else {
+			die(err)
+		}
+	}
 
 	if *setDefaultRoute {
 		die(configureDefaultRoute("eth0", "192.168.241.1"))

--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -323,6 +323,7 @@ func main() {
 	}
 	die(os.WriteFile("/etc/hosts", []byte(strings.Join(hosts, "\n")), 0755))
 	die(os.WriteFile("/etc/resolv.conf", []byte("nameserver 8.8.8.8"), 0755))
+	die(syscall.Symlink("/proc/mounts", "/etc/mtab"))
 
 	if *setDefaultRoute {
 		die(configureDefaultRoute("eth0", "192.168.241.1"))

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -80,6 +80,7 @@ go_test(
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/filecache",
         "//enterprise/server/remote_execution/workspace",
+        "//enterprise/server/util/ext4",
         "//proto:remote_execution_go_proto",
         "//server/backends/disk_cache",
         "//server/interfaces",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/firecracker"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/workspace"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ext4"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/disk_cache"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/action_cache_server"
@@ -296,7 +297,8 @@ func TestFirecrackerSnapshotAndResume(t *testing.T) {
 
 func TestFirecrackerFileMapping(t *testing.T) {
 	numFiles := 100
-	fileSizeBytes := int64(1000)
+	fileSizeBytes := int64(1_000_000)
+	scratchTestFileSizeBytes := int64(50_000_000)
 	ctx := context.Background()
 	env := getTestEnv(ctx, t)
 
@@ -320,8 +322,16 @@ func TestFirecrackerFileMapping(t *testing.T) {
 		}
 	}
 
+	workspaceDirSize, err := disk.DirSize(rootDir)
+	require.NoError(t, err)
+
 	cmd := &repb.Command{
-		Arguments: []string{"sh", "-c", `find -name '*.txt' -exec cp {} {}.out \;`},
+		Arguments: []string{"sh", "-c", `
+			find -name '*.txt' -exec cp {} {}.out \;
+			</dev/zero head -c ` + fmt.Sprint(scratchTestFileSizeBytes) + ` > ~/scratch_file.txt
+			# Sleep a bit to ensure we get a good disk usage sample.
+			sleep 1
+		`},
 	}
 	expectedResult := &interfaces.CommandResult{
 		ExitCode: 0,
@@ -348,9 +358,53 @@ func TestFirecrackerFileMapping(t *testing.T) {
 		t.Fatalf("error: %s", res.Error)
 	}
 
-	// Check that the result has usage stats, but don't perform equality checks
-	// on them.
+	// Check that the result has the expected disk usage stats.
 	assert.True(t, res.UsageStats != nil)
+	var workspaceFSU, scratchFSU *repb.UsageStats_FileSystemUsage
+	for _, fsu := range res.UsageStats.PeakFileSystemUsage {
+		if fsu.Target == "/workspace" {
+			workspaceFSU = fsu
+		} else if fsu.Target == "/" {
+			scratchFSU = fsu
+		}
+	}
+
+	const workspaceDiskSlackSpaceBytes = 2_000_000_000
+	if workspaceFSU == nil {
+		assert.Fail(t, "/workspace disk usage was not reported")
+	} else {
+		assert.Equal(t, "ext4", workspaceFSU.GetFstype())
+		assert.Equal(t, "/dev/vdc", workspaceFSU.GetSource())
+		assert.InDelta(
+			t, workspaceFSU.GetUsedBytes(),
+			// Expected size is twice the input size, since we duplicate the inputs.
+			2*workspaceDirSize,
+			10_000_000,
+			"used workspace disk size")
+		expectedTotalSize := ext4.MinDiskImageSizeBytes + workspaceDirSize + workspaceDiskSlackSpaceBytes
+		assert.InDelta(
+			t, expectedTotalSize, workspaceFSU.GetTotalBytes(),
+			60_000_000,
+			"total workspace disk size")
+	}
+	if scratchFSU == nil {
+		assert.Fail(t, "scratch (/) disk usage was not reported")
+	} else {
+		assert.Equal(t, "overlay", scratchFSU.GetFstype())
+		assert.Equal(t, "overlayfs:/scratch/bbvmroot", scratchFSU.GetSource())
+		const approxInitialScratchDiskSizeBytes = 60e6
+		assert.InDelta(
+			t, approxInitialScratchDiskSizeBytes+scratchTestFileSizeBytes,
+			scratchFSU.GetUsedBytes(),
+			20_000_000,
+			"used scratch disk size")
+		assert.InDelta(
+			t, 1_000_000*opts.ScratchDiskSizeMB+ext4.MinDiskImageSizeBytes+approxInitialScratchDiskSizeBytes,
+			scratchFSU.GetTotalBytes(),
+			20_000_000,
+			"total scratch disk size")
+	}
+
 	res.UsageStats = nil
 
 	assert.Equal(t, expectedResult, res)

--- a/enterprise/server/vmexec/BUILD
+++ b/enterprise/server/vmexec/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//proto:vmexec_go_proto",
         "//server/util/log",
         "//server/util/status",
+        "@com_github_elastic_gosigar//:gosigar",
         "@com_github_vishvananda_netlink//:netlink",
         "@org_golang_google_grpc//status",
         "@org_golang_x_sys//unix",

--- a/enterprise/server/vmexec/vmexec.go
+++ b/enterprise/server/vmexec/vmexec.go
@@ -7,11 +7,13 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sort"
 	"syscall"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/elastic/gosigar"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
@@ -307,9 +309,16 @@ func (c *command) Run(ctx context.Context, msgs chan *message) (*vmxpb.ExecStrea
 		_, err := io.Copy(&stderrWriter{msgs}, c.stderrReader)
 		stderrErrCh <- err
 	}()
-	// TODO(bduffany): monitor stats from the whole VM, not just
+	// TODO(bduffany): report memory/CPU stats from the whole VM, not just
 	// the process being executed.
+	var peakFSU []*repb.UsageStats_FileSystemUsage
 	statsListener := func(stats *repb.UsageStats) {
+		// Update the stats with disk usage.
+		if fsu := getFileSystemUsage(); fsu != nil {
+			peakFSU = updatePeakFileSystemUsage(peakFSU, fsu)
+		}
+		stats.PeakFileSystemUsage = peakFSU
+
 		msgs <- &message{Response: &vmxpb.ExecStreamedResponse{UsageStats: stats}}
 	}
 	_, err := commandutil.RunWithProcessTreeCleanup(ctx, c.cmd, statsListener)
@@ -341,4 +350,73 @@ type stderrWriter struct{ msgs chan *message }
 func (w *stderrWriter) Write(b []byte) (int, error) {
 	w.msgs <- &message{Response: &vmxpb.ExecStreamedResponse{Stderr: b}}
 	return len(b), nil
+}
+
+func getFileSystemUsage() []*repb.UsageStats_FileSystemUsage {
+	fsl := &gosigar.FileSystemList{}
+	if err := fsl.Get(); err != nil {
+		log.Errorf("Failed to get filesystem usage: %s", err)
+		return nil
+	}
+	out := make([]*repb.UsageStats_FileSystemUsage, 0, len(fsl.List))
+	for _, fs := range fsl.List {
+		// Only consider the root FS and the workspace FS.
+		// Otherwise the list is really messy, containing things like
+		// tmpfs, udev, cgroup, etc. which aren't very interesting.
+		if !(fs.DirName == "/" || fs.DirName == "/workspace") {
+			continue
+		}
+
+		fsu := &gosigar.FileSystemUsage{}
+		if err := fsu.Get(fs.DirName); err != nil {
+			log.Errorf("Failed to get filesystem usage for %s: %s", fs.DevName, err)
+			continue
+		}
+		out = append(out, &repb.UsageStats_FileSystemUsage{
+			Source:     fs.DevName,
+			Target:     fs.DirName,
+			Fstype:     fs.SysTypeName,
+			UsedBytes:  int64(fsu.Used),
+			TotalBytes: int64(fsu.Total),
+		})
+	}
+	return out
+}
+
+func updatePeakFileSystemUsage(peak, current []*repb.UsageStats_FileSystemUsage) []*repb.UsageStats_FileSystemUsage {
+	// Keep track of which indexes in the `current` list that we have merged
+	// into the `peak` list.
+	observed := map[int]bool{}
+
+	for _, p := range peak {
+		var cur *repb.UsageStats_FileSystemUsage
+		for i, c := range current {
+			if p.Target == c.Target {
+				cur = c
+				observed[i] = true
+				break
+			}
+		}
+		if cur == nil {
+			// The FS disappeared somehow.
+			// Keep it in the `peak` list with its last observed value.
+			continue
+		}
+		if cur.UsedBytes > p.UsedBytes {
+			p.UsedBytes = cur.UsedBytes
+		}
+	}
+	for i, c := range current {
+		// If we see an FS that we haven't previously observed in the `peak`
+		// list then append it to the end.
+		if !observed[i] {
+			peak = append(peak, c)
+		}
+	}
+	// Sort to ensure deterministic ordering.
+	sort.Slice(peak, func(i, j int) bool {
+		return peak[i].Target < peak[j].Target
+	})
+
+	return peak
 }

--- a/enterprise/server/vmexec/vmexec_test.go
+++ b/enterprise/server/vmexec/vmexec_test.go
@@ -97,6 +97,7 @@ func TestExecStreamed_Stats(t *testing.T) {
 	assert.LessOrEqual(t, res.UsageStats.GetCpuNanos(), int64(1.6e9), "should use around 1e9 CPU nanos")
 	assert.GreaterOrEqual(t, res.UsageStats.GetMemoryBytes(), int64(1e9), "should use at least 1GB memory")
 	assert.LessOrEqual(t, res.UsageStats.GetMemoryBytes(), int64(1.6e9), "shouldn't use much more than 1GB memory")
+	assert.NotEmpty(t, res.UsageStats.GetPeakFileSystemUsage(), "file system usage should not be empty")
 }
 
 func TestExecStreamed_Timeout(t *testing.T) {


### PR DESCRIPTION
Fixes the "file exists" error caused by `/etc/mtab` already existing in some images.

The fix is in this commit: https://github.com/buildbuddy-io/buildbuddy/pull/3295/commits/5bee4595eb35e6250e91740427311c25542bb06b

---

**Version bump**: Patch
