### PR TITLE
vbd: don't try to clean up in-use mounts

### DIFF
--- a/enterprise/server/cmd/executor/executor_linux.go
+++ b/enterprise/server/cmd/executor/executor_linux.go
@@ -34,7 +34,7 @@ func setupNetworking(rootContext context.Context) {
 }
 
 func cleanupFUSEMounts() {
-	if err := vbd.UnmountAll(); err != nil {
+	if err := vbd.CleanStaleMounts(); err != nil {
 		log.Warningf("Failed to cleanup Virtual Block Device mounts from previous runs: %s", err)
 	}
 }

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -96,10 +96,10 @@ func init() {
 // See README.md for more details on the filesystem layout.
 func cleanExecutorRoot(t *testing.T, path string) {
 	if os.Getuid() == 0 {
-		// Clean up stubborn VBD mounts that might've been left around from
-		// previous tests that were interrupted. Otherwise we won't be able to
-		// clean up old firecracker workspaces.
-		err := vbd.UnmountAll()
+		// Clean up VBD mounts that might've been left around from previous
+		// tests that were interrupted. Otherwise we won't be able to clean up
+		// old firecracker workspaces.
+		err := vbd.CleanStaleMounts()
 		require.NoError(t, err)
 	}
 

--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -20,6 +20,17 @@ import (
 const (
 	// FileName is the name of the single file exposed under the mount dir.
 	FileName = "file"
+
+	// flockSuffix is a suffix given to the lock file associated with the VBD
+	// mount. The lock file is created as a sibling of the mount directory, with
+	// this suffix appended.
+	//
+	// Note: normally, a cleaner approach would be to just lock the directory
+	// itself. However, that doesn't work in this case, because we're mounting
+	// something over the directory path, causing the underlying directory node
+	// to change before/after mounting. flock() locks the underlying node, not
+	// the path name. See `man 2 flock` for more info.
+	flockSuffix = ".lock"
 )
 
 // BlockDevice is the interface backing VBD IO operations.
@@ -36,6 +47,7 @@ type FS struct {
 	store     BlockDevice
 	root      *Node
 	server    *fuse.Server
+	lockFile  *os.File
 	mountPath string
 }
 
@@ -61,6 +73,18 @@ func (f *FS) Mount(path string) error {
 	if err := os.MkdirAll(path, 0755); err != nil {
 		return err
 	}
+
+	// Note: we use a sibling lock file rather than just locking the VBD mount
+	// directory, since the mount directory path no longer refers to the same
+	// underlying node once the FUSE dir is mounted to it.
+	lockFile, err := os.Create(path + flockSuffix)
+	if err != nil {
+		return status.WrapError(err, "create file lock")
+	}
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		return status.WrapError(err, "acquire file lock")
+	}
+	f.lockFile = lockFile
 
 	nodeAttrTimeout := 6 * time.Hour
 	opts := &fusefs.Options{
@@ -101,8 +125,18 @@ func (f *FS) Unmount() error {
 	err := f.server.Unmount()
 	f.server.Wait()
 	f.server = nil
-	if err := os.Remove(f.mountPath); err != nil {
-		log.Errorf("Failed to unmount vbd: %s", err)
+	if err == nil {
+		// If we successfully unmounted, then the mount path should point to
+		// an empty dir. Remove it.
+		if err := os.Remove(f.mountPath); err != nil {
+			log.Errorf("Failed to unmount vbd: %s", err)
+		}
+	}
+	if err := os.Remove(f.lockFile.Name()); err != nil {
+		log.Errorf("Failed to remove vbd lock file: %s", err)
+	}
+	if err := f.lockFile.Close(); err != nil {
+		log.Errorf("Failed to unlock vbd lock file: %s", err)
 	}
 	log.Debugf("Unmounted %s", f.mountPath)
 	return err
@@ -190,8 +224,9 @@ func (r *reader) Size() int {
 
 func (r *reader) Done() {}
 
-// UnmountAll unmounts all VBD devices on the system.
-func UnmountAll() error {
+// CleanStaleMounts unmounts all VBD mounts on the system that are not currently
+// in use.
+func CleanStaleMounts() error {
 	f, err := os.Open("/proc/mounts")
 	if err != nil {
 		return err
@@ -208,10 +243,38 @@ func UnmountAll() error {
 		if name != "vbd" {
 			continue
 		}
+
+		// We keep a lockfile for each VBD mount that determines whether it's
+		// still in use. If we can successfully lock it, then it must no longer
+		// be in use by any process, and should be safe to unmount.
+
+		f, err := os.Open(path + flockSuffix)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// The dir was removed since we initially listed the mounts;
+				// this is normal.
+				continue
+			}
+			return status.InternalErrorf("unmount vbd: open lockfile: %s", err)
+		}
+		defer f.Close()
+		// Try to lock the file but don't block if it's in use.
+		if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+			log.Debugf("Not unmounting in-use vbd mount at %q", path)
+			continue
+		}
+
 		b, err := exec.Command("fusermount", "-u", path).CombinedOutput()
 		if err != nil {
 			return status.InternalErrorf("unmount vbd: fusermount -u: %q", string(b))
 		}
+
+		// Clean up the lock file too.
+		if err := os.Remove(f.Name()); err != nil {
+			log.Warningf("Failed to remove vbd lockfile: %s", err)
+		}
+
+		log.Debugf("Unmounted stale vbd at %q", path)
 	}
 	return nil
 }

--- a/enterprise/server/remote_execution/vbd/vbd_test.go
+++ b/enterprise/server/remote_execution/vbd/vbd_test.go
@@ -47,6 +47,11 @@ func TestVBD(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(fSize), s.Size())
 
+	// Try cleaning up VBD mounts while the VBD is mounted; this should succeed,
+	// and should not affect our currently mounted VBD.
+	err = vbd.CleanStaleMounts()
+	require.NoError(t, err)
+
 	// Try random reads and writes to the virtual file
 	{
 		f, err := os.OpenFile(filepath.Join(dir, vbd.FileName), os.O_RDWR, 0)


### PR DESCRIPTION
Use file-locking to avoid trying to clean up VBD mounts that are currently in use by other executor / test processes.

This fixes one of the blockers for running `firecracker_test` concurrently / with sharding.

The implementation uses `flock` for locking - see `man 2 flock`.

**Related issues**: N/A
