### PR TITLE
Create new repos with `main` as the default branch

### DIFF
--- a/enterprise/server/githubapp/BUILD
+++ b/enterprise/server/githubapp/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//server/util/status",
         "@com_github_go_git_go_git_v5//:go-git",
         "@com_github_go_git_go_git_v5//config",
+        "@com_github_go_git_go_git_v5//plumbing",
         "@com_github_go_git_go_git_v5//plumbing/object",
         "@com_github_go_git_go_git_v5//plumbing/transport/http",
         "@com_github_golang_jwt_jwt//:jwt",

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -29,6 +29,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/golang-jwt/jwt"
 	"github.com/google/go-github/v43/github"
 	"golang.org/x/oauth2"
@@ -695,6 +696,10 @@ func cloneTemplate(email, tmpDirName, token, srcURL, destURL, srcDir string) err
 	if err != nil {
 		return err
 	}
+	err = gitRepo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Main))
+	if err != nil {
+		return err
+	}
 	gitWorkTree, err := gitRepo.Worktree()
 	if err != nil {
 		return err
@@ -713,14 +718,14 @@ func cloneTemplate(email, tmpDirName, token, srcURL, destURL, srcDir string) err
 
 	// Create a new remote and push to it
 	remote, err := gitRepo.CreateRemote(&config.RemoteConfig{
-		Name: "origin",
+		Name: git.DefaultRemoteName,
 		URLs: []string{destURL},
 	})
 	if err != nil {
 		return err
 	}
 	return remote.Push(&git.PushOptions{
-		RemoteName: "origin",
+		RemoteName: git.DefaultRemoteName,
 		Auth:       auth,
 		Force:      true,
 	})


### PR DESCRIPTION
In https://github.com/buildbuddy-io/buildbuddy/pull/4779 the default branch was unintentionally switched to `master`.