### PR TITLE
Migration Cache: Ensure we read the same number of bytes from src and dest

### DIFF
--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -442,8 +442,6 @@ type doubleReader struct {
 	doubleReadBuf []byte
 	bytesReadSrc  int
 	bytesReadDest int
-	lastSrcError  error
-	lastDestErr   error
 }
 
 func (d *doubleReader) Read(p []byte) (n int, err error) {
@@ -457,16 +455,17 @@ func (d *doubleReader) Read(p []byte) (n int, err error) {
 			}
 
 			var dstN int
-			dstN, dstErr = d.dest.Read(d.doubleReadBuf)
+			dstN, dstErr = io.ReadFull(d.dest, d.doubleReadBuf)
+			if dstErr == io.ErrUnexpectedEOF {
+				dstErr = io.EOF
+			}
 			d.bytesReadDest += dstN
-			d.lastDestErr = dstErr
 			return nil
 		})
 	}
 
 	srcN, srcErr := d.src.Read(p)
 	d.bytesReadSrc += srcN
-	d.lastSrcError = srcErr
 
 	eg.Wait()
 	// Don't log on EOF errors when reading chunks, because the readers from different caches
@@ -482,14 +481,11 @@ func (d *doubleReader) Close() error {
 	eg := &errgroup.Group{}
 	if d.dest != nil {
 		// Don't log on byte differences for AC records, because there could be minor differences in metadata like timestamps
+		if d.r.GetCacheType() == rspb.CacheType_CAS && d.bytesReadDest != d.bytesReadSrc {
+			log.Warningf("Migration %v read err, src read %d bytes, dest read %d bytes", d.r, d.bytesReadSrc, d.bytesReadDest)
+		}
+
 		eg.Go(func() error {
-			if d.lastSrcError == io.EOF && d.lastDestErr != io.EOF {
-				destBuf, err := io.ReadAll(d.dest)
-				if err != nil {
-					log.Warningf("Migration %v read err: failed to read remaining bytes from dest cache: %s", d.r, err)
-				}
-				d.bytesReadDest += len(destBuf)
-			}
 			dstErr := d.dest.Close()
 			if dstErr != nil {
 				log.Warningf("Migration dest reader close err: %s", dstErr)
@@ -500,12 +496,6 @@ func (d *doubleReader) Close() error {
 
 	srcErr := d.src.Close()
 	eg.Wait()
-
-	if d.dest != nil {
-		if d.r.GetCacheType() == rspb.CacheType_CAS && d.bytesReadDest != d.bytesReadSrc {
-			log.Warningf("Migration %v read err, src read %d bytes, dest read %d bytes", d.r, d.bytesReadSrc, d.bytesReadDest)
-		}
-	}
 
 	return srcErr
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
When we compare the bytes we read from src and dest in migration cache, it's
possible that we read the all the contents from the source but not from the
dest. This could be the case in the newChunkedReader in pebble cache, where we
pipe the chunks in a seperate go routine. 

Use io.ReadFull to read from dest cache. 
