### PR TITLE
Optimize podman IsImageCached

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//server/util/healthcheck",
         "//server/util/lockingbuffer",
         "//server/util/log",
+        "//server/util/lru",
         "//server/util/networking",
         "//server/util/prefix",
         "//server/util/random",


### PR DESCRIPTION
`IsImageCached` consistently adds at least 20ms of action overhead locally (10% of total execution time for a local NOP action) and around 30ms of overhead remotely. Optimize it by caching its result when returns true, since we don't expect podman images to disappear.

Also use `podman image exists` which appears to run a few ms faster than `podman image inspect` and is also more straightforward.

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/c4bfd41d-25dd-4503-91e4-660c97be05aa)

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/2844
