### PR TITLE
Fix cli to work with `--enable_platform_specific_config`

### DIFF
--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -683,6 +683,8 @@ func ExpandConfigs(args []string) ([]string, error) {
 	return CanonicalizeArgs(args)
 }
 
+// Mirroring the behavior here:
+// https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/runtime/ConfigExpander.java#L41
 func getBazelOS() string {
 	switch runtime.GOOS {
 	case "linux":

--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -27,7 +27,8 @@ import (
 )
 
 const (
-	workspacePrefix = `%workspace%/`
+	workspacePrefix                  = `%workspace%/`
+	enablePlatformSpecificConfigFlag = "enable_platform_specific_config"
 )
 
 var (
@@ -752,15 +753,11 @@ func expandConfigs(workspaceDir string, args []string) ([]string, error) {
 	}
 	args = concat(args[:commandIndex+1], defaultArgs, args[commandIndex+1:])
 
-	enable, enableIndex, enableLength := arg.FindLast(args, "enable_platform_specific_config")
-	noEnable, noEnableIndex, noEnableLength := arg.FindLast(args, "noenable_platform_specific_config")
+	enable, enableIndex, enableLength := arg.FindLast(args, enablePlatformSpecificConfigFlag)
+	_, noEnableIndex, _ := arg.FindLast(args, "no"+enablePlatformSpecificConfigFlag)
 	if enableIndex > noEnableIndex {
 		if enable == "true" || enable == "yes" || enable == "1" || enable == "" {
 			args = concat(args[:enableIndex], []string{"--config", getBazelOS()}, args[enableIndex+enableLength:])
-		}
-	} else if noEnableIndex > enableIndex {
-		if noEnable == "false" || noEnable == "no" || noEnable == "0" {
-			args = concat(args[:noEnableIndex], []string{"--config", getBazelOS()}, args[noEnableIndex+noEnableLength:])
 		}
 	}
 


### PR DESCRIPTION
Since we do a custom parse of the `.bazelrc`, we need to handle the `--enable_platform_specific_config` specially, as it is supposed to be equivalent to `--config=<os>`. This PR substitutes the last instance of this flag, if it is set to true, with the appropriate `--config` option immediately before we do `--config` substitution.
