### PR TITLE
Pebble Cache: delete in a queue

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -68,7 +68,9 @@ var (
 	dirDeletionDelay          = flag.Duration("cache.pebble.dir_deletion_delay", time.Hour, "How old directories must be before being eligible for deletion when empty")
 	atimeUpdateThresholdFlag  = flag.Duration("cache.pebble.atime_update_threshold", DefaultAtimeUpdateThreshold, "Don't update atime if it was updated more recently than this")
 	atimeBufferSizeFlag       = flag.Int("cache.pebble.atime_buffer_size", DefaultAtimeBufferSize, "Buffer up to this many atime updates in a channel before dropping atime updates")
-	sampleBufferSize          = flag.Int("cache.pebbles.sample_buffer_size", DefaultSampleBufferSize, "Buffer up to this many samples for eviction")
+	sampleBufferSize          = flag.Int("cache.pebbles.sample_buffer_size", DefaultSampleBufferSize, "Buffer up to this many samples for eviction sampling")
+	deleteBufferSize          = flag.Int("cache.pebbles.delete_buffer_size", DefaultDeleteBufferSize, "Buffer up to this many samples for eviction eviction")
+	numDeleteWorkers          = flag.Int("cache.pebbles.num_delete_workers", DefaultNumDeleteWorkers, "Number of deletes in parallel")
 	samplesPerBatch           = flag.Int("cache.pebbles.samples_per_batch", DefaultSamplesPerBatch, "How many keys we read forward every time we get a random key.")
 	minEvictionAgeFlag        = flag.Duration("cache.pebble.min_eviction_age", DefaultMinEvictionAge, "Don't evict anything unless it's been idle for at least this long")
 	forceCompaction           = flag.Bool("cache.pebble.force_compaction", false, "If set, compact the DB when it's created")
@@ -98,6 +100,8 @@ var (
 	DefaultAtimeBufferSize      = 100000
 	DefaultSampleBufferSize     = 8000
 	DefaultSamplesPerBatch      = 10000
+	DefaultDeleteBufferSize     = 20
+	DefaultNumDeleteWorkers     = 2
 	DefaultMinEvictionAge       = 6 * time.Hour
 
 	DefaultName         = "pebble_cache"
@@ -165,6 +169,9 @@ type Options struct {
 	MinEvictionAge       *time.Duration
 	SampleBufferSize     *int
 	SamplesPerBatch      *int
+	SampleTimeout        *time.Duration
+	DeleteBufferSize     *int
+	NumDeleteWorkers     *int
 
 	IncludeMetadataSize bool
 
@@ -352,6 +359,8 @@ func Register(env environment.Env) error {
 		AtimeUpdateThreshold:        atimeUpdateThresholdFlag,
 		AtimeBufferSize:             atimeBufferSizeFlag,
 		SampleBufferSize:            sampleBufferSize,
+		DeleteBufferSize:            deleteBufferSize,
+		NumDeleteWorkers:            numDeleteWorkers,
 		SamplesPerBatch:             samplesPerBatch,
 		MinEvictionAge:              minEvictionAgeFlag,
 		AverageChunkSizeBytes:       *averageChunkSizeBytes,
@@ -640,7 +649,7 @@ func NewPebbleCache(env environment.Env, opts *Options) (*PebbleCache, error) {
 			if err := disk.EnsureDirectoryExists(blobDir); err != nil {
 				return err
 			}
-			pe, err := newPartitionEvictor(part, pc.fileStorer, blobDir, pc.leaser, pc.locker, pc, clock, pc.accesses, *opts.MinEvictionAge, opts.Name, opts.IncludeMetadataSize, *opts.SampleBufferSize, *opts.SamplesPerBatch)
+			pe, err := newPartitionEvictor(part, pc.fileStorer, blobDir, pc.leaser, pc.locker, pc, clock, pc.accesses, *opts.MinEvictionAge, opts.Name, opts.IncludeMetadataSize, *opts.SampleBufferSize, *opts.SamplesPerBatch, *opts.DeleteBufferSize, *opts.NumDeleteWorkers)
 			if err != nil {
 				return err
 			}
@@ -2363,6 +2372,7 @@ func (k *evictionKey) String() string {
 }
 
 type partitionEvictor struct {
+	ctx           context.Context
 	mu            *sync.Mutex
 	part          disk.Partition
 	fileStorer    filestore.Store
@@ -2373,6 +2383,7 @@ type partitionEvictor struct {
 	versionGetter versionGetter
 	accesses      chan<- *accessTimeUpdate
 	samples       chan *approxlru.Sample[*evictionKey]
+	deletes       chan *approxlru.Sample[*evictionKey]
 	rng           *rand.Rand
 	clock         clockwork.Clock
 
@@ -2387,6 +2398,8 @@ type partitionEvictor struct {
 
 	samplesPerBatch int
 
+	numDeleteWorkers int
+
 	includeMetadataSize bool
 }
 
@@ -2394,22 +2407,24 @@ type versionGetter interface {
 	minDatabaseVersion() filestore.PebbleKeyVersion
 }
 
-func newPartitionEvictor(part disk.Partition, fileStorer filestore.Store, blobDir string, dbg pebble.Leaser, locker lockmap.Locker, vg versionGetter, clock clockwork.Clock, accesses chan<- *accessTimeUpdate, minEvictionAge time.Duration, cacheName string, includeMetadataSize bool, sampleBufferSize int, samplesPerBatch int) (*partitionEvictor, error) {
+func newPartitionEvictor(part disk.Partition, fileStorer filestore.Store, blobDir string, dbg pebble.Leaser, locker lockmap.Locker, vg versionGetter, clock clockwork.Clock, accesses chan<- *accessTimeUpdate, minEvictionAge time.Duration, cacheName string, includeMetadataSize bool, sampleBufferSize int, samplesPerBatch int, deleteBufferSize int, numDeleteWorkers int) (*partitionEvictor, error) {
 	pe := &partitionEvictor{
-		mu:              &sync.Mutex{},
-		part:            part,
-		fileStorer:      fileStorer,
-		blobDir:         blobDir,
-		dbGetter:        dbg,
-		locker:          locker,
-		versionGetter:   vg,
-		accesses:        accesses,
-		rng:             rand.New(rand.NewSource(time.Now().UnixNano())),
-		clock:           clock,
-		minEvictionAge:  minEvictionAge,
-		cacheName:       cacheName,
-		samples:         make(chan *approxlru.Sample[*evictionKey], sampleBufferSize),
-		samplesPerBatch: samplesPerBatch,
+		mu:               &sync.Mutex{},
+		part:             part,
+		fileStorer:       fileStorer,
+		blobDir:          blobDir,
+		dbGetter:         dbg,
+		locker:           locker,
+		versionGetter:    vg,
+		accesses:         accesses,
+		rng:              rand.New(rand.NewSource(time.Now().UnixNano())),
+		clock:            clock,
+		minEvictionAge:   minEvictionAge,
+		cacheName:        cacheName,
+		samples:          make(chan *approxlru.Sample[*evictionKey], sampleBufferSize),
+		samplesPerBatch:  samplesPerBatch,
+		deletes:          make(chan *approxlru.Sample[*evictionKey], deleteBufferSize),
+		numDeleteWorkers: numDeleteWorkers,
 	}
 	metricLbls := prometheus.Labels{
 		metrics.PartitionID:    part.ID,
@@ -2423,14 +2438,11 @@ func newPartitionEvictor(part disk.Partition, fileStorer filestore.Store, blobDi
 		EvictionEvictLatencyUsec:    metrics.PebbleCacheEvictionEvictLatencyUsec.With(metricLbls),
 		RateLimit:                   float64(*evictionRateLimit),
 		MaxSizeBytes:                int64(JanitorCutoffThreshold * float64(part.MaxSizeBytes)),
-		OnEvict: func(ctx context.Context, sample *approxlru.Sample[*evictionKey]) (skip bool, err error) {
+		OnEvict: func(ctx context.Context, sample *approxlru.Sample[*evictionKey]) error {
 			return pe.evict(ctx, sample)
 		},
 		OnSample: func(ctx context.Context, n int) ([]*approxlru.Sample[*evictionKey], error) {
 			return pe.sample(ctx, n)
-		},
-		OnRefresh: func(ctx context.Context, key *evictionKey) (skip bool, timestamp time.Time, err error) {
-			return pe.refresh(ctx, key)
 		},
 	})
 	if err != nil {
@@ -2464,6 +2476,27 @@ func (e *partitionEvictor) startSampleGenerator(quitChan chan struct{}) {
 		<-e.samples
 	}
 	close(e.samples)
+}
+
+func (e *partitionEvictor) processEviction(quitChan chan struct{}) {
+	eg := &errgroup.Group{}
+	for i := 0; i < e.numDeleteWorkers; i++ {
+		eg.Go(func() error {
+			for {
+				select {
+				case <-quitChan:
+					return nil
+				case sampleToDelete := <-e.deletes:
+					e.doEvict(sampleToDelete)
+				}
+			}
+		})
+	}
+	eg.Wait()
+	for len(e.deletes) > 0 {
+		s := <-e.deletes
+		e.doEvict(s)
+	}
 }
 
 func (e *partitionEvictor) generateSamplesForEviction(quitChan chan struct{}) error {
@@ -2514,6 +2547,7 @@ func (e *partitionEvictor) generateSamplesForEviction(quitChan chan struct{}) er
 			shouldCreateNewIter = true
 		}
 		if !iter.Valid() {
+			log.Info("iter is invalid; generate new random key")
 			// This should happen once every totalCount times or when
 			// we exausted the iter.
 			randomKey, err := e.randomKey(64)
@@ -2794,69 +2828,56 @@ func (e *partitionEvictor) randomKey(digestLength int) ([]byte, error) {
 	return keyBytes, nil
 }
 
-func (e *partitionEvictor) evict(ctx context.Context, sample *approxlru.Sample[*evictionKey]) (bool, error) {
+func (e *partitionEvictor) evict(ctx context.Context, sample *approxlru.Sample[*evictionKey]) error {
+	e.deletes <- sample
+	return nil
+}
+
+func (e *partitionEvictor) doEvict(sample *approxlru.Sample[*evictionKey]) {
 	db, err := e.dbGetter.DB()
 	if err != nil {
-		return false, err
+		log.Warningf("unable to get db: %s", err)
+		return
 	}
 	defer db.Close()
 
 	var key filestore.PebbleKey
 	version, err := key.FromBytes(sample.Key.bytes)
 	if err != nil {
-		return false, err
+		log.Warningf("unable to read key %s: %s", sample.Key, err)
+		return
 	}
 	unlockFn := e.locker.Lock(key.LockID())
 	defer unlockFn()
 
-	_, closer, err := db.Get(sample.Key.bytes)
-	if err == pebble.ErrNotFound {
-		return true, nil
-	}
+	md, err := readFileMetadata(e.ctx, db, sample.Key.bytes)
 	if err != nil {
-		return false, err
+		if status.IsNotFoundError(err) {
+			log.Infof("try to evict %s cannot find md: %s", sample.Key, err)
+			return
+		}
+		log.Infof("try to evict %s can't read md: %s", sample.Key, err)
+		return
 	}
-	closer.Close()
-	age := time.Since(sample.Timestamp)
+	atime := time.UnixMicro(md.GetLastAccessUsec())
+	age := time.Since(atime)
+	if sample.Timestamp != atime {
+		// atime have been updated
+		log.Infof("try to evict %s atime updated", sample.Key)
+		// update the sample key
+		return
+	}
+
 	if err := e.deleteFile(key, version, sample.SizeBytes, sample.Key.storageMetadata); err != nil {
 		log.Errorf("Error evicting file for key %q: %s (ignoring)", sample.Key, err)
-		return false, nil
+		return
 	}
 	lbls := prometheus.Labels{metrics.PartitionID: e.part.ID, metrics.CacheNameLabel: e.cacheName}
 	metrics.DiskCacheNumEvictions.With(lbls).Inc()
 	metrics.DiskCacheBytesEvicted.With(lbls).Add(float64(sample.SizeBytes))
 	metrics.DiskCacheEvictionAgeMsec.With(lbls).Observe(float64(age.Milliseconds()))
 	metrics.DiskCacheLastEvictionAgeUsec.With(lbls).Set(float64(age.Microseconds()))
-	return false, nil
-}
-
-func (e *partitionEvictor) refresh(ctx context.Context, key *evictionKey) (bool, time.Time, error) {
-	db, err := e.dbGetter.DB()
-	if err != nil {
-		return false, time.Time{}, err
-	}
-	defer db.Close()
-
-	var pebbleKey filestore.PebbleKey
-	if _, err := pebbleKey.FromBytes(key.bytes); err != nil {
-		return false, time.Time{}, err
-	}
-	unlockFn := e.locker.RLock(pebbleKey.LockID())
-	defer unlockFn()
-
-	md, err := readFileMetadata(ctx, db, key.bytes)
-	if err != nil {
-		if !status.IsNotFoundError(err) {
-			log.Warningf("could not refresh atime for %q: %s", key.String(), err)
-		}
-		return true, time.Time{}, nil
-	}
-	atime := time.UnixMicro(md.GetLastAccessUsec())
-	age := e.clock.Since(atime)
-	if age < e.minEvictionAge {
-		return true, time.Time{}, nil
-	}
-	return false, atime, nil
+	return
 }
 
 func (e *partitionEvictor) sample(ctx context.Context, k int) ([]*approxlru.Sample[*evictionKey], error) {
@@ -3251,6 +3272,10 @@ func (p *PebbleCache) Start() error {
 		})
 		p.eg.Go(func() error {
 			evictor.startSampleGenerator(p.quitChan)
+			return nil
+		})
+		p.eg.Go(func() error {
+			evictor.processEviction(p.quitChan)
 			return nil
 		})
 	}

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2859,18 +2859,14 @@ func (e *partitionEvictor) doEvict(sample *approxlru.Sample[*evictionKey]) {
 	md, err := readFileMetadata(e.ctx, db, sample.Key.bytes)
 	if err != nil {
 		if status.IsNotFoundError(err) {
-			log.Infof("try to evict %s cannot find md: %s", sample.Key, err)
 			return
 		}
-		log.Infof("try to evict %s can't read md: %s", sample.Key, err)
 		return
 	}
 	atime := time.UnixMicro(md.GetLastAccessUsec())
 	age := time.Since(atime)
 	if sample.Timestamp != atime {
-		// atime have been updated
-		log.Infof("try to evict %s atime updated", sample.Key)
-		// update the sample key
+		// atime have been updated. Do not evict.
 		return
 	}
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -169,7 +169,6 @@ type Options struct {
 	MinEvictionAge       *time.Duration
 	SampleBufferSize     *int
 	SamplesPerBatch      *int
-	SampleTimeout        *time.Duration
 	DeleteBufferSize     *int
 	NumDeleteWorkers     *int
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2553,7 +2553,6 @@ func (e *partitionEvictor) generateSamplesForEviction(quitChan chan struct{}) er
 			shouldCreateNewIter = true
 		}
 		if !iter.Valid() {
-			log.Info("iter is invalid; generate new random key")
 			// This should happen once every totalCount times or when
 			// we exausted the iter.
 			randomKey, err := e.randomKey(64)
@@ -2865,7 +2864,7 @@ func (e *partitionEvictor) doEvict(sample *approxlru.Sample[*evictionKey]) {
 	}
 	atime := time.UnixMicro(md.GetLastAccessUsec())
 	age := time.Since(atime)
-	if sample.Timestamp != atime {
+	if !sample.Timestamp.Equal(atime) {
 		// atime have been updated. Do not evict.
 		return
 	}

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -2067,6 +2067,15 @@ var (
 		PartitionID,
 		CacheNameLabel,
 	})
+	PebbleCacheEvictionSamplesChanSize2 = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "pebble_cache_eviction_samples_chan_size_2",
+		Help:      "Num of items in eviction samples chan",
+	}, []string{
+		PartitionID,
+		CacheNameLabel,
+	})
 
 	PebbleCacheEvictionResampleLatencyUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: bbNamespace,

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -2067,15 +2067,6 @@ var (
 		PartitionID,
 		CacheNameLabel,
 	})
-	PebbleCacheEvictionSamplesChanSize2 = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: bbNamespace,
-		Subsystem: "remote_cache",
-		Name:      "pebble_cache_eviction_samples_chan_size_2",
-		Help:      "Num of items in eviction samples chan",
-	}, []string{
-		PartitionID,
-		CacheNameLabel,
-	})
 
 	PebbleCacheEvictionResampleLatencyUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: bbNamespace,

--- a/server/util/approxlru/approxlru.go
+++ b/server/util/approxlru/approxlru.go
@@ -42,18 +42,11 @@ func (s *Sample[T]) String() string {
 // OnEvict requests that the given key be evicted. The callback may return
 // skip=true to indicate that the given sample is no longer valid and should be
 // removed from the eviction pool.
-type OnEvict[T Key] func(ctx context.Context, sample *Sample[T]) (skip bool, err error)
+type OnEvict[T Key] func(ctx context.Context, sample *Sample[T]) error
 
 // OnSample requests that n random samples be provided from the underlying data.
 type OnSample[T Key] func(ctx context.Context, n int) ([]*Sample[T], error)
 
-// OnRefresh requests the latest access timestamp for the given key. The
-// callback may return skip=true to indicate that the given sample is no longer
-// valid and should be removed from the eviction pool.
-type OnRefresh[T Key] func(ctx context.Context, key T) (skip bool, timestamp time.Time, error error)
-
-// LRU implements a thread safe fixed size LRU cache using sampled eviction.
-//
 // The LRU does not store information about the full set of keys or values that
 // is subject to eviction, instead relying on user provided callbacks to perform
 // sampling of the full universe of data.
@@ -73,12 +66,12 @@ type LRU[T Key] struct {
 	maxSizeBytes                int64
 	onEvict                     OnEvict[T]
 	onSample                    OnSample[T]
-	onRefresh                   OnRefresh[T]
 	evictionResampleLatencyUsec prometheus.Observer
 	evictionEvictLatencyUsec    prometheus.Observer
 	limiter                     *rate.Limiter
 
-	samplePool []*Sample[T]
+	samplePool         []*Sample[T]
+	numEvictionWorkers int
 
 	mu              sync.Mutex
 	ctx             context.Context
@@ -110,11 +103,11 @@ type Opts[T Key] struct {
 	EvictionEvictLatencyUsec prometheus.Observer
 	// RateLimit is the maximum number of evictions to perform per second.
 	// If not set, no limit is enforced.
-	RateLimit float64
+	RateLimit          float64
+	NumEvictionWorkers int
 
-	OnEvict   OnEvict[T]
-	OnSample  OnSample[T]
-	OnRefresh OnRefresh[T]
+	OnEvict  OnEvict[T]
+	OnSample OnSample[T]
 }
 
 func New[T Key](opts *Opts[T]) (*LRU[T], error) {
@@ -137,9 +130,6 @@ func New[T Key](opts *Opts[T]) (*LRU[T], error) {
 	if opts.OnSample == nil {
 		return nil, status.FailedPreconditionError("sample callback is required")
 	}
-	if opts.OnRefresh == nil {
-		return nil, status.FailedPreconditionError("refresh callback is required")
-	}
 	rateLimit := rate.Limit(opts.RateLimit)
 	if rateLimit == 0 {
 		rateLimit = rate.Inf
@@ -151,7 +141,6 @@ func New[T Key](opts *Opts[T]) (*LRU[T], error) {
 		maxSizeBytes:                opts.MaxSizeBytes,
 		onEvict:                     opts.OnEvict,
 		onSample:                    opts.OnSample,
-		onRefresh:                   opts.OnRefresh,
 		evictionResampleLatencyUsec: opts.EvictionResampleLatencyUsec,
 		evictionEvictLatencyUsec:    opts.EvictionEvictLatencyUsec,
 		limiter:                     rate.NewLimiter(rateLimit, 1),
@@ -207,6 +196,7 @@ func (l *LRU[T]) UpdateSizeBytes(sizeBytes int64) {
 }
 
 func (l *LRU[T]) resampleK(k int) error {
+	log.Infof("resampleK %d", k)
 	seen := make(map[string]struct{}, len(l.samplePool))
 	for _, entry := range l.samplePool {
 		seen[entry.Key.ID()] = struct{}{}
@@ -250,59 +240,14 @@ func (l *LRU[T]) evictSingleKey() (*Sample[T], error) {
 	for i := len(l.samplePool) - 1; i >= 0; i-- {
 		sample := l.samplePool[i]
 
-		l.mu.Lock()
-		oldLocalSizeBytes := l.localSizeBytes
-		oldGlobalSizeBytes := l.globalSizeBytes
-		l.mu.Unlock()
-
-		skip, timestamp, err := l.onRefresh(l.ctx, sample.Key)
-		if err != nil {
-			log.Infof("Could not refresh timestamp for %q: %s", sample.Key, err)
-			continue
-		}
-		if skip {
-			continue
-		}
-		if sample.Timestamp != timestamp {
-			log.Infof("Evictor skipping %q; atime has changed %s -> %s", sample.Key, sample.Timestamp, timestamp)
-			// Update the timestamp to the new value so this sample can be
-			// removed later when the pool is trimmed.
-			sample.Timestamp = timestamp
-			continue
-		}
-
 		log.Infof("Evictor attempting to evict %q (last accessed %s)", sample.Key, time.Since(sample.Timestamp))
-		skip, err = l.onEvict(l.ctx, sample)
+		err := l.onEvict(l.ctx, sample)
 		if err != nil {
 			log.Warningf("Could not evict %q: %s", sample.Key, err)
 			continue
 		}
 
-		l.mu.Lock()
-
-		// The user (e.g. pebble cache) is the source of truth of the size
-		// data, but the LRU also needs to do its own accounting in between
-		// the times that the user provides a size update to the LRU.
-		// We skip our own accounting here if we detect that the size has
-		// changed since it means the user provided their own size update
-		// which takes priority.
-		if l.localSizeBytes == oldLocalSizeBytes {
-			l.localSizeBytes -= sample.SizeBytes
-		}
-		if l.globalSizeBytes == oldGlobalSizeBytes {
-			// Assume eviction on remote servers is happening at the same
-			// rate as local eviction. It's fine to be wrong as we expect the
-			// actual sizes to be periodically to be reset to the true numbers
-			// using UpdateSizeBytes from data received from other servers.
-			l.globalSizeBytes -= int64(float64(sample.SizeBytes) * float64(l.globalSizeBytes) / float64(l.localSizeBytes))
-		}
-		l.mu.Unlock()
-
 		l.samplePool = append(l.samplePool[:i], l.samplePool[i+1:]...)
-
-		if skip {
-			continue
-		}
 
 		return sample, nil
 	}
@@ -334,6 +279,7 @@ func (l *LRU[T]) evict() (*Sample[T], error) {
 		if status.IsNotFoundError(err) {
 			// If no candidates were evictable in the whole pool, resample
 			// the pool.
+			log.Info("resample the whole pool")
 			l.samplePool = l.samplePool[:0]
 			if err := l.resampleK(l.samplePoolSize); err != nil {
 				return nil, err

--- a/server/util/approxlru/approxlru.go
+++ b/server/util/approxlru/approxlru.go
@@ -196,7 +196,6 @@ func (l *LRU[T]) UpdateSizeBytes(sizeBytes int64) {
 }
 
 func (l *LRU[T]) resampleK(k int) error {
-	log.Infof("resampleK %d", k)
 	seen := make(map[string]struct{}, len(l.samplePool))
 	for _, entry := range l.samplePool {
 		seen[entry.Key.ID()] = struct{}{}

--- a/server/util/approxlru/approxlru.go
+++ b/server/util/approxlru/approxlru.go
@@ -279,7 +279,6 @@ func (l *LRU[T]) evict() (*Sample[T], error) {
 		if status.IsNotFoundError(err) {
 			// If no candidates were evictable in the whole pool, resample
 			// the pool.
-			log.Info("resample the whole pool")
 			l.samplePool = l.samplePool[:0]
 			if err := l.resampleK(l.samplePoolSize); err != nil {
 				return nil, err


### PR DESCRIPTION
combine onRefresh and onEvict in approxlru.go

In pebble cache, onEvict will put the sample on a queue; and we delete the
entry in background. Before we delete from pebble, we will check the last access
time and only delete if it's not recently read.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
