### PR TITLE
Firecracker: proactively evict old snapshots from filecache to reduce snapshot evictions

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -520,6 +520,13 @@ func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context, instanceName st
 			return nil, err
 		}
 		baseMemSnapshotPath = filepath.Join(baseDir, fullMemSnapshotName)
+
+		// The base snapshot is no longer useful since we're merging on top
+		// of it and replacing the paused VM snapshot with the new merged
+		// snapshot. Delete it to prevent unnecessary filecache evictions.
+		if err := loader.DeleteSnapshot(baseSnapshotDigest); err != nil {
+			log.Warningf("Failed to delete snapshot: %s", err)
+		}
 	}
 
 	if err := c.machine.PauseVM(ctx); err != nil {

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -231,6 +231,12 @@ func (c *fileCache) AddFile(node *repb.FileNode, existingFilePath string) {
 	c.l.Add(key(node), e)
 }
 
+func (c *fileCache) DeleteFile(node *repb.FileNode) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.l.Remove(key(node))
+}
+
 func (c *fileCache) WaitForDirectoryScanToComplete() {
 	<-c.dirScanDone
 }

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -12,5 +12,20 @@ go_library(
         "//server/remote_cache/digest",
         "//server/util/hash",
         "//server/util/status",
+    ],
+)
+
+go_test(
+    name = "snaploader_test",
+    srcs = ["snaploader_test.go"],
+    deps = [
+        ":snaploader",
+        "//enterprise/server/remote_execution/filecache",
+        "//proto:remote_execution_go_proto",
+        "//server/environment",
+        "//server/testutil/testenv",
+        "//server/testutil/testfs",
+        "//server/util/hash",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -1,0 +1,117 @@
+package snaploader_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaploader"
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/util/hash"
+	"github.com/stretchr/testify/require"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+func TestPackAndUnpack(t *testing.T) {
+	const maxFilecacheSizeBytes = 1_000_000 // 1MB
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	filecacheDir := testfs.MakeTempDir(t)
+	fc, err := filecache.NewFileCache(filecacheDir, maxFilecacheSizeBytes)
+	require.NoError(t, err)
+	fc.WaitForDirectoryScanToComplete()
+	env.SetFileCache(fc)
+	workDir := testfs.MakeTempDir(t)
+
+	// Create two snapshots, A and B, each with artifacts totaling 100KB,
+	// and add them to the cache. Note, the snapshot digests don't actually
+	// correspond to any real content; they just need to be unique cache
+	// keys.
+	la, err := snaploader.New(ctx, env, workDir, "" /*=instanceName*/)
+	require.NoError(t, err)
+	da := &repb.Digest{Hash: hash.String("manifest-A"), SizeBytes: 1}
+	sa := makeFakeSnapshot(t, workDir, da)
+	da, err = la.CacheSnapshot(sa)
+	require.NoError(t, err)
+
+	lb, err := snaploader.New(ctx, env, workDir, "" /*=instanceName*/)
+	require.NoError(t, err)
+	db := &repb.Digest{Hash: hash.String("manifest-B"), SizeBytes: 1}
+	sb := makeFakeSnapshot(t, workDir, db)
+	db, err = lb.CacheSnapshot(sb)
+	require.NoError(t, err)
+
+	// We should be able to unpack snapshot A, delete it, and then replace it
+	// with a new snapshot several times, without evicting snapshot B.
+	for i := 0; i < 20; i++ {
+		// Unpack (this should also evict from cache).
+		outDir := testfs.MakeDirAll(t, workDir, fmt.Sprintf("unpack-a-%d", i))
+		mustUnpack(t, ctx, env, da, workDir, outDir, sa)
+
+		// Delete, since it's no longer needed.
+		// Note: we construct a new loader here to ensure the current
+		// snapshot manifest gets loaded.
+		loader, err := snaploader.New(ctx, env, workDir, "" /*=instanceName*/)
+		require.NoError(t, err)
+		err = loader.DeleteSnapshot(da)
+		require.NoError(t, err)
+
+		// Re-add to cache with the same key, but with new contents.
+		sa = makeFakeSnapshot(t, workDir, da)
+		da, err = la.CacheSnapshot(sa)
+		require.NoError(t, err)
+	}
+
+	// Snapshot B should not have been evicted.
+	outDir := testfs.MakeDirAll(t, workDir, "unpack-b")
+	mustUnpack(t, ctx, env, db, workDir, outDir, sb)
+}
+
+func makeFakeSnapshot(t *testing.T, workDir string, d *repb.Digest) *snaploader.LoadSnapshotOptions {
+	return &snaploader.LoadSnapshotOptions{
+		ForceSnapshotDigest: d,
+		MemSnapshotPath:     makeRandomFile(t, workDir, "mem", 100_000),
+		VMStateSnapshotPath: makeRandomFile(t, workDir, "vmstate", 1_000),
+		KernelImagePath:     makeRandomFile(t, workDir, "kernel", 1_000),
+		InitrdImagePath:     makeRandomFile(t, workDir, "initrd", 1_000),
+		ContainerFSPath:     makeRandomFile(t, workDir, "containerfs", 1_000),
+	}
+}
+
+func makeRandomFile(t *testing.T, rootDir, prefix string, size int) string {
+	name := prefix + "-" + strconv.Itoa(rand.Int())
+	testfs.WriteRandomString(t, rootDir, name, size)
+	return filepath.Join(rootDir, name)
+}
+
+// Unpacks a snapshot to outDir and asserts that the contents match the
+// originally cached contents.
+func mustUnpack(t *testing.T, ctx context.Context, env environment.Env, d *repb.Digest, workDir, outDir string, originalSnapshot *snaploader.LoadSnapshotOptions) {
+	loader, err := snaploader.New(ctx, env, workDir, "" /*=instanceName*/)
+	require.NoError(t, err)
+	err = loader.UnpackSnapshot(d, outDir)
+	require.NoError(t, err)
+
+	for _, path := range []string{
+		originalSnapshot.MemSnapshotPath,
+		originalSnapshot.VMStateSnapshotPath,
+		originalSnapshot.KernelImagePath,
+		originalSnapshot.InitrdImagePath,
+		originalSnapshot.ContainerFSPath,
+	} {
+		originalContent := testfs.ReadFileAsString(t, filepath.Dir(path), filepath.Base(path))
+		unpackedContent := testfs.ReadFileAsString(t, outDir, filepath.Base(path))
+		if originalContent != unpackedContent {
+			// Note: not using require.Equal since the diff would be useless due
+			// to the content being random.
+			require.FailNow(t, "unpacked snapshot content does not match original snapshot")
+		}
+	}
+}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -554,6 +554,7 @@ type RemoteExecutionService interface {
 
 type FileCache interface {
 	FastLinkFile(f *repb.FileNode, outputPath string) bool
+	DeleteFile(f *repb.FileNode) bool
 	AddFile(f *repb.FileNode, existingFilePath string)
 	WaitForDirectoryScanToComplete()
 }


### PR DESCRIPTION
Today, the following scenario can happen:
- Workflows A and B run, and we store snapshots A and B respectively once the workflow runs are complete.
- Workflow A then runs several times. Each run causes something like 20-40GB of files to be added to filecache, eventually causing snapshot B to get evicted.
- Workflow B attempts to run but its snapshot was evicted. So it has to be retried, and is assigned a cold runner.

(Note, there are many other scenarios where this can happen - "workflow A" can be replaced with any combination of workflows other than B, which collectively run enough times to cause hundreds of GB of filecache churn, enough to evict B)

The fix in this PR is to manually evict base snapshots from filecache (i.e. the snapshot from the previous run of the container) as soon as they are no longer needed. We merge diff snapshots on top of base snapshots, so they are essentially useless once we merge on top of them, and so they are safe to evict. This effectively frees up space in the LRU for more paused runner snapshots.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
