### PR TITLE
Fix workflow runs for forked repos

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1611,7 +1611,10 @@ func readConfig() (*config.BuildBuddyConfig, error) {
 	f, err := os.Open(config.FilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return config.GetDefault(), nil
+			// Note: targetRepoDefaultBranch is only used to compute triggers,
+			// but we don't read triggers in the CI runner (since the runner is
+			// already triggered). So we exclude the default branch here.
+			return config.GetDefault("" /*=targetRepoDefaultBranch*/), nil
 		}
 		return nil, status.FailedPreconditionErrorf("open %q: %s", config.FilePath, err)
 	}

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -216,18 +216,13 @@ func (a *GitHubApp) handleWorkflowEvent(ctx context.Context, eventType string, e
 		ctx, row.GitRepository, wd, tok.GetToken())
 }
 
-func (a *GitHubApp) GetInstallationToken(ctx context.Context, owner string) (string, error) {
-	u, err := perms.AuthenticatedUser(ctx, a.env)
-	if err != nil {
-		return "", err
-	}
+func (a *GitHubApp) GetInstallationTokenForStatusReportingOnly(ctx context.Context, owner string) (string, error) {
 	var installation tables.GitHubAppInstallation
-	err = a.env.GetDBHandle().DB(ctx).Raw(`
+	err := a.env.GetDBHandle().DB(ctx).Raw(`
 		SELECT *
 		FROM "GitHubAppInstallations"
-		WHERE group_id = ?
-		AND owner = ?
-	`, u.GetGroupID(), owner).Take(&installation).Error
+		WHERE owner = ?
+	`, owner).Take(&installation).Error
 	if err != nil {
 		if db.IsRecordNotFound(err) {
 			return "", status.NotFoundErrorf("failed to look up GitHub app installation: %s", err)

--- a/enterprise/server/webhooks/github/github.go
+++ b/enterprise/server/webhooks/github/github.go
@@ -124,19 +124,21 @@ func ParseWebhookData(event interface{}) (*interfaces.WebhookData, error) {
 			"Ref",
 			"Repo.CloneURL",
 			"Repo.Private",
+			"Repo.DefaultBranch",
 		)
 		if err != nil {
 			return nil, err
 		}
 		branch := strings.TrimPrefix(v["Ref"], "refs/heads/")
 		return &interfaces.WebhookData{
-			EventName:          webhook_data.EventName.Push,
-			PushedRepoURL:      v["Repo.CloneURL"],
-			PushedBranch:       branch,
-			SHA:                v["HeadCommit.ID"],
-			TargetRepoURL:      v["Repo.CloneURL"],
-			TargetBranch:       branch,
-			IsTargetRepoPublic: v["Repo.Private"] == "false",
+			EventName:               webhook_data.EventName.Push,
+			PushedRepoURL:           v["Repo.CloneURL"],
+			PushedBranch:            branch,
+			SHA:                     v["HeadCommit.ID"],
+			TargetRepoURL:           v["Repo.CloneURL"],
+			TargetRepoDefaultBranch: v["Repo.DefaultBranch"],
+			TargetBranch:            branch,
+			IsTargetRepoPublic:      v["Repo.Private"] == "false",
 		}, nil
 
 	case *gh.PullRequestEvent:
@@ -178,6 +180,7 @@ func parsePullRequestOrReview(event interface{}) (*interfaces.WebhookData, error
 		"PullRequest.Head.SHA",
 		"PullRequest.Base.Repo.CloneURL",
 		"PullRequest.Base.Repo.Private",
+		"PullRequest.Base.Repo.DefaultBranch",
 		"PullRequest.Base.Ref",
 		"PullRequest.User.Login",
 	)
@@ -186,14 +189,15 @@ func parsePullRequestOrReview(event interface{}) (*interfaces.WebhookData, error
 	}
 	isTargetRepoPublic := v["PullRequest.Base.Repo.Private"] == "false"
 	return &interfaces.WebhookData{
-		EventName:          webhook_data.EventName.PullRequest,
-		PushedRepoURL:      v["PullRequest.Head.Repo.CloneURL"],
-		PushedBranch:       v["PullRequest.Head.Ref"],
-		SHA:                v["PullRequest.Head.SHA"],
-		TargetRepoURL:      v["PullRequest.Base.Repo.CloneURL"],
-		IsTargetRepoPublic: isTargetRepoPublic,
-		TargetBranch:       v["PullRequest.Base.Ref"],
-		PullRequestAuthor:  v["PullRequest.User.Login"],
+		EventName:               webhook_data.EventName.PullRequest,
+		PushedRepoURL:           v["PullRequest.Head.Repo.CloneURL"],
+		PushedBranch:            v["PullRequest.Head.Ref"],
+		SHA:                     v["PullRequest.Head.SHA"],
+		TargetRepoURL:           v["PullRequest.Base.Repo.CloneURL"],
+		TargetRepoDefaultBranch: v["PullRequest.Base.Repo.DefaultBranch"],
+		IsTargetRepoPublic:      isTargetRepoPublic,
+		TargetBranch:            v["PullRequest.Base.Ref"],
+		PullRequestAuthor:       v["PullRequest.User.Login"],
 	}, nil
 }
 

--- a/enterprise/server/webhooks/github/github_test.go
+++ b/enterprise/server/webhooks/github/github_test.go
@@ -28,12 +28,13 @@ func TestParseRequest_ValidPushEvent_Success(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, &interfaces.WebhookData{
-		EventName:     "push",
-		PushedRepoURL: "https://github.com/test/hello_bb_ci.git",
-		PushedBranch:  "main",
-		SHA:           "258044d28288d5f6f1c5928b0e22580296fec666",
-		TargetRepoURL: "https://github.com/test/hello_bb_ci.git",
-		TargetBranch:  "main",
+		EventName:               "push",
+		PushedRepoURL:           "https://github.com/test/hello_bb_ci.git",
+		PushedBranch:            "main",
+		SHA:                     "258044d28288d5f6f1c5928b0e22580296fec666",
+		TargetRepoURL:           "https://github.com/test/hello_bb_ci.git",
+		TargetRepoDefaultBranch: "main",
+		TargetBranch:            "main",
 	}, data)
 }
 
@@ -44,13 +45,14 @@ func TestParseRequest_ValidPullRequestEvent_Success(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, &interfaces.WebhookData{
-		EventName:         "pull_request",
-		PushedRepoURL:     "https://github.com/test/hello_bb_ci.git",
-		PushedBranch:      "pr-1613157046",
-		SHA:               "21006e203e433034cd4d82859d28d3bc1dbdf9f7",
-		TargetRepoURL:     "https://github.com/test/hello_bb_ci.git",
-		TargetBranch:      "main",
-		PullRequestAuthor: "test",
+		EventName:               "pull_request",
+		PushedRepoURL:           "https://github.com/test/hello_bb_ci.git",
+		PushedBranch:            "pr-1613157046",
+		SHA:                     "21006e203e433034cd4d82859d28d3bc1dbdf9f7",
+		TargetRepoURL:           "https://github.com/test/hello_bb_ci.git",
+		TargetRepoDefaultBranch: "main",
+		TargetBranch:            "main",
+		PullRequestAuthor:       "test",
 	}, data)
 }
 
@@ -61,15 +63,16 @@ func TestParseRequest_ValidPullRequestReviewEvent_Success(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, &interfaces.WebhookData{
-		EventName:           "pull_request",
-		PushedRepoURL:       "https://github.com/test2/bb-workflows-test.git",
-		PushedBranch:        "pr-test",
-		SHA:                 "7d27db5443e48541a49693422c3b30fe6e8e3e9f",
-		TargetRepoURL:       "https://github.com/test/bb-workflows-test.git",
-		IsTargetRepoPublic:  true,
-		TargetBranch:        "main",
-		PullRequestAuthor:   "test2",
-		PullRequestApprover: "test",
+		EventName:               "pull_request",
+		PushedRepoURL:           "https://github.com/test2/bb-workflows-test.git",
+		PushedBranch:            "pr-test",
+		SHA:                     "7d27db5443e48541a49693422c3b30fe6e8e3e9f",
+		TargetRepoURL:           "https://github.com/test/bb-workflows-test.git",
+		TargetRepoDefaultBranch: "main",
+		IsTargetRepoPublic:      true,
+		TargetBranch:            "main",
+		PullRequestAuthor:       "test2",
+		PullRequestApprover:     "test",
 	}, data)
 }
 

--- a/enterprise/server/webhooks/webhook_data/webhook_data.go
+++ b/enterprise/server/webhooks/webhook_data/webhook_data.go
@@ -21,9 +21,9 @@ func init() {
 
 func DebugString(wd *interfaces.WebhookData) string {
 	return fmt.Sprintf(
-		"event=%s, pushed=%s@%s:%s, target=%s@%s (public=%t), pr_author=%s, pr_approver=%s",
+		"event=%s, pushed=%s@%s:%s, target=%s@%s (public=%t, default_branch=%s), pr_author=%s, pr_approver=%s",
 		wd.EventName,
 		wd.PushedRepoURL, wd.PushedBranch, wd.SHA,
-		wd.TargetRepoURL, wd.TargetBranch, wd.IsTargetRepoPublic,
+		wd.TargetRepoURL, wd.TargetBranch, wd.IsTargetRepoPublic, wd.TargetRepoDefaultBranch,
 		wd.PullRequestAuthor, wd.PullRequestApprover)
 }

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -980,7 +980,7 @@ func (ws *workflowService) fetchWorkflowConfig(ctx context.Context, gitProvider 
 	b, err := gitProvider.GetFileContents(ctx, workflow.AccessToken, webhookData.PushedRepoURL, config.FilePath, webhookData.SHA)
 	if err != nil {
 		if status.IsNotFoundError(err) {
-			return config.GetDefault(), nil
+			return config.GetDefault(webhookData.TargetRepoDefaultBranch), nil
 		}
 		return nil, err
 	}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -484,10 +484,11 @@ type GitHubApp interface {
 
 	GetAccessibleGitHubRepos(context.Context, *ghpb.GetAccessibleReposRequest) (*ghpb.GetAccessibleReposResponse, error)
 
-	// GetInstallationToken returns an installation token for the installation
-	// associated with the authenticated group ID and the given installation
-	// owner (GitHub username or org name).
-	GetInstallationToken(ctx context.Context, owner string) (string, error)
+	// GetInstallationTokenForStatusReportingOnly returns an installation token
+	// for the installation associated with the given installation owner (GitHub
+	// username or org name). It does not authorize the authenticated group ID,
+	// so should be used for status reporting only.
+	GetInstallationTokenForStatusReportingOnly(ctx context.Context, owner string) (string, error)
 
 	// GetRepositoryInstallationToken returns an installation token for the given
 	// GitRepository.
@@ -564,6 +565,11 @@ type WebhookData struct {
 	// workflow.
 	// Ex: "https://github.com/acme-inc/acme"
 	TargetRepoURL string
+
+	// TargetRepoDefaultBranch is the default / main branch of the target repo.
+	// The default branch can be configured in the repo settings on GitHub.
+	// Ex: "main"
+	TargetRepoDefaultBranch string
 
 	// TargetBranch is the branch associated with the event that determines whether
 	// actions should be triggered. For push events this is the branch that was


### PR DESCRIPTION
- Improve the "default" workflow configuration (used when buildbuddy.yaml is missing) so that it runs whenever (a) the repo's default branch (i.e. main/master) is pushed, or (b) whenever a PR branch is pushed. This is needed because we don't get `push` events when the forked repo is pushed.
- Fix the GitHub token plumbing so that the authentication works the same as how legacy workflows work.
- Improve logging.

**Related issues**: N/A
