### PR TITLE
make invocation and trend services use pattern filter fields when specified

### DIFF
--- a/enterprise/server/invocation_search_service/invocation_search_service.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service.go
@@ -129,6 +129,9 @@ func (s *InvocationSearchService) QueryInvocations(ctx context.Context, req *inp
 	if command := req.GetQuery().GetCommand(); command != "" {
 		q.AddWhereClause("i.command = ?", command)
 	}
+	if pattern := req.GetQuery().GetPattern(); pattern != "" {
+		q.AddWhereClause("i.pattern = ?", pattern)
+	}
 	if sha := req.GetQuery().GetCommitSha(); sha != "" {
 		q.AddWhereClause("i.commit_sha = ?", sha)
 	}

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -163,6 +163,10 @@ func addWhereClauses(q *query_builder.Query, tq *stpb.TrendQuery, reqCtx *ctxpb.
 		q.AddWhereClause("command = ?", command)
 	}
 
+	if pattern := tq.GetPattern(); pattern != "" {
+		q.AddWhereClause("pattern = ?", pattern)
+	}
+
 	if commitSHA := tq.GetCommitSha(); commitSHA != "" {
 		q.AddWhereClause("commit_sha = ?", commitSHA)
 	}
@@ -723,6 +727,10 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 
 	if command := req.GetQuery().GetCommand(); command != "" {
 		q.AddWhereClause("command = ?", command)
+	}
+
+	if pattern := req.GetQuery().GetPattern(); pattern != "" {
+		q.AddWhereClause("pattern = ?", pattern)
 	}
 
 	if commitSHA := req.GetQuery().GetCommitSha(); commitSHA != "" {


### PR DESCRIPTION
planning to just handle flag-guarding client-side, let me know if you feel otherwise.