### PR TITLE
Add a buildbuddy_remote_downloader config to ci_runner generated bazelrc

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1579,6 +1579,7 @@ func writeBazelrc(path, invocationID string) error {
 	}...)
 	if *cacheBackend != "" {
 		lines = append(lines, "build:buildbuddy_remote_cache --remote_cache="+*cacheBackend)
+		lines = append(lines, "build:buildbuddy_experimental_remote_downloader --experimental_remote_downloader="+*cacheBackend)
 	}
 	if *rbeBackend != "" {
 		lines = append(lines, "build:buildbuddy_remote_executor --remote_executor="+*rbeBackend)


### PR DESCRIPTION
We can make use of this config to dogfood the remote asset API in dev/prod. This could potentially make builds faster and less flaky since we'll be fetching repos from the co-located apps instead of github / NPM etc. (but I think dogfooding is the more important benefit)

Kept the "experimental_" prefix since presumably it might be promoted to non-experimental at some point, and we'll want to have both flag variants for backwards compatibility.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
