### PR TITLE
Remove private image workflow

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -267,20 +267,6 @@ platform(
     },
 )
 
-# TODO(#2523): remove this once 403 errors pulling private images with
-# streaming are resolved.
-platform(
-    name = "private_workflow_image",
-    constraint_values = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:linux",
-    ],
-    exec_properties = {
-        "OSFamily": "Linux",
-        "container-image": "docker://gcr.io/flame-private/rbe-ubuntu20-04-workflows:latest",
-    },
-)
-
 # TODO(bduffany): The sh_toolchain config here is a workaround for
 # https://github.com/aspect-build/rules_swc/issues/20
 # We should probably either move these to the buildbuddy-toolchain repo

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -78,16 +78,6 @@ actions:
           - "*"
     bazel_commands:
       - test //... --config=linux-workflows --test_tag_filters=+bare --build_tag_filters=+bare
-  - name: Private Image Tests
-    triggers:
-      push:
-        branches:
-          - "master"
-      pull_request:
-        branches:
-          - "*"
-    bazel_commands:
-      - test //... --config=linux-workflows --host_platform=//:private_workflow_image --remote_exec_header=x-buildbuddy-platform.container-registry-username=_json_key --remote_exec_header=x-buildbuddy-platform.container-registry-password='${GCR_FLAME_PRIVATE_PASSWORD}'
 
 plugins:
   - path: cli/plugins/go-deps


### PR DESCRIPTION
Have seen a 4xx error in a little bit. Will re-add if it crops up again.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/2357