### PR TITLE
Fix workflows not checking out the commit they are reporting for

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1363,6 +1363,10 @@ func (ws *workspace) applyPatch(ctx context.Context, bsClient bspb.ByteStreamCli
 }
 
 func (ws *workspace) sync(ctx context.Context) error {
+	if *pushedBranch == "" && *targetBranch == "" {
+		return status.InvalidArgumentError("expected at least one of `pushed_branch` or `target_branch` to be set")
+	}
+
 	// Fetch the pushed and target branches from their respective remotes.
 	// "base" here is referring to the repo on which the workflow is configured.
 	// "fork" is referring to the forked repo, if the runner was triggered by a
@@ -1394,13 +1398,9 @@ func (ws *workspace) sync(ctx context.Context) error {
 	if *pushedRepoURL != "" {
 		checkoutRef = fmt.Sprintf("%s/%s", gitRemoteName(*pushedRepoURL), *pushedBranch)
 		checkoutLocalBranchName = *pushedBranch
-	} else if *targetBranch != "" {
+	} else {
 		checkoutRef = fmt.Sprintf("%s/%s", gitRemoteName(*targetRepoURL), *targetBranch)
 		checkoutLocalBranchName = *targetBranch
-	} else {
-		// If no branch is passed in, stay on the default branch
-		checkoutRef = "HEAD"
-		checkoutLocalBranchName = "local"
 	}
 
 	// TODO(Maggie): If commit sha is not set, pull the actual sha so that it can be used in reporting

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1402,9 +1402,12 @@ func (ws *workspace) sync(ctx context.Context) error {
 		checkoutLocalBranchName = "local"
 	}
 
-	checkoutCommit := *commitSHA
+	// TODO(Maggie): If commit sha is not set, pull the actual sha so that it can be used in reporting
+	checkoutCommit := "HEAD"
 	if *targetCommitSHA != "" {
 		checkoutCommit = *targetCommitSHA
+	} else if *commitSHA != "" {
+		checkoutCommit = *commitSHA
 	}
 
 	// Clean up in case a previous workflow made a mess.

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1397,8 +1397,7 @@ func (ws *workspace) sync(ctx context.Context) error {
 		checkoutRef = fmt.Sprintf("%s/%s", gitRemoteName(*targetRepoURL), *targetBranch)
 		checkoutLocalBranchName = *targetBranch
 	} else {
-		// If no branch is passed in, stay on the default branch
-		checkoutRef = ""
+		// If no branch is passed in, stay on the default branch. Don't set checkoutRef
 		checkoutLocalBranchName = "local"
 	}
 
@@ -1425,8 +1424,10 @@ func (ws *workspace) sync(ctx context.Context) error {
 	}
 
 	// Checkout the git branch
-	if err := git(ctx, ws.log, "checkout", "--force", checkoutRef); err != nil {
-		return err
+	if checkoutRef != "" {
+		if err := git(ctx, ws.log, "checkout", "--force", checkoutRef); err != nil {
+			return err
+		}
 	}
 
 	// Checkout a specific commit on the branch and create the local branch if it doesn't already exist

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -148,16 +148,11 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		"--target_repo_url=" + repoURL.String(),
 		"--bazel_sub_command=" + req.GetBazelCommand(),
 		"--invocation_id=" + invocationID,
+		"--commit_sha=" + req.GetRepoState().GetCommitSha(),
+		"--target_branch=" + req.GetRepoState().GetBranch(),
 	}
 	if strings.HasPrefix(req.GetBazelCommand(), "run ") {
 		args = append(args, "--record_run_metadata")
-	}
-	if req.GetRepoState().GetCommitSha() != "" {
-		// TODO(Maggie): Delete --target_commit_sha
-		args = append(args, "--target_commit_sha="+req.GetRepoState().GetCommitSha())
-		args = append(args, "--commit_sha="+req.GetRepoState().GetCommitSha())
-	} else {
-		args = append(args, "--target_branch="+req.GetRepoState().GetBranch())
 	}
 	if req.GetInstanceName() != "" {
 		args = append(args, "--remote_instance_name="+req.GetInstanceName())

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -153,7 +153,9 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		args = append(args, "--record_run_metadata")
 	}
 	if req.GetRepoState().GetCommitSha() != "" {
+		// TODO(Maggie): Delete --target_commit_sha
 		args = append(args, "--target_commit_sha="+req.GetRepoState().GetCommitSha())
+		args = append(args, "--commit_sha="+req.GetRepoState().GetCommitSha())
 	} else {
 		args = append(args, "--target_branch="+req.GetRepoState().GetBranch())
 	}

--- a/server/testutil/testgit/testgit.go
+++ b/server/testutil/testgit/testgit.go
@@ -134,6 +134,16 @@ func MakeTempRepoClone(t testing.TB, path string) string {
 	return copyPath
 }
 
+// CommitFiles writes the given file contents and creates a new commit with the changes.
+// Contents are specified as a map of file path to file contents.
+// Returns the sha of the new commit
+func CommitFiles(t testing.TB, repoPath string, contents map[string]string) string {
+	testfs.WriteAllFileContents(t, repoPath, contents)
+	testshell.Run(t, repoPath, `git add . && git commit -m "Initial commit"`)
+	commitSHA := strings.TrimSpace(testshell.Run(t, repoPath, `git rev-parse HEAD`))
+	return commitSHA
+}
+
 func configure(t testing.TB, repoPath string) {
 	testshell.Run(t, repoPath, `
 		git config user.name "Test"


### PR DESCRIPTION
Example situation this would fix:

1. Push a commit (C1) to a feature branch that prints "A" in a test
2. The triggered workflow will report commit=C1 and print "A"
3. Push a commit (C2) to the feature branch that prints "B"
4. Rerun the initial workflow
5. It should report commit=C1 and print "A". Currently, it will print "B" because the workflow always pulls the HEAD commit