### PR TITLE
Allow distinguishing manual removals from evictions in LRU OnEvict callback

### DIFF
--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -86,10 +86,10 @@ func sizeFn(value interface{}) int64 {
 	return 0
 }
 
-func evictFn(value interface{}, removed bool) {
+func evictFn(value interface{}, reason lru.EvictionReason) {
 	if v, ok := value.(*entry); ok {
 		syscall.Unlink(v.value)
-		if !removed {
+		if reason == lru.SizeEviction {
 			age := time.Since(time.UnixMicro(v.addedAtUsec)).Microseconds()
 			metrics.FileCacheLastEvictionAgeUsec.Set(float64(age))
 		}

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -86,11 +86,13 @@ func sizeFn(value interface{}) int64 {
 	return 0
 }
 
-func evictFn(value interface{}) {
+func evictFn(value interface{}, removed bool) {
 	if v, ok := value.(*entry); ok {
 		syscall.Unlink(v.value)
-		age := time.Since(time.UnixMicro(v.addedAtUsec)).Microseconds()
-		metrics.FileCacheLastEvictionAgeUsec.Set(float64(age))
+		if !removed {
+			age := time.Since(time.UnixMicro(v.addedAtUsec)).Microseconds()
+			metrics.FileCacheLastEvictionAgeUsec.Set(float64(age))
+		}
 	}
 }
 

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -600,7 +600,7 @@ func makeRecordFromInfo(key *fileKey, info fs.FileInfo) *fileRecord {
 	}
 }
 
-func (p *partition) evictFn(value interface{}) {
+func (p *partition) evictFn(value interface{}, removed bool) {
 	if v, ok := value.(*fileRecord); ok {
 		i, err := os.Stat(v.FullPath())
 		if err == nil {

--- a/server/util/lru/lru_test.go
+++ b/server/util/lru/lru_test.go
@@ -12,8 +12,11 @@ func TestAdd(t *testing.T) {
 
 	l, err := lru.NewLRU(&lru.Config{
 		MaxSize: 10,
-		OnEvict: func(value interface{}) { evictions = append(evictions, value.(int)) },
-		SizeFn:  func(value interface{}) int64 { return int64(value.(int)) },
+		OnEvict: func(value interface{}, removed bool) {
+			evictions = append(evictions, value.(int))
+			require.False(t, removed, "should be evicted, not removed")
+		},
+		SizeFn: func(value interface{}) int64 { return int64(value.(int)) },
 	})
 	require.NoError(t, err)
 
@@ -29,8 +32,11 @@ func TestPushBack(t *testing.T) {
 
 	l, err := lru.NewLRU(&lru.Config{
 		MaxSize: 10,
-		OnEvict: func(value interface{}) { evictions = append(evictions, value.(int)) },
-		SizeFn:  func(value interface{}) int64 { return int64(value.(int)) },
+		OnEvict: func(value interface{}, removed bool) {
+			evictions = append(evictions, value.(int))
+			require.False(t, removed, "should be evicted, not removed")
+		},
+		SizeFn: func(value interface{}) int64 { return int64(value.(int)) },
 	})
 	require.NoError(t, err)
 
@@ -39,4 +45,32 @@ func TestPushBack(t *testing.T) {
 	require.False(t, l.PushBack("c", 3))
 	require.Equal(t, 1, len(evictions))
 	require.Equal(t, 3, evictions[0])
+}
+
+func TestRemoveOldest(t *testing.T) {
+	evictions := make([]int, 0)
+
+	l, err := lru.NewLRU(&lru.Config{
+		MaxSize: 10,
+		OnEvict: func(value interface{}, removed bool) {
+			evictions = append(evictions, value.(int))
+			require.False(t, removed, "should be evicted, not removed")
+		},
+		SizeFn: func(value interface{}) int64 { return int64(value.(int)) },
+	})
+	require.NoError(t, err)
+
+	require.True(t, l.Add("a", 5))
+	require.True(t, l.Add("b", 4))
+	require.Empty(t, evictions)
+
+	oldest, ok := l.RemoveOldest()
+	require.True(t, ok)
+	require.Equal(t, 5, oldest.(int))
+	require.Equal(t, []int{5}, evictions)
+
+	oldest, ok = l.RemoveOldest()
+	require.True(t, ok)
+	require.Equal(t, 4, oldest.(int))
+	require.Equal(t, []int{5, 4}, evictions)
 }


### PR DESCRIPTION
We don't want manual removals to count towards `last_eviction_age` metrics.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
