### PR TITLE
scheduler_server: flip remove_stale_executors to true

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -43,7 +43,9 @@ var (
 	defaultPoolName              = flag.String("remote_execution.default_pool_name", "", "The default executor pool to use if one is not specified.")
 	sharedExecutorPoolGroupID    = flag.String("remote_execution.shared_executor_pool_group_id", "", "Group ID that owns the shared executor pool.")
 	requireExecutorAuthorization = flag.Bool("remote_execution.require_executor_authorization", false, "If true, executors connecting to this server must provide a valid executor API key.")
-	removeStaleExecutors         = flag.Bool("remote_execution.remove_stale_executors", false, "If true, executors are removed if they are not heard from for a prolonged amount of time.")
+
+	// TODO(sluongng): remove this flag once we have released a new BuildBuddy version.
+	removeStaleExecutors = flag.Bool("remote_execution.remove_stale_executors", true, "If true, executors are removed if they are not heard from for a prolonged amount of time.")
 )
 
 const (


### PR DESCRIPTION
Not setting this flag to true would make BuildBuddy iterate through
the stale executors during scheduling.  With sufficient amount of
stale executors, scheduling process could be significantly slower.

Since we have set this flag to true in production for a while, let's
deprecate it by setting the default to true in up-coming release and
remove the flag entirely in a subsequent release.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
