### PR TITLE
Add container type to ImageCacheToken to prevent sharing tokens across container types

### DIFF
--- a/enterprise/server/remote_execution/containers/bare/bare.go
+++ b/enterprise/server/remote_execution/containers/bare/bare.go
@@ -46,6 +46,10 @@ func NewBareCommandContainer(opts *Opts) container.CommandContainer {
 	return &bareCommandContainer{opts: opts}
 }
 
+func (_ *bareCommandContainer) ContainerType() platform.ContainerType {
+	return platform.BareContainerType
+}
+
 func (c *bareCommandContainer) Run(ctx context.Context, command *repb.Command, workDir string, creds container.PullCredentials) *interfaces.CommandResult {
 	return c.exec(ctx, command, workDir, nil /*=stdio*/)
 }

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -188,6 +188,10 @@ const (
 	ctrDidNotExitCleanly
 )
 
+func (_ *dockerCommandContainer) ContainerType() platform.ContainerType {
+	return platform.DockerContainerType
+}
+
 func (r *dockerCommandContainer) Run(ctx context.Context, command *repb.Command, workDir string, creds container.PullCredentials) *interfaces.CommandResult {
 	result := &interfaces.CommandResult{
 		CommandDebugString: fmt.Sprintf("(docker) %s", command.GetArguments()),

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -625,6 +625,10 @@ func alignToMultiple(n int64, multiple int64) int64 {
 	return n + multiple - remainder
 }
 
+func (_ *FirecrackerContainer) ContainerType() platform.ContainerType {
+	return platform.FirecrackerContainerType
+}
+
 // State returns the container state to be persisted to disk so that this
 // container can be reconstructed from the state on disk after an executor
 // restart.

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -336,6 +336,10 @@ func NewPodmanCommandContainer(env environment.Env, image, buildRoot string, opt
 	}
 }
 
+func (_ *podmanCommandContainer) ContainerType() platform.ContainerType {
+	return platform.PodmanContainerType
+}
+
 func addUserArgs(args []string, options *PodmanOptions) []string {
 	if options.ForceRoot {
 		args = append(args, "--user=0:0")

--- a/enterprise/server/remote_execution/containers/sandbox/sandbox.go
+++ b/enterprise/server/remote_execution/containers/sandbox/sandbox.go
@@ -285,6 +285,10 @@ func New(options *Options) container.CommandContainer {
 	}
 }
 
+func (_ *sandbox) ContainerType() platform.ContainerType {
+	return platform.SandboxContainerType
+}
+
 func (c *sandbox) runCmdInSandbox(ctx context.Context, command *repb.Command, workDir string, stdio *container.Stdio) *interfaces.CommandResult {
 	result := &interfaces.CommandResult{
 		CommandDebugString: fmt.Sprintf("(sandbox) %s", command.GetArguments()),

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1268,6 +1268,8 @@ type ImageCacheToken struct {
 	GroupID string
 	// ImageRef is the remote image ref, e.g. "gcr.io/foo/bar:v1.0"
 	ImageRef string
+	// IsolationType is the isolation type, e.g. "docker"
+	IsolationType string
 }
 
 // ImageCacheAuthenticator validates access to locally cached images.


### PR DESCRIPTION
This prevents a theoretical bug where we accidentally share tokens for the same image across isolation types. This shouldn't happen, but Brandon and I noticed it as a possibility in https://github.com/buildbuddy-io/buildbuddy/pull/4869

**Related issues**: N/A
