### PR TITLE
docker: use ContainerAttach to capture std{out,err}

### DIFF
--- a/enterprise/server/remote_execution/containers/docker/BUILD
+++ b/enterprise/server/remote_execution/containers/docker/BUILD
@@ -23,6 +23,7 @@ go_library(
         "@com_github_docker_go_units//:go-units",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/enterprise/server/remote_execution/containers/docker/docker_test.go
+++ b/enterprise/server/remote_execution/containers/docker/docker_test.go
@@ -197,8 +197,8 @@ func TestDockerRun_Timeout_StdoutStderrStillVisible(t *testing.T) {
 	res := c.Run(ctx, cmd, workDir, container.PullCredentials{})
 
 	assert.True(
-		t, status.IsDeadlineExceededError(res.Error),
-		"expected DeadlineExceeded error, got: %s", res.Error)
+		t, status.IsUnavailableError(res.Error),
+		"expected UnavailableError error, got: %s", res.Error)
 	assert.Less(
 		t, res.ExitCode, 0,
 		"if timed out, exit code should be < 0 (unset)")


### PR DESCRIPTION
Our previous approach was prone to race conditions between the container
starting up and our call to `ContainerLogs` API. In the case where we call
the log API before container actually started, we get no outputs.  This
resulted in flaky tests observed in our CI.

Switch to use `ContainerAttach` API to capture the container outputs as
they are streamed out to reliably obtain the logs.


<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
