### PR TITLE
server/util/db: allow compilation without cgo

### DIFF
--- a/server/util/db/BUILD
+++ b/server/util/db/BUILD
@@ -2,7 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "db",
-    srcs = ["db.go"],
+    srcs = [
+        "db.go",
+        "db_cgo.go",
+        "db_nocgo.go",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/db",
     visibility = ["//visibility:public"],
     deps = [

--- a/server/util/db/db_cgo.go
+++ b/server/util/db/db_cgo.go
@@ -1,0 +1,40 @@
+//go:build cgo
+
+package db
+
+import (
+	"database/sql/driver"
+	"errors"
+	"fmt"
+
+	gomysql "github.com/go-sql-driver/mysql"
+	gopostgres "github.com/jackc/pgx/v5/stdlib"
+	gosqlite "github.com/mattn/go-sqlite3"
+)
+
+func getDriver(ds DataSource) (driver.Driver, error) {
+	switch ds.DriverName() {
+	case sqliteDriver:
+		return &gosqlite.SQLiteDriver{}, nil
+	case mysqlDriver:
+		return &gomysql.MySQLDriver{}, nil
+	case postgresDriver:
+		return &gopostgres.Driver{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported database driver %s", ds.DriverName())
+	}
+}
+
+func (h *DBHandle) IsDuplicateKeyError(err error) bool {
+	var mysqlErr *gomysql.MySQLError
+	// Defined at https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html#error_er_dup_entry
+	if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
+		return true
+	}
+	var sqliteErr gosqlite.Error
+	// Defined at https://www.sqlite.org/rescode.html#constraint_unique
+	if errors.As(err, &sqliteErr) && sqliteErr.ExtendedCode == 2067 {
+		return true
+	}
+	return false
+}

--- a/server/util/db/db_nocgo.go
+++ b/server/util/db/db_nocgo.go
@@ -1,0 +1,32 @@
+//go:build !cgo
+
+package db
+
+import (
+	"database/sql/driver"
+	"errors"
+	"fmt"
+
+	gomysql "github.com/go-sql-driver/mysql"
+	gopostgres "github.com/jackc/pgx/v5/stdlib"
+)
+
+func getDriver(ds DataSource) (driver.Driver, error) {
+	switch ds.DriverName() {
+	case mysqlDriver:
+		return &gomysql.MySQLDriver{}, nil
+	case postgresDriver:
+		return &gopostgres.Driver{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported database driver %s", ds.DriverName())
+	}
+}
+
+func (h *DBHandle) IsDuplicateKeyError(err error) bool {
+	var mysqlErr *gomysql.MySQLError
+	// Defined at https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html#error_er_dup_entry
+	if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Provide an alternative compilcation option when build without cgo on
some platforms. In particular, remove sqlite support when cgo is off.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
