### PR TITLE
.bazelrc: add skymeld config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,9 @@
+# Skymeld merges the analysis phase and execution phase.
+# This allows build and test executions to start before the analysis phase finishes,
+# thus speeding up the build overall .
+build:skymeld --experimental_skymeld_ui
+build:skymeld --experimental_merged_skyframe_analysis_execution
+
 # Build with --config=local to send build logs to your local server
 build:local --bes_results_url=http://localhost:8080/invocation/
 build:local --bes_backend=grpc://localhost:1985

--- a/template-user.bazelrc
+++ b/template-user.bazelrc
@@ -37,3 +37,6 @@
 #
 # Print out test logs if there is any error
 #test --test_output=errors
+#
+# Enable Skymeld to speed up build
+#build --config=skymeld


### PR DESCRIPTION
This config is great to help when use in combination with `--config=remote-target-linux`

As user switches between local build and remote cross-build, Bazel's analysis cache will
get dropped and needs to be rebuilt. Using Skymeld greatly speed up the total
analysis + execution time.


<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
