### PR TITLE
Stop setting `final_before_usec` column in usage rows

### DIFF
--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -277,15 +277,6 @@ func (ut *tracker) flushCounts(ctx context.Context, groupID string, p period, co
 			PeriodStartUsec: p.Start().UnixMicro(),
 			Region:          ut.region,
 			UsageCounts:     *counts,
-			// While we're migrating to INSERT-only flushing, we still need to
-			// write FinalBeforeUsec to be compatible with old apps that still
-			// rely on it to know whether the collection period data has been
-			// written. Note that this only matters if a new app happens to
-			// write a collection period starting at the beginning of an hour.
-			//
-			// TODO(bduffany): remove this once all apps are migrated to flush
-			// at 1 minute granularity.
-			FinalBeforeUsec: p.Start().Add(periodDuration).UnixMicro(),
 		}
 
 		b, _ := json.Marshal(tu)

--- a/enterprise/server/usage/usage_test.go
+++ b/enterprise/server/usage/usage_test.go
@@ -80,9 +80,6 @@ func queryAllUsages(t *testing.T, te *testenv.TestEnv) []*tables.Usage {
 		require.NoError(t, err)
 		// Throw out Model timestamps to simplify assertions.
 		tu.Model = tables.Model{}
-		// Clear out FinalBeforeUsec to simplify assertions; this is being
-		// phased out.
-		tu.FinalBeforeUsec = 0
 		usages = append(usages, tu)
 	}
 	return usages

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -626,27 +626,6 @@ type Usage struct {
 	// is included in this usage row.
 	PeriodStartUsec int64 `gorm:"not null;index:group_period_region_index_v2,priority:2"`
 
-	// FinalBeforeUsec is the time before which all collection period data in this
-	// usage period is finalized. This is used to guarantee that collection period
-	// data is added to this row in strictly increasing order of collection period
-	// start time.
-	//
-	// Consider the following diagram:
-	//
-	// [xxxxxxxxxxxxxxxxxxx)------------------)
-	// ^ PeriodStart       ^ FinalBefore      ^ PeriodEnd = PeriodStart + 1hr
-	//
-	// Usage data occuring in the x-marked region cannot be added to this usage
-	// row any longer, since the data is finalized.
-	//
-	// When writing the next collection period's data, the FinalBefore timestamp
-	// is updated as follows:
-	//
-	// [xxxxxxxxxxxxxxxxxxx[xxxxxx)-----------)
-	//                     ^ FinalBefore (before update) = CollectionPeriodStart
-	//                            ^ FinalBefore (after update) = CollectionPeriodEnd
-	FinalBeforeUsec int64
-
 	// Region is the region in which the usage data was originally gathered.
 	// Since we have a global DB deployment but usage data is collected
 	// per-region, this effectively partitions the usage table by region, allowing


### PR DESCRIPTION
Apps no longer read this field as of https://github.com/buildbuddy-io/buildbuddy/pull/4403 which has been fully rolled out.

**Related issues**: N/A
