### PR TITLE
Bump soci-snapshotter version run as soci-store and linked into app from v0.0.4 to v0.0.5

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -246,8 +246,8 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         name = "com_github_awslabs_soci_snapshotter",
         importpath = "github.com/awslabs/soci-snapshotter",
         replace = "github.com/buildbuddy-io/soci-snapshotter",
-        sum = "h1:1kEJq3IYRa97x+erW+Yjbix6+JzfwmpIOf0YXjL1zIs=",
-        version = "v0.0.4",
+        sum = "h1:G6Adpu0lUQ9Qja6OUxG/gB0loz1UzlNo9804f9kjDPo=",
+        version = "v0.0.5",
     )
 
     go_repository(
@@ -7012,11 +7012,11 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
     )
 
     http_file(
-        name = "com_github_buildbuddy_io_soci_snapshotter-soci-store-v0.0.4-linux-amd64",
-        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-store-v0.0.4-linux-amd64"],
-        sha256 = "e58a0d93e9fc414699123f97a321e9d79e84260cbb1b2935052a84bfbfaec6e5",
+        name = "com_github_buildbuddy_io_soci_snapshotter-soci-store-v0.0.5-linux-amd64",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-store-v0.0.5-linux-amd64"],
+        sha256 = "e626cac7bb01cc4911a16e6d6a8b4419c29922c8bd74db02d984969635d6f997",
         executable = True,
-        downloaded_file_path = "soci-store-v0.0.4-linux-amd64",
+        downloaded_file_path = "soci-store-v0.0.5-linux-amd64",
     )
 
     http_file(

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -90,10 +90,10 @@ container_layer(
     files = [
         ":firecracker",
         ":jailer",
-        "@com_github_buildbuddy_io_soci_snapshotter-soci-store-v0.0.4-linux-amd64//file:soci-store-v0.0.4-linux-amd64",
+        "@com_github_buildbuddy_io_soci_snapshotter-soci-store-v0.0.5-linux-amd64//file:soci-store-v0.0.5-linux-amd64",
     ],
     symlinks = {
-        "/usr/bin/soci-store": "/usr/bin/soci-store-v0.0.4-linux-amd64",
+        "/usr/bin/soci-store": "/usr/bin/soci-store-v0.0.5-linux-amd64",
     },
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/buildbuddy-io/buildbuddy
 go 1.20
 
 replace (
-	github.com/awslabs/soci-snapshotter => github.com/buildbuddy-io/soci-snapshotter v0.0.4
+	github.com/awslabs/soci-snapshotter => github.com/buildbuddy-io/soci-snapshotter v0.0.5
 	github.com/buildkite/terminal-to-html/v3 => github.com/buildbuddy-io/terminal-to-html/v3 v3.7.0-patched-1
 	github.com/firecracker-microvm/firecracker-go-sdk => github.com/bduffany/firecracker-go-sdk v0.0.0-20230702173145-62f8e172aec2
 	github.com/go-redsync/redsync/v4 v4.4.1 => github.com/bduffany/redsync/v4 v4.4.1-minimal

--- a/go.sum
+++ b/go.sum
@@ -827,8 +827,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/buildbuddy-io/soci-snapshotter v0.0.4 h1:1kEJq3IYRa97x+erW+Yjbix6+JzfwmpIOf0YXjL1zIs=
-github.com/buildbuddy-io/soci-snapshotter v0.0.4/go.mod h1:25BojoSLodZQgb0Wh4Mv5Eo4HUL4ZpZuBDgOVn0BuA0=
+github.com/buildbuddy-io/soci-snapshotter v0.0.5 h1:G6Adpu0lUQ9Qja6OUxG/gB0loz1UzlNo9804f9kjDPo=
+github.com/buildbuddy-io/soci-snapshotter v0.0.5/go.mod h1:25BojoSLodZQgb0Wh4Mv5Eo4HUL4ZpZuBDgOVn0BuA0=
 github.com/buildbuddy-io/tensorflow-proto v0.0.0-20220908151343-929b41ab4dc6 h1:LcKnQdAYrT3LOZt0mTgw6uiEi7QVkH75cCxPj+AbkLA=
 github.com/buildbuddy-io/tensorflow-proto v0.0.0-20220908151343-929b41ab4dc6/go.mod h1:sbWYLPDSURZSehjnwnFclswM4ErueZHCVxXimWH6Uo4=
 github.com/buildbuddy-io/terminal-to-html/v3 v3.7.0-patched-1 h1:XMnC81zIjWBw5SRc/TqPOP4vHPftVhdNl5azJrOwz+Y=


### PR DESCRIPTION
**Related issues**: N/A
