### PR TITLE
Fill eviction sample pool when approxlru is first created.

### DIFF
--- a/server/util/approxlru/BUILD
+++ b/server/util/approxlru/BUILD
@@ -20,5 +20,6 @@ go_test(
         ":approxlru",
         "//server/util/status",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_exp//slices",
     ],
 )

--- a/server/util/approxlru/approxlru.go
+++ b/server/util/approxlru/approxlru.go
@@ -311,8 +311,13 @@ func (l *LRU[T]) evict() (*Sample[T], error) {
 	// Resample every time we evict keys.
 	// N.B. We might end up evicting less than deletesPerEviction keys below
 	// but sampling extra keys is harmless.
+	numToSample := l.deletesPerEviction
+	// Fill the pool if it's empty.
+	if len(l.samplePool) == 0 {
+		numToSample = l.samplePoolSize
+	}
 	start := time.Now()
-	if err := l.resampleK(l.deletesPerEviction); err != nil {
+	if err := l.resampleK(numToSample); err != nil {
 		return nil, err
 	}
 	if l.evictionResampleLatencyUsec != nil {


### PR DESCRIPTION
Adjust eviction test to check that evicted entries are older than 95% of the remaining entries rather than strictly comparing to the oldest entry.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
