### PR TITLE
Add an option to rate limit writes in migration cache

### DIFF
--- a/enterprise/server/backends/migration_cache/config.go
+++ b/enterprise/server/backends/migration_cache/config.go
@@ -21,9 +21,8 @@ type MigrationConfig struct {
 	// CopyChanFullWarningIntervalMin controls how often we should log when the copy chan is full
 	CopyChanFullWarningIntervalMin int64 `yaml:"copy_chan_full_warning_interval_min"`
 	MaxCopiesPerSec                int   `yaml:"max_copies_per_sec"`
-	// Whether we rate limit Write(). If so, we will write to destination cache
-	// in the background and use MaxCopiesPerSec to control the speed.
-	RateLimitWriteToDest bool `yaml:"rate_limit_writes"`
+	// AsyncDestWrites controls whether we write to destination cache in the background
+	AsyncDestWrites bool `yaml:"async_dest_writes"`
 }
 
 type CacheConfig struct {

--- a/enterprise/server/backends/migration_cache/config.go
+++ b/enterprise/server/backends/migration_cache/config.go
@@ -21,6 +21,9 @@ type MigrationConfig struct {
 	// CopyChanFullWarningIntervalMin controls how often we should log when the copy chan is full
 	CopyChanFullWarningIntervalMin int64 `yaml:"copy_chan_full_warning_interval_min"`
 	MaxCopiesPerSec                int   `yaml:"max_copies_per_sec"`
+	// Whether we rate limit Write(). If so, we will write to destination cache
+	// in the background and use MaxCopiesPerSec to control the speed.
+	RateLimitWriteToDest bool `yaml:"rate_limit_writes"`
 }
 
 type CacheConfig struct {

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -46,6 +46,7 @@ type MigrationCache struct {
 	copyChan                    chan *copyData
 	copyChanFullWarningInterval time.Duration
 	numCopiesDropped            *int64
+	rateLimitWriteToDest        bool
 }
 
 func Register(env environment.Env) error {
@@ -93,6 +94,7 @@ func NewMigrationCache(env environment.Env, migrationConfig *MigrationConfig, sr
 		eg:                          &errgroup.Group{},
 		copyChanFullWarningInterval: time.Duration(migrationConfig.CopyChanFullWarningIntervalMin) * time.Minute,
 		numCopiesDropped:            &zero,
+		rateLimitWriteToDest:        migrationConfig.RateLimitWriteToDest,
 	}
 }
 
@@ -752,6 +754,12 @@ func (mc *MigrationCache) Writer(ctx context.Context, r *rspb.ResourceName) (int
 		return nil, err
 	}
 
+	if mc.rateLimitWriteToDest {
+		// We will write to the destination cache in the background
+		mc.sendNonBlockingCopy(ctx, r, false /*=onlyCopyMissing*/)
+		return mc.src.Writer(ctx, r)
+	}
+
 	eg := &errgroup.Group{}
 	var dstErr error
 	var destWriter interfaces.CommittedWriteCloser
@@ -863,40 +871,15 @@ func (mc *MigrationCache) sendNonBlockingCopy(ctx context.Context, r *rspb.Resou
 }
 
 func (mc *MigrationCache) Set(ctx context.Context, r *rspb.ResourceName, data []byte) error {
-	if err := mc.checkSafeToMigrate(ctx); err != nil {
+	wc, err := mc.Writer(ctx, r)
+	if err != nil {
 		return err
 	}
-
-	eg, gctx := errgroup.WithContext(ctx)
-	var srcErr, dstErr error
-
-	// Double write data to both caches
-	eg.Go(func() error {
-		srcErr = mc.src.Set(gctx, r, data)
-		return srcErr
-	})
-
-	eg.Go(func() error {
-		dstErr = mc.dest.Set(gctx, r, data)
-		return nil // don't fail if there's an error from this cache
-	})
-
-	if err := eg.Wait(); err != nil {
-		if dstErr == nil {
-			// If error during write to source cache (source of truth), must delete from destination cache
-			deleteErr := mc.dest.Delete(ctx, r)
-			if deleteErr != nil && !status.IsNotFoundError(deleteErr) {
-				log.Warningf("Migration double write err: src write of digest %v failed, but could not delete from dest cache: %s", r.GetDigest(), deleteErr)
-			}
-		}
+	defer wc.Close()
+	if _, err := wc.Write(data); err != nil {
 		return err
 	}
-
-	if dstErr != nil {
-		log.Warningf("Migration double write err: failure writing digest %v to dest cache: %s", r.GetDigest(), dstErr)
-	}
-
-	return srcErr
+	return wc.Commit()
 }
 
 type copyData struct {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
In early stages of migration while we are backfilling from source cache, we need
the ability to rate limit writes to destination cache to avoid overwhelming the
destination cache which causes Write latency goes up and compaction debt goes up
for example.

Also in this PR, I used mc.Writer() to implement Set() method to make the logic
simpler and also allow us to write data in background in the Set() method.
