### PR TITLE
Fix edge cases with org join flow

### DIFF
--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -727,7 +727,10 @@ func (d *UserDB) RequestToJoinGroup(ctx context.Context, groupID string) (grpb.G
 			return err
 		}
 		if existing != nil {
-			return status.AlreadyExistsError("You've already requested to join this organization.")
+			if existing.MembershipStatus == int32(grpb.GroupMembershipStatus_REQUESTED) {
+				return status.AlreadyExistsError("You've already requested to join this organization.")
+			}
+			return status.AlreadyExistsError("You're already in this organization.")
 		}
 		return tx.Create(&tables.UserGroup{
 			UserUserID:       userID,

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -112,10 +112,14 @@ func NewUserDB(env environment.Env, h interfaces.DBHandle) (*UserDB, error) {
 }
 
 func (d *UserDB) GetGroupByID(ctx context.Context, groupID string) (*tables.Group, error) {
+	return d.getGroupByID(d.h.DB(ctx), groupID)
+}
+
+func (d *UserDB) getGroupByID(tx *db.DB, groupID string) (*tables.Group, error) {
 	if groupID == "" {
 		return nil, status.InvalidArgumentError("Group ID cannot be empty.")
 	}
-	query := d.h.DB(ctx).Raw(`SELECT * FROM `+"`Groups`"+` AS g WHERE g.group_id = ?`, groupID)
+	query := tx.Raw(`SELECT * FROM `+"`Groups`"+` AS g WHERE g.group_id = ?`, groupID)
 	group := &tables.Group{}
 	if err := query.Take(group).Error; err != nil {
 		if db.IsRecordNotFound(err) {
@@ -560,7 +564,7 @@ func (d *UserDB) createGroup(ctx context.Context, tx *db.DB, userID string, g *t
 	if err != nil {
 		return "", err
 	}
-	if err = d.addUserToGroup(ctx, tx, userID, groupID); err != nil {
+	if err = d.addUserToGroup(tx, userID, groupID); err != nil {
 		return "", err
 	}
 	return groupID, nil
@@ -639,38 +643,17 @@ func (d *UserDB) DeleteGroupGitHubToken(ctx context.Context, groupID string) err
 }
 
 func (d *UserDB) AddUserToGroup(ctx context.Context, userID string, groupID string) error {
-	if err := d.authorizeGroupAdminRole(ctx, groupID); err != nil {
-		return err
-	}
 	return d.h.Transaction(ctx, func(tx *db.DB) error {
-		return d.addUserToGroup(ctx, tx, userID, groupID)
+		return d.addUserToGroup(tx, userID, groupID)
 	})
 }
 
-func (d *UserDB) addUserToGroup(ctx context.Context, tx *db.DB, userID, groupID string) error {
-	existing, err := getUserGroup(tx, userID, groupID)
-	if err != nil && !db.IsRecordNotFound(err) {
-		return err
-	}
-	if existing != nil {
-		if existing.MembershipStatus == int32(grpb.GroupMembershipStatus_REQUESTED) {
-			return tx.Exec(`
-				UPDATE UserGroups
-				SET membership_status = ?
-				WHERE user_user_id = ?
-				AND group_group_id = ?
-				`,
-				grpb.GroupMembershipStatus_MEMBER,
-				userID,
-				groupID,
-			).Error
-		}
-		return status.AlreadyExistsError("You're already in this organization.")
-	}
+func (d *UserDB) addUserToGroup(tx *db.DB, userID, groupID string) error {
 	row := &struct{ Count int64 }{}
-	err = tx.Raw(
-		"SELECT COUNT(*) AS count FROM UserGroups WHERE group_group_id = ?", groupID,
-	).Take(row).Error
+	err := tx.Raw(`
+		SELECT COUNT(*) AS count FROM UserGroups
+		WHERE group_group_id = ? AND membership_status = ?
+	`, groupID, grpb.GroupMembershipStatus_MEMBER).Take(row).Error
 	if err != nil {
 		return err
 	}
@@ -679,37 +662,82 @@ func (d *UserDB) addUserToGroup(ctx context.Context, tx *db.DB, userID, groupID 
 	if row.Count == 0 {
 		r = role.Admin
 	}
+
+	existing, err := getUserGroup(tx, userID, groupID)
+	if err != nil && !db.IsRecordNotFound(err) {
+		return err
+	}
+	if existing != nil {
+		if existing.MembershipStatus == int32(grpb.GroupMembershipStatus_REQUESTED) {
+			return tx.Exec(`
+				UPDATE UserGroups
+				SET membership_status = ?, role = ?
+				WHERE user_user_id = ?
+				AND group_group_id = ?
+				`,
+				grpb.GroupMembershipStatus_MEMBER,
+				r,
+				userID,
+				groupID,
+			).Error
+		}
+		return status.AlreadyExistsError("You're already in this organization.")
+	}
 	return tx.Exec(
 		"INSERT INTO UserGroups (user_user_id, group_group_id, membership_status, role) VALUES(?, ?, ?, ?)",
 		userID, groupID, int32(grpb.GroupMembershipStatus_MEMBER), r,
 	).Error
 }
 
-func (d *UserDB) RequestToJoinGroup(ctx context.Context, userID string, groupID string) error {
+func (d *UserDB) RequestToJoinGroup(ctx context.Context, groupID string) (grpb.GroupMembershipStatus, error) {
+	u, err := perms.AuthenticatedUser(ctx, d.env)
+	if err != nil {
+		return 0, err
+	}
+	userID := u.GetUserID()
 	if userID == "" {
-		return status.InvalidArgumentError("User ID is required.")
+		return 0, status.InvalidArgumentError("User ID is required.")
 	}
 	if groupID == "" {
-		return status.InvalidArgumentError("Group ID is required.")
+		return 0, status.InvalidArgumentError("Group ID is required.")
 	}
-	return d.h.Transaction(ctx, func(tx *db.DB) error {
+	var newStatus grpb.GroupMembershipStatus
+	err = d.h.Transaction(ctx, func(tx *db.DB) error {
+		tu, err := d.getUser(tx, u.GetUserID())
+		if err != nil {
+			return err
+		}
+		group, err := d.getGroupByID(tx, groupID)
+		if err != nil {
+			return err
+		}
+		// If the org has an owned domain that matches the user's email,
+		// the user can join directly as a member.
+		newStatus = grpb.GroupMembershipStatus_REQUESTED
+		if group.OwnedDomain != "" && group.OwnedDomain == getEmailDomain(tu.Email) {
+			newStatus = grpb.GroupMembershipStatus_MEMBER
+			return d.addUserToGroup(tx, userID, groupID)
+		}
+
+		// Check if there's an existing request and return AlreadyExists if so.
 		existing, err := getUserGroup(tx, userID, groupID)
 		if err != nil {
 			return err
 		}
-		if existing == nil {
-			return tx.Create(&tables.UserGroup{
-				UserUserID:       userID,
-				GroupGroupID:     groupID,
-				Role:             uint32(role.Default),
-				MembershipStatus: int32(grpb.GroupMembershipStatus_REQUESTED),
-			}).Error
-		}
-		if existing.MembershipStatus == int32(grpb.GroupMembershipStatus_REQUESTED) {
+		if existing != nil {
 			return status.AlreadyExistsError("You've already requested to join this organization.")
 		}
-		return status.AlreadyExistsError("You're already in this organization.")
+		return tx.Create(&tables.UserGroup{
+			UserUserID:       userID,
+			GroupGroupID:     groupID,
+			Role:             uint32(role.Default),
+			MembershipStatus: int32(newStatus),
+		}).Error
 	})
+	if err != nil {
+		return 0, err
+	}
+	return newStatus, nil
 }
 
 func (d *UserDB) GetGroupUsers(ctx context.Context, groupID string, statuses []grpb.GroupMembershipStatus) ([]*grpb.GetGroupUsersResponse_GroupUser, error) {
@@ -796,13 +824,7 @@ func (d *UserDB) UpdateGroupUsers(ctx context.Context, groupID string, updates [
 					return err
 				}
 			case grpb.UpdateGroupUsersRequest_Update_ADD:
-				if err := tx.Exec(`
-						UPDATE UserGroups
-						SET membership_status = ?
-						WHERE user_user_id = ? AND group_group_id = ?`,
-					int32(grpb.GroupMembershipStatus_MEMBER),
-					update.GetUserId().GetId(),
-					groupID).Error; err != nil {
+				if err := d.addUserToGroup(tx, update.GetUserId().GetId(), groupID); err != nil {
 					return err
 				}
 			case grpb.UpdateGroupUsersRequest_Update_UNKNOWN_MEMBERSHIP_ACTION:
@@ -987,61 +1009,67 @@ func (d *UserDB) GetUser(ctx context.Context) (*tables.User, error) {
 	if err != nil {
 		return nil, err
 	}
-	user := &tables.User{}
+	var user *tables.User
 	err = d.h.Transaction(ctx, func(tx *db.DB) error {
-		userRow := tx.Raw(`SELECT * FROM Users WHERE user_id = ?`, u.GetUserID())
-		if err := userRow.Take(user).Error; err != nil {
-			return err
-		}
-		groupRows, err := tx.Raw(`
-			SELECT
-				g.user_id,
-				g.group_id,
-				g.url_identifier,
-				g.name,
-				g.owned_domain,
-				g.github_token,
-				g.sharing_enabled,
-				g.user_owned_keys_enabled,
-				g.use_group_owned_executors,
-				g.saml_idp_metadata_url,
-				g.suggestion_preference,
-				ug.role
-			FROM `+"`Groups`"+` as g
-			JOIN UserGroups as ug
-			ON g.group_id = ug.group_group_id
-			WHERE ug.user_user_id = ? AND ug.membership_status = ?
-		`, u.GetUserID(), int32(grpb.GroupMembershipStatus_MEMBER)).Rows()
-		if err != nil {
-			return err
-		}
-		defer groupRows.Close()
-		for groupRows.Next() {
-			gr := &tables.GroupRole{}
-			err := groupRows.Scan(
-				// NOTE: When updating the group fields here, update GetImpersonatedUser
-				// as well.
-				&gr.Group.UserID,
-				&gr.Group.GroupID,
-				&gr.Group.URLIdentifier,
-				&gr.Group.Name,
-				&gr.Group.OwnedDomain,
-				&gr.Group.GithubToken,
-				&gr.Group.SharingEnabled,
-				&gr.Group.UserOwnedKeysEnabled,
-				&gr.Group.UseGroupOwnedExecutors,
-				&gr.Group.SamlIdpMetadataUrl,
-				&gr.Group.SuggestionPreference,
-				&gr.Role,
-			)
-			if err != nil {
-				return err
-			}
-			user.Groups = append(user.Groups, gr)
-		}
-		return nil
+		user, err = d.getUser(tx, u.GetUserID())
+		return err
 	})
 	return user, err
+}
+
+func (d *UserDB) getUser(tx *db.DB, userID string) (*tables.User, error) {
+	user := &tables.User{}
+	userRow := tx.Raw(`SELECT * FROM Users WHERE user_id = ?`, userID)
+	if err := userRow.Take(user).Error; err != nil {
+		return nil, err
+	}
+	groupRows, err := tx.Raw(`
+		SELECT
+			g.user_id,
+			g.group_id,
+			g.url_identifier,
+			g.name,
+			g.owned_domain,
+			g.github_token,
+			g.sharing_enabled,
+			g.user_owned_keys_enabled,
+			g.use_group_owned_executors,
+			g.saml_idp_metadata_url,
+			g.suggestion_preference,
+			ug.role
+		FROM `+"`Groups`"+` as g
+		JOIN UserGroups as ug
+		ON g.group_id = ug.group_group_id
+		WHERE ug.user_user_id = ? AND ug.membership_status = ?
+	`, userID, int32(grpb.GroupMembershipStatus_MEMBER)).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer groupRows.Close()
+	for groupRows.Next() {
+		gr := &tables.GroupRole{}
+		err := groupRows.Scan(
+			// NOTE: When updating the group fields here, update GetImpersonatedUser
+			// as well.
+			&gr.Group.UserID,
+			&gr.Group.GroupID,
+			&gr.Group.URLIdentifier,
+			&gr.Group.Name,
+			&gr.Group.OwnedDomain,
+			&gr.Group.GithubToken,
+			&gr.Group.SharingEnabled,
+			&gr.Group.UserOwnedKeysEnabled,
+			&gr.Group.UseGroupOwnedExecutors,
+			&gr.Group.SamlIdpMetadataUrl,
+			&gr.Group.SuggestionPreference,
+			&gr.Role,
+		)
+		if err != nil {
+			return nil, err
+		}
+		user.Groups = append(user.Groups, gr)
+	}
+	return user, nil
 }
 
 func (d *UserDB) GetImpersonatedUser(ctx context.Context) (*tables.User, error) {
@@ -1161,4 +1189,12 @@ func hasAdminOnlyCapabilities(capabilities []akpb.ApiKey_Capability) bool {
 		}
 	}
 	return false
+}
+
+func getEmailDomain(email string) string {
+	chunks := strings.Split(email, "@")
+	if len(chunks) == 0 {
+		return ""
+	}
+	return chunks[len(chunks)-1]
 }

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -442,27 +442,9 @@ func (s *BuildBuddyServer) JoinGroup(ctx context.Context, req *grpb.JoinGroupReq
 	if auth == nil || userDB == nil {
 		return nil, status.UnimplementedError("Not Implemented")
 	}
-	user, err := userDB.GetUser(ctx)
-	if err != nil {
+	if _, err := userDB.RequestToJoinGroup(ctx, req.GetId()); err != nil {
 		return nil, err
 	}
-	group, err := userDB.GetGroupByID(ctx, req.GetId())
-	if err != nil {
-		return nil, err
-	}
-	// If the user's email matches the group's owned domain, they can be added
-	// as a member immediately.
-	if group.OwnedDomain != "" && group.OwnedDomain == getEmailDomain(user.Email) {
-		if err := userDB.AddUserToGroup(ctx, user.UserID, req.GetId()); err != nil {
-			return nil, err
-		}
-	} else {
-		// Otherwise submit a request to join the group.
-		if err := userDB.RequestToJoinGroup(ctx, user.UserID, req.GetId()); err != nil {
-			return nil, err
-		}
-	}
-
 	return &grpb.JoinGroupResponse{}, nil
 }
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -343,8 +343,15 @@ type UserDB interface {
 	InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (string, error)
 	GetGroupByID(ctx context.Context, groupID string) (*tables.Group, error)
 	GetGroupByURLIdentifier(ctx context.Context, urlIdentifier string) (*tables.Group, error)
-	AddUserToGroup(ctx context.Context, userID string, groupID string) error
-	RequestToJoinGroup(ctx context.Context, userID string, groupID string) error
+
+	// RequestToJoinGroup performs an attempt for the authenticated user to join
+	// the given group. If the user email matches the group's owned domain, the
+	// user is immediately added to the group. Otherwise, a pending membership
+	// request is submitted. The return value is the user's new membership
+	// status within the group after the transaction is performed (either
+	// REQUESTED or MEMBER).
+	RequestToJoinGroup(ctx context.Context, groupID string) (grpb.GroupMembershipStatus, error)
+
 	GetGroupUsers(ctx context.Context, groupID string, statuses []grpb.GroupMembershipStatus) ([]*grpb.GetGroupUsersResponse_GroupUser, error)
 	UpdateGroupUsers(ctx context.Context, groupID string, updates []*grpb.UpdateGroupUsersRequest_Update) error
 	DeleteGroupGitHubToken(ctx context.Context, groupID string) error


### PR DESCRIPTION
:point_right: **Recommended:** [review with whitespace diff hidden](https://github.com/buildbuddy-io/buildbuddy/pull/3517/files?diff=split&w=1). (The UserDB diff is much cleaner this way) 

* Instead of `buildbuddy_server` performing multiple separate transactions to look up the group and decide whether to auto-join by domain association or submit a request to join the org, consolidate all of this logic into a single DB transaction in `RequestToJoinOrg`, and remove the `AddUserToGroup` func in UserDB.
* Fix edge case where `addUserToGroup` would not auto-promote to admin if the group was empty and there were existing membership requests which had not been approved.
* Fix edge case where we return PermissionDenied if users try to join an org after the org has claimed domain ownership and also after the user was created (this was because of the admin auth check in AddUserToGroup - this PR removes that func entirely).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
