### PR TITLE
Incorporate IP access check into interceptors.

### DIFF
--- a/enterprise/server/iprules/BUILD
+++ b/enterprise/server/iprules/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//proto:iprules_go_proto",
         "//server/environment",
         "//server/interfaces",
+        "//server/metrics",
         "//server/tables",
         "//server/util/alert",
         "//server/util/authutil",
@@ -18,6 +19,7 @@ go_library(
         "//server/util/perms",
         "//server/util/role",
         "//server/util/status",
+        "@com_github_prometheus_client_golang//prometheus",
     ],
 )
 

--- a/server/http/protolet/protolet.go
+++ b/server/http/protolet/protolet.go
@@ -101,7 +101,7 @@ type HTTPHandlers struct {
 	RequestHandler http.Handler
 }
 
-func GenerateHTTPHandlers(server interface{}) (*HTTPHandlers, error) {
+func GenerateHTTPHandlers(servicePrefix string, server interface{}) (*HTTPHandlers, error) {
 	if reflect.ValueOf(server).Type().Kind() != reflect.Ptr {
 		return nil, fmt.Errorf("GenerateHTTPHandlers must be called with a pointer to an RPC service implementation")
 	}
@@ -113,7 +113,7 @@ func GenerateHTTPHandlers(server interface{}) (*HTTPHandlers, error) {
 		if !isRPCMethod(method) {
 			continue
 		}
-		handlerFns[method.Name] = method.Func
+		handlerFns[servicePrefix+method.Name] = method.Func
 	}
 
 	bodyParserMiddleware := func(next http.Handler) http.Handler {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1212,4 +1212,9 @@ type IPRulesService interface {
 	// Authorize checks whether the authenticated user in the context is allowed
 	// to access the specified groupId.
 	AuthorizeGroup(ctx context.Context, groupID string) error
+
+	// AuthorizeHTTPRequest checks whether the specified HTTP request should be
+	// allowed based on the authenticated user and group information in the
+	// context.
+	AuthorizeHTTPRequest(ctx context.Context, r *http.Request) error
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1209,8 +1209,9 @@ type IPRulesService interface {
 	// to access the group identified in the context.
 	Authorize(ctx context.Context) error
 
-	// Authorize checks whether the authenticated user in the context is allowed
-	// to access the specified groupId.
+	// AuthorizeGroup checks whether the authenticated user in the context is
+	// allowed to access the specified groupId. This function should not be used
+	// in performance sensitive code paths.
 	AuthorizeGroup(ctx context.Context, groupID string) error
 
 	// AuthorizeHTTPRequest checks whether the specified HTTP request should be

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -300,7 +300,7 @@ func StartAndRunServices(env environment.Env) {
 
 	// Generate HTTP (protolet) handlers for the BuildBuddy API, so it
 	// can be called over HTTP(s).
-	protoletHandler, err := protolet.GenerateHTTPHandlers(env.GetBuildBuddyServer())
+	protoletHandler, err := protolet.GenerateHTTPHandlers("/rpc/BuildBuddyService/", env.GetBuildBuddyServer())
 	if err != nil {
 		log.Fatalf("Error initializing RPC over HTTP handlers for BuildBuddy server: %s", err)
 	}
@@ -370,7 +370,7 @@ func StartAndRunServices(env environment.Env) {
 
 	// Register API as an HTTP service.
 	if api := env.GetAPIService(); api != nil {
-		apiProtoHandlers, err := protolet.GenerateHTTPHandlers(api)
+		apiProtoHandlers, err := protolet.GenerateHTTPHandlers("/api/v1/", api)
 		if err != nil {
 			log.Fatalf("Error initializing RPC over HTTP handlers for API: %s", err)
 		}

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1933,6 +1933,16 @@ var (
 		APIKeyLookupStatus,
 	})
 
+	IPRulesCheckLatencyUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "auth",
+		Name:      "ip_rules_check_latency_usec",
+		Buckets:   durationUsecBuckets(1*time.Microsecond, 5*time.Second, 2),
+		Help:      "Latency of IP authorization checks.",
+	}, []string{
+		StatusHumanReadableLabel,
+	})
+
 	EncryptionKeyRefreshCount = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "encryption",

--- a/server/role_filter/role_filter.go
+++ b/server/role_filter/role_filter.go
@@ -3,7 +3,7 @@ package role_filter
 import (
 	"context"
 	"flag"
-	"strings"
+	"path"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
@@ -202,9 +202,7 @@ func ServerAdminOnlyRPCs() []string {
 func AuthorizeRPC(ctx context.Context, env environment.Env, rpcName string) error {
 	// Strip off the service name since it varies depending on whether it was
 	// accessed via protolet or gRPC.
-	if si := strings.LastIndex(rpcName, "/"); si >= 0 {
-		rpcName = rpcName[si+1:]
-	}
+	rpcName = path.Base(rpcName)
 
 	if stringSliceContains(RoleIndependentRPCs(), rpcName) {
 		return nil

--- a/server/role_filter/role_filter.go
+++ b/server/role_filter/role_filter.go
@@ -3,6 +3,7 @@ package role_filter
 import (
 	"context"
 	"flag"
+	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
@@ -199,6 +200,12 @@ func ServerAdminOnlyRPCs() []string {
 // If the RPC accesses any specific resources within the org, further
 // authorization checks may be needed beyond this coarse-grained filter.
 func AuthorizeRPC(ctx context.Context, env environment.Env, rpcName string) error {
+	// Strip off the service name since it varies depending on whether it was
+	// accessed via protolet or gRPC.
+	if si := strings.LastIndex(rpcName, "/"); si >= 0 {
+		rpcName = rpcName[si+1:]
+	}
+
 	if stringSliceContains(RoleIndependentRPCs(), rpcName) {
 		return nil
 	}


### PR DESCRIPTION
 - For HTTP, check all requests except GetUser which will be used to inform the frontend as to whether user has access to the target group.

   I removed the HTTP Path prefix stripping from the interceptors so that it's always possible for interceptors to know the requested URI.

 - For gRPC all requests are checked.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
