### PR TITLE
Mark keyboard-selected invocation with yellow instead of blue

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -438,7 +438,7 @@ svg.icon.orange {
 }
 
 .card.selected-keyboard-shortcuts {
-  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
   border-left: 6px solid #ffd54f;
 }
 

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -438,8 +438,8 @@ svg.icon.orange {
 }
 
 .card.selected-keyboard-shortcuts {
-  box-shadow: 4px 4px 4px #ccc;
-  border-left: 6px solid #039be5;
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  border-left: 6px solid #ffd54f;
 }
 
 .card.card-success {


### PR DESCRIPTION
The blue we use is the same as the one for running invocations, so it's not obvious when you select one that's running. Also updated the box shadow per Siggi's suggestion. Here's how it all looks now:

![Screenshot 2023-05-11 at 3 29 04 PM](https://github.com/buildbuddy-io/buildbuddy/assets/455246/44dffcf0-a7d0-4e4b-9a07-f7b454ab0b54)

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/2244
