### PR TITLE
Remove confusing PubSub log message.

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -815,7 +815,9 @@ func (s *ExecutionServer) waitExecution(ctx context.Context, req *repb.WaitExecu
 	for {
 		msg, ok := <-streamPubSubChan
 		if !ok {
-			log.CtxInfof(ctx, "WaitExecution %q: exiting early because PubSub channel was closed", req.GetName())
+			if ctx.Err() != nil {
+				log.CtxInfof(ctx, "WaitExecution %q: client disconnected before action completed: %s", req.GetName(), ctx.Err())
+			}
 			return status.UnavailableErrorf("Stream PubSub channel closed for %q", req.GetName())
 		}
 		var data string


### PR DESCRIPTION
Instead, explicitely log if client disconnected.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
