### PR TITLE
Pull some more stuff out of oidc.go into claims.go and cookie.go

### DIFF
--- a/enterprise/server/oidc/BUILD
+++ b/enterprise/server/oidc/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//server/util/status",
         "//server/util/url",
         "@com_github_coreos_go_oidc//:go-oidc",
-        "@com_github_golang_jwt_jwt//:jwt",
         "@com_github_google_uuid//:uuid",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_grpc//credentials",

--- a/enterprise/server/oidc/BUILD
+++ b/enterprise/server/oidc/BUILD
@@ -42,6 +42,7 @@ go_test(
         "//enterprise/server/testutil/enterprise_testenv",
         "//server/tables",
         "//server/util/authutil",
+        "//server/util/cookie",
         "//server/util/status",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/oidc/oidc_test.go
+++ b/enterprise/server/oidc/oidc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/cookie"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,9 +93,9 @@ func TestAuthenticateHTTPRequest(t *testing.T) {
 
 	sessionID := "e34ff952-6ef0-4a35-ae3d-fe6166fe277e"
 	// Valid JWT cookie, but user does not exist.
-	request.AddCookie(&http.Cookie{Name: jwtCookie, Value: validJWT})
-	request.AddCookie(&http.Cookie{Name: authIssuerCookie, Value: testIssuer})
-	request.AddCookie(&http.Cookie{Name: sessionIDCookie, Value: sessionID})
+	request.AddCookie(&http.Cookie{Name: cookie.JWTCookie, Value: validJWT})
+	request.AddCookie(&http.Cookie{Name: cookie.AuthIssuerCookie, Value: testIssuer})
+	request.AddCookie(&http.Cookie{Name: cookie.SessionIDCookie, Value: sessionID})
 	authCtx = auth.AuthenticatedHTTPContext(response, request)
 	requireAuthenticationError(t, authCtx)
 
@@ -124,9 +125,9 @@ func TestAuthenticateHTTPRequest(t *testing.T) {
 	// DB doesn't have a refresh token so authentication should fail.
 	request, err = http.NewRequest(http.MethodGet, "/", strings.NewReader(""))
 	require.NoErrorf(t, err, "could not create HTTP request")
-	request.AddCookie(&http.Cookie{Name: jwtCookie, Value: expiredJWT})
-	request.AddCookie(&http.Cookie{Name: authIssuerCookie, Value: testIssuer})
-	request.AddCookie(&http.Cookie{Name: sessionIDCookie, Value: sessionID})
+	request.AddCookie(&http.Cookie{Name: cookie.JWTCookie, Value: expiredJWT})
+	request.AddCookie(&http.Cookie{Name: cookie.AuthIssuerCookie, Value: testIssuer})
+	request.AddCookie(&http.Cookie{Name: cookie.SessionIDCookie, Value: sessionID})
 	authCtx = auth.AuthenticatedHTTPContext(response, request)
 	requireAuthenticationError(t, authCtx)
 
@@ -137,7 +138,7 @@ func TestAuthenticateHTTPRequest(t *testing.T) {
 	response = httptest.NewRecorder()
 	authCtx = auth.AuthenticatedHTTPContext(response, request)
 	requireAuthenticated(t, authCtx)
-	newJwtCookie := getResponseCookie(response.Result(), jwtCookie)
+	newJwtCookie := getResponseCookie(response.Result(), cookie.JWTCookie)
 	require.NotNil(t, newJwtCookie, "JWT cookie should be updated")
 	require.Equal(t, refreshedJWT, newJwtCookie.Value, "JWT cookie should be updated")
 	require.Equal(t, validUserToken, authCtx.Value(contextUserKey), "context user details should match details returned by provider")

--- a/server/util/claims/BUILD
+++ b/server/util/claims/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//server/environment",
         "//server/interfaces",
         "//server/tables",
+        "//server/util/authutil",
         "//server/util/capabilities",
         "//server/util/flagutil",
         "//server/util/lru",

--- a/server/util/cookie/cookie.go
+++ b/server/util/cookie/cookie.go
@@ -2,8 +2,21 @@ package cookie
 
 import (
 	"flag"
+	"fmt"
 	"net/http"
 	"time"
+)
+
+const (
+	// The name of the auth cookies used to authenticate the
+	// client.
+	JWTCookie             = "Authorization"
+	SessionIDCookie       = "Session-ID"
+	sessionDurationCookie = "Session-Duration-Seconds"
+	AuthIssuerCookie      = "Authorization-Issuer"
+	RedirCookie           = "Redirect-Url"
+
+	loginCookieDuration = 365 * 24 * time.Hour
 )
 
 var (
@@ -31,4 +44,19 @@ func GetCookie(r *http.Request, name string) string {
 		return c.Value
 	}
 	return ""
+}
+
+func SetLoginCookie(w http.ResponseWriter, jwt, issuer, sessionID string, sessionExpireTime int64) {
+	expiry := time.Now().Add(loginCookieDuration)
+	SetCookie(w, JWTCookie, jwt, expiry, true /* httpOnly= */)
+	SetCookie(w, AuthIssuerCookie, issuer, expiry, true /* httpOnly= */)
+	SetCookie(w, SessionIDCookie, sessionID, expiry, true /* httpOnly= */)
+	// Don't make the session duration cookie httpOnly so the front end knows how frequently it needs to refresh tokens.
+	SetCookie(w, sessionDurationCookie, fmt.Sprintf("%d", sessionExpireTime-time.Now().Unix()), expiry, false /* httpOnly= */)
+}
+
+func ClearLoginCookie(w http.ResponseWriter) {
+	ClearCookie(w, JWTCookie)
+	ClearCookie(w, AuthIssuerCookie)
+	ClearCookie(w, SessionIDCookie)
 }


### PR DESCRIPTION
These methods are used in both oidc and github auth.

We pull the following methods into cookie.go:
- SetLoginCookie
- ClearLoginCookie

And the following methods into claims.go
- ClaimsFromContext
- AuthContextFromClaims