### PR TITLE
Don't cache image pull auth result during initial warmup

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -780,11 +780,10 @@ func (p *pool) warmupImage(ctx context.Context, cfg *WarmupConfig) error {
 	if err != nil {
 		return err
 	}
-	err = container.PullImageIfNecessary(
-		ctx, p.env,
-		c, creds, platProps.ContainerImage,
-	)
-	if err != nil {
+	// Note: intentionally bypassing PullImageIfNecessary here to avoid caching
+	// the auth result, since it makes it tricker to debug per-action
+	// misconfiguration.
+	if err := c.PullImage(ctx, creds); err != nil {
 		return err
 	}
 	log.Infof("Warmup: %s pulled image %q in %s", cfg.Isolation, cfg.Image, time.Since(start))


### PR DESCRIPTION
The current behavior is fine from an auth perspective but makes it trickier to identify misconfigured per-action credentials for self-hosted executors, since it would take 15 minutes for the warmup cache token to expire, and only then would we start actually returning an error for the misconfigured per-action credentials.

**Related issues**: N/A
