### PR TITLE
Use a deterministic cache key for firecracker snapshots

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_darwin.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_darwin.go
@@ -65,12 +65,12 @@ func (c *FirecrackerContainer) Stats(ctx context.Context) (*repb.UsageStats, err
 func (c *FirecrackerContainer) SetTaskFileSystemLayout(fsLayout *container.FileSystemLayout) {
 }
 
-func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOverride string, instanceName string, snapshotDigest *repb.Digest) error {
+func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOverride string) error {
 	return status.UnimplementedError("Not yet implemented.")
 }
 
-func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context, instanceName string, d *repb.Digest, baseSnapshotDigest *repb.Digest) (*repb.Digest, error) {
-	return nil, status.UnimplementedError("Not yet implemented.")
+func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context) error {
+	return status.UnimplementedError("Not yet implemented.")
 }
 
 func (c *FirecrackerContainer) SendPrepareFileSystemRequestToGuest(ctx context.Context, req *vmfspb.PrepareRequest) (*vmfspb.PrepareResponse, error) {

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -25,7 +25,6 @@ go_test(
         "//server/environment",
         "//server/testutil/testenv",
         "//server/testutil/testfs",
-        "//server/util/hash",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/tools/vmstart/vmstart.go
+++ b/tools/vmstart/vmstart.go
@@ -132,12 +132,13 @@ func main() {
 
 	var c *firecracker.FirecrackerContainer
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
+	// TODO: make snapshotID work again.
 	if *snapshotID != "" {
 		c, err = firecracker.NewContainer(ctx, env, auth, opts)
 		if err != nil {
 			log.Fatalf("Error creating container: %s", err)
 		}
-		if err := c.LoadSnapshot(ctx, "" /*workspaceFS*/, *remoteInstanceName, parseSnapshotID(*snapshotID)); err != nil {
+		if err := c.LoadSnapshot(ctx, "" /*workspaceFS*/); err != nil {
 			log.Fatalf("Error loading snapshot: %s", err)
 		}
 	} else {
@@ -160,11 +161,10 @@ func main() {
 		for {
 			<-sigc
 			log.Errorf("Capturing snapshot...")
-			snapshotDigest, err := c.SaveSnapshot(ctx, *remoteInstanceName, nil, nil /*=baseSnapshotDigest*/)
-			if err != nil {
+			if err := c.SaveSnapshot(ctx); err != nil {
 				log.Fatalf("Error dumping snapshot: %s", err)
 			}
-			log.Printf("Created snapshot with ID %s/%d", snapshotDigest.GetHash(), snapshotDigest.GetSizeBytes())
+			log.Printf("Saved snapshot")
 		}
 	}()
 


### PR DESCRIPTION
Instead of making the snapshot digest optional (`opts.ForceSnapshotDigest`) and/or stateful (`c.pausedSnapshotDigest`), always use a non-nil digest that is deterministically computed from the VM configuration hash (and runner ID, for now[^1]).

This allows us to simplify the logic around saving/loading snapshots, while also resolving one of the blockers for snapshot sharing, since snapshot sharing will require computing a deterministic snapshot digest based solely on the VM configuration required by the task, and then checking the cache (local and/or remote) to see whether a matching snapshot is available.

[^1]: In the future, we'll remove runner ID to enable snapshot sharing - but we are blocked on having a way to ensure that runners can't concurrently access the same snapshot