### PR TITLE
Split the authenticator interface into separate interfaces

### DIFF
--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -114,8 +114,6 @@ type InstallationAuthenticator interface {
 	AnonymousUsageEnabled() bool
 	// Return a slice containing the providers
 	PublicIssuers() []string
-	// Whether SSO is enabled for this authenticator
-	SSOEnabled() bool
 }
 
 type HTTPAuthenticator interface {
@@ -134,6 +132,9 @@ type HTTPAuthenticator interface {
 	//
 	// Application code can retrieve the stored information by calling AuthenticatedUser.
 	AuthenticatedHTTPContext(w http.ResponseWriter, r *http.Request) context.Context
+
+	// Whether SSO is enabled for this authenticator
+	SSOEnabled() bool
 }
 
 type GRPCAuthenticator interface {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -107,7 +107,7 @@ const (
 	AuthAnonymousUser = "ANON"
 )
 
-type Authenticator interface {
+type InstallationAuthenticator interface {
 	// The ID of the admin group
 	AdminGroupID() string
 	// Whether or not anonymous usage is enabled
@@ -116,6 +116,9 @@ type Authenticator interface {
 	PublicIssuers() []string
 	// Whether SSO is enabled for this authenticator
 	SSOEnabled() bool
+}
+
+type HTTPAuthenticator interface {
 	// Redirect to configured authentication provider.
 	Login(w http.ResponseWriter, r *http.Request)
 	// Clear any logout state.
@@ -131,7 +134,9 @@ type Authenticator interface {
 	//
 	// Application code can retrieve the stored information by calling AuthenticatedUser.
 	AuthenticatedHTTPContext(w http.ResponseWriter, r *http.Request) context.Context
+}
 
+type GRPCAuthenticator interface {
 	// AuthenticatedGRPCContext authenticates the user using the credentials present in the gRPC metadata and creates a
 	// child context that contains the result.
 	//
@@ -148,7 +153,9 @@ type Authenticator interface {
 	// long running operation). For all other cases it is better to use the information cached in the context
 	// retrieved via AuthenticatedUser.
 	AuthenticateGRPCRequest(ctx context.Context) (UserInfo, error)
+}
 
+type UserAuthenticator interface {
 	// FillUser may be used to construct an initial tables.User object. It
 	// is filled based on information from the authenticator's JWT.
 	FillUser(ctx context.Context, user *tables.User) error
@@ -157,7 +164,8 @@ type Authenticator interface {
 	//
 	// See AuthenticatedHTTPContext/AuthenticatedGRPCContext for a description of how the context is created.
 	AuthenticatedUser(ctx context.Context) (UserInfo, error)
-
+}
+type APIKeyAuthenticator interface {
 	// Parses and returns a BuildBuddy API key from the given string.
 	ParseAPIKeyFromString(string) (string, error)
 
@@ -171,6 +179,14 @@ type Authenticator interface {
 	// AuthContextFromTrustedJWT returns an authenticated context using a JWT
 	// which has been previously authenticated.
 	AuthContextFromTrustedJWT(ctx context.Context, jwt string) context.Context
+}
+
+type Authenticator interface {
+	InstallationAuthenticator
+	UserAuthenticator
+	HTTPAuthenticator
+	GRPCAuthenticator
+	APIKeyAuthenticator
 }
 
 type BuildBuddyServer interface {


### PR DESCRIPTION
This splits the Authenticator interface into 5 separate interfaces:
- HTTPAuthenticator
- GRPCAuthenticator
- UserAuthenticator
- APIKeyAuthenticator
- InstallationAuthenticator

Each of these new, smaller interfaces has just a handful of methods, making it easier to implement.

This is a first (small) step in a series of clean-ups that I first attempted but abandoned 2 years ago with: https://github.com/buildbuddy-io/buildbuddy/pull/1008/files

This change will allow us to remove the concept of a "fallback authenticator" which the `SAMLAuthenticator` currently relies on for methods it doesn't care about (the SAMLAuthenticator only implements HTTPAuthenticator and UserAuthenticator methods and forwards the rest to the fallback).

The ultimate goal here is clean up the `SAMLAuthenticator` and `OIDCAuthenticator` interaction in order to introduce a new `HTTPAuthenticator` that supports Github authentication.

(There is a chance we could get rid of `InstallationAuthenticator` since it basically just forwards installation level config flags. We could also potentially combine `HTTPAuthenticator` and `UserAuthenticator` into a single interface, but I don't think there's a huge downside in keeping these granular).