### PR TITLE
Handle aws errors the way they're supposed to be handled

### DIFF
--- a/server/backends/blobstore/aws/BUILD
+++ b/server/backends/blobstore/aws/BUILD
@@ -19,7 +19,7 @@ go_library(
         "@com_github_aws_aws_sdk_go_v2_credentials//stscreds",
         "@com_github_aws_aws_sdk_go_v2_feature_s3_manager//:manager",
         "@com_github_aws_aws_sdk_go_v2_service_s3//:s3",
+        "@com_github_aws_aws_sdk_go_v2_service_s3//types",
         "@com_github_aws_aws_sdk_go_v2_service_sts//:sts",
-        "@com_github_aws_smithy_go//:smithy-go",
     ],
 )


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

When I initially committed this error handling, I had not found the way AWS SDK v2 errors were meant to be handled, so it was clumsy and inelegant.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
