### PR TITLE
Don't set `--network` flag on podman exec

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -524,9 +524,6 @@ func (c *podmanCommandContainer) Exec(ctx context.Context, cmd *repb.Command, st
 		podmanRunArgs = append(podmanRunArgs, "--env", fmt.Sprintf("%s=%s", envVar.GetName(), envVar.GetValue()))
 	}
 	podmanRunArgs = addUserArgs(podmanRunArgs, c.options)
-	if strings.ToLower(c.options.Network) == "off" {
-		podmanRunArgs = append(podmanRunArgs, "--network=none")
-	}
 	if stdio.Stdin != nil {
 		podmanRunArgs = append(podmanRunArgs, "--interactive")
 	}


### PR DESCRIPTION
When re-using podman containers, we shouldn't set the `--network` flag because the `podman exec` command doesn't take the flag like `podman run` does (`podman create` does instead).