### PR TITLE
Fix `getTab` to return empty string if only `#` is present in url

### DIFF
--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -306,7 +306,8 @@ class Router {
   }
 
   getTab() {
-    return window.location.hash.split("@")[0];
+    let tab = window.location.hash.split("@")[0];
+    return tab == "#" ? "" : tab;
   }
 
   getLineNumber() {


### PR DESCRIPTION
This more closely matches the behavior of `window.location.hash` which `getTab` replaces.

This fixes an issue where if you (accidentally or intentionally) select a line on a test log, you switch tabs to a non-existent one.

**Related issues**: N/A