### PR TITLE
Fix potential goroutine leak

### DIFF
--- a/enterprise/server/scheduling/scheduler_client/scheduler_client.go
+++ b/enterprise/server/scheduling/scheduler_client/scheduler_client.go
@@ -180,7 +180,7 @@ func (r *Registration) maintainRegistrationAndStreamWork(ctx context.Context) {
 		r.setConnected(true)
 
 		schedulerMsgs := make(chan *scpb.RegisterAndStreamWorkResponse)
-		schedulerErr := make(chan error)
+		schedulerErr := make(chan error, 1)
 		go func() {
 			for {
 				msg, err := stream.Recv()


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy/pull/4978 added a new `schedulerErr` channel. When sending on that channel and the context is cancelled, it's possible the goroutine which is supposed to receive from that channel has already exited ([here](https://github.com/buildbuddy-io/buildbuddy/blob/aa2d5443698a9544a389f7a43b3929f6a7bcf554/enterprise/server/scheduling/scheduler_client/scheduler_client.go#L109))

The fix in this PR is to use a channel buffer size of 1 so that the error will just go into the buffer in this case, then the channel will be garbage collected.

**Related issues**: N/A
