### PR TITLE
firecracker: simplify chroot provisioning

### DIFF
--- a/buildpatches/com_github_firecracker_microvm_firecracker_go_sdk_jailer.patch
+++ b/buildpatches/com_github_firecracker_microvm_firecracker_go_sdk_jailer.patch
@@ -1,0 +1,25 @@
+diff --git a/jailer.go b/jailer.go
+index e261fae..a5e055d 100644
+--- a/jailer.go
++++ b/jailer.go
+@@ -413,10 +413,19 @@ func LinkFilesHandler(kernelImageFileName string) Handler {
+ 			}
+ 
+ 			// copy all drives to the root fs
++			rootfsPrefix := rootfs + string(os.PathSeparator)
+ 			for i, drive := range m.Cfg.Drives {
+ 				hostPath := StringValue(drive.PathOnHost)
+-				driveFileName := filepath.Base(hostPath)
+ 
++				// If the provided host path is already within the rootfs then just
++				// update the drive path to be rootfs-relative.
++				if strings.HasPrefix(hostPath, rootfsPrefix) {
++					rootfsRelativePath := strings.TrimPrefix(hostPath, rootfsPrefix)
++					m.Cfg.Drives[i].PathOnHost = String(rootfsRelativePath)
++					continue
++				}
++
++				driveFileName := filepath.Base(hostPath)
+ 				if err := os.Link(
+ 					hostPath,
+ 					filepath.Join(rootfs, driveFileName),

--- a/deps.bzl
+++ b/deps.bzl
@@ -1591,6 +1591,12 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "com_github_firecracker_microvm_firecracker_go_sdk",
         importpath = "github.com/firecracker-microvm/firecracker-go-sdk",
+        patch_args = ["-p1"],
+        # TODO(bduffany): when
+        # https://github.com/firecracker-microvm/firecracker-go-sdk/pull/510 is
+        # merged, cherry-pick the final revision into our fork, and remove this
+        # patch.
+        patches = ["@{}//buildpatches:com_github_firecracker_microvm_firecracker_go_sdk_jailer.patch".format(workspace_name)],
         replace = "github.com/buildbuddy-io/firecracker-go-sdk",
         sum = "h1:Wx6fPNZOs0SJ9NpTsLbJsItORvEM9D94k/vr8ZwIBEg=",
         version = "v0.0.0-20230721-1d5c50b",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -363,7 +363,6 @@ type FirecrackerContainer struct {
 	containerImage   string // the OCI container image. ex "alpine:latest"
 	actionWorkingDir string // the action directory with inputs / outputs
 	containerFSPath  string // the path to the container ext4 image
-	tempDir          string // path for writing disk images before the chroot is created
 	user             string // user to execute all commands as
 
 	rmOnce *sync.Once
@@ -1649,27 +1648,12 @@ func (c *FirecrackerContainer) create(ctx context.Context) error {
 	c.rmOnce = &sync.Once{}
 	c.rmErr = nil
 
-	var err error
-	c.tempDir, err = os.MkdirTemp(c.jailerRoot, "fc-container-*")
-	if err != nil {
-		return err
-	}
 	if err := os.MkdirAll(c.getChroot(), 0755); err != nil {
 		return status.InternalErrorf("failed to create chroot dir: %s", err)
 	}
 
 	scratchFSPath := c.scratchFSPath()
 	workspaceFSPath := c.workspaceFSPath()
-
-	// When mounting the workspace image directly as a block device (rather than
-	// as an NBD), the firecracker go SDK expects the disk images to be outside
-	// the chroot, and will move them to the chroot for us. So we place them in
-	// a temp dir so that the SDK doesn't complain that the chroot paths already
-	// exist when it tries to create them.
-	if !*enableNBD {
-		scratchFSPath = filepath.Join(c.tempDir, scratchFSName)
-		workspaceFSPath = filepath.Join(c.tempDir, workspaceFSName)
-	}
 	if *EnableRootfs {
 		if err := c.initRootfsStore(ctx); err != nil {
 			return status.WrapError(err, "create root image")
@@ -1685,7 +1669,6 @@ func (c *FirecrackerContainer) create(ctx context.Context) error {
 	if err := c.createWorkspaceImage(ctx, "" /*=workspaceDir*/, workspaceFSPath); err != nil {
 		return err
 	}
-	log.CtxDebugf(ctx, "Scratch and workspace disk images written to %q", c.tempDir)
 	log.CtxDebugf(ctx, "Using container image at %q", c.containerFSPath)
 	log.CtxDebugf(ctx, "getChroot() is %q", c.getChroot())
 	fcCfg, err := c.getConfig(ctx, c.containerFSPath, scratchFSPath, workspaceFSPath)
@@ -1983,12 +1966,6 @@ func (c *FirecrackerContainer) remove(ctx context.Context) error {
 	if err := c.cleanupNetworking(ctx); err != nil {
 		log.CtxErrorf(ctx, "Error cleaning up networking: %s", err)
 		lastErr = err
-	}
-	if c.tempDir != "" {
-		if err := os.RemoveAll(c.tempDir); err != nil {
-			log.CtxErrorf(ctx, "Error removing workspace fs: %s", err)
-			lastErr = err
-		}
 	}
 	if err := os.RemoveAll(filepath.Dir(c.getChroot())); err != nil {
 		log.CtxErrorf(ctx, "Error removing chroot: %s", err)


### PR DESCRIPTION
Instead of having firecracker-go-sdk hardlink files into the chroot for us, we now create the files directly in the chroot. This is required in order to use FUSE for the disk image files, since the SDK's hardlink attempt would fail as it crosses filesystem boundaries. It also results in simpler code - the current `tempDir` approach was purely working around the SDK's hardlinking behavior.

This requires patching the go SDK to skip hardlinking in the case where the file is already inside the chroot. I have sent https://github.com/firecracker-microvm/firecracker-go-sdk/pull/510 to upstream the patch.

**Related issues**: N/A
