### PR TITLE
Remove unnecessary timeout causing flakes in docker test

### DIFF
--- a/enterprise/server/remote_execution/containers/docker/docker_test.go
+++ b/enterprise/server/remote_execution/containers/docker/docker_test.go
@@ -192,7 +192,7 @@ func TestDockerRun_Timeout_StdoutStderrStillVisible(t *testing.T) {
 		ctx, env, c, container.PullCredentials{}, "mirror.gcr.io/library/busybox")
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	go func() {


### PR DESCRIPTION
We don't need the 10 second timeout - we really just want to wait for the container to create `output.txt` which we're already doing via an explicit poll on that file. The 10 second timeout will just cause the test to be flaky if the machine is under high load.

**Related issues**: N/A
