### PR TITLE
Support min, max, and active version for clarity and better rollback support

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -164,7 +164,8 @@ type PebbleCache struct {
 	atimeBufferSize      int
 	minEvictionAge       time.Duration
 
-	lastDBVersion filestore.PebbleKeyVersion
+	minDBVersion filestore.PebbleKeyVersion
+	maxDBVersion filestore.PebbleKeyVersion
 
 	env    environment.Env
 	db     *pebble.DB
@@ -364,7 +365,7 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 	if err != nil {
 		return nil, err
 	}
-	pc.lastDBVersion = filestore.PebbleKeyVersion(versionMetadata.GetVersion())
+	pc.minDBVersion, pc.maxDBVersion = filestore.PebbleKeyVersion(versionMetadata.GetMinVersion()), filestore.PebbleKeyVersion(versionMetadata.GetMaxVersion())
 
 	peMu := sync.Mutex{}
 	eg := errgroup.Group{}
@@ -445,21 +446,28 @@ func (p *PebbleCache) databaseVersionMetadata() (*rfpb.VersionMetadata, error) {
 	return versionMetadata, nil
 }
 
-// currentDatabaseVersion returns the currently stored filestore.PebbleKeyVersion.
+// minDatabaseVersion returns the currently stored filestore.PebbleKeyVersion.
 // It is safe to call this function in a loop -- the underlying metadata will
-// only be fetched a max of once per second.
-func (p *PebbleCache) currentDatabaseVersion() filestore.PebbleKeyVersion {
+// only be fetched on cache startup and when updated.
+func (p *PebbleCache) minDatabaseVersion() filestore.PebbleKeyVersion {
 	unlockFn := p.locker.RLock(string(p.databaseVersionKey()))
 	defer unlockFn()
-	return p.lastDBVersion
+	return p.minDBVersion
+}
+
+func (p *PebbleCache) maxDatabaseVersion() filestore.PebbleKeyVersion {
+	unlockFn := p.locker.RLock(string(p.databaseVersionKey()))
+	defer unlockFn()
+	return p.maxDBVersion
 }
 
 func (p *PebbleCache) activeDatabaseVersion() filestore.PebbleKeyVersion {
 	return filestore.PebbleKeyVersion(*activeKeyVersion)
 }
 
-// updateDatabaseVersion updates the database version to newVersion.
-func (p *PebbleCache) updateDatabaseVersion(newVersion filestore.PebbleKeyVersion) error {
+// updateDatabaseVersion updates the min and max versions of the database.
+// Both the stored metadata and instance variables are updated.
+func (p *PebbleCache) updateDatabaseVersions(minVersion, maxVersion filestore.PebbleKeyVersion) error {
 	versionKey := p.databaseVersionKey()
 	unlockFn := p.locker.Lock(string(versionKey))
 	defer unlockFn()
@@ -470,7 +478,8 @@ func (p *PebbleCache) updateDatabaseVersion(newVersion filestore.PebbleKeyVersio
 	}
 
 	newVersionMetadata := proto.Clone(oldVersionMetadata).(*rfpb.VersionMetadata)
-	newVersionMetadata.Version = int64(newVersion)
+	newVersionMetadata.MinVersion = int64(minVersion)
+	newVersionMetadata.MaxVersion = int64(maxVersion)
 	newVersionMetadata.LastModifyUsec = time.Now().UnixMicro()
 
 	buf, err := proto.Marshal(newVersionMetadata)
@@ -487,7 +496,8 @@ func (p *PebbleCache) updateDatabaseVersion(newVersion filestore.PebbleKeyVersio
 		return err
 	}
 
-	p.lastDBVersion = newVersion
+	p.minDBVersion = minVersion
+	p.maxDBVersion = maxVersion
 
 	log.Printf("Pebble Cache: db version changed from %+v to %+v", oldVersionMetadata, newVersionMetadata)
 	return nil
@@ -843,7 +853,7 @@ func (p *PebbleCache) Statusz(ctx context.Context) string {
 		totalCASCount += casCount
 		totalACCount += acCount
 	}
-	buf += fmt.Sprintf("Stored data version: %d, new writes version: %d\n", p.currentDatabaseVersion(), p.activeDatabaseVersion())
+	buf += fmt.Sprintf("Min DB version: %d, Max DB version: %d, Active version: %d\n", p.minDatabaseVersion(), p.maxDatabaseVersion(), p.activeDatabaseVersion())
 	buf += fmt.Sprintf("[All Partitions] Total Size: %d bytes\n", totalSizeBytes)
 	buf += fmt.Sprintf("[All Partitions] CAS total: %d items\n", totalCASCount)
 	buf += fmt.Sprintf("[All Partitions] AC total: %d items\n", totalACCount)
@@ -903,7 +913,7 @@ func (p *PebbleCache) blobDir(partID string) string {
 func (p *PebbleCache) lookupFileMetadataAndVersion(ctx context.Context, iter *pebble.Iterator, key filestore.PebbleKey) (*rfpb.FileMetadata, filestore.PebbleKeyVersion, error) {
 	fileMetadata := &rfpb.FileMetadata{}
 	var lastErr error
-	for version := p.activeDatabaseVersion(); version >= p.currentDatabaseVersion(); version-- {
+	for version := p.maxDatabaseVersion(); version >= p.minDatabaseVersion(); version-- {
 		keyBytes, err := key.Bytes(version)
 		if err != nil {
 			return nil, -1, err
@@ -924,7 +934,7 @@ func (p *PebbleCache) lookupFileMetadata(ctx context.Context, iter *pebble.Itera
 // iterHasKey returns a bool indicating if the provided iterator has the
 // exact key specified.
 func (p *PebbleCache) iterHasKey(iter *pebble.Iterator, key filestore.PebbleKey) (bool, error) {
-	for version := p.activeDatabaseVersion(); version >= p.currentDatabaseVersion(); version-- {
+	for version := p.maxDatabaseVersion(); version >= p.minDatabaseVersion(); version-- {
 		keyBytes, err := key.Bytes(version)
 		if err != nil {
 			return false, err
@@ -1594,7 +1604,7 @@ type partitionEvictor struct {
 }
 
 type versionGetter interface {
-	currentDatabaseVersion() filestore.PebbleKeyVersion
+	minDatabaseVersion() filestore.PebbleKeyVersion
 }
 
 func newPartitionEvictor(part disk.Partition, fileStorer filestore.Store, blobDir string, dbg pebbleutil.Leaser, locker lockmap.Locker, vg versionGetter, accesses chan<- *accessTimeUpdate, atimeBufferSize int, minEvictionAge time.Duration, cacheName string) (*partitionEvictor, error) {
@@ -1835,7 +1845,7 @@ func (e *partitionEvictor) Statusz(ctx context.Context) string {
 var digestChars = []byte("abcdef1234567890")
 
 func (e *partitionEvictor) randomKey(digestLength int) ([]byte, error) {
-	version := e.versionGetter.currentDatabaseVersion()
+	version := e.versionGetter.minDatabaseVersion()
 	buf := bytes.NewBuffer(make([]byte, 0, digestLength))
 	for i := 0; i < digestLength; i++ {
 		buf.WriteByte(digestChars[e.rng.Intn(len(digestChars))])

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -88,9 +88,15 @@ message PartitionMetadatas {
   repeated PartitionMetadata metadata = 1;
 }
 
+// Next tag: 4
 message VersionMetadata {
   // The int64 representation of a PebbleKeyVersion.
-  int64 version = 1;
+  // This is the minimum version of data stored in the DB.
+  int64 min_version = 1;
+
+  // The int64 representation of a PebbleKeyVersion.
+  // This is the maximum version of data stored in the DB.
+  int64 max_version = 3;
 
   // The time when the version was last changed.
   int64 last_modify_usec = 2;


### PR DESCRIPTION
Adds a max database version, also tracked in metadata, in case we roll back the active version.