### PR TITLE
[Remote Snapshot] Simplify structure of snaploader and cow code

### DIFF
--- a/enterprise/server/remote_execution/blockio/BUILD
+++ b/enterprise/server/remote_execution/blockio/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
+        "//server/interfaces",
         "//server/remote_cache/digest",
         "//server/util/status",
         "@org_golang_x_exp//maps",

--- a/enterprise/server/remote_execution/blockio/BUILD
+++ b/enterprise/server/remote_execution/blockio/BUILD
@@ -6,6 +6,8 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/blockio",
     visibility = ["//visibility:public"],
     deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/remote_cache/digest",
         "//server/util/status",
         "@org_golang_x_exp//maps",
         "@org_golang_x_sys//unix",
@@ -19,6 +21,9 @@ go_test(
     srcs = ["blockio_test.go"],
     deps = [
         ":blockio",
+        "//proto:remote_execution_go_proto",
+        "//server/interfaces",
+        "//server/remote_cache/digest",
         "//server/testutil/testfs",
         "//server/util/disk",
         "@com_github_stretchr_testify//require",
@@ -38,6 +43,9 @@ go_test(
     tags = ["performance"],
     deps = [
         ":blockio",
+        "//proto:remote_execution_go_proto",
+        "//server/interfaces",
+        "//server/remote_cache/digest",
         "//server/testutil/testfs",
         "//server/util/disk",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/remote_execution/blockio/blockio_test.go
+++ b/enterprise/server/remote_execution/blockio/blockio_test.go
@@ -45,7 +45,7 @@ func TestMmap_Digest(t *testing.T) {
 	require.NoError(t, err)
 	actualDigest1, err := s.Digest()
 	require.NoError(t, err)
-	r, err := s.Reader()
+	r, err := interfaces.StoreReader(s)
 	require.NoError(t, err)
 	expectedDigest, err := digest.Compute(r, repb.DigestFunction_BLAKE3)
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestMmap_Digest(t *testing.T) {
 	require.Equal(t, len(randomBuf), n)
 	actualDigest2, err := s.Digest()
 	require.NoError(t, err)
-	r, err = s.Reader()
+	r, err = interfaces.StoreReader(s)
 	require.NoError(t, err)
 	expectedDigest, err = digest.Compute(r, repb.DigestFunction_BLAKE3)
 	require.NoError(t, err)
@@ -209,7 +209,7 @@ func TestCOW_Resize(t *testing.T) {
 				require.NoError(t, err)
 				// Now read back the whole COW and make sure it matches our
 				// expected data.
-				cowReader, err := cow.Reader()
+				cowReader, err := interfaces.StoreReader(cow)
 				require.NoError(t, err)
 				b, err := io.ReadAll(cowReader)
 				require.NoError(t, err)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -939,7 +939,7 @@ func (c *FirecrackerContainer) initRootfsStore(ctx context.Context) error {
 // cheap (just updates size metadata). Also note that this does not update the
 // ext4 superblock to be aware of the increased block device size - instead, the
 // guest does that by issuing an EXT4_IOC_RESIZE_FS syscall.
-func (c *FirecrackerContainer) resizeRootfs(ctx context.Context, cf *snaploader.ChunkedFile) error {
+func (c *FirecrackerContainer) resizeRootfs(ctx context.Context, cf *blockio.COWStore) error {
 	curSize, err := cf.SizeBytes()
 	if err != nil {
 		return status.WrapError(err, "get container image size")

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -393,12 +393,12 @@ type FirecrackerContainer struct {
 	// When NBD is enabled, this is the running NBD server that serves the VM
 	// disks.
 	nbdServer      *nbdserver.Server
-	scratchStore   *snaploader.ChunkedFile
-	rootStore      *snaploader.ChunkedFile
-	workspaceStore *snaploader.ChunkedFile
+	scratchStore   *blockio.COWStore
+	rootStore      *blockio.COWStore
+	workspaceStore *blockio.COWStore
 
 	uffdHandler *uffd.Handler
-	memoryStore *snaploader.ChunkedFile
+	memoryStore *blockio.COWStore
 
 	jailerRoot         string            // the root dir the jailer will work in
 	machine            *fcclient.Machine // the firecracker machine object.
@@ -527,7 +527,7 @@ func NewContainer(ctx context.Context, env environment.Env, imageCacheAuth *cont
 
 // MergeDiffSnapshot reads from diffSnapshotPath and writes all non-zero blocks
 // into the baseSnapshotPath file or the baseSnapshotStore if non-nil.
-func MergeDiffSnapshot(ctx context.Context, baseSnapshotPath string, baseSnapshotStore *snaploader.ChunkedFile, diffSnapshotPath string, concurrency int, bufSize int) error {
+func MergeDiffSnapshot(ctx context.Context, baseSnapshotPath string, baseSnapshotStore *blockio.COWStore, diffSnapshotPath string, concurrency int, bufSize int) error {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
@@ -716,7 +716,7 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 		VMStateSnapshotPath: filepath.Join(c.getChroot(), snapshotDetails.vmStateSnapshotName),
 		KernelImagePath:     kernelImagePath,
 		InitrdImagePath:     initrdImagePath,
-		ChunkedFiles:        map[string]*snaploader.ChunkedFile{},
+		ChunkedFiles:        map[string]*blockio.COWStore{},
 	}
 	if *enableNBD {
 		if c.rootStore != nil {
@@ -999,7 +999,7 @@ func (c *FirecrackerContainer) createWorkspaceImage(ctx context.Context, workspa
 	return nil
 }
 
-func (c *FirecrackerContainer) convertToCOW(ctx context.Context, filePath, chunkDir string) (*snaploader.ChunkedFile, error) {
+func (c *FirecrackerContainer) convertToCOW(ctx context.Context, filePath, chunkDir string) (*blockio.COWStore, error) {
 	start := time.Now()
 	if err := os.Mkdir(chunkDir, 0755); err != nil {
 		return nil, status.WrapError(err, "make chunk dir")
@@ -1015,7 +1015,7 @@ func (c *FirecrackerContainer) convertToCOW(ctx context.Context, filePath, chunk
 	}
 	size, _ := cow.SizeBytes()
 	log.CtxInfof(ctx, "COWStore conversion for %q (%d MB) completed in %s", filepath.Base(chunkDir), size/1e6, time.Since(start))
-	return &snaploader.ChunkedFile{COWStore: cow}, nil
+	return cow, nil
 }
 
 func cowChunkSizeBytes() int64 {
@@ -1456,7 +1456,7 @@ func (c *FirecrackerContainer) setupUFFDHandler(ctx context.Context) error {
 		return status.WrapError(err, "create uffd handler")
 	}
 	sockAbsPath := filepath.Join(c.getChroot(), uffdSockName)
-	if err := h.Start(ctx, sockAbsPath, c.memoryStore.COWStore); err != nil {
+	if err := h.Start(ctx, sockAbsPath, c.memoryStore); err != nil {
 		return status.WrapError(err, "start uffd handler")
 	}
 	c.uffdHandler = h

--- a/enterprise/server/remote_execution/nbd/nbdserver/nbdserver.go
+++ b/enterprise/server/remote_execution/nbd/nbdserver/nbdserver.go
@@ -18,13 +18,13 @@ import (
 // Device is a block store exported by a server along with its associated
 // metadata.
 type Device struct {
-	blockio.Store
+	*blockio.COWStore
 	Metadata *nbdpb.DeviceMetadata
 }
 
-func NewExt4Device(store blockio.Store, name string) (*Device, error) {
+func NewExt4Device(store *blockio.COWStore, name string) (*Device, error) {
 	return &Device{
-		Store: store,
+		COWStore: store,
 		Metadata: &nbdpb.DeviceMetadata{
 			Name:           name,
 			FilesystemType: nbdpb.FilesystemType_EXT4_FILESYSTEM_TYPE,

--- a/enterprise/server/remote_execution/nbd/nbdserver/nbdserver_test.go
+++ b/enterprise/server/remote_execution/nbd/nbdserver/nbdserver_test.go
@@ -25,13 +25,13 @@ func TestNBDServer(t *testing.T) {
 	path := filepath.Join(tmp, "f")
 	err := os.WriteFile(path, make([]byte, fileSizeBytes), 0644)
 	require.NoError(t, err)
-	f, err := blockio.NewMmap(path)
+	cow, err := blockio.ConvertFileToCOW(path, 200, tmp)
 	require.NoError(t, err)
-	defer f.Close()
+
 	// Create a server hosting a device backed by the file
 	const deviceName = "test"
 	dev := &nbdserver.Device{
-		Store:    f,
+		COWStore: cow,
 		Metadata: &nbdpb.DeviceMetadata{Name: deviceName},
 	}
 	s, err := nbdserver.New(ctx, env, dev)

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -33,6 +33,7 @@ go_test(
         "//enterprise/server/remote_execution/blockio",
         "//enterprise/server/remote_execution/filecache",
         "//proto:remote_execution_go_proto",
+        "//server/interfaces",
         "//server/testutil/testenv",
         "//server/testutil/testfs",
         "//server/util/random",

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -104,8 +104,8 @@ func TestPackAndUnpackChunkedFiles(t *testing.T) {
 	keyA, err := snaploader.NewKey(taskA, "config-hash-a", "")
 	require.NoError(t, err)
 	optsA := makeFakeSnapshot(t, workDirA)
-	optsA.ChunkedFiles = map[string]*snaploader.ChunkedFile{
-		"scratchfs": {COWStore: cowA},
+	optsA.ChunkedFiles = map[string]*blockio.COWStore{
+		"scratchfs": cowA,
 	}
 	snapA, err := loader.CacheSnapshot(ctx, keyA, optsA)
 	require.NoError(t, err)
@@ -129,7 +129,9 @@ func TestPackAndUnpackChunkedFiles(t *testing.T) {
 	// mustUnpack already verifies the contents against cowA, but this will give
 	// us false confidence if cowA was somehow mutated. So check again against
 	// the originally snapshotted bytes, rather than the original COW instance.
-	scratchfsBytesC, err := io.ReadAll(blockio.Reader(unpackedC.ChunkedFiles["scratchfs"]))
+	r, err := unpackedC.ChunkedFiles["scratchfs"].Reader()
+	require.NoError(t, err)
+	scratchfsBytesC, err := io.ReadAll(r)
 	require.NoError(t, err)
 	if !bytes.Equal(scratchfsBytesA, scratchfsBytesC) {
 		require.FailNow(t, "scratchfs bytes for VM C should match original contents from snapshot A")
@@ -152,7 +154,7 @@ func makeRandomFile(t *testing.T, rootDir, prefix string, size int) string {
 	return filepath.Join(rootDir, name)
 }
 
-func writeRandomRange(t *testing.T, store blockio.Store) {
+func writeRandomRange(t *testing.T, store *blockio.COWStore) {
 	s, err := store.SizeBytes()
 	require.NoError(t, err)
 	off := rand.Intn(int(s))
@@ -195,8 +197,9 @@ func mustUnpack(t *testing.T, ctx context.Context, loader snaploader.Loader, sna
 	return unpacked
 }
 
-func mustReadStore(t *testing.T, store blockio.Store) []byte {
-	r := blockio.Reader(store)
+func mustReadStore(t *testing.T, store *blockio.COWStore) []byte {
+	r, err := store.Reader()
+	require.NoError(t, err)
 	b, err := io.ReadAll(r)
 	require.NoError(t, err)
 	return b

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/blockio"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaploader"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
@@ -129,7 +130,7 @@ func TestPackAndUnpackChunkedFiles(t *testing.T) {
 	// mustUnpack already verifies the contents against cowA, but this will give
 	// us false confidence if cowA was somehow mutated. So check again against
 	// the originally snapshotted bytes, rather than the original COW instance.
-	r, err := unpackedC.ChunkedFiles["scratchfs"].Reader()
+	r, err := interfaces.StoreReader(unpackedC.ChunkedFiles["scratchfs"])
 	require.NoError(t, err)
 	scratchfsBytesC, err := io.ReadAll(r)
 	require.NoError(t, err)
@@ -198,7 +199,7 @@ func mustUnpack(t *testing.T, ctx context.Context, loader snaploader.Loader, sna
 }
 
 func mustReadStore(t *testing.T, store *blockio.COWStore) []byte {
-	r, err := store.Reader()
+	r, err := interfaces.StoreReader(store)
 	require.NoError(t, err)
 	b, err := io.ReadAll(r)
 	require.NoError(t, err)

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1220,3 +1220,14 @@ type IPRulesService interface {
 	// context.
 	AuthorizeHTTPRequest(ctx context.Context, r *http.Request) error
 }
+
+// Store models a block-level storage system, which is useful as a backend
+type Store interface {
+	io.ReaderAt
+	io.WriterAt
+	io.Closer
+
+	Reader() (io.Reader, error)
+	Sync() error
+	SizeBytes() (int64, error)
+}

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1227,7 +1227,16 @@ type Store interface {
 	io.WriterAt
 	io.Closer
 
-	Reader() (io.Reader, error)
 	Sync() error
 	SizeBytes() (int64, error)
+}
+
+// StoreReader returns an io.Reader that reads all bytes from the given store,
+// starting at offset 0 and ending at SizeBytes.
+func StoreReader(store Store) (io.Reader, error) {
+	size, err := store.SizeBytes()
+	if err != nil {
+		return nil, err
+	}
+	return io.NewSectionReader(store, 0, size), nil
 }


### PR DESCRIPTION
Given that we are only using the COW store for one use case, remove the various interfaces and nested structs for simplicity