### PR TITLE
Fix the build

### DIFF
--- a/enterprise/app/BUILD.bazel
+++ b/enterprise/app/BUILD.bazel
@@ -36,6 +36,7 @@ esbuild(
         ":fastbuild": False,
         "//conditions:default": True,
     }),
+    visibility = ["//visibility:public"],
     deps = [
         ":app",
     ],
@@ -72,6 +73,7 @@ genrule(
         done;
         cat out > $@;
     """,
+    visibility = ["//visibility:public"],
 )
 
 sha(
@@ -80,6 +82,7 @@ sha(
         ":style.css",
         "//enterprise/app:app_bundle",
     ],
+    visibility = ["//visibility:public"],
 )
 
 ts_library(

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -8,7 +8,7 @@ go_library(
     name = "executor_lib",
     srcs = ["executor.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/executor",
-    visibility = ["//enterprise/server/cmd/executor/yaml_doc:__pkg__"],
+    visibility = ["//visibility:public"],
     deps = [
         "//enterprise:bundle",
         "//enterprise/server/auth",

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
-package(default_visibility = ["//enterprise:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 go_library(
     name = "server_lib",

--- a/enterprise/server/image_converter/BUILD
+++ b/enterprise/server/image_converter/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
-package(default_visibility = ["//enterprise:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 go_library(
     name = "image_converter_lib",

--- a/enterprise/server/remote_execution/vfs/BUILD
+++ b/enterprise/server/remote_execution/vfs/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-package(default_visibility = ["//enterprise:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 go_library(
     name = "vfs",

--- a/enterprise/server/tasksize/BUILD
+++ b/enterprise/server/tasksize/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-package(default_visibility = ["//enterprise:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 go_library(
     name = "tasksize",

--- a/enterprise/server/util/vfs_server/BUILD
+++ b/enterprise/server/util/vfs_server/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-package(default_visibility = ["//enterprise:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 go_library(
     name = "vfs_server",


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy/commit/88b49fc88c626c7e1e9b06f3f9f33e9d11c80f19 was a little overzealous in restricting visibility and it broke buildbuddy-internal: https://app.buildbuddy.io/invocation/dc1d8c0f-0176-4881-8d53-bb9e1a15f605

This PR makes a handful of packages publicly visibly again so they can be depended on from buildbuddy-internal.

**Version bump**: Patch