### PR TITLE
Minor tweaks to main page headings

### DIFF
--- a/website/src/components/integrations/integrations.module.css
+++ b/website/src/components/integrations/integrations.module.css
@@ -1,7 +1,3 @@
-.text {
-  width: 100%;
-  max-width: 800px;
-}
 .title {
   font-size: 28px;
   line-height: 44px;

--- a/website/src/components/integrations/integrations.tsx
+++ b/website/src/components/integrations/integrations.tsx
@@ -7,7 +7,7 @@ function Component() {
   return (
     <div className={`${common.section} ${common.sectionGray} ${styles.integrationSection}`}>
       <div className={common.container}>
-        <div className={styles.text}>
+        <div className={common.centeredText}>
           <h2 className={styles.title}>BuildBuddy integrates with</h2>
         </div>
       </div>

--- a/website/src/css/common.module.css
+++ b/website/src/css/common.module.css
@@ -82,6 +82,7 @@
   font-size: 56px;
   line-height: 64px;
   font-weight: 700;
+  text-wrap: balance;
 }
 
 .subtitle {


### PR DESCRIPTION
* Center the "BuildBuddy integrates with" heading (it looks a tad awkward left-aligned)
* Use `text-wrap: balance` so titles like "BuildBuddy is enterprise Bazel" render like "BuildBuddy is / enterprise Bazel" instead of "BuildBuddy is enterprise / Bazel" (the "Bazel" felt a tad awkward sitting on its own line)

**Related issues**: N/A
