### PR TITLE
extend deadline when we actually process copy

### DIFF
--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -851,17 +851,14 @@ func (mc *MigrationCache) sendNonBlockingCopy(ctx context.Context, r *rspb.Resou
 	}
 
 	log.Debugf("Migration attempting copy digest %v, instance %s, cache %v", r.GetDigest(), r.GetInstanceName(), r.GetCacheType())
-	ctx, cancel := background.ExtendContextForFinalization(ctx, 10*time.Second)
 	select {
 	case mc.copyChan <- &copyData{
 		d:         r,
 		ctx:       ctx,
-		ctxCancel: cancel,
 	}:
 	default:
 		log.Debugf("Migration dropping copy digest %v, instance %s, cache %v", r.GetDigest(), r.GetInstanceName(), r.GetCacheType())
 		*mc.numCopiesDropped++
-		cancel()
 	}
 }
 
@@ -905,7 +902,6 @@ func (mc *MigrationCache) Set(ctx context.Context, r *rspb.ResourceName, data []
 type copyData struct {
 	d         *rspb.ResourceName
 	ctx       context.Context
-	ctxCancel context.CancelFunc
 }
 
 func (mc *MigrationCache) copyDataInBackground() error {
@@ -958,7 +954,9 @@ func (mc *MigrationCache) monitorCopyChanFullness() {
 }
 
 func (mc *MigrationCache) copy(c *copyData) {
-	defer c.ctxCancel()
+	ctx, cancel := background.ExtendContextForFinalization(c.ctx, 10*time.Second)
+	c.ctx = ctx
+	defer cancel()
 
 	destContains, err := mc.dest.Contains(c.ctx, c.d)
 	if err != nil {

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -853,8 +853,8 @@ func (mc *MigrationCache) sendNonBlockingCopy(ctx context.Context, r *rspb.Resou
 	log.Debugf("Migration attempting copy digest %v, instance %s, cache %v", r.GetDigest(), r.GetInstanceName(), r.GetCacheType())
 	select {
 	case mc.copyChan <- &copyData{
-		d:         r,
-		ctx:       ctx,
+		d:   r,
+		ctx: ctx,
 	}:
 	default:
 		log.Debugf("Migration dropping copy digest %v, instance %s, cache %v", r.GetDigest(), r.GetInstanceName(), r.GetCacheType())
@@ -900,8 +900,8 @@ func (mc *MigrationCache) Set(ctx context.Context, r *rspb.ResourceName, data []
 }
 
 type copyData struct {
-	d         *rspb.ResourceName
-	ctx       context.Context
+	d   *rspb.ResourceName
+	ctx context.Context
 }
 
 func (mc *MigrationCache) copyDataInBackground() error {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Right now we extend the deadline when we enqueue the copy. But by the time we dequeue it and process it, the timeout might be close to be expired. This will lead to copy error warning. 
