### PR TITLE
Filter out any window messages that aren't from buildbuddy

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -104,7 +104,7 @@ export class AuthService {
   }
 
   handleLoggedIn(response: user.GetUserResponse) {
-    window.opener?.postMessage("", window.location.origin);
+    window.opener?.postMessage({ type: "buildbuddy_message", error: "", success: true }, window.location.origin);
     localStorage.removeItem(AUTO_LOGIN_ATTEMPTED_STORAGE_KEY);
     this.emitUser(this.userFromResponse(response));
   }

--- a/app/errors/error_service.ts
+++ b/app/errors/error_service.ts
@@ -21,7 +21,10 @@ export class ErrorService {
       return;
     }
     alertService.error(String(error));
-    window.opener?.postMessage(String(error), window.location.origin);
+    window.opener?.postMessage(
+      { type: "buildbuddy_message", error: String(error), success: false },
+      window.location.origin
+    );
   }
 }
 

--- a/app/util/popup.ts
+++ b/app/util/popup.ts
@@ -33,13 +33,16 @@ export default {
 
       // If we receieve a message, resolve or reject the promise based on the presence of error text.
       popupEventListener = function (e: MessageEvent) {
+        if (!e.data || e.data.type != "buildbuddy_message") {
+          return;
+        }
         clearTimeout(timeoutId);
         clearInterval(popupTimer);
         window.removeEventListener("message", popupEventListener, false);
         popup?.close();
         console.log("Received message from popup: " + e.data);
-        if (e.data != "") {
-          reject(e.data);
+        if (!e.data.success) {
+          reject(e.data.error);
         }
         resolve(e.data);
       };


### PR DESCRIPTION
This prevents plugins like [React Developer Tools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi/related) from unintentionally posting window messages that interfere with the flow.