### PR TITLE
Add a caching layer for encryption/decryption keys.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -1982,7 +1982,7 @@ func TestEncryption(t *testing.T) {
 		require.NoError(t, err)
 		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
 		err = pc.Set(ctx, rn, buf)
-		require.ErrorContains(t, err, "no encryption key available")
+		require.ErrorContains(t, err, "no key available")
 
 		err = pc.Stop()
 		require.NoError(t, err)

--- a/enterprise/server/crypter_service/BUILD
+++ b/enterprise/server/crypter_service/BUILD
@@ -12,10 +12,15 @@ go_library(
         "//server/interfaces",
         "//server/remote_cache/digest",
         "//server/tables",
+        "//server/util/log",
+        "//server/util/retry",
         "//server/util/status",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@io_gorm_gorm//:gorm",
         "@org_golang_x_crypto//chacha20poly1305",
         "@org_golang_x_crypto//hkdf",
+        "@org_golang_x_sync//singleflight",
+        "@org_uber_go_atomic//:atomic",
     ],
 )
 
@@ -24,7 +29,6 @@ go_test(
     srcs = ["crypter_service_test.go"],
     embed = [":crypter_service"],
     deps = [
-        "//enterprise/server/backends/kms",
         "//proto:raft_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/environment",
@@ -32,10 +36,10 @@ go_test(
         "//server/tables",
         "//server/testutil/testauth",
         "//server/testutil/testenv",
-        "//server/testutil/testfs",
         "//server/util/ioutil",
         "//server/util/status",
         "//server/util/testing/flags",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/crypter_service/crypter_service_test.go
+++ b/enterprise/server/crypter_service/crypter_service_test.go
@@ -3,26 +3,26 @@ package crypter_service
 import (
 	"bytes"
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/rand"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	mrand "math/rand"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/kms"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
-	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/util/ioutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
@@ -35,13 +35,111 @@ var (
 	dummyDigest = &repb.Digest{Hash: "foo", SizeBytes: 123}
 )
 
-func generateKMSKey(t *testing.T, kmsDir string, id string) string {
+type fakeKmsKey struct {
+	key        []byte
+	err        error
+	fetchCount int
+}
+
+type fakeKMS struct {
+	t    *testing.T
+	mu   sync.Mutex
+	keys map[string]*fakeKmsKey
+}
+
+func newFakeKMS(t *testing.T) *fakeKMS {
+	return &fakeKMS{
+		t:    t,
+		keys: make(map[string]*fakeKmsKey),
+	}
+}
+
+func (f *fakeKMS) SetKey(uri string, key []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.keys[uri] = &fakeKmsKey{key: key}
+}
+
+func (f *fakeKMS) ReturnError(uri string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.keys[uri] = &fakeKmsKey{err: err}
+}
+
+func (f *fakeKMS) FetchMasterKey() (interfaces.AEAD, error) {
+	return f.FetchKey("master")
+}
+
+func (f *fakeKMS) ResetFetchCount(uri string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	keyData, ok := f.keys[uri]
+	if !ok {
+		require.FailNowf(f.t, "key not found", "key %q not in fake KMS", uri)
+	}
+	keyData.fetchCount = 0
+}
+
+func (f *fakeKMS) GetFetchCount(uri string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	keyData, ok := f.keys[uri]
+	if !ok {
+		require.FailNowf(f.t, "key not found", "key %q not in fake KMS", uri)
+	}
+	return keyData.fetchCount
+}
+
+type gcmAESAEAD struct {
+	ciph cipher.AEAD
+}
+
+func (g *gcmAESAEAD) Encrypt(plaintext, associatedData []byte) ([]byte, error) {
+	nonce := make([]byte, g.ciph.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	out := g.ciph.Seal(nil, nonce, plaintext, associatedData)
+	return append(nonce, out...), nil
+}
+
+func (g *gcmAESAEAD) Decrypt(ciphertext, associatedData []byte) ([]byte, error) {
+	if len(ciphertext) < g.ciph.NonceSize() {
+		return nil, status.InvalidArgumentErrorf("input ciphertext too short")
+	}
+	nonce := ciphertext[:g.ciph.NonceSize()]
+	return g.ciph.Open(nil, nonce, ciphertext[g.ciph.NonceSize():], associatedData)
+}
+
+func (f *fakeKMS) FetchKey(uri string) (interfaces.AEAD, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	keyData, ok := f.keys[uri]
+	if !ok {
+		return nil, status.NotFoundErrorf("key %q not found", uri)
+	}
+	keyData.fetchCount++
+	if keyData.err != nil {
+		return nil, keyData.err
+	}
+
+	bc, err := aes.NewCipher(keyData.key)
+	if err != nil {
+		return nil, err
+	}
+	ciph, err := cipher.NewGCM(bc)
+	if err != nil {
+		return nil, err
+	}
+	return &gcmAESAEAD{ciph: ciph}, nil
+}
+
+func generateKMSKey(t *testing.T, f *fakeKMS, id string) string {
 	key := make([]byte, 32)
 	_, err := rand.Read(key)
 	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(kmsDir, id), key, 0644)
-	require.NoError(t, err)
-	return "local-insecure-kms://" + id
+	f.SetKey(id, key)
+	return id
 }
 
 func writeInRandomChunks(t *testing.T, w interfaces.Encryptor, data []byte) {
@@ -58,7 +156,7 @@ func writeInRandomChunks(t *testing.T, w interfaces.Encryptor, data []byte) {
 	require.NoError(t, err)
 }
 
-func createKey(t *testing.T, env environment.Env, keyID, groupID, groupKeyURI string) (*tables.EncryptionKey, *tables.EncryptionKeyVersion) {
+func createKey(t *testing.T, env environment.Env, keyID, groupID, groupKeyURI string) {
 	kmsClient := env.GetKMS()
 
 	masterKeyPart := make([]byte, 32)
@@ -88,35 +186,47 @@ func createKey(t *testing.T, env environment.Env, keyID, groupID, groupKeyURI st
 		GroupKeyURI:        groupKeyURI,
 		GroupEncryptedKey:  encGroupKeyPart,
 	}
-	return key, keyVersion
+	ctx := context.Background()
+	err = env.GetDBHandle().DB(ctx).Create(key).Error
+	require.NoError(t, err)
+	err = env.GetDBHandle().DB(ctx).Create(keyVersion).Error
+	require.NoError(t, err)
 }
 
-func getEnv(t *testing.T) (*testenv.TestEnv, string) {
+func getEnv(t *testing.T) (*testenv.TestEnv, *fakeKMS) {
 	mrand.Seed(time.Now().UnixMicro())
 
-	kmsDir := testfs.MakeTempDir(t)
-	masterKeyURI := generateKMSKey(t, kmsDir, "masterKey")
+	flags.Set(t, "database.enable_encryption_schema", true)
 
-	flags.Set(t, "keystore.local_insecure_kms_directory", kmsDir)
-	flags.Set(t, "keystore.master_key_uri", masterKeyURI)
+	kms := newFakeKMS(t)
+
+	generateKMSKey(t, kms, "master")
+
 	env := testenv.GetTestEnv(t)
-	err := kms.Register(env)
-	require.NoError(t, err)
-	return env, kmsDir
+	env.SetKMS(kms)
+	return env, kms
 }
 
 func TestEncryptDecrypt(t *testing.T) {
-	env, kmsDir := getEnv(t)
-	customerKeyURI := generateKMSKey(t, kmsDir, "customerKey")
+	env, kms := getEnv(t)
+	customerKeyURI := generateKMSKey(t, kms, "customerKey")
 
+	userID := "US123"
 	groupID := "GR123"
-	_, keyVersion := createKey(t, env, "EK123", groupID, customerKeyURI)
+	auther := testauth.NewTestAuthenticator(testauth.TestUsers(userID, groupID))
+	env.SetAuthenticator(auther)
+	createKey(t, env, "EK123", groupID, customerKeyURI)
 
-	crypter := New(env)
+	ctx, err := auther.WithAuthenticatedUser(context.Background(), userID)
+	require.NoError(t, err)
+
+	crypter, err := New(env, clockwork.NewRealClock())
+	defer crypter.Stop()
+	require.NoError(t, err)
 	out := bytes.NewBuffer(nil)
 	for _, size := range []int64{1, 10, 100, 1000, 1000 * 1000} {
 		t.Run(fmt.Sprint(size), func(t *testing.T) {
-			e, err := crypter.newEncryptorWithKey(dummyDigest, ioutil.NewCustomCommitWriteCloser(out), groupID, keyVersion, 1024)
+			e, err := crypter.newEncryptorWithChunkSize(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out), groupID, 1024)
 			require.NoError(t, err)
 
 			testData := make([]byte, size)
@@ -127,7 +237,7 @@ func TestEncryptDecrypt(t *testing.T) {
 			// not affect the final result.
 			writeInRandomChunks(t, e, testData)
 
-			d, err := crypter.newDecryptorWithKey(dummyDigest, io.NopCloser(out), groupID, keyVersion, 1024)
+			d, err := crypter.newDecryptorWithChunkSize(ctx, dummyDigest, io.NopCloser(out), e.Metadata(), groupID, 1024)
 			require.NoError(t, err)
 			decrypted, err := io.ReadAll(d)
 			require.NoError(t, err)
@@ -140,16 +250,24 @@ func TestEncryptDecrypt(t *testing.T) {
 }
 
 func TestDecryptWrongGroup(t *testing.T) {
-	env, kmsDir := getEnv(t)
-	customerKeyURI := generateKMSKey(t, kmsDir, "customerKey")
+	env, kms := getEnv(t)
+	customerKeyURI := generateKMSKey(t, kms, "customerKey")
 
+	userID := "US123"
 	groupID := "GR123"
-	_, keyVersion := createKey(t, env, "EK123", groupID, customerKeyURI)
+	auther := testauth.NewTestAuthenticator(testauth.TestUsers(userID, groupID))
+	env.SetAuthenticator(auther)
+	createKey(t, env, "EK123", groupID, customerKeyURI)
 
-	crypter := New(env)
+	ctx, err := auther.WithAuthenticatedUser(context.Background(), userID)
+	require.NoError(t, err)
+
+	crypter, err := New(env, clockwork.NewRealClock())
+	defer crypter.Stop()
+	require.NoError(t, err)
 	out := bytes.NewBuffer(nil)
 
-	e, err := crypter.newEncryptorWithKey(dummyDigest, ioutil.NewCustomCommitWriteCloser(out), groupID, keyVersion, 1024)
+	e, err := crypter.newEncryptorWithChunkSize(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out), groupID, 1024)
 	require.NoError(t, err)
 
 	testData := make([]byte, 1000)
@@ -159,30 +277,39 @@ func TestDecryptWrongGroup(t *testing.T) {
 	writeInRandomChunks(t, e, testData)
 
 	// Reading with the correct groupID should be OK.
-	d, err := crypter.newDecryptorWithKey(dummyDigest, io.NopCloser(bytes.NewReader(out.Bytes())), groupID, keyVersion, 1024)
+	d, err := crypter.newDecryptorWithChunkSize(ctx, dummyDigest, io.NopCloser(bytes.NewReader(out.Bytes())), e.Metadata(), groupID, 1024)
 	require.NoError(t, err)
 	decrypted, err := io.ReadAll(d)
 	require.NoError(t, err)
 	require.Equal(t, decrypted, testData)
 
 	// If group ID doesn't match, authentication should fail.
-	d, err = crypter.newDecryptorWithKey(dummyDigest, io.NopCloser(bytes.NewReader(out.Bytes())), "GRBAD", keyVersion, 1024)
+	d, err = crypter.newDecryptorWithChunkSize(ctx, dummyDigest, io.NopCloser(bytes.NewReader(out.Bytes())), e.Metadata(), "GRBAD", 1024)
 	require.NoError(t, err)
 	decrypted, err = io.ReadAll(d)
 	require.ErrorContains(t, err, "authentication failed")
 }
 
 func TestDecryptWrongDigest(t *testing.T) {
-	env, kmsDir := getEnv(t)
-	customerKeyURI := generateKMSKey(t, kmsDir, "customerKey")
+	env, kms := getEnv(t)
+	customerKeyURI := generateKMSKey(t, kms, "customerKey")
 
+	userID := "US123"
 	groupID := "GR123"
-	_, keyVersion := createKey(t, env, "EK123", groupID, customerKeyURI)
+	auther := testauth.NewTestAuthenticator(testauth.TestUsers(userID, groupID))
+	env.SetAuthenticator(auther)
 
-	crypter := New(env)
+	createKey(t, env, "EK123", groupID, customerKeyURI)
+
+	ctx, err := auther.WithAuthenticatedUser(context.Background(), userID)
+	require.NoError(t, err)
+
+	crypter, err := New(env, clockwork.NewRealClock())
+	defer crypter.Stop()
+	require.NoError(t, err)
 	out := bytes.NewBuffer(nil)
 
-	e, err := crypter.newEncryptorWithKey(dummyDigest, ioutil.NewCustomCommitWriteCloser(out), groupID, keyVersion, 1024)
+	e, err := crypter.newEncryptorWithChunkSize(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out), groupID, 1024)
 	require.NoError(t, err)
 
 	testData := make([]byte, 1000)
@@ -191,29 +318,27 @@ func TestDecryptWrongDigest(t *testing.T) {
 
 	writeInRandomChunks(t, e, testData)
 
-	d, err := crypter.newDecryptorWithKey(dummyDigest, io.NopCloser(bytes.NewReader(out.Bytes())), groupID, keyVersion, 1024)
+	d, err := crypter.newDecryptorWithChunkSize(ctx, dummyDigest, io.NopCloser(bytes.NewReader(out.Bytes())), e.Metadata(), groupID, 1024)
 	require.NoError(t, err)
 	decrypted, err := io.ReadAll(d)
 	require.NoError(t, err)
 	require.Equal(t, decrypted, testData)
 
 	wrongHashDigest := &repb.Digest{Hash: "badhash", SizeBytes: dummyDigest.SizeBytes}
-	d, err = crypter.newDecryptorWithKey(wrongHashDigest, io.NopCloser(bytes.NewReader(out.Bytes())), groupID, keyVersion, 1024)
+	d, err = crypter.newDecryptorWithChunkSize(ctx, wrongHashDigest, io.NopCloser(bytes.NewReader(out.Bytes())), e.Metadata(), groupID, 1024)
 	require.NoError(t, err)
 	decrypted, err = io.ReadAll(d)
 	require.ErrorContains(t, err, "authentication failed")
 
 	wrongSizeDigest := &repb.Digest{Hash: dummyDigest.Hash, SizeBytes: 9999999999999999}
-	d, err = crypter.newDecryptorWithKey(wrongSizeDigest, io.NopCloser(bytes.NewReader(out.Bytes())), groupID, keyVersion, 1024)
+	d, err = crypter.newDecryptorWithChunkSize(ctx, wrongSizeDigest, io.NopCloser(bytes.NewReader(out.Bytes())), e.Metadata(), groupID, 1024)
 	require.NoError(t, err)
 	decrypted, err = io.ReadAll(d)
 	require.ErrorContains(t, err, "authentication failed")
 }
 
 func TestKeyLookup(t *testing.T) {
-	flags.Set(t, "database.enable_encryption_schema", true)
-
-	env, kmsDir := getEnv(t)
+	env, kms := getEnv(t)
 
 	userID1 := "US123"
 	groupID1 := "GR123"
@@ -226,31 +351,18 @@ func TestKeyLookup(t *testing.T) {
 	auther := testauth.NewTestAuthenticator(testauth.TestUsers(userID1, groupID1, userID2, groupID2, userID3, groupID3))
 	env.SetAuthenticator(auther)
 
-	group1KeyURI := generateKMSKey(t, kmsDir, "group1Key")
-	group2KeyURI := generateKMSKey(t, kmsDir, "group2Key")
+	group1KeyURI := generateKMSKey(t, kms, "group1Key")
+	group2KeyURI := generateKMSKey(t, kms, "group2Key")
 	ctx := context.Background()
 
 	// Add separate keys for the first and second users.
 	// Third user doesn't have a key configured.
+	createKey(t, env, group1KeyID, groupID1, group1KeyURI)
+	createKey(t, env, group2KeyID, groupID2, group2KeyURI)
 
-	{
-		// user 1
-		key, keyVersion := createKey(t, env, group1KeyID, groupID1, group1KeyURI)
-		err := env.GetDBHandle().DB(ctx).Create(key).Error
-		require.NoError(t, err)
-		err = env.GetDBHandle().DB(ctx).Create(keyVersion).Error
-		require.NoError(t, err)
-	}
-	{
-		// user 2
-		key, keyVersion := createKey(t, env, group2KeyID, groupID2, group2KeyURI)
-		err := env.GetDBHandle().DB(ctx).Create(key).Error
-		require.NoError(t, err)
-		err = env.GetDBHandle().DB(ctx).Create(keyVersion).Error
-		require.NoError(t, err)
-	}
-
-	crypter := New(env)
+	crypter, err := New(env, clockwork.NewRealClock())
+	defer crypter.Stop()
+	require.NoError(t, err)
 
 	// user1 should be able to encrypt and decrypt using their own key.
 	{
@@ -315,5 +427,191 @@ func TestKeyLookup(t *testing.T) {
 		ctx, err = auther.WithAuthenticatedUser(ctx, userID2)
 		_, err = crypter.NewDecryptor(ctx, dummyDigest, io.NopCloser(bytes.NewReader(nil)), &rfpb.EncryptionMetadata{EncryptionKeyId: group1KeyID, Version: 1})
 		require.True(t, status.IsNotFoundError(err))
+	}
+}
+
+func testEncryptDecrypt(ctx context.Context, t *testing.T, auther *testauth.TestAuthenticator, crypter *Crypter, userID string, expectedKeyID string) {
+	out := bytes.NewBuffer(nil)
+	ctx, err := auther.WithAuthenticatedUser(ctx, userID)
+	require.NoError(t, err)
+	c, err := crypter.NewEncryptor(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out))
+	require.NoError(t, err)
+	require.Equal(t, c.Metadata().GetEncryptionKeyId(), expectedKeyID)
+	require.EqualValues(t, c.Metadata().GetVersion(), 1)
+
+	input := []byte("hello world")
+	writeInRandomChunks(t, c, input)
+	d, err := crypter.NewDecryptor(ctx, dummyDigest, io.NopCloser(bytes.NewReader(out.Bytes())), c.Metadata())
+	require.NoError(t, err)
+	decrypted := make([]byte, len(input))
+	_, err = d.Read(decrypted)
+	require.NoError(t, err)
+	require.Equal(t, input, decrypted)
+}
+
+func testKeyError(ctx context.Context, t *testing.T, auther *testauth.TestAuthenticator, crypter *Crypter, userID string, clock clockwork.FakeClock) error {
+	out := bytes.NewBuffer(nil)
+	ctx, err := auther.WithAuthenticatedUser(ctx, userID)
+	require.NoError(t, err)
+
+	// If we are expecting an error, keep advancing the clock to run out the
+	// retries.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-time.After(5 * time.Millisecond):
+				clock.Advance(1 * time.Second)
+			}
+		}
+	}()
+	_, err = crypter.NewEncryptor(ctx, dummyDigest, ioutil.NewCustomCommitWriteCloser(out))
+	require.Error(t, err)
+	return err
+}
+
+// advances the fake clock once and waits for the refresh to be done.
+func advanceTimeAndWaitForRefresh(clock clockwork.FakeClock, crypter *Crypter, dur time.Duration) {
+	lastRun := crypter.testGetLastCacheRefreshRun()
+	clock.Advance(dur)
+	for !crypter.testGetLastCacheRefreshRun().After(lastRun) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	for crypter.testGetCacheActiveRefreshOps() > 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// similar to above, but continuously moves fake clock forward while refresh in
+// progress for testing error scenarios where retries may be attempted.
+func contAdvanceTimeAndWaitForRefresh(clock clockwork.FakeClock, crypter *Crypter, dur time.Duration) {
+	lastRun := crypter.testGetLastCacheRefreshRun()
+	clock.Advance(dur)
+	for !crypter.testGetLastCacheRefreshRun().After(lastRun) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	for crypter.testGetCacheActiveRefreshOps() > 0 {
+		time.Sleep(5 * time.Millisecond)
+		clock.Advance(1 * time.Second)
+	}
+}
+
+func TestKeyCaching(t *testing.T) {
+	env, kms := getEnv(t)
+
+	userID1 := "US123"
+	groupID1 := "GR123"
+	group1KeyID := "EK123"
+	userID2 := "US456"
+	groupID2 := "GR456"
+	group2KeyID := "EK456"
+	auther := testauth.NewTestAuthenticator(testauth.TestUsers(userID1, groupID1, userID2, groupID2))
+	env.SetAuthenticator(auther)
+
+	group1KeyURI := generateKMSKey(t, kms, "group1Key")
+	group2KeyURI := generateKMSKey(t, kms, "group2Key")
+	ctx := context.Background()
+
+	// Add separate keys for the first and second users.
+	// Third user doesn't have a key configured.
+	createKey(t, env, group1KeyID, groupID1, group1KeyURI)
+	createKey(t, env, group2KeyID, groupID2, group2KeyURI)
+
+	// Note that encryption and decryption keys are cached separately so a
+	// encryption/decryption round trip requires two key lookups.
+
+	// Back to back operations should only fetch the keys once.
+	{
+		crypter, err := New(env, clockwork.NewRealClock())
+		require.NoError(t, err)
+		kms.ResetFetchCount(group1KeyURI)
+		testEncryptDecrypt(ctx, t, auther, crypter, userID1, group1KeyID)
+		require.Equal(t, 2, kms.GetFetchCount(group1KeyURI))
+		testEncryptDecrypt(ctx, t, auther, crypter, userID1, group1KeyID)
+		require.Equal(t, 2, kms.GetFetchCount(group1KeyURI))
+		crypter.Stop()
+	}
+
+	// Various cache refresh conditions.
+	{
+		clock := clockwork.NewFakeClock()
+		crypter, err := New(env, clock)
+		require.NoError(t, err)
+		kms.ResetFetchCount(group1KeyURI)
+		kms.ResetFetchCount(group2KeyURI)
+		testEncryptDecrypt(ctx, t, auther, crypter, userID1, group1KeyID)
+		require.Equal(t, 2, kms.GetFetchCount(group1KeyURI))
+
+		// If we're not close enough to expiration, no refresh should be
+		// triggered.
+		advanceTimeAndWaitForRefresh(clock, crypter, keyRefreshScanFrequency)
+		require.Equal(t, 2, kms.GetFetchCount(group1KeyURI))
+
+		// If we are getting closer to expiration, but the keys have not been
+		// used recently then we should not have tried to refresh them.
+		advanceTimeAndWaitForRefresh(clock, crypter, 6*time.Minute)
+		require.Equal(t, 2, kms.GetFetchCount(group1KeyURI))
+
+		// Perform encryption/decryption ops which should mark the key as
+		// recently used.
+		testEncryptDecrypt(ctx, t, auther, crypter, userID1, group1KeyID)
+		require.Equal(t, 2, kms.GetFetchCount(group1KeyURI))
+		// On the next fresh, we should attempt to fetch the keys from KMS.
+		advanceTimeAndWaitForRefresh(clock, crypter, keyRefreshScanFrequency)
+		require.Equal(t, 4, kms.GetFetchCount(group1KeyURI))
+
+		// If we are past expiration, the keys should be removed from the cache
+		// and the next ops should trigger a new fetch.
+		advanceTimeAndWaitForRefresh(clock, crypter, 20*time.Minute)
+		require.Equal(t, 4, kms.GetFetchCount(group1KeyURI))
+		testEncryptDecrypt(ctx, t, auther, crypter, userID1, group1KeyID)
+		require.Equal(t, 6, kms.GetFetchCount(group1KeyURI))
+
+		// There shouldn't have been any fetches of the group2 keys.
+		require.Equal(t, 0, kms.GetFetchCount(group2KeyURI))
+
+		crypter.Stop()
+	}
+
+	// Test refresh error handling.
+	{
+		clock := clockwork.NewFakeClock()
+		crypter, err := New(env, clock)
+		require.NoError(t, err)
+		kms.ResetFetchCount(group1KeyURI)
+		kms.ResetFetchCount(group2KeyURI)
+		testEncryptDecrypt(ctx, t, auther, crypter, userID1, group1KeyID)
+		require.Equal(t, 2, kms.GetFetchCount(group1KeyURI))
+
+		kms.ReturnError(group1KeyURI, status.UnavailableError("mainframe down"))
+
+		// If we are getting closer to expiration, we should try to refresh.
+		advanceTimeAndWaitForRefresh(clock, crypter, 6*time.Minute)
+		// Need to use the key so it's marked as recently used.
+		testEncryptDecrypt(ctx, t, auther, crypter, userID1, group1KeyID)
+		contAdvanceTimeAndWaitForRefresh(clock, crypter, keyRefreshScanFrequency)
+		require.Greater(t, kms.GetFetchCount(group1KeyURI), 2)
+
+		// Next scan loop shouldn't try to refresh the key since it has already
+		// been recently checked.
+		oldCount := kms.GetFetchCount(group1KeyURI)
+		advanceTimeAndWaitForRefresh(clock, crypter, keyRefreshScanFrequency)
+		require.Equal(t, oldCount, kms.GetFetchCount(group1KeyURI))
+
+		// But we should try again once we get past the retry interval.
+		oldCount = kms.GetFetchCount(group1KeyURI)
+		contAdvanceTimeAndWaitForRefresh(clock, crypter, keyRefreshRetryInterval)
+		require.Greater(t, kms.GetFetchCount(group1KeyURI), oldCount)
+
+		// Encryption should continue to use the cached key until we reach
+		// expiration time.
+		testEncryptDecrypt(ctx, t, auther, crypter, userID1, group1KeyID)
+
+		advanceTimeAndWaitForRefresh(clock, crypter, 20*time.Minute)
+		err = testKeyError(ctx, t, auther, crypter, userID1, clock)
+		require.True(t, status.IsUnavailableError(err))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/hashicorp/memberlist v0.3.1
 	github.com/hashicorp/serf v0.9.6
 	github.com/jhump/protoreflect v1.9.0
+	github.com/jonboulle/clockwork v0.3.0
 	github.com/jsimonetti/rtnetlink v0.0.0-20210714135244-af39de65d6ad
 	github.com/klauspost/compress v1.15.12
 	github.com/lestrrat-go/jwx v1.2.11
@@ -93,6 +94,7 @@ require (
 	go.opentelemetry.io/otel/exporters/jaeger v1.11.1
 	go.opentelemetry.io/otel/sdk v1.11.1
 	go.opentelemetry.io/otel/trace v1.11.1
+	go.uber.org/atomic v1.10.0
 	golang.org/x/crypto v0.6.0
 	golang.org/x/oauth2 v0.1.0
 	golang.org/x/sync v0.1.0
@@ -197,7 +199,6 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/jonboulle/clockwork v0.3.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/josharian/native v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -257,7 +258,6 @@ require (
 	go.mongodb.org/mongo-driver v1.10.4 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/otel/metric v0.33.0 // indirect
-	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/goleak v1.1.12 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.23.0 // indirect

--- a/server/util/retry/BUILD
+++ b/server/util/retry/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = ["retry.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/retry",
     visibility = ["//visibility:public"],
+    deps = ["@com_github_jonboulle_clockwork//:clockwork"],
 )
 
 go_test(


### PR DESCRIPTION
Allow keys to be cached in memory for up to 10 minutes. Start trying to refresh keys after 5 minutes, if the key has been used recently. Remove key from cache if we are unable to refresh it before expiration or if it was not used recently.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
