### PR TITLE
Fix broken `diff` mode in bb fix

### DIFF
--- a/cli/fix/BUILD
+++ b/cli/fix/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//cli/log",
         "//cli/translate",
         "//cli/workspace",
+        "//server/util/flag",
         "@com_github_bazelbuild_buildtools//buildifier:go_default_library",
     ],
 )

--- a/cli/test/integration/cli/cli_test.go
+++ b/cli/test/integration/cli/cli_test.go
@@ -325,7 +325,7 @@ func TestQueryFile(t *testing.T) {
 func TestFix(t *testing.T) {
 	ws := testcli.NewWorkspace(t)
 
-	cmd := testcli.Command(t, ws, "fix", "-mode", "diff")
+	cmd := testcli.Command(t, ws, "fix", "--diff")
 	b, err := testcli.CombinedOutput(cmd)
 
 	require.NoError(t, err, "output:\n%s", string(b))

--- a/tools/checkstyle/checkstyle.sh
+++ b/tools/checkstyle/checkstyle.sh
@@ -40,7 +40,7 @@ function run() {
 }
 
 run BuildFiles \
-  "$BB_PATH" fix -mode=diff
+  "$BB_PATH" fix --diff
 
 run GoDeps \
   env GO_PATH="$GO_PATH" \


### PR DESCRIPTION
`bb fix -mode=diff` used to work in 5.0.21 (the version used in our current checkstyle GH action), but broke somewhere along the way. This PR fixes it, but uses an explicit `--diff` flag instead of forwarding `-mode=diff` to gazelle (because `bb fix` now does more than just call gazelle, and we can't safely forward the same args to all commands). Also supports buildifier diffs.

**Related issues**: N/A
