### PR TITLE
Recreate iter every 1M entries to avoid holding on to old sstables for too long. 

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1152,8 +1152,10 @@ func (p *PebbleCache) backgroundRepairIteration(quitChan chan struct{}, opts *re
 		// Create a new iterator once in a while to avoid holding on to sstables
 		// for too long.
 		if totalCount != 0 && totalCount%1_000_000 == 0 {
+			k := make([]byte, len(iter.Key()))
+			copy(k, iter.Key())
 			newIter := db.NewIter(&pebble.IterOptions{
-				LowerBound: iter.Key(),
+				LowerBound: k,
 				UpperBound: keys.MaxByte,
 			})
 			iter.Close()

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1125,6 +1125,8 @@ func (p *PebbleCache) backgroundRepairIteration(quitChan chan struct{}, opts *re
 		LowerBound: keys.MinByte,
 		UpperBound: keys.MaxByte,
 	})
+	// We update the iter variable later on, so we need to wrap the Close call
+	// in a func to operate on the correct iterator instance.
 	defer func() {
 		iter.Close()
 	}()


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
