### PR TITLE
Roll-forward "Upgrade bb toolchain to get `dockerNetwork=off`"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -356,9 +356,9 @@ dockerfile_image(
 
 http_archive(
     name = "io_buildbuddy_buildbuddy_toolchain",
-    sha256 = "e899f235b36cb901b678bd6f55c1229df23fcbc7921ac7a3585d29bff2bf9cfd",
-    strip_prefix = "buildbuddy-toolchain-fd351ca8f152d66fc97f9d98009e0ae000854e8f",
-    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/fd351ca8f152d66fc97f9d98009e0ae000854e8f.tar.gz"],
+    sha256 = "1cab6ef3ae9b4211ab9d57826edd4bbc34e5b9e5cb1927c97f0788d8e7ad0442",
+    strip_prefix = "buildbuddy-toolchain-b043878a82f266fd78369b794a105b57dc0b2600",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/b043878a82f266fd78369b794a105b57dc0b2600.tar.gz"],
 )
 
 load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")

--- a/cli/test/integration/cli/BUILD
+++ b/cli/test/integration/cli/BUILD
@@ -3,6 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "cli_test",
     srcs = ["cli_test.go"],
+    exec_properties = {
+        # TODO: remove network dependency.
+        "test.dockerNetwork": "bridge",
+    },
     shard_count = 4,
     deps = [
         "//cli/log",

--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -16,6 +16,10 @@ go_test(
     # exec_properties = {
     #     "container-image": "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.3.0",
     # },
+    exec_properties = {
+        # TODO: remove network dependency.
+        "test.dockerNetwork": "bridge",
+    },
     shard_count = 12,
     deps = [
         "//proto:eventlog_go_proto",

--- a/enterprise/server/test/integration/workflow/BUILD
+++ b/enterprise/server/test/integration/workflow/BUILD
@@ -2,7 +2,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "workflow_test",
-    size = "small",
     srcs = ["workflow_test.go"],
     # ci_runner gets invoked directly by this test since the RBE test framework
     # currently does not support dockerized execution of commands. So for now we
@@ -12,6 +11,10 @@ go_test(
     # exec_properties = {
     #     "container-image": "docker://gcr.io/flame-public/buildbuddy-ci-runner:v2.3.0",
     # },
+    exec_properties = {
+        # TODO: remove network dependency.
+        "test.dockerNetwork": "bridge",
+    },
     shard_count = 2,
     deps = [
         "//enterprise/server/invocation_search_service",

--- a/enterprise/server/test/webdriver/invocation/BUILD
+++ b/enterprise/server/test/webdriver/invocation/BUILD
@@ -2,8 +2,12 @@ load("//rules/webdriver:index.bzl", "go_web_test_suite")
 
 go_web_test_suite(
     name = "invocation_test",
-    size = "small",
     srcs = ["invocation_test.go"],
+    exec_properties = {
+        # This test can be run against deployed buildbuddy instances, so it
+        # requires networking.
+        "test.dockerNetwork": "bridge",
+    },
     shard_count = 2,
     deps = [
         "//enterprise/server/testutil/buildbuddy_enterprise",

--- a/rules/webdriver/index.bzl
+++ b/rules/webdriver/index.bzl
@@ -34,6 +34,7 @@ def go_web_test_suite(
         visibility = None,
         web_test_data = None,
         wrapped_test_tags = DEFAULT_WRAPPED_TEST_TAGS,
+        exec_properties = {},
         **kwargs):
     # TODO(bduffany): Generate a test to automatically enforce `shard_count == number of tests`
     if not shard_count:
@@ -50,9 +51,10 @@ def go_web_test_suite(
     size = size or "large"
     wrapped_test_name = name + "_wrapped_test"
 
-    exec_properties = {
+    test_exec_properties = {
         "container-image": "docker://gcr.io/flame-public/rbe-ubuntu20-04-webtest@sha256:754fee72cee06fc72215b5d7edf31ef45116a4468cf5a5ccd4301acd83cba531",
     }
+    test_exec_properties.update(exec_properties)
 
     go_test(
         name = wrapped_test_name,
@@ -64,7 +66,7 @@ def go_web_test_suite(
         tags = wrapped_test_tags,
         timeout = timeout,
         visibility = ["//visibility:private"],
-        exec_properties = exec_properties,
+        exec_properties = test_exec_properties,
         **kwargs
     )
 
@@ -93,5 +95,5 @@ def go_web_test_suite(
         # browser-overrides map, it can be wrapped in a map like so:
         #
         # {"default": { "your_map_key": "your_map_value" }}.
-        exec_properties = {"default": exec_properties},
+        exec_properties = {"default": test_exec_properties},
     )


### PR DESCRIPTION
Added `test.dockerNetwork=bridge` to the webdriver test to fix it. Also change `dockerNetwork` => `test.dockerNetwork` so that only the test actions get networking, not the actions that build the tests.

**Related issues**: N/A
