### PR TITLE
proto/auditlog: remove unused acl deps

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -26,7 +26,6 @@ proto_library(
         "auditlog.proto",
     ],
     deps = [
-        ":acl_proto",
         ":api_key_proto",
         ":context_proto",
         ":encryption_proto",
@@ -633,7 +632,6 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/auditlog",
     proto = ":auditlog_proto",
     deps = [
-        ":acl_go_proto",
         ":api_key_go_proto",
         ":context_go_proto",
         ":encryption_go_proto",
@@ -1245,7 +1243,6 @@ ts_proto_library(
     name = "auditlog_ts_proto",
     proto = ":auditlog_proto",
     deps = [
-        ":acl_ts_proto",
         ":api_key_ts_proto",
         ":context_ts_proto",
         ":encryption_ts_proto",

--- a/proto/auditlog.proto
+++ b/proto/auditlog.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package auditlog;
 
-import "proto/acl.proto";
 import "proto/api_key.proto";
 import "proto/context.proto";
 import "proto/encryption.proto";


### PR DESCRIPTION
This fixes the complaint

```
INFO: From Generating Descriptor Set proto_library //proto:auditlog_proto:
proto/auditlog.proto:5:1: warning: Import proto/acl.proto is unused.
```

from build log.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
