### PR TITLE
Store selected group ID in cookie instead of local storage.

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -27,13 +27,14 @@ export class AuthService {
   register() {
     if (!capabilities.auth) return;
     // Set initially preferred group ID from cookie.
-    const preferredGroupId = this.getCookie(SELECTED_GROUP_ID_COOKIE) ||
-        window.localStorage.getItem(SELECTED_GROUP_ID_LOCAL_STORAGE_KEY) ||
-        "";
+    const preferredGroupId =
+      this.getCookie(SELECTED_GROUP_ID_COOKIE) ||
+      window.localStorage.getItem(SELECTED_GROUP_ID_LOCAL_STORAGE_KEY) ||
+      "";
     rpcService.requestContext.groupId = preferredGroupId;
     // Store the group ID in a cookie in case it was loaded from the old
     // local storage location.
-    this.setCookie(SELECTED_GROUP_ID_COOKIE, preferredGroupId)
+    this.setCookie(SELECTED_GROUP_ID_COOKIE, preferredGroupId);
     // Set impersonating group ID from session storage, so impersonation doesn't
     // persist across different sessions.
     rpcService.requestContext.impersonatingGroupId =
@@ -71,11 +72,11 @@ export class AuthService {
   }
 
   setCookie(name: string, value: string) {
-    let cookie = `${name}=${value}; max-age=31536000;`
+    let cookie = `${name}=${value}; max-age=31536000;`;
     if (capabilities.config.subdomainsEnabled) {
-      cookie += ` domain=${capabilities.config.domain};`
+      cookie += ` domain=${capabilities.config.domain};`;
     }
-    document.cookie = cookie
+    document.cookie = cookie;
   }
 
   startRefreshTimer() {
@@ -195,7 +196,7 @@ export class AuthService {
   async setSelectedGroupId(groupId: string, { reload = false }: { reload?: boolean } = {}) {
     if (!this.user) throw new Error("failed to set selected group ID: not logged in");
 
-    this.setCookie(SELECTED_GROUP_ID_COOKIE, groupId)
+    this.setCookie(SELECTED_GROUP_ID_COOKIE, groupId);
     if (reload) {
       // Don't publish a new user to avoid UI flickering.
       window.location.reload();

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -11,6 +11,8 @@ import { User } from "./user";
 
 export { User };
 
+const SELECTED_GROUP_ID_COOKIE = "Selected-Group-ID"
+// Group ID used to be stored in local storage, but has been transitioned to being stored in a cookie.
 const SELECTED_GROUP_ID_LOCAL_STORAGE_KEY = "selected_group_id";
 const IMPERSONATING_GROUP_ID_SESSION_STORAGE_KEY = "impersonating_group_id";
 const AUTO_LOGIN_ATTEMPTED_STORAGE_KEY = "auto_login_attempted";
@@ -24,8 +26,8 @@ export class AuthService {
 
   register() {
     if (!capabilities.auth) return;
-    // Set initially preferred group ID from local storage.
-    rpcService.requestContext.groupId = window.localStorage.getItem(SELECTED_GROUP_ID_LOCAL_STORAGE_KEY) || "";
+    // Set initially preferred group ID from cookie.
+    rpcService.requestContext.groupId = this.getCookie(SELECTED_GROUP_ID_COOKIE) || window.localStorage.getItem(SELECTED_GROUP_ID_LOCAL_STORAGE_KEY) || "";
     // Set impersonating group ID from session storage, so impersonation doesn't
     // persist across different sessions.
     rpcService.requestContext.impersonatingGroupId =
@@ -179,7 +181,7 @@ export class AuthService {
   async setSelectedGroupId(groupId: string, { reload = false }: { reload?: boolean } = {}) {
     if (!this.user) throw new Error("failed to set selected group ID: not logged in");
 
-    window.localStorage.setItem(SELECTED_GROUP_ID_LOCAL_STORAGE_KEY, groupId);
+    document.cookie = `${SELECTED_GROUP_ID_COOKIE}=${groupId}; domain=${capabilities.config.domain}; max-age=31536000;`
     if (reload) {
       // Don't publish a new user to avoid UI flickering.
       window.location.reload();

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -11,7 +11,7 @@ import { User } from "./user";
 
 export { User };
 
-const SELECTED_GROUP_ID_COOKIE = "Selected-Group-ID"
+const SELECTED_GROUP_ID_COOKIE = "Selected-Group-ID";
 // Group ID used to be stored in local storage, but has been transitioned to being stored in a cookie.
 const SELECTED_GROUP_ID_LOCAL_STORAGE_KEY = "selected_group_id";
 const IMPERSONATING_GROUP_ID_SESSION_STORAGE_KEY = "impersonating_group_id";
@@ -27,7 +27,10 @@ export class AuthService {
   register() {
     if (!capabilities.auth) return;
     // Set initially preferred group ID from cookie.
-    rpcService.requestContext.groupId = this.getCookie(SELECTED_GROUP_ID_COOKIE) || window.localStorage.getItem(SELECTED_GROUP_ID_LOCAL_STORAGE_KEY) || "";
+    rpcService.requestContext.groupId =
+      this.getCookie(SELECTED_GROUP_ID_COOKIE) ||
+      window.localStorage.getItem(SELECTED_GROUP_ID_LOCAL_STORAGE_KEY) ||
+      "";
     // Set impersonating group ID from session storage, so impersonation doesn't
     // persist across different sessions.
     rpcService.requestContext.impersonatingGroupId =
@@ -181,7 +184,7 @@ export class AuthService {
   async setSelectedGroupId(groupId: string, { reload = false }: { reload?: boolean } = {}) {
     if (!this.user) throw new Error("failed to set selected group ID: not logged in");
 
-    document.cookie = `${SELECTED_GROUP_ID_COOKIE}=${groupId}; domain=${capabilities.config.domain}; max-age=31536000;`
+    document.cookie = `${SELECTED_GROUP_ID_COOKIE}=${groupId}; domain=${capabilities.config.domain}; max-age=31536000;`;
     if (reload) {
       // Don't publish a new user to avoid UI flickering.
       window.location.reload();


### PR DESCRIPTION
Having the group ID in a cookie will allow group switching to work properly between subdomain and app w/o having to resort to additional hacks.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
