### PR TITLE
Figure out template url and repo name if not set in repo creation flow

### DIFF
--- a/enterprise/app/repo/repo.tsx
+++ b/enterprise/app/repo/repo.tsx
@@ -40,13 +40,37 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
     githubInstallationsResponse: null,
     isCreating: false,
 
-    template: this.props.search.get("template") || "",
-    repoName: this.props.search.get("name") || "",
+    template: this.getTemplate(),
+    repoName: this.getRepoName(),
     private: true,
 
     repoResponse: null,
     workflowResponse: null,
   };
+
+  getTemplate() {
+    let paramTemplate = this.props.search.get("template");
+    if (paramTemplate) {
+      return paramTemplate;
+    }
+    let referrer = document.referrer;
+    if (referrer.startsWith("https://github.com/")) {
+      return referrer;
+    }
+    return "";
+  }
+
+  getRepoName() {
+    let paramRepoName = this.props.search.get("name");
+    if (paramRepoName) {
+      return paramRepoName;
+    }
+    let lastTemplatePath = this.getTemplate().replace(/\/$/, "").split("/").pop();
+    if (lastTemplatePath) {
+      return lastTemplatePath;
+    }
+    return "";
+  }
 
   fetchGithubInstallations() {
     if (!this.props.user || !this.props.user.githubToken) {


### PR DESCRIPTION
In the Heroku button does this: https://devcenter.heroku.com/articles/heroku-button#adding-the-heroku-button

If template isn't set, and you're being referred from a github repo - use that github repo as the template.

This allows you to create super simple "Deploy this repo" style buttons without any param fiddling.

Also adds some logic where if a repo name isn't provided, we use the last path component of the template url.

**Related issues**: N/A
