### PR TITLE
[SS] Start eager fetching at the chunk following the one that is accessed

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -525,7 +525,7 @@ type eagerFetchData struct {
 }
 
 func (s *COWStore) eagerFetchNextChunks(offset int64) {
-	currentOffset := offset
+	currentOffset := offset + s.chunkSizeBytes
 	for i := 0; i < numChunksToEagerFetch; i++ {
 		s.sendNonBlockingEagerFetch(currentOffset)
 		currentOffset += s.chunkSizeBytes


### PR DESCRIPTION
The accessed chunk will be accessed in the foreground, so we can start eager fetching at the following chunk. This makes the `eagerFetchNextChunks` parameter a little more intuitive
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
