### PR TITLE
Add support for rendering `coverage` runs

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -194,6 +194,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
 
       return (
         <TargetComponent
+          model={this.state.model}
           invocationId={this.props.invocationId}
           hash={this.props.hash}
           files={this.state.model.getFiles(completed?.buildEvent)}

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -2035,3 +2035,15 @@ code .comment {
   width: 0.8em;
   margin-left: 0.2em;
 }
+
+.coverage-source {
+  font-weight: 600;
+}
+
+.coverage-percent {
+  font-weight: 700;
+}
+
+.coverage-details {
+  color: #aaa;
+}

--- a/app/target/BUILD
+++ b/app/target/BUILD
@@ -10,9 +10,11 @@ ts_library(
         "//app/auth:auth_service",
         "//app/components/button:link_button",
         "//app/format",
+        "//app/invocation:invocation_model",
         "//app/router",
         "//app/target:action_card",
         "//app/target:target_artifacts_card",
+        "//app/target:target_test_coverage_card",
         "//app/target:target_test_document_card",
         "//app/target:target_test_log_card",
         "//app/util:clipboard",
@@ -109,5 +111,21 @@ ts_library(
         "@npm//lucide-react",
         "@npm//react",
         "@npm//tslib",
+    ],
+)
+
+ts_library(
+    name = "target_test_coverage_card",
+    srcs = ["target_test_coverage_card.tsx"],
+    deps = [
+        "//app/format",
+        "//app/invocation:invocation_model",
+        "//app/service:rpc_service",
+        "//app/util:color",
+        "//app/util:lcov",
+        "//proto:invocation_ts_proto",
+        "@npm//@types/react",
+        "@npm//lucide-react",
+        "@npm//react",
     ],
 )

--- a/app/target/target.tsx
+++ b/app/target/target.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import TargetTestLogCardComponent from "./target_test_log_card";
 import TargetTestDocumentCardComponent from "./target_test_document_card";
+import TargetTestCoverageCardComponent from "./target_test_coverage_card";
 import TargetArtifactsCardComponent from "./target_artifacts_card";
 import ActionCardComponent from "./action_card";
 import router from "../router/router";
@@ -14,6 +15,7 @@ import { copyToClipboard } from "../util/clipboard";
 import alert_service from "../alert/alert_service";
 import { timestampToDateWithFallback } from "../util/proto";
 import { OutlinedLinkButton } from "../components/button/link_button";
+import InvocationModel from "../invocation/invocation_model";
 
 interface Props {
   invocationId: string;
@@ -21,6 +23,7 @@ interface Props {
   repo?: string;
   targetLabel: string;
   hash: string;
+  model: InvocationModel;
 
   files: build_event_stream.IFile[];
   configuredEvent: invocation.InvocationEvent;
@@ -277,6 +280,7 @@ export default class TargetComponent extends React.Component<Props> {
                   invocationId={this.props.invocationId}
                   testResult={result}
                 />
+                <TargetTestCoverageCardComponent model={this.props.model} testResult={result} />
               </span>
             ))}
           {actionEvents.map((action) => (

--- a/app/target/target_test_coverage_card.tsx
+++ b/app/target/target_test_coverage_card.tsx
@@ -1,0 +1,128 @@
+import { Percent } from "lucide-react";
+import React from "react";
+
+import { invocation } from "../../proto/invocation_ts_proto";
+import format from "../format/format";
+import InvocationModel from "../invocation/invocation_model";
+import rpcService from "../service/rpc_service";
+import { percentageColor } from "../util/color";
+import { parseLcov } from "../util/lcov";
+
+interface Props {
+  testResult: invocation.InvocationEvent;
+  model: InvocationModel;
+}
+
+interface State {
+  lcov: any[];
+}
+
+export default class TargetTestCoverageCardComponent extends React.Component<Props> {
+  state: State = {
+    lcov: [],
+  };
+
+  componentDidMount() {
+    this.fetchTestXML();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.testResult !== prevProps.testResult) {
+      this.fetchTestXML();
+    }
+  }
+
+  fetchTestXML() {
+    let testXMLUrl = this.props.testResult.buildEvent.testResult.testActionOutput.find(
+      (log: any) => log.name == "test.lcov"
+    )?.uri;
+
+    if (!testXMLUrl) {
+      this.setState({ lcov: null });
+      return;
+    }
+
+    if (!testXMLUrl.startsWith("bytestream://")) {
+      this.setState({ lcov: null });
+      return;
+    }
+
+    rpcService
+      .fetchBytestreamFile(testXMLUrl, this.props.model.getId())
+      .then((contents: string) => {
+        this.setState({ lcov: parseLcov(contents) });
+      })
+      .catch(() => {
+        this.setState({
+          lcov: null,
+        });
+      });
+  }
+
+  render() {
+    let testXMLUrl = this.props.testResult.buildEvent.testResult.testActionOutput.find(
+      (log: any) => log.name == "test.lcov"
+    )?.uri;
+
+    let error = undefined;
+    if (!testXMLUrl) {
+      error = (
+        <>
+          To see test coverage data, run{" "}
+          <span className="inline-code">
+            bazel coverage {this.props.testResult?.buildEvent?.id?.testResult?.label || ""}
+          </span>
+        </>
+      );
+    }
+
+    if (testXMLUrl && !testXMLUrl.startsWith("bytestream://")) {
+      error = <>To see test coverage data, enable remote caching.</>;
+    }
+
+    let repoPath = "";
+    if (this.props.model.getRepo()?.includes("github.com")) {
+      repoPath = `/code/${format.formatGitUrl(this.props.model.getRepo())}/`;
+    }
+
+    return (
+      <div className="card">
+        <Percent className="icon purple" />
+        <div className="content">
+          <div className="title">Test coverage</div>
+          <div className="details">
+            {error}
+            {!error &&
+              this.state.lcov &&
+              this.state.lcov.length > 0 &&
+              this.state.lcov
+                .filter((record) => Boolean(record.sourceFile))
+                .map((record) => {
+                  const percent = (record.numLinesHit * 1.0) / record.numLinesFound;
+                  return (
+                    <div className="coverage-record">
+                      <a
+                        href={
+                          repoPath
+                            ? `${repoPath}${
+                                record.sourceFile
+                              }?lcov=${testXMLUrl}&invocation_id=${this.props.model.getId()}&commit=${this.props.model.getCommit()}`
+                            : "#"
+                        }>
+                        <span className="coverage-source">{record.sourceFile}</span>:{" "}
+                        <span className="coverage-percent" style={{ color: percentageColor(percent) }}>
+                          {format.percent(percent)}%
+                        </span>{" "}
+                        <span className="coverage-details">
+                          ({record.numLinesHit} hits / {record.numLinesFound} lines)
+                        </span>
+                      </a>
+                    </div>
+                  );
+                })}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/app/util/BUILD
+++ b/app/util/BUILD
@@ -108,3 +108,8 @@ ts_library(
         "@npm//long",
     ],
 )
+
+ts_library(
+    name = "lcov",
+    srcs = ["lcov.ts"],
+)

--- a/app/util/color.ts
+++ b/app/util/color.ts
@@ -183,3 +183,14 @@ function hash(value: string) {
   }
   return hash;
 }
+
+/**
+ * Returns a color between red and green based on a percentage value between 0 and 1.
+ *
+ * @param value the percentage value between 0 and 1
+ * @returns a color between red and green
+ */
+export function percentageColor(value: number) {
+  var hue = (value * 120).toString(10);
+  return ["hsl(", hue, ",75%,50%)"].join("");
+}

--- a/app/util/lcov.ts
+++ b/app/util/lcov.ts
@@ -2,62 +2,62 @@
  * Takes an lcov file an input and returns a structured lcov object
  */
 export function parseLcov(input: string) {
-    const records = input.split("end_of_record");
-    let items = [];
-    for (let record of records) {
-      let item = {
-        sourceFile: "",
-        testName: "",
-        functionName: "",
-        numFunctionsFound: 0,
-        numFunctionsHit: 0,
-        branchData: [] as string[],
-        branchesFound: 0,
-        branchesHit: 0,
-        data: [] as string[],
-        numLinesFound: 0,
-        numLinesHit: 0,
-      };
-      const lines = record.split("\n");
-      for (let line of lines) {
-        const part = line.split(":");
-        switch (part[0]) {
-          case "TN":
-            item.testName = part[1];
-            break;
-          case "SF":
-            item.sourceFile = part[1];
-            break;
-          case "FN":
-            item.functionName = part[1];
-            break;
-          case "FNF":
-            item.numFunctionsFound = parseInt(part[1]);
-            break;
-          case "FNH":
-            item.numFunctionsHit = parseInt(part[1]);
-            break;
-          case "BRDA":
-            item.branchData.push(part[1]);
-            break;
-          case "BRF":
-            item.branchesFound = parseInt(part[1]);
-            break;
-          case "BRH":
-            item.branchesHit = parseInt(part[1]);
-            break;
-          case "DA":
-            item.data.push(part[1]);
-            break;
-          case "LF":
-            item.numLinesFound = parseInt(part[1]);
-            break;
-          case "LH":
-            item.numLinesHit = parseInt(part[1]);
-            break;
-        }
+  const records = input.split("end_of_record");
+  let items = [];
+  for (let record of records) {
+    let item = {
+      sourceFile: "",
+      testName: "",
+      functionName: "",
+      numFunctionsFound: 0,
+      numFunctionsHit: 0,
+      branchData: [] as string[],
+      branchesFound: 0,
+      branchesHit: 0,
+      data: [] as string[],
+      numLinesFound: 0,
+      numLinesHit: 0,
+    };
+    const lines = record.split("\n");
+    for (let line of lines) {
+      const part = line.split(":");
+      switch (part[0]) {
+        case "TN":
+          item.testName = part[1];
+          break;
+        case "SF":
+          item.sourceFile = part[1];
+          break;
+        case "FN":
+          item.functionName = part[1];
+          break;
+        case "FNF":
+          item.numFunctionsFound = parseInt(part[1]);
+          break;
+        case "FNH":
+          item.numFunctionsHit = parseInt(part[1]);
+          break;
+        case "BRDA":
+          item.branchData.push(part[1]);
+          break;
+        case "BRF":
+          item.branchesFound = parseInt(part[1]);
+          break;
+        case "BRH":
+          item.branchesHit = parseInt(part[1]);
+          break;
+        case "DA":
+          item.data.push(part[1]);
+          break;
+        case "LF":
+          item.numLinesFound = parseInt(part[1]);
+          break;
+        case "LH":
+          item.numLinesHit = parseInt(part[1]);
+          break;
       }
-      items.push(item);
     }
-    return items;
+    items.push(item);
   }
+  return items;
+}

--- a/app/util/lcov.ts
+++ b/app/util/lcov.ts
@@ -1,0 +1,63 @@
+/**
+ * Takes an lcov file an input and returns a structured lcov object
+ */
+export function parseLcov(input: string) {
+    const records = input.split("end_of_record");
+    let items = [];
+    for (let record of records) {
+      let item = {
+        sourceFile: "",
+        testName: "",
+        functionName: "",
+        numFunctionsFound: 0,
+        numFunctionsHit: 0,
+        branchData: [] as string[],
+        branchesFound: 0,
+        branchesHit: 0,
+        data: [] as string[],
+        numLinesFound: 0,
+        numLinesHit: 0,
+      };
+      const lines = record.split("\n");
+      for (let line of lines) {
+        const part = line.split(":");
+        switch (part[0]) {
+          case "TN":
+            item.testName = part[1];
+            break;
+          case "SF":
+            item.sourceFile = part[1];
+            break;
+          case "FN":
+            item.functionName = part[1];
+            break;
+          case "FNF":
+            item.numFunctionsFound = parseInt(part[1]);
+            break;
+          case "FNH":
+            item.numFunctionsHit = parseInt(part[1]);
+            break;
+          case "BRDA":
+            item.branchData.push(part[1]);
+            break;
+          case "BRF":
+            item.branchesFound = parseInt(part[1]);
+            break;
+          case "BRH":
+            item.branchesHit = parseInt(part[1]);
+            break;
+          case "DA":
+            item.data.push(part[1]);
+            break;
+          case "LF":
+            item.numLinesFound = parseInt(part[1]);
+            break;
+          case "LH":
+            item.numLinesHit = parseInt(part[1]);
+            break;
+        }
+      }
+      items.push(item);
+    }
+    return items;
+  }

--- a/enterprise/app/code/BUILD
+++ b/enterprise/app/code/BUILD
@@ -18,6 +18,7 @@ ts_library(
         "//app/components/modal",
         "//app/components/spinner",
         "//app/service:rpc_service",
+        "//app/util:lcov",
         "//enterprise/app/code:code_build_button",
         "//enterprise/app/code:code_empty",
         "//enterprise/app/code:code_pull_request",

--- a/enterprise/app/code/code.css
+++ b/enterprise/app/code/code.css
@@ -309,3 +309,11 @@
   cursor: pointer;
   stroke: #2196f3;
 }
+
+.codeCoverageHit {
+  background-color: #c5e1a5;
+}
+
+.codeCoverageMiss {
+  background-color: #ef9a9a;
+}

--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -23,6 +23,7 @@ import Dialog, {
   DialogTitle,
 } from "../../../app/components/dialog/dialog";
 import Modal from "../../../app/components/modal/modal";
+import { parseLcov } from "../../../app/util/lcov";
 
 interface Props {
   user: User;
@@ -116,7 +117,7 @@ export default class CodeComponent extends React.Component<Props, State> {
   }
 
   isSingleFile() {
-    return Boolean(this.props.search.get("bytestream_url"));
+    return Boolean(this.props.search.get("bytestream_url")) || Boolean(this.props.search.get("lcov"));
   }
 
   componentDidMount() {
@@ -135,14 +136,68 @@ export default class CodeComponent extends React.Component<Props, State> {
     let bytestreamURL = this.props.search.get("bytestream_url");
     let invocationID = this.props.search.get("invocation_id");
     let filename = this.props.search.get("filename");
-    if (this.isSingleFile()) {
+    if (this.isSingleFile() && bytestreamURL) {
       rpcService.fetchBytestreamFile(bytestreamURL, invocationID, "text").then((result: any) => {
         this.editor.setModel(monaco.editor.createModel(result, undefined, monaco.Uri.file(filename || "file")));
       });
       return;
     }
 
+    let lcovURL = this.props.search.get("lcov");
+    let commit = this.props.search.get("commit");
+    if (this.isSingleFile() && lcovURL) {
+      this.octokit.rest.repos
+        .getContent({
+          owner: this.currentOwner(),
+          repo: this.currentRepo(),
+          path: this.currentPath(),
+          ref: commit || this.state.commitSHA || "master",
+        })
+        .then((response) => {
+          this.navigateToContent(this.currentPath(), response.data.content);
+          rpcService.fetchBytestreamFile(lcovURL, invocationID, "text").then((result: any) => {
+            let records = parseLcov(result);
+            for (let record of records) {
+              if (record.sourceFile == this.currentPath()) {
+                this.editor.deltaDecorations(
+                  this.editor.getModel().getAllDecorations(),
+                  record.data.map((r) => {
+                    const parts = r.split(",");
+                    const lineNum = parseInt(parts[0]);
+                    const hit = parts[1] == "1";
+                    return {
+                      range: new monaco.Range(lineNum, 0, lineNum, 0),
+                      options: {
+                        isWholeLine: true,
+                        className: hit ? "codeCoverageHit" : "codeCoverageMiss",
+                        marginClassName: hit ? "codeCoverageHit" : "codeCoverageMiss",
+                        minimap: { color: hit ? "#c5e1a5" : "#ef9a9a", position: 1 },
+                      },
+                    };
+                  })
+                );
+              }
+            }
+            console.log(result);
+          });
+        });
+      return;
+    }
+
     if (this.currentPath()) {
+      if (!this.state.fullPathToModelMap.has(this.currentPath())) {
+        this.octokit.rest.repos
+          .getContent({
+            owner: this.currentOwner(),
+            repo: this.currentRepo(),
+            path: this.currentPath(),
+            ref: this.state.commitSHA || "master",
+          })
+          .then((response) => {
+            this.navigateToContent(this.currentPath(), response.data.content);
+          });
+      }
+
       if (this.state.mergeConflicts.has(this.currentPath())) {
         this.handleViewConflictClicked(
           this.currentPath(),
@@ -268,21 +323,25 @@ export default class CodeComponent extends React.Component<Props, State> {
       })
       .then((response: any) => {
         console.log(response);
-        let fileContents = atob(response.data.content);
-        this.state.originalFileContents.set(fullPath, fileContents);
-        this.updateState({
-          originalFileContents: this.state.originalFileContents,
-          changes: this.state.changes,
-        });
-        let model = this.state.fullPathToModelMap.get(fullPath);
-        if (!model) {
-          model = monaco.editor.createModel(fileContents, undefined, monaco.Uri.file(fullPath));
-          this.state.fullPathToModelMap.set(fullPath, model);
-          this.updateState({ fullPathToModelMap: this.state.fullPathToModelMap });
-        }
-        this.editor.setModel(model);
+        this.navigateToContent(fullPath, response.data.content);
         this.navigateToPath(fullPath);
       });
+  }
+
+  navigateToContent(fullPath: string, content: string) {
+    let fileContents = atob(content);
+    this.state.originalFileContents.set(fullPath, fileContents);
+    this.updateState({
+      originalFileContents: this.state.originalFileContents,
+      changes: this.state.changes,
+    });
+    let model = this.state.fullPathToModelMap.get(fullPath);
+    if (!model) {
+      model = monaco.editor.createModel(fileContents, undefined, monaco.Uri.file(fullPath));
+      this.state.fullPathToModelMap.set(fullPath, model);
+      this.updateState({ fullPathToModelMap: this.state.fullPathToModelMap });
+    }
+    this.editor.setModel(model);
   }
 
   navigateToPath(path: string) {

--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -154,7 +154,7 @@ export default class CodeComponent extends React.Component<Props, State> {
           ref: commit || this.state.commitSHA || "master",
         })
         .then((response) => {
-          this.navigateToContent(this.currentPath(), response.data.content);
+          this.navigateToContent(this.currentPath(), (response.data as any).content);
           rpcService.fetchBytestreamFile(lcovURL, invocationID, "text").then((result: any) => {
             let records = parseLcov(result);
             for (let record of records) {

--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -194,7 +194,7 @@ export default class CodeComponent extends React.Component<Props, State> {
             ref: this.state.commitSHA || "master",
           })
           .then((response) => {
-            this.navigateToContent(this.currentPath(), response.data.content);
+            this.navigateToContent(this.currentPath(), (response.data as any).content);
           });
       }
 


### PR DESCRIPTION
For `bazel coverage` runs, we'll now show this file level breakdown on the test target page:
<img width="1498" alt="Screenshot 2023-04-10 at 3 19 20 PM" src="https://user-images.githubusercontent.com/1704556/231010020-295baf56-a876-4670-ba14-ac32acc99406.png">

If using github, and build metadata is set - clicking on these files will show you a test coverage overlay:
<img width="1509" alt="Screenshot 2023-04-10 at 3 19 34 PM" src="https://user-images.githubusercontent.com/1704556/231010200-4acc9272-910d-44cf-ae42-e232c67773d4.png">

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
