### PR TITLE
cli/picker: skip using picker when some flags are provided

### DIFF
--- a/cli/picker/picker.go
+++ b/cli/picker/picker.go
@@ -21,6 +21,19 @@ func HandlePicker(args []string) []string {
 	// If the command is build, test, or query without a specified target - apply to all targets.
 	command := arg.GetCommand(args)
 
+	bzlArgs := arg.GetBazelArgs(args)
+	for _, bzlArg := range bzlArgs {
+		// Skip using the picker if the user has specified a query file.
+		if strings.Contains(command, "query") && strings.Contains(bzlArg, "--query_file") {
+			return args
+		}
+
+		// Skip using the picker if the user has specified a target pattern file.
+		if command == "build" && strings.Contains(bzlArg, "--target_pattern_file") {
+			return args
+		}
+	}
+
 	// If it's a build, test, or query - apply to all targets.
 	if command == "build" || command == "test" || command == "query" {
 		args = append(args, "//...")

--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -295,7 +295,7 @@ func TestTerminalOutput(t *testing.T) {
 	require.Contains(t, term.Render(), "\x1b[32mINFO")
 }
 
-func TestNoPickerUsed(t *testing.T) {
+func TestTargetPatternFile(t *testing.T) {
 	ws := testcli.NewWorkspace(t)
 	testfs.WriteAllFileContents(t, ws, map[string]string{
 		"BUILD":       `sh_test(name = "nop", srcs = ["nop.sh"])`,

--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -295,6 +295,18 @@ func TestTerminalOutput(t *testing.T) {
 	require.Contains(t, term.Render(), "\x1b[32mINFO")
 }
 
+func TestNoPickerUsed(t *testing.T) {
+	ws := testcli.NewWorkspace(t)
+	testfs.WriteAllFileContents(t, ws, map[string]string{
+		"BUILD":       `sh_test(name = "nop", srcs = ["nop.sh"])`,
+		"nop.sh":      "",
+		"targets.txt": "//:nop",
+	})
+
+	_, err := testcli.CombinedOutput(testcli.Command(t, ws, "build", "--target_pattern_file=targets.txt"))
+	require.NoError(t, err)
+}
+
 func TestFix(t *testing.T) {
 	ws := testcli.NewWorkspace(t)
 


### PR DESCRIPTION
In case where Bazel target patterns are provided via a flag instead of
args, don't use our picker.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
