### PR TITLE
Fix CI runner duplicate stderr logging

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -467,7 +467,7 @@ func run() error {
 
 	// Write setup logs to the current task's stderr (to make debugging easier),
 	// and also to the invocation.
-	ws.log = io.MultiWriter(os.Stderr, buildEventReporter)
+	ws.log = buildEventReporter
 	ws.hostname, ws.username = getHostAndUserName()
 
 	// Change the current working directory to respect WORKDIR_OVERRIDE, if set.

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -464,9 +464,9 @@ func run() error {
 	if err != nil {
 		return err
 	}
-
-	// Write setup logs to the current task's stderr (to make debugging easier),
-	// and also to the invocation.
+	// Note: logs written to the buildEventReporter will be written as
+	// invocation progress events as well as written to the workflow action's
+	// stderr.
 	ws.log = buildEventReporter
 	ws.hostname, ws.username = getHostAndUserName()
 


### PR DESCRIPTION
`buildEventReporter` already copies all writes to `os.Stderr` since it wraps an `invocationLog` which sets up an stderr `MultiWriter` [here](https://cs.github.com/buildbuddy-io/buildbuddy/blob/90a109254b9a39a175b0712b17cb4b7ee626b231/enterprise/server/cmd/ci_runner/main.go#L666). So by setting up `ws.log` as `io.MultiWriter(os.Stderr, buildEventReporter)`, we are effectively duplicating the writes to stderr, resulting in confusing output. This PR fixes that.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
