### PR TITLE
Fix recycling failures on second recycling attempt

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -269,30 +269,33 @@ func TestFirecrackerSnapshotAndResume(t *testing.T) {
 		}
 	})
 
-	if err := c.Pause(ctx); err != nil {
-		t.Fatalf("unable to pause container: %s", err)
-	}
-	if err := c.Unpause(ctx); err != nil {
-		t.Fatalf("unable to unpause container: %s", err)
-	}
+	// Try pause, unpause, exec several times.
+	for i := 0; i < 3; i++ {
+		if err := c.Pause(ctx); err != nil {
+			t.Fatalf("unable to pause container: %s", err)
+		}
+		if err := c.Unpause(ctx); err != nil {
+			t.Fatalf("unable to unpause container: %s", err)
+		}
 
-	cmd := &repb.Command{
-		Arguments: []string{"sh", "-c", `printf "$GREETING $(cat world.txt)" && printf "foo" >&2`},
-		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
-			{Name: "GREETING", Value: "Hello"},
-		},
-	}
-	expectedResult := &interfaces.CommandResult{
-		ExitCode: 0,
-		Stdout:   []byte("Hello world"),
-		Stderr:   []byte("foo"),
-	}
+		cmd := &repb.Command{
+			Arguments: []string{"sh", "-c", `printf "$GREETING $(cat world.txt)" && printf "foo" >&2`},
+			EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+				{Name: "GREETING", Value: "Hello"},
+			},
+		}
+		expectedResult := &interfaces.CommandResult{
+			ExitCode: 0,
+			Stdout:   []byte("Hello world"),
+			Stderr:   []byte("foo"),
+		}
 
-	res := c.Exec(ctx, cmd, nil /*=stdio*/)
-	if res.Error != nil {
-		t.Fatalf("error: %s", res.Error)
+		res := c.Exec(ctx, cmd, nil /*=stdio*/)
+		if res.Error != nil {
+			t.Fatalf("error: %s", res.Error)
+		}
+		assert.Equal(t, expectedResult, res)
 	}
-	assert.Equal(t, expectedResult, res)
 }
 
 func TestFirecrackerFileMapping(t *testing.T) {

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -161,8 +161,8 @@ func (l *FileCacheLoader) GetConfigurationData(snapshotDigest *repb.Digest) ([]b
 // UnpackSnapshot unpacks all of the files in a snapshot to the specified output
 // directory.
 func (l *FileCacheLoader) UnpackSnapshot(snapshotDigest *repb.Digest, outputDirectory string) error {
-	if l.snapshotDigest != snapshotDigest {
-		return status.InvalidArgumentError("Snapshot configration already fetched with different digest")
+	if l.snapshotDigest != nil && l.snapshotDigest != snapshotDigest {
+		return status.InvalidArgumentErrorf("Snapshot configuration already fetched with different digest %q", digest.String(l.snapshotDigest))
 	}
 
 	if l.manifest == nil {


### PR DESCRIPTION
Fixes "Snapshot configuration already fetched with different digest"

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
