### PR TITLE
Store chunks outside of pebble

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2181,8 +2181,8 @@ func (p *PebbleCache) Writer(ctx context.Context, r *rspb.ResourceName) (interfa
 	return p.newWrappedWriter(ctx, fileRecord, key, shouldCompress, rfpb.FileMetadata_COMPLETE_FILE_TYPE)
 }
 
-// newWrappedWriter returns an interfaces.CommittedWriteCloser that on Write,
-// it will
+// newWrappedWriter returns an interfaces.CommittedWriteCloser that on Write
+// will:
 // (1) compress the data if shouldCompress is true; and then
 // (2) encrypt the data if encryption is enabled
 // (3) write the data using input wcm's Write method.


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Store chunks outside of pebble if they are bigger than maxInlineFileSizeBytes. 
When tested locally, the eviction latency doesn't spike, the eviction rate don't
plateaued and can get to about the same as the current rate in production, no
compaction debt accumulated.
