### PR TITLE
proto/bes: upgrade to latest BES change

### DIFF
--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -453,6 +453,8 @@ message Configuration {
   string platform_name = 2;
   string cpu = 3;
   map<string, string> make_variable = 4;
+  // Whether this configuration is used for building tools.
+  bool is_tool = 5;
 }
 
 // Payload of the event indicating the expansion of a target pattern.
@@ -522,6 +524,13 @@ message File {
     // The contents of the file, if they are guaranteed to be short.
     bytes contents = 3;
   }
+
+  // Digest of the file, using the build tool's configured digest algorithm,
+  // hex-encoded.
+  string digest = 5;
+
+  // Length of the file in bytes.
+  int64 length = 6;
 }
 
 message Tree {
@@ -842,6 +851,7 @@ message BuildFinished {
     // Examples of suspensions are SIGSTOP, or the hardware being put to sleep.
     // If was_suspended is true, then most of the timings for this build are
     // suspect.
+    // NOTE: This is no longer set and is deprecated.
     bool was_suspended = 1;
   }
 
@@ -862,7 +872,7 @@ message BuildFinished {
   // End of the build.
   google.protobuf.Timestamp finish_time = 5;
 
-  AnomalyReport anomaly_report = 4;
+  AnomalyReport anomaly_report = 4 [deprecated = true];
 }
 
 message BuildMetrics {
@@ -924,6 +934,10 @@ message BuildMetrics {
     // if there was no major GC during the build.
     int64 peak_post_gc_heap_size = 2;
 
+    // Size of the peak tenured space JVM heap size event in bytes post GC. Note
+    // that this reports 0 if there was no major GC during the build.
+    int64 peak_post_gc_tenured_space_heap_size = 4;
+
     message GarbageMetrics {
       // Type of garbage collected, e.g. G1 Old Gen.
       string type = 1;
@@ -958,7 +972,19 @@ message BuildMetrics {
   TargetMetrics target_metrics = 3;
 
   message PackageMetrics {
-    // Number of BUILD files (aka packages) loaded during this build.
+    // Number of BUILD files (aka packages) successfully loaded during this
+    // build.
+    //
+    // [For Bazel binaries built at source states] Before Dec 2021, this value
+    // was the number of packages attempted to be loaded, for a particular
+    // definition of "attempted".
+    //
+    // After Dec 2021, this value would sometimes overcount because the same
+    // package could sometimes be attempted to be loaded multiple times due to
+    // memory pressure.
+    //
+    // After Feb 2022, this value is the number of packages successfully
+    // loaded.
     int64 packages_loaded = 1;
   }
   PackageMetrics package_metrics = 4;
@@ -969,6 +995,8 @@ message BuildMetrics {
     // The elapsed wall time in milliseconds during this build.
     int64 wall_time_in_ms = 2;
     // The elapsed wall time in milliseconds during the analysis phase.
+    // When analysis and execution phases are interleaved, this measures the
+    // elapsed time from the first analysis work to the last.
     int64 analysis_phase_time_in_ms = 3;
   }
   TimingMetrics timing_metrics = 5;
@@ -1059,8 +1087,11 @@ message BuildMetrics {
 
   // Information about all workers that were alive during the invocation.
   message WorkerMetrics {
-    // Unique id of worker.
-    int32 worker_id = 1;
+    // Deprecated. Use worker_ids instead of this field.
+    int32 worker_id = 1 [deprecated = true];
+
+    // Ids of workers. Could be multiple in case of multiplex workers
+    repeated uint32 worker_ids = 8;
     // Worker process id. If there is no process for worker, equals to zero.
     uint32 process_id = 2;
     // Mnemonic of running worker.
@@ -1078,6 +1109,8 @@ message BuildMetrics {
       int64 collect_time_in_ms = 1;
       // RSS size of worker process.
       int32 worker_memory_in_kb = 2;
+      // Epoch unix time of last action started on specific worker.
+      int64 last_action_start_time_in_ms = 3;
     }
 
     // Combined workers statistics.
@@ -1085,6 +1118,34 @@ message BuildMetrics {
   }
 
   repeated WorkerMetrics worker_metrics = 9;
+
+  // Information about host network.
+  message NetworkMetrics {
+    // Information for all the network traffic going on on the host machine
+    // during the invocation.
+    message SystemNetworkStats {
+      // Total bytes sent during the invocation.
+      uint64 bytes_sent = 1;
+      // Total bytes received during the invocation.
+      uint64 bytes_recv = 2;
+      // Total packets sent during the invocation.
+      uint64 packets_sent = 3;
+      // Total packets received during the invocation.
+      uint64 packets_recv = 4;
+      // Peak bytes/sec sent during the invocation.
+      uint64 peak_bytes_sent_per_sec = 5;
+      // Peak bytes/sec received during the invocation.
+      uint64 peak_bytes_recv_per_sec = 6;
+      // Peak packets/sec sent during the invocation.
+      uint64 peak_packets_sent_per_sec = 7;
+      // Peak packets/sec received during the invocation.
+      uint64 peak_packets_recv_per_sec = 8;
+    }
+
+    SystemNetworkStats system_network_stats = 1;
+  }
+
+  NetworkMetrics network_metrics = 10;
 }
 
 // Event providing additional statistics/logs after completion of the build.


### PR DESCRIPTION
This upgrade our BES proto to the latest BES from Bazel's master branch.
The latest change to BES proto in bazel.git, as of this change, is

```
commit d31dd094c56270d892040ce65586af9b76a99744
Author: Googler <wilwell@google.com>
Date:   Thu Dec 22 04:52:07 2022 -0800

    Support multiplex workers in WorkerMetricsCollector.
```

This PR was generated by extracting all the changes from bazel.git with
```
$ git diff c674101d004eccd795a06e19674e317b04b1b36a..HEAD \
      -- \
      src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto \
      > bes.patch
```

The change c674101d004eccd795a06e19674e317b04b1b36a was already applied in our version of bes.proto
so I assumed that's when we last updated/copied the file.

And then apply it into buildbuddy.git with

```
$ git apply -v ../../bazelbuild/bazel/bes.patch -C2 -p10
```

Note that `-C` was used to fuzzily apply some hunks without exact match.

Some style changes was manually filtered out when commiting this PR

```
--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -444,7 +444,8 @@ message WorkspaceStatus {
 // build.
 message BuildMetadata {
   // Custom metadata for the build.
-  map<string, string> metadata = 1;
+  map<string, string> metadata = 1
+      ;
 }

 // Payload of an event reporting details of a given configuration.
@@ -452,7 +453,8 @@ message Configuration {
   string mnemonic = 1;
   string platform_name = 2;
   string cpu = 3;
-  map<string, string> make_variable = 4;
+  map<string, string> make_variable = 4
+      ;
   // Whether this configuration is used for building tools.
   bool is_tool = 5;
 }
```

<!--
Optional: Provide additional description (beyond the PR title).
Description should provide any background or motivation needed for the change, as well
as a high-level overview of the approach taken (if the change is not straightforward).
Detailed rationale for specific sections of the code are probably better off as code comments
so that future readers of that code can benefit.
-->

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
