### PR TITLE
cli/version: simplified w. embedsrcs

### DIFF
--- a/cli/version/BUILD
+++ b/cli/version/BUILD
@@ -1,5 +1,5 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("//rules/flags:index.bzl", "write_flag_to_file")
 
 string_flag(
@@ -7,30 +7,26 @@ string_flag(
     build_setting_default = "unknown",
 )
 
-# TODO(bduffany): This can be simplified a bit once go:embed supports
-# generated files: https://github.com/bazelbuild/rules_go/pull/3285
 write_flag_to_file(
-    name = "version_flag.go",
+    name = "version_flag.txt",
     flag = ":cli_version",
-    template = """package version
-
-var cliVersionFlag = "%s"
-""",
-)
-
-go_library(
-    name = "version_lib",
-    srcs = [":version_flag.go"],
-    importpath = "github.com/buildbuddy-io/buildbuddy/cli/version",
+    template = "%s",
 )
 
 go_library(
     name = "version",
-    srcs = ["version.go"],  # keep
-    embed = [":version_lib"],  # keep
+    srcs = ["version.go"],
+    embedsrcs = ["version_flag.txt"],  # keep
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/version",
     visibility = ["//visibility:public"],
+    deps = ["//cli/arg"],
+)
+
+go_test(
+    name = "version_test",
+    srcs = ["version_test.go"],
     deps = [
-        "//cli/arg",
+        ":version",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/cli/version/BUILD
+++ b/cli/version/BUILD
@@ -10,7 +10,6 @@ string_flag(
 write_flag_to_file(
     name = "version_flag.txt",
     flag = ":cli_version",
-    template = "%s",
 )
 
 go_library(

--- a/cli/version/version.go
+++ b/cli/version/version.go
@@ -1,10 +1,14 @@
 package version
 
 import (
+	_ "embed"
 	"fmt"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 )
+
+//go:embed version_flag.txt
+var cliVersionFlag string
 
 func HandleVersion(args []string) (exitCode int, err error) {
 	if arg.GetCommand(args) != "version" {

--- a/cli/version/version_test.go
+++ b/cli/version/version_test.go
@@ -1,0 +1,33 @@
+package version_test
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmbeddedVersion(t *testing.T) {
+	require.Contains(t, version.String(), "unknown")
+}
+
+func TestHandleVersion(t *testing.T) {
+	rescueStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	exitCode, err := version.HandleVersion([]string{"version", "--cli"})
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+
+	err = w.Close()
+	require.NoError(t, err)
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	os.Stdout = rescueStdout
+
+	require.Contains(t, string(out), "unknown")
+}


### PR DESCRIPTION
I was trying to figure out how we are installing bb CLI in Github Action lint check
when I stumbled upon this code.

Added a test for it as well.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
