### PR TITLE
Fix BES ip rule handling.

### DIFF
--- a/enterprise/server/iprules/BUILD
+++ b/enterprise/server/iprules/BUILD
@@ -36,6 +36,7 @@ go_test(
         "//proto:iprules_go_proto",
         "//server/environment",
         "//server/testutil/testauth",
+        "//server/util/authutil",
         "//server/util/clientip",
         "//server/util/status",
         "//server/util/testing/flags",

--- a/enterprise/server/iprules/BUILD
+++ b/enterprise/server/iprules/BUILD
@@ -36,6 +36,7 @@ go_test(
         "//proto:iprules_go_proto",
         "//server/environment",
         "//server/testutil/testauth",
+        "//server/util/claims",
         "//server/util/clientip",
         "//server/util/status",
         "//server/util/testing/flags",

--- a/enterprise/server/iprules/BUILD
+++ b/enterprise/server/iprules/BUILD
@@ -36,7 +36,6 @@ go_test(
         "//proto:iprules_go_proto",
         "//server/environment",
         "//server/testutil/testauth",
-        "//server/util/claims",
         "//server/util/clientip",
         "//server/util/status",
         "//server/util/testing/flags",

--- a/enterprise/server/iprules/iprules.go
+++ b/enterprise/server/iprules/iprules.go
@@ -263,10 +263,8 @@ func (s *Service) AuthorizeGroup(ctx context.Context, groupID string) error {
 func (s *Service) Authorize(ctx context.Context) error {
 	u, err := perms.AuthenticatedUser(ctx, s.env)
 	if err != nil {
-		if authutil.IsAnonymousUserError(err) {
-			return nil
-		}
-		return err
+		// If auth failed we don't need to (and can't) apply IP rules.
+		return nil
 	}
 
 	// Server admins in impersonation mode can bypass IP rules.

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -1012,6 +1012,11 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 					}
 					return status.UnknownError(fmt.Sprintf("%v", authError))
 				}
+				if irs := e.env.GetIPRulesService(); irs != nil {
+					if err := irs.Authorize(e.ctx); err != nil {
+						return err
+					}
+				}
 			}
 		}
 

--- a/server/testutil/testauth/testauth.go
+++ b/server/testutil/testauth/testauth.go
@@ -211,6 +211,9 @@ func (a *TestAuthenticator) AuthenticateGRPCRequest(ctx context.Context) (interf
 }
 
 func (a *TestAuthenticator) AuthenticatedUser(ctx context.Context) (interfaces.UserInfo, error) {
+	if err, ok := authutil.AuthErrorFromContext(ctx); ok {
+		return nil, err
+	}
 	if jwt, ok := ctx.Value(jwtHeader).(string); ok {
 		return a.authenticateJWT(jwt)
 	}


### PR DESCRIPTION
Don't return error in IP rules service if auth failed for any reason.

Add separate IP auth check in BES handler.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
