### PR TITLE
Enable affinity routing unconditionally, with an shutoff flag in case of emergency.

### DIFF
--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	affinityRoutingPermitted = flag.Bool("executor.affinity_routing_permitted", true, "If set, along with the 'affinity-routing' platform property, then (experimental) affinity routing is used. If false, then affinity routing is never used. This flag is intended to be used as an emergency shut-off for this experimental feature.")
+	affinityRoutingEnabled = flag.Bool("executor.affinity_routing_enabled", true, "Enables affinity routing, which attempts to route actions to the executor that most recently ran that action. This flag is intended for disabling this feature in an emergency.")
 )
 
 const (
@@ -276,9 +276,7 @@ func (s runnerRecycler) RoutingInfo(params routingParams) (int, string, error) {
 type affinityRouter struct{}
 
 func (affinityRouter) Applies(params routingParams) bool {
-	return *affinityRoutingPermitted &&
-		platform.IsTrue(platform.FindValue(params.cmd.GetPlatform(), platform.AffinityRoutingPropertyName)) &&
-		getFirstOutput(params.cmd) != ""
+	return *affinityRoutingEnabled && getFirstOutput(params.cmd) != ""
 }
 
 func (affinityRouter) preferredNodeLimit(params routingParams) int {
@@ -322,6 +320,9 @@ func (s affinityRouter) RoutingInfo(params routingParams) (int, string, error) {
 }
 
 func getFirstOutput(cmd *repb.Command) string {
+	if cmd == nil {
+		return ""
+	}
 	if len(cmd.OutputPaths) > 0 && cmd.OutputPaths[0] != "" {
 		return cmd.OutputPaths[0]
 	} else if len(cmd.OutputFiles) > 0 && cmd.OutputFiles[0] != "" {

--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	affinityRoutingEnabled = flag.Bool("executor.affinity_routing_enabled", true, "Enables affinity routing, which attempts to route actions to the executor that most recently ran that action. This flag is intended for disabling this feature in an emergency.")
+	affinityRoutingEnabled = flag.Bool("executor.affinity_routing_enabled", true, "Enables affinity routing, which attempts to route actions to the executor that most recently ran that action.")
 )
 
 const (

--- a/enterprise/server/test/integration/task_router/task_router_test.go
+++ b/enterprise/server/test/integration/task_router/task_router_test.go
@@ -234,7 +234,7 @@ func TestTaskRouter_RankNodes_AffinityRoutingDisabled(t *testing.T) {
 	env := newTestEnv(t)
 	router := newTaskRouter(t, env)
 	ctx := withAuthUser(t, context.Background(), env, "US1")
-	flags.Set(t, "executor.affinity_routing_permitted", false)
+	flags.Set(t, "executor.affinity_routing_enabled", false)
 	cmd := &repb.Command{
 		Platform: &repb.Platform{
 			Properties: []*repb.Platform_Property{
@@ -250,7 +250,7 @@ func TestTaskRouter_RankNodes_AffinityRoutingDisabled(t *testing.T) {
 
 	nodes := sequentiallyNumberedNodes(100)
 
-	// No nodes should be preferred as affinity routing is not permitted.
+	// No nodes should be preferred as affinity routing is disabled.
 	ranked := router.RankNodes(ctx, cmd, instanceName, nodes)
 	require.ElementsMatch(t, nodes, ranked)
 	requireNonSequential(t, ranked)


### PR DESCRIPTION
**Related issues**: [222](https://github.com/buildbuddy-io/buildbuddy-internal/issues/222)