### PR TITLE
Allow new firecracker runners to start from snapshots

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -85,6 +85,7 @@ go_test(
         "//enterprise/server/remote_execution/filecache",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/remote_execution/runner",
+        "//enterprise/server/remote_execution/snaploader",
         "//enterprise/server/remote_execution/workspace",
         "//enterprise/server/util/ext4",
         "//proto:firecracker_go_proto",
@@ -119,6 +120,7 @@ go_test(
     args = [
         "--executor.firecracker_enable_nbd=true",
         "--executor.firecracker_enable_uffd=true",
+        "--executor.enable_local_snapshot_sharing=true",
     ],
     exec_properties = {
         "test.Pool": "bare",
@@ -141,6 +143,7 @@ go_test(
         "//enterprise/server/remote_execution/filecache",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/remote_execution/runner",
+        "//enterprise/server/remote_execution/snaploader",
         "//enterprise/server/remote_execution/workspace",
         "//enterprise/server/util/ext4",
         "//proto:firecracker_go_proto",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/runner"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaploader"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/workspace"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ext4"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/disk_cache"
@@ -377,12 +378,9 @@ func TestFirecrackerSnapshotAndResume(t *testing.T) {
 }
 
 func TestFirecracker_LocalSnapshotSharing(t *testing.T) {
-	// TODO(Maggie): Enable test when NBD is stable
-	t.Skip()
-
-	flags.Set(t, "executor.firecracker_enable_nbd", true)
-	flags.Set(t, "executor.firecracker_enable_uffd", true)
-	flags.Set(t, "executor.enable_local_snapshot_sharing", true)
+	if !*snaploader.EnableLocalSnapshotSharing {
+		t.Skip("Snapshot sharing is not enabled")
+	}
 
 	ctx := context.Background()
 	env := getTestEnv(ctx, t)
@@ -390,6 +388,14 @@ func TestFirecracker_LocalSnapshotSharing(t *testing.T) {
 	cacheAuth := container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{})
 	rootDir := testfs.MakeTempDir(t)
 	jailerRoot := tempJailerRoot(t)
+
+	var containersToCleanup []*firecracker.FirecrackerContainer
+	t.Cleanup(func() {
+		for _, vm := range containersToCleanup {
+			err := vm.Remove(ctx)
+			assert.NoError(t, err)
+		}
+	})
 
 	// Returns a task that appends the message to a logfile, then prints the logfile so far
 	appendToLog := func(message string) *repb.Command {
@@ -419,16 +425,21 @@ func TestFirecracker_LocalSnapshotSharing(t *testing.T) {
 		},
 		JailerRoot: jailerRoot,
 	}
-	baseVM, err := firecracker.NewContainer(ctx, env, cacheAuth, &repb.ExecutionTask{}, opts)
+	task := &repb.ExecutionTask{
+		Command: &repb.Command{
+			// Note: platform must match in order to share snapshots
+			Platform: &repb.Platform{Properties: []*repb.Platform_Property{
+				{Name: "recycle-runner", Value: "true"},
+			}},
+		},
+	}
+	baseVM, err := firecracker.NewContainer(ctx, env, cacheAuth, task, opts)
 	require.NoError(t, err)
+	containersToCleanup = append(containersToCleanup, baseVM)
 	err = container.PullImageIfNecessary(ctx, env, cacheAuth, baseVM, container.PullCredentials{}, opts.ContainerImage)
 	require.NoError(t, err)
 	err = baseVM.Create(ctx, opts.ActionWorkingDirectory)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		err = baseVM.Remove(ctx)
-		require.NoError(t, err)
-	})
 
 	// Create a snapshot. Data written to this snapshot should persist
 	// when other VMs reuse the snapshot
@@ -455,13 +466,20 @@ func TestFirecracker_LocalSnapshotSharing(t *testing.T) {
 			},
 			JailerRoot: jailerRoot,
 		}
-		forkedVM, err := firecracker.NewContainer(ctx, env, cacheAuth, &repb.ExecutionTask{}, opts)
+		forkedVM, err := firecracker.NewContainer(ctx, env, cacheAuth, task, opts)
 		require.NoError(t, err)
 		containers = append(containers, forkedVM)
+		containersToCleanup = append(containersToCleanup, forkedVM)
 
-		// The new VM should reuse the Base VM's snapshot
-		err = forkedVM.Unpause(ctx)
-		require.NoError(t, err)
+		// The new VM should reuse the Base VM's snapshot, whether we call
+		// Create() or Unpause()
+		if i%2 == 0 {
+			err = forkedVM.Unpause(ctx)
+			require.NoError(t, err)
+		} else {
+			err = forkedVM.Create(ctx, workDir)
+			require.NoError(t, err)
+		}
 
 		// Write VM-specific data to the log
 		cmd = appendToLog(fmt.Sprintf("Fork-%d", i))
@@ -514,10 +532,12 @@ func TestFirecracker_LocalSnapshotSharing(t *testing.T) {
 		},
 		JailerRoot: jailerRoot,
 	}
-	c, err = firecracker.NewContainer(ctx, env, cacheAuth, &repb.ExecutionTask{}, opts)
+	c, err = firecracker.NewContainer(ctx, env, cacheAuth, task, opts)
 	require.NoError(t, err)
+	containersToCleanup = append(containersToCleanup, c)
+
 	// This VM should load the snapshot saved by the last forked VM to Pause
-	err = c.Unpause(ctx)
+	err = c.Create(ctx, workDir)
 	require.NoError(t, err)
 	cmd = appendToLog("Last")
 	res = c.Exec(ctx, cmd, nil /*=stdio*/)
@@ -525,8 +545,6 @@ func TestFirecracker_LocalSnapshotSharing(t *testing.T) {
 	require.Equal(t, "Base\nFork-3\nLast\n", string(res.Stdout))
 
 	err = c.Pause(ctx)
-	require.NoError(t, err)
-	err = c.Remove(ctx)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Building off of https://github.com/buildbuddy-io/buildbuddy/pull/4532 and https://github.com/buildbuddy-io/buildbuddy/pull/4574, this PR makes it so that runners can start from snapshot without having to be matched to a runner in the runner pool.

**Related issues**: N/A
