### PR TITLE
Add explicit `rules_proto` dependency to WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -448,8 +448,6 @@ http_file(
 
 # Proto rules
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 http_archive(
     name = "rules_proto",
     sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -445,3 +445,19 @@ http_file(
     sha256 = "6a8ba1c9f858386edba0ea82b7bf8168ef513d1eb0df3a08cc7cf4bb89f856d0",
     url = "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem",
 )
+
+# Proto rules
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
+    strip_prefix = "rules_proto-5.3.0-21.7",
+    urls = [
+        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
+    ],
+)
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -458,6 +458,9 @@ http_archive(
         "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
     ],
 )
+
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
 rules_proto_dependencies()
+
 rules_proto_toolchains()


### PR DESCRIPTION
Right now we're just lucky this gets imported transitively by one of our other dependencies.

We use it here, but never explicitly import it:
https://github.com/buildbuddy-io/buildbuddy/blob/master/proto/BUILD#L1