### PR TITLE
Add a memory constraint to the minimum task size

### DIFF
--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -48,7 +48,8 @@ const (
 	// These are an extra safeguard against overscheduling, and help account
 	// for task overhead that is not measured explicitly (e.g. task setup).
 
-	MinimumMilliCPU = int64(250)
+	MinimumMilliCPU    = int64(250)
+	MinimumMemoryBytes = int64(6_000_000)
 
 	// Additional resources needed depending on task characteristics
 
@@ -378,6 +379,9 @@ func applyMinimums(size *scpb.TaskSize) *scpb.TaskSize {
 	clone := proto.Clone(size).(*scpb.TaskSize)
 	if clone.EstimatedMilliCpu < MinimumMilliCPU {
 		clone.EstimatedMilliCpu = MinimumMilliCPU
+	}
+	if clone.EstimatedMemoryBytes < MinimumMemoryBytes {
+		clone.EstimatedMemoryBytes = MinimumMemoryBytes
 	}
 	return clone
 }

--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -164,7 +164,7 @@ func TestSizer_Get_ShouldReturnRecordedUsageStats(t *testing.T) {
 		"subsequent milliCPU estimate should equal recorded milliCPU")
 }
 
-func TestEstimate_RespectsMinimumSize(t *testing.T) {
+func TestEstimate_RespectsMinimumCpuSize(t *testing.T) {
 	sz := tasksize.Estimate(&repb.ExecutionTask{
 		Command: &repb.Command{Platform: &repb.Platform{
 			Properties: []*repb.Platform_Property{{
@@ -173,6 +173,17 @@ func TestEstimate_RespectsMinimumSize(t *testing.T) {
 		}},
 	})
 	require.Equal(t, tasksize.MinimumMilliCPU, sz.EstimatedMilliCpu)
+}
+
+func TestEstimate_RespectsMinimumMemorySize(t *testing.T) {
+	sz := tasksize.Estimate(&repb.ExecutionTask{
+		Command: &repb.Command{Platform: &repb.Platform{
+			Properties: []*repb.Platform_Property{{
+				Name: "EstimatedMemory", Value: "1e3",
+			}},
+		}},
+	})
+	require.Equal(t, tasksize.MinimumMemoryBytes, sz.EstimatedMemoryBytes)
 }
 
 func TestSizer_RespectsMinimumSize(t *testing.T) {
@@ -209,4 +220,5 @@ func TestSizer_RespectsMinimumSize(t *testing.T) {
 
 	ts := sizer.Get(ctx, task)
 	assert.Equal(t, tasksize.MinimumMilliCPU, ts.GetEstimatedMilliCpu())
+	assert.Equal(t, tasksize.MinimumMemoryBytes, ts.GetEstimatedMemoryBytes())
 }


### PR DESCRIPTION
I got this number (6MB) from running `rbeperf` against dev. That tool runs a bunch of parallel remote executions that do a trivial task (running `echo`), and measures the time and (memory and CPU) usage stats reported. A sample output of the memory usage is below, but it was pretty reproducible, especially the memory component.

I checked out the CPU usage as well and it looks like our estimate of 250milliCPU is a bit high, we could probably bump it down to about 100milliCPU. One has to hack `rbeperf` a little bit to get the rate of CPU use by dividing the total CPU used by the execution time.

All of this is subject to the measurement error in `procstats`, of which there is a bit. But it's probably good enough for a first pass at least.

```
Peak memory usage:
  249856 - 831078 bytes: |||||||||||||||||||||
 831079 - 1412301 bytes: ||
1412302 - 1993524 bytes: |||
1993525 - 2574747 bytes: |
2574748 - 3155970 bytes: |||||||
3155971 - 3737193 bytes: ||||
3737194 - 4318416 bytes: ||||||||||
4318417 - 4899639 bytes: ||||||||
4899640 - 5480862 bytes: |||||||||
5480863 - 6062085 bytes: |||||||||||||||||||||||||||||||||||

P50: 4534272    P95: 5939200    P99: 6057984
```

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/2516
