### PR TITLE
server/static: refactor to support FOSS build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -170,6 +170,14 @@ build:macos --cxxopt=-std=c++17
 build:windows --host_cxxopt=/std:c++17
 build:windows --cxxopt=/std:c++17
 
+# Special config to help build FOSS without the //enterprise source code (WIP)
+#
+# Usage:
+#
+#   bazel build --config=foss server
+#
+build:foss --@io_bazel_rules_go//go/config:tags=buildbuddy_foss
+
 # Run Webdriver tests with --config=webdriver-debug to debug webdriver tests locally.
 # See server/testutil/webtester/webtester.go for more details.
 test:webdriver-debug --test_arg=-webdriver_debug

--- a/enterprise/server/githubauth/BUILD
+++ b/enterprise/server/githubauth/BUILD
@@ -1,10 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+# gazelle:default_visibility //enterprise:__subpackages__,//server/static:__pkg__
+package(default_visibility = [
+    "//enterprise:__subpackages__",
+    "//server/static:__pkg__",
+])
+
 go_library(
     name = "githubauth",
     srcs = ["githubauth.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/githubauth",
-    visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/githubapp",
         "//server/backends/github",
@@ -20,5 +25,3 @@ go_library(
         "@com_github_google_uuid//:uuid",
     ],
 )
-
-package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/invocation_stat_service/config/BUILD
+++ b/enterprise/server/invocation_stat_service/config/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-# TODO(sluongng): ensure all //enterprise code are not dependency of FOSS code
 # gazelle:default_visibility //enterprise:__subpackages__,//server/static:__pkg__
 package(default_visibility = [
     "//enterprise:__subpackages__",

--- a/platforms/configs/BUILD
+++ b/platforms/configs/BUILD
@@ -1,3 +1,5 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
 package(default_visibility = ["//visibility:public"])
 
 config_setting(
@@ -22,4 +24,11 @@ config_setting(
         "@platforms//os:macos",
         "@platforms//cpu:arm64",
     ],
+)
+
+config_setting(
+    name = "buildbuddy_foss",
+    flag_values = {
+        "@io_bazel_rules_go//go/config:tags": "buildbuddy_foss",
+    },
 )

--- a/server/static/BUILD
+++ b/server/static/BUILD
@@ -2,14 +2,14 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "static",
-    srcs = ["static.go"],
+    srcs = [
+        "static.go",
+        "static_enterprise.go",
+        "static_foss.go",  #keep
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/static",
     visibility = ["//visibility:public"],
     deps = [
-        "//enterprise/server/githubauth",
-        "//enterprise/server/invocation_stat_service/config",
-        "//enterprise/server/remote_execution/config",
-        "//enterprise/server/scheduling/scheduler_server/config",
         "//proto:config_go_proto",
         "//server/backends/github",
         "//server/build_event_protocol/target_tracker",
@@ -23,5 +23,13 @@ go_library(
         "//server/version",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
         "@org_golang_google_protobuf//encoding/protojson",
-    ],
+    ] + select({
+        "//platforms/configs:buildbuddy_foss": [],
+        "//conditions:default": [
+            "//enterprise/server/githubauth",
+            "//enterprise/server/invocation_stat_service/config",
+            "//enterprise/server/remote_execution/config",
+            "//enterprise/server/scheduling/scheduler_server/config",
+        ],
+    }),  #keep
 )

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/githubauth"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/github"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/target_tracker"
 	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
@@ -23,9 +22,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/version"
 	"google.golang.org/protobuf/encoding/protojson"
 
-	iss_config "github.com/buildbuddy-io/buildbuddy/enterprise/server/invocation_stat_service/config"
-	remote_execution_config "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/config"
-	scheduler_server_config "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/scheduler_server/config"
 	cfgpb "github.com/buildbuddy-io/buildbuddy/proto/config"
 )
 
@@ -153,18 +149,18 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		DefaultToDenseMode:                     *defaultToDenseMode,
 		GithubEnabled:                          github.IsLegacyOAuthAppEnabled(),
 		GithubAppEnabled:                       env.GetGitHubApp() != nil,
-		GithubAuthEnabled:                      githubauth.IsEnabled(env),
+		GithubAuthEnabled:                      githubAuthEnabled(env),
 		AnonymousUsageEnabled:                  env.GetAuthenticator().AnonymousUsageEnabled(ctx),
 		TestDashboardEnabled:                   target_tracker.TargetTrackingEnabled(),
-		UserOwnedExecutorsEnabled:              remote_execution_config.RemoteExecutionEnabled() && scheduler_server_config.UserOwnedExecutorsEnabled(),
-		ExecutorKeyCreationEnabled:             remote_execution_config.RemoteExecutionEnabled() && *enableExecutorKeyCreation,
-		WorkflowsEnabled:                       remote_execution_config.RemoteExecutionEnabled() && *enableWorkflows,
+		UserOwnedExecutorsEnabled:              remoteExecutionEnabled() && userOwnedExecutorsEnabled(),
+		ExecutorKeyCreationEnabled:             remoteExecutionEnabled() && *enableExecutorKeyCreation,
+		WorkflowsEnabled:                       remoteExecutionEnabled() && *enableWorkflows,
 		CodeEditorEnabled:                      *codeEditorEnabled,
-		RemoteExecutionEnabled:                 remote_execution_config.RemoteExecutionEnabled(),
+		RemoteExecutionEnabled:                 remoteExecutionEnabled(),
 		SsoEnabled:                             env.GetAuthenticator().SSOEnabled(),
 		GlobalFilterEnabled:                    true,
 		UsageEnabled:                           *usageEnabled,
-		ForceUserOwnedDarwinExecutors:          remote_execution_config.RemoteExecutionEnabled() && scheduler_server_config.ForceUserOwnedDarwinExecutors(),
+		ForceUserOwnedDarwinExecutors:          remoteExecutionEnabled() && forceUserOwnedDarwinExecutors(),
 		TestGridV2Enabled:                      *testGridV2Enabled,
 		DetailedCacheStatsEnabled:              hit_tracker.DetailedStatsEnabled(),
 		ExpandedSuggestionsEnabled:             *expandedSuggestionsEnabled,
@@ -172,7 +168,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		SecretsEnabled:                         env.GetSecretService() != nil,
 		TestOutputManifestsEnabled:             *testOutputManifestsEnabled,
 		UserOwnedKeysEnabled:                   env.GetAuthDB() != nil && env.GetAuthDB().GetUserOwnedKeysEnabled(),
-		TrendsHeatmapEnabled:                   iss_config.TrendsHeatmapEnabled() && env.GetOLAPDBHandle() != nil,
+		TrendsHeatmapEnabled:                   trendsHeatmapEnabled() && env.GetOLAPDBHandle() != nil,
 		PatternFilterEnabled:                   *patternFilterEnabled,
 		BotSuggestionsEnabled:                  env.GetSuggestionService() != nil,
 		MultipleSuggestionProviders:            env.GetSuggestionService() != nil && env.GetSuggestionService().MultipleProvidersConfigured(),

--- a/server/static/static_enterprise.go
+++ b/server/static/static_enterprise.go
@@ -1,0 +1,32 @@
+//go:build !buildbuddy_foss
+
+package static
+
+import (
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/githubauth"
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+
+	iss_config "github.com/buildbuddy-io/buildbuddy/enterprise/server/invocation_stat_service/config"
+	remote_execution_config "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/config"
+	scheduler_server_config "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/scheduler_server/config"
+)
+
+func githubAuthEnabled(env environment.Env) bool {
+	return githubauth.IsEnabled(env)
+}
+
+func trendsHeatmapEnabled() bool {
+	return iss_config.TrendsHeatmapEnabled()
+}
+
+func remoteExecutionEnabled() bool {
+	return remote_execution_config.RemoteExecutionEnabled()
+}
+
+func userOwnedExecutorsEnabled() bool {
+	return scheduler_server_config.UserOwnedExecutorsEnabled()
+}
+
+func forceUserOwnedDarwinExecutors() bool {
+	return scheduler_server_config.ForceUserOwnedDarwinExecutors()
+}

--- a/server/static/static_foss.go
+++ b/server/static/static_foss.go
@@ -1,0 +1,27 @@
+//go:build buildbuddy_foss
+
+package static
+
+import (
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+)
+
+func githubAuthEnabled(env environment.Env) bool {
+	return false
+}
+
+func trendsHeatmapEnabled() bool {
+	return false
+}
+
+func remoteExecutionEnabled() bool {
+	return false
+}
+
+func userOwnedExecutorsEnabled() bool {
+	return false
+}
+
+func forceUserOwnedDarwinExecutors() bool {
+	return false
+}


### PR DESCRIPTION
Some of our FOSS code depend on sources in //enterprise to provide
the right config values. This prevents builds from our FOSS repo from
functioning correctly.

Leveraging rules_go's `tags` flag to specify a special Go build
directive `buildbuddy_foss` to selectively favor FOSS source code over
enterprise source code. Also, wrap this flag with a build config
`//platforms/configs:buildbuddy_foss` so that we can selectively declare
dependencies.

This enables us to do this

```
> rm -rf enterprise
> bazel build --config=foss server/static/...
```

Future PRs will leverage these new control knobs to fix FOSS builds
for good.
