### PR TITLE
Use hermetic_cc_toolchain to statically link against musl

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,13 +39,7 @@ build:remote-shared --jobs=100
 build:remote-shared --verbose_failures
 build:remote-shared --platforms=@buildbuddy_toolchain//:platform_bare_linux
 build:remote-shared --host_platform=@buildbuddy_toolchain//:platform_bare_linux
-# build:remote-shared --platforms=@hermetic_cc_toolchain//toolchain/platform:linux_amd64
-# build:remote-shared --host_platform=@hermetic_cc_toolchain//toolchain/platform:linux_amd64
-# build:remote-shared --crosstool_top=@buildbuddy_toolchain//:ubuntu_cc_toolchain_suite
-# build:remote-shared --extra_toolchains=@buildbuddy_toolchain//:ubuntu_cc_toolchain
 build:remote-shared --extra_toolchains=//:sh_toolchain
-# build:remote-shared --host_javabase=@bazel_tools//tools/jdk:absolute_javabase
-# build:remote-shared --define=ABSOLUTE_JAVABASE=/path/to/my/jdk
 
 # Build with --config=remote to use BuildBuddy RBE.
 build:remote --config=remote-shared

--- a/.bazelrc
+++ b/.bazelrc
@@ -41,8 +41,8 @@ build:remote-shared --platforms=@buildbuddy_toolchain//:platform_bare_linux
 build:remote-shared --host_platform=@buildbuddy_toolchain//:platform_bare_linux
 # build:remote-shared --platforms=@hermetic_cc_toolchain//toolchain/platform:linux_amd64
 # build:remote-shared --host_platform=@hermetic_cc_toolchain//toolchain/platform:linux_amd64
-build:remote-shared --crosstool_top=@buildbuddy_toolchain//:ubuntu_cc_toolchain_suite
-build:remote-shared --extra_toolchains=@buildbuddy_toolchain//:ubuntu_cc_toolchain
+# build:remote-shared --crosstool_top=@buildbuddy_toolchain//:ubuntu_cc_toolchain_suite
+# build:remote-shared --extra_toolchains=@buildbuddy_toolchain//:ubuntu_cc_toolchain
 build:remote-shared --extra_toolchains=//:sh_toolchain
 # build:remote-shared --host_javabase=@bazel_tools//tools/jdk:absolute_javabase
 # build:remote-shared --define=ABSOLUTE_JAVABASE=/path/to/my/jdk
@@ -116,7 +116,7 @@ build:workflows --config=buildbuddy_bes_results_url
 build:workflows --config=buildbuddy_remote_cache
 # Temporarily disabled while testing blake3.
 #build:workflows --config=buildbuddy_experimental_remote_downloader
-# build:workflows --@io_bazel_rules_go//go/config:race
+build:workflows --@io_bazel_rules_go//go/config:race
 
 # Configuration used for Linux workflows
 build:linux-workflows --config=remote-shared

--- a/.bazelrc
+++ b/.bazelrc
@@ -37,8 +37,10 @@ build:remote-shared --remote_timeout=600
 build:remote-shared --remote_download_minimal
 build:remote-shared --jobs=100
 build:remote-shared --verbose_failures
-build:remote-shared --platforms=@buildbuddy_toolchain//:platform_linux
-build:remote-shared --host_platform=@buildbuddy_toolchain//:platform_linux
+# build:remote-shared --platforms=@buildbuddy_toolchain//:platform_linux
+# build:remote-shared --host_platform=@buildbuddy_toolchain//:platform_linux
+# build:remote-shared --platforms=@hermetic_cc_toolchain//toolchain/platform:linux_amd64
+# build:remote-shared --host_platform=@hermetic_cc_toolchain//toolchain/platform:linux_amd64
 build:remote-shared --crosstool_top=@buildbuddy_toolchain//:ubuntu_cc_toolchain_suite
 build:remote-shared --extra_toolchains=@buildbuddy_toolchain//:ubuntu_cc_toolchain
 build:remote-shared --extra_toolchains=//:sh_toolchain

--- a/.bazelrc
+++ b/.bazelrc
@@ -147,6 +147,12 @@ build:auto-release --config=remote
 build:auto-release --remote_instance_name=buildbuddy-io/buildbuddy/auto-release
 build:auto-release -c opt
 
+build --incompatible_enable_cc_toolchain_resolution
+build --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build --copt=-fPIC
+# build --linkopt=-static
+build --linkopt=-static-pie
+
 # By default, build logs get sent to the production server
 build --bes_results_url=https://app.buildbuddy.io/invocation/
 build --bes_backend=grpcs://remote.buildbuddy.io

--- a/.bazelrc
+++ b/.bazelrc
@@ -37,8 +37,8 @@ build:remote-shared --remote_timeout=600
 build:remote-shared --remote_download_minimal
 build:remote-shared --jobs=100
 build:remote-shared --verbose_failures
-# build:remote-shared --platforms=@buildbuddy_toolchain//:platform_linux
-# build:remote-shared --host_platform=@buildbuddy_toolchain//:platform_linux
+build:remote-shared --platforms=@buildbuddy_toolchain//:platform_bare_linux
+build:remote-shared --host_platform=@buildbuddy_toolchain//:platform_bare_linux
 # build:remote-shared --platforms=@hermetic_cc_toolchain//toolchain/platform:linux_amd64
 # build:remote-shared --host_platform=@hermetic_cc_toolchain//toolchain/platform:linux_amd64
 build:remote-shared --crosstool_top=@buildbuddy_toolchain//:ubuntu_cc_toolchain_suite

--- a/.bazelrc
+++ b/.bazelrc
@@ -116,7 +116,7 @@ build:workflows --config=buildbuddy_bes_results_url
 build:workflows --config=buildbuddy_remote_cache
 # Temporarily disabled while testing blake3.
 #build:workflows --config=buildbuddy_experimental_remote_downloader
-build:workflows --@io_bazel_rules_go//go/config:race
+# build:workflows --@io_bazel_rules_go//go/config:race
 
 # Configuration used for Linux workflows
 build:linux-workflows --config=remote-shared

--- a/.bazelrc
+++ b/.bazelrc
@@ -151,15 +151,14 @@ build:auto-release --config=remote
 build:auto-release --remote_instance_name=buildbuddy-io/buildbuddy/auto-release
 build:auto-release -c opt
 
-build --incompatible_enable_cc_toolchain_resolution
-# build --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build --@io_bazel_rules_go//go/config:static=true
-# build --@io_bazel_rules_go//go/config:linkmode=pie
-build --copt=-fPIC
-# build --linkopt=-no-pie
-build --linkopt=-static
-# build --linkopt=-static-pie
-# build --action_env=GOTAGS=-tags=osusergo,netgo
+build:linux --incompatible_enable_cc_toolchain_resolution
+build:linux --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:linux --@io_bazel_rules_go//go/config:static=true
+# build:linux --@io_bazel_rules_go//go/config:linkmode=pie
+build:linux --copt=-fPIC
+# build:linux --linkopt=-static
+# build:linux --linkopt=-static-pie
+# build:linux --action_env=GOTAGS=-tags=osusergo,netgo
 
 # By default, build logs get sent to the production server
 build --bes_results_url=https://app.buildbuddy.io/invocation/

--- a/.bazelrc
+++ b/.bazelrc
@@ -152,7 +152,7 @@ build:auto-release --remote_instance_name=buildbuddy-io/buildbuddy/auto-release
 build:auto-release -c opt
 
 build --incompatible_enable_cc_toolchain_resolution
-build --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+# build --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build --@io_bazel_rules_go//go/config:static=true
 # build --@io_bazel_rules_go//go/config:linkmode=pie
 build --copt=-fPIC

--- a/.bazelrc
+++ b/.bazelrc
@@ -149,9 +149,11 @@ build:auto-release -c opt
 
 build --incompatible_enable_cc_toolchain_resolution
 build --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build --@io_bazel_rules_go//go/config:static=true
+# build --@io_bazel_rules_go//go/config:linkmode=pie
 build --copt=-fPIC
-# build --linkopt=-static
-build --linkopt=-static-pie
+build --linkopt=-static
+# build --linkopt=-static-pie
 
 # By default, build logs get sent to the production server
 build --bes_results_url=https://app.buildbuddy.io/invocation/

--- a/.bazelrc
+++ b/.bazelrc
@@ -154,8 +154,9 @@ build:auto-release -c opt
 build --incompatible_enable_cc_toolchain_resolution
 build --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build --@io_bazel_rules_go//go/config:static=true
-build --@io_bazel_rules_go//go/config:linkmode=pie
+# build --@io_bazel_rules_go//go/config:linkmode=pie
 build --copt=-fPIC
+# build --linkopt=-no-pie
 build --linkopt=-static
 # build --linkopt=-static-pie
 # build --action_env=GOTAGS=-tags=osusergo,netgo

--- a/.bazelrc
+++ b/.bazelrc
@@ -148,11 +148,7 @@ build:auto-release -c opt
 build:linux --incompatible_enable_cc_toolchain_resolution
 build:linux --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:linux --@io_bazel_rules_go//go/config:static=true
-# build:linux --@io_bazel_rules_go//go/config:linkmode=pie
 build:linux --copt=-fPIC
-# build:linux --linkopt=-static
-# build:linux --linkopt=-static-pie
-# build:linux --action_env=GOTAGS=-tags=osusergo,netgo
 
 # By default, build logs get sent to the production server
 build --bes_results_url=https://app.buildbuddy.io/invocation/

--- a/.bazelrc
+++ b/.bazelrc
@@ -150,7 +150,7 @@ build:auto-release -c opt
 build --incompatible_enable_cc_toolchain_resolution
 build --action_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build --@io_bazel_rules_go//go/config:static=true
-# build --@io_bazel_rules_go//go/config:linkmode=pie
+build --@io_bazel_rules_go//go/config:linkmode=pie
 build --copt=-fPIC
 build --linkopt=-static
 # build --linkopt=-static-pie

--- a/.bazelrc
+++ b/.bazelrc
@@ -44,6 +44,8 @@ build:remote-shared --host_platform=@buildbuddy_toolchain//:platform_bare_linux
 build:remote-shared --crosstool_top=@buildbuddy_toolchain//:ubuntu_cc_toolchain_suite
 build:remote-shared --extra_toolchains=@buildbuddy_toolchain//:ubuntu_cc_toolchain
 build:remote-shared --extra_toolchains=//:sh_toolchain
+# build:remote-shared --host_javabase=@bazel_tools//tools/jdk:absolute_javabase
+# build:remote-shared --define=ABSOLUTE_JAVABASE=/path/to/my/jdk
 
 # Build with --config=remote to use BuildBuddy RBE.
 build:remote --config=remote-shared
@@ -156,6 +158,7 @@ build --@io_bazel_rules_go//go/config:linkmode=pie
 build --copt=-fPIC
 build --linkopt=-static
 # build --linkopt=-static-pie
+# build --action_env=GOTAGS=-tags=osusergo,netgo
 
 # By default, build logs get sent to the production server
 build --bes_results_url=https://app.buildbuddy.io/invocation/

--- a/BUILD
+++ b/BUILD
@@ -38,7 +38,6 @@ write_file(
                     "asmdecl",
                     "assign",
                     "atomicalign",
-                    # "cgocall",
                     "buildtag",
                     "cgocall",
                     "composites",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -384,9 +384,9 @@ dockerfile_image(
 # Keep up-to-date with docs/rbe-setup.md and docs/rbe-github-actions.md
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    sha256 = "c487fd8a32e278d664c8dc4d4773e35d32d883527bee47c9e11d2947ae2f30a3",
-    strip_prefix = "buildbuddy-toolchain-a88ae46d4a9ae0043f3c79a28ffa91831b7ebed5",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/a88ae46d4a9ae0043f3c79a28ffa91831b7ebed5.tar.gz"],
+    sha256 = "94d015a29a782f1d559d72a088ffa4f01faf35706019f25b82751327e9a2bbcc",
+    strip_prefix = "buildbuddy-toolchain-44663aedc95b7fefdf94d81eb4ad4b48a5a67633",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/44663aedc95b7fefdf94d81eb4ad4b48a5a67633.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,8 +51,6 @@ install_static_dependencies()
 # gazelle:repository_macro deps.bzl%install_go_mod_dependencies
 install_go_mod_dependencies()
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 HERMETIC_CC_TOOLCHAIN_VERSION = "v2.0.0"
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -72,10 +72,10 @@ zig_toolchains()
 register_toolchains(
     "@zig_sdk//toolchain:linux_amd64_musl",
     "@zig_sdk//toolchain:linux_arm64_musl",
-    "@zig_sdk//toolchain:darwin_amd64",
-    "@zig_sdk//toolchain:darwin_arm64",
-    "@zig_sdk//toolchain:windows_amd64",
-    "@zig_sdk//toolchain:windows_arm64",
+    # "@zig_sdk//toolchain:darwin_amd64",
+    # "@zig_sdk//toolchain:darwin_arm64",
+    # "@zig_sdk//toolchain:windows_amd64",
+    # "@zig_sdk//toolchain:windows_arm64",
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -384,9 +384,9 @@ dockerfile_image(
 # Keep up-to-date with docs/rbe-setup.md and docs/rbe-github-actions.md
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    sha256 = "1cab6ef3ae9b4211ab9d57826edd4bbc34e5b9e5cb1927c97f0788d8e7ad0442",
-    strip_prefix = "buildbuddy-toolchain-b043878a82f266fd78369b794a105b57dc0b2600",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/b043878a82f266fd78369b794a105b57dc0b2600.tar.gz"],
+    sha256 = "c487fd8a32e278d664c8dc4d4773e35d32d883527bee47c9e11d2947ae2f30a3",
+    strip_prefix = "buildbuddy-toolchain-a88ae46d4a9ae0043f3c79a28ffa91831b7ebed5",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/a88ae46d4a9ae0043f3c79a28ffa91831b7ebed5.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,6 +51,35 @@ install_static_dependencies()
 # gazelle:repository_macro deps.bzl%install_go_mod_dependencies
 install_go_mod_dependencies()
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+HERMETIC_CC_TOOLCHAIN_VERSION = "v2.0.0"
+
+http_archive(
+    name = "hermetic_cc_toolchain",
+    sha256 = "57f03a6c29793e8add7bd64186fc8066d23b5ffd06fe9cc6b0b8c499914d3a65",
+    urls = [
+        "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
+        "https://github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
+    ],
+)
+
+load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_toolchains = "toolchains")
+
+# Plain zig_toolchains() will pick reasonable defaults. See
+# toolchain/defs.bzl:toolchains on how to change the Zig SDK version and
+# download URL.
+zig_toolchains()
+
+register_toolchains(
+    "@zig_sdk//toolchain:linux_amd64_musl",
+    "@zig_sdk//toolchain:linux_arm64_musl",
+    "@zig_sdk//toolchain:darwin_amd64",
+    "@zig_sdk//toolchain:darwin_arm64",
+    "@zig_sdk//toolchain:windows_amd64",
+    "@zig_sdk//toolchain:windows_arm64",
+)
+
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchains", "go_rules_dependencies")
 

--- a/buildpatches/com_github_awslabs_soci_snapshotter.patch
+++ b/buildpatches/com_github_awslabs_soci_snapshotter.patch
@@ -1,0 +1,34 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000..7ab2087
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,6 @@
++module(
++    name = "soci_snapshotter",
++    version = "0.0.7",
++)
++
++bazel_dep(name = "zlib", version = "1.3")
+diff --git a/WORKSPACE.bzlmod b/WORKSPACE.bzlmod
+new file mode 100644
+index 0000000..fafa28d
+--- /dev/null
++++ b/WORKSPACE.bzlmod
+@@ -0,0 +1,2 @@
++# When Bzlmod is enabled, this file replaces the content of the original WORKSPACE
++# and makes sure no WORKSPACE prefix or suffix are added when Bzlmod is enabled.
+diff --git a/ztoc/compression/BUILD.bazel b/ztoc/compression/BUILD.bazel
+index 0d10a4d..bca5dac 100644
+--- a/ztoc/compression/BUILD.bazel
++++ b/ztoc/compression/BUILD.bazel
+@@ -11,7 +11,8 @@ go_library(
+         "zinfo.go",
+     ],
+     cgo = True,
+-    clinkopts = ["-Lztoc/compression/ztoc/out -l:libz.a"],
++    cdeps = ["@zlib//:zlib"],
++    clinkopts = ["-Lztoc/compression/ztoc/out"],
+     copts = ["-Iztoc/compression/ztoc/compression"],
+     importpath = "github.com/awslabs/soci-snapshotter/ztoc/compression",
+     visibility = ["//visibility:public"],

--- a/buildpatches/com_github_awslabs_soci_snapshotter.patch
+++ b/buildpatches/com_github_awslabs_soci_snapshotter.patch
@@ -6,7 +6,7 @@ index 0000000..7ab2087
 @@ -0,0 +1,6 @@
 +module(
 +    name = "soci_snapshotter",
-+    version = "0.0.7",
++    version = "0.0.8",
 +)
 +
 +bazel_dep(name = "zlib", version = "1.3")

--- a/cli/testutil/testcli/testcli.go
+++ b/cli/testutil/testcli/testcli.go
@@ -99,7 +99,37 @@ func CombinedOutput(cmd *exec.Cmd) ([]byte, error) {
 // to use the pre-downloaded bazel binary from test runfiles.
 func NewWorkspace(t *testing.T) string {
 	ws := testbazel.MakeTempWorkspace(t, map[string]string{
-		"WORKSPACE":     "",
+		"WORKSPACE": `
+workspace(name = "test")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+
+HERMETIC_CC_TOOLCHAIN_VERSION = "v2.0.0"
+
+http_archive(
+    name = "hermetic_cc_toolchain",
+    sha256 = "57f03a6c29793e8add7bd64186fc8066d23b5ffd06fe9cc6b0b8c499914d3a65",
+    urls = [
+        "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
+        "https://github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
+    ],
+)
+
+load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_toolchains = "toolchains")
+
+# Plain zig_toolchains() will pick reasonable defaults. See
+# toolchain/defs.bzl:toolchains on how to change the Zig SDK version and
+# download URL.
+zig_toolchains()
+
+register_toolchains(
+    "@zig_sdk//toolchain:linux_amd64_musl",
+    "@zig_sdk//toolchain:linux_arm64_musl",
+    "@zig_sdk//toolchain:darwin_amd64",
+    "@zig_sdk//toolchain:darwin_arm64",
+    "@zig_sdk//toolchain:windows_amd64",
+    "@zig_sdk//toolchain:windows_arm64",
+)
+`,
 		".bazelversion": testbazel.BinaryPath(t),
 	})
 	// Make it a git workspace to test git metadata.

--- a/deps.bzl
+++ b/deps.bzl
@@ -371,6 +371,8 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "com_github_awslabs_soci_snapshotter",
         importpath = "github.com/awslabs/soci-snapshotter",
+        patch_args = ["-p1"],
+        patches = ["@{}//buildpatches:com_github_awslabs_soci_snapshotter.patch".format(workspace_name)],
         replace = "github.com/buildbuddy-io/soci-snapshotter",
         sum = "h1:skoAXrwJCa9YsOP/+ojXX2Wge/syyFRcP+imYwEGxWg=",
         version = "v0.0.8",

--- a/enterprise/server/cmd/goinit/BUILD
+++ b/enterprise/server/cmd/goinit/BUILD
@@ -25,6 +25,6 @@ go_library(
 go_binary(
     name = "goinit",
     embed = [":goinit_lib"],
-    pure = "on",
+    # pure = "on", # causes the init file to require an ELF interpreter which the kernel does not have access to
     static = "on",
 )

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -79,6 +79,12 @@ var (
 func init() {
 	// Set umask to match the executor process.
 	syscall.Umask(0)
+
+	// Some tests need iptables which is in /usr/sbin.
+	err := os.Setenv("PATH", os.Getenv("PATH")+":/usr/sbin")
+	if err != nil {
+		log.Fatal(err.Error())
+	}
 }
 
 // cleanExecutorRoot cleans all entries in the test root dir *except* for cached
@@ -180,10 +186,6 @@ func getTestEnv(ctx context.Context, t *testing.T, opts envOpts) *testenv.TestEn
 	require.NoError(t, err)
 	fc.WaitForDirectoryScanToComplete()
 	env.SetFileCache(fc)
-
-	// Some tests need iptables which is in /usr/sbin.
-	err = os.Setenv("PATH", os.Getenv("PATH")+":/usr/sbin")
-	require.NoError(t, err)
 
 	return env
 }
@@ -445,7 +447,7 @@ func TestFirecracker_LocalSnapshotSharing(t *testing.T) {
 		ActionWorkingDirectory: workDir,
 		VMConfiguration: &fcpb.VMConfiguration{
 			NumCpus:           1,
-			MemSizeMb:         minMemSizeMB, // small to make snapshotting faster.
+			MemSizeMb:         minMemSizeMB * 2, // small to make snapshotting faster.
 			EnableNetworking:  false,
 			ScratchDiskSizeMb: 100,
 		},
@@ -763,7 +765,7 @@ func TestFirecrackerComplexFileMapping(t *testing.T) {
 		ActionWorkingDirectory: rootDir,
 		VMConfiguration: &fcpb.VMConfiguration{
 			NumCpus:           1,
-			MemSizeMb:         minMemSizeMB,
+			MemSizeMb:         minMemSizeMB * 2,
 			EnableNetworking:  false,
 			ScratchDiskSizeMb: 100,
 		},
@@ -935,7 +937,7 @@ func TestFirecrackerRun_ReapOrphanedZombieProcess(t *testing.T) {
 		ActionWorkingDirectory: workDir,
 		VMConfiguration: &fcpb.VMConfiguration{
 			NumCpus:           1,
-			MemSizeMb:         2500,
+			MemSizeMb:         3500,
 			ScratchDiskSizeMb: 100,
 		},
 		JailerRoot: tempJailerRoot(t),

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -161,7 +161,37 @@ actions:
 	}
 
 	workspaceContentsWithExitScriptAndMergeDisabled = map[string]string{
-		"WORKSPACE": "",
+		"WORKSPACE": `
+workspace(name = "test")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+
+HERMETIC_CC_TOOLCHAIN_VERSION = "v2.0.0"
+
+http_archive(
+    name = "hermetic_cc_toolchain",
+    sha256 = "57f03a6c29793e8add7bd64186fc8066d23b5ffd06fe9cc6b0b8c499914d3a65",
+    urls = [
+        "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
+        "https://github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
+    ],
+)
+
+load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_toolchains = "toolchains")
+
+# Plain zig_toolchains() will pick reasonable defaults. See
+# toolchain/defs.bzl:toolchains on how to change the Zig SDK version and
+# download URL.
+zig_toolchains()
+
+register_toolchains(
+    "@zig_sdk//toolchain:linux_amd64_musl",
+    "@zig_sdk//toolchain:linux_arm64_musl",
+    "@zig_sdk//toolchain:darwin_amd64",
+    "@zig_sdk//toolchain:darwin_arm64",
+    "@zig_sdk//toolchain:windows_amd64",
+    "@zig_sdk//toolchain:windows_arm64",
+)
+`,
 		"BUILD":     `sh_binary(name = "exit", srcs = ["exit.sh"])`,
 		"exit.sh":   `exit "$1"`,
 		"buildbuddy.yaml": `

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -147,8 +147,8 @@ register_toolchains(
     "@zig_sdk//toolchain:windows_arm64",
 )
 `,
-		"BUILD":     `sh_binary(name = "exit", srcs = ["exit.sh"])`,
-		"exit.sh":   `exit "$1"`,
+		"BUILD":   `sh_binary(name = "exit", srcs = ["exit.sh"])`,
+		"exit.sh": `exit "$1"`,
 		"buildbuddy.yaml": `
 actions:
   - name: "Exit 36"

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -192,8 +192,8 @@ register_toolchains(
     "@zig_sdk//toolchain:windows_arm64",
 )
 `,
-		"BUILD":     `sh_binary(name = "exit", srcs = ["exit.sh"])`,
-		"exit.sh":   `exit "$1"`,
+		"BUILD":   `sh_binary(name = "exit", srcs = ["exit.sh"])`,
+		"exit.sh": `exit "$1"`,
 		"buildbuddy.yaml": `
 actions:
   - name: "Test"

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -116,7 +116,37 @@ actions:
 	}
 
 	workspaceContentsWithLocalEnvironmentalErrorAction = map[string]string{
-		"WORKSPACE": `workspace(name = "test")`,
+		"WORKSPACE": `
+workspace(name = "test")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+
+HERMETIC_CC_TOOLCHAIN_VERSION = "v2.0.0"
+
+http_archive(
+    name = "hermetic_cc_toolchain",
+    sha256 = "57f03a6c29793e8add7bd64186fc8066d23b5ffd06fe9cc6b0b8c499914d3a65",
+    urls = [
+        "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
+        "https://github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
+    ],
+)
+
+load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_toolchains = "toolchains")
+
+# Plain zig_toolchains() will pick reasonable defaults. See
+# toolchain/defs.bzl:toolchains on how to change the Zig SDK version and
+# download URL.
+zig_toolchains()
+
+register_toolchains(
+    "@zig_sdk//toolchain:linux_amd64_musl",
+    "@zig_sdk//toolchain:linux_arm64_musl",
+    "@zig_sdk//toolchain:darwin_amd64",
+    "@zig_sdk//toolchain:darwin_arm64",
+    "@zig_sdk//toolchain:windows_amd64",
+    "@zig_sdk//toolchain:windows_arm64",
+)
+`,
 		"BUILD":     `sh_binary(name = "exit", srcs = ["exit.sh"])`,
 		"exit.sh":   `exit "$1"`,
 		"buildbuddy.yaml": `

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/buildbuddy-io/buildbuddy
 go 1.21
 
 replace (
-	github.com/awslabs/soci-snapshotter => github.com/buildbuddy-io/soci-snapshotter v0.0.8
+	github.com/awslabs/soci-snapshotter => github.com/buildbuddy-io/soci-snapshotter v0.0.8 // keep in sync with buildpatches/com_github_awslabs_soci_snapshotter.patch
 	github.com/buildkite/terminal-to-html/v3 => github.com/buildbuddy-io/terminal-to-html/v3 v3.7.0-patched-1
 	github.com/firecracker-microvm/firecracker-go-sdk => github.com/buildbuddy-io/firecracker-go-sdk v0.0.0-20230721-1d5c50b
 	github.com/go-redsync/redsync/v4 v4.4.1 => github.com/bduffany/redsync/v4 v4.4.1-minimal


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

Adds `hermetic_cc_toolchain` as the new toolchain for C and C++ compilation. Patches `soci-snapshotter` to depend on `zlib`. Adds build options to `.bazelrc` to perform static linking and an [ASLR-able binary](https://stackoverflow.com/questions/61553723/whats-the-difference-between-statically-linked-and-not-a-dynamic-executable).

Edits: Does not work on Mac. Could not build PIE-able code without crashing the race detector during analysis, so no ASLR.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
