### PR TITLE
protobuf: upgrade to 24.4

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -199,9 +199,9 @@ googletest_deps()
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "b29fc5fc13926f347b7a8b676ae1e63f7ccdb92c2fc8ca326bc3a883dcc168ac",
-    strip_prefix = "protobuf-23.0",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v23.0/protobuf-23.0.tar.gz"],
+    sha256 = "616bb3536ac1fff3fb1a141450fa28b875e985712170ea7f1bfe5e5fc41e2cd8",
+    strip_prefix = "protobuf-24.4",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protobuf-24.4.tar.gz"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")


### PR DESCRIPTION
Main highlights for v24
https://github.com/protocolbuffers/protobuf/releases/tag/v24.0

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
