### PR TITLE
[Firecracker] Add support to compute full digest of snapshot files

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -71,7 +71,6 @@ var debugStreamVMLogs = flag.Bool("executor.firecracker_debug_stream_vm_logs", f
 var debugTerminal = flag.Bool("executor.firecracker_debug_terminal", false, "Run an interactive terminal in the Firecracker VM connected to the executor's controlling terminal. For debugging only.")
 var enableNBD = flag.Bool("executor.firecracker_enable_nbd", false, "Enables network block devices for firecracker VMs.")
 var enableUFFD = flag.Bool("executor.firecracker_enable_uffd", false, "Enables userfaultfd for firecracker VMs.")
-var enableLocalSnapshotSharing = flag.Bool("executor.firecracker_enable_local_snapshot_sharing", false, "Enables local snapshot sharing for firecracker VMs. Also requires that firecracker_enable_nbd is true.")
 var dieOnFirecrackerFailure = flag.Bool("executor.die_on_firecracker_failure", false, "Makes the host executor process die if any command orchestrating or running Firecracker fails. Useful for capturing failures preemptively. WARNING: using this option MAY leave the host machine in an unhealthy state on Firecracker failure; some post-hoc cleanup may be necessary.")
 
 const (
@@ -484,7 +483,7 @@ func NewContainer(ctx context.Context, env environment.Env, imageCacheAuth *cont
 		// TODO(Maggie): Once local snapshot sharing is stable, remove runner ID
 		// from the snapshot key
 		runnerID := c.id
-		if *enableNBD && *enableLocalSnapshotSharing {
+		if *enableNBD && *snaploader.EnableLocalSnapshotSharing {
 			runnerID = ""
 		}
 		c.snapshotKey, err = snaploader.NewKey(task, cd.GetHash(), runnerID)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -373,7 +373,7 @@ func TestFirecracker_LocalSnapshotSharing(t *testing.T) {
 	t.Skip()
 
 	flags.Set(t, "executor.firecracker_enable_nbd", true)
-	flags.Set(t, "executor.firecracker_enable_local_snapshot_sharing", true)
+	flags.Set(t, "executor.enable_local_snapshot_sharing", true)
 
 	ctx := context.Background()
 	env := getTestEnv(ctx, t)

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -247,6 +247,13 @@ func (c *fileCache) AddFile(node *repb.FileNode, existingFilePath string) {
 	c.l.Add(k, e)
 }
 
+func (c *fileCache) ContainsFile(node *repb.FileNode) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	k := key(node)
+	return c.l.Contains(k)
+}
+
 func (c *fileCache) DeleteFile(node *repb.FileNode) bool {
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -338,7 +338,7 @@ func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, cow *blocki
 				return nil, status.WrapError(err, "sync dirty chunk")
 			}
 		}
-		d, err := digest.Compute(blockio.Reader(c), repb.DigestFunction_SHA256)
+		d, err := digest.Compute(blockio.Reader(c), repb.DigestFunction_BLAKE3)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
@@ -283,16 +282,6 @@ func (l *FileCacheLoader) CacheSnapshot(ctx context.Context, key *fcpb.SnapshotK
 		return nil, err
 	}
 	return &Snapshot{key: key, manifest: manifest}, nil
-}
-
-func readerFromFile(filePath string) (io.Reader, error) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	return bufio.NewReader(file), nil
 }
 
 func (l *FileCacheLoader) unpackCOW(ctx context.Context, file *fcpb.ChunkedFile, outputDirectory string) (cow *blockio.COWStore, err error) {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -676,6 +676,7 @@ type FileCache interface {
 	FastLinkFile(f *repb.FileNode, outputPath string) bool
 	DeleteFile(f *repb.FileNode) bool
 	AddFile(f *repb.FileNode, existingFilePath string)
+	ContainsFile(node *repb.FileNode) bool
 	WaitForDirectoryScanToComplete()
 
 	// TempDir returns a directory that is guaranteed to be on the same device


### PR DESCRIPTION
This fixes a race condition with local snapshot sharing (described at https://github.com/buildbuddy-io/buildbuddy/pull/4532) and will be needed for remote snapshot sharing

It also adds unit test coverage to ensure that when UFFD is enabled, the snaploader doesn't overwrite memory snapshot files it shouldn't