### PR TITLE
Add soci binary to app image

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6091,6 +6091,13 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         executable = True,
         downloaded_file_path = "soci-store-v0.1-linux-amd64",
     )
+    http_file(
+        name = "com_github_iain_macdonald_soci_snapshotter-soci-v0.2.3-linux-amd64",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-v0.2.3-linux-amd64"],
+        sha256 = "7a9c7b3e49cdd5ea81e1a57576fc17f04ef8ff1f1234e38666ba7bfef1dcd42b",
+        executable = True,
+        downloaded_file_path = "soci-v0.2.3-linux-amd64",
+    )
 
     http_file(
         name = "com_github_redis_redis-redis-server-v6.2.1-linux-x86_64",

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_layer")
 
 # gazelle:default_visibility //enterprise:__subpackages__,@buildbuddy_internal//:__subpackages__
 package(default_visibility = [
@@ -92,9 +92,21 @@ go_binary(
     embed = [":server_lib"],
 )
 
+container_layer(
+    name = "app_tools",
+    directory = "/usr/bin",
+    files = [
+        "@com_github_iain_macdonald_soci_snapshotter-soci-v0.2.3-linux-amd64//file:soci-v0.2.3-linux-amd64",
+    ],
+    symlinks = {
+        "/usr/bin/soci": "/usr/bin/soci-v0.2.3-linux-amd64",
+    },
+)
+
 container_image(
     name = "base_image",
     base = "@buildbuddy_go_image_base//image",
+    layers = [":app_tools"],
     symlinks = {
         "config.yaml": "app/enterprise/server/cmd/server/buildbuddy.runfiles/buildbuddy/enterprise/config/buildbuddy.release.yaml",
         "buildbuddy": "tmp",


### PR DESCRIPTION
This will be used in https://github.com/buildbuddy-io/buildbuddy/pull/3726

Longer term I would like to just call the code directly and remove this dependency, but for now this is simpler.
