### PR TITLE
Use group ID as authenticated data for master portion of key.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -1895,7 +1895,7 @@ func createKey(t *testing.T, env environment.Env, keyID, groupID, groupKeyURI st
 
 	masterAEAD, err := kmsClient.FetchMasterKey()
 	require.NoError(t, err)
-	encMasterKeyPart, err := masterAEAD.Encrypt(masterKeyPart, nil)
+	encMasterKeyPart, err := masterAEAD.Encrypt(masterKeyPart, []byte(groupID))
 	require.NoError(t, err)
 
 	groupAEAD, err := kmsClient.FetchKey(groupKeyURI)

--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -207,7 +207,7 @@ func (c *keyCache) derivedKey(groupID string, key *tables.EncryptionKeyVersion) 
 		return nil, err
 	}
 
-	masterKeyPortion, err := bbmk.Decrypt(key.MasterEncryptedKey, nil)
+	masterKeyPortion, err := bbmk.Decrypt(key.MasterEncryptedKey, []byte(groupID))
 	if err != nil {
 		return nil, err
 	}
@@ -670,7 +670,7 @@ func (c *Crypter) reencryptKey(ctx context.Context, ekv *encryptionKeyVersionWit
 		return err
 	}
 
-	masterKeyPortion, err := bbmk.Decrypt(ekv.MasterEncryptedKey, nil)
+	masterKeyPortion, err := bbmk.Decrypt(ekv.MasterEncryptedKey, []byte(ekv.GroupID))
 	if err != nil {
 		return err
 	}
@@ -678,7 +678,7 @@ func (c *Crypter) reencryptKey(ctx context.Context, ekv *encryptionKeyVersionWit
 	if err != nil {
 		return err
 	}
-	encMasterKeyPortion, err := bbmk.Encrypt(masterKeyPortion, nil)
+	encMasterKeyPortion, err := bbmk.Encrypt(masterKeyPortion, []byte(ekv.GroupID))
 	if err != nil {
 		return err
 	}
@@ -891,7 +891,7 @@ func (c *Crypter) enableEncryption(ctx context.Context, kmsConfig *enpb.KMSConfi
 		return status.InternalErrorf("could not generate key id: %s", err)
 	}
 
-	encMasterKeyPart, err := masterKeyClient.Encrypt(masterKeyPart, nil)
+	encMasterKeyPart, err := masterKeyClient.Encrypt(masterKeyPart, []byte(u.GetGroupID()))
 	if err != nil {
 		return status.InternalErrorf("could not encrypt master portion of composite key: %s", err)
 	}

--- a/enterprise/server/crypter_service/crypter_service_test.go
+++ b/enterprise/server/crypter_service/crypter_service_test.go
@@ -186,7 +186,7 @@ func createKey(t *testing.T, env environment.Env, clock clockwork.Clock, keyID, 
 
 	masterAEAD, err := kmsClient.FetchMasterKey()
 	require.NoError(t, err)
-	encMasterKeyPart, err := masterAEAD.Encrypt(masterKeyPart, nil)
+	encMasterKeyPart, err := masterAEAD.Encrypt(masterKeyPart, []byte(groupID))
 	require.NoError(t, err)
 
 	groupAEAD, err := kmsClient.FetchKey(groupKeyURI)


### PR DESCRIPTION
This prevents the encrypted content to be decrypted on behalf of the wrong customer (e.g. due to a bug). 
Not a problem in practice because we already use the group ID for the encrypted customer key. 

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
