### PR TITLE
Fix bug with quota update pubsub being closed too early

### DIFF
--- a/enterprise/server/quota/quota_manager.go
+++ b/enterprise/server/quota/quota_manager.go
@@ -561,10 +561,9 @@ func (qm *QuotaManager) reloadNamespaces() error {
 // starts a background goroutine to reload namespaces on each update.
 func (qm *QuotaManager) listenForUpdates(ctx context.Context) {
 	subscriber := qm.ps.Subscribe(ctx, pubSubChannelName)
-	defer subscriber.Close()
-	pubsubChan := subscriber.Chan()
 	go func() {
-		for range pubsubChan {
+		defer subscriber.Close()
+		for range subscriber.Chan() {
 			err := qm.reloadNamespaces()
 			if err != nil {
 				alert.UnexpectedEvent("quota-cannot-reload", " quota manager failed to reload configs: %s", err)

--- a/server/testutil/pubsub/BUILD
+++ b/server/testutil/pubsub/BUILD
@@ -5,5 +5,8 @@ go_library(
     srcs = ["pubsub.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/pubsub",
     visibility = ["//visibility:public"],
-    deps = ["//server/interfaces"],
+    deps = [
+        "//server/interfaces",
+        "//server/util/log",
+    ],
 )


### PR DESCRIPTION
Accidentally introduced this bug in the last PR: we should `defer Close()` within the goroutine, otherwise it's closed immediately.

**Related issues**: N/A
