### PR TITLE
Store the image-to-SOCI-index mapping as an ActionResult

### DIFF
--- a/enterprise/server/sociartifactstore/BUILD
+++ b/enterprise/server/sociartifactstore/BUILD
@@ -62,6 +62,7 @@ go_test(
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//proto:soci_go_proto",
+        "//server/remote_cache/action_cache_server",
         "//server/remote_cache/digest",
         "//server/testutil/testenv",
         "//server/testutil/testport",

--- a/enterprise/server/sociartifactstore/sociartifactstore.go
+++ b/enterprise/server/sociartifactstore/sociartifactstore.go
@@ -297,7 +297,11 @@ func (s *SociArtifactStore) getArtifactsFromCache(ctx context.Context, imageConf
 			InlineStdout: true,
 		})
 	if err != nil {
-		recordOutcome("soci_index_pointer_contains_error")
+		if status.IsNotFoundError(err) {
+			recordOutcome("action_result_missing")
+		} else {
+			recordOutcome("action_result_error")
+		}
 		return nil, err
 	}
 	// The SOCI Index digest is serialized in the stdout field so we can
@@ -308,7 +312,7 @@ func (s *SociArtifactStore) getArtifactsFromCache(ctx context.Context, imageConf
 	}
 	sociIndexResourceName, err := digest.ParseDownloadResourceName(string(actionResult.StdoutRaw))
 	if err != nil {
-		recordOutcome("malformed_soci_index_pointer")
+		recordOutcome("soci_index_pointer_malformed")
 		return nil, err
 	}
 

--- a/enterprise/server/sociartifactstore/sociartifactstore.go
+++ b/enterprise/server/sociartifactstore/sociartifactstore.go
@@ -333,6 +333,10 @@ func (s *SociArtifactStore) getArtifactsFromCache(ctx context.Context, imageConf
 				outputFile.NodeProperties.Properties[0].Value)
 		}
 	}
+	if sociIndexDigest == nil {
+		recordOutcome("action_result_missing_soci_index")
+		return nil, status.InternalError("malformed action result, missing soci index")
+	}
 	recordOutcome("cached")
 	return getArtifactsResponse(imageConfigHash, sociIndexDigest, ztocDigests), nil
 }

--- a/enterprise/server/sociartifactstore/sociartifactstore.go
+++ b/enterprise/server/sociartifactstore/sociartifactstore.go
@@ -48,7 +48,7 @@ import (
 
 var (
 	layerStorage       = flag.String("soci_artifact_store.layer_storage", "/tmp/", "Directory in which to store pulled container image layers for indexing by soci artifact store.")
-	sociIndexCacheSeed = flag.String("soci_artifact_store.cache_seed", "socicache-09272023", "If set, this seed is hashed with container image IDs to generate cache keys storing soci indexes.")
+	sociIndexCacheSeed = flag.String("soci_artifact_store.cache_seed", "socicache-092872023", "If set, this seed is hashed with container image IDs to generate cache keys storing soci indexes.")
 )
 
 const (

--- a/enterprise/server/sociartifactstore/sociartifactstore.go
+++ b/enterprise/server/sociartifactstore/sociartifactstore.go
@@ -73,6 +73,7 @@ const (
 	sociImageLayerMediaTypeKey = "com.amazon.soci.image-layer-mediaType"
 	sociBuildToolIdentifierKey = "com.amazon.soci.build-tool-identifier"
 
+	// ActionResult.OutputFiles.NodeProperties type definitions
 	artifactTypeKey       = "type"
 	sociIndexArtifactType = "soci"
 	ztocArtifactType      = "ztoc"

--- a/enterprise/server/sociartifactstore/sociartifactstore_test.go
+++ b/enterprise/server/sociartifactstore/sociartifactstore_test.go
@@ -321,8 +321,8 @@ func writeActionResult(ctx context.Context, t *testing.T, env *testenv.TestEnv, 
 				Digest: sociIndexDigest,
 				NodeProperties: &repb.NodeProperties{
 					Properties: []*repb.NodeProperty{&repb.NodeProperty{
-						Name:  artifactTypeKey,
-						Value: sociIndexArtifactType,
+						Name:  "type",
+						Value: "soci",
 					}},
 				},
 			}},
@@ -335,8 +335,8 @@ func writeActionResult(ctx context.Context, t *testing.T, env *testenv.TestEnv, 
 				Digest: ztocDigest,
 				NodeProperties: &repb.NodeProperties{
 					Properties: []*repb.NodeProperty{&repb.NodeProperty{
-						Name:  artifactTypeKey,
-						Value: ztocArtifactType,
+						Name:  "type",
+						Value: "ztoc",
 					}},
 				},
 			})

--- a/enterprise/server/sociartifactstore/sociartifactstore_test.go
+++ b/enterprise/server/sociartifactstore/sociartifactstore_test.go
@@ -69,15 +69,13 @@ func TestIndexExists(t *testing.T) {
 		Hash:      "aa58f9f015faed905d18144fe7aaf55bac280a8276f84a08e05b970a95fd56bb",
 		SizeBytes: 99024,
 	}
-	serializedSociIndexResourceName, err := digest.NewResourceName(&sociIndexDigest, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256).DownloadString()
-	require.NoError(t, err)
 
 	writeFileContentsToCache(ctx, t, env, &sociIndexDigest, "test_data/soci_indexes/2c4c1f7de7a83d2b1b302bce865ed7ba8e14870db155daecabeba08be37eb5c4.json", rspb.CacheType_CAS)
 	writeFileContentsToCache(ctx, t, env, &ztocDigest1, "test_data/ztocs/5fa40df4606c1d9daa7119a18f7106b672d352f6f56d250547b41572bcf384de.ztoc", rspb.CacheType_CAS)
 	writeFileContentsToCache(ctx, t, env, &ztocDigest2, "test_data/ztocs/aa58f9f015faed905d18144fe7aaf55bac280a8276f84a08e05b970a95fd56bb.ztoc", rspb.CacheType_CAS)
 	writeActionResult(ctx, t, env,
 		getSociIndexKey(t, "sha256:dd04f266fd693e9ae2abee66dd7d3b61b8b42dcf38099cade554c6a34d1ae63b"),
-		[]byte(serializedSociIndexResourceName),
+		&sociIndexDigest,
 		[]*repb.Digest{
 			&ztocDigest1,
 			&ztocDigest2,
@@ -134,15 +132,13 @@ func TestIndexPartiallyExists(t *testing.T) {
 		Hash:      "aa58f9f015faed905d18144fe7aaf55bac280a8276f84a08e05b970a95fd56bb",
 		SizeBytes: 99024,
 	}
-	serializedSociIndexResourceName, err := digest.NewResourceName(&sociIndexDigest, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256).DownloadString()
-	require.NoError(t, err)
 
 	writeFileContentsToCache(ctx, t, env, &sociIndexDigest, "test_data/soci_indexes/2c4c1f7de7a83d2b1b302bce865ed7ba8e14870db155daecabeba08be37eb5c4.json", rspb.CacheType_CAS)
 	writeFileContentsToCache(ctx, t, env, &ztocDigest1, "test_data/ztocs/5fa40df4606c1d9daa7119a18f7106b672d352f6f56d250547b41572bcf384de.ztoc", rspb.CacheType_CAS)
 	// Don't write the second ztoc (aa58f...) to the cache.
 	writeActionResult(ctx, t, env,
 		getSociIndexKey(t, "sha256:dd04f266fd693e9ae2abee66dd7d3b61b8b42dcf38099cade554c6a34d1ae63b"),
-		[]byte(serializedSociIndexResourceName),
+		&sociIndexDigest,
 		[]*repb.Digest{
 			&ztocDigest1,
 			&ztocDigest2,
@@ -317,13 +313,33 @@ func writeFileContentsToCache(ctx context.Context, t *testing.T, env *testenv.Te
 	require.NoError(t, env.GetCache().Set(ctx, resourceName.ToProto(), data))
 }
 
-func writeActionResult(ctx context.Context, t *testing.T, env *testenv.TestEnv, actionDigest *repb.Digest, stdout []byte, outputFileDigests []*repb.Digest) {
+func writeActionResult(ctx context.Context, t *testing.T, env *testenv.TestEnv, actionDigest *repb.Digest, sociIndexDigest *repb.Digest, ztocDigests []*repb.Digest) {
 	req := repb.UpdateActionResultRequest{
 		ActionDigest: actionDigest,
-		ActionResult: &repb.ActionResult{StdoutRaw: stdout},
+		ActionResult: &repb.ActionResult{
+			OutputFiles: []*repb.OutputFile{&repb.OutputFile{
+				Digest: sociIndexDigest,
+				NodeProperties: &repb.NodeProperties{
+					Properties: []*repb.NodeProperty{&repb.NodeProperty{
+						Name:  artifactTypeKey,
+						Value: sociIndexArtifactType,
+					}},
+				},
+			}},
+		},
 	}
-	for _, outputFileDigest := range outputFileDigests {
-		req.ActionResult.OutputFiles = append(req.ActionResult.OutputFiles, &repb.OutputFile{Digest: outputFileDigest})
+	for _, ztocDigest := range ztocDigests {
+		req.ActionResult.OutputFiles = append(
+			req.ActionResult.OutputFiles,
+			&repb.OutputFile{
+				Digest: ztocDigest,
+				NodeProperties: &repb.NodeProperties{
+					Properties: []*repb.NodeProperty{&repb.NodeProperty{
+						Name:  artifactTypeKey,
+						Value: ztocArtifactType,
+					}},
+				},
+			})
 	}
 	_, err := env.GetActionCacheServer().UpdateActionResult(ctx, &req)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR changes the format of the image-to-SOCI-index that's stored in the ActionCache. Previously, a cache entry was written using the rehashed, salted image's config hash as the key and the serialized digest of the SOCI index as the value. However, this had a few drawbacks including increased difficulty debugging the ActionCache entries using the ActionCacheServer APIs and requiring multiple trips to the cache to unpack a SOCI index. This PR changes the image-to-index mapping to be stored as an ActionResult with all of the SOCI artifacts (index and ZToCs) stored as OutputFiles with a NodeProperty denoting their type. This should address both shortcomings mentioned previously.

**Related issues**: N/A
