### PR TITLE
config: Propagate parse failures upward

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -66,7 +66,7 @@ func expandStringValue(value string) (string, error) {
 // LoadFromFile parses the flags and loads the config from a string.
 func LoadFromData(data string) error {
 	if err := flagyaml.PopulateFlagsFromData(data); err != nil {
-		return nil
+		return err
 	}
 	var lastErr error
 	common.DefaultFlagSet.VisitAll(func(f *flag.Flag) {

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -225,4 +225,29 @@ secret_struct_slice_flag:
 		require.NoError(t, err)
 		require.Equal(t, []secretHolder{{Secret: "FIRST\nSECRET"}, {Secret: "SECOND\nSECRET"}}, *secretStructSliceFlag)
 	}
+
+}
+
+func TestLoadFromData(t *testing.T) {
+	// Can successfully parse int config item
+	{
+		flags := replaceFlagsForTesting(t)
+		_ = flags.Int("must_be_a_number", 0, "")
+		err := config.LoadFromData(strings.TrimSpace(`
+must_be_a_number: 4
+	`))
+		require.NoError(t, err)
+	}
+
+	// Parse error when config value causes type mismatch
+	{
+		flags := replaceFlagsForTesting(t)
+		_ = flags.Int("must_be_a_number", 0, "")
+		err := config.LoadFromData(strings.TrimSpace(`
+must_be_a_number: "not a string, like this"
+	`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "retyping YAML map")
+		require.Contains(t, err.Error(), "into int")
+	}
 }


### PR DESCRIPTION
This change returns the parse error upward when a config fails to parse, instead of early-returning no error. This fixes an issue where a malformed config results in a confusing failure to launch:

```
2023/07/07 22:32:10.053 INF BuildBuddy v2.12.49 (933606adb4ed2c807eab7a9edcc27782eb0e1d10) compiled with go1.20.5 X:nocoverageredesign
2023/07/07 22:32:10.054 INF Reading buildbuddy config from '/local/config.yaml'
2023/07/07 22:32:10.062 INF Auto-migrating DB
2023/07/07 22:32:10.078 INF Successfully configured sqlite database.
2023/07/07 22:32:10.079 WRN No authentication will be configured: rpc error: code = Internal desc = OIDC authenticator failed to configure: rpc error: code = FailedPrecondition desc = No auth providers specified in config!
2023/07/07 22:32:10.080 FTL rpc error: code = Internal desc = Invalid Remote Execution Redis config.
```

This is happening becuase the parse failure essentially causes the config to be discarded, at which point default values are used, which happens to result in an invalid configuration.

With this change, Buildbuddy will still fail to launch, but will print the actual config parse error instead.

Tested: Built an image with this change and used to debug a config that wouldn't launch properly after updating (spoiler: turns out it's always been malformed, and is only now properly validated)

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
