### PR TITLE
Use channel instead of callback to communicate leadership changes

### DIFF
--- a/enterprise/server/raft/listener/BUILD
+++ b/enterprise/server/raft/listener/BUILD
@@ -6,5 +6,8 @@ go_library(
     name = "listener",
     srcs = ["listener.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/listener",
-    deps = ["@com_github_lni_dragonboat_v4//raftio"],
+    deps = [
+        "//server/util/log",
+        "@com_github_lni_dragonboat_v4//raftio",
+    ],
 )


### PR DESCRIPTION
this is pt1 of 2, the second part actually makes uses of the channels to update rangeleases as soon as leadership changes.