### PR TITLE
tsconfig: update rootdirs for target-linux

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,8 @@
       "bazel-bin",
       "bazel-out/k8-opt/bin",
       "bazel-out/k8-fastbuild/bin",
+      "bazel-out/platform_linux-fastbuild/bin",
+      "bazel-out/platform_linux-opt/bin",
       "bazel-out/darwin-opt/bin",
       "bazel-out/darwin-fastbuild/bin",
       "bazel-out/darwin_arm64-opt/bin",


### PR DESCRIPTION
In #4769, we make it so that `--config=target-linux` would store outputs
in a new dir with name includes the platform information.

Include this new dir schema in tsconfig.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
