### PR TITLE
Add support for multiple digest functions

### DIFF
--- a/cli/parser/BUILD
+++ b/cli/parser/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//cli/log",
         "//cli/storage",
         "//cli/workspace",
+        "//proto:remote_execution_go_proto",
         "//server/remote_cache/digest",
         "//server/util/disk",
         "@com_github_google_shlex//:shlex",

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -21,6 +21,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/google/shlex"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
 const (
@@ -418,7 +420,7 @@ func runBazelHelpWithCache(topic string) (string, error) {
 			return "", err
 		}
 		defer f.Close()
-		d, err := digest.Compute(f)
+		d, err := digest.Compute(f, repb.DigestFunction_SHA256)
 		if err != nil {
 			return "", err
 		}

--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -299,7 +299,7 @@ func TestGetSet(t *testing.T) {
 		// Get() the bytes from the cache.
 		rbuf, err := mc.Get(ctx, r)
 		require.NoError(t, err)
-		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 		require.True(t, d.GetHash() == d2.GetHash())
 	}
 }

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -1790,7 +1790,7 @@ func TestMigrateVersions(t *testing.T) {
 			require.NoError(t, err)
 
 			// Compute a digest for the bytes returned.
-			d2, err := digest.Compute(bytes.NewReader(rbuf))
+			d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 			if d.GetHash() != d2.GetHash() {
 				t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), d.GetHash())
 			}

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -232,7 +232,7 @@ func TestIsolation(t *testing.T) {
 			}
 
 			// Compute a digest for the bytes returned.
-			d2, err := digest.Compute(bytes.NewReader(rbuf))
+			d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 			if err != nil {
 				t.Fatalf("Error computing digest: %s", err.Error())
 			}
@@ -284,7 +284,7 @@ func TestGetSet(t *testing.T) {
 		}
 
 		// Compute a digest for the bytes returned.
-		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 		if d.GetHash() != d2.GetHash() {
 			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), d.GetHash())
 		}
@@ -768,7 +768,7 @@ func TestMultiGetSet(t *testing.T) {
 		if !ok {
 			t.Fatalf("Multi-get failed to return expected digest: %q", d.GetHash())
 		}
-		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -881,10 +881,10 @@ func TestCompression(t *testing.T) {
 	compressedInlineBuf := compression.CompressZstd(nil, inlineBlob)
 
 	// Note: Digest is of uncompressed contents
-	d, err := digest.Compute(bytes.NewReader(blob))
+	d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
 	require.NoError(t, err)
 
-	inlineD, err := digest.Compute(bytes.NewReader(inlineBlob))
+	inlineD, err := digest.Compute(bytes.NewReader(inlineBlob), repb.DigestFunction_SHA256)
 	require.NoError(t, err)
 
 	compressedRN := &resource.ResourceName{
@@ -1047,7 +1047,7 @@ func TestCompression_BufferPoolReuse(t *testing.T) {
 		blob := compressibleBlobOfSize(100)
 
 		// Note: Digest is of uncompressed contents
-		d, err := digest.Compute(bytes.NewReader(blob))
+		d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
 		require.NoError(t, err)
 		decompressedRN := &resource.ResourceName{
 			Digest:     d,
@@ -1105,7 +1105,7 @@ func TestCompression_ParallelRequests(t *testing.T) {
 			blob := compressibleBlobOfSize(10000)
 
 			// Note: Digest is of uncompressed contents
-			d, err := digest.Compute(bytes.NewReader(blob))
+			d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
 			require.NoError(t, err)
 			decompressedRN := &resource.ResourceName{
 				Digest:     d,
@@ -1157,7 +1157,7 @@ func TestCompression_NoEarlyEviction(t *testing.T) {
 		require.Less(t, len(compressed), len(blob))
 		totalSizeCompresedData += len(compressed)
 
-		d, err := digest.Compute(bytes.NewReader(blob))
+		d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
 		require.NoError(t, err)
 		digestBlobs[d] = blob
 	}
@@ -1210,7 +1210,7 @@ func TestCompressionOffset(t *testing.T) {
 	compressedBuf := compression.CompressZstd(nil, blob)
 
 	// Note: Digest is of uncompressed contents
-	d, err := digest.Compute(bytes.NewReader(blob))
+	d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
 	require.NoError(t, err)
 
 	compressedRN := &resource.ResourceName{
@@ -1522,7 +1522,7 @@ func TestStartupScan(t *testing.T) {
 		require.NoError(t, err)
 
 		// Compute a digest for the bytes returned.
-		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 		if d.GetHash() != d2.GetHash() {
 			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), d.GetHash())
 		}

--- a/enterprise/server/composable_cache/composable_cache_test.go
+++ b/enterprise/server/composable_cache/composable_cache_test.go
@@ -47,7 +47,7 @@ func writeDigest(ctx context.Context, t *testing.T, c interfaces.Cache, sizeByte
 func readAndVerifyDigest(ctx context.Context, t *testing.T, c interfaces.Cache, d *resource.ResourceName) {
 	r, err := c.Reader(ctx, d, 0, 0)
 	require.NoError(t, err)
-	rd, err := digest.Compute(r)
+	rd, err := digest.Compute(r, repb.DigestFunction_SHA256)
 	require.NoError(t, err)
 	err = r.Close()
 	require.NoError(t, err)

--- a/enterprise/server/image_converter/image_converter.go
+++ b/enterprise/server/image_converter/image_converter.go
@@ -389,7 +389,7 @@ func (c *imageConverter) convertLayer(ctx context.Context, req *rgpb.ConvertLaye
 	if err := newLayer.Close(); err != nil {
 		return nil, status.UnknownErrorf("could not close new layer reader: %s", err)
 	}
-	newLayerDigest, err := digest.Compute(bytes.NewReader(newLayerData))
+	newLayerDigest, err := digest.Compute(bytes.NewReader(newLayerData), repb.DigestFunction_SHA256)
 	if err != nil {
 		return nil, status.UnknownErrorf("could not compute digest of new layer: %s", err)
 	}

--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -602,7 +602,7 @@ func (ff *BatchFileFetcher) FetchFiles(filesToFetch FileMap, opts *DownloadTreeO
 		d := dk.ToDigest()
 
 		// Write empty files directly (skip checking cache and downloading).
-		if d.GetHash() == digest.EmptySha256 {
+		if digest.IsEmpty(d) {
 			for _, fp := range filePointers {
 				if err := writeFile(fp, []byte("")); err != nil {
 					return err
@@ -743,14 +743,14 @@ func fetchDir(ctx context.Context, bsClient bspb.ByteStreamClient, reqDigest *di
 func DirMapFromTree(tree *repb.Tree) (rootDigest *repb.Digest, dirMap map[digest.Key]*repb.Directory, err error) {
 	dirMap = make(map[digest.Key]*repb.Directory, 1+len(tree.Children))
 
-	rootDigest, err = digest.ComputeForMessage(tree.Root)
+	rootDigest, err = digest.ComputeForMessage(tree.Root, repb.DigestFunction_SHA256)
 	if err != nil {
 		return nil, nil, err
 	}
 	dirMap[digest.NewKey(rootDigest)] = tree.Root
 
 	for _, child := range tree.Children {
-		d, err := digest.ComputeForMessage(child)
+		d, err := digest.ComputeForMessage(child, repb.DigestFunction_SHA256)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -829,7 +829,7 @@ func DownloadTree(ctx context.Context, env environment.Env, instanceName string,
 			if err := os.MkdirAll(newRoot, dirPerms); err != nil {
 				return err
 			}
-			if child.GetDigest().Hash == digest.EmptySha256 && child.GetDigest().SizeBytes == 0 {
+			if digest.IsEmpty(child.GetDigest()) && child.GetDigest().SizeBytes == 0 {
 				continue
 			}
 			childDir, ok := dirMap[digest.NewKey(child.GetDigest())]

--- a/enterprise/server/remote_execution/dirtools/dirtools_test.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools_test.go
@@ -44,7 +44,7 @@ func TestDownloadTree(t *testing.T) {
 		},
 	}
 
-	childDigest, err := digest.ComputeForMessage(childDir)
+	childDigest, err := digest.ComputeForMessage(childDir, repb.DigestFunction_SHA256)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestDownloadTreeWithFileCache(t *testing.T) {
 		},
 	}
 
-	childDigest, err := digest.ComputeForMessage(childDir)
+	childDigest, err := digest.ComputeForMessage(childDir, repb.DigestFunction_SHA256)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func TestDownloadTreeEmptyDigest(t *testing.T) {
 		},
 	}
 
-	childDigest, err := digest.ComputeForMessage(childDir)
+	childDigest, err := digest.ComputeForMessage(childDir, repb.DigestFunction_SHA256)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -265,7 +265,7 @@ func addToFileCache(t *testing.T, env *testenv.TestEnv, tempDir, data string) {
 	if _, err := f.Write([]byte(data)); err != nil {
 		t.Fatal(err)
 	}
-	d, err := digest.Compute(strings.NewReader(data))
+	d, err := digest.Compute(strings.NewReader(data), repb.DigestFunction_SHA256)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/server/util/cacheproxy/cacheproxy_test.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy_test.go
@@ -108,7 +108,7 @@ func TestReaderMaxOffset(t *testing.T) {
 	readSeeker := bytes.NewReader(buf.Bytes())
 
 	// Compute a digest for the random bytes.
-	d, err := digest.Compute(readSeeker)
+	d, err := digest.Compute(readSeeker, repb.DigestFunction_SHA256)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,7 +293,7 @@ func TestReader(t *testing.T) {
 		readSeeker := bytes.NewReader(buf.Bytes())
 
 		// Compute a digest for the random bytes.
-		d, err := digest.Compute(readSeeker)
+		d, err := digest.Compute(readSeeker, repb.DigestFunction_SHA256)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -387,7 +387,7 @@ func TestWriter(t *testing.T) {
 		readSeeker := bytes.NewReader(buf.Bytes())
 
 		// Compute a digest for the random bytes.
-		d, err := digest.Compute(readSeeker)
+		d, err := digest.Compute(readSeeker, repb.DigestFunction_SHA256)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -590,7 +590,7 @@ func TestContains(t *testing.T) {
 		readSeeker := bytes.NewReader(buf.Bytes())
 
 		// Compute a digest for the random bytes.
-		d, err := digest.Compute(readSeeker)
+		d, err := digest.Compute(readSeeker, repb.DigestFunction_SHA256)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -663,7 +663,7 @@ func TestOversizeBlobs(t *testing.T) {
 		readSeeker := bytes.NewReader(buf.Bytes())
 
 		// Compute a digest for the random bytes.
-		d, err := digest.Compute(readSeeker)
+		d, err := digest.Compute(readSeeker, repb.DigestFunction_SHA256)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -690,7 +690,7 @@ func TestOversizeBlobs(t *testing.T) {
 		// bytes that were uploaded, even though they are keyed
 		// under a different digest.
 		readSeeker.Seek(0, 0)
-		d1, err := digest.Compute(readSeeker)
+		d1, err := digest.Compute(readSeeker, repb.DigestFunction_SHA256)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -748,7 +748,7 @@ func TestFindMissing(t *testing.T) {
 			readSeeker := bytes.NewReader(buf.Bytes())
 
 			// Compute a digest for the random bytes.
-			d, err := digest.Compute(readSeeker)
+			d, err := digest.Compute(readSeeker, repb.DigestFunction_SHA256)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -817,7 +817,7 @@ func TestGetMulti(t *testing.T) {
 			readSeeker := bytes.NewReader(buf.Bytes())
 
 			// Compute a digest for the random bytes.
-			d, err := digest.Compute(readSeeker)
+			d, err := digest.Compute(readSeeker, repb.DigestFunction_SHA256)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/server/util/ext4/ext4_test.go
+++ b/enterprise/server/util/ext4/ext4_test.go
@@ -68,7 +68,7 @@ func TestE2E(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		d, err := digest.Compute(f)
+		d, err := digest.Compute(f, repb.DigestFunction_SHA256)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -631,7 +631,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 	if cache == nil {
 		return nil, status.UnavailableError("No cache configured.")
 	}
-	inputRootDigest, err := digest.ComputeForMessage(&repb.Directory{})
+	inputRootDigest, err := digest.ComputeForMessage(&repb.Directory{}, repb.DigestFunction_SHA256)
 	if err != nil {
 		return nil, err
 	}

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -83,7 +83,7 @@ func TestGetSet(t *testing.T) {
 		require.NoError(t, err)
 
 		// Compute a digest for the bytes returned.
-		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 		if d.GetHash() != d2.GetHash() {
 			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), d.GetHash())
 		}
@@ -250,7 +250,7 @@ func TestMultiGetSet(t *testing.T) {
 		if !ok {
 			t.Fatalf("Multi-get failed to return expected digest: %q", d.GetHash())
 		}
-		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -407,7 +407,7 @@ func TestSizeLimit(t *testing.T) {
 			t.Fatalf("Error getting %q from cache: %s", d.GetHash(), err.Error())
 		}
 		// Compute a digest for the bytes returned.
-		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 		if d.GetHash() != d2.GetHash() {
 			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), d.GetHash())
 		}
@@ -470,7 +470,7 @@ func TestLRU(t *testing.T) {
 			t.Fatalf("Error getting %q from cache: %s", d.GetHash(), err.Error())
 		}
 		// Compute a digest for the bytes returned.
-		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 		if d.GetHash() != d2.GetHash() {
 			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), d.GetHash())
 		}

--- a/server/backends/memory_cache/memory_cache_test.go
+++ b/server/backends/memory_cache/memory_cache_test.go
@@ -119,7 +119,7 @@ func TestIsolation(t *testing.T) {
 			}
 
 			// Compute a digest for the bytes returned.
-			d2, err := digest.Compute(bytes.NewReader(rbuf))
+			d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 			if err != nil {
 				t.Fatalf("Error computing digest: %s", err.Error())
 			}
@@ -165,7 +165,7 @@ func TestGetSet(t *testing.T) {
 		}
 
 		// Compute a digest for the bytes returned.
-		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 		if d.GetHash() != d2.GetHash() {
 			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), d.GetHash())
 		}
@@ -206,7 +206,7 @@ func TestMultiGetSet(t *testing.T) {
 		if !ok {
 			t.Fatalf("Multi-get failed to return expected digest: %q", d.GetHash())
 		}
-		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -316,7 +316,7 @@ func TestSizeLimit(t *testing.T) {
 			t.Fatalf("Error getting %q from cache: %s", r.GetDigest().GetHash(), err.Error())
 		}
 		// Compute a digest for the bytes returned.
-		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 		if r.GetDigest().GetHash() != d2.GetHash() {
 			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), r.GetDigest().GetHash())
 		}
@@ -376,7 +376,7 @@ func TestLRU(t *testing.T) {
 			t.Fatalf("Error getting %q from cache: %s", r.GetDigest().GetHash(), err.Error())
 		}
 		// Compute a digest for the bytes returned.
-		d2, err := digest.Compute(bytes.NewReader(rbuf))
+		d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
 		if r.GetDigest().GetHash() != d2.GetHash() {
 			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), d.GetHash())
 		}

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -278,7 +278,7 @@ func (s *ByteStreamServer) initStreamState(ctx context.Context, req *bspb.WriteR
 	}
 
 	var committedWriteCloser interfaces.CommittedWriteCloser
-	if digest.IsEmpty(r.GetDigest()) && !exists {
+	if !digest.IsEmpty(r.GetDigest()) && !exists {
 		cacheWriter, err := s.cache.Writer(ctx, casRN.ToProto())
 		if err != nil {
 			return nil, err

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -278,14 +278,14 @@ func (s *ByteStreamServer) initStreamState(ctx context.Context, req *bspb.WriteR
 	}
 
 	var committedWriteCloser interfaces.CommittedWriteCloser
-	if !digest.IsEmpty(r.GetDigest()) && !exists {
+	if digest.IsEmpty(r.GetDigest()) {
+		committedWriteCloser = ioutil.DiscardWriteCloser()
+	} else {
 		cacheWriter, err := s.cache.Writer(ctx, casRN.ToProto())
 		if err != nil {
 			return nil, err
 		}
 		committedWriteCloser = cacheWriter
-	} else {
-		committedWriteCloser = ioutil.DiscardWriteCloser()
 	}
 	ws.cacheCommitter = committedWriteCloser
 	ws.cacheCloser = committedWriteCloser

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -231,7 +231,7 @@ func TestRPCReadWriteLargeBlob(t *testing.T) {
 
 	blob, err := random.RandomString(10_000_000)
 	require.NoError(t, err)
-	d, err := digest.Compute(strings.NewReader(blob))
+	d, err := digest.Compute(strings.NewReader(blob), repb.DigestFunction_SHA256)
 	require.NoError(t, err)
 	instanceNameDigest := digest.NewResourceName(d, "")
 
@@ -264,7 +264,7 @@ func TestRPCWriteAndReadCompressed(t *testing.T) {
 		require.NotEqual(t, blob, compressedBlob, "sanity check: blob != compressedBlob")
 
 		// Note: Digest is of uncompressed contents
-		d, err := digest.Compute(bytes.NewReader(blob))
+		d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
 		require.NoError(t, err)
 
 		// ByteStream.Read should return NOT_FOUND initially.
@@ -341,7 +341,7 @@ func TestRPCWriteCompressedReadUncompressed(t *testing.T) {
 		require.NotEqual(t, blob, compressedBlob, "sanity check: blob != compressedBlob")
 
 		// Note: Digest is of uncompressed contents
-		d, err := digest.Compute(bytes.NewReader(blob))
+		d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
 		require.NoError(t, err)
 
 		// ByteStream.Read should return NOT_FOUND initially.
@@ -408,7 +408,7 @@ func TestRPCWriteUncompressedReadCompressed(t *testing.T) {
 		blob := compressibleBlobOfSize(blobSize)
 
 		// Note: Digest is of uncompressed contents
-		d, err := digest.Compute(bytes.NewReader(blob))
+		d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
 		require.NoError(t, err)
 
 		// Upload uncompressed via bytestream.
@@ -445,7 +445,7 @@ func Test_CacheHandlesCompression(t *testing.T) {
 	require.NotEqual(t, blob, compressedBlob, "sanity check: blob != compressedBlob")
 
 	// Note: Digest is of uncompressed contents
-	d, err := digest.Compute(bytes.NewReader(blob))
+	d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
 	require.NoError(t, err)
 
 	testCases := []struct {

--- a/server/remote_cache/capabilities_server/BUILD
+++ b/server/remote_cache/capabilities_server/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//proto:semver_go_proto",
         "//server/environment",
         "//server/remote_cache/config",
+        "//server/remote_cache/digest",
         "//server/util/bazel_request",
         "//server/util/perms",
     ],

--- a/server/remote_cache/capabilities_server/capabilities_server.go
+++ b/server/remote_cache/capabilities_server/capabilities_server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -59,7 +60,7 @@ func (s *CapabilitiesServer) GetCapabilities(ctx context.Context, req *repb.GetC
 	}
 	if s.supportCAS {
 		c.CacheCapabilities = &repb.CacheCapabilities{
-			DigestFunctions: []repb.DigestFunction_Value{repb.DigestFunction_SHA256},
+			DigestFunctions: digest.SupportedDigestFunctions(),
 			ActionCacheUpdateCapabilities: &repb.ActionCacheUpdateCapabilities{
 				UpdateEnabled: s.actionCacheUpdateEnabled(ctx),
 			},

--- a/server/remote_cache/capabilities_server/capabilities_server.go
+++ b/server/remote_cache/capabilities_server/capabilities_server.go
@@ -5,9 +5,9 @@ import (
 	"math"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
-	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -93,10 +93,7 @@ func (s *ContentAddressableStorageServer) FindMissingBlobs(ctx context.Context, 
 	}
 	digestsToLookup := make([]*resource.ResourceName, 0, len(req.GetBlobDigests()))
 	for _, d := range req.GetBlobDigests() {
-		if d.GetHash() == digest.EmptySha256 {
-			continue
-		}
-		if d.GetHash() == digest.EmptyHash {
+		if digest.IsEmpty(d) || d.GetHash() == digest.EmptyHash {
 			continue
 		}
 		rn := digest.NewCASResourceName(d, req.GetInstanceName()).ToProto()
@@ -177,7 +174,7 @@ func (s *ContentAddressableStorageServer) BatchUpdateBlobs(ctx context.Context, 
 			uploadTracker.CloseWithBytesTransferred(int64(bytesWrittenToCache), int64(bytesFromClient), uploadRequest.GetCompressor(), "cas_server")
 		}()
 
-		if uploadDigest.GetHash() == digest.EmptySha256 {
+		if digest.IsEmpty(uploadDigest) {
 			rsp.Responses = append(rsp.Responses, &repb.BatchUpdateBlobsResponse_Response{
 				Digest: uploadDigest,
 				Status: &statuspb.Status{Code: int32(codes.OK)},
@@ -302,7 +299,7 @@ func (s *ContentAddressableStorageServer) BatchReadBlobs(ctx context.Context, re
 			downloadTracker.CloseWithBytesTransferred(int64(data.bytesReadFromCache), int64(data.bytesDownloadedToClient), data.compressor, "cas_server")
 		})
 
-		if readDigest.GetHash() != digest.EmptySha256 {
+		if !digest.IsEmpty(readDigest) {
 			rn := digest.NewCASResourceName(readDigest, req.GetInstanceName())
 			if readZstd {
 				rn.SetCompressor(repb.Compressor_ZSTD)
@@ -313,7 +310,7 @@ func (s *ContentAddressableStorageServer) BatchReadBlobs(ctx context.Context, re
 	cacheRsp, err := s.cache.GetMulti(ctx, cacheRequest)
 
 	for _, d := range req.GetDigests() {
-		if d.GetHash() == digest.EmptySha256 {
+		if digest.IsEmpty(d) {
 			rsp.Responses = append(rsp.Responses, &repb.BatchReadBlobsResponse_Response{
 				Digest: d,
 				Status: &statuspb.Status{Code: int32(codes.OK)},
@@ -496,7 +493,7 @@ func (s *ContentAddressableStorageServer) fetchDir(ctx context.Context, dirName 
 
 func makeTreeCacheDigest(d *repb.Digest) (*repb.Digest, error) {
 	buf := bytes.NewBuffer([]byte(d.GetHash() + *treeCacheSeed))
-	return digest.Compute(buf)
+	return digest.Compute(buf, digest.Type(d))
 }
 
 func (s *ContentAddressableStorageServer) fetchDirectory(ctx context.Context, remoteInstanceName string, dd *repb.DirectoryWithDigest) ([]*repb.DirectoryWithDigest, error) {
@@ -507,7 +504,7 @@ func (s *ContentAddressableStorageServer) fetchDirectory(ctx context.Context, re
 	subdirDigests := make([]*resource.ResourceName, 0, len(dir.Directories))
 	for _, dirNode := range dir.Directories {
 		d := dirNode.GetDigest()
-		if d.GetHash() == digest.EmptySha256 {
+		if digest.IsEmpty(d) {
 			continue
 		}
 		rn := digest.NewCASResourceName(d, remoteInstanceName).ToProto()
@@ -569,7 +566,7 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 	if req.RootDigest == nil {
 		return status.InvalidArgumentError("RootDigest is required to GetTree")
 	}
-	if req.GetRootDigest().GetHash() == digest.EmptySha256 {
+	if digest.IsEmpty(req.GetRootDigest()) {
 		return nil
 	}
 

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -706,9 +706,15 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 func isComplete(children []*repb.DirectoryWithDigest) bool {
 	allDigests := make(map[string]struct{}, len(children))
 	for _, child := range children {
+		if digest.IsEmpty(child.GetDigest()) {
+			continue
+		}
 		allDigests[child.GetDigest().GetHash()] = struct{}{}
 	}
 	for _, child := range children {
+		if digest.IsEmpty(child.GetDigest()) {
+			continue
+		}
 		dir := child.Directory
 		if len(dir.Directories) == 0 && len(dir.Files) == 0 && len(dir.Symlinks) == 0 {
 			log.Warningf("corrupted tree: empty dir: %+v, digest: %q", dir, child.GetDigest().GetHash())

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -115,7 +115,7 @@ func TestBatchUpdateAndReadCompressedBlobs(t *testing.T) {
 	compressedBlob := compression.CompressZstd(nil, blob)
 
 	// Note: Digest is of uncompressed contents
-	d, err := digest.Compute(bytes.NewReader(blob))
+	d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
 	require.NoError(t, err)
 
 	// FindMissingBlobs should report that the blob is missing, initially.
@@ -210,7 +210,7 @@ func TestBatchUpdateRejectsCompressedBlobsIfCompressionDisabled(t *testing.T) {
 	compressedBlob := compression.CompressZstd(nil, blob)
 
 	// Note: Digest is of uncompressed contents
-	d, err := digest.Compute(bytes.NewReader(blob))
+	d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
 	require.NoError(t, err)
 
 	// Upload compressed blob via BatchUpdate.
@@ -321,7 +321,7 @@ func TestBatchUpdateAndRead_CacheHandlesCompression(t *testing.T) {
 			}
 
 			// Note: Digest is of uncompressed contents
-			d, err := digest.Compute(bytes.NewReader(blob))
+			d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
 			require.NoError(t, err, tc.name)
 
 			// FindMissingBlobs should report that the blob is missing, initially.

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -3,8 +3,10 @@ package digest
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
 	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/sha512"
 	"fmt"
 	"hash"
 	"io"
@@ -275,15 +277,15 @@ func HashForDigestType(digestType repb.DigestFunction_Value) (hash.Hash, error) 
 func Type(d *repb.Digest) repb.DigestFunction_Value {
 	// TODO: determine this via enum in digest?
 	switch len(d.GetHash()) {
-	case 40:
+	case sha1.Size * 2:
 		return repb.DigestFunction_SHA1
-	case 32:
+	case md5.Size * 2:
 		return repb.DigestFunction_MD5
-	case 64:
+	case sha256.Size * 2:
 		return repb.DigestFunction_SHA256
-	case 96:
+	case sha512.Size384 * 2:
 		return repb.DigestFunction_SHA384
-	case 128:
+	case sha512.Size * 2:
 		return repb.DigestFunction_SHA512
 	default:
 		return repb.DigestFunction_UNKNOWN

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -34,16 +34,7 @@ const (
 )
 
 var (
-	// Cache keys must be:
-	//  - lower case
-	//  - ascii
-	//  - a sha256 sum
-	hashKeyRegex *regexp.Regexp
-
-	// Matches:
-	// - "blobs/469db13020c60f8bdf9c89aa4e9a449914db23139b53a24d064f967a51057868/39120"
-	// - "blobs/ac/469db13020c60f8bdf9c89aa4e9a449914db23139b53a24d064f967a51057868/39120"
-	// - "uploads/2042a8f9-eade-4271-ae58-f5f6f5a32555/blobs/8afb02ca7aace3ae5cd8748ac589e2e33022b1a4bfd22d5d234c5887e270fe9c/17997850"
+	hashKeyRegex     *regexp.Regexp
 	uploadRegex      *regexp.Regexp
 	downloadRegex    *regexp.Regexp
 	actionCacheRegex *regexp.Regexp
@@ -71,10 +62,18 @@ func init() {
 		hashMatchers = append(hashMatchers, fmt.Sprintf("[a-f0-9]{%d}", df.sizeBytes*2))
 		knownDigestFunctions = append(knownDigestFunctions, df.digestType)
 	}
-
 	joinedMatchers := strings.Join(hashMatchers, "|")
 
+	// Cache keys must be:
+	//  - lower case
+	//  - ascii
+	//  - a sha256 sum
 	hashKeyRegex = regexp.MustCompile(fmt.Sprintf("^(%s)$", joinedMatchers))
+
+	// Matches:
+	// - "blobs/469db13020c60f8bdf9c89aa4e9a449914db23139b53a24d064f967a51057868/39120"
+	// - "blobs/ac/469db13020c60f8bdf9c89aa4e9a449914db23139b53a24d064f967a51057868/39120"
+	// - "uploads/2042a8f9-eade-4271-ae58-f5f6f5a32555/blobs/8afb02ca7aace3ae5cd8748ac589e2e33022b1a4bfd22d5d234c5887e270fe9c/17997850"
 	uploadRegex = regexp.MustCompile(fmt.Sprintf(`^(?:(?:(?P<instance_name>.*)/)?uploads/(?P<uuid>[a-f0-9-]{36})/)?(?P<blob_type>blobs|compressed-blobs/zstd)/(?P<hash>%s)/(?P<size>\d+)`, joinedMatchers))
 	downloadRegex = regexp.MustCompile(fmt.Sprintf(`^(?:(?P<instance_name>.*)/)?(?P<blob_type>blobs|compressed-blobs/zstd)/(?P<hash>%s)/(?P<size>\d+)`, joinedMatchers))
 	actionCacheRegex = regexp.MustCompile(fmt.Sprintf(`^(?:(?P<instance_name>.*)/)?(?P<blob_type>blobs|compressed-blobs/zstd)/ac/(?P<hash>%s)/(?P<size>\d+)`, joinedMatchers))

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -3,8 +3,10 @@ package digest
 import (
 	"bytes"
 	"context"
+	"crypto/sha1"
 	"crypto/sha256"
 	"fmt"
+	"hash"
 	"io"
 	"math/rand"
 	"path/filepath"
@@ -27,9 +29,8 @@ import (
 )
 
 const (
-	hashKeyLength = 64
-	EmptySha256   = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-	EmptyHash     = ""
+	EmptySha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	EmptyHash   = ""
 )
 
 var (
@@ -37,16 +38,51 @@ var (
 	//  - lower case
 	//  - ascii
 	//  - a sha256 sum
-	hashKeyRegex = regexp.MustCompile("^[a-f0-9]{64}$")
+	hashKeyRegex *regexp.Regexp
 
 	// Matches:
 	// - "blobs/469db13020c60f8bdf9c89aa4e9a449914db23139b53a24d064f967a51057868/39120"
 	// - "blobs/ac/469db13020c60f8bdf9c89aa4e9a449914db23139b53a24d064f967a51057868/39120"
 	// - "uploads/2042a8f9-eade-4271-ae58-f5f6f5a32555/blobs/8afb02ca7aace3ae5cd8748ac589e2e33022b1a4bfd22d5d234c5887e270fe9c/17997850"
-	uploadRegex      = regexp.MustCompile(`^(?:(?:(?P<instance_name>.*)/)?uploads/(?P<uuid>[a-f0-9-]{36})/)?(?P<blob_type>blobs|compressed-blobs/zstd)/(?P<hash>[a-f0-9]{64})/(?P<size>\d+)`)
-	downloadRegex    = regexp.MustCompile(`^(?:(?P<instance_name>.*)/)?(?P<blob_type>blobs|compressed-blobs/zstd)/(?P<hash>[a-f0-9]{64})/(?P<size>\d+)`)
-	actionCacheRegex = regexp.MustCompile(`^(?:(?P<instance_name>.*)/)?(?P<blob_type>blobs|compressed-blobs/zstd)/ac/(?P<hash>[a-f0-9]{64})/(?P<size>\d+)`)
+	uploadRegex      *regexp.Regexp
+	downloadRegex    *regexp.Regexp
+	actionCacheRegex *regexp.Regexp
+
+	knownDigestFunctions []repb.DigestFunction_Value
 )
+
+func init() {
+	digestFunctions := []struct {
+		digestType repb.DigestFunction_Value
+		sizeBytes  int
+	}{
+		{
+			digestType: repb.DigestFunction_SHA256,
+			sizeBytes:  sha256.Size,
+		},
+		{
+			digestType: repb.DigestFunction_SHA1,
+			sizeBytes:  sha1.Size,
+		},
+	}
+
+	hashMatchers := make([]string, 0)
+	for _, df := range digestFunctions {
+		hashMatchers = append(hashMatchers, fmt.Sprintf("[a-f0-9]{%d}", df.sizeBytes*2))
+		knownDigestFunctions = append(knownDigestFunctions, df.digestType)
+	}
+
+	joinedMatchers := strings.Join(hashMatchers, "|")
+
+	hashKeyRegex = regexp.MustCompile(fmt.Sprintf("^(%s)$", joinedMatchers))
+	uploadRegex = regexp.MustCompile(fmt.Sprintf(`^(?:(?:(?P<instance_name>.*)/)?uploads/(?P<uuid>[a-f0-9-]{36})/)?(?P<blob_type>blobs|compressed-blobs/zstd)/(?P<hash>%s)/(?P<size>\d+)`, joinedMatchers))
+	downloadRegex = regexp.MustCompile(fmt.Sprintf(`^(?:(?P<instance_name>.*)/)?(?P<blob_type>blobs|compressed-blobs/zstd)/(?P<hash>%s)/(?P<size>\d+)`, joinedMatchers))
+	actionCacheRegex = regexp.MustCompile(fmt.Sprintf(`^(?:(?P<instance_name>.*)/)?(?P<blob_type>blobs|compressed-blobs/zstd)/ac/(?P<hash>%s)/(?P<size>\d+)`, joinedMatchers))
+}
+
+func SupportedDigestFunctions() []repb.DigestFunction_Value {
+	return knownDigestFunctions
+}
 
 type ResourceName struct {
 	rn *rspb.ResourceName
@@ -101,6 +137,10 @@ func (r *ResourceName) ToProto() *rspb.ResourceName {
 
 func (r *ResourceName) GetDigest() *repb.Digest {
 	return r.rn.GetDigest()
+}
+
+func (r *ResourceName) DigestType() repb.DigestFunction_Value {
+	return Type(r.rn.GetDigest())
 }
 
 func (r *ResourceName) GetInstanceName() string {
@@ -202,14 +242,10 @@ func Validate(d *repb.Digest) (string, error) {
 		return "", status.InvalidArgumentErrorf("Invalid (negative) digest size")
 	}
 	if d.SizeBytes == int64(0) {
-		if d.Hash == EmptySha256 {
+		if IsEmpty(d) {
 			return d.Hash, nil
 		}
 		return "", status.InvalidArgumentError("Invalid (zero-length) SHA256 hash")
-	}
-
-	if len(d.Hash) != hashKeyLength {
-		return "", status.InvalidArgumentError(fmt.Sprintf("Hash length was %d, expected %d", len(d.Hash), hashKeyLength))
 	}
 
 	if !hashKeyRegex.MatchString(d.Hash) {
@@ -218,16 +254,67 @@ func Validate(d *repb.Digest) (string, error) {
 	return d.Hash, nil
 }
 
-func ComputeForMessage(in proto.Message) (*repb.Digest, error) {
+func ComputeForMessage(in proto.Message, digestType repb.DigestFunction_Value) (*repb.Digest, error) {
 	data, err := proto.Marshal(in)
 	if err != nil {
 		return nil, err
 	}
-	return Compute(bytes.NewReader(data))
+	return Compute(bytes.NewReader(data), digestType)
 }
 
-func Compute(in io.Reader) (*repb.Digest, error) {
-	h := sha256.New()
+func HashForDigestType(digestType repb.DigestFunction_Value) (hash.Hash, error) {
+	switch digestType {
+	case repb.DigestFunction_SHA1:
+		return sha1.New(), nil
+	case repb.DigestFunction_SHA256:
+		return sha256.New(), nil
+	default:
+		return nil, status.UnimplementedErrorf("No support for digest type: %s", digestType)
+	}
+}
+
+func Type(d *repb.Digest) repb.DigestFunction_Value {
+	// TODO: determine this via enum in digest?
+	switch len(d.GetHash()) {
+	case 40:
+		return repb.DigestFunction_SHA1
+	case 32:
+		return repb.DigestFunction_MD5
+	case 64:
+		return repb.DigestFunction_SHA256
+	case 96:
+		return repb.DigestFunction_SHA384
+	case 128:
+		return repb.DigestFunction_SHA512
+	default:
+		return repb.DigestFunction_UNKNOWN
+	}
+}
+
+func IsEmpty(d *repb.Digest) bool {
+	digestType := Type(d)
+	switch digestType {
+	case repb.DigestFunction_SHA1:
+		return d.GetHash() == "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+	case repb.DigestFunction_MD5:
+		return d.GetHash() == "d41d8cd98f00b204e9800998ecf8427e"
+	case repb.DigestFunction_SHA256:
+		return d.GetHash() == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	case repb.DigestFunction_SHA384:
+		return d.GetHash() == "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+	case repb.DigestFunction_SHA512:
+		return d.GetHash() == "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+	default:
+		return false
+	}
+}
+
+func Compute(in io.Reader, digestType repb.DigestFunction_Value) (*repb.Digest, error) {
+	h, err := HashForDigestType(digestType)
+	if err != nil {
+		return nil, err
+	}
+
 	// Read file in 32KB chunks (default)
 	n, err := io.Copy(h, in)
 	if err != nil {
@@ -356,7 +443,7 @@ func MissingDigestError(d *repb.Digest) error {
 
 func Parse(str string) (*repb.Digest, error) {
 	dParts := strings.SplitN(str, "/", 2)
-	if len(dParts) != 2 || len(dParts[0]) != 64 {
+	if len(dParts) != 2 {
 		return nil, status.FailedPreconditionErrorf("Error parsing digest %q: should be of form 'f31e59431cdc5d631853e28151fb664f859b5f4c5dc94f0695408a6d31b84724/142'", str)
 	}
 	i, err := strconv.ParseInt(dParts[1], 10, 64)
@@ -489,7 +576,7 @@ func (g *Generator) RandomDigestReader(sizeBytes int64) (*repb.Digest, io.ReadSe
 	readSeeker := bytes.NewReader(buf.Bytes())
 
 	// Compute a digest for the random bytes.
-	d, err := Compute(readSeeker)
+	d, err := Compute(readSeeker, repb.DigestFunction_SHA256)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -69,6 +69,16 @@ func TestParseResourceName(t *testing.T) {
 			matcher:      uploadRegex,
 			wantParsed:   newZstdResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "instance_name"),
 		},
+		{ // action
+			resourceName: "instance_name/blobs/ac/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+			matcher:      actionCacheRegex,
+			wantParsed:   NewResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "instance_name"),
+		},
+		{ // invalid action
+			resourceName: "instance_name/blobs/notac/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
+			matcher:      actionCacheRegex,
+			wantError:    status.InvalidArgumentError(""),
+		},
 	}
 	for _, tc := range cases {
 		gotParsed, gotErr := parseResourceName(tc.resourceName, tc.matcher)

--- a/server/test/integration/remote_asset/remote_asset_test.go
+++ b/server/test/integration/remote_asset/remote_asset_test.go
@@ -87,7 +87,7 @@ func serveArchive(t *testing.T, contents map[string]string) (*repb.Digest, *url.
 	testshell.Run(t, ws, "tar czf archive.tar.gz $(find . -type f)")
 	b, err := os.ReadFile(filepath.Join(ws, "archive.tar.gz"))
 	require.NoError(t, err)
-	d, err := digest.Compute(bytes.NewReader(b))
+	d, err := digest.Compute(bytes.NewReader(b), repb.DigestFunction_SHA256)
 	require.NoError(t, err)
 	u := testhttp.StartServer(t, http.FileServer(http.Dir(ws)))
 	u.Path = "/archive.tar.gz"
@@ -97,7 +97,7 @@ func serveArchive(t *testing.T, contents map[string]string) (*repb.Digest, *url.
 func serveFile(t *testing.T, content string) (*repb.Digest, *url.URL) {
 	ws := testfs.MakeTempDir(t)
 	testfs.WriteAllFileContents(t, ws, map[string]string{"file.txt": content})
-	d, err := digest.Compute(strings.NewReader(content))
+	d, err := digest.Compute(strings.NewReader(content), repb.DigestFunction_SHA256)
 	require.NoError(t, err)
 	u := testhttp.StartServer(t, http.FileServer(http.Dir(ws)))
 	u.Path = "/file.txt"

--- a/server/testutil/testdigest/testdigest.go
+++ b/server/testutil/testdigest/testdigest.go
@@ -38,7 +38,7 @@ func NewRandomDigestBuf(t testing.TB, sizeBytes int64) (*repb.Digest, []byte) {
 
 func ReadDigestAndClose(t *testing.T, r io.ReadCloser) *repb.Digest {
 	defer r.Close()
-	d, err := digest.Compute(r)
+	d, err := digest.Compute(r, repb.DigestFunction_SHA256)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Support multiple digest functions in remote cache functionality.

N.B. This does not yet add support for multiple remote execution digest functions; that's dependent on https://github.com/bazelbuild/remote-apis/pull/236 being merged and support being added to Bazel (https://github.com/bazelbuild/bazel/pull/16791).
