### PR TITLE
Upgrade soci-store version to 0.0.6

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -372,8 +372,8 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         name = "com_github_awslabs_soci_snapshotter",
         importpath = "github.com/awslabs/soci-snapshotter",
         replace = "github.com/buildbuddy-io/soci-snapshotter",
-        sum = "h1:G6Adpu0lUQ9Qja6OUxG/gB0loz1UzlNo9804f9kjDPo=",
-        version = "v0.0.5",
+        sum = "h1:/D3xQ2+sYC0fYYzCiDEdT+YyIFVv2UEu3aK+rmueG0A=",
+        version = "v0.0.6",
     )
 
     go_repository(
@@ -7071,11 +7071,11 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
     )
 
     http_file(
-        name = "com_github_buildbuddy_io_soci_snapshotter-soci-store-v0.0.5-linux-amd64",
-        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-store-v0.0.5-linux-amd64"],
-        sha256 = "e626cac7bb01cc4911a16e6d6a8b4419c29922c8bd74db02d984969635d6f997",
+        name = "com_github_buildbuddy_io_soci_snapshotter-soci-store-v0.0.6-linux-amd64",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-store-v0.0.6-linux-amd64"],
+        sha256 = "c875e736776c22c9ea4c3e8bba057620c0b209bf1c9147acbe982ec3c65e799e",
         executable = True,
-        downloaded_file_path = "soci-store-v0.0.5-linux-amd64",
+        downloaded_file_path = "soci-store-v0.0.6-linux-amd64",
     )
 
     http_file(

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -96,10 +96,10 @@ container_layer(
     files = [
         ":firecracker",
         ":jailer",
-        "@com_github_buildbuddy_io_soci_snapshotter-soci-store-v0.0.5-linux-amd64//file:soci-store-v0.0.5-linux-amd64",
+        "@com_github_buildbuddy_io_soci_snapshotter-soci-store-v0.0.6-linux-amd64//file:soci-store-v0.0.6-linux-amd64",
     ],
     symlinks = {
-        "/usr/bin/soci-store": "/usr/bin/soci-store-v0.0.5-linux-amd64",
+        "/usr/bin/soci-store": "/usr/bin/soci-store-v0.0.6-linux-amd64",
     },
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/buildbuddy-io/buildbuddy
 go 1.20
 
 replace (
-	github.com/awslabs/soci-snapshotter => github.com/buildbuddy-io/soci-snapshotter v0.0.5
+	github.com/awslabs/soci-snapshotter => github.com/buildbuddy-io/soci-snapshotter v0.0.6
 	github.com/buildkite/terminal-to-html/v3 => github.com/buildbuddy-io/terminal-to-html/v3 v3.7.0-patched-1
 	github.com/firecracker-microvm/firecracker-go-sdk => github.com/buildbuddy-io/firecracker-go-sdk v0.0.0-20230721-1d5c50b
 	github.com/go-redsync/redsync/v4 v4.4.1 => github.com/bduffany/redsync/v4 v4.4.1-minimal

--- a/go.sum
+++ b/go.sum
@@ -866,8 +866,8 @@ github.com/buildbuddy-io/fastcdc-go v0.2.0-rc2 h1:yu6OEmUHMQqiMQ3BOLlhYUe6O34nb4
 github.com/buildbuddy-io/fastcdc-go v0.2.0-rc2/go.mod h1:PGFBIloiASFbiKnkCd/hmHXxngxYDYtisyurJ/zyDNM=
 github.com/buildbuddy-io/firecracker-go-sdk v0.0.0-20230721-1d5c50b h1:Wx6fPNZOs0SJ9NpTsLbJsItORvEM9D94k/vr8ZwIBEg=
 github.com/buildbuddy-io/firecracker-go-sdk v0.0.0-20230721-1d5c50b/go.mod h1:pcsIXRGgbFGr9QtUdlQCP/z6tuB7EMw6zXgFkcu7Q0c=
-github.com/buildbuddy-io/soci-snapshotter v0.0.5 h1:G6Adpu0lUQ9Qja6OUxG/gB0loz1UzlNo9804f9kjDPo=
-github.com/buildbuddy-io/soci-snapshotter v0.0.5/go.mod h1:25BojoSLodZQgb0Wh4Mv5Eo4HUL4ZpZuBDgOVn0BuA0=
+github.com/buildbuddy-io/soci-snapshotter v0.0.6 h1:/D3xQ2+sYC0fYYzCiDEdT+YyIFVv2UEu3aK+rmueG0A=
+github.com/buildbuddy-io/soci-snapshotter v0.0.6/go.mod h1:25BojoSLodZQgb0Wh4Mv5Eo4HUL4ZpZuBDgOVn0BuA0=
 github.com/buildbuddy-io/tensorflow-proto v0.0.0-20220908151343-929b41ab4dc6 h1:LcKnQdAYrT3LOZt0mTgw6uiEi7QVkH75cCxPj+AbkLA=
 github.com/buildbuddy-io/tensorflow-proto v0.0.0-20220908151343-929b41ab4dc6/go.mod h1:sbWYLPDSURZSehjnwnFclswM4ErueZHCVxXimWH6Uo4=
 github.com/buildbuddy-io/terminal-to-html/v3 v3.7.0-patched-1 h1:XMnC81zIjWBw5SRc/TqPOP4vHPftVhdNl5azJrOwz+Y=


### PR DESCRIPTION
This version has a few important fixes:
- https://github.com/buildbuddy-io/soci-snapshotter/pull/8
- https://github.com/buildbuddy-io/soci-snapshotter/pull/10

I'm hoping to finish up the work to run the store in-process in the executor, making this process obsolete, but I think the two fixes above are important enough to go ahead and do this upgrade without waiting for that.

**Related issues**: N/A
