### PR TITLE
Fix error handling in lease reconnect

### DIFF
--- a/enterprise/server/scheduling/task_leaser/task_leaser.go
+++ b/enterprise/server/scheduling/task_leaser/task_leaser.go
@@ -79,6 +79,7 @@ func (t *TaskLeaser) pingServer(ctx context.Context) ([]byte, error) {
 		if !*enableReconnect || !status.IsUnavailableError(err) {
 			return nil, err
 		}
+		originalErr := err
 		// Server is unavailable (e.g. shutting down); retry. Note that we don't
 		// start the retry context timeout until after observing the disconnect
 		// error.
@@ -93,7 +94,7 @@ func (t *TaskLeaser) pingServer(ctx context.Context) ([]byte, error) {
 			r = retry.DefaultWithContext(ctx)
 		}
 		if !r.Next() {
-			return nil, err
+			return nil, originalErr
 		}
 	}
 	if rsp.GetReconnectToken() != "" {


### PR DESCRIPTION
Unclear whether this was actually happening in practice, but I noticed while re-checking this code that we are returning the wrong error when there are no more retries due to the context being cancelled.

**Related issues**: N/A
