### PR TITLE
Exit schema change script upon failure

### DIFF
--- a/tools/gorm/print_schema_changes.sh
+++ b/tools/gorm/print_schema_changes.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # This script can be used to determine whether there will be any gorm db schema changes from a git branch
 #


### PR DESCRIPTION
Otherwise if the build failed, the script would continue and it would seem like there were no schema changes.
