### PR TITLE
Wait for and print BES errors when `sync` is set on CLI runs.

### DIFF
--- a/server/build_event_protocol/build_event_server/build_event_server.go
+++ b/server/build_event_protocol/build_event_server/build_event_server.go
@@ -143,6 +143,7 @@ func (s *BuildEventProtocolServer) PublishBuildToolEventStream(stream pepb.Publi
 		case err := <-errCh:
 			if err == io.EOF {
 				if s.synchronous {
+					// Close the streams early so that we can Wait() for any forwarding errors.
 					closeStreamsOnce.Do(func() { closeForwardingStreams(forwardingStreams) })
 					if err := eg.Wait(); err != nil {
 						return disconnectWithErr(err)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
The previous behavior waits for the upload to finish, but the errors aren't propagated back to the CLI.  With this change, error output for bad API keys, messed up metadata, etc. can be printed client-side.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
