### PR TITLE
Add frontend support for labeling smaller time intervals in drilldowns.

### DIFF
--- a/enterprise/app/trends/drilldown_page.tsx
+++ b/enterprise/app/trends/drilldown_page.tsx
@@ -715,8 +715,8 @@ export default class DrilldownPageComponent extends React.Component<Props, State
       return null;
     }
 
-    const startDate = moment(this.currentZoomFilters.dateRangeMicros.startInclusive / 1000).format("YYYY-MM-DD");
-    const endDate = moment((this.currentZoomFilters.dateRangeMicros.endExclusive - 1) / 1000).format("YYYY-MM-DD");
+    const startDate = moment(this.currentZoomFilters.dateRangeMicros.startInclusive / 1000).format("lll");
+    const endDate = moment(this.currentZoomFilters.dateRangeMicros.endExclusive / 1000).format("lll");
     const startValue = this.renderYBucketValue(this.currentZoomFilters.bucketRange.startInclusive);
     const endValue = this.renderYBucketValue(this.currentZoomFilters.bucketRange.endExclusive);
 
@@ -756,8 +756,8 @@ export default class DrilldownPageComponent extends React.Component<Props, State
       return null;
     }
 
-    const startDate = moment(this.currentHeatmapSelection.dateRangeMicros.startInclusive / 1000).format("YYYY-MM-DD");
-    const endDate = moment((this.currentHeatmapSelection.dateRangeMicros.endExclusive - 1) / 1000).format("YYYY-MM-DD");
+    const startDate = moment(this.currentHeatmapSelection.dateRangeMicros.startInclusive / 1000).format("lll");
+    const endDate = moment(this.currentHeatmapSelection.dateRangeMicros.endExclusive / 1000).format("lll");
     const startValue = this.renderYBucketValue(this.currentHeatmapSelection.bucketRange.startInclusive);
     const endValue = this.renderYBucketValue(this.currentHeatmapSelection.bucketRange.endExclusive);
     return (

--- a/enterprise/app/trends/drilldown_page.tsx
+++ b/enterprise/app/trends/drilldown_page.tsx
@@ -715,8 +715,8 @@ export default class DrilldownPageComponent extends React.Component<Props, State
       return null;
     }
 
-    const startDate = moment(this.currentZoomFilters.dateRangeMicros.startInclusive / 1000).format("lll");
-    const endDate = moment(this.currentZoomFilters.dateRangeMicros.endExclusive / 1000).format("lll");
+    const startDate = moment(this.currentZoomFilters.dateRangeMicros.startInclusive / 1000).format("MMM D HH:mm");
+    const endDate = moment(this.currentZoomFilters.dateRangeMicros.endExclusive / 1000).format("MMM D HH:mm");
     const startValue = this.renderYBucketValue(this.currentZoomFilters.bucketRange.startInclusive);
     const endValue = this.renderYBucketValue(this.currentZoomFilters.bucketRange.endExclusive);
 
@@ -780,21 +780,23 @@ export default class DrilldownPageComponent extends React.Component<Props, State
     return (
       <div className="trend-chart">
         <div className="trend-chart-title">
-          Drilldown by
-          <Select
-            className="drilldown-page-select"
-            onChange={this.handleMetricChange.bind(this)}
-            value={this.selectedMetric.name}>
-            {METRIC_OPTIONS.map(
-              (o) =>
-                o.name && (
-                  <Option key={o.name} value={o.name}>
-                    {o.name}
-                  </Option>
-                )
-            )}
-          </Select>
-          {this.renderZoomChip()}
+          <span className="drilldown-by-text">Drilldown by</span>
+          <div className="drilldown-page-selection-group">
+            <Select
+              className="drilldown-page-select"
+              onChange={this.handleMetricChange.bind(this)}
+              value={this.selectedMetric.name}>
+              {METRIC_OPTIONS.map(
+                (o) =>
+                  o.name && (
+                    <Option key={o.name} value={o.name}>
+                      {o.name}
+                    </Option>
+                  )
+              )}
+            </Select>
+            {this.renderZoomChip()}
+          </div>
         </div>
         {this.state.loading && <div className="loading"></div>}
         {!this.state.loading && (

--- a/enterprise/app/trends/trends.css
+++ b/enterprise/app/trends/trends.css
@@ -94,6 +94,18 @@
   color: #4daf62;
 }
 
+.drilldown-by-text {
+  display: inline-block;
+  height: 40px;
+  line-height: 40px;
+  vertical-align: top;
+}
+
+.drilldown-page-selection-group {
+  display: inline-block;
+  margin: 0 0 0 16px;
+}
+
 .drilldown-page-zoom-summary {
   display: inline-block;
   height: 40px;
@@ -112,6 +124,13 @@
   margin-left: 8px;
   height: 40px;
   max-height: 40px;
+}
+
+@media (max-width: 1200px) {
+  .drilldown-page-zoom-summary.zoomed {
+    display: block;
+    margin: 12px 0 0;
+  }
 }
 
 .drilldown-page-zoom-summary.zoomed .drilldown-page-zoom-filters {
@@ -136,7 +155,7 @@
 
 .select.drilldown-page-select {
   font-size: 16px;
-  margin: 0 16px;
+  margin: 0;
 }
 
 .drilldown-selection-summary {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
This  changes rendering when the feature is off a teensy bit, but it still works just fine.  Seems better to just rely on what the server sends.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
