### PR TITLE
Prevent container.Remove() being called while other operations are in progress

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -482,9 +482,6 @@ func (t *TracedCommandContainer) Exec(ctx context.Context, command *repb.Command
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
 
-	log.Infof("Exec()...")
-	defer log.Infof("Exec done!")
-
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	if t.removed {
@@ -524,10 +521,8 @@ func (t *TracedCommandContainer) Remove(ctx context.Context) error {
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
 
-	log.Infof("Remove()")
-
-	// Get an *exclusive* lock here to ensure any other pending operations are
-	// completed before we remove.
+	// Get an *exclusive* lock here to ensure any other concurrent operations
+	// are completed before we remove.
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.removed {

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -33,12 +33,21 @@ const (
 	// Time window over which to measure CPU usage when exporting the milliCPU
 	// used metric.
 	cpuUsageUpdateInterval = 1 * time.Second
+
+	// Exit code used when returning an error instead of an actual exit code.
+	// TODO: fix circular dependency with commandutil and reference that const
+	// instead.
+	noExitCode = -2
 )
 
 var (
 	// Metrics is a shared metrics object to handle proper prometheus metrics
 	// accounting across container instances.
 	Metrics = NewContainerMetrics()
+
+	// ErrRemoved is returned by TracedCommandContainer operations when an
+	// operation fails due to the container already being removed.
+	ErrRemoved = status.UnavailableError("container has been removed")
 
 	containerRegistries     = flag.Slice("executor.container_registries", []ContainerRegistry{}, "")
 	debugUseLocalImagesOnly = flag.Bool("debug_use_local_images_only", false, "Do not pull OCI images and only used locally cached images. This can be set to test local image builds during development without needing to push to a container registry. Not intended for production use.")
@@ -401,69 +410,157 @@ func GetPullCredentials(env environment.Env, props *platform.Properties) (PullCr
 	return PullCredentials{}, nil
 }
 
-// TracedCommandContainer is a wrapper that creates tracing spans for all CommandContainer methods.
+// TracedCommandContainer is a wrapper that creates tracing spans for all
+// CommandContainer methods. It also provides some basic protection against race
+// conditions, such as preventing Remove() from being called twice or while
+// other operations are in progress.
 type TracedCommandContainer struct {
-	Delegate CommandContainer
 	implAttr attribute.KeyValue
+
+	// This mutex is used only to prevent Remove() from being called
+	// concurrently with other operations. Exec() may be called concurrently
+	// with Pause() and Unpause() because persistent workers are implemented
+	// using a long-running Exec() operation.
+	mu       sync.RWMutex
+	removed  bool
+	Delegate CommandContainer
 }
 
 func (t *TracedCommandContainer) Run(ctx context.Context, command *repb.Command, workingDir string, creds PullCredentials) *interfaces.CommandResult {
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if t.removed {
+		return &interfaces.CommandResult{ExitCode: noExitCode, Error: ErrRemoved}
+	}
+
 	return t.Delegate.Run(ctx, command, workingDir, creds)
 }
 
 func (t *TracedCommandContainer) IsImageCached(ctx context.Context) (bool, error) {
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if t.removed {
+		return false, ErrRemoved
+	}
+
 	return t.Delegate.IsImageCached(ctx)
 }
 
 func (t *TracedCommandContainer) PullImage(ctx context.Context, creds PullCredentials) error {
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if t.removed {
+		return ErrRemoved
+	}
+
 	return t.Delegate.PullImage(ctx, creds)
 }
 
 func (t *TracedCommandContainer) Create(ctx context.Context, workingDir string) error {
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if t.removed {
+		return ErrRemoved
+	}
+
 	return t.Delegate.Create(ctx, workingDir)
 }
 
 func (t *TracedCommandContainer) Exec(ctx context.Context, command *repb.Command, opts *Stdio) *interfaces.CommandResult {
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
+
+	log.Infof("Exec()...")
+	defer log.Infof("Exec done!")
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if t.removed {
+		return &interfaces.CommandResult{ExitCode: noExitCode, Error: ErrRemoved}
+	}
+
 	return t.Delegate.Exec(ctx, command, opts)
 }
 
 func (t *TracedCommandContainer) Unpause(ctx context.Context) error {
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if t.removed {
+		return ErrRemoved
+	}
+
 	return t.Delegate.Unpause(ctx)
 }
 
 func (t *TracedCommandContainer) Pause(ctx context.Context) error {
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if t.removed {
+		return ErrRemoved
+	}
+
 	return t.Delegate.Pause(ctx)
 }
 
 func (t *TracedCommandContainer) Remove(ctx context.Context) error {
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
+
+	log.Infof("Remove()")
+
+	// Get an *exclusive* lock here to ensure any other pending operations are
+	// completed before we remove.
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.removed {
+		return ErrRemoved
+	}
+	t.removed = true
+
 	return t.Delegate.Remove(ctx)
 }
 
 func (t *TracedCommandContainer) Stats(ctx context.Context) (*repb.UsageStats, error) {
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if t.removed {
+		return nil, ErrRemoved
+	}
+
 	return t.Delegate.Stats(ctx)
 }
 
 func (t *TracedCommandContainer) State(ctx context.Context) (*rnpb.ContainerState, error) {
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if t.removed {
+		return nil, ErrRemoved
+	}
+
 	return t.Delegate.State(ctx)
 }
 

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -437,13 +437,13 @@ func (r *commandRunner) Remove(ctx context.Context) error {
 		if err := r.shutdown(ctx); err != nil {
 			errs = append(errs, err)
 		}
-		if err := r.Container.Remove(ctx); err != nil {
-			errs = append(errs, err)
-		}
 		if r.stopPersistentWorker != nil {
 			if err := r.stopPersistentWorker(); err != nil {
 				errs = append(errs, err)
 			}
+		}
+		if err := r.Container.Remove(ctx); err != nil {
+			errs = append(errs, err)
 		}
 	}
 	if err := r.removeVFS(); err != nil {

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -158,6 +158,12 @@ func newRunnerPool(t *testing.T, env *testenv.TestEnv, cfg *RunnerPoolOptions) *
 	p, err := NewPool(env, cfg.PoolOptions)
 	require.NoError(t, err)
 	require.NotNil(t, p)
+	t.Cleanup(func() {
+		// Always make sure we can cleanly shut down the pool at the end of each
+		// test.
+		err := p.Shutdown(env.GetServerContext())
+		require.NoError(t, err)
+	})
 	return p
 }
 


### PR DESCRIPTION
Ensure that we can't call `container.Remove()` while other operations are in progress, and also make operations fail immediately after the container is already removed.

This will likely fix https://github.com/buildbuddy-io/buildbuddy-internal/issues/2554, and at minimum it should give us better information as to whether a container operation is failing because of `Remove()` having already been called (on executor shutdown).

**Related issues**: N/A
