### PR TITLE
CLI: Support Bazel subtractive patterns properly

### DIFF
--- a/cli/arg/arg.go
+++ b/cli/arg/arg.go
@@ -101,9 +101,10 @@ func GetCommandAndIndex(args []string) (string, int) {
 // Returns a list of bazel targets specified in the given set of arguments, if any.
 // This function assumes that the arguments are canonicalized.
 func GetTargets(args []string) []string {
+	command := GetCommand(args)
 	nonOptionArgs := []string{}
 	for _, arg := range args {
-		if arg == "--" {
+		if arg == "--" && command == "run" {
 			break
 		}
 		if !strings.HasPrefix(arg, "-") {

--- a/cli/arg/arg_test.go
+++ b/cli/arg/arg_test.go
@@ -2,11 +2,10 @@ package arg
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-import "testing"
 
 func TestFindLast(t *testing.T) {
 	repr := func(val string, idx, length int) string {
@@ -66,7 +65,12 @@ func TestGetTargets(t *testing.T) {
 	targets = GetTargets(args)
 	assert.Equal(t, []string{"foo", "bar"}, targets)
 
-	args = []string{"build", "--opt=val", "foo", "bar", "--", "baz"}
+	args = []string{"run", "--opt=val", "foo", "bar", "--", "baz"}
+	targets = GetTargets(args)
+	assert.Equal(t, []string{"foo", "bar"}, targets)
+
+	// Support subtractive patterns https://bazel.build/run/build#specifying-build-targets
+	args = []string{"build", "--opt=val", "--", "foo", "bar", "-baz"}
 	targets = GetTargets(args)
 	assert.Equal(t, []string{"foo", "bar"}, targets)
 

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -126,6 +126,9 @@ func run() (exitCode int, err error) {
 		return -1, err
 	}
 
+	// Show a picker if target argument is omitted.
+	args = picker.HandlePicker(args)
+
 	// Parse args.
 	bazelArgs, execArgs := arg.SplitExecutableArgs(args)
 	// TODO: Expanding configs results in a long explicit command line in the BB
@@ -161,9 +164,6 @@ func run() (exitCode int, err error) {
 			return -1, err
 		}
 	}
-
-	// Show a picker if target argument is omitted.
-	args = picker.HandlePicker(args)
 
 	// Note: sidecar is configured after pre-bazel plugins, since pre-bazel
 	// plugins may change the value of bes_backend, remote_cache,


### PR DESCRIPTION
This causes the CLI to parse Bazel's subtractive patterns syntax correctly: https://bazel.build/run/build#specifying-build-targets

For example you can run:
```
bazel build -- foo/... -foo/bar/...
```

Which will build everything in `foo/...` but excludes the subdirectory `foo/bar/...`.

Also adds a test.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->