### PR TITLE
Improve execution tracing

### DIFF
--- a/cli/execute/execute.go
+++ b/cli/execute/execute.go
@@ -133,11 +133,14 @@ func execute(cmdArgs []string) error {
 		return err
 	}
 	start := time.Now()
+	stageStart := start
 	log.Debugf("Preparing action for %s", cmd)
 	arn, err := rexec.Prepare(ctx, env, *instanceName, df, action, cmd, *inputRoot)
 	if err != nil {
 		return err
 	}
+	log.Debugf("Uploaded inputs in %s", time.Since(stageStart))
+	stageStart = time.Now()
 	log.Debug("Starting /Execute request")
 	stream, err := rexec.Start(ctx, env, arn)
 	if err != nil {
@@ -152,11 +155,14 @@ func execute(cmdArgs []string) error {
 		// We failed to execute.
 		return response.Err
 	}
+	log.Debugf("Execution completed in %s", time.Since(stageStart))
+	stageStart = time.Now()
 	log.Debugf("Downloading result")
 	res, err := rexec.GetResult(ctx, env, *instanceName, df, response.ExecuteResponse.GetResult())
 	if err != nil {
 		return status.WrapError(err, "execution failed")
 	}
+	log.Debugf("Downloaded results in %s", time.Since(stageStart))
 	log.Debugf("End-to-end execution time: %s", time.Since(start))
 
 	os.Stdout.Write(res.Stdout)

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -187,6 +187,9 @@ func (s *ExecutionServer) pubSubChannelForExecutionID(executionID string) *pubsu
 }
 
 func (s *ExecutionServer) insertExecution(ctx context.Context, executionID, invocationID, snippet string, stage repb.ExecutionStage_Value) error {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
 	if s.env.GetDBHandle() == nil {
 		return status.FailedPreconditionError("database not configured")
 	}
@@ -220,6 +223,9 @@ func (s *ExecutionServer) insertExecution(ctx context.Context, executionID, invo
 }
 
 func (s *ExecutionServer) insertInvocationLink(ctx context.Context, executionID, invocationID string, linkType sipb.StoredInvocationLink_Type) error {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
 	// Add the invocation links to Redis. MySQL insertion sometimes can take a
 	// longer time to finish and the insertion can be finished after the
 	// execution is complete.
@@ -417,6 +423,9 @@ func (s *ExecutionServer) Execute(req *repb.ExecuteRequest, stream repb.Executio
 }
 
 func (s *ExecutionServer) Dispatch(ctx context.Context, req *repb.ExecuteRequest) (string, error) {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
 	scheduler := s.env.GetSchedulerService()
 	if scheduler == nil {
 		return "", status.FailedPreconditionErrorf("No scheduler service configured")

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -679,6 +679,9 @@ func (np *nodePool) FindConnectedExecutorByID(executorID string) *executionNode 
 }
 
 func (np *nodePool) AddUnclaimedTask(ctx context.Context, taskID string) error {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
 	key := np.key.redisUnclaimedTasksKey()
 	m := &redis.Z{
 		Member: taskID,
@@ -1116,6 +1119,9 @@ func (s *SchedulerServer) redisKeyForTask(taskID string) string {
 }
 
 func (s *SchedulerServer) insertTask(ctx context.Context, taskID string, metadata *scpb.SchedulingMetadata, serializedTask []byte) error {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
+
 	serializedMetadata, err := proto.Marshal(metadata)
 	if err != nil {
 		return status.InternalErrorf("unable to serialize scheduling metadata: %v", err)


### PR DESCRIPTION
* Add a few spans to better understand scheduling overhead
* Have `bb execute` report time from each stage (when running with `--verbose=1`)

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/2844
