### PR TITLE
Add the jailer binary to the executor image

### DIFF
--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -76,6 +76,7 @@ container_layer(
     files = [
         "@com_github_containerd_stargz_snapshotter-v0.11.4-linux-amd64//:stargz-store",
         "@com_github_firecracker_microvm_firecracker-v1.1.1-x86_64//:firecracker-v1.1.1-x86_64",
+        "@com_github_firecracker_microvm_firecracker-v1.1.1-x86_64//:jailer-v1.1.1-x86_64",
     ],
     symlinks = {
         "/usr/bin/firecracker": "/usr/bin/firecracker-v1.1.1-x86_64",


### PR DESCRIPTION
Firecracker is in the image already but I forgot to include jailer in my last PR too.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
