### PR TITLE
bazelrc: remote-target-linux use platform in output dir, stop repo RE

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -32,7 +32,6 @@ build:cache --experimental_remote_cache_compression
 build:remote-shared --remote_upload_local_results
 build:remote-shared --remote_timeout=600
 build:remote-shared --remote_download_minimal
-build:remote-shared --experimental_repo_remote_exec
 build:remote-shared --jobs=100
 build:remote-shared --verbose_failures
 build:remote-shared --platforms=@buildbuddy_toolchain//:platform_linux
@@ -68,8 +67,10 @@ build:target-linux --host_cpu=k8
 #   bazel test --config=x //...
 build:remote-target-linux --config=target-linux
 build:remote-target-linux --config=remote
+build:remote-target-linux --experimental_platform_in_output_dir
 build:remote-target-linux-dev --config=target-linux
 build:remote-target-linux-dev --config=remote-dev
+build:remote-target-linux-dev --experimental_platform_in_output_dir
 
 # Configuration used for GitHub actions-based CI
 build:ci --config=remote

--- a/.bazelrc
+++ b/.bazelrc
@@ -55,6 +55,8 @@ build:remote-dev --remote_executor=grpcs://buildbuddy.buildbuddy.dev
 #   - Tell Bazel to use Linux-compatible toolchains to build
 build:target-linux --cpu=k8
 build:target-linux --host_cpu=k8
+# Write linux-target build outputs in a separate directory from host build outputs.
+build:target-linux --experimental_platform_in_output_dir
 
 # Build with --config=remote-target-linux* to build on remote Linux Executors.
 # from non-Linux machines (e.g. MacOS).
@@ -67,10 +69,8 @@ build:target-linux --host_cpu=k8
 #   bazel test --config=x //...
 build:remote-target-linux --config=target-linux
 build:remote-target-linux --config=remote
-build:remote-target-linux --experimental_platform_in_output_dir
 build:remote-target-linux-dev --config=target-linux
 build:remote-target-linux-dev --config=remote-dev
-build:remote-target-linux-dev --experimental_platform_in_output_dir
 
 # Configuration used for GitHub actions-based CI
 build:ci --config=remote


### PR DESCRIPTION
This flag changes the name of output directories under `bazel-out/*` to
contain the platform information. This means that if a user were to
switch between a local build and a remote build
using `--config=remote-target-linux`, they would be able to retain the
output from both configs.

Also disabling `experimental_repo_remote_exec`. This flag is meant to
allow repository rules, when marked with `remotable = True` to be
executed remotely with RBE. The main purpose of this is to allow
toolchains to probe remote execution platforms information to setup
appropriate toolchains and paths. We do not use this effect in our
repository anywhere, however it will make us re-run all repository rules
when toggle between `--config=remote-target-linux` build and local build.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
