### PR TITLE
Make `Login`, `Auth`, and `Logout` handlers return errors instead of redirecting

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -25,7 +25,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lru"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
-	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
 	"github.com/buildbuddy-io/buildbuddy/server/util/role"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/golang-jwt/jwt"
@@ -37,6 +36,7 @@ import (
 	"google.golang.org/grpc/peer"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
+	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
 	burl "github.com/buildbuddy-io/buildbuddy/server/util/url"
 	oidc "github.com/coreos/go-oidc"
 )

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -1372,8 +1372,3 @@ func UserFromTrustedJWT(ctx context.Context) (interfaces.UserInfo, error) {
 	// WARNING: app/auth/auth_service.ts depends on this status being UNAUTHENTICATED.
 	return nil, authutil.AnonymousUserError(userNotFoundMsg)
 }
-
-func redirectWithError(w http.ResponseWriter, r *http.Request, err error) {
-	log.Warning(err.Error())
-	http.Redirect(w, r, "/?error="+url.QueryEscape(err.Error()), http.StatusTemporaryRedirect)
-}

--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -312,4 +313,18 @@ func WrapAuthenticatedExternalHandler(env environment.Env, next http.Handler) ht
 		RequestID,
 		RecoverAndAlert,
 	})
+}
+
+type HandlerFunc func(http.ResponseWriter, *http.Request) error
+
+func (f HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	err := f(w, r)
+	if err != nil {
+		redirectWithError(w, r, err)
+	}
+}
+
+func redirectWithError(w http.ResponseWriter, r *http.Request, err error) {
+	log.Warning(err.Error())
+	http.Redirect(w, r, "/?error="+url.QueryEscape(err.Error()), http.StatusTemporaryRedirect)
 }

--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -315,9 +315,9 @@ func WrapAuthenticatedExternalHandler(env environment.Env, next http.Handler) ht
 	})
 }
 
-type HandlerFunc func(http.ResponseWriter, *http.Request) error
+type RedirectOnError func(http.ResponseWriter, *http.Request) error
 
-func (f HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (f RedirectOnError) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := f(w, r)
 	if err != nil {
 		log.Warning(err.Error())

--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -320,11 +320,7 @@ type HandlerFunc func(http.ResponseWriter, *http.Request) error
 func (f HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := f(w, r)
 	if err != nil {
-		redirectWithError(w, r, err)
+		log.Warning(err.Error())
+		http.Redirect(w, r, "/?error="+url.QueryEscape(err.Error()), http.StatusTemporaryRedirect)
 	}
-}
-
-func redirectWithError(w http.ResponseWriter, r *http.Request, err error) {
-	log.Warning(err.Error())
-	http.Redirect(w, r, "/?error="+url.QueryEscape(err.Error()), http.StatusTemporaryRedirect)
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -118,11 +118,11 @@ type InstallationAuthenticator interface {
 
 type HTTPAuthenticator interface {
 	// Redirect to configured authentication provider.
-	Login(w http.ResponseWriter, r *http.Request)
+	Login(w http.ResponseWriter, r *http.Request) error
 	// Clear any logout state.
-	Logout(w http.ResponseWriter, r *http.Request)
+	Logout(w http.ResponseWriter, r *http.Request) error
 	// Handle a callback from authentication provider.
-	Auth(w http.ResponseWriter, r *http.Request)
+	Auth(w http.ResponseWriter, r *http.Request) error
 
 	// AuthenticatedHTTPContext authenticates the user using the credentials present in the HTTP request and creates a
 	// child context that contains the results.

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -359,9 +359,9 @@ func StartAndRunServices(env environment.Env) {
 	mux.Handle("/readyz", env.GetHealthChecker().ReadinessHandler())
 
 	if auth := env.GetAuthenticator(); auth != nil {
-		mux.Handle("/login/", interceptors.SetSecurityHeaders(interceptors.HandlerFunc(auth.Login)))
-		mux.Handle("/auth/", interceptors.SetSecurityHeaders(interceptors.HandlerFunc(auth.Auth)))
-		mux.Handle("/logout/", interceptors.SetSecurityHeaders(interceptors.HandlerFunc(auth.Logout)))
+		mux.Handle("/login/", interceptors.SetSecurityHeaders(interceptors.RedirectOnError(auth.Login)))
+		mux.Handle("/auth/", interceptors.SetSecurityHeaders(interceptors.RedirectOnError(auth.Auth)))
+		mux.Handle("/logout/", interceptors.SetSecurityHeaders(interceptors.RedirectOnError(auth.Logout)))
 	}
 
 	if err := github.Register(env); err != nil {

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -359,9 +359,9 @@ func StartAndRunServices(env environment.Env) {
 	mux.Handle("/readyz", env.GetHealthChecker().ReadinessHandler())
 
 	if auth := env.GetAuthenticator(); auth != nil {
-		mux.Handle("/login/", interceptors.SetSecurityHeaders(http.HandlerFunc(auth.Login)))
-		mux.Handle("/auth/", interceptors.SetSecurityHeaders(http.HandlerFunc(auth.Auth)))
-		mux.Handle("/logout/", interceptors.SetSecurityHeaders(http.HandlerFunc(auth.Logout)))
+		mux.Handle("/login/", interceptors.SetSecurityHeaders(interceptors.HandlerFunc(auth.Login)))
+		mux.Handle("/auth/", interceptors.SetSecurityHeaders(interceptors.HandlerFunc(auth.Auth)))
+		mux.Handle("/logout/", interceptors.SetSecurityHeaders(interceptors.HandlerFunc(auth.Logout)))
 	}
 
 	if err := github.Register(env); err != nil {

--- a/server/nullauth/BUILD
+++ b/server/nullauth/BUILD
@@ -9,5 +9,6 @@ go_library(
         "//server/interfaces",
         "//server/tables",
         "//server/util/authutil",
+        "//server/util/status",
     ],
 )

--- a/server/nullauth/nullauth.go
+++ b/server/nullauth/nullauth.go
@@ -7,6 +7,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
 
 func NewNullAuthenticator(anonymousUsageEnabled bool, adminGroupID string) *NullAuthenticator {
@@ -53,16 +54,16 @@ func (a *NullAuthenticator) FillUser(ctx context.Context, user *tables.User) err
 	return nil
 }
 
-func (a *NullAuthenticator) Login(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+func (a *NullAuthenticator) Login(w http.ResponseWriter, r *http.Request) error {
+	return status.UnimplementedError("Auth not implemented")
 }
 
-func (a *NullAuthenticator) Auth(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+func (a *NullAuthenticator) Auth(w http.ResponseWriter, r *http.Request) error {
+	return status.UnimplementedError("Auth not implemented")
 }
 
-func (a *NullAuthenticator) Logout(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+func (a *NullAuthenticator) Logout(w http.ResponseWriter, r *http.Request) error {
+	return status.UnimplementedError("Auth not implemented")
 }
 
 func (a *NullAuthenticator) ParseAPIKeyFromString(input string) (string, error) {

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -211,16 +211,16 @@ func (a *TestAuthenticator) FillUser(ctx context.Context, user *tables.User) err
 	return nil
 }
 
-func (a *TestAuthenticator) Login(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+func (a *TestAuthenticator) Login(w http.ResponseWriter, r *http.Request) error {
+	return status.UnimplementedError("Auth not implemented")
 }
 
-func (a *TestAuthenticator) Auth(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+func (a *TestAuthenticator) Auth(w http.ResponseWriter, r *http.Request) error {
+	return status.UnimplementedError("Auth not implemented")
 }
 
-func (a *TestAuthenticator) Logout(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
+func (a *TestAuthenticator) Logout(w http.ResponseWriter, r *http.Request) error {
+	return status.UnimplementedError("Auth not implemented")
 }
 
 func (a *TestAuthenticator) ParseAPIKeyFromString(input string) (string, error) {


### PR DESCRIPTION
This PR makes the HTTPAuthenticator methods `Login`, `Auth`, and `Logout` return errors rather than just immediately redirecting the browser.

This lets us reason about how each of these calls behaved when we have multiple HTTPAuthenticators.

Adds a `HandlerFunc` that converts these errors into a browser redirect.
