### PR TITLE
Disable credential helper for 'git fetch'

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1546,7 +1546,7 @@ func (ws *workspace) fetch(ctx context.Context, remoteURL string, branches []str
 	if _, err := git(ctx, io.Discard, "remote", "add", remoteName, authURL); err != nil && !isRemoteAlreadyExists(err) {
 		return status.UnknownErrorf("Command `git remote add %q <url>` failed.", remoteName)
 	}
-	fetchArgs := append([]string{"fetch", "--filter=blob:none", "--force", remoteName}, branches...)
+	fetchArgs := append([]string{"-c", "credential.helper=", "fetch", "--filter=blob:none", "--force", remoteName}, branches...)
 	if _, err := git(ctx, ws.log, fetchArgs...); err != nil {
 		return err
 	}


### PR DESCRIPTION
Disables the git credential helper for `git fetch`. It's unclear why sometimes we are getting 'invalid username or password' on certain `git fetch` commands, but this PR will let us rule out whether it's because of the cred helper.

**Related issues**: N/A
