### PR TITLE
CLI: allow setting bazel version w/ env var when using .bazelversion method

### DIFF
--- a/cli/bazelisk/BUILD
+++ b/cli/bazelisk/BUILD
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/bazelisk",
     deps = [
         "//cli/arg",
+        "//cli/log",
         "//cli/workspace",
         "@com_github_bazelbuild_bazelisk//core:go_default_library",
         "@com_github_bazelbuild_bazelisk//repositories:go_default_library",

--- a/cli/bazelisk/bazelisk.go
+++ b/cli/bazelisk/bazelisk.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bazelbuild/bazelisk/core"
 	"github.com/bazelbuild/bazelisk/repositories"
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
 )
 
@@ -99,7 +100,7 @@ func InvokeRunScript(path string) (exitCode int, err error) {
 // This will return true when referencing a CLI release in .bazelversion such as
 // "buildbuddy-io/0.0.13" and then running `bazelisk`.
 func IsInvokedByBazelisk() bool {
-	return os.Getenv("BAZELISK_SKIP_WRAPPER") == "true"
+	return filepath.Base(os.Args[0]) == "bazelisk" || os.Getenv("BAZELISK_SKIP_WRAPPER") == "true"
 }
 
 // makePipeWriter adapts a writer to an *os.File by using an os.Pipe().
@@ -167,6 +168,27 @@ func getBazeliskHome() (string, error) {
 	return filepath.Join(userCacheDir, "bazelisk"), nil
 }
 
+func getEnvVersion() string {
+	// When using the .bazelversion method, users still need a way to be able to
+	// specify a CLI version via env, while still allowing bazelisk to invoke
+	// the CLI instead of bazel. "BB_USE_BAZEL_VERSION" gives users a way to do
+	// that.
+	if v := os.Getenv("BB_USE_BAZEL_VERSION"); v != "" {
+		return v
+	}
+	return os.Getenv("USE_BAZEL_VERSION")
+}
+
+func setEnvVersion(value string) error {
+	if err := os.Setenv("BB_USE_BAZEL_VERSION", value); err != nil {
+		return err
+	}
+	if err := os.Setenv("USE_BAZEL_VERSION", value); err != nil {
+		return err
+	}
+	return nil
+}
+
 // ResolveVersion returns the actual bazel version that will be used by
 // bazelisk.
 // This will either return a version string like "5.0.0" or an absolute path to
@@ -175,7 +197,7 @@ func ResolveVersion() (string, error) {
 	if err := setBazelVersion(); err != nil {
 		return "", err
 	}
-	rawVersion := os.Getenv("USE_BAZEL_VERSION")
+	rawVersion := getEnvVersion()
 	// If using a file path "version", return the file path directly.
 	if filepath.IsAbs(rawVersion) {
 		return rawVersion, nil
@@ -220,6 +242,7 @@ func ResolveVersion() (string, error) {
 func setBazelVersion() error {
 	setVersionOnce.Do(func() {
 		setVersionErr = setBazelVersionImpl()
+		log.Debugf("setBazelVersion: Set env version to %s", getEnvVersion())
 	})
 	return setVersionErr
 }
@@ -237,11 +260,13 @@ func isCLIVersion(version string) bool {
 }
 
 func setBazelVersionImpl() error {
-	// If USE_BAZEL_VERSION is already set and not pointing to us (the BB CLI),
-	// preserve that value.
-	envVersion := os.Getenv("USE_BAZEL_VERSION")
+	// If the version is already set via env var and not pointing to us (the BB
+	// CLI), preserve that value.
+	envVersion := getEnvVersion()
 	if envVersion != "" && !isCLIVersion(envVersion) {
-		return nil
+		// Set the env version to its current value so that both env vars take
+		// on the value (BB_USE_BAZEL_VERSION and USE_BAZEL_VERSION)
+		return setEnvVersion(envVersion)
 	}
 
 	// TODO: Handle the cases where we were invoked via .bazeliskrc
@@ -249,12 +274,13 @@ func setBazelVersionImpl() error {
 
 	ws, err := workspace.Path()
 	if err != nil {
-		return os.Setenv("USE_BAZEL_VERSION", "latest")
+		return setEnvVersion("latest")
 	}
 	parts, err := ParseVersionDotfile(filepath.Join(ws, ".bazelversion"))
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
+	log.Debugf(".bazelversion file contents: %s", parts)
 	// If we appear first in .bazelversion, ignore that version to prevent
 	// bazelisk from invoking us recursively.
 	if IsInvokedByBazelisk() {
@@ -265,10 +291,9 @@ func setBazelVersionImpl() error {
 	// If we couldn't find a non-BB bazel version in .bazelversion at this
 	// point, default to "latest".
 	if len(parts) == 0 {
-		return os.Setenv("USE_BAZEL_VERSION", "latest")
+		return setEnvVersion("latest")
 	}
-
-	return os.Setenv("USE_BAZEL_VERSION", parts[0])
+	return setEnvVersion(parts[0])
 }
 
 // ParseVersionDotfile returns the non-empty lines from the given .bazelversion

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -54,6 +54,15 @@ func run() (exitCode int, err error) {
 	// (--verbose, etc.)
 	args := log.Configure(os.Args[1:])
 
+	log.Debugf("CLI started at %s", start)
+	log.Debugf("args[0]: %s", os.Args[0])
+	log.Debugf("env: BAZEL_REAL=%s", os.Getenv("BAZEL_REAL"))
+	log.Debugf("env: BAZELISK_SKIP_WRAPPER=%s", os.Getenv("BAZELISK_SKIP_WRAPPER"))
+	log.Debugf("env: USE_BAZEL_VERSION=%s", os.Getenv("USE_BAZEL_VERSION"))
+	log.Debugf("env: BB_USE_BAZEL_VERSION=%s", os.Getenv("BB_USE_BAZEL_VERSION"))
+
+	bazelisk.ResolveVersion()
+
 	// Make sure startup args are always in the format --foo=bar.
 	args, err = parser.CanonicalizeStartupArgs(args)
 	if err != nil {

--- a/cli/testutil/testcli/BUILD
+++ b/cli/testutil/testcli/BUILD
@@ -10,6 +10,7 @@ go_library(
     deps = [
         "//cli/storage",
         "//server/testutil/testbazel",
+        "//server/testutil/testbazelisk",
         "//server/testutil/testfs",
         "//server/testutil/testgit",
         "//server/util/lockingbuffer",

--- a/server/testutil/testbazelisk/BUILD
+++ b/server/testutil/testbazelisk/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "testbazelisk",
+    testonly = 1,
+    srcs = ["testbazelisk.go"],
+    data = ["@com_github_bazelbuild_bazelisk//:bazelisk"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/testbazelisk",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_stretchr_testify//require",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+    ],
+)

--- a/server/testutil/testbazelisk/testbazelisk.go
+++ b/server/testutil/testbazelisk/testbazelisk.go
@@ -1,0 +1,16 @@
+package testbazelisk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	bazelgo "github.com/bazelbuild/rules_go/go/tools/bazel"
+)
+
+// BinaryPath returns the path to bazelisk in runfiles.
+func BinaryPath(t *testing.T) string {
+	path, err := bazelgo.Runfile("external/com_github_bazelbuild_bazelisk/bazelisk_/bazelisk")
+	require.NoError(t, err, "failed to locate bazelisk")
+	return path
+}


### PR DESCRIPTION
Adds a new env var `BB_USE_BAZEL_VERSION` that can be used instead of `USE_BAZEL_VERSION` when using the `.bazelversion` method for running the CLI under bazelisk. `USE_BAZEL_VERSION` doesn't work because it bypasses the CLI entirely.

**Related issues**: N/A
