### PR TITLE
Add cache API to check whether encryption is supported for the user.

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -1016,3 +1016,7 @@ func (c *Cache) SupportsCompressor(compressor repb.Compressor_Value) bool {
 	}
 	return false
 }
+
+func (c *Cache) SupportsEncryption(ctx context.Context) bool {
+	return c.local.SupportsEncryption(ctx)
+}

--- a/enterprise/server/backends/gcs_cache/gcs_cache.go
+++ b/enterprise/server/backends/gcs_cache/gcs_cache.go
@@ -526,3 +526,7 @@ func (g *GCSCache) Stop() error {
 func (g *GCSCache) SupportsCompressor(compressor repb.Compressor_Value) bool {
 	return compressor == repb.Compressor_IDENTITY
 }
+
+func (g *GCSCache) SupportsEncryption(ctx context.Context) bool {
+	return false
+}

--- a/enterprise/server/backends/memcache/memcache.go
+++ b/enterprise/server/backends/memcache/memcache.go
@@ -321,3 +321,7 @@ func (c *Cache) Stop() error {
 func (c *Cache) SupportsCompressor(compressor repb.Compressor_Value) bool {
 	return compressor == repb.Compressor_IDENTITY
 }
+
+func (c *Cache) SupportsEncryption(ctx context.Context) bool {
+	return false
+}

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -900,3 +900,7 @@ func (mc *MigrationCache) Stop() error {
 func (mc *MigrationCache) SupportsCompressor(compressor repb.Compressor_Value) bool {
 	return mc.src.SupportsCompressor(compressor) && mc.dest.SupportsCompressor(compressor)
 }
+
+func (mc *MigrationCache) SupportsEncryption(ctx context.Context) bool {
+	return mc.src.SupportsEncryption(ctx) && mc.dest.SupportsEncryption(ctx)
+}

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -31,6 +31,7 @@ var (
 )
 
 type MigrationCache struct {
+	env                  environment.Env
 	src                  interfaces.Cache
 	dest                 interfaces.Cache
 	doubleReadPercentage float64
@@ -60,7 +61,7 @@ func Register(env environment.Env) error {
 		return err
 	}
 	cacheMigrationConfig.SetConfigDefaults()
-	mc := NewMigrationCache(cacheMigrationConfig, srcCache, destCache)
+	mc := NewMigrationCache(env, cacheMigrationConfig, srcCache, destCache)
 
 	if env.GetCache() != nil {
 		log.Warningf("Overriding configured cache with migration_cache. If running a migration, all cache configs" +
@@ -76,9 +77,10 @@ func Register(env environment.Env) error {
 	return nil
 }
 
-func NewMigrationCache(migrationConfig *MigrationConfig, srcCache interfaces.Cache, destCache interfaces.Cache) *MigrationCache {
+func NewMigrationCache(env environment.Env, migrationConfig *MigrationConfig, srcCache interfaces.Cache, destCache interfaces.Cache) *MigrationCache {
 	zero := int64(0)
 	return &MigrationCache{
+		env:                         env,
 		src:                         srcCache,
 		dest:                        destCache,
 		doubleReadPercentage:        migrationConfig.DoubleReadPercentage,
@@ -157,6 +159,21 @@ func pebbleCacheFromConfig(env environment.Env, cfg *PebbleCacheConfig) (*pebble
 	return c, nil
 }
 
+func (mc *MigrationCache) checkSafeToMigrate(ctx context.Context) error {
+	u, err := mc.env.GetAuthenticator().AuthenticatedUser(ctx)
+	if err != nil {
+		// This is an anon user which is ok.
+		return nil
+	}
+	if !u.GetCacheEncryptionEnabled() {
+		return nil
+	}
+	if mc.src.SupportsEncryption(ctx) && !mc.dest.SupportsEncryption(ctx) {
+		return status.FailedPreconditionError("not safe to copy from encrypted cache to unencrypted cache")
+	}
+	return nil
+}
+
 func (mc *MigrationCache) Contains(ctx context.Context, r *rspb.ResourceName) (bool, error) {
 	eg, gctx := errgroup.WithContext(ctx)
 	var srcErr, dstErr error
@@ -232,6 +249,10 @@ func (mc *MigrationCache) Metadata(ctx context.Context, r *rspb.ResourceName) (*
 }
 
 func (mc *MigrationCache) FindMissing(ctx context.Context, resources []*rspb.ResourceName) ([]*repb.Digest, error) {
+	if err := mc.checkSafeToMigrate(ctx); err != nil {
+		return nil, err
+	}
+
 	eg, gctx := errgroup.WithContext(ctx)
 	var srcErr, dstErr error
 	var srcMissing, dstMissing []*repb.Digest
@@ -292,6 +313,10 @@ func (mc *MigrationCache) FindMissing(ctx context.Context, resources []*rspb.Res
 }
 
 func (mc *MigrationCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {
+	if err := mc.checkSafeToMigrate(ctx); err != nil {
+		return nil, err
+	}
+
 	eg, gctx := errgroup.WithContext(ctx)
 	var srcErr, dstErr error
 	var srcData map[*repb.Digest][]byte
@@ -335,6 +360,10 @@ func (mc *MigrationCache) GetMulti(ctx context.Context, resources []*rspb.Resour
 }
 
 func (mc *MigrationCache) SetMulti(ctx context.Context, kvs map[*rspb.ResourceName][]byte) error {
+	if err := mc.checkSafeToMigrate(ctx); err != nil {
+		return err
+	}
+
 	eg, gctx := errgroup.WithContext(ctx)
 	var srcErr, dstErr error
 
@@ -468,6 +497,10 @@ func (d *doubleReader) Close() error {
 }
 
 func (mc *MigrationCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompressedOffset, limit int64) (io.ReadCloser, error) {
+	if err := mc.checkSafeToMigrate(ctx); err != nil {
+		return nil, err
+	}
+
 	eg := &errgroup.Group{}
 	var dstErr error
 	var destReader io.ReadCloser
@@ -583,6 +616,10 @@ func (d *doubleWriter) Close() error {
 }
 
 func (mc *MigrationCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfaces.CommittedWriteCloser, error) {
+	if err := mc.checkSafeToMigrate(ctx); err != nil {
+		return nil, err
+	}
+
 	eg := &errgroup.Group{}
 	var dstErr error
 	var destWriter interfaces.CommittedWriteCloser
@@ -622,6 +659,10 @@ func (mc *MigrationCache) Writer(ctx context.Context, r *rspb.ResourceName) (int
 }
 
 func (mc *MigrationCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, error) {
+	if err := mc.checkSafeToMigrate(ctx); err != nil {
+		return nil, err
+	}
+
 	eg, gctx := errgroup.WithContext(ctx)
 	var srcErr, dstErr error
 	var srcBuf []byte
@@ -693,6 +734,10 @@ func (mc *MigrationCache) sendNonBlockingCopy(ctx context.Context, r *rspb.Resou
 }
 
 func (mc *MigrationCache) Set(ctx context.Context, r *rspb.ResourceName, data []byte) error {
+	if err := mc.checkSafeToMigrate(ctx); err != nil {
+		return err
+	}
+
 	eg, gctx := errgroup.WithContext(ctx)
 	var srcErr, dstErr error
 

--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -115,7 +115,7 @@ func TestACIsolation(t *testing.T) {
 	destCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirDest}, maxSizeBytes)
 	require.NoError(t, err)
 
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d1, buf1 := testdigest.NewRandomDigestBuf(t, 100)
 	r1 := &rspb.ResourceName{
@@ -148,7 +148,7 @@ func TestACIsolation_RemoteInstanceName(t *testing.T) {
 	require.NoError(t, err)
 	destCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirDest}, maxSizeBytes)
 	require.NoError(t, err)
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d1, buf1 := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -183,7 +183,7 @@ func TestSet_DoubleWrite(t *testing.T) {
 	require.NoError(t, err)
 	destCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirDest}, maxSizeBytes)
 	require.NoError(t, err)
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -213,7 +213,7 @@ func TestSet_DestWriteErr(t *testing.T) {
 	srcCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirSrc}, int64(defaultExt4BlockSize*10))
 	require.NoError(t, err)
 	destCache := &errorCache{}
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -237,7 +237,7 @@ func TestSet_SrcWriteErr(t *testing.T) {
 	srcCache := &errorCache{}
 	destCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirSrc}, int64(1000))
 	require.NoError(t, err)
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -260,7 +260,7 @@ func TestSet_SrcAndDestWriteErr(t *testing.T) {
 
 	srcCache := &errorCache{}
 	destCache := &errorCache{}
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -282,7 +282,7 @@ func TestGetSet(t *testing.T) {
 	require.NoError(t, err)
 	destCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirDest}, maxSizeBytes)
 	require.NoError(t, err)
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	testSizes := []int64{
 		1, 10, 100, 1000, 10000, 1000000, 10000000,
@@ -316,7 +316,7 @@ func TestGet_DoubleRead(t *testing.T) {
 	destCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirDest}, maxSizeBytes)
 	require.NoError(t, err)
 
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{DoubleReadPercentage: 1.0}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{DoubleReadPercentage: 1.0}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -341,7 +341,7 @@ func TestGet_DestReadErr(t *testing.T) {
 	require.NoError(t, err)
 	destCache := &errorCache{}
 
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{DoubleReadPercentage: 1.0}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{DoubleReadPercentage: 1.0}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -370,7 +370,7 @@ func TestGet_SrcReadErr(t *testing.T) {
 	destCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirSrc}, maxSizeBytes)
 	require.NoError(t, err)
 
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{DoubleReadPercentage: 1.0}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{DoubleReadPercentage: 1.0}, srcCache, destCache)
 
 	// Write data to dest cache only
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
@@ -402,7 +402,7 @@ func TestGetSet_EmptyData(t *testing.T) {
 	destCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirDest}, maxSizeBytes)
 	require.NoError(t, err)
 
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{DoubleReadPercentage: 1.0}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{DoubleReadPercentage: 1.0}, srcCache, destCache)
 
 	d, _ := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -437,7 +437,7 @@ func TestCopyDataInBackground(t *testing.T) {
 		CopyChanBufferSize: numTests + 1,
 	}
 	config.SetConfigDefaults()
-	mc := migration_cache.NewMigrationCache(config, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, config, srcCache, destCache)
 	mc.Start() // Starts copying in background
 	defer mc.Stop()
 
@@ -486,7 +486,7 @@ func TestCopyDataInBackground_ExceedsCopyChannelSize(t *testing.T) {
 		CopyChanFullWarningIntervalMin: 1,
 	}
 	config.SetConfigDefaults()
-	mc := migration_cache.NewMigrationCache(config, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, config, srcCache, destCache)
 	mc.Start() // Starts copying in background
 	defer mc.Stop()
 
@@ -536,7 +536,7 @@ func TestCopyDataInBackground_RateLimitMax(t *testing.T) {
 		MaxCopiesPerSec:    1,
 	}
 	config.SetConfigDefaults()
-	mc := migration_cache.NewMigrationCache(config, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, config, srcCache, destCache)
 	mc.Start() // Starts copying in background
 	defer mc.Stop()
 
@@ -593,7 +593,7 @@ func TestCopyDataInBackground_RateLimitMin(t *testing.T) {
 		MaxCopiesPerSec:    10,
 	}
 	config.SetConfigDefaults()
-	mc := migration_cache.NewMigrationCache(config, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, config, srcCache, destCache)
 	mc.Start() // Starts copying in background
 	defer mc.Stop()
 
@@ -651,7 +651,7 @@ func TestCopyDataInBackground_DrainOnShutdown(t *testing.T) {
 		MaxCopiesPerSec:    1,
 	}
 	config.SetConfigDefaults()
-	mc := migration_cache.NewMigrationCache(config, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, config, srcCache, destCache)
 	mc.Start() // Starts copying in background
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
@@ -715,7 +715,7 @@ func TestCopyDataInBackground_AuthenticatedUser(t *testing.T) {
 		MaxCopiesPerSec:    10,
 	}
 	config.SetConfigDefaults()
-	mc := migration_cache.NewMigrationCache(config, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, config, srcCache, destCache)
 	mc.Start() // Starts copying in background
 	defer mc.Stop()
 
@@ -784,7 +784,7 @@ func TestCopyDataInBackground_MultipleIsolations(t *testing.T) {
 		MaxCopiesPerSec:    10,
 	}
 	config.SetConfigDefaults()
-	mc := migration_cache.NewMigrationCache(config, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, config, srcCache, destCache)
 	mc.Start() // Starts copying in background
 	defer mc.Stop()
 
@@ -847,7 +847,7 @@ func TestCopyDataInBackground_FindMissing(t *testing.T) {
 		LogNotFoundErrors:    true,
 	}
 	config.SetConfigDefaults()
-	mc := migration_cache.NewMigrationCache(config, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, config, srcCache, destCache)
 	mc.Start() // Starts copying in background
 	defer mc.Stop()
 
@@ -900,7 +900,7 @@ func TestContains(t *testing.T) {
 	require.NoError(t, err)
 	destCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirDest}, maxSizeBytes)
 	require.NoError(t, err)
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -934,7 +934,7 @@ func TestContains_DestErr(t *testing.T) {
 	srcCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirSrc}, maxSizeBytes)
 	require.NoError(t, err)
 	destCache := &errorCache{}
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -961,7 +961,7 @@ func TestMetadata(t *testing.T) {
 	require.NoError(t, err)
 	destCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirDest}, maxSizeBytes)
 	require.NoError(t, err)
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -993,7 +993,7 @@ func TestMetadata_DestErr(t *testing.T) {
 	srcCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirSrc}, maxSizeBytes)
 	require.NoError(t, err)
 	destCache := &errorCache{}
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -1020,7 +1020,7 @@ func TestFindMissing(t *testing.T) {
 	require.NoError(t, err)
 	destCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirDest}, maxSizeBytes)
 	require.NoError(t, err)
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{LogNotFoundErrors: true, DoubleReadPercentage: 1}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{LogNotFoundErrors: true, DoubleReadPercentage: 1}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -1057,7 +1057,7 @@ func TestFindMissing_DestSrcMismatch(t *testing.T) {
 	require.NoError(t, err)
 	destCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirDest}, maxSizeBytes)
 	require.NoError(t, err)
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{LogNotFoundErrors: true, DoubleReadPercentage: 1}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{LogNotFoundErrors: true, DoubleReadPercentage: 1}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -1100,7 +1100,7 @@ func TestFindMissing_DestErr(t *testing.T) {
 	srcCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirSrc}, maxSizeBytes)
 	require.NoError(t, err)
 	destCache := &errorCache{}
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -1133,7 +1133,7 @@ func TestGetMultiWithCopying(t *testing.T) {
 	require.NoError(t, err)
 	config := &migration_cache.MigrationConfig{}
 	config.SetConfigDefaults()
-	mc := migration_cache.NewMigrationCache(config, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, config, srcCache, destCache)
 	mc.Start() // Starts copying in background
 	defer mc.Stop()
 
@@ -1186,7 +1186,7 @@ func TestSetMulti(t *testing.T) {
 	require.NoError(t, err)
 	config := &migration_cache.MigrationConfig{}
 	config.SetConfigDefaults()
-	mc := migration_cache.NewMigrationCache(config, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, config, srcCache, destCache)
 
 	eg, ctx := errgroup.WithContext(ctx)
 	lock := sync.RWMutex{}
@@ -1235,7 +1235,7 @@ func TestDelete(t *testing.T) {
 	require.NoError(t, err)
 	destCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirDest}, maxSizeBytes)
 	require.NoError(t, err)
-	mc := migration_cache.NewMigrationCache(&migration_cache.MigrationConfig{}, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, &migration_cache.MigrationConfig{}, srcCache, destCache)
 
 	d, buf := testdigest.NewRandomDigestBuf(t, 100)
 	r := &rspb.ResourceName{
@@ -1287,7 +1287,7 @@ func TestReadWrite(t *testing.T) {
 		DoubleReadPercentage: 1.0,
 	}
 	config.SetConfigDefaults()
-	mc := migration_cache.NewMigrationCache(config, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, config, srcCache, destCache)
 	mc.Start() // Starts copying in background
 	defer mc.Stop()
 
@@ -1360,7 +1360,7 @@ func TestReaderWriter_DestFails(t *testing.T) {
 	destCache := &errorCache{}
 	config := &migration_cache.MigrationConfig{DoubleReadPercentage: 1.0}
 	config.SetConfigDefaults()
-	mc := migration_cache.NewMigrationCache(config, srcCache, destCache)
+	mc := migration_cache.NewMigrationCache(te, config, srcCache, destCache)
 	mc.Start() // Starts copying in background
 	defer mc.Stop()
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2333,3 +2333,67 @@ func BenchmarkSet(b *testing.B) {
 		}
 	}
 }
+
+func TestSupportsEncryption(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	apiKey1 := "AK2222"
+	group1 := "GR7890"
+	apiKey2 := "AK3333"
+	group2 := "GR1111"
+	testUsers := testauth.TestUsers(apiKey1, group1, apiKey2, group2)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(testUsers))
+
+	maxSizeBytes := int64(1_000_000_000) // 1GB
+	rootDir := testfs.MakeTempDir(t)
+	group1PartitionID := "user1part"
+	group2PartitionID := "user2part"
+	opts := &pebble_cache.Options{
+		RootDirectory:          rootDir,
+		MaxSizeBytes:           maxSizeBytes,
+		MaxInlineFileSizeBytes: 100,
+		Partitions: []disk.Partition{
+			{
+				ID:           pebble_cache.DefaultPartitionID,
+				MaxSizeBytes: maxSizeBytes,
+			},
+			{
+				ID:           group1PartitionID,
+				MaxSizeBytes: maxSizeBytes,
+			},
+			{
+				ID:                  group2PartitionID,
+				MaxSizeBytes:        maxSizeBytes,
+				EncryptionSupported: true,
+			},
+		},
+		PartitionMappings: []disk.PartitionMapping{
+			{
+				GroupID:     group1,
+				PartitionID: group1PartitionID,
+			},
+			{
+				GroupID:     group2,
+				PartitionID: group2PartitionID,
+			},
+		},
+	}
+
+	pc, err := pebble_cache.NewPebbleCache(te, opts)
+	require.NoError(t, err)
+	err = pc.Start()
+	require.NoError(t, err)
+
+	// Anon write should go to the default partition which doesn't support
+	// encryption.
+	ctx := getAnonContext(t, te)
+	require.False(t, pc.SupportsEncryption(ctx))
+
+	// First group is mapped to a partition that does not have encryption
+	// support.
+	ctx = te.GetAuthenticator().AuthContextFromAPIKey(context.Background(), apiKey1)
+	require.False(t, pc.SupportsEncryption(ctx))
+
+	// Second user should be able to use encryption.
+	ctx = te.GetAuthenticator().AuthContextFromAPIKey(context.Background(), apiKey2)
+	require.True(t, pc.SupportsEncryption(ctx))
+}

--- a/enterprise/server/backends/redis_cache/redis_cache.go
+++ b/enterprise/server/backends/redis_cache/redis_cache.go
@@ -372,3 +372,7 @@ func (c *Cache) Stop() error {
 func (c *Cache) SupportsCompressor(compressor repb.Compressor_Value) bool {
 	return compressor == repb.Compressor_IDENTITY
 }
+
+func (c *Cache) SupportsEncryption(ctx context.Context) bool {
+	return false
+}

--- a/enterprise/server/backends/s3_cache/s3_cache.go
+++ b/enterprise/server/backends/s3_cache/s3_cache.go
@@ -598,3 +598,7 @@ func (s3c *S3Cache) Stop() error {
 func (s3c *S3Cache) SupportsCompressor(compressor repb.Compressor_Value) bool {
 	return compressor == repb.Compressor_IDENTITY
 }
+
+func (s3c *S3Cache) SupportsEncryption(ctx context.Context) bool {
+	return false
+}

--- a/enterprise/server/composable_cache/composable_cache.go
+++ b/enterprise/server/composable_cache/composable_cache.go
@@ -277,3 +277,7 @@ func (c *ComposableCache) Writer(ctx context.Context, r *rspb.ResourceName) (int
 func (c *ComposableCache) SupportsCompressor(compressor repb.Compressor_Value) bool {
 	return compressor == repb.Compressor_IDENTITY
 }
+
+func (c *ComposableCache) SupportsEncryption(ctx context.Context) bool {
+	return false
+}

--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -594,3 +594,7 @@ func (rc *RaftCache) Delete(ctx context.Context, r *rspb.ResourceName) error {
 func (rc *RaftCache) SupportsCompressor(compressor repb.Compressor_Value) bool {
 	return compressor == repb.Compressor_IDENTITY
 }
+
+func (rc *RaftCache) SupportsEncryption(ctx context.Context) bool {
+	return false
+}

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -1243,3 +1243,7 @@ func (p *partition) writer(ctx context.Context, r *rspb.ResourceName) (interface
 func (c *DiskCache) SupportsCompressor(compressor repb.Compressor_Value) bool {
 	return compressor == repb.Compressor_IDENTITY
 }
+
+func (c *DiskCache) SupportsEncryption(ctx context.Context) bool {
+	return false
+}

--- a/server/backends/memory_cache/memory_cache.go
+++ b/server/backends/memory_cache/memory_cache.go
@@ -255,3 +255,7 @@ func (m *MemoryCache) Stop() error {
 func (m *MemoryCache) SupportsCompressor(compressor repb.Compressor_Value) bool {
 	return compressor == repb.Compressor_IDENTITY
 }
+
+func (c *MemoryCache) SupportsEncryption(ctx context.Context) bool {
+	return false
+}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -240,6 +240,7 @@ type Cache interface {
 
 	// SupportsCompressor returns whether the cache supports storing data compressed with the given compressor
 	SupportsCompressor(compressor repb.Compressor_Value) bool
+	SupportsEncryption(ctx context.Context) bool
 }
 
 type StoppableCache interface {


### PR DESCRIPTION
This is currently only true for pebble cache if the user is mapped to a partition that has encryption support enabled.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
