### PR TITLE
use output from ResourceNameFromProto to fill DigestFunction in FileRecords

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -611,7 +611,7 @@ func (c *Cache) Metadata(ctx context.Context, r *rspb.ResourceName) (*interfaces
 			c.log.Debugf("Metadata(%q) not found on peer %s", cacheproxy.ResourceIsolationString(r), peer)
 			continue
 		}
-		c.log.Warningf("Metadata(%q) lookup failed on peer %s: (err: %+v)", cacheproxy.ResourceIsolationString(r), peer, err)
+		c.log.Debugf("Metadata(%q) lookup failed on peer %s: (err: %+v)", cacheproxy.ResourceIsolationString(r), peer, err)
 
 		// Got an error -- mark this peer as failed and try the next one.
 		ps.MarkPeerAsFailed(peer)

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -611,7 +611,7 @@ func (c *Cache) Metadata(ctx context.Context, r *rspb.ResourceName) (*interfaces
 			c.log.Debugf("Metadata(%q) not found on peer %s", cacheproxy.ResourceIsolationString(r), peer)
 			continue
 		}
-		c.log.Debugf("Metadata(%q) lookup failed on peer %s: (err: %+v)", cacheproxy.ResourceIsolationString(r), peer, err)
+		c.log.Debugf("Metadata(%q) lookup failed on peer %s: (err: %v)", cacheproxy.ResourceIsolationString(r), peer, err)
 
 		// Got an error -- mark this peer as failed and try the next one.
 		ps.MarkPeerAsFailed(peer)

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -611,6 +611,7 @@ func (c *Cache) Metadata(ctx context.Context, r *rspb.ResourceName) (*interfaces
 			c.log.Debugf("Metadata(%q) not found on peer %s", cacheproxy.ResourceIsolationString(r), peer)
 			continue
 		}
+		c.log.Warningf("Metadata(%q) lookup failed on peer %s: (err: %+v)", cacheproxy.ResourceIsolationString(r), peer, err)
 
 		// Got an error -- mark this peer as failed and try the next one.
 		ps.MarkPeerAsFailed(peer)

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1377,7 +1377,7 @@ func (p *PebbleCache) makeFileRecord(ctx context.Context, r *rspb.ResourceName) 
 		return nil, err
 	}
 
-	groupID, partID := p.lookupGroupAndPartitionID(ctx, r.GetInstanceName())
+	groupID, partID := p.lookupGroupAndPartitionID(ctx, rn.GetInstanceName())
 
 	encryptionEnabled, err := p.encryptionEnabled(ctx)
 	if err != nil {
@@ -1395,14 +1395,14 @@ func (p *PebbleCache) makeFileRecord(ctx context.Context, r *rspb.ResourceName) 
 
 	return &rfpb.FileRecord{
 		Isolation: &rfpb.Isolation{
-			CacheType:          r.GetCacheType(),
-			RemoteInstanceName: r.GetInstanceName(),
+			CacheType:          rn.GetCacheType(),
+			RemoteInstanceName: rn.GetInstanceName(),
 			PartitionId:        partID,
 			GroupId:            groupID,
 		},
-		Digest:         r.GetDigest(),
-		DigestFunction: r.GetDigestFunction(),
-		Compressor:     r.GetCompressor(),
+		Digest:         rn.GetDigest(),
+		DigestFunction: rn.GetDigestFunction(),
+		Compressor:     rn.GetCompressor(),
 		Encryption:     encryption,
 	}, nil
 }

--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -339,21 +339,21 @@ func (rc *RaftCache) makeFileRecord(ctx context.Context, r *rspb.ResourceName) (
 		return nil, err
 	}
 
-	groupID, partID, err := rc.lookupGroupAndPartitionID(ctx, r.GetInstanceName())
+	groupID, partID, err := rc.lookupGroupAndPartitionID(ctx, rn.GetInstanceName())
 	if err != nil {
 		return nil, err
 	}
 
 	return &rfpb.FileRecord{
 		Isolation: &rfpb.Isolation{
-			CacheType:          r.GetCacheType(),
-			RemoteInstanceName: r.GetInstanceName(),
+			CacheType:          rn.GetCacheType(),
+			RemoteInstanceName: rn.GetInstanceName(),
 			PartitionId:        partID,
 			GroupId:            groupID,
 		},
-		Digest:         r.GetDigest(),
-		DigestFunction: r.GetDigestFunction(),
-		Compressor:     r.GetCompressor(),
+		Digest:         rn.GetDigest(),
+		DigestFunction: rn.GetDigestFunction(),
+		Compressor:     rn.GetCompressor(),
 		Encryption:     nil,
 	}, nil
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
This fixes an issue where GetCacheMetadata was failing because the provided ResourceName didn't have a digest hash function set.

In the future, GetCacheMetadata should be updated to explicitly provide a HashFunction, but this code still shouldn't ignore the side effects of ResourceNameFromProto.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
