### PR TITLE
Close the reader that passed into compression.NewZstdxxxxxReader(..)

### DIFF
--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -140,7 +140,7 @@ func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_Re
 
 		// Counter for the number of bytes from the original reader containing decompressed bytes
 		counter = &ioutil.Counter{}
-		reader, err = compression.NewZstdCompressingReader(io.TeeReader(reader, counter), rbuf[:bufSize], cbuf[:bufSize])
+		reader, err = compression.NewZstdCompressingReader(io.NopCloser(io.TeeReader(reader, counter)), rbuf[:bufSize], cbuf[:bufSize])
 		if err != nil {
 			return status.InternalErrorf("Failed to compress blob: %s", err)
 		}

--- a/server/util/compression/compression_test.go
+++ b/server/util/compression/compression_test.go
@@ -12,7 +12,7 @@ func Test_NewZstdDecompressingReader(t *testing.T) {
 	blob := "AAAAAAAAAAAAA"
 	compressedBlob := CompressZstd(nil, []byte(blob))
 	compressedReader := strings.NewReader(string(compressedBlob))
-	decompressedReader, err := NewZstdDecompressingReader(compressedReader)
+	decompressedReader, err := NewZstdDecompressingReader(io.NopCloser(compressedReader))
 	require.NoError(t, err)
 
 	b, err := io.ReadAll(decompressedReader)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Change the input arguments to io.ReadCloser, and return a wrappedReader that
contains the PipeReader and also the inputReader. When we close the returned
reader, we close both the pipe reader and also the input reader.
