### PR TITLE
Fix a few more AC requests missing DigestFunction

### DIFF
--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -885,8 +885,9 @@ func (r *Env) GetActionResultForFailedAction(ctx context.Context, cmd *Command, 
 		assert.FailNow(r.t, fmt.Sprintf("unable to attach invocation ID %q to digest", invocationID))
 	}
 	req := &repb.GetActionResultRequest{
-		InstanceName: cmd.GetActionResourceName().GetInstanceName(),
-		ActionDigest: actionResultDigest,
+		InstanceName:   cmd.GetActionResourceName().GetInstanceName(),
+		ActionDigest:   actionResultDigest,
+		DigestFunction: cmd.GetActionResourceName().GetDigestFunction(),
 	}
 	acClient := r.GetActionResultStorageClient()
 	return acClient.GetActionResult(context.Background(), req)

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -222,8 +222,9 @@ func GetActionResult(ctx context.Context, acClient repb.ActionCacheClient, ar *d
 		return nil, status.InvalidArgumentError("Cannot download non-AC resource from action cache")
 	}
 	req := &repb.GetActionResultRequest{
-		ActionDigest: ar.GetDigest(),
-		InstanceName: ar.GetInstanceName(),
+		ActionDigest:   ar.GetDigest(),
+		InstanceName:   ar.GetInstanceName(),
+		DigestFunction: ar.GetDigestFunction(),
 	}
 	return acClient.GetActionResult(ctx, req)
 }


### PR DESCRIPTION
This should fix `tools/cas` not being able to fetch blake3 action results.

**Related issues**: N/A
