### PR TITLE
tools/rbeperf: move under //enterprise/tools

### DIFF
--- a/enterprise/server/test/integration/remote_execution/rbeclient/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/BUILD
@@ -1,11 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-# TODO(sluongng): ensure all //enterprise code are not dependency of FOSS code
-# gazelle:default_visibility //enterprise:__subpackages__,//tools/rbeperf:__pkg__
-package(default_visibility = [
-    "//enterprise:__subpackages__",
-    "//tools/rbeperf:__pkg__",
-])
+package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(
     name = "rbeclient",

--- a/enterprise/tools/rbeperf/BUILD
+++ b/enterprise/tools/rbeperf/BUILD
@@ -2,10 +2,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "rbeperf_lib",
     srcs = ["rbeperf.go"],
-    importpath = "github.com/buildbuddy-io/buildbuddy/tools/rbeperf",
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/tools/rbeperf",
     visibility = ["//visibility:private"],
     deps = [
         "//enterprise/server/test/integration/remote_execution/rbeclient",

--- a/enterprise/tools/rbeperf/rbeperf.go
+++ b/enterprise/tools/rbeperf/rbeperf.go
@@ -2,7 +2,7 @@
 //
 // Example usage:
 //
-//	$ blaze run //tools/rbeperf -- \
+//	$ blaze run //enterprise/tools/rbeperf -- \
 //	  --server=grpcs://remote.buildbuddy.dev \
 //	  --api_key=XXX \
 //	  --workload basic_sequential


### PR DESCRIPTION
This represent an alternative approach to #3671

RBE is an enterprise-only feature of BuildBuddy. Our bench test tool
rbeperf has dependencies on //enterprise source code and therefore,
could not be built from FOSS version of the repo.

Because our internal repo reference this tool, there will be a short
period of time where CI in our internal repo is broken. A separate PR
will be sent to update the references in our internal repo.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
