### PR TITLE
[FC] Clean up any firecracker processes in the clean networking script

### DIFF
--- a/tools/firecracker_clean_networking.sh
+++ b/tools/firecracker_clean_networking.sh
@@ -22,3 +22,6 @@ echo >&2 "Restore backup with: sudo iptables-restore < $BACKUP_FILE"
 
 echo >&2 "Cleaning up iptables veth* rules"
 grep -vP '\bveth' <<<"$IPTABLES" | uniq | iptables-restore
+
+echo >&2 "Cleaning up any remaining firecracker processes"
+killall firecracker


### PR DESCRIPTION
Leftover VMs that weren't properly cleaned up can interfere when trying to run additional VMs
