### PR TITLE
Normalize repo URL when filtering by repo

### DIFF
--- a/enterprise/app/filter/filter.tsx
+++ b/enterprise/app/filter/filter.tsx
@@ -499,7 +499,7 @@ export default class FilterComponent extends React.Component<FilterProps, State>
                   <div className="option-group-title">Repo</div>
                   <div className="option-group-input">
                     <TextInput
-                      placeholder={"e.g. https://github.com/buildbuddy-io/buildbuddy"}
+                      placeholder={"e.g. github.com/buildbuddy-io/buildbuddy"}
                       value={this.state.repo}
                       onChange={(e) => this.setState({ repo: e.target.value })}
                     />

--- a/enterprise/server/invocation_search_service/BUILD
+++ b/enterprise/server/invocation_search_service/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//server/util/blocklist",
         "//server/util/db",
         "//server/util/filter",
+        "//server/util/git",
         "//server/util/perms",
         "//server/util/query_builder",
         "//server/util/status",

--- a/enterprise/server/invocation_search_service/invocation_search_service.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/blocklist"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/filter"
+	"github.com/buildbuddy-io/buildbuddy/server/util/git"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/query_builder"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -100,6 +101,13 @@ func addPermissionsCheckToQuery(u interfaces.UserInfo, q *query_builder.Query) {
 }
 
 func (s *InvocationSearchService) QueryInvocations(ctx context.Context, req *inpb.SearchInvocationRequest) (*inpb.SearchInvocationResponse, error) {
+	if req.GetQuery().GetRepoUrl() != "" {
+		norm, err := git.NormalizeRepoURL(req.GetQuery().GetRepoUrl())
+		if err == nil { // if we normalized successfully
+			req.Query.RepoUrl = norm.String()
+		}
+	}
+
 	if err := s.checkPreconditions(req); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow things like `github.com/buildbuddy-io/buildbuddy` or even `buildbuddy-io/buildbuddy` to avoid confusion when filtering by repo.

---

**Version bump**: Patch <!-- Required. Choose from: Major, Minor, Patch, None -->

<!-- See https://semver.org/#semantic-versioning-specification-semver. Summary:
* Major: Breaking change that causes existing functionality to not work as expected.
* Minor: Non-breaking change that adds functionality (examples: new feature; new API options)
* Patch: Non-breaking change that fixes an issue, improves performance, or refactors
         code.
* None:  Changed files are not included in releases (tests, docs, development setup,
         production configs)
-->

<!-- Optional:
**Related issues**: Fixes #1, Unblocks #2 ...
-->
