### PR TITLE
Disallow creating user-owned executor keys

### DIFF
--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -385,7 +385,8 @@ export default class ApiKeysComponent extends React.Component<ApiKeysComponentPr
                 </label>
               </div>
 
-              {capabilities.executorKeyCreation && (
+              {/* User-owned keys cannot be used to register executors. */}
+              {capabilities.executorKeyCreation && !this.props.userOwnedOnly && (
                 <div className="field-container">
                   <label className="checkbox-row">
                     <input

--- a/enterprise/server/backends/userdb/userdb_test.go
+++ b/enterprise/server/backends/userdb/userdb_test.go
@@ -1094,7 +1094,7 @@ func TestUserOwnedKeys_CreateAndUpdateCapabilities(t *testing.T) {
 		{Name: "Developer_CASWrite_OK", Role: role.Developer, Capabilities: []akpb.ApiKey_Capability{akpb.ApiKey_CAS_WRITE_CAPABILITY}, OK: true},
 		{Name: "Admin_ACWrite_OK", Role: role.Admin, Capabilities: []akpb.ApiKey_Capability{akpb.ApiKey_CACHE_WRITE_CAPABILITY}, OK: true},
 		{Name: "Developer_ACWrite_Fail", Role: role.Developer, Capabilities: []akpb.ApiKey_Capability{akpb.ApiKey_CACHE_WRITE_CAPABILITY}, OK: false},
-		{Name: "Admin_Executor_OK", Role: role.Admin, Capabilities: []akpb.ApiKey_Capability{akpb.ApiKey_REGISTER_EXECUTOR_CAPABILITY}, OK: true},
+		{Name: "Admin_Executor_Fail", Role: role.Admin, Capabilities: []akpb.ApiKey_Capability{akpb.ApiKey_REGISTER_EXECUTOR_CAPABILITY}, OK: false},
 		{Name: "Developer_Executor_Fail", Role: role.Developer, Capabilities: []akpb.ApiKey_Capability{akpb.ApiKey_REGISTER_EXECUTOR_CAPABILITY}, OK: false},
 	} {
 		t.Run(test.Name, func(t *testing.T) {


### PR DESCRIPTION
The semantics of these would be unclear (e.g. can other members of the org run builds on your user-owned executor?)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
