### PR TITLE
[UFFD] Ensure firecracker VM and UFFD handler are shut down before saving snapshots to the cache

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1858,8 +1858,12 @@ func (c *FirecrackerContainer) remove(ctx context.Context) error {
 	return lastErr
 }
 
-// Pause freezes a container so that it no longer consumes CPU resources.
-// It pauses the VM, takes a snapshot, and saves the snapshot to cache
+func (c *FirecrackerContainer) Pause(ctx context.Context) error {
+	return c.PauseAndSaveSnapshot(ctx)
+}
+
+// PauseAndSaveSnapshot freezes a container so that it no longer consumes CPU resources.
+// It also takes a snapshot and saves it to the cache
 //
 // If the VM is resumed after this point, the VM state and memory snapshots
 // immediately become invalid and another call to SaveSnapshot is required. This
@@ -1868,7 +1872,7 @@ func (c *FirecrackerContainer) remove(ctx context.Context) error {
 // Resuming the VM may change the disk state, causing the original VM state to
 // become invalid (e.g., the kernel's page cache may no longer be in sync with
 // the disk, which can cause all sorts of issues).
-func (c *FirecrackerContainer) Pause(ctx context.Context) error {
+func (c *FirecrackerContainer) PauseAndSaveSnapshot(ctx context.Context) error {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -189,6 +189,7 @@ func (h *Handler) handle(ctx context.Context, memoryStore *blockio.COWStore) err
 	}
 	uffd := setup.Uffd
 	mappings := setup.Mappings
+	defer syscall.Close(int(uffd))
 
 	pollFDs := []unix.PollFd{
 		{Fd: int32(uffd), Events: C.POLLIN},

--- a/enterprise/tools/vmstart/vmstart.go
+++ b/enterprise/tools/vmstart/vmstart.go
@@ -167,7 +167,7 @@ func main() {
 		for {
 			<-sigc
 			log.Errorf("Capturing snapshot...")
-			if err := c.PauseAndSaveSnapshot(ctx); err != nil {
+			if err := c.Pause(ctx); err != nil {
 				log.Fatalf("Error dumping snapshot: %s", err)
 			}
 			log.Printf("Saved snapshot")

--- a/enterprise/tools/vmstart/vmstart.go
+++ b/enterprise/tools/vmstart/vmstart.go
@@ -167,7 +167,7 @@ func main() {
 		for {
 			<-sigc
 			log.Errorf("Capturing snapshot...")
-			if err := c.SaveSnapshot(ctx); err != nil {
+			if err := c.PauseAndSaveSnapshot(ctx); err != nil {
 				log.Fatalf("Error dumping snapshot: %s", err)
 			}
 			log.Printf("Saved snapshot")


### PR DESCRIPTION
Fix a race condition where the UFFD handler is still trying to access the snapshots in the background at the same time that we're trying to merge them and save them to the cache

Also inline most of the logic from SaveSnapshot() into Pause(), so it's more clear that we're doing a lot more than just saving a snapshot (i.e. we're shutting down the VM and cleaning up resources).

**Related issues**: N/A
