### PR TITLE
Fix summary text for sub-day time ranges.

### DIFF
--- a/app/format/format.tsx
+++ b/app/format/format.tsx
@@ -223,29 +223,6 @@ export function formatDate(date: Date): string {
 
 const DATE_RANGE_SEPARATOR = "\u2013";
 
-export function formatPreviousDateRange(startDate: Date, endDate?: Date, { now = new Date() } = {}): string {
-  if (usingSubDayTimeRange(startDate, endDate)) {
-    return "the previous time period";
-  }
-  if (!endDate) {
-    endDate = now;
-  }
-  if (isSameDay(now, endDate)) {
-    if (isSameDay(startDate, LOCAL_EPOCH)) {
-      return "";
-    }
-  }
-
-  if (isSameDay(startDate, endDate)) {
-    if (isSameDay(startDate, now)) {
-      return "yesterday";
-    }
-    return "the day before";
-  }
-
-  return `the previous ${differenceInCalendarDays(startDate, endDate) + 1} days`;
-}
-
 function usingSubDayTimeRange(startDate: Date, endDate?: Date): boolean {
   const startCopy = new Date(startDate);
   startCopy.setHours(0, 0, 0, 0);

--- a/enterprise/app/filter/filter_util.tsx
+++ b/enterprise/app/filter/filter_util.tsx
@@ -1,5 +1,5 @@
 import capabilities from "../../../app/capabilities/capabilities";
-import { differenceInCalendarDays, formatDateRange, formatPreviousDateRange } from "../../../app/format/format";
+import { differenceInCalendarDays, durationMillis, formatDateRange } from "../../../app/format/format";
 import * as proto from "../../../app/util/proto";
 import { google as google_duration } from "../../../proto/duration_ts_proto";
 import { google as google_timestamp } from "../../../proto/timestamp_ts_proto";
@@ -197,15 +197,22 @@ export function isExecutionMetric(m: stat_filter.Metric): boolean {
   return m.execution !== null && m.execution !== undefined;
 }
 
-export function formatPreviousDateRangeFromSearchParams(search: URLSearchParams): string {
-  const { startDate, endDate } = getDisplayDateRange(search);
-  return formatPreviousDateRange(startDate, endDate);
-}
+export function formatDateRangeDurationFromSearchParams(search: URLSearchParams): string {
+  const startDate = getStartDate(search);
+  const endDate = getEndDate(search) ?? moment(new Date()).add(1, "days").startOf("day").toDate();
+  const deltaMillis = endDate.getTime() - startDate.getTime();
 
-export function getDayCountStringFromSearchParams(search: URLSearchParams): string {
-  const { startDate, endDate } = getDisplayDateRange(search);
-  const diff = differenceInCalendarDays(startDate, endDate ?? new Date()) + 1;
-  return diff == 1 ? "1 day" : `${diff} days`;
+  if (
+    startDate.getMinutes() != 0 ||
+    endDate?.getMinutes() != 0 ||
+    startDate.getHours() != 0 ||
+    endDate?.getHours() != 0
+  ) {
+    return durationMillis(deltaMillis);
+  }
+
+  const diff = differenceInCalendarDays(startDate, endDate ?? new Date());
+  return diff == 1 ? "day" : `${diff} days`;
 }
 
 export function formatDateRangeFromSearchParams(search: URLSearchParams): string {

--- a/enterprise/app/trends/summary_card.tsx
+++ b/enterprise/app/trends/summary_card.tsx
@@ -6,8 +6,7 @@ import { stats } from "../../../proto/stats_ts_proto";
 import {
   isAnyNonDateFilterSet,
   formatDateRangeFromSearchParams,
-  formatPreviousDateRangeFromSearchParams,
-  getDayCountStringFromSearchParams,
+  formatDateRangeDurationFromSearchParams,
 } from "../filter/filter_util";
 
 interface Props {
@@ -35,17 +34,25 @@ function renderDelta(currentValue: number, previousValue: number): JSX.Element {
 export default class TrendsSummaryCard extends React.Component<Props> {
   renderChangeText(currentValue: number, previousValue: number): JSX.Element {
     if (previousValue == 0) {
-      return <div className="trend-sub-item">No data available for the previous period.</div>;
+      return (
+        <div className="trend-sub-item">
+          No data available for the previous {formatDateRangeDurationFromSearchParams(this.props.search)}.
+        </div>
+      );
     }
     const rawPercentage = (currentValue - previousValue) / previousValue;
     if (Math.abs(rawPercentage) < 0.01) {
-      return <div className="trend-sub-item">That's the same as the previous period.</div>;
+      return (
+        <div className="trend-sub-item">
+          That's the same as the previous {formatDateRangeDurationFromSearchParams(this.props.search)}.
+        </div>
+      );
     }
 
     return (
       <div className="trend-sub-item">
-        That's {renderDelta(currentValue, previousValue)} from{" "}
-        {formatPreviousDateRangeFromSearchParams(this.props.search)}.
+        That's {renderDelta(currentValue, previousValue)} from the previous{" "}
+        {formatDateRangeDurationFromSearchParams(this.props.search)}.
       </div>
     );
   }
@@ -56,7 +63,7 @@ export default class TrendsSummaryCard extends React.Component<Props> {
     const previousCacheRequestTotal =
       +(this.props.previousPeriod?.acCacheHits ?? 0) + +(this.props.previousPeriod?.acCacheMisses ?? 0);
     const previousCacheHitRate = +(this.props.previousPeriod?.acCacheHits ?? 0) / previousCacheRequestTotal;
-    const formattedTimePeriod = getDayCountStringFromSearchParams(this.props.search);
+    const formattedTimePeriod = formatDateRangeDurationFromSearchParams(this.props.search);
     return (
       <div className="trend-chart">
         <div className="trend-chart-title">
@@ -84,10 +91,9 @@ export default class TrendsSummaryCard extends React.Component<Props> {
                 {cacheRequestTotal > 0 && (
                   <span>
                     That's {renderDelta(cacheHitRate, previousCacheHitRate)} from the previous {formattedTimePeriod},
-                    when your action cache hit rate was <strong>{format.percent(previousCacheHitRate)}%</strong>
+                    when your action cache hit rate was <strong>{format.percent(previousCacheHitRate)}%</strong>.
                   </span>
                 )}
-                {"."}
               </div>
             )}
           </a>
@@ -98,15 +104,17 @@ export default class TrendsSummaryCard extends React.Component<Props> {
                 {format.cpuSavingsSec(+this.props.currentPeriod.cpuMicrosSaved / 1000000)} saved
               </span>
             </div>
-            <div className="trend-sub-item">
-              <span>
-                That's at least{" "}
-                <span className="trend-change up">
-                  {format.durationMillis(+this.props.currentPeriod.cpuMicrosSaved / 8000)}
-                </span>{" "}
-                not waiting for code to compile on an 8-core machine in the last {formattedTimePeriod}.
-              </span>
-            </div>
+            {+this.props.currentPeriod.cpuMicrosSaved > 0 && (
+              <div className="trend-sub-item">
+                <span>
+                  That's at least{" "}
+                  <span className="trend-change up">
+                    {format.durationMillis(+this.props.currentPeriod.cpuMicrosSaved / 8000)}
+                  </span>{" "}
+                  not waiting for code to compile on an 8-core machine in the last {formattedTimePeriod}.
+                </span>
+              </div>
+            )}
           </a>
         </div>
       </div>

--- a/enterprise/app/trends/trends.css
+++ b/enterprise/app/trends/trends.css
@@ -28,13 +28,12 @@
   user-select: none;
 }
 
-/*
- * A hack: cursor is not configurable in recharts, so in we go. This could be
+/* A hack: cursor is not configurable in recharts, so in we go. This could be
  * better (it currently sets cursor:pointer on the axis grid, too, but there
  * isn't a ton to be done.
  */
 .trend-chart.zoomable .recharts-surface {
-  cursor: pointer;
+  cursor: pointer; /* forgive me */
 }
 
 .trend-chart-title {

--- a/enterprise/app/trends/trends.css
+++ b/enterprise/app/trends/trends.css
@@ -28,12 +28,13 @@
   user-select: none;
 }
 
-/* A hack: cursor is not configurable in recharts, so in we go. This could be
+/*
+ * A hack: cursor is not configurable in recharts, so in we go. This could be
  * better (it currently sets cursor:pointer on the axis grid, too, but there
  * isn't a ton to be done.
  */
 .trend-chart.zoomable .recharts-surface {
-  cursor: pointer; /* forgive me */
+  cursor: pointer;
 }
 
 .trend-chart-title {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
This fixes it so that we show "6 hours" instead of "1 day" if you only have 6 hours selected, etc.  Really, this UI should probably change a bit when the ranges are so small but that's talk for later.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
