### PR TITLE
Fixes / improvements to firecracker debug mode

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -60,6 +60,7 @@ go_library(
             "@com_github_google_uuid//:uuid",
             "@com_github_sirupsen_logrus//:logrus",
             "@org_golang_google_grpc//:go_default_library",
+            "@org_golang_google_protobuf//proto",
             "@org_golang_x_sync//errgroup",
             "@org_golang_x_sys//unix",
         ],

--- a/enterprise/tools/vmstart/vmstart.go
+++ b/enterprise/tools/vmstart/vmstart.go
@@ -97,7 +97,8 @@ func getActionAndCommand(ctx context.Context, bsClient bspb.ByteStreamClient, ac
 func main() {
 	flag.Parse()
 
-	flagutil.SetValueForFlagName("executor.firecracker_debug_mode", true, nil, false)
+	flagutil.SetValueForFlagName("executor.firecracker_debug_stream_vm_logs", true, nil, false)
+	flagutil.SetValueForFlagName("executor.firecracker_debug_terminal", true, nil, false)
 
 	rand.Seed(time.Now().Unix())
 


### PR DESCRIPTION
* Fix issue that debug mode was broken by https://github.com/buildbuddy-io/buildbuddy/pull/3797
* Split "debug mode" concept into 2 separate flags - VM log streaming, and interactive mode (which starts a terminal in the VM). Most of the time, I don't actually want the VM terminal, and occasionally it messes up my host terminal and I have to kill the whole term to fix it.

**Related issues**: N/A
