### PR TITLE
integration/remote_execution: fix darwin tests

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -27,7 +27,6 @@ actions:
         //...
         -//enterprise/server/test/integration/ci_runner:all
         -//enterprise/server/test/integration/workflow:all
-        -//enterprise/server/test/integration/remote_execution/...
   - name: Benchmark
     container_image: ubuntu-20.04
     triggers:

--- a/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
+++ b/enterprise/server/test/integration/remote_execution/bazel_rbe/bazel_rbe_test.go
@@ -5,6 +5,7 @@ package bazel_rbe_test
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
@@ -424,10 +425,16 @@ def _exec_impl(ctx):
 
 exec = rule(implementation = _exec_impl, attrs = {"command": attr.string()})
 `,
-		"BUILD": `
-load(":defs.bzl", "exec")
-exec(name = "exec", command = """` + shCommand + `""")
-`,
+		"BUILD": fmt.Sprintf(`load(":defs.bzl", "exec")
+
+exec(
+  name = "exec",
+  command = """%s""",
+  exec_properties = {
+    "OSFamily": "%s",
+    "Arch": "%s",
+  },
+)`, shCommand, runtime.GOOS, runtime.GOARCH),
 	})
 	// Execute just the test action remotely.
 	buildArgs := []string{


### PR DESCRIPTION
Fix a set of previously skipped tests because build actions were missing
platform properties to select the executor created and registered
locally.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
