### PR TITLE
bep/accumulator: add BuildToolLogs as important

### DIFF
--- a/server/build_event_protocol/accumulator/accumulator.go
+++ b/server/build_event_protocol/accumulator/accumulator.go
@@ -246,6 +246,8 @@ func IsImportantEvent(event *build_event_stream.BuildEvent) bool {
 		return true
 	case *build_event_stream.BuildEvent_BuildMetadata:
 		return true
+	case *build_event_stream.BuildEvent_BuildToolLogs:
+		return true
 	case *build_event_stream.BuildEvent_WorkspaceStatus:
 		return true
 	case *build_event_stream.BuildEvent_WorkflowConfigured:


### PR DESCRIPTION
We need this event as it contains the timing profile of the build.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
