### PR TITLE
Remove atime update alert.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -821,12 +821,8 @@ func (p *PebbleCache) updateAtime(key filestore.PebbleKey) error {
 	if err != nil {
 		return err
 	}
-	if key.EncryptionKeyID() != md.GetEncryptionMetadata().GetEncryptionKeyId() && len(md.GetStorageMetadata().GetChunkedMetadata().GetResource()) == 0 {
-		log.Warningf("[%s] atime update mismatch for %q: key %#v metadata %+v", p.name, string(keyBytes), key, md)
-		err := status.FailedPreconditionErrorf("key vs metadata encryption mismatch for %q: %q vs %q", string(keyBytes), key.EncryptionKeyID(), md.GetEncryptionMetadata().GetEncryptionKeyId())
-		alert.UnexpectedEvent("atime_update_encryption_mismatch", err.Error())
-		return err
-	}
+
+	log.Debugf("[%s] atime update for %q: key %#v metadata %+v", p.name, string(keyBytes), key, md)
 
 	atime := time.UnixMicro(md.GetLastAccessUsec())
 	if !olderThanThreshold(atime, p.atimeUpdateThreshold) {


### PR DESCRIPTION
It's flagging already-broken keys which is too noisy.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
