### PR TITLE
Do not increment attempt count on lease reconnect

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -135,6 +135,7 @@ var (
 
 		-- If the client supports reconnect, validate reconnectToken if
 		-- the lease is still in its reconnection grace period.
+		local isNewAttempt = true
 		if ARGV[1] == "true" then
 			local token = redis.call("hget", KEYS[1], "reconnectToken")
 			if token ~= nil and token ~= "" then
@@ -142,10 +143,12 @@ var (
 				if token ~= ARGV[2] and periodEnd > tonumber(ARGV[3]) then
 					return 12
 				end
+				isNewAttempt = false
 			end
 		end
-
-		redis.call("hincrby", KEYS[1], "attemptCount", 1)
+		if isNewAttempt then
+			redis.call("hincrby", KEYS[1], "attemptCount", 1)
+		end
 		redis.call("hset", KEYS[1], "leaseId", ARGV[4])	
 
 		return redis.call("hset", KEYS[1], "claimed", "1")


### PR DESCRIPTION
A reconnect does not begin a new execution attempt, so we shouldn't increment the attempt count.

This is causing some workflow actions to fail after not being retried the full 5 times.

**Related issues**: N/A
