### PR TITLE
Move shortcut registration calls from componentWillMount to componentDidMount

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -89,7 +89,9 @@ export default class InvocationComponent extends React.Component<Props, State> {
       next: () => this.forceUpdate(),
     });
     this.logsModel.startFetching();
+  }
 
+  componentDidMount() {
     let handle = shortcuts.register(KeyCombo.u, () => {
       // Used to select the correct invocation on the history page so that
       // selecting an invocation with 'enter' and then going back with 'u' ends

--- a/app/invocation/invocation_share_button.tsx
+++ b/app/invocation/invocation_share_button.tsx
@@ -45,7 +45,7 @@ export default class InvocationShareButtonComponent extends React.Component<
 
   private inputRef = React.createRef<HTMLInputElement>();
 
-  componentWillMount() {
+  componentDidMount() {
     let handle = shortcuts.register(KeyCombo.shift_c, () => {
       this.copyShareUrl();
     });

--- a/app/shortcuts/shortcuts.tsx
+++ b/app/shortcuts/shortcuts.tsx
@@ -111,6 +111,10 @@ export class Shortcuts {
   // no longer invokable. This function will throw an error if the same
   // shortcut is registered multiple times, so if the calling component will
   // unmount and remount, shortcuts should be deregistered and reregistered.
+  //
+  // IMPORTANT: usually you'll want to register shortcuts in componentDidMount
+  // not componentWillMount because componentWillMount can be called when
+  // another component is still mounted, causing shortcut conflicts.
   public register(keyCombo: KeyCombo, action: () => void): string {
     return this.registerSequence([keyCombo], action);
   }
@@ -121,6 +125,10 @@ export class Shortcuts {
   // same shortcut is registered multiple times, so if the calling component
   // will unmount and remount, shortcuts should be deregistered and
   // reregistered.
+  //
+  // IMPORTANT: usually you'll want to register shortcuts in componentDidMount
+  // not componentWillMount because componentWillMount can be called when
+  // another component is still mounted, causing shortcut conflicts.
   public registerSequence(keyCombo: KeyCombo[], action: () => void): string {
     if (this.shortcuts == null) {
       this.shortcuts = new Map<string, Shortcut>();

--- a/app/shortcuts/shortcuts.tsx
+++ b/app/shortcuts/shortcuts.tsx
@@ -141,9 +141,7 @@ export class Shortcuts {
     let shortcut = new Shortcut(keyCombo, action);
     for (let otherShortcut of this.shortcuts.values()) {
       if (shortcut.collidesWith(otherShortcut)) {
-        console.warn("Duplicate keyboard shortcut registered: " + shortcut.keyCombo);
-        // TODO(iain): throw an error here once bugs are bashed.
-        // throw new Error("Duplicate keyboard shortcut registered: " + shortcut.keyCombo);
+        throw new Error("Duplicate keyboard shortcut registered: " + shortcut.keyCombo);
       }
     }
     this.shortcuts.set(handle, shortcut);


### PR DESCRIPTION
This is to fix a bug with shortcuts where a link from a synthetic workflow invocation to its sub-invocations would crash the page due to the Error thrown in duplicate keyboard shortcut detection. This is because when navigating to that link, React creates the invocation component for the sub-invocation and calls `componentWillMount()` before calling `componentWillUnmount()` on the previous, synthetic invocation. However, it doesn't call `componentDidMount()` until the previous component is unmounted, so if we register the shortcuts in there instead then there are no duplicate shortcuts registered.