### PR TITLE
Separate encrypted content on disk.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1207,16 +1207,7 @@ func (p *PebbleCache) encryptionEnabled(ctx context.Context, partitionID string)
 		return false, status.FailedPreconditionError("encryption requested, but crypter not available")
 	}
 
-	for _, p := range p.partitions {
-		if p.ID == partitionID {
-			if !p.EncryptionSupported {
-				return false, status.FailedPreconditionError("encryption enabled, but writing to a partition that doesn't support encryption")
-			}
-			return true, nil
-		}
-	}
-
-	return false, status.InvalidArgumentError("partition not found")
+	return true, nil
 }
 
 func (p *PebbleCache) makeFileRecord(ctx context.Context, r *rspb.ResourceName) (*rfpb.FileRecord, error) {

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -1948,30 +1948,12 @@ func TestEncryption(t *testing.T) {
 	rootDir := testfs.MakeTempDir(t)
 	maxSizeBytes := int64(1_000_000_000) // 1GB
 
-	// Customer has encryption enabled but partition does not support encryption.
-	{
-		opts := &pebble_cache.Options{RootDirectory: rootDir, MaxSizeBytes: maxSizeBytes}
-		pc, err := pebble_cache.NewPebbleCache(te, opts)
-		require.NoError(t, err)
-		err = pc.Start()
-		require.NoError(t, err)
-
-		ctx, err := auther.WithAuthenticatedUser(context.Background(), userID)
-		require.NoError(t, err)
-		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
-		err = pc.Set(ctx, rn, buf)
-		require.ErrorContains(t, err, "partition that doesn't support encryption")
-
-		err = pc.Stop()
-		require.NoError(t, err)
-	}
-
 	// Customer has encryption enabled, but no keys are available.
 	{
 		opts := &pebble_cache.Options{
 			RootDirectory: rootDir,
 			Partitions: []disk.Partition{{
-				ID: pebble_cache.DefaultPartitionID, EncryptionSupported: true, MaxSizeBytes: maxSizeBytes,
+				ID: pebble_cache.DefaultPartitionID, MaxSizeBytes: maxSizeBytes,
 			}},
 		}
 		pc, err := pebble_cache.NewPebbleCache(te, opts)
@@ -2054,7 +2036,7 @@ func TestEncryptionAndCompression(t *testing.T) {
 	opts := &pebble_cache.Options{
 		RootDirectory: rootDir,
 		Partitions: []disk.Partition{{
-			ID: pebble_cache.DefaultPartitionID, EncryptionSupported: true, MaxSizeBytes: maxSizeBytes,
+			ID: pebble_cache.DefaultPartitionID, MaxSizeBytes: maxSizeBytes,
 		}},
 	}
 	pc, err := pebble_cache.NewPebbleCache(te, opts)
@@ -2430,8 +2412,7 @@ func TestSampling(t *testing.T) {
 	opts := &pebble_cache.Options{
 		RootDirectory: rootDir,
 		Partitions: []disk.Partition{{
-			ID:                  pebble_cache.DefaultPartitionID,
-			EncryptionSupported: true,
+			ID: pebble_cache.DefaultPartitionID,
 			// Force all entries to be evicted as soon as they pass the minimum
 			// eviction age.
 			MaxSizeBytes: 2,

--- a/enterprise/server/crypter_service/crypter_service_test.go
+++ b/enterprise/server/crypter_service/crypter_service_test.go
@@ -723,7 +723,7 @@ func TestConfigAPI(t *testing.T) {
 		RootDirectory: rootDir,
 		Partitions: []disk.Partition{
 			{ID: "default", MaxSizeBytes: cacheSizeBytes},
-			{ID: customPartID, MaxSizeBytes: cacheSizeBytes, EncryptionSupported: true},
+			{ID: customPartID, MaxSizeBytes: cacheSizeBytes},
 		},
 		PartitionMappings: []disk.PartitionMapping{
 			{GroupID: groupID, PartitionID: customPartID},

--- a/enterprise/server/raft/filestore/filestore.go
+++ b/enterprise/server/raft/filestore/filestore.go
@@ -358,6 +358,9 @@ func (fs *fileStorer) FileKey(r *rfpb.FileRecord) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if r.GetEncryption().GetKeyId() != "" {
+		hash += "_" + r.GetEncryption().GetKeyId()
+	}
 	partDir := PartitionDirectoryPrefix + partID
 	if r.GetIsolation().GetCacheType() == rspb.CacheType_AC {
 		return []byte(filepath.Join(partDir, groupID, isolation, remoteInstanceHash, hash[:4], hash)), nil


### PR DESCRIPTION
The same digest may exist in the cache in both unencrypted and encrypted formats.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
