### PR TITLE
Add explicit check for empty group ID

### DIFF
--- a/server/util/authutil/authutil.go
+++ b/server/util/authutil/authutil.go
@@ -9,6 +9,10 @@ import (
 // AuthorizeGroupRole checks whether the given user has any of the allowed roles
 // within the given group.
 func AuthorizeGroupRole(u interfaces.UserInfo, groupID string, allowedRoles role.Role) error {
+	if groupID == "" {
+		return status.PermissionDeniedError("A group ID is required")
+	}
+
 	r := role.None
 	for _, m := range u.GetGroupMemberships() {
 		if m.GroupID == groupID {


### PR DESCRIPTION
Users should never have a group with an empty GroupID in their `GetGroupMemberships()` list, so `authutil.AuthorizeGroupRole` should always return "You do not have access to the requested organization" today if an empty GroupID is passed in.

This PR just makes the empty group ID case a bit more explicit, to give an even stronger guarantee that we always return an error if the group ID is empty.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
