### PR TITLE
Simplify snapshot manifest file IO

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -501,7 +501,7 @@ func mergeDiffSnapshot(ctx context.Context, baseSnapshotPath string, diffSnapsho
 }
 
 func (c *FirecrackerContainer) unpackBaseSnapshot(ctx context.Context) (string, error) {
-	loader, err := snaploader.New(c.env, c.jailerRoot)
+	loader, err := snaploader.New(c.env)
 	if err != nil {
 		return "", err
 	}
@@ -606,7 +606,7 @@ func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context) error {
 	}
 
 	snaploaderStart := time.Now()
-	loader, err := snaploader.New(c.env, c.jailerRoot)
+	loader, err := snaploader.New(c.env)
 	if err != nil {
 		return err
 	}
@@ -689,7 +689,7 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context, workspaceDirOve
 		ForwardSignals: make([]os.Signal, 0),
 	}
 
-	loader, err := snaploader.New(c.env, c.jailerRoot)
+	loader, err := snaploader.New(c.env)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["snaploader.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaploader",
     deps = [
+        "//enterprise/server/util/filecacheutil",
         "//proto:remote_execution_go_proto",
         "//server/environment",
         "//server/remote_cache/digest",

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -33,14 +33,14 @@ func TestPackAndUnpack(t *testing.T) {
 	// and add them to the cache. Note, the snapshot digests don't actually
 	// correspond to any real content; they just need to be unique cache
 	// keys.
-	la, err := snaploader.New(env, workDir)
+	la, err := snaploader.New(env)
 	require.NoError(t, err)
 	da := snaploader.NewKey("vm-config-hash-A", "runner-A")
 	sa := makeFakeSnapshot(t, workDir)
 	err = la.CacheSnapshot(ctx, da, sa)
 	require.NoError(t, err)
 
-	lb, err := snaploader.New(env, workDir)
+	lb, err := snaploader.New(env)
 	require.NoError(t, err)
 	db := snaploader.NewKey("vm-config-hash-B", "runner-B")
 	sb := makeFakeSnapshot(t, workDir)
@@ -57,7 +57,7 @@ func TestPackAndUnpack(t *testing.T) {
 		// Delete, since it's no longer needed.
 		// Note: we construct a new loader here to ensure the current
 		// snapshot manifest gets loaded.
-		loader, err := snaploader.New(env, workDir)
+		loader, err := snaploader.New(env)
 		require.NoError(t, err)
 		err = loader.DeleteSnapshot(ctx, da)
 		require.NoError(t, err)
@@ -92,7 +92,7 @@ func makeRandomFile(t *testing.T, rootDir, prefix string, size int) string {
 // Unpacks a snapshot to outDir and asserts that the contents match the
 // originally cached contents.
 func mustUnpack(t *testing.T, ctx context.Context, env environment.Env, d *repb.Digest, workDir, outDir string, originalSnapshot *snaploader.LoadSnapshotOptions) {
-	loader, err := snaploader.New(env, workDir)
+	loader, err := snaploader.New(env)
 	require.NoError(t, err)
 	err = loader.UnpackSnapshot(ctx, d, outDir)
 	require.NoError(t, err)

--- a/enterprise/server/util/filecacheutil/BUILD
+++ b/enterprise/server/util/filecacheutil/BUILD
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "filecacheutil",
+    srcs = ["filecacheutil.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/filecacheutil",
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/interfaces",
+        "//server/util/log",
+        "//server/util/random",
+        "//server/util/status",
+    ],
+)

--- a/enterprise/server/util/filecacheutil/filecacheutil.go
+++ b/enterprise/server/util/filecacheutil/filecacheutil.go
@@ -1,0 +1,62 @@
+package filecacheutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/random"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+// Read atomically reads a file from filecache.
+func Read(fc interfaces.FileCache, node *repb.FileNode) ([]byte, error) {
+	tmp, err := tempPath(fc, node.GetDigest().GetHash())
+	if err != nil {
+		return nil, err
+	}
+	if !fc.FastLinkFile(node, tmp) {
+		return nil, status.NotFoundErrorf("digest %s not found", node.GetDigest().GetHash())
+	}
+	defer func() {
+		if err := os.Remove(tmp); err != nil {
+			log.Warningf("Failed to remove filecache temp file: %s", err)
+		}
+	}()
+	return os.ReadFile(tmp)
+}
+
+// Write atomically writes the given bytes to filecache.
+func Write(fc interfaces.FileCache, node *repb.FileNode, b []byte) (n int, err error) {
+	tmp, err := tempPath(fc, node.GetDigest().GetHash())
+	if err != nil {
+		return 0, err
+	}
+	f, err := os.Create(tmp)
+	if err != nil {
+		return 0, status.InternalErrorf("filecache temp file creation failed: %s", err)
+	}
+	defer func() {
+		if err := os.Remove(tmp); err != nil {
+			log.Warningf("Failed to remove filecache temp file: %s", err)
+		}
+	}()
+	n, err = f.Write(b)
+	if err != nil {
+		return n, err
+	}
+	fc.AddFile(node, tmp)
+	return n, nil
+}
+
+func tempPath(fc interfaces.FileCache, name string) (string, error) {
+	randStr, err := random.RandomString(10)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(fc.TempDir(), fmt.Sprintf("%s.%s.tmp", name, randStr)), nil
+}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -575,6 +575,11 @@ type FileCache interface {
 	DeleteFile(f *repb.FileNode) bool
 	AddFile(f *repb.FileNode, existingFilePath string)
 	WaitForDirectoryScanToComplete()
+
+	// TempDir returns a directory that is guaranteed to be on the same device
+	// as the filecache. The directory is not unique per call. Callers should
+	// generate globally unique file names under this directory.
+	TempDir() string
 }
 
 type SchedulerService interface {


### PR DESCRIPTION
The snaploader accepts a workingDirectory param which it only uses to stage temporary files for copying to/from the filecache, and the loader impl has a decent amount of complexity around managing these temp files, which are only needed so that we can read/write bytes to/from the filecache.

This PR moves this complexity out of snaploader and into a new `filecacheutil` package, which should make the snaploader code a bit easier to work with.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
