### PR TITLE
Propagate error in distributed write.

### DIFF
--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -603,6 +603,12 @@ func (wc *streamWriteCloser) Write(data []byte) (int, error) {
 		Resource:    wc.r,
 	}
 	err := wc.stream.Send(req)
+	if err == io.EOF {
+		_, streamErr := wc.stream.CloseAndRecv()
+		if streamErr != nil {
+			return 0, streamErr
+		}
+	}
 	return len(data), err
 }
 


### PR DESCRIPTION
If the distributed cache peer closes the stream with an error, this will return the error from the peer instead of io.EOF

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
