### PR TITLE
Update repo flow to use popups

### DIFF
--- a/enterprise/app/repo/BUILD
+++ b/enterprise/app/repo/BUILD
@@ -14,6 +14,7 @@ ts_library(
         "//app/errors:error_service",
         "//app/router",
         "//app/service:rpc_service",
+        "//app/util:popup",
         "//enterprise/app/secrets:secret_util",
         "//proto:github_ts_proto",
         "//proto:repo_ts_proto",

--- a/enterprise/app/repo/repo.css
+++ b/enterprise/app/repo/repo.css
@@ -1,6 +1,6 @@
 .create-repo-page {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
-  Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans,
+    Droid Sans, Helvetica Neue, sans-serif;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -9,7 +9,7 @@
 }
 
 .create-repo-page .card {
-  box-shadow: 0 1px 3px 0 rgba(0,0,0,.1),0 1px 2px -1px rgba(0,0,0,.1);
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
   border: 1px solid hsl(240 5.9% 90%);
 }
 

--- a/enterprise/app/repo/repo.css
+++ b/enterprise/app/repo/repo.css
@@ -1,4 +1,6 @@
 .create-repo-page {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+  Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -6,11 +8,17 @@
   min-height: 100%;
 }
 
+.create-repo-page .card {
+  box-shadow: 0 1px 3px 0 rgba(0,0,0,.1),0 1px 2px -1px rgba(0,0,0,.1);
+  border: 1px solid hsl(240 5.9% 90%);
+}
+
 .create-repo-page .repo-block {
   flex-direction: column;
   width: 50vw;
   max-width: 600px;
-  margin: 32px 0 0 0;
+  box-sizing: border-box;
+  margin: 24px 0 0 0;
 }
 
 .create-repo-page .repo-create {
@@ -44,12 +52,14 @@
 
 .create-repo-page .repo-picker input,
 .create-repo-page .repo-picker select,
+.create-repo-page .repo-picker button,
 .create-repo-page .deployment-config input {
   padding: 12px;
   width: 100%;
   border-radius: 8px;
   border: 1px solid #aaa;
   font-family: inherit;
+  font-weight: inherit;
   font-size: 1.2em;
   height: initial;
 }
@@ -73,6 +83,7 @@
   color: #fff;
   transition: 300ms ease-in-out;
   box-sizing: border-box;
+  gap: 8px;
 }
 
 .create-repo-page .view-buttons .view-button,
@@ -173,4 +184,75 @@
 
 .create-repo-page .deployment-config div:first-of-type {
   font-family: monospace;
+}
+
+.create-repo-page .template {
+  transition: all 100ms ease-in-out;
+  display: flex;
+  box-sizing: border-box;
+  overflow: hidden;
+  width: 100%;
+}
+
+.create-repo-page .template-block {
+  padding-right: 0 !important;
+}
+
+.create-repo-page .template-metadata {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 8px;
+  flex-grow: 1;
+  flex-shrink: 0;
+  width: calc(100% - 100px);
+  overflow: hidden;
+  padding-right: 8px;
+}
+
+.create-repo-page .template-name {
+  font-weight: 800;
+  font-size: 2.5em;
+  line-height: 1.2em;
+  max-height: 2.4em;
+  display: block;
+  overflow: hidden;
+}
+
+.create-repo-page .template-props {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow: hidden;
+  max-width: 100%;
+  width: 100%;
+}
+
+.create-repo-page .template-repo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 100%;
+}
+
+.create-repo-page .template-repo-name {
+  display: block;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.create-repo-page .template-repo svg {
+  flex-shrink: 0;
+}
+
+.create-repo-page .template-image {
+  width: 100px;
+  flex-shrink: 0;
+  object-fit: cover;
+  object-position: 0 50%;
 }

--- a/enterprise/app/repo/repo.tsx
+++ b/enterprise/app/repo/repo.tsx
@@ -132,10 +132,14 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
   }
 
   async loginAndLinkGithub() {
-    if (!this.props.user) {
-      await this.loginToGithub();
+    try {
+      if (!this.props.user) {
+        await this.loginToGithub();
+      }
+      await this.linkGithubAccount();
+    } catch (e) {
+      error_service.handleError(e);
     }
-    await this.linkGithubAccount();
   }
 
   loginToGithub() {
@@ -146,8 +150,7 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
           link: "true",
         })}`
       )
-      .then(() => auth_service.refreshUser())
-      .catch(error_service.handleError);
+      .then(() => auth_service.refreshUser());
   }
 
   linkGithubAccount() {
@@ -170,8 +173,7 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
           }
           return resp;
         });
-      })
-      .catch(error_service.handleError);
+      });
   }
 
   handleInstallationPicked(e: React.ChangeEvent<HTMLSelectElement>) {
@@ -308,14 +310,11 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
     let needsGCPLink =
       isGCPDeploy && !this.state.secretsResponse?.secret.map((s) => s.name).includes(gcpRefreshTokenKey);
 
-    if (isGCPDeploy && needsGCPLink) {
-      await this.linkGoogleCloud()
-        .then(() => this.fetchSecrets())
-        .catch(error_service.handleError);
-    }
-
     this.setState({ isDeploying: true });
     try {
+      if (isGCPDeploy && needsGCPLink) {
+        await this.linkGoogleCloud().then(() => this.fetchSecrets());
+      }
       if (this.getUnsetSecrets().length) {
         await this.saveSecrets();
       }

--- a/enterprise/app/repo/repo.tsx
+++ b/enterprise/app/repo/repo.tsx
@@ -4,16 +4,16 @@ import rpc_service from "../../../app/service/rpc_service";
 import { github } from "../../../proto/github_ts_proto";
 import { repo } from "../../../proto/repo_ts_proto";
 import Spinner from "../../../app/components/spinner/spinner";
-import { ChevronRightSquare, Github, UserIcon } from "lucide-react";
-import auth_service from "../../../app/auth/auth_service";
+import { BookCopy, ChevronRightSquare, CloudIcon, Folders, Github } from "lucide-react";
 import { workflow } from "../../../proto/workflow_ts_proto";
 import Select from "../../../app/components/select/select";
 import Checkbox from "../../../app/components/checkbox/checkbox";
 import TextInput from "../../../app/components/input/input";
 import { encryptAndUpdate } from "../secrets/secret_util";
-import { User } from "../../../app/auth/auth_service";
+import auth_service, { User } from "../../../app/auth/auth_service";
 import { secrets } from "../../../proto/secrets_ts_proto";
 import router from "../../../app/router/router";
+import popup from "../../../app/util/popup";
 
 export interface RepoComponentProps {
   path: string;
@@ -78,6 +78,18 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
     return this.props.search.get("dir") || "";
   }
 
+  getTemplateName() {
+    return this.props.search.get("templatename") || "";
+  }
+
+  getTemplateUrl() {
+    return this.props.search.get("template") || "";
+  }
+
+  getTemplateImage() {
+    return this.props.search.get("image") || "";
+  }
+
   getRepoName() {
     let paramRepoName = this.props.search.get("name");
     if (paramRepoName) {
@@ -93,13 +105,14 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
   fetchGithubInstallations() {
     if (!this.props.user || !this.props.user.githubLinked) {
       this.setState({ githubInstallationsLoading: false });
-      return;
+      return Promise.resolve(null);
     }
-    rpc_service.service
+    return rpc_service.service
       .getGithubUserInstallations(new github.GetGithubUserInstallationsRequest())
       .then((response) => {
         console.log(response);
         this.setState({ githubInstallationsResponse: response });
+        return response;
       })
       .catch((e) => error_service.handleError(e))
       .finally(() => this.setState({ githubInstallationsLoading: false }));
@@ -107,7 +120,7 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
 
   fetchSecrets() {
     if (!this.props.user) return;
-    rpc_service.service.listSecrets(new secrets.ListSecretsRequest()).then((response) => {
+    return rpc_service.service.listSecrets(new secrets.ListSecretsRequest()).then((response) => {
       console.log(response);
       this.setState({ secretsResponse: response });
     });
@@ -118,16 +131,57 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
     this.fetchSecrets();
   }
 
-  handleInstallationPicked(e: React.ChangeEvent<HTMLSelectElement>) {
-    if (e.target.value == "-1") {
-      window.location.href = `/auth/github/app/link/?${new URLSearchParams({
-        group_id: this.props.user?.selectedGroup.id || "",
-        user_id: this.props.user?.displayUser.userId?.id || "",
-        redirect_url: window.location.href,
-        install: "true",
-      })}`;
+  async loginAndLinkGithub() {
+    if (!this.props.user) {
+      await this.loginToGithub();
     }
-    let index = Number(e.target.value);
+    await this.linkGithubAccount();
+  }
+
+  loginToGithub() {
+    return popup
+      .open(
+        `/login/github/?${new URLSearchParams({
+          redirect_url: window.location.href,
+          link: "true",
+        })}`
+      )
+      .then(() => auth_service.refreshUser())
+      .catch(error_service.handleError);
+  }
+
+  linkGithubAccount() {
+    return popup
+      .open(
+        `/auth/github/app/link/?${new URLSearchParams({
+          group_id: this.props.user?.selectedGroup.id || "",
+          user_id: this.props.user?.displayUser.userId?.id || "",
+          redirect_url: window.location.href,
+          install: "true",
+        })}`
+      )
+      .then(() => this.fetchSecrets())
+      .then(() => {
+        return this.fetchGithubInstallations()?.then((resp) => {
+          let installationId = auth_service.getCookie("Github-Linked-Installation-ID");
+          let installationIndex = resp?.installations.findIndex((i) => i.id.toString() == installationId);
+          if (installationIndex && installationIndex > 0) {
+            this.selectInstallation(installationIndex);
+          }
+          return resp;
+        });
+      })
+      .catch(error_service.handleError);
+  }
+
+  handleInstallationPicked(e: React.ChangeEvent<HTMLSelectElement>) {
+    this.selectInstallation(Number(e.target.value));
+  }
+
+  selectInstallation(index: number) {
+    if (index == -1) {
+      return this.loginAndLinkGithub();
+    }
     localStorage[selectedInstallationIndexLocalStorageKey] = index;
     this.setState({ selectedInstallationIndex: index });
   }
@@ -218,6 +272,17 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
   }
 
   async handleCreateClicked() {
+    if (!this.state.githubInstallationsResponse?.installations?.length) {
+      // TODO(siggisim): Instead of showing link popup again, show an in-app picker if
+      // there is more than one github org, or skip the linking if there's exactly one.
+      await this.loginAndLinkGithub();
+    }
+
+    if (!this.hasPermissions()) {
+      // TODO(siggisim): Make sure this permissions thing works well.
+      await this.showPermissions();
+    }
+
     this.setState({ isCreating: true });
     try {
       await this.linkInstallation();
@@ -239,6 +304,16 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
   }
 
   async handleDeployClicked(repoResponse: repo.CreateRepoResponse) {
+    let isGCPDeploy = this.getSecrets().includes(gcpRefreshTokenKey);
+    let needsGCPLink =
+      isGCPDeploy && !this.state.secretsResponse?.secret.map((s) => s.name).includes(gcpRefreshTokenKey);
+
+    if (isGCPDeploy && needsGCPLink) {
+      await this.linkGoogleCloud()
+        .then(() => this.fetchSecrets())
+        .catch(error_service.handleError);
+    }
+
     this.setState({ isDeploying: true });
     try {
       if (this.getUnsetSecrets().length) {
@@ -252,11 +327,21 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
     }
   }
 
-  handlePermissionsClicked() {
+  showPermissions() {
     let selectedInstallation = this.state.githubInstallationsResponse?.installations[
       this.state.selectedInstallationIndex
     ];
-    window.location.href = selectedInstallation?.url + `/permissions/update`;
+    popup.open(selectedInstallation?.url + `/permissions/update`);
+  }
+
+  linkGoogleCloud() {
+    return popup.open(
+      `/login/?${new URLSearchParams({
+        issuer_url: "https://accounts.google.com",
+        link_gcp_for_group: this.props.user?.selectedGroup.id || "",
+        redirect_url: window.location.href,
+      })}`
+    );
   }
 
   render() {
@@ -271,68 +356,58 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
     }
 
     let isGCPDeploy = this.getSecrets().includes(gcpRefreshTokenKey);
-    let needsGCPLink =
-      isGCPDeploy && !this.state.secretsResponse?.secret.map((s) => s.name).includes(gcpRefreshTokenKey);
     let deployDestination = isGCPDeploy ? " to Google Cloud" : "";
     return (
       <div className="create-repo-page">
-        {!this.props.user && (
-          <div className="repo-block card login-buttons">
-            <div className="repo-title">Get started</div>
-            <button
-              className="github-button"
-              onClick={() =>
-                (window.location.href = `/login/github/?${new URLSearchParams({
-                  redirect_url: window.location.href,
-                  link: "true",
-                })}`)
-              }>
-              <Github /> Continue with Github
-            </button>
-            <button className="google-button" onClick={() => auth_service.login()}>
-              <UserIcon /> Continue with Google
-            </button>
-          </div>
-        )}
-        {this.props.user && !this.state.githubInstallationsResponse?.installations && (
-          <div className="repo-block card login-buttons">
-            <div className="repo-title">Get started</div>
-            <button
-              className="github-button"
-              onClick={() =>
-                (window.location.href = `/auth/github/app/link/?${new URLSearchParams({
-                  user_id: this.props.user?.displayUser?.userId?.id || "",
-                  group_id: this.props.user?.selectedGroup?.id || "",
-                  redirect_url: window.location.href,
-                  install: "true",
-                })}`)
-              }>
-              <Github /> Link Github
-            </button>
-          </div>
-        )}
-        <div
-          className={`repo-block card repo-create ${
-            this.props.user && this.state.githubInstallationsResponse?.installations ? "" : "disabled"
-          }`}>
-          <div className="repo-title">Create git repository</div>
-          <div className="repo-picker">
-            <div>
-              <div>Git scope</div>
-              <div>
-                <Select
-                  onChange={this.handleInstallationPicked.bind(this)}
-                  value={this.state.selectedInstallationIndex}>
-                  {this.state.githubInstallationsResponse?.installations.map((i, index: number) => (
-                    <option value={index}>{`${i.login}`}</option>
-                  ))}
-                  {!this.state.githubInstallationsResponse?.installations && (
-                    <option value={-1}>Pick a git scope...</option>
+        <div className="create-repo-page-details">
+          <div className="repo-block card template-block">
+            <div className="template">
+              <div className="template-metadata">
+                <div className="template-name">{this.getTemplateName()}</div>
+                <div className="template-props">
+                  <div className="template-repo">
+                    <Github />
+                    <div className="template-repo-name">
+                      {this.getTemplateUrl().replaceAll("https://github.com/", "").split("/")[0]}
+                    </div>
+                  </div>
+                  <div className="template-repo">
+                    <BookCopy />
+                    <div className="template-repo-name">
+                      {this.getTemplateUrl().replaceAll("https://github.com/", "").split("/")[1]}
+                    </div>
+                  </div>
+                  {this.getTemplateDirectory() && (
+                    <div className="template-repo">
+                      <Folders />
+                      <div className="template-repo-name">{this.getTemplateDirectory().replaceAll("/", " / ")}</div>
+                    </div>
                   )}
-                  <option value={-1}>+ Add Github Account</option>
-                </Select>
+                </div>
               </div>
+              {this.getTemplateImage() && <img className="template-image" src={this.getTemplateImage()} />}
             </div>
+          </div>
+        </div>
+        <div className={`repo-block card repo-create`}>
+          <div className="repo-title">Create repository</div>
+          <div className="repo-picker">
+            {this.state.githubInstallationsResponse?.installations &&
+              this.state.githubInstallationsResponse?.installations.length > 0 && (
+                <div>
+                  <div>Git scope</div>
+                  <div>
+                    <Select
+                      onChange={this.handleInstallationPicked.bind(this)}
+                      value={this.state.selectedInstallationIndex}>
+                      {this.state.githubInstallationsResponse?.installations.map((i, index: number) => (
+                        <option value={index}>{`${i.login}`}</option>
+                      ))}
+                      <option value={-1}>+ Add Github Account</option>
+                    </Select>
+                  </div>
+                </div>
+              )}
             <div>
               <div>Repository name</div>
               <div>
@@ -344,21 +419,12 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
             <Checkbox checked={this.state.private} onChange={this.handlePrivateChanged.bind(this)} />
             Create private git repository
           </label>
-          {!this.hasPermissions() && (
-            <button className="permissions-button" onClick={this.handlePermissionsClicked.bind(this)}>
-              Grant permissions
-            </button>
-          )}
           {!this.state.repoResponse && (
             <button
-              disabled={
-                !this.state.githubInstallationsResponse?.installations ||
-                !this.hasPermissions() ||
-                this.state.isCreating
-              }
+              disabled={this.state.isCreating}
               className="create-button"
               onClick={this.handleCreateClicked.bind(this)}>
-              {this.state.isCreating ? "Creating..." : "Create repository"}
+              <Github /> {this.state.isCreating ? "Creating..." : "Create repository"}
             </button>
           )}
           {this.state.repoResponse && (
@@ -376,8 +442,7 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
           )}
         </div>
         {this.getSecrets().length > 0 && (
-          <div
-            className={`repo-block card repo-create ${this.props.user && this.state.repoResponse ? "" : "disabled"}`}>
+          <div className={`repo-block card repo-create`}>
             <div className="repo-title">Configure deployment</div>
             <div className="deployment-configs">
               {this.getUnsetSecrets().map((s) => (
@@ -385,7 +450,6 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
                   <div>{s}</div>
                   <div>
                     <TextInput
-                      type="password"
                       placeholder={s}
                       value={this.state.secrets.get(s)}
                       onChange={(e) => {
@@ -397,30 +461,11 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
                 </div>
               ))}
             </div>
-            {needsGCPLink && (
-              <button
-                disabled={!this.state.githubInstallationsResponse?.installations}
-                className="create-button"
-                onClick={() =>
-                  (window.location.href = `/login/?${new URLSearchParams({
-                    issuer_url: "https://accounts.google.com",
-                    link_gcp_for_group: this.props.user?.selectedGroup.id || "",
-                    redirect_url: window.location.href,
-                  })}`)
-                }>
-                Link Google Cloud
-              </button>
-            )}
             <button
-              disabled={
-                !this.state.githubInstallationsResponse?.installations ||
-                !this.hasPermissions() ||
-                this.state.isDeploying ||
-                Boolean(this.state.workflowResponse) ||
-                needsGCPLink
-              }
+              disabled={!this.state.repoResponse || this.state.isDeploying || Boolean(this.state.workflowResponse)}
               className="create-button"
               onClick={() => this.handleDeployClicked(this.state.repoResponse!)}>
+              <CloudIcon />{" "}
               {this.state.isDeploying || this.state.workflowResponse
                 ? `Deploying${deployDestination}...`
                 : `Deploy${deployDestination}`}

--- a/enterprise/app/repo/repo.tsx
+++ b/enterprise/app/repo/repo.tsx
@@ -360,34 +360,40 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
     return (
       <div className="create-repo-page">
         <div className="create-repo-page-details">
-          <div className="repo-block card template-block">
-            <div className="template">
-              <div className="template-metadata">
-                <div className="template-name">{this.getTemplateName()}</div>
-                <div className="template-props">
-                  <div className="template-repo">
-                    <Github />
-                    <div className="template-repo-name">
-                      {this.getTemplateUrl().replaceAll("https://github.com/", "").split("/")[0]}
-                    </div>
+          {this.getTemplateName() && (
+            <div className="repo-block card template-block">
+              <div className="template">
+                <div className="template-metadata">
+                  <div className="template-name">{this.getTemplateName()}</div>
+                  <div className="template-props">
+                    {this.getTemplateUrl() && (
+                      <div className="template-repo">
+                        <Github />
+                        <div className="template-repo-name">
+                          {this.getTemplateUrl().replaceAll("https://github.com/", "").split("/")[0]}
+                        </div>
+                      </div>
+                    )}
+                    {this.getTemplateUrl() && (
+                      <div className="template-repo">
+                        <BookCopy />
+                        <div className="template-repo-name">
+                          {this.getTemplateUrl().replaceAll("https://github.com/", "").split("/").pop()}
+                        </div>
+                      </div>
+                    )}
+                    {this.getTemplateDirectory() && (
+                      <div className="template-repo">
+                        <Folders />
+                        <div className="template-repo-name">{this.getTemplateDirectory().replaceAll("/", " / ")}</div>
+                      </div>
+                    )}
                   </div>
-                  <div className="template-repo">
-                    <BookCopy />
-                    <div className="template-repo-name">
-                      {this.getTemplateUrl().replaceAll("https://github.com/", "").split("/")[1]}
-                    </div>
-                  </div>
-                  {this.getTemplateDirectory() && (
-                    <div className="template-repo">
-                      <Folders />
-                      <div className="template-repo-name">{this.getTemplateDirectory().replaceAll("/", " / ")}</div>
-                    </div>
-                  )}
                 </div>
+                {this.getTemplateImage() && <img className="template-image" src={this.getTemplateImage()} />}
               </div>
-              {this.getTemplateImage() && <img className="template-image" src={this.getTemplateImage()} />}
             </div>
-          </div>
+          )}
         </div>
         <div className={`repo-block card repo-create`}>
           <div className="repo-title">Create repository</div>

--- a/enterprise/server/gcplink/gcplink.go
+++ b/enterprise/server/gcplink/gcplink.go
@@ -43,8 +43,7 @@ var (
 
 // Returns true if the request contains either a gcp link url param or cookie.
 func IsLinkRequest(r *http.Request) bool {
-	return (r.URL.Query().Get(linkParamName) != "" && cookie.GetCookie(r, cookie.AuthIssuerCookie) == Issuer) ||
-		cookie.GetCookie(r, linkCookieName) != ""
+	return r.URL.Query().Get(linkParamName) != "" || cookie.GetCookie(r, linkCookieName) != ""
 }
 
 // Redirects the user to the auth flow with a request for the GCP scope.

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -53,6 +53,7 @@ const (
 	stateCookieName   = "Github-State-Token"
 	groupIDCookieName = "Github-Linked-Group-ID"
 	userIDCookieName  = "Github-Linked-User-ID"
+	installationIDCookieName  = "Github-Linked-Installation-ID"
 )
 
 // State represents a status value that GitHub's statuses API understands.
@@ -218,10 +219,10 @@ func (c *OAuthHandler) StartAuthFlow(w http.ResponseWriter, r *http.Request, red
 		redirectWithError(w, r, err)
 		return
 	}
-	setCookie(w, stateCookieName, state)
-	setCookie(w, userIDCookieName, userID)
-	setCookie(w, groupIDCookieName, groupID)
-	setCookie(w, cookie.RedirCookie, redirectURL)
+	setCookie(w, stateCookieName, state, true)
+	setCookie(w, userIDCookieName, userID, true)
+	setCookie(w, groupIDCookieName, groupID, true)
+	setCookie(w, cookie.RedirCookie, redirectURL, true)
 
 	var authURL string
 	if r.FormValue("install") == "true" && c.InstallURL != "" {
@@ -432,6 +433,8 @@ func (c *OAuthHandler) handleInstallation(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		return false, err
 	}
+	// Set a client readable cookie with installation id, so it knows which installation was most recently installed. 
+	setCookie(w, installationIDCookieName, rawID, false)
 	if redirect != "" {
 		http.Redirect(w, r, redirect, http.StatusTemporaryRedirect)
 		return true, nil
@@ -555,12 +558,12 @@ func appendStatusNameSuffix(p *GithubStatusPayload) *GithubStatusPayload {
 	return NewGithubStatusPayload(name, p.TargetURL, p.Description, p.State)
 }
 
-func setCookie(w http.ResponseWriter, name, value string) {
+func setCookie(w http.ResponseWriter, name, value string, httpOnly bool) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     name,
 		Value:    value,
 		Expires:  time.Now().Add(time.Hour),
-		HttpOnly: true,
+		HttpOnly: httpOnly,
 		SameSite: http.SameSiteLaxMode,
 		Path:     "/",
 	})

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -50,10 +50,10 @@ const (
 	FailureState State = "failure"
 	SuccessState State = "success"
 
-	stateCookieName   = "Github-State-Token"
-	groupIDCookieName = "Github-Linked-Group-ID"
-	userIDCookieName  = "Github-Linked-User-ID"
-	installationIDCookieName  = "Github-Linked-Installation-ID"
+	stateCookieName          = "Github-State-Token"
+	groupIDCookieName        = "Github-Linked-Group-ID"
+	userIDCookieName         = "Github-Linked-User-ID"
+	installationIDCookieName = "Github-Linked-Installation-ID"
 )
 
 // State represents a status value that GitHub's statuses API understands.
@@ -433,7 +433,7 @@ func (c *OAuthHandler) handleInstallation(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		return false, err
 	}
-	// Set a client readable cookie with installation id, so it knows which installation was most recently installed. 
+	// Set a client readable cookie with installation id, so it knows which installation was most recently installed.
 	setCookie(w, installationIDCookieName, rawID, false)
 	if redirect != "" {
 		http.Redirect(w, r, redirect, http.StatusTemporaryRedirect)


### PR DESCRIPTION
This is still a bit of a work in progress, but this state is definitely better than what's currently live in dev.

This PR does a few things, happy to break it up if it's a pain to review:
- Switches to using popups instead of redirects for all linking / auth
  - This allows us to remove like 3 or 4 buttons that were needed for all sorts of edge cases
  - Moves the edge case handling to when either the create repo button is clicked or the deploy button is clicked
-  Adds some query parameters which allows us to render a nice title with an image if present
- Adds a cookie with the last github app installation id so we can automatically select it if it was just installed

Screenshot:
<img width="1445" alt="Screenshot 2023-10-06 at 5 12 51 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/98fce163-eaaf-4f0b-aeea-4eaf896f0e53">
