### PR TITLE
Don't render random floating `0` if there are no invocations in an org

### DIFF
--- a/app/invocation/invocation_cache_card.tsx
+++ b/app/invocation/invocation_cache_card.tsx
@@ -26,7 +26,7 @@ export default class CacheCardComponent extends React.Component<Props> {
           {!hasCacheStats && (
             <div className="no-cache-stats">Cache stats only available when using BuildBuddy cache.</div>
           )}
-          {this.props.model.cacheStats.length && (
+          {Boolean(this.props.model.cacheStats.length) && (
             <div className="details">
               {hasCacheStats && !this.props.model.hasCacheWriteCapability() && (
                 <div className="cache-details">

--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -640,7 +640,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
               </div>
             )}
           </div>
-          {this.state.invocations?.length && (
+          {this.state.invocations?.length > 0 && (
             <div className="container nopadding-dense">
               <div className={`grid ${this.state.invocations.length < 20 ? "grid-grow" : ""}`}>
                 {this.state.invocations.map((invocation) => (

--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -640,7 +640,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
               </div>
             )}
           </div>
-          {this.state.invocations?.length > 0 && (
+          {Boolean(this.state.invocations?.length) && (
             <div className="container nopadding-dense">
               <div className={`grid ${this.state.invocations.length < 20 ? "grid-grow" : ""}`}>
                 {this.state.invocations.map((invocation) => (

--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -640,7 +640,7 @@ export default class HistoryComponent extends React.Component<Props, State> {
               </div>
             )}
           </div>
-          {Boolean(this.state.invocations?.length) && (
+          {this.state.invocations && this.state.invocations.length > 0 && (
             <div className="container nopadding-dense">
               <div className={`grid ${this.state.invocations.length < 20 ? "grid-grow" : ""}`}>
                 {this.state.invocations.map((invocation) => (


### PR DESCRIPTION
Example (I've done this a million times myself on accident):
<img width="1074" alt="Screenshot 2023-05-17 at 1 55 09 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/1b1d3797-46f5-42f3-bbec-3027c7c3c9d3">
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
