### PR TITLE
CLI: support `.concat()` on builtins in js BUILD files

### DIFF
--- a/cli/translate/js/js_test.go
+++ b/cli/translate/js/js_test.go
@@ -21,7 +21,7 @@ ts_library({
 
 ts_library({
   name: "alert_service",
-  srcs: ["alert_service.ts"],
+  srcs: glob(["*.ts"]).concat(["alert_service.ts"]),
   strict: true,
   deps: ["@npm//rxjs"],
   foo: DEFAULT_LANGUAGES,
@@ -56,7 +56,7 @@ package(default_visibility = ["//visibility:public"])
 
 ts_library(name = "alert", srcs = ["alert.tsx"], strict = True, deps = sorted(["//app/alert:alert_service", "//app/components/banner", "@npm//@types/react", "@npm//react", "@npm//rxjs"]))
 
-ts_library(name = "alert_service", srcs = ["alert_service.ts"], strict = True, deps = ["@npm//rxjs"], foo = DEFAULT_LANGUAGES)
+ts_library(name = "alert_service", srcs = glob(["*.ts"]) + ["alert_service.ts"], strict = True, deps = ["@npm//rxjs"], foo = DEFAULT_LANGUAGES)
 
 ts_library(name = "my_service", srcs = select({":release_build": ["config/buildbuddy.release.yaml"], "//conditions:default": glob(["config/**"])}), strict = False, deps = ["@npm//my_service"])
 

--- a/cli/translate/js/translate.js
+++ b/cli/translate/js/translate.js
@@ -55,7 +55,13 @@ function translateObject(arg, toplevel) {
 }
 
 let builtin = (name, args) => {
-  return { builtin: name + "(" + translateArg(args, true) + ")" };
+  let rendered = name + "(" + translateArg(args, true) + ")";
+  return {
+    builtin: rendered,
+    concat: (concatArg) => {
+      return { builtin: `${rendered} + ${translateArg(concatArg, false)}` };
+    },
+  };
 };
 let rule = (name, args) => {
   output += name + "(" + translateArgs(args) + ")\n\n";


### PR DESCRIPTION
This allows you to concatenate lists generated with builtins like `glob()` or `select()`.

For example, something like:
```
srcs = glob([
    "src/**",
    "static/**",
    "docs/**",
]) + [
    "docusaurus.config.js",
    "yarn.lock",
    "sidebars.js",
    "//server/cmd/buildbuddy/yaml_doc:generate_mdx",
    "//server/metrics:generate_mdx",
    "//enterprise/server/cmd/server/yaml_doc:generate_mdx",
    "//enterprise/server/cmd/executor/yaml_doc:generate_mdx",
]
```

Could be represented as:
```
srcs: glob([
    "src/**",
    "static/**",
    "docs/**",
]).concat([
    "docusaurus.config.js",
    "yarn.lock",
    "sidebars.js",
    "//server/cmd/buildbuddy/yaml_doc:generate_mdx",
    "//server/metrics:generate_mdx",
    "//enterprise/server/cmd/server/yaml_doc:generate_mdx",
    "//enterprise/server/cmd/executor/yaml_doc:generate_mdx",
])
```
