### PR TITLE
Guard against possible data race with NBD server + snapshotting

### DIFF
--- a/enterprise/server/remote_execution/nbd/nbdserver/nbdserver.go
+++ b/enterprise/server/remote_execution/nbd/nbdserver/nbdserver.go
@@ -87,7 +87,7 @@ func (s *Server) Start(lis net.Listener) error {
 }
 
 func (s *Server) Stop() error {
-	s.server.Stop()
+	s.server.GracefulStop()
 	return nil
 }
 


### PR DESCRIPTION
Not sure if this was actually happening or was causing problems, but before saving snapshots we should ensure that any in-progress writes to disk COWStores are complete, by calling `GracefulStop()` (which waits for RPCs to complete, vs. `Stop()` which just cancels contexts).

We already do something similar for the UFFD handler, so it makes sense to do it for the NBD server too.

**Related issues**: N/A
