### PR TITLE
Make QueryBuilder auto-parenthesize WHERE clauses

### DIFF
--- a/server/util/query_builder/query_builder.go
+++ b/server/util/query_builder/query_builder.go
@@ -140,7 +140,11 @@ func (q *Query) Build() (string, []interface{}) {
 	}
 	q.arguments = append(argsInJoinClauses, q.arguments...)
 	if len(q.whereClauses) > 0 {
-		whereRestrict := strings.Join(q.whereClauses, andQueryJoiner)
+		whereClauses := make([]string, 0, len(q.whereClauses))
+		for _, c := range q.whereClauses {
+			whereClauses = append(whereClauses, " ("+c+") ")
+		}
+		whereRestrict := strings.Join(whereClauses, andQueryJoiner)
 		fullQuery += pad(whereSQLKeyword) + pad(whereRestrict)
 	}
 	if q.groupBy != "" {


### PR DESCRIPTION
This way, if people write code like `.AddWhereClause("a.b = ? OR c.d = ?")` and then later `.AddWhereClause("x.y = ?")`, the query will be correctly generated as `(a.b = ? OR c.d = ?) AND (x.y = ?)`

Also add a `normalize` func to help normalize whitespace (for test assertions only), since I was going crazy trying to check the differences in all the generated queries.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
