### PR TITLE
add a flag in migration cache to clear pebble cache on start up

### DIFF
--- a/enterprise/server/backends/migration_cache/config.go
+++ b/enterprise/server/backends/migration_cache/config.go
@@ -48,7 +48,7 @@ type PebbleCacheConfig struct {
 	MinEvictionAge              *time.Duration          `yaml:"min_eviction_age"`
 	MinBytesAutoZstdCompression int64                   `yaml:"min_bytes_auto_zstd_compression"`
 	AverageChunkSizeBytes       int                     `yaml:"average_chunk_size_bytes"`
-	ClearCacheBeforeMigration   bool                    `yaml:"clear_cache_before_migration"`
+	ClearCacheOnStartup         bool                    `yaml:"clear_cache_on_startup"`
 }
 
 func (cfg *MigrationConfig) SetConfigDefaults() {

--- a/enterprise/server/backends/migration_cache/config.go
+++ b/enterprise/server/backends/migration_cache/config.go
@@ -48,6 +48,7 @@ type PebbleCacheConfig struct {
 	MinEvictionAge              *time.Duration          `yaml:"min_eviction_age"`
 	MinBytesAutoZstdCompression int64                   `yaml:"min_bytes_auto_zstd_compression"`
 	AverageChunkSizeBytes       int                     `yaml:"average_chunk_size_bytes"`
+	ClearCacheBeforeMigration   bool                    `yaml:"clear_cache_before_migration"`
 }
 
 func (cfg *MigrationConfig) SetConfigDefaults() {

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -153,6 +153,7 @@ func pebbleCacheFromConfig(env environment.Env, cfg *PebbleCacheConfig) (*pebble
 		AtimeBufferSize:             cfg.AtimeBufferSize,
 		MinEvictionAge:              cfg.MinEvictionAge,
 		AverageChunkSizeBytes:       cfg.AverageChunkSizeBytes,
+		ClearCacheBeforeMigration:   cfg.ClearCacheBeforeMigration,
 	}
 	c, err := pebble_cache.NewPebbleCache(env, opts)
 	if err != nil {

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -153,7 +153,7 @@ func pebbleCacheFromConfig(env environment.Env, cfg *PebbleCacheConfig) (*pebble
 		AtimeBufferSize:             cfg.AtimeBufferSize,
 		MinEvictionAge:              cfg.MinEvictionAge,
 		AverageChunkSizeBytes:       cfg.AverageChunkSizeBytes,
-		ClearCacheBeforeMigration:   cfg.ClearCacheBeforeMigration,
+		ClearCacheOnStartup:         cfg.ClearCacheOnStartup,
 	}
 	c, err := pebble_cache.NewPebbleCache(env, opts)
 	if err != nil {

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -177,7 +177,7 @@ type Options struct {
 
 	Clock clockwork.Clock
 
-	ClearCacheBeforeMigration bool
+	ClearCacheOnStartup bool
 }
 
 type sizeUpdate struct {
@@ -480,7 +480,7 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 	if err := validateOpts(opts); err != nil {
 		return nil, err
 	}
-	if opts.ClearCacheBeforeMigration {
+	if opts.ClearCacheOnStartup {
 		log.Infof("Removing directory %q before starting cache %s", opts.RootDirectory, opts.Name)
 		if err := os.RemoveAll(opts.RootDirectory); err != nil {
 			return nil, err

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -481,7 +481,7 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 		return nil, err
 	}
 	if opts.ClearCacheBeforeMigration {
-		log.Infof("Removing directory %q", opts.RootDirectory)
+		log.Infof("Removing directory %q before starting cache %s", opts.RootDirectory, opts.Name)
 		if err := os.RemoveAll(opts.RootDirectory); err != nil {
 			return nil, err
 		}

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -239,8 +239,6 @@ type PebbleCache struct {
 
 	oldMetrics    pebble.Metrics
 	eventListener *pebbleEventListener
-
-	clearCacheBeforeMigration bool
 }
 
 type pebbleEventListener struct {

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -176,6 +176,8 @@ type Options struct {
 	IncludeMetadataSize bool
 
 	Clock clockwork.Clock
+
+	ClearCacheBeforeMigration bool
 }
 
 type sizeUpdate struct {
@@ -237,6 +239,8 @@ type PebbleCache struct {
 
 	oldMetrics    pebble.Metrics
 	eventListener *pebbleEventListener
+
+	clearCacheBeforeMigration bool
 }
 
 type pebbleEventListener struct {
@@ -477,6 +481,12 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 	SetOptionDefaults(opts)
 	if err := validateOpts(opts); err != nil {
 		return nil, err
+	}
+	if opts.ClearCacheBeforeMigration {
+		log.Infof("Removing directory %q", opts.RootDirectory)
+		if err := os.RemoveAll(opts.RootDirectory); err != nil {
+			return nil, err
+		}
 	}
 	if err := disk.EnsureDirectoryExists(opts.RootDirectory); err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Need to delete the cdc cache to restart migration in prod/dev
