### PR TITLE
Allow oauth login to work for subdomains.

### DIFF
--- a/server/endpoint_urls/build_buddy_url/build_buddy_url.go
+++ b/server/endpoint_urls/build_buddy_url/build_buddy_url.go
@@ -2,6 +2,7 @@ package build_buddy_url
 
 import (
 	"net/url"
+	"strings"
 
 	flagtypes "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types"
 )
@@ -14,4 +15,13 @@ func WithPath(path string) *url.URL {
 
 func String() string {
 	return buildBuddyURL.String()
+}
+
+func Domain() string {
+	hostname := buildBuddyURL.Hostname()
+	pts := strings.Split(hostname, ".")
+	if len(pts) < 2 {
+		return hostname
+	}
+	return strings.Join(pts[len(pts)-2:], ".")
 }

--- a/server/endpoint_urls/build_buddy_url/build_buddy_url.go
+++ b/server/endpoint_urls/build_buddy_url/build_buddy_url.go
@@ -17,6 +17,9 @@ func String() string {
 	return buildBuddyURL.String()
 }
 
+// Domain returns the domain portion of the BuildBuddy URL.
+// e.g. If the URL is "app.buildbuddy.io", the returned domain will be
+// "buildbuddy.io".
 func Domain() string {
 	hostname := buildBuddyURL.Hostname()
 	pts := strings.Split(hostname, ".")

--- a/server/util/cookie/BUILD
+++ b/server/util/cookie/BUILD
@@ -5,4 +5,8 @@ go_library(
     srcs = ["cookie.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/cookie",
     visibility = ["//visibility:public"],
+    deps = [
+        "//server/endpoint_urls/build_buddy_url",
+        "//server/util/subdomain",
+    ],
 )

--- a/server/util/cookie/BUILD
+++ b/server/util/cookie/BUILD
@@ -5,8 +5,5 @@ go_library(
     srcs = ["cookie.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/cookie",
     visibility = ["//visibility:public"],
-    deps = [
-        "//server/endpoint_urls/build_buddy_url",
-        "//server/util/subdomain",
-    ],
+    deps = ["//server/endpoint_urls/build_buddy_url"],
 )

--- a/server/util/cookie/cookie.go
+++ b/server/util/cookie/cookie.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
+	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
 )
 
 const (
@@ -23,10 +26,19 @@ var (
 	httpsOnlyCookies = flag.Bool("auth.https_only_cookies", false, "If true, cookies will only be set over https connections.")
 )
 
+func cookieDomain() string {
+	domain := ""
+	if subdomain.Enabled() {
+		domain = build_buddy_url.Domain()
+	}
+	return domain
+}
+
 func SetCookie(w http.ResponseWriter, name, value string, expiry time.Time, httpOnly bool) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     name,
 		Value:    value,
+		Domain:   cookieDomain(),
 		Expires:  expiry,
 		HttpOnly: httpOnly,
 		SameSite: http.SameSiteLaxMode,

--- a/server/util/cookie/cookie.go
+++ b/server/util/cookie/cookie.go
@@ -62,7 +62,13 @@ func clearCookie(w http.ResponseWriter, name, domain string) {
 }
 
 func ClearCookie(w http.ResponseWriter, name string) {
-	clearCookie(w, name, cookieDomain())
+	cd := cookieDomain()
+	// If we're setting the domain on cookies, make sure we also clear out
+	// any cookies that didn't have the domain set.
+	if cd != "" {
+		clearCookie(w, name, "" /*=domain*/)
+	}
+	clearCookie(w, name, cd)
 }
 
 func GetCookie(r *http.Request, name string) string {

--- a/server/util/cookie/cookie.go
+++ b/server/util/cookie/cookie.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
-	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
 )
 
 const (
@@ -23,12 +22,13 @@ const (
 )
 
 var (
-	httpsOnlyCookies = flag.Bool("auth.https_only_cookies", false, "If true, cookies will only be set over https connections.")
+	httpsOnlyCookies  = flag.Bool("auth.https_only_cookies", false, "If true, cookies will only be set over https connections.")
+	domainWideCookies = flag.Bool("auth.domain_wide_cookies", false, "If true, cookies will have domain set so that they are accessible on domain and all subdomains.")
 )
 
 func cookieDomain() string {
 	domain := ""
-	if subdomain.Enabled() {
+	if *domainWideCookies {
 		domain = build_buddy_url.Domain()
 	}
 	return domain

--- a/server/util/subdomain/subdomain.go
+++ b/server/util/subdomain/subdomain.go
@@ -40,3 +40,7 @@ func Get(ctx context.Context) string {
 	v, _ := ctx.Value(subdomainKey).(string)
 	return v
 }
+
+func Enabled() bool {
+	return *enableSubdomainMatching
+}

--- a/server/util/url/url.go
+++ b/server/util/url/url.go
@@ -2,6 +2,7 @@ package url
 
 import (
 	"net/url"
+	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -24,9 +25,13 @@ func ValidateRedirect(env environment.Env, redirectURL string) error {
 	if err != nil {
 		return err
 	}
-	myURL := build_buddy_url.WithPath("")
-	if redir.Hostname() != "" && redir.Hostname() != myURL.Hostname() {
-		return status.InvalidArgumentErrorf("Redirect url %q not found on this domain %q", redirectURL, myURL.Host)
+	if redir.Hostname() == "" {
+		return nil
+	}
+
+	myDomain := build_buddy_url.Domain()
+	if redir.Hostname() != myDomain && !strings.HasSuffix(redir.Hostname(), "."+myDomain) {
+		return status.InvalidArgumentErrorf("Redirect url %q not found on this domain %q", redirectURL, myDomain)
 	}
 	return nil
 }


### PR DESCRIPTION
Set domain on cookies to allow cookies to be shared across subdomains and domain. Auth flow will happen on the domain auth endpoint and redirect back to the subdomain after auth.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
