### PR TITLE
[FC] Don't prevent runner recycling if networking cleanup fails

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1447,7 +1447,12 @@ func (c *FirecrackerContainer) setupNetworking(ctx context.Context) error {
 	}
 
 	if err := networking.CreateNetNamespace(ctx, c.id); err != nil {
-		return err
+		if strings.Contains(err.Error(), "File exists") {
+			// Don't fail if we failed to cleanup the networking on a previous run
+			log.Warningf("Networking cleanup failure. Net namespace already exists: %s", err)
+		} else {
+			return err
+		}
 	}
 	if err := networking.CreateTapInNamespace(ctx, c.id, tapDeviceName); err != nil {
 		return err
@@ -1578,15 +1583,15 @@ func (c *FirecrackerContainer) cleanupNetworking(ctx context.Context) error {
 		}
 	}
 	if err := networking.RemoveNetNamespace(ctx, c.id); err != nil {
-		log.Warningf("RemoveNetNamespace for vm id %s failed with: %s", c.id, err)
+		log.Warningf("Networking cleanup failure. RemoveNetNamespace for vm id %s failed with: %s", c.id, err)
 		lastErr = err
 	}
 	if err := networking.DeleteRoute(ctx, c.vmIdx); err != nil {
-		log.Warningf("DeleteRoute for vm idx %d failed with: %s", c.vmIdx, err)
+		log.Warningf("Networking cleanup failure. DeleteRoute for vm idx %d failed with: %s", c.vmIdx, err)
 		lastErr = err
 	}
 	if err := networking.DeleteRuleIfSecondaryNetworkEnabled(ctx, c.vmIdx); err != nil {
-		log.Warningf("DeleteRuleIfSecondaryNetworkEnabled for vm idx %d failed with: %s", c.vmIdx, err)
+		log.Warningf("Networking cleanup failure. DeleteRuleIfSecondaryNetworkEnabled for vm idx %d failed with: %s", c.vmIdx, err)
 		lastErr = err
 	}
 	return lastErr


### PR DESCRIPTION
Networking cleanup failures are preventing us from recycling runners and customers are seeing slow workflows. See [thread](https://buildbuddy-corp.slack.com/archives/C0495TM9UUE/p1695740849246189) for more info.

I realized that because we are returning the lastErr in cleanupNetworking, it's not guaranteed that DeleteRuleIfSecondaryNetworkEnabled is actually the culprit. I added more debug logging to clarify which rule the context is being canceled for.

Also dump the vm logs on failure to see if there's any useful debug info

I also checked to make sure that VM setup won't break if we fail to clean up networking. 
* The opposite of `DeleteRuleIfSecondaryNetworkEnabled` is `ip rule add from cloneIP lookup routingTableName` - this is idempotent and can be rerun multiple times, even if the rule already exists
* The opposite of `DeleteRoute` is `ip route add cloneIP via cloneEndpointAddr` - [we already check whether the route exists before adding it](https://github.com/buildbuddy-io/buildbuddy/blob/master/server/util/networking/networking.go#L344)
* The opposite of `RemoveNetNamespace` is `ip netns add NetNamespace(netNamespace)` - I added an extra check to not fail if the namespace already exists