### PR TITLE
Always show tags drilldown, even if there's only one.

### DIFF
--- a/enterprise/app/trends/drilldown_page.tsx
+++ b/enterprise/app/trends/drilldown_page.tsx
@@ -754,6 +754,14 @@ export default class DrilldownPageComponent extends React.Component<Props, State
     );
   }
 
+  shouldShowDrilldownChart(type: stats.DrilldownType, numEntries: number) {
+    if (type == stats.DrilldownType.TAG_DRILLDOWN_TYPE) {
+      return capabilities.config.tagsUiEnabled && numEntries > 0;
+    } else {
+      return numEntries > 1;
+    }
+  }
+
   render() {
     return (
       <div className="trend-chart">
@@ -807,7 +815,7 @@ export default class DrilldownPageComponent extends React.Component<Props, State
                       <div className="container nopadding-dense">
                         {this.state.drilldownData.chart.map(
                           (chart) =>
-                            chart.entry.length > 1 && (
+                            this.shouldShowDrilldownChart(chart.drilldownType, chart.entry.length) && (
                               <div className="drilldown-page-dd-chart">
                                 <div className="drilldown-page-dd-chart-title">
                                   {this.formatDrilldownType(chart.drilldownType)}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
This doesn't matter as much for other drilldowns, which generally are always set, but this change lets us see cases where only some builds have tags set, which can be useful.

![image](https://github.com/buildbuddy-io/buildbuddy/assets/10570856/780a11f4-8bb1-4bf9-982f-4e6e0c002e8c)

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
