### PR TITLE
Add more logs to help understand invocation status reporting

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -894,6 +894,8 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 			return nil
 		}
 		e.attempt = ti.Attempt
+		e.ctx = log.EnrichContext(e.ctx, "invocation_attempt", fmt.Sprintf("%d", e.attempt))
+		log.CtxInfof(e.ctx, "Created invocation %q, attempt %d", ti.InvocationID, ti.Attempt)
 		chunkFileSizeBytes := *chunkFileSizeBytes
 		if chunkFileSizeBytes == 0 {
 			chunkFileSizeBytes = defaultChunkFileSizeBytes

--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -132,14 +132,16 @@ func (r *BuildStatusReporter) flushPayloadsIfWorkspaceLoaded(ctx context.Context
 		repoURL := r.buildEventAccumulator.RepoURL()
 		ownerRepo, err := gitutil.OwnerRepoFromRepoURL(repoURL)
 		if err != nil {
-			log.Warningf("Failed to report GitHub status: %s", err)
+			log.CtxWarningf(ctx, "Failed to report GitHub status: %s", err)
 			break
 		}
 		commitSHA := r.buildEventAccumulator.CommitSHA()
 		err = r.githubClient.CreateStatus(ctx, ownerRepo, commitSHA, r.appendStatusNameSuffix(payload))
 		if err != nil {
-			log.Warningf("Failed to report GitHub status: %s", err)
+			log.CtxWarningf(ctx, "Failed to report GitHub status: %s", err)
+			continue
 		}
+		log.CtxInfof(ctx, "Reported GitHub status %q", payload.State)
 	}
 
 	r.payloads = make([]*github.GithubStatusPayload, 0)


### PR DESCRIPTION
* Add a log message when we successfully create an invocation in the DB
* Enriches the logging context with the attempt number
* Add a log when we successfully report a GitHub status, not just when we fail to report.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
