### PR TITLE
Update subdomain existence check.

### DIFF
--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -368,12 +368,14 @@ class Router {
     // Require the user to create an org if they are logged in but not part of
     // an org.
     if (user && !user.groups?.length) {
-      if (capabilities.config.customerSubdomain) {
-        const params = new URLSearchParams({ source_url: window.location.href });
-        return Path.orgAccessDeniedPath + "?" + params.toString();
-      } else {
-        return Path.createOrgPath;
-      }
+      return Path.createOrgPath;
+    }
+
+    // No selected group on subdomain means either the group doesn't exist or
+    // the user does not have access to it.
+    if (user && !user.selectedGroup.id && capabilities.config.customerSubdomain) {
+      const params = new URLSearchParams({ source_url: window.location.href });
+      return Path.orgAccessDeniedPath + "?" + params.toString();
     }
 
     const path = window.location.pathname;

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -826,6 +826,7 @@ func selectedGroup(ctx context.Context, preferredGroupID string, groupRoles []*t
 				return gr
 			}
 		}
+		return nil
 	}
 	if preferredGroupID != "" {
 		for _, gr := range groupRoles {


### PR DESCRIPTION
Since we're no longer filtering groups on subdomains, we can no longer use the group list to determine whether the subdomain exists.

Instead check whether there is a selected group ID and don't set a selected group on a subdomain if the subdomain doesn't match any group user has access to.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
