### PR TITLE
[Remote Snapshot] Simplify snaploader code by consolidating GetSnapshot and UnpackSnapshot

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/README.md
+++ b/enterprise/server/remote_execution/containers/firecracker/README.md
@@ -138,7 +138,7 @@ shows the directories relevant to a firecracker container instance:
         #
         # When resuming a VM from snapshot, these files are expected to
         # already be here. Since we delete the chroot across runs of the
-        # VM, we write these files using loader.UnpackSnapshot().
+        # VM, we write these files using loader.GetSnapshot().
         - vmlinux # Linux kernel image
         - initrd.cpio # initial RAM disk, mounted when booting the VM
         - full-mem.snap # full memory snapshot

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -32,6 +32,7 @@ go_test(
         ":snaploader",
         "//enterprise/server/remote_execution/copy_on_write",
         "//enterprise/server/remote_execution/filecache",
+        "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/testutil/testenv",

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/stretchr/testify/require"
 
+	fcpb "github.com/buildbuddy-io/buildbuddy/proto/firecracker"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
@@ -51,7 +52,7 @@ func TestPackAndUnpack(t *testing.T) {
 	keyB, err := snaploader.NewKey(taskB, "vm-config-hash-B", "runner-B")
 	require.NoError(t, err)
 	optsB := makeFakeSnapshot(t, workDir)
-	snapB, err := loader.CacheSnapshot(ctx, keyB, optsB)
+	_, err = loader.CacheSnapshot(ctx, keyB, optsB)
 	require.NoError(t, err)
 
 	// We should be able to unpack snapshot A, delete it, and then replace it
@@ -59,7 +60,7 @@ func TestPackAndUnpack(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		// Unpack (this should also evict from cache).
 		outDir := testfs.MakeDirAll(t, workDir, fmt.Sprintf("unpack-a-%d", i))
-		mustUnpack(t, ctx, loader, snapA, outDir, optsA)
+		mustUnpack(t, ctx, loader, keyA, outDir, optsA)
 
 		// Delete, since it's no longer needed.
 		err = loader.DeleteSnapshot(ctx, snapA)
@@ -73,7 +74,7 @@ func TestPackAndUnpack(t *testing.T) {
 
 	// Snapshot B should not have been evicted.
 	outDir := testfs.MakeDirAll(t, workDir, "unpack-b")
-	mustUnpack(t, ctx, loader, snapB, outDir, optsB)
+	mustUnpack(t, ctx, loader, keyB, outDir, optsB)
 }
 
 func TestPackAndUnpackChunkedFiles(t *testing.T) {
@@ -109,7 +110,7 @@ func TestPackAndUnpackChunkedFiles(t *testing.T) {
 	optsA.ChunkedFiles = map[string]*copy_on_write.COWStore{
 		"scratchfs": cowA,
 	}
-	snapA, err := loader.CacheSnapshot(ctx, key, optsA)
+	_, err = loader.CacheSnapshot(ctx, key, optsA)
 	require.NoError(t, err)
 	// Note: we'd normally close cowA here, but we keep it open so that
 	// mustUnpack() can verify the original contents.
@@ -118,20 +119,19 @@ func TestPackAndUnpackChunkedFiles(t *testing.T) {
 	// unpacked from a snapshot.
 	// i.e. For SnapA -> ForkA -> ForkA' we want to make sure ForkA' functions
 	// correctly
-	originalSnap := snapA
+	// To test this, read and write to the same snapshot key multiple times
 	originalOpts := optsA
 	for i := 0; i < 3; i++ {
 		forkWorkDir := testfs.MakeDirAll(t, workDir, fmt.Sprintf("VM-%d", i))
-		unpacked := mustUnpack(t, ctx, loader, originalSnap, forkWorkDir, originalOpts)
+		unpacked := mustUnpack(t, ctx, loader, key, forkWorkDir, originalOpts)
 		forkCOW := unpacked.ChunkedFiles["scratchfs"]
 		writeRandomRange(t, forkCOW)
 		forkOpts := makeFakeSnapshot(t, forkWorkDir)
 		forkOpts.ChunkedFiles = map[string]*copy_on_write.COWStore{
 			"scratchfs": forkCOW,
 		}
-		forkSnap, err := loader.CacheSnapshot(ctx, key, forkOpts)
+		_, err = loader.CacheSnapshot(ctx, key, forkOpts)
 		require.NoError(t, err)
-		originalSnap = forkSnap
 		originalOpts = forkOpts
 	}
 }
@@ -168,7 +168,7 @@ func TestPackAndUnpackChunkedFiles_Immutability(t *testing.T) {
 	optsA.ChunkedFiles = map[string]*copy_on_write.COWStore{
 		"scratchfs": cowA,
 	}
-	snapA, err := loader.CacheSnapshot(ctx, keyA, optsA)
+	_, err = loader.CacheSnapshot(ctx, keyA, optsA)
 	require.NoError(t, err)
 	// Note: we'd normally close cowA here, but we keep it open so that
 	// mustUnpack() can verify the original contents.
@@ -179,14 +179,14 @@ func TestPackAndUnpackChunkedFiles_Immutability(t *testing.T) {
 
 	// Now unpack the snapshot for use by VM B, then make a modification.
 	workDirB := testfs.MakeDirAll(t, workDir, "VM-B")
-	unpackedB := mustUnpack(t, ctx, loader, snapA, workDirB, optsA)
+	unpackedB := mustUnpack(t, ctx, loader, keyA, workDirB, optsA)
 	cowB := unpackedB.ChunkedFiles["scratchfs"]
 	writeRandomRange(t, cowB)
 
 	// Unpack the snapshot again for use by VM C. It should see the original
 	// contents, not the modification made by VM B.
 	workDirC := testfs.MakeDirAll(t, workDir, "VM-C")
-	unpackedC := mustUnpack(t, ctx, loader, snapA, workDirC, optsA)
+	unpackedC := mustUnpack(t, ctx, loader, keyA, workDirC, optsA)
 	// mustUnpack already verifies the contents against cowA, but this will give
 	// us false confidence if cowA was somehow mutated. So check again against
 	// the originally snapshotted bytes, rather than the original COW instance.
@@ -228,8 +228,8 @@ func writeRandomRange(t *testing.T, store *copy_on_write.COWStore) {
 
 // Unpacks a snapshot to outDir and asserts that the contents match the
 // originally cached contents.
-func mustUnpack(t *testing.T, ctx context.Context, loader snaploader.Loader, snap *snaploader.Snapshot, outDir string, originalSnapshot *snaploader.CacheSnapshotOptions) *snaploader.UnpackedSnapshot {
-	unpacked, err := loader.UnpackSnapshot(ctx, snap, outDir)
+func mustUnpack(t *testing.T, ctx context.Context, loader snaploader.Loader, snapshotKey *fcpb.SnapshotKey, outDir string, originalSnapshot *snaploader.CacheSnapshotOptions) *snaploader.UnpackedSnapshot {
+	unpacked, err := loader.GetSnapshot(ctx, snapshotKey, outDir)
 	require.NoError(t, err)
 
 	for _, path := range []string{


### PR DESCRIPTION
Only having one function will make some future changes simpler, because both functions need some shared data and we won't have to pass the data between the two functions.