### PR TITLE
Run the executor under tini in the release image too.

### DIFF
--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -122,9 +122,20 @@ container_image(
 #
 # This target can be run locally with enterprise/tools/run_executor_image.sh
 go_image(
-    name = "executor_image",
+    name = "executor_go_image",
     base = ":base_image",
     binary = ":executor",
+    tags = ["manual"],
+)
+
+container_image(
+    name = "executor_image",
+    base = ":executor_go_image",
+    entrypoint = [
+        "/tini",
+        "--",
+        "/app/enterprise/server/cmd/executor/executor",
+    ],
     tags = ["manual"],
 )
 


### PR DESCRIPTION
Analogue of https://github.com/buildbuddy-io/buildbuddy-internal/pull/2536/files but for the release image.

Also updates the `run_executor_image` script since `container_image` targets cannot be run directly, like `go_image` targets can.

**Related issues**: N/A
