### PR TITLE
fix width of title workflow history so that the status charts always line up.

### DIFF
--- a/enterprise/app/workflows/action_list.tsx
+++ b/enterprise/app/workflows/action_list.tsx
@@ -168,7 +168,7 @@ export default class ActionListComponent extends React.Component<ActionListCompo
           return (
             <Link href={router.getWorkflowActionHistoryUrl(this.props.repoUrl, h.actionName)}>
               <div className={"card action-history-card card-" + getCardClass(latestRunStatus)}>
-                <div>
+                <div className="title-section">
                   <div className="title">{h.actionName}</div>
                   {latestCompletedRun && (
                     <div className="subtitle">

--- a/enterprise/app/workflows/workflows.css
+++ b/enterprise/app/workflows/workflows.css
@@ -443,6 +443,10 @@
   justify-content: space-between;
 }
 
+.workflows-page .card.action-history-card .title-section {
+  flex: 0 0 200px;
+}
+
 .workflows-page .action-stat {
   display: inline-block;
 }


### PR DESCRIPTION


<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
