### PR TITLE
Use EventParser logic for repo URL, commit SHA, and role

### DIFF
--- a/server/build_event_protocol/accumulator/BUILD
+++ b/server/build_event_protocol/accumulator/BUILD
@@ -7,12 +7,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:build_event_stream_go_proto",
-        "//proto:command_line_go_proto",
         "//proto:invocation_go_proto",
         "//proto:invocation_status_go_proto",
         "//server/build_event_protocol/event_parser",
         "//server/build_event_protocol/invocation_format",
-        "//server/util/git",
         "//server/util/log",
         "//server/util/timeutil",
     ],

--- a/server/build_event_protocol/accumulator/accumulator.go
+++ b/server/build_event_protocol/accumulator/accumulator.go
@@ -3,11 +3,9 @@ package accumulator
 import (
 	"context"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
-	"github.com/buildbuddy-io/buildbuddy/proto/command_line"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/event_parser"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/invocation_format"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -15,13 +13,9 @@ import (
 
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
 	inspb "github.com/buildbuddy-io/buildbuddy/proto/invocation_status"
-	gitutil "github.com/buildbuddy-io/buildbuddy/server/util/git"
 )
 
 const (
-	repoURLFieldName                      = "repoURL"
-	commitSHAFieldName                    = "commitSHA"
-	roleFieldName                         = "role"
 	workflowIDFieldName                   = "workflowID"
 	actionNameFieldName                   = "actionName"
 	disableCommitStatusReportingFieldName = "disableCommitStatusReporting"
@@ -30,9 +24,6 @@ const (
 
 var (
 	buildMetadataFieldMapping = map[string]string{
-		"REPO_URL":                        repoURLFieldName,
-		"COMMIT_SHA":                      commitSHAFieldName,
-		"ROLE":                            roleFieldName,
 		"DISABLE_COMMIT_STATUS_REPORTING": disableCommitStatusReportingFieldName,
 		"DISABLE_TARGET_TRACKING":         disableTargetTrackingFieldName,
 	}
@@ -56,13 +47,6 @@ type Accumulator interface {
 	WorkspaceIsLoaded() bool
 	BuildMetadataIsLoaded() bool
 	BuildFinished() bool
-
-	// TODO(bduffany): Remove these methods in favor of reading them directly
-	// from the Invocation() proto fields.
-
-	RepoURL() string
-	CommitSHA() string
-	Role() string
 }
 
 // BEValues is an in-memory data structure created for each new stream of build
@@ -108,13 +92,10 @@ func (v *BEValues) AddEvent(event *build_event_stream.BuildEvent) error {
 	switch p := event.Payload.(type) {
 	case *build_event_stream.BuildEvent_Started:
 		v.handleStartedEvent(event)
-	case *build_event_stream.BuildEvent_StructuredCommandLine:
-		v.populateWorkspaceInfoFromStructuredCommandLine(p.StructuredCommandLine)
 	case *build_event_stream.BuildEvent_BuildMetadata:
 		v.populateWorkspaceInfoFromBuildMetadata(p.BuildMetadata)
 		v.sawBuildMetadataEvent = true
 	case *build_event_stream.BuildEvent_WorkspaceStatus:
-		v.populateWorkspaceInfoFromWorkspaceStatus(p.WorkspaceStatus)
 		v.sawWorkspaceStatusEvent = true
 	case *build_event_stream.BuildEvent_WorkflowConfigured:
 		v.handleWorkflowConfigured(p.WorkflowConfigured)
@@ -150,39 +131,9 @@ func (v *BEValues) Finalize(ctx context.Context) {
 	if v.BuildFinished() {
 		invocation.InvocationStatus = inspb.InvocationStatus_COMPLETE_INVOCATION_STATUS
 	}
-
-	// Do some logging so that we can understand whether the invocation fields
-	// observed by BuildStatusReporter / TargetTracker differ from the fields
-	// that we store in the DB. (This code is part of a refactor that aims
-	// to consolidate EventParser and Accumulator).
-	// TODO(bduffany): Decide how to reconcile any differences logged here, and
-	// remove this logging.
-	if v.RepoURL() != invocation.GetRepoUrl() {
-		log.CtxInfof(ctx, "Accumulator: repo_url mismatch: %q != %q", v.RepoURL(), invocation.GetRepoUrl())
-	}
-	if v.CommitSHA() != invocation.GetCommitSha() {
-		log.CtxInfof(ctx, "Accumulator: commit_sha mismatch: %q != %q", v.CommitSHA(), invocation.GetCommitSha())
-	}
-	if v.Role() != invocation.GetRole() {
-		log.CtxInfof(ctx, "Accumulator: role mismatch: %q != %q", v.Role(), invocation.GetRole())
-	}
 }
 func (v *BEValues) StartTime() time.Time {
 	return v.buildStartTime
-}
-
-// RepoURL returns the normalized repo URL.
-func (v *BEValues) RepoURL() string {
-	rawURL := v.getStringValue(repoURLFieldName)
-	normalizedURL, err := gitutil.NormalizeRepoURL(rawURL)
-	if err != nil {
-		return rawURL
-	}
-	return normalizedURL.String()
-}
-
-func (v *BEValues) CommitSHA() string {
-	return v.getStringValue(commitSHAFieldName)
 }
 
 func (v *BEValues) DisableCommitStatusReporting() bool {
@@ -191,10 +142,6 @@ func (v *BEValues) DisableCommitStatusReporting() bool {
 
 func (v *BEValues) DisableTargetTracking() bool {
 	return v.getBoolValue(disableTargetTrackingFieldName)
-}
-
-func (v *BEValues) Role() string {
-	return v.getStringValue(roleFieldName)
 }
 
 func (v *BEValues) Pattern() string {
@@ -237,10 +184,6 @@ func (v *BEValues) getStringValue(fieldName string) string {
 }
 
 func (v *BEValues) setStringValue(fieldName, proposedValue string) bool {
-	if fieldName == repoURLFieldName {
-		proposedValue = gitutil.StripRepoURLCredentials(proposedValue)
-	}
-
 	existing, ok := v.valuesMap[fieldName]
 	if ok && existing != "" {
 		return false
@@ -258,57 +201,10 @@ func (v *BEValues) handleStartedEvent(event *build_event_stream.BuildEvent) {
 	v.buildStartTime = timeutil.GetTimeWithFallback(event.GetStarted().GetStartTime(), event.GetStarted().GetStartTimeMillis())
 }
 
-func (v *BEValues) populateWorkspaceInfoFromStructuredCommandLine(commandLine *command_line.CommandLine) {
-	for _, section := range commandLine.Sections {
-		if list := section.GetOptionList(); list == nil {
-			continue
-		}
-		for _, option := range section.GetOptionList().Option {
-			if option.OptionName != "ENV" && option.OptionName != "client_env" {
-				continue
-			}
-			parts := strings.Split(option.OptionValue, "=")
-			if len(parts) != 2 {
-				continue
-			}
-			environmentVariable := parts[0]
-			value := parts[1]
-			switch environmentVariable {
-			case "CIRCLE_REPOSITORY_URL", "GITHUB_REPOSITORY", "BUILDKITE_REPO", "TRAVIS_REPO_SLUG", "GIT_URL", "CI_REPOSITORY_URL", "REPO_URL":
-				v.setStringValue(repoURLFieldName, value)
-			case "CIRCLE_SHA1", "GITHUB_SHA", "BUILDKITE_COMMIT", "TRAVIS_COMMIT", "GIT_COMMIT", "CI_COMMIT_SHA", "COMMIT_SHA", "VOLATILE_GIT_COMMIT":
-				v.setStringValue(commitSHAFieldName, value)
-			case "CI":
-				if value != "" {
-					v.setStringValue(roleFieldName, "CI")
-				}
-			case "CI_RUNNER":
-				if value != "" {
-					v.setStringValue(roleFieldName, "CI_RUNNER")
-				}
-			}
-		}
-	}
-}
-
 func (v *BEValues) populateWorkspaceInfoFromBuildMetadata(metadata *build_event_stream.BuildMetadata) {
 	for mdKey, mdVal := range metadata.Metadata {
 		if fieldName := buildMetadataFieldMapping[mdKey]; fieldName != "" {
 			v.setStringValue(fieldName, mdVal)
-		}
-	}
-}
-
-func (v *BEValues) populateWorkspaceInfoFromWorkspaceStatus(workspace *build_event_stream.WorkspaceStatus) {
-	for _, item := range workspace.Item {
-		if item.Key == "REPO_URL" {
-			v.setStringValue(repoURLFieldName, item.Value)
-		}
-		if item.Key == "COMMIT_SHA" {
-			v.setStringValue(commitSHAFieldName, item.Value)
-		}
-		if item.Key == "ROLE" {
-			v.setStringValue(roleFieldName, item.Value)
 		}
 	}
 }

--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -69,7 +69,7 @@ func (r *BuildStatusReporter) initGHClient(ctx context.Context) *github.GithubCl
 }
 
 func (r *BuildStatusReporter) ReportStatusForEvent(ctx context.Context, event *build_event_stream.BuildEvent) {
-	if role := r.buildEventAccumulator.Role(); !(role == "CI" || role == "CI_RUNNER") {
+	if role := r.buildEventAccumulator.Invocation().GetRole(); !(role == "CI" || role == "CI_RUNNER") {
 		return
 	}
 
@@ -129,13 +129,13 @@ func (r *BuildStatusReporter) flushPayloadsIfWorkspaceLoaded(ctx context.Context
 		}
 
 		// TODO(siggisim): Kick these into a queue or something (but maintain order).
-		repoURL := r.buildEventAccumulator.RepoURL()
+		repoURL := r.buildEventAccumulator.Invocation().GetRepoUrl()
 		ownerRepo, err := gitutil.OwnerRepoFromRepoURL(repoURL)
 		if err != nil {
 			log.CtxWarningf(ctx, "Failed to report GitHub status: %s", err)
 			break
 		}
-		commitSHA := r.buildEventAccumulator.CommitSHA()
+		commitSHA := r.buildEventAccumulator.Invocation().GetCommitSha()
 		if ownerRepo != "" && commitSHA != "" {
 			err = r.githubClient.CreateStatus(ctx, ownerRepo, commitSHA, r.appendStatusNameSuffix(payload))
 			if err != nil {

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -198,7 +198,7 @@ func (t *TargetTracker) writeTestTargets(ctx context.Context, permissions *perms
 		// Stop write test targets to MySQL when writes to OLAP DB is enabled
 		return nil
 	}
-	repoURL := t.buildEventAccumulator.RepoURL()
+	repoURL := t.buildEventAccumulator.Invocation().GetRepoUrl()
 	knownTargets, err := readRepoTargets(ctx, t.env, repoURL)
 	if err != nil {
 		return err
@@ -252,7 +252,7 @@ func (t *TargetTracker) writeTestTargetStatuses(ctx context.Context, permissions
 		// Stop write test targets to MySQL when writes to OLAP DB is enabled
 		return nil
 	}
-	repoURL := t.buildEventAccumulator.RepoURL()
+	repoURL := t.buildEventAccumulator.Invocation().GetRepoUrl()
 	invocationUUID, err := uuid.StringToBytes(t.invocationID())
 	if err != nil {
 		return err
@@ -295,12 +295,12 @@ func (t *TargetTracker) writeTestTargetStatusesToOLAPDB(ctx context.Context, per
 		log.CtxInfo(ctx, "skip writing test target statuses to OLAPDB because group_id is empty")
 		return nil
 	}
-	repoURL := t.buildEventAccumulator.RepoURL()
+	repoURL := t.buildEventAccumulator.Invocation().GetRepoUrl()
 	if repoURL == "" {
 		log.CtxInfo(ctx, "skip writing test target status because repo_url is empty")
 		return nil
 	}
-	commitSHA := t.buildEventAccumulator.CommitSHA()
+	commitSHA := t.buildEventAccumulator.Invocation().GetCommitSha()
 	if commitSHA == "" {
 		log.CtxInfo(ctx, "skip writing test target status because commit_sha is empty")
 		return nil
@@ -341,7 +341,7 @@ func (t *TargetTracker) writeTestTargetStatusesToOLAPDB(ctx context.Context, per
 			StartTimeUsec:  testStartTimeUsec,
 			DurationUsec:   target.totalDuration.Microseconds(),
 			BranchName:     t.buildEventAccumulator.Invocation().GetBranchName(),
-			Role:           t.buildEventAccumulator.Role(),
+			Role:           t.buildEventAccumulator.Invocation().GetRole(),
 			Command:        t.buildEventAccumulator.Invocation().GetCommand(),
 		})
 	}
@@ -408,7 +408,7 @@ func (t *TargetTracker) handleWorkspaceStatusEvent(ctx context.Context, event *b
 		log.CtxDebugf(ctx, "Not tracking targets for %q because it's not a test", t.invocationID())
 		return
 	}
-	if t.buildEventAccumulator.Role() != "CI" {
+	if t.buildEventAccumulator.Invocation().GetRole() != "CI" {
 		log.CtxDebugf(ctx, "Not tracking targets for %q because it's not a CI build", t.invocationID())
 		return
 	}
@@ -432,7 +432,7 @@ func (t *TargetTracker) handleLastEvent(ctx context.Context, event *build_event_
 		log.Debugf("Not tracking targets statuses for %q because it's not a test", t.invocationID())
 		return
 	}
-	if t.buildEventAccumulator.Role() != "CI" {
+	if t.buildEventAccumulator.Invocation().GetRole() != "CI" {
 		log.CtxDebugf(ctx, "Not tracking target statuses for %q because it's not a CI build", t.invocationID())
 		return
 	}

--- a/server/build_event_protocol/target_tracker/target_tracker_test.go
+++ b/server/build_event_protocol/target_tracker/target_tracker_test.go
@@ -83,20 +83,8 @@ func (a *fakeAccumulator) Invocation() *inpb.Invocation {
 	}
 }
 
-func (a *fakeAccumulator) Role() string {
-	return a.role
-}
-
-func (a *fakeAccumulator) RepoURL() string {
-	return a.repoURL
-}
-
 func (a *fakeAccumulator) StartTime() time.Time {
 	return time.Now()
-}
-
-func (a *fakeAccumulator) CommitSHA() string {
-	return ""
 }
 
 func (a *fakeAccumulator) DisableCommitStatusReporting() bool {


### PR DESCRIPTION
Based on logging, this will cause a few metadata computations in the wild to change, but I figure it's better to consolidate this logic and help users deal with the effects of this change on a case-by-case basis, rather than having these confusing code paths for metadata computation (the confusion is that both codepaths are computing the same metadata, but one codepath would apply to GH status reporting and test grid, and the other codepath would apply to DB fields that we display in the UI).

**Related issues**: N/A
