### PR TITLE
Add scripts to test/bench firecracker locally

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -116,6 +116,8 @@ go_test(
     ],
 )
 
+# NOTE: to run this test locally, use `test.sh` or `bench.sh`
+#
 # TODO(bduffany): once blockio is fully enabled, set blockio flag(s) on
 # firecracker_test and remove this one.
 go_test(

--- a/enterprise/server/remote_execution/containers/firecracker/README.md
+++ b/enterprise/server/remote_execution/containers/firecracker/README.md
@@ -5,19 +5,33 @@
 Firecracker only runs on Linux, so when testing Firecracker,
 make sure to test from a Linux machine.
 
-To test firecracker locally, make sure to run `sudo tools/enable_local_firecracker.sh`. You will need to re-run this
-every time you reboot your machine.
+As a pre-requisite, you'll need to run
+`./tools/enable_local_firecracker.sh` to install `firecracker` and
+`jailer` in your PATH.
 
-You can then run the executor with `--executor.enable_firecracker=true`,
-then run Bazel targets with `exec_properties` configured with
-`"workload-isolation-type": "firecracker"`.
+Then, to test firecracker locally, you will need `mount()` permissions,
+which requires root. To run the test suite as root, use one of the
+convenience scripts:
+
+```shell
+./enterprise/server/remote_execution/containers/firecracker/test.sh
+# or for benchmarking:
+./enterprise/server/remote_execution/containers/firecracker/bench.sh
+```
+
+To run the executor locally with Firecracker enabled, you'll need to run
+`bazel` with `--run_under=sudo` and enable firecracker explicitly:
+
+```shell
+bazel run --run_under=sudo //enterprise/server/cmd/executor -- \
+  --executor.enable_firecracker=true
+```
+
+Then, you can build or test Bazel targets with `exec_properties`
+configured with `"workload-isolation-type": "firecracker"`.
 
 If you want to test workflows locally with firecracker, make sure to set
-`--app.workflows_enable_firecracker=true`.
-
-You can also test firecracker just by running
-`bazel test //enterprise/server/remote_execution/containers/firecracker:firecracker_test`. Make sure to run these tests
-before submitting any changes.
+`--app.workflows_enable_firecracker=true` on the app.
 
 ## Troubleshooting
 

--- a/enterprise/server/remote_execution/containers/firecracker/bench.sh
+++ b/enterprise/server/remote_execution/containers/firecracker/bench.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+exec ./enterprise/server/remote_execution/containers/firecracker/test.sh \
+  -- \
+  -test.bench=. \
+  -test.benchtime=1x \
+  -test.run=^Bench \
+  --app.log_level=error \
+  "$@"

--- a/enterprise/server/remote_execution/containers/firecracker/test.sh
+++ b/enterprise/server/remote_execution/containers/firecracker/test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -e
+
+# Firecracker tests have to be run as root since they use FUSE mounts.
+# This is a convenience script intended for local development, which
+# builds the test as the current user and runs it as root.
+#
+# Bazel args can be provided to this script.
+# Args after "--" are passed to the 'go test' command, e.g. "-test.run=MyTestFilter"
+
+# BAZEL env var: can be overridden to e.g. 'bb' or 'bazel --startup_opt=...'
+: "${BAZEL:=bazel}"
+# RUN_UNDER: test wrapper. 'sudo strace -f' is also useful.
+: "${RUN_UNDER:=sudo}"
+: "${TARGET:=firecracker_test_blockio}"
+
+BAZEL_ARGS=()
+# Read test 'args' attribute into GO_TEST_ARGS array
+mapfile -t GO_TEST_ARGS < <(
+  ./tools/buildozer.sh -output_json 'print args' \
+    "//enterprise/server/remote_execution/containers/firecracker:$TARGET" |
+    jq -r '.records[0].fields[0].list.strings[]'
+)
+
+# Split bazel args from binary args.
+IN_TEST_ARGS=0
+for arg in "$@"; do
+  if ((IN_TEST_ARGS)); then
+    GO_TEST_ARGS+=("$arg")
+  elif [[ "$arg" == "--" ]]; then
+    IN_TEST_ARGS=1
+  else
+    BAZEL_ARGS+=("$arg")
+  fi
+done
+
+$BAZEL \
+  build "//enterprise/server/remote_execution/containers/firecracker:$TARGET" \
+  "${BAZEL_ARGS[@]}"
+
+echo "Running test as root (may ask for password)"
+$RUN_UNDER \
+  "./bazel-bin/enterprise/server/remote_execution/containers/firecracker/${TARGET}_/$TARGET" \
+  "${GO_TEST_ARGS[@]}"

--- a/tools/buildozer.sh
+++ b/tools/buildozer.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+# TODO: provision buildozer with bazel
+if ! command -v buildozer >/dev/null; then
+  echo >&2 "Missing 'buildozer' in \$PATH. Install with:"
+  echo >&2 "    go install github.com/bazelbuild/buildtools/buildozer@latest"
+  exit 1
+fi
+exec buildozer "$@"


### PR DESCRIPTION
Testing requires `mount()` privileges once we enable VBD. Add some scripts to make this slightly less painful.

**Related issues**: N/A
