### PR TITLE
Add initial block storage layer for NBD / UFFD

### DIFF
--- a/enterprise/server/remote_execution/blockio/BUILD
+++ b/enterprise/server/remote_execution/blockio/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "blockio",
+    srcs = ["blockio.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/blockio",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/util/status",
+    ],
+)
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/remote_execution/blockio/BUILD
+++ b/enterprise/server/remote_execution/blockio/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "blockio",
@@ -11,3 +11,13 @@ go_library(
 )
 
 package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_test(
+    name = "blockio_test",
+    srcs = ["blockio_test.go"],
+    deps = [
+        ":blockio",
+        "//server/testutil/testfs",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/remote_execution/blockio/blockio.go
+++ b/enterprise/server/remote_execution/blockio/blockio.go
@@ -45,7 +45,12 @@ type Mmap struct {
 	data []byte
 }
 
-func NewMmap(f *os.File) (*Mmap, error) {
+// NewMmap returns an Mmap for an existing file.
+func NewMmap(path string) (*Mmap, error) {
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
 	s, err := f.Stat()
 	if err != nil {
 		return nil, err

--- a/enterprise/server/remote_execution/blockio/blockio.go
+++ b/enterprise/server/remote_execution/blockio/blockio.go
@@ -1,0 +1,100 @@
+package blockio
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+)
+
+// Store models a block-level storage system, which is useful as a backend for a
+// Network Block Device (NBD) or userfaultfd(2).
+type Store interface {
+	io.ReaderAt
+	io.WriterAt
+	io.Closer
+
+	// Sync flushes any buffered pages to the store, if applicable.
+	Sync() error
+
+	// Size returns the total addressable size of the store in bytes.
+	SizeBytes() (int64, error)
+}
+
+// File implements the Store interface using standard file operations.
+type File struct{ *os.File }
+
+// NewFile returns a File store for an existing file.
+func NewFile(path string) (*File, error) {
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+	return &File{File: f}, nil
+}
+
+func (f *File) SizeBytes() (int64, error) {
+	return fileSizeBytes(f.File)
+}
+
+// Mmap implements the Store interface using a memory-mapped file.
+type Mmap struct {
+	file *os.File
+	data []byte
+}
+
+func NewMmap(f *os.File) (*Mmap, error) {
+	s, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	data, err := syscall.Mmap(int(f.Fd()), 0, int(s.Size()), syscall.PROT_WRITE, syscall.MAP_PRIVATE)
+	if err != nil {
+		return nil, fmt.Errorf("mmap: %s", err)
+	}
+	return &Mmap{file: f, data: data}, nil
+}
+
+func (m *Mmap) ReadAt(p []byte, off int64) (n int, err error) {
+	if off < 0 || int(off)+len(p) > len(m.data) {
+		return 0, status.InvalidArgumentErrorf("invalid offset %x", off)
+	}
+	copy(p, m.data[int(off):int(off)+len(p)])
+	return len(p), nil
+}
+
+func (m *Mmap) WriteAt(p []byte, off int64) (n int, err error) {
+	if off < 0 || int(off)+len(p) > len(m.data) {
+		return 0, status.InvalidArgumentErrorf("invalid offset %x", off)
+	}
+	copy(m.data[int(off):int(off)+len(p)], p)
+	return len(p), nil
+}
+
+func (m *Mmap) Sync() error {
+	return m.file.Sync()
+}
+
+func (m *Mmap) Close() error {
+	if err := syscall.Munmap(m.data); err != nil {
+		_ = m.file.Close()
+		return err
+	}
+	return m.file.Close()
+}
+
+func (m *Mmap) SizeBytes() (int64, error) {
+	return fileSizeBytes(m.file)
+}
+
+func fileSizeBytes(f *os.File) (int64, error) {
+	s, err := f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return s.Size(), nil
+}
+
+// TODO: add a Store supporting copy-on-write.

--- a/enterprise/server/remote_execution/blockio/blockio_test.go
+++ b/enterprise/server/remote_execution/blockio/blockio_test.go
@@ -1,0 +1,74 @@
+package blockio_test
+
+import (
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/blockio"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	backingFileSizeBytes int64 = 1_000_000
+)
+
+func TestFile(t *testing.T) {
+	path := makeEmptyBackingFile(t)
+	s, err := blockio.NewFile(path)
+	require.NoError(t, err)
+	testStore(t, s)
+}
+
+func TestMmap(t *testing.T) {
+	path := makeEmptyBackingFile(t)
+	s, err := blockio.NewMmap(path)
+	require.NoError(t, err)
+	testStore(t, s)
+}
+
+func makeEmptyBackingFile(t *testing.T) string {
+	root := testfs.MakeTempDir(t)
+	path := filepath.Join(root, "f")
+	err := os.WriteFile(path, make([]byte, backingFileSizeBytes), 0644)
+	require.NoError(t, err, "write empty file")
+	return path
+}
+
+func testStore(t *testing.T, s blockio.Store) {
+	size, err := s.SizeBytes()
+	require.NoError(t, err, "SizeBytes failed")
+	require.Equal(t, backingFileSizeBytes, size, "unexpected SizeBytes")
+
+	expectedContent := make([]byte, int(size))
+	buf := make([]byte, int(size))
+	for i := 0; i < 100; i++ {
+		// With equal probability, either (a) read a random range and make sure
+		// it matches expectedContent, or (b) write a random range and update
+		// our expectedContent for subsequent reads.
+		offset := rand.Int63n(int64(len(expectedContent)))
+		length := rand.Int63n(int64(len(expectedContent)) - offset)
+		if rand.Float64() > 0.5 {
+			n, err := s.ReadAt(buf[:length], offset)
+			require.NoError(t, err)
+			require.Equal(t, length, int64(n))
+			require.Equal(t, expectedContent[offset:offset+length], buf[:length])
+		} else {
+			_, err := rand.Read(buf[:length])
+			require.NoError(t, err)
+
+			n, err := s.WriteAt(buf[:length], offset)
+			require.NoError(t, err)
+			require.Equal(t, length, int64(n))
+
+			copy(expectedContent[offset:offset+length], buf[:length])
+		}
+	}
+	// Make sure we can sync and close without error.
+	err = s.Sync()
+	require.NoError(t, err, "Sync failed")
+	err = s.Close()
+	require.NoError(t, err, "Close failed")
+}


### PR DESCRIPTION
- Add an interface for block-level storage
- Add a `File` implementation that uses `read()/write()`
- Add an `Mmap` implementation that uses `mmap()`. This is a bit experimental, but so far it seems to perform much better than `File`, with a tradeoff that it uses more memory. In a test with Bazel, the performance of nbd+Mmap is only 2% worse than our existing implementation which uses firecracker's Drive API to mount an ext4 image as a block device, compared to 20% worse for nbd+File.

In future PRs, this can be evolved to support copy-on-write (for forkable snapshots) as well as remote snapshot storage (e.g. lazily downloading blocks from cache).

**Related issues**: N/A
