### PR TITLE
pebble_cache_test/TestSampling:increase the time when we wait for the unencrypted digest to evict.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2862,8 +2862,9 @@ func TestSampling(t *testing.T) {
 			// kick in. The unencrypted test digest should be evicted.
 			clock.Advance(minEvictionAge - 1*time.Minute)
 
-			for i := 0; i < 5; i++ {
+			for i := 0; i < 8; i++ {
 				if exists, err := pc.Contains(anonCtx, rn); err == nil && !exists {
+					log.Infof("i = %d: unencrypted test digest is evicted", i)
 					break
 				}
 				time.Sleep(500 * time.Millisecond)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/2553
1. increase the number of attemps when we check whether unencrypted digest is
   evicted in the test.
2. Add some logging

Note: I was not able to reproduce running locally with --run_per_test=1000, or
run it remotely with --run_per_test=100.
