### PR TITLE
Add logging for executions missing invocation ID

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -440,6 +440,9 @@ func (s *ExecutionServer) Dispatch(ctx context.Context, req *repb.ExecuteRequest
 	tracing.AddStringAttributeToCurrentSpan(ctx, "task_id", executionID)
 
 	invocationID := bazel_request.GetInvocationID(ctx)
+	if invocationID == "" {
+		log.CtxInfof(ctx, "Execution %q is missing invocation ID metadata. Request metadata: %+v", executionID, bazel_request.GetRequestMetadata(ctx))
+	}
 
 	if err := s.insertExecution(ctx, executionID, invocationID, generateCommandSnippet(command), repb.ExecutionStage_UNKNOWN); err != nil {
 		return "", err


### PR DESCRIPTION
We think that https://github.com/buildbuddy-io/buildbuddy-internal/issues/2533 is happening because the execution is missing an invocation ID. We depend on invocation ID in order to get failed action results for a particular invocation.

This will let us know whether the request metadata is missing entirely or if bazel possibly has a bug where it sets the metadata but just doesn't set the invocation ID in some cases, or if we have a bug somehow in the way that we're extracting the invocation ID.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/2533
