### PR TITLE
Timeseries chart bug fixes

### DIFF
--- a/app/flame_chart/flame_chart.tsx
+++ b/app/flame_chart/flame_chart.tsx
@@ -527,7 +527,7 @@ class HoveredRefLine extends React.Component<HoveredRefLineState> {
   render() {
     const { line } = this.state;
     if (!line) return <></>;
-    let roundedSeconds = Math.round(this.state?.seconds || 0);
+    let roundedSeconds = Math.round(this.state?.seconds / line.dt || 0) * line.dt;
     let point = line.pointsByXCoord.get(roundedSeconds) || null;
     if (!point) return <></>;
     return (
@@ -570,7 +570,7 @@ class HoveredLineInfo extends React.Component<HoveredLineInfoState> {
   render() {
     const { line } = this.state;
     if (!line) return <></>;
-    let roundedSeconds = Math.round(this.state?.seconds || 0);
+    let roundedSeconds = Math.round(this.state?.seconds / line.dt || 0) * line.dt;
     let point = line.pointsByXCoord.get(roundedSeconds) || null;
     if (!point) return <></>;
     const {

--- a/app/flame_chart/flame_chart.tsx
+++ b/app/flame_chart/flame_chart.tsx
@@ -527,7 +527,7 @@ class HoveredRefLine extends React.Component<HoveredRefLineState> {
   render() {
     const { line } = this.state;
     if (!line) return <></>;
-    let roundedSeconds = Math.round(this.state?.seconds / line.dt || 0) * line.dt;
+    let roundedSeconds = Math.round((this.state?.seconds || 0) / line.dt || 0) * line.dt;
     let point = line.pointsByXCoord.get(roundedSeconds) || null;
     if (!point) return <></>;
     return (
@@ -570,7 +570,7 @@ class HoveredLineInfo extends React.Component<HoveredLineInfoState> {
   render() {
     const { line } = this.state;
     if (!line) return <></>;
-    let roundedSeconds = Math.round(this.state?.seconds / line.dt || 0) * line.dt;
+    let roundedSeconds = Math.round((this.state?.seconds || 0) / line.dt) * line.dt;
     let point = line.pointsByXCoord.get(roundedSeconds) || null;
     if (!point) return <></>;
     const {

--- a/app/flame_chart/profile_model.ts
+++ b/app/flame_chart/profile_model.ts
@@ -153,14 +153,13 @@ export function buildTimeSeries(events: TraceEvent[]): TimeSeries[] {
         events: [],
       };
       timelines.push(timeSeries);
-    } else {
-      for (const key in event.args) {
-        if (key == TIME_SERIES_EVENT_NAMES_AND_ARG_KEYS.get(event.name)) {
-          event.value = event.args[key];
-        }
-      }
-      timeSeries!.events.push(event);
     }
+    for (const key in event.args) {
+      if (key == TIME_SERIES_EVENT_NAMES_AND_ARG_KEYS.get(event.name)) {
+        event.value = event.args[key];
+      }
+    }
+    timeSeries!.events.push(event);
   }
   return timelines;
 }


### PR DESCRIPTION
1. Added a field in the LineModel to indicate the sample rate. The
   sample rate for action count is every 0.2 seconds, while for other
   graphs, the sample rates are every second. This should fix the issue
   where some data points are not annotated for action count graphs when
   hovering.

2. Fixed a bug where the first data point is not added to the LineModel.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
