### PR TITLE
website: fix category in all tags page

### DIFF
--- a/website/theme/BlogTagsListPage/index.tsx
+++ b/website/theme/BlogTagsListPage/index.tsx
@@ -8,7 +8,7 @@ import Translate from "@docusaurus/Translate";
 
 function getCategoryOfTag(tag: string) {
   // tag's category should be customizable
-  return tag[0].toUpperCase();
+  return tag.name[0].toUpperCase();
 }
 
 function BlogTagsListPage(props: Props): JSX.Element {
@@ -16,7 +16,7 @@ function BlogTagsListPage(props: Props): JSX.Element {
 
   const tagCategories: { [category: string]: string[] } = {};
   Object.keys(tags).forEach((tag) => {
-    const category = getCategoryOfTag(tag);
+    const category = getCategoryOfTag(tags[tag]);
     tagCategories[category] = tagCategories[category] || [];
     tagCategories[category].push(tag);
   });


### PR DESCRIPTION
Previously we take the first character in the key in `tags` as
the tag category.

However, `tags` is currently like this:

```
{
  "/blog/tags/company": {
    "allTagsPath": "/blog/tags",
    "slug": "/blog/tags/company",
    "name": "company",
    "count": 12,
    "permalink": "/blog/tags/company"
  },
  "/blog/tags/team": {
    "allTagsPath": "/blog/tags",
    "slug": "/blog/tags/team",
    "name": "team",
    "count": 10,
    "permalink": "/blog/tags/team"
  },
  "/blog/tags/rules-xcodeproj": {
    "allTagsPath": "/blog/tags",
    "slug": "/blog/tags/rules-xcodeproj",
    "name": "rules_xcodeproj",
    "count": 4,
    "permalink": "/blog/tags/rules-xcodeproj"
  },
  ...
}
```

So the first character ended up being `/` and all tags ended up being in
the same category `/`.

Use tag's name initial character as category.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
