### PR TITLE
Fix UFFDIO_COPY size within last memory chunk

### DIFF
--- a/enterprise/server/remote_execution/blockio/blockio.go
+++ b/enterprise/server/remote_execution/blockio/blockio.go
@@ -274,14 +274,15 @@ func (c *COWStore) GetRelativeOffsetFromChunkStart(offset uintptr) uintptr {
 }
 
 // GetChunkStartAddressAndSize returns the start address of the chunk containing
-// the input offset, and the chunk size
+// the input offset, and the size of the chunk. Note that the returned chunk
+// size may not be equal to ChunkSizeBytes() if it's the last chunk in the file.
 func (c *COWStore) GetChunkStartAddressAndSize(offset uintptr, write bool) (uintptr, int64, error) {
 	chunkStartOffset := c.chunkStartOffset(int64(offset))
 	chunkStartAddress, err := c.GetPageAddress(uintptr(chunkStartOffset), write)
 	if err != nil {
 		return 0, 0, err
 	}
-	return chunkStartAddress, c.chunkSizeBytes, nil
+	return chunkStartAddress, c.calculateChunkSize(chunkStartOffset), nil
 }
 
 // GetPageAddress returns the memory address for the given byte offset into

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -268,11 +268,6 @@ func resolvePageFault(uffd uintptr, faultingRegion uint64, src uint64, size uint
 	}
 	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uffd, UFFDIO_COPY, uintptr(unsafe.Pointer(&copyData)))
 	if errno != 0 {
-		if errno == unix.ENOENT {
-			// The faulting process changed its virtual memory layout simultaneously with an outstanding UFFDIO_COPY
-			// The UFFDIO_COPY will have aborted and the handler should continue to serve page faults
-			return 0, nil
-		}
 		return 0, status.InternalErrorf("UFFDIO_COPY failed with errno(%d)", errno)
 	}
 	return int64(copyData.Copy), nil


### PR DESCRIPTION
In my local testing this fixes the "possible stuck request" issue that we've seen with `firecracker_test_blockio`.

**Related issues**: N/A
