### PR TITLE
[Release] Fix version tag and commit not getting embedded correctly

### DIFF
--- a/server/version/BUILD
+++ b/server/version/BUILD
@@ -1,15 +1,35 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+genrule(
+    name = "populate_version",
+    outs = ["version.txt"],
+    cmd_bash = """
+        version=$$(grep ^STABLE_VERSION_TAG bazel-out/stable-status.txt | cut -d' ' -f2); \
+        echo "$$version" > $@;
+    """,
+    stamp = 1,
+)
+
+genrule(
+    name = "populate_commit",
+    outs = ["commit.txt"],
+    cmd_bash = """
+        commit=$$(grep ^STABLE_COMMIT_SHA bazel-out/stable-status.txt | cut -d' ' -f2); \
+        echo "$$commit" > $@;
+    """,
+    stamp = 1,
+)
+
 go_library(
     name = "version",
     srcs = ["version.go"],
+    embedsrcs = [
+        "version.txt",
+        "commit.txt",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/version",
     visibility = ["//visibility:public"],
-    x_defs = {
-        "commitSha": "{STABLE_COMMIT_SHA}",
-        "versionTag": "{STABLE_VERSION_TAG}",
-    },
     deps = [
         "//server/metrics",
         "//server/util/log",

--- a/server/version/BUILD
+++ b/server/version/BUILD
@@ -6,7 +6,7 @@ genrule(
     outs = ["version.txt"],
     cmd_bash = """
         version=$$(grep ^STABLE_VERSION_TAG bazel-out/stable-status.txt | cut -d' ' -f2); \
-        echo "$$version" > $@;
+        printf '%s' $$version > $@;
     """,
     stamp = 1,
 )
@@ -16,7 +16,7 @@ genrule(
     outs = ["commit.txt"],
     cmd_bash = """
         commit=$$(grep ^STABLE_COMMIT_SHA bazel-out/stable-status.txt | cut -d' ' -f2); \
-        echo "$$commit" > $@;
+        printf '%s' $$commit > $@;
     """,
     stamp = 1,
 )

--- a/server/version/version.go
+++ b/server/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	_ "embed"
 	"fmt"
 	"runtime"
 
@@ -13,8 +14,12 @@ const (
 	unknownValue = "unknown"
 )
 
-// This is set by x_defs in the BUILD file.
+// The text files are populated by the populate_* genrules
+//
+//go:embed commit.txt
 var commitSha string
+
+//go:embed version.txt
 var versionTag string
 
 func init() {


### PR DESCRIPTION
The commit and version keep getting set to UNKNOWN in version.go, ruining our app version metric. There seems to be a bug where x_defs does not consistently embed the data during releases.

In this commit we try another approach where we use a genrule that explicitly sets stamp = 1 and directly reads from bazel-out/stable-status.txt (described here: https://github.com/bazelbuild/bazel/issues/4942#issuecomment-1506315647)

There's some additional context at the bottom of this thread: https://buildbuddy-corp.slack.com/archives/C01D5GHRJ59/p1694026279817119
