### PR TITLE
sluongng/misc runner test improvements

### DIFF
--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -69,6 +69,7 @@ go_test(
         "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/testutil/testfs",
+        "//server/testutil/testrand",
         "//server/util/disk",
         "//server/util/status",
         "//server/util/testing/flags",

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -336,10 +336,10 @@ func TestRunnerPool_Shutdown_RunnersReturnRetriableOrNilError(t *testing.T) {
 	env := newTestEnv(t)
 	ctx := withAuthenticatedUser(t, context.Background(), env, "US1")
 
-	// Run 100 trials where we create a pool that runs 50 tasks using runner
+	// Run 30 trials where we create a pool that runs 50 tasks using runner
 	// recycling, shutting down the pool after roughly half of the tasks have been
 	// started.
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 30; i++ {
 		pool := newRunnerPool(t, env, noLimitsCfg)
 		numTasks := 50
 		tasksStarted := make(chan struct{}, numTasks)

--- a/server/testutil/testrand/BUILD
+++ b/server/testutil/testrand/BUILD
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "testrand",
+    srcs = ["testrand.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/testrand",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/server/testutil/testrand/testrand.go
+++ b/server/testutil/testrand/testrand.go
@@ -1,0 +1,25 @@
+package testrand
+
+import (
+	"math/rand"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Provide deteministic random numbers for tests.
+// Account for Bazel setting the TEST_RANDOM_SEED environment variable when
+// --runs_per_test=n is used.
+func NewRandom(t *testing.T) *rand.Rand {
+	seed := int64(0)
+	if bazelRandSeed := os.Getenv("TEST_RANDOM_SEED"); bazelRandSeed != "" {
+		// TEST_RANDOM_SEED is set by Bazel when --runs_per_test=n is used
+		runSeed, err := strconv.Atoi(bazelRandSeed)
+		require.NoError(t, err)
+
+		seed += int64(runSeed)
+	}
+	return rand.New(rand.NewSource(seed))
+}


### PR DESCRIPTION
This introduce 2 changes as a follow-up to #3738

```
runner_test: use sub-tests with t.Run()

Since each iteration in this test is self-contained, let's use sub-tests
by calling t.Run() in each iteration.

This should let us track each iteration separately and help debugging
them easier in the future.
```

```
introduce testrand for deterministic random during test

We want our tests to be reliably cached thus having a fixed seed
random source is much desirable.

Furthermore, Bazel would set it's own seed when executing the same test
multiple times (for flakiness detection).

Introduce testrand package to handle that logic and apply it into
runner_test.
```


<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: None <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
