### PR TITLE
Improve BufferedProtoReader throughput

### DIFF
--- a/server/util/protofile/BUILD
+++ b/server/util/protofile/BUILD
@@ -8,8 +8,6 @@ go_library(
     deps = [
         "//server/interfaces",
         "//server/util/status",
-        "@org_golang_google_grpc//codes",
-        "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//proto",
     ],
 )

--- a/tools/replay_invocation/BUILD
+++ b/tools/replay_invocation/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//server/util/protofile",
         "@com_github_google_uuid//:uuid",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/anypb",
     ],
 )


### PR DESCRIPTION
For a real invocation with 750K events, this PR reduces the time spent in `LookupInvocation` from 8.0s to 2.0s (serving from a local disk blobstore on SSD, with a 16-core/32-thread AMD Ryzen CPU).

The previous code would fetch blobs using multiple goroutines, but unmarshaling would be done on a single goroutine (the caller of `ReadProto`). This created a CPU bottleneck.

In this PR, the bottleneck is addressed: the goroutine responsible for fetching a single blob now also eagerly unmarshals all the proto messages in the blob, and `ReadProto` now just returns buffered messages instead of needing to unmarshal buffered raw bytes.

**Related issues**: N/A
