### PR TITLE
Make group ID sampling work for ANON data.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1934,6 +1934,10 @@ type partitionEvictor struct {
 	// item count.
 	groupIDApproxCounts []groupIDApproxCount
 
+	// A random pseudo group ID we assign for ANON data so that we can sample
+	// it like any other group ID.
+	anonPseudoGroupID string
+
 	atimeBufferSize int
 	minEvictionAge  time.Duration
 }
@@ -1944,19 +1948,20 @@ type versionGetter interface {
 
 func newPartitionEvictor(part disk.Partition, fileStorer filestore.Store, blobDir string, dbg pebble.Leaser, locker lockmap.Locker, vg versionGetter, clock clockwork.Clock, accesses chan<- *accessTimeUpdate, atimeBufferSize int, minEvictionAge time.Duration, cacheName string) (*partitionEvictor, error) {
 	pe := &partitionEvictor{
-		mu:              &sync.Mutex{},
-		part:            part,
-		fileStorer:      fileStorer,
-		blobDir:         blobDir,
-		dbGetter:        dbg,
-		locker:          locker,
-		versionGetter:   vg,
-		accesses:        accesses,
-		rng:             rand.New(rand.NewSource(time.Now().UnixNano())),
-		clock:           clock,
-		atimeBufferSize: atimeBufferSize,
-		minEvictionAge:  minEvictionAge,
-		cacheName:       cacheName,
+		mu:                &sync.Mutex{},
+		part:              part,
+		fileStorer:        fileStorer,
+		blobDir:           blobDir,
+		dbGetter:          dbg,
+		locker:            locker,
+		versionGetter:     vg,
+		accesses:          accesses,
+		rng:               rand.New(rand.NewSource(time.Now().UnixNano())),
+		clock:             clock,
+		atimeBufferSize:   atimeBufferSize,
+		minEvictionAge:    minEvictionAge,
+		cacheName:         cacheName,
+		anonPseudoGroupID: fmt.Sprintf("GR%020d", random.RandUint64()),
 	}
 	l, err := approxlru.New(&approxlru.Opts[*evictionKey]{
 		SamplePoolSize:     *samplePoolSize,
@@ -2027,6 +2032,14 @@ func (e *partitionEvictor) sampleGroupID() (string, error) {
 	var key filestore.PebbleKey
 	if _, err := key.FromBytes(iter.Key()); err != nil {
 		return "", err
+	}
+
+	// The special ANON group doesn't follow the regular group key format, so it
+	// won't be found through regular sampling. To get around this, we make up
+	// a random group ID for it and pretend it exists in the keyspace so that
+	// it can be sampled like any other group.
+	if randomGroupID < e.anonPseudoGroupID && (key.GroupID() == "" || key.GroupID() > e.anonPseudoGroupID) {
+		return interfaces.AuthAnonymousUser, nil
 	}
 
 	// We hit a key without a group ID (i.e. a CAS entry).


### PR DESCRIPTION
Keys for ANON data don't follow the normal key format so they won't be found when sampling keys with the "GR" prefix.

To make the process work for ANON keys, we make up a random pseudo group ID for anon keys that's only used when sampling group IDs. When sampling, we check if we would have hit this group ID had it really existed in the key space and if so return the ANON group as the sampled group id.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
