### PR TITLE
show input directory *total* sizes on action page

### DIFF
--- a/app/components/digest/digest.tsx
+++ b/app/components/digest/digest.tsx
@@ -13,7 +13,6 @@ export type DigestProps = {
   expandOnHover?: boolean;
   hashWidth?: string;
   sizeWidth?: string;
-  totalSize?: Long;
 };
 
 export const DigestComponent = React.forwardRef((props: DigestProps, ref: React.Ref<HTMLInputElement>) => {
@@ -39,7 +38,7 @@ export const DigestComponent = React.forwardRef((props: DigestProps, ref: React.
           style={{
             ...(props.sizeWidth !== undefined && { width: props.sizeWidth }),
           }}>
-          {format.bytes(props.digest.sizeBytes)} {props.totalSize ? `(Total: ${format.bytes(+props.totalSize)})` : ""}
+          {format.bytes(props.digest.sizeBytes)}
         </span>
       )}
     </span>

--- a/app/components/digest/digest.tsx
+++ b/app/components/digest/digest.tsx
@@ -13,6 +13,7 @@ export type DigestProps = {
   expandOnHover?: boolean;
   hashWidth?: string;
   sizeWidth?: string;
+  totalSize?: Long;
 };
 
 export const DigestComponent = React.forwardRef((props: DigestProps, ref: React.Ref<HTMLInputElement>) => {
@@ -38,7 +39,7 @@ export const DigestComponent = React.forwardRef((props: DigestProps, ref: React.
           style={{
             ...(props.sizeWidth !== undefined && { width: props.sizeWidth }),
           }}>
-          {format.bytes(props.digest.sizeBytes)}
+          {format.bytes(props.digest.sizeBytes)} {props.totalSize ? `(Total: ${format.bytes(+props.totalSize)})` : ""}
         </span>
       )}
     </span>

--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -136,6 +136,7 @@ ts_library(
     srcs = ["invocation_action_input_node.tsx"],
     deps = [
         "//app/components/digest",
+        "//app/format",
         "//proto:remote_execution_ts_proto",
         "@npm//@types/react",
         "@npm//lucide-react",

--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -124,6 +124,7 @@ ts_library(
         "//app/service:rpc_service",
         "//app/terminal",
         "//proto:remote_execution_ts_proto",
+        "//proto:resource_ts_proto",
         "@npm//@types/react",
         "@npm//lucide-react",
         "@npm//react",

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -44,6 +44,7 @@
   color: #000;
   margin-left: 8px;
   padding: 0 8px;
+  white-space: nowrap;
 }
 
 .input-tree-node-name .digest-component {

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -38,6 +38,14 @@
   user-select: none;
 }
 
+.input-tree-node .input-tree-node-size {
+  background-color: #eee;
+  border-radius: 4px;
+  color: #000;
+  margin-left: 8px;
+  padding: 0 8px;
+}
+
 .input-tree-node-name .digest-component {
   margin-left: 8px;
 }

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -69,11 +69,9 @@ export default class InvocationActionCardComponent extends React.Component<Props
     const remoteInstanceName = this.props.model.optionsMap.get("remote_instance_name") || undefined;
     rpcService.service
       .getTreeDirectorySizes({
-        resourceName: resource.ResourceName.create({
-          digest: rootDigest,
-          cacheType: resource.CacheType.CAS,
-          instanceName: remoteInstanceName,
-        }),
+        rootDigest: rootDigest,
+        instanceName: remoteInstanceName,
+        /* TODO(jdhollen): pass back the DigestFunction used for the invocation. */
       })
       .then((r) => {
         this.setState({ treeShaToTotalSizeMap: r.sizes });

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -21,7 +21,7 @@ interface State {
   action?: build.bazel.remote.execution.v2.Action;
   loadingAction: boolean;
   actionResult?: build.bazel.remote.execution.v2.ActionResult;
-  treeShaToTotalSizeMap: Record<string, Long>;
+  treeShaToTotalSizeMap: Map<string, Number>;
   command?: build.bazel.remote.execution.v2.Command;
   error?: string;
   inputRoot?: build.bazel.remote.execution.v2.Directory;
@@ -36,7 +36,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
   state: State = {
     treeShaToExpanded: new Map<string, boolean>(),
     treeShaToChildrenMap: new Map<string, InputNode[]>(),
-    treeShaToTotalSizeMap: {},
+    treeShaToTotalSizeMap: new Map<string, Number>(),
     inputDirs: [],
     loadingAction: true,
   };
@@ -74,10 +74,14 @@ export default class InvocationActionCardComponent extends React.Component<Props
         /* TODO(jdhollen): pass back the DigestFunction used for the invocation. */
       })
       .then((r) => {
-        this.setState({ treeShaToTotalSizeMap: r.sizes });
+        const sizes = new Map<string, Number>();
+        r.sizes.forEach((v) => {
+          sizes.set(v.digest, +v.totalSize);
+        });
+        this.setState({ treeShaToTotalSizeMap: sizes });
       })
       .catch((e) => {
-        this.setState({ treeShaToTotalSizeMap: {} });
+        this.setState({ treeShaToTotalSizeMap: new Map<string, Number>() });
       });
   }
 

--- a/app/invocation/invocation_action_input_node.tsx
+++ b/app/invocation/invocation_action_input_node.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { build } from "../../proto/remote_execution_ts_proto";
 import { Download, FolderMinus, FolderPlus } from "lucide-react";
 import DigestComponent from "../components/digest/digest";
+import format from "../format/format";
 
 interface Props {
   node: InputNode;
@@ -21,6 +22,7 @@ export interface InputNode {
 export default class InputNodeComponent extends React.Component<Props, State> {
   render() {
     const digestString = this.props.node.obj.digest?.hash + "/" + this.props.node.obj.digest?.sizeBytes;
+    const totalSize = this.props.treeShaToTotalSizeMap[digestString];
     const expanded = this.props.treeShaToExpanded.get(digestString);
     return (
       <div className="input-tree-node">
@@ -41,12 +43,8 @@ export default class InputNodeComponent extends React.Component<Props, State> {
             )}
           </span>{" "}
           <span className="input-tree-node-label">{this.props.node.obj.name}</span>
-          {this.props.node.obj?.digest && (
-            <DigestComponent
-              digest={this.props.node.obj.digest}
-              totalSize={this.props.treeShaToTotalSizeMap[digestString]}
-            />
-          )}
+          {totalSize ? <span className="input-tree-node-size">{`${format.bytes(+totalSize)} total`}</span> : ""}
+          {this.props.node.obj?.digest && <DigestComponent digest={this.props.node.obj.digest} />}
         </div>
         {expanded && (
           <div className="input-tree-node-children">

--- a/app/invocation/invocation_action_input_node.tsx
+++ b/app/invocation/invocation_action_input_node.tsx
@@ -7,6 +7,7 @@ interface Props {
   node: InputNode;
   treeShaToExpanded: Map<string, boolean>;
   treeShaToChildrenMap: Map<string, InputNode[]>;
+  treeShaToTotalSizeMap: Record<string, Long>;
   handleFileClicked: any;
 }
 
@@ -19,11 +20,10 @@ export interface InputNode {
 
 export default class InputNodeComponent extends React.Component<Props, State> {
   render() {
-    const expanded = this.props.treeShaToExpanded.get(
-      this.props.node.obj.digest?.hash + "/" + this.props.node.obj.digest?.sizeBytes
-    );
+    const digestString = this.props.node.obj.digest?.hash + "/" + this.props.node.obj.digest?.sizeBytes;
+    const expanded = this.props.treeShaToExpanded.get(digestString);
     return (
-      <div className={`input-tree-node`}>
+      <div className="input-tree-node">
         <div
           className={`input-tree-node-name ${expanded ? "input-tree-node-expanded" : ""}`}
           onClick={() => this.props.handleFileClicked(this.props.node)}>
@@ -41,20 +41,24 @@ export default class InputNodeComponent extends React.Component<Props, State> {
             )}
           </span>{" "}
           <span className="input-tree-node-label">{this.props.node.obj.name}</span>
-          {this.props.node.obj?.digest && <DigestComponent digest={this.props.node.obj.digest} />}
+          {this.props.node.obj?.digest && (
+            <DigestComponent
+              digest={this.props.node.obj.digest}
+              totalSize={this.props.treeShaToTotalSizeMap[digestString]}
+            />
+          )}
         </div>
         {expanded && (
           <div className="input-tree-node-children">
-            {this.props.treeShaToChildrenMap
-              .get(this.props.node.obj.digest?.hash + "/" + this.props.node.obj.digest?.sizeBytes)
-              ?.map((child: any) => (
-                <InputNodeComponent
-                  node={child}
-                  treeShaToExpanded={this.props.treeShaToExpanded}
-                  treeShaToChildrenMap={this.props.treeShaToChildrenMap}
-                  handleFileClicked={this.props.handleFileClicked}
-                />
-              ))}
+            {this.props.treeShaToChildrenMap.get(digestString)?.map((child: any) => (
+              <InputNodeComponent
+                node={child}
+                treeShaToExpanded={this.props.treeShaToExpanded}
+                treeShaToChildrenMap={this.props.treeShaToChildrenMap}
+                treeShaToTotalSizeMap={this.props.treeShaToTotalSizeMap}
+                handleFileClicked={this.props.handleFileClicked}
+              />
+            ))}
           </div>
         )}
       </div>

--- a/app/invocation/invocation_action_input_node.tsx
+++ b/app/invocation/invocation_action_input_node.tsx
@@ -8,7 +8,7 @@ interface Props {
   node: InputNode;
   treeShaToExpanded: Map<string, boolean>;
   treeShaToChildrenMap: Map<string, InputNode[]>;
-  treeShaToTotalSizeMap: Record<string, Long>;
+  treeShaToTotalSizeMap: Map<string, Number>;
   handleFileClicked: any;
 }
 
@@ -22,7 +22,7 @@ export interface InputNode {
 export default class InputNodeComponent extends React.Component<Props, State> {
   render() {
     const digestString = this.props.node.obj.digest?.hash + "/" + this.props.node.obj.digest?.sizeBytes;
-    const totalSize = this.props.treeShaToTotalSizeMap[digestString];
+    const totalSize = this.props.treeShaToTotalSizeMap.get(digestString);
     const expanded = this.props.treeShaToExpanded.get(digestString);
     return (
       <div className="input-tree-node">

--- a/proto/buildbuddy_service.proto
+++ b/proto/buildbuddy_service.proto
@@ -110,6 +110,8 @@ service BuildBuddyService {
       returns (cache.GetCacheScoreCardResponse);
   rpc GetCacheMetadata(cache.GetCacheMetadataRequest)
       returns (cache.GetCacheMetadataResponse);
+  rpc GetTreeDirectorySizes(cache.GetTreeDirectorySizesRequest)
+      returns (cache.GetTreeDirectorySizesResponse);
 
   // Targets API
   rpc GetTarget(target.GetTargetRequest) returns (target.GetTargetResponse);

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -267,10 +267,20 @@ message GetTreeDirectorySizesRequest {
   build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 4;
 }
 
+message DigestWithTotalSize {
+  // The stringified digest in the form <hash/size>
+  string digest = 1;
+
+  // The total size of the specified object in the CAS, *including* the
+  // recursively expanded subcontents of child directories if this is a
+  // Directory.
+  int64 total_size = 2;
+}
+
 message GetTreeDirectorySizesResponse {
   context.ResponseContext response_context = 1;
 
   // A map from the digest string (hash/bytes) to the *total* cumulative size
   // of the directory (i.e., a different, potentially larger number of bytes).
-  map<string, int64> sizes = 2;
+  repeated DigestWithTotalSize sizes = 2;
 }

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -260,8 +260,11 @@ message TreeCache {
 message GetTreeDirectorySizesRequest {
   context.RequestContext request_context = 1;
 
-  // The resource name of the root of the tree.
-  resource.ResourceName resource_name = 2;
+  build.bazel.remote.execution.v2.Digest root_digest = 2;
+
+  string instance_name = 3;
+
+  build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 4;
 }
 
 message GetTreeDirectorySizesResponse {

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -252,3 +252,22 @@ message DirectoryWithDigest {
 message TreeCache {
   repeated DirectoryWithDigest children = 1;
 }
+
+// Fetch the cumulative sizes of all of the directories beneath the specified
+// root.  If the cache doesn't hold the full file hierarchy for any subtree,
+// all parents of the subtree will *not* be calculated, since we can't know
+// the "true" size of the tree.
+message GetTreeDirectorySizesRequest {
+  context.RequestContext request_context = 1;
+
+  // The resource name of the root of the tree.
+  resource.ResourceName resource_name = 2;
+}
+
+message GetTreeDirectorySizesResponse {
+  context.ResponseContext response_context = 1;
+
+  // A map from the digest string (hash/bytes) to the *total* cumulative size
+  // of the directory (i.e., a different, potentially larger number of bytes).
+  map<string, int64> sizes = 2;
+}

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -42,6 +42,7 @@ go_library(
         "//server/environment",
         "//server/eventlog",
         "//server/interfaces",
+        "//server/remote_cache/directory_size",
         "//server/remote_cache/scorecard",
         "//server/role_filter",
         "//server/tables",

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/eventlog"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/directory_size"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/scorecard"
 	"github.com/buildbuddy-io/buildbuddy/server/role_filter"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
@@ -1008,6 +1009,10 @@ func (s *BuildBuddyServer) GetExecution(ctx context.Context, req *espb.GetExecut
 		return es.GetExecution(ctx, req)
 	}
 	return nil, status.UnimplementedError("Not implemented")
+}
+
+func (s *BuildBuddyServer) GetTreeDirectorySizes(ctx context.Context, req *capb.GetTreeDirectorySizesRequest) (*capb.GetTreeDirectorySizesResponse, error) {
+	return directory_size.GetTreeDirectorySizes(ctx, s.env, req)
 }
 
 func (s *BuildBuddyServer) GetExecutionNodes(ctx context.Context, req *scpb.GetExecutionNodesRequest) (*scpb.GetExecutionNodesResponse, error) {

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -71,6 +71,7 @@ type Env interface {
 	GetRemoteExecutionClient() repb.ExecutionClient
 	SetRemoteExecutionClient(repb.ExecutionClient)
 	GetContentAddressableStorageClient() repb.ContentAddressableStorageClient
+	SetContentAddressableStorageClient(repb.ContentAddressableStorageClient)
 	GetAPIService() interfaces.ApiService
 	SetAPIService(interfaces.ApiService)
 	GetFileCache() interfaces.FileCache

--- a/server/remote_cache/content_addressable_storage_server/BUILD
+++ b/server/remote_cache/content_addressable_storage_server/BUILD
@@ -19,6 +19,8 @@ go_library(
         "//server/util/alert",
         "//server/util/capabilities",
         "//server/util/compression",
+        "//server/util/grpc_client",
+        "//server/util/grpc_server",
         "//server/util/log",
         "//server/util/prefix",
         "//server/util/status",

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -17,6 +17,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/capabilities"
 	"github.com/buildbuddy-io/buildbuddy/server/util/compression"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -62,6 +64,14 @@ func Register(env environment.Env) error {
 		return status.InternalErrorf("Error initializing ContentAddressableStorageServer: %s", err)
 	}
 	env.SetCASServer(casServer)
+
+	conn, err := grpc_client.DialTarget(fmt.Sprintf("grpc://localhost:%d", grpc_server.Port()))
+	casClient := repb.NewContentAddressableStorageClient(conn)
+	if err != nil {
+		return status.InternalErrorf("Error initializing ContentAddressableStorageClient: %s", err)
+	}
+	env.SetContentAddressableStorageClient(casClient)
+
 	return nil
 }
 

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -107,7 +107,7 @@ func ResourceNameFromProto(in *rspb.ResourceName) *ResourceName {
 
 func NewResourceName(d *repb.Digest, instanceName string, cacheType rspb.CacheType, digestFunction repb.DigestFunction_Value) *ResourceName {
 	if digestFunction == repb.DigestFunction_UNKNOWN {
-		digestFunction = oldStyleDigestFunction(d)
+		digestFunction = InferOldStyleDigestFunctionInDesperation(d)
 	}
 	return &ResourceName{
 		rn: &rspb.ResourceName{
@@ -313,7 +313,7 @@ func HashForDigestType(digestType repb.DigestFunction_Value) (hash.Hash, error) 
 	}
 }
 
-func oldStyleDigestFunction(d *repb.Digest) repb.DigestFunction_Value {
+func InferOldStyleDigestFunctionInDesperation(d *repb.Digest) repb.DigestFunction_Value {
 	switch len(d.GetHash()) {
 	case sha1.Size * 2:
 		return repb.DigestFunction_SHA1
@@ -425,7 +425,7 @@ func parseResourceName(resourceName string, matcher *regexp.Regexp, cacheType rs
 	// Determine the digest function by looking at the digest length.
 	// If a digest_function value was specified in the bytestream URL, this
 	// is a new style hash, so lookup the type based on that value.
-	digestFunction := oldStyleDigestFunction(d)
+	digestFunction := InferOldStyleDigestFunctionInDesperation(d)
 	if dfString, ok := result["digest_function"]; ok && dfString != "" {
 		if df, ok := repb.DigestFunction_Value_value[strings.ToUpper(dfString)]; ok {
 			digestFunction = repb.DigestFunction_Value(df)

--- a/server/remote_cache/directory_size/BUILD
+++ b/server/remote_cache/directory_size/BUILD
@@ -10,8 +10,5 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//server/environment",
         "//server/remote_cache/digest",
-        "//server/util/grpc_client",
-        "//server/util/grpc_server",
-        "//server/util/status",
     ],
 )

--- a/server/remote_cache/directory_size/BUILD
+++ b/server/remote_cache/directory_size/BUILD
@@ -10,5 +10,6 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//server/environment",
         "//server/remote_cache/digest",
+        "//server/util/status",
     ],
 )

--- a/server/remote_cache/directory_size/BUILD
+++ b/server/remote_cache/directory_size/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "directory_size",
+    srcs = ["directory_size.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/remote_cache/directory_size",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//proto:cache_go_proto",
+        "//server/environment",
+        "//server/remote_cache/digest",
+        "//server/util/grpc_client",
+        "//server/util/grpc_server",
+        "//server/util/status",
+    ],
+)

--- a/server/remote_cache/directory_size/BUILD
+++ b/server/remote_cache/directory_size/BUILD
@@ -6,8 +6,8 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/remote_cache/directory_size",
     visibility = ["//visibility:public"],
     deps = [
-        "//proto:remote_execution_go_proto",
         "//proto:cache_go_proto",
+        "//proto:remote_execution_go_proto",
         "//server/environment",
         "//server/remote_cache/digest",
         "//server/util/grpc_client",

--- a/server/remote_cache/directory_size/directory_size.go
+++ b/server/remote_cache/directory_size/directory_size.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	directorySizesEnabled = flag.Bool("cache.directory_sizes_enabled", true, "If true, enable user-owned API keys.")
+	directorySizesEnabled = flag.Bool("cache.directory_sizes_enabled", true, "If true, enable an RPC that computes the cumulative size of directories stored in the cache.")
 )
 
 // A helper object to tally up the size total size (including contents) of each

--- a/server/remote_cache/directory_size/directory_size.go
+++ b/server/remote_cache/directory_size/directory_size.go
@@ -192,8 +192,6 @@ func GetTreeDirectorySizes(ctx context.Context, env environment.Env, req *capb.G
 		}
 	}
 
-	dsc.GetOutput()
-
 	return &capb.GetTreeDirectorySizesResponse{
 		Sizes: dsc.GetOutput(),
 	}, nil

--- a/server/remote_cache/directory_size/directory_size.go
+++ b/server/remote_cache/directory_size/directory_size.go
@@ -140,8 +140,12 @@ func (dsc *directorySizeCounter) finish(digest string) {
 // Outputs only completed branches--if for some reason we couldn't find one of
 // the directories in the directory tree, we don't output a total size for any
 // of its parents because the size would be incorrect.
-func (dsc *directorySizeCounter) GetOutput() map[string]int64 {
-	return dsc.totalSize
+func (dsc *directorySizeCounter) GetOutput() []*capb.DigestWithTotalSize {
+	out := make([]*capb.DigestWithTotalSize, 0, len(dsc.totalSize))
+	for k, v := range dsc.totalSize {
+		out = append(out, &capb.DigestWithTotalSize{Digest: k, TotalSize: v})
+	}
+	return out
 }
 
 func GetTreeDirectorySizes(ctx context.Context, env environment.Env, req *capb.GetTreeDirectorySizesRequest) (*capb.GetTreeDirectorySizesResponse, error) {

--- a/server/remote_cache/directory_size/directory_size.go
+++ b/server/remote_cache/directory_size/directory_size.go
@@ -1,0 +1,184 @@
+package directory_size
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+var (
+	directorySizesEnabled = flag.Bool("cache.directory_sizes_enabled", true, "If true, enable user-owned API keys.")
+)
+
+// A helper object to tally up the size total size (including contents) of each
+// directory in a tree using a streamed GetTree response.  Simply add the
+// individual directories via Add() and then call GetOutput().
+type directorySizeCounter struct {
+	// A map from digest to digests that are waiting for this digest to be done.
+	// When this digest is removed from waitingOn, it should bubble up and
+	// compute sizes for all entries in this set.  If a parent technically
+	// contains the same child digest twice (e.g., two empty directories), it
+	// will appear in this list twice so that we properly count its total size.
+	parents map[string][]string
+	// A map from digest to its pending children.  When this set is empty, we
+	// know the real size of the directory and we should bubble up the directory
+	// size to the digests in parents.
+	pendingChildren map[string]map[string]struct{}
+	// The pending size of the directory node with the specified digest.  When the
+	// set in childrenPending is empty, this value will be the computed total size
+	// of the directory and be moved over to totalSize
+	pendingSize map[string]int64
+	// The total size of the directory node with the specified digest.  When the
+	// set in childrenPending is empty, this value will be the computed total size
+	// of the directory.
+	totalSize map[string]int64
+
+	digestFunction repb.DigestFunction_Value
+}
+
+func NewDirectorySizeCounter(digestFunction repb.DigestFunction_Value) *directorySizeCounter {
+	return &directorySizeCounter{
+		parents:         make(map[string][]string),
+		pendingChildren: make(map[string]map[string]struct{}),
+		pendingSize:     make(map[string]int64),
+		totalSize:       make(map[string]int64),
+		digestFunction:  digestFunction,
+	}
+}
+
+func (dsc *directorySizeCounter) Add(dir *repb.Directory) error {
+	dirDigest, err := digest.ComputeForMessage(dir, dsc.digestFunction)
+	if err != nil {
+		return err
+	}
+	digestString := digest.String(dirDigest)
+	if _, ok := dsc.totalSize[digestString]; ok {
+		// We're already in the process of computing this directory's size.
+		return nil
+	}
+	if _, ok := dsc.pendingSize[digestString]; ok {
+		// We're already in the process of computing this directory's size.
+		return nil
+	}
+
+	// Create..
+	dsc.pendingSize[digestString] = dirDigest.GetSizeBytes()
+	for _, f := range dir.GetFiles() {
+		dsc.pendingSize[digestString] += f.GetDigest().GetSizeBytes()
+	}
+	if len(dir.GetDirectories()) == 0 {
+		dsc.finish(digestString)
+		return nil
+	}
+
+	dsc.pendingChildren[digestString] = make(map[string]struct{})
+
+	for _, d := range dir.GetDirectories() {
+		dh := digest.String(d.GetDigest())
+		if subDirTotal, ok := dsc.totalSize[dh]; ok {
+			dsc.pendingSize[digestString] += subDirTotal
+			continue
+		}
+		if _, ok := dsc.parents[dh]; !ok {
+			dsc.parents[dh] = make([]string, 0)
+		}
+		dsc.pendingChildren[digestString][dh] = struct{}{}
+		dsc.parents[dh] = append(dsc.parents[dh], digestString)
+	}
+
+	if len(dsc.pendingChildren[digestString]) == 0 {
+		dsc.finish(digestString)
+	}
+	return nil
+}
+
+// Completes the computation of a subtree's size and recursively computes the
+// size of any parent directories that are now also fully known.
+func (dsc *directorySizeCounter) finish(digest string) {
+	if _, ok := dsc.totalSize[digest]; ok {
+		return
+	}
+
+	total := dsc.pendingSize[digest]
+	dsc.totalSize[digest] = total
+	for _, parent := range dsc.parents[digest] {
+		dsc.pendingSize[parent] += total
+	}
+	for _, parent := range dsc.parents[digest] {
+		delete(dsc.pendingChildren[parent], digest)
+		if len(dsc.pendingChildren[parent]) == 0 {
+			dsc.finish(parent)
+		}
+	}
+	delete(dsc.parents, digest)
+	delete(dsc.pendingChildren, digest)
+	delete(dsc.pendingSize, digest)
+}
+
+// Outputs only completed branches--if for some reason we couldn't find one of
+// the directories in the directory tree, we don't output a total size for any
+// of its parents because the size would be incorrect.
+func (dsc *directorySizeCounter) GetOutput() map[string]int64 {
+	return dsc.totalSize
+}
+
+func GetTreeDirectorySizes(ctx context.Context, env environment.Env, req *capb.GetTreeDirectorySizesRequest) (*capb.GetTreeDirectorySizesResponse, error) {
+	if !*directorySizesEnabled {
+		return &capb.GetTreeDirectorySizesResponse{}, nil
+	}
+	// XXX: Validate access? Is group ID getting added to cache request implicitly good enough?
+	r := req.GetResourceName()
+
+	conn, err := grpc_client.DialTarget(fmt.Sprintf("grpc://localhost:%d", grpc_server.Port()))
+	casClient := repb.NewContentAddressableStorageClient(conn)
+	if err != nil {
+		return nil, status.InternalErrorf("Error initializing ByteStreamClient: %s", err)
+	}
+
+	// Fetch the full tree.
+	nextPageToken := ""
+	dsc := NewDirectorySizeCounter(r.GetDigestFunction())
+	for {
+		stream, err := casClient.GetTree(ctx, &repb.GetTreeRequest{
+			RootDigest:     r.GetDigest(),
+			InstanceName:   r.GetInstanceName(),
+			PageToken:      nextPageToken,
+			DigestFunction: r.GetDigestFunction(),
+		})
+
+		if err != nil {
+			return nil, err
+		}
+		for {
+			rsp, err := stream.Recv()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return nil, err
+			}
+			for _, directory := range rsp.GetDirectories() {
+				dsc.Add(directory)
+			}
+		}
+		if nextPageToken == "" {
+			break
+		}
+	}
+
+	dsc.GetOutput()
+
+	return &capb.GetTreeDirectorySizesResponse{
+		Sizes: dsc.GetOutput(),
+	}, nil
+}

--- a/server/remote_cache/directory_size/directory_size.go
+++ b/server/remote_cache/directory_size/directory_size.go
@@ -20,20 +20,24 @@ var (
 // directory in a tree using a streamed GetTree response.  Simply add the
 // individual directories via Add() and then call GetOutput().
 type directorySizeCounter struct {
+
 	// A map from digest to digests that are waiting for this digest to be done.
 	// When this digest is removed from waitingOn, it should bubble up and
 	// compute sizes for all entries in this set.  If a parent technically
 	// contains the same child digest twice (e.g., two empty directories), it
 	// will appear in this list twice so that we properly count its total size.
 	parents map[string][]string
+
 	// A map from digest to its pending children.  When this set is empty, we
 	// know the real size of the directory and we should bubble up the directory
 	// size to the digests in parents.
 	pendingChildren map[string]map[string]struct{}
+
 	// The pending size of the directory node with the specified digest.  When the
 	// set in childrenPending is empty, this value will be the computed total size
 	// of the directory and be moved over to totalSize
 	pendingSize map[string]int64
+
 	// The total size of the directory node with the specified digest.  When the
 	// set in childrenPending is empty, this value will be the computed total size
 	// of the directory.

--- a/server/remote_cache/directory_size/directory_size.go
+++ b/server/remote_cache/directory_size/directory_size.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -154,6 +155,9 @@ func GetTreeDirectorySizes(ctx context.Context, env environment.Env, req *capb.G
 	}
 
 	casClient := env.GetContentAddressableStorageClient()
+	if casClient == nil {
+		return nil, status.UnimplementedError("Directory tree size computation requires a connection to a CAS server.")
+	}
 	nextPageToken := ""
 	dsc := NewDirectorySizeCounter(req.GetDigestFunction())
 	digestFunction := req.GetDigestFunction()

--- a/server/role_filter/role_filter.go
+++ b/server/role_filter/role_filter.go
@@ -32,6 +32,7 @@ var (
 		"GetEventLogChunk",
 		"GetCacheScoreCard",
 		"GetCacheMetadata",
+		"GetTreeDirectorySizes",
 		"GetTarget",
 		"GetTargetHistory",
 		"GetExecution",


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
This is a little easier to parse than the current setup, which only shows the directory proto size.

The code for this is a little involved because I avoided holding the entire GetTree response in memory.  I try to clean up pending state as we finish calculating the size of directories.  Basically we just hold a few maps and then we only send a map from digest to size at the end.  This definitely saves memory because, if nothing else, we only hold the FileNode protos in memory while processing their containing directory.

Note that this sometimes shows *inflated* sizes because it will count the same file as many times as it appears (for example, the screenshot below shows `node` and `npm` in multiple places--the actual download size for this action was 150MB).  I don't think there's a great way to keep this feature comprehensible, performant, and _not_ do this, but i'm open to suggestions.

It looks like this:
<img width="1248" alt="Screenshot 2023-08-28 at 9 48 31 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/10570856/b4f83d69-0581-42fc-9599-f768124c1320">


<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
