### PR TITLE
CLI: Only set sync flag if we need a sidecar

### DIFF
--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -155,14 +155,15 @@ func ConfigureSidecar(args []string) []string {
 		sidecarArgs = append(sidecarArgs, fmt.Sprintf("--cache_dir=%s", diskCacheDir))
 	}
 
+	// If there aren't any sidecar arguments, we don't need to spin up a sidecar at all.
+	if len(sidecarArgs) == 0 {
+		return args
+	}
+
 	if synchronousWriteFlag == "1" || synchronousWriteFlag == "true" {
 		sidecarArgs = append(sidecarArgs, "--synchronous_write")
 		sidecarArgs = append(sidecarArgs, "--bes_synchronous")
 		args = append(args, "--bes_upload_mode=wait_for_upload_complete")
-	}
-
-	if len(sidecarArgs) == 0 {
-		return args
 	}
 
 	sidecarArgs = append(sidecarArgs, []string{


### PR DESCRIPTION
Before this change, we'd unnecessarily start the sidecar if `--sync=true` is set (which it is if the CI=true environment variable is set) but BES / cache flags were not set.