### PR TITLE
sluongng/redirect https port

### DIFF
--- a/server/http/interceptors/BUILD
+++ b/server/http/interceptors/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "interceptors",
@@ -17,5 +17,15 @@ go_library(
         "//server/util/uuid",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_protobuf//proto",
+    ],
+)
+
+go_test(
+    name = "interceptors_test",
+    srcs = ["interceptors_test.go"],
+    embed = [":interceptors"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -43,7 +43,7 @@ func SetSecurityHeaders(next http.Handler) http.Handler {
 	})
 }
 
-func RedirectIfNotForwardedHTTPS(env environment.Env, next http.Handler) http.Handler {
+func RedirectIfNotForwardedHTTPS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		protocol := r.Header.Get("X-Forwarded-Proto") // Set by load balancer
 		// Our k8s healthchecks set "server-type" header, but Google LB healthchecks don't support them so we check the UA.

--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -43,13 +43,13 @@ func SetSecurityHeaders(next http.Handler) http.Handler {
 	})
 }
 
-func RedirectIfNotForwardedHTTPS(next http.Handler) http.Handler {
+func RedirectIfNotForwardedHTTPS(next http.Handler, sslServerAddr string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		protocol := r.Header.Get("X-Forwarded-Proto") // Set by load balancer
 		// Our k8s healthchecks set "server-type" header, but Google LB healthchecks don't support them so we check the UA.
 		isHealthCheck := r.Header.Get("server-type") != "" || strings.HasPrefix(r.Header.Get("User-Agent"), "GoogleHC/")
 		if *upgradeInsecure && !isHealthCheck && protocol != "https" {
-			http.Redirect(w, r, "https://"+r.Host+r.URL.String(), http.StatusMovedPermanently)
+			http.Redirect(w, r, "https://"+sslServerAddr+r.URL.String(), http.StatusMovedPermanently)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/server/http/interceptors/interceptors_test.go
+++ b/server/http/interceptors/interceptors_test.go
@@ -75,7 +75,7 @@ func TestRedirectIfNotForwardedHTTPS(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			RedirectIfNotForwardedHTTPS(nil, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			RedirectIfNotForwardedHTTPS(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprint(w, r.Header)
 			})).ServeHTTP(rr, req)
 

--- a/server/http/interceptors/interceptors_test.go
+++ b/server/http/interceptors/interceptors_test.go
@@ -1,0 +1,89 @@
+package interceptors
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedirectIfNotForwardedHTTPS(t *testing.T) {
+	originalVal := *upgradeInsecure
+	t.Cleanup(func() {
+		*upgradeInsecure = originalVal
+	})
+	*upgradeInsecure = true
+
+	tests := []struct {
+		name            string
+		route           string
+		expectedCode    int
+		expectedHeaders http.Header
+		setup           func(*http.Request)
+	}{
+		{
+			"https request",
+			"/foo",
+			http.StatusOK,
+			http.Header{},
+			func(req *http.Request) {
+				req.Header.Set("X-Forwarded-Proto", "https")
+			},
+		},
+		{
+			"http request with X-Forwarded-Proto header",
+			"/foo",
+			http.StatusMovedPermanently,
+			http.Header{
+				"Location": []string{"https://example.com/foo"},
+			},
+			func(req *http.Request) {
+				req.Header.Set("X-Forwarded-Proto", "http")
+			},
+		},
+		{
+			"http request without X-Forwarded-Proto header",
+			"/foo",
+			http.StatusMovedPermanently,
+			http.Header{
+				"Location": []string{"https://example.com/foo"},
+			},
+			func(req *http.Request) {
+				req.Header.Del("X-Forwarded-Proto")
+			},
+		},
+		{
+			"healthcheck request without X-Forwarded-Proto header",
+			"/health",
+			http.StatusOK,
+			http.Header{},
+			func(req *http.Request) {
+				req.Header.Del("X-Forwarded-Proto")
+				req.Header.Set("User-Agent", "GoogleHC/1.0")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.route, nil)
+			if tt.setup != nil {
+				tt.setup(req)
+			}
+
+			rr := httptest.NewRecorder()
+			RedirectIfNotForwardedHTTPS(nil, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, r.Header)
+			})).ServeHTTP(rr, req)
+
+			require.Equal(t, tt.expectedCode, rr.Code)
+
+			for headerName, expectedValues := range tt.expectedHeaders {
+				assert.Equal(t, expectedValues, rr.Header().Values(headerName))
+			}
+		})
+	}
+}

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -434,7 +434,7 @@ func StartAndRunServices(env environment.Env) {
 			sslServer.ListenAndServeTLS("", "")
 		}()
 		go func() {
-			http.ListenAndServe(fmt.Sprintf("%s:%d", *listen, *port), interceptors.RedirectIfNotForwardedHTTPS(env, sslHandler))
+			http.ListenAndServe(fmt.Sprintf("%s:%d", *listen, *port), interceptors.RedirectIfNotForwardedHTTPS(sslHandler))
 		}()
 	} else {
 		// If no SSL is enabled, we'll just serve things as-is.

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -434,7 +434,10 @@ func StartAndRunServices(env environment.Env) {
 			sslServer.ListenAndServeTLS("", "")
 		}()
 		go func() {
-			http.ListenAndServe(fmt.Sprintf("%s:%d", *listen, *port), interceptors.RedirectIfNotForwardedHTTPS(sslHandler))
+			http.ListenAndServe(
+				fmt.Sprintf("%s:%d", *listen, *port),
+				interceptors.RedirectIfNotForwardedHTTPS(sslHandler, sslServer.Addr),
+			)
 		}()
 	} else {
 		// If no SSL is enabled, we'll just serve things as-is.


### PR DESCRIPTION
When we redirect http traffic to https, make sure that we use the configured ssl server's address and port
instead of the original request's host.

Refactor RedirectIfNotForwardedHTTPS to do the following:

1. Added a basic unit test to verify current behavior.

2. Remove env parameter, which is no longer needed since a637a0cad803d6f6159496c77f21496875e15eef.

3. Pass sslServer.Addr from libmain down to the interceptor and use it as the redirected host.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->

Fixes #3653