### PR TITLE
add a tiny bit of documentation about tags to metadata guide.

### DIFF
--- a/docs/guide-metadata.md
+++ b/docs/guide-metadata.md
@@ -216,7 +216,7 @@ Then you'll need to add a `workspace_status.sh` file to the root of your workspa
 
 ## Custom Links
 
-You can add custom links to the BuildBuddy overview page using the `BUILDBUDDY_LINKS` build metadata flag. These links must be comma separated, and in the form [link text](https://linkurl.com). Urls must begin with either `http://` or `https://`.
+You can add custom links to the BuildBuddy overview page using the `BUILDBUDDY_LINKS` build metadata flag. These links must be comma separated, and in the form `[link text](https://linkurl.com)`. Urls must begin with either `http://` or `https://`.
 
 Example:
 

--- a/docs/guide-metadata.md
+++ b/docs/guide-metadata.md
@@ -224,6 +224,11 @@ Example:
 --build_metadata=BUILDBUDDY_LINKS="[Search Github](https://github.com/search),[GCP Dashboard](https://console.cloud.google.com/home/dashboard)"
 ```
 
+## Tags
+
+You can add free-text tags to a build by passing a comma-separated string to the `TAGS` build metadata flag.
+
+
 ## Environment variable redacting
 
 By default, all environment variables are redacted by BuildBuddy except for `USER`, `GITHUB_ACTOR` `GITHUB_REPOSITORY`, `GITHUB_SHA`, `GITHUB_RUN_ID`, `BUILDKITE_BUILD_URL`, `BUILDKITE_JOB_ID`, `CIRCLE_REPOSITORY_URL`, `GITHUB_REPOSITORY`, `BUILDKITE_REPO`, `TRAVIS_REPO_SLUG`, `GIT_URL`,

--- a/docs/guide-metadata.md
+++ b/docs/guide-metadata.md
@@ -226,8 +226,15 @@ Example:
 
 ## Tags
 
-You can add free-text tags to a build by passing a comma-separated string to the `TAGS` build metadata flag.
+You can add multiple free-text tags to a build by passing a comma-separated string to the `TAGS` build metadata flag.
 
+Example:
+
+```
+--build_metadata=TAGS="foo,bar,baz"
+```
+
+You can filter by these tags on build history pages and the trends page. Note that when filtering by tags, you will not see in-progress and disconnected builds.
 
 ## Environment variable redacting
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
fixing the BUILDBUDDY_LINKS documentation to actually show the markdown format, too--looks like a docusaurus upgrade started parsing our example of how to make a link as a markdown link.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
