### PR TITLE
frontend code for sub-day trends intervals.

### DIFF
--- a/enterprise/app/trends/BUILD
+++ b/enterprise/app/trends/BUILD
@@ -23,8 +23,10 @@ ts_library(
         "//enterprise/app/trends:summary_card",
         "//enterprise/app/trends:trends_chart",
         "//proto:stats_ts_proto",
+        "@npm//@types/long",
         "@npm//@types/moment",
         "@npm//@types/react",
+        "@npm//long",
         "@npm//moment",
         "@npm//react",
         "@npm//rxjs",
@@ -39,7 +41,7 @@ ts_library(
         "//proto:stats_ts_proto",
         "@npm//@types/d3-time",
         "@npm//d3-time",
-    ]
+    ],
 )
 
 ts_library(
@@ -57,6 +59,7 @@ ts_library(
         "//enterprise/app/trends:trends_chart",
         "//enterprise/app/trends:trends_model",
         "//enterprise/app/trends:trends_requests",
+        "//proto:stats_ts_proto",
         "@npm//@types/moment",
         "@npm//@types/react",
         "@npm//moment",
@@ -89,6 +92,8 @@ ts_library(
         "//app/util:proto",
         "//enterprise/app/trends:common",
         "//proto:stats_ts_proto",
+        "@npm//@types/long",
+        "@npm//long",
     ],
 )
 

--- a/enterprise/app/trends/BUILD
+++ b/enterprise/app/trends/BUILD
@@ -17,15 +17,14 @@ ts_library(
         "//enterprise/app/filter",
         "//enterprise/app/filter:filter_util",
         "//enterprise/app/trends:cache_chart",
+        "//enterprise/app/trends:common",
         "//enterprise/app/trends:drilldown_page",
         "//enterprise/app/trends:percentile_chart",
         "//enterprise/app/trends:summary_card",
         "//enterprise/app/trends:trends_chart",
         "//proto:stats_ts_proto",
-        "@npm//@types/d3-time",
         "@npm//@types/moment",
         "@npm//@types/react",
-        "@npm//d3-time",
         "@npm//moment",
         "@npm//react",
         "@npm//rxjs",
@@ -36,6 +35,11 @@ ts_library(
 ts_library(
     name = "common",
     srcs = ["common.ts"],
+    deps = [
+        "//proto:stats_ts_proto",
+        "@npm//@types/d3-time",
+        "@npm//d3-time",
+    ]
 )
 
 ts_library(
@@ -83,9 +87,8 @@ ts_library(
     srcs = ["trends_model.ts"],
     deps = [
         "//app/util:proto",
+        "//enterprise/app/trends:common",
         "//proto:stats_ts_proto",
-        "@npm//@types/d3-time",
-        "@npm//d3-time",
     ],
 )
 

--- a/enterprise/app/trends/cache_chart.tsx
+++ b/enterprise/app/trends/cache_chart.tsx
@@ -17,6 +17,7 @@ interface Props {
   title: string;
   id?: string;
   data: number[];
+  ticks: number[];
   secondaryBarName: string;
   extractLabel: (datum: number) => string;
   formatHoverLabel: (datum: number) => string;
@@ -68,7 +69,7 @@ export default class CacheChartComponent extends React.Component<Props> {
           <ComposedChart data={this.props.data}>
             <CartesianGrid strokeDasharray="3 3" />
             <Legend />
-            <XAxis dataKey={(v) => v} tickFormatter={this.props.extractLabel} ticks={this.props.data} />
+            <XAxis dataKey={(v) => v} tickFormatter={this.props.extractLabel} ticks={this.props.ticks} />
             <YAxis yAxisId="hits" tickFormatter={format.count} allowDecimals={false} />
             <YAxis
               domain={[0, 100]}

--- a/enterprise/app/trends/common.ts
+++ b/enterprise/app/trends/common.ts
@@ -1,4 +1,7 @@
-enum TrendsTab {
+import { stats } from "../../../proto/stats_ts_proto";
+import { timeHour, timeDay, timeMinute } from "d3-time";
+
+export enum TrendsTab {
   OVERVIEW,
   BUILDS,
   CACHE,
@@ -6,4 +9,44 @@ enum TrendsTab {
   DRILLDOWN,
 }
 
-export default TrendsTab;
+export function computeTimeKeys(
+  interval: stats.StatsInterval | null | undefined,
+  domain: [Date, Date]
+): { timeKeys: number[]; ticks: number[] } {
+  // XXX: Read step from RPC response instead.
+  if (!interval) {
+    // Just let recharts pick the days to render.
+    return { timeKeys: timeDay.range(timeDay.floor(domain[0]), domain[1]).map((v) => v.getTime()), ticks: [] };
+  } else if (interval.type == stats.IntervalType.INTERVAL_TYPE_HOUR) {
+    let hourMultiple = Math.floor(domain[0].getHours() / +interval.count);
+    domain[0].setHours(hourMultiple * +interval.count);
+    domain[0].setMinutes(0);
+    const keyDates = timeHour.range(domain[0], domain[1], +interval.count);
+    const hourMods = [24, 12, 6, 3, 1];
+    let ticks: number[] = [];
+    for (let i = 0; i < hourMods.length; i++) {
+      ticks = keyDates.filter((d) => d.getHours() % hourMods[i] === 0 && d.getMinutes() == 0).map((v) => v.getTime());
+      if (ticks.length >= 4) {
+        break;
+      }
+    }
+    return { timeKeys: keyDates.map((v) => v.getTime()), ticks };
+  } else if (interval.type == stats.IntervalType.INTERVAL_TYPE_MINUTE) {
+    let minuteMultiple = Math.floor(domain[0].getMinutes() / +interval.count);
+    domain[0].setMinutes(minuteMultiple * +interval.count);
+
+    const keyDates = timeMinute.range(domain[0], domain[1], +interval.count);
+    const minuteMods = [720, 360, 180, 60, 30];
+    let ticks: number[] = [];
+    for (let i = 0; i < minuteMods.length; i++) {
+      ticks = keyDates
+        .filter((d) => (d.getHours() * 60 + d.getMinutes()) % minuteMods[i] === 0)
+        .map((v) => v.getTime());
+      if (ticks.length >= 4) {
+        break;
+      }
+    }
+    return { timeKeys: keyDates.map((v) => v.getTime()), ticks };
+  }
+  return { timeKeys: timeDay.range(timeDay.floor(domain[0]), domain[1]).map((v) => v.getTime()), ticks: [] };
+}

--- a/enterprise/app/trends/common.ts
+++ b/enterprise/app/trends/common.ts
@@ -13,15 +13,24 @@ export function computeTimeKeys(
   interval: stats.StatsInterval | null | undefined,
   domain: [Date, Date]
 ): { timeKeys: number[]; ticks: number[] } {
-  // XXX: Read step from RPC response instead.
   if (!interval) {
     // Just let recharts pick the days to render.
     return { timeKeys: timeDay.range(timeDay.floor(domain[0]), domain[1]).map((v) => v.getTime()), ticks: [] };
   } else if (interval.type == stats.IntervalType.INTERVAL_TYPE_HOUR) {
-    let hourMultiple = Math.floor(domain[0].getHours() / +interval.count);
+    // First, round down to the nearest interval in the local time.
+    // For example, for a 2-hour interval, this will round 3:30 to 2:00.
+    const hourMultiple = Math.floor(domain[0].getHours() / +interval.count);
     domain[0].setHours(hourMultiple * +interval.count);
     domain[0].setMinutes(0);
+
+    // These are the keys that we expect to have data for in the graph.
     const keyDates = timeHour.range(domain[0], domain[1], +interval.count);
+
+    // We can't show too many ticks on the graph, and recharts does a bad
+    // job with selecting ticks (for example, it might always pick noon
+    // instead of midnight).  So we progressively search through "good"
+    // intervals (midnight, midnight+noon, 0-6-12-18, etc.) until we find
+    // a tick gap that gives us at least 4 ticks in the graph.
     const hourMods = [24, 12, 6, 3, 1];
     let ticks: number[] = [];
     for (let i = 0; i < hourMods.length; i++) {
@@ -32,10 +41,19 @@ export function computeTimeKeys(
     }
     return { timeKeys: keyDates.map((v) => v.getTime()), ticks };
   } else if (interval.type == stats.IntervalType.INTERVAL_TYPE_MINUTE) {
-    let minuteMultiple = Math.floor(domain[0].getMinutes() / +interval.count);
+    // First, round down to the nearest interval in the local time.
+    // For example, for a 15-minute interval, this will round 3:53 to 3:45.
+    const minuteMultiple = Math.floor(domain[0].getMinutes() / +interval.count);
     domain[0].setMinutes(minuteMultiple * +interval.count);
 
+    // These are the keys that we expect to have data for in the graph.
     const keyDates = timeMinute.range(domain[0], domain[1], +interval.count);
+
+    // We can't show too many ticks on the graph, and recharts does a bad
+    // job with selecting ticks (for example, it might always pick noon
+    // instead of midnight).  So we progressively search through "good"
+    // intervals (midnight, midnight+noon, 0-6-12-18, etc.) until we find
+    // a tick gap that gives us at least 4 ticks in the graph.
     const minuteMods = [720, 360, 180, 60, 30];
     let ticks: number[] = [];
     for (let i = 0; i < minuteMods.length; i++) {

--- a/enterprise/app/trends/common.ts
+++ b/enterprise/app/trends/common.ts
@@ -50,9 +50,9 @@ export function computeTimeKeys(
     const keyDates = timeMinute.range(domain[0], domain[1], +interval.count);
 
     // We can't show too many ticks on the graph, and recharts does a bad
-    // job with selecting ticks (for example, it might always pick noon
+    // job with selecting ticks (for example, it might always pick 12:30
     // instead of midnight).  So we progressively search through "good"
-    // intervals (midnight, midnight+noon, 0-6-12-18, etc.) until we find
+    // intervals (12 hours, 6h, 3h, 1h, 30 minutes) until we find
     // a tick gap that gives us at least 4 ticks in the graph.
     const minuteMods = [720, 360, 180, 60, 30];
     let ticks: number[] = [];

--- a/enterprise/app/trends/new_trends.tsx
+++ b/enterprise/app/trends/new_trends.tsx
@@ -4,7 +4,7 @@ import FilterComponent from "../filter/filter";
 import capabilities from "../../../app/capabilities/capabilities";
 import DrilldownPageComponent from "./drilldown_page";
 import TrendsModel from "./trends_model";
-import TrendsTab from "./common";
+import { TrendsTab } from "./common";
 import SimpleTrendsTabComponent from "./simple_trends_tab";
 import { TrendsRpcCache } from "./trends_requests";
 

--- a/enterprise/app/trends/percentile_chart.tsx
+++ b/enterprise/app/trends/percentile_chart.tsx
@@ -17,6 +17,7 @@ export interface PercentilesChartProps {
   title: string;
   id?: string;
   data: number[];
+  ticks: number[];
   extractLabel: (datum: number) => string;
   formatHoverLabel: (datum: number) => string;
   extractP50: (datum: number) => number;
@@ -48,7 +49,7 @@ export default class PercentilesChartComponent extends React.Component<Percentil
             onClick={this.handleRowClick.bind(this)}>
             <CartesianGrid strokeDasharray="3 3" />
             <Legend />
-            <XAxis dataKey={(v) => v} tickFormatter={this.props.extractLabel} ticks={this.props.data} />
+            <XAxis dataKey={(v) => v} tickFormatter={this.props.extractLabel} ticks={this.props.ticks} />
             <YAxis yAxisId="duration" tickFormatter={format.durationSec} allowDecimals={false} width={84} />
             <Tooltip
               content={

--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -16,6 +16,7 @@ import router from "../../../app/router/router";
 import * as proto from "../../../app/util/proto";
 import DrilldownPageComponent from "./drilldown_page";
 import { computeTimeKeys } from "./common";
+import Long from "long";
 
 const BITS_PER_BYTE = 8;
 
@@ -173,14 +174,18 @@ export default class TrendsComponent extends React.Component<Props, State> {
         request.query!.updatedBefore ? proto.timestampToDate(request.query!.updatedBefore) : new Date(),
       ];
 
+      const interval =
+        response.interval ??
+        stats.StatsInterval.create({ type: stats.IntervalType.INTERVAL_TYPE_DAY, count: Long.fromNumber(1) });
+
       this.setState({
         stats: response.trendStat,
-        ...computeTimeKeys(response.interval, domain),
+        ...computeTimeKeys(interval, domain),
         currentSummary: response.currentSummary || undefined,
         previousSummary: response.previousSummary || undefined,
         timeToStatMap,
         timeToExecutionStatMap,
-        interval: response.interval ? response.interval.type : stats.IntervalType.INTERVAL_TYPE_DAY,
+        interval: interval.type,
         enableInvocationPercentileCharts: response.hasInvocationStatPercentiles,
         loading: false,
       });

--- a/enterprise/app/trends/trends_chart.tsx
+++ b/enterprise/app/trends/trends_chart.tsx
@@ -17,6 +17,7 @@ import {
 interface Props {
   title: string;
   data: number[];
+  ticks: number[];
   id?: string;
 
   extractLabel: (datum: number) => string;
@@ -84,7 +85,7 @@ export default class TrendsChartComponent extends React.Component<Props> {
           <ComposedChart data={this.props.data}>
             <CartesianGrid strokeDasharray="3 3" />
             <Legend />
-            <XAxis dataKey={(v) => v} tickFormatter={this.props.extractLabel} ticks={this.props.data} />
+            <XAxis dataKey={(v) => v} tickFormatter={this.props.extractLabel} ticks={this.props.ticks} />
             <YAxis
               yAxisId="primary"
               tickFormatter={this.props.formatTickValue}

--- a/enterprise/app/trends/trends_model.ts
+++ b/enterprise/app/trends/trends_model.ts
@@ -1,6 +1,6 @@
 import { timestampToDate } from "../../../app/util/proto";
 import { stats } from "../../../proto/stats_ts_proto";
-import { timeHour, timeDay } from "d3-time";
+import { computeTimeKeys } from "./common";
 
 /**
  * This is a shared model class for "trends" data, which currently just means
@@ -17,6 +17,7 @@ export default class TrendsModel {
   private error?: string;
   private data: stats.GetTrendResponse;
   private timeKeys: number[];
+  private ticks: number[];
   private timeToStatMap: Map<number, stats.ITrendStat>;
   private timeToExecutionStatMap: Map<number, stats.IExecutionStat>;
 
@@ -32,19 +33,26 @@ export default class TrendsModel {
         // End date may not be defined -- default to today.
         request?.query?.updatedBefore ? timestampToDate(request.query.updatedBefore) : new Date(),
       ];
-      this.timeKeys = computeTimeKeys(domain);
+      const computed = computeTimeKeys(this.data.interval, domain);
+      this.timeKeys = computed.timeKeys;
+      this.ticks = computed.ticks;
     } else {
       this.timeKeys = [];
+      this.ticks = [];
     }
 
     this.timeToStatMap = new Map<number, stats.ITrendStat>();
     for (let stat of response?.trendStat ?? []) {
-      const time = new Date(stat.name + " 00:00").getTime();
+      const time = stat.bucketStartTimeMicros
+        ? +stat.bucketStartTimeMicros / 1000
+        : new Date(stat.name + " 00:00").getTime();
       this.timeToStatMap.set(time, stat);
     }
     this.timeToExecutionStatMap = new Map<number, stats.IExecutionStat>();
     for (let stat of response?.executionStat ?? []) {
-      const time = new Date(stat.name + " 00:00").getTime();
+      const time = stat.bucketStartTimeMicros
+        ? +stat.bucketStartTimeMicros / 1000
+        : new Date(stat.name + " 00:00").getTime();
       this.timeToExecutionStatMap.set(time, stat);
     }
   }
@@ -73,6 +81,14 @@ export default class TrendsModel {
     return this.timeKeys;
   }
 
+  public getTicks() {
+    return this.ticks;
+  }
+
+  public getInterval() {
+    return this.data.interval ?? stats.IntervalType.INTERVAL_TYPE_DAY;
+  }
+
   public getCurrentSummary() {
     return this.data.currentSummary;
   }
@@ -91,14 +107,5 @@ export default class TrendsModel {
 
   public getError() {
     return this.error;
-  }
-}
-
-// TODO(jdhollen): support specifying a mod to skip specific ticks
-function computeTimeKeys(domain: [Date, Date]): number[] {
-  if (domain[1].getTime() - domain[0].getTime() > 1000 * 60 * 60 * 48) {
-    return timeDay.range(timeDay.floor(domain[0]), domain[1]).map((d: Date) => d.getTime());
-  } else {
-    return timeHour.range(timeHour.floor(domain[0]), domain[1]).map((d: Date) => d.getTime());
   }
 }

--- a/enterprise/app/trends/trends_model.ts
+++ b/enterprise/app/trends/trends_model.ts
@@ -1,3 +1,4 @@
+import Long from "long";
 import { timestampToDate } from "../../../app/util/proto";
 import { stats } from "../../../proto/stats_ts_proto";
 import { computeTimeKeys } from "./common";
@@ -33,7 +34,11 @@ export default class TrendsModel {
         // End date may not be defined -- default to today.
         request?.query?.updatedBefore ? timestampToDate(request.query.updatedBefore) : new Date(),
       ];
-      const computed = computeTimeKeys(this.data.interval, domain);
+      const interval =
+        this.data.interval ??
+        stats.StatsInterval.create({ type: stats.IntervalType.INTERVAL_TYPE_DAY, count: Long.fromNumber(1) });
+
+      const computed = computeTimeKeys(interval, domain);
       this.timeKeys = computed.timeKeys;
       this.ticks = computed.ticks;
     } else {
@@ -86,7 +91,7 @@ export default class TrendsModel {
   }
 
   public getInterval() {
-    return this.data.interval ?? stats.IntervalType.INTERVAL_TYPE_DAY;
+    return this.data.interval || stats.IntervalType.INTERVAL_TYPE_DAY;
   }
 
   public getCurrentSummary() {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
Still some changes to make clicks work for sub-day values, etc., but despite all appearances this is intended to have no visible effect in prod.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
