### PR TITLE
github: Uprade actions setup-go and cache

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -23,12 +23,12 @@ jobs:
       #   uses: tj-actions/changed-files@v34.4.2
 
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: "1.20.5" # Keep in sync with WORKSPACE
 
       - name: Mount go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # In order:
           # * Module download cache


### PR DESCRIPTION
Got a warning from https://github.com/buildbuddy-io/buildbuddy/actions/runs/5202382221

```
Node.js 12 actions are deprecated.
Please update the following actions to use Node.js 16: actions/setup-go@v2, actions/cache@v2.

For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
