### PR TITLE
workflows: verify cross compiling Executor to target arm64

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -10,6 +10,17 @@ actions:
           - "master"
     bazel_commands:
       - test //... --config=linux-workflows --test_tag_filters=-performance,-webdriver,-docker --build_metadata=TAGS=linux-workflow
+  - name: Build executor (linux_arm64)
+    container_image: ubuntu-20.04
+    triggers:
+      push:
+        branches:
+          - "master"
+      pull_request:
+        branches:
+          - "master"
+    bazel_commands:
+      - build //enterprise/server/cmd/executor:executor_arm64 --config=linux-workflows
   - name: Test (darwin_amd64)
     os: "darwin"
     triggers:

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -68,6 +68,26 @@ go_binary(
     embed = [":executor_lib"],
 )
 
+go_binary(
+    name = "executor_arm64",
+    args = [
+        "--config_file=enterprise/config/executor.local.yaml",
+        "--port=8888",
+        "--monitoring_port=9091",
+        "--max_shutdown_duration=3s",
+    ],
+    cgo = False,
+    data = [
+        "//enterprise:config_files",
+        "//enterprise:licenses",
+    ],
+    embed = [":executor_lib"],
+    goarch = "arm64",
+    goos = "linux",
+    pure = "on",
+    tags = ["manual"],
+)
+
 # Executor expects "firecracker" and "jailer" binaries in $PATH,
 # and they can't be symlinks (otherwise the VM will not start).
 # Rename the firecracker/jailer binaries so that we can place


### PR DESCRIPTION
We do have self-hosted customers running Executors on Arm64.

Let's ensure that we could validate that at minimum, our code could
compile successfully in CI by applying a transition on the executor
binary target.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
