### PR TITLE
Add nil check to pauseVM

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -535,6 +535,10 @@ func (c *FirecrackerContainer) unpackBaseSnapshot(ctx context.Context) (string, 
 }
 
 func (c *FirecrackerContainer) pauseVM(ctx context.Context) error {
+	if c.machine == nil {
+		return status.InternalError("failed to pause VM: machine is not started")
+	}
+
 	if err := c.machine.PauseVM(ctx); err != nil {
 		log.CtxErrorf(ctx, "Error pausing VM: %s", err)
 		return err


### PR DESCRIPTION
Having trouble reproducing the panic due to `c.machine` being nil, but adding a nil check for now to prevent a panic. Logging an error instead of panicking should make it easier to see the order of operations in the logs.

**Related issues**: N/A
