### PR TITLE
vfs: make compatible with linux arm64

### DIFF
--- a/enterprise/server/remote_execution/vfs/BUILD
+++ b/enterprise/server/remote_execution/vfs/BUILD
@@ -11,7 +11,8 @@ go_library(
     srcs = [
         "vfs.go",
         "vfs_darwin.go",
-        "vfs_linux.go",
+        "vfs_linux_amd64.go",
+        "vfs_linux_arm64.go",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/vfs",
     deps = [

--- a/enterprise/server/remote_execution/vfs/vfs_linux_amd64.go
+++ b/enterprise/server/remote_execution/vfs/vfs_linux_amd64.go
@@ -1,0 +1,17 @@
+//go:build linux && amd64
+
+package vfs
+
+import (
+	"syscall"
+
+	vfspb "github.com/buildbuddy-io/buildbuddy/proto/vfs"
+)
+
+func attrsToStat(attr *vfspb.Attrs) *syscall.Stat_t {
+	return &syscall.Stat_t{
+		Size:  attr.GetSize(),
+		Mode:  attr.GetPerm(),
+		Nlink: uint64(attr.GetNlink()),
+	}
+}

--- a/enterprise/server/remote_execution/vfs/vfs_linux_arm64.go
+++ b/enterprise/server/remote_execution/vfs/vfs_linux_arm64.go
@@ -1,5 +1,4 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux && arm64
 
 package vfs
 
@@ -13,6 +12,6 @@ func attrsToStat(attr *vfspb.Attrs) *syscall.Stat_t {
 	return &syscall.Stat_t{
 		Size:  attr.GetSize(),
 		Mode:  attr.GetPerm(),
-		Nlink: uint64(attr.GetNlink()),
+		Nlink: attr.GetNlink(),
 	}
 }


### PR DESCRIPTION
We have a customer reporting not being able to compile our executor on
arm64 platform after #4051.

```
enterprise/server/remote_execution/vfs/vfs_linux.go:16:10: cannot use uint64(attr.GetNlink()) (value of type uint64) as uint32 value in struct literal
```

Make sure we have a separate implementation for arm64.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
