### PR TITLE
Add missing request/response context fields

### DIFF
--- a/proto/quota.proto
+++ b/proto/quota.proto
@@ -104,6 +104,7 @@ message GetNamespaceRequest {
 }
 
 message GetNamespaceResponse {
-  context.ResponseContext request_context = 1;
+  context.ResponseContext response_context = 1;
+
   repeated Namespace namespaces = 2;
 }

--- a/proto/target.proto
+++ b/proto/target.proto
@@ -184,6 +184,8 @@ message TargetGroup {
 }
 
 message GetTargetRequest {
+  context.RequestContext request_context = 6;
+
   // Invocation ID to fetch targets for.
   string invocation_id = 1;
 
@@ -207,5 +209,7 @@ message GetTargetRequest {
 }
 
 message GetTargetResponse {
+  context.ResponseContext response_context = 2;
+
   repeated TargetGroup target_groups = 1;
 }

--- a/proto/user.proto
+++ b/proto/user.proto
@@ -13,6 +13,8 @@ message GetUserRequest {
 }
 
 message GetUserResponse {
+  context.ResponseContext response_context = 6;
+
   user_id.DisplayUser display_user = 1;
 
   // The groups this user is a member of.
@@ -40,8 +42,12 @@ message CreateUserRequest {
   // UserID (buildbuddy) is generated.
   // Other values (like name, etc) will have initial values that are pulled
   // from the authentication provider response.
+
+  context.RequestContext request_context = 1;
 }
 
 message CreateUserResponse {
+  context.ResponseContext response_context = 2;
+
   user_id.DisplayUser display_user = 1;
 }

--- a/server/role_filter/BUILD
+++ b/server/role_filter/BUILD
@@ -21,6 +21,7 @@ go_test(
     deps = [
         ":role_filter",
         "//proto:buildbuddy_service_go_proto",
+        "//proto:context_go_proto",
         "//proto/api/v1:api_v1_go_proto",
         "@com_github_stretchr_testify//assert",
     ],

--- a/server/role_filter/role_filter_test.go
+++ b/server/role_filter/role_filter_test.go
@@ -9,6 +9,7 @@ import (
 
 	apipb "github.com/buildbuddy-io/buildbuddy/proto/api/v1"
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
+	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
 )
 
 func TestAllRPCsHaveExplicitRolesSpecified(t *testing.T) {
@@ -37,4 +38,25 @@ func TestAllRPCsHaveExplicitRolesSpecified(t *testing.T) {
 		"All BuildBuddyService RPCs listed in role_filter.go should be valid BuildBuddy service RPCs. "+
 			"(check for typos, or if you deleted an RPC, remove it from role_filter.go)",
 	)
+}
+
+func TestBuildBuddyServiceRPCsHaveRequestAndResponseContextFields(t *testing.T) {
+	type Req interface{ GetRequestContext() *ctxpb.RequestContext }
+	type Res interface{ GetResponseContext() *ctxpb.ResponseContext }
+	reqType := reflect.TypeOf((*Req)(nil)).Elem()
+	resType := reflect.TypeOf((*Res)(nil)).Elem()
+
+	buildbuddyServiceType := reflect.TypeOf((*bbspb.BuildBuddyServiceServer)(nil)).Elem()
+	for i := 0; i < buildbuddyServiceType.NumMethod(); i++ {
+		methodFunc := buildbuddyServiceType.Method(i).Type
+		methodName := buildbuddyServiceType.Method(i).Name
+		reqMsg := methodFunc.In(1)
+		if !reqMsg.Implements(reqType) {
+			assert.Failf(t, "missing request_context field", "BuildBuddyService/%s request message %s must have a field 'context.RequestContext request_context'", methodName, reqMsg)
+		}
+		resMsg := methodFunc.Out(0)
+		if !resMsg.Implements(resType) {
+			assert.Failf(t, "missing response_context field", "BuildBuddyService/%s response message %s must have a field 'context.ResponseContext response_context'", methodName, resMsg)
+		}
+	}
 }


### PR DESCRIPTION
Fixes a bug that GetTarget does not work in impersonation mode.

More generally, some things like role_filter / impersonation / selected group ID depend on the request context being set, so make sure we set it everywhere.

Add missing request / response context fields and a test to make sure we can't forget in the future.

**Related issues**: N/A
