### PR TITLE
Show partial test results in the invocation page

### DIFF
--- a/server/api/common/common.go
+++ b/server/api/common/common.go
@@ -173,6 +173,15 @@ func TestTimingFromSummary(testSummary *bespb.TestSummary) *cmnpb.Timing {
 	}
 }
 
+func TestResultTiming(testResult *bespb.TestResult) *cmnpb.Timing {
+	startTime := timeutil.GetTimeWithFallback(testResult.GetTestAttemptStart(), testResult.GetTestAttemptStartMillisEpoch())
+	duration := timeutil.GetDurationWithFallback(testResult.GetTestAttemptDuration(), testResult.GetTestAttemptDurationMillis())
+	return &cmnpb.Timing{
+		StartTime: timestamppb.New(startTime),
+		Duration:  durationpb.New(duration),
+	}
+}
+
 func TargetMapFromInvocation(inv *inpb.Invocation) TargetMap {
 	targetMap := make(TargetMap)
 	for _, event := range inv.GetEvent() {


### PR DESCRIPTION
If we have a TestResult event for a given label but we haven't yet gotten the TestSummary (because the test is still running), make sure we show a target status in the invocation page. This will let users see failed test results sooner, which is useful for longer running tests with multiple shards / attempts.

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/2606
