### PR TITLE
Ignore directory_output in TargetComplete events

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -607,9 +607,6 @@ export default class InvocationModel {
     if (!event?.completed) {
       return [];
     }
-    if (event.completed.directoryOutput?.length) {
-      return event.completed.directoryOutput || [];
-    }
     return (
       event.completed.outputGroup
         ?.flatMap((group) => group.fileSets)


### PR DESCRIPTION
These artifacts aren't very useful since according to the BES proto, they will never have a URI set, and also the current logic is preventing `output_group` files from being visible when `directory_output` is present.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
