### PR TITLE
Rework group picker behavior on subdomains.

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -193,10 +193,18 @@ export class AuthService {
     rpcService.requestContext.groupId = this.user?.selectedGroup?.id || "";
   }
 
-  async setSelectedGroupId(groupId: string, { reload = false }: { reload?: boolean } = {}) {
+  async setSelectedGroupId(groupId: string, groupURL: string, { reload = false }: { reload?: boolean } = {}) {
     if (!this.user) throw new Error("failed to set selected group ID: not logged in");
 
     this.setCookie(SELECTED_GROUP_ID_COOKIE, groupId);
+
+    // If we're on a subdomain and the new group is on a different subdomain then
+    // we have to use a redirect.
+    if (capabilities.config.customerSubdomain && new URL(groupURL).hostname != window.location.hostname) {
+      window.location.href = groupURL;
+      return;
+    }
+
     if (reload) {
       // Don't publish a new user to avoid UI flickering.
       window.location.reload();

--- a/enterprise/app/org/create_org.tsx
+++ b/enterprise/app/org/create_org.tsx
@@ -19,8 +19,8 @@ export default class CreateOrgComponent extends OrgForm<grp.CreateGroupRequest> 
     return new grp.CreateGroupRequest({ ...DEFAULT_VALUES, ...values });
   }
   async submitRequest() {
-    const rsp = await rpcService.service.createGroup(this.state.request);
-    await authService.setSelectedGroupId(rsp.id, rsp.url);
+    const response = await rpcService.service.createGroup(this.state.request);
+    await authService.setSelectedGroupId(response.id, response.url);
     router.navigateTo(Path.settingsPath);
   }
 

--- a/enterprise/app/org/create_org.tsx
+++ b/enterprise/app/org/create_org.tsx
@@ -19,8 +19,8 @@ export default class CreateOrgComponent extends OrgForm<grp.CreateGroupRequest> 
     return new grp.CreateGroupRequest({ ...DEFAULT_VALUES, ...values });
   }
   async submitRequest() {
-    const { id } = await rpcService.service.createGroup(this.state.request);
-    await authService.setSelectedGroupId(id);
+    const rsp = await rpcService.service.createGroup(this.state.request);
+    await authService.setSelectedGroupId(rsp.id, rsp.url);
     router.navigateTo(Path.settingsPath);
   }
 

--- a/enterprise/app/org/join_org.tsx
+++ b/enterprise/app/org/join_org.tsx
@@ -66,12 +66,12 @@ export default class JoinOrgComponent extends React.Component<JoinOrgComponentPr
       return;
     }
 
-    await authService.setSelectedGroupId(org.id);
+    await authService.setSelectedGroupId(org.id, org.url);
     router.navigateHome();
   }
 
   private async onViewBuildsClicked(org: grp.GetGroupResponse) {
-    await authService.setSelectedGroupId(org.id);
+    await authService.setSelectedGroupId(org.id, org.url);
     router.navigateHome();
   }
 

--- a/enterprise/app/settings/github_complete_installation.tsx
+++ b/enterprise/app/settings/github_complete_installation.tsx
@@ -54,8 +54,13 @@ export default class CompleteGitHubAppInstallationDialog extends React.Component
 
   private onChangeSelectedGroup(e: React.ChangeEvent<HTMLSelectElement>) {
     this.setState({ isRefreshingUser: true });
+    const grp = this.props.user.groups.find((g) => g.id === e.target.value);
+    // Should not be possible.
+    if (!grp) {
+      throw new Error("group not found");
+    }
     authService
-      .setSelectedGroupId(e.target.value)
+      .setSelectedGroupId(grp.id, grp?.url)
       .catch((e) => errorService.handleError(e))
       .finally(() => this.setState({ isRefreshingUser: false }));
   }

--- a/enterprise/app/sidebar/BUILD
+++ b/enterprise/app/sidebar/BUILD
@@ -13,6 +13,7 @@ ts_library(
         "//app/components/link",
         "//app/router",
         "//app/service:rpc_service",
+        "//proto:group_ts_proto",
         "@npm//@types/react",
         "@npm//lucide-react",
         "@npm//react",

--- a/enterprise/app/sidebar/sidebar.tsx
+++ b/enterprise/app/sidebar/sidebar.tsx
@@ -31,6 +31,8 @@ import capabilities from "../../../app/capabilities/capabilities";
 import Link, { LinkProps } from "../../../app/components/link/link";
 import router, { Path } from "../../../app/router/router";
 import rpcService from "../../../app/service/rpc_service";
+import rpc_service from "../../../app/service/rpc_service";
+import { grp } from "../../../proto/group_ts_proto";
 
 interface Props {
   user?: User;
@@ -69,10 +71,10 @@ export default class SidebarComponent extends React.Component<Props, State> {
     window.dispatchEvent(new CustomEvent("groupSearchClick"));
   }
 
-  async handleOrgClicked(groupId: string) {
+  async handleOrgClicked(groupId: string, groupURL: string) {
     if (this.props.user?.selectedGroup?.id === groupId) return;
 
-    await authService.setSelectedGroupId(groupId, { reload: true });
+    await authService.setSelectedGroupId(groupId, groupURL, { reload: true });
   }
 
   isHomeSelected() {
@@ -260,7 +262,7 @@ export default class SidebarComponent extends React.Component<Props, State> {
                       className={`sidebar-item org-picker-item ${
                         group.id === this.props.user?.selectedGroup.id ? "selected" : ""
                       }`}
-                      onClick={this.handleOrgClicked.bind(this, group.id)}>
+                      onClick={this.handleOrgClicked.bind(this, group.id, group.url)}>
                       {group.id === this.props.user?.selectedGroup.id ? (
                         <CheckCircle className="icon" />
                       ) : (

--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -60,6 +60,11 @@ message Group {
 
   // Controls whether user-owned API keys are enabled.
   bool user_owned_keys_enabled = 11;
+
+  // Default URL from the group. If custom subdomains are enabled this will
+  // reference the group subdomain, otherwise it will point to the default
+  // BuildBuddy URL.
+  string url = 12;
 }
 
 message JoinGroupRequest {
@@ -106,6 +111,11 @@ message GetGroupResponse {
 
   // True if the group has SSO enabled.
   bool sso_enabled = 5;
+
+  // Default URL from the group. If custom subdomains are enabled this will
+  // reference the group subdomain, otherwise it will point to the default
+  // BuildBuddy URL.
+  string url = 6;
 }
 
 message GetGroupUsersRequest {
@@ -204,6 +214,11 @@ message CreateGroupResponse {
   // ID of the created group.
   // Ex. "GR4576963743584254779"
   string id = 1;
+
+  // Default URL from the group. If custom subdomains are enabled this will
+  // reference the group subdomain, otherwise it will point to the default
+  // BuildBuddy URL.
+  string url = 3;
 }
 
 message UpdateGroupRequest {

--- a/server/util/claims/BUILD
+++ b/server/util/claims/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//server/util/request_context",
         "//server/util/role",
         "//server/util/status",
-        "//server/util/subdomain",
         "@com_github_golang_jwt_jwt//:jwt",
     ],
 )

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -14,7 +14,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/lru"
 	"github.com/buildbuddy-io/buildbuddy/server/util/role"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
 	"github.com/golang-jwt/jwt"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
@@ -144,9 +143,6 @@ func ClaimsFromSubID(ctx context.Context, env environment.Env, subID string) (*C
 		for _, g := range u.Groups {
 			if g.Group.GroupID == c.GetGroupId() {
 				eg = c.GetGroupId()
-				if sd := subdomain.Get(ctx); sd != "" && (g.Group.URLIdentifier == nil || *g.Group.URLIdentifier != sd) {
-					return nil, status.PermissionDeniedErrorf("Selected group is not available via current subdomain.")
-				}
 			}
 		}
 	}


### PR DESCRIPTION
The previous UX was not great as it made switching groups difficult.

Now the group picker works and redirects to the appropriate subdomain, if necessary.

Create org also works on subdomain and redirects to the new URL after creation.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
