### PR TITLE
docker_test: use mirror.gcr.io intead of docker.io

### DIFF
--- a/enterprise/server/remote_execution/containers/docker/docker_test.go
+++ b/enterprise/server/remote_execution/containers/docker/docker_test.go
@@ -60,7 +60,7 @@ func TestDockerRun(t *testing.T) {
 	env := testenv.GetTestEnv(t)
 	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
 	cacheAuth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c := docker.NewDockerContainer(env, cacheAuth, dc, "docker.io/library/busybox", rootDir, cfg)
+	c := docker.NewDockerContainer(env, cacheAuth, dc, "mirror.gcr.io/library/busybox", rootDir, cfg)
 
 	res := c.Run(ctx, cmd, workDir, container.PullCredentials{})
 
@@ -96,7 +96,7 @@ func TestDockerLifecycleControl(t *testing.T) {
 	env := testenv.GetTestEnv(t)
 	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
 	cacheAuth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c := docker.NewDockerContainer(env, cacheAuth, dc, "docker.io/library/busybox", rootDir, cfg)
+	c := docker.NewDockerContainer(env, cacheAuth, dc, "mirror.gcr.io/library/busybox", rootDir, cfg)
 
 	isContainerRunning := false
 	t.Cleanup(func() {
@@ -115,7 +115,7 @@ func TestDockerLifecycleControl(t *testing.T) {
 
 	err = container.PullImageIfNecessary(
 		ctx, env, cacheAuth, c, container.PullCredentials{},
-		"docker.io/library/busybox",
+		"mirror.gcr.io/library/busybox",
 	)
 	require.NoError(t, err)
 
@@ -185,10 +185,10 @@ func TestDockerRun_Timeout_StdoutStderrStillVisible(t *testing.T) {
 	env := testenv.GetTestEnv(t)
 	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
 	cacheAuth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c := docker.NewDockerContainer(env, cacheAuth, dc, "docker.io/library/busybox", rootDir, cfg)
+	c := docker.NewDockerContainer(env, cacheAuth, dc, "mirror.gcr.io/library/busybox", rootDir, cfg)
 	// Ensure the image is cached
 	err = container.PullImageIfNecessary(
-		ctx, env, cacheAuth, c, container.PullCredentials{}, "docker.io/library/busybox")
+		ctx, env, cacheAuth, c, container.PullCredentials{}, "mirror.gcr.io/library/busybox")
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
@@ -239,10 +239,10 @@ func TestDockerExec_Timeout_StdoutStderrStillVisible(t *testing.T) {
 	env := testenv.GetTestEnv(t)
 	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
 	cacheAuth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c := docker.NewDockerContainer(env, cacheAuth, dc, "docker.io/library/busybox", rootDir, cfg)
+	c := docker.NewDockerContainer(env, cacheAuth, dc, "mirror.gcr.io/library/busybox", rootDir, cfg)
 	// Ensure the image is cached
 	err = container.PullImageIfNecessary(
-		ctx, env, cacheAuth, c, container.PullCredentials{}, "docker.io/library/busybox")
+		ctx, env, cacheAuth, c, container.PullCredentials{}, "mirror.gcr.io/library/busybox")
 	require.NoError(t, err)
 
 	err = c.Create(ctx, workDir)
@@ -299,10 +299,10 @@ func TestDockerExec_Stdio(t *testing.T) {
 	env := testenv.GetTestEnv(t)
 	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
 	cacheAuth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c := docker.NewDockerContainer(env, cacheAuth, dc, "docker.io/library/busybox", rootDir, cfg)
+	c := docker.NewDockerContainer(env, cacheAuth, dc, "mirror.gcr.io/library/busybox", rootDir, cfg)
 	err = container.PullImageIfNecessary(
 		ctx, env, cacheAuth, c, container.PullCredentials{},
-		"docker.io/library/busybox",
+		"mirror.gcr.io/library/busybox",
 	)
 	require.NoError(t, err)
 	err = c.Create(ctx, workDir)
@@ -348,7 +348,7 @@ func TestDockerRun_LongRunningProcess_CanGetAllLogs(t *testing.T) {
 	env := testenv.GetTestEnv(t)
 	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
 	cacheAuth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
-	c := docker.NewDockerContainer(env, cacheAuth, dc, "docker.io/library/busybox", rootDir, cfg)
+	c := docker.NewDockerContainer(env, cacheAuth, dc, "mirror.gcr.io/library/busybox", rootDir, cfg)
 
 	res := c.Run(ctx, cmd, workDir, container.PullCredentials{})
 


### PR DESCRIPTION
A follow up from #4341.
This helps us avoid the rate limit from docker.io.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
