### PR TITLE
Add option to release.py to bump the minor version vs the patch version

### DIFF
--- a/release.py
+++ b/release.py
@@ -66,6 +66,15 @@ def bump_patch_version(version):
     parts[-1] = str(patch_int +1)
     return ".".join(parts)
 
+def bump_minor_version(version):
+    parts = version.split(".")
+    # Bump minor version
+    minor_version = int(parts[-2])
+    parts[-2] = str(minor_version +1)
+    # Set patch version to 0
+    parts[-1] = str(0)
+    return ".".join(parts)
+
 def yes_or_no(question):
     while "the answer is invalid":
         reply = input(question+" (y/n): ").lower().strip()
@@ -181,6 +190,7 @@ def main():
     parser.add_argument('--skip_version_bump', default=False, action='store_true')
     parser.add_argument('--skip_latest_tag', default=False, action='store_true')
     parser.add_argument('--force', default=False, action='store_true')
+    parser.add_argument('--bump_patch_version', default=False, action='store_true')
     args = parser.parse_args()
 
     if workspace_is_clean():
@@ -203,7 +213,11 @@ def main():
 
     new_version = old_version
     if not skip_version_bump:
-        new_version = bump_patch_version(old_version)
+        if args.bump_patch_version:
+            new_version = bump_patch_version(old_version)
+        else:
+            new_version = bump_minor_version(old_version)
+
         release_notes = generate_release_notes(old_version)
         print("release notes:\n %s" % release_notes)
         print('I found existing version: %s' % old_version)

--- a/release.py
+++ b/release.py
@@ -190,7 +190,7 @@ def main():
     parser.add_argument('--skip_version_bump', default=False, action='store_true')
     parser.add_argument('--skip_latest_tag', default=False, action='store_true')
     parser.add_argument('--force', default=False, action='store_true')
-    parser.add_argument('--bump_patch_version', default=False, action='store_true')
+    parser.add_argument('--bump_version_type', default='minor', choices=['major', 'minor', 'patch'])
     args = parser.parse_args()
 
     if workspace_is_clean():
@@ -213,10 +213,12 @@ def main():
 
     new_version = old_version
     if not skip_version_bump:
-        if args.bump_patch_version:
+        if args.bump_version_type == 'patch':
             new_version = bump_patch_version(old_version)
-        else:
+        elif args.bump_version_type == 'minor':
             new_version = bump_minor_version(old_version)
+        else:
+            die(f"Unimplemented bump version type: {args.bump_version_type}")
 
         release_notes = generate_release_notes(old_version)
         print("release notes:\n %s" % release_notes)


### PR DESCRIPTION
Will also change the default behavior of the script to bump the minor version, instead of the patch version as it is doing now.

**Related Slack thread**: https://buildbuddy-corp.slack.com/archives/C01D5GHRJ59/p1687987660161869
