### PR TITLE
Add an `async` option to ExecuteWorkflow

### DIFF
--- a/docs/enterprise-api.md
+++ b/docs/enterprise-api.md
@@ -823,6 +823,8 @@ message ExecuteWorkflowRequest {
   // Workflow invocations are private by default, but this can be
   // set to "PUBLIC" to make the workflow invocation public.
   string visibility = 5;
+  // If true, start the workflow but do not wait for the status to be returned.
+  bool async = 6;
 }
 ```
 
@@ -839,11 +841,13 @@ message ExecuteWorkflowResponse {
     // The BuildBuddy invocation ID from executing the action.
     string invocation_id = 2;
 
-    // The GRPC status from executing the action.
+    // The gRPC status from executing the action, or from starting the action if
+    // async is true.
     google.rpc.Status status = 3;
   }
 
-  // A list of the actions executed by the API.
+  // A list of the actions executed by the API, or actions started if async is
+  // true.
   repeated ActionStatus action_statuses = 1;
 }
 ```

--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -546,6 +546,7 @@ func (s *APIServer) ExecuteWorkflow(ctx context.Context, req *apipb.ExecuteWorkf
 		TargetBranch:   req.GetRef(),
 		Clean:          req.GetClean(),
 		Visibility:     req.GetVisibility(),
+		Async:          req.GetAsync(),
 	}
 	rsp, err := wfs.ExecuteWorkflow(ctx, r)
 	if err != nil {

--- a/enterprise/server/test/integration/workflow/BUILD
+++ b/enterprise/server/test/integration/workflow/BUILD
@@ -31,6 +31,7 @@ go_test(
         "//server/testutil/testgit",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//codes",
     ],
 )
 

--- a/proto/api/v1/workflow.proto
+++ b/proto/api/v1/workflow.proto
@@ -30,6 +30,8 @@ message ExecuteWorkflowRequest {
   // Workflow invocations are private by default, but this can be
   // set to "PUBLIC" to make the workflow invocation public.
   string visibility = 5;
+  // If true, start the workflow but do not wait for the status to be returned.
+  bool async = 6;
 }
 
 message ExecuteWorkflowResponse {
@@ -42,10 +44,12 @@ message ExecuteWorkflowResponse {
     // The BuildBuddy invocation ID from executing the action.
     string invocation_id = 2;
 
-    // The GRPC status from executing the action.
+    // The gRPC status from executing the action, or from starting the action if
+    // async is true.
     google.rpc.Status status = 3;
   }
 
-  // A list of the actions executed by the API.
+  // A list of the actions executed by the API, or actions started if async is
+  // true.
   repeated ActionStatus action_statuses = 1;
 }

--- a/proto/workflow.proto
+++ b/proto/workflow.proto
@@ -173,6 +173,9 @@ message ExecuteWorkflowRequest {
 
   // Optional: PR number associated with the workflow run.
   int64 pull_request_number = 13;
+
+  // If true, start the workflow but do not wait for the status to be returned.
+  bool async = 14;
 }
 
 message ExecuteWorkflowResponse {
@@ -191,11 +194,13 @@ message ExecuteWorkflowResponse {
     // The BuildBuddy invocation ID from executing the action.
     string invocation_id = 2;
 
-    // The GRPC status from executing the action.
+    // The gRPC status from executing the action, or from starting the action if
+    // async is true.
     google.rpc.Status status = 3;
   }
 
-  // A list of the actions executed by the API.
+  // A list of the actions executed by the API, or actions started if async is
+  // true.
   repeated ActionStatus action_statuses = 3;
 }
 


### PR DESCRIPTION
The UI will set `async: true` so it can link to the invocation page without needing to wait for the workflow task to be dequeued. Making this opt-in to avoid a breaking change to the public API.

Also fix a bug that `waitForWorkflowInvocationCreated` failures weren't getting propagated to the `ActionStatus.status` field (discovered this while I was failing to get the test to fail when commenting out `async: true`).

**Related issues**: N/A
