### PR TITLE
Pin CLI Ubuntu release image to ubuntu-20.04

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, 'release skip')"
     outputs:
       version: ${{ steps.version.outputs.VERSION }}
@@ -52,7 +52,7 @@ jobs:
             --repo=buildbuddy-io/bazel --title="$TAG" --draft --notes="Release version $TAG"
 
   sync-plugins:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: create-release
     steps:
       - name: Checkout buildbuddy-io/buildbuddy
@@ -114,7 +114,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             shell: bash
           - os: macos-11
             shell: bash


### PR DESCRIPTION
The upgrade from 22.04.1 -> 22.04.2 results in the errors

```
bb: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by bb)
bb: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by bb)
```

Pin to 20.04 to be consistent with the app release.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
