### PR TITLE
Fix webdriver test

### DIFF
--- a/enterprise/server/test/webdriver/invocation/invocation_test.go
+++ b/enterprise/server/test/webdriver/invocation/invocation_test.go
@@ -56,7 +56,6 @@ func TestAuthenticatedInvocation_CacheEnabled(t *testing.T) {
 	cacheRequestsCard := wt.FindByDebugID("cache-results-table").Text()
 	assert.Contains(t, cacheRequestsCard, "Write")
 	assert.NotContains(t, cacheRequestsCard, "Hit")
-	wt.FindByDebugID("cache-results-table").Text()
 
 	// Second build of the same target
 	testbazel.Clean(context.Background(), t, workspacePath)

--- a/enterprise/server/test/webdriver/invocation/invocation_test.go
+++ b/enterprise/server/test/webdriver/invocation/invocation_test.go
@@ -51,10 +51,7 @@ func TestAuthenticatedInvocation_CacheEnabled(t *testing.T) {
 	// Make sure we can view the cache section
 	wt.FindByDebugID("cache-sections")
 	wt.FindByDebugID("filter-cache-requests").SendKeys("All")
-	cacheRequestsCard := wt.FindByDebugID("cache-results-table").Text()
-	assert.Contains(t, cacheRequestsCard, "Miss")
-	assert.Contains(t, cacheRequestsCard, "Write")
-	assert.NotContains(t, cacheRequestsCard, "Hit")
+	wt.FindByDebugID("cache-results-table").Text()
 
 	// Second build of the same target
 	testbazel.Clean(context.Background(), t, workspacePath)
@@ -73,7 +70,7 @@ func TestAuthenticatedInvocation_CacheEnabled(t *testing.T) {
 	// Cache section should contain a cache hit
 	wt.FindByDebugID("cache-sections")
 	wt.FindByDebugID("filter-cache-requests").SendKeys("All")
-	cacheRequestsCard = wt.FindByDebugID("cache-results-table").Text()
+	cacheRequestsCard := wt.FindByDebugID("cache-results-table").Text()
 	assert.Contains(t, cacheRequestsCard, "Hit")
 
 	// Make sure it shows up in repo history


### PR DESCRIPTION
For prod and dev targets, the builds may have cached data from previous runs
