### PR TITLE
Render TargetGroups in the UI

### DIFF
--- a/app/components/spinner/spinner.css
+++ b/app/components/spinner/spinner.css
@@ -23,3 +23,7 @@
 .spinner.white:before {
   background-image: url("/image/loader-white.svg");
 }
+
+.spinner.small-spinner {
+  --size: 16px;
+}

--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -660,6 +660,7 @@ ts_library(
         "//app/invocation:target_util",
         "//app/service:rpc_service",
         "//app/util:clipboard",
+        "//proto:duration_ts_proto",
         "//proto:target_ts_proto",
         "//proto/api/v1:common_ts_proto",
         "@npm//@types/react",

--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -528,7 +528,10 @@ ts_library(
     srcs = ["invocation_targets.tsx"],
     deps = [
         "//app/invocation:invocation_model",
+        "//app/invocation:invocation_target_group_card",
         "//app/invocation:invocation_targets_card",
+        "//proto:target_ts_proto",
+        "//proto/api/v1:common_ts_proto",
         "@npm//@types/react",
         "@npm//lucide-react",
         "@npm//react",
@@ -644,5 +647,33 @@ ts_library(
         "@npm//lucide-react",
         "@npm//react",
         "@npm//tslib",
+    ],
+)
+
+ts_library(
+    name = "invocation_target_group_card",
+    srcs = ["invocation_target_group_card.tsx"],
+    deps = [
+        "//app/components/link",
+        "//app/components/spinner",
+        "//app/errors:error_service",
+        "//app/invocation:target_util",
+        "//app/service:rpc_service",
+        "//app/util:clipboard",
+        "//proto:target_ts_proto",
+        "//proto/api/v1:common_ts_proto",
+        "@npm//@types/react",
+        "@npm//lucide-react",
+        "@npm//react",
+        "@npm//tslib",
+    ],
+)
+
+ts_library(
+    name = "target_util",
+    srcs = ["target_util.tsx"],
+    deps = [
+        "//app/util:proto",
+        "//proto/api/v1:common_ts_proto",
     ],
 )

--- a/app/invocation/invocation_target_group_card.tsx
+++ b/app/invocation/invocation_target_group_card.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { google as google_duration } from "../../proto/duration_ts_proto";
 import { target } from "../../proto/target_ts_proto";
 import { api as api_common } from "../../proto/api/v1/common_ts_proto";
 import { CheckCircle, ChevronRight, Clock, Copy, HelpCircle, SkipForward, XCircle } from "lucide-react";
@@ -159,7 +160,9 @@ export default class TargetGroupCard extends React.Component<TargetGroupCardProp
                     {target.rootCause && <span className="root-cause-badge">Root cause</span>}
                   </div>
                   <div className="target-duration">
-                    {renderDuration(target.timing ?? new api_common.v1.Timing({ duration: {} }))}
+                    {renderDuration(
+                      target.timing ?? new api_common.v1.Timing({ duration: new google_duration.protobuf.Duration() })
+                    )}
                   </div>
                 </Link>
               ))}

--- a/app/invocation/target_util.tsx
+++ b/app/invocation/target_util.tsx
@@ -1,0 +1,22 @@
+import { api as api_common } from "../../proto/api/v1/common_ts_proto";
+import { durationToMillis } from "../util/proto";
+
+export function renderTestSize(size: api_common.v1.TestSize): string {
+  const TestSize = api_common.v1.TestSize;
+  switch (size) {
+    case TestSize.ENORMOUS:
+      return "Enormous";
+    case TestSize.LARGE:
+      return "Large";
+    case TestSize.MEDIUM:
+      return "Medium";
+    case TestSize.SMALL:
+      return "Small";
+    default:
+      return "";
+  }
+}
+
+export function renderDuration(timing: api_common.v1.Timing): string {
+  return `${(durationToMillis(timing.duration) / 1000).toFixed(3)} seconds`;
+}

--- a/app/invocation/target_util.tsx
+++ b/app/invocation/target_util.tsx
@@ -18,5 +18,9 @@ export function renderTestSize(size: api_common.v1.TestSize): string {
 }
 
 export function renderDuration(timing: api_common.v1.Timing): string {
-  return `${(durationToMillis(timing.duration) / 1000).toFixed(3)} seconds`;
+  let ms = 0;
+  if (timing.duration) {
+    ms = durationToMillis(timing.duration) / 1000;
+  }
+  return `${ms.toFixed(3)} seconds`;
 }

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -617,6 +617,16 @@ body {
   user-select: none;
 }
 
+.card .more-loading {
+  margin-top: 16px;
+  color: #757575;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  user-select: none;
+}
+
 .card-suggestion-message {
   word-break: normal;
   max-width: 800px;

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -1321,7 +1321,15 @@ func streamRawInvocationEvents(env environment.Env, ctx context.Context, streamI
 // in memory.
 func LookupInvocation(env environment.Env, ctx context.Context, iid string) (*inpb.Invocation, error) {
 	var events []*inpb.InvocationEvent
-	inv, err := LookupInvocationWithCallback(ctx, env, iid, maxEventCount, func(event *inpb.InvocationEvent) error {
+	inv, err := LookupInvocationWithCallback(ctx, env, iid, func(event *inpb.InvocationEvent) error {
+		// Certain buggy rulesets will mark intermediate output files as
+		// important-outputs. This can result in very large BES streams which
+		// use a ton of memory and are not displayable by the browser. If we
+		// detect a large number of events coming through, begin dropping non-
+		// important events so that this invocation can be displayed.
+		if len(events) >= maxEventCount && !accumulator.IsImportantEvent(event.BuildEvent) {
+			return nil
+		}
 		events = append(events, event)
 		return nil
 	})
@@ -1336,7 +1344,7 @@ func LookupInvocation(env environment.Env, ctx context.Context, iid string) (*in
 // events instead of buffering events into the events list.
 //
 // TODO: switch to using this API wherever possible.
-func LookupInvocationWithCallback(ctx context.Context, env environment.Env, iid string, limit int, cb invocationEventCB) (*inpb.Invocation, error) {
+func LookupInvocationWithCallback(ctx context.Context, env environment.Env, iid string, cb invocationEventCB) (*inpb.Invocation, error) {
 	ti, err := env.GetInvocationDB().LookupInvocation(ctx, iid)
 	if err != nil {
 		return nil, err
@@ -1389,22 +1397,7 @@ func LookupInvocationWithCallback(ctx context.Context, env environment.Env, iid 
 		beValues := accumulator.NewBEValues(invocation)
 		events := []*inpb.InvocationEvent{}
 		structuredCommandLines := []*command_line.CommandLine{}
-
-		eventCount := 0
 		err := streamRawInvocationEvents(env, ctx, streamID, func(event *inpb.InvocationEvent) error {
-			eventCount += 1
-			// Certain buggy rulesets will mark intermediate output
-			// files as important-outputs. This can result in very
-			// large BES streams which use a ton of memory and are
-			// not displayable by the browser. If we detect a large
-			// number of events coming through, begin dropping non-
-			// important events so that this invocation can be
-			// displayed.
-			if limit >= 0 && eventCount > limit {
-				if !accumulator.IsImportantEvent(event.BuildEvent) {
-					return nil
-				}
-			}
 			if redactor != nil {
 				if err := redactor.RedactAPIKeysWithSlowRegexp(ctx, event.BuildEvent); err != nil {
 					return err

--- a/server/build_event_protocol/event_index/BUILD
+++ b/server/build_event_protocol/event_index/BUILD
@@ -11,5 +11,6 @@ go_library(
         "//proto:target_go_proto",
         "//proto/api/v1:common_go_proto",
         "//server/api/common",
+        "//server/build_event_protocol/accumulator",
     ],
 )

--- a/server/build_event_protocol/event_index/event_index.go
+++ b/server/build_event_protocol/event_index/event_index.go
@@ -3,11 +3,19 @@ package event_index
 import (
 	"sort"
 
+	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/accumulator"
+
 	cmnpb "github.com/buildbuddy-io/buildbuddy/proto/api/v1/common"
 	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
 	trpb "github.com/buildbuddy-io/buildbuddy/proto/target"
 	api_common "github.com/buildbuddy-io/buildbuddy/server/api/common"
+)
+
+const (
+	// Only index up to this many non-important events as a safeguard against
+	// excessive memory / CPU consumption.
+	maxEventCount = 2_000_000
 )
 
 // Index holds a few data structures to make it easier to aggregate data from
@@ -24,6 +32,7 @@ type Index struct {
 	// top-level invocation proto.
 	TopLevelEvents []*inpb.InvocationEvent
 
+	eventCount      int
 	rootCauseLabels map[string]bool
 }
 
@@ -42,6 +51,11 @@ func New() *Index {
 // Add adds a single event to the index.
 // Don't forget to call Finalize once all events are added.
 func (idx *Index) Add(event *inpb.InvocationEvent) {
+	if idx.eventCount >= maxEventCount && !accumulator.IsImportantEvent(event.GetBuildEvent()) {
+		return
+	}
+	idx.eventCount++
+
 	switch p := event.GetBuildEvent().GetPayload().(type) {
 	case *bespb.BuildEvent_NamedSetOfFiles:
 		nsid := event.GetBuildEvent().GetId().GetNamedSet().GetId()

--- a/server/build_event_protocol/event_index/event_index.go
+++ b/server/build_event_protocol/event_index/event_index.go
@@ -74,7 +74,7 @@ func (idx *Index) Add(event *inpb.InvocationEvent) {
 			}
 		}
 	case *bespb.BuildEvent_TestSummary:
-		label := event.GetBuildEvent().GetId().GetTargetCompleted().GetLabel()
+		label := event.GetBuildEvent().GetId().GetTestSummary().GetLabel()
 		summary := p.TestSummary
 		idx.TestTargetByLabel[label] = &trpb.Target{
 			Metadata: &trpb.TargetMetadata{Label: label},

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -74,12 +74,6 @@ var (
 const (
 	bytestreamProtocolPrefix  = "bytestream://"
 	actioncacheProtocolPrefix = "actioncache://"
-
-	// Max number of events to process in a single GetInvocation request when
-	// serving paginated invocations. Even though we are paginating, this limit
-	// is in place because we currently have to process every event on every
-	// request.
-	paginatedInvocationEventLimit = 2_000_000
 )
 
 type BuildBuddyServer struct {
@@ -114,8 +108,7 @@ func (s *BuildBuddyServer) GetInvocation(ctx context.Context, req *inpb.GetInvoc
 			return nil
 		}
 		inv, err := build_event_handler.LookupInvocationWithCallback(
-			ctx, s.env, req.GetLookup().GetInvocationId(),
-			paginatedInvocationEventLimit, callback)
+			ctx, s.env, req.GetLookup().GetInvocationId(), callback)
 		if err != nil {
 			return nil, err
 		}
@@ -145,8 +138,7 @@ func (s *BuildBuddyServer) GetTarget(ctx context.Context, req *trpb.GetTargetReq
 		return nil
 	}
 	inv, err := build_event_handler.LookupInvocationWithCallback(
-		ctx, s.env, req.GetInvocationId(),
-		paginatedInvocationEventLimit, callback)
+		ctx, s.env, req.GetInvocationId(), callback)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Render TargetGroups as cards in the UI
- Fix a few server-side bugs
- Increase the build event limit when rendering paginated invocations.

Note: this does not yet render the artifacts card or the target page. That'll be a separate PR.

**Related issues**: N/A
