### PR TITLE
Print bb version in checkstyle

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -66,6 +66,7 @@ jobs:
         run: |
           # Invoke gazelle via bb fix for TypeScript support
           cli/install.sh
+          bb version
           bb fix -mode diff > gazelle-diff.txt || true
           echo "gazelle diff:"
           cat gazelle-diff.txt


### PR DESCRIPTION
When I install the latest version of `bb` and run `bb fix -mode diff` on master, it produces a non-empty diff. This is a bit of a head-scratcher since checkstyle is passing.

Adding a `bb version` step just to sanity check which version of `bb` we're using for checkstyle.

**Related issues**: N/A
