### PR TITLE
Revert "template-user.bazelrc: remote reference to target-linux"

### DIFF
--- a/template-user.bazelrc
+++ b/template-user.bazelrc
@@ -24,6 +24,16 @@
 ## Uncomment the line below and update the path to point to your local toolchain directory
 #build --override_repository=io_buildbuddy_buildbuddy_toolchain=/ABSOLUTE_PATH_TO_YOUR_TOOLCHAIN_DIRECTORY/buildbuddy-toolchain/
 
+###############################################
+## Remote build from Mac Laptop on Linux RBE ##
+###############################################
+# Use this config with --config=x (cross build)
+#build:x --config=target-linux
+#
+# Show more actions in the terminal output.
+# When execute build remotely, up-to 100 actions could be running in parallel.
+#build --ui_actions_shown=32
+
 ##########
 ## Misc ##
 ##########
@@ -35,7 +45,3 @@
 #
 # Enable Skymeld to speed up build
 #build --config=skymeld
-#
-# Show more actions in the terminal output.
-# When execute build remotely, up-to 100 actions could be running in parallel.
-#build --ui_actions_shown=32


### PR DESCRIPTION
Breaking builds with:

```
$ bazel test //...
INFO: Invocation ID: 09c1ba23-182c-4711-b14d-73f7fa08ae8e
INFO: Streaming build results to: https://buildbuddy.buildbuddy.io/invocation/09c1ba23-182c-4711-b14d-73f7fa08ae8e
INFO: Analyzed 2090 targets (0 packages loaded, 0 targets configured).
INFO: Found 1752 targets and 338 test targets...
ERROR: /home/vadim/.cache/bazel/_bazel_vadim/1a436641b22027f0192ad730e21e3600/external/com_google_absl/absl/base/BUILD.bazel:53:11: Compiling absl/base/log_severity.cc [for tool] failed: undeclared inclusion(s) in rule '@com_google_absl//absl/base:log_severity':
this rule is missing dependency declarations for the following files included by 'absl/base/log_severity.cc':
  '/usr/lib/gcc/x86_64-linux-gnu/11/include/stddef.h'
  '/usr/lib/gcc/x86_64-linux-gnu/11/include/stdarg.h'
  '/usr/lib/gcc/x86_64-linux-gnu/11/include/stdint.h'
  '/usr/lib/gcc/x86_64-linux-gnu/11/include/limits.h'
  '/usr/lib/gcc/x86_64-linux-gnu/11/include/syslimits.h'
```

Reverts buildbuddy-io/buildbuddy#5126