### PR TITLE
Throw an error and disconnect the invocation when tag list is too long for mysql

### DIFF
--- a/server/build_event_protocol/accumulator/accumulator.go
+++ b/server/build_event_protocol/accumulator/accumulator.go
@@ -100,8 +100,10 @@ func (v *BEValues) Invocation() *inpb.Invocation {
 	return v.parser.GetInvocation()
 }
 
-func (v *BEValues) AddEvent(event *build_event_stream.BuildEvent) {
-	v.parser.ParseEvent(event)
+func (v *BEValues) AddEvent(event *build_event_stream.BuildEvent) error {
+	if err := v.parser.ParseEvent(event); err != nil {
+		return err
+	}
 
 	switch p := event.Payload.(type) {
 	case *build_event_stream.BuildEvent_Started:
@@ -139,6 +141,7 @@ func (v *BEValues) AddEvent(event *build_event_stream.BuildEvent) {
 			}
 		}
 	}
+	return nil
 }
 
 func (v *BEValues) Finalize(ctx context.Context) {

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -1104,7 +1104,9 @@ func (e *EventChannel) processSingleEvent(event *inpb.InvocationEvent, iid strin
 	}
 	e.redactor.RedactMetadata(event.BuildEvent)
 	// Accumulate a subset of invocation fields in memory.
-	e.beValues.AddEvent(event.BuildEvent)
+	if err := e.beValues.AddEvent(event.BuildEvent); err != nil {
+		return err
+	}
 
 	switch p := event.BuildEvent.Payload.(type) {
 	case *build_event_stream.BuildEvent_Progress:
@@ -1381,7 +1383,9 @@ func LookupInvocation(env environment.Env, ctx context.Context, iid string) (*in
 					return err
 				}
 				redactor.RedactMetadata(event.BuildEvent)
-				beValues.AddEvent(event.BuildEvent)
+				if err := beValues.AddEvent(event.BuildEvent); err != nil {
+					return err
+				}
 			}
 			events = append(events, event)
 			switch p := event.BuildEvent.Payload.(type) {
@@ -1523,7 +1527,7 @@ func TableInvocationToProto(i *tables.Invocation) *inpb.Invocation {
 	out.DownloadOutputsOption = inpb.DownloadOutputsOption(i.DownloadOutputsOption)
 	out.RemoteExecutionEnabled = i.RemoteExecutionEnabled
 	out.UploadLocalResultsEnabled = i.UploadLocalResultsEnabled
-	out.Tags = invocation_format.SplitAndTrimTags(i.Tags, false)
+	out.Tags, _ = invocation_format.SplitAndTrimTags(i.Tags, false)
 	return out
 }
 

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -1527,6 +1527,8 @@ func TableInvocationToProto(i *tables.Invocation) *inpb.Invocation {
 	out.DownloadOutputsOption = inpb.DownloadOutputsOption(i.DownloadOutputsOption)
 	out.RemoteExecutionEnabled = i.RemoteExecutionEnabled
 	out.UploadLocalResultsEnabled = i.UploadLocalResultsEnabled
+	// Don't bother with validation here; just give the user whatever the DB
+	// claims the tags are.
 	out.Tags, _ = invocation_format.SplitAndTrimTags(i.Tags, false)
 	return out
 }

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -1523,7 +1523,7 @@ func TableInvocationToProto(i *tables.Invocation) *inpb.Invocation {
 	out.DownloadOutputsOption = inpb.DownloadOutputsOption(i.DownloadOutputsOption)
 	out.RemoteExecutionEnabled = i.RemoteExecutionEnabled
 	out.UploadLocalResultsEnabled = i.UploadLocalResultsEnabled
-	out.Tags = invocation_format.SplitAndTrimTags(i.Tags)
+	out.Tags = invocation_format.SplitAndTrimTags(i.Tags, false)
 	return out
 }
 

--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -121,7 +121,7 @@ func (sep *StreamingEventParser) GetInvocation() *inpb.Invocation {
 	return sep.invocation
 }
 
-func (sep *StreamingEventParser) ParseEvent(event *build_event_stream.BuildEvent) {
+func (sep *StreamingEventParser) ParseEvent(event *build_event_stream.BuildEvent) error {
 	switch p := event.Payload.(type) {
 	case *build_event_stream.BuildEvent_Progress:
 		{
@@ -210,9 +210,9 @@ func (sep *StreamingEventParser) ParseEvent(event *build_event_stream.BuildEvent
 		{
 			metadata := p.BuildMetadata.Metadata
 			if metadata == nil {
-				return
+				return nil
 			}
-			sep.fillInvocationFromBuildMetadata(metadata)
+			return sep.fillInvocationFromBuildMetadata(metadata)
 		}
 	case *build_event_stream.BuildEvent_ConvenienceSymlinksIdentified:
 		{
@@ -221,11 +221,12 @@ func (sep *StreamingEventParser) ParseEvent(event *build_event_stream.BuildEvent
 		{
 			wfc := p.WorkflowConfigured
 			if wfc == nil {
-				return
+				return nil
 			}
 			sep.fillInvocationFromWorkflowConfigured(wfc)
 		}
 	}
+	return nil
 }
 
 func (sep *StreamingEventParser) fillInvocationFromStructuredCommandLine(commandLine *command_line.CommandLine) {
@@ -363,7 +364,7 @@ func (sep *StreamingEventParser) fillInvocationFromWorkspaceStatus(workspaceStat
 	}
 }
 
-func (sep *StreamingEventParser) fillInvocationFromBuildMetadata(metadata map[string]string) {
+func (sep *StreamingEventParser) fillInvocationFromBuildMetadata(metadata map[string]string) error {
 	priority := buildMetadataPriority
 	if sha, ok := metadata["COMMIT_SHA"]; ok && sha != "" {
 		sep.setCommitSha(sha, priority)
@@ -390,8 +391,11 @@ func (sep *StreamingEventParser) fillInvocationFromBuildMetadata(metadata map[st
 		sep.setReadPermission(inpb.InvocationPermission_PUBLIC, priority)
 	}
 	if tags, ok := metadata["TAGS"]; ok && tags != "" {
-		sep.setTags(tags, priority)
+		if err := sep.setTags(tags, priority); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func (sep *StreamingEventParser) fillInvocationFromWorkflowConfigured(workflowConfigured *build_event_stream.WorkflowConfigured) {
@@ -460,9 +464,14 @@ func (sep *StreamingEventParser) setPattern(value []string, priority int) {
 		sep.invocation.Pattern = value
 	}
 }
-func (sep *StreamingEventParser) setTags(value string, priority int) {
+func (sep *StreamingEventParser) setTags(value string, priority int) error {
 	if *tagsEnabled && sep.priority.Tags <= priority {
+		tags, err := invocation_format.SplitAndTrimTags(value, true)
+		if err != nil {
+			return err
+		}
 		sep.priority.Tags = priority
-		sep.invocation.Tags = invocation_format.SplitAndTrimTags(value, true)
+		sep.invocation.Tags = tags
 	}
+	return nil
 }

--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -463,6 +463,6 @@ func (sep *StreamingEventParser) setPattern(value []string, priority int) {
 func (sep *StreamingEventParser) setTags(value string, priority int) {
 	if *tagsEnabled && sep.priority.Tags <= priority {
 		sep.priority.Tags = priority
-		sep.invocation.Tags = invocation_format.SplitAndTrimTags(value)
+		sep.invocation.Tags = invocation_format.SplitAndTrimTags(value, true)
 	}
 }

--- a/server/build_event_protocol/invocation_format/BUILD
+++ b/server/build_event_protocol/invocation_format/BUILD
@@ -18,6 +18,7 @@ go_test(
     deps = [
         ":invocation_format",
         "//proto:invocation_go_proto",
+        "//server/util/status",
         "@com_github_stretchr_testify//assert",
     ],
 )

--- a/server/build_event_protocol/invocation_format/invocation_format.go
+++ b/server/build_event_protocol/invocation_format/invocation_format.go
@@ -44,7 +44,7 @@ func ShortFormatPatterns(patterns []string) string {
 
 // Splits the provided comma-separated tag string and trims off any trailing
 // and leading whitespace from each tag.  If validate it set to true and the
-// trimmed, comma-separated string containing the tags would be longer than 255
+// trimmed, comma-separated string containing the tags would be longer than 160
 // characters, an error is returned.
 func SplitAndTrimTags(tags string, validate bool) ([]*invocation.Invocation_Tag, error) {
 	if len(tags) == 0 {
@@ -56,7 +56,7 @@ func SplitAndTrimTags(tags string, validate bool) ([]*invocation.Invocation_Tag,
 	for _, t := range splitTags {
 		trimmed := strings.TrimSpace(t)
 		if len(trimmed) > 0 {
-			if validate && totalLength+len(trimmed) > 255 {
+			if validate && totalLength+len(trimmed) > 160 {
 				return nil, status.InvalidArgumentError("Tag list is too long.")
 			}
 			totalLength += len(trimmed) + 1

--- a/server/build_event_protocol/invocation_format/invocation_format.go
+++ b/server/build_event_protocol/invocation_format/invocation_format.go
@@ -43,12 +43,12 @@ func ShortFormatPatterns(patterns []string) string {
 }
 
 // Splits the provided comma-separated tag string and trims off any trailing
-// and leading whitespace from each tag.  If truncate it set to true, any tags
-// that would make the trimmed, comma-separated string containing the tags
-// longer than 255 characters will be dropped along with all following tags.
-func SplitAndTrimTags(tags string, truncate bool) []*invocation.Invocation_Tag {
+// and leading whitespace from each tag.  If validate it set to true and the
+// trimmed, comma-separated string containing the tags would be longer than 255
+// characters, an error is returned.
+func SplitAndTrimTags(tags string, validate bool) ([]*invocation.Invocation_Tag, error) {
 	if len(tags) == 0 {
-		return []*invocation.Invocation_Tag{}
+		return []*invocation.Invocation_Tag{}, nil
 	}
 	splitTags := strings.Split(tags, ",")
 	totalLength := 0
@@ -56,14 +56,14 @@ func SplitAndTrimTags(tags string, truncate bool) []*invocation.Invocation_Tag {
 	for _, t := range splitTags {
 		trimmed := strings.TrimSpace(t)
 		if len(trimmed) > 0 {
-			if truncate && totalLength+len(trimmed) > 255 {
-				break
+			if validate && totalLength+len(trimmed) > 255 {
+				return nil, status.InvalidArgumentError("Tag list is too long.")
 			}
 			totalLength += len(trimmed) + 1
 			out = append(out, &invocation.Invocation_Tag{Name: trimmed})
 		}
 	}
-	return out
+	return out, nil
 }
 
 func JoinTags(tags []*invocation.Invocation_Tag) (string, error) {

--- a/server/build_event_protocol/invocation_format/invocation_format.go
+++ b/server/build_event_protocol/invocation_format/invocation_format.go
@@ -42,15 +42,24 @@ func ShortFormatPatterns(patterns []string) string {
 	return out
 }
 
-func SplitAndTrimTags(tags string) []*invocation.Invocation_Tag {
+// Splits the provided comma-separated tag string and trims off any trailing
+// and leading whitespace from each tag.  If truncate it set to true, any tags
+// that would make the trimmed,comma-separated list longer than 255 characters
+// will be dropped.
+func SplitAndTrimTags(tags string, truncate bool) []*invocation.Invocation_Tag {
 	if len(tags) == 0 {
 		return []*invocation.Invocation_Tag{}
 	}
 	splitTags := strings.Split(tags, ",")
+	totalLength := 0
 	out := make([]*invocation.Invocation_Tag, 0, len(splitTags))
 	for _, t := range splitTags {
 		trimmed := strings.TrimSpace(t)
 		if len(trimmed) > 0 {
+			if truncate && totalLength+len(trimmed) > 255 {
+				break
+			}
+			totalLength += len(trimmed) + 1
 			out = append(out, &invocation.Invocation_Tag{Name: trimmed})
 		}
 	}

--- a/server/build_event_protocol/invocation_format/invocation_format.go
+++ b/server/build_event_protocol/invocation_format/invocation_format.go
@@ -44,8 +44,8 @@ func ShortFormatPatterns(patterns []string) string {
 
 // Splits the provided comma-separated tag string and trims off any trailing
 // and leading whitespace from each tag.  If truncate it set to true, any tags
-// that would make the trimmed,comma-separated list longer than 255 characters
-// will be dropped.
+// that would make the trimmed, comma-separated string containing the tags
+// longer than 255 characters will be dropped along with all following tags.
 func SplitAndTrimTags(tags string, truncate bool) []*invocation.Invocation_Tag {
 	if len(tags) == 0 {
 		return []*invocation.Invocation_Tag{}

--- a/server/build_event_protocol/invocation_format/invocation_format_test.go
+++ b/server/build_event_protocol/invocation_format/invocation_format_test.go
@@ -6,6 +6,7 @@ import (
 
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/invocation_format"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,26 +35,34 @@ func makeTagSlice(args ...string) []*inpb.Invocation_Tag {
 func TestSplitAndTrimTags(t *testing.T) {
 	longTag := "l" + strings.Repeat("o", 253) + "ng"
 	lotsOfWhitespace := strings.Repeat(" ", 255)
+	tooLong := status.InvalidArgumentError("Tag list is too long.")
 	for _, testCase := range []struct {
-		input    string
-		truncate bool
-		expected []*inpb.Invocation_Tag
+		input         string
+		truncate      bool
+		expected      []*inpb.Invocation_Tag
+		expectedError error
 	}{
-		{"", false, makeTagSlice()},
-		{",", false, makeTagSlice()},
-		{",  ,,,", false, makeTagSlice()},
-		{"beef", false, makeTagSlice("beef")},
-		{"  beef ", false, makeTagSlice("beef")},
-		{"beef,beer", false, makeTagSlice("beef", "beer")},
-		{" art , beef, beer , cheese..,ten dollars,,", false, makeTagSlice("art", "beef", "beer", "cheese..", "ten dollars")},
-		{" art , beef, beer , cheese..,ten dollars,,", true, makeTagSlice("art", "beef", "beer", "cheese..", "ten dollars")},
-		{longTag + ",short1", false, makeTagSlice(longTag, "short1")},
-		{longTag, true, makeTagSlice()},
-		{longTag + ",short1", true, makeTagSlice()},
-		{"short1,short2," + longTag + ",short3", true, makeTagSlice("short1", "short2")},
-		{"lots of whitespace" + lotsOfWhitespace + "," + lotsOfWhitespace + "and,more,tags", true, makeTagSlice("lots of whitespace", "and", "more", "tags")},
+		{"", false, makeTagSlice(), nil},
+		{",", false, makeTagSlice(), nil},
+		{",  ,,,", false, makeTagSlice(), nil},
+		{"beef", false, makeTagSlice("beef"), nil},
+		{"  beef ", false, makeTagSlice("beef"), nil},
+		{"beef,beer", false, makeTagSlice("beef", "beer"), nil},
+		{" art , beef, beer , cheese..,ten dollars,,", false, makeTagSlice("art", "beef", "beer", "cheese..", "ten dollars"), nil},
+		{" art , beef, beer , cheese..,ten dollars,,", true, makeTagSlice("art", "beef", "beer", "cheese..", "ten dollars"), nil},
+		{longTag + ",short1", false, makeTagSlice(longTag, "short1"), nil},
+		{longTag, true, nil, tooLong},
+		{longTag + ",short1", true, nil, tooLong},
+		{"short1,short2," + longTag + ",short3", true, nil, tooLong},
+		{"lots of whitespace" + lotsOfWhitespace + "," + lotsOfWhitespace + "and,more,tags", true, makeTagSlice("lots of whitespace", "and", "more", "tags"), nil},
 	} {
-		assert.Equal(t, testCase.expected, invocation_format.SplitAndTrimTags(testCase.input, testCase.truncate))
+		tags, err := invocation_format.SplitAndTrimTags(testCase.input, testCase.truncate)
+		assert.Equal(t, tags, testCase.expected)
+		if testCase.expectedError == nil {
+			assert.Nil(t, err)
+		} else {
+			assert.EqualError(t, err, testCase.expectedError.Error())
+		}
 	}
 }
 

--- a/server/build_event_protocol/invocation_format/invocation_format_test.go
+++ b/server/build_event_protocol/invocation_format/invocation_format_test.go
@@ -33,7 +33,7 @@ func makeTagSlice(args ...string) []*inpb.Invocation_Tag {
 }
 
 func TestSplitAndTrimTags(t *testing.T) {
-	longTag := "l" + strings.Repeat("o", 253) + "ng"
+	longTag := "l" + strings.Repeat("o", 158) + "ng"
 	lotsOfWhitespace := strings.Repeat(" ", 255)
 	tooLong := status.InvalidArgumentError("Tag list is too long.")
 	for _, testCase := range []struct {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
This will prevent us from storing any incomplete tags.  Doesn't seem worth blocking a build to me, but I'm willing to be convinced.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
