### PR TITLE
Fix up github auth redirects

### DIFF
--- a/enterprise/server/githubauth/BUILD
+++ b/enterprise/server/githubauth/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//server/util/authutil",
         "//server/util/claims",
         "//server/util/cookie",
-        "//server/util/flagutil",
         "//server/util/log",
         "//server/util/status",
         "@com_github_golang_jwt_jwt//:jwt",

--- a/enterprise/server/githubauth/githubauth.go
+++ b/enterprise/server/githubauth/githubauth.go
@@ -14,7 +14,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/cookie"
-	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/golang-jwt/jwt"
@@ -27,10 +26,6 @@ const (
 	loginPath      = "/login/github/"
 	authPath       = "/auth/github/"
 	jwtDuration    = 24 * 365 * time.Hour
-)
-
-var (
-	jwtKey = flagutil.New("github.jwt_key", "", "The key to use when signing JWT tokens for github auth.", flagutil.SecretTag)
 )
 
 type authenticatedGitHubUser struct {
@@ -49,7 +44,7 @@ func NewGithubAuthenticator(env environment.Env) *githubAuthenticator {
 }
 
 func IsEnabled(env environment.Env) bool {
-	return githubapp.IsEnabled() && *jwtKey != ""
+	return githubapp.IsEnabled() && *github.JwtKey != ""
 }
 
 func (a *githubAuthenticator) Login(w http.ResponseWriter, r *http.Request) error {
@@ -308,12 +303,12 @@ func (a *githubAuthenticator) renewToken(ctx context.Context, authToken string) 
 }
 
 func jwtKeyFunc(token *jwt.Token) (interface{}, error) {
-	return []byte(*jwtKey), nil
+	return []byte(*github.JwtKey), nil
 }
 
 func assembleJWT(c jwt.Claims) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, c)
-	tokenString, err := token.SignedString([]byte(*jwtKey))
+	tokenString, err := token.SignedString([]byte(*github.JwtKey))
 	return tokenString, err
 }
 

--- a/server/backends/github/BUILD
+++ b/server/backends/github/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//server/http/interceptors",
         "//server/tables",
         "//server/util/authutil",
+        "//server/util/cookie",
         "//server/util/flagutil",
         "//server/util/log",
         "//server/util/perms",

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -20,6 +20,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/http/interceptors"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/cookie"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
@@ -32,6 +33,7 @@ import (
 
 var (
 	statusNameSuffix = flag.String("github.status_name_suffix", "", "Suffix to be appended to all reported GitHub status names. Useful for differentiating BuildBuddy deployments. For example: '(dev)' ** Enterprise only **")
+	JwtKey           = flagutil.New("github.jwt_key", "", "The key to use when signing JWT tokens for github auth.", flagutil.SecretTag)
 
 	// TODO: Mark these deprecated once the new GitHub app is implemented.
 
@@ -51,10 +53,9 @@ const (
 	FailureState State = "failure"
 	SuccessState State = "success"
 
-	stateCookieName    = "Github-State-Token"
-	redirectCookieName = "Github-Redirect-Url"
-	groupIDCookieName  = "Github-Linked-Group-ID"
-	userIDCookieName   = "Github-Linked-User-ID"
+	stateCookieName   = "Github-State-Token"
+	groupIDCookieName = "Github-Linked-Group-ID"
+	userIDCookieName  = "Github-Linked-User-ID"
 )
 
 // State represents a status value that GitHub's statuses API understands.
@@ -223,7 +224,7 @@ func (c *OAuthHandler) StartAuthFlow(w http.ResponseWriter, r *http.Request, red
 	setCookie(w, stateCookieName, state)
 	setCookie(w, userIDCookieName, userID)
 	setCookie(w, groupIDCookieName, groupID)
-	setCookie(w, redirectCookieName, redirectURL)
+	setCookie(w, cookie.RedirCookie, redirectURL)
 
 	var authURL string
 	if r.FormValue("install") == "true" && c.InstallURL != "" {
@@ -244,9 +245,11 @@ func (c *OAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, err := perms.AuthenticatedUser(r.Context(), c.env)
 	if err != nil {
 		// If not logged in to the app (e.g. when installing directly from
-		// GitHub), log in first, then come back here to complete the
-		// installation.
-		loginURL := fmt.Sprintf("/?redirect_url=%s", url.QueryEscape(r.URL.String()))
+		// GitHub), redirect to the account creation flow flow.
+		loginURL := fmt.Sprintf("/auth/github/?" + r.URL.RawQuery)
+		if *JwtKey == "" {
+			loginURL = fmt.Sprintf("/?redirect_url=%s", url.QueryEscape(r.URL.String()))
+		}
 		http.Redirect(w, r, loginURL, http.StatusTemporaryRedirect)
 		return
 	}
@@ -292,7 +295,7 @@ func (c *OAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	appRedirectURL := getState(r, redirectCookieName)
+	appRedirectURL := getState(r, cookie.RedirCookie)
 	if appRedirectURL == "" {
 		appRedirectURL = "/"
 	}
@@ -603,7 +606,7 @@ func redirectWithError(w http.ResponseWriter, r *http.Request, err error) {
 	redirectURL := &url.URL{Path: "/"}
 	// Respect the original redirect_url parameter that was set when initiating
 	// the flow.
-	if s := getState(r, redirectCookieName); s != "" {
+	if s := getState(r, cookie.RedirCookie); s != "" {
 		if u, err := url.Parse(s); err == nil {
 			redirectURL = u
 		}

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -245,7 +245,7 @@ func (c *OAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, err := perms.AuthenticatedUser(r.Context(), c.env)
 	if err != nil {
 		// If not logged in to the app (e.g. when installing directly from
-		// GitHub), redirect to the account creation flow flow.
+		// GitHub), redirect to the account creation flow.
 		loginURL := fmt.Sprintf("/auth/github/?" + r.URL.RawQuery)
 		if *JwtKey == "" {
 			loginURL = fmt.Sprintf("/?redirect_url=%s", url.QueryEscape(r.URL.String()))


### PR DESCRIPTION
This PR fixes two issues with the current Github auth setup relating to redirects:
1) This uses the standard `Redirect-Url` redirect cookie instead of the more specific `Github-Redirect-Url` so that Github logins with a redirect_url parameter set are correctly redirected after the user logs in.
2) If Github auth is enabled, and a user hits the `/auth/github/link/` endpoint but is not already logged in - redirect them to the github login flow instead of to `/`.