### PR TITLE
Don't set ROLE=CI for pull request runs

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1589,7 +1589,6 @@ func writeBazelrc(path, invocationID string) error {
 	defer f.Close()
 
 	lines := []string{
-		"build --build_metadata=ROLE=CI",
 		"build --build_metadata=PARENT_INVOCATION_ID=" + invocationID,
 		// Note: these pieces of metadata are set to match the WorkspaceStatus event
 		// for the outer (workflow) invocation.
@@ -1608,7 +1607,10 @@ func writeBazelrc(path, invocationID string) error {
 	if *workflowID != "" {
 		lines = append(lines, "build --build_metadata=WORKFLOW_ID="+*workflowID)
 	}
-	if *prNumber != 0 {
+	if *prNumber == 0 {
+		lines = append(lines, "build --build_metadata=ROLE=CI")
+	} else {
+		lines = append(lines, "build --build_metadata=ROLE=PR")
 		lines = append(lines, "build --build_metadata=PULL_REQUEST_NUMBER="+fmt.Sprintf("%d", *prNumber))
 	}
 	if *pushedRepoURL != *targetRepoURL {


### PR DESCRIPTION
We don't want these PR workflows to show up in the test grid, and build_metadata accumulates so there's no way to override this.
