### PR TITLE
lru: use go generic

### DIFF
--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -962,26 +962,26 @@ type XcodeLocator interface {
 }
 
 // LRU implements a Least Recently Used cache.
-type LRU interface {
+type LRU[V any] interface {
 	// Inserts a value into the LRU. A boolean is returned that indicates
 	// if the value was successfully added.
-	Add(key, value interface{}) bool
+	Add(key string, value V) bool
 
 	// Inserts a value into the back of the LRU. A boolean is returned that
 	// indicates if the value was successfully added.
-	PushBack(key, value interface{}) bool
+	PushBack(key string, value V) bool
 
 	// Gets a value from the LRU, returns a boolean indicating if the value
 	// was present.
-	Get(key interface{}) (interface{}, bool)
+	Get(key string) (V, bool)
 
 	// Returns a boolean indicating if the value is present in the LRU.
-	Contains(key interface{}) bool
+	Contains(key string) bool
 
 	// Removes a value from the LRU, releasing resources associated with
 	// that value. Returns a boolean indicating if the value was sucessfully
 	// removed.
-	Remove(key interface{}) bool
+	Remove(key string) bool
 
 	// Purge Remove()s all items in the LRU.
 	Purge()
@@ -993,7 +993,7 @@ type LRU interface {
 	Len() int
 
 	// Remove()s the oldest value in the LRU. (See Remove() above).
-	RemoveOldest() (interface{}, bool)
+	RemoveOldest() (V, bool)
 
 	// Returns metrics about the status of the LRU.
 	Metrics() string

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -258,15 +258,15 @@ type ClaimsCache struct {
 	ttl time.Duration
 
 	mu  sync.Mutex
-	lru interfaces.LRU
+	lru interfaces.LRU[*Claims]
 }
 
 func NewClaimsCache(ctx context.Context, ttl time.Duration) (*ClaimsCache, error) {
-	config := &lru.Config{
+	config := &lru.Config[*Claims]{
 		MaxSize: claimsCacheSize,
-		SizeFn:  func(v interface{}) int64 { return 1 },
+		SizeFn:  func(v *Claims) int64 { return 1 },
 	}
-	lru, err := lru.NewLRU(config)
+	lru, err := lru.NewLRU[*Claims](config)
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +279,7 @@ func (c *ClaimsCache) Get(token string) (*Claims, error) {
 	c.mu.Unlock()
 
 	if ok {
-		if claims := v.(*Claims); claims.ExpiresAt > time.Now().Unix() {
+		if claims := v; claims.ExpiresAt > time.Now().Unix() {
 			return claims, nil
 		}
 	}

--- a/server/util/lru/lru_test.go
+++ b/server/util/lru/lru_test.go
@@ -15,12 +15,12 @@ type eviction struct {
 func TestAdd(t *testing.T) {
 	evictions := []eviction{}
 
-	l, err := lru.NewLRU(&lru.Config{
+	l, err := lru.NewLRU[int](&lru.Config[int]{
 		MaxSize: 10,
-		OnEvict: func(value interface{}, reason lru.EvictionReason) {
-			evictions = append(evictions, eviction{value.(int), reason})
+		OnEvict: func(value int, reason lru.EvictionReason) {
+			evictions = append(evictions, eviction{value, reason})
 		},
-		SizeFn: func(value interface{}) int64 { return int64(value.(int)) },
+		SizeFn: func(value int) int64 { return int64(value) },
 	})
 	require.NoError(t, err)
 
@@ -46,12 +46,12 @@ func TestAdd(t *testing.T) {
 func TestAdd_UpdateInPlace(t *testing.T) {
 	evictions := []eviction{}
 
-	l, err := lru.NewLRU(&lru.Config{
+	l, err := lru.NewLRU[int](&lru.Config[int]{
 		MaxSize: 10,
-		OnEvict: func(value interface{}, reason lru.EvictionReason) {
-			evictions = append(evictions, eviction{value.(int), reason})
+		OnEvict: func(value int, reason lru.EvictionReason) {
+			evictions = append(evictions, eviction{value, reason})
 		},
-		SizeFn:        func(value interface{}) int64 { return int64(value.(int)) },
+		SizeFn:        func(value int) int64 { return int64(value) },
 		UpdateInPlace: true,
 	})
 	require.NoError(t, err)
@@ -75,12 +75,12 @@ func TestAdd_UpdateInPlace(t *testing.T) {
 func TestPushBack(t *testing.T) {
 	evictions := []eviction{}
 
-	l, err := lru.NewLRU(&lru.Config{
+	l, err := lru.NewLRU[int](&lru.Config[int]{
 		MaxSize: 10,
-		OnEvict: func(value interface{}, reason lru.EvictionReason) {
-			evictions = append(evictions, eviction{value.(int), reason})
+		OnEvict: func(value int, reason lru.EvictionReason) {
+			evictions = append(evictions, eviction{value, reason})
 		},
-		SizeFn: func(value interface{}) int64 { return int64(value.(int)) },
+		SizeFn: func(value int) int64 { return int64(value) },
 	})
 	require.NoError(t, err)
 
@@ -98,12 +98,12 @@ func TestPushBack(t *testing.T) {
 func TestRemoveOldest(t *testing.T) {
 	evictions := []eviction{}
 
-	l, err := lru.NewLRU(&lru.Config{
+	l, err := lru.NewLRU[int](&lru.Config[int]{
 		MaxSize: 10,
-		OnEvict: func(value interface{}, reason lru.EvictionReason) {
-			evictions = append(evictions, eviction{value.(int), reason})
+		OnEvict: func(value int, reason lru.EvictionReason) {
+			evictions = append(evictions, eviction{value, reason})
 		},
-		SizeFn: func(value interface{}) int64 { return int64(value.(int)) },
+		SizeFn: func(value int) int64 { return int64(value) },
 	})
 	require.NoError(t, err)
 
@@ -113,11 +113,11 @@ func TestRemoveOldest(t *testing.T) {
 
 	oldest, ok := l.RemoveOldest()
 	require.True(t, ok)
-	require.Equal(t, 5, oldest.(int))
+	require.Equal(t, 5, oldest)
 	require.Equal(t, []eviction{{5, lru.SizeEviction}}, evictions)
 
 	oldest, ok = l.RemoveOldest()
 	require.True(t, ok)
-	require.Equal(t, 4, oldest.(int))
+	require.Equal(t, 4, oldest)
 	require.Equal(t, []eviction{{5, lru.SizeEviction}, {4, lru.SizeEviction}}, evictions)
 }


### PR DESCRIPTION
Make use of go generic to make LRU package type-safe.

This restricts `key`'s type from `interface{} / any` to `string`, which is what we use throughout the entire code base.
It also lets us eliminate the type switch inside `keyHash()` func, further simplifying our code.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
