### PR TITLE
Add remote snapshot manifest key to logs

### DIFF
--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//server/util/status",
         "//server/util/tracing",
         "@com_github_prometheus_client_golang//prometheus",
+        "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_x_sync//errgroup",


### PR DESCRIPTION
This will make it easier to track errors across particular snapshot keys, as well as let us pull and inspect them locally.

**Related issues**: N/A
