### PR TITLE
[FC] Propogate networking cleanup errors

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2033,11 +2033,7 @@ func (c *FirecrackerContainer) remove(ctx context.Context) error {
 	}
 	if err := c.cleanupNetworking(ctx); err != nil {
 		log.CtxErrorf(ctx, "Error cleaning up networking: %s\n%s", err, string(c.vmLog.Tail()))
-		// TODO(Maggie): Debug root cause for failures
-		// Don't fail if networking cleanup was not successful bc it's preventing VMs from
-		// being recycled. Even if they aren't properly cleaned up, leftover
-		// rules shouldn't prevent recycled VMs from working
-		// lastErr = err
+		lastErr = err
 	}
 
 	if c.vfsServer != nil {


### PR DESCRIPTION
Revert silently ignoring networking cleanup errors so we don't un-intentionally start leaving a lot of trash behind on the executors.

Based on logs in dev, networking cleanup errors come from trying to delete ip routes that don't exist. This should fix that: #4937

**Related issues**: #4924
