### PR TITLE
Enable golang staticcheck analyzer S1009 (Omit redundant nil check on slices)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -43,7 +43,6 @@ nogo(
     ] + staticcheck_analyzers(ANALYZERS + [
         "-S1007",
         "-S1008",
-        "-S1009",
         "-S1011",
         "-S1012",
         "-S1017",

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -272,7 +272,7 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 		execution.StatusCode = executeResponse.GetStatus().GetCode()
 		execution.StatusMessage = trimStatus(executeResponse.GetStatus().GetMessage())
 		execution.ExitCode = executeResponse.GetResult().GetExitCode()
-		if details := executeResponse.GetStatus().GetDetails(); details != nil && len(details) > 0 {
+		if details := executeResponse.GetStatus().GetDetails(); len(details) > 0 {
 			serializedDetails, err := proto.Marshal(details[0])
 			if err == nil {
 				execution.SerializedStatusDetails = serializedDetails

--- a/server/eventlog/eventlog.go
+++ b/server/eventlog/eventlog.go
@@ -366,7 +366,7 @@ type ANSICursorBufferWriter struct {
 }
 
 func (w *ANSICursorBufferWriter) Write(ctx context.Context, p []byte) (int, error) {
-	if p == nil || len(p) == 0 {
+	if len(p) == 0 {
 		return w.WriteWithTailCloser.WriteWithTail(ctx, p, nil)
 	}
 


### PR DESCRIPTION
**Related issues**: N/A
