### PR TITLE
Remove digest.NewGenericResourceName; use digest.NewResourceName everywhere.

### DIFF
--- a/cli/cache_proxy/BUILD
+++ b/cli/cache_proxy/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/environment",
         "//server/interfaces",
         "//server/remote_cache/byte_stream_server",

--- a/cli/cache_proxy/cache_proxy.go
+++ b/cli/cache_proxy/cache_proxy.go
@@ -214,7 +214,7 @@ func (p *CacheProxy) Read(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServ
 		if err != nil {
 			if err == io.EOF {
 				if localFile != nil {
-					resourceName := digest.NewGenericResourceName(d, instanceName)
+					resourceName := digest.NewResourceName(d, instanceName, rspb.CacheType_CAS)
 					if _, err := cachetools.UploadFromReader(ctx, p.localBSSClient, resourceName, localFile); err != nil {
 						log.Errorf("error uploading from reader: %s", err.Error())
 					}

--- a/cli/cache_proxy/cache_proxy.go
+++ b/cli/cache_proxy/cache_proxy.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 

--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//proto:build_event_stream_go_proto",
         "//proto:command_line_go_proto",
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/real_environment",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",

--- a/enterprise/server/cmd/smash/BUILD
+++ b/enterprise/server/cmd/smash/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/smash",
     deps = [
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/util/grpc_client",

--- a/enterprise/server/image_converter/BUILD
+++ b/enterprise/server/image_converter/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//enterprise/server/backends/redis_client",
         "//proto:registry_go_proto",
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/config",
         "//server/environment",
         "//server/interfaces",

--- a/enterprise/server/image_converter/image_converter.go
+++ b/enterprise/server/image_converter/image_converter.go
@@ -42,6 +42,7 @@ import (
 
 	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	ctrname "github.com/google/go-containerregistry/pkg/name"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
@@ -394,7 +395,7 @@ func (c *imageConverter) convertLayer(ctx context.Context, req *rgpb.ConvertLaye
 		return nil, status.UnknownErrorf("could not compute digest of new layer: %s", err)
 	}
 
-	rn := digest.NewGenericResourceName(newLayerDigest, registryInstanceName)
+	rn := digest.NewResourceName(newLayerDigest, registryInstanceName, rspb.CacheType_CAS)
 	casDigest, err := cachetools.UploadFromReader(ctx, c.bsClient, rn, bytes.NewReader(newLayerData))
 	if err != nil {
 		return nil, status.UnknownErrorf("could not upload converted layer %q: %s", newLayerDigest, err)

--- a/enterprise/server/remote_execution/dirtools/BUILD
+++ b/enterprise/server/remote_execution/dirtools/BUILD
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/dirtools",
     deps = [
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/environment",
         "//server/interfaces",
         "//server/remote_cache/cachetools",

--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
@@ -701,7 +702,7 @@ func (ff *BatchFileFetcher) bytestreamReadFiles(ctx context.Context, instanceNam
 	if err != nil {
 		return err
 	}
-	resourceName := digest.NewGenericResourceName(fp.FileNode.Digest, instanceName)
+	resourceName := digest.NewResourceName(fp.FileNode.Digest, instanceName, rspb.CacheType_CAS)
 	if ff.supportsCompression() {
 		resourceName.SetCompressor(repb.Compressor_ZSTD)
 	}

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -119,9 +119,9 @@ func redisKeyForPendingExecutionID(ctx context.Context, adResource *digest.Resou
 		return "", err
 	}
 	downloadString, err := adResource.DownloadString()
-        if err != nil {
-                return "", err
-        }
+	if err != nil {
+		return "", err
+	}
 	return fmt.Sprintf("pendingExecution/%s%s", userPrefix, downloadString), nil
 }
 
@@ -618,9 +618,9 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 	}
 
 	downloadString, err := adInstanceDigest.DownloadString()
-        if err != nil {
-                return err
-        }
+	if err != nil {
+		return err
+	}
 	invocationID := bazel_request.GetInvocationID(stream.Context())
 
 	executionID := ""

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -118,7 +118,11 @@ func redisKeyForPendingExecutionID(ctx context.Context, adResource *digest.Resou
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("pendingExecution/%s%s", userPrefix, adResource.DownloadString()), nil
+	downloadString, err := adResource.DownloadString()
+        if err != nil {
+                return "", err
+        }
+	return fmt.Sprintf("pendingExecution/%s%s", userPrefix, downloadString), nil
 }
 
 func redisKeyForPendingExecutionDigest(executionID string) string {
@@ -414,20 +418,20 @@ func (s *ExecutionServer) Dispatch(ctx context.Context, req *repb.ExecuteRequest
 	if sizer == nil {
 		return "", status.FailedPreconditionError("No task sizer configured")
 	}
-	adInstanceDigest := digest.NewGenericResourceName(req.GetActionDigest(), req.GetInstanceName())
+	adInstanceDigest := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName(), rspb.CacheType_CAS)
 	action := &repb.Action{}
 	if err := cachetools.ReadProtoFromCAS(ctx, s.cache, adInstanceDigest, action); err != nil {
 		log.CtxErrorf(ctx, "Error fetching action: %s", err.Error())
 		return "", err
 	}
-	cmdInstanceDigest := digest.NewGenericResourceName(action.GetCommandDigest(), req.GetInstanceName())
+	cmdInstanceDigest := digest.NewResourceName(action.GetCommandDigest(), req.GetInstanceName(), rspb.CacheType_CAS)
 	command := &repb.Command{}
 	if err := cachetools.ReadProtoFromCAS(ctx, s.cache, cmdInstanceDigest, command); err != nil {
 		log.CtxErrorf(ctx, "Error fetching command: %s", err.Error())
 		return "", err
 	}
 
-	r := digest.NewGenericResourceName(req.GetActionDigest(), req.GetInstanceName())
+	r := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName(), rspb.CacheType_CAS)
 	executionID, err := r.UploadString()
 	if err != nil {
 		return "", err
@@ -607,18 +611,22 @@ func (s *ExecutionServer) deletePendingExecution(ctx context.Context, executionI
 }
 
 func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) error {
-	adInstanceDigest := digest.NewGenericResourceName(req.GetActionDigest(), req.GetInstanceName())
+	adInstanceDigest := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName(), rspb.CacheType_CAS)
 	ctx, err := prefix.AttachUserPrefixToContext(stream.Context(), s.env)
 	if err != nil {
 		return err
 	}
 
+	downloadString, err := adInstanceDigest.DownloadString()
+        if err != nil {
+                return err
+        }
 	invocationID := bazel_request.GetInvocationID(stream.Context())
 
 	executionID := ""
 	if !req.GetSkipCacheLookup() {
 		if actionResult, err := s.getActionResultFromCache(ctx, adInstanceDigest); err == nil {
-			r := digest.NewGenericResourceName(req.GetActionDigest(), req.GetInstanceName())
+			r := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName(), rspb.CacheType_CAS)
 			executionID, err := r.UploadString()
 			if err != nil {
 				return err
@@ -640,7 +648,7 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 			}
 			if ee != "" {
 				ctx = log.EnrichContext(ctx, log.ExecutionIDKey, ee)
-				log.CtxInfof(ctx, "Reusing execution %q for execution request %q for invocation %q", ee, adInstanceDigest.DownloadString(), invocationID)
+				log.CtxInfof(ctx, "Reusing execution %q for execution request %q for invocation %q", ee, downloadString, invocationID)
 				executionID = ee
 				metrics.RemoteExecutionMergedActions.With(prometheus.Labels{metrics.GroupID: s.getGroupIDForMetrics(ctx)}).Inc()
 				if err := s.insertInvocationLink(ctx, ee, invocationID, sipb.StoredInvocationLink_MERGED); err != nil {
@@ -653,15 +661,15 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 	// Create a new execution unless we found an existing identical action we
 	// can wait on.
 	if executionID == "" {
-		log.CtxInfof(ctx, "Scheduling new execution for %q for invocation %q", adInstanceDigest.DownloadString(), invocationID)
+		log.CtxInfof(ctx, "Scheduling new execution for %q for invocation %q", downloadString, invocationID)
 		newExecutionID, err := s.Dispatch(ctx, req)
 		if err != nil {
-			log.CtxErrorf(ctx, "Error dispatching execution for %q: %s", adInstanceDigest.DownloadString(), err)
+			log.CtxErrorf(ctx, "Error dispatching execution for %q: %s", downloadString, err)
 			return err
 		}
 		ctx = log.EnrichContext(ctx, log.ExecutionIDKey, newExecutionID)
 		executionID = newExecutionID
-		log.CtxInfof(ctx, "Scheduled execution %q for request %q for invocation %q", executionID, adInstanceDigest.DownloadString(), invocationID)
+		log.CtxInfof(ctx, "Scheduled execution %q for request %q for invocation %q", executionID, downloadString, invocationID)
 	}
 
 	waitReq := repb.WaitExecutionRequest{
@@ -1023,7 +1031,7 @@ func (s *ExecutionServer) fetchCommandForTask(ctx context.Context, actionResourc
 		return nil, err
 	}
 	cmdDigest := action.GetCommandDigest()
-	cmdInstanceNameDigest := digest.NewGenericResourceName(cmdDigest, actionResourceName.GetInstanceName())
+	cmdInstanceNameDigest := digest.NewResourceName(cmdDigest, actionResourceName.GetInstanceName(), rspb.CacheType_CAS)
 	cmd := &repb.Command{}
 	if err := cachetools.ReadProtoFromCAS(ctx, s.cache, cmdInstanceNameDigest, cmd); err != nil {
 		return nil, err

--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//enterprise/server/auth",
         "//enterprise/server/remote_execution/operation",
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/environment",
         "//server/interfaces",
         "//server/metrics",

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 const (
@@ -157,7 +158,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	task := st.ExecutionTask
 	req := task.GetExecuteRequest()
 	taskID := task.GetExecutionId()
-	adInstanceDigest := digest.NewGenericResourceName(req.GetActionDigest(), req.GetInstanceName())
+	adInstanceDigest := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName(), rspb.CacheType_AC)
 
 	acClient := s.env.GetActionCacheClient()
 
@@ -307,7 +308,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		if err != nil {
 			return finishWithErrFn(status.UnavailableErrorf("Error uploading action result: %s", err.Error()))
 		}
-		adInstanceDigest = digest.NewGenericResourceName(resultDigest, req.GetInstanceName())
+		adInstanceDigest = digest.NewResourceName(resultDigest, req.GetInstanceName(), rspb.CacheType_AC)
 	}
 	if err := cachetools.UploadActionResult(ctx, acClient, adInstanceDigest, actionResult); err != nil {
 		return finishWithErrFn(status.UnavailableErrorf("Error uploading action result: %s", err.Error()))

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//enterprise/server/util/vfs_server",
         "//proto:acl_go_proto",
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//proto:scheduler_go_proto",
         "//proto:user_id_go_proto",
         "//proto:vfs_go_proto",

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -53,6 +53,7 @@ import (
 
 	aclpb "github.com/buildbuddy-io/buildbuddy/proto/acl"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 	uidpb "github.com/buildbuddy-io/buildbuddy/proto/user_id"
 	vfspb "github.com/buildbuddy-io/buildbuddy/proto/vfs"
@@ -269,10 +270,10 @@ func (r *commandRunner) PrepareForTask(ctx context.Context) error {
 }
 
 func (r *commandRunner) DownloadInputs(ctx context.Context, ioStats *repb.IOStats) error {
-	rootInstanceDigest := digest.NewGenericResourceName(
+	rootInstanceDigest := digest.NewResourceName(
 		r.task.GetAction().GetInputRootDigest(),
-		r.task.GetExecuteRequest().GetInstanceName(),
-	)
+		r.task.GetExecuteRequest().GetInstanceName(), rspb.CacheType_CAS)
+
 	inputTree, err := cachetools.GetTreeFromRootDirectoryDigest(ctx, r.env.GetContentAddressableStorageClient(), rootInstanceDigest)
 	if err != nil {
 		return err

--- a/enterprise/server/test/integration/remote_execution/rbeclient/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//enterprise/server/remote_execution/dirtools",
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/environment",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",

--- a/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	gstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -271,7 +272,7 @@ func (c *Client) PrepareCommand(ctx context.Context, instanceName string, name s
 	command := &Command{
 		gRPCClientSource:   c.gRPClientSource,
 		Name:               name,
-		actionResourceName: digest.NewGenericResourceName(actionDigest, instanceName),
+		actionResourceName: digest.NewResourceName(actionDigest, instanceName, rspb.CacheType_AC),
 	}
 
 	return command, nil
@@ -283,7 +284,7 @@ func (c *Client) DownloadActionOutputs(ctx context.Context, env environment.Env,
 		if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
 			return err
 		}
-		d := digest.NewGenericResourceName(out.GetDigest(), res.InstanceName)
+		d := digest.NewResourceName(out.GetDigest(), res.InstanceName, rspb.CacheType_CAS)
 		f, err := os.Create(path)
 		if err != nil {
 			return err
@@ -299,7 +300,7 @@ func (c *Client) DownloadActionOutputs(ctx context.Context, env environment.Env,
 		if err := os.MkdirAll(path, 0777); err != nil {
 			return err
 		}
-		treeDigest := digest.NewGenericResourceName(dir.GetTreeDigest(), res.InstanceName)
+		treeDigest := digest.NewResourceName(dir.GetTreeDigest(), res.InstanceName, rspb.CacheType_CAS)
 		tree := &repb.Tree{}
 		if err := cachetools.GetBlobAsProto(ctx, c.gRPClientSource.GetByteStreamClient(), treeDigest, tree); err != nil {
 			return err

--- a/enterprise/server/test/integration/remote_execution/rbetest/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbetest/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//proto:context_go_proto",
         "//proto:publish_build_event_go_proto",
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//proto:scheduler_go_proto",
         "//server/build_event_protocol/build_event_handler",
         "//server/build_event_protocol/build_event_server",

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -77,6 +77,7 @@ import (
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 	guuid "github.com/google/uuid"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
@@ -955,7 +956,7 @@ func (r *Env) GetActionResultForFailedAction(ctx context.Context, cmd *Command, 
 func (r *Env) GetStdoutAndStderr(ctx context.Context, actionResult *repb.ActionResult, instanceName string) (string, string, error) {
 	stdout := ""
 	if actionResult.GetStdoutDigest() != nil {
-		d := digest.NewGenericResourceName(actionResult.GetStdoutDigest(), instanceName)
+		d := digest.NewResourceName(actionResult.GetStdoutDigest(), instanceName, rspb.CacheType_CAS)
 		buf := bytes.NewBuffer(make([]byte, 0, d.GetDigest().GetSizeBytes()))
 		err := cachetools.GetBlob(ctx, r.GetByteStreamClient(), d, buf)
 		if err != nil {
@@ -966,7 +967,7 @@ func (r *Env) GetStdoutAndStderr(ctx context.Context, actionResult *repb.ActionR
 
 	stderr := ""
 	if actionResult.GetStderrDigest() != nil {
-		d := digest.NewGenericResourceName(actionResult.GetStderrDigest(), instanceName)
+		d := digest.NewResourceName(actionResult.GetStderrDigest(), instanceName, rspb.CacheType_CAS)
 		buf := bytes.NewBuffer(make([]byte, 0, d.GetDigest().GetSizeBytes()))
 		err := cachetools.GetBlob(ctx, r.GetByteStreamClient(), d, buf)
 		if err != nil {

--- a/enterprise/server/workflow/service/BUILD
+++ b/enterprise/server/workflow/service/BUILD
@@ -54,6 +54,7 @@ go_test(
         "//enterprise/server/testutil/enterprise_testenv",
         "//proto:buildbuddy_service_go_proto",
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//proto:workflow_go_proto",
         "//server/backends/repo_downloader",
         "//server/buildbuddy_server",

--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -35,6 +35,7 @@ import (
 	workflow "github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/service"
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	wfpb "github.com/buildbuddy-io/buildbuddy/proto/workflow"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
@@ -125,12 +126,12 @@ type execution struct {
 // getExecution fetches digest contents of an ExecuteRequest.
 func getExecution(t *testing.T, ctx context.Context, te *testenv.TestEnv, executeRequest *repb.ExecuteRequest) *execution {
 	instanceName := executeRequest.GetInstanceName()
-	ar := digest.NewGenericResourceName(executeRequest.GetActionDigest(), instanceName)
+	ar := digest.NewResourceName(executeRequest.GetActionDigest(), instanceName, rspb.CacheType_CAS)
 	action := &repb.Action{}
 	err := cachetools.GetBlobAsProto(ctx, te.GetByteStreamClient(), ar, action)
 	require.NoError(t, err)
 	command := &repb.Command{}
-	cr := digest.NewGenericResourceName(action.GetCommandDigest(), instanceName)
+	cr := digest.NewResourceName(action.GetCommandDigest(), instanceName, rspb.CacheType_CAS)
 	err = cachetools.GetBlobAsProto(ctx, te.GetByteStreamClient(), cr, command)
 	require.NoError(t, err)
 	return &execution{

--- a/server/remote_asset/fetch_server/fetch_server.go
+++ b/server/remote_asset/fetch_server/fetch_server.go
@@ -222,7 +222,7 @@ func mirrorToCache(ctx context.Context, bsClient bspb.ByteStreamClient, remoteIn
 	// response to cache.
 	if expectedSHA256 != "" && rsp.ContentLength >= 0 {
 		d := &repb.Digest{Hash: expectedSHA256, SizeBytes: rsp.ContentLength}
-		rn := digest.NewGenericResourceName(d, remoteInstanceName)
+		rn := digest.NewResourceName(d, remoteInstanceName, rspb.CacheType_CAS)
 		if _, err := cachetools.UploadFromReader(ctx, bsClient, rn, rsp.Body); err != nil {
 			return nil, status.UnavailableErrorf("failed to upload %s to cache: %s", digest.String(d), err)
 		}

--- a/server/remote_cache/digest/BUILD
+++ b/server/remote_cache/digest/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/util/alert",
+        "//server/util/log",
         "//server/util/status",
         "@com_github_google_uuid//:uuid",
         "@com_github_zeebo_blake3//:blake3",

--- a/server/remote_cache/digest/BUILD
+++ b/server/remote_cache/digest/BUILD
@@ -9,7 +9,6 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/util/alert",
-        "//server/util/log",
         "//server/util/status",
         "@com_github_google_uuid//:uuid",
         "@com_github_zeebo_blake3//:blake3",
@@ -28,6 +27,7 @@ go_test(
     embed = [":digest"],
     deps = [
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/util/compression",
         "//server/util/status",
         "@com_github_stretchr_testify//assert",

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -90,16 +90,6 @@ type ResourceName struct {
 	rn *rspb.ResourceName
 }
 
-func NewGenericResourceName(d *repb.Digest, instanceName string) *ResourceName {
-	return &ResourceName{
-		rn: &rspb.ResourceName{
-			Digest:       d,
-			InstanceName: instanceName,
-			Compressor:   repb.Compressor_IDENTITY,
-		},
-	}
-}
-
 func NewResourceName(d *repb.Digest, instanceName string, cacheType rspb.CacheType) *ResourceName {
 	return &ResourceName{
 		rn: &rspb.ResourceName{
@@ -335,7 +325,7 @@ func isResourceName(url string, matcher *regexp.Regexp) bool {
 	return matcher.MatchString(url)
 }
 
-func parseResourceName(resourceName string, matcher *regexp.Regexp) (*ResourceName, error) {
+func parseResourceName(resourceName string, matcher *regexp.Regexp, cacheType rspb.CacheType) (*ResourceName, error) {
 	match := matcher.FindStringSubmatch(resourceName)
 	result := make(map[string]string, len(match))
 	for i, name := range matcher.SubexpNames() {
@@ -373,21 +363,21 @@ func parseResourceName(resourceName string, matcher *regexp.Regexp) (*ResourceNa
 		compressor = repb.Compressor_ZSTD
 	}
 	d := &repb.Digest{Hash: hash, SizeBytes: sizeBytes}
-	r := NewGenericResourceName(d, instanceName)
+	r := NewResourceName(d, instanceName, cacheType)
 	r.SetCompressor(compressor)
 	return r, nil
 }
 
 func ParseUploadResourceName(resourceName string) (*ResourceName, error) {
-	return parseResourceName(resourceName, uploadRegex)
+	return parseResourceName(resourceName, uploadRegex, rspb.CacheType_CAS)
 }
 
 func ParseDownloadResourceName(resourceName string) (*ResourceName, error) {
-	return parseResourceName(resourceName, downloadRegex)
+	return parseResourceName(resourceName, downloadRegex, rspb.CacheType_CAS)
 }
 
 func ParseActionCacheResourceName(resourceName string) (*ResourceName, error) {
-	return parseResourceName(resourceName, actionCacheRegex)
+	return parseResourceName(resourceName, actionCacheRegex, rspb.CacheType_AC)
 }
 
 func IsDownloadResourceName(url string) bool {

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	gstatus "google.golang.org/grpc/status"
 )
 

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -82,7 +82,7 @@ func TestParseResourceName(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		gotParsed, gotErr := parseResourceName(tc.resourceName, tc.matcher)
+		gotParsed, gotErr := parseResourceName(tc.resourceName, tc.matcher, rspb.CacheType_CAS)
 		if gstatus.Code(gotErr) != gstatus.Code(tc.wantError) {
 			t.Errorf("parseResourceName(%q) got err %v; want %v", tc.resourceName, gotErr, tc.wantError)
 			continue

--- a/server/remote_cache/digest/digest_test.go
+++ b/server/remote_cache/digest/digest_test.go
@@ -42,7 +42,7 @@ func TestParseResourceName(t *testing.T) {
 		{ // download, resource with instance name
 			resourceName: "my_instance_name/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			matcher:      downloadRegex,
-			wantParsed:   NewGenericResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "my_instance_name"),
+			wantParsed:   NewResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "my_instance_name", rspb.CacheType_CAS),
 		},
 		{ // download, resource with zstd compression
 			resourceName: "/compressed-blobs/zstd/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
@@ -57,12 +57,12 @@ func TestParseResourceName(t *testing.T) {
 		{ // download, resource with digest only
 			resourceName: "/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			matcher:      downloadRegex,
-			wantParsed:   NewGenericResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, ""),
+			wantParsed:   NewResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "", rspb.CacheType_CAS),
 		},
 		{ // upload, UUID and instance name
 			resourceName: "instance_name/uploads/2148e1f1-aacc-41eb-a31c-22b6da7c7ac1/blobs/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			matcher:      uploadRegex,
-			wantParsed:   NewGenericResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "instance_name"),
+			wantParsed:   NewResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "instance_name", rspb.CacheType_CAS),
 		},
 		{ // upload, UUID, instance name, and compression
 			resourceName: "instance_name/uploads/2148e1f1-aacc-41eb-a31c-22b6da7c7ac1/compressed-blobs/zstd/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
@@ -72,7 +72,7 @@ func TestParseResourceName(t *testing.T) {
 		{ // action
 			resourceName: "instance_name/blobs/ac/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
 			matcher:      actionCacheRegex,
-			wantParsed:   NewGenericResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "instance_name"),
+			wantParsed:   NewResourceName(&repb.Digest{Hash: "072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d", SizeBytes: 1234}, "instance_name", rspb.CacheType_CAS),
 		},
 		{ // invalid action
 			resourceName: "instance_name/blobs/notac/072d9dd55aacaa829d7d1cc9ec8c4b5180ef49acac4a3c2f3ca16a3db134982d/1234",
@@ -97,7 +97,7 @@ func TestParseResourceName(t *testing.T) {
 }
 
 func newZstdResourceName(d *repb.Digest, instanceName string) *ResourceName {
-	r := NewGenericResourceName(d, instanceName)
+	r := NewResourceName(d, instanceName, rspb.CacheType_CAS)
 	r.SetCompressor(repb.Compressor_ZSTD)
 	return r
 }

--- a/tools/cacheload/BUILD
+++ b/tools/cacheload/BUILD
@@ -9,6 +9,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/metrics",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",

--- a/tools/cacheload/cacheload.go
+++ b/tools/cacheload/cacheload.go
@@ -122,7 +122,7 @@ func incrementPromErrorMetric(err error) {
 
 func writeBlob(ctx context.Context, client bspb.ByteStreamClient) (*repb.Digest, error) {
 	d, buf := newRandomDigestBuf(randomBlobSize())
-	resourceName := digest.NewGenericResourceName(d, *instanceName)
+	resourceName := digest.NewResourceName(d, *instanceName, rspb.CacheType_CAS)
 	if *writeCompressed {
 		resourceName.SetCompressor(repb.Compressor_ZSTD)
 	}
@@ -142,7 +142,7 @@ func writeBlob(ctx context.Context, client bspb.ByteStreamClient) (*repb.Digest,
 }
 
 func readBlob(ctx context.Context, client bspb.ByteStreamClient, d *repb.Digest) error {
-	resourceName := digest.NewGenericResourceName(d, *instanceName)
+	resourceName := digest.NewResourceName(d, *instanceName, rspb.CacheType_CAS)
 	if *readCompressed {
 		resourceName.SetCompressor(repb.Compressor_ZSTD)
 	}

--- a/tools/cacheload/cacheload.go
+++ b/tools/cacheload/cacheload.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 

--- a/tools/cas/cas.go
+++ b/tools/cas/cas.go
@@ -134,7 +134,7 @@ func main() {
 			if err != nil {
 				log.Fatalf(err.Error())
 			}
-			ind := digest.NewGenericResourceName(failedDigest, ind.GetInstanceName())
+			ind := digest.NewResourceName(failedDigest, ind.GetInstanceName(), rspb.CacheType_CAS)
 			ar, err = cachetools.GetActionResult(ctx, acClient, ind)
 			if err != nil {
 				log.Fatal(err.Error())

--- a/tools/vmstart/BUILD
+++ b/tools/vmstart/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//enterprise/server/remote_execution/containers/firecracker",
         "//enterprise/server/remote_execution/filecache",
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//proto:vmvfs_go_proto",
         "//server/real_environment",
         "//server/remote_cache/cachetools",

--- a/tools/vmstart/vmstart.go
+++ b/tools/vmstart/vmstart.go
@@ -160,7 +160,7 @@ func main() {
 			log.Fatalf("Error parsing action digest %q: %s", *actionDigest, err)
 		}
 
-		actionInstanceDigest := digest.NewGenericResourceName(d, *remoteInstanceName)
+		actionInstanceDigest := digest.NewResourceName(d, *remoteInstanceName, rspb.CacheType_CAS)
 
 		action, cmd, err := cachetools.GetActionAndCommand(ctx, env.GetByteStreamClient(), actionInstanceDigest)
 		if err != nil {
@@ -171,7 +171,7 @@ func main() {
 		out, _ = prototext.Marshal(cmd)
 		log.Infof("Command:\n%s", string(out))
 
-		tree, err := cachetools.GetTreeFromRootDirectoryDigest(ctx, env.GetContentAddressableStorageClient(), digest.NewGenericResourceName(action.GetInputRootDigest(), *remoteInstanceName))
+		tree, err := cachetools.GetTreeFromRootDirectoryDigest(ctx, env.GetContentAddressableStorageClient(), digest.NewResourceName(action.GetInputRootDigest(), *remoteInstanceName, rspb.CacheType_CAS))
 		if err != nil {
 			log.Fatalf("Could not fetch input root structure: %s", err)
 		}

--- a/tools/vmstart/vmstart.go
+++ b/tools/vmstart/vmstart.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	vmfspb "github.com/buildbuddy-io/buildbuddy/proto/vmvfs"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )


### PR DESCRIPTION
- Remove digest.NewGenericResourceName; use digest.NewResourceName everywhere
- Add explicit error checking to ResourceName.{UploadString,DownloadString} methods: it's an error to try to upload or download AC objects using the bytestream API, and an indication that the wrong type of resource is being used.
