### PR TITLE
Simplify runner pool matching and improve diagnostics

### DIFF
--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -65,7 +65,6 @@ go_test(
         "//enterprise/server/remote_execution/workspace",
         "//enterprise/server/tasksize",
         "//proto:remote_execution_go_proto",
-        "//proto:scheduler_go_proto",
         "//proto:worker_go_proto",
         "//server/testutil/testauth",
         "//server/testutil/testenv",

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -31,7 +31,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
 	wkpb "github.com/buildbuddy-io/buildbuddy/proto/worker"
 )
 
@@ -559,16 +558,16 @@ func TestRunnerPool_GetDifferentRunnerForDifferentAffinityKey(t *testing.T) {
 }
 
 func TestRunnerPool_TaskSize(t *testing.T) {
-	oneGB := &scpb.TaskSize{EstimatedMemoryBytes: 1e9}
-	twoGB := &scpb.TaskSize{EstimatedMemoryBytes: 2e9}
+	oneGB := "1000000000"
+	twoGB := "2000000000"
 
 	for _, test := range []struct {
 		Name          string
-		Size1, Size2  *scpb.TaskSize
+		Size1, Size2  string
 		WFID1, WFID2  string
 		ShouldRecycle bool
 	}{
-		{Name: "DifferentSize_NonWorkflow_ShouldRecycle", Size1: oneGB, Size2: twoGB, WFID1: "", WFID2: "", ShouldRecycle: true},
+		{Name: "DifferentSize_NonWorkflow_ShouldNotRecycle", Size1: oneGB, Size2: twoGB, WFID1: "", WFID2: "", ShouldRecycle: false},
 		{Name: "SameSize_Workflow_ShouldRecycle", Size1: oneGB, Size2: oneGB, WFID1: "WF1", WFID2: "WF1", ShouldRecycle: true},
 		{Name: "DifferentSize_Workflow_ShouldNotRecycle", Size1: oneGB, Size2: twoGB, WFID1: "WF1", WFID2: "WF1", ShouldRecycle: false},
 		{Name: "SameSize_DifferentWorkflowIDs_ShouldNotRecycle", Size1: oneGB, Size2: oneGB, WFID1: "WF1", WFID2: "WF2", ShouldRecycle: false},
@@ -578,12 +577,12 @@ func TestRunnerPool_TaskSize(t *testing.T) {
 			pool := newRunnerPool(t, env, noLimitsCfg)
 			ctxUser1 := withAuthenticatedUser(t, context.Background(), env, "US1")
 			t1 := newTask()
-			t1.SchedulingMetadata = &scpb.SchedulingMetadata{TaskSize: test.Size1}
 			p1 := t1.ExecutionTask.Command.Platform
+			p1.Properties = append(p1.Properties, &repb.Platform_Property{Name: platform.EstimatedMemoryPropertyName, Value: test.Size1})
 			p1.Properties = append(p1.Properties, &repb.Platform_Property{Name: platform.WorkflowIDPropertyName, Value: test.WFID1})
 			t2 := newTask()
-			t2.SchedulingMetadata = &scpb.SchedulingMetadata{TaskSize: test.Size2}
 			p2 := t2.ExecutionTask.Command.Platform
+			p2.Properties = append(p2.Properties, &repb.Platform_Property{Name: platform.EstimatedMemoryPropertyName, Value: test.Size2})
 			p2.Properties = append(p2.Properties, &repb.Platform_Property{Name: platform.WorkflowIDPropertyName, Value: test.WFID2})
 
 			r1 := mustGetNewRunner(t, ctxUser1, pool, t1)


### PR DESCRIPTION
Instead of matching tasks to runners based on a big list of properties that manually copied over from values that are derived from platform props, just directly match on the whole platform proto.

While this slightly changes the matching behavior for tasks in general, it should not make a practical difference. Workflow task matching should not be affected at all.

Benefits:
* Simplifies the code
* Makes the runner pool's matching consistent with the task router's matching (the task router hashes the platform to compute the redis routing key)
* Since the match key is now essentially just `(groupID, instanceName, sha256(platform))` we can easily add this key to the logs and get much better diagnostics when runners aren't reused.

Tested:
- `runner_test.go` covers this code pretty well and still passes (after a slight modification to assert based on requested task size rather than actual task size, which should be fine)
- Sanity checked that changing the order of exec_properties in bazel still results in the same platform hash (since bazel sorts the properties by name)
- Tested in dev - workflows still hit warm runners ([example](https://app.buildbuddy.dev/invocation/2721985b-26e6-4e61-98ab-1c85ef7fa9bd?role=CI_RUNNER))

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
