### PR TITLE
Log backfill duration.

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -546,10 +546,14 @@ func dedupeBackfills(backfills []*backfillOrder) []*backfillOrder {
 	return deduped
 }
 
-func (c *Cache) backfillPeers(ctx context.Context, backfills []*backfillOrder) error {
+func (c *Cache) backfillPeers(ctx context.Context, backfills []*backfillOrder) (err error) {
 	if len(backfills) == 0 {
 		return nil
 	}
+	start := time.Now()
+	defer func() {
+		log.CtxDebugf(ctx, "backfill took %s err %v", time.Since(start), err)
+	}()
 	backfills = dedupeBackfills(backfills)
 	eg, gCtx := errgroup.WithContext(ctx)
 	for _, bf := range backfills {


### PR DESCRIPTION
I suspect this may be contributing to slow reads on restarts.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
