### PR TITLE
Small cleanup to snaploader

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -511,7 +511,7 @@ func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context, instanceName st
 	// merge the modified pages on top of the existing memory snapshot.
 	baseMemSnapshotPath := ""
 	if baseSnapshotDigest != nil {
-		loader, err := snaploader.New(ctx, c.env, c.jailerRoot)
+		loader, err := snaploader.New(c.env, c.jailerRoot)
 		if err != nil {
 			return nil, err
 		}
@@ -587,7 +587,7 @@ func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context, instanceName st
 	}
 
 	snaploaderStart := time.Now()
-	loader, err := snaploader.New(ctx, c.env, c.jailerRoot)
+	loader, err := snaploader.New(c.env, c.jailerRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -671,7 +671,7 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 		ForwardSignals: make([]os.Signal, 0),
 	}
 
-	loader, err := snaploader.New(ctx, c.env, c.jailerRoot)
+	loader, err := snaploader.New(c.env, c.jailerRoot)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -511,7 +511,7 @@ func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context, instanceName st
 	// merge the modified pages on top of the existing memory snapshot.
 	baseMemSnapshotPath := ""
 	if baseSnapshotDigest != nil {
-		loader, err := snaploader.New(ctx, c.env, c.jailerRoot, instanceName)
+		loader, err := snaploader.New(ctx, c.env, c.jailerRoot)
 		if err != nil {
 			return nil, err
 		}
@@ -519,7 +519,7 @@ func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context, instanceName st
 		if err := disk.EnsureDirectoryExists(baseDir); err != nil {
 			return nil, err
 		}
-		if err := loader.UnpackSnapshot(baseSnapshotDigest, baseDir); err != nil {
+		if err := loader.UnpackSnapshot(ctx, baseSnapshotDigest, baseDir); err != nil {
 			return nil, err
 		}
 		baseMemSnapshotPath = filepath.Join(baseDir, fullMemSnapshotName)
@@ -527,7 +527,7 @@ func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context, instanceName st
 		// The base snapshot is no longer useful since we're merging on top
 		// of it and replacing the paused VM snapshot with the new merged
 		// snapshot. Delete it to prevent unnecessary filecache evictions.
-		if err := loader.DeleteSnapshot(baseSnapshotDigest); err != nil {
+		if err := loader.DeleteSnapshot(ctx, baseSnapshotDigest); err != nil {
 			log.Warningf("Failed to delete snapshot: %s", err)
 		}
 	}
@@ -587,11 +587,11 @@ func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context, instanceName st
 	}
 
 	snaploaderStart := time.Now()
-	loader, err := snaploader.New(ctx, c.env, c.jailerRoot, instanceName)
+	loader, err := snaploader.New(ctx, c.env, c.jailerRoot)
 	if err != nil {
 		return nil, err
 	}
-	snapshotDigest, err := loader.CacheSnapshot(opts)
+	snapshotDigest, err := loader.CacheSnapshot(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -671,12 +671,12 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 		ForwardSignals: make([]os.Signal, 0),
 	}
 
-	loader, err := snaploader.New(ctx, c.env, c.jailerRoot, instanceName)
+	loader, err := snaploader.New(ctx, c.env, c.jailerRoot)
 	if err != nil {
 		return err
 	}
 
-	configurationData, err := loader.GetConfigurationData(snapshotDigest)
+	configurationData, err := loader.GetConfigurationData(ctx, snapshotDigest)
 	if err != nil {
 		return err
 	}
@@ -706,7 +706,7 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 	}
 	log.CtxDebugf(ctx, "Command: %v", reflect.Indirect(reflect.Indirect(reflect.ValueOf(machine)).FieldByName("cmd")).FieldByName("Args"))
 
-	if err := loader.UnpackSnapshot(snapshotDigest, c.getChroot()); err != nil {
+	if err := loader.UnpackSnapshot(ctx, snapshotDigest, c.getChroot()); err != nil {
 		return err
 	}
 

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -79,16 +79,14 @@ func enumerateFiles(snapOpts *LoadSnapshotOptions) []string {
 }
 
 type Loader interface {
-	CacheSnapshot(snapOpts *LoadSnapshotOptions) (*repb.Digest, error)
-	UnpackSnapshot(snapshotDigest *repb.Digest, outputDirectory string) error
-	DeleteSnapshot(snapshotDigest *repb.Digest) error
-	GetConfigurationData(snapshotDigest *repb.Digest) ([]byte, error)
+	CacheSnapshot(ctx context.Context, snapOpts *LoadSnapshotOptions) (*repb.Digest, error)
+	UnpackSnapshot(ctx context.Context, snapshotDigest *repb.Digest, outputDirectory string) error
+	DeleteSnapshot(ctx context.Context, snapshotDigest *repb.Digest) error
+	GetConfigurationData(ctx context.Context, snapshotDigest *repb.Digest) ([]byte, error)
 }
 
 type FileCacheLoader struct {
-	ctx              context.Context
 	env              environment.Env
-	instanceName     string // TODO: remove (this is unused)
 	workingDirectory string
 	snapshotDigest   *repb.Digest
 	manifest         *manifestData
@@ -96,12 +94,10 @@ type FileCacheLoader struct {
 
 // New returns a new snapshot.Loader that can be used to download the specified
 // snapshot into the target chroot.
-func New(ctx context.Context, env environment.Env, workingDirectory, instanceName string) (Loader, error) {
+func New(ctx context.Context, env environment.Env, workingDirectory string) (Loader, error) {
 	l := &FileCacheLoader{
-		ctx:              ctx,
 		env:              env,
 		workingDirectory: workingDirectory,
-		instanceName:     instanceName,
 	}
 	return l, nil
 }
@@ -132,7 +128,7 @@ func (l *FileCacheLoader) unpackManifest(snapshotDigest *repb.Digest) error {
 
 // GetConfigurationData returns the configuration data associated with a
 // snapshot.
-func (l *FileCacheLoader) GetConfigurationData(snapshotDigest *repb.Digest) ([]byte, error) {
+func (l *FileCacheLoader) GetConfigurationData(ctx context.Context, snapshotDigest *repb.Digest) ([]byte, error) {
 	if err := l.unpackManifest(snapshotDigest); err != nil {
 		return nil, err
 	}
@@ -141,7 +137,7 @@ func (l *FileCacheLoader) GetConfigurationData(snapshotDigest *repb.Digest) ([]b
 
 // UnpackSnapshot unpacks all of the files in a snapshot to the specified output
 // directory.
-func (l *FileCacheLoader) UnpackSnapshot(snapshotDigest *repb.Digest, outputDirectory string) error {
+func (l *FileCacheLoader) UnpackSnapshot(ctx context.Context, snapshotDigest *repb.Digest, outputDirectory string) error {
 	if l.snapshotDigest != nil && l.snapshotDigest != snapshotDigest {
 		return status.InvalidArgumentErrorf("Snapshot configuration already fetched with different digest %q", digest.String(l.snapshotDigest))
 	}
@@ -159,7 +155,7 @@ func (l *FileCacheLoader) UnpackSnapshot(snapshotDigest *repb.Digest, outputDire
 	return nil
 }
 
-func (l *FileCacheLoader) DeleteSnapshot(snapshotDigest *repb.Digest) error {
+func (l *FileCacheLoader) DeleteSnapshot(ctx context.Context, snapshotDigest *repb.Digest) error {
 	if l.snapshotDigest != nil && l.snapshotDigest != snapshotDigest {
 		return status.InvalidArgumentErrorf("Snapshot configuration already fetched with different digest %q", digest.String(l.snapshotDigest))
 	}
@@ -201,7 +197,7 @@ func (m *manifestData) String() string {
 // the snapshot ID and the file name. A manifest file that
 // that lists all files. Finally, an action result is cached that describes all
 // files -- this allows for fast existence checking and easy download.
-func (l *FileCacheLoader) CacheSnapshot(snapOpts *LoadSnapshotOptions) (*repb.Digest, error) {
+func (l *FileCacheLoader) CacheSnapshot(ctx context.Context, snapOpts *LoadSnapshotOptions) (*repb.Digest, error) {
 	if l.env.GetFileCache() == nil {
 		return nil, status.FailedPreconditionErrorf("Unable to cache snapshot: FileCache not enabled")
 	}

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -94,7 +94,7 @@ type FileCacheLoader struct {
 
 // New returns a new snapshot.Loader that can be used to download the specified
 // snapshot into the target chroot.
-func New(ctx context.Context, env environment.Env, workingDirectory string) (Loader, error) {
+func New(env environment.Env, workingDirectory string) (Loader, error) {
 	l := &FileCacheLoader{
 		env:              env,
 		workingDirectory: workingDirectory,

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -34,18 +34,18 @@ func TestPackAndUnpack(t *testing.T) {
 	// and add them to the cache. Note, the snapshot digests don't actually
 	// correspond to any real content; they just need to be unique cache
 	// keys.
-	la, err := snaploader.New(ctx, env, workDir, "" /*=instanceName*/)
+	la, err := snaploader.New(ctx, env, workDir)
 	require.NoError(t, err)
 	da := &repb.Digest{Hash: hash.String("manifest-A"), SizeBytes: 1}
 	sa := makeFakeSnapshot(t, workDir, da)
-	da, err = la.CacheSnapshot(sa)
+	da, err = la.CacheSnapshot(ctx, sa)
 	require.NoError(t, err)
 
-	lb, err := snaploader.New(ctx, env, workDir, "" /*=instanceName*/)
+	lb, err := snaploader.New(ctx, env, workDir)
 	require.NoError(t, err)
 	db := &repb.Digest{Hash: hash.String("manifest-B"), SizeBytes: 1}
 	sb := makeFakeSnapshot(t, workDir, db)
-	db, err = lb.CacheSnapshot(sb)
+	db, err = lb.CacheSnapshot(ctx, sb)
 	require.NoError(t, err)
 
 	// We should be able to unpack snapshot A, delete it, and then replace it
@@ -58,14 +58,14 @@ func TestPackAndUnpack(t *testing.T) {
 		// Delete, since it's no longer needed.
 		// Note: we construct a new loader here to ensure the current
 		// snapshot manifest gets loaded.
-		loader, err := snaploader.New(ctx, env, workDir, "" /*=instanceName*/)
+		loader, err := snaploader.New(ctx, env, workDir)
 		require.NoError(t, err)
-		err = loader.DeleteSnapshot(da)
+		err = loader.DeleteSnapshot(ctx, da)
 		require.NoError(t, err)
 
 		// Re-add to cache with the same key, but with new contents.
 		sa = makeFakeSnapshot(t, workDir, da)
-		da, err = la.CacheSnapshot(sa)
+		da, err = la.CacheSnapshot(ctx, sa)
 		require.NoError(t, err)
 	}
 
@@ -94,9 +94,9 @@ func makeRandomFile(t *testing.T, rootDir, prefix string, size int) string {
 // Unpacks a snapshot to outDir and asserts that the contents match the
 // originally cached contents.
 func mustUnpack(t *testing.T, ctx context.Context, env environment.Env, d *repb.Digest, workDir, outDir string, originalSnapshot *snaploader.LoadSnapshotOptions) {
-	loader, err := snaploader.New(ctx, env, workDir, "" /*=instanceName*/)
+	loader, err := snaploader.New(ctx, env, workDir)
 	require.NoError(t, err)
-	err = loader.UnpackSnapshot(d, outDir)
+	err = loader.UnpackSnapshot(ctx, d, outDir)
 	require.NoError(t, err)
 
 	for _, path := range []string{

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -34,14 +34,14 @@ func TestPackAndUnpack(t *testing.T) {
 	// and add them to the cache. Note, the snapshot digests don't actually
 	// correspond to any real content; they just need to be unique cache
 	// keys.
-	la, err := snaploader.New(ctx, env, workDir)
+	la, err := snaploader.New(env, workDir)
 	require.NoError(t, err)
 	da := &repb.Digest{Hash: hash.String("manifest-A"), SizeBytes: 1}
 	sa := makeFakeSnapshot(t, workDir, da)
 	da, err = la.CacheSnapshot(ctx, sa)
 	require.NoError(t, err)
 
-	lb, err := snaploader.New(ctx, env, workDir)
+	lb, err := snaploader.New(env, workDir)
 	require.NoError(t, err)
 	db := &repb.Digest{Hash: hash.String("manifest-B"), SizeBytes: 1}
 	sb := makeFakeSnapshot(t, workDir, db)
@@ -58,7 +58,7 @@ func TestPackAndUnpack(t *testing.T) {
 		// Delete, since it's no longer needed.
 		// Note: we construct a new loader here to ensure the current
 		// snapshot manifest gets loaded.
-		loader, err := snaploader.New(ctx, env, workDir)
+		loader, err := snaploader.New(env, workDir)
 		require.NoError(t, err)
 		err = loader.DeleteSnapshot(ctx, da)
 		require.NoError(t, err)
@@ -94,7 +94,7 @@ func makeRandomFile(t *testing.T, rootDir, prefix string, size int) string {
 // Unpacks a snapshot to outDir and asserts that the contents match the
 // originally cached contents.
 func mustUnpack(t *testing.T, ctx context.Context, env environment.Env, d *repb.Digest, workDir, outDir string, originalSnapshot *snaploader.LoadSnapshotOptions) {
-	loader, err := snaploader.New(ctx, env, workDir)
+	loader, err := snaploader.New(env, workDir)
 	require.NoError(t, err)
 	err = loader.UnpackSnapshot(ctx, d, outDir)
 	require.NoError(t, err)


### PR DESCRIPTION
* Remove `instanceName` from constructor (instead, we'll want to change `snapshotDigest *repb.Digest` to `snapshotResourceName *rspb.ResourceName` and pass around the instance name that way)
* Add `ctx` to all interface methods, since we'll need this for a remote cache-based `Loader` implementation
* Don't store `ctx` in the loader struct

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
