### PR TITLE
go: upgrade to 1.21

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21.0" # Keep in sync with WORKSPACE
+          go-version: "1.21.1" # Keep in sync with WORKSPACE
 
       - name: gofmt
         run: |

--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20.6" # Keep in sync with WORKSPACE
+          go-version: "1.21.0" # Keep in sync with WORKSPACE
 
       - name: gofmt
         run: |

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,42 +62,42 @@ go_download_sdk(
     name = "go_sdk_linux",
     goarch = "amd64",
     goos = "linux",
-    version = "1.20.6",  # Keep in sync with .github/workflows/checkstyle.yaml
+    version = "1.21.0",  # Keep in sync with .github/workflows/checkstyle.yaml
 )
 
 go_download_sdk(
     name = "go_sdk_linux_arm64",
     goarch = "arm64",
     goos = "linux",
-    version = "1.20.6",
+    version = "1.21.0",
 )
 
 go_download_sdk(
     name = "go_sdk_darwin",
     goarch = "amd64",
     goos = "darwin",
-    version = "1.20.6",
+    version = "1.21.0",
 )
 
 go_download_sdk(
     name = "go_sdk_darwin_arm64",
     goarch = "arm64",
     goos = "darwin",
-    version = "1.20.6",
+    version = "1.21.0",
 )
 
 go_download_sdk(
     name = "go_sdk_windows",
     goarch = "amd64",
     goos = "windows",
-    version = "1.20.6",
+    version = "1.21.0",
 )
 
 go_download_sdk(
     name = "go_sdk_windows_arm64",
     goarch = "arm64",
     goos = "windows",
-    version = "1.20.6",
+    version = "1.21.0",
 )
 
 go_register_toolchains(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,42 +62,42 @@ go_download_sdk(
     name = "go_sdk_linux",
     goarch = "amd64",
     goos = "linux",
-    version = "1.21.0",  # Keep in sync with .github/workflows/checkstyle.yaml
+    version = "1.21.1",  # Keep in sync with .github/workflows/checkstyle.yaml
 )
 
 go_download_sdk(
     name = "go_sdk_linux_arm64",
     goarch = "arm64",
     goos = "linux",
-    version = "1.21.0",
+    version = "1.21.1",
 )
 
 go_download_sdk(
     name = "go_sdk_darwin",
     goarch = "amd64",
     goos = "darwin",
-    version = "1.21.0",
+    version = "1.21.1",
 )
 
 go_download_sdk(
     name = "go_sdk_darwin_arm64",
     goarch = "arm64",
     goos = "darwin",
-    version = "1.21.0",
+    version = "1.21.1",
 )
 
 go_download_sdk(
     name = "go_sdk_windows",
     goarch = "amd64",
     goos = "windows",
-    version = "1.21.0",
+    version = "1.21.1",
 )
 
 go_download_sdk(
     name = "go_sdk_windows_arm64",
     goarch = "arm64",
     goos = "windows",
-    version = "1.21.0",
+    version = "1.21.1",
 )
 
 go_register_toolchains(


### PR DESCRIPTION
For more information: https://go.dev/blog/go1.21

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
