### PR TITLE
[DNM] Testing snapshot cache size

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -117,6 +117,7 @@ go_test(
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",
+        "//server/backends/disk_cache",
         "//server/interfaces",
         "//server/remote_cache/action_cache_server",
         "//server/remote_cache/byte_stream_server",

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -101,6 +101,7 @@ go_test(
     ],
     deps = [
         ":firecracker",
+        "//enterprise/server/backends/pebble_cache",
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/filecache",
@@ -116,7 +117,6 @@ go_test(
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",
-        "//server/backends/disk_cache",
         "//server/interfaces",
         "//server/remote_cache/action_cache_server",
         "//server/remote_cache/byte_stream_server",
@@ -174,6 +174,8 @@ go_test(
     ],
     deps = [
         ":firecracker",
+        "//enterprise:bundle",
+        "//enterprise/server/backends/pebble_cache",
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/filecache",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -108,7 +108,7 @@ const (
 	firecrackerSocketWaitTimeout = 3 * time.Second
 
 	// How long to wait when dialing the vmexec server inside the VM.
-	vSocketDialTimeout = 30 * time.Second
+	vSocketDialTimeout = 100 * time.Second
 
 	// How long to wait for the jailer directory to be created.
 	jailerDirectoryCreationTimeout = 1 * time.Second
@@ -197,7 +197,7 @@ const (
 	guestVFSMountDir = "/vfs"
 
 	// How long to allow for the VM to be finalized (paused, outputs copied, etc.)
-	finalizationTimeout = 10 * time.Second
+	finalizationTimeout = 100 * time.Second
 )
 
 var (

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1124,7 +1124,8 @@ func (c *FirecrackerContainer) convertToCOW(ctx context.Context, filePath, chunk
 		return nil, status.WrapError(err, "make chunk dir")
 	}
 	// Use vmCtx for the COW since IO may be done outside of the task ctx.
-	cow, err := copy_on_write.ConvertFileToCOW(c.vmCtx, c.env, filePath, cowChunkSizeBytes(), chunkDir, c.snapshotKeySet.GetBranchKey().GetInstanceName(), c.supportsRemoteSnapshots)
+	name := filepath.Base(filePath)
+	cow, err := copy_on_write.ConvertFileToCOW(c.vmCtx, c.env, filePath, cowChunkSizeBytes(), chunkDir, c.snapshotKeySet.GetBranchKey().GetInstanceName(), c.supportsRemoteSnapshots, name)
 	if err != nil {
 		return nil, status.WrapError(err, "convert file to COW")
 	}

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -53,6 +53,8 @@ var eagerFetchConcurrency = flag.Int("executor.snaploader_eager_fetch_concurrenc
 //
 // A COWStore supports concurrent reads/writes
 type COWStore struct {
+	name string
+
 	ctx                context.Context
 	env                environment.Env
 	remoteInstanceName string
@@ -96,7 +98,7 @@ type COWStore struct {
 // NewCOWStore creates a COWStore from the given chunks. The chunks should be
 // open initially, and will be closed when calling Close on the returned
 // COWStore.
-func NewCOWStore(ctx context.Context, env environment.Env, chunks []*Mmap, chunkSizeBytes, totalSizeBytes int64, dataDir string, remoteInstanceName string, remoteEnabled bool) (*COWStore, error) {
+func NewCOWStore(ctx context.Context, env environment.Env, chunks []*Mmap, chunkSizeBytes, totalSizeBytes int64, dataDir string, remoteInstanceName string, remoteEnabled bool, name string) (*COWStore, error) {
 	stat, err := os.Stat(dataDir)
 	if err != nil {
 		return nil, err
@@ -107,6 +109,7 @@ func NewCOWStore(ctx context.Context, env environment.Env, chunks []*Mmap, chunk
 	}
 
 	s := &COWStore{
+		name:               name,
 		ctx:                ctx,
 		env:                env,
 		remoteInstanceName: remoteInstanceName,
@@ -610,7 +613,7 @@ func (s *COWStore) fetchChunk(offset int64) error {
 // If an error is returned from this function, the caller should decide what to
 // do with any files written to dataDir. Typically the caller should provide an
 // empty dataDir and remove the dir and contents if there is an error.
-func ConvertFileToCOW(ctx context.Context, env environment.Env, filePath string, chunkSizeBytes int64, dataDir string, remoteInstanceName string, remoteEnabled bool) (store *COWStore, err error) {
+func ConvertFileToCOW(ctx context.Context, env environment.Env, filePath string, chunkSizeBytes int64, dataDir string, remoteInstanceName string, remoteEnabled bool, name string) (store *COWStore, err error) {
 	f, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
@@ -708,7 +711,7 @@ func ConvertFileToCOW(ctx context.Context, env environment.Env, filePath string,
 		}
 	}
 
-	return NewCOWStore(ctx, env, chunks, chunkSizeBytes, totalSizeBytes, dataDir, remoteInstanceName, remoteEnabled)
+	return NewCOWStore(ctx, env, chunks, chunkSizeBytes, totalSizeBytes, dataDir, remoteInstanceName, remoteEnabled, name)
 }
 
 // Mmap uses a memory-mapped file to represent a section of a larger composite

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",
         "//server/util/authutil",
+        "//server/util/flag",
         "//server/util/hash",
         "//server/util/log",
         "//server/util/perms",

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -542,7 +542,6 @@ func (l *FileCacheLoader) CacheSnapshot(ctx context.Context, key *fcpb.SnapshotK
 			}
 			out.Digest = d
 			forceCache := strings.Contains(fileName, "mem")
-			fmt.Printf("Hey: forceCache is %v, name is %s", forceCache, fileName)
 			return snaputil.Cache(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), opts.Remote, d, key.InstanceName, filePath, forceCache)
 		})
 	}

--- a/enterprise/server/remote_execution/snaputil/snaputil.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil.go
@@ -115,7 +115,7 @@ func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytest
 	}
 
 	rn := digest.NewResourceName(d, remoteInstanceName, rspb.CacheType_CAS, repb.DigestFunction_BLAKE3)
-	rn.SetCompressor(repb.Compressor_ZSTD)
+	//rn.SetCompressor(repb.Compressor_ZSTD)
 	file, err := os.Open(path)
 	if err != nil {
 		return err

--- a/enterprise/server/remote_execution/snaputil/snaputil.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil.go
@@ -102,9 +102,9 @@ func GetBytes(ctx context.Context, localCache interfaces.FileCache, bsClient byt
 
 // Cache saves a file written to `path` to the local cache, and the remote cache
 // if remote snapshot sharing is enabled
-func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytestream.ByteStreamClient, remoteEnabled bool, d *repb.Digest, remoteInstanceName string, path string) error {
+func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytestream.ByteStreamClient, remoteEnabled bool, d *repb.Digest, remoteInstanceName string, path string, forceCache bool) error {
 	localCacheErr := cacheLocally(ctx, localCache, d, path)
-	if !*EnableRemoteSnapshotSharing || *RemoteSnapshotReadonly || !remoteEnabled {
+	if (!*EnableRemoteSnapshotSharing || *RemoteSnapshotReadonly || !remoteEnabled) && !forceCache {
 		return localCacheErr
 	}
 
@@ -143,7 +143,7 @@ func CacheBytes(ctx context.Context, localCache interfaces.FileCache, bsClient b
 		}
 	}()
 
-	return Cache(ctx, localCache, bsClient, remoteEnabled, d, remoteInstanceName, tmpPath)
+	return Cache(ctx, localCache, bsClient, remoteEnabled, d, remoteInstanceName, tmpPath, false)
 }
 
 // cacheLocally copies the data at `path` to the local filecache with


### PR DESCRIPTION
In these tests, a VM is started, executes a command and snapshotted. Then a fork loads the snapshot, executes the same command and is snapshotted.

Original cache size: After original VM is snapshotted
New cache size: After forked VM is snapshotted

VM configuration:
&fcpb.VMConfiguration{
					NumCpus:           6,
					MemSizeMb:         8000,
					EnableNetworking:  true,
					ScratchDiskSizeMb: 20_000,
}
CDC chunk size is 524288B (0.5MB).

### Memory Snapshots

**For cache Pebble compression cdc after no execution:** 
Original cache size with memory snapshot: 12MB
Cached "memory" in 7.520937475s - 359 MB (92 chunks) dirty
New cache size with memory snapshot: 34 MB
Difference in cache size: 21

**For cache Pebble cdc, no compression after no execution:** 
Original cache size with memory snapshot: 44MB
Cached "memory" in 433.123447ms - 359 MB (92 chunks) dirty
New cache size with memory snapshot: 308 MB
Difference in cache size: 263

**For cache disk after no execution:** 
Original cache size with memory snapshot: 50MB
Cached "memory" in 376.702477ms - 359 MB (92 chunks) dirty
New cache size with memory snapshot: 335 MB
Difference in cache size: 285
 
**For cache Pebble compression cdc after no-op execution (`exit`):** 
Original cache size with memory snapshot: 26MB
Cached "memory" in 191.678565ms - 148 MB (38 chunks) dirty
New cache size with memory snapshot: 30 MB
Difference in cache size: 3

**For cache Pebble cdc, no compression after no-op execution (`exit`):** 
Original cache size with memory snapshot: 282MB
Cached "memory" in 168.308582ms - 148 MB (38 chunks) dirty
New cache size with memory snapshot: 360 MB
Difference in cache size: 77

**For cache disk after no-op execution (`exit`):** 
Original cache size with memory snapshot: 289MB
Cached "memory" in 1.386376782s - 140 MB (36 chunks) dirty
New cache size with memory snapshot: 390 MB
Difference in cache size: 101

**For cache Pebble compression cdc after bazel build:** 
Original cache size with memory snapshot: 1908MB
Cached "memory" in 1m7.265503034s - 4152 MB (1063 chunks) dirty
New cache size with memory snapshot: 2753 MB
Difference in cache size: 844

**For cache Pebble cdc, no compression after bazel build:** 
Original cache size with memory snapshot: 5984MB
Cached "memory" in 2m13.094494492s - 4550 MB (1165 chunks) dirty
New cache size with memory snapshot: 9119 MB
Difference in cache size: 3134

**For cache disk after bazel build:** 
Original cache size with memory snapshot: 5648MB
Cached "memory" in 1m50.253090422s - 4589 MB (1175 chunks) dirty
New cache size with memory snapshot: 8582 MB
Difference in cache size: 2933

### Disk Snapshots

**For cache Pebble compression cdc after no execution:**
Original cache size with snapshot: 12MB
Cached "rootfs" in 1.576697002s - 97 MB (25 chunks) dirty
New cache size with snapshot: 34 MB
Difference in cache size: 22

**For cache Pebble cdc, no compression after no execution:**
Original cache size with snapshot: 44MB
Cached "rootfs" in 1.352030782s - 97 MB (25 chunks) dirty
New cache size with snapshot: 310 MB
Difference in cache size: 265

**For cache disk after no execution:**
Original cache size with snapshot: 50MB
Cached "rootfs" in 1.46902041s - 97 MB (25 chunks) dirty
New cache size with snapshot: 339 MB
Difference in cache size: 289

**For cache Pebble compression cdc after no-op execution (`exit`):**
Original cache size with snapshot: 44MB
New cache size with snapshot: 48 MB
Difference in cache size: 4
Cached "rootfs" in 11.726387538s - 132 MB (34 chunks) dirty

**For cache Pebble cdc, no compression after no-op execution (`exit`):**
Original cache size with snapshot: 418MB
New cache size with snapshot: 495 MB
Difference in cache size: 77
Cached "rootfs" in 65.873066ms - 132 MB (34 chunks) dirty

**For cache disk after no-op execution (`exit`):**
Original cache size with snapshot: 484MB
New cache size with snapshot: 597 MB
Difference in cache size: 113
Cached "rootfs" in 1m57.350089605s - 4109 MB (1052 chunks) dirty

**For cache Pebble compression cdc after bazel build:**
Original cache size with snapshot: 1964MB
New cache size with snapshot: 3042 MB
Difference in cache size: 1078
Cached "rootfs" in 33.930100415s - 4148 MB (1062 chunks) dirty

**For cache Pebble cdc, no compression after bazel build:**
Original cache size with snapshot: 6244MB
Cached "rootfs" in 7.08947843s - 58 MB (15 chunks) dirty
New cache size with snapshot: 9016 MB
Difference in cache size: 2772
Cached "rootfs" in 1m56.421565322s - 4199 MB (1075 chunks) dirty

**For cache disk after bazel build:**
Original cache size with snapshot: 6156MB
Cached "rootfs" in 51.352827502s - 89 MB (23 chunks) dirty
New cache size with snapshot: 8582 MB
Difference in cache size: 2425


### With various memory-related bazel flags
Results: https://docs.google.com/document/d/1EDcY5IJpqkEmF_gKMP7Z00rx8ryj3H29DD6HsRtKZPA/edit
