### PR TITLE
record the size of artifact instead of the chunk size in DiskCacheAddedFileSizeBytes

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1842,9 +1842,9 @@ type cdcWriter struct {
 	chunker       *chunker.Chunker
 	writtenChunks []*rspb.ResourceName
 
-	numChunks      int
-	firstChunk     []byte
-	isCompleteFile bool
+	numChunks  int
+	firstChunk []byte
+	fileType   rfpb.FileMetadata_FileType
 
 	eg *errgroup.Group
 }
@@ -1901,7 +1901,7 @@ func (p *PebbleCache) newCDCCommitedWriteCloser(ctx context.Context, fileRecord 
 			return err
 		}
 		if cdcw.numChunks == 1 {
-			cdcw.isCompleteFile = true
+			cdcw.fileType = rfpb.FileMetadata_COMPLETE_FILE_TYPE
 			// When there is only one single chunk, we want to store the original
 			// file record with the original key instead of computed digest from
 			// the chunkData. This is because the chunkData can be compressed or
@@ -1920,12 +1920,9 @@ func (p *PebbleCache) newCDCCommitedWriteCloser(ctx context.Context, fileRecord 
 			StoredSizeBytes: 0,
 			LastAccessUsec:  now,
 			LastModifyUsec:  now,
+			FileType:        rfpb.FileMetadata_COMPLETE_FILE_TYPE,
 		}
-		err := p.writeMetadata(ctx, db, key, md)
-		if err == nil {
-			metrics.DiskCacheAddedFileSizeBytes.With(prometheus.Labels{metrics.CacheNameLabel: p.name}).Observe(float64(bytesWritten))
-		}
-		return err
+		return p.writeMetadata(ctx, db, key, md)
 	}
 	return cwc, nil
 }
@@ -1944,6 +1941,7 @@ func (cdcw *cdcWriter) writeChunk(chunkData []byte) error {
 	}
 
 	if cdcw.numChunks == 2 {
+		cdcw.fileType = rfpb.FileMetadata_CHUNK_FILE_TYPE
 		if err := cdcw.writeChunkWhenMultiple(cdcw.firstChunk); err != nil {
 			return err
 		}
@@ -1961,7 +1959,7 @@ func (cdcw *cdcWriter) writeRawChunk(fileRecord *rfpb.FileRecord, key filestore.
 	ctx := cdcw.ctx
 	p := cdcw.pc
 	inlineWriter := p.fileStorer.InlineWriter(ctx, fileRecord.GetDigest().GetSizeBytes())
-	wcm, err := p.newWrappedWriter(ctx, inlineWriter, fileRecord, key, cdcw.shouldCompress || cdcw.isCompressed, cdcw.isCompleteFile)
+	wcm, err := p.newWrappedWriter(ctx, inlineWriter, fileRecord, key, cdcw.shouldCompress || cdcw.isCompressed, cdcw.fileType)
 	if err != nil {
 		return err
 	}
@@ -2117,7 +2115,7 @@ func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfa
 			// have one chunk. We write them directly inline to avoid unnecessary
 			// processing.
 			wcm := p.fileStorer.InlineWriter(ctx, r.GetDigest().GetSizeBytes())
-			return p.newWrappedWriter(ctx, wcm, fileRecord, key, shouldCompress, true /*=isCompleteFile*/)
+			return p.newWrappedWriter(ctx, wcm, fileRecord, key, shouldCompress, rfpb.FileMetadata_COMPLETE_FILE_TYPE)
 		}
 		// we enabled cdc chunking
 		return p.newCDCCommitedWriteCloser(ctx, fileRecord, key, shouldCompress, isCompressed)
@@ -2135,7 +2133,7 @@ func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfa
 		wcm = fw
 	}
 
-	return p.newWrappedWriter(ctx, wcm, fileRecord, key, shouldCompress, true /*=isCompleteFile*/)
+	return p.newWrappedWriter(ctx, wcm, fileRecord, key, shouldCompress, rfpb.FileMetadata_COMPLETE_FILE_TYPE)
 }
 
 // newWrappedWriter returns an interfaces.CommittedWriteCloser that on Write,
@@ -2144,7 +2142,7 @@ func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfa
 // (2) encrypt the data if encryption is enabled
 // (3) write the data using input wcm's Write method.
 // On Commit, it will write the metadata for fileRecord.
-func (p *PebbleCache) newWrappedWriter(ctx context.Context, wcm interfaces.MetadataWriteCloser, fileRecord *rfpb.FileRecord, key filestore.PebbleKey, shouldCompress bool, isCompleteFile bool) (interfaces.CommittedWriteCloser, error) {
+func (p *PebbleCache) newWrappedWriter(ctx context.Context, wcm interfaces.MetadataWriteCloser, fileRecord *rfpb.FileRecord, key filestore.PebbleKey, shouldCompress bool, fileType rfpb.FileMetadata_FileType) (interfaces.CommittedWriteCloser, error) {
 	// Grab another lease and pass the Close function to the writer
 	// so it will be closed when the writer is.
 	db, err := p.leaser.DB()
@@ -2164,12 +2162,9 @@ func (p *PebbleCache) newWrappedWriter(ctx context.Context, wcm interfaces.Metad
 			StoredSizeBytes:    bytesWritten,
 			LastAccessUsec:     now,
 			LastModifyUsec:     now,
+			FileType:           fileType,
 		}
-		err := p.writeMetadata(ctx, db, key, md)
-		if err == nil && isCompleteFile {
-			metrics.DiskCacheAddedFileSizeBytes.With(prometheus.Labels{metrics.CacheNameLabel: p.name}).Observe(float64(bytesWritten))
-		}
-		return err
+		return p.writeMetadata(ctx, db, key, md)
 	}
 
 	wc := interfaces.CommittedWriteCloser(cwc)
@@ -2228,6 +2223,16 @@ func (p *PebbleCache) writeMetadata(ctx context.Context, db pebble.IPebbleDB, ke
 	if err = db.Set(keyBytes, protoBytes, pebble.NoSync); err == nil {
 		partitionID := md.GetFileRecord().GetIsolation().GetPartitionId()
 		p.sendSizeUpdate(partitionID, key.CacheType(), addSizeOp, md, len(keyBytes))
+
+		sizeBytes := md.GetStoredSizeBytes()
+		for _, cm := range md.GetStorageMetadata().GetChunkedMetadata().GetResource() {
+			// For an entry that points to multiple chunks, the file size is the
+			// sum of the size of the chunks instead of stored_size_bytes.
+			sizeBytes += cm.GetDigest().GetSizeBytes()
+		}
+		if md.GetFileType() == rfpb.FileMetadata_COMPLETE_FILE_TYPE {
+			metrics.DiskCacheAddedFileSizeBytes.With(prometheus.Labels{metrics.CacheNameLabel: p.name}).Observe(float64(sizeBytes))
+		}
 	}
 
 	return err

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -87,11 +87,11 @@ message FileMetadata {
   int64 last_modify_usec = 5;
 
   enum FileType {
-	  UNKNOWN_FILE_TYPE = 0;
-	  // This is a complete file.
-	  COMPLETE_FILE_TYPE = 1;
-	  // This is a chunk coming from a larger file.
-	  CHUNK_FILE_TYPE = 2;
+    UNKNOWN_FILE_TYPE = 0;
+    // This is a complete file.
+    COMPLETE_FILE_TYPE = 1;
+    // This is a chunk coming from a larger file.
+    CHUNK_FILE_TYPE = 2;
   }
 
   FileType file_type = 7;

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -85,6 +85,16 @@ message FileMetadata {
 
   // Last modify time of the record
   int64 last_modify_usec = 5;
+
+  enum FileType {
+	  UNKNOWN_FILE_TYPE = 0;
+	  // This is a complete file.
+	  COMPLETE_FILE_TYPE = 1;
+	  // This is a chunk coming from a larger file.
+	  CHUNK_FILE_TYPE = 2;
+  }
+
+  FileType file_type = 7;
 }
 
 message EncryptionMetadata {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
add a enum in FileMetadata to indicate whether an entry is for a complete file or for a chunk that is part of a larger file. 
In writeMetadata, we only record the metric if FileMetadata indicates that it's a complete file. If it consists of multiple chunks, we sum up the size of all the chunks, and use that when we record DiskCacheAddedFileSizeBytes. 
