### PR TITLE
Do nothing while draining queue

### DIFF
--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -915,8 +915,7 @@ func (mc *MigrationCache) copyDataInBackground() error {
 	// concurrently queued as the cache is shutting down, and if we try to enqueue a copy to the closed
 	// channel it will panic
 	for len(mc.copyChan) > 0 {
-		c := <-mc.copyChan
-		mc.copy(c)
+		<-mc.copyChan
 	}
 	return nil
 }

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2516,8 +2516,7 @@ func (e *partitionEvictor) processEviction(quitChan chan struct{}) {
 	}
 	eg.Wait()
 	for len(e.deletes) > 0 {
-		s := <-e.deletes
-		e.doEvict(s)
+		<-e.deletes
 	}
 }
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Don't do expensive work like eviction or copying while draining queue, b/c this
can cause pebble cache not properly shut down and we have inconsistencies
between pebble keys and blobs on disk.
