### PR TITLE
Use ANSI quotes for queries and quote table names

### DIFF
--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -84,7 +84,7 @@ func (s *APIServer) GetInvocation(ctx context.Context, req *apipb.GetInvocationR
 		return nil, status.InvalidArgumentErrorf("InvocationSelector must contain a valid invocation_id or commit_sha")
 	}
 
-	q := query_builder.NewQuery(`SELECT * FROM Invocations`)
+	q := query_builder.NewQuery(`SELECT * FROM "Invocations"`)
 	q = q.AddWhereClause(`group_id = ?`, user.GetGroupID())
 	if req.GetSelector().GetInvocationId() != "" {
 		q = q.AddWhereClause(`invocation_id = ?`, req.GetSelector().GetInvocationId())

--- a/enterprise/server/execution_search_service/execution_search_service.go
+++ b/enterprise/server/execution_search_service/execution_search_service.go
@@ -129,7 +129,7 @@ func (s *ExecutionSearchService) SearchExecutions(ctx context.Context, req *expb
 		return nil, err
 	}
 
-	q := query_builder.NewQuery(`SELECT * FROM Executions`)
+	q := query_builder.NewQuery(`SELECT * FROM "Executions"`)
 
 	// Always filter to the currently selected (and authorized) group.
 	q.AddWhereClause("group_id = ?", u.GetGroupID())

--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -67,9 +67,9 @@ func (es *ExecutionService) queryExecutions(ctx context.Context, baseQuery *quer
 
 func (es *ExecutionService) getInvocationExecutions(ctx context.Context, invocationID string) ([]tables.Execution, error) {
 	q := query_builder.NewQuery(`
-		SELECT e.* FROM InvocationExecutions ie
-		JOIN Executions e ON e.execution_id = ie.execution_id
-		JOIN Invocations i ON i.invocation_id = e.invocation_id
+		SELECT e.* FROM "InvocationExecutions" ie
+		JOIN "Executions" e ON e.execution_id = ie.execution_id
+		JOIN "Invocations" i ON i.invocation_id = e.invocation_id
 	`)
 	q.AddWhereClause(`ie.invocation_id = ?`, invocationID)
 	return es.queryExecutions(ctx, q)

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -160,7 +160,7 @@ func (a *GitHubApp) handleInstallationEvent(ctx context.Context, event *github.I
 		return nil
 	}
 	result := a.env.GetDBHandle().DB(ctx).Exec(`
-		DELETE FROM GitHubAppInstallations
+		DELETE FROM "GitHubAppInstallations"
 		WHERE installation_id = ?
 	`, event.GetInstallation().GetID())
 	if result.Error != nil {
@@ -193,7 +193,7 @@ func (a *GitHubApp) handleWorkflowEvent(ctx context.Context, event any) error {
 	}{}
 	err = a.env.GetDBHandle().DB(ctx).Raw(`
 		SELECT i.installation_id, r.*
-		FROM GitHubAppInstallations i, GitRepositories r
+		FROM "GitHubAppInstallations" i, "GitRepositories" r
 		WHERE r.repo_url = ?
 		AND i.owner = ?
 		AND i.group_id = r.group_id
@@ -217,7 +217,7 @@ func (a *GitHubApp) GetInstallationToken(ctx context.Context, owner string) (str
 	var installation tables.GitHubAppInstallation
 	err = a.env.GetDBHandle().DB(ctx).Raw(`
 		SELECT *
-		FROM GitHubAppInstallations
+		FROM "GitHubAppInstallations"
 		WHERE group_id = ?
 		AND owner = ?
 	`, u.GetGroupID(), owner).Take(&installation).Error
@@ -243,7 +243,7 @@ func (a *GitHubApp) GetGitHubAppInstallations(ctx context.Context, req *ghpb.Get
 	db := a.env.GetDBHandle().DB(ctx)
 	rows, err := db.Raw(`
 		SELECT *
-		FROM GitHubAppInstallations
+		FROM "GitHubAppInstallations"
 		WHERE group_id = ?
 		ORDER BY owner ASC
 	`, u.GetGroupID()).Rows()
@@ -324,7 +324,7 @@ func (a *GitHubApp) createInstallation(ctx context.Context, in *tables.GitHubApp
 		// first. That installation must be stale since GitHub only allows
 		// one installation per owner.
 		err := tx.Exec(`
-			DELETE FROM GitHubAppInstallations
+			DELETE FROM "GitHubAppInstallations"
 			WHERE owner = ?`,
 			in.Owner,
 		).Error
@@ -350,7 +350,7 @@ func (a *GitHubApp) UnlinkGitHubAppInstallation(ctx context.Context, req *ghpb.U
 		var ti tables.GitHubAppInstallation
 		err := tx.Raw(`
 			SELECT *
-			FROM GitHubAppInstallations
+			FROM "GitHubAppInstallations"
 			WHERE installation_id = ?
 			`+dbh.SelectForUpdateModifier()+`
 		`, req.GetInstallationId()).Take(&ti).Error
@@ -361,7 +361,7 @@ func (a *GitHubApp) UnlinkGitHubAppInstallation(ctx context.Context, req *ghpb.U
 			return err
 		}
 		return tx.Exec(`
-			DELETE FROM GitHubAppInstallations
+			DELETE FROM "GitHubAppInstallations"
 			WHERE installation_id = ?
 		`, req.GetInstallationId()).Error
 	})
@@ -378,7 +378,7 @@ func (a *GitHubApp) GetInstallationByOwner(ctx context.Context, owner string) (*
 	}
 	installation := &tables.GitHubAppInstallation{}
 	err = a.env.GetDBHandle().DB(ctx).Raw(`
-		SELECT * FROM GitHubAppInstallations
+		SELECT * FROM "GitHubAppInstallations"
 		WHERE group_id = ?
 		AND owner = ?
 	`, u.GetGroupID(), owner).Take(installation).Error
@@ -399,7 +399,7 @@ func (a *GitHubApp) GetLinkedGitHubRepos(ctx context.Context, req *ghpb.GetLinke
 	d := a.env.GetDBHandle().DB(ctx)
 	rows, err := d.Raw(`
 		SELECT *
-		FROM GitRepositories
+		FROM "GitRepositories"
 		WHERE group_id = ?
 		ORDER BY repo_url ASC
 	`, u.GetGroupID()).Rows()
@@ -482,7 +482,7 @@ func (a *GitHubApp) UnlinkGitHubRepo(ctx context.Context, req *ghpb.UnlinkRepoRe
 		return nil, err
 	}
 	result := a.env.GetDBHandle().DB(ctx).Exec(`
-		DELETE FROM GitRepositories
+		DELETE FROM "GitRepositories"
 		WHERE group_id = ?
 		AND repo_url = ?
 	`, u.GetGroupID(), req.GetRepoUrl())

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -62,7 +62,7 @@ func (r *runnerService) lookupAPIKey(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	q := query_builder.NewQuery(`SELECT * FROM APIKeys`)
+	q := query_builder.NewQuery(`SELECT * FROM "APIKeys"`)
 	q.AddWhereClause("group_id = ?", u.GetGroupID())
 	qStr, qArgs := q.Build()
 	k := &tables.APIKey{}

--- a/enterprise/server/invocation_search_service/invocation_search_service.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service.go
@@ -119,7 +119,7 @@ func (s *InvocationSearchService) QueryInvocations(ctx context.Context, req *inp
 		return nil, status.ResourceExhaustedErrorf("Too many rows.")
 	}
 
-	q := query_builder.NewQuery(`SELECT * FROM Invocations as i`)
+	q := query_builder.NewQuery(`SELECT * FROM "Invocations" as i`)
 
 	// Don't include anonymous builds.
 	q.AddWhereClause("((i.user_id != '' AND i.user_id IS NOT NULL) OR (i.group_id != '' AND i.group_id IS NOT NULL))")

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -110,7 +110,7 @@ func (i *InvocationStatService) getTrendBasicQuery(timezoneOffsetMinutes int32) 
 	    SUM(total_upload_size_bytes) as total_upload_size_bytes,
 	    SUM(total_download_usec) as total_download_usec,
         SUM(total_upload_usec) as total_upload_usec
-        FROM Invocations`
+        FROM "Invocations"`
 	return q
 }
 
@@ -281,7 +281,7 @@ func (i *InvocationStatService) getInvocationTrend(ctx context.Context, req *stp
 func (i *InvocationStatService) getExecutionTrendQuery(timezoneOffsetMinutes int32) string {
 	return fmt.Sprintf("SELECT %s as name,", i.olapdbh.DateFromUsecTimestamp("updated_at_usec", timezoneOffsetMinutes)) + `
 	quantilesExactExclusive(0.5, 0.75, 0.9, 0.95, 0.99)(IF(worker_start_timestamp_usec > queued_timestamp_usec, worker_start_timestamp_usec - queued_timestamp_usec, 0)) AS queue_duration_usec_quantiles
-	FROM Executions
+	FROM "Executions"
 	`
 }
 
@@ -393,7 +393,7 @@ func (i *InvocationStatService) GetInvocationStatBaseQuery(aggColumn string) str
 	    COUNT(CASE WHEN (success AND invocation_status = 1) THEN 1 END) as total_num_sucessful_builds,
 	    COUNT(CASE WHEN (success != true AND invocation_status = 1) THEN 1 END) as total_num_failing_builds,
 	    SUM(action_count) as total_actions
-            FROM Invocations`
+            FROM "Invocations"`
 	return q
 }
 
@@ -411,7 +411,7 @@ type MetricRange = struct {
 }
 
 func (i *InvocationStatService) getMetricRange(ctx context.Context, table string, metric string, whereClauseStr string, whereClauseArgs []interface{}) (*MetricRange, error) {
-	rangeQuery := fmt.Sprintf("SELECT min(%s) as low, max(%s) as high FROM %s %s", metric, metric, table, whereClauseStr)
+	rangeQuery := fmt.Sprintf(`SELECT min(%s) as low, max(%s) as high FROM "%s" %s`, metric, metric, table, whereClauseStr)
 	var rows *sql.Rows
 	rows, err := i.olapdbh.RawWithOptions(ctx, clickhouse.Opts().WithQueryName("query_metric_range"), rangeQuery, whereClauseArgs...).Rows()
 	if err != nil {
@@ -617,7 +617,7 @@ func (i *InvocationStatService) getHeatmapQueryAndBuckets(ctx context.Context, r
 					roundDown(updated_at_usec, CAST(%s AS Array(Int64))) AS timestamp,
 					roundDown(%s, CAST(%s AS Array(Int64))) AS bucket,
 					count(*) AS v
-					FROM %s %s
+					FROM "%s" %s
 					GROUP BY timestamp, bucket)
 			GROUP BY timestamp, bucket ORDER BY timestamp, bucket)
 		GROUP BY timestamp ORDER BY timestamp`,
@@ -829,14 +829,14 @@ func (i *InvocationStatService) getDrilldownSubquery(ctx context.Context, drilld
 		return fmt.Sprintf(
 			`(SELECT %s, 0 AS totals_first, count(*) AS total,
 					countIf(%s) AS selection, countIf(not(%s)) AS inverse
-				FROM %s %s)`,
+				FROM "%s" %s)`,
 			nulledOutFieldList, drilldown, drilldown, table, where), args
 	}
 
 	return fmt.Sprintf(`
 		(SELECT %s, 1 AS totals_first, count(*) AS total, countIf(%s) AS selection,
 			countIf(not(%s)) AS inverse
-		FROM %s %s
+		FROM "%s" %s
 		GROUP BY %s ORDER BY selection DESCENDING, total DESCENDING LIMIT 25)`,
 		nulledOutFieldList, drilldown, drilldown, table, where, col), args
 }

--- a/enterprise/server/quota/quota_manager.go
+++ b/enterprise/server/quota/quota_manager.go
@@ -105,7 +105,7 @@ func fetchConfigFromDB(env environment.Env, namespace string) (map[string]*names
 	ctx := env.GetServerContext()
 	config := make(map[string]*namespaceConfig)
 	err := env.GetDBHandle().TransactionWithOptions(ctx, db.Opts().WithQueryName("fetch_quota_config"), func(tx *db.DB) error {
-		q := query_builder.NewQuery(`SELECT * FROM QuotaBuckets`)
+		q := query_builder.NewQuery(`SELECT * FROM "QuotaBuckets"`)
 		if namespace != "" {
 			q = q.AddWhereClause(`namespace = ?`, namespace)
 		}
@@ -137,7 +137,7 @@ func fetchConfigFromDB(env environment.Env, namespace string) (map[string]*names
 			}
 		}
 
-		groupQuery := query_builder.NewQuery(`SELECT * FROM QuotaGroups`)
+		groupQuery := query_builder.NewQuery(`SELECT * FROM "QuotaGroups"`)
 		if namespace != "" {
 			groupQuery = groupQuery.AddWhereClause(`namespace = ?`, namespace)
 		}
@@ -376,10 +376,10 @@ func (qm *QuotaManager) RemoveNamespace(ctx context.Context, req *qpb.RemoveName
 	}
 	err := qm.env.GetDBHandle().TransactionWithOptions(ctx, db.Opts().WithQueryName("query_manager_insert_buckets"), func(tx *db.DB) error {
 		ns := req.GetNamespace()
-		if err := tx.Exec(`DELETE FROM QuotaGroups WHERE namespace = ?`, ns).Error; err != nil {
+		if err := tx.Exec(`DELETE FROM "QuotaGroups" WHERE namespace = ?`, ns).Error; err != nil {
 			return err
 		}
-		if err := tx.Exec(`DELETE FROM QuotaBuckets WHERE namespace = ?`, ns).Error; err != nil {
+		if err := tx.Exec(`DELETE FROM "QuotaBuckets" WHERE namespace = ?`, ns).Error; err != nil {
 			return err
 		}
 		return nil
@@ -422,7 +422,7 @@ func (qm *QuotaManager) ApplyBucket(ctx context.Context, req *qpb.ApplyBucketReq
 	err := dbh.TransactionWithOptions(ctx, db.Opts().WithQueryName("apply_bucket"), func(tx *db.DB) error {
 		row := &struct{ Count int64 }{}
 		err := tx.Raw(
-			`SELECT COUNT(*) AS count FROM QuotaBuckets WHERE namespace = ? AND name = ?`, req.GetNamespace(), req.GetBucketName(),
+			`SELECT COUNT(*) AS count FROM "QuotaBuckets" WHERE namespace = ? AND name = ?`, req.GetNamespace(), req.GetBucketName(),
 		).Take(row).Error
 		if err != nil {
 			return err
@@ -447,7 +447,7 @@ func (qm *QuotaManager) ApplyBucket(ctx context.Context, req *qpb.ApplyBucketReq
 			return err
 		}
 		if req.GetBucketName() == defaultBucketName {
-			return tx.Exec(`DELETE FROM QuotaGroups WHERE namespace = ? AND quota_key = ?`, req.GetNamespace(), quotaKey).Error
+			return tx.Exec(`DELETE FROM "QuotaGroups" WHERE namespace = ? AND quota_key = ?`, req.GetNamespace(), quotaKey).Error
 		} else {
 			return tx.Model(&existing).Where("namespace = ? AND quota_key = ?", req.GetNamespace(), quotaKey).Updates(quotaGroup).Error
 		}
@@ -523,10 +523,10 @@ func (qm *QuotaManager) updateBucket(ctx context.Context, namespace string, buck
 func (qm *QuotaManager) removeBucket(ctx context.Context, namespace string, bucketName string) error {
 	dbh := qm.env.GetDBHandle()
 	return dbh.TransactionWithOptions(ctx, db.Opts().WithQueryName("remove_bucket"), func(tx *db.DB) error {
-		if err := tx.Exec(`DELETE FROM QuotaGroups WHERE namespace = ? AND bucket_name = ?`, namespace, bucketName).Error; err != nil {
+		if err := tx.Exec(`DELETE FROM "QuotaGroups" WHERE namespace = ? AND bucket_name = ?`, namespace, bucketName).Error; err != nil {
 			return err
 		}
-		return tx.Exec(`DELETE FROM QuotaBuckets WHERE namespace = ? AND name = ?`, namespace, bucketName).Error
+		return tx.Exec(`DELETE FROM "QuotaBuckets" WHERE namespace = ? AND name = ?`, namespace, bucketName).Error
 	})
 }
 

--- a/enterprise/server/quota/quota_manager_test.go
+++ b/enterprise/server/quota/quota_manager_test.go
@@ -50,7 +50,7 @@ func fetchAllQuotaBuckets(t *testing.T, env *testenv.TestEnv, ctx context.Contex
 func fetchQuotaBuckets(t *testing.T, env *testenv.TestEnv, ctx context.Context, namespace string) []*tables.QuotaBucket {
 	res := []*tables.QuotaBucket{}
 	dbh := env.GetDBHandle()
-	q := query_builder.NewQuery(`SELECT * FROM QuotaBuckets`)
+	q := query_builder.NewQuery(`SELECT * FROM "QuotaBuckets"`)
 	if namespace != "" {
 		q.AddWhereClause("namespace = ?", namespace)
 	}
@@ -72,7 +72,7 @@ func fetchQuotaBuckets(t *testing.T, env *testenv.TestEnv, ctx context.Context, 
 func fetchAllQuotaGroups(t *testing.T, env *testenv.TestEnv, ctx context.Context) []*tables.QuotaGroup {
 	res := []*tables.QuotaGroup{}
 	dbh := env.GetDBHandle()
-	rows, err := dbh.DB(ctx).Raw(`SELECT * FROM QuotaGroups`).Rows()
+	rows, err := dbh.DB(ctx).Raw(`SELECT * FROM "QuotaGroups"`).Rows()
 	require.NoError(t, err)
 
 	for rows.Next() {
@@ -537,7 +537,7 @@ func TestModifyNamespace_RemoveBucket(t *testing.T) {
 			assert.Empty(t, cmp.Diff(tc.wantBuckets, got, protocmp.Transform(), sortProtos))
 			row := &struct{ Count int }{}
 			result := db.Raw(
-				`SELECT COUNT(*) as count FROM QuotaGroups WHERE namespace = ? AND bucket_name = ?`,
+				`SELECT COUNT(*) as count FROM "QuotaGroups" WHERE namespace = ? AND bucket_name = ?`,
 				tc.req.GetNamespace(), tc.req.GetRemoveBucket(),
 			).Scan(row)
 			require.NoError(t, result.Error)
@@ -801,7 +801,7 @@ func TestQuotaManagerApplyBucket(t *testing.T) {
 				assert.NoError(t, err)
 				row := &struct{ BucketName string }{}
 				result := db.Raw(
-					`SELECT bucket_name FROM QuotaGroups WHERE namespace = ? AND quota_key = ?`,
+					`SELECT bucket_name FROM "QuotaGroups" WHERE namespace = ? AND quota_key = ?`,
 					tc.req.GetNamespace(), tc.wantQuotaKey,
 				).Scan(row)
 				require.NoError(t, result.Error)

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -1083,7 +1083,7 @@ func (s *ExecutionServer) Cancel(ctx context.Context, invocationID string) error
 func (s *ExecutionServer) executionIDs(ctx context.Context, invocationID string) ([]string, error) {
 	dbh := s.env.GetDBHandle()
 	rows, err := dbh.DB(ctx).Raw(
-		"SELECT execution_id FROM Executions WHERE invocation_id = ? AND stage != ?",
+		`SELECT execution_id FROM "Executions" WHERE invocation_id = ? AND stage != ?`,
 		invocationID,
 		repb.ExecutionStage_COMPLETED).Rows()
 	if err != nil {

--- a/enterprise/server/secrets/secrets.go
+++ b/enterprise/server/secrets/secrets.go
@@ -76,7 +76,7 @@ func (s *SecretService) listSecretsIncludingValues(ctx context.Context) (*skpb.L
 		return nil, status.FailedPreconditionError("A database is required")
 	}
 
-	q := query_builder.NewQuery(`SELECT name, value FROM Secrets`)
+	q := query_builder.NewQuery(`SELECT name, value FROM "Secrets"`)
 	q.AddWhereClause("group_id = ?", u.GetGroupID())
 	q.SetOrderBy("name", true /*ascending*/)
 	queryStr, args := q.Build()
@@ -152,7 +152,7 @@ func (s *SecretService) UpdateSecret(ctx context.Context, req *skpb.UpdateSecret
 	if err != nil {
 		return nil, err
 	}
-	err = dbHandle.DB(ctx).Exec(`REPLACE INTO Secrets (user_id, group_id, name, value, perms) VALUES (?, ?, ?, ?, ?)`,
+	err = dbHandle.DB(ctx).Exec(`REPLACE INTO "Secrets" (user_id, group_id, name, value, perms) VALUES (?, ?, ?, ?, ?)`,
 		u.GetUserID(), u.GetGroupID(), req.GetSecret().GetName(), req.GetSecret().GetValue(), secretPerms.Perms).Error
 	if err != nil {
 		return nil, err
@@ -175,7 +175,7 @@ func (s *SecretService) DeleteSecret(ctx context.Context, req *skpb.DeleteSecret
 		return nil, status.InvalidArgumentError("A non-empty secret name is required")
 	}
 
-	err = dbHandle.DB(ctx).Exec(`DELETE FROM Secrets WHERE group_id = ? AND name = ?`, u.GetGroupID(), req.GetSecret().GetName()).Error
+	err = dbHandle.DB(ctx).Exec(`DELETE FROM "Secrets" WHERE group_id = ? AND name = ?`, u.GetGroupID(), req.GetSecret().GetName()).Error
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/test/integration/invocation_webhook/invocation_webhook_test.go
+++ b/enterprise/server/test/integration/invocation_webhook/invocation_webhook_test.go
@@ -51,7 +51,7 @@ func TestInvocationUploadWebhook(t *testing.T) {
 	require.NoError(t, err)
 	ctx := context.Background()
 	db := dbh.DB(ctx)
-	err = db.Exec("UPDATE `Groups` SET invocation_webhook_url = ?", ws.URL.String()).Error
+	err = db.Exec(`UPDATE "Groups" SET invocation_webhook_url = ?`, ws.URL.String()).Error
 	require.NoError(t, err)
 	apiKey := tables.APIKey{}
 	dbResult := db.Where("group_id = ?", userdb.DefaultGroupID).First(&apiKey)

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -275,7 +275,7 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, c collection
 		// Create a row for the corresponding usage period if one doesn't already
 		// exist.
 		res := tx.Exec(`
-			INSERT `+dbh.InsertIgnoreModifier()+` INTO Usages (
+			INSERT `+dbh.InsertIgnoreModifier()+` INTO "Usages" (
 				group_id,
 				period_start_usec,
 				region,
@@ -310,7 +310,7 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, c collection
 		// been written (for example, if the previous flush failed to delete the
 		// data from Redis).
 		return tx.Exec(`
-			UPDATE Usages
+			UPDATE "Usages"
 			SET
 				final_before_usec = ?,
 				invocations = invocations + ?,

--- a/enterprise/server/usage/usage_test.go
+++ b/enterprise/server/usage/usage_test.go
@@ -69,7 +69,7 @@ func queryAllUsages(t *testing.T, te *testenv.TestEnv) []*tables.Usage {
 	ctx := context.Background()
 	dbh := te.GetDBHandle()
 	rows, err := dbh.DB(ctx).Raw(`
-		SELECT * From Usages
+		SELECT * From "Usages"
 		ORDER BY group_id, period_start_usec, region ASC;
 	`).Rows()
 	require.NoError(t, err)

--- a/enterprise/server/usage_service/usage_service.go
+++ b/enterprise/server/usage_service/usage_service.go
@@ -102,7 +102,7 @@ func (s *usageService) scanUsages(ctx context.Context, groupID string, start, en
 		SUM(cas_cache_hits) AS cas_cache_hits,
 		SUM(total_download_size_bytes) AS total_download_size_bytes,
 		SUM(linux_execution_duration_usec) AS linux_execution_duration_usec
-		FROM Usages
+		FROM "Usages"
 		WHERE period_start_usec >= ? AND period_start_usec < ?
 		AND group_id = ?
 		GROUP BY period

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -253,12 +253,12 @@ func (ws *workflowService) DeleteWorkflow(ctx context.Context, req *wfpb.DeleteW
 		var q *db.DB
 		if req.GetId() != "" {
 			q = tx.Raw(`
-				SELECT * FROM Workflows WHERE workflow_id = ?
+				SELECT * FROM "Workflows" WHERE workflow_id = ?
 				`+ws.env.GetDBHandle().SelectForUpdateModifier()+`
 			`, req.GetId())
 		} else {
 			q = tx.Raw(`
-				SELECT * FROM Workflows
+				SELECT * FROM "Workflows"
 				WHERE group_id = ? AND repo_url = ?
 				`+ws.env.GetDBHandle().SelectForUpdateModifier()+`
 			`, authenticatedUser.GetGroupID(), req.GetRepoUrl())
@@ -270,7 +270,7 @@ func (ws *workflowService) DeleteWorkflow(ctx context.Context, req *wfpb.DeleteW
 		if err := perms.AuthorizeWrite(&authenticatedUser, acl); err != nil {
 			return err
 		}
-		return tx.Exec(`DELETE FROM Workflows WHERE workflow_id = ?`, wf.WorkflowID).Error
+		return tx.Exec(`DELETE FROM "Workflows" WHERE workflow_id = ?`, wf.WorkflowID).Error
 	})
 	if err != nil {
 		return nil, err
@@ -295,7 +295,7 @@ func (ws *workflowService) DeleteWorkflow(ctx context.Context, req *wfpb.DeleteW
 
 func (ws *workflowService) GetLinkedWorkflows(ctx context.Context, accessToken string) ([]string, error) {
 	q, args := query_builder.
-		NewQuery("SELECT workflow_id FROM Workflows").
+		NewQuery(`SELECT workflow_id FROM "Workflows"`).
 		AddWhereClause("access_token = ?", accessToken).
 		Build()
 	rows, err := ws.env.GetDBHandle().DB(ctx).Raw(q, args...).Rows()
@@ -332,7 +332,7 @@ func (ws *workflowService) GetWorkflows(ctx context.Context, req *wfpb.GetWorkfl
 	}
 
 	rsp := &wfpb.GetWorkflowsResponse{}
-	q := query_builder.NewQuery(`SELECT workflow_id, name, repo_url, webhook_id FROM Workflows`)
+	q := query_builder.NewQuery(`SELECT workflow_id, name, repo_url, webhook_id FROM "Workflows"`)
 	// Respect selected group ID.
 	q.AddWhereClause(`group_id = ?`, groupID)
 	// Adds user / permissions check.
@@ -419,7 +419,7 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 	} else {
 		wf = &tables.Workflow{}
 		err = ws.env.GetDBHandle().DB(ctx).Raw(
-			`SELECT * FROM Workflows WHERE workflow_id = ?`,
+			`SELECT * FROM "Workflows" WHERE workflow_id = ?`,
 			req.GetWorkflowId(),
 		).Take(wf).Error
 		if err != nil {
@@ -448,14 +448,14 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 		wf.InstanceNameSuffix = suffix
 		if gitRepository != nil {
 			err = ws.env.GetDBHandle().DB(ctx).Exec(`
-				UPDATE GitRepositories
+				UPDATE "GitRepositories"
 				SET instance_name_suffix = ?
 				WHERE group_id = ? AND repo_url = ?`,
 				wf.InstanceNameSuffix, gitRepository.GroupID, gitRepository.RepoURL,
 			).Error
 		} else {
 			err = ws.env.GetDBHandle().DB(ctx).Exec(`
-				UPDATE Workflows
+				UPDATE "Workflows"
 				SET instance_name_suffix = ?
 				WHERE workflow_id = ?`,
 				wf.InstanceNameSuffix, wf.WorkflowID,
@@ -544,7 +544,7 @@ func (ws *workflowService) getRepositoryWorkflow(ctx context.Context, id string)
 	gitRepository := &tables.GitRepository{}
 	err = ws.env.GetDBHandle().DB(ctx).Raw(`
 		SELECT *
-		FROM GitRepositories
+		FROM "GitRepositories"
 		WHERE group_id = ?
 		AND repo_url = ?
 	`, groupID, repoURL.String()).Take(gitRepository).Error

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -352,7 +352,7 @@ func (c *OAuthHandler) requestAccessToken(r *http.Request, code string) error {
 		}
 		log.Infof("Linking GitHub account for group %s", groupID)
 		err = c.env.GetDBHandle().DB(ctx).Exec(
-			`UPDATE `+"`Groups`"+` SET github_token = ? WHERE group_id = ?`,
+			`UPDATE "Groups" SET github_token = ? WHERE group_id = ?`,
 			accessTokenResponse.AccessToken, groupID).Error
 		if err != nil {
 			return status.PermissionDeniedErrorf("error linking github account to group: %v", err)
@@ -366,7 +366,7 @@ func (c *OAuthHandler) requestAccessToken(r *http.Request, code string) error {
 		}
 		log.Infof("Linking GitHub account for user %s", userID)
 		err = c.env.GetDBHandle().DB(ctx).Exec(
-			`UPDATE `+"`Users`"+` SET github_token = ? WHERE user_id = ?`,
+			`UPDATE "Users" SET github_token = ? WHERE user_id = ?`,
 			accessTokenResponse.AccessToken, userID).Error
 		if err != nil {
 			return status.PermissionDeniedErrorf("Error linking github account to user: %v", err)
@@ -488,7 +488,7 @@ func (c *GithubClient) populateTokenIfNecessary(ctx context.Context, ownerRepo s
 	}
 
 	var group tables.Group
-	err = dbHandle.DB(ctx).Raw(`SELECT github_token FROM `+"`Groups`"+` WHERE group_id = ?`,
+	err = dbHandle.DB(ctx).Raw(`SELECT github_token FROM "Groups" WHERE group_id = ?`,
 		userInfo.GetGroupID()).First(&group).Error
 	if err != nil {
 		return err

--- a/server/backends/invocationdb/invocationdb_test.go
+++ b/server/backends/invocationdb/invocationdb_test.go
@@ -30,7 +30,7 @@ func TestCreateReadUpdateDelete(t *testing.T) {
 		require.True(t, created)
 
 		err = dbh.DB(ctx).Exec(`
-			INSERT INTO InvocationExecutions (invocation_id, execution_id)
+			INSERT INTO "InvocationExecutions" (invocation_id, execution_id)
 			VALUES (?, ?)`, iid, iid+"-execution").Error
 		require.NoError(t, err)
 	}
@@ -42,7 +42,7 @@ func TestCreateReadUpdateDelete(t *testing.T) {
 	require.Nil(t, inv)
 	require.True(t, db.IsRecordNotFound(err), "expected RecordNotFound, got: %v", err)
 	err = dbh.DB(ctx).Raw(
-		`SELECT * FROM InvocationExecutions WHERE invocation_id = ?`,
+		`SELECT * FROM "InvocationExecutions" WHERE invocation_id = ?`,
 		"invocation-0",
 	).Take(&tables.InvocationExecution{}).Error
 	require.True(t, db.IsRecordNotFound(err))
@@ -62,7 +62,7 @@ func TestCreateReadUpdateDelete(t *testing.T) {
 	require.Equal(t, "//pattern:2", inv.Pattern)
 	ie := &tables.InvocationExecution{}
 	err = dbh.DB(ctx).Raw(
-		`SELECT * FROM InvocationExecutions WHERE invocation_id = ?`,
+		`SELECT * FROM "InvocationExecutions" WHERE invocation_id = ?`,
 		"invocation-2",
 	).Take(ie).Error
 	require.NoError(t, err)

--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -60,7 +60,7 @@ func (r *BuildStatusReporter) initGHClient(ctx context.Context) *github.GithubCl
 	if workflowID := r.buildEventAccumulator.WorkflowID(); workflowID != "" {
 		if dbh := r.env.GetDBHandle(); dbh != nil {
 			workflow := &tables.Workflow{}
-			if err := dbh.DB(ctx).Raw(`SELECT * from Workflows WHERE workflow_id = ?`, workflowID).Take(workflow).Error; err == nil {
+			if err := dbh.DB(ctx).Raw(`SELECT * from "Workflows" WHERE workflow_id = ?`, workflowID).Take(workflow).Error; err == nil {
 				return github.NewGithubClient(r.env, workflow.AccessToken)
 			}
 		}

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -459,7 +459,7 @@ func isTestCommand(command string) bool {
 }
 
 func readRepoTargetsWithTx(ctx context.Context, env environment.Env, repoURL string, tx *db.DB) ([]*tables.Target, error) {
-	q := query_builder.NewQuery(`SELECT * FROM Targets as t`)
+	q := query_builder.NewQuery(`SELECT * FROM "Targets" as t`)
 	q = q.AddWhereClause(`t.repo_url = ?`, repoURL)
 	if err := perms.AddPermissionsCheckToQueryWithTableAlias(ctx, env, q, "t"); err != nil {
 		return nil, err
@@ -546,7 +546,7 @@ func insertTargets(ctx context.Context, env environment.Env, targets []*tables.T
 			valueArgs = append(valueArgs, nowUsec)
 		}
 		err := env.GetDBHandle().TransactionWithOptions(ctx, db.Opts().WithQueryName("target_tracker_insert_targets"), func(tx *db.DB) error {
-			stmt := fmt.Sprintf("INSERT INTO Targets (repo_url, target_id, user_id, group_id, perms, label, rule_type, created_at_usec, updated_at_usec) VALUES %s", strings.Join(valueStrings, ","))
+			stmt := fmt.Sprintf(`INSERT INTO "Targets" (repo_url, target_id, user_id, group_id, perms, label, rule_type, created_at_usec, updated_at_usec) VALUES %s`, strings.Join(valueStrings, ","))
 			return tx.Exec(stmt, valueArgs...).Error
 		})
 		if err != nil {
@@ -588,7 +588,7 @@ func insertOrUpdateTargetStatuses(ctx context.Context, env environment.Env, stat
 			valueArgs = append(valueArgs, nowUsec)
 		}
 		err := env.GetDBHandle().TransactionWithOptions(ctx, db.Opts().WithQueryName("target_tracker_insert_target_statuses"), func(tx *db.DB) error {
-			stmt := fmt.Sprintf("INSERT INTO TargetStatuses (target_id, invocation_uuid, target_type, test_size, status, start_time_usec, duration_usec, created_at_usec, updated_at_usec) VALUES %s", strings.Join(valueStrings, ","))
+			stmt := fmt.Sprintf(`INSERT INTO "TargetStatuses" (target_id, invocation_uuid, target_type, test_size, status, start_time_usec, duration_usec, created_at_usec, updated_at_usec) VALUES %s`, strings.Join(valueStrings, ","))
 			return tx.Exec(stmt, valueArgs...).Error
 		})
 		if err != nil {

--- a/server/build_event_protocol/target_tracker/target_tracker_test.go
+++ b/server/build_event_protocol/target_tracker/target_tracker_test.go
@@ -442,7 +442,7 @@ func TestTrackTargetsForEventsAborted(t *testing.T) {
 
 func assertTargetsAndTargetStatusesMatch(t *testing.T, te *testenv.TestEnv, expected []Row) {
 	var got []Row
-	query := "SELECT rule_type, label, repo_url, test_size, status, target_type FROM Targets t JOIN TargetStatuses ts ON t.target_id = ts.target_id"
+	query := `SELECT rule_type, label, repo_url, test_size, status, target_type FROM "Targets" t JOIN "TargetStatuses" ts ON t.target_id = ts.target_id`
 	err := te.GetDBHandle().DB(context.Background()).Raw(query).Scan(&got).Error
 	require.NoError(t, err)
 	assert.ElementsMatch(t, got, expected)

--- a/server/build_event_protocol/webhooks/webhooks.go
+++ b/server/build_event_protocol/webhooks/webhooks.go
@@ -59,7 +59,7 @@ func (h *invocationUploadHook) NotifyComplete(ctx context.Context, in *inpb.Invo
 	row := &struct{ InvocationWebhookURL string }{}
 	err := dbh.RawWithOptions(
 		ctx, db.Opts().WithStaleReads(),
-		"SELECT invocation_webhook_url FROM `Groups` WHERE group_id = ?",
+		`SELECT invocation_webhook_url FROM "Groups" WHERE group_id = ?`,
 		groupID,
 	).Take(row).Error
 	if err != nil {

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -723,17 +723,17 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 
 	// Initialize UserGroups.membership_status to 1 if the column doesn't exist.
 	if m.HasTable("UserGroups") && !m.HasColumn(&UserGroup{}, "membership_status") {
-		if err := db.Exec("ALTER TABLE UserGroups ADD membership_status int").Error; err != nil {
+		if err := db.Exec(`ALTER TABLE "UserGroups" ADD membership_status int`).Error; err != nil {
 			return nil, err
 		}
-		if err := db.Exec("UPDATE UserGroups SET membership_status = ?", int32(grpb.GroupMembershipStatus_MEMBER)).Error; err != nil {
+		if err := db.Exec(`UPDATE "UserGroups" SET membership_status = ?`, int32(grpb.GroupMembershipStatus_MEMBER)).Error; err != nil {
 			return nil, err
 		}
 	}
 	// Initialize UserGroups.role to Admin if the role column doesn't exist.
 	if m.HasTable("UserGroups") && !m.HasColumn(&UserGroup{}, "role") {
 		postMigrate = append(postMigrate, func() error {
-			return db.Exec("UPDATE UserGroups SET role = ?", uint32(role.Admin)).Error
+			return db.Exec(`UPDATE "UserGroups" SET role = ?`, uint32(role.Admin)).Error
 		})
 	}
 
@@ -747,7 +747,7 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 		}
 		// Before creating a unique index, need to replace empty strings with NULL.
 		if !m.HasIndex("Groups", "url_identifier_unique_index") {
-			if err := db.Exec(`UPDATE ` + "`Groups`" + ` SET url_identifier = NULL WHERE url_identifier = ""`).Error; err != nil {
+			if err := db.Exec(`UPDATE "Groups" SET url_identifier = NULL WHERE url_identifier = ''`).Error; err != nil {
 				return nil, err
 			}
 		}
@@ -756,7 +756,7 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 	// Migrate Groups.APIKey to APIKey rows.
 	if m.HasTable("Groups") && m.HasColumn(&Group{}, "api_key") && !m.HasTable("APIKeys") {
 		postMigrate = append(postMigrate, func() error {
-			rows, err := db.Raw(`SELECT group_id, api_key FROM ` + "`Groups`" + ``).Rows()
+			rows, err := db.Raw(`SELECT group_id, api_key FROM "Groups"`).Rows()
 			if err != nil {
 				return err
 			}
@@ -783,7 +783,7 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 				}
 
 				if err := db.Exec(
-					`INSERT INTO APIKeys (api_key_id, group_id, perms, value, label) VALUES (?, ?, ?, ?, ?)`,
+					`INSERT INTO "APIKeys" (api_key_id, group_id, perms, value, label) VALUES (?, ?, ?, ?, ?)`,
 					pk, g.GroupID, apiKeyPerms, apiKey, "Default API key").Error; err != nil {
 					return err
 				}
@@ -825,7 +825,7 @@ func PreAutoMigrate(db *gorm.DB) ([]PostAutoMigrateLogic, error) {
 			if err := m.DropIndex("TargetStatuses", "target_status_invocation_pk"); err != nil {
 				return err
 			}
-			if err := db.Exec("ALTER TABLE TargetStatuses ALTER invocation_pk SET DEFAULT 0").Error; err != nil {
+			if err := db.Exec(`ALTER TABLE "TargetStatuses" ALTER invocation_pk SET DEFAULT 0`).Error; err != nil {
 				return err
 			}
 			return nil
@@ -855,8 +855,8 @@ func postMigrateInvocationUUIDForMySQL(db *gorm.DB) error {
 		return err
 	}
 	updateTargetStatusStmt := `
-		UPDATE TargetStatuses ts SET invocation_uuid=
-			(SELECT invocation_uuid FROM Invocations i 
+		UPDATE "TargetStatuses" ts SET invocation_uuid=
+			(SELECT invocation_uuid FROM "Invocations" i 
 			WHERE i.invocation_pk=ts.invocation_pk)
 		WHERE invocation_uuid IS NULL`
 	if err := updateInBatches(db, updateTargetStatusStmt, 10000); err != nil {
@@ -867,7 +867,7 @@ func postMigrateInvocationUUIDForMySQL(db *gorm.DB) error {
 	// a target status has a invocation_pk that's not in Invocations table. It's OK
 	// to delete these target statuses because these target statuses are not showing
 	// up in the UI right now.
-	deleteTargetStatusStmt := `DELETE FROM TargetStatuses WHERE invocation_uuid IS NULL`
+	deleteTargetStatusStmt := `DELETE FROM "TargetStatuses" WHERE invocation_uuid IS NULL`
 	if err := updateInBatches(db, deleteTargetStatusStmt, 10000); err != nil {
 		return err
 	}
@@ -887,21 +887,21 @@ func postMigrateInvocationUUIDForMySQL(db *gorm.DB) error {
 		return err
 	}
 
-	changePKStmt := "ALTER TABLE TargetStatuses "
+	changePKStmt := `ALTER TABLE "TargetStatuses" `
 	if primaryKeyCount > 0 {
-		// Only drop primarky keys when they exist.
-		changePKStmt += "DROP PRIMARY KEY, "
+		// Only drop primary keys when they exist.
+		changePKStmt += `DROP PRIMARY KEY, `
 	}
-	changePKStmt += "ADD PRIMARY KEY(target_id, invocation_uuid), "
+	changePKStmt += `ADD PRIMARY KEY(target_id, invocation_uuid), `
 
 	isStrictModeEnabled, err := isStrictModeEnabled(db)
 	if err != nil {
 		return err
 	}
 	if isStrictModeEnabled {
-		changePKStmt += "ALGORITHM=INPLACE, LOCK=NONE"
+		changePKStmt += `ALGORITHM=INPLACE, LOCK=NONE`
 	} else {
-		changePKStmt += "ALGORITHM=COPY"
+		changePKStmt += `ALGORITHM=COPY`
 	}
 	if err := db.Exec(changePKStmt).Error; err != nil {
 		return err
@@ -927,10 +927,10 @@ func postMigrateInvocationUUIDForSQLite(db *gorm.DB) error {
 			if err != nil {
 				return err
 			}
-			if err := db.Exec(`UPDATE TargetStatusesOld SET invocation_uuid = ? WHERE invocation_pk = ? `, invocationUUID, invocation.InvocationPK).Error; err != nil {
+			if err := db.Exec(`UPDATE "TargetStatusesOld" SET invocation_uuid = ? WHERE invocation_pk = ? `, invocationUUID, invocation.InvocationPK).Error; err != nil {
 				return err
 			}
-			if err := db.Exec(`UPDATE Invocations SET invocation_uuid = ? WHERE invocation_id = ? `, invocationUUID, invocation.InvocationID).Error; err != nil {
+			if err := db.Exec(`UPDATE "Invocations" SET invocation_uuid = ? WHERE invocation_id = ? `, invocationUUID, invocation.InvocationID).Error; err != nil {
 				return err
 			}
 		}
@@ -942,14 +942,14 @@ func postMigrateInvocationUUIDForSQLite(db *gorm.DB) error {
 	}
 
 	// Copy data from TargetStatusesOld to the new table
-	insertStmt := `INSERT INTO TargetStatuses
+	insertStmt := `INSERT INTO "TargetStatuses"
 			(target_id, invocation_uuid, target_type, test_size, status,
 			start_time_usec, duration_usec, created_at_usec, updated_at_usec)
 		SELECT 
 			target_id, invocation_uuid, target_type, test_size, status,
 			start_time_usec, duration_usec, created_at_usec, updated_at_usec 
 		FROM 
-			TargetStatusesOld`
+			"TargetStatusesOld"`
 
 	if err := db.Exec(insertStmt).Error; err != nil {
 		return err
@@ -969,22 +969,22 @@ func dropIndexIfExists(m gorm.Migrator, table, indexName string) {
 // Manual migration called after auto-migration.
 func PostAutoMigrate(db *gorm.DB) error {
 	invocationIndices := map[string]string{
-		"invocations_trends_query_index":      "(`group_id`, `updated_at_usec`)",
-		"invocations_trends_query_role_index": "(`group_id`, `role`, `updated_at_usec`)",
-		"invocations_stats_group_id_index":    "(`group_id`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_user_index":        "(`group_id`, `user`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_host_index":        "(`group_id`, `host`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_repo_index":        "(`group_id`, `repo_url`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_branch_index":      "(`group_id`, `branch_name`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_commit_index":      "(`group_id`, `commit_sha`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
-		"invocations_stats_role_index":        "(`group_id`, `role`, `action_count`, `duration_usec`, `updated_at_usec`, `success`, `invocation_status`)",
+		"invocations_trends_query_index":      `("group_id", "updated_at_usec")`,
+		"invocations_trends_query_role_index": `("group_id", "role", "updated_at_usec")`,
+		"invocations_stats_group_id_index":    `("group_id", "action_count", "duration_usec", "updated_at_usec", "success", "invocation_status")`,
+		"invocations_stats_user_index":        `("group_id", "user", "action_count", "duration_usec", "updated_at_usec", "success", "invocation_status")`,
+		"invocations_stats_host_index":        `("group_id", "host", "action_count", "duration_usec", "updated_at_usec", "success", "invocation_status")`,
+		"invocations_stats_repo_index":        `("group_id", "repo_url", "action_count", "duration_usec", "updated_at_usec", "success", "invocation_status")`,
+		"invocations_stats_branch_index":      `("group_id", "branch_name", "action_count", "duration_usec", "updated_at_usec", "success", "invocation_status")`,
+		"invocations_stats_commit_index":      `("group_id", "commit_sha", "action_count", "duration_usec", "updated_at_usec", "success", "invocation_status")`,
+		"invocations_stats_role_index":        `("group_id", "role", "action_count", "duration_usec", "updated_at_usec", "success", "invocation_status")`,
 	}
 	prefixIndicesByDialect := map[string]map[string]string{
 		mysqlDialect: map[string]string{
-			"invocations_test_grid_query_command_index": "(`group_id` (25), `role` (10), `repo_url`, `command` (10), `created_at_usec` DESC)",
+			"invocations_test_grid_query_command_index": `("group_id" (25), "role" (10), "repo_url", "command" (10), "created_at_usec" DESC)`,
 		},
 		sqliteDialect: map[string]string{
-			"invocations_test_grid_query_command_index": "(`group_id`, `role`, `repo_url`, `command` , `created_at_usec` DESC)",
+			"invocations_test_grid_query_command_index": `("group_id", "role", "repo_url", "command" , "created_at_usec" DESC)`,
 		},
 	}
 	prefixIndexes, ok := prefixIndicesByDialect[db.Dialector.Name()]
@@ -995,7 +995,7 @@ func PostAutoMigrate(db *gorm.DB) error {
 	}
 
 	executionIndices := map[string]string{
-		"executions_created_at_usec_index": "(`created_at_usec`)",
+		"executions_created_at_usec_index": `("created_at_usec")`,
 	}
 
 	indicesByTable := map[string]map[string]string{
@@ -1010,7 +1010,7 @@ func PostAutoMigrate(db *gorm.DB) error {
 				if m.HasIndex(tableName, indexName) {
 					continue
 				}
-				err := db.Exec(fmt.Sprintf("CREATE INDEX `%s` ON `%s`%s", indexName, tableName, cols)).Error
+				err := db.Exec(fmt.Sprintf(`CREATE INDEX "%s" ON "%s" %s`, indexName, tableName, cols)).Error
 				if err != nil {
 					log.Errorf("Error creating %s on table %q: %s", indexName, tableName, err)
 				}
@@ -1065,7 +1065,7 @@ func PostAutoMigrate(db *gorm.DB) error {
 }
 
 func dropColumnInPlaceForMySQL(db *gorm.DB, table Table, column string) error {
-	return db.Exec("ALTER TABLE `" + table.TableName() + "` DROP COLUMN " + column + ", ALGORITHM=INPLACE, LOCK=NONE").Error
+	return db.Exec(`ALTER TABLE "` + table.TableName() + `" DROP COLUMN ` + column + `, ALGORITHM=INPLACE, LOCK=NONE`).Error
 }
 
 func hasPrimaryKey(db *gorm.DB, table Table, key string) (bool, error) {

--- a/server/target/target.go
+++ b/server/target/target.go
@@ -332,11 +332,11 @@ func readPaginatedTargetsFromOLAPDB(ctx context.Context, env environment.Env, re
 	}
 
 	//  Build the query:
-	//  SELECT [a list of fields] FROM TestTargetStatuses
+	//  SELECT [a list of fields] FROM "TestTargetStatuses"
 	//  WHERE commit_sha IN (
 	//    SELECT commit_sha FROM (
 	//      SELECT commit_sha, max(invocation_start_time_usec)
-	//      as latest_created_at_usec FROM TestTargetStatuses
+	//      as latest_created_at_usec FROM "TestTargetStatuses"
 	//      WHERE group_id = '[group_id]'
 	//      AND repo_url = '[repo_url]
 	//      AND commit_sha != ''
@@ -353,7 +353,7 @@ func readPaginatedTargetsFromOLAPDB(ctx context.Context, env environment.Env, re
 	// Build the query to select the most recent distinct commits.
 	innerCommitQuery := query_builder.NewQuery(`
 		SELECT commit_sha, max(invocation_start_time_usec) as latest_created_at_usec 
-		FROM TestTargetStatuses`)
+		FROM "TestTargetStatuses"`)
 	innerCommitQuery.AddWhereClause("group_id = ?", groupID)
 	innerCommitQuery.AddWhereClause("repo_url = ?", repo)
 	innerCommitQuery.SetGroupBy("commit_sha")
@@ -374,7 +374,7 @@ func readPaginatedTargetsFromOLAPDB(ctx context.Context, env environment.Env, re
 		SELECT label, rule_type, target_type, test_size, status,
 		start_time_usec, duration_usec, invocation_uuid, commit_sha, branch_name,
 		repo_url, invocation_start_time_usec
-		FROM TestTargetStatuses`)
+		FROM "TestTargetStatuses"`)
 
 	q.AddWhereInClause("commit_sha", outerCommitQuery)
 	q.AddWhereClause("group_id = ?", groupID)
@@ -395,7 +395,7 @@ func readPaginatedTargetsFromPrimaryDB(ctx context.Context, env environment.Env,
 	// Build the query to select the distinct commits.
 	commitQuery := query_builder.NewQuery(`
 		SELECT commit_sha, max(created_at_usec) as latest_created_at_usec 
-		FROM Invocations `)
+		FROM "Invocations" `)
 	commitQuery.AddWhereClause("group_id = ?", req.GetRequestContext().GetGroupId())
 	if repo != "" {
 		commitQuery.AddWhereClause("repo_url = ?", repo)
@@ -419,7 +419,7 @@ func readPaginatedTargetsFromPrimaryDB(ctx context.Context, env environment.Env,
 	joinQuery := query_builder.NewQuery(`
 		SELECT invocation_uuid, invocation_id, inv.commit_sha, branch_name, repo_url, 
 		created_at_usec 
-		FROM Invocations as inv`)
+		FROM "Invocations" as inv`)
 	joinQuery.AddJoinClause(commitQuery, "commits", "inv.commit_sha=commits.commit_sha")
 	joinQuery.AddWhereClause("inv.group_id = ?", req.GetRequestContext().GetGroupId())
 	joinQuery.AddWhereClause("inv.role = ?", ciRole)
@@ -436,8 +436,8 @@ func readPaginatedTargetsFromPrimaryDB(ctx context.Context, env environment.Env,
 		SELECT t.target_id, t.label, t.rule_type, ts.target_type, ts.test_size, ts.status,
 		ts.start_time_usec, ts.duration_usec, i.invocation_id, i.commit_sha, i.branch_name,
 		i.repo_url, i.created_at_usec
-		FROM Targets as t
-		JOIN TargetStatuses as ts ON ts.target_id = t.target_id`)
+		FROM "Targets" as t
+		JOIN "TargetStatuses" as ts ON ts.target_id = t.target_id`)
 	q.AddJoinClause(joinQuery, "i", "ts.invocation_uuid = i.invocation_uuid")
 	return fetchTargetsFromPrimaryDB(ctx, env, q, repo)
 }

--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -483,6 +484,10 @@ func ParseDatasource(fileResolver fs.FS, datasource string, advancedConfig *Adva
 			return nil, status.FailedPreconditionError("endpoint is required")
 		}
 
+		if ac.Driver == mysqlDriver {
+			dsn.AddParam("sql_mode", "ANSI_QUOTES")
+		}
+
 		if ac.UseAWSIAM {
 			if ac.Region == "" {
 				return nil, status.FailedPreconditionError("region is required to enable AWS IAM")
@@ -523,6 +528,19 @@ func ParseDatasource(fileResolver fs.FS, datasource string, advancedConfig *Adva
 			return nil, fmt.Errorf("malformed db connection string")
 		}
 		driverName, connString := parts[0], parts[1]
+		switch driverName {
+		case mysqlDriver:
+			u, err := url.Parse(datasource)
+			if err != nil {
+				return nil, fmt.Errorf("malformed mySQL connection string: %s", err)
+			}
+			u.Query().Add("sql_mode", "ANSI_QUOTES")
+			parts := strings.SplitN(u.String(), "://", 2)
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("malformed db connection string")
+			}
+			connString = parts[1]
+		}
 		return &fixedDSNDataSource{driver: driverName, dsn: connString}, nil
 	}
 

--- a/server/util/db/db_test.go
+++ b/server/util/db/db_test.go
@@ -56,7 +56,7 @@ func TestParseDataSource(t *testing.T) {
 	require.Equal(t, "mysql", ds.DriverName())
 	dsn, err = ds.DSN()
 	require.NoError(t, err)
-	require.Equal(t, "user:pass@tcp(host:port)/db", dsn)
+	require.Equal(t, "user:pass@tcp(host:port)/db?sql_mode=ANSI_QUOTES", dsn)
 
 	ds, err = db.ParseDatasource(fileResolver, "", &db.AdvancedConfig{
 		Driver:   "mysql",
@@ -70,5 +70,5 @@ func TestParseDataSource(t *testing.T) {
 	require.Equal(t, "mysql", ds.DriverName())
 	dsn, err = ds.DSN()
 	require.NoError(t, err)
-	require.Equal(t, "user:pass@tcp(host:port)/db?foo=bar", dsn)
+	require.Equal(t, "user:pass@tcp(host:port)/db?foo=bar&sql_mode=ANSI_QUOTES", dsn)
 }

--- a/server/util/query_builder/query_builder_test.go
+++ b/server/util/query_builder/query_builder_test.go
@@ -16,7 +16,7 @@ func normalize(t *testing.T, query string) string {
 	// The current logic in this func blindly strips whitespace, which might
 	// change the meaning of queries containing strings. So for now, just fail
 	// the test if we see any string delimiters.
-	if strings.Contains(query, "\"") || strings.Contains(query, "'") || strings.Contains(query, "`") {
+	if strings.Contains(query, "'") || strings.Contains(query, "`") {
 		assert.FailNow(t, "normalizeSpace cannot yet handle string or backtick literals")
 	}
 
@@ -72,9 +72,9 @@ func TestOrClauses_Multiple(t *testing.T) {
 }
 
 func TestJoinClause(t *testing.T) {
-	q := query_builder.NewQuery("SELECT id, t1, t2 FROM targets AS t")
+	q := query_builder.NewQuery(`SELECT id, t1, t2 FROM "Targets" AS t`)
 
-	subQuery := query_builder.NewQuery("SELECT id, i1, i2 FROM invocations AS i")
+	subQuery := query_builder.NewQuery(`SELECT id, i1, i2 FROM "Invocations" AS i`)
 	subQuery.AddWhereClause("i3 > ?", 4)
 	subQuery.AddWhereClause("i4 > ?", 6)
 	subQuery.SetOrderBy("i.id", false)
@@ -86,10 +86,10 @@ func TestJoinClause(t *testing.T) {
 	qStr, qArgs := q.Build()
 	expectedQueryStr := `
 		SELECT id, t1, t2
-		FROM targets AS t
+		FROM "Targets" AS t
 		JOIN (
 			SELECT id, i1, i2
-			FROM invocations AS i
+			FROM "Invocations" AS i
 			WHERE (i3 > ?) AND (i4 > ?)
 			ORDER BY i.id DESC
 			LIMIT 20
@@ -102,14 +102,14 @@ func TestJoinClause(t *testing.T) {
 }
 
 func TestJoinInOriginalQuery(t *testing.T) {
-	qb := query_builder.NewQuery("SELECT ak.user_id, g.group_id FROM Groups AS g, APIKeys AS ak")
+	qb := query_builder.NewQuery(`SELECT ak.user_id, g.group_id FROM "Groups" AS g, "APIKeys" AS ak`)
 	qb.AddWhereClause(`ak.group_id = g.group_id`)
 	qb.AddWhereClause(`g.group_id = ?`, "GR1")
 	q, args := qb.Build()
 
 	expectedQueryStr := `
 		SELECT ak.user_id, g.group_id
-		FROM Groups AS g, APIKeys AS ak
+		FROM "Groups" AS g, "APIKeys" AS ak
 		WHERE (ak.group_id = g.group_id) AND (g.group_id = ?)
 	`
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

The motivation for this is that postgres does not and cannot use backticks to
indicate identifiers such as table names, so if we want to support postgres, we
need to switch to double quotes for that purpose (sql_mode="ANSI_QUOTES" in
mysql). We also need to quote table names, since we use mixed-case table names,
postgres is case sensitive, and unquoted identifiers are all converted to lower
case by postgres. This also means all strings must be specified with single
qoutes (`'`).

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
