### PR TITLE
Deflake docker_test

### DIFF
--- a/enterprise/server/remote_execution/containers/docker/BUILD
+++ b/enterprise/server/remote_execution/containers/docker/BUILD
@@ -47,6 +47,7 @@ go_test(
         "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/testutil/testfs",
+        "//server/util/disk",
         "//server/util/status",
         "@com_github_docker_docker//client",
         "@com_github_stretchr_testify//assert",


### PR DESCRIPTION
Instead of hoping the docker action will complete within 1 second, wait for an explicit signal that the action is done (specifically, wait for output.txt to be created). Also give a little bit of time for the stdout/stderr written by the action to be flushed to docker logs and for us to collect the output from the logs.

**Related issues**: N/A
