### PR TITLE
[SS] Don't re-cache snapshot chunks that are already cached

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/BUILD
+++ b/enterprise/server/remote_execution/copy_on_write/BUILD
@@ -24,6 +24,7 @@ go_test(
     srcs = ["copy_on_write_test.go"],
     deps = [
         ":copy_on_write",
+        "//enterprise/server/remote_execution/snaputil",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/remote_cache/digest",
@@ -48,6 +49,7 @@ go_test(
     tags = ["performance"],
     deps = [
         ":copy_on_write",
+        "//enterprise/server/remote_execution/snaputil",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/remote_cache/digest",

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -795,7 +795,11 @@ func (m *Mmap) Mapped() bool {
 	return m.safeReadMapped()
 }
 
-func (m *Mmap) SafeReadSource() snaputil.ChunkSource {
+func (m *Mmap) Source() snaputil.ChunkSource {
+	return m.safeReadSource()
+}
+
+func (m *Mmap) safeReadSource() snaputil.ChunkSource {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.source

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/copy_on_write"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/snaputil"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
@@ -523,7 +524,7 @@ func newMmap(t *testing.T) (*copy_on_write.Mmap, string) {
 	s, err := f.Stat()
 	require.NoError(t, err)
 
-	mmap, err := copy_on_write.NewMmapFd(ctx, env, root, int(f.Fd()), int(s.Size()), 0, "")
+	mmap, err := copy_on_write.NewMmapFd(ctx, env, root, int(f.Fd()), int(s.Size()), 0, snaputil.ChunkSourceLocalFile, "")
 	require.NoError(t, err)
 	return mmap, path
 }

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -594,7 +594,7 @@ func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, remoteInsta
 			}
 			fn.Digest = d
 
-			chunkSrc := c.SafeReadSource()
+			chunkSrc := c.Source()
 			// If the chunk was pulled from a cache and is not dirty, we don't need
 			// to re-cache it.
 			// If it was chunked directly from a snapshot file, it may not exist

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -346,7 +346,7 @@ func (l *FileCacheLoader) UnpackSnapshot(ctx context.Context, snapshot *Snapshot
 
 	for _, fileNode := range snapshot.manifest.Files {
 		outputPath := filepath.Join(outputDirectory, fileNode.GetName())
-		if err := snaputil.GetArtifact(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), fileNode.GetDigest(), snapshot.key.InstanceName, outputPath); err != nil {
+		if _, err := snaputil.GetArtifact(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), fileNode.GetDigest(), snapshot.key.InstanceName, outputPath); err != nil {
 			return nil, err
 		}
 	}
@@ -559,6 +559,7 @@ func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, remoteInsta
 	eg.SetLimit(chunkedFileWriteConcurrency)
 
 	chunks := cow.SortedChunks()
+	chunkSourceCounter := make(map[snaputil.ChunkSource]int, len(chunks))
 	for _, c := range chunks {
 		c := c
 		fn := &repb.FileNode{
@@ -568,7 +569,8 @@ func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, remoteInsta
 		tree.Root.Files = append(tree.Root.Files, fn)
 		eg.Go(func() error {
 			ctx := egCtx
-			if cow.Dirty(c.Offset) {
+			dirty := cow.Dirty(c.Offset)
+			if dirty {
 				chunkSize, err := c.SizeBytes()
 				if err != nil {
 					return status.WrapError(err, "dirty chunk size")
@@ -590,12 +592,19 @@ func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, remoteInsta
 			}
 			fn.Digest = d
 
-			if c.Mapped() {
+			chunkSrc := c.SafeReadSource()
+			// If the chunk was pulled from a cache and is not dirty, we don't need
+			// to re-cache it.
+			// If it was chunked directly from a snapshot file, it may not exist
+			// in the cache yet, and we should cache it.
+			shouldCache := dirty || (chunkSrc == snaputil.ChunkSourceLocalFile)
+			if shouldCache {
 				path := filepath.Join(cow.DataDir(), copy_on_write.ChunkName(c.Offset, cow.Dirty(c.Offset)))
 				if err := snaputil.Cache(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), d, remoteInstanceName, path); err != nil {
 					return status.WrapError(err, "write chunk to cache")
 				}
 			}
+			chunkSourceCounter[chunkSrc]++
 
 			return nil
 		})
@@ -636,6 +645,15 @@ func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, remoteInsta
 		metrics.FileName:             name,
 		metrics.RecycledRunnerStatus: recycleStatus,
 	}).Add(float64(dirtyBytes))
+
+	for chunkSrc, count := range chunkSourceCounter {
+		metrics.COWSnapshotChunkSourceRatio.With(prometheus.Labels{
+			metrics.GroupID:              gid,
+			metrics.FileName:             name,
+			metrics.RecycledRunnerStatus: recycleStatus,
+			metrics.ChunkSource:          snaputil.ChunkSourceLabel(chunkSrc),
+		}).Observe(float64(count / len(chunks)))
+	}
 
 	return treeDigest, nil
 }

--- a/enterprise/server/remote_execution/snaputil/snaputil_test.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil_test.go
@@ -46,8 +46,9 @@ func TestCacheAndFetchArtifact(t *testing.T) {
 	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), d, "", b)
 	require.NoError(t, err)
 	outputPath := filepath.Join(tmpDir, "fetch")
-	err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), d, "", outputPath)
+	chunkSrc, err := snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), d, "", outputPath)
 	require.NoError(t, err)
+	require.Equal(t, snaputil.ChunkSourceLocalFilecache, chunkSrc)
 
 	// Read bytes from outputPath and validate with original bytes
 	fetchedStr := testfs.ReadFileAsString(t, tmpDir, "fetch")
@@ -62,8 +63,9 @@ func TestCacheAndFetchArtifact(t *testing.T) {
 	err = env.GetCache().Delete(ctx, rn)
 	require.NoError(t, err)
 	outputPathLocalFetch := filepath.Join(tmpDir, "fetch_local")
-	err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), d, "", outputPathLocalFetch)
+	chunkSrc, err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), d, "", outputPathLocalFetch)
 	require.NoError(t, err)
+	require.Equal(t, snaputil.ChunkSourceLocalFilecache, chunkSrc)
 	fetchedStr = testfs.ReadFileAsString(t, tmpDir, "fetch_local")
 	require.Equal(t, randomStr, fetchedStr)
 
@@ -73,8 +75,9 @@ func TestCacheAndFetchArtifact(t *testing.T) {
 	deleted := fc.DeleteFile(&repb.FileNode{Digest: d})
 	require.True(t, deleted)
 	outputPathRemoteFetch := filepath.Join(tmpDir, "fetch_remote")
-	err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), d, "", outputPathRemoteFetch)
+	chunkSrc, err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), d, "", outputPathRemoteFetch)
 	require.NoError(t, err)
+	require.Equal(t, snaputil.ChunkSourceRemoteCache, chunkSrc)
 	fetchedStr = testfs.ReadFileAsString(t, tmpDir, "fetch_remote")
 	require.Equal(t, randomStr, fetchedStr)
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -208,6 +208,10 @@ const (
 	// sharing status (Ex. 'disabled' or 'local_sharing_enabled')
 	SnapshotSharingStatus = "snapshot_sharing_status"
 
+	// For chunked snapshot files, describes the initialization source of the
+	// chunk (Ex. `remote_cache` or `local_filecache`)
+	ChunkSource = "chunk_source"
+
 	// For remote execution runners, describes the recycling status (Ex.
 	// 'clean' if the runner is not recycled or 'recycled')
 	RecycledRunnerStatus = "recycled_runner_status"
@@ -1037,6 +1041,18 @@ var (
 		GroupID,
 		FileName,
 		RecycledRunnerStatus,
+	})
+
+	COWSnapshotChunkSourceRatio = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "firecracker",
+		Name:      "cow_snapshot_chunk_source_ratio",
+		Help:      "After a copy-on-write snapshot has been used, the percentage of chunks that were initialized by the given source.",
+	}, []string{
+		GroupID,
+		FileName,
+		RecycledRunnerStatus,
+		ChunkSource,
 	})
 
 	RecycleRunnerRequests = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
Add an initialization source to each snapshot chunk. If the chunk was fetched from the cache, we don't need to re-cache it. Even though the cache has short-circuiting behavior if we try to re-upload a chunk that is already cached, a good amount of data could've already been streamed by the time that it exits. 

Also add some metrics to validate our hypothesis that most chunks should be cached locally.