### PR TITLE
Implement GitHub app installation management

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1994,11 +1994,14 @@ code .comment {
 
 .loading {
   width: 100%;
-  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-grow: 1;
+}
+
+.loading:not(.loading-slim) {
+  height: 100%;
 }
 
 .loading:before {

--- a/enterprise/app/settings/BUILD
+++ b/enterprise/app/settings/BUILD
@@ -44,6 +44,7 @@ ts_library(
         "//app/components/button",
         "//app/components/button:link_button",
         "//app/components/dialog",
+        "//app/components/dialog:simple_modal_dialog",
         "//app/components/link",
         "//app/components/modal",
         "//app/components/spinner",

--- a/enterprise/app/settings/BUILD
+++ b/enterprise/app/settings/BUILD
@@ -84,6 +84,7 @@ ts_library(
 ts_library(
     name = "github_complete_installation",
     srcs = ["github_complete_installation.tsx"],
+    strict = True,
     deps = [
         "//app/alert:alert_service",
         "//app/auth:auth_service",

--- a/enterprise/app/settings/settings.css
+++ b/enterprise/app/settings/settings.css
@@ -95,6 +95,32 @@
   }
 }
 
+.settings .github-app-installations {
+  display: flex;
+  flex-direction: column;
+  border-radius: 8px;
+  border: 1px solid #eee;
+  margin-top: 16px;
+}
+
+.settings .github-app-installation {
+  padding: 16px;
+  box-sizing: border-box;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: space-between;
+}
+
+.settings .github-app-installation:not(:last-child) {
+  border-bottom: 1px solid #eee;
+}
+
+.settings .github-app-installation .installation-owner {
+  margin-right: auto;
+}
+
 /* Medium to small screen */
 @media (max-width: 1280px) {
   .settings .settings-layout {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -463,8 +463,7 @@ type WorkflowService interface {
 }
 
 type GitHubApp interface {
-	// TODO(bduffany): Add webhook handler, install handler, repo management
-	// API, installation management API.
+	// TODO(bduffany): Add webhook handler and repo management API
 
 	LinkGitHubAppInstallation(context.Context, *ghpb.LinkAppInstallationRequest) (*ghpb.LinkAppInstallationResponse, error)
 	GetGitHubAppInstallations(context.Context, *ghpb.GetAppInstallationsRequest) (*ghpb.GetAppInstallationsResponse, error)


### PR DESCRIPTION
- Shows all installations that your linked GitHub account has access to, as well as all installations linked to your org (even if your linked GitHub account doesn't have access to the installation)
  - If not yet linked to BB, show a "Link" button that calls LinkGitHubAppInstallation
  - If linked to BB (any org, even ones you aren't a member of), show an unlink button
    - If not linked to the currently selected org, show a warning

In a separate PR, I might add convenience links for managing each individual installation (via GitHub), but for now that can be done via the "Setup" button then selecting the installation (it's just an extra click)

https://user-images.githubusercontent.com/2414826/229212245-386b24e6-261d-4e99-bf47-89ad632c1272.mp4



---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
