### PR TITLE
Fix some typing issues with setTimeout

### DIFF
--- a/enterprise/app/history/history_invocation_card.tsx
+++ b/enterprise/app/history/history_invocation_card.tsx
@@ -39,7 +39,7 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
     time: Date.now(),
   };
 
-  interval: number;
+  interval?: number;
 
   componentDidMount() {
     this.updateTimeIfInProgress();
@@ -50,11 +50,11 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
       return;
     }
     this.setState({ time: Date.now() });
-    this.interval = setTimeout(() => this.updateTimeIfInProgress(), durationRefreshIntervalMillis);
+    this.interval = window.setInterval(() => this.updateTimeIfInProgress(), durationRefreshIntervalMillis);
   }
 
   componentWillUnmount() {
-    clearInterval(this.interval);
+    window.clearInterval(this.interval);
   }
 
   handleInvocationClicked() {

--- a/enterprise/app/workflows/github_app_import.tsx
+++ b/enterprise/app/workflows/github_app_import.tsx
@@ -134,8 +134,8 @@ export default class GitHubAppImport extends React.Component<GitHubAppImportProp
   private onChangeSearch(e: React.ChangeEvent<HTMLInputElement>) {
     const searchQuery = e.target.value;
     this.setState({ searchQuery, accessibleReposLoading: true });
-    clearTimeout(this.searchTimeout);
-    this.searchTimeout = setTimeout(() => this.search(), SEARCH_DEBOUNCE_DURATION_MS);
+    window.clearTimeout(this.searchTimeout);
+    this.searchTimeout = window.setTimeout(() => this.search(), SEARCH_DEBOUNCE_DURATION_MS);
   }
 
   private onChangeOwner(e: React.ChangeEvent<HTMLSelectElement>) {


### PR DESCRIPTION
Our use of `setTimeout` is causing some type errors when running `tsc` because it expects the return type to be `Timeout`, which is only true for `nodejs`. This is because `@types/node` is being included in the tsc compile somewhere as a transitive dep. It doesn't affect our bazel builds, but shows up in the IDE. This PR switches us to `window.setTimeout` instead to ensure the browser types are used and fix the typing issues.

Also fixes a bug that we were using `setTimeout` instead of `setInterval` in one place.

**Related issues**: N/A
