### PR TITLE
Limit subdomain check to buildbuddy URL domain.

### DIFF
--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math/rand"
+	"net/url"
 	"strconv"
 	"testing"
 	"time"
@@ -503,6 +504,9 @@ func TestAPIKeyAuditLogs(t *testing.T) {
 
 func TestSubdomainRestrictions(t *testing.T) {
 	flags.Set(t, "app.enable_subdomain_matching", true)
+	u, err := url.Parse("https://app.buildbuddy.dev")
+	require.NoError(t, err)
+	flags.Set(t, "app.build_buddy_url", *u)
 
 	ctx := context.Background()
 	env := setupEnv(t)

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -948,7 +948,7 @@ func (s *BuildBuddyServer) replaceURLSubdomain(ctx context.Context, rawURL strin
 		return rawURL
 	}
 
-	domain := urlutil.GetDomain(pURL)
+	domain := urlutil.GetDomain(pURL.Hostname())
 	newHost := *g.URLIdentifier + "." + domain
 	if pURL.Port() != "" {
 		newHost += ":" + pURL.Port()

--- a/server/endpoint_urls/build_buddy_url/build_buddy_url.go
+++ b/server/endpoint_urls/build_buddy_url/build_buddy_url.go
@@ -41,5 +41,5 @@ func ValidateRedirect(redirectURL string) error {
 // e.g. If the URL is "app.buildbuddy.io", the returned domain will be
 // "buildbuddy.io".
 func Domain() string {
-	return urlutil.GetDomain(buildBuddyURL)
+	return urlutil.GetDomain(buildBuddyURL.Hostname())
 }

--- a/server/util/subdomain/BUILD
+++ b/server/util/subdomain/BUILD
@@ -5,7 +5,12 @@ go_library(
     srcs = ["subdomain.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/subdomain",
     visibility = ["//visibility:public"],
-    deps = ["//server/util/flagutil"],
+    deps = [
+        "//server/endpoint_urls/build_buddy_url",
+        "//server/util/flagutil",
+        "//server/util/log",
+        "//server/util/urlutil",
+    ],
 )
 
 go_test(

--- a/server/util/subdomain/BUILD
+++ b/server/util/subdomain/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//server/endpoint_urls/build_buddy_url",
         "//server/util/flagutil",
-        "//server/util/log",
         "//server/util/urlutil",
     ],
 )

--- a/server/util/subdomain/subdomain.go
+++ b/server/util/subdomain/subdomain.go
@@ -5,7 +5,9 @@ import (
 	"flag"
 	"strings"
 
+	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/urlutil"
 )
 
 const subdomainKey = "subdomain"
@@ -25,6 +27,12 @@ func SetHost(ctx context.Context, host string) context.Context {
 	if len(parts) < 3 {
 		return ctx
 	}
+
+	hostDomain := urlutil.GetDomain(host)
+	if build_buddy_url.Domain() != hostDomain {
+		return ctx
+	}
+
 	subdomain := parts[0]
 	for _, ds := range *defaultSubdomains {
 		if ds == subdomain {

--- a/server/util/subdomain/subdomain_test.go
+++ b/server/util/subdomain/subdomain_test.go
@@ -2,6 +2,7 @@ package subdomain_test
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
@@ -12,6 +13,9 @@ import (
 func TestSetHost(t *testing.T) {
 	flags.Set(t, "app.enable_subdomain_matching", true)
 	flags.Set(t, "app.default_subdomains", []string{"app", "cache"})
+	u, err := url.Parse("https://app.buildbuddy.io")
+	require.NoError(t, err)
+	flags.Set(t, "app.build_buddy_url", *u)
 
 	getSubdomain := func(in string) string {
 		return subdomain.Get(subdomain.SetHost(context.Background(), in))
@@ -23,4 +27,7 @@ func TestSetHost(t *testing.T) {
 	// Subdomains in default_subdomains list should not be returned.
 	require.Equal(t, "", getSubdomain("app.buildbuddy.io"))
 	require.Equal(t, "", getSubdomain("cache.buildbuddy.io"))
+
+	// Subdomains on a different domain shouldn't match.
+	require.Equal(t, "", getSubdomain("sub.notbuildbuddy.io"))
 }

--- a/server/util/urlutil/urlutil.go
+++ b/server/util/urlutil/urlutil.go
@@ -14,13 +14,12 @@ func SameHostname(urlStringA, urlStringB string) bool {
 	return false
 }
 
-// GetDomain returns the domain portion of the passed URL.
+// GetDomain returns the domain portion of the passed host name.
 // e.g. app.buildbuddy.io will return buildbuddy.io
 //
 // N.B. This does not generalize to all domains. Don't use this if you need
 // something that works for arbitrary domains.
-func GetDomain(url *url.URL) string {
-	hostname := url.Hostname()
+func GetDomain(hostname string) string {
 	pts := strings.Split(hostname, ".")
 	if len(pts) < 2 {
 		return hostname


### PR DESCRIPTION
This avoids incorrectly applying subdomain checks for internal traffic (i.e. distributed cache RPCs)

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
