### PR TITLE
Render execution status message in executions table

### DIFF
--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -809,6 +809,12 @@
   font-weight: 600;
 }
 
+.invocation-execution-row-status-message {
+  color: #e53935;
+  margin-top: 2px;
+  font-size: 12px;
+}
+
 .invocation-execution-row-stats div {
   margin-right: 8px;
 }

--- a/app/invocation/invocation_execution_table.tsx
+++ b/app/invocation/invocation_execution_table.tsx
@@ -71,6 +71,9 @@ export default class InvocationExecutionTable extends React.Component<Props> {
                     {execution?.executedActionMetadata?.ioStats?.fileUploadCount} files)
                   </div>
                 </div>
+                {execution.status?.code !== 0 && execution.status?.message && (
+                  <div className="invocation-execution-row-status-message">{execution.status.message}</div>
+                )}
               </div>
             </Link>
           );


### PR DESCRIPTION
A simple solution to hold us over until https://github.com/buildbuddy-io/buildbuddy-internal/issues/2774 is implemented - just render the status message from the Executions table which is already available in the UI.

Looks like this: 

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/04e6fab2-e691-497c-b9d6-4272d1c548e6)

The action page doesn't currently have access to the Execution row, so it's simplest to render this in the table for now (rather than awkwardly passing it to the action page via URL params or something like that)

**Related issues**: N/A
