### PR TITLE
Fix misc bugs with paginated invocations / targets

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -681,9 +681,6 @@ ts_library(
     srcs = ["target_util.tsx"],
     deps = [
         "//app/util:proto",
-        "//proto:timestamp_ts_proto",
         "//proto/api/v1:common_ts_proto",
-        "@npm//@types/long",
-        "@npm//long",
     ],
 )

--- a/app/invocation/invocation_target_group_card.tsx
+++ b/app/invocation/invocation_target_group_card.tsx
@@ -134,8 +134,8 @@ export default class TargetGroupCard extends React.Component<TargetGroupCardProp
       case Status.FAILED_TO_BUILD:
         className = "card-failure";
         icon = <XCircle className="icon red" />;
-        presentVerb = `failing ${targets.length === 1 ? "target" : "targets"}`;
-        pastVerb = `${targets.length === 1 ? "target" : "targets"} failed`;
+        presentVerb = `${targets.length === 1 ? "target" : "targets"} failed to build`;
+        pastVerb = `${targets.length === 1 ? "target" : "targets"} failed to build`;
         break;
       case Status.TIMED_OUT:
         className = "card-timeout";
@@ -197,11 +197,7 @@ export default class TargetGroupCard extends React.Component<TargetGroupCardProp
                       <span className="target-label">{target.metadata?.label}</span>{" "}
                       {target.rootCause && <span className="root-cause-badge">Root cause</span>}
                     </div>
-                    <div className="target-duration">
-                      {renderDuration(
-                        target.timing ?? new api_common.v1.Timing({ duration: new google_duration.protobuf.Duration() })
-                      )}
-                    </div>
+                    <div className="target-duration">{!!target.timing?.duration && renderDuration(target.timing)}</div>
                   </Link>
                 ))}
               </div>

--- a/app/invocation/invocation_targets.tsx
+++ b/app/invocation/invocation_targets.tsx
@@ -37,13 +37,20 @@ export default class TargetsComponent extends React.Component<Props> {
     );
   }
 
+  private isGroupVisible(group: target.TargetGroup): boolean {
+    if (!group.targets.length || !STATUS_ORDERING.includes(group.status)) {
+      return false;
+    }
+
+    const ok = OK_STATUSES.has(group.status);
+    return this.props.mode === "passing" ? ok : !ok;
+  }
+
   render() {
     if (this.props.model.invocation.targetGroups.length) {
       // Paginated invocation; render target groups.
       return this.props.model.invocation.targetGroups
-        .filter((group) => group.targets.length)
-        .filter((group) => this.props.mode === "failing" || OK_STATUSES.has(group.status))
-        .filter((group) => STATUS_ORDERING.includes(group.status))
+        .filter((group) => this.isGroupVisible(group))
         .sort((a, b) => STATUS_ORDERING.indexOf(a.status) - STATUS_ORDERING.indexOf(b.status))
         .map((group) => this.renderTargetGroup(group));
     }

--- a/app/invocation/target_util.tsx
+++ b/app/invocation/target_util.tsx
@@ -1,7 +1,5 @@
 import { api as api_common } from "../../proto/api/v1/common_ts_proto";
 import { durationToMillis } from "../util/proto";
-import { google as google_timestamp } from "../../proto/timestamp_ts_proto";
-import Long from "long";
 
 export function renderTestSize(size: api_common.v1.TestSize): string {
   const TestSize = api_common.v1.TestSize;
@@ -25,15 +23,4 @@ export function renderDuration(timing: api_common.v1.Timing): string {
     ms = durationToMillis(timing.duration) / 1000;
   }
   return `${ms.toFixed(3)} seconds`;
-}
-
-export function getEndTimestamp(timing: api_common.v1.Timing): google_timestamp.protobuf.Timestamp | null {
-  if (!timing.startTime || !timing.duration) return null;
-  const startNanos = Number(timing.startTime.seconds) * 1e9 + timing.startTime.nanos;
-  const endNanos = startNanos + Number(timing.duration.seconds) * 1e9 + timing.duration.nanos;
-  const endSeconds = Math.floor(endNanos / 1e9);
-  return new google_timestamp.protobuf.Timestamp({
-    seconds: Long.fromNumber(endSeconds),
-    nanos: endNanos - endSeconds * 1e9,
-  });
 }

--- a/app/target/target.tsx
+++ b/app/target/target.tsx
@@ -163,10 +163,10 @@ export default class TargetComponent extends React.Component<Props> {
       const lastStopDate = timestampToDateWithFallback(testSummary?.lastStopTime, testSummary?.lastStopTimeMillis);
       return format.formatDate(lastStopDate);
     }
-    if (this.props.completedEvent?.eventTime?.seconds) {
-      return format.formatTimestampMillis(+this.props.completedEvent?.eventTime.seconds * 1000);
+    if (this.props.completedEvent?.eventTime) {
+      return format.formatTimestamp(this.props.completedEvent.eventTime);
     }
-    return format.formatTimestampMillis(+(this.props.configuredEvent?.eventTime?.seconds ?? 0) * 1000);
+    return format.formatTimestamp(this.props.configuredEvent?.eventTime || {});
   }
 
   handleCopyClicked(label: string) {

--- a/app/target/target_v2.tsx
+++ b/app/target/target_v2.tsx
@@ -12,13 +12,13 @@ import { invocation } from "../../proto/invocation_ts_proto";
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
 import { copyToClipboard } from "../util/clipboard";
 import alert_service from "../alert/alert_service";
-import { timestampToDateWithFallback } from "../util/proto";
+import { addDurationToTimestamp, timestampToDateWithFallback } from "../util/proto";
 import { OutlinedLinkButton } from "../components/button/link_button";
 import { target } from "../../proto/target_ts_proto";
 import { api as api_common } from "../../proto/api/v1/common_ts_proto";
 import rpc_service from "../service/rpc_service";
 import error_service from "../errors/error_service";
-import { getEndTimestamp, renderTestSize } from "../invocation/target_util";
+import { renderTestSize } from "../invocation/target_util";
 
 const Status = api_common.v1.Status;
 
@@ -179,10 +179,8 @@ export default class TargetV2Component extends React.Component<TargetProps, Stat
       return format.formatDate(lastStopDate);
     }
     if (!this.state.target?.timing?.startTime) return "";
-    if (!this.state.target.timing.duration) return format.formatTimestamp(this.state.target.timing.startTime);
-    const end = getEndTimestamp(this.state.target.timing);
-    if (!end) return "";
-    return format.formatTimestamp(end);
+    const endTime = addDurationToTimestamp(this.state.target.timing.startTime, this.state.target.timing.duration);
+    return format.formatTimestamp(endTime);
   }
 
   handleCopyClicked(label: string) {

--- a/app/util/proto.ts
+++ b/app/util/proto.ts
@@ -67,3 +67,20 @@ export function durationToMillisWithFallback(
 
   return Number(fallbackMillis);
 }
+
+export function addDurationToTimestamp(
+  timestamp: google_timestamp.protobuf.ITimestamp,
+  duration: google_duration.protobuf.IDuration | null | undefined
+) {
+  if (!duration) return timestamp;
+
+  const startNanos = Long.fromValue(timestamp.seconds ?? 0)
+    .mul(1e9)
+    .add(timestamp.nanos ?? 0);
+  const endNanos = startNanos.add(Long.fromValue(duration.seconds ?? 0).mul(1e9)).add(timestamp.nanos ?? 0);
+
+  return new google_timestamp.protobuf.Timestamp({
+    seconds: endNanos.div(1e9),
+    nanos: endNanos.mod(1e9).toNumber(),
+  });
+}

--- a/server/build_event_protocol/event_index/BUILD
+++ b/server/build_event_protocol/event_index/BUILD
@@ -12,5 +12,6 @@ go_library(
         "//proto/api/v1:common_go_proto",
         "//server/api/common",
         "//server/build_event_protocol/accumulator",
+        "@org_golang_google_protobuf//types/known/durationpb",
     ],
 )


### PR DESCRIPTION
* Fix missing timing and rule type metadata on target page
* Tweak the `endTime` calculation to avoid rounding errors (I noticed this because the timestamp rendered in V1 is different than V2 by a millisecond, which seemed significant enough to fix).
* Don't report TestSummary events when status == 0 (NO_STATUS), otherwise these appear as failed tests which is confusing. So far, I've only seen NO_STATUS when the test is aborted due to an unrelated target in the invocation failing.
* Fix build time duration not being rendered in listing (for now, we'll just use the time between the Configured -> Completed events being published).
* Fix FAILED_TO_BUILD label in target listing card ("failed" -> "failed to build").
* Fix SKIPPED targets card not rendering (need to handle the Aborted event).

**Related issues**: N/A
