### PR TITLE
Add pebble write stall metrics to prom

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -3296,6 +3296,11 @@ func (p *PebbleCache) updatePebbleMetrics() error {
 	// Block cache metrics.
 	metrics.PebbleCachePebbleBlockCacheSizeBytes.With(nameLabel).Set(float64(m.BlockCache.Size))
 
+	// Write Stall metrics
+	count, dur := p.eventListener.writeStallStats()
+	metrics.PebbleCacheWriteStallCount.With(nameLabel).Set(float64(count))
+	metrics.PebbleCacheWriteStallDurationUsec.With(nameLabel).Observe(float64(dur.Microseconds()))
+
 	p.oldMetrics = *m
 
 	return nil

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -2285,6 +2285,25 @@ var (
 		CacheNameLabel,
 	})
 
+	PebbleCacheWriteStallCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "pebble_cache_pebble_write_stall_count",
+		Help:      "The number of write stalls",
+	}, []string{
+		CacheNameLabel,
+	})
+
+	PebbleCacheWriteStallDurationUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "pebble_cache_pebble_write_stall_duration_usec",
+		Buckets:   coarseMicrosecondToHour,
+		Help:      "The duration of write stall in pebble, in microseconds.",
+	}, []string{
+		CacheNameLabel,
+	})
+
 	// Temporary metric to verify AC sampling behavior.
 	PebbleCacheGroupIDSampleCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Right now these metrics are only available in statusz page, and it's difficult
to monitor the trend.
