### PR TITLE
Change default type from false -> 0

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -200,7 +200,7 @@ type Group struct {
 	Model
 
 	SharingEnabled       bool `gorm:"default:1;type:tinyint(1)"`
-	UserOwnedKeysEnabled bool `gorm:"not null;default:false;type:tinyint(1)"`
+	UserOwnedKeysEnabled bool `gorm:"not null;default:0;type:tinyint(1)"`
 
 	// If enabled, builds for this group will always use their own executors instead of the installation-wide shared
 	// executors.


### PR DESCRIPTION
When running the script to detect schema changes, I noticed that the mysql db was always running `ALTER TABLE `Groups` MODIFY COLUMN `user_owned_keys_enabled` tinyint(1) NOT NULL DEFAULT false`. This is because it thought that the default value type was changing from false to 0 (triggering [this](https://github.com/go-gorm/gorm/blob/master/migrator/migrator.go#L510)).

The boolean is represented as a tiny-int, so false is stored as 0 anyway