### PR TITLE
Use GetUser to communicate if user can't access selected group.

### DIFF
--- a/app/auth/BUILD
+++ b/app/auth/BUILD
@@ -27,5 +27,6 @@ ts_library(
         "//app/service:rpc_service",
         "//proto:group_ts_proto",
         "//proto:user_id_ts_proto",
+        "//proto:user_ts_proto",
     ],
 )

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -158,10 +158,13 @@ export class AuthService {
   }
 
   userFromResponse(response: user.GetUserResponse) {
+    const selectedGroupId = response.selectedGroup?.groupId ? response.selectedGroup.groupId : response.selectedGroupId;
+
     return new User({
       displayUser: response.displayUser as user_id.DisplayUser,
       groups: response.userGroup as grp.Group[],
-      selectedGroup: response.userGroup.find((group) => group.id === response.selectedGroupId) as grp.Group,
+      selectedGroup: response.userGroup.find((group) => group.id === selectedGroupId) as grp.Group,
+      selectedGroupAccess: response.selectedGroup?.access,
       githubLinked: response.githubLinked,
       allowedRpcs: new Set(
         response.allowedRpc.map(

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -184,7 +184,7 @@ export class AuthService {
     this.updateRequestContext();
     // Ensure that the user we are about to emit will see a route they are
     // authorized to view.
-    router.rerouteIfNecessary(user);
+    router.setUser(user);
     this.userStream.next(user);
   }
 

--- a/app/auth/user.ts
+++ b/app/auth/user.ts
@@ -1,11 +1,13 @@
 import { grp } from "../../proto/group_ts_proto";
 import { user_id } from "../../proto/user_id_ts_proto";
 import { BuildBuddyServiceRpcName } from "../service/rpc_service";
+import { user } from "../../proto/user_ts_proto";
 
 export class User {
   displayUser: user_id.DisplayUser;
   groups: grp.Group[];
   selectedGroup: grp.Group;
+  selectedGroupAccess: user.SelectedGroup.Access;
   allowedRpcs: Set<BuildBuddyServiceRpcName>;
   githubLinked: boolean;
   /** Whether the user is temporarily acting as a member of the selected group. */
@@ -20,6 +22,7 @@ export class User {
     // issues in practice since the router will redirect to the "create org"
     // page on initial page load if the user is not a part of any groups.
     this.selectedGroup = init.selectedGroup ?? new grp.Group();
+    this.selectedGroupAccess = init.selectedGroupAccess ?? user.SelectedGroup.Access.ALLOWED;
     this.allowedRpcs = init.allowedRpcs!;
     this.githubLinked = init.githubLinked!;
     this.isImpersonating = init.isImpersonating!;

--- a/app/router/BUILD
+++ b/app/router/BUILD
@@ -18,6 +18,7 @@ ts_library(
         "//app/router:router_params",
         "//app/service:rpc_service",
         "//app/shortcuts",
+        "//proto:user_ts_proto",
         "@npm//tslib",
     ],
 )

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -51,7 +51,9 @@ class Router {
     });
   }
 
-  private handlePathChanged(pathChangeHandler: VoidFunction) {
+  // checks whether user has access to the current page, and if not returns
+  // URL to redirect to.
+  private checkGroupAccess() {
     const path = window.location.pathname;
     // Disallowed access to the selected group means one of two things:
     // 1) This is a customer subdomain and the user does not have access to
@@ -70,7 +72,15 @@ class Router {
         source_url: window.location.href,
         denied_reason: this.user.selectedGroupAccess.toString(),
       });
-      window.history.replaceState({}, "", Path.orgAccessDeniedPath + "?" + params.toString());
+      return Path.orgAccessDeniedPath + "?" + params.toString();
+    }
+    return "";
+  }
+
+  private handlePathChanged(pathChangeHandler: VoidFunction) {
+    const newUrl = this.checkGroupAccess();
+    if (newUrl) {
+      window.history.replaceState({}, "", newUrl);
       return;
     }
     pathChangeHandler();
@@ -402,6 +412,11 @@ class Router {
     // an org.
     if (user && !user.groups?.length) {
       return Path.createOrgPath;
+    }
+
+    const newUrl = this.checkGroupAccess();
+    if (newUrl) {
+      return newUrl;
     }
 
     const path = window.location.pathname;

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -53,6 +53,11 @@ class Router {
 
   private handlePathChanged(pathChangeHandler: VoidFunction) {
     const path = window.location.pathname;
+    // Disallowed access to the selected group means one of two things:
+    // 1) This is a customer subdomain and the user does not have access to
+    //    the group or the subdomain doesn't exist.
+    // 2) User is a member of the group but is being blocked by group
+    //    IP rules.
     if (
       this.user &&
       this.user.selectedGroupAccess != user_proto.SelectedGroup.Access.ALLOWED &&
@@ -400,26 +405,6 @@ class Router {
     }
 
     const path = window.location.pathname;
-
-    // Disallowed access to the selected group means one of two things:
-    // 1) This is a customer subdomain and the user does not have access to
-    //    the group or the subdomain doesn't exist.
-    // 2) User is a member of the group but is being blocked by group
-    //    IP rules.
-    if (
-      user &&
-      user.selectedGroupAccess != user_proto.SelectedGroup.Access.ALLOWED &&
-      // A user may have access to an invocation w/o having access to group.
-      !path.startsWith(Path.invocationPath) &&
-      !path.startsWith(Path.joinOrgPath)
-    ) {
-      const params = new URLSearchParams({
-        source_url: window.location.href,
-        denied_reason: user.selectedGroupAccess.toString(),
-      });
-      return Path.orgAccessDeniedPath + "?" + params.toString();
-    }
-
     if (path === Path.orgAccessDeniedPath) {
       return Path.home;
     }

--- a/enterprise/app/org/BUILD
+++ b/enterprise/app/org/BUILD
@@ -117,6 +117,7 @@ ts_library(
         "//app/auth:user",
         "//app/components/button",
         "//app/router",
+        "//proto:user_ts_proto",
         "@npm//@types/react",
         "@npm//react",
     ],

--- a/enterprise/app/org/org_access_denied.tsx
+++ b/enterprise/app/org/org_access_denied.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import FilledButton from "../../../app/components/button/button";
 import authService from "../../../app/auth/auth_service";
 import router from "../../../app/router/router";
+import { user } from "../../../proto/user_ts_proto";
 
 export type Props = {
   user: User;
@@ -19,6 +20,9 @@ export default class OrgAccessDeniedComponent extends React.Component<Props> {
   }
 
   render() {
+    const params = new URLSearchParams(window.location.search);
+    const deniedByIpRules = params.get("denied_reason") == user.SelectedGroup.Access.DENIED_BY_IP_RULES.toString();
+
     return (
       <div className="state-page">
         <div className="shelf">
@@ -26,7 +30,8 @@ export default class OrgAccessDeniedComponent extends React.Component<Props> {
             <div className="titles">
               <div className="title">Access denied</div>
             </div>
-            <div className="details">You are not authorized to access this site.</div>
+            {!deniedByIpRules && <div className="details">You are not authorized to access this site.</div>}
+            {deniedByIpRules && <div className="details">Access blocked by Organization IP Rules.</div>}
             {this.props.user?.subdomainGroupID && (
               <div>
                 <FilledButton onClick={this.handleImpersonateClicked.bind(this)} className="impersonate-button">

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -242,12 +242,7 @@ export default class EnterpriseRootComponent extends React.Component {
       (fallback && !capabilities.auth);
     let login = fallback && !setup && !repo && !this.state.loading && !this.state.user;
     let home = fallback && !setup && !this.state.loading && this.state.user;
-    let sidebar =
-      Boolean(this.state.user) &&
-      Boolean(this.state.user?.groups?.length) &&
-      (!capabilities.config.customerSubdomain || this.state.user?.selectedGroup.id) &&
-      !code &&
-      !repo;
+    let sidebar = Boolean(this.state.user) && Boolean(this.state.user?.groups?.length) && !code && !repo;
     let menu = !sidebar && !repo && !code && !this.state.loading;
 
     return (

--- a/enterprise/app/sidebar/BUILD
+++ b/enterprise/app/sidebar/BUILD
@@ -14,6 +14,7 @@ ts_library(
         "//app/router",
         "//app/service:rpc_service",
         "//proto:group_ts_proto",
+        "//proto:user_ts_proto",
         "@npm//@types/react",
         "@npm//lucide-react",
         "@npm//react",

--- a/enterprise/app/sidebar/sidebar.tsx
+++ b/enterprise/app/sidebar/sidebar.tsx
@@ -33,6 +33,7 @@ import router, { Path } from "../../../app/router/router";
 import rpcService from "../../../app/service/rpc_service";
 import rpc_service from "../../../app/service/rpc_service";
 import { grp } from "../../../proto/group_ts_proto";
+import { user } from "../../../proto/user_ts_proto";
 
 interface Props {
   user?: User;
@@ -154,80 +155,87 @@ export default class SidebarComponent extends React.Component<Props, State> {
           </a>
         </div>
         <div className="sidebar-body">
-          <SidebarLink selected={this.isHomeSelected()} href={Path.home} title="All builds">
-            <List className="icon" />
-            <span className="sidebar-item-text">All builds</span>
-          </SidebarLink>
-          <SidebarLink selected={this.isTrendsSelected()} href={Path.trendsPath} title="Trends">
-            <BarChart2 className="icon" />
-            <span className="sidebar-item-text">Trends</span>
-          </SidebarLink>
-          {capabilities.test && (
-            <SidebarLink selected={this.isTapSelected()} href={Path.tapPath} title="Tests">
-              <LayoutGrid className="icon" />
-              <span className="sidebar-item-text">Tests</span>
-            </SidebarLink>
-          )}
-          <SidebarLink selected={this.isUsersSelected()} href="/#users" title="Users">
-            <Users className="icon" />
-            <span className="sidebar-item-text">Users</span>
-          </SidebarLink>
-          <SidebarLink selected={this.isReposSelected()} href="/#repos" title="Repos">
-            <Github className="icon" />
-            <span className="sidebar-item-text">Repos</span>
-          </SidebarLink>
-          <SidebarLink selected={this.isBranchesSelected()} href="/#branches" title="Branches">
-            <GitBranch className="icon" />
-            <span className="sidebar-item-text">Branches</span>
-          </SidebarLink>
-          <SidebarLink selected={this.isCommitsSelected()} href="/#commits" title="Commits">
-            <GitCommit className="icon" />
-            <span className="sidebar-item-text">Commits</span>
-          </SidebarLink>
-          <SidebarLink selected={this.isHostsSelected()} href="/#hosts" title="Hosts">
-            <HardDrive className="icon" />
-            <span className="sidebar-item-text">Hosts</span>
-          </SidebarLink>
-          {router.canAccessExecutorsPage(this.props.user) && (
-            <SidebarLink selected={this.isExecutorsSelected()} href={Path.executorsPath} title="Executors">
-              <Cloud className="icon" />
-              <span className="sidebar-item-text">Executors</span>
-            </SidebarLink>
-          )}
-          {router.canAccessWorkflowsPage(this.props.user) && (
-            <SidebarLink selected={this.isWorkflowsSelected()} href={Path.workflowsPath} title="Workflows">
-              <PlayCircle className="icon" />
-              <span className="sidebar-item-text">Workflows</span>
-            </SidebarLink>
-          )}
-          {capabilities.code && (
-            <SidebarLink selected={this.isCodeSelected()} href={Path.codePath} title="Code">
-              <Code className="icon" />
-              <span className="sidebar-item-text">Code</span>
-            </SidebarLink>
-          )}
-          <SidebarLink selected={this.isSetupSelected()} href={Path.setupPath} title="Quickstart">
-            <Terminal className="icon" />
-            <span className="sidebar-item-text">Quickstart</span>
-          </SidebarLink>
+          {this.props.user?.selectedGroupAccess === user.SelectedGroup.Access.ALLOWED && (
+            <>
+              <SidebarLink selected={this.isHomeSelected()} href={Path.home} title="All builds">
+                <List className="icon" />
+                <span className="sidebar-item-text">All builds</span>
+              </SidebarLink>
+              <SidebarLink selected={this.isTrendsSelected()} href={Path.trendsPath} title="Trends">
+                <BarChart2 className="icon" />
+                <span className="sidebar-item-text">Trends</span>
+              </SidebarLink>
+              {capabilities.test && (
+                <SidebarLink selected={this.isTapSelected()} href={Path.tapPath} title="Tests">
+                  <LayoutGrid className="icon" />
+                  <span className="sidebar-item-text">Tests</span>
+                </SidebarLink>
+              )}
+              <SidebarLink selected={this.isUsersSelected()} href="/#users" title="Users">
+                <Users className="icon" />
+                <span className="sidebar-item-text">Users</span>
+              </SidebarLink>
+              <SidebarLink selected={this.isReposSelected()} href="/#repos" title="Repos">
+                <Github className="icon" />
+                <span className="sidebar-item-text">Repos</span>
+              </SidebarLink>
+              <SidebarLink selected={this.isBranchesSelected()} href="/#branches" title="Branches">
+                <GitBranch className="icon" />
+                <span className="sidebar-item-text">Branches</span>
+              </SidebarLink>
+              <SidebarLink selected={this.isCommitsSelected()} href="/#commits" title="Commits">
+                <GitCommit className="icon" />
+                <span className="sidebar-item-text">Commits</span>
+              </SidebarLink>
+              <SidebarLink selected={this.isHostsSelected()} href="/#hosts" title="Hosts">
+                <HardDrive className="icon" />
+                <span className="sidebar-item-text">Hosts</span>
+              </SidebarLink>
+              {router.canAccessExecutorsPage(this.props.user) && (
+                <SidebarLink selected={this.isExecutorsSelected()} href={Path.executorsPath} title="Executors">
+                  <Cloud className="icon" />
+                  <span className="sidebar-item-text">Executors</span>
+                </SidebarLink>
+              )}
+              {router.canAccessWorkflowsPage(this.props.user) && (
+                <SidebarLink selected={this.isWorkflowsSelected()} href={Path.workflowsPath} title="Workflows">
+                  <PlayCircle className="icon" />
+                  <span className="sidebar-item-text">Workflows</span>
+                </SidebarLink>
+              )}
+              {capabilities.code && (
+                <SidebarLink selected={this.isCodeSelected()} href={Path.codePath} title="Code">
+                  <Code className="icon" />
+                  <span className="sidebar-item-text">Code</span>
+                </SidebarLink>
+              )}
+              <SidebarLink selected={this.isSetupSelected()} href={Path.setupPath} title="Quickstart">
+                <Terminal className="icon" />
+                <span className="sidebar-item-text">Quickstart</span>
+              </SidebarLink>
 
-          <SidebarLink selected={this.isSettingsSelected()} href={Path.settingsPath} title="Settings">
-            <Sliders className="icon" />
-            <span className="sidebar-item-text">Settings</span>
-          </SidebarLink>
+              <SidebarLink selected={this.isSettingsSelected()} href={Path.settingsPath} title="Settings">
+                <Sliders className="icon" />
+                <span className="sidebar-item-text">Settings</span>
+              </SidebarLink>
 
-          {router.canAccessUsagePage(this.props.user) && (
-            <SidebarLink selected={this.isUsageSelected()} href={Path.usagePath} title="Usage">
-              <Gauge className="icon" />
-              <span className="sidebar-item-text">Usage</span>
-            </SidebarLink>
+              {router.canAccessUsagePage(this.props.user) && (
+                <SidebarLink selected={this.isUsageSelected()} href={Path.usagePath} title="Usage">
+                  <Gauge className="icon" />
+                  <span className="sidebar-item-text">Usage</span>
+                </SidebarLink>
+              )}
+              {router.canAccessAuditLogsPage(this.props.user) && capabilities.config.auditLogsUiEnabled && (
+                <SidebarLink selected={this.isAuditLogsSelected()} href={Path.auditLogsPath}>
+                  <Fingerprint className="icon" />
+                  <span className="sidebar-item-text">Audit logs</span>
+                </SidebarLink>
+              )}
+            </>
           )}
-          {router.canAccessAuditLogsPage(this.props.user) && capabilities.config.auditLogsUiEnabled && (
-            <SidebarLink selected={this.isAuditLogsSelected()} href={Path.auditLogsPath}>
-              <Fingerprint className="icon" />
-              <span className="sidebar-item-text">Audit logs</span>
-            </SidebarLink>
-          )}
+          {/*
+           * Sidebar items below will be visible even if the user does not have access to the selected group.
+           */}
           <a className="sidebar-item" href="https://www.buildbuddy.io/docs/" target="_blank" title="Docs">
             <BookOpen className="icon" />
             <span className="sidebar-item-text">Docs</span>

--- a/enterprise/app/sidebar/sidebar.tsx
+++ b/enterprise/app/sidebar/sidebar.tsx
@@ -155,87 +155,80 @@ export default class SidebarComponent extends React.Component<Props, State> {
           </a>
         </div>
         <div className="sidebar-body">
-          {this.props.user?.selectedGroupAccess === user.SelectedGroup.Access.ALLOWED && (
-            <>
-              <SidebarLink selected={this.isHomeSelected()} href={Path.home} title="All builds">
-                <List className="icon" />
-                <span className="sidebar-item-text">All builds</span>
-              </SidebarLink>
-              <SidebarLink selected={this.isTrendsSelected()} href={Path.trendsPath} title="Trends">
-                <BarChart2 className="icon" />
-                <span className="sidebar-item-text">Trends</span>
-              </SidebarLink>
-              {capabilities.test && (
-                <SidebarLink selected={this.isTapSelected()} href={Path.tapPath} title="Tests">
-                  <LayoutGrid className="icon" />
-                  <span className="sidebar-item-text">Tests</span>
-                </SidebarLink>
-              )}
-              <SidebarLink selected={this.isUsersSelected()} href="/#users" title="Users">
-                <Users className="icon" />
-                <span className="sidebar-item-text">Users</span>
-              </SidebarLink>
-              <SidebarLink selected={this.isReposSelected()} href="/#repos" title="Repos">
-                <Github className="icon" />
-                <span className="sidebar-item-text">Repos</span>
-              </SidebarLink>
-              <SidebarLink selected={this.isBranchesSelected()} href="/#branches" title="Branches">
-                <GitBranch className="icon" />
-                <span className="sidebar-item-text">Branches</span>
-              </SidebarLink>
-              <SidebarLink selected={this.isCommitsSelected()} href="/#commits" title="Commits">
-                <GitCommit className="icon" />
-                <span className="sidebar-item-text">Commits</span>
-              </SidebarLink>
-              <SidebarLink selected={this.isHostsSelected()} href="/#hosts" title="Hosts">
-                <HardDrive className="icon" />
-                <span className="sidebar-item-text">Hosts</span>
-              </SidebarLink>
-              {router.canAccessExecutorsPage(this.props.user) && (
-                <SidebarLink selected={this.isExecutorsSelected()} href={Path.executorsPath} title="Executors">
-                  <Cloud className="icon" />
-                  <span className="sidebar-item-text">Executors</span>
-                </SidebarLink>
-              )}
-              {router.canAccessWorkflowsPage(this.props.user) && (
-                <SidebarLink selected={this.isWorkflowsSelected()} href={Path.workflowsPath} title="Workflows">
-                  <PlayCircle className="icon" />
-                  <span className="sidebar-item-text">Workflows</span>
-                </SidebarLink>
-              )}
-              {capabilities.code && (
-                <SidebarLink selected={this.isCodeSelected()} href={Path.codePath} title="Code">
-                  <Code className="icon" />
-                  <span className="sidebar-item-text">Code</span>
-                </SidebarLink>
-              )}
-              <SidebarLink selected={this.isSetupSelected()} href={Path.setupPath} title="Quickstart">
-                <Terminal className="icon" />
-                <span className="sidebar-item-text">Quickstart</span>
-              </SidebarLink>
-
-              <SidebarLink selected={this.isSettingsSelected()} href={Path.settingsPath} title="Settings">
-                <Sliders className="icon" />
-                <span className="sidebar-item-text">Settings</span>
-              </SidebarLink>
-
-              {router.canAccessUsagePage(this.props.user) && (
-                <SidebarLink selected={this.isUsageSelected()} href={Path.usagePath} title="Usage">
-                  <Gauge className="icon" />
-                  <span className="sidebar-item-text">Usage</span>
-                </SidebarLink>
-              )}
-              {router.canAccessAuditLogsPage(this.props.user) && capabilities.config.auditLogsUiEnabled && (
-                <SidebarLink selected={this.isAuditLogsSelected()} href={Path.auditLogsPath}>
-                  <Fingerprint className="icon" />
-                  <span className="sidebar-item-text">Audit logs</span>
-                </SidebarLink>
-              )}
-            </>
+          <SidebarLink selected={this.isHomeSelected()} href={Path.home} title="All builds">
+            <List className="icon" />
+            <span className="sidebar-item-text">All builds</span>
+          </SidebarLink>
+          <SidebarLink selected={this.isTrendsSelected()} href={Path.trendsPath} title="Trends">
+            <BarChart2 className="icon" />
+            <span className="sidebar-item-text">Trends</span>
+          </SidebarLink>
+          {capabilities.test && (
+            <SidebarLink selected={this.isTapSelected()} href={Path.tapPath} title="Tests">
+              <LayoutGrid className="icon" />
+              <span className="sidebar-item-text">Tests</span>
+            </SidebarLink>
           )}
-          {/*
-           * Sidebar items below will be visible even if the user does not have access to the selected group.
-           */}
+          <SidebarLink selected={this.isUsersSelected()} href="/#users" title="Users">
+            <Users className="icon" />
+            <span className="sidebar-item-text">Users</span>
+          </SidebarLink>
+          <SidebarLink selected={this.isReposSelected()} href="/#repos" title="Repos">
+            <Github className="icon" />
+            <span className="sidebar-item-text">Repos</span>
+          </SidebarLink>
+          <SidebarLink selected={this.isBranchesSelected()} href="/#branches" title="Branches">
+            <GitBranch className="icon" />
+            <span className="sidebar-item-text">Branches</span>
+          </SidebarLink>
+          <SidebarLink selected={this.isCommitsSelected()} href="/#commits" title="Commits">
+            <GitCommit className="icon" />
+            <span className="sidebar-item-text">Commits</span>
+          </SidebarLink>
+          <SidebarLink selected={this.isHostsSelected()} href="/#hosts" title="Hosts">
+            <HardDrive className="icon" />
+            <span className="sidebar-item-text">Hosts</span>
+          </SidebarLink>
+          {router.canAccessExecutorsPage(this.props.user) && (
+            <SidebarLink selected={this.isExecutorsSelected()} href={Path.executorsPath} title="Executors">
+              <Cloud className="icon" />
+              <span className="sidebar-item-text">Executors</span>
+            </SidebarLink>
+          )}
+          {router.canAccessWorkflowsPage(this.props.user) && (
+            <SidebarLink selected={this.isWorkflowsSelected()} href={Path.workflowsPath} title="Workflows">
+              <PlayCircle className="icon" />
+              <span className="sidebar-item-text">Workflows</span>
+            </SidebarLink>
+          )}
+          {capabilities.code && (
+            <SidebarLink selected={this.isCodeSelected()} href={Path.codePath} title="Code">
+              <Code className="icon" />
+              <span className="sidebar-item-text">Code</span>
+            </SidebarLink>
+          )}
+          <SidebarLink selected={this.isSetupSelected()} href={Path.setupPath} title="Quickstart">
+            <Terminal className="icon" />
+            <span className="sidebar-item-text">Quickstart</span>
+          </SidebarLink>
+
+          <SidebarLink selected={this.isSettingsSelected()} href={Path.settingsPath} title="Settings">
+            <Sliders className="icon" />
+            <span className="sidebar-item-text">Settings</span>
+          </SidebarLink>
+
+          {router.canAccessUsagePage(this.props.user) && (
+            <SidebarLink selected={this.isUsageSelected()} href={Path.usagePath} title="Usage">
+              <Gauge className="icon" />
+              <span className="sidebar-item-text">Usage</span>
+            </SidebarLink>
+          )}
+          {router.canAccessAuditLogsPage(this.props.user) && capabilities.config.auditLogsUiEnabled && (
+            <SidebarLink selected={this.isAuditLogsSelected()} href={Path.auditLogsPath}>
+              <Fingerprint className="icon" />
+              <span className="sidebar-item-text">Audit logs</span>
+            </SidebarLink>
+          )}
           <a className="sidebar-item" href="https://www.buildbuddy.io/docs/" target="_blank" title="Docs">
             <BookOpen className="icon" />
             <span className="sidebar-item-text">Docs</span>

--- a/proto/user.proto
+++ b/proto/user.proto
@@ -12,6 +12,18 @@ message GetUserRequest {
   user_id.UserId user_id = 1;
 }
 
+message SelectedGroup {
+  string group_id = 1;
+
+  enum Access {
+    UNKNOWN = 0;
+    ALLOWED = 1;
+    DENIED = 2;
+    DENIED_BY_IP_RULES = 3;
+  }
+  Access access = 2;
+}
+
 message GetUserResponse {
   reserved 5;
 
@@ -22,14 +34,18 @@ message GetUserResponse {
   // The groups this user is a member of.
   repeated grp.Group user_group = 2;
 
-  // The ID of the user's currently selected group to be displayed in the UI.
+  // Deprecated, use selected_group instead.
+  string selected_group_id = 3 [deprecated = true];
+
+  // Information about the user's currently selected group to be displayed in
+  // the UI.
   //
   // In most cases, this will match the group_id in the original request
   // context, which should be populated from client preferences. However, if the
   // user no longer has access to the group or if no group_id was set, this will
   // be set to one of the group IDs in user_group as a fallback. If user_group
   // is empty, this will also be empty.
-  string selected_group_id = 3;
+  SelectedGroup selected_group = 9;
 
   // List of BuildBuddyService RPC names that the user is allowed to perform
   // for their currently selected group.


### PR DESCRIPTION
Use it to communicate if the user has selected a group that they have access to but cannot access due to IP rules. Also use the same mechanism for communicating subdomain access issues.

Update UI to show a minimal sidebar if user doesn't have access to the selceted group so that the user still has access to the group switcher.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
