### PR TITLE
Allow vmstart to load remote snapshots

### DIFF
--- a/enterprise/tools/vmstart/BUILD
+++ b/enterprise/tools/vmstart/BUILD
@@ -12,6 +12,7 @@ go_library(
     srcs = ["vmstart.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/tools/vmstart",
     deps = [
+        "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/containers/firecracker",
         "//enterprise/server/remote_execution/filecache",
@@ -19,6 +20,7 @@ go_library(
         "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
+        "//proto:runner_go_proto",
         "//proto:vmvfs_go_proto",
         "//server/real_environment",
         "//server/remote_cache/cachetools",
@@ -27,9 +29,12 @@ go_library(
         "//server/util/grpc_client",
         "//server/util/healthcheck",
         "//server/util/log",
+        "//server/util/networking",
+        "//server/util/rexec",
         "//server/util/status",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//encoding/prototext",
     ],
 )

--- a/enterprise/tools/vmstart/vmstart.go
+++ b/enterprise/tools/vmstart/vmstart.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"flag"
+	"fmt"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -11,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/firecracker"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/filecache"
@@ -22,13 +26,17 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/networking"
+	"github.com/buildbuddy-io/buildbuddy/server/util/rexec"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/prototext"
 
 	fcpb "github.com/buildbuddy-io/buildbuddy/proto/firecracker"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
+	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
 	vmfspb "github.com/buildbuddy-io/buildbuddy/proto/vmvfs"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
@@ -39,13 +47,31 @@ var (
 	registryPassword    = flag.String("container_registry_password", "", "Password to use when pulling the image")
 	cacheTarget         = flag.String("cache_target", "grpcs://remote.buildbuddy.dev", "The remote cache target")
 	snapshotDir         = flag.String("snapshot_dir", "/tmp/filecache", "The directory to store snapshots in")
-	snapshotDirMaxBytes = flag.Int64("snapshot_dir_max_bytes", 10000000000, "The max number of bytes the snapshot_dir can be")
+	snapshotDirMaxBytes = flag.Int64("snapshot_dir_max_bytes", 20_000_000_000, "The max number of bytes the snapshot_dir can be")
 	remoteInstanceName  = flag.String("remote_instance_name", "", "The remote_instance_name for caching snapshots and interacting with the CAS if an action digest is specified")
 	forceVMIdx          = flag.Int("force_vm_idx", -1, "VM index to force to avoid network conflicts -- random by default")
-	snapshotID          = flag.String("snapshot_id", "", "The snapshot ID to load")
 	apiKey              = flag.String("api_key", "", "The API key to use to interact with the remote cache.")
 	actionDigest        = flag.String("action_digest", "", "The optional digest of the action you want to mount.")
+
+	// Note: this key can be copied and pasted from logs:
+	//
+	//  "INFO: Fetched remote snapshot manifest {...}" // copy this JSON
+	//
+	// At the shell, paste it in single quotes: -remote_snapshot_key='<paste>'
+	// Make sure to also set -api_key for proper auth. The API key must match
+	// the group ID in the logs.
+	remoteSnapshotKeyJSON = flag.String("remote_snapshot_key", "", "JSON struct containing a remote snapshot key that the VM should be resumed from.")
+
+	tty  = flag.Bool("tty", false, "Enable debug terminal. This doesn't always work when resuming from snapshot.")
+	repl = flag.Bool("repl", false, "Start a basic REPL for running bash commands with Exec().")
 )
+
+type RemoteSnapshotKey struct {
+	GroupID      string `json:"group_id"`
+	InstanceName string `json:"instance_name"`
+	KeyDigest    string `json:"key_digest"`
+	Key          any    `json:"key"`
+}
 
 func getToolEnv() *real_environment.RealEnv {
 	healthChecker := healthcheck.NewHealthChecker("tool")
@@ -69,7 +95,23 @@ func getToolEnv() *real_environment.RealEnv {
 	return re
 }
 
-func parseSnapshotID(in string) *repb.Digest {
+func parseSnapshotKeyJSON(in string) (*RemoteSnapshotKey, *fcpb.SnapshotKey) {
+	k := &RemoteSnapshotKey{}
+	if err := json.Unmarshal([]byte(in), k); err != nil {
+		log.Fatalf("Failed to parse remote snapshot key: %s", err)
+	}
+	b, err := json.Marshal(k.Key)
+	if err != nil {
+		log.Fatalf("Failed to marshal SnapshotKey: %s", err)
+	}
+	pk := &fcpb.SnapshotKey{}
+	if err := protojson.Unmarshal(b, pk); err != nil {
+		log.Fatalf("Failed to unmashal SnapshotKey: %s", err)
+	}
+	return k, pk
+}
+
+func parseDigest(in string) *repb.Digest {
 	parts := strings.SplitN(in, "/", 2)
 	if len(parts) != 2 || len(parts[0]) != 64 {
 		log.Fatalf("Error parsing snapshotID %q (not in hash/size form)", in)
@@ -100,13 +142,34 @@ func main() {
 	flag.Parse()
 
 	flagutil.SetValueForFlagName("executor.firecracker_debug_stream_vm_logs", true, nil, false)
-	flagutil.SetValueForFlagName("executor.firecracker_debug_terminal", true, nil, false)
+	if *tty {
+		flagutil.SetValueForFlagName("executor.firecracker_debug_terminal", true, nil, false)
+	}
+	if *repl && *tty {
+		log.Fatalf("Only one of -tty or -repl may be set.")
+	}
+
+	// Enable copy-on-write + remote snapshot sharing, but don't re-upload
+	// back to the remote:
+	if os.Getuid() != 0 {
+		log.Fatalf("Must be run as root: 'bazel run --run_under=sudo'")
+	}
+	flagutil.SetValueForFlagName("executor.firecracker_enable_uffd", true, nil, false)
+	flagutil.SetValueForFlagName("executor.firecracker_enable_vbd", true, nil, false)
+	flagutil.SetValueForFlagName("executor.firecracker_enable_merged_rootfs", true, nil, false)
+	flagutil.SetValueForFlagName("executor.enable_local_snapshot_sharing", true, nil, false)
+	flagutil.SetValueForFlagName("executor.enable_remote_snapshot_sharing", true, nil, false)
+	flagutil.SetValueForFlagName("executor.remote_snapshot_readonly", true, nil, false)
 
 	rand.Seed(time.Now().Unix())
 
 	env := getToolEnv()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	if err := networking.DeleteNetNamespaces(ctx); err != nil {
+		log.Warningf("Failed to clean up network namespaces: %s", err)
+	}
 
 	if *apiKey != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-api-key", *apiKey)
@@ -143,9 +206,16 @@ func main() {
 	}
 
 	var c *firecracker.FirecrackerContainer
-	// TODO: make snapshotID work again.
-	if *snapshotID != "" {
-		c, err = firecracker.NewContainer(ctx, env, &repb.ExecutionTask{}, opts)
+	if *remoteSnapshotKeyJSON != "" {
+		// Runner recycling is needed to allow starting from snapshot.
+		p, err := rexec.MakePlatform("recycle-runner=true")
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		task := &repb.ExecutionTask{Command: &repb.Command{Platform: p}}
+		_, key := parseSnapshotKeyJSON(*remoteSnapshotKeyJSON)
+		opts.SavedState = &rnpb.FirecrackerState{SnapshotKey: key}
+		c, err = firecracker.NewContainer(ctx, env, task, opts)
 		if err != nil {
 			log.Fatalf("Error creating container: %s", err)
 		}
@@ -177,6 +247,15 @@ func main() {
 			}
 			log.Printf("Saved snapshot")
 		}
+	}()
+
+	go func() {
+		env.GetHealthChecker().WaitForGracefulShutdown()
+		log.Infof("Shutdown: removing VM")
+		if err := c.Remove(ctx); err != nil {
+			log.Errorf("Failed to remove VM: %s", err)
+		}
+		os.Exit(2)
 	}()
 
 	if *actionDigest != "" {
@@ -221,8 +300,31 @@ func main() {
 
 	log.Printf("Started firecracker container!")
 	log.Printf("To capture a snapshot at any time, send SIGTERM (killall vmstart)")
-	if err := c.Wait(ctx); err != nil {
-		log.Printf("Wait err: %s", err)
+
+	if *repl {
+		log.Infof("Starting Exec() repl (enter bash commands; quit with Ctrl+D)")
+		s := bufio.NewScanner(os.Stdin)
+		for {
+			fmt.Fprintf(os.Stderr, "bash> ")
+			if !s.Scan() {
+				break
+			}
+			res := c.Exec(ctx, &repb.Command{
+				Arguments: []string{"bash", "-c", s.Text()},
+			}, &commandutil.Stdio{
+				Stdout: os.Stdout,
+				Stderr: os.Stderr,
+			})
+			if res.Error != nil {
+				log.Error(res.Error.Error())
+			}
+		}
+	}
+
+	if *tty {
+		if err := c.Wait(ctx); err != nil {
+			log.Errorf("Wait err: %s", err)
+		}
 	}
 
 	if err := c.Remove(ctx); err != nil {


### PR DESCRIPTION
Adds several improvements to `enterprise/tools/vmstart`:

* Allow loading remote snapshots.
* Add a "repl" mode to allow entering commands into the VM using a super basic Bash REPL. The VM debug terminal can't be used when starting from remote snapshots, because the tty flags need to be set via boot args.
* Call vm.Remove() when pressing Ctrl+C instead of doing nothing.
* Run networking cleanup before doing anything to prevent random network errors.

**Related issues**: N/A
