### PR TITLE
Fix dev webdriver QA tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -69,8 +69,6 @@ build:workflows --remote_instance_name=buildbuddy-io/buildbuddy/workflows
 build:workflows --color=yes
 build:workflows --disk_cache=
 build:workflows --flaky_test_attempts=2
-# TODO(http://go/b/1575): De-flake and remove this
-build:workflows --flaky_test_attempts=//enterprise/server/test/webdriver/invocation:invocation_test_chromium-local@4
 # Use BuildBuddy endpoints from the ci_runner-generated bazelrc.
 # These will point to local, dev, or prod, depending on which app created the workflow action.
 build:workflows --config=buildbuddy_bes_backend

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -46,7 +46,8 @@ actions:
           - "master"
     bazel_commands:
       # TODO(http://go/b/958): See if we can remove --remote_download_outputs=toplevel
-      - test //... --config=linux-workflows --remote_download_outputs=toplevel --test_tag_filters=+webdriver
+      # TODO(http://go/b/1575): De-flake, and remove --flaky_test_attempts
+      - test //... --config=linux-workflows --remote_download_outputs=toplevel --test_tag_filters=+webdriver --flaky_test_attempts=4
   # TODO(bduffany): Move docker tests to the Test workflow when they are fast enough.
   - name: Docker tests
     container_image: ubuntu-20.04

--- a/enterprise/server/test/webdriver/invocation/BUILD
+++ b/enterprise/server/test/webdriver/invocation/BUILD
@@ -9,7 +9,6 @@ go_web_test_suite(
         "//enterprise/server/testutil/buildbuddy_enterprise",
         "//server/testutil/testbazel",
         "//server/testutil/webtester",
-        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/test/webdriver/invocation/invocation_test.go
+++ b/enterprise/server/test/webdriver/invocation/invocation_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/buildbuddy_enterprise"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testbazel"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/webtester"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,7 +32,10 @@ func TestAuthenticatedInvocation_CacheEnabled(t *testing.T) {
 	webtester.Login(wt, target)
 
 	// Get the build flags needed for BuildBuddy, including API key, bes results url, bes backend, and remote cache
-	buildbuddyBuildFlags := webtester.GetBazelBuildFlags(wt, target.HTTPURL(), webtester.WithEnableCache)
+	buildbuddyBuildFlags := webtester.GetBazelBuildFlags(
+		wt, target.HTTPURL(),
+		webtester.WithEnableCache,
+		webtester.WithAPIKeySelection("Default"))
 	t.Log(buildbuddyBuildFlags)
 	buildArgs = append(buildArgs, buildbuddyBuildFlags...)
 
@@ -47,18 +49,18 @@ func TestAuthenticatedInvocation_CacheEnabled(t *testing.T) {
 	wt.Get(target.HTTPURL() + "/invocation/" + result.InvocationID)
 
 	details := wt.FindByDebugID("invocation-details").Text()
-	assert.Contains(t, details, "Succeeded")
-	assert.NotContains(t, details, "Failed")
-	assert.Contains(t, details, "//:a")
-	assert.Contains(t, details, "Cache on")
-	assert.Contains(t, details, "Remote execution off")
+	require.Contains(t, details, "Succeeded")
+	require.NotContains(t, details, "Failed")
+	require.Contains(t, details, "//:a")
+	require.Contains(t, details, "Cache on")
+	require.Contains(t, details, "Remote execution off")
 
 	// Make sure we can view the cache section
 	wt.FindByDebugID("cache-sections")
 	wt.FindByDebugID("filter-cache-requests").SendKeys("All")
 	cacheRequestsCard := wt.FindByDebugID("cache-results-table").Text()
-	assert.Contains(t, cacheRequestsCard, "Write")
-	assert.NotContains(t, cacheRequestsCard, "Hit")
+	require.Contains(t, cacheRequestsCard, "Write")
+	require.NotContains(t, cacheRequestsCard, "Hit")
 
 	// Second build of the same target
 	testbazel.Clean(context.Background(), t, workspacePath)
@@ -68,29 +70,29 @@ func TestAuthenticatedInvocation_CacheEnabled(t *testing.T) {
 	wt.Get(target.HTTPURL() + "/invocation/" + result.InvocationID)
 
 	details = wt.FindByDebugID("invocation-details").Text()
-	assert.Contains(t, details, "Succeeded")
-	assert.NotContains(t, details, "Failed")
-	assert.Contains(t, details, "//:a")
-	assert.Contains(t, details, "Cache on")
-	assert.Contains(t, details, "Remote execution off")
+	require.Contains(t, details, "Succeeded")
+	require.NotContains(t, details, "Failed")
+	require.Contains(t, details, "//:a")
+	require.Contains(t, details, "Cache on")
+	require.Contains(t, details, "Remote execution off")
 
 	// Cache section should contain a cache hit
 	wt.FindByDebugID("cache-sections")
 	wt.FindByDebugID("filter-cache-requests").SendKeys("All")
 	cacheRequestsCard = wt.FindByDebugID("cache-results-table").Text()
-	assert.Contains(t, cacheRequestsCard, "Hit")
+	require.Contains(t, cacheRequestsCard, "Hit")
 
 	// Make sure it shows up in repo history
 	webtester.ClickSidebarItem(wt, "Repos")
 
 	historyCardTitle := wt.Find(".history .card .title").Text()
-	assert.Equal(t, "test-owner/test-repo", historyCardTitle)
+	require.Equal(t, "test-owner/test-repo", historyCardTitle)
 
 	// Make sure it shows up in commit history
 	webtester.ClickSidebarItem(wt, "Commits")
 
 	historyCardTitle = wt.Find(".history .card .title").Text()
-	assert.Equal(t, "Commit cc5011", historyCardTitle)
+	require.Equal(t, "Commit cc5011", historyCardTitle)
 
 	// Sanity check that the login button is not present while logged in,
 	// since we rely on this to check whether we're logged out
@@ -180,11 +182,11 @@ func TestAuthenticatedInvocation_PersonalAPIKey_CacheEnabled(t *testing.T) {
 	wt.Get(target.HTTPURL() + "/invocation/" + result.InvocationID)
 
 	details := wt.FindByDebugID("invocation-details").Text()
-	assert.Contains(t, details, "Succeeded")
-	assert.NotContains(t, details, "Failed")
-	assert.Contains(t, details, "//:a")
-	assert.Contains(t, details, "Cache on")
-	assert.Contains(t, details, "Remote execution off")
+	require.Contains(t, details, "Succeeded")
+	require.NotContains(t, details, "Failed")
+	require.Contains(t, details, "//:a")
+	require.Contains(t, details, "Cache on")
+	require.Contains(t, details, "Remote execution off")
 
 	// Make sure we can view the cache section
 	wt.FindByDebugID("cache-sections")


### PR DESCRIPTION
Select the group-owned API key ("Default") instead of the personal API key to ensure that the bazel builds can upload AC results to cache.

Also switch from `assert` to `require` so that the test stops executing once it fails, so we can see exactly where it failed (both w/ `--config=webdriver-debug`, and the end-of-test screenshot)

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
