### PR TITLE
Don't refresh entire eviction pool on every eviction

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2517,7 +2517,7 @@ func (e *partitionEvictor) refresh(ctx context.Context, key *evictionKey) (bool,
 		return true, time.Time{}, nil
 	}
 	atime := time.UnixMicro(md.GetLastAccessUsec())
-	age := time.Since(atime)
+	age := e.clock.Since(atime)
 	if age < e.minEvictionAge {
 		return true, time.Time{}, nil
 	}
@@ -2635,7 +2635,6 @@ func (e *partitionEvictor) sample(ctx context.Context, k int) ([]*approxlru.Samp
 					SizeBytes: fileMetadata.GetStoredSizeBytes(),
 					Timestamp: atime,
 				}
-
 				samples = append(samples, sample)
 			}
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2338,7 +2338,7 @@ func TestSampling(t *testing.T) {
 
 	// Advance time (to force newer atime) and write the same digest
 	// encrypted. The encrypted key should have the same digest prefix as the
-	// unencrypted key and come before the unencrypted key in lexicographical f
+	// unencrypted key and come before the unencrypted key in lexicographical
 	// order.
 	clock.Advance(5 * time.Minute)
 	err = pc.Set(ctx, rn, buf)

--- a/server/util/approxlru/approxlru.go
+++ b/server/util/approxlru/approxlru.go
@@ -251,6 +251,9 @@ func (l *LRU[T]) evictSingleKey() (*Sample[T], error) {
 		}
 		if sample.Timestamp != timestamp {
 			log.Warningf("Evictor skipping %q; atime has changed %s -> %s", sample.Key, sample.Timestamp, timestamp)
+			// Update the timestamp to the new value so this sample can be
+			// removed later when the pool is trimmed.
+			sample.Timestamp = timestamp
 			continue
 		}
 

--- a/server/util/approxlru/approxlru.go
+++ b/server/util/approxlru/approxlru.go
@@ -243,14 +243,14 @@ func (l *LRU[T]) evictSingleKey() (*Sample[T], error) {
 
 		skip, timestamp, err := l.onRefresh(l.ctx, sample.Key)
 		if err != nil {
-			log.Warningf("Could not refresh timestamp for %q: %s", sample.Key, err)
+			log.Infof("Could not refresh timestamp for %q: %s", sample.Key, err)
 			continue
 		}
 		if skip {
 			continue
 		}
 		if sample.Timestamp != timestamp {
-			log.Warningf("Evictor skipping %q; atime has changed %s -> %s", sample.Key, sample.Timestamp, timestamp)
+			log.Infof("Evictor skipping %q; atime has changed %s -> %s", sample.Key, sample.Timestamp, timestamp)
 			// Update the timestamp to the new value so this sample can be
 			// removed later when the pool is trimmed.
 			sample.Timestamp = timestamp

--- a/server/util/approxlru/approxlru.go
+++ b/server/util/approxlru/approxlru.go
@@ -235,6 +235,7 @@ func (l *LRU[T]) resampleK(k int) error {
 func (l *LRU[T]) evictSingleKey() (*Sample[T], error) {
 	for i := len(l.samplePool) - 1; i >= 0; i-- {
 		sample := l.samplePool[i]
+
 		l.mu.Lock()
 		oldLocalSizeBytes := l.localSizeBytes
 		oldGlobalSizeBytes := l.globalSizeBytes
@@ -248,12 +249,12 @@ func (l *LRU[T]) evictSingleKey() (*Sample[T], error) {
 		if skip {
 			continue
 		}
-		if timestamp != sample.Timestamp {
+		if sample.Timestamp != timestamp {
 			log.Warningf("Evictor skipping %q; atime has changed %s -> %s", sample.Key, sample.Timestamp, timestamp)
 			continue
 		}
 
-		log.Infof("Evictor attempting to evict %q (last accessed %s)", sample.Key, time.Since(sample.Timestamp))
+		log.Warningf("Evictor attempting to evict %q (last accessed %s)", sample.Key, time.Since(sample.Timestamp))
 		skip, err = l.onEvict(l.ctx, sample)
 		if err != nil {
 			log.Warningf("Could not evict %q: %s", sample.Key, err)


### PR DESCRIPTION
Profiling + metrics show that eviction can be a bottleneck. A major contributor is refreshing the atime of every item in the pool on every eviction.

This CL stops doing that -- instead the approxlru will refresh an item before deleting and skip deletion if the sample's atime differs between the pool value and the live value.