### PR TITLE
Refactor user-owned keys API with user-specific endpoints

### DIFF
--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -161,7 +161,7 @@ function getRpcMethodNames(serviceClass: Function) {
 
 type Rpc<Request, Response> = (request: Request) => Promise<Response>;
 
-type CancelableRpc<Request, Response> = (request: Request) => CancelablePromise<Response>;
+export type CancelableRpc<Request, Response> = (request: Request) => CancelablePromise<Response>;
 
 type RpcMethodNames<Service> = keyof Omit<Service, keyof protobufjs.rpc.Service>;
 

--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { User } from "../../../app/auth/auth_service";
+import rpc_service from "../../../app/service/rpc_service";
 import capabilities from "../../../app/capabilities/capabilities";
 import FilledButton from "../../../app/components/button/button";
 import ApiKeysComponent from "../api_keys/api_keys";
@@ -222,7 +223,13 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                           </div>
                         </>
                       )}
-                      <ApiKeysComponent user={this.props.user} />
+                      <ApiKeysComponent
+                        user={this.props.user}
+                        get={rpc_service.service.getApiKeys}
+                        create={rpc_service.service.createApiKey}
+                        update={rpc_service.service.updateApiKey}
+                        delete={rpc_service.service.deleteApiKey}
+                      />
                     </>
                   )}
                   {activeTabId === TabId.PersonalApiKeys &&
@@ -241,7 +248,14 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                             </Banner>
                           </div>
                         )}
-                        <ApiKeysComponent user={this.props.user} userOwnedOnly />
+                        <ApiKeysComponent
+                          user={this.props.user}
+                          userOwnedOnly
+                          get={rpc_service.service.getUserApiKeys}
+                          create={rpc_service.service.createUserApiKey}
+                          update={rpc_service.service.updateUserApiKey}
+                          delete={rpc_service.service.deleteUserApiKey}
+                        />
                       </>
                     )}
                   {activeTabId === TabId.OrgSecrets && capabilities.config.secretsEnabled && (

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -227,6 +227,14 @@ func (d *UserDB) CreateAPIKey(ctx context.Context, groupID string, label string,
 	return createAPIKey(d.h.DB(ctx), groupID, newAPIKeyToken(), label, caps, visibleToDevelopers)
 }
 
+func (d *UserDB) GetUserAPIKeys(ctx context.Context, groupID string) ([]*tables.APIKey, error) {
+	return nil, status.UnimplementedError("Not implemented")
+}
+
+func (d *UserDB) CreateUserAPIKey(ctx context.Context, groupID, label string) (*tables.APIKey, error) {
+	return nil, status.UnimplementedError("Not implemented")
+}
+
 func createAPIKey(db *db.DB, groupID, value, label string, caps []akpb.ApiKey_Capability, visibleToDevelopers bool) (*tables.APIKey, error) {
 	pk, err := tables.PrimaryKeyForTable("APIKeys")
 	if err != nil {

--- a/proto/api_key.proto
+++ b/proto/api_key.proto
@@ -57,11 +57,6 @@ message CreateApiKeyRequest {
 
   // True if this API key should be visible to developers.
   bool visible_to_developers = 5;
-
-  // The ID of the user to create the API key for.
-  // Only applicable to user-level API keys.
-  // ex: "US123456789"
-  string user_id = 6;
 }
 
 message CreateApiKeyResponse {
@@ -77,10 +72,6 @@ message GetApiKeysRequest {
   // The ID of the group to get API keys for.
   // ex: "GR123456789"
   string group_id = 2;
-
-  // The ID of the user to get API keys for.
-  // ex: "US123456789"
-  string user_id = 3;
 }
 
 message GetApiKeysResponse {

--- a/proto/buildbuddy_service.proto
+++ b/proto/buildbuddy_service.proto
@@ -70,7 +70,7 @@ service BuildBuddyService {
   rpc CreateGroup(grp.CreateGroupRequest) returns (grp.CreateGroupResponse);
   rpc UpdateGroup(grp.UpdateGroupRequest) returns (grp.UpdateGroupResponse);
 
-  // API Keys API
+  // Org API Keys API
   rpc GetApiKeys(api_key.GetApiKeysRequest)
       returns (api_key.GetApiKeysResponse);
   rpc CreateApiKey(api_key.CreateApiKeyRequest)
@@ -78,6 +78,16 @@ service BuildBuddyService {
   rpc UpdateApiKey(api_key.UpdateApiKeyRequest)
       returns (api_key.UpdateApiKeyResponse);
   rpc DeleteApiKey(api_key.DeleteApiKeyRequest)
+      returns (api_key.DeleteApiKeyResponse);
+
+  // User API keys API
+  rpc GetUserApiKeys(api_key.GetApiKeysRequest)
+      returns (api_key.GetApiKeysResponse);
+  rpc CreateUserApiKey(api_key.CreateApiKeyRequest)
+      returns (api_key.CreateApiKeyResponse);
+  rpc UpdateUserApiKey(api_key.UpdateApiKeyRequest)
+      returns (api_key.UpdateApiKeyResponse);
+  rpc DeleteUserApiKey(api_key.DeleteApiKeyRequest)
       returns (api_key.DeleteApiKeyResponse);
 
   // Execution API

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -565,6 +565,22 @@ func (s *BuildBuddyServer) DeleteApiKey(ctx context.Context, req *akpb.DeleteApi
 	return &akpb.DeleteApiKeyResponse{}, nil
 }
 
+func (s *BuildBuddyServer) GetUserApiKeys(ctx context.Context, req *akpb.GetApiKeysRequest) (*akpb.GetApiKeysResponse, error) {
+	return nil, status.UnimplementedErrorf("Not implemented")
+}
+
+func (s *BuildBuddyServer) CreateUserApiKey(ctx context.Context, req *akpb.CreateApiKeyRequest) (*akpb.CreateApiKeyResponse, error) {
+	return nil, status.UnimplementedErrorf("Not implemented")
+}
+
+func (s *BuildBuddyServer) UpdateUserApiKey(ctx context.Context, req *akpb.UpdateApiKeyRequest) (*akpb.UpdateApiKeyResponse, error) {
+	return nil, status.UnimplementedErrorf("Not implemented")
+}
+
+func (s *BuildBuddyServer) DeleteUserApiKey(ctx context.Context, req *akpb.DeleteApiKeyRequest) (*akpb.DeleteApiKeyResponse, error) {
+	return nil, status.UnimplementedErrorf("Not implemented")
+}
+
 func selectedGroup(preferredGroupID string, groupRoles []*tables.GroupRole) *tables.GroupRole {
 	if preferredGroupID != "" {
 		for _, gr := range groupRoles {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -345,13 +345,6 @@ type UserDB interface {
 	UpdateGroupUsers(ctx context.Context, groupID string, updates []*grpb.UpdateGroupUsersRequest_Update) error
 	DeleteGroupGitHubToken(ctx context.Context, groupID string) error
 
-	// API Keys API
-	GetAPIKey(ctx context.Context, apiKeyID string) (*tables.APIKey, error)
-
-	// GetAPIKeys returns group-level API keys that the user is authorized to
-	// access.
-	GetAPIKeys(ctx context.Context, groupID string) ([]*tables.APIKey, error)
-
 	// GetAPIKeyForInternalUseOnly returns any API key for the group. It is only
 	// to be used in situations where the user has a pre-authorized grant to
 	// access resources on behalf of the org, such as a publicly shared
@@ -359,11 +352,42 @@ type UserDB interface {
 	// resources and must not be returned to the caller.
 	GetAPIKeyForInternalUseOnly(ctx context.Context, groupID string) (*tables.APIKey, error)
 
+	// API Keys API.
+	//
+	// All of these functions authenticate the user if applicable and
+	// authorize access to the relevant user IDs, group IDs, and API keys,
+	// taking the group role into account.
+	//
+	// Any operations involving user-level keys return an error if user-level
+	// keys are not enabled by the org.
+
+	// GetAPIKeys returns group-level API keys that the user is authorized to
+	// access.
+	GetAPIKeys(ctx context.Context, groupID string) ([]*tables.APIKey, error)
+
+	// CreateAPIKey creates a group-level API key.
 	CreateAPIKey(ctx context.Context, groupID string, label string, capabilities []akpb.ApiKey_Capability, visibleToDevelopers bool) (*tables.APIKey, error)
+
+	// GetUserAPIKeys returns all user-owned API keys within a group.
+	GetUserAPIKeys(ctx context.Context, groupID string) ([]*tables.APIKey, error)
+
+	// CreateUserAPIKey creates a user-owned API key within the group.
+	CreateUserAPIKey(ctx context.Context, groupID, label string) (*tables.APIKey, error)
+
+	// GetAPIKey returns an API key by ID. The key may be user-owned or
+	// group-owned.
+	GetAPIKey(ctx context.Context, apiKeyID string) (*tables.APIKey, error)
+
+	// UpdateAPIKey updates an API key by ID. The key may be user-owned or
+	// group-owned.
 	UpdateAPIKey(ctx context.Context, key *tables.APIKey) error
+
+	// DeleteAPIKey deletes an API key by ID. The key may be user-owned or
+	// group-owned.
 	DeleteAPIKey(ctx context.Context, apiKeyID string) error
 
-	// To support secrets API
+	// Secrets API
+
 	GetOrCreatePublicKey(ctx context.Context, groupID string) (string, error)
 }
 

--- a/server/role_filter/role_filter.go
+++ b/server/role_filter/role_filter.go
@@ -67,8 +67,14 @@ var (
 		"DeleteInvocation",
 		"CancelExecutions",
 		"ExecuteWorkflow",
-		// Setup
+		// Org API keys (implementation only returns developer-visible keys
+		// for developers; admins can see all keys).
 		"GetApiKeys",
+		// User-level API keys
+		"GetUserApiKeys",
+		"CreateUserApiKey",
+		"UpdateUserApiKey",
+		"DeleteUserApiKey",
 		// Remote Bazel
 		"Run",
 	}
@@ -82,7 +88,7 @@ var (
 		"UpdateGroupUsers",
 		// Org GitHub account link management
 		"UnlinkGitHubAccount",
-		// API key management
+		// Org API key management
 		"CreateApiKey",
 		"UpdateApiKey",
 		"DeleteApiKey",


### PR DESCRIPTION
* Add separate RPCs (and stub impls) for user-level API keys. The Request/Response protos are exactly the same as the corresponding group-level RPCs.
* Remove `user_id` field that was added previously, since the user API keys API will always use the authenticated user ID.
* Add 2 new UserDB methods (and stub impls): GetUserAPIKeys and CreateUserAPIKey. These operations are scoped to the authenticated user ID.
* Keep Update/Delete DB methods the same, since those operate in API key ID scope, rather than user/group scope. We use generic `perms`/`role`-based auth for those, so the logic will be exactly the same for user-owned and group-owned keys.
* Add docs to all API keys methods of UserDB.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
