### PR TITLE
Continue to sign new JWTs using old key.

### DIFF
--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -32,9 +32,10 @@ const (
 )
 
 var (
-	jwtKey      = flag.String("auth.jwt_key", "set_the_jwt_in_config", "The key to use when signing JWT tokens.", flag.Secret)
-	newJwtKey   = flag.String("auth.new_jwt_key", "", "If set, new JWTs will be signed using this key. For verifications both this and the old JWT key will be tried.")
-	jwtDuration = flag.Duration("auth.jwt_duration", 6*time.Hour, "Maximum lifetime of the generated JWT.")
+	jwtKey             = flag.String("auth.jwt_key", "set_the_jwt_in_config", "The key to use when signing JWT tokens.", flag.Secret)
+	newJwtKey          = flag.String("auth.new_jwt_key", "", "If set, JWT verifications will try both this and the old JWT key.", flag.Secret)
+	signUsingNewJwtKey = flag.Bool("auth.sign_using_new_jwt_key", false, "If true, new JWTs will be signed using the new JWT key.")
+	jwtDuration        = flag.Duration("auth.jwt_duration", 6*time.Hour, "Maximum lifetime of the generated JWT.")
 )
 
 type Claims struct {
@@ -244,7 +245,11 @@ func assembleJWT(ctx context.Context, c *Claims) (string, error) {
 	expiresAt -= (expiresAt % 60)
 	c.StandardClaims = jwt.StandardClaims{ExpiresAt: expiresAt}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, c)
-	tokenString, err := token.SignedString([]byte(*jwtKey))
+	key := *jwtKey
+	if *newJwtKey != "" && *signUsingNewJwtKey {
+		key = *newJwtKey
+	}
+	tokenString, err := token.SignedString([]byte(key))
 	return tokenString, err
 }
 

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -244,11 +244,7 @@ func assembleJWT(ctx context.Context, c *Claims) (string, error) {
 	expiresAt -= (expiresAt % 60)
 	c.StandardClaims = jwt.StandardClaims{ExpiresAt: expiresAt}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, c)
-	key := *jwtKey
-	if *newJwtKey != "" {
-		key = *newJwtKey
-	}
-	tokenString, err := token.SignedString([]byte(key))
+	tokenString, err := token.SignedString([]byte(*jwtKey))
 	return tokenString, err
 }
 


### PR DESCRIPTION
All apps must be aware of the new key before it can be used for signing.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
