### PR TITLE
Populate encryption key segment in pebble key when encryption is on.

### DIFF
--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -595,6 +595,14 @@ func (c *Crypter) newEncryptorWithChunkSize(ctx context.Context, digest *repb.Di
 	}, nil
 }
 
+func (c *Crypter) ActiveKey(ctx context.Context) (*rfpb.EncryptionMetadata, error) {
+	loadedKey, err := c.cache.encryptionKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return loadedKey.metadata, nil
+}
+
 func (c *Crypter) NewEncryptor(ctx context.Context, digest *repb.Digest, w interfaces.CommittedWriteCloser) (interfaces.Encryptor, error) {
 	u, err := c.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1110,6 +1110,8 @@ type Crypter interface {
 	SetEncryptionConfig(ctx context.Context, req *enpb.SetEncryptionConfigRequest) (*enpb.SetEncryptionConfigResponse, error)
 	GetEncryptionConfig(ctx context.Context, req *enpb.GetEncryptionConfigRequest) (*enpb.GetEncryptionConfigResponse, error)
 
+	ActiveKey(ctx context.Context) (*rfpb.EncryptionMetadata, error)
+
 	NewEncryptor(ctx context.Context, d *repb.Digest, w CommittedWriteCloser) (Encryptor, error)
 	NewDecryptor(ctx context.Context, d *repb.Digest, r io.ReadCloser, em *rfpb.EncryptionMetadata) (Decryptor, error)
 }


### PR DESCRIPTION
I also wrapped the crypter error in a Unavaiable status so it doesn't look like a "digest not found" error to bazel/users.

Note: this builds on top of https://github.com/buildbuddy-io/buildbuddy/pull/3888

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
