### PR TITLE
Make RetypeAndFilterYAMLMap properly print format string for invalid maps

### DIFF
--- a/server/util/flagutil/yaml/yaml.go
+++ b/server/util/flagutil/yaml/yaml.go
@@ -633,7 +633,7 @@ func RetypeAndFilterYAMLMap(yamlMap map[string]any, typeMap map[string]any, pref
 			yamlSubmap, ok := yamlMap[k].(map[string]any)
 			if !ok {
 				// this is a value, not a map, and there is no corresponding type
-				alert.UnexpectedEvent("Input YAML contained non-map value %v of type %T at label %s", yamlMap[k], yamlMap[k], strings.Join(label, "."))
+				alert.UnexpectedEvent("invalid_yaml_submap", "Input YAML contained non-map value %v of type %T at label %s", yamlMap[k], yamlMap[k], strings.Join(label, "."))
 				delete(yamlMap, k)
 			}
 			err := RetypeAndFilterYAMLMap(yamlSubmap, t, label)


### PR DESCRIPTION
Missing arg was failing to format the error string when i failed to type my yaml properly.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
