### PR TITLE
GH app: show GitHub Account link instead of installation link if account is not linked

### DIFF
--- a/enterprise/app/workflows/github_app_import.tsx
+++ b/enterprise/app/workflows/github_app_import.tsx
@@ -170,6 +170,13 @@ export default class GitHubAppImport extends React.Component<GitHubAppImportProp
     return new Set(this.state.linkedReposResponse?.repoUrls || []);
   }
 
+  private githubLinkURL(): string {
+    return `/auth/github/app/link/?${new URLSearchParams({
+      user_id: this.props.user?.displayUser?.userId?.id || "",
+      group_id: this.props.user?.selectedGroup?.id || "",
+      redirect_url: window.location.href,
+    })}`;
+  }
   private appInstallURL(): string {
     return `/auth/github/app/link/?${new URLSearchParams({
       user_id: this.props.user?.displayUser?.userId?.id || "",
@@ -251,9 +258,17 @@ export default class GitHubAppImport extends React.Component<GitHubAppImportProp
           </div>
         </div>
         <div className="container content-container">
-          {!this.state.installationsResponse?.installations?.length && (
+          {!this.props.user.githubToken && (
             <Banner type="info" className="install-app-banner">
-              <div>To get started, install the BuildBuddy app on GitHub.</div>
+              <div>To get started, link a GitHub account to your BuildBuddy account.</div>
+              <LinkButton className="big-button" href={this.githubLinkURL()}>
+                Link GitHub account
+              </LinkButton>
+            </Banner>
+          )}
+          {this.props.user.githubToken && !this.state.installationsResponse?.installations?.length && (
+            <Banner type="info" className="install-app-banner">
+              <div>To link a repository, install the BuildBuddy app on GitHub.</div>
               <LinkButton className="big-button" href={this.appInstallURL()}>
                 Install
               </LinkButton>


### PR DESCRIPTION
Encourage GitHub account link before setting up an installation. This way, if the org already has an installation linked, but the user isn't logged in, we can just fetch and show the existing installation, rather than (confusingly) asking them to set up a new installation.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
