### PR TITLE
Bump default resource allocation for workflows

### DIFF
--- a/docs/workflows-config.md
+++ b/docs/workflows-config.md
@@ -179,7 +179,9 @@ build or fetch these dependencies.
 
 :::
 
-## Linux image configuration
+## Linux configuration
+
+### Docker image
 
 By default, workflows run on an Ubuntu 18.04-based image. You can use
 a newer, Ubuntu 20.04-based image using the `container_image` action
@@ -196,13 +198,31 @@ actions:
 The supported values for `container_image` are `"ubuntu-18.04"` (default)
 or `"ubuntu-20.04"`.
 
+### VM resources
+
+BuildBuddy cloud isolates Linux workflows using
+[Firecracker MicroVMs](./rbe-microvms.md).
+
 By default, workflow VMs have the following resources available:
 
-- 3 CPU
-- 8 GB of RAM
-- 20 GB of disk space
+- 4 CPU cores
+- 16 GB\* of RAM
+- 20 GB\* of disk space
+
+\* These are SI units: 1 GB = 10^9 bytes.
 
 These values are configurable using [resource requests](#resourcerequests).
+For example, the default resource limits would be configured explicitly
+as follows:
+
+```yaml
+actions:
+  - name: Test
+    resource_requests:
+      cpu: 4
+      memory: 16_000_000_000 # bytes
+      disk: 20_000_000_000 # bytes
+```
 
 ## Mac configuration
 

--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -34,8 +34,8 @@ const (
 
 	// Definitions for BCU ("BuildBuddy Compute Unit")
 
-	ComputeUnitsToMilliCPU = 1000      // 1 BCU = 1000 milli-CPU
-	ComputeUnitsToRAMBytes = 2.5 * 1e9 // 1 BCU = 2.5GB of memory
+	ComputeUnitsToMilliCPU = 1000    // 1 BCU = 1000 milli-CPU
+	ComputeUnitsToRAMBytes = 4 * 1e9 // 1 BCU = 4GB of memory
 
 	// Default resource estimates
 

--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -95,7 +95,7 @@ func TestEstimate_BCUPlatformProps_ConvertsBCUToTaskSize(t *testing.T) {
 		},
 	})
 
-	assert.Equal(t, int64(2*2.5*1e9), ts.EstimatedMemoryBytes)
+	assert.Equal(t, int64(2*4*1e9), ts.EstimatedMemoryBytes)
 	assert.Equal(t, int64(2*1000), ts.EstimatedMilliCpu)
 	assert.Equal(t, tasksize.DefaultFreeDiskEstimate, ts.EstimatedFreeDiskBytes)
 }

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -69,7 +69,7 @@ var (
 	workflowsDefaultImage         = flag.String("remote_execution.workflows_default_image", platform.DockerPrefix+platform.Ubuntu18_04WorkflowsImage, "The default container-image property to use for workflows. Must include docker:// prefix if applicable.")
 	workflowsCIRunnerDebug        = flag.Bool("remote_execution.workflows_ci_runner_debug", false, "Whether to run the CI runner in debug mode.")
 	workflowsCIRunnerBazelCommand = flag.String("remote_execution.workflows_ci_runner_bazel_command", "", "Bazel command to be used by the CI runner.")
-	workflowsLinuxComputeUnits    = flag.Int("remote_execution.workflows_linux_compute_units", 3, "Number of BuildBuddy compute units (BCU) to reserve for Linux workflow actions.")
+	workflowsLinuxComputeUnits    = flag.Int("remote_execution.workflows_linux_compute_units", 4, "Number of BuildBuddy compute units (BCU) to reserve for Linux workflow actions.")
 	workflowsMacComputeUnits      = flag.Int("remote_execution.workflows_mac_compute_units", 3, "Number of BuildBuddy compute units (BCU) to reserve for Mac workflow actions.")
 
 	workflowURLMatcher = regexp.MustCompile(`^.*/webhooks/workflow/(?P<instance_name>.*)$`)


### PR DESCRIPTION
Our workflows feel a bit sluggish currently and have been occasionally hitting OOM errors. Bumping from 3CPU/7.5GB mem => 4CPU/10GB mem should improve the overall experience and also might help alleviate a bit of pressure on the workflow executors that we suspect is caused by running too many VMs concurrently.

**Related issues**: N/A
