### PR TITLE
publish WorkflowConfiguredEvent a smidge sooner

### DIFF
--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -1307,8 +1307,9 @@ message WorkflowConfigured {
   // Adheres to the same naming convention as GOARCH in golang.
   string arch = 12;
 
-  // Container image spec for the workflow, if applicable.
-  string container_image = 13;
+  // This formerly held the workflow's configured container image. It was
+  // dropped from protocol so that the event could be published earlier.
+  reserved 13;
 }
 
 // Event describing a workflow command that completed.


### PR DESCRIPTION
This makes it so that misconfigured and unknown workflows are still logged.

We should probably rename WorkflowConfiguredEvent because the workflow isn't configured yet when this is published, but that can be done separately.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
