### PR TITLE
[Remote Snapshot] Rename copy on write package

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -20,10 +20,10 @@ go_library(
         "@platforms//os:linux",
     ],
     deps = [
-        "//enterprise/server/remote_execution/blockio",
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/containers/docker",
+        "//enterprise/server/remote_execution/copy_on_write",
         "//enterprise/server/remote_execution/nbd/nbdserver",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/remote_execution/snaploader",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -20,10 +20,10 @@ import (
 	"time"
 
 	"github.com/armon/circbuf"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/blockio"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/docker"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/nbd/nbdserver"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaploader"
@@ -393,12 +393,12 @@ type FirecrackerContainer struct {
 	// When NBD is enabled, this is the running NBD server that serves the VM
 	// disks.
 	nbdServer      *nbdserver.Server
-	scratchStore   *blockio.COWStore
-	rootStore      *blockio.COWStore
-	workspaceStore *blockio.COWStore
+	scratchStore   *copy_on_write.COWStore
+	rootStore      *copy_on_write.COWStore
+	workspaceStore *copy_on_write.COWStore
 
 	uffdHandler *uffd.Handler
-	memoryStore *blockio.COWStore
+	memoryStore *copy_on_write.COWStore
 
 	jailerRoot         string            // the root dir the jailer will work in
 	machine            *fcclient.Machine // the firecracker machine object.
@@ -527,7 +527,7 @@ func NewContainer(ctx context.Context, env environment.Env, imageCacheAuth *cont
 
 // MergeDiffSnapshot reads from diffSnapshotPath and writes all non-zero blocks
 // into the baseSnapshotPath file or the baseSnapshotStore if non-nil.
-func MergeDiffSnapshot(ctx context.Context, baseSnapshotPath string, baseSnapshotStore *blockio.COWStore, diffSnapshotPath string, concurrency int, bufSize int) error {
+func MergeDiffSnapshot(ctx context.Context, baseSnapshotPath string, baseSnapshotStore *copy_on_write.COWStore, diffSnapshotPath string, concurrency int, bufSize int) error {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
@@ -716,7 +716,7 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 		VMStateSnapshotPath: filepath.Join(c.getChroot(), snapshotDetails.vmStateSnapshotName),
 		KernelImagePath:     kernelImagePath,
 		InitrdImagePath:     initrdImagePath,
-		ChunkedFiles:        map[string]*blockio.COWStore{},
+		ChunkedFiles:        map[string]*copy_on_write.COWStore{},
 	}
 	if *enableNBD {
 		if c.rootStore != nil {
@@ -841,7 +841,7 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 		return err
 	}
 	if len(unpacked.ChunkedFiles) > 0 && !(*enableNBD || *enableUFFD) {
-		return status.InternalError("blockio support is disabled but snapshot contains chunked files")
+		return status.InternalError("copy_on_write support is disabled but snapshot contains chunked files")
 	}
 	for name, cow := range unpacked.ChunkedFiles {
 		switch name {
@@ -999,12 +999,12 @@ func (c *FirecrackerContainer) createWorkspaceImage(ctx context.Context, workspa
 	return nil
 }
 
-func (c *FirecrackerContainer) convertToCOW(ctx context.Context, filePath, chunkDir string) (*blockio.COWStore, error) {
+func (c *FirecrackerContainer) convertToCOW(ctx context.Context, filePath, chunkDir string) (*copy_on_write.COWStore, error) {
 	start := time.Now()
 	if err := os.Mkdir(chunkDir, 0755); err != nil {
 		return nil, status.WrapError(err, "make chunk dir")
 	}
-	cow, err := blockio.ConvertFileToCOW(filePath, cowChunkSizeBytes(), chunkDir)
+	cow, err := copy_on_write.ConvertFileToCOW(filePath, cowChunkSizeBytes(), chunkDir)
 	if err != nil {
 		return nil, status.WrapError(err, "convert file to COW")
 	}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -939,7 +939,7 @@ func (c *FirecrackerContainer) initRootfsStore(ctx context.Context) error {
 // cheap (just updates size metadata). Also note that this does not update the
 // ext4 superblock to be aware of the increased block device size - instead, the
 // guest does that by issuing an EXT4_IOC_RESIZE_FS syscall.
-func (c *FirecrackerContainer) resizeRootfs(ctx context.Context, cf *blockio.COWStore) error {
+func (c *FirecrackerContainer) resizeRootfs(ctx context.Context, cf *copy_on_write.COWStore) error {
 	curSize, err := cf.SizeBytes()
 	if err != nil {
 		return status.WrapError(err, "get container image size")

--- a/enterprise/server/remote_execution/copy_on_write/BUILD
+++ b/enterprise/server/remote_execution/copy_on_write/BUILD
@@ -1,9 +1,9 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "blockio",
-    srcs = ["blockio.go"],
-    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/blockio",
+    name = "copy_on_write",
+    srcs = ["copy_on_write.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write",
     visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
@@ -18,10 +18,10 @@ go_library(
 package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_test(
-    name = "blockio_test",
-    srcs = ["blockio_test.go"],
+    name = "copy_on_write_test",
+    srcs = ["copy_on_write_test.go"],
     deps = [
-        ":blockio",
+        ":copy_on_write",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/remote_cache/digest",
@@ -32,8 +32,8 @@ go_test(
 )
 
 go_test(
-    name = "blockio_benchmark_test",
-    srcs = ["blockio_test.go"],
+    name = "copy_on_write_benchmark_test",
+    srcs = ["copy_on_write_test.go"],
     args = [
         "-test.skip=^Test",
         "-test.bench=.",
@@ -43,7 +43,7 @@ go_test(
     ],
     tags = ["performance"],
     deps = [
-        ":blockio",
+        ":copy_on_write",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/remote_cache/digest",

--- a/enterprise/server/remote_execution/nbd/nbdserver/BUILD
+++ b/enterprise/server/remote_execution/nbd/nbdserver/BUILD
@@ -5,7 +5,7 @@ go_library(
     srcs = ["nbdserver.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/nbd/nbdserver",
     deps = [
-        "//enterprise/server/remote_execution/blockio",
+        "//enterprise/server/remote_execution/copy_on_write",
         "//proto:nbd_go_proto",
         "//server/environment",
         "//server/util/grpc_server",
@@ -22,7 +22,7 @@ go_test(
     srcs = ["nbdserver_test.go"],
     deps = [
         ":nbdserver",
-        "//enterprise/server/remote_execution/blockio",
+        "//enterprise/server/remote_execution/copy_on_write",
         "//proto:nbd_go_proto",
         "//server/testutil/testenv",
         "//server/testutil/testfs",

--- a/enterprise/server/remote_execution/nbd/nbdserver/nbdserver.go
+++ b/enterprise/server/remote_execution/nbd/nbdserver/nbdserver.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"sync"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/blockio"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -18,11 +18,11 @@ import (
 // Device is a block store exported by a server along with its associated
 // metadata.
 type Device struct {
-	*blockio.COWStore
+	*copy_on_write.COWStore
 	Metadata *nbdpb.DeviceMetadata
 }
 
-func NewExt4Device(store *blockio.COWStore, name string) (*Device, error) {
+func NewExt4Device(store *copy_on_write.COWStore, name string) (*Device, error) {
 	return &Device{
 		COWStore: store,
 		Metadata: &nbdpb.DeviceMetadata{

--- a/enterprise/server/remote_execution/nbd/nbdserver/nbdserver_test.go
+++ b/enterprise/server/remote_execution/nbd/nbdserver/nbdserver_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/blockio"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/nbd/nbdserver"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
@@ -19,13 +19,13 @@ import (
 func TestNBDServer(t *testing.T) {
 	ctx := context.Background()
 	env := testenv.GetTestEnv(t)
-	// Make a blockio.Store from an empty file
+	// Make a copy_on_write.Store from an empty file
 	const fileSizeBytes = 1000
 	tmp := testfs.MakeTempDir(t)
 	path := filepath.Join(tmp, "f")
 	err := os.WriteFile(path, make([]byte, fileSizeBytes), 0644)
 	require.NoError(t, err)
-	cow, err := blockio.ConvertFileToCOW(path, 200, tmp)
+	cow, err := copy_on_write.ConvertFileToCOW(path, 200, tmp)
 	require.NoError(t, err)
 
 	// Create a server hosting a device backed by the file

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -7,7 +7,7 @@ go_library(
     srcs = ["snaploader.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaploader",
     deps = [
-        "//enterprise/server/remote_execution/blockio",
+        "//enterprise/server/remote_execution/copy_on_write",
         "//enterprise/server/util/filecacheutil",
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
@@ -30,7 +30,7 @@ go_test(
     srcs = ["snaploader_test.go"],
     deps = [
         ":snaploader",
-        "//enterprise/server/remote_execution/blockio",
+        "//enterprise/server/remote_execution/copy_on_write",
         "//enterprise/server/remote_execution/filecache",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",

--- a/enterprise/server/remote_execution/uffd/BUILD
+++ b/enterprise/server/remote_execution/uffd/BUILD
@@ -11,7 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = select({
         "@io_bazel_rules_go//go/platform:linux": [
-            "//enterprise/server/remote_execution/blockio",
+            "//enterprise/server/remote_execution/copy_on_write",
             "//server/util/log",
             "//server/util/status",
             "@org_golang_x_sys//unix",


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

Now that this package only has structs dealing with copy-on-write, rename it to reflect that. Also change ordering of the file so that the COWStruct is defined at the top (preference thing where I find it easier to read a file if the main struct is defined first).  
