### PR TITLE
Move identity service check inside interceptor function.

### DIFF
--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -435,12 +435,10 @@ func setHeadersStreamClientInterceptor() grpc.StreamClientInterceptor {
 }
 
 func getClientIdentityAdder(env environment.Env) func(ctx context.Context) context.Context {
-	if env == nil || env.GetClientIdentityService() == nil {
-		return func(ctx context.Context) context.Context {
+	return func(ctx context.Context) context.Context {
+		if env.GetClientIdentityService() == nil {
 			return ctx
 		}
-	}
-	return func(ctx context.Context) context.Context {
 		ctx, err := env.GetClientIdentityService().AddIdentityToContext(ctx)
 		if err != nil {
 			alert.UnexpectedEvent("could_not_add_server_identity", err.Error())


### PR DESCRIPTION
The remote execution client was registered before the identity service which meant the header was never added for execution requests. This change makes the registration order irrelevant.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
