### PR TITLE
Remove unused db in cdcw

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1833,7 +1833,6 @@ func (p *PebbleCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompre
 type cdcWriter struct {
 	ctx        context.Context
 	pc         *PebbleCache
-	db         pebble.IPebbleDB
 	fileRecord *rfpb.FileRecord
 	key        filestore.PebbleKey
 
@@ -1860,7 +1859,6 @@ func (p *PebbleCache) newCDCCommitedWriteCloser(ctx context.Context, fileRecord 
 		ctx:            ctx,
 		eg:             eg,
 		pc:             p,
-		db:             db,
 		key:            key,
 		fileRecord:     fileRecord,
 		shouldCompress: shouldCompress,
@@ -2011,7 +2009,6 @@ func (cdcw *cdcWriter) Write(buf []byte) (int, error) {
 
 func (cdcw *cdcWriter) Close() error {
 	defer cdcw.chunker.Close()
-	defer cdcw.db.Close()
 	return nil
 }
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
We call cdcw.Close() at the start of the C[ommit function](https://github.com/buildbuddy-io/buildbuddy/blob/6f2da2755192a8e309c709947629c326745a841d/enterprise/server/backends/pebble_cache/pebble_cache.go#L1879) to wait until the chunker finished processing. However, previously we also closed the db. in cdcw.Close(). This means that we are closing the db before the file-level metadata is written. When Pebble Cache stops, it waits for the leaser to close and then close the edits channel. So in this case, we can send size updates after the edits channel closed. 
