### PR TITLE
Fix bug in key derivation input.

### DIFF
--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -216,7 +216,7 @@ func (c *keyCache) derivedKey(groupID string, key *tables.EncryptionKeyVersion) 
 		return nil, err
 	}
 
-	ckSrc := make([]byte, len(masterKeyPortion)+len(groupKeyPortion))
+	ckSrc := make([]byte, 0, len(masterKeyPortion)+len(groupKeyPortion))
 	ckSrc = append(ckSrc, masterKeyPortion...)
 	ckSrc = append(ckSrc, groupKeyPortion...)
 


### PR DESCRIPTION
We were feeding 64 bytes of zeroes prior to feeding the actual keys.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
