### PR TITLE
render cache savings on invocations card when trends summary is enabled.

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -68,6 +68,7 @@ ts_library(
         "//app/components/tooltip",
         "//app/errors:error_service",
         "//app/format",
+        "//app/invocation:invocation_execution_util",
         "//app/invocation:invocation_model",
         "//app/router",
         "//app/service:rpc_service",

--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -59,6 +59,7 @@ ts_library(
     srcs = ["cache_requests_card.tsx"],
     strict = False,
     deps = [
+        "//app/capabilities",
         "//app/components/button",
         "//app/components/digest",
         "//app/components/filter_input",
@@ -78,6 +79,7 @@ ts_library(
         "//proto:field_mask_ts_proto",
         "//proto:invocation_status_ts_proto",
         "//proto:resource_ts_proto",
+        "//proto:timestamp_ts_proto",
         "@npm//@types/react",
         "@npm//lucide-react",
         "@npm//react",
@@ -206,6 +208,7 @@ ts_library(
     name = "invocation_cache_card",
     srcs = ["invocation_cache_card.tsx"],
     deps = [
+        "//app/capabilities",
         "//app/format",
         "//app/invocation:invocation_model",
         "@npm//@types/react",

--- a/app/invocation/cache_requests_card.tsx
+++ b/app/invocation/cache_requests_card.tsx
@@ -15,7 +15,6 @@ import Button, { OutlinedButton } from "../components/button/button";
 import Spinner from "../components/spinner/spinner";
 import Select, { Option } from "../components/select/select";
 import { FilterInput } from "../components/filter_input/filter_input";
-
 import * as format from "../format/format";
 import * as proto from "../util/proto";
 import { google as google_field_mask } from "../../proto/field_mask_ts_proto";

--- a/app/invocation/cache_requests_card.tsx
+++ b/app/invocation/cache_requests_card.tsx
@@ -3,6 +3,7 @@ import router from "../router/router";
 import InvocationModel from "./invocation_model";
 import { X, ArrowUp, ArrowDown, ArrowLeftRight, ChevronRight, Check, SortAsc, SortDesc } from "lucide-react";
 import { cache } from "../../proto/cache_ts_proto";
+import { google as google_ts } from "../../proto/timestamp_ts_proto";
 import { invocation_status } from "../../proto/invocation_status_ts_proto";
 import { resource } from "../../proto/resource_ts_proto";
 import rpc_service from "../service/rpc_service";
@@ -14,11 +15,14 @@ import Button, { OutlinedButton } from "../components/button/button";
 import Spinner from "../components/spinner/spinner";
 import Select, { Option } from "../components/select/select";
 import { FilterInput } from "../components/filter_input/filter_input";
+
 import * as format from "../format/format";
 import * as proto from "../util/proto";
 import { google as google_field_mask } from "../../proto/field_mask_ts_proto";
 import { pinBottomMiddleToMouse, Tooltip } from "../components/tooltip/tooltip";
 import { BuildBuddyError } from "../util/errors";
+import { subtractTimestamp } from "./invocation_execution_util";
+import capabilities from "../capabilities/capabilities";
 
 export interface CacheRequestsCardProps {
   model: InvocationModel;
@@ -181,6 +185,26 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
 
   private getActionUrl(digestHash: string) {
     return `/invocation/${this.props.model.getId()}?actionDigest=${digestHash}#action`;
+  }
+
+  private hasSavingsData(result: cache.ScoreCard.IResult): boolean {
+    return Boolean(result.executionStartTimestamp && result.executionCompletedTimestamp);
+  }
+
+  private renderSavingsString(result: cache.ScoreCard.IResult, compact: boolean = true) {
+    if (!this.hasSavingsData(result)) {
+      return "--";
+    }
+    const timestampUsec = subtractTimestamp(result.executionCompletedTimestamp!, result.executionStartTimestamp!);
+    if (compact) {
+      return format.compactDurationMillis(timestampUsec / 1000);
+    } else {
+      return format.durationUsec(timestampUsec);
+    }
+  }
+
+  private renderSavingsColumn(result: cache.ScoreCard.IResult) {
+    return <div className="duration-column">{this.renderSavingsString(result)}</div>;
   }
 
   private renderWaterfallBar(
@@ -373,6 +397,7 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
           </div>
         )}
         <div className="duration-column">{format.compactDurationMillis(proto.durationToMillis(result.duration))}</div>
+        {capabilities.config.trendsSummaryEnabled && this.renderSavingsColumn(result)}
         {this.renderWaterfallBar(result, startTimeMillis, durationMillis)}
       </Tooltip>
     ));
@@ -475,6 +500,12 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
         </>
         <>
           <b>Duration</b> <span>{format.durationMillis(proto.durationToMillis(result.duration))}</span>
+          {capabilities.config.trendsSummaryEnabled && this.hasSavingsData(result) && (
+            <>
+              <b>CPU saved by cache hit</b>
+              <span>{this.renderSavingsString(result, false)}</span>
+            </>
+          )}
         </>
         {lastAccessed ? (
           <>
@@ -543,6 +574,7 @@ export default class CacheRequestsCardComponent extends React.Component<CacheReq
             <div className="digest-column">Digest (hash/size)</div>
             {this.isCompressedSizeColumnVisible() && <div className="compressed-size-column">Compression</div>}
             <div className="duration-column">Duration</div>
+            {capabilities.config.trendsSummaryEnabled && <div className="duration-column">Savings</div>}
             <div className="waterfall-column">Waterfall</div>
           </div>
           {groups === null && (

--- a/app/invocation/invocation_cache_card.tsx
+++ b/app/invocation/invocation_cache_card.tsx
@@ -3,6 +3,7 @@ import InvocationModel from "./invocation_model";
 import format from "../format/format";
 import { PieChart as PieChartIcon, AlertCircle as AlertCircleIcon } from "lucide-react";
 import { ResponsiveContainer, PieChart, Pie, Cell } from "recharts";
+import capabilities from "../capabilities/capabilities";
 
 interface Props {
   model: InvocationModel;
@@ -35,8 +36,13 @@ export default class CacheCardComponent extends React.Component<Props> {
                 </div>
               )}
               {this.props.model.cacheStats.map((cacheStat) => {
-                let downloadThroughput = BITS_PER_BYTE * (+cacheStat.downloadThroughputBytesPerSecond / 1000000);
-                let uploadThroughput = BITS_PER_BYTE * (+cacheStat.uploadThroughputBytesPerSecond / 1000000);
+                const downloadThroughput = BITS_PER_BYTE * (+cacheStat.downloadThroughputBytesPerSecond / 1000000);
+                const uploadThroughput = BITS_PER_BYTE * (+cacheStat.uploadThroughputBytesPerSecond / 1000000);
+
+                const renderExecTime =
+                  +cacheStat.totalCachedActionExecUsec > 0 || +cacheStat.totalUncachedActionExecUsec > 0;
+                const cachedExecTime = format.durationUsec(cacheStat.totalCachedActionExecUsec);
+                const uncachedExecTime = format.durationUsec(cacheStat.totalUncachedActionExecUsec);
                 return (
                   <div debug-id="cache-sections" className="cache-sections">
                     <div className="cache-section">
@@ -119,6 +125,30 @@ export default class CacheCardComponent extends React.Component<Props> {
                         </div>
                       </div>
                     </div>
+                    {capabilities.config.trendsSummaryEnabled && renderExecTime && (
+                      <div className="cache-section">
+                        <div className="cache-title">CPU savings</div>
+                        <div className="cache-subtitle">Theoretical and actual CPU used</div>
+                        <div className="cache-chart">
+                          {this.drawChart(
+                            +cacheStat.totalCachedActionExecUsec,
+                            "#4CAF50",
+                            +cacheStat.totalUncachedActionExecUsec,
+                            "#f44336"
+                          )}
+                          <div>
+                            <div className="cache-chart-label">
+                              <span className="color-swatch cache-hit-color-swatch"></span>
+                              <span className="cache-stat">{cachedExecTime}</span> not executed
+                            </div>
+                            <div className="cache-chart-label">
+                              <span className="color-swatch cache-miss-color-swatch"></span>
+                              <span className="cache-stat">{uncachedExecTime}</span> executed
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    )}
                   </div>
                 );
               })}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
more sending this out for opinions on the text and positioning of this content on the page, because there are a lot of options.  the stuff i have now is a placeholder more than anything.

It currently looks like... this: 
![image](https://github.com/buildbuddy-io/buildbuddy/assets/10570856/1449a9bf-f17d-4249-8ea1-d175d6555e8d)

and... this:
![image](https://github.com/buildbuddy-io/buildbuddy/assets/10570856/7ed2fac0-c445-4a6f-8ae3-6d5ca41fd4d2)

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
