### PR TITLE
executor: use git refs for snapshot read/write

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -481,7 +481,7 @@ type FirecrackerContainer struct {
 	// based on the incoming task. If there is a new task, you may want to call
 	// NewContainer again rather than directly unpausing a pre-existing container,
 	// to make sure these fields are updated and the best snapshot match is used
-	snapshotKey             *fcpb.SnapshotKey
+	snapshotKeySet          *fcpb.SnapshotKeySet
 	createFromSnapshot      bool
 	supportsRemoteSnapshots bool
 
@@ -598,7 +598,7 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 		if *snaputil.EnableLocalSnapshotSharing {
 			runnerID = ""
 		}
-		c.snapshotKey, err = snaploader.NewKey(task, cd.GetHash(), runnerID)
+		c.snapshotKeySet, err = snaploader.SnapshotKeySet(task, cd.GetHash(), runnerID)
 		if err != nil {
 			return nil, err
 		}
@@ -607,11 +607,11 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 
 		recyclingEnabled := platform.IsTrue(platform.FindValue(task.GetCommand().GetPlatform(), platform.RecycleRunnerPropertyName))
 		if recyclingEnabled && *snaputil.EnableLocalSnapshotSharing {
-			_, err := loader.GetSnapshot(ctx, c.snapshotKey, c.supportsRemoteSnapshots)
+			_, err := loader.GetSnapshot(ctx, c.snapshotKeySet, c.supportsRemoteSnapshots)
 			c.createFromSnapshot = (err == nil)
 		}
 	} else {
-		c.snapshotKey = opts.SavedState.GetSnapshotKey()
+		c.snapshotKeySet = &fcpb.SnapshotKeySet{BranchKey: opts.SavedState.GetSnapshotKey()}
 
 		// TODO(bduffany): add version info to snapshots. For example, if a
 		// breaking change is made to the vmexec API, the executor should not
@@ -725,8 +725,8 @@ func alignToMultiple(n int64, multiple int64) int64 {
 	return n + multiple - remainder
 }
 
-func (c *FirecrackerContainer) SnapshotKey() *fcpb.SnapshotKey {
-	return proto.Clone(c.snapshotKey).(*fcpb.SnapshotKey)
+func (c *FirecrackerContainer) SnapshotKeySet() *fcpb.SnapshotKeySet {
+	return proto.Clone(c.snapshotKeySet).(*fcpb.SnapshotKeySet)
 }
 
 // State returns the container state to be persisted to disk so that this
@@ -745,7 +745,7 @@ func (c *FirecrackerContainer) State(ctx context.Context) (*rnpb.ContainerState,
 		IsolationType: string(platform.FirecrackerContainerType),
 		FirecrackerState: &rnpb.FirecrackerState{
 			VmConfiguration: c.vmConfig,
-			SnapshotKey:     c.snapshotKey,
+			SnapshotKey:     c.snapshotKeySet.GetBranchKey(),
 		},
 	}
 	return state, nil
@@ -840,7 +840,11 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 	}
 
 	snaploaderStart := time.Now()
-	if err := c.loader.CacheSnapshot(ctx, c.snapshotKey, opts); err != nil {
+	// Note: we only update the main snapshot here, i.e. the one corresponding
+	// to the pushed git branch. We do not update the fallback key(s) that we
+	// might've read from, i.e. the ones corresponding to the PR base branch or
+	// repo's default branch.
+	if err := c.loader.CacheSnapshot(ctx, c.snapshotKeySet.GetBranchKey(), opts); err != nil {
 		return status.WrapError(err, "add snapshot to cache")
 	}
 	log.CtxDebugf(ctx, "snaploader.CacheSnapshot took %s", time.Since(snaploaderStart))
@@ -935,7 +939,7 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 	}
 	log.CtxDebugf(ctx, "Command: %v", reflect.Indirect(reflect.Indirect(reflect.ValueOf(machine)).FieldByName("cmd")).FieldByName("Args"))
 
-	snap, err := c.loader.GetSnapshot(ctx, c.snapshotKey, c.supportsRemoteSnapshots)
+	snap, err := c.loader.GetSnapshot(ctx, c.snapshotKeySet, c.supportsRemoteSnapshots)
 	if err != nil {
 		return status.WrapError(err, "failed to get snapshot")
 	}
@@ -1120,7 +1124,7 @@ func (c *FirecrackerContainer) convertToCOW(ctx context.Context, filePath, chunk
 		return nil, status.WrapError(err, "make chunk dir")
 	}
 	// Use vmCtx for the COW since IO may be done outside of the task ctx.
-	cow, err := copy_on_write.ConvertFileToCOW(c.vmCtx, c.env, filePath, cowChunkSizeBytes(), chunkDir, c.snapshotKey.InstanceName, c.supportsRemoteSnapshots)
+	cow, err := copy_on_write.ConvertFileToCOW(c.vmCtx, c.env, filePath, cowChunkSizeBytes(), chunkDir, c.snapshotKeySet.GetBranchKey().GetInstanceName(), c.supportsRemoteSnapshots)
 	if err != nil {
 		return nil, status.WrapError(err, "convert file to COW")
 	}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -840,10 +840,10 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 	}
 
 	snaploaderStart := time.Now()
-	// Note: we only update the main snapshot here, i.e. the one corresponding
-	// to the pushed git branch. We do not update the fallback key(s) that we
-	// might've read from, i.e. the ones corresponding to the PR base branch or
-	// repo's default branch.
+	// Note: we only update the snapshot corresponding to the pushed git branch.
+	// We do not update the snapshot for any fallback key(s) that we may have
+	// read from, i.e. ones corresponding to the PR's base branch or the repo's
+	// default branch.
 	if err := c.loader.CacheSnapshot(ctx, c.snapshotKeySet.GetBranchKey(), opts); err != nil {
 		return status.WrapError(err, "add snapshot to cache")
 	}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_performance_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_performance_test.go
@@ -220,9 +220,9 @@ func TestFirecracker_RemoteSnapshotSharing_ManualBenchmarking(t *testing.T) {
 		require.NoError(t, err)
 		configHash, err := digest.ComputeForMessage(opts.VMConfiguration, repb.DigestFunction_SHA256)
 		require.NoError(t, err)
-		snapshotKey, err := snaploader.NewKey(task, configHash.GetHash(), "")
+		keySet, err := snaploader.SnapshotKeySet(task, configHash.GetHash(), "")
 		require.NoError(t, err)
-		snapMetadata, err := loader.GetSnapshot(ctx, snapshotKey, enableRemote)
+		snapMetadata, err := loader.GetSnapshot(ctx, keySet, enableRemote)
 		require.NoError(t, err)
 		for _, f := range snapMetadata.GetFiles() {
 			if rand.Intn(100) < 30 {
@@ -376,9 +376,9 @@ func TestFirecracker_RemoteSnapshotSharing_ManualBenchmarking(t *testing.T) {
 		require.NoError(t, err)
 		configHash, err := digest.ComputeForMessage(opts.VMConfiguration, repb.DigestFunction_SHA256)
 		require.NoError(t, err)
-		snapshotKey, err := snaploader.NewKey(task, configHash.GetHash(), "")
+		keySet, err := snaploader.SnapshotKeySet(task, configHash.GetHash(), "")
 		require.NoError(t, err)
-		snapMetadata, err := loader.GetSnapshot(ctx, snapshotKey, true)
+		snapMetadata, err := loader.GetSnapshot(ctx, keySet, true)
 		require.NoError(t, err)
 		for _, f := range snapMetadata.GetFiles() {
 			if rand.Intn(100) < 30 {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -782,13 +782,13 @@ func TestFirecrackerSnapshotVersioning(t *testing.T) {
 	require.NoError(t, err)
 	c2, err := firecracker.NewContainer(ctx, env, task, opts)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(c1.SnapshotKey(), c2.SnapshotKey(), protocmp.Transform()))
+	require.Empty(t, cmp.Diff(c1.SnapshotKeySet(), c2.SnapshotKeySet(), protocmp.Transform()))
 
 	// Change guest API version; snapshot keys should not be equal.
 	opts.ExecutorConfig.GuestAPIVersion = "something-else"
 	c3, err := firecracker.NewContainer(ctx, env, task, opts)
 	require.NoError(t, err)
-	require.NotEmpty(t, cmp.Diff(c1.SnapshotKey(), c3.SnapshotKey(), protocmp.Transform()))
+	require.NotEmpty(t, cmp.Diff(c1.SnapshotKeySet(), c3.SnapshotKeySet(), protocmp.Transform()))
 }
 
 func TestFirecrackerComplexFileMapping(t *testing.T) {

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -26,7 +26,6 @@ go_library(
         "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/anypb",
-        "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -26,6 +26,7 @@ go_library(
         "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/anypb",
+        "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -23,6 +23,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -43,21 +44,58 @@ const (
 	chunkedFileWriteConcurrency = 4
 )
 
-// NewKey returns the cache key for a snapshot.
+// SnapshotKeySet returns the cache keys for potential snapshot matches,
+// as well as the key that should be written to.
+//
 // TODO: include a version number in the key somehow, so that
 // if we make breaking changes e.g. to the vmexec API or firecracker
 // version etc., we can ensure that incompatible snapshots don't get reused.
-func NewKey(task *repb.ExecutionTask, configurationHash, runnerID string) (*fcpb.SnapshotKey, error) {
+func SnapshotKeySet(task *repb.ExecutionTask, configurationHash, runnerID string) (*fcpb.SnapshotKeySet, error) {
 	pd, err := digest.ComputeForMessage(task.GetCommand().GetPlatform(), repb.DigestFunction_SHA256)
 	if err != nil {
 		return nil, status.WrapErrorf(err, "failed to compute platform hash")
 	}
-	return &fcpb.SnapshotKey{
-		InstanceName:      task.GetExecuteRequest().GetInstanceName(),
-		PlatformHash:      pd.GetHash(),
-		ConfigurationHash: configurationHash,
-		RunnerId:          runnerID,
-	}, nil
+
+	branchRef, fallbackRefs := gitRefs(task)
+	keys := &fcpb.SnapshotKeySet{
+		BranchKey: &fcpb.SnapshotKey{
+			InstanceName:      task.GetExecuteRequest().GetInstanceName(),
+			PlatformHash:      pd.GetHash(),
+			ConfigurationHash: configurationHash,
+			Ref:               branchRef,
+			RunnerId:          runnerID,
+		},
+	}
+	for _, ref := range fallbackRefs {
+		fallbackKey := proto.Clone(keys.BranchKey).(*fcpb.SnapshotKey)
+		fallbackKey.Ref = ref
+		keys.FallbackKeys = append(keys.FallbackKeys, fallbackKey)
+	}
+	return keys, nil
+}
+
+func gitRefs(task *repb.ExecutionTask) (branchRef string, fallbackRefs []string) {
+	// NOTE: keep these names in sync with workflow service
+	branchRef = getEnv(task, "GIT_BRANCH")
+	if branchRef == "" {
+		return "", nil
+	}
+	for _, fallback := range []string{"GIT_BASE_BRANCH", "GIT_REPO_DEFAULT_BRANCH"} {
+		v := getEnv(task, fallback)
+		if v != "" && v != branchRef && !slices.Contains(fallbackRefs, v) {
+			fallbackRefs = append(fallbackRefs, v)
+		}
+	}
+	return branchRef, fallbackRefs
+}
+
+func getEnv(task *repb.ExecutionTask, name string) string {
+	for _, e := range task.GetCommand().GetEnvironmentVariables() {
+		if e.GetName() == name {
+			return e.GetValue()
+		}
+	}
+	return ""
 }
 
 // localManifestKey returns the key for the local snapshot manifest.
@@ -205,10 +243,11 @@ type Loader interface {
 	// snapshot configuration and artifact paths specified by opts.
 	CacheSnapshot(ctx context.Context, key *fcpb.SnapshotKey, opts *CacheSnapshotOptions) error
 
-	// GetSnapshot loads the metadata for the snapshot. It does not
+	// GetSnapshot loads the metadata for the snapshot. If the main key is not
+	// found, it tries falling back to one of the fallback keys. It does not
 	// unpack any snapshot artifacts.
 	// It returns UnavailableError if the metadata has expired from cache.
-	GetSnapshot(ctx context.Context, key *fcpb.SnapshotKey, remoteEnabled bool) (*Snapshot, error)
+	GetSnapshot(ctx context.Context, key *fcpb.SnapshotKeySet, remoteEnabled bool) (*Snapshot, error)
 
 	// UnpackSnapshot unpacks a snapshot to the given directory.
 	// It returns UnavailableError if any snapshot artifacts have expired
@@ -227,24 +266,44 @@ func New(env environment.Env) (*FileCacheLoader, error) {
 	return &FileCacheLoader{env: env}, nil
 }
 
-func (l *FileCacheLoader) GetSnapshot(ctx context.Context, key *fcpb.SnapshotKey, remoteEnabled bool) (*Snapshot, error) {
-	var manifest *fcpb.SnapshotManifest
-	var err error
+func (l *FileCacheLoader) GetSnapshot(ctx context.Context, keys *fcpb.SnapshotKeySet, remoteEnabled bool) (*Snapshot, error) {
+	var lastErr error
+	allKeys := append([]*fcpb.SnapshotKey{keys.GetBranchKey()}, keys.FallbackKeys...)
+	for _, key := range allKeys {
+		manifest, err := l.getSnapshot(ctx, key, remoteEnabled)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if key == keys.GetBranchKey() {
+			log.CtxInfof(ctx, "Found preferred snapshot ref=%q in cache", key.GetRef())
+		} else {
+			log.CtxInfof(ctx, "Found fallback snapshot ref=%q in cache", key.GetRef())
+		}
+		return &Snapshot{
+			key:      key,
+			manifest: manifest,
+		}, nil
+	}
+	return nil, lastErr
+}
+
+func (l *FileCacheLoader) getSnapshot(ctx context.Context, key *fcpb.SnapshotKey, remoteEnabled bool) (*fcpb.SnapshotManifest, error) {
 	if *snaputil.EnableRemoteSnapshotSharing && remoteEnabled {
-		manifest, err = l.fetchRemoteManifest(ctx, key)
+		manifest, err := l.fetchRemoteManifest(ctx, key)
 		if err != nil {
 			log.CtxInfof(ctx, "Failed to fetch remote snapshot manifest: %s", err)
 			return nil, status.WrapError(err, "fetch remote manifest")
 		}
-		log.CtxInfof(ctx, "Fetched remote snapshot manifest %s", keyDebugString(ctx, l.env, key))
-	} else {
-		manifest, err = l.getLocalManifest(ctx, key)
-		if err != nil {
-			return nil, status.WrapError(err, "get local manifest")
-		}
+		log.CtxInfof(ctx, "Fetched remote snapshot manifest")
+		return manifest, nil
 	}
 
-	return &Snapshot{key: key, manifest: manifest, remoteEnabled: remoteEnabled}, nil
+	manifest, err := l.getLocalManifest(ctx, key)
+	if err != nil {
+		return nil, status.WrapError(err, "get local manifest")
+	}
+	return manifest, nil
 }
 
 // fetchRemoteManifest fetches the most recent snapshot manifest from the remote
@@ -752,9 +811,9 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, imageRef, ima
 
 	// TODO: use an Action for this key instead (to allow remote snapshot
 	// sharing).
-	key := &fcpb.SnapshotKey{
+	key := &fcpb.SnapshotKeySet{BranchKey: &fcpb.SnapshotKey{
 		ConfigurationHash: hashStrings("__UnpackContainerImage", imageRef),
-	}
+	}}
 
 	snap, err := l.GetSnapshot(ctx, key, *snaputil.EnableRemoteSnapshotSharing)
 	if err != nil && !(status.IsNotFoundError(err) || status.IsUnavailableError(err)) {
@@ -775,7 +834,7 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, imageRef, ima
 	// ChunkedFile then add it to cache.
 	// TODO(bduffany): single-flight this.
 	start := time.Now()
-	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, key.InstanceName, *snaputil.EnableRemoteSnapshotSharing)
+	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, "" /*=instanceName*/, *snaputil.EnableRemoteSnapshotSharing)
 	if err != nil {
 		return nil, status.WrapError(err, "convert image to COW")
 	}
@@ -784,7 +843,7 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, imageRef, ima
 		ChunkedFiles: map[string]*copy_on_write.COWStore{rootfsFileName: cow},
 		Recycled:     false,
 	}
-	if err := l.CacheSnapshot(ctx, key, opts); err != nil {
+	if err := l.CacheSnapshot(ctx, key.GetBranchKey(), opts); err != nil {
 		return nil, status.WrapError(err, "cache containerfs snapshot")
 	}
 	log.CtxDebugf(ctx, "Converted containerfs to COW in %s", time.Since(start))

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -60,13 +60,13 @@ func TestPackAndUnpackChunkedFiles(t *testing.T) {
 
 		// Now store a snapshot for VM A, including the COW we created.
 		task := &repb.ExecutionTask{}
-		key, err := snaploader.NewKey(task, "config-hash", "")
+		keys, err := snaploader.SnapshotKeySet(task, "config-hash", "")
 		require.NoError(t, err)
 		optsA := makeFakeSnapshot(t, workDirA, enableRemote)
 		optsA.ChunkedFiles = map[string]*copy_on_write.COWStore{
 			"scratchfs": cowA,
 		}
-		err = loader.CacheSnapshot(ctx, key, optsA)
+		err = loader.CacheSnapshot(ctx, keys.GetBranchKey(), optsA)
 		require.NoError(t, err)
 		// Note: we'd normally close cowA here, but we keep it open so that
 		// mustUnpack() can verify the original contents.
@@ -78,18 +78,80 @@ func TestPackAndUnpackChunkedFiles(t *testing.T) {
 		originalOpts := optsA
 		for i := 0; i < 3; i++ {
 			forkWorkDir := testfs.MakeDirAll(t, workDir, fmt.Sprintf("VM-%d", i))
-			unpacked := mustUnpack(t, ctx, loader, key, forkWorkDir, originalOpts)
+			unpacked := mustUnpack(t, ctx, loader, keys, forkWorkDir, originalOpts)
 			forkCOW := unpacked.ChunkedFiles["scratchfs"]
 			writeRandomRange(t, forkCOW)
 			forkOpts := makeFakeSnapshot(t, forkWorkDir, enableRemote)
 			forkOpts.ChunkedFiles = map[string]*copy_on_write.COWStore{
 				"scratchfs": forkCOW,
 			}
-			err := loader.CacheSnapshot(ctx, key, forkOpts)
+			err := loader.CacheSnapshot(ctx, keys.GetBranchKey(), forkOpts)
 			require.NoError(t, err)
 			originalOpts = forkOpts
 		}
 	}
+}
+
+func TestUnpackFallbackKey(t *testing.T) {
+	const maxFilecacheSizeBytes = 20_000_000 // 20 MB
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+	filecacheDir := testfs.MakeTempDir(t)
+	fc, err := filecache.NewFileCache(filecacheDir, maxFilecacheSizeBytes, false)
+	require.NoError(t, err)
+	fc.WaitForDirectoryScanToComplete()
+	env.SetFileCache(fc)
+	testcache.Setup(t, env)
+	loader, err := snaploader.New(env)
+	require.NoError(t, err)
+	workDir := testfs.MakeTempDir(t)
+
+	task := &repb.ExecutionTask{
+		Command: &repb.Command{
+			EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+				// Set env vars matching a push to the main branch.
+				{Name: "GIT_BRANCH", Value: "main"},
+				{Name: "GIT_BASE_BRANCH", Value: ""},
+				{Name: "GIT_REPO_DEFAULT_BRANCH", Value: "main"},
+			},
+		},
+	}
+	keys, err := snaploader.SnapshotKeySet(task, "config-hash", "")
+	require.NoError(t, err)
+	require.Equal(t, "main", keys.GetBranchKey().GetRef())
+	require.Empty(t, keys.GetFallbackKeys())
+
+	opts := makeFakeSnapshot(t, workDir)
+	err = loader.CacheSnapshot(ctx, keys.GetBranchKey(), opts)
+	require.NoError(t, err)
+
+	forkTask := &repb.ExecutionTask{
+		Command: &repb.Command{
+			EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+				// Set env vars matching a stacked PR, with the main branch as
+				// the last fallback.
+				{Name: "GIT_BRANCH", Value: "my-cool-pr"},
+				{Name: "GIT_BASE_BRANCH", Value: "my-cool-stacked-pr-base-branch"},
+				{Name: "GIT_REPO_DEFAULT_BRANCH", Value: "main"},
+			},
+		},
+	}
+	forkWorkDir := testfs.MakeDirAll(t, workDir, "VM-fallback")
+	forkKeys, err := snaploader.SnapshotKeySet(forkTask, "config-hash", "")
+	require.NoError(t, err)
+	require.Equal(t, "my-cool-pr", forkKeys.GetBranchKey().GetRef())
+	require.Len(t, forkKeys.GetFallbackKeys(), 2)
+	require.Equal(t, "my-cool-stacked-pr-base-branch", forkKeys.FallbackKeys[0].Ref)
+	require.Equal(t, "main", forkKeys.FallbackKeys[1].Ref)
+
+	// Sanity check that the branch key is not found in cache, to make sure
+	// we're actually falling back.
+	_, err = loader.GetSnapshot(ctx, &fcpb.SnapshotKeySet{BranchKey: forkKeys.GetBranchKey()})
+	require.Error(t, err)
+
+	// Now try unpacking with the complete PR key set, including fallbacks. This
+	// should succeed.
+	mustUnpack(t, ctx, loader, forkKeys, forkWorkDir, opts)
 }
 
 func TestPackAndUnpackChunkedFiles_Immutability(t *testing.T) {
@@ -122,13 +184,13 @@ func TestPackAndUnpackChunkedFiles_Immutability(t *testing.T) {
 		writeRandomRange(t, cowA)
 		// Now store a snapshot for VM A, including the COW we created.
 		taskA := &repb.ExecutionTask{}
-		keyA, err := snaploader.NewKey(taskA, "config-hash-a", "")
+		keysA, err := snaploader.SnapshotKeySet(taskA, "config-hash-a", "")
 		require.NoError(t, err)
 		optsA := makeFakeSnapshot(t, workDirA, enableRemote)
 		optsA.ChunkedFiles = map[string]*copy_on_write.COWStore{
 			"scratchfs": cowA,
 		}
-		err = loader.CacheSnapshot(ctx, keyA, optsA)
+		err = loader.CacheSnapshot(ctx, keysA.GetBranchKey(), optsA)
 		require.NoError(t, err)
 		// Note: we'd normally close cowA here, but we keep it open so that
 		// mustUnpack() can verify the original contents.
@@ -139,14 +201,14 @@ func TestPackAndUnpackChunkedFiles_Immutability(t *testing.T) {
 
 		// Now unpack the snapshot for use by VM B, then make a modification.
 		workDirB := testfs.MakeDirAll(t, workDir, "VM-B")
-		unpackedB := mustUnpack(t, ctx, loader, keyA, workDirB, optsA)
+		unpackedB := mustUnpack(t, ctx, loader, keysA, workDirB, optsA)
 		cowB := unpackedB.ChunkedFiles["scratchfs"]
 		writeRandomRange(t, cowB)
 
 		// Unpack the snapshot again for use by VM C. It should see the original
 		// contents, not the modification made by VM B.
 		workDirC := testfs.MakeDirAll(t, workDir, "VM-C")
-		unpackedC := mustUnpack(t, ctx, loader, keyA, workDirC, optsA)
+		unpackedC := mustUnpack(t, ctx, loader, keysA, workDirC, optsA)
 		// mustUnpack already verifies the contents against cowA, but this will give
 		// us false confidence if cowA was somehow mutated. So check again against
 		// the originally snapshotted bytes, rather than the original COW instance.
@@ -186,18 +248,22 @@ func TestRemoteSnapshotFetching(t *testing.T) {
 	require.NoError(t, err)
 	writeRandomRange(t, cowA)
 	task := &repb.ExecutionTask{}
-	key, err := snaploader.NewKey(task, "config-hash", "")
+	keys, err := snaploader.SnapshotKeySet(task, "config-hash", "")
 	require.NoError(t, err)
 	optsA := makeFakeSnapshot(t, workDirA, true)
 	optsA.ChunkedFiles = map[string]*copy_on_write.COWStore{
 		"scratchfs": cowA,
 	}
-	err = loader.CacheSnapshot(ctx, key, optsA)
+	err = loader.CacheSnapshot(ctx, keys.GetBranchKey(), optsA)
 	require.NoError(t, err)
 
 	// Delete some artifacts from the local cache, so we can test fetching artifacts
 	// from both the local and remote cache
+<<<<<<< HEAD
 	snapMetadata, err := loader.GetSnapshot(ctx, key, true)
+=======
+	snapMetadata, err := loader.GetSnapshot(ctx, keys)
+>>>>>>> 04d73b83c (executor: use git refs for snapshot read/write)
 	require.NoError(t, err)
 	for i, f := range snapMetadata.GetFiles() {
 		if i%2 == 0 {
@@ -218,14 +284,14 @@ func TestRemoteSnapshotFetching(t *testing.T) {
 	originalOpts := optsA
 	for i := 0; i < 3; i++ {
 		forkWorkDir := testfs.MakeDirAll(t, workDir, fmt.Sprintf("VM-%d", i))
-		unpacked := mustUnpack(t, ctx, loader, key, forkWorkDir, originalOpts)
+		unpacked := mustUnpack(t, ctx, loader, keys, forkWorkDir, originalOpts)
 		forkCOW := unpacked.ChunkedFiles["scratchfs"]
 		writeRandomRange(t, forkCOW)
 		forkOpts := makeFakeSnapshot(t, forkWorkDir, true)
 		forkOpts.ChunkedFiles = map[string]*copy_on_write.COWStore{
 			"scratchfs": forkCOW,
 		}
-		err := loader.CacheSnapshot(ctx, key, forkOpts)
+		err := loader.CacheSnapshot(ctx, keys.GetBranchKey(), forkOpts)
 		require.NoError(t, err)
 		originalOpts = forkOpts
 	}
@@ -258,17 +324,21 @@ func TestRemoteSnapshotFetching_RemoteEviction(t *testing.T) {
 	require.NoError(t, err)
 	writeRandomRange(t, cowA)
 	task := &repb.ExecutionTask{}
-	key, err := snaploader.NewKey(task, "config-hash", "")
+	keys, err := snaploader.SnapshotKeySet(task, "config-hash", "")
 	require.NoError(t, err)
 	optsA := makeFakeSnapshot(t, workDirA, true)
 	optsA.ChunkedFiles = map[string]*copy_on_write.COWStore{
 		"scratchfs": cowA,
 	}
-	err = loader.CacheSnapshot(ctx, key, optsA)
+	err = loader.CacheSnapshot(ctx, keys.GetBranchKey(), optsA)
 	require.NoError(t, err)
 
 	// Delete some artifacts from the remote cache (arbitrarily the first one for simplicity)
+<<<<<<< HEAD
 	snapMetadata, err := loader.GetSnapshot(ctx, key, true)
+=======
+	snapMetadata, err := loader.GetSnapshot(ctx, keys)
+>>>>>>> 04d73b83c (executor: use git refs for snapshot read/write)
 	require.NoError(t, err)
 	for _, f := range snapMetadata.GetFiles() {
 		rn := digest.NewResourceName(f.GetDigest(), "", rspb.CacheType_CAS, repb.DigestFunction_BLAKE3).ToProto()
@@ -287,7 +357,11 @@ func TestRemoteSnapshotFetching_RemoteEviction(t *testing.T) {
 
 	// Even though the assets still exist in the local cache, the remote cache
 	// should serve as the source of truth on whether a snapshot is valid
+<<<<<<< HEAD
 	_, err = loader.GetSnapshot(ctx, key, true)
+=======
+	_, err = loader.GetSnapshot(ctx, keys)
+>>>>>>> 04d73b83c (executor: use git refs for snapshot read/write)
 	require.Error(t, err)
 }
 
@@ -324,34 +398,43 @@ func TestGetSnapshot_CacheIsolation(t *testing.T) {
 		optsA.ChunkedFiles = map[string]*copy_on_write.COWStore{
 			"scratchfs": cowA,
 		}
-		originalKey := keyWithInstanceName(t, "remote-A")
-		err = loader.CacheSnapshot(ctx, originalKey, optsA)
+		originalKeys := keysWithInstanceName(t, "remote-A")
+		err = loader.CacheSnapshot(ctx, originalKeys.GetBranchKey(), optsA)
 		require.NoError(t, err)
 
 		// Fetching snapshot with same group id and instance name should succeed
 		workDirB := testfs.MakeDirAll(t, workDir, "VM-B")
-		_ = mustUnpack(t, ctx, loader, originalKey, workDirB, optsA)
+		_ = mustUnpack(t, ctx, loader, originalKeys, workDirB, optsA)
 
 		// Fetching snapshot with same group id different instance name should fail
+<<<<<<< HEAD
 		keyNewInstanceName := keyWithInstanceName(t, "remote-C")
 		_, err = loader.GetSnapshot(ctx, keyNewInstanceName, enableRemote)
+=======
+		keysNewInstanceName := keysWithInstanceName(t, "remote-C")
+		_, err = loader.GetSnapshot(ctx, keysNewInstanceName)
+>>>>>>> 04d73b83c (executor: use git refs for snapshot read/write)
 		require.Error(t, err)
 
 		// Fetching snapshot with different group id same instance name should fail
 		ctxNewGroup, err := auth.WithAuthenticatedUser(context.Background(), "US2")
 		require.NoError(t, err)
+<<<<<<< HEAD
 		_, err = loader.GetSnapshot(ctxNewGroup, originalKey, enableRemote)
+=======
+		_, err = loader.GetSnapshot(ctxNewGroup, originalKeys)
+>>>>>>> 04d73b83c (executor: use git refs for snapshot read/write)
 		require.Error(t, err)
 	}
 }
 
-func keyWithInstanceName(t *testing.T, instanceName string) *fcpb.SnapshotKey {
+func keysWithInstanceName(t *testing.T, instanceName string) *fcpb.SnapshotKeySet {
 	task := &repb.ExecutionTask{
 		ExecuteRequest: &repb.ExecuteRequest{
 			InstanceName: instanceName,
 		},
 	}
-	key, err := snaploader.NewKey(task, "config-hash", "")
+	key, err := snaploader.SnapshotKeySet(task, "config-hash", "")
 	require.NoError(t, err)
 	return key
 }
@@ -386,8 +469,13 @@ func writeRandomRange(t *testing.T, store *copy_on_write.COWStore) {
 
 // Unpacks a snapshot to outDir and asserts that the contents match the
 // originally cached contents.
+<<<<<<< HEAD
 func mustUnpack(t *testing.T, ctx context.Context, loader snaploader.Loader, snapshotKey *fcpb.SnapshotKey, outDir string, originalSnapshot *snaploader.CacheSnapshotOptions) *snaploader.UnpackedSnapshot {
 	snap, err := loader.GetSnapshot(ctx, snapshotKey, true /*enableRemote*/)
+=======
+func mustUnpack(t *testing.T, ctx context.Context, loader snaploader.Loader, snapshotKeySet *fcpb.SnapshotKeySet, outDir string, originalSnapshot *snaploader.CacheSnapshotOptions) *snaploader.UnpackedSnapshot {
+	snap, err := loader.GetSnapshot(ctx, snapshotKeySet)
+>>>>>>> 04d73b83c (executor: use git refs for snapshot read/write)
 	require.NoError(t, err)
 	unpacked, err := loader.UnpackSnapshot(ctx, snap, outDir)
 	require.NoError(t, err)

--- a/proto/firecracker.proto
+++ b/proto/firecracker.proto
@@ -26,6 +26,20 @@ message VMConfiguration {
   // TODO: add container_image here?
 }
 
+message SnapshotKeySet {
+  // Snapshot key to be read from when resuming the snapshot and written to when
+  // the task is complete.
+  //
+  // For workflows, this is associated with the git branch checked out in the
+  // snapshotted git repo directory.
+  SnapshotKey branch_key = 1;
+
+  // Fallback keys to try reading if the main key is not found. These are
+  // read-only; only the main key will be updated when writing the snapshot back
+  // to cache.
+  repeated SnapshotKey fallback_keys = 2;
+}
+
 message SnapshotKey {
   // Remote instance name associated with the snapshot.
   string instance_name = 1;


### PR DESCRIPTION
:arrow_right: depends on https://github.com/buildbuddy-io/buildbuddy/pull/5115

* Use main git ref (pushed branch name) for reading and writing
* Use fallback git refs for reading only (PR base branch and repo default branch, if different from PR base branch)

**Related issues**: N/A
