### PR TITLE
Add a flag that logs the output of podman pull operations

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -782,7 +782,6 @@ func (c *podmanCommandContainer) pullImage(ctx context.Context, creds container.
 	stdio := &container.Stdio{}
 	if *podmanPullLogLevel != "" {
 		stdio = &container.Stdio{
-			Stdin:  nil,
 			Stdout: log.Writer("[podman pull] "),
 			Stderr: log.Writer("[podman pull] "),
 		}


### PR DESCRIPTION
**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/2523