### PR TITLE
Modify impersonation api key permission check.

### DIFF
--- a/server/role_filter/role_filter.go
+++ b/server/role_filter/role_filter.go
@@ -213,6 +213,13 @@ func AuthorizeRPC(ctx context.Context, env environment.Env, rpcName string) erro
 	}
 
 	if stringSliceContains(ServerAdminOnlyRPCs(), rpcName) {
+		// If impersonation is in effect, it implies the user is an admin.
+		// Can't check group membership because impersonation modifies
+		// group information.
+		if u.IsImpersonating() {
+			return nil
+		}
+
 		serverAdminGID := env.GetAuthenticator().AdminGroupID()
 		if serverAdminGID == "" {
 			return status.PermissionDeniedError("Permission Denied.")


### PR DESCRIPTION
The API will be called after impersonation is already in effect in which case we can't rely on checking admin group membership.

Instead check the impersonation bit, which can only be set for authenticated admins.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
