### PR TITLE
Use milliseconds for key age metric.

### DIFF
--- a/enterprise/server/crypter_service/crypter_service.go
+++ b/enterprise/server/crypter_service/crypter_service.go
@@ -822,7 +822,7 @@ func (c *Crypter) keyReencryptorIteration(cutoff time.Time) error {
 			// as a precaution.
 			_ = lim.Wait(c.env.GetServerContext())
 			reencryptKey(ekv)
-			metrics.EncryptionKeyLastEncryptedAgeUsec.Observe(float64(time.Since(time.UnixMicro(ekv.LastEncryptedAtUsec)).Microseconds()))
+			metrics.EncryptionKeyLastEncryptedAgeMsec.Observe(float64(time.Since(time.UnixMicro(ekv.LastEncryptedAtUsec)).Milliseconds()))
 		}
 	}
 	return nil

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1809,7 +1809,7 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "encryption",
 		Name:      "key_last_encryption_age_msec",
-		Buckets:   durationUsecBuckets(1*time.Hour, 1*time.Hour*24*7, 4),
+		Buckets:   exponentialBucketRange(float64(1*time.Hour.Milliseconds()), float64(7*24*time.Hour.Milliseconds()), 4),
 		Help:      "Age of encrypted keys (i.e. how long it has been since the keys were re-encrypted).",
 	})
 )

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1803,10 +1803,12 @@ var (
 		Help:      "Total number of decryption errors.",
 	})
 
-	EncryptionKeyLastEncryptedAgeUsec = promauto.NewHistogram(prometheus.HistogramOpts{
+	// This metric is in milliseconds because Grafana heatmaps don't display
+	// microsecond durations nicely when they can contain large durations.
+	EncryptionKeyLastEncryptedAgeMsec = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "encryption",
-		Name:      "key_last_encryption_age_usec",
+		Name:      "key_last_encryption_age_msec",
 		Buckets:   durationUsecBuckets(1*time.Hour, 1*time.Hour*24*7, 4),
 		Help:      "Age of encrypted keys (i.e. how long it has been since the keys were re-encrypted).",
 	})


### PR DESCRIPTION
Unfortunately, Grafana still can't display nice legends for heat maps where the units are in microseconds.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
