### PR TITLE
gazelle: fix missing file warning

### DIFF
--- a/cli/version/BUILD
+++ b/cli/version/BUILD
@@ -8,14 +8,15 @@ string_flag(
 )
 
 write_flag_to_file(
-    name = "version_flag.txt",
+    name = "version_flag",
+    out = "version_flag.txt",
     flag = ":cli_version",
 )
 
 go_library(
     name = "version",
     srcs = ["version.go"],
-    embedsrcs = ["version_flag.txt"],  # keep
+    embedsrcs = [":version_flag"],  # keep
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/version",
     visibility = ["//visibility:public"],
     deps = ["//cli/arg"],

--- a/deployment/BUILD
+++ b/deployment/BUILD
@@ -37,6 +37,7 @@ string_flag(
 
 write_flag_to_file(
     name = "image_tag_file",
+    out = "image_tag_file",
     flag = ":image_tag",
     visibility = ["//visibility:public"],
 )

--- a/rules/flags/index.bzl
+++ b/rules/flags/index.bzl
@@ -1,7 +1,8 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
 def _write_flag_to_file_impl(ctx):
-    out = ctx.actions.declare_file(ctx.attr.name)
+    out_file = ctx.attr.out if ctx.attr.out else ctx.attr.name
+    out = ctx.actions.declare_file(out_file)
     ctx.actions.write(out, ctx.attr.template % ctx.attr.flag[BuildSettingInfo].value)
     return DefaultInfo(files = depset([out]))
 
@@ -11,5 +12,6 @@ write_flag_to_file = rule(
     attrs = {
         "flag": attr.label(providers = [BuildSettingInfo]),
         "template": attr.string(default = "%s", doc = "A string where the literal '%s' is substituted with the flag value."),
+        "out": attr.string(default = "", doc = "The name of the output file."),
     },
 )

--- a/rules/flags/index.bzl
+++ b/rules/flags/index.bzl
@@ -1,8 +1,7 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
 def _write_flag_to_file_impl(ctx):
-    out_file = ctx.attr.out if ctx.attr.out else ctx.attr.name
-    out = ctx.actions.declare_file(out_file)
+    out = ctx.actions.declare_file(ctx.attr.out)
     ctx.actions.write(out, ctx.attr.template % ctx.attr.flag[BuildSettingInfo].value)
     return DefaultInfo(files = depset([out]))
 
@@ -12,6 +11,6 @@ write_flag_to_file = rule(
     attrs = {
         "flag": attr.label(providers = [BuildSettingInfo]),
         "template": attr.string(default = "%s", doc = "A string where the literal '%s' is substituted with the flag value."),
-        "out": attr.string(default = "", doc = "The name of the output file."),
+        "out": attr.string(doc = "The name of the output file."),
     },
 )


### PR DESCRIPTION
When a file referenced in embedsrcs is a generated file, Gazelle will
try it best to look up neighbor rules within the same package for "out"
and "outs" attributes that declare such file.

However, our write_flag_to_file uses "name" attribute to specify the
file name, thus trip up Gazelle at runtime.

Provide an optional "out" attribute in write_flag_to_file to avoid
Gazelle warning.

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
