### PR TITLE
Add version exemplars test and move version bit to end of bytes

### DIFF
--- a/enterprise/server/raft/filestore/filestore_test.go
+++ b/enterprise/server/raft/filestore/filestore_test.go
@@ -53,3 +53,33 @@ func TestKeyVersionCrossCompatibility(t *testing.T) {
 		}
 	}
 }
+
+func TestKnownVersions(t *testing.T) {
+	versionExemplars := map[filestore.PebbleKeyVersion][]string{
+		filestore.UndefinedKeyVersion: []string{
+			"PTFOO/cas/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2",
+			"PTFOO/GR7890/ac/2364854541/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309",
+		},
+		filestore.Version1: []string{
+			"PTFOO/cas/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2/v1",
+			"PTFOO/GR7890/ac/2364854541/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/v1",
+		},
+		filestore.Version2: []string{
+			"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/cas/v2",
+			"PTFOO/GR7890/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/ac/2364854541/v2",
+		},
+	}
+
+	for version := filestore.UndefinedKeyVersion; version < filestore.TestingMaxKeyVersion; version++ {
+		exemplars, ok := versionExemplars[version]
+		if !ok {
+			t.Fatalf("Please add test exemplars for pebble key version: %d", version)
+		}
+		for _, exemplar := range exemplars {
+			var key filestore.PebbleKey
+			parsedVersion, err := key.FromBytes([]byte(exemplar))
+			assert.NoError(t, err)
+			assert.Equal(t, version, parsedVersion)
+		}
+	}
+}


### PR DESCRIPTION
This moves the version to the end (as discussed) to ensure data at different versions is stored in such a way as to be adjacent (and likely in the same block). Also adds a test with exemplars of each key version.