### PR TITLE
config: fix FOSS local config not setting up cache

### DIFF
--- a/config/buildbuddy.local.yaml
+++ b/config/buildbuddy.local.yaml
@@ -2,6 +2,11 @@ app:
   log_error_stack_traces: true
 storage:
   ttl_seconds: 86400 # One day in seconds.
+  disk:
+    root_directory: /tmp/${USER}_buildbuddy
   enable_chunked_event_logs: true
+  tempdir: /tmp/${USER}
 cache:
   max_size_bytes: 1000000000 # 1 GB
+  disk:
+    root_directory: /tmp/${USER}-buildbuddy-cache


### PR DESCRIPTION
Ensure that the local disk cache is used when we run the FOSS server
locally with `bazel run server`.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
