### PR TITLE
Support fetching executors from multiple regions

### DIFF
--- a/app/capabilities/capabilities.tsx
+++ b/app/capabilities/capabilities.tsx
@@ -32,13 +32,7 @@ export class Capabilities {
   usage: boolean = false;
   userManagement: boolean = false;
 
-  register(name: string, enterprise: boolean, paths: Array<string>) {
-    this.name = name;
-    this.paths = new Set(paths);
-    this.enterprise = enterprise;
-
-    this.createOrg = this.enterprise;
-
+  constructor() {
     this.invocationSharing = true;
     this.compareInvocations = true;
     this.deleteInvocation = true;
@@ -61,6 +55,14 @@ export class Capabilities {
     this.code = this.config.codeEditorEnabled;
     this.usage = this.config.usageEnabled;
     this.userManagement = this.config.userManagementEnabled;
+  }
+
+  register(name: string, enterprise: boolean, paths: Array<string>) {
+    this.name = name;
+    this.paths = new Set(paths);
+    this.enterprise = enterprise;
+
+    this.createOrg = this.enterprise;
 
     if (window.gtag) {
       window.gtag("set", {

--- a/app/service/BUILD.bazel
+++ b/app/service/BUILD.bazel
@@ -6,6 +6,7 @@ ts_library(
     name = "rpc_service",
     srcs = ["rpc_service.ts"],
     deps = [
+        "//app/capabilities",
         "//app/util:async",
         "//proto:buildbuddy_service_ts_proto",
         "//proto:context_ts_proto",

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -131,4 +131,16 @@ message FrontendConfig {
 
   // Whether IP rules UI is enabled.
   bool ip_rules_enabled = 43;
+
+  // Regional servers.
+  repeated Region regions = 44;
+}
+
+message Region {
+  // The name of the regional server. Ex: "Europe"
+  string name = 1;
+
+  // The http endpoint of the regional server, including https://.
+  // Ex: "https://app.buildbuddy.io"
+  string server = 2;
 }

--- a/server/http/interceptors/BUILD
+++ b/server/http/interceptors/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//server/util/alert",
         "//server/util/clientip",
         "//server/util/log",
+        "//server/util/region",
         "//server/util/request_context",
         "//server/util/subdomain",
         "//server/util/uuid",

--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -24,6 +24,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/clientip"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/region"
 	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
 	"github.com/buildbuddy-io/buildbuddy/server/util/uuid"
 	"github.com/prometheus/client_golang/prometheus"
@@ -330,6 +331,7 @@ func WrapAuthenticatedExternalProtoletHandler(env environment.Env, httpPrefix st
 		RequestID,
 		ClientIP,
 		Subdomain,
+		region.CORS,
 		RecoverAndAlert,
 	})
 }

--- a/server/static/BUILD
+++ b/server/static/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//server/environment",
         "//server/remote_cache/hit_tracker",
         "//server/util/flag",
+        "//server/util/region",
         "//server/util/status",
         "//server/util/subdomain",
         "//server/version",

--- a/server/static/BUILD
+++ b/server/static/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//server/endpoint_urls/build_buddy_url",
         "//server/environment",
         "//server/remote_cache/hit_tracker",
+        "//server/util/flag",
         "//server/util/status",
         "//server/util/subdomain",
         "//server/version",

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -54,14 +54,14 @@ var (
 	newTrendsUIEnabled                     = flag.Bool("app.new_trends_ui_enabled", false, "If set, show a new trends UI with a bit more organization.")
 	trendsRangeSelectionEnabled            = flag.Bool("app.trends_range_selection", false, "If set, let users drag to select time ranges in the trends UI.")
 	ipRulesUIEnabled                       = flag.Bool("app.ip_rules_ui_enabled", false, "If set, show the IP rules tab in settings page.")
-	regions                       		   = flag.Slice("regions", []Region{}, "A list of regions that executors might be connected to.")
+	regions                                = flag.Slice("regions", []Region{}, "A list of regions that executors might be connected to.")
 
 	jsEntryPointPath = flag.String("js_entry_point_path", "/app/app_bundle/app.js?hash={APP_BUNDLE_HASH}", "Absolute URL path of the app JS entry point")
 	disableGA        = flag.Bool("disable_ga", false, "If true; ga will be disabled")
 )
 
 type Region struct {
-	Name string
+	Name   string
 	Server string
 }
 
@@ -193,7 +193,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		CustomerSubdomain:                      subdomain.Get(ctx) != "",
 		Domain:                                 build_buddy_url.Domain(),
 		IpRulesEnabled:                         *ipRulesUIEnabled,
-		Regions: regionsToProto(*regions),
+		Regions:                                regionsToProto(*regions),
 	}
 
 	configJSON, err := protojson.Marshal(&config)
@@ -216,7 +216,7 @@ func regionsToProto(regions []Region) []*cfgpb.Region {
 	protos := []*cfgpb.Region{}
 	for _, r := range regions {
 		protos = append(protos, &cfgpb.Region{
-			Name: r.Name,
+			Name:   r.Name,
 			Server: r.Server,
 		})
 	}

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -2,7 +2,6 @@ package static
 
 import (
 	"context"
-	"flag"
 	"html/template"
 	"io/fs"
 	"net/http"
@@ -17,6 +16,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/hit_tracker"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
 	"github.com/buildbuddy-io/buildbuddy/server/version"
@@ -54,10 +54,16 @@ var (
 	newTrendsUIEnabled                     = flag.Bool("app.new_trends_ui_enabled", false, "If set, show a new trends UI with a bit more organization.")
 	trendsRangeSelectionEnabled            = flag.Bool("app.trends_range_selection", false, "If set, let users drag to select time ranges in the trends UI.")
 	ipRulesUIEnabled                       = flag.Bool("app.ip_rules_ui_enabled", false, "If set, show the IP rules tab in settings page.")
+	regions                       		   = flag.Slice("regions", []Region{}, "A list of regions that executors might be connected to.")
 
 	jsEntryPointPath = flag.String("js_entry_point_path", "/app/app_bundle/app.js?hash={APP_BUNDLE_HASH}", "Absolute URL path of the app JS entry point")
 	disableGA        = flag.Bool("disable_ga", false, "If true; ga will be disabled")
 )
+
+type Region struct {
+	Name string
+	Server string
+}
 
 func FSFromRelPath(relPath string) (fs.FS, error) {
 	// Figure out where our runfiles (static content bundled with the binary) live.
@@ -187,6 +193,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		CustomerSubdomain:                      subdomain.Get(ctx) != "",
 		Domain:                                 build_buddy_url.Domain(),
 		IpRulesEnabled:                         *ipRulesUIEnabled,
+		Regions: regionsToProto(*regions),
 	}
 
 	configJSON, err := protojson.Marshal(&config)
@@ -203,6 +210,17 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
+}
+
+func regionsToProto(regions []Region) []*cfgpb.Region {
+	protos := []*cfgpb.Region{}
+	for _, r := range regions {
+		protos = append(protos, &cfgpb.Region{
+			Name: r.Name,
+			Server: r.Server,
+		})
+	}
+	return protos
 }
 
 func AppBundleHash(bundleFS fs.FS) (string, error) {

--- a/server/util/region/BUILD
+++ b/server/util/region/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "region",
+    srcs = ["region.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/region",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:config_go_proto",
+        "//server/util/flag",
+    ],
+)

--- a/server/util/region/region.go
+++ b/server/util/region/region.go
@@ -1,0 +1,72 @@
+package region
+
+import (
+	"net/http"
+
+	cfgpb "github.com/buildbuddy-io/buildbuddy/proto/config"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+)
+
+var (
+	regions = flag.Slice("regions", []Region{}, "A list of regions that executors might be connected to.")
+)
+
+type Region struct {
+	Name   string
+	Server string
+}
+
+func Protos() []*cfgpb.Region {
+	protos := []*cfgpb.Region{}
+	for _, r := range *regions {
+		protos = append(protos, &cfgpb.Region{
+			Name:   r.Name,
+			Server: r.Server,
+		})
+	}
+	return protos
+}
+
+func isRegionalServer(server string) bool {
+	for _, region := range *regions {
+		if region.Server == server {
+			return true
+		}
+	}
+	return false
+}
+
+// Greatly simplified version of:
+// https://github.com/gorilla/handlers/blob/main/cors.go
+func CORS(next http.Handler) http.Handler {
+	// If no regions are configured, we don't have to do anything.
+	if len(*regions) == 0 {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// We only need CORS for POST and OPTIONS requests.
+		if r.Method != "POST" && r.Method != "OPTIONS" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// If we're not dealing with a regional server, we don't have to set any CORS headers.
+		if r.Header.Get("Origin") == "" || !isRegionalServer(r.Header.Get("Origin")) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// If we're dealing with a regional server, set CORS headers.
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
+
+		// If it's an OPTIONS request, we can exit early.
+		if r.Method == "OPTIONS" {
+			w.Header().Set("Access-Control-Allow-Methods", r.Header.Get("Access-Control-Request-Method"))
+			w.Header().Set("Access-Control-Allow-Headers", r.Header.Get("Access-Control-Request-Headers"))
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
<img width="1459" alt="Screenshot 2023-09-27 at 5 23 16 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/412109da-d3cc-4454-a736-a35717248eea">

Decided to just fetch executors in parallel from each region and display them for now. We can add a dropdown once the number of regions gets higher.

Probably still need to set a CORS header that includes these regions, but that's tough to test locally.