### PR TITLE
Use COW storage for firecracker VM NBDs

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -30,6 +30,7 @@ go_library(
             "//server/util/status",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
+            "//enterprise/server/remote_execution/blockio",
             "//enterprise/server/remote_execution/commandutil",
             "//enterprise/server/remote_execution/container",
             "//enterprise/server/remote_execution/nbd/nbdserver",
@@ -86,6 +87,7 @@ go_test(
         "//enterprise:bundle",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/filecache",
+        "//enterprise/server/remote_execution/platform",
         "//enterprise/server/remote_execution/runner",
         "//enterprise/server/remote_execution/workspace",
         "//enterprise/server/util/ext4",
@@ -135,6 +137,7 @@ go_test(
         "//enterprise:bundle",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/filecache",
+        "//enterprise/server/remote_execution/platform",
         "//enterprise/server/remote_execution/runner",
         "//enterprise/server/remote_execution/workspace",
         "//enterprise/server/util/ext4",

--- a/enterprise/server/remote_execution/nbd/nbdserver/nbdserver.go
+++ b/enterprise/server/remote_execution/nbd/nbdserver/nbdserver.go
@@ -20,13 +20,9 @@ type Device struct {
 	Metadata *nbdpb.DeviceMetadata
 }
 
-func NewExt4Device(path, name string) (*Device, error) {
-	m, err := blockio.NewMmap(path)
-	if err != nil {
-		return nil, err
-	}
+func NewExt4Device(store blockio.Store, name string) (*Device, error) {
 	return &Device{
-		Store: m,
+		Store: store,
 		Metadata: &nbdpb.DeviceMetadata{
 			Name:           name,
 			FilesystemType: nbdpb.FilesystemType_EXT4_FILESYSTEM_TYPE,


### PR DESCRIPTION
:point_right: based on https://github.com/buildbuddy-io/buildbuddy/pull/4205

* Use the new `blockio.COWStore` for the NBD backing storage
* Save and load the COW as part of the snapshot

Compared to plain ext4, the `git clone && bazel build` test with NBD + COW enabled is about 6-10% slower (~62s with NBD disabled, vs. ~66-68s with NBD enabled). I haven't yet tried making the block size larger or other optimizations, so there might be some room for improvement here.

**Related issues**: N/A
