### PR TITLE
Remove New{CAS,AC}ResourceName methods

### DIFF
--- a/cli/cache_proxy/cache_proxy.go
+++ b/cli/cache_proxy/cache_proxy.go
@@ -214,7 +214,7 @@ func (p *CacheProxy) Read(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServ
 		if err != nil {
 			if err == io.EOF {
 				if localFile != nil {
-					resourceName := digest.NewResourceName(d, instanceName)
+					resourceName := digest.NewGenericResourceName(d, instanceName)
 					if _, err := cachetools.UploadFromReader(ctx, p.localBSSClient, resourceName, localFile); err != nil {
 						log.Errorf("error uploading from reader: %s", err.Error())
 					}

--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -413,13 +413,13 @@ func (s *APIServer) DeleteFile(ctx context.Context, req *apipb.DeleteFileRequest
 		if err != nil {
 			return nil, status.InvalidArgumentErrorf("Invalid URL. Does not match expected actioncache URI pattern: %s", err)
 		}
-		resourceName = digest.NewACResourceName(parsedRN.GetDigest(), parsedRN.GetInstanceName()).ToProto()
+		resourceName = digest.NewResourceName(parsedRN.GetDigest(), parsedRN.GetInstanceName(), rspb.CacheType_AC).ToProto()
 	} else if digest.IsDownloadResourceName(urlStr) {
 		parsedRN, err := digest.ParseDownloadResourceName(urlStr)
 		if err != nil {
 			return nil, status.InvalidArgumentErrorf("Invalid URL. Does not match expected CAS URI pattern: %s", err)
 		}
-		resourceName = digest.NewCASResourceName(parsedRN.GetDigest(), parsedRN.GetInstanceName()).ToProto()
+		resourceName = digest.NewResourceName(parsedRN.GetDigest(), parsedRN.GetInstanceName(), rspb.CacheType_CAS).ToProto()
 	} else {
 		return nil, status.InvalidArgumentErrorf("Invalid URL. Only actioncache and CAS URIs supported.")
 	}

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -508,14 +508,14 @@ func TestCopyPartitionData(t *testing.T) {
 				size = 1000
 			}
 			d, buf := testdigest.NewRandomDigestBuf(t, size)
-			r := digest.NewCASResourceName(d, instanceName).ToProto()
+			r := digest.NewResourceName(d, instanceName, rspb.CacheType_CAS).ToProto()
 			defaultResources = append(defaultResources, r)
 			err = pc.Set(ctx, r, buf)
 			require.NoError(t, err)
 		}
 		for i := 0; i < 10; i++ {
 			d, buf := testdigest.NewRandomDigestBuf(t, 100)
-			r := digest.NewACResourceName(d, instanceName).ToProto()
+			r := digest.NewResourceName(d, instanceName, rspb.CacheType_AC).ToProto()
 			defaultResources = append(defaultResources, r)
 			err = pc.Set(ctx, r, buf)
 			require.NoError(t, err)
@@ -527,14 +527,14 @@ func TestCopyPartitionData(t *testing.T) {
 		ctx := te.GetAuthenticator().AuthContextFromAPIKey(context.Background(), testAPIKey)
 		for i := 0; i < 10; i++ {
 			d, buf := testdigest.NewRandomDigestBuf(t, 1000)
-			r := digest.NewCASResourceName(d, instanceName).ToProto()
+			r := digest.NewResourceName(d, instanceName, rspb.CacheType_CAS).ToProto()
 			customResources = append(customResources, r)
 			err = pc.Set(ctx, r, buf)
 			require.NoError(t, err)
 		}
 		for i := 0; i < 10; i++ {
 			d, buf := testdigest.NewRandomDigestBuf(t, 100)
-			r := digest.NewACResourceName(d, instanceName).ToProto()
+			r := digest.NewResourceName(d, instanceName, rspb.CacheType_AC).ToProto()
 			customResources = append(customResources, r)
 			err = pc.Set(ctx, r, buf)
 			require.NoError(t, err)

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -989,7 +989,7 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 		runfiles = append(runfiles, &bespb.File{
 			Name: relPath,
 			File: &bespb.File_Uri{
-				Uri: fmt.Sprintf("%s%s", bytestreamURIPrefix, digest.NewResourceName(d.ToDigest(), *remoteInstanceName).DownloadString()),
+				Uri: fmt.Sprintf("%s%s", bytestreamURIPrefix, digest.NewGenericResourceName(d.ToDigest(), *remoteInstanceName).DownloadString()),
 			},
 		})
 	}
@@ -1043,7 +1043,7 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 			mu.Lock()
 			runfileDirs = append(runfileDirs, &bespb.Tree{
 				Name: relPath,
-				Uri:  fmt.Sprintf("%s%s", bytestreamURIPrefix, digest.NewResourceName(td, *remoteInstanceName).DownloadString()),
+				Uri:  fmt.Sprintf("%s%s", bytestreamURIPrefix, digest.NewGenericResourceName(td, *remoteInstanceName).DownloadString()),
 			})
 			mu.Unlock()
 			return nil
@@ -1325,7 +1325,7 @@ func (ws *workspace) applyPatch(ctx context.Context, bsClient bspb.ByteStreamCli
 	if err != nil {
 		return err
 	}
-	if err := cachetools.GetBlob(ctx, bsClient, digest.NewResourceName(d, *remoteInstanceName), f); err != nil {
+	if err := cachetools.GetBlob(ctx, bsClient, digest.NewGenericResourceName(d, *remoteInstanceName), f); err != nil {
 		_ = f.Close()
 		return err
 	}

--- a/enterprise/server/cmd/smash/smash.go
+++ b/enterprise/server/cmd/smash/smash.go
@@ -137,7 +137,7 @@ func newRandomDigestBuf(sizeBytes int64) (*repb.Digest, []byte) {
 
 func writeDataFunc(mtd *desc.MethodDescriptor, cd *runner.CallData) []byte {
 	d, buf := newRandomDigestBuf(randomBlobSize())
-	resourceName, err := digest.NewResourceName(d, *instanceName).UploadString()
+	resourceName, err := digest.NewGenericResourceName(d, *instanceName).UploadString()
 	if err != nil {
 		log.Fatalf("Error computing upload resource name: %s", err)
 	}
@@ -157,7 +157,7 @@ func writeDataFunc(mtd *desc.MethodDescriptor, cd *runner.CallData) []byte {
 func readDataFunc(mtd *desc.MethodDescriptor, cd *runner.CallData) []byte {
 	randomDigest := preWrittenDigests[rand.Intn(len(preWrittenDigests))]
 
-	resourceName := digest.NewResourceName(randomDigest, *instanceName).DownloadString()
+	resourceName := digest.NewGenericResourceName(randomDigest, *instanceName).DownloadString()
 	rr := &bspb.ReadRequest{
 		ResourceName: resourceName,
 		ReadOffset:   0,

--- a/enterprise/server/image_converter/image_converter.go
+++ b/enterprise/server/image_converter/image_converter.go
@@ -394,7 +394,7 @@ func (c *imageConverter) convertLayer(ctx context.Context, req *rgpb.ConvertLaye
 		return nil, status.UnknownErrorf("could not compute digest of new layer: %s", err)
 	}
 
-	rn := digest.NewResourceName(newLayerDigest, registryInstanceName)
+	rn := digest.NewGenericResourceName(newLayerDigest, registryInstanceName)
 	casDigest, err := cachetools.UploadFromReader(ctx, c.bsClient, rn, bytes.NewReader(newLayerData))
 	if err != nil {
 		return nil, status.UnknownErrorf("could not upload converted layer %q: %s", newLayerDigest, err)

--- a/enterprise/server/raft/cache/cache_test.go
+++ b/enterprise/server/raft/cache/cache_test.go
@@ -261,7 +261,7 @@ func TestCacheShutdown(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, cacheRPCTimeout)
 		defer cancel()
 		d, buf := testdigest.NewRandomDigestBuf(t, 100)
-		rn := digest.NewCASResourceName(d, "remote/instance/name").ToProto()
+		rn := digest.NewResourceName(d, "remote/instance/name", rspb.CacheType_CAS).ToProto()
 		writeDigest(t, ctx, rc1, rn, buf)
 		digestsWritten = append(digestsWritten, rn)
 	}
@@ -273,7 +273,7 @@ func TestCacheShutdown(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, cacheRPCTimeout)
 		defer cancel()
 		d, buf := testdigest.NewRandomDigestBuf(t, 100)
-		rn := digest.NewCASResourceName(d, "remote/instance/name").ToProto()
+		rn := digest.NewResourceName(d, "remote/instance/name", rspb.CacheType_CAS).ToProto()
 		writeDigest(t, ctx, rc1, rn, buf)
 		digestsWritten = append(digestsWritten, rn)
 	}

--- a/enterprise/server/registry/registry.go
+++ b/enterprise/server/registry/registry.go
@@ -200,7 +200,7 @@ func blobResourceName(h v1.Hash) *rspb.ResourceName {
 		// to be large. The server uses this to determine the buffer size.
 		SizeBytes: 1024 * 1024 * 4,
 	}
-	rn := digest.NewCASResourceName(d, registryInstanceName).ToProto()
+	rn := digest.NewResourceName(d, registryInstanceName, rspb.CacheType_CAS).ToProto()
 	return rn
 }
 

--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -701,7 +701,7 @@ func (ff *BatchFileFetcher) bytestreamReadFiles(ctx context.Context, instanceNam
 	if err != nil {
 		return err
 	}
-	resourceName := digest.NewResourceName(fp.FileNode.Digest, instanceName)
+	resourceName := digest.NewGenericResourceName(fp.FileNode.Digest, instanceName)
 	if ff.supportsCompression() {
 		resourceName.SetCompressor(repb.Compressor_ZSTD)
 	}

--- a/enterprise/server/remote_execution/execution_server/BUILD
+++ b/enterprise/server/remote_execution/execution_server/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//enterprise/server/util/execution",
         "//proto:execution_stats_go_proto",
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//proto:scheduler_go_proto",
         "//proto:stored_invocation_go_proto",
         "//server/environment",

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -157,7 +157,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	task := st.ExecutionTask
 	req := task.GetExecuteRequest()
 	taskID := task.GetExecutionId()
-	adInstanceDigest := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName())
+	adInstanceDigest := digest.NewGenericResourceName(req.GetActionDigest(), req.GetInstanceName())
 
 	acClient := s.env.GetActionCacheClient()
 
@@ -307,7 +307,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		if err != nil {
 			return finishWithErrFn(status.UnavailableErrorf("Error uploading action result: %s", err.Error()))
 		}
-		adInstanceDigest = digest.NewResourceName(resultDigest, req.GetInstanceName())
+		adInstanceDigest = digest.NewGenericResourceName(resultDigest, req.GetInstanceName())
 	}
 	if err := cachetools.UploadActionResult(ctx, acClient, adInstanceDigest, actionResult); err != nil {
 		return finishWithErrFn(status.UnavailableErrorf("Error uploading action result: %s", err.Error()))

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -269,7 +269,7 @@ func (r *commandRunner) PrepareForTask(ctx context.Context) error {
 }
 
 func (r *commandRunner) DownloadInputs(ctx context.Context, ioStats *repb.IOStats) error {
-	rootInstanceDigest := digest.NewResourceName(
+	rootInstanceDigest := digest.NewGenericResourceName(
 		r.task.GetAction().GetInputRootDigest(),
 		r.task.GetExecuteRequest().GetInstanceName(),
 	)

--- a/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
@@ -271,7 +271,7 @@ func (c *Client) PrepareCommand(ctx context.Context, instanceName string, name s
 	command := &Command{
 		gRPCClientSource:   c.gRPClientSource,
 		Name:               name,
-		actionResourceName: digest.NewResourceName(actionDigest, instanceName),
+		actionResourceName: digest.NewGenericResourceName(actionDigest, instanceName),
 	}
 
 	return command, nil
@@ -283,7 +283,7 @@ func (c *Client) DownloadActionOutputs(ctx context.Context, env environment.Env,
 		if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
 			return err
 		}
-		d := digest.NewResourceName(out.GetDigest(), res.InstanceName)
+		d := digest.NewGenericResourceName(out.GetDigest(), res.InstanceName)
 		f, err := os.Create(path)
 		if err != nil {
 			return err
@@ -299,7 +299,7 @@ func (c *Client) DownloadActionOutputs(ctx context.Context, env environment.Env,
 		if err := os.MkdirAll(path, 0777); err != nil {
 			return err
 		}
-		treeDigest := digest.NewResourceName(dir.GetTreeDigest(), res.InstanceName)
+		treeDigest := digest.NewGenericResourceName(dir.GetTreeDigest(), res.InstanceName)
 		tree := &repb.Tree{}
 		if err := cachetools.GetBlobAsProto(ctx, c.gRPClientSource.GetByteStreamClient(), treeDigest, tree); err != nil {
 			return err

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -955,7 +955,7 @@ func (r *Env) GetActionResultForFailedAction(ctx context.Context, cmd *Command, 
 func (r *Env) GetStdoutAndStderr(ctx context.Context, actionResult *repb.ActionResult, instanceName string) (string, string, error) {
 	stdout := ""
 	if actionResult.GetStdoutDigest() != nil {
-		d := digest.NewResourceName(actionResult.GetStdoutDigest(), instanceName)
+		d := digest.NewGenericResourceName(actionResult.GetStdoutDigest(), instanceName)
 		buf := bytes.NewBuffer(make([]byte, 0, d.GetDigest().GetSizeBytes()))
 		err := cachetools.GetBlob(ctx, r.GetByteStreamClient(), d, buf)
 		if err != nil {
@@ -966,7 +966,7 @@ func (r *Env) GetStdoutAndStderr(ctx context.Context, actionResult *repb.ActionR
 
 	stderr := ""
 	if actionResult.GetStderrDigest() != nil {
-		d := digest.NewResourceName(actionResult.GetStderrDigest(), instanceName)
+		d := digest.NewGenericResourceName(actionResult.GetStderrDigest(), instanceName)
 		buf := bytes.NewBuffer(make([]byte, 0, d.GetDigest().GetSizeBytes()))
 		err := cachetools.GetBlob(ctx, r.GetByteStreamClient(), d, buf)
 		if err != nil {

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -202,7 +202,7 @@ func getResources(resources []*rspb.ResourceName, isolation *dcpb.Isolation, dig
 	rns := make([]*rspb.ResourceName, 0)
 	for _, k := range digestKeys {
 		d := digestFromKey(k)
-		rn := digest.NewCacheResourceName(d, instanceName, cacheType).ToProto()
+		rn := digest.NewResourceName(d, instanceName, cacheType).ToProto()
 		rns = append(rns, rn)
 	}
 

--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -125,12 +125,12 @@ type execution struct {
 // getExecution fetches digest contents of an ExecuteRequest.
 func getExecution(t *testing.T, ctx context.Context, te *testenv.TestEnv, executeRequest *repb.ExecuteRequest) *execution {
 	instanceName := executeRequest.GetInstanceName()
-	ar := digest.NewResourceName(executeRequest.GetActionDigest(), instanceName)
+	ar := digest.NewGenericResourceName(executeRequest.GetActionDigest(), instanceName)
 	action := &repb.Action{}
 	err := cachetools.GetBlobAsProto(ctx, te.GetByteStreamClient(), ar, action)
 	require.NoError(t, err)
 	command := &repb.Command{}
-	cr := digest.NewResourceName(action.GetCommandDigest(), instanceName)
+	cr := digest.NewGenericResourceName(action.GetCommandDigest(), instanceName)
 	err = cachetools.GetBlobAsProto(ctx, te.GetByteStreamClient(), cr, command)
 	require.NoError(t, err)
 	return &execution{

--- a/server/backends/disk_cache/disk_cache_test.go
+++ b/server/backends/disk_cache/disk_cache_test.go
@@ -787,7 +787,7 @@ func TestZeroLengthFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Ensure that the goodDigest exists and the zero length one does not.
-	exists, err := dc.Contains(ctx, digest.NewCASResourceName(badDigest, "").ToProto())
+	exists, err := dc.Contains(ctx, digest.NewResourceName(badDigest, "", rspb.CacheType_CAS).ToProto())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -795,7 +795,7 @@ func TestZeroLengthFiles(t *testing.T) {
 		t.Fatalf("%q (empty file) should not be mapped in cache.", badDigest.GetHash())
 	}
 
-	exists, err = dc.Contains(ctx, digest.NewCASResourceName(goodDigest, "").ToProto())
+	exists, err = dc.Contains(ctx, digest.NewResourceName(goodDigest, "", rspb.CacheType_CAS).ToProto())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/remote_asset/fetch_server/BUILD
+++ b/server/remote_asset/fetch_server/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//proto:remote_asset_go_proto",
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/environment",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",

--- a/server/remote_asset/fetch_server/fetch_server.go
+++ b/server/remote_asset/fetch_server/fetch_server.go
@@ -22,6 +22,7 @@ import (
 
 	rapb "github.com/buildbuddy-io/buildbuddy/proto/remote_asset"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	gcodes "google.golang.org/grpc/codes"
@@ -125,7 +126,7 @@ func (p *FetchServer) FetchBlob(ctx context.Context, req *rapb.FetchBlobRequest)
 				SizeBytes: 1,
 			}
 			expectedSHA256 = blobDigest.Hash
-			cacheRN := digest.NewCASResourceName(blobDigest, req.GetInstanceName())
+			cacheRN := digest.NewResourceName(blobDigest, req.GetInstanceName(), rspb.CacheType_CAS)
 
 			log.CtxInfof(ctx, "Looking up %s in cache", blobDigest.Hash)
 
@@ -142,7 +143,7 @@ func (p *FetchServer) FetchBlob(ctx context.Context, req *rapb.FetchBlobRequest)
 			// Even though we successfully fetched metadata, we need to renew
 			// the cache entry (using Contains()) to ensure that it doesn't
 			// expire by the time the client requests it from cache.
-			cacheRN = digest.NewCASResourceName(blobDigest, req.GetInstanceName())
+			cacheRN = digest.NewResourceName(blobDigest, req.GetInstanceName(), rspb.CacheType_CAS)
 			exists, err := cache.Contains(ctx, cacheRN.ToProto())
 			if err != nil {
 				log.CtxErrorf(ctx, "Failed to renew %s: %s", digest.String(blobDigest), err)
@@ -221,7 +222,7 @@ func mirrorToCache(ctx context.Context, bsClient bspb.ByteStreamClient, remoteIn
 	// response to cache.
 	if expectedSHA256 != "" && rsp.ContentLength >= 0 {
 		d := &repb.Digest{Hash: expectedSHA256, SizeBytes: rsp.ContentLength}
-		rn := digest.NewResourceName(d, remoteInstanceName)
+		rn := digest.NewGenericResourceName(d, remoteInstanceName)
 		if _, err := cachetools.UploadFromReader(ctx, bsClient, rn, rsp.Body); err != nil {
 			return nil, status.UnavailableErrorf("failed to upload %s to cache: %s", digest.String(d), err)
 		}

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -67,7 +67,7 @@ func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteIns
 	appendDigest := func(d *repb.Digest) {
 		if d != nil && d.GetSizeBytes() > 0 {
 			mu.Lock()
-			rn := digest.NewCASResourceName(d, remoteInstanceName).ToProto()
+			rn := digest.NewResourceName(d, remoteInstanceName, rspb.CacheType_CAS).ToProto()
 			outputFileDigests = append(outputFileDigests, rn)
 			mu.Unlock()
 		}
@@ -80,7 +80,7 @@ func ValidateActionResult(ctx context.Context, cache interfaces.Cache, remoteIns
 	for _, d := range r.OutputDirectories {
 		dc := d
 		g.Go(func() error {
-			rn := digest.NewCASResourceName(dc.GetTreeDigest(), remoteInstanceName).ToProto()
+			rn := digest.NewResourceName(dc.GetTreeDigest(), remoteInstanceName, rspb.CacheType_CAS).ToProto()
 			blob, err := cache.Get(gCtx, rn)
 			if err != nil {
 				return err
@@ -214,7 +214,7 @@ func (s *ActionCacheServer) UpdateActionResult(ctx context.Context, req *repb.Up
 
 	ht := hit_tracker.NewHitTracker(ctx, s.env, true)
 	d := req.GetActionDigest()
-	acResource := digest.NewACResourceName(d, req.GetInstanceName())
+	acResource := digest.NewResourceName(d, req.GetInstanceName(), rspb.CacheType_AC)
 	uploadTracker := ht.TrackUpload(d)
 
 	// Context: https://github.com/bazelbuild/remote-apis/pull/131

--- a/server/remote_cache/byte_stream_server/BUILD
+++ b/server/remote_cache/byte_stream_server/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//proto:api_key_go_proto",
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/environment",
         "//server/interfaces",
         "//server/remote_cache/config",
@@ -32,6 +33,7 @@ go_test(
     embed = [":byte_stream_server"],
     deps = [
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/backends/memory_metrics_collector",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -21,6 +21,7 @@ import (
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	remote_cache_config "github.com/buildbuddy-io/buildbuddy/server/remote_cache/config"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
@@ -111,7 +112,7 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 	}
 	downloadTracker := ht.TrackDownload(r.GetDigest())
 
-	cacheRN := digest.NewCASResourceName(r.GetDigest(), r.GetInstanceName())
+	cacheRN := digest.NewResourceName(r.GetDigest(), r.GetInstanceName(), rspb.CacheType_CAS)
 	passthroughCompressionEnabled := s.cache.SupportsCompressor(r.GetCompressor()) && req.ReadOffset == 0 && req.ReadLimit == 0
 	if passthroughCompressionEnabled {
 		cacheRN.SetCompressor(r.GetCompressor())
@@ -257,7 +258,7 @@ func (s *ByteStreamServer) initStreamState(ctx context.Context, req *bspb.WriteR
 		resourceNameString: req.ResourceName,
 	}
 
-	casRN := digest.NewCASResourceName(r.GetDigest(), r.GetInstanceName())
+	casRN := digest.NewResourceName(r.GetDigest(), r.GetInstanceName(), rspb.CacheType_CAS)
 	if s.cache.SupportsCompressor(r.GetCompressor()) {
 		casRN.SetCompressor(r.GetCompressor())
 	}

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	guuid "github.com/google/uuid"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	gstatus "google.golang.org/grpc/status"
@@ -100,46 +101,51 @@ func TestRPCRead(t *testing.T) {
 		offset       int64
 	}{
 		{ // Simple Read
-			resourceName: digest.NewCASResourceName(&repb.Digest{
+			resourceName: digest.NewResourceName(&repb.Digest{
 				Hash:      "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d",
 				SizeBytes: 1234,
-			}, ""),
+			}, "", rspb.CacheType_CAS),
+
 			wantData:  randStr(1234),
 			wantError: nil,
 			offset:    0,
 		},
 		{ // Large Read
-			resourceName: digest.NewCASResourceName(&repb.Digest{
+			resourceName: digest.NewResourceName(&repb.Digest{
 				Hash:      "ffd14ebb6c1b2701ac793ea1aff6dddf8540e734bd6d051ac2a24aa3ec062781",
 				SizeBytes: 1000 * 1000 * 100,
-			}, ""),
+			}, "", rspb.CacheType_CAS),
+
 			wantData:  randStr(1000 * 1000 * 100),
 			wantError: nil,
 			offset:    0,
 		},
 		{ // 0 length read
-			resourceName: digest.NewCASResourceName(&repb.Digest{
+			resourceName: digest.NewResourceName(&repb.Digest{
 				Hash:      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 				SizeBytes: 0,
-			}, ""),
+			}, "", rspb.CacheType_CAS),
+
 			wantData:  "",
 			wantError: nil,
 			offset:    0,
 		},
 		{ // Offset
-			resourceName: digest.NewCASResourceName(&repb.Digest{
+			resourceName: digest.NewResourceName(&repb.Digest{
 				Hash:      "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d",
 				SizeBytes: 1234,
-			}, ""),
+			}, "", rspb.CacheType_CAS),
+
 			wantData:  randStr(1234),
 			wantError: nil,
 			offset:    1,
 		},
 		{ // Max offset
-			resourceName: digest.NewCASResourceName(&repb.Digest{
+			resourceName: digest.NewResourceName(&repb.Digest{
 				Hash:      "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d",
 				SizeBytes: 1234,
-			}, ""),
+			}, "", rspb.CacheType_CAS),
+
 			wantData:  randStr(1234),
 			wantError: nil,
 			offset:    1234,
@@ -179,7 +185,7 @@ func TestRPCWrite(t *testing.T) {
 
 	// Test that a regular bytestream upload works.
 	d, readSeeker := testdigest.NewRandomDigestReader(t, 1000)
-	instanceNameDigest := digest.NewResourceName(d, "")
+	instanceNameDigest := digest.NewGenericResourceName(d, "")
 	_, err := cachetools.UploadFromReader(ctx, bsClient, instanceNameDigest, readSeeker)
 	if err != nil {
 		t.Fatal(err)
@@ -194,7 +200,7 @@ func TestRPCMalformedWrite(t *testing.T) {
 
 	// Test that a malformed upload (incorrect digest) is rejected.
 	d, buf := testdigest.NewRandomDigestBuf(t, 1000)
-	instanceNameDigest := digest.NewResourceName(d, "")
+	instanceNameDigest := digest.NewGenericResourceName(d, "")
 	buf[0] = ^buf[0] // flip bits in byte to corrupt digest.
 
 	readSeeker := bytes.NewReader(buf)
@@ -213,7 +219,7 @@ func TestRPCTooLongWrite(t *testing.T) {
 	// Test that a malformed upload (wrong bytesize) is rejected.
 	d, buf := testdigest.NewRandomDigestBuf(t, 1000)
 	d.SizeBytes += 1 // increment expected byte count by 1 to trigger mismatch.
-	instanceNameDigest := digest.NewResourceName(d, "")
+	instanceNameDigest := digest.NewGenericResourceName(d, "")
 
 	readSeeker := bytes.NewReader(buf)
 	_, err := cachetools.UploadFromReader(ctx, bsClient, instanceNameDigest, readSeeker)
@@ -233,7 +239,7 @@ func TestRPCReadWriteLargeBlob(t *testing.T) {
 	require.NoError(t, err)
 	d, err := digest.Compute(strings.NewReader(blob), repb.DigestFunction_SHA256)
 	require.NoError(t, err)
-	instanceNameDigest := digest.NewResourceName(d, "")
+	instanceNameDigest := digest.NewGenericResourceName(d, "")
 
 	// Write
 	_, err = cachetools.UploadFromReader(ctx, bsClient, instanceNameDigest, strings.NewReader(blob))

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -90,7 +90,7 @@ type ResourceName struct {
 	rn *rspb.ResourceName
 }
 
-func NewResourceName(d *repb.Digest, instanceName string) *ResourceName {
+func NewGenericResourceName(d *repb.Digest, instanceName string) *ResourceName {
 	return &ResourceName{
 		rn: &rspb.ResourceName{
 			Digest:       d,
@@ -100,35 +100,13 @@ func NewResourceName(d *repb.Digest, instanceName string) *ResourceName {
 	}
 }
 
-func NewCacheResourceName(d *repb.Digest, instanceName string, cacheType rspb.CacheType) *ResourceName {
+func NewResourceName(d *repb.Digest, instanceName string, cacheType rspb.CacheType) *ResourceName {
 	return &ResourceName{
 		rn: &rspb.ResourceName{
 			Digest:       d,
 			InstanceName: instanceName,
 			Compressor:   repb.Compressor_IDENTITY,
 			CacheType:    cacheType,
-		},
-	}
-}
-
-func NewCASResourceName(d *repb.Digest, instanceName string) *ResourceName {
-	return &ResourceName{
-		rn: &rspb.ResourceName{
-			Digest:       d,
-			InstanceName: instanceName,
-			Compressor:   repb.Compressor_IDENTITY,
-			CacheType:    rspb.CacheType_CAS,
-		},
-	}
-}
-
-func NewACResourceName(d *repb.Digest, instanceName string) *ResourceName {
-	return &ResourceName{
-		rn: &rspb.ResourceName{
-			Digest:       d,
-			InstanceName: instanceName,
-			Compressor:   repb.Compressor_IDENTITY,
-			CacheType:    rspb.CacheType_AC,
 		},
 	}
 }
@@ -385,7 +363,7 @@ func parseResourceName(resourceName string, matcher *regexp.Regexp) (*ResourceNa
 		compressor = repb.Compressor_ZSTD
 	}
 	d := &repb.Digest{Hash: hash, SizeBytes: sizeBytes}
-	r := NewResourceName(d, instanceName)
+	r := NewGenericResourceName(d, instanceName)
 	r.SetCompressor(compressor)
 	return r, nil
 }

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -42,7 +42,7 @@ func TestParseResourceName(t *testing.T) {
 		{ // download, resource with instance name
 			resourceName: "my_instance_name/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			matcher:      downloadRegex,
-			wantParsed:   NewResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "my_instance_name"),
+			wantParsed:   NewGenericResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "my_instance_name"),
 		},
 		{ // download, resource with zstd compression
 			resourceName: "/compressed-blobs/zstd/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
@@ -57,12 +57,12 @@ func TestParseResourceName(t *testing.T) {
 		{ // download, resource with digest only
 			resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			matcher:      downloadRegex,
-			wantParsed:   NewResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, ""),
+			wantParsed:   NewGenericResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, ""),
 		},
 		{ // upload, UUID and instance name
 			resourceName: "instance_name/uploads/2148e1f1-aacc-41eb-a31c-22b6da7c7ac1/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			matcher:      uploadRegex,
-			wantParsed:   NewResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "instance_name"),
+			wantParsed:   NewGenericResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "instance_name"),
 		},
 		{ // upload, UUID, instance name, and compression
 			resourceName: "instance_name/uploads/2148e1f1-aacc-41eb-a31c-22b6da7c7ac1/compressed-blobs/zstd/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
@@ -72,7 +72,7 @@ func TestParseResourceName(t *testing.T) {
 		{ // action
 			resourceName: "instance_name/blobs/ac/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			matcher:      actionCacheRegex,
-			wantParsed:   NewResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "instance_name"),
+			wantParsed:   NewGenericResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "instance_name"),
 		},
 		{ // invalid action
 			resourceName: "instance_name/blobs/notac/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
@@ -97,7 +97,7 @@ func TestParseResourceName(t *testing.T) {
 }
 
 func newZstdResourceName(d *repb.Digest, instanceName string) *ResourceName {
-	r := NewResourceName(d, instanceName)
+	r := NewGenericResourceName(d, instanceName)
 	r.SetCompressor(repb.Compressor_ZSTD)
 	return r
 }

--- a/tools/cacheload/cacheload.go
+++ b/tools/cacheload/cacheload.go
@@ -122,7 +122,7 @@ func incrementPromErrorMetric(err error) {
 
 func writeBlob(ctx context.Context, client bspb.ByteStreamClient) (*repb.Digest, error) {
 	d, buf := newRandomDigestBuf(randomBlobSize())
-	resourceName := digest.NewResourceName(d, *instanceName)
+	resourceName := digest.NewGenericResourceName(d, *instanceName)
 	if *writeCompressed {
 		resourceName.SetCompressor(repb.Compressor_ZSTD)
 	}
@@ -142,7 +142,7 @@ func writeBlob(ctx context.Context, client bspb.ByteStreamClient) (*repb.Digest,
 }
 
 func readBlob(ctx context.Context, client bspb.ByteStreamClient, d *repb.Digest) error {
-	resourceName := digest.NewResourceName(d, *instanceName)
+	resourceName := digest.NewGenericResourceName(d, *instanceName)
 	if *readCompressed {
 		resourceName.SetCompressor(repb.Compressor_ZSTD)
 	}

--- a/tools/cas/cas.go
+++ b/tools/cas/cas.go
@@ -75,7 +75,7 @@ func main() {
 	if *blobType == "ActionResult" {
 		cacheType = rspb.CacheType_AC
 	}
-	ind := digest.NewCacheResourceName(d, *instanceName, cacheType)
+	ind := digest.NewResourceName(d, *instanceName, cacheType)
 	conn, err := grpc_client.DialTarget(*target)
 	if err != nil {
 		log.Fatalf("Error dialing CAS target: %s", err)
@@ -134,7 +134,7 @@ func main() {
 			if err != nil {
 				log.Fatalf(err.Error())
 			}
-			ind := digest.NewResourceName(failedDigest, ind.GetInstanceName())
+			ind := digest.NewGenericResourceName(failedDigest, ind.GetInstanceName())
 			ar, err = cachetools.GetActionResult(ctx, acClient, ind)
 			if err != nil {
 				log.Fatal(err.Error())

--- a/tools/vmstart/vmstart.go
+++ b/tools/vmstart/vmstart.go
@@ -160,7 +160,7 @@ func main() {
 			log.Fatalf("Error parsing action digest %q: %s", *actionDigest, err)
 		}
 
-		actionInstanceDigest := digest.NewResourceName(d, *remoteInstanceName)
+		actionInstanceDigest := digest.NewGenericResourceName(d, *remoteInstanceName)
 
 		action, cmd, err := cachetools.GetActionAndCommand(ctx, env.GetByteStreamClient(), actionInstanceDigest)
 		if err != nil {
@@ -171,7 +171,7 @@ func main() {
 		out, _ = prototext.Marshal(cmd)
 		log.Infof("Command:\n%s", string(out))
 
-		tree, err := cachetools.GetTreeFromRootDirectoryDigest(ctx, env.GetContentAddressableStorageClient(), digest.NewResourceName(action.GetInputRootDigest(), *remoteInstanceName))
+		tree, err := cachetools.GetTreeFromRootDirectoryDigest(ctx, env.GetContentAddressableStorageClient(), digest.NewGenericResourceName(action.GetInputRootDigest(), *remoteInstanceName))
 		if err != nil {
 			log.Fatalf("Could not fetch input root structure: %s", err)
 		}


### PR DESCRIPTION
- Renames NewResourceName to NewGenericResourceName
- Renames NewCacheResourceName to NewResourceName
- Removes all NewCASResourceName and NewACResourceName callsites -- instead calling NewResourceName directly

In a followup I'll introduce digest_function as an argument to NewResourceName, this CL makes that one simpler.