### PR TITLE
move bytes deleted to remote cache dashboard

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -4610,114 +4610,6 @@
                 }
               },
               "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "binBps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 73
-          },
-          "id": 6434,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "repeat": "cache_name",
-          "repeatDirection": "h",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom"
-              },
-              "editorMode": "code",
-              "expr": "sum by(pod_name, partition_id) (deriv(buildbuddy_remote_cache_disk_cache_partition_size_bytes{region=\"${region}\", cache_name=\"${cache_name}\"}[10m]))",
-              "legendFormat": "{{partition_id}} partition size delta",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prom"
-              },
-              "editorMode": "code",
-              "expr": "sum by(pod_name, partition_id) (rate(buildbuddy_remote_cache_disk_cache_partition_size_bytes_evicted{region=\"${region}\", cache_name=\"${cache_name}\"}[10m]))",
-              "hide": false,
-              "legendFormat": "{{partition_id}} size evicted",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "Bytes deleted per second (${cache_name})",
-          "type": "timeseries"
-        },
-        {
-          "collapsed": true,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prom"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
               "max": 1,
               "min": 0,
               "thresholds": {
@@ -4740,7 +4632,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 81
+            "y": 73
           },
           "id": 2182,
           "options": {
@@ -4812,7 +4704,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 89
+            "y": 81
           },
           "heatmap": {},
           "hideZeroBuckets": false,

--- a/tools/metrics/grafana/dashboards/cache.json
+++ b/tools/metrics/grafana/dashboards/cache.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 15,
+  "id": 6,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -63,6 +63,7 @@
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -102,7 +103,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 1
           },
           "id": 2370,
           "options": {
@@ -174,7 +175,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 25
+            "y": 9
           },
           "heatmap": {},
           "hideZeroBuckets": false,
@@ -223,7 +224,7 @@
               "unit": "dtdurationms"
             }
           },
-          "pluginVersion": "9.3.1",
+          "pluginVersion": "10.1.0",
           "repeat": "cache_name",
           "repeatDirection": "h",
           "reverseYBuckets": false,
@@ -259,6 +260,140 @@
             "show": true
           },
           "yBucketBound": "auto"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": [
+              {
+                "__systemRef": "hideSeriesFrom",
+                "matcher": {
+                  "id": "byNames",
+                  "options": {
+                    "mode": "exclude",
+                    "names": [
+                      "bytes evicted buildbuddy-app-5 "
+                    ],
+                    "prefix": "All except:",
+                    "readOnly": true
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 6201,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "repeat": "cache_name",
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by(pod_name) (deriv(buildbuddy_remote_cache_disk_cache_partition_size_bytes{region=\"${region}\", cache_name=\"${cache_name}\", partition_id=\"${partition_id}\"}[${window}]))",
+              "instant": false,
+              "legendFormat": "total partition size delta {{pod_name}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by(pod_name) (rate(buildbuddy_remote_cache_disk_cache_partition_size_bytes_evicted{region=\"${region}\", cache_name=\"${cache_name}\", partition_id=\"${partition_id}\"}[${window}]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "bytes evicted {{pod_name}} ",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Bytes evicted rate (${cache_name})",
+          "type": "timeseries"
         }
       ],
       "repeat": "partition_id",
@@ -272,7 +407,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 3
+        "y": 4
       },
       "id": 3104,
       "panels": [
@@ -336,7 +471,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 30
           },
           "id": 3187,
           "options": {
@@ -439,7 +574,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 30
           },
           "id": 3269,
           "options": {
@@ -554,7 +689,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 30
+            "y": 38
           },
           "id": 3433,
           "options": {
@@ -621,7 +756,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 30
+            "y": 38
           },
           "id": 3597,
           "options": {
@@ -686,7 +821,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 5
       },
       "id": 5799,
       "panels": [
@@ -779,7 +914,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 24
+            "y": 32
           },
           "id": 5720,
           "options": {
@@ -874,7 +1009,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 24
+            "y": 32
           },
           "id": 5955,
           "options": {
@@ -969,7 +1104,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 32
+            "y": 40
           },
           "id": 5877,
           "options": {
@@ -1064,7 +1199,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 32
+            "y": 40
           },
           "id": 6111,
           "options": {
@@ -1184,7 +1319,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 40
+            "y": 48
           },
           "id": 6033,
           "options": {
@@ -1279,7 +1414,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 40
+            "y": 48
           },
           "id": 6189,
           "options": {
@@ -1316,7 +1451,7 @@
     }
   ],
   "refresh": "1m",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
It's difficult to examine the graph when we show two queries for all different
combo pod_name and partition_id in the same graph. It's better to move them to
per partition graph in remote cache dashboard.
