### PR TITLE
CLI: Fix empty args when API key is not found in `.git/config`

### DIFF
--- a/cli/login/login.go
+++ b/cli/login/login.go
@@ -78,7 +78,7 @@ func ConfigureAPIKey(args []string) ([]string, error) {
 		// Making this fatal would be inconvenient for new workspaces,
 		// so just log a debug message and move on.
 		log.Debugf("failed to configure API key from .git/config: %s", err)
-		return nil, nil
+		return args, nil
 	}
 
 	return append(args, "--"+apiKeyHeader+"="+strings.TrimSpace(apiKey)), nil


### PR DESCRIPTION
Note, this is not related to https://github.com/buildbuddy-io/buildbuddy-internal/issues/2022, just coincidental.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
