### PR TITLE
server/util/bazel: remove old Bazel versions and simplify

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6284,30 +6284,6 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         executable = True,
     )
     http_file(
-        name = "io_bazel_bazel-3.7-darwin-x86_64",
-        sha256 = "80c82e93a12ba30021692b11c78007807e82383a673be1602573b944beb359ab",
-        urls = ["https://github.com/bazelbuild/bazel/releases/download/3.7.2/bazel-3.7.2-darwin-x86_64"],
-        executable = True,
-    )
-    http_file(
-        name = "io_bazel_bazel-3.7-linux-x86_64",
-        sha256 = "70dc0bee198a4c3d332925a32d464d9036a831977501f66d4996854ad4e4fc0d",
-        urls = ["https://github.com/bazelbuild/bazel/releases/download/3.7.2/bazel-3.7.2-linux-x86_64"],
-        executable = True,
-    )
-    http_file(
-        name = "io_bazel_bazel-4.1-darwin-x86_64",
-        sha256 = "2eecc3abb0ff653ed0bffdb9fbfda7b08548c2868f13da4a995f01528db200a9",
-        urls = ["https://github.com/bazelbuild/bazel/releases/download/4.1.0/bazel-4.1.0-darwin-x86_64"],
-        executable = True,
-    )
-    http_file(
-        name = "io_bazel_bazel-4.1-linux-x86_64",
-        sha256 = "0eb2e378d2782e7810753e2162245ad1179c1bb12f848c692b4a595b4edf779b",
-        urls = ["https://github.com/bazelbuild/bazel/releases/download/4.1.0/bazel-4.1.0-linux-x86_64"],
-        executable = True,
-    )
-    http_file(
         name = "io_bazel_bazel-5.3.2-darwin-x86_64",
         sha256 = "fe01824013184899386a4807435e38811949ca13f46713e7fc39c70fa1528a17",
         urls = ["https://github.com/bazelbuild/bazel/releases/download/5.3.2/bazel-5.3.2-darwin-x86_64"],

--- a/server/util/bazel/BUILD
+++ b/server/util/bazel/BUILD
@@ -1,78 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load(":defs.bzl", "extract_bazel_installation")
+load(":defs.bzl", "bazel_pkg_tar")
 
-genrule(
-    name = "bazel-3.7_crossplatform",
-    srcs = select({
-        "@bazel_tools//src/conditions:darwin": ["@io_bazel_bazel-3.7-darwin-x86_64//file:downloaded"],
-        "//conditions:default": ["@io_bazel_bazel-3.7-linux-x86_64//file:downloaded"],
-    }),
-    outs = ["bazel-3.7"],
-    cmd_bash = "cp $(SRCS) $@",
-    executable = True,
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "bazel-4.1_crossplatform",
-    srcs = select({
-        "@bazel_tools//src/conditions:darwin": ["@io_bazel_bazel-4.1-darwin-x86_64//file:downloaded"],
-        "//conditions:default": ["@io_bazel_bazel-4.1-linux-x86_64//file:downloaded"],
-    }),
-    outs = ["bazel-4.1"],
-    cmd_bash = "cp $(SRCS) $@",
-    executable = True,
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "bazel-5.3.2_crossplatform",
-    srcs = select({
-        "@bazel_tools//src/conditions:darwin": ["@io_bazel_bazel-5.3.2-darwin-x86_64//file:downloaded"],
-        "//conditions:default": ["@io_bazel_bazel-5.3.2-linux-x86_64//file:downloaded"],
-    }),
-    outs = ["bazel-5.3.2"],
-    cmd_bash = "cp $(SRCS) $@",
-    executable = True,
-    visibility = ["//visibility:public"],
-)
-
-extract_bazel_installation(
-    name = "bazel-5.3.2_extract_installation",
-    bazel = ":bazel-5.3.2_crossplatform",
-    out_dir = "bazel-5.3.2_install",
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "bazel-6.0.0_crossplatform",
-    srcs = select({
-        "@bazel_tools//src/conditions:darwin": ["@io_bazel_bazel-6.0.0-darwin-x86_64//file:downloaded"],
-        "//conditions:default": ["@io_bazel_bazel-6.0.0-linux-x86_64//file:downloaded"],
-    }),
-    outs = ["bazel-6.0.0"],
-    cmd_bash = "cp $(SRCS) $@",
-    executable = True,
-    visibility = ["//visibility:public"],
-)
-
-extract_bazel_installation(
-    name = "bazel-6.0.0_extract_installation",
-    bazel = ":bazel-6.0.0_crossplatform",
-    out_dir = "bazel-6.0.0_install",
-    visibility = ["//visibility:public"],
-)
-
-pkg_tar(
+bazel_pkg_tar(
     name = "bazel_binaries_tar",
-    srcs = [
-        ":bazel-3.7_crossplatform",
-        ":bazel-4.1_crossplatform",
-        ":bazel-5.3.2_crossplatform",
-        ":bazel-6.0.0_crossplatform",
+    versions = [
+        "5.3.2",
+        "6.0.0",
     ],
-    package_dir = "/bazel",
     visibility = ["//visibility:public"],
 )
 

--- a/server/util/bazel/defs.bzl
+++ b/server/util/bazel/defs.bzl
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
 def _extract_bazel_installation_impl(ctx):
     out_dir = ctx.actions.declare_directory(ctx.attr.out_dir)
     ctx.actions.run_shell(
@@ -31,4 +33,32 @@ extract_bazel_installation = rule(
         "bazel": attr.label(executable = True, cfg = "exec", mandatory = True, allow_single_file = True),
         "out_dir": attr.string(mandatory = True),
     },
+    doc = "Extract Bazel's executable zip file into install_base directory and cache it to reuse later",
 )
+
+def bazel_pkg_tar(name, versions = [], **kwargs):
+    """Create a tar file containing Bazel executable for each version in versions."""
+    for version in versions:
+        native.genrule(
+            name = "bazel-{}_crossplatform".format(version),
+            srcs = select({
+                "@bazel_tools//src/conditions:darwin": ["@io_bazel_bazel-{}-darwin-x86_64//file:downloaded".format(version)],
+                "//conditions:default": ["@io_bazel_bazel-{}-linux-x86_64//file:downloaded".format(version)],
+            }),
+            outs = ["bazel-{}".format(version)],
+            cmd_bash = "cp $(SRCS) $@",
+            executable = True,
+            **kwargs
+        )
+        extract_bazel_installation(
+            name = "bazel-{}_extract_installation".format(version),
+            bazel = ":bazel-{}_crossplatform".format(version),
+            out_dir = "bazel-{}_install".format(version),
+            **kwargs
+        )
+    pkg_tar(
+        name = name,
+        srcs = [":bazel-{}_crossplatform".format(version) for version in versions],
+        package_dir = "/bazel",
+        **kwargs
+    )


### PR DESCRIPTION
We are no longer running prober against Bazel 3 and 4.
Our integration test is also using Bazel 5.3 as default.

Remove Bazel 3 and 4 and simplify related configuration and
added doc.

---

This was a result of me wanting to setup some integration tests to
verify Bazel's symlink behavior in more recent versions. Those tests
will be added in future PRs.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
