### PR TITLE
Don't use common interceptors for nbdserver

### DIFF
--- a/enterprise/server/remote_execution/nbd/nbdserver/nbdserver.go
+++ b/enterprise/server/remote_execution/nbd/nbdserver/nbdserver.go
@@ -75,7 +75,10 @@ func (s *Server) SetDevice(name string, device *Device) {
 // Start starts the device server.
 // lis will be closed when calling Stop().
 func (s *Server) Start(lis net.Listener) error {
-	s.server = grpc.NewServer(grpc_server.CommonGRPCServerOptions(s.env)...)
+	// Intentionally using a minimal set of server options here here since the
+	// common interceptors add overhead to each disk I/O operation and also add
+	// noise to the logs.
+	s.server = grpc.NewServer(grpc_server.KeepaliveEnforcementPolicy())
 	nbdpb.RegisterBlockDeviceServer(s.server, s)
 	go func() {
 		_ = s.server.Serve(lis)

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -219,12 +219,16 @@ func CommonGRPCServerOptions(env environment.Env) []grpc.ServerOption {
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
 		grpc.MaxRecvMsgSize(*gRPCMaxRecvMsgSizeBytes),
-		// Set to avoid errors: Bandwidth exhausted HTTP/2 error code: ENHANCE_YOUR_CALM Received Goaway too_many_pings
-		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-			MinTime:             10 * time.Second, // If a client pings more than once every 10 seconds, terminate the connection
-			PermitWithoutStream: true,             // Allow pings even when there are no active streams
-		}),
+		KeepaliveEnforcementPolicy(),
 	}
+}
+
+func KeepaliveEnforcementPolicy() grpc.ServerOption {
+	// Set to avoid errors: Bandwidth exhausted HTTP/2 error code: ENHANCE_YOUR_CALM Received Goaway too_many_pings
+	return grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+		MinTime:             10 * time.Second, // If a client pings more than once every 10 seconds, terminate the connection
+		PermitWithoutStream: true,             // Allow pings even when there are no active streams
+	})
 }
 
 func MaxRecvMsgSizeBytes() int {


### PR DESCRIPTION
This interceptors add too much noise to the logs and (probably) add unnecessary overhead to each I/O operation. The nbdserver is sort of an "implementation detail" of the executor and not exposed externally, so we don't get much benefit from using the common interceptors.

**Related issues**: N/A
