### PR TITLE
Do less fake-keyboard probing during fc boot

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1057,7 +1057,7 @@ func (c *FirecrackerContainer) getChroot() string {
 // they will be hardlinked to the chroot when starting the machine (see
 // NaiveChrootStrategy).
 func (c *FirecrackerContainer) getConfig(ctx context.Context, containerFS, scratchFS, workspaceFS string) (*fcclient.Config, error) {
-	bootArgs := "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules=1 random.trust_cpu=on i8042.noaux=1 tsc=reliable ipv6.disable=1"
+	bootArgs := "ro console=ttyS0 noapic reboot=k panic=1 pci=off nomodules=1 random.trust_cpu=on i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd tsc=reliable ipv6.disable=1"
 	var netNS string
 
 	if c.vmConfig.EnableNetworking {


### PR DESCRIPTION
From https://github.com/firecracker-microvm/firecracker/blob/main/docs/api_requests/actions.md#intel-and-amd-only-sendctrlaltdel:

```
at boot time, the Linux driver for i8042 spends a few tens of milliseconds probing the device. This can be disabled by using these kernel command line parameters:

i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd
```