### PR TITLE
Make reads and writes linearizable

### DIFF
--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -371,22 +371,27 @@ func (rc *RaftCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompres
 		return nil, err
 	}
 
-	var readCloser io.ReadCloser
+	var rsp *rfpb.GetMultiResponse
 	err = rc.sender.Run(ctx, fileMetadataKey, func(c rfspb.ApiClient, h *rfpb.Header) error {
-		req := &rfpb.ReadRequest{
+		req := &rfpb.GetMultiRequest{
 			Header:     h,
-			FileRecord: fileRecord,
-			Offset:     uncompressedOffset,
-			Limit:      limit,
+			FileRecords: []*rfpb.FileRecord{fileRecord},
 		}
-		r, err := rc.apiClient.RemoteReader(ctx, c, req)
+		r, err := c.GetMulti(ctx, req)
 		if err != nil {
 			return err
 		}
-		readCloser = r
+		rsp = r
 		return nil
 	})
-	return readCloser, err
+	if err != nil {
+		return nil, err
+	}
+	if len(rsp.GetResponses()) != 1 {
+		return nil, status.InternalError("GetMulti response did not containe requested FileRecord")
+	}
+	md := rsp.GetResponses()[0].GetFileMetadata()
+	return rc.fileStorer.InlineReader(md.GetStorageMetadata().GetInlineMetadata(), uncompressedOffset, limit)
 }
 
 type raftWriteCloser struct {
@@ -548,7 +553,7 @@ func (rc *RaftCache) GetMulti(ctx context.Context, resources []*rspb.ResourceNam
 			if !ok {
 				return nil, status.InternalError("type is not *rfpb.FileRecord")
 			}
-			req.FileRecord = append(req.FileRecord, fr)
+			req.FileRecords = append(req.FileRecords, fr)
 		}
 		return c.GetMulti(ctx, req)
 	})
@@ -560,10 +565,10 @@ func (rc *RaftCache) GetMulti(ctx context.Context, resources []*rspb.ResourceNam
 	for _, rsp := range rsps {
 		fmr, ok := rsp.(*rfpb.GetMultiResponse)
 		if !ok {
-			return nil, status.InternalError("response not of type *rfpb.FindMissingResponse")
+			return nil, status.InternalError("response not of type *rfpb.GetMultiResponse")
 		}
-		for _, frd := range fmr.GetData() {
-			dataMap[frd.GetFileRecord().GetDigest()] = frd.GetData()
+		for _, r := range fmr.GetResponses() {
+			dataMap[r.GetFileRecord().GetDigest()] = r.GetFileMetadata().GetStorageMetadata().GetInlineMetadata().GetData()
 		}
 	}
 

--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -374,7 +374,7 @@ func (rc *RaftCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompres
 	var rsp *rfpb.GetMultiResponse
 	err = rc.sender.Run(ctx, fileMetadataKey, func(c rfspb.ApiClient, h *rfpb.Header) error {
 		req := &rfpb.GetMultiRequest{
-			Header:     h,
+			Header:      h,
 			FileRecords: []*rfpb.FileRecord{fileRecord},
 		}
 		r, err := c.GetMulti(ctx, req)

--- a/enterprise/server/raft/rbuilder/rbuilder.go
+++ b/enterprise/server/raft/rbuilder/rbuilder.go
@@ -82,6 +82,18 @@ func (bb *BatchBuilder) Add(m proto.Message) *BatchBuilder {
 		req.Value = &rfpb.RequestUnion_FindMissing{
 			FindMissing: value,
 		}
+	case *rfpb.GetMultiRequest:
+		req.Value = &rfpb.RequestUnion_GetMulti{
+			GetMulti: value,
+		}
+	case *rfpb.SetMultiRequest:
+		req.Value = &rfpb.RequestUnion_SetMulti{
+			SetMulti: value,
+		}
+	case *rfpb.MetadataRequest:
+		req.Value = &rfpb.RequestUnion_Metadata{
+			Metadata: value,
+		}
 	default:
 		bb.setErr(status.FailedPreconditionErrorf("BatchBuilder.Add handling for %+v not implemented.", m))
 		return bb
@@ -241,4 +253,31 @@ func (br *BatchResponse) FindMissingResponse(n int) (*rfpb.FindMissingResponse, 
 	}
 	u := br.cmd.GetUnion()[n]
 	return u.GetFindMissing(), br.unionError(u)
+}
+
+func (br *BatchResponse) GetMultiResponse(n int) (*rfpb.GetMultiResponse, error) {
+	br.checkIndex(n)
+	if br.err != nil {
+		return nil, br.err
+	}
+	u := br.cmd.GetUnion()[n]
+	return u.GetGetMulti(), br.unionError(u)
+}
+
+func (br *BatchResponse) SetMultiResponse(n int) (*rfpb.SetMultiResponse, error) {
+	br.checkIndex(n)
+	if br.err != nil {
+		return nil, br.err
+	}
+	u := br.cmd.GetUnion()[n]
+	return u.GetSetMulti(), br.unionError(u)
+}
+
+func (br *BatchResponse) MetadataResponse(n int) (*rfpb.MetadataResponse, error) {
+	br.checkIndex(n)
+	if br.err != nil {
+		return nil, br.err
+	}
+	u := br.cmd.GetUnion()[n]
+	return u.GetMetadata(), br.unionError(u)
 }

--- a/enterprise/server/raft/replica/BUILD
+++ b/enterprise/server/raft/replica/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//enterprise/server/util/pebble",
         "//proto:raft_go_proto",
         "//proto:raft_service_go_proto",
-        "//server/interfaces",
         "//server/metrics",
         "//server/util/log",
         "//server/util/qps",
@@ -52,6 +51,7 @@ go_test(
         "//server/util/status",
         "@com_github_lni_dragonboat_v4//statemachine",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//proto",
     ],
 )

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -20,7 +20,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/pebble"
-	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/qps"
@@ -927,6 +926,83 @@ func (sm *Replica) findMissing(db ReplicaReader, req *rfpb.FindMissingRequest) (
 	return rsp, nil
 }
 
+func (sm *Replica) getMulti(db ReplicaReader, req *rfpb.GetMultiRequest) (*rfpb.GetMultiResponse, error) {
+	rsp := &rfpb.GetMultiResponse{
+		Responses: make([]*rfpb.GetMultiResponse_Response, len(req.GetFileRecords())),
+	}
+
+	iter := db.NewIter(nil /*default iterOptions*/)
+	defer iter.Close()
+
+	for i, fileRecord := range req.GetFileRecords() {
+		fr := fileRecord
+
+		fileMetadataKey, err := sm.fileMetadataKey(fileRecord)
+		if err != nil {
+			return nil, err
+		}
+
+		r := rsp.Responses[i]
+		r.FileRecord = fr
+
+		fileMetadata, err := lookupFileMetadata(iter, fileMetadataKey)
+		if err != nil {
+			r.Status = gstatus.Convert(err).Proto()
+		} else {
+			r.FileMetadata = fileMetadata
+			sm.sendAccessTimeUpdate(fileMetadata)
+		}
+	}
+
+	return rsp, nil
+}
+
+func (sm *Replica) setMulti(wb pebble.Batch, req *rfpb.SetMultiRequest) (*rfpb.SetMultiResponse, error) {
+	rsp := &rfpb.SetMultiResponse{
+		Responses: make([]*rfpb.SetMultiResponse_Response, len(req.GetFileMetadatas())),
+	}
+
+	for i, fileMetadata := range req.GetFileMetadatas() {
+		fm := fileMetadata
+
+		r := rsp.Responses[i]
+		r.FileRecord = fm.GetFileRecord()
+
+		fileMetadataKey, err := sm.fileMetadataKey(fm.GetFileRecord())
+		if err != nil {
+			return nil, err
+		}
+		buf, err := proto.Marshal(fm)
+		if err != nil {
+			return nil, err
+		}
+		if err := sm.rangeCheckedSet(wb, fileMetadataKey, buf); err != nil {
+			r.Status = gstatus.Convert(err).Proto()
+		}
+	}
+
+	return rsp, nil
+}
+
+func (sm *Replica) metadata(db ReplicaReader, req *rfpb.MetadataRequest) (*rfpb.MetadataResponse, error) {
+	fileMetadataKey, err := sm.fileMetadataKey(req.GetFileRecord())
+	if err != nil {
+		return nil, err
+	}
+
+	iter := db.NewIter(nil /*default iterOptions*/)
+	defer iter.Close()
+
+	fileMetadata, err := lookupFileMetadata(iter, fileMetadataKey)
+	if err != nil {
+		return nil, err
+	}
+	fileMetadata.StorageMetadata = nil // nil out because this is not a read call.
+	return &rfpb.MetadataResponse{
+		FileMetadata: fileMetadata,
+	}, nil
+}
+
 func statusProto(err error) *statuspb.Status {
 	s, _ := gstatus.FromError(err)
 	return s.Proto()
@@ -976,6 +1052,12 @@ func (sm *Replica) handlePropose(wb pebble.Batch, req *rfpb.RequestUnion, rsp *r
 			SimpleSplit: r,
 		}
 		rsp.Status = statusProto(err)
+	case *rfpb.RequestUnion_SetMulti:
+		r, err := sm.setMulti(wb, value.SetMulti)
+		rsp.Value = &rfpb.ResponseUnion_SetMulti{
+			SetMulti: r,
+		}
+		rsp.Status = statusProto(err)
 	default:
 		rsp.Status = statusProto(status.UnimplementedErrorf("SyncPropose handling for %+v not implemented.", req))
 	}
@@ -1001,6 +1083,18 @@ func (sm *Replica) handleRead(db ReplicaReader, req *rfpb.RequestUnion) *rfpb.Re
 		r, err := sm.findMissing(db, value.FindMissing)
 		rsp.Value = &rfpb.ResponseUnion_FindMissing{
 			FindMissing: r,
+		}
+		rsp.Status = statusProto(err)
+	case *rfpb.RequestUnion_GetMulti:
+		r, err := sm.getMulti(db, value.GetMulti)
+		rsp.Value = &rfpb.ResponseUnion_GetMulti{
+			GetMulti: r,
+		}
+		rsp.Status = statusProto(err)
+	case *rfpb.RequestUnion_Metadata:
+		r, err := sm.metadata(db, value.Metadata)
+		rsp.Value = &rfpb.ResponseUnion_Metadata{
+			Metadata: r,
 		}
 		rsp.Status = statusProto(err)
 	default:
@@ -1035,21 +1129,6 @@ func (sm *Replica) validateRange(header *rfpb.Header) error {
 		return status.OutOfRangeErrorf("%s: generation: %d requested: %d", constants.RangeNotCurrentMsg, sm.rangeDescriptor.GetGeneration(), header.GetGeneration())
 	}
 	return nil
-}
-
-func (sm *Replica) metadataForRecord(db pebble.Reader, fileRecord *rfpb.FileRecord) (*rfpb.FileMetadata, error) {
-	fileMetadataKey, err := sm.fileMetadataKey(fileRecord)
-	if err != nil {
-		return nil, err
-	}
-
-	iter := db.NewIter(nil /*default iterOptions*/)
-	fileMetadata, err := lookupFileMetadata(iter, fileMetadataKey)
-	iter.Close()
-	if err != nil {
-		return nil, err
-	}
-	return fileMetadata, nil
 }
 
 type accessTimeUpdate struct {
@@ -1197,88 +1276,6 @@ func (sm *Replica) Sample(ctx context.Context, partitionID string, n int) ([]*rf
 	}
 
 	return samples, nil
-}
-
-func (sm *Replica) Metadata(ctx context.Context, header *rfpb.Header, fileRecord *rfpb.FileRecord) (*rfpb.FileMetadata, error) {
-	db, err := sm.leaser.DB()
-	if err != nil {
-		return nil, err
-	}
-	defer db.Close()
-
-	if err := sm.validateRange(header); err != nil {
-		return nil, err
-	}
-
-	return sm.metadataForRecord(db, fileRecord)
-}
-
-func (sm *Replica) Reader(ctx context.Context, header *rfpb.Header, fileRecord *rfpb.FileRecord, offset, limit int64) (io.ReadCloser, error) {
-	db, err := sm.leaser.DB()
-	if err != nil {
-		return nil, err
-	}
-
-	if err := sm.validateRange(header); err != nil {
-		db.Close()
-		return nil, err
-	}
-
-	sm.readQPS.Inc()
-
-	fileMetadata, err := sm.metadataForRecord(db, fileRecord)
-	db.Close()
-
-	if err != nil {
-		return nil, err
-	}
-	rc, err := sm.fileStorer.NewReader(ctx, sm.fileDir, fileMetadata.GetStorageMetadata(), offset, limit)
-	if err != nil {
-		return nil, err
-	}
-	sm.sendAccessTimeUpdate(fileMetadata)
-	return rc, nil
-}
-
-func (sm *Replica) GetMulti(ctx context.Context, header *rfpb.Header, fileRecords []*rfpb.FileRecord) ([]*rfpb.GetMultiResponse_Data, error) {
-	reader, err := sm.leaser.DB()
-	if err != nil {
-		return nil, err
-	}
-	defer reader.Close()
-
-	if err := sm.validateRange(header); err != nil {
-		return nil, err
-	}
-
-	var rsp []*rfpb.GetMultiResponse_Data
-	var buf bytes.Buffer
-	for _, fileRecord := range fileRecords {
-		rc, err := sm.Reader(ctx, header, fileRecord, 0, 0)
-		if err != nil {
-			return nil, err
-		}
-		_, err = io.Copy(&buf, rc)
-		rc.Close()
-		if err != nil {
-			return nil, err
-		}
-
-		data := make([]byte, buf.Len())
-		copy(data, buf.Bytes())
-		rsp = append(rsp, &rfpb.GetMultiResponse_Data{FileRecord: fileRecord, Data: data})
-		buf.Reset()
-	}
-	return rsp, nil
-}
-
-func (sm *Replica) Writer(ctx context.Context, header *rfpb.Header, fileRecord *rfpb.FileRecord) (interfaces.MetadataWriteCloser, error) {
-	if err := sm.validateRange(header); err != nil {
-		return nil, err
-	}
-
-	writeCloserMetadata := sm.fileStorer.InlineWriter(ctx, fileRecord.GetDigest().GetSizeBytes())
-	return writeCloserMetadata, nil
 }
 
 // Update updates the IOnDiskStateMachine instance. The input Entry slice

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -279,7 +279,6 @@ func (sm *Replica) rangeCheckedSet(wb pebble.Batch, key, val []byte) error {
 	if !isLocalKey(key) {
 		if sm.mappedRange != nil && sm.mappedRange.Contains(key) {
 			sm.rangeMu.RUnlock()
-			sm.log.Infof("%q isFileRecordKey: %t", key, isFileRecordKey(key))
 			if isFileRecordKey(key) {
 				if err := sm.updateAndFlushPartitionMetadatas(wb, key, val, nil /*=fileMetadata*/, fileRecordAdd); err != nil {
 					return err

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -73,7 +73,7 @@ func newTestReplica(t *testing.T, rootDir string, shardID, replicaID uint64, sto
 		db.Close()
 	})
 
-	return replica.New(leaser, shardID, replicaID, store, partitions)
+	return replica.New(leaser, shardID, replicaID, store)
 }
 
 func TestOpenCloseReplica(t *testing.T) {

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -78,6 +78,7 @@ go_test(
         "@com_github_lni_dragonboat_v4//config",
         "@com_github_lni_dragonboat_v4//raftio",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//proto",
     ],
 )

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -640,7 +640,7 @@ func (s *Store) LeasedRange(header *rfpb.Header) (*replica.Replica, error) {
 }
 
 func (s *Store) ReplicaFactoryFn(shardID, replicaID uint64) dbsm.IOnDiskStateMachine {
-	r := replica.New(s.leaser, shardID, replicaID, s, s.partitions)
+	r := replica.New(s.leaser, shardID, replicaID, s)
 	return r
 }
 

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
-	"io"
 	"net"
 	"sort"
 	"sync"
@@ -842,6 +841,7 @@ func (s *Store) SyncRead(ctx context.Context, req *rfpb.SyncReadRequest) (*rfpb.
 	}, nil
 }
 
+// TODO(tylerw): consolidate these in a non-confusing way.
 func (s *Store) FindMissing(ctx context.Context, req *rfpb.FindMissingRequest) (*rfpb.FindMissingResponse, error) {
 	_, err := s.LeasedRange(req.GetHeader())
 	if err != nil {
@@ -864,63 +864,66 @@ func (s *Store) FindMissing(ctx context.Context, req *rfpb.FindMissingRequest) (
 }
 
 func (s *Store) GetMulti(ctx context.Context, req *rfpb.GetMultiRequest) (*rfpb.GetMultiResponse, error) {
-	r, err := s.LeasedRange(req.GetHeader())
+	_, err := s.LeasedRange(req.GetHeader())
 	if err != nil {
 		return nil, err
 	}
-	data, err := r.GetMulti(ctx, req.GetHeader(), req.GetFileRecord())
+	shardID := req.GetHeader().GetReplica().GetShardId()
+	batch, err := rbuilder.NewBatchBuilder().Add(req).ToProto()
 	if err != nil {
 		return nil, err
 	}
-	return &rfpb.GetMultiResponse{
-		Data: data,
-	}, nil
+	batch.Header = req.GetHeader()
+	rsp, err := client.SyncReadLocal(ctx, s.nodeHost, shardID, batch)
+	if err != nil {
+		if err == dragonboat.ErrShardNotFound {
+			return nil, status.OutOfRangeErrorf("%s: cluster %d not found", constants.RangeLeaseInvalidMsg, shardID)
+		}
+		return nil, err
+	}
+	return rbuilder.NewBatchResponseFromProto(rsp).GetMultiResponse(0)
 }
 
-type streamWriter struct {
-	stream rfspb.Api_ReadServer
-}
-
-func (w *streamWriter) Write(buf []byte) (int, error) {
-	err := w.stream.Send(&rfpb.ReadResponse{
-		Data: buf,
-	})
-	return len(buf), err
+func (s *Store) SetMulti(ctx context.Context, req *rfpb.SetMultiRequest) (*rfpb.SetMultiResponse, error) {
+	_, err := s.LeasedRange(req.GetHeader())
+	if err != nil {
+		return nil, err
+	}
+	shardID := req.GetHeader().GetReplica().GetShardId()
+	batch, err := rbuilder.NewBatchBuilder().Add(req).ToProto()
+	if err != nil {
+		return nil, err
+	}
+	batch.Header = req.GetHeader()
+	rsp, err := client.SyncReadLocal(ctx, s.nodeHost, shardID, batch)
+	if err != nil {
+		if err == dragonboat.ErrShardNotFound {
+			return nil, status.OutOfRangeErrorf("%s: cluster %d not found", constants.RangeLeaseInvalidMsg, shardID)
+		}
+		return nil, err
+	}
+	return rbuilder.NewBatchResponseFromProto(rsp).SetMultiResponse(0)
 }
 
 func (s *Store) Metadata(ctx context.Context, req *rfpb.MetadataRequest) (*rfpb.MetadataResponse, error) {
-	r, err := s.LeasedRange(req.GetHeader())
+	_, err := s.LeasedRange(req.GetHeader())
 	if err != nil {
 		return nil, err
 	}
-	md, err := r.Metadata(ctx, req.GetHeader(), req.GetFileRecord())
+	shardID := req.GetHeader().GetReplica().GetShardId()
+	batch, err := rbuilder.NewBatchBuilder().Add(req).ToProto()
 	if err != nil {
 		return nil, err
 	}
-
-	return &rfpb.MetadataResponse{Metadata: md}, nil
-}
-
-func (s *Store) Read(req *rfpb.ReadRequest, stream rfspb.Api_ReadServer) error {
-	r, err := s.LeasedRange(req.GetHeader())
+	batch.Header = req.GetHeader()
+	rsp, err := client.SyncReadLocal(ctx, s.nodeHost, shardID, batch)
 	if err != nil {
-		return err
+		if err == dragonboat.ErrShardNotFound {
+			return nil, status.OutOfRangeErrorf("%s: cluster %d not found", constants.RangeLeaseInvalidMsg, shardID)
+		}
+		return nil, err
 	}
-
-	readCloser, err := r.Reader(stream.Context(), req.GetHeader(), req.GetFileRecord(), req.GetOffset(), req.GetLimit())
-	if err != nil {
-		return err
-	}
-	defer readCloser.Close()
-
-	bufSize := int64(readBufSizeBytes)
-	d := req.GetFileRecord().GetDigest()
-	if d.GetSizeBytes() > 0 && d.GetSizeBytes() < bufSize {
-		bufSize = d.GetSizeBytes()
-	}
-	copyBuf := make([]byte, bufSize)
-	_, err = io.CopyBuffer(&streamWriter{stream}, readCloser, copyBuf)
-	return err
+	return rbuilder.NewBatchResponseFromProto(rsp).MetadataResponse(0)
 }
 
 func (s *Store) OnEvent(updateType serf.EventType, event serf.Event) {

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -590,7 +590,7 @@ func (s *Store) replicaForRange(rangeID uint64) (*replica.Replica, *rfpb.RangeDe
 // done by using the LeasedRange function.
 func (s *Store) validatedRange(header *rfpb.Header) (*replica.Replica, *rfpb.RangeDescriptor, error) {
 	if header == nil {
-		return nil, nil, status.FailedPreconditionError("Nil header not allowed")
+		return nil, nil, status.FailedPreconditionError("Header must be set (was nil)")
 	}
 
 	r, rd, err := s.replicaForRange(header.GetRangeId())

--- a/enterprise/server/raft/usagetracker/usagetracker.go
+++ b/enterprise/server/raft/usagetracker/usagetracker.go
@@ -224,7 +224,7 @@ func (pu *partitionUsage) refresh(ctx context.Context, key *ReplicaSample) (skip
 		}
 		return false, time.Time{}, err
 	}
-	atime := time.UnixMicro(rsp.GetMetadata().GetLastAccessUsec())
+	atime := time.UnixMicro(rsp.GetFileMetadata().GetLastAccessUsec())
 	return false, atime, nil
 }
 

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -231,6 +231,9 @@ message RequestUnion {
     DeleteRangeRequest delete_range = 14;
     SimpleSplitRequest simple_split = 15;
     FindMissingRequest find_missing = 16;
+    GetMultiRequest get_multi = 17;
+    SetMultiRequest set_multi = 18;
+    MetadataRequest metadata = 19;
   }
 }
 
@@ -253,6 +256,9 @@ message ResponseUnion {
     DeleteRangeResponse delete_range = 15;
     SimpleSplitResponse simple_split = 16;
     FindMissingResponse find_missing = 17;
+    GetMultiResponse get_multi = 18;
+    SetMultiResponse set_multi = 19;
+    MetadataResponse metadata = 20;
   }
 }
 
@@ -532,29 +538,7 @@ message MetadataRequest {
 }
 
 message MetadataResponse {
-  FileMetadata metadata = 1;
-}
-
-message ReadRequest {
-  Header header = 1;
-  FileRecord file_record = 2;
-  int64 offset = 3;
-  int64 limit = 4;
-}
-
-message ReadResponse {
-  bytes data = 1;
-}
-
-message WriteRequest {
-  Header header = 1;
-  FileRecord file_record = 2;
-  bool finish_write = 3;
-  bytes data = 4;
-}
-
-message WriteResponse {
-  int64 committed_size = 1;
+  FileMetadata file_metadata = 1;
 }
 
 message FindMissingRequest {
@@ -568,16 +552,41 @@ message FindMissingResponse {
 
 message GetMultiRequest {
   Header header = 1;
-  Isolation isolation = 2;
-  repeated FileRecord file_record = 3;
+  repeated FileRecord file_records = 2;
 }
 
 message GetMultiResponse {
-  message Data {
+  message Response {
+    // The FileRecord that was requested.
     FileRecord file_record = 1;
-    bytes data = 2;
+
+    // The FileMetadata that matches
+    FileMetadata file_metadata = 2;
+
+    // The result of attempting to upload that blob.
+    google.rpc.Status status = 3;
   }
-  repeated Data data = 1;
+
+  // The responses to the requests.
+  repeated Response responses = 1;
+}
+
+message SetMultiRequest {
+  Header header = 1;
+  repeated FileMetadata file_metadatas = 2;
+}
+
+message SetMultiResponse {
+  message Response {
+    // The blob digest to which this response corresponds.
+    FileRecord file_record = 1;
+
+    // The result of attempting to upload that blob.
+    google.rpc.Status status = 2;
+  }
+
+  // The responses to the requests.
+  repeated Response responses = 1;
 }
 
 message TransferLeadershipRequest {

--- a/proto/raft_service.proto
+++ b/proto/raft_service.proto
@@ -20,9 +20,9 @@ service Api {
   rpc TransferLeadership(TransferLeadershipRequest)
       returns (TransferLeadershipResponse);
 
-  // Data API.
+  // Metadata API.
   rpc Metadata(MetadataRequest) returns (MetadataResponse);
-  rpc Read(ReadRequest) returns (stream ReadResponse);
   rpc FindMissing(FindMissingRequest) returns (FindMissingResponse);
   rpc GetMulti(GetMultiRequest) returns (GetMultiResponse);
+  rpc SetMulti(SetMultiRequest) returns (SetMultiResponse);
 }


### PR DESCRIPTION
Make all reads and writes linearizable so we're not fighting the library. Basically just means rather than going around the raft locks when reading and writing stuff, we run the requests through the statemachine as raftgod intended.

There's a small performance impact for writes and seemingly none for reads. Will come back and fix that once other stuff is solid.
