### PR TITLE
Silence gorm logging during print schema script or output will interfere

### DIFF
--- a/server/util/clickhouse/BUILD
+++ b/server/util/clickhouse/BUILD
@@ -22,5 +22,6 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus",
         "@io_gorm_driver_clickhouse//:clickhouse",
         "@io_gorm_gorm//:gorm",
+        "@io_gorm_gorm//logger",
     ],
 )

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -22,6 +22,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/prometheus/client_golang/prometheus"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 
 	clickhouse "github.com/ClickHouse/clickhouse-go/v2"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -269,6 +270,7 @@ func Register(env environment.Env) error {
 	if *autoMigrateDB || *printSchemaChangesAndExit {
 		sqlStrings := make([]string, 0)
 		if *printSchemaChangesAndExit {
+			db.Logger = logger.Default.LogMode(logger.Silent)
 			if err := gormutil.RegisterLogSQLCallback(db, &sqlStrings); err != nil {
 				return err
 			}

--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -654,6 +654,7 @@ func GetConfiguredDatabase(env environment.Env) (interfaces.DBHandle, error) {
 	if *autoMigrateDB || *autoMigrateDBAndExit || *printSchemaChangesAndExit {
 		sqlStrings := make([]string, 0)
 		if *printSchemaChangesAndExit {
+			primaryDB.Logger = logger.Default.LogMode(logger.Silent)
 			if err := gormutil.RegisterLogSQLCallback(primaryDB, &sqlStrings); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
If there is a slow query that takes > 200ms, GORM will print that to stdout by default. The schema diff script assumes that we are only logging to stdout if there is a schema change, so we want to silence any other output while it's running.