### PR TITLE
Expand COW concurrency tests

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/BUILD
+++ b/enterprise/server/remote_execution/copy_on_write/BUILD
@@ -33,6 +33,7 @@ go_test(
     srcs = ["copy_on_write_test.go"],
     deps = [
         ":copy_on_write",
+        "//enterprise/server/remote_execution/copy_on_write/cow_cgo_testutil",
         "//enterprise/server/remote_execution/snaputil",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
@@ -64,6 +65,7 @@ go_test(
     tags = ["performance"],
     deps = [
         ":copy_on_write",
+        "//enterprise/server/remote_execution/copy_on_write/cow_cgo_testutil",
         "//enterprise/server/remote_execution/snaputil",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",

--- a/enterprise/server/remote_execution/copy_on_write/cow_cgo_testutil/BUILD
+++ b/enterprise/server/remote_execution/copy_on_write/cow_cgo_testutil/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "cow_cgo_testutil",
+    testonly = 1,
+    srcs = ["cow_cgo_testutil.go"],
+    cgo = True,
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write/cow_cgo_testutil",
+    visibility = ["//visibility:public"],
+)
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/remote_execution/copy_on_write/cow_cgo_testutil/cow_cgo_testutil.go
+++ b/enterprise/server/remote_execution/copy_on_write/cow_cgo_testutil/cow_cgo_testutil.go
@@ -1,0 +1,21 @@
+// This package exists only because gazelle complains if we try to use cgo
+// directly in copy_on_write_test.go
+package cow_cgo_testutil
+
+/*
+#define _GNU_SOURCE
+#include <fcntl.h>
+
+int get_F_OFD_SETLKW() {
+#ifdef F_OFD_SETLKW
+	return F_OFD_SETLKW;
+#else
+	return 0;
+#endif
+}
+*/
+import "C"
+
+var (
+	F_OFD_SETLKW = int(C.get_F_OFD_SETLKW())
+)


### PR DESCRIPTION
* Add a `StoreTester` which allows reading and writing random ranges concurrently and also validates byte contents (rather than just checking whether the race detector is triggered)
* Use byte-range locking to avoid concurrent writes of overlapping byte ranges. In practice, the guest's block device driver will avoid doing these types of writes, because block device files do not guarantee atomicity for `read()` or `write()`. If we can assume that overlapping byte writes will never happen concurrently, we can acquire finer-grained locks (e.g. writes can lock per-chunk instead of locking the whole store)

**Related issues**: N/A
