### PR TITLE
Add secret expansion to config files (enterprise only).

### DIFF
--- a/enterprise/server/backends/configsecrets/BUILD
+++ b/enterprise/server/backends/configsecrets/BUILD
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "configsecrets",
+    srcs = ["configsecrets.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/configsecrets",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/util/flagutil/yaml",
+        "//server/util/status",
+        "@com_google_cloud_go_secretmanager//apiv1",
+        "@com_google_cloud_go_secretmanager//apiv1/secretmanagerpb",
+        "@org_golang_google_api//option",
+        "@org_golang_x_oauth2//google",
+    ],
+)

--- a/enterprise/server/backends/configsecrets/BUILD
+++ b/enterprise/server/backends/configsecrets/BUILD
@@ -15,3 +15,5 @@ go_library(
         "@org_golang_x_oauth2//google",
     ],
 )
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/backends/configsecrets/BUILD
+++ b/enterprise/server/backends/configsecrets/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/configsecrets",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/interfaces",
         "//server/util/flagutil/yaml",
         "//server/util/status",
         "@com_google_cloud_go_secretmanager//apiv1",

--- a/enterprise/server/backends/configsecrets/configsecrets.go
+++ b/enterprise/server/backends/configsecrets/configsecrets.go
@@ -1,0 +1,65 @@
+package configsecrets
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/yaml"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+)
+
+var (
+	configSecretProvider = flag.String("config_secrets.provider", "", "Secrets provider to use for config variable substitution. Currently only 'gcp' is supported.")
+
+	configSecretsGCPProject = flag.String("config_secrets.gcp.project_id", "", "GCP project from which secrets will be loaded.")
+)
+
+type gcpProvider struct {
+	client *secretmanager.Client
+}
+
+func (gcp *gcpProvider) GetSecret(ctx context.Context, name string) ([]byte, error) {
+	s, err := gcp.client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{
+		Name: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", *configSecretsGCPProject, name),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return s.GetPayload().GetData(), nil
+}
+
+func Configure() error {
+	if *configSecretProvider == "" {
+		return nil
+	}
+
+	var provider interfaces.ConfigSecretProvider
+	if *configSecretProvider == "gcp" {
+		if *configSecretsGCPProject == "" {
+			return status.InvalidArgumentErrorf("GCP project not specified for external secrets")
+		}
+
+		creds, err := google.FindDefaultCredentials(context.Background())
+		if err != nil {
+			return err
+		}
+		client, err := secretmanager.NewClient(context.Background(), option.WithCredentials(creds))
+		if err != nil {
+			return err
+		}
+		provider = &gcpProvider{client: client}
+	} else {
+		return status.InvalidArgumentErrorf("unknown config secrets provider %q", *configSecretProvider)
+	}
+
+	yaml.SecretProvider = provider
+
+	return nil
+}

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//enterprise:bundle",
         "//enterprise/server/auth",
+        "//enterprise/server/backends/configsecrets",
         "//enterprise/server/backends/gcs_cache",
         "//enterprise/server/backends/memcache",
         "//enterprise/server/backends/redis_cache",

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -190,6 +190,8 @@ func main() {
 
 	rootContext := context.Background()
 
+	// Flags must be parsed before config secrets integration is enabled since
+	// that feature itself depends on flag values.
 	flag.Parse()
 	if err := configsecrets.Configure(); err != nil {
 		log.Fatalf("Could not prepare config secrets provider: %s", err)

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/auth"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/configsecrets"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/gcs_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/memcache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_cache"
@@ -189,6 +190,10 @@ func main() {
 
 	rootContext := context.Background()
 
+	flag.Parse()
+	if err := configsecrets.Configure(); err != nil {
+		log.Fatalf("Could not prepare config secrets provider: %s", err)
+	}
 	if err := config.Load(); err != nil {
 		log.Fatalf("Error loading config from file: %s", err)
 	}

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//enterprise/server/api",
         "//enterprise/server/auth",
         "//enterprise/server/backends/authdb",
+        "//enterprise/server/backends/configsecrets",
         "//enterprise/server/backends/distributed",
         "//enterprise/server/backends/gcs_cache",
         "//enterprise/server/backends/kms",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/api"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/auth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/authdb"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/configsecrets"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/distributed"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/gcs_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/kms"
@@ -169,6 +170,11 @@ func convertToProdOrDie(ctx context.Context, env *real_environment.RealEnv) {
 func main() {
 	rootContext := context.Background()
 	version.Print()
+
+	flag.Parse()
+	if err := configsecrets.Configure(); err != nil {
+		log.Fatalf("Could not prepare config secrets provider: %s", err)
+	}
 
 	if err := config.Load(); err != nil {
 		log.Fatalf("Error loading config from file: %s", err)

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -171,11 +171,12 @@ func main() {
 	rootContext := context.Background()
 	version.Print()
 
+	// Flags must be parsed before config secrets integration is enabled since
+	// that feature itself depends on flag values.
 	flag.Parse()
 	if err := configsecrets.Configure(); err != nil {
 		log.Fatalf("Could not prepare config secrets provider: %s", err)
 	}
-
 	if err := config.Load(); err != nil {
 		log.Fatalf("Error loading config from file: %s", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ replace (
 require (
 	cloud.google.com/go/compute/metadata v0.2.3
 	cloud.google.com/go/logging v1.6.1
+	cloud.google.com/go/secretmanager v1.9.0
 	cloud.google.com/go/storage v1.27.0
 	github.com/AlecAivazis/survey/v2 v2.3.4
 	github.com/Azure/azure-storage-blob-go v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ cloud.google.com/go/retail v1.9.0/go.mod h1:g6jb6mKuCS1QKnH/dpu7isX253absFl6iE92
 cloud.google.com/go/scheduler v1.4.0/go.mod h1:drcJBmxF3aqZJRhmkHQ9b3uSSpQoltBPGPxGAWROx6s=
 cloud.google.com/go/scheduler v1.5.0/go.mod h1:ri073ym49NW3AfT6DZi21vLZrG07GXr5p3H1KxN5QlI=
 cloud.google.com/go/secretmanager v1.6.0/go.mod h1:awVa/OXF6IiyaU1wQ34inzQNc4ISIDIrId8qE5QGgKA=
+cloud.google.com/go/secretmanager v1.9.0 h1:xE6uXljAC1kCR8iadt9+/blg1fvSbmenlsDN4fT9gqw=
+cloud.google.com/go/secretmanager v1.9.0/go.mod h1:b71qH2l1yHmWQHt9LC80akm86mX8AL6X1MA01dW8ht4=
 cloud.google.com/go/security v1.5.0/go.mod h1:lgxGdyOKKjHL4YG3/YwIL2zLqMFCKs0UbQwgyZmfJl4=
 cloud.google.com/go/security v1.7.0/go.mod h1:mZklORHl6Bg7CNnnjLH//0UlAlaXqiG7Lb9PsPXLfD0=
 cloud.google.com/go/security v1.8.0/go.mod h1:hAQOwgmaHhztFhiQ41CjDODdWP0+AE1B3sX4OFlq+GU=

--- a/server/cmd/buildbuddy/main.go
+++ b/server/cmd/buildbuddy/main.go
@@ -24,6 +24,7 @@ var (
 func main() {
 	version.Print()
 
+	flag.Parse()
 	if err := config.Load(); err != nil {
 		log.Fatalf("Error loading config from file: %s", err)
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -28,7 +28,6 @@ func Path() string {
 
 // Load parses the flags and loads the config file specified by config.Path().
 func Load() error {
-	flag.Parse()
 	return flagyaml.PopulateFlagsFromFile(Path())
 }
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1127,3 +1127,7 @@ type Crypter interface {
 type SingleFlightDeduper interface {
 	Do(ctx context.Context, key string, work func() ([]byte, error)) ([]byte, error)
 }
+
+type ConfigSecretProvider interface {
+	GetSecret(ctx context.Context, name string) ([]byte, error)
+}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1128,6 +1128,7 @@ type SingleFlightDeduper interface {
 	Do(ctx context.Context, key string, work func() ([]byte, error)) ([]byte, error)
 }
 
+// ConfigSecretProvider provides secrets interpolation into configs.
 type ConfigSecretProvider interface {
 	GetSecret(ctx context.Context, name string) ([]byte, error)
 }

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -105,7 +105,7 @@ func (te *TestEnv) GRPCServer(lis net.Listener) (*grpc.Server, func()) {
 }
 
 func GetTestEnv(t testing.TB) *TestEnv {
-	flags.PopulateFlagsFromData(t, []byte(testConfigData))
+	flags.PopulateFlagsFromData(t, testConfigData)
 	testRootDir := testfs.MakeTempDir(t)
 	if flag.Lookup("storage.disk.root_directory") != nil {
 		flags.Set(t, "storage.disk.root_directory", fmt.Sprintf("%s/storage", testRootDir))

--- a/server/util/flagutil/types/types_test.go
+++ b/server/util/flagutil/types/types_test.go
@@ -241,7 +241,7 @@ string_alias2: "moo"
 string_alias3: "oink"
 string_alias: "meow"
 `
-	err = flagyaml.PopulateFlagsFromData([]byte(yamlData))
+	err = flagyaml.PopulateFlagsFromData(yamlData)
 	require.NoError(t, err)
 	assert.Equal(t, "meow", *flagString)
 
@@ -263,7 +263,7 @@ string_slice_alias3:
 string_slice_alias:
   - "meow"
 `
-	err = flagyaml.PopulateFlagsFromData([]byte(yamlData))
+	err = flagyaml.PopulateFlagsFromData(yamlData)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"test", "squeak", "woof", "moo", "oink", "ribbit", "meow"}, *flagStringSlice)
 
@@ -274,7 +274,7 @@ string_slice_alias:
 	yamlData = `
 string_alias: "meow"
 `
-	err = flagyaml.PopulateFlagsFromData([]byte(yamlData))
+	err = flagyaml.PopulateFlagsFromData(yamlData)
 	require.NoError(t, err)
 	assert.Equal(t, "meow", *flagString)
 
@@ -286,7 +286,7 @@ string_alias: "meow"
 	yamlData = `
 string_alias: "meow"
 `
-	err = flagyaml.PopulateFlagsFromData([]byte(yamlData))
+	err = flagyaml.PopulateFlagsFromData(yamlData)
 	require.NoError(t, err)
 	assert.Equal(t, "moo", *flagString)
 
@@ -298,7 +298,7 @@ string_alias: "meow"
 	yamlData = `
 string: "meow"
 `
-	err = flagyaml.PopulateFlagsFromData([]byte(yamlData))
+	err = flagyaml.PopulateFlagsFromData(yamlData)
 	require.NoError(t, err)
 	assert.Equal(t, "moo", *flagString)
 
@@ -310,7 +310,7 @@ string: "meow"
 	yamlData = `
 string_alias: "meow"
 `
-	err = flagyaml.PopulateFlagsFromData([]byte(yamlData))
+	err = flagyaml.PopulateFlagsFromData(yamlData)
 	require.NoError(t, err)
 	assert.Equal(t, "moo", *flagString)
 
@@ -451,7 +451,7 @@ deprecated_string: "moo"
 deprecated_string_slice:
   - "hey"
 `
-	err = flagyaml.PopulateFlagsFromData([]byte(yamlData))
+	err = flagyaml.PopulateFlagsFromData(yamlData)
 	require.NoError(t, err)
 	assert.Equal(t, *flagInt, 7)
 	assert.Equal(t, *flagString, "moo")
@@ -514,7 +514,7 @@ deprecated_string: "moo"
 deprecated_string_slice:
   - "hey"
 `
-	err = flagyaml.PopulateFlagsFromData([]byte(yamlData))
+	err = flagyaml.PopulateFlagsFromData(yamlData)
 	require.NoError(t, err)
 	assert.Equal(t, *flagInt, 7)
 	assert.Equal(t, *flagString, "moo")

--- a/server/util/flagutil/yaml/BUILD
+++ b/server/util/flagutil/yaml/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/yaml",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/interfaces",
         "//server/util/alert",
         "//server/util/flagutil/common",
         "//server/util/log",
@@ -22,6 +23,7 @@ go_test(
         ":yaml",
         "//server/util/flagutil/common",
         "//server/util/flagutil/types",
+        "//server/util/status",
         "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/server/util/flagutil/yaml/yaml_test.go
+++ b/server/util/flagutil/yaml/yaml_test.go
@@ -264,7 +264,7 @@ first:
     unknown: 9009
     no: "definitely not"
 `
-	err := flagyaml.PopulateFlagsFromData([]byte(yamlData))
+	err := flagyaml.PopulateFlagsFromData(yamlData)
 	require.NoError(t, err)
 	assert.Equal(t, true, *flagBool)
 	assert.Equal(t, int(1), *flagOneTwoInt)
@@ -282,13 +282,13 @@ func TestBadPopulateFlagsFromData(t *testing.T) {
 	yamlData := `
 	bool: true
 `
-	err := flagyaml.PopulateFlagsFromData([]byte(yamlData))
+	err := flagyaml.PopulateFlagsFromData(yamlData)
 	require.Error(t, err)
 
 	flags := replaceFlagsForTesting(t)
 
 	flags.Var(&unsupportedFlagValue{}, "bad", "")
-	err = flagyaml.PopulateFlagsFromData([]byte{})
+	err = flagyaml.PopulateFlagsFromData("")
 	require.Error(t, err)
 
 	flags = replaceFlagsForTesting(t)
@@ -297,7 +297,7 @@ func TestBadPopulateFlagsFromData(t *testing.T) {
 	yamlData = `
 bool: 7
 `
-	err = flagyaml.PopulateFlagsFromData([]byte(yamlData))
+	err = flagyaml.PopulateFlagsFromData(yamlData)
 	require.Error(t, err)
 }
 
@@ -415,7 +415,7 @@ first:
     unknown: 9009
     no: "definitely not"
 `
-	err := flagyaml.OverrideFlagsFromData([]byte(yamlData))
+	err := flagyaml.OverrideFlagsFromData(yamlData)
 	require.NoError(t, err)
 	assert.Equal(t, true, *flagBool)
 	assert.Equal(t, int(1), *flagOneTwoInt)
@@ -444,16 +444,16 @@ func TestSecretExpansion(t *testing.T) {
 
 	os.Setenv("SOMEENV", "foo")
 	envFlag := flags.String("env_flag", "", "")
-	err := flagyaml.PopulateFlagsFromData([]byte(strings.TrimSpace(`
+	err := flagyaml.PopulateFlagsFromData(strings.TrimSpace(`
 		env_flag: ${SOMEENV}
-	`)))
+	`))
 	require.NoError(t, err)
 	require.Equal(t, "foo", *envFlag)
 
 	secretFlag := flags.String("secret_flag", "", "")
-	err = flagyaml.PopulateFlagsFromData([]byte(strings.TrimSpace(`
+	err = flagyaml.PopulateFlagsFromData(strings.TrimSpace(`
 		secret_flag: ${SECRET:FOO}
-	`)))
+	`))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no secret provider")
 
@@ -461,18 +461,18 @@ func TestSecretExpansion(t *testing.T) {
 	defer func() {
 		flagyaml.SecretProvider = nil
 	}()
-	err = flagyaml.PopulateFlagsFromData([]byte(strings.TrimSpace(`
+	err = flagyaml.PopulateFlagsFromData(strings.TrimSpace(`
 		secret_flag: ${SECRET:FOO}
-	`)))
+	`))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not found")
 
 	flagyaml.SecretProvider = &fakeSecretProvider{
 		secrets: map[string]string{"FOO": "BAR"},
 	}
-	err = flagyaml.PopulateFlagsFromData([]byte(strings.TrimSpace(`
+	err = flagyaml.PopulateFlagsFromData(strings.TrimSpace(`
 		secret_flag: ${SECRET:FOO}
-	`)))
+	`))
 	require.NoError(t, err)
 	require.Equal(t, "BAR", *secretFlag)
 }

--- a/server/util/testing/flags/flags.go
+++ b/server/util/testing/flags/flags.go
@@ -14,7 +14,7 @@ import (
 
 var populateFlagsOnce sync.Once
 
-func PopulateFlagsFromData(t testing.TB, testConfigData []byte) {
+func PopulateFlagsFromData(t testing.TB, testConfigData string) {
 	populateFlagsOnce.Do(func() {
 		// add placeholder type for type adding by testing
 		flag.VisitAll(func(flg *flag.Flag) {


### PR DESCRIPTION
Any flag values in format ${SECRET:foo} are loaded from the configured secret store. Initially only GCP is supported.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
