### PR TITLE
Tweak some pebble options

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -369,7 +369,7 @@ func ensureDefaultPartitionExists(opts *Options) {
 func defaultPebbleOptions() *pebble.Options {
 	// These values Borrowed from CockroachDB.
 	return &pebble.Options{
-		MaxConcurrentCompactions:    func() { return 10 },
+		MaxConcurrentCompactions:    10,
 		MemTableSize:                64 << 20, // 64 MB
 	}
 }

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -367,8 +367,13 @@ func ensureDefaultPartitionExists(opts *Options) {
 
 // defaultPebbleOptions returns default pebble config options.
 func defaultPebbleOptions() *pebble.Options {
-	// TODO: tune options here.
-	return &pebble.Options{}
+	// These values Borrowed from CockroachDB.
+	return &pebble.Options{
+		MaxConcurrentCompactions:    func() { return 10 },
+		L0StopWritesThreshold:       1000,
+		MemTableStopWritesThreshold: 4,
+		MemTableSize:                64 << 20, // 64 MB
+	}
 }
 
 // NewPebbleCache creates a new cache from the provided env and opts.

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -370,8 +370,8 @@ func ensureDefaultPartitionExists(opts *Options) {
 func defaultPebbleOptions() *pebble.Options {
 	// These values Borrowed from CockroachDB.
 	return &pebble.Options{
-		MaxConcurrentCompactions:    10,
-		MemTableSize:                64 << 20, // 64 MB
+		MaxConcurrentCompactions: 10,
+		MemTableSize:             64 << 20, // 64 MB
 	}
 }
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -370,8 +370,6 @@ func defaultPebbleOptions() *pebble.Options {
 	// These values Borrowed from CockroachDB.
 	return &pebble.Options{
 		MaxConcurrentCompactions:    func() { return 10 },
-		L0StopWritesThreshold:       1000,
-		MemTableStopWritesThreshold: 4,
 		MemTableSize:                64 << 20, // 64 MB
 	}
 }


### PR DESCRIPTION
These appear relatively safe to and should help address the large compaction backlog we see on some apps.
