### PR TITLE
Store all files from BuildToolLogs events

### DIFF
--- a/server/build_event_protocol/accumulator/accumulator.go
+++ b/server/build_event_protocol/accumulator/accumulator.go
@@ -69,7 +69,7 @@ type BEValues struct {
 	sawBuildMetadataEvent          bool
 	sawFinishedEvent               bool
 	buildStartTime                 time.Time
-	bytestreamProfileURI           *url.URL
+	buildToolLogURIs               []*url.URL
 	profileName                    string
 	hasBytestreamTestActionOutputs bool
 
@@ -114,9 +114,8 @@ func (v *BEValues) AddEvent(event *build_event_stream.BuildEvent) error {
 				if url, err := url.Parse(uri); err != nil {
 					log.Warningf("Error parsing uri from BuildToolLogs: %s", uri)
 				} else if url.Scheme == "bytestream" {
-					v.bytestreamProfileURI = url
+					v.buildToolLogURIs = append(v.buildToolLogURIs, url)
 				}
-				break
 			}
 		}
 	case *build_event_stream.BuildEvent_TestResult:
@@ -185,8 +184,8 @@ func (v *BEValues) BuildFinished() bool {
 	return v.sawFinishedEvent
 }
 
-func (v *BEValues) BytestreamProfileURI() *url.URL {
-	return v.bytestreamProfileURI
+func (v *BEValues) BuildToolLogURIs() []*url.URL {
+	return v.buildToolLogURIs
 }
 
 func (v *BEValues) HasBytestreamTestActionOutputs() bool {

--- a/server/build_event_protocol/accumulator/accumulator.go
+++ b/server/build_event_protocol/accumulator/accumulator.go
@@ -109,7 +109,6 @@ func (v *BEValues) AddEvent(event *build_event_stream.BuildEvent) error {
 		v.sawFinishedEvent = true
 	case *build_event_stream.BuildEvent_BuildToolLogs:
 		for _, toolLog := range p.BuildToolLogs.Log {
-			// Get the first non-empty URI like we do in the app.
 			if uri := toolLog.GetUri(); uri != "" {
 				if url, err := url.Parse(uri); err != nil {
 					log.Warningf("Error parsing uri from BuildToolLogs: %s", uri)

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -823,9 +823,7 @@ func (e *EventChannel) FinalizeInvocation(iid string) error {
 	if !*disablePersistArtifacts {
 		testOutputURIs := e.beValues.TestOutputURIs()
 		persist.URIs = make([]*url.URL, 0, len(testOutputURIs))
-		if e.beValues.BytestreamProfileURI() != nil {
-			persist.URIs = append(persist.URIs, e.beValues.BytestreamProfileURI())
-		}
+		persist.URIs = append(persist.URIs, e.beValues.BuildToolLogURIs()...)
 		persist.URIs = append(persist.URIs, testOutputURIs...)
 	}
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
No client behavior change in this one (i.e., we're still just kind of assuming that the first entry with a uri in BuildToolLogs is the profile, which does seem to work but doesn't seem to be guaranteed in the protocol.)
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
