### PR TITLE
Allow users to optionally link a GCP account

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -441,17 +441,3 @@ http_file(
     sha256 = "6a8ba1c9f858386edba0ea82b7bf8168ef513d1eb0df3a08cc7cf4bb89f856d0",
     url = "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem",
 )
-
-load("//rules/download:download.bzl", "download")
-
-download(
-    name = "gcloud",
-    sha256 = {
-        "linux": "332627b07483ed0e91155c4a9189e15bbdf1ae20265d6784f94672f566831387",
-        "mac-arm": "791a18beddd6620ffd52a4d6a1e14ad5f02a9126e05e78b7250d6b55f4116beb",
-    },
-    urls = {
-        "linux": ["https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-443.0.0-linux-x86_64.tar.gz"],
-        "mac-arm": ["https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-443.0.0-darwin-arm.tar.gz"],
-    },
-)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -441,3 +441,17 @@ http_file(
     sha256 = "6a8ba1c9f858386edba0ea82b7bf8168ef513d1eb0df3a08cc7cf4bb89f856d0",
     url = "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem",
 )
+
+load("//rules/download:download.bzl", "download")
+
+download(
+    name = "gcloud",
+    sha256 = {
+        "linux": "332627b07483ed0e91155c4a9189e15bbdf1ae20265d6784f94672f566831387",
+        "mac-arm": "791a18beddd6620ffd52a4d6a1e14ad5f02a9126e05e78b7250d6b55f4116beb",
+    },
+    urls = {
+        "linux": ["https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-443.0.0-linux-x86_64.tar.gz"],
+        "mac-arm": ["https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-443.0.0-darwin-arm.tar.gz"],
+    },
+)

--- a/enterprise/server/gcplink/BUILD
+++ b/enterprise/server/gcplink/BUILD
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "gcplink",
+    srcs = ["gcplink.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/gcplink",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//enterprise/server/util/keystore",
+        "//proto:context_go_proto",
+        "//proto:secrets_go_proto",
+        "//server/environment",
+        "//server/util/cookie",
+        "//server/util/request_context",
+        "//server/util/status",
+    ],
+)
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/gcplink/gcplink.go
+++ b/enterprise/server/gcplink/gcplink.go
@@ -1,0 +1,83 @@
+package gcplink
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/keystore"
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/util/cookie"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
+	skpb "github.com/buildbuddy-io/buildbuddy/proto/secrets"
+	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
+)
+
+const (
+	Issuer                      = "https://accounts.google.com"
+	scope                       = "https://www.googleapis.com/auth/cloud-platform"
+	paramName                   = "link_gcp_for_group"
+	cookieName                  = "link-gcp-for-group"
+	cookieDuration              = 1 * time.Hour
+	refreshTokenEnvVariableName = "CLOUDSDK_AUTH_REFRESH_TOKEN"
+	authAccountEnvVariableName  = "CLOUDSDK_AUTH_ACCOUNT"
+)
+
+func IsLinkRequest(r *http.Request) bool {
+	return (r.URL.Query().Get(paramName) != "" && cookie.GetCookie(r, cookie.AuthIssuerCookie) == Issuer) ||
+		cookie.GetCookie(r, cookieName) != ""
+}
+
+func RequestAccess(w http.ResponseWriter, r *http.Request, authUrl string) {
+	authUrl = strings.ReplaceAll(authUrl, "scope=", fmt.Sprintf("scope=%s+", scope))
+	cookie.SetCookie(w, cookieName, r.URL.Query().Get(paramName), time.Now().Add(cookieDuration), true)
+	http.Redirect(w, r, authUrl, http.StatusTemporaryRedirect)
+}
+
+func LinkForGroup(env environment.Env, w http.ResponseWriter, r *http.Request, email, refreshToken string) error {
+	rc := &ctxpb.RequestContext{
+		GroupId: cookie.GetCookie(r, cookieName),
+	}
+	ctx := requestcontext.ContextWithProtoRequestContext(r.Context(), rc)
+	ctx = env.GetAuthenticator().AuthenticatedHTTPContext(w, r.WithContext(ctx))
+	secretResponse, err := env.GetSecretService().GetPublicKey(ctx, &skpb.GetPublicKeyRequest{
+		RequestContext: rc,
+	})
+	if err != nil {
+		return status.PermissionDeniedErrorf("Error getting public key: %s", err)
+	}
+	box, err := keystore.NewAnonymousSealedBox(secretResponse.PublicKey.Value, refreshToken)
+	if err != nil {
+		return status.PermissionDeniedErrorf("Error sealing box: %s", err)
+	}
+	_, _, err = env.GetSecretService().UpdateSecret(ctx, &skpb.UpdateSecretRequest{
+		RequestContext: rc,
+		Secret: &skpb.Secret{
+			Name:  refreshTokenEnvVariableName,
+			Value: box,
+		},
+	})
+	if err != nil {
+		return status.PermissionDeniedErrorf("Error updating secret: %s", err)
+	}
+	box, err = keystore.NewAnonymousSealedBox(secretResponse.PublicKey.Value, email)
+	if err != nil {
+		return status.PermissionDeniedErrorf("Error sealing box: %s", err)
+	}
+	_, _, err = env.GetSecretService().UpdateSecret(ctx, &skpb.UpdateSecretRequest{
+		RequestContext: rc,
+		Secret: &skpb.Secret{
+			Name:  authAccountEnvVariableName,
+			Value: box,
+		},
+	})
+	if err != nil {
+		return status.PermissionDeniedErrorf("Error updating secret: %s", err)
+	}
+	cookie.ClearCookie(w, cookieName)
+	http.Redirect(w, r, cookie.GetCookie(r, cookie.RedirCookie), http.StatusTemporaryRedirect)
+	return nil
+}

--- a/enterprise/server/gcplink/gcplink.go
+++ b/enterprise/server/gcplink/gcplink.go
@@ -41,6 +41,7 @@ func LinkForGroup(env environment.Env, w http.ResponseWriter, r *http.Request, e
 	rc := &ctxpb.RequestContext{
 		GroupId: cookie.GetCookie(r, cookieName),
 	}
+	cookie.ClearCookie(w, cookieName)
 	ctx := requestcontext.ContextWithProtoRequestContext(r.Context(), rc)
 	ctx = env.GetAuthenticator().AuthenticatedHTTPContext(w, r.WithContext(ctx))
 	secretResponse, err := env.GetSecretService().GetPublicKey(ctx, &skpb.GetPublicKeyRequest{
@@ -77,7 +78,6 @@ func LinkForGroup(env environment.Env, w http.ResponseWriter, r *http.Request, e
 	if err != nil {
 		return status.PermissionDeniedErrorf("Error updating secret: %s", err)
 	}
-	cookie.ClearCookie(w, cookieName)
 	http.Redirect(w, r, cookie.GetCookie(r, cookie.RedirCookie), http.StatusTemporaryRedirect)
 	return nil
 }

--- a/enterprise/server/oidc/BUILD
+++ b/enterprise/server/oidc/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["oidc.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/oidc",
     deps = [
+        "//enterprise/server/gcplink",
         "//enterprise/server/selfauth",
         "//server/endpoint_urls/build_buddy_url",
         "//server/environment",


### PR DESCRIPTION
We request the GCP scope if the `link_gcp_for_group` url param is set in the auth flow.

If this param is set, we create secrets with the account email and refresh tokens.