### PR TITLE
CLI: propagate --verbose flag to child invocations

### DIFF
--- a/cli/log/log.go
+++ b/cli/log/log.go
@@ -2,11 +2,14 @@ package log
 
 import (
 	"log"
+	"os"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 )
 
 const (
+	verboseEnvVarName = "BB_VERBOSE"
+
 	debugPrefix   = "\x1b[33m[bb-debug]\x1b[m "
 	WarningPrefix = "\x1b[33mWarning:\x1b[m "
 )
@@ -15,7 +18,14 @@ var verbose bool
 
 func Configure(args []string) []string {
 	verboseFlagVal, args := arg.Pop(args, "verbose")
+	if verboseFlagVal == "" {
+		verboseFlagVal = os.Getenv(verboseEnvVarName)
+	}
 	verbose = verboseFlagVal == "1" || verboseFlagVal == "true"
+	if verbose {
+		// Propagate the flag value to nested invocations (via env var)
+		os.Setenv(verboseEnvVarName, "1")
+	}
 	log.SetFlags(0)
 	return args
 }


### PR DESCRIPTION
* Set `BB_VERBOSE=1` as an env var, and respect that env var, so that child invocations run in verbose mode as well.
* As a side benefit, this also allows setting `BB_VERBOSE=1` as an env var for the top level invocation, instead of using the `--verbose=true` flag which is slightly less ergonomic in some situations.

**Related issues**: N/A
