### PR TITLE
vbd: fix fsync "operation not supported" error

### DIFF
--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -143,6 +143,7 @@ type fileHandle struct {
 
 var _ fusefs.FileReader = (*fileHandle)(nil)
 var _ fusefs.FileWriter = (*fileHandle)(nil)
+var _ fusefs.FileFsyncer = (*fileHandle)(nil)
 
 func (h *fileHandle) Read(ctx context.Context, p []byte, off int64) (res fuse.ReadResult, errno syscall.Errno) {
 	return &reader{h.file, off, len(p)}, 0
@@ -155,6 +156,11 @@ func (h *fileHandle) Write(ctx context.Context, p []byte, off int64) (uint32, sy
 		return uint32(n), syscall.EIO
 	}
 	return uint32(n), 0
+}
+
+func (h *fileHandle) Fsync(ctx context.Context, flags uint32) syscall.Errno {
+	// Do nothing for now; snaploader will sync contents to disk before adding to cache.
+	return fusefs.OK
 }
 
 type reader struct {

--- a/enterprise/server/remote_execution/vbd/vbd_test.go
+++ b/enterprise/server/remote_execution/vbd/vbd_test.go
@@ -82,6 +82,10 @@ func TestVBD(t *testing.T) {
 				copy(b[offset:offset+length], p)
 			}
 		}
+		// Try sync() on the virtual file (this is a NOP for now, but should at
+		// least not fail)
+		err = f.Sync()
+		require.NoError(t, err)
 	}
 }
 


### PR DESCRIPTION
I occasionally would see firecracker logging errors due to `fsync` failing on the block device backing file. I'm not 100% sure whether the errors were fatal, but we may as well implement `fsync` to avoid the errors.

**Related issues**: N/A
