### PR TITLE
Have user-owned keys flag control key auth and API

### DIFF
--- a/enterprise/server/backends/authdb/BUILD
+++ b/enterprise/server/backends/authdb/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/authdb",
     deps = [
         "//proto:group_go_proto",
+        "//server/environment",
         "//server/interfaces",
         "//server/tables",
         "//server/util/db",
@@ -28,6 +29,7 @@ go_test(
         "//server/util/db",
         "//server/util/role",
         "//server/util/status",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/role"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -320,6 +321,7 @@ func createRandomAPIKeys(t *testing.T, ctx context.Context, env environment.Env)
 }
 
 func setupEnv(t *testing.T) environment.Env {
+	flags.Set(t, "app.user_owned_keys_enabled", true)
 	env := enterprise_testenv.New(t)
 	enterprise_testauth.Configure(t, env) // provisions AuthDB and UserDB
 	return env

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -38,6 +38,7 @@ var (
 	addUserToDomainGroup = flag.Bool("app.add_user_to_domain_group", false, "Cloud-Only")
 	createGroupPerUser   = flag.Bool("app.create_group_per_user", false, "Cloud-Only")
 	noDefaultUserGroup   = flag.Bool("app.no_default_user_group", false, "Cloud-Only")
+	userOwnedKeysEnabled = flag.Bool("app.user_owned_keys_enabled", false, "If true, enable user-owned API keys.")
 
 	orgName   = flag.String("org.name", "Organization", "The name of your organization, which is displayed on your organization's build history.")
 	orgDomain = flag.String("org.domain", "", "Your organization's email domain. If this is set, only users with email addresses in this domain will be able to register for a BuildBuddy account.")
@@ -248,7 +249,14 @@ func (d *UserDB) CreateAPIKey(ctx context.Context, groupID string, label string,
 	return createAPIKey(d.h.DB(ctx), "" /*=userID*/, groupID, newAPIKeyToken(), label, caps, visibleToDevelopers)
 }
 
+func (d *UserDB) GetUserOwnedKeysEnabled() bool {
+	return *userOwnedKeysEnabled
+}
+
 func (d *UserDB) GetUserAPIKeys(ctx context.Context, groupID string) ([]*tables.APIKey, error) {
+	if !*userOwnedKeysEnabled {
+		return nil, status.UnimplementedError("not implemented")
+	}
 	if groupID == "" {
 		return nil, status.InvalidArgumentError("Group ID cannot be empty.")
 	}
@@ -298,6 +306,9 @@ func (d *UserDB) GetUserAPIKeys(ctx context.Context, groupID string) ([]*tables.
 }
 
 func (d *UserDB) CreateUserAPIKey(ctx context.Context, groupID, label string, capabilities []akpb.ApiKey_Capability) (*tables.APIKey, error) {
+	if !*userOwnedKeysEnabled {
+		return nil, status.UnimplementedError("not implemented")
+	}
 	if groupID == "" {
 		return nil, status.InvalidArgumentError("Group ID cannot be nil.")
 	}

--- a/enterprise/server/backends/userdb/userdb_test.go
+++ b/enterprise/server/backends/userdb/userdb_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func newTestEnv(t *testing.T) *testenv.TestEnv {
+	flags.Set(t, "app.user_owned_keys_enabled", true)
 	env := enterprise_testenv.New(t)
 	enterprise_testauth.Configure(t, env)
 	return env

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -105,7 +105,7 @@ func configureFilesystemsOrDie(realEnv *real_environment.RealEnv) {
 // source main() entry point and the enterprise main() entry point, both of
 // which import from libmain.go.
 func convertToProdOrDie(ctx context.Context, env *real_environment.RealEnv) {
-	env.SetAuthDB(authdb.NewAuthDB(env.GetDBHandle()))
+	env.SetAuthDB(authdb.NewAuthDB(env, env.GetDBHandle()))
 	configureFilesystemsOrDie(env)
 
 	if err := auth.Register(ctx, env); err != nil {

--- a/enterprise/server/testutil/enterprise_testenv/enterprise_testenv.go
+++ b/enterprise/server/testutil/enterprise_testenv/enterprise_testenv.go
@@ -52,6 +52,6 @@ func GetCustomTestEnv(t *testing.T, opts *Options) *testenv.TestEnv {
 		assert.FailNow(t, "could not create user DB", err.Error())
 	}
 	env.SetUserDB(userDB)
-	env.SetAuthDB(authdb.NewAuthDB(env.GetDBHandle()))
+	env.SetAuthDB(authdb.NewAuthDB(env, env.GetDBHandle()))
 	return env
 }

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -561,7 +561,7 @@ func (s *BuildBuddyServer) DeleteApiKey(ctx context.Context, req *akpb.DeleteApi
 
 func (s *BuildBuddyServer) GetUserApiKeys(ctx context.Context, req *akpb.GetApiKeysRequest) (*akpb.GetApiKeysResponse, error) {
 	userDB := s.env.GetUserDB()
-	if userDB == nil {
+	if userDB == nil || !userDB.GetUserOwnedKeysEnabled() {
 		return nil, status.UnimplementedError("Not Implemented")
 	}
 	groupID := req.GetGroupId()
@@ -586,7 +586,7 @@ func (s *BuildBuddyServer) GetUserApiKeys(ctx context.Context, req *akpb.GetApiK
 
 func (s *BuildBuddyServer) CreateUserApiKey(ctx context.Context, req *akpb.CreateApiKeyRequest) (*akpb.CreateApiKeyResponse, error) {
 	userDB := s.env.GetUserDB()
-	if userDB == nil {
+	if userDB == nil || !userDB.GetUserOwnedKeysEnabled() {
 		return nil, status.UnimplementedError("Not Implemented")
 	}
 	k, err := userDB.CreateUserAPIKey(ctx, req.GetGroupId(), req.GetLabel(), req.GetCapability())
@@ -607,7 +607,7 @@ func (s *BuildBuddyServer) CreateUserApiKey(ctx context.Context, req *akpb.Creat
 
 func (s *BuildBuddyServer) UpdateUserApiKey(ctx context.Context, req *akpb.UpdateApiKeyRequest) (*akpb.UpdateApiKeyResponse, error) {
 	userDB := s.env.GetUserDB()
-	if userDB == nil {
+	if userDB == nil || !userDB.GetUserOwnedKeysEnabled() {
 		return nil, status.UnimplementedError("Not Implemented")
 	}
 	updates := &tables.APIKey{
@@ -624,7 +624,7 @@ func (s *BuildBuddyServer) UpdateUserApiKey(ctx context.Context, req *akpb.Updat
 
 func (s *BuildBuddyServer) DeleteUserApiKey(ctx context.Context, req *akpb.DeleteApiKeyRequest) (*akpb.DeleteApiKeyResponse, error) {
 	userDB := s.env.GetUserDB()
-	if userDB == nil {
+	if userDB == nil || !userDB.GetUserOwnedKeysEnabled() {
 		return nil, status.UnimplementedError("Not Implemented")
 	}
 	if err := userDB.DeleteAPIKey(ctx, req.GetId()); err != nil {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -372,6 +372,9 @@ type UserDB interface {
 	// CreateAPIKey creates a group-level API key.
 	CreateAPIKey(ctx context.Context, groupID string, label string, capabilities []akpb.ApiKey_Capability, visibleToDevelopers bool) (*tables.APIKey, error)
 
+	// GetUserOwnedKeysEnabled returns whether user-owned keys are enabled.
+	GetUserOwnedKeysEnabled() bool
+
 	// GetUserAPIKeys returns all user-owned API keys within a group.
 	GetUserAPIKeys(ctx context.Context, groupID string) ([]*tables.APIKey, error)
 

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -37,7 +37,6 @@ var (
 	testGridV2Enabled          = flag.Bool("app.test_grid_v2_enabled", true, "Whether to enable test grid V2")
 	usageEnabled               = flag.Bool("app.usage_enabled", false, "If set, the usage page will be enabled in the UI.")
 	expandedSuggestionsEnabled = flag.Bool("app.expanded_suggestions_enabled", false, "If set, enable more build suggestions in the UI.")
-	userOwnedKeysEnabled       = flag.Bool("app.user_owned_keys_enabled", false, "If set, enable the UI controls for user-owned API keys.")
 	enableWorkflows            = flag.Bool("remote_execution.enable_workflows", false, "Whether to enable BuildBuddy workflows.")
 	enableExecutorKeyCreation  = flag.Bool("remote_execution.enable_executor_key_creation", false, "If enabled, UI will allow executor keys to be created.")
 	testOutputManifestsEnabled = flag.Bool("app.test_output_manifests_enabled", true, "If set, the target page will render the contents of test output zips.")
@@ -154,7 +153,7 @@ func serveIndexTemplate(env environment.Env, tpl *template.Template, version, js
 		QuotaManagementEnabled:        env.GetQuotaManager() != nil,
 		SecretsEnabled:                env.GetSecretService() != nil,
 		TestOutputManifestsEnabled:    *testOutputManifestsEnabled,
-		UserOwnedKeysEnabled:          *userOwnedKeysEnabled,
+		UserOwnedKeysEnabled:          env.GetUserDB() != nil && env.GetUserDB().GetUserOwnedKeysEnabled(),
 		TrendsHeatmapEnabled:          iss_config.TrendsHeatmapEnabled() && env.GetOLAPDBHandle() != nil,
 	}
 


### PR DESCRIPTION
The `app.enable_user_owned_keys` flag would previously only control whether the settings UI is enabled.

This PR makes it so that the flag controls whether the API is enabled, as well as whether user-owned keys can be used to authenticate.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
