### PR TITLE
go: upgrade to 1.20.5

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.20.4" # Keep in sync with WORKSPACE
+          go-version: "1.20.5" # Keep in sync with WORKSPACE
 
       - name: Mount go cache
         uses: actions/cache@v2

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -58,28 +58,28 @@ go_download_sdk(
     name = "go_sdk_linux",
     goarch = "amd64",
     goos = "linux",
-    version = "1.20.4",  # Keep in sync with .github/workflows/checkstyle.yaml
+    version = "1.20.5",  # Keep in sync with .github/workflows/checkstyle.yaml
 )
 
 go_download_sdk(
     name = "go_sdk_linux_arm64",
     goarch = "arm64",
     goos = "linux",
-    version = "1.20.4",
+    version = "1.20.5",
 )
 
 go_download_sdk(
     name = "go_sdk_darwin",
     goarch = "amd64",
     goos = "darwin",
-    version = "1.20.4",
+    version = "1.20.5",
 )
 
 go_download_sdk(
     name = "go_sdk_darwin_arm64",
     goarch = "arm64",
     goos = "darwin",
-    version = "1.20.4",
+    version = "1.20.5",
 )
 
 go_register_toolchains(


### PR DESCRIPTION
Several CVE related to CGO
https://github.com/golang/go/issues?q=milestone%3AGo1.20.5+label%3ACherryPickApproved

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
