### PR TITLE
Move Validate/Empty functions to ResourceName class

### DIFF
--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -142,8 +142,8 @@ func (g *GCSCache) setBucketTTL(ctx context.Context, bucketName string, ageInDay
 }
 
 func (g *GCSCache) key(ctx context.Context, r *rspb.ResourceName) (string, error) {
-	hash, err := digest.Validate(r.GetDigest())
-	if err != nil {
+	rn := digest.ResourceNameFromProto(r)
+	if err := rn.Validate(); err != nil {
 		return "", err
 	}
 	userPrefix, err := prefix.UserPrefixFromContext(ctx)
@@ -154,7 +154,7 @@ func (g *GCSCache) key(ctx context.Context, r *rspb.ResourceName) (string, error
 	if len(isolationPrefix) > 0 && isolationPrefix[len(isolationPrefix)-1] != '/' {
 		isolationPrefix += "/"
 	}
-	return userPrefix + isolationPrefix + hash, nil
+	return userPrefix + isolationPrefix + rn.GetDigest().GetHash(), nil
 }
 
 func (g *GCSCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error) {

--- a/enterprise/server/backends/memcache/memcache.go
+++ b/enterprise/server/backends/memcache/memcache.go
@@ -67,8 +67,8 @@ func NewCache(mcServers ...string) *Cache {
 }
 
 func (c *Cache) key(ctx context.Context, r *rspb.ResourceName) (string, error) {
-	hash, err := digest.Validate(r.GetDigest())
-	if err != nil {
+	rn := digest.ResourceNameFromProto(r)
+	if err := rn.Validate(); err != nil {
 		return "", err
 	}
 	userPrefix, err := prefix.UserPrefixFromContext(ctx)
@@ -79,7 +79,7 @@ func (c *Cache) key(ctx context.Context, r *rspb.ResourceName) (string, error) {
 	if len(isolationPrefix) > 0 && isolationPrefix[len(isolationPrefix)-1] != '/' {
 		isolationPrefix += "/"
 	}
-	return userPrefix + isolationPrefix + hash, nil
+	return userPrefix + isolationPrefix + rn.GetDigest().GetHash(), nil
 }
 
 func (c *Cache) mcGet(key string) ([]byte, error) {

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1165,8 +1165,8 @@ func (p *PebbleCache) lookupGroupAndPartitionID(ctx context.Context, remoteInsta
 }
 
 func (p *PebbleCache) makeFileRecord(ctx context.Context, r *rspb.ResourceName) (*rfpb.FileRecord, error) {
-	_, err := digest.Validate(r.GetDigest())
-	if err != nil {
+	rn := digest.ResourceNameFromProto(r)
+	if err := rn.Validate(); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/server/backends/redis_cache/redis_cache.go
+++ b/enterprise/server/backends/redis_cache/redis_cache.go
@@ -80,8 +80,8 @@ func (c *Cache) eligibleForCache(d *repb.Digest) bool {
 }
 
 func (c *Cache) key(ctx context.Context, r *rspb.ResourceName) (string, error) {
-	hash, err := digest.Validate(r.GetDigest())
-	if err != nil {
+	rn := digest.ResourceNameFromProto(r)
+	if err := rn.Validate(); err != nil {
 		return "", err
 	}
 	userPrefix, err := prefix.UserPrefixFromContext(ctx)
@@ -92,7 +92,7 @@ func (c *Cache) key(ctx context.Context, r *rspb.ResourceName) (string, error) {
 	if len(isolationPrefix) > 0 && isolationPrefix[len(isolationPrefix)-1] != '/' {
 		isolationPrefix += "/"
 	}
-	return userPrefix + isolationPrefix + hash, nil
+	return userPrefix + isolationPrefix + rn.GetDigest().GetHash(), nil
 }
 
 func (c *Cache) rdbGet(ctx context.Context, key string) ([]byte, error) {

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -225,10 +225,11 @@ func (s3c *S3Cache) setBucketTTL(ctx context.Context, bucketName string, ageInDa
 }
 
 func (s3c *S3Cache) key(ctx context.Context, r *rspb.ResourceName) (string, error) {
-	hash, err := digest.Validate(r.GetDigest())
-	if err != nil {
+	rn := digest.ResourceNameFromProto(r)
+	if err := rn.Validate(); err != nil {
 		return "", err
 	}
+	hash := rn.GetDigest().GetHash()
 	userPrefix, err := prefix.UserPrefixFromContext(ctx)
 	if err != nil {
 		return "", err

--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -334,8 +334,8 @@ func (rc *RaftCache) lookupGroupAndPartitionID(ctx context.Context, remoteInstan
 }
 
 func (rc *RaftCache) makeFileRecord(ctx context.Context, r *rspb.ResourceName) (*rfpb.FileRecord, error) {
-	_, err := digest.Validate(r.GetDigest())
-	if err != nil {
+	rn := digest.ResourceNameFromProto(r)
+	if err := rn.Validate(); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -602,8 +602,9 @@ func (ff *BatchFileFetcher) FetchFiles(filesToFetch FileMap, opts *DownloadTreeO
 	for dk, filePointers := range filesToFetch {
 		d := dk.ToDigest()
 
+		rn := digest.NewResourceName(dk.ToDigest(), ff.instanceName, rspb.CacheType_CAS)
 		// Write empty files directly (skip checking cache and downloading).
-		if digest.IsEmpty(d) {
+		if rn.IsEmpty() {
 			for _, fp := range filePointers {
 				if err := writeFile(fp, []byte("")); err != nil {
 					return err
@@ -830,7 +831,8 @@ func DownloadTree(ctx context.Context, env environment.Env, instanceName string,
 			if err := os.MkdirAll(newRoot, dirPerms); err != nil {
 				return err
 			}
-			if digest.IsEmpty(child.GetDigest()) && child.GetDigest().SizeBytes == 0 {
+			rn := digest.NewResourceName(child.GetDigest(), instanceName, rspb.CacheType_CAS)
+			if rn.IsEmpty() && rn.GetDigest().SizeBytes == 0 {
 				continue
 			}
 			childDir, ok := dirMap[digest.NewKey(child.GetDigest())]

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -230,3 +230,15 @@ message GetCacheMetadataResponse {
   int64 last_modify_usec = 4;
   int64 digest_size_bytes = 5;
 }
+
+// Used to cache GetTree responses.
+message DirectoryWithDigest {
+  reserved 2;
+
+  build.bazel.remote.execution.v2.Directory directory = 1;
+  resource.ResourceName resource_name = 3;
+}
+
+message TreeCache {
+  repeated DirectoryWithDigest children = 1;
+}

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -1283,15 +1283,6 @@ message Tree {
   repeated Directory children = 2;
 }
 
-message DirectoryWithDigest {
-  Directory directory = 1;
-  Digest digest = 2;
-}
-
-message TreeCache {
-  repeated DirectoryWithDigest children = 1;
-}
-
 // An `OutputDirectory` is the output in an `ActionResult` corresponding to a
 // directory's full contents rather than a single file.
 message OutputDirectory {

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -937,10 +937,12 @@ func (fk *fileKey) FullPath() string {
 }
 
 func (p *partition) key(ctx context.Context, cacheType rspb.CacheType, remoteInstanceName string, d *repb.Digest) (*fileKey, error) {
-	hash, err := digest.Validate(d)
-	if err != nil {
+	rn := digest.NewResourceName(d, remoteInstanceName, cacheType)
+	if err := rn.Validate(); err != nil {
 		return nil, err
 	}
+	hash := rn.GetDigest().GetHash()
+
 	userPrefix, err := prefix.UserPrefixFromContext(ctx)
 	if err != nil {
 		return nil, err

--- a/server/backends/memory_cache/memory_cache.go
+++ b/server/backends/memory_cache/memory_cache.go
@@ -68,14 +68,15 @@ func NewMemoryCache(maxSizeBytes int64) (*MemoryCache, error) {
 }
 
 func (m *MemoryCache) key(ctx context.Context, r *rspb.ResourceName) (string, error) {
-	hash, err := digest.Validate(r.GetDigest())
-	if err != nil {
+	rn := digest.ResourceNameFromProto(r)
+	if err := rn.Validate(); err != nil {
 		return "", err
 	}
 	userPrefix, err := prefix.UserPrefixFromContext(ctx)
 	if err != nil {
 		return "", err
 	}
+	hash := rn.GetDigest().GetHash()
 
 	var key string
 	if r.GetCacheType() == rspb.CacheType_AC {

--- a/server/remote_cache/action_cache_server/action_cache_server.go
+++ b/server/remote_cache/action_cache_server/action_cache_server.go
@@ -137,11 +137,11 @@ func (s *ActionCacheServer) GetActionResult(ctx context.Context, req *repb.GetAc
 	if req.ActionDigest == nil {
 		return nil, status.InvalidArgumentError("ActionDigest is a required field")
 	}
-	_, err := digest.Validate(req.ActionDigest)
-	if err != nil {
+	rn := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName(), rspb.CacheType_AC)
+	if err := rn.Validate(); err != nil {
 		return nil, err
 	}
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, s.env)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, s.env)
 	if err != nil {
 		return nil, err
 	}
@@ -194,11 +194,11 @@ func (s *ActionCacheServer) UpdateActionResult(ctx context.Context, req *repb.Up
 	if req.ActionResult == nil {
 		return nil, status.InvalidArgumentError("ActionResult is a required field")
 	}
-	_, err := digest.Validate(req.GetActionDigest())
-	if err != nil {
+	rn := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName(), rspb.CacheType_AC)
+	if err := rn.Validate(); err != nil {
 		return nil, err
 	}
-	ctx, err = prefix.AttachUserPrefixToContext(ctx, s.env)
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, s.env)
 	if err != nil {
 		return nil, err
 	}

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -106,7 +106,7 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 	}
 
 	ht := hit_tracker.NewHitTracker(ctx, s.env, false /*=ac*/)
-	if digest.IsEmpty(r.GetDigest()) {
+	if r.IsEmpty() {
 		ht.TrackEmptyHit()
 		return nil
 	}
@@ -279,7 +279,7 @@ func (s *ByteStreamServer) initStreamState(ctx context.Context, req *bspb.WriteR
 	}
 
 	var committedWriteCloser interfaces.CommittedWriteCloser
-	if digest.IsEmpty(r.GetDigest()) {
+	if r.IsEmpty() {
 		committedWriteCloser = ioutil.DiscardWriteCloser()
 	} else {
 		cacheWriter, err := s.cache.Writer(ctx, casRN.ToProto())

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -53,7 +53,7 @@ func GetBlobChunk(ctx context.Context, bsClient bspb.ByteStreamClient, r *digest
 	if bsClient == nil {
 		return 0, status.FailedPreconditionError("ByteStreamClient not configured")
 	}
-	if digest.IsEmpty(r.GetDigest()) {
+	if r.IsEmpty() {
 		return 0, nil
 	}
 
@@ -131,7 +131,7 @@ func UploadFromReader(ctx context.Context, bsClient bspb.ByteStreamClient, r *di
 	if bsClient == nil {
 		return nil, status.FailedPreconditionError("ByteStreamClient not configured")
 	}
-	if digest.IsEmpty(r.GetDigest()) {
+	if r.IsEmpty() {
 		return r.GetDigest(), nil
 	}
 	resourceName, err := r.UploadString()
@@ -315,15 +315,15 @@ func UploadBytesToCache(ctx context.Context, cache interfaces.Cache, cacheType r
 	if err != nil {
 		return nil, err
 	}
-	if digest.IsEmpty(d) {
+	resourceName := digest.NewResourceName(d, remoteInstanceName, cacheType)
+	if resourceName.IsEmpty() {
 		return d, nil
 	}
 	// Go back to the beginning so we can re-read the file contents as we upload.
 	if _, err := in.Seek(0, io.SeekStart); err != nil {
 		return nil, err
 	}
-	resourceName := digest.NewResourceName(d, remoteInstanceName, cacheType).ToProto()
-	wc, err := cache.Writer(ctx, resourceName)
+	wc, err := cache.Writer(ctx, resourceName.ToProto())
 	if err != nil {
 		return nil, err
 	}

--- a/server/remote_cache/content_addressable_storage_server/BUILD
+++ b/server/remote_cache/content_addressable_storage_server/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:api_key_go_proto",
+        "//proto:cache_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/environment",

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
+	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	remote_cache_config "github.com/buildbuddy-io/buildbuddy/server/remote_cache/config"
@@ -93,11 +94,11 @@ func (s *ContentAddressableStorageServer) FindMissingBlobs(ctx context.Context, 
 	}
 	digestsToLookup := make([]*rspb.ResourceName, 0, len(req.GetBlobDigests()))
 	for _, d := range req.GetBlobDigests() {
-		if digest.IsEmpty(d) || d.GetHash() == digest.EmptyHash {
+		rn := digest.NewResourceName(d, req.GetInstanceName(), rspb.CacheType_CAS)
+		if rn.IsEmpty() {
 			continue
 		}
-		rn := digest.NewResourceName(d, req.GetInstanceName(), rspb.CacheType_CAS).ToProto()
-		digestsToLookup = append(digestsToLookup, rn)
+		digestsToLookup = append(digestsToLookup, rn.ToProto())
 	}
 	missing, err := s.cache.FindMissing(ctx, digestsToLookup)
 	if err != nil {
@@ -160,12 +161,11 @@ func (s *ContentAddressableStorageServer) BatchUpdateBlobs(ctx context.Context, 
 	ht := hit_tracker.NewHitTracker(ctx, s.env, false)
 	kvs := make(map[*rspb.ResourceName][]byte, len(req.Requests))
 	for _, uploadRequest := range req.Requests {
-		uploadDigest := uploadRequest.GetDigest()
-		_, err := digest.Validate(uploadDigest)
-		if err != nil {
+		rn := digest.NewResourceName(uploadRequest.GetDigest(), req.GetInstanceName(), rspb.CacheType_CAS)
+		if err := rn.Validate(); err != nil {
 			return nil, err
 		}
-		uploadTracker := ht.TrackUpload(uploadDigest)
+		uploadTracker := ht.TrackUpload(rn.GetDigest())
 		// defers are preetty cheap: https://tpaschalis.github.io/defer-internals/
 		// so doing 100-1000 or so in this loop is fine.
 		bytesWrittenToCache := 0
@@ -174,9 +174,9 @@ func (s *ContentAddressableStorageServer) BatchUpdateBlobs(ctx context.Context, 
 			uploadTracker.CloseWithBytesTransferred(int64(bytesWrittenToCache), int64(bytesFromClient), uploadRequest.GetCompressor(), "cas_server")
 		}()
 
-		if digest.IsEmpty(uploadDigest) {
+		if rn.IsEmpty() {
 			rsp.Responses = append(rsp.Responses, &repb.BatchUpdateBlobsResponse_Response{
-				Digest: uploadDigest,
+				Digest: rn.GetDigest(),
 				Status: &statuspb.Status{Code: int32(codes.OK)},
 			})
 			// Skip putting this in the kv map -- we don't want to attempt to
@@ -186,7 +186,7 @@ func (s *ContentAddressableStorageServer) BatchUpdateBlobs(ctx context.Context, 
 		if !s.supportsCompressor(uploadRequest.Compressor) {
 			err := status.UnimplementedErrorf("Unsupported compressor %s", uploadRequest.Compressor)
 			rsp.Responses = append(rsp.Responses, &repb.BatchUpdateBlobsResponse_Response{
-				Digest: uploadDigest,
+				Digest: rn.GetDigest(),
 				Status: gstatus.Convert(err).Proto(),
 			})
 			continue
@@ -197,7 +197,7 @@ func (s *ContentAddressableStorageServer) BatchUpdateBlobs(ctx context.Context, 
 			decompressedData, err = zstdDecompress(uploadRequest.GetData(), uploadRequest.GetDigest().GetSizeBytes())
 			if err != nil {
 				rsp.Responses = append(rsp.Responses, &repb.BatchUpdateBlobsResponse_Response{
-					Digest: uploadDigest,
+					Digest: rn.GetDigest(),
 					Status: gstatus.Convert(err).Proto(),
 				})
 				continue
@@ -205,24 +205,23 @@ func (s *ContentAddressableStorageServer) BatchUpdateBlobs(ctx context.Context, 
 		}
 		checksum.Write(decompressedData)
 		computedDigest := fmt.Sprintf("%x", checksum.Sum(nil))
-		if computedDigest != uploadDigest.GetHash() {
-			err := status.DataLossErrorf("Uploaded bytes checksum (%q) did not match digest (%q).", computedDigest, uploadDigest.GetHash())
+		if computedDigest != rn.GetDigest().GetHash() {
+			err := status.DataLossErrorf("Uploaded bytes checksum (%q) did not match digest (%q).", computedDigest, rn.GetDigest().GetHash())
 			rsp.Responses = append(rsp.Responses, &repb.BatchUpdateBlobsResponse_Response{
-				Digest: uploadDigest,
+				Digest: rn.GetDigest(),
 				Status: gstatus.Convert(err).Proto(),
 			})
 			continue
 		}
-		if int64(len(decompressedData)) != uploadDigest.GetSizeBytes() {
-			err := status.DataLossErrorf("Uploaded blob size (%d) did not match expected size (%d).", len(decompressedData), uploadDigest.GetSizeBytes())
+		if int64(len(decompressedData)) != rn.GetDigest().GetSizeBytes() {
+			err := status.DataLossErrorf("Uploaded blob size (%d) did not match expected size (%d).", len(decompressedData), rn.GetDigest().GetSizeBytes())
 			rsp.Responses = append(rsp.Responses, &repb.BatchUpdateBlobsResponse_Response{
-				Digest: uploadDigest,
+				Digest: rn.GetDigest(),
 				Status: gstatus.Convert(err).Proto(),
 			})
 			continue
 		}
 
-		rn := digest.NewResourceName(uploadDigest, req.GetInstanceName(), rspb.CacheType_CAS)
 		// If cache doesn't support compression type, store decompressed data
 		dataToCache := decompressedData
 		if s.cache.SupportsCompressor(uploadRequest.GetCompressor()) {
@@ -289,18 +288,19 @@ func (s *ContentAddressableStorageServer) BatchReadBlobs(ctx context.Context, re
 	clientAcceptsZstd := remote_cache_config.ZstdTranscodingEnabled() && clientAcceptsCompressor(req.AcceptableCompressors, repb.Compressor_ZSTD)
 	readZstd := clientAcceptsZstd && s.cache.SupportsCompressor(repb.Compressor_ZSTD)
 
+	requestedResources := make([]*digest.ResourceName, 0, len(req.GetDigests()))
 	for _, readDigest := range req.GetDigests() {
-		_, err := digest.Validate(readDigest)
-		if err != nil {
+		rn := digest.NewResourceName(readDigest, req.GetInstanceName(), rspb.CacheType_CAS)
+		if err := rn.Validate(); err != nil {
 			return nil, err
 		}
-		downloadTracker := ht.TrackDownload(readDigest)
+		requestedResources = append(requestedResources, rn)
+		downloadTracker := ht.TrackDownload(rn.GetDigest())
 		closeTrackerFuncs = append(closeTrackerFuncs, func(data downloadTrackerData) {
 			downloadTracker.CloseWithBytesTransferred(int64(data.bytesReadFromCache), int64(data.bytesDownloadedToClient), data.compressor, "cas_server")
 		})
 
-		if !digest.IsEmpty(readDigest) {
-			rn := digest.NewResourceName(readDigest, req.GetInstanceName(), rspb.CacheType_CAS)
+		if !rn.IsEmpty() {
 			if readZstd {
 				rn.SetCompressor(repb.Compressor_ZSTD)
 			}
@@ -309,18 +309,18 @@ func (s *ContentAddressableStorageServer) BatchReadBlobs(ctx context.Context, re
 	}
 	cacheRsp, err := s.cache.GetMulti(ctx, cacheRequest)
 
-	for _, d := range req.GetDigests() {
-		if digest.IsEmpty(d) {
+	for _, rn := range requestedResources {
+		if rn.IsEmpty() {
 			rsp.Responses = append(rsp.Responses, &repb.BatchReadBlobsResponse_Response{
-				Digest: d,
+				Digest: rn.GetDigest(),
 				Status: &statuspb.Status{Code: int32(codes.OK)},
 			})
 			continue
 		}
 
-		data, ok := cacheRsp[d]
+		data, ok := cacheRsp[rn.GetDigest()]
 		blobRsp := &repb.BatchReadBlobsResponse_Response{
-			Digest: d,
+			Digest: rn.GetDigest(),
 			Data:   data,
 		}
 		if clientAcceptsZstd {
@@ -331,7 +331,7 @@ func (s *ContentAddressableStorageServer) BatchReadBlobs(ctx context.Context, re
 
 		if !ok || os.IsNotExist(err) {
 			blobRsp.Status = &statuspb.Status{Code: int32(codes.NotFound)}
-		} else if d.GetSizeBytes() != int64(len(data)) && !readZstd {
+		} else if rn.GetDigest().GetSizeBytes() != int64(len(data)) && !readZstd {
 			// We only expect the data length to be different from the digest if we read compressed data.
 			// If we weren't reading compressed data, consider the data corrupted and return that it is not found
 			blobRsp.Status = &statuspb.Status{Code: int32(codes.NotFound)}
@@ -473,13 +473,12 @@ func (d *dirStack) SerializeToToken() (string, error) {
 	return token, nil
 }
 
-func (s *ContentAddressableStorageServer) fetchDir(ctx context.Context, dirName *rspb.ResourceName) (*repb.Directory, error) {
-	_, err := digest.Validate(dirName.GetDigest())
-	if err != nil {
+func (s *ContentAddressableStorageServer) fetchDir(ctx context.Context, dirName *digest.ResourceName) (*repb.Directory, error) {
+	if err := dirName.Validate(); err != nil {
 		return nil, err
 	}
 	// Fetch the "Directory" object which enumerates all the blobs in the directory
-	blob, err := s.cache.Get(ctx, dirName)
+	blob, err := s.cache.Get(ctx, dirName.ToProto())
 	if err != nil {
 		return nil, err
 	}
@@ -491,31 +490,30 @@ func (s *ContentAddressableStorageServer) fetchDir(ctx context.Context, dirName 
 	return dir, nil
 }
 
-func makeTreeCacheDigest(d *repb.Digest) (*repb.Digest, error) {
-	buf := bytes.NewBuffer([]byte(d.GetHash() + *treeCacheSeed))
-	return digest.Compute(buf, digest.Type(d))
+func makeTreeCacheDigest(rn *rspb.ResourceName, digestFunction repb.DigestFunction_Value) (*repb.Digest, error) {
+	buf := bytes.NewBuffer([]byte(rn.GetDigest().GetHash() + *treeCacheSeed))
+	return digest.Compute(buf, digestFunction)
 }
 
-func (s *ContentAddressableStorageServer) fetchDirectory(ctx context.Context, remoteInstanceName string, dd *repb.DirectoryWithDigest) ([]*repb.DirectoryWithDigest, error) {
+func (s *ContentAddressableStorageServer) fetchDirectory(ctx context.Context, remoteInstanceName string, dd *capb.DirectoryWithDigest) ([]*capb.DirectoryWithDigest, error) {
 	dir := dd.Directory
 	if len(dir.Directories) == 0 {
 		return nil, nil
 	}
 	subdirDigests := make([]*rspb.ResourceName, 0, len(dir.Directories))
 	for _, dirNode := range dir.Directories {
-		d := dirNode.GetDigest()
-		if digest.IsEmpty(d) {
+		rn := digest.NewResourceName(dirNode.GetDigest(), remoteInstanceName, rspb.CacheType_CAS)
+		if rn.IsEmpty() {
 			continue
 		}
-		rn := digest.NewResourceName(d, remoteInstanceName, rspb.CacheType_CAS).ToProto()
-		subdirDigests = append(subdirDigests, rn)
+		subdirDigests = append(subdirDigests, rn.ToProto())
 	}
 	rspMap, err := s.cache.GetMulti(ctx, subdirDigests)
 	if err != nil {
 		return nil, err
 	}
 
-	children := make([]*repb.DirectoryWithDigest, 0, len(subdirDigests))
+	children := make([]*capb.DirectoryWithDigest, 0, len(subdirDigests))
 	for _, rn := range subdirDigests {
 		d := rn.GetDigest()
 		blob, ok := rspMap[d]
@@ -530,7 +528,7 @@ func (s *ContentAddressableStorageServer) fetchDirectory(ctx context.Context, re
 			log.Warningf("Found empty directory for digest: %s blob: [%+v]", d.GetHash(), blob)
 			return nil, status.NotFoundErrorf("Found empty directory for digest %s.", d.GetHash())
 		}
-		children = append(children, &repb.DirectoryWithDigest{Directory: subDir, Digest: d})
+		children = append(children, &capb.DirectoryWithDigest{Directory: subDir, ResourceName: rn})
 	}
 	return children, nil
 }
@@ -566,7 +564,8 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 	if req.RootDigest == nil {
 		return status.InvalidArgumentError("RootDigest is required to GetTree")
 	}
-	if digest.IsEmpty(req.GetRootDigest()) {
+	rootDirRN := digest.NewResourceName(req.GetRootDigest(), req.GetInstanceName(), rspb.CacheType_CAS)
+	if rootDirRN.IsEmpty() {
 		return nil
 	}
 
@@ -574,7 +573,6 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 	if err != nil {
 		return err
 	}
-	rootDirRN := digest.NewResourceName(req.GetRootDigest(), req.GetInstanceName(), rspb.CacheType_CAS).ToProto()
 	rootDir, err := s.fetchDir(ctx, rootDirRN)
 	if err != nil {
 		return err
@@ -587,12 +585,13 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 	fetchCount := 0
 	fetchDuration := time.Duration(0)
 
-	finishDir := func(dirWithDigest *repb.DirectoryWithDigest) error {
+	finishDir := func(dirWithDigest *capb.DirectoryWithDigest) error {
 		mu.Lock()
 		defer mu.Unlock()
 
 		dir := dirWithDigest.Directory
-		d := dirWithDigest.Digest
+		rn := digest.ResourceNameFromProto(dirWithDigest.ResourceName)
+		d := rn.GetDigest()
 
 		if rspSizeBytes+d.GetSizeBytes() > gRPCMaxSize {
 			if err := stream.Send(rsp); err != nil {
@@ -607,20 +606,20 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 		return nil
 	}
 
-	var fetch func(ctx context.Context, dirWithDigest *repb.DirectoryWithDigest, level int) ([]*repb.DirectoryWithDigest, error)
-	fetch = func(ctx context.Context, dirWithDigest *repb.DirectoryWithDigest, level int) ([]*repb.DirectoryWithDigest, error) {
+	var fetch func(ctx context.Context, dirWithDigest *capb.DirectoryWithDigest, level int) ([]*capb.DirectoryWithDigest, error)
+	fetch = func(ctx context.Context, dirWithDigest *capb.DirectoryWithDigest, level int) ([]*capb.DirectoryWithDigest, error) {
 		if len(dirWithDigest.Directory.Directories) == 0 {
-			return []*repb.DirectoryWithDigest{dirWithDigest}, nil
+			return []*capb.DirectoryWithDigest{dirWithDigest}, nil
 		}
 
-		treeCacheDigest, err := makeTreeCacheDigest(dirWithDigest.Digest)
+		treeCacheDigest, err := makeTreeCacheDigest(dirWithDigest.GetResourceName(), req.GetDigestFunction())
 		if err != nil {
 			return nil, err
 		}
 		if *enableTreeCaching {
 			treeCacheRN := digest.NewResourceName(treeCacheDigest, req.GetInstanceName(), rspb.CacheType_AC).ToProto()
 			if blob, err := s.cache.Get(ctx, treeCacheRN); err == nil {
-				treeCache := &repb.TreeCache{}
+				treeCache := &capb.TreeCache{}
 				if err := proto.Unmarshal(blob, treeCache); err == nil {
 					if isComplete(treeCache.GetChildren()) {
 						return treeCache.GetChildren(), nil
@@ -641,7 +640,7 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 		fetchCount += 1
 		mu.Unlock()
 
-		allDescendents := make([]*repb.DirectoryWithDigest, 0, len(children))
+		allDescendents := make([]*capb.DirectoryWithDigest, 0, len(children))
 		allDescendents = append(allDescendents, dirWithDigest)
 
 		eg, egCtx := errgroup.WithContext(ctx)
@@ -664,7 +663,7 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 		}
 
 		if level > minTreeCacheLevel && len(allDescendents) > minTreeCacheDescendents && *enableTreeCaching {
-			treeCache := &repb.TreeCache{
+			treeCache := &capb.TreeCache{
 				Children: allDescendents,
 			}
 			if isComplete(treeCache.GetChildren()) {
@@ -683,9 +682,9 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 		return allDescendents, nil
 	}
 
-	allDirs, err := fetch(ctx, &repb.DirectoryWithDigest{
-		Directory: rootDir,
-		Digest:    req.GetRootDigest(),
+	allDirs, err := fetch(ctx, &capb.DirectoryWithDigest{
+		Directory:    rootDir,
+		ResourceName: rootDirRN.ToProto(),
 	}, 0)
 	if err != nil {
 		return err
@@ -703,21 +702,23 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 	return nil
 }
 
-func isComplete(children []*repb.DirectoryWithDigest) bool {
+func isComplete(children []*capb.DirectoryWithDigest) bool {
 	allDigests := make(map[string]struct{}, len(children))
 	for _, child := range children {
-		if digest.IsEmpty(child.GetDigest()) {
+		rn := digest.ResourceNameFromProto(child.GetResourceName())
+		if rn.IsEmpty() {
 			continue
 		}
-		allDigests[child.GetDigest().GetHash()] = struct{}{}
+		allDigests[rn.GetDigest().GetHash()] = struct{}{}
 	}
 	for _, child := range children {
-		if digest.IsEmpty(child.GetDigest()) {
+		rn := digest.ResourceNameFromProto(child.GetResourceName())
+		if rn.IsEmpty() {
 			continue
 		}
 		dir := child.Directory
 		if len(dir.Directories) == 0 && len(dir.Files) == 0 && len(dir.Symlinks) == 0 {
-			log.Warningf("corrupted tree: empty dir: %+v, digest: %q", dir, child.GetDigest().GetHash())
+			log.Warningf("corrupted tree: empty dir: %+v, digest: %q", dir, rn.GetDigest().GetHash())
 			return false
 		}
 		for _, dirNode := range child.GetDirectory().GetDirectories() {

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -48,7 +48,7 @@ const (
 
 var (
 	enableTreeCaching = flag.Bool("cache.enable_tree_caching", true, "If true, cache GetTree responses (full and partial)")
-	treeCacheSeed     = flag.String("cache.tree_cache_seed", "treecache-07012022", "If set, hash this with digests before caching / reading from tree cache")
+	treeCacheSeed     = flag.String("cache.tree_cache_seed", "treecache-03011023", "If set, hash this with digests before caching / reading from tree cache")
 )
 
 type ContentAddressableStorageServer struct {


### PR DESCRIPTION
The refactoring continues!

- Add regex support for parsing digest_function from bytestream URIs
- Move TreeCache protos to cache.proto file and store ResourceNames instead of Digests
- Bump TreeCache seed (because stored data format is changing)
- Move IsEmpty() and Validate() to the ResourceName class because they are dependent on digest function