### PR TITLE
Add a route to select a specific group ID.

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -176,6 +176,18 @@ export class AuthService {
     rpcService.requestContext.groupId = this.user?.selectedGroup?.id || "";
   }
 
+  redirectToGroupId(groupId: string) {
+    const newURL = new URL(window.location.href)
+    const path = newURL.searchParams.get("path")
+    if (!path) {
+      throw new Error("path parameter missing")
+    }
+    newURL.searchParams.delete("path")
+    window.localStorage.setItem(SELECTED_GROUP_ID_LOCAL_STORAGE_KEY, groupId);
+    newURL.pathname = path
+    window.location.replace(newURL.toString())
+  }
+
   async setSelectedGroupId(groupId: string, { reload = false }: { reload?: boolean } = {}) {
     if (!this.user) throw new Error("failed to set selected group ID: not logged in");
 

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -94,6 +94,12 @@ export default class EnterpriseRootComponent extends React.Component {
 
   componentDidMount() {
     errorService.register();
+    if (this.state.path.startsWith("/org/GR")) {
+      const groupId = window.location.pathname.split("/").pop();
+      if (groupId && groupId.startsWith("GR")) {
+        authService.redirectToGroupId(groupId);
+      }
+    }
   }
 
   handlePathChange() {


### PR DESCRIPTION
/org/GR123?path=/foo will set the selected group to GR123 and redirect to /foo.

When switching groups on a subdomain, we need a way to redirect to a specific group on the app subdomain if the group does not have a URL identifier set.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
