### PR TITLE
Fix unqualified imports in bb fix

### DIFF
--- a/cli/fix/typescript/typescript.go
+++ b/cli/fix/typescript/typescript.go
@@ -121,6 +121,9 @@ func (t *TS) GenerateRules(args language.GenerateArgs) language.GenerateResult {
 		for i := 0; i < int(tree.RootNode().ChildCount()); i++ {
 			child := tree.RootNode().Child(i)
 			if child.Type() == "import_statement" {
+				if child.NamedChild(1) == nil {
+					continue
+				}
 				ruleImports = append(ruleImports, child.NamedChild(1).Child(1).Content(data))
 			}
 		}


### PR DESCRIPTION
`import pkg` causes us to panic because we assume `import stuff from pkg` format. The panic happens because `stuff` is nil in the former case.

**Related issues**: N/A
