### PR TITLE
Add cdc chunking support to PebbleCache.

### DIFF
--- a/enterprise/server/backends/pebble_cache/BUILD
+++ b/enterprise/server/backends/pebble_cache/BUILD
@@ -48,7 +48,7 @@ go_library(
 
 go_test(
     name = "pebble_cache_test",
-    size = "small",
+    size = "medium",
     srcs = ["pebble_cache_test.go"],
     shard_count = 8,
     deps = [

--- a/enterprise/server/backends/pebble_cache/BUILD
+++ b/enterprise/server/backends/pebble_cache/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//enterprise/server/raft/filestore",
         "//enterprise/server/raft/keys",
+        "//enterprise/server/util/chunker",
         "//enterprise/server/util/pebble",
         "//proto:raft_go_proto",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1860,10 +1860,11 @@ func (p *PebbleCache) newCDCCommitedWriteCloser(ctx context.Context, fileRecord 
 			return err
 		}
 		if cdcw.numChunks == 1 {
-			// When there is only one single chunk, we want to store the original file
-			// record with the original key instead of computed digest from the
-			// chunkData. This is because the chunkData can be compressed or encrypted,
-			// so the digest computed from it will be different from the original digest.
+			// When there is only one single chunk, we want to store the original
+			// file record with the original key instead of computed digest from
+			// the chunkData. This is because the chunkData can be compressed or
+			// encrypted, so the digest computed from it will be different from
+			// the original digest.
 			return cdcw.writeRawChunk(cdcw.fileRecord, cdcw.key, cdcw.firstChunk)
 		}
 		now := p.clock.Now().UnixMicro()

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1896,6 +1896,8 @@ func (cdcw *cdcWriter) writeChunk(chunkData []byte) error {
 		if err := cdcw.writeChunkWhenMultiple(cdcw.firstChunk); err != nil {
 			return err
 		}
+		// We no longer need the first chunk anymore.
+		cdcw.firstChunk = nil
 	}
 	// we need to copy the data because once the chunker calls Next, chunkData
 	// will be invalidated.
@@ -1955,7 +1957,7 @@ func (cdcw *cdcWriter) writeChunkWhenMultiple(chunkData []byte) error {
 	}
 
 	// We use cdcw.writtenChunks for the file-level metadata, and this needs to
-	// be in the orther. Otherwise, when we read the file, the chunks will be
+	// be in order. Otherwise, when we read the file, the chunks will be
 	// read out of order.
 	cdcw.writtenChunks = append(cdcw.writtenChunks, rn)
 
@@ -2956,6 +2958,8 @@ func (e *partitionEvictor) deleteFile(key filestore.PebbleKey, version filestore
 	case storageMetadata.GetInlineMetadata() != nil:
 		break
 	case storageMetadata.GetChunkedMetadata() != nil:
+		// We should not update partition size b/c we only deleted a file-level
+		// entry and not the actual chunks.
 		break
 	default:
 		return status.FailedPreconditionErrorf("Unnown storage metadata type: %+v", storageMetadata)

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -97,7 +97,7 @@ var (
 	minBytesAutoZstdCompression = flag.Int64("cache.pebble.min_bytes_auto_zstd_compression", 0, "Blobs larger than this will be zstd compressed before written to disk.")
 
 	// Chunking related flags
-	averageChunkSizeBytes = flag.Int("cache.pebble.average_chunk_size_bytes", 0, "Average size of chunks that's stored in the cache")
+	averageChunkSizeBytes = flag.Int("cache.pebble.average_chunk_size_bytes", 0, "Average size of chunks that's stored in the cache. Disabled if 0.")
 )
 
 var (
@@ -1804,8 +1804,8 @@ func (p *PebbleCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompre
 	return pebble.ReadCloserWithFunc(rc, db.Close), nil
 }
 
-// A writer that will chunk the raw content using Content-Define Chunking,
-// and then encrypt and compress when needed
+// A writer that will chunk bytes written to it using Content-Defined Chunking,
+// and then, if configured, encrypt and compress the chunked bytes.
 type cdcWriter struct {
 	ctx        context.Context
 	pc         *PebbleCache
@@ -1830,10 +1830,6 @@ func (p *PebbleCache) newCDCCommitedWriteCloser(ctx context.Context, fileRecord 
 		return nil, err
 	}
 
-	if err != nil {
-		return nil, err
-	}
-
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.SetLimit(10)
 	cdcw := &cdcWriter{
@@ -1848,6 +1844,9 @@ func (p *PebbleCache) newCDCCommitedWriteCloser(ctx context.Context, fileRecord 
 	}
 
 	chunker, err := chunker.New(ctx, p.averageChunkSizeBytes, cdcw.writeChunk)
+	if err != nil {
+		return nil, err
+	}
 	cdcw.chunker = chunker
 
 	cwc := ioutil.NewCustomCommitWriteCloser(cdcw)
@@ -1860,6 +1859,10 @@ func (p *PebbleCache) newCDCCommitedWriteCloser(ctx context.Context, fileRecord 
 			return err
 		}
 		if cdcw.numChunks == 1 {
+			// When there is only one single chunk, we want to store the original file
+			// record with the original key instead of computed digest from the
+			// chunkData. This is because the chunkData can be compressed or encrypted,
+			// so the digest computed from it will be different from the original digest.
 			return cdcw.writeRawChunk(cdcw.fileRecord, cdcw.key, cdcw.firstChunk)
 		}
 		now := p.clock.Now().UnixMicro()
@@ -1880,6 +1883,10 @@ func (cdcw *cdcWriter) writeChunk(chunkData []byte) error {
 	cdcw.numChunks++
 
 	if cdcw.numChunks == 1 {
+		// We will wait to write the first chunk until either cdcw.Commit() is
+		// called or the second chunk is encountered.
+		// In the former case, there is only one chunk, we don't want to write a
+		// file-level metadata entry and a chunk entry into pebble.
 		cdcw.firstChunk = make([]byte, len(chunkData))
 		copy(cdcw.firstChunk, chunkData)
 		return nil
@@ -1918,14 +1925,6 @@ func (cdcw *cdcWriter) writeRawChunk(fileRecord *rfpb.FileRecord, key filestore.
 	return nil
 }
 
-func (cdcw *cdcWriter) writeChunkWhenSingle(chunkData []byte) error {
-	// When there is only one single chunk, we want to store the original file
-	// record with the original key instead of computed digest from the
-	// chunkData. This is because the chunkData can be compressed or encrypted,
-	// so the digest computed from it will be different from the original digest.
-	return cdcw.writeRawChunk(cdcw.fileRecord, cdcw.key, chunkData)
-}
-
 func (cdcw *cdcWriter) writeChunkWhenMultiple(chunkData []byte) error {
 	ctx := cdcw.ctx
 	p := cdcw.pc
@@ -1958,6 +1957,10 @@ func (cdcw *cdcWriter) writeChunkWhenMultiple(chunkData []byte) error {
 	if err != nil {
 		return err
 	}
+
+	// We use cdcw.writtenChunks for the file-level metadata, and this needs to
+	// be in the orther. Otherwise, when we read the file, the chunks will be
+	// read out of order.
 	cdcw.writtenChunks = append(cdcw.writtenChunks, r)
 
 	cdcw.eg.Go(func() error {
@@ -3205,7 +3208,7 @@ type readCloser struct {
 }
 
 // newChunkedReader returns a reader to read chunked content.
-// When shouldDecompress is true, the content readed is decompressed.
+// When shouldDecompress is true, the content read is decompressed.
 func (p *PebbleCache) newChunkedReader(ctx context.Context, chunkedMD *rfpb.StorageMetadata_ChunkedMetadata, shouldDecompress bool) (io.ReadCloser, error) {
 	missing, err := p.FindMissing(ctx, chunkedMD.GetResource())
 	if err != nil {

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -54,7 +54,6 @@ import (
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	cache_config "github.com/buildbuddy-io/buildbuddy/server/cache/config"
 )
@@ -1814,7 +1813,7 @@ type cdcWriter struct {
 	fileRecord *rfpb.FileRecord
 	key        filestore.PebbleKey
 
-	writtenChunks  []*resource.ResourceName
+	writtenChunks  []*rspb.ResourceName
 	shouldCompress bool
 	isCompressed   bool
 
@@ -1909,7 +1908,7 @@ func (cdcw *cdcWriter) writeChunkWhenMultiple(chunkData []byte) error {
 	if err != nil {
 		return err
 	}
-	r := &resource.ResourceName{
+	r := &rspb.ResourceName{
 		Digest:         d,
 		InstanceName:   cdcw.fileRecord.GetIsolation().GetRemoteInstanceName(),
 		CacheType:      cdcw.fileRecord.GetIsolation().GetCacheType(),
@@ -3192,7 +3191,7 @@ func (p *PebbleCache) newChunkedReader(ctx context.Context, chunkedMD *rfpb.Stor
 	pr, pw := io.Pipe()
 	go func() {
 		for _, resourceName := range chunkedMD.GetResource() {
-			rn := proto.Clone(resourceName).(*resource.ResourceName)
+			rn := proto.Clone(resourceName).(*rspb.ResourceName)
 			if shouldDecompress && rn.GetCompressor() == repb.Compressor_ZSTD {
 				rn.Compressor = repb.Compressor_IDENTITY
 			}

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/filestore"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/chunker"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/pebble"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -53,6 +54,7 @@ import (
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	cache_config "github.com/buildbuddy-io/buildbuddy/server/cache/config"
 )
@@ -94,6 +96,9 @@ var (
 
 	// Compression related flags
 	minBytesAutoZstdCompression = flag.Int64("cache.pebble.min_bytes_auto_zstd_compression", 0, "Blobs larger than this will be zstd compressed before written to disk.")
+
+	// Chunking related flags
+	averageChunkSizeBytes = flag.Int("cache.pebble.average_chunk_size_bytes_bytes", 0, "Average size of chunks that's stored in the cache")
 )
 
 var (
@@ -155,6 +160,7 @@ type Options struct {
 	MaxSizeBytes           int64
 	BlockCacheSizeBytes    int64
 	MaxInlineFileSizeBytes int64
+	AverageChunkSizeBytes  int
 
 	AtimeUpdateThreshold *time.Duration
 	AtimeBufferSize      *int
@@ -184,6 +190,7 @@ type PebbleCache struct {
 	maxSizeBytes           int64
 	blockCacheSizeBytes    int64
 	maxInlineFileSizeBytes int64
+	averageChunkSizeBytes  int
 
 	atimeUpdateThreshold time.Duration
 	atimeBufferSize      int
@@ -328,6 +335,7 @@ func Register(env environment.Env) error {
 		AtimeUpdateThreshold:        atimeUpdateThresholdFlag,
 		AtimeBufferSize:             atimeBufferSizeFlag,
 		MinEvictionAge:              minEvictionAgeFlag,
+		AverageChunkSizeBytes:       *averageChunkSizeBytes,
 	}
 	c, err := NewPebbleCache(env, opts)
 	if err != nil {
@@ -470,6 +478,7 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 		maxSizeBytes:                opts.MaxSizeBytes,
 		blockCacheSizeBytes:         opts.BlockCacheSizeBytes,
 		maxInlineFileSizeBytes:      opts.MaxInlineFileSizeBytes,
+		averageChunkSizeBytes:       opts.AverageChunkSizeBytes,
 		atimeUpdateThreshold:        *opts.AtimeUpdateThreshold,
 		atimeBufferSize:             *opts.AtimeBufferSize,
 		minEvictionAge:              *opts.MinEvictionAge,
@@ -1727,6 +1736,9 @@ func (p *PebbleCache) deleteFileAndMetadata(ctx context.Context, key filestore.P
 	case storageMetadata.GetInlineMetadata() != nil:
 		// Already deleted; see comment above.
 		break
+	case storageMetadata.GetChunkedMetadata() != nil:
+		// need to clean up the remaining chunks.
+		break
 	default:
 		return status.FailedPreconditionErrorf("Unnown storage metadata type: %+v", storageMetadata)
 	}
@@ -1793,6 +1805,169 @@ func (p *PebbleCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompre
 	return pebble.ReadCloserWithFunc(rc, db.Close), nil
 }
 
+// A writer that will chunk the raw content using Content-Define Chunking,
+// and then encrypt and compress when needed
+type cdcWriter struct {
+	ctx        context.Context
+	pc         *PebbleCache
+	db         pebble.IPebbleDB
+	fileRecord *rfpb.FileRecord
+	key        filestore.PebbleKey
+
+	writtenChunks  []*resource.ResourceName
+	shouldCompress bool
+	isCompressed   bool
+
+	chunker *chunker.Chunker
+}
+
+func (p *PebbleCache) newCDCCommitedWriteCloser(ctx context.Context, fileRecord *rfpb.FileRecord, key filestore.PebbleKey, shouldCompress bool, isCompressed bool) (interfaces.CommittedWriteCloser, error) {
+	db, err := p.leaser.DB()
+	if err != nil {
+		return nil, err
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	cdcw := &cdcWriter{
+		ctx:            ctx,
+		pc:             p,
+		db:             db,
+		key:            key,
+		fileRecord:     fileRecord,
+		shouldCompress: shouldCompress,
+		isCompressed:   isCompressed,
+	}
+
+	chunker, err := chunker.New(ctx, p.averageChunkSizeBytes, cdcw.writeChunkWhenSingle, cdcw.writeChunkWhenMultiple)
+	cdcw.chunker = chunker
+
+	cwc := ioutil.NewCustomCommitWriteCloser(cdcw)
+	cwc.CloseFn = db.Close
+	cwc.CommitFn = func(bytesWritten int64) error {
+		if err := cdcw.Close(); err != nil {
+			return err
+		}
+
+		numChunks, err := chunker.NumChunks()
+		if err != nil {
+			return err
+		}
+		now := p.clock.Now().UnixMicro()
+
+		if numChunks > 1 {
+			md := &rfpb.FileMetadata{
+				FileRecord:      fileRecord,
+				StorageMetadata: cdcw.Metadata(),
+				StoredSizeBytes: bytesWritten,
+				LastAccessUsec:  now,
+				LastModifyUsec:  now,
+			}
+			return p.writeMetadata(ctx, db, key, md)
+		}
+		return nil
+	}
+	return cwc, nil
+}
+
+func (cdcw *cdcWriter) writeRawChunk(fileRecord *rfpb.FileRecord, key filestore.PebbleKey, chunkData []byte) error {
+	ctx := cdcw.ctx
+	p := cdcw.pc
+	inlineWriter := p.fileStorer.InlineWriter(ctx, fileRecord.GetDigest().GetSizeBytes())
+	wcm, err := p.newWrappedWriter(ctx, inlineWriter, fileRecord, key, cdcw.shouldCompress || cdcw.isCompressed)
+	if err != nil {
+		return err
+	}
+	_, err = wcm.Write(chunkData)
+	if err != nil {
+		return err
+	}
+	if err := wcm.Close(); err != nil {
+		return err
+	}
+	if err := wcm.Commit(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cdcw *cdcWriter) writeChunkWhenSingle(chunkData []byte) error {
+	// When there is only one single chunk, we want to store the original file
+	// record with the original key instead of computed digest from the
+	// chunkData. This is because the chunkData can be compressed or encrypted,
+	// so the digest computed from it will be different from the original digest.
+	return cdcw.writeRawChunk(cdcw.fileRecord, cdcw.key, chunkData)
+}
+
+func (cdcw *cdcWriter) writeChunkWhenMultiple(chunkData []byte) error {
+	ctx := cdcw.ctx
+	p := cdcw.pc
+
+	d, err := digest.Compute(bytes.NewReader(chunkData), cdcw.fileRecord.GetDigestFunction())
+	if err != nil {
+		return err
+	}
+	r := &resource.ResourceName{
+		Digest:         d,
+		InstanceName:   cdcw.fileRecord.GetIsolation().GetRemoteInstanceName(),
+		CacheType:      cdcw.fileRecord.GetIsolation().GetCacheType(),
+		DigestFunction: cdcw.fileRecord.GetDigestFunction(),
+		Compressor:     cdcw.fileRecord.GetCompressor(),
+	}
+	if cdcw.shouldCompress && r.Compressor == repb.Compressor_IDENTITY {
+		// we need to compress the chunk, but this data hasn't been compressed yet.
+		// so we need to set the resource name to identity to signal to the nested
+		// writer to compress it.
+		r.Compressor = repb.Compressor_IDENTITY
+	} else {
+		r.Compressor = repb.Compressor_ZSTD
+	}
+	fileRecord, err := p.makeFileRecord(ctx, r)
+
+	if err != nil {
+		return err
+	}
+	key, err := p.fileStorer.PebbleKey(fileRecord)
+	if err != nil {
+		return err
+	}
+	err = cdcw.writeRawChunk(fileRecord, key, chunkData)
+	if err != nil {
+		return err
+	}
+	cdcw.writtenChunks = append(cdcw.writtenChunks, r)
+	return nil
+}
+
+func (cdcw *cdcWriter) Write(buf []byte) (int, error) {
+	// If the bytes being written are compressed, we decompress them in
+	// order to generate CDC chunks, then compress those chunks.
+	if cdcw.isCompressed {
+		decompressed, err := compression.DecompressZstd(nil, buf)
+		if err != nil {
+			return -1, err
+		}
+		_, err = cdcw.chunker.Write(decompressed)
+		return len(buf), err
+	}
+	return cdcw.chunker.Write(buf)
+}
+
+func (cdcw *cdcWriter) Close() error {
+	defer cdcw.db.Close()
+	return cdcw.chunker.Close()
+}
+
+func (cdcw *cdcWriter) Metadata() *rfpb.StorageMetadata {
+	return &rfpb.StorageMetadata{
+		ChunkedMetadata: &rfpb.StorageMetadata_ChunkedMetadata{
+			Resource: cdcw.writtenChunks,
+		},
+	}
+}
+
 // zstdCompressor compresses bytes before writing them to the nested writer
 type zstdCompressor struct {
 	cacheName string
@@ -1849,6 +2024,7 @@ func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfa
 	// If data is not already compressed, return a writer that will compress it before writing
 	// Only compress data over a given size for more optimal compression ratios
 	shouldCompress := r.GetCompressor() == repb.Compressor_IDENTITY && r.GetDigest().GetSizeBytes() >= p.minBytesAutoZstdCompression
+	isCompressed := r.GetCompressor() == repb.Compressor_ZSTD
 	if shouldCompress {
 		r = &rspb.ResourceName{
 			Digest:         r.GetDigest(),
@@ -1866,6 +2042,11 @@ func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfa
 	key, err := p.fileStorer.PebbleKey(fileRecord)
 	if err != nil {
 		return nil, err
+	}
+
+	if p.averageChunkSizeBytes > 0 {
+		// we enabled cdc chunking
+		return p.newCDCCommitedWriteCloser(ctx, fileRecord, key, shouldCompress, isCompressed)
 	}
 
 	var wcm interfaces.MetadataWriteCloser
@@ -1967,9 +2148,11 @@ func (p *PebbleCache) writeMetadata(ctx context.Context, db pebble.IPebbleDB, ke
 	}
 
 	if err = db.Set(keyBytes, protoBytes, pebble.NoSync); err == nil {
-		partitionID := md.GetFileRecord().GetIsolation().GetPartitionId()
-		p.sendSizeUpdate(partitionID, key.CacheType(), md.GetStoredSizeBytes())
-		metrics.DiskCacheAddedFileSizeBytes.With(prometheus.Labels{metrics.CacheNameLabel: p.name}).Observe(float64(md.GetStoredSizeBytes()))
+		if md.GetStorageMetadata().GetChunkedMetadata() == nil {
+			partitionID := md.GetFileRecord().GetIsolation().GetPartitionId()
+			p.sendSizeUpdate(partitionID, key.CacheType(), md.GetStoredSizeBytes())
+			metrics.DiskCacheAddedFileSizeBytes.With(prometheus.Labels{metrics.CacheNameLabel: p.name}).Observe(float64(md.GetStoredSizeBytes()))
+		}
 	}
 
 	return err
@@ -2740,6 +2923,8 @@ func (e *partitionEvictor) deleteFile(key filestore.PebbleKey, version filestore
 		}
 	case storageMetadata.GetInlineMetadata() != nil:
 		break
+	case storageMetadata.GetChunkedMetadata() != nil:
+		break
 	default:
 		return status.FailedPreconditionErrorf("Unnown storage metadata type: %+v", storageMetadata)
 	}
@@ -2993,6 +3178,39 @@ type readCloser struct {
 	io.Closer
 }
 
+// newChunkedReader returns a reader to read chunked content.
+// When shouldDecompress is true, the content readed is decompressed.
+func (p *PebbleCache) newChunkedReader(ctx context.Context, chunkedMD *rfpb.StorageMetadata_ChunkedMetadata, shouldDecompress bool) (io.ReadCloser, error) {
+	missing, err := p.FindMissing(ctx, chunkedMD.GetResource())
+	if err != nil {
+		return nil, err
+	}
+	if len(missing) > 0 {
+		return nil, status.NotFoundError("chunks were missing")
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		for _, resourceName := range chunkedMD.GetResource() {
+			rn := proto.Clone(resourceName).(*resource.ResourceName)
+			if shouldDecompress && rn.GetCompressor() == repb.Compressor_ZSTD {
+				rn.Compressor = repb.Compressor_IDENTITY
+			}
+			buf, err := p.Get(ctx, rn)
+			if err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+			if _, err := pw.Write(buf); err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+		}
+		pw.Close()
+	}()
+	return pr, nil
+}
+
 func (p *PebbleCache) reader(ctx context.Context, iter pebble.Iterator, r *rspb.ResourceName, uncompressedOffset int64, uncompressedLimit int64) (io.ReadCloser, error) {
 	fileRecord, err := p.makeFileRecord(ctx, r)
 	if err != nil {
@@ -3040,7 +3258,15 @@ func (p *PebbleCache) reader(ctx context.Context, iter pebble.Iterator, r *rspb.
 		limit = uncompressedLimit
 	}
 
-	reader, err := p.fileStorer.NewReader(ctx, blobDir, fileMetadata.GetStorageMetadata(), offset, limit)
+	shouldDecompress := cachedCompression == repb.Compressor_ZSTD && requestedCompression == repb.Compressor_IDENTITY
+
+	var reader io.ReadCloser
+	md := fileMetadata.GetStorageMetadata()
+	if chunkedMD := md.GetChunkedMetadata(); chunkedMD != nil {
+		reader, err = p.newChunkedReader(ctx, chunkedMD, shouldDecompress)
+	} else {
+		reader, err = p.fileStorer.NewReader(ctx, blobDir, md, offset, limit)
+	}
 	if err != nil {
 		if status.IsNotFoundError(err) || os.IsNotExist(err) {
 			unlockFn := p.locker.Lock(key.LockID())
@@ -3059,7 +3285,9 @@ func (p *PebbleCache) reader(ctx context.Context, iter pebble.Iterator, r *rspb.
 			}
 			reader = d
 		}
-		if cachedCompression == repb.Compressor_ZSTD && requestedCompression == repb.Compressor_IDENTITY {
+		if shouldDecompress && md.GetChunkedMetadata() == nil {
+			// We don't need to decompress the chunked reader's content since
+			// it already returns decompressed content from its children.
 			dr, err := compression.NewZstdDecompressingReader(reader)
 			if err != nil {
 				return nil, err

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1736,13 +1736,14 @@ func (p *PebbleCache) deleteFileAndMetadata(ctx context.Context, key filestore.P
 		// Already deleted; see comment above.
 		break
 	case storageMetadata.GetChunkedMetadata() != nil:
-		// need to clean up the remaining chunks.
 		break
 	default:
 		return status.FailedPreconditionErrorf("Unnown storage metadata type: %+v", storageMetadata)
 	}
 
-	p.sendSizeUpdate(partitionID, key.CacheType(), -1*md.GetStoredSizeBytes())
+	if md.GetStoredSizeBytes() > 0 {
+		p.sendSizeUpdate(partitionID, key.CacheType(), -1*md.GetStoredSizeBytes())
+	}
 	return nil
 }
 
@@ -1870,7 +1871,10 @@ func (p *PebbleCache) newCDCCommitedWriteCloser(ctx context.Context, fileRecord 
 		md := &rfpb.FileMetadata{
 			FileRecord:      fileRecord,
 			StorageMetadata: cdcw.Metadata(),
-			StoredSizeBytes: bytesWritten,
+			// The chunks the file record pointed are stored seperately and are
+			// not evicted when this entry is evicted. Therefore, the stored
+			// size bytes should be zero to avoid double counting.
+			StoredSizeBytes: 0,
 			LastAccessUsec:  now,
 			LastModifyUsec:  now,
 		}
@@ -2173,7 +2177,9 @@ func (p *PebbleCache) writeMetadata(ctx context.Context, db pebble.IPebbleDB, ke
 		if err := db.Delete(oldKeyBytes, pebble.NoSync); err != nil {
 			return err
 		}
-		p.sendSizeUpdate(oldMD.GetFileRecord().GetIsolation().GetPartitionId(), key.CacheType(), -1*oldMD.GetStoredSizeBytes())
+		if oldMD.GetStoredSizeBytes() > 0 {
+			p.sendSizeUpdate(oldMD.GetFileRecord().GetIsolation().GetPartitionId(), key.CacheType(), -1*oldMD.GetStoredSizeBytes())
+		}
 	}
 
 	keyBytes, err := key.Bytes(p.activeDatabaseVersion())
@@ -2182,7 +2188,7 @@ func (p *PebbleCache) writeMetadata(ctx context.Context, db pebble.IPebbleDB, ke
 	}
 
 	if err = db.Set(keyBytes, protoBytes, pebble.NoSync); err == nil {
-		if md.GetStorageMetadata().GetChunkedMetadata() == nil {
+		if md.GetStoredSizeBytes() > 0 {
 			partitionID := md.GetFileRecord().GetIsolation().GetPartitionId()
 			p.sendSizeUpdate(partitionID, key.CacheType(), md.GetStoredSizeBytes())
 			metrics.DiskCacheAddedFileSizeBytes.With(prometheus.Labels{metrics.CacheNameLabel: p.name}).Observe(float64(md.GetStoredSizeBytes()))
@@ -2958,14 +2964,14 @@ func (e *partitionEvictor) deleteFile(key filestore.PebbleKey, version filestore
 	case storageMetadata.GetInlineMetadata() != nil:
 		break
 	case storageMetadata.GetChunkedMetadata() != nil:
-		// We should not update partition size b/c we only deleted a file-level
-		// entry and not the actual chunks.
 		break
 	default:
 		return status.FailedPreconditionErrorf("Unnown storage metadata type: %+v", storageMetadata)
 	}
 
-	e.updateSize(key.CacheType(), -1*storedSizeBytes)
+	if storedSizeBytes > 0 {
+		e.updateSize(key.CacheType(), -1*storedSizeBytes)
+	}
 	return nil
 }
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -42,7 +42,6 @@ import (
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
@@ -2471,7 +2470,7 @@ func TestEncryptionAndCompression(t *testing.T) {
 			desc := fmt.Sprintf("%s_%s", tc.name, tp.desc)
 			t.Run(desc, func(t *testing.T) {
 				var dataToWrite []byte
-				var rnToWrite, rnToRead *resource.ResourceName
+				var rnToWrite, rnToRead *rspb.ResourceName
 				if tc.isWriteCompressed {
 					dataToWrite = compressedBuf
 					rnToWrite = compressedRN

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -1809,8 +1809,9 @@ func TestLRU(t *testing.T) {
 				// None of the most recently added files should have been evicted.
 				require.Equal(t, 0, len(evictionsByQuartile[4]))
 
-				require.LessOrEqual(t, len(evictionsByQuartile[1]), len(evictionsByQuartile[2]))
-				require.LessOrEqual(t, len(evictionsByQuartile[2]), len(evictionsByQuartile[3]))
+				// Relax the conditions a little to de-flake the tests.
+				require.LessOrEqual(t, len(evictionsByQuartile[1]), len(evictionsByQuartile[2])+1)
+				require.LessOrEqual(t, len(evictionsByQuartile[2]), len(evictionsByQuartile[3])+1)
 				require.Greater(t, len(evictionsByQuartile[3]), 0)
 			})
 		}

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -42,6 +42,7 @@ import (
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	"github.com/buildbuddy-io/buildbuddy/proto/resource"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
@@ -49,11 +50,13 @@ var (
 	emptyUserMap = testauth.TestUsers()
 )
 
+const (
+	averageChunkSizeBytes = 64 * 4
+)
+
 func getAnonContext(t testing.TB, env environment.Env) context.Context {
 	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), env)
-	if err != nil {
-		t.Errorf("error attaching user prefix: %v", err)
-	}
+	require.NoError(t, err)
 	return ctx
 }
 
@@ -116,49 +119,44 @@ func TestSetOptionDefaults(t *testing.T) {
 	require.Equal(t, &minEvictionAge, opts.MinEvictionAge)
 }
 
-func TestACIsolation(t *testing.T) {
-	te := testenv.GetTestEnv(t)
-	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
-	ctx := getAnonContext(t, te)
-
-	maxSizeBytes := int64(1_000_000_000) // 1GB
-	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{RootDirectory: testfs.MakeTempDir(t), MaxSizeBytes: maxSizeBytes})
-	if err != nil {
-		t.Fatal(err)
-	}
-	pc.Start()
-	defer pc.Stop()
-
-	r1, buf1 := testdigest.NewRandomResourceAndBuf(t, 100, rspb.CacheType_AC, "foo")
-	r2 := proto.Clone(r1).(*rspb.ResourceName)
-	r2.InstanceName = "bar"
-
-	require.Nil(t, pc.Set(ctx, r1, buf1))
-	require.Nil(t, pc.Set(ctx, r2, []byte("evilbuf")))
-
-	got1, err := pc.Get(ctx, r1)
-	require.NoError(t, err)
-	require.Equal(t, buf1, got1)
-
-	contains, err := pc.Contains(ctx, r1)
-	require.NoError(t, err)
-	require.True(t, contains)
-}
-
 func TestIsolation(t *testing.T) {
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
 	ctx := getAnonContext(t, te)
 
 	maxSizeBytes := int64(1_000_000_000) // 1GB
-	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{RootDirectory: testfs.MakeTempDir(t), MaxSizeBytes: maxSizeBytes})
-	if err != nil {
-		t.Fatal(err)
-	}
-	pc.Start()
-	defer pc.Stop()
 
+	type params struct {
+		desc                   string
+		testDataSizeBytes      int64
+		maxInlineFileSizeBytes int64
+		averageChunkSizeBytes  int
+	}
+
+	testParams := []params{
+		{
+			desc:                   "file is written inline, chunking turned off",
+			testDataSizeBytes:      100,
+			maxInlineFileSizeBytes: 1,
+		},
+		{
+			desc:                   "file is written on disk, chunking turned off",
+			testDataSizeBytes:      1000,
+			maxInlineFileSizeBytes: 100,
+		},
+		{
+			desc:                  "file is chunked",
+			testDataSizeBytes:     2 * 1024, // Ensure that the file is chunked
+			averageChunkSizeBytes: 64 * 4,
+		},
+		{
+			desc:                  "file is not chunked, chunking turned on",
+			testDataSizeBytes:     60, // Ensure that the file is not chunked
+			averageChunkSizeBytes: 64 * 4,
+		},
+	}
 	type test struct {
+		desc           string
 		cacheType1     rspb.CacheType
 		cacheType2     rspb.CacheType
 		instanceName1  string
@@ -203,39 +201,52 @@ func TestIsolation(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		r1, buf := testdigest.NewRandomResourceAndBuf(t, 100, test.cacheType1, test.instanceName1)
-		// Set() the bytes in cache1.
-		err = pc.Set(ctx, r1, buf)
+	for _, tp := range testParams {
+		options := &pebble_cache.Options{
+			RootDirectory:          testfs.MakeTempDir(t),
+			MaxSizeBytes:           maxSizeBytes,
+			AverageChunkSizeBytes:  tp.averageChunkSizeBytes,
+			MaxInlineFileSizeBytes: tp.maxInlineFileSizeBytes,
+		}
+		pc, err := pebble_cache.NewPebbleCache(te, options)
 		require.NoError(t, err)
+		err = pc.Start()
+		require.NoError(t, err)
+		defer pc.Stop()
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("%s(%s)", test.desc, tp.desc), func(t *testing.T) {
+				r1, buf := testdigest.NewRandomResourceAndBuf(t, 100, test.cacheType1, test.instanceName1)
+				// Set() the bytes in cache1.
+				err = pc.Set(ctx, r1, buf)
+				require.NoError(t, err)
 
-		r2 := proto.Clone(r1).(*rspb.ResourceName)
-		r2.InstanceName = test.instanceName2
-		r2.CacheType = test.cacheType2
-		// Get() the bytes from cache2.
-		rbuf, err := pc.Get(ctx, r2)
-		if test.shouldBeShared {
-			// if the caches should be shared but there was an error
-			// getting the digest: fail.
-			if err != nil {
-				t.Fatalf("Error getting %q from cache: %s", r1.GetDigest().GetHash(), err.Error())
-			}
+				r2 := proto.Clone(r1).(*rspb.ResourceName)
+				r2.InstanceName = test.instanceName2
+				r2.CacheType = test.cacheType2
 
-			// Compute a digest for the bytes returned.
-			d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
-			if err != nil {
-				t.Fatalf("Error computing digest: %s", err.Error())
-			}
+				contains, err := pc.Contains(ctx, r2)
+				require.NoError(t, err)
+				require.Equal(t, test.shouldBeShared, contains)
 
-			if r1.GetDigest().GetHash() != d2.GetHash() {
-				t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), r1.GetDigest().GetHash())
-			}
-		} else {
-			// if the caches should *not* be shared but there was
-			// no error getting the digest: fail.
-			if err == nil {
-				t.Fatalf("Got %q from cache, but should have been isolated.", r1.GetDigest().GetHash())
-			}
+				// Get() the bytes from cache2.
+				rbuf, err := pc.Get(ctx, r2)
+				if test.shouldBeShared {
+					// if the caches should be shared but there was an error
+					// getting the digest: fail.
+					require.NoError(t, err, "Error getting %q from cache: %s", r2.GetDigest().GetHash(), err)
+
+					// Compute a digest for the bytes returned.
+					d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
+					require.NoError(t, err, "Error computing digest: %s", err)
+
+					require.Equal(t, r1.GetDigest().GetHash(), d2.GetHash())
+
+				} else {
+					// if the caches should *not* be shared but there was
+					// no error getting the digest: fail.
+					require.ErrorContains(t, err, "not found", "Got %q from cache, but should have been isolated.", r2.GetDigest().GetHash())
+				}
+			})
 		}
 	}
 }
@@ -246,33 +257,55 @@ func TestGetSet(t *testing.T) {
 	ctx := getAnonContext(t, te)
 
 	maxSizeBytes := int64(1_000_000_000) // 1GB
-	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{RootDirectory: testfs.MakeTempDir(t), MaxSizeBytes: maxSizeBytes})
-	if err != nil {
-		t.Fatal(err)
-	}
-	pc.Start()
-	defer pc.Stop()
 
+	type testCase struct {
+		desc                   string
+		maxInlineFileSizeBytes int64
+		averageChunkSizeBytes  int
+	}
+
+	testCases := []testCase{
+		{
+			desc:                   "chunking turned off",
+			maxInlineFileSizeBytes: 100,
+		},
+		{
+			desc:                  "chunking turned on",
+			averageChunkSizeBytes: 64 * 4,
+		},
+	}
 	testSizes := []int64{
-		1, 10, 100, 1000, 10000, 1000000, 10000000,
+		1, 10, 100, 256, 512, 1000, 1024, 2 * 1024, 10000, 1000000, 10000000,
 	}
-	for _, testSize := range testSizes {
-		r, buf := testdigest.RandomCASResourceBuf(t, testSize)
-		// Set() the bytes in the cache.
-		err := pc.Set(ctx, r, buf)
-		if err != nil {
-			t.Fatalf("Error setting %q in cache: %s", r.GetDigest().GetHash(), err.Error())
+	for _, tc := range testCases {
+		options := &pebble_cache.Options{
+			RootDirectory:          testfs.MakeTempDir(t),
+			MaxSizeBytes:           maxSizeBytes,
+			AverageChunkSizeBytes:  tc.averageChunkSizeBytes,
+			MaxInlineFileSizeBytes: tc.maxInlineFileSizeBytes,
 		}
-		// Get() the bytes from the cache.
-		rbuf, err := pc.Get(ctx, r)
-		if err != nil {
-			t.Fatalf("Error getting %q from cache: %s", r.GetDigest().GetHash(), err.Error())
-		}
+		pc, err := pebble_cache.NewPebbleCache(te, options)
+		require.NoError(t, err)
+		err = pc.Start()
+		require.NoError(t, err)
+		defer pc.Stop()
+		for _, testSize := range testSizes {
+			desc := fmt.Sprintf("test size: %d (%s)", testSize, tc.desc)
+			t.Run(desc, func(t *testing.T) {
+				r, buf := testdigest.RandomCASResourceBuf(t, testSize)
+				// Set() the bytes in the cache.
+				err := pc.Set(ctx, r, buf)
+				require.NoError(t, err, "Error setting %q in cache: %s", r.GetDigest().GetHash(), err)
 
-		// Compute a digest for the bytes returned.
-		d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
-		if r.GetDigest().GetHash() != d2.GetHash() {
-			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), r.GetDigest().GetHash())
+				// Get() the bytes from the cache.
+				rbuf, err := pc.Get(ctx, r)
+				require.NoError(t, err, "Error getting %q from cache: %s", r.GetDigest().GetHash(), err)
+
+				// Compute a digest for the bytes returned.
+				d2, err := digest.Compute(bytes.NewReader(rbuf), r.GetDigestFunction())
+				require.NoError(t, err)
+				require.Equal(t, r.GetDigest().GetHash(), d2.GetHash())
+			})
 		}
 	}
 }
@@ -283,15 +316,21 @@ func TestDupeWrites(t *testing.T) {
 	ctx := getAnonContext(t, te)
 
 	maxSizeBytes := int64(1_000_000_000) // 1GB
-	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{
-		RootDirectory:          testfs.MakeTempDir(t),
-		MaxSizeBytes:           maxSizeBytes,
-		MaxInlineFileSizeBytes: 100,
-	})
-	require.NoError(t, err)
-	err = pc.Start()
-	require.NoError(t, err)
-	defer pc.Stop()
+
+	var testParams = []struct {
+		desc                   string
+		maxInlineFileSizeBytes int64
+		averageChunkSizeBytes  int
+	}{
+		{
+			desc:                   "chunking off",
+			maxInlineFileSizeBytes: 100,
+		},
+		{
+			desc:                  "chunking on",
+			averageChunkSizeBytes: 64 * 4,
+		},
+	}
 
 	var tests = []struct {
 		name      string
@@ -304,40 +343,51 @@ func TestDupeWrites(t *testing.T) {
 		{"ac_extern", 1000, rspb.CacheType_AC},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			r, buf := testdigest.NewRandomResourceAndBuf(t, test.size, test.cacheType, "" /*instanceName*/)
+	for _, tp := range testParams {
+		options := &pebble_cache.Options{
+			RootDirectory:          testfs.MakeTempDir(t),
+			MaxSizeBytes:           maxSizeBytes,
+			AverageChunkSizeBytes:  tp.averageChunkSizeBytes,
+			MaxInlineFileSizeBytes: tp.maxInlineFileSizeBytes,
+		}
+		pc, err := pebble_cache.NewPebbleCache(te, options)
+		require.NoError(t, err)
+		err = pc.Start()
+		require.NoError(t, err)
+		for _, test := range tests {
+			desc := fmt.Sprintf("%s(%s)", test.name, tp.desc)
+			t.Run(desc, func(t *testing.T) {
+				r, buf := testdigest.NewRandomResourceAndBuf(t, test.size, test.cacheType, "" /*instanceName*/)
 
-			w1, err := pc.Writer(ctx, r)
-			require.NoError(t, err)
-			_, err = w1.Write(buf)
-			require.NoError(t, err)
+				w1, err := pc.Writer(ctx, r)
+				require.NoError(t, err)
+				_, err = w1.Write(buf)
+				require.NoError(t, err)
 
-			w2, err := pc.Writer(ctx, r)
-			require.NoError(t, err)
-			_, err = w2.Write(buf)
-			require.NoError(t, err)
+				w2, err := pc.Writer(ctx, r)
+				require.NoError(t, err)
+				_, err = w2.Write(buf)
+				require.NoError(t, err)
 
-			err = w1.Commit()
-			require.NoError(t, err)
-			err = w1.Close()
-			require.NoError(t, err)
+				err = w1.Commit()
+				require.NoError(t, err)
+				err = w1.Close()
+				require.NoError(t, err)
 
-			err = w2.Commit()
-			require.NoError(t, err)
-			err = w2.Close()
-			require.NoError(t, err)
+				err = w2.Commit()
+				require.NoError(t, err)
+				err = w2.Close()
+				require.NoError(t, err)
 
-			// Verify we can read the data back after dupe writes are done.
-			rbuf, err := pc.Get(ctx, r)
-			require.NoError(t, err)
+				// Verify we can read the data back after dupe writes are done.
+				rbuf, err := pc.Get(ctx, r)
+				require.NoError(t, err)
 
-			// Compute a digest for the bytes returned.
-			d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
-			if r.GetDigest().GetHash() != d2.GetHash() {
-				t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), r.GetDigest().GetHash())
-			}
-		})
+				// Compute a digest for the bytes returned.
+				d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
+				require.Equal(t, r.GetDigest().GetHash(), d2.GetHash())
+			})
+		}
 	}
 }
 
@@ -425,6 +475,15 @@ func TestIsolateByGroupIds(t *testing.T) {
 }
 
 func TestCopyPartitionData(t *testing.T) {
+	chunkingOn := []bool{true, false}
+	for _, tc := range chunkingOn {
+		t.Run(fmt.Sprintf("chunkingOn=%t", tc), func(t *testing.T) {
+			testCopyPartitionData(t, tc)
+		})
+	}
+}
+
+func testCopyPartitionData(t *testing.T, chunkingOn bool) {
 	te := testenv.GetTestEnv(t)
 	testAPIKey := "AK2222"
 	testGroup := "GR7890"
@@ -458,6 +517,10 @@ func TestCopyPartitionData(t *testing.T) {
 		},
 	}
 
+	if chunkingOn {
+		opts.AverageChunkSizeBytes = 64 * 4
+	}
+
 	// Create a cache and write some data in default and custom partitions.
 
 	pc, err := pebble_cache.NewPebbleCache(te, opts)
@@ -475,7 +538,7 @@ func TestCopyPartitionData(t *testing.T) {
 			size := int64(10)
 			// Mix of inline and extern data.
 			if i > 5 {
-				size = 1000
+				size = 2 * 1024
 			}
 			r, buf := testdigest.NewRandomResourceAndBuf(t, size, rspb.CacheType_CAS, instanceName)
 			defaultResources = append(defaultResources, r)
@@ -494,7 +557,12 @@ func TestCopyPartitionData(t *testing.T) {
 	{
 		ctx := te.GetAuthenticator().AuthContextFromAPIKey(context.Background(), testAPIKey)
 		for i := 0; i < 10; i++ {
-			r, buf := testdigest.NewRandomResourceAndBuf(t, 1000, rspb.CacheType_CAS, instanceName)
+			size := int64(10)
+			// Mix of inline and extern data.
+			if i > 5 {
+				size = 2 * 1024
+			}
+			r, buf := testdigest.NewRandomResourceAndBuf(t, size, rspb.CacheType_CAS, instanceName)
 			customResources = append(customResources, r)
 			err = pc.Set(ctx, r, buf)
 			require.NoError(t, err)
@@ -645,17 +713,8 @@ func TestMetadata(t *testing.T) {
 	ctx := getAnonContext(t, te)
 
 	maxSizeBytes := int64(1_000_000_000) // 1GB
-	options := &pebble_cache.Options{
-		RootDirectory:               testfs.MakeTempDir(t),
-		MaxSizeBytes:                maxSizeBytes,
-		MinBytesAutoZstdCompression: math.MaxInt64, // Turn off automatic compression
-	}
-	pc, err := pebble_cache.NewPebbleCache(te, options)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pc.Start()
-	defer pc.Stop()
+
+	withChunking := []bool{true, false}
 
 	testCases := []struct {
 		name       string
@@ -687,54 +746,73 @@ func TestMetadata(t *testing.T) {
 	testSizes := []int64{
 		1, 10, 100, 1000, 10000, 1000000, 10000000,
 	}
-	for _, tc := range testCases {
-		for _, testSize := range testSizes {
-			r, buf := testdigest.RandomCASResourceBuf(t, testSize)
-			r.CacheType = tc.cacheType
-			r.Compressor = tc.compressor
+	for _, chunkingOn := range withChunking {
+		options := &pebble_cache.Options{
+			RootDirectory:               testfs.MakeTempDir(t),
+			MaxSizeBytes:                maxSizeBytes,
+			MaxInlineFileSizeBytes:      100,
+			MinBytesAutoZstdCompression: math.MaxInt64, // Turn off automatic compression
+		}
+		if chunkingOn {
+			options.AverageChunkSizeBytes = 64 * 4
+		}
+		pc, err := pebble_cache.NewPebbleCache(te, options)
+		require.NoError(t, err)
+		err = pc.Start()
+		require.NoError(t, err)
+		defer pc.Stop()
+		for _, tc := range testCases {
+			for _, testSize := range testSizes {
+				desc := fmt.Sprintf("testSize: %d %s (chunkingOn=%t)", testSize, tc.name, chunkingOn)
+				t.Run(desc, func(t *testing.T) {
+					r, buf := testdigest.RandomCASResourceBuf(t, testSize)
+					r.CacheType = tc.cacheType
+					r.Compressor = tc.compressor
 
-			dataToWrite := buf
-			if tc.compressor == repb.Compressor_ZSTD {
-				dataToWrite = compression.CompressZstd(nil, buf)
+					dataToWrite := buf
+					if tc.compressor == repb.Compressor_ZSTD {
+						dataToWrite = compression.CompressZstd(nil, buf)
+					}
+
+					// Set data in the cache.
+					err := pc.Set(ctx, r, dataToWrite)
+					require.NoError(t, err, tc.name)
+
+					// Metadata should return correct size, regardless of queried size.
+					rWrongSize := proto.Clone(r).(*rspb.ResourceName)
+					rWrongSize.Digest.SizeBytes = 1
+
+					md, err := pc.Metadata(ctx, rWrongSize)
+					require.NoError(t, err, tc.name)
+					require.Equal(t, int64(len(dataToWrite)), md.StoredSizeBytes, tc.name)
+					require.Equal(t, testSize, md.DigestSizeBytes, tc.name)
+					lastAccessTime1 := md.LastAccessTimeUsec
+					lastModifyTime1 := md.LastModifyTimeUsec
+					require.NotZero(t, lastAccessTime1)
+					require.NotZero(t, lastModifyTime1)
+
+					// Last access time should not update since last call to Metadata()
+					md, err = pc.Metadata(ctx, rWrongSize)
+					require.NoError(t, err, tc.name)
+					require.Equal(t, int64(len(dataToWrite)), md.StoredSizeBytes, tc.name)
+					require.Equal(t, testSize, md.DigestSizeBytes, tc.name)
+					lastAccessTime2 := md.LastAccessTimeUsec
+					lastModifyTime2 := md.LastModifyTimeUsec
+					require.Equal(t, lastAccessTime1, lastAccessTime2)
+					require.Equal(t, lastModifyTime1, lastModifyTime2)
+
+					// After updating data, last access and modify time should update
+					err = pc.Set(ctx, r, dataToWrite)
+					md, err = pc.Metadata(ctx, rWrongSize)
+					require.NoError(t, err, tc.name)
+					require.Equal(t, int64(len(dataToWrite)), md.StoredSizeBytes, tc.name)
+					require.Equal(t, testSize, md.DigestSizeBytes, tc.name)
+					lastAccessTime3 := md.LastAccessTimeUsec
+					lastModifyTime3 := md.LastModifyTimeUsec
+					require.Greater(t, lastAccessTime3, lastAccessTime1)
+					require.Greater(t, lastModifyTime3, lastModifyTime2)
+				})
 			}
-
-			// Set data in the cache.
-			err := pc.Set(ctx, r, dataToWrite)
-			require.NoError(t, err, tc.name)
-
-			// Metadata should return correct size, regardless of queried size.
-			rWrongSize := proto.Clone(r).(*rspb.ResourceName)
-			rWrongSize.Digest.SizeBytes = 1
-
-			md, err := pc.Metadata(ctx, rWrongSize)
-			require.NoError(t, err, tc.name)
-			require.Equal(t, int64(len(dataToWrite)), md.StoredSizeBytes, tc.name)
-			require.Equal(t, testSize, md.DigestSizeBytes, tc.name)
-			lastAccessTime1 := md.LastAccessTimeUsec
-			lastModifyTime1 := md.LastModifyTimeUsec
-			require.NotZero(t, lastAccessTime1)
-			require.NotZero(t, lastModifyTime1)
-
-			// Last access time should not update since last call to Metadata()
-			md, err = pc.Metadata(ctx, rWrongSize)
-			require.NoError(t, err, tc.name)
-			require.Equal(t, int64(len(dataToWrite)), md.StoredSizeBytes, tc.name)
-			require.Equal(t, testSize, md.DigestSizeBytes, tc.name)
-			lastAccessTime2 := md.LastAccessTimeUsec
-			lastModifyTime2 := md.LastModifyTimeUsec
-			require.Equal(t, lastAccessTime1, lastAccessTime2)
-			require.Equal(t, lastModifyTime1, lastModifyTime2)
-
-			// After updating data, last access and modify time should update
-			err = pc.Set(ctx, r, dataToWrite)
-			md, err = pc.Metadata(ctx, rWrongSize)
-			require.NoError(t, err, tc.name)
-			require.Equal(t, int64(len(dataToWrite)), md.StoredSizeBytes, tc.name)
-			require.Equal(t, testSize, md.DigestSizeBytes, tc.name)
-			lastAccessTime3 := md.LastAccessTimeUsec
-			lastModifyTime3 := md.LastModifyTimeUsec
-			require.Greater(t, lastAccessTime3, lastAccessTime1)
-			require.Greater(t, lastModifyTime3, lastModifyTime2)
 		}
 	}
 }
@@ -761,31 +839,53 @@ func TestMultiGetSet(t *testing.T) {
 	pc.Start()
 	defer pc.Stop()
 
-	digests := randomDigests(t, 10, 20, 11, 30, 40)
-	if err := pc.SetMulti(ctx, digests); err != nil {
-		t.Fatalf("Error multi-setting digests: %s", err.Error())
+	var testCases = []struct {
+		desc                   string
+		maxInlineFileSizeBytes int64
+		averageChunkSizeBytes  int
+	}{
+		{
+			desc:                   "chunking off",
+			maxInlineFileSizeBytes: 100,
+		},
+		{
+			desc:                  "chunking on",
+			averageChunkSizeBytes: 64 * 4,
+		},
 	}
-	resourceNames := make([]*rspb.ResourceName, 0, len(digests))
-	for d := range digests {
-		resourceNames = append(resourceNames, d)
-	}
-	m, err := pc.GetMulti(ctx, resourceNames)
-	if err != nil {
-		t.Fatalf("Error multi-getting digests: %s", err.Error())
-	}
-	for rn := range digests {
-		d := rn.GetDigest()
-		rbuf, ok := m[d]
-		if !ok {
-			t.Fatalf("Multi-get failed to return expected digest: %q", d.GetHash())
-		}
-		d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if d.GetHash() != d2.GetHash() {
-			t.Fatalf("Returned digest %q did not match multi-set value: %q", d2.GetHash(), d.GetHash())
-		}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			options := &pebble_cache.Options{
+				RootDirectory:          testfs.MakeTempDir(t),
+				MaxSizeBytes:           maxSizeBytes,
+				MaxInlineFileSizeBytes: tc.maxInlineFileSizeBytes,
+				AverageChunkSizeBytes:  tc.averageChunkSizeBytes,
+			}
+			pc, err := pebble_cache.NewPebbleCache(te, options)
+			require.NoError(t, err)
+			err = pc.Start()
+			require.NoError(t, err)
+			defer pc.Stop()
+
+			digests := randomDigests(t, 10, 20, 11, 30, 1024, 40)
+			err = pc.SetMulti(ctx, digests)
+			require.NoError(t, err)
+			resourceNames := make([]*rspb.ResourceName, 0, len(digests))
+			for d := range digests {
+				resourceNames = append(resourceNames, d)
+			}
+			m, err := pc.GetMulti(ctx, resourceNames)
+			require.NoError(t, err)
+			for rn := range digests {
+				d := rn.GetDigest()
+				rbuf, ok := m[d]
+				require.True(t, ok, "Multi-get failed to return expected digest: %q", d.GetHash())
+				d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
+				require.NoError(t, err)
+				require.Equal(t, d.GetHash(), d2.GetHash())
+			}
+		})
 	}
 }
 
@@ -795,39 +895,58 @@ func TestReadWrite(t *testing.T) {
 	ctx := getAnonContext(t, te)
 
 	maxSizeBytes := int64(1_000_000_000) // 1GB
-	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{RootDirectory: testfs.MakeTempDir(t), MaxSizeBytes: maxSizeBytes})
-	if err != nil {
-		t.Fatal(err)
-	}
-	pc.Start()
-	defer pc.Stop()
 
-	testSizes := []int64{
-		1, 10, 100, 1000, 10000, 1000000, 10000000,
+	type testCase struct {
+		desc                   string
+		maxInlineFileSizeBytes int64
+		averageChunkSizeBytes  int
 	}
-	for _, testSize := range testSizes {
-		rn, buf := testdigest.RandomCASResourceBuf(t, testSize)
-		// Use Writer() to set the bytes in the cache.
-		wc, err := pc.Writer(ctx, rn)
-		if err != nil {
-			t.Fatalf("Error getting %q writer: %s", rn.GetDigest().GetHash(), err.Error())
+	testCases := []testCase{
+		{
+			desc:                   "chunking turned off",
+			maxInlineFileSizeBytes: 100,
+		},
+		{
+			desc:                  "chunking turned on",
+			averageChunkSizeBytes: 64 * 4,
+		},
+	}
+	testSizes := []int64{
+		1, 10, 100, 256, 512, 1000, 1024, 2 * 1024, 10000, 1000000, 10000000,
+	}
+	for _, tc := range testCases {
+		options := &pebble_cache.Options{
+			RootDirectory:          testfs.MakeTempDir(t),
+			MaxSizeBytes:           maxSizeBytes,
+			AverageChunkSizeBytes:  tc.averageChunkSizeBytes,
+			MaxInlineFileSizeBytes: tc.maxInlineFileSizeBytes,
 		}
-		_, err = wc.Write(buf)
+		pc, err := pebble_cache.NewPebbleCache(te, options)
 		require.NoError(t, err)
-		if err := wc.Commit(); err != nil {
-			t.Fatalf("Error closing writer: %s", err.Error())
-		}
-		if err := wc.Close(); err != nil {
-			t.Fatalf("Error closing writer: %s", err.Error())
-		}
-		// Use Reader() to get the bytes from the cache.
-		reader, err := pc.Reader(ctx, rn, 0, 0)
-		if err != nil {
-			t.Fatalf("Error getting %q reader: %s", rn.GetDigest().GetHash(), err.Error())
-		}
-		d2 := testdigest.ReadDigestAndClose(t, reader)
-		if rn.GetDigest().GetHash() != d2.GetHash() {
-			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), rn.GetDigest().GetHash())
+		err = pc.Start()
+		require.NoError(t, err)
+		defer pc.Stop()
+
+		for _, testSize := range testSizes {
+			desc := fmt.Sprintf("test size: %d (%s)", testSize, tc.desc)
+			t.Run(desc, func(t *testing.T) {
+				rn, buf := testdigest.RandomCASResourceBuf(t, testSize)
+				// Use Writer() to set the bytes in the cache.
+				wc, err := pc.Writer(ctx, rn)
+				require.NoError(t, err, "Error getting %q writer", rn.GetDigest().GetHash())
+				_, err = wc.Write(buf)
+				require.NoError(t, err)
+				err = wc.Commit()
+				require.NoError(t, err)
+				err = wc.Close()
+				require.NoError(t, err)
+
+				// Use Reader() to get the bytes from the cache.
+				reader, err := pc.Reader(ctx, rn, 0, 0)
+				require.NoError(t, err, "Error getting %q reader", rn.GetDigest().GetHash())
+				d2 := testdigest.ReadDigestAndClose(t, reader)
+				require.Equal(t, rn.GetDigest().GetHash(), d2.GetHash())
+			})
 		}
 	}
 }
@@ -838,41 +957,70 @@ func TestSizeLimit(t *testing.T) {
 	ctx := getAnonContext(t, te)
 
 	maxSizeBytes := int64(100_000_000)
-	rootDir := testfs.MakeTempDir(t)
-	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{RootDirectory: rootDir, MaxSizeBytes: maxSizeBytes})
-	if err != nil {
-		t.Fatal(err)
+
+	testCases := []struct {
+		desc                   string
+		maxInlineFileSizeBytes int64
+		averageChunkSizeBytes  int
+	}{
+		{
+			desc:                   "inline_chunking_off",
+			maxInlineFileSizeBytes: 100,
+		},
+		{
+			desc:                   "disk_chunking_off",
+			maxInlineFileSizeBytes: 2000,
+		},
+		{
+			desc:                   "chunking_on",
+			maxInlineFileSizeBytes: 64 * 4,
+		},
 	}
-	pc.Start()
-	defer pc.Stop()
 
-	resourceKeys := make([]*rspb.ResourceName, 0, 150000)
-	for i := 0; i < 150; i++ {
-		r, buf := testdigest.RandomCASResourceBuf(t, 1000)
-		resourceKeys = append(resourceKeys, r)
-		if err := pc.Set(ctx, r, buf); err != nil {
-			t.Fatalf("Error setting %q in cache: %s", r.GetDigest().GetHash(), err.Error())
-		}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			rootDir := testfs.MakeTempDir(t)
+			options := &pebble_cache.Options{
+				RootDirectory:          rootDir,
+				MaxSizeBytes:           maxSizeBytes,
+				AverageChunkSizeBytes:  tc.averageChunkSizeBytes,
+				MaxInlineFileSizeBytes: tc.maxInlineFileSizeBytes,
+			}
+			pc, err := pebble_cache.NewPebbleCache(te, options)
+			require.NoError(t, err)
+			err = pc.Start()
+			require.NoError(t, err)
+			defer pc.Stop()
+
+			resourceKeys := make([]*rspb.ResourceName, 0, 150000)
+			for i := 0; i < 150; i++ {
+				r, buf := testdigest.RandomCASResourceBuf(t, 1000)
+				resourceKeys = append(resourceKeys, r)
+				if err := pc.Set(ctx, r, buf); err != nil {
+					t.Fatalf("Error setting %q in cache: %s", r.GetDigest().GetHash(), err.Error())
+				}
+			}
+
+			time.Sleep(pebble_cache.JanitorCheckPeriod)
+			pc.TestingWaitForGC()
+
+			// Expect the sum of all contained digests be less than or equal to max
+			// size bytes.
+			containedDigestsSize := int64(0)
+			for _, r := range resourceKeys {
+				if ok, err := pc.Contains(ctx, r); err == nil && ok {
+					containedDigestsSize += r.Digest.GetSizeBytes()
+				}
+			}
+			require.LessOrEqual(t, containedDigestsSize, maxSizeBytes)
+
+			// Expect the on disk directory size be less than or equal to max size
+			// bytes.
+			dirSize, err := disk.DirSize(rootDir)
+			require.NoError(t, err)
+			require.LessOrEqual(t, dirSize, maxSizeBytes)
+		})
 	}
-
-	time.Sleep(pebble_cache.JanitorCheckPeriod)
-	pc.TestingWaitForGC()
-
-	// Expect the sum of all contained digests be less than or equal to max
-	// size bytes.
-	containedDigestsSize := int64(0)
-	for _, r := range resourceKeys {
-		if ok, err := pc.Contains(ctx, r); err == nil && ok {
-			containedDigestsSize += r.Digest.GetSizeBytes()
-		}
-	}
-	require.LessOrEqual(t, containedDigestsSize, maxSizeBytes)
-
-	// Expect the on disk directory size be less than or equal to max size
-	// bytes.
-	dirSize, err := disk.DirSize(rootDir)
-	require.NoError(t, err)
-	require.LessOrEqual(t, dirSize, maxSizeBytes)
 }
 
 func writeResource(t *testing.T, ctx context.Context, pc *pebble_cache.PebbleCache, r *rspb.ResourceName, data []byte) {
@@ -898,126 +1046,121 @@ func readResource(t *testing.T, ctx context.Context, pc *pebble_cache.PebbleCach
 }
 
 func TestCompression(t *testing.T) {
-	// Make blob big enough to require multiple chunks to compress
-	blob := compressibleBlobOfSize(pebble_cache.CompressorBufSizeBytes + 1)
-	compressedBuf := compression.CompressZstd(nil, blob)
+	maxInlineFileSizeBytes := int64(1024)
+	averageChunkSizeBytes := 64 * 4
+	maxSizeBytes := int64(1_000_000_000) // 1GB
 
-	inlineBlob := compressibleBlobOfSize(int(pebble_cache.DefaultMaxInlineFileSizeBytes - 100))
-	compressedInlineBuf := compression.CompressZstd(nil, inlineBlob)
+	te := testenv.GetTestEnv(t)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
+	ctx := getAnonContext(t, te)
 
-	// Note: Digest is of uncompressed contents
-	d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
-	require.NoError(t, err)
-
-	inlineD, err := digest.Compute(bytes.NewReader(inlineBlob), repb.DigestFunction_SHA256)
-	require.NoError(t, err)
-
-	decompressedRN := digest.NewResourceName(d, "" /*instanceName*/, rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
-	compressedRN := proto.Clone(decompressedRN).(*rspb.ResourceName)
-	compressedRN.Compressor = repb.Compressor_ZSTD
-
-	decompressedInlineRN := digest.NewResourceName(inlineD, "" /*instanceName*/, rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
-	compressedInlineRN := proto.Clone(decompressedInlineRN).(*rspb.ResourceName)
-	compressedInlineRN.Compressor = repb.Compressor_ZSTD
-
-	testCases := []struct {
-		name             string
-		rnToWrite        *rspb.ResourceName
-		dataToWrite      []byte
-		rnToRead         *rspb.ResourceName
-		isReadCompressed bool
-		// You cannot directly compare the compressed bytes because there may be differences with the compression headers
-		// due to the chunking compression algorithm used
-		expectedUncompressedReadData []byte
+	testParams := []struct {
+		desc                  string
+		blobSize              int
+		averageChunkSizeBytes int
 	}{
 		{
-			name:                         "write_compressed_read_compressed",
-			rnToWrite:                    compressedRN,
-			dataToWrite:                  compressedBuf,
-			rnToRead:                     compressedRN,
-			isReadCompressed:             true,
-			expectedUncompressedReadData: blob,
+			desc:     "disk_multiple_compression_chunk",
+			blobSize: pebble_cache.CompressorBufSizeBytes + 1,
 		},
 		{
-			name:                         "write_compressed_read_decompressed",
-			rnToWrite:                    compressedRN,
-			dataToWrite:                  compressedBuf,
-			rnToRead:                     decompressedRN,
-			expectedUncompressedReadData: blob,
+			desc:     "inline",
+			blobSize: int(maxInlineFileSizeBytes) - 100,
 		},
 		{
-			name:                         "write_uncompressed_read_compressed",
-			rnToWrite:                    decompressedRN,
-			dataToWrite:                  blob,
-			rnToRead:                     compressedRN,
-			isReadCompressed:             true,
-			expectedUncompressedReadData: blob,
+			desc:                  "chunking_on_multiple_cdc_chunks",
+			blobSize:              pebble_cache.CompressorBufSizeBytes + 1,
+			averageChunkSizeBytes: averageChunkSizeBytes,
 		},
 		{
-			name:                         "write_uncompressed_read_decompressed",
-			rnToWrite:                    decompressedRN,
-			dataToWrite:                  blob,
-			rnToRead:                     decompressedRN,
-			expectedUncompressedReadData: blob,
+			desc:                  "chunking_on_multiple_cdc_chunks_single_compression_chunk",
+			blobSize:              pebble_cache.CompressorBufSizeBytes - 1,
+			averageChunkSizeBytes: averageChunkSizeBytes,
 		},
 		{
-			name:                         "inline_write_compressed_read_compressed",
-			rnToWrite:                    compressedInlineRN,
-			dataToWrite:                  compressedInlineBuf,
-			rnToRead:                     compressedInlineRN,
-			isReadCompressed:             true,
-			expectedUncompressedReadData: inlineBlob,
-		},
-		{
-			name:                         "inline_write_compressed_read_decompressed",
-			rnToWrite:                    compressedInlineRN,
-			dataToWrite:                  compressedInlineBuf,
-			rnToRead:                     decompressedInlineRN,
-			expectedUncompressedReadData: inlineBlob,
-		},
-		{
-			name:                         "inline_write_uncompressed_read_compressed",
-			rnToWrite:                    decompressedInlineRN,
-			dataToWrite:                  inlineBlob,
-			rnToRead:                     compressedInlineRN,
-			isReadCompressed:             true,
-			expectedUncompressedReadData: inlineBlob,
-		},
-		{
-			name:                         "inline_write_uncompressed_read_decompressed",
-			rnToWrite:                    decompressedInlineRN,
-			dataToWrite:                  inlineBlob,
-			rnToRead:                     decompressedInlineRN,
-			expectedUncompressedReadData: inlineBlob,
+			desc:                  "chunking_on_single_chunk",
+			blobSize:              averageChunkSizeBytes/4 - 1,
+			averageChunkSizeBytes: averageChunkSizeBytes,
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			te := testenv.GetTestEnv(t)
-			te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
-			ctx := getAnonContext(t, te)
+	testCases := []struct {
+		name              string
+		isWriteCompressed bool
+		isReadCompressed  bool
+	}{
+		{
+			name:              "write_compressed_read_compressed",
+			isWriteCompressed: true,
+			isReadCompressed:  true,
+		},
+		{
+			name:              "write_compressed_read_decompressed",
+			isWriteCompressed: true,
+			isReadCompressed:  false,
+		},
+		{
+			name:              "write_uncompressed_read_compressed",
+			isWriteCompressed: false,
+			isReadCompressed:  true,
+		},
+		{
+			name:              "write_uncompressed_read_decompressed",
+			isWriteCompressed: false,
+			isReadCompressed:  false,
+		},
+	}
 
-			maxSizeBytes := int64(1_000_000_000) // 1GB
-			opts := &pebble_cache.Options{
-				RootDirectory: testfs.MakeTempDir(t),
-				MaxSizeBytes:  maxSizeBytes,
-			}
-			pc, err := pebble_cache.NewPebbleCache(te, opts)
-			require.NoError(t, err)
-			pc.Start()
-			defer pc.Stop()
+	for _, tp := range testParams {
+		blob := compressibleBlobOfSize(tp.blobSize)
+		compressedBuf := compression.CompressZstd(nil, blob)
+		// Note: Digest is of uncompressed contents
+		d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
+		require.NoError(t, err)
+		decompressedRN := digest.NewResourceName(d, "" /*instanceName*/, rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
+		compressedRN := proto.Clone(decompressedRN).(*rspb.ResourceName)
+		compressedRN.Compressor = repb.Compressor_ZSTD
 
-			writeResource(t, ctx, pc, tc.rnToWrite, tc.dataToWrite)
-
-			// Read data
-			data := readResource(t, ctx, pc, tc.rnToRead, 0, 0)
-			if tc.isReadCompressed {
-				data, err = compression.DecompressZstd(nil, data)
+		for _, tc := range testCases {
+			desc := fmt.Sprintf("%s_%s", tp.desc, tc.name)
+			t.Run(desc, func(t *testing.T) {
+				opts := &pebble_cache.Options{
+					RootDirectory:          testfs.MakeTempDir(t),
+					MaxSizeBytes:           maxSizeBytes,
+					MaxInlineFileSizeBytes: maxInlineFileSizeBytes,
+					AverageChunkSizeBytes:  tp.averageChunkSizeBytes,
+				}
+				pc, err := pebble_cache.NewPebbleCache(te, opts)
 				require.NoError(t, err)
-			}
-			require.Equal(t, tc.expectedUncompressedReadData, data)
-		})
+				err = pc.Start()
+				require.NoError(t, err)
+				defer pc.Stop()
+				var dataToWrite []byte
+				var rnToRead, rnToWrite *rspb.ResourceName
+				if tc.isWriteCompressed {
+					dataToWrite = compressedBuf
+					rnToWrite = compressedRN
+				} else {
+					dataToWrite = blob
+					rnToWrite = decompressedRN
+				}
+				if tc.isReadCompressed {
+					rnToRead = compressedRN
+				} else {
+					rnToRead = decompressedRN
+				}
+
+				writeResource(t, ctx, pc, rnToWrite, dataToWrite)
+
+				// Read data
+				data := readResource(t, ctx, pc, rnToRead, 0, 0)
+				if tc.isReadCompressed {
+					data, err = compression.DecompressZstd(nil, data)
+					require.NoError(t, err)
+				}
+				require.Equal(t, blob, data)
+			})
+		}
 	}
 }
 
@@ -1027,47 +1170,70 @@ func TestCompression_BufferPoolReuse(t *testing.T) {
 	ctx := getAnonContext(t, te)
 
 	maxSizeBytes := int64(1000)
-	opts := &pebble_cache.Options{
-		RootDirectory: testfs.MakeTempDir(t),
-		MaxSizeBytes:  maxSizeBytes,
+
+	testCases := []struct {
+		desc                   string
+		maxInlineFileSizeBytes int
+		averageChunkSizeBytes  int
+		blobSize               int
+	}{
+		{
+			desc:                  "chunking on single chunk",
+			averageChunkSizeBytes: 64 * 4,
+			blobSize:              60,
+		},
+		{
+			desc:                  "chunking on multiple chunks",
+			averageChunkSizeBytes: 64 * 4,
+			blobSize:              2 * 1024,
+		},
+		{
+			desc:                   "chunking off inline",
+			maxInlineFileSizeBytes: 1024,
+			blobSize:               100,
+		},
+		{
+			desc:                   "chunking off inline",
+			maxInlineFileSizeBytes: 1,
+			blobSize:               100,
+		},
 	}
-	pc, err := pebble_cache.NewPebbleCache(te, opts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pc.Start()
-	defer pc.Stop()
 
-	// Do multiple reads to reuse buffers in bufferpool
-	for i := 0; i < 5; i++ {
-		blob := compressibleBlobOfSize(100)
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			opts := &pebble_cache.Options{
+				RootDirectory:          testfs.MakeTempDir(t),
+				MaxSizeBytes:           maxSizeBytes,
+				MaxInlineFileSizeBytes: int64(tc.maxInlineFileSizeBytes),
+				AverageChunkSizeBytes:  tc.averageChunkSizeBytes,
+			}
+			pc, err := pebble_cache.NewPebbleCache(te, opts)
+			require.NoError(t, err)
+			err = pc.Start()
+			require.NoError(t, err)
+			defer pc.Stop()
 
-		// Note: Digest is of uncompressed contents
-		d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
-		require.NoError(t, err)
-		decompressedRN := digest.NewResourceName(d, "" /*instanceName*/, rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
+			// Do multiple reads to reuse buffers in bufferpool
+			for i := 0; i < 5; i++ {
+				blob := compressibleBlobOfSize(tc.blobSize)
 
-		// Write non-compressed data to cache
-		wc, err := pc.Writer(ctx, decompressedRN)
-		require.NoError(t, err)
-		n, err := wc.Write(blob)
-		require.NoError(t, err)
-		require.Equal(t, len(blob), n)
-		err = wc.Commit()
-		require.NoError(t, err)
-		err = wc.Close()
-		require.NoError(t, err)
+				// Note: Digest is of uncompressed contents
+				d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
+				require.NoError(t, err, "i=%d", i)
+				decompressedRN := digest.NewResourceName(d, "" /*instanceName*/, rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
 
-		compressedRN := proto.Clone(decompressedRN).(*rspb.ResourceName)
-		compressedRN.Compressor = repb.Compressor_ZSTD
+				// Write non-compressed data to cache
+				writeResource(t, ctx, pc, decompressedRN, blob)
 
-		reader, err := pc.Reader(ctx, compressedRN, 0, 0)
-		require.NoError(t, err)
-		defer reader.Close()
-		data, err := io.ReadAll(reader)
-		require.NoError(t, err)
-		decompressed, err := compression.DecompressZstd(nil, data)
-		require.Equal(t, blob, decompressed)
+				compressedRN := proto.Clone(decompressedRN).(*rspb.ResourceName)
+				compressedRN.Compressor = repb.Compressor_ZSTD
+
+				data := readResource(t, ctx, pc, compressedRN, 0, 0)
+				decompressed, err := compression.DecompressZstd(nil, data)
+				require.NoError(t, err, "i=%d", i)
+				require.Equal(t, blob, decompressed, "i=%d", i)
+			}
+		})
 	}
 }
 
@@ -1075,55 +1241,76 @@ func TestCompression_ParallelRequests(t *testing.T) {
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
 	ctx := getAnonContext(t, te)
-
 	maxSizeBytes := int64(1000)
-	opts := &pebble_cache.Options{
-		RootDirectory: testfs.MakeTempDir(t),
-		MaxSizeBytes:  maxSizeBytes,
+
+	testCases := []struct {
+		desc                   string
+		maxInlineFileSizeBytes int
+		averageChunkSizeBytes  int
+		blobSize               int
+	}{
+		{
+			desc:                  "chunking on single chunk",
+			averageChunkSizeBytes: 64 * 4,
+			blobSize:              60,
+		},
+		{
+			desc:                  "chunking on multiple chunks",
+			averageChunkSizeBytes: 64 * 4,
+			blobSize:              2 * 1024,
+		},
+		{
+			desc:                   "chunking off inline",
+			maxInlineFileSizeBytes: 1024,
+			blobSize:               100,
+		},
+		{
+			desc:                   "chunking off inline",
+			maxInlineFileSizeBytes: 1,
+			blobSize:               100,
+		},
 	}
-	pc, err := pebble_cache.NewPebbleCache(te, opts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pc.Start()
-	defer pc.Stop()
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			opts := &pebble_cache.Options{
+				RootDirectory:          testfs.MakeTempDir(t),
+				MaxSizeBytes:           maxSizeBytes,
+				MaxInlineFileSizeBytes: int64(tc.maxInlineFileSizeBytes),
+				AverageChunkSizeBytes:  tc.averageChunkSizeBytes,
+			}
+			pc, err := pebble_cache.NewPebbleCache(te, opts)
+			require.NoError(t, err)
+			err = pc.Start()
+			require.NoError(t, err)
+			defer pc.Stop()
 
-	eg := errgroup.Group{}
-	for i := 0; i < 10; i++ {
-		eg.Go(func() error {
-			blob := compressibleBlobOfSize(10000)
+			eg := errgroup.Group{}
+			for i := 0; i < 10; i++ {
+				eg.Go(func() error {
+					blob := compressibleBlobOfSize(tc.blobSize)
 
-			// Note: Digest is of uncompressed contents
-			d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
-			require.NoError(t, err)
-			decompressedRN := digest.NewResourceName(d, "" /*instanceName*/, rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
+					// Note: Digest is of uncompressed contents
+					d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
+					require.NoError(t, err)
+					decompressedRN := digest.NewResourceName(d, "" /*instanceName*/, rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
 
-			// Write non-compressed data to cache
-			wc, err := pc.Writer(ctx, decompressedRN)
-			require.NoError(t, err)
-			n, err := wc.Write(blob)
-			require.NoError(t, err)
-			require.Equal(t, len(blob), n)
-			err = wc.Commit()
-			require.NoError(t, err)
-			err = wc.Close()
-			require.NoError(t, err)
+					// Write non-compressed data to cache
+					writeResource(t, ctx, pc, decompressedRN, blob)
 
-			// Read data in compressed form
-			compressedRN := proto.Clone(decompressedRN).(*rspb.ResourceName)
-			compressedRN.Compressor = repb.Compressor_ZSTD
+					// Read data in compressed form
+					compressedRN := proto.Clone(decompressedRN).(*rspb.ResourceName)
+					compressedRN.Compressor = repb.Compressor_ZSTD
 
-			reader, err := pc.Reader(ctx, compressedRN, 0, 0)
-			require.NoError(t, err)
-			defer reader.Close()
-			data, err := io.ReadAll(reader)
-			require.NoError(t, err)
-			decompressed, err := compression.DecompressZstd(nil, data)
-			require.Equal(t, blob, decompressed)
-			return nil
+					data := readResource(t, ctx, pc, compressedRN, 0, 0)
+					decompressed, err := compression.DecompressZstd(nil, data)
+					require.NoError(t, err)
+					require.Equal(t, blob, decompressed)
+					return nil
+				})
+			}
+			eg.Wait()
 		})
 	}
-	eg.Wait()
 }
 
 func TestCompression_NoEarlyEviction(t *testing.T) {
@@ -1151,81 +1338,140 @@ func TestCompression_NoEarlyEviction(t *testing.T) {
 		math.Ceil( // account for integer rounding
 			float64(totalSizeCompresedData) *
 				(1 / pebble_cache.JanitorCutoffThreshold))) // account for .9 evictor cutoff
-	opts := &pebble_cache.Options{
-		RootDirectory:  testfs.MakeTempDir(t),
-		MaxSizeBytes:   maxSizeBytes,
-		MinEvictionAge: &minEvictionAge,
-	}
-	pc, err := pebble_cache.NewPebbleCache(te, opts)
-	require.NoError(t, err)
-	pc.Start()
-	defer pc.Stop()
 
-	// Write decompressed bytes to the cache. Because blob compression is enabled, pebble should compress before writing
-	for d, blob := range digestBlobs {
-		rn := digest.NewResourceName(d, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
-		err = pc.Set(ctx, rn, blob)
-		require.NoError(t, err)
+	testCases := []struct {
+		desc                  string
+		averageChunkSizeBytes int
+	}{
+		{
+			desc:                  "cdc chunking on",
+			averageChunkSizeBytes: 64 * 4,
+		},
+		{
+			desc:                  "cdc chunking off",
+			averageChunkSizeBytes: 0,
+		},
 	}
-	time.Sleep(pebble_cache.JanitorCheckPeriod)
-	pc.TestingWaitForGC()
 
-	// All reads should succeed. Nothing should've been evicted
-	for d, blob := range digestBlobs {
-		rn := digest.NewResourceName(d, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
-		data, err := pc.Get(ctx, rn)
-		require.NoError(t, err)
-		require.True(t, bytes.Equal(blob, data))
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			opts := &pebble_cache.Options{
+				RootDirectory:  testfs.MakeTempDir(t),
+				MaxSizeBytes:   maxSizeBytes,
+				MinEvictionAge: &minEvictionAge,
+			}
+			pc, err := pebble_cache.NewPebbleCache(te, opts)
+			require.NoError(t, err)
+			err = pc.Start()
+			require.NoError(t, err)
+			defer pc.Stop()
+
+			// Write decompressed bytes to the cache. Because blob compression is enabled, pebble should compress before writing
+			for d, blob := range digestBlobs {
+				rn := digest.NewResourceName(d, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
+				err = pc.Set(ctx, rn, blob)
+				require.NoError(t, err)
+			}
+			time.Sleep(pebble_cache.JanitorCheckPeriod)
+			pc.TestingWaitForGC()
+
+			// All reads should succeed. Nothing should've been evicted
+			for d, blob := range digestBlobs {
+				rn := digest.NewResourceName(d, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
+				data, err := pc.Get(ctx, rn)
+				require.NoError(t, err)
+				require.True(t, bytes.Equal(blob, data))
+			}
+		})
 	}
 }
 
 func TestCompressionOffset(t *testing.T) {
-	// Make blob big enough to require multiple chunks to compress
-	blob := compressibleBlobOfSize(pebble_cache.CompressorBufSizeBytes + 1)
-	compressedBuf := compression.CompressZstd(nil, blob)
-
-	// Note: Digest is of uncompressed contents
-	d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
-	require.NoError(t, err)
-
-	decompressedRN := digest.NewResourceName(d, "" /*instanceName*/, rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
-	compressedRN := proto.Clone(decompressedRN).(*rspb.ResourceName)
-	compressedRN.Compressor = repb.Compressor_ZSTD
-
-	te := testenv.GetTestEnv(t)
-	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
-	ctx := getAnonContext(t, te)
-
+	maxInlineFileSizeBytes := 1024
 	maxSizeBytes := int64(1_000_000_000) // 1GB
-	opts := &pebble_cache.Options{
-		RootDirectory: testfs.MakeTempDir(t),
-		MaxSizeBytes:  maxSizeBytes,
+	averageChunkSizeBytes := 64 * 4
+
+	testCases := []struct {
+		desc                  string
+		blobSize              int
+		averageChunkSizeBytes int
+		readOffset            int64
+		readLimit             int64
+	}{
+		{
+			desc:       "disk_multiple_compression_chunk",
+			blobSize:   pebble_cache.CompressorBufSizeBytes + 1,
+			readOffset: 2 * 1024,
+			readLimit:  10,
+		},
+		{
+			desc:       "inline",
+			blobSize:   maxInlineFileSizeBytes - 100,
+			readOffset: 512,
+			readLimit:  10,
+		},
+		{
+			desc:                  "chunking_on_multiple_cdc_chunks",
+			blobSize:              pebble_cache.CompressorBufSizeBytes + 1,
+			averageChunkSizeBytes: averageChunkSizeBytes,
+			readOffset:            2 * 1024,
+			readLimit:             10,
+		},
+		{
+			desc:                  "chunking_on_multiple_cdc_chunks_single_compression_chunk",
+			blobSize:              pebble_cache.CompressorBufSizeBytes - 1,
+			averageChunkSizeBytes: averageChunkSizeBytes,
+			readOffset:            2 * 1024,
+			readLimit:             10,
+		},
+		{
+			desc:                  "chunking_on_single_chunk",
+			blobSize:              averageChunkSizeBytes/4 - 1,
+			averageChunkSizeBytes: averageChunkSizeBytes,
+			readOffset:            20,
+			readLimit:             10,
+		},
 	}
-	pc, err := pebble_cache.NewPebbleCache(te, opts)
-	require.NoError(t, err)
-	pc.Start()
-	defer pc.Stop()
 
-	// Write data to cache
-	wc, err := pc.Writer(ctx, compressedRN)
-	require.NoError(t, err)
-	_, err = wc.Write(compressedBuf)
-	require.NoError(t, err)
-	err = wc.Commit()
-	require.NoError(t, err)
-	err = wc.Close()
-	require.NoError(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Make blob big enough to require multiple chunks to compress
+			blob := compressibleBlobOfSize(tc.blobSize)
+			compressedBuf := compression.CompressZstd(nil, blob)
 
-	// Read data
-	offset := int64(1024)
-	limit := int64(10)
-	reader, err := pc.Reader(ctx, decompressedRN, offset, limit)
-	require.NoError(t, err)
-	defer reader.Close()
-	data, err := io.ReadAll(reader)
-	require.NoError(t, err)
+			// Note: Digest is of uncompressed contents
+			d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
+			require.NoError(t, err)
 
-	require.Equal(t, blob[offset:offset+limit], data)
+			decompressedRN := digest.NewResourceName(d, "" /*instanceName*/, rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
+			compressedRN := proto.Clone(decompressedRN).(*rspb.ResourceName)
+			compressedRN.Compressor = repb.Compressor_ZSTD
+
+			te := testenv.GetTestEnv(t)
+			te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
+			ctx := getAnonContext(t, te)
+
+			opts := &pebble_cache.Options{
+				RootDirectory:          testfs.MakeTempDir(t),
+				MaxSizeBytes:           maxSizeBytes,
+				AverageChunkSizeBytes:  tc.averageChunkSizeBytes,
+				MaxInlineFileSizeBytes: int64(maxInlineFileSizeBytes),
+			}
+			pc, err := pebble_cache.NewPebbleCache(te, opts)
+			require.NoError(t, err)
+			err = pc.Start()
+			require.NoError(t, err)
+			defer pc.Stop()
+
+			// Write data to cache
+			writeResource(t, ctx, pc, compressedRN, compressedBuf)
+
+			// Read data
+			data := readResource(t, ctx, pc, decompressedRN, tc.readOffset, tc.readLimit)
+			require.NoError(t, err)
+			require.Equal(t, blob[tc.readOffset:tc.readOffset+tc.readLimit], data)
+		})
+	}
 }
 
 func compressibleBlobOfSize(sizeBytes int) []byte {
@@ -1245,34 +1491,61 @@ func compressibleBlobOfSize(sizeBytes int) []byte {
 }
 
 func TestFindMissing(t *testing.T) {
-	te := testenv.GetTestEnv(t)
-	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
-	ctx := getAnonContext(t, te)
-
-	maxSizeBytes := int64(1000)
-	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{RootDirectory: testfs.MakeTempDir(t), MaxSizeBytes: maxSizeBytes})
-	if err != nil {
-		t.Fatal(err)
+	maxSizeBytes := int64(1_000_000_000) // 1GB
+	tests := []struct {
+		desc                   string
+		averageChunkSizeBytes  int
+		maxInlineFileSizeBytes int64
+	}{
+		{
+			desc:                  "chunking_on",
+			averageChunkSizeBytes: 64 * 4,
+		},
+		{
+			desc:                   "chunking_off",
+			maxInlineFileSizeBytes: 100,
+		},
 	}
-	pc.Start()
-	defer pc.Stop()
+	testSizes := []int64{50, 100, 1000, 1500, 10000}
+	for _, tc := range tests {
+		for _, testSize := range testSizes {
+			desc := fmt.Sprintf("%s_test_size_%d", tc.desc, testSize)
+			t.Run(desc, func(t *testing.T) {
+				te := testenv.GetTestEnv(t)
+				te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
+				ctx := getAnonContext(t, te)
 
-	r, buf := testdigest.RandomCASResourceBuf(t, 100)
-	notSetR1, _ := testdigest.RandomCASResourceBuf(t, 100)
-	notSetR2, _ := testdigest.RandomCASResourceBuf(t, 100)
+				options := &pebble_cache.Options{
+					RootDirectory:          testfs.MakeTempDir(t),
+					MaxSizeBytes:           maxSizeBytes,
+					AverageChunkSizeBytes:  tc.averageChunkSizeBytes,
+					MaxInlineFileSizeBytes: tc.maxInlineFileSizeBytes,
+				}
+				pc, err := pebble_cache.NewPebbleCache(te, options)
+				require.NoError(t, err)
+				err = pc.Start()
+				require.NoError(t, err)
+				defer pc.Stop()
 
-	err = pc.Set(ctx, r, buf)
-	require.NoError(t, err)
+				r, buf := testdigest.RandomCASResourceBuf(t, testSize)
+				notSetR1, _ := testdigest.RandomCASResourceBuf(t, testSize)
+				notSetR2, _ := testdigest.RandomCASResourceBuf(t, testSize)
 
-	rns := []*rspb.ResourceName{r, notSetR1, notSetR2}
-	missing, err := pc.FindMissing(ctx, rns)
-	require.NoError(t, err)
-	require.ElementsMatch(t, []*repb.Digest{notSetR1.GetDigest(), notSetR2.GetDigest()}, missing)
+				err = pc.Set(ctx, r, buf)
+				require.NoError(t, err)
 
-	rns = []*rspb.ResourceName{r}
-	missing, err = pc.FindMissing(ctx, rns)
-	require.NoError(t, err)
-	require.Empty(t, missing)
+				rns := []*rspb.ResourceName{r, notSetR1, notSetR2}
+				missing, err := pc.FindMissing(ctx, rns)
+				require.NoError(t, err)
+				require.ElementsMatch(t, []*repb.Digest{notSetR1.GetDigest(), notSetR2.GetDigest()}, missing)
+
+				rns = []*rspb.ResourceName{r}
+				missing, err = pc.FindMissing(ctx, rns)
+				require.NoError(t, err)
+				require.Empty(t, missing)
+			})
+		}
+	}
 }
 
 func TestNoEarlyEviction(t *testing.T) {
@@ -1280,216 +1553,315 @@ func TestNoEarlyEviction(t *testing.T) {
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
 	ctx := getAnonContext(t, te)
 
+	testCases := []struct {
+		desc                   string
+		averageChunkSizeBytes  int
+		maxInlineFileSizeBytes int64
+		digestSize             int64
+	}{
+		{
+			desc:                   "chunking_off_inline_file",
+			maxInlineFileSizeBytes: 200,
+			digestSize:             100,
+		},
+		{
+			desc:                   "chunking_off_disk",
+			maxInlineFileSizeBytes: 1,
+			digestSize:             100,
+		},
+		{
+			desc:                  "chunking_on_single_chunk",
+			averageChunkSizeBytes: 64 * 4,
+			digestSize:            63,
+		},
+		{
+			desc:                  "chunking_on_multiple_chunk",
+			averageChunkSizeBytes: 64 * 4,
+			digestSize:            2 * 1064,
+		},
+	}
+
 	numDigests := 10
-	digestSize := int64(100)
-	maxSizeBytes := int64(
-		math.Ceil( // account for integer rounding
-			float64(numDigests) *
-				float64(digestSize) *
-				(1 / pebble_cache.JanitorCutoffThreshold))) // account for .9 evictor cutoff
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			maxSizeBytes := int64(
+				math.Ceil( // account for integer rounding
+					float64(numDigests) *
+						float64(tc.digestSize) *
+						(1 / pebble_cache.JanitorCutoffThreshold))) // account for .9 evictor cutoff
 
-	rootDir := testfs.MakeTempDir(t)
-	atimeUpdateThreshold := time.Duration(0) // update atime on every access
-	atimeBufferSize := 0                     // blocking channel of atime updates
-	minEvictionAge := time.Duration(0)       // no min eviction age
-	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{
-		RootDirectory:        rootDir,
-		MaxSizeBytes:         maxSizeBytes,
-		AtimeUpdateThreshold: &atimeUpdateThreshold,
-		AtimeBufferSize:      &atimeBufferSize,
-		MinEvictionAge:       &minEvictionAge,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	pc.Start()
-	defer pc.Stop()
+			rootDir := testfs.MakeTempDir(t)
+			atimeUpdateThreshold := time.Duration(0) // update atime on every access
+			atimeBufferSize := 0                     // blocking channel of atime updates
+			minEvictionAge := time.Duration(0)       // no min eviction age
+			pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{
+				RootDirectory:          rootDir,
+				MaxSizeBytes:           maxSizeBytes,
+				AtimeUpdateThreshold:   &atimeUpdateThreshold,
+				AtimeBufferSize:        &atimeBufferSize,
+				MinEvictionAge:         &minEvictionAge,
+				AverageChunkSizeBytes:  tc.averageChunkSizeBytes,
+				MaxInlineFileSizeBytes: tc.maxInlineFileSizeBytes,
+			})
+			require.NoError(t, err)
+			err = pc.Start()
+			require.NoError(t, err)
+			defer pc.Stop()
 
-	// Should be able to add 10 things without anything getting evicted
-	resourceKeys := make([]*rspb.ResourceName, numDigests)
-	for i := 0; i < numDigests; i++ {
-		r, buf := testdigest.RandomCASResourceBuf(t, digestSize)
-		resourceKeys[i] = r
-		if err := pc.Set(ctx, r, buf); err != nil {
-			t.Fatalf("Error setting %q in cache: %s", r.GetDigest().GetHash(), err)
-		}
-	}
+			// Should be able to add 10 things without anything getting evicted
+			resourceKeys := make([]*rspb.ResourceName, numDigests)
+			for i := 0; i < numDigests; i++ {
+				r, buf := testdigest.RandomCASResourceBuf(t, tc.digestSize)
+				resourceKeys[i] = r
 
-	time.Sleep(pebble_cache.JanitorCheckPeriod)
-	pc.TestingWaitForGC()
+				err := pc.Set(ctx, r, buf)
+				require.NoError(t, err)
+			}
 
-	// Verify that nothing was evicted
-	for _, r := range resourceKeys {
-		_, err = pc.Get(ctx, r)
-		require.NoError(t, err)
+			time.Sleep(pebble_cache.JanitorCheckPeriod)
+			pc.TestingWaitForGC()
+
+			// Verify that nothing was evicted
+			for _, r := range resourceKeys {
+				_, err = pc.Get(ctx, r)
+				require.NoError(t, err)
+			}
+		})
 	}
 }
 
 func testLRU(t *testing.T, testACEviction bool) {
-	if testACEviction {
-		flags.Set(t, "cache.pebble.active_key_version", 3)
-		flags.Set(t, "cache.pebble.ac_eviction_enabled", true)
-	}
-	te := testenv.GetTestEnv(t)
-	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
-	ctx := getAnonContext(t, te)
-
-	numDigests := 100
-	digestSize := 100
-	maxSizeBytes := int64(math.Ceil( // account for integer rounding
-		float64(numDigests) * float64(digestSize) * (1 / pebble_cache.JanitorCutoffThreshold))) // account for .9 evictor cutoff
-	rootDir := testfs.MakeTempDir(t)
-	atimeUpdateThreshold := time.Duration(0) // update atime on every access
-	atimeBufferSize := 0                     // blocking channel of atime updates
-	minEvictionAge := time.Duration(0)       // no min eviction age
-	opts := &pebble_cache.Options{
-		RootDirectory:               rootDir,
-		MaxSizeBytes:                maxSizeBytes,
-		AtimeUpdateThreshold:        &atimeUpdateThreshold,
-		AtimeBufferSize:             &atimeBufferSize,
-		MinEvictionAge:              &minEvictionAge,
-		MinBytesAutoZstdCompression: maxSizeBytes,
-	}
-	pc, err := pebble_cache.NewPebbleCache(te, opts)
-	require.NoError(t, err)
-	pc.Start()
-
-	quartile := numDigests / 4
-
-	resourceKeys := make([]*rspb.ResourceName, numDigests)
-	for i := range resourceKeys {
-		cacheType := rspb.CacheType_CAS
-		if testACEviction && i%2 == 0 {
-			cacheType = rspb.CacheType_AC
-		}
-		r, buf := testdigest.NewRandomResourceAndBuf(t, 100, cacheType, "")
-		resourceKeys[i] = r
-		if err := pc.Set(ctx, r, buf); err != nil {
-			t.Fatalf("Error setting %q in cache: %s", r.GetDigest().GetHash(), err)
-		}
-	}
-
-	// Use the digests in the following way:
-	// 1) first 3 quartiles
-	// 2) first 2 quartiles
-	// 3) first quartile
-	// This sets us up so we add an additional quartile of data
-	// and then expect data from the 3rd quartile (least recently used)
-	// to be the most evicted.
-	for i := 3; i > 0; i-- {
-		log.Printf("Using data from 0:%d", quartile*i)
-		for j := 0; j < quartile*i; j++ {
-			r := resourceKeys[j]
-			_, err = pc.Get(ctx, r)
-			require.NoError(t, err)
-		}
-	}
-
-	// Write more data.
-	for i := 0; i < quartile; i++ {
-		cacheType := rspb.CacheType_CAS
-		if testACEviction && i%2 == 0 {
-			cacheType = rspb.CacheType_AC
-		}
-		r, buf := testdigest.NewRandomResourceAndBuf(t, 100, cacheType, "")
-		resourceKeys = append(resourceKeys, r)
-		if err := pc.Set(ctx, r, buf); err != nil {
-			t.Fatalf("Error setting %q in cache: %s", r.GetDigest().GetHash(), err)
-		}
-	}
-
-	pc.Stop()
-	pc, err = pebble_cache.NewPebbleCache(te, opts)
-	require.NoError(t, err)
-	err = pc.Start()
-	require.NoError(t, err)
-
-	time.Sleep(pebble_cache.JanitorCheckPeriod)
-	pc.TestingWaitForGC()
-
-	evictionsByQuartile := make([][]*repb.Digest, 5)
-	for i, r := range resourceKeys {
-		ok, err := pc.Contains(ctx, r)
-		evicted := err != nil || !ok
-		q := i / quartile
-		if evicted {
-			evictionsByQuartile[q] = append(evictionsByQuartile[q], r.GetDigest())
-		}
-	}
-
-	for quartile, evictions := range evictionsByQuartile {
-		count := len(evictions)
-		sample := ""
-		for i, d := range evictions {
-			if i > 3 {
-				break
-			}
-			sample += d.GetHash()
-			sample += ", "
-		}
-		log.Infof("Evicted %d keys in quartile: %d (%s)", count, quartile, sample)
-	}
-
-	// None of the files "used" just before adding more should have been
-	// evicted.
-	require.Equal(t, 0, len(evictionsByQuartile[0]))
-
-	// None of the most recently added files should have been evicted.
-	require.Equal(t, 0, len(evictionsByQuartile[4]))
-
-	require.LessOrEqual(t, len(evictionsByQuartile[1]), len(evictionsByQuartile[2]))
-	require.LessOrEqual(t, len(evictionsByQuartile[2]), len(evictionsByQuartile[3]))
-	require.Greater(t, len(evictionsByQuartile[3]), 0)
 }
 
 func TestLRU(t *testing.T) {
-	testLRU(t, false /*=testACEviction*/)
-}
+	testCases := []struct {
+		desc                   string
+		averageChunkSizeBytes  int
+		maxInlineFileSizeBytes int64
+		digestSize             int64
+	}{
+		{
+			desc:                  "chunking_on_multiple_chunks",
+			averageChunkSizeBytes: 64 * 4,
+			digestSize:            2 * 1024,
+		},
+		{
+			desc:                  "chunking_on_single_chunk",
+			averageChunkSizeBytes: 64 * 4,
+			digestSize:            2 * 1024,
+		},
+		{
+			desc:                   "chunking_off_inline",
+			maxInlineFileSizeBytes: 1024,
+			digestSize:             100,
+		},
+		{
+			desc:                   "chunking_off_disk",
+			maxInlineFileSizeBytes: 1,
+			digestSize:             100,
+		},
+	}
+	withACEviction := []bool{true, false}
 
-func TestLRUWithACEviction(t *testing.T) {
-	testLRU(t, true /*=testACEviction*/)
+	for _, testACEviction := range withACEviction {
+		for _, tc := range testCases {
+			desc := fmt.Sprintf("%s_ac_eviction_%t", tc.desc, testACEviction)
+			t.Run(desc, func(t *testing.T) {
+				if testACEviction {
+					flags.Set(t, "cache.pebble.active_key_version", 3)
+					flags.Set(t, "cache.pebble.ac_eviction_enabled", true)
+				}
+				te := testenv.GetTestEnv(t)
+				te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
+				ctx := getAnonContext(t, te)
+
+				numDigests := 100
+				maxSizeBytes := int64(math.Ceil( // account for integer rounding
+					float64(numDigests) * float64(tc.digestSize) * (1 / pebble_cache.JanitorCutoffThreshold))) // account for .9 evictor cutoff
+				rootDir := testfs.MakeTempDir(t)
+				atimeUpdateThreshold := time.Duration(0) // update atime on every access
+				atimeBufferSize := 0                     // blocking channel of atime updates
+				minEvictionAge := time.Duration(0)       // no min eviction age
+				opts := &pebble_cache.Options{
+					RootDirectory:               rootDir,
+					MaxSizeBytes:                maxSizeBytes,
+					AtimeUpdateThreshold:        &atimeUpdateThreshold,
+					AtimeBufferSize:             &atimeBufferSize,
+					MinEvictionAge:              &minEvictionAge,
+					MinBytesAutoZstdCompression: maxSizeBytes,
+					MaxInlineFileSizeBytes:      tc.maxInlineFileSizeBytes,
+					AverageChunkSizeBytes:       tc.averageChunkSizeBytes,
+				}
+				pc, err := pebble_cache.NewPebbleCache(te, opts)
+				require.NoError(t, err)
+				err = pc.Start()
+				require.NoError(t, err)
+
+				quartile := numDigests / 4
+
+				resourceKeys := make([]*rspb.ResourceName, numDigests)
+				for i := range resourceKeys {
+					cacheType := rspb.CacheType_CAS
+					if testACEviction && i%2 == 0 {
+						cacheType = rspb.CacheType_AC
+					}
+					r, buf := testdigest.NewRandomResourceAndBuf(t, tc.digestSize, cacheType, "")
+					resourceKeys[i] = r
+					err := pc.Set(ctx, r, buf)
+					require.NoError(t, err)
+				}
+
+				// Use the digests in the following way:
+				// 1) first 3 quartiles
+				// 2) first 2 quartiles
+				// 3) first quartile
+				// This sets us up so we add an additional quartile of data
+				// and then expect data from the 3rd quartile (least recently used)
+				// to be the most evicted.
+				for i := 3; i > 0; i-- {
+					log.Printf("Using data from 0:%d", quartile*i)
+					for j := 0; j < quartile*i; j++ {
+						r := resourceKeys[j]
+						_, err = pc.Get(ctx, r)
+						require.NoError(t, err)
+					}
+				}
+
+				// Write more data.
+				for i := 0; i < quartile; i++ {
+					cacheType := rspb.CacheType_CAS
+					if testACEviction && i%2 == 0 {
+						cacheType = rspb.CacheType_AC
+					}
+					r, buf := testdigest.NewRandomResourceAndBuf(t, tc.digestSize, cacheType, "")
+					resourceKeys = append(resourceKeys, r)
+					err := pc.Set(ctx, r, buf)
+					require.NoError(t, err)
+				}
+
+				pc.Stop()
+				pc, err = pebble_cache.NewPebbleCache(te, opts)
+				require.NoError(t, err)
+				err = pc.Start()
+				require.NoError(t, err)
+
+				time.Sleep(pebble_cache.JanitorCheckPeriod)
+				pc.TestingWaitForGC()
+
+				evictionsByQuartile := make([][]*repb.Digest, 5)
+				for i, r := range resourceKeys {
+					ok, err := pc.Contains(ctx, r)
+					evicted := err != nil || !ok
+					q := i / quartile
+					if evicted {
+						evictionsByQuartile[q] = append(evictionsByQuartile[q], r.GetDigest())
+					}
+				}
+
+				for quartile, evictions := range evictionsByQuartile {
+					count := len(evictions)
+					sample := ""
+					for i, d := range evictions {
+						if i > 3 {
+							break
+						}
+						sample += d.GetHash()
+						sample += ", "
+					}
+					log.Infof("Evicted %d keys in quartile: %d (%s)", count, quartile, sample)
+				}
+
+				// None of the files "used" just before adding more should have been
+				// evicted.
+				require.Equal(t, 0, len(evictionsByQuartile[0]))
+
+				// None of the most recently added files should have been evicted.
+				require.Equal(t, 0, len(evictionsByQuartile[4]))
+
+				require.LessOrEqual(t, len(evictionsByQuartile[1]), len(evictionsByQuartile[2]))
+				require.LessOrEqual(t, len(evictionsByQuartile[2]), len(evictionsByQuartile[3]))
+				require.Greater(t, len(evictionsByQuartile[3]), 0)
+			})
+		}
+	}
 }
 
 func TestStartupScan(t *testing.T) {
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
 	ctx := getAnonContext(t, te)
-	rootDir := testfs.MakeTempDir(t)
 	maxSizeBytes := int64(1_000_000_000) // 1GB
-	options := &pebble_cache.Options{RootDirectory: rootDir, MaxSizeBytes: maxSizeBytes}
-	pc, err := pebble_cache.NewPebbleCache(te, options)
-	if err != nil {
-		t.Fatal(err)
+
+	testCases := []struct {
+		desc                   string
+		averageChunkSizeBytes  int
+		maxInlineFileSizeBytes int64
+		digestSize             int64
+	}{
+		{
+			desc:                  "chunking_on_single_chunk",
+			averageChunkSizeBytes: 64 * 4,
+			digestSize:            63,
+		},
+		{
+			desc:                  "chunking_on_multiple_chunks",
+			averageChunkSizeBytes: 64 * 4,
+			digestSize:            2 * 1024,
+		},
+		{
+			desc:                  "chunking_off_inline",
+			averageChunkSizeBytes: 64 * 4,
+			digestSize:            2 * 1024,
+		},
+		{
+			desc:                  "chunking_off_disk",
+			averageChunkSizeBytes: 64 * 4,
+			digestSize:            2 * 1024,
+		},
 	}
-	pc.Start()
-	resources := make([]*rspb.ResourceName, 0)
-	for i := 0; i < 1000; i++ {
-		remoteInstanceName := fmt.Sprintf("remote-instance-%d", i)
-		r, buf := testdigest.NewRandomResourceAndBuf(t, 1000, rspb.CacheType_AC, remoteInstanceName)
-		err = pc.Set(ctx, r, buf)
-		require.NoError(t, err)
-		resources = append(resources, r)
-	}
-	log.Printf("Wrote %d digests", len(resources))
 
-	time.Sleep(pebble_cache.JanitorCheckPeriod)
-	pc.TestingWaitForGC()
-	pc.Stop()
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			rootDir := testfs.MakeTempDir(t)
+			options := &pebble_cache.Options{
+				RootDirectory:          rootDir,
+				MaxSizeBytes:           maxSizeBytes,
+				AverageChunkSizeBytes:  tc.averageChunkSizeBytes,
+				MaxInlineFileSizeBytes: tc.maxInlineFileSizeBytes,
+			}
+			pc, err := pebble_cache.NewPebbleCache(te, options)
+			require.NoError(t, err)
+			err = pc.Start()
+			require.NoError(t, err)
+			resources := make([]*rspb.ResourceName, 0)
+			for i := 0; i < 1000; i++ {
+				remoteInstanceName := fmt.Sprintf("remote-instance-%d", i)
+				r, buf := testdigest.NewRandomResourceAndBuf(t, tc.digestSize, rspb.CacheType_AC, remoteInstanceName)
+				err = pc.Set(ctx, r, buf)
+				require.NoError(t, err)
+				resources = append(resources, r)
+			}
+			log.Printf("Wrote %d digests", len(resources))
 
-	pc2, err := pebble_cache.NewPebbleCache(te, options)
-	require.NoError(t, err)
+			time.Sleep(pebble_cache.JanitorCheckPeriod)
+			pc.TestingWaitForGC()
+			pc.Stop()
 
-	pc2.Start()
-	defer pc2.Stop()
-	for _, r := range resources {
-		rbuf, err := pc2.Get(ctx, r)
-		require.NoError(t, err)
+			pc2, err := pebble_cache.NewPebbleCache(te, options)
+			require.NoError(t, err)
 
-		// Compute a digest for the bytes returned.
-		d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
-		if r.GetDigest().GetHash() != d2.GetHash() {
-			t.Fatalf("Returned digest %q did not match set value: %q", d2.GetHash(), r.GetDigest().GetHash())
-		}
+			err = pc2.Start()
+			require.NoError(t, err)
+			defer pc2.Stop()
+			for _, r := range resources {
+				rbuf, err := pc2.Get(ctx, r)
+				require.NoError(t, err)
+
+				// Compute a digest for the bytes returned.
+				d2, err := digest.Compute(bytes.NewReader(rbuf), repb.DigestFunction_SHA256)
+				require.Equal(t, r.GetDigest().GetHash(), d2.GetHash())
+			}
+		})
 	}
 }
 
@@ -1791,78 +2163,90 @@ func getCrypterEnv(t *testing.T) (*testenv.TestEnv, string) {
 }
 
 func TestEncryption(t *testing.T) {
-	te, kmsDir := getCrypterEnv(t)
-
-	userID := "US123"
-	groupID := "GR123"
-	groupKeyID := "EK123"
-	user := testauth.User(userID, groupID)
-	user.CacheEncryptionEnabled = true
-	users := map[string]interfaces.UserInfo{userID: user}
-	auther := testauth.NewTestAuthenticator(users)
-	te.SetAuthenticator(auther)
-
-	rootDir := testfs.MakeTempDir(t)
 	maxSizeBytes := int64(1_000_000_000) // 1GB
-
-	// Customer has encryption enabled, but no keys are available.
-	{
-		opts := &pebble_cache.Options{
-			RootDirectory: rootDir,
-			Partitions: []disk.Partition{{
-				ID: pebble_cache.DefaultPartitionID, MaxSizeBytes: maxSizeBytes,
-			}},
-		}
-		pc, err := pebble_cache.NewPebbleCache(te, opts)
-		require.NoError(t, err)
-		err = pc.Start()
-		require.NoError(t, err)
-
-		ctx, err := auther.WithAuthenticatedUser(context.Background(), userID)
-		require.NoError(t, err)
-		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
-		err = pc.Set(ctx, rn, buf)
-		require.ErrorContains(t, err, "no key available")
-
-		err = pc.Stop()
-		require.NoError(t, err)
+	testCases := []struct {
+		desc                   string
+		averageChunkSizeBytes  int
+		maxInlineFileSizeBytes int64
+		digestSize             int64
+	}{
+		{
+			desc:                  "chunking_on_single_chunk",
+			averageChunkSizeBytes: 64 * 4,
+			digestSize:            63,
+		},
+		{
+			desc:                  "chunking_on_multiple_chunks",
+			averageChunkSizeBytes: 64 * 4,
+			digestSize:            2 * 1024,
+		},
+		{
+			desc:                   "chunking_off_inline",
+			maxInlineFileSizeBytes: 200,
+			digestSize:             100,
+		},
+		{
+			desc:                   "chunking_off_disk",
+			maxInlineFileSizeBytes: 100,
+			digestSize:             1000,
+		},
 	}
 
-	// Happy case.
-	{
-		ctx, err := auther.WithAuthenticatedUser(context.Background(), userID)
-		require.NoError(t, err)
+	withKey := []bool{false, true}
 
-		group1KeyURI := generateKMSKey(t, kmsDir, "group1Key")
-		key, keyVersion := createKey(t, te, groupKeyID, groupID, group1KeyURI)
-		err = te.GetDBHandle().DB(ctx).Create(key).Error
-		require.NoError(t, err)
-		err = te.GetDBHandle().DB(ctx).Create(keyVersion).Error
-		require.NoError(t, err)
+	for _, tc := range testCases {
+		for _, isKeyAvailable := range withKey {
+			desc := fmt.Sprintf("%s_is_key_available_%t", tc.desc, isKeyAvailable)
+			t.Run(desc, func(t *testing.T) {
+				te, kmsDir := getCrypterEnv(t)
+				rootDir := testfs.MakeTempDir(t)
 
-		opts := &pebble_cache.Options{
-			RootDirectory: rootDir,
-			Partitions: []disk.Partition{{
-				ID: pebble_cache.DefaultPartitionID, EncryptionSupported: true, MaxSizeBytes: maxSizeBytes,
-			}},
+				userID := "US123"
+				groupID := "GR123"
+				groupKeyID := "EK123"
+				user := testauth.User(userID, groupID)
+				user.CacheEncryptionEnabled = true
+				users := map[string]interfaces.UserInfo{userID: user}
+				auther := testauth.NewTestAuthenticator(users)
+				te.SetAuthenticator(auther)
+
+				ctx, err := auther.WithAuthenticatedUser(context.Background(), userID)
+				require.NoError(t, err)
+
+				if isKeyAvailable {
+					group1KeyURI := generateKMSKey(t, kmsDir, "group1Key")
+					key, keyVersion := createKey(t, te, groupKeyID, groupID, group1KeyURI)
+					err = te.GetDBHandle().DB(ctx).Create(key).Error
+					require.NoError(t, err)
+					err = te.GetDBHandle().DB(ctx).Create(keyVersion).Error
+					require.NoError(t, err)
+				}
+
+				opts := &pebble_cache.Options{
+					RootDirectory: rootDir,
+					Partitions: []disk.Partition{{
+						ID: pebble_cache.DefaultPartitionID, MaxSizeBytes: maxSizeBytes,
+					}},
+				}
+				pc, err := pebble_cache.NewPebbleCache(te, opts)
+				require.NoError(t, err)
+				err = pc.Start()
+				require.NoError(t, err)
+
+				rn, buf := testdigest.RandomCASResourceBuf(t, tc.digestSize)
+				err = pc.Set(ctx, rn, buf)
+				if !isKeyAvailable {
+					require.ErrorContains(t, err, "no key available")
+				} else {
+					readBuf, err := pc.Get(ctx, rn)
+					require.NoError(t, err)
+					require.Equal(t, buf, readBuf)
+				}
+
+				err = pc.Stop()
+				require.NoError(t, err)
+			})
 		}
-		pc, err := pebble_cache.NewPebbleCache(te, opts)
-		require.NoError(t, err)
-		err = pc.Start()
-		require.NoError(t, err)
-
-		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
-		err = pc.Set(ctx, rn, buf)
-		require.NoError(t, err)
-
-		readBuf, err := pc.Get(ctx, rn)
-		require.NoError(t, err)
-		if !bytes.Equal(buf, readBuf) {
-			require.FailNow(t, "original text and decrypted text didn't match")
-		}
-
-		err = pc.Stop()
-		require.NoError(t, err)
 	}
 }
 
@@ -1871,67 +2255,103 @@ func TestEncryption(t *testing.T) {
 func TestEncryptedUnencryptedSameDigest(t *testing.T) {
 	flags.Set(t, "cache.pebble.active_key_version", 3)
 
-	te, kmsDir := getCrypterEnv(t)
-
-	userID := "US123"
-	groupID := "GR123"
-	user := testauth.User(userID, groupID)
-	user.CacheEncryptionEnabled = true
-	users := map[string]interfaces.UserInfo{userID: user}
-	auther := testauth.NewTestAuthenticator(users)
-	te.SetAuthenticator(auther)
-
-	rootDir := testfs.MakeTempDir(t)
-	maxSizeBytes := int64(1_000_000_000) // 1GB
-	ctx := context.Background()
-
-	groupKeyID := "EK456"
-	group1KeyURI := generateKMSKey(t, kmsDir, "group1Key")
-	key, keyVersion := createKey(t, te, groupKeyID, groupID, group1KeyURI)
-	err := te.GetDBHandle().DB(ctx).Create(key).Error
-	require.NoError(t, err)
-	err = te.GetDBHandle().DB(ctx).Create(keyVersion).Error
-	require.NoError(t, err)
-
-	opts := &pebble_cache.Options{
-		RootDirectory: rootDir,
-		Partitions: []disk.Partition{{
-			ID: pebble_cache.DefaultPartitionID, MaxSizeBytes: maxSizeBytes,
-		}},
-		MaxInlineFileSizeBytes: 1,
-	}
-	pc, err := pebble_cache.NewPebbleCache(te, opts)
-	require.NoError(t, err)
-	err = pc.Start()
-	require.NoError(t, err)
-
-	userCtx, err := auther.WithAuthenticatedUser(context.Background(), userID)
-	require.NoError(t, err)
-	anonCtx := getAnonContext(t, te)
-
-	rn, buf := testdigest.RandomCASResourceBuf(t, 100)
-	err = pc.Set(anonCtx, rn, buf)
-	require.NoError(t, err)
-	err = pc.Set(userCtx, rn, buf)
-	require.NoError(t, err)
-
-	readBuf, err := pc.Get(userCtx, rn)
-	require.NoError(t, err)
-	if !bytes.Equal(buf, readBuf) {
-		require.FailNow(t, "original text and decrypted text didn't match")
+	testCases := []struct {
+		desc                   string
+		averageChunkSizeBytes  int
+		maxInlineFileSizeBytes int64
+		digestSize             int64
+	}{
+		{
+			desc:                  "chunking_on_single_chunk",
+			averageChunkSizeBytes: 64 * 4,
+			digestSize:            63,
+		},
+		{
+			desc:                  "chunking_on_multiple_chunks",
+			averageChunkSizeBytes: 64 * 4,
+			digestSize:            2 * 1024,
+		},
+		{
+			desc:                   "chunking_off_inline",
+			maxInlineFileSizeBytes: 200,
+			digestSize:             100,
+		},
+		{
+			desc:                   "chunking_off_disk",
+			maxInlineFileSizeBytes: 100,
+			digestSize:             1000,
+		},
 	}
 
-	readBuf, err = pc.Get(anonCtx, rn)
-	require.NoError(t, err)
-	if !bytes.Equal(buf, readBuf) {
-		require.FailNow(t, "original text and read text didn't match")
-	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			te, kmsDir := getCrypterEnv(t)
 
-	err = pc.Stop()
-	require.NoError(t, err)
+			userID := "US123"
+			groupID := "GR123"
+			user := testauth.User(userID, groupID)
+			user.CacheEncryptionEnabled = true
+			users := map[string]interfaces.UserInfo{userID: user}
+			auther := testauth.NewTestAuthenticator(users)
+			te.SetAuthenticator(auther)
+
+			rootDir := testfs.MakeTempDir(t)
+			maxSizeBytes := int64(1_000_000_000) // 1GB
+			ctx := context.Background()
+
+			groupKeyID := "EK456"
+			group1KeyURI := generateKMSKey(t, kmsDir, "group1Key")
+			key, keyVersion := createKey(t, te, groupKeyID, groupID, group1KeyURI)
+			err := te.GetDBHandle().DB(ctx).Create(key).Error
+			require.NoError(t, err)
+			err = te.GetDBHandle().DB(ctx).Create(keyVersion).Error
+			require.NoError(t, err)
+
+			opts := &pebble_cache.Options{
+				RootDirectory: rootDir,
+				Partitions: []disk.Partition{{
+					ID: pebble_cache.DefaultPartitionID, MaxSizeBytes: maxSizeBytes,
+				}},
+				MaxInlineFileSizeBytes: tc.maxInlineFileSizeBytes,
+				AverageChunkSizeBytes:  tc.averageChunkSizeBytes,
+			}
+			pc, err := pebble_cache.NewPebbleCache(te, opts)
+			require.NoError(t, err)
+			err = pc.Start()
+			require.NoError(t, err)
+
+			userCtx, err := auther.WithAuthenticatedUser(context.Background(), userID)
+			require.NoError(t, err)
+			anonCtx := getAnonContext(t, te)
+
+			rn, buf := testdigest.RandomCASResourceBuf(t, tc.digestSize)
+			err = pc.Set(anonCtx, rn, buf)
+			require.NoError(t, err)
+			err = pc.Set(userCtx, rn, buf)
+			require.NoError(t, err)
+
+			readBuf, err := pc.Get(userCtx, rn)
+			require.NoError(t, err)
+			if !bytes.Equal(buf, readBuf) {
+				require.FailNow(t, "original text and decrypted text didn't match")
+			}
+
+			readBuf, err = pc.Get(anonCtx, rn)
+			require.NoError(t, err)
+			if !bytes.Equal(buf, readBuf) {
+				require.FailNow(t, "original text and read text didn't match")
+			}
+			err = pc.Stop()
+			require.NoError(t, err)
+
+		})
+	}
 }
 
 func TestEncryptionAndCompression(t *testing.T) {
+	maxInlineFileSizeBytes := int64(1024)
+	averageChunkSizeBytes := 64 * 4
+
 	te, kmsDir := getCrypterEnv(t)
 
 	userID := "US123"
@@ -1953,107 +2373,142 @@ func TestEncryptionAndCompression(t *testing.T) {
 	err = te.GetDBHandle().DB(ctx).Create(keyVersion).Error
 	require.NoError(t, err)
 
-	rootDir := testfs.MakeTempDir(t)
-	maxSizeBytes := int64(1_000_000_000) // 1GB
-	opts := &pebble_cache.Options{
-		RootDirectory: rootDir,
-		Partitions: []disk.Partition{{
-			ID: pebble_cache.DefaultPartitionID, MaxSizeBytes: maxSizeBytes,
-		}},
-	}
-	pc, err := pebble_cache.NewPebbleCache(te, opts)
-	require.NoError(t, err)
-	err = pc.Start()
-	require.NoError(t, err)
-
-	// Make blob big enough to require multiple chunks to compress
-	blob := compressibleBlobOfSize(pebble_cache.CompressorBufSizeBytes + 1)
-	compressedBuf := compression.CompressZstd(nil, blob)
-
-	// Note: Digest is of uncompressed contents
-	d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
-	require.NoError(t, err)
-
-	decompressedRN := digest.NewResourceName(d, "" /*instanceName*/, rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
-	compressedRN := proto.Clone(decompressedRN).(*rspb.ResourceName)
-	compressedRN.Compressor = repb.Compressor_ZSTD
-
-	testCases := []struct {
-		name             string
-		rnToWrite        *rspb.ResourceName
-		dataToWrite      []byte
-		rnToRead         *rspb.ResourceName
-		isReadCompressed bool
-		readOffset       int64
-		readLimit        int64
-		expectedReadData []byte
+	testParams := []struct {
+		desc                  string
+		blobSize              int
+		averageChunkSizeBytes int
 	}{
 		{
-			name:             "write_compressed_read_compressed",
-			rnToWrite:        compressedRN,
-			dataToWrite:      compressedBuf,
-			rnToRead:         compressedRN,
-			isReadCompressed: true,
-			expectedReadData: blob,
+			desc:     "disk_multiple_compression_chunk",
+			blobSize: pebble_cache.CompressorBufSizeBytes + 1,
 		},
 		{
-			name:             "write_compressed_read_decompressed",
-			rnToWrite:        compressedRN,
-			dataToWrite:      compressedBuf,
-			rnToRead:         decompressedRN,
-			expectedReadData: blob,
+			desc:     "inline",
+			blobSize: int(maxInlineFileSizeBytes) - 100,
 		},
 		{
-			name:             "write_compressed_read_decompressed_offset",
-			rnToWrite:        compressedRN,
-			dataToWrite:      compressedBuf,
-			rnToRead:         decompressedRN,
-			readOffset:       10,
-			readLimit:        20,
-			expectedReadData: blob[10:30],
+			desc:                  "chunking_on_multiple_cdc_chunks",
+			blobSize:              pebble_cache.CompressorBufSizeBytes + 1,
+			averageChunkSizeBytes: averageChunkSizeBytes,
 		},
 		{
-			name:             "write_uncompressed_read_compressed",
-			rnToWrite:        decompressedRN,
-			dataToWrite:      blob,
-			rnToRead:         compressedRN,
-			isReadCompressed: true,
-			expectedReadData: blob,
+			desc:                  "chunking_on_multiple_cdc_chunks_single_compression_chunk",
+			blobSize:              pebble_cache.CompressorBufSizeBytes - 1,
+			averageChunkSizeBytes: averageChunkSizeBytes,
 		},
 		{
-			name:             "write_uncompressed_read_decompressed",
-			rnToWrite:        decompressedRN,
-			dataToWrite:      blob,
-			rnToRead:         decompressedRN,
-			expectedReadData: blob,
-		},
-		{
-			name:             "write_uncompressed_read_decompressed_offset",
-			rnToWrite:        decompressedRN,
-			dataToWrite:      blob,
-			rnToRead:         decompressedRN,
-			readOffset:       10,
-			readLimit:        20,
-			expectedReadData: blob[10:30],
+			desc:                  "chunking_on_single_chunk",
+			blobSize:              averageChunkSizeBytes/4 - 1,
+			averageChunkSizeBytes: averageChunkSizeBytes,
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			writeResource(t, ctx, pc, tc.rnToWrite, tc.dataToWrite)
-
-			// Read data
-			data := readResource(t, ctx, pc, tc.rnToRead, tc.readOffset, tc.readLimit)
-			if tc.isReadCompressed {
-				data, err = compression.DecompressZstd(nil, data)
-				require.NoError(t, err)
-			}
-			require.Equal(t, tc.expectedReadData, data)
-		})
+	testCases := []struct {
+		name              string
+		isWriteCompressed bool
+		isReadCompressed  bool
+		testOffset        bool
+	}{
+		{
+			name:              "write_compressed_read_compressed",
+			isWriteCompressed: true,
+			isReadCompressed:  true,
+		},
+		{
+			name:              "write_compressed_read_decompressed",
+			isWriteCompressed: true,
+			isReadCompressed:  false,
+		},
+		{
+			name:              "write_compressed_read_decompressed_offset",
+			isWriteCompressed: true,
+			isReadCompressed:  false,
+		},
+		{
+			name:              "write_uncompressed_read_compressed",
+			isWriteCompressed: false,
+			isReadCompressed:  true,
+		},
+		{
+			name:              "write_uncompressed_read_decompressed",
+			isWriteCompressed: false,
+			isReadCompressed:  false,
+		},
+		{
+			name:              "write_uncompressed_read_decompressed_offset",
+			isWriteCompressed: false,
+			isReadCompressed:  false,
+		},
 	}
 
-	err = pc.Stop()
-	require.NoError(t, err)
+	for _, tp := range testParams {
+		rootDir := testfs.MakeTempDir(t)
+		maxSizeBytes := int64(1_000_000_000) // 1GB
+		opts := &pebble_cache.Options{
+			RootDirectory: rootDir,
+			Partitions: []disk.Partition{{
+				ID: pebble_cache.DefaultPartitionID, MaxSizeBytes: maxSizeBytes,
+			}},
+		}
+		pc, err := pebble_cache.NewPebbleCache(te, opts)
+		require.NoError(t, err)
+		err = pc.Start()
+		require.NoError(t, err)
+
+		// Make blob big enough to require multiple chunks to compress
+		blob := compressibleBlobOfSize(tp.blobSize)
+		compressedBuf := compression.CompressZstd(nil, blob)
+
+		// Note: Digest is of uncompressed contents
+		d, err := digest.Compute(bytes.NewReader(blob), repb.DigestFunction_SHA256)
+		require.NoError(t, err)
+
+		decompressedRN := digest.NewResourceName(d, "" /*instanceName*/, rspb.CacheType_CAS, repb.DigestFunction_SHA256).ToProto()
+		compressedRN := proto.Clone(decompressedRN).(*rspb.ResourceName)
+		compressedRN.Compressor = repb.Compressor_ZSTD
+
+		for _, tc := range testCases {
+			desc := fmt.Sprintf("%s_%s", tc.name, tp.desc)
+			t.Run(desc, func(t *testing.T) {
+				var dataToWrite []byte
+				var rnToWrite, rnToRead *resource.ResourceName
+				if tc.isWriteCompressed {
+					dataToWrite = compressedBuf
+					rnToWrite = compressedRN
+				} else {
+					dataToWrite = blob
+					rnToWrite = decompressedRN
+				}
+				if tc.isReadCompressed {
+					rnToRead = compressedRN
+				} else {
+					rnToRead = decompressedRN
+				}
+				writeResource(t, ctx, pc, rnToWrite, dataToWrite)
+
+				// Read data
+				readOffset := int64(0)
+				readLimit := int64(0)
+				if tc.testOffset {
+					readOffset = int64(tp.blobSize) - 30
+					readLimit = 20
+				}
+				data := readResource(t, ctx, pc, rnToRead, readOffset, readLimit)
+				if tc.isReadCompressed {
+					data, err = compression.DecompressZstd(nil, data)
+					require.NoError(t, err)
+				}
+				expectedReadData := blob
+				if tc.testOffset {
+					expectedReadData = blob[readOffset : readOffset+readLimit]
+				}
+				require.Equal(t, expectedReadData, data)
+			})
+		}
+
+		err = pc.Stop()
+		require.NoError(t, err)
+	}
 }
 
 func BenchmarkGetMulti(b *testing.B) {
@@ -2311,77 +2766,97 @@ func TestSampling(t *testing.T) {
 	err = te.GetDBHandle().DB(ctx).Create(keyVersion).Error
 	require.NoError(t, err)
 
-	rootDir := testfs.MakeTempDir(t)
-	minEvictionAge := 1 * time.Hour
-	clock := clockwork.NewFakeClock()
-
-	opts := &pebble_cache.Options{
-		RootDirectory: rootDir,
-		Partitions: []disk.Partition{{
-			ID: pebble_cache.DefaultPartitionID,
-			// Force all entries to be evicted as soon as they pass the minimum
-			// eviction age.
-			MaxSizeBytes: 2,
-		}},
-		MinEvictionAge: &minEvictionAge,
-		Clock:          clock,
-	}
-	pc, err := pebble_cache.NewPebbleCache(te, opts)
-	require.NoError(t, err)
-	err = pc.Start()
-	require.NoError(t, err)
-
-	rn, buf := testdigest.RandomCASResourceBuf(t, 100)
-	anonCtx := getAnonContext(t, te)
-	err = pc.Set(anonCtx, rn, buf)
-	require.NoError(t, err)
-
-	// Advance time (to force newer atime) and write the same digest
-	// encrypted. The encrypted key should have the same digest prefix as the
-	// unencrypted key and come before the unencrypted key in lexicographical
-	// order.
-	clock.Advance(5 * time.Minute)
-	err = pc.Set(ctx, rn, buf)
-	require.NoError(t, err)
-
-	// Write some random digests as well.
-	var randomResources []*rspb.ResourceName
-	for i := 0; i < 100; i++ {
-		rn, buf := testdigest.RandomCASResourceBuf(t, 100)
-		anonCtx := getAnonContext(t, te)
-		err = pc.Set(anonCtx, rn, buf)
-		require.NoError(t, err)
-		randomResources = append(randomResources, rn)
+	testCases := []struct {
+		desc                  string
+		averageChunkSizeBytes int
+	}{
+		{
+			desc:                  "chunking_on",
+			averageChunkSizeBytes: 64 * 4,
+		},
+		{
+			desc:                  "chunking_on",
+			averageChunkSizeBytes: 0,
+		},
 	}
 
-	// Now advance the clock past the min eviction age to allow eviction to
-	// kick in. The unencrypted test digest should be evicted.
-	clock.Advance(minEvictionAge - 1*time.Minute)
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
 
-	for i := 0; i < 5; i++ {
-		if exists, err := pc.Contains(anonCtx, rn); err == nil && !exists {
-			break
-		}
-		time.Sleep(500 * time.Millisecond)
+			rootDir := testfs.MakeTempDir(t)
+			minEvictionAge := 1 * time.Hour
+			clock := clockwork.NewFakeClock()
+
+			opts := &pebble_cache.Options{
+				RootDirectory: rootDir,
+				Partitions: []disk.Partition{{
+					ID: pebble_cache.DefaultPartitionID,
+					// Force all entries to be evicted as soon as they pass the minimum
+					// eviction age.
+					MaxSizeBytes: 2,
+				}},
+				MinEvictionAge:        &minEvictionAge,
+				AverageChunkSizeBytes: tc.averageChunkSizeBytes,
+				Clock:                 clock,
+			}
+			pc, err := pebble_cache.NewPebbleCache(te, opts)
+			require.NoError(t, err)
+			err = pc.Start()
+			require.NoError(t, err)
+
+			rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+			anonCtx := getAnonContext(t, te)
+			err = pc.Set(anonCtx, rn, buf)
+			require.NoError(t, err)
+
+			// Advance time (to force newer atime) and write the same digest
+			// encrypted. The encrypted key should have the same digest prefix as the
+			// unencrypted key and come before the unencrypted key in lexicographical f
+			// order.
+			clock.Advance(5 * time.Minute)
+			err = pc.Set(ctx, rn, buf)
+			require.NoError(t, err)
+
+			// Write some random digests as well.
+			var randomResources []*rspb.ResourceName
+			for i := 0; i < 100; i++ {
+				rn, buf := testdigest.RandomCASResourceBuf(t, 100)
+				anonCtx := getAnonContext(t, te)
+				err = pc.Set(anonCtx, rn, buf)
+				require.NoError(t, err)
+				randomResources = append(randomResources, rn)
+			}
+
+			// Now advance the clock past the min eviction age to allow eviction to
+			// kick in. The unencrypted test digest should be evicted.
+			clock.Advance(minEvictionAge - 1*time.Minute)
+
+			for i := 0; i < 5; i++ {
+				if exists, err := pc.Contains(anonCtx, rn); err == nil && !exists {
+					break
+				}
+				time.Sleep(500 * time.Millisecond)
+			}
+
+			// The unencrypted key should no longer exist.
+			unencryptedExists, err := pc.Contains(anonCtx, rn)
+			require.NoError(t, err)
+			require.False(t, unencryptedExists)
+
+			// The encrypted key should still exist.
+			encryptedExists, err := pc.Contains(ctx, rn)
+			require.NoError(t, err)
+			require.True(t, encryptedExists)
+
+			// The other random digests should also exist.
+			for _, rr := range randomResources {
+				exists, err := pc.Contains(anonCtx, rr)
+				require.NoError(t, err)
+				require.True(t, exists)
+			}
+
+			err = pc.Stop()
+			require.NoError(t, err)
+		})
 	}
-
-	// The unencrypted key should no longer exist.
-	unencryptedExists, err := pc.Contains(anonCtx, rn)
-	require.NoError(t, err)
-	require.False(t, unencryptedExists)
-
-	// The encrypted key should still exist.
-	encryptedExists, err := pc.Contains(ctx, rn)
-	require.NoError(t, err)
-	require.True(t, encryptedExists)
-
-	// The other random digests should also exist.
-	for _, rr := range randomResources {
-		exists, err := pc.Contains(anonCtx, rr)
-		require.NoError(t, err)
-		require.True(t, exists)
-	}
-
-	err = pc.Stop()
-	require.NoError(t, err)
 }

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2807,14 +2807,13 @@ func TestSampling(t *testing.T) {
 			averageChunkSizeBytes: 64 * 4,
 		},
 		{
-			desc:                  "chunking_on",
+			desc:                  "chunking_off",
 			averageChunkSizeBytes: 0,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-
 			rootDir := testfs.MakeTempDir(t)
 			minEvictionAge := 1 * time.Hour
 			clock := clockwork.NewFakeClock()

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -62,6 +62,11 @@ message StorageMetadata {
   }
   InlineMetadata inline_metadata = 3;
 
+  message ChunkedMetadata {
+    repeated resource.ResourceName resource = 1;
+  }
+  ChunkedMetadata chunked_metadata = 4;
+
   // Insert other storage types (gcs, etc) here.
   // Upon read, the server will first read this record and then serve the
   // contents of the the specified location.


### PR DESCRIPTION
When chunking is enabled, during write, we will first attempt to
chunk it, and then compress each individual chunk, and finally encrypt the chunk
if encryption is enabled.  If the data is compressed, we will first decompress it
before we chunk it.

If there is only one single chunk, we will write the chunk inline,
similar to how we write small files inline when chunking is disabled.
If there are multiple chunks, we will write a file record in Pebble. which include
all the resource names that points to the chunks. Every chunks will be
stored inline in Pebble.

Added unit tests.

This is based on Tyler's PR:
https://github.com/buildbuddy-io/buildbuddy/pull/3457

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
