### PR TITLE
Call local_keychain.PutCredentials before pulling private images…

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -31,6 +31,7 @@ go_library(
         "//server/util/random",
         "//server/util/retry",
         "//server/util/status",
+        "@com_github_awslabs_soci_snapshotter//proto",
         "@com_github_opencontainers_go_digest//:go-digest",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_protobuf//proto",


### PR DESCRIPTION
…so the soci-snapshotter can use the credentials as well. This enables streaming private container images.

This depends on https://github.com/buildbuddy-io/buildbuddy/pull/4304

**Related issues**: N/A
