### PR TITLE
refactor: clean up `this.setState({ ...this.state, ... })`

### DIFF
--- a/app/docs/BUILD
+++ b/app/docs/BUILD
@@ -30,6 +30,5 @@ ts_library(
         "//proto:bazel_config_ts_proto",
         "@npm//@types/react",
         "@npm//react",
-        "@npm//tslib",
     ],
 )

--- a/app/docs/setup.tsx
+++ b/app/docs/setup.tsx
@@ -29,7 +29,7 @@ export default class SetupComponent extends React.Component<Props> {
       .getBazelConfig(request)
       .then((response: bazel_config.GetBazelConfigResponse) => {
         console.log(response);
-        this.setState({ ...this.state, bazelConfigResponse: response });
+        this.setState({ bazelConfigResponse: response });
       })
       .catch((e) => error_service.handleError(e));
   }

--- a/app/docs/setup_code.tsx
+++ b/app/docs/setup_code.tsx
@@ -38,7 +38,7 @@ export default class SetupCodeComponent extends React.Component<Props, State> {
 
   componentWillMount() {
     authService.userStream.subscribe({
-      next: (user: User) => this.setState({ ...this.state, user }),
+      next: (user: User) => this.setState({ user }),
     });
 
     if (this.props.bazelConfigResponse) {

--- a/app/invocation/invocation_artifacts_card.tsx
+++ b/app/invocation/invocation_artifacts_card.tsx
@@ -31,7 +31,7 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
   }
 
   handleMoreArtifactsClicked() {
-    this.setState({ ...this.state, numPages: this.state.numPages + 1 });
+    this.setState({ numPages: this.state.numPages + 1 });
   }
 
   render() {

--- a/app/invocation/invocation_details_card.tsx
+++ b/app/invocation/invocation_details_card.tsx
@@ -24,7 +24,6 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
 
   handleMoreInvocationClicked() {
     this.setState({
-      ...this.state,
       limit: this.state.limit ? undefined : defaultPageSize,
     });
   }

--- a/app/invocation/invocation_raw_logs_card.tsx
+++ b/app/invocation/invocation_raw_logs_card.tsx
@@ -37,7 +37,7 @@ export default class RawLogsCardComponent extends React.Component<Props, State> 
   }
 
   handleFilterChange(event: any) {
-    this.setState({ ...this.state, filterString: event.target.value });
+    this.setState({ filterString: event.target.value });
   }
 
   handleDownloadClicked() {

--- a/app/root/BUILD.bazel
+++ b/app/root/BUILD.bazel
@@ -23,6 +23,5 @@ ts_library(
         "//app/router",
         "@npm//@types/react",
         "@npm//react",
-        "@npm//tslib",
     ],
 )

--- a/app/root/root.tsx
+++ b/app/root/root.tsx
@@ -37,7 +37,7 @@ export default class RootComponent extends React.Component {
     authService.register();
     router.register(this.handlePathChange.bind(this));
     authService.userStream.subscribe({
-      next: (user?: User) => this.setState({ ...this.state, user }),
+      next: (user?: User) => this.setState({ user }),
     });
     faviconService.setDefaultFavicon();
     window._preferences = this.state.preferences;
@@ -60,7 +60,7 @@ export default class RootComponent extends React.Component {
   }
 
   handlePreferencesChanged() {
-    this.setState({ ...this.state, preferences: this.state.preferences });
+    this.forceUpdate();
   }
 
   render() {

--- a/app/target/BUILD
+++ b/app/target/BUILD
@@ -39,7 +39,6 @@ ts_library(
         "@npm//@types/react",
         "@npm//lucide-react",
         "@npm//react",
-        "@npm//tslib",
     ],
 )
 
@@ -54,7 +53,6 @@ ts_library(
         "@npm//@types/react",
         "@npm//lucide-react",
         "@npm//react",
-        "@npm//tslib",
     ],
 )
 
@@ -110,7 +108,6 @@ ts_library(
         "@npm//@types/react",
         "@npm//lucide-react",
         "@npm//react",
-        "@npm//tslib",
     ],
 )
 

--- a/app/target/action_card.tsx
+++ b/app/target/action_card.tsx
@@ -50,23 +50,21 @@ export default class ActionCardComponent extends React.Component<Props, State> {
     }
 
     if (!logUrl.startsWith("bytestream://")) {
-      this.setState({ ...this.state, cacheEnabled: false });
+      this.setState({ cacheEnabled: false });
       return;
     }
 
-    this.setState({ ...this.state, loadingStderr: true });
+    this.setState({ loadingStderr: true });
     rpcService
       .fetchBytestreamFile(logUrl, this.props.invocationId)
       .then((contents: string) => {
         this.setState({
-          ...this.state,
           stdErr: contents,
           loadingStderr: false,
         });
       })
       .catch(() => {
         this.setState({
-          ...this.state,
           stdErr: "Error loading bytestream stderr!",
         });
       });
@@ -80,23 +78,21 @@ export default class ActionCardComponent extends React.Component<Props, State> {
     }
 
     if (!logUrl.startsWith("bytestream://")) {
-      this.setState({ ...this.state, cacheEnabled: false });
+      this.setState({ cacheEnabled: false });
       return;
     }
 
-    this.setState({ ...this.state, loadingStdout: true });
+    this.setState({ loadingStdout: true });
     rpcService
       .fetchBytestreamFile(logUrl, this.props.invocationId)
       .then((contents: string) => {
         this.setState({
-          ...this.state,
           stdOut: contents,
           loadingStdout: false,
         });
       })
       .catch(() => {
         this.setState({
-          ...this.state,
           stdErr: "Error loading bytestream stdout!",
         });
       });

--- a/app/target/target_artifacts_card.tsx
+++ b/app/target/target_artifacts_card.tsx
@@ -47,17 +47,16 @@ export default class TargetArtifactsCardComponent extends React.Component<Props,
       return;
     }
 
-    this.setState({ ...this.state, loading: true });
+    this.setState({ loading: true });
     const request = new zip.GetZipManifestRequest();
     request.uri = testOutputsUri;
     rpcService.service
       .getZipManifest(request)
       .then((response) => {
-        this.setState({ ...this.state, manifest: response.manifest, loading: false });
+        this.setState({ manifest: response.manifest, loading: false });
       })
       .catch(() => {
         this.setState({
-          ...this.state,
           loading: false,
           manifest: null,
         });

--- a/app/target/target_test_log_card.tsx
+++ b/app/target/target_test_log_card.tsx
@@ -47,19 +47,18 @@ export default class TargetTestLogCardComponent extends React.Component<Props, S
     }
 
     if (!testLogUrl.startsWith("bytestream://")) {
-      this.setState({ ...this.state, cacheEnabled: false });
+      this.setState({ cacheEnabled: false });
       return;
     }
 
-    this.setState({ ...this.state, loading: true });
+    this.setState({ loading: true });
     rpcService
       .fetchBytestreamFile(testLogUrl, this.props.invocationId)
       .then((contents: string) => {
-        this.setState({ ...this.state, testLog: contents, loading: false });
+        this.setState({ testLog: contents, loading: false });
       })
       .catch(() => {
         this.setState({
-          ...this.state,
           loading: false,
           testLog: "Error loading bytestream test.log!",
         });

--- a/enterprise/app/root/BUILD.bazel
+++ b/enterprise/app/root/BUILD.bazel
@@ -42,6 +42,5 @@ ts_library(
         "@npm//@types/react",
         "@npm//lucide-react",
         "@npm//react",
-        "@npm//tslib",
     ],
 )

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -76,10 +76,10 @@ export default class EnterpriseRootComponent extends React.Component {
 
   componentWillMount() {
     if (!capabilities.auth) {
-      this.setState({ ...this.state, user: undefined, loading: false });
+      this.setState({ user: undefined, loading: false });
     }
     authService.userStream.subscribe({
-      next: (user?: User) => this.setState({ ...this.state, user, loading: false }),
+      next: (user?: User) => this.setState({ user, loading: false }),
     });
     authService.register();
     router.register(this.handlePathChange.bind(this));
@@ -105,7 +105,7 @@ export default class EnterpriseRootComponent extends React.Component {
   }
 
   handlePreferencesChanged() {
-    this.setState({ ...this.state, preferences: this.state.preferences });
+    this.forceUpdate();
   }
 
   handleOrganizationClicked() {

--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -140,7 +140,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
       request.query.pattern = pattern;
     }
 
-    this.setState({ ...this.state, loading: true });
+    this.setState({ loading: true });
     rpcService.service.getTrend(request).then((response) => {
       console.log(response);
       const dateToStatMap = new Map<string, stats.ITrendStat>();
@@ -152,7 +152,6 @@ export default class TrendsComponent extends React.Component<Props, State> {
         dateToExecutionStatMap.set(stat.name ?? "", stat);
       }
       this.setState({
-        ...this.state,
         stats: response.trendStat,
         dates: getDatesBetween(
           // Start date should always be defined.


### PR DESCRIPTION
It's not necessary to explicitly spread `...this.state` when calling `setState()` since React will preserve existing state and update only the keys specified in the passed in state updates record.

Also clean up `this.setState({ x: this.state.x })`. It's more clear to call `forceUpdate()` in this scenario.

---

**Version bump**: Patch
