### PR TITLE
Fix missing Test target metadata in target v2 page

### DIFF
--- a/server/build_event_protocol/event_index/event_index.go
+++ b/server/build_event_protocol/event_index/event_index.go
@@ -70,6 +70,7 @@ func (idx *Index) Add(event *inpb.InvocationEvent) {
 		idx.BuildTargetByLabel[label] = &trpb.Target{
 			Metadata: &trpb.TargetMetadata{
 				Label:    label,
+				TestSize: cmnpb.TestSize(p.Configured.GetTestSize()),
 				RuleType: p.Configured.GetTargetKind(),
 			},
 			Status: cmnpb.Status_BUILDING,
@@ -120,8 +121,13 @@ func (idx *Index) Add(event *inpb.InvocationEvent) {
 			// the TestSummary for now.
 			return
 		}
+		configuredTarget := idx.BuildTargetByLabel[label]
 		idx.TestTargetByLabel[label] = &trpb.Target{
-			Metadata:    &trpb.TargetMetadata{Label: label},
+			Metadata: &trpb.TargetMetadata{
+				Label:    label,
+				TestSize: configuredTarget.GetMetadata().GetTestSize(),
+				RuleType: configuredTarget.GetMetadata().GetRuleType(),
+			},
 			Status:      api_common.TestStatusToStatus(summary.GetOverallStatus()),
 			Timing:      api_common.TestTimingFromSummary(summary),
 			TestSummary: summary,


### PR DESCRIPTION
Fixes these 2 little chips not showing up for Test targets (they were rendering correctly for build targets, just not test targets)

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/4f980357-3bc9-4b00-a20e-a053d0927a1b)

**Related issues**: N/A
