### PR TITLE
Fix remote ActionResult fetches in the invocation action page

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -180,7 +180,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
       const option = this.props.model.optionsMap.get(optionName);
       if (!option) continue;
 
-      address = address.replace("grpc://", "").replace("grpcs://", "");
+      address = option.replace("grpc://", "").replace("grpcs://", "");
       break;
     }
     if (this.props.model.optionsMap.get("remote_instance_name")) {


### PR DESCRIPTION
Fixes a regression in the change here: https://github.com/buildbuddy-io/buildbuddy/pull/3299/files#diff-01b2f827d97e58166368c89e6233cb1f240a2b9964f79c1a676a5e6786122b30R177-R184

That change caused us to stop passing the gRPC target in the bytestream URL, but the target is required in some cases (e.g. for europe.remote.buildbuddy.io)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
