### PR TITLE
improve cache migration dashboard

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -7670,7 +7670,7 @@
             "uid": "prom"
           },
           "editorMode": "code",
-          "expr": "sum(rate(buildbuddy_remote_cache_migration_not_found_error_count{region=\"${region}\", type=\"reader\"}[${window}])) / (sum(rate(buildbuddy_remote_cache_migration_not_found_error_count{region=\"${region}\", type=\"reader\"}[${window}])) + sum(rate(buildbuddy_remote_cache_migration_double_read_hit_count{region=\"${region}\", type=\"reader\"}[${window}])))",
+          "expr": "sum by (type) (rate(buildbuddy_remote_cache_migration_not_found_error_count{region=\"${region}\"}[${window}])) / (sum by (type) (rate(buildbuddy_remote_cache_migration_not_found_error_count{region=\"${region}\"}[${window}])) + sum by (type) (rate(buildbuddy_remote_cache_migration_double_read_hit_count{region=\"${region}\"}[${window}])))",
           "legendFormat": "{{cache_type}}",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Show the ration of double read hit to missing count for all cache request type
instead of just reader.
