### PR TITLE
Firecracker: ignore old-style persisted snapshots when snapshot sharing is enabled

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -431,6 +431,10 @@ func (p *Provider) New(ctx context.Context, props *platform.Properties, task *re
 			InitDockerd:       props.InitDockerd,
 			EnableDockerdTcp:  props.EnableDockerdTCP,
 		}
+	} else if *snaputil.EnableLocalSnapshotSharing {
+		// When local snapshot sharing is enabled, reject old-style persisted
+		// snapshots, since these aren't shareable (i.e. COW-formatted).
+		return nil, status.UnavailableError("ignoring persisted snapshot; this functionality has been replaced by local snapshot sharing")
 	} else {
 		vmConfig = state.GetContainerState().GetFirecrackerState().GetVmConfiguration()
 	}


### PR DESCRIPTION
I'm not really sure if old snapshots (non-shareable) and new snapshots (shareable) are compatible, but don't want to have to spend any time testing it - so when snapshot sharing is enabled, just ignore old persisted snapshots.

**Related issues**: N/A
