### PR TITLE
Upgrade soci-store binary to buildbuddy-io/soci-snapshotterv0.0.4

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -7042,11 +7042,11 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
     )
 
     http_file(
-        name = "com_github_buildbuddy_io_soci_snapshotter-soci-store-c1b8cd5a19f8ec80bc0bb488a897d8b00a4a4723-linux-amd64",
-        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-store-c1b8cd5a19f8ec80bc0bb488a897d8b00a4a4723-linux-amd64"],
-        sha256 = "da38c7afed40a7a6dc91363003fe18d8f3197f5ddcbcde08fb075fa55aa3037c",
+        name = "com_github_buildbuddy_io_soci_snapshotter-soci-store-v0.0.4-linux-amd64",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-store-v0.0.4-linux-amd64"],
+        sha256 = "e58a0d93e9fc414699123f97a321e9d79e84260cbb1b2935052a84bfbfaec6e5",
         executable = True,
-        downloaded_file_path = "soci-store-c1b8cd5a19f8ec80bc0bb488a897d8b00a4a4723-linux-amd64",
+        downloaded_file_path = "soci-store-v0.0.4-linux-amd64",
     )
 
     http_file(

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -90,10 +90,10 @@ container_layer(
     files = [
         ":firecracker",
         ":jailer",
-        "@com_github_buildbuddy_io_soci_snapshotter-soci-store-c1b8cd5a19f8ec80bc0bb488a897d8b00a4a4723-linux-amd64//file:soci-store-c1b8cd5a19f8ec80bc0bb488a897d8b00a4a4723-linux-amd64",
+        "@com_github_buildbuddy_io_soci_snapshotter-soci-store-v0.0.4-linux-amd64//file:soci-store-v0.0.4-linux-amd64",
     ],
     symlinks = {
-        "/usr/bin/soci-store": "/usr/bin/soci-store-c1b8cd5a19f8ec80bc0bb488a897d8b00a4a4723-linux-amd64",
+        "/usr/bin/soci-store": "/usr/bin/soci-store-v0.0.4-linux-amd64",
     },
 )
 


### PR DESCRIPTION
This lets us start the store with the [local_keychain service](https://github.com/buildbuddy-io/soci-snapshotter/blob/main/service/keychain/local_keychain/local_keychain.go) enabled so we can pass credentials back and forth.

There's a bunch of crap in [buildbuddy-tools](https://console.cloud.google.com/storage/browser/buildbuddy-tools/binaries/soci-snapshotter?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&project=flame-build&prefix=&forceOnObjectsSortingFiltering=false) now (including this version), I have a reminder set to go in and clean it up (except the version we're using!) once this one looks good.

**Related issues**: N/A
