### PR TITLE
Don't set instance name when writing soci artifacts to cache

### DIFF
--- a/enterprise/server/sociartifactstore/sociartifactstore.go
+++ b/enterprise/server/sociartifactstore/sociartifactstore.go
@@ -285,7 +285,6 @@ func blobKey(hash string) string {
 func resourceName(digest *repb.Digest) *rspb.ResourceName {
 	return &rspb.ResourceName{
 		Digest:         digest,
-		InstanceName:   "soci",
 		Compressor:     repb.Compressor_IDENTITY,
 		CacheType:      rspb.CacheType_CAS,
 		DigestFunction: repb.DigestFunction_SHA256,


### PR DESCRIPTION
Vadim tells me it's not needed

**Related issues**: N/A
