### PR TITLE
Don't include version info when using `-c fastbuild`

### DIFF
--- a/server/version/BUILD
+++ b/server/version/BUILD
@@ -1,23 +1,28 @@
-load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 genrule(
     name = "populate_version",
     outs = ["version.txt"],
-    cmd_bash = """
-        version=$$(grep ^STABLE_VERSION_TAG bazel-out/stable-status.txt | cut -d' ' -f2); \
-        printf '%s' $$version > $@;
-    """,
+    cmd_bash = select({
+        "//:fastbuild": "touch $@",
+        "//conditions:default": """
+            version=$$(grep ^STABLE_VERSION_TAG bazel-out/stable-status.txt | cut -d' ' -f2); \
+            printf '%s' $$version > $@;
+        """,
+    }),
     stamp = 1,
 )
 
 genrule(
     name = "populate_commit",
     outs = ["commit.txt"],
-    cmd_bash = """
-        commit=$$(grep ^STABLE_COMMIT_SHA bazel-out/stable-status.txt | cut -d' ' -f2); \
-        printf '%s' $$commit > $@;
-    """,
+    cmd_bash = select({
+        "//:fastbuild": "touch $@",
+        "//conditions:default": """
+            commit=$$(grep ^STABLE_COMMIT_SHA bazel-out/stable-status.txt | cut -d' ' -f2); \
+            printf '%s' $$commit > $@;
+        """,
+    }),
     stamp = 1,
 )
 


### PR DESCRIPTION
Fixes a bug that lots of cache invalidations are happening on every commit.

Credit to @sluongng for finding this bug.

**Related issues**: N/A
