### PR TITLE
blobstore/aws: fix NotFound error handling

### DIFF
--- a/server/backends/blobstore/aws/aws.go
+++ b/server/backends/blobstore/aws/aws.go
@@ -147,9 +147,9 @@ func (a *AwsS3BlobStore) bucketExists(ctx context.Context, bucketName string) (b
 	}
 	var nf *s3types.NotFound
 	if errors.As(err, &nf) {
-		return false, err
+		return false, nil
 	}
-	return false, nil
+	return false, err
 }
 
 func (a *AwsS3BlobStore) createBucketIfNotExists(ctx context.Context, bucketName string) error {


### PR DESCRIPTION
When configure AWS S3 blobstore, we first call HeadBucket to check
whether if the bucket exists. Upon a NotFound error, we should be
attempting to create a new bucket. For any other errors, such as
credential error or SigningError, we want to surface that logic
back to the user.

Flip the return statement between NotFound and other error types when
calling HeadBucket.
