### PR TITLE
Improve split performance by cloning the underlying pebble DB.

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1109,6 +1109,48 @@ func (s *Store) isLeader(clusterID uint64) bool {
 	return false
 }
 
+func (s *Store) CloneCluster(ctx context.Context, req *rfpb.CloneClusterRequest) (*rfpb.CloneClusterResponse, error) {
+	src, err := s.GetReplica(req.GetSourceRangeId())
+	if err != nil {
+		return nil, err
+	}
+
+	dst, err := s.GetReplica(req.GetDestRangeId())
+	if err != nil {
+		return nil, err
+	}
+
+	if err := dst.ImportDB(src); err != nil {
+		return nil, err
+	}
+
+	// The snapshot request requires a deadline to be set on the context.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	// Force compaction so that dragonboat doesn't try to use the existing raft
+	// logs for recovery. The logs are "wrong" since we performed the database
+	// clone outside of raft. With the raft snapshot in place, recovery attempts
+	// will ask the state machine (replica) to provide a snapshot which will
+	// reflect the cloned data.
+	opts := dragonboat.SnapshotOption{
+		OverrideCompactionOverhead: true,
+		CompactionOverhead:         0,
+	}
+	if _, err := s.nodeHost.SyncRequestSnapshot(ctx, dst.ClusterID, opts); err != nil {
+		return nil, err
+	}
+
+	return &rfpb.CloneClusterResponse{}, nil
+}
+
+func (s *Store) TransferLeadership(ctx context.Context, req *rfpb.TransferLeadershipRequest) (*rfpb.TransferLeadershipResponse, error) {
+	if err := s.nodeHost.RequestLeaderTransfer(req.GetClusterId(), req.GetTargetNodeId()); err != nil {
+		return nil, err
+	}
+	return &rfpb.TransferLeadershipResponse{}, nil
+}
+
 func (s *Store) StartCluster(ctx context.Context, req *rfpb.StartClusterRequest) (*rfpb.StartClusterResponse, error) {
 	rc := raftConfig.GetRaftConfig(req.GetClusterId(), req.GetNodeId())
 
@@ -1510,33 +1552,6 @@ func (s *Store) GetClusterMembership(ctx context.Context, clusterID uint64) ([]*
 	return replicas, nil
 }
 
-// createSnapshot saves a snapshot of a replica's pebble database only to a
-// snapshot file on the local filesystem. Stored file data is not part of this
-// snapshot. An identifier for the snapshot is returned.
-func (s *Store) createSnapshot(ctx context.Context, req *rfpb.CreateSnapshotRequest) (*rfpb.CreateSnapshotResponse, error) {
-	r, err := s.GetReplica(req.GetHeader().GetRangeId())
-	if err != nil {
-		return nil, err
-	}
-	snapFile, err := os.CreateTemp(s.rootDir, "snapfile-*")
-	if err != nil {
-		return nil, err
-	}
-	pSnap, err := r.PrepareSnapshot()
-	if err != nil {
-		return nil, err
-	}
-	if err := r.SaveSnapshotRange(pSnap, snapFile, req.GetStart(), req.GetEnd()); err != nil {
-		return nil, err
-	}
-	if err := snapFile.Close(); err != nil {
-		return nil, err
-	}
-	return &rfpb.CreateSnapshotResponse{
-		SnapId: snapFile.Name(),
-	}, nil
-}
-
 // loadSnapshot ingests an already created snapshot (see createSnapshot above)
 // into a range by sending all records in the snapshot over raft to the new
 // range. This may require copying stored file data -- that can be prevented by
@@ -1738,32 +1753,11 @@ func (s *Store) SplitCluster(ctx context.Context, req *rfpb.SplitClusterRequest)
 
 	s.log.Infof("splitlog: acquired split lease")
 
-	// Copy stored data from the old range -> new range by creating a
-	// snapshot of the db, copying stored files, then loading the snapshot
-	// of the db onto the new replica via RAFT.
-	createSnapshotRsp, err := s.createSnapshot(ctx, &rfpb.CreateSnapshotRequest{
-		Header: req.GetHeader(),
-		Start:  findSplitRsp.GetSplit(),
-		End:    oldLeft.GetRight(),
-	})
-	if err != nil {
-		return nil, status.InternalErrorf("could not create snapshot: %s", err)
+	if err := bringup.CloneCluster(ctx, s.apiClient, bootStrapInfo, req.GetRange().GetRangeId(), newIDs.rangeID); err != nil {
+		return nil, status.InternalErrorf("could not clone cluster: %s", err)
 	}
 
-	s.log.Infof("splitlog: snapshotted existing cluster metadata %+v", createSnapshotRsp)
-	loadSnapReq := &rfpb.LoadSnapshotRequest{
-		Header: &rfpb.Header{
-			RangeId:    newIDs.rangeID,
-			Generation: newRight.Generation,
-		},
-		SnapId: createSnapshotRsp.GetSnapId(),
-	}
-	loadSnapRsp, err := s.loadSnapshot(ctx, loadSnapReq)
-	if err != nil {
-		return nil, status.InternalErrorf("could not load snapshot: %s", err)
-	}
-
-	s.log.Infof("splitlog: loaded cluster metadata snapshot into new cluster: %+v", loadSnapRsp)
+	s.log.Infof("splitlog: cloned cluster")
 
 	// As mentioned above, add the replicas to right range now that it is
 	// about to be activated.
@@ -1816,7 +1810,18 @@ func (s *Store) SplitCluster(ctx context.Context, req *rfpb.SplitClusterRequest)
 		return nil, status.InternalErrorf("could not delete old data: %s", err)
 	}
 
-	s.log.Infof("splitlog: cleaned up old data on cluster %d", clusterID)
+	s.log.Infof("splitlog: cleaned up old data on left cluster %d", clusterID)
+
+	// Delete old data from right range
+	rightDeleteReq := rbuilder.NewBatchBuilder().Add(&rfpb.DeleteRangeRequest{
+		Start: newLeft.Left,
+		End:   newLeft.Right,
+	})
+	if err := client.SyncProposeLocalBatchNoRsp(ctx, s.nodeHost, newIDs.clusterID, rightDeleteReq); err != nil {
+		return nil, status.InternalErrorf("could not delete old data: %s", err)
+	}
+
+	s.log.Infof("splitlog: cleaned up old data on right cluster %d", newIDs.clusterID)
 
 	metrics.RaftSplits.With(prometheus.Labels{
 		metrics.RaftNodeHostIDLabel: s.nodeHost.ID(),

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -458,6 +458,13 @@ message StartClusterResponse {
   BatchCmdResponse batch = 1;
 }
 
+message CloneClusterRequest {
+  uint64 source_range_id = 1;
+  uint64 dest_range_id = 2;
+}
+
+message CloneClusterResponse {}
+
 message RemoveDataRequest {
   uint64 cluster_id = 1;
   uint64 node_id = 2;
@@ -585,3 +592,10 @@ message GetMultiResponse {
   }
   repeated Data data = 1;
 }
+
+message TransferLeadershipRequest {
+  uint64 cluster_id = 1;
+  uint64 target_node_id = 2;
+}
+
+message TransferLeadershipResponse {}

--- a/proto/raft_service.proto
+++ b/proto/raft_service.proto
@@ -10,6 +10,8 @@ service Api {
   // Raft Meta-API.
   rpc StartCluster(raft.StartClusterRequest)
       returns (raft.StartClusterResponse);
+  rpc CloneCluster(raft.CloneClusterRequest)
+      returns (raft.CloneClusterResponse);
   rpc RemoveData(raft.RemoveDataRequest) returns (raft.RemoveDataResponse);
   rpc AddClusterNode(raft.AddClusterNodeRequest)
       returns (raft.AddClusterNodeResponse);
@@ -20,6 +22,8 @@ service Api {
       returns (raft.SplitClusterResponse);
   rpc SyncPropose(SyncProposeRequest) returns (SyncProposeResponse);
   rpc SyncRead(SyncReadRequest) returns (SyncReadResponse);
+  rpc TransferLeadership(TransferLeadershipRequest)
+      returns (TransferLeadershipResponse);
 
   // Data API.
   rpc Metadata(MetadataRequest) returns (MetadataResponse);


### PR DESCRIPTION
Before splitting, we start a new cluster that will become the new right side. This is unchanged from before, but because the pebble DB is already open on the new cluster we have to swap the DB with the cloned data after the replica is already running.

After the clone operation is done, we force dragonboat library to take a Raft snapshot and to compact the Raft log. This "tricks" the library into using the replica-provided snapshot data for recovery operations. This is important because the real Raft log does not contain the keys that were cloned.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
