### PR TITLE
Don't fail the release assets script if there are assets missing

### DIFF
--- a/tools/check_release_assets_uploaded.py
+++ b/tools/check_release_assets_uploaded.py
@@ -80,7 +80,6 @@ def main():
 
     if len(expected_assets) > 0:
         print(f"Missing assets {expected_assets}", file=sys.stderr)
-        exit(1)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Failing should be reserved if something actually breaks