### PR TITLE
Include versioning info in firecracker snapshot key

### DIFF
--- a/enterprise/server/cmd/goinit/BUILD
+++ b/enterprise/server/cmd/goinit/BUILD
@@ -2,6 +2,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
+exports_files(srcs = ["main.go"])
+
 go_library(
     name = "goinit_lib",
     srcs = ["main.go"],

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -15,6 +15,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
+    embedsrcs = ["guest_api_hash.sha256"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/firecracker",
     target_compatible_with = [
         "@platforms//os:linux",
@@ -68,6 +69,16 @@ go_library(
     ],
 )
 
+genrule(
+    name = "guest_api_hash",
+    srcs = [
+        "//enterprise/server/cmd/goinit:main.go",
+        "//enterprise/server/vmexec:vmexec.go",
+    ],
+    outs = ["guest_api_hash.sha256"],
+    cmd_bash = """sha256sum $(SRCS) | sha256sum | awk '{printf "%s", $$1}' > $@""",
+)
+
 go_test(
     name = "firecracker_test",
     timeout = "long",
@@ -116,9 +127,11 @@ go_test(
         "//server/util/networking",
         "//server/util/status",
         "//server/util/testing/flags",
+        "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_protobuf//testing/protocmp",
         "@org_golang_x_sync//errgroup",
     ],
 )
@@ -153,7 +166,6 @@ go_test(
     ],
     deps = [
         ":firecracker",
-        "//enterprise:bundle",
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/filecache",
@@ -165,6 +177,7 @@ go_test(
         "//enterprise/server/remote_execution/workspace",
         "//enterprise/server/testutil/testcontainer",
         "//enterprise/server/util/ext4",
+        "//enterprise/server/util/oci",
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:scheduler_go_proto",
@@ -175,19 +188,19 @@ go_test(
         "//server/remote_cache/content_addressable_storage_server",
         "//server/remote_cache/digest",
         "//server/testutil/testauth",
-        "//server/testutil/testcache",
         "//server/testutil/testdigest",
         "//server/testutil/testenv",
         "//server/testutil/testfs",
         "//server/util/disk",
-        "//server/util/fileresolver",
         "//server/util/log",
         "//server/util/networking",
         "//server/util/status",
         "//server/util/testing/flags",
+        "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_protobuf//testing/protocmp",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/enterprise/server/remote_execution/containers/firecracker/containeropts.go
+++ b/enterprise/server/remote_execution/containers/firecracker/containeropts.go
@@ -16,6 +16,10 @@ type ContainerOpts struct {
 	// is stored along with the state.
 	VMConfiguration *fcpb.VMConfiguration
 
+	// ExecutorConfig contains executor-level configuration, such as firecracker
+	// and jailer paths / versioning info. This is required.
+	ExecutorConfig *ExecutorConfig
+
 	// Saved state pointing to the snapshot manifest in filecache. When set,
 	// the VMConfiguration will be loaded from the snapshot manifest rather than
 	// the VMConfiguration field.
@@ -45,8 +49,4 @@ type ContainerOpts struct {
 	// allowing for multiple locally-started VMs to avoid using
 	// conflicting network interfaces.
 	ForceVMIdx int
-
-	// The root directory to store all files in. This needs to be
-	// short, less than 38 characters. If unset, /tmp will be used.
-	JailerRoot string
 }

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -20,6 +20,8 @@ import (
 	"syscall"
 	"time"
 
+	_ "embed"
+
 	"github.com/armon/circbuf"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
@@ -78,7 +80,27 @@ var enableUFFD = flag.Bool("executor.firecracker_enable_uffd", false, "Enables u
 var dieOnFirecrackerFailure = flag.Bool("executor.die_on_firecracker_failure", false, "Makes the host executor process die if any command orchestrating or running Firecracker fails. Useful for capturing failures preemptively. WARNING: using this option MAY leave the host machine in an unhealthy state on Firecracker failure; some post-hoc cleanup may be necessary.")
 var workspaceDiskSlackSpaceMB = flag.Int64("executor.firecracker_workspace_disk_slack_space_mb", 2_000, "Extra space to allocate to firecracker workspace disks, in megabytes. ** Experimental **")
 
+//go:embed guest_api_hash.sha256
+var GuestAPIHash string
+
 const (
+	// goinitVersion determines the version of the go init binary that this
+	// executor supports. This version needs to be bumped when making
+	// incompatible changes to the goinit binary. This includes but is not
+	// limited to:
+	//
+	// - Adding new platform prop based features that depend on goinit support,
+	//   such as dockerd init options.
+	// - Adding new features to the vmexec.Exec service.
+	//
+	// We manually maintain this version instead of using a hash of the goinit
+	// binary because we expect the hash to be unstable, likely changing with
+	// each executor release.
+	//
+	// NOTE: this is part of the snapshot cache key, so bumping this version
+	// will make existing cached snapshots unusable.
+	GuestAPIVersion = "0"
+
 	// How long to wait for the VMM to listen on the firecracker socket.
 	firecrackerSocketWaitTimeout = 3 * time.Second
 
@@ -176,18 +198,8 @@ const (
 )
 
 var (
-	locateBinariesOnceMap sync.Map
-	locateBinariesError   error
-	masqueradingOnce      sync.Once
-	masqueradingErr       error
-
-	// kernel + initrd
-	kernelImagePath string
-	initrdImagePath string
-
-	// firecracker + jailer
-	firecrackerBinPath string
-	jailerBinPath      string
+	masqueradingOnce sync.Once
+	masqueradingErr  error
 
 	vmIdx   int
 	vmIdxMu sync.Mutex
@@ -306,13 +318,78 @@ func checkIfFilesExist(targetDir string, files ...string) bool {
 	return true
 }
 
-type Provider struct {
-	env          environment.Env
-	dockerClient *dockerclient.Client
-	buildRoot    string
+// ExecutorConfig contains configuration that is computed once at executor
+// startup and applies to all VMs created by the executor.
+type ExecutorConfig struct {
+	JailerRoot string
+
+	InitrdImagePath       string
+	KernelImagePath       string
+	FirecrackerBinaryPath string
+	JailerBinaryPath      string
+
+	KernelVersion      string
+	FirecrackerVersion string
+	GuestAPIVersion    string
 }
 
-func NewProvider(env environment.Env, hostBuildRoot string) *Provider {
+// GetExecutorConfig computes the ExecutorConfig for this executor instance.
+//
+// WARNING: The given buildRootDir will be used as the jailer root dir. Because
+// of the limitation on the length of unix sock file paths (103), this directory
+// path needs to be short. Specifically, a full sock path will look like:
+// /tmp/firecracker/217d4de0-4b28-401b-891b-18e087718ad1/root/run/fc.sock
+// everything after "/tmp" is 65 characters, so 38 are left for the jailerRoot.
+func GetExecutorConfig(ctx context.Context, buildRootDir string) (*ExecutorConfig, error) {
+	bundle := vmsupport_bundle.Get()
+	initrdPath, err := putFileIntoDir(ctx, bundle, "enterprise/vmsupport/bin/initrd.cpio", buildRootDir, 0755)
+	if err != nil {
+		return nil, err
+	}
+	kernelPath, err := putFileIntoDir(ctx, bundle, "enterprise/vmsupport/bin/vmlinux", buildRootDir, 0755)
+	if err != nil {
+		return nil, err
+	}
+	// TODO: when running as root, these should come from the bundle instead of
+	// $PATH, since we don't need to rely on the user having configured special
+	// perms on these binaries.
+	firecrackerPath, err := exec.LookPath("firecracker")
+	if err != nil {
+		return nil, err
+	}
+	jailerPath, err := exec.LookPath("jailer")
+	if err != nil {
+		return nil, err
+	}
+	kernelDigest, err := digest.ComputeForFile(kernelPath, repb.DigestFunction_SHA256)
+	if err != nil {
+		return nil, err
+	}
+	firecrackerDigest, err := digest.ComputeForFile(firecrackerPath, repb.DigestFunction_SHA256)
+	if err != nil {
+		return nil, err
+	}
+	return &ExecutorConfig{
+		// For now just use the build root dir as the jailer root dir, since
+		// these are guaranteed to be on the same FS.
+		JailerRoot:            buildRootDir,
+		InitrdImagePath:       initrdPath,
+		KernelImagePath:       kernelPath,
+		FirecrackerBinaryPath: firecrackerPath,
+		JailerBinaryPath:      jailerPath,
+		KernelVersion:         kernelDigest.GetHash(),
+		FirecrackerVersion:    firecrackerDigest.GetHash(),
+		GuestAPIVersion:       GuestAPIVersion,
+	}, nil
+}
+
+type Provider struct {
+	env            environment.Env
+	dockerClient   *dockerclient.Client
+	executorConfig *ExecutorConfig
+}
+
+func NewProvider(env environment.Env, hostBuildRoot string) (*Provider, error) {
 	// Best effort trying to initialize the docker client. If it fails, we'll
 	// simply fall back to use skopeo to download and cache container images.
 	client, err := docker.NewClient()
@@ -320,11 +397,16 @@ func NewProvider(env environment.Env, hostBuildRoot string) *Provider {
 		client = nil
 	}
 
-	return &Provider{
-		env:          env,
-		dockerClient: client,
-		buildRoot:    hostBuildRoot,
+	executorConfig, err := GetExecutorConfig(env.GetServerContext(), hostBuildRoot)
+	if err != nil {
+		return nil, err
 	}
+
+	return &Provider{
+		env:            env,
+		dockerClient:   client,
+		executorConfig: executorConfig,
+	}, nil
 }
 
 func (p *Provider) New(ctx context.Context, props *platform.Properties, task *repb.ScheduledTask, state *rnpb.RunnerState, workingDir string) (container.CommandContainer, error) {
@@ -350,7 +432,7 @@ func (p *Provider) New(ctx context.Context, props *platform.Properties, task *re
 		User:                   props.DockerUser,
 		DockerClient:           p.dockerClient,
 		ActionWorkingDirectory: workingDir,
-		JailerRoot:             p.buildRoot,
+		ExecutorConfig:         p.executorConfig,
 	}
 	c, err := NewContainer(ctx, p.env, task.GetExecutionTask(), opts)
 	if err != nil {
@@ -388,6 +470,7 @@ type FirecrackerContainer struct {
 	// including VM startup time
 	currentTaskInitTimeUsec int64
 
+	executorConfig *ExecutorConfig
 	// dockerClient is used to optimize image pulls by reusing image layers from
 	// the Docker cache as well as deduping multiple requests for the same image.
 	dockerClient *dockerclient.Client
@@ -436,37 +519,25 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 	if err != nil {
 		return nil, err
 	}
-
-	// WARNING: because of the limitation on the length of unix sock file
-	// paths (103), this directory path needs to be short. Specifically, a
-	// full sock path will look like:
-	// /tmp/firecracker/217d4de0-4b28-401b-891b-18e087718ad1/root/run/fc.sock
-	// everything after "/tmp" is 65 characters, so 38 are left for the
-	// jailerRoot.
-	if opts.JailerRoot == "" {
-		opts.JailerRoot = "/tmp"
+	if opts.ExecutorConfig == nil {
+		return nil, status.InvalidArgumentError("missing opts.ExecutorConfig")
 	}
-	if len(opts.JailerRoot) > 38 {
-		return nil, status.InvalidArgumentErrorf("JailerRoot must be < 38 characters. Was %q (%d).", opts.JailerRoot, len(opts.JailerRoot))
+	if len(opts.ExecutorConfig.JailerRoot) > 38 {
+		return nil, status.InvalidArgumentErrorf("build root dir %q length %d exceeds 38 character limit", opts.ExecutorConfig.JailerRoot, len(opts.ExecutorConfig.JailerRoot))
 	}
-	if err := disk.EnsureDirectoryExists(opts.JailerRoot); err != nil {
+	if err := disk.EnsureDirectoryExists(opts.ExecutorConfig.JailerRoot); err != nil {
 		return nil, err
 	}
 
-	// Ensure our kernel and initrd exist on the same filesystem where we'll
-	// be jailing containers. This allows us to hardlink these files rather
-	// than copying them around over and over again.
-	if err := copyStaticFiles(context.Background(), env, opts.JailerRoot); err != nil {
-		return nil, err
-	}
 	loader, err := snaploader.New(env)
 	if err != nil {
 		return nil, err
 	}
 
 	c := &FirecrackerContainer{
-		vmConfig:           opts.VMConfiguration,
-		jailerRoot:         opts.JailerRoot,
+		vmConfig:           proto.Clone(opts.VMConfiguration).(*fcpb.VMConfiguration),
+		executorConfig:     opts.ExecutorConfig,
+		jailerRoot:         opts.ExecutorConfig.JailerRoot,
 		dockerClient:       opts.DockerClient,
 		containerImage:     opts.ContainerImage,
 		user:               opts.User,
@@ -478,12 +549,15 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 		cancelVmCtx:        func(err error) {},
 	}
 
+	c.vmConfig.KernelVersion = c.executorConfig.KernelVersion
+	c.vmConfig.FirecrackerVersion = c.executorConfig.FirecrackerVersion
+	c.vmConfig.GuestApiVersion = c.executorConfig.GuestAPIVersion
+
 	if opts.ForceVMIdx != 0 {
 		c.vmIdx = opts.ForceVMIdx
 	}
 
 	if opts.SavedState == nil {
-		c.vmConfig = proto.Clone(c.vmConfig).(*fcpb.VMConfiguration)
 		c.vmConfig.DebugMode = *debugTerminal
 
 		if err := c.newID(ctx); err != nil {
@@ -627,6 +701,10 @@ func alignToMultiple(n int64, multiple int64) int64 {
 	return n + multiple - remainder
 }
 
+func (c *FirecrackerContainer) SnapshotKey() *fcpb.SnapshotKey {
+	return proto.Clone(c.snapshotKey).(*fcpb.SnapshotKey)
+}
+
 // State returns the container state to be persisted to disk so that this
 // container can be reconstructed from the state on disk after an executor
 // restart.
@@ -712,8 +790,8 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 	opts := &snaploader.CacheSnapshotOptions{
 		VMConfiguration:     c.vmConfig,
 		VMStateSnapshotPath: filepath.Join(c.getChroot(), snapshotDetails.vmStateSnapshotName),
-		KernelImagePath:     kernelImagePath,
-		InitrdImagePath:     initrdImagePath,
+		KernelImagePath:     c.executorConfig.KernelImagePath,
+		InitrdImagePath:     c.executorConfig.InitrdImagePath,
 		ChunkedFiles:        map[string]*copy_on_write.COWStore{},
 		Recycled:            c.recycled,
 	}
@@ -785,13 +863,13 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 		Seccomp:           fcclient.SeccompConfig{Enabled: true},
 		DisableValidation: true,
 		JailerCfg: &fcclient.JailerConfig{
-			JailerBinary:   jailerBinPath,
+			JailerBinary:   c.executorConfig.JailerBinaryPath,
 			ChrootBaseDir:  c.jailerRoot,
 			ID:             c.id,
 			UID:            fcclient.Int(unix.Geteuid()),
 			GID:            fcclient.Int(unix.Getegid()),
 			NumaNode:       fcclient.Int(0), // TODO(tylerw): randomize this?
-			ExecFile:       firecrackerBinPath,
+			ExecFile:       c.executorConfig.FirecrackerBinaryPath,
 			ChrootStrategy: fcclient.NewNaiveChrootStrategy(""),
 			Stdout:         c.vmLogWriter(),
 			Stderr:         c.vmLogWriter(),
@@ -1156,6 +1234,13 @@ func (c *FirecrackerContainer) getConfig(ctx context.Context, rootFS, containerF
 	}
 
 	// Pass some flags to the init script.
+	//
+	// !!! WARNING !!!
+	//
+	// When adding new flags, you'll probably want to bump goinitVersion,
+	// otherwise the flags will not actually be used until all of the older
+	// snapshots expire from cache (which can take an indefinite amount of
+	// time).
 	if c.vmConfig.DebugMode {
 		bootArgs = "-debug_mode " + bootArgs
 	}
@@ -1178,8 +1263,8 @@ func (c *FirecrackerContainer) getConfig(ctx context.Context, rootFS, containerF
 	cfg := &fcclient.Config{
 		VMID:            c.id,
 		SocketPath:      firecrackerSocketPath,
-		KernelImagePath: kernelImagePath,
-		InitrdPath:      initrdImagePath,
+		KernelImagePath: c.executorConfig.KernelImagePath,
+		InitrdPath:      c.executorConfig.InitrdImagePath,
 		KernelArgs:      bootArgs,
 		ForwardSignals:  make([]os.Signal, 0),
 		NetNS:           netNS,
@@ -1191,14 +1276,14 @@ func (c *FirecrackerContainer) getConfig(ctx context.Context, rootFS, containerF
 			{Path: firecrackerVSockPath},
 		},
 		JailerCfg: &fcclient.JailerConfig{
-			JailerBinary:   jailerBinPath,
+			JailerBinary:   c.executorConfig.JailerBinaryPath,
 			ChrootBaseDir:  c.jailerRoot,
 			ID:             c.id,
 			UID:            fcclient.Int(unix.Geteuid()),
 			GID:            fcclient.Int(unix.Getegid()),
 			NumaNode:       fcclient.Int(0), // TODO(tylerw): randomize this?
-			ExecFile:       firecrackerBinPath,
-			ChrootStrategy: fcclient.NewNaiveChrootStrategy(kernelImagePath),
+			ExecFile:       c.executorConfig.FirecrackerBinaryPath,
+			ChrootStrategy: fcclient.NewNaiveChrootStrategy(c.executorConfig.KernelImagePath),
 			Stdout:         c.vmLogWriter(),
 			Stderr:         c.vmLogWriter(),
 			CgroupVersion:  cgroupVersion,
@@ -1264,30 +1349,6 @@ func (c *FirecrackerContainer) vmLogWriter() io.Writer {
 		return io.MultiWriter(c.vmLog, os.Stderr)
 	}
 	return c.vmLog
-}
-
-func copyStaticFiles(ctx context.Context, env environment.Env, workingDir string) error {
-	ctx, span := tracing.StartSpan(ctx)
-	defer span.End()
-
-	locateBinariesOnce, _ := locateBinariesOnceMap.LoadOrStore(workingDir, &sync.Once{})
-	locateBinariesOnce.(*sync.Once).Do(func() {
-		fsys := vmsupport_bundle.Get()
-		initrdImagePath, locateBinariesError = putFileIntoDir(ctx, fsys, "enterprise/vmsupport/bin/initrd.cpio", workingDir, 0755)
-		if locateBinariesError != nil {
-			return
-		}
-		kernelImagePath, locateBinariesError = putFileIntoDir(ctx, fsys, "enterprise/vmsupport/bin/vmlinux", workingDir, 0755)
-		if locateBinariesError != nil {
-			return
-		}
-		firecrackerBinPath, locateBinariesError = exec.LookPath("firecracker")
-		if locateBinariesError != nil {
-			return
-		}
-		jailerBinPath, locateBinariesError = exec.LookPath("jailer")
-	})
-	return locateBinariesError
 }
 
 type loopMount struct {

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -28,7 +28,7 @@ var (
 	enableBareRunner           = flag.Bool("executor.enable_bare_runner", false, "Enables running execution commands directly on the host without isolation.")
 	enablePodman               = flag.Bool("executor.enable_podman", false, "Enables running execution commands inside podman container.")
 	enableSandbox              = flag.Bool("executor.enable_sandbox", false, "Enables running execution commands inside of sandbox-exec.")
-	enableFirecracker          = flag.Bool("executor.enable_firecracker", false, "Enables running execution commands inside of firecracker VMs")
+	EnableFirecracker          = flag.Bool("executor.enable_firecracker", false, "Enables running execution commands inside of firecracker VMs")
 	forcedNetworkIsolationType = flag.String("executor.forced_network_isolation_type", "", "If set, run all commands that require networking with this isolation")
 	defaultImage               = flag.String("executor.default_image", Ubuntu16_04Image, "The default docker image to use to warm up executors or if no platform property is set. Ex: gcr.io/flame-public/executor-docker-default:enterprise-v1.5.4")
 	enableVFS                  = flag.Bool("executor.enable_vfs", false, "Whether FUSE based filesystem is enabled.")
@@ -337,7 +337,7 @@ func GetExecutorProperties() *ExecutorProperties {
 		}
 	}
 
-	if *enableFirecracker {
+	if *EnableFirecracker {
 		if runtime.GOOS == "darwin" {
 			log.Warning("Firecracker was enabled, but is unsupported on darwin. Ignoring.")
 		} else {

--- a/enterprise/server/remote_execution/runner/runner_linux.go
+++ b/enterprise/server/remote_execution/runner/runner_linux.go
@@ -37,7 +37,13 @@ func (p *pool) initContainerProviders() error {
 	if podmanProvider != nil {
 		providers[platform.PodmanContainerType] = podmanProvider
 	}
-	providers[platform.FirecrackerContainerType] = firecracker.NewProvider(p.env, *rootDirectory)
+	if *platform.EnableFirecracker {
+		p, err := firecracker.NewProvider(p.env, *rootDirectory)
+		if err != nil {
+			return status.FailedPreconditionErrorf("Failed to initialize firecracker container provider: %s", err)
+		}
+		providers[platform.FirecrackerContainerType] = p
+	}
 	providers[platform.BareContainerType] = &bare.Provider{}
 
 	p.containerProviders = providers

--- a/enterprise/server/vmexec/BUILD
+++ b/enterprise/server/vmexec/BUILD
@@ -2,6 +2,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
+exports_files(srcs = ["vmexec.go"])
+
 go_library(
     name = "vmexec",
     srcs = ["vmexec.go"],

--- a/enterprise/tools/vmstart/vmstart.go
+++ b/enterprise/tools/vmstart/vmstart.go
@@ -125,6 +125,10 @@ func main() {
 	if *forceVMIdx != -1 {
 		vmIdx = *forceVMIdx
 	}
+	cfg, err := firecracker.GetExecutorConfig(ctx, "/tmp/remote_build/")
+	if err != nil {
+		log.Fatalf("Failed to get executor configuration: %s", err)
+	}
 	opts := firecracker.ContainerOpts{
 		VMConfiguration: &fcpb.VMConfiguration{
 			NumCpus:           1,
@@ -135,7 +139,7 @@ func main() {
 		ContainerImage:         *image,
 		ActionWorkingDirectory: emptyActionDir,
 		ForceVMIdx:             vmIdx,
-		JailerRoot:             "/tmp/remote_build/",
+		ExecutorConfig:         cfg,
 	}
 
 	var c *firecracker.FirecrackerContainer

--- a/proto/firecracker.proto
+++ b/proto/firecracker.proto
@@ -21,7 +21,7 @@ message VMConfiguration {
   bool enable_dockerd_tcp = 7;
   string kernel_version = 8;
   string firecracker_version = 9;
-  string goinit_version = 10;
+  string guest_api_version = 10;
 
   // TODO: add container_image here?
 }

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -11,6 +11,7 @@ import (
 	"hash"
 	"io"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -363,6 +364,15 @@ func Compute(in io.Reader, digestType repb.DigestFunction_Value) (*repb.Digest, 
 		Hash:      fmt.Sprintf("%x", h.Sum(nil)),
 		SizeBytes: n,
 	}, nil
+}
+
+func ComputeForFile(path string, digestType repb.DigestFunction_Value) (*repb.Digest, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return Compute(f, digestType)
 }
 
 // AddInvocationIDToDigest combines the hash of the input digest and input invocationID and re-hash.


### PR DESCRIPTION
Once we enable snapshot sharing (either local or remote), this will be required in order to start running VMs on newer software versions (firecracker, kernel, or goinit binary). Otherwise, actions can get stuck on old snapshots for as long as the snapshot remains in remote cache, which can be ~forever. Newer executor versions will potentially be incompatible with older snapshot versions, which can result in various classes of bugs (resume failures, unexpected VM states or execution results, etc.).

The goinit binary version is especially important since changes to this binary are unlikely to be backwards compatible (e.g. adding a new goinit flag is not a backwards compatible change, so we need to bump the goinit version when adding a new flag).

**Related issues**: N/A
