### PR TITLE
[SS] Limit non-workflow actions to local-only snapshot sharing

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -458,10 +458,9 @@ func (p *Provider) New(ctx context.Context, props *platform.Properties, task *re
 
 // FirecrackerContainer executes commands inside of a firecracker VM.
 type FirecrackerContainer struct {
-	id          string // a random GUID, unique per-run of firecracker
-	vmIdx       int    // the index of this vm on the host machine
-	loader      *snaploader.FileCacheLoader
-	snapshotKey *fcpb.SnapshotKey
+	id     string // a random GUID, unique per-run of firecracker
+	vmIdx  int    // the index of this vm on the host machine
+	loader *snaploader.FileCacheLoader
 
 	vmConfig         *fcpb.VMConfiguration
 	containerImage   string // the OCI container image. ex "alpine:latest"
@@ -477,6 +476,14 @@ type FirecrackerContainer struct {
 
 	// Whether the VM was recycled.
 	recycled bool
+
+	// The following snapshot-related fields are initialized in NewContainer
+	// based on the incoming task. If there is a new task, you may want to call
+	// NewContainer again rather than directly unpausing a pre-existing container,
+	// to make sure these fields are updated and the best snapshot match is used
+	snapshotKey             *fcpb.SnapshotKey
+	createFromSnapshot      bool
+	supportsRemoteSnapshots bool
 
 	// When the VM was initialized (i.e. created or unpaused) for the command
 	// it is currently executing
@@ -508,7 +515,6 @@ type FirecrackerContainer struct {
 	machine            *fcclient.Machine // the firecracker machine object.
 	vmLog              *VMLog
 	env                environment.Env
-	createFromSnapshot bool
 	mountWorkspaceFile bool
 
 	cleanupVethPair func(context.Context) error
@@ -572,6 +578,9 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 		c.vmIdx = opts.ForceVMIdx
 	}
 
+	isWorkflow := platform.FindValue(task.GetCommand().GetPlatform(), platform.WorkflowIDPropertyName) != ""
+	c.supportsRemoteSnapshots = isWorkflow && *snaputil.EnableRemoteSnapshotSharing
+
 	if opts.SavedState == nil {
 		c.vmConfig.DebugMode = *debugTerminal
 
@@ -598,7 +607,7 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 
 		recyclingEnabled := platform.IsTrue(platform.FindValue(task.GetCommand().GetPlatform(), platform.RecycleRunnerPropertyName))
 		if recyclingEnabled && *snaputil.EnableLocalSnapshotSharing {
-			_, err := loader.GetSnapshot(ctx, c.snapshotKey)
+			_, err := loader.GetSnapshot(ctx, c.snapshotKey, c.supportsRemoteSnapshots)
 			c.createFromSnapshot = (err == nil)
 		}
 	} else {
@@ -809,6 +818,7 @@ func (c *FirecrackerContainer) saveSnapshot(ctx context.Context, snapshotDetails
 		InitrdImagePath:     c.executorConfig.InitrdImagePath,
 		ChunkedFiles:        map[string]*copy_on_write.COWStore{},
 		Recycled:            c.recycled,
+		Remote:              c.supportsRemoteSnapshots,
 	}
 	if *enableVBD {
 		if c.rootStore != nil {
@@ -925,7 +935,7 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 	}
 	log.CtxDebugf(ctx, "Command: %v", reflect.Indirect(reflect.Indirect(reflect.ValueOf(machine)).FieldByName("cmd")).FieldByName("Args"))
 
-	snap, err := c.loader.GetSnapshot(ctx, c.snapshotKey)
+	snap, err := c.loader.GetSnapshot(ctx, c.snapshotKey, c.supportsRemoteSnapshots)
 	if err != nil {
 		return status.WrapError(err, "failed to get snapshot")
 	}
@@ -1110,7 +1120,7 @@ func (c *FirecrackerContainer) convertToCOW(ctx context.Context, filePath, chunk
 		return nil, status.WrapError(err, "make chunk dir")
 	}
 	// Use vmCtx for the COW since IO may be done outside of the task ctx.
-	cow, err := copy_on_write.ConvertFileToCOW(c.vmCtx, c.env, filePath, cowChunkSizeBytes(), chunkDir, c.snapshotKey.InstanceName)
+	cow, err := copy_on_write.ConvertFileToCOW(c.vmCtx, c.env, filePath, cowChunkSizeBytes(), chunkDir, c.snapshotKey.InstanceName, c.supportsRemoteSnapshots)
 	if err != nil {
 		return nil, status.WrapError(err, "convert file to COW")
 	}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -945,7 +945,7 @@ func TestFirecracker_RemoteSnapshotSharing_ManualBenchmarking(t *testing.T) {
 		require.NoError(t, err)
 		snapshotKey, err := snaploader.NewKey(task, configHash.GetHash(), "")
 		require.NoError(t, err)
-		snapMetadata, err := loader.GetSnapshot(ctx, snapshotKey)
+		snapMetadata, err := loader.GetSnapshot(ctx, snapshotKey, enableRemote)
 		require.NoError(t, err)
 		for _, f := range snapMetadata.GetFiles() {
 			if rand.Intn(100) < 30 {
@@ -1101,7 +1101,7 @@ func TestFirecracker_RemoteSnapshotSharing_ManualBenchmarking(t *testing.T) {
 		require.NoError(t, err)
 		snapshotKey, err := snaploader.NewKey(task, configHash.GetHash(), "")
 		require.NoError(t, err)
-		snapMetadata, err := loader.GetSnapshot(ctx, snapshotKey)
+		snapMetadata, err := loader.GetSnapshot(ctx, snapshotKey, true)
 		require.NoError(t, err)
 		for _, f := range snapMetadata.GetFiles() {
 			if rand.Intn(100) < 30 {

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -57,6 +57,10 @@ type COWStore struct {
 	env                environment.Env
 	remoteInstanceName string
 
+	// Whether the store supports remote fetching/caching of artifacts
+	// in addition to local caching
+	remoteEnabled bool
+
 	mu sync.RWMutex // Protects chunks and dirty
 
 	// chunks is a mapping of chunk offset to the backing data store
@@ -92,7 +96,7 @@ type COWStore struct {
 // NewCOWStore creates a COWStore from the given chunks. The chunks should be
 // open initially, and will be closed when calling Close on the returned
 // COWStore.
-func NewCOWStore(ctx context.Context, env environment.Env, chunks []*Mmap, chunkSizeBytes, totalSizeBytes int64, dataDir string, remoteInstanceName string) (*COWStore, error) {
+func NewCOWStore(ctx context.Context, env environment.Env, chunks []*Mmap, chunkSizeBytes, totalSizeBytes int64, dataDir string, remoteInstanceName string, remoteEnabled bool) (*COWStore, error) {
 	stat, err := os.Stat(dataDir)
 	if err != nil {
 		return nil, err
@@ -106,6 +110,7 @@ func NewCOWStore(ctx context.Context, env environment.Env, chunks []*Mmap, chunk
 		ctx:                ctx,
 		env:                env,
 		remoteInstanceName: remoteInstanceName,
+		remoteEnabled:      remoteEnabled,
 		chunks:             chunkMap,
 		dirty:              make(map[int64]bool, 0),
 		dataDir:            dataDir,
@@ -508,7 +513,7 @@ func (s *COWStore) initDirtyChunk(offset int64, size int64) (ogChunk *Mmap, newC
 	if ogChunk != nil {
 		chunkSource = ogChunk.source
 	}
-	newChunk, err = NewMmapFd(s.ctx, s.env, s.DataDir(), fd, int(size), offset, chunkSource, s.remoteInstanceName)
+	newChunk, err = NewMmapFd(s.ctx, s.env, s.DataDir(), fd, int(size), offset, chunkSource, s.remoteInstanceName, s.remoteEnabled)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -601,7 +606,7 @@ func (s *COWStore) fetchChunk(offset int64) error {
 // If an error is returned from this function, the caller should decide what to
 // do with any files written to dataDir. Typically the caller should provide an
 // empty dataDir and remove the dir and contents if there is an error.
-func ConvertFileToCOW(ctx context.Context, env environment.Env, filePath string, chunkSizeBytes int64, dataDir string, remoteInstanceName string) (store *COWStore, err error) {
+func ConvertFileToCOW(ctx context.Context, env environment.Env, filePath string, chunkSizeBytes int64, dataDir string, remoteInstanceName string, remoteEnabled bool) (store *COWStore, err error) {
 	f, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
@@ -685,7 +690,7 @@ func ConvertFileToCOW(ctx context.Context, env environment.Env, filePath string,
 				return nil, err
 			}
 		}
-		return NewMmapFd(ctx, env, dataDir, int(chunkFile.Fd()), int(chunkFileSize), chunkStartOffset, snaputil.ChunkSourceLocalFile, remoteInstanceName)
+		return NewMmapFd(ctx, env, dataDir, int(chunkFile.Fd()), int(chunkFileSize), chunkStartOffset, snaputil.ChunkSourceLocalFile, remoteInstanceName, remoteEnabled)
 	}
 
 	// TODO: iterate through the file with multiple goroutines
@@ -699,7 +704,7 @@ func ConvertFileToCOW(ctx context.Context, env environment.Env, filePath string,
 		}
 	}
 
-	return NewCOWStore(ctx, env, chunks, chunkSizeBytes, totalSizeBytes, dataDir, remoteInstanceName)
+	return NewCOWStore(ctx, env, chunks, chunkSizeBytes, totalSizeBytes, dataDir, remoteInstanceName, remoteEnabled)
 }
 
 // Mmap uses a memory-mapped file to represent a section of a larger composite
@@ -714,6 +719,10 @@ type Mmap struct {
 	env                environment.Env
 	remoteInstanceName string
 
+	// Whether the store supports remote fetching/caching of artifacts
+	// in addition to local caching
+	remoteEnabled bool
+
 	Offset  int64
 	dataDir string
 
@@ -727,7 +736,7 @@ type Mmap struct {
 
 // NewLazyMmap returns an mmap that is set up only when the file is read or
 // written to.
-func NewLazyMmap(ctx context.Context, env environment.Env, dataDir string, offset int64, digest *repb.Digest, remoteInstanceName string) (*Mmap, error) {
+func NewLazyMmap(ctx context.Context, env environment.Env, dataDir string, offset int64, digest *repb.Digest, remoteInstanceName string, remoteEnabled bool) (*Mmap, error) {
 	if dataDir == "" {
 		return nil, status.FailedPreconditionError("missing dataDir")
 	}
@@ -738,6 +747,7 @@ func NewLazyMmap(ctx context.Context, env environment.Env, dataDir string, offse
 		ctx:                ctx,
 		env:                env,
 		remoteInstanceName: remoteInstanceName,
+		remoteEnabled:      remoteEnabled,
 		Offset:             offset,
 		data:               nil,
 		source:             snaputil.ChunkSourceUnmapped,
@@ -746,7 +756,7 @@ func NewLazyMmap(ctx context.Context, env environment.Env, dataDir string, offse
 	}, nil
 }
 
-func NewMmapFd(ctx context.Context, env environment.Env, dataDir string, fd, size int, offset int64, source snaputil.ChunkSource, remoteInstanceName string) (*Mmap, error) {
+func NewMmapFd(ctx context.Context, env environment.Env, dataDir string, fd, size int, offset int64, source snaputil.ChunkSource, remoteInstanceName string, remoteEnabled bool) (*Mmap, error) {
 	if source == snaputil.ChunkSourceUnmapped {
 		return nil, status.InvalidArgumentError("ChunkSourceUnmapped is not a valid source when initializing a chunk from a fd")
 	}
@@ -756,6 +766,7 @@ func NewMmapFd(ctx context.Context, env environment.Env, dataDir string, fd, siz
 	}
 	return &Mmap{
 		remoteInstanceName: remoteInstanceName,
+		remoteEnabled:      remoteEnabled,
 		ctx:                ctx,
 		env:                env,
 		Offset:             offset,
@@ -788,7 +799,6 @@ func mmapDataFromFd(fd, size int) ([]byte, error) {
 	return data, nil
 }
 
-// TODO(Maggie): Pre-emptively initialize chunks in the background on startup
 func (m *Mmap) initMap() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -803,7 +813,7 @@ func (m *Mmap) initMap() error {
 	}
 
 	outputPath := filepath.Join(m.dataDir, ChunkName(m.Offset, false /*dirty*/))
-	artifactSrc, err := snaputil.GetArtifact(m.ctx, m.env.GetFileCache(), m.env.GetByteStreamClient(), m.lazyDigest, m.remoteInstanceName, outputPath)
+	artifactSrc, err := snaputil.GetArtifact(m.ctx, m.env.GetFileCache(), m.env.GetByteStreamClient(), m.remoteEnabled, m.lazyDigest, m.remoteInstanceName, outputPath)
 	if err != nil {
 		return status.WrapErrorf(err, "fetch snapshot chunk for offset %d digest %s", m.Offset, m.lazyDigest.Hash)
 	}

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
@@ -109,7 +109,7 @@ func TestCOW_Basic(t *testing.T) {
 	path := makeEmptyTempFile(t, backingFileSizeBytes)
 	dataDir := testfs.MakeTempDir(t)
 	chunkSizeBytes := backingFileSizeBytes / 2
-	s, err := copy_on_write.ConvertFileToCOW(ctx, env, path, chunkSizeBytes, dataDir, "")
+	s, err := copy_on_write.ConvertFileToCOW(ctx, env, path, chunkSizeBytes, dataDir, "", false)
 	require.NoError(t, err)
 	// Don't validate against the backing file, since COWFromFile makes a copy
 	// of the underlying file.
@@ -122,7 +122,7 @@ func TestCOW_Concurrency(t *testing.T) {
 	path := makeEmptyTempFile(t, backingFileSizeBytes)
 	dataDir := testfs.MakeTempDir(t)
 	chunkSizeBytes := backingFileSizeBytes / 2
-	s, err := copy_on_write.ConvertFileToCOW(ctx, env, path, chunkSizeBytes, dataDir, "")
+	s, err := copy_on_write.ConvertFileToCOW(ctx, env, path, chunkSizeBytes, dataDir, "", false)
 	require.NoError(t, err)
 
 	eg := &errgroup.Group{}
@@ -191,7 +191,7 @@ func TestCOW_SparseData(t *testing.T) {
 	outDir := testfs.MakeTempDir(t)
 
 	// Now split the file.
-	c, err := copy_on_write.ConvertFileToCOW(ctx, env, dataFilePath, chunkSize, outDir, "")
+	c, err := copy_on_write.ConvertFileToCOW(ctx, env, dataFilePath, chunkSize, outDir, "", false)
 	require.NoError(t, err)
 	t.Cleanup(func() { c.Close() })
 
@@ -255,7 +255,7 @@ func TestCOW_Resize(t *testing.T) {
 				startBuf := randBytes(t, int(test.OldSize))
 				src := makeTempFile(t, startBuf)
 				dir := testfs.MakeTempDir(t)
-				cow, err := copy_on_write.ConvertFileToCOW(ctx, env, src, chunkSize, dir, "")
+				cow, err := copy_on_write.ConvertFileToCOW(ctx, env, src, chunkSize, dir, "", false)
 				require.NoError(t, err)
 
 				// Resize the COW
@@ -384,7 +384,7 @@ func BenchmarkCOW_ReadWritePerformance(b *testing.B) {
 				}
 				chunkDir, err := os.MkdirTemp(tmp, "")
 				require.NoError(b, err)
-				cow, err := copy_on_write.ConvertFileToCOW(ctx, env, f.Name(), chunkSize, chunkDir, "")
+				cow, err := copy_on_write.ConvertFileToCOW(ctx, env, f.Name(), chunkSize, chunkDir, "", false)
 				require.NoError(b, err)
 				err = os.Remove(f.Name())
 				require.NoError(b, err)
@@ -524,7 +524,7 @@ func newMmap(t *testing.T) (*copy_on_write.Mmap, string) {
 	s, err := f.Stat()
 	require.NoError(t, err)
 
-	mmap, err := copy_on_write.NewMmapFd(ctx, env, root, int(f.Fd()), int(s.Size()), 0, snaputil.ChunkSourceLocalFile, "")
+	mmap, err := copy_on_write.NewMmapFd(ctx, env, root, int(f.Fd()), int(s.Size()), 0, snaputil.ChunkSourceLocalFile, "", false)
 	require.NoError(t, err)
 	return mmap, path
 }

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -129,8 +129,9 @@ func fileDigest(filePath string) (*repb.Digest, error) {
 
 // Snapshot holds a snapshot manifest along with the corresponding cache key.
 type Snapshot struct {
-	key      *fcpb.SnapshotKey
-	manifest *fcpb.SnapshotManifest
+	key           *fcpb.SnapshotKey
+	manifest      *fcpb.SnapshotManifest
+	remoteEnabled bool
 }
 
 func (s *Snapshot) GetVMConfiguration() *fcpb.VMConfiguration {
@@ -168,6 +169,9 @@ type CacheSnapshotOptions struct {
 
 	// Whether the snapshot is from a recycled VM
 	Recycled bool
+
+	// Whether to save the snapshot to the remote cache (in addition to locally)
+	Remote bool
 }
 
 type UnpackedSnapshot struct {
@@ -204,7 +208,7 @@ type Loader interface {
 	// GetSnapshot loads the metadata for the snapshot. It does not
 	// unpack any snapshot artifacts.
 	// It returns UnavailableError if the metadata has expired from cache.
-	GetSnapshot(ctx context.Context, key *fcpb.SnapshotKey) (*Snapshot, error)
+	GetSnapshot(ctx context.Context, key *fcpb.SnapshotKey, remoteEnabled bool) (*Snapshot, error)
 
 	// UnpackSnapshot unpacks a snapshot to the given directory.
 	// It returns UnavailableError if any snapshot artifacts have expired
@@ -223,10 +227,10 @@ func New(env environment.Env) (*FileCacheLoader, error) {
 	return &FileCacheLoader{env: env}, nil
 }
 
-func (l *FileCacheLoader) GetSnapshot(ctx context.Context, key *fcpb.SnapshotKey) (*Snapshot, error) {
+func (l *FileCacheLoader) GetSnapshot(ctx context.Context, key *fcpb.SnapshotKey, remoteEnabled bool) (*Snapshot, error) {
 	var manifest *fcpb.SnapshotManifest
 	var err error
-	if *snaputil.EnableRemoteSnapshotSharing {
+	if *snaputil.EnableRemoteSnapshotSharing && remoteEnabled {
 		manifest, err = l.fetchRemoteManifest(ctx, key)
 		if err != nil {
 			log.CtxInfof(ctx, "Failed to fetch remote snapshot manifest: %s", err)
@@ -240,7 +244,7 @@ func (l *FileCacheLoader) GetSnapshot(ctx context.Context, key *fcpb.SnapshotKey
 		}
 	}
 
-	return &Snapshot{key: key, manifest: manifest}, nil
+	return &Snapshot{key: key, manifest: manifest, remoteEnabled: remoteEnabled}, nil
 }
 
 // fetchRemoteManifest fetches the most recent snapshot manifest from the remote
@@ -378,7 +382,7 @@ func chunkedFileProperty(chunkedFileTree *repb.Tree, propertyName string) (int64
 }
 
 func (l *FileCacheLoader) chunkedFileTree(ctx context.Context, remoteInstanceName string, chunkedFileMetadata *repb.OutputDirectory, tmpDir string) (*repb.Tree, error) {
-	b, err := snaputil.GetBytes(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), chunkedFileMetadata.GetTreeDigest(), remoteInstanceName, tmpDir)
+	b, err := snaputil.GetBytes(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), true /*remoteEnabled*/, chunkedFileMetadata.GetTreeDigest(), remoteInstanceName, tmpDir)
 	if err != nil {
 		return nil, status.UnavailableErrorf("failed to read chunked file tree: %s", status.Message(err))
 	}
@@ -396,7 +400,7 @@ func (l *FileCacheLoader) UnpackSnapshot(ctx context.Context, snapshot *Snapshot
 
 	for _, fileNode := range snapshot.manifest.Files {
 		outputPath := filepath.Join(outputDirectory, fileNode.GetName())
-		if _, err := snaputil.GetArtifact(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), fileNode.GetDigest(), snapshot.key.InstanceName, outputPath); err != nil {
+		if _, err := snaputil.GetArtifact(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), snapshot.remoteEnabled, fileNode.GetDigest(), snapshot.key.InstanceName, outputPath); err != nil {
 			return nil, err
 		}
 	}
@@ -406,7 +410,7 @@ func (l *FileCacheLoader) UnpackSnapshot(ctx context.Context, snapshot *Snapshot
 	}
 	// Construct COWs from chunks.
 	for _, cf := range snapshot.manifest.ChunkedFiles {
-		cow, err := l.unpackCOW(ctx, cf, snapshot.key.InstanceName, outputDirectory)
+		cow, err := l.unpackCOW(ctx, cf, snapshot.key.InstanceName, outputDirectory, snapshot.remoteEnabled)
 		if err != nil {
 			return nil, status.WrapError(err, "unpack COW")
 		}
@@ -469,7 +473,7 @@ func (l *FileCacheLoader) CacheSnapshot(ctx context.Context, key *fcpb.SnapshotK
 				}
 			}
 			out.Digest = d
-			return snaputil.Cache(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), d, key.InstanceName, filePath)
+			return snaputil.Cache(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), opts.Remote, d, key.InstanceName, filePath)
 		})
 	}
 	for name, cow := range opts.ChunkedFiles {
@@ -481,7 +485,7 @@ func (l *FileCacheLoader) CacheSnapshot(ctx context.Context, key *fcpb.SnapshotK
 		ar.OutputDirectories = append(ar.OutputDirectories, dir)
 		eg.Go(func() error {
 			ctx := egCtx
-			treeDigest, err := l.cacheCOW(ctx, name, key.InstanceName, cow, opts.Recycled)
+			treeDigest, err := l.cacheCOW(ctx, name, key.InstanceName, cow, opts)
 			if err != nil {
 				return status.WrapErrorf(err, "cache %q COW", name)
 			}
@@ -544,7 +548,7 @@ func (l *FileCacheLoader) checkAllArtifactsExist(ctx context.Context, manifest *
 	return nil
 }
 
-func (l *FileCacheLoader) unpackCOW(ctx context.Context, file *fcpb.ChunkedFile, remoteInstanceName string, outputDirectory string) (cf *copy_on_write.COWStore, err error) {
+func (l *FileCacheLoader) unpackCOW(ctx context.Context, file *fcpb.ChunkedFile, remoteInstanceName string, outputDirectory string, remoteEnabled bool) (cf *copy_on_write.COWStore, err error) {
 	dataDir := filepath.Join(outputDirectory, file.GetName())
 	if err := os.Mkdir(dataDir, 0755); err != nil {
 		return nil, status.InternalErrorf("failed to create COW data dir %q: %s", dataDir, err)
@@ -563,13 +567,13 @@ func (l *FileCacheLoader) unpackCOW(ctx context.Context, file *fcpb.ChunkedFile,
 		// TODO: Make a unit test where there is less data in a chunk than the chunk size
 		// But when we fetch from the remote cache, it will need the actual
 		// data size in the digest
-		c, err := copy_on_write.NewLazyMmap(ctx, l.env, dataDir, chunk.GetOffset(), chunk.GetDigest(), remoteInstanceName)
+		c, err := copy_on_write.NewLazyMmap(ctx, l.env, dataDir, chunk.GetOffset(), chunk.GetDigest(), remoteInstanceName, remoteEnabled)
 		if err != nil {
 			return nil, status.WrapError(err, "create mmap for chunk")
 		}
 		chunks = append(chunks, c)
 	}
-	cow, err := copy_on_write.NewCOWStore(ctx, l.env, chunks, file.GetChunkSize(), file.GetSize(), dataDir, remoteInstanceName)
+	cow, err := copy_on_write.NewCOWStore(ctx, l.env, chunks, file.GetChunkSize(), file.GetSize(), dataDir, remoteInstanceName, remoteEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -578,7 +582,7 @@ func (l *FileCacheLoader) unpackCOW(ctx context.Context, file *fcpb.ChunkedFile,
 
 // cacheCOW represents a COWStore as an action result tree and saves the store
 // to the cache. Returns the digest of the tree
-func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, remoteInstanceName string, cow *copy_on_write.COWStore, recycled bool) (*repb.Digest, error) {
+func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, remoteInstanceName string, cow *copy_on_write.COWStore, cacheOpts *CacheSnapshotOptions) (*repb.Digest, error) {
 	var dirtyBytes, dirtyChunkCount int64
 	start := time.Now()
 	defer func() {
@@ -654,7 +658,7 @@ func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, remoteInsta
 			shouldCache := dirty || (chunkSrc == snaputil.ChunkSourceLocalFile)
 			if shouldCache {
 				path := filepath.Join(cow.DataDir(), copy_on_write.ChunkName(c.Offset, cow.Dirty(c.Offset)))
-				if err := snaputil.Cache(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), d, remoteInstanceName, path); err != nil {
+				if err := snaputil.Cache(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), cacheOpts.Remote, d, remoteInstanceName, path); err != nil {
 					return status.WrapError(err, "write chunk to cache")
 				}
 			}
@@ -679,7 +683,7 @@ func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, remoteInsta
 	if err != nil {
 		return nil, err
 	}
-	if err := snaputil.CacheBytes(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), treeDigest, remoteInstanceName, treeBytes); err != nil {
+	if err := snaputil.CacheBytes(ctx, l.env.GetFileCache(), l.env.GetByteStreamClient(), cacheOpts.Remote, treeDigest, remoteInstanceName, treeBytes); err != nil {
 		return nil, err
 	}
 
@@ -688,7 +692,7 @@ func (l *FileCacheLoader) cacheCOW(ctx context.Context, name string, remoteInsta
 		return nil, err
 	}
 	recycleStatus := "clean"
-	if recycled {
+	if cacheOpts.Recycled {
 		recycleStatus = "recycled"
 	}
 	metrics.COWSnapshotDirtyChunkRatio.With(prometheus.Labels{
@@ -748,7 +752,7 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, imageRef, ima
 		ConfigurationHash: hashStrings("__UnpackContainerImage", imageRef),
 	}
 
-	snap, err := l.GetSnapshot(ctx, key)
+	snap, err := l.GetSnapshot(ctx, key, *snaputil.EnableRemoteSnapshotSharing)
 	if err != nil && !(status.IsNotFoundError(err) || status.IsUnavailableError(err)) {
 		return nil, err
 	}
@@ -767,7 +771,7 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, imageRef, ima
 	// ChunkedFile then add it to cache.
 	// TODO(bduffany): single-flight this.
 	start := time.Now()
-	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, key.InstanceName)
+	cow, err := copy_on_write.ConvertFileToCOW(ctx, l.env, imageExt4Path, chunkSize, outDir, key.InstanceName, *snaputil.EnableRemoteSnapshotSharing)
 	if err != nil {
 		return nil, status.WrapError(err, "convert image to COW")
 	}

--- a/enterprise/server/remote_execution/snaputil/BUILD
+++ b/enterprise/server/remote_execution/snaputil/BUILD
@@ -34,6 +34,7 @@ go_test(
         "//server/testutil/testfs",
         "//server/util/prefix",
         "//server/util/random",
+        "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/server/remote_execution/snaputil/snaputil_test.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/require"
 
@@ -43,10 +44,10 @@ func TestCacheAndFetchArtifact(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test caching and fetching
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), d, "", b)
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b)
 	require.NoError(t, err)
 	outputPath := filepath.Join(tmpDir, "fetch")
-	chunkSrc, err := snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), d, "", outputPath)
+	chunkSrc, err := snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), true, d, "", outputPath)
 	require.NoError(t, err)
 	require.Equal(t, snaputil.ChunkSourceLocalFilecache, chunkSrc)
 
@@ -55,7 +56,7 @@ func TestCacheAndFetchArtifact(t *testing.T) {
 	require.Equal(t, randomStr, fetchedStr)
 
 	// Test rewriting same digest
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), d, "", b)
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b)
 	require.NoError(t, err)
 
 	// Delete from remote cache, make sure we can still read
@@ -63,19 +64,19 @@ func TestCacheAndFetchArtifact(t *testing.T) {
 	err = env.GetCache().Delete(ctx, rn)
 	require.NoError(t, err)
 	outputPathLocalFetch := filepath.Join(tmpDir, "fetch_local")
-	chunkSrc, err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), d, "", outputPathLocalFetch)
+	chunkSrc, err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), true, d, "", outputPathLocalFetch)
 	require.NoError(t, err)
 	require.Equal(t, snaputil.ChunkSourceLocalFilecache, chunkSrc)
 	fetchedStr = testfs.ReadFileAsString(t, tmpDir, "fetch_local")
 	require.Equal(t, randomStr, fetchedStr)
 
 	// Rewrite artifact and delete from local cache, make sure we can still read
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), d, "", b)
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b)
 	require.NoError(t, err)
 	deleted := fc.DeleteFile(ctx, &repb.FileNode{Digest: d})
 	require.True(t, deleted)
 	outputPathRemoteFetch := filepath.Join(tmpDir, "fetch_remote")
-	chunkSrc, err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), d, "", outputPathRemoteFetch)
+	chunkSrc, err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), true, d, "", outputPathRemoteFetch)
 	require.NoError(t, err)
 	require.Equal(t, snaputil.ChunkSourceRemoteCache, chunkSrc)
 	fetchedStr = testfs.ReadFileAsString(t, tmpDir, "fetch_remote")
@@ -83,8 +84,46 @@ func TestCacheAndFetchArtifact(t *testing.T) {
 
 	// Test writing bogus digest
 	bogusDigest, _ := testdigest.NewRandomResourceAndBuf(t, 1000, rspb.CacheType_CAS, "")
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), bogusDigest.Digest, "", b)
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, bogusDigest.Digest, "", b)
 	require.Error(t, err)
+}
+
+func TestCacheAndFetchArtifact_LocalOnly(t *testing.T) {
+	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
+
+	env := testenv.GetTestEnv(t)
+	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), env)
+	require.NoError(t, err)
+	tmpDir := testfs.MakeTempDir(t)
+
+	fc, err := filecache.NewFileCache(tmpDir, 10000, false)
+	require.NoError(t, err)
+	testcache.Setup(t, env)
+
+	length := rand.Intn(1000)
+	randomStr, err := random.RandomString(length)
+	require.NoError(t, err)
+	b := []byte(randomStr)
+	d, err := digest.Compute(bytes.NewReader(b), repb.DigestFunction_BLAKE3)
+	require.NoError(t, err)
+
+	// Read and write bytes from local cache
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), false /*remoteEnabled*/, d, "", b)
+	require.NoError(t, err)
+	outputPath := filepath.Join(tmpDir, "fetch")
+	chunkSrc, err := snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), false /*remoteEnabled*/, d, "", outputPath)
+	require.NoError(t, err)
+	require.Equal(t, snaputil.ChunkSourceLocalFilecache, chunkSrc)
+	// Read bytes from outputPath and validate with original bytes
+	fetchedStr := testfs.ReadFileAsString(t, tmpDir, "fetch")
+	require.Equal(t, randomStr, fetchedStr)
+
+	// Delete artifact from local cache, make sure we can no longer read it
+	deleted := fc.DeleteFile(ctx, &repb.FileNode{Digest: d})
+	require.True(t, deleted)
+	outputPathRemoteFetch := filepath.Join(tmpDir, "fetch_err")
+	_, err = snaputil.GetArtifact(ctx, fc, env.GetByteStreamClient(), false /*remoteEnabled*/, d, "", outputPathRemoteFetch)
+	require.True(t, status.IsUnavailableError(err))
 }
 
 func TestCacheAndFetchBytes(t *testing.T) {
@@ -107,16 +146,16 @@ func TestCacheAndFetchBytes(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test caching and fetching
-	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), d, "", b)
+	err = snaputil.CacheBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", b)
 	require.NoError(t, err)
-	fetchedBytes, err := snaputil.GetBytes(ctx, fc, env.GetByteStreamClient(), d, "", tmpDir)
+	fetchedBytes, err := snaputil.GetBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", tmpDir)
 	require.NoError(t, err)
 	require.Equal(t, randomStr, string(fetchedBytes))
 
 	// Delete from local cache, make sure we can still read
 	deleted := fc.DeleteFile(ctx, &repb.FileNode{Digest: d})
 	require.True(t, deleted)
-	fetchedBytes, err = snaputil.GetBytes(ctx, fc, env.GetByteStreamClient(), d, "", tmpDir)
+	fetchedBytes, err = snaputil.GetBytes(ctx, fc, env.GetByteStreamClient(), true, d, "", tmpDir)
 	require.NoError(t, err)
 	require.Equal(t, randomStr, string(fetchedBytes))
 }


### PR DESCRIPTION
Limit non-workflow actions that try to use runner recycling to local-only snapshot sharing, because it would be too expensive for large builds to upload a full snapshot per action. 
