### PR TITLE
Fix website being horizontally scrollable on mobile

### DIFF
--- a/website/src/css/general.css
+++ b/website/src/css/general.css
@@ -51,6 +51,10 @@ html body[data-theme="dark"] {
   --aa-selected-color-rgb: 80, 80, 80;
 }
 
+#__docusaurus {
+  overflow-x: hidden;
+}
+
 a {
   text-decoration: none;
 }


### PR DESCRIPTION
The main page scrolls horizontally, revealing blank content. This PR fixes it.

**Related issues**: N/A
