### PR TITLE
[Remote Snapshot] Add recycled runner status to dirty chunk metrics

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -713,6 +713,7 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 		KernelImagePath:     kernelImagePath,
 		InitrdImagePath:     initrdImagePath,
 		ChunkedFiles:        map[string]*copy_on_write.COWStore{},
+		Recycled:            c.recycled,
 	}
 	if *enableVBD {
 		if c.rootStore != nil {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -991,7 +991,7 @@ var (
 	// histogram_quantile(
 	//   0.95,
 	//   sum by(le, group_id) (
-	//      rate(buildbuddy_firecracker_stage_duration_msec_bucket{job="executor-workflows", stage="task_lifecycle"}[5m])
+	//      rate(buildbuddy_firecracker_stage_duration_usec_bucket{job="executor-workflows", stage="task_lifecycle"}[5m])
 	//     )
 	//  )
 	// ```
@@ -1005,6 +1005,7 @@ var (
 	}, []string{
 		GroupID,
 		FileName,
+		RecycledRunnerStatus,
 	})
 
 	// #### Examples
@@ -1014,7 +1015,7 @@ var (
 	// # Visualize with the Bar Gauge type
 	// # Legend: {{le}}
 	// # Format: Heatmap
-	// sum(buildbuddy_firecracker_cow_snapshot_dirty_chunk_ratio) by(le)
+	// sum(buildbuddy_firecracker_cow_snapshot_dirty_chunk_ratio_bucket) by(le)
 	// ```
 
 	COWSnapshotDirtyBytes = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -1025,6 +1026,7 @@ var (
 	}, []string{
 		GroupID,
 		FileName,
+		RecycledRunnerStatus,
 	})
 
 	RecycleRunnerRequests = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
We'd expect to see fewer dirty chunks with recycled VMs. Without this field, it's harder to interpret the data.
