### PR TITLE
Fix timeout not working for docker actions.

### DIFF
--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -284,6 +284,9 @@ func (r *dockerCommandContainer) Run(ctx context.Context, command *repb.Command,
 		select {
 		case err := <-errCh:
 			mu.Lock()
+			// We don't want to propagate the error from the above goroutine so
+			// we set a signal to avoid returning an error since we're already
+			// going to return one here.
 			exitedUncleanly = true
 			mu.Unlock()
 			// Close the output reader so that the above goroutine can also

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -273,6 +273,9 @@ func (r *dockerCommandContainer) Run(ctx context.Context, command *repb.Command,
 		statusCh, errCh := r.client.ContainerWait(ctx, cid, dockercontainer.WaitConditionNotRunning)
 		select {
 		case err := <-errCh:
+			// Close the output reader so that the above goroutine can also
+			// exit.
+			hijackedResp.Close()
 			return wrapDockerErr(err, "container did not exit cleanly")
 		case s := <-statusCh:
 			exitedCleanly = true

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -267,6 +267,9 @@ func (r *dockerCommandContainer) Run(ctx context.Context, command *repb.Command,
 		_, err := stdcopy.StdCopy(&stdout, &stderr, hijackedResp.Reader)
 		result.Stdout = stdout.Bytes()
 		result.Stderr = stderr.Bytes()
+		if ctx.Err() == context.DeadlineExceeded || ctx.Err() == context.Canceled {
+			return nil
+		}
 		return wrapDockerErr(err, "failed to copy docker container output")
 	})
 	eg.Go(func() error {


### PR DESCRIPTION
ContainerAttach does not respect the passed context. The returned reader will not be closed if the context times out, preventing the output copying goroutine from ever finishing.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
