### PR TITLE
Secret manager tweaks:

### DIFF
--- a/enterprise/server/secrets/BUILD
+++ b/enterprise/server/secrets/BUILD
@@ -16,5 +16,6 @@ go_library(
         "//server/util/perms",
         "//server/util/query_builder",
         "//server/util/status",
+        "@io_gorm_gorm//:gorm",
     ],
 )

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1138,7 +1138,8 @@ func (s *BuildBuddyServer) ListSecrets(ctx context.Context, req *skpb.ListSecret
 }
 func (s *BuildBuddyServer) UpdateSecret(ctx context.Context, req *skpb.UpdateSecretRequest) (*skpb.UpdateSecretResponse, error) {
 	if secretService := s.env.GetSecretService(); secretService != nil {
-		return secretService.UpdateSecret(ctx, req)
+		rsp, _, err := secretService.UpdateSecret(ctx, req)
+		return rsp, err
 	}
 	return nil, status.UnimplementedError("Not implemented")
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1101,7 +1101,7 @@ type KMS interface {
 type SecretService interface {
 	GetPublicKey(ctx context.Context, req *skpb.GetPublicKeyRequest) (*skpb.GetPublicKeyResponse, error)
 	ListSecrets(ctx context.Context, req *skpb.ListSecretsRequest) (*skpb.ListSecretsResponse, error)
-	UpdateSecret(ctx context.Context, req *skpb.UpdateSecretRequest) (*skpb.UpdateSecretResponse, error)
+	UpdateSecret(ctx context.Context, req *skpb.UpdateSecretRequest) (*skpb.UpdateSecretResponse, bool, error)
 	DeleteSecret(ctx context.Context, req *skpb.DeleteSecretRequest) (*skpb.DeleteSecretResponse, error)
 
 	// Internal use only -- fetches decoded secrets for use in running a command.


### PR DESCRIPTION
  - Don't use "REPLACE INTO" which is mysql-specific
  - Don't include user_id in key when updating secrets since any user in the org should be able to update the same key
  - Return a boolean to indicate whether it's a new secret to facilitate proper audit logging

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
