### PR TITLE
Bump open file limit in CLI if `--watch` flag is used

### DIFF
--- a/cli/watcher/BUILD
+++ b/cli/watcher/BUILD
@@ -8,6 +8,7 @@ go_library(
         "//cli/arg",
         "//cli/log",
         "//cli/workspace",
+        "//server/util/rlimit",
         "//server/util/status",
         "@com_github_bduffany_godemon//:godemon",
         "@com_github_google_shlex//:shlex",

--- a/cli/watcher/watcher.go
+++ b/cli/watcher/watcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
+	"github.com/buildbuddy-io/buildbuddy/server/util/rlimit"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/google/shlex"
 )
@@ -29,6 +30,11 @@ func Watch() (exitCode int, err error) {
 		return -1, nil
 	}
 	args = append(args[:idx], args[idx+1:]...)
+
+	err = rlimit.MaxRLimit()
+	if err != nil {
+		log.Printf("Failed to bump open file limits: %s", err)
+	}
 
 	// Allow specifying --watcher_flags to forward args to the watcher.
 	// Mostly useful for debugging, e.g. --watcher_flags='--verbose'


### PR DESCRIPTION
ibazel does this too: https://github.com/bazelbuild/bazel-watcher/blob/1f4db7637dbfd00a9e66eea6920bfb42f403ee0c/cmd/ibazel/main_unix.go#L43
