### PR TITLE
Add platform and credentials to GetSociArtifacts

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -184,6 +184,7 @@ proto_library(
         "soci.proto",
     ],
     deps = [
+        ":registry_proto",
         ":remote_execution_proto",
     ],
 )
@@ -678,6 +679,7 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/soci",
     proto = ":soci_proto",
     deps = [
+        ":registry_go_proto",
         ":remote_execution_go_proto",
     ],
 )

--- a/proto/soci.proto
+++ b/proto/soci.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "proto/registry.proto";
 import "proto/remote_execution.proto";
 
 package soci;
@@ -28,7 +29,14 @@ message Artifact {
 }
 
 message GetArtifactsRequest {
-  string image_name = 1;
+  string image = 1;
+
+  // If an image has multiple variants, this selector is used
+  // to select a single variant.
+  registry.Platform platform = 2;
+
+  // Optional credentials for accessing the target image.
+  registry.Credentials credentials = 3;
 }
 
 message GetArtifactsResponse {


### PR DESCRIPTION
Because it has to resolve the image name into a reference just like GetOptimizedImage, so the request may as well look the same.

**Version bump**: Minor