### PR TITLE
Fix new usage count columns causing dropped updates during rollout

### DIFF
--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -313,7 +313,11 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, c collection
 			unsupportedField := ""
 			var unsupportedFieldValue any
 			for f, v := range fields {
-				if v == nil || v == "" {
+				// If a column that we don't yet know about has an empty label
+				// or is an int64 (i.e. counter value), then it's safe to
+				// update.
+				_, isInt64 := v.(int64)
+				if v == nil || v == "" || isInt64 {
 					continue
 				}
 				if _, ok := schema.FieldsByDBName[f]; !ok {


### PR DESCRIPTION
(NOTE: we have not dropped any usage updates yet! This is just preemptively fixing a bug that would cause dropped updates during an app rollout the next time we add new count columns to the usage table).

If adding a new field to `UsageCounts`, old apps that do not support the new field during a rollout will currently drop usage updates when they try to update a usage row but see that there is an unsupported column.

This is new behavior introduced by https://github.com/buildbuddy-io/buildbuddy/pull/4371 to make sure we don't misattribute usage counts to incorrect labels during app rollouts.

However, this behavior is not desired when adding new _count_ columns (as opposed to label columns), since the existing logic is forwards-compatible with unsupported count columns.

This PR corrects the undesired behavior by adding the following logic: if the unsupported field is an int64, then assume it's a count field, and it should be safe to update.

A downside to this approach is that our assumption can be broken in two ways:
* If we later decide to add an int64 column to the usage "key", since the column will be treated as a count rather than part of the key. In that case, we could potentially misattribute counts during a rollout.
* If we want a non-int64 count for some reason, we need to update the above logic to check for not only int64, but also the new type as well (e.g. float64) 

This PR adds some warnings to `tables.go` to make these limitations extra clear.

A more robust design that avoids these limitations would be to separate the usage key + counts into separate tables, but that would have the downside of making querying more difficult and potentially less performant.

**Related issues**: N/A
