### PR TITLE
Add protos for nbd

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -295,6 +295,11 @@ proto_library(
 )
 
 proto_library(
+    name = "nbd_proto",
+    srcs = ["nbd.proto"],
+)
+
+proto_library(
     name = "build_event_stream_proto",
     srcs = ["build_event_stream.proto"],
     deps = [
@@ -779,6 +784,13 @@ go_proto_library(
     compilers = ["@io_bazel_rules_go//proto:go_grpc"],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/vfs",
     proto = ":vfs_proto",
+)
+
+go_proto_library(
+    name = "nbd_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/nbd",
+    proto = ":nbd_proto",
 )
 
 go_proto_library(

--- a/proto/nbd.proto
+++ b/proto/nbd.proto
@@ -1,0 +1,77 @@
+syntax = "proto3";
+
+package nbd;
+
+// Remote block device service.
+//
+// Clients can use this service to read and write blocks from a remote device
+// that serves the underlying block data.
+//
+// Servers are responsible for writing and serving the block data to persistent
+// storage.
+service BlockDevice {
+  // Returns metadata for a device label. The label is a well-known value by
+  // both the client and server that corresponds to a desired device.
+  rpc Metadata(MetadataRequest) returns (MetadataResponse);
+
+  // Reads a block from a device with a given ID.
+  rpc Read(ReadRequest) returns (ReadResponse);
+
+  // Writes a block to a device with a given ID.
+  rpc Write(WriteRequest) returns (WriteResponse);
+}
+
+message DeviceMetadata {
+  // The device ID to be included in IO requests.
+  uint64 device_id = 1;
+
+  // The device label used to identify the device in metadata requests.
+  // Ex: "scratchfs"
+  string label = 2;
+
+  // The size of the block device in bytes.
+  uint64 size_bytes = 3;
+
+  // The filesystem type to be used in mount(2) operations, such as "ext4".
+  string filesystem_type = 4;
+}
+
+message MetadataRequest {
+  // The unique label of the device to fetch metadata for.
+  // Ex: "scratchfs"
+  string label = 1;
+}
+
+message MetadataResponse {
+  // The metadata for the requested device.
+  DeviceMetadata device_metadata = 1;
+}
+
+message ReadRequest {
+  // The ID of the device to read from.
+  uint64 device_id = 1;
+
+  // The offset at which to start reading.
+  uint64 offset = 2;
+
+  // The number of bytes to read.
+  uint64 length = 3;
+}
+
+message ReadResponse {
+  // The stored data with the requested offset and length.
+  bytes data = 1;
+}
+
+message WriteRequest {
+  // The device to read from.
+  uint64 device_id = 1;
+
+  // The offset at which to write the data.
+  uint64 offset = 2;
+
+  // The data to write.
+  bytes data = 3;
+}
+
+message WriteResponse {}

--- a/proto/nbd.proto
+++ b/proto/nbd.proto
@@ -30,7 +30,7 @@ message DeviceMetadata {
   string label = 2;
 
   // The size of the block device in bytes.
-  uint64 size_bytes = 3;
+  int64 size_bytes = 3;
 
   // The filesystem type to be used in mount(2) operations, such as "ext4".
   string filesystem_type = 4;
@@ -52,10 +52,10 @@ message ReadRequest {
   uint64 device_id = 1;
 
   // The offset at which to start reading.
-  uint64 offset = 2;
+  int64 offset = 2;
 
   // The number of bytes to read.
-  uint64 length = 3;
+  int64 length = 3;
 }
 
 message ReadResponse {
@@ -68,7 +68,7 @@ message WriteRequest {
   uint64 device_id = 1;
 
   // The offset at which to write the data.
-  uint64 offset = 2;
+  int64 offset = 2;
 
   // The data to write.
   bytes data = 3;

--- a/proto/nbd.proto
+++ b/proto/nbd.proto
@@ -20,6 +20,14 @@ service BlockDevice {
   rpc Write(WriteRequest) returns (WriteResponse);
 }
 
+// Filesystem format of a particular block device.
+enum FilesystemType {
+  UNKNOWN_FILESYSTEM_TYPE = 0;
+
+  // ext4 filesystem.
+  EXT4_FILESYSTEM_TYPE = 1;
+}
+
 message DeviceMetadata {
   // The human readable name of the device. This is pre-agreed upon by the
   // client and server, and does not have to be globally unique; the same name
@@ -31,8 +39,8 @@ message DeviceMetadata {
   // The size of the block device in bytes.
   int64 size_bytes = 2;
 
-  // The filesystem type to be used in mount(2) operations, such as "ext4".
-  string filesystem_type = 3;
+  // The filesystem type to be used in mount(2) operations.
+  FilesystemType filesystem_type = 3;
 }
 
 message MetadataRequest {

--- a/proto/nbd.proto
+++ b/proto/nbd.proto
@@ -10,8 +10,7 @@ package nbd;
 // Servers are responsible for writing and serving the block data to persistent
 // storage.
 service BlockDevice {
-  // Returns metadata for a device label. The label is a well-known value by
-  // both the client and server that corresponds to a desired device.
+  // Returns metadata for a device.
   rpc Metadata(MetadataRequest) returns (MetadataResponse);
 
   // Reads a block from a device with a given ID.
@@ -22,24 +21,24 @@ service BlockDevice {
 }
 
 message DeviceMetadata {
-  // The device ID to be included in IO requests.
-  uint64 device_id = 1;
-
-  // The device label used to identify the device in metadata requests.
-  // Ex: "scratchfs"
-  string label = 2;
+  // The human readable name of the device. This is pre-agreed upon by the
+  // client and server, and does not have to be globally unique; the same name
+  // can refer to different underlying storage instances depending on the
+  // client/server identity.
+  // Ex: "workspacefs".
+  string name = 1;
 
   // The size of the block device in bytes.
-  int64 size_bytes = 3;
+  int64 size_bytes = 2;
 
   // The filesystem type to be used in mount(2) operations, such as "ext4".
-  string filesystem_type = 4;
+  string filesystem_type = 3;
 }
 
 message MetadataRequest {
-  // The unique label of the device to fetch metadata for.
+  // The name of the device to fetch metadata for.
   // Ex: "scratchfs"
-  string label = 1;
+  string name = 1;
 }
 
 message MetadataResponse {
@@ -48,8 +47,8 @@ message MetadataResponse {
 }
 
 message ReadRequest {
-  // The ID of the device to read from.
-  uint64 device_id = 1;
+  // The name of the device to read from.
+  string name = 1;
 
   // The offset at which to start reading.
   int64 offset = 2;
@@ -64,8 +63,8 @@ message ReadResponse {
 }
 
 message WriteRequest {
-  // The device to read from.
-  uint64 device_id = 1;
+  // The name of the device to read from.
+  string name = 1;
 
   // The offset at which to write the data.
   int64 offset = 2;


### PR DESCRIPTION
The executor serves this `BlockDevice` service and the VM uses a little `BlockDevice` client as part of its local NBD server. The client talks to the executor to request reads/writes from a backing storage (which eventually will involve a copy-on-write mechanism implemented in the executor).

**Related issues**: N/A
