### PR TITLE
Save last CLI flag value under buildbuddy subdir

### DIFF
--- a/cli/ask/ask.go
+++ b/cli/ask/ask.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
@@ -137,11 +138,15 @@ func getPreviousFlagPath(flagName string) string {
 	if err != nil {
 		return ""
 	}
-	dir, err := os.UserCacheDir()
+	cacheDir, err := storage.CacheDir()
 	if err != nil {
 		return ""
 	}
-	return dir + "/last_bb_" + flagName + "-" + hash.String(workspaceDir) + ".txt"
+	flagsDir := filepath.Join(cacheDir, "last_flag_values", hash.String(workspaceDir))
+	if err := os.MkdirAll(flagsDir, 0755); err != nil {
+		return ""
+	}
+	return filepath.Join(flagsDir, flagName+".txt")
 }
 
 func getPreviousFlag(flag string) (string, error) {


### PR DESCRIPTION
Changes the flag location from

```
~/.cache/last_bb_{name}_{workspaceHash}.txt
```

to

```
~/.cache/buildbuddy/last_flag_values/{workspaceHash}/{name}.txt
```

this makes it easier to clear the CLI cache - just `rm -rf ~/.cache/buildbuddy`

**Related issues**: N/A
