### PR TITLE
Add docker compose to the CI runner image

### DIFF
--- a/dockerfiles/rbe-ubuntu20-04/Dockerfile
+++ b/dockerfiles/rbe-ubuntu20-04/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get update && \
     apt-get install -y \
       docker-ce \
       docker-ce-cli \
+      docker-compose-plugin \
       containerd.io \
       && \
     apt-get remove -y gnupg && \


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
Docker compose lets us run healthchecks on docker contatiners we bring up, which is helpful for testing postgres.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
