### PR TITLE
Close pr on cancel in chunker

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2040,10 +2040,8 @@ func (cdcw *cdcWriter) Write(buf []byte) (int, error) {
 // closeChunkerAndWait closes the chunker and waiting for the data that has
 // already been passed to the chunker to be processed.
 func (cdcw *cdcWriter) closeChunkerAndWait() error {
-	closeErr := cdcw.chunker.Close()
-	if closeErr == nil {
-		cdcw.isChunkerClosed = true
-	}
+	closed, closeErr := cdcw.chunker.Close()
+	cdcw.isChunkerClosed = closed
 	if err := cdcw.eg.Wait(); err != nil {
 		return err
 	}

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2040,8 +2040,8 @@ func (cdcw *cdcWriter) Write(buf []byte) (int, error) {
 // closeChunkerAndWait closes the chunker and waiting for the data that has
 // already been passed to the chunker to be processed.
 func (cdcw *cdcWriter) closeChunkerAndWait() error {
-	closed, closeErr := cdcw.chunker.Close()
-	cdcw.isChunkerClosed = closed
+	closeErr := cdcw.chunker.Close()
+	cdcw.isChunkerClosed = true
 	if err := cdcw.eg.Wait(); err != nil {
 		return err
 	}

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -984,7 +984,7 @@ func TestReadWrite(t *testing.T) {
 	}
 }
 
-func TestWriteCancel(t *testing.T) {
+func TestWriteCancelBeforeCommit(t *testing.T) {
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
 
@@ -1026,7 +1026,61 @@ func TestWriteCancel(t *testing.T) {
 			require.NoError(t, err)
 			cancel()
 			err = wc.Commit()
+			require.ErrorContains(t, err, "context canceled")
+			err = wc.Close()
 			require.NoError(t, err)
+
+			err = pc.Stop()
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestCancelBeforeWrite(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
+
+	maxSizeBytes := int64(1_000_000_000) // 1GB
+
+	type testCase struct {
+		desc                   string
+		maxInlineFileSizeBytes int64
+		averageChunkSizeBytes  int
+		testSize               int64
+	}
+	testCases := []testCase{
+		{
+			desc:                  "chunking turned on",
+			averageChunkSizeBytes: 64 * 4,
+			testSize:              256,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			options := &pebble_cache.Options{
+				RootDirectory:          testfs.MakeTempDir(t),
+				MaxSizeBytes:           maxSizeBytes,
+				AverageChunkSizeBytes:  tc.averageChunkSizeBytes,
+				MaxInlineFileSizeBytes: tc.maxInlineFileSizeBytes,
+			}
+			pc, err := pebble_cache.NewPebbleCache(te, options)
+			require.NoError(t, err)
+			err = pc.Start()
+			require.NoError(t, err)
+
+			ctx := getAnonContext(t, te)
+			ctx, cancel := context.WithCancel(ctx)
+			rn, buf := newCASResourceBuf(t, tc.testSize)
+			// Use Writer() to set the bytes in the cache.
+			wc, err := pc.Writer(ctx, rn)
+			require.NoError(t, err, "Error getting %q writer", rn.GetDigest().GetHash())
+			cancel()
+			// Wait for cancel to take effect.
+			time.Sleep(100 * time.Millisecond)
+			_, err = wc.Write(buf)
+			require.ErrorContains(t, err, "context canceled")
+			err = wc.Commit()
+			require.ErrorContains(t, err, "context canceled")
 			err = wc.Close()
 			require.NoError(t, err)
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -729,7 +729,6 @@ func TestIsolateAnonUsers(t *testing.T) {
 func TestMetadata(t *testing.T) {
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
-	ctx := getAnonContext(t, te)
 
 	maxSizeBytes := int64(1_000_000_000) // 1GB
 
@@ -782,6 +781,7 @@ func TestMetadata(t *testing.T) {
 			for _, testSize := range testSizes {
 				desc := fmt.Sprintf("testSize: %d %s (averageChunkSizeBytes=%d)", testSize, tc.name, averageChunkSizeBytes)
 				t.Run(desc, func(t *testing.T) {
+					ctx := getAnonContext(t, te)
 					r, buf := newCASResourceBuf(t, testSize)
 					r.CacheType = tc.cacheType
 					r.Compressor = tc.compressor
@@ -1929,7 +1929,6 @@ func TestLRU(t *testing.T) {
 func TestStartupScan(t *testing.T) {
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
-	ctx := getAnonContext(t, te)
 	maxSizeBytes := int64(1_000_000_000) // 1GB
 
 	testCases := []struct {
@@ -1949,19 +1948,20 @@ func TestStartupScan(t *testing.T) {
 			digestSize:            2 * 1024,
 		},
 		{
-			desc:                  "chunking_off_inline",
-			averageChunkSizeBytes: 64 * 4,
-			digestSize:            2 * 1024,
+			desc:                   "chunking_off_inline",
+			maxInlineFileSizeBytes: 1000,
+			digestSize:             100,
 		},
 		{
-			desc:                  "chunking_off_disk",
-			averageChunkSizeBytes: 64 * 4,
-			digestSize:            2 * 1024,
+			desc:                   "chunking_off_disk",
+			maxInlineFileSizeBytes: 1000,
+			digestSize:             2000,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			ctx := getAnonContext(t, te)
 			rootDir := testfs.MakeTempDir(t)
 			options := &pebble_cache.Options{
 				RootDirectory:          rootDir,
@@ -1977,6 +1977,7 @@ func TestStartupScan(t *testing.T) {
 			for i := 0; i < 1000; i++ {
 				remoteInstanceName := fmt.Sprintf("remote-instance-%d", i)
 				r, buf := newResourceAndBuf(t, tc.digestSize, rspb.CacheType_AC, remoteInstanceName)
+				log.Infof("write i=%d", i)
 				err = pc.Set(ctx, r, buf)
 				require.NoError(t, err)
 				resources = append(resources, r)

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -729,6 +729,7 @@ func TestIsolateAnonUsers(t *testing.T) {
 func TestMetadata(t *testing.T) {
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
+	ctx := getAnonContext(t, te)
 
 	maxSizeBytes := int64(1_000_000_000) // 1GB
 
@@ -781,7 +782,6 @@ func TestMetadata(t *testing.T) {
 			for _, testSize := range testSizes {
 				desc := fmt.Sprintf("testSize: %d %s (averageChunkSizeBytes=%d)", testSize, tc.name, averageChunkSizeBytes)
 				t.Run(desc, func(t *testing.T) {
-					ctx := getAnonContext(t, te)
 					r, buf := newCASResourceBuf(t, testSize)
 					r.CacheType = tc.cacheType
 					r.Compressor = tc.compressor
@@ -1929,6 +1929,7 @@ func TestLRU(t *testing.T) {
 func TestStartupScan(t *testing.T) {
 	te := testenv.GetTestEnv(t)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
+	ctx := getAnonContext(t, te)
 	maxSizeBytes := int64(1_000_000_000) // 1GB
 
 	testCases := []struct {
@@ -1961,7 +1962,6 @@ func TestStartupScan(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			ctx := getAnonContext(t, te)
 			rootDir := testfs.MakeTempDir(t)
 			options := &pebble_cache.Options{
 				RootDirectory:          rootDir,
@@ -1977,7 +1977,6 @@ func TestStartupScan(t *testing.T) {
 			for i := 0; i < 1000; i++ {
 				remoteInstanceName := fmt.Sprintf("remote-instance-%d", i)
 				r, buf := newResourceAndBuf(t, tc.digestSize, rspb.CacheType_AC, remoteInstanceName)
-				log.Infof("write i=%d", i)
 				err = pc.Set(ctx, r, buf)
 				require.NoError(t, err)
 				resources = append(resources, r)

--- a/enterprise/server/util/chunker/chunker.go
+++ b/enterprise/server/util/chunker/chunker.go
@@ -103,9 +103,9 @@ func New(ctx context.Context, averageSize int, writeChunkFn WriteFunc) (*Chunker
 
 	go func() {
 		<-ctx.Done()
-		pr.CloseWithError(ctx.Err())
 		c.mu.Lock()
 		defer c.mu.Unlock()
+		pr.CloseWithError(ctx.Err())
 		if c.err == nil {
 			c.err = ctx.Err()
 		}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Close pr instead of pw in the chunker on context cancellation.

pw.Write() returns "io: read/write on closed pipe" if pw is already closed.
However, if we close the pr with ctx.Err(), then pw.Write() will return the
given error. 

We also need to let Chunker.Close() return an error if the context
is cancelled, so that Commit() in pebble cache will return early and not writing
0 chunk to pebble.
