### PR TITLE
Sever BUILD link between app and sociartifactstore

### DIFF
--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -47,7 +47,6 @@ go_library(
         "//enterprise/server/scheduling/task_router",
         "//enterprise/server/secrets",
         "//enterprise/server/selfauth",
-        "//enterprise/server/sociartifactstore",
         "//enterprise/server/splash",
         "//enterprise/server/suggestion",
         "//enterprise/server/tasksize",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -36,7 +36,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_router"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/secrets"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/selfauth"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/sociartifactstore"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/splash"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/suggestion"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/tasksize"
@@ -272,9 +271,6 @@ func main() {
 		log.Fatalf("%v", err)
 	}
 	if err := crypter_service.Register(realEnv); err != nil {
-		log.Fatalf("%v", err)
-	}
-	if err := sociartifactstore.Register(realEnv); err != nil {
 		log.Fatalf("%v", err)
 	}
 


### PR DESCRIPTION
Since https://github.com/buildbuddy-io/buildbuddy/pull/3726 the apps have failed to start due to:

`ERROR 2023-04-19T20:05:17.461150912Z [resource.labels.containerName: migrate-db] /app/enterprise/buildbuddy: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory`

Siggi and I suspect this is due to something in the soci code that we're now depending on. This PR breaks the build-time link between the app/server code and sociartifactstore so this error should stop happening, but without having to revert that entire PR (which now has a second one stacked on top).
