### PR TITLE
Add support for v5 keys

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -329,7 +329,7 @@ func (m *v3ToV4Migrator) Migrate(val []byte) []byte             { return val }
 type v4ToV5Migrator struct{}
 
 func (m *v4ToV5Migrator) FromVersion() filestore.PebbleKeyVersion {
-	return filestore.Version3
+	return filestore.Version4
 }
 func (m *v4ToV5Migrator) ToVersion() filestore.PebbleKeyVersion { return filestore.Version5 }
 func (m *v4ToV5Migrator) Migrate(val []byte) []byte             { return val }

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -326,6 +326,14 @@ func (m *v3ToV4Migrator) FromVersion() filestore.PebbleKeyVersion {
 func (m *v3ToV4Migrator) ToVersion() filestore.PebbleKeyVersion { return filestore.Version4 }
 func (m *v3ToV4Migrator) Migrate(val []byte) []byte             { return val }
 
+type v4ToV5Migrator struct{}
+
+func (m *v4ToV5Migrator) FromVersion() filestore.PebbleKeyVersion {
+	return filestore.Version3
+}
+func (m *v4ToV5Migrator) ToVersion() filestore.PebbleKeyVersion { return filestore.Version5 }
+func (m *v4ToV5Migrator) Migrate(val []byte) []byte             { return val }
+
 // Register creates a new PebbleCache from the configured flags and sets it in
 // the provided env.
 func Register(env environment.Env) error {
@@ -577,6 +585,10 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 		if pc.activeDatabaseVersion() >= filestore.Version4 {
 			// Migrate keys from 3->4.
 			pc.migrators = append(pc.migrators, &v3ToV4Migrator{})
+		}
+		if pc.activeDatabaseVersion() >= filestore.Version5 {
+			// Migrate keys from 4->5.
+			pc.migrators = append(pc.migrators, &v4ToV5Migrator{})
 		}
 	}
 

--- a/enterprise/server/raft/filestore/BUILD
+++ b/enterprise/server/raft/filestore/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/interfaces",
+        "//server/remote_cache/digest",
         "//server/util/disk",
         "//server/util/log",
         "//server/util/status",

--- a/enterprise/server/raft/filestore/filestore.go
+++ b/enterprise/server/raft/filestore/filestore.go
@@ -423,7 +423,6 @@ func (pmk *PebbleKey) parseVersion5(parts [][]byte) error {
 	}
 	pmk.digestFunction = repb.DigestFunction_Value(intDigestFunction)
 	pmk.partID = strings.TrimPrefix(pmk.partID, PartitionDirectoryPrefix)
-	pmk.groupID = remapFixedToANONGroupID(trimFixedWidthGroupID(pmk.groupID))
 
 	slash := []byte{filepath.Separator}
 	pmk.fullKey = bytes.Join(parts, slash)

--- a/enterprise/server/raft/filestore/filestore.go
+++ b/enterprise/server/raft/filestore/filestore.go
@@ -401,16 +401,14 @@ func (pmk *PebbleKey) parseVersion4(parts [][]byte) error {
 }
 
 func (pmk *PebbleKey) parseVersion5(parts [][]byte) error {
-	//"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/1/cas/v5",
-	//"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/cas/EK123/v5",
-	//"PTFOO/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/9/ac/v5",
-	//"PTFOO/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/1/ac/EK123/v5",
 	digestFunctionString := ""
-
 	switch len(parts) {
-
+	//"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/1/cas/v5",
+	//"PTFOO/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/9/ac/v5",
 	case 5:
 		pmk.partID, pmk.hash, digestFunctionString, pmk.isolation = string(parts[0]), string(parts[1]), string(parts[2]), string(parts[3])
+	//"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/cas/EK123/v5",
+	//"PTFOO/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/1/ac/EK123/v5",
 	case 6:
 		pmk.partID, pmk.hash, digestFunctionString, pmk.isolation, pmk.encryptionKeyID = string(parts[0]), string(parts[1]), string(parts[2]), string(parts[3]), string(parts[4])
 	default:
@@ -426,9 +424,7 @@ func (pmk *PebbleKey) parseVersion5(parts [][]byte) error {
 	pmk.digestFunction = repb.DigestFunction_Value(intDigestFunction)
 	pmk.partID = strings.TrimPrefix(pmk.partID, PartitionDirectoryPrefix)
 	pmk.groupID = remapFixedToANONGroupID(trimFixedWidthGroupID(pmk.groupID))
-	// check hash length against digest type
-	// check isolation value
-	// extract Partition?
+
 	slash := []byte{filepath.Separator}
 	pmk.fullKey = bytes.Join(parts, slash)
 	return nil

--- a/enterprise/server/raft/filestore/filestore.go
+++ b/enterprise/server/raft/filestore/filestore.go
@@ -418,7 +418,7 @@ func (pmk *PebbleKey) parseVersion5(parts [][]byte) error {
 	// Parse hash type string back into a digestFunction enum.
 	intDigestFunction, err := strconv.Atoi(digestFunctionString)
 	if err != nil || intDigestFunction == 0 {
-		// It is an error for a v4 key to have a 0 digestFunction value.
+		// It is an error for a v5 key to have a 0 digestFunction value.
 		return parseError(parts)
 	}
 	pmk.digestFunction = repb.DigestFunction_Value(intDigestFunction)

--- a/enterprise/server/raft/filestore/filestore.go
+++ b/enterprise/server/raft/filestore/filestore.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -90,6 +91,11 @@ const (
 	// fixed ANON group ID in GR{20} format.
 	Version4
 
+	// Version5 simplifies the keyspace (to simplify eviction) by encoding
+	// AC keys under a synthetic digest made from their remote instance
+	// name, groupID, and digest.
+	Version5
+
 	// TestingMaxKeyVersion should not be used directly -- it is always
 	// 1 more than the highest defined version, which allows for tests
 	// to iterate across all versions from UndefinedKeyVersion to
@@ -105,6 +111,13 @@ type PebbleKey struct {
 	hash               string
 	encryptionKeyID    string
 	digestFunction     repb.DigestFunction_Value
+
+	// For Version5 keys and beyond, creating a key from the above fields is
+	// a *lossy* procedure. This means it's impossible to take a raw key and
+	// back out the groupID or other information. For that reason, when a
+	// v5+ key is parsed, the full key bytes are preserved here so that the
+	// key can be re-serialized.
+	fullKey []byte
 }
 
 func (pmk PebbleKey) String() string {
@@ -117,7 +130,11 @@ func (pmk PebbleKey) String() string {
 
 func (pmk PebbleKey) LockID() string {
 	if pmk.isolation == "ac" {
-		return filepath.Join(pmk.isolation, pmk.groupID, pmk.remoteInstanceHash, pmk.hash)
+		fmk, err := pmk.Bytes(Version5)
+		if err != nil {
+			return err.Error()
+		}
+		return string(fmk)
 	}
 	return filepath.Join(pmk.isolation, pmk.hash)
 }
@@ -227,7 +244,32 @@ func (pmk *PebbleKey) Bytes(version PebbleKeyVersion) ([]byte, error) {
 		partDir := PartitionDirectoryPrefix + pmk.partID
 		filePath = filepath.Join(partDir, filePath, "v4")
 		return []byte(filePath), nil
+	case Version5:
+		if len(pmk.fullKey) > 0 {
+			return pmk.fullKey, nil
+		}
+		hashStr := pmk.hash
+		if pmk.isolation == "ac" {
+			hashExtra := remapANONToFixedGroupID(FixedWidthGroupID(pmk.groupID))
+			rih := pmk.remoteInstanceHash
+			if rih == "" {
+				rih = "0"
+			}
+			hashExtra += "|" + rih + "|" + pmk.hash
+			h, err := digest.HashForDigestType(pmk.digestFunction)
+			if err != nil {
+				return nil, err
+			}
+			if _, err := h.Write([]byte(hashExtra)); err != nil {
+				return nil, err
+			}
+			hashStr = fmt.Sprintf("%x", h.Sum(nil))
+		}
 
+		filePath := filepath.Join(hashStr, strconv.Itoa(int(pmk.digestFunction)), pmk.isolation, pmk.encryptionKeyID)
+		partDir := PartitionDirectoryPrefix + pmk.partID
+		filePath = filepath.Join(partDir, filePath, "v5")
+		return []byte(filePath), nil
 	default:
 		return nil, status.FailedPreconditionErrorf("Unknown key version: %v", version)
 	}
@@ -358,6 +400,40 @@ func (pmk *PebbleKey) parseVersion4(parts [][]byte) error {
 	return nil
 }
 
+func (pmk *PebbleKey) parseVersion5(parts [][]byte) error {
+	//"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/1/cas/v5",
+	//"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/cas/EK123/v5",
+	//"PTFOO/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/9/ac/v5",
+	//"PTFOO/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/1/ac/EK123/v5",
+	digestFunctionString := ""
+
+	switch len(parts) {
+
+	case 5:
+		pmk.partID, pmk.hash, digestFunctionString, pmk.isolation = string(parts[0]), string(parts[1]), string(parts[2]), string(parts[3])
+	case 6:
+		pmk.partID, pmk.hash, digestFunctionString, pmk.isolation, pmk.encryptionKeyID = string(parts[0]), string(parts[1]), string(parts[2]), string(parts[3]), string(parts[4])
+	default:
+		return parseError(parts)
+	}
+
+	// Parse hash type string back into a digestFunction enum.
+	intDigestFunction, err := strconv.Atoi(digestFunctionString)
+	if err != nil || intDigestFunction == 0 {
+		// It is an error for a v4 key to have a 0 digestFunction value.
+		return parseError(parts)
+	}
+	pmk.digestFunction = repb.DigestFunction_Value(intDigestFunction)
+	pmk.partID = strings.TrimPrefix(pmk.partID, PartitionDirectoryPrefix)
+	pmk.groupID = remapFixedToANONGroupID(trimFixedWidthGroupID(pmk.groupID))
+	// check hash length against digest type
+	// check isolation value
+	// extract Partition?
+	slash := []byte{filepath.Separator}
+	pmk.fullKey = bytes.Join(parts, slash)
+	return nil
+}
+
 func (pmk *PebbleKey) FromBytes(in []byte) (PebbleKeyVersion, error) {
 	version := UndefinedKeyVersion
 	slash := []byte{filepath.Separator}
@@ -395,6 +471,8 @@ func (pmk *PebbleKey) FromBytes(in []byte) (PebbleKeyVersion, error) {
 		return Version3, pmk.parseVersion3(parts)
 	case Version4:
 		return Version4, pmk.parseVersion4(parts)
+	case Version5:
+		return Version5, pmk.parseVersion5(parts)
 	default:
 		return -1, status.InvalidArgumentErrorf("Unable to parse %q to pebble key", in)
 	}

--- a/enterprise/server/raft/filestore/filestore.go
+++ b/enterprise/server/raft/filestore/filestore.go
@@ -250,7 +250,7 @@ func (pmk *PebbleKey) Bytes(version PebbleKeyVersion) ([]byte, error) {
 		}
 		hashStr := pmk.hash
 		if pmk.isolation == "ac" {
-			hashExtra := remapANONToFixedGroupID(FixedWidthGroupID(pmk.groupID))
+			hashExtra := remapANONToFixedGroupID(pmk.groupID)
 			rih := pmk.remoteInstanceHash
 			if rih == "" {
 				rih = "0"

--- a/enterprise/server/raft/filestore/filestore_test.go
+++ b/enterprise/server/raft/filestore/filestore_test.go
@@ -21,9 +21,10 @@ func TestKeyVersionCrossCompatibility(t *testing.T) {
 	fs := filestore.New()
 
 	// What we are testing here is that for every version a key can be
-	// written at, it can also be re-read and rewritten at every other version.
+	// written at, it can also be re-read and rewritten at every *later*
+	// version.
 	for i := filestore.UndefinedKeyVersion; i < filestore.TestingMaxKeyVersion; i++ {
-		r, _ := testdigest.RandomACResourceBuf(t, 100)
+		r, _ := testdigest.RandomCASResourceBuf(t, 100)
 		fr := &rfpb.FileRecord{
 			Isolation: &rfpb.Isolation{
 				CacheType:          r.GetCacheType(),
@@ -43,10 +44,9 @@ func TestKeyVersionCrossCompatibility(t *testing.T) {
 		keyBytes, err := sourceKey.Bytes(i)
 		require.NoError(t, err)
 
-		for j := filestore.UndefinedKeyVersion; j < filestore.TestingMaxKeyVersion; j++ {
+		for j := i; j < filestore.TestingMaxKeyVersion; j++ {
 			parsedKey := &filestore.PebbleKey{}
 			parsedVersion, err := parsedKey.FromBytes(keyBytes)
-
 			assert.NoError(t, err)
 			assert.Equal(t, i, parsedVersion)
 			assert.Equal(t, sourceKey.String(), parsedKey.String())
@@ -89,6 +89,13 @@ func TestKnownVersions(t *testing.T) {
 			"PTFOO/GR74042147050500190371/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/ac/2364854541/EK123/v4",
 			"PTFOO/GR74042147050500190371/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/ac/0/v4",
 		},
+		filestore.Version5: {
+			"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/cas/v5",
+			"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/cas/EK123/v5",
+			"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/ac/v5",
+			"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/ac/EK123/v5",
+			"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/ac/v5",
+		},
 	}
 
 	for version := filestore.UndefinedKeyVersion; version < filestore.TestingMaxKeyVersion; version++ {
@@ -114,6 +121,7 @@ func TestMigration(t *testing.T) {
 			filestore.Version2:            "PTFOO/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2/cas/v2",
 			filestore.Version3:            "PTFOO/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2/cas/v3",
 			filestore.Version4:            "PTFOO/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2/1/cas/v4",
+			filestore.Version5:            "PTFOO/baec85817b2bf76db939f38e33f1acccdfeb5683885d014717918bbc0c1996d2/1/cas/v5",
 		},
 		{
 			filestore.UndefinedKeyVersion: "PTFOO/GR7890/ac/2364854541/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309",
@@ -121,6 +129,7 @@ func TestMigration(t *testing.T) {
 			filestore.Version2:            "PTFOO/GR00000000000000007890/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/ac/2364854541/v2",
 			filestore.Version3:            "PTFOO/GR00000000000000007890/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/ac/2364854541/v3",
 			filestore.Version4:            "PTFOO/GR00000000000000007890/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/1/ac/2364854541/v4",
+			filestore.Version5:            "PTFOO/8a15be57cb4fbdcb97ba10f53c7e1a9b4d4f1a2046397bf4c3976a7563d1af9e/1/ac/v5",
 		},
 		{
 			filestore.UndefinedKeyVersion: "PTdefault/GR7890/ac/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f",
@@ -128,6 +137,7 @@ func TestMigration(t *testing.T) {
 			filestore.Version2:            "PTdefault/GR00000000000000007890/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/ac/v2",
 			filestore.Version3:            "PTdefault/GR00000000000000007890/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/ac/0/v3",
 			filestore.Version4:            "PTdefault/GR00000000000000007890/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/1/ac/0/v4",
+			filestore.Version5:            "PTdefault/222273c5bd20964122befab6babe5459a463136dff38bb4b4155b54c5275e19f/1/ac/v5",
 		},
 		{
 			filestore.UndefinedKeyVersion: "PTdefault/ANON/ac/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f",
@@ -135,6 +145,7 @@ func TestMigration(t *testing.T) {
 			filestore.Version2:            "PTdefault/ANON/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/ac/v2",
 			filestore.Version3:            "PTdefault/ANON/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/ac/0/v3",
 			filestore.Version4:            "PTdefault/GR74042147050500190371/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/1/ac/0/v4",
+			filestore.Version5:            "PTdefault/4929cde6f4c93cd5ab0ffde947e7e5da09bdb0677057c2ae7ea75b083c67feaa/1/ac/v5",
 		},
 	}
 
@@ -148,7 +159,7 @@ func TestMigration(t *testing.T) {
 			_, err := parsedKey.FromBytes([]byte(key))
 			require.NoError(t, err)
 
-			for version := filestore.UndefinedKeyVersion; version < filestore.TestingMaxKeyVersion; version++ {
+			for version := startingVersion; version < filestore.TestingMaxKeyVersion; version++ {
 				t.Run(fmt.Sprintf("from_v%d_to_v%d", startingVersion, version), func(t *testing.T) {
 					versionedKey, err := parsedKey.Bytes(version)
 					require.NoError(t, err)

--- a/enterprise/server/raft/filestore/filestore_test.go
+++ b/enterprise/server/raft/filestore/filestore_test.go
@@ -129,7 +129,7 @@ func TestMigration(t *testing.T) {
 			filestore.Version2:            "PTFOO/GR00000000000000007890/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/ac/2364854541/v2",
 			filestore.Version3:            "PTFOO/GR00000000000000007890/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/ac/2364854541/v3",
 			filestore.Version4:            "PTFOO/GR00000000000000007890/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/1/ac/2364854541/v4",
-			filestore.Version5:            "PTFOO/8a15be57cb4fbdcb97ba10f53c7e1a9b4d4f1a2046397bf4c3976a7563d1af9e/1/ac/v5",
+			filestore.Version5:            "PTFOO/8d35507f8943fa0242206a2077054c0ead9c71ba9f5d01c6b7f3578c6d4ba464/1/ac/v5",
 		},
 		{
 			filestore.UndefinedKeyVersion: "PTdefault/GR7890/ac/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f",
@@ -137,7 +137,7 @@ func TestMigration(t *testing.T) {
 			filestore.Version2:            "PTdefault/GR00000000000000007890/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/ac/v2",
 			filestore.Version3:            "PTdefault/GR00000000000000007890/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/ac/0/v3",
 			filestore.Version4:            "PTdefault/GR00000000000000007890/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f/1/ac/0/v4",
-			filestore.Version5:            "PTdefault/222273c5bd20964122befab6babe5459a463136dff38bb4b4155b54c5275e19f/1/ac/v5",
+			filestore.Version5:            "PTdefault/1e664dcc33e701dc7d59472f93f110159ca128b5e52e4e849d6eefeb4bda7f72/1/ac/v5",
 		},
 		{
 			filestore.UndefinedKeyVersion: "PTdefault/ANON/ac/ffb4ed9aea57f797c92a1a8ea784dde745becc35ca60315cb14f3a3db772939f",


### PR DESCRIPTION
The reason for introducing this key format change is to simplify key eviction for AC entries.

All keys would look like:

```
//"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/1/cas/v5"
//"PTFOO/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/9/ac/v5"
//"PTFOO/9c1385f58c3caf4a21a2626217c86303a9d157603d95eb6799811abb12ebce6b/9/cas/EK123/v5"
//"PTFOO/647c5961cba680d5deeba0169a64c8913d6b5b77495a1ee21c808ac6a514f309/1/ac/EK123/v5"
```