### PR TITLE
Extend firecracker vmexec timeout

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -76,7 +76,7 @@ const (
 	firecrackerSocketWaitTimeout = 3 * time.Second
 
 	// How long to wait when dialing the vmexec server inside the VM.
-	vSocketDialTimeout = 10 * time.Second
+	vSocketDialTimeout = 30 * time.Second
 
 	// How long to wait for the jailer directory to be created.
 	jailerDirectoryCreationTimeout = 1 * time.Second


### PR DESCRIPTION
There have been an increasing number of timeouts when we try to connect to the vmexec agent inside of firecracker VMs. Extend the timeout as a stopgap until we can find and resolve the underlying problem. Slack thread [here](https://buildbuddy-corp.slack.com/archives/C0495TM9UUE/p1690566102378579)