### PR TITLE
Add total_uncached_action_exec_usec in Invocations MySQL and ClickHouse tables

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -144,9 +144,16 @@ type Invocation struct {
 	// invocation.
 	TotalUploadTransferredSizeBytes int64
 
-	TotalDownloadUsec                int64
-	TotalUploadUsec                  int64
-	TotalCachedActionExecUsec        int64
+	TotalDownloadUsec int64
+	TotalUploadUsec   int64
+
+	// TotalCachedActionExecUsec is the sum of the original execution duration
+	// of the action that hits the action cache.
+	TotalCachedActionExecUsec int64
+	// TotalUncachedActionExecUsec is the sum of the execution duration the action
+	// that misses the action cache.
+	TotalUncachedActionExecUsec int64
+
 	DownloadThroughputBytesPerSecond int64
 	InvocationUUID                   []byte `gorm:"size:16;default:NULL;uniqueIndex:invocation_invocation_uuid;unique"`
 	Success                          bool   `gorm:"type:tinyint(1)"`

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -105,6 +105,7 @@ type Invocation struct {
 	TotalDownloadUsec                 int64
 	TotalUploadUsec                   int64
 	TotalCachedActionExecUsec         int64
+	TotalUncachedActionExecUsec       int64
 	DownloadThroughputBytesPerSecond  int64
 	UploadThroughputBytesPerSecond    int64
 }
@@ -407,6 +408,7 @@ func ToInvocationFromPrimaryDB(ti *tables.Invocation) *Invocation {
 		TotalDownloadTransferredSizeBytes: ti.TotalDownloadTransferredSizeBytes,
 		TotalUploadTransferredSizeBytes:   ti.TotalUploadTransferredSizeBytes,
 		TotalCachedActionExecUsec:         ti.TotalCachedActionExecUsec,
+		TotalUncachedActionExecUsec:       ti.TotalUncachedActionExecUsec,
 		DownloadThroughputBytesPerSecond:  ti.DownloadThroughputBytesPerSecond,
 		UploadThroughputBytesPerSecond:    ti.UploadThroughputBytesPerSecond,
 	}


### PR DESCRIPTION
total_cached_action_exec_usec already exists in Invocations
tables in MySQL and ClickHouse, but it's no longer populated; so I'm
just going to re-use this field.
