### PR TITLE
cleanup: have AuthorizeRead accept UserInfo instead of *UserInfo

### DIFF
--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -782,7 +782,7 @@ func (d *AuthDB) GetAPIKey(ctx context.Context, apiKeyID string) (*tables.APIKey
 		return nil, err
 	}
 	acl := perms.ToACLProto(&uidpb.UserId{Id: key.UserID}, key.GroupID, key.Perms)
-	if err := perms.AuthorizeRead(&user, acl); err != nil {
+	if err := perms.AuthorizeRead(user, acl); err != nil {
 		return nil, err
 	}
 	if err := d.fillDecryptedAPIKey(key); err != nil {

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1739,7 +1739,7 @@ func (s *SchedulerServer) getExecutionNodesFromRedis(ctx context.Context, groupI
 				return nil, err
 			}
 
-			err := perms.AuthorizeRead(&user, registeredNode.GetAcl())
+			err := perms.AuthorizeRead(user, registeredNode.GetAcl())
 			if err != nil {
 				continue
 			}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -509,7 +509,7 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 
 	// Authorize workflow access
 	wfACL := perms.ToACLProto(&uidpb.UserId{Id: wf.GroupID}, wf.GroupID, wf.Perms)
-	if err := perms.AuthorizeRead(&user, wfACL); err != nil {
+	if err := perms.AuthorizeRead(user, wfACL); err != nil {
 		return nil, err
 	}
 

--- a/server/backends/invocationdb/invocationdb.go
+++ b/server/backends/invocationdb/invocationdb.go
@@ -166,7 +166,7 @@ func (d *InvocationDB) LookupInvocation(ctx context.Context, invocationID string
 		if err != nil {
 			return nil, err
 		}
-		if err := perms.AuthorizeRead(&u, getACL(ti)); err != nil {
+		if err := perms.AuthorizeRead(u, getACL(ti)); err != nil {
 			return nil, err
 		}
 	}

--- a/server/util/perms/perms.go
+++ b/server/util/perms/perms.go
@@ -110,11 +110,10 @@ func AuthenticatedUser(ctx context.Context, env environment.Env) (interfaces.Use
 	return auth.AuthenticatedUser(ctx)
 }
 
-func AuthorizeRead(authenticatedUser *interfaces.UserInfo, acl *aclpb.ACL) error {
-	if authenticatedUser == nil {
-		return status.InvalidArgumentError("authenticatedUser cannot be nil.")
+func AuthorizeRead(u interfaces.UserInfo, acl *aclpb.ACL) error {
+	if u == nil {
+		return status.InvalidArgumentError("user cannot be nil.")
 	}
-	u := *authenticatedUser
 	if acl == nil {
 		return status.InvalidArgumentError("acl cannot be nil.")
 	}


### PR DESCRIPTION
UserInfo is an interface so there's no need for the extra level of indirection. (I wrote this when I just started learning Go and didn't have much intuition about interfaces yet.)

**Related issues**: N/A
