### PR TITLE
Remove the additionallayerstore argument from storage.conf so per-image streaming works correctly.

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -168,8 +168,6 @@ func NewProvider(env environment.Env, buildRoot string) (*Provider, error) {
 driver = "overlay"
 runroot = "/run/containers/storage"
 graphroot = "/var/lib/containers/storage"
-[storage.options]
-additionallayerstores=["/var/lib/soci-store/store:ref"]
 `
 		if err := os.WriteFile("/etc/containers/storage.conf", []byte(storageConf), 0644); err != nil {
 			return nil, status.UnavailableErrorf("could not write storage config: %s", err)


### PR DESCRIPTION
Podman **always** uses the additional layer stores specified in storage.conf, so writing this means that running the executor with `--executor.podman.enable_image_streaming=true` and `--executor.podman.enable_private_image_streaming=false` will cause podman to hit the additional layer store for all images (including private ones), generating a bunch of not found logs in the soci-store.

**Related issues**: N/A
