### PR TITLE
runner: allow setting podID using environment variable

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -140,6 +140,9 @@ var (
 )
 
 func k8sPodID() (string, error) {
+	if podID := os.Getenv("K8S_POD_ID"); podID != "" {
+		return podID, nil
+	}
 	if _, err := os.Stat("/proc/1/cpuset"); err != nil {
 		if os.IsNotExist(err) {
 			return "", nil


### PR DESCRIPTION
When cgroup v2 or other container orchestration is used, it's possible
that podID is not set in `/proc/*/cpuset` and become empty.

Let's provide a way for user to explicitly set podID from K8s container
definition via environment variable.

For example, one could use the following config

```yaml

  containers:
    - name: buildbuddy-executor
      ...
      env:
      - name: K8S_POD_ID
        valueFrom:
          fieldRef:
            fieldPath: metadata.uid
```

to set this value.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
