### PR TITLE
CLI: fix commands like `bb info | grep bazel-bin`

### DIFF
--- a/cli/bazelisk/bazelisk.go
+++ b/cli/bazelisk/bazelisk.go
@@ -201,11 +201,23 @@ func setBazelVersion() error {
 	return setVersionErr
 }
 
+func isCLIVersion(version string) bool {
+	if strings.HasPrefix(version, "buildbuddy-io/") {
+		return true
+	}
+	// Bazelisk also allows hard-coding a path to the bb CLI as the "version",
+	// like /usr/local/bin/bb.
+	if strings.HasSuffix(version, "/bb") {
+		return true
+	}
+	return false
+}
+
 func setBazelVersionImpl() error {
 	// If USE_BAZEL_VERSION is already set and not pointing to us (the BB CLI),
 	// preserve that value.
 	envVersion := os.Getenv("USE_BAZEL_VERSION")
-	if envVersion != "" && !strings.HasPrefix(envVersion, "buildbuddy-io/") {
+	if envVersion != "" && !isCLIVersion(envVersion) {
 		return nil
 	}
 
@@ -223,7 +235,7 @@ func setBazelVersionImpl() error {
 	// If we appear first in .bazelversion, ignore that version to prevent
 	// bazelisk from invoking us recursively.
 	if IsInvokedByBazelisk() {
-		for len(parts) > 0 && strings.HasPrefix(parts[0], "buildbuddy-io/") {
+		for len(parts) > 0 && isCLIVersion(parts[0]) {
 			parts = parts[1:]
 		}
 	}

--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -25,7 +25,10 @@ func TestBazelVersion(t *testing.T) {
 	ws := testcli.NewWorkspace(t)
 	cmd := testcli.Command(t, ws, "version")
 
-	b, err := testcli.CombinedOutput(cmd)
+	// Note: this test makes sure that the version output appears in stdout
+	// (not stderr), so that tools can do things like `bb version | grep ...`
+	// the same way they can with vanilla bazel.
+	b, err := testcli.Output(cmd)
 	output := string(b)
 	require.NoError(t, err, "output: %s", string(b))
 

--- a/cli/testutil/testcli/testcli.go
+++ b/cli/testutil/testcli/testcli.go
@@ -52,6 +52,20 @@ func Command(t *testing.T, workspacePath string, args ...string) *exec.Cmd {
 	return cmd
 }
 
+// Output is like cmd.Output() except that it allows streaming CLI outputs for
+// debugging purposes.
+func Output(cmd *exec.Cmd) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	var w io.Writer = buf
+	if *streamOutputs {
+		w = io.MultiWriter(w, os.Stderr)
+		cmd.Stderr = os.Stderr
+	}
+	cmd.Stdout = w
+	err := cmd.Run()
+	return buf.Bytes(), err
+}
+
 // CombinedOutput is like cmd.CombinedOutput() except that it allows streaming
 // CLI outputs for debugging purposes.
 func CombinedOutput(cmd *exec.Cmd) ([]byte, error) {


### PR DESCRIPTION
This is another fix for GOPACKAGESDRIVER, which runs `bazel info` and tries to parse the output. It's currently broken because https://github.com/buildbuddy-io/buildbuddy/pull/3312 caused all bazel output to go to stderr.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
