### PR TITLE
[RSS] Add manual performance tests that run git clone + bazel for more realistic results

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -706,7 +706,7 @@ func TestFirecracker_RemoteSnapshotSharing(t *testing.T) {
 
 // Prints performance data about various Firecracker commands
 // Run with:
-// ./enterprise/server/remote_execution/containers/firecracker/test.sh --@io_bazel_rules_go//go/config:race  -- -test.run=TestFirecracker_RemoteSnapshotSharing_ManualBenchmarking -test_manual_benchmark
+// ./enterprise/server/remote_execution/containers/firecracker/test.sh -- -test.run=TestFirecracker_RemoteSnapshotSharing_ManualBenchmarking -test_manual_benchmark
 func TestFirecracker_RemoteSnapshotSharing_ManualBenchmarking(t *testing.T) {
 	if !*testManualBenchmark {
 		t.Skip()


### PR DESCRIPTION
Results: (Includes #5027)

(remote_snapshot_sharing=true) Bazel build on a clean runner took  1m7.718469349s.
(remote_snapshot_sharing=true) Bazel build on a recycled runner (100% locally cached) took 2.162489981s.
(remote_snapshot_sharing=true) Bazel build (30% locally cached) took 1m5.167310881s. 70% artifacts fetched remotely.
(remote_snapshot_sharing=true) Bazel build (0% locally cached) took 1m13.816709152s. 100% artifacts fetched remotely.

(remote_snapshot_sharing=false) Bazel build on a clean runner took 1m23.309983265s.
(remote_snapshot_sharing=false) Bazel build on a recycled runner (100% locally cached) took 1.996104061s.
(remote_snapshot_sharing=false) Bazel build (30% locally cached) took 1m18.716916804s. Could not start from snapshot, had to prepare clean runner.
(remote_snapshot_sharing=false) Bazel build (0% locally cached) took 1m33.259871746s. Could not start from snapshot, had to prepare clean runner.


======= More Detailed Breakdowns =======

(remote_snapshot_sharing=true) Pausing a new VM took 11.039187529s.
(remote_snapshot_sharing=false) Pausing a new VM took 3.224299522s.
(remote_snapshot_sharing=true) Pausing a VM that had started from a snapshot and had no non-metadata changes took 5.847615543s.
(remote_snapshot_sharing=false) Pausing a VM that had started from a snapshot and had no non-metadata changes took 3.767005323s.
(remote_snapshot_sharing=true) Pausing a VM that had started from a snapshot and had execution-related changes took 3.326133345s.
(remote_snapshot_sharing=false) Pausing a VM that had started from a snapshot and had execution-related changes took 964.355972ms.
(remote_snapshot_sharing=true) Unpausing a VM that is fully cached in filecache took 300.910616ms.
(remote_snapshot_sharing=false) Unpausing a VM that is fully cached in filecache took 265.095001ms.
(remote_snapshot_sharing=true) Unpausing a VM where ~30% of artifacts were evicted from filecache and must be fetched remotely. Took 546.868224ms.
(remote_snapshot_sharing=true) Unpausing a VM where all artifacts were evicted from filecache and must be fetched remotely. Took 1.811583556s.
