### PR TITLE
Fix podman pull error handling

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//server/util/disk",
         "//server/util/grpc_client",
         "//server/util/healthcheck",
+        "//server/util/lockingbuffer",
         "//server/util/log",
         "//server/util/networking",
         "//server/util/prefix",

--- a/server/util/log/log.go
+++ b/server/util/log/log.go
@@ -485,6 +485,7 @@ func CtxFatalf(ctx context.Context, format string, args ...interface{}) {
 }
 
 type logWriter struct {
+	ctx    context.Context
 	prefix string
 }
 
@@ -494,7 +495,7 @@ func (w *logWriter) Write(b []byte) (int, error) {
 		if line == "" {
 			continue
 		}
-		Infof("%s%s", w.prefix, line)
+		CtxInfof(w.ctx, "%s%s", w.prefix, line)
 	}
 	return len(b), nil
 }
@@ -502,5 +503,12 @@ func (w *logWriter) Write(b []byte) (int, error) {
 // Writer returns a writer that outputs written data to the log with each line
 // prepended with the given prefix.
 func Writer(prefix string) io.Writer {
-	return &logWriter{prefix: prefix}
+	return &logWriter{ctx: context.Background(), prefix: prefix}
+}
+
+// CtxWriter returns a writer that outputs written data to the log with each
+// line prepended with the given prefix. Logs are enriched with information from
+// the context (e.g. invocation_id, request_id).
+func CtxWriter(ctx context.Context, prefix string) io.Writer {
+	return &logWriter{ctx: ctx, prefix: prefix}
 }


### PR DESCRIPTION
* When `podman_pull_log_level` is set, don't drop stderr from the error message returned back to bazel. This was happening in dev only. The reason this was happening is that if `stdio.Stderr` is non-nil then stderr will not be buffered in the pullResult, and instead only streamed to `stdio.Stderr`.
* Use new `CtxWriter` so we can associate the pull logs with task ID.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/2572
