### PR TITLE
Revert "Remove podman images that hit the input/output error bug"

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -80,9 +80,8 @@ var (
 	// Additional time used to kill the container if the command doesn't exit cleanly
 	containerFinalizationTimeout = 10 * time.Second
 
-	storageErrorRegex     = regexp.MustCompile(`(?s)A storage corruption might have occurred.*Error: readlink.*no such file or directory`)
-	inputOutputErrorRegex = regexp.MustCompile(`can't stat lower layer.*input/output error`)
-	userRegex             = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*(:[a-z0-9_-]*)?$`)
+	storageErrorRegex = regexp.MustCompile(`(?s)A storage corruption might have occurred.*Error: readlink.*no such file or directory`)
+	userRegex         = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*(:[a-z0-9_-]*)?$`)
 
 	// A map from image name to pull status. This is used to avoid parallel pulling of the same image.
 	pullOperations sync.Map
@@ -90,10 +89,6 @@ var (
 
 const (
 	podmanInternalExitCode = 125
-
-	// error code returned by podman when it can't invoke the requested command.
-	podmanCannotInvokeExitCode = 126
-
 	// podmanExecSIGKILLExitCode is the exit code returned by `podman exec` when the exec
 	// process is killed due to the parent container being removed.
 	podmanExecSIGKILLExitCode = 137
@@ -962,27 +957,19 @@ func (c *podmanCommandContainer) killContainerIfRunning(ctx context.Context) err
 	return err
 }
 
-// An image can be corrupted in a couple of circumstances:
-//   - If "podman pull" command is killed when pulling a parent layer, more details:
-//     https://github.com/containers/storage/issues/1136
-//   - Due to a bug streaming the container image:
-//     https://github.com/buildbuddy-io/buildbuddy-internal/issues/2570
-//
-// In either case we need to remove the image before re-pulling the image in order to fix it.
+// An image can be corrupted if "podman pull" command is killed when pulling a parent layer.
+// More details can be found at https://github.com/containers/storage/issues/1136. When this
+// happens when need to remove the image before re-pulling the image in order to fix it.
 func (c *podmanCommandContainer) maybeCleanupCorruptedImages(ctx context.Context, result *interfaces.CommandResult) error {
-	stderr := string(result.Stderr)
-	if result.ExitCode == podmanInternalExitCode && storageErrorRegex.MatchString(stderr) {
-		log.CtxInfo(ctx, "podman detected storage corruption, removing image")
-		result.Error = status.UnavailableError("a storage corruption occurred")
-		result.ExitCode = commandutil.NoExitCode
-		return removeImage(ctx, c.image)
-	} else if result.ExitCode == podmanCannotInvokeExitCode && inputOutputErrorRegex.MatchString(stderr) {
-		log.CtxInfo(ctx, "podman detected input/output error, removing image")
-		result.Error = status.UnavailableError("an input/output error occurred streaming the image")
-		result.ExitCode = commandutil.NoExitCode
-		return removeImage(ctx, c.image)
+	if result.ExitCode != podmanInternalExitCode {
+		return nil
 	}
-	return nil
+	if !storageErrorRegex.MatchString(string(result.Stderr)) {
+		return nil
+	}
+	result.Error = status.UnavailableError("a storage corruption occurred")
+	result.ExitCode = commandutil.NoExitCode
+	return removeImage(ctx, c.image)
 }
 
 func removeImage(ctx context.Context, imageName string) error {


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#4694 because it seems to cause errors like this:
```
Error: creating container storage: parsing named reference "1b696e3c115a1a1baa7fc1554e466ff2feeadc807888722e7ce71b7bb2792cde": invalid repository name (1b696e3c115a1a1baa7fc1554e466ff2feeadc807888722e7ce71b7bb2792cde), cannot specify 64-byte hexadecimal strings
```