### PR TITLE
Add a LockID() string method to PebbleKey and use it

### DIFF
--- a/enterprise/server/raft/filestore/filestore.go
+++ b/enterprise/server/raft/filestore/filestore.go
@@ -98,6 +98,13 @@ func (pmk *PebbleKey) String() string {
 	return string(fmk)
 }
 
+func (pmk *PebbleKey) LockID() string {
+	if pmk.isolation == "ac" {
+		return filepath.Join(pmk.isolation, pmk.remoteInstanceHash, pmk.hash)
+	}
+	return filepath.Join(pmk.isolation, pmk.hash)
+}
+
 func (pmk *PebbleKey) Bytes(version PebbleKeyVersion) ([]byte, error) {
 	switch version {
 	case UndefinedKeyVersion:

--- a/enterprise/server/util/pebbleutil/pebbleutil.go
+++ b/enterprise/server/util/pebbleutil/pebbleutil.go
@@ -233,17 +233,8 @@ func GetCopy(b pebble.Reader, key []byte) ([]byte, error) {
 	return val, nil
 }
 
-// IterHasKey returns a bool indicating if the provided iterator has the
-// exact key specified.
-func IterHasKey(iter *pebble.Iterator, key []byte) bool {
-	if iter.SeekGE(key) && bytes.Compare(iter.Key(), key) == 0 {
-		return true
-	}
-	return false
-}
-
 func LookupProto(iter *pebble.Iterator, key []byte, pb proto.Message) error {
-	if !IterHasKey(iter, key) {
+	if !iter.SeekGE(key) || bytes.Compare(iter.Key(), key) != 0 {
 		return status.NotFoundErrorf("key %q not found", key)
 	}
 	if err := proto.Unmarshal(iter.Value(), pb); err != nil {


### PR DESCRIPTION
This changes the pebble lock-key from a raw fileMetadataKey to a string containing:

AC: cache type, remote instance name, digest
CAS: cache type, digest
