### PR TITLE
Re-link sociartifactstore back into app

### DIFF
--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -47,6 +47,7 @@ go_library(
         "//enterprise/server/scheduling/task_router",
         "//enterprise/server/secrets",
         "//enterprise/server/selfauth",
+        "//enterprise/server/sociartifactstore",
         "//enterprise/server/splash",
         "//enterprise/server/suggestion",
         "//enterprise/server/tasksize",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_router"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/secrets"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/selfauth"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/sociartifactstore"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/splash"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/suggestion"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/tasksize"
@@ -271,6 +272,9 @@ func main() {
 		log.Fatalf("%v", err)
 	}
 	if err := crypter_service.Register(realEnv); err != nil {
+		log.Fatalf("%v", err)
+	}
+	if err := sociartifactstore.Register(realEnv); err != nil {
 		log.Fatalf("%v", err)
 	}
 


### PR DESCRIPTION
I removed this in https://github.com/buildbuddy-io/buildbuddy/pull/3815 because it was causing the apps to fail to start due to an unmet libstdc++ dependency. After https://github.com/buildbuddy-io/buildbuddy/pull/3837 and https://github.com/buildbuddy-io/buildbuddy-internal/pull/2250 this dependency is met, so this should be good to go again.

**Related issues**: N/A
