### PR TITLE
cleanup: remove executor gRPC server

### DIFF
--- a/enterprise/app/executors/executor_card.tsx
+++ b/enterprise/app/executors/executor_card.tsx
@@ -16,10 +16,8 @@ export default class ExecutorCardComponent extends React.Component<Props> {
         <div className="content">
           <div className="details">
             <div className="executor-section">
-              <div className="executor-section-title">Address:</div>
-              <div>
-                {this.props.node.host}:{this.props.node.port}
-              </div>
+              <div className="executor-section-title">Hostname:</div>
+              <div>{this.props.node.host}</div>
             </div>
             <div className="executor-section">
               <div className="executor-section-title">Executor Host ID:</div>

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -31,14 +31,11 @@ go_library(
         "//server/environment",
         "//server/metrics",
         "//server/real_environment",
-        "//server/remote_cache/action_cache_server",
-        "//server/remote_cache/byte_stream_server",
-        "//server/remote_cache/content_addressable_storage_server",
         "//server/resources",
         "//server/ssl",
         "//server/util/fileresolver",
+        "//server/util/flagutil",
         "//server/util/grpc_client",
-        "//server/util/grpc_server",
         "//server/util/healthcheck",
         "//server/util/log",
         "//server/util/monitoring",
@@ -50,7 +47,6 @@ go_library(
         "@go_googleapis//google/bytestream:bytestream_go_proto",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//encoding/gzip",
-        "@org_golang_google_grpc//test/bufconn",
     ],
 )
 

--- a/enterprise/server/scheduling/scheduler_client/scheduler_client.go
+++ b/enterprise/server/scheduling/scheduler_client/scheduler_client.go
@@ -33,8 +33,6 @@ const (
 type Options struct {
 	// TESTING ONLY: overrides the hostname reported when registering executor
 	HostnameOverride string
-	// TESTING ONLY: overrides the port reported when registering executor
-	PortOverride int32
 	// TESTING ONLY: overrides the API key sent by the client
 	APIKeyOverride string
 }
@@ -48,17 +46,10 @@ func makeExecutionNode(pool, executorID, executorHostID string, options *Options
 		}
 		hostname = resHostname
 	}
-	port := options.PortOverride
-	if port == 0 {
-		resPort, err := resources.GetMyPort()
-		if err != nil {
-			return nil, status.InternalErrorf("could not determine local port: %s", err)
-		}
-		port = resPort
-	}
 	return &scpb.ExecutionNode{
-		Host:                  hostname,
-		Port:                  port,
+		Host: hostname,
+		// TODO: stop setting port once the scheduler no longer requires it.
+		Port:                  1,
 		AssignableMemoryBytes: resources.GetAllocatedRAMBytes(),
 		AssignableMilliCpu:    resources.GetAllocatedCPUMillis(),
 		Os:                    resources.GetOS(),

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -941,8 +941,8 @@ func (s *SchedulerServer) GetPoolInfo(ctx context.Context, os, requestedPool, wo
 }
 
 func (s *SchedulerServer) checkPreconditions(node *scpb.ExecutionNode) error {
-	if node.GetHost() == "" || node.GetPort() == 0 {
-		return status.FailedPreconditionErrorf("Cannot register node with empty host/port: %s:%d", node.GetHost(), node.GetPort())
+	if node.GetHost() == "" {
+		return status.FailedPreconditionError("executor node registration is missing 'host' field")
 	}
 
 	return nil
@@ -965,12 +965,11 @@ func (s *SchedulerServer) RemoveConnectedExecutor(ctx context.Context, handle *e
 	// Don't use the stream context since we want to do cleanup when stream context is cancelled.
 	ctx, cancel := context.WithTimeout(context.Background(), removeExecutorCleanupTimeout)
 	defer cancel()
-	addr := fmt.Sprintf("%s:%d", node.GetHost(), node.GetPort())
 	if err := s.deleteNode(ctx, node, nodePoolKey); err != nil {
-		log.CtxWarningf(ctx, "Scheduler: could not unregister node %q: %s", addr, err)
+		log.CtxWarningf(ctx, "Scheduler: could not unregister node %q: %s", node.GetExecutorId(), err)
 		return
 	}
-	log.CtxInfof(ctx, "Scheduler: unregistered worker node: %q", addr)
+	log.CtxInfof(ctx, "Scheduler: unregistered node %q", node.GetExecutorId())
 }
 
 func (s *SchedulerServer) deleteNode(ctx context.Context, node *scpb.ExecutionNode, poolKey nodePoolKey) error {
@@ -996,8 +995,7 @@ func (s *SchedulerServer) AddConnectedExecutor(ctx context.Context, handle *exec
 	if !newExecutor {
 		return nil
 	}
-	addr := fmt.Sprintf("%s:%d", node.GetHost(), node.GetPort())
-	log.CtxInfof(ctx, "Scheduler: registered executor %q (host ID %q, addr %q, version %q) for pool %+v", node.GetExecutorId(), node.GetExecutorHostId(), addr, node.GetVersion(), poolKey)
+	log.CtxInfof(ctx, "Scheduler: registered executor %q (host ID %q, host %q, version %q) for pool %+v", node.GetExecutorId(), node.GetExecutorHostId(), node.GetHost(), node.GetVersion(), poolKey)
 	metrics.RemoteExecutionExecutorRegistrationCount.With(prometheus.Labels{metrics.VersionLabel: node.GetVersion()}).Inc()
 
 	go func() {

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -969,7 +969,7 @@ func (s *SchedulerServer) RemoveConnectedExecutor(ctx context.Context, handle *e
 		log.CtxWarningf(ctx, "Scheduler: could not unregister node %q: %s", node.GetExecutorId(), err)
 		return
 	}
-	log.CtxInfof(ctx, "Scheduler: unregistered node %q", node.GetExecutorId())
+	log.CtxInfof(ctx, "Scheduler: unregistered node %q (executor ID %q)", node.GetHost(), node.GetExecutorId())
 }
 
 func (s *SchedulerServer) deleteNode(ctx context.Context, node *scpb.ExecutionNode, poolKey nodePoolKey) error {

--- a/enterprise/server/test/integration/remote_execution/rbetest/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbetest/BUILD
@@ -54,7 +54,6 @@ go_library(
         "//server/testutil/testport",
         "//server/util/fileresolver",
         "//server/util/grpc_client",
-        "//server/util/grpc_server",
         "//server/util/log",
         "//server/util/prefix",
         "//server/util/retry",

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -196,11 +196,6 @@ service Scheduler {
       returns (EnqueueTaskReservationResponse) {}
 }
 
-service QueueExecutor {
-  rpc EnqueueTaskReservation(EnqueueTaskReservationRequest)
-      returns (EnqueueTaskReservationResponse) {}
-}
-
 message ExecutionNode {
   // Remote execution node host.
   // Ex. "10.52.6.5"
@@ -208,7 +203,7 @@ message ExecutionNode {
 
   // Remote execution node port.
   // Ex. 1987
-  int32 port = 2;
+  int32 port = 2 [deprecated = true];
 
   // Assignable memory bytes in remote execution node.
   // Ex. 26843545600


### PR DESCRIPTION
The executor no longer serves gRPC requests, so it should be safe to remove the gRPC server.

Since we're no longer depending on `grpc_server.go`, I defined a new deprecated "grpc_port" flag in executor.go to avoid breaking people who have old configs and are still setting that for whatever reason. We can remove the flag later after giving people some time to notice the deprecation warning. (I don't recall seeing any of the other flags ever being set for the executor, like `app.grpc_max_recv_msg_size_bytes`, `grpcs_port`, `internal_grpc_port` etc., but I could be mistaken)

Also update the scheduler to no longer require `port` metadata from the executor registration. After this PR is rolled out and all scheduler instances stop checking `port != 0`, we can send a follow-up to stop hard-coding the `port` field to `1` and remove it from the proto.

**Related issues**: N/A
