### PR TITLE
deprecate app.user_management_enabled flag

### DIFF
--- a/app/capabilities/capabilities.tsx
+++ b/app/capabilities/capabilities.tsx
@@ -30,7 +30,6 @@ export class Capabilities {
   code: boolean = false;
   sso: boolean = false;
   usage: boolean = false;
-  userManagement: boolean = false;
 
   constructor() {
     this.invocationSharing = true;
@@ -54,7 +53,6 @@ export class Capabilities {
     this.executorKeyCreation = this.config.executorKeyCreationEnabled;
     this.code = this.config.codeEditorEnabled;
     this.usage = this.config.usageEnabled;
-    this.userManagement = this.config.userManagementEnabled;
   }
 
   register(name: string, enterprise: boolean, paths: Array<string>) {

--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -237,7 +237,7 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
                       {capabilities.createOrg && <EditOrgComponent user={this.props.user} />}
                     </>
                   )}
-                  {activeTabId === TabId.OrgMembers && capabilities.userManagement && (
+                  {activeTabId === TabId.OrgMembers && (
                     <>
                       <div className="settings-option-title">Members of {this.props.user.selectedGroupName()}</div>
                       <OrgMembersComponent user={this.props.user} />

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -48,7 +48,7 @@ message FrontendConfig {
   // Whether or not the usage page is enabled.
   bool usage_enabled = 15;
 
-  reserved 16; // DEPRECATED user_management_enabled
+  reserved 16;  // DEPRECATED user_management_enabled
 
   // Whether Darwin (macOS) executors must be self-hosted.
   bool force_user_owned_darwin_executors = 17;

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -48,9 +48,7 @@ message FrontendConfig {
   // Whether or not the usage page is enabled.
   bool usage_enabled = 15;
 
-  // Whether or not user management is enabled.
-  // DEPRECATED: This is now always true.
-  bool user_management_enabled = 16 [deprecated = true];
+  reserved 16; // DEPRECATED user_management_enabled
 
   // Whether Darwin (macOS) executors must be self-hosted.
   bool force_user_owned_darwin_executors = 17;

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -49,7 +49,8 @@ message FrontendConfig {
   bool usage_enabled = 15;
 
   // Whether or not user management is enabled.
-  bool user_management_enabled = 16;
+  // DEPRECATED: This is now always true.
+  bool user_management_enabled = 16 [deprecated = true];
 
   // Whether Darwin (macOS) executors must be self-hosted.
   bool force_user_owned_darwin_executors = 17;

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -37,7 +37,7 @@ const (
 var (
 	defaultToDenseMode                     = flag.Bool("app.default_to_dense_mode", false, "Enables the dense UI mode by default.")
 	codeEditorEnabled                      = flag.Bool("app.code_editor_enabled", false, "If set, code editor functionality will be enabled.")
-	userManagementEnabled                  = flag.Bool("app.user_management_enabled", true, "If set, the user management page will be enabled in the UI.")
+	userManagementEnabled                  = flag.Bool("app.user_management_enabled", true, "If set, the user management page will be enabled in the UI.", flag.Deprecated("This flag has no effect and will be removed in the future."))
 	testGridV2Enabled                      = flag.Bool("app.test_grid_v2_enabled", true, "Whether to enable test grid V2")
 	usageEnabled                           = flag.Bool("app.usage_enabled", false, "If set, the usage page will be enabled in the UI.")
 	expandedSuggestionsEnabled             = flag.Bool("app.expanded_suggestions_enabled", false, "If set, enable more build suggestions in the UI.")

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -164,7 +164,6 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		SsoEnabled:                             env.GetAuthenticator().SSOEnabled(),
 		GlobalFilterEnabled:                    true,
 		UsageEnabled:                           *usageEnabled,
-		UserManagementEnabled:                  *userManagementEnabled,
 		ForceUserOwnedDarwinExecutors:          remote_execution_config.RemoteExecutionEnabled() && scheduler_server_config.ForceUserOwnedDarwinExecutors(),
 		TestGridV2Enabled:                      *testGridV2Enabled,
 		DetailedCacheStatsEnabled:              hit_tracker.DetailedStatsEnabled(),


### PR DESCRIPTION
This has been set to true by default for a while now.
Let's clean it up.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
