### PR TITLE
blobstore/util: wrap all blobstore impl with prefix

### DIFF
--- a/server/backends/blobstore/BUILD
+++ b/server/backends/blobstore/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//server/backends/blobstore/azure",
         "//server/backends/blobstore/disk",
         "//server/backends/blobstore/gcs",
+        "//server/backends/blobstore/util",
         "//server/environment",
         "//server/interfaces",
         "//server/util/log",

--- a/server/backends/blobstore/aws/aws.go
+++ b/server/backends/blobstore/aws/aws.go
@@ -174,7 +174,7 @@ func (a *AwsS3BlobStore) download(ctx context.Context, blobName string) ([]byte,
 	ctx, spn := tracing.StartSpan(ctx)
 	_, err := a.downloader.DownloadWithContext(ctx, buff, &s3.GetObjectInput{
 		Bucket: a.bucket,
-		Key:    aws.String(util.BlobPath(blobName)),
+		Key:    aws.String(blobName),
 	})
 	spn.End()
 
@@ -203,7 +203,7 @@ func (a *AwsS3BlobStore) WriteBlob(ctx context.Context, blobName string, data []
 func (a *AwsS3BlobStore) upload(ctx context.Context, blobName string, compressedData []byte) (int, error) {
 	uploadParams := &s3manager.UploadInput{
 		Bucket: a.bucket,
-		Key:    aws.String(util.BlobPath(blobName)),
+		Key:    aws.String(blobName),
 		Body:   bytes.NewReader(compressedData),
 	}
 	ctx, spn := tracing.StartSpan(ctx)
@@ -224,7 +224,7 @@ func (a *AwsS3BlobStore) DeleteBlob(ctx context.Context, blobName string) error 
 func (a *AwsS3BlobStore) delete(ctx context.Context, blobName string) error {
 	deleteParams := &s3.DeleteObjectInput{
 		Bucket: a.bucket,
-		Key:    aws.String(util.BlobPath(blobName)),
+		Key:    aws.String(blobName),
 	}
 
 	ctx, spn := tracing.StartSpan(ctx)
@@ -242,7 +242,7 @@ func (a *AwsS3BlobStore) delete(ctx context.Context, blobName string) error {
 func (a *AwsS3BlobStore) BlobExists(ctx context.Context, blobName string) (bool, error) {
 	params := &s3.HeadObjectInput{
 		Bucket: a.bucket,
-		Key:    aws.String(util.BlobPath(blobName)),
+		Key:    aws.String(blobName),
 	}
 
 	ctx, spn := tracing.StartSpan(ctx)
@@ -273,7 +273,7 @@ func (a *AwsS3BlobStore) Writer(ctx context.Context, blobName string) (interface
 			ctx,
 			&s3manager.UploadInput{
 				Bucket: a.bucket,
-				Key:    aws.String(util.BlobPath(blobName)),
+				Key:    aws.String(blobName),
 				Body:   pr,
 			},
 		)

--- a/server/backends/blobstore/azure/azure.go
+++ b/server/backends/blobstore/azure/azure.go
@@ -101,7 +101,7 @@ func (z *AzureBlobStore) createContainerIfNotExists(ctx context.Context) error {
 }
 
 func (z *AzureBlobStore) ReadBlob(ctx context.Context, blobName string) ([]byte, error) {
-	blobURL := z.containerURL.NewBlockBlobURL(util.BlobPath(blobName))
+	blobURL := z.containerURL.NewBlockBlobURL(blobName)
 	response, err := blobURL.Download(ctx, 0 /*=offset*/, azblob.CountToEnd, azblob.BlobAccessConditions{}, false /*=rangeGetContentMD5*/, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
 		if z.isAzureError(err, azblob.ServiceCodeBlobNotFound) {
@@ -130,7 +130,7 @@ func (z *AzureBlobStore) WriteBlob(ctx context.Context, blobName string, data []
 	}
 	n := len(compressedData)
 	start := time.Now()
-	blobURL := z.containerURL.NewBlockBlobURL(util.BlobPath(blobName))
+	blobURL := z.containerURL.NewBlockBlobURL(blobName)
 	ctx, spn := tracing.StartSpan(ctx)
 	_, err = azblob.UploadBufferToBlockBlob(ctx, compressedData, blobURL, azblob.UploadToBlockBlobOptions{})
 	spn.End()
@@ -140,7 +140,7 @@ func (z *AzureBlobStore) WriteBlob(ctx context.Context, blobName string, data []
 
 func (z *AzureBlobStore) DeleteBlob(ctx context.Context, blobName string) error {
 	start := time.Now()
-	blobURL := z.containerURL.NewBlockBlobURL(util.BlobPath(blobName))
+	blobURL := z.containerURL.NewBlockBlobURL(blobName)
 	ctx, spn := tracing.StartSpan(ctx)
 	_, err := blobURL.Delete(ctx, azblob.DeleteSnapshotsOptionNone, azblob.BlobAccessConditions{})
 	spn.End()
@@ -149,7 +149,7 @@ func (z *AzureBlobStore) DeleteBlob(ctx context.Context, blobName string) error 
 }
 
 func (z *AzureBlobStore) BlobExists(ctx context.Context, blobName string) (bool, error) {
-	blobURL := z.containerURL.NewBlockBlobURL(util.BlobPath(blobName))
+	blobURL := z.containerURL.NewBlockBlobURL(blobName)
 	ctx, spn := tracing.StartSpan(ctx)
 	defer spn.End()
 	if _, err := blobURL.GetProperties(ctx, azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{}); err != nil {
@@ -175,7 +175,7 @@ func (z *AzureBlobStore) Writer(ctx context.Context, blobName string) (interface
 		_, err := azblob.UploadStreamToBlockBlob(
 			ctx,
 			pr,
-			z.containerURL.NewBlockBlobURL(util.BlobPath(blobName)),
+			z.containerURL.NewBlockBlobURL(blobName),
 			azblob.UploadStreamToBlockBlobOptions{},
 		)
 		errch <- err

--- a/server/backends/blobstore/blobstore.go
+++ b/server/backends/blobstore/blobstore.go
@@ -7,6 +7,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/backends/blobstore/azure"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/blobstore/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/blobstore/gcs"
+	"github.com/buildbuddy-io/buildbuddy/server/backends/blobstore/util"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -14,6 +15,15 @@ import (
 
 // Returns whatever blobstore is specified in the config.
 func GetConfiguredBlobstore(env environment.Env) (interfaces.Blobstore, error) {
+	bs, err := getBlobstore(env)
+	if err != nil {
+		return bs, err
+	}
+
+	return util.NewDefaultPrefixBlobstore(bs), nil
+}
+
+func getBlobstore(env environment.Env) (interfaces.Blobstore, error) {
 	log.Debug("Configuring blobstore")
 	ctx := env.GetServerContext()
 	if gcs.UseGCSBlobStore() {

--- a/server/backends/blobstore/disk/BUILD
+++ b/server/backends/blobstore/disk/BUILD
@@ -21,6 +21,7 @@ go_test(
     embed = [":disk"],
     deps = [
         "//server/backends/blobstore/util",
+        "//server/interfaces",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/backends/blobstore/disk/disk.go
+++ b/server/backends/blobstore/disk/disk.go
@@ -53,7 +53,7 @@ func (d *DiskBlobStore) blobPath(blobName string) (string, error) {
 	if strings.Contains(blobName, "..") {
 		return "", fmt.Errorf("blobName (%s) must not contain ../", blobName)
 	}
-	return filepath.Join(d.rootDir, util.BlobPath(blobName)), nil
+	return filepath.Join(d.rootDir, blobName), nil
 }
 
 func (d *DiskBlobStore) WriteBlob(ctx context.Context, blobName string, data []byte) (int, error) {

--- a/server/backends/blobstore/disk/disk_test.go
+++ b/server/backends/blobstore/disk/disk_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/backends/blobstore/util"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,54 +15,87 @@ func TestDiskBlobStore(t *testing.T) {
 		name             string
 		prefix, blobName string
 		blob             []byte
+		useWriter        bool
 	}{
 		{
-			"WithoutPrefix",
-			"",
-			"test_blob",
-			[]byte("test"),
+			name:      "WithoutPrefix",
+			prefix:    "",
+			blobName:  "test_blob",
+			blob:      []byte("test"),
+			useWriter: false,
 		},
 		{
-			"WithPrefix",
-			"my_prefix",
-			"test_blob",
-			[]byte("test"),
+			name:      "WithPrefix",
+			prefix:    "my_prefix",
+			blobName:  "test_blob",
+			blob:      []byte("test"),
+			useWriter: false,
+		},
+		{
+			name:      "WithoutPrefixUseWriter",
+			prefix:    "",
+			blobName:  "test_blob",
+			blob:      []byte("test"),
+			useWriter: true,
+		},
+		{
+			name:      "WithPrefixUseWriter",
+			prefix:    "my_prefix",
+			blobName:  "test_blob",
+			blob:      []byte("test"),
+			useWriter: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			util.BlobPath = func(blobName string) string {
-				return filepath.Join(tc.prefix, blobName)
-			}
-
 			originalRootDir := *rootDirectory
 			*rootDirectory = t.TempDir()
 			t.Cleanup(func() {
 				*rootDirectory = originalRootDir
 			})
 
-			dbs, err := NewDiskBlobStore()
+			var bs interfaces.Blobstore
+			bs, err := NewDiskBlobStore()
 			require.NoError(t, err)
+			if tc.prefix != "" {
+				bs = util.NewPrefixBlobstore(bs, tc.prefix)
+			}
 
 			ctx := context.Background()
-			n, err := dbs.WriteBlob(ctx, tc.blobName, tc.blob)
-			require.NoError(t, err)
-			require.Greater(t, n, 0)
+			if tc.useWriter {
+				w, err := bs.Writer(ctx, tc.blobName)
+				require.NoError(t, err)
+				n, err := w.Write(tc.blob)
+				require.NoError(t, err)
+				require.Greater(t, n, 0)
+
+				// The blob should not exist until we commit.
+				exist, err := bs.BlobExists(ctx, tc.blobName)
+				require.NoError(t, err)
+				require.True(t, !exist)
+
+				require.NoError(t, w.Commit())
+				require.NoError(t, w.Close())
+			} else {
+				n, err := bs.WriteBlob(ctx, tc.blobName, tc.blob)
+				require.NoError(t, err)
+				require.Greater(t, n, 0)
+			}
 
 			path := filepath.Join(*rootDirectory, tc.prefix, tc.blobName)
 			require.FileExists(t, path)
 
-			exist, err := dbs.BlobExists(ctx, tc.blobName)
+			exist, err := bs.BlobExists(ctx, tc.blobName)
 			require.NoError(t, err)
 			require.True(t, exist)
 
-			b, err := dbs.ReadBlob(ctx, tc.blobName)
+			b, err := bs.ReadBlob(ctx, tc.blobName)
 			require.NoError(t, err)
 			require.Equal(t, b, tc.blob)
 
-			err = dbs.DeleteBlob(ctx, tc.blobName)
+			err = bs.DeleteBlob(ctx, tc.blobName)
 			require.NoError(t, err)
 
-			exist, err = dbs.BlobExists(ctx, tc.blobName)
+			exist, err = bs.BlobExists(ctx, tc.blobName)
 			require.NoError(t, err)
 			require.False(t, exist)
 		})

--- a/server/backends/blobstore/gcs/gcs.go
+++ b/server/backends/blobstore/gcs/gcs.go
@@ -82,7 +82,7 @@ func (g *GCSBlobStore) createBucketIfNotExists(ctx context.Context, bucketName s
 }
 
 func (g *GCSBlobStore) ReadBlob(ctx context.Context, blobName string) ([]byte, error) {
-	reader, err := g.bucketHandle.Object(util.BlobPath(blobName)).NewReader(ctx)
+	reader, err := g.bucketHandle.Object(blobName).NewReader(ctx)
 	if err != nil {
 		if err == storage.ErrObjectNotExist {
 			return nil, status.NotFoundError(err.Error())
@@ -98,7 +98,7 @@ func (g *GCSBlobStore) ReadBlob(ctx context.Context, blobName string) ([]byte, e
 }
 
 func (g *GCSBlobStore) WriteBlob(ctx context.Context, blobName string, data []byte) (int, error) {
-	writer := g.bucketHandle.Object(util.BlobPath(blobName)).NewWriter(ctx)
+	writer := g.bucketHandle.Object(blobName).NewWriter(ctx)
 	defer writer.Close()
 	compressedData, err := util.Compress(data)
 	if err != nil {
@@ -115,7 +115,7 @@ func (g *GCSBlobStore) WriteBlob(ctx context.Context, blobName string, data []by
 func (g *GCSBlobStore) DeleteBlob(ctx context.Context, blobName string) error {
 	start := time.Now()
 	ctx, spn := tracing.StartSpan(ctx)
-	err := g.bucketHandle.Object(util.BlobPath(blobName)).Delete(ctx)
+	err := g.bucketHandle.Object(blobName).Delete(ctx)
 	spn.End()
 	util.RecordDeleteMetrics(gcsLabel, start, err)
 	if err == storage.ErrObjectNotExist {
@@ -126,7 +126,7 @@ func (g *GCSBlobStore) DeleteBlob(ctx context.Context, blobName string) error {
 
 func (g *GCSBlobStore) BlobExists(ctx context.Context, blobName string) (bool, error) {
 	ctx, spn := tracing.StartSpan(ctx)
-	_, err := g.bucketHandle.Object(util.BlobPath(blobName)).Attrs(ctx)
+	_, err := g.bucketHandle.Object(blobName).Attrs(ctx)
 	spn.End()
 	if err == storage.ErrObjectNotExist {
 		return false, nil
@@ -139,7 +139,7 @@ func (g *GCSBlobStore) BlobExists(ctx context.Context, blobName string) (bool, e
 
 func (g *GCSBlobStore) Writer(ctx context.Context, blobName string) (interfaces.CommittedWriteCloser, error) {
 	ctx, cancel := context.WithCancel(ctx)
-	bw := g.bucketHandle.Object(util.BlobPath(blobName)).NewWriter(ctx)
+	bw := g.bucketHandle.Object(blobName).NewWriter(ctx)
 
 	zw := util.NewCompressWriter(bw)
 	cwc := ioutil.NewCustomCommitWriteCloser(zw)

--- a/server/backends/blobstore/util/BUILD
+++ b/server/backends/blobstore/util/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/backends/blobstore/util",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/interfaces",
         "//server/metrics",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_grpc//status",


### PR DESCRIPTION
Introduce PrefixBlobstore to wrap arround all existing blobstore
implementations to provide prefix support out-of-the-box.  This should
help us avoid the overhead of having to call util.BlobPath explicitly in
each blobstore implementation.

until.BlobPath is kept exported so that we could mock it during testing.

This may conflict with #3717 and require a merge conflict resolve if
this is merged after.
In which case, author could re-use this comby command for refactoring.

```bash
comby 'util.BlobPath(:[1])' ':[1]' server/backends/blobstore/**/*.go -exclude server/backends/blobstore/util/
```

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
