### PR TITLE
Automatically include client identity in intra-server RPCs.

### DIFF
--- a/cli/ask/ask.go
+++ b/cli/ask/ask.go
@@ -96,7 +96,7 @@ func HandleAsk(args []string) (int, error) {
 		lastBackend = "grpcs://" + lastBackend
 	}
 
-	conn, err := grpc_client.DialTarget(lastBackend)
+	conn, err := grpc_client.DialSimple(lastBackend)
 	if err != nil {
 		return 1, err
 	}

--- a/cli/cmd/sidecar/sidecar.go
+++ b/cli/cmd/sidecar/sidecar.go
@@ -177,7 +177,7 @@ func registerBESProxy(env *real_environment.RealEnv, grpcServer *grpc.Server) {
 
 func registerCacheProxy(ctx context.Context, env *real_environment.RealEnv, grpcServer *grpc.Server) {
 	cacheTarget := normalizeGrpcTarget(*remoteCache)
-	conn, err := grpc_client.DialTarget(cacheTarget)
+	conn, err := grpc_client.DialSimple(cacheTarget)
 	if err != nil {
 		log.Fatalf("Error dialing remote cache: %s", err.Error())
 	}

--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -86,7 +86,7 @@ func downloadFile(uri string) error {
 		return err
 	}
 
-	conn, err := grpc_client.DialTarget(*target)
+	conn, err := grpc_client.DialSimple(*target)
 	if err != nil {
 		return err
 	}

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -478,7 +478,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 	healthChecker := healthcheck.NewHealthChecker("ci-runner")
 	env := real_environment.NewRealEnv(healthChecker)
 
-	conn, err := grpc_client.DialTarget(opts.Server)
+	conn, err := grpc_client.DialSimple(opts.Server)
 	if err != nil {
 		return 0, status.UnavailableErrorf("could not connect to BuildBuddy remote bazel service %q: %s", opts.Server, err)
 	}
@@ -574,7 +574,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 	}
 
 	if fetchOutputs && exitCode == 0 {
-		conn, err := grpc_client.DialTarget(opts.Server)
+		conn, err := grpc_client.DialSimple(opts.Server)
 		if err != nil {
 			return 0, fmt.Errorf("could not communicate with sidecar: %s", err)
 		}

--- a/cli/sidecar/sidecar.go
+++ b/cli/sidecar/sidecar.go
@@ -235,7 +235,7 @@ func stripProtocol(target string) string {
 // sidecar alive as long as this process is alive by issuing background ping
 // requests.
 func keepaliveSidecar(ctx context.Context, sidecarSocket string) error {
-	conn, err := grpc_client.DialTarget("unix://" + sidecarSocket)
+	conn, err := grpc_client.DialSimple("unix://" + sidecarSocket)
 	if err != nil {
 		return err
 	}

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -91,7 +91,7 @@ func uploadFile(args []string) error {
 		ctx = metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-api-key", apiKey)
 	}
 
-	conn, err := grpc_client.DialTarget(*target)
+	conn, err := grpc_client.DialSimple(*target)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/backends/distributed/distributed_test.go
+++ b/enterprise/server/backends/distributed/distributed_test.go
@@ -58,7 +58,7 @@ func newMemoryCache(t *testing.T, maxSizeBytes int64) interfaces.Cache {
 }
 
 func waitForReady(t *testing.T, addr string) {
-	conn, err := grpc_client.DialTarget("grpc://"+addr, grpc.WithBlock(), grpc.WithTimeout(maxWaitForReadyDuration))
+	conn, err := grpc_client.DialSimple("grpc://"+addr, grpc.WithBlock(), grpc.WithTimeout(maxWaitForReadyDuration))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/server/build_event_publisher/build_event_publisher.go
+++ b/enterprise/server/build_event_publisher/build_event_publisher.go
@@ -86,7 +86,7 @@ func (p *Publisher) Start(ctx context.Context) {
 // run performs a single attempt to stream any currently buffered events
 // as well as all subsequently published events to the BES backend.
 func (p *Publisher) run(ctx context.Context) error {
-	conn, err := grpc_client.DialTarget(p.besBackend)
+	conn, err := grpc_client.DialSimple(p.besBackend)
 	if err != nil {
 		return status.WrapError(err, "error dialing bes_backend")
 	}

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1014,7 +1014,7 @@ func uploadRunfiles(ctx context.Context, workspaceRoot, runfilesDir string) ([]*
 	if err != nil {
 		return nil, nil, err
 	}
-	conn, err := grpc_client.DialTarget(*cacheBackend)
+	conn, err := grpc_client.DialSimple(*cacheBackend)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1494,7 +1494,7 @@ func (ws *workspace) sync(ctx context.Context) error {
 	}
 
 	if len(*patchURIs) > 0 {
-		conn, err := grpc_client.DialTarget(*cacheBackend)
+		conn, err := grpc_client.DialSimple(*cacheBackend)
 		if err != nil {
 			return err
 		}

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -73,7 +73,7 @@ func InitializeCacheClientsOrDie(cacheTarget string, realEnv *real_environment.R
 	} else if u, err := url.Parse(cacheTarget); err == nil && u.Hostname() == "cloud.buildbuddy.io" {
 		log.Warning("You are using the old BuildBuddy endpoint, cloud.buildbuddy.io. Migrate `executor.app_target` to remote.buildbuddy.io for improved performance.")
 	}
-	conn, err = grpc_client.DialTarget(cacheTarget)
+	conn, err = grpc_client.Dial(realEnv, cacheTarget)
 	if err != nil {
 		log.Fatalf("Unable to connect to cache '%s': %s", cacheTarget, err)
 	}
@@ -138,7 +138,7 @@ func GetConfiguredEnvironmentOrDie(healthChecker *healthcheck.HealthChecker) env
 		}
 	}
 
-	conn, err := grpc_client.DialTarget(*appTarget)
+	conn, err := grpc_client.Dial(realEnv, *appTarget)
 	if err != nil {
 		log.Fatalf("Unable to connect to app '%s': %s", *appTarget, err)
 	}

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -73,7 +73,7 @@ func InitializeCacheClientsOrDie(cacheTarget string, realEnv *real_environment.R
 	} else if u, err := url.Parse(cacheTarget); err == nil && u.Hostname() == "cloud.buildbuddy.io" {
 		log.Warning("You are using the old BuildBuddy endpoint, cloud.buildbuddy.io. Migrate `executor.app_target` to remote.buildbuddy.io for improved performance.")
 	}
-	conn, err = grpc_client.Dial(realEnv, cacheTarget)
+	conn, err = grpc_client.DialInterservice(realEnv, cacheTarget)
 	if err != nil {
 		log.Fatalf("Unable to connect to cache '%s': %s", cacheTarget, err)
 	}
@@ -138,7 +138,7 @@ func GetConfiguredEnvironmentOrDie(healthChecker *healthcheck.HealthChecker) env
 		}
 	}
 
-	conn, err := grpc_client.Dial(realEnv, *appTarget)
+	conn, err := grpc_client.DialInterservice(realEnv, *appTarget)
 	if err != nil {
 		log.Fatalf("Unable to connect to app '%s': %s", *appTarget, err)
 	}

--- a/enterprise/server/cmd/executor/executor.go
+++ b/enterprise/server/cmd/executor/executor.go
@@ -73,7 +73,7 @@ func InitializeCacheClientsOrDie(cacheTarget string, realEnv *real_environment.R
 	} else if u, err := url.Parse(cacheTarget); err == nil && u.Hostname() == "cloud.buildbuddy.io" {
 		log.Warning("You are using the old BuildBuddy endpoint, cloud.buildbuddy.io. Migrate `executor.app_target` to remote.buildbuddy.io for improved performance.")
 	}
-	conn, err = grpc_client.DialInterservice(realEnv, cacheTarget)
+	conn, err = grpc_client.DialInternal(realEnv, cacheTarget)
 	if err != nil {
 		log.Fatalf("Unable to connect to cache '%s': %s", cacheTarget, err)
 	}
@@ -138,7 +138,7 @@ func GetConfiguredEnvironmentOrDie(healthChecker *healthcheck.HealthChecker) env
 		}
 	}
 
-	conn, err := grpc_client.DialInterservice(realEnv, *appTarget)
+	conn, err := grpc_client.DialInternal(realEnv, *appTarget)
 	if err != nil {
 		log.Fatalf("Unable to connect to app '%s': %s", *appTarget, err)
 	}

--- a/enterprise/server/cmd/smash/smash.go
+++ b/enterprise/server/cmd/smash/smash.go
@@ -95,7 +95,7 @@ func writeBlobsForReading(ctx context.Context, numBlobs int) []*repb.Digest {
 	if *ssl {
 		prefix = "grpcs://"
 	}
-	conn, err := grpc_client.DialTarget(prefix + *cacheTarget)
+	conn, err := grpc_client.DialSimple(prefix + *cacheTarget)
 	if err != nil {
 		log.Fatalf("Unable to connect to cache '%s': %s", *cacheTarget, err)
 	}

--- a/enterprise/server/iprules/iprules.go
+++ b/enterprise/server/iprules/iprules.go
@@ -279,10 +279,6 @@ func (s *Service) AuthorizeHTTPRequest(ctx context.Context, r *http.Request) err
 		return nil
 	}
 
-	if r.URL.Path == "/rpc/BuildBuddyService/GetGroup" {
-		return nil
-	}
-
 	// All other APIs are subject to IP access checks.
 	if strings.HasPrefix(r.URL.Path, "/rpc/") || strings.HasPrefix(r.URL.Path, "/api/") {
 		err := s.Authorize(ctx)

--- a/enterprise/server/iprules/iprules.go
+++ b/enterprise/server/iprules/iprules.go
@@ -279,6 +279,10 @@ func (s *Service) AuthorizeHTTPRequest(ctx context.Context, r *http.Request) err
 		return nil
 	}
 
+	if r.URL.Path == "/rpc/BuildBuddyService/GetGroup" {
+		return nil
+	}
+
 	// All other APIs are subject to IP access checks.
 	if strings.HasPrefix(r.URL.Path, "/rpc/") || strings.HasPrefix(r.URL.Path, "/api/") {
 		err := s.Authorize(ctx)

--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -60,7 +60,7 @@ func (c *APIClient) getClient(ctx context.Context, peer string) (rfspb.ApiClient
 	if client, ok := c.clients[peer]; ok {
 		return client, nil
 	}
-	conn, err := grpc_client.DialTarget("grpc://" + peer)
+	conn, err := grpc_client.DialSimple("grpc://" + peer)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -214,7 +214,7 @@ additionallayerstores=["/var/lib/soci-store/store:ref"]
 }
 
 func intializeSociArtifactStoreClient(env environment.Env, target string) (socipb.SociArtifactStoreClient, error) {
-	conn, err := grpc_client.DialTarget(target)
+	conn, err := grpc_client.DialSimple(target)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func intializeSociArtifactStoreClient(env environment.Env, target string) (socip
 }
 
 func initializeSociStoreKeychainClient(env environment.Env, target string) (sspb.LocalKeychainClient, error) {
-	conn, err := grpc_client.DialTarget(target)
+	conn, err := grpc_client.DialSimple(target)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/remote_execution/redis_client/redis_client.go
+++ b/enterprise/server/remote_execution/redis_client/redis_client.go
@@ -28,7 +28,7 @@ func RegisterRemoteExecutionClient(env environment.Env) error {
 	if err != nil {
 		return status.InternalErrorf("Error initializing remote execution client: %s", err)
 	}
-	conn, err := grpc_client.DialTarget(fmt.Sprintf("grpc://localhost:%d", grpc_port))
+	conn, err := grpc_client.Dial(env, fmt.Sprintf("grpc://localhost:%d", grpc_port))
 	if err != nil {
 		return status.InternalErrorf("Error initializing remote execution client: %s", err)
 	}

--- a/enterprise/server/remote_execution/redis_client/redis_client.go
+++ b/enterprise/server/remote_execution/redis_client/redis_client.go
@@ -28,7 +28,7 @@ func RegisterRemoteExecutionClient(env environment.Env) error {
 	if err != nil {
 		return status.InternalErrorf("Error initializing remote execution client: %s", err)
 	}
-	conn, err := grpc_client.DialInterservice(env, fmt.Sprintf("grpc://localhost:%d", grpc_port))
+	conn, err := grpc_client.DialInternal(env, fmt.Sprintf("grpc://localhost:%d", grpc_port))
 	if err != nil {
 		return status.InternalErrorf("Error initializing remote execution client: %s", err)
 	}

--- a/enterprise/server/remote_execution/redis_client/redis_client.go
+++ b/enterprise/server/remote_execution/redis_client/redis_client.go
@@ -28,7 +28,7 @@ func RegisterRemoteExecutionClient(env environment.Env) error {
 	if err != nil {
 		return status.InternalErrorf("Error initializing remote execution client: %s", err)
 	}
-	conn, err := grpc_client.Dial(env, fmt.Sprintf("grpc://localhost:%d", grpc_port))
+	conn, err := grpc_client.DialInterservice(env, fmt.Sprintf("grpc://localhost:%d", grpc_port))
 	if err != nil {
 		return status.InternalErrorf("Error initializing remote execution client: %s", err)
 	}

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -789,7 +789,7 @@ func (c *schedulerClientCache) get(hostPort string) (schedulerClient, error) {
 			client = schedulerClient{localServer: c.localServer}
 		} else {
 			// This is non-blocking so it's OK to hold the lock.
-			conn, err := grpc_client.Dial(c.env, "grpc://"+hostPort)
+			conn, err := grpc_client.DialInterservice(c.env, "grpc://"+hostPort)
 			if err != nil {
 				return schedulerClient{}, status.UnavailableErrorf("could not dial scheduler: %s", err)
 			}

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -789,7 +789,7 @@ func (c *schedulerClientCache) get(hostPort string) (schedulerClient, error) {
 			client = schedulerClient{localServer: c.localServer}
 		} else {
 			// This is non-blocking so it's OK to hold the lock.
-			conn, err := grpc_client.DialInterservice(c.env, "grpc://"+hostPort)
+			conn, err := grpc_client.DialInternal(c.env, "grpc://"+hostPort)
 			if err != nil {
 				return schedulerClient{}, status.UnavailableErrorf("could not dial scheduler: %s", err)
 			}

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -740,6 +740,8 @@ func (c *schedulerClient) EnqueueTaskReservation(ctx context.Context, request *s
 }
 
 type schedulerClientCache struct {
+	env environment.Env
+
 	mu      sync.Mutex
 	clients map[string]schedulerClient
 	// Address of this app instance. If the destination address matches the address of this instance, we call into
@@ -748,8 +750,9 @@ type schedulerClientCache struct {
 	localServer         *SchedulerServer
 }
 
-func newSchedulerClientCache(localServerHostPort string, localServer *SchedulerServer) *schedulerClientCache {
+func newSchedulerClientCache(env environment.Env, localServerHostPort string, localServer *SchedulerServer) *schedulerClientCache {
 	cache := &schedulerClientCache{
+		env:                 env,
 		clients:             make(map[string]schedulerClient),
 		localServerHostPort: localServerHostPort,
 		localServer:         localServer,
@@ -786,7 +789,7 @@ func (c *schedulerClientCache) get(hostPort string) (schedulerClient, error) {
 			client = schedulerClient{localServer: c.localServer}
 		} else {
 			// This is non-blocking so it's OK to hold the lock.
-			conn, err := grpc_client.DialTarget("grpc://" + hostPort)
+			conn, err := grpc_client.Dial(c.env, "grpc://"+hostPort)
 			if err != nil {
 				return schedulerClient{}, status.UnavailableErrorf("could not dial scheduler: %s", err)
 			}
@@ -883,7 +886,7 @@ func NewSchedulerServerWithOptions(env environment.Env, options *Options) (*Sche
 		enableRedisAvailabilityMonitoring: remote_execution_config.RemoteExecutionEnabled() && env.GetRemoteExecutionService().RedisAvailabilityMonitoringEnabled(),
 		ownHostPort:                       fmt.Sprintf("%s:%d", ownHostname, ownPort),
 	}
-	s.schedulerClientCache = newSchedulerClientCache(s.ownHostPort, s)
+	s.schedulerClientCache = newSchedulerClientCache(env, s.ownHostPort, s)
 	return s, nil
 }
 

--- a/enterprise/server/tasksize_model/tasksize_model.go
+++ b/enterprise/server/tasksize_model/tasksize_model.go
@@ -105,7 +105,7 @@ func New(env environment.Env) (*Model, error) {
 	}
 
 	// Connect to TF serving.
-	conn, err := grpc_client.DialTarget(*servingAddress)
+	conn, err := grpc_client.DialSimple(*servingAddress)
 	if err != nil {
 		return nil, status.UnavailableErrorf("failed to dial TensorFlow serving at %s: %s", *servingAddress, err)
 	}

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -377,7 +377,7 @@ func newBuildBuddyServer(t *testing.T, env *buildBuddyServerEnv, opts *BuildBudd
 	}
 	server.start()
 
-	clientConn, err := grpc_client.DialTarget(fmt.Sprintf("grpc://localhost:%d", port))
+	clientConn, err := grpc_client.DialSimple(fmt.Sprintf("grpc://localhost:%d", port))
 	if err != nil {
 		assert.FailNowf(t, "could not connect to BuildBuddy server", err.Error())
 	}

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -151,7 +151,7 @@ func (c *CacheProxy) getClient(ctx context.Context, peer string) (dcpb.Distribut
 		return client, nil
 	}
 	log.Debugf("Creating new client for peer: %q", peer)
-	conn, err := grpc_client.DialTarget("grpc://" + peer)
+	conn, err := grpc_client.Dial(c.env, "grpc://"+peer)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -151,7 +151,7 @@ func (c *CacheProxy) getClient(ctx context.Context, peer string) (dcpb.Distribut
 		return client, nil
 	}
 	log.Debugf("Creating new client for peer: %q", peer)
-	conn, err := grpc_client.Dial(c.env, "grpc://"+peer)
+	conn, err := grpc_client.DialInterservice(c.env, "grpc://"+peer)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -151,7 +151,7 @@ func (c *CacheProxy) getClient(ctx context.Context, peer string) (dcpb.Distribut
 		return client, nil
 	}
 	log.Debugf("Creating new client for peer: %q", peer)
-	conn, err := grpc_client.DialInterservice(c.env, "grpc://"+peer)
+	conn, err := grpc_client.DialInternal(c.env, "grpc://"+peer)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/tools/rbeperf/rbeperf.go
+++ b/enterprise/tools/rbeperf/rbeperf.go
@@ -839,7 +839,7 @@ func main() {
 		}
 	}
 
-	clientConn, err := grpc_client.DialTarget(*server, grpc.WithBlock(), grpc.WithTimeout(5*time.Second))
+	clientConn, err := grpc_client.DialSimple(*server, grpc.WithBlock(), grpc.WithTimeout(5*time.Second))
 	if err != nil {
 		log.Fatalf("Could not connect to server %q: %s", *server, err)
 	}

--- a/enterprise/tools/replay_action/replay_action.go
+++ b/enterprise/tools/replay_action/replay_action.go
@@ -126,7 +126,7 @@ func printOutputFile(ctx context.Context, from bspb.ByteStreamClient, d *repb.Di
 }
 
 func getClients(target string) (bspb.ByteStreamClient, repb.ExecutionClient, repb.ContentAddressableStorageClient) {
-	conn, err := grpc_client.DialTarget(target)
+	conn, err := grpc_client.DialSimple(target)
 	if err != nil {
 		log.Fatalf("Error dialing executor: %s", err.Error())
 	}

--- a/enterprise/tools/vmstart/vmstart.go
+++ b/enterprise/tools/vmstart/vmstart.go
@@ -57,7 +57,7 @@ func getToolEnv() *real_environment.RealEnv {
 	fc.WaitForDirectoryScanToComplete()
 	re.SetFileCache(fc)
 
-	conn, err := grpc_client.DialTarget(*cacheTarget)
+	conn, err := grpc_client.DialSimple(*cacheTarget)
 	if err != nil {
 		log.Fatalf("Unable to connect to cache '%s': %s", *cacheTarget, err)
 	}

--- a/server/build_event_protocol/build_event_proxy/build_event_proxy.go
+++ b/server/build_event_protocol/build_event_proxy/build_event_proxy.go
@@ -34,7 +34,7 @@ func (c *BuildEventProxyClient) reconnectIfNecessary() {
 	}
 	c.clientMux.Lock()
 	defer c.clientMux.Unlock()
-	conn, err := grpc_client.DialTarget(c.target)
+	conn, err := grpc_client.DialSimple(c.target)
 	if err != nil {
 		log.Warningf("Unable to connect to proxy host '%s': %s", c.target, err)
 		c.client = nil

--- a/server/bytestream/bytestream.go
+++ b/server/bytestream/bytestream.go
@@ -184,7 +184,7 @@ func streamFromUrl(ctx context.Context, env environment.Env, url *url.URL, grpcs
 		url.Host = url.Hostname() + ":80"
 	}
 
-	conn, err := grpc_client.Dial(env, grpcTargetForFileURL(url, grpcs))
+	conn, err := grpc_client.DialInterservice(env, grpcTargetForFileURL(url, grpcs))
 	if err != nil {
 		return err
 	}

--- a/server/bytestream/bytestream.go
+++ b/server/bytestream/bytestream.go
@@ -184,7 +184,7 @@ func streamFromUrl(ctx context.Context, env environment.Env, url *url.URL, grpcs
 		url.Host = url.Hostname() + ":80"
 	}
 
-	conn, err := grpc_client.DialInterservice(env, grpcTargetForFileURL(url, grpcs))
+	conn, err := grpc_client.DialInternal(env, grpcTargetForFileURL(url, grpcs))
 	if err != nil {
 		return err
 	}

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -257,7 +257,7 @@ func registerLocalGRPCClients(env environment.Env) error {
 	// Identify ourselves as an app client in gRPC requests to other apps.
 	usageutil.SetClientType("app")
 
-	conn, err := grpc_client.DialTarget(fmt.Sprintf("grpc://localhost:%d", grpc_server.Port()))
+	conn, err := grpc_client.Dial(env, fmt.Sprintf("grpc://localhost:%d", grpc_server.Port()))
 	if err != nil {
 		return status.InternalErrorf("Error initializing ByteStreamClient: %s", err)
 	}

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -257,7 +257,7 @@ func registerLocalGRPCClients(env environment.Env) error {
 	// Identify ourselves as an app client in gRPC requests to other apps.
 	usageutil.SetClientType("app")
 
-	conn, err := grpc_client.DialInterservice(env, fmt.Sprintf("grpc://localhost:%d", grpc_server.Port()))
+	conn, err := grpc_client.DialInternal(env, fmt.Sprintf("grpc://localhost:%d", grpc_server.Port()))
 	if err != nil {
 		return status.InternalErrorf("Error initializing ByteStreamClient: %s", err)
 	}

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -257,7 +257,7 @@ func registerLocalGRPCClients(env environment.Env) error {
 	// Identify ourselves as an app client in gRPC requests to other apps.
 	usageutil.SetClientType("app")
 
-	conn, err := grpc_client.Dial(env, fmt.Sprintf("grpc://localhost:%d", grpc_server.Port()))
+	conn, err := grpc_client.DialInterservice(env, fmt.Sprintf("grpc://localhost:%d", grpc_server.Port()))
 	if err != nil {
 		return status.InternalErrorf("Error initializing ByteStreamClient: %s", err)
 	}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -65,7 +65,7 @@ func Register(env environment.Env) error {
 	}
 	env.SetCASServer(casServer)
 
-	conn, err := grpc_client.Dial(env, fmt.Sprintf("grpc://localhost:%d", grpc_server.Port()))
+	conn, err := grpc_client.DialInterservice(env, fmt.Sprintf("grpc://localhost:%d", grpc_server.Port()))
 	casClient := repb.NewContentAddressableStorageClient(conn)
 	if err != nil {
 		return status.InternalErrorf("Error initializing ContentAddressableStorageClient: %s", err)

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -65,7 +65,7 @@ func Register(env environment.Env) error {
 	}
 	env.SetCASServer(casServer)
 
-	conn, err := grpc_client.DialTarget(fmt.Sprintf("grpc://localhost:%d", grpc_server.Port()))
+	conn, err := grpc_client.Dial(env, fmt.Sprintf("grpc://localhost:%d", grpc_server.Port()))
 	casClient := repb.NewContentAddressableStorageClient(conn)
 	if err != nil {
 		return status.InternalErrorf("Error initializing ContentAddressableStorageClient: %s", err)

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -65,7 +65,7 @@ func Register(env environment.Env) error {
 	}
 	env.SetCASServer(casServer)
 
-	conn, err := grpc_client.DialInterservice(env, fmt.Sprintf("grpc://localhost:%d", grpc_server.Port()))
+	conn, err := grpc_client.DialInternal(env, fmt.Sprintf("grpc://localhost:%d", grpc_server.Port()))
 	casClient := repb.NewContentAddressableStorageClient(conn)
 	if err != nil {
 		return status.InternalErrorf("Error initializing ContentAddressableStorageClient: %s", err)

--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -482,20 +482,26 @@ func GetStreamInterceptor(env environment.Env) grpc.ServerOption {
 	)
 }
 
-func GetUnaryClientInterceptor(env environment.Env) grpc.DialOption {
+func GetUnaryClientInterceptor() grpc.DialOption {
 	return grpc.WithChainUnaryInterceptor(
 		otelgrpc.UnaryClientInterceptor(),
 		grpc_prometheus.UnaryClientInterceptor,
 		setHeadersUnaryClientInterceptor(),
-		setClientIdentityUnaryClientInteceptor(env),
 	)
 }
 
-func GetStreamClientInterceptor(env environment.Env) grpc.DialOption {
+func GetUnaryClientIdentityInterceptor(env environment.Env) grpc.DialOption {
+	return grpc.WithChainUnaryInterceptor(setClientIdentityUnaryClientInteceptor(env))
+}
+
+func GetStreamClientInterceptor() grpc.DialOption {
 	return grpc.WithChainStreamInterceptor(
 		otelgrpc.StreamClientInterceptor(),
 		grpc_prometheus.StreamClientInterceptor,
 		setHeadersStreamClientInterceptor(),
-		setClientIdentityStreamClientInterceptor(env),
 	)
+}
+
+func GetStreamClientIdentityInterceptor(env environment.Env) grpc.DialOption {
+	return grpc.WithChainStreamInterceptor(setClientIdentityStreamClientInterceptor(env))
 }

--- a/server/rpc/interceptors/interceptors_test.go
+++ b/server/rpc/interceptors/interceptors_test.go
@@ -84,7 +84,7 @@ func BenchmarkInstrumentedClient(b *testing.B) {
 		grpcServer.Serve(lis)
 	}()
 
-	conn, err := grpc_client.DialTarget("grpc://" + listenAddr)
+	conn, err := grpc_client.DialSimple("grpc://" + listenAddr)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -176,7 +176,7 @@ func BenchmarkInstrumentedAll(b *testing.B) {
 		grpcServer.Serve(lis)
 	}()
 
-	conn, err := grpc_client.DialTarget("grpc://" + listenAddr)
+	conn, err := grpc_client.DialSimple("grpc://" + listenAddr)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/server/telemetry/telemetry_client.go
+++ b/server/telemetry/telemetry_client.go
@@ -84,7 +84,7 @@ func (t *TelemetryClient) Stop() {
 
 func (t *TelemetryClient) logTelemetryData() {
 	ctx := t.env.GetServerContext()
-	conn, err := grpc_client.DialTarget(*telemetryEndpoint)
+	conn, err := grpc_client.DialSimple(*telemetryEndpoint)
 	if err != nil {
 		log.Debugf("Error dialing endpoint: %s", err)
 		return

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -89,7 +89,7 @@ func (te *TestEnv) LocalGRPCServer() (*grpc.Server, func()) {
 }
 
 func (te *TestEnv) LocalGRPCConn(ctx context.Context, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	dialOptions := grpc_client.CommonGRPCClientOptions(te)
+	dialOptions := grpc_client.CommonGRPCClientOptions()
 	dialOptions = append(dialOptions, grpc.WithContextDialer(te.bufDialer))
 	dialOptions = append(dialOptions, grpc.WithInsecure())
 	dialOptions = append(dialOptions, opts...)

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -89,7 +89,7 @@ func (te *TestEnv) LocalGRPCServer() (*grpc.Server, func()) {
 }
 
 func (te *TestEnv) LocalGRPCConn(ctx context.Context, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	dialOptions := grpc_client.CommonGRPCClientOptions()
+	dialOptions := grpc_client.CommonGRPCClientOptions(te)
 	dialOptions = append(dialOptions, grpc.WithContextDialer(te.bufDialer))
 	dialOptions = append(dialOptions, grpc.WithInsecure())
 	dialOptions = append(dialOptions, opts...)

--- a/server/testutil/testgrpc/testgrpc.go
+++ b/server/testutil/testgrpc/testgrpc.go
@@ -77,7 +77,7 @@ func (p *Proxy) GRPCTarget() string {
 }
 
 func (p *Proxy) Dial() *grpc.ClientConn {
-	conn, err := grpc_client.DialTarget(p.GRPCTarget())
+	conn, err := grpc_client.DialSimple(p.GRPCTarget())
 	require.NoError(p.t, err)
 	return conn
 }
@@ -90,7 +90,7 @@ func RandomDialer(targets ...string) Director {
 		r := rand.Intn(len(targets))
 		for i := 0; i < len(targets); i++ {
 			target := targets[(r+i)%len(targets)]
-			cc, err = grpc_client.DialTarget(target)
+			cc, err = grpc_client.DialSimple(target)
 			if status.IsUnavailableError(err) {
 				continue
 			}

--- a/server/util/grpc_client/BUILD
+++ b/server/util/grpc_client/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/grpc_client",
     visibility = ["//visibility:public"],
     deps = [
+        "//server/environment",
         "//server/rpc/interceptors",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials/google",

--- a/server/util/grpc_client/grpc_client.go
+++ b/server/util/grpc_client/grpc_client.go
@@ -16,17 +16,17 @@ import (
 // DialSimple handles some of the logic around detecting the correct GRPC
 // connection type and applying relevant options when connecting.
 //
-// NOTE: Clients within BuildBuddy servers (i.e. executor) should use the Dial
+// NOTE: Clients within BuildBuddy servers (i.e. executor) should use the DialInterservice
 // variant with an env argument.
 func DialSimple(target string, extraOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
-	return Dial(nil, target, extraOptions...)
+	return DialInterservice(nil, target, extraOptions...)
 }
 
-// Dial is similar to DialSimple, but it adds additional interceptors
+// DialInterservice is similar to DialSimple, but it adds additional interceptors
 // (such as client identity) based on the specified environment.
 //
 // Outside of BuildBuddy servers, DialSimple may be used instead.
-func Dial(env environment.Env, target string, extraOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
+func DialInterservice(env environment.Env, target string, extraOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
 	dialOptions := CommonGRPCClientOptions(env)
 	dialOptions = append(dialOptions, extraOptions...)
 	u, err := url.Parse(target)

--- a/server/util/grpc_client/grpc_client.go
+++ b/server/util/grpc_client/grpc_client.go
@@ -16,8 +16,9 @@ import (
 // DialSimple handles some of the logic around detecting the correct GRPC
 // connection type and applying relevant options when connecting.
 //
-// NOTE: Clients within BuildBuddy servers (i.e. app, executor) should use the
-// DialInternal variant with an env argument.
+// This function should be used when dialing from outside of BuildBuddy servers
+// such as from cli tools and the like. When dialing from BuildBuddy servers
+// (app, executor) you should use DialInternal.
 func DialSimple(target string, extraOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
 	dialOptions := CommonGRPCClientOptions()
 	dialOptions = append(dialOptions, extraOptions...)

--- a/tools/cacheload/cacheload.go
+++ b/tools/cacheload/cacheload.go
@@ -185,7 +185,7 @@ func main() {
 		monitoring.StartMonitoringHandler(fmt.Sprintf("%s:%d", *listen, *monitoringPort))
 	}
 
-	conn, err := grpc_client.DialTarget(*cacheTarget, grpc.WithBlock(), grpc.WithTimeout(*timeout))
+	conn, err := grpc_client.DialSimple(*cacheTarget, grpc.WithBlock(), grpc.WithTimeout(*timeout))
 	if err != nil {
 		log.Fatalf("Unable to connect to target '%s': %s", *cacheTarget, err)
 	}

--- a/tools/cas/cas.go
+++ b/tools/cas/cas.go
@@ -90,7 +90,7 @@ func main() {
 		ind = digest.NewResourceName(ind.GetDigest(), *instanceName, ind.GetCacheType(), ind.GetDigestFunction())
 	}
 
-	conn, err := grpc_client.DialTarget(*target)
+	conn, err := grpc_client.DialSimple(*target)
 	if err != nil {
 		log.Fatalf("Error dialing CAS target: %s", err)
 	}

--- a/tools/replay_invocation/replay_invocation.go
+++ b/tools/replay_invocation/replay_invocation.go
@@ -87,7 +87,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error configuring blobstore: %s", err.Error())
 	}
-	conn, err := grpc_client.DialTarget(*besBackend)
+	conn, err := grpc_client.DialSimple(*besBackend)
 	if err != nil {
 		log.Fatalf("Error dialing bes backend: %s", err.Error())
 	}


### PR DESCRIPTION
grpc_client.Dial is a new function that takes an env and automatically adds a client identity interceptor, if necessary.

grpc_client.DialSimple is the former grpc_client.DialTarget func that can be used in non-server code.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
