### PR TITLE
Fix UFFD / VBD context being cancelled too early

### DIFF
--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -125,6 +125,9 @@ func (h *Handler) Start(ctx context.Context, socketPath string, memoryStore *cop
 
 	go func() {
 		h.handleErr = h.handle(ctx, memoryStore)
+		if h.handleErr != nil {
+			log.CtxErrorf(ctx, "UFFD handler failed: %s", h.handleErr)
+		}
 		close(h.handleDoneChan)
 	}()
 	return nil


### PR DESCRIPTION
LoadSnapshot was calling `monitorVMContext` then passing the returned context to the UFFD / VBD handlers. However, this context is cancelled at the end of LoadSnapshot, so if UFFD / VBD need to do any remote chunk fetches they would fail with "context cancelled."

This PR moves the `monitorVMContext` after the UFFD / VBD setup so that their context can outlive the LoadSnapshot call.

The RemoteSnapshot test is failing because of this, but we didn't catch this because it's disabled currently.

**Related issues**: N/A
