### PR TITLE
Export Cache Usage data to consumers via prometheus

### DIFF
--- a/enterprise/server/backends/prom/prom.go
+++ b/enterprise/server/backends/prom/prom.go
@@ -50,13 +50,40 @@ var (
 				Type: dto.MetricType_HISTOGRAM.Enum(),
 			},
 		},
+		{
+			sourceMetricName: "buildbuddy_remote_cache_num_hits_exported",
+			labelNames:       []string{metrics.CacheTypeLabel},
+			exportedFamily: &dto.MetricFamily{
+				Name: proto.String("exported_buildbuddy_remote_cache_num_hits"),
+				Help: proto.String("Number of cache hits"),
+				Type: dto.MetricType_GAUGE.Enum(),
+			},
+		},
+		{
+			sourceMetricName: "buildbuddy_remote_cache_download_size_bytes_exported",
+			labelNames:       []string{},
+			exportedFamily: &dto.MetricFamily{
+				Name: proto.String("exported_buildbuddy_remote_cache_download_size_bytes"),
+				Help: proto.String("Number of bytes downloaded from the remote cache"),
+				Type: dto.MetricType_GAUGE.Enum(),
+			},
+		},
+		{
+			sourceMetricName: "buildbuddy_remote_cache_upload_size_bytes_exported",
+			labelNames:       []string{},
+			exportedFamily: &dto.MetricFamily{
+				Name: proto.String("exported_buildbuddy_remote_cache_upload_size_bytes"),
+				Help: proto.String("Number of bytes uploaded to the remote cache"),
+				Type: dto.MetricType_GAUGE.Enum(),
+			},
+		},
 	}
 )
 
 const (
 	redisMetricsKeyPrefix = "exportedMetrics"
 	// The version in redis cache, as part of the redis key.
-	version = "v1"
+	version = "v2"
 	// The time for the metrics to expire in redis.
 	metricsExpiration = 30*time.Second - 50*time.Millisecond
 

--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//enterprise/server/util/redisutil",
         "//server/environment",
         "//server/interfaces",
+        "//server/metrics",
         "//server/tables",
         "//server/util/alert",
         "//server/util/authutil",
@@ -20,6 +21,7 @@ go_library(
         "//server/util/status",
         "//server/util/timeutil",
         "@com_github_go_redis_redis_v8//:redis",
+        "@com_github_prometheus_client_golang//prometheus",
     ],
 )
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -368,6 +368,16 @@ var (
 		CacheEventTypeLabel,
 	})
 
+	CacheNumHitsExported = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "num_hits_exported",
+		Help:      "Number of cache hits.",
+	}, []string{
+		CacheTypeLabel,
+		GroupID,
+	})
+
 	CacheDownloadSizeBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",
@@ -377,6 +387,15 @@ var (
 	}, []string{
 		CacheTypeLabel,
 		ServerName,
+	})
+
+	CacheDownloadSizeBytesExported = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "download_size_bytes_exported",
+		Help:      "Number of bytes downloaded from the remote cache.",
+	}, []string{
+		GroupID,
 	})
 
 	// #### Examples
@@ -415,6 +434,15 @@ var (
 	}, []string{
 		CacheTypeLabel,
 		ServerName,
+	})
+
+	CacheUploadSizeBytesExported = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "upload_size_bytes_exported",
+		Help:      "Number of bytes uploaded to the remote cache",
+	}, []string{
+		GroupID,
 	})
 
 	// #### Examples

--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -560,6 +560,7 @@ func (h *HitTracker) recordCacheUsage(ctx context.Context, d *repb.Digest, actio
 	if err != nil {
 		return status.WrapError(err, "get usage labels")
 	}
+
 	return h.usage.Increment(h.ctx, labels, c)
 }
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A

This covers Action cache hits, CAS hits, total bytes downloaded from cache,
total bytes uploaded to cache.

Add new counter metrics instead of using the existing histogram since I need to add group id label and don't want to increase cardinality. 
