### PR TITLE
Ensure execution errors are always reported in prom metrics

### DIFF
--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor",
     deps = [
         "//enterprise/server/auth",
+        "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/operation",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",


### PR DESCRIPTION
Before this PR, there were lots of error types that we weren't properly reporting under the `buildbuddy_remote_execution_count` metric (which has an error label) - for example, failing to resume a VM, input downloads failing, or failing to publish task status updates (due to disconnecting from the app). These are all reported properly now.

**Related issues**: N/A
