### PR TITLE
Downgrade a few recently added logs to INFO level

### DIFF
--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -185,7 +185,7 @@ func (s *taskSizer) Update(ctx context.Context, cmd *repb.Command, md *repb.Exec
 	defer func() {
 		props, err := platform.ParseProperties(&repb.ExecutionTask{Command: cmd})
 		if err != nil {
-			log.CtxWarningf(ctx, "Failed to parse task properties: %s", err)
+			log.CtxInfof(ctx, "Failed to parse task properties: %s", err)
 		}
 		groupID, _ := s.groupKey(ctx)
 		metrics.RemoteExecutionTaskSizeWriteRequests.With(prometheus.Labels{

--- a/enterprise/server/tasksize_model/tasksize_model.go
+++ b/enterprise/server/tasksize_model/tasksize_model.go
@@ -195,7 +195,7 @@ func (m *Model) Predict(ctx context.Context, task *repb.ExecutionTask) *scpb.Tas
 	// sizes are used as hard limits on allowed resources.
 	props, err := platform.ParseProperties(task)
 	if err != nil {
-		log.Warningf("Failed to parse task properties: %s", err)
+		log.CtxInfof(ctx, "Failed to parse task properties: %s", err)
 		return nil
 	}
 	// If a task size is explicitly requested, measured task size is not used.


### PR DESCRIPTION
I left these as comments in https://github.com/buildbuddy-io/buildbuddy/pull/4650 but accidentally auto-merged.

**Related issues**: N/A
