### PR TITLE
Make workflows more robust during CAS/Execution latency spikes

### DIFF
--- a/enterprise/server/workflow/service/BUILD
+++ b/enterprise/server/workflow/service/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/tables",
+        "//server/util/alert",
         "//server/util/background",
         "//server/util/bazel_request",
         "//server/util/db",

--- a/enterprise/server/workflow/service/BUILD
+++ b/enterprise/server/workflow/service/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/tables",
+        "//server/util/background",
         "//server/util/bazel_request",
         "//server/util/db",
         "//server/util/git",

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/util/background"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -77,6 +78,16 @@ const (
 	// A workflow ID prefix that identifies a Workflow as being a
 	// "synthetic" workflow adapted from a GitRepository.
 	repoWorkflowIDPrefix = "WF#GitRepository"
+
+	// Number of workers to work on processing webhook events in the background.
+	webhookWorkerCount = 64
+
+	// Max number of webhook payloads to buffer in memory. This is intentionally
+	// large to help deal with spikes in cache write latency.
+	webhookWorkerTaskQueueSize = 2000
+
+	// How long to wait before giving up on processing a webhook payload.
+	webhookWorkerTimeout = 30 * time.Second
 )
 
 // getWebhookID returns a string that can be used to uniquely identify a webhook.
@@ -108,13 +119,83 @@ func instanceName(wf *tables.Workflow, wd *interfaces.WebhookData, workflowActio
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(strings.Join(keys, "|"))))
 }
 
+// startWorkflowTask represents a workflow to be started in the background in
+// response to a webhook event. This is done in the background to avoid timeouts
+// in the HTTP response to the webhook sender, in particular when there are
+// spikes in CAS or Execution service latency.
+type startWorkflowTask struct {
+	ctx         context.Context
+	gitProvider interfaces.GitProvider
+	webhookData *interfaces.WebhookData
+	workflow    *tables.Workflow
+}
+
 type workflowService struct {
 	env environment.Env
+
+	wg    sync.WaitGroup
+	tasks chan *startWorkflowTask
 }
 
 func NewWorkflowService(env environment.Env) *workflowService {
-	return &workflowService{
-		env: env,
+	ws := &workflowService{
+		env:   env,
+		tasks: make(chan *startWorkflowTask, webhookWorkerTaskQueueSize),
+	}
+	ws.startBackgroundWorkers()
+	return ws
+}
+
+func (ws *workflowService) startBackgroundWorkers() {
+	for i := 0; i < webhookWorkerCount; i++ {
+		ws.wg.Add(1)
+		go func() {
+			defer ws.wg.Done()
+
+			for task := range ws.tasks {
+				ws.runStartWorkflowTask(task)
+			}
+		}()
+	}
+	ws.env.GetHealthChecker().RegisterShutdownFunction(func(ctx context.Context) error {
+		// Wait until the HTTP server shuts down to ensure that all in-flight
+		// webhook requests are done being handled and that no further HTTP
+		// webhook requests will come in.
+		ws.env.GetHTTPServerWaitGroup().Wait()
+		// Now that all in-flight HTTP requests have completed, it is safe to
+		// close the tasks channel. Once we do this, the background workers
+		// should exit as soon as they drain and execute the remaining tasks in
+		// the channel.
+		close(ws.tasks)
+		// Wait for all workers to exit.
+		ws.wg.Wait()
+		return nil
+	})
+}
+
+func (ws *workflowService) enqueueStartWorkflowTask(ctx context.Context, gitProvider interfaces.GitProvider, wd *interfaces.WebhookData, wf *tables.Workflow) error {
+	t := &startWorkflowTask{
+		ctx:         ctx,
+		gitProvider: gitProvider,
+		webhookData: wd,
+		workflow:    wf,
+	}
+	select {
+	case ws.tasks <- t:
+		return nil
+	default:
+		return status.ResourceExhaustedError("workflow task queue is full")
+	}
+}
+
+func (ws *workflowService) runStartWorkflowTask(task *startWorkflowTask) {
+	// Keep the existing context values from the client but set a new timeout
+	// since the HTTP request has already completed at this point.
+	ctx, cancel := background.ExtendContextForFinalization(task.ctx, webhookWorkerTimeout)
+	defer cancel()
+
+	if err := ws.startWorkflow(ctx, task.gitProvider, task.webhookData, task.workflow); err != nil {
+		log.Errorf("Failed to start workflow in the background: %s", err)
 	}
 }
 
@@ -1005,7 +1086,7 @@ func (ws *workflowService) HandleRepositoryEvent(ctx context.Context, repo *tabl
 		return err
 	}
 	wf := ws.gitRepositoryWorkflow(repo, accessToken).Workflow
-	return ws.startWorkflow(ctx, provider, wd, wf)
+	return ws.enqueueStartWorkflowTask(ctx, provider, wd, wf)
 }
 
 func (ws *workflowService) startLegacyWorkflow(ctx context.Context, webhookID string, r *http.Request) error {
@@ -1028,7 +1109,7 @@ func (ws *workflowService) startLegacyWorkflow(ctx context.Context, webhookID st
 	if err != nil {
 		return status.WrapErrorf(err, "failed to lookup workflow for webhook ID %q", webhookID)
 	}
-	return ws.startWorkflow(ctx, gitProvider, wd, wf)
+	return ws.enqueueStartWorkflowTask(ctx, gitProvider, wd, wf)
 }
 
 func (ws *workflowService) startWorkflow(ctx context.Context, gitProvider interfaces.GitProvider, wd *interfaces.WebhookData, wf *tables.Workflow) error {
@@ -1064,8 +1145,9 @@ func (ws *workflowService) startWorkflow(ctx context.Context, gitProvider interf
 	if err != nil {
 		return err
 	}
-	var actionsStarted []*config.Action
+	var wg sync.WaitGroup
 	for _, action := range cfg.Actions {
+		action := action
 		if !config.MatchesAnyTrigger(action, wd.EventName, wd.TargetBranch) {
 			jt, _ := json.Marshal(action.Triggers)
 			log.CtxDebugf(ctx, "Action %s not matched, triggers=%s", action.Name, string(jt))
@@ -1076,22 +1158,29 @@ func (ws *workflowService) startWorkflow(ctx context.Context, gitProvider interf
 			return err
 		}
 		invocationID := invocationUUID.String()
-		_, err = ws.executeWorkflow(ctx, apiKey, wf, wd, isTrusted, action, invocationID, nil /*=extraCIRunnerArgs*/)
-		if err != nil {
-			if err == ApprovalRequired {
-				log.CtxInfof(ctx, "Skipping workflow action %s (%s) %q (requires approval)", wf.WorkflowID, wf.RepoURL, action.Name)
-				if err := ws.createApprovalRequiredStatus(ctx, wf, wd, action.Name); err != nil {
-					log.CtxWarningf(ctx, "Failed to create workflow %s (%s) action status: %s", wf.WorkflowID, wf.RepoURL, err)
+
+		// Start executions in parallel to help reduce workflow start latency
+		// for repos with lots of workflow actions.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			_, err = ws.executeWorkflow(ctx, apiKey, wf, wd, isTrusted, action, invocationID, nil /*=extraCIRunnerArgs*/)
+			if err != nil {
+				if err == ApprovalRequired {
+					log.CtxInfof(ctx, "Skipping workflow action %s (%s) %q (requires approval)", wf.WorkflowID, wf.RepoURL, action.Name)
+					if err := ws.createApprovalRequiredStatus(ctx, wf, wd, action.Name); err != nil {
+						log.CtxWarningf(ctx, "Failed to create workflow %s (%s) action status: %s", wf.WorkflowID, wf.RepoURL, err)
+					}
+					return
 				}
-				continue
+				// TODO: Create a UI for these errors instead of just logging on the
+				// server.
+				log.CtxWarningf(ctx, "Failed to execute workflow %s (%s) action %q: %s", wf.WorkflowID, wf.RepoURL, action.Name, err)
 			}
-			// TODO: Create a UI for these errors instead of just logging on the
-			// server.
-			log.CtxWarningf(ctx, "Failed to execute workflow %s (%s) action %q: %s", wf.WorkflowID, wf.RepoURL, action.Name, err)
-		}
-		actionsStarted = append(actionsStarted, action)
+		}()
 	}
-	log.CtxInfof(ctx, "Started %d workflow action(s)", len(actionsStarted))
+	wg.Wait()
 	return nil
 }
 

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -3,6 +3,7 @@ package environment
 import (
 	"context"
 	"io/fs"
+	"sync"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/go-redis/redis/v8"
@@ -112,6 +113,7 @@ type Env interface {
 	GetFileResolver() fs.FS
 	GetMux() interfaces.HttpServeMux
 	SetMux(interfaces.HttpServeMux)
+	GetHTTPServerWaitGroup() *sync.WaitGroup
 	GetInternalHTTPMux() interfaces.HttpServeMux
 	SetInternalHTTPMux(mux interfaces.HttpServeMux)
 	GetListenAddr() string

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -395,7 +395,9 @@ func StartAndRunServices(env environment.Env) {
 		Handler: env.GetMux(),
 	}
 
+	env.GetHTTPServerWaitGroup().Add(1)
 	env.GetHealthChecker().RegisterShutdownFunction(func(ctx context.Context) error {
+		defer env.GetHTTPServerWaitGroup().Done()
 		err := server.Shutdown(ctx)
 		return err
 	})

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -3,6 +3,7 @@ package real_environment
 import (
 	"context"
 	"io/fs"
+	"sync"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -83,6 +84,7 @@ type RealEnv struct {
 	fileResolver                     fs.FS
 	internalHTTPMux                  interfaces.HttpServeMux
 	mux                              interfaces.HttpServeMux
+	httpServerWaitGroup              *sync.WaitGroup
 	listenAddr                       string
 	buildbuddyServer                 interfaces.BuildBuddyServer
 	sslService                       interfaces.SSLService
@@ -110,9 +112,10 @@ type RealEnv struct {
 
 func NewRealEnv(h interfaces.HealthChecker) *RealEnv {
 	return &RealEnv{
-		healthChecker:    h,
-		serverContext:    context.Background(),
-		executionClients: make(map[string]*executionClientConfig, 0),
+		healthChecker:       h,
+		serverContext:       context.Background(),
+		executionClients:    make(map[string]*executionClientConfig, 0),
+		httpServerWaitGroup: &sync.WaitGroup{},
 	}
 }
 
@@ -422,6 +425,10 @@ func (r *RealEnv) GetMux() interfaces.HttpServeMux {
 
 func (r *RealEnv) SetMux(mux interfaces.HttpServeMux) {
 	r.mux = mux
+}
+
+func (r *RealEnv) GetHTTPServerWaitGroup() *sync.WaitGroup {
+	return r.httpServerWaitGroup
 }
 
 func (r *RealEnv) GetInternalHTTPMux() interfaces.HttpServeMux {


### PR DESCRIPTION
(1) Process webhook requests in the background so that we can immediately respond to GitHub's HTTP request instead of potentially timing out waiting for CAS writes / Execute requests.

(2) Start workflow actions in parallel. This should reduce the overall workflow start latency in the case where a repo has many actions (rules_xcodeproj for example has 15 actions), especially in the case where there is a spike in CAS write latency / Execution service latency. For example, if CAS writes are taking 1s and there are 15 workflow actions, then starting the actions in serial means that the last action will be artificially delayed by 14s.

**Related issues**: N/A
