### PR TITLE
Navigate to workflows page after linking a repo

### DIFF
--- a/enterprise/app/workflows/github_app_import.tsx
+++ b/enterprise/app/workflows/github_app_import.tsx
@@ -161,7 +161,7 @@ export default class GitHubAppImport extends React.Component<GitHubAppImportProp
       .linkGitHubRepo(linkRequest)
       .then(() => {
         alertService.success("Successfully linked " + repoUrl);
-        this.fetch();
+        router.navigateTo("/workflows/");
       })
       .catch((e) => errorService.handleError(e))
       .finally(() => this.setState({ linkRequest: null, linkLoading: false }));


### PR DESCRIPTION
Navigate back to the workflows list once a repo is linked, so that the user can see that the workflow was added alongside the other workflows. (Basing this on feedback that this flow is more intuitive. Incidentally, this is also what we did for the old workflow link flow)

---

**Version bump**: Patch
