### PR TITLE
Handle ErrNoSession errors correctly in SAML flow

### DIFF
--- a/enterprise/server/saml/BUILD
+++ b/enterprise/server/saml/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//server/util/claims",
         "//server/util/cookie",
         "//server/util/flag",
+        "//server/util/log",
         "//server/util/status",
         "@com_github_crewjam_saml//:saml",
         "@com_github_crewjam_saml//samlsp",

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -23,6 +23,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
 	"github.com/buildbuddy-io/buildbuddy/server/util/cookie"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
@@ -231,7 +232,8 @@ func (a *SAMLAuthenticator) Login(w http.ResponseWriter, r *http.Request) error 
 	}
 	cookie.SetCookie(w, slugCookie, slug, time.Now().Add(cookieDuration), true /* httpOnly= */)
 	session, err := sp.Session.GetSession(r)
-	if err != nil {
+	if err != nil && err != samlsp.ErrNoSession {
+		log.Warningf("SAML error getting session: %s", err)
 		return err
 	}
 	if session != nil {


### PR DESCRIPTION
This handling was broken by: https://github.com/buildbuddy-io/buildbuddy/commit/4e1c317d3d8d33b5316d9f1f96c573607d5164cf