### PR TITLE
Alias proto imports (including resource)

### DIFF
--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_handler"
 	"github.com/buildbuddy-io/buildbuddy/server/bytestream"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -30,6 +29,7 @@ import (
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
 	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	elpb "github.com/buildbuddy-io/buildbuddy/proto/eventlog"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 var (
@@ -407,7 +407,7 @@ func (s *APIServer) DeleteFile(ctx context.Context, req *apipb.DeleteFileRequest
 	}
 	urlStr := strings.TrimPrefix(parsedURL.RequestURI(), "/")
 
-	var resourceName *resource.ResourceName
+	var resourceName *rspb.ResourceName
 	if digest.IsActionCacheResourceName(urlStr) {
 		parsedRN, err := digest.ParseActionCacheResourceName(urlStr)
 		if err != nil {

--- a/enterprise/server/api/api_server_test.go
+++ b/enterprise/server/api/api_server_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/proto/api_key"
 	"github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_handler"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
@@ -25,6 +24,7 @@ import (
 	apipb "github.com/buildbuddy-io/buildbuddy/proto/api/v1"
 	bepb "github.com/buildbuddy-io/buildbuddy/proto/build_events"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 var userMap = testauth.TestUsers("user1", "group1")
@@ -251,9 +251,9 @@ func TestDeleteFile_CAS(t *testing.T) {
 
 	// Save file
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	if err := s.env.GetCache().Set(ctx, r, buf); err != nil {
 		t.Fatal(err)
@@ -285,9 +285,9 @@ func TestDeleteFile_AC(t *testing.T) {
 
 	// Save file
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_AC,
+		CacheType: rspb.CacheType_AC,
 	}
 	if err = env.GetCache().Set(ctx, r, buf); err != nil {
 		t.Fatal(err)
@@ -320,9 +320,9 @@ func TestDeleteFile_AC_RemoteInstanceName(t *testing.T) {
 	// Save file
 	remoteInstanceName := "remote/instance"
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:       d,
-		CacheType:    resource.CacheType_AC,
+		CacheType:    rspb.CacheType_AC,
 		InstanceName: remoteInstanceName,
 	}
 	if err = env.GetCache().Set(ctx, r, buf); err != nil {
@@ -354,9 +354,9 @@ func TestDeleteFile_NonExistentFile(t *testing.T) {
 
 	// Do not write data to the cache
 	d, _ := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 
 	casURI := fmt.Sprintf("blobs/%s/%d", d.GetHash(), d.GetSizeBytes())
@@ -382,9 +382,9 @@ func TestDeleteFile_LeadingSlash(t *testing.T) {
 
 	// Save file
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	if err = s.env.GetCache().Set(ctx, r, buf); err != nil {
 		t.Fatal(err)

--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/migration_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pebble_cache"
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/disk_cache"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -27,6 +26,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 const (
@@ -53,7 +53,7 @@ func getAnonContext(t *testing.T, env environment.Env) context.Context {
 
 // waitForCopy keeps checking the destination cache to see whether the background process has
 // copied the given digest over
-func waitForCopy(t *testing.T, ctx context.Context, destCache interfaces.Cache, r *resource.ResourceName) {
+func waitForCopy(t *testing.T, ctx context.Context, destCache interfaces.Cache, r *rspb.ResourceName) {
 	for delay := 50 * time.Millisecond; delay < 1*time.Minute; delay *= 2 {
 		contains, err := destCache.Contains(ctx, r)
 		require.NoError(t, err, "error calling contains on dest cache")
@@ -74,11 +74,11 @@ type errorCache struct {
 	interfaces.Cache
 }
 
-func (c *errorCache) Set(ctx context.Context, r *resource.ResourceName, data []byte) error {
+func (c *errorCache) Set(ctx context.Context, r *rspb.ResourceName, data []byte) error {
 	return errors.New("error cache set err")
 }
 
-func (c *errorCache) Get(ctx context.Context, r *resource.ResourceName) ([]byte, error) {
+func (c *errorCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error) {
 	return nil, errors.New("error cache get err")
 }
 
@@ -86,19 +86,19 @@ func (c *errorCache) DeleteDeprecated(ctx context.Context, d *repb.Digest) error
 	return errors.New("error cache delete err")
 }
 
-func (c *errorCache) Contains(ctx context.Context, r *resource.ResourceName) (bool, error) {
+func (c *errorCache) Contains(ctx context.Context, r *rspb.ResourceName) (bool, error) {
 	return false, errors.New("error cache contains err")
 }
 
-func (c *errorCache) Metadata(ctx context.Context, r *resource.ResourceName) (*interfaces.CacheMetadata, error) {
+func (c *errorCache) Metadata(ctx context.Context, r *rspb.ResourceName) (*interfaces.CacheMetadata, error) {
 	return nil, errors.New("error cache metadata err")
 }
 
-func (c *errorCache) Writer(ctx context.Context, r *resource.ResourceName) (interfaces.CommittedWriteCloser, error) {
+func (c *errorCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {
 	return nil, errors.New("error cache writer err")
 }
 
-func (c *errorCache) Reader(ctx context.Context, r *resource.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+func (c *errorCache) Reader(ctx context.Context, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
 	return nil, errors.New("error cache reader err")
 }
 
@@ -118,9 +118,9 @@ func TestACIsolation(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d1, buf1 := testdigest.NewRandomDigestBuf(t, 100)
-	r1 := &resource.ResourceName{
+	r1 := &rspb.ResourceName{
 		Digest:    d1,
-		CacheType: resource.CacheType_AC,
+		CacheType: rspb.CacheType_AC,
 	}
 	require.NoError(t, mc.Set(ctx, r1, buf1))
 
@@ -129,9 +129,9 @@ func TestACIsolation(t *testing.T) {
 	require.Equal(t, buf1, got1)
 
 	// Data should not be in CAS cache
-	gotCAS, err := mc.Get(ctx, &resource.ResourceName{
+	gotCAS, err := mc.Get(ctx, &rspb.ResourceName{
 		Digest:    d1,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	})
 	require.True(t, status.IsNotFoundError(err))
 	require.Nil(t, gotCAS)
@@ -151,9 +151,9 @@ func TestACIsolation_RemoteInstanceName(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d1, buf1 := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:       d1,
-		CacheType:    resource.CacheType_AC,
+		CacheType:    rspb.CacheType_AC,
 		InstanceName: "remote",
 	}
 	require.NoError(t, mc.Set(ctx, r, buf1))
@@ -163,9 +163,9 @@ func TestACIsolation_RemoteInstanceName(t *testing.T) {
 	require.Equal(t, buf1, got1)
 
 	// Data should not be in CAS cache
-	gotCAS, err := mc.Get(ctx, &resource.ResourceName{
+	gotCAS, err := mc.Get(ctx, &rspb.ResourceName{
 		Digest:       d1,
-		CacheType:    resource.CacheType_CAS,
+		CacheType:    rspb.CacheType_CAS,
 		InstanceName: "remote",
 	})
 	require.True(t, status.IsNotFoundError(err))
@@ -186,9 +186,9 @@ func TestSet_DoubleWrite(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = mc.Set(ctx, r, buf)
 	require.NoError(t, err)
@@ -216,9 +216,9 @@ func TestSet_DestWriteErr(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = mc.Set(ctx, r, buf)
 	require.NoError(t, err)
@@ -240,9 +240,9 @@ func TestSet_SrcWriteErr(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = mc.Set(ctx, r, buf)
 	require.Error(t, err)
@@ -263,9 +263,9 @@ func TestSet_SrcAndDestWriteErr(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err := mc.Set(ctx, r, buf)
 	require.Error(t, err)
@@ -289,9 +289,9 @@ func TestGetSet(t *testing.T) {
 	}
 	for _, testSize := range testSizes {
 		d, buf := testdigest.NewRandomDigestBuf(t, testSize)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 		err = mc.Set(ctx, r, buf)
 		require.NoError(t, err, "error setting digest in cache")
@@ -319,9 +319,9 @@ func TestGet_DoubleRead(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{DoubleReadPercentage: 1.0}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = mc.Set(ctx, r, buf)
 	require.NoError(t, err)
@@ -344,17 +344,17 @@ func TestGet_DestReadErr(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{DoubleReadPercentage: 1.0}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = mc.Set(ctx, r, buf)
 	require.NoError(t, err)
 
 	// Should return data from src cache without error
-	data, err := mc.Get(ctx, &resource.ResourceName{
+	data, err := mc.Get(ctx, &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	})
 	require.NoError(t, err)
 	require.True(t, bytes.Equal(buf, data))
@@ -374,17 +374,17 @@ func TestGet_SrcReadErr(t *testing.T) {
 
 	// Write data to dest cache only
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = destCache.Set(ctx, r, buf)
 	require.NoError(t, err)
 
 	// Should return error
-	data, err := mc.Get(ctx, &resource.ResourceName{
+	data, err := mc.Get(ctx, &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	})
 	require.Error(t, err)
 	require.Nil(t, data)
@@ -405,16 +405,16 @@ func TestGetSet_EmptyData(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{DoubleReadPercentage: 1.0}, srcCache, destCache)
 
 	d, _ := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = mc.Set(ctx, r, []byte{})
 	require.NoError(t, err)
 
-	data, err := mc.Get(ctx, &resource.ResourceName{
+	data, err := mc.Get(ctx, &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	})
 	require.NoError(t, err)
 	require.True(t, bytes.Equal([]byte{}, data))
@@ -446,9 +446,9 @@ func TestCopyDataInBackground(t *testing.T) {
 	for i := 0; i < numTests; i++ {
 		eg.Go(func() error {
 			d, buf := testdigest.NewRandomDigestBuf(t, 100)
-			r := &resource.ResourceName{
+			r := &rspb.ResourceName{
 				Digest:    d,
-				CacheType: resource.CacheType_CAS,
+				CacheType: rspb.CacheType_CAS,
 			}
 			lock.Lock()
 			defer lock.Unlock()
@@ -495,9 +495,9 @@ func TestCopyDataInBackground_ExceedsCopyChannelSize(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		eg.Go(func() error {
 			d, buf := testdigest.NewRandomDigestBuf(t, 100)
-			r := &resource.ResourceName{
+			r := &rspb.ResourceName{
 				Digest:    d,
-				CacheType: resource.CacheType_CAS,
+				CacheType: rspb.CacheType_CAS,
 			}
 			lock.Lock()
 			defer lock.Unlock()
@@ -507,9 +507,9 @@ func TestCopyDataInBackground_ExceedsCopyChannelSize(t *testing.T) {
 
 			// We should exceed the copy channel size, but should not prevent us from continuing
 			// to read from the cache
-			data, err := mc.Get(ctx, &resource.ResourceName{
+			data, err := mc.Get(ctx, &rspb.ResourceName{
 				Digest:    d,
-				CacheType: resource.CacheType_CAS,
+				CacheType: rspb.CacheType_CAS,
 			})
 			require.NoError(t, err)
 			require.True(t, bytes.Equal(buf, data))
@@ -547,9 +547,9 @@ func TestCopyDataInBackground_RateLimitMax(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		eg.Go(func() error {
 			d, buf := testdigest.NewRandomDigestBuf(t, 100)
-			r := &resource.ResourceName{
+			r := &rspb.ResourceName{
 				Digest:    d,
-				CacheType: resource.CacheType_CAS,
+				CacheType: rspb.CacheType_CAS,
 			}
 			lock.Lock()
 			defer lock.Unlock()
@@ -558,9 +558,9 @@ func TestCopyDataInBackground_RateLimitMax(t *testing.T) {
 			require.NoError(t, err)
 
 			// Get should queue copy in background
-			data, err := mc.Get(ctx, &resource.ResourceName{
+			data, err := mc.Get(ctx, &rspb.ResourceName{
 				Digest:    d,
-				CacheType: resource.CacheType_CAS,
+				CacheType: rspb.CacheType_CAS,
 			})
 			require.NoError(t, err)
 			require.True(t, bytes.Equal(buf, data))
@@ -604,9 +604,9 @@ func TestCopyDataInBackground_RateLimitMin(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		eg.Go(func() error {
 			d, buf := testdigest.NewRandomDigestBuf(t, 100)
-			r := &resource.ResourceName{
+			r := &rspb.ResourceName{
 				Digest:    d,
-				CacheType: resource.CacheType_CAS,
+				CacheType: rspb.CacheType_CAS,
 			}
 			lock.Lock()
 			defer lock.Unlock()
@@ -615,9 +615,9 @@ func TestCopyDataInBackground_RateLimitMin(t *testing.T) {
 			require.NoError(t, err)
 
 			// Get should queue copy in background
-			data, err := mc.Get(ctx, &resource.ResourceName{
+			data, err := mc.Get(ctx, &rspb.ResourceName{
 				Digest:    d,
-				CacheType: resource.CacheType_CAS,
+				CacheType: rspb.CacheType_CAS,
 			})
 			require.NoError(t, err)
 			require.True(t, bytes.Equal(buf, data))
@@ -655,14 +655,14 @@ func TestCopyDataInBackground_DrainOnShutdown(t *testing.T) {
 	mc.Start() // Starts copying in background
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	d2, buf2 := testdigest.NewRandomDigestBuf(t, 100)
-	r2 := &resource.ResourceName{
+	r2 := &rspb.ResourceName{
 		Digest:    d2,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = srcCache.Set(ctx, r, buf)
 	require.NoError(t, err)
@@ -725,17 +725,17 @@ func TestCopyDataInBackground_AuthenticatedUser(t *testing.T) {
 
 	// Save data to different isolations in src cache
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = srcCache.Set(authenticatedCtx, r, buf)
 	require.NoError(t, err)
 
 	d2, buf2 := testdigest.NewRandomDigestBuf(t, 100)
-	r2 := &resource.ResourceName{
+	r2 := &rspb.ResourceName{
 		Digest:       d2,
-		CacheType:    resource.CacheType_AC,
+		CacheType:    rspb.CacheType_AC,
 		InstanceName: "dog",
 	}
 	err = srcCache.Set(authenticatedCtx, r2, buf2)
@@ -790,18 +790,18 @@ func TestCopyDataInBackground_MultipleIsolations(t *testing.T) {
 
 	// Save data to different isolations in src cache
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:       d,
-		CacheType:    resource.CacheType_AC,
+		CacheType:    rspb.CacheType_AC,
 		InstanceName: "cat",
 	}
 	err = srcCache.Set(ctx, r, buf)
 	require.NoError(t, err)
 
 	d2, buf2 := testdigest.NewRandomDigestBuf(t, 100)
-	r2 := &resource.ResourceName{
+	r2 := &rspb.ResourceName{
 		Digest:       d2,
-		CacheType:    resource.CacheType_CAS,
+		CacheType:    rspb.CacheType_CAS,
 		InstanceName: "cow",
 	}
 	err = srcCache.Set(ctx, r2, buf2)
@@ -853,33 +853,33 @@ func TestCopyDataInBackground_FindMissing(t *testing.T) {
 
 	// Save digest to both caches - does not need to be copied to dest, but should be there
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r1 := &resource.ResourceName{
+	r1 := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = mc.Set(ctx, r1, buf)
 	require.NoError(t, err)
 
 	// Save digest to only src cache - should be copied to dest cache
 	d2, buf2 := testdigest.NewRandomDigestBuf(t, 100)
-	r2 := &resource.ResourceName{
+	r2 := &rspb.ResourceName{
 		Digest:    d2,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = srcCache.Set(ctx, r2, buf2)
 	require.NoError(t, err)
 
 	// Save digest to only dest cache - should not be copied to src cache
 	d3, buf3 := testdigest.NewRandomDigestBuf(t, 100)
-	r3 := &resource.ResourceName{
+	r3 := &rspb.ResourceName{
 		Digest:    d3,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = destCache.Set(ctx, r3, buf3)
 	require.NoError(t, err)
 
 	// FindMissing should queue copies in background
-	missing, err := mc.FindMissing(ctx, []*resource.ResourceName{r1, r2, r3})
+	missing, err := mc.FindMissing(ctx, []*rspb.ResourceName{r1, r2, r3})
 	require.NoError(t, err)
 	require.Equal(t, []*repb.Digest{d3}, missing)
 
@@ -903,9 +903,9 @@ func TestContains(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:       d,
-		CacheType:    resource.CacheType_AC,
+		CacheType:    rspb.CacheType_AC,
 		InstanceName: remoteInstanceName,
 	}
 	err = mc.Set(ctx, r, buf)
@@ -916,10 +916,10 @@ func TestContains(t *testing.T) {
 	require.True(t, contains)
 
 	notWrittenDigest, _ := testdigest.NewRandomDigestBuf(t, 100)
-	contains, err = mc.Contains(ctx, &resource.ResourceName{
+	contains, err = mc.Contains(ctx, &rspb.ResourceName{
 		Digest:       notWrittenDigest,
 		InstanceName: "",
-		CacheType:    resource.CacheType_CAS,
+		CacheType:    rspb.CacheType_CAS,
 	})
 	require.NoError(t, err)
 	require.False(t, contains)
@@ -937,9 +937,9 @@ func TestContains_DestErr(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = mc.Set(ctx, r, buf)
 	require.NoError(t, err)
@@ -964,9 +964,9 @@ func TestMetadata(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = mc.Set(ctx, r, buf)
 	require.NoError(t, err)
@@ -976,9 +976,9 @@ func TestMetadata(t *testing.T) {
 	require.Equal(t, int64(100), md.StoredSizeBytes)
 
 	notWrittenDigest, _ := testdigest.NewRandomDigestBuf(t, 100)
-	md, err = mc.Metadata(ctx, &resource.ResourceName{
+	md, err = mc.Metadata(ctx, &rspb.ResourceName{
 		Digest:    notWrittenDigest,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	})
 	require.True(t, status.IsNotFoundError(err))
 	require.Nil(t, md)
@@ -996,9 +996,9 @@ func TestMetadata_DestErr(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = mc.Set(ctx, r, buf)
 	require.NoError(t, err)
@@ -1023,9 +1023,9 @@ func TestFindMissing(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{LogNotFoundErrors: true, DoubleReadPercentage: 1}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	notSetD1, _ := testdigest.NewRandomDigestBuf(t, 100)
 	notSetD2, _ := testdigest.NewRandomDigestBuf(t, 100)
@@ -1034,13 +1034,13 @@ func TestFindMissing(t *testing.T) {
 	require.NoError(t, err)
 
 	digests := []*repb.Digest{d, notSetD1, notSetD2}
-	rns := digest.ResourceNames(resource.CacheType_CAS, "", digests)
+	rns := digest.ResourceNames(rspb.CacheType_CAS, "", digests)
 	missing, err := mc.FindMissing(ctx, rns)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []*repb.Digest{notSetD1, notSetD2}, missing)
 
 	digests = []*repb.Digest{d}
-	rns = digest.ResourceNames(resource.CacheType_CAS, "", digests)
+	rns = digest.ResourceNames(rspb.CacheType_CAS, "", digests)
 	missing, err = mc.FindMissing(ctx, rns)
 	require.NoError(t, err)
 	require.Empty(t, missing)
@@ -1060,19 +1060,19 @@ func TestFindMissing_DestSrcMismatch(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{LogNotFoundErrors: true, DoubleReadPercentage: 1}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	d2, buf2 := testdigest.NewRandomDigestBuf(t, 100)
-	r2 := &resource.ResourceName{
+	r2 := &rspb.ResourceName{
 		Digest:    d2,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	d3, buf3 := testdigest.NewRandomDigestBuf(t, 100)
-	r3 := &resource.ResourceName{
+	r3 := &rspb.ResourceName{
 		Digest:    d3,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 
 	// Set d in both caches, but set d2 and d3 in only one of the caches
@@ -1084,7 +1084,7 @@ func TestFindMissing_DestSrcMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	digests := []*repb.Digest{d, d2, d3}
-	rns := digest.ResourceNames(resource.CacheType_CAS, "", digests)
+	rns := digest.ResourceNames(rspb.CacheType_CAS, "", digests)
 	missing, err := mc.FindMissing(ctx, rns)
 	require.NoError(t, err)
 	// Even though d3 is written to the dest cache, expect output to reflect that it's missing from src cache
@@ -1103,9 +1103,9 @@ func TestFindMissing_DestErr(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	notSetD1, _ := testdigest.NewRandomDigestBuf(t, 100)
 	notSetD2, _ := testdigest.NewRandomDigestBuf(t, 100)
@@ -1114,7 +1114,7 @@ func TestFindMissing_DestErr(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should return data from src cache without error
-	rns := digest.ResourceNames(resource.CacheType_CAS, "", []*repb.Digest{d, notSetD1, notSetD2})
+	rns := digest.ResourceNames(rspb.CacheType_CAS, "", []*repb.Digest{d, notSetD1, notSetD2})
 	missing, err := mc.FindMissing(ctx, rns)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []*repb.Digest{notSetD1, notSetD2}, missing)
@@ -1139,24 +1139,24 @@ func TestGetMultiWithCopying(t *testing.T) {
 
 	eg, ctx := errgroup.WithContext(ctx)
 	lock := sync.RWMutex{}
-	resourceNames := make([]*resource.ResourceName, 50)
+	resourceNames := make([]*rspb.ResourceName, 50)
 	expected := make(map[*repb.Digest][]byte, 50)
 	for i := 0; i < 50; i++ {
 		idx := i
 		eg.Go(func() error {
 			d, buf := testdigest.NewRandomDigestBuf(t, 100)
-			r := &resource.ResourceName{
+			r := &rspb.ResourceName{
 				Digest:    d,
-				CacheType: resource.CacheType_CAS,
+				CacheType: rspb.CacheType_CAS,
 			}
 			lock.Lock()
 			defer lock.Unlock()
 			err = srcCache.Set(ctx, r, buf)
 			require.NoError(t, err)
 
-			resourceNames[idx] = &resource.ResourceName{
+			resourceNames[idx] = &rspb.ResourceName{
 				Digest:    d,
-				CacheType: resource.CacheType_CAS,
+				CacheType: rspb.CacheType_CAS,
 			}
 			expected[d] = buf
 			return nil
@@ -1190,13 +1190,13 @@ func TestSetMulti(t *testing.T) {
 
 	eg, ctx := errgroup.WithContext(ctx)
 	lock := sync.RWMutex{}
-	dataToSet := make(map[*resource.ResourceName][]byte, 50)
+	dataToSet := make(map[*rspb.ResourceName][]byte, 50)
 	for i := 0; i < 50; i++ {
 		eg.Go(func() error {
 			d, buf := testdigest.NewRandomDigestBuf(t, 100)
-			rn := &resource.ResourceName{
+			rn := &rspb.ResourceName{
 				Digest:    d,
-				CacheType: resource.CacheType_CAS,
+				CacheType: rspb.CacheType_CAS,
 			}
 			lock.Lock()
 			defer lock.Unlock()
@@ -1238,9 +1238,9 @@ func TestDelete(t *testing.T) {
 	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = mc.Set(ctx, r, buf)
 	require.NoError(t, err)
@@ -1296,9 +1296,9 @@ func TestReadWrite(t *testing.T) {
 	}
 	for _, testSize := range testSizes {
 		d, buf := testdigest.NewRandomDigestBuf(t, testSize)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 		w, err := mc.Writer(ctx, r)
 		require.NoError(t, err)
@@ -1365,9 +1365,9 @@ func TestReaderWriter_DestFails(t *testing.T) {
 	defer mc.Stop()
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 
 	// Will fail to set a dest writer

--- a/enterprise/server/composable_cache/composable_cache_test.go
+++ b/enterprise/server/composable_cache/composable_cache_test.go
@@ -9,14 +9,15 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/composable_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis"
-	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/stretchr/testify/require"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 func testEnvAndContext(t *testing.T) (environment.Env, context.Context) {
@@ -29,9 +30,9 @@ func testEnvAndContext(t *testing.T) (environment.Env, context.Context) {
 
 func writeDigest(ctx context.Context, t *testing.T, c interfaces.Cache, sizeBytes int64) *repb.Digest {
 	d, buf := testdigest.NewRandomDigestBuf(t, sizeBytes)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	w, err := c.Writer(ctx, r)
 	require.NoError(t, err)
@@ -44,7 +45,7 @@ func writeDigest(ctx context.Context, t *testing.T, c interfaces.Cache, sizeByte
 	return d
 }
 
-func readAndVerifyDigest(ctx context.Context, t *testing.T, c interfaces.Cache, d *resource.ResourceName) {
+func readAndVerifyDigest(ctx context.Context, t *testing.T, c interfaces.Cache, d *rspb.ResourceName) {
 	r, err := c.Reader(ctx, d, 0, 0)
 	require.NoError(t, err)
 	rd, err := digest.Compute(r, repb.DigestFunction_SHA256)
@@ -69,9 +70,9 @@ func TestReadThrough(t *testing.T) {
 	// outer cache on read.
 	{
 		d := writeDigest(ctx, t, inner, 99)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 
 		// Check that we can read the digest through the composable cache.
@@ -85,9 +86,9 @@ func TestReadThrough(t *testing.T) {
 	// still read it from the composable cache.
 	{
 		d := writeDigest(ctx, t, inner, 100)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 
 		// Check that we can read the digest through the composable cache.
@@ -97,9 +98,9 @@ func TestReadThrough(t *testing.T) {
 	// Perform a partial read and check that outer has the correct (full) blob.
 	{
 		d := writeDigest(ctx, t, inner, 99)
-		rn := &resource.ResourceName{
+		rn := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 
 		r, err := c.Reader(ctx, rn, 0, 0)

--- a/enterprise/server/raft/cache/cache_test.go
+++ b/enterprise/server/raft/cache/cache_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
@@ -23,6 +22,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	raft_cache "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/cache"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 var (
@@ -41,7 +41,7 @@ func getEnvAuthAndCtx(t *testing.T) (*testenv.TestEnv, *testauth.TestAuthenticat
 	return te, ta, ctx
 }
 
-func readAndCompareDigest(t *testing.T, ctx context.Context, c interfaces.Cache, d *resource.ResourceName) {
+func readAndCompareDigest(t *testing.T, ctx context.Context, c interfaces.Cache, d *rspb.ResourceName) {
 	reader, err := c.Reader(ctx, d, 0, 0)
 	if err != nil {
 		require.FailNow(t, fmt.Sprintf("cache: %+v", c), err)
@@ -50,7 +50,7 @@ func readAndCompareDigest(t *testing.T, ctx context.Context, c interfaces.Cache,
 	require.Equal(t, d.GetDigest().GetHash(), d1.GetHash())
 }
 
-func writeDigest(t *testing.T, ctx context.Context, c interfaces.Cache, d *resource.ResourceName, buf []byte) {
+func writeDigest(t *testing.T, ctx context.Context, c interfaces.Cache, d *rspb.ResourceName, buf []byte) {
 	writeCloser, err := c.Writer(ctx, d)
 	if err != nil {
 		require.FailNow(t, fmt.Sprintf("cache: %+v", c), err)
@@ -209,9 +209,9 @@ func TestReaderAndWriter(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
 		d, buf := testdigest.NewRandomDigestBuf(t, 100)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:       d,
-			CacheType:    resource.CacheType_CAS,
+			CacheType:    rspb.CacheType_CAS,
 			InstanceName: "remote/instance/name",
 		}
 		writeDigest(t, ctx, rc1, r, buf)
@@ -256,7 +256,7 @@ func TestCacheShutdown(t *testing.T) {
 	waitForHealthy(t, rc1, rc2, rc3)
 
 	cacheRPCTimeout := 5 * time.Second
-	digestsWritten := make([]*resource.ResourceName, 0)
+	digestsWritten := make([]*rspb.ResourceName, 0)
 	for i := 0; i < 5; i++ {
 		ctx, cancel := context.WithTimeout(ctx, cacheRPCTimeout)
 		defer cancel()
@@ -323,16 +323,16 @@ func TestDistributedRanges(t *testing.T) {
 	}
 	waitForHealthy(t, raftCaches...)
 
-	digests := make([]*resource.ResourceName, 0)
+	digests := make([]*rspb.ResourceName, 0)
 	for i := 0; i < 10; i++ {
 		rc := raftCaches[rand.Intn(len(raftCaches))]
 
 		ctx, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
 		d, buf := testdigest.NewRandomDigestBuf(t, 100)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:       d,
-			CacheType:    resource.CacheType_CAS,
+			CacheType:    rspb.CacheType_CAS,
 			InstanceName: "remote/instance/name",
 		}
 		writeDigest(t, ctx, rc, r, buf)
@@ -380,27 +380,27 @@ func TestFindMissingBlobs(t *testing.T) {
 	// wait for them all to become healthy
 	waitForHealthy(t, rc1, rc2, rc3)
 
-	digestsWritten := make([]*resource.ResourceName, 0)
+	digestsWritten := make([]*rspb.ResourceName, 0)
 	for i := 0; i < 10; i++ {
 		ctx, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
 		d, buf := testdigest.NewRandomDigestBuf(t, 100)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:       d,
-			CacheType:    resource.CacheType_CAS,
+			CacheType:    rspb.CacheType_CAS,
 			InstanceName: "remote/instance/name",
 		}
 		digestsWritten = append(digestsWritten, r)
 		writeDigest(t, ctx, rc1, r, buf)
 	}
 
-	missingDigests := make([]*resource.ResourceName, 0)
+	missingDigests := make([]*rspb.ResourceName, 0)
 	expectedMissingHashes := make([]string, 0)
 	for i := 0; i < 10; i++ {
 		d, _ := testdigest.NewRandomDigestBuf(t, 100)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:       d,
-			CacheType:    resource.CacheType_CAS,
+			CacheType:    rspb.CacheType_CAS,
 			InstanceName: "remote/instance/name",
 		}
 

--- a/enterprise/server/raft/filestore/filestore.go
+++ b/enterprise/server/raft/filestore/filestore.go
@@ -12,13 +12,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 const (
@@ -37,9 +37,9 @@ func fileRecordSegments(r *rfpb.FileRecord) (partID string, groupID string, isol
 	partID = r.GetIsolation().GetPartitionId()
 	groupID = r.GetIsolation().GetGroupId()
 
-	if r.GetIsolation().GetCacheType() == resource.CacheType_CAS {
+	if r.GetIsolation().GetCacheType() == rspb.CacheType_CAS {
 		isolation = "cas"
-	} else if r.GetIsolation().GetCacheType() == resource.CacheType_AC {
+	} else if r.GetIsolation().GetCacheType() == rspb.CacheType_AC {
 		isolation = "ac"
 		if remoteInstanceName := r.GetIsolation().GetRemoteInstanceName(); remoteInstanceName != "" {
 			remoteInstanceHash = strconv.Itoa(int(crc32.ChecksumIEEE([]byte(remoteInstanceName))))
@@ -105,14 +105,14 @@ func (pmk PebbleKey) LockID() string {
 	return filepath.Join(pmk.isolation, pmk.hash)
 }
 
-func (pmk PebbleKey) CacheType() resource.CacheType {
+func (pmk PebbleKey) CacheType() rspb.CacheType {
 	switch pmk.isolation {
 	case "ac":
-		return resource.CacheType_AC
+		return rspb.CacheType_AC
 	case "cas":
-		return resource.CacheType_CAS
+		return rspb.CacheType_CAS
 	default:
-		return resource.CacheType_UNKNOWN_CACHE_TYPE
+		return rspb.CacheType_UNKNOWN_CACHE_TYPE
 	}
 }
 
@@ -292,7 +292,7 @@ func (fs *fileStorer) FileKey(r *rfpb.FileRecord) ([]byte, error) {
 		return nil, err
 	}
 	partDir := PartitionDirectoryPrefix + partID
-	if r.GetIsolation().GetCacheType() == resource.CacheType_AC {
+	if r.GetIsolation().GetCacheType() == rspb.CacheType_AC {
 		return []byte(filepath.Join(partDir, groupID, isolation, remoteInstanceHash, hash[:4], hash)), nil
 	} else {
 		return []byte(filepath.Join(partDir, isolation, remoteInstanceHash, hash[:4], hash)), nil

--- a/enterprise/server/raft/filestore/filestore_test.go
+++ b/enterprise/server/raft/filestore/filestore_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/filestore"
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 func TestKeyVersionCrossCompatibility(t *testing.T) {
@@ -24,7 +24,7 @@ func TestKeyVersionCrossCompatibility(t *testing.T) {
 		d, _ := testdigest.NewRandomDigestBuf(t, 100)
 		fr := &rfpb.FileRecord{
 			Isolation: &rfpb.Isolation{
-				CacheType:          resource.CacheType_AC,
+				CacheType:          rspb.CacheType_AC,
 				RemoteInstanceName: "remote_instance_name",
 				PartitionId:        partitionID,
 				GroupId:            testGroupID,
@@ -32,7 +32,7 @@ func TestKeyVersionCrossCompatibility(t *testing.T) {
 			Digest: d,
 		}
 		if i%2 == 0 {
-			fr.Isolation.CacheType = resource.CacheType_CAS
+			fr.Isolation.CacheType = rspb.CacheType_CAS
 		}
 		sourceKey, err := fs.PebbleKey(fr)
 		require.NoError(t, err)

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/replica"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
@@ -26,6 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	dbsm "github.com/lni/dragonboat/v3/statemachine"
 )
 
@@ -159,7 +159,7 @@ func randomRecord(t *testing.T, partition string, sizeBytes int64) (*rfpb.FileRe
 	d, buf := testdigest.NewRandomDigestBuf(t, sizeBytes)
 	return &rfpb.FileRecord{
 		Isolation: &rfpb.Isolation{
-			CacheType:   resource.CacheType_CAS,
+			CacheType:   rspb.CacheType_CAS,
 			PartitionId: partition,
 			GroupId:     interfaces.AuthAnonymousUser,
 		},
@@ -498,7 +498,7 @@ func TestReplicaFileWriteSnapshotRestore(t *testing.T) {
 
 	fileRecord := &rfpb.FileRecord{
 		Isolation: &rfpb.Isolation{
-			CacheType:   resource.CacheType_CAS,
+			CacheType:   rspb.CacheType_CAS,
 			PartitionId: "default",
 			GroupId:     interfaces.AuthAnonymousUser,
 		},
@@ -565,7 +565,7 @@ func TestReplicaFileWriteDelete(t *testing.T) {
 	d, buf := testdigest.NewRandomDigestBuf(t, 1000)
 	fileRecord := &rfpb.FileRecord{
 		Isolation: &rfpb.Isolation{
-			CacheType:   resource.CacheType_CAS,
+			CacheType:   rspb.CacheType_CAS,
 			PartitionId: "default",
 			GroupId:     interfaces.AuthAnonymousUser,
 		},
@@ -716,7 +716,7 @@ func TestFindSplitPoint(t *testing.T) {
 			d, buf := testdigest.NewRandomDigestBuf(t, sizeBytes)
 			fileRecord := &rfpb.FileRecord{
 				Isolation: &rfpb.Isolation{
-					CacheType:   resource.CacheType_CAS,
+					CacheType:   rspb.CacheType_CAS,
 					PartitionId: partitionID,
 					GroupId:     interfaces.AuthAnonymousUser,
 				},

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/replica"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/store"
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/gossip"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
@@ -39,6 +38,7 @@ import (
 	_ "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/logger"
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
 	rfspb "github.com/buildbuddy-io/buildbuddy/proto/raft_service"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	dbConfig "github.com/lni/dragonboat/v3/config"
 )
 
@@ -271,7 +271,7 @@ func writeRecord(ctx context.Context, t *testing.T, ts *TestingStore, groupID st
 	d, buf := testdigest.NewRandomDigestBuf(t, sizeBytes)
 	fr := &rfpb.FileRecord{
 		Isolation: &rfpb.Isolation{
-			CacheType:   resource.CacheType_CAS,
+			CacheType:   rspb.CacheType_CAS,
 			PartitionId: groupID,
 		},
 		Digest: d,

--- a/enterprise/server/registry/registry.go
+++ b/enterprise/server/registry/registry.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
@@ -34,6 +33,7 @@ import (
 
 	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	ctrname "github.com/google/go-containerregistry/pkg/name"
 )
 
@@ -104,7 +104,7 @@ func (r *registry) getCachedManifest(ctx context.Context, d string) (*rgpb.Manif
 		return nil, status.UnknownErrorf("could not unmarshal manifest proto %s: %s", d, err)
 	}
 
-	cacheResources := digest.ResourceNames(resource.CacheType_CAS, registryInstanceName, mfProto.CasDependencies)
+	cacheResources := digest.ResourceNames(rspb.CacheType_CAS, registryInstanceName, mfProto.CasDependencies)
 	missing, err := r.cache.FindMissing(ctx, cacheResources)
 	if err != nil {
 		return nil, status.UnavailableErrorf("could not check blob existence in CAS: %s", err)
@@ -192,7 +192,7 @@ func parseRangeHeader(val string) ([]byteRange, error) {
 	return parsedRanges, nil
 }
 
-func blobResourceName(h v1.Hash) *resource.ResourceName {
+func blobResourceName(h v1.Hash) *rspb.ResourceName {
 	d := &repb.Digest{
 		Hash: h.Hex,
 		// We don't actually know the blob size.

--- a/enterprise/server/remote_execution/dirtools/dirtools_test.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/dirtools"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/byte_stream_server"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
@@ -19,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
@@ -245,9 +245,9 @@ func setFile(t *testing.T, env *testenv.TestEnv, ctx context.Context, instanceNa
 		Hash:      hashString,
 		SizeBytes: int64(len(dataBytes)),
 	}
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:       d,
-		CacheType:    resource.CacheType_CAS,
+		CacheType:    rspb.CacheType_CAS,
 		InstanceName: instanceName,
 	}
 	env.GetCache().Set(ctx, r, dataBytes)

--- a/enterprise/server/test/performance/cache/cache_test.go
+++ b/enterprise/server/test/performance/cache/cache_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/distributed"
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/disk_cache"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/memory_cache"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -20,6 +19,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
+
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 const (
@@ -52,7 +53,7 @@ func getAnonContext(t testing.TB, te *testenv.TestEnv) context.Context {
 }
 
 type digestBuf struct {
-	d   *resource.ResourceName
+	d   *rspb.ResourceName
 	buf []byte
 }
 
@@ -60,9 +61,9 @@ func makeDigests(t testing.TB, numDigests int, digestSizeBytes int64) []*digestB
 	digestBufs := make([]*digestBuf, 0, numDigests)
 	for i := 0; i < numDigests; i++ {
 		d, buf := testdigest.NewRandomDigestBuf(t, digestSizeBytes)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 		digestBufs = append(digestBufs, &digestBuf{
 			d:   r,
@@ -149,7 +150,7 @@ func benchmarkGet(ctx context.Context, c interfaces.Cache, digestSizeBytes int64
 func benchmarkGetMulti(ctx context.Context, c interfaces.Cache, digestSizeBytes int64, b *testing.B) {
 	digestBufs := makeDigests(b, numDigests, digestSizeBytes)
 	setDigestsInCache(b, ctx, c, digestBufs)
-	digests := make([]*resource.ResourceName, 0, len(digestBufs))
+	digests := make([]*rspb.ResourceName, 0, len(digestBufs))
 	var sumBytes int64
 	for _, dbuf := range digestBufs {
 		digests = append(digests, dbuf.d)
@@ -170,7 +171,7 @@ func benchmarkGetMulti(ctx context.Context, c interfaces.Cache, digestSizeBytes 
 func benchmarkFindMissing(ctx context.Context, c interfaces.Cache, digestSizeBytes int64, b *testing.B) {
 	digestBufs := makeDigests(b, numDigests, digestSizeBytes)
 	setDigestsInCache(b, ctx, c, digestBufs)
-	digests := make([]*resource.ResourceName, 0, len(digestBufs))
+	digests := make([]*rspb.ResourceName, 0, len(digestBufs))
 	for _, dbuf := range digestBufs {
 		digests = append(digests, dbuf.d)
 	}

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
@@ -29,6 +28,7 @@ import (
 
 	dcpb "github.com/buildbuddy-io/buildbuddy/proto/distributed_cache"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 const (
@@ -52,7 +52,7 @@ type CacheProxy struct {
 	server                *grpc.Server
 	clients               map[string]*dcClient
 	heartbeatCallback     func(ctx context.Context, peer string)
-	hintedHandoffCallback func(ctx context.Context, peer string, r *resource.ResourceName)
+	hintedHandoffCallback func(ctx context.Context, peer string, r *rspb.ResourceName)
 	listenAddr            string
 	zone                  string
 }
@@ -118,7 +118,7 @@ func (c *CacheProxy) SetHeartbeatCallbackFunc(fn func(ctx context.Context, peer 
 	c.heartbeatCallback = fn
 }
 
-func (c *CacheProxy) SetHintedHandoffCallbackFunc(fn func(ctx context.Context, peer string, r *resource.ResourceName)) {
+func (c *CacheProxy) SetHintedHandoffCallbackFunc(fn func(ctx context.Context, peer string, r *rspb.ResourceName)) {
 	c.hintedHandoffCallback = fn
 }
 
@@ -178,13 +178,13 @@ func (c *CacheProxy) readWriteContext(ctx context.Context) (context.Context, err
 // Distributed cache requests now contain resource.ResourceName structs, replacing usage of the dcpb.Isolation and
 // dcpb.Key structs. However during a rollout, the new resource fields may not be set, and may require fallback to the
 // older deprecated fields
-func getResource(r *resource.ResourceName, isolation *dcpb.Isolation, digestKey *dcpb.Key) *resource.ResourceName {
+func getResource(r *rspb.ResourceName, isolation *dcpb.Isolation, digestKey *dcpb.Key) *rspb.ResourceName {
 	if r != nil {
 		return r
 	}
 
 	d := digestFromKey(digestKey)
-	return &resource.ResourceName{
+	return &rspb.ResourceName{
 		Digest:       d,
 		CacheType:    isolation.GetCacheType(),
 		InstanceName: isolation.GetRemoteInstanceName(),
@@ -192,14 +192,14 @@ func getResource(r *resource.ResourceName, isolation *dcpb.Isolation, digestKey 
 	}
 }
 
-func getResources(resources []*resource.ResourceName, isolation *dcpb.Isolation, digestKeys []*dcpb.Key) []*resource.ResourceName {
+func getResources(resources []*rspb.ResourceName, isolation *dcpb.Isolation, digestKeys []*dcpb.Key) []*rspb.ResourceName {
 	if resources != nil {
 		return resources
 	}
 
 	instanceName := isolation.GetRemoteInstanceName()
 	cacheType := isolation.GetCacheType()
-	rns := make([]*resource.ResourceName, 0)
+	rns := make([]*rspb.ResourceName, 0)
 	for _, k := range digestKeys {
 		d := digestFromKey(k)
 		rn := digest.NewCacheResourceName(d, instanceName, cacheType).ToProto()
@@ -246,7 +246,7 @@ func (c *CacheProxy) Metadata(ctx context.Context, req *dcpb.MetadataRequest) (*
 }
 
 // ResourceIsolationString returns a compact representation of a resource's isolation that is suitable for logging.
-func ResourceIsolationString(r *resource.ResourceName) string {
+func ResourceIsolationString(r *rspb.ResourceName) string {
 	rep := filepath.Join(r.GetInstanceName(), digest.CacheTypeToPrefix(r.GetCacheType()), r.GetDigest().GetHash())
 	if !strings.HasSuffix(rep, "/") {
 		rep += "/"
@@ -280,7 +280,7 @@ func (c *CacheProxy) GetMulti(ctx context.Context, req *dcpb.GetMultiRequest) (*
 	rsp := &dcpb.GetMultiResponse{}
 	for d, buf := range found {
 		if len(buf) == 0 {
-			rn := &resource.ResourceName{
+			rn := &rspb.ResourceName{
 				Digest:       d,
 				InstanceName: req.GetIsolation().GetRemoteInstanceName(),
 				CacheType:    req.GetIsolation().GetCacheType(),
@@ -338,7 +338,7 @@ func (c *CacheProxy) Read(req *dcpb.ReadRequest, stream dcpb.DistributedCache_Re
 	return err
 }
 
-func (c *CacheProxy) callHintedHandoffCB(ctx context.Context, peer string, r *resource.ResourceName) {
+func (c *CacheProxy) callHintedHandoffCB(ctx context.Context, peer string, r *rspb.ResourceName) {
 	if c.hintedHandoffCallback != nil {
 		c.hintedHandoffCallback(ctx, peer, r)
 	}
@@ -405,19 +405,19 @@ func (c *CacheProxy) Heartbeat(ctx context.Context, req *dcpb.HeartbeatRequest) 
 	return &dcpb.HeartbeatResponse{}, nil
 }
 
-func (c *CacheProxy) RemoteContains(ctx context.Context, peer string, r *resource.ResourceName) (bool, error) {
+func (c *CacheProxy) RemoteContains(ctx context.Context, peer string, r *rspb.ResourceName) (bool, error) {
 	isolation := &dcpb.Isolation{
 		CacheType:          r.GetCacheType(),
 		RemoteInstanceName: r.GetInstanceName(),
 	}
-	missing, err := c.RemoteFindMissing(ctx, peer, isolation, []*resource.ResourceName{r})
+	missing, err := c.RemoteFindMissing(ctx, peer, isolation, []*rspb.ResourceName{r})
 	if err != nil {
 		return false, err
 	}
 	return len(missing) == 0, nil
 }
 
-func (c *CacheProxy) RemoteMetadata(ctx context.Context, peer string, r *resource.ResourceName) (*interfaces.CacheMetadata, error) {
+func (c *CacheProxy) RemoteMetadata(ctx context.Context, peer string, r *rspb.ResourceName) (*interfaces.CacheMetadata, error) {
 	isolation := &dcpb.Isolation{
 		CacheType:          r.GetCacheType(),
 		RemoteInstanceName: r.GetInstanceName(),
@@ -444,7 +444,7 @@ func (c *CacheProxy) RemoteMetadata(ctx context.Context, peer string, r *resourc
 	}, nil
 }
 
-func (c *CacheProxy) RemoteFindMissing(ctx context.Context, peer string, isolation *dcpb.Isolation, resources []*resource.ResourceName) ([]*repb.Digest, error) {
+func (c *CacheProxy) RemoteFindMissing(ctx context.Context, peer string, isolation *dcpb.Isolation, resources []*rspb.ResourceName) ([]*repb.Digest, error) {
 	req := &dcpb.FindMissingRequest{
 		Isolation: isolation,
 	}
@@ -471,7 +471,7 @@ func (c *CacheProxy) RemoteFindMissing(ctx context.Context, peer string, isolati
 	return missing, nil
 }
 
-func (c *CacheProxy) RemoteDelete(ctx context.Context, peer string, r *resource.ResourceName) error {
+func (c *CacheProxy) RemoteDelete(ctx context.Context, peer string, r *rspb.ResourceName) error {
 	isolation := &dcpb.Isolation{
 		CacheType:          r.GetCacheType(),
 		RemoteInstanceName: r.GetInstanceName(),
@@ -493,7 +493,7 @@ func (c *CacheProxy) RemoteDelete(ctx context.Context, peer string, r *resource.
 	return nil
 }
 
-func (c *CacheProxy) RemoteGetMulti(ctx context.Context, peer string, isolation *dcpb.Isolation, resources []*resource.ResourceName) (map[*repb.Digest][]byte, error) {
+func (c *CacheProxy) RemoteGetMulti(ctx context.Context, peer string, isolation *dcpb.Isolation, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	req := &dcpb.GetMultiRequest{
 		Isolation: isolation,
 	}
@@ -522,7 +522,7 @@ func (c *CacheProxy) RemoteGetMulti(ctx context.Context, peer string, isolation 
 	return resultMap, nil
 }
 
-func (c *CacheProxy) RemoteReader(ctx context.Context, peer string, r *resource.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+func (c *CacheProxy) RemoteReader(ctx context.Context, peer string, r *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
 	isolation := &dcpb.Isolation{
 		CacheType:          r.GetCacheType(),
 		RemoteInstanceName: r.GetInstanceName(),
@@ -583,7 +583,7 @@ func (c *CacheProxy) RemoteReader(ctx context.Context, peer string, r *resource.
 type streamWriteCloser struct {
 	cancelFunc    context.CancelFunc
 	stream        dcpb.DistributedCache_WriteClient
-	r             *resource.ResourceName
+	r             *rspb.ResourceName
 	key           *dcpb.Key
 	isolation     *dcpb.Isolation
 	handoffPeer   string
@@ -646,14 +646,14 @@ func newBufferedStreadWriteCloser(swc *streamWriteCloser) *bufferedStreamWriteCl
 	}
 }
 
-func (c *CacheProxy) RemoteWriter(ctx context.Context, peer, handoffPeer string, r *resource.ResourceName) (interfaces.CommittedWriteCloser, error) {
+func (c *CacheProxy) RemoteWriter(ctx context.Context, peer, handoffPeer string, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {
 	// Stopping a write mid-stream is difficult because Write streams are
 	// unidirectional. The server can close the stream early, but this does
 	// not necessarily save the client any work. So, to attempt to reduce
 	// duplicate writes, we call Contains before writing a new digest, and
 	// if it already exists, we'll return a devnull writecloser so no bytes
 	// are transmitted over the network.
-	if r.GetCacheType() == resource.CacheType_CAS {
+	if r.GetCacheType() == rspb.CacheType_CAS {
 		if alreadyExists, err := c.RemoteContains(ctx, peer, r); err == nil && alreadyExists {
 			log.Debugf("Skipping duplicate CAS write of %q", r.GetDigest().GetHash())
 			return ioutil.DiscardWriteCloser(), nil

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/disk_cache"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -26,6 +25,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 var (
@@ -68,9 +68,9 @@ func TestGetSet(t *testing.T) {
 	}
 	for _, testSize := range testSizes {
 		d, buf := testdigest.NewRandomDigestBuf(t, testSize)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:       d,
-			CacheType:    resource.CacheType_CAS,
+			CacheType:    rspb.CacheType_CAS,
 			InstanceName: instanceName,
 		}
 		// Set() the bytes in the cache.
@@ -105,9 +105,9 @@ func TestMetadata(t *testing.T) {
 	}
 	for _, testSize := range testSizes {
 		d, buf := testdigest.NewRandomDigestBuf(t, testSize)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:       d,
-			CacheType:    resource.CacheType_AC,
+			CacheType:    rspb.CacheType_AC,
 			InstanceName: "remoteInstanceName",
 		}
 		// Set() the bytes in the cache.
@@ -116,9 +116,9 @@ func TestMetadata(t *testing.T) {
 
 		// Metadata should return true size of the blob, regardless of queried size.
 		digestWrongSize := &repb.Digest{Hash: d.GetHash(), SizeBytes: 1}
-		rn := &resource.ResourceName{
+		rn := &rspb.ResourceName{
 			Digest:       digestWrongSize,
-			CacheType:    resource.CacheType_AC,
+			CacheType:    rspb.CacheType_AC,
 			InstanceName: "remoteInstanceName",
 		}
 
@@ -165,9 +165,9 @@ func TestMetadataFileDoesNotExist(t *testing.T) {
 
 	testSize := int64(100)
 	d, _ := testdigest.NewRandomDigestBuf(t, testSize)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 
 	md, err := dc.Metadata(ctx, r)
@@ -175,13 +175,13 @@ func TestMetadataFileDoesNotExist(t *testing.T) {
 	require.Nil(t, md)
 }
 
-func randomDigests(t *testing.T, sizes ...int64) map[*resource.ResourceName][]byte {
-	m := make(map[*resource.ResourceName][]byte)
+func randomDigests(t *testing.T, sizes ...int64) map[*rspb.ResourceName][]byte {
+	m := make(map[*rspb.ResourceName][]byte)
 	for _, size := range sizes {
 		d, buf := testdigest.NewRandomDigestBuf(t, size)
-		rn := &resource.ResourceName{
+		rn := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 		m[rn] = buf
 	}
@@ -202,22 +202,22 @@ func TestFindMissing(t *testing.T) {
 	notSetD2, _ := testdigest.NewRandomDigestBuf(t, 100)
 
 	remoteInstanceName := "farFarAway"
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:       d,
-		CacheType:    resource.CacheType_AC,
+		CacheType:    rspb.CacheType_AC,
 		InstanceName: remoteInstanceName,
 	}
 	err = dc.Set(ctx, r, buf)
 	require.NoError(t, err)
 
 	digests := []*repb.Digest{d, notSetD1, notSetD2}
-	rns := digest.ResourceNames(resource.CacheType_AC, remoteInstanceName, digests)
+	rns := digest.ResourceNames(rspb.CacheType_AC, remoteInstanceName, digests)
 	missing, err := dc.FindMissing(ctx, rns)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []*repb.Digest{notSetD1, notSetD2}, missing)
 
 	digests = []*repb.Digest{d}
-	rns = digest.ResourceNames(resource.CacheType_AC, remoteInstanceName, digests)
+	rns = digest.ResourceNames(rspb.CacheType_AC, remoteInstanceName, digests)
 	missing, err = dc.FindMissing(ctx, rns)
 	require.NoError(t, err)
 	require.Empty(t, missing)
@@ -236,7 +236,7 @@ func TestMultiGetSet(t *testing.T) {
 	if err := dc.SetMulti(ctx, digests); err != nil {
 		t.Fatalf("Error multi-setting digests: %s", err.Error())
 	}
-	resourceNames := make([]*resource.ResourceName, 0, len(digests))
+	resourceNames := make([]*rspb.ResourceName, 0, len(digests))
 	for d := range digests {
 		resourceNames = append(resourceNames, d)
 	}
@@ -274,9 +274,9 @@ func TestReadWrite(t *testing.T) {
 	for _, testSize := range testSizes {
 		ctx := getAnonContext(t, te)
 		d, r := testdigest.NewRandomDigestReader(t, testSize)
-		rn := &resource.ResourceName{
+		rn := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 		// Use Writer() to set the bytes in the cache.
 		wc, err := dc.Writer(ctx, rn)
@@ -314,9 +314,9 @@ func TestReadOffset(t *testing.T) {
 	}
 	ctx := getAnonContext(t, te)
 	d, r := testdigest.NewRandomDigestReader(t, 100)
-	rn := &resource.ResourceName{
+	rn := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	// Use Writer() to set the bytes in the cache.
 	wc, err := dc.Writer(ctx, rn)
@@ -353,9 +353,9 @@ func TestReadOffsetLimit(t *testing.T) {
 	ctx := getAnonContext(t, te)
 	size := int64(10)
 	d, buf := testdigest.NewRandomDigestBuf(t, size)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	err = dc.Set(ctx, r, buf)
 	require.NoError(t, err)
@@ -383,7 +383,7 @@ func TestSizeLimit(t *testing.T) {
 	dc.WaitUntilMapped()
 	ctx := getAnonContext(t, te)
 	digestBufs := randomDigests(t, 400, 400, 400)
-	digestKeys := make([]*resource.ResourceName, 0, len(digestBufs))
+	digestKeys := make([]*rspb.ResourceName, 0, len(digestBufs))
 	for d, buf := range digestBufs {
 		if err := dc.Set(ctx, d, buf); err != nil {
 			t.Fatalf("Error setting %q in cache: %s", d.GetDigest().GetHash(), err.Error())
@@ -426,7 +426,7 @@ func TestLRU(t *testing.T) {
 	dc.WaitUntilMapped()
 	ctx := getAnonContext(t, te)
 	digestBufs := randomDigests(t, 400, 400)
-	digestKeys := make([]*resource.ResourceName, 0, len(digestBufs))
+	digestKeys := make([]*rspb.ResourceName, 0, len(digestBufs))
 	for r, buf := range digestBufs {
 		if err := dc.Set(ctx, r, buf); err != nil {
 			t.Fatalf("Error setting %q in cache: %s", r.GetDigest().GetHash(), err.Error())
@@ -444,9 +444,9 @@ func TestLRU(t *testing.T) {
 	// Now write one more digest, which should evict the oldest digest,
 	// (the second one we wrote).
 	d, buf := testdigest.NewRandomDigestBuf(t, 400)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 	if err := dc.Set(ctx, r, buf); err != nil {
 		t.Fatal(err)
@@ -494,9 +494,9 @@ func TestFileAtomicity(t *testing.T) {
 		eg.Go(func() error {
 			lock.Lock()
 			defer lock.Unlock()
-			r := &resource.ResourceName{
+			r := &rspb.ResourceName{
 				Digest:    d,
-				CacheType: resource.CacheType_CAS,
+				CacheType: rspb.CacheType_CAS,
 			}
 			if err := dc.Set(gctx, r, buf); err != nil {
 				return err
@@ -543,9 +543,9 @@ func TestAsyncLoading(t *testing.T) {
 	// Ensure that files on disk exist *immediately*, even though
 	// they may not have been async processed yet.
 	for _, d := range digests {
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 		exists, err := dc.Contains(ctx, r)
 		if err != nil {
@@ -558,9 +558,9 @@ func TestAsyncLoading(t *testing.T) {
 	// Write some more files, just to ensure the LRU is appended to.
 	for i := 0; i < 1000; i++ {
 		d, buf := testdigest.NewRandomDigestBuf(t, 10000)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 		if err := dc.Set(ctx, r, buf); err != nil {
 			t.Fatal(err)
@@ -572,9 +572,9 @@ func TestAsyncLoading(t *testing.T) {
 
 	// Check that everything still exists.
 	for _, d := range digests {
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 		exists, err := dc.Contains(ctx, r)
 		if err != nil {
@@ -597,7 +597,7 @@ func waitForEviction(t *testing.T, dc *disk_cache.DiskCache) {
 	require.FailNow(t, "eviction did not happen in time")
 }
 
-func expectedDefaultV1DiskPath(rootDir string, r *resource.ResourceName) string {
+func expectedDefaultV1DiskPath(rootDir string, r *rspb.ResourceName) string {
 	return filepath.Join(rootDir, interfaces.AuthAnonymousUser, r.GetDigest().GetHash())
 }
 
@@ -609,12 +609,12 @@ func testEviction(t *testing.T, rootDir string) {
 	require.NoError(t, err)
 
 	// Fill the cache.
-	resources := make([]*resource.ResourceName, 0)
+	resources := make([]*rspb.ResourceName, 0)
 	for i := 0; i < 999; i++ {
 		d, buf := testdigest.NewRandomDigestBuf(t, 10000)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 		err := dc.Set(ctx, r, buf)
 		require.NoError(t, err)
@@ -648,7 +648,7 @@ func testEviction(t *testing.T, rootDir string) {
 
 	for i := 0; i < 500; i++ {
 		d, buf := testdigest.NewRandomDigestBuf(t, 10000)
-		r := &resource.ResourceName{Digest: d, CacheType: resource.CacheType_CAS}
+		r := &rspb.ResourceName{Digest: d, CacheType: rspb.CacheType_CAS}
 		err := dc.Set(ctx, r, buf)
 		require.NoError(t, err)
 	}
@@ -699,12 +699,12 @@ func TestJanitorThread(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Fill the cache.
-	digests := make([]*resource.ResourceName, 0)
+	digests := make([]*rspb.ResourceName, 0)
 	for i := 0; i < 999; i++ {
 		d, buf := testdigest.NewRandomDigestBuf(t, 10000)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 		err := dc.Set(ctx, r, buf)
 		if err != nil {
@@ -742,7 +742,7 @@ func TestDefaultToV2Layout(t *testing.T) {
 
 		c, ctx := newCacheAndContext(t, &disk_cache.Options{ForceV1Layout: true, RootDirectory: rootDir}, 10_000_000)
 		d, data := testdigest.NewRandomDigestBuf(t, 1000)
-		err := c.Set(ctx, &resource.ResourceName{Digest: d, CacheType: resource.CacheType_CAS}, data)
+		err := c.Set(ctx, &rspb.ResourceName{Digest: d, CacheType: rspb.CacheType_CAS}, data)
 		require.NoError(t, err)
 
 		c, ctx = newCacheAndContext(t, &disk_cache.Options{RootDirectory: rootDir}, 10_000_000)
@@ -898,9 +898,9 @@ func TestNonDefaultPartition(t *testing.T) {
 	{
 		ctx, err := prefix.AttachUserPrefixToContext(context.Background(), te)
 		d, buf := testdigest.NewRandomDigestBuf(t, 1000)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 
 		err = dc.Set(ctx, r, buf)
@@ -921,9 +921,9 @@ func TestNonDefaultPartition(t *testing.T) {
 		ctx, err = prefix.AttachUserPrefixToContext(ctx, te)
 		require.NoError(t, err)
 		d, buf := testdigest.NewRandomDigestBuf(t, 1000)
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 
 		err = dc.Set(ctx, r, buf)
@@ -946,9 +946,9 @@ func TestNonDefaultPartition(t *testing.T) {
 		require.NoError(t, err)
 		d, buf := testdigest.NewRandomDigestBuf(t, 1000)
 		instanceName := "nonmatchingprefix"
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:       d,
-			CacheType:    resource.CacheType_CAS,
+			CacheType:    rspb.CacheType_CAS,
 			InstanceName: instanceName,
 		}
 
@@ -973,9 +973,9 @@ func TestNonDefaultPartition(t *testing.T) {
 		require.NoError(t, err)
 		d, buf := testdigest.NewRandomDigestBuf(t, 1000)
 		instanceName := otherPartitionPrefix + "hello"
-		r := &resource.ResourceName{
+		r := &rspb.ResourceName{
 			Digest:       d,
-			CacheType:    resource.CacheType_CAS,
+			CacheType:    rspb.CacheType_CAS,
 			InstanceName: instanceName,
 		}
 
@@ -1006,9 +1006,9 @@ func TestV2Layout(t *testing.T) {
 
 	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), te)
 	d, buf := testdigest.NewRandomDigestBuf(t, 1000)
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	}
 
 	err = dc.Set(ctx, r, buf)
@@ -1022,9 +1022,9 @@ func TestV2Layout(t *testing.T) {
 	require.NoError(t, err)
 	require.Truef(t, ok, "digest should be in the cache")
 
-	_, err = dc.Get(ctx, &resource.ResourceName{
+	_, err = dc.Get(ctx, &rspb.ResourceName{
 		Digest:    d,
-		CacheType: resource.CacheType_CAS,
+		CacheType: rspb.CacheType_CAS,
 	})
 	require.NoError(t, err)
 }
@@ -1109,9 +1109,9 @@ func TestV2LayoutMigration(t *testing.T) {
 	testHash := "7e09daa1b85225442942ff853d45618323c56b85a553c5188cec2fd1009cd620"
 	{
 		d := &repb.Digest{Hash: testHash, SizeBytes: 5}
-		buf, err := dc.Get(ctx, &resource.ResourceName{
+		buf, err := dc.Get(ctx, &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		})
 		require.NoError(t, err)
 		require.Equal(t, []byte("test1"), buf)
@@ -1119,9 +1119,9 @@ func TestV2LayoutMigration(t *testing.T) {
 
 	{
 		d := &repb.Digest{Hash: testHash, SizeBytes: 5}
-		rn := &resource.ResourceName{
+		rn := &rspb.ResourceName{
 			Digest:       d,
-			CacheType:    resource.CacheType_CAS,
+			CacheType:    rspb.CacheType_CAS,
 			InstanceName: "prefix",
 		}
 		ok, err := dc.Contains(ctx, rn)
@@ -1139,9 +1139,9 @@ func TestV2LayoutMigration(t *testing.T) {
 		require.NoError(t, err)
 
 		d := &repb.Digest{Hash: testHash, SizeBytes: 5}
-		rn := &resource.ResourceName{
+		rn := &rspb.ResourceName{
 			Digest:    d,
-			CacheType: resource.CacheType_CAS,
+			CacheType: rspb.CacheType_CAS,
 		}
 		ok, err := dc.Contains(ctx, rn)
 		require.NoError(t, err)
@@ -1158,9 +1158,9 @@ func TestV2LayoutMigration(t *testing.T) {
 		require.NoError(t, err)
 
 		d := &repb.Digest{Hash: testHash, SizeBytes: 5}
-		rn := &resource.ResourceName{
+		rn := &rspb.ResourceName{
 			Digest:       d,
-			CacheType:    resource.CacheType_CAS,
+			CacheType:    rspb.CacheType_CAS,
 			InstanceName: "prefix",
 		}
 		ok, err := dc.Contains(ctx, rn)

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	"github.com/buildbuddy-io/buildbuddy/proto/command_line"
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/accumulator"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_status_reporter"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/invocation_format"
@@ -50,6 +49,7 @@ import (
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
 	pgpb "github.com/buildbuddy-io/buildbuddy/proto/pagination"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	sipb "github.com/buildbuddy-io/buildbuddy/proto/stored_invocation"
 	uidpb "github.com/buildbuddy-io/buildbuddy/proto/user_id"
 	api_common "github.com/buildbuddy-io/buildbuddy/server/api/common"
@@ -576,7 +576,7 @@ func (w *webhookNotifier) lookupInvocation(ctx context.Context, ij *invocationJW
 						"response_type",
 					},
 				},
-				CacheType:    resource.CacheType_AC,
+				CacheType:    rspb.CacheType_AC,
 				RequestType:  capb.RequestType_READ,
 				ResponseType: capb.ResponseType_NOT_FOUND,
 			},

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/clickhouse/schema"
 	"github.com/buildbuddy-io/buildbuddy/server/util/role"
@@ -28,6 +27,7 @@ import (
 	qpb "github.com/buildbuddy-io/buildbuddy/proto/quota"
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 	skpb "github.com/buildbuddy-io/buildbuddy/proto/secrets"
@@ -222,18 +222,18 @@ type CacheMetadata struct {
 // storing of blob data based on its size.
 type Cache interface {
 	// Normal cache-like operations
-	Contains(ctx context.Context, r *resource.ResourceName) (bool, error)
-	Metadata(ctx context.Context, r *resource.ResourceName) (*CacheMetadata, error)
-	FindMissing(ctx context.Context, resources []*resource.ResourceName) ([]*repb.Digest, error)
-	Get(ctx context.Context, r *resource.ResourceName) ([]byte, error)
-	GetMulti(ctx context.Context, resources []*resource.ResourceName) (map[*repb.Digest][]byte, error)
-	Set(ctx context.Context, r *resource.ResourceName, data []byte) error
-	SetMulti(ctx context.Context, kvs map[*resource.ResourceName][]byte) error
-	Delete(ctx context.Context, r *resource.ResourceName) error
+	Contains(ctx context.Context, r *rspb.ResourceName) (bool, error)
+	Metadata(ctx context.Context, r *rspb.ResourceName) (*CacheMetadata, error)
+	FindMissing(ctx context.Context, resources []*rspb.ResourceName) ([]*repb.Digest, error)
+	Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error)
+	GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error)
+	Set(ctx context.Context, r *rspb.ResourceName, data []byte) error
+	SetMulti(ctx context.Context, kvs map[*rspb.ResourceName][]byte) error
+	Delete(ctx context.Context, r *rspb.ResourceName) error
 
 	// Low level interface used for seeking and stream-writing.
-	Reader(ctx context.Context, r *resource.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error)
-	Writer(ctx context.Context, r *resource.ResourceName) (CommittedWriteCloser, error)
+	Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error)
+	Writer(ctx context.Context, r *rspb.ResourceName) (CommittedWriteCloser, error)
 
 	// SupportsCompressor returns whether the cache supports storing data compressed with the given compressor
 	SupportsCompressor(compressor repb.Compressor_Value) bool

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
@@ -19,6 +18,7 @@ import (
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 type ActionCacheServer struct {
@@ -50,7 +50,7 @@ func NewActionCacheServer(env environment.Env) (*ActionCacheServer, error) {
 	}, nil
 }
 
-func checkFilesExist(ctx context.Context, cache interfaces.Cache, digests []*resource.ResourceName) error {
+func checkFilesExist(ctx context.Context, cache interfaces.Cache, digests []*rspb.ResourceName) error {
 	missing, err := cache.FindMissing(ctx, digests)
 	if err != nil {
 		return err
@@ -62,7 +62,7 @@ func checkFilesExist(ctx context.Context, cache interfaces.Cache, digests []*res
 }
 
 func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteInstanceName string, r *repb.ActionResult) error {
-	outputFileDigests := make([]*resource.ResourceName, 0, len(r.OutputFiles))
+	outputFileDigests := make([]*rspb.ResourceName, 0, len(r.OutputFiles))
 	mu := &sync.Mutex{}
 	appendDigest := func(d *repb.Digest) {
 		if d != nil && d.GetSizeBytes() > 0 {
@@ -150,9 +150,9 @@ func (s *ActionCacheServer) GetActionResult(ctx context.Context, req *repb.GetAc
 	// Fetch the "ActionResult" object which enumerates all the files in the action.
 	d := req.GetActionDigest()
 	downloadTracker := ht.TrackDownload(d)
-	blob, err := s.cache.Get(ctx, &resource.ResourceName{
+	blob, err := s.cache.Get(ctx, &rspb.ResourceName{
 		Digest:       d,
-		CacheType:    resource.CacheType_AC,
+		CacheType:    rspb.CacheType_AC,
 		InstanceName: req.GetInstanceName(),
 	})
 	if err != nil {

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
@@ -23,6 +22,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	gcodes "google.golang.org/grpc/codes"
 	gstatus "google.golang.org/grpc/status"
@@ -296,7 +296,7 @@ func ReadProtoFromAC(ctx context.Context, cache interfaces.Cache, d *digest.Reso
 	return readProtoFromCache(ctx, cache, acRN, out)
 }
 
-func UploadBytesToCache(ctx context.Context, cache interfaces.Cache, cacheType resource.CacheType, remoteInstanceName string, in io.ReadSeeker) (*repb.Digest, error) {
+func UploadBytesToCache(ctx context.Context, cache interfaces.Cache, cacheType rspb.CacheType, remoteInstanceName string, in io.ReadSeeker) (*repb.Digest, error) {
 	d, err := digest.Compute(in, repb.DigestFunction_SHA256)
 	if err != nil {
 		return nil, err
@@ -322,10 +322,10 @@ func UploadBytesToCache(ctx context.Context, cache interfaces.Cache, cacheType r
 }
 
 func UploadBytesToCAS(ctx context.Context, cache interfaces.Cache, instanceName string, in io.ReadSeeker) (*repb.Digest, error) {
-	return UploadBytesToCache(ctx, cache, resource.CacheType_CAS, instanceName, in)
+	return UploadBytesToCache(ctx, cache, rspb.CacheType_CAS, instanceName, in)
 }
 
-func uploadProtoToCache(ctx context.Context, cache interfaces.Cache, cacheType resource.CacheType, instanceName string, in proto.Message) (*repb.Digest, error) {
+func uploadProtoToCache(ctx context.Context, cache interfaces.Cache, cacheType rspb.CacheType, instanceName string, in proto.Message) (*repb.Digest, error) {
 	data, err := proto.Marshal(in)
 	if err != nil {
 		return nil, err
@@ -336,11 +336,11 @@ func uploadProtoToCache(ctx context.Context, cache interfaces.Cache, cacheType r
 
 func UploadBlobToCAS(ctx context.Context, cache interfaces.Cache, instanceName string, blob []byte) (*repb.Digest, error) {
 	reader := bytes.NewReader(blob)
-	return UploadBytesToCache(ctx, cache, resource.CacheType_CAS, instanceName, reader)
+	return UploadBytesToCache(ctx, cache, rspb.CacheType_CAS, instanceName, reader)
 }
 
 func UploadProtoToCAS(ctx context.Context, cache interfaces.Cache, instanceName string, in proto.Message) (*repb.Digest, error) {
-	return uploadProtoToCache(ctx, cache, resource.CacheType_CAS, instanceName, in)
+	return uploadProtoToCache(ctx, cache, rspb.CacheType_CAS, instanceName, in)
 }
 
 func SupportsCompression(ctx context.Context, capabilitiesClient repb.CapabilitiesClient) (bool, error) {
@@ -646,7 +646,7 @@ func uploadDir(ul *BatchCASUploader, dirPath string, visited []*repb.Directory) 
 }
 
 func UploadProtoToAC(ctx context.Context, cache interfaces.Cache, instanceName string, in proto.Message) (*repb.Digest, error) {
-	return uploadProtoToCache(ctx, cache, resource.CacheType_AC, instanceName, in)
+	return uploadProtoToCache(ctx, cache, rspb.CacheType_AC, instanceName, in)
 }
 
 func isExecutable(info os.FileInfo) bool {

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/memory_cache"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/memory_metrics_collector"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -32,6 +31,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	gcodes "google.golang.org/grpc/codes"
 )
@@ -63,7 +63,7 @@ type evilCache struct {
 	interfaces.Cache
 }
 
-func (e *evilCache) GetMulti(ctx context.Context, resources []*resource.ResourceName) (map[*repb.Digest][]byte, error) {
+func (e *evilCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	rsp, err := e.Cache.GetMulti(ctx, resources)
 	for d := range rsp {
 		rsp[d] = []byte{}

--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
@@ -24,6 +23,7 @@ import (
 
 	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 )
 
@@ -268,9 +268,9 @@ func (h *HitTracker) recordDetailedStats(d *repb.Digest, stats *detailedStats) e
 
 	// TODO(bduffany): Use protos instead of counterType so we can avoid this
 	// translation
-	cacheType := resource.CacheType_CAS
+	cacheType := rspb.CacheType_CAS
 	if h.actionCache {
-		cacheType = resource.CacheType_AC
+		cacheType = rspb.CacheType_AC
 	}
 	requestType := capb.RequestType_READ
 	if stats.Status == Upload {

--- a/server/remote_cache/hit_tracker/hit_tracker_test.go
+++ b/server/remote_cache/hit_tracker/hit_tracker_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/memory_metrics_collector"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/hit_tracker"
@@ -19,6 +18,7 @@ import (
 
 	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 func TestHitTracker_RecordsDetailedStats(t *testing.T) {
@@ -56,7 +56,7 @@ func TestHitTracker_RecordsDetailedStats(t *testing.T) {
 	assert.Equal(t, "GoCompile", actual.ActionMnemonic)
 	assert.Equal(t, "f498500e6d2825ef3bd5564bb56c439da36efe38ab4936ae0ff93794e704ccb4", actual.ActionId)
 	assert.Equal(t, "//foo:bar", actual.TargetId)
-	assert.Equal(t, resource.CacheType_CAS, actual.CacheType)
+	assert.Equal(t, rspb.CacheType_CAS, actual.CacheType)
 	assert.Equal(t, capb.RequestType_READ, actual.RequestType)
 	assert.Equal(t, d.Hash, actual.GetDigest().GetHash())
 	assert.Equal(t, d.SizeBytes, actual.GetDigest().GetSizeBytes())

--- a/server/remote_cache/scorecard/scorecard_test.go
+++ b/server/remote_cache/scorecard/scorecard_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/scorecard"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
@@ -24,6 +23,7 @@ import (
 
 	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	gcodes "google.golang.org/grpc/codes"
 )
@@ -38,7 +38,7 @@ var (
 	besUpload = &capb.ScoreCard_Result{
 		ActionId:    "bes-upload",
 		Digest:      &repb.Digest{Hash: "aaa", SizeBytes: 1_000},
-		CacheType:   resource.CacheType_CAS,
+		CacheType:   rspb.CacheType_CAS,
 		RequestType: capb.RequestType_WRITE,
 		Status:      &statuspb.Status{Code: int32(gcodes.OK)},
 		StartTime:   timestamppb.New(time.Unix(100, 0)),
@@ -49,7 +49,7 @@ var (
 		ActionMnemonic: "GoCompile",
 		TargetId:       "//foo",
 		Digest:         &repb.Digest{Hash: "abc", SizeBytes: 111},
-		CacheType:      resource.CacheType_AC,
+		CacheType:      rspb.CacheType_AC,
 		RequestType:    capb.RequestType_READ,
 		Status:         &statuspb.Status{Code: int32(gcodes.NotFound)},
 		StartTime:      timestamppb.New(time.Unix(300, 0)),
@@ -60,7 +60,7 @@ var (
 		ActionMnemonic: "GoCompile",
 		TargetId:       "//foo",
 		Digest:         &repb.Digest{Hash: "ccc", SizeBytes: 10_000},
-		CacheType:      resource.CacheType_CAS,
+		CacheType:      rspb.CacheType_CAS,
 		RequestType:    capb.RequestType_WRITE,
 		Status:         &statuspb.Status{Code: int32(gcodes.OK)},
 		StartTime:      timestamppb.New(time.Unix(200, 0)),
@@ -71,7 +71,7 @@ var (
 		ActionMnemonic: "GoLink",
 		TargetId:       "//bar",
 		Digest:         &repb.Digest{Hash: "fff", SizeBytes: 100_000},
-		CacheType:      resource.CacheType_CAS,
+		CacheType:      rspb.CacheType_CAS,
 		RequestType:    capb.RequestType_READ,
 		Status:         &statuspb.Status{Code: int32(gcodes.OK)},
 		StartTime:      timestamppb.New(time.Unix(400, 0)),
@@ -113,7 +113,7 @@ func TestGetCacheScoreCard_Filter_CacheType(t *testing.T) {
 		InvocationId: invocationID,
 		Filter: &capb.GetCacheScoreCardRequest_Filter{
 			Mask:      &fieldmaskpb.FieldMask{Paths: []string{"cache_type"}},
-			CacheType: resource.CacheType_AC,
+			CacheType: rspb.CacheType_AC,
 		},
 	}
 

--- a/server/testutil/testcompression/testcompression.go
+++ b/server/testutil/testcompression/testcompression.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"io"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/compression"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 // CompressionCache simulates a cache that supports compression for unit tests
@@ -18,7 +18,7 @@ type CompressionCache struct {
 	interfaces.Cache
 }
 
-func (c *CompressionCache) Get(ctx context.Context, r *resource.ResourceName) ([]byte, error) {
+func (c *CompressionCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error) {
 	data, err := c.Cache.Get(ctx, r)
 	if err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func (c *CompressionCache) Get(ctx context.Context, r *resource.ResourceName) ([
 	return cachedDataWithCompression, nil
 }
 
-func (c *CompressionCache) Reader(ctx context.Context, rn *resource.ResourceName, offset, limit int64) (io.ReadCloser, error) {
+func (c *CompressionCache) Reader(ctx context.Context, rn *rspb.ResourceName, offset, limit int64) (io.ReadCloser, error) {
 	buf, err := c.Get(ctx, rn)
 	if err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func (c *CompressionCache) Reader(ctx context.Context, rn *resource.ResourceName
 	return io.NopCloser(r), nil
 }
 
-func (c *CompressionCache) GetMulti(ctx context.Context, resources []*resource.ResourceName) (map[*repb.Digest][]byte, error) {
+func (c *CompressionCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
 	foundMap := make(map[*repb.Digest][]byte, len(resources))
 	for _, r := range resources {
 		data, err := c.Get(ctx, r)
@@ -64,7 +64,7 @@ func (c *CompressionCache) GetMulti(ctx context.Context, resources []*resource.R
 	return foundMap, nil
 }
 
-func dataWithCompression(requestedResource *resource.ResourceName, cachedData []byte) ([]byte, error) {
+func dataWithCompression(requestedResource *rspb.ResourceName, cachedData []byte) ([]byte, error) {
 	isCompressed := int64(len(cachedData)) != requestedResource.GetDigest().GetSizeBytes()
 	if isCompressed {
 		if requestedResource.GetCompressor() == repb.Compressor_ZSTD {


### PR DESCRIPTION
This makes resource (a proto) consistent with other proto imports.

The aliasing is nice because it makes it clear when reading the code that you're dealing with a proto and all that entails (versioning, serialization, copying, etc...).

I noticed this when refactoring some other stuff to support additional digest types and figured I'd clean it up before doing that refactor.