### PR TITLE
Refactor task_router and add a new routing property that routes actions to executors that most recently executed similar actions (based on the first bazel output)

### DIFF
--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -64,7 +64,7 @@ const (
 	unsetContainerImageVal = "none"
 
 	RecycleRunnerPropertyName            = "recycle-runner"
-	OutputAffinityRoutingPropertyName    = "output-affinity-routing"
+	AffinityRoutingPropertyName          = "affinity-routing"
 	preserveWorkspacePropertyName        = "preserve-workspace"
 	nonrootWorkspacePropertyName         = "nonroot-workspace"
 	cleanWorkspaceInputsPropertyName     = "clean-workspace-inputs"
@@ -138,7 +138,7 @@ type Properties struct {
 	DockerUser                string
 	DockerNetwork             string
 	RecycleRunner             bool
-	OutputAffinityRouting     bool
+	AffinityRouting           bool
 	EnableVFS                 bool
 	IncludeSecrets            bool
 
@@ -254,7 +254,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		DockerUser:                stringProp(m, DockerUserPropertyName, ""),
 		DockerNetwork:             stringProp(m, dockerNetworkPropertyName, ""),
 		RecycleRunner:             boolProp(m, RecycleRunnerPropertyName, false),
-		OutputAffinityRouting:     boolProp(m, OutputAffinityRoutingPropertyName, false),
+		AffinityRouting:           boolProp(m, AffinityRoutingPropertyName, false),
 		EnableVFS:                 vfsEnabled,
 		IncludeSecrets:            boolProp(m, IncludeSecretsPropertyName, false),
 		PreserveWorkspace:         boolProp(m, preserveWorkspacePropertyName, false),

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -64,6 +64,7 @@ const (
 	unsetContainerImageVal = "none"
 
 	RecycleRunnerPropertyName            = "recycle-runner"
+	OutputAffinityRoutingPropertyName    = "output-affinity-routing"
 	preserveWorkspacePropertyName        = "preserve-workspace"
 	nonrootWorkspacePropertyName         = "nonroot-workspace"
 	cleanWorkspaceInputsPropertyName     = "clean-workspace-inputs"
@@ -137,6 +138,7 @@ type Properties struct {
 	DockerUser                string
 	DockerNetwork             string
 	RecycleRunner             bool
+	OutputAffinityRouting     bool
 	EnableVFS                 bool
 	IncludeSecrets            bool
 
@@ -252,6 +254,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		DockerUser:                stringProp(m, DockerUserPropertyName, ""),
 		DockerNetwork:             stringProp(m, dockerNetworkPropertyName, ""),
 		RecycleRunner:             boolProp(m, RecycleRunnerPropertyName, false),
+		OutputAffinityRouting:     boolProp(m, OutputAffinityRoutingPropertyName, false),
 		EnableVFS:                 vfsEnabled,
 		IncludeSecrets:            boolProp(m, IncludeSecretsPropertyName, false),
 		PreserveWorkspace:         boolProp(m, preserveWorkspacePropertyName, false),

--- a/enterprise/server/scheduling/task_router/BUILD
+++ b/enterprise/server/scheduling/task_router/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//proto:remote_execution_go_proto",
         "//server/environment",
         "//server/interfaces",
+        "//server/util/hash",
         "//server/util/log",
         "//server/util/perms",
         "//server/util/status",

--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -2,6 +2,7 @@ package task_router
 
 import (
 	"context"
+	"flag"
 	"math/rand"
 	"strings"
 	"time"
@@ -17,6 +18,10 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+var (
+	affinityRoutingPermitted = flag.Bool("executor.affinity_routing_permitted", true, "If set, along with the 'affinity-routing' platform property, then (experimental) affinity routing is used. If false, then affinity routing is never used. This flag is intended to be used as an emergency shut-off for this experimental feature.")
 )
 
 const (
@@ -271,7 +276,8 @@ func (s runnerRecycler) RoutingInfo(params routingParams) (int, string, error) {
 type affinityRouter struct{}
 
 func (affinityRouter) Applies(params routingParams) bool {
-	return platform.IsTrue(platform.FindValue(params.cmd.GetPlatform(), platform.AffinityRoutingPropertyName)) &&
+	return *affinityRoutingPermitted &&
+		platform.IsTrue(platform.FindValue(params.cmd.GetPlatform(), platform.AffinityRoutingPropertyName)) &&
 		getFirstOutput(params.cmd) != ""
 }
 

--- a/enterprise/server/test/integration/task_router/BUILD
+++ b/enterprise/server/test/integration/task_router/BUILD
@@ -14,6 +14,7 @@ go_test(
         "//server/environment",
         "//server/interfaces",
         "//server/testutil/testauth",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/test/integration/task_router/task_router_test.go
+++ b/enterprise/server/test/integration/task_router/task_router_test.go
@@ -115,14 +115,14 @@ func TestTaskRouter_RankNodes_DefaultNodeLimit_ReturnsOnlyLatestNodeMarkedComple
 	requireNonSequential(t, ranked[1:])
 }
 
-func TestTaskRouter_RankNodes_OutputAffinityRouting(t *testing.T) {
+func TestTaskRouter_RankNodes_AffinityRouting(t *testing.T) {
 	env := newTestEnv(t)
 	router := newTaskRouter(t, env)
 	ctx := withAuthUser(t, context.Background(), env, "US1")
 	cmd := &repb.Command{
 		Platform: &repb.Platform{
 			Properties: []*repb.Platform_Property{
-				{Name: "output-affinity-routing", Value: "true"},
+				{Name: "affinity-routing", Value: "true"},
 			},
 		},
 		OutputPaths: []string{"/bazel-out/foo.a"},
@@ -158,14 +158,14 @@ func TestTaskRouter_RankNodes_OutputAffinityRouting(t *testing.T) {
 	requireNotAlwaysRanked(0, executorID2, t, router, ctx, cmd, instanceName)
 }
 
-func TestTaskRouter_RankNodes_OutputAffinityRoutingNoOutputs(t *testing.T) {
+func TestTaskRouter_RankNodes_AffinityRoutingNoOutputs(t *testing.T) {
 	env := newTestEnv(t)
 	router := newTaskRouter(t, env)
 	ctx := withAuthUser(t, context.Background(), env, "US1")
 	cmd := &repb.Command{
 		Platform: &repb.Platform{
 			Properties: []*repb.Platform_Property{
-				{Name: "output-affinity-routing", Value: "true"},
+				{Name: "affinity-routing", Value: "true"},
 			},
 		},
 	}
@@ -190,7 +190,7 @@ func TestTaskRouter_RankNodes_RunnerRecyclingTakesPrecedence(t *testing.T) {
 		Platform: &repb.Platform{
 			Properties: []*repb.Platform_Property{
 				{Name: "recycle-runner", Value: "true"},
-				{Name: "output-affinity-routing", Value: "true"},
+				{Name: "affinity-routing", Value: "true"},
 			},
 		},
 		OutputPaths: []string{"/bazel-out/foo.a"},
@@ -203,7 +203,7 @@ func TestTaskRouter_RankNodes_RunnerRecyclingTakesPrecedence(t *testing.T) {
 		Platform: &repb.Platform{
 			Properties: []*repb.Platform_Property{
 				{Name: "recycle-runner", Value: "true"},
-				{Name: "output-affinity-routing", Value: "true"},
+				{Name: "affinity-routing", Value: "true"},
 			},
 		},
 	}

--- a/server/util/hash/hash.go
+++ b/server/util/hash/hash.go
@@ -7,8 +7,12 @@ import (
 	"unsafe"
 )
 
+func Bytes(input []byte) string {
+	return fmt.Sprintf("%x", sha256.Sum256(input))
+}
+
 func String(input string) string {
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(input)))
+	return Bytes([]byte(input))
 }
 
 //go:noescape

--- a/server/util/hash/hash_test.go
+++ b/server/util/hash/hash_test.go
@@ -7,6 +7,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestHashBytes(t *testing.T) {
+	emptyHash := hash.Bytes([]byte(""))
+	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", emptyHash)
+
+	fooHash := hash.Bytes([]byte("foo"))
+	assert.Equal(t, "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae", fooHash)
+}
+
 func TestHashString(t *testing.T) {
 	emptyHash := hash.String("")
 	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", emptyHash)


### PR DESCRIPTION
**Related issues**: [222](https://github.com/buildbuddy-io/buildbuddy-internal/issues/222)
