### PR TITLE
Make pebble key migrator rate limit only apply to moves.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -670,7 +670,6 @@ func (p *PebbleCache) migrateData(quitChan chan struct{}) error {
 			return nil
 		default:
 		}
-		_ = limiter.Wait(p.env.GetServerContext())
 
 		if time.Since(lastStatusUpdate) > 10*time.Second {
 			log.Infof("Pebble Cache: data migration progress: saw %d keys, migrated %d to version: %d in %s. Current key: %q", keysSeen, keysMigrated, maxVersion, time.Since(migrationStart), string(iter.Key()))
@@ -712,6 +711,8 @@ func (p *PebbleCache) migrateData(quitChan chan struct{}) error {
 		if version < minVersion {
 			minVersion = version
 		}
+
+		_ = limiter.Wait(p.env.GetServerContext())
 
 		moveKey := func() error {
 			keyBytes, err := key.Bytes(version)


### PR DESCRIPTION
We have not run into issues in the past with scanning over the keys in the database.

The current migration won't finish before the next release. 

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
