### PR TITLE
Add a bogus trendsSummary for initial loading to keep layout steady

### DIFF
--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -51,6 +51,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
     enableInvocationPercentileCharts: false,
     timeKeys: [],
     ticks: [],
+    currentSummary: capabilities.config.trendsSummaryEnabled ? stats.Summary.create({}) : undefined,
   };
 
   subscription?: Subscription;


### PR DESCRIPTION
We should be showing the summary in the vast majority of cases in prod at this point (i.e., the user needs to choose a 6-month date range and refresh the page or something like that), so this seems like a better default than the opposite.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
