### PR TITLE
Fix impersonation bar styling

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1551,7 +1551,7 @@ code .comment {
 
 @media (max-width: 800px) {
   .hide-on-mobile {
-    display: none;
+    display: none !important;
   }
 
   .login-box {

--- a/enterprise/app/root/root.css
+++ b/enterprise/app/root/root.css
@@ -16,17 +16,29 @@ body {
   background-color: #ffc107;
   padding: 4px 32px;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
   box-shadow: 0 -1px 1px rgba(0, 0, 0, 0.12) inset;
 }
 
-.impersonation-toolbar .exit-button {
-  margin-left: auto;
+.impersonation-toolbar .impersonation-caution {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 4px;
 }
 
-.impersonation-toolbar .generate-api-key-button {
-  margin-left: 32px;
+.impersonation-toolbar .impersonation-caution .icon {
+  margin-top: 3px;
+}
+
+.impersonation-toolbar .icon {
+  width: 16px;
+  height: 16px;
+}
+
+.impersonation-toolbar .spacer {
+  margin-left: auto;
 }
 
 .impersonation-toolbar button {

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -127,20 +127,27 @@ class ImpersonationComponent extends React.Component<ImpersonationProps, Imperso
   render() {
     return (
       <div className="impersonation-toolbar">
-        <AlertCircle className="icon black" />
-        <span>
-          Authenticated as a member of <b>{this.props.user.selectedGroupName()}</b> ({this.props.user.selectedGroup?.id}
-          ). Proceed with caution.
-        </span>
+        <div className="impersonation-caution">
+          <AlertCircle className="icon black" />
+          <span>
+            <span className="hide-on-mobile">Caution: authenticated as a member of </span>
+            <b>{this.props.user.selectedGroupName()}</b> ({this.props.user.selectedGroup?.id})
+          </span>
+        </div>
+        <div className="spacer" />
         <OutlinedButton
           onClick={this.handleGenerateImpersonationAPIKeyClicked.bind(this)}
-          className="generate-api-key-button">
-          <span>{this.state.apiKey ? "Copy" : "Generate"} temporary API key</span>
-          {this.state.isCopied ? <Check style={{ stroke: "green" }} className="icon" /> : <Copy className="icon" />}
+          className="generate-api-key-button hide-on-mobile">
+          <span>{this.state.apiKey ? "Copy" : "Get"} temporary API key</span>
+          {this.state.isCopied ? (
+            <Check style={{ stroke: "green" }} className="icon black" />
+          ) : (
+            <Copy className="icon black" />
+          )}
         </OutlinedButton>
         <OutlinedButton onClick={this.handleExitImpersonationModeClicked.bind(this)} className="exit-button">
           <span>Exit</span>
-          <LogOut className="icon black" width={16} />
+          <LogOut className="icon black" />
         </OutlinedButton>
       </div>
     );


### PR DESCRIPTION
* Enable flex-wrap
* Make it less verbose on mobile and hide the API key button (it's probably impractical to actually use an API key on mobile)

Screenshot (simulating `iPhone 12 Pro` screen dimensions)

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/58558e27-9cff-4e3c-9296-dfe9c634b5ae)

**Related issues**: N/A
