### PR TITLE
Switch from XHR to Fetch API

### DIFF
--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -102,8 +102,11 @@ export default class InvocationTimingCardComponent extends React.Component<Props
     // Note: we use responseType "text" instead of "json" since the profile is
     // not always valid JSON (the trailing "]}" may be missing).
     rpcService
-      .fetchBytestreamFile(profileFile.uri, this.props.model.getInvocationId(), "text", { storedEncoding })
-      .then((contents: string) => this.updateProfile(parseProfile(contents)))
+      .fetchBytestreamFile(profileFile.uri, this.props.model.getInvocationId(), "text", {
+        // Set the stored encoding header to prevent the server from double-gzipping.
+        headers: { "X-Stored-Encoding-Hint": storedEncoding },
+      })
+      .then((contents) => this.updateProfile(parseProfile(contents)))
       .catch((e) => errorService.handleError(e))
       .finally(() => this.setState({ loading: false }));
   }


### PR DESCRIPTION
This is in preparation for switching the timing profile to use a streaming HTTP request for loading and parsing the JSON profile. XHR supports streaming but it's very ugly.

* Switch from XHR to Fetch
* Remove `storedEncoding` as a method param (since it's pretty niche), and instead pass the stored-encoding header directly via the standard `RequestInit` object
* Improve type safety of fetch() method - instead of `Promise<any>`, returns `Promise<ArrayBuffer>` when setting request type to `arraybuffer`, `Promise<string>` when setting request type to `"text"`, etc.

**Related issues**: N/A
