### PR TITLE
Add --sync=true flag to cli

### DIFF
--- a/cli/cache_proxy/BUILD
+++ b/cli/cache_proxy/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/cache_proxy",
     visibility = ["//visibility:public"],
     deps = [
-        "//cli/arg",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/environment",

--- a/cli/cache_proxy/BUILD
+++ b/cli/cache_proxy/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/cache_proxy",
     visibility = ["//visibility:public"],
     deps = [
+        "//cli/arg",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/environment",

--- a/cli/cache_proxy/cache_proxy.go
+++ b/cli/cache_proxy/cache_proxy.go
@@ -28,8 +28,9 @@ import (
 )
 
 var (
-	readThrough  = flag.Bool("read_through", true, "If true, cache remote reads locally")
-	writeThrough = flag.Bool("write_through", true, "If true, upload writes to remote cache too")
+	readThrough      = flag.Bool("read_through", true, "If true, cache remote reads locally")
+	writeThrough     = flag.Bool("write_through", true, "If true, upload writes to remote cache too")
+	synchronousWrite = flag.Bool("synchronous_write", false, "If true, wait until writes to remote cache are finished")
 )
 
 const (
@@ -259,8 +260,14 @@ func (p *CacheProxy) Write(stream bspb.ByteStream_WriteServer) error {
 				return err
 			}
 			if *writeThrough {
-				if err := p.qWorker.EnqueueRemoteWrite(stream.Context(), wreq); err != nil {
-					log.Errorf("Error enqueueing write request to remote: %s", err.Error())
+				if *synchronousWrite {
+					if err := p.qWorker.RemoteWriteBlocked(stream.Context(), wreq); err != nil {
+						log.Errorf("Error write to remote cache: %s", err)
+					}
+				} else {
+					if err := p.qWorker.EnqueueRemoteWrite(stream.Context(), wreq); err != nil {
+						log.Errorf("Error enqueueing write request to remote: %s", err.Error())
+					}
 				}
 			}
 			return stream.SendAndClose(lastRsp)
@@ -348,4 +355,13 @@ func (qw *queueWorker) EnqueueRemoteWrite(ctx context.Context, wreq *bspb.WriteR
 	default:
 		return status.ResourceExhaustedError("Queue was at capacity.")
 	}
+}
+
+func (qw *queueWorker) RemoteWriteBlocked(ctx context.Context, wreq *bspb.WriteRequest) error {
+	md, _ := metadata.FromIncomingContext(ctx)
+	req := queueReq{
+		metadata:          md,
+		writeResourceName: wreq.GetResourceName(),
+	}
+	return qw.handleWriteRequest(req)
 }

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -117,9 +117,6 @@ func isCI(args []string) bool {
 func ConfigureSidecar(args []string) []string {
 	// Disable sidecar on CI for now since the async upload behavior can cause
 	// problems if the CI runner terminates before the uploads have completed.
-	// TODO: The sidecar is just an async BES/cache proxy at the moment, but if
-	// we add more sidecar features then we should find a way to re-enable it in
-	// "synchronous" mode on CI.
 	if isCI(args) {
 		log.Debugf("CI build detected.")
 		syncFlag := arg.Get(args, "sync")
@@ -160,6 +157,7 @@ func ConfigureSidecar(args []string) []string {
 
 	if synchronousWriteFlag == "1" || synchronousWriteFlag == "true" {
 		sidecarArgs = append(sidecarArgs, "--synchronous_write")
+		sidecarArgs = append(sidecarArgs, "--build_event_server.synchronous")
 		args = append(args, "--bes_upload_mode=wait_for_upload_complete")
 	}
 

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -95,8 +95,15 @@ func restartSidecarIfNecessary(ctx context.Context, bbCacheDir string, args []st
 	return sockPath, nil
 }
 
+func isFlagTrue(flag string) bool {
+	if flag == "1" || strings.EqualFold(flag, "true") {
+		return true
+	}
+	return false
+}
+
 func isCI(args []string) bool {
-	if os.Getenv("CI") == "1" || strings.EqualFold(os.Getenv("CI"), "true") {
+	if isFlagTrue(os.Getenv("CI")) {
 		return true
 	}
 	for _, md := range arg.GetMulti(args, "build_metadata") {
@@ -114,8 +121,12 @@ func ConfigureSidecar(args []string) []string {
 	// we add more sidecar features then we should find a way to re-enable it in
 	// "synchronous" mode on CI.
 	if isCI(args) {
-		log.Debugf("CI build detected; sidecar is disabled.")
-		return args
+		log.Debugf("CI build detected.")
+		syncFlag := arg.Get(args, "sync")
+		if !isFlagTrue(syncFlag) {
+			log.Debugf("CI build detected. add --sync=true")
+			args = append(args, "--sync=true")
+		}
 	}
 
 	log.Debugf("Configuring sidecar")
@@ -133,6 +144,7 @@ func ConfigureSidecar(args []string) []string {
 	besBackendFlag := arg.Get(args, "bes_backend")
 	remoteCacheFlag := arg.Get(args, "remote_cache")
 	remoteExecFlag := arg.Get(args, "remote_executor")
+	synchronousWriteFlag, args := arg.Pop(args, "sync")
 
 	if besBackendFlag != "" {
 		sidecarArgs = append(sidecarArgs, "--bes_backend="+besBackendFlag)
@@ -144,6 +156,11 @@ func ConfigureSidecar(args []string) []string {
 		// disk caches.
 		diskCacheDir := filepath.Join(cacheDir, "filecache")
 		sidecarArgs = append(sidecarArgs, fmt.Sprintf("--cache_dir=%s", diskCacheDir))
+	}
+
+	if synchronousWriteFlag == "1" || synchronousWriteFlag == "true" {
+		sidecarArgs = append(sidecarArgs, "--synchronous_write")
+		args = append(args, "--bes_upload_mode=wait_for_upload_complete")
 	}
 
 	if len(sidecarArgs) == 0 {

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -157,7 +157,7 @@ func ConfigureSidecar(args []string) []string {
 
 	if synchronousWriteFlag == "1" || synchronousWriteFlag == "true" {
 		sidecarArgs = append(sidecarArgs, "--synchronous_write")
-		sidecarArgs = append(sidecarArgs, "--build_event_server.synchronous")
+		sidecarArgs = append(sidecarArgs, "--bes_synchronous")
 		args = append(args, "--bes_upload_mode=wait_for_upload_complete")
 	}
 

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -355,7 +355,7 @@ func newBuildBuddyServer(t *testing.T, env *buildBuddyServerEnv, opts *BuildBudd
 
 	scheduler, err := scheduler_server.NewSchedulerServerWithOptions(env, &opts.SchedulerServerOptions)
 	require.NoError(t, err, "could not set up SchedulerServer")
-	buildEventServer, err := build_event_server.NewBuildEventProtocolServer(env)
+	buildEventServer, err := build_event_server.NewBuildEventProtocolServer(env, false)
 	require.NoError(t, err, "could not set up BuildEventProtocolServer")
 	buildBuddyServiceServer, err := buildbuddy_server.NewBuildBuddyServer(env, nil /*=sslService*/)
 	require.NoError(t, err, "could not set up BuildBuddyServiceServer")

--- a/server/build_event_protocol/build_event_proxy/BUILD
+++ b/server/build_event_protocol/build_event_proxy/BUILD
@@ -13,5 +13,6 @@ go_library(
         "//server/util/log",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_protobuf//types/known/emptypb",
+        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/server/build_event_protocol/build_event_server/BUILD
+++ b/server/build_event_protocol/build_event_server/BUILD
@@ -14,5 +14,6 @@ go_library(
         "//server/util/status",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_protobuf//types/known/emptypb",
+        "@org_golang_x_sync//errgroup",
     ],
 )


### PR DESCRIPTION
When --sync=true, we will
1) pass --bes_upload_mode=wait_for_upload_complete
2) pass --synchronous_write to cache_proxy in the sidecar. When
   synchronous_write flag is set, cache_proxy will not use the worker
   queue to process the write requests async.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: 
https://github.com/buildbuddy-io/buildbuddy-internal/issues/2108
