### PR TITLE
Ignore bazel-buildbuddy/ and website/ in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "sourceMap": false,
     "isolatedModules": true,
     "downlevelIteration": true,
+    "skipLibCheck": true,
     "composite": true,
     "target": "ES2016",
     "baseUrl": ".",
@@ -23,5 +24,6 @@
       "bazel-out/darwin_arm64-opt/bin",
       "bazel-out/darwin_arm64-fastbuild/bin"
     ]
-  }
+  },
+  "exclude": ["bazel-buildbuddy", "website"]
 }


### PR DESCRIPTION
Provides a nice performance boost for TS analysis  (20s -> 6s to run `tsc` at the repo root).

Can profile the TS compiler with

```bash
# Clean up profiler garbage (isolate-XXX...) but keep tsbuildinfo around,
# to simulate a warm-ish build
git ls-files --others --exclude-standard | grep -v tsbuildinfo | xargs --no-run-if-empty rm
# Prepare a clean dir for profiler output
rm -rf /tmp/ts_trace/* && mkdir -p /tmp/ts_trace
# Profile
time node --trace-ic ./node_modules/typescript/lib/tsc.js --noEmit --generateTrace /tmp/ts_trace/ -p tsconfig.json
# Load /tmp/ts_trace/trace.json into chrome://tracing
```

Most of the remaining time is spent parsing protos. Our protos contain tons of duplicate code because each individual `ts_proto_library` bundles all of its transitive dependencies. This seems to be a limitation of protobufjs unless I'm missing some sort of config option that lets the codegen ignore missing transitive deps when compiling. We might want to consider consolidating all the protos into a single target (probably buildbuddy_service_ts_proto) and/or moving to a different codegen that supports incremental compilation.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
