### PR TITLE
Add SociArtifactStore proto

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -179,6 +179,16 @@ proto_library(
 )
 
 proto_library(
+    name = "soci_proto",
+    srcs = [
+        "soci.proto",
+    ],
+    deps = [
+        ":remote_execution_proto",
+    ],
+)
+
+proto_library(
     name = "stat_filter_proto",
     srcs = ["stat_filter.proto"],
 )
@@ -659,6 +669,16 @@ go_proto_library(
     proto = ":secrets_proto",
     deps = [
         ":context_go_proto",
+    ],
+)
+
+go_proto_library(
+    name = "soci_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/soci",
+    proto = ":soci_proto",
+    deps = [
+        ":remote_execution_go_proto",
     ],
 )
 

--- a/proto/soci.proto
+++ b/proto/soci.proto
@@ -5,42 +5,41 @@ import "proto/remote_execution.proto";
 package soci;
 
 enum Type {
-    UNKNOWN_TYPE = 0;
+  UNKNOWN_TYPE = 0;
 
-    // The SOCI Index is a JSON file containing indexing information for some
-    // layers of the images. It is basically a mapping from the digest of the
-    // layer to the digest of the ZTOC. Note that some layers may be absent as
-    // only layers above a certain size are indexed.
-    SOCI_INDEX = 1;
+  // The SOCI Index is a JSON file containing indexing information for some
+  // layers of the images. It is basically a mapping from the digest of the
+  // layer to the digest of the ZTOC. Note that some layers may be absent as
+  // only layers above a certain size are indexed.
+  SOCI_INDEX = 1;
 
-    // The ZTOC (Zip Table Of Contents) is a JSON file containing indexing
-    // information for a single layer. It is basically a mapping from file path
-    // to the byte offsets in the zipped layer where the file exists.
-    ZTOC = 2;
+  // The ZTOC (Zip Table Of Contents) is a JSON file containing indexing
+  // information for a single layer. It is basically a mapping from file path
+  // to the byte offsets in the zipped layer where the file exists.
+  ZTOC = 2;
 }
 
 // A single SOCI artifact.
 message Artifact {
-    build.bazel.remote.execution.v2.Digest digest = 1;
-    Type type = 2;
-    bytes data = 3;
+  build.bazel.remote.execution.v2.Digest digest = 1;
+  Type type = 2;
+  bytes data = 3;
 }
 
 message ReadRequest {
-    // The (OCI, sha256:foo) digest of the image manifest.
-    string image_manifest_digest = 1;
+  // The (OCI, sha256:foo) digest of the image manifest.
+  string image_manifest_digest = 1;
 }
 
 message WriteRequest {
-    // The (OCI, sha256:foo) digest of the image manifest.
-    string image_manifest_digest = 1;
-    Artifact artifact = 2;
+  // The (OCI, sha256:foo) digest of the image manifest.
+  string image_manifest_digest = 1;
+  Artifact artifact = 2;
 }
 
-message WriteResponse {
-}
+message WriteResponse {}
 
 service SociArtifactStore {
-   rpc Read(ReadRequest) returns (stream Artifact);
-   rpc Write(stream WriteRequest) returns (WriteResponse);
+  rpc Read(ReadRequest) returns (stream Artifact);
+  rpc Write(stream WriteRequest) returns (WriteResponse);
 }

--- a/proto/soci.proto
+++ b/proto/soci.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+import "proto/remote_execution.proto";
+
+package soci;
+
+enum Type {
+    UNKNOWN_TYPE = 0;
+
+    // The SOCI Index is a JSON file containing indexing information for some
+    // layers of the images. It is basically a mapping from the digest of the
+    // layer to the digest of the ZTOC. Note that some layers may be absent as
+    // only layers above a certain size are indexed.
+    SOCI_INDEX = 1;
+
+    // The ZTOC (Zip Table Of Contents) is a JSON file containing indexing
+    // information for a single layer. It is basically a mapping from file path
+    // to the byte offsets in the zipped layer where the file exists.
+    ZTOC = 2;
+}
+
+// A single SOCI artifact.
+message Artifact {
+    build.bazel.remote.execution.v2.Digest digest = 1;
+    Type type = 2;
+    bytes data = 3;
+}
+
+message ReadRequest {
+    // The (OCI, sha256:foo) digest of the image manifest.
+    string image_manifest_digest = 1;
+}
+
+message WriteRequest {
+    // The (OCI, sha256:foo) digest of the image manifest.
+    string image_manifest_digest = 1;
+    Artifact artifact = 2;
+}
+
+message WriteResponse {
+}
+
+service SociArtifactStore {
+   rpc Read(ReadRequest) returns (stream Artifact);
+   rpc Write(stream WriteRequest) returns (WriteResponse);
+}

--- a/proto/soci.proto
+++ b/proto/soci.proto
@@ -27,13 +27,15 @@ message Artifact {
 }
 
 message ReadRequest {
-  // The (OCI, sha256:foo) digest of the image manifest.
-  string image_manifest_digest = 1;
+  // The image ID, which is the digest of the image's config, found with:
+  //     podman inspect <image>
+  string image_id = 1;
 }
 
 message WriteRequest {
-  // The (OCI, sha256:foo) digest of the image manifest.
-  string image_manifest_digest = 1;
+  // The image ID, which is the digest of the image's config, found with:
+  //     podman inspect <image>
+  string image_id = 1;
   Artifact artifact = 2;
 }
 

--- a/proto/soci.proto
+++ b/proto/soci.proto
@@ -27,14 +27,14 @@ message Artifact {
   Type type = 2;
 }
 
-message ReadRequest {
+message GetArtifactsRequest {
   string image_name = 1;
 }
 
-message ReadResponse {
-  repeated Artifact = 1;
+message GetArtifactsResponse {
+  repeated Artifact artifact = 1;
 }
 
 service SociArtifactStore {
-  rpc Read(ReadRequest) returns (ReadResponse);
+  rpc GetArtifacts(GetArtifactsRequest) returns (GetArtifactsResponse);
 }

--- a/proto/soci.proto
+++ b/proto/soci.proto
@@ -21,27 +21,20 @@ enum Type {
 
 // A single SOCI artifact.
 message Artifact {
+  // The digest of the artifact. The bytes of the artifact may be retrieved
+  // from the CAS using this digest.
   build.bazel.remote.execution.v2.Digest digest = 1;
   Type type = 2;
-  bytes data = 3;
 }
 
 message ReadRequest {
-  // The image ID, which is the digest of the image's config, found with:
-  //     podman inspect <image>
-  string image_id = 1;
+  string image_name = 1;
 }
 
-message WriteRequest {
-  // The image ID, which is the digest of the image's config, found with:
-  //     podman inspect <image>
-  string image_id = 1;
-  Artifact artifact = 2;
+message ReadResponse {
+  repeated Artifact = 1;
 }
-
-message WriteResponse {}
 
 service SociArtifactStore {
-  rpc Read(ReadRequest) returns (stream Artifact);
-  rpc Write(stream WriteRequest) returns (WriteResponse);
+  rpc Read(ReadRequest) returns (ReadResponse);
 }


### PR DESCRIPTION
This adds a new RPC service that has one request: Read which returns pointers to all of the SOCI artifacts required to stream the requested image. These pointers are pointers to data in the CAS, which the client will read from if it needs the data.

**Version bump**:  Minor