### PR TITLE
[RFC] workflow.proto: allow custom action

### DIFF
--- a/proto/workflow.proto
+++ b/proto/workflow.proto
@@ -176,6 +176,30 @@ message ExecuteWorkflowRequest {
 
   // If true, start the workflow but do not wait for the status to be returned.
   bool async = 14;
+
+  // Optional: Custom actions to execute. Correspond to actions in
+  // buildbuddy.yaml. If this is set, action_names will be ignored.
+  repeated CustomAction custom_action = 15;
+}
+
+message CustomAction {
+  string name = 1;
+  string os = 2;
+  string arch = 3;
+  string self_hosted = 4;
+  string container_image = 5;
+  ResourceRequests resource_requests = 6;
+  string user = 7;
+  repeated string git_clean_exclude = 8;
+  string bazel_workspace_dir = 9;
+  map<string, string> env = 10;
+  repeated string bazel_commands = 11;
+}
+
+message ResourceRequests {
+  string cpu = 1;
+  string memory = 2;
+  string disk = 3;
 }
 
 message ExecuteWorkflowResponse {


### PR DESCRIPTION
User may have a needs to execute custom Workflow Actions that is only
known at runtime and cannot be configured before hand.

For this use case, we could add `custom_action` field which mirror
workflow/config.BuildBuddyConfig struct. This way user could craft their
own set of actions before making the request.

When this happen, we shall ignore the `buildbuddy.yaml` inside the repo
as well as the action_names filter.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
