### PR TITLE
Increase minimum ext4 fs size from 220k to 225k

### DIFF
--- a/enterprise/server/util/ext4/ext4.go
+++ b/enterprise/server/util/ext4/ext4.go
@@ -18,7 +18,7 @@ const (
 	// MinDiskImageSizeBytes is the approximate minimum size needed for an ext4
 	// image. The functions in this package which create disk images will fail
 	// if the provided size is any smaller.
-	MinDiskImageSizeBytes = 220e3
+	MinDiskImageSizeBytes = 225e3
 )
 
 // DirectoryToImage creates an ext4 image of the specified size from inputDir


### PR DESCRIPTION
On recent versions of Ubuntu (22.04+ on my machine and Tyler's new machine) builds with firecracker remote execution fail with errors like this:
```
2023/02/14 19:37:16.727 ERR Error running "/sbin/mke2fs -L  -N 0 -O ^64bit -m 5 -r 1 -t ext4 /tmp/iain_remote_build/fc-container-3506787005/workspacefs.ext4 220K": exit status 1 mke2fs 1.46.5 (30-Dec-2021)
Creating regular file /tmp/iain_remote_build/fc-container-3506787005/workspacefs.ext4
/tmp/iain_remote_build/fc-container-3506787005/workspacefs.ext4: Not enough space to build proposed filesystem while setting up superblock
```

This is because the minimum disk size we provide for constructing an empty ext4 filesystem for the executor is too small to hold an empty filesystem. I'm guessing this minimum size increased with a newer version of the filesystem that's included in 22.04 and later (possibly earlier as well), which is why this didn't affect Tyler's old machine and doesn't affect prod. Adding 5kb fixes the problem on Tyler's machine (22.04).

**Version bump**: Patch