### PR TITLE
Add prometheus metrics for logs

### DIFF
--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1612,6 +1612,15 @@ var (
 	/// (sum(buildbuddy_pebble_compression_ratio_count) - sum(buildbuddy_pebble_compression_ratio_bucket{le="1.0"})) / sum(buildbuddy_pebble_compression_ratio_count)
 	/// ```
 
+	Logs = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "logger",
+		Name:      "log_count",
+		Help:      "The number of logs",
+	}, []string{
+		StatusHumanReadableLabel,
+	})
+
 	/// ### Raft cache metrics
 
 	RaftRanges = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/server/util/log/BUILD
+++ b/server/util/log/BUILD
@@ -6,8 +6,10 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/log",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/metrics",
         "//server/util/log/gcp",
         "//server/util/status",
+        "@com_github_prometheus_client_golang//prometheus",
         "@com_github_rs_zerolog//:zerolog",
         "@com_github_rs_zerolog//log",
         "@org_golang_google_grpc//codes",

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -14,7 +14,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -210,27 +212,42 @@ func (l *Logger) Infof(format string, args ...interface{}) {
 // Warning logs to the WARNING log.
 func (l *Logger) Warning(message string) {
 	l.zl.Warn().Msg(message)
+	metrics.Logs.With(prometheus.Labels{
+		metrics.StatusHumanReadableLabel: "warning",
+	}).Inc()
 }
 
 // Warningf logs to the WARNING log. Arguments are handled in the manner of fmt.Printf.
 func (l *Logger) Warningf(format string, args ...interface{}) {
 	l.zl.Warn().Msgf(format, args...)
+	metrics.Logs.With(prometheus.Labels{
+		metrics.StatusHumanReadableLabel: "warning",
+	}).Inc()
 }
 
 // Error logs to the ERROR log.
 func (l *Logger) Error(message string) {
 	l.zl.Error().Msg(message)
+	metrics.Logs.With(prometheus.Labels{
+		metrics.StatusHumanReadableLabel: "error",
+	}).Inc()
 }
 
 // Errorf logs to the ERROR log. Arguments are handled in the manner of fmt.Printf.
 func (l *Logger) Errorf(format string, args ...interface{}) {
 	l.zl.Error().Msgf(format, args...)
+	metrics.Logs.With(prometheus.Labels{
+		metrics.StatusHumanReadableLabel: "error",
+	}).Inc()
 }
 
 // Fatal logs to the FATAL log. Arguments are handled in the manner of fmt.Print.
 // It calls os.Exit() with exit code 1.
 func (l *Logger) Fatal(message string) {
 	log.Fatal().Msg(message)
+	metrics.Logs.With(prometheus.Labels{
+		metrics.StatusHumanReadableLabel: "fatal",
+	}).Inc()
 	// Make sure fatal logs will exit.
 	os.Exit(1)
 }
@@ -239,6 +256,9 @@ func (l *Logger) Fatal(message string) {
 // It calls os.Exit() with exit code 1.
 func (l *Logger) Fatalf(format string, args ...interface{}) {
 	log.Fatal().Msgf(format, args...)
+	metrics.Logs.With(prometheus.Labels{
+		metrics.StatusHumanReadableLabel: "fatal",
+	}).Inc()
 	// Make sure fatal logs will exit.
 	os.Exit(1)
 }


### PR DESCRIPTION
Adding these so that for automatic releases the metric detection script can query whether the canary has an abnormally high number of warning/error logs. 
