### PR TITLE
IP rule impersonation fixes.

### DIFF
--- a/enterprise/server/iprules/iprules_test.go
+++ b/enterprise/server/iprules/iprules_test.go
@@ -48,7 +48,7 @@ func TestEnforcementNotEnabled(t *testing.T) {
 	require.NoError(t, err)
 
 	// Checking by group ID should also pass.
-	err = irs.AuthorizeGroup(ctx, u.Groups[0].Group.GroupID)
+	err = irs.AuthorizeGroup(authCtx, u.Groups[0].Group.GroupID)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
 - Don't enforce IP rules for GetGroup API as it's now used for impersonation.

 - AuthorizeGroup should check the impersonation bit, like Authorize does.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
