### PR TITLE
CLI: Don't return EOF for early-exit writes in cache_proxy

### DIFF
--- a/cli/cache_proxy/cache_proxy.go
+++ b/cli/cache_proxy/cache_proxy.go
@@ -251,10 +251,15 @@ func (p *CacheProxy) Write(stream bspb.ByteStream_WriteServer) error {
 		if wreq == nil {
 			wreq = rsp
 		}
+		writeDone := rsp.GetFinishWrite()
 		if err := clientStream.Send(rsp); err != nil {
-			return err
+			if err == io.EOF {
+				writeDone = true
+			} else {
+				return err
+			}
 		}
-		if rsp.GetFinishWrite() {
+		if writeDone {
 			lastRsp, err := clientStream.CloseAndRecv()
 			if err != nil {
 				return err


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
