### PR TITLE
rules_go: upgrade to v0.40.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,10 +20,10 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",
+    sha256 = "51dc53293afe317d2696d4d6433a4c33feedb7748a9e352072e2ec3c0dafd2c6",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.40.1/rules_go-v0.40.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.40.1/rules_go-v0.40.1.zip",
     ],
 )
 

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -470,7 +470,7 @@ func TestFirecrackerComplexFileMapping(t *testing.T) {
 	} else {
 		assert.Equal(t, "overlay", scratchFSU.GetFstype())
 		assert.Equal(t, "overlayfs:/scratch/bbvmroot", scratchFSU.GetSource())
-		const approxInitialScratchDiskSizeBytes = 40e6
+		const approxInitialScratchDiskSizeBytes = 38e6
 		assert.InDelta(
 			t, approxInitialScratchDiskSizeBytes+scratchTestFileSizeBytes,
 			scratchFSU.GetUsedBytes(),


### PR DESCRIPTION
For more information:
https://github.com/bazelbuild/rules_go/releases/tag/v0.40.1
https://github.com/bazelbuild/rules_go/releases/tag/v0.40.0

This should help with https://github.com/buildbuddy-io/buildbuddy-internal/issues/2314
thanks to https://github.com/bazelbuild/rules_go/pull/3566

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
