### PR TITLE
add "zstd" option for X-Stored-Encoding-Hint

### DIFF
--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -22,7 +22,7 @@ type ExtendedBuildBuddyService = CancelableService<buildbuddy.service.BuildBuddy
  */
 export type BuildBuddyServiceRpcName = RpcMethodNames<buildbuddy.service.BuildBuddyService>;
 
-export type FileEncoding = "gzip" | "";
+export type FileEncoding = "gzip" | "zstd" | "";
 
 export type XMLHttpResponseType = XMLHttpRequest["responseType"];
 
@@ -140,6 +140,8 @@ class RpcService {
       // that it doesn't double-gzip.
       if (storedEncoding === "gzip") {
         request.setRequestHeader("X-Stored-Encoding-Hint", "gzip");
+      } else if (storedEncoding === "zstd") {
+        request.setRequestHeader("X-Stored-Encoding-Hint", "zstd");
       }
       request.send();
     });

--- a/server/http/interceptors/BUILD
+++ b/server/http/interceptors/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//server/role_filter",
         "//server/util/alert",
         "//server/util/clientip",
+        "//server/util/compression",
         "//server/util/log",
         "//server/util/region",
         "//server/util/request_context",


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
Execution graph debug info (`--experimental_execution_graph_log`) writes out a zstd-compressed file, which we want to get to the client, but browsers can't handle zstd over the wire... yet.  Doing this server-side, where we already have support for it, seems way better than taking some weird js dep.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
