### PR TITLE
Allow the tree cache to work even if it's missing the empty digest

### DIFF
--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -645,8 +645,12 @@ func isComplete(children []*capb.DirectoryWithDigest) bool {
 			return false
 		}
 		for _, dirNode := range child.GetDirectory().GetDirectories() {
+			grn := digest.NewResourceName(dirNode.GetDigest(), "", rspb.CacheType_CAS, rn.GetDigestFunction())
+			if grn.IsEmpty() {
+				continue
+			}
 			if _, ok := allDigests[dirNode.GetDigest().GetHash()]; !ok {
-				log.Debugf("incomplete tree: (missing digest: %q), allDigests: %+v", dirNode.GetDigest().GetHash(), allDigests)
+				log.Warningf("incomplete tree: (missing digest: %q), allDigests: %+v", dirNode.GetDigest().GetHash(), allDigests)
 				return false
 			}
 		}


### PR DESCRIPTION
I went back and found some logs indicating that we were throwing away "incomplete" tree cache entries that were incomplete only because they lacked the empty digest, which is fine. This CL fixes that.

Sample log:
```
incomplete tree: (missing digest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"), allDigests: map[00a89f8681f48b389a .... etc
```