### PR TITLE
More firecracker debugging fixes

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -225,6 +225,11 @@ func PullImageIfNecessary(ctx context.Context, env environment.Env, cacheAuth *I
 	if *debugUseLocalImagesOnly {
 		return nil
 	}
+	if env.GetAuthenticator() == nil {
+		// If we don't have an authenticator available, fall back to
+		// authenticating the creds with the image registry on every request.
+		return ctr.PullImage(ctx, creds)
+	}
 	isCached, err := ctr.IsImageCached(ctx)
 	if err != nil {
 		return err

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -687,13 +687,6 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 		netNS = networking.NetNamespacePath(c.id)
 	}
 
-	var stdout io.Writer = c.vmLog
-	var stderr io.Writer = c.vmLog
-	if *debugStreamVMLogs {
-		stdout = io.MultiWriter(stdout, os.Stdout)
-		stderr = io.MultiWriter(stderr, os.Stderr)
-	}
-
 	cgroupVersion, err := getCgroupVersion()
 	if err != nil {
 		return err
@@ -715,8 +708,8 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 			NumaNode:       fcclient.Int(0), // TODO(tylerw): randomize this?
 			ExecFile:       firecrackerBinPath,
 			ChrootStrategy: fcclient.NewNaiveChrootStrategy(""),
-			Stdout:         stdout,
-			Stderr:         stderr,
+			Stdout:         c.vmLogWriter(),
+			Stderr:         c.vmLogWriter(),
 			CgroupVersion:  cgroupVersion,
 		},
 		Snapshot: fcclient.SnapshotConfig{
@@ -912,24 +905,15 @@ func (c *FirecrackerContainer) getChroot() string {
 func (c *FirecrackerContainer) getConfig(ctx context.Context, containerFS, scratchFS, workspaceFS string) (*fcclient.Config, error) {
 	bootArgs := "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules=1 random.trust_cpu=on i8042.noaux=1 tsc=reliable ipv6.disable=1"
 	var netNS string
-	var stdout io.Writer = c.vmLog
-	var stderr io.Writer = c.vmLog
 
 	if c.vmConfig.EnableNetworking {
 		bootArgs += " " + machineIPBootArgs
 		netNS = networking.NetNamespacePath(c.id)
 	}
 
-	// End the kernel args, before passing some more args to init.
-	if !c.vmConfig.DebugMode {
-		bootArgs += " quiet"
-	}
-
 	// Pass some flags to the init script.
 	if c.vmConfig.DebugMode {
 		bootArgs = "-debug_mode " + bootArgs
-		stdout = io.MultiWriter(stdout, os.Stdout)
-		stderr = io.MultiWriter(stderr, os.Stderr)
 	}
 	if c.vmConfig.EnableNetworking {
 		bootArgs = "-set_default_route " + bootArgs
@@ -975,8 +959,8 @@ func (c *FirecrackerContainer) getConfig(ctx context.Context, containerFS, scrat
 			NumaNode:       fcclient.Int(0), // TODO(tylerw): randomize this?
 			ExecFile:       firecrackerBinPath,
 			ChrootStrategy: fcclient.NewNaiveChrootStrategy(kernelImagePath),
-			Stdout:         stdout,
-			Stderr:         stderr,
+			Stdout:         c.vmLogWriter(),
+			Stderr:         c.vmLogWriter(),
 			CgroupVersion:  cgroupVersion,
 		},
 		MachineCfg: fcmodels.MachineConfiguration{
@@ -1013,14 +997,19 @@ func (c *FirecrackerContainer) getConfig(ctx context.Context, containerFS, scrat
 			},
 		}
 	}
-	cfg.JailerCfg.Stdout = c.vmLog
-	cfg.JailerCfg.Stderr = c.vmLog
-	if c.vmConfig.DebugMode {
-		cfg.JailerCfg.Stdout = io.MultiWriter(cfg.JailerCfg.Stdout, os.Stdout)
-		cfg.JailerCfg.Stderr = io.MultiWriter(cfg.JailerCfg.Stderr, os.Stderr)
+	cfg.JailerCfg.Stdout = c.vmLogWriter()
+	cfg.JailerCfg.Stderr = c.vmLogWriter()
+	if *debugTerminal {
 		cfg.JailerCfg.Stdin = os.Stdin
 	}
 	return cfg, nil
+}
+
+func (c *FirecrackerContainer) vmLogWriter() io.Writer {
+	if *debugStreamVMLogs || *debugTerminal {
+		return io.MultiWriter(c.vmLog, os.Stderr)
+	}
+	return c.vmLog
 }
 
 func copyStaticFiles(ctx context.Context, env environment.Env, workingDir string) error {


### PR DESCRIPTION
* Fix vmstart (it was failing because `PullImageIfNecessary` expects an authenticator, but vmstart doesn't set one up. In this case, we can disable image cache auth that is based on group ID, and instead authenticate directly with the remote registry). Also, make sure to stream stdout/stderr to the terminal when the new `debug_terminal` flag is enabled, even if `debug_stream_vm_logs` is not enabled. Otherwise, we can send keyboard input to the VM but can't see the output.
* Don't set the `quiet` kernel option ever. Otherwise, we'll only see kernel logs when debug mode is enabled, but we always want kernel logs to be available (e.g. when dumping kernel logs for debugging)
* Fix up a few places that I missed in https://github.com/buildbuddy-io/buildbuddy/pull/4218 where I meant to reference the new `debug_stream_vm_logs` flag instead of `vmConfig.DebugMode` (which maps to the new `debug_terminal` flag).

**Related issues**: N/A
