### PR TITLE
Refactor KMS manager to support serving keys from local files.

### DIFF
--- a/enterprise/server/backends/kms/BUILD
+++ b/enterprise/server/backends/kms/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//server/util/status",
         "@com_github_google_tink_go//core/registry",
         "@com_github_google_tink_go//integration/gcpkms",
+        "@com_github_google_tink_go//tink",
         "@org_golang_google_api//option",
     ],
 )

--- a/enterprise/server/backends/kms/kms.go
+++ b/enterprise/server/backends/kms/kms.go
@@ -2,7 +2,12 @@ package kms
 
 import (
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"flag"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -11,29 +16,37 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/google/tink/go/core/registry"
 	"github.com/google/tink/go/integration/gcpkms"
+	"github.com/google/tink/go/tink"
 	"google.golang.org/api/option"
 )
 
+const (
+	gcpKMSPrefix           = "gcp-kms://"
+	localInsecureKMSPrefix = "local-insecure-kms://"
+)
+
 var (
-	masterKeyURI       = flag.String("keystore.master_key_uri", "", "The master key URI (see tink docs for example)")
-	gcpCredentialsFile = flag.String("keystore.gcp.credentials_file", "", "A path to a gcp JSON credentials file that will be used to authenticate.")
+	masterKeyURI              = flag.String("keystore.master_key_uri", "", "The master key URI (see tink docs for example)")
+	gcpCredentialsFile        = flag.String("keystore.gcp.credentials_file", "", "A path to a gcp JSON credentials file that will be used to authenticate.")
+	localInsecureKMSDirectory = flag.String("keystore.local_insecure_kms_directory", "", "For development only. If set, keys in format local-insecure-kms://[id] are read from this directory.")
 )
 
 type KMS struct {
-	client registry.KMSClient
+	gcpClient              registry.KMSClient
+	localInsecureKMSClient registry.KMSClient
 }
 
 func New(ctx context.Context) (*KMS, error) {
 	kms := &KMS{}
-	var err error
-	switch {
-	case strings.HasPrefix(*masterKeyURI, "gcp-kms://"):
-		err = kms.initGCPClient(ctx)
-	case strings.HasPrefix(*masterKeyURI, "aws-kms://"):
-		err = status.UnimplementedError("AWS KMS not yet implemented")
-	}
-	if err != nil {
+	if err := kms.initGCPClient(ctx); err != nil {
 		return nil, err
+	}
+	if err := kms.initLocalInsecureKMSClient(ctx); err != nil {
+		return nil, err
+	}
+	_, err := kms.clientForURI(*masterKeyURI)
+	if err != nil {
+		return nil, status.InvalidArgumentErrorf("master key URI not supported")
 	}
 	return kms, nil
 }
@@ -56,15 +69,93 @@ func (k *KMS) initGCPClient(ctx context.Context) error {
 		log.Debugf("KMS: using credentials file: %q", *gcpCredentialsFile)
 		opts = append(opts, option.WithCredentialsFile(*gcpCredentialsFile))
 	}
-	client, err := gcpkms.NewClientWithOptions(ctx, *masterKeyURI, opts...)
+	client, err := gcpkms.NewClientWithOptions(ctx, gcpKMSPrefix, opts...)
 	if err != nil {
 		return err
 	}
-	registry.RegisterKMSClient(client)
-	k.client = client
+	k.gcpClient = client
 	return nil
 }
 
+func (k *KMS) initLocalInsecureKMSClient(ctx context.Context) error {
+	if *localInsecureKMSDirectory == "" {
+		return nil
+	}
+	client := &LocalInsecureKMS{root: *localInsecureKMSDirectory}
+	k.localInsecureKMSClient = client
+	return nil
+}
+
+func (k *KMS) clientForURI(uri string) (registry.KMSClient, error) {
+	if strings.HasPrefix(uri, gcpKMSPrefix) {
+		return k.gcpClient, nil
+	} else if strings.HasPrefix(uri, localInsecureKMSPrefix) && k.localInsecureKMSClient != nil {
+		return k.localInsecureKMSClient, nil
+	}
+	log.Warningf("no matching client for URI %q", uri)
+	return nil, status.InvalidArgumentError("no matching client for key URI")
+}
+
 func (k *KMS) FetchMasterKey() (interfaces.AEAD, error) {
-	return k.client.GetAEAD(*masterKeyURI)
+	return k.FetchKey(*masterKeyURI)
+}
+
+func (k *KMS) FetchKey(uri string) (interfaces.AEAD, error) {
+	c, err := k.clientForURI(uri)
+	if err != nil {
+		return nil, status.NotFoundErrorf("no handler available for KMS URI")
+	}
+	return c.GetAEAD(uri)
+}
+
+type gcmAESAEAD struct {
+	ciph cipher.AEAD
+}
+
+func (g *gcmAESAEAD) Encrypt(plaintext, associatedData []byte) ([]byte, error) {
+	nonce := make([]byte, g.ciph.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	out := g.ciph.Seal(nil, nonce, plaintext, associatedData)
+	return append(nonce, out...), nil
+}
+
+func (g *gcmAESAEAD) Decrypt(ciphertext, associatedData []byte) ([]byte, error) {
+	if len(ciphertext) < g.ciph.NonceSize() {
+		return nil, status.InvalidArgumentErrorf("input ciphertext too short")
+	}
+	nonce := ciphertext[:g.ciph.NonceSize()]
+	return g.ciph.Open(nil, nonce, ciphertext[g.ciph.NonceSize():], associatedData)
+}
+
+// LocalInsecureKMS is a KMS client that reads unencrypted keys from a local
+// directory.
+// Useful for testing encryption related functionality w/o depending on a real
+// KMS. Not suitable for production use.
+type LocalInsecureKMS struct {
+	root string
+}
+
+func (l *LocalInsecureKMS) Supported(keyURI string) bool {
+	return strings.HasPrefix(keyURI, localInsecureKMSPrefix)
+}
+
+func (l *LocalInsecureKMS) GetAEAD(keyURI string) (tink.AEAD, error) {
+	id := strings.TrimPrefix(keyURI, localInsecureKMSPrefix)
+	path := filepath.Join(l.root, id)
+	key, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	bc, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	g, err := cipher.NewGCM(bc)
+	if err != nil {
+		return nil, err
+	}
+	return &gcmAESAEAD{g}, nil
 }

--- a/enterprise/server/util/keystore/BUILD
+++ b/enterprise/server/util/keystore/BUILD
@@ -18,8 +18,10 @@ go_test(
     srcs = ["keystore_test.go"],
     deps = [
         ":keystore",
-        "//server/interfaces",
+        "//enterprise/server/backends/kms",
         "//server/testutil/testenv",
+        "//server/testutil/testfs",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1010,6 +1010,7 @@ type AEAD interface {
 // data.
 type KMS interface {
 	FetchMasterKey() (AEAD, error)
+	FetchKey(uri string) (AEAD, error)
 }
 
 // SecretService manages secrets for an org.


### PR DESCRIPTION
This makes it possible to test KMS-dependent functionality locally without depending on an external KMS.

The KMS interface gains a new FetchKey method to support fetching arbitrary keys necessary to support customer managed keys.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
