### PR TITLE
CLI: don't set empty API key header if not logged in

### DIFF
--- a/cli/login/login.go
+++ b/cli/login/login.go
@@ -80,6 +80,9 @@ func ConfigureAPIKey(args []string) ([]string, error) {
 		log.Debugf("failed to configure API key from .git/config: %s", err)
 		return args, nil
 	}
+	if apiKey == "" {
+		return args, nil
+	}
 
 	return append(args, "--"+apiKeyHeader+"="+strings.TrimSpace(apiKey)), nil
 }


### PR DESCRIPTION
An empty API key header is considered invalid, so this causes invocation auth to fail.

---

**Version bump**: Patch
