### PR TITLE
checkstyle: remove actions/cache

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -27,20 +27,6 @@ jobs:
         with:
           go-version: "1.20.5" # Keep in sync with WORKSPACE
 
-      - name: Mount go cache
-        uses: actions/cache@v3
-        with:
-          # In order:
-          # * Module download cache
-          # * Build cache (Linux)
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}
-            ${{ runner.os }}-go-
-
       - name: gofmt
         run: |
           gofmt -d . > gofmt-diff.txt || true


### PR DESCRIPTION
After #4131, we have upgraded actions/setup-go to version 4, which
includes similar cache functionality as actions/cache. (1)
This causes the 2 cache mounting steps to collide, leading to buggy
behaviors in Github Actions (2).

Remove actions/cache as it's no longer needed.

(1): https://github.com/actions/setup-go/blob/v4.0.1/README.md#v4
(2): https://github.com/buildbuddy-io/buildbuddy/actions/runs/5206047156/jobs/9392179281#step:20:3

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
