### PR TITLE
Add a background process to re-encrypt existing keys.

### DIFF
--- a/enterprise/server/crypter_service/BUILD
+++ b/enterprise/server/crypter_service/BUILD
@@ -21,6 +21,7 @@ go_library(
         "@org_golang_x_crypto//chacha20poly1305",
         "@org_golang_x_crypto//hkdf",
         "@org_golang_x_sync//singleflight",
+        "@org_golang_x_time//rate",
         "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -745,7 +745,7 @@ func (c *Crypter) keyRencryptorIteration(cutoff time.Time) error {
 			if err := c.reencryptKey(qCtx, ekv); err != nil {
 				log.Warningf("could not reencrypt key %q: %s", ekv.EncryptionKeyID, err)
 			} else {
-				break
+				return
 			}
 		}
 
@@ -754,8 +754,7 @@ func (c *Crypter) keyRencryptorIteration(cutoff time.Time) error {
 		// the DB.
 		uCtx, uCancel := context.WithTimeout(c.env.GetServerContext(), keyReencryptTimeout/4)
 		defer uCancel()
-		// Unconditionally update the last attempt timestamp, whether we
-		// succeeded or not.
+		// Update the attempt timestamp.
 		q := `
 				UPDATE "EncryptionKeyVersions"
 				SET last_encryption_attempt_at_usec = ?

--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"time"
 
+	mrand "math/rand"
+
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
@@ -33,7 +35,8 @@ import (
 )
 
 var (
-	keyTTL = flag.Duration("crypter.key_ttl", 10*time.Minute, "The maximum amount of time a key can be cached without being re-verified before it is considered invalid.")
+	keyTTL               = flag.Duration("crypter.key_ttl", 10*time.Minute, "The maximum amount of time a key can be cached without being re-verified before it is considered invalid.")
+	keyReencryptInterval = flag.Duration("crypter.key_reencrypt_interval", 6*time.Hour, "How frequently keys will be re-encrypted (to support key rotation).")
 )
 
 const (
@@ -49,6 +52,11 @@ const (
 	keyRefreshRetryInterval = 30 * time.Second
 	keyRefreshDeadline      = 25 * time.Second
 	keyErrCacheTime         = 10 * time.Second
+
+	// Timeout for querying keys to re-encrypt.
+	keyReencryptListQueryTimeout = 60 * time.Second
+	// Timeout for re-encrypting a single key.
+	keyReencryptTimeout = 60 * time.Second
 )
 
 // Note: there are two types of keys in the cache, one with only groupID set
@@ -366,6 +374,7 @@ type Crypter struct {
 	env      environment.Env
 	dbh      interfaces.DBHandle
 	kms      interfaces.KMS
+	clock    clockwork.Clock
 	cache    *keyCache
 	quitChan chan struct{}
 }
@@ -394,13 +403,16 @@ func New(env environment.Env, clock clockwork.Clock) (*Crypter, error) {
 	}
 	quitChan := make(chan struct{})
 	cache.startRefresher(quitChan)
-	return &Crypter{
+	c := &Crypter{
 		env:      env,
 		kms:      env.GetKMS(),
+		clock:    clock,
 		dbh:      env.GetDBHandle(),
 		cache:    cache,
 		quitChan: quitChan,
-	}, nil
+	}
+	c.startKeyReencryptor(quitChan)
+	return c, nil
 }
 
 type Encryptor struct {
@@ -637,6 +649,164 @@ func (c *Crypter) NewDecryptor(ctx context.Context, digest *repb.Digest, r io.Re
 	return c.newDecryptorWithChunkSize(ctx, digest, r, em, u.GetGroupID(), plainTextChunkSize)
 }
 
+type encryptionKeyVersionWithGroupID struct {
+	GroupID string
+	tables.EncryptionKeyVersion
+}
+
+func (c *Crypter) reencryptKey(ctx context.Context, ekv *encryptionKeyVersionWithGroupID) error {
+	bbmk, err := c.kms.FetchMasterKey()
+	if err != nil {
+		return err
+	}
+
+	gmk, err := c.kms.FetchKey(ekv.GroupKeyURI)
+	if err != nil {
+		return err
+	}
+
+	masterKeyPortion, err := bbmk.Decrypt(ekv.MasterEncryptedKey, nil)
+	if err != nil {
+		return err
+	}
+	groupKeyPortion, err := gmk.Decrypt(ekv.GroupEncryptedKey, []byte(ekv.GroupID))
+	if err != nil {
+		return err
+	}
+	encMasterKeyPortion, err := bbmk.Encrypt(masterKeyPortion, nil)
+	if err != nil {
+		return err
+	}
+	encGroupKeyPortion, err := gmk.Encrypt(groupKeyPortion, []byte(ekv.GroupID))
+	if err != nil {
+		return err
+	}
+
+	q := `
+		UPDATE "EncryptionKeyVersions"
+		SET master_encrypted_key = ?,
+			group_encrypted_key = ?,
+			last_encryption_attempt_at_usec = ?,
+			last_encrypted_at_usec = ?
+		WHERE encryption_key_id = ? AND version = ?
+	`
+	now := c.clock.Now()
+	args := []interface{}{encMasterKeyPortion, encGroupKeyPortion, now.UnixMicro(), now.UnixMicro(), ekv.EncryptionKeyID, ekv.Version}
+	if err := c.dbh.DB(ctx).Exec(q, args...).Error; err != nil {
+		return err
+	}
+
+	log.Infof("Successfully re-encrypted key %q version %d", ekv.EncryptionKeyID, ekv.Version)
+
+	return nil
+}
+
+func (c *Crypter) keyRencryptorIteration(cutoff time.Time) error {
+	queryKeys := func() ([]*encryptionKeyVersionWithGroupID, error) {
+		ctx, cancel := context.WithTimeout(c.env.GetServerContext(), keyReencryptListQueryTimeout)
+		defer cancel()
+		q := `
+			SELECT ek.group_id, ekv.*
+			FROM "EncryptionKeyVersions" ekv
+			JOIN "EncryptionKeys" ek ON ek.encryption_key_id = ekv.encryption_key_id
+			WHERE ekv.last_encryption_attempt_at_usec < ?
+			LIMIT 1000
+	`
+
+		retrier := retry.DefaultWithContext(ctx)
+		var lastErr error
+		var ekvs []*encryptionKeyVersionWithGroupID
+		for retrier.Next() {
+			ekvs = nil
+			rows, err := c.dbh.DB(ctx).Raw(q, cutoff.UnixMicro()).Rows()
+			if err != nil {
+				lastErr = err
+				continue
+			}
+
+			for rows.Next() {
+				var ekv encryptionKeyVersionWithGroupID
+				if err := c.dbh.DB(ctx).ScanRows(rows, &ekv); err != nil {
+					return nil, err
+				}
+				ekvs = append(ekvs, &ekv)
+			}
+			return ekvs, nil
+		}
+
+		return nil, lastErr
+	}
+
+	reencryptKey := func(ekv *encryptionKeyVersionWithGroupID) {
+		qCtx, qCancel := context.WithTimeout(c.env.GetServerContext(), keyReencryptTimeout)
+		defer qCancel()
+		retrier := retry.DefaultWithContext(qCtx)
+		for retrier.Next() {
+			if err := c.reencryptKey(qCtx, ekv); err != nil {
+				log.Warningf("could not reencrypt key %q: %s", ekv.EncryptionKeyID, err)
+			} else {
+				break
+			}
+		}
+
+		// Use a separate context in case we already fully used up the time on
+		// the previous one. We still want to make sure we have time to update
+		// the DB.
+		uCtx, uCancel := context.WithTimeout(c.env.GetServerContext(), keyReencryptTimeout/4)
+		defer uCancel()
+		// Unconditionally update the last attempt timestamp, whether we
+		// succeeded or not.
+		q := `
+				UPDATE "EncryptionKeyVersions"
+				SET last_encryption_attempt_at_usec = ?
+				WHERE encryption_key_id = ? AND version = ?
+			`
+		now := c.clock.Now()
+		args := []interface{}{now.UnixMicro(), ekv.EncryptionKeyID, ekv.Version}
+		if err := c.dbh.DB(uCtx).Exec(q, args...).Error; err != nil {
+			log.Warningf("could not update attempt timestamp: %s", err)
+		}
+	}
+
+	for {
+		remainingKeys, err := queryKeys()
+		if err != nil {
+			return err
+		}
+
+		if len(remainingKeys) == 0 {
+			break
+		}
+
+		for _, ekv := range remainingKeys {
+			reencryptKey(ekv)
+		}
+	}
+	return nil
+}
+
+func (c *Crypter) startKeyReencryptor(quitChan chan struct{}) {
+	// All the apps will be re-encrypting keys. We add a jitter to try to avoid
+	// having apps do duplicate work.
+	jitter := time.Duration(mrand.Int63n(int64(*keyReencryptInterval / 2)))
+	go func() {
+		for {
+			cutoff := c.clock.Now().Add(-*keyReencryptInterval).Add(-jitter)
+
+			if err := c.keyRencryptorIteration(cutoff); err != nil {
+				log.Warningf("could not rencrypt keys: %s", err)
+			}
+
+			select {
+			case <-quitChan:
+				return
+			case <-c.clock.After(1 * time.Minute):
+				break
+			}
+		}
+	}()
+}
+
 func (c *Crypter) Stop() {
 	close(c.quitChan)
 }
@@ -733,12 +903,15 @@ func (c *Crypter) enableEncryption(ctx context.Context, kmsConfig *enpb.KMSConfi
 		EncryptionKeyID: keyID,
 		GroupID:         u.GetGroupID(),
 	}
+	now := c.clock.Now()
 	keyVersion := &tables.EncryptionKeyVersion{
-		EncryptionKeyID:    keyID,
-		Version:            1,
-		MasterEncryptedKey: encMasterKeyPart,
-		GroupKeyURI:        groupKeyURI,
-		GroupEncryptedKey:  encGroupKeyPart,
+		EncryptionKeyID:             keyID,
+		Version:                     1,
+		MasterEncryptedKey:          encMasterKeyPart,
+		GroupKeyURI:                 groupKeyURI,
+		GroupEncryptedKey:           encGroupKeyPart,
+		LastEncryptionAttemptAtUsec: now.UnixMicro(),
+		LastEncryptedAtUsec:         now.UnixMicro(),
 	}
 	err = c.env.GetDBHandle().Transaction(ctx, func(tx *gorm.DB) error {
 		if err := tx.Create(key).Error; err != nil {

--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -54,6 +54,8 @@ const (
 	keyRefreshDeadline      = 25 * time.Second
 	keyErrCacheTime         = 10 * time.Second
 
+	// How often to check for keys needing re-encryption.
+	keyReencryptCheckInterval = 15 * time.Minute
 	// Timeout for querying keys to re-encrypt.
 	keyReencryptListQueryTimeout = 60 * time.Second
 	// Timeout for re-encrypting a single key.
@@ -807,7 +809,7 @@ func (c *Crypter) startKeyReencryptor(quitChan chan struct{}) {
 			select {
 			case <-quitChan:
 				return
-			case <-c.clock.After(1 * time.Minute):
+			case <-c.clock.After(keyReencryptCheckInterval):
 				break
 			}
 		}

--- a/enterprise/server/crypter_service/crypter_service_test.go
+++ b/enterprise/server/crypter_service/crypter_service_test.go
@@ -480,6 +480,9 @@ func testDecryption(ctx context.Context, t *testing.T, crypter *Crypter, input [
 }
 
 func testEncryptDecrypt(ctx context.Context, t *testing.T, auther *testauth.TestAuthenticator, crypter *Crypter, userID string, expectedKeyID string) {
+	ctx, err := auther.WithAuthenticatedUser(ctx, userID)
+	require.NoError(t, err)
+
 	input := []byte("hello world")
 
 	encrypted, metadata := testEncrypt(ctx, t, auther, crypter, userID, expectedKeyID, input)

--- a/enterprise/server/crypter_service/crypter_service_test.go
+++ b/enterprise/server/crypter_service/crypter_service_test.go
@@ -174,7 +174,7 @@ func writeInRandomChunks(t *testing.T, w interfaces.Encryptor, data []byte) {
 	require.NoError(t, err)
 }
 
-func createKey(t *testing.T, env environment.Env, keyID, groupID, groupKeyURI string) {
+func createKey(t *testing.T, env environment.Env, clock clockwork.Clock, keyID, groupID, groupKeyURI string) *tables.EncryptionKeyVersion {
 	kmsClient := env.GetKMS()
 
 	masterKeyPart := make([]byte, 32)
@@ -198,17 +198,20 @@ func createKey(t *testing.T, env environment.Env, keyID, groupID, groupKeyURI st
 		GroupID:         groupID,
 	}
 	keyVersion := &tables.EncryptionKeyVersion{
-		EncryptionKeyID:    keyID,
-		Version:            1,
-		MasterEncryptedKey: encMasterKeyPart,
-		GroupKeyURI:        groupKeyURI,
-		GroupEncryptedKey:  encGroupKeyPart,
+		EncryptionKeyID:             keyID,
+		Version:                     1,
+		MasterEncryptedKey:          encMasterKeyPart,
+		GroupKeyURI:                 groupKeyURI,
+		GroupEncryptedKey:           encGroupKeyPart,
+		LastEncryptionAttemptAtUsec: clock.Now().UnixMicro(),
+		LastEncryptedAtUsec:         clock.Now().UnixMicro(),
 	}
 	ctx := context.Background()
 	err = env.GetDBHandle().DB(ctx).Create(key).Error
 	require.NoError(t, err)
 	err = env.GetDBHandle().DB(ctx).Create(keyVersion).Error
 	require.NoError(t, err)
+	return keyVersion
 }
 
 func getEnv(t *testing.T) (*testenv.TestEnv, *fakeKMS) {
@@ -233,7 +236,9 @@ func TestEncryptDecrypt(t *testing.T) {
 	groupID := "GR123"
 	auther := testauth.NewTestAuthenticator(testauth.TestUsers(userID, groupID))
 	env.SetAuthenticator(auther)
-	createKey(t, env, "EK123", groupID, customerKeyURI)
+	clock := clockwork.NewRealClock()
+
+	createKey(t, env, clock, "EK123", groupID, customerKeyURI)
 
 	ctx, err := auther.WithAuthenticatedUser(context.Background(), userID)
 	require.NoError(t, err)
@@ -275,7 +280,9 @@ func TestDecryptWrongGroup(t *testing.T) {
 	groupID := "GR123"
 	auther := testauth.NewTestAuthenticator(testauth.TestUsers(userID, groupID))
 	env.SetAuthenticator(auther)
-	createKey(t, env, "EK123", groupID, customerKeyURI)
+	clock := clockwork.NewRealClock()
+
+	createKey(t, env, clock, "EK123", groupID, customerKeyURI)
 
 	ctx, err := auther.WithAuthenticatedUser(context.Background(), userID)
 	require.NoError(t, err)
@@ -316,8 +323,9 @@ func TestDecryptWrongDigest(t *testing.T) {
 	groupID := "GR123"
 	auther := testauth.NewTestAuthenticator(testauth.TestUsers(userID, groupID))
 	env.SetAuthenticator(auther)
+	clock := clockwork.NewRealClock()
 
-	createKey(t, env, "EK123", groupID, customerKeyURI)
+	createKey(t, env, clock, "EK123", groupID, customerKeyURI)
 
 	ctx, err := auther.WithAuthenticatedUser(context.Background(), userID)
 	require.NoError(t, err)
@@ -372,11 +380,12 @@ func TestKeyLookup(t *testing.T) {
 	group1KeyURI := generateKMSKey(t, kms, "group1Key")
 	group2KeyURI := generateKMSKey(t, kms, "group2Key")
 	ctx := context.Background()
+	clock := clockwork.NewRealClock()
 
 	// Add separate keys for the first and second users.
 	// Third user doesn't have a key configured.
-	createKey(t, env, group1KeyID, groupID1, group1KeyURI)
-	createKey(t, env, group2KeyID, groupID2, group2KeyURI)
+	createKey(t, env, clock, group1KeyID, groupID1, group1KeyURI)
+	createKey(t, env, clock, group2KeyID, groupID2, group2KeyURI)
 
 	crypter, err := New(env, clockwork.NewRealClock())
 	defer crypter.Stop()
@@ -448,7 +457,7 @@ func TestKeyLookup(t *testing.T) {
 	}
 }
 
-func testEncryptDecrypt(ctx context.Context, t *testing.T, auther *testauth.TestAuthenticator, crypter *Crypter, userID string, expectedKeyID string) {
+func testEncrypt(ctx context.Context, t *testing.T, auther *testauth.TestAuthenticator, crypter *Crypter, userID string, expectedKeyID string, input []byte) ([]byte, *rfpb.EncryptionMetadata) {
 	out := bytes.NewBuffer(nil)
 	ctx, err := auther.WithAuthenticatedUser(ctx, userID)
 	require.NoError(t, err)
@@ -457,14 +466,24 @@ func testEncryptDecrypt(ctx context.Context, t *testing.T, auther *testauth.Test
 	require.Equal(t, c.Metadata().GetEncryptionKeyId(), expectedKeyID)
 	require.EqualValues(t, c.Metadata().GetVersion(), 1)
 
-	input := []byte("hello world")
 	writeInRandomChunks(t, c, input)
-	d, err := crypter.NewDecryptor(ctx, dummyDigest, io.NopCloser(bytes.NewReader(out.Bytes())), c.Metadata())
+	return out.Bytes(), c.Metadata()
+}
+
+func testDecryption(ctx context.Context, t *testing.T, crypter *Crypter, input []byte, metadata *rfpb.EncryptionMetadata, expectedOutput []byte) {
+	d, err := crypter.NewDecryptor(ctx, dummyDigest, io.NopCloser(bytes.NewReader(input)), metadata)
 	require.NoError(t, err)
-	decrypted := make([]byte, len(input))
+	decrypted := make([]byte, len(expectedOutput))
 	_, err = d.Read(decrypted)
 	require.NoError(t, err)
-	require.Equal(t, input, decrypted)
+	require.Equal(t, expectedOutput, decrypted)
+}
+
+func testEncryptDecrypt(ctx context.Context, t *testing.T, auther *testauth.TestAuthenticator, crypter *Crypter, userID string, expectedKeyID string) {
+	input := []byte("hello world")
+
+	encrypted, metadata := testEncrypt(ctx, t, auther, crypter, userID, expectedKeyID, input)
+	testDecryption(ctx, t, crypter, encrypted, metadata, input)
 }
 
 func testKeyError(ctx context.Context, t *testing.T, auther *testauth.TestAuthenticator, crypter *Crypter, userID string, clock clockwork.FakeClock) error {
@@ -532,11 +551,12 @@ func TestKeyCaching(t *testing.T) {
 	group1KeyURI := generateKMSKey(t, kms, "group1Key")
 	group2KeyURI := generateKMSKey(t, kms, "group2Key")
 	ctx := context.Background()
+	clock := clockwork.NewRealClock()
 
 	// Add separate keys for the first and second users.
 	// Third user doesn't have a key configured.
-	createKey(t, env, group1KeyID, groupID1, group1KeyURI)
-	createKey(t, env, group2KeyID, groupID2, group2KeyURI)
+	createKey(t, env, clock, group1KeyID, groupID1, group1KeyURI)
+	createKey(t, env, clock, group2KeyID, groupID2, group2KeyURI)
 
 	// Note that encryption and decryption keys are cached separately so a
 	// encryption/decryption round trip requires two key lookups.
@@ -768,4 +788,69 @@ func TestConfigAPI(t *testing.T) {
 	_, err = pc.Get(apiKeyCtx, encryptedResource)
 	require.Error(t, err)
 	require.True(t, status.IsNotFoundError(err))
+}
+
+func TestKeyReencryption(t *testing.T) {
+	env, kms := getEnv(t)
+
+	userID1 := "US123"
+	groupID1 := "GR123"
+	group1KeyID := "EK123"
+	userID2 := "US456"
+	groupID2 := "GR456"
+	group2KeyID := "EK456"
+	auther := testauth.NewTestAuthenticator(testauth.TestUsers(userID1, groupID1, userID2, groupID2))
+	env.SetAuthenticator(auther)
+
+	group1KeyURI := generateKMSKey(t, kms, "group1Key")
+	group2KeyURI := generateKMSKey(t, kms, "group2Key")
+	clock := clockwork.NewFakeClock()
+	crypter, err := New(env, clock)
+	require.NoError(t, err)
+
+	// Add separate keys for the first and second users.
+	user1KeyDBEntry := createKey(t, env, clock, group1KeyID, groupID1, group1KeyURI)
+	user2KeyDBEntry := createKey(t, env, clock, group2KeyID, groupID2, group2KeyURI)
+
+	// Write some data for bother users. We should be able to read the data
+	// back after we re-encrypt the keys.
+	user1Data := []byte("hello user1")
+	user1Ctx, err := auther.WithAuthenticatedUser(context.Background(), userID1)
+	require.NoError(t, err)
+	user1EncData, user1EncMD := testEncrypt(user1Ctx, t, auther, crypter, userID1, group1KeyID, user1Data)
+	user2Data := []byte("hello user2")
+	user2Ctx, err := auther.WithAuthenticatedUser(context.Background(), userID2)
+	require.NoError(t, err)
+	user2EncData, user2EncMD := testEncrypt(user2Ctx, t, auther, crypter, userID2, group2KeyID, user2Data)
+
+	// Allow the keys to be expired from the cache now so we don't have to
+	// worry about the cached values when re-encryption happens.
+	advanceTimeAndWaitForRefresh(clock, crypter, *keyTTL+1*time.Minute)
+
+	clock.Advance(*keyReencryptInterval * 2)
+
+	var user1NewKeyDBEntry, user2NewKeyDBEntry tables.EncryptionKeyVersion
+	for i := 0; i < 5; i++ {
+		q := `SELECT * FROM "EncryptionKeyVersions" WHERE encryption_key_id = ? AND version = 1`
+		err = env.GetDBHandle().DB(context.Background()).Raw(q, group1KeyID).Take(&user1NewKeyDBEntry).Error
+		require.NoError(t, err)
+		err = env.GetDBHandle().DB(context.Background()).Raw(q, group2KeyID).Take(&user2NewKeyDBEntry).Error
+		require.NoError(t, err)
+		if user1NewKeyDBEntry.LastEncryptionAttemptAtUsec > user1KeyDBEntry.LastEncryptionAttemptAtUsec &&
+			user2NewKeyDBEntry.LastEncryptionAttemptAtUsec > user2KeyDBEntry.LastEncryptionAttemptAtUsec {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// Verify that the encrypted key contents is different from before.
+	require.NotEqual(t, user1KeyDBEntry.GroupEncryptedKey, user1NewKeyDBEntry.GroupEncryptedKey)
+	require.NotEqual(t, user1KeyDBEntry.MasterEncryptedKey, user1NewKeyDBEntry.MasterEncryptedKey)
+
+	require.NotEqual(t, user2KeyDBEntry.GroupEncryptedKey, user2NewKeyDBEntry.GroupEncryptedKey)
+	require.NotEqual(t, user2KeyDBEntry.MasterEncryptedKey, user2NewKeyDBEntry.MasterEncryptedKey)
+
+	// Verify that existing content can continue to be decrypted.
+	testDecryption(user1Ctx, t, crypter, user1EncData, user1EncMD, user1Data)
+	testDecryption(user2Ctx, t, crypter, user2EncData, user2EncMD, user2Data)
 }

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -718,7 +718,7 @@ type EncryptionKeyVersion struct {
 
 	// Last time we attempted to encrypt composite key portions using the KMS
 	// keys.
-	LastEncryptionAttemptAtUsec int64
+	LastEncryptionAttemptAtUsec int64 `gorm:"index:last_encryption_attempt_idx"`
 	// Last time the composite key portions were encrypted using the KMS keys.
 	LastEncryptedAtUsec int64
 }

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -715,6 +715,12 @@ type EncryptionKeyVersion struct {
 	GroupKeyURI string
 	// Group portion of the composite key encrypted using the above group key.
 	GroupEncryptedKey []byte
+
+	// Last time we attempted to encrypt composite key portions using the KMS
+	// keys.
+	LastEncryptionAttemptAtUsec int64
+	// Last time the composite key portions were encrypted using the KMS keys.
+	LastEncryptedAtUsec int64
 }
 
 func (*EncryptionKeyVersion) TableName() string {


### PR DESCRIPTION
If a customer has rotation enabled for their key then the key material is going to keep changing and the old key material will become unavailable. To make sure we can always decrypt the internal keys, we will periodically re-encrypt the keys using the latest available key version in the customer KMS.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
