### PR TITLE
Allow GetGroup to return group info for the current subdomain.

### DIFF
--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -54,6 +54,7 @@ go_library(
         "//server/util/request_context",
         "//server/util/role",
         "//server/util/status",
+        "//server/util/subdomain",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//encoding/protojson",

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/role"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
@@ -340,8 +341,13 @@ func (s *BuildBuddyServer) GetGroup(ctx context.Context, req *grpb.GetGroupReque
 	}
 	urlIdentifier := strings.TrimSpace(req.GetUrlIdentifier())
 	if urlIdentifier == "" {
-		return nil, status.InvalidArgumentError("URL identifier is required.")
+		if sd := subdomain.Get(ctx); sd != "" {
+			urlIdentifier = sd
+		} else {
+			return nil, status.InvalidArgumentError("URL identifier is required.")
+		}
 	}
+
 	group, err := userDB.GetGroupByURLIdentifier(ctx, urlIdentifier)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This will make org.domain.com/join work the same as domain.com/join/org

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
