### PR TITLE
Implement UI for user-level API keys

### DIFF
--- a/app/auth/user.ts
+++ b/app/auth/user.ts
@@ -11,6 +11,10 @@ export class User {
   /** Whether the user is temporarily acting as a member of the selected group. */
   isImpersonating: boolean;
 
+  getId() {
+    return this.displayUser.userId.id;
+  }
+
   selectedGroupName() {
     if (this.selectedGroup?.name == "DEFAULT_GROUP") return "Organization";
     return this.selectedGroup?.name?.trim();
@@ -22,5 +26,9 @@ export class User {
 
   canImpersonate() {
     return this.allowedRpcs.has("getInvocationOwner");
+  }
+
+  isGroupAdmin() {
+    return this.allowedRpcs.has("updateGroup");
   }
 }

--- a/enterprise/app/org/edit_org.tsx
+++ b/enterprise/app/org/edit_org.tsx
@@ -33,6 +33,7 @@ export default class EditOrgComponent extends OrgForm<grp.UpdateGroupRequest> {
       urlIdentifier: group.urlIdentifier,
       autoPopulateFromOwnedDomain: Boolean(group.ownedDomain),
       sharingEnabled: group.sharingEnabled,
+      userOwnedKeysEnabled: group.userOwnedKeysEnabled,
       useGroupOwnedExecutors: group.useGroupOwnedExecutors,
       suggestionPreference: group.suggestionPreference,
     });

--- a/enterprise/app/org/org_form.tsx
+++ b/enterprise/app/org/org_form.tsx
@@ -190,6 +190,24 @@ export default abstract class OrgForm<T extends GroupRequest> extends React.Comp
             <span>Default to self-hosted executors</span>
           </label>
         )}
+        {capabilities.config.userOwnedKeysEnabled && (
+          <label className="form-row input-label">
+            <input
+              autoComplete="off"
+              onFocus={this.onFocus.bind(this)}
+              onChange={this.onChange.bind(this)}
+              type="checkbox"
+              name="userOwnedKeysEnabled"
+              checked={request.userOwnedKeysEnabled}
+            />
+            <span>Enable user-owned API keys</span>
+          </label>
+        )}
+        {initialRequest.userOwnedKeysEnabled && !request.userOwnedKeysEnabled && (
+          <Banner className="form-row" type="warning">
+            This change will deactivate (but not delete) existing keys.
+          </Banner>
+        )}
       </>
     );
   }

--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -25,6 +25,7 @@ enum TabId {
   OrgApiKeys = "org/api-keys",
   OrgSecrets = "org/secrets",
   PersonalPreferences = "personal/preferences",
+  PersonalApiKeys = "personal/api-keys",
   ServerQuota = "server/quota",
 }
 
@@ -98,7 +99,7 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                   </SettingsTab>
                 )}
                 <SettingsTab id={TabId.OrgApiKeys} activeTabId={activeTabId}>
-                  API keys
+                  Org API keys
                 </SettingsTab>
                 {capabilities.config.secretsEnabled && router.canAccessOrgSecretsPage(this.props.user) && (
                   <SettingsTab id={TabId.OrgSecrets} activeTabId={activeTabId}>
@@ -114,6 +115,11 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                 <SettingsTab id={TabId.PersonalPreferences} activeTabId={activeTabId}>
                   Preferences
                 </SettingsTab>
+                {this.props.user?.selectedGroup?.userOwnedKeysEnabled && (
+                  <SettingsTab id={TabId.PersonalApiKeys} activeTabId={activeTabId}>
+                    Personal API keys
+                  </SettingsTab>
+                )}
               </div>
               {this.props.user.canCall("getNamespace") && capabilities.config.quotaManagementEnabled && (
                 <>
@@ -172,13 +178,25 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                   {activeTabId === TabId.OrgGitHub && capabilities.github && <GitHubLink user={this.props.user} />}
                   {activeTabId === TabId.OrgApiKeys && capabilities.manageApiKeys && (
                     <>
-                      <div className="settings-option-title">API keys</div>
+                      <div className="settings-option-title">Org API keys</div>
                       <div className="settings-option-description">
                         API keys grant access to your BuildBuddy organization.
                       </div>
                       <ApiKeysComponent user={this.props.user} />
                     </>
                   )}
+                  {activeTabId === TabId.PersonalApiKeys &&
+                    capabilities.manageApiKeys &&
+                    this.props.user?.selectedGroup?.userOwnedKeysEnabled && (
+                      <>
+                        <div className="settings-option-title">Personal API keys</div>
+                        <div className="settings-option-description">
+                          Personal API keys let you run builds within your organization that are authenticated as your
+                          user account.
+                        </div>
+                        <ApiKeysComponent user={this.props.user} userOwnedOnly />
+                      </>
+                    )}
                   {activeTabId === TabId.OrgSecrets && capabilities.config.secretsEnabled && (
                     <SecretsComponent path={this.props.path} search={this.props.search} />
                   )}

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -71,4 +71,7 @@ message FrontendConfig {
 
   // Whether to render test outputs.zip contents in the targets UI.
   bool test_output_manifests_enabled = 23;
+
+  // Whether to enable the user-owned keys UI.
+  bool user_owned_keys_enabled = 24;
 }

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -37,6 +37,7 @@ var (
 	testGridV2Enabled          = flag.Bool("app.test_grid_v2_enabled", true, "Whether to enable test grid V2")
 	usageEnabled               = flag.Bool("app.usage_enabled", false, "If set, the usage page will be enabled in the UI.")
 	expandedSuggestionsEnabled = flag.Bool("app.expanded_suggestions_enabled", false, "If set, enable more build suggestions in the UI.")
+	userOwnedKeysEnabled       = flag.Bool("app.user_owned_keys_enabled", false, "If set, enable the UI controls for user-owned API keys.")
 	enableWorkflows            = flag.Bool("remote_execution.enable_workflows", false, "Whether to enable BuildBuddy workflows.")
 	enableExecutorKeyCreation  = flag.Bool("remote_execution.enable_executor_key_creation", false, "If enabled, UI will allow executor keys to be created.")
 	testOutputManifestsEnabled = flag.Bool("app.test_output_manifests_enabled", true, "If set, the target page will render the contents of test output zips.")
@@ -153,6 +154,7 @@ func serveIndexTemplate(env environment.Env, tpl *template.Template, version, js
 		QuotaManagementEnabled:        env.GetQuotaManager() != nil,
 		SecretsEnabled:                env.GetSecretService() != nil,
 		TestOutputManifestsEnabled:    *testOutputManifestsEnabled,
+		UserOwnedKeysEnabled:          *userOwnedKeysEnabled,
 	}
 
 	configJSON, err := protojson.Marshal(&config)


### PR DESCRIPTION
Setup changes:
* Add "(personal key)" label to the dropdown
* Don't show the API key value in the dropdown (since it was getting too long)

---

![image](https://user-images.githubusercontent.com/2414826/215558166-9eb392b5-ab63-4ed9-939a-2e2fb6eceae8.png)

---

Org settings:
* Add checkbox to enable (code is commented out for now, until we're ready to launch).
* Unchecking the checkbox shows a warning banner indicating that the change will deactivate any existing keys.

---

![image](https://user-images.githubusercontent.com/2414826/215559903-f4c4ebb9-fe19-47ec-8788-9b42a679a6c0.png)

---

Settings:
* Add tabs
* Render personal keys page

---

![image](https://user-images.githubusercontent.com/2414826/215558934-9b80bcc9-98e6-4141-a0ce-54e0195b9379.png)

---

![image (1)](https://user-images.githubusercontent.com/2414826/215560204-1dab757f-b3cd-4417-9e05-e0e27c1a960e.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
