### PR TITLE
Log podman pull latency too so we can see the exact number (metric just has a bucketized one)

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -540,9 +540,11 @@ func (c *podmanCommandContainer) PullImage(ctx context.Context, creds container.
 	if err := c.pullImage(ctx, creds); err != nil {
 		return err
 	}
+	pullLatency := time.Now().Sub(startTime)
+	log.Infof("podman pulled image %s in %s", c.image, pullLatency)
 	metrics.PodmanColdImagePullLatencyMsec.
 		With(prometheus.Labels{metrics.ContainerImageTag: c.image}).
-		Observe(float64(time.Now().Sub(startTime).Milliseconds()))
+		Observe(float64(pullLatency.Milliseconds()))
 	ps.pulled = true
 	return nil
 }


### PR DESCRIPTION
**Related issues**: N/A
