### PR TITLE
pebble_cache_test: mark as flaky

### DIFF
--- a/enterprise/server/backends/pebble_cache/BUILD
+++ b/enterprise/server/backends/pebble_cache/BUILD
@@ -49,6 +49,7 @@ go_test(
     name = "pebble_cache_test",
     size = "small",
     srcs = ["pebble_cache_test.go"],
+    flaky = True,
     shard_count = 8,
     deps = [
         ":pebble_cache",


### PR DESCRIPTION
Although the flaky rate is relatively low, it's still blocking CI
occasionally. Mark the test as flaky for Bazel to automatically retry
them.

Some failure examples
```
--- FAIL: TestLRUWithACEviction (1.74s)
    pebble_cache_test.go:1441:
                Error Trace:    enterprise/server/backends/pebble_cache/pebble_cache_test.go:1441
                                                        enterprise/server/backends/pebble_cache/pebble_cache_test.go:1450
                Error:          "12" is not less than or equal to "11"
                Test:           TestLRUWithACEviction

--- FAIL: TestSampling (2.64s)
    pebble_cache_test.go:2371:
                Error Trace:    enterprise/server/backends/pebble_cache/pebble_cache_test.go:2371
                Error:          Should be false
                Test:           TestSampling
```

Reproduce command
```
> bazel test \
      --config=remote-target-linux \
      --runs_per_test=100 \
      --@io_bazel_rules_go//go/config:race \
      //enterprise/server/backends/pebble_cache:pebble_cache_test
```

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
