### PR TITLE
CLI: improve login command

### DIFF
--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -74,8 +74,10 @@ func run() (exitCode int, err error) {
 	if err != nil || exitCode >= 0 {
 		return exitCode, err
 	}
-	// TODO: Convert this to (exitCode, err) convention
-	args = login.HandleLogin(args)
+	exitCode, err = login.HandleLogin(args)
+	if err != nil || exitCode >= 0 {
+		return exitCode, err
+	}
 
 	// If none of the CLI subcommand handlers were triggered, assume we have a
 	// bazel invocation.
@@ -124,7 +126,10 @@ func run() (exitCode int, err error) {
 	// Fiddle with Bazel args
 	// TODO(bduffany): model these as "built-in" plugins
 	args = tooltag.ConfigureToolTag(args)
-	args = login.ConfigureAPIKey(args)
+	args, err = login.ConfigureAPIKey(args)
+	if err != nil {
+		return -1, err
+	}
 
 	// Prepare convenience env vars for plugins
 	if err := plugin.PrepareEnv(); err != nil {

--- a/cli/login/BUILD
+++ b/cli/login/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//cli/arg",
         "//cli/log",
+        "//cli/parser",
         "//cli/storage",
     ],
 )

--- a/cli/storage/BUILD
+++ b/cli/storage/BUILD
@@ -5,4 +5,5 @@ go_library(
     srcs = ["storage.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/storage",
     visibility = ["//visibility:public"],
+    deps = ["//cli/workspace"],
 )


### PR DESCRIPTION
* Use the new `/settings/cli-login` route (which redirects to the user-level keys page if enabled, else org API keys) instead of `/settings/org/api-keys`
* Automatically open the URL in the browser
* Store the config in `.git/config`, under `buildbuddy.api-key`, so that the API key is repo-specific.

---

**Version bump**: Patch
