### PR TITLE
app/executors: improve OS/Arch UI

### DIFF
--- a/enterprise/app/executors/BUILD
+++ b/enterprise/app/executors/BUILD
@@ -20,6 +20,7 @@ ts_library(
         "//proto:bazel_config_ts_proto",
         "//proto:scheduler_ts_proto",
         "@npm//@types/react",
+        "@npm//lucide-react",
         "@npm//react",
         "@npm//rxjs",
         "@npm//tslib",

--- a/enterprise/app/executors/BUILD
+++ b/enterprise/app/executors/BUILD
@@ -20,7 +20,6 @@ ts_library(
         "//proto:bazel_config_ts_proto",
         "//proto:scheduler_ts_proto",
         "@npm//@types/react",
-        "@npm//lucide-react",
         "@npm//react",
         "@npm//rxjs",
         "@npm//tslib",

--- a/enterprise/app/executors/executors.css
+++ b/enterprise/app/executors/executors.css
@@ -54,3 +54,18 @@
   margin-bottom: 32px;
   max-width: 600px;
 }
+
+.executor-pool-header {
+  display: table;
+  width: 30%;
+  table-layout: fixed;
+}
+
+.executor-pool-header span {
+  display: table-cell;
+  text-align: center;
+}
+
+div.demo span:first-child {
+  text-align: left;
+}

--- a/enterprise/app/executors/executors.css
+++ b/enterprise/app/executors/executors.css
@@ -55,17 +55,22 @@
   max-width: 600px;
 }
 
-.executor-pool-header {
-  display: table;
-  width: 30%;
-  table-layout: fixed;
+.executors-page .executor-details {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 8px;
 }
 
-.executor-pool-header span {
-  display: table-cell;
-  text-align: center;
+.executors-page .executor-detail {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
-div.demo span:first-child {
-  text-align: left;
+.executors-page .pool-size-warning {
+  margin: 0;
+  margin-top: 16px;
+  max-width: initial;
+  display: inline-flex;
 }

--- a/enterprise/app/executors/executors.tsx
+++ b/enterprise/app/executors/executors.tsx
@@ -1,4 +1,3 @@
-import { Cpu, Laptop } from "lucide-react";
 import React from "react";
 import Banner from "../../../app/components/banner/banner";
 import rpcService from "../../../app/service/rpc_service";
@@ -12,6 +11,7 @@ import { bazel_config } from "../../../proto/bazel_config_ts_proto";
 import router from "../../../app/router/router";
 import Select, { Option } from "../../../app/components/select/select";
 import LinkButton from "../../../app/components/button/link_button";
+import { Cpu, Hash, Laptop, LucideIcon } from "lucide-react";
 
 enum FetchType {
   Executors,
@@ -156,33 +156,24 @@ class ExecutorsList extends React.Component<ExecutorsListProps> {
               }
               return (
                 <>
-                  <div className="executor-pool-header">
-                    <span>
-                      <h2>{executors[0].node?.pool || "Default Pool"}</h2>
-                    </span>
-                    {executors[0].node?.os && (
-                      <span>
-                        <Laptop className="icon" />
-                        <a>
-                          {" "}
-                          <b>OS:</b> {executors[0].node?.os}
-                        </a>
-                      </span>
-                    )}
-                    {executors[0].node?.arch && (
-                      <span>
-                        <Cpu className="icon" />
-                        <a>
-                          {" "}
-                          <b>Arch:</b> {executors[0].node?.arch}
-                        </a>
-                      </span>
-                    )}
+                  <h2>{executors[0].node?.pool || "Default Pool"}</h2>
+                  <div className="executor-details">
+                    <ExecutorDetail Icon={Hash} label="">
+                      {executors.length} {executors.length === 1 ? "executor" : "executors"}
+                    </ExecutorDetail>
+                    <ExecutorDetail Icon={Laptop} label="OS">
+                      {executors[0].node?.os || "unknown"}
+                    </ExecutorDetail>
+                    <ExecutorDetail Icon={Cpu} label="Arch">
+                      {executors[0].node?.arch || "unknown"}
+                    </ExecutorDetail>
                   </div>
-                  {executors.length == 1 && <p>There is 1 self-hosted executor in this pool.</p>}
-                  {executors.length > 1 && <p>There are {executors.length} self-hosted executors in this pool.</p>}
                   {executors.length < 3 && (
-                    <p>For better performance and reliability, we suggest running a minimum of 3 executors per pool.</p>
+                    <div>
+                      <Banner type="warning" className="pool-size-warning">
+                        For better performance and reliability, we suggest running a minimum of 3 executors per pool.
+                      </Banner>
+                    </div>
                   )}
                   {executors.map(
                     (node) => node.node && <ExecutorCardComponent node={node.node} isDefault={node.isDefault} />
@@ -194,6 +185,18 @@ class ExecutorsList extends React.Component<ExecutorsListProps> {
       </>
     );
   }
+}
+
+function ExecutorDetail({ Icon, label, children }: { Icon: LucideIcon; label: string; children: React.ReactNode }) {
+  return (
+    <span className="executor-detail">
+      <Icon className="icon" />
+      <span>
+        {label && <>{label}: </>}
+        <b>{children}</b>
+      </span>
+    </span>
+  );
 }
 
 type TabId = "status" | "setup";

--- a/enterprise/app/executors/executors.tsx
+++ b/enterprise/app/executors/executors.tsx
@@ -1,3 +1,4 @@
+import { Cpu, Laptop } from "lucide-react";
 import React from "react";
 import Banner from "../../../app/components/banner/banner";
 import rpcService from "../../../app/service/rpc_service";
@@ -155,10 +156,29 @@ class ExecutorsList extends React.Component<ExecutorsListProps> {
               }
               return (
                 <>
-                  <h2>
-                    {executors[0].node?.os || ""}/{executors[0].node?.arch || ""}{" "}
-                    {executors[0].node?.pool || "Default Pool"}
-                  </h2>
+                  <div className="executor-pool-header">
+                    <span>
+                      <h2>{executors[0].node?.pool || "Default Pool"}</h2>
+                    </span>
+                    {executors[0].node?.os && (
+                      <span>
+                        <Laptop className="icon" />
+                        <a>
+                          {" "}
+                          <b>OS:</b> {executors[0].node?.os}
+                        </a>
+                      </span>
+                    )}
+                    {executors[0].node?.arch && (
+                      <span>
+                        <Cpu className="icon" />
+                        <a>
+                          {" "}
+                          <b>Arch:</b> {executors[0].node?.arch}
+                        </a>
+                      </span>
+                    )}
+                  </div>
                   {executors.length == 1 && <p>There is 1 self-hosted executor in this pool.</p>}
                   {executors.length > 1 && <p>There are {executors.length} self-hosted executors in this pool.</p>}
                   {executors.length < 3 && (


### PR DESCRIPTION
When helping a customer troubleshoot their executor pools,
it was not clear visually which pool was which between multiple
"Default" pools with different OS/Arch combination.

Move the OS/Arch information to their dedicated lines to better display
different attributes of a pool.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
