### PR TITLE
GH app: implement webhooks/workflows

### DIFF
--- a/enterprise/app/settings/github_link.tsx
+++ b/enterprise/app/settings/github_link.tsx
@@ -24,6 +24,7 @@ import SimpleModalDialog from "../../../app/components/dialog/simple_modal_dialo
 
 export interface Props {
   user: User;
+  path: string;
 }
 
 export interface State {
@@ -54,6 +55,14 @@ export default class GitHubLink extends React.Component<Props, State> {
   componentDidMount() {
     if (capabilities.config.githubAppEnabled) {
       this.fetchInstallations();
+    }
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.user !== prevProps.user || this.props.path !== prevProps.path) {
+      if (capabilities.config.githubAppEnabled) {
+        this.fetchInstallations();
+      }
     }
   }
 

--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -220,7 +220,9 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                   )}
                   {activeTabId === TabId.OrgGitHub &&
                     (capabilities.github || capabilities.config.githubAppEnabled) &&
-                    this.props.user.canCall("unlinkGitHubAccount") && <GitHubLink user={this.props.user} />}
+                    this.props.user.canCall("unlinkGitHubAccount") && (
+                      <GitHubLink user={this.props.user} path={this.props.path} />
+                    )}
                   {this.props.path === "/settings/org/github/complete-installation" && (
                     <CompleteGitHubAppInstallationDialog user={this.props.user} search={this.props.search} />
                   )}

--- a/enterprise/server/githubapp/BUILD
+++ b/enterprise/server/githubapp/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/githubapp",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/server/webhooks/github",
         "//proto:github_go_proto",
         "//proto:workflow_go_proto",
         "//server/backends/github",

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -7,8 +7,8 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-github/v43/github"
 	"golang.org/x/oauth2"
 
+	gh_webhooks "github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/github"
 	ghpb "github.com/buildbuddy-io/buildbuddy/proto/github"
 	wfpb "github.com/buildbuddy-io/buildbuddy/proto/workflow"
 	gh_oauth "github.com/buildbuddy-io/buildbuddy/server/backends/github"
@@ -112,6 +113,124 @@ func New(env environment.Env) (*GitHubApp, error) {
 	oauth.InstallURL = fmt.Sprintf("%s/installations/new", *publicLink)
 	app.oauth = oauth
 	return app, nil
+}
+
+func (a *GitHubApp) WebhookHandler() http.Handler {
+	return http.HandlerFunc(a.handleWebhookRequest)
+}
+
+func (a *GitHubApp) handleWebhookRequest(w http.ResponseWriter, req *http.Request) {
+	b, err := github.ValidatePayload(req, []byte(*webhookSecret))
+	if err != nil {
+		log.Debugf("Failed to validate webhook payload: %s", err)
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	t := github.WebHookType(req)
+	event, err := github.ParseWebHook(t, b)
+	if err != nil {
+		log.Debugf("Failed to parse webhook payload for %q event: %s", t, err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := a.handleWebhookEvent(req.Context(), event); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	io.WriteString(w, "OK")
+}
+
+func (a *GitHubApp) handleWebhookEvent(ctx context.Context, event any) error {
+	switch event := event.(type) {
+	case *github.InstallationEvent:
+		return a.handleInstallationEvent(ctx, event)
+	default:
+		return a.handleWorkflowEvent(ctx, event)
+	}
+}
+
+func (a *GitHubApp) handleInstallationEvent(ctx context.Context, event *github.InstallationEvent) error {
+	// Only handling uninstall events for now. We proactively handle this event
+	// by removing references to the installation ID in the DB. Note, however,
+	// that we still need to gracefully handle the case where the installation
+	// ID is suddenly no longer valid, since webhook deliveries aren't 100%
+	// reliable.
+	if event.GetAction() != "deleted" {
+		return nil
+	}
+	result := a.env.GetDBHandle().DB(ctx).Exec(`
+		DELETE FROM GitHubAppInstallations
+		WHERE installation_id = ?
+	`, event.GetInstallation().GetID())
+	if result.Error != nil {
+		log.Errorf("Handling GitHub app uninstall event: failed to delete installation %d from DB: %s", event.GetInstallation().GetID(), result.Error)
+		return nil
+	}
+	log.Infof(
+		"Handling GitHub app uninstall event: removed %d installation row(s) for installation %d",
+		result.RowsAffected, event.GetInstallation().GetID())
+	return nil
+}
+
+func (a *GitHubApp) handleWorkflowEvent(ctx context.Context, event any) error {
+	wd, err := gh_webhooks.ParseWebhookData(event)
+	if err != nil {
+		return err
+	}
+	if wd == nil {
+		// Could not parse any webhook data relevant to workflows;
+		// nothing to do.
+		return nil
+	}
+	repoURL, err := gitutil.ParseGitHubRepoURL(wd.TargetRepoURL)
+	if err != nil {
+		return err
+	}
+	row := &struct {
+		InstallationID int64
+		*tables.GitRepository
+	}{}
+	err = a.env.GetDBHandle().DB(ctx).Raw(`
+		SELECT i.installation_id, r.*
+		FROM GitHubAppInstallations i, GitRepositories r
+		WHERE r.repo_url = ?
+		AND i.owner = ?
+		AND i.group_id = r.group_id
+	`, repoURL.String(), repoURL.Owner).Take(row).Error
+	if err != nil {
+		return status.NotFoundError("the repository as well as a BuildBuddy GitHub app installation must be linked to a BuildBuddy org in order to use workflows")
+	}
+	tok, err := a.createInstallationToken(ctx, row.InstallationID)
+	if err != nil {
+		return err
+	}
+	return a.env.GetWorkflowService().HandleRepositoryEvent(
+		ctx, row.GitRepository, wd, tok.GetToken())
+}
+
+func (a *GitHubApp) GetInstallationToken(ctx context.Context, owner string) (string, error) {
+	u, err := perms.AuthenticatedUser(ctx, a.env)
+	if err != nil {
+		return "", err
+	}
+	var installation tables.GitHubAppInstallation
+	err = a.env.GetDBHandle().DB(ctx).Raw(`
+		SELECT *
+		FROM GitHubAppInstallations
+		WHERE group_id = ?
+		AND owner = ?
+	`, u.GetGroupID(), owner).Take(&installation).Error
+	if err != nil {
+		if db.IsRecordNotFound(err) {
+			return "", status.NotFoundErrorf("failed to look up GitHub app installation: %s", err)
+		}
+		return "", err
+	}
+	tok, err := a.createInstallationToken(ctx, installation.InstallationID)
+	if err != nil {
+		return "", err
+	}
+	return tok.GetToken(), nil
 }
 
 func (a *GitHubApp) GetGitHubAppInstallations(ctx context.Context, req *ghpb.GetAppInstallationsRequest) (*ghpb.GetAppInstallationsResponse, error) {
@@ -594,12 +713,6 @@ func (a *GitHubApp) newAuthenticatedClient(ctx context.Context, accessToken stri
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})
 	tc := oauth2.NewClient(ctx, ts)
 	return github.NewClient(tc), nil
-}
-
-func setURLParam(u *url.URL, key, value string) {
-	q := u.Query()
-	q.Set(key, value)
-	u.RawQuery = q.Encode()
 }
 
 // decodePrivateKey decodes a PEM-format RSA private key.

--- a/enterprise/server/webhooks/github/github.go
+++ b/enterprise/server/webhooks/github/github.go
@@ -108,6 +108,10 @@ func (*githubGitProvider) ParseWebhookData(r *http.Request) (*interfaces.Webhook
 	if err != nil {
 		return nil, status.InvalidArgumentErrorf("failed to parse webhook payload: %s", err)
 	}
+	return ParseWebhookData(event)
+}
+
+func ParseWebhookData(event interface{}) (*interfaces.WebhookData, error) {
 	switch event := event.(type) {
 	case *gh.PushEvent:
 		// Ignore branch deletion events.

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1133,7 +1133,7 @@ func isRepositoryWorkflowID(id string) bool {
 func parseRepositoryWorkflowID(id string) (groupID string, repoURL *gitutil.RepoURL, err error) {
 	parts := strings.SplitN(id, ":", 3)
 	if len(parts) != 3 || parts[0] != repoWorkflowIDPrefix || parts[1] == "" || parts[2] == "" {
-		return "", nil, status.InvalidArgumentError("invalid repository ID: expected REPO:<group_id>:<repo_url>")
+		return "", nil, status.InvalidArgumentErrorf("invalid repository ID: expected '%s:<group_id>:<repo_url>'", repoWorkflowIDPrefix)
 	}
 	groupID = parts[1]
 	repoURL, err = gitutil.ParseGitHubRepoURL(parts[2])

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -69,6 +69,12 @@ var (
 	ApprovalRequired = status.PermissionDeniedErrorf("approval required")
 )
 
+const (
+	// A workflow ID prefix that identifies a Workflow as being a
+	// "synthetic" workflow adapted from a GitRepository.
+	repoWorkflowIDPrefix = "WF#GitRepository"
+)
+
 // getWebhookID returns a string that can be used to uniquely identify a webhook.
 func generateWebhookID() (string, error) {
 	u, err := guuid.NewRandom()
@@ -393,17 +399,31 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 		return nil, err
 	}
 
-	// Lookup workflow
-	wf := &tables.Workflow{}
-	err = ws.env.GetDBHandle().DB(ctx).Raw(
-		`SELECT * FROM Workflows WHERE workflow_id = ?`,
-		req.GetWorkflowId(),
-	).Take(wf).Error
-	if err != nil {
-		if db.IsRecordNotFound(err) {
-			return nil, status.NotFoundError("Workflow not found")
+	// Lookup workflow.
+	// If the workflow ID identifies a GitRepository (rather than a legacy
+	// workflow), look up the GitRepository and construct a synthetic Workflow
+	// from it.
+	var wf *tables.Workflow
+	var gitRepository *tables.GitRepository
+	if isRepositoryWorkflowID(req.GetWorkflowId()) {
+		rwf, err := ws.getRepositoryWorkflow(ctx, req.GetWorkflowId())
+		if err != nil {
+			return nil, err
 		}
-		return nil, status.InternalError(err.Error())
+		gitRepository = rwf.GitRepository
+		wf = rwf.Workflow
+	} else {
+		wf = &tables.Workflow{}
+		err = ws.env.GetDBHandle().DB(ctx).Raw(
+			`SELECT * FROM Workflows WHERE workflow_id = ?`,
+			req.GetWorkflowId(),
+		).Take(wf).Error
+		if err != nil {
+			if db.IsRecordNotFound(err) {
+				return nil, status.NotFoundError("Workflow not found")
+			}
+			return nil, status.InternalError(err.Error())
+		}
 	}
 
 	// Authorize workflow access
@@ -422,12 +442,21 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 			return nil, err
 		}
 		wf.InstanceNameSuffix = suffix
-		err = ws.env.GetDBHandle().Transaction(ctx, func(tx *db.DB) error {
-			return tx.Exec(
-				`UPDATE Workflows SET instance_name_suffix = ? WHERE workflow_id = ?`,
+		if gitRepository != nil {
+			err = ws.env.GetDBHandle().DB(ctx).Exec(`
+				UPDATE GitRepositories
+				SET instance_name_suffix = ?
+				WHERE group_id = ? AND repo_url = ?`,
+				wf.InstanceNameSuffix, gitRepository.GroupID, gitRepository.RepoURL,
+			).Error
+		} else {
+			err = ws.env.GetDBHandle().DB(ctx).Exec(`
+				UPDATE Workflows
+				SET instance_name_suffix = ?
+				WHERE workflow_id = ?`,
 				wf.InstanceNameSuffix, wf.WorkflowID,
 			).Error
-		})
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -494,6 +523,38 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 	}
 
 	return &wfpb.ExecuteWorkflowResponse{InvocationId: invocationID}, nil
+}
+
+func (ws *workflowService) getRepositoryWorkflow(ctx context.Context, id string) (*repositoryWorkflow, error) {
+	app := ws.env.GetGitHubApp()
+	if app == nil {
+		return nil, status.UnimplementedError("GitHub App is not configured")
+	}
+	groupID, repoURL, err := parseRepositoryWorkflowID(id)
+	if err != nil {
+		return nil, err
+	}
+	if err := perms.AuthorizeGroupAccess(ctx, ws.env, groupID); err != nil {
+		return nil, err
+	}
+	gitRepository := &tables.GitRepository{}
+	err = ws.env.GetDBHandle().DB(ctx).Raw(`
+		SELECT *
+		FROM GitRepositories
+		WHERE group_id = ?
+		AND repo_url = ?
+	`, groupID, repoURL.String()).Take(gitRepository).Error
+	if err != nil {
+		if db.IsRecordNotFound(err) {
+			return nil, status.NotFoundErrorf("repo %q not found", repoURL)
+		}
+		return nil, status.InternalErrorf("failed to look up repo %q: %s", repoURL, err)
+	}
+	token, err := app.GetInstallationToken(ctx, repoURL.Owner)
+	if err != nil {
+		return nil, err
+	}
+	return gitRepositoryWorkflow(gitRepository, token), nil
 }
 
 func (ws *workflowService) waitForWorkflowInvocationCreated(ctx context.Context, executionID, invocationID string) error {
@@ -854,7 +915,21 @@ func (ws *workflowService) isTrustedCommit(ctx context.Context, gitProvider inte
 	return gitProvider.IsTrusted(ctx, wf.AccessToken, wd.TargetRepoURL, wd.PullRequestAuthor)
 }
 
-func (ws *workflowService) startWorkflow(webhookID string, r *http.Request) error {
+func (ws *workflowService) HandleRepositoryEvent(ctx context.Context, repo *tables.GitRepository, wd *interfaces.WebhookData, accessToken string) error {
+	u, err := url.Parse(repo.RepoURL)
+	if err != nil {
+		log.Errorf("Failed to parse repo URL %s", u.String())
+		return status.InvalidArgumentError("failed to parse repo URL")
+	}
+	provider, err := ws.providerForRepo(u)
+	if err != nil {
+		return err
+	}
+	wf := gitRepositoryWorkflow(repo, accessToken).Workflow
+	return ws.startWorkflow(ctx, provider, wd, wf)
+}
+
+func (ws *workflowService) startLegacyWorkflow(webhookID string, r *http.Request) error {
 	ctx := r.Context()
 	if err := ws.checkStartWorkflowPreconditions(ctx); err != nil {
 		return err
@@ -877,6 +952,10 @@ func (ws *workflowService) startWorkflow(webhookID string, r *http.Request) erro
 	if err != nil {
 		return status.WrapErrorf(err, "failed to lookup workflow for webhook ID %q", webhookID)
 	}
+	return ws.startWorkflow(ctx, gitProvider, wd, wf)
+}
+
+func (ws *workflowService) startWorkflow(ctx context.Context, gitProvider interfaces.GitProvider, wd *interfaces.WebhookData, wf *tables.Workflow) error {
 	isTrusted, err := ws.isTrustedCommit(ctx, gitProvider, wf, wd)
 	if err != nil {
 		return err
@@ -1016,12 +1095,52 @@ func (ws *workflowService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	webhookID := workflowMatch[1]
-	if err := ws.startWorkflow(webhookID, r); err != nil {
+	if err := ws.startLegacyWorkflow(webhookID, r); err != nil {
 		log.Errorf("Failed to start workflow (webhook ID: %q): %s", webhookID, err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	w.Write([]byte("OK"))
+}
+
+type repositoryWorkflow struct {
+	GitRepository *tables.GitRepository
+	Workflow      *tables.Workflow
+}
+
+// Adapts a GitRepository to a legacy Workflow struct.
+func gitRepositoryWorkflow(repo *tables.GitRepository, accessToken string) *repositoryWorkflow {
+	// Construct an artificial workflow ID which identifies this workflow with
+	// the original GitRepository row.
+	repositoryID := fmt.Sprintf("%s:%s:%s", repoWorkflowIDPrefix, repo.GroupID, repo.RepoURL)
+	wf := &tables.Workflow{
+		WorkflowID:         repositoryID,
+		UserID:             repo.UserID,
+		GroupID:            repo.GroupID,
+		Perms:              repo.Perms,
+		RepoURL:            repo.RepoURL,
+		InstanceNameSuffix: repo.InstanceNameSuffix,
+		AccessToken:        accessToken,
+	}
+	return &repositoryWorkflow{GitRepository: repo, Workflow: wf}
+}
+
+func isRepositoryWorkflowID(id string) bool {
+	_, _, err := parseRepositoryWorkflowID(id)
+	return err == nil
+}
+
+func parseRepositoryWorkflowID(id string) (groupID string, repoURL *gitutil.RepoURL, err error) {
+	parts := strings.SplitN(id, ":", 3)
+	if len(parts) != 3 || parts[0] != repoWorkflowIDPrefix || parts[1] == "" || parts[2] == "" {
+		return "", nil, status.InvalidArgumentError("invalid repository ID: expected REPO:<group_id>:<repo_url>")
+	}
+	groupID = parts[1]
+	repoURL, err = gitutil.ParseGitHubRepoURL(parts[2])
+	if err != nil {
+		return "", nil, status.InvalidArgumentErrorf("invalid repository ID: failed to parse repo URL: %s", err)
+	}
+	return groupID, repoURL, nil
 }
 
 func withEnvOverrides(ctx context.Context, env []*repb.Command_EnvironmentVariable) context.Context {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -456,6 +456,10 @@ type WorkflowService interface {
 	GetRepos(ctx context.Context, req *wfpb.GetReposRequest) (*wfpb.GetReposResponse, error)
 	ServeHTTP(w http.ResponseWriter, r *http.Request)
 
+	// HandleRepositoryEvent handles a webhook event corresponding to the given
+	// GitRepository by initiating any relevant workflow actions.
+	HandleRepositoryEvent(ctx context.Context, repo *tables.GitRepository, wd *WebhookData, accessToken string) error
+
 	// GetLinkedWorkflows returns any workflows linked with the given repo access
 	// token.
 	GetLinkedWorkflows(ctx context.Context, accessToken string) ([]string, error)
@@ -476,6 +480,14 @@ type GitHubApp interface {
 	UnlinkGitHubRepo(context.Context, *ghpb.UnlinkRepoRequest) (*ghpb.UnlinkRepoResponse, error)
 
 	GetAccessibleGitHubRepos(context.Context, *ghpb.GetAccessibleReposRequest) (*ghpb.GetAccessibleReposResponse, error)
+
+	// GetInstallationToken returns an installation token for the installation
+	// associated with the authenticated group ID and the given installation
+	// owner (GitHub username or org name).
+	GetInstallationToken(ctx context.Context, owner string) (string, error)
+
+	// WebhookHandler returns the GitHub webhook HTTP handler.
+	WebhookHandler() http.Handler
 
 	// OAuthHandler returns the OAuth flow HTTP handler.
 	OAuthHandler() http.Handler

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -382,7 +382,7 @@ func StartAndRunServices(env environment.Env) {
 		mux.Handle("/webhooks/workflow/", interceptors.WrapExternalHandler(env, wfs))
 	}
 	if gha := env.GetGitHubApp(); gha != nil {
-		// TODO: handle webhooks; handle new installation redirect endpoint
+		mux.Handle("/webhooks/github/app", interceptors.WrapExternalHandler(env, gha.WebhookHandler()))
 		mux.Handle("/auth/github/app/link/", interceptors.WrapAuthenticatedExternalHandler(env, gha.OAuthHandler()))
 	}
 


### PR DESCRIPTION
Adds all the wiring needed to listen to webhooks from GitHub, validate the webhook secret, and handle webhook events.

The app handles the following events:
* `installation.deleted` (meta-event): proactively unlinks any BB-linked installation from the `GitHubAppInstallation` table, if one exists 
* `push`, `pull_request`: same behavior as before (invoke any workflows as applicable)

A few other related changes for getting workflows working E2E:
* Sets up the plumbing so that the build status reporter can get an installation access token based on REPO_URL invocation metadata + authenticated group ID, and report statuses correctly based on that.
* Assigns a "synthetic" workflow ID to new GitRepository-based workflows so that we can reuse all the existing code that expects a `Workflow`. The workflow ID looks like `WF#GitRepository:<group_id>:<repo_url>`, and we can parse this ID and look up the related GitRepository row from the DB based on this. This also lets us know to use the instance_name_suffix from the `GitRepository` instead of the `Workflow`.
* Fix a small UI bug where installations wouldn't refresh after picking the group to link via the group picker modal.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
