### PR TITLE
use timestamps instead of strings in trends fe code

### DIFF
--- a/enterprise/app/trends/BUILD
+++ b/enterprise/app/trends/BUILD
@@ -22,8 +22,10 @@ ts_library(
         "//enterprise/app/trends:summary_card",
         "//enterprise/app/trends:trends_chart",
         "//proto:stats_ts_proto",
+        "@npm//@types/d3-time",
         "@npm//@types/moment",
         "@npm//@types/react",
+        "@npm//d3-time",
         "@npm//moment",
         "@npm//react",
         "@npm//rxjs",
@@ -82,8 +84,8 @@ ts_library(
     deps = [
         "//app/util:proto",
         "//proto:stats_ts_proto",
-        "@npm//@types/moment",
-        "@npm//moment",
+        "@npm//@types/d3-time",
+        "@npm//d3-time",
     ],
 )
 

--- a/enterprise/app/trends/BUILD
+++ b/enterprise/app/trends/BUILD
@@ -22,7 +22,6 @@ ts_library(
         "//enterprise/app/trends:summary_card",
         "//enterprise/app/trends:trends_chart",
         "//proto:stats_ts_proto",
-        "@npm//@types/d3-time",
         "@npm//@types/moment",
         "@npm//@types/react",
         "@npm//d3-time",
@@ -84,7 +83,6 @@ ts_library(
     deps = [
         "//app/util:proto",
         "//proto:stats_ts_proto",
-        "@npm//@types/d3-time",
         "@npm//d3-time",
     ],
 )

--- a/enterprise/app/trends/BUILD
+++ b/enterprise/app/trends/BUILD
@@ -22,6 +22,7 @@ ts_library(
         "//enterprise/app/trends:summary_card",
         "//enterprise/app/trends:trends_chart",
         "//proto:stats_ts_proto",
+        "@npm//@types/d3-time",
         "@npm//@types/moment",
         "@npm//@types/react",
         "@npm//d3-time",
@@ -83,6 +84,7 @@ ts_library(
     deps = [
         "//app/util:proto",
         "//proto:stats_ts_proto",
+        "@npm//@types/d3-time",
         "@npm//d3-time",
     ],
 )

--- a/enterprise/app/trends/cache_chart.tsx
+++ b/enterprise/app/trends/cache_chart.tsx
@@ -16,19 +16,20 @@ import * as format from "../../../app/format/format";
 interface Props {
   title: string;
   id?: string;
-  data: any[];
+  data: number[];
+  ticks?: number[];
   secondaryBarName: string;
-  extractLabel: (datum: any) => string;
-  formatHoverLabel: (datum: any) => string;
-  extractHits: (datum: any) => number;
-  extractSecondary: (datum: any) => number;
+  extractLabel: (datum: number) => string;
+  formatHoverLabel: (datum: number) => string;
+  extractHits: (datum: number) => number;
+  extractSecondary: (datum: number) => number;
 }
 
 interface CacheChartTooltipProps extends TooltipProps<any, any> {
-  labelFormatter: (datum: any) => string;
-  extractHits: (datum: any) => number;
+  labelFormatter: (datum: number) => string;
+  extractHits: (datum: number) => number;
   secondaryBarName: string;
-  extractSecondary: (datum: any) => number;
+  extractSecondary: (datum: number) => number;
 }
 
 const CacheChartTooltip = ({
@@ -68,7 +69,7 @@ export default class CacheChartComponent extends React.Component<Props> {
           <ComposedChart data={this.props.data}>
             <CartesianGrid strokeDasharray="3 3" />
             <Legend />
-            <XAxis dataKey={this.props.extractLabel} />
+            <XAxis dataKey={(v) => v} tickFormatter={this.props.extractLabel} ticks={this.props.ticks} />
             <YAxis yAxisId="hits" tickFormatter={format.count} allowDecimals={false} />
             <YAxis
               domain={[0, 100]}

--- a/enterprise/app/trends/cache_chart.tsx
+++ b/enterprise/app/trends/cache_chart.tsx
@@ -17,7 +17,6 @@ interface Props {
   title: string;
   id?: string;
   data: number[];
-  ticks?: number[];
   secondaryBarName: string;
   extractLabel: (datum: number) => string;
   formatHoverLabel: (datum: number) => string;
@@ -69,7 +68,7 @@ export default class CacheChartComponent extends React.Component<Props> {
           <ComposedChart data={this.props.data}>
             <CartesianGrid strokeDasharray="3 3" />
             <Legend />
-            <XAxis dataKey={(v) => v} tickFormatter={this.props.extractLabel} ticks={this.props.ticks} />
+            <XAxis dataKey={(v) => v} tickFormatter={this.props.extractLabel} ticks={this.props.data} />
             <YAxis yAxisId="hits" tickFormatter={format.count} allowDecimals={false} />
             <YAxis
               domain={[0, 100]}

--- a/enterprise/app/trends/percentile_chart.tsx
+++ b/enterprise/app/trends/percentile_chart.tsx
@@ -16,19 +16,19 @@ import {
 export interface PercentilesChartProps {
   title: string;
   id?: string;
-  data: string[];
-  extractLabel: (datum: string) => string;
-  formatHoverLabel: (datum: string) => string;
-  extractP50: (datum: string) => number;
-  extractP75: (datum: string) => number;
-  extractP90: (datum: string) => number;
-  extractP95: (datum: string) => number;
-  extractP99: (datum: string) => number;
-  onColumnClicked?: (datum: string) => void;
+  data: number[];
+  extractLabel: (datum: number) => string;
+  formatHoverLabel: (datum: number) => string;
+  extractP50: (datum: number) => number;
+  extractP75: (datum: number) => number;
+  extractP90: (datum: number) => number;
+  extractP95: (datum: number) => number;
+  extractP99: (datum: number) => number;
+  onColumnClicked?: (datum: number) => void;
 }
 
 export default class PercentilesChartComponent extends React.Component<PercentilesChartProps> {
-  private lastDataFromHover: string = "";
+  private lastDataFromHover?: number;
 
   handleRowClick() {
     if (!this.props.onColumnClicked || !this.lastDataFromHover) {
@@ -48,7 +48,7 @@ export default class PercentilesChartComponent extends React.Component<Percentil
             onClick={this.handleRowClick.bind(this)}>
             <CartesianGrid strokeDasharray="3 3" />
             <Legend />
-            <XAxis dataKey={this.props.extractLabel} />
+            <XAxis dataKey={(v) => v} tickFormatter={this.props.extractLabel} ticks={this.props.data} />
             <YAxis yAxisId="duration" tickFormatter={format.durationSec} allowDecimals={false} width={84} />
             <Tooltip
               content={
@@ -106,13 +106,13 @@ export default class PercentilesChartComponent extends React.Component<Percentil
 }
 
 interface PercentilesChartTooltipProps extends TooltipProps<any, any> {
-  labelFormatter: (datum: string) => string;
-  extractP50: (datum: string) => number;
-  extractP75: (datum: string) => number;
-  extractP90: (datum: string) => number;
-  extractP95: (datum: string) => number;
-  extractP99: (datum: string) => number;
-  triggerCallback: (datum: string) => void;
+  labelFormatter: (datum: number) => string;
+  extractP50: (datum: number) => number;
+  extractP75: (datum: number) => number;
+  extractP90: (datum: number) => number;
+  extractP95: (datum: number) => number;
+  extractP99: (datum: number) => number;
+  triggerCallback: (datum: number) => void;
 }
 
 class PercentilesChartTooltip extends React.Component<PercentilesChartTooltipProps> {

--- a/enterprise/app/trends/simple_trends_tab.tsx
+++ b/enterprise/app/trends/simple_trends_tab.tsx
@@ -65,7 +65,8 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
     return moment(tsMillis).format("MMM D");
   }
 
-  onBarClicked(hash: string, sortBy: string, date: number) {
+  onBarClicked(hash: string, sortBy: string, tsMillis: number) {
+    const date = new Date(tsMillis).toISOString().split("T")[0];
     router.navigateTo("/?start=" + date + "&end=" + date + "&sort-by=" + sortBy + hash);
   }
 

--- a/enterprise/app/trends/simple_trends_tab.tsx
+++ b/enterprise/app/trends/simple_trends_tab.tsx
@@ -57,15 +57,15 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
     );
   }
 
-  formatLongDate(date: any) {
-    return moment(date).format("dddd, MMMM Do YYYY");
+  formatLongDate(tsMillis: number) {
+    return moment(tsMillis).format("dddd, MMMM Do YYYY");
   }
 
-  formatShortDate(date: any) {
-    return moment(date).format("MMM D");
+  formatShortDate(tsMillis: number) {
+    return moment(tsMillis).format("MMM D");
   }
 
-  onBarClicked(hash: string, sortBy: string, date: string) {
+  onBarClicked(hash: string, sortBy: string, date: number) {
     router.navigateTo("/?start=" + date + "&end=" + date + "&sort-by=" + sortBy + hash);
   }
 
@@ -89,10 +89,10 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
         <TrendsChartComponent
           title="Builds"
           id="builds"
-          data={model.getDates()}
-          extractValue={(date) => +(model.getStat(date).totalNumBuilds ?? 0)}
-          extractSecondaryValue={(date) => {
-            let stat = model.getStat(date);
+          data={model.getTimeKeys()}
+          extractValue={(tsMillis) => +(model.getStat(tsMillis).totalNumBuilds ?? 0)}
+          extractSecondaryValue={(tsMillis) => {
+            let stat = model.getStat(tsMillis);
             return (+(stat.totalBuildTimeUsec ?? 0) * SECONDS_PER_MICROSECOND) / +(stat.completedInvocationCount ?? 0);
           }}
           extractLabel={this.formatShortDate}
@@ -112,14 +112,14 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
           <PercentilesChartComponent
             title="Build duration"
             id="duration"
-            data={model.getDates()}
+            data={model.getTimeKeys()}
             extractLabel={this.formatShortDate}
             formatHoverLabel={this.formatLongDate}
-            extractP50={(date) => +(model.getStat(date).buildTimeUsecP50 ?? 0) * SECONDS_PER_MICROSECOND}
-            extractP75={(date) => +(model.getStat(date).buildTimeUsecP75 ?? 0) * SECONDS_PER_MICROSECOND}
-            extractP90={(date) => +(model.getStat(date).buildTimeUsecP90 ?? 0) * SECONDS_PER_MICROSECOND}
-            extractP95={(date) => +(model.getStat(date).buildTimeUsecP95 ?? 0) * SECONDS_PER_MICROSECOND}
-            extractP99={(date) => +(model.getStat(date).buildTimeUsecP99 ?? 0) * SECONDS_PER_MICROSECOND}
+            extractP50={(tsMillis) => +(model.getStat(tsMillis).buildTimeUsecP50 ?? 0) * SECONDS_PER_MICROSECOND}
+            extractP75={(tsMillis) => +(model.getStat(tsMillis).buildTimeUsecP75 ?? 0) * SECONDS_PER_MICROSECOND}
+            extractP90={(tsMillis) => +(model.getStat(tsMillis).buildTimeUsecP90 ?? 0) * SECONDS_PER_MICROSECOND}
+            extractP95={(tsMillis) => +(model.getStat(tsMillis).buildTimeUsecP95 ?? 0) * SECONDS_PER_MICROSECOND}
+            extractP99={(tsMillis) => +(model.getStat(tsMillis).buildTimeUsecP99 ?? 0) * SECONDS_PER_MICROSECOND}
             onColumnClicked={this.onBarClicked.bind(this, "", "duration")}
           />
         )}
@@ -127,12 +127,12 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
           <TrendsChartComponent
             title="Build duration"
             id="duration"
-            data={model.getDates()}
-            extractValue={(date) => {
-              let stat = model.getStat(date);
+            data={model.getTimeKeys()}
+            extractValue={(tsMillis) => {
+              let stat = model.getStat(tsMillis);
               return +(stat.totalBuildTimeUsec ?? 0) / +(stat.completedInvocationCount ?? 0) / 1000000;
             }}
-            extractSecondaryValue={(date) => +(model.getStat(date).maxDurationUsec ?? 0) / 1000000}
+            extractSecondaryValue={(tsMillis) => +(model.getStat(tsMillis).maxDurationUsec ?? 0) / 1000000}
             extractLabel={this.formatShortDate}
             formatTickValue={format.durationSec}
             formatHoverLabel={this.formatLongDate}
@@ -147,8 +147,8 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
 
         <TrendsChartComponent
           title="Users with builds"
-          data={model.getDates()}
-          extractValue={(date) => +(model.getStat(date).userCount ?? 0)}
+          data={model.getTimeKeys()}
+          extractValue={(tsMillis) => +(model.getStat(tsMillis).userCount ?? 0)}
           extractLabel={this.formatShortDate}
           formatTickValue={format.count}
           allowDecimals={false}
@@ -159,8 +159,8 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
         />
         <TrendsChartComponent
           title="Commits with builds"
-          data={model.getDates()}
-          extractValue={(date) => +(model.getStat(date).commitCount ?? 0)}
+          data={model.getTimeKeys()}
+          extractValue={(tsMillis) => +(model.getStat(tsMillis).commitCount ?? 0)}
           extractLabel={this.formatShortDate}
           formatTickValue={format.count}
           allowDecimals={false}
@@ -171,8 +171,8 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
         />
         <TrendsChartComponent
           title="Branches with builds"
-          data={model.getDates()}
-          extractValue={(date) => +(model.getStat(date).branchCount ?? 0)}
+          data={model.getTimeKeys()}
+          extractValue={(tsMillis) => +(model.getStat(tsMillis).branchCount ?? 0)}
           extractLabel={this.formatShortDate}
           formatTickValue={format.count}
           allowDecimals={false}
@@ -182,8 +182,8 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
         />
         <TrendsChartComponent
           title="Hosts with builds"
-          data={model.getDates()}
-          extractValue={(date) => +(model.getStat(date).hostCount ?? 0)}
+          data={model.getTimeKeys()}
+          extractValue={(tsMillis) => +(model.getStat(tsMillis).hostCount ?? 0)}
           extractLabel={this.formatShortDate}
           formatTickValue={format.count}
           allowDecimals={false}
@@ -194,8 +194,8 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
         />
         <TrendsChartComponent
           title="Repos with builds"
-          data={model.getDates()}
-          extractValue={(date) => +(model.getStat(date).repoCount ?? 0)}
+          data={model.getTimeKeys()}
+          extractValue={(tsMillis) => +(model.getStat(tsMillis).repoCount ?? 0)}
           extractLabel={this.formatShortDate}
           formatTickValue={format.count}
           allowDecimals={false}
@@ -214,29 +214,29 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
         <CacheChartComponent
           title="Action Cache"
           id="cache"
-          data={model.getDates()}
+          data={model.getTimeKeys()}
           extractLabel={this.formatShortDate}
           formatHoverLabel={this.formatLongDate}
-          extractHits={(date) => +(model.getStat(date).actionCacheHits ?? 0)}
+          extractHits={(tsMillis) => +(model.getStat(tsMillis).actionCacheHits ?? 0)}
           secondaryBarName="misses"
-          extractSecondary={(date) => +(model.getStat(date).actionCacheMisses ?? 0)}
+          extractSecondary={(tsMillis) => +(model.getStat(tsMillis).actionCacheMisses ?? 0)}
         />
         <CacheChartComponent
           title="Content Addressable Store"
-          data={model.getDates()}
+          data={model.getTimeKeys()}
           extractLabel={this.formatShortDate}
           formatHoverLabel={this.formatLongDate}
-          extractHits={(date) => +(model.getStat(date).casCacheHits ?? 0)}
+          extractHits={(tsMillis) => +(model.getStat(tsMillis).casCacheHits ?? 0)}
           secondaryBarName="writes"
-          extractSecondary={(date) => +(model.getStat(date).casCacheUploads ?? 0)}
+          extractSecondary={(tsMillis) => +(model.getStat(tsMillis).casCacheUploads ?? 0)}
         />
         <TrendsChartComponent
           title="Cache read throughput"
-          data={model.getDates()}
-          extractValue={(date) => +(model.getStat(date).totalDownloadSizeBytes ?? 0)}
-          extractSecondaryValue={(date) =>
-            (+(model.getStat(date).totalDownloadSizeBytes ?? 0) * BITS_PER_BYTE) /
-            (+(model.getStat(date).totalDownloadUsec ?? 0) * SECONDS_PER_MICROSECOND)
+          data={model.getTimeKeys()}
+          extractValue={(tsMillis) => +(model.getStat(tsMillis).totalDownloadSizeBytes ?? 0)}
+          extractSecondaryValue={(tsMillis) =>
+            (+(model.getStat(tsMillis).totalDownloadSizeBytes ?? 0) * BITS_PER_BYTE) /
+            (+(model.getStat(tsMillis).totalDownloadUsec ?? 0) * SECONDS_PER_MICROSECOND)
           }
           extractLabel={this.formatShortDate}
           formatTickValue={format.bytes}
@@ -253,11 +253,11 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
 
         <TrendsChartComponent
           title="Cache write throughput"
-          data={model.getDates()}
-          extractValue={(date) => +(model.getStat(date).totalUploadSizeBytes ?? 0)}
-          extractSecondaryValue={(date) =>
-            (+(model.getStat(date).totalUploadSizeBytes ?? 0) * BITS_PER_BYTE) /
-            (+(model.getStat(date).totalUploadUsec ?? 0) * SECONDS_PER_MICROSECOND)
+          data={model.getTimeKeys()}
+          extractValue={(tsMillis) => +(model.getStat(tsMillis).totalUploadSizeBytes ?? 0)}
+          extractSecondaryValue={(tsMillis) =>
+            (+(model.getStat(tsMillis).totalUploadSizeBytes ?? 0) * BITS_PER_BYTE) /
+            (+(model.getStat(tsMillis).totalUploadUsec ?? 0) * SECONDS_PER_MICROSECOND)
           }
           extractLabel={this.formatShortDate}
           formatTickValue={format.bytes}
@@ -275,8 +275,8 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
           <TrendsChartComponent
             title="Saved CPU Time"
             id="savings"
-            data={model.getDates()}
-            extractValue={(date) => +(model.getStat(date).totalCpuMicrosSaved ?? 0) * SECONDS_PER_MICROSECOND}
+            data={model.getTimeKeys()}
+            extractValue={(tsMillis) => +(model.getStat(tsMillis).totalCpuMicrosSaved ?? 0) * SECONDS_PER_MICROSECOND}
             extractLabel={this.formatShortDate}
             formatTickValue={format.durationSec}
             allowDecimals={false}
@@ -294,14 +294,24 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
       model.hasExecutionStats() && (
         <PercentilesChartComponent
           title="Remote Execution Queue Duration"
-          data={model.getDates()}
+          data={model.getTimeKeys()}
           extractLabel={this.formatShortDate}
           formatHoverLabel={this.formatLongDate}
-          extractP50={(date) => +(model.getExecutionStat(date).queueDurationUsecP50 ?? 0) * SECONDS_PER_MICROSECOND}
-          extractP75={(date) => +(model.getExecutionStat(date).queueDurationUsecP75 ?? 0) * SECONDS_PER_MICROSECOND}
-          extractP90={(date) => +(model.getExecutionStat(date).queueDurationUsecP90 ?? 0) * SECONDS_PER_MICROSECOND}
-          extractP95={(date) => +(model.getExecutionStat(date).queueDurationUsecP95 ?? 0) * SECONDS_PER_MICROSECOND}
-          extractP99={(date) => +(model.getExecutionStat(date).queueDurationUsecP99 ?? 0) * SECONDS_PER_MICROSECOND}
+          extractP50={(tsMillis) =>
+            +(model.getExecutionStat(tsMillis).queueDurationUsecP50 ?? 0) * SECONDS_PER_MICROSECOND
+          }
+          extractP75={(tsMillis) =>
+            +(model.getExecutionStat(tsMillis).queueDurationUsecP75 ?? 0) * SECONDS_PER_MICROSECOND
+          }
+          extractP90={(tsMillis) =>
+            +(model.getExecutionStat(tsMillis).queueDurationUsecP90 ?? 0) * SECONDS_PER_MICROSECOND
+          }
+          extractP95={(tsMillis) =>
+            +(model.getExecutionStat(tsMillis).queueDurationUsecP95 ?? 0) * SECONDS_PER_MICROSECOND
+          }
+          extractP99={(tsMillis) =>
+            +(model.getExecutionStat(tsMillis).queueDurationUsecP99 ?? 0) * SECONDS_PER_MICROSECOND
+          }
         />
       )
     );

--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -200,8 +200,8 @@ export default class TrendsComponent extends React.Component<Props, State> {
     return time.format("HH:mm");
   }
 
-  onBarClicked(hash: string, sortBy: string, date: number) {
-    // XXX
+  onBarClicked(hash: string, sortBy: string, tsMillis: number) {
+    const date = new Date(tsMillis).toISOString().split("T")[0];
     router.navigateTo("/?start=" + date + "&end=" + date + "&sort-by=" + sortBy + hash);
   }
 

--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -15,7 +15,7 @@ import { getProtoFilterParams } from "../filter/filter_util";
 import router from "../../../app/router/router";
 import * as proto from "../../../app/util/proto";
 import DrilldownPageComponent from "./drilldown_page";
-import { timeHour, timeDay } from "d3-time";
+import { timeDay } from "d3-time";
 
 const BITS_PER_BYTE = 8;
 

--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -15,6 +15,7 @@ import { getProtoFilterParams } from "../filter/filter_util";
 import router from "../../../app/router/router";
 import * as proto from "../../../app/util/proto";
 import DrilldownPageComponent from "./drilldown_page";
+import { timeHour, timeDay } from "d3-time";
 
 const BITS_PER_BYTE = 8;
 
@@ -27,12 +28,12 @@ interface Props {
 interface State {
   stats: stats.ITrendStat[];
   loading: boolean;
-  dateToStatMap: Map<string, stats.ITrendStat>;
-  dateToExecutionStatMap: Map<string, stats.IExecutionStat>;
+  timeToStatMap: Map<number, stats.ITrendStat>;
+  timeToExecutionStatMap: Map<number, stats.IExecutionStat>;
   enableInvocationPercentileCharts: boolean;
   currentSummary?: stats.Summary;
   previousSummary?: stats.Summary;
-  dates: string[];
+  timeKeys: number[];
 }
 
 const SECONDS_PER_MICROSECOND = 1e-6;
@@ -41,10 +42,10 @@ export default class TrendsComponent extends React.Component<Props, State> {
   state: State = {
     stats: [],
     loading: true,
-    dateToStatMap: new Map<string, stats.ITrendStat>(),
-    dateToExecutionStatMap: new Map<string, stats.IExecutionStat>(),
+    timeToStatMap: new Map<number, stats.ITrendStat>(),
+    timeToExecutionStatMap: new Map<number, stats.IExecutionStat>(),
     enableInvocationPercentileCharts: false,
-    dates: [],
+    timeKeys: [],
   };
 
   subscription?: Subscription;
@@ -149,49 +150,58 @@ export default class TrendsComponent extends React.Component<Props, State> {
     this.setState({ loading: true });
     rpcService.service.getTrend(request).then((response) => {
       console.log(response);
-      const dateToStatMap = new Map<string, stats.ITrendStat>();
+      const timeToStatMap = new Map<number, stats.ITrendStat>();
       for (let stat of response.trendStat) {
-        dateToStatMap.set(stat.name ?? "", stat);
+        const time = new Date(stat.name + " 00:00").getTime();
+        timeToStatMap.set(time, stat);
       }
-      const dateToExecutionStatMap = new Map<string, stats.IExecutionStat>();
+      const timeToExecutionStatMap = new Map<number, stats.IExecutionStat>();
       for (let stat of response.executionStat) {
-        dateToExecutionStatMap.set(stat.name ?? "", stat);
+        const time = new Date(stat.name + " 00:00").getTime();
+        timeToExecutionStatMap.set(time, stat);
       }
+      const domain: [Date, Date] = [
+        proto.timestampToDate(request.query!.updatedAfter!),
+        request.query!.updatedBefore ? proto.timestampToDate(request.query!.updatedBefore) : new Date(),
+      ];
+
       this.setState({
         stats: response.trendStat,
-        dates: getDatesBetween(
-          // Start date should always be defined.
-          proto.timestampToDate(request.query!.updatedAfter || {}),
-          // End date may not be defined -- default to today.
-          request.query!.updatedBefore ? proto.timestampToDate(request.query!.updatedBefore) : new Date()
-        ),
+        timeKeys: computeTimeKeys(domain),
         currentSummary: response.currentSummary || undefined,
         previousSummary: response.previousSummary || undefined,
-        dateToStatMap,
-        dateToExecutionStatMap,
+        timeToStatMap,
+        timeToExecutionStatMap,
         enableInvocationPercentileCharts: response.hasInvocationStatPercentiles,
         loading: false,
       });
     });
   }
 
-  getStat(date: string): stats.ITrendStat {
-    return this.state.dateToStatMap.get(date) || {};
+  getStat(timestampMillis: number): stats.ITrendStat {
+    return this.state.timeToStatMap.get(timestampMillis) || {};
   }
 
-  getExecutionStat(date: string): stats.IExecutionStat {
-    return this.state.dateToExecutionStatMap.get(date) || {};
+  getExecutionStat(timestampMillis: number): stats.IExecutionStat {
+    return this.state.timeToExecutionStatMap.get(timestampMillis) || {};
   }
 
-  formatLongDate(date: any) {
-    return moment(date).format("dddd, MMMM Do YYYY");
+  formatLongDate(timestampMillis: number) {
+    return moment(timestampMillis).format("dddd, MMMM Do YYYY");
   }
 
-  formatShortDate(date: any) {
-    return moment(date).format("MMM D");
+  formatShortDate(timestampMillis: number) {
+    const time = moment(timestampMillis);
+
+    if (time.hour() === 0) {
+      return time.format("MMM D");
+    }
+
+    return time.format("HH:mm");
   }
 
-  onBarClicked(hash: string, sortBy: string, date: string) {
+  onBarClicked(hash: string, sortBy: string, date: number) {
+    // XXX
     router.navigateTo("/?start=" + date + "&end=" + date + "&sort-by=" + sortBy + hash);
   }
 
@@ -236,15 +246,15 @@ export default class TrendsComponent extends React.Component<Props, State> {
               <TrendsChartComponent
                 title="Builds"
                 id="builds"
-                data={this.state.dates}
-                extractValue={(date) => +(this.getStat(date).totalNumBuilds ?? 0)}
-                extractSecondaryValue={(date) => {
-                  let stat = this.getStat(date);
+                data={this.state.timeKeys}
+                extractValue={(tsMillis) => +(this.getStat(tsMillis).totalNumBuilds ?? 0)}
+                extractSecondaryValue={(tsMillis) => {
+                  let stat = this.getStat(tsMillis);
                   return (
                     (+(stat.totalBuildTimeUsec ?? 0) * SECONDS_PER_MICROSECOND) / +(stat.completedInvocationCount ?? 0)
                   );
                 }}
-                extractLabel={this.formatShortDate}
+                extractLabel={this.formatShortDate.bind(this)}
                 formatTickValue={format.count}
                 allowDecimals={false}
                 formatHoverLabel={this.formatLongDate}
@@ -261,14 +271,14 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 <PercentilesChartComponent
                   title="Build duration"
                   id="duration"
-                  data={this.state.dates}
-                  extractLabel={this.formatShortDate}
+                  data={this.state.timeKeys}
+                  extractLabel={this.formatShortDate.bind(this)}
                   formatHoverLabel={this.formatLongDate}
-                  extractP50={(date) => +(this.getStat(date).buildTimeUsecP50 ?? 0) * SECONDS_PER_MICROSECOND}
-                  extractP75={(date) => +(this.getStat(date).buildTimeUsecP75 ?? 0) * SECONDS_PER_MICROSECOND}
-                  extractP90={(date) => +(this.getStat(date).buildTimeUsecP90 ?? 0) * SECONDS_PER_MICROSECOND}
-                  extractP95={(date) => +(this.getStat(date).buildTimeUsecP95 ?? 0) * SECONDS_PER_MICROSECOND}
-                  extractP99={(date) => +(this.getStat(date).buildTimeUsecP99 ?? 0) * SECONDS_PER_MICROSECOND}
+                  extractP50={(tsMillis) => +(this.getStat(tsMillis).buildTimeUsecP50 ?? 0) * SECONDS_PER_MICROSECOND}
+                  extractP75={(tsMillis) => +(this.getStat(tsMillis).buildTimeUsecP75 ?? 0) * SECONDS_PER_MICROSECOND}
+                  extractP90={(tsMillis) => +(this.getStat(tsMillis).buildTimeUsecP90 ?? 0) * SECONDS_PER_MICROSECOND}
+                  extractP95={(tsMillis) => +(this.getStat(tsMillis).buildTimeUsecP95 ?? 0) * SECONDS_PER_MICROSECOND}
+                  extractP99={(tsMillis) => +(this.getStat(tsMillis).buildTimeUsecP99 ?? 0) * SECONDS_PER_MICROSECOND}
                   onColumnClicked={this.onBarClicked.bind(this, "", "duration")}
                 />
               )}
@@ -276,13 +286,13 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 <TrendsChartComponent
                   title="Build duration"
                   id="duration"
-                  data={this.state.dates}
-                  extractValue={(date) => {
-                    let stat = this.getStat(date);
+                  data={this.state.timeKeys}
+                  extractValue={(tsMillis) => {
+                    let stat = this.getStat(tsMillis);
                     return +(stat.totalBuildTimeUsec ?? 0) / +(stat.completedInvocationCount ?? 0) / 1000000;
                   }}
-                  extractSecondaryValue={(date) => +(this.getStat(date).maxDurationUsec ?? 0) / 1000000}
-                  extractLabel={this.formatShortDate}
+                  extractSecondaryValue={(tsMillis) => +(this.getStat(tsMillis).maxDurationUsec ?? 0) / 1000000}
+                  extractLabel={this.formatShortDate.bind(this)}
                   formatTickValue={format.durationSec}
                   formatHoverLabel={this.formatLongDate}
                   formatHoverValue={(value) => `${format.durationSec(value || 0)} average`}
@@ -297,32 +307,32 @@ export default class TrendsComponent extends React.Component<Props, State> {
               <CacheChartComponent
                 title="Action Cache"
                 id="cache"
-                data={this.state.dates}
-                extractLabel={this.formatShortDate}
+                data={this.state.timeKeys}
+                extractLabel={this.formatShortDate.bind(this)}
                 formatHoverLabel={this.formatLongDate}
-                extractHits={(date) => +(this.getStat(date).actionCacheHits ?? 0)}
+                extractHits={(tsMillis) => +(this.getStat(tsMillis).actionCacheHits ?? 0)}
                 secondaryBarName="misses"
-                extractSecondary={(date) => +(this.getStat(date).actionCacheMisses ?? 0)}
+                extractSecondary={(tsMillis) => +(this.getStat(tsMillis).actionCacheMisses ?? 0)}
               />
               <CacheChartComponent
                 title="Content Addressable Store"
-                data={this.state.dates}
-                extractLabel={this.formatShortDate}
+                data={this.state.timeKeys}
+                extractLabel={this.formatShortDate.bind(this)}
                 formatHoverLabel={this.formatLongDate}
-                extractHits={(date) => +(this.getStat(date).casCacheHits ?? 0)}
+                extractHits={(tsMillis) => +(this.getStat(tsMillis).casCacheHits ?? 0)}
                 secondaryBarName="writes"
-                extractSecondary={(date) => +(this.getStat(date).casCacheUploads ?? 0)}
+                extractSecondary={(tsMillis) => +(this.getStat(tsMillis).casCacheUploads ?? 0)}
               />
 
               <TrendsChartComponent
                 title="Cache read throughput"
-                data={this.state.dates}
-                extractValue={(date) => +(this.getStat(date).totalDownloadSizeBytes ?? 0)}
-                extractSecondaryValue={(date) =>
-                  (+(this.getStat(date).totalDownloadSizeBytes ?? 0) * BITS_PER_BYTE) /
-                  (+(this.getStat(date).totalDownloadUsec ?? 0) * SECONDS_PER_MICROSECOND)
+                data={this.state.timeKeys}
+                extractValue={(tsMillis) => +(this.getStat(tsMillis).totalDownloadSizeBytes ?? 0)}
+                extractSecondaryValue={(tsMillis) =>
+                  (+(this.getStat(tsMillis).totalDownloadSizeBytes ?? 0) * BITS_PER_BYTE) /
+                  (+(this.getStat(tsMillis).totalDownloadUsec ?? 0) * SECONDS_PER_MICROSECOND)
                 }
-                extractLabel={this.formatShortDate}
+                extractLabel={this.formatShortDate.bind(this)}
                 formatTickValue={format.bytes}
                 allowDecimals={false}
                 formatSecondaryTickValue={format.bitsPerSecond}
@@ -337,13 +347,13 @@ export default class TrendsComponent extends React.Component<Props, State> {
 
               <TrendsChartComponent
                 title="Cache write throughput"
-                data={this.state.dates}
-                extractValue={(date) => +(this.getStat(date).totalUploadSizeBytes ?? 0)}
-                extractSecondaryValue={(date) =>
-                  (+(this.getStat(date).totalUploadSizeBytes ?? 0) * BITS_PER_BYTE) /
-                  (+(this.getStat(date).totalUploadUsec ?? 0) * SECONDS_PER_MICROSECOND)
+                data={this.state.timeKeys}
+                extractValue={(tsMillis) => +(this.getStat(tsMillis).totalUploadSizeBytes ?? 0)}
+                extractSecondaryValue={(tsMillis) =>
+                  (+(this.getStat(tsMillis).totalUploadSizeBytes ?? 0) * BITS_PER_BYTE) /
+                  (+(this.getStat(tsMillis).totalUploadUsec ?? 0) * SECONDS_PER_MICROSECOND)
                 }
-                extractLabel={this.formatShortDate}
+                extractLabel={this.formatShortDate.bind(this)}
                 formatTickValue={format.bytes}
                 formatSecondaryTickValue={format.bitsPerSecond}
                 formatHoverLabel={this.formatLongDate}
@@ -359,9 +369,11 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 <TrendsChartComponent
                   title="Saved CPU Time"
                   id="savings"
-                  data={this.state.dates}
-                  extractValue={(date) => +(this.getStat(date).totalCpuMicrosSaved ?? 0) * SECONDS_PER_MICROSECOND}
-                  extractLabel={this.formatShortDate}
+                  data={this.state.timeKeys}
+                  extractValue={(tsMillis) =>
+                    +(this.getStat(tsMillis).totalCpuMicrosSaved ?? 0) * SECONDS_PER_MICROSECOND
+                  }
+                  extractLabel={this.formatShortDate.bind(this)}
                   formatTickValue={format.durationSec}
                   allowDecimals={false}
                   formatHoverLabel={this.formatLongDate}
@@ -372,9 +384,9 @@ export default class TrendsComponent extends React.Component<Props, State> {
 
               <TrendsChartComponent
                 title="Users with builds"
-                data={this.state.dates}
-                extractValue={(date) => +(this.getStat(date).userCount ?? 0)}
-                extractLabel={this.formatShortDate}
+                data={this.state.timeKeys}
+                extractValue={(tsMillis) => +(this.getStat(tsMillis).userCount ?? 0)}
+                extractLabel={this.formatShortDate.bind(this)}
                 formatTickValue={format.count}
                 allowDecimals={false}
                 formatHoverLabel={this.formatLongDate}
@@ -384,9 +396,9 @@ export default class TrendsComponent extends React.Component<Props, State> {
               />
               <TrendsChartComponent
                 title="Commits with builds"
-                data={this.state.dates}
-                extractValue={(date) => +(this.getStat(date).commitCount ?? 0)}
-                extractLabel={this.formatShortDate}
+                data={this.state.timeKeys}
+                extractValue={(tsMillis) => +(this.getStat(tsMillis).commitCount ?? 0)}
+                extractLabel={this.formatShortDate.bind(this)}
                 formatTickValue={format.count}
                 allowDecimals={false}
                 formatHoverLabel={this.formatLongDate}
@@ -396,9 +408,9 @@ export default class TrendsComponent extends React.Component<Props, State> {
               />
               <TrendsChartComponent
                 title="Branches with builds"
-                data={this.state.dates}
-                extractValue={(date) => +(this.getStat(date).branchCount ?? 0)}
-                extractLabel={this.formatShortDate}
+                data={this.state.timeKeys}
+                extractValue={(tsMillis) => +(this.getStat(tsMillis).branchCount ?? 0)}
+                extractLabel={this.formatShortDate.bind(this)}
                 formatTickValue={format.count}
                 allowDecimals={false}
                 formatHoverLabel={this.formatLongDate}
@@ -407,9 +419,9 @@ export default class TrendsComponent extends React.Component<Props, State> {
               />
               <TrendsChartComponent
                 title="Hosts with builds"
-                data={this.state.dates}
-                extractValue={(date) => +(this.getStat(date).hostCount ?? 0)}
-                extractLabel={this.formatShortDate}
+                data={this.state.timeKeys}
+                extractValue={(tsMillis) => +(this.getStat(tsMillis).hostCount ?? 0)}
+                extractLabel={this.formatShortDate.bind(this)}
                 formatTickValue={format.count}
                 allowDecimals={false}
                 formatHoverLabel={this.formatLongDate}
@@ -419,9 +431,9 @@ export default class TrendsComponent extends React.Component<Props, State> {
               />
               <TrendsChartComponent
                 title="Repos with builds"
-                data={this.state.dates}
-                extractValue={(date) => +(this.getStat(date).repoCount ?? 0)}
-                extractLabel={this.formatShortDate}
+                data={this.state.timeKeys}
+                extractValue={(tsMillis) => +(this.getStat(tsMillis).repoCount ?? 0)}
+                extractLabel={this.formatShortDate.bind(this)}
                 formatTickValue={format.count}
                 allowDecimals={false}
                 formatHoverLabel={this.formatLongDate}
@@ -429,26 +441,26 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 name="repos with builds"
                 onBarClicked={this.onBarClicked.bind(this, "#repos", "")}
               />
-              {this.state.dateToExecutionStatMap.size > 0 && (
+              {this.state.timeToExecutionStatMap.size > 0 && (
                 <PercentilesChartComponent
                   title="Remote Execution Queue Duration"
-                  data={this.state.dates}
-                  extractLabel={this.formatShortDate}
+                  data={this.state.timeKeys}
+                  extractLabel={this.formatShortDate.bind(this)}
                   formatHoverLabel={this.formatLongDate}
-                  extractP50={(date) =>
-                    +(this.getExecutionStat(date).queueDurationUsecP50 ?? 0) * SECONDS_PER_MICROSECOND
+                  extractP50={(tsMillis) =>
+                    +(this.getExecutionStat(tsMillis).queueDurationUsecP50 ?? 0) * SECONDS_PER_MICROSECOND
                   }
-                  extractP75={(date) =>
-                    +(this.getExecutionStat(date).queueDurationUsecP75 ?? 0) * SECONDS_PER_MICROSECOND
+                  extractP75={(tsMillis) =>
+                    +(this.getExecutionStat(tsMillis).queueDurationUsecP75 ?? 0) * SECONDS_PER_MICROSECOND
                   }
-                  extractP90={(date) =>
-                    +(this.getExecutionStat(date).queueDurationUsecP90 ?? 0) * SECONDS_PER_MICROSECOND
+                  extractP90={(tsMillis) =>
+                    +(this.getExecutionStat(tsMillis).queueDurationUsecP90 ?? 0) * SECONDS_PER_MICROSECOND
                   }
-                  extractP95={(date) =>
-                    +(this.getExecutionStat(date).queueDurationUsecP95 ?? 0) * SECONDS_PER_MICROSECOND
+                  extractP95={(tsMillis) =>
+                    +(this.getExecutionStat(tsMillis).queueDurationUsecP95 ?? 0) * SECONDS_PER_MICROSECOND
                   }
-                  extractP99={(date) =>
-                    +(this.getExecutionStat(date).queueDurationUsecP99 ?? 0) * SECONDS_PER_MICROSECOND
+                  extractP99={(tsMillis) =>
+                    +(this.getExecutionStat(tsMillis).queueDurationUsecP99 ?? 0) * SECONDS_PER_MICROSECOND
                   }
                 />
               )}
@@ -460,11 +472,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
   }
 }
 
-function getDatesBetween(start: Date, end: Date): string[] {
-  const endMoment = moment(end);
-  const formattedDates: string[] = [];
-  for (let date = moment(start); date.isBefore(endMoment); date = date.add(1, "days")) {
-    formattedDates.push(date.format("YYYY-MM-DD"));
-  }
-  return formattedDates;
+// TODO(jdhollen): support smaller time ranges.
+function computeTimeKeys(domain: [Date, Date]): number[] {
+  return timeDay.range(timeDay.floor(domain[0]), domain[1]).map((v) => v.getTime());
 }

--- a/enterprise/app/trends/trends_chart.tsx
+++ b/enterprise/app/trends/trends_chart.tsx
@@ -16,18 +16,18 @@ import {
 
 interface Props {
   title: string;
-  data: any[];
+  data: number[];
   id?: string;
 
-  extractLabel: (datum: any) => string;
-  formatHoverLabel: (datum: any) => string;
+  extractLabel: (datum: number) => string;
+  formatHoverLabel: (datum: number) => string;
   formatHoverValue?: (datum: number) => string;
   formatTickValue?: (datum: number, index: number) => string;
-  extractValue: (datum: any) => number;
+  extractValue: (datum: number) => number;
   allowDecimals?: boolean;
   name: string;
 
-  extractSecondaryValue?: (datum: any) => number;
+  extractSecondaryValue?: (datum: number) => number;
   formatSecondaryHoverValue?: (datum: number) => string;
   formatSecondaryTickValue?: (datum: number, index: number) => string;
   secondaryAllowDecimals?: boolean;
@@ -35,8 +35,8 @@ interface Props {
   secondaryLine?: boolean;
   separateAxis?: boolean;
 
-  onBarClicked?: (date: string) => void;
-  onSecondaryBarClicked?: (date: string) => void;
+  onBarClicked?: (date: number) => void;
+  onSecondaryBarClicked?: (date: number) => void;
 }
 
 interface TrendsChartTooltipProps extends TooltipProps<any, any> {
@@ -84,7 +84,7 @@ export default class TrendsChartComponent extends React.Component<Props> {
           <ComposedChart data={this.props.data}>
             <CartesianGrid strokeDasharray="3 3" />
             <Legend />
-            <XAxis dataKey={this.props.extractLabel} />
+            <XAxis dataKey={(v) => v} tickFormatter={this.props.extractLabel} ticks={this.props.data} />
             <YAxis
               yAxisId="primary"
               tickFormatter={this.props.formatTickValue}

--- a/enterprise/app/trends/trends_model.ts
+++ b/enterprise/app/trends/trends_model.ts
@@ -97,8 +97,8 @@ export default class TrendsModel {
 // TODO(jdhollen): support specifying a mod to skip specific ticks
 function computeTimeKeys(domain: [Date, Date]): number[] {
   if (domain[1].getTime() - domain[0].getTime() > 1000 * 60 * 60 * 48) {
-    return timeDay.range(timeDay.floor(domain[0]), domain[1]).map((v) => v.getTime());
+    return timeDay.range(timeDay.floor(domain[0]), domain[1]).map((d: Date) => d.getTime());
   } else {
-    return timeHour.range(timeHour.floor(domain[0]), domain[1]).map((v) => v.getTime());
+    return timeHour.range(timeHour.floor(domain[0]), domain[1]).map((d: Date) => d.getTime());
   }
 }

--- a/enterprise/app/trends/trends_model.ts
+++ b/enterprise/app/trends/trends_model.ts
@@ -2,15 +2,7 @@ import moment from "moment";
 
 import { timestampToDate } from "../../../app/util/proto";
 import { stats } from "../../../proto/stats_ts_proto";
-
-function getDatesBetween(start: Date, end: Date): string[] {
-  const endMoment = moment(end);
-  const formattedDates: string[] = [];
-  for (let date = moment(start); date.isBefore(endMoment); date = date.add(1, "days")) {
-    formattedDates.push(date.format("YYYY-MM-DD"));
-  }
-  return formattedDates;
-}
+import { timeHour, timeDay } from "d3-time";
 
 /**
  * This is a shared model class for "trends" data, which currently just means
@@ -26,29 +18,36 @@ export default class TrendsModel {
   private loading: boolean;
   private error?: string;
   private data: stats.GetTrendResponse;
-  private dates: string[];
-  private dateToStatMap: Map<string, stats.ITrendStat>;
-  private dateToExecutionStatMap: Map<string, stats.IExecutionStat>;
+  private timeKeys: number[];
+  private timeToStatMap: Map<number, stats.ITrendStat>;
+  private timeToExecutionStatMap: Map<number, stats.IExecutionStat>;
 
   constructor(loading: boolean, error?: string, request?: stats.GetTrendRequest, response?: stats.GetTrendResponse) {
     this.loading = loading;
     this.error = error;
     this.data = response ?? stats.GetTrendResponse.create({});
 
-    this.dates = getDatesBetween(
-      // Note that start date should always be defined, even though we aren't asserting here.
-      timestampToDate(request?.query?.updatedAfter ?? {}),
-      // End date may not be defined -- default to today.
-      request?.query?.updatedBefore ? timestampToDate(request.query.updatedBefore) : new Date()
-    );
-
-    this.dateToStatMap = new Map<string, stats.ITrendStat>();
-    for (let stat of response?.trendStat ?? []) {
-      this.dateToStatMap.set(stat.name, stat);
+    if (request) {
+      const domain: [Date, Date] = [
+        // Note that start date should always be defined, even though we aren't asserting here.
+        timestampToDate(request.query?.updatedAfter ?? {}),
+        // End date may not be defined -- default to today.
+        request?.query?.updatedBefore ? timestampToDate(request.query.updatedBefore) : new Date(),
+      ];
+      this.timeKeys = computeTimeKeys(domain);
+    } else {
+      this.timeKeys = [];
     }
-    this.dateToExecutionStatMap = new Map<string, stats.IExecutionStat>();
+
+    this.timeToStatMap = new Map<number, stats.ITrendStat>();
+    for (let stat of response?.trendStat ?? []) {
+      const time = new Date(stat.name + " 00:00").getTime();
+      this.timeToStatMap.set(time, stat);
+    }
+    this.timeToExecutionStatMap = new Map<number, stats.IExecutionStat>();
     for (let stat of response?.executionStat ?? []) {
-      this.dateToExecutionStatMap.set(stat.name, stat);
+      const time = new Date(stat.name + " 00:00").getTime();
+      this.timeToExecutionStatMap.set(time, stat);
     }
   }
 
@@ -60,20 +59,20 @@ export default class TrendsModel {
     return this.data.trendStat;
   }
 
-  public getStat(date: string): stats.ITrendStat {
-    return this.dateToStatMap.get(date) || {};
+  public getStat(time: number): stats.ITrendStat {
+    return this.timeToStatMap.get(time) || {};
   }
 
   public hasExecutionStats() {
-    return this.dateToExecutionStatMap.size > 0;
+    return this.timeToExecutionStatMap.size > 0;
   }
 
-  public getExecutionStat(date: string): stats.IExecutionStat {
-    return this.dateToExecutionStatMap.get(date) || {};
+  public getExecutionStat(time: number): stats.IExecutionStat {
+    return this.timeToExecutionStatMap.get(time) || {};
   }
 
-  public getDates() {
-    return this.dates;
+  public getTimeKeys() {
+    return this.timeKeys;
   }
 
   public getCurrentSummary() {
@@ -94,5 +93,14 @@ export default class TrendsModel {
 
   public getError() {
     return this.error;
+  }
+}
+
+// TODO(jdhollen): support specifying a mod to skip specific ticks
+function computeTimeKeys(domain: [Date, Date]): number[] {
+  if (domain[1].getTime() - domain[0].getTime() > 1000 * 60 * 60 * 48) {
+    return timeDay.range(timeDay.floor(domain[0]), domain[1]).map((v) => v.getTime());
+  } else {
+    return timeHour.range(timeHour.floor(domain[0]), domain[1]).map((v) => v.getTime());
   }
 }

--- a/enterprise/app/trends/trends_model.ts
+++ b/enterprise/app/trends/trends_model.ts
@@ -1,5 +1,3 @@
-import moment from "moment";
-
 import { timestampToDate } from "../../../app/util/proto";
 import { stats } from "../../../proto/stats_ts_proto";
 import { timeHour, timeDay } from "d3-time";

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/react-window": "^1.8.5",
     "@types/uuid": "^8.3.0",
     "d3-scale": "^4.0.2",
+    "d3-time": "^3.0.0",
     "dagre-d3-react": "^0.2.4",
     "date-fns": "^2.23.0",
     "diff": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@bazel/jasmine": "^5.4.0",
     "@bazel/typescript": "^5.4.0",
     "@types/d3-scale": "^3.0.0",
+    "@types/d3-time": "^3.0.0",
     "@types/dagre-d3": "^0.4.39",
     "@types/diff": "^5.0.1",
     "@types/diff-match-patch": "^1.0.32",


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
this is prep work for making the trends charts all support sub-day entries.  i'm using a slightly-but-not-too-clever trick to make date strings keep working (so that we can keep supporting non-clickhouse without much headache)
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
