### PR TITLE
vmexec: increase sleep duration memory test

### DIFF
--- a/enterprise/server/vmexec/BUILD
+++ b/enterprise/server/vmexec/BUILD
@@ -22,6 +22,7 @@ go_library(
 go_test(
     name = "vmexec_test",
     srcs = ["vmexec_test.go"],
+    flaky = True,
     deps = [
         ":vmexec",
         "//enterprise/server/remote_execution/commandutil",

--- a/enterprise/server/vmexec/vmexec_test.go
+++ b/enterprise/server/vmexec/vmexec_test.go
@@ -77,7 +77,7 @@ func TestExecStreamed_Stdio(t *testing.T) {
 func TestExecStreamed_Stats(t *testing.T) {
 	wd := testfs.MakeTempDir(t)
 	testfs.WriteAllFileContents(t, wd, map[string]string{
-		"mem.py": useMemPythonScript(1e9, 1*time.Second),
+		"mem.py": useMemPythonScript(1e9, 3*time.Second),
 		"cpu.py": useCPUPythonScript(1 * time.Second),
 	})
 	client := startExecService(t)


### PR DESCRIPTION
When this test action is executed in an Executor that is under a heavy load, the polling mechanism we use to monitor resource consumption of the vm could be delayed and thus, reporting inaccurate results.

This is hard to reproduce as our executors autoscale on Kubernetes. This is also low critical as we are currently not using this metric for any billing-related functionality.

De-flake the test for now by increasing the sleep duration. Also, mark the test as flaky to notify future maintainers of this issue.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
