### PR TITLE
Add a basic grpc proxy for tests

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -4148,6 +4148,12 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         sum = "h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=",
         version = "v0.0.0-20190716064945-2f068394615f",
     )
+    go_repository(
+        name = "com_github_mwitkow_grpc_proxy",
+        importpath = "github.com/mwitkow/grpc-proxy",
+        sum = "h1:62uLwA3l2JMH84liO4ZhnjTH5PjFyCYxbHLgXPaJMtI=",
+        version = "v0.0.0-20230212185441-f345521cb9c9",
+    )
 
     go_repository(
         name = "com_github_mxk_go_flowrate",

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.17
 	github.com/mdlayher/vsock v1.2.1
 	github.com/mitchellh/go-ps v1.0.0
+	github.com/mwitkow/grpc-proxy v0.0.0-20230212185441-f345521cb9c9
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc3
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1996,6 +1996,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mwitkow/grpc-proxy v0.0.0-20230212185441-f345521cb9c9 h1:62uLwA3l2JMH84liO4ZhnjTH5PjFyCYxbHLgXPaJMtI=
+github.com/mwitkow/grpc-proxy v0.0.0-20230212185441-f345521cb9c9/go.mod h1:MvMXoufZAtqExNexqi4cjrNYE9MefKddKylxjS+//n0=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nats-io/nats.go v1.8.1/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=
 github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7TDb/4=
@@ -2657,6 +2659,7 @@ golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
+golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
 golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
@@ -2846,6 +2849,7 @@ golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -3189,6 +3193,7 @@ google.golang.org/genproto v0.0.0-20210303154014-9728d6b83eeb/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210329143202-679c6ae281ee/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
+google.golang.org/genproto v0.0.0-20210401141331-865547bb08e2/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=

--- a/server/testutil/testgrpc/BUILD
+++ b/server/testutil/testgrpc/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "testgrpc",
+    testonly = 1,
+    srcs = ["testgrpc.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/testgrpc",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/util/grpc_client",
+        "//server/util/status",
+        "@com_github_mwitkow_grpc_proxy//proxy",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//metadata",
+    ],
+)

--- a/server/testutil/testgrpc/testgrpc.go
+++ b/server/testutil/testgrpc/testgrpc.go
@@ -1,0 +1,86 @@
+package testgrpc
+
+import (
+	"context"
+	"math/rand"
+	"net"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/mwitkow/grpc-proxy/proxy"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// StreamDirector decides how to connect a client request to a backend.
+type StreamDirector func(ctx context.Context, fullMethodName string) (ctxOut context.Context, conn *grpc.ClientConn, err error)
+
+// Proxy is a basic in-process gRPC L7 proxy for use in tests.
+type Proxy struct {
+	t        *testing.T
+	Addr     net.Addr
+	Director StreamDirector
+	Conn     *grpc.ClientConn
+}
+
+// StartProxy runs a test-scoped gRPC proxy. The given director func decides how
+// to connect a client request to a backend. If needed, the func can be nil
+// initially and reconfigured later by setting Director on the returned proxy.
+func StartProxy(t *testing.T, director StreamDirector) *Proxy {
+	lis, err := net.Listen("tcp", "0.0.0.0:0")
+	require.NoError(t, err)
+	p := &Proxy{
+		t:        t,
+		Addr:     lis.Addr(),
+		Director: director,
+	}
+	director = func(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error) {
+		require.NotNil(t, p.Director, "Proxy.Director is nil")
+		return p.Director(ctx, fullMethodName)
+	}
+	handler := grpc.UnknownServiceHandler(proxy.TransparentHandler(proxy.StreamDirector(director)))
+	server := grpc.NewServer(handler)
+	go server.Serve(lis)
+	t.Cleanup(server.Stop)
+	return p
+}
+
+func (p *Proxy) GRPCTarget() string {
+	return "grpc://" + p.Addr.String()
+}
+
+func (p *Proxy) Dial() *grpc.ClientConn {
+	conn, err := grpc_client.DialTarget(p.GRPCTarget())
+	require.NoError(p.t, err)
+	return conn
+}
+
+// RandomDialer returns a StreamDirector that dials a random backend from the
+// given list.
+func RandomDialer(targets ...string) proxy.StreamDirector {
+	return func(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error) {
+		var cc *grpc.ClientConn
+		var err error
+		r := rand.Intn(len(targets))
+		for i := 0; i < len(targets); i++ {
+			target := targets[(r+i)%len(targets)]
+			cc, err = grpc_client.DialTarget(target)
+			if status.IsUnavailableError(err) {
+				continue
+			}
+			if err != nil {
+				return nil, nil, err
+			}
+			break
+		}
+		if cc == nil {
+			return nil, nil, status.UnavailableError("RandomDialer: all backends are unavailable")
+		}
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			ctx = metadata.NewOutgoingContext(ctx, md.Copy())
+		}
+		return ctx, cc, nil
+	}
+}


### PR DESCRIPTION
I'm working on a small change that allows executors to retry task update streams so that tasks aren't affected as much during app rollouts. The test proxy will help us test this, because it will let us control how RPCs are routed to apps (by RPC name). Specifically, we want to make sure that the test connects to app 1 for PublishOperation streaming, then we can kill app 1 and make sure the execution still succeeds (as it should auto-reconnect to app 2).

**Related issues**: N/A
