### PR TITLE
Simplify/fix error handling in copyOutputsToWorkspace

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1957,14 +1957,13 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 			return result
 		}
 
-		copyOutputsErr := c.copyOutputsToWorkspace(ctx)
-		if err := c.machine.ResumeVM(ctx); err != nil {
-			result.Error = status.InternalErrorf("error resuming VM: %s", err)
+		if err := c.copyOutputsToWorkspace(ctx); err != nil {
+			result.Error = status.WrapError(err, "failed to copy action outputs from VM workspace")
 			return result
 		}
 
-		if copyOutputsErr != nil {
-			result.Error = status.WrapError(copyOutputsErr, "failed to copy action outputs from VM workspace")
+		if err := c.machine.ResumeVM(ctx); err != nil {
+			result.Error = status.InternalErrorf("error resuming VM after copying workspace outputs: %s", err)
 			return result
 		}
 	}


### PR DESCRIPTION
If `copyOutputsToWorkspace` fails, we'd previously swallow the error if `ResumeVM` also fails, resulting in a confusing error message. `ResumeVM` will fail in particular if the context deadline is exceeded, which is more often because of a vsock timeout in `copyOutputsToWorkspace`.

This results in a small change in behavior: we won't call `ResumeVM` if we fail to copy workspace outputs, whereas before we would. However, it's unnecessary to resume the VM in this scenario, since we treat the copyOutputs error as fatal and Remove() the VM anyway.

**Related issues**: N/A
