### PR TITLE
nogo: make config json consistent

### DIFF
--- a/cli/cache_proxy/cache_proxy.go
+++ b/cli/cache_proxy/cache_proxy.go
@@ -283,7 +283,6 @@ func (p *CacheProxy) Write(stream bspb.ByteStream_WriteServer) error {
 			return stream.SendAndClose(lastRsp)
 		}
 	}
-	return nil
 }
 
 func (p *CacheProxy) QueryWriteStatus(ctx context.Context, req *bspb.QueryWriteStatusRequest) (*bspb.QueryWriteStatusResponse, error) {

--- a/tools/cacheload/cacheload.go
+++ b/tools/cacheload/cacheload.go
@@ -213,7 +213,6 @@ func main() {
 				log.Printf("Write: %d, Read: %d QPS", writeQPSCounter.Get(), readQPSCounter.Get())
 			}
 		}
-		return nil
 	})
 
 	for i := 0; i < numWriters; i++ {


### PR DESCRIPTION
There are several changes here:

- Disable fieldalignment completely (instead of excluding all files from
  being checked).

- Remove nilness config. The analyzer was removed from an earlier change.

- Switch from including only files under `sever/` and
  `enterprise/server/` to excluding all `external/` files. This will
  include Go files from other directories such as `cli/`.

- Programatically replace all unix path separators with a regex that
  matches both Windows and Unix separators.

- Add comment with example on how to check the rendered json config
  file.

- Add missing configs for some analyzers,
  effectively ignore all external dependencies during linting.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
