### PR TITLE
Use Link component for invocation cards

### DIFF
--- a/enterprise/app/history/BUILD
+++ b/enterprise/app/history/BUILD
@@ -41,6 +41,7 @@ ts_library(
     name = "history_invocation_card",
     srcs = ["history_invocation_card.tsx"],
     deps = [
+        "//app/components/link",
         "//app/format",
         "//app/router",
         "//proto:invocation_status_ts_proto",

--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -666,24 +666,14 @@ export default class HistoryComponent extends React.Component<Props, State> {
         {Boolean(this.state.invocations?.length || this.state.aggregateStats?.length) && (
           <div className="container nopadding-dense">
             {this.state.invocations?.map((invocation) => (
-              <a
-                href={`/invocation/${invocation.invocationId}`}
-                onClick={(e) => {
-                  // TODO(siggisim): Switch this to using the <Link> component
-                  if (e.metaKey || e.ctrlKey) {
-                    return;
-                  }
-                  e.preventDefault();
-                }}>
-                <HistoryInvocationCardComponent
-                  className={this.state.hoveredInvocationId == invocation.invocationId ? "card-hovered" : ""}
-                  onMouseOver={this.handleMouseOver.bind(this, invocation)}
-                  onMouseOut={this.handleMouseOut.bind(this, invocation)}
-                  invocation={invocation}
-                  isSelectedForCompare={invocation.invocationId === this.state.invocationIdToCompare}
-                  isSelectedWithKeyboard={invocation.invocationId === this.state.selectedInvocationId}
-                />
-              </a>
+              <HistoryInvocationCardComponent
+                className={this.state.hoveredInvocationId == invocation.invocationId ? "card-hovered" : ""}
+                onMouseOver={this.handleMouseOver.bind(this, invocation)}
+                onMouseOut={this.handleMouseOut.bind(this, invocation)}
+                invocation={invocation}
+                isSelectedForCompare={invocation.invocationId === this.state.invocationIdToCompare}
+                isSelectedWithKeyboard={invocation.invocationId === this.state.selectedInvocationId}
+              />
             ))}
             {this.state.pageToken && (
               <button

--- a/enterprise/app/history/history_invocation_card.tsx
+++ b/enterprise/app/history/history_invocation_card.tsx
@@ -16,6 +16,7 @@ import {
 import React from "react";
 import format from "../../../app/format/format";
 import router from "../../../app/router/router";
+import Link from "../../../app/components/link/link";
 import { invocation } from "../../../proto/invocation_ts_proto";
 import { invocation_status } from "../../../proto/invocation_status_ts_proto";
 
@@ -56,14 +57,6 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
 
   componentWillUnmount() {
     window.clearInterval(this.interval);
-  }
-
-  handleInvocationClicked(e: any) {
-    // TODO(siggisim): Switch this to using the <Link> component
-    if (e.metaKey || e.ctrlKey) {
-      return;
-    }
-    router.navigateToInvocation(this.props.invocation.invocationId);
   }
 
   // Beware, this method isn't bound to this - so don't use any this. stuff. Event propagation is a nightmare.
@@ -189,9 +182,9 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
     const tags = (this.props.invocation.tags || []).map((t) => t.name).join(", ");
 
     return (
-      <div
+      <Link
         key={this.props.invocation.invocationId}
-        onClick={this.handleInvocationClicked.bind(this, event)}
+        href={`/invocation/${this.props.invocation.invocationId}`}
         onMouseOver={this.props.onMouseOver}
         onMouseOut={this.props.onMouseOut}
         className={`clickable card history-invocation-card
@@ -293,7 +286,7 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
             )}
           </div>
         </div>
-      </div>
+      </Link>
     );
   }
 }


### PR DESCRIPTION
The `preventDefault()` was causing issues for keyboard navigation (pressing enter while an invocation card is focused)

The styling still looks good:

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/7bd1f419-99c0-4427-bfed-cb97ea2225ef)

**Related issues**: N/A
