### PR TITLE
Add gRPC origin header

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1638,6 +1638,10 @@ func writeBazelrc(path, invocationID string) error {
 		lines = append(lines, "build --remote_header=x-buildbuddy-api-key="+apiKey)
 		lines = append(lines, "build:buildbuddy_api_key --remote_header=x-buildbuddy-api-key="+apiKey)
 	}
+	if origin := os.Getenv("BB_GRPC_CLIENT_ORIGIN"); origin != "" {
+		lines = append(lines, "build --remote_header=x-buildbuddy-origin="+origin)
+		lines = append(lines, "build --bes_header=x-buildbuddy-origin="+origin)
+	}
 
 	// Primitive configs pointing to BB endpoints. These are purposely very
 	// fine-grained and do not include any options other than the backend

--- a/enterprise/server/remote_execution/platform/BUILD
+++ b/enterprise/server/remote_execution/platform/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//proto:remote_execution_go_proto",
         "//server/environment",
+        "//server/rpc/interceptors",
         "//server/util/flagutil",
         "//server/util/log",
         "//server/util/status",

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/rpc/interceptors"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -442,6 +443,15 @@ func ApplyOverrides(env environment.Env, executorProps *ExecutorProperties, plat
 		command.EnvironmentVariables = append(command.EnvironmentVariables, &repb.Command_EnvironmentVariable{
 			Name:  name,
 			Value: value,
+		})
+	}
+
+	// TODO: find a cleaner way to set the origin header, other than by
+	// forwarding an env var to the runner.
+	if platformProps.WorkflowID != "" {
+		command.EnvironmentVariables = append(command.EnvironmentVariables, &repb.Command_EnvironmentVariable{
+			Name:  "BB_GRPC_CLIENT_ORIGIN",
+			Value: interceptors.ClientOrigin(),
 		})
 	}
 

--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -37,6 +37,7 @@ var (
 	once              sync.Once
 
 	enableGRPCMetricsByGroupID = flag.Bool("app.enable_grpc_metrics_by_group_id", false, "If enabled, grpc metrics by group ID will be recorded")
+	origin                     = flag.String("grpc_client_origin_header", "", "Header value to set for x-buildbuddy-origin.")
 )
 
 func init() {
@@ -44,6 +45,10 @@ func init() {
 		"x-buildbuddy-jwt": "x-buildbuddy-jwt",
 		"build.bazel.remote.execution.v2.requestmetadata-bin": "build.bazel.remote.execution.v2.requestmetadata-bin",
 	}
+}
+
+func ClientOrigin() string {
+	return *origin
 }
 
 type wrappedServerStreamWithContext struct {
@@ -134,6 +139,9 @@ func setHeadersFromContext(ctx context.Context) context.Context {
 		if contextVal, ok := ctx.Value(contextKey).(string); ok {
 			ctx = metadata.AppendToOutgoingContext(ctx, headerName, contextVal)
 		}
+	}
+	if *origin != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-origin", *origin)
 	}
 	return ctx
 }

--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -47,6 +47,8 @@ func init() {
 	}
 }
 
+// ClientOrigin returns the configured value of x-buildbuddy-origin that will be
+// set on *outgoing* gRPC requests.
 func ClientOrigin() string {
 	return *origin
 }


### PR DESCRIPTION
This will apply to all `executor -> app` requests (as long as the dial is done with `grpc_client.DialTarget()`). The executor will also set an env var to set the origin header for both the "outer" workflow invocation BES stream request as well as the inner one, along with any cache requests on the inner invocation.

**Related issues**: N/A
