### PR TITLE
Incorporate encryption support into pebble cache.

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -145,6 +145,7 @@ type Claims struct {
 	GroupMemberships       []*interfaces.GroupMembership `json:"group_memberships"`
 	Capabilities           []akpb.ApiKey_Capability      `json:"capabilities"`
 	UseGroupOwnedExecutors bool                          `json:"use_group_owned_executors,omitempty"`
+	CacheEncryptionEnabled bool                          `json:"cache_encryption_enabled,omitempty"`
 }
 
 func (c *Claims) GetUserID() string {
@@ -191,6 +192,10 @@ func (c *Claims) HasCapability(cap akpb.ApiKey_Capability) bool {
 
 func (c *Claims) GetUseGroupOwnedExecutors() bool {
 	return c.UseGroupOwnedExecutors
+}
+
+func (c *Claims) GetCacheEncryptionEnabled() bool {
+	return c.CacheEncryptionEnabled
 }
 
 func assembleJWT(ctx context.Context, claims *Claims) (string, error) {
@@ -735,6 +740,7 @@ func APIKeyGroupClaims(akg interfaces.APIKeyGroup) *Claims {
 		},
 		Capabilities:           capabilities.FromInt(akg.GetCapabilities()),
 		UseGroupOwnedExecutors: akg.GetUseGroupOwnedExecutors(),
+		CacheEncryptionEnabled: akg.GetCacheEncryptionEnabled(),
 	}
 }
 

--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -27,6 +27,7 @@ type apiKeyGroup struct {
 	GroupID                string
 	Capabilities           int32
 	UseGroupOwnedExecutors bool
+	CacheEncryptionEnabled bool
 }
 
 func (g *apiKeyGroup) GetUserID() string {
@@ -43,6 +44,10 @@ func (g *apiKeyGroup) GetCapabilities() int32 {
 
 func (g *apiKeyGroup) GetUseGroupOwnedExecutors() bool {
 	return g.UseGroupOwnedExecutors
+}
+
+func (g *apiKeyGroup) GetCacheEncryptionEnabled() bool {
+	return g.CacheEncryptionEnabled
 }
 
 func (d *AuthDB) InsertOrUpdateUserSession(ctx context.Context, sessionID string, session *tables.Session) error {
@@ -151,6 +156,7 @@ func (d *AuthDB) LookupUserFromSubID(ctx context.Context, subID string) (*tables
 				g.sharing_enabled,
 				g.user_owned_keys_enabled,
 				g.use_group_owned_executors,
+				g.cache_encryption_enabled,
 				g.saml_idp_metadata_url,
 				ug.role
 			FROM `+"`Groups`"+` AS g, UserGroups AS ug
@@ -175,6 +181,7 @@ func (d *AuthDB) LookupUserFromSubID(ctx context.Context, subID string) (*tables
 				&gr.Group.SharingEnabled,
 				&gr.Group.UserOwnedKeysEnabled,
 				&gr.Group.UseGroupOwnedExecutors,
+				&gr.Group.CacheEncryptionEnabled,
 				&gr.Group.SamlIdpMetadataUrl,
 				&gr.Role,
 			)
@@ -197,7 +204,8 @@ func (d *AuthDB) newAPIKeyGroupQuery(allowUserOwnedKeys bool) *query_builder.Que
 			ak.capabilities,
 			ak.user_id,
 			g.group_id,
-			g.use_group_owned_executors
+			g.use_group_owned_executors,
+			g.cache_encryption_enabled
 		FROM ` + "`Groups`" + ` AS g,
 		APIKeys AS ak
 	`)

--- a/enterprise/server/backends/pebble_cache/BUILD
+++ b/enterprise/server/backends/pebble_cache/BUILD
@@ -48,6 +48,8 @@ go_test(
     shard_count = 8,
     deps = [
         ":pebble_cache",
+        "//enterprise/server/backends/kms",
+        "//enterprise/server/crypter_service",
         "//enterprise/server/raft/keys",
         "//proto:raft_go_proto",
         "//proto:remote_execution_go_proto",
@@ -55,6 +57,7 @@ go_test(
         "//server/environment",
         "//server/interfaces",
         "//server/remote_cache/digest",
+        "//server/tables",
         "//server/testutil/testauth",
         "//server/testutil/testdigest",
         "//server/testutil/testenv",

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1159,6 +1159,34 @@ func (p *PebbleCache) lookupGroupAndPartitionID(ctx context.Context, remoteInsta
 	return groupID, DefaultPartitionID, nil
 }
 
+func (p *PebbleCache) encryptionEnabled(ctx context.Context, partitionID string) (bool, error) {
+	auth := p.env.GetAuthenticator()
+	if auth == nil {
+		return false, nil
+	}
+	u, err := auth.AuthenticatedUser(ctx)
+	if err != nil {
+		return false, nil
+	}
+	if !u.GetCacheEncryptionEnabled() {
+		return false, nil
+	}
+	if p.env.GetCrypter() == nil {
+		return false, status.FailedPreconditionError("encryption requested by crypter not available")
+	}
+
+	for _, p := range p.partitions {
+		if p.ID == partitionID {
+			if !p.EncryptionSupported {
+				return false, status.FailedPreconditionError("encryption enabled, but writing to a partition that doesn't support encryption")
+			}
+			return true, nil
+		}
+	}
+
+	return false, status.InvalidArgumentError("partition not found")
+}
+
 func (p *PebbleCache) makeFileRecord(ctx context.Context, r *rspb.ResourceName) (*rfpb.FileRecord, error) {
 	rn := digest.ResourceNameFromProto(r)
 	if err := rn.Validate(); err != nil {
@@ -1397,7 +1425,7 @@ func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceNa
 			continue
 		}
 
-		rc, err := p.readerForCompressionType(ctx, r, key, fileMetadata, 0, 0)
+		rc, err := p.reader(ctx, r, key, fileMetadata, 0, 0)
 		if err != nil {
 			if status.IsNotFoundError(err) || os.IsNotExist(err) {
 				unlockFn := p.locker.Lock(key.LockID())
@@ -1596,7 +1624,6 @@ func (p *PebbleCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompre
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("Attempting pebble reader %s", key.String())
 
 	// First, lookup the FileMetadata. If it's not found, we don't have the file.
 	unlockFn := p.locker.RLock(key.LockID())
@@ -1606,7 +1633,7 @@ func (p *PebbleCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompre
 		return nil, err
 	}
 
-	rc, err := p.readerForCompressionType(ctx, r, key, fileMetadata, uncompressedOffset, limit)
+	rc, err := p.reader(ctx, r, key, fileMetadata, uncompressedOffset, limit)
 	if err != nil {
 		if status.IsNotFoundError(err) || os.IsNotExist(err) {
 			unlockFn := p.locker.Lock(key.LockID())
@@ -1651,7 +1678,7 @@ func (dc *writeCloser) Write(p []byte) (int, error) {
 type zstdCompressor struct {
 	cacheName string
 
-	*ioutil.CustomCommitWriteCloser
+	interfaces.CommittedWriteCloser
 	compressBuf []byte
 	bufferPool  *bytebufferpool.Pool
 
@@ -1659,19 +1686,19 @@ type zstdCompressor struct {
 	numCompressedBytes   int
 }
 
-func NewZstdCompressor(cacheName string, wc *ioutil.CustomCommitWriteCloser, bp *bytebufferpool.Pool, digestSize int64) *zstdCompressor {
+func NewZstdCompressor(cacheName string, wc interfaces.CommittedWriteCloser, bp *bytebufferpool.Pool, digestSize int64) *zstdCompressor {
 	compressBuf := bp.Get(digestSize)
 	return &zstdCompressor{
-		cacheName:               cacheName,
-		CustomCommitWriteCloser: wc,
-		compressBuf:             compressBuf,
-		bufferPool:              bp,
+		cacheName:            cacheName,
+		CommittedWriteCloser: wc,
+		compressBuf:          compressBuf,
+		bufferPool:           bp,
 	}
 }
 
 func (z *zstdCompressor) Write(decompressedBytes []byte) (int, error) {
 	z.compressBuf = compression.CompressZstd(z.compressBuf, decompressedBytes)
-	compressedBytesWritten, err := z.CustomCommitWriteCloser.Write(z.compressBuf)
+	compressedBytesWritten, err := z.CommittedWriteCloser.Write(z.compressBuf)
 	if err != nil {
 		return 0, err
 	}
@@ -1690,7 +1717,7 @@ func (z *zstdCompressor) Close() error {
 		Observe(float64(z.numCompressedBytes) / float64(z.numDecompressedBytes))
 
 	z.bufferPool.Put(z.compressBuf)
-	return z.CustomCommitWriteCloser.Close()
+	return z.CommittedWriteCloser.Close()
 }
 
 func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {
@@ -1720,7 +1747,6 @@ func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfa
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("Attempting pebble writer %s", key.String())
 
 	var wcm interfaces.MetadataWriteCloser
 	if r.GetDigest().GetSizeBytes() < p.maxInlineFileSizeBytes {
@@ -1740,16 +1766,19 @@ func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfa
 	if err != nil {
 		return nil, err
 	}
-	wc := ioutil.NewCustomCommitWriteCloser(wcm)
-	wc.CloseFn = db.Close
-	wc.CommitFn = func(bytesWritten int64) error {
+
+	var encryptionMetadata *rfpb.EncryptionMetadata
+	cwc := ioutil.NewCustomCommitWriteCloser(wcm)
+	cwc.CloseFn = db.Close
+	cwc.CommitFn = func(bytesWritten int64) error {
 		now := time.Now().UnixMicro()
 		md := &rfpb.FileMetadata{
-			FileRecord:      fileRecord,
-			StorageMetadata: wcm.Metadata(),
-			StoredSizeBytes: bytesWritten,
-			LastAccessUsec:  now,
-			LastModifyUsec:  now,
+			FileRecord:         fileRecord,
+			StorageMetadata:    wcm.Metadata(),
+			EncryptionMetadata: encryptionMetadata,
+			StoredSizeBytes:    bytesWritten,
+			LastAccessUsec:     now,
+			LastModifyUsec:     now,
 		}
 		protoBytes, err := proto.Marshal(md)
 		if err != nil {
@@ -1785,6 +1814,22 @@ func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfa
 		}
 
 		return err
+	}
+
+	wc := interfaces.CommittedWriteCloser(cwc)
+	shouldEncrypt, err := p.encryptionEnabled(ctx, fileRecord.GetIsolation().GetPartitionId())
+	if err != nil {
+		_ = wc.Close()
+		return nil, err
+	}
+	if shouldEncrypt {
+		ewc, err := p.env.GetCrypter().NewEncryptor(ctx, r.GetDigest(), wc)
+		if err != nil {
+			_ = wc.Close()
+			return nil, err
+		}
+		encryptionMetadata = ewc.Metadata()
+		wc = ewc
 	}
 
 	if shouldCompress {
@@ -2409,30 +2454,61 @@ type readCloser struct {
 	io.Closer
 }
 
-func (p *PebbleCache) readerForCompressionType(ctx context.Context, resource *rspb.ResourceName, key filestore.PebbleKey, fileMetadata *rfpb.FileMetadata, uncompressedOffset int64, uncompressedLimit int64) (io.ReadCloser, error) {
+func (p *PebbleCache) reader(ctx context.Context, resource *rspb.ResourceName, key filestore.PebbleKey, fileMetadata *rfpb.FileMetadata, uncompressedOffset int64, uncompressedLimit int64) (io.ReadCloser, error) {
 	blobDir := p.blobDir()
 	requestedCompression := resource.GetCompressor()
 	cachedCompression := fileMetadata.GetFileRecord().GetCompressor()
+	if requestedCompression == cachedCompression &&
+		requestedCompression != repb.Compressor_IDENTITY &&
+		(uncompressedOffset != 0 || uncompressedLimit != 0) {
+		return nil, status.FailedPreconditionError("passthrough compression does not support offset/limit")
+	}
 
-	// If the data is stored uncompressed, we can use the offset/limit directly
-	// otherwise we need to decompress first.
+	shouldDecrypt, err := p.encryptionEnabled(ctx, fileMetadata.GetFileRecord().GetIsolation().GetPartitionId())
+	if err != nil {
+		return nil, err
+	}
+
+	// If the data is stored uncompressed/unencrypted, we can use the offset/limit directly
+	// otherwise we need to decompress/decrypt first.
 	offset := int64(0)
 	limit := int64(0)
-	if cachedCompression == repb.Compressor_IDENTITY {
+	rawStorage := cachedCompression == repb.Compressor_IDENTITY && !shouldDecrypt
+	if rawStorage {
 		offset = uncompressedOffset
 		limit = uncompressedLimit
 	}
+
 	reader, err := p.fileStorer.NewReader(ctx, blobDir, fileMetadata.GetStorageMetadata(), offset, limit)
 	if err != nil {
 		return nil, err
 	}
 	p.sendAtimeUpdate(key, fileMetadata)
 
-	if requestedCompression == cachedCompression {
-		if requestedCompression != repb.Compressor_IDENTITY && (uncompressedOffset != 0 || uncompressedLimit != 0) {
-			return nil, status.FailedPreconditionError("passthrough compression does not support offset/limit")
+	if !rawStorage {
+		if shouldDecrypt {
+			d, err := p.env.GetCrypter().NewDecryptor(ctx, resource.GetDigest(), reader, fileMetadata.GetEncryptionMetadata())
+			if err != nil {
+				return nil, err
+			}
+			reader = d
 		}
-		return reader, nil
+		if cachedCompression == repb.Compressor_ZSTD && requestedCompression == repb.Compressor_IDENTITY {
+			dr, err := compression.NewZstdDecompressingReader(reader)
+			if err != nil {
+				return nil, err
+			}
+			reader = dr
+		}
+		if uncompressedOffset != 0 {
+			if _, err := io.CopyN(io.Discard, reader, uncompressedOffset); err != nil {
+				_ = reader.Close()
+				return nil, err
+			}
+		}
+		if uncompressedLimit != 0 {
+			reader = &readCloser{io.LimitReader(reader, uncompressedLimit), reader}
+		}
 	}
 
 	if requestedCompression == repb.Compressor_ZSTD && cachedCompression == repb.Compressor_IDENTITY {
@@ -2457,26 +2533,9 @@ func (p *PebbleCache) readerForCompressionType(ctx context.Context, resource *rs
 			compressBuf: compressBuf,
 			bufferPool:  p.bufferPool,
 		}, err
-	} else if requestedCompression == repb.Compressor_IDENTITY && cachedCompression == repb.Compressor_ZSTD {
-		dr, err := compression.NewZstdDecompressingReader(reader)
-		if err != nil {
-			return nil, err
-		}
-		// If offset is set, we need to discard all the bytes before that point.
-		if uncompressedOffset != 0 {
-			if _, err := io.CopyN(io.Discard, dr, uncompressedOffset); err != nil {
-				_ = dr.Close()
-				return nil, err
-			}
-		}
-		if uncompressedLimit != 0 {
-			dr = &readCloser{io.LimitReader(dr, uncompressedLimit), dr}
-		}
-		return dr, nil
-	} else {
-		return nil, fmt.Errorf("unsupported compressor %v requested for %v reader, cached compression is %v",
-			requestedCompression, resource, cachedCompression)
 	}
+
+	return reader, nil
 }
 
 func (p *PebbleCache) Start() error {

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/kms"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/crypter_service"
+	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"hash/crc32"
 	"io"
 	"io/fs"
@@ -937,6 +940,28 @@ func TestSizeLimit(t *testing.T) {
 	require.LessOrEqual(t, dirSize, maxSizeBytes)
 }
 
+func writeResource(t *testing.T, ctx context.Context, pc *pebble_cache.PebbleCache, r *rspb.ResourceName, data []byte) {
+	// Write data to cache
+	wc, err := pc.Writer(ctx, r)
+	require.NoError(t, err)
+	n, err := wc.Write(data)
+	require.NoError(t, err)
+	require.Equal(t, len(data), n)
+	err = wc.Commit()
+	require.NoError(t, err)
+	err = wc.Close()
+	require.NoError(t, err)
+}
+
+func readResource(t *testing.T, ctx context.Context, pc *pebble_cache.PebbleCache, r *rspb.ResourceName, offset, limit int64) []byte {
+	reader, err := pc.Reader(ctx, r, offset, limit)
+	require.NoError(t, err)
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	return data
+}
+
 func TestCompression(t *testing.T) {
 	// Make blob big enough to require multiple chunks to compress
 	blob := compressibleBlobOfSize(pebble_cache.CompressorBufSizeBytes + 1)
@@ -985,7 +1010,7 @@ func TestCompression(t *testing.T) {
 		expectedUncompressedReadData []byte
 	}{
 		{
-			name:                         "Write compressed data, read compressed data",
+			name:                         "write_compressed_read_compressed",
 			rnToWrite:                    compressedRN,
 			dataToWrite:                  compressedBuf,
 			rnToRead:                     compressedRN,
@@ -993,14 +1018,14 @@ func TestCompression(t *testing.T) {
 			expectedUncompressedReadData: blob,
 		},
 		{
-			name:                         "Write compressed data, read decompressed data",
+			name:                         "write_compressed_read_decompressed",
 			rnToWrite:                    compressedRN,
 			dataToWrite:                  compressedBuf,
 			rnToRead:                     decompressedRN,
 			expectedUncompressedReadData: blob,
 		},
 		{
-			name:                         "Write decompressed data, read compressed data",
+			name:                         "write_uncompressed_read_compressed",
 			rnToWrite:                    decompressedRN,
 			dataToWrite:                  blob,
 			rnToRead:                     compressedRN,
@@ -1008,14 +1033,14 @@ func TestCompression(t *testing.T) {
 			expectedUncompressedReadData: blob,
 		},
 		{
-			name:                         "Write decompressed data, read decompressed data",
+			name:                         "write_uncompressed_read_decompressed",
 			rnToWrite:                    decompressedRN,
 			dataToWrite:                  blob,
 			rnToRead:                     decompressedRN,
 			expectedUncompressedReadData: blob,
 		},
 		{
-			name:                         "Write compressed inline data, read compressed data",
+			name:                         "inline_write_compressed_read_compressed",
 			rnToWrite:                    compressedInlineRN,
 			dataToWrite:                  compressedInlineBuf,
 			rnToRead:                     compressedInlineRN,
@@ -1023,14 +1048,14 @@ func TestCompression(t *testing.T) {
 			expectedUncompressedReadData: inlineBlob,
 		},
 		{
-			name:                         "Write compressed inline data, read decompressed data",
+			name:                         "inline_write_compressed_read_decompressed",
 			rnToWrite:                    compressedInlineRN,
 			dataToWrite:                  compressedInlineBuf,
 			rnToRead:                     decompressedInlineRN,
 			expectedUncompressedReadData: inlineBlob,
 		},
 		{
-			name:                         "Write decompressed inline data, read compressed data",
+			name:                         "inline_write_uncompressed_read_compressed",
 			rnToWrite:                    decompressedInlineRN,
 			dataToWrite:                  inlineBlob,
 			rnToRead:                     compressedInlineRN,
@@ -1038,7 +1063,7 @@ func TestCompression(t *testing.T) {
 			expectedUncompressedReadData: inlineBlob,
 		},
 		{
-			name:                         "Write decompressed inline data, read decompressed data",
+			name:                         "inline_write_uncompressed_read_decompressed",
 			rnToWrite:                    decompressedInlineRN,
 			dataToWrite:                  inlineBlob,
 			rnToRead:                     decompressedInlineRN,
@@ -1047,7 +1072,7 @@ func TestCompression(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		{
+		t.Run(tc.name, func(t *testing.T) {
 			te := testenv.GetTestEnv(t)
 			te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
 			ctx := getAnonContext(t, te)
@@ -1058,35 +1083,20 @@ func TestCompression(t *testing.T) {
 				MaxSizeBytes:  maxSizeBytes,
 			}
 			pc, err := pebble_cache.NewPebbleCache(te, opts)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			pc.Start()
 			defer pc.Stop()
 
-			// Write data to cache
-			wc, err := pc.Writer(ctx, tc.rnToWrite)
-			require.NoError(t, err, tc.name)
-			n, err := wc.Write(tc.dataToWrite)
-			require.NoError(t, err, tc.name)
-			require.Equal(t, len(tc.dataToWrite), n)
-			err = wc.Commit()
-			require.NoError(t, err, tc.name)
-			err = wc.Close()
-			require.NoError(t, err, tc.name)
+			writeResource(t, ctx, pc, tc.rnToWrite, tc.dataToWrite)
 
 			// Read data
-			reader, err := pc.Reader(ctx, tc.rnToRead, 0, 0)
-			require.NoError(t, err, tc.name)
-			defer reader.Close()
-			data, err := io.ReadAll(reader)
-			require.NoError(t, err, tc.name)
+			data := readResource(t, ctx, pc, tc.rnToRead, 0, 0)
 			if tc.isReadCompressed {
 				data, err = compression.DecompressZstd(nil, data)
-				require.NoError(t, err, tc.name)
+				require.NoError(t, err)
 			}
-			require.Equal(t, tc.expectedUncompressedReadData, data, tc.name)
-		}
+			require.Equal(t, tc.expectedUncompressedReadData, data)
+		})
 	}
 }
 
@@ -1861,6 +1871,283 @@ func TestMigrateVersions(t *testing.T) {
 			}
 		}
 	}
+}
+
+func generateKMSKey(t *testing.T, kmsDir string, id string) string {
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(kmsDir, id), key, 0644)
+	require.NoError(t, err)
+	return "local-insecure-kms://" + id
+}
+
+func createKey(t *testing.T, env environment.Env, keyID, groupID, groupKeyURI string) (*tables.EncryptionKey, *tables.EncryptionKeyVersion) {
+	kmsClient := env.GetKMS()
+
+	masterKeyPart := make([]byte, 32)
+	_, err := rand.Read(masterKeyPart)
+	require.NoError(t, err)
+	groupKeyPart := make([]byte, 32)
+	_, err = rand.Read(groupKeyPart)
+	require.NoError(t, err)
+
+	masterAEAD, err := kmsClient.FetchMasterKey()
+	require.NoError(t, err)
+	encMasterKeyPart, err := masterAEAD.Encrypt(masterKeyPart, nil)
+	require.NoError(t, err)
+
+	groupAEAD, err := kmsClient.FetchKey(groupKeyURI)
+	require.NoError(t, err)
+	encGroupKeyPart, err := groupAEAD.Encrypt(groupKeyPart, nil)
+
+	key := &tables.EncryptionKey{
+		EncryptionKeyID: keyID,
+		GroupID:         groupID,
+	}
+	keyVersion := &tables.EncryptionKeyVersion{
+		EncryptionKeyID:    keyID,
+		Version:            1,
+		MasterEncryptedKey: encMasterKeyPart,
+		GroupKeyURI:        groupKeyURI,
+		GroupEncryptedKey:  encGroupKeyPart,
+	}
+	return key, keyVersion
+}
+
+func getCrypterEnv(t *testing.T) (*testenv.TestEnv, string) {
+	rand.Seed(time.Now().UnixMicro())
+
+	kmsDir := testfs.MakeTempDir(t)
+	masterKeyURI := generateKMSKey(t, kmsDir, "masterKey")
+
+	flags.Set(t, "database.enable_encryption_schema", true)
+	flags.Set(t, "keystore.local_insecure_kms_directory", kmsDir)
+	flags.Set(t, "keystore.master_key_uri", masterKeyURI)
+	env := testenv.GetTestEnv(t)
+	err := kms.Register(env)
+	require.NoError(t, err)
+	err = crypter_service.Register(env)
+	require.NoError(t, err)
+	return env, kmsDir
+}
+
+func TestEncryption(t *testing.T) {
+	te, kmsDir := getCrypterEnv(t)
+
+	userID := "US123"
+	groupID := "GR123"
+	groupKeyID := "EK123"
+	user := testauth.User(userID, groupID)
+	user.CacheEncryptionEnabled = true
+	users := map[string]interfaces.UserInfo{userID: user}
+	auther := testauth.NewTestAuthenticator(users)
+	te.SetAuthenticator(auther)
+
+	rootDir := testfs.MakeTempDir(t)
+	maxSizeBytes := int64(1_000_000_000) // 1GB
+
+	// Customer has encryption enabled but partition does not support encryption.
+	{
+		opts := &pebble_cache.Options{RootDirectory: rootDir, MaxSizeBytes: maxSizeBytes}
+		pc, err := pebble_cache.NewPebbleCache(te, opts)
+		require.NoError(t, err)
+		err = pc.Start()
+		require.NoError(t, err)
+
+		ctx, err := auther.WithAuthenticatedUser(context.Background(), userID)
+		require.NoError(t, err)
+		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+		err = pc.Set(ctx, rn, buf)
+		require.ErrorContains(t, err, "partition that doesn't support encryption")
+
+		err = pc.Stop()
+		require.NoError(t, err)
+	}
+
+	// Customer has encryption enabled, but no keys are available.
+	{
+		opts := &pebble_cache.Options{
+			RootDirectory: rootDir,
+			Partitions: []disk.Partition{{
+				ID: pebble_cache.DefaultPartitionID, EncryptionSupported: true, MaxSizeBytes: maxSizeBytes,
+			}},
+		}
+		pc, err := pebble_cache.NewPebbleCache(te, opts)
+		require.NoError(t, err)
+		err = pc.Start()
+		require.NoError(t, err)
+
+		ctx, err := auther.WithAuthenticatedUser(context.Background(), userID)
+		require.NoError(t, err)
+		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+		err = pc.Set(ctx, rn, buf)
+		require.ErrorContains(t, err, "no encryption key available")
+
+		err = pc.Stop()
+		require.NoError(t, err)
+	}
+
+	// Happy case.
+	{
+		ctx, err := auther.WithAuthenticatedUser(context.Background(), userID)
+		require.NoError(t, err)
+
+		group1KeyURI := generateKMSKey(t, kmsDir, "group1Key")
+		key, keyVersion := createKey(t, te, groupKeyID, groupID, group1KeyURI)
+		err = te.GetDBHandle().DB(ctx).Create(key).Error
+		require.NoError(t, err)
+		err = te.GetDBHandle().DB(ctx).Create(keyVersion).Error
+		require.NoError(t, err)
+
+		opts := &pebble_cache.Options{
+			RootDirectory: rootDir,
+			Partitions: []disk.Partition{{
+				ID: pebble_cache.DefaultPartitionID, EncryptionSupported: true, MaxSizeBytes: maxSizeBytes,
+			}},
+		}
+		pc, err := pebble_cache.NewPebbleCache(te, opts)
+		require.NoError(t, err)
+		err = pc.Start()
+		require.NoError(t, err)
+
+		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+		err = pc.Set(ctx, rn, buf)
+		require.NoError(t, err)
+
+		readBuf, err := pc.Get(ctx, rn)
+		require.NoError(t, err)
+		if !bytes.Equal(buf, readBuf) {
+			require.FailNow(t, "original text and decrypted text didn't match")
+		}
+
+		err = pc.Stop()
+		require.NoError(t, err)
+	}
+}
+
+func TestEncryptionAndCompression(t *testing.T) {
+	te, kmsDir := getCrypterEnv(t)
+
+	userID := "US123"
+	groupID := "GR123"
+	groupKeyID := "EK123"
+	user := testauth.User(userID, groupID)
+	user.CacheEncryptionEnabled = true
+	users := map[string]interfaces.UserInfo{userID: user}
+	auther := testauth.NewTestAuthenticator(users)
+	te.SetAuthenticator(auther)
+
+	ctx, err := auther.WithAuthenticatedUser(context.Background(), userID)
+	require.NoError(t, err)
+
+	group1KeyURI := generateKMSKey(t, kmsDir, "group1Key")
+	key, keyVersion := createKey(t, te, groupKeyID, groupID, group1KeyURI)
+	err = te.GetDBHandle().DB(ctx).Create(key).Error
+	require.NoError(t, err)
+	err = te.GetDBHandle().DB(ctx).Create(keyVersion).Error
+	require.NoError(t, err)
+
+	rootDir := testfs.MakeTempDir(t)
+	maxSizeBytes := int64(1_000_000_000) // 1GB
+	opts := &pebble_cache.Options{
+		RootDirectory: rootDir,
+		Partitions: []disk.Partition{{
+			ID: pebble_cache.DefaultPartitionID, EncryptionSupported: true, MaxSizeBytes: maxSizeBytes,
+		}},
+	}
+	pc, err := pebble_cache.NewPebbleCache(te, opts)
+	require.NoError(t, err)
+	err = pc.Start()
+	require.NoError(t, err)
+
+	// Make blob big enough to require multiple chunks to compress
+	blob := compressibleBlobOfSize(pebble_cache.CompressorBufSizeBytes + 1)
+	compressedBuf := compression.CompressZstd(nil, blob)
+
+	// Note: Digest is of uncompressed contents
+	d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
+	require.NoError(t, err)
+
+	compressedRN := &rspb.ResourceName{Digest: d, CacheType: rspb.CacheType_CAS, Compressor: repb.Compressor_ZSTD}
+	decompressedRN := &rspb.ResourceName{Digest: d, CacheType: rspb.CacheType_CAS, Compressor: repb.Compressor_IDENTITY}
+
+	testCases := []struct {
+		name             string
+		rnToWrite        *rspb.ResourceName
+		dataToWrite      []byte
+		rnToRead         *rspb.ResourceName
+		isReadCompressed bool
+		readOffset       int64
+		readLimit        int64
+		expectedReadData []byte
+	}{
+		{
+			name:             "write_compressed_read_compressed",
+			rnToWrite:        compressedRN,
+			dataToWrite:      compressedBuf,
+			rnToRead:         compressedRN,
+			isReadCompressed: true,
+			expectedReadData: blob,
+		},
+		{
+			name:             "write_compressed_read_decompressed",
+			rnToWrite:        compressedRN,
+			dataToWrite:      compressedBuf,
+			rnToRead:         decompressedRN,
+			expectedReadData: blob,
+		},
+		{
+			name:             "write_compressed_read_decompressed_offset",
+			rnToWrite:        compressedRN,
+			dataToWrite:      compressedBuf,
+			rnToRead:         decompressedRN,
+			readOffset:       10,
+			readLimit:        20,
+			expectedReadData: blob[10:30],
+		},
+		{
+			name:             "write_uncompressed_read_compressed",
+			rnToWrite:        decompressedRN,
+			dataToWrite:      blob,
+			rnToRead:         compressedRN,
+			isReadCompressed: true,
+			expectedReadData: blob,
+		},
+		{
+			name:             "write_uncompressed_read_decompressed",
+			rnToWrite:        decompressedRN,
+			dataToWrite:      blob,
+			rnToRead:         decompressedRN,
+			expectedReadData: blob,
+		},
+		{
+			name:             "write_uncompressed_read_decompressed_offset",
+			rnToWrite:        decompressedRN,
+			dataToWrite:      blob,
+			rnToRead:         decompressedRN,
+			readOffset:       10,
+			readLimit:        20,
+			expectedReadData: blob[10:30],
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			writeResource(t, ctx, pc, tc.rnToWrite, tc.dataToWrite)
+
+			// Read data
+			data := readResource(t, ctx, pc, tc.rnToRead, tc.readOffset, tc.readLimit)
+			if tc.isReadCompressed {
+				data, err = compression.DecompressZstd(nil, data)
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.expectedReadData, data)
+		})
+	}
+
+	err = pc.Stop()
+	require.NoError(t, err)
 }
 
 func BenchmarkGetMulti(b *testing.B) {

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -633,6 +633,7 @@ func (d *UserDB) InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (stri
 				sharing_enabled = ?,
 				user_owned_keys_enabled = ?,
 				use_group_owned_executors = ?,
+				cache_encryption_enabled = ?,
 				suggestion_preference = ?
 			WHERE group_id = ?`,
 			g.Name,
@@ -641,6 +642,7 @@ func (d *UserDB) InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (stri
 			g.SharingEnabled,
 			g.UserOwnedKeysEnabled,
 			g.UseGroupOwnedExecutors,
+			g.CacheEncryptionEnabled,
 			g.SuggestionPreference,
 			g.GroupID)
 		if res.Error != nil {
@@ -1059,6 +1061,7 @@ func (d *UserDB) getUser(tx *db.DB, userID string) (*tables.User, error) {
 			g.sharing_enabled,
 			g.user_owned_keys_enabled,
 			g.use_group_owned_executors,
+			g.cache_encryption_enabled,
 			g.saml_idp_metadata_url,
 			g.suggestion_preference,
 			ug.role
@@ -1085,6 +1088,7 @@ func (d *UserDB) getUser(tx *db.DB, userID string) (*tables.User, error) {
 			&gr.Group.SharingEnabled,
 			&gr.Group.UserOwnedKeysEnabled,
 			&gr.Group.UseGroupOwnedExecutors,
+			&gr.Group.CacheEncryptionEnabled,
 			&gr.Group.SamlIdpMetadataUrl,
 			&gr.Group.SuggestionPreference,
 			&gr.Role,
@@ -1126,6 +1130,7 @@ func (d *UserDB) GetImpersonatedUser(ctx context.Context) (*tables.User, error) 
 				sharing_enabled,
 				user_owned_keys_enabled,
 				use_group_owned_executors,
+				cache_encryption_enabled,
 				saml_idp_metadata_url,
 				suggestion_preference
 			FROM `+"`Groups`"+`
@@ -1147,6 +1152,7 @@ func (d *UserDB) GetImpersonatedUser(ctx context.Context) (*tables.User, error) 
 				&gr.Group.SharingEnabled,
 				&gr.Group.UserOwnedKeysEnabled,
 				&gr.Group.UseGroupOwnedExecutors,
+				&gr.Group.CacheEncryptionEnabled,
 				&gr.Group.SamlIdpMetadataUrl,
 				&gr.Group.SuggestionPreference,
 			)

--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -33,9 +33,9 @@ const (
 
 // TODO(vadim): pool buffers to reduce allocations
 type Crypter struct {
-	auth interfaces.Authenticator
-	dbh  interfaces.DBHandle
-	kms  interfaces.KMS
+	env environment.Env
+	dbh interfaces.DBHandle
+	kms interfaces.KMS
 }
 
 func Register(env environment.Env) error {
@@ -45,9 +45,9 @@ func Register(env environment.Env) error {
 
 func New(env environment.Env) *Crypter {
 	return &Crypter{
-		kms:  env.GetKMS(),
-		auth: env.GetAuthenticator(),
-		dbh:  env.GetDBHandle(),
+		env: env,
+		kms: env.GetKMS(),
+		dbh: env.GetDBHandle(),
 	}
 }
 
@@ -277,7 +277,7 @@ func (c *Crypter) newEncryptorWithKey(digest *repb.Digest, w interfaces.Committe
 }
 
 func (c *Crypter) NewEncryptor(ctx context.Context, digest *repb.Digest, w interfaces.CommittedWriteCloser) (interfaces.Encryptor, error) {
-	u, err := c.auth.AuthenticatedUser(ctx)
+	u, err := c.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -311,7 +311,7 @@ func (c *Crypter) newDecryptorWithKey(digest *repb.Digest, r io.ReadCloser, grou
 }
 
 func (c *Crypter) NewDecryptor(ctx context.Context, digest *repb.Digest, r io.ReadCloser, em *rfpb.EncryptionMetadata) (interfaces.Decryptor, error) {
-	u, err := c.auth.AuthenticatedUser(ctx)
+	u, err := c.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -64,6 +64,7 @@ message StorageMetadata {
 message FileMetadata {
   FileRecord file_record = 1;
   StorageMetadata storage_metadata = 2;
+  EncryptionMetadata encryption_metadata = 6;
 
   // If data is compressed, this will be the compressed size
   int64 stored_size_bytes = 3;

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -94,6 +94,7 @@ type UserInfo interface {
 	IsAdmin() bool
 	HasCapability(akpb.ApiKey_Capability) bool
 	GetUseGroupOwnedExecutors() bool
+	GetCacheEncryptionEnabled() bool
 }
 
 // Authenticator constants
@@ -306,6 +307,7 @@ type APIKeyGroup interface {
 	GetUserID() string
 	GetGroupID() string
 	GetUseGroupOwnedExecutors() bool
+	GetCacheEncryptionEnabled() bool
 }
 
 type AuthDB interface {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -208,6 +208,8 @@ type Group struct {
 	// executors.
 	UseGroupOwnedExecutors *bool `gorm:"type:tinyint(1)"`
 
+	CacheEncryptionEnabled bool `gorm:"bool"`
+
 	// The SAML IDP Metadata URL for this group.
 	SamlIdpMetadataUrl *string
 

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -49,6 +49,7 @@ type TestUser struct {
 	GroupMemberships       []*interfaces.GroupMembership `json:"group_memberships"`
 	Capabilities           []akpb.ApiKey_Capability      `json:"capabilities"`
 	UseGroupOwnedExecutors bool                          `json:"use_group_owned_executors,omitempty"`
+	CacheEncryptionEnabled bool                          `json:"cache_encryption_enabled,omitempty"`
 }
 
 func (c *TestUser) GetUserID() string                                  { return c.UserID }
@@ -68,8 +69,23 @@ func (c *TestUser) HasCapability(cap akpb.ApiKey_Capability) bool {
 func (c *TestUser) GetUseGroupOwnedExecutors() bool {
 	return c.UseGroupOwnedExecutors
 }
+func (c *TestUser) GetCacheEncryptionEnabled() bool {
+	return c.CacheEncryptionEnabled
+}
 func (c *TestUser) IsImpersonating() bool {
 	return false
+}
+
+func User(userID, groupID string) *TestUser {
+	return &TestUser{
+		UserID:        userID,
+		GroupID:       groupID,
+		AllowedGroups: []string{groupID},
+		GroupMemberships: []*interfaces.GroupMembership{
+			{GroupID: groupID, Role: role.Admin},
+		},
+		Capabilities: capabilities.DefaultAuthenticatedUserCapabilities,
+	}
 }
 
 // TestUsers creates a map of test users from arguments of the form:

--- a/server/testutil/testdigest/BUILD
+++ b/server/testutil/testdigest/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//server/remote_cache/digest",
     ],
 )

--- a/server/testutil/testdigest/testdigest.go
+++ b/server/testutil/testdigest/testdigest.go
@@ -1,6 +1,7 @@
 package testdigest
 
 import (
+	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"io"
 	"sync"
 	"testing"
@@ -34,6 +35,16 @@ func NewRandomDigestBuf(t testing.TB, sizeBytes int64) (*repb.Digest, []byte) {
 		t.Fatal(err)
 	}
 	return d, buf
+}
+
+func RandomCASResourceBuf(t testing.TB, sizeBytes int64) (*resource.ResourceName, []byte) {
+	d, buf := NewRandomDigestBuf(t, sizeBytes)
+	return &resource.ResourceName{Digest: d, CacheType: resource.CacheType_CAS}, buf
+}
+
+func RandomACResourceBuf(t testing.TB, sizeBytes int64) (*resource.ResourceName, []byte) {
+	d, buf := NewRandomDigestBuf(t, sizeBytes)
+	return &resource.ResourceName{Digest: d, CacheType: resource.CacheType_AC}, buf
 }
 
 func ReadDigestAndClose(t *testing.T, r io.ReadCloser) *repb.Digest {

--- a/server/util/disk/disk.go
+++ b/server/util/disk/disk.go
@@ -31,8 +31,9 @@ var (
 )
 
 type Partition struct {
-	ID           string `yaml:"id" json:"id" usage:"The ID of the partition."`
-	MaxSizeBytes int64  `yaml:"max_size_bytes" json:"max_size_bytes" usage:"Maximum size of the partition."`
+	ID                  string `yaml:"id" json:"id" usage:"The ID of the partition."`
+	MaxSizeBytes        int64  `yaml:"max_size_bytes" json:"max_size_bytes" usage:"Maximum size of the partition."`
+	EncryptionSupported bool   `yaml:"encryption_supported" json:"encryption_supported" usage:"Whether encrypted data can be stored on this partition."`
 }
 
 type PartitionMapping struct {


### PR DESCRIPTION
We store a `bool` property on the group to indicate whether a customer has encryption enabled. This property is looked up and cached as part of the normal auth check so that we can avoid doing any additional database lookups to determine if auth is enabled.

Cache partitions have an additional property to indicate whether encrypted content can be stored on that partition. We allow partitions (e.g. the default one) to share CAS data across customers which is incompatible with encryption. We will require dedicated customer partitions before encryption can be enabled.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
