### PR TITLE
sluongng/pebble block cache metrics

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -3186,6 +3186,9 @@ func (p *PebbleCache) updatePebbleMetrics() error {
 		metrics.PebbleCachePebbleLevelTablesMovedCount.With(lbls).Add(float64(l.TablesMoved - ol.TablesMoved))
 	}
 
+	// Block cache metrics.
+	metrics.PebbleCachePebbleBlockCacheSizeBytes.Set(float64(m.BlockCache.Size))
+
 	p.oldMetrics = *m
 
 	return nil

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -2119,6 +2119,14 @@ var (
 		PebbleOperation,
 	})
 
+	// Total size of cache that pebble allocate mamually from system memory using malloc.
+	PebbleCachePebbleBlockCacheSizeBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "pebble_cache_pebble_block_cache_size_bytes",
+		Help:      "The total size in pebble's block cache.",
+	})
+
 	// Temporary metric to verify AC sampling behavior.
 	PebbleCacheGroupIDSampleCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,


### PR DESCRIPTION
Pebble manages it's Block Cache memory manually with 'malloc' and
thus, the usage does not show up in Go runtime metrics.

Export the size of Block Cache to help us track the memory consumption
of Pebble.
