### PR TITLE
Fix firecracker test that won't run on the executor

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -93,7 +93,6 @@ go_test(
         "//server/util/disk",
         "//server/util/fileresolver",
         "//server/util/log",
-        "//server/util/networking",
         "//server/util/status",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/fileresolver"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/buildbuddy-io/buildbuddy/server/util/networking"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -453,10 +452,9 @@ func TestFirecrackerRunWithNetwork(t *testing.T) {
 	rootDir := testfs.MakeTempDir(t)
 	workDir := testfs.MakeDirAll(t, rootDir, "work")
 
-	// Make sure the container can at least send packets via the default route.
-	defaultRouteIP, err := networking.FindDefaultRouteIP(ctx)
-	require.NoError(t, err, "failed to find default route IP")
-	cmd := &repb.Command{Arguments: []string{"ping", "-c1", defaultRouteIP}}
+	// Make sure the container can send packets to something external of the VM
+	googleDNS := "8.8.8.8"
+	cmd := &repb.Command{Arguments: []string{"ping", "-c1", googleDNS}}
 
 	opts := firecracker.ContainerOpts{
 		ContainerImage:         busyboxImage,
@@ -480,7 +478,7 @@ func TestFirecrackerRunWithNetwork(t *testing.T) {
 	}
 
 	assert.Equal(t, 0, res.ExitCode)
-	assert.Contains(t, string(res.Stdout), "64 bytes from "+defaultRouteIP)
+	assert.Contains(t, string(res.Stdout), "64 bytes from "+googleDNS)
 }
 
 func TestFirecrackerRun_ReapOrphanedZombieProcess(t *testing.T) {

--- a/server/util/networking/networking.go
+++ b/server/util/networking/networking.go
@@ -439,25 +439,6 @@ func findRoute(ctx context.Context, prefix string) (route, error) {
 	return route{}, status.FailedPreconditionErrorf("Unable to determine device with prefix: %s", prefix)
 }
 
-// FindDefaultRouteIP finds the default IP used for routing traffic, typically
-// corresponding to a local router or access point.
-//
-// Equivalent to "ip route | grep default | awk '{print $3}'.
-func FindDefaultRouteIP(ctx context.Context) (string, error) {
-	out, err := sudoCommand(ctx, "ip", "route")
-	if err != nil {
-		return "", err
-	}
-	for _, line := range strings.Split(string(out), "\n") {
-		if strings.HasPrefix(line, "default") {
-			if parts := strings.Split(line, " "); len(parts) > 5 {
-				return parts[2], nil
-			}
-		}
-	}
-	return "", status.FailedPreconditionError("Unable to determine default route.")
-}
-
 // EnableMasquerading turns on ipmasq for the device with --device_prefix. This is required
 // for networking to work on vms.
 func EnableMasquerading(ctx context.Context) error {


### PR DESCRIPTION
This test tries to test the network connection of a firecracker VM by pinging the default route. Pinging the default route fails even when run from the executor pod itself. This may have to do with the networking setup on executors. Change the test to ping something else, because that's what the test is ultimately trying to test
