### PR TITLE
remove logging when start_time_usec is not set

### DIFF
--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -315,8 +315,6 @@ func (t *TargetTracker) writeTestTargetStatusesToOLAPDB(ctx context.Context, per
 		testStartTimeUsec := int64(0)
 		if !target.firstStartTime.IsZero() {
 			testStartTimeUsec = target.firstStartTime.UnixMicro()
-		} else {
-			log.CtxWarningf(ctx, "target %q start time is not set", target.label)
 		}
 
 		entries = append(entries, &schema.TestTargetStatus{


### PR DESCRIPTION
start_time_usec is not set when the test is timeout or cancelled. 