### PR TITLE
Fix VM execution not reporting an error when wrapped tasks crash

### DIFF
--- a/enterprise/server/remote_execution/vmexec_client/BUILD
+++ b/enterprise/server/remote_execution/vmexec_client/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//server/util/background",
         "//server/util/status",
         "//server/util/tracing",
+        "@org_golang_google_grpc//status",
         "@org_golang_x_sync//errgroup",
     ],
 )


### PR DESCRIPTION
If tasks get killed rather than exiting (`exit_code == -1`), we should populate `cmdResult.Error` (otherwise we're violating the contract that exactly one of `exit_code >= 0` or `error != nil` holds).

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
