### PR TITLE
sandbox_test: fix broken test

### DIFF
--- a/enterprise/server/remote_execution/containers/sandbox/BUILD
+++ b/enterprise/server/remote_execution/containers/sandbox/BUILD
@@ -28,7 +28,6 @@ go_test(
         ":sandbox",
         "//enterprise/server/remote_execution/container",
         "//proto:remote_execution_go_proto",
-        "//server/config",
         "//server/testutil/testfs",
         "@com_github_stretchr_testify//assert",
     ],

--- a/enterprise/server/remote_execution/containers/sandbox/sandbox_test.go
+++ b/enterprise/server/remote_execution/containers/sandbox/sandbox_test.go
@@ -2,7 +2,6 @@ package sandbox_test
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 	"testing"
@@ -10,7 +9,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/sandbox"
-	"github.com/buildbuddy-io/buildbuddy/server/config"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/stretchr/testify/assert"
 
@@ -18,10 +16,6 @@ import (
 )
 
 func makeTempDirWithWorldTxt(t *testing.T) string {
-	rootDirFlag := flag.Lookup("executor.root_directory")
-	if rootDirFlag == nil {
-		t.Fatal("Missing --executor.root_directory flag.")
-	}
 	dir := testfs.MakeTempDir(t)
 
 	f, err := os.Create(fmt.Sprintf("%s/world.txt", dir))
@@ -38,16 +32,15 @@ func makeTempDirWithWorldTxt(t *testing.T) string {
 
 func TestSandboxedHelloWorld(t *testing.T) {
 	ctx := context.Background()
-	config.RegisterAndParseFlags()
 	tempDir := makeTempDirWithWorldTxt(t)
 	cmd := &repb.Command{
 		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
-			&repb.Command_EnvironmentVariable{Name: "GREETING", Value: "Hello"},
+			{Name: "GREETING", Value: "Hello"},
 		},
 		Arguments: []string{"sh", "-c", fmt.Sprintf("printf \"$GREETING $(cat %s/world.txt)!\"", tempDir)},
 		Platform: &repb.Platform{
 			Properties: []*repb.Platform_Property{
-				&repb.Platform_Property{
+				{
 					Name:  "container-image",
 					Value: "none",
 				},
@@ -74,7 +67,6 @@ func TestSandboxedHelloWorld(t *testing.T) {
 
 func TestCrossContainerReads(t *testing.T) {
 	ctx := context.Background()
-	config.RegisterAndParseFlags()
 	tempDir1 := makeTempDirWithWorldTxt(t)
 	goodCmd := &repb.Command{
 		Arguments: []string{"ls", tempDir1},


### PR DESCRIPTION
`config.RegisterAndParseFlags()` has been removed since #1938 so this
test has been failing to compile for quite some times.

```
enterprise/server/remote_execution/containers/sandbox/sandbox_test.go:41:9: undefined: config.RegisterAndParseFlags
enterprise/server/remote_execution/containers/sandbox/sandbox_test.go:77:9: undefined: config.RegisterAndParseFlags
```

`//server/config` is now auto initialized on startup so let's remote the
rootDirFlag check all together.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
