### PR TITLE
Update LRU size when overwriting an existing LRU key with a different size

### DIFF
--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -511,7 +511,15 @@ func newPartition(id string, rootDir string, maxSizeBytes int64, useV2Layout boo
 		internedStrings:  make(map[string]string, 0),
 		doneAsyncLoading: make(chan struct{}),
 	}
-	l, err := lru.NewLRU(&lru.Config{MaxSize: maxSizeBytes, OnEvict: p.evictFn, SizeFn: sizeFn})
+	config := &lru.Config{
+		MaxSize: maxSizeBytes,
+		OnEvict: p.evictFn,
+		SizeFn:  sizeFn,
+		// Update LRU entries in place to prevent overwrites from deleting the
+		// file (via evictFn).
+		UpdateInPlace: true,
+	}
+	l, err := lru.NewLRU(config)
 	if err != nil {
 		return nil, err
 	}

--- a/server/util/lru/lru.go
+++ b/server/util/lru/lru.go
@@ -106,11 +106,9 @@ func (c *LRU) Add(key, value interface{}) bool {
 	if !ok {
 		return false
 	}
-	// Check for existing item
+	// Remove any existing item.
 	if ent, ok := c.lookupItem(pk, ck); ok {
-		c.evictList.MoveToFront(ent)
-		ent.Value.(*Entry).value = value
-		return true
+		c.removeElement(ent)
 	}
 
 	// Add new item
@@ -125,6 +123,8 @@ func (c *LRU) Add(key, value interface{}) bool {
 // PushBack adds a value to the back of the cache, but only if there is
 // sufficient capacity.
 //
+// If the item already exists, it is first removed.
+//
 // This is useful for populating the cache initially, by iterating over existing
 // items in MRU to LRU order and repeatedly calling PushBack on each item.
 //
@@ -134,10 +134,9 @@ func (c *LRU) PushBack(key, value interface{}) bool {
 	if !ok {
 		return false
 	}
-	// Check for existing item
+	// Remove any existing item.
 	if ent, ok := c.lookupItem(pk, ck); ok {
-		ent.Value.(*Entry).value = value
-		return true
+		c.removeElement(ent)
 	}
 
 	size := c.sizeFn(value)

--- a/server/util/lru/lru.go
+++ b/server/util/lru/lru.go
@@ -26,16 +26,21 @@ type Config struct {
 	// Maximum amount of data to store in the cache.
 	// The size of each entry is determined by SizeFn.
 	MaxSize int64
+	// Whether adding an item with a key that already exists should update the
+	// existing entry's size and value, instead of evicting the old entry and
+	// invoking the OnEvict callback.
+	UpdateInPlace bool
 }
 
 // LRU implements a non-thread safe fixed size LRU cache
 type LRU struct {
-	sizeFn      SizeFn
-	evictList   *list.List
-	items       map[uint64][]*list.Element
-	onEvict     EvictedCallback
-	maxSize     int64
-	currentSize int64
+	sizeFn        SizeFn
+	evictList     *list.List
+	items         map[uint64][]*list.Element
+	onEvict       EvictedCallback
+	maxSize       int64
+	currentSize   int64
+	updateInPlace bool
 }
 
 // Entry is used to hold a value in the evictList
@@ -54,12 +59,13 @@ func NewLRU(config *Config) (interfaces.LRU, error) {
 		return nil, status.InvalidArgumentError("SizeFn is required")
 	}
 	c := &LRU{
-		currentSize: 0,
-		maxSize:     config.MaxSize,
-		evictList:   list.New(),
-		items:       make(map[uint64][]*list.Element),
-		onEvict:     config.OnEvict,
-		sizeFn:      config.SizeFn,
+		currentSize:   0,
+		maxSize:       config.MaxSize,
+		evictList:     list.New(),
+		items:         make(map[uint64][]*list.Element),
+		onEvict:       config.OnEvict,
+		sizeFn:        config.SizeFn,
+		updateInPlace: config.UpdateInPlace,
 	}
 	return c, nil
 }
@@ -106,13 +112,24 @@ func (c *LRU) Add(key, value interface{}) bool {
 	if !ok {
 		return false
 	}
-	// Remove any existing item.
-	if ent, ok := c.lookupItem(pk, ck); ok {
-		c.removeElement(ent)
-	}
 
-	// Add new item
-	c.addItem(pk, ck, value, c.sizeFn(value), true /*=front*/)
+	if ent, ok := c.lookupItem(pk, ck); ok {
+		if c.updateInPlace {
+			// Replace the existing item, moving it to the front.
+			oldSize := c.sizeFn(ent.Value.(*Entry).value)
+			newSize := c.sizeFn(value)
+			c.currentSize += (newSize - oldSize)
+			c.evictList.MoveToFront(ent)
+			ent.Value.(*Entry).value = value
+		} else {
+			// Remove the existing item and re-insert
+			c.removeElement(ent)
+			c.addItem(pk, ck, value, c.sizeFn(value), true /*=front*/)
+		}
+	} else {
+		// Add new item
+		c.addItem(pk, ck, value, c.sizeFn(value), true /*=front*/)
+	}
 
 	for c.currentSize > c.maxSize {
 		c.removeOldest()
@@ -123,8 +140,6 @@ func (c *LRU) Add(key, value interface{}) bool {
 // PushBack adds a value to the back of the cache, but only if there is
 // sufficient capacity.
 //
-// If the item already exists, it is first removed.
-//
 // This is useful for populating the cache initially, by iterating over existing
 // items in MRU to LRU order and repeatedly calling PushBack on each item.
 //
@@ -134,12 +149,23 @@ func (c *LRU) PushBack(key, value interface{}) bool {
 	if !ok {
 		return false
 	}
-	// Remove any existing item.
+
+	size := c.sizeFn(value)
 	if ent, ok := c.lookupItem(pk, ck); ok {
+		// Update or replace the existing item if there is capacity.
+		sizeDelta := size - c.sizeFn(ent.Value.(*Entry).value)
+		if c.currentSize+sizeDelta > c.maxSize {
+			return false
+		}
+		if c.updateInPlace {
+			ent.Value.(*Entry).value = value
+			c.currentSize += sizeDelta
+			return true
+		}
+		// Remove the existing item.
 		c.removeElement(ent)
 	}
 
-	size := c.sizeFn(value)
 	if c.currentSize+size > c.maxSize {
 		return false
 	}

--- a/server/util/lru/lru_test.go
+++ b/server/util/lru/lru_test.go
@@ -20,8 +20,13 @@ func TestAdd(t *testing.T) {
 	require.True(t, l.Add("a", 5))
 	require.True(t, l.Add("b", 4))
 	require.True(t, l.Add("c", 3))
-	require.Equal(t, 1, len(evictions))
-	require.Equal(t, 5, evictions[0])
+	require.Equal(t, []int{5}, evictions)
+
+	// Now overwrite "c" so that its new size exceeds the max cache size;
+	// should *remove* the existing "c" entry since it'll be overwritten, and
+	// then *evict* the "a" entry.
+	require.True(t, l.Add("c", 10))
+	require.Equal(t, []int{5, 3, 4}, evictions)
 }
 
 func TestPushBack(t *testing.T) {
@@ -38,4 +43,11 @@ func TestPushBack(t *testing.T) {
 	require.True(t, l.PushBack("b", 4))
 	require.False(t, l.PushBack("c", 3), "c should not be added since there isn't enough capacity")
 	require.Empty(t, evictions)
+
+	// Now attempt to overwrite "b" with a size that would exceed the cache
+	// capacity; this should fail.
+	require.False(t, l.PushBack("b", 10))
+	// Note: we technically didn't need to evict the old "b" in this case,
+	// but the current impl does so for simplicity.
+	require.Equal(t, []int{4}, evictions)
 }


### PR DESCRIPTION
Fixes a small bug that overwriting an LRU element with a larger size than the existing value's size can potentially cause the LRU to exceed its max size, and that overwriting an LRU element with a smaller size than the existing key can potentially cause the LRU to have wasted capacity (and in pathological cases, could also cause the LRU to have a negative size).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
