### PR TITLE
Remove old nullAuthenticator check from old authenticator setup

### DIFF
--- a/enterprise/server/saml/BUILD
+++ b/enterprise/server/saml/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//server/endpoint_urls/build_buddy_url",
         "//server/environment",
         "//server/interfaces",
-        "//server/nullauth",
         "//server/tables",
         "//server/util/authutil",
         "//server/util/claims",

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -16,7 +16,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
-	"github.com/buildbuddy-io/buildbuddy/server/nullauth"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
@@ -58,9 +57,6 @@ type SAMLAuthenticator struct {
 
 func IsEnabled(env environment.Env) bool {
 	if (*certFile == "" && *cert == "") || env.GetAuthenticator() == nil {
-		return false
-	}
-	if _, ok := env.GetAuthenticator().(*nullauth.NullAuthenticator); ok {
 		return false
 	}
 	return true


### PR DESCRIPTION
Previously we checked to see if the registered auth was nullAuthenticator because we didn't want to use nullAuthenticator as a fallback.

In the new model where we don't a fallback, we don't need this check anymore.