### PR TITLE
Add Language interface used for WORKSPACE generation

### DIFF
--- a/cli/fix/BUILD
+++ b/cli/fix/BUILD
@@ -49,4 +49,11 @@ go_library(
     ],
 )
 
+go_library(
+    name = "language",
+    srcs = ["language.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/fix/language",
+    visibility = ["//visibility:public"],
+)
+
 package(default_visibility = ["//cli:__subpackages__"])

--- a/cli/fix/golang/BUILD
+++ b/cli/fix/golang/BUILD
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "golang",
+    srcs = ["golang.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/fix/golang",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cli/log",
+        "@bazel_gazelle//language:go_default_library",
+        "@bazel_gazelle//language/go:go_default_library",
+    ],
+)
+
+package(default_visibility = ["//cli:__subpackages__"])

--- a/cli/fix/golang/golang.go
+++ b/cli/fix/golang/golang.go
@@ -13,13 +13,13 @@ import (
 
 const (
 	goFileExtensions = ".go"
-	goModFileName = "go.mod"
-	goWorkFileName = "go.work"
+	goModFileName    = "go.mod"
+	goWorkFileName   = "go.work"
 
 	// TODO(siggisim): Make these configurable or infer them from the repo
-	defaultGoVersion = "1.20"
-	defaultRulesGoVersion = "0.36.0"
-	defaultGazelleVersion = "0.26.0"
+	defaultGoVersion         = "1.20"
+	defaultRulesGoVersion    = "0.36.0"
+	defaultGazelleVersion    = "0.26.0"
 	defaultRulesProtoVersion = "5.3.0-21.7"
 )
 
@@ -42,9 +42,9 @@ func NewLanguage() language.Language {
 
 func (g *Golang) Deps() []string {
 	return []string{
-		"github/bazelbuild/rules_go@"+defaultRulesGoVersion,
-		"github/bazelbuild/bazel-gazelle@"+defaultGazelleVersion,
-		"github/bazelbuild/rules_proto@"+defaultRulesProtoVersion,
+		"github/bazelbuild/rules_go@" + defaultRulesGoVersion,
+		"github/bazelbuild/bazel-gazelle@" + defaultGazelleVersion,
+		"github/bazelbuild/rules_proto@" + defaultRulesProtoVersion,
 	}
 }
 
@@ -63,7 +63,7 @@ func (g *Golang) ConsolidateDepFiles(deps map[string][]string) map[string][]stri
 		return deps
 	}
 	if foundGoModFiles && len(goModFiles) > 1 {
-		goWorkContents := "go "+defaultGoVersion+"\n"
+		goWorkContents := "go " + defaultGoVersion + "\n"
 		for _, m := range goModFiles {
 			goWorkContents += "use ./" + path.Dir(m) + "\n"
 		}

--- a/cli/fix/golang/golang.go
+++ b/cli/fix/golang/golang.go
@@ -1,0 +1,80 @@
+package golang
+
+import (
+	"os"
+	"path"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/buildbuddy-io/buildbuddy/cli/log"
+
+	gazelleGolang "github.com/bazelbuild/bazel-gazelle/language/go"
+)
+
+const (
+	goFileExtensions = ".go"
+	goModFileName = "go.mod"
+	goWorkFileName = "go.work"
+
+	// TODO(siggisim): Make these configurable or infer them from the repo
+	defaultGoVersion = "1.20"
+	defaultRulesGoVersion = "0.36.0"
+	defaultGazelleVersion = "0.26.0"
+	defaultRulesProtoVersion = "5.3.0-21.7"
+)
+
+type Golang struct {
+	language.Language
+	language.RepoImporter
+	language.ModuleAwareLanguage
+}
+
+func NewLanguage() language.Language {
+	l := gazelleGolang.NewLanguage()
+	ri := l.(language.RepoImporter)
+	mal := l.(language.ModuleAwareLanguage)
+	return &Golang{
+		Language:            l,
+		RepoImporter:        ri,
+		ModuleAwareLanguage: mal,
+	}
+}
+
+func (g *Golang) Deps() []string {
+	return []string{
+		"github/bazelbuild/rules_go@"+defaultRulesGoVersion,
+		"github/bazelbuild/bazel-gazelle@"+defaultGazelleVersion,
+		"github/bazelbuild/rules_proto@"+defaultRulesProtoVersion,
+	}
+}
+
+func (g *Golang) IsSourceFile(path string) bool {
+	return strings.HasSuffix(path, goFileExtensions)
+}
+
+func (g *Golang) IsDepFile(path string) bool {
+	return strings.HasSuffix(path, goModFileName)
+}
+
+func (g *Golang) ConsolidateDepFiles(deps map[string][]string) map[string][]string {
+	goModFiles, foundGoModFiles := deps[goModFileName]
+	goWorkFiles, foundGoWorkFiles := deps[goWorkFileName]
+	if foundGoModFiles && len(goModFiles) == 1 {
+		return deps
+	}
+	if foundGoModFiles && len(goModFiles) > 1 {
+		goWorkContents := "go "+defaultGoVersion+"\n"
+		for _, m := range goModFiles {
+			goWorkContents += "use ./" + path.Dir(m) + "\n"
+		}
+		os.WriteFile(goWorkFileName, []byte(goWorkContents), 0777)
+		delete(deps, goModFileName)
+	}
+	if foundGoWorkFiles && len(goWorkFiles) > 1 {
+		log.Fatalf("Found multiple %s files, not sure what to do: %+v", goWorkFileName, goWorkFiles)
+	}
+	if foundGoWorkFiles {
+		delete(deps, goModFileName)
+	}
+	return deps
+}

--- a/cli/fix/language.go
+++ b/cli/fix/language.go
@@ -1,0 +1,12 @@
+package language
+
+type Language interface {
+	// Returns any WORKSPACE or MODULE dependencies needed for this language.
+	Deps() []string
+	// Returns true if the file is a source file written in this language.
+	IsSourceFile(path string) bool
+	// Returns true if the file is a dependency file used by this langugae.
+	IsDepFile(path string) bool
+	// Gives the language an opportunity to consolidate multiple dep files before update-repos is called.
+	ConsolidateDepFiles(deps map[string][]string) map[string][]string
+}


### PR DESCRIPTION
This interface includes extra methods for gazelle languages that can be used to automatically generate WORKSPACE / MODULE files for the language.

Included in this PR is an implementation of this interface for gazelle's built-in golang language implementation.