### PR TITLE
docs: document env-overrides* headers

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -72,8 +72,8 @@ as normal Bazel actions shown above.
 
 For secrets that have a short Time To Live (TTL), BuildBuddy supports setting
 environment variables via special headers passed at the Bazel command line.
-Using `env-overrides` is more secure than setting environment variables with Bazel,
-as it prevents the secrets from being stored in the remote cache.
+Headers are more secure than setting environment variables with Bazel,
+as they are not stored in the remote cache.
 
 ```bash
 # For simple secrets

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -72,7 +72,8 @@ as normal Bazel actions shown above.
 
 For secrets that have a short Time To Live (TTL), BuildBuddy supports setting
 environment variables via special headers passed at the Bazel command line.
-
+Using `env-overrides` is more secure than setting environment variables with Bazel,
+as it prevents the secrets from being stored in the remote cache.
 
 ```bash
 # For simple secrets
@@ -115,10 +116,12 @@ These secrets will be set as environment variables at action execution time,
 overriding the default environment variables on your container image as well as
 the environment variables set by Bazel as part of the action configuration.
 
-Using `env-overrides` is more secure than setting environment variables with Bazel,
-as it prevents the secrets from being stored in the remote cache. However,
-these secrets *may* be cached as part of action results if not properly handled.
-For example, avoid printing secret values to the command line.
+:::warning
+
+Secrets may be cached as part of action results if not properly handled.
+Avoid printing secret values to the console or storing them in action outputs.
+
+:::
 
 Secrets that are passed through `env-overrides` or `env-overrides-base64` headers
 are not subjected to `include-secrets` control documented above.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -68,6 +68,52 @@ repository.
 Workflow secrets are accessed via environment variables, in the same way
 as normal Bazel actions shown above.
 
+## Sort-lived secrets
+
+For secrets that have a short Time To Live(TTL) duration, or ephemeral secrets,
+BuildBuddy provides special headers that could be set via Bazel command line.
+
+```bash
+# For simple secrets
+--remote_exec_header=x-buildbuddy-platform.env-overrides=VAR_A=value_a,VAR_B=val_b
+
+## At execution:
+> echo $VAR_A
+value_a
+> echo $VAR_B
+val_b
+
+---
+
+# For more complex secrets
+
+## First encode the secrets using base64
+> echo -n 'VAR_C={"a": 1, "b", 2}' | base64
+> echo -n 'VAR_D=asdfa!@#C,+{}' | base64
+
+## then use the base64-encoded strings in the `env-overrides-base64` header, comma separated.
+--remote_exec_header=x-buildbuddy-platform.env-overrides-base64=VkFSX0M9eyJhIjogMSwgImIiLCAyfQ==,VkFSX0Q9YXNkZmEhQCNDLCt7fQ==
+
+## At execution:
+> echo $VAR_C
+{"a": 1, "b", 2}
+> echo $VAR_D
+asdfa!@#C,+{}
+```
+
+> Note: If 2 values are given to the same variables, the last value will be used.
+> `env-overrides` values will be applied BEFORE `env-overrides-base64` and thus,
+> the latter would take priority.
+
+These secrets will be set as environment variables at Actions' Execution Time,
+overriding the default environment variables on your container image as well as
+the environment variables set in your Action's protobuf object. For this reason,
+using these secrets does not affect Action Cache Entry while could affect Action's
+result and could lead to Cache poisoning if miss used.
+
+Secrets that are passed through `env-overrides` or `env-overrides-base64` headers
+are not subjected to `include-secrets` control documented above.
+
 ## Security notes
 
 Secrets are encrypted on the client-side using


### PR DESCRIPTION
Provide documentation for the env-overrides headers as a way to supply
ephemeral secrets to builds.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
