### PR TITLE
Fix GitHub app install URL

### DIFF
--- a/enterprise/app/settings/github_link.tsx
+++ b/enterprise/app/settings/github_link.tsx
@@ -47,6 +47,7 @@ export default class GitHubLink extends React.Component<Props, State> {
       group_id: this.props.user.selectedGroup.id,
       user_id: this.props.user.displayUser.userId?.id || "",
       redirect_url: window.location.href,
+      install: "true",
     });
     return `/auth/github/app/link/?${params}`;
   }


### PR DESCRIPTION
Accidentally broke this while cleaning up the PR for review :sweat_smile: 

We need to set `install=true` in the URL because the same endpoint handles plain old OAuth linking (just linking a GH token to the User) as well as the combined OAuth+Install flow.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
