### PR TITLE
auth: log auth errors

### DIFF
--- a/enterprise/server/auth/BUILD
+++ b/enterprise/server/auth/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//server/tables",
         "//server/util/authutil",
         "//server/util/claims",
+        "//server/util/log",
         "//server/util/status",
         "@com_github_golang_jwt_jwt//:jwt",
     ],

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -94,7 +94,7 @@ func (a *authenticator) Login(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 	if len(errors) > 0 {
-		log.Errorf("login failed: %s", errors)
+		log.Infof("login failed: %s", errors)
 		return errors[0]
 	}
 	return status.NotFoundErrorf("No authenticator registered to handle login path: %s", r.URL.Path)
@@ -115,7 +115,7 @@ func (a *authenticator) Auth(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 	if len(errors) > 0 {
-		log.Errorf("auth failed: %s", errors)
+		log.Infof("auth failed: %s", errors)
 		return errors[0]
 	}
 	return status.NotFoundErrorf("No authenticator registered to auth path: %s", r.URL.Path)
@@ -149,7 +149,7 @@ func (a *authenticator) FillUser(ctx context.Context, user *tables.User) error {
 		}
 	}
 	if len(errors) > 0 {
-		log.Errorf("fill user failed: %s", errors)
+		log.Infof("fill user failed: %s", errors)
 		return errors[0]
 	}
 	return status.UnauthenticatedErrorf("No user authenticators configured")
@@ -168,7 +168,7 @@ func (a *authenticator) AuthenticatedUser(ctx context.Context) (interfaces.UserI
 		}
 	}
 	if len(errors) > 0 {
-		log.Errorf("authenticated user failed: %s", errors)
+		log.Infof("authenticated user failed: %s", errors)
 		return nil, errors[0]
 	}
 	return nil, status.UnauthenticatedErrorf("No user authenticators configured")

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	"github.com/golang-jwt/jwt"
@@ -93,6 +94,7 @@ func (a *authenticator) Login(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 	if len(errors) > 0 {
+		log.Errorf("login failed: %s", errors)
 		return errors[0]
 	}
 	return status.NotFoundErrorf("No authenticator registered to handle login path: %s", r.URL.Path)
@@ -113,6 +115,7 @@ func (a *authenticator) Auth(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 	if len(errors) > 0 {
+		log.Errorf("auth failed: %s", errors)
 		return errors[0]
 	}
 	return status.NotFoundErrorf("No authenticator registered to auth path: %s", r.URL.Path)
@@ -146,6 +149,7 @@ func (a *authenticator) FillUser(ctx context.Context, user *tables.User) error {
 		}
 	}
 	if len(errors) > 0 {
+		log.Errorf("fill user failed: %s", errors)
 		return errors[0]
 	}
 	return status.UnauthenticatedErrorf("No user authenticators configured")
@@ -164,6 +168,7 @@ func (a *authenticator) AuthenticatedUser(ctx context.Context) (interfaces.UserI
 		}
 	}
 	if len(errors) > 0 {
+		log.Errorf("authenticated user failed: %s", errors)
 		return nil, errors[0]
 	}
 	return nil, status.UnauthenticatedErrorf("No user authenticators configured")

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -94,7 +94,7 @@ func (a *authenticator) Login(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 	if len(errors) > 0 {
-		log.Infof("login failed: %s", errors)
+		log.Infof("Failed login attempt: %s", errors)
 		return errors[0]
 	}
 	return status.NotFoundErrorf("No authenticator registered to handle login path: %s", r.URL.Path)
@@ -115,7 +115,7 @@ func (a *authenticator) Auth(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 	if len(errors) > 0 {
-		log.Infof("auth failed: %s", errors)
+		log.Infof("Failed to authorize HTTP request: %s", errors)
 		return errors[0]
 	}
 	return status.NotFoundErrorf("No authenticator registered to auth path: %s", r.URL.Path)
@@ -149,7 +149,7 @@ func (a *authenticator) FillUser(ctx context.Context, user *tables.User) error {
 		}
 	}
 	if len(errors) > 0 {
-		log.Infof("fill user failed: %s", errors)
+		log.Infof("Failed to fill authenticated user fields: %s", errors)
 		return errors[0]
 	}
 	return status.UnauthenticatedErrorf("No user authenticators configured")
@@ -168,7 +168,7 @@ func (a *authenticator) AuthenticatedUser(ctx context.Context) (interfaces.UserI
 		}
 	}
 	if len(errors) > 0 {
-		log.Infof("authenticated user failed: %s", errors)
+		log.Infof("Failed to authenticate user: %s", errors)
 		return nil, errors[0]
 	}
 	return nil, status.UnauthenticatedErrorf("No user authenticators configured")


### PR DESCRIPTION
Right now we are only returning the first error for all the
authenticator errors. However, since we always configure OIDC
authenticator, only OIDC authenticator error is returned.

This is fine from user perspective, but from the sysadmin / operation
perspective, we have no way to verify whether the issue is coming from
SAML or Github authenticator to troubleshoot.

Log out the errors to help aid troubleshooting.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
