### PR TITLE
During sampling, don't treat lack of groups as an error.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2581,6 +2581,9 @@ func (e *partitionEvictor) sampleGroup() {
 	}
 
 	groupID, err := e.randomGroupForEvictionSampling()
+	if status.IsNotFoundError(err) {
+		return
+	}
 	if err != nil {
 		log.Warningf("could not sample group in partition %q: %s", e.part.ID, err)
 		return
@@ -2618,7 +2621,7 @@ func (e *partitionEvictor) sample(ctx context.Context, k int) ([]*approxlru.Samp
 			if err == nil {
 				cacheType = rspb.CacheType_AC
 				groupID = gid
-			} else {
+			} else if !status.IsNotFoundError(err) {
 				log.Warningf("no groups to sample for %q: %s", e.part.ID, err)
 			}
 		}


### PR DESCRIPTION
Inactive partitions may not have any AC entries and thus nothing to sample.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
