### PR TITLE
Remove todo that's not even true.

### DIFF
--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -475,7 +475,6 @@ func ApplyOverrides(env environment.Env, executorProps *ExecutorProperties, plat
 			Value: usageutil.ClientOrigin(),
 		})
 
-		// TODO(vadim): find a way to limit this to shared executors
 		if cis := env.GetClientIdentityService(); cis != nil {
 			h, err := cis.IdentityHeader(&interfaces.ClientIdentity{
 				Origin: interfaces.ClientIdentityInternalOrigin,


### PR DESCRIPTION
The platform override happens on the executor which means it can only be set within shared executors.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
