### PR TITLE
Upgrade soci-store version to v0.0.7

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -7073,7 +7073,7 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
     http_file(
         name = "com_github_buildbuddy_io_soci_snapshotter-soci-store-v0.0.7-linux-amd64",
         urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-store-v0.0.7-linux-amd64"],
-        sha256 = "0f205eeb5b066704966b619bd6cb01e3c157a8fc645ab5940c5083a2271eb2f3",
+        sha256 = "1149c110188a552982498e29fe52ae6c65a91d389e95a98d00a7b8dd771e109e",
         executable = True,
         downloaded_file_path = "soci-store-v0.0.7-linux-amd64",
     )

--- a/deps.bzl
+++ b/deps.bzl
@@ -372,8 +372,8 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
         name = "com_github_awslabs_soci_snapshotter",
         importpath = "github.com/awslabs/soci-snapshotter",
         replace = "github.com/buildbuddy-io/soci-snapshotter",
-        sum = "h1:G6Adpu0lUQ9Qja6OUxG/gB0loz1UzlNo9804f9kjDPo=",
-        version = "v0.0.5",
+        sum = "h1:d2vXO1zu1N9hoZgQKzoufVoKfEtq6wuwVJHfRlgDyDM=",
+        version = "v0.0.7",
     )
 
     go_repository(
@@ -7071,11 +7071,11 @@ def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
     )
 
     http_file(
-        name = "com_github_buildbuddy_io_soci_snapshotter-soci-store-v0.0.5-linux-amd64",
-        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-store-v0.0.5-linux-amd64"],
-        sha256 = "e626cac7bb01cc4911a16e6d6a8b4419c29922c8bd74db02d984969635d6f997",
+        name = "com_github_buildbuddy_io_soci_snapshotter-soci-store-v0.0.7-linux-amd64",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-store-v0.0.7-linux-amd64"],
+        sha256 = "0f205eeb5b066704966b619bd6cb01e3c157a8fc645ab5940c5083a2271eb2f3",
         executable = True,
-        downloaded_file_path = "soci-store-v0.0.5-linux-amd64",
+        downloaded_file_path = "soci-store-v0.0.7-linux-amd64",
     )
 
     http_file(

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -96,10 +96,10 @@ container_layer(
     files = [
         ":firecracker",
         ":jailer",
-        "@com_github_buildbuddy_io_soci_snapshotter-soci-store-v0.0.5-linux-amd64//file:soci-store-v0.0.5-linux-amd64",
+        "@com_github_buildbuddy_io_soci_snapshotter-soci-store-v0.0.7-linux-amd64//file:soci-store-v0.0.7-linux-amd64",
     ],
     symlinks = {
-        "/usr/bin/soci-store": "/usr/bin/soci-store-v0.0.5-linux-amd64",
+        "/usr/bin/soci-store": "/usr/bin/soci-store-v0.0.7-linux-amd64",
     },
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/buildbuddy-io/buildbuddy
 go 1.20
 
 replace (
-	github.com/awslabs/soci-snapshotter => github.com/buildbuddy-io/soci-snapshotter v0.0.5
+	github.com/awslabs/soci-snapshotter => github.com/buildbuddy-io/soci-snapshotter v0.0.7
 	github.com/buildkite/terminal-to-html/v3 => github.com/buildbuddy-io/terminal-to-html/v3 v3.7.0-patched-1
 	github.com/firecracker-microvm/firecracker-go-sdk => github.com/buildbuddy-io/firecracker-go-sdk v0.0.0-20230721-1d5c50b
 	github.com/go-redsync/redsync/v4 v4.4.1 => github.com/bduffany/redsync/v4 v4.4.1-minimal

--- a/go.sum
+++ b/go.sum
@@ -866,8 +866,8 @@ github.com/buildbuddy-io/fastcdc-go v0.2.0-rc2 h1:yu6OEmUHMQqiMQ3BOLlhYUe6O34nb4
 github.com/buildbuddy-io/fastcdc-go v0.2.0-rc2/go.mod h1:PGFBIloiASFbiKnkCd/hmHXxngxYDYtisyurJ/zyDNM=
 github.com/buildbuddy-io/firecracker-go-sdk v0.0.0-20230721-1d5c50b h1:Wx6fPNZOs0SJ9NpTsLbJsItORvEM9D94k/vr8ZwIBEg=
 github.com/buildbuddy-io/firecracker-go-sdk v0.0.0-20230721-1d5c50b/go.mod h1:pcsIXRGgbFGr9QtUdlQCP/z6tuB7EMw6zXgFkcu7Q0c=
-github.com/buildbuddy-io/soci-snapshotter v0.0.5 h1:G6Adpu0lUQ9Qja6OUxG/gB0loz1UzlNo9804f9kjDPo=
-github.com/buildbuddy-io/soci-snapshotter v0.0.5/go.mod h1:25BojoSLodZQgb0Wh4Mv5Eo4HUL4ZpZuBDgOVn0BuA0=
+github.com/buildbuddy-io/soci-snapshotter v0.0.7 h1:d2vXO1zu1N9hoZgQKzoufVoKfEtq6wuwVJHfRlgDyDM=
+github.com/buildbuddy-io/soci-snapshotter v0.0.7/go.mod h1:25BojoSLodZQgb0Wh4Mv5Eo4HUL4ZpZuBDgOVn0BuA0=
 github.com/buildbuddy-io/tensorflow-proto v0.0.0-20220908151343-929b41ab4dc6 h1:LcKnQdAYrT3LOZt0mTgw6uiEi7QVkH75cCxPj+AbkLA=
 github.com/buildbuddy-io/tensorflow-proto v0.0.0-20220908151343-929b41ab4dc6/go.mod h1:sbWYLPDSURZSehjnwnFclswM4ErueZHCVxXimWH6Uo4=
 github.com/buildbuddy-io/terminal-to-html/v3 v3.7.0-patched-1 h1:XMnC81zIjWBw5SRc/TqPOP4vHPftVhdNl5azJrOwz+Y=


### PR DESCRIPTION
This version has a few important fixes:

- https://github.com/buildbuddy-io/soci-snapshotter/pull/8
- https://github.com/buildbuddy-io/soci-snapshotter/pull/10
- https://github.com/buildbuddy-io/soci-snapshotter/pull/11
I'm hoping to finish up the work to run the store in-process in the executor, making this process obsolete, but I think the two fixes above are important enough to go ahead and do this upgrade without waiting for that.

This is a second attempt at https://github.com/buildbuddy-io/buildbuddy/pull/4657

I'll manually push this to dev before submitting to test this time :-P

Related issues: N/A