### PR TITLE
Temporarily disable init-dockerd in CI runner image

### DIFF
--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1198,14 +1198,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 			},
 		},
 	}
-	if isSharedFirecrackerWorkflow {
-		// For firecracker workflows, init dockerd in case local actions or
-		// setup scripts want to use it.
-		cmd.Platform.Properties = append(cmd.Platform.Properties, &repb.Platform_Property{
-			Name:  "init-dockerd",
-			Value: "true",
-		})
-	} else {
+	if !isSharedFirecrackerWorkflow {
 		// For docker/podman workflows, run with `--init` so that the bazel
 		// process can be reaped.
 		cmd.Platform.Properties = append(cmd.Platform.Properties, &repb.Platform_Property{


### PR DESCRIPTION
This breaks `docker login` when running as a non-root user.

This is a partial revert of https://github.com/buildbuddy-io/buildbuddy/pull/5099

**Related issues**: N/A
