### PR TITLE
Fix up commit & branch links

### DIFF
--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -17,7 +17,7 @@ import HistoryInvocationStatCardComponent from "./history_invocation_stat_card";
 import { ProtoFilterParams, getProtoFilterParams } from "../filter/filter_util";
 import Spinner from "../../../app/components/spinner/spinner";
 import Long from "long";
-import { BarChart2, CheckCircle, Clock, GitCommit, Github, Hash, Percent, XCircle } from "lucide-react";
+import { BarChart2, CheckCircle, Clock, GitBranch, GitCommit, Github, Hash, Percent, XCircle } from "lucide-react";
 
 interface State {
   /**
@@ -366,6 +366,20 @@ export default class HistoryComponent extends React.Component<Props, State> {
     // TODO(bduffany): Make sure scope-filtered queries are optimized and remove this limitation.
     const hideSummaryStats = Boolean(scope);
 
+    const commitLink =
+      this.state.invocations?.length &&
+      this.state.invocations[0].repoUrl &&
+      this.state.invocations[0].repoUrl.startsWith("https://github.com")
+        ? `${this.state.invocations[0].repoUrl}/commit/${this.props.commit}`
+        : "";
+
+    const branchLink =
+      this.state.invocations?.length &&
+      this.state.invocations[0].repoUrl &&
+      this.state.invocations[0].repoUrl.startsWith("https://github.com")
+        ? `${this.state.invocations[0].repoUrl}/tree/${this.props.branch}`
+        : "";
+
     return (
       <div className="history">
         <div className="shelf">
@@ -415,7 +429,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
                   <span>
                     <span className="history-title">{this.props.username}'s builds</span>
                     <a className="history-button" href={`/trends/?user=${this.props.username}`}>
-                      <BarChart2 /> Trends
+                      <BarChart2 /> View Trends
                     </a>
                   </span>
                 )}
@@ -423,7 +437,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
                   <span>
                     <span className="history-title">Builds on {this.props.hostname}</span>
                     <a className="history-button" href={`/trends/?host=${this.props.hostname}`}>
-                      <BarChart2 /> Trends
+                      <BarChart2 /> View Trends
                     </a>
                   </span>
                 )}
@@ -432,11 +446,11 @@ export default class HistoryComponent extends React.Component<Props, State> {
                     <span className="history-title">Builds of {format.formatGitUrl(this.props.repo)}</span>
                     {this.getRepoUrl() && (
                       <a className="history-button" target="_blank" href={this.getRepoUrl()}>
-                        <Github /> Repo
+                        <Github /> View Repo
                       </a>
                     )}
                     <a className="history-button" href={`/trends/?repo=${this.props.repo}`}>
-                      <BarChart2 /> Trends
+                      <BarChart2 /> View Trends
                     </a>
                   </>
                 )}
@@ -445,7 +459,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
                     <span className="history-title">Workflow runs of {format.formatGitUrl(this.props.repo)}</span>
                     {this.getRepoUrl() && (
                       <a className="history-button" target="_blank" href={this.getRepoUrl()}>
-                        <Github /> Repo
+                        <Github /> View Repo
                       </a>
                     )}
                   </>
@@ -453,8 +467,13 @@ export default class HistoryComponent extends React.Component<Props, State> {
                 {this.props.branch && (
                   <>
                     <span className="history-title">Builds from branch {this.props.branch}</span>
+                    {branchLink && (
+                      <a className="history-button" target="_blank" href={branchLink}>
+                        <GitBranch /> View Branch
+                      </a>
+                    )}
                     <a className="history-button" href={`/trends/?branch=${this.props.branch}`}>
-                      <BarChart2 /> Trends
+                      <BarChart2 /> View Trends
                     </a>
                   </>
                 )}
@@ -463,14 +482,13 @@ export default class HistoryComponent extends React.Component<Props, State> {
                     <span className="history-title">
                       Builds from commit {format.formatCommitHash(this.props.commit)}
                     </span>
-                    <a
-                      className="history-button"
-                      target="_blank"
-                      href={`https://github.com/search?q=hash%3A${this.props.commit}`}>
-                      <GitCommit /> Commit
-                    </a>
+                    {commitLink && (
+                      <a className="history-button" target="_blank" href={commitLink}>
+                        <GitCommit /> View Commit
+                      </a>
+                    )}
                     <a className="history-button" href={`/trends/?commit=${this.props.commit}`}>
-                      <BarChart2 /> Trends
+                      <BarChart2 /> View Trends
                     </a>
                   </span>
                 )}

--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -429,7 +429,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
                   <span>
                     <span className="history-title">{this.props.username}'s builds</span>
                     <a className="history-button" href={`/trends/?user=${this.props.username}`}>
-                      <BarChart2 /> View Trends
+                      <BarChart2 /> View trends
                     </a>
                   </span>
                 )}
@@ -437,7 +437,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
                   <span>
                     <span className="history-title">Builds on {this.props.hostname}</span>
                     <a className="history-button" href={`/trends/?host=${this.props.hostname}`}>
-                      <BarChart2 /> View Trends
+                      <BarChart2 /> View trends
                     </a>
                   </span>
                 )}
@@ -446,11 +446,11 @@ export default class HistoryComponent extends React.Component<Props, State> {
                     <span className="history-title">Builds of {format.formatGitUrl(this.props.repo)}</span>
                     {this.getRepoUrl() && (
                       <a className="history-button" target="_blank" href={this.getRepoUrl()}>
-                        <Github /> View Repo
+                        <Github /> View repo
                       </a>
                     )}
                     <a className="history-button" href={`/trends/?repo=${this.props.repo}`}>
-                      <BarChart2 /> View Trends
+                      <BarChart2 /> View trends
                     </a>
                   </>
                 )}
@@ -459,7 +459,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
                     <span className="history-title">Workflow runs of {format.formatGitUrl(this.props.repo)}</span>
                     {this.getRepoUrl() && (
                       <a className="history-button" target="_blank" href={this.getRepoUrl()}>
-                        <Github /> View Repo
+                        <Github /> View repo
                       </a>
                     )}
                   </>
@@ -469,11 +469,11 @@ export default class HistoryComponent extends React.Component<Props, State> {
                     <span className="history-title">Builds from branch {this.props.branch}</span>
                     {branchLink && (
                       <a className="history-button" target="_blank" href={branchLink}>
-                        <GitBranch /> View Branch
+                        <GitBranch /> View branch
                       </a>
                     )}
                     <a className="history-button" href={`/trends/?branch=${this.props.branch}`}>
-                      <BarChart2 /> View Trends
+                      <BarChart2 /> View trends
                     </a>
                   </>
                 )}
@@ -484,11 +484,11 @@ export default class HistoryComponent extends React.Component<Props, State> {
                     </span>
                     {commitLink && (
                       <a className="history-button" target="_blank" href={commitLink}>
-                        <GitCommit /> View Commit
+                        <GitCommit /> View commit
                       </a>
                     )}
                     <a className="history-button" href={`/trends/?commit=${this.props.commit}`}>
-                      <BarChart2 /> View Trends
+                      <BarChart2 /> View trends
                     </a>
                   </span>
                 )}


### PR DESCRIPTION
Currently the links on commit history just take you to a github search for the commit sha - which gives you pretty lame results.

With this change - we'll link directly to the commit or branch if it's a github repo. Otherwise we won't show the button.

We can later expand this logic to support other providers.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
