### PR TITLE
bazelrc: support generate coverage output with lcov and genhtml

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -149,6 +149,12 @@ test:webdriver-debug --test_env=DISPLAY
 # otherwise), and display verbose webdriver output in the terminal.
 test:webdriver-debug --test_output=streamed
 
+# Currently only works for go tests
+# Coverage outputs could be viewed with `genhtml`:
+#   $ genhtml -o cover bazel-out/_coverage/_coverage_report.dat
+#   $ open cover/index.html
+coverage --combined_report=lcov
+
 # Try importing a user specific .bazelrc
 # You can create your own by copying and editing the template-user.bazelrc template:
 # cp template-user.bazelrc user.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ user.bazelrc
 # BuildBuddy certs
 buildbuddy-cert.pem
 buildbuddy-key.pem
+
+# genhtml coverage outputs
+/cover


### PR DESCRIPTION
Used this recently to help with writing tests for #3800 and #3861.
Super helpful to identify code branches with missing tests.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
