### PR TITLE
Rename `install_buildbuddy_dependencies` => `install_go_mod_dependencies`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,12 +42,12 @@ http_archive(
     ],
 )
 
-load(":deps.bzl", "install_buildbuddy_dependencies")
+load(":deps.bzl", "install_go_mod_dependencies")
 
 # Install gazelle and go_rules dependencies after ours so that our go module versions take precedence.
 
-# gazelle:repository_macro deps.bzl%install_buildbuddy_dependencies
-install_buildbuddy_dependencies()
+# gazelle:repository_macro deps.bzl%install_go_mod_dependencies
+install_go_mod_dependencies()
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchains", "go_rules_dependencies")
@@ -192,6 +192,9 @@ http_archive(
 )
 
 load("@com_google_googletest//:googletest_deps.bzl", "googletest_deps")
+
+# gazelle:repository_macro deps.bzl%install_go_mod_dependencies
+install_go_mod_dependencies()
 
 googletest_deps()
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,7 +42,9 @@ http_archive(
     ],
 )
 
-load(":deps.bzl", "install_go_mod_dependencies")
+load(":deps.bzl", "install_go_mod_dependencies", "install_static_dependencies")
+
+install_static_dependencies()
 
 # Install gazelle and go_rules dependencies after ours so that our go module versions take precedence.
 
@@ -192,9 +194,6 @@ http_archive(
 )
 
 load("@com_google_googletest//:googletest_deps.bzl", "googletest_deps")
-
-# gazelle:repository_macro deps.bzl%install_go_mod_dependencies
-install_go_mod_dependencies()
 
 googletest_deps()
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -7049,6 +7049,8 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
         version = "v3.3.0",
     )
 
+# Manually created
+def install_static_dependencies(workspace_name = "buildbuddy"):
     http_archive(
         name = "com_github_buildbuddy_io_firecracker_firecracker-v1.4.0-20230720-cf5f56f",
         sha256 = "b36d9ad62ca467d2794635c4f19b0993c11bb46ed3b575037287964f9c82cc9b",

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,8 +1,8 @@
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
-# bazelisk run //:gazelle -- update-repos -from_file=go.mod -to_macro=deps.bzl%install_buildbuddy_dependencies
-def install_buildbuddy_dependencies(workspace_name = "buildbuddy"):
+# bazelisk run //:gazelle -- update-repos -from_file=go.mod -to_macro=deps.bzl%install_go_mod_dependencies
+def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "cc_mvdan_gofumpt",
         importpath = "mvdan.cc/gofumpt",

--- a/tools/fix_go_deps.sh
+++ b/tools/fix_go_deps.sh
@@ -74,7 +74,7 @@ fi
 
 # Update deps.bzl (using Gazelle)
 if ! "${GAZELLE_COMMAND[@]}" update-repos -from_file=go.mod \
-  -to_macro=deps.bzl%install_buildbuddy_dependencies \
+  -to_macro=deps.bzl%install_go_mod_dependencies \
 	-prune=true &>"$tmp_log_file"; then
   echo "Auto-updating 'deps.bzl' failed. Logs:" >&2
   cat "$tmp_log_file" >&2

--- a/tools/update_deps.sh
+++ b/tools/update_deps.sh
@@ -2,4 +2,4 @@
 set -e
 cd "$(dirname "$(realpath "$0")")/.."
 bazelisk run \
-    //:gazelle -- update-repos -from_file=go.mod -to_macro=deps.bzl%install_buildbuddy_dependencies
+    //:gazelle -- update-repos -from_file=go.mod -to_macro=deps.bzl%install_go_mod_dependencies


### PR DESCRIPTION
This change:
 1) Allows us to have different functions for different language ecosystems (i.e. install_package_json_dependencies, etc)
2) Makes it easier for automated tooling to generate this function name (i.e `install_%s_dependencies` where %s is the name of the file where the dependencies came from). 

I have a separate change do to the same in the internal repo.