### PR TITLE
Fix esbuild pointing to non-existent directory

### DIFF
--- a/enterprise/app/esbuild.config.mjs
+++ b/enterprise/app/esbuild.config.mjs
@@ -1,15 +1,22 @@
 import * as path from "path";
+import { existsSync } from "node:fs";
 
 // browserifyPathPlugin remaps the nodejs "path" module to "path-browserify".
 // This is needed for libsodium: https://github.com/evanw/esbuild/issues/1786
 let browserifyPathPlugin = {
   name: "path-browserify",
   setup(build) {
+    let entry = path.join(process.cwd(), "node_modules");
+    // detect if we are building from buildbuddy-internal repo and
+    // adjust 'node_modules' path accordingly
+    if (!existsSync(entry)) {
+      entry = path.join(process.cwd(), "external/com_github_buildbuddy_io_buildbuddy", "node_modules");
+    }
     build.onResolve({ filter: /^path$/ }, () => ({
       // Note: the plugin API currently doesn't have a way to just replace
       // require("path") with require("path-browserify"); we have to resolve the
       // import to an actual file path.
-      path: path.join(process.cwd(), "node_modules/path-browserify/index.js"),
+      path: entry + "/path-browserify/index.js",
     }));
   },
 };


### PR DESCRIPTION
When attempting to upgrade rules_nodejs for the internal repo, it seems
that the location of `node_modules` directory could be moved to be under
the Open Source repo (this repo).

Attempting to detect the usual 'node_modules' directory not being there
and switch to use the new path under 'external/'.

This fix is expected to be a no-op in the current repo and the current
internal repo.  However this should help unblock this internal PR:
https://github.com/buildbuddy-io/buildbuddy-internal/pull/2270

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
