### PR TITLE
A few more small heatmap bug fixes

### DIFF
--- a/enterprise/app/trends/drilldown_page.tsx
+++ b/enterprise/app/trends/drilldown_page.tsx
@@ -506,6 +506,7 @@ export default class DrilldownPageComponent extends React.Component<Props, State
   handleClearZoom() {
     router.setQuery({
       ...Object.fromEntries(this.props.search.entries()),
+      [DD_SELECTED_AREA_URL_PARAM]: "",
       [DD_ZOOM_URL_PARAM]: "",
     });
   }
@@ -529,29 +530,38 @@ export default class DrilldownPageComponent extends React.Component<Props, State
     );
   }
 
+  navigateForBarClick(paramName: string, paramValue: string) {
+    router.setQuery({
+      ...Object.fromEntries(this.props.search.entries()),
+      [paramName]: paramValue,
+      [DD_SELECTED_AREA_URL_PARAM]: "",
+      [DD_ZOOM_URL_PARAM]: "",
+    });
+  }
+
   handleBarClick(d: stats.DrilldownType, e?: CategoricalChartState) {
     if (!e || !e.activeLabel) {
       return;
     }
     switch (d) {
       case stats.DrilldownType.USER_DRILLDOWN_TYPE:
-        router.setQueryParam("user", e.activeLabel);
+        this.navigateForBarClick("user", e.activeLabel);
         return;
       case stats.DrilldownType.HOSTNAME_DRILLDOWN_TYPE:
-        router.setQueryParam("host", e.activeLabel);
+        this.navigateForBarClick("host", e.activeLabel);
         return;
       case stats.DrilldownType.REPO_URL_DRILLDOWN_TYPE:
-        router.setQueryParam("repo", e.activeLabel);
+        this.navigateForBarClick("repo", e.activeLabel);
         return;
       case stats.DrilldownType.COMMIT_SHA_DRILLDOWN_TYPE:
-        router.setQueryParam("commit", e.activeLabel);
+        this.navigateForBarClick("commit", e.activeLabel);
         return;
       case stats.DrilldownType.BRANCH_DRILLDOWN_TYPE:
-        router.setQueryParam("branch", e.activeLabel);
+        this.navigateForBarClick("branch", e.activeLabel);
         return;
       case stats.DrilldownType.PATTERN_DRILLDOWN_TYPE:
         if (capabilities.config.patternFilterEnabled) {
-          router.setQueryParam("pattern", e.activeLabel);
+          this.navigateForBarClick("pattern", e.activeLabel);
         }
         return;
       case stats.DrilldownType.GROUP_ID_DRILLDOWN_TYPE:

--- a/enterprise/app/trends/drilldown_page.tsx
+++ b/enterprise/app/trends/drilldown_page.tsx
@@ -537,6 +537,7 @@ export default class DrilldownPageComponent extends React.Component<Props, State
       [DD_SELECTED_AREA_URL_PARAM]: "",
       [DD_ZOOM_URL_PARAM]: "",
     });
+    window.scrollTo({ top: 0 });
   }
 
   handleBarClick(d: stats.DrilldownType, e?: CategoricalChartState) {

--- a/enterprise/app/trends/heatmap.tsx
+++ b/enterprise/app/trends/heatmap.tsx
@@ -318,8 +318,10 @@ class HeatmapComponentInternal extends React.Component<HeatmapProps, State> {
     if (!this.pendingClick) {
       return;
     }
-    const data = this.computeBucket(e.clientX, e.clientY);
 
+    const data = this.computeBucket(e.clientX, e.clientY);
+    // If the user has dragged the mouse of the heatmap or only clicked one
+    // cell, then we just use the already-pending click.
     if (!data || (this.pendingClick[0].metric == data.metric && this.pendingClick[0].timestamp == data.timestamp)) {
       const selectedData = this.pendingClick;
       this.pendingClick = undefined;

--- a/enterprise/app/trends/heatmap.tsx
+++ b/enterprise/app/trends/heatmap.tsx
@@ -319,13 +319,8 @@ class HeatmapComponentInternal extends React.Component<HeatmapProps, State> {
       return;
     }
     const data = this.computeBucket(e.clientX, e.clientY);
-    if (!data) {
-      this.pendingClick = undefined;
-      this.setState({ selectionToRender: undefined });
-      return;
-    }
 
-    if (this.pendingClick[0].metric == data.metric && this.pendingClick[0].timestamp == data.timestamp) {
+    if (!data || (this.pendingClick[0].metric == data.metric && this.pendingClick[0].timestamp == data.timestamp)) {
       const selectedData = this.pendingClick;
       this.pendingClick = undefined;
       this.maybeFireSelectionCallback(selectedData);


### PR DESCRIPTION
- Use last-hovered selection if the user drags their mouse outside of the heatmap area--this seems less surprising than just dropping the selection attempt (Maggie and Brandon both had feedback to this effect).
- Clear selection when the user clicks on a drilldown bar (otherwise, the user keeps seeing a list of invocations and bar charts even though the new heatmap doesn't show a selection).
- Clear the active selection when zoom is cleared.
- Scroll to top when a bar is selected for filtering.
---

**Version bump**: Patch
