### PR TITLE
goinit: provide backup dns

### DIFF
--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -338,7 +338,12 @@ func main() {
 		"ff02::2		ip6-allrouters",
 	}
 	die(os.WriteFile("/etc/hosts", []byte(strings.Join(hosts, "\n")), 0755))
-	die(os.WriteFile("/etc/resolv.conf", []byte("nameserver 8.8.8.8"), 0755))
+	nameServers := []string{
+		"nameserver 8.8.8.8",
+		"nameserver 8.8.4.4",
+		"nameserver 1.1.1.1",
+	}
+	die(os.WriteFile("/etc/resolv.conf", []byte(strings.Join(nameServers, "\n")), 0755))
 	if _, err := os.Stat("/etc/mtab"); err != nil {
 		if os.IsNotExist(err) {
 			die(syscall.Symlink("/proc/mounts", "/etc/mtab"))


### PR DESCRIPTION
In case 8.8.8.8 being unavailable, we shall first fail over to Google's
secondary DNS 8.8.4.4.  In the rare case where both fail, we fallback to
CloudFlare's DNS 1.1.1.1.

This should help us narrow down the root cause of flaky firecracker
baremetal tests such as:

```
docker:
  Error response from daemon:
    Get https://mirror.gcr.io/v2/: dial tcp:
      lookup mirror.gcr.io on 8.8.8.8:53: read udp 192.168.241.2:42099->8.8.8.8:53: i/o timeout.
```

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
