### PR TITLE
prevent exponentially multiplying setIntervals on pending build cards

### DIFF
--- a/enterprise/app/history/history_invocation_card.tsx
+++ b/enterprise/app/history/history_invocation_card.tsx
@@ -57,7 +57,6 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
     this.setState({ time: Date.now() });
     if (!this.interval) {
       this.interval = window.setInterval(() => {
-        console.log("updating");
         this.updateTimeIfInProgress();
       }, durationRefreshIntervalMillis);
     }

--- a/enterprise/app/history/history_invocation_card.tsx
+++ b/enterprise/app/history/history_invocation_card.tsx
@@ -49,10 +49,18 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
 
   updateTimeIfInProgress() {
     if (!this.isInProgress()) {
+      if (this.interval) {
+        window.clearInterval(this.interval);
+      }
       return;
     }
     this.setState({ time: Date.now() });
-    this.interval = window.setInterval(() => this.updateTimeIfInProgress(), durationRefreshIntervalMillis);
+    if (!this.interval) {
+      this.interval = window.setInterval(() => {
+        console.log("updating");
+        this.updateTimeIfInProgress();
+      }, durationRefreshIntervalMillis);
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
didn't bother looking up when this happened, but i noticed that my browser tabs were hitting 100% cpu, and yeah, after a minute or something the main js thread is basically constantly spinning doing this--looks like we treated a setinterval as a settimeout by accident.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
