### PR TITLE
mem_metrics_collector: return a copy of the map on ReadCounts

### DIFF
--- a/server/backends/memory_metrics_collector/memory_metrics_collector.go
+++ b/server/backends/memory_metrics_collector/memory_metrics_collector.go
@@ -235,7 +235,11 @@ func (m *MemoryMetricsCollector) ReadCounts(ctx context.Context, key string) (ma
 
 	if existingValIface, ok := m.l.Get(key); ok {
 		if existingVal, ok := existingValIface.(map[string]int64); ok {
-			return existingVal, nil
+			counts := make(map[string]int64, len(existingVal))
+			for k, v := range existingVal {
+				counts[k] = v
+			}
+			return counts, nil
 		}
 	}
 


### PR DESCRIPTION
We received a crash report with

```
fatal error: concurrent map iteration and map write

goroutine 1779257345 [running]:
github.com/buildbuddy-io/buildbuddy/server/remote_cache/hit_tracker.ScoreCard({0x23e6608, 0xc0bae78f00}, {0x2405988?, 0xc000895680?}, {0xc0cf58aed0, 0x24})
	server/remote_cache/hit_tracker/hit_tracker.go:564 +0x2b1
github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_handler.LookupInvocation.func1()
	server/build_event_protocol/build_event_handler/build_event_handler.go:1235 +0x6b

...
```

so let's ensure that we do not return the map directly from LRU but a
copy of it to avoid race conditions.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
