### PR TITLE
two minor interaction improvements for the drilldowns page.

### DIFF
--- a/enterprise/app/trends/drilldown_page.tsx
+++ b/enterprise/app/trends/drilldown_page.tsx
@@ -530,7 +530,7 @@ export default class DrilldownPageComponent extends React.Component<Props, State
 
   roundDateRangesAndAddZoomFiltersToQuery(query: CommonQueryFields) {
     // updatedAfter should always be set, but typescript can't know that.
-    if (query.updatedAfter) {
+    if (!capabilities.config.trendsRangeSelectionEnabled && query.updatedAfter) {
       query.updatedAfter = usecToTimestamp(
         moment(+query.updatedAfter.seconds * 1000)
           .startOf("day")

--- a/enterprise/app/trends/drilldown_page.tsx
+++ b/enterprise/app/trends/drilldown_page.tsx
@@ -306,7 +306,7 @@ export default class DrilldownPageComponent extends React.Component<Props, State
       updatedAfter: filterParams.updatedAfter,
       status: filterParams.status,
     });
-    this.roundDateRangesAndAddZoomFiltersToQuery(drilldownRequest.query);
+    this.roundEndDateAndAddZoomFiltersToQuery(drilldownRequest.query);
     drilldownRequest.filter = this.toStatFilterList(this.currentHeatmapSelection);
     drilldownRequest.drilldownMetric = this.selectedMetric.metric;
     rpcService.service
@@ -347,7 +347,7 @@ export default class DrilldownPageComponent extends React.Component<Props, State
       pageToken: "",
       count: 25,
     });
-    this.roundDateRangesAndAddZoomFiltersToQuery(request.query!);
+    this.roundEndDateAndAddZoomFiltersToQuery(request.query!);
 
     rpcService.service
       .searchExecution(request)
@@ -393,7 +393,7 @@ export default class DrilldownPageComponent extends React.Component<Props, State
       pageToken: "",
       count: 25,
     });
-    this.roundDateRangesAndAddZoomFiltersToQuery(request.query!);
+    this.roundEndDateAndAddZoomFiltersToQuery(request.query!);
 
     rpcService.service
       .searchInvocation(request)
@@ -447,7 +447,7 @@ export default class DrilldownPageComponent extends React.Component<Props, State
       maximumDuration: isExecution ? undefined : filterParams.maximumDuration,
       status: filterParams.status,
     });
-    this.roundDateRangesAndAddZoomFiltersToQuery(heatmapRequest.query);
+    this.roundEndDateAndAddZoomFiltersToQuery(heatmapRequest.query);
 
     rpcService.service
       .getStatHeatmap(heatmapRequest)
@@ -528,15 +528,7 @@ export default class DrilldownPageComponent extends React.Component<Props, State
     });
   }
 
-  roundDateRangesAndAddZoomFiltersToQuery(query: CommonQueryFields) {
-    // updatedAfter should always be set, but typescript can't know that.
-    if (!capabilities.config.trendsRangeSelectionEnabled && query.updatedAfter) {
-      query.updatedAfter = usecToTimestamp(
-        moment(+query.updatedAfter.seconds * 1000)
-          .startOf("day")
-          .unix() * 1e6
-      );
-    }
+  roundEndDateAndAddZoomFiltersToQuery(query: CommonQueryFields) {
     if (!query.updatedBefore) {
       // Always explicitly set "now" to the start of the next day so that the
       // length of the last bucket doesn't change on page refresh.  This

--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -12,7 +12,7 @@ import { Subscription } from "rxjs";
 import FilterComponent from "../filter/filter";
 import capabilities from "../../../app/capabilities/capabilities";
 import { getProtoFilterParams, getEndDate } from "../filter/filter_util";
-import router from "../../../app/router/router";
+import router, { Path } from "../../../app/router/router";
 import * as proto from "../../../app/util/proto";
 import DrilldownPageComponent from "./drilldown_page";
 import { computeTimeKeys } from "./common";
@@ -79,7 +79,7 @@ export default class TrendsComponent extends React.Component<Props, State> {
   }
 
   updateSelectedTab(tab: "charts" | "drilldown") {
-    window.location.hash = "#" + tab;
+    router.navigateTo(Path.trendsPath + "#" + tab);
   }
 
   getSelectedTab(): "charts" | "drilldown" {


### PR DESCRIPTION
- don't round heatmap start date to start-of-day.  this is obsolete now that we've changed "last 30 days" to "midnight 30 days ago".  all it does now is make the heatmap look weird when the user picks "14:05-14:10" and it shows "00:00-14:10" instead.
- use `navigateTo` when switching trends tabs so that drilldown params get blown away--this prevents weirdness when going back and forth between charts + heatmap (e.g., if you switch the date selection on the charts page, the "selected" area might "not include builds" anymore).
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
