### PR TITLE
Immediately propagate UFFD errors instead of waiting for timeout

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -405,9 +405,10 @@ type FirecrackerContainer struct {
 	mountWorkspaceFile bool
 
 	cleanupVethPair func(context.Context) error
+	vmCtx           context.Context
 	// cancelVmCtx cancels the Machine context, stopping the VMM if it hasn't
 	// already been stopped manually.
-	cancelVmCtx context.CancelFunc
+	cancelVmCtx context.CancelCauseFunc
 }
 
 func NewContainer(ctx context.Context, env environment.Env, task *repb.ExecutionTask, opts ContainerOpts) (*FirecrackerContainer, error) {
@@ -465,7 +466,7 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 		loader:             loader,
 		vmLog:              vmLog,
 		mountWorkspaceFile: *firecrackerMountWorkspaceFile,
-		cancelVmCtx:        func() {},
+		cancelVmCtx:        func(err error) {},
 	}
 
 	if opts.ForceVMIdx != 0 {
@@ -567,7 +568,7 @@ func MergeDiffSnapshot(ctx context.Context, baseSnapshotPath string, baseSnapsho
 			for {
 				select {
 				case <-ctx.Done():
-					return ctx.Err()
+					return context.Cause(ctx)
 				default:
 					break
 				}
@@ -797,8 +798,13 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 		return err
 	}
 
-	vmCtx, cancel := context.WithCancel(context.Background())
-	c.cancelVmCtx = cancel
+	vmCtx, cancelVmCtx := context.WithCancelCause(context.Background())
+	c.vmCtx = vmCtx
+	c.cancelVmCtx = cancelVmCtx
+
+	ctx, cancel := c.monitorVMContext(ctx)
+	defer cancel()
+
 	var snapOpt fcclient.Opt
 	if *enableUFFD {
 		uffdType := fcclient.MemoryBackendType(fcmodels.MemoryBackendBackendTypeUffdPrivileged)
@@ -870,7 +876,7 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 
 	conn, err := c.dialVMExecServer(ctx)
 	if err != nil {
-		return status.InternalErrorf("Failed to dial firecracker VM exec port: %s", err)
+		return err
 	}
 	defer conn.Close()
 
@@ -1442,6 +1448,12 @@ func (c *FirecrackerContainer) setupUFFDHandler(ctx context.Context) error {
 	if err := h.Start(ctx, sockAbsPath, c.memoryStore); err != nil {
 		return status.WrapError(err, "start uffd handler")
 	}
+	go func() {
+		// If we fail to handle a uffd request, terminate the VM.
+		if err := h.Wait(); err != nil {
+			c.cancelVmCtx(err)
+		}
+	}()
 	c.uffdHandler = h
 	return nil
 }
@@ -1673,7 +1685,8 @@ func (c *FirecrackerContainer) create(ctx context.Context) error {
 		return status.WrapError(err, "failed to init nbd server")
 	}
 
-	vmCtx, cancel := context.WithCancel(context.Background())
+	vmCtx, cancel := context.WithCancelCause(context.Background())
+	c.vmCtx = vmCtx
 	c.cancelVmCtx = cancel
 
 	machineOpts := []fcclient.Opt{
@@ -1730,17 +1743,19 @@ func (c *FirecrackerContainer) dialVMExecServer(ctx context.Context) (*grpc.Clie
 	vsockPath := filepath.Join(c.getChroot(), firecrackerVSockPath)
 	conn, err := vsock.SimpleGRPCDial(ctx, vsockPath, vsock.VMExecPort)
 	if err != nil {
-		if err == context.DeadlineExceeded {
-			// If we never connected to the VM exec port, it's likely because of a
-			// fatal error in the init binary. Search for the logged error and return
-			// it if found.
+		if err := context.Cause(ctx); err != nil {
+			// If the context was cancelled for any reason (timed out or VM
+			// crashed), check the VM logs which might have more relevant crash
+			// info, otherwise return the context error.
 			if err := c.parseFatalInitError(); err != nil {
 				return nil, err
 			}
-			// Intentionally not returning DeadlineExceededError here since it is not
-			// a Bazel-retryable error, but this particular timeout should be retryable.
+			// Intentionally not returning DeadlineExceededError here since it
+			// is not a Bazel-retryable error, but this particular timeout
+			// should be retryable.
+			return nil, status.InternalErrorf("failed to connect to VM: %s", err)
 		}
-		return nil, status.InternalErrorf("Failed to connect to firecracker VM exec server: %s", err)
+		return nil, status.InternalErrorf("failed to connect to VM: %s", err)
 	}
 	return conn, nil
 }
@@ -1773,6 +1788,23 @@ func (c *FirecrackerContainer) SendPrepareFileSystemRequestToGuest(ctx context.C
 	return rsp, err
 }
 
+// monitorVMContext returns a context that is cancelled if the VM exits. The
+// returned cancel func should be called after any VM requests are completed, to
+// clean up the goroutine that monitors the VM context. Otherwise, the goroutine
+// will stay running until the VM exits, which may not be desirable in some
+// situations.
+func (c *FirecrackerContainer) monitorVMContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancelCause(ctx)
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-c.vmCtx.Done():
+			cancel(context.Cause(c.vmCtx))
+		}
+	}()
+	return ctx, func() { cancel(nil) }
+}
+
 // Exec runs a command inside a container, with the same working dir set when
 // creating the container.
 // If stdin is non-nil, the contents of stdin reader will be piped to the stdin of
@@ -1784,6 +1816,11 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 	defer span.End()
 
 	start := time.Now()
+
+	// Ensure that ctx gets cancelled if the VM crashes.
+	ctx, cancel := c.monitorVMContext(ctx)
+	defer cancel()
+
 	result := &interfaces.CommandResult{ExitCode: commandutil.NoExitCode}
 	defer func() {
 		execDuration := time.Since(start)
@@ -1840,7 +1877,7 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 	result = c.SendExecRequestToGuest(ctx, cmd, workDir, stdio)
 	close(execDone)
 
-	ctx, cancel := background.ExtendContextForFinalization(ctx, finalizationTimeout)
+	ctx, cancel = background.ExtendContextForFinalization(ctx, finalizationTimeout)
 	defer cancel()
 
 	// If FUSE is enabled then outputs are already in the workspace.
@@ -1932,7 +1969,7 @@ func (c *FirecrackerContainer) remove(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, finalizationTimeout)
 	defer cancel()
 
-	defer c.cancelVmCtx()
+	defer c.cancelVmCtx(fmt.Errorf("VM removed"))
 
 	var lastErr error
 
@@ -2016,6 +2053,9 @@ func (c *FirecrackerContainer) Pause(ctx context.Context) error {
 }
 
 func (c *FirecrackerContainer) pause(ctx context.Context) error {
+	ctx, cancel := c.monitorVMContext(ctx)
+	defer cancel()
+
 	snapDetails, err := c.snapshotDetails(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
Before this PR, when we encountered a UFFD failure, we'd wait for several seconds trying to dial the VM, then eventually time out with "deadline exceeded", and the UFFD error would be logged to the console instead of getting surfaced as the root cause of the dial error.

Now, UFFD failures immediately cause any pending VM operations to be cancelled and the UFFD errors are surfaced directly.

* If the UFFD handler fails to handle a page fault, cancel the VM context immediately, setting the cancel cause to the UFFD error.
* Update `Exec`, `Pause`, and `Unpause` to make their `ctx` track the VM context, so that as soon as the VM ctx is cancelled, their ctx gets cancelled too (with the same cause as the VM ctx cancellation).

**Related issues**: N/A
