### PR TITLE
Don't throw an error on duplicate keyboard shortcut

### DIFF
--- a/app/shortcuts/shortcuts.tsx
+++ b/app/shortcuts/shortcuts.tsx
@@ -141,7 +141,7 @@ export class Shortcuts {
     let shortcut = new Shortcut(keyCombo, action);
     for (let otherShortcut of this.shortcuts.values()) {
       if (shortcut.collidesWith(otherShortcut)) {
-        console.warn("Duplicate keyboard shortcut registered: " + shortcut.keyCombo)
+        console.warn("Duplicate keyboard shortcut registered: " + shortcut.keyCombo);
         // TODO(iain): throw an error here once bugs are bashed.
         // throw new Error("Duplicate keyboard shortcut registered: " + shortcut.keyCombo);
       }

--- a/app/shortcuts/shortcuts.tsx
+++ b/app/shortcuts/shortcuts.tsx
@@ -141,7 +141,9 @@ export class Shortcuts {
     let shortcut = new Shortcut(keyCombo, action);
     for (let otherShortcut of this.shortcuts.values()) {
       if (shortcut.collidesWith(otherShortcut)) {
-        throw new Error("Duplicate keyboard shortcut registered: " + shortcut.keyCombo);
+        console.warn("Duplicate keyboard shortcut registered: " + shortcut.keyCombo)
+        // TODO(iain): throw an error here once bugs are bashed.
+        // throw new Error("Duplicate keyboard shortcut registered: " + shortcut.keyCombo);
       }
     }
     this.shortcuts.set(handle, shortcut);


### PR DESCRIPTION
This causes an issue clicking into sub-invocations from workflow invocations.