### PR TITLE
Fix PushBack implementation

### DIFF
--- a/server/util/lru/lru_test.go
+++ b/server/util/lru/lru_test.go
@@ -36,7 +36,6 @@ func TestPushBack(t *testing.T) {
 
 	require.True(t, l.PushBack("a", 5))
 	require.True(t, l.PushBack("b", 4))
-	require.False(t, l.PushBack("c", 3))
-	require.Equal(t, 1, len(evictions))
-	require.Equal(t, 3, evictions[0])
+	require.False(t, l.PushBack("c", 3), "c should not be added since there isn't enough capacity")
+	require.Empty(t, evictions)
 }


### PR DESCRIPTION
Our only existing usage of `PushBack` is to scan existing items for adding to the disk cache. The intention of the calling code (based on the comment) is to scan through existing entries on disk and add them to the LRU until it's filled up. But the current impl has a bug that the last item to be added actually causes an eviction of the last item that was pushed to the back. This is not a big deal, but slightly confusing behavior that's worth fixing in case it causes problems down the road.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
