### PR TITLE
Add missing Close() in clearARPCache

### DIFF
--- a/enterprise/server/vmexec/vmexec.go
+++ b/enterprise/server/vmexec/vmexec.go
@@ -47,6 +47,7 @@ func clearARPCache() error {
 	if err != nil {
 		return err
 	}
+	defer handle.Close()
 	links, err := netlink.LinkList()
 	if err != nil {
 		return err


### PR DESCRIPTION
This missing Close() probably wasn't causing any problems, just something small I noticed while poking around various networking-related firecracker things.

**Related issues**: N/A
