### PR TITLE
Respect user key capabilities set by admins

### DIFF
--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -377,6 +377,7 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
                     onChange={this.onChangeCASOnly.bind(this, request, onChange)}
                     checked={isCASOnly(request)}
                     disabled={!this.canChangeCapabilities()}
+                    debug-id="cas-only-radio-button"
                   />
                   <span>
                     CAS-only key <span className="field-description">(disable action cache uploads)</span>

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -344,7 +344,7 @@ func (d *UserDB) CreateUserAPIKey(ctx context.Context, groupID, label string, ca
 			return status.PermissionDeniedErrorf("group %q does not have user-owned keys enabled", groupID)
 		}
 
-		key, err := createAPIKey(tx, u.GetUserID(), groupID, newAPIKeyToken(), label, userAPIKeyCapabilities, false /*=visibleToDevelopers*/)
+		key, err := createAPIKey(tx, u.GetUserID(), groupID, newAPIKeyToken(), label, capabilities, false /*=visibleToDevelopers*/)
 		if err != nil {
 			return err
 		}

--- a/enterprise/server/backends/userdb/userdb_test.go
+++ b/enterprise/server/backends/userdb/userdb_test.go
@@ -1119,6 +1119,10 @@ func TestUserOwnedKeys_CreateAndUpdateCapabilities(t *testing.T) {
 				ctx1, g.GroupID, "US1's key", test.Capabilities)
 			if test.OK {
 				require.NoError(t, err)
+				// Read back the capabilities, make sure they took effect.
+				key, err := udb.GetAPIKey(ctx1, key.APIKeyID)
+				require.NoError(t, err)
+				require.Equal(t, capabilities.ToInt(test.Capabilities), key.Capabilities)
 			} else {
 				require.Truef(
 					t, status.IsPermissionDeniedError(err),
@@ -1136,6 +1140,10 @@ func TestUserOwnedKeys_CreateAndUpdateCapabilities(t *testing.T) {
 			err = udb.UpdateAPIKey(ctx1, key)
 			if test.OK {
 				require.NoError(t, err)
+				// Capabilities should not have changed.
+				key, err := udb.GetAPIKey(ctx1, key.APIKeyID)
+				require.NoError(t, err)
+				require.Equal(t, capabilities.ToInt(test.Capabilities), key.Capabilities)
 			} else {
 				require.Truef(
 					t, status.IsPermissionDeniedError(err),

--- a/enterprise/server/test/webdriver/invocation/invocation_test.go
+++ b/enterprise/server/test/webdriver/invocation/invocation_test.go
@@ -146,7 +146,7 @@ func TestAuthenticatedInvocation_PersonalAPIKey_CacheEnabled(t *testing.T) {
 		wt.Find(`.organization-form-submit-button`).Click()
 		wt.Find(`.form-success-message`)
 	}
-	// Create a personal API key
+	// Create a personal API key with CAS-only permissions
 	wt.Find(`[href="/settings/personal/api-keys"]`).Click()
 	existingKeys := wt.FindAll(`.api-key-value`)
 	apiKey := ""
@@ -155,6 +155,7 @@ func TestAuthenticatedInvocation_PersonalAPIKey_CacheEnabled(t *testing.T) {
 	} else {
 		wt.FindByDebugID("create-new-api-key").Click()
 		wt.Find(`.dialog-wrapper [name="label"]`).SendKeys("test-personal-key")
+		wt.FindByDebugID("cas-only-radio-button").Click()
 		wt.Find(`.dialog-wrapper button[type="submit"]`).Click()
 		apiKey = wt.Find(`.api-key-value`).Text()
 	}


### PR DESCRIPTION
When admins set Read+Write capabilities in the UI, we were silently ignoring these requested capabilities and writing CAS-only to the DB. This PR fixes that.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
