### PR TITLE
Support a "queued" invocation view and use it for queued workflows

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -609,6 +609,7 @@ ts_library(
         "@npm//long",
         "@npm//lucide-react",
         "@npm//react",
+        "@npm//tslib",
     ],
 )
 

--- a/app/invocation/invocation_in_progress.tsx
+++ b/app/invocation/invocation_in_progress.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 interface Props {
   invocationId: string;
+  title?: React.ReactNode;
 }
 
 export default class InvocationInProgressComponent extends React.Component<Props> {
@@ -12,7 +13,7 @@ export default class InvocationInProgressComponent extends React.Component<Props
           <div className="container">
             <div className="breadcrumbs">Invocation {this.props.invocationId}</div>
             <div className="titles">
-              <div className="title">Invocation in progress...</div>
+              <div className="title">{this.props.title || "Invocation in progress..."}</div>
             </div>
             <div className="details">This page will refresh every few seconds.</div>
           </div>

--- a/app/invocation/invocation_logs_model.tsx
+++ b/app/invocation/invocation_logs_model.tsx
@@ -26,6 +26,7 @@ export default class InvocationLogsModel {
   constructor(private invocationId: string) {}
 
   startFetching() {
+    this.stopFetching();
     this.fetchTail();
   }
 

--- a/app/invocation/workflow_rerun_button.tsx
+++ b/app/invocation/workflow_rerun_button.tsx
@@ -78,6 +78,7 @@ export default class WorkflowRerunButton extends React.Component<WorkflowRerunBu
           clean,
           visibility: this.props.model.buildMetadataMap.get("VISIBILITY") || "",
           pullRequestNumber: Long.fromString(this.props.model.buildMetadataMap.get("PULL_REQUEST_NUMBER") || "0"),
+          async: true,
         })
       )
       .then((response) => {
@@ -96,7 +97,7 @@ export default class WorkflowRerunButton extends React.Component<WorkflowRerunBu
         });
 
         if (invocationId !== "") {
-          router.navigateTo(`/invocation/${invocationId}`);
+          router.navigateTo(`/invocation/${invocationId}?queued=true`);
         } else {
           errorService.handleError(errorMsg);
         }

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -119,7 +119,11 @@ class Router {
    */
   setQueryParam(key: string, value: any) {
     const url = new URL(window.location.href);
-    url.searchParams.set(key, String(value));
+    if (value === undefined || value === null) {
+      url.searchParams.delete(key);
+    } else {
+      url.searchParams.set(key, String(value));
+    }
     window.history.replaceState({}, "", url.href);
   }
 

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1289,7 +1289,7 @@ func (ws *workflowService) createApprovalRequiredStatus(ctx context.Context, wf 
 func (ws *workflowService) createQueuedStatus(ctx context.Context, wf *tables.Workflow, wd *interfaces.WebhookData, actionName, invocationID string) error {
 	invocationURL := build_buddy_url.WithPath("/invocation/" + invocationID)
 	invocationURL.RawQuery = "queued=true"
-	status := github.NewGithubStatusPayload(actionName, invocationURL.String(), "Waiting for available worker...", github.PendingState)
+	status := github.NewGithubStatusPayload(actionName, invocationURL.String(), "Queued...", github.PendingState)
 	ownerRepo, err := gitutil.OwnerRepoFromRepoURL(wd.TargetRepoURL)
 	if err != nil {
 		return err


### PR DESCRIPTION
* When clicking the workflow re-run button, set `async: true` in the ExecuteWorkflowRequest to avoid waiting for the invocation to be created. Instead, just wait for the action to be queued, and navigate to the invocation page with `?queued=true`.
* When `queued=true` is set in the URL on the invocation page, show a page similar to the "Invocation is in progress..." screen, but with the title "Invocation is waiting for an available worker..." instead.
* Whenever we enqueue a workflow action, publish a pending status to GitHub with the message "Queued...". The status "Details" link points to an invocation URL with `queued=true`.

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/2243
