### PR TITLE
Cleanup: Consolidate APIKeyGroup queries in authdb

### DIFF
--- a/enterprise/server/backends/authdb/BUILD
+++ b/enterprise/server/backends/authdb/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//server/interfaces",
         "//server/tables",
         "//server/util/db",
+        "//server/util/query_builder",
         "//server/util/status",
     ],
 )

--- a/server/util/query_builder/query_builder_test.go
+++ b/server/util/query_builder/query_builder_test.go
@@ -55,3 +55,13 @@ func TestJoinClause(t *testing.T) {
 	assert.Equal(t, expectedQueryStr, strings.TrimSpace(qStr))
 	assert.Equal(t, []interface{}{4, 6, 10}, qArgs)
 }
+
+func TestJoinInOriginalQuery(t *testing.T) {
+	qb := query_builder.NewQuery("SELECT ak.user_id, g.group_id FROM `Groups` AS g, APIKeys AS ak")
+	qb.AddWhereClause(`ak.group_id = g.group_id`)
+	qb.AddWhereClause(`g.group_id = ?`, "GR1")
+	q, args := qb.Build()
+
+	assert.Equal(t, "SELECT ak.user_id, g.group_id FROM `Groups` AS g, APIKeys AS ak WHERE  ak.group_id = g.group_id AND g.group_id = ? ", q)
+	assert.Equal(t, []interface{}{"GR1"}, args)
+}


### PR DESCRIPTION
Move the common query parts to a single func since we'll be adding more fields onto this query and adding more WHERE clauses as part of user-owned API keys.

This should be a NOP.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
