### PR TITLE
Add async option to RunRequest

### DIFF
--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -387,12 +387,13 @@ export default class CodeComponent extends React.Component<Props, State> {
     request.gitRepo.repoUrl = `https://github.com/${this.currentOwner()}/${this.currentRepo()}.git`;
     request.bazelCommand = `${args} ${this.getBazelFlags()}`;
     request.repoState = this.getRepoState();
+    request.async = true;
 
     this.updateState({ isBuilding: true });
     rpcService.service
       .run(request)
       .then((response: runner.RunResponse) => {
-        window.open(`/invocation/${response.invocationId}`, "_blank");
+        window.open(`/invocation/${response.invocationId}?queued=true`, "_blank");
       })
       .catch((error: any) => {
         alert(error);
@@ -405,6 +406,7 @@ export default class CodeComponent extends React.Component<Props, State> {
   getRepoState() {
     let state = new runner.RunRequest.RepoState();
     state.commitSha = this.state.commitSHA;
+    state.branch = this.state.repoResponse.data.default_branch;
     var enc = new TextEncoder();
     for (let path of this.state.changes.keys()) {
       state.patch.push(

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -266,11 +266,17 @@ func (r *runnerService) Run(ctx context.Context, req *rnpb.RunRequest) (*rnpb.Ru
 	if err != nil {
 		return nil, err
 	}
+
+	res := &rnpb.RunResponse{InvocationId: invocationID}
+	if req.GetAsync() {
+		return res, nil
+	}
+
 	if err := waitUntilInvocationExists(ctx, r.env, executionID, invocationID); err != nil {
 		return nil, err
 	}
 
-	return &rnpb.RunResponse{InvocationId: invocationID}, nil
+	return res, nil
 }
 
 // waitUntilInvocationExists waits until the specified invocationID exists or

--- a/proto/runner.proto
+++ b/proto/runner.proto
@@ -80,6 +80,9 @@ message RunRequest {
 
   // Arch on which to run. Defaults to "amd64".
   string arch = 8;
+
+  // If true, start the runner but do not wait for the action to be scheduled.
+  bool async = 9;
 }
 
 message RunResponse {


### PR DESCRIPTION
This matches the new async option in the `ExecuteWorkflowRequest` and allows clicking run button to immediately take you to the invocation page (with a queued message) instead of having a button that feels unresponsive.

Also populates the repoState.branch value which is now required.