### PR TITLE
fix bad falsey check for 'tags are unsupported' warning on execution drilldowns.

### DIFF
--- a/enterprise/app/trends/drilldown_page.tsx
+++ b/enterprise/app/trends/drilldown_page.tsx
@@ -422,7 +422,7 @@ export default class DrilldownPageComponent extends React.Component<Props, State
     const isExecution = isExecutionMetric(heatmapRequest.metric);
 
     // TODO(jdhollen): Support tags on executions.
-    if (isExecution && filterParams.tags && filterParams.tags.length > 0) {
+    if (isExecution && filterParams.tags?.length > 0) {
       this.setState({ unsupported: true });
     }
 

--- a/enterprise/app/trends/drilldown_page.tsx
+++ b/enterprise/app/trends/drilldown_page.tsx
@@ -422,7 +422,7 @@ export default class DrilldownPageComponent extends React.Component<Props, State
     const isExecution = isExecutionMetric(heatmapRequest.metric);
 
     // TODO(jdhollen): Support tags on executions.
-    if (isExecution && filterParams.tags?.length > 0) {
+    if (isExecution && filterParams.tags && filterParams.tags.length > 0) {
       this.setState({ unsupported: true });
     }
 

--- a/enterprise/app/trends/drilldown_page.tsx
+++ b/enterprise/app/trends/drilldown_page.tsx
@@ -422,7 +422,7 @@ export default class DrilldownPageComponent extends React.Component<Props, State
     const isExecution = isExecutionMetric(heatmapRequest.metric);
 
     // TODO(jdhollen): Support tags on executions.
-    if (isExecution && filterParams.tags) {
+    if (isExecution && filterParams.tags && filterParams.tags.length > 0) {
       this.setState({ unsupported: true });
     }
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
oops, this bar is always showing right now.  hasn't made a cut yet.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
