### PR TITLE
Clean up protolet debug message

### DIFF
--- a/server/http/protolet/BUILD
+++ b/server/http/protolet/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/http/protolet",
     visibility = ["//visibility:public"],
     deps = [
-        "//server/util/log",
         "//server/util/request_context",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_google_protobuf//encoding/protojson",

--- a/server/http/protolet/protolet.go
+++ b/server/http/protolet/protolet.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"reflect"
 
-	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/request_context"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -115,7 +114,6 @@ func GenerateHTTPHandlers(server interface{}) (*HTTPHandlers, error) {
 			continue
 		}
 		handlerFns[method.Name] = method.Func
-		log.Debugf("Auto-registered HTTP handler for %s", method.Name)
 	}
 
 	bodyParserMiddleware := func(next http.Handler) http.Handler {


### PR DESCRIPTION
protolet is pretty stable and well-tested so these log messages aren't needed anymore (they add lots of noise when running tests)

**Related issues**: N/A
