### PR TITLE
Allow evicting more than 1 key before resampling.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -77,6 +77,7 @@ var (
 	forceCompaction           = flag.Bool("cache.pebble.force_compaction", false, "If set, compact the DB when it's created")
 	forceCalculateMetadata    = flag.Bool("cache.pebble.force_calculate_metadata", false, "If set, partition size and counts will be calculated even if cached information is available.")
 	samplesPerEviction        = flag.Int("cache.pebble.samples_per_eviction", 20, "How many records to sample on each eviction")
+	deletesPerEviction        = flag.Int("cache.pebble.deletes_per_eviction", 5, "Maximum number keys to delete in one eviction attempt before resampling.")
 	samplePoolSize            = flag.Int("cache.pebble.sample_pool_size", 500, "How many deletion candidates to maintain between evictions")
 	evictionRateLimit         = flag.Int("cache.pebble.eviction_rate_limit", 50, "Maximum number of entries to evict per second (per partition).")
 	copyPartition             = flag.String("cache.pebble.copy_partition_data", "", "If set, all data will be copied from the source partition to the destination partition on startup. The cache will not serve data while the copy is in progress. Specified in format source_partition_id:destination_partition_id,")
@@ -2077,6 +2078,7 @@ func newPartitionEvictor(part disk.Partition, fileStorer filestore.Store, blobDi
 	l, err := approxlru.New(&approxlru.Opts[*evictionKey]{
 		SamplePoolSize:     *samplePoolSize,
 		SamplesPerEviction: *samplesPerEviction,
+		DeletesPerEviction: *deletesPerEviction,
 		RateLimit:          float64(*evictionRateLimit),
 		MaxSizeBytes:       int64(JanitorCutoffThreshold * float64(part.MaxSizeBytes)),
 		OnEvict: func(ctx context.Context, sample *approxlru.Sample[*evictionKey]) (skip bool, err error) {

--- a/server/util/approxlru/approxlru.go
+++ b/server/util/approxlru/approxlru.go
@@ -16,6 +16,8 @@ const (
 	// evictCheckPeriod is how often the janitor thread will wake up to
 	// check the cache size.
 	evictCheckPeriod = 1 * time.Second
+
+	defaultDeletesPerEviction = 5
 )
 
 type Key interface {
@@ -65,6 +67,7 @@ type OnRefresh[T Key] func(ctx context.Context, key T) (skip bool, timestamp tim
 //	http://antirez.com/news/109
 type LRU[T Key] struct {
 	samplesPerEviction int
+	deletesPerEviction int
 	samplePoolSize     int
 	maxSizeBytes       int64
 	onEvict            OnEvict[T]
@@ -89,6 +92,9 @@ type Opts[T Key] struct {
 	// new deletion candidate to the sample pool. Increasing this number
 	// makes eviction slower but improves sampled-LRU accuracy.
 	SamplesPerEviction int
+	// DeletesPerEviction is the number of keys to evict from the sample pool
+	// in one eviction cycle before refilling the sample pool.
+	DeletesPerEviction int
 	// SamplePoolSize is the number of deletion candidates to maintain in
 	// memory at a time. Increasing this number uses more memory but
 	// improves sampled-LRU accuracy.
@@ -109,6 +115,10 @@ func New[T Key](opts *Opts[T]) (*LRU[T], error) {
 	if opts.SamplesPerEviction == 0 {
 		return nil, status.FailedPreconditionError("samples per eviction is required")
 	}
+	deletesPerEviction := opts.DeletesPerEviction
+	if opts.DeletesPerEviction == 0 {
+		deletesPerEviction = defaultDeletesPerEviction
+	}
 	if opts.MaxSizeBytes == 0 {
 		return nil, status.FailedPreconditionError("max size is required")
 	}
@@ -128,6 +138,7 @@ func New[T Key](opts *Opts[T]) (*LRU[T], error) {
 	l := &LRU[T]{
 		samplePoolSize:     opts.SamplePoolSize,
 		samplesPerEviction: opts.SamplesPerEviction,
+		deletesPerEviction: deletesPerEviction,
 		maxSizeBytes:       opts.MaxSizeBytes,
 		onEvict:            opts.OnEvict,
 		onSample:           opts.OnSample,
@@ -236,63 +247,94 @@ func (l *LRU[T]) resampleK(k int) error {
 	return nil
 }
 
+func (l *LRU[T]) evictSingleKey() (*Sample[T], error) {
+	for i := len(l.samplePool) - 1; i >= 0; i-- {
+		sample := l.samplePool[i]
+		l.mu.Lock()
+		oldLocalSizeBytes := l.localSizeBytes
+		oldGlobalSizeBytes := l.globalSizeBytes
+		l.mu.Unlock()
+
+		log.Infof("Evictor attempting to evict %q (last accessed %s)", sample.Key, time.Since(sample.Timestamp))
+		skip, err := l.onEvict(l.ctx, sample)
+		if err != nil {
+			log.Warningf("Could not evict %q: %s", sample.Key, err)
+			continue
+		}
+
+		l.mu.Lock()
+
+		// The user (e.g. pebble cache) is the source of truth of the size
+		// data, but the LRU also needs to do its own accounting in between
+		// the times that the user provides a size update to the LRU.
+		// We skip our own accounting here if we detect that the size has
+		// changed since it means the user provided their own size update
+		// which takes priority.
+		if l.localSizeBytes == oldLocalSizeBytes {
+			l.localSizeBytes -= sample.SizeBytes
+		}
+		if l.globalSizeBytes == oldGlobalSizeBytes {
+			// Assume eviction on remote servers is happening at the same
+			// rate as local eviction. It's fine to be wrong as we expect the
+			// actual sizes to be periodically to be reset to the true numbers
+			// using UpdateSizeBytes from data received from other servers.
+			l.globalSizeBytes -= int64(float64(sample.SizeBytes) * float64(l.globalSizeBytes) / float64(l.localSizeBytes))
+		}
+		l.mu.Unlock()
+
+		l.samplePool = append(l.samplePool[:i], l.samplePool[i+1:]...)
+
+		if skip {
+			continue
+		}
+
+		return sample, nil
+	}
+
+	return nil, status.NotFoundErrorf("could not find sample to evict")
+}
+
 func (l *LRU[T]) evict() (*Sample[T], error) {
-	// Resample every time we evict a key
-	if err := l.resampleK(1); err != nil {
+	// Resample every time we evict keys.
+	// N.B. We might end up evicting less than deletesPerEviction keys below
+	// but sampling extra keys is harmless.
+	if err := l.resampleK(l.deletesPerEviction); err != nil {
 		return nil, err
 	}
 
+	var evicted []*Sample[T]
 	for {
-		for i := len(l.samplePool) - 1; i >= 0; i-- {
-			sample := l.samplePool[i]
-			l.mu.Lock()
-			oldLocalSizeBytes := l.localSizeBytes
-			oldGlobalSizeBytes := l.globalSizeBytes
-			l.mu.Unlock()
-
-			log.Infof("Evictor attempting to evict %q (last accessed %s)", sample.Key, time.Since(sample.Timestamp))
-			skip, err := l.onEvict(l.ctx, sample)
-			if err != nil {
-				log.Warningf("Could not evict %q: %s", sample.Key, err)
-				continue
+		evictedKey, err := l.evictSingleKey()
+		if status.IsNotFoundError(err) {
+			// If no candidates were evictable in the whole pool, resample
+			// the pool.
+			l.samplePool = l.samplePool[:0]
+			if err := l.resampleK(l.samplePoolSize); err != nil {
+				return nil, err
 			}
-
-			l.mu.Lock()
-
-			// The user (e.g. pebble cache) is the source of truth of the size
-			// data, but the LRU also needs to do its own accounting in between
-			// the times that the user provides a size update to the LRU.
-			// We skip our own accounting here if we detect that the size has
-			// changed since it means the user provided their own size update
-			// which takes priority.
-			if l.localSizeBytes == oldLocalSizeBytes {
-				l.localSizeBytes -= sample.SizeBytes
-			}
-			if l.globalSizeBytes == oldGlobalSizeBytes {
-				// Assume eviction on remote servers is happening at the same
-				// rate as local eviction. It's fine to be wrong as we expect the
-				// actual sizes to be periodically to be reset to the true numbers
-				// using UpdateSizeBytes from data received from other servers.
-				l.globalSizeBytes -= int64(float64(sample.SizeBytes) * float64(l.globalSizeBytes) / float64(l.localSizeBytes))
-			}
-			l.mu.Unlock()
-
-			l.samplePool = append(l.samplePool[:i], l.samplePool[i+1:]...)
-
-			if skip {
-				continue
-			}
-
-			return sample, nil
-		}
-
-		// If no candidates were evictable in the whole pool, resample
-		// the pool.
-		l.samplePool = l.samplePool[:0]
-		if err := l.resampleK(l.samplePoolSize); err != nil {
+			continue
+		} else if err != nil {
 			return nil, err
 		}
+
+		evicted = append(evicted, evictedKey)
+
+		if len(evicted) == l.deletesPerEviction {
+			break
+		}
+
+		l.mu.Lock()
+		globalSizeBytes := l.globalSizeBytes
+		localSizeBytes := l.localSizeBytes
+		l.mu.Unlock()
+
+		// Cache is under the max, so we can stop early.
+		if globalSizeBytes <= l.maxSizeBytes || localSizeBytes == 0 {
+			break
+		}
 	}
+
+	return evicted[len(evicted)-1], nil
 }
 
 func (l *LRU[T]) ttl() error {


### PR DESCRIPTION
`evictSingleKey` is the extracted inner loop from `evict` w/o changes. 

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
