### PR TITLE
Allow flag utils to work with CLI subcommands

### DIFF
--- a/server/endpoint_urls/events_api_url/BUILD
+++ b/server/endpoint_urls/events_api_url/BUILD
@@ -5,5 +5,5 @@ go_library(
     srcs = ["events_api_url.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/events_api_url",
     visibility = ["//visibility:public"],
-    deps = ["//server/util/flagutil/types"],
+    deps = ["//server/util/flag"],
 )

--- a/server/endpoint_urls/events_api_url/events_api_url.go
+++ b/server/endpoint_urls/events_api_url/events_api_url.go
@@ -3,10 +3,10 @@ package events_api_url
 import (
 	"net/url"
 
-	flagtypes "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 )
 
-var eventsAPIURL = flagtypes.URLFromString("app.events_api_url", "", "Overrides the default build event protocol gRPC address shown by BuildBuddy on the configuration screen.")
+var eventsAPIURL = flag.URL("app.events_api_url", "", "Overrides the default build event protocol gRPC address shown by BuildBuddy on the configuration screen.")
 
 func WithPath(path string) *url.URL {
 	return eventsAPIURL.ResolveReference(&url.URL{Path: path})

--- a/server/endpoint_urls/remote_exec_api_url/BUILD
+++ b/server/endpoint_urls/remote_exec_api_url/BUILD
@@ -5,5 +5,5 @@ go_library(
     srcs = ["remote_exec_api_url.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/remote_exec_api_url",
     visibility = ["//visibility:public"],
-    deps = ["//server/util/flagutil/types"],
+    deps = ["//server/util/flag"],
 )

--- a/server/endpoint_urls/remote_exec_api_url/remote_exec_api_url.go
+++ b/server/endpoint_urls/remote_exec_api_url/remote_exec_api_url.go
@@ -3,10 +3,10 @@ package remote_exec_api_url
 import (
 	"net/url"
 
-	flagtypes "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 )
 
-var remoteExecAPIURL = flagtypes.URLFromString("app.remote_execution_api_url", "", "Overrides the default remote execution protocol gRPC address shown by BuildBuddy on the configuration screen.")
+var remoteExecAPIURL = flag.URL("app.remote_execution_api_url", "", "Overrides the default remote execution protocol gRPC address shown by BuildBuddy on the configuration screen.")
 
 func WithPath(path string) *url.URL {
 	return remoteExecAPIURL.ResolveReference(&url.URL{Path: path})

--- a/server/util/flag/BUILD
+++ b/server/util/flag/BUILD
@@ -5,5 +5,8 @@ go_library(
     srcs = ["flag.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/flag",
     visibility = ["//visibility:public"],
-    deps = ["//server/util/flagutil/types/autoflags"],
+    deps = [
+        "//server/util/flagutil/common",
+        "//server/util/flagutil/types/autoflags",
+    ],
 )

--- a/server/util/flag/flag.go
+++ b/server/util/flag/flag.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types/autoflags"
 )
 
@@ -26,35 +27,35 @@ func Parse() {
 }
 
 func String(name string, value string, usage string, tags ...autoflags.Taggable) *string {
-	return autoflags.New(name, value, usage, tags...)
+	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
 func Bool(name string, value bool, usage string, tags ...autoflags.Taggable) *bool {
-	return autoflags.New(name, value, usage, tags...)
+	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
 func Int(name string, value int, usage string, tags ...autoflags.Taggable) *int {
-	return autoflags.New(name, value, usage, tags...)
+	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
 func Int64(name string, value int64, usage string, tags ...autoflags.Taggable) *int64 {
-	return autoflags.New(name, value, usage, tags...)
+	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
 func UInt(name string, value uint, usage string, tags ...autoflags.Taggable) *uint {
-	return autoflags.New(name, value, usage, tags...)
+	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
 func UInt64(name string, value uint64, usage string, tags ...autoflags.Taggable) *uint64 {
-	return autoflags.New(name, value, usage, tags...)
+	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
 func Float64(name string, value float64, usage string, tags ...autoflags.Taggable) *float64 {
-	return autoflags.New(name, value, usage, tags...)
+	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
 func Duration(name string, value time.Duration, usage string, tags ...autoflags.Taggable) *time.Duration {
-	return autoflags.New(name, value, usage, tags...)
+	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
 func URL(name string, value string, usage string, tags ...autoflags.Taggable) *url.URL {
@@ -63,13 +64,13 @@ func URL(name string, value string, usage string, tags ...autoflags.Taggable) *u
 		log.Fatalf("Error parsing default URL value '%s' for flag: %v", value, err)
 		return nil
 	}
-	return autoflags.New(name, *u, usage, tags...)
+	return autoflags.New(common.DefaultFlagSet, name, *u, usage, tags...)
 }
 
 func Slice[T any](name string, value []T, usage string, tags ...autoflags.Taggable) *[]T {
-	return autoflags.New(name, value, usage, tags...)
+	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
 func Struct[T any](name string, value T, usage string, tags ...autoflags.Taggable) *T {
-	return autoflags.New(name, value, usage, tags...)
+	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }

--- a/server/util/flagutil/common/common_test.go
+++ b/server/util/flagutil/common/common_test.go
@@ -38,101 +38,101 @@ func replaceFlagsForTesting(t *testing.T) *flag.FlagSet {
 func TestSetValueForFlagName(t *testing.T) {
 	flags := replaceFlagsForTesting(t)
 	flagBool := flags.Bool("bool", false, "")
-	err := common.SetValueForFlagName("bool", true, map[string]struct{}{}, true)
+	err := common.SetValueForFlagName(flags, "bool", true, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, true, *flagBool)
 
 	flags = replaceFlagsForTesting(t)
 	flagBool = flags.Bool("bool", false, "")
-	err = common.SetValueForFlagName("bool", true, map[string]struct{}{"bool": {}}, true)
+	err = common.SetValueForFlagName(flags, "bool", true, map[string]struct{}{"bool": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, false, *flagBool)
 
 	flags = replaceFlagsForTesting(t)
 	flagInt := flags.Int("int", 2, "")
-	err = common.SetValueForFlagName("int", 1, map[string]struct{}{}, true)
+	err = common.SetValueForFlagName(flags, "int", 1, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, 1, *flagInt)
 
 	flags = replaceFlagsForTesting(t)
 	flagInt = flags.Int("int", 2, "")
-	err = common.SetValueForFlagName("int", 1, map[string]struct{}{"int": {}}, true)
+	err = common.SetValueForFlagName(flags, "int", 1, map[string]struct{}{"int": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, 2, *flagInt)
 
 	flags = replaceFlagsForTesting(t)
 	flagInt64 := flags.Int64("int64", 2, "")
-	err = common.SetValueForFlagName("int64", 1, map[string]struct{}{}, true)
+	err = common.SetValueForFlagName(flags, "int64", 1, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), *flagInt64)
 
 	flags = replaceFlagsForTesting(t)
 	flagInt64 = flags.Int64("int64", 2, "")
-	err = common.SetValueForFlagName("int64", 1, map[string]struct{}{"int64": {}}, true)
+	err = common.SetValueForFlagName(flags, "int64", 1, map[string]struct{}{"int64": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), *flagInt64)
 
 	flags = replaceFlagsForTesting(t)
 	flagUint := flags.Uint("uint", 2, "")
-	err = common.SetValueForFlagName("uint", 1, map[string]struct{}{}, true)
+	err = common.SetValueForFlagName(flags, "uint", 1, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, uint(1), *flagUint)
 
 	flags = replaceFlagsForTesting(t)
 	flagUint = flags.Uint("uint", 2, "")
-	err = common.SetValueForFlagName("uint", 1, map[string]struct{}{"uint": {}}, true)
+	err = common.SetValueForFlagName(flags, "uint", 1, map[string]struct{}{"uint": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, uint(2), *flagUint)
 
 	flags = replaceFlagsForTesting(t)
 	flagUint64 := flags.Uint64("uint64", 2, "")
-	err = common.SetValueForFlagName("uint64", 1, map[string]struct{}{}, true)
+	err = common.SetValueForFlagName(flags, "uint64", 1, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1), *flagUint64)
 
 	flags = replaceFlagsForTesting(t)
 	flagUint64 = flags.Uint64("uint64", 2, "")
-	err = common.SetValueForFlagName("uint64", 1, map[string]struct{}{"uint64": {}}, true)
+	err = common.SetValueForFlagName(flags, "uint64", 1, map[string]struct{}{"uint64": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(2), *flagUint64)
 
 	flags = replaceFlagsForTesting(t)
 	flagFloat64 := flags.Float64("float64", 2, "")
-	err = common.SetValueForFlagName("float64", 1, map[string]struct{}{}, true)
+	err = common.SetValueForFlagName(flags, "float64", 1, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, float64(1), *flagFloat64)
 
 	flags = replaceFlagsForTesting(t)
 	flagFloat64 = flags.Float64("float64", 2, "")
-	err = common.SetValueForFlagName("float64", 1, map[string]struct{}{"float64": {}}, true)
+	err = common.SetValueForFlagName(flags, "float64", 1, map[string]struct{}{"float64": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, float64(2), *flagFloat64)
 
 	flags = replaceFlagsForTesting(t)
 	flagString := flags.String("string", "2", "")
-	err = common.SetValueForFlagName("string", "1", map[string]struct{}{}, true)
+	err = common.SetValueForFlagName(flags, "string", "1", map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, "1", *flagString)
 
 	flags = replaceFlagsForTesting(t)
 	flagString = flags.String("string", "2", "")
-	err = common.SetValueForFlagName("string", "1", map[string]struct{}{"string": {}}, true)
+	err = common.SetValueForFlagName(flags, "string", "1", map[string]struct{}{"string": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, "2", *flagString)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagURL := flagtypes.URLFromString("url", "https://www.example.com", "")
+	flagURL := flagtypes.URLFromString(flags, "url", "https://www.example.com", "")
 	u, err := url.Parse("https://www.example.com:8080")
 	require.NoError(t, err)
-	err = common.SetValueForFlagName("url", *u, map[string]struct{}{}, true)
+	err = common.SetValueForFlagName(flags, "url", *u, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, url.URL{Scheme: "https", Host: "www.example.com:8080"}, *flagURL)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagURL = flagtypes.URLFromString("url", "https://www.example.com", "")
+	flagURL = flagtypes.URLFromString(flags, "url", "https://www.example.com", "")
 	u, err = url.Parse("https://www.example.com:8080")
 	require.NoError(t, err)
-	err = common.SetValueForFlagName("url", *u, map[string]struct{}{"url": {}}, true)
+	err = common.SetValueForFlagName(flags, "url", *u, map[string]struct{}{"url": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, url.URL{Scheme: "https", Host: "www.example.com"}, *flagURL)
 
@@ -140,55 +140,55 @@ func TestSetValueForFlagName(t *testing.T) {
 	stringSlice := make([]string, 2)
 	stringSlice[0] = "1"
 	stringSlice[1] = "2"
-	flagtypes.StringSliceVar(&stringSlice, "string_slice", stringSlice, "")
-	err = common.SetValueForFlagName("string_slice", []string{"3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, map[string]struct{}{}, true)
+	flagtypes.StringSliceVar(flags, &stringSlice, "string_slice", stringSlice, "")
+	err = common.SetValueForFlagName(flags, "string_slice", []string{"3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, stringSlice)
 
 	flags = replaceFlagsForTesting(t)
-	flagStringSlice := flagtypes.StringSlice("string_slice", []string{"1", "2"}, "")
-	err = common.SetValueForFlagName("string_slice", []string{"3"}, map[string]struct{}{"string_slice": {}}, true)
+	flagStringSlice := flagtypes.StringSlice(flags, "string_slice", []string{"1", "2"}, "")
+	err = common.SetValueForFlagName(flags, "string_slice", []string{"3"}, map[string]struct{}{"string_slice": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2", "3"}, *(*[]string)(flags.Lookup("string_slice").Value.(*flagtypes.StringSliceFlag)))
 	assert.Equal(t, []string{"1", "2", "3"}, *flagStringSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagStringSlice = flagtypes.StringSlice("string_slice", []string{"1", "2"}, "")
-	err = common.SetValueForFlagName("string_slice", []string{"3"}, map[string]struct{}{}, false)
+	flagStringSlice = flagtypes.StringSlice(flags, "string_slice", []string{"1", "2"}, "")
+	err = common.SetValueForFlagName(flags, "string_slice", []string{"3"}, map[string]struct{}{}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"3"}, *flagStringSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagStringSlice = flagtypes.StringSlice("string_slice", []string{"1", "2"}, "")
-	err = common.SetValueForFlagName("string_slice", []string{"3"}, map[string]struct{}{"string_slice": {}}, false)
+	flagStringSlice = flagtypes.StringSlice(flags, "string_slice", []string{"1", "2"}, "")
+	err = common.SetValueForFlagName(flags, "string_slice", []string{"3"}, map[string]struct{}{"string_slice": {}}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, *flagStringSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
 	flagStructSlice := []testStruct{{Field: 1}, {Field: 2}}
-	flagtypes.JSONSliceVar(&flagStructSlice, "struct_slice", flagStructSlice, "")
-	err = common.SetValueForFlagName("struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{}, true)
+	flagtypes.JSONSliceVar(flags, &flagStructSlice, "struct_slice", flagStructSlice, "")
+	err = common.SetValueForFlagName(flags, "struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}, {Field: 3}}, flagStructSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
 	flagStructSlice = []testStruct{{Field: 1}, {Field: 2}}
-	flagtypes.JSONSliceVar(&flagStructSlice, "struct_slice", flagStructSlice, "")
-	err = common.SetValueForFlagName("struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{"struct_slice": {}}, true)
+	flagtypes.JSONSliceVar(flags, &flagStructSlice, "struct_slice", flagStructSlice, "")
+	err = common.SetValueForFlagName(flags, "struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{"struct_slice": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}, {Field: 3}}, flagStructSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
 	flagStructSlice = []testStruct{{Field: 1}, {Field: 2}}
-	flagtypes.JSONSliceVar(&flagStructSlice, "struct_slice", flagStructSlice, "")
-	err = common.SetValueForFlagName("struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{}, false)
+	flagtypes.JSONSliceVar(flags, &flagStructSlice, "struct_slice", flagStructSlice, "")
+	err = common.SetValueForFlagName(flags, "struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 3}}, flagStructSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
 	flagStructSlice = []testStruct{{Field: 1}, {Field: 2}}
-	flagtypes.JSONSliceVar(&flagStructSlice, "struct_slice", flagStructSlice, "")
-	err = common.SetValueForFlagName("struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{"struct_slice": {}}, false)
+	flagtypes.JSONSliceVar(flags, &flagStructSlice, "struct_slice", flagStructSlice, "")
+	err = common.SetValueForFlagName(flags, "struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{"struct_slice": {}}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}}, flagStructSlice)
 }
@@ -196,69 +196,69 @@ func TestSetValueForFlagName(t *testing.T) {
 func TestBadSetValueForFlagName(t *testing.T) {
 	flags := replaceFlagsForTesting(t)
 	_ = flags.Bool("bool", false, "")
-	err := common.SetValueForFlagName("bool", 0, map[string]struct{}{}, true)
+	err := common.SetValueForFlagName(flags, "bool", 0, map[string]struct{}{}, true)
 	require.Error(t, err)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	err = common.SetValueForFlagName("bool", false, map[string]struct{}{}, true)
+	err = common.SetValueForFlagName(flags, "bool", false, map[string]struct{}{}, true)
 	require.Error(t, err)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	_ = flagtypes.StringSlice("string_slice", []string{"1", "2"}, "")
-	err = common.SetValueForFlagName("string_slice", "3", map[string]struct{}{}, true)
+	_ = flagtypes.StringSlice(flags, "string_slice", []string{"1", "2"}, "")
+	err = common.SetValueForFlagName(flags, "string_slice", "3", map[string]struct{}{}, true)
 	require.Error(t, err)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	_ = flagtypes.StringSlice("string_slice", []string{"1", "2"}, "")
-	err = common.SetValueForFlagName("string_slice", "3", map[string]struct{}{}, false)
+	_ = flagtypes.StringSlice(flags, "string_slice", []string{"1", "2"}, "")
+	err = common.SetValueForFlagName(flags, "string_slice", "3", map[string]struct{}{}, false)
 	require.Error(t, err)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
 	flagStructSlice := []testStruct{{Field: 1}, {Field: 2}}
-	flagtypes.JSONSliceVar(&flagStructSlice, "struct_slice", flagStructSlice, "")
-	err = common.SetValueForFlagName("struct_slice", testStruct{Field: 3}, map[string]struct{}{}, true)
+	flagtypes.JSONSliceVar(flags, &flagStructSlice, "struct_slice", flagStructSlice, "")
+	err = common.SetValueForFlagName(flags, "struct_slice", testStruct{Field: 3}, map[string]struct{}{}, true)
 	require.Error(t, err)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
 	flagStructSlice = []testStruct{{Field: 1}, {Field: 2}}
-	flagtypes.JSONSliceVar(&flagStructSlice, "struct_slice", flagStructSlice, "")
-	err = common.SetValueForFlagName("struct_slice", testStruct{Field: 3}, map[string]struct{}{}, false)
+	flagtypes.JSONSliceVar(flags, &flagStructSlice, "struct_slice", flagStructSlice, "")
+	err = common.SetValueForFlagName(flags, "struct_slice", testStruct{Field: 3}, map[string]struct{}{}, false)
 	require.Error(t, err)
 }
 
 func TestDereferencedValueFromFlagName(t *testing.T) {
 	flags := replaceFlagsForTesting(t)
 	_ = flags.Bool("bool", false, "")
-	v, err := common.GetDereferencedValue[bool]("bool")
+	v, err := common.GetDereferencedValue[bool](flags, "bool")
 	require.NoError(t, err)
 	assert.Equal(t, false, v)
 
 	flags = replaceFlagsForTesting(t)
 	_ = flags.Bool("bool", true, "")
-	v, err = common.GetDereferencedValue[bool]("bool")
+	v, err = common.GetDereferencedValue[bool](flags, "bool")
 	require.NoError(t, err)
 	assert.Equal(t, true, v)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	_ = flagtypes.StringSlice("string_slice", []string{"1", "2"}, "")
-	stringSlice, err := common.GetDereferencedValue[[]string]("string_slice")
+	_ = flagtypes.StringSlice(flags, "string_slice", []string{"1", "2"}, "")
+	stringSlice, err := common.GetDereferencedValue[[]string](flags, "string_slice")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, stringSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	structSlice := flagtypes.JSONSlice("struct_slice", []testStruct{{Field: 1}, {Field: 2}}, "")
+	structSlice := flagtypes.JSONSlice(flags, "struct_slice", []testStruct{{Field: 1}, {Field: 2}}, "")
 	require.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}}, *structSlice)
 }
 
 func TestBadDereferencedValueFromFlagName(t *testing.T) {
-	_ = replaceFlagsForTesting(t)
-	_, err := common.GetDereferencedValue[any]("unknown_flag")
+	flags := replaceFlagsForTesting(t)
+	_, err := common.GetDereferencedValue[any](flags, "unknown_flag")
 	require.Error(t, err)
 }
 
 func SetWithOverride(t *testing.T) {
-	_ = replaceFlagsForTesting(t)
+	flags := replaceFlagsForTesting(t)
 
 	defaultBool := false
 	defaultInt := 37
@@ -267,40 +267,40 @@ func SetWithOverride(t *testing.T) {
 	defaultEmptyStructSlice := []testStruct{}
 	defaultStructSlice := []testStruct{{Field: 0, Meadow: "ert+"}, {Field: 1, Meadow: "y76p"}, {Field: 2, Meadow: "olu8"}}
 
-	boolFromFlag := autoflags.New("bool_flag", defaultBool, "")
-	intFromFlag := autoflags.New("int_flag", defaultInt, "")
-	emptyStringSliceFromFlag := autoflags.New("empty_string_slice_flag", defaultEmptyStringSlice, "")
-	stringSliceFromFlag := autoflags.New("string_slice_flag", defaultStringSlice, "")
-	emptyStructSliceFromFlag := autoflags.New("empty_struct_slice_flag", defaultEmptyStructSlice, "")
-	structSliceFromFlag := autoflags.New("struct_slice_flag", defaultStructSlice, "")
+	boolFromFlag := autoflags.New(flags, "bool_flag", defaultBool, "")
+	intFromFlag := autoflags.New(flags, "int_flag", defaultInt, "")
+	emptyStringSliceFromFlag := autoflags.New(flags, "empty_string_slice_flag", defaultEmptyStringSlice, "")
+	stringSliceFromFlag := autoflags.New(flags, "string_slice_flag", defaultStringSlice, "")
+	emptyStructSliceFromFlag := autoflags.New(flags, "empty_struct_slice_flag", defaultEmptyStructSlice, "")
+	structSliceFromFlag := autoflags.New(flags, "struct_slice_flag", defaultStructSlice, "")
 
-	common.SetWithOverride("bool_flag", "true")
+	common.SetWithOverride(flags, "bool_flag", "true")
 	assert.Equal(t, true, *boolFromFlag)
 
-	common.SetWithOverride("int_flag", "20")
+	common.SetWithOverride(flags, "int_flag", "20")
 	assert.Equal(t, 20, *intFromFlag)
 
-	common.SetWithOverride("empty_string_slice_flag", "yo,what up,hey")
+	common.SetWithOverride(flags, "empty_string_slice_flag", "yo,what up,hey")
 	assert.Equal(t, []string{"yo", "what up", "hey"}, *emptyStringSliceFromFlag)
 
-	common.SetWithOverride("string_slice_flag", "flour,cornmeal,baking powder,sugar")
+	common.SetWithOverride(flags, "string_slice_flag", "flour,cornmeal,baking powder,sugar")
 	assert.Equal(t, []string{"flour", "corn meal", "baking powder", "sugar"}, *stringSliceFromFlag)
 
 	newEmptyStructSliceFlag := []testStruct{{Field: 5, Meadow: "halibut"}, {Field: 9, Meadow: "sheep's cheese"}, {Field: 11, Meadow: "tamahtoes"}}
 	jsonForEmptyStructSliceFlag, err := json.Marshal(newEmptyStructSliceFlag)
 	require.NoError(t, err)
-	common.SetWithOverride("empty_struct_slice_flag", string(jsonForEmptyStructSliceFlag))
+	common.SetWithOverride(flags, "empty_struct_slice_flag", string(jsonForEmptyStructSliceFlag))
 	assert.Equal(t, newEmptyStructSliceFlag, *emptyStructSliceFromFlag)
 
 	newStructSliceFlag := []testStruct{{Field: 207, Meadow: "PURPLE PEOPLE"}}
 	jsonForStructSliceFlag, err := json.Marshal(newStructSliceFlag)
 	require.NoError(t, err)
-	common.SetWithOverride("struct_slice_flag", string(jsonForStructSliceFlag))
+	common.SetWithOverride(flags, "struct_slice_flag", string(jsonForStructSliceFlag))
 	assert.Equal(t, newStructSliceFlag, *structSliceFromFlag)
 }
 
 func TestResetFlags(t *testing.T) {
-	_ = replaceFlagsForTesting(t)
+	flags := replaceFlagsForTesting(t)
 
 	defaultBool := false
 	defaultInt := 37
@@ -309,12 +309,12 @@ func TestResetFlags(t *testing.T) {
 	defaultEmptyStructSlice := []testStruct{}
 	defaultStructSlice := []testStruct{{Field: 0, Meadow: "ert+"}, {Field: 1, Meadow: "y76p"}, {Field: 2, Meadow: "olu8"}}
 
-	boolFromFlag := autoflags.New("bool_flag", defaultBool, "")
-	intFromFlag := autoflags.New("int_flag", defaultInt, "")
-	emptyStringSliceFromFlag := autoflags.New("empty_string_slice_flag", defaultEmptyStringSlice, "")
-	stringSliceFromFlag := autoflags.New("string_slice_flag", defaultStringSlice, "")
-	emptyStructSliceFromFlag := autoflags.New("empty_struct_slice_flag", defaultEmptyStructSlice, "")
-	structSliceFromFlag := autoflags.New("struct_slice_flag", defaultStructSlice, "")
+	boolFromFlag := autoflags.New(flags, "bool_flag", defaultBool, "")
+	intFromFlag := autoflags.New(flags, "int_flag", defaultInt, "")
+	emptyStringSliceFromFlag := autoflags.New(flags, "empty_string_slice_flag", defaultEmptyStringSlice, "")
+	stringSliceFromFlag := autoflags.New(flags, "string_slice_flag", defaultStringSlice, "")
+	emptyStructSliceFromFlag := autoflags.New(flags, "empty_struct_slice_flag", defaultEmptyStructSlice, "")
+	structSliceFromFlag := autoflags.New(flags, "struct_slice_flag", defaultStructSlice, "")
 
 	*boolFromFlag = true
 	*intFromFlag = 20
@@ -323,7 +323,7 @@ func TestResetFlags(t *testing.T) {
 	*emptyStructSliceFromFlag = append(*emptyStructSliceFromFlag, testStruct{Field: 3, Meadow: "hi"})
 	*structSliceFromFlag = append(*structSliceFromFlag, testStruct{Field: 3, Meadow: "hi"})
 
-	err := common.ResetFlags()
+	err := common.ResetFlags(flags)
 	require.NoError(t, err)
 
 	assert.Equal(t, defaultBool, *boolFromFlag)

--- a/server/util/flagutil/flagutil.go
+++ b/server/util/flagutil/flagutil.go
@@ -11,20 +11,26 @@ import (
 // be appended to the current slice value; otherwise, a slice value will replace
 // the current slice value. appendSlice has no effect if the values in question
 // are not slices.
-var SetValueForFlagName = common.SetValueForFlagName
+func SetValueForFlagName(name string, newValue any, setFlags map[string]struct{}, appendSlice bool) error {
+	return common.SetValueForFlagName(common.DefaultFlagSet, name, newValue, setFlags, appendSlice)
+}
 
 // SetWithOverride sets the flag's value by creating a new, empty flag.Value of
 // the same type as the flag Value specified by name, calling
 // `Set.(newValueString)` on the new flag.Value, and then explicitly setting the
 // data pointed to by flagValue to the data pointed to by the new flag value.
-var SetWithOverride = common.SetWithOverride
+func SetWithOverride(name, newValueString string) error {
+	return common.SetWithOverride(common.DefaultFlagSet, name, newValueString)
+}
 
 // ResetFlags resets all flags to their default values, as specified by
 // the string stored in the corresponding flag.DefValue.
-var ResetFlags = common.ResetFlags
+func ResetFlags() error {
+	return common.ResetFlags(common.DefaultFlagSet)
+}
 
 // GetDereferencedValue retypes and returns the dereferenced Value for
 // a given flag name.
 func GetDereferencedValue[T any](name string) (T, error) {
-	return common.GetDereferencedValue[T](name)
+	return common.GetDereferencedValue[T](common.DefaultFlagSet, name)
 }

--- a/server/util/flagutil/types/autoflags/BUILD
+++ b/server/util/flagutil/types/autoflags/BUILD
@@ -9,7 +9,6 @@ go_library(
         "//server/util/flagutil:__subpackages__",
     ],
     deps = [
-        "//server/util/flagutil/common",
         "//server/util/flagutil/types",
         "//server/util/flagutil/yaml",
     ],

--- a/server/util/flagutil/types/autoflags/autoflags_test.go
+++ b/server/util/flagutil/types/autoflags/autoflags_test.go
@@ -47,168 +47,168 @@ func replaceIgnoreSetForTesting(t *testing.T) map[string]struct{} {
 
 func TestNew(t *testing.T) {
 	flags := replaceFlagsForTesting(t) //nolint:SA4006
-	flagBool := New("bool", false, "")
-	err := common.SetValueForFlagName("bool", true, map[string]struct{}{}, true)
+	flagBool := New(flags, "bool", false, "")
+	err := common.SetValueForFlagName(flags, "bool", true, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, true, *flagBool)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagBool = New("bool", false, "")
-	err = common.SetValueForFlagName("bool", true, map[string]struct{}{"bool": {}}, true)
+	flagBool = New(flags, "bool", false, "")
+	err = common.SetValueForFlagName(flags, "bool", true, map[string]struct{}{"bool": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, false, *flagBool)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagInt := New("int", 2, "")
-	err = common.SetValueForFlagName("int", 1, map[string]struct{}{}, true)
+	flagInt := New(flags, "int", 2, "")
+	err = common.SetValueForFlagName(flags, "int", 1, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, 1, *flagInt)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagInt = New("int", 2, "")
-	err = common.SetValueForFlagName("int", 1, map[string]struct{}{"int": {}}, true)
+	flagInt = New(flags, "int", 2, "")
+	err = common.SetValueForFlagName(flags, "int", 1, map[string]struct{}{"int": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, 2, *flagInt)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagInt64 := New("int64", int64(2), "")
-	err = common.SetValueForFlagName("int64", 1, map[string]struct{}{}, true)
+	flagInt64 := New(flags, "int64", int64(2), "")
+	err = common.SetValueForFlagName(flags, "int64", 1, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), *flagInt64)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagInt64 = New("int64", int64(2), "")
-	err = common.SetValueForFlagName("int64", 1, map[string]struct{}{"int64": {}}, true)
+	flagInt64 = New(flags, "int64", int64(2), "")
+	err = common.SetValueForFlagName(flags, "int64", 1, map[string]struct{}{"int64": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), *flagInt64)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagUint := New("uint", uint(2), "")
-	err = common.SetValueForFlagName("uint", 1, map[string]struct{}{}, true)
+	flagUint := New(flags, "uint", uint(2), "")
+	err = common.SetValueForFlagName(flags, "uint", 1, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, uint(1), *flagUint)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagUint = New("uint", uint(2), "")
-	err = common.SetValueForFlagName("uint", 1, map[string]struct{}{"uint": {}}, true)
+	flagUint = New(flags, "uint", uint(2), "")
+	err = common.SetValueForFlagName(flags, "uint", 1, map[string]struct{}{"uint": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, uint(2), *flagUint)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagUint64 := New("uint64", uint64(2), "")
-	err = common.SetValueForFlagName("uint64", 1, map[string]struct{}{}, true)
+	flagUint64 := New(flags, "uint64", uint64(2), "")
+	err = common.SetValueForFlagName(flags, "uint64", 1, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1), *flagUint64)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagUint64 = New("uint64", uint64(2), "")
-	err = common.SetValueForFlagName("uint64", 1, map[string]struct{}{"uint64": {}}, true)
+	flagUint64 = New(flags, "uint64", uint64(2), "")
+	err = common.SetValueForFlagName(flags, "uint64", 1, map[string]struct{}{"uint64": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(2), *flagUint64)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagFloat64 := New("float64", float64(2), "")
-	err = common.SetValueForFlagName("float64", 1, map[string]struct{}{}, true)
+	flagFloat64 := New(flags, "float64", float64(2), "")
+	err = common.SetValueForFlagName(flags, "float64", 1, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, float64(1), *flagFloat64)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagFloat64 = New("float64", float64(2), "")
-	err = common.SetValueForFlagName("float64", 1, map[string]struct{}{"float64": {}}, true)
+	flagFloat64 = New(flags, "float64", float64(2), "")
+	err = common.SetValueForFlagName(flags, "float64", 1, map[string]struct{}{"float64": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, float64(2), *flagFloat64)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagString := New("string", "2", "")
-	err = common.SetValueForFlagName("string", "1", map[string]struct{}{}, true)
+	flagString := New(flags, "string", "2", "")
+	err = common.SetValueForFlagName(flags, "string", "1", map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, "1", *flagString)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagString = New("string", "2", "")
-	err = common.SetValueForFlagName("string", "1", map[string]struct{}{"string": {}}, true)
+	flagString = New(flags, "string", "2", "")
+	err = common.SetValueForFlagName(flags, "string", "1", map[string]struct{}{"string": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, "2", *flagString)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
 	defaultURL := url.URL{Scheme: "https", Host: "www.example.com"}
-	flagURL := New("url", defaultURL, "")
+	flagURL := New(flags, "url", defaultURL, "")
 	u, err := url.Parse("https://www.example.com:8080")
 	require.NoError(t, err)
-	err = common.SetValueForFlagName("url", *u, map[string]struct{}{}, true)
+	err = common.SetValueForFlagName(flags, "url", *u, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, url.URL{Scheme: "https", Host: "www.example.com"}, defaultURL)
 	assert.Equal(t, url.URL{Scheme: "https", Host: "www.example.com:8080"}, *flagURL)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagURL = New("url", url.URL{Scheme: "https", Host: "www.example.com"}, "")
+	flagURL = New(flags, "url", url.URL{Scheme: "https", Host: "www.example.com"}, "")
 	u, err = url.Parse("https://www.example.com:8080")
 	require.NoError(t, err)
-	err = common.SetValueForFlagName("url", *u, map[string]struct{}{"url": {}}, true)
+	err = common.SetValueForFlagName(flags, "url", *u, map[string]struct{}{"url": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, url.URL{Scheme: "https", Host: "www.example.com"}, *flagURL)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
 	defaultStringSlice := []string{"1", "2"}
-	stringSlice := New("string_slice", defaultStringSlice, "")
-	err = common.SetValueForFlagName("string_slice", []string{"3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, map[string]struct{}{}, true)
+	stringSlice := New(flags, "string_slice", defaultStringSlice, "")
+	err = common.SetValueForFlagName(flags, "string_slice", []string{"3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, defaultStringSlice)
 	assert.Equal(t, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, *stringSlice)
 
 	flags = replaceFlagsForTesting(t)
-	stringSlice = New("string_slice", defaultStringSlice, "")
-	err = common.SetValueForFlagName("string_slice", []string{"3"}, map[string]struct{}{"string_slice": {}}, true)
+	stringSlice = New(flags, "string_slice", defaultStringSlice, "")
+	err = common.SetValueForFlagName(flags, "string_slice", []string{"3"}, map[string]struct{}{"string_slice": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, defaultStringSlice)
 	assert.Equal(t, []string{"1", "2", "3"}, *(*[]string)(flags.Lookup("string_slice").Value.(*flagtypes.StringSliceFlag)))
 	assert.Equal(t, []string{"1", "2", "3"}, *stringSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	stringSlice = New("string_slice", defaultStringSlice, "")
-	err = common.SetValueForFlagName("string_slice", []string{"3"}, map[string]struct{}{}, false)
+	stringSlice = New(flags, "string_slice", defaultStringSlice, "")
+	err = common.SetValueForFlagName(flags, "string_slice", []string{"3"}, map[string]struct{}{}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, defaultStringSlice)
 	assert.Equal(t, []string{"3"}, *stringSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	stringSlice = New("string_slice", defaultStringSlice, "")
-	err = common.SetValueForFlagName("string_slice", []string{"3"}, map[string]struct{}{"string_slice": {}}, false)
+	stringSlice = New(flags, "string_slice", defaultStringSlice, "")
+	err = common.SetValueForFlagName(flags, "string_slice", []string{"3"}, map[string]struct{}{"string_slice": {}}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, defaultStringSlice)
 	assert.Equal(t, []string{"1", "2"}, *stringSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
 	defaultStructSlice := []testStruct{{Field: 1}, {Field: 2}}
-	structSlice := New("struct_slice", defaultStructSlice, "")
-	err = common.SetValueForFlagName("struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{}, true)
+	structSlice := New(flags, "struct_slice", defaultStructSlice, "")
+	err = common.SetValueForFlagName(flags, "struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}, {Field: 3}}, *structSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	structSlice = New("struct_slice", defaultStructSlice, "")
-	err = common.SetValueForFlagName("struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{"struct_slice": {}}, true)
+	structSlice = New(flags, "struct_slice", defaultStructSlice, "")
+	err = common.SetValueForFlagName(flags, "struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{"struct_slice": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}}, defaultStructSlice)
 	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}, {Field: 3}}, *structSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	structSlice = New("struct_slice", defaultStructSlice, "")
-	err = common.SetValueForFlagName("struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{}, false)
+	structSlice = New(flags, "struct_slice", defaultStructSlice, "")
+	err = common.SetValueForFlagName(flags, "struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 3}}, *structSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	structSlice = New("struct_slice", defaultStructSlice, "")
-	err = common.SetValueForFlagName("struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{"struct_slice": {}}, false)
+	structSlice = New(flags, "struct_slice", defaultStructSlice, "")
+	err = common.SetValueForFlagName(flags, "struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{"struct_slice": {}}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}}, *structSlice)
 }
 
 func TestYAMLIgnoreTag(t *testing.T) {
-	_ = replaceFlagsForTesting(t)
+	flags := replaceFlagsForTesting(t)
 	_ = replaceIgnoreSetForTesting(t)
-	flagBool := New("bool", false, "", YAMLIgnoreTag)
+	flagBool := New(flags, "bool", false, "", YAMLIgnoreTag)
 
 	yamlData := `
 	bool: true

--- a/server/util/flagutil/types/types_test.go
+++ b/server/util/flagutil/types/types_test.go
@@ -34,7 +34,7 @@ func TestStringSliceFlag(t *testing.T) {
 
 	flags := replaceFlagsForTesting(t)
 
-	foo := StringSlice("foo", []string{}, "A list of foos")
+	foo := StringSlice(flags, "foo", []string{}, "A list of foos")
 	assert.Equal(t, []string{}, *foo)
 	assert.Equal(t, []string{}, *(*[]string)(flags.Lookup("foo").Value.(*StringSliceFlag)))
 	err = flags.Set("foo", "foo0,foo1")
@@ -46,7 +46,7 @@ func TestStringSliceFlag(t *testing.T) {
 	assert.Equal(t, []string{"foo0", "foo1", "foo2", "foo3", "foo4", "foo5"}, *foo)
 	assert.Equal(t, []string{"foo0", "foo1", "foo2", "foo3", "foo4", "foo5"}, *(*[]string)(flags.Lookup("foo").Value.(*StringSliceFlag)))
 
-	bar := StringSlice("bar", []string{"bar0", "bar1"}, "A list of bars")
+	bar := StringSlice(flags, "bar", []string{"bar0", "bar1"}, "A list of bars")
 	assert.Equal(t, []string{"bar0", "bar1"}, *bar)
 	assert.Equal(t, []string{"bar0", "bar1"}, *(*[]string)(flags.Lookup("bar").Value.(*StringSliceFlag)))
 	err = flags.Set("bar", "bar2")
@@ -56,7 +56,7 @@ func TestStringSliceFlag(t *testing.T) {
 	assert.Equal(t, []string{"bar0", "bar1", "bar2", "bar3", "bar4", "bar5"}, *bar)
 	assert.Equal(t, []string{"bar0", "bar1", "bar2", "bar3", "bar4", "bar5"}, *(*[]string)(flags.Lookup("bar").Value.(*StringSliceFlag)))
 
-	baz := StringSlice("baz", []string{}, "A list of bazs")
+	baz := StringSlice(flags, "baz", []string{}, "A list of bazs")
 	err = flags.Set("baz", flags.Lookup("bar").Value.String())
 	assert.NoError(t, err)
 	assert.Equal(t, *bar, *baz)
@@ -75,7 +75,7 @@ func TestStructSliceFlag(t *testing.T) {
 
 	flags := replaceFlagsForTesting(t)
 
-	fooFlag := JSONSlice("foo", []testStruct{}, "A list of foos")
+	fooFlag := JSONSlice(flags, "foo", []testStruct{}, "A list of foos")
 	assert.Equal(t, []testStruct{}, *fooFlag)
 	assert.Equal(t, []testStruct{}, ([]testStruct)(flags.Lookup("foo").Value.(*JSONSliceFlag[[]testStruct]).Slice()))
 	err = flags.Set("foo", `[{"field":3,"meadow":"watership down"}]`)
@@ -88,11 +88,11 @@ func TestStructSliceFlag(t *testing.T) {
 	assert.Equal(t, []testStruct{{Field: 3, Meadow: "watership down"}, {Field: 5, Meadow: "runnymede"}}, ([]testStruct)(flags.Lookup("foo").Value.(*JSONSliceFlag[[]testStruct]).Slice()))
 
 	barFlag := []testStruct{{Field: 11, Meadow: "arcadia"}, {Field: 13, Meadow: "kingcombe"}}
-	JSONSliceVar(&barFlag, "bar", barFlag, "A list of bars")
+	JSONSliceVar(flags, &barFlag, "bar", barFlag, "A list of bars")
 	assert.Equal(t, []testStruct{{Field: 11, Meadow: "arcadia"}, {Field: 13, Meadow: "kingcombe"}}, barFlag)
 	assert.Equal(t, []testStruct{{Field: 11, Meadow: "arcadia"}, {Field: 13, Meadow: "kingcombe"}}, ([]testStruct)(flags.Lookup("bar").Value.(*JSONSliceFlag[[]testStruct]).Slice()))
 
-	fooxFlag := JSONSlice("foox", []testStruct{}, "A list of fooxes")
+	fooxFlag := JSONSlice(flags, "foox", []testStruct{}, "A list of fooxes")
 	assert.Equal(t, []testStruct{}, *fooxFlag)
 	assert.Equal(t, []testStruct{}, ([]testStruct)(flags.Lookup("foox").Value.(*JSONSliceFlag[[]testStruct]).Slice()))
 	err = flags.Set("foox", `[{"field":13,"meadow":"cors y llyn"},{},{"field":15}]`)
@@ -105,7 +105,7 @@ func TestStructSliceFlag(t *testing.T) {
 	assert.Equal(t, []testStruct{{Field: 13, Meadow: "cors y llyn"}, {}, {Field: 15}, {Field: 17, Meadow: "red hill"}, {}, {Field: 19}}, ([]testStruct)(flags.Lookup("foox").Value.(*JSONSliceFlag[[]testStruct]).Slice()))
 
 	bazFlag := []testStruct{}
-	JSONSliceVar(&bazFlag, "baz", bazFlag, "A list of bazs")
+	JSONSliceVar(flags, &bazFlag, "baz", bazFlag, "A list of bazs")
 	err = flags.Set("baz", flags.Lookup("bar").Value.String())
 	assert.NoError(t, err)
 	assert.Equal(t, barFlag, bazFlag)
@@ -124,7 +124,7 @@ func TestProtoSliceFlag(t *testing.T) {
 
 	flags := replaceFlagsForTesting(t)
 
-	fooFlag := JSONSlice("foo", []*timestamppb.Timestamp{}, "A list of foos")
+	fooFlag := JSONSlice(flags, "foo", []*timestamppb.Timestamp{}, "A list of foos")
 	assert.Equal(t, []*timestamppb.Timestamp{}, *fooFlag)
 	assert.Equal(t, []*timestamppb.Timestamp{}, ([]*timestamppb.Timestamp)(flags.Lookup("foo").Value.(*JSONSliceFlag[[]*timestamppb.Timestamp]).Slice()))
 	err = flags.Set("foo", `[{"seconds":3,"nanos":5}]`)
@@ -137,11 +137,11 @@ func TestProtoSliceFlag(t *testing.T) {
 	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 3, Nanos: 5}, {Seconds: 5, Nanos: 9}}, ([]*timestamppb.Timestamp)(flags.Lookup("foo").Value.(*JSONSliceFlag[[]*timestamppb.Timestamp]).Slice()))
 
 	barFlag := []*timestamppb.Timestamp{{Seconds: 11, Nanos: 100}, {Seconds: 13, Nanos: 256}}
-	JSONSliceVar(&barFlag, "bar", barFlag, "A list of bars")
+	JSONSliceVar(flags, &barFlag, "bar", barFlag, "A list of bars")
 	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 11, Nanos: 100}, {Seconds: 13, Nanos: 256}}, barFlag)
 	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 11, Nanos: 100}, {Seconds: 13, Nanos: 256}}, ([]*timestamppb.Timestamp)(flags.Lookup("bar").Value.(*JSONSliceFlag[[]*timestamppb.Timestamp]).Slice()))
 
-	fooxFlag := JSONSlice("foox", []*timestamppb.Timestamp{}, "A list of fooxes")
+	fooxFlag := JSONSlice(flags, "foox", []*timestamppb.Timestamp{}, "A list of fooxes")
 	assert.Equal(t, []*timestamppb.Timestamp{}, *fooxFlag)
 	assert.Equal(t, []*timestamppb.Timestamp{}, ([]*timestamppb.Timestamp)(flags.Lookup("foox").Value.(*JSONSliceFlag[[]*timestamppb.Timestamp]).Slice()))
 	err = flags.Set("foox", `[{"seconds":13,"nanos":64},{},{"seconds":15}]`)
@@ -154,7 +154,7 @@ func TestProtoSliceFlag(t *testing.T) {
 	assert.Equal(t, []*timestamppb.Timestamp{{Seconds: 13, Nanos: 64}, {}, {Seconds: 15}, {Seconds: 17, Nanos: 9001}, {}, {Seconds: 19}}, ([]*timestamppb.Timestamp)(flags.Lookup("foox").Value.(*JSONSliceFlag[[]*timestamppb.Timestamp]).Slice()))
 
 	bazFlag := []*timestamppb.Timestamp{}
-	JSONSliceVar(&bazFlag, "baz", bazFlag, "A list of bazs")
+	JSONSliceVar(flags, &bazFlag, "baz", bazFlag, "A list of bazs")
 	err = flags.Set("baz", flags.Lookup("bar").Value.String())
 	assert.NoError(t, err)
 	assert.Equal(t, barFlag, bazFlag)
@@ -173,7 +173,7 @@ func TestJSONStructFlag(t *testing.T) {
 	flags := replaceFlagsForTesting(t)
 	flagName := "foo"
 
-	f := JSONStruct(flagName, testStruct{}, "A flag that should contain a testStruct")
+	f := JSONStruct(flags, flagName, testStruct{}, "A flag that should contain a testStruct")
 	assert.Equal(t, testStruct{}, *f)
 	assert.Equal(t, testStruct{}, (flags.Lookup(flagName).Value.(*JSONStructFlag[testStruct]).Struct()))
 
@@ -194,8 +194,8 @@ func TestJSONStructFlag(t *testing.T) {
 func TestFlagAlias(t *testing.T) {
 	flags := replaceFlagsForTesting(t)
 	s := flags.String("string", "test", "")
-	as := Alias[string]("string", "string_alias")
-	aas := Alias[string]("string_alias", "string_alias_alias")
+	as := Alias[string](flags, "string", "string_alias")
+	aas := Alias[string](flags, "string_alias", "string_alias_alias")
 	assert.Equal(t, *s, "test")
 	assert.Equal(t, s, as)
 	assert.Equal(t, as, aas)
@@ -226,15 +226,15 @@ func TestFlagAlias(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, reflect.TypeOf((*string)(nil)), aasfYAMLType)
 
-	p := Alias[string]("string_alias_alias")
+	p := Alias[string](flags, "string_alias_alias")
 	assert.Equal(t, aas, p)
 
 	flags = replaceFlagsForTesting(t)
 
 	flagString := flags.String("string", "test", "")
-	Alias[string]("string", "string_alias")
-	Alias[string]("string", "string_alias2")
-	Alias[string]("string", "string_alias3")
+	Alias[string](flags, "string", "string_alias")
+	Alias[string](flags, "string", "string_alias2")
+	Alias[string](flags, "string", "string_alias3")
 	yamlData := `
 string: "woof"
 string_alias2: "moo"
@@ -247,10 +247,10 @@ string_alias: "meow"
 
 	flags = replaceFlagsForTesting(t)
 
-	flagStringSlice := StringSlice("string_slice", []string{"test"}, "")
-	Alias[[]string]("string_slice", "string_slice_alias")
-	Alias[[]string]("string_slice", "string_slice_alias2")
-	Alias[[]string]("string_slice", "string_slice_alias3")
+	flagStringSlice := StringSlice(flags, "string_slice", []string{"test"}, "")
+	Alias[[]string](flags, "string_slice", "string_slice_alias")
+	Alias[[]string](flags, "string_slice", "string_slice_alias2")
+	Alias[[]string](flags, "string_slice", "string_slice_alias3")
 	flags.Set("string_slice", "squeak")
 	yamlData = `
 string_slice:
@@ -270,7 +270,7 @@ string_slice_alias:
 	flags = replaceFlagsForTesting(t)
 
 	flagString = flags.String("string", "test", "")
-	Alias[string]("string", "string_alias")
+	Alias[string](flags, "string", "string_alias")
 	yamlData = `
 string_alias: "meow"
 `
@@ -281,7 +281,7 @@ string_alias: "meow"
 	flags = replaceFlagsForTesting(t)
 
 	flagString = flags.String("string", "test", "")
-	Alias[string]("string", "string_alias")
+	Alias[string](flags, "string", "string_alias")
 	flags.Set("string", "moo")
 	yamlData = `
 string_alias: "meow"
@@ -293,7 +293,7 @@ string_alias: "meow"
 	flags = replaceFlagsForTesting(t)
 
 	flagString = flags.String("string", "test", "")
-	Alias[string]("string", "string_alias")
+	Alias[string](flags, "string", "string_alias")
 	flags.Set("string_alias", "moo")
 	yamlData = `
 string: "meow"
@@ -305,7 +305,7 @@ string: "meow"
 	flags = replaceFlagsForTesting(t)
 
 	flagString = flags.String("string", "test", "")
-	Alias[string]("string", "string_alias")
+	Alias[string](flags, "string", "string_alias")
 	flags.Set("string_alias", "moo")
 	yamlData = `
 string_alias: "meow"
@@ -316,45 +316,45 @@ string_alias: "meow"
 
 	flags = replaceFlagsForTesting(t)
 	flagString = flags.String("string", "2", "")
-	Alias[string]("string", "string_alias")
-	err = common.SetValueForFlagName("string_alias", "1", map[string]struct{}{}, true)
+	Alias[string](flags, "string", "string_alias")
+	err = common.SetValueForFlagName(flags, "string_alias", "1", map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, "1", *flagString)
 
 	flags = replaceFlagsForTesting(t)
 	flagString = flags.String("string", "2", "")
-	Alias[string]("string", "string_alias")
-	err = common.SetValueForFlagName("string_alias", "1", map[string]struct{}{"string": {}}, true)
+	Alias[string](flags, "string", "string_alias")
+	err = common.SetValueForFlagName(flags, "string_alias", "1", map[string]struct{}{"string": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, "2", *flagString)
 
 	string_slice := make([]string, 2)
 	string_slice[0] = "1"
 	string_slice[1] = "2"
-	StringSliceVar(&string_slice, "string_slice", string_slice, "")
-	Alias[[]string]("string_slice", "string_slice_alias")
-	err = common.SetValueForFlagName("string_slice_alias", []string{"3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, map[string]struct{}{}, true)
+	StringSliceVar(flags, &string_slice, "string_slice", string_slice, "")
+	Alias[[]string](flags, "string_slice", "string_slice_alias")
+	err = common.SetValueForFlagName(flags, "string_slice_alias", []string{"3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, string_slice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagStringSlice = StringSlice("string_slice", []string{"1", "2"}, "")
-	Alias[[]string]("string_slice", "string_slice_alias")
-	err = common.SetValueForFlagName("string_slice_alias", []string{"3"}, map[string]struct{}{"string_slice": {}}, true)
+	flagStringSlice = StringSlice(flags, "string_slice", []string{"1", "2"}, "")
+	Alias[[]string](flags, "string_slice", "string_slice_alias")
+	err = common.SetValueForFlagName(flags, "string_slice_alias", []string{"3"}, map[string]struct{}{"string_slice": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2", "3"}, *flagStringSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagStringSlice = StringSlice("string_slice", []string{"1", "2"}, "")
-	Alias[[]string]("string_slice", "string_slice_alias")
-	err = common.SetValueForFlagName("string_slice_alias", []string{"3"}, map[string]struct{}{}, false)
+	flagStringSlice = StringSlice(flags, "string_slice", []string{"1", "2"}, "")
+	Alias[[]string](flags, "string_slice", "string_slice_alias")
+	err = common.SetValueForFlagName(flags, "string_slice_alias", []string{"3"}, map[string]struct{}{}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"3"}, *flagStringSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagStringSlice = StringSlice("string_slice", []string{"1", "2"}, "")
-	Alias[[]string]("string_slice", "string_slice_alias")
-	err = common.SetValueForFlagName("string_slice_alias", []string{"3"}, map[string]struct{}{"string_slice": {}}, false)
+	flagStringSlice = StringSlice(flags, "string_slice", []string{"1", "2"}, "")
+	Alias[[]string](flags, "string_slice", "string_slice_alias")
+	err = common.SetValueForFlagName(flags, "string_slice_alias", []string{"3"}, map[string]struct{}{"string_slice": {}}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, *flagStringSlice)
 
@@ -362,56 +362,56 @@ string_alias: "meow"
 	string_slice = make([]string, 2)
 	string_slice[0] = "1"
 	string_slice[1] = "2"
-	StringSliceVar(&string_slice, "string_slice", string_slice, "")
-	Alias[[]string]("string_slice", "string_slice_alias")
-	Alias[[]string]("string_slice_alias", "string_slice_alias_alias")
-	err = common.SetValueForFlagName("string_slice_alias_alias", []string{"3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, map[string]struct{}{}, true)
+	StringSliceVar(flags, &string_slice, "string_slice", string_slice, "")
+	Alias[[]string](flags, "string_slice", "string_slice_alias")
+	Alias[[]string](flags, "string_slice_alias", "string_slice_alias_alias")
+	err = common.SetValueForFlagName(flags, "string_slice_alias_alias", []string{"3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, map[string]struct{}{}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "1", "2"}, string_slice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagStringSlice = StringSlice("string_slice", []string{"1", "2"}, "")
-	Alias[[]string]("string_slice", "string_slice_alias")
-	Alias[[]string]("string_slice_alias", "string_slice_alias_alias")
-	err = common.SetValueForFlagName("string_slice_alias_alias", []string{"3"}, map[string]struct{}{"string_slice": {}}, true)
+	flagStringSlice = StringSlice(flags, "string_slice", []string{"1", "2"}, "")
+	Alias[[]string](flags, "string_slice", "string_slice_alias")
+	Alias[[]string](flags, "string_slice_alias", "string_slice_alias_alias")
+	err = common.SetValueForFlagName(flags, "string_slice_alias_alias", []string{"3"}, map[string]struct{}{"string_slice": {}}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2", "3"}, *flagStringSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagStringSlice = StringSlice("string_slice", []string{"1", "2"}, "")
-	Alias[[]string]("string_slice", "string_slice_alias")
-	Alias[[]string]("string_slice_alias", "string_slice_alias_alias")
-	err = common.SetValueForFlagName("string_slice_alias_alias", []string{"3"}, map[string]struct{}{}, false)
+	flagStringSlice = StringSlice(flags, "string_slice", []string{"1", "2"}, "")
+	Alias[[]string](flags, "string_slice", "string_slice_alias")
+	Alias[[]string](flags, "string_slice_alias", "string_slice_alias_alias")
+	err = common.SetValueForFlagName(flags, "string_slice_alias_alias", []string{"3"}, map[string]struct{}{}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"3"}, *flagStringSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	flagStringSlice = StringSlice("string_slice", []string{"1", "2"}, "")
-	Alias[[]string]("string_slice", "string_slice_alias")
-	Alias[[]string]("string_slice_alias", "string_slice_alias_alias")
-	err = common.SetValueForFlagName("string_slice_alias_alias", []string{"3"}, map[string]struct{}{"string_slice": {}}, false)
+	flagStringSlice = StringSlice(flags, "string_slice", []string{"1", "2"}, "")
+	Alias[[]string](flags, "string_slice", "string_slice_alias")
+	Alias[[]string](flags, "string_slice_alias", "string_slice_alias_alias")
+	err = common.SetValueForFlagName(flags, "string_slice_alias_alias", []string{"3"}, map[string]struct{}{"string_slice": {}}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, *flagStringSlice)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	_ = StringSlice("string_slice", []string{"1", "2"}, "")
-	stringSlice, err := common.GetDereferencedValue[[]string]("string_slice")
+	_ = StringSlice(flags, "string_slice", []string{"1", "2"}, "")
+	stringSlice, err := common.GetDereferencedValue[[]string](flags, "string_slice")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, stringSlice)
 
-	_ = Alias[[]string]("string_slice", "string_slice_alias")
-	stringSliceAlias, err := common.GetDereferencedValue[[]string]("string_slice_alias")
+	_ = Alias[[]string](flags, "string_slice", "string_slice_alias")
+	stringSliceAlias, err := common.GetDereferencedValue[[]string](flags, "string_slice_alias")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, stringSliceAlias)
 
-	_ = Alias[[]string]("string_slice_alias", "string_slice_alias_alias")
-	stringSliceAliasAlias, err := common.GetDereferencedValue[[]string]("string_slice_alias_alias")
+	_ = Alias[[]string](flags, "string_slice_alias", "string_slice_alias_alias")
+	stringSliceAliasAlias, err := common.GetDereferencedValue[[]string](flags, "string_slice_alias_alias")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"1", "2"}, stringSliceAliasAlias)
 
 	flags = replaceFlagsForTesting(t) //nolint:SA4006
-	JSONSlice("struct_slice", []testStruct{{Field: 1}, {Field: 2}}, "")
-	structSlice, err := common.GetDereferencedValue[[]testStruct]("struct_slice")
+	JSONSlice(flags, "struct_slice", []testStruct{{Field: 1}, {Field: 2}}, "")
+	structSlice, err := common.GetDereferencedValue[[]testStruct](flags, "struct_slice")
 	require.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}}, structSlice)
 
@@ -422,26 +422,26 @@ string_alias: "meow"
 
 func TestDeprecatedVar(t *testing.T) {
 	flags := replaceFlagsForTesting(t)
-	flagInt := DeprecatedVar[int](NewPrimitiveFlag(5), "deprecated_int", "", "migration plan")
-	flagStringSlice := DeprecatedVar[[]string](NewStringSliceFlag(&[]string{"hi"}), "deprecated_string_slice", "", "migration plan")
+	flagInt := DeprecatedVar[int](flags, NewPrimitiveFlag(5), "deprecated_int", "", "migration plan")
+	flagStringSlice := DeprecatedVar[[]string](flags, NewStringSliceFlag(&[]string{"hi"}), "deprecated_string_slice", "", "migration plan")
 	assert.Equal(t, *flagInt, 5)
 	assert.Equal(t, *flagStringSlice, []string{"hi"})
 	flags.Set("deprecated_int", "7")
 	flags.Set("deprecated_string_slice", "hello")
 	assert.Equal(t, *flagStringSlice, []string{"hi", "hello"})
 	assert.Equal(t, *flagInt, 7)
-	testInt, err := common.GetDereferencedValue[int]("deprecated_int")
+	testInt, err := common.GetDereferencedValue[int](flags, "deprecated_int")
 	require.NoError(t, err)
 	assert.Equal(t, testInt, 7)
-	testStringSlice, err := common.GetDereferencedValue[[]string]("deprecated_string_slice")
+	testStringSlice, err := common.GetDereferencedValue[[]string](flags, "deprecated_string_slice")
 	require.NoError(t, err)
 	assert.Equal(t, testStringSlice, []string{"hi", "hello"})
 
 	flags = replaceFlagsForTesting(t)
 
-	flagInt = DeprecatedVar[int](NewPrimitiveFlag(5), "deprecated_int", "", "migration plan")
-	flagString := DeprecatedVar[string](NewPrimitiveFlag(""), "deprecated_string", "", "migration plan")
-	flagStringSlice = DeprecatedVar[[]string](NewStringSliceFlag(&[]string{"hi"}), "deprecated_string_slice", "", "migration plan")
+	flagInt = DeprecatedVar[int](flags, NewPrimitiveFlag(5), "deprecated_int", "", "migration plan")
+	flagString := DeprecatedVar[string](flags, NewPrimitiveFlag(""), "deprecated_string", "", "migration plan")
+	flagStringSlice = DeprecatedVar[[]string](flags, NewStringSliceFlag(&[]string{"hi"}), "deprecated_string_slice", "", "migration plan")
 	flags.Set("deprecated_int", "7")
 	flags.Set("deprecated_string_slice", "hello")
 	yamlData := `
@@ -455,13 +455,13 @@ deprecated_string_slice:
 	assert.Equal(t, *flagInt, 7)
 	assert.Equal(t, *flagString, "moo")
 	assert.Equal(t, *flagStringSlice, []string{"hi", "hello", "hey"})
-	testInt, err = common.GetDereferencedValue[int]("deprecated_int")
+	testInt, err = common.GetDereferencedValue[int](flags, "deprecated_int")
 	require.NoError(t, err)
 	assert.Equal(t, testInt, 7)
-	testString, err := common.GetDereferencedValue[string]("deprecated_string")
+	testString, err := common.GetDereferencedValue[string](flags, "deprecated_string")
 	require.NoError(t, err)
 	assert.Equal(t, testString, "moo")
-	testStringSlice, err = common.GetDereferencedValue[[]string]("deprecated_string_slice")
+	testStringSlice, err = common.GetDereferencedValue[[]string](flags, "deprecated_string_slice")
 	require.NoError(t, err)
 	assert.Equal(t, testStringSlice, []string{"hi", "hello", "hey"})
 
@@ -481,19 +481,19 @@ deprecated_string_slice:
 func TestDeprecate(t *testing.T) {
 	flags := replaceFlagsForTesting(t)
 	flagInt := flags.Int("deprecated_int", 5, "some usage text")
-	Deprecate[int]("deprecated_int", "migration plan")
-	flagStringSlice := StringSlice("deprecated_string_slice", []string{"hi"}, "")
-	Deprecate[[]string]("deprecated_string_slice", "migration plan")
+	Deprecate[int](flags, "deprecated_int", "migration plan")
+	flagStringSlice := StringSlice(flags, "deprecated_string_slice", []string{"hi"}, "")
+	Deprecate[[]string](flags, "deprecated_string_slice", "migration plan")
 	assert.Equal(t, *flagInt, 5)
 	assert.Equal(t, *flagStringSlice, []string{"hi"})
 	flags.Set("deprecated_int", "7")
 	flags.Set("deprecated_string_slice", "hello")
 	assert.Equal(t, *flagStringSlice, []string{"hi", "hello"})
 	assert.Equal(t, *flagInt, 7)
-	testInt, err := common.GetDereferencedValue[int]("deprecated_int")
+	testInt, err := common.GetDereferencedValue[int](flags, "deprecated_int")
 	require.NoError(t, err)
 	assert.Equal(t, testInt, 7)
-	testStringSlice, err := common.GetDereferencedValue[[]string]("deprecated_string_slice")
+	testStringSlice, err := common.GetDereferencedValue[[]string](flags, "deprecated_string_slice")
 	require.NoError(t, err)
 	assert.Equal(t, testStringSlice, []string{"hi", "hello"})
 	assert.Equal(t, "some usage text **DEPRECATED** migration plan", flags.Lookup("deprecated_int").Usage)
@@ -501,10 +501,10 @@ func TestDeprecate(t *testing.T) {
 	flags = replaceFlagsForTesting(t)
 
 	flagInt = flags.Int("deprecated_int", 5, "some usage text")
-	Deprecate[int]("deprecated_int", "migration plan")
+	Deprecate[int](flags, "deprecated_int", "migration plan")
 	flagString := flags.String("deprecated_string", "", "")
-	Deprecate[string]("deprecated_string", "migration plan")
-	flagStringSlice = DeprecatedVar[[]string](NewStringSliceFlag(&[]string{"hi"}), "deprecated_string_slice", "", "migration plan")
+	Deprecate[string](flags, "deprecated_string", "migration plan")
+	flagStringSlice = DeprecatedVar[[]string](flags, NewStringSliceFlag(&[]string{"hi"}), "deprecated_string_slice", "", "migration plan")
 	flags.Set("deprecated_int", "7")
 	flags.Set("deprecated_string_slice", "hello")
 	yamlData := `
@@ -518,13 +518,13 @@ deprecated_string_slice:
 	assert.Equal(t, *flagInt, 7)
 	assert.Equal(t, *flagString, "moo")
 	assert.Equal(t, *flagStringSlice, []string{"hi", "hello", "hey"})
-	testInt, err = common.GetDereferencedValue[int]("deprecated_int")
+	testInt, err = common.GetDereferencedValue[int](flags, "deprecated_int")
 	require.NoError(t, err)
 	assert.Equal(t, testInt, 7)
-	testString, err := common.GetDereferencedValue[string]("deprecated_string")
+	testString, err := common.GetDereferencedValue[string](flags, "deprecated_string")
 	require.NoError(t, err)
 	assert.Equal(t, testString, "moo")
-	testStringSlice, err = common.GetDereferencedValue[[]string]("deprecated_string_slice")
+	testStringSlice, err = common.GetDereferencedValue[[]string](flags, "deprecated_string_slice")
 	require.NoError(t, err)
 	assert.Equal(t, testStringSlice, []string{"hi", "hello", "hey"})
 	assert.Equal(t, "some usage text **DEPRECATED** migration plan", flags.Lookup("deprecated_int").Usage)

--- a/server/util/flagutil/yaml/yaml.go
+++ b/server/util/flagutil/yaml/yaml.go
@@ -453,7 +453,7 @@ func GenerateDocumentedMarshalerFromFlag(flg *flag.Flag) (DocumentedMarshaler, e
 	if err != nil {
 		return nil, status.InternalErrorf("Error encountered generating default YAML from flags when processing flag %s: %s", flg.Name, err)
 	}
-	v, err := common.GetDereferencedValue[any](flg.Name)
+	v, err := common.GetDereferencedValue[any](common.DefaultFlagSet, flg.Name)
 	if err != nil {
 		return nil, status.InternalErrorf("Error encountered generating default YAML from flags: %s", err)
 	}
@@ -744,12 +744,12 @@ func populateFlagsFromYAML(a any, prefix []string, node *yaml.Node, setFlags map
 	if flg == nil {
 		return nil
 	}
-	return setValueForYAML(flg.Value, name, a, setFlags, appendSlice)
+	return setValueForYAML(common.DefaultFlagSet, flg.Value, name, a, setFlags, appendSlice)
 }
 
-func setValueForYAML(flagValue flag.Value, name string, newValue any, setFlags map[string]struct{}, appendSlice bool, setHooks ...func()) error {
+func setValueForYAML(flagset *flag.FlagSet, flagValue flag.Value, name string, newValue any, setFlags map[string]struct{}, appendSlice bool, setHooks ...func()) error {
 	if v, ok := flagValue.(YAMLSetValueHooked); ok {
 		setHooks = append(setHooks, v.YAMLSetValueHook)
 	}
-	return common.SetValueWithCustomIndirectBehavior(flagValue, name, newValue, setFlags, appendSlice, setValueForYAML, setHooks...)
+	return common.SetValueWithCustomIndirectBehavior(common.DefaultFlagSet, flagValue, name, newValue, setFlags, appendSlice, setValueForYAML, setHooks...)
 }

--- a/server/util/flagutil/yaml/yaml_test.go
+++ b/server/util/flagutil/yaml/yaml_test.go
@@ -42,11 +42,11 @@ func TestGenerateYAMLTypeMapFromFlags(t *testing.T) {
 
 	flags.Bool("bool", true, "")
 	flags.Int("one.two.int", 10, "")
-	flagtypes.StringSlice("one.two.string_slice", []string{"hi", "hello"}, "")
+	flagtypes.StringSlice(flags, "one.two.string_slice", []string{"hi", "hello"}, "")
 	flags.Float64("one.two.two_and_a_half.float64", 5.2, "")
-	flagtypes.JSONSlice("one.two.three.struct_slice", []testStruct{{Field: 4, Meadow: "Great"}}, "")
+	flagtypes.JSONSlice(flags, "one.two.three.struct_slice", []testStruct{{Field: 4, Meadow: "Great"}}, "")
 	flags.String("a.b.string", "xxx", "")
-	flagtypes.URLFromString("a.b.url", "https://www.example.com", "")
+	flagtypes.URLFromString(flags, "a.b.url", "https://www.example.com", "")
 	actual, err := flagyaml.GenerateYAMLMapWithValuesFromFlags(
 		func(flg *flag.Flag) (reflect.Type, error) {
 			return flagyaml.GetYAMLTypeForFlagValue(flg.Value)
@@ -228,14 +228,14 @@ func TestPopulateFlagsFromData(t *testing.T) {
 
 	flagBool := flags.Bool("bool", true, "")
 	flagOneTwoInt := flags.Int("one.two.int", 10, "")
-	flagOneTwoStringSlice := flagtypes.StringSlice("one.two.string_slice", []string{"hi", "hello"}, "")
+	flagOneTwoStringSlice := flagtypes.StringSlice(flags, "one.two.string_slice", []string{"hi", "hello"}, "")
 	flagOneTwoTwoAndAHalfFloat := flags.Float64("one.two.two_and_a_half.float64", 5.2, "")
 	flagOneTwoThreeStructSlice := []testStruct{{Field: 4, Meadow: "Great"}}
-	flagtypes.JSONSliceVar(&flagOneTwoThreeStructSlice, "one.two.three.struct_slice", flagOneTwoThreeStructSlice, "")
+	flagtypes.JSONSliceVar(flags, &flagOneTwoThreeStructSlice, "one.two.three.struct_slice", flagOneTwoThreeStructSlice, "")
 	flagABString := flags.String("a.b.string", "xxx", "")
 	flagABStructSlice := []testStruct{{Field: 7, Meadow: "Chimney"}}
-	flagtypes.JSONSliceVar(&flagABStructSlice, "a.b.struct_slice", flagABStructSlice, "")
-	flagABURL := flagtypes.URLFromString("a.b.url", "https://www.example.com", "")
+	flagtypes.JSONSliceVar(flags, &flagABStructSlice, "a.b.struct_slice", flagABStructSlice, "")
+	flagABURL := flagtypes.URLFromString(flags, "a.b.url", "https://www.example.com", "")
 	yamlData := `
 bool: true
 one:
@@ -302,14 +302,14 @@ func TestPopulateFlagsFromYAML(t *testing.T) {
 
 	flagBool := flags.Bool("bool", true, "")
 	flagOneTwoInt := flags.Int("one.two.int", 10, "")
-	flagOneTwoStringSlice := flagtypes.JSONSlice("one.two.string_slice", []string{"hi", "hello"}, "")
+	flagOneTwoStringSlice := flagtypes.JSONSlice(flags, "one.two.string_slice", []string{"hi", "hello"}, "")
 	flagOneTwoTwoAndAHalfFloat := flags.Float64("one.two.two_and_a_half.float64", 5.2, "")
 	flagOneTwoThreeStructSlice := []testStruct{{Field: 4, Meadow: "Great"}}
-	flagtypes.JSONSliceVar(&flagOneTwoThreeStructSlice, "one.two.three.struct_slice", flagOneTwoThreeStructSlice, "")
+	flagtypes.JSONSliceVar(flags, &flagOneTwoThreeStructSlice, "one.two.three.struct_slice", flagOneTwoThreeStructSlice, "")
 	flagABString := flags.String("a.b.string", "xxx", "")
 	flagABStructSlice := []testStruct{{Field: 7, Meadow: "Chimney"}}
-	flagtypes.JSONSliceVar(&flagABStructSlice, "a.b.struct_slice", flagABStructSlice, "")
-	flagABURL := flagtypes.URLFromString("a.b.url", "https://www.example.com", "")
+	flagtypes.JSONSliceVar(flags, &flagABStructSlice, "a.b.struct_slice", flagABStructSlice, "")
+	flagABURL := flagtypes.URLFromString(flags, "a.b.url", "https://www.example.com", "")
 	input := map[string]any{
 		"bool": false,
 		"one": map[string]any{
@@ -379,14 +379,14 @@ func TestOverrideFlagsFromData(t *testing.T) {
 
 	flagBool := flags.Bool("bool", true, "")
 	flagOneTwoInt := flags.Int("one.two.int", 10, "")
-	flagOneTwoStringSlice := flagtypes.StringSlice("one.two.string_slice", []string{"hi", "hello"}, "")
+	flagOneTwoStringSlice := flagtypes.StringSlice(flags, "one.two.string_slice", []string{"hi", "hello"}, "")
 	flagOneTwoTwoAndAHalfFloat := flags.Float64("one.two.two_and_a_half.float64", 5.2, "")
 	flagOneTwoThreeStructSlice := []testStruct{{Field: 4, Meadow: "Great"}}
-	flagtypes.JSONSliceVar(&flagOneTwoThreeStructSlice, "one.two.three.struct_slice", flagOneTwoThreeStructSlice, "")
+	flagtypes.JSONSliceVar(flags, &flagOneTwoThreeStructSlice, "one.two.three.struct_slice", flagOneTwoThreeStructSlice, "")
 	flagABString := flags.String("a.b.string", "xxx", "")
 	flagABStructSlice := []testStruct{{Field: 7, Meadow: "Chimney"}}
-	flagtypes.JSONSliceVar(&flagABStructSlice, "a.b.struct_slice", flagABStructSlice, "")
-	flagABURL := flagtypes.URLFromString("a.b.url", "https://www.example.com", "")
+	flagtypes.JSONSliceVar(flags, &flagABStructSlice, "a.b.struct_slice", flagABStructSlice, "")
+	flagABURL := flagtypes.URLFromString(flags, "a.b.url", "https://www.example.com", "")
 	yamlData := `
 bool: true
 one:


### PR DESCRIPTION
I'm attempting to write a `bb execute` command that runs an arbitrary command as a remote execution request, but noticed that I can't add a multi-valued `remote_header` flag matching Bazel's flag, because the StringSlice() func only works on the default flag set.

This PR updates the flag utils to explicitly plumb through the FlagSet everywhere instead of referencing DefaultFlagSet. The top-level utils such as `flag.StringSlice()` still use the default flag set (flag.CommandLine).

**Related issues**: N/A
