### PR TITLE
upgrade vm kernel image to 5.15

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -7144,7 +7144,7 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
     )
     http_file(
         name = "org_kernel_git_linux_kernel-vmlinux",
-        sha256 = "57fb3f81d91709c9fe36ba420ca29042eac314f931ade2218daf085b031cf40f",
-        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/linux/vmlinux-v5.4-57fb3f81d91709c9fe36ba420ca29042eac314f931ade2218daf085b031cf40f"],
+        sha256 = "4582d9c5d572c0449f55cc1cf317bf154dc0ff25df97378991f7c5bc9554f14e",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/linux/vmlinux-v5.15-4582d9c5d572c0449f55cc1cf317bf154dc0ff25df97378991f7c5bc9554f14e"],
         executable = True,
     )

--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -220,7 +220,7 @@ func main() {
 	log.Infof("Starting BuildBuddy init (args: %s)", os.Args)
 
 	die(mkdirp("/dev", 0755))
-	die(mount("devtmpfs", "/dev", "devtmpfs", syscall.MS_NOSUID, "mode=0620,gid=5,ptmxmode=666"))
+	die(mount("devtmpfs", "/dev", "devtmpfs", syscall.MS_NOSUID, "mode=0620,gid=5"))
 
 	// The following devices are provided by our firecracker implementation:
 	//


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
This seems to fix segfaulting issues in Brandon's repro script on my test setup (a c2 machine running 20.04 / 5.15 on the host and the 20.04 workflows image on the guest).


Do we want to flag guard this? probably?  It's basically as easy to roll back as it is to flag guard though, so I dunno. I'd like to wait to merge this until later this week so that it can have longer to bake, which I guess is just another reason to flag guard it.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
