### PR TITLE
Fix URL weirdness when entering impersonation.

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -224,10 +224,17 @@ export class AuthService {
   }
 
   // Enters impersonation for the given group, which may either be a group ID or a URL identifier.
-  async enterImpersonationMode(query: string) {
+  async enterImpersonationMode(query: string, { redirectUrl = ""}: { redirectUrl?: string} = {}) {
     const request = grp.GetGroupRequest.create(query.startsWith("GR") ? { groupId: query } : { urlIdentifier: query });
     const response = await rpc_service.service.getGroup(request);
     this.setCookie(IMPERSONATING_GROUP_ID_COOKIE, response.id, { maxAge: 0 });
+
+    // If we have an explicit redirect URL, navigate there directly.
+    if (redirectUrl) {
+      window.location.href = redirectUrl
+      return
+    }
+
     // If the new group is on a different subdomain then we have to use a redirect.
     if (capabilities.config.subdomainsEnabled && new URL(response.url).hostname != window.location.hostname) {
       window.location.href = response.url + window.location.pathname + window.location.search;

--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -224,15 +224,15 @@ export class AuthService {
   }
 
   // Enters impersonation for the given group, which may either be a group ID or a URL identifier.
-  async enterImpersonationMode(query: string, { redirectUrl = ""}: { redirectUrl?: string} = {}) {
+  async enterImpersonationMode(query: string, { redirectUrl = "" }: { redirectUrl?: string } = {}) {
     const request = grp.GetGroupRequest.create(query.startsWith("GR") ? { groupId: query } : { urlIdentifier: query });
     const response = await rpc_service.service.getGroup(request);
     this.setCookie(IMPERSONATING_GROUP_ID_COOKIE, response.id, { maxAge: 0 });
 
     // If we have an explicit redirect URL, navigate there directly.
     if (redirectUrl) {
-      window.location.href = redirectUrl
-      return
+      window.location.href = redirectUrl;
+      return;
     }
 
     // If the new group is on a different subdomain then we have to use a redirect.

--- a/enterprise/app/org/org_access_denied.tsx
+++ b/enterprise/app/org/org_access_denied.tsx
@@ -13,10 +13,7 @@ export default class OrgAccessDeniedComponent extends React.Component<Props> {
   handleImpersonateClicked() {
     const params = new URLSearchParams(window.location.search);
     const sourceUrl = params.get("source_url");
-    if (sourceUrl) {
-      router.navigateTo(sourceUrl);
-    }
-    authService.enterImpersonationMode(this.props.user.subdomainGroupID);
+    authService.enterImpersonationMode(this.props.user.subdomainGroupID, { redirectUrl: sourceUrl ?? undefined});
   }
 
   render() {

--- a/enterprise/app/org/org_access_denied.tsx
+++ b/enterprise/app/org/org_access_denied.tsx
@@ -13,7 +13,7 @@ export default class OrgAccessDeniedComponent extends React.Component<Props> {
   handleImpersonateClicked() {
     const params = new URLSearchParams(window.location.search);
     const sourceUrl = params.get("source_url");
-    authService.enterImpersonationMode(this.props.user.subdomainGroupID, { redirectUrl: sourceUrl ?? undefined});
+    authService.enterImpersonationMode(this.props.user.subdomainGroupID, { redirectUrl: sourceUrl ?? undefined });
   }
 
   render() {


### PR DESCRIPTION
The navigateTo call was going through the access check which tried to manipulate the URL prior to impersonation. Instead, redirect directly to the target URL.

Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/2780

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
