### PR TITLE
Add UI redirect for CLI login

### DIFF
--- a/app/components/banner/banner.css
+++ b/app/components/banner/banner.css
@@ -7,7 +7,7 @@
 }
 
 .banner.banner-info {
-  background: #e3f2fd;
+  background: #e1f5fe;
 }
 
 .banner.banner-success {
@@ -15,7 +15,7 @@
 }
 
 .banner.banner-warning {
-  background: #fffde7;
+  background: #fff3e0;
 }
 
 .banner.banner-error {

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -215,6 +215,10 @@ class Router {
 
   replaceParams(params: Record<string, string>) {
     const newUrl = getModifiedUrl({ query: params });
+    this.replaceURL(newUrl);
+  }
+
+  replaceURL(newUrl: string) {
     window.history.replaceState({ path: newUrl }, "", newUrl);
   }
 

--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -10,6 +10,7 @@ import router from "../../../app/router/router";
 import UserPreferences from "../../../app/preferences/preferences";
 import GitHubLink from "./github_link";
 import QuotaComponent from "../quota/quota";
+import Banner from "../../../app/components/banner/banner";
 
 export interface SettingsProps {
   user: User;
@@ -42,16 +43,20 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
     document.title = `Settings | BuildBuddy`;
 
     // Handle the redirect for CLI login.
-    if (this.isCLILogin()) {
+    if (this.isCLILoginPath()) {
       if (capabilities.config.userOwnedKeysEnabled && this.props.user?.selectedGroup?.userOwnedKeysEnabled) {
-        router.replaceURL("/settings/personal/api-keys");
+        router.replaceURL("/settings/personal/api-keys?cli-login=1");
       } else {
-        router.replaceURL("/settings/org/api-keys");
+        router.replaceURL("/settings/org/api-keys?cli-login=1");
       }
     }
   }
 
   private isCLILogin() {
+    return this.props.search.get("cli-login") === "1";
+  }
+
+  private isCLILoginPath() {
     return this.props.path === CLI_LOGIN_PATH || this.props.path === CLI_LOGIN_PATH + "/";
   }
 
@@ -81,7 +86,7 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
   }
 
   render() {
-    if (this.isCLILogin()) {
+    if (this.isCLILoginPath()) {
       return null;
     }
 
@@ -201,6 +206,22 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                       <div className="settings-option-description">
                         API keys grant access to your BuildBuddy organization.
                       </div>
+                      {this.isCLILogin() && (
+                        <>
+                          <div className="settings-option-description">
+                            <Banner type="info">
+                              {capabilities.config.userOwnedKeysEnabled && (
+                                <>
+                                  To log in as <b>{this.props.user.displayUser.email}</b>, an organization administrator
+                                  must enable user-owned API keys in Org details.{" "}
+                                </>
+                              )}
+                              To log in as the organization <b>{this.props.user.selectedGroupName()}</b>, copy one of
+                              the keys below and paste it back into the login prompt.
+                            </Banner>
+                          </div>
+                        </>
+                      )}
                       <ApiKeysComponent user={this.props.user} />
                     </>
                   )}
@@ -213,6 +234,13 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                           Personal API keys let you run builds within your organization that are authenticated as your
                           user account.
                         </div>
+                        {this.isCLILogin() && (
+                          <div className="settings-option-description">
+                            <Banner type="info">
+                              To login, copy one of the API keys below and paste it back into the login prompt.
+                            </Banner>
+                          </div>
+                        )}
                         <ApiKeysComponent user={this.props.user} userOwnedOnly />
                       </>
                     )}

--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -31,6 +31,8 @@ enum TabId {
 
 const TAB_IDS = new Set<string>(Object.values(TabId));
 
+const CLI_LOGIN_PATH = "/settings/cli-login";
+
 function isTabId(id: string): id is TabId {
   return TAB_IDS.has(id);
 }
@@ -38,6 +40,19 @@ function isTabId(id: string): id is TabId {
 export default class SettingsComponent extends React.Component<SettingsProps> {
   componentWillMount() {
     document.title = `Settings | BuildBuddy`;
+
+    // Handle the redirect for CLI login.
+    if (this.isCLILogin()) {
+      if (capabilities.config.userOwnedKeysEnabled && this.props.user?.selectedGroup?.userOwnedKeysEnabled) {
+        router.replaceURL("/settings/personal/api-keys");
+      } else {
+        router.replaceURL("/settings/org/api-keys");
+      }
+    }
+  }
+
+  private isCLILogin() {
+    return this.props.path === CLI_LOGIN_PATH || this.props.path === CLI_LOGIN_PATH + "/";
   }
 
   private getDefaultTabId(): TabId {
@@ -66,6 +81,10 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
   }
 
   render() {
+    if (this.isCLILogin()) {
+      return null;
+    }
+
     const activeTabId = this.getActiveTabId();
 
     return (


### PR DESCRIPTION
Add a supported URL `/settings/cli-login` that redirects to `/settings/personal/api-keys` if user-owned keys are supported, else `/settings/org/api-keys`.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
