### PR TITLE
Fix UFFD race condition between Wait and Stop

### DIFF
--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -340,7 +340,6 @@ func (h *Handler) Stop() error {
 
 	// Wait for handle() to finish processing open requests
 	<-h.handleDoneChan
-	h.handleDoneChan = nil
 
 	h.earlyTerminationReader.Close()
 	h.earlyTerminationWriter.Close()


### PR DESCRIPTION
We call Wait in a background thread in firecracker to check if the handler has shut down early due to an error. We call Stop() when we are explicitly telling the handler to shut down, for example if we are pausing the VM. There is a race condition where Stop might try to set handleDoneChan=nil at the same time that the background Wait thread is trying to read it.
