### PR TITLE
testfs: avoid collisions in temp dirs/files

### DIFF
--- a/server/testutil/testfs/testfs.go
+++ b/server/testutil/testfs/testfs.go
@@ -24,7 +24,7 @@ func RunfilePath(t testing.TB, path string) string {
 // MakeTempDir creates and returns an empty directory that exists for the scope
 // of a test.
 func MakeTempDir(t testing.TB) string {
-	tmpDir, err := os.MkdirTemp(os.Getenv("TEST_TMPDIR"), "buildbuddy-test-*")
+	tmpDir, err := os.MkdirTemp(os.Getenv("TEST_TMPDIR"), "buildbuddy-test-*****")
 	if err != nil {
 		assert.FailNow(t, "failed to create temp dir", err)
 	}
@@ -45,7 +45,7 @@ func MakeDirAll(t testing.TB, rootDir, childPath string) string {
 }
 
 func MakeSocket(t testing.TB, socketName string) string {
-	socketDir, err := os.MkdirTemp("/tmp", "buildbuddy-test-*")
+	socketDir, err := os.MkdirTemp("/tmp", "buildbuddy-test-*****")
 	if err != nil {
 		assert.FailNow(t, "failed to create temp dir", err)
 	}
@@ -62,7 +62,7 @@ func MakeTempFile(t testing.TB, rootDir, pattern string) string {
 		rootDir = os.Getenv("TEST_TMPDIR")
 	}
 	if pattern == "" {
-		pattern = "buildbuddy-test-*"
+		pattern = "buildbuddy-test-*****"
 	}
 	tmpFile, err := os.CreateTemp(rootDir, pattern)
 	if err != nil {


### PR DESCRIPTION
In rare scenarios where the test execution is run locally on a weaker
sandbox environment (darwin), a single random digit temp file/dir could
cause collisions and led to 1 test deleting another test's files/dirs.

This causes flakiness in our tests when executing in Darwin, leading to
timeout in some scenarios. Example:

https://app.buildbuddy.io/invocation/cea0ac33-beca-4793-9588-87528336f277?target=%2F%2Fserver%2Fbackends%2Fdisk_cache%3Adisk_cache_test

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
