### PR TITLE
executor_image: remove RedHat registry overrides

### DIFF
--- a/dockerfiles/executor_image/data/registries.conf
+++ b/dockerfiles/executor_image/data/registries.conf
@@ -7,15 +7,3 @@ prefix = "docker.io"
 location = "docker.io"
 [[registry.mirror]]
 location="mirror.gcr.io"
-
-# 2020-10-27 a number of images are not present in gcr.io, and podman barfs spectacularly when trying to fetch them. We've
-# hand-copied those to quay, using skopeo copy --all ...
-[[registry]]
-prefix="docker.io/library"
-location="quay.io/libpod"
-
-# 2021-03-23 these are used in buildah system tests, but not (yet?) listed in the global shortnames.conf.
-[aliases]
-busybox="docker.io/library/busybox"
-ubuntu="docker.io/library/ubuntu"
-php="docker.io/library/php"


### PR DESCRIPTION
In #1861, this file was brought over from (1).

However, the redhat overrides created some problems like this:

```
==================== Test output for //enterprise/server/remote_execution/containers/firecracker:firecracker_test (run 1 of 3):
...
2023/07/19 08:11:21.424 ERR                        firecracker.go:989 > nonCmdExit returning error: rpc error: code = Internal desc = skopeo copy error: "time=\"2023-07-19T08:11:21Z\" level=fatal msg=\"initializing source docker://ubuntu:20.04: reading manifest 20.04 in quay.io/libpod/ubuntu: manifest unknown\"\n": exit status 1
--- FAIL: TestFirecrackerRun_ReapOrphanedZombieProcess (0.83s)
    firecracker_test.go:606: rpc error: code = Internal desc = skopeo copy error: "time=\"2023-07-19T08:11:21Z\" level=fatal msg=\"initializing source docker://ubuntu:20.04: reading manifest 20.04 in quay.io/libpod/ubuntu: manifest unknown\"\n": exit status 1
```

when the image `docker.io/library/ubuntu:20.04` was used.
See https://app.buildbuddy.io/invocation/cd1694ce-c5b0-4b5a-9d81-d8a996a46117 for more info.

Remove RedHat's overrides to avoid the quay.io/libpod proxy.
Effectively route all `docker.io` traffics to `mirror.gcr.io` with
`docker.io` (rate limited) as fallback.

(1): https://github.com/containers/podman/blob/main/test/registries.conf

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy/pull/4341
