### PR TITLE
Make firecracker debug_mode flag work everywhere

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/README.md
+++ b/enterprise/server/remote_execution/containers/firecracker/README.md
@@ -23,11 +23,12 @@ before submitting any changes.
 
 ### VM crashes / `DebugMode`
 
-You can configure Firecracker with `DebugMode: true` to see more detailed
+You can run Firecracker in debug mode to see more detailed
 VM logs, including logs from the init binary and vmexec server.
-When testing, you can set this manually in the container options.
-When running the executor, you can configure debug mode with
-`--executor.firecracker_debug_mode=true`.
+
+To run in debug mode, set `--executor.firecracker_debug_mode=true`
+on the executor, or pass `--test_arg=--executor.firecracker_debug_mode=true`
+to `bazel test`.
 
 It's useful to use debug mode whenever the executor can't connect
 to the VM (indicating the VM might have crashed).

--- a/enterprise/server/remote_execution/containers/firecracker/containeropts.go
+++ b/enterprise/server/remote_execution/containers/firecracker/containeropts.go
@@ -42,10 +42,6 @@ type ContainerOpts struct {
 	// They are here primarily for debugging and running
 	// VMs outside of the normal action-execution framework.
 
-	// DebugMode runs init in debugmode and enables stdin/stdout so
-	// that machines can be logged into via the console.
-	DebugMode bool
-
 	// ForceVMIdx forces a machine to use a particular vm index,
 	// allowing for multiple locally-started VMs to avoid using
 	// conflicting network interfaces.

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -59,6 +59,7 @@ import (
 
 var firecrackerMountWorkspaceFile = flag.Bool("executor.firecracker_mount_workspace_file", false, "Enables mounting workspace filesystem to improve performance of copying action outputs.")
 var firecrackerCgroupVersion = flag.String("executor.firecracker_cgroup_version", "", "Specifies the cgroup version for firecracker to use.")
+var firecrackerDebugMode = flag.Bool("executor.firecracker_debug_mode", false, "Run firecracker in debug mode, printing VM logs to the terminal.")
 var dieOnFirecrackerFailure = flag.Bool("executor.die_on_firecracker_failure", false, "Makes the host executor process die if any command orchestrating or running Firecracker fails. Useful for capturing failures preemptively. WARNING: using this option MAY leave the host machine in an unhealthy state on Firecracker failure; some post-hoc cleanup may be necessary.")
 
 const (
@@ -368,7 +369,7 @@ func NewContainer(ctx context.Context, env environment.Env, imageCacheAuth *cont
 			ScratchDiskSizeMb: opts.ScratchDiskSizeMB,
 			EnableNetworking:  opts.EnableNetworking,
 			InitDockerd:       opts.InitDockerd,
-			DebugMode:         opts.DebugMode,
+			DebugMode:         *firecrackerDebugMode,
 		},
 		loader:             loader,
 		jailerRoot:         opts.JailerRoot,

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -87,7 +87,6 @@ var (
 	podmanEnableStats         = flag.Bool("executor.podman.enable_stats", false, "Whether to enable cgroup-based podman stats.")
 	podmanWarmupDefaultImages = flag.Bool("executor.podman.warmup_default_images", true, "Whether to warmup the default podman images or not.")
 	bareEnableStats           = flag.Bool("executor.bare.enable_stats", false, "Whether to enable stats for bare command execution.")
-	firecrackerDebugMode      = flag.Bool("executor.firecracker_debug_mode", false, "Run firecracker in debug mode, printing VM logs to the terminal.")
 )
 
 const (
@@ -1099,7 +1098,6 @@ func (p *pool) newContainerImpl(ctx context.Context, props *platform.Properties,
 			EnableNetworking:       true,
 			InitDockerd:            props.InitDockerd,
 			JailerRoot:             p.buildRoot,
-			DebugMode:              *firecrackerDebugMode,
 		}
 		c, err := firecracker.NewContainer(ctx, p.env, p.imageCacheAuth, task.GetExecutionTask(), opts)
 		if err != nil {

--- a/enterprise/tools/vmstart/BUILD
+++ b/enterprise/tools/vmstart/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//server/real_environment",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
+        "//server/util/flagutil",
         "//server/util/grpc_client",
         "//server/util/healthcheck",
         "//server/util/log",

--- a/enterprise/tools/vmstart/vmstart.go
+++ b/enterprise/tools/vmstart/vmstart.go
@@ -17,6 +17,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -95,6 +96,8 @@ func getActionAndCommand(ctx context.Context, bsClient bspb.ByteStreamClient, ac
 func main() {
 	flag.Parse()
 
+	flagutil.SetValueForFlagName("executor.firecracker_debug_mode", true, nil, false)
+
 	rand.Seed(time.Now().Unix())
 
 	env := getToolEnv()
@@ -125,7 +128,6 @@ func main() {
 		MemSizeMB:              2500,
 		ScratchDiskSizeMB:      100,
 		EnableNetworking:       true,
-		DebugMode:              true,
 		ForceVMIdx:             vmIdx,
 		JailerRoot:             "/tmp/remote_build/",
 	}


### PR DESCRIPTION
Before, `--executor.firecracker_debug_mode=true` would only work when running the executor.

Now, it works in tests, as well as the `vmstart` util.

**Related issues**: N/A
