### PR TITLE
Update soci-store data paths to be under /var/lib/containers

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -109,10 +109,10 @@ const (
 	enableStreamingStoreArg = "--storage-opt=additionallayerstore=/var/lib/soci-store/store:ref"
 
 	// The directory where soci artifact blobs are stored
-	sociBlobDirectory = "/var/lib/soci-snapshotter-grpc/content/blobs/sha256/"
+	sociBlobDirectory = "/var/lib/containers/soci/content/blobs/sha256/"
 
 	// The directory whre soci indexes are stored
-	sociIndexDirectory = "/var/lib/soci-snapshotter-grpc/indexes/"
+	sociIndexDirectory = "/var/lib/containers/soci/indexes/"
 
 	sociStorePath         = "/var/lib/soci-store/store"
 	sociStoreCredCacheTtl = 1 * time.Hour

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -150,7 +150,7 @@ index_store_path = "%s"
 	return nil
 }
 
-func runSociStore(ctx context.Context) error {
+func runSociStore(ctx context.Context) {
 	for {
 		log.Infof("Starting soci store")
 		args := []string{fmt.Sprintf("--local_keychain_port=%d", *sociStoreKeychainPort)}

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -108,8 +108,12 @@ const (
 	// argument to podman to enable the use of the soci store for streaming
 	enableStreamingStoreArg = "--storage-opt=additionallayerstore=/var/lib/soci-store/store:ref"
 
+	// soci-store data root
+	sociDataRootDirectory = "/var/lib/containers/soci"
+
 	// The directory where soci artifact blobs are stored
-	sociBlobDirectory = "/var/lib/containers/soci/content/blobs/sha256/"
+	sociContentDirectory = "/var/lib/containers/soci/content"
+	sociBlobDirectory    = "/var/lib/containers/soci/content/blobs/sha256/"
 
 	// The directory whre soci indexes are stored
 	sociIndexDirectory = "/var/lib/containers/soci/indexes/"
@@ -132,11 +136,11 @@ type Provider struct {
 }
 
 func prepareSociStore(ctx context.Context) error {
-	sociStoreConf := `
-root_path = "/var/lib/containers/soci"
-content_store_path = "/var/lib/containers/soci/content"
-index_store_path = "/var/lib/containers/soci/indexes"
-`
+	sociStoreConf := fmt.Sprintf(`
+root_path = "%s"
+content_store_path = "%s"
+index_store_path = "%s"
+`, sociDataRootDirectory, sociContentDirectory, sociIndexDirectory)
 	if err := os.MkdirAll("/etc/soci-store", 0644); err != nil {
 		return err
 	}


### PR DESCRIPTION
This has the effect of preserving the soci-store data across executor container restarts which should address the Input/output bug streaming public images we observed last week.

**Related issues**: N/A
