### PR TITLE
bazelignore: add more dirs under website

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -3,3 +3,6 @@ bazel-buildbuddy
 bazel-out
 bazel-testlogs
 node_modules
+website/.docusaurus
+website/build
+website/node_modules


### PR DESCRIPTION
Before this PR, if one were to run something like

```
echo 'invalid_star_lark()' > website/node_modules/BUILD
```

Then `bazel build //website/...` would be broken.
This may also apply to node_modules dependencies that may contain a
`build` file and user happen to be using a file system that is case
insensitive.

Add the remaining directories under "website" from the output of

```
git status --ignored
```

to `.bazelignore` to tell Bazel about it.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
