### PR TITLE
Firecracker: don't setup VFS if not enabled

### DIFF
--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -52,6 +52,7 @@ var (
 	path                    = flag.String("path", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "The path to use when executing cmd")
 	vmExecPort              = flag.Uint("vm_exec_port", vsock.VMExecPort, "The vsock port number to listen on for VM Exec service.")
 	enableRootfs            = flag.Bool("enable_rootfs", false, "Whether the rootfs disk is enabled instead of separate containerfs + scratchfs disks")
+	enableVFS               = flag.Bool("enable_vfs", false, "Whether to run the VFS client.")
 	debugMode               = flag.Bool("debug_mode", false, "If true, attempt to set root pw and start getty.")
 	logLevel                = flag.String("log_level", "info", "The loglevel to emit logs at")
 	setDefaultRoute         = flag.Bool("set_default_route", false, "If true, will set the default eth0 route to 192.168.246.1")
@@ -446,6 +447,9 @@ func main() {
 		return cmd.Run()
 	})
 	eg.Go(func() error {
+		if !*enableVFS {
+			return nil
+		}
 		cmd := exec.CommandContext(ctx, os.Args[0], append(os.Args[1:], "--vmvfs")...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -139,8 +139,8 @@ func TestGuestAPIVersion(t *testing.T) {
 	// Note that if you go with option 1, ALL VM snapshots will be invalidated
 	// which will negatively affect customer experience. Be careful!
 	const (
-		expectedHash    = "dba052af79775a1d586dfcd32c4b841a4ccb363139bf8469c5706a66d91700f4"
-		expectedVersion = "5"
+		expectedHash    = "7796aefdcbcda98399a962d0a3f9f2909e39dba10f5cf2e6050f960cf021bb9e"
+		expectedVersion = "6"
 	)
 	assert.Equal(t, expectedHash, firecracker.GuestAPIHash)
 	assert.Equal(t, expectedVersion, firecracker.GuestAPIVersion)


### PR DESCRIPTION
`Create()` and `Unpause()` both call `setupVFSServer` unconditionally, but it should be conditioned on whether VFS (experimental FUSE filesystem) is enabled.

Also, the VM unconditionally spawns the `vmvfs` binary, which isn't needed when VFS is not enabled.

**Related issues**: N/A
