### PR TITLE
Remove dedicated partition requirement for encryption.

### DIFF
--- a/enterprise/app/encryption/encryption.tsx
+++ b/enterprise/app/encryption/encryption.tsx
@@ -15,7 +15,6 @@ import { BuildBuddyError } from "../../../app/util/errors";
 import error_service from "../../../app/errors/error_service";
 
 interface State {
-  encryptionSupported: boolean;
   encryptionEnabled: boolean;
   supportedKMS: encryption.KMS[];
 
@@ -41,7 +40,6 @@ interface State {
 
 export default class EncryptionComponent extends React.Component<{}, State> {
   state: State = {
-    encryptionSupported: false,
     encryptionEnabled: false,
     supportedKMS: [],
     isDisableModalOpen: false,
@@ -65,7 +63,6 @@ export default class EncryptionComponent extends React.Component<{}, State> {
     try {
       const response = await rpc_service.service.getEncryptionConfig(encryption.GetEncryptionConfigRequest.create());
       this.setState({
-        encryptionSupported: response.supported,
         encryptionEnabled: response.enabled,
         supportedKMS: response.supportedKms,
       });
@@ -276,13 +273,7 @@ export default class EncryptionComponent extends React.Component<{}, State> {
   render() {
     return (
       <>
-        {!this.state.encryptionSupported && (
-          <div>
-            To configure customer managed encryption keys, please reach out to us via Slack or email us at
-            support@buildbuddy.io.
-          </div>
-        )}
-        {this.state.encryptionSupported && this.state.encryptionEnabled && (
+        {this.state.encryptionEnabled && (
           <div>
             <p>Customer-managed encryption keys are enabled.</p>
 
@@ -322,7 +313,7 @@ export default class EncryptionComponent extends React.Component<{}, State> {
             </Modal>
           </div>
         )}
-        {this.state.encryptionSupported && !this.state.encryptionEnabled && (
+        {!this.state.encryptionEnabled && (
           <div>
             <p>Customer managed encryption keys are not currently enabled.</p>
             <p>

--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -146,7 +146,7 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                     Secrets
                   </SettingsTab>
                 )}
-                {router.canAccessEncryptionPage(this.props.user) && (
+                {capabilities.config.customerManagedEncryptionKeysEnabled && router.canAccessEncryptionPage(this.props.user) && (
                   <SettingsTab id={TabId.OrgCacheEncryption} activeTabId={activeTabId}>
                     Encryption keys
                   </SettingsTab>

--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -146,11 +146,12 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                     Secrets
                   </SettingsTab>
                 )}
-                {capabilities.config.customerManagedEncryptionKeysEnabled && router.canAccessEncryptionPage(this.props.user) && (
-                  <SettingsTab id={TabId.OrgCacheEncryption} activeTabId={activeTabId}>
-                    Encryption keys
-                  </SettingsTab>
-                )}
+                {capabilities.config.customerManagedEncryptionKeysEnabled &&
+                  router.canAccessEncryptionPage(this.props.user) && (
+                    <SettingsTab id={TabId.OrgCacheEncryption} activeTabId={activeTabId}>
+                      Encryption keys
+                    </SettingsTab>
+                  )}
               </div>
               <div className="settings-tab-group-header">
                 <div className="settings-tab-group-title">Personal settings</div>

--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -864,10 +864,6 @@ func (c *Crypter) enableEncryption(ctx context.Context, kmsConfig *enpb.KMSConfi
 		return err
 	}
 
-	if !c.env.GetCache().SupportsEncryption(ctx) {
-		return status.UnavailableError("enabling encryption requires an account with dedicated storage")
-	}
-
 	// Get the KMS clients for the customer and our own keys. This doesn't
 	// actually talk to the KMS systems yet.
 	groupKeyClient, err := c.env.GetKMS().FetchKey(groupKeyURI)
@@ -1012,8 +1008,7 @@ func (c *Crypter) GetEncryptionConfig(ctx context.Context, req *enpb.GetEncrypti
 	}
 
 	rsp := &enpb.GetEncryptionConfigResponse{
-		Supported: c.env.GetCache().SupportsEncryption(ctx),
-		Enabled:   g.CacheEncryptionEnabled,
+		Enabled: g.CacheEncryptionEnabled,
 	}
 
 	for _, t := range c.env.GetKMS().SupportedTypes() {

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -92,4 +92,7 @@ message FrontendConfig {
 
   // Whether or not we show the new summary section on the trends page.
   bool trends_summary_enabled = 30;
+
+  // Whether to show encryption settings.
+  bool customer_managed_encryption_keys_enabled = 31;
 }

--- a/proto/encryption.proto
+++ b/proto/encryption.proto
@@ -47,8 +47,7 @@ enum KMS {
 message GetEncryptionConfigResponse {
   context.ResponseContext response_context = 1;
 
-  bool supported = 2;
-  bool enabled = 3;
+  bool enabled = 2;
 
-  repeated KMS supported_kms = 4;
+  repeated KMS supported_kms = 3;
 }

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -40,8 +40,8 @@ var (
 	enableWorkflows                      = flag.Bool("remote_execution.enable_workflows", false, "Whether to enable BuildBuddy workflows.")
 	enableExecutorKeyCreation            = flag.Bool("remote_execution.enable_executor_key_creation", false, "If enabled, UI will allow executor keys to be created.")
 	testOutputManifestsEnabled           = flag.Bool("app.test_output_manifests_enabled", true, "If set, the target page will render the contents of test output zips.")
-	patternFilterEnabled       = flag.Bool("app.pattern_filter_enabled", true, "If set, allow filtering by pattern in the client.")
-	executionSearchEnabled     = flag.Bool("app.execution_search_enabled", true, "If set, fetch lists of executions from the OLAP DB in the trends UI.")
+	patternFilterEnabled                 = flag.Bool("app.pattern_filter_enabled", true, "If set, allow filtering by pattern in the client.")
+	executionSearchEnabled               = flag.Bool("app.execution_search_enabled", true, "If set, fetch lists of executions from the OLAP DB in the trends UI.")
 	trendsSummaryEnabled                 = flag.Bool("app.trends_summary_enabled", false, "If set, show the new 'summary' section at the top of the trends UI.")
 	customerManagedEncryptionKeysEnabled = flag.Bool("app.customer_managed_encryption_keys_enabled", false, "If set, show customer-managed encryption configuration UI.")
 

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -31,18 +31,19 @@ const (
 )
 
 var (
-	defaultToDenseMode         = flag.Bool("app.default_to_dense_mode", false, "Enables the dense UI mode by default.")
-	codeEditorEnabled          = flag.Bool("app.code_editor_enabled", false, "If set, code editor functionality will be enabled.")
-	userManagementEnabled      = flag.Bool("app.user_management_enabled", true, "If set, the user management page will be enabled in the UI.")
-	testGridV2Enabled          = flag.Bool("app.test_grid_v2_enabled", true, "Whether to enable test grid V2")
-	usageEnabled               = flag.Bool("app.usage_enabled", false, "If set, the usage page will be enabled in the UI.")
-	expandedSuggestionsEnabled = flag.Bool("app.expanded_suggestions_enabled", false, "If set, enable more build suggestions in the UI.")
-	enableWorkflows            = flag.Bool("remote_execution.enable_workflows", false, "Whether to enable BuildBuddy workflows.")
-	enableExecutorKeyCreation  = flag.Bool("remote_execution.enable_executor_key_creation", false, "If enabled, UI will allow executor keys to be created.")
-	testOutputManifestsEnabled = flag.Bool("app.test_output_manifests_enabled", true, "If set, the target page will render the contents of test output zips.")
+	defaultToDenseMode                   = flag.Bool("app.default_to_dense_mode", false, "Enables the dense UI mode by default.")
+	codeEditorEnabled                    = flag.Bool("app.code_editor_enabled", false, "If set, code editor functionality will be enabled.")
+	userManagementEnabled                = flag.Bool("app.user_management_enabled", true, "If set, the user management page will be enabled in the UI.")
+	testGridV2Enabled                    = flag.Bool("app.test_grid_v2_enabled", true, "Whether to enable test grid V2")
+	usageEnabled                         = flag.Bool("app.usage_enabled", false, "If set, the usage page will be enabled in the UI.")
+	expandedSuggestionsEnabled           = flag.Bool("app.expanded_suggestions_enabled", false, "If set, enable more build suggestions in the UI.")
+	enableWorkflows                      = flag.Bool("remote_execution.enable_workflows", false, "Whether to enable BuildBuddy workflows.")
+	enableExecutorKeyCreation            = flag.Bool("remote_execution.enable_executor_key_creation", false, "If enabled, UI will allow executor keys to be created.")
+	testOutputManifestsEnabled           = flag.Bool("app.test_output_manifests_enabled", true, "If set, the target page will render the contents of test output zips.")
 	patternFilterEnabled       = flag.Bool("app.pattern_filter_enabled", true, "If set, allow filtering by pattern in the client.")
 	executionSearchEnabled     = flag.Bool("app.execution_search_enabled", true, "If set, fetch lists of executions from the OLAP DB in the trends UI.")
-	trendsSummaryEnabled       = flag.Bool("app.trends_summary_enabled", false, "If set, show the new 'summary' section at the top of the trends UI.")
+	trendsSummaryEnabled                 = flag.Bool("app.trends_summary_enabled", false, "If set, show the new 'summary' section at the top of the trends UI.")
+	customerManagedEncryptionKeysEnabled = flag.Bool("app.customer_managed_encryption_keys_enabled", false, "If set, show customer-managed encryption configuration UI.")
 
 	jsEntryPointPath = flag.String("js_entry_point_path", "/app/app_bundle/app.js?hash={APP_BUNDLE_HASH}", "Absolute URL path of the app JS entry point")
 	disableGA        = flag.Bool("disable_ga", false, "If true; ga will be disabled")
@@ -134,35 +135,36 @@ type FrontendTemplateData struct {
 
 func serveIndexTemplate(env environment.Env, tpl *template.Template, version, jsPath, stylePath string, w http.ResponseWriter) {
 	config := cfgpb.FrontendConfig{
-		Version:                       version,
-		ConfiguredIssuers:             env.GetAuthenticator().PublicIssuers(),
-		DefaultToDenseMode:            *defaultToDenseMode,
-		GithubEnabled:                 github.IsLegacyOAuthAppEnabled(),
-		GithubAppEnabled:              env.GetGitHubApp() != nil,
-		AnonymousUsageEnabled:         env.GetAuthenticator().AnonymousUsageEnabled(),
-		TestDashboardEnabled:          target_tracker.TargetTrackingEnabled(),
-		UserOwnedExecutorsEnabled:     remote_execution_config.RemoteExecutionEnabled() && scheduler_server_config.UserOwnedExecutorsEnabled(),
-		ExecutorKeyCreationEnabled:    remote_execution_config.RemoteExecutionEnabled() && *enableExecutorKeyCreation,
-		WorkflowsEnabled:              remote_execution_config.RemoteExecutionEnabled() && *enableWorkflows,
-		CodeEditorEnabled:             *codeEditorEnabled,
-		RemoteExecutionEnabled:        remote_execution_config.RemoteExecutionEnabled(),
-		SsoEnabled:                    env.GetAuthenticator().SSOEnabled(),
-		GlobalFilterEnabled:           true,
-		UsageEnabled:                  *usageEnabled,
-		UserManagementEnabled:         *userManagementEnabled,
-		ForceUserOwnedDarwinExecutors: remote_execution_config.RemoteExecutionEnabled() && scheduler_server_config.ForceUserOwnedDarwinExecutors(),
-		TestGridV2Enabled:             *testGridV2Enabled,
-		DetailedCacheStatsEnabled:     hit_tracker.DetailedStatsEnabled(),
-		ExpandedSuggestionsEnabled:    *expandedSuggestionsEnabled,
-		QuotaManagementEnabled:        env.GetQuotaManager() != nil,
-		SecretsEnabled:                env.GetSecretService() != nil,
-		TestOutputManifestsEnabled:    *testOutputManifestsEnabled,
-		UserOwnedKeysEnabled:          env.GetUserDB() != nil && env.GetUserDB().GetUserOwnedKeysEnabled(),
-		TrendsHeatmapEnabled:          iss_config.TrendsHeatmapEnabled() && env.GetOLAPDBHandle() != nil,
-		PatternFilterEnabled:          *patternFilterEnabled,
-		BotSuggestionsEnabled:         env.GetSuggestionService() != nil,
-		ExecutionSearchEnabled:        *executionSearchEnabled,
-		TrendsSummaryEnabled:          *trendsSummaryEnabled,
+		Version:                              version,
+		ConfiguredIssuers:                    env.GetAuthenticator().PublicIssuers(),
+		DefaultToDenseMode:                   *defaultToDenseMode,
+		GithubEnabled:                        github.IsLegacyOAuthAppEnabled(),
+		GithubAppEnabled:                     env.GetGitHubApp() != nil,
+		AnonymousUsageEnabled:                env.GetAuthenticator().AnonymousUsageEnabled(),
+		TestDashboardEnabled:                 target_tracker.TargetTrackingEnabled(),
+		UserOwnedExecutorsEnabled:            remote_execution_config.RemoteExecutionEnabled() && scheduler_server_config.UserOwnedExecutorsEnabled(),
+		ExecutorKeyCreationEnabled:           remote_execution_config.RemoteExecutionEnabled() && *enableExecutorKeyCreation,
+		WorkflowsEnabled:                     remote_execution_config.RemoteExecutionEnabled() && *enableWorkflows,
+		CodeEditorEnabled:                    *codeEditorEnabled,
+		RemoteExecutionEnabled:               remote_execution_config.RemoteExecutionEnabled(),
+		SsoEnabled:                           env.GetAuthenticator().SSOEnabled(),
+		GlobalFilterEnabled:                  true,
+		UsageEnabled:                         *usageEnabled,
+		UserManagementEnabled:                *userManagementEnabled,
+		ForceUserOwnedDarwinExecutors:        remote_execution_config.RemoteExecutionEnabled() && scheduler_server_config.ForceUserOwnedDarwinExecutors(),
+		TestGridV2Enabled:                    *testGridV2Enabled,
+		DetailedCacheStatsEnabled:            hit_tracker.DetailedStatsEnabled(),
+		ExpandedSuggestionsEnabled:           *expandedSuggestionsEnabled,
+		QuotaManagementEnabled:               env.GetQuotaManager() != nil,
+		SecretsEnabled:                       env.GetSecretService() != nil,
+		TestOutputManifestsEnabled:           *testOutputManifestsEnabled,
+		UserOwnedKeysEnabled:                 env.GetUserDB() != nil && env.GetUserDB().GetUserOwnedKeysEnabled(),
+		TrendsHeatmapEnabled:                 iss_config.TrendsHeatmapEnabled() && env.GetOLAPDBHandle() != nil,
+		PatternFilterEnabled:                 *patternFilterEnabled,
+		BotSuggestionsEnabled:                env.GetSuggestionService() != nil,
+		ExecutionSearchEnabled:               *executionSearchEnabled,
+		TrendsSummaryEnabled:                 *trendsSummaryEnabled,
+		CustomerManagedEncryptionKeysEnabled: *customerManagedEncryptionKeysEnabled,
 	}
 
 	configJSON, err := protojson.Marshal(&config)


### PR DESCRIPTION
With the new pebble key format, content is implicitely separated by customer via the encryption key ID so there's no longer a need to require a dedicated storage partition.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
