### PR TITLE
CLI: Fix startup options parse error

### DIFF
--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -365,6 +365,7 @@ func CanonicalizeArgs(args []string) ([]string, error) {
 }
 
 func canonicalizeArgs(args []string, help BazelHelpFunc, onlyStartupOptions bool) ([]string, error) {
+	args, execArgs := arg.SplitExecutableArgs(args)
 	schema, err := getCommandLineSchema(args, help, onlyStartupOptions)
 	if err != nil {
 		return nil, err
@@ -410,7 +411,7 @@ func canonicalizeArgs(args []string, help BazelHelpFunc, onlyStartupOptions bool
 		}
 		canonical = append(canonical, out[i])
 	}
-	return canonical, nil
+	return arg.JoinExecutableArgs(canonical, execArgs), nil
 }
 
 // runBazelHelpWithCache returns the `bazel help <topic>` output for the version

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -364,6 +364,30 @@ func TestCanonicalizeStartupArgs(t *testing.T) {
 	require.Equal(t, expectedCanonicalArgs, canonicalArgs)
 }
 
+func TestCanonicalizeArgs_Passthrough(t *testing.T) {
+	args := []string{
+		"--output_base", "build",
+		"test",
+		"//:some_target",
+		"--",
+		"cmd",
+		"-foo=bar",
+	}
+
+	canonicalArgs, err := canonicalizeArgs(args, staticHelpFromTestData, true)
+
+	require.NoError(t, err)
+	expectedCanonicalArgs := []string{
+		"--output_base=build",
+		"test",
+		"//:some_target",
+		"--",
+		"cmd",
+		"-foo=bar",
+	}
+	require.Equal(t, expectedCanonicalArgs, canonicalArgs)
+}
+
 func staticHelpFromTestData(topic string) (string, error) {
 	if topic == "startup_options" {
 		return test_data.BazelHelpStartupOptionsOutput, nil


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/2427
