### PR TITLE
Support RANGELEASE consistency

### DIFF
--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -376,7 +376,7 @@ func (rc *RaftCache) Reader(ctx context.Context, r *rspb.ResourceName, uncompres
 	if err != nil {
 		return nil, err
 	}
-	rsp, err := rc.sender.SyncRead(ctx, fileMetadataKey, req)
+	rsp, err := rc.sender.SyncRead(ctx, fileMetadataKey, req, sender.WithConsistencyMode(rfpb.Header_RANGELEASE))
 	if err != nil {
 		return nil, err
 	}
@@ -519,7 +519,7 @@ func (rc *RaftCache) findMissingResourceNames(ctx context.Context, resourceNames
 			}
 		}
 		return missingDigests, nil
-	})
+	}, sender.WithConsistencyMode(rfpb.Header_RANGELEASE))
 	if err != nil {
 		return nil, err
 	}
@@ -584,7 +584,7 @@ func (rc *RaftCache) GetMulti(ctx context.Context, resources []*rspb.ResourceNam
 			}
 		}
 		return found, nil
-	})
+	}, sender.WithConsistencyMode(rfpb.Header_RANGELEASE))
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/raft/nodeliveness/BUILD
+++ b/enterprise/server/raft/nodeliveness/BUILD
@@ -26,6 +26,7 @@ go_test(
     deps = [
         ":nodeliveness",
         "//enterprise/server/raft/constants",
+        "//enterprise/server/raft/sender",
         "//proto:raft_go_proto",
         "//server/util/status",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/raft/nodeliveness/nodeliveness_test.go
+++ b/enterprise/server/raft/nodeliveness/nodeliveness_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/nodeliveness"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/stretchr/testify/require"
 
@@ -75,7 +76,7 @@ func (tp *testingProposer) SyncPropose(ctx context.Context, _ []byte, batch *rfp
 	return nil, nil
 }
 
-func (tp *testingProposer) SyncRead(ctx context.Context, _ []byte, batch *rfpb.BatchCmdRequest) (*rfpb.BatchCmdResponse, error) {
+func (tp *testingProposer) SyncRead(ctx context.Context, _ []byte, batch *rfpb.BatchCmdRequest, mods ...sender.Option) (*rfpb.BatchCmdResponse, error) {
 	return nil, status.UnimplementedError("not implemented in testingProposer")
 }
 

--- a/enterprise/server/raft/rangelease/rangelease_test.go
+++ b/enterprise/server/raft/rangelease/rangelease_test.go
@@ -136,22 +136,8 @@ func (t *testingSender) SyncPropose(ctx context.Context, key []byte, batch *rfpb
 	return resp, nil
 }
 
-func (t *testingSender) SyncRead(ctx context.Context, key []byte, batch *rfpb.BatchCmdRequest) (*rfpb.BatchCmdResponse, error) {
-	buf, err := proto.Marshal(batch)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := t.tp.SyncRead(ctx, shardID, buf)
-	if err != nil {
-		return nil, err
-	}
-
-	resp := &rfpb.BatchCmdResponse{}
-	if err := proto.Unmarshal(res.([]byte), resp); err != nil {
-		return nil, err
-	}
-	return resp, nil
+func (t *testingSender) SyncRead(ctx context.Context, key []byte, batch *rfpb.BatchCmdRequest, mods ...sender.Option) (*rfpb.BatchCmdResponse, error) {
+	return nil, status.UnimplementedError("not implemented in testingSender")
 }
 
 func newTestingProposerAndSender(t testing.TB) (*testingProposer, *testingSender) {

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -22,7 +22,7 @@ import (
 
 type ISender interface {
 	SyncPropose(ctx context.Context, key []byte, batch *rfpb.BatchCmdRequest) (*rfpb.BatchCmdResponse, error)
-	SyncRead(ctx context.Context, key []byte, batch *rfpb.BatchCmdRequest) (*rfpb.BatchCmdResponse, error)
+	SyncRead(ctx context.Context, key []byte, batch *rfpb.BatchCmdRequest, mods ...Option) (*rfpb.BatchCmdResponse, error)
 }
 
 type Sender struct {
@@ -362,7 +362,7 @@ func (s *Sender) SyncPropose(ctx context.Context, key []byte, batchCmd *rfpb.Bat
 	return rsp.GetBatch(), nil
 }
 
-func (s *Sender) SyncRead(ctx context.Context, key []byte, batchCmd *rfpb.BatchCmdRequest) (*rfpb.BatchCmdResponse, error) {
+func (s *Sender) SyncRead(ctx context.Context, key []byte, batchCmd *rfpb.BatchCmdRequest, mods ...Option) (*rfpb.BatchCmdResponse, error) {
 	var rsp *rfpb.SyncReadResponse
 	err := s.Run(ctx, key, func(c rfspb.ApiClient, h *rfpb.Header) error {
 		r, err := c.SyncRead(ctx, &rfpb.SyncReadRequest{
@@ -374,7 +374,7 @@ func (s *Sender) SyncRead(ctx context.Context, key []byte, batchCmd *rfpb.BatchC
 		}
 		rsp = r
 		return nil
-	})
+	}, mods...)
 	if err != nil {
 		return nil, err
 	}

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -397,6 +397,7 @@ message Header {
   enum ConsistencyMode {
     LINEARIZABLE = 0;
     STALE = 1;
+    RANGELEASE = 2;
   }
 
   // The consistency mode that should be used for this operation.


### PR DESCRIPTION
This gives the performance of STALE reads with the consistency guarantees of a LINEARIZABLE raft read.