### PR TITLE
Compaction tweaks

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -433,7 +433,7 @@ func ensureDefaultPartitionExists(opts *Options) {
 func defaultPebbleOptions(el *pebbleEventListener) *pebble.Options {
 	// These values Borrowed from CockroachDB.
 	opts := &pebble.Options{
-        // The amount of L0 read-amplification necessary to trigger an L0 compaction.
+		// The amount of L0 read-amplification necessary to trigger an L0 compaction.
 		L0CompactionThreshold:    2,
 		MaxConcurrentCompactions: 12,
 		MemTableSize:             64 << 20, // 64 MB
@@ -448,7 +448,7 @@ func defaultPebbleOptions(el *pebbleEventListener) *pebble.Options {
 	// is enabled (if CompactionDebtConcurrency was not already exceeded).
 	// Every multiple of this value enables another concurrent
 	// compaction up to MaxConcurrentCompactions.
-	opts.Experimental.L0CompactionConcurrency = 2
+	opts.Experimental.L0CompactionConcurrency = 4
 	// CompactionDebtConcurrency controls the threshold of compaction debt
 	// at which additional compaction concurrency slots are added. For every
 	// multiple of this value in compaction debt bytes, an additional

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -432,8 +432,9 @@ func ensureDefaultPartitionExists(opts *Options) {
 // defaultPebbleOptions returns default pebble config options.
 func defaultPebbleOptions(el *pebbleEventListener) *pebble.Options {
 	// These values Borrowed from CockroachDB.
-	return &pebble.Options{
-		MaxConcurrentCompactions: 6,
+	opts := &pebble.Options{
+		L0CompactionThreshold:    2,
+		MaxConcurrentCompactions: 12,
 		MemTableSize:             64 << 20, // 64 MB
 		EventListener: pebble.EventListener{
 			WriteStallBegin: el.WriteStallBegin,
@@ -441,6 +442,11 @@ func defaultPebbleOptions(el *pebbleEventListener) *pebble.Options {
 			DiskSlow:        el.DiskSlow,
 		},
 	}
+
+	opts.Experimental.L0CompactionConcurrency = 2
+	opts.Experimental.CompactionDebtConcurrency = 10 << 30
+
+	return opts
 }
 
 // NewPebbleCache creates a new cache from the provided env and opts.


### PR DESCRIPTION
- Start compaction sooner: L0CompactionThreshold = 2
- Start parallel compactions sooner: L0CompactionConcurrency = 2
- Raise max compactions limit: MaxConcurrentCompactions = 12
- Slow down the rate at which parallel slots are added: CompactionDebtConcurrency = 10 << 30 (10GB of compaction debt per slot)