### PR TITLE
two date range selection bug fixes

### DIFF
--- a/app/format/format.tsx
+++ b/app/format/format.tsx
@@ -260,7 +260,7 @@ export function formatDateRange(startDate: Date, endDate?: Date, { now = new Dat
   // act like the user has selected a range that includes that day--rewind to
   // the day before _for rendering purposes only_.
   // ANNOYING NOTE: because we still set dates based on YYYY-MM-DD strings in
-  // a few places, we still need to guard for the 1-day cause where start and
+  // a few places, we still need to guard for the 1-day case where start and
   // end are both the same YYYY-MM-DD string.
   if (endDate && endDate.getTime() > startDate.getTime()) {
     const startOfDay = moment(endDate).startOf("day").toDate();

--- a/app/format/format.tsx
+++ b/app/format/format.tsx
@@ -256,6 +256,19 @@ export function formatDateRange(startDate: Date, endDate?: Date, { now = new Dat
     return `${start} ${DATE_RANGE_SEPARATOR} ${end}`;
   }
 
+  // If the end date is explicitly set to midnight on a given day, we shouldn't
+  // act like the user has selected a range that includes that day--rewind to
+  // the day before _for rendering purposes only_.
+  // ANNOYING NOTE: because we still set dates based on YYYY-MM-DD strings in
+  // a few places, we still need to guard for the 1-day cause where start and
+  // end are both the same YYYY-MM-DD string.
+  if (endDate && endDate.getTime() > startDate.getTime()) {
+    const startOfDay = moment(endDate).startOf("day").toDate();
+    if (startOfDay.getTime() === endDate.getTime()) {
+      endDate = moment(startOfDay).subtract(1, "day").toDate();
+    }
+  }
+
   // Start time is at midnight, end date is (implicitly or explicitly) today.
   if (!endDate || isSameDay(now, endDate)) {
     if (isSameDay(now, startDate)) {

--- a/enterprise/app/trends/cache_chart.tsx
+++ b/enterprise/app/trends/cache_chart.tsx
@@ -177,6 +177,7 @@ export default class CacheChartComponent extends React.Component<Props, State> {
             {this.state.refAreaLeft && this.state.refAreaRight ? (
               <ReferenceArea
                 yAxisId="percent"
+                ifOverflow="visible"
                 x1={Math.min(+this.state.refAreaLeft, +this.state.refAreaRight)}
                 x2={Math.max(+this.state.refAreaLeft, +this.state.refAreaRight)}
                 strokeOpacity={0.3}

--- a/enterprise/app/trends/percentile_chart.tsx
+++ b/enterprise/app/trends/percentile_chart.tsx
@@ -165,6 +165,7 @@ export default class PercentilesChartComponent extends React.Component<Percentil
             {this.state.refAreaLeft && this.state.refAreaRight ? (
               <ReferenceArea
                 yAxisId="duration"
+                ifOverflow="visible"
                 x1={Math.min(+this.state.refAreaLeft, +this.state.refAreaRight)}
                 x2={Math.max(+this.state.refAreaLeft, +this.state.refAreaRight)}
                 strokeOpacity={0.3}

--- a/enterprise/app/trends/trends_chart.tsx
+++ b/enterprise/app/trends/trends_chart.tsx
@@ -135,9 +135,6 @@ export default class TrendsChartComponent extends React.Component<Props, State> 
 
   render() {
     const hasSecondaryAxis = this.props.extractSecondaryValue && this.props.separateAxis;
-    console.log("DATA: ");
-    console.log(this.props.data);
-    console.log(this.state.refAreaLeft + " " + this.state.refAreaRight);
     return (
       <div id={this.props.id} className={`trend-chart ${this.props.onZoomSelection ? "zoomable" : ""}`}>
         <div className="trend-chart-title">{this.props.title}</div>

--- a/enterprise/app/trends/trends_chart.tsx
+++ b/enterprise/app/trends/trends_chart.tsx
@@ -135,6 +135,9 @@ export default class TrendsChartComponent extends React.Component<Props, State> 
 
   render() {
     const hasSecondaryAxis = this.props.extractSecondaryValue && this.props.separateAxis;
+    console.log("DATA: ");
+    console.log(this.props.data);
+    console.log(this.state.refAreaLeft + " " + this.state.refAreaRight);
     return (
       <div id={this.props.id} className={`trend-chart ${this.props.onZoomSelection ? "zoomable" : ""}`}>
         <div className="trend-chart-title">{this.props.title}</div>
@@ -235,6 +238,7 @@ export default class TrendsChartComponent extends React.Component<Props, State> 
             {this.state.refAreaLeft && this.state.refAreaRight ? (
               <ReferenceArea
                 yAxisId="primary"
+                ifOverflow="visible"
                 x1={Math.min(+this.state.refAreaLeft, +this.state.refAreaRight)}
                 x2={Math.max(+this.state.refAreaLeft, +this.state.refAreaRight)}
                 strokeOpacity={0.3}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
- Let "overflowed" reference areas render as a workaround for a really weird recharts bug (it sometimes thinks that the last cell in the chart is outside of the y axis for very specific combinations of window width + number of bars in the chart, seemingly a floating point error)
- Fix date range rendering in an edge case: show "Sep 18" instead of "Sep 18-19" when the selected time range is Midnight Sep 18 - Midnight Sep 19

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
