### PR TITLE
Add explicit group ID, instance name, and platform hash to snapshot cache key

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -325,7 +325,7 @@ type FirecrackerContainer struct {
 	cancelVmCtx context.CancelFunc
 }
 
-func NewContainer(ctx context.Context, env environment.Env, imageCacheAuth *container.ImageCacheAuthenticator, opts ContainerOpts) (*FirecrackerContainer, error) {
+func NewContainer(ctx context.Context, env environment.Env, imageCacheAuth *container.ImageCacheAuthenticator, task *repb.ExecutionTask, opts ContainerOpts) (*FirecrackerContainer, error) {
 	vmLog, err := NewVMLog(vmLogTailBufSize)
 	if err != nil {
 		return nil, err
@@ -391,7 +391,10 @@ func NewContainer(ctx context.Context, env environment.Env, imageCacheAuth *cont
 	if err != nil {
 		return nil, status.InternalErrorf("failed to marshal VMConfiguration: %s", err)
 	}
-	c.snapshotKey = snaploader.NewKey(cd.GetHash(), c.id)
+	c.snapshotKey, err = snaploader.NewKey(task, cd.GetHash(), c.id)
+	if err != nil {
+		return nil, status.WrapError(err, "failed to compute snapshot key")
+	}
 
 	return c, nil
 }

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_darwin.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_darwin.go
@@ -17,7 +17,7 @@ import (
 
 type FirecrackerContainer struct{}
 
-func NewContainer(ctx context.Context, env environment.Env, imageCacheAuth *container.ImageCacheAuthenticator, opts ContainerOpts) (*FirecrackerContainer, error) {
+func NewContainer(ctx context.Context, env environment.Env, imageCacheAuth *container.ImageCacheAuthenticator, task *repb.ExecutionTask, opts ContainerOpts) (*FirecrackerContainer, error) {
 	c := &FirecrackerContainer{}
 	return c, nil
 }

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -178,7 +178,7 @@ func TestFirecrackerRunSimple(t *testing.T) {
 		JailerRoot:             tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c, err := firecracker.NewContainer(ctx, env, auth, opts)
+	c, err := firecracker.NewContainer(ctx, env, auth, &repb.ExecutionTask{}, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestFirecrackerLifecycle(t *testing.T) {
 		JailerRoot:             tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c, err := firecracker.NewContainer(ctx, env, auth, opts)
+	c, err := firecracker.NewContainer(ctx, env, auth, &repb.ExecutionTask{}, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func TestFirecrackerSnapshotAndResume(t *testing.T) {
 		ScratchDiskSizeMB:      100,
 		JailerRoot:             tempJailerRoot(t),
 	}
-	c, err := firecracker.NewContainer(ctx, env, cacheAuth, opts)
+	c, err := firecracker.NewContainer(ctx, env, cacheAuth, &repb.ExecutionTask{}, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -376,7 +376,7 @@ func TestFirecrackerFileMapping(t *testing.T) {
 		JailerRoot:             tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c, err := firecracker.NewContainer(ctx, env, auth, opts)
+	c, err := firecracker.NewContainer(ctx, env, auth, &repb.ExecutionTask{}, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -468,7 +468,7 @@ func TestFirecrackerRunWithNetwork(t *testing.T) {
 		JailerRoot:             tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c, err := firecracker.NewContainer(ctx, env, auth, opts)
+	c, err := firecracker.NewContainer(ctx, env, auth, &repb.ExecutionTask{}, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -536,7 +536,7 @@ func TestFirecrackerRun_ReapOrphanedZombieProcess(t *testing.T) {
 		JailerRoot:             tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c, err := firecracker.NewContainer(ctx, env, auth, opts)
+	c, err := firecracker.NewContainer(ctx, env, auth, &repb.ExecutionTask{}, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -606,7 +606,7 @@ func TestFirecrackerNonRoot(t *testing.T) {
 		JailerRoot:             tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c, err := firecracker.NewContainer(ctx, env, auth, opts)
+	c, err := firecracker.NewContainer(ctx, env, auth, &repb.ExecutionTask{}, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -639,7 +639,7 @@ func TestFirecrackerRunNOPWithZeroDisk(t *testing.T) {
 		ScratchDiskSizeMB: 0,
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c, err := firecracker.NewContainer(ctx, env, auth, opts)
+	c, err := firecracker.NewContainer(ctx, env, auth, &repb.ExecutionTask{}, opts)
 	require.NoError(t, err)
 
 	// Run will handle the full lifecycle: no need to call Remove() here.
@@ -687,7 +687,7 @@ func TestFirecrackerRunWithDocker(t *testing.T) {
 		JailerRoot:             tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c, err := firecracker.NewContainer(ctx, env, auth, opts)
+	c, err := firecracker.NewContainer(ctx, env, auth, &repb.ExecutionTask{}, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -724,7 +724,7 @@ func TestFirecrackerExecWithRecycledWorkspaceWithNewContents(t *testing.T) {
 		ScratchDiskSizeMB:      2000,
 		JailerRoot:             tempJailerRoot(t),
 	}
-	c, err := firecracker.NewContainer(ctx, env, cacheAuth, opts)
+	c, err := firecracker.NewContainer(ctx, env, cacheAuth, &repb.ExecutionTask{}, opts)
 	require.NoError(t, err)
 	err = container.PullImageIfNecessary(ctx, env, cacheAuth, c, container.PullCredentials{}, opts.ContainerImage)
 	require.NoError(t, err)
@@ -810,7 +810,7 @@ func TestFirecrackerExecWithRecycledWorkspaceWithDocker(t *testing.T) {
 		EnableNetworking:       true,
 		InitDockerd:            true,
 	}
-	c, err := firecracker.NewContainer(ctx, env, cacheAuth, opts)
+	c, err := firecracker.NewContainer(ctx, env, cacheAuth, &repb.ExecutionTask{}, opts)
 	require.NoError(t, err)
 	err = container.PullImageIfNecessary(ctx, env, cacheAuth, c, container.PullCredentials{}, opts.ContainerImage)
 	require.NoError(t, err)
@@ -904,7 +904,7 @@ func TestFirecrackerExecWithDockerFromSnapshot(t *testing.T) {
 		ScratchDiskSizeMB:      1000,
 		JailerRoot:             tempJailerRoot(t),
 	}
-	c, err := firecracker.NewContainer(ctx, env, cacheAuth, opts)
+	c, err := firecracker.NewContainer(ctx, env, cacheAuth, &repb.ExecutionTask{}, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -981,7 +981,7 @@ func TestFirecrackerRun_Timeout_DebugOutputIsAvailable(t *testing.T) {
 		JailerRoot:             tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c, err := firecracker.NewContainer(ctx, env, auth, opts)
+	c, err := firecracker.NewContainer(ctx, env, auth, &repb.ExecutionTask{}, opts)
 	require.NoError(t, err)
 
 	cmd := &repb.Command{Arguments: []string{"sh", "-c", `
@@ -1024,7 +1024,7 @@ func TestFirecrackerExec_Timeout_DebugOutputIsAvailable(t *testing.T) {
 		JailerRoot:             tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c, err := firecracker.NewContainer(ctx, env, auth, opts)
+	c, err := firecracker.NewContainer(ctx, env, auth, &repb.ExecutionTask{}, opts)
 	require.NoError(t, err)
 	err = container.PullImageIfNecessary(ctx, env, auth, c, container.PullCredentials{}, opts.ContainerImage)
 	require.NoError(t, err)
@@ -1075,7 +1075,7 @@ func TestFirecrackerLargeResult(t *testing.T) {
 		JailerRoot:             tempJailerRoot(t),
 	}
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c, err := firecracker.NewContainer(ctx, env, auth, opts)
+	c, err := firecracker.NewContainer(ctx, env, auth, &repb.ExecutionTask{}, opts)
 	require.NoError(t, err)
 	const stdoutSize = 10_000_000
 	cmd := &repb.Command{Arguments: []string{"sh", "-c", fmt.Sprintf(`yes | head -c %d`, stdoutSize)}}

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -1101,7 +1101,7 @@ func (p *pool) newContainerImpl(ctx context.Context, props *platform.Properties,
 			JailerRoot:             p.buildRoot,
 			DebugMode:              *firecrackerDebugMode,
 		}
-		c, err := firecracker.NewContainer(ctx, p.env, p.imageCacheAuth, opts)
+		c, err := firecracker.NewContainer(ctx, p.env, p.imageCacheAuth, task.GetExecutionTask(), opts)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -11,7 +11,9 @@ go_library(
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/environment",
+        "//server/remote_cache/digest",
         "//server/util/hash",
+        "//server/util/perms",
         "//server/util/status",
         "@org_golang_google_protobuf//proto",
     ],
@@ -23,6 +25,7 @@ go_test(
     deps = [
         ":snaploader",
         "//enterprise/server/remote_execution/filecache",
+        "//proto:remote_execution_go_proto",
         "//server/testutil/testenv",
         "//server/testutil/testfs",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/stretchr/testify/require"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
 func TestPackAndUnpack(t *testing.T) {
@@ -32,13 +34,17 @@ func TestPackAndUnpack(t *testing.T) {
 	// keys.
 	loader, err := snaploader.New(env)
 	require.NoError(t, err)
-	keyA := snaploader.NewKey("vm-config-hash-A", "runner-A")
+	taskA := &repb.ExecutionTask{}
+	keyA, err := snaploader.NewKey(taskA, "vm-config-hash-A", "runner-A")
+	require.NoError(t, err)
 	optsA := makeFakeSnapshot(t, workDir)
 	snapA, err := loader.CacheSnapshot(ctx, keyA, optsA)
 	require.NoError(t, err)
 
 	require.NoError(t, err)
-	keyB := snaploader.NewKey("vm-config-hash-B", "runner-B")
+	taskB := &repb.ExecutionTask{}
+	keyB, err := snaploader.NewKey(taskB, "vm-config-hash-B", "runner-B")
+	require.NoError(t, err)
 	optsB := makeFakeSnapshot(t, workDir)
 	snapB, err := loader.CacheSnapshot(ctx, keyB, optsB)
 	require.NoError(t, err)

--- a/enterprise/tools/vmstart/vmstart.go
+++ b/enterprise/tools/vmstart/vmstart.go
@@ -134,7 +134,7 @@ func main() {
 	auth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	// TODO: make snapshotID work again.
 	if *snapshotID != "" {
-		c, err = firecracker.NewContainer(ctx, env, auth, opts)
+		c, err = firecracker.NewContainer(ctx, env, auth, &repb.ExecutionTask{}, opts)
 		if err != nil {
 			log.Fatalf("Error creating container: %s", err)
 		}
@@ -142,7 +142,7 @@ func main() {
 			log.Fatalf("Error loading snapshot: %s", err)
 		}
 	} else {
-		c, err = firecracker.NewContainer(ctx, env, auth, opts)
+		c, err = firecracker.NewContainer(ctx, env, auth, &repb.ExecutionTask{}, opts)
 		if err != nil {
 			log.Fatalf("Error creating container: %s", err)
 		}


### PR DESCRIPTION
Snapshot isolation by group_id, instance_name, and platform hash is currently implicit in the fact that only one `Runner` can use a snapshot at a time, and runners are effectively isolated by group_id, instance_name, and platform_hash.

Eventually we'd like to be able to look up snapshots from cache without needing a pre-existing `Runner` in the runner pool. So this PR is a step towards that goal by making these properties explicit rather than implicit.

**Related issues**: N/A
