### PR TITLE
add backend support for smaller time increments in drilldowns.

### DIFF
--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -564,8 +564,8 @@ func getTimeIncrement(duration time.Duration) time.Duration {
 	if duration <= 48*time.Hour {
 		return 15 * time.Minute
 	}
-	if duration <= (96)*time.Hour {
-		return 30 * time.Hour
+	if duration <= 96*time.Hour {
+		return 30 * time.Minute
 	}
 	return 1 * time.Hour
 }

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -558,25 +558,16 @@ func (i *InvocationStatService) getMetricBuckets(ctx context.Context, table stri
 }
 
 func getTimeIncrement(duration time.Duration) time.Duration {
-	if duration <= 8*time.Hour {
+	if duration <= 16*time.Hour {
 		return 5 * time.Minute
 	}
-	if duration <= 25*time.Hour {
+	if duration <= 48*time.Hour {
 		return 15 * time.Minute
 	}
-	if duration <= 49*time.Hour {
-		return 30 * time.Minute
+	if duration <= (96)*time.Hour {
+		return 30 * time.Hour
 	}
-	if duration <= (5*24)*time.Hour {
-		return time.Hour
-	}
-	if duration <= (8*24)*time.Hour {
-		return 2 * time.Hour
-	}
-	if duration <= (15*24)*time.Hour {
-		return 4 * time.Hour
-	}
-	return 8 * time.Hour
+	return 1 * time.Hour
 }
 
 const ONE_WEEK = 7 * 24 * time.Hour
@@ -619,8 +610,8 @@ func getTimestampBuckets(q *stpb.TrendQuery, requestContext *ctxpb.RequestContex
 
 	var timestampBuckets []int64
 	timestampBuckets = append(timestampBuckets, start.UnixMicro())
-	// When the queried time range is less than a month, we show smaller buckets.
-	if *finerDrilldownTimeIncrements && time.Duration(endSec-startSec)*time.Second <= (31*24)*time.Hour {
+	// When the queried time range is less than eight days, we show smaller buckets.
+	if *finerDrilldownTimeIncrements && time.Duration(endSec-startSec)*time.Second <= (8*24)*time.Hour {
 		increment := getTimeIncrement(time.Duration(endSec-startSec) * time.Second)
 		current := start.Round(increment)
 		for current.Before(start) || current.Equal(start) {

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -622,7 +622,10 @@ func getTimestampBuckets(q *stpb.TrendQuery, requestContext *ctxpb.RequestContex
 	// When the queried time range is less than a month, we show smaller buckets.
 	if *finerDrilldownTimeIncrements && time.Duration(endSec-startSec)*time.Second <= (31*24)*time.Hour {
 		increment := getTimeIncrement(time.Duration(endSec-startSec) * time.Second)
-		current := start.Add(increment)
+		current := start.Round(increment)
+		for current.Before(start) {
+			current = current.Add(increment)
+		}
 		for current.Before(end) {
 			timestampBuckets = append(timestampBuckets, current.UnixMicro())
 			current = current.Add(increment)

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -567,16 +567,16 @@ func getTimeIncrement(duration time.Duration) time.Duration {
 	if duration <= 49*time.Hour {
 		return 30 * time.Minute
 	}
-	if duration <= (8*24)*time.Hour {
+	if duration <= (5*24)*time.Hour {
 		return time.Hour
 	}
-	if duration <= (15*24)*time.Hour {
+	if duration <= (8*24)*time.Hour {
 		return 2 * time.Hour
 	}
-	if duration <= (31*24)*time.Hour {
+	if duration <= (15*24)*time.Hour {
 		return 4 * time.Hour
 	}
-	return time.Hour
+	return 8 * time.Hour
 }
 
 const ONE_WEEK = 7 * 24 * time.Hour

--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -623,7 +623,7 @@ func getTimestampBuckets(q *stpb.TrendQuery, requestContext *ctxpb.RequestContex
 	if *finerDrilldownTimeIncrements && time.Duration(endSec-startSec)*time.Second <= (31*24)*time.Hour {
 		increment := getTimeIncrement(time.Duration(endSec-startSec) * time.Second)
 		current := start.Round(increment)
-		for current.Before(start) {
+		for current.Before(start) || current.Equal(start) {
 			current = current.Add(increment)
 		}
 		for current.Before(end) {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
I'm not seeing an appreciable difference in performance for this.  I'll fix the axis / timestamp rendering in the frontend separately (this is flag-guarded)

Before: <img width="1422" alt="Screenshot 2023-09-06 at 11 11 25 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/10570856/738c9627-7969-431a-8e90-9cb3713b7241">
After: 
<img width="1408" alt="Screenshot 2023-09-06 at 11 12 05 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/10570856/a817e3db-e3d9-45f9-99ae-6eb71c45a0c3">

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
