### PR TITLE
Don't register Crypter service if there's no KMS configured.

### DIFF
--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -371,6 +371,10 @@ type Crypter struct {
 }
 
 func Register(env environment.Env) error {
+	if env.GetKMS() == nil {
+		return nil
+	}
+
 	crypter, err := New(env, clockwork.NewRealClock())
 	if err != nil {
 		return err


### PR DESCRIPTION
@sluongng ran into a panic accessing the settings page w/o a KMS configured

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
