### PR TITLE
Add a util package for length-delimited proto streams

### DIFF
--- a/cli/printlog/BUILD
+++ b/cli/printlog/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//cli/arg",
         "//cli/log",
         "//proto:remote_execution_log_go_proto",
+        "//server/util/protodelim",
         "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//proto",
     ],

--- a/cli/printlog/printlog.go
+++ b/cli/printlog/printlog.go
@@ -1,9 +1,6 @@
 package printlog
 
 import (
-	"bufio"
-	"bytes"
-	"encoding/binary"
 	"flag"
 	"fmt"
 	"io"
@@ -11,6 +8,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/protodelim"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
@@ -68,9 +66,9 @@ func printLog(path string, m proto.Message) error {
 }
 
 func copyUnmarshaled(w io.Writer, grpcLog io.Reader, m proto.Message) error {
-	pr := NewDelimitedProtoReader(grpcLog)
+	pr := protodelim.NewReader(grpcLog, protodelim.ReadUvarint)
 	for {
-		err := pr.Unmarshal(m)
+		err := pr.Read(m)
 		if err == io.EOF {
 			return nil
 		}
@@ -88,25 +86,4 @@ func copyUnmarshaled(w io.Writer, grpcLog io.Reader, m proto.Message) error {
 			return err
 		}
 	}
-}
-
-type DelimitedProtoReader struct {
-	buf bytes.Buffer
-	r   *bufio.Reader
-}
-
-func NewDelimitedProtoReader(r io.Reader) *DelimitedProtoReader {
-	return &DelimitedProtoReader{r: bufio.NewReader(r)}
-}
-
-func (p *DelimitedProtoReader) Unmarshal(m proto.Message) error {
-	size, err := binary.ReadUvarint(p.r)
-	if err != nil {
-		return err
-	}
-	p.buf.Reset()
-	if _, err := io.CopyN(&p.buf, p.r, int64(size)); err != nil {
-		return err
-	}
-	return proto.Unmarshal(p.buf.Bytes(), m)
 }

--- a/server/util/protodelim/BUILD
+++ b/server/util/protodelim/BUILD
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "protodelim",
+    srcs = ["protodelim.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/protodelim",
+    visibility = ["//visibility:public"],
+    deps = ["@org_golang_google_protobuf//proto"],
+)

--- a/server/util/protodelim/protodelim.go
+++ b/server/util/protodelim/protodelim.go
@@ -1,0 +1,69 @@
+// package protodelim contains utilities for working with length-delimited
+// proto streams.
+package protodelim
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+
+	"google.golang.org/protobuf/proto"
+)
+
+var (
+	// ErrNegativeLength is returned when a negative length is read from a
+	// varint-delimited stream.
+	ErrNegativeLength = errors.New("unexpected negative length")
+)
+
+// delimiterFunc is a function that reads the length delimiter from a stream.
+type delimiterFunc func(io.ByteReader) (uint64, error)
+
+// ReadUvarint is a length delimiter for uvarint-encoded lengths.
+func ReadUvarint(r io.ByteReader) (uint64, error) {
+	return binary.ReadUvarint(r)
+}
+
+// ReadVarint is a length delimiter for varint-encoded lengths.
+func ReadVarint(r io.ByteReader) (uint64, error) {
+	n, err := binary.ReadVarint(r)
+	if err != nil {
+		return 0, err
+	}
+	if n < 0 {
+		return 0, ErrNegativeLength
+	}
+	return uint64(n), nil
+}
+
+// Reader is a length-delimited proto reader.
+type Reader struct {
+	buf       bytes.Buffer
+	br        *bufio.Reader
+	delimiter delimiterFunc
+}
+
+// NewReader returns a new length-delimited proto reader, where the given
+// function is used to read lengths (usually either ReadUvarint or ReadVarint
+// from this package).
+func NewReader(r io.Reader, delimiter delimiterFunc) *Reader {
+	return &Reader{
+		br:        bufio.NewReader(r),
+		delimiter: delimiter,
+	}
+}
+
+// Read reads a proto from the stream.
+func (r *Reader) Read(m proto.Message) error {
+	size, err := r.delimiter(r.br)
+	if err != nil {
+		return err
+	}
+	r.buf.Reset()
+	if _, err := io.CopyN(&r.buf, r.br, int64(size)); err != nil {
+		return err
+	}
+	return proto.Unmarshal(r.buf.Bytes(), m)
+}

--- a/server/util/protofile/BUILD
+++ b/server/util/protofile/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/interfaces",
+        "//server/util/protodelim",
         "//server/util/status",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",


### PR DESCRIPTION
* Add a package `protodelim` for consuming length-delimited proto streams. The name is inspired by the discussion [here](https://github.com/golang/protobuf/issues/1382) and also follows a similar naming convention to proto packages that deal with proto encodings (`protojson`, `protowire`, etc.)
* Use the package in `cli/printlog` and `server/util/protofile`. Will also be used in https://github.com/buildbuddy-io/buildbuddy/pull/3386
This should also reduce the amount of allocations in `ReadProto` (in `protofile.go`) since the new util reuses the same buffer across all unmarshal operations.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
