### PR TITLE
Add webdriver test for keyboard shortcuts

### DIFF
--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -157,7 +157,7 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                 <div className="settings-tab-group-subtitle">{this.props.user.displayUser.name?.full}</div>
               </div>
               <div className="settings-tab-group">
-                <SettingsTab id={TabId.PersonalPreferences} activeTabId={activeTabId}>
+                <SettingsTab id={TabId.PersonalPreferences} activeTabId={activeTabId} debugId="personal-preferences">
                   Preferences
                 </SettingsTab>
                 {this.props.user?.selectedGroup?.userOwnedKeysEnabled && (
@@ -209,7 +209,8 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                   </div>
                   <FilledButton
                     className="settings-button"
-                    onClick={() => this.props.preferences.toggleKeyboardShortcuts()}>
+                    onClick={() => this.props.preferences.toggleKeyboardShortcuts()}
+                    debug-id="keyboard-shortcuts-button">
                     {this.props.preferences.keyboardShortcutsEnabled ? "Disable" : "Enable"} keyboard shortcuts
                   </FilledButton>
                 </>
@@ -330,6 +331,7 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
 type SettingsTabProps = {
   id: TabId;
   activeTabId: TabId;
+  debugId?: string;
 };
 
 class SettingsTab extends React.Component<SettingsTabProps> {
@@ -337,7 +339,8 @@ class SettingsTab extends React.Component<SettingsTabProps> {
     return (
       <Link
         className={`settings-tab ${this.props.activeTabId === this.props.id ? "active-tab" : ""}`}
-        href={`/settings/${this.props.id}`}>
+        href={`/settings/${this.props.id}`}
+        debug-id={this.props.debugId}>
         {this.props.children}
       </Link>
     );

--- a/enterprise/server/test/webdriver/shortcuts/BUILD
+++ b/enterprise/server/test/webdriver/shortcuts/BUILD
@@ -1,0 +1,17 @@
+load("//rules/webdriver:index.bzl", "go_web_test_suite")
+
+go_web_test_suite(
+    name = "shortcuts_test",
+    size = "small",
+    srcs = ["shortcuts_test.go"],
+    shard_count = 2,
+    deps = [
+        "//enterprise/server/testutil/buildbuddy_enterprise",
+        "//server/testutil/testbazel",
+        "//server/testutil/webtester",
+        "@com_github_tebeka_selenium//:selenium",
+        "@com_github_stretchr_testify//require",
+    ],
+)
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/test/webdriver/shortcuts/BUILD
+++ b/enterprise/server/test/webdriver/shortcuts/BUILD
@@ -9,8 +9,8 @@ go_web_test_suite(
         "//enterprise/server/testutil/buildbuddy_enterprise",
         "//server/testutil/testbazel",
         "//server/testutil/webtester",
-        "@com_github_tebeka_selenium//:selenium",
         "@com_github_stretchr_testify//require",
+        "@com_github_tebeka_selenium//:selenium",
     ],
 )
 

--- a/enterprise/server/test/webdriver/shortcuts/shortcuts_test.go
+++ b/enterprise/server/test/webdriver/shortcuts/shortcuts_test.go
@@ -93,12 +93,10 @@ func newWebTester(t *testing.T) (*webtester.WebTester, buildbuddy_enterprise.Web
 
 func enableShortcuts(t *testing.T, wt *webtester.WebTester) {
 	webtester.ClickSidebarItem(wt, "Settings")
-	preferencesButton := wt.FindByDebugID("personal-preferences")
-	preferencesButton.Click()
+	wt.FindByDebugID("personal-preferences").Click()
 	shortcutsButton := wt.FindByDebugID("keyboard-shortcuts-button")
 	require.Equal(t, "Enable keyboard shortcuts", shortcutsButton.Text())
 	shortcutsButton.Click()
-	shortcutsButton = wt.FindByDebugID("keyboard-shortcuts-button")
 	require.Equal(t, "Disable keyboard shortcuts", shortcutsButton.Text())
 }
 

--- a/enterprise/server/test/webdriver/shortcuts/shortcuts_test.go
+++ b/enterprise/server/test/webdriver/shortcuts/shortcuts_test.go
@@ -112,11 +112,12 @@ func TestCopyInvocationLink(t *testing.T) {
 	// TODO: it'd be nice to verify the contents of the clipboard, but selenium
 	// doesn't have great support for that. The current recommendation is to
 	// paste into a textbox and then read the contents. For now, just verify
-	// that the toast shows. It takes a lil bit for the banner to render, so
-	// give it 100ms before failing.
-	bannerContent := wt.Find(".banner.banner-success").Find(".banner-content")
+	// that the toast shows.
+	// It takes a sec for the banner to render, give it 100ms before failing.
 	wt.WaitWithTimeout(
-		func() bool { return bannerContent.Text() == "Copied invocation link to clipboard" },
+		func() bool {
+			return wt.Has(".banner.banner-success") && wt.Find(".banner.banner-success").Find(".banner-content").Text() == "Copied invocation link to clipboard"
+		},
 		100*time.Millisecond)
 }
 

--- a/enterprise/server/test/webdriver/shortcuts/shortcuts_test.go
+++ b/enterprise/server/test/webdriver/shortcuts/shortcuts_test.go
@@ -49,9 +49,9 @@ func TestNavShortcuts(t *testing.T) {
 
 func TestInvocationNavShortcuts(t *testing.T) {
 	wt, target := newWebTester(t)
-	enableShortcuts(t, wt)
-
 	invocationIDs := []string{addBuild(t, wt, target), addBuild(t, wt, target), addBuild(t, wt, target)}
+
+	enableShortcuts(t, wt)
 
 	wt.FindBody().SendKeys("ga")
 	wt.FindBody().SendKeys("j")
@@ -87,7 +87,6 @@ func newWebTester(t *testing.T) (*webtester.WebTester, buildbuddy_enterprise.Web
 	wt := webtester.New(t)
 	target := buildbuddy_enterprise.SetupWebTarget(t)
 	webtester.Login(wt, target)
-	wt.Get(target.HTTPURL())
 	return wt, target
 }
 

--- a/enterprise/server/test/webdriver/shortcuts/shortcuts_test.go
+++ b/enterprise/server/test/webdriver/shortcuts/shortcuts_test.go
@@ -1,0 +1,144 @@
+package invocation_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/buildbuddy_enterprise"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testbazel"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/webtester"
+	"github.com/stretchr/testify/require"
+	"github.com/tebeka/selenium"
+)
+
+func TestShortcutsDisabled(t *testing.T) {
+	wt := webtester.New(t)
+	target := buildbuddy_enterprise.SetupWebTarget(t)
+	webtester.Login(wt, target)
+	wt.Get(target.HTTPURL())
+
+	wt.FindBody().SendKeys("?")
+	wt.AssertNotFound(".keyboard-shortcut-title")
+}
+
+func TestHelpMenu(t *testing.T) {
+	wt := webtester.New(t)
+	target := buildbuddy_enterprise.SetupWebTarget(t)
+	webtester.Login(wt, target)
+	wt.Get(target.HTTPURL())
+
+	enableShortcuts(t, wt)
+
+	wt.FindBody().SendKeys("?")
+	shortcutHelp := wt.Find(".keyboard-shortcut-title")
+	require.Contains(t, "BuildBuddy Keyboard Shortcuts", shortcutHelp.Text())
+
+	wt.FindBody().SendKeys(selenium.EscapeKey)
+	wt.AssertNotFound(".keyboard-shortcut-title")
+}
+
+func TestNavShortcuts(t *testing.T) {
+	wt := webtester.New(t)
+	target := buildbuddy_enterprise.SetupWebTarget(t)
+	webtester.Login(wt, target)
+	wt.Get(target.HTTPURL())
+
+	enableShortcuts(t, wt)
+
+	wt.FindBody().SendKeys("ga")
+	require.Equal(t, target.HTTPURL()+"/", wt.CurrentURL())
+	wt.FindBody().SendKeys("gr")
+	require.Equal(t, target.HTTPURL()+"/trends/", wt.CurrentURL())
+	wt.FindBody().SendKeys("gt")
+	require.Equal(t, target.HTTPURL()+"/tests/", wt.CurrentURL())
+	wt.FindBody().SendKeys("gx")
+	require.Equal(t, target.HTTPURL()+"/executors/", wt.CurrentURL())
+	wt.FindBody().SendKeys("gq")
+	require.Equal(t, target.HTTPURL()+"/docs/setup/", wt.CurrentURL())
+	wt.FindBody().SendKeys("gg")
+	require.Equal(t, target.HTTPURL()+"/settings/", wt.CurrentURL())
+}
+
+func TestInvocationNavShortcuts(t *testing.T) {
+	wt := webtester.New(t)
+	target := buildbuddy_enterprise.SetupWebTarget(t)
+	webtester.Login(wt, target)
+	wt.Get(target.HTTPURL())
+
+	enableShortcuts(t, wt)
+
+	invocationIDs := []string{addBuild(t, wt, target), addBuild(t, wt, target), addBuild(t, wt, target)}
+
+	wt.FindBody().SendKeys("ga")
+	wt.FindBody().SendKeys("j")
+	wt.SendKeyCombo([]string{selenium.EnterKey})
+	require.Equal(t, target.HTTPURL()+"/invocation/"+invocationIDs[2], wt.CurrentURL())
+
+	wt.FindBody().SendKeys("u")
+	for i := 1; i < 5; i++ {
+		wt.FindBody().SendKeys("j")
+	}
+	wt.SendKeyCombo([]string{selenium.EnterKey})
+	require.Equal(t, target.HTTPURL()+"/invocation/"+invocationIDs[0], wt.CurrentURL())
+
+	wt.FindBody().SendKeys("u")
+	wt.FindBody().SendKeys("k")
+	wt.SendKeyCombo([]string{selenium.EnterKey})
+	require.Equal(t, target.HTTPURL()+"/invocation/"+invocationIDs[1], wt.CurrentURL())
+
+	wt.FindBody().SendKeys("u")
+	for i := 1; i < 5; i++ {
+		wt.FindBody().SendKeys("k")
+	}
+	wt.SendKeyCombo([]string{selenium.EnterKey})
+	require.Equal(t, target.HTTPURL()+"/invocation/"+invocationIDs[2], wt.CurrentURL())
+}
+
+func TestCopyInvocationLink(t *testing.T) {
+	wt := webtester.New(t)
+	target := buildbuddy_enterprise.SetupWebTarget(t)
+	webtester.Login(wt, target)
+	wt.Get(target.HTTPURL())
+
+	enableShortcuts(t, wt)
+
+	invocationID := addBuild(t, wt, target)
+
+	wt.Get(target.HTTPURL() + "/invocation/" + invocationID)
+
+	wt.SendKeyCombo([]string{selenium.ShiftKey, "c"})
+
+	// TODO: it'd be nice to verify the contents of the clipboard, but selenium
+	// doesn't have great support for that. The current recommendation is to
+	// paste into a textbox and then read the contents. For now, just verify
+	// that the toast shows. It takes a lil bit for the banner to render, so
+	// give it 100ms before failing.
+	bannerContent := wt.Find(".banner.banner-success").Find(".banner-content")
+	wt.WaitWithTimeout(
+		func() bool { return bannerContent.Text() == "Copied invocation link to clipboard" },
+		100*time.Millisecond)
+}
+
+func enableShortcuts(t *testing.T, wt *webtester.WebTester) {
+	webtester.ClickSidebarItem(wt, "Settings")
+	preferencesButton := wt.FindByDebugID("personal-preferences")
+	preferencesButton.Click()
+	shortcutsButton := wt.FindByDebugID("keyboard-shortcuts-button")
+	require.Equal(t, "Enable keyboard shortcuts", shortcutsButton.Text())
+	shortcutsButton.Click()
+	shortcutsButton = wt.FindByDebugID("keyboard-shortcuts-button")
+	require.Equal(t, "Disable keyboard shortcuts", shortcutsButton.Text())
+}
+
+func addBuild(t *testing.T, wt *webtester.WebTester, target buildbuddy_enterprise.WebTarget) string {
+	workspacePath := testbazel.MakeTempWorkspace(t, map[string]string{
+		"WORKSPACE": "",
+		"BUILD":     `genrule(name = "a", outs = ["a.sh"], cmd_bash = "touch $@")`,
+	})
+	// Get the build flags needed for BuildBuddy, including API key, bes results url, bes backend, and remote cache
+	buildArgs := append([]string{"//:a"}, webtester.GetBazelBuildFlags(wt, target.HTTPURL())...)
+	result := testbazel.Invoke(context.Background(), t, workspacePath, "build", buildArgs...)
+	require.NotEmpty(t, result.InvocationID)
+	return result.InvocationID
+}

--- a/server/testutil/webtester/webtester.go
+++ b/server/testutil/webtester/webtester.go
@@ -200,13 +200,6 @@ func (el *Element) Text() string {
 	return txt
 }
 
-// Value returns the text of the element.
-func (el *Element) Value() string {
-	val, err := el.webElement.GetAttribute("value")
-	require.NoError(el.t, err)
-	return val
-}
-
 // IsSelected returns whether the element is selected.
 func (el *Element) IsSelected() bool {
 	val, err := el.webElement.IsSelected()

--- a/server/testutil/webtester/webtester.go
+++ b/server/testutil/webtester/webtester.go
@@ -48,6 +48,7 @@ func New(t *testing.T) *WebTester {
 		// `SetWindowSize` returning an error in headless mode
 		// https://github.com/yukinying/chrome-headless-browser-docker/issues/11
 		"--window-size=1920,1000",
+		"--enable-javascript",
 	}
 	chromedriverArgs := []string{}
 	if *debug {

--- a/server/testutil/webtester/webtester.go
+++ b/server/testutil/webtester/webtester.go
@@ -48,7 +48,6 @@ func New(t *testing.T) *WebTester {
 		// `SetWindowSize` returning an error in headless mode
 		// https://github.com/yukinying/chrome-headless-browser-docker/issues/11
 		"--window-size=1920,1000",
-		"--enable-javascript",
 	}
 	chromedriverArgs := []string{}
 	if *debug {
@@ -116,13 +115,6 @@ func (wt *WebTester) FindBody() *Element {
 	return &Element{wt.t, el}
 }
 
-// Has returns true if the DOM contains an element matching the given CSS
-// selector or false otherwise.
-func (wt *WebTester) Has(cssSelector string) bool {
-	_, err := wt.driver.FindElement(selenium.ByCSSSelector, cssSelector)
-	return err == nil
-}
-
 // Find returns the element matching the given CSS selector. Exactly one
 // element must be matched, otherwise the test fails.
 func (wt *WebTester) Find(cssSelector string) *Element {
@@ -188,28 +180,6 @@ func (wt *WebTester) screenshot(tag string) error {
 	return nil
 }
 
-// Sends the provided key combination to the browser. All keys are pressed in
-// the order passed, and then released in that order.
-func (wt *WebTester) SendKeyCombo(keys []string) {
-	for _, key := range keys {
-		err := wt.driver.KeyDown(key)
-		require.NoError(wt.t, err, "Failed to send keystroke "+key)
-	}
-	for _, key := range keys {
-		err := wt.driver.KeyUp(key)
-		require.NoError(wt.t, err, "Failed to send keystroke "+key)
-	}
-}
-
-// WaitWithTimeout waits for up to timeout for the provided condition to return
-// true and fails the test if it does not within the timeout.
-func (wt *WebTester) WaitWithTimeout(condition func() bool, timeout time.Duration) {
-	err := wt.driver.WaitWithTimeout(
-		func(wd selenium.WebDriver) (bool, error) { return condition(), nil },
-		timeout)
-	require.NoError(wt.t, err)
-}
-
 // Element wraps selenium.WebElement, failing the test instead of returning
 // errors for all of its API methods.
 type Element struct {
@@ -228,6 +198,13 @@ func (el *Element) Text() string {
 	txt, err := el.webElement.Text()
 	require.NoError(el.t, err)
 	return txt
+}
+
+// Value returns the text of the element.
+func (el *Element) Value() string {
+	val, err := el.webElement.GetAttribute("value")
+	require.NoError(el.t, err)
+	return val
 }
 
 // IsSelected returns whether the element is selected.

--- a/server/testutil/webtester/webtester.go
+++ b/server/testutil/webtester/webtester.go
@@ -115,6 +115,13 @@ func (wt *WebTester) FindBody() *Element {
 	return &Element{wt.t, el}
 }
 
+// Has returns true if the DOM contains an element matching the given CSS
+// selector or false otherwise.
+func (wt *WebTester) Has(cssSelector string) bool {
+	_, err := wt.driver.FindElement(selenium.ByCSSSelector, cssSelector)
+	return err == nil
+}
+
 // Find returns the element matching the given CSS selector. Exactly one
 // element must be matched, otherwise the test fails.
 func (wt *WebTester) Find(cssSelector string) *Element {


### PR DESCRIPTION
I tried to add a test for shift-c that copies the invocation page url, but couldn't get the banner to render remotely and actually pasting the link into a random text box elsewhere (on the settings page) interfered with the local clipboard and felt janky, but I'm open to suggestions.

**Related issues**: N/A
