### PR TITLE
ci_runner,executor: remove os-specific syscall

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -17,7 +17,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/build_event_publisher"
@@ -854,7 +853,13 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 		// completed so that the outer workflow invocation gets disconnected
 		// rather than finishing with an error.
 		if *workflowID != "" && exitCode == bazelLocalEnvironmentalErrorExitCode {
-			syscall.Kill(os.Getpid(), syscall.SIGKILL)
+			p, err := os.FindProcess(os.Getpid())
+			if err != nil {
+				return err
+			}
+			if err := p.Kill(); err != nil {
+				return err
+			}
 		}
 
 		// If this is a successfully "bazel run" invocation from which we are extracting run information via

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -10,6 +10,8 @@ go_library(
         "executor.go",
         "executor_linux.go",
         "executor_notlinux.go",
+        "executor_unix.go",
+        "executor_windows.go",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/executor",
     visibility = ["//visibility:public"],

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"syscall"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/auth"
@@ -143,14 +142,7 @@ func GetConfiguredEnvironmentOrDie(healthChecker *healthcheck.HealthChecker) env
 }
 
 func main() {
-	// The default umask (0022) has the effect of clearing the group-write and
-	// others-write bits when setting up workspace directories, regardless of the
-	// permissions bits passed to mkdir. We want to create these directories with
-	// 0777 permissions in some cases, because we need those to be writable by the
-	// container user, and it is too costly to enable those permissions via
-	// explicit chown or chmod calls on those directories. So, we clear the umask
-	// here to allow group-write and others-write permissions.
-	syscall.Umask(0)
+	setUmask()
 
 	rootContext := context.Background()
 

--- a/enterprise/server/cmd/executor/executor_unix.go
+++ b/enterprise/server/cmd/executor/executor_unix.go
@@ -1,0 +1,16 @@
+//go:build unix
+
+package main
+
+import "syscall"
+
+func setUmask() {
+	// The default umask (0022) has the effect of clearing the group-write and
+	// others-write bits when setting up workspace directories, regardless of the
+	// permissions bits passed to mkdir. We want to create these directories with
+	// 0777 permissions in some cases, because we need those to be writable by the
+	// container user, and it is too costly to enable those permissions via
+	// explicit chown or chmod calls on those directories. So, we clear the umask
+	// here to allow group-write and others-write permissions.
+	syscall.Umask(0)
+}

--- a/enterprise/server/cmd/executor/executor_windows.go
+++ b/enterprise/server/cmd/executor/executor_windows.go
@@ -1,0 +1,4 @@
+package main
+
+func setUmask() {
+}


### PR DESCRIPTION
Replace the os-specific syscall in ci_runner and executor by using an os-specific source file, or by switching to an alternative implementation.