### PR TITLE
CLI: Don't apply .bazelrc when running `bazel help` to collect metadata

### DIFF
--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -462,7 +462,7 @@ func runBazelHelpWithCache(topic string) (string, error) {
 	buf := &bytes.Buffer{}
 	log.Printf("\x1b[90mGathering metadata for bazel %s...\x1b[m", topic)
 	opts := &bazelisk.RunOpts{Stdout: io.MultiWriter(tmp, buf)}
-	exitCode, err := bazelisk.Run([]string{"help", topic}, opts)
+	exitCode, err := bazelisk.Run([]string{"--ignore_all_rc_files", "help", topic}, opts)
 	if err != nil {
 		return "", fmt.Errorf("failed to run bazel: %s", err)
 	}


### PR DESCRIPTION
If you apply .bazelrc options and you have `common` flags in your .bazelrc to the `bazel help` command, which may be invalid.

This causes problems until this Bazel fix is in (but will continue to cause problems on old versions):
https://github.com/bazelbuild/bazel/pull/18609