### PR TITLE
refactor: Move IsAnonymousUserError to authutil

### DIFF
--- a/enterprise/server/remote_execution/container/BUILD
+++ b/enterprise/server/remote_execution/container/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//server/environment",
         "//server/interfaces",
         "//server/metrics",
+        "//server/util/authutil",
         "//server/util/flagutil",
         "//server/util/log",
         "//server/util/perms",

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
@@ -267,7 +268,7 @@ func NewImageCacheToken(ctx context.Context, env environment.Env, creds PullCred
 	groupID := ""
 	u, err := perms.AuthenticatedUser(ctx, env)
 	if err != nil {
-		if !perms.IsAnonymousUserError(err) {
+		if !authutil.IsAnonymousUserError(err) {
 			return ImageCacheToken{}, err
 		}
 	} else {

--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//server/environment",
         "//server/interfaces",
         "//server/util/alert",
+        "//server/util/authutil",
         "//server/util/background",
         "//server/util/disk",
         "//server/util/grpc_client",

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -21,6 +21,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/background"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
@@ -387,7 +388,7 @@ func (c *podmanCommandContainer) optImageRefKey(ctx context.Context) (string, er
 	groupID := ""
 	u, err := perms.AuthenticatedUser(ctx, c.env)
 	if err != nil {
-		if !perms.IsAnonymousUserError(err) {
+		if !authutil.IsAnonymousUserError(err) {
 			return "", err
 		}
 	} else {

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//server/remote_cache/digest",
         "//server/resources",
         "//server/util/alert",
+        "//server/util/authutil",
         "//server/util/background",
         "//server/util/flagutil",
         "//server/util/lockingbuffer",

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -37,6 +37,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/resources"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/background"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lockingbuffer"
@@ -914,7 +915,7 @@ func (p *pool) Get(ctx context.Context, st *repb.ScheduledTask) (interfaces.Runn
 	}
 
 	user, err := auth.UserFromTrustedJWT(ctx)
-	if err != nil && !perms.IsAnonymousUserError(err) {
+	if err != nil && !authutil.IsAnonymousUserError(err) {
 		return nil, err
 	}
 	if props.RecycleRunner && err != nil {

--- a/enterprise/server/tasksize/BUILD
+++ b/enterprise/server/tasksize/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//proto:scheduler_go_proto",
         "//server/environment",
         "//server/metrics",
+        "//server/util/authutil",
         "//server/util/log",
         "//server/util/perms",
         "//server/util/status",

--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/tasksize_model"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -260,7 +261,7 @@ func (s *taskSizer) taskSizeKey(ctx context.Context, cmd *repb.Command) (string,
 func (s *taskSizer) groupKey(ctx context.Context) (string, error) {
 	u, err := perms.AuthenticatedUser(ctx, s.env)
 	if err != nil {
-		if perms.IsAnonymousUserError(err) && s.env.GetAuthenticator().AnonymousUsageEnabled() {
+		if authutil.IsAnonymousUserError(err) && s.env.GetAuthenticator().AnonymousUsageEnabled() {
 			return "ANON", nil
 		}
 		return "", err

--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//server/environment",
         "//server/interfaces",
         "//server/tables",
+        "//server/util/authutil",
         "//server/util/db",
         "//server/util/log",
         "//server/util/perms",

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -11,6 +11,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
@@ -139,7 +140,7 @@ func NewTracker(env environment.Env, clock timeutil.Clock, flushLock interfaces.
 func (ut *tracker) Increment(ctx context.Context, uc *tables.UsageCounts) error {
 	groupID, err := perms.AuthenticatedGroupID(ctx, ut.env)
 	if err != nil {
-		if perms.IsAnonymousUserError(err) && ut.env.GetAuthenticator().AnonymousUsageEnabled() {
+		if authutil.IsAnonymousUserError(err) && ut.env.GetAuthenticator().AnonymousUsageEnabled() {
 			// Don't track anonymous usage for now.
 			return nil
 		}

--- a/server/util/authutil/authutil.go
+++ b/server/util/authutil/authutil.go
@@ -30,3 +30,13 @@ func AuthorizeGroupRole(u interfaces.UserInfo, groupID string, allowedRoles role
 	}
 	return nil
 }
+
+// IsAnonymousUserError can be used to check whether an error returned by
+// functions which return the authenticated user (such as AuthenticatedUser or
+// AuthenticateSelectedGroupID) is due to an anonymous user accessing the
+// service. This is useful for allowing anonymous users to proceed, in cases
+// where anonymous usage is explicitly enabled in the app config, and we support
+// anonymous usage for the part of the service where this is used.
+func IsAnonymousUserError(err error) bool {
+	return status.IsUnauthenticatedError(err) || status.IsPermissionDeniedError(err) || status.IsUnimplementedError(err)
+}

--- a/server/util/capabilities/BUILD
+++ b/server/util/capabilities/BUILD
@@ -8,7 +8,7 @@ go_library(
     deps = [
         "//proto:api_key_go_proto",
         "//server/environment",
-        "//server/util/perms",
+        "//server/util/authutil",
         "//server/util/status",
     ],
 )

--- a/server/util/capabilities/capabilities.go
+++ b/server/util/capabilities/capabilities.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
@@ -48,7 +48,7 @@ func IsGranted(ctx context.Context, env environment.Env, cap akpb.ApiKey_Capabil
 	authIsRequired := !a.AnonymousUsageEnabled()
 	user, err := a.AuthenticatedUser(ctx)
 	if err != nil {
-		if perms.IsAnonymousUserError(err) {
+		if authutil.IsAnonymousUserError(err) {
 			if authIsRequired {
 				return false, nil
 			}
@@ -66,7 +66,7 @@ func ForAuthenticatedUser(ctx context.Context, env environment.Env) ([]akpb.ApiK
 	}
 	u, err := auth.AuthenticatedUser(ctx)
 	if err != nil {
-		if perms.IsAnonymousUserError(err) && auth.AnonymousUsageEnabled() {
+		if authutil.IsAnonymousUserError(err) && auth.AnonymousUsageEnabled() {
 			return DefaultAuthenticatedUserCapabilities, nil
 		}
 		return nil, err

--- a/server/util/perms/BUILD
+++ b/server/util/perms/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//proto:user_id_go_proto",
         "//server/environment",
         "//server/interfaces",
+        "//server/util/authutil",
         "//server/util/log",
         "//server/util/query_builder",
         "//server/util/status",


### PR DESCRIPTION
Context: The `perms` package was originally intended to just be utils for dealing with `perms` bits, and I added a few unrelated funcs there a while back before I understood its original purpose and before `authutil` existed. This func was one of them :)

There are a few other misplaced funcs in here like `perms.AuthenticatedUser` -- will find better homes for those in future PRs.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
