### PR TITLE
runner_test: fix timeout on darwin

### DIFF
--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -336,10 +336,10 @@ func TestRunnerPool_Shutdown_RunnersReturnRetriableOrNilError(t *testing.T) {
 	env := newTestEnv(t)
 	ctx := withAuthenticatedUser(t, context.Background(), env, "US1")
 
-	// Run 100 trials where we create a pool that runs 50 tasks using runner
+	// Run 30 trials where we create a pool that runs 50 tasks using runner
 	// recycling, shutting down the pool after roughly half of the tasks have been
 	// started.
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 30; i++ {
 		pool := newRunnerPool(t, env, noLimitsCfg)
 		numTasks := 50
 		tasksStarted := make(chan struct{}, numTasks)


### PR DESCRIPTION
After investigation in https://github.com/buildbuddy-io/buildbuddy/pull/3701,
it's shown that on average, Shutdown_RunnersReturnRetriableOrNilError
could only finish 40+ trials out of 100 on Intel Mac. This is after we
have sharded the runner_test action to the exact test count (18) so that
each test func is run on it's own shard with dedicated CPU.

The root cause of the slowness is with how the test is constructed and
run. Our test would attempt to spin up 50 execution tasks asynchronously
in separate goroutines. Then in the main goroutune, wait until the task
count hit 50/2=25 and shutdown the runner pool arruptedly to check for
error. Repeat this trial 100 times and ensure that in total it took less
than 60 seconds to complete.

This works well if the test execution is provided with a generous
amount of CPU to manage 50+ goroutines, but on our CI, the test is given
a limited amount of CPU to work with. On Darwin CI, the test is often
executed in parallel with other tests, giving it less resources to
manage multiple goroutines. This caused each iteration(trial) to take more
than 1 second to complete, making the cost of 100 trials to be beyond the
60 seconds timeout.

Upon tagging the test with `exclusive`, the shard running this test
would finish 100 trials in 44 seconds.

Reduce the trial count on Darwin to 30 to avoid timeout.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
