### PR TITLE
Copy firecracker/jailer from deps.bzl as part of enable_local_firecracker.sh

### DIFF
--- a/tools/enable_local_firecracker.sh
+++ b/tools/enable_local_firecracker.sh
@@ -11,11 +11,6 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
 fi
 
-if ! command -v jailer &>/dev/null; then
-    echo "jailer could not be found (install firecracker + jailer?)"
-    exit 1
-fi
-
 if ! command -v ip &>/dev/null; then
     echo "ip could not be found (install iproute2?)"
     exit 1
@@ -23,6 +18,14 @@ fi
 
 if ! command -v iptables &>/dev/null; then
     echo "iptables could not be found"
+    exit 1
+fi
+
+# Install firecracker to make sure the local version matches the one in deps.bzl.
+tools/install_firecracker.sh
+
+if ! command -v jailer &>/dev/null; then
+    echo "jailer could not be found (make sure /usr/local/bin is in PATH)"
     exit 1
 fi
 

--- a/tools/install_firecracker.sh
+++ b/tools/install_firecracker.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+
+# Installs or update firecracker to match the local version in deps.bzl.
+
+: "${BAZEL:=bazelisk}"
+
+if ! [[ "$SUDO_USER" ]]; then
+  echo >&2 "Script must be run with sudo."
+  exit 1
+fi
+
+# Build as the original user to avoid creating a bunch of files that can only be
+# removed with sudo.
+echo >&2 "Fetching firecracker/jailer with bazel..."
+WORKSPACE_DIR=$(pwd)
+su - "$SUDO_USER" -c "
+  cd $WORKSPACE_DIR
+  $BAZEL build //enterprise/server/cmd/executor:firecracker //enterprise/server/cmd/executor:jailer
+"
+
+cp_with_backup() {
+  src="$1"
+  dst="$2"
+  if [[ -e "$dst" ]]; then
+    if cmp --silent "$src" "$dst"; then
+      return
+    fi
+    backup=$(mktemp --suffix "-$(basename "$dst")")
+    echo >&2 "Backing up existing $dst to $backup"
+    mv "$dst" "$backup"
+  fi
+  cp "$src" "$dst"
+}
+
+cp_with_backup bazel-bin/enterprise/server/cmd/executor/firecracker /usr/local/bin/firecracker
+cp_with_backup bazel-bin/enterprise/server/cmd/executor/jailer /usr/local/bin/jailer


### PR DESCRIPTION
When running firecracker locally (i.e. not on an executor), after updating the firecracker/jailer version in `deps.bzl`, we have to copy the new `firecracker` / `jailer` binaries to `/usr/local/bin/`. This PR makes it so that `enable_local_firecracker.sh` does this automatically.

A future improvement would be to check whether the firecracker/jailer SHA256 located in PATH matches the one bundled in vmsupport, and if not, then fail the action with a loud error saying that the one in PATH needs to be updated. Otherwise, it's really easy to run the executor with an outdated firecracker/jailer version and then be unknowingly testing the wrong thing.

**Related issues**: N/A
