### PR TITLE
Rename `bazel_exit_code` in invocation API to `exit_code_name`

### DIFF
--- a/docs/enterprise-api.md
+++ b/docs/enterprise-api.md
@@ -179,11 +179,11 @@ message Invocation {
   // Only included if include_metadata = true.
   repeated InvocationMetadata workspace_status = 22;
 
-  // Bazel exit code name for the invocation.
+  // Exit code name for the invocation.
   // At the time of writing, valid exit code names are listed here:
   // https://github.com/bazelbuild/bazel/blob/b3602eb14cf27494a0a754bc215ec2b94d13d89b/src/main/java/com/google/devtools/build/lib/util/ExitCode.java#L42-L72
   // Ex: "INTERRUPTED".
-  string bazel_exit_code = 23;
+  string exit_code_name = 23;
 }
 
 // Key value pair containing invocation metadata.

--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -128,7 +128,7 @@ func (s *APIServer) GetInvocation(ctx context.Context, req *apipb.GetInvocationR
 			BranchName:    ti.BranchName,
 			CommitSha:     ti.CommitSHA,
 			Role:          ti.Role,
-			BazelExitCode: ti.BazelExitCode,
+			ExitCodeName:  ti.BazelExitCode,
 		}
 
 		invocations = append(invocations, apiInvocation)

--- a/proto/api/v1/invocation.proto
+++ b/proto/api/v1/invocation.proto
@@ -82,11 +82,11 @@ message Invocation {
   // Only included if include_metadata = true.
   repeated InvocationMetadata workspace_status = 22;
 
-  // Bazel exit code name for the invocation.
+  // Exit code name for the invocation.
   // At the time of writing, valid exit code names are listed here:
   // https://github.com/bazelbuild/bazel/blob/b3602eb14cf27494a0a754bc215ec2b94d13d89b/src/main/java/com/google/devtools/build/lib/util/ExitCode.java#L42-L72
   // Ex: "INTERRUPTED".
-  string bazel_exit_code = 23;
+  string exit_code_name = 23;
 }
 
 // Key value pair containing invocation metadata.


### PR DESCRIPTION
* Drop `bazel_` prefix since this could also apply to workflow invocations if we decide to add named exit codes in the future.
* Add `_name` suffix to make it more obvious that it's a string (`exit_code` sounds like an int, and in the future we might actually want to add an `exit_code` field which is an int)

**Related issues**: N/A
