### PR TITLE
Don't report streamable images as cached

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -556,10 +556,6 @@ func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, st
 }
 
 func (c *podmanCommandContainer) IsImageCached(ctx context.Context) (bool, error) {
-	if c.imageIsStreamable {
-		return true, nil
-	}
-
 	// Try to avoid the `pull` command which results in a network roundtrip.
 	listResult := runPodman(ctx, "image", &container.Stdio{}, "inspect", "--format={{.ID}}", c.image)
 	if listResult.ExitCode == podmanInternalExitCode {


### PR DESCRIPTION
We initially decided to report streamable images as cached locally because we didn't think they'd need to be pulled. This turned out to be wrong, we have to pull them to populate local layer information, though the pull is fast. I suspect that incorrectly reporting them as cached is causing us to incorrectly not run `podman pull` in circumstances where we should be doing so.

Practically, this does not matter because if the image hasn't been pulled during the executors lifetime, the cache authenticator won't know about it and will force a repull here: https://github.com/buildbuddy-io/buildbuddy/blob/cf05b786a85e65c5d6e6d482891986adb73d5488/enterprise/server/remote_execution/container/container.go#L254  but this unexpected behavior could cause a bug if anyone ever changes that logic.

**Related issues**: N/A
