### PR TITLE
Improve error handling for GitHub status reporter

### DIFF
--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -136,7 +136,10 @@ func (r *BuildStatusReporter) flushPayloadsIfWorkspaceLoaded(ctx context.Context
 			break
 		}
 		commitSHA := r.buildEventAccumulator.CommitSHA()
-		r.githubClient.CreateStatus(ctx, ownerRepo, commitSHA, r.appendStatusNameSuffix(payload))
+		err = r.githubClient.CreateStatus(ctx, ownerRepo, commitSHA, r.appendStatusNameSuffix(payload))
+		if err != nil {
+			log.Warningf("Failed to report GitHub status: %s", err)
+		}
 	}
 
 	r.payloads = make([]*github.GithubStatusPayload, 0)


### PR DESCRIPTION
This PR is intended to help diagnose an issue where we are failing to report some statuses to GitHub, leaving certain workflow checks in a "pending" state.

* Log a warning if we fail to marshal the status payload (should never happen).
* Log a warning if we fail to create an HTTP request (should never happen).
* If GitHub returns an HTTP error (status >= 400), the HTTP client `.Do()` func treats the request as successful. Explicitly check the status code and log a warning if GitHub doesn't return a success code for whatever reason.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
