### PR TITLE
Small styling tweaks for API key value

### DIFF
--- a/enterprise/app/api_keys/api_keys.css
+++ b/enterprise/app/api_keys/api_keys.css
@@ -86,10 +86,11 @@
 
 .api-keys .api-key-value {
   font-family: monospace;
-  font-size: 16px;
+  font-size: 12px;
   background: #eee;
   border-radius: 8px;
-  padding: 0 16px;
+  padding-left: 16px;
+  padding-right: 4px;
   align-self: stretch;
   display: flex;
   align-items: center;
@@ -99,24 +100,16 @@
 }
 
 .api-keys .api-key-value button {
-  padding: 8px;
-  color: var(--color-black);
-  background: transparent;
-  border: 0;
-  border-radius: 2px;
-  appearance: none;
-  outline: 0;
-
-  &:hover {
-    background: rgba(0, 0, 0, 0.06);
-  }
+  width: 32px;
+  height: 32px;
+  border-color: transparent;
+  min-height: initial;
 }
 
 .api-keys .api-key-label svg,
 .api-keys .api-key-value svg {
   width: 16px;
   height: 16px;
-  opacity: 0.7;
 }
 
 .api-keys .api-key-label svg {

--- a/enterprise/app/api_keys/api_keys.css
+++ b/enterprise/app/api_keys/api_keys.css
@@ -71,12 +71,11 @@
 
 .api-keys .api-key-value {
   box-sizing: border-box;
-  flex-basis: 240px;
+  width: fit-content;
   flex-shrink: 0;
 }
 
-.api-keys .api-key-label > span,
-.api-keys .api-key-value > span {
+.api-keys .api-key-label > span {
   flex-grow: 1;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -95,8 +94,11 @@
   display: flex;
   align-items: center;
   white-space: nowrap;
-  text-overflow: ellipsis;
   overflow-x: hidden;
+}
+
+.api-keys .api-key-value .display-value {
+  margin-right: 4px;
 }
 
 .api-keys .api-key-value button {

--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -622,7 +622,7 @@ class ApiKeyField extends React.Component<ApiKeyFieldProps, ApiKeyFieldState> {
 
     return (
       <div className="api-key-value">
-        <span>{displayValue}</span>
+        <span className="display-value">{displayValue}</span>
         <OutlinedButton className="api-key-value-copy icon-button" onClick={this.handleCopyClick.bind(this)}>
           {isCopied ? <Check style={{ stroke: "green" }} className="icon" /> : <Copy className="icon" />}
         </OutlinedButton>

--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -589,11 +589,13 @@ interface ApiKeyFieldState {
 const ApiKeyFieldDefaultState: ApiKeyFieldState = {
   isCopied: false,
   hideValue: true,
-  displayValue: "************",
+  displayValue: "••••••••••••••••••••",
 };
 
 class ApiKeyField extends React.Component<ApiKeyFieldProps, ApiKeyFieldState> {
   state = ApiKeyFieldDefaultState;
+
+  private copyTimeout: number | undefined;
 
   // onClick handler function for the copy button
   private handleCopyClick() {
@@ -601,7 +603,8 @@ class ApiKeyField extends React.Component<ApiKeyFieldProps, ApiKeyFieldState> {
     this.setState({ isCopied: true }, () => {
       alert_service.success("Copied API key to clipboard");
     });
-    setTimeout(() => {
+    clearTimeout(this.copyTimeout);
+    this.copyTimeout = window.setTimeout(() => {
       this.setState({ isCopied: false });
     }, 4000);
   }
@@ -620,12 +623,12 @@ class ApiKeyField extends React.Component<ApiKeyFieldProps, ApiKeyFieldState> {
     return (
       <div className="api-key-value">
         <span>{displayValue}</span>
-        <button className="api-key-value-copy" onClick={this.handleCopyClick.bind(this)} disabled={isCopied}>
+        <OutlinedButton className="api-key-value-copy icon-button" onClick={this.handleCopyClick.bind(this)}>
           {isCopied ? <Check style={{ stroke: "green" }} className="icon" /> : <Copy className="icon" />}
-        </button>
-        <button className="api-key-value-hide" onClick={this.toggleHideValue.bind(this)}>
+        </OutlinedButton>
+        <OutlinedButton className="api-key-value-hide icon-button" onClick={this.toggleHideValue.bind(this)}>
           {hideValue ? <Eye className="icon" /> : <EyeOff className="icon" />}
-        </button>
+        </OutlinedButton>
       </div>
     );
   }


### PR DESCRIPTION
* Decrease font size to allow full API key to be displayed, instead of truncating w/ ellipsis
* Use unicode bullet `•` instead of `*` (looks a bit nicer)
* Reuse `<OutlinedButton>` w/ `icon-button` class for controls (had to remove `disabled` state + tweaked logic, since the default `[disabled]` styling for `<OutlinedButton>` shows a 'cancel' cursor which felt a bit weird)


**Related issues**: N/A
