### PR TITLE
Transparently retry PublishOperation streams

### DIFF
--- a/enterprise/server/remote_execution/operation/BUILD
+++ b/enterprise/server/remote_execution/operation/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//server/remote_cache/digest",
         "//server/util/flagutil",
         "//server/util/log",
+        "//server/util/retry",
         "//server/util/status",
         "@org_golang_google_genproto//googleapis/longrunning",
         "@org_golang_google_grpc//status",

--- a/enterprise/server/remote_execution/operation/operation.go
+++ b/enterprise/server/remote_execution/operation/operation.go
@@ -3,11 +3,14 @@ package operation
 import (
 	"context"
 	"encoding/base64"
+	"io"
 	"net/url"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/retry"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"google.golang.org/genproto/googleapis/longrunning"
 	"google.golang.org/protobuf/proto"
@@ -16,6 +19,153 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	gstatus "google.golang.org/grpc/status"
 )
+
+const (
+	// Timeout for retrying a PublishOperation stream.
+	reconnectTimeout = 5 * time.Second
+)
+
+// retryingClient works like a PublishOperationClient but transparently
+// re-connects the stream when disconnected. The retryingClient does not re-dial
+// the backend; instead it depends on the client connection being terminated by
+// an L7 proxy.
+type retryingClient struct {
+	ctx          context.Context
+	client       repb.ExecutionClient
+	clientStream repb.Execution_PublishOperationClient
+	lastMsg      *longrunning.Operation
+}
+
+// Publish begins a PublishOperation stream and transparently reconnects the
+// stream if disconnected. After a disconnect (either in Send or CloseAndRecv),
+// it will re-publish the last sent message if applicable to ensure that the
+// server has acknowledged it.
+func Publish(ctx context.Context, client repb.ExecutionClient) (*retryingClient, error) {
+	clientStream, err := client.PublishOperation(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &retryingClient{
+		ctx:          ctx,
+		client:       client,
+		clientStream: clientStream,
+	}, nil
+}
+
+func (c *retryingClient) Context() context.Context {
+	return c.ctx
+}
+
+func (c *retryingClient) Send(msg *longrunning.Operation) error {
+	// If CloseAndRecv fails, this message isn't guaranteed to be ack'd by the
+	// server, so when retrying CloseAndRecv we need to re-send this message
+	// first to ensure it is ack'd.
+	c.lastMsg = msg
+	return c.sendWithRetry(msg)
+}
+
+func (c *retryingClient) sendWithRetry(msg *longrunning.Operation) error {
+	var lastErr error
+	retryCtx, cancel := context.WithTimeout(c.ctx, reconnectTimeout)
+	defer cancel()
+	r := retry.DefaultWithContext(retryCtx)
+	for r.Next() {
+		err := c.clientStream.Send(msg)
+		if err == nil {
+			return nil
+		}
+		if err != io.EOF {
+			return err
+		}
+		lastErr = err
+		log.CtxInfof(c.ctx, "PublishOperation stream disconnected; attempting to reconnect.")
+		// EOF means we got disconnected; reconnect and retry.
+		if err := c.reconnect(retryCtx); err != nil {
+			return status.WrapError(err, "failed to reconnect PublishOperation stream")
+		}
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	// Retry loop didn't even execute once; this should only happen if
+	// there is a ctx error. Return that error.
+	if retryCtx.Err() != nil {
+		return retryCtx.Err()
+	}
+	// Should never happen, but make sure we still return an error in this case.
+	return status.UnknownError("Send: unknown error")
+}
+
+func (s *retryingClient) reconnect(retryCtx context.Context) error {
+	r := retry.DefaultWithContext(retryCtx)
+	var lastErr error
+	for r.Next() {
+		// Note, we don't use the retryCtx here because it has a timeout, and we
+		// don't want this timeout to affect the RPC once it succeeds.
+		clientStream, err := s.client.PublishOperation(s.ctx)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		log.CtxInfof(s.ctx, "Successfully reconnected PublishOperation stream.")
+		s.clientStream = clientStream
+		return nil
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	// Retry loop didn't even execute once; this should only happen if
+	// there is a ctx error. Return that error.
+	if retryCtx.Err() != nil {
+		return retryCtx.Err()
+	}
+	// Should never happen, but make sure we still return an error in this case.
+	return status.UnknownError("reconnect: unknown error")
+}
+
+func (c *retryingClient) CloseAndRecv() (*repb.PublishOperationResponse, error) {
+	var lastErr error
+	retryCtx, cancel := context.WithTimeout(c.ctx, reconnectTimeout)
+	defer cancel()
+	r := retry.DefaultWithContext(retryCtx)
+	for r.Next() {
+		res, err := c.clientStream.CloseAndRecv()
+		if err == nil {
+			return res, nil
+		}
+		if err != io.EOF {
+			return nil, err
+		}
+		lastErr = err
+		log.CtxInfof(c.ctx, "PublishOperation stream disconnected; attempting to reconnect.")
+		// Stream is broken; reconnect and retry. If this fails, return the
+		// original error.
+		if err := c.reconnect(retryCtx); err != nil {
+			log.CtxWarningf(c.ctx, "Failed to reconnect operation stream: %s", err)
+			break
+		}
+		// Since CloseAndRecv failed, the server isn't guaranteed to have gotten
+		// our last published message, so publish it again. But if that fails,
+		// just return the original error.
+		if c.lastMsg == nil {
+			continue
+		}
+		if err := c.sendWithRetry(c.lastMsg); err != nil {
+			log.CtxWarningf(c.ctx, "Failed to retry un-acknowledged operation update: %s", err)
+			break
+		}
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	// Retry loop didn't even execute once; this should only happen if
+	// there is a ctx error. Return that error.
+	if retryCtx.Err() != nil {
+		return nil, retryCtx.Err()
+	}
+	// Should never happen, but make sure we still return an error in this case.
+	return nil, status.UnknownError("CloseAndRecv: unknown error")
+}
 
 func Assemble(stage repb.ExecutionStage_Value, name string, r *digest.ResourceName, er *repb.ExecuteResponse) (*longrunning.Operation, error) {
 	if r == nil || er == nil {

--- a/enterprise/server/scheduling/priority_task_scheduler/BUILD
+++ b/enterprise/server/scheduling/priority_task_scheduler/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/priority_task_scheduler",
     deps = [
         "//enterprise/server/remote_execution/executor",
+        "//enterprise/server/remote_execution/operation",
         "//enterprise/server/scheduling/priority_queue",
         "//enterprise/server/scheduling/task_leaser",
         "//enterprise/server/tasksize",

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/operation"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/priority_queue"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/task_leaser"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/tasksize"
@@ -318,7 +319,7 @@ func (q *PriorityTaskScheduler) runTask(ctx context.Context, st *repb.ScheduledT
 
 	execTask := st.ExecutionTask
 	ctx = q.propagateExecutionTaskValuesToContext(ctx, execTask)
-	clientStream, err := q.env.GetRemoteExecutionClient().PublishOperation(ctx)
+	clientStream, err := operation.Publish(ctx, q.env.GetRemoteExecutionClient())
 	if err != nil {
 		log.CtxWarningf(ctx, "Error opening publish operation stream: %s", err)
 		return true, status.WrapError(err, "failed to open execution status update stream")

--- a/enterprise/server/test/integration/remote_execution/BUILD
+++ b/enterprise/server/test/integration/remote_execution/BUILD
@@ -32,13 +32,18 @@ go_test(
         "//server/testutil/testfs",
         "//server/testutil/testmetrics",
         "//server/util/bazel",
+        "//server/util/grpc_client",
+        "//server/util/log",
         "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_google_uuid//:uuid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//metadata",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/timestamppb",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/enterprise/server/test/integration/remote_execution/rbeclient/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/util/log",
+        "//server/util/retry",
         "//server/util/status",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//status",

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -3,6 +3,7 @@ package remote_execution_test
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -29,11 +30,16 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testmetrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -1684,4 +1690,103 @@ func TestActionMerging(t *testing.T) {
 	cmd4 := rbe.Execute(cmd, &rbetest.ExecuteOpts{CheckCache: true, APIKey: rbe.APIKey1, InvocationID: "invocation4"})
 	op4 := cmd4.WaitAccepted()
 	require.Equal(t, op3, op4, "expected actions to be merged")
+}
+
+func TestAppShutdownDuringExecution(t *testing.T) {
+	// Set a short progress publish interval since we want to test killing an
+	// app while an update stream is in progress, and want to catch the error
+	// early.
+	flags.Set(t, "executor.task_progress_publish_interval", 50*time.Millisecond)
+	initialTasksStarted := testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount)
+
+	rbe := rbetest.NewRBETestEnv(t)
+
+	app1 := rbe.AddBuildBuddyServer()
+	app2 := rbe.AddBuildBuddyServer()
+	rbe.AddExecutor(t)
+
+	// Set up a custom proxy director that makes sure we choose app1 for the
+	// initial PublishOperation request, so that we can test stopping app1 while
+	// the task is in progress.
+	var mu sync.Mutex
+	app1Healthy := true
+	director := func(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error) {
+		mu.Lock()
+		target := ""
+		if app1Healthy && fullMethodName == "/build.bazel.remote.execution.v2.Execution/PublishOperation" {
+			log.Debugf("Routing %q to app 1", fullMethodName)
+			target = app1.GRPCAddress()
+		} else {
+			log.Debugf("Routing %q to app 2", fullMethodName)
+			target = app2.GRPCAddress()
+		}
+		mu.Unlock()
+
+		conn, err := grpc_client.DialSimple(target)
+		if err != nil {
+			return nil, nil, err
+		}
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			ctx = metadata.NewOutgoingContext(ctx, md.Copy())
+		}
+		return ctx, conn, nil
+	}
+	rbe.AppProxy.Director = director
+
+	var cmds []*rbetest.ControlledCommand
+	for i := 0; i < 10; i++ {
+		cmd := rbe.ExecuteControlledCommand(fmt.Sprintf("cmd-%d", i), &rbetest.ExecuteControlledOpts{
+			// Allow reconnecting with WaitExecution since the test will hard
+			// stop the app, which kills the Execute stream.
+			AllowReconnect: true,
+		})
+		cmds = append(cmds, cmd)
+	}
+	for _, cmd := range cmds {
+		cmd.WaitStarted()
+	}
+
+	// Maybe give enough time for a few progress updates to be published.
+	randSleepMillis(0, 100)
+
+	// Initiate a graceful shutdown of app 1 and have the proxy start directing
+	// to app2. As soon as the graceful shutdown starts, the executor should try
+	// to reconnect to a different app.
+	mu.Lock()
+	app1Healthy = false
+	mu.Unlock()
+	app1.Shutdown()
+
+	// Simulate the shutdown grace period elapsing, which should cause a
+	// hard stop of the gRPC server on app 1.
+	time.Sleep(100 * time.Millisecond)
+	app1.Stop()
+
+	eg := &errgroup.Group{}
+	for _, cmd := range cmds {
+		cmd := cmd
+		eg.Go(func() error {
+			// Maybe let the command continue execution for a bit, then exit.
+			randSleepMillis(0, 50)
+
+			cmd.Exit(0)
+			res := cmd.Wait()
+			require.Equal(t, 0, res.ExitCode)
+			return res.Err
+		})
+	}
+	err := eg.Wait()
+	require.NoError(t, err)
+
+	// Make sure we only ever started a single task execution per command (tasks
+	// should not be re-executed just because the app goes down).
+	tasksStarted := testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount) - initialTasksStarted
+	require.Equal(
+		t, float64(len(cmds)), tasksStarted,
+		"no tasks should have been retried")
+}
+
+func randSleepMillis(min, max int) {
+	r := rand.Int63n(int64(max-min)) + int64(min)
+	time.Sleep(time.Duration(r))
 }

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -1697,7 +1697,7 @@ func TestAppShutdownDuringExecution(t *testing.T) {
 	// app while an update stream is in progress, and want to catch the error
 	// early.
 	flags.Set(t, "executor.task_progress_publish_interval", 50*time.Millisecond)
-	initialTasksStarted := testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount)
+	initialTasksStartedCount := testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount)
 
 	rbe := rbetest.NewRBETestEnv(t)
 
@@ -1780,10 +1780,8 @@ func TestAppShutdownDuringExecution(t *testing.T) {
 
 	// Make sure we only ever started a single task execution per command (tasks
 	// should not be re-executed just because the app goes down).
-	tasksStarted := testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount) - initialTasksStarted
-	require.Equal(
-		t, float64(len(cmds)), tasksStarted,
-		"no tasks should have been retried")
+	tasksStartedCount := testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount) - initialTasksStartedCount
+	require.Equal(t, float64(len(cmds)), tasksStartedCount, "no tasks should have been retried")
 }
 
 func randSleepMillis(min, max int) {

--- a/server/resources/resources.go
+++ b/server/resources/resources.go
@@ -86,12 +86,18 @@ func Configure() error {
 			return status.InvalidArgumentErrorf("Only one of the 'executor.memory_bytes' config option and 'SYS_MEMORY_BYTES' environment variable may be set")
 		}
 		allocatedRAMBytes = *memoryBytes
+	} else {
+		// If flag is not set, fall back to env var, or total memory.
+		setSysRAMBytes()
 	}
 	if *milliCPU > 0 {
 		if os.Getenv(cpuEnvVarName) != "" {
 			return status.InvalidArgumentErrorf("Only one of the 'executor.millicpu' config option and 'SYS_MILLICPU' environment variable may be set")
 		}
 		allocatedCPUMillis = *milliCPU
+	} else {
+		// If flag is not set, fall back to env var, or available cores.
+		setSysMilliCPUCapacity()
 	}
 
 	log.Debugf("Set allocatedRAMBytes to %d", allocatedRAMBytes)


### PR DESCRIPTION
The executor currently has 2 streams to the app that it maintains for each task, each of which can be broken when the apps roll out and cause a task retry:
- LeaseTask
- PublishOperation

This PR allows us to transparently retry PublishOperation, which should roughly cut in half the number of times that a task has to be retried because of an app rollout / disconnect.

In a later PR we can retry LeaseTask as well, though this is more complex.

---

Description of the changes in this PR:
- There are two stream methods in a `PublishOperation` stream client: `Send()` publishes a status update, and `CloseAndRecv()` terminates the stream and waits for the server to ack that it has received all messages.
- Note, `Send()` does not guarantee that the server has ack'd the message. So if `Send()` fails, it's possible that _multiple_ messages actually failed to send.
- Luckily though, only the _last sent_ message matters, since newer messages effectively replace the execution status of older messages. e.g. if we drop both the IN_PROGRESS and COMPLETE messages, we only need to re-publish the COMPLETE message, since that reflects the current status of the task and the IN_PROGRESS update is no longer relevant.
- When sending a message, we buffer the last message sent, so that we can re-send it if needed.
- We re-send the buffered message if either Send() or CloseAndRecv() fails. It's especially important to re-send if CloseAndRecv() fails, because CloseAndRecv() succeeding is what guarantees that the server has acked the message. (`Send()` does not guarantee that the server received the message.)

**Related issues**: N/A
