### PR TITLE
[FC] Extend the context for networking cleanup

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1573,6 +1573,11 @@ func (c *FirecrackerContainer) cleanupNetworking(ctx context.Context) error {
 	}
 	c.isNetworkSetup = false
 
+	// Even if the context was canceled, extend the life of the context for
+	// cleanup
+	ctx, cancel := background.ExtendContextForFinalization(ctx, time.Second*1)
+	defer cancel()
+
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 


### PR DESCRIPTION
Firecracker logs show lots of errors that we are failing to cleanup networking due to context canceled errors. In these cases, we still want to ensure the cleanup happens.

Related: https://github.com/buildbuddy-io/buildbuddy/pull/4924
