### PR TITLE
Clarify wording of GH app repo permissions button

### DIFF
--- a/enterprise/app/workflows/github_app_import.tsx
+++ b/enterprise/app/workflows/github_app_import.tsx
@@ -224,7 +224,7 @@ export default class GitHubAppImport extends React.Component<GitHubAppImportProp
         )}
         <div className="create-other-container">
           <a className="create-other clickable" href={this.appInstallURL()}>
-            Configure BuildBuddy app on GitHub <ExternalLink className="icon" />
+            Don't see a repo in this list? Configure repo permissions <ExternalLink className="icon" />
           </a>
         </div>
       </>


### PR DESCRIPTION
Make the UX slightly nicer when you want to add another repo that the linked app installation doesn't have access to.

![image](https://user-images.githubusercontent.com/2414826/231299907-1946fa6b-6f0e-443e-95e5-d0745ef2c818.png)


---

**Version bump**: Patch
