### PR TITLE
Stop sending API Key value in List/GetBazelConfig APIs.

### DIFF
--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -461,11 +461,7 @@ func TestAPIKeyAuditLogs(t *testing.T) {
 		}
 		_, err = env.GetBuildBuddyServer().GetApiKeys(adminCtx, req)
 		require.NoError(t, err)
-		require.Len(t, al.GetAllEntries(), 1)
-		e := al.GetAllEntries()[0]
-		require.Equal(t, alpb.ResourceType_GROUP_API_KEY, e.Resource.GetType())
-		require.Equal(t, alpb.Action_LIST, e.Action)
-		require.Equal(t, req, e.Request)
+		require.Empty(t, al.GetAllEntries())
 	}
 
 	// Update Org API key.

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -476,16 +476,13 @@ func (s *BuildBuddyServer) GetApiKeys(ctx context.Context, req *akpb.GetApiKeysR
 		ApiKey: make([]*akpb.ApiKey, 0, len(tableKeys)),
 	}
 	for _, k := range tableKeys {
+		// API Key value must be retrieved via GetAPIKey API.
 		rsp.ApiKey = append(rsp.ApiKey, &akpb.ApiKey{
 			Id:                  k.APIKeyID,
-			Value:               k.Value,
 			Label:               k.Label,
 			Capability:          capabilities.FromInt(k.Capabilities),
 			VisibleToDevelopers: k.VisibleToDevelopers,
 		})
-	}
-	if al := s.env.GetAuditLogger(); al != nil {
-		al.Log(ctx, &alpb.ResourceID{Type: alpb.ResourceType_GROUP_API_KEY}, alpb.Action_LIST, req)
 	}
 	return rsp, nil
 }
@@ -633,9 +630,9 @@ func (s *BuildBuddyServer) GetUserApiKeys(ctx context.Context, req *akpb.GetApiK
 		ApiKey: make([]*akpb.ApiKey, 0, len(tableKeys)),
 	}
 	for _, k := range tableKeys {
+		// API Key value must be retrieved via GetAPIKey API.
 		rsp.ApiKey = append(rsp.ApiKey, &akpb.ApiKey{
 			Id:                  k.APIKeyID,
-			Value:               k.Value,
 			Label:               k.Label,
 			Capability:          capabilities.FromInt(k.Capabilities),
 			VisibleToDevelopers: k.VisibleToDevelopers,
@@ -904,6 +901,8 @@ func (s *BuildBuddyServer) GetBazelConfig(ctx context.Context, req *bzpb.GetBaze
 
 	credentials := make([]*bzpb.Credentials, len(groupAPIKeys))
 	for i, apiKey := range groupAPIKeys {
+		// API Key value must be retrieved via GetAPIKey API.
+		apiKey.Value = ""
 		credentials[i] = &bzpb.Credentials{
 			ApiKey: apiKey,
 		}

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -630,7 +630,7 @@ func (s *BuildBuddyServer) GetUserApiKeys(ctx context.Context, req *akpb.GetApiK
 		ApiKey: make([]*akpb.ApiKey, 0, len(tableKeys)),
 	}
 	for _, k := range tableKeys {
-		// API Key value must be retrieved via GetAPIKey API.
+		// API Key value must be retrieved via GetUserAPIKey API.
 		rsp.ApiKey = append(rsp.ApiKey, &akpb.ApiKey{
 			Id:                  k.APIKeyID,
 			Label:               k.Label,


### PR DESCRIPTION
UI will start calling GetAPIKey to retrieve the value.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
