### PR TITLE
Limit the max number of build events that can be buffered in memory

### DIFF
--- a/server/build_event_protocol/build_event_handler/BUILD
+++ b/server/build_event_protocol/build_event_handler/BUILD
@@ -72,6 +72,7 @@ go_test(
         "//server/testutil/testclock",
         "//server/testutil/testenv",
         "//server/util/protofile",
+        "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_google_uuid//:uuid",
         "@com_github_stretchr_testify//assert",

--- a/tools/replay_invocation/replay_invocation.go
+++ b/tools/replay_invocation/replay_invocation.go
@@ -106,7 +106,7 @@ func main() {
 	log.Infof("Replaying events...")
 	for {
 		ie := &inpb.InvocationEvent{}
-		err := pr.ReadProto(ctx, ie)
+		_, err := pr.ReadProto(ctx, ie)
 		if err != nil {
 			if err == io.EOF {
 				if sequenceNum == 0 {


### PR DESCRIPTION
This is a safe guard to protect the apps until https://github.com/buildbuddy-io/buildbuddy-internal/issues/749 is fixed.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/749
