### PR TITLE
Upgrade build_event_stream.proto to bazel.git 5f1a5709b3

### DIFF
--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -910,6 +910,11 @@ message BuildMetrics {
       // When the last action of this type ended being executed, in
       // milliseconds from the epoch.
       int64 last_ended_ms = 4;
+
+      // Accumulated CPU time of all spawned actions of this type.
+      // This is only set if all the actions reported a time
+      google.protobuf.Duration system_time = 5;
+      google.protobuf.Duration user_time = 6;
     }
     // Contains the top N actions by number of actions executed.
     repeated ActionData action_data = 4;
@@ -920,6 +925,7 @@ message BuildMetrics {
     message RunnerCount {
       string name = 1;
       int32 count = 2;
+      string exec_kind = 3;
     }
     repeated RunnerCount runner_count = 6;
   }
@@ -1146,6 +1152,27 @@ message BuildMetrics {
   }
 
   NetworkMetrics network_metrics = 10;
+
+  // Information about worker pool actions.
+  message WorkerPoolMetrics {
+    // Statistics of worker pool per worker pool hash. Basically it's a map from
+    // worker pool hash to statistics.
+    repeated WorkerPoolStats worker_pool_stats = 1;
+
+    message WorkerPoolStats {
+      // Hash of worker pool these stats are for. Contains information about
+      // startup flags.
+      int32 hash = 1;
+      // Mnemonic of workers these stats are for.
+      string mnemonic = 2;
+      // Number of workers created during a build.
+      int64 created_count = 3;
+      // Number of workers destroyed during a build.
+      int64 destroyed_count = 4;
+    }
+  }
+
+  WorkerPoolMetrics worker_pool_metrics = 11;
 }
 
 // Event providing additional statistics/logs after completion of the build.


### PR DESCRIPTION
This includes the changes from latest Bazel's HEAD.

```
> git log --oneline \
          --reverse \
          d31dd094c56270d892040ce65586af9b76a99744..HEAD \
          -- \
          src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto

0e1d1b6b75 Add exec_kind to RunnerCount in BEP
1acc7a843b Add option to expose package metrics via the BEP.
0ebf7bc837 Automated rollback of commit 1acc7a843bf0996c26a1e3d74bb64514395b7e7f.
284e5a3aee Add WorkerPool metrics in `blaze.invocations` table.
5f1a5709b3 Cpu timec to bep
```

Note how `1acc7a843b` was reverted by `0ebf7bc837` so those changes are
skipped.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
