### PR TITLE
De-flake shortcuts_test.go

### DIFF
--- a/enterprise/server/test/webdriver/shortcuts/BUILD
+++ b/enterprise/server/test/webdriver/shortcuts/BUILD
@@ -2,7 +2,7 @@ load("//rules/webdriver:index.bzl", "go_web_test_suite")
 
 go_web_test_suite(
     name = "shortcuts_test",
-    size = "small",
+    size = "medium",
     srcs = ["shortcuts_test.go"],
     shard_count = 2,
     tags = ["manual"],  # TODO(iain-macdonald): Fix and re-enable


### PR DESCRIPTION
This PR makes a few small changes to make shortcuts_test.go not flaky anymore:
- Increases the size from small to medium because it was timing out about one time in 50.
- Adds a check that there are indeed three invocations in the test that exercises the history page navigation shortcuts, this was causing lots of failures later in the test previously, so this makes it a little bit more obvious that it's not a problem navigating between invocations but a problem that there are not as many invocations as expected.
- Sets an API key for invocations run against the test server. Without this _some_ invocations aren't correctly recorded. I didn't dig into why it only happens some times.
- And finally, removes the manual tag from the test so it can run in CI.

Here's a link with 100/100 runs passing: https://app.buildbuddy.io/invocation/5e128d04-6e9e-4a2b-a25f-0509be585bf2

**Related issues**: N/A
