### PR TITLE
remove shard count in usage_test_mysql and usage_test_postgres

### DIFF
--- a/enterprise/server/backends/userdb/BUILD
+++ b/enterprise/server/backends/userdb/BUILD
@@ -62,7 +62,6 @@ go_test(
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
     },
-    shard_count = 5,
     tags = ["docker"],
     deps = [
         ":userdb",
@@ -97,7 +96,6 @@ go_test(
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
     },
-    shard_count = 5,
     tags = ["docker"],
     deps = [
         ":userdb",

--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -58,7 +58,6 @@ go_test(
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
     },
-    shard_count = 7,
     tags = ["docker"],
     deps = [
         ":usage",
@@ -92,7 +91,6 @@ go_test(
         "test.init-dockerd": "true",
         "test.recycle-runner": "true",
     },
-    shard_count = 7,
     tags = ["docker"],
     deps = [
         ":usage",


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

When run usage_test_mysql and usage_test_postgres locally, 6/7 tests fail the 
second time because all the tests grab the same mysql port; and there seems to be
some concurrency issue when resetting databases.

We no longer need sharding since we have reuse_server set to true.
**Related issues**: N/A
