### PR TITLE
Fix firecracker failing to start

### DIFF
--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -70,18 +70,33 @@ go_binary(
     embed = [":executor_lib"],
 )
 
+# Executor expects "firecracker" and "jailer" binaries in $PATH,
+# and they can't be symlinks (otherwise the VM will not start).
+# Rename the firecracker/jailer binaries so that we can place
+# those into /usr/bin as regular files.
+
+genrule(
+    name = "firecracker_rename",
+    srcs = ["@com_github_firecracker_microvm_firecracker-v1.1.1-x86_64//:firecracker-v1.1.1-x86_64"],
+    outs = ["firecracker"],
+    cmd = "cp $(SRCS) $@",
+)
+
+genrule(
+    name = "jailer_rename",
+    srcs = ["@com_github_firecracker_microvm_firecracker-v1.1.1-x86_64//:jailer-v1.1.1-x86_64"],
+    outs = ["jailer"],
+    cmd = "cp $(SRCS) $@",
+)
+
 container_layer(
     name = "executor_tools",
     directory = "/usr/bin",
     files = [
+        ":firecracker",
+        ":jailer",
         "@com_github_containerd_stargz_snapshotter-v0.11.4-linux-amd64//:stargz-store",
-        "@com_github_firecracker_microvm_firecracker-v1.1.1-x86_64//:firecracker-v1.1.1-x86_64",
-        "@com_github_firecracker_microvm_firecracker-v1.1.1-x86_64//:jailer-v1.1.1-x86_64",
     ],
-    symlinks = {
-        "/usr/bin/firecracker": "/usr/bin/firecracker-v1.1.1-x86_64",
-        "/usr/bin/jailer": "/usr/bin/jailer-v1.1.1-x86_64",
-    },
 )
 
 container_image(


### PR DESCRIPTION
Firecracker does not seem to like `/usr/bin/firecracker` being a symlink (introduced in https://github.com/buildbuddy-io/buildbuddy/pull/3566). it fails to connect to the VM socket without giving any feedback as to why. Reproduced locally using the script added in https://github.com/buildbuddy-io/buildbuddy/pull/3575 and verified the fix.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
