### PR TITLE
Fall back to slow image pull on SociArtifactStore.GetArtifacts RPC error

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -558,7 +558,9 @@ func (c *podmanCommandContainer) getSociArtifacts(ctx context.Context, creds con
 	}
 	resp, err := c.sociArtifactStoreClient.GetArtifacts(ctx, &req)
 	if err != nil {
-		return err
+		log.Infof("Error fetching soci artifacts %v", err)
+		// Fall back to pulling the image without streaming.
+		return nil
 	}
 	for _, artifact := range resp.Artifacts {
 		if artifact.Type == socipb.Type_UNKNOWN_TYPE {


### PR DESCRIPTION
If the SociArtifactStore returns an RPC error for some reason the artifacts won't be available (or may be only partially available), but the executor can still pull the image without streaming. This PR changes the executor code to fall back to the non-streaming image pull instead of returning an error in this case.

**Related issues**: N/A
