### PR TITLE
Include protocol version in chunk auth data.

### DIFF
--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -441,7 +441,7 @@ type Encryptor struct {
 }
 
 func makeChunkAuthHeader(chunkIndex uint32, d *repb.Digest, groupID string) []byte {
-	return []byte(strings.Join([]string{fmt.Sprint(chunkIndex), digest.String(d), groupID}, ","))
+	return []byte(strings.Join([]string{fmt.Sprint(encryptedDataHeaderVersion), fmt.Sprint(chunkIndex), digest.String(d), groupID}, ","))
 }
 
 func (e *Encryptor) flushBlock() error {


### PR DESCRIPTION
This is to prevent cross-version attacks in the future if/when we need to alter the encryption format.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
