### PR TITLE
Mark nonce column in APIKeys as unique

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -350,7 +350,7 @@ type APIKey struct {
 	// The API key token used for authentication.
 	Value          string `gorm:"default:NULL;uniqueIndex:api_key_value_composite_index;index:api_key_unencrypted_value_index;"`
 	EncryptedValue string `gorm:"default:'';uniqueIndex:api_key_value_composite_index;index:api_key_encrypted_value_index;"`
-	Nonce          string `gorm:"default:NULL;"`
+	Nonce          string `gorm:"default:NULL;unique"`
 	Perms          int32  `gorm:"default:NULL"`
 	// Capabilities that are enabled for this key. Defaults to CACHE_WRITE.
 	//


### PR DESCRIPTION
The db schema changes script is failing because the Nonce column is unique in the db (select column_key FROM information_schema.columns where column_name="Nonce";), but it's not marked as unique in our schema.
Because gorm thinks the uniqueness value is changing, gorm tries to migrate the column. Fix the discrepancy by marking it as unique in our schema.

**Related issues**: N/A
