### PR TITLE
Support CORS for org subdomains

### DIFF
--- a/server/util/region/BUILD
+++ b/server/util/region/BUILD
@@ -15,5 +15,5 @@ go_test(
     name = "region_test",
     srcs = ["region_test.go"],
     embed = [":region"],
-    deps = ["@tools_gotest//assert"],
+    deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/server/util/region/BUILD
+++ b/server/util/region/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "region",
@@ -9,4 +9,11 @@ go_library(
         "//proto:config_go_proto",
         "//server/util/flag",
     ],
+)
+
+go_test(
+    name = "region_test",
+    srcs = ["region_test.go"],
+    embed = [":region"],
+    deps = ["@tools_gotest//assert"],
 )

--- a/server/util/region/region_test.go
+++ b/server/util/region/region_test.go
@@ -1,0 +1,27 @@
+package region
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func Test_IsRegionalServer(t *testing.T) {
+	for _, testCase := range []struct {
+		url     string
+		match   bool
+		regions []Region
+	}{
+		{"https://subdomain.buildbuddy.io", true, []Region{{Subdomains: "https://*.buildbuddy.io"}}},
+		{"https://subdomain-wish-dashes.buildbuddy.io", true, []Region{{Subdomains: "https://*.buildbuddy.io"}}},
+		{"https://subdomain.europe.buildbuddy.io", true, []Region{{Subdomains: "https://*.europe.buildbuddy.io"}}},
+		{"https://evilbuildbuddy.io", false, []Region{{Subdomains: "https://*.buildbuddy.io"}}},
+		{"https://subdomain.evilbuildbuddy.io", false, []Region{{Subdomains: "https://*.buildbuddy.io"}}},
+		{"https:///subdomain.buildbuddy.io", false, []Region{{Subdomains: "https://*.buildbuddy.io"}}},
+		{"subdomain.buildbuddy.io", false, []Region{{Subdomains: "https://*.buildbuddy.io"}}},
+		{"http://subdomain.buildbuddy", false, []Region{{Subdomains: "https://*.buildbuddy.io"}}},
+		{"http://subdomain.buildbuddy.io.foo", false, []Region{{Subdomains: "https://*.buildbuddy.io"}}},
+	} {
+		assert.Equal(t, testCase.match, isRegionalServer(testCase.regions, testCase.url))
+	}
+}

--- a/server/util/region/region_test.go
+++ b/server/util/region/region_test.go
@@ -3,7 +3,7 @@ package region
 import (
 	"testing"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_IsRegionalServer(t *testing.T) {


### PR DESCRIPTION
Currently CORS works correctly when making a request from https://app.buildbuddy.io to https://app.europe.buildbuddy.io

This adds support for making requests from https://my-org.buildbuddy.io to https://app.europe.buildbuddy.io