### PR TITLE
Stop the UFFD handler from running in the background when the VM is paused

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -136,6 +136,7 @@ go_test(
     tags = [
         "bare",  # Firecracker tests must be run with bare execution so they aren't nested within another container
         # TODO: enable on CI once we fix race conditions and timeouts
+        "manual",
         "no-sandbox",  # Firecracker is not compatible with Bazel's sandbox environment
     ],
     target_compatible_with = [

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -136,7 +136,6 @@ go_test(
     tags = [
         "bare",  # Firecracker tests must be run with bare execution so they aren't nested within another container
         # TODO: enable on CI once we fix race conditions and timeouts
-        "manual",
         "no-sandbox",  # Firecracker is not compatible with Bazel's sandbox environment
     ],
     target_compatible_with = [

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -94,34 +94,37 @@ func NewHandler() (*Handler, error) {
 // Start fulfills UFFD requests using the given memory store. If the UFFD object has not already
 // been initialized, it will also listen on the given socket path for Firecracker's UFFD initialization message
 func (h *Handler) Start(ctx context.Context, socketPath string, memoryStore *blockio.COWStore) error {
-	if h.quitChan == nil {
-		// Create a FD that can be used to terminate Poll early
-		pipeRead, pipeWrite, err := os.Pipe()
-		if err != nil {
-			return status.WrapError(err, "create early-termination fd")
-		}
-		h.earlyTerminationReader = pipeRead
-		h.earlyTerminationWriter = pipeWrite
-
-		// Initialize quitChan. Stop() will wait until this is closed to verify the handler has completed handling
-		// open requests
-		h.quitChan = make(chan struct{}, 0)
-
-		go func() {
-			if h.uffd == 0 {
-				// Get uffd sent from firecracker
-				err = h.receiveSetupMsg(ctx, socketPath)
-				if err != nil {
-					log.CtxErrorf(ctx, "Failed to receive setup message from firecracker: %s", err)
-					return
-				}
-			}
-
-			if err = h.handle(ctx, memoryStore); err != nil {
-				log.CtxErrorf(ctx, "Failed to handle firecracker memory requests: %s", err)
-			}
-		}()
+	if h.quitChan != nil {
+		log.Info("UFFD handler was already running when Start() was called")
+		return nil
 	}
+
+	// Create a FD that can be used to terminate Poll early
+	pipeRead, pipeWrite, err := os.Pipe()
+	if err != nil {
+		return status.WrapError(err, "create early-termination fd")
+	}
+	h.earlyTerminationReader = pipeRead
+	h.earlyTerminationWriter = pipeWrite
+
+	// Initialize quitChan. Stop() will wait until this is closed to verify the handler has completed handling
+	// open requests
+	h.quitChan = make(chan struct{}, 0)
+
+	go func() {
+		if h.uffd == 0 {
+			// Get uffd sent from firecracker
+			err = h.receiveSetupMsg(ctx, socketPath)
+			if err != nil {
+				log.CtxErrorf(ctx, "Failed to receive setup message from firecracker: %s", err)
+				return
+			}
+		}
+
+		if err = h.handle(ctx, memoryStore); err != nil {
+			log.CtxErrorf(ctx, "Failed to handle firecracker memory requests: %s", err)
+		}
+	}()
 	return nil
 }
 

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -78,7 +78,7 @@ type setupMessage struct {
 // When loading a firecracker memory snapshot, this userfaultfd handler can be used to handle page faults for the VM.
 // This handler uses a blockio.COWStore to manage the snapshot - allowing it to be served remotely, compressed, etc.
 type Handler struct {
-	wg sync.WaitGroup
+	quitChan chan struct{}
 
 	earlyTerminationReader *os.File
 	earlyTerminationWriter *os.File

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -212,6 +212,8 @@ func (h *Handler) handle(ctx context.Context, memoryStore *blockio.COWStore) err
 		}
 
 		// Poll UFFD for messages
+		// Poll blocks until a message is ready to be read. A timeout is necessary so that if the handler receives
+		// a shutdown message on quitChan while Poll is waiting, Poll will exit and restart the loop to check quitChan
 		_, pollErr := unix.Poll(pollFDs, 500 /* timeout in ms */)
 		if pollErr != nil {
 			if pollErr == unix.EINTR {

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -93,6 +93,8 @@ func NewHandler() (*Handler, error) {
 
 // Start fulfills UFFD requests using the given memory store. If the UFFD object has not already
 // been initialized, it will also listen on the given socket path for Firecracker's UFFD initialization message
+//
+// This method is idempotent. If the handler is already running, it will not do anything
 func (h *Handler) Start(ctx context.Context, socketPath string, memoryStore *blockio.COWStore) error {
 	if h.quitChan != nil {
 		log.Info("UFFD handler was already running when Start() was called")
@@ -304,6 +306,10 @@ func pageStartAddress(addr uint64, pageSize int) uintptr {
 	return uintptr(addr & ^(uint64(pageSize) - 1))
 }
 
+// Stops the background thread listening for page fault notifications. The UFFD object is saved on the handler
+// after it is initialized, so the handler can be restarted by calling Start() again
+//
+// This method is idempotent. If the handler is already stopped, it will not do anything
 func (h *Handler) Stop() error {
 	if h.earlyTerminationWriter == nil || h.earlyTerminationReader == nil || h.quitChan == nil {
 		log.Info("UFFD handler was already stopped when Stop() was called")

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -88,8 +88,7 @@ type Handler struct {
 
 func NewHandler() (*Handler, error) {
 	return &Handler{
-		wg:       sync.WaitGroup{},
-		quitChan: make(chan struct{}, 0),
+		wg: sync.WaitGroup{},
 	}, nil
 }
 
@@ -205,16 +204,8 @@ func (h *Handler) handle(ctx context.Context, memoryStore *blockio.COWStore) err
 	}
 
 	for {
-		select {
-		case <-h.quitChan:
-			return nil
-		default:
-		}
-
 		// Poll UFFD for messages
-		// Poll blocks until a message is ready to be read. A timeout is necessary so that if the handler receives
-		// a shutdown message on quitChan while Poll is waiting, Poll will exit and restart the loop to check quitChan
-		_, pollErr := unix.Poll(pollFDs, 500 /* timeout in ms */)
+		_, pollErr := unix.Poll(pollFDs, -1)
 		if pollErr != nil {
 			if pollErr == unix.EINTR {
 				// Poll call was interrupted by another signal - retry

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -94,18 +94,6 @@ func NewHandler() (*Handler, error) {
 // Start fulfills UFFD requests using the given memory store. If the UFFD object has not already
 // been initialized, it will also listen on the given socket path for Firecracker's UFFD initialization message
 func (h *Handler) Start(ctx context.Context, socketPath string, memoryStore *blockio.COWStore) error {
-	if h.uffd == 0 {
-		// Get uffd sent from firecracker
-		err := h.receiveSetupMsg(ctx, socketPath)
-		if err != nil {
-			return status.WrapError(err, "receive setup message from firecracker")
-		}
-	}
-
-	// Initialize quitChan. Stop() will wait until this is closed to verify the handler has completed handling
-	// open requests
-	h.quitChan = make(chan struct{}, 0)
-
 	// Create a FD that can be used to terminate Poll early
 	pipeRead, pipeWrite, err := os.Pipe()
 	if err != nil {
@@ -114,8 +102,21 @@ func (h *Handler) Start(ctx context.Context, socketPath string, memoryStore *blo
 	h.earlyTerminationReader = pipeRead
 	h.earlyTerminationWriter = pipeWrite
 
+	// Initialize quitChan. Stop() will wait until this is closed to verify the handler has completed handling
+	// open requests
+	h.quitChan = make(chan struct{}, 0)
+
 	go func() {
-		if err := h.handle(ctx, memoryStore); err != nil {
+		if h.uffd == 0 {
+			// Get uffd sent from firecracker
+			err = h.receiveSetupMsg(ctx, socketPath)
+			if err != nil {
+				log.CtxErrorf(ctx, "Failed to receive setup message from firecracker: %s", err)
+				return
+			}
+		}
+
+		if err = h.handle(ctx, memoryStore); err != nil {
 			log.CtxErrorf(ctx, "Failed to handle firecracker memory requests: %s", err)
 		}
 	}()

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -207,13 +207,12 @@ func (h *Handler) handle(ctx context.Context, memoryStore *blockio.COWStore) err
 	for {
 		select {
 		case <-h.quitChan:
-			h.wg.Done()
 			return nil
 		default:
 		}
 
 		// Poll UFFD for messages
-		_, pollErr := unix.Poll(pollFDs, -1)
+		_, pollErr := unix.Poll(pollFDs, 500 /* timeout in ms */)
 		if pollErr != nil {
 			if pollErr == unix.EINTR {
 				// Poll call was interrupted by another signal - retry

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"net"
 	"os"
-	"sync"
 	"syscall"
 	"unsafe"
 
@@ -87,9 +86,7 @@ type Handler struct {
 }
 
 func NewHandler() (*Handler, error) {
-	return &Handler{
-		wg: sync.WaitGroup{},
-	}, nil
+	return &Handler{}, nil
 }
 
 // Start starts a goroutine to listen on the given socket path for Firecracker's


### PR DESCRIPTION
Stop the UFFD handler from running in the background when the VM is paused so it isn't wasting resources. Also add support to the UFFD handler so that it can be stopped and restarted using the same uffd object

This also fixes a race condition. For some reason, there can still be page faults when the VM is paused. I wonder if there is some lightweight process that continues to run on the paused VM to listen for API requests or something

The race condition occurs when the background UFFD thread tries to serve a page fault and read from a blockio chunk. At the same time, in MergeDiffSnapshot we are creating copies of dirty chunks and unmapping the old chunks. The race occurs when we try to read from a chunk that is simultaneously being unmapped