### PR TITLE
Upgrade com_google_protobuf to 3.22.2

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -133,7 +133,7 @@ test --test_tag_filters=-docker
 build --build_tag_filters=-docker
 
 # Use C++17 standard for all C++ compilation
-build --action_env=BAZEL_CXXOPTS="-std=c++17"
+build --host_cxxopt=-std=c++17
 
 # Run Webdriver tests with --config=webdriver-debug to debug webdriver tests locally.
 # See server/testutil/webtester/webtester.go for more details.

--- a/.bazelrc
+++ b/.bazelrc
@@ -132,6 +132,9 @@ build --experimental_inprocess_symlink_creation
 test --test_tag_filters=-docker
 build --build_tag_filters=-docker
 
+# Use C++17 standard for all C++ compilation
+build --action_env=BAZEL_CXXOPTS="-std=c++17"
+
 # Run Webdriver tests with --config=webdriver-debug to debug webdriver tests locally.
 # See server/testutil/webtester/webtester.go for more details.
 test:webdriver-debug --test_arg=-webdriver_debug

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -121,6 +121,29 @@ yarn_install(
     yarn_lock = "//:yarn.lock",
 )
 
+# Proto -- must be before container_repositories so we don't inherit their rules_pkg.
+
+# NB: The name must be "com_google_protobuf".
+
+# Required by com_google_protobuf
+http_archive(
+    name = "com_google_googletest",
+    sha256 = "ffa17fbc5953900994e2deec164bb8949879ea09b411e07f215bfbb1f87f4632",
+    strip_prefix = "googletest-1.13.0",
+    urls = ["https://github.com/google/googletest/archive/v1.13.0.zip"],
+)
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "2118051b4fb3814d59d258533a4e35452934b1ddb41230261c9543384cbb4dfc",
+    strip_prefix = "protobuf-3.22.2",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.22.2.tar.gz"],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
 # Docker
 
 http_archive(
@@ -200,20 +223,6 @@ k8s_defaults(
     name = "k8s_deploy",
     kind = "deployment",
 )
-
-# Proto
-
-# NB: The name must be "com_google_protobuf".
-http_archive(
-    name = "com_google_protobuf",
-    sha256 = "7c9731ff49ebe1cc4a0650a21d40acc099043f4d584b24632bafc0f5328bc3ff",
-    strip_prefix = "protobuf-3.19.0",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.19.0/protobuf-all-3.19.0.zip"],
-)
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()
 
 load("@io_bazel_rules_docker//contrib:dockerfile_build.bzl", "dockerfile_image")
 


### PR DESCRIPTION
This fixes a compiler warning encountered on newer machines:

```
In file included from /usr/include/string.h:535,
                 from external/com_google_protobuf/src/google/protobuf/stubs/port.h:39,
                 from external/com_google_protobuf/src/google/protobuf/stubs/common.h:48,
                 from external/com_google_protobuf/src/google/protobuf/message_lite.h:45,
                 from external/com_google_protobuf/src/google/protobuf/message_lite.cc:36:
In function 'void* memcpy(void*, const void*, size_t)',
    inlined from 'uint8_t* google::protobuf::io::EpsCopyOutputStream::WriteRaw(const void*, int, uint8_t*)' at external/com_google_protobuf/src/google/protobuf/io/coded_stream.h:706:16,
    inlined from 'virtual uint8_t* google::protobuf::internal::ImplicitWeakMessage::_InternalSerialize(uint8_t*, google::protobuf::io::EpsCopyOutputStream*) const' at external/com_google_protobuf/src/google/protobuf/implicit_weak_message.h:84:28,
    inlined from 'bool google::protobuf::MessageLite::SerializePartialToZeroCopyStream(google::protobuf::io::ZeroCopyOutputStream*) const' at external/com_google_protobuf/src/google/protobuf/message_lite.cc:412:30:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:29:33: warning: 'void* __builtin___memcpy_chk(void*, const void*, long unsigned int, long unsigned int)' specified size between 18446744071562067968 and 18446744073709551615 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Here's the PR that fixed the error: https://github.com/protocolbuffers/protobuf/commit/887daf693fa17d7baf7b55b278132a7115beae30

**Version bump**: Patch