### PR TITLE
Control the toString() method of BuildBuddyError

### DIFF
--- a/app/util/errors.ts
+++ b/app/util/errors.ts
@@ -23,4 +23,8 @@ export class BuildBuddyError extends Error {
 
     return new BuildBuddyError(code as ErrorCode, description);
   }
+
+  toString() {
+    return this.description;
+  }
 }


### PR DESCRIPTION
Without this, it falls back to the toString() of `Error` which adds a `Error: ` prefix which we don't always want.