### PR TITLE
coerce data to boolean in a way that makes strict mode happy.

### DIFF
--- a/app/target/target_test_cases_card.tsx
+++ b/app/target/target_test_cases_card.tsx
@@ -92,7 +92,7 @@ export default class TargetTestCasesCardComponent extends React.Component<Props>
                           <div className="test-case-message">
                             {child.getAttribute("message")} {child.getAttribute("type")}
                           </div>
-                          {Boolean(child.textContent?.trim()) && (
+                          {!!child.textContent?.trim() && (
                             <TerminalComponent
                               value={child.textContent
                                 .replaceAll(`�[`, `\u001b[`)

--- a/app/target/target_test_cases_card.tsx
+++ b/app/target/target_test_cases_card.tsx
@@ -92,7 +92,7 @@ export default class TargetTestCasesCardComponent extends React.Component<Props>
                           <div className="test-case-message">
                             {child.getAttribute("message")} {child.getAttribute("type")}
                           </div>
-                          {child.textContent?.trim() && (
+                          {Boolean(child.textContent?.trim()) && (
                             <TerminalComponent
                               value={child.textContent
                                 .replaceAll(`�[`, `\u001b[`)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
strict mode doesn't like `Boolean(foo?.bar)`, seemingly because it worries that calling `Boolean` might modify `foo` to `null`.

also, note that this one was probably fine, but i'd rather keep emitting nothing instead of `""`
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
