### PR TITLE
Add IP rules service for manipulating and checking IP rules.

### DIFF
--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -203,6 +203,7 @@ type apiKeyGroup struct {
 	Capabilities           int32
 	UseGroupOwnedExecutors bool
 	CacheEncryptionEnabled bool
+	EnforceIPRules         bool
 }
 
 func (g *apiKeyGroup) GetAPIKeyID() string {
@@ -227,6 +228,10 @@ func (g *apiKeyGroup) GetUseGroupOwnedExecutors() bool {
 
 func (g *apiKeyGroup) GetCacheEncryptionEnabled() bool {
 	return g.CacheEncryptionEnabled
+}
+
+func (g *apiKeyGroup) GetEnforceIPRules() bool {
+	return g.EnforceIPRules
 }
 
 func (d *AuthDB) InsertOrUpdateUserSession(ctx context.Context, sessionID string, session *tables.Session) error {
@@ -443,6 +448,7 @@ func (d *AuthDB) LookupUserFromSubID(ctx context.Context, subID string) (*tables
 				g.user_owned_keys_enabled,
 				g.use_group_owned_executors,
 				g.cache_encryption_enabled,
+				g.enforce_ip_rules,
 				g.saml_idp_metadata_url,
 				ug.role
 			FROM "Groups" AS g, "UserGroups" AS ug
@@ -468,6 +474,7 @@ func (d *AuthDB) LookupUserFromSubID(ctx context.Context, subID string) (*tables
 				&gr.Group.UserOwnedKeysEnabled,
 				&gr.Group.UseGroupOwnedExecutors,
 				&gr.Group.CacheEncryptionEnabled,
+				&gr.Group.EnforceIPRules,
 				&gr.Group.SamlIdpMetadataUrl,
 				&gr.Role,
 			)
@@ -492,7 +499,8 @@ func (d *AuthDB) newAPIKeyGroupQuery(subDomain string, allowUserOwnedKeys bool) 
 			ak.user_id,
 			g.group_id,
 			g.use_group_owned_executors,
-			g.cache_encryption_enabled
+			g.cache_encryption_enabled,
+			g.enforce_ip_rules
 		FROM "Groups" AS g,
 		"APIKeys" AS ak
 	`)

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -335,7 +335,8 @@ func (d *UserDB) InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (stri
 				use_group_owned_executors = ?,
 				cache_encryption_enabled = ?,
 				suggestion_preference = ?,
-				restrict_clean_workflow_runs_to_admins = ?
+				restrict_clean_workflow_runs_to_admins = ?,
+				enforce_ip_rules = ?
 			WHERE group_id = ?`,
 			g.Name,
 			g.URLIdentifier,
@@ -346,6 +347,7 @@ func (d *UserDB) InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (stri
 			g.CacheEncryptionEnabled,
 			g.SuggestionPreference,
 			g.RestrictCleanWorkflowRunsToAdmins,
+			g.EnforceIPRules,
 			g.GroupID)
 		if res.Error != nil {
 			return res.Error

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -40,6 +40,7 @@ go_library(
         "//enterprise/server/hostedrunner",
         "//enterprise/server/invocation_search_service",
         "//enterprise/server/invocation_stat_service",
+        "//enterprise/server/iprules",
         "//enterprise/server/quota",
         "//enterprise/server/raft/cache",
         "//enterprise/server/remote_execution/execution_server",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/hostedrunner"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/invocation_search_service"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/invocation_stat_service"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/iprules"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/quota"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/execution_server"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/scheduler_server"
@@ -251,6 +252,10 @@ func main() {
 		log.Fatalf("%v", err)
 	}
 	if err := auditlog.Register(realEnv); err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	if err := iprules.Register(realEnv); err != nil {
 		log.Fatalf("%v", err)
 	}
 

--- a/enterprise/server/iprules/BUILD
+++ b/enterprise/server/iprules/BUILD
@@ -1,10 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+package(default_visibility = ["//enterprise:__subpackages__"])
+
 go_library(
     name = "iprules",
     srcs = ["iprules.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/iprules",
-    visibility = ["//visibility:public"],
     deps = [
         "//proto:iprules_go_proto",
         "//server/environment",
@@ -19,8 +20,6 @@ go_library(
         "//server/util/status",
     ],
 )
-
-package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_test(
     name = "iprules_test",

--- a/enterprise/server/iprules/BUILD
+++ b/enterprise/server/iprules/BUILD
@@ -1,0 +1,41 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "iprules",
+    srcs = ["iprules.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/iprules",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:iprules_go_proto",
+        "//server/environment",
+        "//server/interfaces",
+        "//server/tables",
+        "//server/util/alert",
+        "//server/util/authutil",
+        "//server/util/clientip",
+        "//server/util/lru",
+        "//server/util/perms",
+        "//server/util/role",
+        "//server/util/status",
+    ],
+)
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_test(
+    name = "iprules_test",
+    srcs = ["iprules_test.go"],
+    deps = [
+        ":iprules",
+        "//enterprise/server/testutil/enterprise_testauth",
+        "//enterprise/server/testutil/enterprise_testenv",
+        "//proto:context_go_proto",
+        "//proto:iprules_go_proto",
+        "//server/environment",
+        "//server/testutil/testauth",
+        "//server/util/clientip",
+        "//server/util/status",
+        "//server/util/testing/flags",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/iprules/iprules.go
+++ b/enterprise/server/iprules/iprules.go
@@ -158,7 +158,7 @@ func (s *Service) AuthorizeGroup(ctx context.Context, groupID string) error {
 	clientIP := net.ParseIP(rawClientIP)
 	// Client IP is not parsable.
 	if clientIP == nil {
-		return status.FailedPreconditionErrorf("client IP %q is not valid", clientIP)
+		return status.FailedPreconditionErrorf("client IP %q is not valid", rawClientIP)
 	}
 
 	allowed, ok := s.cache.Get(groupID)

--- a/enterprise/server/iprules/iprules.go
+++ b/enterprise/server/iprules/iprules.go
@@ -1,0 +1,261 @@
+package iprules
+
+import (
+	"context"
+	"flag"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/tables"
+	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/clientip"
+	"github.com/buildbuddy-io/buildbuddy/server/util/lru"
+	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
+	"github.com/buildbuddy-io/buildbuddy/server/util/role"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	irpb "github.com/buildbuddy-io/buildbuddy/proto/iprules"
+)
+
+var (
+	enableIPRules = flag.Bool("auth.ip_rules.enable", false, "If true, IP rules will be checked during auth.")
+	cacheTTL      = flag.Duration("auth.ip_rules.cache_ttl", 5*time.Minute, "Duration of time IP rules will be cached in memory.")
+)
+
+const (
+	cacheSize = 100_000
+)
+
+type ipRuleCacheEntry struct {
+	allowed      []*net.IPNet
+	expiresAfter time.Time
+}
+
+type ipRuleCache interface {
+	Add(groupID string, allowed []*net.IPNet)
+	Get(groupID string) ([]*net.IPNet, bool)
+}
+
+type memIpRuleCache struct {
+	mu  sync.Mutex
+	lru interfaces.LRU[*ipRuleCacheEntry]
+}
+
+func (c *memIpRuleCache) Get(groupID string) (allowed []*net.IPNet, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.lru.Get(groupID)
+	if !ok {
+		return nil, ok
+	}
+	if time.Now().After(entry.expiresAfter) {
+		c.lru.Remove(groupID)
+		return nil, false
+	}
+	return entry.allowed, true
+}
+
+func (c *memIpRuleCache) Add(groupID string, allowed []*net.IPNet) {
+	c.mu.Lock()
+	c.lru.Add(groupID, &ipRuleCacheEntry{allowed: allowed, expiresAfter: time.Now().Add(*cacheTTL)})
+	c.mu.Unlock()
+}
+
+type noopIpRuleCache struct {
+}
+
+func (c *noopIpRuleCache) Add(groupID string, allowed []*net.IPNet) {
+}
+
+func (c *noopIpRuleCache) Get(groupID string) ([]*net.IPNet, bool) {
+	return nil, false
+}
+
+func newIpRuleCache() (ipRuleCache, error) {
+	if *cacheTTL == 0 {
+		return &noopIpRuleCache{}, nil
+	}
+	config := &lru.Config[*ipRuleCacheEntry]{
+		MaxSize: cacheSize,
+		SizeFn:  func(v *ipRuleCacheEntry) int64 { return int64(len(v.allowed)) },
+	}
+	l, err := lru.NewLRU[*ipRuleCacheEntry](config)
+	if err != nil {
+		return nil, err
+	}
+	return &memIpRuleCache{
+		lru: l,
+	}, nil
+}
+
+type Service struct {
+	env environment.Env
+
+	cache ipRuleCache
+}
+
+func New(env environment.Env) (*Service, error) {
+	cache, err := newIpRuleCache()
+	if err != nil {
+		return nil, err
+	}
+	return &Service{
+		env:   env,
+		cache: cache,
+	}, nil
+}
+
+func Register(env environment.Env) error {
+	if !*enableIPRules {
+		return nil
+	}
+
+	enforcer, err := New(env)
+	if err != nil {
+		return err
+	}
+	env.SetIPRulesService(enforcer)
+	return nil
+}
+
+func (s *Service) loadRulesFromDB(ctx context.Context, groupID string) ([]*net.IPNet, error) {
+	rows, err := s.env.GetDBHandle().DB(ctx).Raw(
+		`SELECT * FROM "IPRules" WHERE group_id = ?`, groupID).Rows()
+	if err != nil {
+		return nil, err
+	}
+
+	var allowed []*net.IPNet
+	for rows.Next() {
+		r := &tables.IPRule{}
+		if err := s.env.GetDBHandle().DB(ctx).ScanRows(rows, r); err != nil {
+			return nil, err
+		}
+		_, ipNet, err := net.ParseCIDR(r.CIDR)
+		if err != nil {
+			alert.UnexpectedEvent("unparsable CIDR rule", "rule %q", r.CIDR)
+			continue
+		}
+		allowed = append(allowed, ipNet)
+	}
+	return allowed, nil
+}
+
+func (s *Service) CheckGroup(ctx context.Context, groupID string) (bool, error) {
+	g, err := s.env.GetUserDB().GetGroupByID(ctx, groupID)
+	if err != nil {
+		return false, nil
+	}
+	if !g.EnforceIPRules {
+		return true, nil
+	}
+
+	rawClientIP := clientip.Get(ctx)
+	clientIP := net.ParseIP(rawClientIP)
+	// Client IP is not parsable.
+	if clientIP == nil {
+		return false, status.FailedPreconditionErrorf("client IP %q is not valid", clientIP)
+	}
+
+	allowed, ok := s.cache.Get(groupID)
+	if !ok {
+		rs, err := s.loadRulesFromDB(ctx, groupID)
+		if err != nil {
+			return false, err
+		}
+		s.cache.Add(groupID, rs)
+		allowed = rs
+	}
+
+	for _, a := range allowed {
+		if a.Contains(clientIP) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (s *Service) Check(ctx context.Context) (bool, error) {
+	u, err := perms.AuthenticatedUser(ctx, s.env)
+	if authutil.IsAnonymousUserError(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	// Server admins in impersonation mode can bypass IP rules.
+	if u.IsImpersonating() {
+		return true, nil
+	}
+
+	if !u.GetEnforceIPRules() {
+		return true, nil
+	}
+
+	return s.CheckGroup(ctx, u.GetGroupID())
+}
+
+func (s *Service) AddRule(ctx context.Context, req *irpb.AddRuleRequest) (*irpb.AddRuleResponse, error) {
+	u, err := perms.AuthenticatedUser(ctx, s.env)
+	if err != nil {
+		return nil, err
+	}
+	if err := authutil.AuthorizeGroupRole(u, req.GetRequestContext().GetGroupId(), role.Admin); err != nil {
+		return nil, err
+	}
+
+	id, err := tables.PrimaryKeyForTable("IPRules")
+	if err != nil {
+		return nil, err
+	}
+
+	groupID := req.GetRequestContext().GetGroupId()
+	r := req.GetRule()
+	q := `INSERT INTO "IPRules" (created_at_usec, ip_rule_id, group_id, cidr, description) VALUES (?, ?, ?, ?, ?)`
+	if err := s.env.GetDBHandle().DB(ctx).Exec(q, time.Now().UnixMicro(), id, groupID, r.GetCidr(), r.GetDescription()).Error; err != nil {
+		return nil, err
+	}
+	r.IpRuleId = id
+	return &irpb.AddRuleResponse{Rule: r}, nil
+}
+
+func (s *Service) UpdateRule(ctx context.Context, req *irpb.UpdateRuleRequest) (*irpb.UpdateRuleResponse, error) {
+	u, err := perms.AuthenticatedUser(ctx, s.env)
+	if err != nil {
+		return nil, err
+	}
+	if err := authutil.AuthorizeGroupRole(u, req.GetRequestContext().GetGroupId(), role.Admin); err != nil {
+		return nil, err
+	}
+
+	groupID := req.GetRequestContext().GetGroupId()
+	r := req.GetRule()
+	q := `UPDATE "IPRules" SET cidr = ?, description = ? WHERE group_id = ? AND ip_rule_id = ?`
+	if err := s.env.GetDBHandle().DB(ctx).Exec(q, r.GetCidr(), r.GetDescription(), groupID, r.GetIpRuleId()).Error; err != nil {
+		return nil, err
+	}
+	return &irpb.UpdateRuleResponse{}, nil
+}
+
+func (s *Service) DeleteRule(ctx context.Context, req *irpb.DeleteRuleRequest) (*irpb.DeleteRuleResponse, error) {
+	u, err := perms.AuthenticatedUser(ctx, s.env)
+	if err != nil {
+		return nil, err
+	}
+	if err := authutil.AuthorizeGroupRole(u, req.GetRequestContext().GetGroupId(), role.Admin); err != nil {
+		return nil, err
+	}
+
+	groupID := req.GetRequestContext().GetGroupId()
+	q := `DELETE FROM "IPRules" WHERE group_id = ? AND ip_rule_id = ?`
+	if err := s.env.GetDBHandle().DB(ctx).Exec(q, groupID, req.GetIpRuleId()).Error; err != nil {
+		return nil, err
+	}
+	return &irpb.DeleteRuleResponse{}, nil
+}

--- a/enterprise/server/iprules/iprules.go
+++ b/enterprise/server/iprules/iprules.go
@@ -143,6 +143,9 @@ func (s *Service) loadRulesFromDB(ctx context.Context, groupID string) ([]*net.I
 		}
 		allowed = append(allowed, ipNet)
 	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
 	return allowed, nil
 }
 

--- a/enterprise/server/iprules/iprules_test.go
+++ b/enterprise/server/iprules/iprules_test.go
@@ -1,0 +1,151 @@
+package iprules_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/iprules"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testauth"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
+	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
+	irpb "github.com/buildbuddy-io/buildbuddy/proto/iprules"
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
+	"github.com/buildbuddy-io/buildbuddy/server/util/clientip"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/require"
+)
+
+func newIPRulesService(t *testing.T, env environment.Env) *iprules.Service {
+	flags.Set(t, "auth.ip_rules.enable", true)
+	flags.Set(t, "auth.ip_rules.cache_ttl", 0)
+
+	s, err := iprules.New(env)
+	require.NoError(t, err)
+	return s
+}
+
+func getEnv(t *testing.T) environment.Env {
+	env := enterprise_testenv.New(t)
+	enterprise_testauth.Configure(t, env)
+	return env
+}
+
+func TestEnforcementNotEnabled(t *testing.T) {
+	env := getEnv(t)
+	ctx := context.Background()
+
+	u := enterprise_testauth.CreateRandomUser(t, env, "org1.invalid")
+
+	irs := newIPRulesService(t, env)
+	auther := env.GetAuthenticator().(*testauth.TestAuthenticator)
+	authCtx, err := auther.WithAuthenticatedUser(ctx, u.UserID)
+	require.NoError(t, err)
+
+	// The test group does not have IP rule enabled, so the check should pass.
+	ok, err := irs.Check(authCtx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Checking by group ID should also pass.
+	ok, err = irs.CheckGroup(ctx, u.Groups[0].Group.GroupID)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestEnforcement(t *testing.T) {
+	env := getEnv(t)
+	ctx := context.Background()
+
+	u := enterprise_testauth.CreateRandomUser(t, env, "org1.invalid")
+	g := u.Groups[0].Group
+	groupID := g.GroupID
+
+	irs := newIPRulesService(t, env)
+	auther := env.GetAuthenticator().(*testauth.TestAuthenticator)
+	authCtx, err := auther.WithAuthenticatedUser(ctx, u.UserID)
+	require.NoError(t, err)
+
+	_, err = irs.AddRule(authCtx, &irpb.AddRuleRequest{
+		RequestContext: &ctxpb.RequestContext{GroupId: groupID},
+		Rule:           &irpb.IPRule{Cidr: "1.2.3.0/24", Description: "rule1"},
+	})
+	require.NoError(t, err)
+	rsp, err := irs.AddRule(authCtx, &irpb.AddRuleRequest{
+		RequestContext: &ctxpb.RequestContext{GroupId: groupID},
+		Rule:           &irpb.IPRule{Cidr: "4.5.6.7/32", Description: "rule2"},
+	})
+	require.NoError(t, err)
+	rule2 := rsp.GetRule()
+
+	// Rules not in effect yet, should pass.
+	ok, err := irs.Check(authCtx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Enable IP rule enforcement.
+	g.EnforceIPRules = true
+	urlIdentifier := "foo"
+	g.URLIdentifier = &urlIdentifier
+	_, err = env.GetUserDB().InsertOrUpdateGroup(authCtx, &g)
+	require.NoError(t, err)
+
+	// Re-auth to pick up new group settings.
+	authCtx, err = auther.WithAuthenticatedUser(ctx, u.UserID)
+	require.NoError(t, err)
+
+	// No IP in context, check should fail.
+	_, err = irs.Check(authCtx)
+	require.Error(t, err)
+	require.True(t, status.IsFailedPreconditionError(err))
+
+	// An IP in the middle of the first rule.
+	authCtx = context.WithValue(authCtx, clientip.ContextKey, "1.2.3.15")
+	ok, err = irs.Check(authCtx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Exact match to second rule.
+	authCtx = context.WithValue(authCtx, clientip.ContextKey, "4.5.6.7")
+	ok, err = irs.Check(authCtx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Non-matching IP.
+	authCtx = context.WithValue(authCtx, clientip.ContextKey, "5.6.7.8")
+	ok, err = irs.Check(authCtx)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// Update the second rule to something else. Old rule should no longer
+	// apply.
+	rule2.Cidr = "8.8.8.8/32"
+	rule2.Description = "updated rule2"
+	_, err = irs.UpdateRule(authCtx, &irpb.UpdateRuleRequest{
+		RequestContext: &ctxpb.RequestContext{GroupId: groupID},
+		Rule:           rule2,
+	})
+	require.NoError(t, err)
+	authCtx = context.WithValue(authCtx, clientip.ContextKey, "4.5.6.7")
+	ok, err = irs.Check(authCtx)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// New rule value should apply.
+	authCtx = context.WithValue(authCtx, clientip.ContextKey, "8.8.8.8")
+	ok, err = irs.Check(authCtx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Delete rule2. Its value should no longer apply.
+	_, err = irs.DeleteRule(authCtx, &irpb.DeleteRuleRequest{
+		RequestContext: &ctxpb.RequestContext{GroupId: groupID},
+		IpRuleId:       rule2.IpRuleId,
+	})
+	require.NoError(t, err)
+	authCtx = context.WithValue(authCtx, clientip.ContextKey, "8.8.8.8")
+	ok, err = irs.Check(authCtx)
+	require.NoError(t, err)
+	require.False(t, ok)
+}

--- a/enterprise/server/testutil/enterprise_testauth/enterprise_testauth.go
+++ b/enterprise/server/testutil/enterprise_testauth/enterprise_testauth.go
@@ -122,7 +122,11 @@ func CreateRandomGroups(t *testing.T, env environment.Env) []*tables.User {
 func CreateRandomUser(t *testing.T, env environment.Env, domain string) *tables.User {
 	udb := env.GetUserDB()
 	tu := randomUser(t, domain)
-	err := udb.InsertUser(context.Background(), tu)
+	ctx := context.Background()
+	err := udb.InsertUser(ctx, tu)
+	require.NoError(t, err)
+	// Refresh user to pick up default group.
+	tu, err = udb.GetUserByID(ctx, tu.UserID)
 	require.NoError(t, err)
 	return tu
 }

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -387,6 +387,14 @@ proto_library(
 )
 
 proto_library(
+    name = "iprules_proto",
+    srcs = ["iprules.proto"],
+    deps = [
+        ":context_proto",
+    ],
+)
+
+proto_library(
     name = "user_proto",
     srcs = ["user.proto"],
     exports = [":user_id_proto"],
@@ -957,6 +965,15 @@ go_proto_library(
 )
 
 go_proto_library(
+    name = "iprules_go_proto",
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/iprules",
+    proto = ":iprules_proto",
+    deps = [
+        ":context_go_proto",
+    ],
+)
+
+go_proto_library(
     name = "raft_service_go_proto",
     compilers = ["@io_bazel_rules_go//proto:go_grpc"],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/raft_service",
@@ -1479,6 +1496,14 @@ ts_proto_library(
     name = "invocation_policy_ts_proto",
     proto = ":invocation_policy_proto",
     deps = [],
+)
+
+ts_proto_library(
+    name = "iprules_ts_proto",
+    proto = ":iprules_proto",
+    deps = [
+        ":context_ts_proto",
+    ],
 )
 
 ts_proto_library(

--- a/proto/iprules.proto
+++ b/proto/iprules.proto
@@ -1,0 +1,56 @@
+syntax = "proto3";
+
+package iprules;
+
+import "proto/context.proto";
+
+message IPRule {
+  string ip_rule_id = 1;
+
+  // Allowed IP range, in CIDR notation (e.g. 1.2.3.0/24)
+  string cidr = 2;
+
+  string description = 3;
+}
+
+message AddRuleRequest {
+  context.RequestContext request_context = 1;
+
+  IPRule rule = 2;
+}
+
+message AddRuleResponse {
+  context.ResponseContext response_context = 1;
+
+  IPRule rule = 2;
+}
+
+message UpdateRuleRequest {
+  context.RequestContext request_context = 1;
+
+  IPRule rule = 2;
+}
+
+message UpdateRuleResponse {
+  context.ResponseContext response_context = 1;
+}
+
+message DeleteRuleRequest {
+  context.RequestContext request_context = 1;
+
+  string ip_rule_id = 2;
+}
+
+message DeleteRuleResponse {
+  context.ResponseContext response_context = 1;
+}
+
+message GetRulesRequest {
+  context.RequestContext request_context = 1;
+}
+
+message GetRulesResponse {
+  context.ResponseContext response_context = 1;
+
+  repeated IPRule ip_rules = 2;
+}

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -159,4 +159,6 @@ type Env interface {
 	SetPromQuerier(interfaces.PromQuerier)
 	GetAuditLogger() interfaces.AuditLogger
 	SetAuditLogger(logger interfaces.AuditLogger)
+	GetIPRulesService() interfaces.IPRulesService
+	SetIPRulesService(interfaces.IPRulesService)
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -105,6 +105,7 @@ type UserInfo interface {
 	HasCapability(akpb.ApiKey_Capability) bool
 	GetUseGroupOwnedExecutors() bool
 	GetCacheEncryptionEnabled() bool
+	GetEnforceIPRules() bool
 }
 
 // Authenticator constants
@@ -339,6 +340,7 @@ type APIKeyGroup interface {
 	GetGroupID() string
 	GetUseGroupOwnedExecutors() bool
 	GetCacheEncryptionEnabled() bool
+	GetEnforceIPRules() bool
 }
 
 type AuthDB interface {
@@ -1200,4 +1202,9 @@ type ConfigSecretProvider interface {
 type AuditLogger interface {
 	Log(ctx context.Context, resource *alpb.ResourceID, action alpb.Action, request proto.Message)
 	GetLogs(ctx context.Context, req *alpb.GetAuditLogsRequest) (*alpb.GetAuditLogsResponse, error)
+}
+
+type IPRulesService interface {
+	CheckGroup(ctx context.Context, groupID string) (bool, error)
+	Check(ctx context.Context) (bool, error)
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1205,6 +1205,11 @@ type AuditLogger interface {
 }
 
 type IPRulesService interface {
-	CheckGroup(ctx context.Context, groupID string) (bool, error)
-	Check(ctx context.Context) (bool, error)
+	// Authorize checks whether the authenticated user in the context is allowed
+	// to access the group identified in the context.
+	Authorize(ctx context.Context) error
+
+	// Authorize checks whether the authenticated user in the context is allowed
+	// to access the specified groupId.
+	AuthorizeGroup(ctx context.Context, groupID string) error
 }

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -110,6 +110,7 @@ type RealEnv struct {
 	singleFlightDeduper              interfaces.SingleFlightDeduper
 	promQuerier                      interfaces.PromQuerier
 	auditLog                         interfaces.AuditLogger
+	ipRulesService                   interfaces.IPRulesService
 }
 
 func NewRealEnv(h interfaces.HealthChecker) *RealEnv {
@@ -625,4 +626,12 @@ func (r *RealEnv) GetAuditLogger() interfaces.AuditLogger {
 }
 func (r *RealEnv) SetAuditLogger(l interfaces.AuditLogger) {
 	r.auditLog = l
+}
+
+func (r *RealEnv) GetIPRulesService() interfaces.IPRulesService {
+	return r.ipRulesService
+}
+
+func (r *RealEnv) SetIPRulesService(e interfaces.IPRulesService) {
+	r.ipRulesService = e
 }

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -229,6 +229,7 @@ type Group struct {
 	UseGroupOwnedExecutors *bool
 
 	CacheEncryptionEnabled bool `gorm:"not null;default:0"`
+	EnforceIPRules         bool `gorm:"not null;default:0"`
 
 	// The SAML IDP Metadata URL for this group.
 	SamlIdpMetadataUrl *string
@@ -727,6 +728,18 @@ func (*EncryptionKeyVersion) TableName() string {
 	return "EncryptionKeyVersions"
 }
 
+type IPRule struct {
+	Model
+	IPRuleID    string `gorm:"primaryKey"`
+	GroupID     string `gorm:"index:ip_rule_group_id_idx"`
+	CIDR        string `gorm:"column:cidr"`
+	Description string
+}
+
+func (*IPRule) TableName() string {
+	return "IPRules"
+}
+
 type PostAutoMigrateLogic func() error
 
 // Manual migration called before auto-migration.
@@ -1212,6 +1225,7 @@ func RegisterTables() {
 	registerTable("GR", &Group{})
 	registerTable("IE", &InvocationExecution{})
 	registerTable("IN", &Invocation{})
+	registerTable("IR", &IPRule{})
 	registerTable("QB", &QuotaBucket{})
 	registerTable("QG", &QuotaGroup{})
 	registerTable("RE", &GitRepository{})

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -51,6 +51,7 @@ type TestUser struct {
 	Capabilities           []akpb.ApiKey_Capability      `json:"capabilities"`
 	UseGroupOwnedExecutors bool                          `json:"use_group_owned_executors,omitempty"`
 	CacheEncryptionEnabled bool                          `json:"cache_encryption_enabled,omitempty"`
+	EnforceIPRules         bool                          `json:"enforce_ip_rules,omitempty"`
 }
 
 func (c *TestUser) GetAPIKeyID() string                                { return "" }
@@ -73,6 +74,9 @@ func (c *TestUser) GetUseGroupOwnedExecutors() bool {
 }
 func (c *TestUser) GetCacheEncryptionEnabled() bool {
 	return c.CacheEncryptionEnabled
+}
+func (c *TestUser) GetEnforceIPRules() bool {
+	return c.EnforceIPRules
 }
 func (c *TestUser) IsImpersonating() bool {
 	return false

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -48,6 +48,7 @@ type Claims struct {
 	Capabilities           []akpb.ApiKey_Capability      `json:"capabilities"`
 	UseGroupOwnedExecutors bool                          `json:"use_group_owned_executors,omitempty"`
 	CacheEncryptionEnabled bool                          `json:"cache_encryption_enabled,omitempty"`
+	EnforceIPRules         bool                          `json:"enforce_ip_rules,omitempty"`
 }
 
 func (c *Claims) GetAPIKeyID() string {
@@ -104,6 +105,10 @@ func (c *Claims) GetCacheEncryptionEnabled() bool {
 	return c.CacheEncryptionEnabled
 }
 
+func (c *Claims) GetEnforceIPRules() bool {
+	return c.EnforceIPRules
+}
+
 func ParseClaims(token string) (*Claims, error) {
 	claims := &Claims{}
 	_, err := jwt.ParseWithClaims(token, claims, jwtKeyFunc)
@@ -126,6 +131,7 @@ func APIKeyGroupClaims(akg interfaces.APIKeyGroup) *Claims {
 		Capabilities:           capabilities.FromInt(akg.GetCapabilities()),
 		UseGroupOwnedExecutors: akg.GetUseGroupOwnedExecutors(),
 		CacheEncryptionEnabled: akg.GetCacheEncryptionEnabled(),
+		EnforceIPRules:         akg.GetEnforceIPRules(),
 	}
 }
 
@@ -175,6 +181,7 @@ func userClaims(u *tables.User, effectiveGroup string) *Claims {
 	allowedGroups := make([]string, 0, len(u.Groups))
 	groupMemberships := make([]*interfaces.GroupMembership, 0, len(u.Groups))
 	cacheEncryptionEnabled := false
+	enforceIPRules := false
 	for _, g := range u.Groups {
 		allowedGroups = append(allowedGroups, g.Group.GroupID)
 		groupMemberships = append(groupMemberships, &interfaces.GroupMembership{
@@ -183,6 +190,7 @@ func userClaims(u *tables.User, effectiveGroup string) *Claims {
 		})
 		if g.Group.GroupID == effectiveGroup {
 			cacheEncryptionEnabled = g.Group.CacheEncryptionEnabled
+			enforceIPRules = g.Group.EnforceIPRules
 		}
 	}
 	return &Claims{
@@ -191,6 +199,7 @@ func userClaims(u *tables.User, effectiveGroup string) *Claims {
 		AllowedGroups:          allowedGroups,
 		GroupID:                effectiveGroup,
 		CacheEncryptionEnabled: cacheEncryptionEnabled,
+		EnforceIPRules:         enforceIPRules,
 	}
 }
 


### PR DESCRIPTION
There's a new group-level settings that determines whether IP rules are applied.

Currently, IP rules are a simple unordered list of allowed IP ranges.

IP rules are cached to avoid having to load them for every request.

Next PR hooks up the service for enforcement.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
