### PR TITLE
Fix BES error when bazel doesn't receive all ACKs

### DIFF
--- a/cli/devnull/devnull.go
+++ b/cli/devnull/devnull.go
@@ -22,6 +22,9 @@ func (c *nullEventChannel) HandleEvent(event *pepb.PublishBuildToolEventStreamRe
 func (c *nullEventChannel) GetNumDroppedEvents() uint64 {
 	return 0
 }
+func (c *nullEventChannel) GetInitialSequenceNumber() int64 {
+	return 1
+}
 func (c *nullEventChannel) Close() {}
 
 func (c *nullEventChannel) Context() context.Context {

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -80,6 +80,10 @@ const (
 
 	// Exit code in Finished event indicating that the build was interrupted (i.e. killed by user).
 	InterruptedExitCode = 8
+
+	// First sequence number that we expect to see in the ordered build event
+	// stream.
+	firstExpectedSequenceNumber = 1
 )
 
 var (
@@ -683,6 +687,7 @@ type EventChannel struct {
 	bufferedEvents                   []*inpb.InvocationEvent
 	unprocessedStartingEvents        map[string]struct{}
 	numDroppedEventsBeforeProcessing uint64
+	initialSequenceNumber            int64
 	hasReceivedEventWithOptions      bool
 	hasReceivedStartedEvent          bool
 	logWriter                        *eventlog.EventLogWriter
@@ -838,6 +843,26 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 	seqNo := event.OrderedBuildEvent.SequenceNumber
 	streamID := event.OrderedBuildEvent.StreamId
 	iid := streamID.InvocationId
+
+	if e.initialSequenceNumber == 0 {
+		e.initialSequenceNumber = seqNo
+	}
+	// We only allow initial sequence numbers greater than one in the case where
+	// Bazel failed to receive all of our ACKs after we finalized an invocation
+	// (marking it complete). In that case we just void the channel and ACK all
+	// events without doing any work. Otherwise, we treat it as a client error.
+	if e.initialSequenceNumber > firstExpectedSequenceNumber {
+		in, err := e.env.GetInvocationDB().LookupInvocation(e.ctx, iid)
+		if err != nil {
+			return status.WrapErrorf(err, "build event had unexpected initial sequence number %d, and failed to look up existing invocation", seqNo)
+		}
+		if in.InvocationStatus == int64(inspb.InvocationStatus_COMPLETE_INVOCATION_STATUS) {
+			log.Infof("Voiding EventChannel for invocation %s: invocation is already finalized", iid)
+			e.isVoid = true
+			return nil
+		}
+		return status.InvalidArgumentErrorf("received initial sequence number %d for build event stream retry of incomplete invocation, but expected sequence number %d", seqNo, firstExpectedSequenceNumber)
+	}
 
 	if isFinalEvent(event.OrderedBuildEvent) {
 		return nil
@@ -1145,6 +1170,10 @@ func (e *EventChannel) writeBuildMetadata(ctx context.Context, invocationID stri
 
 func (e *EventChannel) GetNumDroppedEvents() uint64 {
 	return e.numDroppedEventsBeforeProcessing
+}
+
+func (e *EventChannel) GetInitialSequenceNumber() int64 {
+	return e.initialSequenceNumber
 }
 
 func extractOptions(event *build_event_stream.BuildEvent) (string, error) {

--- a/server/build_event_protocol/build_event_handler/build_event_handler_test.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler_test.go
@@ -532,7 +532,7 @@ func TestHandleEventWithUsageTracking(t *testing.T) {
 	channel := handler.OpenChannel(ctx, testInvocationID)
 
 	// Send started event with api key
-	request := streamRequest(startedEvent("--remote_header='"+testauth.APIKeyHeader+"=USER1' --should_be_redacted=USER1"), testInvocationID, 2)
+	request := streamRequest(startedEvent("--remote_header='"+testauth.APIKeyHeader+"=USER1' --should_be_redacted=USER1"), testInvocationID, 1)
 	err = channel.HandleEvent(request)
 	assert.NoError(t, err)
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -191,6 +191,7 @@ type BuildEventChannel interface {
 	FinalizeInvocation(iid string) error
 	HandleEvent(event *pepb.PublishBuildToolEventStreamRequest) error
 	GetNumDroppedEvents() uint64
+	GetInitialSequenceNumber() int64
 	Close()
 }
 


### PR DESCRIPTION
If Bazel doesn't receive all the ACKs that we send after finalizing the invocation, Bazel will attempt to retry the invocation starting from the last ACK'd sequence number, plus one.

In this case, we currently return an error due to a sequence number mismatch. This PR makes it so that we just re-ACK all the events that Bazel thinks it needed to re-send, without doing any additional work.

**Related issues**: #3980
