### PR TITLE
CLI: fix 'bb help completion'

### DIFF
--- a/cli/help/BUILD
+++ b/cli/help/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//cli/bazelisk",
         "//cli/parser",
         "//cli/version",
+        "//server/util/lockingbuffer",
     ],
 )
 

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -1,7 +1,6 @@
 package help
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +11,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
 	"github.com/buildbuddy-io/buildbuddy/cli/parser"
 	"github.com/buildbuddy-io/buildbuddy/cli/version"
+	"github.com/buildbuddy-io/buildbuddy/server/util/lockingbuffer"
 )
 
 const (
@@ -58,7 +58,7 @@ func showHelp(subcommand string, modifiers []string) (exitCode int, err error) {
 		bazelArgs = append(bazelArgs, subcommand)
 	}
 	bazelArgs = append(bazelArgs, modifiers...)
-	buf := bytes.NewBuffer(nil)
+	buf := lockingbuffer.New()
 	exitCode, err = bazelisk.Run(bazelArgs, &bazelisk.RunOpts{Stdout: buf, Stderr: buf})
 	if err != nil {
 		io.Copy(os.Stdout, buf)

--- a/cli/help/help.go
+++ b/cli/help/help.go
@@ -37,8 +37,8 @@ func HandleHelp(args []string) (exitCode int, err error) {
 		return showHelp("", getHelpModifiers(args))
 	}
 	if cmd == "help" {
-		bazelCommand, _ := parser.GetBazelCommandAndIndex(args[idx+1:])
-		return showHelp(bazelCommand, getHelpModifiers(args))
+		helpTopic := arg.GetCommand(args[idx+1:])
+		return showHelp(helpTopic, getHelpModifiers(args))
 	}
 	if arg.ContainsExact(args, "-h") || arg.ContainsExact(args, "--help") {
 		bazelCommand, _ := parser.GetBazelCommandAndIndex(args)

--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -37,6 +37,20 @@ func TestBazelVersion(t *testing.T) {
 	require.NotContains(t, output, log.WarningPrefix)
 }
 
+func TestBazelHelp(t *testing.T) {
+	ws := testcli.NewWorkspace(t)
+	cmd := testcli.Command(t, ws, "help", "completion")
+
+	// Note: this test makes sure that the help output appears in stdout (not
+	// stderr), so that tools can do things like `eval $(bb help completion)`
+	// the same way they can with vanilla bazel.
+	b, err := testcli.Output(cmd)
+	output := string(b)
+	require.NoError(t, err, "output: %s", string(b))
+
+	require.Contains(t, output, `BAZEL_STARTUP_OPTIONS="`)
+}
+
 func TestBazelBuildWithLocalPlugin(t *testing.T) {
 	ws := testcli.NewWorkspace(t)
 	testfs.WriteAllFileContents(t, ws, map[string]string{

--- a/server/util/lockingbuffer/lockingbuffer.go
+++ b/server/util/lockingbuffer/lockingbuffer.go
@@ -50,3 +50,9 @@ func (lb *LockingBuffer) ReadAll() ([]byte, error) {
 	lb.buffer.Reset()
 	return b, err
 }
+
+func (lb *LockingBuffer) String() string {
+	lb.mu.RLock()
+	defer lb.mu.RUnlock()
+	return lb.buffer.String()
+}


### PR DESCRIPTION
Make it work even if the help topic is not a bazel command - not all help topics are bazel commands, such as `completion` and `target-syntax`.

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/2448
