### PR TITLE
make clicks on smallest-possible buckets go directly to build history

### DIFF
--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -12,7 +12,6 @@ import {
   PERSISTENT_URL_PARAMS,
   START_DATE_PARAM_NAME,
 } from "./router_params";
-import { getStartDate, getEndDate } from "../../enterprise/app/filter/filter_util";
 
 class Router {
   user?: User;
@@ -162,12 +161,6 @@ class Router {
   navigateToDatePreserveHash(startTimeMillis: number, endTimeMillis?: number) {
     const url = new URL(window.location.href);
 
-    const currentStart = getStartDate(url.searchParams).getTime();
-    const currentEnd = getEndDate(url.searchParams)?.getTime();
-    if (currentStart === startTimeMillis && currentEnd === endTimeMillis) {
-      return;
-    }
-
     url.searchParams.set(START_DATE_PARAM_NAME, String(startTimeMillis));
     if (endTimeMillis) {
       url.searchParams.set(END_DATE_PARAM_NAME, String(endTimeMillis));
@@ -176,7 +169,8 @@ class Router {
     }
     url.searchParams.delete(LAST_N_DAYS_PARAM_NAME);
     url.hash = window.location.hash;
-    window.history.pushState({}, "", url.href);
+
+    this.navigateTo(url.href);
   }
 
   /**

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -12,6 +12,7 @@ import {
   PERSISTENT_URL_PARAMS,
   START_DATE_PARAM_NAME,
 } from "./router_params";
+import { getStartDate, getEndDate } from "../../enterprise/app/filter/filter_util";
 
 class Router {
   user?: User;
@@ -151,7 +152,8 @@ class Router {
 
   /**
    * Sets the date to the specified start and end times. A missing end time
-   * will cause the end of the range to be left open (i.e., "until now").
+   * will cause the end of the range to be left open (i.e., "until now"). If
+   * the new date range matches the current selection, this is a no-op.
    *
    * - Creates a new browser history entry.
    * - Preserves global filter params except "days" if set.
@@ -159,6 +161,13 @@ class Router {
    */
   navigateToDatePreserveHash(startTimeMillis: number, endTimeMillis?: number) {
     const url = new URL(window.location.href);
+
+    const currentStart = getStartDate(url.searchParams).getTime();
+    const currentEnd = getEndDate(url.searchParams)?.getTime();
+    if (currentStart === startTimeMillis && currentEnd === endTimeMillis) {
+      return;
+    }
+
     url.searchParams.set(START_DATE_PARAM_NAME, String(startTimeMillis));
     if (endTimeMillis) {
       url.searchParams.set(END_DATE_PARAM_NAME, String(endTimeMillis));

--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -160,7 +160,6 @@ class Router {
    */
   navigateToDatePreserveHash(startTimeMillis: number, endTimeMillis?: number) {
     const url = new URL(window.location.href);
-
     url.searchParams.set(START_DATE_PARAM_NAME, String(startTimeMillis));
     if (endTimeMillis) {
       url.searchParams.set(END_DATE_PARAM_NAME, String(endTimeMillis));

--- a/enterprise/app/trends/cache_chart.tsx
+++ b/enterprise/app/trends/cache_chart.tsx
@@ -75,8 +75,7 @@ export default class CacheChartComponent extends React.Component<Props, State> {
 
   onMouseDown(e: CategoricalChartState) {
     if (!this.props.onZoomSelection || !e) {
-      this.state.refAreaLeft = undefined;
-      this.state.refAreaRight = undefined;
+      this.setState({ refAreaLeft: undefined, refAreaRight: undefined });
       return;
     }
     this.setState({ refAreaLeft: e.activeLabel, refAreaRight: e.activeLabel });
@@ -84,20 +83,18 @@ export default class CacheChartComponent extends React.Component<Props, State> {
 
   onMouseMove(e: CategoricalChartState) {
     if (!this.props.onZoomSelection || !e) {
-      this.state.refAreaLeft = undefined;
-      this.state.refAreaRight = undefined;
+      this.setState({ refAreaLeft: undefined, refAreaRight: undefined });
       return;
     }
     if (!this.state.refAreaLeft) {
       return;
     }
-    this.state.refAreaLeft && this.setState({ refAreaRight: e.activeLabel });
+    this.setState({ refAreaRight: e.activeLabel });
   }
 
   onMouseUp(e: CategoricalChartState) {
     if (!this.props.onZoomSelection || !e) {
-      this.state.refAreaLeft = undefined;
-      this.state.refAreaRight = undefined;
+      this.setState({ refAreaLeft: undefined, refAreaRight: undefined });
       return;
     }
     const finalRightValue = e.activeLabel;
@@ -110,8 +107,7 @@ export default class CacheChartComponent extends React.Component<Props, State> {
       }
       this.props.onZoomSelection(v1, v2);
     }
-    this.state.refAreaLeft = undefined;
-    this.state.refAreaRight = undefined;
+    this.setState({ refAreaLeft: undefined, refAreaRight: undefined });
   }
 
   shouldRenderTooltip(): boolean {

--- a/enterprise/app/trends/percentile_chart.tsx
+++ b/enterprise/app/trends/percentile_chart.tsx
@@ -49,8 +49,7 @@ export default class PercentilesChartComponent extends React.Component<Percentil
 
   onMouseDown(e: CategoricalChartState) {
     if (!this.props.onZoomSelection || !e) {
-      this.state.refAreaLeft = undefined;
-      this.state.refAreaRight = undefined;
+      this.setState({ refAreaLeft: undefined, refAreaRight: undefined });
       return;
     }
     this.setState({ refAreaLeft: e.activeLabel, refAreaRight: e.activeLabel });
@@ -58,20 +57,18 @@ export default class PercentilesChartComponent extends React.Component<Percentil
 
   onMouseMove(e: CategoricalChartState) {
     if (!this.props.onZoomSelection || !e) {
-      this.state.refAreaLeft = undefined;
-      this.state.refAreaRight = undefined;
+      this.setState({ refAreaLeft: undefined, refAreaRight: undefined });
       return;
     }
     if (!this.state.refAreaLeft) {
       return;
     }
-    this.state.refAreaLeft && this.setState({ refAreaRight: e.activeLabel });
+    this.setState({ refAreaRight: e.activeLabel });
   }
 
   onMouseUp(e: CategoricalChartState) {
     if (!this.props.onZoomSelection || !e) {
-      this.state.refAreaLeft = undefined;
-      this.state.refAreaRight = undefined;
+      this.setState({ refAreaLeft: undefined, refAreaRight: undefined });
       return;
     }
     const finalRightValue = e.activeLabel;
@@ -84,8 +81,7 @@ export default class PercentilesChartComponent extends React.Component<Percentil
       }
       this.props.onZoomSelection(v1, v2);
     }
-    this.state.refAreaLeft = undefined;
-    this.state.refAreaRight = undefined;
+    this.setState({ refAreaLeft: undefined, refAreaRight: undefined });
   }
 
   shouldRenderTooltip(): boolean {

--- a/enterprise/app/trends/simple_trends_tab.tsx
+++ b/enterprise/app/trends/simple_trends_tab.tsx
@@ -89,7 +89,7 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
     return <div>Overview...</div>;
   }
 
-  onChartZoomed(low: number, high: number) {
+  onChartZoomed(sortBy: string, low: number, high: number) {
     if (!this.state.trendsModel) {
       return;
     }
@@ -114,6 +114,14 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
     } else {
       end = timeKeys[highBucketIndex + 1];
     }
+
+    // If the user selects a time range 5 minutes or smaller, short-circuit
+    // and take them straight to the build history page because the chart
+    // can't get any more detailed than this.
+    if ((end ?? new Date().getTime()) - low <= 5 * 60 * 1000) {
+      router.navigateTo("/?start=" + low + "&end=" + end + "&sort-by=" + sortBy);
+    }
+
     router.navigateToDatePreserveHash(low, end);
   }
 
@@ -142,7 +150,9 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
           secondaryLine={true}
           separateAxis={true}
           onBarClicked={this.onBarClicked.bind(this, "", "")}
-          onZoomSelection={capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined}
+          onZoomSelection={
+            capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
+          }
         />
         {model.hasInvocationStatPercentiles() && (
           <PercentilesChartComponent
@@ -159,7 +169,7 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
             extractP99={(tsMillis) => +(model.getStat(tsMillis).buildTimeUsecP99 ?? 0) * SECONDS_PER_MICROSECOND}
             onColumnClicked={this.onBarClicked.bind(this, "", "duration")}
             onZoomSelection={
-              capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined
+              capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "duration") : undefined
             }
           />
         )}
@@ -184,7 +194,7 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
             onBarClicked={this.onBarClicked.bind(this, "", "")}
             onSecondaryBarClicked={this.onBarClicked.bind(this, "", "duration")}
             onZoomSelection={
-              capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined
+              capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
             }
           />
         )}
@@ -270,7 +280,9 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
           extractHits={(tsMillis) => +(model.getStat(tsMillis).actionCacheHits ?? 0)}
           secondaryBarName="misses"
           extractSecondary={(tsMillis) => +(model.getStat(tsMillis).actionCacheMisses ?? 0)}
-          onZoomSelection={capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined}
+          onZoomSelection={
+            capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
+          }
         />
         <CacheChartComponent
           title="Content Addressable Store"
@@ -281,7 +293,9 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
           extractHits={(tsMillis) => +(model.getStat(tsMillis).casCacheHits ?? 0)}
           secondaryBarName="writes"
           extractSecondary={(tsMillis) => +(model.getStat(tsMillis).casCacheUploads ?? 0)}
-          onZoomSelection={capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined}
+          onZoomSelection={
+            capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
+          }
         />
         <TrendsChartComponent
           title="Cache read throughput"
@@ -303,7 +317,9 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
           secondaryName="download rate"
           secondaryLine={true}
           separateAxis={true}
-          onZoomSelection={capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined}
+          onZoomSelection={
+            capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
+          }
         />
 
         <TrendsChartComponent
@@ -325,7 +341,9 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
           secondaryName="upload rate"
           secondaryLine={true}
           separateAxis={true}
-          onZoomSelection={capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined}
+          onZoomSelection={
+            capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
+          }
         />
 
         {capabilities.config.trendsSummaryEnabled && (
@@ -342,7 +360,7 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
             formatHoverValue={(value) => `${format.durationSec(value || 0)} CPU time saved`}
             name="saved cpu time"
             onZoomSelection={
-              capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined
+              capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
             }
           />
         )}
@@ -374,7 +392,9 @@ export default class SimpleTrendsTabComponent extends React.Component<Props, Sta
           extractP99={(tsMillis) =>
             +(model.getExecutionStat(tsMillis).queueDurationUsecP99 ?? 0) * SECONDS_PER_MICROSECOND
           }
-          onZoomSelection={capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined}
+          onZoomSelection={
+            capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
+          }
         />
       )
     );

--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -225,7 +225,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
     router.navigateTo("/?start=" + date + "&end=" + date + "&sort-by=" + sortBy + hash);
   }
 
-  onChartZoomed(low: number, high: number) {
+  onChartZoomed(sortBy: string, low: number, high: number) {
     // Low is the start point, but high is actually the low bound of the bucket
     // that the user selected, so we need to compute the high bound of that
     // bucket using our list of keys.
@@ -246,6 +246,14 @@ export default class TrendsComponent extends React.Component<Props, State> {
     } else {
       end = this.state.timeKeys[highBucketIndex + 1];
     }
+
+    // If the user selects a time range 5 minutes or smaller, short-circuit
+    // and take them straight to the build history page because the chart
+    // can't get any more detailed than this.
+    if ((end ?? new Date().getTime()) - low <= 5 * 60 * 1000) {
+      router.navigateTo("/?start=" + low + "&end=" + end + "&sort-by=" + sortBy);
+    }
+
     router.navigateToDatePreserveHash(low, end);
   }
 
@@ -319,7 +327,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 separateAxis={true}
                 onBarClicked={this.onBarClicked.bind(this, "", "")}
                 onZoomSelection={
-                  capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined
+                  capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
                 }
               />
               {this.state.enableInvocationPercentileCharts && (
@@ -337,7 +345,9 @@ export default class TrendsComponent extends React.Component<Props, State> {
                   extractP99={(tsMillis) => +(this.getStat(tsMillis).buildTimeUsecP99 ?? 0) * SECONDS_PER_MICROSECOND}
                   onColumnClicked={this.onBarClicked.bind(this, "", "duration")}
                   onZoomSelection={
-                    capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined
+                    capabilities.config.trendsRangeSelectionEnabled
+                      ? this.onChartZoomed.bind(this, "duration")
+                      : undefined
                   }
                 />
               )}
@@ -362,7 +372,9 @@ export default class TrendsComponent extends React.Component<Props, State> {
                   onBarClicked={this.onBarClicked.bind(this, "", "")}
                   onSecondaryBarClicked={this.onBarClicked.bind(this, "", "duration")}
                   onZoomSelection={
-                    capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined
+                    capabilities.config.trendsRangeSelectionEnabled
+                      ? this.onChartZoomed.bind(this, "duration")
+                      : undefined
                   }
                 />
               )}
@@ -378,7 +390,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 secondaryBarName="misses"
                 extractSecondary={(tsMillis) => +(this.getStat(tsMillis).actionCacheMisses ?? 0)}
                 onZoomSelection={
-                  capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined
+                  capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
                 }
               />
               <CacheChartComponent
@@ -391,7 +403,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 secondaryBarName="writes"
                 extractSecondary={(tsMillis) => +(this.getStat(tsMillis).casCacheUploads ?? 0)}
                 onZoomSelection={
-                  capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined
+                  capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
                 }
               />
 
@@ -416,7 +428,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 secondaryLine={true}
                 separateAxis={true}
                 onZoomSelection={
-                  capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined
+                  capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
                 }
               />
 
@@ -440,7 +452,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 secondaryLine={true}
                 separateAxis={true}
                 onZoomSelection={
-                  capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined
+                  capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
                 }
               />
 
@@ -460,7 +472,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                   formatHoverValue={(value) => `${format.durationSec(value || 0)} CPU time saved`}
                   name="saved cpu time"
                   onZoomSelection={
-                    capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined
+                    capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
                   }
                 />
               )}
@@ -552,7 +564,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
                     +(this.getExecutionStat(tsMillis).queueDurationUsecP99 ?? 0) * SECONDS_PER_MICROSECOND
                   }
                   onZoomSelection={
-                    capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this) : undefined
+                    capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
                   }
                 />
               )}

--- a/enterprise/app/trends/trends_chart.tsx
+++ b/enterprise/app/trends/trends_chart.tsx
@@ -90,8 +90,7 @@ export default class TrendsChartComponent extends React.Component<Props, State> 
 
   onMouseDown(e: CategoricalChartState) {
     if (!this.props.onZoomSelection || !e) {
-      this.state.refAreaLeft = undefined;
-      this.state.refAreaRight = undefined;
+      this.setState({ refAreaLeft: undefined, refAreaRight: undefined });
       return;
     }
     this.setState({ refAreaLeft: e.activeLabel, refAreaRight: e.activeLabel });
@@ -99,20 +98,18 @@ export default class TrendsChartComponent extends React.Component<Props, State> 
 
   onMouseMove(e: CategoricalChartState) {
     if (!this.props.onZoomSelection || !e) {
-      this.state.refAreaLeft = undefined;
-      this.state.refAreaRight = undefined;
+      this.setState({ refAreaLeft: undefined, refAreaRight: undefined });
       return;
     }
     if (!this.state.refAreaLeft) {
       return;
     }
-    this.state.refAreaLeft && this.setState({ refAreaRight: e.activeLabel });
+    this.setState({ refAreaRight: e.activeLabel });
   }
 
   onMouseUp(e: CategoricalChartState) {
     if (!this.props.onZoomSelection || !e) {
-      this.state.refAreaLeft = undefined;
-      this.state.refAreaRight = undefined;
+      this.setState({ refAreaLeft: undefined, refAreaRight: undefined });
       return;
     }
     const finalRightValue = e.activeLabel;
@@ -125,8 +122,7 @@ export default class TrendsChartComponent extends React.Component<Props, State> 
       }
       this.props.onZoomSelection(v1, v2);
     }
-    this.state.refAreaLeft = undefined;
-    this.state.refAreaRight = undefined;
+    this.setState({ refAreaLeft: undefined, refAreaRight: undefined });
   }
 
   shouldRenderTooltip(): boolean {

--- a/enterprise/app/trends/trends_chart.tsx
+++ b/enterprise/app/trends/trends_chart.tsx
@@ -135,9 +135,6 @@ export default class TrendsChartComponent extends React.Component<Props, State> 
 
   render() {
     const hasSecondaryAxis = this.props.extractSecondaryValue && this.props.separateAxis;
-    console.log("DATA: ");
-    console.log(this.props.data);
-    console.log(this.state.refAreaLeft + " " + this.state.refAreaRight);
     return (
       <div id={this.props.id} className={`trend-chart ${this.props.onZoomSelection ? "zoomable" : ""}`}>
         <div className="trend-chart-title">{this.props.title}</div>

--- a/enterprise/app/trends/trends_chart.tsx
+++ b/enterprise/app/trends/trends_chart.tsx
@@ -135,6 +135,9 @@ export default class TrendsChartComponent extends React.Component<Props, State> 
 
   render() {
     const hasSecondaryAxis = this.props.extractSecondaryValue && this.props.separateAxis;
+    console.log("DATA: ");
+    console.log(this.props.data);
+    console.log(this.state.refAreaLeft + " " + this.state.refAreaRight);
     return (
       <div id={this.props.id} className={`trend-chart ${this.props.onZoomSelection ? "zoomable" : ""}`}>
         <div className="trend-chart-title">{this.props.title}</div>


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
currently, these clicks do worse than nothing--if the date range doesnt change, they just push an extra entry onto the history stack for the user to back up through.

this makes these bars go straight to the build history page, which is maybe not the *most* intuitive thing, but it's definitely better than what we've got now.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
