### PR TITLE
Remove default listener

### DIFF
--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -211,7 +211,7 @@ func NewRaftCache(env environment.Env, conf *Config) (*RaftCache, error) {
 	// keys. The rangeCache is where this information is cached, and the
 	// sender interface is what makes it simple to address data across the
 	// cluster.
-	raftListener := listener.DefaultListener()
+	raftListener := listener.NewRaftListener()
 	nhc := dbConfig.NodeHostConfig{
 		WALDir:         filepath.Join(conf.RootDir, "wal"),
 		NodeHostDir:    filepath.Join(conf.RootDir, "nodehost"),
@@ -231,7 +231,7 @@ func NewRaftCache(env environment.Env, conf *Config) (*RaftCache, error) {
 
 	rc.apiClient = client.NewAPIClient(env, rc.nodeHost.ID())
 	rc.sender = sender.New(rc.rangeCache, rc.registry, rc.apiClient)
-	store, err := store.New(conf.RootDir, rc.nodeHost, rc.gossipManager, rc.sender, rc.registry, rc.apiClient, rc.grpcAddress, rc.conf.Partitions)
+	store, err := store.New(conf.RootDir, rc.nodeHost, rc.gossipManager, rc.sender, rc.registry, raftListener, rc.apiClient, rc.grpcAddress, rc.conf.Partitions)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/raft/listener/listener.go
+++ b/enterprise/server/raft/listener/listener.go
@@ -7,14 +7,6 @@ import (
 	"github.com/lni/dragonboat/v4/raftio"
 )
 
-var (
-	defaultListener = NewRaftListener()
-)
-
-func DefaultListener() *RaftListener {
-	return defaultListener
-}
-
 type RaftListener struct {
 	mu sync.Mutex
 

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -112,7 +112,7 @@ func (sf *storeFactory) NewStore(t *testing.T) (*TestingStore, *dragonboat.NodeH
 		return reg, nil
 	})
 
-	raftListener := listener.DefaultListener()
+	raftListener := listener.NewRaftListener()
 	nhc := dbConfig.NodeHostConfig{
 		WALDir:         filepath.Join(ts.RootDir, "wal"),
 		NodeHostDir:    filepath.Join(ts.RootDir, "nodehost"),
@@ -138,7 +138,7 @@ func (sf *storeFactory) NewStore(t *testing.T) (*TestingStore, *dragonboat.NodeH
 	rc := rangecache.New()
 	ts.Sender = sender.New(rc, reg, apiClient)
 	reg.AddNode(nodeHost.ID(), ts.RaftAddress, ts.GRPCAddress)
-	s, err := store.New(ts.RootDir, nodeHost, gm, ts.Sender, reg, apiClient, ts.GRPCAddress, []disk.Partition{})
+	s, err := store.New(ts.RootDir, nodeHost, gm, ts.Sender, reg, raftListener, apiClient, ts.GRPCAddress, []disk.Partition{})
 	require.NoError(t, err)
 	require.NotNil(t, s)
 	s.Start()


### PR DESCRIPTION
This causes bugs in another CL i'm working on because the same listener is reused in tests when it shouldn't be.