### PR TITLE
return error on commit when the number of chunks in storageMetadata is smaller than 1.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1922,6 +1922,11 @@ func (p *PebbleCache) newCDCCommitedWriteCloser(ctx context.Context, fileRecord 
 			LastModifyUsec:  now,
 			FileType:        rfpb.FileMetadata_COMPLETE_FILE_TYPE,
 		}
+
+		if numChunks := len(md.StorageMetadata.GetChunkedMetadata().GetResource()); numChunks <= 1 {
+			log.Errorf("expected to have more than one chunks, but actually have %d for digest %s", numChunks, fileRecord.GetDigest().GetHash())
+			return status.InternalErrorf("invalid number of chunks (%d)", numChunks)
+		}
 		return p.writeMetadata(ctx, db, key, md)
 	}
 	return cwc, nil


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
There are some bad entries in pebble cache in dev when cdc is enabled where the
number of chunks in storage metadata is zero and inlineMetadata is nil.

Add logging and return error in commit function so we can catch them earlier.
