### PR TITLE
Don't call setInterval with larger than a day

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -68,7 +68,8 @@ export class AuthService {
     console.info(`Refreshing access token every ${refreshFrequencySeconds} seconds.`);
     setInterval(() => {
       if (this.user) this.refreshToken();
-    }, refreshFrequencySeconds * 1000);
+      // Calling setInterval with a number larger than a 32 bit int causes refresh spamming
+    }, Math.min(refreshFrequencySeconds * 1000, 86400000)); // One day in ms
   }
 
   refreshToken() {


### PR DESCRIPTION
Fun quirk I found when working on auth stuff, if you call setInterval with larger than a 32 bit integer - you get an overflow and the setInterval function gets spammed:
https://stackoverflow.com/questions/39007056/is-there-a-maximum-delay-limit-for-window-setinterval