### PR TITLE
Move toolchain registration into WORKSPACE

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,9 +39,8 @@ build:remote-shared --jobs=100
 build:remote-shared --verbose_failures
 build:remote-shared --platforms=@buildbuddy_toolchain//:platform_linux
 build:remote-shared --host_platform=@buildbuddy_toolchain//:platform_linux
-build:remote-shared --crosstool_top=@buildbuddy_toolchain//:ubuntu_cc_toolchain_suite
-build:remote-shared --extra_toolchains=@buildbuddy_toolchain//:ubuntu_cc_toolchain
-build:remote-shared --extra_toolchains=//:sh_toolchain
+
+build --incompatible_enable_cc_toolchain_resolution
 
 # Build with --config=remote to use BuildBuddy RBE.
 build:remote --config=remote-shared
@@ -53,27 +52,9 @@ build:remote-dev --config=remote-shared
 build:remote-dev --config=cache-dev
 build:remote-dev --remote_executor=grpcs://buildbuddy.buildbuddy.dev
 
-# Build with --config=target-linux to
-#   - Tell Bazel to build binaries for linux
-#   - Tell Bazel to use Linux-compatible toolchains to build
-build:target-linux --cpu=k8
-build:target-linux --host_cpu=k8
-# Write linux-target build outputs in a separate directory from host build outputs.
-build:target-linux --experimental_platform_in_output_dir
-
-# Build with --config=remote-target-linux* to build on remote Linux Executors.
-# from non-Linux machines (e.g. MacOS).
-#
-# Example usage in user.bazelrc:
-#   build --remote_header=x-buildbuddy-api-key=<foo>
-#   build:x --config=remote-target-linux
-#
-# Then you could start building/testing remotely with MacOS with:
-#   bazel test --config=x //...
-build:remote-target-linux --config=target-linux
-build:remote-target-linux --config=remote
-build:remote-target-linux-dev --config=target-linux
-build:remote-target-linux-dev --config=remote-dev
+# Write build outputs in a platform-specific directory,
+# avoid outputs being wiped and rewritten when switching between platforms.
+build --experimental_platform_in_output_dir
 
 # Configuration used for GitHub actions-based CI
 build:ci --config=remote

--- a/.bazelrc
+++ b/.bazelrc
@@ -38,7 +38,7 @@ build:remote-shared --remote_download_minimal
 build:remote-shared --jobs=100
 build:remote-shared --verbose_failures
 build:remote-shared --platforms=@buildbuddy_toolchain//:platform_linux
-build:remote-shared --host_platform=@buildbuddy_toolchain//:platform_linux
+build:remote-shared --extra_execution_platforms=@buildbuddy_toolchain//:platform_linux
 
 build --incompatible_enable_cc_toolchain_resolution
 

--- a/BUILD
+++ b/BUILD
@@ -266,20 +266,3 @@ platform(
         "enable-vfs": "true",
     },
 )
-
-# TODO(bduffany): The sh_toolchain config here is a workaround for
-# https://github.com/aspect-build/rules_swc/issues/20
-# We should probably either move these to the buildbuddy-toolchain repo
-# or add a symlink from /usr/bin/bash -> /bin/bash to remove the need for these.
-load("@bazel_tools//tools/sh:sh_toolchain.bzl", "sh_toolchain")
-
-sh_toolchain(
-    name = "bash_rbe_ubuntu1604",
-    path = "/bin/bash",
-)
-
-toolchain(
-    name = "sh_toolchain",
-    toolchain = ":bash_rbe_ubuntu1604",
-    toolchain_type = "@bazel_tools//tools/sh:toolchain_type",
-)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -461,3 +461,8 @@ load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_
 rules_proto_dependencies()
 
 rules_proto_toolchains()
+
+register_toolchains(
+    "//toolchains:sh_toolchain",
+    "@buildbuddy_toolchain//:ubuntu_cc_toolchain",
+)

--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -1,0 +1,19 @@
+# TODO(bduffany): The sh_toolchain config here is a workaround for
+# https://github.com/aspect-build/rules_swc/issues/20
+# We should probably either move these to the buildbuddy-toolchain repo
+# or add a symlink from /usr/bin/bash -> /bin/bash to remove the need for these.
+load("@bazel_tools//tools/sh:sh_toolchain.bzl", "sh_toolchain")
+
+sh_toolchain(
+    name = "bash_rbe_ubuntu1604",
+    path = "/bin/bash",
+)
+
+toolchain(
+    name = "sh_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+    ],
+    toolchain = ":bash_rbe_ubuntu1604",
+    toolchain_type = "@bazel_tools//tools/sh:toolchain_type",
+)


### PR DESCRIPTION
Register our toolchains inside WORKSPACE.
Then enable automatic cc toolchain resolution for auto selection based
on platform compatibility.

This let us get rid of the manual toolchain declaration when building with
`--config=remote`. Subsequently, we won't need to specify `--cpu` and
`--host_cpu` to aid cc_toolchain_suite detection.
