### PR TITLE
CLI: Support different github repo formats

### DIFF
--- a/cli/add/add.go
+++ b/cli/add/add.go
@@ -106,6 +106,10 @@ func HandleAdd(args []string) (int, error) {
 
 // TODO(siggisim): Support specifying a version.
 func FetchModuleOrDisambiguate(module string) (string, *RegistryResponse, error) {
+	module = strings.Replace(module, "https://", "", 1)
+	module = strings.Replace(module, "github.com/", "github/", 1)
+	module = strings.TrimRight(module, "/")
+
 	res, err := fetch(module)
 	if err != nil {
 		return "", nil, err

--- a/cli/translate/yaml/yaml.go
+++ b/cli/translate/yaml/yaml.go
@@ -297,10 +297,10 @@ func renderTemplate(from, into string) {
 
 	repo := from
 	if strings.HasPrefix(from, "github/") {
-		repo = strings.Replace(from, "github/", "https://github.com/", 1)
-	} else if strings.HasPrefix(from, "github.com") {
+		repo = "https://github.com/" + strings.TrimPrefix(from, "github/")
+	} else if strings.HasPrefix(from, "github.com/") {
 		repo = "https://" + from
-	} else if !strings.HasPrefix(from, "https://github.com") {
+	} else if !strings.HasPrefix(from, "https://github.com/") {
 		log.Warnf("unknown template %s", from)
 		return
 	}

--- a/cli/translate/yaml/yaml.go
+++ b/cli/translate/yaml/yaml.go
@@ -295,11 +295,16 @@ func renderTemplate(from, into string) {
 	}
 	log.Debugf("grabbing template from %s and putting it into %q", from, into)
 
-	if !strings.HasPrefix(from, "github/") {
+	repo := from
+	if strings.HasPrefix(from, "github/") {
+		repo = strings.Replace(from, "github/", "https://github.com/", 1)
+	} else if strings.HasPrefix(from, "github.com") {
+		repo = "https://" + from
+	} else if !strings.HasPrefix(from, "https://github.com") {
 		log.Warnf("unknown template %s", from)
+		return
 	}
-
-	repo := strings.Replace(from, "github/", "https://github.com/", 1)
+	repo = strings.TrimRight(repo, "/")
 
 	cmd := exec.Command("git", "clone", "--depth=1", repo+".git", into)
 	err := cmd.Run()


### PR DESCRIPTION
This supports the following github repo formats for templates and deps:
- github/buildbuddy-io/buildbuddy
- github/buildbuddy-io/buildbuddy/
- github.com/buildbuddy-io/buildbuddy
- github.com/buildbuddy-io/buildbuddy/
- https://github.com/buildbuddy-io/buildbuddy
- https://github.com/buildbuddy-io/buildbuddy/
