### PR TITLE
go_sdk: add windows Go toolchains

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -93,7 +93,7 @@ go_download_sdk(
 )
 
 go_download_sdk(
-    name = "go_sdk_windows_amr64",
+    name = "go_sdk_windows_arm64",
     goarch = "arm64",
     goos = "windows",
     version = "1.20.5",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,6 +85,20 @@ go_download_sdk(
     version = "1.20.5",
 )
 
+go_download_sdk(
+    name = "go_sdk_windows",
+    goarch = "amd64",
+    goos = "windows",
+    version = "1.20.5",
+)
+
+go_download_sdk(
+    name = "go_sdk_windows_amr64",
+    goarch = "arm64",
+    goos = "windows",
+    version = "1.20.5",
+)
+
 go_register_toolchains(
     nogo = "@//:vet",
 )


### PR DESCRIPTION
We need this to verify how Executor could be built targeting Windows
platform.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/2314
