### PR TITLE
Include encryption key in pebble key.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1227,7 +1227,7 @@ func (p *PebbleCache) makeFileRecord(ctx context.Context, r *rspb.ResourceName) 
 	if encryptionEnabled {
 		ak, err := p.env.GetCrypter().ActiveKey(ctx)
 		if err != nil {
-			return nil, status.UnavailableErrorf("could not obtain encryption key: %s", err)
+			return nil, status.FailedPreconditionErrorf("encryption key not available: %s", err)
 		}
 		encryption = &rfpb.Encryption{KeyId: ak.GetEncryptionKeyId()}
 	}

--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -595,6 +595,14 @@ func (c *Crypter) newEncryptorWithChunkSize(ctx context.Context, digest *repb.Di
 	}, nil
 }
 
+func (c *Crypter) ActiveKey(ctx context.Context) (*rfpb.EncryptionMetadata, error) {
+	loadedKey, err := c.cache.encryptionKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return loadedKey.metadata, nil
+}
+
 func (c *Crypter) NewEncryptor(ctx context.Context, digest *repb.Digest, w interfaces.CommittedWriteCloser) (interfaces.Encryptor, error) {
 	u, err := c.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {

--- a/enterprise/server/crypter_service/crypter_service_test.go
+++ b/enterprise/server/crypter_service/crypter_service_test.go
@@ -745,12 +745,12 @@ func TestConfigAPI(t *testing.T) {
 	// The previously written unencrypted data becomes inaccessible.
 	_, err = pc.Get(apiKeyCtx, plaintextResource)
 	require.Error(t, err)
-	require.True(t, status.IsUnavailableError(err))
+	require.True(t, status.IsFailedPreconditionError(err))
 
 	// Shouldn't be able to read the encrypted resource anymore.
 	_, err = pc.Get(apiKeyCtx, encryptedResource)
 	require.Error(t, err)
-	require.True(t, status.IsUnavailableError(err))
+	require.True(t, status.IsFailedPreconditionError(err))
 
 	// Restore the key so we can test disabling encryption via the API.
 	kms.SetKey(groupKMSKeyID, groupKMSKey)

--- a/enterprise/server/raft/filestore/filestore.go
+++ b/enterprise/server/raft/filestore/filestore.go
@@ -75,6 +75,8 @@ const (
 	// regardless of remote instance name.
 	Version2
 
+	Version3
+
 	// TestingMaxKeyVersion should not be used directly -- it is always
 	// 1 more than the highest defined version, which allows for tests
 	// to iterate across all versions from UndefinedKeyVersion to
@@ -88,6 +90,7 @@ type PebbleKey struct {
 	isolation          string
 	remoteInstanceHash string
 	hash               string
+	encryptionKey      string
 }
 
 func (pmk PebbleKey) String() string {
@@ -114,6 +117,10 @@ func (pmk PebbleKey) CacheType() rspb.CacheType {
 	default:
 		return rspb.CacheType_UNKNOWN_CACHE_TYPE
 	}
+}
+
+func (pmk PebbleKey) Hash() string {
+	return pmk.hash
 }
 
 // Returns a group ID that is zero padded to 20 digits in order to make all
@@ -163,6 +170,18 @@ func (pmk *PebbleKey) Bytes(version PebbleKeyVersion) ([]byte, error) {
 		}
 		partDir := PartitionDirectoryPrefix + pmk.partID
 		filePath = filepath.Join(partDir, filePath, "v2")
+		return []byte(filePath), nil
+	case Version3:
+		rih := pmk.remoteInstanceHash
+		if pmk.isolation == "ac" && rih == "" {
+			rih = "0"
+		}
+		filePath := filepath.Join(pmk.hash, pmk.isolation, rih, pmk.encryptionKey)
+		if pmk.isolation == "ac" {
+			filePath = filepath.Join(fixedWidthGroupID(pmk.groupID), filePath)
+		}
+		partDir := PartitionDirectoryPrefix + pmk.partID
+		filePath = filepath.Join(partDir, filePath, "v3")
 		return []byte(filePath), nil
 	default:
 		return nil, status.FailedPreconditionErrorf("Unknown key version: %v", version)
@@ -219,6 +238,38 @@ func (pmk *PebbleKey) parseVersion2(parts [][]byte) error {
 	return nil
 }
 
+func (pmk *PebbleKey) parseVersion3(parts [][]byte) error {
+	switch len(parts) {
+	// CAS artifact
+	// PTfoo/abcd12345asdasdasd123123123asdasdasd/v3
+	case 4:
+		pmk.partID, pmk.hash, pmk.isolation = string(parts[0]), string(parts[1]), string(parts[2])
+	// encrypted CAS artifact
+	// PTfoo/abcd12345asdasdasd123123123asdasdasd/EK123/v3
+	case 5:
+		pmk.partID, pmk.hash, pmk.isolation, pmk.encryptionKey = string(parts[0]), string(parts[1]), string(parts[2]), string(parts[3])
+	// AC artifact
+	// PTfoo/GR123/abcd12345asdasdasd123123123asdasdasd/ac/123/v3
+	case 6:
+		pmk.partID, pmk.groupID, pmk.hash, pmk.isolation, pmk.remoteInstanceHash = string(parts[0]), string(parts[1]), string(parts[2]), string(parts[3]), string(parts[4])
+		if pmk.remoteInstanceHash == "0" {
+			pmk.remoteInstanceHash = ""
+		}
+	// encrypted AC artifact
+	// PTfoo/GR123/abcd12345asdasdasd123123123asdasdasd/ac/123/EK123/v3
+	case 7:
+		pmk.partID, pmk.groupID, pmk.hash, pmk.isolation, pmk.remoteInstanceHash, pmk.encryptionKey = string(parts[0]), string(parts[1]), string(parts[2]), string(parts[3]), string(parts[4]), string(parts[5])
+		if pmk.remoteInstanceHash == "0" {
+			pmk.remoteInstanceHash = ""
+		}
+	default:
+		return parseError(parts)
+	}
+	pmk.partID = strings.TrimPrefix(pmk.partID, PartitionDirectoryPrefix)
+	pmk.groupID = trimFixedWidthGroupID(pmk.groupID)
+	return nil
+}
+
 func (pmk *PebbleKey) FromBytes(in []byte) (PebbleKeyVersion, error) {
 	version := UndefinedKeyVersion
 	slash := []byte{filepath.Separator}
@@ -247,6 +298,8 @@ func (pmk *PebbleKey) FromBytes(in []byte) (PebbleKeyVersion, error) {
 		return Version1, pmk.parseVersion1(parts)
 	case Version2:
 		return Version2, pmk.parseVersion2(parts)
+	case Version3:
+		return Version3, pmk.parseVersion3(parts)
 	default:
 		return -1, status.InvalidArgumentErrorf("Unable to parse %q to pebble key", in)
 	}
@@ -348,6 +401,7 @@ func (fs *fileStorer) PebbleKey(r *rfpb.FileRecord) (PebbleKey, error) {
 		isolation:          isolation,
 		remoteInstanceHash: remoteInstanceHash,
 		hash:               hash,
+		encryptionKey:      r.GetEncryption().GetKeyId(),
 	}, nil
 }
 

--- a/enterprise/server/raft/filestore/filestore_test.go
+++ b/enterprise/server/raft/filestore/filestore_test.go
@@ -57,20 +57,25 @@ func TestKeyVersionCrossCompatibility(t *testing.T) {
 
 func TestKnownVersions(t *testing.T) {
 	versionExemplars := map[filestore.PebbleKeyVersion][]string{
-		filestore.UndefinedKeyVersion: []string{
+		filestore.UndefinedKeyVersion: {
 			"PTFOO/cas/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2",
 			"PTFOO/GR7890/ac/2364854541/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309",
 			"PTdefault/GR5787812970202071253/ac/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f",
 		},
-		filestore.Version1: []string{
+		filestore.Version1: {
 			"PTFOO/cas/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2/v1",
 			"PTFOO/GR7890/ac/2364854541/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/v1",
 			"PTFOO/GR7890/ac/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/v1",
 		},
-		filestore.Version2: []string{
+		filestore.Version2: {
 			"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/cas/v2",
 			"PTFOO/GR00000000000000007890/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/ac/2364854541/v2",
 			"PTFOO/GR00000000000000007890/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/ac/v2",
+		},
+		filestore.Version3: {
+			"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/cas/v3",
+			"PTFOO/GR00000000000000007890/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/ac/2364854541/v3",
+			"PTFOO/GR00000000000000007890/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/ac/0/v3",
 		},
 	}
 
@@ -95,16 +100,19 @@ func TestMigration(t *testing.T) {
 			filestore.UndefinedKeyVersion: "PTFOO/cas/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2",
 			filestore.Version1:            "PTFOO/cas/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2/v1",
 			filestore.Version2:            "PTFOO/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2/cas/v2",
+			filestore.Version3:            "PTFOO/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2/cas/v3",
 		},
 		{
 			filestore.UndefinedKeyVersion: "PTFOO/GR7890/ac/2364854541/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309",
 			filestore.Version1:            "PTFOO/GR7890/ac/2364854541/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/v1",
 			filestore.Version2:            "PTFOO/GR00000000000000007890/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/ac/2364854541/v2",
+			filestore.Version3:            "PTFOO/GR00000000000000007890/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/ac/2364854541/v3",
 		},
 		{
 			filestore.UndefinedKeyVersion: "PTdefault/GR7890/ac/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f",
 			filestore.Version1:            "PTdefault/GR7890/ac/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/v1",
 			filestore.Version2:            "PTdefault/GR00000000000000007890/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/ac/v2",
+			filestore.Version3:            "PTdefault/GR00000000000000007890/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/ac/0/v3",
 		},
 	}
 

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -26,10 +26,15 @@ message Isolation {
   string group_id = 4;
 }
 
+message Encryption {
+  string key_id = 1;
+}
+
 message FileRecord {
   Isolation isolation = 1;
   build.bazel.remote.execution.v2.Digest digest = 2;
   build.bazel.remote.execution.v2.Compressor.Value compressor = 3;
+  Encryption encryption = 4;
 }
 
 message StorageMetadata {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1110,6 +1110,8 @@ type Crypter interface {
 	SetEncryptionConfig(ctx context.Context, req *enpb.SetEncryptionConfigRequest) (*enpb.SetEncryptionConfigResponse, error)
 	GetEncryptionConfig(ctx context.Context, req *enpb.GetEncryptionConfigRequest) (*enpb.GetEncryptionConfigResponse, error)
 
+	ActiveKey(ctx context.Context) (*rfpb.EncryptionMetadata, error)
+
 	NewEncryptor(ctx context.Context, d *repb.Digest, w CommittedWriteCloser) (Encryptor, error)
 	NewDecryptor(ctx context.Context, d *repb.Digest, r io.ReadCloser, em *rfpb.EncryptionMetadata) (Decryptor, error)
 }


### PR DESCRIPTION
Turning encryption on or off should be a seamless operation from Bazel's perspective. If we don't include this information in the key, we'd have to get the information from the value which would negatively impact certain APIs (e.g. FindMissing) both in performance and complexity.

For example, if the user turns off encryption we want FindMissing to not report previously written encrypted blobs as present which would require unmarshalling and checking the value for each key.

We have to adjust the eviction sampling to take into account the fact that there could be more than one key with the same digest prefix. Note that this can also be true in the new AC key format if the same digest appears under multiple remote instance name hashes.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
