### PR TITLE
Fix a race condition in pebble cache GetMulti

### DIFF
--- a/enterprise/server/backends/migration_cache/migration_cache_test.go
+++ b/enterprise/server/backends/migration_cache/migration_cache_test.go
@@ -960,11 +960,15 @@ func TestGetMultiWithCopying(t *testing.T) {
 	rootDirSrc := testfs.MakeTempDir(t)
 	rootDirDest := testfs.MakeTempDir(t)
 
-	srcCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirSrc}, maxSizeBytes)
+	srcCache, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{RootDirectory: rootDirSrc, MaxSizeBytes: maxSizeBytes})
 	require.NoError(t, err)
-	destCache, err := disk_cache.NewDiskCache(te, &disk_cache.Options{RootDirectory: rootDirDest}, maxSizeBytes)
+	err = srcCache.Start()
 	require.NoError(t, err)
-	config := &migration_cache.MigrationConfig{}
+	destCache, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{RootDirectory: rootDirDest, MaxSizeBytes: maxSizeBytes})
+	require.NoError(t, err)
+	err = destCache.Start()
+	require.NoError(t, err)
+	config := &migration_cache.MigrationConfig{DoubleReadPercentage: 1.0}
 	config.SetConfigDefaults()
 	mc := migration_cache.NewMigrationCache(te, config, srcCache, destCache)
 	mc.Start() // Starts copying in background

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -12,7 +12,6 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1605,9 +1604,6 @@ func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceNa
 	defer db.Close()
 
 	foundMap := make(map[*repb.Digest][]byte, len(resources))
-	sort.Slice(resources, func(i, j int) bool {
-		return resources[i].GetDigest().GetHash() < resources[j].GetDigest().GetHash()
-	})
 
 	buf := &bytes.Buffer{}
 	for _, r := range resources {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Delete the code to sort the input resources in GetMulti. This causes a race 
condition when we are migrating from one pebble cache to another.  

Also, switched to use pebble cache in migration_cache_test.
