### PR TITLE
Persist the user-owned keys setting

### DIFF
--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -424,7 +424,8 @@ func (d *UserDB) InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (stri
 				name = ?,
 				url_identifier = ?,
 				owned_domain = ?,
-				sharing_enabled = ?, 
+				sharing_enabled = ?,
+				user_owned_keys_enabled = ?,
 				use_group_owned_executors = ?,
 				suggestion_preference = ?
 			WHERE group_id = ?`,
@@ -432,6 +433,7 @@ func (d *UserDB) InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (stri
 			g.URLIdentifier,
 			g.OwnedDomain,
 			g.SharingEnabled,
+			g.UserOwnedKeysEnabled,
 			g.UseGroupOwnedExecutors,
 			g.SuggestionPreference,
 			g.GroupID)
@@ -796,6 +798,7 @@ func (d *UserDB) GetUser(ctx context.Context) (*tables.User, error) {
 				g.owned_domain,
 				g.github_token,
 				g.sharing_enabled,
+				g.user_owned_keys_enabled,
 				g.use_group_owned_executors,
 				g.saml_idp_metadata_url,
 				g.suggestion_preference,
@@ -821,6 +824,7 @@ func (d *UserDB) GetUser(ctx context.Context) (*tables.User, error) {
 				&gr.Group.OwnedDomain,
 				&gr.Group.GithubToken,
 				&gr.Group.SharingEnabled,
+				&gr.Group.UserOwnedKeysEnabled,
 				&gr.Group.UseGroupOwnedExecutors,
 				&gr.Group.SamlIdpMetadataUrl,
 				&gr.Group.SuggestionPreference,

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -199,6 +199,7 @@ func makeGroups(groupRoles []*tables.GroupRole) []*grpb.Group {
 			GithubLinked:           githubToken != "",
 			UrlIdentifier:          urlIdentifier,
 			SharingEnabled:         g.SharingEnabled,
+			UserOwnedKeysEnabled:   g.UserOwnedKeysEnabled,
 			UseGroupOwnedExecutors: g.UseGroupOwnedExecutors != nil && *g.UseGroupOwnedExecutors,
 			SuggestionPreference:   g.SuggestionPreference,
 		})
@@ -357,6 +358,7 @@ func (s *BuildBuddyServer) CreateGroup(ctx context.Context, req *grpb.CreateGrou
 		Name:                   groupName,
 		OwnedDomain:            groupOwnedDomain,
 		SharingEnabled:         req.GetSharingEnabled(),
+		UserOwnedKeysEnabled:   req.GetUserOwnedKeysEnabled(),
 		UseGroupOwnedExecutors: &useGroupOwnedExecutors,
 	}
 	urlIdentifier := strings.TrimSpace(req.GetUrlIdentifier())
@@ -421,6 +423,7 @@ func (s *BuildBuddyServer) UpdateGroup(ctx context.Context, req *grpb.UpdateGrou
 	}
 	group.SharingEnabled = req.GetSharingEnabled()
 	useGroupOwnedExecutors := req.GetUseGroupOwnedExecutors()
+	group.UserOwnedKeysEnabled = req.GetUserOwnedKeysEnabled()
 	group.UseGroupOwnedExecutors = &useGroupOwnedExecutors
 	group.SuggestionPreference = req.GetSuggestionPreference()
 	if group.SuggestionPreference == grpb.SuggestionPreference_UNKNOWN_SUGGESTION_PREFERENCE {


### PR DESCRIPTION
Persist the setting when creating or updating a group, and return the setting back to the UI.

Has no effect yet, since `--app.user_owned_keys_enabled` is not set to `true` anywhere, and this determines whether we show the setting in the UI, and the API (as of this PR) does not support creating user-level keys yet.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
