### PR TITLE
profile_model: fix tid === 0

### DIFF
--- a/app/flame_chart/profile_model.ts
+++ b/app/flame_chart/profile_model.ts
@@ -188,7 +188,7 @@ export function buildThreadTimelines(events: TraceEvent[], { visibilityThreshold
   }
 
   for (const event of events) {
-    event.tid = threadNameToTidMap.get(threadNameByTid.get(event.tid) || "") || -1;
+    event.tid = threadNameToTidMap.get(threadNameByTid.get(event.tid) || "") ?? -1;
   }
 
   events.sort(eventComparator);


### PR DESCRIPTION
"Critical Path" thread in Bazel profile has tid === 0.
When we validate ThreadID mapping with ThreadName, we mistakenly
detect Critical Path as having no name, thus overriding ThreadID to -1.

Fix this by switching from OR to Nullish Coalescing operator (1)
```
> thradNameToTidMap.get("Critical Path") || -1
-1

> thradNameToTidMap.get("Critical Path") ?? -1
0
```

(1): https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
