### PR TITLE
Add support for encrypting API keys.

### DIFF
--- a/enterprise/server/backends/authdb/BUILD
+++ b/enterprise/server/backends/authdb/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//server/util/random",
         "//server/util/role",
         "//server/util/status",
+        "@org_golang_x_crypto//chacha20",
     ],
 )
 
@@ -29,6 +30,7 @@ go_test(
     name = "authdb_test",
     srcs = ["authdb_test.go"],
     deps = [
+        ":authdb",
         "//enterprise/server/testutil/enterprise_testauth",
         "//enterprise/server/testutil/enterprise_testenv",
         "//server/environment",
@@ -57,6 +59,7 @@ go_test(
     },
     tags = ["docker"],
     deps = [
+        ":authdb",
         "//enterprise/server/testutil/enterprise_testauth",
         "//enterprise/server/testutil/enterprise_testenv",
         "//server/environment",
@@ -85,6 +88,7 @@ go_test(
     },
     tags = ["docker"],
     deps = [
+        ":authdb",
         "//enterprise/server/testutil/enterprise_testauth",
         "//enterprise/server/testutil/enterprise_testenv",
         "//server/environment",

--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -34,7 +34,7 @@ const (
 	apiKeyNonceLength = 6
 
 	// Encrypted API keys have this prefix in the database.
-	apiKeyEncryptedValuePrefix = "en"
+	apiKeyEncryptedValuePrefix = "en$"
 
 	apiKeyEncryptionBackfillBatchSize = 100
 )

--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -2,7 +2,10 @@ package authdb
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"flag"
+	"fmt"
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -17,6 +20,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/buildbuddy-io/buildbuddy/server/util/role"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"golang.org/x/crypto/chacha20"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
 	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
@@ -25,19 +29,108 @@ import (
 
 const (
 	apiKeyLength = 20
+
+	// For encrypted keys, the first N characters serve as the nonce.
+	apiKeyNonceLength = 6
+
+	// Encrypted API keys have this prefix in the database.
+	apiKeyEncryptedValuePrefix = "en"
+
+	apiKeyEncryptionBackfillBatchSize = 100
 )
 
 var (
 	userOwnedKeysEnabled = flag.Bool("app.user_owned_keys_enabled", false, "If true, enable user-owned API keys.")
+	apiKeyEncryptionKey  = flag.String("auth.api_key_encryption.key", "", "Base64-encoded encryption key for API keys.")
+	encryptNewKeys       = flag.Bool("auth.api_key_encryption.encrypt_new_keys", false, "If enabled, all new API keys will be written in an encrypted format.")
+	encryptOldKeys       = flag.Bool("auth.api_key_encryption.encrypt_old_keys", false, "If enabled, all existing unencrypted keys will be encrypted on startup.")
 )
 
 type AuthDB struct {
 	env environment.Env
 	h   interfaces.DBHandle
+
+	// Nil if API key encryption is not enabled.
+	apiKeyEncryptionKey []byte
 }
 
-func NewAuthDB(env environment.Env, h interfaces.DBHandle) *AuthDB {
-	return &AuthDB{env: env, h: h}
+func NewAuthDB(env environment.Env, h interfaces.DBHandle) (*AuthDB, error) {
+	adb := &AuthDB{env: env, h: h}
+	if *apiKeyEncryptionKey != "" {
+		key, err := base64.StdEncoding.DecodeString(*apiKeyEncryptionKey)
+		if err != nil {
+			return nil, status.InvalidArgumentErrorf("could not decode API Key encryption key: %s", err)
+		}
+		if len(key) != chacha20.KeySize {
+			return nil, status.InvalidArgumentError("API Key encryption key does not have expected length")
+		}
+		adb.apiKeyEncryptionKey = key
+		if err := adb.backfillUnencryptedKeys(); err != nil {
+			return nil, err
+		}
+	}
+	return adb, nil
+}
+
+func (d *AuthDB) backfillUnencryptedKeys() error {
+	if d.apiKeyEncryptionKey == nil {
+		return nil
+	}
+	if !*encryptOldKeys {
+		return nil
+	}
+
+	ctx := d.env.GetServerContext()
+	dbh := d.env.GetDBHandle().DB(ctx)
+
+	for {
+		query := fmt.Sprintf(`SELECT * FROM "APIKeys" WHERE value NOT LIKE '%s%%' LIMIT %d`, apiKeyEncryptedValuePrefix, apiKeyEncryptionBackfillBatchSize)
+		rows, err := dbh.Raw(query).Rows()
+		if err != nil {
+			return err
+		}
+		var keysToUpdate []*tables.APIKey
+		for rows.Next() {
+			var apk tables.APIKey
+			if err := dbh.ScanRows(rows, &apk); err != nil {
+				return err
+			}
+			keysToUpdate = append(keysToUpdate, &apk)
+		}
+
+		if len(keysToUpdate) == 0 {
+			break
+		}
+
+		rowsUpdated := 0
+		for _, apk := range keysToUpdate {
+			encrypted, nonce, err := d.encryptAPIKey(apk.Value)
+			if err != nil {
+				return err
+			}
+			if err := dbh.Exec(`
+			UPDATE "APIKeys"
+			SET value = ?, nonce = ?
+			WHERE api_key_id = ?`,
+				encrypted, nonce, apk.APIKeyID,
+			).Error; err != nil {
+				return err
+			}
+			rowsUpdated++
+		}
+		if rowsUpdated == 0 {
+			break
+		}
+	}
+
+	idxName := "api_key_nonce_index"
+	if !dbh.Migrator().HasIndex("APIKeys", idxName) {
+		if err := dbh.Exec(fmt.Sprintf(`CREATE UNIQUE INDEX %s ON "APIKeys" (nonce)`, idxName)).Error; err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 type apiKeyGroup struct {
@@ -99,15 +192,86 @@ func (d *AuthDB) ClearSession(ctx context.Context, sessionID string) error {
 	return err
 }
 
+func (d *AuthDB) encryptAPIKey(apiKey string) (string, string, error) {
+	if len(apiKey) != apiKeyLength {
+		return "", "", status.FailedPreconditionErrorf("Invalid API key %q", redactInvalidAPIKey(apiKey))
+	}
+	if d.apiKeyEncryptionKey == nil {
+		return "", "", status.FailedPreconditionError("API key encryption is not enabled")
+	}
+
+	nonce := apiKey[:apiKeyNonceLength]
+	paddedNonce := make([]byte, chacha20.NonceSize)
+	copy(paddedNonce, nonce)
+	ciph, err := chacha20.NewUnauthenticatedCipher(d.apiKeyEncryptionKey, paddedNonce)
+	if err != nil {
+		return "", "", status.InternalErrorf("could not create API key cipher: %s", err)
+	}
+
+	data := []byte(apiKey[apiKeyNonceLength:])
+	ciph.XORKeyStream(data, data)
+	data = append([]byte(apiKey[:apiKeyNonceLength]), data...)
+	return apiKeyEncryptedValuePrefix + hex.EncodeToString(data), nonce, nil
+}
+
+func (d *AuthDB) decryptAPIKey(encryptedAPIKey string) (string, error) {
+	if !strings.HasPrefix(encryptedAPIKey, apiKeyEncryptedValuePrefix) {
+		return "", status.FailedPreconditionErrorf("Encrypted API key has invalid prefix")
+	}
+	encryptedAPIKey = strings.TrimPrefix(encryptedAPIKey, apiKeyEncryptedValuePrefix)
+	if d.apiKeyEncryptionKey == nil {
+		return "", status.FailedPreconditionError("API key encryption is not enabled")
+	}
+	decoded, err := hex.DecodeString(encryptedAPIKey)
+	if err != nil {
+		return "", err
+	}
+	if len(decoded) < apiKeyNonceLength {
+		return "", status.FailedPreconditionError("Encrypted API key too short")
+	}
+	nonce := make([]byte, chacha20.NonceSize)
+	copy(nonce, decoded[:apiKeyNonceLength])
+	data := decoded[apiKeyNonceLength:]
+	ciph, err := chacha20.NewUnauthenticatedCipher(d.apiKeyEncryptionKey, nonce)
+	if err != nil {
+		return "", status.InternalErrorf("could not create API key cipher: %s", err)
+	}
+	ciph.XORKeyStream(data, data)
+	return string(decoded[:apiKeyNonceLength]) + string(data), nil
+}
+
+func (d *AuthDB) fillDecryptedAPIKey(ak *tables.APIKey) error {
+	if d.apiKeyEncryptionKey == nil || !strings.HasPrefix(ak.Value, apiKeyEncryptedValuePrefix) {
+		return nil
+	}
+	key, err := d.decryptAPIKey(ak.Value)
+	if err != nil {
+		return err
+	}
+	ak.Value = key
+	return nil
+}
+
 func (d *AuthDB) GetAPIKeyGroupFromAPIKey(ctx context.Context, apiKey string) (interfaces.APIKeyGroup, error) {
-	if strings.Contains(strings.TrimSpace(apiKey), " ") || len(strings.TrimSpace(apiKey)) > apiKeyLength {
+	apiKey = strings.TrimSpace(apiKey)
+	if strings.Contains(apiKey, " ") || len(apiKey) != apiKeyLength {
 		return nil, status.UnauthenticatedErrorf("Invalid API key %q", redactInvalidAPIKey(apiKey))
 	}
 
 	akg := &apiKeyGroup{}
 	err := d.h.TransactionWithOptions(ctx, db.Opts().WithStaleReads(), func(tx *db.DB) error {
 		qb := d.newAPIKeyGroupQuery(true /*=allowUserOwnedKeys*/)
-		qb.AddWhereClause(`ak.value = ?`, apiKey)
+		keyClauses := query_builder.OrClauses{}
+		keyClauses.AddOr("ak.value = ?", apiKey)
+		if d.apiKeyEncryptionKey != nil {
+			encryptedAPIKey, _, err := d.encryptAPIKey(apiKey)
+			if err != nil {
+				return err
+			}
+			keyClauses.AddOr("ak.value = ?", encryptedAPIKey)
+		}
+		keyQuery, keyArgs := keyClauses.Build()
+		qb.AddWhereClause(keyQuery, keyArgs...)
 		q, args := qb.Build()
 		existingRow := tx.Raw(q, args...)
 		return existingRow.Take(akg).Error
@@ -259,7 +423,12 @@ func redactInvalidAPIKey(key string) string {
 	return key[:1] + "***" + key[len(key)-1:]
 }
 
-func createAPIKey(db *db.DB, userID, groupID, value, label string, caps []akpb.ApiKey_Capability, visibleToDevelopers bool) (*tables.APIKey, error) {
+func (d *AuthDB) createAPIKey(db *db.DB, userID, groupID, label string, caps []akpb.ApiKey_Capability, visibleToDevelopers bool) (*tables.APIKey, error) {
+	key, err := newAPIKeyToken()
+	if err != nil {
+		return nil, err
+	}
+
 	pk, err := tables.PrimaryKeyForTable("APIKeys")
 	if err != nil {
 		return nil, err
@@ -270,6 +439,16 @@ func createAPIKey(db *db.DB, userID, groupID, value, label string, caps []akpb.A
 	} else {
 		keyPerms = perms.OWNER_READ | perms.OWNER_WRITE
 	}
+
+	nonce := ""
+	if d.apiKeyEncryptionKey != nil && *encryptNewKeys {
+		ek, n, err := d.encryptAPIKey(key)
+		if err != nil {
+			return nil, err
+		}
+		nonce = n
+		key = ek
+	}
 	err = db.Exec(`
 		INSERT INTO "APIKeys" (
 			api_key_id,
@@ -278,15 +457,17 @@ func createAPIKey(db *db.DB, userID, groupID, value, label string, caps []akpb.A
 			perms,
 			capabilities,
 			value,
+			nonce,
 			label,
 			visible_to_developers
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		pk,
 		userID,
 		groupID,
 		keyPerms,
 		capabilities.ToInt(caps),
-		value,
+		key,
+		nonce,
 		label,
 		visibleToDevelopers,
 	).Error
@@ -297,7 +478,7 @@ func createAPIKey(db *db.DB, userID, groupID, value, label string, caps []akpb.A
 		APIKeyID:            pk,
 		UserID:              userID,
 		GroupID:             groupID,
-		Value:               value,
+		Value:               key,
 		Label:               label,
 		Perms:               keyPerms,
 		Capabilities:        capabilities.ToInt(caps),
@@ -305,17 +486,8 @@ func createAPIKey(db *db.DB, userID, groupID, value, label string, caps []akpb.A
 	}, nil
 }
 
-func randomToken(length int) string {
-	// NB: Keep in sync with BuildBuddyServer#redactAPIKeys, which relies on this exact impl.
-	token, err := random.RandomString(length)
-	if err != nil {
-		token = "bUiLdBuDdy"
-	}
-	return token
-}
-
-func newAPIKeyToken() string {
-	return randomToken(apiKeyLength)
+func newAPIKeyToken() (string, error) {
+	return random.RandomString(apiKeyLength)
 }
 
 func (d *AuthDB) authorizeGroupAdminRole(ctx context.Context, groupID string) error {
@@ -337,14 +509,14 @@ func (d *AuthDB) CreateAPIKey(ctx context.Context, groupID string, label string,
 		return nil, err
 	}
 
-	return createAPIKey(d.h.DB(ctx), "" /*=userID*/, groupID, newAPIKeyToken(), label, caps, visibleToDevelopers)
+	return d.createAPIKey(d.h.DB(ctx), "" /*=userID*/, groupID, label, caps, visibleToDevelopers)
 }
 
 func (d *AuthDB) CreateAPIKeyWithoutAuthCheck(tx *db.DB, groupID string, label string, caps []akpb.ApiKey_Capability, visibleToDevelopers bool) (*tables.APIKey, error) {
 	if groupID == "" {
 		return nil, status.InvalidArgumentError("Group ID cannot be nil.")
 	}
-	return createAPIKey(tx, "" /*=userID*/, groupID, newAPIKeyToken(), label, caps, visibleToDevelopers)
+	return d.createAPIKey(tx, "" /*=userID*/, groupID, label, caps, visibleToDevelopers)
 }
 
 // Returns whether the given capabilities list contains any capabilities that
@@ -408,7 +580,7 @@ func (d *AuthDB) CreateUserAPIKey(ctx context.Context, groupID, label string, ca
 			return status.PermissionDeniedErrorf("group %q does not have user-owned keys enabled", groupID)
 		}
 
-		key, err := createAPIKey(tx, u.GetUserID(), groupID, newAPIKeyToken(), label, capabilities, false /*=visibleToDevelopers*/)
+		key, err := d.createAPIKey(tx, u.GetUserID(), groupID, label, capabilities, false /*=visibleToDevelopers*/)
 		if err != nil {
 			return err
 		}
@@ -462,6 +634,9 @@ func (d *AuthDB) GetAPIKeyForInternalUseOnly(ctx context.Context, groupID string
 		}
 		return nil, err
 	}
+	if err := d.fillDecryptedAPIKey(key); err != nil {
+		return nil, err
+	}
 	return key, nil
 }
 
@@ -498,6 +673,9 @@ func (d *AuthDB) GetAPIKeys(ctx context.Context, groupID string) ([]*tables.APIK
 	for rows.Next() {
 		k := &tables.APIKey{}
 		if err := d.h.DB(ctx).ScanRows(rows, k); err != nil {
+			return nil, err
+		}
+		if err := d.fillDecryptedAPIKey(k); err != nil {
 			return nil, err
 		}
 		keys = append(keys, k)
@@ -616,6 +794,9 @@ func (d *AuthDB) GetUserAPIKeys(ctx context.Context, groupID string) ([]*tables.
 	for rows.Next() {
 		k := &tables.APIKey{}
 		if err := d.h.DB(ctx).ScanRows(rows, k); err != nil {
+			return nil, err
+		}
+		if err := d.fillDecryptedAPIKey(k); err != nil {
 			return nil, err
 		}
 		keys = append(keys, k)

--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -41,7 +41,7 @@ var (
 	userOwnedKeysEnabled = flag.Bool("app.user_owned_keys_enabled", false, "If true, enable user-owned API keys.")
 	apiKeyEncryptionKey  = flag.String("auth.api_key_encryption.key", "", "Base64-encoded 256-bit encryption key for API keys.")
 	encryptNewKeys       = flag.Bool("auth.api_key_encryption.encrypt_new_keys", false, "If enabled, all new API keys will be written in an encrypted format.")
-	encryptOldKeys       = flag.Bool("auth.api_key_encryption.encrypt_old_keys", false, "If enabled, all existing unencrypted keys will be encrypted on startup.")
+	encryptOldKeys       = flag.Bool("auth.api_key_encryption.encrypt_old_keys", false, "If enabled, all existing unencrypted keys will be encrypted on startup. The unencrypted keys will remain in the database and will need to be cleared manually after verifying the success of the migration.")
 )
 
 type AuthDB struct {

--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -2,13 +2,14 @@ package authdb_test
 
 import (
 	"context"
-	crand "crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"math/rand"
 	"strconv"
 	"testing"
 	"time"
+
+	crand "crypto/rand"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/authdb"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testauth"

--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -2,11 +2,15 @@ package authdb_test
 
 import (
 	"context"
+	crand "crypto/rand"
+	"encoding/base64"
+	"fmt"
 	"math/rand"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/authdb"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testauth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -80,33 +84,71 @@ func TestSessionInsertUpdateDeleteRead(t *testing.T) {
 }
 
 func TestGetAPIKeyGroupFromAPIKey(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
+	for _, encrypt := range []bool{false, true} {
+		t.Run(fmt.Sprintf("encrypt_%t", encrypt), func(t *testing.T) {
+			if encrypt {
+				key := make([]byte, 32)
+				crand.Read(key)
+				flags.Set(t, "auth.api_key_encryption.key", base64.StdEncoding.EncodeToString(key))
+				flags.Set(t, "auth.api_key_encryption.encrypt_new_keys", true)
+			}
+			ctx := context.Background()
+			env := setupEnv(t)
+			adb := env.GetAuthDB()
+
+			keys := createRandomAPIKeys(t, ctx, env)
+			randKey := keys[rand.Intn(len(keys))]
+
+			akg, err := adb.GetAPIKeyGroupFromAPIKey(ctx, randKey.Value)
+			require.NoError(t, err)
+
+			assert.Equal(t, "", akg.GetUserID())
+			assert.Equal(t, randKey.GroupID, akg.GetGroupID())
+			assert.Equal(t, randKey.Capabilities, akg.GetCapabilities())
+			assert.Equal(t, false, akg.GetUseGroupOwnedExecutors())
+
+			// Using an invalid or empty value should produce an error
+			akg, err = adb.GetAPIKeyGroupFromAPIKey(ctx, "")
+			require.Nil(t, akg)
+			require.Truef(
+				t, status.IsUnauthenticatedError(err),
+				"expected Unauthenticated error; got: %v", err)
+			akg, err = adb.GetAPIKeyGroupFromAPIKey(ctx, "INVALID")
+			require.Nil(t, akg)
+			require.Truef(
+				t, status.IsUnauthenticatedError(err),
+				"expected Unauthenticated error; got: %v", err)
+		})
+	}
+}
+
+func TestBackfillUnencryptedKeys(t *testing.T) {
 	ctx := context.Background()
 	env := setupEnv(t)
 	adb := env.GetAuthDB()
 
 	keys := createRandomAPIKeys(t, ctx, env)
-	randKey := keys[rand.Intn(len(keys))]
 
-	akg, err := adb.GetAPIKeyGroupFromAPIKey(ctx, randKey.Value)
+	// Create a new AuthDB instance with encryption backfill enabled. This
+	// should encrypt all the keys created above.
+	key := make([]byte, 32)
+	crand.Read(key)
+	flags.Set(t, "auth.api_key_encryption.key", base64.StdEncoding.EncodeToString(key))
+	flags.Set(t, "auth.api_key_encryption.encrypt_new_keys", true)
+	flags.Set(t, "auth.api_key_encryption.encrypt_old_keys", true)
+	adb, err := authdb.NewAuthDB(env, env.GetDBHandle())
 	require.NoError(t, err)
 
-	assert.Equal(t, "", akg.GetUserID())
-	assert.Equal(t, randKey.GroupID, akg.GetGroupID())
-	assert.Equal(t, randKey.Capabilities, akg.GetCapabilities())
-	assert.Equal(t, false, akg.GetUseGroupOwnedExecutors())
+	// Verify that we can still find the keys after backfill.
+	for _, k := range keys {
+		akg, err := adb.GetAPIKeyGroupFromAPIKey(ctx, k.Value)
+		require.NoError(t, err)
 
-	// Using an invalid or empty value should produce an error
-	akg, err = adb.GetAPIKeyGroupFromAPIKey(ctx, "")
-	require.Nil(t, akg)
-	require.Truef(
-		t, status.IsUnauthenticatedError(err),
-		"expected Unauthenticated error; got: %v", err)
-	akg, err = adb.GetAPIKeyGroupFromAPIKey(ctx, "INVALID")
-	require.Nil(t, akg)
-	require.Truef(
-		t, status.IsUnauthenticatedError(err),
-		"expected Unauthenticated error; got: %v", err)
+		assert.Equal(t, "", akg.GetUserID())
+		assert.Equal(t, k.GroupID, akg.GetGroupID())
+		assert.Equal(t, k.Capabilities, akg.GetCapabilities())
+		assert.Equal(t, false, akg.GetUseGroupOwnedExecutors())
+	}
 }
 
 func TestGetAPIKeyGroupFromAPIKeyID(t *testing.T) {
@@ -189,6 +231,45 @@ func TestGetAPIKeyGroupFromBasicAuth(t *testing.T) {
 	require.Truef(
 		t, status.IsUnauthenticatedError(err),
 		"expected Unauthenticated error; got: %v", err)
+}
+
+func TestGetAPIKeys(t *testing.T) {
+	for _, encrypt := range []bool{false, true} {
+		t.Run(fmt.Sprintf("encrypt_%t", encrypt), func(t *testing.T) {
+			if encrypt {
+				key := make([]byte, 32)
+				crand.Read(key)
+				flags.Set(t, "auth.api_key_encryption.key", base64.StdEncoding.EncodeToString(key))
+				flags.Set(t, "auth.api_key_encryption.encrypt_new_keys", true)
+			}
+			ctx := context.Background()
+			env := setupEnv(t)
+			adb := env.GetAuthDB()
+
+			users := enterprise_testauth.CreateRandomGroups(t, env)
+			// Get a random admin user.
+			var admin *tables.User
+			for _, u := range users {
+				if role.Role(u.Groups[0].Role) == role.Admin {
+					admin = u
+					break
+				}
+			}
+			require.NotNil(t, admin)
+			groupID := admin.Groups[0].Group.GroupID
+			auth := env.GetAuthenticator().(*testauth.TestAuthenticator)
+			adminCtx, err := auth.WithAuthenticatedUser(ctx, admin.UserID)
+			require.NoError(t, err)
+			keys, err := adb.GetAPIKeys(adminCtx, groupID)
+			require.NoError(t, err)
+
+			// Verify that we can auth using all of the returned keys.
+			for _, k := range keys {
+				_, err := adb.GetAPIKeyGroupFromAPIKey(ctx, k.Value)
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestGetAPIKeyGroup_UserOwnedKeys(t *testing.T) {

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -112,7 +112,11 @@ func configureFilesystemsOrDie(realEnv *real_environment.RealEnv) {
 // source main() entry point and the enterprise main() entry point, both of
 // which import from libmain.go.
 func convertToProdOrDie(ctx context.Context, env *real_environment.RealEnv) {
-	env.SetAuthDB(authdb.NewAuthDB(env, env.GetDBHandle()))
+	db, err := authdb.NewAuthDB(env, env.GetDBHandle())
+	if err != nil {
+		log.Fatalf("Could not setup auth DB: %s", err)
+	}
+	env.SetAuthDB(db)
 	configureFilesystemsOrDie(env)
 
 	if err := auth.Register(ctx, env); err != nil {

--- a/enterprise/server/quota/quota_manager_test.go
+++ b/enterprise/server/quota/quota_manager_test.go
@@ -642,7 +642,8 @@ func TestRemoveNamespace(t *testing.T) {
 
 func TestQuotaManagerApplyBucket(t *testing.T) {
 	env := testenv.GetTestEnv(t)
-	env.SetAuthDB(authdb.NewAuthDB(env, env.GetDBHandle()))
+	adb, err := authdb.NewAuthDB(env, env.GetDBHandle())
+	env.SetAuthDB(adb)
 	udb, err := userdb.NewUserDB(env, env.GetDBHandle())
 	require.NoError(t, err)
 	env.SetUserDB(udb)

--- a/enterprise/server/testutil/enterprise_testenv/BUILD
+++ b/enterprise/server/testutil/enterprise_testenv/BUILD
@@ -17,5 +17,6 @@ go_library(
         "//server/util/log",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/testutil/enterprise_testenv/enterprise_testenv.go
+++ b/enterprise/server/testutil/enterprise_testenv/enterprise_testenv.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type Options struct {
@@ -47,7 +48,9 @@ func GetCustomTestEnv(t *testing.T, opts *Options) *testenv.TestEnv {
 	flags.Set(t, "app.create_group_per_user", true)
 	flags.Set(t, "app.no_default_user_group", true)
 
-	env.SetAuthDB(authdb.NewAuthDB(env, env.GetDBHandle()))
+	db, err := authdb.NewAuthDB(env, env.GetDBHandle())
+	require.NoError(t, err)
+	env.SetAuthDB(db)
 	userDB, err := userdb.NewUserDB(env, env.GetDBHandle())
 	if err != nil {
 		assert.FailNow(t, "could not create user DB", err.Error())

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -339,16 +339,18 @@ func (s *Session) TableName() string {
 }
 
 type APIKey struct {
+	Model
+
+	APIKeyID string `gorm:"primaryKey"`
 	// The user-specified description of the API key that helps them
 	// remember what it's for.
-	Label    string
-	APIKeyID string `gorm:"primaryKey"`
-	UserID   string
-	GroupID  string `gorm:"index:api_key_group_id_index"`
+	Label   string
+	UserID  string
+	GroupID string `gorm:"index:api_key_group_id_index"`
 	// The API key token used for authentication.
 	Value string `gorm:"default:NULL;unique;uniqueIndex:api_key_value_index;"`
-	Model
-	Perms int32 `gorm:"default:NULL"`
+	Nonce string `gorm:"default:NULL;"`
+	Perms int32  `gorm:"default:NULL"`
 	// Capabilities that are enabled for this key. Defaults to CACHE_WRITE.
 	//
 	// NOTE: If the default is changed, a DB migration may be required to

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -348,9 +348,10 @@ type APIKey struct {
 	UserID  string
 	GroupID string `gorm:"index:api_key_group_id_index"`
 	// The API key token used for authentication.
-	Value string `gorm:"default:NULL;unique;uniqueIndex:api_key_value_index;"`
-	Nonce string `gorm:"default:NULL;"`
-	Perms int32  `gorm:"default:NULL"`
+	Value          string `gorm:"default:NULL;uniqueIndex:api_key_value_composite_index;index:api_key_unencrypted_value_index;"`
+	EncryptedValue string `gorm:"default:'';uniqueIndex:api_key_value_composite_index;index:api_key_encrypted_value_index;"`
+	Nonce          string `gorm:"default:NULL;"`
+	Perms          int32  `gorm:"default:NULL"`
 	// Capabilities that are enabled for this key. Defaults to CACHE_WRITE.
 	//
 	// NOTE: If the default is changed, a DB migration may be required to
@@ -1042,6 +1043,11 @@ func PostAutoMigrate(db *gorm.DB) error {
 	dropIndexIfExists(m, "Executions", "execution_invocation_id")
 	dropIndexIfExists(m, "Targets", "target_target_id")
 	dropIndexIfExists(m, "Invocations", "invocations_test_grid_query_index")
+	// Drop the unique indexes on the value column. They were replaced by a
+	// combination of a composite unique index on (value, encrypted_value) and
+	// non-unique indexes each column.
+	dropIndexIfExists(m, "APIKeys", "value")
+	dropIndexIfExists(m, "APIKeys", "api_key_value_index")
 
 	type ColRef struct {
 		table  Table


### PR DESCRIPTION
I decided to use the same column to store either the plaintext or encrypted value of the API key to simplify the schema.

There are three flags to control the behavior of the feature and to allow a gradual rollout:
 - auth.api_key_encryption.key when the key is set, the auth code will look for keys matching both the unencrypted and unencrypted form of the key. Rolling out this flag first will allow encrypted keys to be recognized by all apps once they are in the database.

  - auth.api_key_encryption.encrypt_new_keys when this is set, all newly created keys will be writen in an encrypted format

  - auth.api_key_encryption.encrypt_old_keys on startup, any existing unencryptde keys will be encrypted

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
