### PR TITLE
Don't return shutdown error after lease has been finalized

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1503,7 +1503,7 @@ func (s *SchedulerServer) LeaseTask(stream scpb.Scheduler_LeaseTaskServer) error
 		// return a shut down error early, rather than waiting until we're
 		// hard-stopped. The client should retry the lease with the reconnect
 		// token we sent earlier.
-		if s.isShuttingDown() && reconnectToken != "" {
+		if s.isShuttingDown() && reconnectToken != "" && claimed {
 			return status.UnavailableError("server is shutting down")
 		}
 		rsp.ClosedCleanly = !claimed


### PR DESCRIPTION
When the client is sending its lease finalization request (`finalize=true`) and the app is shutting down, we shouldn't return a shutdown error. This is for 2 reasons:
1. There is no need for the client to retry the lease at that point, because we finalized the lease successfully. A well-behaved client should immediately close the stream after we return the success message, so in practice we don't need to worry too much about the open client stream delaying shutdown for much longer.
2. (Worse) if the client does retry, it will fail, because the server won't be able to find the task. This is because in the previous attempt which set `finalize=true`, we called `deleteClaimedTask`.

**Related issues**: N/A
