### PR TITLE
Remove sorting in pebble_cache.FindMissing

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1461,10 +1461,6 @@ func (p *PebbleCache) FindMissing(ctx context.Context, resources []*rspb.Resourc
 	iter := db.NewIter(nil /*default iterOptions*/)
 	defer iter.Close()
 
-	sort.Slice(resources, func(i, j int) bool {
-		return resources[i].GetDigest().GetHash() < resources[j].GetDigest().GetHash()
-	})
-
 	var missing []*repb.Digest
 	for _, r := range resources {
 		fileRecord, err := p.makeFileRecord(ctx, r)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

Don't sort the input resource names in FindMissing. This has the side effect of 
changing the order of the input slice; and benchmark tests didn't show that it
impact performances after removing the sort.
**Related issues**: N/A
