### PR TITLE
Fix repo flow RBODs and permissions flow

### DIFF
--- a/enterprise/app/repo/repo.tsx
+++ b/enterprise/app/repo/repo.tsx
@@ -116,7 +116,6 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
         this.setState({ githubInstallationsResponse: response });
         return response;
       })
-      .catch((e) => error_service.handleError(e))
       .finally(() => this.setState({ githubInstallationsLoading: false }));
   }
 
@@ -129,7 +128,12 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
   }
 
   componentDidMount() {
-    this.fetchGithubInstallations();
+    this.fetchGithubInstallations().catch((e) => {
+      // Log the error, but we don't need to show it to the user since
+      // when they click the Create repository button, we'll do a GitHub
+      // link if installations aren't present.
+      console.log(e);
+    });
     this.fetchSecrets();
   }
 
@@ -350,7 +354,12 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
     let selectedInstallation = this.state.githubInstallationsResponse?.installations[
       this.state.selectedInstallationIndex
     ];
-    popup.open(selectedInstallation?.url + `/permissions/update`);
+    return popup.open(selectedInstallation?.url + `/permissions/update`).catch((e) => {
+      // Log an error here, but let's keep going since sometimes the Github UI
+      // doesn't redirect after a permissions change, and the user has to X out
+      // of the window.
+      console.log(e);
+    });
   }
 
   linkGoogleCloud() {


### PR DESCRIPTION
There are two flows / issues that this fixes.

The first is if you'd previously linked an Oauth (non-app) Github integration, when we first fetch available installations we get an error which was previously shown to the user. With this PR, we no longer show that error to the user, since in this scenario we'll link the Github app when they click "Create repository".

The second is the flow where you have accepted some permissions, but not the new updated permissions. In this case we weren't returning the promise form the permissions popup, so we weren't waiting on the permissions change to continue in the flow. This change fixes that by returning the promise. It also attempts to continue if the popup is closed, since Github doesn't always seem to perform a redirect in the permissions update flow.