### PR TITLE
Add new pebble key format that includes the encryption key ID.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -217,6 +217,14 @@ func (m *v1ToV2Migrator) FromVersion() filestore.PebbleKeyVersion {
 func (m *v1ToV2Migrator) ToVersion() filestore.PebbleKeyVersion { return filestore.Version2 }
 func (m *v1ToV2Migrator) Migrate(val []byte) []byte             { return val }
 
+type v2ToV3Migrator struct{}
+
+func (m *v2ToV3Migrator) FromVersion() filestore.PebbleKeyVersion {
+	return filestore.Version2
+}
+func (m *v2ToV3Migrator) ToVersion() filestore.PebbleKeyVersion { return filestore.Version3 }
+func (m *v2ToV3Migrator) Migrate(val []byte) []byte             { return val }
+
 // Register creates a new PebbleCache from the configured flags and sets it in
 // the provided env.
 func Register(env environment.Env) error {
@@ -418,6 +426,10 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 		if pc.activeDatabaseVersion() >= filestore.Version2 {
 			// Migrate keys from 1->2.
 			pc.migrators = append(pc.migrators, &v1ToV2Migrator{})
+		}
+		if pc.activeDatabaseVersion() >= filestore.Version3 {
+			// Migrate keys from 2->3.
+			pc.migrators = append(pc.migrators, &v2ToV3Migrator{})
 		}
 	}
 

--- a/enterprise/server/raft/filestore/BUILD
+++ b/enterprise/server/raft/filestore/BUILD
@@ -22,6 +22,7 @@ go_test(
     deps = [
         ":filestore",
         "//proto:raft_go_proto",
+        "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/testutil/testdigest",
         "@com_github_stretchr_testify//assert",

--- a/enterprise/server/raft/filestore/filestore.go
+++ b/enterprise/server/raft/filestore/filestore.go
@@ -75,6 +75,10 @@ const (
 	// regardless of remote instance name.
 	Version2
 
+	// Version3 adds an optional encryption key ID for keys that refer to
+	// encrypted data.
+	Version3
+
 	// TestingMaxKeyVersion should not be used directly -- it is always
 	// 1 more than the highest defined version, which allows for tests
 	// to iterate across all versions from UndefinedKeyVersion to
@@ -88,6 +92,7 @@ type PebbleKey struct {
 	isolation          string
 	remoteInstanceHash string
 	hash               string
+	encryptionKeyID    string
 }
 
 func (pmk PebbleKey) String() string {
@@ -114,6 +119,10 @@ func (pmk PebbleKey) CacheType() rspb.CacheType {
 	default:
 		return rspb.CacheType_UNKNOWN_CACHE_TYPE
 	}
+}
+
+func (pmk PebbleKey) Hash() string {
+	return pmk.hash
 }
 
 // Returns a group ID that is zero padded to 20 digits in order to make all
@@ -163,6 +172,18 @@ func (pmk *PebbleKey) Bytes(version PebbleKeyVersion) ([]byte, error) {
 		}
 		partDir := PartitionDirectoryPrefix + pmk.partID
 		filePath = filepath.Join(partDir, filePath, "v2")
+		return []byte(filePath), nil
+	case Version3:
+		rih := pmk.remoteInstanceHash
+		if pmk.isolation == "ac" && rih == "" {
+			rih = "0"
+		}
+		filePath := filepath.Join(pmk.hash, pmk.isolation, rih, pmk.encryptionKeyID)
+		if pmk.isolation == "ac" {
+			filePath = filepath.Join(fixedWidthGroupID(pmk.groupID), filePath)
+		}
+		partDir := PartitionDirectoryPrefix + pmk.partID
+		filePath = filepath.Join(partDir, filePath, "v3")
 		return []byte(filePath), nil
 	default:
 		return nil, status.FailedPreconditionErrorf("Unknown key version: %v", version)
@@ -219,6 +240,38 @@ func (pmk *PebbleKey) parseVersion2(parts [][]byte) error {
 	return nil
 }
 
+func (pmk *PebbleKey) parseVersion3(parts [][]byte) error {
+	switch len(parts) {
+	// CAS artifact
+	// PTfoo/abcd12345asdasdasd123123123asdasdasd/v3
+	case 4:
+		pmk.partID, pmk.hash, pmk.isolation = string(parts[0]), string(parts[1]), string(parts[2])
+	// encrypted CAS artifact
+	// PTfoo/abcd12345asdasdasd123123123asdasdasd/EK123/v3
+	case 5:
+		pmk.partID, pmk.hash, pmk.isolation, pmk.encryptionKeyID = string(parts[0]), string(parts[1]), string(parts[2]), string(parts[3])
+	// AC artifact
+	// PTfoo/GR123/abcd12345asdasdasd123123123asdasdasd/ac/123/v3
+	case 6:
+		pmk.partID, pmk.groupID, pmk.hash, pmk.isolation, pmk.remoteInstanceHash = string(parts[0]), string(parts[1]), string(parts[2]), string(parts[3]), string(parts[4])
+		if pmk.remoteInstanceHash == "0" {
+			pmk.remoteInstanceHash = ""
+		}
+	// encrypted AC artifact
+	// PTfoo/GR123/abcd12345asdasdasd123123123asdasdasd/ac/123/EK123/v3
+	case 7:
+		pmk.partID, pmk.groupID, pmk.hash, pmk.isolation, pmk.remoteInstanceHash, pmk.encryptionKeyID = string(parts[0]), string(parts[1]), string(parts[2]), string(parts[3]), string(parts[4]), string(parts[5])
+		if pmk.remoteInstanceHash == "0" {
+			pmk.remoteInstanceHash = ""
+		}
+	default:
+		return parseError(parts)
+	}
+	pmk.partID = strings.TrimPrefix(pmk.partID, PartitionDirectoryPrefix)
+	pmk.groupID = trimFixedWidthGroupID(pmk.groupID)
+	return nil
+}
+
 func (pmk *PebbleKey) FromBytes(in []byte) (PebbleKeyVersion, error) {
 	version := UndefinedKeyVersion
 	slash := []byte{filepath.Separator}
@@ -247,6 +300,8 @@ func (pmk *PebbleKey) FromBytes(in []byte) (PebbleKeyVersion, error) {
 		return Version1, pmk.parseVersion1(parts)
 	case Version2:
 		return Version2, pmk.parseVersion2(parts)
+	case Version3:
+		return Version3, pmk.parseVersion3(parts)
 	default:
 		return -1, status.InvalidArgumentErrorf("Unable to parse %q to pebble key", in)
 	}
@@ -348,6 +403,7 @@ func (fs *fileStorer) PebbleKey(r *rfpb.FileRecord) (PebbleKey, error) {
 		isolation:          isolation,
 		remoteInstanceHash: remoteInstanceHash,
 		hash:               hash,
+		encryptionKeyID:    r.GetEncryption().GetKeyId(),
 	}, nil
 }
 

--- a/enterprise/server/raft/filestore/filestore_test.go
+++ b/enterprise/server/raft/filestore/filestore_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
@@ -57,20 +58,27 @@ func TestKeyVersionCrossCompatibility(t *testing.T) {
 
 func TestKnownVersions(t *testing.T) {
 	versionExemplars := map[filestore.PebbleKeyVersion][]string{
-		filestore.UndefinedKeyVersion: []string{
+		filestore.UndefinedKeyVersion: {
 			"PTFOO/cas/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2",
 			"PTFOO/GR7890/ac/2364854541/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309",
 			"PTdefault/GR5787812970202071253/ac/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f",
 		},
-		filestore.Version1: []string{
+		filestore.Version1: {
 			"PTFOO/cas/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2/v1",
 			"PTFOO/GR7890/ac/2364854541/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/v1",
 			"PTFOO/GR7890/ac/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/v1",
 		},
-		filestore.Version2: []string{
+		filestore.Version2: {
 			"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/cas/v2",
 			"PTFOO/GR00000000000000007890/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/ac/2364854541/v2",
 			"PTFOO/GR00000000000000007890/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/ac/v2",
+		},
+		filestore.Version3: {
+			"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/cas/v3",
+			"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/cas/EK123/v3",
+			"PTFOO/GR00000000000000007890/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/ac/2364854541/v3",
+			"PTFOO/GR00000000000000007890/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/ac/2364854541/EK123/v3",
+			"PTFOO/GR00000000000000007890/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/ac/0/v3",
 		},
 	}
 
@@ -95,16 +103,19 @@ func TestMigration(t *testing.T) {
 			filestore.UndefinedKeyVersion: "PTFOO/cas/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2",
 			filestore.Version1:            "PTFOO/cas/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2/v1",
 			filestore.Version2:            "PTFOO/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2/cas/v2",
+			filestore.Version3:            "PTFOO/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2/cas/v3",
 		},
 		{
 			filestore.UndefinedKeyVersion: "PTFOO/GR7890/ac/2364854541/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309",
 			filestore.Version1:            "PTFOO/GR7890/ac/2364854541/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/v1",
 			filestore.Version2:            "PTFOO/GR00000000000000007890/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/ac/2364854541/v2",
+			filestore.Version3:            "PTFOO/GR00000000000000007890/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/ac/2364854541/v3",
 		},
 		{
 			filestore.UndefinedKeyVersion: "PTdefault/GR7890/ac/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f",
 			filestore.Version1:            "PTdefault/GR7890/ac/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/v1",
 			filestore.Version2:            "PTdefault/GR00000000000000007890/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/ac/v2",
+			filestore.Version3:            "PTdefault/GR00000000000000007890/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/ac/0/v3",
 		},
 	}
 
@@ -195,5 +206,61 @@ func TestLockID(t *testing.T) {
 			assert.NotContains(t, uniqueLocks, l)
 			uniqueLocks[l] = struct{}{}
 		}
+	}
+}
+
+func formatKey(t *testing.T, fr *rfpb.FileRecord) string {
+	fs := filestore.New()
+	pk, err := fs.PebbleKey(fr)
+	require.NoError(t, err)
+	bs, err := pk.Bytes(filestore.Version3)
+	require.NoError(t, err)
+	return string(bs)
+}
+
+func TestVersion3(t *testing.T) {
+	partitionID := "foo"
+	groupID := "GR123"
+	d := &repb.Digest{Hash: "647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309", SizeBytes: 123}
+
+	// AC
+	{
+		// AC w/o instance name.
+		fr := &rfpb.FileRecord{
+			Isolation: &rfpb.Isolation{
+				CacheType:          rspb.CacheType_AC,
+				RemoteInstanceName: "",
+				PartitionId:        partitionID,
+				GroupId:            groupID,
+			},
+			Digest: d,
+		}
+		require.Equal(t, "PTfoo/GR00000000000000000123/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/ac/0/v3", formatKey(t, fr))
+
+		// AC w/ instance name.
+		fr.Isolation.RemoteInstanceName = "remote_instance_name"
+		require.Equal(t, "PTfoo/GR00000000000000000123/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/ac/2364854541/v3", formatKey(t, fr))
+
+		// AC w/ instance name & encryption.
+		fr.Encryption = &rfpb.Encryption{KeyId: "EK456"}
+		require.Equal(t, "PTfoo/GR00000000000000000123/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/ac/2364854541/EK456/v3", formatKey(t, fr))
+	}
+
+	// CAS
+	{
+		// CAS w/o encryption
+		fr := &rfpb.FileRecord{
+			Isolation: &rfpb.Isolation{
+				CacheType:   rspb.CacheType_CAS,
+				PartitionId: partitionID,
+				GroupId:     groupID,
+			},
+			Digest: d,
+		}
+		require.Equal(t, "PTfoo/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/cas/v3", formatKey(t, fr))
+
+		// CAS w/ encryption
+		fr.Encryption = &rfpb.Encryption{KeyId: "EK456"}
+		require.Equal(t, "PTfoo/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/cas/EK456/v3", formatKey(t, fr))
 	}
 }

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -26,10 +26,15 @@ message Isolation {
   string group_id = 4;
 }
 
+message Encryption {
+  string key_id = 1;
+}
+
 message FileRecord {
   Isolation isolation = 1;
   build.bazel.remote.execution.v2.Digest digest = 2;
   build.bazel.remote.execution.v2.Compressor.Value compressor = 3;
+  Encryption encryption = 4;
 }
 
 message StorageMetadata {


### PR DESCRIPTION
This format adds an optional encryption key segment for keys that refer to encrypted contents.

This version also makes the "remote instance hash" segment always be present even if the remote instance name is empty. Instead of omitting the segment, we use a "0" value. This simplifies the parsing logic as the encryption key is also optional.

Adding the encryption key ID to the key makes it simple to deal with transitions from having encryption enabled to off, or even if the encryption is turned off and on again.

For example, if a user has encryption enabled and then turns it off, we want previously written encrypted artifacts to be treated as non-existent. Without having the encryption metadata in the key, we would have to unmarshal and check every value during FindMissing calls which would affect the performance and complexity of the implementation. Adding the encryption key ID to the key simplifies this since the keys would be different when encryption is off and when on (or even when turned off and re-enabled with a different key).

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
