### PR TITLE
Make impersonation play better with subdomains.

### DIFF
--- a/enterprise/app/group_search/group_search.tsx
+++ b/enterprise/app/group_search/group_search.tsx
@@ -34,19 +34,9 @@ export default class GroupSearchComponent extends React.Component<{}, State> {
 
   private onSearch() {
     const query = this.state.query.trim();
-
-    // If the query looks like a group ID, navigate directly to it.
-    if (query.startsWith("GR")) {
-      const groupId = query;
-      auth_service.enterImpersonationMode(groupId);
-      return;
-    }
-
-    // Otherwise try to look up the group by its exact URL identifier.
     this.setState({ loading: true });
-    rpc_service.service
-      .getGroup(grp.GetGroupRequest.create({ urlIdentifier: query }))
-      .then((response) => auth_service.enterImpersonationMode(response.id))
+    auth_service
+      .enterImpersonationMode(query)
       .catch((e) => error_service.handleError(e))
       .finally(() => this.setState({ loading: false }));
   }

--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -94,6 +94,9 @@ message GetGroupRequest {
   //
   // Ex: "iteration-inc"
   string url_identifier = 1;
+
+  // Look up group by its unique ID.
+  string group_id = 3;
 }
 
 // Publicly visible group info.

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -48,6 +48,7 @@ go_library(
         "//server/tables",
         "//server/target",
         "//server/util/alert",
+        "//server/util/authutil",
         "//server/util/capabilities",
         "//server/util/flagutil",
         "//server/util/log",


### PR DESCRIPTION
Use a cookie instead of session storage to store the impersonated group ID so that the value can be set across subdomains.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
