### PR TITLE
Fix zooming issues with trace viewer

### DIFF
--- a/app/trace/trace_viewer.css
+++ b/app/trace/trace_viewer.css
@@ -6,7 +6,8 @@
 }
 
 .trace-viewer .panel {
-  position: relative;
+  position: absolute;
+  inset: 0;
   overflow-x: scroll;
   overflow-y: scroll;
 }
@@ -24,6 +25,7 @@
 .trace-viewer .panel-container {
   border-radius: 2px;
   border: 2px solid #eee;
+  box-sizing: border-box;
 }
 
 .trace-viewer .panel::-webkit-scrollbar-thumb {

--- a/app/trace/trace_viewer.tsx
+++ b/app/trace/trace_viewer.tsx
@@ -16,6 +16,12 @@ export interface TraceViewProps {
   profile: Profile;
 }
 
+// The browser starts struggling if we have a div much greater than this width
+// in pixels. For now we rely on the browser for rendering the horizontal
+// scrollbar, so we don't allow the horizontally scrollable width to exceed this
+// value.
+const SCROLL_WIDTH_LIMIT = 18_000_000;
+
 /**
  * Renders an interactive trace profile viewer for an invocation.
  */
@@ -100,6 +106,7 @@ export default class TraceViewer extends React.Component<TraceViewProps, {}> {
    */
   private update(dt = 0) {
     this.canvasXPerModelX.min = this.panels[0].container.clientWidth / this.model.xMax;
+    this.canvasXPerModelX.max = SCROLL_WIDTH_LIMIT / this.model.xMax;
     this.canvasXPerModelX.step(dt, { threshold: 1e-9 });
 
     for (const panel of this.panels) {
@@ -267,13 +274,7 @@ export default class TraceViewer extends React.Component<TraceViewProps, {}> {
               height: `${panel.height}px`,
               position: "relative",
             }}>
-            <div
-              key={i}
-              className="panel"
-              style={{
-                height: `${panel.height}px`,
-              }}
-              onScroll={(e) => this.onScroll(e, i)}>
+            <div key={i} className="panel" onScroll={(e) => this.onScroll(e, i)}>
               <canvas ref={this.canvasRefs[i]} onMouseDown={(e) => this.onCanvasMouseDown(e, i)} />
               {/*
                * This sizer div is used to make the total scrollable area


### PR DESCRIPTION
* Update panel to be absolutely positioned within its container to fix jitter when zoom animation is running.
* Apply a max zoom level to prevent the inner scrollable div's width from exceeding the apparent max width that browsers are capable of handling (once we get above this threshold, various weird things start happening)

**Related issues**: N/A
