### PR TITLE
Make bytebufferpool less error-prone.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -3474,7 +3474,7 @@ func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.R
 		readBuf := p.bufferPool.Get(bufSize)
 		compressBuf := p.bufferPool.Get(bufSize)
 
-		cr, err := compression.NewZstdCompressingReader(reader, readBuf[:bufSize], compressBuf[:bufSize])
+		cr, err := compression.NewZstdCompressingReader(reader, readBuf, compressBuf)
 		if err != nil {
 			p.bufferPool.Put(readBuf)
 			p.bufferPool.Put(compressBuf)

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -318,19 +318,18 @@ func (c *CacheProxy) Read(req *dcpb.ReadRequest, stream dcpb.DistributedCache_Re
 	copyBuf := c.bufferPool.Get(bufSize)
 	defer c.bufferPool.Put(copyBuf)
 
-	buf := copyBuf[:bufSize]
 	for {
-		n, err := io.ReadFull(reader, buf)
+		n, err := io.ReadFull(reader, copyBuf)
 		if err == io.EOF {
 			break
 		} else if err == io.ErrUnexpectedEOF {
-			if err := stream.Send(&dcpb.ReadResponse{Data: buf[:n]}); err != nil {
+			if err := stream.Send(&dcpb.ReadResponse{Data: copyBuf[:n]}); err != nil {
 				return err
 			}
 		} else if err != nil {
 			return err
 		} else {
-			if err := stream.Send(&dcpb.ReadResponse{Data: buf}); err != nil {
+			if err := stream.Send(&dcpb.ReadResponse{Data: copyBuf}); err != nil {
 				return err
 			}
 			continue

--- a/server/util/bytebufferpool/bytebufferpool.go
+++ b/server/util/bytebufferpool/bytebufferpool.go
@@ -29,10 +29,13 @@ func (p *safeSyncPool[T]) Put(buf T) {
 	p.pool.Put(buf)
 }
 
-// Pool is a wrapper around `sync.Pool` that manages pool for buffers of different lengths of n (using power of 2).
+// Pool is a wrapper around `sync.Pool` for use cases where the size of the
+// needed buffer may vary. For fixed size buffers, use sync.Pool directly.
 type Pool struct {
-	// pools contain slices of lengths that are powers of 2. the slice itself is indexed by the exponent.
-	// index 0 containing a pool of 2^0 length slices, index 1 containing 2^1 length slices and so forth.
+	// pools contain slices of capacities that are powers of 2. the slice itself
+	// is indexed by the exponent.
+	// index 0 containing a pool of 2^0 capacity slices, index 1 containing 2^1
+	// capacity slices and so forth.
 	pools         []safeSyncPool[*[]byte]
 	maxBufferSize int
 }
@@ -54,10 +57,8 @@ func New(maxBufferSize int) *Pool {
 	return bp
 }
 
-// Get returns a byte slice of at least the specified length.
-//
-// CAUTION: In most cases the returned slice will have a greater than requested length. Don't use this package if you
-// need buffers of exact lengths.
+// Get returns a byte slice of the specified length, up to the maximum length
+// configured in the pool.
 func (bp *Pool) Get(length int64) []byte {
 	// Calculate the smallest power of 2 exponent x where 2^x >= length
 	idx := bits.Len64(uint64(length - 1))
@@ -67,13 +68,17 @@ func (bp *Pool) Get(length int64) []byte {
 	if idx >= len(bp.pools) {
 		idx = len(bp.pools) - 1
 	}
-	return *bp.pools[idx].Get()
+	buf := *bp.pools[idx].Get()
+	if length > int64(cap(buf)) {
+		length = int64(cap(buf))
+	}
+	return buf[:length]
 }
 
 // Put returns a byte slice back into the pool.
 func (bp *Pool) Put(buf []byte) {
-	// Calculate the largest power of 2 exponent x where 2^x <= length
-	idx := bits.Len64(uint64(len(buf))) - 1
+	// Calculate the largest power of 2 exponent x where 2^x <= cap
+	idx := bits.Len64(uint64(cap(buf))) - 1
 	if idx < 0 {
 		return
 	}

--- a/server/util/bytebufferpool/bytebufferpool_test.go
+++ b/server/util/bytebufferpool/bytebufferpool_test.go
@@ -11,20 +11,23 @@ func TestBufferSize(t *testing.T) {
 	bp := bytebufferpool.New(1024)
 
 	type test struct {
-		dataSize    int64
-		wantBufSize int
+		dataSize   int64
+		wantBufLen int
+		wantBufCap int
 	}
 	for _, testCase := range []test{
-		{dataSize: 0, wantBufSize: 1},
-		{dataSize: 1, wantBufSize: 1},
-		{dataSize: 8, wantBufSize: 8},
-		{dataSize: 12, wantBufSize: 16},
-		{dataSize: 15, wantBufSize: 16},
-		{dataSize: 16, wantBufSize: 16},
-		{dataSize: 17, wantBufSize: 32},
+		{dataSize: 0, wantBufLen: 0, wantBufCap: 1},
+		{dataSize: 1, wantBufLen: 1, wantBufCap: 1},
+		{dataSize: 8, wantBufLen: 8, wantBufCap: 8},
+		{dataSize: 12, wantBufLen: 12, wantBufCap: 16},
+		{dataSize: 15, wantBufLen: 15, wantBufCap: 16},
+		{dataSize: 16, wantBufLen: 16, wantBufCap: 16},
+		{dataSize: 17, wantBufLen: 17, wantBufCap: 32},
+		{dataSize: 1024, wantBufLen: 1024, wantBufCap: 1024},
+		{dataSize: 1025, wantBufLen: 1024, wantBufCap: 1024},
 	} {
-		assert.EqualValues(t, testCase.wantBufSize, len(bp.Get(testCase.dataSize)), "incorrect buffer len for length %d", testCase.dataSize)
-		assert.EqualValues(t, testCase.wantBufSize, cap(bp.Get(testCase.dataSize)), "incorrect buffer cap for data of length %d", testCase.dataSize)
+		assert.EqualValues(t, testCase.wantBufLen, len(bp.Get(testCase.dataSize)), "incorrect buffer len for length %d", testCase.dataSize)
+		assert.EqualValues(t, testCase.wantBufCap, cap(bp.Get(testCase.dataSize)), "incorrect buffer cap for data of length %d", testCase.dataSize)
 	}
 }
 


### PR DESCRIPTION
When buffers are returned, look at the capacity instead of the length to make sure the buffers are returned to the right bucket. There's at least one codepath where the buffer is returned with a smaller length.

Since we're now looking at the capacity instead of the length, we can automatically return buffers of the correct length instead of asking callers to do it.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
