### PR TITLE
Actually persist the new API key attributes.

### DIFF
--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -568,7 +568,7 @@ func (d *AuthDB) createAPIKey(db *db.DB, ak tables.APIKey) (*tables.APIKey, erro
 			nonce,
 			label,
 			visible_to_developers,
-		    impersonation,
+			impersonation,
 			expiry_usec
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		pk,

--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -567,8 +567,10 @@ func (d *AuthDB) createAPIKey(db *db.DB, ak tables.APIKey) (*tables.APIKey, erro
 			encrypted_value,
 			nonce,
 			label,
-			visible_to_developers
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			visible_to_developers,
+		    impersonation,
+			expiry_usec
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		pk,
 		ak.UserID,
 		ak.GroupID,
@@ -579,6 +581,8 @@ func (d *AuthDB) createAPIKey(db *db.DB, ak tables.APIKey) (*tables.APIKey, erro
 		nonce,
 		ak.Label,
 		ak.VisibleToDevelopers,
+		ak.Impersonation,
+		ak.ExpiryUsec,
 	).Error
 	if err != nil {
 		return nil, err

--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -564,7 +564,7 @@ func TestImpersonationAPIKeys(t *testing.T) {
 	}
 
 	auth := env.GetAuthenticator().(*testauth.TestAuthenticator)
-	adminCtx, err := auth.WithAuthenticatedUser(ctx, admin.UserID)
+	serverAdminCtx, err := auth.WithAuthenticatedUser(ctx, admin.UserID)
 	require.NoError(t, err)
 
 	// Should not be able to create an impersonation key if you're not a server
@@ -573,7 +573,7 @@ func TestImpersonationAPIKeys(t *testing.T) {
 		req := &akpb.CreateImpersonationApiKeyRequest{
 			RequestContext: &ctxpb.RequestContext{GroupId: u.Groups[0].Group.GroupID},
 		}
-		_, err := env.GetBuildBuddyServer().CreateImpersonationApiKey(adminCtx, req)
+		_, err := env.GetBuildBuddyServer().CreateImpersonationApiKey(serverAdminCtx, req)
 		require.Error(t, err)
 		require.True(t, status.IsPermissionDeniedError(err))
 	}
@@ -584,21 +584,42 @@ func TestImpersonationAPIKeys(t *testing.T) {
 	auth.ServerAdminGroupID = admin.Groups[0].Group.GroupID
 	for _, u := range users {
 		al.Reset()
-		req := &akpb.CreateImpersonationApiKeyRequest{
-			RequestContext: &ctxpb.RequestContext{GroupId: u.Groups[0].Group.GroupID},
-		}
-		rsp, err := env.GetBuildBuddyServer().CreateImpersonationApiKey(adminCtx, req)
+		targetGroupID := u.Groups[0].Group.GroupID
+		targetGroupAdminCtx, err := auth.WithAuthenticatedUser(ctx, u.UserID)
+		require.NoError(t, err)
+		prevKeys, err := adb.GetAPIKeys(targetGroupAdminCtx, targetGroupID)
 		require.NoError(t, err)
 
+		req := &akpb.CreateImpersonationApiKeyRequest{
+			RequestContext: &ctxpb.RequestContext{GroupId: targetGroupID},
+		}
+		rsp, err := env.GetBuildBuddyServer().CreateImpersonationApiKey(serverAdminCtx, req)
+		require.NoError(t, err)
+
+		// Verify audit log entry.
 		require.Len(t, al.GetAllEntries(), 1)
 		e := al.GetAllEntries()[0]
 		require.Equal(t, alpb.ResourceType_GROUP, e.Resource.GetType())
-		require.Equal(t, u.Groups[0].Group.GroupID, e.Resource.GetId())
+		require.Equal(t, targetGroupID, e.Resource.GetId())
 		require.Equal(t, alpb.Action_CREATE_IMPERSONATION_API_KEY, e.Action)
 		require.Equal(t, req, e.Request)
 
+		// Verify the new API key is usable.
 		_, err = adb.GetAPIKeyGroupFromAPIKey(ctx, rsp.GetApiKey().GetValue())
 		require.NoError(t, err)
+
+		// Verify correct key attributes.
+		key, err := adb.GetAPIKey(targetGroupAdminCtx, rsp.GetApiKey().GetId())
+		require.NoError(t, err)
+		require.True(t, key.Impersonation)
+		require.NotEqualValues(t, 0, key.ExpiryUsec)
+
+		// Verify "list" operation does not include the impersonation key.
+		if role.Role(u.Groups[0].Role) == role.Admin {
+			keys, err := adb.GetAPIKeys(targetGroupAdminCtx, targetGroupID)
+			require.NoError(t, err)
+			require.Equal(t, prevKeys, keys)
+		}
 	}
 }
 


### PR DESCRIPTION
:face_with_spiral_eyes: 

**Related issues**: N/A
