### PR TITLE
Display stderr and some additional info for failed actions

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -266,6 +266,8 @@ ts_library(
     srcs = ["invocation_error_card.tsx"],
     deps = [
         "//app/invocation:invocation_model",
+        "//app/service:rpc_service",
+        "//app/terminal",
         "//proto:failure_details_ts_proto",
         "@npm//@types/react",
         "@npm//lucide-react",

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -171,6 +171,11 @@
   overflow-y: scroll;
 }
 
+.invocation-error-card .error-contents-important {
+  font-weight: bold;
+  margin-top: 16px;
+}
+
 .file-name {
   display: flex;
   align-items: flex-start;

--- a/app/invocation/invocation_error_card.tsx
+++ b/app/invocation/invocation_error_card.tsx
@@ -2,24 +2,46 @@ import { AlertCircle } from "lucide-react";
 import React from "react";
 import InvocationModel from "./invocation_model";
 import { failure_details } from "../../proto/failure_details_ts_proto";
+import TerminalComponent from "../terminal/terminal";
+import rpc_service from "../service/rpc_service";
 
 interface Props {
   model: InvocationModel;
 }
 
+interface State {
+  stdErr: string;
+}
+
 /**
  * Displays a card containing the main reason that an invocation failed.
  */
-export default class ErrorCardComponent extends React.Component<Props> {
+export default class ErrorCardComponent extends React.Component<Props, State> {
+  state: State = {
+    stdErr: "",
+  };
+
+  componentDidMount() {
+    if (this.props.model.failedAction?.action?.stderr?.uri) {
+      rpc_service
+        .fetchBytestreamFile(
+          this.props.model.failedAction?.action.stderr?.uri,
+          this.props.model.getInvocationId(),
+          "text"
+        )
+        .then((resp) => this.setState({ stdErr: resp }));
+    }
+  }
+
   render() {
     let title = "";
     let description = "";
     if (this.props.model.failedAction?.action?.failureDetail?.message) {
-      title = "Build action failed";
+      title = `${this.props.model.failedAction?.action?.type} action failed with exit code ${this.props.model.failedAction?.action?.exitCode}`;
       description = this.props.model.failedAction.action.failureDetail.message;
       const spawnCode = this.props.model.failedAction?.action?.failureDetail?.spawn?.code;
       if (spawnCode) {
-        title += ` (code: ${failure_details.Spawn.Code[spawnCode]})`;
+        title += ` (${failure_details.Spawn.Code[spawnCode]})`;
       }
     } else if (this.props.model.aborted?.aborted?.description) {
       title = "Build aborted";
@@ -33,8 +55,12 @@ export default class ErrorCardComponent extends React.Component<Props> {
         <AlertCircle className="icon red" />
         <div className="content">
           <div className="title">{title}</div>
+          <div className="subtitle">{this.props.model.failedAction?.action?.label}</div>
           <div className="details">
-            <pre className="error-contents">{description}</pre>
+            <pre className="error-contents">
+              {description}
+              {this.state.stdErr && <div className="error-contents-important">{this.state.stdErr}</div>}
+            </pre>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Before (not super useful for compilation failures):
<img width="1502" alt="Screenshot 2023-08-24 at 4 15 58 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/2bfaf417-90f2-476d-afd9-2651506b65d4">

After:
<img width="1500" alt="Screenshot 2023-08-24 at 4 15 23 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/122c07c8-e014-41c4-a6eb-8ee5dc8697de">

