### PR TITLE
Ensure outer workflow invocation gets disconnected on LOCAL_ENVIRONMENTAL_ERROR

### DIFF
--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -20,6 +20,7 @@ go_test(
     deps = [
         "//proto:eventlog_go_proto",
         "//proto:invocation_go_proto",
+        "//proto:invocation_status_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/remote_cache/cachetools",
         "//server/testutil/app",

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
@@ -26,6 +27,7 @@ import (
 	bazelgo "github.com/bazelbuild/rules_go/go/tools/bazel"
 	elpb "github.com/buildbuddy-io/buildbuddy/proto/eventlog"
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
+	inspb "github.com/buildbuddy-io/buildbuddy/proto/invocation_status"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
@@ -113,6 +115,21 @@ actions:
 `,
 	}
 
+	workspaceContentsWithLocalEnvironmentalErrorAction = map[string]string{
+		"WORKSPACE": `workspace(name = "test")`,
+		"BUILD":     `sh_binary(name = "exit", srcs = ["exit.sh"])`,
+		"exit.sh":   `exit "$1"`,
+		"buildbuddy.yaml": `
+actions:
+  - name: "Exit 36"
+    triggers:
+      pull_request: { branches: [ master ] }
+      push: { branches: [ master ] }
+    bazel_commands:
+      - run :exit -- 36
+`,
+	}
+
 	invocationIDPattern = regexp.MustCompile(`Invocation URL:\s+.*?/invocation/([a-f0-9-]+)`)
 )
 
@@ -122,8 +139,12 @@ type result struct {
 	// InvocationIDs are the invocation IDs parsed from the output.
 	// There should be one invocation ID for each action.
 	InvocationIDs []string
-	// ExitCode is the exit code of the runner itself.
+	// ExitCode is the exit code of the runner itself, or -1 if the runner was
+	// terminated by a signal.
 	ExitCode int
+	// Signal is the signal that terminated the runner, or -1 if the runner
+	// exited.
+	Signal syscall.Signal
 }
 
 func invokeRunner(t *testing.T, args []string, env []string, workDir string) *result {
@@ -144,15 +165,24 @@ func invokeRunner(t *testing.T, args []string, env []string, workDir string) *re
 	cmd.Dir = workDir
 	cmd.Env = env
 	outputBytes, err := cmd.CombinedOutput()
-	exitCode := 0
+	exitCode := -1
+	signal := syscall.Signal(-1)
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
+			ws := exitErr.Sys().(syscall.WaitStatus)
+			if ws.Exited() {
+				exitCode = ws.ExitStatus()
+			} else {
+				signal = ws.Signal()
+			}
 		} else {
 			t.Fatal(err)
 		}
+	} else {
+		exitCode = 0
 	}
 	output := string(outputBytes)
+	t.Log(output)
 
 	invocationIDs := []string{}
 	iidMatches := invocationIDPattern.FindAllStringSubmatch(output, -1)
@@ -164,6 +194,7 @@ func invokeRunner(t *testing.T, args []string, env []string, workDir string) *re
 	return &result{
 		Output:        output,
 		ExitCode:      exitCode,
+		Signal:        signal,
 		InvocationIDs: invocationIDs,
 	}
 }
@@ -794,4 +825,31 @@ func TestHostedBazel_ApplyingAndDiscardingPatches(t *testing.T) {
 			t.Log(runnerInvocation.ConsoleBuffer)
 		}
 	}
+}
+
+func TestLocalEnvironmentalError(t *testing.T) {
+	wsPath := testfs.MakeTempDir(t)
+	repoPath, headCommitSHA := makeGitRepo(t, workspaceContentsWithLocalEnvironmentalErrorAction)
+	runnerFlags := []string{
+		"--workflow_id=test-workflow",
+		"--action_name=Exit 36",
+		"--trigger_event=push",
+		"--pushed_repo_url=file://" + repoPath,
+		"--pushed_branch=master",
+		"--commit_sha=" + headCommitSHA,
+		"--target_repo_url=file://" + repoPath,
+		"--target_branch=master",
+	}
+	// Start the app so the runner can use it as the BES backend.
+	app := buildbuddy.Run(t)
+	runnerFlags = append(runnerFlags, app.BESBazelFlags()...)
+
+	result := invokeRunner(t, runnerFlags, nil, wsPath)
+
+	require.Equal(t, syscall.SIGKILL, result.Signal, "runner process should have signaled its own PID with SIGKILL")
+	runnerInvocation := singleInvocation(t, app, result)
+	require.NotEqual(
+		t, inspb.InvocationStatus_COMPLETE_INVOCATION_STATUS,
+		runnerInvocation.GetInvocationStatus(),
+		"runner invocation status not be COMPLETE_INVOCATION_STATUS")
 }


### PR DESCRIPTION
The previous code allowed the workflow invocation to cleanly terminate, which prevents it from being retried.

**Related issues**: N/A
