### PR TITLE
Add type-safe fixed-size byte buffer pool option to `bytebufferpool` package.

### DIFF
--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -47,7 +47,7 @@ type CacheProxy struct {
 	env                   environment.Env
 	cache                 interfaces.Cache
 	log                   log.Logger
-	bufferPool            *bytebufferpool.Pool
+	readBufPool           *bytebufferpool.VariableSizePool
 	writeBufPool          sync.Pool
 	mu                    *sync.Mutex
 	server                *grpc.Server

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -47,7 +47,7 @@ type CacheProxy struct {
 	env                   environment.Env
 	cache                 interfaces.Cache
 	log                   log.Logger
-	readBufPool           *bytebufferpool.Pool
+	bufferPool            *bytebufferpool.Pool
 	writeBufPool          sync.Pool
 	mu                    *sync.Mutex
 	server                *grpc.Server
@@ -63,7 +63,7 @@ func NewCacheProxy(env environment.Env, c interfaces.Cache, listenAddr string) *
 		env:         env,
 		cache:       c,
 		log:         log.NamedSubLogger(fmt.Sprintf("CacheProxy(%s)", listenAddr)),
-		readBufPool: bytebufferpool.New(readBufSizeBytes),
+		readBufPool: bytebufferpool.VariableSize(readBufSizeBytes),
 		writeBufPool: sync.Pool{
 			New: func() any {
 				return bufio.NewWriterSize(io.Discard, readBufSizeBytes)

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -38,7 +38,7 @@ var (
 type ByteStreamServer struct {
 	env        environment.Env
 	cache      interfaces.Cache
-	bufferPool *bytebufferpool.Pool
+	bufferPool *bytebufferpool.VariableSizePool
 }
 
 func Register(env environment.Env) error {
@@ -62,7 +62,7 @@ func NewByteStreamServer(env environment.Env) (*ByteStreamServer, error) {
 	return &ByteStreamServer{
 		env:        env,
 		cache:      cache,
-		bufferPool: bytebufferpool.New(readBufSizeBytes),
+		bufferPool: bytebufferpool.VariableSize(readBufSizeBytes),
 	}, nil
 }
 

--- a/server/remote_cache/cachetools/cachetools.go
+++ b/server/remote_cache/cachetools/cachetools.go
@@ -399,7 +399,7 @@ type BatchCASUploader struct {
 	once            *sync.Once
 	compress        bool
 	eg              *errgroup.Group
-	bufferPool      *bytebufferpool.Pool
+	bufferPool      *bytebufferpool.VariableSizePool
 	unsentBatchReq  *repb.BatchUpdateBlobsRequest
 	uploads         map[digest.Key]struct{}
 	instanceName    string
@@ -417,7 +417,7 @@ func NewBatchCASUploader(ctx context.Context, env environment.Env, instanceName 
 		once:            &sync.Once{},
 		compress:        false,
 		eg:              eg,
-		bufferPool:      bytebufferpool.New(uploadBufSizeBytes),
+		bufferPool:      bytebufferpool.VariableSize(uploadBufSizeBytes),
 		unsentBatchReq:  &repb.BatchUpdateBlobsRequest{InstanceName: instanceName, DigestFunction: digestFunction},
 		unsentBatchSize: 0,
 		instanceName:    instanceName,

--- a/server/util/bytebufferpool/bytebufferpool_test.go
+++ b/server/util/bytebufferpool/bytebufferpool_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBufferSize(t *testing.T) {
-	bp := bytebufferpool.New(1024)
+	bp := bytebufferpool.VariableSize(1024)
 
 	type test struct {
 		dataSize   int64
@@ -32,7 +32,7 @@ func TestBufferSize(t *testing.T) {
 }
 
 func TestReuse(t *testing.T) {
-	bp := bytebufferpool.New(1024)
+	bp := bytebufferpool.VariableSize(1024)
 
 	for i := 1; i < 20; i++ {
 		bp.Put(make([]byte, i))


### PR DESCRIPTION
It essentially already existed (safeSyncPool) but was private to the package.

Removed use of generics since we were ever using it with a single type. 