### PR TITLE
Extend X-Forwarded-For parsing.

### DIFF
--- a/server/rpc/interceptors/BUILD
+++ b/server/rpc/interceptors/BUILD
@@ -22,6 +22,7 @@ go_library(
         "@io_opentelemetry_go_contrib_instrumentation_google_golang_org_grpc_otelgrpc//:otelgrpc",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//peer",
         "@org_golang_google_protobuf//proto",
     ],
 )

--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -3,6 +3,7 @@ package interceptors
 import (
 	"context"
 	"flag"
+	"net/netip"
 	"runtime"
 	"strconv"
 	"strings"
@@ -23,6 +24,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/protobuf/proto"
 
 	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
@@ -111,7 +113,20 @@ func addClientIPToContext(ctx context.Context) context.Context {
 		return ctx
 	}
 
-	ctx, _ = clientip.SetFromXForwardedForHeader(ctx, hdrs[0])
+	ctx, ok = clientip.SetFromXForwardedForHeader(ctx, hdrs[0])
+	if ok {
+		return ctx
+	}
+
+	if p, ok := peer.FromContext(ctx); ok {
+		ap, err := netip.ParseAddrPort(p.Addr.String())
+		if err != nil {
+			alert.UnexpectedEvent("invalid peer %q", p.Addr.String())
+			return ctx
+		}
+		return context.WithValue(ctx, clientip.ContextKey, ap.Addr().String())
+	}
+
 	return ctx
 }
 

--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -121,7 +121,7 @@ func addClientIPToContext(ctx context.Context) context.Context {
 	if p, ok := peer.FromContext(ctx); ok {
 		ap, err := netip.ParseAddrPort(p.Addr.String())
 		if err != nil {
-			alert.UnexpectedEvent("invalid peer %q", p.Addr.String())
+			alert.UnexpectedEvent("invalid peer %q", p.Addr.String(), err.Error())
 			return ctx
 		}
 		return context.WithValue(ctx, clientip.ContextKey, ap.Addr().String())

--- a/server/util/clientip/BUILD
+++ b/server/util/clientip/BUILD
@@ -5,4 +5,5 @@ go_library(
     srcs = ["clientip.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/clientip",
     visibility = ["//visibility:public"],
+    deps = ["//server/util/flag"],
 )

--- a/server/util/clientip/BUILD
+++ b/server/util/clientip/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "clientip",
@@ -6,4 +6,14 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/clientip",
     visibility = ["//visibility:public"],
     deps = ["//server/util/flag"],
+)
+
+go_test(
+    name = "clientip_test",
+    srcs = ["clientip_test.go"],
+    deps = [
+        ":clientip",
+        "//server/util/testing/flags",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/server/util/clientip/clientip.go
+++ b/server/util/clientip/clientip.go
@@ -3,9 +3,15 @@ package clientip
 import (
 	"context"
 	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 )
 
 const ContextKey = "clientIP"
+
+var (
+	trustXForwardedForHeader = flag.Bool("auth.trust_xforwardedfor_header", false, "If true, client IP information will be retrieved from the X-Forwarded-For header. Should only be enabled if the BuildBuddy server is only accessible behind a trusted proxy.")
+)
 
 func Get(ctx context.Context) string {
 	if v, ok := ctx.Value(ContextKey).(string); ok {
@@ -15,10 +21,18 @@ func Get(ctx context.Context) string {
 }
 
 func SetFromXForwardedForHeader(ctx context.Context, header string) (context.Context, bool) {
-	ips := strings.Split(header, ",")
-	if len(ips) < 2 {
+	if !*trustXForwardedForHeader || header == "" {
 		return ctx, false
 	}
+
+	ips := strings.Split(header, ",")
+
+	// If there's only a single IP in the header, return it directly.
+	// This handles the header format set by NGINX.
+	if len(ips) == 1 {
+		return context.WithValue(ctx, ContextKey, ips[0]), true
+	}
+
 	// For GCLB, the header format is [client supplied IP,]client IP, LB IP
 	// We always look at the client IP as seen by GCLB as the client supplied
 	// value can't be trusted if it's present.

--- a/server/util/clientip/clientip.go
+++ b/server/util/clientip/clientip.go
@@ -30,11 +30,11 @@ func SetFromXForwardedForHeader(ctx context.Context, header string) (context.Con
 	// If there's only a single IP in the header, return it directly.
 	// This handles the header format set by NGINX.
 	if len(ips) == 1 {
-		return context.WithValue(ctx, ContextKey, ips[0]), true
+		return context.WithValue(ctx, ContextKey, strings.TrimSpace(ips[0])), true
 	}
 
 	// For GCLB, the header format is [client supplied IP,]client IP, LB IP
 	// We always look at the client IP as seen by GCLB as the client supplied
 	// value can't be trusted if it's present.
-	return context.WithValue(ctx, ContextKey, ips[len(ips)-2]), true
+	return context.WithValue(ctx, ContextKey, strings.TrimSpace(ips[len(ips)-2])), true
 }

--- a/server/util/clientip/clientip_test.go
+++ b/server/util/clientip/clientip_test.go
@@ -1,0 +1,37 @@
+package clientip_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/clientip"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisabled(t *testing.T) {
+	ctx, ok := clientip.SetFromXForwardedForHeader(context.Background(), "1.2.3.4")
+	require.False(t, ok)
+	require.Equal(t, "", clientip.Get(ctx))
+}
+
+func TestNGINXHeader(t *testing.T) {
+	flags.Set(t, "auth.trust_xforwardedfor_header", true)
+	ctx, ok := clientip.SetFromXForwardedForHeader(context.Background(), "1.2.3.4")
+	require.True(t, ok)
+	require.Equal(t, "1.2.3.4", clientip.Get(ctx))
+}
+
+func TestGCPLBHeader(t *testing.T) {
+	flags.Set(t, "auth.trust_xforwardedfor_header", true)
+
+	// If there are exactly two values, we use the second IP from the right.
+	ctx, ok := clientip.SetFromXForwardedForHeader(context.Background(), "4.3.2.1, 1.2.3.4")
+	require.True(t, ok)
+	require.Equal(t, "4.3.2.1", clientip.Get(ctx))
+
+	// If there are more than two values, we still use the second IP from the right.
+	ctx, ok = clientip.SetFromXForwardedForHeader(context.Background(), "8.8.8.8, 4.3.2.1, 1.2.3.4")
+	require.True(t, ok)
+	require.Equal(t, "4.3.2.1", clientip.Get(ctx))
+}


### PR DESCRIPTION
 - Support single-IP format used by NGINX.
 - Don't trust X-Forwarded-For header unless explicitly enabled by flag.
 - Fall back to peer IP for RPCs if header is absent/not trusted.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
