### PR TITLE
Fix some conditional logic re. github legacy OAuth-only app

### DIFF
--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -125,16 +125,17 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                     Members
                   </SettingsTab>
                 )}
-                {router.canAccessOrgGitHubLinkPage(this.props.user) && capabilities.github && (
-                  <SettingsTab id={TabId.OrgGitHub} activeTabId={activeTabId}>
-                    <span>GitHub link</span>
-                    {/* If the user has a group-level GitHub link and the new GitHub App is
+                {router.canAccessOrgGitHubLinkPage(this.props.user) &&
+                  (capabilities.github || capabilities.config.githubAppEnabled) && (
+                    <SettingsTab id={TabId.OrgGitHub} activeTabId={activeTabId}>
+                      <span>GitHub link</span>
+                      {/* If the user has a group-level GitHub link and the new GitHub App is
                         enabled, show a deprecation alert. */}
-                    {capabilities.config.githubAppEnabled && this.props.user.selectedGroup.githubLinked && (
-                      <AlertCircle className="icon orange" />
-                    )}
-                  </SettingsTab>
-                )}
+                      {capabilities.config.githubAppEnabled && this.props.user.selectedGroup.githubLinked && (
+                        <AlertCircle className="icon orange" />
+                      )}
+                    </SettingsTab>
+                  )}
                 <SettingsTab id={TabId.OrgApiKeys} activeTabId={activeTabId}>
                   Org API keys
                 </SettingsTab>
@@ -218,7 +219,7 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                     </>
                   )}
                   {activeTabId === TabId.OrgGitHub &&
-                    capabilities.github &&
+                    (capabilities.github || capabilities.config.githubAppEnabled) &&
                     this.props.user.canCall("unlinkGitHubAccount") && <GitHubLink user={this.props.user} />}
                   {this.props.path === "/settings/org/github/complete-installation" && (
                     <CompleteGitHubAppInstallationDialog user={this.props.user} search={this.props.search} />

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -12,7 +12,7 @@ message FrontendConfig {
   // Whether to default to Dense UI mode.
   bool default_to_dense_mode = 3;
 
-  // Whether Github linking is enabled.
+  // Whether the GitHub legacy OAuth-only app is enabled.
   bool github_enabled = 4;
 
   // Whether anonymous usage is enabled.

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -136,7 +136,7 @@ func legacyClientSecret() string {
 }
 
 func IsLegacyOAuthAppEnabled() bool {
-	if *clientID == "" && legacyClientSecret() == "" && *accessToken == "" {
+	if *clientID == "" || legacyClientSecret() == "" {
 		return false
 	}
 	return true
@@ -432,12 +432,16 @@ func (c *GithubClient) CreateStatus(ctx context.Context, ownerRepo string, commi
 }
 
 func (c *GithubClient) populateTokenIfNecessary(ctx context.Context) error {
-	if c.githubToken != "" || !IsLegacyOAuthAppEnabled() {
+	if c.githubToken != "" {
 		return nil
 	}
 
 	if *accessToken != "" {
 		c.githubToken = *accessToken
+		return nil
+	}
+
+	if !IsLegacyOAuthAppEnabled() {
 		return nil
 	}
 


### PR DESCRIPTION
* `IsLegacyOAuthAppEnabled` should not return true if the server-level `--github.access_token` is the only github-related flag that is set. Otherwise, we'll show broken account link functionality in the UI.
* UI should show the org-level GitHub link page if the GitHub app is enabled but the legacy OAuth app is disabled.

---

**Version bump**: Patch
