### PR TITLE
Add more versioning fields to snapshot key

### DIFF
--- a/proto/firecracker.proto
+++ b/proto/firecracker.proto
@@ -19,6 +19,9 @@ message VMConfiguration {
   bool init_dockerd = 5;
   bool debug_mode = 6;
   bool enable_dockerd_tcp = 7;
+  string kernel_version = 8;
+  string firecracker_version = 9;
+  string goinit_version = 10;
 
   // TODO: add container_image here?
 }


### PR DESCRIPTION
Adds the following fields to the VMConfiguration proto (which affects the snapshot key):

* **kernel_version**: if we upgrade the kernel to fix bugs / pull in security improvements etc. we want old snapshots to be invalidated. For now, this can be a SHA256 of the vmlinux binary.
* **firecracker_version**: make sure we don't have to worry about snapshot backwards/forwards compatibility - we'll only ever support loading snapshots that were created by the locally available firecracker version.
* **goinit_version**: if we make changes to goinit, we want those to be reflected immediately rather than having to wait indefinitely for the snapshots to pick up the new binary version. For now, we can manually maintain a version number, since the SHA256 is very likely to change with each executor release.

**Related issues**: N/A
