### PR TITLE
Strip debug symbols for release builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -119,6 +119,7 @@ build:mac-workflows --config=workflows
 build:release-shared -c opt
 build:release-shared --stamp
 build:release-shared --define release=true
+build:release-shared --strip=always
 
 # Configuration used for Linux releases
 build:release --config=release-shared


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

This is to address release binary size.

Stripping symbols saves us 38 MB of a current 184 MB on the executor, 47 MB of a current 222 MB on the enterprise app, and 18 MB of a current 68 MB on the FOSS app.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: Addresses buildbuddy-io/buildbuddy-internal#2342
