### PR TITLE
Surface action failure details at top of invocation page

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -266,6 +266,7 @@ ts_library(
     srcs = ["invocation_error_card.tsx"],
     deps = [
         "//app/invocation:invocation_model",
+        "//proto:failure_details_ts_proto",
         "@npm//@types/react",
         "@npm//lucide-react",
         "@npm//react",

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -162,6 +162,15 @@
   height: 18px;
 }
 
+.invocation-error-card .error-contents {
+  background: #fafafa;
+  border-radius: 8px;
+  padding: 8px 16px;
+  max-height: 360px;
+  white-space: pre-wrap;
+  overflow-y: scroll;
+}
+
 .file-name {
   display: flex;
   align-items: flex-start;

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -336,9 +336,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
             />
           )}
 
-          {(activeTab === "all" || activeTab == "log") && this.state.model.aborted?.aborted?.description && (
-            <ErrorCardComponent model={this.state.model} />
-          )}
+          {(activeTab === "all" || activeTab == "log") && <ErrorCardComponent model={this.state.model} />}
 
           {(activeTab === "all" || activeTab == "log") && this.state.model.botSuggestions.length > 0 && (
             <InvocationBotCard suggestions={this.state.model.botSuggestions} />

--- a/app/invocation/invocation_error_card.tsx
+++ b/app/invocation/invocation_error_card.tsx
@@ -1,20 +1,40 @@
 import { AlertCircle } from "lucide-react";
 import React from "react";
 import InvocationModel from "./invocation_model";
+import { failure_details } from "../../proto/failure_details_ts_proto";
 
 interface Props {
   model: InvocationModel;
 }
 
+/**
+ * Displays a card containing the main reason that an invocation failed.
+ */
 export default class ErrorCardComponent extends React.Component<Props> {
   render() {
+    let title = "";
+    let description = "";
+    if (this.props.model.failedAction?.action?.failureDetail?.message) {
+      title = "Build action failed";
+      description = this.props.model.failedAction.action.failureDetail.message;
+      const spawnCode = this.props.model.failedAction?.action?.failureDetail?.spawn?.code;
+      if (spawnCode) {
+        title += ` (code: ${failure_details.Spawn.Code[spawnCode]})`;
+      }
+    } else if (this.props.model.aborted?.aborted?.description) {
+      title = "Build aborted";
+      description = this.props.model.aborted.aborted.description;
+    } else {
+      return null;
+    }
+
     return (
-      <div className="card card-failure">
-        <AlertCircle className="icon" />
+      <div className="invocation-error-card card card-failure">
+        <AlertCircle className="icon red" />
         <div className="content">
-          <div className="title">Error</div>
+          <div className="title">{title}</div>
           <div className="details">
-            {this.props.model.aborted?.aborted?.description || "No description was found for this error."}
+            <pre className="error-contents">{description}</pre>
           </div>
         </div>
       </div>

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -44,6 +44,7 @@ export default class InvocationModel {
   structuredCommandLine: command_line.CommandLine[] = [];
   finished?: build_event_stream.BuildFinished;
   aborted?: build_event_stream.BuildEvent;
+  failedAction?: build_event_stream.BuildEvent;
   toolLogs?: build_event_stream.BuildToolLogs;
   workflowConfigured?: build_event_stream.WorkflowConfigured;
   childInvocationsConfigured?: build_event_stream.ChildInvocationsConfigured;
@@ -111,6 +112,10 @@ export default class InvocationModel {
         let results = this.actionMap.get(buildEvent.id.actionCompleted.label) || [];
         results.push(event as invocation.InvocationEvent);
         this.actionMap.set(buildEvent.id.actionCompleted.label, results);
+
+        if (buildEvent?.action?.failureDetail?.message && !this.failedAction) {
+          this.failedAction = buildEvent;
+        }
       }
       if (buildEvent.testSummary && buildEvent.id?.testSummary?.label) {
         this.testSummaryMap.set(buildEvent.id.testSummary.label, event as invocation.InvocationEvent);

--- a/server/build_event_protocol/event_index/event_index.go
+++ b/server/build_event_protocol/event_index/event_index.go
@@ -146,6 +146,11 @@ func (idx *Index) Add(event *inpb.InvocationEvent) {
 		}
 	case *bespb.BuildEvent_Action:
 		idx.ActionEvents = append(idx.ActionEvents, event.GetBuildEvent())
+		// Include failed ActionEvents in the top level events so that they
+		// can be rendered as the reason the invocation failed.
+		if p.Action.GetFailureDetail().GetMessage() != "" {
+			idx.TopLevelEvents = append(idx.TopLevelEvents, event)
+		}
 	case *bespb.BuildEvent_Aborted:
 		label := event.GetBuildEvent().GetId().GetTargetCompleted().GetLabel()
 		target := idx.BuildTargetByLabel[label]


### PR DESCRIPTION
Invocation: https://app.buildbuddy.dev/invocation/936ea81e-f90e-4296-a3f7-fbeec5dfdb66

Before (we have to scroll up in the logs to see the root cause):

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/03990813-84ff-40b4-b1b8-162a1e910596)

After:

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/5918a3c0-fbac-46bb-83ea-a81798292078)

**Related issues**: N/A
