### PR TITLE
Broadcast range messages on events channel

### DIFF
--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -246,8 +246,10 @@ func NewRaftCache(env environment.Env, conf *Config) (*RaftCache, error) {
 		return nil, err
 	}
 
+	eventsCh, _ := rc.store.AddEventListener()
+
 	// start the driver once bringup is complete.
-	rc.driver = driver.New(rc.store, rc.gossipManager)
+	rc.driver = driver.New(rc.store, rc.gossipManager, eventsCh)
 	go func() {
 		for !rc.clusterStarter.Done() {
 			time.Sleep(100 * time.Millisecond)

--- a/enterprise/server/raft/driver/BUILD
+++ b/enterprise/server/raft/driver/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/driver",
     deps = [
         "//enterprise/server/raft/constants",
+        "//enterprise/server/raft/events",
         "//enterprise/server/raft/store",
         "//proto:raft_go_proto",
         "//proto:raft_service_go_proto",
@@ -17,6 +18,7 @@ go_library(
         "//server/util/statusz",
         "@com_github_hashicorp_serf//serf",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/enterprise/server/raft/driver/driver.go
+++ b/enterprise/server/raft/driver/driver.go
@@ -272,6 +272,11 @@ func (d *Driver) Start() error {
 }
 
 func (d *Driver) Stop() error {
+	now := time.Now()
+	defer func() {
+		log.Printf("Driver shutdown finished in %s", time.Since(now))
+	}()
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 

--- a/enterprise/server/raft/driver/driver.go
+++ b/enterprise/server/raft/driver/driver.go
@@ -11,12 +11,14 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/events"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/store"
 	"github.com/buildbuddy-io/buildbuddy/server/gossip"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/statusz"
 	"github.com/hashicorp/serf/serf"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
@@ -91,7 +93,7 @@ type ClusterMap struct {
 	rangeUsage map[uint64]*rfpb.ReplicaUsage
 
 	// map of nhid -> replicas running on node
-	replicas map[string]replicaSet
+	replicas replicaSet
 }
 
 type timestampedUsage struct {
@@ -107,7 +109,7 @@ func NewClusterMap() *ClusterMap {
 		leaveTime:    make(map[string]time.Time),
 		leasedRanges: make(map[uint64]*rfpb.RangeDescriptor),
 		rangeUsage:   make(map[uint64]*rfpb.ReplicaUsage),
-		replicas:     make(map[string]replicaSet),
+		replicas:     make(replicaSet),
 	}
 }
 
@@ -131,7 +133,7 @@ func (cm *ClusterMap) ObserveNode(nhid string, usage *rfpb.StoreUsage, nodeStatu
 	return nil
 }
 
-func (cm *ClusterMap) ObserveLocalReplicaUsage(nhid string, usage *rfpb.ReplicaUsage, rd *rfpb.RangeDescriptor) error {
+func (cm *ClusterMap) ObserveLocalReplicaUsage(usage *rfpb.ReplicaUsage, rd *rfpb.RangeDescriptor) error {
 	if usage == nil {
 		return status.FailedPreconditionError("nil range usage")
 	}
@@ -141,24 +143,17 @@ func (cm *ClusterMap) ObserveLocalReplicaUsage(nhid string, usage *rfpb.ReplicaU
 
 	cm.rangeUsage[rd.GetRangeId()] = usage
 
-	if _, ok := cm.replicas[nhid]; !ok {
-		cm.replicas[nhid] = NewReplicaSet()
-	}
-	cm.replicas[nhid].Add(usage.GetReplica())
+	cm.replicas.Add(usage.GetReplica())
 
 	return nil
 }
 
-func (cm *ClusterMap) OnReplicaUsageUpdate(nhid string, ru *rfpb.ReplicaUsage, rd *rfpb.RangeDescriptor) {
-	if err := cm.ObserveLocalReplicaUsage(nhid, ru, rd); err != nil {
-		log.Errorf("Error observing local range usage: %s", err)
-	}
-}
 func (cm *ClusterMap) OnRangeLeaseAcquired(rd *rfpb.RangeDescriptor) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	cm.leasedRanges[rd.GetRangeId()] = rd
 }
+
 func (cm *ClusterMap) OnRangeLeaseDropped(rd *rfpb.RangeDescriptor) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
@@ -225,26 +220,28 @@ func (cm *ClusterMap) MeanProposeQPS() float64 {
 type Driver struct {
 	store         rfspb.ApiServer
 	gossipManager *gossip.GossipManager
-	mu            *sync.Mutex
-	started       bool
-	quit          chan struct{}
-	ClusterMap    *ClusterMap
-	startTime     time.Time
+	updates       <-chan events.Event
+
+	mu         *sync.Mutex
+	ClusterMap *ClusterMap
+	startTime  time.Time
+
+	eg       *errgroup.Group
+	egCancel context.CancelFunc
 }
 
-func New(store *store.Store, gossipManager *gossip.GossipManager) *Driver {
+func New(store *store.Store, gossipManager *gossip.GossipManager, updates <-chan events.Event) *Driver {
 	d := &Driver{
 		store:         store,
 		gossipManager: gossipManager,
+		updates:       updates,
 		mu:            &sync.Mutex{},
-		started:       false,
 		ClusterMap:    NewClusterMap(),
 		startTime:     time.Now(),
 	}
 	// Register the driver as a gossip listener so that it receives
 	// gossip callbacks.
 	gossipManager.AddListener(d)
-	store.AddRangeUsageListener(d.ClusterMap)
 	statusz.AddSection("raft_driver", "Placement Driver", d)
 	return d
 }
@@ -256,14 +253,20 @@ func (d *Driver) Start() error {
 	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if d.started {
-		return nil
-	}
 
-	d.quit = make(chan struct{})
-	go d.manageClustersLoop()
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	d.egCancel = cancelFunc
 
-	d.started = true
+	eg, gctx := errgroup.WithContext(ctx)
+	d.eg = eg
+
+	eg.Go(func() error {
+		return d.handleEvents(gctx)
+	})
+	eg.Go(func() error {
+		return d.manageClustersLoop(gctx)
+	})
+
 	log.Debugf("Driver started")
 	return nil
 }
@@ -271,11 +274,10 @@ func (d *Driver) Start() error {
 func (d *Driver) Stop() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if !d.started {
-		return nil
-	}
-	close(d.quit)
-	d.started = false
+
+	d.egCancel()
+	d.eg.Wait()
+
 	log.Debugf("Driver stopped")
 	return nil
 }
@@ -283,17 +285,53 @@ func (d *Driver) Stop() error {
 // manageClustersLoop loops does not return; call it from a goroutine.
 // It will loop forever calling "manageClusters" until the quit channel
 // is closed by driver.Close().
-func (d *Driver) manageClustersLoop() {
+func (d *Driver) manageClustersLoop(ctx context.Context) error {
 	for {
 		select {
-		case <-d.quit:
-			return
+		case <-ctx.Done():
+			return nil
 		case <-time.After(*driverPollInterval):
 			err := d.manageClusters()
 			if err != nil {
 				log.Errorf("Manage clusters error: %s", err)
 			}
 		}
+	}
+}
+
+func (d *Driver) handleEvents(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case e := <-d.updates:
+			d.processSingleEvent(e)
+		}
+	}
+}
+
+func (d *Driver) processSingleEvent(e events.Event) {
+	switch e.EventType() {
+	case events.EventRangeUsageUpdated:
+		rangeUsageEvent, ok := e.(events.RangeUsageEvent)
+		if !ok {
+			return
+		}
+		d.ClusterMap.ObserveLocalReplicaUsage(rangeUsageEvent.ReplicaUsage, rangeUsageEvent.RangeDescriptor)
+	case events.EventRangeLeaseAcquired:
+		rangeEvent, ok := e.(events.RangeEvent)
+		if !ok {
+			return
+		}
+		d.ClusterMap.OnRangeLeaseAcquired(rangeEvent.RangeDescriptor)
+	case events.EventRangeLeaseDropped:
+		rangeEvent, ok := e.(events.RangeEvent)
+		if !ok {
+			return
+		}
+		d.ClusterMap.OnRangeLeaseDropped(rangeEvent.RangeDescriptor)
+	default:
+		return
 	}
 }
 

--- a/enterprise/server/raft/driver/driver.go
+++ b/enterprise/server/raft/driver/driver.go
@@ -280,8 +280,10 @@ func (d *Driver) Stop() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	d.egCancel()
-	d.eg.Wait()
+	if d.egCancel != nil {
+		d.egCancel()
+		d.eg.Wait()
+	}
 
 	log.Debugf("Driver stopped")
 	return nil

--- a/enterprise/server/raft/driver/driver_test.go
+++ b/enterprise/server/raft/driver/driver_test.go
@@ -54,7 +54,7 @@ func (tn *testNode) flush() {
 		rd := &rfpb.RangeDescriptor{
 			RangeId: ru.GetReplica().GetShardId(),
 		}
-		require.NoError(tn.state.tb, tn.state.cm.ObserveLocalReplicaUsage(tn.nhid, ru, rd))
+		require.NoError(tn.state.tb, tn.state.cm.ObserveLocalReplicaUsage(ru, rd))
 	}
 	require.NoError(tn.state.tb, tn.state.cm.ObserveNode(tn.nhid, storeUsage, serf.StatusAlive))
 }

--- a/enterprise/server/raft/events/BUILD
+++ b/enterprise/server/raft/events/BUILD
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "events",
+    srcs = ["events.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/events",
+    visibility = ["//visibility:public"],
+    deps = ["//proto:raft_go_proto"],
+)
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/raft/events/events.go
+++ b/enterprise/server/raft/events/events.go
@@ -1,0 +1,87 @@
+package events
+
+import (
+	"fmt"
+
+	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+)
+
+type EventType int
+
+const (
+	// Value will be the added range's RangeDescriptor.
+	EventRangeAdded EventType = iota
+	// Value will be the removed range's RangeDescriptor.
+	EventRangeRemoved
+	// Value will be the range's RangeUsage.
+	EventRangeUsageUpdated
+	// Value will be the lease-acquired range's RangeDescriptor.
+	EventRangeLeaseAcquired
+	// Value will be the lease-dropped range's RangeDescriptor.
+	EventRangeLeaseDropped
+)
+
+type Event interface {
+	EventType() EventType
+	String() string
+}
+
+func (t EventType) String() string {
+	switch t {
+	case EventRangeAdded:
+		return "range-added"
+	case EventRangeRemoved:
+		return "range-removed"
+	case EventRangeUsageUpdated:
+		return "range-usage-updated"
+	case EventRangeLeaseAcquired:
+		return "range-lease-acquired"
+	case EventRangeLeaseDropped:
+		return "range-lease-dropped"
+	default:
+		return fmt.Sprintf("unknown event type: %d", t)
+	}
+}
+
+type RangeEvent struct {
+	Type            EventType
+	RangeDescriptor *rfpb.RangeDescriptor
+}
+
+func (r RangeEvent) EventType() EventType {
+	return r.Type
+}
+
+func (r RangeEvent) String() string {
+	switch r.Type {
+	case EventRangeAdded:
+		return "range-added"
+	case EventRangeRemoved:
+		return "range-removed"
+	case EventRangeLeaseAcquired:
+		return "range-lease-acquired"
+	case EventRangeLeaseDropped:
+		return "range-lease-dropped"
+	default:
+		return fmt.Sprintf("unknown event type: %d", r.Type)
+	}
+}
+
+type RangeUsageEvent struct {
+	Type            EventType
+	RangeDescriptor *rfpb.RangeDescriptor
+	ReplicaUsage    *rfpb.ReplicaUsage
+}
+
+func (u RangeUsageEvent) EventType() EventType {
+	return u.Type
+}
+
+func (u RangeUsageEvent) String() string {
+	switch u.Type {
+	case EventRangeUsageUpdated:
+		return "range-usage-updated"
+	default:
+		return fmt.Sprintf("unknown event type: %d", u.Type)
+	}
+}

--- a/enterprise/server/raft/leasekeeper/BUILD
+++ b/enterprise/server/raft/leasekeeper/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/leasekeeper",
     visibility = ["//visibility:public"],
     deps = [
+        "//enterprise/server/raft/events",
         "//enterprise/server/raft/listener",
         "//enterprise/server/raft/nodeliveness",
         "//enterprise/server/raft/rangelease",

--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -62,6 +62,11 @@ func (lk *LeaseKeeper) Start() {
 }
 
 func (lk *LeaseKeeper) Stop() {
+	now := time.Now()
+	defer func() {
+		log.Printf("Leasekeeper shutdown finished in %s", time.Since(now))
+	}()
+
 	lk.mu.Lock()
 	defer lk.mu.Unlock()
 	close(lk.quitAll)

--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/events"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/listener"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/nodeliveness"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rangelease"
@@ -18,9 +19,10 @@ import (
 type shardID uint64
 
 type LeaseKeeper struct {
-	nodeHost *dragonboat.NodeHost
-	liveness *nodeliveness.Liveness
-	listener *listener.RaftListener
+	nodeHost  *dragonboat.NodeHost
+	liveness  *nodeliveness.Liveness
+	listener  *listener.RaftListener
+	broadcast chan<- events.Event
 
 	// map shardID -> leaseAndContext
 	leases sync.Map
@@ -36,14 +38,15 @@ type LeaseKeeper struct {
 	cancelNodeLivenessUpdates func()
 }
 
-func New(nodeHost *dragonboat.NodeHost, liveness *nodeliveness.Liveness, listener *listener.RaftListener) *LeaseKeeper {
+func New(nodeHost *dragonboat.NodeHost, liveness *nodeliveness.Liveness, listener *listener.RaftListener, broadcast chan<- events.Event) *LeaseKeeper {
 	return &LeaseKeeper{
-		nodeHost: nodeHost,
-		liveness: liveness,
-		listener: listener,
-		mu:       sync.Mutex{},
-		leases:   sync.Map{},
-		leaders:  make(map[shardID]bool),
+		nodeHost:  nodeHost,
+		liveness:  liveness,
+		listener:  listener,
+		broadcast: broadcast,
+		mu:        sync.Mutex{},
+		leases:    sync.Map{},
+		leaders:   make(map[shardID]bool),
 	}
 }
 
@@ -67,9 +70,23 @@ func (lk *LeaseKeeper) Stop() {
 }
 
 type leaseAndContext struct {
-	ctx    context.Context
-	cancel context.CancelFunc
-	l      *rangelease.Lease
+	ctx       context.Context
+	cancel    context.CancelFunc
+	l         *rangelease.Lease
+	broadcast chan<- events.Event
+}
+
+func (lac *leaseAndContext) broadcastLeaseStatus(eventType events.EventType) {
+	re := events.RangeEvent{
+		Type:            eventType,
+		RangeDescriptor: lac.l.GetRangeDescriptor(),
+	}
+	select {
+	case lac.broadcast <- re:
+		break
+	default:
+		log.Warningf("dropping lease status update %+v", re)
+	}
 }
 
 func (lac *leaseAndContext) Update(leader bool) {
@@ -78,6 +95,7 @@ func (lac *leaseAndContext) Update(leader bool) {
 	}
 	lac.ctx, lac.cancel = context.WithCancel(context.TODO())
 
+	valid := lac.l.Valid()
 	start := time.Now()
 	if leader {
 		if err := lac.l.Lease(lac.ctx); err != nil {
@@ -85,10 +103,17 @@ func (lac *leaseAndContext) Update(leader bool) {
 			return
 		}
 		log.Debugf("Updated lease state [%s] %s after callback", lac.l.String(), time.Since(start))
+		if !valid {
+			lac.broadcastLeaseStatus(events.EventRangeLeaseAcquired)
+		}
 	} else {
 		// This is a no-op if we don't have the lease.
 		if err := lac.l.Release(lac.ctx); err != nil {
 			log.Errorf("Error dropping rangelease (%s): %s", lac.l, err)
+			return
+		}
+		if valid {
+			lac.broadcastLeaseStatus(events.EventRangeLeaseDropped)
 		}
 	}
 }
@@ -127,7 +152,8 @@ func (lk *LeaseKeeper) watchLeases() {
 
 func (lk *LeaseKeeper) newLeaseAndContext(rd *rfpb.RangeDescriptor) leaseAndContext {
 	return leaseAndContext{
-		l: rangelease.New(lk.nodeHost, lk.liveness, rd),
+		l:         rangelease.New(lk.nodeHost, lk.liveness, rd),
+		broadcast: lk.broadcast,
 	}
 }
 

--- a/enterprise/server/raft/listener/BUILD
+++ b/enterprise/server/raft/listener/BUILD
@@ -7,7 +7,6 @@ go_library(
     srcs = ["listener.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/listener",
     deps = [
-        "//proto:raft_go_proto",
         "//server/util/log",
         "@com_github_lni_dragonboat_v4//raftio",
     ],

--- a/enterprise/server/raft/listener/BUILD
+++ b/enterprise/server/raft/listener/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["listener.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/listener",
     deps = [
+        "//proto:raft_go_proto",
         "//server/util/log",
         "@com_github_lni_dragonboat_v4//raftio",
     ],

--- a/enterprise/server/raft/replica/BUILD
+++ b/enterprise/server/raft/replica/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/replica",
     deps = [
         "//enterprise/server/raft/constants",
+        "//enterprise/server/raft/events",
         "//enterprise/server/raft/filestore",
         "//enterprise/server/raft/keys",
         "//enterprise/server/raft/rbuilder",

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//enterprise/server/raft/client",
         "//enterprise/server/raft/config",
         "//enterprise/server/raft/constants",
+        "//enterprise/server/raft/events",
         "//enterprise/server/raft/filestore",
         "//enterprise/server/raft/keys",
         "//enterprise/server/raft/leasekeeper",

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/client"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/events"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/filestore"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/leasekeeper"
@@ -82,22 +83,25 @@ type Store struct {
 	leaseKeeper *leasekeeper.LeaseKeeper
 	replicas    sync.Map // map of uint64 rangeID -> *replica.Replica
 
-	usageUpdates        chan *rfpb.ReplicaUsage
-	usages              *usagetracker.Tracker
-	rangeUsageListeners []RangeUsageListener
+	eventsMu       sync.Mutex
+	events         chan events.Event
+	eventListeners []chan events.Event
+
+	usages *usagetracker.Tracker
 
 	metaRangeMu   sync.Mutex
 	metaRangeData []byte
 
 	fileStorer filestore.Store
 
-	closeLeaderUpdatesChan func()
-	eg                     errgroup.Group
-	egCancel               context.CancelFunc
+	eg       *errgroup.Group
+	egCancel context.CancelFunc
 }
 
 func New(rootDir string, nodeHost *dragonboat.NodeHost, gossipManager *gossip.GossipManager, sender *sender.Sender, registry registry.NodeRegistry, listener *listener.RaftListener, apiClient *client.APIClient, grpcAddress string, partitions []disk.Partition) (*Store, error) {
 	nodeLiveness := nodeliveness.New(nodeHost.ID(), sender)
+
+	eventsChan := make(chan events.Event, 100)
 	s := &Store{
 		rootDir:       rootDir,
 		grpcAddr:      grpcAddress,
@@ -111,14 +115,16 @@ func New(rootDir string, nodeHost *dragonboat.NodeHost, gossipManager *gossip.Go
 		liveness:      nodeLiveness,
 		log:           log.NamedSubLogger(nodeHost.ID()),
 
-		rangeMu:             sync.RWMutex{},
-		openRanges:          make(map[uint64]*rfpb.RangeDescriptor),
-		rangeUsageListeners: make([]RangeUsageListener, 0),
+		rangeMu:    sync.RWMutex{},
+		openRanges: make(map[uint64]*rfpb.RangeDescriptor),
 
-		leaseKeeper: leasekeeper.New(nodeHost, nodeLiveness, listener),
+		leaseKeeper: leasekeeper.New(nodeHost, nodeLiveness, listener, eventsChan),
 		replicas:    sync.Map{},
 
-		usageUpdates:  make(chan *rfpb.ReplicaUsage, 100),
+		eventsMu:       sync.Mutex{},
+		events:         eventsChan,
+		eventListeners: make([]chan events.Event, 0),
+
 		metaRangeMu:   sync.Mutex{},
 		metaRangeData: make([]byte, 0),
 		fileStorer:    filestore.New(),
@@ -245,36 +251,39 @@ func (s *Store) Statusz(ctx context.Context) string {
 	return buf
 }
 
-func (s *Store) handleUsageUpdates(ctx context.Context, usageUpdatesChan <-chan *rfpb.ReplicaUsage) error {
-	for {
-		select {
-		case usage := <-usageUpdatesChan:
-			if rd := s.lookupRange(usage.GetRangeId()); rd != nil {
-				s.NotifyUsage(usage, rd)
-			} else {
-				log.Warningf("Usage update for unknown range: %d", usage.GetRangeId())
+func (s *Store) handleEvents(ctx context.Context) error {
+	for e := range s.events {
+		log.Debugf("event: %+v", e)
+		s.eventsMu.Lock()
+		for _, ch := range s.eventListeners {
+			select {
+			case ch <- e:
+				continue
+			default:
+				log.Warningf("Dropped event: %s", e)
 			}
-		case <-ctx.Done():
-			return nil
 		}
+		s.eventsMu.Unlock()
 	}
+	return nil
 }
 
-func (s *Store) NotifyUsage(replicaUsage *rfpb.ReplicaUsage, rd *rfpb.RangeDescriptor) {
-	for _, rep := range rd.GetReplicas() {
-		ru := proto.Clone(replicaUsage).(*rfpb.ReplicaUsage)
-		ru.Replica = rep
+func (s *Store) AddEventListener() (<-chan events.Event, func()) {
+	s.eventsMu.Lock()
+	defer s.eventsMu.Unlock()
 
-		nhid, _, err := s.registry.ResolveNHID(rep.GetShardId(), rep.GetReplicaId())
-		if err != nil {
-			log.Errorf("Error resolving nhid: %s", err)
-			return
-		}
-		for _, rul := range s.rangeUsageListeners {
-			rul.OnReplicaUsageUpdate(nhid, ru, rd)
+	ch := make(chan events.Event, 10)
+	s.eventListeners = append(s.eventListeners, ch)
+	closeFunc := func() {
+		s.eventsMu.Lock()
+		defer s.eventsMu.Unlock()
+		for i, l := range s.eventListeners {
+			if l == ch {
+				s.eventListeners = append(s.eventListeners[:i], s.eventListeners[:i+1]...)
+			}
 		}
 	}
-	s.updateTags()
+	return ch, closeFunc
 }
 
 func (s *Store) Start() error {
@@ -298,8 +307,9 @@ func (s *Store) Start() error {
 	s.egCancel = cancelFunc
 
 	eg, gctx := errgroup.WithContext(ctx)
+	s.eg = eg
 	eg.Go(func() error {
-		return s.handleUsageUpdates(gctx, s.usageUpdates)
+		return s.handleEvents(gctx)
 	})
 	s.leaseKeeper.Start()
 	return nil
@@ -381,14 +391,18 @@ func (s *Store) updateUsages(r *replica.Replica) error {
 	return nil
 }
 
-type RangeUsageListener interface {
-	OnReplicaUsageUpdate(nhid string, ru *rfpb.ReplicaUsage, rd *rfpb.RangeDescriptor)
-	OnRangeLeaseAcquired(rd *rfpb.RangeDescriptor)
-	OnRangeLeaseDropped(rd *rfpb.RangeDescriptor)
-}
+func (s *Store) sendRangeEvent(eventType events.EventType, rd *rfpb.RangeDescriptor) {
+	ev := events.RangeEvent{
+		Type:            eventType,
+		RangeDescriptor: rd,
+	}
 
-func (s *Store) AddRangeUsageListener(rul RangeUsageListener) {
-	s.rangeUsageListeners = append(s.rangeUsageListeners, rul)
+	select {
+	case s.events <- ev:
+		break
+	default:
+		s.log.Warningf("Dropping range event: %+v", ev)
+	}
 }
 
 // We need to implement the Add/RemoveRange interface so that stores opened and
@@ -419,6 +433,8 @@ func (s *Store) AddRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 		return
 	}
 
+	s.sendRangeEvent(events.EventRangeAdded, rd)
+
 	if rangelease.ContainsMetaRange(rd) {
 		// If we own the metarange, use gossip to notify other nodes
 		// of that fact.
@@ -431,7 +447,6 @@ func (s *Store) AddRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 	}
 
 	s.leaseKeeper.AddRange(rd)
-
 	// Start goroutines for these so that Adding ranges is quick.
 	go s.updateTags()
 	go s.updateUsages(r)
@@ -455,6 +470,7 @@ func (s *Store) RemoveRange(rd *rfpb.RangeDescriptor, r *replica.Replica) {
 		return
 	}
 
+	s.sendRangeEvent(events.EventRangeRemoved, rd)
 	s.leaseKeeper.RemoveRange(rd)
 	go s.updateTags()
 }
@@ -540,7 +556,7 @@ func (s *Store) LeasedRange(header *rfpb.Header) (*replica.Replica, error) {
 }
 
 func (s *Store) ReplicaFactoryFn(shardID, replicaID uint64) dbsm.IOnDiskStateMachine {
-	r := replica.New(s.leaser, shardID, replicaID, s, s.usageUpdates)
+	r := replica.New(s.leaser, shardID, replicaID, s, s.events)
 	return r
 }
 
@@ -828,6 +844,7 @@ func (s *Store) Usage() *rfpb.StoreUsage {
 	return su
 }
 
+// TODO(tylerw): remove this; let usagetracker listen on events channel.
 func (s *Store) RefreshReplicaUsages() []*rfpb.ReplicaUsage {
 	s.rangeMu.RLock()
 	openRanges := make([]*rfpb.RangeDescriptor, 0, len(s.openRanges))


### PR DESCRIPTION
Previously there were various components that could update or depend on cluster state and each required a different set of information. That led to a multiplicative number of types / channels. Instead, use a single events channel and allow various components (leasekeeper, store, usagetracker, driver) to read and write what they need from the channel.