### PR TITLE
Return MissingDigestError for missing tree root as well

### DIFF
--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -1523,7 +1523,7 @@ func TestCommandWithMissingInputRootDigest(t *testing.T) {
 	}, &rbetest.ExecuteOpts{SimulateMissingDigest: true})
 	err := cmd.MustFailToStart()
 
-	require.Contains(t, err.Error(), "not found in cache")
+	require.True(t, status.IsFailedPreconditionError(err))
 	taskCount := testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount)
 	// NotFound errors should not be retried by the scheduler, since this test
 	// is simulating a bazel task, and bazel will retry on its own.

--- a/server/remote_cache/content_addressable_storage_server/BUILD
+++ b/server/remote_cache/content_addressable_storage_server/BUILD
@@ -55,7 +55,9 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@go_googleapis//google/bytestream:bytestream_go_proto",
+        "@go_googleapis//google/rpc:errdetails_go_proto",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -482,6 +482,9 @@ func (s *ContentAddressableStorageServer) fetchDir(ctx context.Context, dirName 
 	// Fetch the "Directory" object which enumerates all the blobs in the directory
 	blob, err := s.cache.Get(ctx, dirName.ToProto())
 	if err != nil {
+		if status.IsNotFoundError(err) {
+			return nil, digest.MissingDigestError(dirName.GetDigest())
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
We already return MissingDigest errors for files in the tree, but were not correctly returning this error if the root of the tree is missing.