### PR TITLE
bazel: fix //enterprise package visibility

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@bazel_gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "nogo")
 load("@npm//@bazel/typescript:index.bzl", "ts_config")
 load("//rules/go:index.bzl", "go_sdk_tool")
@@ -42,6 +42,11 @@ nogo(
     ],
 )
 
+gazelle_binary(
+    name = "bb_gazelle_binary",
+    languages = DEFAULT_LANGUAGES + ["@bazel_gazelle//language/bazel/visibility:go_default_library"],
+)
+
 # Ignore the node_modules dir
 # gazelle:exclude node_modules
 # Ignore generated proto files
@@ -56,7 +61,10 @@ nogo(
 # gazelle:exclude **/node_modules/**
 # TODO(siggisim): remove once we support .css imports properly
 # gazelle:exclude website/**
-gazelle(name = "gazelle")
+gazelle(
+    name = "gazelle",
+    gazelle = ":bb_gazelle_binary",
+)
 
 # Example usage: "bazel run //:gofmt -- -w ."
 go_sdk_tool(

--- a/enterprise/BUILD
+++ b/enterprise/BUILD
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+# gazelle:default_visibility //enterprise:__subpackages__
 package(default_visibility = ["//enterprise:__subpackages__"])
 
 filegroup(

--- a/enterprise/app/BUILD.bazel
+++ b/enterprise/app/BUILD.bazel
@@ -36,7 +36,6 @@ esbuild(
         ":fastbuild": False,
         "//conditions:default": True,
     }),
-    visibility = ["//visibility:public"],
     deps = [
         ":app",
     ],
@@ -73,7 +72,6 @@ genrule(
         done;
         cat out > $@;
     """,
-    visibility = ["//visibility:public"],
 )
 
 sha(
@@ -82,7 +80,6 @@ sha(
         ":style.css",
         "//enterprise/app:app_bundle",
     ],
-    visibility = ["//visibility:public"],
 )
 
 ts_library(

--- a/enterprise/deployment/BUILD
+++ b/enterprise/deployment/BUILD
@@ -61,3 +61,5 @@ container_push(
     tag_file = "//deployment:image_tag_file",
     tags = ["manual"],
 )
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/dockerfiles/rbe-ubuntu20-04-workflows/BUILD
+++ b/enterprise/dockerfiles/rbe-ubuntu20-04-workflows/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/BUILD
+++ b/enterprise/server/BUILD
@@ -2,3 +2,5 @@ alias(
     name = "server",
     actual = "//enterprise/server/cmd/server:buildbuddy",
 )
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/backends/kms/BUILD
+++ b/enterprise/server/backends/kms/BUILD
@@ -1,9 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-package(default_visibility = [
-    "//enterprise:__subpackages__",
-    "//tools:__subpackages__",
-])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(
     name = "kms",

--- a/enterprise/server/backends/redis_execution_collector/BUILD
+++ b/enterprise/server/backends/redis_execution_collector/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "redis_execution_collector",
     srcs = ["redis_execution_collector.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_execution_collector",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
         "//proto:stored_invocation_go_proto",

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -2,12 +2,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(
     name = "executor_lib",
     srcs = ["executor.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/executor",
+    visibility = ["//enterprise/server/cmd/executor/yaml_doc:__pkg__"],
     deps = [
         "//enterprise:bundle",
         "//enterprise/server/auth",

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(
     name = "server_lib",

--- a/enterprise/server/image_converter/BUILD
+++ b/enterprise/server/image_converter/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(
     name = "image_converter_lib",

--- a/enterprise/server/invocation_stat_service/config/BUILD
+++ b/enterprise/server/invocation_stat_service/config/BUILD
@@ -1,8 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+package(default_visibility = [
+    "//enterprise:__subpackages__",
+    "//server/static:__pkg__",
+])
+
 go_library(
     name = "config",
     srcs = ["config.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/invocation_stat_service/config",
-    visibility = ["//visibility:public"],
 )

--- a/enterprise/server/invocation_stat_service/config/BUILD
+++ b/enterprise/server/invocation_stat_service/config/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+# TODO(sluongng): ensure all //enterprise code are not dependency of FOSS code
+# gazelle:default_visibility //enterprise:__subpackages__,//server/static:__pkg__
 package(default_visibility = [
     "//enterprise:__subpackages__",
     "//server/static:__pkg__",

--- a/enterprise/server/remote_execution/config/BUILD
+++ b/enterprise/server/remote_execution/config/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+# TODO(sluongng): ensure all //enterprise code are not dependency of FOSS code
+# gazelle:default_visibility //enterprise:__subpackages__,//server/buildbuddy_server:__pkg__,//server/static:__pkg__,//server/telemetry:__pkg__
 package(default_visibility = [
     "//enterprise:__subpackages__",
     "//server/buildbuddy_server:__pkg__",

--- a/enterprise/server/remote_execution/container/BUILD
+++ b/enterprise/server/remote_execution/container/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+# TODO(sluongng): ensure all //enterprise code are not dependency of FOSS code
+# gazelle:default_visibility //enterprise:__subpackages__,//tools/vmstart:__pkg__
 package(default_visibility = [
     "//enterprise:__subpackages__",
     "//tools/vmstart:__pkg__",

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+# TODO(sluongng): ensure all //enterprise code are not dependency of FOSS code
+# gazelle:default_visibility //enterprise:__subpackages__,//tools/vmstart:__pkg__
 package(default_visibility = [
     "//enterprise:__subpackages__",
     "//tools/vmstart:__pkg__",

--- a/enterprise/server/remote_execution/dirtools/BUILD
+++ b/enterprise/server/remote_execution/dirtools/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+# TODO(sluongng): ensure all //enterprise code are not dependency of FOSS code
+# gazelle:default_visibility //enterprise:__subpackages__,//cli/remotebazel:__pkg__
 package(default_visibility = [
     "//cli/remotebazel:__pkg__",
     "//enterprise:__subpackages__",

--- a/enterprise/server/remote_execution/filecache/BUILD
+++ b/enterprise/server/remote_execution/filecache/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+# TODO(sluongng): ensure all //enterprise code are not dependency of FOSS code
+# gazelle:default_visibility //enterprise:__subpackages__,//tools/vmstart:__pkg__
 package(default_visibility = [
     "//enterprise:__subpackages__",
     "//tools/vmstart:__pkg__",

--- a/enterprise/server/remote_execution/runner/testworker/BUILD
+++ b/enterprise/server/remote_execution/runner/testworker/BUILD
@@ -1,6 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
-package(default_visibility = ["//enterprise/server/remote_execution/runner:__subpackages__"])
+# gazelle:default_visibility //enterprise/server/remote_execution/runner:__subpackages__
+package(default_visibility = [
+    "//enterprise:__subpackages__",
+    "//enterprise/server/remote_execution/runner:__subpackages__",
+])
 
 go_library(
     name = "testworker_lib",

--- a/enterprise/server/remote_execution/vfs/BUILD
+++ b/enterprise/server/remote_execution/vfs/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(
     name = "vfs",

--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -1,6 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-package(default_visibility = ["//enterprise:__subpackages__"])
+# TODO(sluongng): ensure all //enterprise code are not dependency of FOSS code
+# gazelle:default_visibility //enterprise:__subpackages__,//server/static:__pkg__
+package(default_visibility = [
+    "//enterprise:__subpackages__",
+    "//server/static:__pkg__",
+])
 
 go_library(
     name = "scheduler_server",

--- a/enterprise/server/tasksize/BUILD
+++ b/enterprise/server/tasksize/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(
     name = "tasksize",

--- a/enterprise/server/test/integration/build_logs/BUILD
+++ b/enterprise/server/test/integration/build_logs/BUILD
@@ -17,3 +17,5 @@ go_test(
         "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/test/integration/invocation_webhook/BUILD
+++ b/enterprise/server/test/integration/invocation_webhook/BUILD
@@ -20,3 +20,5 @@ go_test(
         "@org_golang_google_protobuf//encoding/protojson",
     ],
 )
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/test/integration/remote_cache/BUILD
+++ b/enterprise/server/test/integration/remote_cache/BUILD
@@ -20,3 +20,5 @@ go_test(
         "@org_golang_google_protobuf//encoding/prototext",
     ],
 )
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/test/integration/remote_execution/BUILD
+++ b/enterprise/server/test/integration/remote_execution/BUILD
@@ -41,3 +41,5 @@ go_test(
         "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/test/integration/remote_execution/bazel_rbe/BUILD
+++ b/enterprise/server/test/integration/remote_execution/bazel_rbe/BUILD
@@ -17,3 +17,5 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/test/integration/remote_execution/proto/BUILD
+++ b/enterprise/server/test/integration/remote_execution/proto/BUILD
@@ -1,7 +1,12 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
-package(default_visibility = ["//enterprise/server/test/integration/remote_execution:__subpackages__"])
+# TODO(sluongng): ensure all //enterprise code are not dependency of FOSS code
+# gazelle:default_visibility //enterprise/server/test/integration/remote_execution:__subpackages__
+package(default_visibility = [
+    "//enterprise:__subpackages__",
+    "//enterprise/server/test/integration/remote_execution:__subpackages__",
+])
 
 proto_library(
     name = "remoteexecutiontest_proto",

--- a/enterprise/server/test/integration/remote_execution/rbeclient/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+# TODO(sluongng): ensure all //enterprise code are not dependency of FOSS code
+# gazelle:default_visibility //enterprise:__subpackages__,//tools/rbeperf:__pkg__
 package(default_visibility = [
     "//enterprise:__subpackages__",
     "//tools/rbeperf:__pkg__",

--- a/enterprise/server/test/integration/workflow/BUILD
+++ b/enterprise/server/test/integration/workflow/BUILD
@@ -33,3 +33,5 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/test/performance/cache/BUILD
+++ b/enterprise/server/test/performance/cache/BUILD
@@ -23,3 +23,5 @@ go_test(
         "//server/util/prefix",
     ],
 )
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/test/webdriver/BUILD
+++ b/enterprise/server/test/webdriver/BUILD
@@ -2,3 +2,5 @@
 # and let it manage deps for existing go_web_test_suite rules.
 
 # gazelle:map_kind go_test go_web_test_suite //rules/webdriver:index.bzl
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/test/webdriver/invocation/BUILD
+++ b/enterprise/server/test/webdriver/invocation/BUILD
@@ -13,3 +13,5 @@ go_web_test_suite(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/testutil/testredis/BUILD
+++ b/enterprise/server/testutil/testredis/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+# TODO(sluongng): ensure all //enterprise code are not dependency of FOSS code
+# gazelle:default_visibility //enterprise:__subpackages__,//server/util/dsingleflight:__pkg__
 package(default_visibility = [
     "//enterprise:__subpackages__",
     "//server/util/dsingleflight:__pkg__",

--- a/enterprise/server/util/execution/BUILD
+++ b/enterprise/server/util/execution/BUILD
@@ -11,3 +11,5 @@ go_library(
         "//server/tables",
     ],
 )
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/util/execution/BUILD
+++ b/enterprise/server/util/execution/BUILD
@@ -4,7 +4,7 @@ go_library(
     name = "execution",
     srcs = ["execution.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/execution",
-    visibility = ["//visibility:public"],
+    visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//proto:remote_execution_go_proto",
         "//proto:stored_invocation_go_proto",

--- a/enterprise/server/util/vfs_server/BUILD
+++ b/enterprise/server/util/vfs_server/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(
     name = "vfs_server",

--- a/enterprise/server/util/vsock/BUILD
+++ b/enterprise/server/util/vsock/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+# TODO(sluongng): ensure all //enterprise code are not dependency of FOSS code
+# gazelle:default_visibility //enterprise:__subpackages__,//tools/vmexec_client:__pkg__
 package(default_visibility = [
     "//enterprise:__subpackages__",
     "//tools/vmexec_client:__pkg__",

--- a/enterprise/server/webhooks/bitbucket/test_data/BUILD
+++ b/enterprise/server/webhooks/bitbucket/test_data/BUILD
@@ -1,6 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-package(default_visibility = ["//enterprise/server/webhooks/bitbucket:__subpackages__"])
+# gazelle:default_visibility //enterprise/server/webhooks/bitbucket:__subpackages__
+package(default_visibility = [
+    "//enterprise:__subpackages__",
+    "//enterprise/server/webhooks/bitbucket:__subpackages__",
+])
 
 go_library(
     name = "test_data",

--- a/enterprise/server/webhooks/github/test_data/BUILD
+++ b/enterprise/server/webhooks/github/test_data/BUILD
@@ -1,6 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-package(default_visibility = ["//enterprise/server/webhooks/github:__subpackages__"])
+# gazelle:default_visibility //enterprise/server/webhooks/github:__subpackages__
+package(default_visibility = [
+    "//enterprise:__subpackages__",
+    "//enterprise/server/webhooks/github:__subpackages__",
+])
 
 go_library(
     name = "test_data",

--- a/enterprise/server/workflow/config/test_data/BUILD
+++ b/enterprise/server/workflow/config/test_data/BUILD
@@ -1,6 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-package(default_visibility = ["//enterprise/server/workflow/config:__subpackages__"])
+# gazelle:default_visibility //enterprise/server/workflow/config:__subpackages__
+package(default_visibility = [
+    "//enterprise:__subpackages__",
+    "//enterprise/server/workflow/config:__subpackages__",
+])
 
 go_library(
     name = "test_data",

--- a/enterprise/tools/check_metrics/BUILD
+++ b/enterprise/tools/check_metrics/BUILD
@@ -23,5 +23,5 @@ go_library(
 go_binary(
     name = "check_metrics",
     embed = [":check_metrics_lib"],
-    visibility = ["//visibility:public"],
+    visibility = ["//enterprise:__subpackages__"],
 )

--- a/enterprise/tools/check_metrics/BUILD
+++ b/enterprise/tools/check_metrics/BUILD
@@ -25,3 +25,5 @@ go_binary(
     embed = [":check_metrics_lib"],
     visibility = ["//enterprise:__subpackages__"],
 )
+
+package(default_visibility = ["//enterprise:__subpackages__"])


### PR DESCRIPTION
We organize `//enterprise/...` code to have a different license compare to
code in `//... -//enterprise/...`. Yet, there are packages outside of
`enterprise` dir that depends on the code inside `enterprise` directory.

This PR is the first step in correcting that problem. Ensure that all
code within `//enterprise/...` has a strict visibility set to
`//enterprise:__subpackages__`. Exceptions are strictly stated so that
we could query for them in the future and apply appropriate refactoring.

Before this PR
```
> bazel query 'visible(//..., //enterprise/...)' | wc -l
29
```

After this PR
```
> bazel query 'visible(//..., //enterprise/...)' | wc -l
4
```

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
