### PR TITLE
Make executor key type a radio selection instead of checkbox

### DIFF
--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -238,67 +238,27 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
     onChange(e.target.name, e.target.value);
   }
 
-  private onChangeCapability<T extends ApiKeyFields>(
-    request: T,
-    capability: api_key.ApiKey.Capability,
-    enabled: boolean,
-    onChange: (name: string, value: any) => any
-  ) {
-    request.capability ??= [];
-    if (enabled) {
-      request.capability.push(capability);
-    } else {
-      request.capability = request.capability.filter((cap) => cap !== capability);
-    }
-    onChange("capability", request.capability);
+  private onSelectReadOnly(onChange: (name: string, value: any) => any) {
+    onChange("capability", []);
   }
 
-  private onChangeReadOnly<T extends ApiKeyFields>(
-    request: T,
-    onChange: (name: string, value: any) => any,
-    e: React.ChangeEvent<HTMLInputElement>
-  ) {
-    this.onChangeCapability(request, api_key.ApiKey.Capability.CACHE_WRITE_CAPABILITY, false, onChange);
-    this.onChangeCapability(request, api_key.ApiKey.Capability.CAS_WRITE_CAPABILITY, false, onChange);
+  private onSelectCASOnly(onChange: (name: string, value: any) => any) {
+    onChange("capability", [api_key.ApiKey.Capability.CAS_WRITE_CAPABILITY]);
   }
 
-  private onChangeCASOnly<T extends ApiKeyFields>(
-    request: T,
-    onChange: (name: string, value: any) => any,
-    e: React.ChangeEvent<HTMLInputElement>
-  ) {
-    this.onChangeCapability(request, api_key.ApiKey.Capability.CACHE_WRITE_CAPABILITY, false, onChange);
-    this.onChangeCapability(request, api_key.ApiKey.Capability.CAS_WRITE_CAPABILITY, true, onChange);
+  private onSelectReadWrite(onChange: (name: string, value: any) => any) {
+    onChange("capability", [api_key.ApiKey.Capability.CACHE_WRITE_CAPABILITY]);
   }
 
-  private onChangeReadWrite<T extends ApiKeyFields>(
-    request: T,
-    onChange: (name: string, value: any) => any,
-    e: React.ChangeEvent<HTMLInputElement>
-  ) {
-    this.onChangeCapability(request, api_key.ApiKey.Capability.CACHE_WRITE_CAPABILITY, true, onChange);
-    this.onChangeCapability(request, api_key.ApiKey.Capability.CAS_WRITE_CAPABILITY, false, onChange);
-  }
-
-  private onChangeVisibility<T extends ApiKeyFields>(
-    request: T,
-    onChange: (name: string, value: any) => any,
-    e: React.ChangeEvent<HTMLInputElement>
-  ) {
-    onChange("visibleToDevelopers", e.target.checked);
-  }
-
-  private onChangeRegisterExecutor<T extends ApiKeyFields>(
-    request: T,
-    onChange: (name: string, value: any) => any,
-    e: React.ChangeEvent<HTMLInputElement>
-  ) {
-    this.onChangeCapability(
-      request,
+  private onSelectExecutor(onChange: (name: string, value: any) => any) {
+    onChange("capability", [
+      api_key.ApiKey.Capability.CACHE_WRITE_CAPABILITY,
       api_key.ApiKey.Capability.REGISTER_EXECUTOR_CAPABILITY,
-      e.target.checked,
-      onChange
-    );
+    ]);
+  }
+
+  private onChangeVisibility(onChange: (name: string, value: any) => any, e: React.ChangeEvent<HTMLInputElement>) {
+    onChange("visibleToDevelopers", e.target.checked);
   }
 
   private canChangeCapabilities(): boolean {
@@ -348,7 +308,7 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
                 <label className="checkbox-row">
                   <input
                     type="radio"
-                    onChange={this.onChangeReadWrite.bind(this, request, onChange)}
+                    onChange={this.onSelectReadWrite.bind(this, onChange)}
                     checked={isReadWrite(request)}
                     disabled={!this.canChangeCapabilities()}
                   />
@@ -361,7 +321,7 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
                 <label className="checkbox-row">
                   <input
                     type="radio"
-                    onChange={this.onChangeReadOnly.bind(this, request, onChange)}
+                    onChange={this.onSelectReadOnly.bind(this, onChange)}
                     checked={isReadOnly(request)}
                     disabled={!this.canChangeCapabilities()}
                   />
@@ -374,7 +334,7 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
                 <label className="checkbox-row">
                   <input
                     type="radio"
-                    onChange={this.onChangeCASOnly.bind(this, request, onChange)}
+                    onChange={this.onSelectCASOnly.bind(this, onChange)}
                     checked={isCASOnly(request)}
                     disabled={!this.canChangeCapabilities()}
                   />
@@ -388,9 +348,9 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
                 <div className="field-container">
                   <label className="checkbox-row">
                     <input
-                      type="checkbox"
-                      onChange={this.onChangeRegisterExecutor.bind(this, request, onChange)}
-                      checked={hasCapability(request, api_key.ApiKey.Capability.REGISTER_EXECUTOR_CAPABILITY)}
+                      type="radio"
+                      onChange={this.onSelectExecutor.bind(this, onChange)}
+                      checked={isExecutorKey(request)}
                       disabled={!this.canChangeCapabilities()}
                     />
                     <span>
@@ -405,7 +365,7 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
                   <label className="checkbox-row">
                     <input
                       type="checkbox"
-                      onChange={this.onChangeVisibility.bind(this, request, onChange)}
+                      onChange={this.onChangeVisibility.bind(this, onChange)}
                       checked={request.visibleToDevelopers}
                     />
                     <span>
@@ -561,35 +521,45 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
   }
 }
 
-function hasCapability<T extends ApiKeyFields>(apiKey: T | null, capability: api_key.ApiKey.Capability) {
-  return Boolean(apiKey?.capability?.some((existingCapability) => existingCapability === capability));
+function capabilitiesToInt(capabilities: api_key.ApiKey.Capability[]): number {
+  let out = 0;
+  for (const capability of capabilities) {
+    out |= capability;
+  }
+  return out;
+}
+
+function hasExactCapabilities<T extends ApiKeyFields>(apiKey: T | null, capabilities: api_key.ApiKey.Capability[]) {
+  return capabilitiesToInt(apiKey?.capability || []) === capabilitiesToInt(capabilities);
 }
 
 function isReadWrite<T extends ApiKeyFields>(apiKey: T | null) {
-  return hasCapability(apiKey, api_key.ApiKey.Capability.CACHE_WRITE_CAPABILITY);
+  return hasExactCapabilities(apiKey, [api_key.ApiKey.Capability.CACHE_WRITE_CAPABILITY]);
 }
 
 function isCASOnly<T extends ApiKeyFields>(apiKey: T | null) {
-  return hasCapability(apiKey, api_key.ApiKey.Capability.CAS_WRITE_CAPABILITY);
+  return hasExactCapabilities(apiKey, [api_key.ApiKey.Capability.CAS_WRITE_CAPABILITY]);
+}
+
+function isExecutorKey<T extends ApiKeyFields>(apiKey: T | null) {
+  return hasExactCapabilities(apiKey, [
+    api_key.ApiKey.Capability.CACHE_WRITE_CAPABILITY,
+    api_key.ApiKey.Capability.REGISTER_EXECUTOR_CAPABILITY,
+  ]);
 }
 
 function isReadOnly<T extends ApiKeyFields>(apiKey: T | null) {
-  return (
-    !hasCapability(apiKey, api_key.ApiKey.Capability.CACHE_WRITE_CAPABILITY) &&
-    !hasCapability(apiKey, api_key.ApiKey.Capability.CAS_WRITE_CAPABILITY)
-  );
+  return hasExactCapabilities(apiKey, []);
 }
 
 function describeCapabilities<T extends ApiKeyFields>(apiKey: T) {
   let capabilities = "Read+Write";
   if (isReadOnly(apiKey)) {
     capabilities = "Read-only";
-  }
-  if (isCASOnly(apiKey)) {
+  } else if (isCASOnly(apiKey)) {
     capabilities = "CAS-only";
-  }
-  if (hasCapability(apiKey, api_key.ApiKey.Capability.REGISTER_EXECUTOR_CAPABILITY)) {
-    capabilities += "+Executor";
+  } else if (isExecutorKey(apiKey)) {
+    capabilities = "Executor";
   }
   if (apiKey.visibleToDevelopers) {
     capabilities += " [D]";


### PR DESCRIPTION
Executor keys must have CACHE_WRITE_CAPABILITY, otherwise they cannot upload AC results. So make the executor key type a radio selection rather than a checkbox attribute, to ensure that CACHE_WRITE_CAPABILITY is always applied. Also simplify the code a bunch.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
