### PR TITLE
Have executor request re-enqueue as part of closing the lease.

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1409,7 +1409,7 @@ func (s *SchedulerServer) LeaseTask(stream scpb.Scheduler_LeaseTaskServer) error
 			}
 		}
 
-		done := req.GetFinalize() || req.GetRelease()
+		done := req.GetFinalize() || req.GetRelease() || req.GetReEnqueue()
 
 		if req.GetFinalize() && claimed {
 			// Finalize deletes the task (and implicitly releases the lease).
@@ -1422,8 +1422,10 @@ func (s *SchedulerServer) LeaseTask(stream scpb.Scheduler_LeaseTaskServer) error
 			} else {
 				log.CtxWarningf(ctx, "Could not delete claimed task %q: %s", taskID, err)
 			}
-		} else if req.GetRelease() && claimed {
+		} else if (req.GetRelease() || req.GetReEnqueue()) && claimed {
 			// Release removes the claim on the task without deleting the task.
+			// "release" was deprecated in favor of "reEnqueue" but remains
+			// for backwards compatibility with older executors.
 
 			err := s.unclaimTask(ctx, taskID)
 			if err == nil {
@@ -1431,6 +1433,12 @@ func (s *SchedulerServer) LeaseTask(stream scpb.Scheduler_LeaseTaskServer) error
 				log.CtxInfof(ctx, "LeaseTask task %q successfully released by %q", taskID, executorID)
 			} else {
 				log.CtxWarningf(ctx, "Could not release lease for task %q: %s", taskID, err)
+			}
+
+			if req.GetReEnqueue() {
+				if _, err := s.ReEnqueueTask(ctx, &scpb.ReEnqueueTaskRequest{TaskId: taskID, Reason: req.GetReEnqueueReason().GetMessage()}); err != nil {
+					log.CtxErrorf(ctx, "LeaseTask %q tried to re-enqueue task requested by executor but failed with err: %s", taskID, err)
+				}
 			}
 		}
 

--- a/enterprise/server/scheduling/task_leaser/BUILD
+++ b/enterprise/server/scheduling/task_leaser/BUILD
@@ -13,5 +13,6 @@ go_library(
         "//server/util/log",
         "//server/util/status",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//status",
     ],
 )

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -476,6 +476,7 @@ proto_library(
         ":context_proto",
         ":trace_proto",
         "@com_google_protobuf//:timestamp_proto",
+        "@go_googleapis//google/rpc:status_proto",
     ],
 )
 
@@ -978,6 +979,7 @@ go_proto_library(
         ":acl_go_proto",
         ":context_go_proto",
         ":trace_go_proto",
+        "@go_googleapis//google/rpc:status_go_proto",
     ],
 )
 

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "google/rpc/status.proto";
 import "google/protobuf/timestamp.proto";
 import "proto/acl.proto";
 import "proto/context.proto";
@@ -24,6 +25,7 @@ message LeaseTaskRequest {
   // Mutually exclusive with `release`.
   bool finalize = 2;
 
+  // DEPRECATED
   // Indicates that the lease should be released without finalizing (deleting)
   // the task.
   // Mutually exclusive with `finalize`.
@@ -31,6 +33,13 @@ message LeaseTaskRequest {
 
   // ID of the executor making the request.
   string executor_id = 4;
+
+  // Indicates that the leased task could not be run to completion and should
+  // be re-enqueued to be retried.
+  bool re_enqueue = 5;
+  // Optional description of why the task needs to be re-enqueued (may be
+  // visible to end user).
+  google.rpc.Status re_enqueue_reason = 6;
 }
 
 message LeaseTaskResponse {


### PR DESCRIPTION
Previously it was possible for a task to get stuck in limbo if the executor succesfully released the lease but was not able to contact the scheduler to re-enqueue the task.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
