### PR TITLE
Don't make `GetBazelConfigRequest` any time you visit timing profile

### DIFF
--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -51,7 +51,7 @@ const groupByAllStorageValue = "all";
 export default class InvocationTimingCardComponent extends React.Component<Props, State> {
   state: State = {
     profile: null,
-    loading: false,
+    loading: true,
     threadNumPages: 1,
     threadToNumEventPagesMap: new Map<number, number>(),
     threadMap: new Map<number, Thread>(),
@@ -82,7 +82,9 @@ export default class InvocationTimingCardComponent extends React.Component<Props
   }
 
   fetchProfile() {
-    if (!this.isTimingEnabled()) return;
+    if (!this.isTimingEnabled()) {
+      this.setState({ loading: false });
+    }
 
     // Already fetched
     if (this.state.profile) return;


### PR DESCRIPTION
`GetBazelConfigRequest` requests show up in the audit log, so we don't want to make these requests unnecessarily.

Currently the `SetupCodeComponent` is briefly shown when the component is rendered but before the timing profile request is made. This causes an api key viewed audit log entry to be created any time you visit the timing profile.

Separately we should change the UX of the `SetupCodeComponent` to require a click instead of automatically making a request that triggers an audit log entry.