### PR TITLE
Retry LeaseTask on app shutdown

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//server/util/grpc_client",
         "//server/util/log",
         "//server/util/perms",
+        "//server/util/random",
         "//server/util/status",
         "//server/util/tracing",
         "@com_github_go_redis_redis_v8//:redis",
@@ -36,6 +37,7 @@ go_library(
         "@org_golang_google_grpc//peer",
         "@org_golang_google_protobuf//encoding/prototext",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//types/known/durationpb",
         "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )

--- a/enterprise/server/scheduling/task_leaser/BUILD
+++ b/enterprise/server/scheduling/task_leaser/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//server/util/authutil",
         "//server/util/flag",
         "//server/util/log",
+        "//server/util/retry",
         "//server/util/status",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -55,11 +55,8 @@ message LeaseTaskRequest {
   // support reconnection.
   bool supports_reconnect = 7;
 
-  // The reconnect token that was returned by the server when the task was
-  // previously transitioned to "reconnecting" state. If the reconnect token is
-  // valid and the reconnection grace period has not yet elapsed, then the
-  // client will be allowed to reclaim the task, effectively resuming the
-  // previous lease.
+  // The token issued by the server when initially establishing the lease. This
+  // should be set by the client when attempting to retry a disconnected lease.
   string reconnect_token = 8;
 }
 
@@ -76,9 +73,7 @@ message LeaseTaskResponse {
   // Whether or not the lease was closed cleanly.
   bool closed_cleanly = 3;
 
-  // If present, the lease has been placed into "reconnecting" state due to the
-  // server shutting down. The client should immediately terminate the current
-  // lease stream and initiate a new LeaseTask stream with this token.
+  // A token that may be used to retry the lease if it disconnects.
   string reconnect_token = 4;
 }
 


### PR DESCRIPTION
Implements the reconnection changes described in the proto docs added here: https://github.com/buildbuddy-io/buildbuddy/pull/4983

The executor changes are behind the flag `executor.enable_lease_reconnect` which is set to true by default. The app's behavior is gated by the client's reported value of this flag, as well as the app flag `remote_execution.lease_reconnect_grace_period` being greater than 0 (defaults to 1s)

**Related issues**: N/A
