### PR TITLE
Add option to force bazel clean --expunge before running workflow actions

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -139,6 +139,9 @@ var (
 	// Test-only flags
 	fallbackToCleanCheckout = flag.Bool("fallback_to_clean_checkout", true, "Fallback to cloning the repo from scratch if sync fails (for testing purposes only).")
 
+	// TODO(Maggie): Clean up this flag when done debugging segfaults
+	forceExpunge = flag.Bool("force_expunge", false, "If set, run bazel clean --expunge before every action.")
+
 	shellCharsRequiringQuote = regexp.MustCompile(`[^\w@%+=:,./-]`)
 
 	// TODO(Maggie): Clean up this field - consolidate with --commit_sha
@@ -857,6 +860,9 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 			args = appendBazelSubcommandArgs(args, "--script_path="+runScript)
 		}
 
+		if *forceExpunge {
+			runCommand(ctx, *bazelCommand, []string{"clean", "--expunge"}, ar.action.Env, ar.action.BazelWorkspaceDir, ar.reporter)
+		}
 		runErr := runCommand(ctx, *bazelCommand, expandEnv(args), ar.action.Env, ar.action.BazelWorkspaceDir, ar.reporter)
 		exitCode := getExitCode(runErr)
 		if exitCode != noExitCode {

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -35,6 +35,9 @@ type Action struct {
 	BazelWorkspaceDir string            `yaml:"bazel_workspace_dir"`
 	Env               map[string]string `yaml:"env"`
 	BazelCommands     []string          `yaml:"bazel_commands"`
+
+	// TODO(Maggie): Clean up this flag when done debugging segfaults
+	ForceExpunge bool `yaml:"force_expunge"`
 }
 
 type Triggers struct {

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -68,9 +68,6 @@ var (
 	workflowsLinuxComputeUnits    = flag.Int("remote_execution.workflows_linux_compute_units", 3, "Number of BuildBuddy compute units (BCU) to reserve for Linux workflow actions.")
 	workflowsMacComputeUnits      = flag.Int("remote_execution.workflows_mac_compute_units", 3, "Number of BuildBuddy compute units (BCU) to reserve for Mac workflow actions.")
 
-	// TODO(Maggie): Clean up this flag when done debugging segfaults
-	workflowsForceExpunge = flag.Bool("remote_execution.workflows_force_expunge", false, "If set, run bazel clean --expunge before every workflow action.")
-
 	workflowURLMatcher = regexp.MustCompile(`^.*/webhooks/workflow/(?P<instance_name>.*)$`)
 
 	// ApprovalRequired is an error indicating that a workflow action could not be
@@ -940,7 +937,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 			"--trigger_event=" + wd.EventName,
 			"--bazel_command=" + ws.ciRunnerBazelCommand(),
 			"--debug=" + fmt.Sprintf("%v", ws.ciRunnerDebugMode()),
-			"--force_expunge=" + fmt.Sprintf("%v", *workflowsForceExpunge),
+			"--force_expunge=" + fmt.Sprintf("%v", workflowAction.ForceExpunge),
 		}, extraArgs...),
 		Platform: &repb.Platform{
 			Properties: []*repb.Platform_Property{

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -68,6 +68,9 @@ var (
 	workflowsLinuxComputeUnits    = flag.Int("remote_execution.workflows_linux_compute_units", 3, "Number of BuildBuddy compute units (BCU) to reserve for Linux workflow actions.")
 	workflowsMacComputeUnits      = flag.Int("remote_execution.workflows_mac_compute_units", 3, "Number of BuildBuddy compute units (BCU) to reserve for Mac workflow actions.")
 
+	// TODO(Maggie): Clean up this flag when done debugging segfaults
+	workflowsForceExpunge = flag.Bool("remote_execution.workflows_force_expunge", false, "If set, run bazel clean --expunge before every workflow action.")
+
 	workflowURLMatcher = regexp.MustCompile(`^.*/webhooks/workflow/(?P<instance_name>.*)$`)
 
 	// ApprovalRequired is an error indicating that a workflow action could not be
@@ -937,6 +940,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 			"--trigger_event=" + wd.EventName,
 			"--bazel_command=" + ws.ciRunnerBazelCommand(),
 			"--debug=" + fmt.Sprintf("%v", ws.ciRunnerDebugMode()),
+			"--force_expunge=" + fmt.Sprintf("%v", *workflowsForceExpunge),
 		}, extraArgs...),
 		Platform: &repb.Platform{
 			Properties: []*repb.Platform_Property{


### PR DESCRIPTION
The segfault always seems to occur when gazelle is fetching dependencies. To try and trigger the segfault more frequently for debugging purposes, add an option to force a `bazel clean --expunge` before every workflow action that we can turn on in dev. Planning to use this [repo](https://github.com/maggie-lou/buildbuddy-workflow-test/commit/8766ec5babccda94c763a83a7abc60e13b49de49) + a script that triggers lots of ExecuteWorkflow requests to test