### PR TITLE
testenv: raise default log level to 'warn'

### DIFF
--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -36,7 +36,7 @@ var (
 )
 
 func init() {
-	*log.LogLevel = "debug"
+	*log.LogLevel = "warn"
 	*log.IncludeShortFileName = true
 	log.Configure()
 }


### PR DESCRIPTION
When set at 'debug', we have a lot of logs which make it hard to find
reason why a test fail initially.
Raise the default log level in test to reduce the noise level.

Individual tests could still override this value in their own package.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
