### PR TITLE
Explicitly return exit code 0 in dev QA script

### DIFF
--- a/tools/dev_qa.sh
+++ b/tools/dev_qa.sh
@@ -164,3 +164,5 @@ echo "- Abseil (C++) build:     https://app.buildbuddy.dev/invocation/$abseil_ii
 echo "- Bazel (Java) build:     https://app.buildbuddy.dev/invocation/$bazel_iid"
 echo "- Python build:     https://app.buildbuddy.dev/invocation/$python_iid"
 (( loadtest )) && echo "- Tensorflow build:  https://app.buildbuddy.dev/invocation/$tensorflow_iid"
+
+exit 0


### PR DESCRIPTION
If the loadtest flag was not set, previously this script was returning exit code 1 incorrectly
