### PR TITLE
Fix filecache entries not being overwritable

### DIFF
--- a/enterprise/server/remote_execution/filecache/BUILD
+++ b/enterprise/server/remote_execution/filecache/BUILD
@@ -32,8 +32,11 @@ go_test(
     deps = [
         ":filecache",
         "//proto:remote_execution_go_proto",
+        "//server/metrics",
         "//server/testutil/testfs",
+        "//server/testutil/testmetrics",
         "//server/util/hash",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -219,6 +219,11 @@ func (c *fileCache) FastLinkFile(node *repb.FileNode, outputPath string) (hit bo
 func (c *fileCache) AddFile(node *repb.FileNode, existingFilePath string) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+
+	// Remove any existing entry first.
+	k := key(node)
+	c.l.Remove(k)
+
 	fp := c.filecachePath(node)
 	if err := fastcopy.FastCopy(existingFilePath, fp); err != nil {
 		log.Warningf("Error adding file to filecache: %s", err.Error())
@@ -230,7 +235,7 @@ func (c *fileCache) AddFile(node *repb.FileNode, existingFilePath string) {
 		value:       fp,
 	}
 	metrics.FileCacheAddedFileSizeBytes.Observe(float64(e.sizeBytes))
-	c.l.Add(key(node), e)
+	c.l.Add(k, e)
 }
 
 func (c *fileCache) DeleteFile(node *repb.FileNode) bool {


### PR DESCRIPTION
`Filecache.Add` does not overwrite entries at a given key. This is usually not an issue,  since contents should normally match the keys (which are SHA256 digests of the content), and so any overwrites would be a NOP.

But `snaploader.FileCacheLoader` depends on being able to write entries where the key doesn't necessarily reflect the content digest, similar to AC.

This was broken and was causing problems in some unit tests that I'm adding in one of my branches, though I'm not sure yet whether this caused any problems in practice.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
