### PR TITLE
Serve timing profile artifact from blobstore

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -730,6 +730,19 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 		invocation.LastChunkId = e.logWriter.GetLastChunkId(ctx)
 	}
 
+	if e.beValues.ProfileURI() != nil {
+		w, err := e.env.GetBlobstore().Writer(ctx, invocation.InvocationId+"/"+strconv.FormatUint(invocation.Attempt, 10)+"/"+e.beValues.ProfileName())
+		if err != nil {
+			return err
+		}
+		if err := bytestream.StreamBytestreamFile(ctx, e.env, e.beValues.ProfileURI(), w); err != nil {
+			return err
+		}
+		if err := w.Close(); err != nil {
+			return err
+		}
+	}
+
 	ti, err := e.tableInvocationFromProto(invocation, iid)
 	if err != nil {
 		return err

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -731,7 +731,7 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 	}
 
 	if e.beValues.ProfileURI() != nil {
-		w, err := e.env.GetBlobstore().Writer(ctx, invocation.InvocationId+"/artifacts/"+e.beValues.ProfileName())
+		w, err := e.env.GetBlobstore().Writer(ctx, invocation.InvocationId+"/artifacts/timing_profile/"+e.beValues.ProfileName())
 		if err != nil {
 			return err
 		}

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -736,6 +736,11 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 			return err
 		}
 		if err := bytestream.StreamBytestreamFile(ctx, e.env, e.beValues.ProfileURI(), w); err != nil {
+			w.Close()
+			return err
+		}
+		if err := w.Commit(); err != nil {
+			w.Close()
 			return err
 		}
 		if err := w.Close(); err != nil {

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -731,7 +731,7 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 	}
 
 	if e.beValues.ProfileURI() != nil {
-		w, err := e.env.GetBlobstore().Writer(ctx, invocation.InvocationId+"/"+strconv.FormatUint(invocation.Attempt, 10)+"/"+e.beValues.ProfileName())
+		w, err := e.env.GetBlobstore().Writer(ctx, invocation.InvocationId+"/artifacts/"+e.beValues.ProfileName())
 		if err != nil {
 			return err
 		}

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -730,24 +730,6 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 		invocation.LastChunkId = e.logWriter.GetLastChunkId(ctx)
 	}
 
-	if e.beValues.ProfileURI() != nil {
-		w, err := e.env.GetBlobstore().Writer(ctx, invocation.InvocationId+"/artifacts/timing_profile/"+e.beValues.ProfileName())
-		if err != nil {
-			return err
-		}
-		if err := bytestream.StreamBytestreamFile(ctx, e.env, e.beValues.ProfileURI(), w); err != nil {
-			w.Close()
-			return err
-		}
-		if err := w.Commit(); err != nil {
-			w.Close()
-			return err
-		}
-		if err := w.Close(); err != nil {
-			return err
-		}
-	}
-
 	ti, err := e.tableInvocationFromProto(invocation, iid)
 	if err != nil {
 		return err

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1195,7 +1195,7 @@ func (s *BuildBuddyServer) serveArtifact(ctx context.Context, w http.ResponseWri
 		} else if status.IsNotFoundError(err) {
 			http.Error(w, "File not found", http.StatusNotFound)
 		} else {
-			log.Warningf("Error looking up invocation %s for build log fetch: %s", iid, err)
+			log.Errorf("Error looking up invocation %s for build log fetch: %s", iid, err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 		}
 		return

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1229,7 +1229,7 @@ func (s *BuildBuddyServer) serveArtifact(ctx context.Context, w http.ResponseWri
 		}
 	case "timing_profile":
 		name := params.Get("name")
-		b, err := s.env.GetBlobstore().ReadBlob(ctx, iid+"/artifacts/"+name)
+		b, err := s.env.GetBlobstore().ReadBlob(ctx, iid+"/artifacts/timing_profile/"+name)
 		if err != nil {
 			log.Warningf("Error serving timing profile '%s' for invocation %s: %s", name, iid, err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1202,12 +1202,13 @@ func (s *BuildBuddyServer) serveArtifact(ctx context.Context, w http.ResponseWri
 	switch params.Get("artifact") {
 	case "buildlog":
 		attempt, err := strconv.ParseUint(params.Get("attempt"), 10, 64)
-		if err == nil {
+		if err != nil {
 			http.Error(
 				w,
 				fmt.Sprintf("Attempt param '%s' is not parseable to uint64.", params.Get("attempt")),
 				http.StatusBadRequest,
 			)
+			return
 		}
 		c := chunkstore.New(
 			s.env.GetBlobstore(),

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1200,12 +1200,12 @@ func (s *BuildBuddyServer) serveArtifact(ctx context.Context, w http.ResponseWri
 		}
 		return
 	}
-	attempt := uint64(0)
-	if n, err := strconv.ParseUint(params.Get("attempt"), 10, 64); err == nil {
-		attempt = n
-	}
 	switch params.Get("artifact") {
 	case "buildlog":
+		attempt := uint64(0)
+		if n, err := strconv.ParseUint(params.Get("attempt"), 10, 64); err == nil {
+			attempt = n
+		}
 		c := chunkstore.New(
 			s.env.GetBlobstore(),
 			&chunkstore.ChunkstoreOptions{},
@@ -1229,7 +1229,7 @@ func (s *BuildBuddyServer) serveArtifact(ctx context.Context, w http.ResponseWri
 		}
 	case "timing_profile":
 		name := params.Get("name")
-		b, err := s.env.GetBlobstore().ReadBlob(ctx, iid+"/"+strconv.FormatUint(attempt, 10)+"/"+name)
+		b, err := s.env.GetBlobstore().ReadBlob(ctx, iid+"/artifacts/"+name)
 		if err != nil {
 			log.Warningf("Error serving timing profile '%s' for invocation %s: %s", name, iid, err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Add the ability to retrieve an invocation's timing profile artifact from blobstore.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
