### PR TITLE
Add a flag to enable readonly remote snapshot sharing

### DIFF
--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -496,7 +496,7 @@ func (l *FileCacheLoader) cacheActionResult(ctx context.Context, key *fcpb.Snaps
 	if err != nil {
 		return err
 	}
-	if *snaputil.EnableRemoteSnapshotSharing {
+	if *snaputil.EnableRemoteSnapshotSharing && !*snaputil.RemoteSnapshotReadonly {
 		d, err := remoteManifestKey(key)
 		if err != nil {
 			return err

--- a/enterprise/server/remote_execution/snaputil/snaputil.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil.go
@@ -22,6 +22,7 @@ import (
 
 var EnableLocalSnapshotSharing = flag.Bool("executor.enable_local_snapshot_sharing", false, "Enables local snapshot sharing for firecracker VMs. Also requires that executor.firecracker_enable_nbd is true.")
 var EnableRemoteSnapshotSharing = flag.Bool("executor.enable_remote_snapshot_sharing", false, "Enables remote snapshot sharing for firecracker VMs. Also requires that executor.firecracker_enable_nbd and executor.firecracker_enable_uffd are true.")
+var RemoteSnapshotReadonly = flag.Bool("executor.remote_snapshot_readonly", false, "Disables remote snapshot writes.")
 
 func GetArtifact(ctx context.Context, localCache interfaces.FileCache, bsClient bytestream.ByteStreamClient, d *repb.Digest, instanceName string, outputPath string) error {
 	node := &repb.FileNode{Digest: d}
@@ -75,7 +76,7 @@ func GetBytes(ctx context.Context, localCache interfaces.FileCache, bsClient byt
 // if remote snapshot sharing is enabled
 func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytestream.ByteStreamClient, d *repb.Digest, remoteInstanceName string, path string) error {
 	localCacheErr := cacheLocally(localCache, d, path)
-	if !*EnableRemoteSnapshotSharing {
+	if !*EnableRemoteSnapshotSharing || *RemoteSnapshotReadonly {
 		return localCacheErr
 	}
 


### PR DESCRIPTION
We want `tools/vmstart` to be able to read snapshots from remote cache (for debugging purposes), but not overwrite them.

**Related issues**: N/A
