### PR TITLE
protobuf: patch link opts on macos

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -135,6 +135,8 @@ http_archive(
 
 http_archive(
     name = "com_google_protobuf",
+    patch_args = ["-p1"],
+    patches = ["//buildpatches:protobuf.patch"],
     sha256 = "2118051b4fb3814d59d258533a4e35452934b1ddb41230261c9543384cbb4dfc",
     strip_prefix = "protobuf-3.22.2",
     urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.22.2.tar.gz"],

--- a/buildpatches/protobuf.patch
+++ b/buildpatches/protobuf.patch
@@ -1,0 +1,16 @@
+--- a/build_defs/cpp_opts.bzl
++++ b/build_defs/cpp_opts.bzl
+@@ -36,6 +36,11 @@
+         # Suppress linker warnings about files with no symbols defined.
+         "-ignore:4221",
+     ],
++    "@platforms//os:macos": [
++        "-lpthread",
++        "-lm",
++        "-framework CoreFoundation",
++    ],
+     "//conditions:default": [
+         "-lpthread",
+         "-lm",
+exit 1
+


### PR DESCRIPTION
After recent protobuf upgrade, some team members have experienced the
mysterious error

```
Executing genrule @com_google_protobuf//src/google/protobuf:gen_wkt_cc_sources
...
dyld[97646]: symbol not found in flat namespace '_CFRelease'
```

This seems to be caused by
`com_google_protobuf/src/google/protobuf/compiler/protoc_nowkt`
was linked with missing symbols on MacOS.  Overriding the default link
opts to add `-framework CoreFoundation` fixes the issue.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
