### PR TITLE
Update go version to 1.20

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.19.3" # Keep in sync with WORKSPACE
+          go-version: "1.20.1" # Keep in sync with WORKSPACE
 
       - name: Mount go cache
         uses: actions/cache@v2

--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.20.1" # Keep in sync with WORKSPACE
+          go-version: "1.20.3" # Keep in sync with WORKSPACE
 
       - name: Mount go cache
         uses: actions/cache@v2

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -58,28 +58,28 @@ go_download_sdk(
     name = "go_sdk_linux",
     goarch = "amd64",
     goos = "linux",
-    version = "1.19.3",  # Keep in sync with .github/workflows/checkstyle.yaml
+    version = "1.20.1",  # Keep in sync with .github/workflows/checkstyle.yaml
 )
 
 go_download_sdk(
     name = "go_sdk_linux_arm64",
     goarch = "arm64",
     goos = "linux",
-    version = "1.19.3",
+    version = "1.20.1",
 )
 
 go_download_sdk(
     name = "go_sdk_darwin",
     goarch = "amd64",
     goos = "darwin",
-    version = "1.19.3",
+    version = "1.20.1",
 )
 
 go_download_sdk(
     name = "go_sdk_darwin_arm64",
     goarch = "arm64",
     goos = "darwin",
-    version = "1.19.3",
+    version = "1.20.1",
 )
 
 go_register_toolchains(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,28 +54,28 @@ go_download_sdk(
     name = "go_sdk_linux",
     goarch = "amd64",
     goos = "linux",
-    version = "1.20.1",  # Keep in sync with .github/workflows/checkstyle.yaml
+    version = "1.20.3",  # Keep in sync with .github/workflows/checkstyle.yaml
 )
 
 go_download_sdk(
     name = "go_sdk_linux_arm64",
     goarch = "arm64",
     goos = "linux",
-    version = "1.20.1",
+    version = "1.20.3",
 )
 
 go_download_sdk(
     name = "go_sdk_darwin",
     goarch = "amd64",
     goos = "darwin",
-    version = "1.20.1",
+    version = "1.20.3",
 )
 
 go_download_sdk(
     name = "go_sdk_darwin_arm64",
     goarch = "arm64",
     goos = "darwin",
-    version = "1.20.1",
+    version = "1.20.3",
 )
 
 go_register_toolchains(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,14 +20,10 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "b18e85b0d6686f5072752cb5adc98f9a44efeb9f02181a59e040e092017e58c2",
-    strip_prefix = "rules_go-d756ad91feb9ca43800e781ab29c117623abed90",
-    # Version 0.39.0 has a bug in its go_sdk detection that was fixed in
-    # https://github.com/bazelbuild/rules_go/commit/d756ad91feb9ca43800e781ab29c117623abed90
-    #
-    # TODO: update to 0.39.1 or 0.40.0 with that fix.
+    sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",
     urls = [
-        "https://github.com/bazelbuild/rules_go/archive/d756ad91feb9ca43800e781ab29c117623abed90.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
     ],
 )
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -337,8 +337,8 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "com_github_bazelbuild_rules_go",
         importpath = "github.com/bazelbuild/rules_go",
-        sum = "h1:ZEr61H97IXcyUOp3hqbT9C7Rym+DynKNSYBRrNjdiow=",
-        version = "v0.39.1-0.20230402170438-d756ad91feb9",
+        sum = "h1:wkJLUDx59dntWMghuL8++GteoU1To6sRoKJXuyFtmf8=",
+        version = "v0.39.1",
     )
     go_repository(
         name = "com_github_bazelbuild_rules_webtesting",

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/awslabs/soci-snapshotter v0.1.0
 	github.com/bazelbuild/bazel-gazelle v0.29.0
 	github.com/bazelbuild/bazelisk v1.11.0
-	github.com/bazelbuild/rules_go v0.39.1-0.20230402170438-d756ad91feb9
+	github.com/bazelbuild/rules_go v0.39.1
 	github.com/bazelbuild/rules_webtesting v0.0.0-20210910170740-6b2ef24cfe95
 	github.com/bduffany/godemon v0.0.0-20221115232931-09721d48e30e
 	github.com/bojand/ghz v0.110.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildbuddy-io/buildbuddy
 
-go 1.18
+go 1.20
 
 replace (
 	// There's a bug building longrunning v0.3.0 with bazel:

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,8 @@ github.com/bazelbuild/bazelisk v1.11.0/go.mod h1:3zOen/lU/rEGgghOIkqfpO2+PhRXvZy
 github.com/bazelbuild/buildtools v0.0.0-20230111132423-06e8e2436a75 h1:DraHsDqTYhf6w1369EEdFyA5hjJnGX88xNJRv1+20E0=
 github.com/bazelbuild/buildtools v0.0.0-20230111132423-06e8e2436a75/go.mod h1:689QdV3hBP7Vo9dJMmzhoYIyo/9iMhEmHkJcnaPRCbo=
 github.com/bazelbuild/rules_go v0.29.0/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=
-github.com/bazelbuild/rules_go v0.39.1-0.20230402170438-d756ad91feb9 h1:ZEr61H97IXcyUOp3hqbT9C7Rym+DynKNSYBRrNjdiow=
-github.com/bazelbuild/rules_go v0.39.1-0.20230402170438-d756ad91feb9/go.mod h1:TMHmtfpvyfsxaqfL9WnahCsXMWDMICTw7XeK9yVb+YU=
+github.com/bazelbuild/rules_go v0.39.1 h1:wkJLUDx59dntWMghuL8++GteoU1To6sRoKJXuyFtmf8=
+github.com/bazelbuild/rules_go v0.39.1/go.mod h1:TMHmtfpvyfsxaqfL9WnahCsXMWDMICTw7XeK9yVb+YU=
 github.com/bazelbuild/rules_webtesting v0.0.0-20210910170740-6b2ef24cfe95 h1:zmBkl2nxjRojoW9PtGVEtW/91kHieotlD7cL9vFq06c=
 github.com/bazelbuild/rules_webtesting v0.0.0-20210910170740-6b2ef24cfe95/go.mod h1:M+vCvqp/1BViNuVL630BoiGqld9Q1vQzvf9bN/dWTeg=
 github.com/bduffany/godemon v0.0.0-20221115232931-09721d48e30e h1:Th4pNly+xoH2szOq4aA+uAFmg5h37BCyq3pFqnZGJ70=

--- a/server/util/flagutil/common/BUILD
+++ b/server/util/flagutil/common/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common",
     visibility = [
         "//server/util/flagutil:__subpackages__",
-        "//server/util/testing/flags:__subpackages__",
     ],
     deps = [
         "//server/util/status",

--- a/server/util/testing/flags/BUILD
+++ b/server/util/testing/flags/BUILD
@@ -8,7 +8,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/util/flagutil",
-        "//server/util/flagutil/common",
         "//server/util/flagutil/yaml",
         "@com_github_stretchr_testify//require",
     ],

--- a/server/util/testing/flags/flags.go
+++ b/server/util/testing/flags/flags.go
@@ -2,13 +2,13 @@ package flags
 
 import (
 	"flag"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/stretchr/testify/require"
 
-	flagutil_common "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
 	flagyaml "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/yaml"
 )
 
@@ -17,7 +17,11 @@ var populateFlagsOnce sync.Once
 func PopulateFlagsFromData(t testing.TB, testConfigData []byte) {
 	populateFlagsOnce.Do(func() {
 		// add placeholder type for type adding by testing
-		flagutil_common.AddTestFlagTypeForTesting(flag.Lookup("test.benchtime").Value, &struct{}{})
+		flag.VisitAll(func(flg *flag.Flag) {
+			if strings.HasPrefix(flg.Name, "test.") {
+				flagyaml.IgnoreFlagForYAML(flg.Name)
+			}
+		})
 		err := flagyaml.PopulateFlagsFromData(testConfigData)
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

Also update rules_go to 0.39.1.

Adjust flags handling in testing to future-proof against new flags being added to go's testing facilities.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
