### PR TITLE
Send metarange via user event

### DIFF
--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -199,10 +199,6 @@ func NewRaftCache(env environment.Env, conf *Config) (*RaftCache, error) {
 	}
 	rc.gossipManager = gossipManager
 
-	// Register the range cache as a gossip listener, so that it can
-	// discover which nodes maintain the meta range..
-	rc.gossipManager.AddListener(rc.rangeCache)
-
 	// A NodeHost is basically a single node (think 'computer') that can be
 	// a member of raft clusters. This nodehost is configured with a dynamic
 	// NodeRegistryFactory that allows raft to resolve other nodehosts that

--- a/enterprise/server/raft/rangecache/BUILD
+++ b/enterprise/server/raft/rangecache/BUILD
@@ -7,13 +7,11 @@ go_library(
     srcs = ["rangecache.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rangecache",
     deps = [
-        "//enterprise/server/raft/constants",
         "//proto:raft_go_proto",
         "//server/metrics",
         "//server/util/log",
         "//server/util/rangemap",
         "//server/util/status",
-        "@com_github_hashicorp_serf//serf",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_protobuf//proto",
     ],
@@ -25,12 +23,9 @@ go_test(
     srcs = ["rangecache_test.go"],
     deps = [
         ":rangecache",
-        "//enterprise/server/raft/constants",
         "//enterprise/server/raft/keys",
         "//proto:raft_go_proto",
         "//server/util/log",
-        "@com_github_hashicorp_serf//serf",
         "@com_github_stretchr_testify//require",
-        "@org_golang_google_protobuf//proto",
     ],
 )

--- a/enterprise/server/raft/rangecache/rangecache.go
+++ b/enterprise/server/raft/rangecache/rangecache.go
@@ -108,7 +108,7 @@ func (rc *RangeCache) updateRange(rangeDescriptor *rfpb.RangeDescriptor) error {
 func (rc *RangeCache) OnEvent(updateType serf.EventType, event serf.Event) {
 	switch updateType {
 	case serf.EventUser:
-                userEvent, _ := event.(serf.UserEvent)
+		userEvent, _ := event.(serf.UserEvent)
 		// Whenever the metarange data changes, for any
 		// reason, start a goroutine that ensures the
 		// node liveness record is up to date.

--- a/enterprise/server/raft/rangecache/rangecache.go
+++ b/enterprise/server/raft/rangecache/rangecache.go
@@ -3,12 +3,10 @@ package rangecache
 import (
 	"sync"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/rangemap"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	"github.com/hashicorp/serf/serf"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/protobuf/proto"
 
@@ -103,25 +101,6 @@ func (rc *RangeCache) updateRange(rangeDescriptor *rfpb.RangeDescriptor) error {
 		}
 	}
 	return nil
-}
-
-func (rc *RangeCache) OnEvent(updateType serf.EventType, event serf.Event) {
-	switch updateType {
-	case serf.EventUser:
-		userEvent, _ := event.(serf.UserEvent)
-		if userEvent.Name == constants.MetaRangeTag {
-			rd := &rfpb.RangeDescriptor{}
-			if err := proto.Unmarshal(userEvent.Payload, rd); err != nil {
-				log.Errorf("error parsing metarange: %s", err)
-				return
-			}
-			if err := rc.updateRange(rd); err != nil {
-				log.Errorf("Error updating ranges: %s", err)
-			}
-		}
-	default:
-		break
-	}
 }
 
 func (rc *RangeCache) UpdateRange(rangeDescriptor *rfpb.RangeDescriptor) error {

--- a/enterprise/server/raft/rangecache/rangecache.go
+++ b/enterprise/server/raft/rangecache/rangecache.go
@@ -109,9 +109,6 @@ func (rc *RangeCache) OnEvent(updateType serf.EventType, event serf.Event) {
 	switch updateType {
 	case serf.EventUser:
 		userEvent, _ := event.(serf.UserEvent)
-		// Whenever the metarange data changes, for any
-		// reason, start a goroutine that ensures the
-		// node liveness record is up to date.
 		if userEvent.Name == constants.MetaRangeTag {
 			rd := &rfpb.RangeDescriptor{}
 			if err := proto.Unmarshal(userEvent.Payload, rd); err != nil {

--- a/enterprise/server/raft/rangecache/rangecache.go
+++ b/enterprise/server/raft/rangecache/rangecache.go
@@ -112,7 +112,7 @@ func (rc *RangeCache) OnEvent(updateType serf.EventType, event serf.Event) {
 		if userEvent.Name == constants.MetaRangeTag {
 			rd := &rfpb.RangeDescriptor{}
 			if err := proto.Unmarshal(userEvent.Payload, rd); err != nil {
-				log.Errorf("unparsable rangeset: %s", err)
+				log.Errorf("error parsing metarange: %s", err)
 				return
 			}
 			if err := rc.updateRange(rd); err != nil {

--- a/enterprise/server/raft/rangecache/rangecache_test.go
+++ b/enterprise/server/raft/rangecache/rangecache_test.go
@@ -3,13 +3,10 @@ package rangecache_test
 import (
 	"testing"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rangecache"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/hashicorp/serf/serf"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
 )
@@ -34,31 +31,17 @@ func init() {
 	log.Configure()
 }
 
-func metaRangeEvent(t *testing.T, rangeDescriptor *rfpb.RangeDescriptor) (serf.EventType, serf.Event) {
-	buf, err := proto.Marshal(rangeDescriptor)
-	if err != nil {
-		t.Fatalf("error marshaling proto: %s", err)
-	}
-
-	event := serf.UserEvent{
-		Name:    constants.MetaRangeTag,
-		Payload: buf,
-	}
-
-	return serf.EventUser, event
-}
-
 func TestMemberEvent(t *testing.T) {
 	rc := rangecache.New()
 
-	rc.OnEvent(metaRangeEvent(t, &rfpb.RangeDescriptor{
+	rc.UpdateRange(&rfpb.RangeDescriptor{
 		Start:      keys.MinByte,
 		End:        keys.MaxByte,
 		Generation: 1,
 		Replicas: []*rfpb.ReplicaDescriptor{
 			{ShardId: 1, ReplicaId: 1},
 		},
-	}))
+	})
 
 	// Make sure we get back that range descriptor.
 	rd := rc.Get([]byte("a"))
@@ -80,7 +63,7 @@ func TestSimple(t *testing.T) {
 		},
 	}
 
-	rc.OnEvent(metaRangeEvent(t, rd))
+	rc.UpdateRange(rd)
 
 	rr := rc.Get([]byte("m"))
 	require.NotNil(t, rr)
@@ -104,7 +87,7 @@ func TestRangeUpdatedMemberEvent(t *testing.T) {
 	}
 
 	// Advertise a (fake) range advertisement.
-	rc.OnEvent(metaRangeEvent(t, rd1))
+	rc.UpdateRange(rd1)
 
 	rd2 := &rfpb.RangeDescriptor{
 		Start:      keys.MinByte,
@@ -118,7 +101,7 @@ func TestRangeUpdatedMemberEvent(t *testing.T) {
 	}
 
 	// Now advertise again, with a higher generation this time.
-	rc.OnEvent(metaRangeEvent(t, rd2))
+	rc.UpdateRange(rd2)
 
 	rr := rc.Get([]byte("m"))
 	require.NotNil(t, rr)
@@ -142,7 +125,7 @@ func TestRangeStaleMemberEvent(t *testing.T) {
 	}
 
 	// Advertise a (fake) range advertisement.
-	rc.OnEvent(metaRangeEvent(t, rd1))
+	rc.UpdateRange(rd1)
 
 	rd2 := &rfpb.RangeDescriptor{
 		Start:      []byte("a"),
@@ -156,7 +139,7 @@ func TestRangeStaleMemberEvent(t *testing.T) {
 	}
 
 	// Send another member event with the stale advertisement.
-	rc.OnEvent(metaRangeEvent(t, rd2))
+	rc.UpdateRange(rd2)
 
 	// Expect that the range update was not accepted.
 	require.Nil(t, rc.Get([]byte("m")))

--- a/enterprise/server/raft/rangecache/rangecache_test.go
+++ b/enterprise/server/raft/rangecache/rangecache_test.go
@@ -41,7 +41,7 @@ func metaRangeEvent(t *testing.T, rangeDescriptor *rfpb.RangeDescriptor) (serf.E
 	}
 
 	event := serf.UserEvent{
-		Name: constants.MetaRangeTag,
+		Name:    constants.MetaRangeTag,
 		Payload: buf,
 	}
 

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -147,6 +147,10 @@ func (s *Sender) LookupRangeDescriptor(ctx context.Context, key []byte, skipCach
 	return rangeDescriptor, nil
 }
 
+func (s *Sender) UpdateRange(rangeDescriptor *rfpb.RangeDescriptor) error {
+	return s.rangeCache.UpdateRange(rangeDescriptor)
+}
+
 type runFunc func(c rfspb.ApiClient, h *rfpb.Header) error
 
 func (s *Sender) tryReplicas(ctx context.Context, rd *rfpb.RangeDescriptor, fn runFunc) (int, error) {

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -904,7 +904,7 @@ func (s *Store) AddRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 			s.log.Errorf("Error marshaling metarange descriptor: %s", err)
 			return
 		}
-		go s.gossipManager.SendUserEvent(constants.MetaRangeTag, buf, /*coalesce=*/false)
+		go s.gossipManager.SendUserEvent(constants.MetaRangeTag, buf /*coalesce=*/, false)
 	}
 
 	// Start goroutines for these so that Adding ranges is quick.

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -904,7 +904,7 @@ func (s *Store) AddRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 			s.log.Errorf("Error marshaling metarange descriptor: %s", err)
 			return
 		}
-		go s.gossipManager.SetTags(map[string]string{constants.MetaRangeTag: string(buf)})
+		go s.gossipManager.SendUserEvent(constants.MetaRangeTag, buf, /*coalesce=*/false)
 	}
 
 	// Start goroutines for these so that Adding ranges is quick.

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -136,7 +136,6 @@ func (sf *storeFactory) NewStore(t *testing.T) (*TestingStore, *dragonboat.NodeH
 	ts.APIClient = apiClient
 
 	rc := rangecache.New()
-	gm.AddListener(rc)
 	ts.Sender = sender.New(rc, reg, apiClient)
 	reg.AddNode(nodeHost.ID(), ts.RaftAddress, ts.GRPCAddress)
 	s, err := store.New(ts.RootDir, nodeHost, gm, ts.Sender, reg, apiClient, ts.GRPCAddress, []disk.Partition{})


### PR DESCRIPTION
Explicitly disable event quiescing so there's no delay when advertising the metarange.