### PR TITLE
Firecracker: improve `--debug_stream_command_outputs` behavior

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -84,6 +84,7 @@ var (
 	contextBasedShutdown      = flag.Bool("executor.context_based_shutdown_enabled", false, "Whether to remove runners using context cancelation. This is a transitional flag that will be removed in a future executor version.")
 	podmanEnableStats         = flag.Bool("executor.podman.enable_stats", false, "Whether to enable cgroup-based podman stats.")
 	bareEnableStats           = flag.Bool("executor.bare.enable_stats", false, "Whether to enable stats for bare command execution.")
+	firecrackerDebugMode      = flag.Bool("executor.firecracker_debug_mode", false, "Run firecracker in debug mode, printing VM logs to the terminal.")
 )
 
 const (
@@ -1075,7 +1076,7 @@ func (p *pool) newContainerImpl(ctx context.Context, props *platform.Properties,
 			InitDockerd:            props.InitDockerd,
 			JailerRoot:             p.buildRoot,
 			AllowSnapshotStart:     false,
-			DebugMode:              *commandutil.DebugStreamCommandOutputs,
+			DebugMode:              *firecrackerDebugMode,
 		}
 		c, err := firecracker.NewContainer(p.env, p.imageCacheAuth, opts)
 		if err != nil {

--- a/enterprise/server/remote_execution/vmexec_client/vmexec_client.go
+++ b/enterprise/server/remote_execution/vmexec_client/vmexec_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
@@ -41,6 +42,10 @@ func Execute(ctx context.Context, client vmxpb.ExecClient, cmd *repb.Command, wo
 	stderrw := io.Writer(&stderr)
 	if stdio.Stderr != nil {
 		stderrw = stdio.Stderr
+	}
+	if *commandutil.DebugStreamCommandOutputs {
+		stdoutw = io.MultiWriter(os.Stdout, stdoutw)
+		stderrw = io.MultiWriter(os.Stderr, stderrw)
 	}
 	req := &vmxpb.ExecRequest{
 		WorkingDirectory: workDir,


### PR DESCRIPTION
In https://github.com/buildbuddy-io/buildbuddy/pull/1611, `--debug_stream_command_outputs` was repurposed to start the VM in debug mode. Debug mode streams the VM logs to the terminal, but does not actually stream any output from the commands executed (I'm not sure if this was always the case or if it broke at some point).

This PR makes 2 changes:

* Now that we have stdout/stderr streaming (in `vmexec_client.go`), `--debug_stream_command_outputs` can actually stream the command stderr/stdout (which is the original intent of the flag).
* Instead of enabling debug mode whenever `--debug_stream_command_outputs` is enabled, this PR adds a separate flag `--executor.firecracker_debug_mode` to explicitly enable debug mode. The main reason for this change is that debug mode hijacks the TTY so that Ctrl+C is handled by the VM instead of the executor, and you have to quit the whole terminal emulator to kill the executor, which is super annoying.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
