### PR TITLE
Keep the docker socket around when we enable docker over tcp

### DIFF
--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -160,7 +160,7 @@ func startDockerd(ctx context.Context) error {
 
 	args := []string{}
 	if *enableDockerdTCP {
-		args = append(args, "--host=tcp://0.0.0.0:2375", "--tls=false")
+		args = append(args, "--host=unix:///var/run/docker.sock", "--host=tcp://0.0.0.0:2375", "--tls=false")
 	}
 
 	cmd := exec.CommandContext(ctx, "dockerd", args...)


### PR DESCRIPTION
Keep the docker socket around when enabling docker over tcp.

Some tests use both (tcp and socket), and we don't gain much from removing the socket when this flag is set.