### PR TITLE
Remove .github/workflows directory when creating repo from template

### DIFF
--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -683,6 +683,11 @@ func cloneTemplate(email, tmpDirName, token, srcURL, destURL, srcDir string) err
 	if err != nil {
 		return err
 	}
+	// Remove any github workflows directories, because we won't have permission to create them
+	err = os.RemoveAll(filepath.Join(tmpDir, ".github/workflows"))
+	if err != nil {
+		return err
+	}
 	// Don't allow paths with dots or other non alphanumeric path components
 	if !validPathRegex.MatchString(srcDir) {
 		return status.FailedPreconditionErrorf("invalid template path: %q", srcDir)


### PR DESCRIPTION
We don't have permission to create this directory (since we don't ask for workflow permissions).