### PR TITLE
[POC] Support arbitrary workflow steps

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -8,8 +8,10 @@ actions:
       pull_request:
         branches:
           - "master"
-    bazel_commands:
-      - test //... --config=workflows --test_tag_filters=-performance,-webdriver,-docker
+    steps:
+      - run: echo 'Hello world!'
+      - bazel: test //... --config=workflows --test_tag_filters=-performance,-webdriver,-docker
+      - run: echo 'Hello again!'
   - name: Test (darwin_amd64)
     os: "darwin"
     triggers:

--- a/enterprise/server/workflow/config/BUILD
+++ b/enterprise/server/workflow/config/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/config",
     deps = [
         "//enterprise/server/webhooks/webhook_data",
+        "//server/util/status",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )


### PR DESCRIPTION
Adds support for workflow steps which can contain arbitrary bash scripts as well as bazel commands. See `buildbuddy.yaml` for the config syntax.

This is just an experiment, but if we feel this is worth adding, I can polish it up and add tests.

Some TODOs:
* What to do if the user writes `run: bazel test //...` (tries to run bazel as a bash script step) instead of `bazel: test //...` (runs bazel with our supported bazelrc / output base / metadata args etc.)? Do we want to just make these fail for now (i.e. link `bazel` in PATH to a script that fails and prints an error), or should we try to write a bazel wrapper in PATH which somehow links the bazel invocations to the parent workflow?
* Display the script commands in the UI a little better (don't link to an invocation 404 page)

![image](https://user-images.githubusercontent.com/2414826/223508116-7d9ad6c2-b5ed-4cf8-8db4-bcb38669ff28.png)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
