### PR TITLE
Don't multiply resource requests by 0.8

### DIFF
--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -67,7 +67,7 @@ const (
 	MaxEstimatedFreeDisk = int64(100 * 1e9) // 100GB
 
 	// The fraction of an executor's allocatable resources to make available for task sizing.
-	MaxResourceCapacityRatio = 0.8
+	MaxResourceCapacityRatio = 1
 
 	// The expiration for task usage measurements stored in Redis.
 	sizeMeasurementExpiration = 5 * 24 * time.Hour


### PR DESCRIPTION
Executors don't look super over-utilized, and we can adjust task sizing instead if this becomes an issue
