### PR TITLE
Firecracker: Link vmvfs into init binary

### DIFF
--- a/buildpatches/com_github_hanwen_go_fuse_v2.patch
+++ b/buildpatches/com_github_hanwen_go_fuse_v2.patch
@@ -1,0 +1,62 @@
+diff --git a/splice/pair_linux.go b/splice/pair_linux.go
+index f8923e3..fafdebf 100644
+--- a/splice/pair_linux.go
++++ b/splice/pair_linux.go
+@@ -40,7 +40,7 @@ func (p *Pair) WriteTo(fd uintptr, n int) (int, error) {
+ const _SPLICE_F_NONBLOCK = 0x2
+ 
+ func (p *Pair) discard() {
+-	_, err := syscall.Splice(p.r, nil, int(devNullFD), nil, int(p.size), _SPLICE_F_NONBLOCK)
++	_, err := syscall.Splice(p.r, nil, devNullFD(), nil, int(p.size), _SPLICE_F_NONBLOCK)
+ 	if err == syscall.EAGAIN {
+ 		// all good.
+ 	} else if err != nil {
+diff --git a/splice/splice.go b/splice/splice.go
+index cbb20b4..e1316ba 100644
+--- a/splice/splice.go
++++ b/splice/splice.go
+@@ -11,6 +11,7 @@ import (
+ 	"io/ioutil"
+ 	"log"
+ 	"os"
++	"sync"
+ 	"syscall"
+ )
+ 
+@@ -30,8 +31,11 @@ func MaxPipeSize() int {
+ // Since Linux 2.6.11, the pipe capacity is 65536 bytes.
+ const DefaultPipeSize = 16 * 4096
+ 
+-// We empty pipes by splicing to /dev/null.
+-var devNullFD uintptr
++var (
++	devNullFDOnce  sync.Once
++	devNullFDValue int
++	devNullFDErr   error
++)
+ 
+ func init() {
+ 	content, err := ioutil.ReadFile("/proc/sys/fs/pipe-max-size")
+@@ -51,13 +55,17 @@ func init() {
+ 	resizable = resizable && (errNo == 0)
+ 	r.Close()
+ 	w.Close()
++}
+ 
+-	fd, err := syscall.Open("/dev/null", os.O_WRONLY, 0)
+-	if err != nil {
+-		log.Panicf("splice: %v", err)
++// We empty pipes by splicing to /dev/null.
++func devNullFD() int {
++	devNullFDOnce.Do(func() {
++		devNullFDValue, devNullFDErr = syscall.Open("/dev/null", os.O_WRONLY, 0)
++	})
++	if devNullFDErr != nil {
++		panic(fmt.Sprintf("failed to open /dev/null: %s", devNullFDErr))
+ 	}
+-
+-	devNullFD = uintptr(fd)
++	return devNullFDValue
+ }
+ 
+ // copy & paste from syscall.

--- a/deps.bzl
+++ b/deps.bzl
@@ -2331,6 +2331,9 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "com_github_hanwen_go_fuse_v2",
         importpath = "github.com/hanwen/go-fuse/v2",
+        patch_args = ["-p1"],
+        patch_tool = "patch",
+        patches = ["@{}//buildpatches:com_github_hanwen_go_fuse_v2.patch".format(workspace_name)],
         sum = "h1:jo5QZYmBLNcl9ovypWaQ5yXMSSV+Ch68xoC3rtZvvBM=",
         version = "v2.2.0",
     )

--- a/enterprise/server/cmd/goinit/BUILD
+++ b/enterprise/server/cmd/goinit/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//enterprise/server/util/vsock",
         "//enterprise/server/vmexec",
+        "//enterprise/server/vmvfs:vmvfs_lib",
         "//proto:vmexec_go_proto",
         "//server/util/log",
         "//server/util/retry",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -199,6 +199,7 @@ func TestFirecrackerRunSimple(t *testing.T) {
 	if res.Error != nil {
 		t.Fatal(res.Error)
 	}
+	res.UsageStats = nil
 	assert.Equal(t, expectedResult, res)
 }
 
@@ -431,7 +432,7 @@ func TestFirecrackerFileMapping(t *testing.T) {
 	} else {
 		assert.Equal(t, "overlay", scratchFSU.GetFstype())
 		assert.Equal(t, "overlayfs:/scratch/bbvmroot", scratchFSU.GetSource())
-		const approxInitialScratchDiskSizeBytes = 60e6
+		const approxInitialScratchDiskSizeBytes = 40e6
 		assert.InDelta(
 			t, approxInitialScratchDiskSizeBytes+scratchTestFileSizeBytes,
 			scratchFSU.GetUsedBytes(),

--- a/enterprise/server/vmvfs/BUILD
+++ b/enterprise/server/vmvfs/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -16,11 +16,4 @@ go_library(
         "@com_github_mdlayher_vsock//:vsock",
         "@org_golang_google_grpc//:go_default_library",
     ],
-)
-
-go_binary(
-    name = "vmvfs",
-    embed = [":vmvfs_lib"],
-    pure = "on",
-    static = "on",
 )

--- a/enterprise/vmsupport/bin/BUILD
+++ b/enterprise/vmsupport/bin/BUILD
@@ -4,13 +4,11 @@ genrule(
     name = "mkinitrd",
     srcs = [
         "//enterprise/server/cmd/goinit",
-        "//enterprise/server/vmvfs",
     ],
     outs = ["initrd.cpio"],
     cmd_bash = """
         env \
             GOINIT=$(location //enterprise/server/cmd/goinit:goinit) \
-            VMVFS=$(location //enterprise/server/vmvfs) \
             CPIO=$(location //enterprise/tools/cpio) \
             ./$(location mkinitrd.sh) \
             "$@"

--- a/enterprise/vmsupport/bin/mkinitrd.sh
+++ b/enterprise/vmsupport/bin/mkinitrd.sh
@@ -8,7 +8,6 @@ RANDOM_STR=$(
 ROOT_DIR="${RANDOM_STR}"
 mkdir -p "${ROOT_DIR}"
 cp "${GOINIT}" "${ROOT_DIR}/init"
-cp "${VMVFS}" "${ROOT_DIR}/vmvfs"
 
 abspath() {
   if ! [[ "$1" =~ ^/ ]]; then
@@ -22,5 +21,5 @@ FSPATH="$(abspath "$1")"
 CPIO="$(abspath "$CPIO")"
 (
   cd "$ROOT_DIR"
-  "$CPIO" -out "$FSPATH" -- init vmvfs
+  "$CPIO" -out "$FSPATH" -- init
 )


### PR DESCRIPTION
This reduces the size of the initial RAM disk from 50MB -> 26MB

The go-fuse patch is required because it eagerly tries to read `/dev/null` in an `init()` func, and panics because it doesn't exist (as we haven't yet mounted devtempfs to /dev). I will see if I can upstream these changes and remove the patch in a follow-up.

**Related issues**: N/A
