### PR TITLE
Replace some usages of testdigest.NewRandomDigestBuf with testdigest.RandomCASResourceBuf

### DIFF
--- a/server/backends/disk_cache/BUILD
+++ b/server/backends/disk_cache/BUILD
@@ -50,6 +50,7 @@ go_test(
         "//server/util/prefix",
         "//server/util/status",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//proto",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/server/testutil/testdigest/testdigest.go
+++ b/server/testutil/testdigest/testdigest.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
 var (
@@ -37,14 +37,17 @@ func NewRandomDigestBuf(t testing.TB, sizeBytes int64) (*repb.Digest, []byte) {
 	return d, buf
 }
 
-func RandomCASResourceBuf(t testing.TB, sizeBytes int64) (*resource.ResourceName, []byte) {
+func NewRandomResourceAndBuf(t testing.TB, sizeBytes int64, cacheType rspb.CacheType, instanceName string) (*rspb.ResourceName, []byte) {
 	d, buf := NewRandomDigestBuf(t, sizeBytes)
-	return &resource.ResourceName{Digest: d, CacheType: resource.CacheType_CAS}, buf
+	return digest.NewResourceName(d, instanceName, cacheType, repb.DigestFunction_SHA256).ToProto(), buf
 }
 
-func RandomACResourceBuf(t testing.TB, sizeBytes int64) (*resource.ResourceName, []byte) {
-	d, buf := NewRandomDigestBuf(t, sizeBytes)
-	return &resource.ResourceName{Digest: d, CacheType: resource.CacheType_AC}, buf
+func RandomCASResourceBuf(t testing.TB, sizeBytes int64) (*rspb.ResourceName, []byte) {
+	return NewRandomResourceAndBuf(t, sizeBytes, rspb.CacheType_CAS, "" /*instanceName*/)
+}
+
+func RandomACResourceBuf(t testing.TB, sizeBytes int64) (*rspb.ResourceName, []byte) {
+	return NewRandomResourceAndBuf(t, sizeBytes, rspb.CacheType_AC, "" /*instanceName*/)
 }
 
 func ReadDigestAndClose(t *testing.T, r io.ReadCloser) *repb.Digest {


### PR DESCRIPTION
In our test code, we have a fair number of tests that contain stanzas like this:

```
       d, buf := testdigest.NewRandomDigestBuf(t, size)
       r := &rspb.ResourceName{
               Digest:    d,
               CacheType: rspb.CacheType_CAS,
       }
```

This CL is the first in a series which simplifies this to simply call `testdigest.RandomCASResourceBuf` (or a variant) instead. Fixing these tests is a bit of a blocker for https://github.com/buildbuddy-io/buildbuddy/pull/4110 which otherwise would require many many test fixes that add a single field to the manually constructed ResourceName proto.