### PR TITLE
Roll forward "usage: remove reliance on unique index for upsert query" (#4329)

### DIFF
--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//server/util/status",
         "//server/util/timeutil",
         "@com_github_go_redis_redis_v8//:redis",
-        "@io_gorm_gorm//clause",
     ],
 )
 

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -19,7 +19,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/timeutil"
 	"github.com/go-redis/redis/v8"
-	"gorm.io/gorm/clause"
 
 	usage_config "github.com/buildbuddy-io/buildbuddy/enterprise/server/usage/config"
 )
@@ -278,6 +277,58 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, c collection
 	}
 	dbh := ut.env.GetDBHandle()
 	return dbh.TransactionWithOptions(ctx, db.Opts().WithQueryName("upsert_usage"), func(tx *db.DB) error {
+		// First check whether the row already exists. Make sure to select for
+		// update in order to lock the row.
+		rows, err := tx.Raw(`
+			SELECT *
+			FROM "Usages"
+			WHERE
+				region = ?
+				AND group_id = ?
+				AND period_start_usec = ?
+			`+dbh.SelectForUpdateModifier(),
+			pk.Region,
+			pk.GroupID,
+			pk.PeriodStartUsec,
+		).Rows()
+		if err != nil {
+			return err
+		}
+
+		schema, err := db.TableSchema(tx, &tables.Usage{})
+		if err != nil {
+			return status.WrapError(err, "failed to get usage table schema")
+		}
+
+		existingRowCount := 0
+		for rows.Next() {
+			existingRowCount++
+			fields := map[string]any{}
+			if err := tx.ScanRows(rows, &fields); err != nil {
+				return err
+			}
+
+			unsupportedField := ""
+			var unsupportedFieldValue any
+			for f, v := range fields {
+				if v == nil || v == "" {
+					continue
+				}
+				if _, ok := schema.FieldsByDBName[f]; !ok {
+					unsupportedField = f
+					unsupportedFieldValue = v
+					break
+				}
+			}
+			if unsupportedField != "" {
+				alert.UnexpectedEvent("usage_update_dropped", "Usage update transaction aborted since existing usage row contains unsupported column %q = %q", unsupportedField, unsupportedFieldValue)
+				return nil
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+
 		tu := &tables.Usage{
 			GroupID:         pk.GroupID,
 			PeriodStartUsec: pk.PeriodStartUsec,
@@ -285,21 +336,21 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, c collection
 			FinalBeforeUsec: c.End().UnixMicro(),
 			UsageCounts:     *counts,
 		}
-		// Create a row for the corresponding usage period if one doesn't already
-		// exist.
-		res := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(tu)
-		if res.Error != nil {
-			return res.Error
+		if existingRowCount == 0 {
+			return tx.Create(tu).Error
 		}
-		if res.RowsAffected != 0 {
-			// Insert worked; we're done.
+		if existingRowCount > 1 {
+			// Drop the usage update and alert about it, but there's not much we
+			// can do to recover in this case so don't roll back the transaction
+			// (since that would cause the flush to keep being retried).
+			alert.UnexpectedEvent("usage_update_dropped", "Usage update transaction aborted since it would affect more than one row")
 			return nil
 		}
 
 		// Update the usage row, but only if collection period data has not already
 		// been written (for example, if the previous flush failed to delete the
 		// data from Redis).
-		return tx.Exec(`
+		res := tx.Exec(`
 			UPDATE "Usages"
 			SET
 				final_before_usec = ?,
@@ -330,7 +381,20 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, c collection
 			tu.PeriodStartUsec,
 			tu.Region,
 			c.Start().UnixMicro(),
-		).Error
+		)
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected > 1 {
+			// Note: this should never happen since we should be first querying
+			// the rows to update above, and only applying the update if the
+			// number of selected rows was 1.
+			alert.UnexpectedEvent("usage_update_logic_error", "Usage update transaction rolled back due to unexpected affected row count %d", res.RowsAffected)
+			// Note: returning an error here causes the transaction to be rolled
+			// back.
+			return status.InternalErrorf("unexpected number of rows affected (%d)", res.RowsAffected)
+		}
+		return nil
 	})
 }
 

--- a/enterprise/server/usage/usage_test.go
+++ b/enterprise/server/usage/usage_test.go
@@ -487,6 +487,97 @@ func TestUsageTracker_AllFieldsAreMapped(t *testing.T) {
 	}}, usages)
 }
 
+func TestUsageTracker_Upsert_ForwardCompatibleWithNewLabelFields(t *testing.T) {
+	flags.Set(t, "app.usage_tracking_enabled", true)
+	flags.Set(t, "app.region", "us-west1")
+	te := setupEnv(t)
+	clock := testclock.StartingAt(usage1Collection1Start)
+	ut, err := usage.NewTracker(te, clock, &nopDistributedLock{})
+	require.NoError(t, err)
+	ctx := context.Background()
+	ctx1 := authContext(te, "US1")
+
+	// Simulate a newer app version migrating the usage schema such that it has
+	// a new label column "unsupported_label" which we don't yet know about.
+	err = te.GetDBHandle().DB(ctx).Exec(`
+		ALTER TABLE "Usages" ADD unsupported_label VARCHAR(255)
+	`).Error
+	require.NoError(t, err)
+
+	// We should still be able to write usage data despite this new column
+	// being added.
+	err = ut.Increment(ctx1, &tables.UsageCounts{Invocations: 1})
+	require.NoError(t, err)
+	clock.Set(clock.Now().Add(2 * collectionPeriodDuration))
+	err = te.GetMetricsCollector().Flush(ctx)
+	require.NoError(t, err)
+	err = ut.FlushToDB(ctx)
+	require.NoError(t, err)
+
+	usages := queryAllUsages(t, te)
+	require.Equal(t, []*tables.Usage{
+		{
+			Region:          "us-west1",
+			GroupID:         "GR1",
+			PeriodStartUsec: usage1Start.UnixMicro(),
+			FinalBeforeUsec: usage1Collection2Start.UnixMicro(),
+			UsageCounts:     tables.UsageCounts{Invocations: 1},
+		},
+	}, usages)
+
+	// However, if a row exists with the unsupported label set, we should not
+	// update that row, even if all other labels match.
+	res := te.GetDBHandle().DB(ctx).Exec(`
+		INSERT INTO "Usages" (
+			region,
+			group_id,
+			period_start_usec,
+			final_before_usec,
+			invocations,
+			unsupported_label
+		) VALUES (?, ?, ?, ?, ?, ?)
+		`,
+		"us-west1",
+		"GR1",
+		usage1Start.UnixMicro(),
+		usage1Collection2Start.UnixMicro(),
+		1,
+		"unsupported_label_value",
+	)
+	require.NoError(t, res.Error)
+
+	// This update should be dropped because we can't currently distinguish
+	// between the row with the new label unset, and the row with the new label
+	// set.
+	err = ut.Increment(ctx1, &tables.UsageCounts{CASCacheHits: 7})
+	require.NoError(t, err)
+	clock.Set(clock.Now().Add(2 * collectionPeriodDuration))
+	err = te.GetMetricsCollector().Flush(ctx)
+	require.NoError(t, err)
+	err = ut.FlushToDB(ctx)
+	require.NoError(t, err)
+
+	usages = queryAllUsages(t, te)
+	require.Equal(t, []*tables.Usage{
+		{
+			Region:          "us-west1",
+			GroupID:         "GR1",
+			PeriodStartUsec: usage1Start.UnixMicro(),
+			FinalBeforeUsec: usage1Collection2Start.UnixMicro(),
+			UsageCounts:     tables.UsageCounts{Invocations: 1},
+		},
+		// This second row looks like a duplicate of the first, but in the DB
+		// it has the unsupported label set.
+		{
+			Region:          "us-west1",
+			GroupID:         "GR1",
+			PeriodStartUsec: usage1Start.UnixMicro(),
+			FinalBeforeUsec: usage1Collection2Start.UnixMicro(),
+			UsageCounts:     tables.UsageCounts{Invocations: 1},
+		},
+	}, usages)
+}
+
 func increasingCountsStartingAt(value int64) *tables.UsageCounts {
 	counts := &tables.UsageCounts{}
 	countsValue := reflect.ValueOf(counts).Elem()

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -618,13 +618,13 @@ type UsageCounts struct {
 type Usage struct {
 	Model
 
-	GroupID string `gorm:"not null;uniqueIndex:group_period_region_index,priority:1"`
+	GroupID string `gorm:"not null;index:group_period_region_index_v2,priority:1"`
 
 	// PeriodStartUsec is the time at which the usage period started, in
 	// microseconds since the Unix epoch. The usage period duration is 1 hour.
 	// Only usage data occurring in collection periods inside this 1 hour period
 	// is included in this usage row.
-	PeriodStartUsec int64 `gorm:"not null;uniqueIndex:group_period_region_index,priority:2"`
+	PeriodStartUsec int64 `gorm:"not null;index:group_period_region_index_v2,priority:2"`
 
 	// FinalBeforeUsec is the time before which all collection period data in this
 	// usage period is finalized. This is used to guarantee that collection period
@@ -651,7 +651,7 @@ type Usage struct {
 	// Since we have a global DB deployment but usage data is collected
 	// per-region, this effectively partitions the usage table by region, allowing
 	// the FinalBeforeUsec logic to work independently in each region.
-	Region string `gorm:"not null;uniqueIndex:group_period_region_index,priority:3"`
+	Region string `gorm:"not null;index:group_period_region_index_v2,priority:3"`
 
 	UsageCounts
 }

--- a/server/util/db/BUILD
+++ b/server/util/db/BUILD
@@ -27,6 +27,7 @@ go_library(
         "@io_gorm_driver_sqlite//:sqlite",
         "@io_gorm_gorm//:gorm",
         "@io_gorm_gorm//logger",
+        "@io_gorm_gorm//schema",
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel//codes",
         "@io_opentelemetry_go_otel_trace//:trace",

--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
+	"gorm.io/gorm/schema"
 
 	// We support MySQL (preferred) and Sqlite3.
 	// New dialects need to be added to openDB() as well.
@@ -1008,4 +1009,14 @@ func (h *DBHandle) IsDeadlockError(err error) bool {
 		return true
 	}
 	return false
+}
+
+// TableSchema can be used to get the schema for a given table.
+func TableSchema(db *DB, model any) (*schema.Schema, error) {
+	stmt := &gorm.Statement{DB: db}
+	// Note: Parse() is cheap since gorm uses a cache internally.
+	if err := stmt.Parse(model); err != nil {
+		return nil, err
+	}
+	return stmt.Schema, nil
 }


### PR DESCRIPTION
Rolling forward with some debug logging so that we can trace what happened if the manually enforced uniqueness constraint is not working properly in dev.

- Roll-forward commit (unchanged): 7acfa2ac0665306c555e2bb74a0fcd46f910a901
- Debug logging commit: d637ae1c7cb5528ac0633c86848d5fc8b9e3f51e

**Related issues**: N/A
