### PR TITLE
Revert "Upgrade bb toolchain to get `dockerNetwork=off`"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -356,9 +356,9 @@ dockerfile_image(
 
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    sha256 = "1cab6ef3ae9b4211ab9d57826edd4bbc34e5b9e5cb1927c97f0788d8e7ad0442",
-    strip_prefix = "buildbuddy-toolchain-b043878a82f266fd78369b794a105b57dc0b2600",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/b043878a82f266fd78369b794a105b57dc0b2600.tar.gz"],
+    sha256 = "e899f235b36cb901b678bd6f55c1229df23fcbc7921ac7a3585d29bff2bf9cfd",
+    strip_prefix = "buildbuddy-toolchain-fd351ca8f152d66fc97f9d98009e0ae000854e8f",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/fd351ca8f152d66fc97f9d98009e0ae000854e8f.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")

--- a/cli/test/integration/cli/BUILD
+++ b/cli/test/integration/cli/BUILD
@@ -3,10 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "cli_test",
     srcs = ["cli_test.go"],
-    exec_properties = {
-        # TODO: remove network dependency.
-        "dockerNetwork": "bridge",
-    },
     shard_count = 4,
     deps = [
         "//cli/log",

--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -16,10 +16,6 @@ go_test(
     # exec_properties = {
     #     "container-image": "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.3.0",
     # },
-    exec_properties = {
-        # TODO: remove network dependency.
-        "dockerNetwork": "bridge",
-    },
     shard_count = 12,
     deps = [
         "//proto:eventlog_go_proto",

--- a/enterprise/server/test/integration/workflow/BUILD
+++ b/enterprise/server/test/integration/workflow/BUILD
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "workflow_test",
+    size = "small",
     srcs = ["workflow_test.go"],
     # ci_runner gets invoked directly by this test since the RBE test framework
     # currently does not support dockerized execution of commands. So for now we
@@ -11,10 +12,6 @@ go_test(
     # exec_properties = {
     #     "container-image": "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.3.0",
     # },
-    exec_properties = {
-        # TODO: remove network dependency.
-        "dockerNetwork": "bridge",
-    },
     shard_count = 2,
     deps = [
         "//enterprise/server/invocation_search_service",


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#4735

It might breaker the server/testutil/webtester/webtester.go

https://app.buildbuddy.io/invocation/e629172c-a4dc-4ff1-b0a0-8928771b16ac