### PR TITLE
Use same CLI version in buildfix and checkstyle

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: gazelle
         run: |
           # Invoke gazelle via bb fix for TypeScript support
-          cli/install.sh tags/5.0.18
+          cli/install.sh tags/5.0.20  # keep in sync with buildfix.sh
           bb version
           bb fix -mode diff > gazelle-diff.txt || true
           echo "gazelle diff:"

--- a/buildfix.sh
+++ b/buildfix.sh
@@ -62,11 +62,8 @@ fi
 
 if ((GAZELLE)); then
   echo "Fixing BUILD deps with gazelle..."
-  CLI_LATEST_VERSION=$(
-    curl -fsSL https://api.github.com/repos/buildbuddy-io/bazel/releases/latest |
-      perl -nle 'if (/"tag_name": "(.*?)"/){ print $1 }'
-  )
-  USE_BAZEL_VERSION="buildbuddy-io/$CLI_LATEST_VERSION" bazel fix
+  CLI_VERSION="5.0.20" # keep in sync with checkstyle.yaml
+  USE_BAZEL_VERSION="buildbuddy-io/$CLI_VERSION" bazel fix
 fi
 
 echo 'All done!'

--- a/enterprise/server/remote_execution/filecache/BUILD
+++ b/enterprise/server/remote_execution/filecache/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/metrics",
-        "//server/util/alert",
         "//server/util/disk",
         "//server/util/fastcopy",
         "//server/util/log",

--- a/enterprise/server/util/chunker/BUILD
+++ b/enterprise/server/util/chunker/BUILD
@@ -6,8 +6,5 @@ go_library(
     name = "chunker",
     srcs = ["chunker.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/chunker",
-    deps = [
-        "//server/util/status",
-        "@com_github_jotfs_fastcdc_go//:fastcdc-go",
-    ],
+    deps = ["@com_github_jotfs_fastcdc_go//:fastcdc-go"],
 )

--- a/server/util/lru/BUILD
+++ b/server/util/lru/BUILD
@@ -6,9 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/lru",
     visibility = ["//visibility:public"],
     deps = [
-        "//server/interfaces",
         "//server/util/hash",
-        "//server/util/log",
         "//server/util/status",
         "@com_github_cespare_xxhash_v2//:xxhash",
     ],


### PR DESCRIPTION
buildfix.sh produces a nonempty diff today, presumably because the CLI version in checkstyle doesn't match the one in buildfix.

**Related issues**: N/A
