### PR TITLE
Fix crypter_test flakiness.

### DIFF
--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -301,7 +301,7 @@ func (c *keyCache) refreshKey(ctx context.Context, ck cacheKey, cacheError bool)
 		if cacheError {
 			c.cacheAdd(ck, &cacheEntry{
 				err:          lastErr,
-				expiresAfter: time.Now().Add(keyErrCacheTime),
+				expiresAfter: c.clock.Now().Add(keyErrCacheTime),
 			})
 		}
 		return nil, status.UnavailableErrorf("exhausted attempts to refresh key, last error: %s", lastErr)


### PR DESCRIPTION
Actually use the fake clock in error caching :facepalm:

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
