### PR TITLE
Firecracker: fix corruption due to resuming VM after snapshotting

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1610,10 +1610,6 @@ func (c *FirecrackerContainer) remove(ctx context.Context) error {
 	// point either (a) the VM should be paused and we should have already taken
 	// a snapshot, or (b) we are just calling Remove() to force a cleanup
 	// regardless of VM state (e.g. executor shutdown).
-	//
-	// Also note that firecracker doesn't have a clean shutdown mechanism
-	// currently; machine.Shutdown() in the Go SDK doesn't actually shutdown;
-	// instead it sends Ctrl+Alt+Del which just logs out.
 
 	if err := c.machine.StopVMM(); err != nil {
 		log.CtxErrorf(ctx, "Error stopping VMM: %s", err)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -522,6 +522,16 @@ func (c *FirecrackerContainer) unpackBaseSnapshot(ctx context.Context) (string, 
 	return baseDir, nil
 }
 
+// SaveSnapshot pauses the VM and takes a snapshot, saving the snapshot to
+// cache.
+//
+// If the VM is resumed after this point, the VM state and memory snapshots
+// immediately become invalid and another call to SaveSnapshot is required. This
+// is because we don't save a copy of the disk when taking a snapshot, and
+// instead reuse the same disk image across snapshots (for performance reasons).
+// Resuming the VM may change the disk state, causing the original VM state to
+// become invalid (e.g., the kernel's page cache may no longer be in sync with
+// the disk, which can cause all sorts of issues).
 func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context) error {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
@@ -617,13 +627,6 @@ func (c *FirecrackerContainer) SaveSnapshot(ctx context.Context) error {
 		return err
 	}
 	log.CtxDebugf(ctx, "snaploader.CacheSnapshot took %s", time.Since(snaploaderStart))
-
-	resumeStart := time.Now()
-	if err := c.machine.ResumeVM(ctx); err != nil {
-		return err
-	}
-	log.CtxDebugf(ctx, "VMM ResumeVM took %s", time.Since(resumeStart))
-
 	return nil
 }
 
@@ -1603,12 +1606,17 @@ func (c *FirecrackerContainer) remove(ctx context.Context) error {
 
 	var lastErr error
 
-	if err := c.machine.Shutdown(ctx); err != nil {
-		log.CtxErrorf(ctx, "Error shutting down machine: %s", err)
-		lastErr = err
-	}
+	// Note: we don't attempt any kind of clean shutdown here, because at this
+	// point either (a) the VM should be paused and we should have already taken
+	// a snapshot, or (b) we are just calling Remove() to force a cleanup
+	// regardless of VM state (e.g. executor shutdown).
+	//
+	// Also note that firecracker doesn't have a clean shutdown mechanism
+	// currently; machine.Shutdown() in the Go SDK doesn't actually shutdown;
+	// instead it sends Ctrl+Alt+Del which just logs out.
+
 	if err := c.machine.StopVMM(); err != nil {
-		log.CtxErrorf(ctx, "Error stopping VM: %s", err)
+		log.CtxErrorf(ctx, "Error stopping VMM: %s", err)
 		lastErr = err
 	}
 	if err := c.cleanupNetworking(ctx); err != nil {


### PR DESCRIPTION
Before this PR, the firecracker implementation of `Pause()` would take the following steps:

1. Pause the VM
2. Take a VM state snapshot + memory snapshot
3. Save all snapshot artifacts to filecache (VM state, memory, disk). Importantly, the disk snapshot is not copied. Instead, we reuse the same disk image across snapshots.
4. Resume the VM
5. "Shut down" the VM (`machine.ShutDown()`)
6. Stop the VMM (`machine.StopVMM()`, which kills firecracker using SIGTERM)
7. Clean up networking
8. Remove all temp files

There are a bunch of problems with this approach:

- `machine.ShutDown()` (step 4) doesn't actually shut down the VM; instead it sends Ctrl+Alt+Del which on Linux just logs out.
- Even if we could do a clean shut down of the VM, it would be unnecessary. We've already taken a snapshot pre-shutdown, and we want to resume the VM from this pre-shutdown state. Any cleanup work done in shutdown would not be reflected in the VM state / memory snapshot.
- Resuming the VM after we've taken a snapshot occasionally causes the snapshot to become corrupt (about 10% of the time, based on some local testing). This is because we don't actually create a proper snapshot of the disk image (for performance reasons). Instead we reuse the same disk image across VM snapshots. By resuming the VM, we're risking the disk snapshot getting mutated, e.g. because of deferred writes due to kernel page caching, or other background process writes (e.g. docker daemon or bazel server process). This will cause the snapshotted kernel page cache to go out of sync with the disk, which can cause all sorts of issues.
- If the `ShutDown()` times out (which usually happens whenever there is corruption), we also fail to clean up the network. This is because the network cleanup uses the same context as the machine shutdown context, which timed out. These network cleanup failures can cause other issues after enough actions are run on the same executor. This is because we only have 1000 possible IPs on the host that we can assign, and we cycle through those IPs. If we fail to clean up one of the networks assigned to one of the IPs then we may fail to set up the network the next time we wrap back around to that IP.  Or worse, we could successfully set up the network but it may be in an unexpected state (I haven't dug into this to see whether we ever use more than 1000 IPs in a single executor run in practice).

So, this PR just removes steps 4 and 5 to fix the corruption as well as potential networking issues.

Tested with 10 builds, where each build consists of 10 actions (so 100 actions total per test). Each action has recycle-runner=true, and a unique runner pool key (action 1 can only reuse VM 1, action 2 can only reuse VM 2, etc.). Actions are run in parallel with `--jobs=3`. Each test was allowed a "warmup" build to populate the runner pool.

Before this PR:

```
N=10*10, WARM=90, COLD=10, WARM_RATIO=90.00%
AVG_BUILD_DURATION_SECONDS=3.77
```

After this PR:

```
N=10*10, WARM=100, COLD=0, WARM_RATIO=100.00%
AVG_BUILD_DURATION_SECONDS=2.26
```

In the "before" scenario, there are lots of errors logged like "Error shutting down machine: context deadline exceeded." which are likely due to the VM getting into a corrupted state.

---

**Version bump**: Patch
