### PR TITLE
Improve error handling in EnableMasquerading

### DIFF
--- a/server/util/networking/networking.go
+++ b/server/util/networking/networking.go
@@ -442,10 +442,10 @@ func findRoute(ctx context.Context, prefix string) (route, error) {
 // for networking to work on vms.
 func EnableMasquerading(ctx context.Context) error {
 	route, err := findRoute(ctx, *routePrefix)
-	device := route.device
 	if err != nil {
 		return err
 	}
+	device := route.device
 	// Skip appending the rule if it's already in the table.
 	err = runCommand(ctx, "iptables", "--wait", "-t", "nat", "--check", "POSTROUTING", "-o", device, "-j", "MASQUERADE")
 	if err == nil {


### PR DESCRIPTION
This isn't actually a bug because `route` is an empty `route{}` rather than `nil` but the existing code just seemed error prone.

**Related issues**: N/A
