### PR TITLE
workflows: set env vars needed for snapshot matching

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -502,23 +502,6 @@ func run() error {
 	}
 	ws.rootDir = rootDir
 
-	if *workflowID != "" {
-		if err := os.Setenv("CI", "true"); err != nil {
-			return status.WrapError(err, "set CI=true")
-		}
-	}
-
-	// Set convenience env vars (best-effort).
-	if *prNumber != 0 {
-		os.Setenv("GIT_PR_NUMBER", fmt.Sprint(*prNumber))
-	}
-	if *commitSHA != "" {
-		os.Setenv("GIT_COMMIT", fmt.Sprint(*commitSHA))
-	}
-	if *pushedBranch != "" {
-		os.Setenv("GIT_BRANCH", fmt.Sprint(*pushedBranch))
-	}
-
 	// Set BUILDBUDDY_CI_RUNNER_ABSPATH so that we can re-invoke ourselves
 	// as the git credential helper reliably, even after chdir.
 	absPath, err := filepath.Abs(os.Args[0])

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1100,7 +1100,14 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 	if err != nil {
 		return nil, err
 	}
-	envVars := []*repb.Command_EnvironmentVariable{}
+	envVars := []*repb.Command_EnvironmentVariable{
+		{Name: "CI", Value: "true"},
+		{Name: "GIT_COMMIT", Value: wd.SHA},
+		{Name: "GIT_BRANCH", Value: wd.PushedBranch},
+		{Name: "GIT_BASE_BRANCH", Value: wd.TargetBranch},
+		{Name: "GIT_REPO_DEFAULT_BRANCH", Value: wd.TargetRepoDefaultBranch},
+		{Name: "GIT_PR_NUMBER", Value: fmt.Sprintf("%d", wd.PullRequestNumber)},
+	}
 	containerImage := ""
 	isolationType := ""
 	os := strings.ToLower(workflowAction.OS)

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -122,39 +122,6 @@ message SchedulingMetadata {
   string executor_group_id = 5;
   // Group ID of the user that issued the Execute request.
   string task_group_id = 6;
-
-  // Firecracker remote snapshot sharing options.
-  //
-  // These allow matching tasks to remote snapshots based on properties other
-  // than Platform properties, since the Platform is hashed as part of the
-  // routing key.
-  //
-  // In particular, we would like to match tasks to snapshots based on the
-  // desired git revision of the repo in the snapshot, but we don't want the git
-  // revision info as part of the Platform (since the revision changes
-  // frequently, e.g. PR branch name).
-  //
-  // If not set, tasks will not be matched to remote snapshots at all, and
-  // instead only be matched to snapshots in the executor's local cache.
-  RemoteSnapshotOptions remote_snapshot_options = 9;
-}
-
-message RemoteSnapshotOptions {
-  // Primary git ref associated with the snapshot.
-  //
-  // When reading the snapshot from remote cache, the snapshot associated with
-  // this ref will be preferred if it exists, otherwise the fallback ref will be
-  // used.
-  //
-  // When writing the snapshot back to cache, this ref (not the fallback_ref)
-  // will always be used as the ref part of the key.
-  //
-  // Example: "my-cool-branch".
-  string ref = 1;
-
-  // Optional fallback ref in case the preferred one is unavailable.
-  // Example: "main"
-  string fallback_ref = 2;
 }
 
 message ScheduleTaskRequest {


### PR DESCRIPTION
* Removes `RemoteSnapshotOptions` - after offline discussion we decided to use env instead.
* Set `GIT_BRANCH`, `GIT_BASE_BRANCH`, `GIT_REPO_DEFAULT_BRANCH` in env, which are all useful for snapshot matching.

**Related issues**: N/A
