### PR TITLE
cli: avoid setting empty API key header in upload/download commands

### DIFF
--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -107,7 +107,7 @@ func downloadFile(uri string) error {
 	}
 
 	ctx := context.Background()
-	if apiKey, err := storage.ReadRepoConfig("api-key"); err == nil {
+	if apiKey, err := storage.ReadRepoConfig("api-key"); err == nil && apiKey != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-api-key", apiKey)
 	}
 

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -87,7 +87,7 @@ func uploadFile(args []string) error {
 	defer f.Close()
 
 	ctx := context.Background()
-	if apiKey, err := storage.ReadRepoConfig("api-key"); err == nil {
+	if apiKey, err := storage.ReadRepoConfig("api-key"); err == nil && apiKey != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-api-key", apiKey)
 	}
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
