### PR TITLE
Omit / truncate some pattern events from invocation

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -246,6 +246,7 @@ ts_library(
     srcs = ["invocation_details_card.tsx"],
     deps = [
         "//app/alert:alert_service",
+        "//app/components/banner",
         "//app/invocation:invocation_model",
         "//app/util:clipboard",
         "//proto:command_line_ts_proto",

--- a/app/invocation/invocation_details_card.tsx
+++ b/app/invocation/invocation_details_card.tsx
@@ -5,6 +5,7 @@ import { copyToClipboard } from "../util/clipboard";
 import alert_service from "../alert/alert_service";
 import { command_line } from "../../proto/command_line_ts_proto";
 import shlex from "shlex";
+import Banner from "../components/banner/banner";
 
 interface Props {
   model: InvocationModel;
@@ -275,6 +276,9 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
                       onClick={this.handleCopyClicked.bind(this, this.explicitCommandLine())}
                     />
                   </div>
+                  {this.props.model.invocation.patternsTruncated && (
+                    <Banner type="warning">Patterns have been truncated due to size limitations.</Banner>
+                  )}
                   <div className="invocation-section">
                     <code className="wrap">{this.explicitCommandLine()}</code>
                   </div>
@@ -291,6 +295,9 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
                       )}
                     />
                   </div>
+                  {this.props.model.invocation.patternsTruncated && (
+                    <Banner type="warning">Patterns have been truncated due to size limitations.</Banner>
+                  )}
                   <div className="invocation-section">
                     <code className="wrap">
                       {this.bazelCommandAndPatternWithOptions(this.props.model.optionsParsed?.cmdLine ?? [])}

--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -137,6 +137,10 @@ message Invocation {
   // Target groups, containing initial data pages for target listings. The
   // target group with status unspecified will have artifacts expanded.
   repeated target.TargetGroup target_groups = 32;
+
+  // Whether the pattern expanded event was truncated due to the total pattern
+  // length being too large.
+  bool patterns_truncated = 33;
 }
 
 message InvocationEvent {


### PR DESCRIPTION
- Omit some pattern lists which are not consumed by the UI:
  - Expanded event IDs which occur in the Children list of the Started event - there will be one of these per pattern
  - TestSuiteExpansions
- Truncate the Expanded event to 10KB and show a banner in the UI when truncated. A real invocation with 750K events had a total pattern length of about 13MB which was causing the All / Details tabs to take 7-8s to render when clicked, and also would be slow to load on slower connections.

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/d6bf6625-3a67-4c67-9dfb-0610791d6fd0)

**Related issues**: N/A
