### PR TITLE
use target label as the map key

### DIFF
--- a/proto/target.proto
+++ b/proto/target.proto
@@ -9,7 +9,8 @@ package target;
 message Target {
   // The id of this target.
   // For example: "TS12345".
-  string id = 1;
+  // DEPRECATED: Use repo_url and label to identify a target.
+  string id = 1 [deprecated = true];
 
   // The label of the target.
   // For example: "//server/test:foo"


### PR DESCRIPTION
Deprecate target.id. target_id=md5(repo_url, label). It was used
in mysql Target table as a primary key. But we don't need this key
in clickhouse.
