### PR TITLE
proto: update proto from Bazel upstream

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -13,6 +13,11 @@ proto_library(
 )
 
 proto_library(
+    name = "action_cache_proto",
+    srcs = ["action_cache.proto"],
+)
+
+proto_library(
     name = "api_key_proto",
     srcs = ["api_key.proto"],
     deps = [
@@ -345,10 +350,12 @@ proto_library(
     name = "build_event_stream_proto",
     srcs = ["build_event_stream.proto"],
     deps = [
+        ":action_cache_proto",
         ":command_line_proto",
         ":failure_details_proto",
         ":invocation_policy_proto",
         ":package_load_metrics_proto",
+        "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
@@ -648,6 +655,12 @@ go_proto_library(
 )
 
 go_proto_library(
+    name = "action_cache_go_proto",
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/action_cache",
+    proto = ":action_cache_proto",
+)
+
+go_proto_library(
     name = "api_key_go_proto",
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/api_key",
     proto = ":api_key_proto",
@@ -799,6 +812,7 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream",
     proto = ":build_event_stream_proto",
     deps = [
+        ":action_cache_go_proto",
         ":command_line_go_proto",
         ":failure_details_go_proto",
         ":invocation_policy_go_proto",
@@ -1283,6 +1297,11 @@ ts_proto_library(
 )
 
 ts_proto_library(
+    name = "action_cache_ts_proto",
+    proto = ":action_cache_proto",
+)
+
+ts_proto_library(
     name = "api_key_ts_proto",
     proto = ":api_key_proto",
     deps = [
@@ -1445,6 +1464,8 @@ ts_proto_library(
     name = "build_event_stream_ts_proto",
     proto = ":build_event_stream_proto",
     deps = [
+        ":action_cache_ts_proto",
+        ":any_ts_proto",
         ":command_line_ts_proto",
         ":descriptor_ts_proto",
         ":duration_ts_proto",

--- a/proto/action_cache.proto
+++ b/proto/action_cache.proto
@@ -1,0 +1,59 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package blaze;
+
+option java_package = "com.google.devtools.build.lib.actions.cache";
+option java_outer_classname = "Protos";
+
+// Information about the action cache behavior during a single build.
+message ActionCacheStatistics {
+  // Size of the action cache in bytes.
+  //
+  // This is computed by the code that persists the action cache to disk and
+  // represents the size of the written files, which has no direct relation to
+  // the number of entries in the cache.
+  uint64 size_in_bytes = 1;
+
+  // Time it took to save the action cache to disk.
+  uint64 save_time_in_ms = 2;
+
+  // Reasons for not finding an action in the cache.
+  enum MissReason {
+    DIFFERENT_ACTION_KEY = 0;
+    DIFFERENT_DEPS = 1;
+    DIFFERENT_ENVIRONMENT = 2;
+    DIFFERENT_FILES = 3;
+    CORRUPTED_CACHE_ENTRY = 4;
+    NOT_CACHED = 5;
+    UNCONDITIONAL_EXECUTION = 6;
+  }
+
+  // Detailed information for a particular miss reason.
+  message MissDetail {
+    MissReason reason = 1;
+    int32 count = 2;
+  }
+
+  // Cache counters.
+  int32 hits = 3;
+  int32 misses = 4;
+
+  // Breakdown of the cache misses based on the reasons behind them.
+  repeated MissDetail miss_details = 5;
+
+  // NEXT TAG: 6
+}

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// LINT: LEGACY_NAMES
+
 syntax = "proto3";
 
 package build_event_stream;
 
+import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
+import "proto/action_cache.proto";
 import "proto/command_line.proto";
 import "proto/invocation_policy.proto";
 import "proto/failure_details.proto";
@@ -200,6 +204,24 @@ message BuildEventId {
     int32 attempt = 4;
   }
 
+  // Identifier of an event reporting progress of an individual test run.
+  message TestProgressId {
+    // The label of the target for the action.
+    string label = 1;
+    // The configuration under which the action is running.
+    ConfigurationId configuration = 2;
+    // The run number of the test action (e.g. for runs_per_test > 1).
+    int32 run = 3;
+    // For sharded tests, the shard number of the test action.
+    int32 shard = 4;
+    // The execution attempt number which may increase due to retries (e.g. for
+    // flaky tests).
+    int32 attempt = 5;
+    // An incrementing count used to differentiate TestProgressIds for the same
+    // test attempt.
+    int32 opaque_count = 6;
+  }
+
   // Identifier of an event reporting the summary of a test.
   message TestSummaryId {
     string label = 1;
@@ -228,6 +250,9 @@ message BuildEventId {
 
   // Identifier of an event signalling that the coverage actions are finished.
   message CoverageActionsFinishedId {}
+
+  // Identifier of an event providing the ExecRequest of a run command.
+  message ExecRequestId {}
 
   // BUILDBUDDY-SPECIFIC EVENTS BELOW
 
@@ -281,6 +306,7 @@ message BuildEventId {
     UnconfiguredLabelId unconfigured_label = 19;
     ConfiguredLabelId configured_label = 21;
     TestResultId test_result = 8;
+    TestProgressId test_progress = 29;
     TestSummaryId test_summary = 7;
     TargetSummaryId target_summary = 26;
     BuildFinishedId build_finished = 9;
@@ -290,6 +316,7 @@ message BuildEventId {
     BuildMetadataId build_metadata = 24;
     ConvenienceSymlinksIdentifiedId convenience_symlinks_identified = 25;
     CoverageActionsFinishedId coverage_actions_finished = 27;
+    ExecRequestId exec_request = 28;
 
     // BUILDBUDDY EVENTS BELOW
     // Starting at field #1000 to avoid conflicting with potential future
@@ -599,6 +626,15 @@ message ActionExecuted {
 
   // Only populated if success = false, and sometimes not even then.
   failure_details.FailureDetail failure_detail = 11;
+
+  // Start of action execution, before any attempted execution begins.
+  google.protobuf.Timestamp start_time = 12;
+
+  // End of action execution, after all attempted execution completes.
+  google.protobuf.Timestamp end_time = 13;
+
+  // Additional details about action execution supplied by any/all strategies.
+  repeated google.protobuf.Any strategy_details = 14;
 }
 
 // Collection of all output files belonging to that output group.
@@ -768,6 +804,15 @@ message TestResult {
   ExecutionInfo execution_info = 8;
 }
 
+// Event payload providing information about an active, individual test run.
+message TestProgress {
+  // Identifies a resource that may provide information about an active test
+  // run. The resource is not necessarily a file and may need to be queried
+  // for information. The URI is not guaranteed to be available after the test
+  // completes. The string is encoded according to RFC2396.
+  string uri = 1;
+}
+
 // Payload of the event summarizing a test.
 message TestSummary {
   // Wrapper around BlazeTestStatus to support importing that enum to proto3.
@@ -883,6 +928,9 @@ message BuildFinished {
   google.protobuf.Timestamp finish_time = 5;
 
   AnomalyReport anomaly_report = 4 [deprecated = true];
+
+  // Only populated if success = false, and sometimes not even then.
+  failure_details.FailureDetail failure_detail = 6;
 }
 
 message BuildMetrics {
@@ -938,6 +986,8 @@ message BuildMetrics {
       string exec_kind = 3;
     }
     repeated RunnerCount runner_count = 6;
+
+    blaze.ActionCacheStatistics action_cache_statistics = 7;
   }
   ActionSummary action_summary = 1;
 
@@ -1010,6 +1060,9 @@ message BuildMetrics {
   PackageMetrics package_metrics = 4;
 
   message TimingMetrics {
+    // For Skymeld,
+    // analysis_phase_time_in_ms + execution_phase_time_in_ms >= wall_time_in_ms
+    //
     // The CPU time in milliseconds consumed during this build.
     int64 cpu_time_in_ms = 1;
     // The elapsed wall time in milliseconds during this build.
@@ -1018,6 +1071,10 @@ message BuildMetrics {
     // When analysis and execution phases are interleaved, this measures the
     // elapsed time from the first analysis work to the last.
     int64 analysis_phase_time_in_ms = 3;
+    // The elapsed wall time in milliseconds during the execution phase.
+    // When analysis and execution phases are interleaved, this measures the
+    // elapsed time from the first action execution to the last.
+    int64 execution_phase_time_in_ms = 4;
   }
   TimingMetrics timing_metrics = 5;
 
@@ -1240,6 +1297,22 @@ message ConvenienceSymlink {
   string target = 3;
 }
 
+// Event that contains the ExecRequest of a run command announced only after a
+// successful build and before trying to execute the requested command-line.
+message ExecRequestConstructed {
+  bytes working_directory = 1;
+  repeated bytes argv = 2;
+  repeated EnvironmentVariable environment_variable = 3;
+  repeated bytes environment_variable_to_clear = 4;
+  bool should_exec = 5;
+}
+
+// An environment variable provided by a run command after a successful build.
+message EnvironmentVariable {
+  bytes name = 1;
+  bytes value = 2;
+}
+
 // BUILDBUDDY-SPECIFIC EVENTS BELOW
 
 // Event describing a workflow invocation as well as the bazel commands to be
@@ -1418,6 +1491,7 @@ message BuildEvent {
     NamedSetOfFiles named_set_of_files = 15;
     TargetComplete completed = 8;
     TestResult test_result = 10;
+    TestProgress test_progress = 30;
     TestSummary test_summary = 9;
     TargetSummary target_summary = 28;
     BuildFinished finished = 14;
@@ -1426,6 +1500,7 @@ message BuildEvent {
     WorkspaceConfig workspace_info = 25;
     BuildMetadata build_metadata = 26;
     ConvenienceSymlinksIdentified convenience_symlinks_identified = 27;
+    ExecRequestConstructed exec_request = 29;
 
     // BUILDBUDDY-SPECIFIC EVENTS BELOW.
     // Starting at field #1000 to avoid conflicting with potential future

--- a/proto/failure_details.proto
+++ b/proto/failure_details.proto
@@ -147,7 +147,7 @@ message FailureDetail {
     StarlarkLoading starlark_loading = 179;
     ExternalDeps external_deps = 181;
     DiffAwareness diff_awareness = 182;
-    ModqueryCommand modquery_command = 183;
+    ModCommand mod_command = 183;
     BuildReport build_report = 184;
   }
 
@@ -278,7 +278,7 @@ message BuildProgress {
         [(metadata) = { exit_code: 45 }];
     BES_UPLOAD_RETRY_LIMIT_EXCEEDED_FAILURE = 17
         [(metadata) = { exit_code: 38 }];
-    reserved 1, 2, 18;  // For internal use
+    reserved 1, 2, 18, 20;  // For internal use
   }
   Code code = 1;
   // Additional data could include the build progress upload endpoint.
@@ -295,6 +295,7 @@ message RemoteOptions {
     CREDENTIALS_WRITE_FAILURE = 3 [(metadata) = { exit_code: 36 }];
     DOWNLOADER_WITHOUT_GRPC_CACHE = 4 [(metadata) = { exit_code: 2 }];
     EXECUTION_WITH_INVALID_CACHE = 5 [(metadata) = { exit_code: 2 }];
+    EXECUTION_WITH_SCRUBBING = 6 [(metadata) = { exit_code: 2 }];
   }
 
   Code code = 1;
@@ -458,6 +459,7 @@ message Execution {
     UNEXPECTED_EXCEPTION = 37 [(metadata) = { exit_code: 1 }];
     reserved 38;
     SOURCE_INPUT_IO_EXCEPTION = 39 [(metadata) = { exit_code: 1 }];
+    SYMLINK_TREE_DELETION_IO_EXCEPTION = 40 [(metadata) = { exit_code: 36 }];
   }
 
   Code code = 1;
@@ -608,6 +610,7 @@ message BuildConfiguration {
     // possibilities in Bazel, so we go with the more straightforward
     // command-line error exit code 2.
     INVALID_OUTPUT_DIRECTORY_MNEMONIC = 11 [(metadata) = { exit_code: 2 }];
+    CONFIGURATION_DISCARDED_ANALYSIS_CACHE = 12 [(metadata) = { exit_code: 2 }];
   }
 
   Code code = 1;
@@ -1031,6 +1034,7 @@ message ActionRewinding {
     ACTION_REWINDING_UNKNOWN = 0 [(metadata) = { exit_code: 37 }];
     LOST_INPUT_TOO_MANY_TIMES = 1 [(metadata) = { exit_code: 1 }];
     LOST_INPUT_IS_SOURCE = 2 [(metadata) = { exit_code: 1 }];
+    REWIND_LOST_INPUTS_PREREQ_UNMET = 3 [(metadata) = { exit_code: 2 }];
   }
 
   Code code = 1;
@@ -1197,6 +1201,7 @@ message Analysis {
     CONFIGURED_VALUE_CREATION_FAILED = 18 [(metadata) = { exit_code: 1 }];
     INCOMPATIBLE_TARGET_REQUESTED = 19 [(metadata) = { exit_code: 1 }];
     ANALYSIS_FAILURE_PROPAGATION_FAILED = 20 [(metadata) = { exit_code: 1 }];
+    ANALYSIS_CACHE_DISCARDED = 21 [(metadata) = { exit_code: 1 }];
   }
 
   Code code = 1;
@@ -1243,6 +1248,7 @@ message PackageLoading {
     BUILTINS_INJECTION_FAILURE = 29 [(metadata) = { exit_code: 1 }];
     SYMLINK_CYCLE_OR_INFINITE_EXPANSION = 30 [(metadata) = { exit_code: 1 }];
     OTHER_IO_EXCEPTION = 31 [(metadata) = { exit_code: 36 }];
+    BAD_REPO_FILE = 32 [(metadata) = { exit_code: 1 }];
   }
 
   Code code = 1;
@@ -1303,9 +1309,9 @@ message DiffAwareness {
   Code code = 1;
 }
 
-message ModqueryCommand {
+message ModCommand {
   enum Code {
-    MODQUERY_COMMAND_UNKNOWN = 0 [(metadata) = { exit_code: 37 }];
+    MOD_COMMAND_UNKNOWN = 0 [(metadata) = { exit_code: 37 }];
     MISSING_ARGUMENTS = 1 [(metadata) = { exit_code: 2 }];
     TOO_MANY_ARGUMENTS = 2 [(metadata) = { exit_code: 2 }];
     INVALID_ARGUMENTS = 3 [(metadata) = { exit_code: 2 }];

--- a/proto/option_filters.proto
+++ b/proto/option_filters.proto
@@ -55,5 +55,5 @@ enum OptionMetadataTag {
   INTERNAL = 4;
   reserved "TRIGGERED_BY_ALL_INCOMPATIBLE_CHANGES";
   reserved 5;
-  EXPLICIT_IN_OUTPUT_PATH = 6;
+  reserved 6;
 }


### PR DESCRIPTION
These proto files are taken from commit
https://github.com/bazelbuild/bazel/commit/76117b4a43b552c681dcf841704fedfd60d3e37b

Highlight:

- Inclusion of ActionCacheStatistics in build_event_stream
  https://github.com/bazelbuild/bazel/pull/17615

- Explicit Execution phase timing (in prepare for Skymeld)
  https://github.com/bazelbuild/bazel/commit/be63eeefa9736d66f4b773bf6043958575eb02d7

- If `--noallow_analysis_cache_discard` is set, BuildFinished may
  contains FailureDetails -> CONFIGURATION_DISCARDED_ANALYSIS_CACHE.
  https://github.com/bazelbuild/bazel/pull/16805/

- ExecRequest event is included for `bazel run`
  https://github.com/bazelbuild/bazel/commit/9a047de5f6cd5c2f1204b2389746d5a9862f10c8

- TestProgress event is included for TestRunner action
  https://github.com/bazelbuild/bazel/commit/d8b8ab0165aa813161d4d7528cbcbdf5c78e1593

- ActionExecuted now includes start/end time and strategy information
  https://github.com/bazelbuild/bazel/commit/2ddacab80af1dca3c04e74809827c47ec4bc8498
