### PR TITLE
Make firecracker test script explicitly fail if buildozer is not installed

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/test.sh
+++ b/enterprise/server/remote_execution/containers/firecracker/test.sh
@@ -14,6 +14,9 @@ set -e
 : "${RUN_UNDER:=sudo}"
 : "${TARGET:=firecracker_test_blockio}"
 
+# Make sure buildozer is installed
+./tools/buildozer.sh
+
 BAZEL_ARGS=()
 # Read test 'args' attribute into GO_TEST_ARGS array
 mapfile -t GO_TEST_ARGS < <(

--- a/tools/buildozer.sh
+++ b/tools/buildozer.sh
@@ -3,7 +3,7 @@ set -e
 
 # TODO: provision buildozer with bazel
 if ! command -v buildozer >/dev/null; then
-  echo >&2 "Missing 'buildozer' in \$PATH. Install with:"
+  echo >&2 "Missing 'buildozer' in \$PATH. Make sure ~/go/bin is in \$PATH and install with:"
   echo >&2 "    go install github.com/bazelbuild/buildtools/buildozer@latest"
   exit 1
 fi


### PR DESCRIPTION
Otherwise, the test script will silently fail to pass input arguments to the test command.
