### PR TITLE
percentile_chart: reverse tooltip ordering

### DIFF
--- a/enterprise/app/trends/percentile_chart.tsx
+++ b/enterprise/app/trends/percentile_chart.tsx
@@ -133,11 +133,11 @@ class PercentilesChartTooltip extends React.Component<PercentilesChartTooltipPro
       <div className="trend-chart-hover">
         <div className="trend-chart-hover-label">{this.props.labelFormatter(data)}</div>
         <div className="trend-chart-hover-value">
-          <div>p50: {format.durationSec(this.props.extractP50(data))}</div>
-          <div>p75: {format.durationSec(this.props.extractP75(data))}</div>
-          <div>p90: {format.durationSec(this.props.extractP90(data))}</div>
-          <div>p95: {format.durationSec(this.props.extractP95(data))}</div>
           <div>p99: {format.durationSec(this.props.extractP99(data))}</div>
+          <div>p95: {format.durationSec(this.props.extractP95(data))}</div>
+          <div>p90: {format.durationSec(this.props.extractP90(data))}</div>
+          <div>p75: {format.durationSec(this.props.extractP75(data))}</div>
+          <div>p50: {format.durationSec(this.props.extractP50(data))}</div>
         </div>
       </div>
     );


### PR DESCRIPTION
P99 is usually higher than P50, thus the P99 line is drawn above.

Reverse the tooltip ordering to match the lines order.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
