### PR TITLE
Add flag to print all goroutine stack traces on shutdown

### DIFF
--- a/server/util/healthcheck/healthcheck.go
+++ b/server/util/healthcheck/healthcheck.go
@@ -29,7 +29,7 @@ import (
 var (
 	maxShutdownDuration           = flag.Duration("max_shutdown_duration", 25*time.Second, "Time to wait for shutdown")
 	shutdownLameduckDuration      = flag.Duration("shutdown_lameduck_duration", 0, "If set, the server will be marked unready but not run shutdown functions until this period passes.")
-	logGoroutineProfileOnShutdown = flag.Bool("debug.log_goroutine_profile_on_shutdown", false, "Whether to print all goroutine stack traces on shutdown.")
+	logGoroutineProfileOnShutdown = flag.Bool("debug.log_goroutine_profile_on_shutdown", false, "Whether to log all goroutine stack traces on shutdown.")
 )
 
 const (


### PR DESCRIPTION
We can set these for the executors so that if we need to reboot them in a pinch when they are stuck, we can see exactly where they got stuck without needing to manually grab a goroutine profile before shutting them down.

**Related issues**: N/A
