### PR TITLE
filecache: log potential unlink error

### DIFF
--- a/enterprise/server/remote_execution/filecache/BUILD
+++ b/enterprise/server/remote_execution/filecache/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/metrics",
+        "//server/util/alert",
         "//server/util/disk",
         "//server/util/fastcopy",
         "//server/util/log",

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -93,12 +93,13 @@ func evictFn(value interface{}, reason lru.EvictionReason) {
 	// TODO(sluongng): consider using Go generic to avoid type assertion.
 	v, ok := value.(*entry)
 	if !ok {
-		log.Warningf("could not cast filecache's value to entry struct: %v", value)
+		log.Errorf("Unexpected filecache entry type %T", value)
 		return
 	}
 
-	err := syscall.Unlink(v.value)
-	log.Errorf("failed to unlink filecache entry %q: %s", v.value, err)
+  if err := syscall.Unlink(v.value); err != nil {
+	  log.Errorf("Failed to unlink filecache entry %q: %s", v.value, err)
+  }
 	if reason == lru.SizeEviction {
 		age := time.Since(time.UnixMicro(v.addedAtUsec)).Microseconds()
 		metrics.FileCacheLastEvictionAgeUsec.Set(float64(age))

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
+	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/fastcopy"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -92,7 +93,7 @@ func sizeFn(value interface{}) int64 {
 func evictFn(value interface{}, reason lru.EvictionReason) {
 	v, ok := value.(*entry)
 	if !ok {
-		log.Errorf("Unexpected filecache entry type %T", value)
+		alert.UnexpectedEvent("filecache", "Unexpected filecache entry type %T", value)
 		return
 	}
 

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -90,16 +90,15 @@ func sizeFn(value interface{}) int64 {
 }
 
 func evictFn(value interface{}, reason lru.EvictionReason) {
-	// TODO(sluongng): consider using Go generic to avoid type assertion.
 	v, ok := value.(*entry)
 	if !ok {
 		log.Errorf("Unexpected filecache entry type %T", value)
 		return
 	}
 
-  if err := syscall.Unlink(v.value); err != nil {
-	  log.Errorf("Failed to unlink filecache entry %q: %s", v.value, err)
-  }
+	if err := syscall.Unlink(v.value); err != nil {
+		log.Errorf("Failed to unlink filecache entry %q: %s", v.value, err)
+	}
 	if reason == lru.SizeEviction {
 		age := time.Since(time.UnixMicro(v.addedAtUsec)).Microseconds()
 		metrics.FileCacheLastEvictionAgeUsec.Set(float64(age))

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -90,12 +90,18 @@ func sizeFn(value interface{}) int64 {
 }
 
 func evictFn(value interface{}, reason lru.EvictionReason) {
-	if v, ok := value.(*entry); ok {
-		syscall.Unlink(v.value)
-		if reason == lru.SizeEviction {
-			age := time.Since(time.UnixMicro(v.addedAtUsec)).Microseconds()
-			metrics.FileCacheLastEvictionAgeUsec.Set(float64(age))
-		}
+	// TODO(sluongng): consider using Go generic to avoid type assertion.
+	v, ok := value.(*entry)
+	if !ok {
+		log.Warningf("could not cast filecache's value to entry struct: %v", value)
+		return
+	}
+
+	err := syscall.Unlink(v.value)
+	log.Errorf("failed to unlink filecache entry %q: %s", v.value, err)
+	if reason == lru.SizeEviction {
+		age := time.Since(time.UnixMicro(v.addedAtUsec)).Microseconds()
+		metrics.FileCacheLastEvictionAgeUsec.Set(float64(age))
 	}
 }
 


### PR DESCRIPTION
We have received a report from a customer with self-hosted executor
regarding cleanup left over.

Let's start tracking if there is any failures during unlink syscall.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
