### PR TITLE
Pin bb version in checkstyle

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: gazelle
         run: |
           # Invoke gazelle via bb fix for TypeScript support
-          cli/install.sh
+          cli/install.sh tags/5.0.6
           bb version
           bb fix -mode diff > gazelle-diff.txt || true
           echo "gazelle diff:"


### PR DESCRIPTION
The CLI install script takes a release arg that defaults to `latest`. We can pass `tags/<tag>` to request a tagged release instead

**Related issues**: N/A
