### PR TITLE
Fix `--transient-store=false` flag breaking older podman versions

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -922,14 +922,13 @@ func (c *podmanCommandContainer) State(ctx context.Context) (*rnpb.ContainerStat
 }
 
 func runPodman(ctx context.Context, subCommand string, stdio *container.Stdio, args ...string) *interfaces.CommandResult {
-	command := []string{
-		"podman",
+	command := []string{"podman"}
+	if *transientStore {
 		// Use transient store to reduce contention.
 		// See https://github.com/containers/podman/issues/19824
-		fmt.Sprintf("--transient-store=%t", *transientStore),
-		subCommand,
+		command = append(command, "--transient-store")
 	}
-
+	command = append(command, subCommand)
 	command = append(command, args...)
 	// Note: we don't collect stats on the podman process, and instead use
 	// cgroups for stats accounting.


### PR DESCRIPTION
If `executor.podman.transient_store` is false then don't pass the flag to podman at all. This makes it so that if an older podman version is installed, the executor can still run (I hit this issue on a GCP VM today).

**Related issues**: N/A
