### PR TITLE
Improve runner pool logging

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -168,7 +168,7 @@ var (
 func openFile(ctx context.Context, env environment.Env, fileName string) (io.ReadCloser, error) {
 	// If the file exists on the filesystem, use that.
 	if path, err := exec.LookPath(fileName); err == nil {
-		log.Debugf("Located %q at %s", fileName, path)
+		log.CtxDebugf(ctx, "Located %q at %s", fileName, path)
 		return os.Open(path)
 	}
 
@@ -230,7 +230,7 @@ func putFileIntoDir(ctx context.Context, env environment.Env, fileName, destDir 
 	}
 	casPath := filepath.Join(fileHome, filepath.Base(fileName))
 	if exists, err := disk.FileExists(ctx, casPath); err == nil && exists {
-		log.Debugf("Found existing %q in path: %q", fileName, casPath)
+		log.CtxDebugf(ctx, "Found existing %q in path: %q", fileName, casPath)
 		return casPath, nil
 	}
 	// Write the file to the new location if it does not exist there already.
@@ -252,7 +252,7 @@ func putFileIntoDir(ctx context.Context, env environment.Env, fileName, destDir 
 	if err := writer.Close(); err != nil {
 		return "", err
 	}
-	log.Debugf("Put %q into new path: %q", fileName, casPath)
+	log.CtxDebugf(ctx, "Put %q into new path: %q", fileName, casPath)
 	return casPath, nil
 }
 
@@ -355,7 +355,7 @@ func (c *FirecrackerContainer) ConfigurationHash() *repb.Digest {
 	}
 }
 
-func NewContainer(env environment.Env, imageCacheAuth *container.ImageCacheAuthenticator, opts ContainerOpts) (*FirecrackerContainer, error) {
+func NewContainer(ctx context.Context, env environment.Env, imageCacheAuth *container.ImageCacheAuthenticator, opts ContainerOpts) (*FirecrackerContainer, error) {
 	vmLog, err := NewVMLog(vmLogTailBufSize)
 	if err != nil {
 		return nil, err
@@ -406,7 +406,7 @@ func NewContainer(env environment.Env, imageCacheAuth *container.ImageCacheAuthe
 		cancelVmCtx:        func() {},
 	}
 
-	if err := c.newID(); err != nil {
+	if err := c.newID(ctx); err != nil {
 		return nil, err
 	}
 	if opts.ForceVMIdx != 0 {
@@ -501,7 +501,7 @@ func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context, instanceName st
 
 	start := time.Now()
 	defer func() {
-		log.Debugf("SaveSnapshot took %s", time.Since(start))
+		log.CtxDebugf(ctx, "SaveSnapshot took %s", time.Since(start))
 	}()
 
 	// If a snapshot already exists, get a reference to the memory snapshot so that we can perform a diff snapshot and
@@ -523,7 +523,7 @@ func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context, instanceName st
 	}
 
 	if err := c.machine.PauseVM(ctx); err != nil {
-		log.Errorf("Error pausing VM: %s", err)
+		log.CtxErrorf(ctx, "Error pausing VM: %s", err)
 		return nil, err
 	}
 
@@ -544,18 +544,18 @@ func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context, instanceName st
 		params.Body.SnapshotType = snapshotType
 	}
 	if err := c.machine.CreateSnapshot(ctx, memSnapshotFile, vmStateSnapshotName, snapshotTypeOpt); err != nil {
-		log.Errorf("Error creating snapshot: %s", err)
+		log.CtxErrorf(ctx, "Error creating snapshot: %s", err)
 		return nil, err
 	}
 
-	log.Debugf("VMM CreateSnapshot %s took %s", snapshotType, time.Since(machineStart))
+	log.CtxDebugf(ctx, "VMM CreateSnapshot %s took %s", snapshotType, time.Since(machineStart))
 
 	if baseMemSnapshotPath != "" {
 		mergeStart := time.Now()
 		if err := mergeDiffSnapshot(ctx, baseMemSnapshotPath, memSnapshotPath, mergeDiffSnapshotConcurrency, mergeDiffSnapshotBlockSize); err != nil {
 			return nil, status.UnknownErrorf("merge diff snapshot failed: %s", err)
 		}
-		log.Debugf("VMM merge diff snapshot took %s", time.Since(mergeStart))
+		log.CtxDebugf(ctx, "VMM merge diff snapshot took %s", time.Since(mergeStart))
 		// Use the merged memory snapshot.
 		memSnapshotPath = baseMemSnapshotPath
 	}
@@ -585,13 +585,13 @@ func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context, instanceName st
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("snaploader.CacheSnapshot took %s", time.Since(snaploaderStart))
+	log.CtxDebugf(ctx, "snaploader.CacheSnapshot took %s", time.Since(snaploaderStart))
 
 	resumeStart := time.Now()
 	if err := c.machine.ResumeVM(ctx); err != nil {
 		return nil, err
 	}
-	log.Debugf("VMM ResumeVM took %s", time.Since(resumeStart))
+	log.CtxDebugf(ctx, "VMM ResumeVM took %s", time.Since(resumeStart))
 
 	return snapshotDigest, nil
 }
@@ -605,13 +605,13 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 
 	start := time.Now()
 	defer func() {
-		log.Debugf("LoadSnapshot %s took %s", snapshotDigest.GetHash(), time.Since(start))
+		log.CtxDebugf(ctx, "LoadSnapshot %s took %s", snapshotDigest.GetHash(), time.Since(start))
 	}()
 
 	c.rmOnce = &sync.Once{}
 	c.rmErr = nil
 
-	if err := c.newID(); err != nil {
+	if err := c.newID(ctx); err != nil {
 		return err
 	}
 
@@ -688,13 +688,13 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 		fcclient.WithLogger(getLogrusLogger(c.constants.DebugMode)),
 		fcclient.WithSnapshot(fullMemSnapshotName, vmStateSnapshotName),
 	}
-	log.Debugf("fullMemSnapshotName: %s, vmStateSnapshotName %s", fullMemSnapshotName, vmStateSnapshotName)
+	log.CtxDebugf(ctx, "fullMemSnapshotName: %s, vmStateSnapshotName %s", fullMemSnapshotName, vmStateSnapshotName)
 
 	machine, err := fcclient.NewMachine(vmCtx, cfg, machineOpts...)
 	if err != nil {
 		return status.InternalErrorf("Failed creating machine: %s", err)
 	}
-	log.Debugf("Command: %v", reflect.Indirect(reflect.Indirect(reflect.ValueOf(machine)).FieldByName("cmd")).FieldByName("Args"))
+	log.CtxDebugf(ctx, "Command: %v", reflect.Indirect(reflect.Indirect(reflect.ValueOf(machine)).FieldByName("cmd")).FieldByName("Args"))
 
 	if err := loader.UnpackSnapshot(snapshotDigest, c.getChroot()); err != nil {
 		return err
@@ -781,11 +781,11 @@ func (c *FirecrackerContainer) hotSwapWorkspace(ctx context.Context, execClient 
 	return nil
 }
 
-func nonCmdExit(err error) *interfaces.CommandResult {
+func nonCmdExit(ctx context.Context, err error) *interfaces.CommandResult {
 	if *dieOnFirecrackerFailure {
-		log.Fatalf("dying on firecracker error: %s", err)
+		log.CtxFatalf(ctx, "dying on firecracker error: %s", err)
 	} else {
-		log.Errorf("nonCmdExit returning error: %s", err)
+		log.CtxErrorf(ctx, "nonCmdExit returning error: %s", err)
 	}
 	return &interfaces.CommandResult{
 		Error:    err,
@@ -797,7 +797,7 @@ func (c *FirecrackerContainer) startedFromSnapshot() bool {
 	return c.externalJailerCmd != nil
 }
 
-func (c *FirecrackerContainer) newID() error {
+func (c *FirecrackerContainer) newID(ctx context.Context) error {
 	vmIdxMu.Lock()
 	defer vmIdxMu.Unlock()
 	u, err := uuid.NewRandom()
@@ -805,7 +805,7 @@ func (c *FirecrackerContainer) newID() error {
 		return err
 	}
 	vmIdx += 1
-	log.Debugf("Container id changing from %q (%d) to %q (%d)", c.id, c.vmIdx, u.String(), vmIdx)
+	log.CtxDebugf(ctx, "Container id changing from %q (%d) to %q (%d)", c.id, c.vmIdx, u.String(), vmIdx)
 	c.id = u.String()
 	c.vmIdx = vmIdx
 
@@ -1057,7 +1057,7 @@ func (c *FirecrackerContainer) copyOutputsToWorkspace(ctx context.Context) error
 
 	start := time.Now()
 	defer func() {
-		log.Debugf("copyOutputsToWorkspace took %s", time.Since(start))
+		log.CtxDebugf(ctx, "copyOutputsToWorkspace took %s", time.Since(start))
 	}()
 	if exists, err := disk.FileExists(ctx, c.workspaceFSPath()); err != nil || !exists {
 		return status.FailedPreconditionErrorf("workspacefs path %q not found", c.workspaceFSPath())
@@ -1075,7 +1075,7 @@ func (c *FirecrackerContainer) copyOutputsToWorkspace(ctx context.Context) error
 	if c.mountWorkspaceFile {
 		m, err := mountExt4ImageUsingLoopDevice(c.workspaceFSPath(), wsDir)
 		if err != nil {
-			log.Warningf("could not mount ext4 image: %s", err)
+			log.CtxWarningf(ctx, "could not mount ext4 image: %s", err)
 			return err
 		}
 		defer m.Unmount()
@@ -1217,9 +1217,9 @@ func (c *FirecrackerContainer) Run(ctx context.Context, command *repb.Command, a
 		// TODO: When loading the snapshot here, need to copy from filecache, not
 		// hard link. Otherwise, this is not safe for concurrent use.
 		if err := c.LoadSnapshot(ctx, actionWorkingDir, "" /*=instanceName*/, snapDigest); err != nil {
-			log.Debugf("LoadSnapshot failed; will start a VM from scratch: %s", err)
+			log.CtxDebugf(ctx, "LoadSnapshot failed; will start a VM from scratch: %s", err)
 		} else {
-			log.Debugf("Started from snapshot %s/%d!", snapDigest.GetHash(), snapDigest.GetSizeBytes())
+			log.CtxDebugf(ctx, "Started from snapshot %s/%d!", snapDigest.GetHash(), snapDigest.GetSizeBytes())
 		}
 	}
 
@@ -1228,12 +1228,12 @@ func (c *FirecrackerContainer) Run(ctx context.Context, command *repb.Command, a
 	if c.machine == nil {
 		log.CtxInfof(ctx, "Pulling image %q", c.containerImage)
 		if err := container.PullImageIfNecessary(ctx, c.env, c.imageCacheAuth, c, creds, c.containerImage); err != nil {
-			return nonCmdExit(err)
+			return nonCmdExit(ctx, err)
 		}
 
 		log.CtxInfof(ctx, "Creating VM.")
 		if err := c.Create(ctx, actionWorkingDir); err != nil {
-			return nonCmdExit(err)
+			return nonCmdExit(ctx, err)
 		}
 
 		if c.allowSnapshotStart && !c.startedFromSnapshot() {
@@ -1244,9 +1244,9 @@ func (c *FirecrackerContainer) Run(ctx context.Context, command *repb.Command, a
 			// TODO: Wait until the VM exec server is ready before saving the initial
 			// snapshot, so the init binary can skip the startup sequence
 			if _, err := c.SaveSnapshot(ctx, "" /*=instanceName*/, snapDigest, nil /*=baseSnapshotDigest*/); err != nil {
-				return nonCmdExit(err)
+				return nonCmdExit(ctx, err)
 			}
-			log.Debugf("Saved snapshot %s/%d for next run", snapDigest.GetHash(), snapDigest.GetSizeBytes())
+			log.CtxDebugf(ctx, "Saved snapshot %s/%d for next run", snapDigest.GetHash(), snapDigest.GetSizeBytes())
 		}
 	}
 
@@ -1276,7 +1276,7 @@ func (c *FirecrackerContainer) Create(ctx context.Context, actionWorkingDir stri
 
 	start := time.Now()
 	defer func() {
-		log.Debugf("Create took %s", time.Since(start))
+		log.CtxDebugf(ctx, "Create took %s", time.Since(start))
 	}()
 
 	c.rmOnce = &sync.Once{}
@@ -1301,9 +1301,9 @@ func (c *FirecrackerContainer) Create(ctx context.Context, actionWorkingDir stri
 	if err := ext4.MakeEmptyImage(ctx, workspaceFSPath, ext4.MinDiskImageSizeBytes); err != nil {
 		return err
 	}
-	log.Debugf("Scratch and workspace disk images written to %q", c.tempDir)
-	log.Debugf("Using container image at %q", c.containerFSPath)
-	log.Debugf("getChroot() is %q", c.getChroot())
+	log.CtxDebugf(ctx, "Scratch and workspace disk images written to %q", c.tempDir)
+	log.CtxDebugf(ctx, "Using container image at %q", c.containerFSPath)
+	log.CtxDebugf(ctx, "getChroot() is %q", c.getChroot())
 	fcCfg, err := c.getConfig(ctx, c.containerFSPath, scratchFSPath, workspaceFSPath)
 	if err != nil {
 		return err
@@ -1328,7 +1328,7 @@ func (c *FirecrackerContainer) Create(ctx context.Context, actionWorkingDir stri
 	if err != nil {
 		return status.InternalErrorf("Failed creating machine: %s", err)
 	}
-	log.Debugf("Command: %v", reflect.Indirect(reflect.Indirect(reflect.ValueOf(m)).FieldByName("cmd")).FieldByName("Args"))
+	log.CtxDebugf(ctx, "Command: %v", reflect.Indirect(reflect.Indirect(reflect.ValueOf(m)).FieldByName("cmd")).FieldByName("Args"))
 
 	err = (func() error {
 		_, span := tracing.StartSpan(ctx)
@@ -1428,7 +1428,7 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 
 	start := time.Now()
 	defer func() {
-		log.Debugf("Exec took %s", time.Since(start))
+		log.CtxDebugf(ctx, "Exec took %s", time.Since(start))
 	}()
 
 	result := &interfaces.CommandResult{ExitCode: commandutil.NoExitCode}
@@ -1455,7 +1455,7 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 	defer func() {
 		// TODO(bduffany): Figure out a good way to surface this in the command result.
 		if err := c.parseOOMError(); err != nil {
-			log.Warningf("OOM error occurred during task execution: %s", err)
+			log.CtxWarningf(ctx, "OOM error occurred during task execution: %s", err)
 		}
 	}()
 
@@ -1525,7 +1525,7 @@ func (c *FirecrackerContainer) PullImage(ctx context.Context, creds container.Pu
 
 	start := time.Now()
 	defer func() {
-		log.Debugf("PullImage took %s", time.Since(start))
+		log.CtxDebugf(ctx, "PullImage took %s", time.Since(start))
 	}()
 	if c.containerFSPath != "" {
 		return nil
@@ -1548,7 +1548,7 @@ func (c *FirecrackerContainer) Remove(ctx context.Context) error {
 
 	start := time.Now()
 	defer func() {
-		log.Debugf("Remove took %s", time.Since(start))
+		log.CtxDebugf(ctx, "Remove took %s", time.Since(start))
 	}()
 
 	if c.rmOnce == nil {
@@ -1570,25 +1570,25 @@ func (c *FirecrackerContainer) remove(ctx context.Context) error {
 	var lastErr error
 
 	if err := c.machine.Shutdown(ctx); err != nil {
-		log.Errorf("Error shutting down machine: %s", err)
+		log.CtxErrorf(ctx, "Error shutting down machine: %s", err)
 		lastErr = err
 	}
 	if err := c.machine.StopVMM(); err != nil {
-		log.Errorf("Error stopping VM: %s", err)
+		log.CtxErrorf(ctx, "Error stopping VM: %s", err)
 		lastErr = err
 	}
 	if err := c.cleanupNetworking(ctx); err != nil {
-		log.Errorf("Error cleaning up networking: %s", err)
+		log.CtxErrorf(ctx, "Error cleaning up networking: %s", err)
 		lastErr = err
 	}
 	if c.tempDir != "" {
 		if err := os.RemoveAll(c.tempDir); err != nil {
-			log.Errorf("Error removing workspace fs: %s", err)
+			log.CtxErrorf(ctx, "Error removing workspace fs: %s", err)
 			lastErr = err
 		}
 	}
 	if err := os.RemoveAll(filepath.Dir(c.getChroot())); err != nil {
-		log.Errorf("Error removing chroot: %s", err)
+		log.CtxErrorf(ctx, "Error removing chroot: %s", err)
 		lastErr = err
 	}
 	if c.vfsServer != nil {
@@ -1605,17 +1605,17 @@ func (c *FirecrackerContainer) Pause(ctx context.Context) error {
 
 	start := time.Now()
 	defer func() {
-		log.Debugf("Pause took %s", time.Since(start))
+		log.CtxDebugf(ctx, "Pause took %s", time.Since(start))
 	}()
 	snapshotDigest, err := c.SaveSnapshot(ctx, "" /*=instanceName*/, nil /*=digest*/, c.pausedSnapshotDigest)
 	if err != nil {
-		log.Errorf("Error saving snapshot: %s", err)
+		log.CtxErrorf(ctx, "Error saving snapshot: %s", err)
 		return err
 	}
 	c.pausedSnapshotDigest = snapshotDigest
 
 	if err := c.Remove(ctx); err != nil {
-		log.Errorf("Error cleaning up after pause: %s", err)
+		log.CtxErrorf(ctx, "Error cleaning up after pause: %s", err)
 		return err
 	}
 	return nil
@@ -1628,7 +1628,7 @@ func (c *FirecrackerContainer) Unpause(ctx context.Context) error {
 
 	start := time.Now()
 	defer func() {
-		log.Debugf("Unpause took %s", time.Since(start))
+		log.CtxDebugf(ctx, "Unpause took %s", time.Since(start))
 	}()
 
 	// Don't hot-swap the workspace into the VM since we haven't yet downloaded inputs.

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_darwin.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_darwin.go
@@ -17,7 +17,7 @@ import (
 
 type FirecrackerContainer struct{}
 
-func NewContainer(env environment.Env, imageCacheAuth *container.ImageCacheAuthenticator, opts ContainerOpts) (*FirecrackerContainer, error) {
+func NewContainer(ctx context.Context, env environment.Env, imageCacheAuth *container.ImageCacheAuthenticator, opts ContainerOpts) (*FirecrackerContainer, error) {
 	c := &FirecrackerContainer{}
 	return c, nil
 }

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -205,7 +205,6 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	}
 	finishedCleanly := false
 	defer func() {
-		ctx := context.Background()
 		go s.runnerPool.TryRecycle(ctx, r, finishedCleanly)
 	}()
 

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -40,6 +40,7 @@ go_library(
         "//server/util/lockingbuffer",
         "//server/util/log",
         "//server/util/perms",
+        "//server/util/random",
         "//server/util/status",
         "@com_github_docker_docker//client",
         "@com_github_prometheus_client_golang//prometheus",

--- a/server/util/networking/networking.go
+++ b/server/util/networking/networking.go
@@ -45,7 +45,7 @@ func sudoCommand(ctx context.Context, args ...string) ([]byte, error) {
 	if err != nil {
 		return nil, status.InternalErrorf("Error running %q %s: %s", cmd.String(), string(out), err)
 	}
-	log.Debugf("Succesfully ran: %q", cmd.String())
+	log.Debugf("Successfully ran: %q", cmd.String())
 	return out, nil
 }
 

--- a/tools/vmstart/vmstart.go
+++ b/tools/vmstart/vmstart.go
@@ -120,7 +120,7 @@ func main() {
 	var c *firecracker.FirecrackerContainer
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	if *snapshotID != "" {
-		c, err = firecracker.NewContainer(env, auth, opts)
+		c, err = firecracker.NewContainer(ctx, env, auth, opts)
 		if err != nil {
 			log.Fatalf("Error creating container: %s", err)
 		}
@@ -128,7 +128,7 @@ func main() {
 			log.Fatalf("Error loading snapshot: %s", err)
 		}
 	} else {
-		c, err = firecracker.NewContainer(env, auth, opts)
+		c, err = firecracker.NewContainer(ctx, env, auth, opts)
 		if err != nil {
 			log.Fatalf("Error creating container: %s", err)
 		}


### PR DESCRIPTION
* Add a log message when recycling is complete (runner is paused and added back to the pool)
* Add a few missing "Failed to recycle runner" logs in cases where we don't recycle due to execution errors
* Add runner descriptions to all logs
  * Runner descriptions look like `abc123:paused:4:WF12345` (short random ID, runner state, number of tasks that have been assigned to the runner throughout its lifetime, workflow ID)
  * Log these descriptions on any operation that changes the runner pool state: taking a runner from the pool, creating a new runner, returning a runner to the pool, evicting a runner from the pool
* Add logs when we reject a runner as a possible candidate for reuse. These will be somewhat verbose but we can remove these once we figure out the runner reuse issues.
* Pass in the task ctx to `TryRecycle` instead of `context.Background()`, so that we get the enriched context fields (execution_id, etc.). Use `ExtendContextForFinalization` to get equivalent background-removal behavior, while preserving log context.
* Use `Ctx` logging variants for all logs in `firecracker.go`, so we get task IDs associated

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->
