### PR TITLE
Create Iterator after Lock

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1587,12 +1587,9 @@ func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceNa
 		return resources[i].GetDigest().GetHash() < resources[j].GetDigest().GetHash()
 	})
 
-	iter := db.NewIter(nil /*default iterOptions*/)
-	defer iter.Close()
-
 	buf := &bytes.Buffer{}
 	for _, r := range resources {
-		rc, err := p.reader(ctx, iter, r, 0, 0)
+		rc, err := p.reader(ctx, db, r, 0, 0)
 		if err != nil {
 			if status.IsNotFoundError(err) || os.IsNotExist(err) {
 				continue
@@ -1776,10 +1773,7 @@ func (p *PebbleCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompre
 	}
 	defer db.Close()
 
-	iter := db.NewIter(nil /*default iterOptions*/)
-	defer iter.Close()
-
-	rc, err := p.reader(ctx, iter, r, uncompressedOffset, limit)
+	rc, err := p.reader(ctx, db, r, uncompressedOffset, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -1944,11 +1938,11 @@ func (p *PebbleCache) writeMetadata(ctx context.Context, db pebble.IPebbleDB, ke
 		return err
 	}
 
-	iter := db.NewIter(nil /*default iterOptions*/)
-	defer iter.Close()
-
 	unlockFn := p.locker.Lock(key.LockID())
 	defer unlockFn()
+
+	iter := db.NewIter(nil /*default iterOptions*/)
+	defer iter.Close()
 
 	if oldMD, version, err := p.lookupFileMetadataAndVersion(ctx, iter, key); err == nil {
 		oldKeyBytes, err := key.Bytes(version)
@@ -2993,7 +2987,7 @@ type readCloser struct {
 	io.Closer
 }
 
-func (p *PebbleCache) reader(ctx context.Context, iter pebble.Iterator, r *rspb.ResourceName, uncompressedOffset int64, uncompressedLimit int64) (io.ReadCloser, error) {
+func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.ResourceName, uncompressedOffset int64, uncompressedLimit int64) (io.ReadCloser, error) {
 	fileRecord, err := p.makeFileRecord(ctx, r)
 	if err != nil {
 		return nil, err
@@ -3004,6 +2998,8 @@ func (p *PebbleCache) reader(ctx context.Context, iter pebble.Iterator, r *rspb.
 	}
 
 	unlockFn := p.locker.RLock(key.LockID())
+	iter := db.NewIter(nil /*default iterOptions*/)
+	defer iter.Close()
 	fileMetadata, err := p.lookupFileMetadata(ctx, iter, key)
 	unlockFn()
 	if err != nil {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
We should create the iterator after we lock the key. Otherwise, when a goroutine
1 tries to write a entry to pebble and another goroutine tries to read the same
entry. If the second goroutine obtains the iterator before the first go routine
finish writes, even when the second goroutine reads after the first goroutine
finished writing, it won't see the entry.

In https://github.com/buildbuddy-io/buildbuddy/pull/4337, I added some cases In
TestCompression_ParallelRequests where we are writing and reading the same
resource in different goroutines (i.e. when the testSize is small). This test 
become flakey due to this issue. After I applied this fix, the test is de-flaked.
