### PR TITLE
add cache name label to pebble cache metrics

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2855,7 +2855,11 @@ func (e *partitionEvictor) sampleGroup() {
 		log.Warningf("could not sample group in partition %q: %s", e.part.ID, err)
 		return
 	}
-	metrics.PebbleCacheGroupIDSampleCount.With(prometheus.Labels{metrics.GroupID: groupID}).Inc()
+	metricLbls := prometheus.Labels{
+		metrics.GroupID:        groupID,
+		metrics.CacheNameLabel: e.cacheName,
+	}
+	metrics.PebbleCacheGroupIDSampleCount.With(metricLbls).Inc()
 }
 
 func (e *partitionEvictor) sample(ctx context.Context, k int) ([]*approxlru.Sample[*evictionKey], error) {
@@ -3179,7 +3183,10 @@ func (p *PebbleCache) updatePebbleMetrics() error {
 
 	// Compaction related metrics.
 	incCompactionMetric := func(compactionType string, oldValue, newValue int64) {
-		lbls := prometheus.Labels{metrics.CompactionType: compactionType}
+		lbls := prometheus.Labels{
+			metrics.CompactionType: compactionType,
+			metrics.CacheNameLabel: p.name,
+		}
 		metrics.PebbleCachePebbleCompactCount.With(lbls).Add(float64(newValue - oldValue))
 	}
 	incCompactionMetric("default", om.Compact.DefaultCount, m.Compact.DefaultCount)
@@ -3188,15 +3195,22 @@ func (p *PebbleCache) updatePebbleMetrics() error {
 	incCompactionMetric("move", om.Compact.MoveCount, m.Compact.MoveCount)
 	incCompactionMetric("read", om.Compact.ReadCount, m.Compact.ReadCount)
 	incCompactionMetric("rewrite", om.Compact.RewriteCount, m.Compact.RewriteCount)
-	metrics.PebbleCachePebbleCompactEstimatedDebtBytes.Set(float64(m.Compact.EstimatedDebt))
-	metrics.PebbleCachePebbleCompactInProgressBytes.Set(float64(m.Compact.InProgressBytes))
-	metrics.PebbleCachePebbleCompactInProgress.Set(float64(m.Compact.NumInProgress))
-	metrics.PebbleCachePebbleCompactMarkedFiles.Set(float64(m.Compact.MarkedFiles))
+
+	nameLabel := prometheus.Labels{
+		metrics.CacheNameLabel: p.name,
+	}
+	metrics.PebbleCachePebbleCompactEstimatedDebtBytes.With(nameLabel).Set(float64(m.Compact.EstimatedDebt))
+	metrics.PebbleCachePebbleCompactInProgressBytes.With(nameLabel).Set(float64(m.Compact.InProgressBytes))
+	metrics.PebbleCachePebbleCompactInProgress.With(nameLabel).Set(float64(m.Compact.NumInProgress))
+	metrics.PebbleCachePebbleCompactMarkedFiles.With(nameLabel).Set(float64(m.Compact.MarkedFiles))
 
 	// Level metrics.
 	for i, l := range m.Levels {
 		ol := om.Levels[i]
-		lbls := prometheus.Labels{metrics.PebbleLevel: strconv.Itoa(i)}
+		lbls := prometheus.Labels{
+			metrics.PebbleLevel:    strconv.Itoa(i),
+			metrics.CacheNameLabel: p.name,
+		}
 		metrics.PebbleCachePebbleLevelSublevels.With(lbls).Set(float64(l.Sublevels))
 		metrics.PebbleCachePebbleLevelNumFiles.With(lbls).Set(float64(l.NumFiles))
 		metrics.PebbleCachePebbleLevelSizeBytes.With(lbls).Set(float64(l.Size))
@@ -3214,7 +3228,7 @@ func (p *PebbleCache) updatePebbleMetrics() error {
 	}
 
 	// Block cache metrics.
-	metrics.PebbleCachePebbleBlockCacheSizeBytes.Set(float64(m.BlockCache.Size))
+	metrics.PebbleCachePebbleBlockCacheSizeBytes.With(nameLabel).Set(float64(m.BlockCache.Size))
 
 	p.oldMetrics = *m
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -2031,34 +2031,43 @@ var (
 		Help:      "Number of compactions performed by the underlying Pebble database.",
 	}, []string{
 		CompactionType,
+		CacheNameLabel,
 	})
 
-	PebbleCachePebbleCompactEstimatedDebtBytes = promauto.NewGauge(prometheus.GaugeOpts{
+	PebbleCachePebbleCompactEstimatedDebtBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",
 		Name:      "pebble_cache_pebble_compact_estimated_debt_bytes",
 		Help:      "Estimated number of bytes that need to be compacted for the LMS to reach a stable state.",
+	}, []string{
+		CacheNameLabel,
 	})
 
-	PebbleCachePebbleCompactInProgressBytes = promauto.NewGauge(prometheus.GaugeOpts{
+	PebbleCachePebbleCompactInProgressBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",
 		Name:      "pebble_cache_pebble_compact_in_progress_bytes",
 		Help:      "Number of bytes present in sstables being written by in-progress compactions.",
+	}, []string{
+		CacheNameLabel,
 	})
 
-	PebbleCachePebbleCompactInProgress = promauto.NewGauge(prometheus.GaugeOpts{
+	PebbleCachePebbleCompactInProgress = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",
 		Name:      "pebble_cache_pebble_compact_in_progress",
 		Help:      "Number of compactions that are in-progress",
+	}, []string{
+		CacheNameLabel,
 	})
 
-	PebbleCachePebbleCompactMarkedFiles = promauto.NewGauge(prometheus.GaugeOpts{
+	PebbleCachePebbleCompactMarkedFiles = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",
 		Name:      "pebble_cache_pebble_compact_marked_files",
 		Help:      "Count of files that are marked for compaction.",
+	}, []string{
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleLevelSublevels = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -2068,6 +2077,7 @@ var (
 		Help:      "Number of sublevels within the level.",
 	}, []string{
 		PebbleLevel,
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleLevelNumFiles = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -2077,6 +2087,7 @@ var (
 		Help:      "The total number of files in the level.",
 	}, []string{
 		PebbleLevel,
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleLevelSizeBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -2086,6 +2097,7 @@ var (
 		Help:      "The total size in bytes of the files in the level.",
 	}, []string{
 		PebbleLevel,
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleLevelScore = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -2095,6 +2107,7 @@ var (
 		Help:      "The level's compaction score.",
 	}, []string{
 		PebbleLevel,
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleLevelBytesInCount = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -2104,6 +2117,7 @@ var (
 		Help:      "The number of incoming bytes from other levels read during compactions. This excludes bytes moved and bytes ingested. For L0 this is the bytes written to the WAL.",
 	}, []string{
 		PebbleLevel,
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleLevelBytesIngestedCount = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -2113,6 +2127,7 @@ var (
 		Help:      "The number of bytes ingested.",
 	}, []string{
 		PebbleLevel,
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleLevelBytesMovedCount = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -2122,6 +2137,7 @@ var (
 		Help:      "The number of bytes moved into the level by a move compaction.",
 	}, []string{
 		PebbleLevel,
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleLevelBytesReadCount = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -2131,6 +2147,7 @@ var (
 		Help:      "The number of bytes read for compactions at the level. This includes bytes read from other levels (BytesIn), as well as bytes read for the level.",
 	}, []string{
 		PebbleLevel,
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleLevelBytesCompactedCount = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -2140,6 +2157,7 @@ var (
 		Help:      "The number of bytes written during compactions.",
 	}, []string{
 		PebbleLevel,
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleLevelBytesFlushedCount = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -2149,6 +2167,7 @@ var (
 		Help:      "The number of bytes written during flushes.",
 	}, []string{
 		PebbleLevel,
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleLevelTablesCompactedCount = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -2158,6 +2177,7 @@ var (
 		Help:      "The number of sstables compacted to this level.",
 	}, []string{
 		PebbleLevel,
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleLevelTablesFlushedCount = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -2167,6 +2187,7 @@ var (
 		Help:      "The number of sstables flushed to this level.",
 	}, []string{
 		PebbleLevel,
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleLevelTablesIngestedCount = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -2176,6 +2197,7 @@ var (
 		Help:      "The number of sstables ingested into this level.",
 	}, []string{
 		PebbleLevel,
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleLevelTablesMovedCount = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -2185,6 +2207,7 @@ var (
 		Help:      "The number of sstables ingested into to this level.",
 	}, []string{
 		PebbleLevel,
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleOpCount = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -2194,6 +2217,7 @@ var (
 		Help:      "The number of operations performed against the pebble database.",
 	}, []string{
 		PebbleOperation,
+		CacheNameLabel,
 	})
 
 	PebbleCachePebbleOpLatencyUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
@@ -2204,14 +2228,17 @@ var (
 		Help:      "The latency of operations performed against the pebble database, in microseconds.",
 	}, []string{
 		PebbleOperation,
+		CacheNameLabel,
 	})
 
 	// Total size of cache that pebble allocate mamually from system memory using malloc.
-	PebbleCachePebbleBlockCacheSizeBytes = promauto.NewGauge(prometheus.GaugeOpts{
+	PebbleCachePebbleBlockCacheSizeBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",
 		Name:      "pebble_cache_pebble_block_cache_size_bytes",
 		Help:      "The total size in pebble's block cache.",
+	}, []string{
+		CacheNameLabel,
 	})
 
 	// Temporary metric to verify AC sampling behavior.
@@ -2222,6 +2249,7 @@ var (
 		Help:      "The number of times a group has been selected for key sampling.",
 	}, []string{
 		GroupID,
+		CacheNameLabel,
 	})
 
 	// ## Podman metrics

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -2217,7 +2217,6 @@ var (
 		Help:      "The number of operations performed against the pebble database.",
 	}, []string{
 		PebbleOperation,
-		CacheNameLabel,
 	})
 
 	PebbleCachePebbleOpLatencyUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
@@ -2228,7 +2227,6 @@ var (
 		Help:      "The latency of operations performed against the pebble database, in microseconds.",
 	}, []string{
 		PebbleOperation,
-		CacheNameLabel,
 	})
 
 	// Total size of cache that pebble allocate mamually from system memory using malloc.


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
When we turn on migration cache, we want to be able to seperate metrics from src
and dest pebble cache.
