### PR TITLE
Refactor //server/util/clickhouse

### DIFF
--- a/server/util/clickhouse/BUILD
+++ b/server/util/clickhouse/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "clickhouse",
@@ -11,6 +11,7 @@ go_library(
         "//server/environment",
         "//server/metrics",
         "//server/tables",
+        "//server/util/clickhouse/schema",
         "//server/util/flagutil",
         "//server/util/log",
         "//server/util/retry",
@@ -19,17 +20,5 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus",
         "@io_gorm_driver_clickhouse//:clickhouse",
         "@io_gorm_gorm//:gorm",
-    ],
-)
-
-go_test(
-    name = "clickhouse_test",
-    srcs = ["clickhouse_test.go"],
-    deps = [
-        ":clickhouse",
-        "//server/tables",
-        "@com_github_go_faker_faker_v4//:faker",
-        "@com_github_stretchr_testify//assert",
-        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -2,7 +2,6 @@ package clickhouse
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/util/clickhouse/schema"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/retry"
@@ -32,13 +32,6 @@ var (
 	connMaxLifetime = flag.Duration("olap_database.conn_max_lifetime", 0, "The maximum lifetime of a connection to clickhouse")
 
 	autoMigrateDB = flag.Bool("olap_database.auto_migrate_db", true, "If true, attempt to automigrate the db when connecting")
-
-	// {installation}, {cluster}, {shard}, {replica} are macros provided by
-	// Altinity/clickhouse-operator; {database}, {table} are macros provided by clickhouse.
-	dataReplicationEnabled = flag.Bool("olap_database.enable_data_replication", false, "If true, data replication is enabled.")
-	zooPath                = flag.String("olap_database.zoo_path", "/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}", "The path to the table name in zookeeper, used to set up data replication")
-	replicaName            = flag.String("olap_database.replica_name", "{replica}", "The replica name of the table in zookeeper")
-	clusterName            = flag.String("olap_database.cluster_name", "{cluster}", "The cluster name of the database")
 )
 
 type DBHandle struct {
@@ -47,216 +40,6 @@ type DBHandle struct {
 
 func (dbh *DBHandle) DB(ctx context.Context) *gorm.DB {
 	return dbh.db.WithContext(ctx)
-}
-
-// Making a new table? Please make sure you:
-// 1) Add your table in getAllTables()
-// 2) Add the table in clickhouse_test.go TestSchemaInSync
-// 3) Make sure all the fields in the corresponding Table deinition in tables.go
-// are present in clickhouse Table definition or in ExcludedFields()
-type Table interface {
-	TableName() string
-	TableOptions() string
-	// Fields that are in the primary DB Table schema; but not in the clickhouse schema.
-	ExcludedFields() []string
-	// Fields that are in the clickhouse Table schema; but not in the primary DB Table Schema.
-	AdditionalFields() []string
-}
-
-func GetAllTables() []Table {
-	return []Table{
-		&Invocation{},
-		&Execution{},
-	}
-}
-
-func getTableClusterOption() string {
-	if *dataReplicationEnabled {
-		return fmt.Sprintf("on cluster '%s'", *clusterName)
-	}
-	return ""
-}
-
-func getEngine() string {
-	if *dataReplicationEnabled {
-		return fmt.Sprintf("ReplicatedReplacingMergeTree('%s', '%s')", *zooPath, *replicaName)
-	}
-	return "ReplacingMergeTree()"
-}
-
-func getAllTables() []Table {
-	return []Table{
-		&Invocation{},
-	}
-}
-
-func tableClusterOption() string {
-	if *dataReplicationEnabled {
-		return fmt.Sprintf("on cluster '%s'", *clusterName)
-	}
-	return ""
-}
-
-// Invocation constains a subset of tables.Invocations.
-type Invocation struct {
-	GroupID        string `gorm:"primaryKey;"`
-	UpdatedAtUsec  int64  `gorm:"primaryKey;"`
-	CreatedAtUsec  int64
-	InvocationUUID string
-	Role           string
-	User           string
-	Host           string
-	CommitSHA      string
-	BranchName     string
-	Command        string
-	BazelExitCode  string
-
-	UserID           string
-	Pattern          string
-	InvocationStatus int64
-	Attempt          uint64
-
-	ActionCount                       int64
-	RepoURL                           string
-	DurationUsec                      int64
-	Success                           bool
-	ActionCacheHits                   int64
-	ActionCacheMisses                 int64
-	ActionCacheUploads                int64
-	CasCacheHits                      int64
-	CasCacheMisses                    int64
-	CasCacheUploads                   int64
-	TotalDownloadSizeBytes            int64
-	TotalUploadSizeBytes              int64
-	TotalDownloadTransferredSizeBytes int64
-	TotalUploadTransferredSizeBytes   int64
-	TotalDownloadUsec                 int64
-	TotalUploadUsec                   int64
-	TotalCachedActionExecUsec         int64
-	DownloadThroughputBytesPerSecond  int64
-	UploadThroughputBytesPerSecond    int64
-}
-
-func (i *Invocation) ExcludedFields() []string {
-	return []string{
-		"InvocationID",
-		"BlobID",
-		"LastChunkId",
-		"RedactionFlags",
-		"CreatedWithCapabilities",
-		"Perms",
-	}
-}
-
-func (i *Invocation) AdditionalFields() []string {
-	return []string{}
-}
-
-func (i *Invocation) TableName() string {
-	return "Invocations"
-}
-
-func (i *Invocation) TableOptions() string {
-	// Note: the sorting key need to be able to uniquely identify the invocation.
-	// ReplacingMergeTree will remove entries with the same sorting key in the background.
-	return fmt.Sprintf("ENGINE=%s ORDER BY (group_id, updated_at_usec, invocation_uuid)", getEngine())
-}
-
-type Execution struct {
-	// Sort keys
-	GroupID        string
-	UpdatedAtUsec  int64
-	InvocationUUID string
-	ExecutionID    string
-
-	// Type from tables.InvocationExecution
-	InvocationLinkType int8
-	CreatedAtUsec      int64
-	UserID             string
-	Worker             string
-
-	Stage int64
-
-	// IOStats
-	FileDownloadCount        int64
-	FileDownloadSizeBytes    int64
-	FileDownloadDurationUsec int64
-	FileUploadCount          int64
-	FileUploadSizeBytes      int64
-	FileUploadDurationUsec   int64
-
-	// UsageStats
-	PeakMemoryBytes int64
-	CPUNanos        int64
-
-	// Task sizing
-	EstimatedMemoryBytes int64
-	EstimatedMilliCPU    int64
-
-	// ExecutedActionMetadata (in addition to Worker above)
-	QueuedTimestampUsec                int64
-	WorkerStartTimestampUsec           int64
-	WorkerCompletedTimestampUsec       int64
-	InputFetchStartTimestampUsec       int64
-	InputFetchCompletedTimestampUsec   int64
-	ExecutionStartTimestampUsec        int64
-	ExecutionCompletedTimestampUsec    int64
-	OutputUploadStartTimestampUsec     int64
-	OutputUploadCompletedTimestampUsec int64
-
-	StatusCode int32
-	ExitCode   int32
-
-	CachedResult bool
-	DoNotCache   bool
-
-	// Fields from Invocations
-	User             string
-	Host             string
-	Pattern          string
-	Role             string
-	BranchName       string
-	CommitSHA        string
-	RepoURL          string
-	Command          string
-	InvocationStatus int64
-	Success          bool
-}
-
-func (e *Execution) TableName() string {
-	return "Executions"
-}
-
-func (e *Execution) TableOptions() string {
-	return fmt.Sprintf("ENGINE=%s ORDER BY (group_id, updated_at_usec, invocation_uuid,execution_id)", getEngine())
-}
-
-func (e *Execution) ExcludedFields() []string {
-	return []string{
-		"InvocationID",
-		"Perms",
-		"SerializedOperation",
-		"SerializedStatusDetails",
-		"CommandSnippet",
-		"StatusMessage",
-	}
-}
-
-func (e *Execution) AdditionalFields() []string {
-	return []string{
-		"InvocationUUID",
-		"User",
-		"Host",
-		"Pattern",
-		"Role",
-		"BranchName",
-		"CommitSHA",
-		"RepoURL",
-		"Command",
-		"InvocationStatus",
-		"Success",
-		"InvocationLinkType",
-	}
 }
 
 // DateFromUsecTimestamp returns an SQL expression compatible with clickhouse
@@ -270,47 +53,51 @@ func (h *DBHandle) DateFromUsecTimestamp(fieldName string, timezoneOffsetMinutes
 	return fmt.Sprintf("FROM_UNIXTIME(%s,", timestampExpr) + "'%F')"
 }
 
-func ToInvocationFromPrimaryDB(ti *tables.Invocation) *Invocation {
-	return &Invocation{
-		GroupID:                           ti.GroupID,
-		UpdatedAtUsec:                     ti.UpdatedAtUsec,
-		CreatedAtUsec:                     ti.CreatedAtUsec,
-		InvocationUUID:                    hex.EncodeToString(ti.InvocationUUID),
-		Role:                              ti.Role,
-		User:                              ti.User,
-		UserID:                            ti.UserID,
-		Host:                              ti.Host,
-		CommitSHA:                         ti.CommitSHA,
-		BranchName:                        ti.BranchName,
-		Command:                           ti.Command,
-		BazelExitCode:                     ti.BazelExitCode,
-		Pattern:                           ti.Pattern,
-		Attempt:                           ti.Attempt,
-		ActionCount:                       ti.ActionCount,
-		InvocationStatus:                  ti.InvocationStatus,
-		RepoURL:                           ti.RepoURL,
-		DurationUsec:                      ti.DurationUsec,
-		Success:                           ti.Success,
-		ActionCacheHits:                   ti.ActionCacheHits,
-		ActionCacheMisses:                 ti.ActionCacheMisses,
-		ActionCacheUploads:                ti.ActionCacheUploads,
-		CasCacheHits:                      ti.CasCacheHits,
-		CasCacheMisses:                    ti.CasCacheMisses,
-		CasCacheUploads:                   ti.CasCacheUploads,
-		TotalDownloadSizeBytes:            ti.TotalDownloadSizeBytes,
-		TotalUploadSizeBytes:              ti.TotalUploadSizeBytes,
-		TotalDownloadUsec:                 ti.TotalDownloadUsec,
-		TotalUploadUsec:                   ti.TotalUploadUsec,
-		TotalDownloadTransferredSizeBytes: ti.TotalDownloadTransferredSizeBytes,
-		TotalUploadTransferredSizeBytes:   ti.TotalUploadTransferredSizeBytes,
-		TotalCachedActionExecUsec:         ti.TotalCachedActionExecUsec,
-		DownloadThroughputBytesPerSecond:  ti.DownloadThroughputBytesPerSecond,
-		UploadThroughputBytesPerSecond:    ti.UploadThroughputBytesPerSecond,
+func isTimeout(err error) bool {
+	if err == nil {
+		return false
 	}
+	return strings.Contains(err.Error(), "i/o timeout")
 }
 
-func buildExecution(in *repb.StoredExecution, inv *sipb.StoredInvocation) *Execution {
-	return &Execution{
+func (h *DBHandle) insertWithRetrier(ctx context.Context, tableName string, numEntries int, value interface{}) error {
+	retrier := retry.DefaultWithContext(ctx)
+	var lastError error
+	for retrier.Next() {
+		res := h.DB(ctx).Create(value)
+		lastError = res.Error
+		if errors.Is(res.Error, syscall.ECONNRESET) || errors.Is(res.Error, syscall.ECONNREFUSED) || isTimeout(res.Error) {
+			// Retry since it's an transient error.
+			log.CtxWarningf(ctx, "attempt (n=%d) to clickhouse table %q failed: %s", retrier.AttemptNumber(), tableName, res.Error)
+			continue
+		}
+		break
+	}
+	statusLabel := "ok"
+	if lastError != nil {
+		statusLabel = "error"
+	}
+	metrics.ClickhouseInsertedCount.With(prometheus.Labels{
+		metrics.ClickhouseTableName:   tableName,
+		metrics.ClickhouseStatusLabel: statusLabel,
+	}).Add(float64(numEntries))
+	if lastError != nil {
+		return status.UnavailableErrorf("insertWithRetrier exceeded retries (n=%d), err: %s", retrier.AttemptNumber(), lastError)
+	}
+	return lastError
+
+}
+
+func (h *DBHandle) FlushInvocationStats(ctx context.Context, ti *tables.Invocation) error {
+	inv := schema.ToInvocationFromPrimaryDB(ti)
+	if err := h.insertWithRetrier(ctx, inv.TableName(), 1, inv); err != nil {
+		return status.UnavailableErrorf("failed to insert invocation (invocation_id = %q), err: %s", ti.InvocationID, err)
+	}
+	return nil
+}
+
+func buildExecution(in *repb.StoredExecution, inv *sipb.StoredInvocation) *schema.Execution {
+	return &schema.Execution{
 		GroupID:                            in.GetGroupId(),
 		UpdatedAtUsec:                      in.GetUpdatedAtUsec(),
 		ExecutionID:                        in.GetExecutionId(),
@@ -352,71 +139,14 @@ func buildExecution(in *repb.StoredExecution, inv *sipb.StoredInvocation) *Execu
 	}
 }
 
-func isTimeout(err error) bool {
-	if err == nil {
-		return false
-	}
-	return strings.Contains(err.Error(), "i/o timeout")
-}
-
-func (h *DBHandle) insertWithRetrier(ctx context.Context, tableName string, numEntries int, value interface{}) error {
-	retrier := retry.DefaultWithContext(ctx)
-	var lastError error
-	for retrier.Next() {
-		res := h.DB(ctx).Create(value)
-		lastError = res.Error
-		if errors.Is(res.Error, syscall.ECONNRESET) || errors.Is(res.Error, syscall.ECONNREFUSED) || isTimeout(res.Error) {
-			// Retry since it's an transient error.
-			log.CtxWarningf(ctx, "attempt (n=%d) to clickhouse table %q failed: %s", retrier.AttemptNumber(), tableName, res.Error)
-			continue
-		}
-		break
-	}
-	statusLabel := "ok"
-	if lastError != nil {
-		statusLabel = "error"
-	}
-	metrics.ClickhouseInsertedCount.With(prometheus.Labels{
-		metrics.ClickhouseTableName:   tableName,
-		metrics.ClickhouseStatusLabel: statusLabel,
-	}).Add(float64(numEntries))
-	if lastError != nil {
-		return status.UnavailableErrorf("insertWithRetrier exceeded retries (n=%d), err: %s", retrier.AttemptNumber(), lastError)
-	}
-	return lastError
-
-}
-
-func (h *DBHandle) FlushInvocationStats(ctx context.Context, ti *tables.Invocation) error {
-	inv := ToInvocationFromPrimaryDB(ti)
-	if err := h.insertWithRetrier(ctx, inv.TableName(), 1, inv); err != nil {
-		return status.UnavailableErrorf("failed to insert invocation (invocation_id = %q), err: %s", ti.InvocationID, err)
-	}
-	return nil
-}
-
 func (h *DBHandle) FlushExecutionStats(ctx context.Context, inv *sipb.StoredInvocation, executions []*repb.StoredExecution) error {
-	entries := make([]*Execution, 0, len(executions))
+	entries := make([]*schema.Execution, 0, len(executions))
 	for _, e := range executions {
 		entries = append(entries, buildExecution(e, inv))
 	}
 	num := len(entries)
-	if err := h.insertWithRetrier(ctx, (&Execution{}).TableName(), num, &entries); err != nil {
+	if err := h.insertWithRetrier(ctx, (&schema.Execution{}).TableName(), num, &entries); err != nil {
 		return status.UnavailableErrorf("failed to insert %d execution(s) for invocation (invocation_id = %q), err: %s", num, inv.GetInvocationId(), err)
-	}
-	return nil
-}
-
-func runMigrations(gdb *gorm.DB) error {
-	log.Info("Auto-migrating clickhouse DB")
-	if clusterOpts := getTableClusterOption(); clusterOpts != "" {
-		gdb = gdb.Set("gorm:table_cluster_options", clusterOpts)
-	}
-	for _, t := range GetAllTables() {
-		gdb = gdb.Set("gorm:table_options", t.TableOptions())
-		if err := gdb.AutoMigrate(t); err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -448,7 +178,7 @@ func Register(env environment.Env) error {
 		return status.InternalErrorf("failed to open gorm clickhouse db: %s", err)
 	}
 	if *autoMigrateDB {
-		if err := runMigrations(db); err != nil {
+		if err := schema.RunMigrations(db); err != nil {
 			return err
 		}
 	}

--- a/server/util/clickhouse/schema/BUILD
+++ b/server/util/clickhouse/schema/BUILD
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "schema",
+    srcs = ["schema.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/clickhouse/schema",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/tables",
+        "//server/util/log",
+        "//server/util/status",
+        "@io_gorm_gorm//:gorm",
+    ],
+)
+
+go_test(
+    name = "schema_test",
+    srcs = ["schema_test.go"],
+    embed = [":schema"],
+    deps = [
+        "//server/tables",
+        "@com_github_go_faker_faker_v4//:faker",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/util/clickhouse/schema/BUILD
+++ b/server/util/clickhouse/schema/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//server/tables",
         "//server/util/log",
-        "//server/util/status",
         "@io_gorm_gorm//:gorm",
     ],
 )

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -1,0 +1,277 @@
+package schema
+
+import (
+	"encoding/hex"
+	"flag"
+	"fmt"
+
+	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"gorm.io/gorm"
+)
+
+var (
+	// {installation}, {cluster}, {shard}, {replica} are macros provided by
+	// Altinity/clickhouse-operator; {database}, {table} are macros provided by clickhouse.
+	dataReplicationEnabled = flag.Bool("olap_database.enable_data_replication", false, "If true, data replication is enabled.")
+	zooPath                = flag.String("olap_database.zoo_path", "/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}", "The path to the table name in zookeeper, used to set up data replication")
+	replicaName            = flag.String("olap_database.replica_name", "{replica}", "The replica name of the table in zookeeper")
+	clusterName            = flag.String("olap_database.cluster_name", "{cluster}", "The cluster name of the database")
+)
+
+// Making a new table? Please make sure you:
+// 1) Add your table in getAllTables()
+// 2) Add the table in clickhouse_test.go TestSchemaInSync
+// 3) Make sure all the fields in the corresponding Table deinition in tables.go
+// are present in clickhouse Table definition or in ExcludedFields()
+type Table interface {
+	TableName() string
+	TableOptions() string
+	// Fields that are in the primary DB Table schema; but not in the clickhouse schema.
+	ExcludedFields() []string
+	// Fields that are in the clickhouse Table schema; but not in the primary DB Table Schema.
+	AdditionalFields() []string
+}
+
+func getAllTables() []Table {
+	return []Table{
+		&Invocation{},
+		&Execution{},
+	}
+}
+
+func getTableClusterOption() string {
+	if *dataReplicationEnabled {
+		return fmt.Sprintf("on cluster '%s'", *clusterName)
+	}
+	return ""
+}
+
+func getEngine() string {
+	if *dataReplicationEnabled {
+		return fmt.Sprintf("ReplicatedReplacingMergeTree('%s', '%s')", *zooPath, *replicaName)
+	}
+	return "ReplacingMergeTree()"
+}
+
+func tableClusterOption() string {
+	if *dataReplicationEnabled {
+		return fmt.Sprintf("on cluster '%s'", *clusterName)
+	}
+	return ""
+}
+
+// Invocation constains a subset of tables.Invocations.
+type Invocation struct {
+	GroupID        string `gorm:"primaryKey;"`
+	UpdatedAtUsec  int64  `gorm:"primaryKey;"`
+	CreatedAtUsec  int64
+	InvocationUUID string
+	Role           string
+	User           string
+	Host           string
+	CommitSHA      string
+	BranchName     string
+	Command        string
+	BazelExitCode  string
+
+	UserID           string
+	Pattern          string
+	InvocationStatus int64
+	Attempt          uint64
+
+	ActionCount                       int64
+	RepoURL                           string
+	DurationUsec                      int64
+	Success                           bool
+	ActionCacheHits                   int64
+	ActionCacheMisses                 int64
+	ActionCacheUploads                int64
+	CasCacheHits                      int64
+	CasCacheMisses                    int64
+	CasCacheUploads                   int64
+	TotalDownloadSizeBytes            int64
+	TotalUploadSizeBytes              int64
+	TotalDownloadTransferredSizeBytes int64
+	TotalUploadTransferredSizeBytes   int64
+	TotalDownloadUsec                 int64
+	TotalUploadUsec                   int64
+	TotalCachedActionExecUsec         int64
+	DownloadThroughputBytesPerSecond  int64
+	UploadThroughputBytesPerSecond    int64
+}
+
+func (i *Invocation) ExcludedFields() []string {
+	return []string{
+		"InvocationID",
+		"BlobID",
+		"LastChunkId",
+		"RedactionFlags",
+		"CreatedWithCapabilities",
+		"Perms",
+	}
+}
+
+func (i *Invocation) AdditionalFields() []string {
+	return []string{}
+}
+
+func (i *Invocation) TableName() string {
+	return "Invocations"
+}
+
+func (i *Invocation) TableOptions() string {
+	// Note: the sorting key need to be able to uniquely identify the invocation.
+	// ReplacingMergeTree will remove entries with the same sorting key in the background.
+	return fmt.Sprintf("ENGINE=%s ORDER BY (group_id, updated_at_usec, invocation_uuid)", getEngine())
+}
+
+type Execution struct {
+	// Sort keys
+	GroupID        string
+	UpdatedAtUsec  int64
+	InvocationUUID string
+	ExecutionID    string
+
+	// Type from tables.InvocationExecution
+	InvocationLinkType int8
+	CreatedAtUsec      int64
+	UserID             string
+	Worker             string
+
+	Stage int64
+
+	// IOStats
+	FileDownloadCount        int64
+	FileDownloadSizeBytes    int64
+	FileDownloadDurationUsec int64
+	FileUploadCount          int64
+	FileUploadSizeBytes      int64
+	FileUploadDurationUsec   int64
+
+	// UsageStats
+	PeakMemoryBytes int64
+	CPUNanos        int64
+
+	// Task sizing
+	EstimatedMemoryBytes int64
+	EstimatedMilliCPU    int64
+
+	// ExecutedActionMetadata (in addition to Worker above)
+	QueuedTimestampUsec                int64
+	WorkerStartTimestampUsec           int64
+	WorkerCompletedTimestampUsec       int64
+	InputFetchStartTimestampUsec       int64
+	InputFetchCompletedTimestampUsec   int64
+	ExecutionStartTimestampUsec        int64
+	ExecutionCompletedTimestampUsec    int64
+	OutputUploadStartTimestampUsec     int64
+	OutputUploadCompletedTimestampUsec int64
+
+	StatusCode int32
+	ExitCode   int32
+
+	CachedResult bool
+	DoNotCache   bool
+
+	// Fields from Invocations
+	User             string
+	Host             string
+	Pattern          string
+	Role             string
+	BranchName       string
+	CommitSHA        string
+	RepoURL          string
+	Command          string
+	InvocationStatus int64
+	Success          bool
+}
+
+func (e *Execution) TableName() string {
+	return "Executions"
+}
+
+func (e *Execution) TableOptions() string {
+	return fmt.Sprintf("ENGINE=%s ORDER BY (group_id, updated_at_usec, invocation_uuid,execution_id)", getEngine())
+}
+
+func (e *Execution) ExcludedFields() []string {
+	return []string{
+		"InvocationID",
+		"Perms",
+		"SerializedOperation",
+		"SerializedStatusDetails",
+		"CommandSnippet",
+		"StatusMessage",
+	}
+}
+
+func (e *Execution) AdditionalFields() []string {
+	return []string{
+		"InvocationUUID",
+		"User",
+		"Host",
+		"Pattern",
+		"Role",
+		"BranchName",
+		"CommitSHA",
+		"RepoURL",
+		"Command",
+		"InvocationStatus",
+		"Success",
+		"InvocationLinkType",
+	}
+}
+
+func RunMigrations(gdb *gorm.DB) error {
+	log.Info("Auto-migrating clickhouse DB")
+	if clusterOpts := getTableClusterOption(); clusterOpts != "" {
+		gdb = gdb.Set("gorm:table_cluster_options", clusterOpts)
+	}
+	for _, t := range getAllTables() {
+		gdb = gdb.Set("gorm:table_options", t.TableOptions())
+		if err := gdb.AutoMigrate(t); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ToInvocationFromPrimaryDB(ti *tables.Invocation) *Invocation {
+	return &Invocation{
+		GroupID:                           ti.GroupID,
+		UpdatedAtUsec:                     ti.UpdatedAtUsec,
+		CreatedAtUsec:                     ti.CreatedAtUsec,
+		InvocationUUID:                    hex.EncodeToString(ti.InvocationUUID),
+		Role:                              ti.Role,
+		User:                              ti.User,
+		UserID:                            ti.UserID,
+		Host:                              ti.Host,
+		CommitSHA:                         ti.CommitSHA,
+		BranchName:                        ti.BranchName,
+		Command:                           ti.Command,
+		BazelExitCode:                     ti.BazelExitCode,
+		Pattern:                           ti.Pattern,
+		Attempt:                           ti.Attempt,
+		ActionCount:                       ti.ActionCount,
+		InvocationStatus:                  ti.InvocationStatus,
+		RepoURL:                           ti.RepoURL,
+		DurationUsec:                      ti.DurationUsec,
+		Success:                           ti.Success,
+		ActionCacheHits:                   ti.ActionCacheHits,
+		ActionCacheMisses:                 ti.ActionCacheMisses,
+		ActionCacheUploads:                ti.ActionCacheUploads,
+		CasCacheHits:                      ti.CasCacheHits,
+		CasCacheMisses:                    ti.CasCacheMisses,
+		CasCacheUploads:                   ti.CasCacheUploads,
+		TotalDownloadSizeBytes:            ti.TotalDownloadSizeBytes,
+		TotalUploadSizeBytes:              ti.TotalUploadSizeBytes,
+		TotalDownloadUsec:                 ti.TotalDownloadUsec,
+		TotalUploadUsec:                   ti.TotalUploadUsec,
+		TotalDownloadTransferredSizeBytes: ti.TotalDownloadTransferredSizeBytes,
+		TotalUploadTransferredSizeBytes:   ti.TotalUploadTransferredSizeBytes,
+		TotalCachedActionExecUsec:         ti.TotalCachedActionExecUsec,
+		DownloadThroughputBytesPerSecond:  ti.DownloadThroughputBytesPerSecond,
+		UploadThroughputBytesPerSecond:    ti.UploadThroughputBytesPerSecond,
+	}
+}

--- a/server/util/clickhouse/schema/schema_test.go
+++ b/server/util/clickhouse/schema/schema_test.go
@@ -1,4 +1,4 @@
-package clickhouse_test
+package schema
 
 import (
 	"encoding/hex"
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
-	"github.com/buildbuddy-io/buildbuddy/server/util/clickhouse"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -24,20 +23,20 @@ func isInList(fieldName string, fields []string) bool {
 
 func TestSchemaInSync(t *testing.T) {
 	tests := []struct {
-		clickhouseTable clickhouse.Table
+		clickhouseTable Table
 		primaryDBTable  interface{}
 	}{
 		{
-			clickhouseTable: &clickhouse.Invocation{},
+			clickhouseTable: &Invocation{},
 			primaryDBTable:  tables.Invocation{},
 		},
 		{
-			clickhouseTable: &clickhouse.Execution{},
+			clickhouseTable: &Execution{},
 			primaryDBTable:  tables.Execution{},
 		},
 	}
 
-	assert.Equal(t, len(clickhouse.GetAllTables()), len(tests), "All clickhouse tables should be present in the tests")
+	assert.Equal(t, len(getAllTables()), len(tests), "All clickhouse tables should be present in the tests")
 
 	for _, tc := range tests {
 
@@ -94,13 +93,13 @@ func TestToInvocationFromPrimaryDB(t *testing.T) {
 	src := &tables.Invocation{}
 	err := faker.FakeData(src)
 	require.NoError(t, err)
-	dest := clickhouse.ToInvocationFromPrimaryDB(src)
+	dest := ToInvocationFromPrimaryDB(src)
 
 	primaryInvType := reflect.TypeOf(*src)
 	primaryInvFields := reflect.VisibleFields(primaryInvType)
 	srcValue := reflect.ValueOf(*src)
 	destValue := reflect.ValueOf(*dest)
-	excludedFields := (&clickhouse.Invocation{}).ExcludedFields()
+	excludedFields := (&Invocation{}).ExcludedFields()
 
 	expectedUUID := hex.EncodeToString(src.InvocationUUID)
 	assert.Equal(t, dest.InvocationUUID, expectedUUID, "src and dest have different values for field 'InvocationUUID'. src = %v, dest = %v", src.InvocationUUID, expectedUUID)


### PR DESCRIPTION
Move Table definition to its own package server/util/clickhouse/schema. This is to prevent a circular dependency in a subsequent PR. https://github.com/buildbuddy-io/buildbuddy/pull/3305