### PR TITLE
Publish replica usage updates via channel

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -468,6 +468,9 @@ func (sm *Replica) loadPartitionMetadata(db ReplicaReader) error {
 	if err != nil {
 		return err
 	}
+	sm.partitionMetadataMu.Lock()
+	defer sm.partitionMetadataMu.Unlock()
+
 	for _, pm := range pms.GetMetadata() {
 		sm.partitionMetadata[pm.GetPartitionId()] = pm
 	}

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -113,9 +113,9 @@ type Replica struct {
 
 	fileStorer filestore.Store
 
-	quitChan chan struct{}
-	accesses chan *accessTimeUpdate
-	usageUpdates chan<-*rfpb.ReplicaUsage
+	quitChan     chan struct{}
+	accesses     chan *accessTimeUpdate
+	usageUpdates chan<- *rfpb.ReplicaUsage
 
 	readQPS        *qps.Counter
 	raftProposeQPS *qps.Counter
@@ -248,7 +248,7 @@ func (sm *Replica) notifyListenersOfUsage(usage *rfpb.ReplicaUsage) {
 		return
 	}
 	select {
-	case sm.usageUpdates<-usage:
+	case sm.usageUpdates <- usage:
 		break
 	default:
 		sm.log.Warningf("dropped usage update")
@@ -1773,7 +1773,7 @@ func (sm *Replica) Close() error {
 }
 
 // CreateReplica creates an ondisk statemachine.
-func New(leaser pebble.Leaser, shardID, replicaID uint64, store IStore, usageUpdates chan<-*rfpb.ReplicaUsage) *Replica {
+func New(leaser pebble.Leaser, shardID, replicaID uint64, store IStore, usageUpdates chan<- *rfpb.ReplicaUsage) *Replica {
 	return &Replica{
 		ShardID:             shardID,
 		ReplicaID:           replicaID,

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -62,7 +62,6 @@ var (
 type IStore interface {
 	AddRange(rd *rfpb.RangeDescriptor, r *Replica)
 	RemoveRange(rd *rfpb.RangeDescriptor, r *Replica)
-	NotifyUsage(ru *rfpb.ReplicaUsage, rd *rfpb.RangeDescriptor)
 	Sender() *sender.Sender
 	AddPeer(ctx context.Context, sourceShardID, newShardID uint64) error
 	SnapshotCluster(ctx context.Context, shardID uint64) error
@@ -116,6 +115,7 @@ type Replica struct {
 
 	quitChan chan struct{}
 	accesses chan *accessTimeUpdate
+	usageUpdates chan<-*rfpb.ReplicaUsage
 
 	readQPS        *qps.Counter
 	raftProposeQPS *qps.Counter
@@ -243,6 +243,18 @@ func rdString(rd *rfpb.RangeDescriptor) string {
 	return fmt.Sprintf("Range(%d) [%q, %q) gen %d", rd.GetRangeId(), rd.GetStart(), rd.GetEnd(), rd.GetGeneration())
 }
 
+func (sm *Replica) notifyListenersOfUsage(usage *rfpb.ReplicaUsage) {
+	if sm.usageUpdates == nil {
+		return
+	}
+	select {
+	case sm.usageUpdates<-usage:
+		break
+	default:
+		sm.log.Warningf("dropped usage update")
+	}
+}
+
 func (sm *Replica) setRange(key, val []byte) error {
 	if !bytes.HasPrefix(key, constants.LocalRangeKey) {
 		return status.FailedPreconditionErrorf("setRange called with non-range key: %s", key)
@@ -269,7 +281,7 @@ func (sm *Replica) setRange(key, val []byte) error {
 	sm.store.AddRange(sm.rangeDescriptor, sm)
 
 	if usage, err := sm.Usage(); err == nil {
-		sm.store.NotifyUsage(usage, sm.rangeDescriptor)
+		sm.notifyListenersOfUsage(usage)
 	}
 	return nil
 }
@@ -1401,10 +1413,7 @@ func (sm *Replica) Update(entries []dbsm.Entry) ([]dbsm.Entry, error) {
 		if err != nil {
 			sm.log.Warningf("Error computing usage: %s", err)
 		} else {
-			sm.rangeMu.RLock()
-			rd := sm.rangeDescriptor
-			sm.rangeMu.RUnlock()
-			sm.store.NotifyUsage(usage, rd)
+			sm.notifyListenersOfUsage(usage)
 		}
 		sm.lastUsageCheckIndex = sm.lastAppliedIndex
 	}
@@ -1764,7 +1773,7 @@ func (sm *Replica) Close() error {
 }
 
 // CreateReplica creates an ondisk statemachine.
-func New(leaser pebble.Leaser, shardID, replicaID uint64, store IStore) *Replica {
+func New(leaser pebble.Leaser, shardID, replicaID uint64, store IStore, usageUpdates chan<-*rfpb.ReplicaUsage) *Replica {
 	return &Replica{
 		ShardID:             shardID,
 		ReplicaID:           replicaID,

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -73,7 +73,7 @@ func newTestReplica(t *testing.T, rootDir string, shardID, replicaID uint64, sto
 		db.Close()
 	})
 
-	return replica.New(leaser, shardID, replicaID, store /*usageUpdates=*/, nil)
+	return replica.New(leaser, shardID, replicaID, store, nil /*=usageUpdates=*/)
 }
 
 func TestOpenCloseReplica(t *testing.T) {

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -52,7 +52,6 @@ func (fs *fakeStore) RemoveRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 func (fs *fakeStore) Sender() *sender.Sender {
 	return nil
 }
-func (fs *fakeStore) NotifyUsage(ru *rfpb.ReplicaUsage, rd *rfpb.RangeDescriptor) {}
 func (fs *fakeStore) AddPeer(ctx context.Context, sourceShardID, newShardID uint64) error {
 	return nil
 }
@@ -74,7 +73,7 @@ func newTestReplica(t *testing.T, rootDir string, shardID, replicaID uint64, sto
 		db.Close()
 	})
 
-	return replica.New(leaser, shardID, replicaID, store)
+	return replica.New(leaser, shardID, replicaID, store, /*usageUpdates=*/nil)
 }
 
 func TestOpenCloseReplica(t *testing.T) {

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -73,7 +73,7 @@ func newTestReplica(t *testing.T, rootDir string, shardID, replicaID uint64, sto
 		db.Close()
 	})
 
-	return replica.New(leaser, shardID, replicaID, store, /*usageUpdates=*/nil)
+	return replica.New(leaser, shardID, replicaID, store /*usageUpdates=*/, nil)
 }
 
 func TestOpenCloseReplica(t *testing.T) {

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -79,8 +79,8 @@ type Store struct {
 	rangeMu    sync.RWMutex
 	openRanges map[uint64]*rfpb.RangeDescriptor
 
-	leases              sync.Map // map of uint64 rangeID -> *rangelease.Lease
-	replicas            sync.Map // map of uint64 rangeID -> *replica.Replica
+	leases   sync.Map // map of uint64 rangeID -> *rangelease.Lease
+	replicas sync.Map // map of uint64 rangeID -> *replica.Replica
 
 	usageUpdates        chan *rfpb.ReplicaUsage
 	usages              *usagetracker.Tracker
@@ -254,7 +254,7 @@ func (s *Store) handleUsageUpdates(ctx context.Context, usageUpdatesChan <-chan 
 				log.Warningf("Usage update for unknown range: %d", usage.GetRangeId())
 			}
 		case <-ctx.Done():
-	                return nil
+			return nil
 		}
 	}
 }

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -81,6 +81,8 @@ type Store struct {
 
 	leases              sync.Map // map of uint64 rangeID -> *rangelease.Lease
 	replicas            sync.Map // map of uint64 rangeID -> *replica.Replica
+
+	usageUpdates        chan *rfpb.ReplicaUsage
 	usages              *usagetracker.Tracker
 	rangeUsageListeners []RangeUsageListener
 
@@ -115,6 +117,7 @@ func New(rootDir string, nodeHost *dragonboat.NodeHost, gossipManager *gossip.Go
 		leases:   sync.Map{},
 		replicas: sync.Map{},
 
+		usageUpdates:  make(chan *rfpb.ReplicaUsage, 100),
 		metaRangeMu:   sync.Mutex{},
 		metaRangeData: make([]byte, 0),
 		fileStorer:    filestore.New(),
@@ -241,6 +244,21 @@ func (s *Store) Statusz(ctx context.Context) string {
 	return buf
 }
 
+func (s *Store) handleUsageUpdates(ctx context.Context, usageUpdatesChan <-chan *rfpb.ReplicaUsage) error {
+	for {
+		select {
+		case usage := <-usageUpdatesChan:
+			if rd := s.lookupRange(usage.GetRangeId()); rd != nil {
+				s.NotifyUsage(usage, rd)
+			} else {
+				log.Warningf("Usage update for unknown range: %d", usage.GetRangeId())
+			}
+		case <-ctx.Done():
+	                return nil
+		}
+	}
+}
+
 func (s *Store) handleLeaderUpdates(ctx context.Context, leaderUpdatesChan <-chan raftio.LeaderInfo) error {
 	for {
 		select {
@@ -303,6 +321,10 @@ func (s *Store) Start() error {
 	eg, gctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		return s.handleLeaderUpdates(gctx, leaderUpdatesChan)
+	})
+
+	eg.Go(func() error {
+		return s.handleUsageUpdates(gctx, s.usageUpdates)
 	})
 
 	return nil
@@ -644,7 +666,7 @@ func (s *Store) LeasedRange(header *rfpb.Header) (*replica.Replica, error) {
 }
 
 func (s *Store) ReplicaFactoryFn(shardID, replicaID uint64) dbsm.IOnDiskStateMachine {
-	r := replica.New(s.leaser, shardID, replicaID, s)
+	r := replica.New(s.leaser, shardID, replicaID, s, s.usageUpdates)
 	return r
 }
 

--- a/server/gossip/gossip.go
+++ b/server/gossip/gossip.go
@@ -106,10 +106,14 @@ func (gm *GossipManager) getTags() map[string]string {
 }
 
 func (gm *GossipManager) SendUserEvent(name string, payload []byte, coalesce bool) error {
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
 	return gm.serfInstance.UserEvent(name, payload, coalesce)
 }
 
 func (gm *GossipManager) Query(name string, payload []byte, params *serf.QueryParam) (*serf.QueryResponse, error) {
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
 	return gm.serfInstance.Query(name, payload, params)
 }
 


### PR DESCRIPTION
This avoids there being any read/write slowdown when callbacks are run.

Previously a series of callbacks would be called which eventually triggered a gossip notification push -- this stuff was all blocking and would slow down every 1000th write request or something. Fix it.
