### PR TITLE
scheduler_server: rm remove_stale_executors flag for good

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -43,9 +43,6 @@ var (
 	defaultPoolName              = flag.String("remote_execution.default_pool_name", "", "The default executor pool to use if one is not specified.")
 	sharedExecutorPoolGroupID    = flag.String("remote_execution.shared_executor_pool_group_id", "", "Group ID that owns the shared executor pool.")
 	requireExecutorAuthorization = flag.Bool("remote_execution.require_executor_authorization", false, "If true, executors connecting to this server must provide a valid executor API key.")
-
-	// TODO(sluongng): remove this flag once we have released a new BuildBuddy version.
-	removeStaleExecutors = flag.Bool("remote_execution.remove_stale_executors", true, "If true, executors are removed if they are not heard from for a prolonged amount of time.")
 )
 
 const (
@@ -543,7 +540,7 @@ func (np *nodePool) fetchExecutionNodes(ctx context.Context) ([]*executionNode, 
 			return nil, err
 		}
 
-		if *removeStaleExecutors && time.Since(node.GetLastPingTime().AsTime()) > executorMaxRegistrationStaleness {
+		if time.Since(node.GetLastPingTime().AsTime()) > executorMaxRegistrationStaleness {
 			log.Infof("Removing stale executor %q from pool %+v", id, np.key)
 			if err := np.rdb.HDel(ctx, np.key.redisPoolKey(), id).Err(); err != nil {
 				log.Warningf("could not remove stale executor: %s", err)
@@ -1009,7 +1006,6 @@ func (s *SchedulerServer) AddConnectedExecutor(ctx context.Context, handle *exec
 		}
 	}()
 	return nil
-
 }
 
 func (s *SchedulerServer) redisKeyForExecutorPools(groupID string) string {


### PR DESCRIPTION
This flag has been flipped to default true in #3859.
Let's remove it entirely since turning it off would cause more problems.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/pull/2278
