### PR TITLE
More granular invocation statuses

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -399,6 +399,7 @@ ts_library(
         "//app/favicon",
         "//app/format",
         "//app/service:rpc_service",
+        "//app/util:exit_codes",
         "//app/util:proto",
         "//proto:api_key_ts_proto",
         "//proto:build_event_stream_ts_proto",

--- a/app/invocation/suggestion_button.tsx
+++ b/app/invocation/suggestion_button.tsx
@@ -77,7 +77,7 @@ export default class SuggestionButton extends React.Component<SuggestionButtonPr
       !capabilities.config.botSuggestionsEnabled ||
       !this.props.user ||
       !this.props.user?.selectedGroup?.botSuggestionsEnabled ||
-      this.props.model.getStatus() != "Failed"
+      this.props.model.invocation.bazelExitCode == "SUCCESS"
     ) {
       return <></>;
     }

--- a/app/util/BUILD
+++ b/app/util/BUILD
@@ -116,3 +116,8 @@ ts_library(
     name = "popup",
     srcs = ["popup.ts"],
 )
+
+ts_library(
+    name = "exit_codes",
+    srcs = ["exit_codes.ts"],
+)

--- a/app/util/exit_codes.ts
+++ b/app/util/exit_codes.ts
@@ -1,0 +1,40 @@
+export function exitCode(exitCode: string) {
+  switch (exitCode) {
+    case "SUCCESS":
+      return "Succeeded";
+    case "BUILD_FAILURE":
+      return "Build failed";
+    case "PARSING_FAILURE":
+      return "Parsing failed";
+    case "COMMAND_LINE_ERROR":
+      return "Bad command line";
+    case "TESTS_FAILED":
+      return "Tests failed";
+    case "PARTIAL_ANALYSIS_FAILURE":
+    case "ANALYSIS_FAILURE":
+      return "Analysis failed";
+    case "NO_TESTS_FOUND":
+      return "No tests found";
+    case "RUN_FAILURE":
+      return "Run failed";
+    case "INTERRUPTED":
+      return "Interrupted";
+    case "REMOTE_ERROR":
+    case "REMOTE_ENVIRONMENTAL_ERROR":
+      return "Remote failure";
+    case "LOCAL_ENVIRONMENTAL_ERROR":
+      return "Local environment failure";
+    case "OOM_ERROR":
+      return "Out of memory";
+    case "BLAZE_INTERNAL_ERROR":
+      return "Bazel internal failure";
+    case "REMOTE_CACHE_EVICTED":
+      return "Cache eviction";
+    case "PUBLISH_ERROR":
+    case "PERSISTENT_BUILD_EVENT_SERVICE_UPLOAD_ERROR":
+      return "Build event failure";
+    case "EXTERNAL_DEPS_ERROR":
+      return "External dep failure";
+  }
+  return "Failed";
+}

--- a/app/util/exit_codes.ts
+++ b/app/util/exit_codes.ts
@@ -1,3 +1,4 @@
+// From https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/util/ExitCode.java#L38
 export function exitCode(exitCode: string) {
   switch (exitCode) {
     case "SUCCESS":
@@ -9,7 +10,7 @@ export function exitCode(exitCode: string) {
     case "COMMAND_LINE_ERROR":
       return "Bad command line";
     case "TESTS_FAILED":
-      return "Tests failed";
+      return "Test failed";
     case "PARTIAL_ANALYSIS_FAILURE":
     case "ANALYSIS_FAILURE":
       return "Analysis failed";

--- a/enterprise/app/history/BUILD
+++ b/enterprise/app/history/BUILD
@@ -44,6 +44,7 @@ ts_library(
         "//app/components/link",
         "//app/format",
         "//app/router",
+        "//app/util:exit_codes",
         "//proto:invocation_status_ts_proto",
         "//proto:invocation_ts_proto",
         "@npm//@types/react",

--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -423,6 +423,9 @@ export default class HistoryComponent extends React.Component<Props, State> {
     if (selectedInvocation.invocationStatus == invocation_status.InvocationStatus.DISCONNECTED_INVOCATION_STATUS) {
       return "grid-block-disconnected";
     }
+    if (selectedInvocation.bazelExitCode == "NO_TESTS_FOUND") {
+      return "grid-block-neutral";
+    }
     return selectedInvocation.success ? "grid-block-success" : "grid-block-failure";
   }
 

--- a/enterprise/app/history/history_invocation_card.tsx
+++ b/enterprise/app/history/history_invocation_card.tsx
@@ -12,6 +12,7 @@ import {
   User,
   Wrench,
   XCircle,
+  Circle,
 } from "lucide-react";
 import React from "react";
 import format from "../../../app/format/format";
@@ -19,6 +20,7 @@ import router from "../../../app/router/router";
 import Link from "../../../app/components/link/link";
 import { invocation } from "../../../proto/invocation_ts_proto";
 import { invocation_status } from "../../../proto/invocation_status_ts_proto";
+import { exitCode } from "../../../app/util/exit_codes";
 
 const durationRefreshIntervalMillis = 3000;
 
@@ -118,6 +120,10 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
       return "card-disconnected";
     }
 
+    if (this.props.invocation.bazelExitCode == "NO_TESTS_FOUND") {
+      return "card-neutral";
+    }
+
     return this.props.invocation.success ? "card-success" : "card-failure";
   }
 
@@ -128,6 +134,10 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
 
     if (this.isDisconnected()) {
       return <HelpCircle className="icon" />;
+    }
+
+    if (this.props.invocation.bazelExitCode == "NO_TESTS_FOUND") {
+      return <Circle className="icon gray" />;
     }
 
     return this.props.invocation.success ? <CheckCircle className="icon green" /> : <XCircle className="icon red" />;
@@ -141,8 +151,7 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
     if (this.isDisconnected()) {
       return "Disconnected";
     }
-
-    return this.props.invocation.success ? "Succeeded" : "Failed";
+    return exitCode(this.props.invocation.bazelExitCode);
   }
 
   private getTitleForWorkflow() {

--- a/server/test/webdriver/invocation/invocation_test.go
+++ b/server/test/webdriver/invocation/invocation_test.go
@@ -58,7 +58,7 @@ func TestInvocationPage_FailedInvocation_BESOnly(t *testing.T) {
 	details := wt.Find(".details").Text()
 
 	assert.NotContains(t, details, "Succeeded")
-	assert.Contains(t, details, "Test failed")
+	assert.Contains(t, details, "Build failed")
 	assert.Contains(t, details, "//:a")
 	assert.Contains(t, details, "Cache off")
 	assert.Contains(t, details, "Remote execution off")

--- a/server/test/webdriver/invocation/invocation_test.go
+++ b/server/test/webdriver/invocation/invocation_test.go
@@ -29,7 +29,7 @@ func TestInvocationPage_SuccessfulInvocation_BESOnly(t *testing.T) {
 	details := wt.Find(".details").Text()
 
 	assert.Contains(t, details, "Succeeded")
-	assert.NotContains(t, details, "Failed")
+	assert.NotContains(t, details, "failed")
 	assert.Contains(t, details, "//:a")
 	assert.Contains(t, details, "Cache off")
 	assert.Contains(t, details, "Remote execution off")
@@ -58,7 +58,7 @@ func TestInvocationPage_FailedInvocation_BESOnly(t *testing.T) {
 	details := wt.Find(".details").Text()
 
 	assert.NotContains(t, details, "Succeeded")
-	assert.Contains(t, details, "Failed")
+	assert.Contains(t, details, "Test failed")
 	assert.Contains(t, details, "//:a")
 	assert.Contains(t, details, "Cache off")
 	assert.Contains(t, details, "Remote execution off")


### PR DESCRIPTION
Shows more granular test statuses in the UI based off of Bazel exit code.

Also makes the "NO_TESTS_FOUND" exit code display as more of a neutral status rather than a hard failure.