### PR TITLE
Auth support for user-level keys

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -726,6 +726,7 @@ func userClaims(u *tables.User, effectiveGroup string) *Claims {
 
 func APIKeyGroupClaims(akg interfaces.APIKeyGroup) *Claims {
 	return &Claims{
+		UserID:        akg.GetUserID(),
 		GroupID:       akg.GetGroupID(),
 		AllowedGroups: []string{akg.GetGroupID()},
 		// For now, API keys are assigned the default role.

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -301,6 +301,7 @@ type InvocationDB interface {
 
 type APIKeyGroup interface {
 	GetCapabilities() int32
+	GetUserID() string
 	GetGroupID() string
 	GetUseGroupOwnedExecutors() bool
 }


### PR DESCRIPTION
* Fill `user_id` field in authenticated `APIKeyGroup`, so that we can tell internally whether a key is user-owned if desired.
* Fill the `user_owned_keys_enabled` field in the authenticated user's group roles.
* Disable authentication with user-owned keys when the setting is disabled via org settings.

Note, this is tested in userdb_test in https://github.com/buildbuddy-io/buildbuddy/pull/3280. The existing functionality for group-level keys is also tested in existing integration tests which use enterprise_testauth (remote_execution_test, workflow service test, etc.)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
