### PR TITLE
Delete timing profile from cache after copying to blobstore

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -277,6 +277,10 @@ export default class InvocationModel {
     return this.invocations.find(() => true)?.invocationId;
   }
 
+  getAttempt() {
+    return this.invocations.find(() => true)?.attempt;
+  }
+
   getHost() {
     return this.invocations.find(() => true)?.host || this.workspaceStatusMap.get("BUILD_HOST") || "Unknown host";
   }

--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -77,10 +77,9 @@ export default class InvocationTimingCardComponent extends React.Component<Props
     return Boolean(this.getProfileFile()?.uri?.startsWith("bytestream://"));
   }
 
-  timingProfileFallbackParams(invocationId: string, attempt: number, name: string) {
+  timingProfileFallbackParams(invocationId: string, name: string) {
     const params: Record<string, string> = {
       invocation_id: invocationId,
-      attempt: attempt.toString(),
       artifact: "timing_profile",
       name: name,
     };
@@ -103,11 +102,7 @@ export default class InvocationTimingCardComponent extends React.Component<Props
         profileFile?.uri,
         this.props.model.getId(),
         isGzipped ? "arraybuffer" : "json",
-        this.timingProfileFallbackParams(
-          this.props.model.getId(),
-          Number(this.props.model.getAttempt()),
-          profileFile?.name
-        )
+        this.timingProfileFallbackParams(this.props.model.getId(), profileFile?.name)
       )
       .then((contents: any) => {
         if (isGzipped) {

--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -77,6 +77,16 @@ export default class InvocationTimingCardComponent extends React.Component<Props
     return Boolean(this.getProfileFile()?.uri?.startsWith("bytestream://"));
   }
 
+  timingProfileFallbackParams(invocationId: string, attempt: number, name: string) {
+    const params: Record<string, string> = {
+      invocation_id: invocationId,
+      attempt: attempt.toString(),
+      artifact: "timing_profile",
+      name: name,
+    };
+    return params;
+  }
+
   fetchProfile() {
     if (!this.isTimingEnabled()) return;
 
@@ -89,7 +99,16 @@ export default class InvocationTimingCardComponent extends React.Component<Props
 
     this.setState({ loading: true });
     rpcService
-      .fetchBytestreamFile(profileFile?.uri, this.props.model.getId(), isGzipped ? "arraybuffer" : "json")
+      .fetchBytestreamFile(
+        profileFile?.uri,
+        this.props.model.getId(),
+        isGzipped ? "arraybuffer" : "json",
+        this.timingProfileFallbackParams(
+          this.props.model.getId(),
+          Number(this.props.model.getAttempt()),
+          profileFile?.name
+        )
+      )
       .then((contents: any) => {
         if (isGzipped) {
           contents = parseProfile(pako.inflate(contents, { to: "string" }));

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -49,7 +49,11 @@ class RpcService {
     return `/file/download?${new URLSearchParams(params)}`;
   }
 
-  getBytestreamUrl(bytestreamURL: string, invocationId: string, { filename = "", zip = "" } = {}): string {
+  getBytestreamUrl(
+    bytestreamURL: string,
+    invocationId: string,
+    { filename = "", zip = "", fallback = "" } = {}
+  ): string {
     const encodedRequestContext = uint8ArrayToBase64(context.RequestContext.encode(this.requestContext).finish());
     const params: Record<string, string> = {
       bytestream_url: bytestreamURL,
@@ -58,6 +62,7 @@ class RpcService {
     };
     if (filename) params.filename = filename;
     if (zip) params.z = zip;
+    if (fallback) params.with_fallback = fallback;
     return this.getDownloadUrl(params);
   }
 
@@ -81,9 +86,15 @@ class RpcService {
   fetchBytestreamFile(
     bytestreamURL: string,
     invocationId: string,
-    responseType?: "arraybuffer" | "json" | "text" | undefined
+    responseType?: "arraybuffer" | "json" | "text" | undefined,
+    fallbackParams?: Record<string, string>
   ) {
-    return this.fetchFile(this.getBytestreamUrl(bytestreamURL, invocationId), responseType || "");
+    let fallback = "";
+    if (fallbackParams) fallback = `?${new URLSearchParams(fallbackParams)?.toString()}`;
+    return this.fetchFile(
+      this.getBytestreamUrl(bytestreamURL, invocationId, { fallback: fallback }),
+      responseType || ""
+    );
   }
 
   fetchFile(fileURL: string, responseType: "arraybuffer" | "json" | "text" | "") {

--- a/server/build_event_protocol/build_event_handler/BUILD
+++ b/server/build_event_protocol/build_event_handler/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//server/interfaces",
         "//server/metrics",
         "//server/olapdbconfig",
+        "//server/remote_cache/digest",
         "//server/remote_cache/hit_tracker",
         "//server/remote_cache/scorecard",
         "//server/tables",

--- a/server/build_event_protocol/build_event_handler/BUILD
+++ b/server/build_event_protocol/build_event_handler/BUILD
@@ -40,6 +40,7 @@ go_library(
         "//server/util/log",
         "//server/util/paging",
         "//server/util/perms",
+        "//server/util/prefix",
         "//server/util/protofile",
         "//server/util/redact",
         "//server/util/status",

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -36,6 +36,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/paging"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
+	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/protofile"
 	"github.com/buildbuddy-io/buildbuddy/server/util/redact"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -446,6 +447,10 @@ func (r *statsRecorder) handleTask(ctx context.Context, task *recordStatsTask) {
 		if err != nil {
 			log.CtxWarningf(ctx, "Could not delete artifact from cache at %s: %s", uri.String(), err)
 			continue
+		}
+		ctx, err := prefix.AttachUserPrefixToContext(ctx, r.env)
+		if err != nil {
+			log.CtxErrorf(ctx, "Could not delete artifact from cache at %s: %s", uri.String(), err)
 		}
 		resourceName := digest.NewResourceName(parsedRN.GetDigest(), parsedRN.GetInstanceName(), rspb.CacheType_CAS, parsedRN.GetDigestFunction()).ToProto()
 		if err := r.env.GetCache().Delete(ctx, resourceName); err != nil {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1187,7 +1187,7 @@ func (s *BuildBuddyServer) serveUsingParams(w http.ResponseWriter, r *http.Reque
 			// Attempt to fall back gracefully if the specified file is not found and
 			// a fallback is specified.
 			if fallback, parseErr := url.Parse(params.Get("with_fallback")); parseErr == nil && fallback.RawQuery != "" {
-				fallback.Query().Del("with_fallback")  // Only fall back once.
+				fallback.Query().Del("with_fallback") // Only fall back once.
 				s.serveUsingParams(w, r, fallback.Query())
 				return
 			} else if parseErr != nil {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1187,12 +1187,13 @@ func (s *BuildBuddyServer) serveUsingParams(w http.ResponseWriter, r *http.Reque
 			// Attempt to fall back gracefully if the specified file is not found and
 			// a fallback is specified.
 			if fallback, parseErr := url.Parse(params.Get("with_fallback")); parseErr == nil && fallback.RawQuery != "" {
+				fallback.Query().Del("with_fallback")  // Only fall back once.
 				s.serveUsingParams(w, r, fallback.Query())
 				return
 			} else if parseErr != nil {
 				log.Infof("Parse Error: %s", parseErr)
 			} else {
-				log.Infof("fallback: %v", fallback)
+				log.Warningf("Fallback without query is invalid: %v", fallback)
 			}
 		}
 		http.Error(w, err.Error(), code)

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1187,8 +1187,9 @@ func (s *BuildBuddyServer) serveUsingParams(w http.ResponseWriter, r *http.Reque
 			// Attempt to fall back gracefully if the specified file is not found and
 			// a fallback is specified.
 			if fallback, parseErr := url.Parse(params.Get("with_fallback")); parseErr == nil && fallback.RawQuery != "" {
-				fallback.Query().Del("with_fallback") // Only fall back once.
-				s.serveUsingParams(w, r, fallback.Query())
+				q := fallback.Query()
+				q.Del("with_fallback") // Only fall back once.
+				s.serveUsingParams(w, r, q)
 				return
 			} else if parseErr != nil {
 				log.Infof("Parse Error: %s", parseErr)

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1167,37 +1167,59 @@ func (s *BuildBuddyServer) getAnyAPIKeyForInvocation(ctx context.Context, invoca
 // them up from our cache servers using the bytestream API or pulling them
 // from blobstore.
 func (s *BuildBuddyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	params := r.URL.Query()
+	s.serveUsingParams(w, r, r.URL.Query())
+}
 
+func (s *BuildBuddyServer) serveUsingParams(w http.ResponseWriter, r *http.Request, params url.Values) {
+	var code int
+	var err error
 	if params.Get("artifact") != "" {
-		s.serveArtifact(r.Context(), w, params)
-		return
-	}
-	if params.Get("bytestream_url") != "" {
+		code, err = s.serveArtifact(r.Context(), w, params)
+	} else if params.Get("bytestream_url") != "" {
 		// bytestream request
-		s.serveBytestream(r.Context(), w, params)
+		code, err = s.serveBytestream(r.Context(), w, params)
+	} else {
+		http.Error(w, `One of "artifact" or "bytestream_url" query param is required`, http.StatusBadRequest)
 		return
 	}
-	http.Error(w, `One of "artifact" or "bytestream_url" query param is required`, http.StatusBadRequest)
+	if err != nil {
+		if code == http.StatusNotFound {
+			// Attempt to fall back gracefully if the specified file is not found and
+			// a fallback is specified.
+			if fallback, parseErr := url.Parse(params.Get("with_fallback")); parseErr == nil && fallback.RawQuery != "" {
+				s.serveUsingParams(w, r, fallback.Query())
+				return
+			} else if parseErr != nil {
+				log.Infof("Parse Error: %s", parseErr)
+			} else {
+				log.Infof("fallback: %v", fallback)
+			}
+		}
+		http.Error(w, err.Error(), code)
+	}
 }
 
 // serveArtifact handles requests that specify particular build artifacts
-func (s *BuildBuddyServer) serveArtifact(ctx context.Context, w http.ResponseWriter, params url.Values) {
+func (s *BuildBuddyServer) serveArtifact(ctx context.Context, w http.ResponseWriter, params url.Values) (int, error) {
 	iid := params.Get("invocation_id")
 	if iid == "" {
-		http.Error(w, "Missing invocation_id param", http.StatusBadRequest)
-		return
+		http.Error(w, "File not found", http.StatusNotFound)
+		return http.StatusBadRequest, status.FailedPreconditionError("Missing invocation_id param")
 	}
 	if _, err := s.env.GetInvocationDB().LookupInvocation(ctx, iid); err != nil {
 		if status.IsPermissionDeniedError(err) {
-			http.Error(w, "Access denied", http.StatusForbidden)
+			return http.StatusForbidden, status.PermissionDeniedErrorf("User does not have permissions to access invocation %s.", iid)
 		} else if status.IsNotFoundError(err) {
 			http.Error(w, "File not found", http.StatusNotFound)
 		} else {
 			log.Errorf("Error looking up invocation %s for build log fetch: %s", iid, err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 		}
-		return
+		if status.IsNotFoundError(err) {
+			return http.StatusNotFound, status.NotFoundErrorf("Invocation %s does not exist.", iid)
+		}
+		log.Warningf("Error looking up invocation %s for build log fetch: %s", iid, err)
+		return http.StatusInternalServerError, status.InternalErrorf("Internal sever error")
 	}
 	switch params.Get("artifact") {
 	case "buildlog":
@@ -1227,8 +1249,7 @@ func (s *BuildBuddyServer) serveArtifact(ctx context.Context, w http.ResponseWri
 		b, err := s.env.GetBlobstore().ReadBlob(ctx, iid+"/artifacts/timing_profile/"+name)
 		if err != nil {
 			log.Warningf("Error serving timing profile '%s' for invocation %s: %s", name, iid, err)
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
-			return
+			return http.StatusInternalServerError, status.InternalErrorf("Internal sever error")
 		}
 		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", name))
 		w.Header().Set("Content-Type", "application/octet-stream")
@@ -1237,16 +1258,16 @@ func (s *BuildBuddyServer) serveArtifact(ctx context.Context, w http.ResponseWri
 		}
 		w.Write(b)
 	default:
-		http.Error(w, "File not found", http.StatusNotFound)
+		return http.StatusBadRequest, status.FailedPreconditionErrorf("Unrecognized artifact \"%s\" requested.", params.Get("artifact"))
 	}
+	return http.StatusOK, nil
 }
 
 // serveBytestream handles requests that specify bytestream URLs.
-func (s *BuildBuddyServer) serveBytestream(ctx context.Context, w http.ResponseWriter, params url.Values) {
+func (s *BuildBuddyServer) serveBytestream(ctx context.Context, w http.ResponseWriter, params url.Values) (int, error) {
 	lookup, err := parseByteStreamURL(params.Get("bytestream_url"), params.Get("filename"))
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
+		return http.StatusBadRequest, err
 	}
 
 	if lookup.URL.User == nil {
@@ -1264,24 +1285,24 @@ func (s *BuildBuddyServer) serveBytestream(ctx context.Context, w http.ResponseW
 		b, err := base64.StdEncoding.DecodeString(zipReference)
 		if err != nil {
 			log.Warningf("Error downloading file: %s", err)
-			http.Error(w, "File not found", http.StatusBadRequest)
-			return
+			return http.StatusBadRequest, status.FailedPreconditionErrorf("\"%s\" is an invalid base64 string.", zipReference)
 		}
 		entry := &zipb.ManifestEntry{}
 		if err := proto.Unmarshal(b, entry); err != nil {
 			log.Warningf("Failed to unmarshal ManifestEntry: %s", err)
-			http.Error(w, "File not found", http.StatusBadRequest)
-			return
+			return http.StatusBadRequest, status.FailedPreconditionErrorf("\"%s\" does not represent a valid ManifestEntry proto when base64 decoded.", zipReference)
 		}
 		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", entry.GetName()))
 		// TODO(jdhollen): Parse output mime type from bazel-generated MANIFEST file.
 		w.Header().Set("Content-Type", "application/octet-stream")
 		err = bytestream.StreamSingleFileFromBytestreamZip(ctx, s.env, lookup.URL, entry, w)
 		if err != nil {
-			log.Warningf("Error downloading zip file contents: %s", err)
-			http.Error(w, "File not found", http.StatusNotFound)
+			if status.IsInvalidArgumentError(err) {
+				return http.StatusBadRequest, err
+			}
+			return http.StatusNotFound, status.NotFoundErrorf("File not found.")
 		}
-		return
+		return http.StatusOK, nil
 	}
 
 	// Stream the file back to our client
@@ -1291,10 +1312,12 @@ func (s *BuildBuddyServer) serveBytestream(ctx context.Context, w http.ResponseW
 	err = bytestream.StreamBytestreamFile(ctx, s.env, lookup.URL, w)
 
 	if err != nil {
-		log.Warningf("Error downloading file: %s", err)
-		http.Error(w, "File not found", http.StatusNotFound)
-		return
+		if status.IsInvalidArgumentError(err) {
+			return http.StatusBadRequest, err
+		}
+		return http.StatusNotFound, status.NotFoundErrorf("File not found.")
 	}
+	return http.StatusOK, nil
 }
 
 func (s *BuildBuddyServer) SetEncryptionConfig(ctx context.Context, request *enpb.SetEncryptionConfigRequest) (*enpb.SetEncryptionConfigResponse, error) {

--- a/server/bytestream/bytestream.go
+++ b/server/bytestream/bytestream.go
@@ -85,6 +85,9 @@ func StreamSingleFileFromBytestreamZip(ctx context.Context, env environment.Env,
 func streamSingleFileFromBytestreamZipInternal(ctx context.Context, env environment.Env, url *url.URL, entry *zipb.ManifestEntry, out io.Writer, streamer Bytestreamer) error {
 	dynamicHeaderBytes, err := validateLocalFileHeader(ctx, env, url, entry, streamer)
 	if err != nil {
+		if !status.IsNotFoundError(err) {
+			log.Warningf("Error streaming zip file contents: %s", err)
+		}
 		return err
 	}
 
@@ -152,7 +155,9 @@ func StreamBytestreamFileChunk(ctx context.Context, env environment.Env, url *ur
 	// Sanitize the error so as to not expose internal services via the
 	// error message.
 	if err != nil {
-		log.Errorf("Error byte-streaming from %q: %s", stripUser(url), err)
+		if !status.IsNotFoundError(err) {
+			log.Errorf("Error byte-streaming from %q: %s", stripUser(url), err)
+		}
 		return status.UnavailableErrorf("failed to read byte stream resource %q", stripUser(url))
 	}
 	return nil


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

Don't continue to persist the timing profile in the cache after it has been stored in blobstore,
as it would be redundant and use up cache that could be devoted to something else.

---

**Version bump**: Minor <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
