### PR TITLE
Add Pebble Cache to benchmark cache test

### DIFF
--- a/enterprise/server/test/performance/cache/BUILD
+++ b/enterprise/server/test/performance/cache/BUILD
@@ -9,6 +9,7 @@ go_test(
     tags = ["performance"],
     deps = [
         "//enterprise/server/backends/distributed",
+        "//enterprise/server/backends/pebble_cache",
         "//proto:resource_go_proto",
         "//server/backends/disk_cache",
         "//server/backends/memory_cache",


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

Add Pebble Cache and Distributed Pebble Cache to benchmark cache test.

Also change the log level to error. Some warning logs make the benchmark result difficult to read. 
**Related issues**: N/A
