### PR TITLE
Make GCS cache writes cancelable

### DIFF
--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -501,10 +501,10 @@ func (g *GCSCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfaces
 		return nil, err
 	}
 	obj := g.bucketHandle.Object(k)
+	ctx, cancel := context.WithCancel(ctx)
 	writer := obj.If(storage.Conditions{DoesNotExist: true}).NewWriter(ctx)
 	setChunkSize(r.GetDigest(), writer)
 	timer := cache_metrics.NewCacheTimer(cacheLabels)
-	ctx, cancel := context.WithCancel(ctx)
 	dwc := &gcsDedupingWriteCloser{
 		cancelFunc:  cancel,
 		WriteCloser: writer,


### PR DESCRIPTION
<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

The `ctx` we pass to the gcs writer must be associated with the `cancel` function we maintain
a refernce to for calling that `cancel` to have any effect.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
