### PR TITLE
Return the correct error when a SAML user doesn't exist yet

### DIFF
--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"net/http"
+	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/oidc"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/saml"
@@ -143,6 +144,9 @@ func (a *authenticator) AuthenticatedUser(ctx context.Context) (interfaces.UserI
 	errors := make([]error, 0)
 	for _, auth := range a.user {
 		if user, err := auth.AuthenticatedUser(ctx); err != nil {
+			if strings.Contains(err.Error(), authutil.UserNotFoundMsg) {
+				return nil, err
+			}
 			errors = append(errors, err)
 		} else {
 			return user, err

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -149,7 +149,10 @@ func (a *SAMLAuthenticator) Logout(w http.ResponseWriter, r *http.Request) error
 func (a *SAMLAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces.UserInfo, error) {
 	if s, _ := a.subjectIDAndSessionFromContext(ctx); s != "" {
 		claims, err := claims.ClaimsFromSubID(ctx, a.env, s)
-		return claims, err
+		if err != nil {
+			return nil, status.UnauthenticatedErrorf(authutil.UserNotFoundMsg)
+		}
+		return claims, nil
 	}
 	return nil, status.UnauthenticatedError("No SAML User found")
 }


### PR DESCRIPTION
Since the auth refactor in this case (where we have a SAML login, but the user doesn't exist yet) we return the error message from the OIDC AuthenticatedUser call (which is that no JWT is found).

This means the UI doesn't know it should attempt to create the user.

We should potentially brainstorm a better API here, but this fixes SAML user creation in the meantime.