### PR TITLE
Allow duplicate client identity headers.

### DIFF
--- a/enterprise/server/clientidentity/BUILD
+++ b/enterprise/server/clientidentity/BUILD
@@ -24,6 +24,7 @@ go_test(
         ":clientidentity",
         "//server/interfaces",
         "//server/util/random",
+        "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_golang_jwt_jwt//:jwt",
         "@com_github_jonboulle_clockwork//:clockwork",

--- a/enterprise/server/clientidentity/clientidentity.go
+++ b/enterprise/server/clientidentity/clientidentity.go
@@ -95,7 +95,12 @@ func (s *Service) ValidateIncomingIdentity(ctx context.Context) (context.Context
 		return ctx, nil
 	}
 	if len(vals) > 1 {
-		return ctx, status.NotFoundError("multiple identity headers present")
+		// When --experimental_remote_downloader is enabled in Bazel, it seems
+		// to send the header twice. To workaround this, we accept the header
+		// as long as it has the same value.
+		if len(vals) != 2 || vals[0] != vals[1] {
+			return ctx, status.PermissionDeniedError("multiple identity headers present")
+		}
 	}
 	headerValue := vals[0]
 	c := &claims{}


### PR DESCRIPTION
Bazel appears to send the header twice when --experimental_remote_downloader is enabled. We'll continue to treat other cases of multiple headers as an error as that would indicate a real problem.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
