### PR TITLE
CLI: Add some new block types to WORKSPACE.yaml parsing

### DIFF
--- a/cli/translate/yaml/BUILD
+++ b/cli/translate/yaml/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/translate/yaml",
     visibility = ["//visibility:public"],
     deps = [
+        "//cli/add",
         "//cli/log",
         "//cli/translate/builtins",
         "@in_gopkg_yaml_v2//:yaml_v2",

--- a/cli/translate/yaml/yaml.go
+++ b/cli/translate/yaml/yaml.go
@@ -61,7 +61,7 @@ func (y *yamlTranslator) translateRule(m yaml.MapSlice) string {
 			if load, ok := i.Value.(yaml.MapSlice); ok {
 				s = s + y.translateLoad(load) + newLineSeparator
 			} else {
-				log.Printf("load: must be a list")
+				log.Warnf("load: must be a list")
 			}
 		case "rules":
 			if rules, ok := i.Value.([]interface{}); ok {
@@ -69,25 +69,25 @@ func (y *yamlTranslator) translateRule(m yaml.MapSlice) string {
 					s = s + y.translateRule(rule.(yaml.MapSlice)) + newLineSeparator
 				}
 			} else {
-				log.Printf("rules: must be a list")
+				log.Warnf("rules: must be a list")
 			}
 		case "deps":
 			if load, ok := i.Value.([]interface{}); ok {
 				s = s + y.translateDeps(load) + newLineSeparator
 			} else {
-				log.Printf("deps: must be a list, instead it was %T", i.Value)
+				log.Warnf("deps: must be a list, instead it was %T", i.Value)
 			}
 		case "bazel":
 			if load, ok := i.Value.(yaml.MapSlice); ok {
 				y.translateBazel(load)
 			} else {
-				log.Printf("bazel: must be a map, instead it was %T", i.Value)
+				log.Warnf("bazel: must be a map, instead it was %T", i.Value)
 			}
 		case "settings":
 			if load, ok := i.Value.(yaml.MapSlice); ok {
 				y.translateSettings(load)
 			} else {
-				log.Printf("settings: must be a list, instead it was %T", i.Value)
+				log.Warnf("settings: must be a list, instead it was %T", i.Value)
 			}
 		case "templates":
 			if load, ok := i.Value.(yaml.MapSlice); ok {
@@ -95,13 +95,13 @@ func (y *yamlTranslator) translateRule(m yaml.MapSlice) string {
 			} else if load, ok := i.Value.([]interface{}); ok {
 				y.translateTemplate(load)
 			} else {
-				log.Printf("template: must be a list or a map, instead it was %T", i.Value)
+				log.Warnf("template: must be a list or a map, instead it was %T", i.Value)
 			}
 		case "raw":
 			if raw, ok := i.Value.(string); ok {
 				s = s + raw + newLineSeparator
 			} else {
-				log.Printf("raw: value must be a string")
+				log.Warnf("raw: value must be a string")
 			}
 		default:
 			translatedValue := y.translateValue(i.Value, ruleName)
@@ -166,7 +166,7 @@ func (y *yamlTranslator) translateValue(v interface{}, ruleName string) string {
 	case nil:
 		return ""
 	default:
-		log.Printf("unknown translateValue type: %T", i)
+		log.Warnf("unknown translateValue type: %T", i)
 		return fmt.Sprintf("unknown translateValue type %T", i)
 	}
 }
@@ -183,7 +183,7 @@ func (y *yamlTranslator) translateLoad(m yaml.MapSlice) string {
 			value = fmt.Sprintf(`"%s"`, i)
 			y.loadList = append(y.loadList, value)
 		default:
-			log.Printf("unknown translateLoad type: %T", i)
+			log.Warnf("unknown translateLoad type: %T", i)
 			return fmt.Sprintf("unknown translateLoad type %T", i)
 		}
 		values = append(values, fmt.Sprintf(`load("%s", %s)`, i.Key.(string), value))
@@ -197,12 +197,12 @@ func (y *yamlTranslator) translateDeps(m []interface{}) string {
 	for _, dep := range m {
 		depString, ok := dep.(string)
 		if !ok {
-			log.Printf("unknown dep type: %T", dep)
+			log.Warnf("unknown dep type: %T", dep)
 			continue
 		}
 		module, resp, err := add.FetchModuleOrDisambiguate(strings.Split(depString, "@")[0])
 		if err != nil {
-			log.Printf("error fetching module: %s", err)
+			log.Warnf("error fetching module: %s", err)
 			continue
 		}
 		output += add.GenerateSnippet(module, resp)
@@ -215,18 +215,18 @@ func (y *yamlTranslator) translateBazel(m yaml.MapSlice) {
 	for _, field := range m {
 		key, ok := field.Key.(string)
 		if !ok {
-			log.Printf("unknown bazel field: %T", field.Key)
+			log.Warnf("unknown bazel field: %T", field.Key)
 			continue
 		}
 		value, ok := field.Value.(string)
 		if !ok {
-			log.Printf("unknown bazel field: %T", field.Value)
+			log.Warnf("unknown bazel field: %T", field.Value)
 			continue
 		}
 		if key == "version" {
 			err := os.WriteFile(".bazelversion", []byte(value), 0644)
 			if err != nil {
-				log.Printf("error writing .bazelversion file: %s", err)
+				log.Warnf("error writing .bazelversion file: %s", err)
 			}
 		}
 	}
@@ -240,7 +240,7 @@ func (y *yamlTranslator) translateSettings(m yaml.MapSlice) {
 
 	err := os.WriteFile(".bazelrc", []byte(bazelrc), 0644)
 	if err != nil {
-		log.Printf("error writing .bazelrc file: %s", err)
+		log.Warnf("error writing .bazelrc file: %s", err)
 	}
 }
 
@@ -263,12 +263,12 @@ func (y *yamlTranslator) translateTemplate(m []interface{}) {
 			for _, x := range slice {
 				key, ok := x.Key.(string)
 				if !ok {
-					log.Printf("unknown key type: %T", x.Value)
+					log.Warnf("unknown key type: %T", x.Value)
 					continue
 				}
 				value, ok := x.Value.(string)
 				if !ok {
-					log.Printf("unknown value type: %T", x.Value)
+					log.Warnf("unknown value type: %T", x.Value)
 					continue
 				}
 				if key == "from" {
@@ -290,13 +290,13 @@ func (y *yamlTranslator) translateTemplate(m []interface{}) {
 
 func renderTemplate(from, into string) {
 	if _, err := os.Stat(into); !os.IsNotExist(err) {
-		log.Printf("skipping template %s, directory %q already exists", from, into)
+		log.Debugf("skipping template %s, directory %q already exists", from, into)
 		return
 	}
-	log.Printf("grabbing template from %s and putting it into %q", from, into)
+	log.Debugf("grabbing template from %s and putting it into %q", from, into)
 
 	if !strings.HasPrefix(from, "github/") {
-		log.Printf("unknown template %s", from)
+		log.Warnf("unknown template %s", from)
 	}
 
 	repo := strings.Replace(from, "github/", "https://github.com/", 1)
@@ -304,10 +304,10 @@ func renderTemplate(from, into string) {
 	cmd := exec.Command("git", "clone", "--depth=1", repo+".git", into)
 	err := cmd.Run()
 	if err != nil {
-		log.Printf("error cloning repo %s: %s", repo, err)
+		log.Warnf("error cloning repo %s: %s", repo, err)
 	}
 	err = os.RemoveAll(filepath.Join(into, ".git"))
 	if err != nil {
-		log.Printf("error cleaning up git directory for %s: %s", repo, err)
+		log.Warnf("error cleaning up git directory for %s: %s", repo, err)
 	}
 }

--- a/cli/workspace/BUILD
+++ b/cli/workspace/BUILD
@@ -4,7 +4,10 @@ go_library(
     name = "workspace",
     srcs = ["workspace.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/workspace",
-    deps = ["//server/util/disk"],
+    deps = [
+        "//cli/log",
+        "//server/util/disk",
+    ],
 )
 
 package(default_visibility = ["//cli:__subpackages__"])


### PR DESCRIPTION
This PR adds support for the following top level blocks in the WORKSPACE.yaml file:
`deps`, `templates`, `settings`, `bazel`, 

This allows you to specify a single file to configure your whole Bazel setup, like so:
```
workspace:
  name: myworkspace

bazel:
  version: 6.1.1

settings:
  bes_results_url: https://app.buildbuddy.io/invocation/
  bes_backend: remote.buildbuddy.io
  remote_cache: remote.buildbuddy.io
  remote_executor: remote.buildbuddy.io

templates:
  server: github/enricofoltran/simple-go-server
  app: github/Kornil/simple-ts-react-app

deps:
  - github/bazelbuild/rules_go
  - github/bazelbuild/rules_docker
  - github/bazelbuild/rules_proto
  - github/bazelbuild/bazel-gazelle
  - github/bazelbuild/rules_nodejs
```

As an escape hatch, you can still add things to your workspace file manually like so:
```
http_archive:
    name: "io_bazel_rules_go"
    sha256: "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996"
    urls:
        - "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip"
        - "https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip"
```

As a total last resort, you can use the `raw:` block to dump whatever else you need in there:
```
raw:
  my_super_special_thing()
```