### PR TITLE
Add API to lookup a single API key.

### DIFF
--- a/enterprise/app/auditlogs/auditlogs.tsx
+++ b/enterprise/app/auditlogs/auditlogs.tsx
@@ -142,6 +142,10 @@ export default class AuditLogsComponent extends React.Component<{}, State> {
     switch (action) {
       case Action.CREATE:
         return "Create";
+      case Action.ACCESS:
+        return "Access";
+      case Action.GET:
+        return "Get";
       case Action.DELETE:
         return "Delete";
       case Action.UPDATE:

--- a/proto/api_key.proto
+++ b/proto/api_key.proto
@@ -81,6 +81,20 @@ message GetApiKeysResponse {
   repeated ApiKey api_key = 2;
 }
 
+message GetApiKeyRequest {
+  context.RequestContext request_context = 1;
+
+  // The ID of the API key to retrieve.
+  // ex: "AK123456789"
+  string api_key_id = 2;
+}
+
+message GetApiKeyResponse {
+  context.ResponseContext response_context = 1;
+
+  ApiKey api_key = 2;
+}
+
 message UpdateApiKeyRequest {
   context.RequestContext request_context = 1;
 

--- a/proto/auditlog.proto
+++ b/proto/auditlog.proto
@@ -89,6 +89,7 @@ message Entry {
     github.UnlinkRepoRequest unlink_repo = 10;
     workflow.ExecuteWorkflowRequest execute_workflow = 11;
     secrets.UpdateSecretRequest update_secret = 12;
+    api_key.GetApiKeyRequest get_api_key = 13;
   }
   message Request {
     APIRequest api_request = 1;

--- a/proto/auditlog.proto
+++ b/proto/auditlog.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package auditlog;
 
-import "proto/acl.proto";
 import "proto/api_key.proto";
 import "proto/context.proto";
 import "proto/encryption.proto";
@@ -47,14 +46,16 @@ enum ResourceType {
 enum Action {
   ACTION_UNKNOWN = 0;
   CREATE = 1;
-  UPDATE = 2;
-  DELETE = 3;
-  LIST = 4;
-  UPDATE_MEMBERSHIP = 5;
-  UPDATE_ENCRYPTION_CONFIG = 6;
-  LINK_GITHUB_REPO = 7;
-  UNLINK_GITHUB_REPO = 8;
-  EXECUTE_CLEAN_WORKFLOW = 9;
+  GET = 2;
+  ACCESS = 3;
+  UPDATE = 4;
+  DELETE = 5;
+  LIST = 6;
+  UPDATE_MEMBERSHIP = 7;
+  UPDATE_ENCRYPTION_CONFIG = 8;
+  LINK_GITHUB_REPO = 9;
+  UNLINK_GITHUB_REPO = 10;
+  EXECUTE_CLEAN_WORKFLOW = 11;
 }
 
 message ResourceID {

--- a/proto/buildbuddy_service.proto
+++ b/proto/buildbuddy_service.proto
@@ -76,6 +76,7 @@ service BuildBuddyService {
   // Org API Keys API
   rpc GetApiKeys(api_key.GetApiKeysRequest)
       returns (api_key.GetApiKeysResponse);
+  rpc GetApiKey(api_key.GetApiKeyRequest) returns (api_key.GetApiKeyResponse);
   rpc CreateApiKey(api_key.CreateApiKeyRequest)
       returns (api_key.CreateApiKeyResponse);
   rpc UpdateApiKey(api_key.UpdateApiKeyRequest)
@@ -86,6 +87,8 @@ service BuildBuddyService {
   // User API keys API
   rpc GetUserApiKeys(api_key.GetApiKeysRequest)
       returns (api_key.GetApiKeysResponse);
+  rpc GetUserApiKey(api_key.GetApiKeyRequest)
+      returns (api_key.GetApiKeyResponse);
   rpc CreateUserApiKey(api_key.CreateApiKeyRequest)
       returns (api_key.CreateApiKeyResponse);
   rpc UpdateUserApiKey(api_key.UpdateApiKeyRequest)

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -489,6 +489,34 @@ func (s *BuildBuddyServer) GetApiKeys(ctx context.Context, req *akpb.GetApiKeysR
 	return rsp, nil
 }
 
+func (s *BuildBuddyServer) GetApiKey(ctx context.Context, req *akpb.GetApiKeyRequest) (*akpb.GetApiKeyResponse, error) {
+	authDB := s.env.GetAuthDB()
+	if authDB == nil {
+		return nil, status.UnimplementedError("Not Implemented")
+	}
+	key, err := authDB.GetAPIKey(ctx, req.GetApiKeyId())
+	if err != nil {
+		return nil, err
+	}
+	if al := s.env.GetAuditLogger(); al != nil {
+		rid := &alpb.ResourceID{
+			Type: alpb.ResourceType_GROUP_API_KEY,
+			Id:   req.GetApiKeyId(),
+			Name: key.Label,
+		}
+		al.Log(ctx, rid, alpb.Action_ACCESS, req)
+	}
+	return &akpb.GetApiKeyResponse{
+		ApiKey: &akpb.ApiKey{
+			Id:                  key.APIKeyID,
+			Value:               key.Value,
+			Label:               key.Label,
+			Capability:          capabilities.FromInt(key.Capabilities),
+			VisibleToDevelopers: key.VisibleToDevelopers,
+		},
+	}, nil
+}
+
 func (s *BuildBuddyServer) CreateApiKey(ctx context.Context, req *akpb.CreateApiKeyRequest) (*akpb.CreateApiKeyResponse, error) {
 	authDB := s.env.GetAuthDB()
 	if authDB == nil {
@@ -613,6 +641,34 @@ func (s *BuildBuddyServer) GetUserApiKeys(ctx context.Context, req *akpb.GetApiK
 		})
 	}
 	return rsp, nil
+}
+
+func (s *BuildBuddyServer) GetUserApiKey(ctx context.Context, req *akpb.GetApiKeyRequest) (*akpb.GetApiKeyResponse, error) {
+	authDB := s.env.GetAuthDB()
+	if authDB == nil {
+		return nil, status.UnimplementedError("Not Implemented")
+	}
+	key, err := authDB.GetAPIKey(ctx, req.GetApiKeyId())
+	if err != nil {
+		return nil, err
+	}
+	if al := s.env.GetAuditLogger(); al != nil {
+		rid := &alpb.ResourceID{
+			Type: alpb.ResourceType_USER_API_KEY,
+			Id:   req.GetApiKeyId(),
+			Name: key.Label,
+		}
+		al.Log(ctx, rid, alpb.Action_ACCESS, req)
+	}
+	return &akpb.GetApiKeyResponse{
+		ApiKey: &akpb.ApiKey{
+			Id:                  key.APIKeyID,
+			Value:               key.Value,
+			Label:               key.Label,
+			Capability:          capabilities.FromInt(key.Capabilities),
+			VisibleToDevelopers: key.VisibleToDevelopers,
+		},
+	}, nil
 }
 
 func (s *BuildBuddyServer) CreateUserApiKey(ctx context.Context, req *akpb.CreateApiKeyRequest) (*akpb.CreateApiKeyResponse, error) {

--- a/server/role_filter/role_filter.go
+++ b/server/role_filter/role_filter.go
@@ -78,8 +78,10 @@ var (
 		// Org API keys (implementation only returns developer-visible keys
 		// for developers; admins can see all keys).
 		"GetApiKeys",
+		"GetApiKey",
 		// User-level API keys
 		"GetUserApiKeys",
+		"GetUserApiKey",
 		"CreateUserApiKey",
 		"UpdateUserApiKey",
 		"DeleteUserApiKey",


### PR DESCRIPTION
Combined with https://github.com/buildbuddy-io/buildbuddy/pull/4351 we can switch to retrieving the API key value on demand instead of as part of the list request. This will provide more useful audit logs around API key use.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
