### PR TITLE
.bazelrc: enable skymeld by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,3 @@
-# Skymeld merges the analysis phase and execution phase.
-# This allows build and test executions to start before the analysis phase finishes,
-# thus speeding up the build overall .
-build:skymeld --experimental_skymeld_ui
-build:skymeld --experimental_merged_skyframe_analysis_execution
-
 # Build with --config=local to send build logs to your local server
 build:local --bes_results_url=http://localhost:8080/invocation/
 build:local --bes_backend=grpc://localhost:1985
@@ -160,6 +154,11 @@ build --enable_runfiles
 # Use syscall to create symlink in-process.
 # Need to work around M1 Mac browser test issue https://github.com/bazelbuild/rules_webtesting/issues/438
 build --experimental_inprocess_symlink_creation
+
+# Skymeld merges the analysis phase and execution phase.
+# This allows build and test executions to start before the analysis phase finishes,
+# thus speeding up the build overall .
+build --experimental_merged_skyframe_analysis_execution
 
 # Don't run Docker and Firecracker tests by default, because they cannot be run on all environments
 # Firecracker tests can only be run on Linux machines with bare execution, and we want to avoid a hard dependency


### PR DESCRIPTION
Skymeld config helps us start build actions without having to wait for
all repository rules to finish executing in Analysis phase.

Effectively, this let us start the frontend builds earlier without
having to wait for the Go external dependencies and toolchain to finish
loading.

Some benchmarks

1. Building `//server` without remote cache

   ```bash
   > hyperfine --prepare 'bazel clean --async' \
               --warmup 1 \
               'bazel build --config=x -k --remote_instance_name="$RANDOM" server' \
               'bazel build --config=x -k --remote_instance_name="$RANDOM" --config=skymeld server'

   Benchmark 1: bazel build --config=x -k --remote_instance_name="$RANDOM" server
     Time (mean ± σ):     241.279 s ± 42.673 s    [User: 0.134 s, System: 0.149 s]
     Range (min … max):   169.694 s … 318.005 s    10 runs

   Benchmark 2: bazel build --config=x -k --remote_instance_name="$RANDOM" --config=skymeld server
     Time (mean ± σ):     213.551 s ± 75.335 s    [User: 0.118 s, System: 0.129 s]
     Range (min … max):   148.260 s … 400.258 s    10 runs

   Summary
     bazel build --config=x -k --remote_instance_name="$RANDOM" --config=skymeld server ran
       1.13 ± 0.45 times faster than bazel build --config=x -k --remote_instance_name="$RANDOM" server
   ```

2. Building `//server` with remote cache

   ```bash
   > hyperfine --prepare 'bazel clean --async' \
               --warmup 1 \
               'bazel build --config=x -k server' \
               'bazel build --config=x -k --config=skymeld server'

   Benchmark 1: bazel build --config=x -k server
     Time (mean ± σ):     19.282 s ±  0.473 s    [User: 0.014 s, System: 0.023 s]
     Range (min … max):   18.656 s … 20.218 s    10 runs

   Benchmark 2: bazel build --config=x -k --config=skymeld server
     Time (mean ± σ):     17.732 s ±  0.407 s    [User: 0.014 s, System: 0.023 s]
     Range (min … max):   17.118 s … 18.626 s    10 runs

   Summary
     bazel build --config=x -k --config=skymeld server ran
       1.09 ± 0.04 times faster than bazel build --config=x -k server
   ```

3. Testing everything with remote cache

   ```bash
   > hyperfine --prepare 'bazel clean --async' \
                   --warmup 1 \
                   'bazel build --config=x -k //...' \
                   'bazel build --config=x -k --config=skymeld //...'
   Benchmark 1: bazel build --config=x -k //...
     Time (mean ± σ):     27.113 s ±  1.020 s    [User: 0.014 s, System: 0.020 s]
     Range (min … max):   25.938 s … 28.833 s    10 runs

   Benchmark 2: bazel build --config=x -k --config=skymeld //...
     Time (mean ± σ):     25.349 s ±  1.155 s    [User: 0.014 s, System: 0.021 s]
     Range (min … max):   23.567 s … 27.314 s    10 runs

   Summary
     bazel build --config=x -k --config=skymeld //... ran
       1.07 ± 0.06 times faster than bazel build --config=x -k //...
   ```

Overall, using Skymeld gives a +7-14% speed improvement over the
existing setup.

Removed `--experimental_skymeld_ui` as it's a no-op flag.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
