### PR TITLE
[UFFD] Copy entire chunks when handling page faults with uffd handler

### DIFF
--- a/enterprise/server/remote_execution/blockio/blockio.go
+++ b/enterprise/server/remote_execution/blockio/blockio.go
@@ -262,6 +262,21 @@ func NewCOWStore(chunks []*Chunk, chunkSizeBytes, totalSizeBytes int64, dataDir 
 	}, nil
 }
 
+func (c *COWStore) GetRelativeOffsetFromChunkStart(offset uintptr) uintptr {
+	chunkStartOffset := c.chunkStartOffset(int64(offset))
+	chunkRelativeAddress := offset - uintptr(chunkStartOffset)
+	return chunkRelativeAddress
+}
+
+func (c *COWStore) GetChunkStartAddressAndSize(offset uintptr, write bool) (uintptr, int64, error) {
+	chunkStartOffset := c.chunkStartOffset(int64(offset))
+	chunkStartAddress, err := c.GetPageAddress(uintptr(chunkStartOffset), write)
+	if err != nil {
+		return 0, 0, err
+	}
+	return chunkStartAddress, c.chunkSizeBytes, nil
+}
+
 // GetPageAddress returns the memory address for the given byte offset into the store.
 //
 // This memory address can be used to handle a page fault with userfaultfd.

--- a/enterprise/server/remote_execution/blockio/blockio.go
+++ b/enterprise/server/remote_execution/blockio/blockio.go
@@ -272,15 +272,14 @@ func (c *COWStore) GetRelativeOffsetFromChunkStart(offset uintptr) uintptr {
 	return chunkRelativeAddress
 }
 
-// GetChunkStartAddressAndSize returns the start address of the chunk containing the input offset,
-// and the chunk size
-func (c *COWStore) GetChunkStartAddressAndSize(offset uintptr, write bool) (uintptr, int64, error) {
+// GetChunkStartAddress returns the start address of the chunk containing the input offset.
+func (c *COWStore) GetChunkStartAddress(offset uintptr, write bool) (uintptr, error) {
 	chunkStartOffset := c.chunkStartOffset(int64(offset))
 	chunkStartAddress, err := c.GetPageAddress(uintptr(chunkStartOffset), write)
 	if err != nil {
-		return 0, 0, err
+		return 0, err
 	}
-	return chunkStartAddress, c.chunkSizeBytes, nil
+	return chunkStartAddress, nil
 }
 
 // GetPageAddress returns the memory address for the given byte offset into the store.

--- a/enterprise/server/remote_execution/blockio/blockio.go
+++ b/enterprise/server/remote_execution/blockio/blockio.go
@@ -272,14 +272,15 @@ func (c *COWStore) GetRelativeOffsetFromChunkStart(offset uintptr) uintptr {
 	return chunkRelativeAddress
 }
 
-// GetChunkStartAddress returns the start address of the chunk containing the input offset.
-func (c *COWStore) GetChunkStartAddress(offset uintptr, write bool) (uintptr, error) {
+// GetChunkStartAddressAndSize returns the start address of the chunk containing the input offset,
+// and the chunk size
+func (c *COWStore) GetChunkStartAddressAndSize(offset uintptr, write bool) (uintptr, int64, error) {
 	chunkStartOffset := c.chunkStartOffset(int64(offset))
 	chunkStartAddress, err := c.GetPageAddress(uintptr(chunkStartOffset), write)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
-	return chunkStartAddress, nil
+	return chunkStartAddress, c.chunkSizeBytes, nil
 }
 
 // GetPageAddress returns the memory address for the given byte offset into the store.

--- a/enterprise/server/remote_execution/blockio/blockio.go
+++ b/enterprise/server/remote_execution/blockio/blockio.go
@@ -262,18 +262,19 @@ func NewCOWStore(chunks []*Chunk, chunkSizeBytes, totalSizeBytes int64, dataDir 
 	}, nil
 }
 
-// GetRelativeOffsetFromChunkStart returns the relative offset from the beginning of the chunk
+// GetRelativeOffsetFromChunkStart returns the relative offset from the
+// beginning of the chunk
 //
-// Ex. Let's say there are 100B chunks. For input offset 205, chunkStartOffset would be 200,
-// and this would return 5
+// Ex. Let's say there are 100B chunks. For input offset 205, chunkStartOffset
+// would be 200, and this would return 5
 func (c *COWStore) GetRelativeOffsetFromChunkStart(offset uintptr) uintptr {
 	chunkStartOffset := c.chunkStartOffset(int64(offset))
 	chunkRelativeAddress := offset - uintptr(chunkStartOffset)
 	return chunkRelativeAddress
 }
 
-// GetChunkStartAddressAndSize returns the start address of the chunk containing the input offset,
-// and the chunk size
+// GetChunkStartAddressAndSize returns the start address of the chunk containing
+// the input offset, and the chunk size
 func (c *COWStore) GetChunkStartAddressAndSize(offset uintptr, write bool) (uintptr, int64, error) {
 	chunkStartOffset := c.chunkStartOffset(int64(offset))
 	chunkStartAddress, err := c.GetPageAddress(uintptr(chunkStartOffset), write)
@@ -283,7 +284,8 @@ func (c *COWStore) GetChunkStartAddressAndSize(offset uintptr, write bool) (uint
 	return chunkStartAddress, c.chunkSizeBytes, nil
 }
 
-// GetPageAddress returns the memory address for the given byte offset into the store.
+// GetPageAddress returns the memory address for the given byte offset into
+// the store.
 //
 // This memory address can be used to handle a page fault with userfaultfd.
 //

--- a/enterprise/server/remote_execution/blockio/blockio.go
+++ b/enterprise/server/remote_execution/blockio/blockio.go
@@ -262,12 +262,18 @@ func NewCOWStore(chunks []*Chunk, chunkSizeBytes, totalSizeBytes int64, dataDir 
 	}, nil
 }
 
+// GetRelativeOffsetFromChunkStart returns the relative offset from the beginning of the chunk
+//
+// Ex. Let's say there are 100B chunks. For input offset 205, chunkStartOffset would be 200,
+// and this would return 5
 func (c *COWStore) GetRelativeOffsetFromChunkStart(offset uintptr) uintptr {
 	chunkStartOffset := c.chunkStartOffset(int64(offset))
 	chunkRelativeAddress := offset - uintptr(chunkStartOffset)
 	return chunkRelativeAddress
 }
 
+// GetChunkStartAddressAndSize returns the start address of the chunk containing the input offset,
+// and the chunk size
 func (c *COWStore) GetChunkStartAddressAndSize(offset uintptr, write bool) (uintptr, int64, error) {
 	chunkStartOffset := c.chunkStartOffset(int64(offset))
 	chunkStartAddress, err := c.GetPageAddress(uintptr(chunkStartOffset), write)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -125,8 +125,8 @@ const (
 	// This is needed because the init binary needs some space to copy files around.
 	minScratchDiskSizeBytes = 64e6
 
-	// Chunk size to use when creating COW images from files. This is the chunk size that will be saved in the cache
-	cowChunkSizeBytes = 4096 * 1000
+	// Chunk size to use when creating COW images from files.
+	cowChunkSizeInPages = 1000
 
 	// The containerfs drive ID.
 	containerFSName  = "containerfs.ext4"
@@ -472,7 +472,7 @@ func MergeDiffSnapshot(ctx context.Context, baseSnapshotPath string, baseSnapsho
 	perThreadBytes = alignToMultiple(perThreadBytes, int64(bufSize))
 	if *enableUFFD {
 		// Ensure goroutines don't cross chunk boundaries and cause race conditions when writing
-		perThreadBytes = alignToMultiple(perThreadBytes, cowChunkSizeBytes)
+		perThreadBytes = alignToMultiple(perThreadBytes, cowChunkSizeBytes())
 	}
 	for i := 0; i < concurrency; i++ {
 		i := i
@@ -891,7 +891,7 @@ func (c *FirecrackerContainer) convertToCOW(ctx context.Context, filePath, chunk
 	if err := os.Mkdir(chunkDir, 0755); err != nil {
 		return nil, status.WrapError(err, "make chunk dir")
 	}
-	cow, err := blockio.ConvertFileToCOW(filePath, cowChunkSizeBytes, chunkDir)
+	cow, err := blockio.ConvertFileToCOW(filePath, cowChunkSizeBytes(), chunkDir)
 	if err != nil {
 		return nil, status.WrapError(err, "convert file to COW")
 	}
@@ -903,6 +903,10 @@ func (c *FirecrackerContainer) convertToCOW(ctx context.Context, filePath, chunk
 	size, _ := cow.SizeBytes()
 	log.CtxInfof(ctx, "COWStore conversion for %q (%d MB) completed in %s", filepath.Base(chunkDir), size/1e6, time.Since(start))
 	return cow, nil
+}
+
+func cowChunkSizeBytes() int64 {
+	return int64(os.Getpagesize() * cowChunkSizeInPages)
 }
 
 // hotSwapWorkspace unmounts the workspace drive from a running firecracker

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -125,8 +125,8 @@ const (
 	// This is needed because the init binary needs some space to copy files around.
 	minScratchDiskSizeBytes = 64e6
 
-	// Chunk size to use when creating COW images from files.
-	cowChunkSizeInPages = 1000
+	// Chunk size to use when creating COW images from files. This is the chunk size that will be saved in the cache
+	cowChunkSizeBytes = 4096 * 1000
 
 	// The containerfs drive ID.
 	containerFSName  = "containerfs.ext4"
@@ -472,7 +472,7 @@ func MergeDiffSnapshot(ctx context.Context, baseSnapshotPath string, baseSnapsho
 	perThreadBytes = alignToMultiple(perThreadBytes, int64(bufSize))
 	if *enableUFFD {
 		// Ensure goroutines don't cross chunk boundaries and cause race conditions when writing
-		perThreadBytes = alignToMultiple(perThreadBytes, cowChunkSizeBytes())
+		perThreadBytes = alignToMultiple(perThreadBytes, cowChunkSizeBytes)
 	}
 	for i := 0; i < concurrency; i++ {
 		i := i
@@ -891,7 +891,7 @@ func (c *FirecrackerContainer) convertToCOW(ctx context.Context, filePath, chunk
 	if err := os.Mkdir(chunkDir, 0755); err != nil {
 		return nil, status.WrapError(err, "make chunk dir")
 	}
-	cow, err := blockio.ConvertFileToCOW(filePath, cowChunkSizeBytes(), chunkDir)
+	cow, err := blockio.ConvertFileToCOW(filePath, cowChunkSizeBytes, chunkDir)
 	if err != nil {
 		return nil, status.WrapError(err, "convert file to COW")
 	}
@@ -903,10 +903,6 @@ func (c *FirecrackerContainer) convertToCOW(ctx context.Context, filePath, chunk
 	size, _ := cow.SizeBytes()
 	log.CtxInfof(ctx, "COWStore conversion for %q (%d MB) completed in %s", filepath.Base(chunkDir), size/1e6, time.Since(start))
 	return cow, nil
-}
-
-func cowChunkSizeBytes() int64 {
-	return int64(os.Getpagesize() * cowChunkSizeInPages)
 }
 
 // hotSwapWorkspace unmounts the workspace drive from a running firecracker

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -234,9 +234,7 @@ func (h *Handler) handle(ctx context.Context, memoryStore *blockio.COWStore) err
 		if err != nil {
 			return status.WrapError(err, "translate to store offset")
 		}
-
 		relOffset := memoryStore.GetRelativeOffsetFromChunkStart(faultStoreOffset)
-
 		hostAddr, allocatedLen, err := memoryStore.GetChunkStartAddressAndSize(uintptr(faultStoreOffset), false /*=write*/)
 		if err != nil {
 			return status.WrapError(err, "get backing page address")

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -22,6 +22,9 @@ import (
 */
 import "C"
 
+// Number of memory pages the handler should copy each time it resolves a page fault
+const uffdCopySizePages = 1000
+
 // UFFD macros - see README for more info
 const UFFDIO_COPY = 0xc028aa03
 
@@ -235,7 +238,7 @@ func (h *Handler) handle(ctx context.Context, memoryStore *blockio.COWStore) err
 			return status.WrapError(err, "translate to store offset")
 		}
 		relOffset := memoryStore.GetRelativeOffsetFromChunkStart(faultStoreOffset)
-		hostAddr, allocatedLen, err := memoryStore.GetChunkStartAddressAndSize(uintptr(faultStoreOffset), false /*=write*/)
+		hostAddr, err := memoryStore.GetChunkStartAddress(uintptr(faultStoreOffset), false /*write*/)
 		if err != nil {
 			return status.WrapError(err, "get backing page address")
 		}
@@ -254,7 +257,7 @@ func (h *Handler) handle(ctx context.Context, memoryStore *blockio.COWStore) err
 	}
 }
 
-// resolvePageFault copies `size` bytes of memory from a `Src` address to the faulting region `Dst`
+// resolvePageFault copies memory from a `Src` address to the faulting region `Dst`
 //
 // When complete, the UFFDIO_COPY call wakes up the process that triggered the page fault (When a process
 // attempts to access unallocated memory, it triggers a page fault and hangs until it has been resolved)
@@ -264,7 +267,7 @@ func resolvePageFault(uffd uintptr, faultingRegion uint64, src uint64, size uint
 	copyData := uffdioCopy{
 		Dst: faultingRegion,
 		Src: src,
-		Len: uint64(size),
+		Len: uint64(copySizeBytes()),
 	}
 	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uffd, UFFDIO_COPY, uintptr(unsafe.Pointer(&copyData)))
 	if errno != 0 {
@@ -337,4 +340,10 @@ func guestMemoryAddrToStoreOffset(addr uintptr, mappings []GuestRegionUFFDMappin
 		return m.Offset + relativeOffset, nil
 	}
 	return 0, status.InternalErrorf("page address 0x%x not found in guest region UFFD mappings", addr)
+}
+
+// Number of bytes the handler should copy each time it resolves a page fault
+// This should be a multiple of the page size
+func copySizeBytes() int64 {
+	return int64(os.Getpagesize() * uffdCopySizePages)
 }


### PR DESCRIPTION
To optimize performance of the UFFD handler, copy an entire chunk of memory when handling page faults, as opposed to just one page. This will reduce the overhead of having to make lots of copy calls for small memory ranges

A chunk size of 1000 memory pages yielded the best performance results in my testing. Some test results:

**Without UFFD:**
Initial pause: ~1s
Subsequent pauses: ~220ms
LoadSnapshot: ~420ms
Unpause: ~420ms

**UFFD loading 1 page at a time:**
Initial pause: ~2.9s
Subsequent pause: ~2.4s
Initial LoadSnapshot: ~2s
Subsequent LoadSnapshot: ~1.3s
Initial Unpause: ~2s
Subsequent Unpause: ~1.3s

**UFFD Loading 512KB chunks:**
Initial pause: ~2.7s
Subsequent pause: ~2.3s
LoadSnapshot: ~565ms
Unpause: ~565ms

**[Chosen] UFFD Loading 1000 page chunks:**
Initial pause: ~2.7s
Subsequent pause: ~2s
LoadSnapshot: ~190ms
Unpause: ~190ms

**UFFD Loading 1500 page chunks:**
Initial pause: ~2.7s
Subsequent pause: ~2s
LoadSnapshot: ~225ms
Unpause: ~225ms
