### PR TITLE
Simplify/refactor snaploader

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -227,6 +227,7 @@ func TestFirecrackerLifecycle(t *testing.T) {
 	if res.Error != nil {
 		t.Fatal(res.Error)
 	}
+	res.UsageStats = nil
 	assert.Equal(t, expectedResult, res)
 }
 

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -11,9 +11,9 @@ go_library(
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/environment",
-        "//server/remote_cache/digest",
         "//server/util/hash",
         "//server/util/status",
+        "@org_golang_google_protobuf//proto",
     ],
 )
 
@@ -23,8 +23,6 @@ go_test(
     deps = [
         ":snaploader",
         "//enterprise/server/remote_execution/filecache",
-        "//proto:remote_execution_go_proto",
-        "//server/environment",
         "//server/testutil/testenv",
         "//server/testutil/testfs",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -2,43 +2,86 @@ package snaploader
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/filecacheutil"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
-	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/hash"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"google.golang.org/protobuf/proto"
 
 	fcpb "github.com/buildbuddy-io/buildbuddy/proto/firecracker"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
-const (
-	// The name of a file that will be included in the snapshot and contains
-	// metadata about the machine configuration that was snapshotted.
-	ManifestFileName = "manifest.bin"
-)
-
-// NewKey returns the cache key that can be used to look up the snapshot
+// Key represents a cache key pointing to a snapshot
 // manifest.
-// TODO(bduffany): once runners are capable of sharing snapshots, remove
-// runnerID from the digest hash.
-// TODO(bduffany): use ResourceName instead of digest and incorporate
+type Key struct {
+	// ConfigurationHash is the hash of the VMConfiguration of the
+	// paused snapshot.
+	ConfigurationHash string
+
+	// RunnerID is the unique ID of the runner that is allowed to access
+	// this snapshot.
+	// TODO: represent readonly ("shareable") snapshots using an empty runner ID.
+	RunnerID string
+}
+
+// NewKey returns the cache key for a snapshot.
+// TODO: pass in a ctx and represent the group ID
+// explicitly in the cache key (for filecache, need to hash the
+// group ID into the key explicitly; for remote cache, the group will
+// instead be present in the JWT used for authenticating w/ the cache)
+// TODO: include a version number in the key somehow, so that we
+// if we make breaking changes e.g. to the vmexec API or firecracker
+// version etc., we can ensure that incompatible snapshots don't get reused.
+// TODO: use ResourceName instead of digest and incorporate
 // remote_instance_name. The instance name is currently implicit in the runnerID
 // since we only match tasks to runners if their instance name matches the
 // runner's instance name. But once we have snapshot sharing, runnerID will no
 // longer be part of the snapshot key.
-func NewKey(configurationHash, runnerID string) *repb.Digest {
-	return &repb.Digest{
-		Hash:      hash.String(hash.String(configurationHash) + hash.String(runnerID)),
-		SizeBytes: 101, // arbitrary
+func NewKey(configurationHash, runnerID string) *Key {
+	return &Key{
+		ConfigurationHash: configurationHash,
+		RunnerID:          runnerID,
 	}
 }
 
-type LoadSnapshotOptions struct {
+// manifestFileCacheKey returns the filecache key for the snapshot manifest
+// file.
+func (s *Key) manifestFileCacheKey() *repb.FileNode {
+	// Note: .manifest is not a real file that we ever create on disk, it's
+	// effectively just part of the cache key used to locate the manifest.
+	return s.artifactFileCacheKey(".manifest", 1 /*=arbitrary size*/)
+}
+
+// artifactFileCacheKey returns the cache key for a particular snapshot
+// artifact.
+func (s *Key) artifactFileCacheKey(name string, sizeBytes int64) *repb.FileNode {
+	// Just hash the file name with the snapshot key digest for now, since it is
+	// too costly to compute the full file digest. Note that this only works
+	// because filecache doesn't verify digests. If we store these remotely in
+	// CAS, then we will need to compute the full digest.
+	return &repb.FileNode{
+		Digest: &repb.Digest{
+			Hash:      hashStrings(s.ConfigurationHash, s.RunnerID, name),
+			SizeBytes: sizeBytes,
+		},
+	}
+}
+
+// Snapshot holds a snapshot manifest along with the corresponding cache key.
+type Snapshot struct {
+	key      *Key
+	manifest *fcpb.SnapshotManifest
+}
+
+func (s *Snapshot) GetVMConfiguration() *fcpb.VMConfiguration {
+	return s.manifest.GetVmConfiguration()
+}
+
+type CacheSnapshotOptions struct {
 	// The following fields are all required.
 	VMConfiguration     *fcpb.VMConfiguration
 	MemSnapshotPath     string
@@ -56,7 +99,7 @@ type LoadSnapshotOptions struct {
 	WorkspaceFSPath string
 }
 
-func enumerateFiles(snapOpts *LoadSnapshotOptions) []string {
+func enumerateFiles(snapOpts *CacheSnapshotOptions) []string {
 	files := []string{
 		snapOpts.MemSnapshotPath,
 		snapOpts.VMStateSnapshotPath,
@@ -73,62 +116,58 @@ func enumerateFiles(snapOpts *LoadSnapshotOptions) []string {
 	return files
 }
 
+// Loader loads and stores snapshot artifacts to cache. Only a single loader
+// instance is required - the loader is stateless and loader operations can be
+// used concurrently by different snapshots.
 type Loader interface {
-	CacheSnapshot(ctx context.Context, snapshotDigest *repb.Digest, snapOpts *LoadSnapshotOptions) error
-	UnpackSnapshot(ctx context.Context, snapshotDigest *repb.Digest, outputDirectory string) error
-	DeleteSnapshot(ctx context.Context, snapshotDigest *repb.Digest) error
-	GetConfiguration(ctx context.Context, snapshotDigest *repb.Digest) (*fcpb.VMConfiguration, error)
+	// CacheSnapshot saves a local snapshot with the given key to cache, with the
+	// snapshot configuration and artifact paths specified by opts.
+	CacheSnapshot(ctx context.Context, key *Key, opts *CacheSnapshotOptions) (*Snapshot, error)
+
+	// GetSnapshot loads the metadata for the snapshot. It does not
+	// unpack any snapshot artifacts.
+	// It returns UnavailableError if the metadata has expired from cache.
+	GetSnapshot(ctx context.Context, key *Key) (*Snapshot, error)
+
+	// UnpackSnapshot unpacks a snapshot to the given directory.
+	// It returns UnavailableError if any snapshot artifacts have expired
+	// from cache.
+	UnpackSnapshot(ctx context.Context, snapshot *Snapshot, outputDirectory string) error
+
+	// DeleteSnapshot removes the snapshot artifacts from cache
+	// as well as the manifest entry.
+	// This is useful to free up cache space used by stale snapshots.
+	// Snapshots are quite large (tens of GB) so a single VM being
+	// paused and resumed can cause significant cache churn.
+	DeleteSnapshot(ctx context.Context, snapshot *Snapshot) error
 }
 
 type FileCacheLoader struct {
-	env            environment.Env
-	snapshotDigest *repb.Digest
-	manifest       *fcpb.SnapshotManifest
+	env environment.Env
 }
 
-// New returns a new snapshot.Loader that can be used to download the specified
-// snapshot into the target chroot.
 func New(env environment.Env) (Loader, error) {
-	l := &FileCacheLoader{
-		env: env,
+	if env.GetFileCache() == nil {
+		return nil, status.InvalidArgumentError("missing FileCache in env")
 	}
-	return l, nil
+	return &FileCacheLoader{env: env}, nil
 }
 
-func (l *FileCacheLoader) unpackManifest(snapshotDigest *repb.Digest) error {
-	if l.env.GetFileCache() == nil {
-		return status.FailedPreconditionErrorf("Unable to load snapshot: FileCache not enabled")
-	}
-	l.snapshotDigest = snapshotDigest
-	manifestNode := fileNodeFromDigest(manifestDigest(l.snapshotDigest))
+func (l *FileCacheLoader) GetSnapshot(ctx context.Context, key *Key) (*Snapshot, error) {
+	manifestNode := key.manifestFileCacheKey()
 	buf, err := filecacheutil.Read(l.env.GetFileCache(), manifestNode)
 	if err != nil {
-		return status.UnavailableErrorf("failed to read snapshot manifest: %s", status.Message(err))
+		return nil, status.UnavailableErrorf("failed to read snapshot manifest: %s", status.Message(err))
 	}
-	return json.Unmarshal(buf, &l.manifest)
+	manifest := &fcpb.SnapshotManifest{}
+	if err := proto.Unmarshal(buf, manifest); err != nil {
+		return nil, status.UnavailableErrorf("failed to unmarshal snapshot manifest: %s", status.Message(err))
+	}
+	return &Snapshot{key: key, manifest: manifest}, nil
 }
 
-// GetConfigurationData returns the VM configuration associated with a snapshot.
-func (l *FileCacheLoader) GetConfiguration(ctx context.Context, snapshotDigest *repb.Digest) (*fcpb.VMConfiguration, error) {
-	if err := l.unpackManifest(snapshotDigest); err != nil {
-		return nil, err
-	}
-	return l.manifest.VmConfiguration, nil
-}
-
-// UnpackSnapshot unpacks all of the files in a snapshot to the specified output
-// directory.
-func (l *FileCacheLoader) UnpackSnapshot(ctx context.Context, snapshotDigest *repb.Digest, outputDirectory string) error {
-	if l.snapshotDigest != nil && l.snapshotDigest != snapshotDigest {
-		return status.InvalidArgumentErrorf("Snapshot configuration already fetched with different digest %q", digest.String(l.snapshotDigest))
-	}
-
-	if l.manifest == nil {
-		if err := l.unpackManifest(snapshotDigest); err != nil {
-			return err
-		}
-	}
-	for _, fileNode := range l.manifest.Files {
+func (l *FileCacheLoader) UnpackSnapshot(ctx context.Context, snapshot *Snapshot, outputDirectory string) error {
+	for _, fileNode := range snapshot.manifest.Files {
 		if !l.env.GetFileCache().FastLinkFile(fileNode, filepath.Join(outputDirectory, fileNode.GetName())) {
 			return status.UnavailableErrorf("snapshot artifact %q not found in local cache", fileNode.GetName())
 		}
@@ -136,78 +175,50 @@ func (l *FileCacheLoader) UnpackSnapshot(ctx context.Context, snapshotDigest *re
 	return nil
 }
 
-func (l *FileCacheLoader) DeleteSnapshot(ctx context.Context, snapshotDigest *repb.Digest) error {
-	if l.snapshotDigest != nil && l.snapshotDigest != snapshotDigest {
-		return status.InvalidArgumentErrorf("Snapshot configuration already fetched with different digest %q", digest.String(l.snapshotDigest))
-	}
-	if l.manifest == nil {
-		if err := l.unpackManifest(snapshotDigest); err != nil {
-			return err
-		}
-	}
+func (l *FileCacheLoader) DeleteSnapshot(ctx context.Context, snapshot *Snapshot) error {
 	// Manually evict the manifest as well as all referenced files.
-	l.env.GetFileCache().DeleteFile(fileNodeFromDigest(manifestDigest(snapshotDigest)))
-	for _, fileNode := range l.manifest.Files {
+	l.env.GetFileCache().DeleteFile(snapshot.key.manifestFileCacheKey())
+	for _, fileNode := range snapshot.manifest.Files {
 		l.env.GetFileCache().DeleteFile(fileNode)
 	}
 	return nil
 }
 
-func manifestDigest(snapshotDigest *repb.Digest) *repb.Digest {
-	return &repb.Digest{
-		Hash:      hash.String(snapshotDigest.GetHash() + ManifestFileName),
-		SizeBytes: int64(101),
-	}
-}
-
-// CacheSnapshot stores a snapshot (described by snapOpts), in the filecache.
-// Each file is individually stored in the filecache under a digest made from
-// the snapshot ID and the file name. A manifest file that
-// that lists all files. Finally, an action result is cached that describes all
-// files -- this allows for fast existence checking and easy download.
-func (l *FileCacheLoader) CacheSnapshot(ctx context.Context, snapshotDigest *repb.Digest, snapOpts *LoadSnapshotOptions) error {
-	if l.env.GetFileCache() == nil {
-		return status.FailedPreconditionErrorf("Unable to cache snapshot: FileCache not enabled")
-	}
-
+func (l *FileCacheLoader) CacheSnapshot(ctx context.Context, key *Key, opts *CacheSnapshotOptions) (*Snapshot, error) {
 	manifest := &fcpb.SnapshotManifest{
-		VmConfiguration: snapOpts.VMConfiguration,
+		VmConfiguration: opts.VMConfiguration,
 	}
-
 	// Put the files from the snapshot into the filecache and record their
 	// names and digests in the manifest so they can be unpacked later.
-	for _, f := range enumerateFiles(snapOpts) {
+	for _, f := range enumerateFiles(opts) {
 		info, err := os.Stat(f)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		filename := filepath.Base(f)
-		fileNameDigest := &repb.Digest{
-			Hash:      hash.String(snapshotDigest.GetHash() + filename),
-			SizeBytes: int64(info.Size()),
-		}
-		fileNode := fileNodeFromDigest(fileNameDigest)
+		fileNode := key.artifactFileCacheKey(filename, info.Size())
 		fileNode.Name = filename
 		l.env.GetFileCache().AddFile(fileNode, f)
 		manifest.Files = append(manifest.Files, fileNode)
 	}
 
-	// Write the manifest files and put it in the filecache too. We'll
+	// Write the manifest file and put it in the filecache too. We'll
 	// retrieve this later in order to unpack the snapshot.
-	b, err := json.Marshal(manifest)
+	b, err := proto.Marshal(manifest)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	manifestNode := fileNodeFromDigest(manifestDigest(snapshotDigest))
+	manifestNode := key.manifestFileCacheKey()
 	if _, err := filecacheutil.Write(l.env.GetFileCache(), manifestNode, b); err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return &Snapshot{key: key, manifest: manifest}, nil
 }
 
-func fileNodeFromDigest(d *repb.Digest) *repb.FileNode {
-	return &repb.FileNode{
-		Digest:       d,
-		IsExecutable: false,
+func hashStrings(strs ...string) string {
+	out := ""
+	for _, s := range strs {
+		out += hash.String(s)
 	}
+	return hash.String(out)
 }

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -10,12 +10,9 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaploader"
-	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/stretchr/testify/require"
-
-	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
 func TestPackAndUnpack(t *testing.T) {
@@ -33,18 +30,17 @@ func TestPackAndUnpack(t *testing.T) {
 	// and add them to the cache. Note, the snapshot digests don't actually
 	// correspond to any real content; they just need to be unique cache
 	// keys.
-	la, err := snaploader.New(env)
+	loader, err := snaploader.New(env)
 	require.NoError(t, err)
-	da := snaploader.NewKey("vm-config-hash-A", "runner-A")
-	sa := makeFakeSnapshot(t, workDir)
-	err = la.CacheSnapshot(ctx, da, sa)
+	keyA := snaploader.NewKey("vm-config-hash-A", "runner-A")
+	optsA := makeFakeSnapshot(t, workDir)
+	snapA, err := loader.CacheSnapshot(ctx, keyA, optsA)
 	require.NoError(t, err)
 
-	lb, err := snaploader.New(env)
 	require.NoError(t, err)
-	db := snaploader.NewKey("vm-config-hash-B", "runner-B")
-	sb := makeFakeSnapshot(t, workDir)
-	err = lb.CacheSnapshot(ctx, db, sb)
+	keyB := snaploader.NewKey("vm-config-hash-B", "runner-B")
+	optsB := makeFakeSnapshot(t, workDir)
+	snapB, err := loader.CacheSnapshot(ctx, keyB, optsB)
 	require.NoError(t, err)
 
 	// We should be able to unpack snapshot A, delete it, and then replace it
@@ -52,29 +48,25 @@ func TestPackAndUnpack(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		// Unpack (this should also evict from cache).
 		outDir := testfs.MakeDirAll(t, workDir, fmt.Sprintf("unpack-a-%d", i))
-		mustUnpack(t, ctx, env, da, workDir, outDir, sa)
+		mustUnpack(t, ctx, loader, snapA, workDir, outDir, optsA)
 
 		// Delete, since it's no longer needed.
-		// Note: we construct a new loader here to ensure the current
-		// snapshot manifest gets loaded.
-		loader, err := snaploader.New(env)
-		require.NoError(t, err)
-		err = loader.DeleteSnapshot(ctx, da)
+		err = loader.DeleteSnapshot(ctx, snapA)
 		require.NoError(t, err)
 
 		// Re-add to cache with the same key, but with new contents.
-		sa = makeFakeSnapshot(t, workDir)
-		err = la.CacheSnapshot(ctx, da, sa)
+		optsA = makeFakeSnapshot(t, workDir)
+		snapA, err = loader.CacheSnapshot(ctx, keyA, optsA)
 		require.NoError(t, err)
 	}
 
 	// Snapshot B should not have been evicted.
 	outDir := testfs.MakeDirAll(t, workDir, "unpack-b")
-	mustUnpack(t, ctx, env, db, workDir, outDir, sb)
+	mustUnpack(t, ctx, loader, snapB, workDir, outDir, optsB)
 }
 
-func makeFakeSnapshot(t *testing.T, workDir string) *snaploader.LoadSnapshotOptions {
-	return &snaploader.LoadSnapshotOptions{
+func makeFakeSnapshot(t *testing.T, workDir string) *snaploader.CacheSnapshotOptions {
+	return &snaploader.CacheSnapshotOptions{
 		MemSnapshotPath:     makeRandomFile(t, workDir, "mem", 100_000),
 		VMStateSnapshotPath: makeRandomFile(t, workDir, "vmstate", 1_000),
 		KernelImagePath:     makeRandomFile(t, workDir, "kernel", 1_000),
@@ -91,10 +83,8 @@ func makeRandomFile(t *testing.T, rootDir, prefix string, size int) string {
 
 // Unpacks a snapshot to outDir and asserts that the contents match the
 // originally cached contents.
-func mustUnpack(t *testing.T, ctx context.Context, env environment.Env, d *repb.Digest, workDir, outDir string, originalSnapshot *snaploader.LoadSnapshotOptions) {
-	loader, err := snaploader.New(env)
-	require.NoError(t, err)
-	err = loader.UnpackSnapshot(ctx, d, outDir)
+func mustUnpack(t *testing.T, ctx context.Context, loader snaploader.Loader, snap *snaploader.Snapshot, workDir, outDir string, originalSnapshot *snaploader.CacheSnapshotOptions) {
+	err := loader.UnpackSnapshot(ctx, snap, outDir)
 	require.NoError(t, err)
 
 	for _, path := range []string{


### PR DESCRIPTION
A few refactors/cleanups in preparation for making snapshots shareable, and generally making the snaploader code easier to work with / less error-prone:

* Instead of having `snaploader.Loader` be stateful (storing the snapshot manifest) and then having to lazily populate / check preconditions about the state in each method, encapsulate the snapshot state into a `Snapshot` struct and pass the state around as a param. The stateful approach felt error prone because we have to remember to create a new `Loader` every time we do something with a snapshot and make sure we don't reuse the `Loader` for other operations.
* Rename `LoadSnapshotOptions` to `CacheSnapshotOptions` since these options are only passed to `CacheSnapshot`.
* Rename functions that mention "digest" to instead say "fileCacheKey," since these aren't true content digests currently, and they only work with the filecache. The filecache supports storing arbitrary key-value pairs, while the remote cache doesn't (even with the AC, the value must be a valid Action).
* Represent the snapshot key as a struct containing `configurationHash` and `runnerID` separately (not hashed together), to make it easier to implement shareable snapshots later (runnerID = "" will mean the snapshot is readonly/shareable; runnerID = nonempty will mean the snapshot should only be used by the runner with the given ID, since it will be overwriting disk contents)

**Related issues**: N/A
