### PR TITLE
change the height of the timing event viewport

### DIFF
--- a/app/flame_chart/flame_chart.tsx
+++ b/app/flame_chart/flame_chart.tsx
@@ -433,7 +433,7 @@ export default class FlameChart extends React.Component<FlameChartProps, Profile
               onMouseDown={this.onMouseDown.bind(this)}
               style={{
                 borderBottom: `${LINE_CHART_BORDER_TOP}px solid #9E9E9E`,
-                height: `calc(60% - ${HORIZONTAL_SCROLLBAR_HEIGHT}px`,
+                height: "60%",
                 overflowX: "initial",
               }}>
               <div


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

`calc(60% - 14px)` causes Firefox to be unable to render timing profile events and 
y-axis misalignment under certain scenarios.

**Related issues**: 
Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/2391
and https://github.com/buildbuddy-io/buildbuddy-internal/issues/2392
