### PR TITLE
Allow visually debugging webdriver tests locally

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -128,6 +128,15 @@ build --enable_runfiles
 test --test_tag_filters=-docker
 build --build_tag_filters=-docker
 
+# Run Webdriver tests with --config=webdriver-debug to debug webdriver tests locally.
+# See server/testutil/webtester/webtester.go for more details.
+test:webdriver-debug --test_arg=-webdriver_debug
+# Forward X server display for local webdriver tests.
+test:webdriver-debug --test_env=DISPLAY
+# When debugging, only run one webdriver test at a time (it's overwhelming
+# otherwise), and display verbose webdriver output in the terminal.
+test:webdriver-debug --test_output=streamed
+
 # Try importing a user specific .bazelrc
 # You can create your own by copying and editing the template-user.bazelrc template:
 # cp template-user.bazelrc user.bazelrc

--- a/deps.bzl
+++ b/deps.bzl
@@ -320,8 +320,8 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "com_github_bazelbuild_rules_webtesting",
         importpath = "github.com/bazelbuild/rules_webtesting",
-        sum = "h1:nhqjA2IslEOLViRBF5djQCiOD//7VyyHNKrqAZ1AuYA=",
-        version = "v0.2.0",
+        sum = "h1:zmBkl2nxjRojoW9PtGVEtW/91kHieotlD7cL9vFq06c=",
+        version = "v0.0.0-20210910170740-6b2ef24cfe95",
     )
     go_repository(
         name = "com_github_bduffany_godemon",

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go v1.43.9
 	github.com/bazelbuild/bazelisk v1.11.0
 	github.com/bazelbuild/rules_go v0.29.0
-	github.com/bazelbuild/rules_webtesting v0.2.0
+	github.com/bazelbuild/rules_webtesting v0.0.0-20210910170740-6b2ef24cfe95
 	github.com/bduffany/godemon v0.0.0-20221115232931-09721d48e30e
 	github.com/bojand/ghz v0.110.0
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/bazelbuild/bazelisk v1.11.0 h1:dmESc1UeF8iqJTOPxlPw2DH9ykZEMwdlL/jQ+U
 github.com/bazelbuild/bazelisk v1.11.0/go.mod h1:3zOen/lU/rEGgghOIkqfpO2+PhRXvZyMCA9iqFJ2c9Q=
 github.com/bazelbuild/rules_go v0.29.0 h1:SfxjyO/V68rVnzOHop92fB0gv/Aa75KNLAN0PMqXbIw=
 github.com/bazelbuild/rules_go v0.29.0/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=
-github.com/bazelbuild/rules_webtesting v0.2.0 h1:nhqjA2IslEOLViRBF5djQCiOD//7VyyHNKrqAZ1AuYA=
-github.com/bazelbuild/rules_webtesting v0.2.0/go.mod h1:M+vCvqp/1BViNuVL630BoiGqld9Q1vQzvf9bN/dWTeg=
+github.com/bazelbuild/rules_webtesting v0.0.0-20210910170740-6b2ef24cfe95 h1:zmBkl2nxjRojoW9PtGVEtW/91kHieotlD7cL9vFq06c=
+github.com/bazelbuild/rules_webtesting v0.0.0-20210910170740-6b2ef24cfe95/go.mod h1:M+vCvqp/1BViNuVL630BoiGqld9Q1vQzvf9bN/dWTeg=
 github.com/bduffany/godemon v0.0.0-20221115232931-09721d48e30e h1:Th4pNly+xoH2szOq4aA+uAFmg5h37BCyq3pFqnZGJ70=
 github.com/bduffany/godemon v0.0.0-20221115232931-09721d48e30e/go.mod h1:led5f4NrGeXrUKOlQA36mgNtNs7gVo86eZUOX42q5+8=
 github.com/bduffany/redsync/v4 v4.4.1-minimal h1:wyBDr+ApDWybbLGMSsepl30KzPAl+HlIQMhJSoLdRKg=


### PR DESCRIPTION
When running bazel tests with `--config=webdriver-debug`, tests will now spawn the GUI for chrome (instead of running in `--headless` mode), so you can see what the test is doing.

If the test fails, the browser window will stay open for 3s so you can see what state the app is in when the failure happened. This duration can be extended further so you can go in and check devtools etc., by setting `--test_arg=-webdriver_end_of_test_delay=1h` (this is super rudimentary for now; there is probably a better way to do this).

Also when running under this debug config, pass `--verbose` to chromedriver, so that if chrome crashes on startup, the root cause will be logged (by default, it logs a super opaque error just saying that chrome has crashed).

Tangentially related: this PR also updates the Go repo version for `rules_webtesting` to match the `http_archive` version in /WORKSPACE (the Go repo was behind the WORKSPACE repo due to https://github.com/bazelbuild/rules_webtesting/issues/452)

https://user-images.githubusercontent.com/2414826/216427609-9259ac88-e183-4eb5-a74a-fab2dbe84be3.mp4

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
