### PR TITLE
Add .bazelversion to internal repo sync

### DIFF
--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -27,9 +27,10 @@ jobs:
           token: ${{ secrets.BUILDBUDDY_APP_TOKEN }}
           path: buildbuddy-internal
 
-      - name: Update deps.bzl
+      - name: Copy files from OSS to internal
         run: |
           cp buildbuddy/deps.bzl buildbuddy-internal/deps.bzl
+          cp buildbuddy/.bazelversion buildbuddy-internal/.bazelversion
 
       - name: Update SHA
         run: |
@@ -43,6 +44,7 @@ jobs:
           git config --local user.name '${{ github.event.head_commit.author.name }}'
           git add WORKSPACE
           git add deps.bzl
+          git add .bazelversion
           cat <<EOF > message.txt
           🔄 ${{ github.event.head_commit.message }}
           Update buildbuddy-io/buildbuddy commit SHA


### PR DESCRIPTION
`.bazelversion` in the internal repo is at 6.0.0 but the OSS one is 6.2.1. This PR should keep these in sync automatically from now on.

**Related issues**: N/A
