### PR TITLE
Fix `bb fix -mode diff`

### DIFF
--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -373,6 +373,12 @@ func CanonicalizeArgs(args []string) ([]string, error) {
 }
 
 func canonicalizeArgs(args []string, help BazelHelpFunc, onlyStartupOptions bool) ([]string, error) {
+	bazelCommand, _ := GetBazelCommandAndIndex(args)
+	if bazelCommand == "" {
+		// Not a bazel command; no startup args to canonicalize.
+		return args, nil
+	}
+
 	args, execArgs := arg.SplitExecutableArgs(args)
 	schema, err := getCommandLineSchema(args, help, onlyStartupOptions)
 	if err != nil {

--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -295,6 +295,15 @@ func TestTerminalOutput(t *testing.T) {
 	require.Contains(t, term.Render(), "\x1b[32mINFO")
 }
 
+func TestFix(t *testing.T) {
+	ws := testcli.NewWorkspace(t)
+
+	cmd := testcli.Command(t, ws, "fix", "-mode", "diff")
+	b, err := testcli.CombinedOutput(cmd)
+
+	require.NoError(t, err, "output:\n%s", string(b))
+}
+
 func retryUntilSuccess(t *testing.T, f func() error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
`bb fix -mode diff` fails with "failed to parse startup options: invalid options syntax: -mode"

**Related issues**: N/A
