### PR TITLE
Mark commandutil_test flaky

### DIFF
--- a/enterprise/server/remote_execution/commandutil/BUILD
+++ b/enterprise/server/remote_execution/commandutil/BUILD
@@ -22,8 +22,9 @@ go_test(
     size = "small",
     srcs = ["commandutil_test.go"],
     data = ["//enterprise/server/remote_execution/commandutil/test_binary"],
-    # Marking this exclusive for now since CPU usage measurements
-    # in the test depend on other jobs running on the same machine.
+    # Marking this exclusive+flaky for now since CPU usage measurements in the
+    # test depend on other jobs running on the same machine.
+    flaky = 1,
     tags = ["exclusive"],
     deps = [
         ":commandutil",


### PR DESCRIPTION
This test seems flaky on macos. If this doesn't help, we can disable it on macos entirely (preferably just the UsageStats-related stuff)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
