### PR TITLE
app/terminal: make search result count white

### DIFF
--- a/app/terminal/terminal.css
+++ b/app/terminal/terminal.css
@@ -128,6 +128,13 @@
   align-items: center;
   padding: 0 8px;
   color: white;
+}
+
+.terminal.light-terminal .search-result-count {
+  color: black;
+}
+
+.terminal .no-results {
   opacity: 0.3;
 }
 

--- a/app/terminal/terminal.css
+++ b/app/terminal/terminal.css
@@ -127,9 +127,7 @@
   display: flex;
   align-items: center;
   padding: 0 8px;
-}
-
-.terminal .no-results {
+  color: white;
   opacity: 0.3;
 }
 


### PR DESCRIPTION
The terminal is black so currently the search result count inherits it's
color from the parent.  Make the text white so it's readable.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
