### PR TITLE
GetCapabilities: set HighApiVersion to 2.3

### DIFF
--- a/server/remote_cache/capabilities_server/capabilities_server.go
+++ b/server/remote_cache/capabilities_server/capabilities_server.go
@@ -50,9 +50,9 @@ func NewCapabilitiesServer(env environment.Env, supportCAS, supportRemoteExec, s
 
 func (s *CapabilitiesServer) GetCapabilities(ctx context.Context, req *repb.GetCapabilitiesRequest) (*repb.ServerCapabilities, error) {
 	c := repb.ServerCapabilities{
-		// Support bazel 2.0 -> 99.9
+		// Support bazel 2.0 -> 2.3
 		LowApiVersion:  &smpb.SemVer{Major: int32(2)},
-		HighApiVersion: &smpb.SemVer{Major: int32(99), Minor: int32(9)},
+		HighApiVersion: &smpb.SemVer{Major: int32(2), Minor: int32(3)},
 	}
 	var compressors []repb.Compressor_Value
 	if s.supportZstd {


### PR DESCRIPTION
The latest version of Remote APIs is v2.3.

Let's make sure that we follow the specification and avoid future v2.4
or v3.0 clients to try using our API before we support it.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/bazelbuild/remote-apis/issues/253
