### PR TITLE
Fix re-running workflows for non-selected but authorized group

### DIFF
--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -234,6 +234,34 @@ func (a *GitHubApp) GetInstallationToken(ctx context.Context, owner string) (str
 	return tok.GetToken(), nil
 }
 
+func (a *GitHubApp) GetRepositoryInstallationToken(ctx context.Context, repo *tables.GitRepository) (string, error) {
+	if err := perms.AuthorizeGroupAccess(ctx, a.env, repo.GroupID); err != nil {
+		return "", err
+	}
+	repoURL, err := gitutil.ParseGitHubRepoURL(repo.RepoURL)
+	if err != nil {
+		return "", err
+	}
+	var installation tables.GitHubAppInstallation
+	err = a.env.GetDBHandle().DB(ctx).Raw(`
+		SELECT *
+		FROM GitHubAppInstallations
+		WHERE group_id = ?
+		AND owner = ?
+	`, repo.GroupID, repoURL.Owner).Take(&installation).Error
+	if err != nil {
+		if db.IsRecordNotFound(err) {
+			return "", status.NotFoundErrorf("failed to look up GitHub app installation: %s", err)
+		}
+		return "", err
+	}
+	tok, err := a.createInstallationToken(ctx, installation.InstallationID)
+	if err != nil {
+		return "", err
+	}
+	return tok.GetToken(), nil
+}
+
 func (a *GitHubApp) GetGitHubAppInstallations(ctx context.Context, req *ghpb.GetAppInstallationsRequest) (*ghpb.GetAppInstallationsResponse, error) {
 	u, err := perms.AuthenticatedUser(ctx, a.env)
 	if err != nil {

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -245,7 +245,7 @@ func (a *GitHubApp) GetRepositoryInstallationToken(ctx context.Context, repo *ta
 	var installation tables.GitHubAppInstallation
 	err = a.env.GetDBHandle().DB(ctx).Raw(`
 		SELECT *
-		FROM GitHubAppInstallations
+		FROM "GitHubAppInstallations"
 		WHERE group_id = ?
 		AND owner = ?
 	`, repo.GroupID, repoURL.Owner).Take(&installation).Error

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -635,7 +635,7 @@ func (ws *workflowService) getRepositoryWorkflow(ctx context.Context, id string)
 		}
 		return nil, status.InternalErrorf("failed to look up repo %q: %s", repoURL, err)
 	}
-	token, err := app.GetInstallationToken(ctx, repoURL.Owner)
+	token, err := app.GetRepositoryInstallationToken(ctx, gitRepository)
 	if err != nil {
 		return nil, err
 	}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -489,7 +489,7 @@ type GitHubApp interface {
 	// owner (GitHub username or org name).
 	GetInstallationToken(ctx context.Context, owner string) (string, error)
 
-	// GetRepositoryInstallationToken returns an installation for the given
+	// GetRepositoryInstallationToken returns an installation token for the given
 	// GitRepository.
 	GetRepositoryInstallationToken(ctx context.Context, repo *tables.GitRepository) (string, error)
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -489,6 +489,10 @@ type GitHubApp interface {
 	// owner (GitHub username or org name).
 	GetInstallationToken(ctx context.Context, owner string) (string, error)
 
+	// GetRepositoryInstallationToken returns an installation for the given
+	// GitRepository.
+	GetRepositoryInstallationToken(ctx context.Context, repo *tables.GitRepository) (string, error)
+
 	// WebhookHandler returns the GitHub webhook HTTP handler.
 	WebhookHandler() http.Handler
 


### PR DESCRIPTION
Fixes an issue that workflows cannot be re-run when the org that owns the workflow isn't selected, even if the authenticated user has access to the workflow.

**Related issues**: Fixed https://github.com/buildbuddy-io/buildbuddy-internal/issues/2246
