### PR TITLE
Remove enable_firecracker from local executor config

### DIFF
--- a/enterprise/config/executor.local.yaml
+++ b/enterprise/config/executor.local.yaml
@@ -3,6 +3,5 @@ executor:
   local_cache_directory: "/tmp/${USER}_filecache"
   docker_socket: /var/run/docker.sock
   docker_inherit_user_ids: true
-  enable_firecracker: true
   app_target: "grpc://localhost:1985"
   local_cache_size_bytes: 10000000000 # 10GB


### PR DESCRIPTION
Firecracker requires a bit of setup to get working properly, especially now that we're making it a hard requirement to run the executor as root. Remove it from the default local config.

**Related issues**: N/A
