### PR TITLE
timing profile breakdown: take into account event.cat

### DIFF
--- a/app/invocation/invocation_breakdown_card.tsx
+++ b/app/invocation/invocation_breakdown_card.tsx
@@ -6,6 +6,7 @@ import { getChartColor } from "../util/color";
 
 interface Props {
   durationMap: Map<string, number>;
+  durationByCategoryMap: Map<string, number>;
 }
 
 interface Datum {
@@ -22,14 +23,15 @@ export default class InvocationBreakdownCardComponent extends React.Component<Pr
     let building = total - analysis - targets;
 
     let runningProcess = this.props.durationMap.get("subprocess.run");
-    let compilingSwift = this.props.durationMap.get("SwiftCompile");
-    let compilingObjc = this.props.durationMap.get("ObjcCompile");
+    let localActionExecution = this.props.durationByCategoryMap.get("local action execution");
+	let localExecution = runningProcess + localActionExecution;
+
     let executingRemotely = this.props.durationMap.get("execute remotely");
     let sandboxSetup = this.props.durationMap.get("sandbox.createFileSystem");
     let sandboxTeardown = this.props.durationMap.get("sandbox.delete");
     let inputMapping = this.props.durationMap.get("AbstractSpawnStrategy.getInputMapping");
     let merkleTree = this.props.durationMap.get("MerkleTree.build(ActionInput)");
-    let downloadOuputs = this.props.durationMap.get("download outputs");
+    let downloadOuputs = this.props.durationByCategoryMap.get("remote output download");
     let uploadMissing = this.props.durationMap.get("upload missing inputs");
     let uploadOutputs = this.props.durationMap.get("upload outputs");
     let checkCache = this.props.durationMap.get("check cache hit");
@@ -46,7 +48,7 @@ export default class InvocationBreakdownCardComponent extends React.Component<Pr
     phaseData = phaseData.sort((a, b) => b.value - a.value).filter((entry) => entry.value > 0);
 
     let executionData = [
-      { value: runningProcess, name: "Executing locally" },
+      { value: localExecution, name: "Executing locally" },
       { value: inputMapping, name: "Input mapping" },
       { value: merkleTree, name: "Merkle tree building" },
       { value: sandboxSetup, name: "Local sandbox creation" },
@@ -58,8 +60,6 @@ export default class InvocationBreakdownCardComponent extends React.Component<Pr
       { value: uploadOutputs, name: "Uploading outputs" },
       { value: detectModifiedOutput, name: "Detect modified output files" },
       { value: stableStatus, name: "Generating stable-status.txt" },
-      { value: compilingSwift, name: "Compiling Swift" },
-      { value: compilingObjc, name: "Compiling Objective-C" },
     ];
 
     executionData = executionData.sort((a, b) => (b?.value || 0) - (a?.value || 0)).filter((entry) => entry.value > 0);

--- a/app/invocation/invocation_breakdown_card.tsx
+++ b/app/invocation/invocation_breakdown_card.tsx
@@ -5,7 +5,9 @@ import format from "../format/format";
 import { getChartColor } from "../util/color";
 
 interface Props {
-  durationMap: Map<string, number>;
+  // The total duration by event names
+  durationByNameMap: Map<string, number>;
+  // The total duration by event categories
   durationByCategoryMap: Map<string, number>;
 }
 
@@ -16,27 +18,27 @@ interface Datum {
 
 export default class InvocationBreakdownCardComponent extends React.Component<Props> {
   render() {
-    let launching = this.props.durationMap.get("Launch Blaze");
-    let total = this.props.durationMap.get("buildTargets");
-    let targets = this.props.durationMap.get("evaluateTargetPatterns");
-    let analysis = this.props.durationMap.get("runAnalysisPhase");
+    let launching = this.props.durationByNameMap.get("Launch Blaze");
+    let total = this.props.durationByNameMap.get("buildTargets");
+    let targets = this.props.durationByNameMap.get("evaluateTargetPatterns");
+    let analysis = this.props.durationByNameMap.get("runAnalysisPhase");
     let building = total - analysis - targets;
 
-    let runningProcess = this.props.durationMap.get("subprocess.run");
+    let runningProcess = this.props.durationByNameMap.get("subprocess.run");
     let localActionExecution = this.props.durationByCategoryMap.get("local action execution");
     let localExecution = runningProcess + localActionExecution;
 
-    let executingRemotely = this.props.durationMap.get("execute remotely");
-    let sandboxSetup = this.props.durationMap.get("sandbox.createFileSystem");
-    let sandboxTeardown = this.props.durationMap.get("sandbox.delete");
-    let inputMapping = this.props.durationMap.get("AbstractSpawnStrategy.getInputMapping");
-    let merkleTree = this.props.durationMap.get("MerkleTree.build(ActionInput)");
+    let executingRemotely = this.props.durationByNameMap.get("execute remotely");
+    let sandboxSetup = this.props.durationByNameMap.get("sandbox.createFileSystem");
+    let sandboxTeardown = this.props.durationByNameMap.get("sandbox.delete");
+    let inputMapping = this.props.durationByNameMap.get("AbstractSpawnStrategy.getInputMapping");
+    let merkleTree = this.props.durationByNameMap.get("MerkleTree.build(ActionInput)");
     let downloadOuputs = this.props.durationByCategoryMap.get("remote output download");
-    let uploadMissing = this.props.durationMap.get("upload missing inputs");
-    let uploadOutputs = this.props.durationMap.get("upload outputs");
-    let checkCache = this.props.durationMap.get("check cache hit");
-    let detectModifiedOutput = this.props.durationMap.get("detectModifiedOutputFiles");
-    let stableStatus = this.props.durationMap.get("BazelWorkspaceStatusAction stable-status.txt");
+    let uploadMissing = this.props.durationByNameMap.get("upload missing inputs");
+    let uploadOutputs = this.props.durationByNameMap.get("upload outputs");
+    let checkCache = this.props.durationByNameMap.get("check cache hit");
+    let detectModifiedOutput = this.props.durationByNameMap.get("detectModifiedOutputFiles");
+    let stableStatus = this.props.durationByNameMap.get("BazelWorkspaceStatusAction stable-status.txt");
 
     let phaseData = [
       { value: launching, name: "Launch" },

--- a/app/invocation/invocation_breakdown_card.tsx
+++ b/app/invocation/invocation_breakdown_card.tsx
@@ -24,7 +24,7 @@ export default class InvocationBreakdownCardComponent extends React.Component<Pr
 
     let runningProcess = this.props.durationMap.get("subprocess.run");
     let localActionExecution = this.props.durationByCategoryMap.get("local action execution");
-	let localExecution = runningProcess + localActionExecution;
+    let localExecution = runningProcess + localActionExecution;
 
     let executingRemotely = this.props.durationMap.get("execute remotely");
     let sandboxSetup = this.props.durationMap.get("sandbox.createFileSystem");

--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -143,11 +143,11 @@ export default class InvocationTimingCardComponent extends React.Component<Props
           this.state.durationMap.set(event.name, event.dur);
         }
 
-		if (this.state.durationByCategoryMap.get(event.cat)) {
+        if (this.state.durationByCategoryMap.get(event.cat)) {
           this.state.durationByCategoryMap.set(event.cat, this.state.durationByCategoryMap.get(event.cat) + event.dur);
-		} else {
+        } else {
           this.state.durationByCategoryMap.set(event.cat, event.dur);
-		}
+        }
       }
 
       if (event.ph == "X") {
@@ -271,7 +271,10 @@ export default class InvocationTimingCardComponent extends React.Component<Props
     return (
       <>
         <FlameChart profile={this.state.profile} />
-        <InvocationBreakdownCardComponent durationMap={this.state.durationMap} durationByCategoryMap={this.state.durationByCategoryMap}/>
+        <InvocationBreakdownCardComponent
+          durationMap={this.state.durationMap}
+          durationByCategoryMap={this.state.durationByCategoryMap}
+        />
 
         {this.renderTimingSuggestionCard()}
 

--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -22,7 +22,7 @@ interface State {
   threadNumPages: number;
   threadToNumEventPagesMap: Map<number, number>;
   threadMap: Map<number, Thread>;
-  durationMap: Map<string, number>;
+  durationByNameMap: Map<string, number>;
   durationByCategoryMap: Map<string, number>;
   sortBy: string;
   groupBy: string;
@@ -53,7 +53,7 @@ export default class InvocationTimingCardComponent extends React.Component<Props
     threadNumPages: 1,
     threadToNumEventPagesMap: new Map<number, number>(),
     threadMap: new Map<number, Thread>(),
-    durationMap: new Map<string, number>(),
+    durationByNameMap: new Map<string, number>(),
     durationByCategoryMap: new Map<string, number>(),
     sortBy: window.localStorage[sortByStorageKey] || sortByTimeAscStorageValue,
     groupBy: window.localStorage[groupByStorageKey] || groupByThreadStorageValue,
@@ -137,17 +137,11 @@ export default class InvocationTimingCardComponent extends React.Component<Props
       };
 
       if (event.dur) {
-        if (this.state.durationMap.get(event.name)) {
-          this.state.durationMap.set(event.name, this.state.durationMap.get(event.name) + event.dur);
-        } else {
-          this.state.durationMap.set(event.name, event.dur);
-        }
-
-        if (this.state.durationByCategoryMap.get(event.cat)) {
-          this.state.durationByCategoryMap.set(event.cat, this.state.durationByCategoryMap.get(event.cat) + event.dur);
-        } else {
-          this.state.durationByCategoryMap.set(event.cat, event.dur);
-        }
+        this.state.durationByNameMap.set(event.name, (this.state.durationByNameMap.get(event.name) || 0) + event.dur);
+        this.state.durationByCategoryMap.set(
+          event.cat,
+          (this.state.durationByCategoryMap.get(event.cat) || 0) + event.dur
+        );
       }
 
       if (event.ph == "X") {
@@ -272,7 +266,7 @@ export default class InvocationTimingCardComponent extends React.Component<Props
       <>
         <FlameChart profile={this.state.profile} />
         <InvocationBreakdownCardComponent
-          durationMap={this.state.durationMap}
+          durationByNameMap={this.state.durationByNameMap}
           durationByCategoryMap={this.state.durationByCategoryMap}
         />
 

--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -23,6 +23,7 @@ interface State {
   threadToNumEventPagesMap: Map<number, number>;
   threadMap: Map<number, Thread>;
   durationMap: Map<string, number>;
+  durationByCategoryMap: Map<string, number>;
   sortBy: string;
   groupBy: string;
   threadPageSize: number;
@@ -53,6 +54,7 @@ export default class InvocationTimingCardComponent extends React.Component<Props
     threadToNumEventPagesMap: new Map<number, number>(),
     threadMap: new Map<number, Thread>(),
     durationMap: new Map<string, number>(),
+    durationByCategoryMap: new Map<string, number>(),
     sortBy: window.localStorage[sortByStorageKey] || sortByTimeAscStorageValue,
     groupBy: window.localStorage[groupByStorageKey] || groupByThreadStorageValue,
     threadPageSize: window.localStorage[threadPageSizeStorageKey] || 10,
@@ -140,6 +142,12 @@ export default class InvocationTimingCardComponent extends React.Component<Props
         } else {
           this.state.durationMap.set(event.name, event.dur);
         }
+
+		if (this.state.durationByCategoryMap.get(event.cat)) {
+          this.state.durationByCategoryMap.set(event.cat, this.state.durationByCategoryMap.get(event.cat) + event.dur);
+		} else {
+          this.state.durationByCategoryMap.set(event.cat, event.dur);
+		}
       }
 
       if (event.ph == "X") {
@@ -263,7 +271,7 @@ export default class InvocationTimingCardComponent extends React.Component<Props
     return (
       <>
         <FlameChart profile={this.state.profile} />
-        <InvocationBreakdownCardComponent durationMap={this.state.durationMap} />
+        <InvocationBreakdownCardComponent durationMap={this.state.durationMap} durationByCategoryMap={this.state.durationByCategoryMap}/>
 
         {this.renderTimingSuggestionCard()}
 


### PR DESCRIPTION
1. use cat = "remote output download" for reporting download
   outputs
2. use both name = "subprocess.run" and cat = "local action execution"
   for "Executing locally"
3. Remove Objc and Swift compilation. Events with "SwiftCompile" and
   "ObjcCompile" can be in two different categories "local action execution" and
   "Remote execution process wall time". As a result, we are double accounting
   for SwiftComiple and ObjcCompile

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**:
https://github.com/buildbuddy-io/buildbuddy-internal/issues/1831
