### PR TITLE
Make impersonation play nice with subdomains.

### DIFF
--- a/app/auth/auth_service.ts
+++ b/app/auth/auth_service.ts
@@ -133,9 +133,6 @@ export class AuthService {
   }
 
   private getUser(request: user.GetUserRequest) {
-    if (rpcService.requestContext.impersonatingGroupId) {
-      return rpcService.service.getImpersonatedUser(request);
-    }
     return rpcService.service.getUser(request);
   }
 
@@ -178,7 +175,7 @@ export class AuthService {
           (name) => (name[0].toLowerCase() + name.substring(1)) as BuildBuddyServiceRpcName
         )
       ),
-      isImpersonating: Boolean(rpcService.requestContext.impersonatingGroupId),
+      isImpersonating: response.isImpersonating,
       subdomainGroupID: response.subdomainGroupId,
     });
   }

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -774,6 +774,9 @@ func (d *UserDB) GetUser(ctx context.Context) (*tables.User, error) {
 	if err != nil {
 		return nil, err
 	}
+	if u.IsImpersonating() {
+		return d.GetImpersonatedUser(ctx)
+	}
 	var user *tables.User
 	err = d.h.Transaction(ctx, func(tx *db.DB) error {
 		user, err = d.getUser(tx, u.GetUserID())

--- a/proto/buildbuddy_service.proto
+++ b/proto/buildbuddy_service.proto
@@ -64,7 +64,6 @@ service BuildBuddyService {
   // User API
   rpc CreateUser(user.CreateUserRequest) returns (user.CreateUserResponse);
   rpc GetUser(user.GetUserRequest) returns (user.GetUserResponse);
-  rpc GetImpersonatedUser(user.GetUserRequest) returns (user.GetUserResponse);
 
   // Groups API
   rpc GetGroup(grp.GetGroupRequest) returns (grp.GetGroupResponse);

--- a/proto/user.proto
+++ b/proto/user.proto
@@ -58,6 +58,9 @@ message GetUserResponse {
   // group ID that owns the subdomain, but only if the user is allowed to
   // impersonate.
   string subdomain_group_id = 8;
+
+  // True if the user is using impersonation to access a group.
+  bool is_impersonating = 10;
 }
 
 message CreateUserRequest {

--- a/server/role_filter/role_filter.go
+++ b/server/role_filter/role_filter.go
@@ -24,7 +24,6 @@ var (
 	roleIndependentRPCs = []string{
 		// RPCs that happen pre-login and don't require group membership.
 		"GetUser",
-		"GetImpersonatedUser",
 		"CreateUser",
 		"GetGroup",
 		// Invocations can be shared publicly, so authorization for these RPCs is

--- a/server/util/claims/BUILD
+++ b/server/util/claims/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//server/util/request_context",
         "//server/util/role",
         "//server/util/status",
+        "//server/util/subdomain",
         "@com_github_golang_jwt_jwt//:jwt",
     ],
 )


### PR DESCRIPTION
If the user is impersonating group X, but tries to access subdomain for group Y then don't enable impersonation on requests for subdomain Y so that subdomain Y can be accessed normally.

This PR slightly changes the semantics of how the frontend communicates impersonation information to the backend. Prior to this change, the frontend would set an impersonation target and would assume that impersonation was in effect. Now, the frontend still sets the impersonation target but now the backend informs the frontend whether impersonation is actually in effect via the GetUser response.

Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/2779

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
