### PR TITLE
goinit: raise inotify.max_user_watches to 1% mem available

### DIFF
--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -346,8 +346,6 @@ func main() {
 		}
 	}
 	die(sysctl(map[string]string{
-		// Default value, but set it explicitly to be sure.
-		"fs.inotify.max_user_instances": "128",
 		// Set to 1% of the 8GB memory.
 		// See https://github.com/torvalds/linux/blob/929ed21dfdb6ee94391db51c9eedb63314ef6847/fs/notify/inotify/inotify_user.c#L838-L844
 		// for more info

--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -58,6 +58,21 @@ func die(err error) {
 	}
 }
 
+func sysctl(conf map[string]string) error {
+	f, err := os.OpenFile("/etc/sysctl.conf", os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	for key, value := range conf {
+		if _, err := f.WriteString(fmt.Sprintf("%s=%s\n", key, value)); err != nil {
+			return err
+		}
+	}
+	return exec.Command("/sbin/sysctl", "-p").Run()
+}
+
 func mkdirp(path string, mode fs.FileMode) error {
 	log.Debugf("mkdir %q (mode: %d)", path, mode)
 	if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -330,6 +345,14 @@ func main() {
 			die(err)
 		}
 	}
+	die(sysctl(map[string]string{
+		// Default value, but set it explicitly to be sure.
+		"fs.inotify.max_user_instances": "128",
+		// Set to 1% of the 8GB memory.
+		// See https://github.com/torvalds/linux/blob/929ed21dfdb6ee94391db51c9eedb63314ef6847/fs/notify/inotify/inotify_user.c#L838-L844
+		// for more info
+		"fs.inotify.max_user_watches": "65536",
+	}))
 
 	if *setDefaultRoute {
 		die(configureDefaultRoute("eth0", "192.168.241.1"))


### PR DESCRIPTION
We have observed that for several Workflows with larger repo, the
default max_user_watches is too low for Bazel's '--watchfs' feature to
work properly.

Let's raise the default max_user_watches according to the recommendation
in a recent Linux Kernel patch (1) where the default value should be 1%
of the memory available (which is 8GB in our case).

(1): https://lore.kernel.org/all/20201109035931.4740-1-longman@redhat.com/T/#u

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**:

Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/2307
