### PR TITLE
fix end date selection on drilldowns page.

### DIFF
--- a/enterprise/app/trends/drilldown_page.tsx
+++ b/enterprise/app/trends/drilldown_page.tsx
@@ -521,13 +521,11 @@ export default class DrilldownPageComponent extends React.Component<Props, State
       );
     }
     if (!query.updatedBefore) {
-      query.updatedBefore = usecToTimestamp(Date.now() * 1000);
+      // Always explicitly set "now" to the start of the next day so that the
+      // length of the last bucket doesn't change on page refresh.  This
+      // prevents weird issues with selections breaking when refreshing.
+      query.updatedBefore = usecToTimestamp(moment().add(1, "day").startOf("day").unix() * 1e6);
     }
-    query.updatedBefore = usecToTimestamp(
-      moment(+query.updatedBefore.seconds * 1000)
-        .endOf("day")
-        .unix() * 1e6
-    );
 
     if (!this.currentZoomFilters) {
       return;


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
this was previously showing two days when only one day was selected--the "before" date was (correctly) being set to midnight on the next day and then i was fastforwarding it to 11:59.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
