### PR TITLE
Add initial blockio copy-on-write Store

### DIFF
--- a/enterprise/server/remote_execution/blockio/BUILD
+++ b/enterprise/server/remote_execution/blockio/BUILD
@@ -19,6 +19,7 @@ go_test(
     deps = [
         ":blockio",
         "//server/testutil/testfs",
+        "//server/util/disk",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/remote_execution/blockio/blockio.go
+++ b/enterprise/server/remote_execution/blockio/blockio.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"syscall"
+	"unsafe"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"golang.org/x/sys/unix"
@@ -42,7 +44,6 @@ func (f *File) SizeBytes() (int64, error) {
 
 // Mmap implements the Store interface using a memory-mapped file.
 type Mmap struct {
-	file *os.File
 	data []byte
 }
 
@@ -57,16 +58,20 @@ func NewMmap(path string) (*Mmap, error) {
 	if err != nil {
 		return nil, err
 	}
-	data, err := syscall.Mmap(int(f.Fd()), 0, int(s.Size()), syscall.PROT_WRITE, syscall.MAP_SHARED)
+	return NewMmapFd(int(f.Fd()), int(s.Size()))
+}
+
+func NewMmapFd(fd, size int) (*Mmap, error) {
+	data, err := syscall.Mmap(fd, 0, size, syscall.PROT_WRITE, syscall.MAP_SHARED)
 	if err != nil {
 		return nil, fmt.Errorf("mmap: %s", err)
 	}
-	return &Mmap{file: f, data: data}, nil
+	return &Mmap{data: data}, nil
 }
 
 func (m *Mmap) ReadAt(p []byte, off int64) (n int, err error) {
 	if off < 0 || int(off)+len(p) > len(m.data) {
-		return 0, status.InvalidArgumentErrorf("invalid offset %x", off)
+		return 0, status.InvalidArgumentErrorf("invalid read at offset 0x%x length 0x%x", off, len(p))
 	}
 	copy(p, m.data[int(off):int(off)+len(p)])
 	return len(p), nil
@@ -74,7 +79,7 @@ func (m *Mmap) ReadAt(p []byte, off int64) (n int, err error) {
 
 func (m *Mmap) WriteAt(p []byte, off int64) (n int, err error) {
 	if off < 0 || int(off)+len(p) > len(m.data) {
-		return 0, status.InvalidArgumentErrorf("invalid offset %x", off)
+		return 0, status.InvalidArgumentErrorf("invalid write at offset 0x%x length 0x%x", off, len(p))
 	}
 	copy(m.data[int(off):int(off)+len(p)], p)
 	return len(p), nil
@@ -85,6 +90,7 @@ func (m *Mmap) Sync() error {
 }
 
 func (m *Mmap) Close() error {
+	// TODO: prevent double-unmap
 	return syscall.Munmap(m.data)
 }
 
@@ -100,4 +106,366 @@ func fileSizeBytes(f *os.File) (int64, error) {
 	return s.Size(), nil
 }
 
-// TODO: add a Store supporting copy-on-write.
+// Hole is a disk-efficient representation of a readonly store containing all
+// zeroes.
+type Hole struct{ Size int64 }
+
+func (e *Hole) ReadAt(p []byte, off int64) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+func (e *Hole) WriteAt(p []byte, off int64) (int, error) {
+	return 0, status.PermissionDeniedError("Hole is read-only")
+}
+
+func (e *Hole) Sync() error {
+	return nil
+}
+
+func (e *Hole) SizeBytes() (int64, error) {
+	return e.Size, nil
+}
+
+func (e *Hole) Close() error {
+	return nil
+}
+
+// COW implements copy-on-write for a Store that has been split into chunks of
+// equal size. Just before a chunk is first written to, the chunk is first
+// copied, and the write is then applied to the copy.
+//
+// A COW can be created either by splitting a file into chunks, or loading
+// chunks from a directory containing artifacts exported by a COW instance.
+type COW struct {
+	Chunks []Store
+	// Indexes of chunks which have been copied from the original chunks due to
+	// writes.
+	dirty map[int]bool
+	// Dir where all chunk data is stored.
+	dataDir string
+
+	// Size of each chunk, except for possibly the last chunk.
+	chunkSizeBytes int64
+	// Total size in bytes. Note that this cannot be computed by simply
+	// multiplying the number of chunks by chunkSizeBytes, because the last
+	// chunk is allowed to be shorter than the rest of the chunks.
+	totalSizeBytes int64
+	// Number of bytes transferred during each IO operation. This is determined
+	// by the filesystem on which the chunks are stored.
+	ioBlockSize int64
+
+	// Scratch buffer used for copying chunks.
+	copyBuf []byte
+}
+
+// NewCOW creates a COW from the given chunks. The chunks should be open
+// initially, and will be closed when calling Close on the returned COW.
+func NewCOW(chunks []Store, chunkSizeBytes, totalSizeBytes int64, dataDir string) (*COW, error) {
+	stat, err := os.Stat(dataDir)
+	if err != nil {
+		return nil, err
+	}
+	return &COW{
+		Chunks:         chunks,
+		dirty:          make(map[int]bool, 0),
+		dataDir:        dataDir,
+		copyBuf:        make([]byte, chunkSizeBytes),
+		chunkSizeBytes: chunkSizeBytes,
+		totalSizeBytes: totalSizeBytes,
+		ioBlockSize:    int64(stat.Sys().(*syscall.Stat_t).Blksize),
+	}, nil
+}
+
+func (c *COW) ReadAt(p []byte, off int64) (int, error) {
+	chunkIdx := int(off / c.chunkSizeBytes)
+	n := 0
+	for len(p) > 0 {
+		chunkRelativeOffset := off % c.chunkSizeBytes
+		readSize := int(c.chunkSizeBytes - chunkRelativeOffset)
+		if readSize > len(p) {
+			readSize = len(p)
+		}
+		nr, err := readFullAt(c.Chunks[chunkIdx], p[:readSize], chunkRelativeOffset)
+		n += nr
+		if err != nil {
+			return n, err
+		}
+		p = p[readSize:]
+		off += int64(readSize)
+		chunkIdx++
+	}
+	return n, nil
+}
+
+func (c *COW) WriteAt(p []byte, off int64) (int, error) {
+	chunkIdx := int(off / c.chunkSizeBytes)
+	n := 0
+	for len(p) > 0 {
+		// On each iteration, write to one chunk, first copying the readonly
+		// chunk if needed.
+		if !c.dirty[chunkIdx] {
+			// If we're newly dirtying a chunk, copy.
+			if err := c.copyChunk(chunkIdx); err != nil {
+				return 0, status.WrapError(err, "failed to copy chunk")
+			}
+			c.dirty[chunkIdx] = true
+		}
+		chunkRelativeOffset := (off + int64(n)) % c.chunkSizeBytes
+		writeSize := int(c.chunkSizeBytes - chunkRelativeOffset)
+		if writeSize > len(p) {
+			writeSize = len(p)
+		}
+		nw, err := c.Chunks[chunkIdx].WriteAt(p[:writeSize], chunkRelativeOffset)
+		n += nw
+		if err != nil {
+			return n, err
+		}
+		if nw != writeSize {
+			return n, io.ErrShortWrite
+		}
+		p = p[writeSize:]
+		chunkIdx++
+	}
+	return n, nil
+}
+
+func (c *COW) Sync() error {
+	var lastErr error
+	// TODO: maybe parallelize
+	for i := range c.Chunks {
+		if !c.dirty[i] {
+			continue
+		}
+		if err := c.Chunks[i].Sync(); err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+func (s *COW) Close() error {
+	var lastErr error
+	// TODO: maybe parallelize
+	for _, c := range s.Chunks {
+		if err := c.Close(); err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+func (s *COW) SizeBytes() (int64, error) {
+	return s.totalSizeBytes, nil
+}
+
+// Dirty returns the chunk indexes of chunks that have been written to (and
+// therefore copied).
+func (s *COW) Dirty() map[int]bool {
+	return s.dirty
+}
+
+func (s *COW) copyChunk(index int) (err error) {
+	src := s.Chunks[index]
+	// Once we've created a copy, we no longer need the source chunk.
+	defer src.Close()
+
+	size, err := src.SizeBytes()
+	if err != nil {
+		return err
+	}
+	dst, err := s.initDirtyChunk(index, size)
+	if err != nil {
+		return status.WrapError(err, "initialize dirty chunk")
+	}
+	s.Chunks[index] = dst
+
+	// Optimization: if copying a hole, the dirty chunk we just initialized
+	// should already contain all 0s, so we're done.
+	if _, ok := src.(*Hole); ok {
+		return nil
+	}
+
+	b := s.copyBuf[:size]
+	// TODO: avoid a full read here in the case where the chunk contains holes.
+	// Can achieve this by having the Mmap keep around the underlying file
+	// descriptor and use fseek (SEEK_DATA) on it.
+	if _, err := readFullAt(src, b, 0); err != nil {
+		return status.WrapError(err, "read chunk for copy")
+	}
+	// Copy to the mmap but skip holes to avoid materializing them as blocks.
+	for off := int64(0); off < size; off += s.ioBlockSize {
+		blockSize := s.ioBlockSize
+		if remainder := size - off; blockSize > remainder {
+			blockSize = remainder
+		}
+		dataBlock := b[off : off+blockSize]
+		if IsEmptyOrAllZero(dataBlock) {
+			continue
+		}
+		if _, err := dst.WriteAt(dataBlock, off); err != nil {
+			return status.WrapError(err, "copy data to new chunk")
+		}
+	}
+	return nil
+}
+
+// Writes a new dirty chunk containing all 0s for the given chunk index.
+func (s *COW) initDirtyChunk(index int, size int64) (Store, error) {
+	path := filepath.Join(s.dataDir, fmt.Sprintf("%d.dirty", index*int(s.chunkSizeBytes)))
+	fd, err := syscall.Open(path, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, err
+	}
+	defer syscall.Close(fd)
+	if err := syscall.Ftruncate(fd, size); err != nil {
+		return nil, err
+	}
+	return NewMmapFd(fd, int(size))
+}
+
+// ConvertFileToCOW reads a file sequentially, splitting it into fixed size,
+// read-only chunks. Any newly created chunks will be written to dataDir. The
+// backing files are named according to their starting byte offset (in base 10).
+// For example, the chunk at offset 4096 is named "4096".
+//
+// When chunks are written to, a new copy of the file is created, named as the
+// chunk index with ".dirty" appended.
+//
+// Empty regions ("holes") in the file are respected. For example, if a chunk
+// contains no data, then the written chunk file will contain no data blocks,
+// and its on-disk representation will only contain metadata.
+//
+// If an error is returned from this function, the caller should decide what to
+// do with any files written to dataDir. Typically the caller should provide an
+// empty dataDir and remove the dir and contents if there is an error.
+func ConvertFileToCOW(filePath string, chunkSizeBytes int64, dataDir string) (store *COW, err error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	totalSizeBytes := stat.Size()
+	fd := int(f.Fd())
+	chunks := make([]Store, 0, blockCount(totalSizeBytes, chunkSizeBytes))
+	defer func() {
+		// If there's an error, clean up any Store instances we created.
+		if err == nil {
+			return
+		}
+		for _, b := range chunks {
+			b.Close()
+		}
+	}()
+
+	// Copy buffer (large enough to copy one data block at a time).
+	ioBlockSize := int64(stat.Sys().(*syscall.Stat_t).Blksize)
+	copyBuf := make([]byte, ioBlockSize)
+
+	// dataOffset points to the start of the current non-empty data block in the
+	// file. It is updated every time we consume a data block.
+	dataOffset, err := syscall.Seek(fd, 0, unix.SEEK_DATA)
+	if err == syscall.ENXIO {
+		// No more data
+		dataOffset = totalSizeBytes
+	} else if err != nil {
+		return nil, status.InternalErrorf("initial data seek failed: %s", err)
+	}
+
+	createChunkFile := func(chunkStartOffset int64) (store Store, err error) {
+		chunkFileSize := chunkSizeBytes
+		if remainder := totalSizeBytes - chunkStartOffset; chunkFileSize > remainder {
+			chunkFileSize = remainder
+		}
+		if dataOffset >= chunkStartOffset+chunkFileSize {
+			// Chunk contains no data; avoid writing a file.
+			return &Hole{Size: chunkFileSize}, nil
+		}
+		chunkFile, err := os.Create(filepath.Join(dataDir, fmt.Sprint(chunkStartOffset)))
+		if err != nil {
+			return nil, err
+		}
+		defer chunkFile.Close()
+		if err := chunkFile.Truncate(chunkFileSize); err != nil {
+			return nil, err
+		}
+		endOffset := chunkStartOffset + chunkSizeBytes
+		if endOffset > totalSizeBytes {
+			endOffset = totalSizeBytes
+		}
+		for dataOffset < endOffset {
+			// Copy the current data block to the output chunk file.
+			chunkFileDataOffset := dataOffset - chunkStartOffset
+			dataBuf := copyBuf
+			if remainder := chunkFileSize - chunkFileDataOffset; remainder < int64(len(dataBuf)) {
+				dataBuf = copyBuf[:remainder]
+			}
+			// TODO: see whether it's faster to mmap the file we're copying
+			// from, rather than issuing read() syscalls for each data block
+			if _, err := io.ReadFull(f, dataBuf); err != nil {
+				return nil, err
+			}
+			if _, err := chunkFile.WriteAt(dataBuf, chunkFileDataOffset); err != nil {
+				return nil, err
+			}
+			// Seek to the next data block, starting from the end of the data
+			// block we just copied.
+			dataOffset += int64(len(dataBuf))
+			dataOffset, err = syscall.Seek(fd, dataOffset, unix.SEEK_DATA)
+			if err == syscall.ENXIO {
+				// No more data
+				dataOffset = totalSizeBytes
+			} else if err != nil {
+				return nil, err
+			}
+		}
+		return NewMmapFd(int(chunkFile.Fd()), int(chunkFileSize))
+	}
+
+	// TODO: iterate through the file with multiple goroutines
+	for chunkStartOffset := int64(0); chunkStartOffset < totalSizeBytes; chunkStartOffset += chunkSizeBytes {
+		chunk, err := createChunkFile(chunkStartOffset)
+		if err != nil {
+			return nil, status.WrapError(err, "failed to create block file")
+		}
+		chunks = append(chunks, chunk)
+	}
+
+	return NewCOW(chunks, chunkSizeBytes, totalSizeBytes, dataDir)
+}
+
+func IsEmptyOrAllZero(data []byte) bool {
+	n := len(data)
+	nRound8 := n & ^0b111
+	i := 0
+	for ; i < nRound8; i += 8 {
+		b := *(*uint64)(unsafe.Pointer(&data[i]))
+		if b != 0 {
+			return false
+		}
+	}
+	for ; i < n; i++ {
+		if data[i] != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func blockCount(totalSizeBytes, blockSizeBytes int64) int64 {
+	b := totalSizeBytes / blockSizeBytes
+	if totalSizeBytes%blockSizeBytes > 0 {
+		b++
+	}
+	return b
+}
+
+func readFullAt(r io.ReaderAt, p []byte, off int64) (n int, err error) {
+	return io.ReadFull(io.NewSectionReader(r, off, int64(len(p))), p)
+}

--- a/enterprise/server/remote_execution/blockio/blockio_test.go
+++ b/enterprise/server/remote_execution/blockio/blockio_test.go
@@ -1,40 +1,125 @@
 package blockio_test
 
 import (
+	"context"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
+	"syscall"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/blockio"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/stretchr/testify/require"
 )
 
 const (
-	backingFileSizeBytes int64 = 8192
+	backingFileSizeBytes int64 = 32 * 1024
 )
 
 func TestFile(t *testing.T) {
-	path := makeEmptyBackingFile(t)
+	path := makeEmptyTempFile(t, backingFileSizeBytes)
 	s, err := blockio.NewFile(path)
 	require.NoError(t, err)
 	testStore(t, s, path)
 }
 
 func TestMmap(t *testing.T) {
-	path := makeEmptyBackingFile(t)
+	path := makeEmptyTempFile(t, backingFileSizeBytes)
 	s, err := blockio.NewMmap(path)
 	require.NoError(t, err)
 	testStore(t, s, path)
 }
 
-func makeEmptyBackingFile(t *testing.T) string {
-	root := testfs.MakeTempDir(t)
-	path := filepath.Join(root, "f")
-	err := os.WriteFile(path, make([]byte, backingFileSizeBytes), 0644)
-	require.NoError(t, err, "write empty file")
-	return path
+func TestCOW_Basic(t *testing.T) {
+	path := makeEmptyTempFile(t, backingFileSizeBytes)
+	dataDir := testfs.MakeTempDir(t)
+	chunkSizeBytes := backingFileSizeBytes / 2
+	s, err := blockio.ConvertFileToCOW(path, chunkSizeBytes, dataDir)
+	require.NoError(t, err)
+	// Don't validate against the backing file, since COWFromFile makes a copy
+	// of the underlying file.
+	testStore(t, s, "" /*=path*/)
+}
+
+func TestCOW_SparseData(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		// Sparse files work a bit differently on macOS, just skip for now.
+		t.SkipNow()
+	}
+
+	// Figure out the IO block size (number of bytes transferred to/from disk
+	// for each IO operation). This is the minimum seek size when using seek()
+	// with SEEK_DATA.
+	tmp := testfs.MakeTempDir(t)
+	stat, err := os.Stat(tmp)
+	require.NoError(t, err)
+	ioBlockSize := int64(stat.Sys().(*syscall.Stat_t).Blksize)
+	// Use a chunk size that is a few times larger than the IO block size.
+	const blocksPerChunk = 4
+	chunkSize := ioBlockSize * blocksPerChunk
+	// Write a file consisting of the following chunks:
+	// - 0: completely empty
+	// - 1: data block at the beginning of the chunk
+	// - 2: data block somewhere in the middle of the chunk
+	// - 3: data block at the end of the chunk
+	chunks := make([][]byte, 4)
+	for i := 0; i < len(chunks); i++ {
+		chunks[i] = make([]byte, chunkSize)
+	}
+	// chunkData[0]: empty
+	chunks[1][0] = 1
+	chunks[2][ioBlockSize] = 1
+	chunks[3][chunkSize-1] = 1
+	data := concatBytes(chunks...)
+	dataFilePath := filepath.Join(tmp, "data.bin")
+	writeSparseFile(t, dataFilePath, data, ioBlockSize)
+	outDir := testfs.MakeTempDir(t)
+
+	// Now split the file.
+	c, err := blockio.ConvertFileToCOW(dataFilePath, chunkSize, outDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { c.Close() })
+
+	// Make sure the full content matches our buffer.
+	dataOut := make([]byte, len(data))
+	n, err := c.ReadAt(dataOut, 0)
+	require.NoError(t, err)
+	require.Equal(t, len(dataOut), n)
+
+	// Inspect the chunk files and ensure they have the expected physical size.
+	for i := 0; i < len(chunks); i++ {
+		chunkPath := filepath.Join(outDir, strconv.Itoa(i*int(chunkSize)))
+		// We wrote one data block per chunk except for the one chunk that was
+		// all empty. The empty chunk should not have written a file.
+		if i == 0 {
+			exists, err := disk.FileExists(context.TODO(), chunkPath)
+			require.NoError(t, err)
+			require.False(t, exists, "chunk 0 should not exist on disk")
+			continue
+		}
+		nb := numIOBlocks(t, chunkPath)
+		require.Equal(t, int64(1), nb, "chunk %d IO block count", i)
+	}
+
+	// Now write a single data byte to the empty chunk (0), and sync it to disk.
+	n, err = c.WriteAt([]byte{1}, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	err = c.Chunks[0].Sync()
+	require.NoError(t, err)
+
+	// Make sure we wrote a dirty chunk with the expected contents, and only a
+	// single IO block on disk (since we only wrote 1 byte).
+	dirtyPath := filepath.Join(outDir, "0.dirty")
+	b, err := os.ReadFile(dirtyPath)
+	expectedContent := make([]byte, len(chunks[0]))
+	expectedContent[0] = 1
+	require.Equal(t, expectedContent, b)
+	require.Equal(t, int64(1), numIOBlocks(t, dirtyPath))
 }
 
 func testStore(t *testing.T, s blockio.Store, path string) {
@@ -44,7 +129,8 @@ func testStore(t *testing.T, s blockio.Store, path string) {
 
 	expectedContent := make([]byte, int(size))
 	buf := make([]byte, int(size))
-	for i := 0; i < 100; i++ {
+	n := 1 + rand.Intn(50)
+	for i := 0; i < n; i++ {
 		// With equal probability, either (a) read a random range and make sure
 		// it matches expectedContent, or (b) write a random range and update
 		// our expectedContent for subsequent reads.
@@ -74,10 +160,67 @@ func testStore(t *testing.T, s blockio.Store, path string) {
 	// expected contents. This is especially important for testing mmap, since
 	// Sync() should guarantee that the contents are flushed from memory back
 	// to disk.
-	b, err := os.ReadFile(path)
-	require.NoError(t, err)
-	require.Equal(t, expectedContent, b)
+	if path != "" {
+		b, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Equal(t, expectedContent, b)
+	}
 
 	err = s.Close()
 	require.NoError(t, err, "Close failed")
+}
+
+func makeTempFile(t *testing.T, content []byte) string {
+	root := testfs.MakeTempDir(t)
+	path := filepath.Join(root, "f")
+	err := os.WriteFile(path, content, 0644)
+	require.NoError(t, err, "write empty file")
+	return path
+}
+
+func makeEmptyTempFile(t *testing.T, sizeBytes int64) string {
+	return makeTempFile(t, make([]byte, sizeBytes))
+}
+
+// writeSparseFile writes only the data blocks from b to the given path, so
+// that the physical size of the file is minimal while still representing the
+// same underlying bytes.
+func writeSparseFile(t *testing.T, path string, b []byte, ioBlockSize int64) {
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	// Truncate to ensure the file has the correct size in case it ends with one
+	// or more empty blocks.
+	err = f.Truncate(int64(len(b)))
+	require.NoError(t, err)
+	for off := int64(0); off < int64(len(b)); off += ioBlockSize {
+		data := b[off:]
+		if int64(len(data)) > ioBlockSize {
+			data = data[:ioBlockSize]
+		}
+		if blockio.IsEmptyOrAllZero(data) {
+			continue
+		}
+		_, err := f.WriteAt(data, off)
+		require.NoError(t, err)
+	}
+}
+
+func numIOBlocks(t *testing.T, path string) int64 {
+	s := &syscall.Stat_t{}
+	err := syscall.Stat(path, s)
+	require.NoError(t, err)
+	// stat() always uses 512 bytes for its block size, which may not match the
+	// IO block size (block size used by the filesystem).
+	// See https://askubuntu.com/a/1308745
+	statBlocksPerIOBlock := int64(s.Blksize) / 512
+	return s.Blocks / statBlocksPerIOBlock
+}
+
+func concatBytes(chunks ...[]byte) []byte {
+	var out []byte
+	for _, c := range chunks {
+		out = append(out, c...)
+	}
+	return out
 }


### PR DESCRIPTION
Adds a method to split a file into fixed-size, immutable chunks, and a corresponding `Store` implementation called `COW` that implements copy-on-write when chunks are modified.

This buys us the ability to represent snapshot artifacts as manifests pointing to immutable chunks in the cache, which can be loaded as a `Store` implementation compatible with NBD/UFFD, paving the way towards shareable snapshots.

For now, all chunks are stored in a dedicated dir (the readonly chunks are stored as `${chunkByteOffset}` and the modified ones are named as `${chunkByteOffset}.dirty`). To store a COW in cache (in a later PR), we can simply add all these chunks to cache, along with a manifest proto indicating the byte offsets of each chunk. To load a COW from cache, we can read back the manifest, then link all the chunks back from cache (as immutable, without the .dirty suffix), and call `NewCOW` with these linked chunks.

Some terminology:
- "Chunk" = a region of data as defined by us. This will probably be something like 512KB in size. This is the granularity at which we do copy-on-write and store artifacts in cache etc.
- "IO block" = the preferred size used when doing IO operations to/from the underlying FS. This is 4KB on my system. So even if a file is 1 byte in size, it still requires a 4KB IO block to represent.
- "Stat block" = the block size reported by `stat(2)`, which is always 512 bytes. (This is mainly relevant for tests that use `stat` to assert on the number of blocks written, but can otherwise be ignored). To find the number of IO blocks in a file, divide the "block" count reported by stat by `(io_block_size / 512)` (e.g. for a page size of 4KB, one IO block is `4096 / 512 = 8` "stat blocks").

To keep performance reasonable, all COW operations try to respect sparse files. In particular:
- It's fast / cheap to chunk up a file initially into a `COW` instance when allocating e.g. a 20GB empty scratch disk, since we can completely skip the large empty region(s) in the disk without creating any chunks.
- _Within_ any chunks that we do create initially, sparse regions are also respected. e.g. if a chunk is 512K and it only contains a single 4K data block, the physical size of the chunk will be 4K.
- Copy-on-write is very cheap when copying a chunk that contained no data ("hole") - it's just an ftruncate call.
- When copying non-holes, we also respect sparse regions within the underlying chunk, but we do process every byte including holes (for now). However, the byte processing should be very fast since we're mostly just copying from one buffer to another. In the future we could optimize this using SEEK_DATA, but it might result in worse performance on average due to the extra seek() syscalls, and will complicate the `Mmap` implementation a bit.

**Related issues**: N/A
