### PR TITLE
seperate pebble op metrics by different instances

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -498,7 +498,7 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 		pebbleOptions.Cache = c
 	}
 
-	db, err := pebble.Open(opts.RootDirectory, pebbleOptions)
+	db, err := pebble.Open(opts.RootDirectory, opts.Name, pebbleOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -64,7 +64,7 @@ func (fs *fakeStore) WithFileReadFn(fn fileReadFn) *fakeStore {
 }
 
 func newTestReplica(t *testing.T, rootDir string, shardID, replicaID uint64, store replica.IStore) *replica.Replica {
-	db, err := pebble.Open(rootDir, &pebble.Options{})
+	db, err := pebble.Open(rootDir, "test", &pebble.Options{})
 	require.NoError(t, err)
 
 	leaser := pebble.NewDBLeaser(db)

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -600,7 +600,7 @@ func New(rootDir string, nodeHost *dragonboat.NodeHost, gossipManager *gossip.Go
 		eg:            &errgroup.Group{},
 	}
 
-	db, err := pebble.Open(rootDir, &pebble.Options{})
+	db, err := pebble.Open(rootDir, "raft_store", &pebble.Options{})
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/util/pebble/pebble.go
+++ b/enterprise/server/util/pebble/pebble.go
@@ -375,16 +375,20 @@ func (idb *instrumentedDB) NewIndexedBatch() Batch {
 	return &instrumentedBatch{batch, batch, idb}
 }
 
-func Open(dbDir string, options *pebble.Options) (IPebbleDB, error) {
+func Open(dbDir string, id string, options *pebble.Options) (IPebbleDB, error) {
 	db, err := pebble.Open(dbDir, options)
 	if err != nil {
 		return nil, err
 	}
 
 	opMetrics := func(op string) *opMetrics {
+		metricsLabels := prometheus.Labels{
+			metrics.PebbleOperation: op,
+			metrics.PebbleID:        id,
+		}
 		return &opMetrics{
-			count: metrics.PebbleCachePebbleOpCount.With(prometheus.Labels{metrics.PebbleOperation: op}),
-			hist:  metrics.PebbleCachePebbleOpLatencyUsec.With(prometheus.Labels{metrics.PebbleOperation: op}),
+			count: metrics.PebbleCachePebbleOpCount.With(metricsLabels),
+			hist:  metrics.PebbleCachePebbleOpLatencyUsec.With(metricsLabels),
 		}
 	}
 	idb := &instrumentedDB{

--- a/enterprise/server/util/pebble/pebble_test.go
+++ b/enterprise/server/util/pebble/pebble_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestCloseLeasedDB(t *testing.T) {
 	rootDir := testfs.MakeTempDir(t)
-	db, err := pebble.Open(rootDir, &pebble.Options{})
+	db, err := pebble.Open(rootDir, "test", &pebble.Options{})
 	require.NoError(t, err)
 
 	leaser := pebble.NewDBLeaser(db)

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -189,6 +189,9 @@ const (
 	// Pebble DB operation type.
 	PebbleOperation = "pebble_op"
 
+	// Pebble DB ID
+	PebbleID = "pebble_id"
+
 	// Name of service the health check is running for (Ex "distributed_cache" or "sql_primary").
 	HealthCheckName = "health_check_name"
 
@@ -2226,6 +2229,7 @@ var (
 		Name:      "pebble_cache_pebble_op_count",
 		Help:      "The number of operations performed against the pebble database.",
 	}, []string{
+		PebbleID,
 		PebbleOperation,
 	})
 
@@ -2236,6 +2240,7 @@ var (
 		Buckets:   durationUsecBuckets(1*time.Microsecond, 30*time.Second, 10),
 		Help:      "The latency of operations performed against the pebble database, in microseconds.",
 	}, []string{
+		PebbleID,
 		PebbleOperation,
 	})
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
During cache migration, it's helpful to see the pebble op metrics separated by
cache names.
