### PR TITLE
Increase timeout on remote_execution_test

### DIFF
--- a/enterprise/server/test/integration/remote_execution/BUILD
+++ b/enterprise/server/test/integration/remote_execution/BUILD
@@ -3,6 +3,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "remote_execution_test",
     size = "small",
+    # TODO(https://github.com/buildbuddy-io/buildbuddy-internal/issues/2379):
+    # make these tests run faster
+    timeout = "long",
     srcs = ["remote_execution_test.go"],
     args = ["--test.v"],
     data = [


### PR DESCRIPTION

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/2379
