### PR TITLE
Fix QPS counter

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1746,6 +1746,10 @@ func (sm *Replica) Close() error {
 	if sm.store != nil && rangeDescriptor != nil {
 		sm.store.RemoveRange(rangeDescriptor, sm)
 	}
+
+	sm.readQPS.Stop()
+	sm.raftProposeQPS.Stop()
+
 	return nil
 }
 
@@ -1761,8 +1765,8 @@ func New(leaser pebble.Leaser, shardID, replicaID uint64, store IStore, broadcas
 		log:                 log.NamedSubLogger(fmt.Sprintf("c%dn%d", shardID, replicaID)),
 		fileStorer:          filestore.New(),
 		accesses:            make(chan *accessTimeUpdate, *atimeBufferSize),
-		readQPS:             qps.NewCounter(),
-		raftProposeQPS:      qps.NewCounter(),
+		readQPS:             qps.NewCounter(1 * time.Minute),
+		raftProposeQPS:      qps.NewCounter(1 * time.Minute),
 		broadcast:           broadcast,
 	}
 }


### PR DESCRIPTION
The QPS counter has a bug where if the QPS has actually dropped to zero, the reported QPS appears to stay stuck at the same value for up to a minute, and even appears to increase after a while, then suddenly drops to 0.

This is because the counter only averages buckets that have a value of 0. So if the QPS is actually zero then only the other buckets are counted (and are weighted higher in the average).

This PR fixes the bug by having a separate notion of "valid" and "zero". All buckets are valid except when the counter is first initialized, and after the averaging window first elapses, all buckets are considered valid.

Other improvements:
* Use `time.Ticker` instead of `time.Sleep` to avoid drift under CPU load.
* Make time window configurable, and set it to 5s in cacheload (for more realtime updates).
* Add a `Stop()` method to stop the goroutine that it started.

**Related issues**: N/A
