### PR TITLE
platform: allow env-overrides in base64

### DIFF
--- a/enterprise/server/remote_execution/platform/platform_test.go
+++ b/enterprise/server/remote_execution/platform/platform_test.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"encoding/base64"
 	"flag"
 	"fmt"
 	"strings"
@@ -430,6 +431,7 @@ func TestParse_ApplyOverrides(t *testing.T) {
 func TestEnvAndArgOverrides(t *testing.T) {
 	plat := &repb.Platform{Properties: []*repb.Platform_Property{
 		{Name: "env-overrides", Value: "A=1,B=2,A=3"},
+		{Name: "env-overrides-base64", Value: base64.StdEncoding.EncodeToString([]byte(`C={"some":1,"value":2}`)) + ",D=invalidIgnored"},
 		{Name: "extra-args", Value: "--foo,--bar=baz"},
 	}}
 	platformProps := ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: plat}})
@@ -453,6 +455,7 @@ func TestEnvAndArgOverrides(t *testing.T) {
 			{Name: "A", Value: "1"},
 			{Name: "B", Value: "2"},
 			{Name: "A", Value: "3"},
+			{Name: "C", Value: `{"some":1,"value":2}`},
 		},
 	}
 


### PR DESCRIPTION
Currently we parse env-overrides request headers with `,` to separate
between different pair of variable's name and value. This approach works
for simple value string but when folks want to pass a JSON containing
commas characters within, the parse would fail.

Provide `env-overrides-base64` as a work around for more complex values.
User could encode the `k=v` pair in base64 and pass it to the new
header. Our server will attempt to decode the pair and append it to
existing overrides.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
