### PR TITLE
use downloadcontent

### DIFF
--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -13,7 +13,7 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
 RUN apt-get update && apt-get install -y umoci iproute2
 
 # Install podman and skopeo
-RUN echo 'deb https://download.opensuse.org/repositories/home:/alvistack/Debian_11/ /' >> /etc/apt/sources.list.d/home:alvistack.list && \
+RUN echo 'deb https://downloadcontent.opensuse.org/repositories/home:/alvistack/Debian_11/ /' >> /etc/apt/sources.list.d/home:alvistack.list && \
     curl -fsSL https://download.opensuse.org/repositories/home:/alvistack/Debian_11/Release.key | gpg --dearmor >> /etc/apt/trusted.gpg.d/home_alvistack_debian11.gpg && \
     apt-get update && apt-get -y upgrade && apt-get install -y podman=100:4.5.0-1 skopeo=100:1.12.0-1
 


### PR DESCRIPTION
download.opensuse.org will use mirror to download; and when the mirror
is updating it will cause digest mismatch.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
