### PR TITLE
Fix 0 chunk error

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1897,6 +1897,12 @@ func (p *PebbleCache) newCDCCommitedWriteCloser(ctx context.Context, fileRecord 
 		}
 
 		if err := cdcw.chunker.Close(); err != nil {
+			// When there is an error when we close the chunker for example
+			// context cancelled, we want to wait the existing pebble cache
+			// writes to finish.
+			if egErr := cdcw.eg.Wait(); egErr != nil {
+				return egErr
+			}
 			return err
 		}
 		if err := cdcw.eg.Wait(); err != nil {

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1882,7 +1882,7 @@ func (p *PebbleCache) newCDCCommitedWriteCloser(ctx context.Context, fileRecord 
 		wc = decompressor
 	}
 
-	chunker, err := chunker.New(p.averageChunkSizeBytes, cdcw.writeChunk)
+	chunker, err := chunker.New(ctx, p.averageChunkSizeBytes, cdcw.writeChunk)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1955,10 +1955,10 @@ func (cdcw *cdcWriter) writeChunk(chunkData []byte) error {
 
 	if cdcw.numChunks == 2 {
 		cdcw.fileType = rfpb.FileMetadata_CHUNK_FILE_TYPE
-		// We no longer need the first chunk anymore.
 		if err := cdcw.writeChunkWhenMultiple(cdcw.firstChunk); err != nil {
 			return err
 		}
+		// We no longer need the first chunk anymore.
 		cdcw.firstChunk = nil
 	}
 	// we need to copy the data because once the chunker calls Next, chunkData
@@ -1972,7 +1972,6 @@ func (cdcw *cdcWriter) writeRawChunk(fileRecord *rfpb.FileRecord, key filestore.
 	ctx := cdcw.ctx
 	p := cdcw.pc
 	inlineWriter := p.fileStorer.InlineWriter(ctx, fileRecord.GetDigest().GetSizeBytes())
-
 	wcm, err := p.newWrappedWriter(ctx, inlineWriter, fileRecord, key, cdcw.shouldCompress || cdcw.isCompressed, cdcw.fileType)
 	if err != nil {
 		return err

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2046,7 +2046,7 @@ func (cdcw *cdcWriter) closeChunkerAndWait() error {
 }
 
 func (cdcw *cdcWriter) Close() error {
-	if cdcw.isChunkerClosed {
+	if !cdcw.isChunkerClosed {
 		return cdcw.closeChunkerAndWait()
 	}
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -984,6 +984,58 @@ func TestReadWrite(t *testing.T) {
 	}
 }
 
+func TestWriteCancel(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
+
+	maxSizeBytes := int64(1_000_000_000) // 1GB
+
+	type testCase struct {
+		desc                   string
+		maxInlineFileSizeBytes int64
+		averageChunkSizeBytes  int
+		testSize               int64
+	}
+	testCases := []testCase{
+		{
+			desc:                  "chunking turned on",
+			averageChunkSizeBytes: 64 * 4,
+			testSize:              256,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			options := &pebble_cache.Options{
+				RootDirectory:          testfs.MakeTempDir(t),
+				MaxSizeBytes:           maxSizeBytes,
+				AverageChunkSizeBytes:  tc.averageChunkSizeBytes,
+				MaxInlineFileSizeBytes: tc.maxInlineFileSizeBytes,
+			}
+			pc, err := pebble_cache.NewPebbleCache(te, options)
+			require.NoError(t, err)
+			err = pc.Start()
+			require.NoError(t, err)
+
+			ctx := getAnonContext(t, te)
+			ctx, cancel := context.WithCancel(ctx)
+			rn, buf := newCASResourceBuf(t, tc.testSize)
+			// Use Writer() to set the bytes in the cache.
+			wc, err := pc.Writer(ctx, rn)
+			require.NoError(t, err, "Error getting %q writer", rn.GetDigest().GetHash())
+			_, err = wc.Write(buf)
+			require.NoError(t, err)
+			cancel()
+			err = wc.Commit()
+			require.ErrorContains(t, err, "context canceled")
+			err = wc.Close()
+			require.NoError(t, err)
+
+			err = pc.Stop()
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestSizeLimit(t *testing.T) {
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -1026,7 +1026,7 @@ func TestWriteCancel(t *testing.T) {
 			require.NoError(t, err)
 			cancel()
 			err = wc.Commit()
-			require.ErrorContains(t, err, "context canceled")
+			require.NoError(t, err)
 			err = wc.Close()
 			require.NoError(t, err)
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Run the server locally with --@io_bazel_rules_go//go/config:race, turn on
cdc with pebble cache, and then run a build (e.g. //app/...)  against the local 
bb server triggers DATA RACE and 0 chunk errors

I added a test where we cancel the context before writing any data. It can reproduce both the data race and 0 chunk error. 
- Add mutex in `cdcWriter` to protect writtenChunks and numChunks.
- In commit, instead of calling `cdcw.Close()` we call `cdcw.chunker.Close()`. In `cdcw.Close()` we ignore the error from `cdcw.chunker.Close()`. It causes us to attempt to write 0 chunks if we cancel the context before any data is written. Returning `cdcw.chunker.Close()` in `cdcw.Close()` doesn't work because we call cdcw.Close() twice: once in CommitFn and once when we close the writer returned by pebble cache. The second time Close() will return a "context canceled" error.  