### PR TITLE
Fix spin loop in pebble atime update handling.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -757,15 +757,16 @@ func (p *PebbleCache) processAccessTimeUpdates(quitChan chan struct{}) error {
 			}
 		case <-quitChan:
 			// Drain any updates in the queue before exiting.
-			select {
-			case u := <-p.accesses:
-				if err := p.updateAtime(u.key); err != nil {
-					log.Warningf("Error updating atime: %s", err)
+			for {
+				select {
+				case u := <-p.accesses:
+					if err := p.updateAtime(u.key); err != nil {
+						log.Warningf("Error updating atime: %s", err)
+					}
+				default:
+					return nil
 				}
-			default:
-				break
 			}
-			return nil
 		}
 	}
 }

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -757,10 +757,13 @@ func (p *PebbleCache) processAccessTimeUpdates(quitChan chan struct{}) error {
 			}
 		case <-quitChan:
 			// Drain any updates in the queue before exiting.
-			for u := range p.accesses {
+			select {
+			case u := <-p.accesses:
 				if err := p.updateAtime(u.key); err != nil {
 					log.Warningf("Error updating atime: %s", err)
 				}
+			default:
+				break
 			}
 			return nil
 		}


### PR DESCRIPTION
Credit to Jim for flagging this. If the atime update channel was empty, we would spin loop on the default case and do nothing.

This changes the select to depend on `quitChan` directly. We used to need this indirection when we batched atime updates, but it's no longer necessary.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
