### PR TITLE
app/invocation_tabs: highlight Execution while viewing action

### DIFF
--- a/app/invocation/invocation_tabs.tsx
+++ b/app/invocation/invocation_tabs.tsx
@@ -26,10 +26,15 @@ export type TabId =
   | "suggestions"
   | "raw"
   | "execution"
-  | "fetches"
-  | "action";
+  | "fetches";
 
 export function getTabId(tab: string): TabId {
+  if (tab === "#action") {
+    // Treat the action tab as the execution tab if executions are enabled,
+    // otherwise treat it as the cache tab.
+    return this.props.executionsEnabled ? "execution" : "cache";
+  }
+
   return (tab.substring(1) as TabId) || "all";
 }
 

--- a/app/invocation/invocation_tabs.tsx
+++ b/app/invocation/invocation_tabs.tsx
@@ -30,9 +30,8 @@ export type TabId =
 
 export function getTabId(tab: string): TabId {
   if (tab === "#action") {
-    // Treat the action tab as the execution tab if executions are enabled,
-    // otherwise treat it as the cache tab.
-    return this.props.executionsEnabled ? "execution" : "cache";
+    // Treat the action tab as the execution tab for highlighting.
+    return "execution";
   }
 
   return (tab.substring(1) as TabId) || "all";

--- a/app/invocation/invocation_tabs.tsx
+++ b/app/invocation/invocation_tabs.tsx
@@ -26,12 +26,13 @@ export type TabId =
   | "suggestions"
   | "raw"
   | "execution"
-  | "fetches";
+  | "fetches"
+  | "action";
 
 export function getTabId(tab: string): TabId {
   if (tab === "#action") {
     // Treat the action tab as the execution tab for highlighting.
-    return "execution";
+    return "execution" as TabId;
   }
 
   return (tab.substring(1) as TabId) || "all";


### PR DESCRIPTION

"action" tab is a child tab that could be accessed via either "Cache"
tab (by clicking on the mnemonic of Cache Request), or via "Execution"
tab.

Let's default it to highlight the Execution tab while viewing "action"
details. If no RBE is enabled, highlight "Cache" tab instead.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
