### PR TITLE
CLI: only pipe stderr through bazel output plugins

### DIFF
--- a/cli/terminal/BUILD
+++ b/cli/terminal/BUILD
@@ -4,7 +4,10 @@ go_library(
     name = "terminal",
     srcs = ["terminal.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/terminal",
-    deps = ["@com_github_mattn_go_isatty//:go-isatty"],
+    deps = [
+        "//cli/parser",
+        "@com_github_mattn_go_isatty//:go-isatty",
+    ],
 )
 
 package(default_visibility = ["//cli:__subpackages__"])

--- a/cli/terminal/terminal.go
+++ b/cli/terminal/terminal.go
@@ -3,10 +3,24 @@ package terminal
 import (
 	"os"
 
+	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 	"github.com/mattn/go-isatty"
 )
 
 // IsTTY returns whether the given file descriptor is connected to a terminal.
 func IsTTY(f *os.File) bool {
 	return isatty.IsTerminal(f.Fd())
+}
+
+func AddTerminalFlags(args []string) []string {
+	_, idx := parser.GetBazelCommandAndIndex(args)
+	if idx == -1 {
+		return args
+	}
+	tArgs := []string{"--curses=yes", "--color=yes"}
+	a := make([]string, 0, len(args)+len(tArgs))
+	a = append(a, args[:idx+1]...)
+	a = append(a, tArgs...)
+	a = append(a, args[idx+1:]...)
+	return a
 }

--- a/docs/cli-plugins.md
+++ b/docs/cli-plugins.md
@@ -255,9 +255,19 @@ exec python3 ./post_bazel.py "$@"
 
 ### `handle_bazel_output.sh`
 
-The `handle_bazel_output.sh` script is piped all Bazel output during a build via stdin. This allows you to transform and modify the output that Bazel displays to users.
+The `handle_bazel_output.sh` script receives on its stdin all of Bazel's
+stderr output (not stdout). This is useful because Bazel outputs warnings,
+errors, and progress output on stderr, allowing you to transform and
+modify the output that Bazel displays to users.
 
-Here's a simple script that calls a python script `handle_bazel_output.py`:
+As an example, we can write a `handle_bazel_output.sh` plugin to take the
+plain output from a build, and add
+[ANSI colors](https://wikipedia.org/wiki/ANSI_escape_code) to Go file
+names to make them easier to spot.
+
+Our `handle_bazel_output.sh` script delegates to a python script
+`handle_bazel_output.py`, gracefully falling back to running `cat` if
+Python is missing:
 
 ```bash
 if ! which python3 &>/dev/null; then
@@ -266,14 +276,6 @@ if ! which python3 &>/dev/null; then
 fi
 exec python3 ./handle_bazel_output.py "$@"
 ```
-
-:::note
-
-If `handle_bazel_output.sh` fails to find one of its required system
-dependencies, it can fall back to running `cat` so that the plugin
-effectively becomes a no-op.
-
-:::
 
 Here is the Python script `handle_bazel_output.py` from the
 `go-highlight` plugin:
@@ -292,7 +294,8 @@ if __name__ == "__main__":
 
 ```
 
-Or another `handle_bazel_output.py` python script that changes the colors of various Bazel outputs:
+As another example, here is a `handle_bazel_output.py` script that changes
+the colors of various Bazel outputs:
 
 ```py
 import re


### PR DESCRIPTION
This avoids merging the stderr streams and stdout streams into a single stream (passed to the plugin pipeline). By merging the streams, we make it difficult for users to parse Bazel output, since Bazel normally puts all of its progress messages out-of-band (on stderr).

We could alternatively fix this by having two separate pipelines, one for stderr and one for stdout, and having two separate plugin types (handle_bazel_stderr, handle_bazel_stdout), but I think having the ability to modify stdout could be error-prone.

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/2315
