### PR TITLE
Fix "metadata mismatch" errors for duplicate non-inline CAS writes.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1775,10 +1775,14 @@ func (p *PebbleCache) Writer(ctx context.Context, r *resource.ResourceName) (int
 		defer unlockFn()
 
 		if oldMD, version, err := p.lookupFileMetadataAndVersion(ctx, iter, key); err == nil {
-			if err := p.deleteFileAndMetadata(ctx, key, version, oldMD); err != nil {
-				log.Errorf("Error deleting old record %q: %s", key.String(), err)
+			oldKeyBytes, err := key.Bytes(version)
+			if err != nil {
 				return err
 			}
+			if err := db.Delete(oldKeyBytes, pebble.NoSync); err != nil {
+				return err
+			}
+			p.sendSizeUpdate(oldMD.GetFileRecord().GetIsolation().GetPartitionId(), key.CacheType(), -1*oldMD.GetStoredSizeBytes())
 		}
 
 		keyBytes, err := key.Bytes(p.activeDatabaseVersion())


### PR DESCRIPTION
By the time CommitFn runs, the disk writer Commit function has already been called and has renamed the file causing us to delete the file we just wrote.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
