### PR TITLE
Use dashes instead of underscores for container names

### DIFF
--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -412,7 +412,7 @@ func generateContainerName() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return "buildbuddy_exec_" + suffix, nil
+	return "buildbuddy-exec-" + suffix, nil
 }
 
 func (r *dockerCommandContainer) Create(ctx context.Context, workDir string) error {

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -844,7 +844,7 @@ func generateContainerName() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return "buildbuddy_exec_" + suffix, nil
+	return "buildbuddy-exec-" + suffix, nil
 }
 
 func (c *podmanCommandContainer) killContainerIfRunning(ctx context.Context) error {


### PR DESCRIPTION
It's dubious whether underscores are allowed / recommended in URLs (it seems to make some Java URL parsing libraries barf) and this name gets returned if you run `hostname -A`.
