### PR TITLE
githubauth: move enable check to server/backends/github

### DIFF
--- a/enterprise/server/auth/BUILD
+++ b/enterprise/server/auth/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//enterprise/server/githubauth",
         "//enterprise/server/oidc",
         "//enterprise/server/saml",
+        "//server/backends/github",
         "//server/environment",
         "//server/interfaces",
         "//server/nullauth",

--- a/enterprise/server/auth/auth.go
+++ b/enterprise/server/auth/auth.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/githubauth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/oidc"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/saml"
+	"github.com/buildbuddy-io/buildbuddy/server/backends/github"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/nullauth"
@@ -42,7 +43,7 @@ func Register(ctx context.Context, env environment.Env) error {
 		userAuthenticators = append(userAuthenticators, samlAuthenticator)
 	}
 
-	if githubauth.IsEnabled(env) {
+	if github.AuthEnabled(env) {
 		ga := githubauth.NewGithubAuthenticator(env)
 		httpAuthenticators = append(httpAuthenticators, ga)
 		userAuthenticators = append(userAuthenticators, ga)

--- a/enterprise/server/githubauth/BUILD
+++ b/enterprise/server/githubauth/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/githubauth",
     visibility = ["//visibility:public"],
     deps = [
-        "//enterprise/server/githubapp",
         "//server/backends/github",
         "//server/environment",
         "//server/interfaces",

--- a/enterprise/server/githubauth/githubauth.go
+++ b/enterprise/server/githubauth/githubauth.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/githubapp"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/github"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -41,10 +40,6 @@ func NewGithubAuthenticator(env environment.Env) *githubAuthenticator {
 	return &githubAuthenticator{
 		env: env,
 	}
-}
-
-func IsEnabled(env environment.Env) bool {
-	return githubapp.IsEnabled() && *github.JwtKey != ""
 }
 
 func (a *githubAuthenticator) Login(w http.ResponseWriter, r *http.Request) error {

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -57,6 +57,10 @@ const (
 	installationIDCookieName = "Github-Linked-Installation-ID"
 )
 
+func AuthEnabled(env environment.Env) bool {
+	return env.GetGitHubApp() != nil && *JwtKey != ""
+}
+
 // State represents a status value that GitHub's statuses API understands.
 type State string
 

--- a/server/static/BUILD
+++ b/server/static/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/static",
     visibility = ["//visibility:public"],
     deps = [
-        "//enterprise/server/githubauth",
         "//enterprise/server/invocation_stat_service/config",
         "//enterprise/server/remote_execution/config",
         "//enterprise/server/scheduling/scheduler_server/config",

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/githubauth"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/github"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/target_tracker"
 	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
@@ -153,7 +152,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		DefaultToDenseMode:                     *defaultToDenseMode,
 		GithubEnabled:                          github.IsLegacyOAuthAppEnabled(),
 		GithubAppEnabled:                       env.GetGitHubApp() != nil,
-		GithubAuthEnabled:                      githubauth.IsEnabled(env),
+		GithubAuthEnabled:                      github.AuthEnabled(env),
 		AnonymousUsageEnabled:                  env.GetAuthenticator().AnonymousUsageEnabled(ctx),
 		TestDashboardEnabled:                   target_tracker.TargetTrackingEnabled(),
 		UserOwnedExecutorsEnabled:              remote_execution_config.RemoteExecutionEnabled() && scheduler_server_config.UserOwnedExecutorsEnabled(),


### PR DESCRIPTION
The check basis is actually using the JwtKey on the github package.
Use it instead.
