### PR TITLE
Change UpdateGroupUsers to use group_id from request context

### DIFF
--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -136,7 +136,8 @@ message UpdateGroupUsersRequest {
   context.RequestContext request_context = 1;
 
   // The ID of the group to update.
-  string group_id = 2;
+  // DEPRECATED in favor of the group ID in the request context.
+  string group_id = 2 [deprecated = true];
 
   // Update applied to a user in the group.
   message Update {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -326,7 +326,7 @@ func (s *BuildBuddyServer) UpdateGroupUsers(ctx context.Context, req *grpb.Updat
 	if userDB == nil {
 		return nil, status.UnimplementedError("Not Implemented")
 	}
-	if err := userDB.UpdateGroupUsers(ctx, req.GetGroupId(), req.GetUpdate()); err != nil {
+	if err := userDB.UpdateGroupUsers(ctx, req.GetUpdate()); err != nil {
 		return nil, err
 	}
 	return &grpb.UpdateGroupUsersResponse{}, nil

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -351,7 +351,7 @@ type UserDB interface {
 	// status values.
 	GetGroupUsers(ctx context.Context, statuses []grpb.GroupMembershipStatus) ([]*grpb.GetGroupUsersResponse_GroupUser, error)
 
-	UpdateGroupUsers(ctx context.Context, groupID string, updates []*grpb.UpdateGroupUsersRequest_Update) error
+	UpdateGroupUsers(ctx context.Context, updates []*grpb.UpdateGroupUsersRequest_Update) error
 	DeleteGroupGitHubToken(ctx context.Context, groupID string) error
 
 	// GetAPIKeyForInternalUseOnly returns any API key for the group. It is only


### PR DESCRIPTION
Depends on https://github.com/buildbuddy-io/buildbuddy/pull/3411/files

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
