### PR TITLE
Add execution_metadata to ScoreCard

### DIFF
--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -206,6 +206,9 @@ message ScoreCard {
 
     // The type of cache relevant to this result.
     resource.CacheType cache_type = 14;
+
+    // The details of the execution that originally produced this result.
+    build.bazel.remote.execution.v2.ExecutedActionMetadata execution_metadata = 15;
   }
 
   // In the interest of saving space, we only show cache misses.

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -208,8 +208,11 @@ message ScoreCard {
     resource.CacheType cache_type = 14;
 
     // The details of the execution that originally produced this result.
-    build.bazel.remote.execution.v2.ExecutedActionMetadata execution_metadata =
-        15;
+
+    // When the worker started executing the action command.
+    google.protobuf.Timestamp execution_start_timestamp = 15;
+    // When the worker completed executing the action command.
+    google.protobuf.Timestamp execution_completed_timestamp = 16;
   }
 
   // In the interest of saving space, we only show cache misses.

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -208,7 +208,8 @@ message ScoreCard {
     resource.CacheType cache_type = 14;
 
     // The details of the execution that originally produced this result.
-    build.bazel.remote.execution.v2.ExecutedActionMetadata execution_metadata = 15;
+    build.bazel.remote.execution.v2.ExecutedActionMetadata execution_metadata =
+        15;
   }
 
   // In the interest of saving space, we only show cache misses.


### PR DESCRIPTION
Execution metadata from ActionCache contains the timestamps for the original execution in the cache. This data can help us calculate how much time it saved per action hit.  