### PR TITLE
Add a script to run the executor_image target locally

### DIFF
--- a/enterprise/config/executor.local.yaml
+++ b/enterprise/config/executor.local.yaml
@@ -1,8 +1,8 @@
 executor:
   root_directory: "/tmp/${USER}_remote_build"
+  local_cache_directory: "/tmp/${USER}_filecache"
   docker_socket: /var/run/docker.sock
   docker_inherit_user_ids: true
   enable_firecracker: true
   app_target: "grpc://localhost:1985"
-  local_cache_directory: "/tmp/filecache"
   local_cache_size_bytes: 10000000000 # 10GB

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -97,6 +97,8 @@ container_image(
 
 # Build a docker image similar to the go_binary above, but use the "go_image"
 # rule from @io_bazel_rules_docker instead, which creates a docker image.
+#
+# This target can be run locally with enterprise/tools/run_executor_image.sh
 go_image(
     name = "executor_image",
     base = ":base_image",

--- a/enterprise/tools/run_executor_image.sh
+++ b/enterprise/tools/run_executor_image.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Builds and runs the executor Docker image locally.
+
+DOCKER_ARGS=(
+  # Make sure we can access /dev/kvm (for firecracker).
+  --privileged
+  # Mount persistent build root dirs and filecache so that
+  # firecracker image warmup doesn't take forever.
+  # The executor.local.yaml defines these with a $USER prefix,
+  # and the executor image will run as root, hence the "root_" prefix.
+  --volume /tmp/root_remote_build:/tmp/root_remote_build
+  --volume /tmp/root_filecache:/tmp/root_filecache
+  # Even though the executor runs as uid 0, the USER env var is
+  # not set for some reason, so set it here.
+  --env "USER=root"
+  # Mount gcloud config so we can pull from gcr.io
+  --volume "$HOME/.config/gcloud:/root/.config/gcloud"
+  # Mount the docker socket.
+  --volume /var/run/docker.sock:/var/run/docker.sock
+  # Mount the local config file.
+  --volume "$PWD/enterprise/config/executor.local.yaml:/executor.local.yaml"
+  # Note: we need "--net=host" but don't need to set it explicitly,
+  # since the `bazel run` target created by rules_docker sets it by default.
+)
+
+bazel run //enterprise/server/cmd/executor:executor_image -- "${DOCKER_ARGS[@]}" -- \
+  --monitoring_port=9091 \
+  --config_file=/executor.local.yaml \
+  "$@"


### PR DESCRIPTION
Created this script while attempting to debug why we timeout when attempting to connect to firecracker. It seems to repro when the executor is running via the executor_image, but not when running the go_binary target directly.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
