### PR TITLE
[FC] Eagerly fetch chunks in the cow store

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/BUILD
+++ b/enterprise/server/remote_execution/copy_on_write/BUILD
@@ -11,9 +11,12 @@ go_library(
         "//server/environment",
         "//server/interfaces",
         "//server/remote_cache/digest",
+        "//server/util/log",
         "//server/util/status",
         "@org_golang_x_exp//maps",
+        "@org_golang_x_sync//errgroup",
         "@org_golang_x_sys//unix",
+        "@org_golang_x_time//rate",
     ],
 )
 

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -15,9 +15,12 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"golang.org/x/exp/maps"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
+	"golang.org/x/time/rate"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
@@ -25,6 +28,22 @@ import (
 const (
 	// Suffix used for dirtied chunks.
 	dirtySuffix = ".dirty"
+
+	// We don't want this to be too big, because we want to prioritize fetching
+	// more recently accessed data. If the chan is too big, we may waste time
+	// churning through stale data
+	eagerFetchChanSize = 100
+
+	maxEagerFetchesPerSec = 100
+
+	// Max number of goroutines allowed to run concurrently when eagerly
+	// fetching chunks
+	eagerFetchConcurrency = 4
+
+	// If we access a chunk, we will queue this number of contiguous chunks
+	// to be eagerly fetched in the background, anticipating that they will
+	// also be accessed
+	numChunksToEagerFetch = 4
 )
 
 // COWStore To enable copy-on-write support for a file, it can be split into
@@ -66,6 +85,10 @@ type COWStore struct {
 
 	// Concurrency-safe pool of buffers that can be used for copying chunks
 	copyBufPool sync.Pool
+
+	eagerFetchChan chan *eagerFetchData
+	eagerFetchEg   *errgroup.Group
+	quitChan       chan struct{}
 }
 
 // NewCOWStore creates a COWStore from the given chunks. The chunks should be
@@ -81,7 +104,7 @@ func NewCOWStore(ctx context.Context, env environment.Env, chunks []*Mmap, chunk
 		chunkMap[c.Offset] = c
 	}
 
-	return &COWStore{
+	s := &COWStore{
 		ctx:                ctx,
 		env:                env,
 		remoteInstanceName: remoteInstanceName,
@@ -98,7 +121,17 @@ func NewCOWStore(ctx context.Context, env environment.Env, chunks []*Mmap, chunk
 		chunkSizeBytes: chunkSizeBytes,
 		totalSizeBytes: totalSizeBytes,
 		ioBlockSize:    int64(stat.Sys().(*syscall.Stat_t).Blksize),
-	}, nil
+		eagerFetchChan: make(chan *eagerFetchData, eagerFetchChanSize),
+		eagerFetchEg:   &errgroup.Group{},
+		quitChan:       make(chan struct{}, 0),
+	}
+
+	s.eagerFetchEg.Go(func() error {
+		s.eagerFetchChunksInBackground()
+		return nil
+	})
+
+	return s, nil
 }
 
 // GetRelativeOffsetFromChunkStart returns the relative offset from the
@@ -138,6 +171,8 @@ func (c *COWStore) GetChunkStartAddressAndSize(offset uintptr, write bool) (uint
 func (c *COWStore) GetPageAddress(offset uintptr, write bool) (uintptr, error) {
 	chunkStartOffset := c.chunkStartOffset(int64(offset))
 	chunkRelativeAddress := offset - uintptr(chunkStartOffset)
+
+	c.eagerFetchNextChunks(chunkStartOffset)
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -188,6 +223,8 @@ func (c *COWStore) ReadAt(p []byte, off int64) (int, error) {
 
 	chunkOffset := c.chunkStartOffset(off)
 	n := 0
+
+	c.eagerFetchNextChunks(chunkOffset)
 
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -260,6 +297,8 @@ func (c *COWStore) WriteAt(p []byte, off int64) (int, error) {
 	chunkOffset := c.chunkStartOffset(off)
 	n := 0
 
+	c.eagerFetchNextChunks(chunkOffset)
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -305,6 +344,10 @@ func (c *COWStore) Sync() error {
 }
 
 func (s *COWStore) Close() error {
+	// Close background goroutine eagerly fetching chunks
+	close(s.quitChan)
+	s.eagerFetchEg.Wait()
+
 	var lastErr error
 	// TODO: maybe parallelize
 	for _, c := range s.chunks {
@@ -471,6 +514,73 @@ func (s *COWStore) initDirtyChunk(offset int64, size int64) (ogChunk *Mmap, newC
 	s.dirty[offset] = true
 
 	return ogChunk, newChunk, nil
+}
+
+type eagerFetchData struct {
+	// Chunk offset to eagerly fetch
+	offset int64
+}
+
+func (s *COWStore) eagerFetchNextChunks(offset int64) {
+	currentOffset := offset
+	for i := 0; i < numChunksToEagerFetch; i++ {
+		s.sendNonBlockingEagerFetch(currentOffset)
+		currentOffset += s.chunkSizeBytes
+	}
+}
+
+func (s *COWStore) sendNonBlockingEagerFetch(offset int64) {
+	select {
+	case s.eagerFetchChan <- &eagerFetchData{offset: offset}:
+	default:
+		log.Debug("COWStore eager fetch chan full")
+	}
+}
+
+func (s *COWStore) eagerFetchChunksInBackground() {
+	rateLimiter := rate.NewLimiter(rate.Limit(maxEagerFetchesPerSec), 1)
+	eg := &errgroup.Group{}
+	eg.SetLimit(eagerFetchConcurrency)
+
+	for {
+		select {
+		case <-s.quitChan:
+			_ = eg.Wait()
+			return
+		case d := <-s.eagerFetchChan:
+			if err := rateLimiter.Wait(s.ctx); err != nil {
+				if err != nil {
+					log.Errorf("COWStore eager fetch rate limiter failed, stopping eager fetches: %s", err)
+				}
+				_ = eg.Wait()
+				return
+			}
+			eg.Go(func() error {
+				err := s.fetchChunk(d.offset)
+				if err != nil {
+					log.Warningf("COWStore eager fetch chunk failed with: %s", err)
+				}
+				return nil
+			})
+		}
+	}
+}
+
+func (s *COWStore) fetchChunk(offset int64) error {
+	s.mu.RLock()
+	c := s.chunks[offset]
+	s.mu.RUnlock()
+
+	// Skip holes
+	if c == nil {
+		return nil
+	}
+
+	var err error
+	if !c.safeReadMapped() {
+		err = c.initMap()
+	}
+	return err
 }
 
 // ConvertFileToCOW reads a file sequentially, splitting it into fixed size,


### PR DESCRIPTION
If we access a snapshot chunk, use a background queue to eagerly fetch the next X contiguous chunks, anticipating that they will also be accessed.

**Some performance results:**
The performance tests build the buildbuddy repo from a snapshot that is cached in the remote cache, but nothing is cached locally in filecache. Every testing scenario was run 6 times. 

Baseline: (45.8s - 50.6s)
Best config - 8 concurrent threads, max 1000 fetches per sec: (24.9s - 27.2s)

**Some additional sample tests for context:**

4 concurrent threads, max 1000 fetches per sec: (25.7s - 27.6s)
4 concurrent threads, max 500 fetches per sec: (28.5 - 29.5s)
8 concurrent threads, max 100 fetches per sec: (37.5s - 40.2)
-  Additional threads not that helpful, because rate limiter is so low
4 concurrent threads, max 100 fetches per sec: (38.1 - 42.3)
4 concurrent threads, max 1000 per sec, 10 contiguous chunks: (27.5 - 30)
- All other tests are with 4 contiguous chunks
- Fetching more chunks each time leads to a slowdown in performance
