### PR TITLE
Support subdirectory templates in repo flow

### DIFF
--- a/enterprise/app/repo/repo.tsx
+++ b/enterprise/app/repo/repo.tsx
@@ -31,6 +31,7 @@ interface RepoComponentState {
 
   repoName: string;
   template: string;
+  templateDirectory: string;
   private: boolean;
   secrets: Map<string, string>;
 
@@ -50,6 +51,7 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
     isDeploying: false,
 
     template: this.getTemplate(),
+    templateDirectory: this.getTemplateDirectory(),
     repoName: this.getRepoName(),
     private: true,
     secrets: new Map<string, string>(),
@@ -70,6 +72,10 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
       return referrer;
     }
     return "";
+  }
+
+  getTemplateDirectory() {
+    return this.props.search.get("dir") || "";
   }
 
   getRepoName() {
@@ -172,6 +178,7 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
     r.name = this.state.repoName;
     r.private = this.state.private;
     r.template = this.state.template;
+    r.templateDirectory = this.state.templateDirectory;
 
     if (selectedInstallation?.targetType == "Organization") {
       r.installationId = selectedInstallation.id;

--- a/enterprise/server/githubapp/BUILD
+++ b/enterprise/server/githubapp/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//server/util/status",
         "@com_github_go_git_go_git_v5//:go-git",
         "@com_github_go_git_go_git_v5//config",
+        "@com_github_go_git_go_git_v5//plumbing/object",
         "@com_github_go_git_go_git_v5//plumbing/transport/http",
         "@com_github_golang_jwt_jwt//:jwt",
         "@com_github_google_go_github_v43//github",

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -656,7 +656,7 @@ func (a *GitHubApp) CreateRepo(ctx context.Context, req *rppb.CreateRepoRequest)
 }
 
 // TODO(siggisim): consider moving template cloning to a remote action if it causes us troubles doing this on apps.
-func cloneTemplate(email, tmpDirName, token, srcURL, destURL, srcDir string) error {	
+func cloneTemplate(email, tmpDirName, token, srcURL, destURL, srcDir string) error {
 	// Make a temporary directory for the template
 	tmpDir, err := scratchspace.MkdirTemp(tmpDirName)
 	if err != nil {
@@ -705,7 +705,7 @@ func cloneTemplate(email, tmpDirName, token, srcURL, destURL, srcDir string) err
 	}
 	_, err = gitWorkTree.Commit("Initial commit", &git.CommitOptions{All: true, Author: &gitobject.Signature{
 		Email: email,
-		When: time.Now(),
+		When:  time.Now(),
 	}})
 	if err != nil {
 		return err

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -37,6 +39,7 @@ import (
 	wfpb "github.com/buildbuddy-io/buildbuddy/proto/workflow"
 	gh_oauth "github.com/buildbuddy-io/buildbuddy/server/backends/github"
 	gitutil "github.com/buildbuddy-io/buildbuddy/server/util/git"
+	gitobject "github.com/go-git/go-git/v5/plumbing/object"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
@@ -48,6 +51,8 @@ var (
 	publicLink    = flag.String("github.app.public_link", "", "GitHub app installation URL.")
 	privateKey    = flagutil.New("github.app.private_key", "", "GitHub app private key.", flagutil.SecretTag)
 	webhookSecret = flagutil.New("github.app.webhook_secret", "", "GitHub app webhook secret used to verify that webhook payload contents were sent by GitHub.", flagutil.SecretTag)
+
+	validPathRegex = regexp.MustCompile(`^[a-zA-Z0-9/]*$`)
 )
 
 const (
@@ -626,7 +631,7 @@ func (a *GitHubApp) CreateRepo(ctx context.Context, req *rppb.CreateRepoRequest)
 	// If we have a template, copy the template contents to the new repo
 	if req.Template != "" {
 		tmpDirName := fmt.Sprintf("template-repo-%d-%s-*", req.InstallationId, req.Name)
-		err = cloneTemplate(tmpDirName, token, req.Template, *repo.CloneURL)
+		err = cloneTemplate(tu.Email, tmpDirName, token, req.Template, *repo.CloneURL, req.TemplateDirectory)
 		if err != nil {
 			return nil, err
 		}
@@ -651,7 +656,7 @@ func (a *GitHubApp) CreateRepo(ctx context.Context, req *rppb.CreateRepoRequest)
 }
 
 // TODO(siggisim): consider moving template cloning to a remote action if it causes us troubles doing this on apps.
-func cloneTemplate(tmpDirName, token, srcURL, destURL string) error {
+func cloneTemplate(email, tmpDirName, token, srcURL, destURL, srcDir string) error {	
 	// Make a temporary directory for the template
 	tmpDir, err := scratchspace.MkdirTemp(tmpDirName)
 	if err != nil {
@@ -664,24 +669,58 @@ func cloneTemplate(tmpDirName, token, srcURL, destURL string) error {
 		Username: "github",
 		Password: token,
 	}
-	gitRepo, err := git.PlainClone(tmpDir, false, &git.CloneOptions{
+
+	_, err = git.PlainClone(tmpDir, false, &git.CloneOptions{
 		URL:  srcURL,
 		Auth: auth,
 	})
 	if err != nil {
 		return err
 	}
+	// Remove existing git information so we can create a single initial commit
+	err = os.RemoveAll(filepath.Join(tmpDir, ".git"))
+	if err != nil {
+		return err
+	}
+	// Don't allow paths with dots or other non alphanumeric path components
+	if !validPathRegex.MatchString(srcDir) {
+		return status.FailedPreconditionErrorf("invalid template path: %q", srcDir)
+	}
+	path := filepath.Join(tmpDir, srcDir)
+	// Intentionally using Lstat to avoid following symlinks
+	if fileInfo, err := os.Lstat(path); err != nil || !fileInfo.IsDir() {
+		return status.FailedPreconditionErrorf("not a valid directory: %q", srcDir)
+	}
+	gitRepo, err := git.PlainInit(path, false)
+	if err != nil {
+		return err
+	}
+	gitWorkTree, err := gitRepo.Worktree()
+	if err != nil {
+		return err
+	}
+	_, err = gitWorkTree.Add(".")
+	if err != nil {
+		return err
+	}
+	_, err = gitWorkTree.Commit("Initial commit", &git.CommitOptions{All: true, Author: &gitobject.Signature{
+		Email: email,
+		When: time.Now(),
+	}})
+	if err != nil {
+		return err
+	}
 
 	// Create a new remote and push to it
 	remote, err := gitRepo.CreateRemote(&config.RemoteConfig{
-		Name: "new-repo",
+		Name: "origin",
 		URLs: []string{destURL},
 	})
 	if err != nil {
 		return err
 	}
 	return remote.Push(&git.PushOptions{
-		RemoteName: "new-repo",
+		RemoteName: "origin",
 		Auth:       auth,
 		Force:      true,
 	})

--- a/proto/repo.proto
+++ b/proto/repo.proto
@@ -26,6 +26,10 @@ message CreateRepoRequest {
   // "https://github.com/buildbuddy-io/go-typescript-starter-template.git"
   string template = 5;
 
+  // An optional subdirectory within the template repo to use a the template.
+  // If unset, the root of the template repo will be used.
+  string template_directory = 9;
+
   // If true, the repository will be created as a private repo.
   bool private = 6;
 


### PR DESCRIPTION
Also squashes template commit history into a single commit, so as not to clutter the git history of the newly created repo.