### PR TITLE
gossip: fix flaky and race test

### DIFF
--- a/server/gossip/gossip_test.go
+++ b/server/gossip/gossip_test.go
@@ -177,8 +177,10 @@ func TestUserQuery(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(3 * time.Second):
+	case <-time.After(5 * time.Second):
+		mu.Lock()
 		t.Fatalf("Timed out waiting for tags to be received: %+v", receivedLetters)
+		mu.Unlock()
 	case <-seenItAll:
 		break
 	}
@@ -239,8 +241,10 @@ func TestUserEvents(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(3 * time.Second):
+	case <-time.After(5 * time.Second):
+		mu.Lock()
 		t.Fatalf("Timed out waiting for tags to be received: %+v", gotData)
+		mu.Unlock()
 	case <-seenItAll:
 		break
 	}


### PR DESCRIPTION
It seems like the timeout on these tests could be a bit low when they
are scheduled on resource limitted Executors.

Upon crash, the test will also trigger race detection of accessing the
variable during `t.Fatalf()` while writing to it in an unfinished
goroutine. Avoid the race detection by acquiring the mutex prior to
`t.Fatalf()`.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
