### PR TITLE
[SS] Fix race condition / bug when copying an unmapped chunk

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -506,6 +506,8 @@ func (s *COWStore) initDirtyChunk(offset int64, size int64) (ogChunk *Mmap, newC
 	ogChunk = s.chunks[offset]
 	chunkSource := snaputil.ChunkSourceHole
 	if ogChunk != nil {
+		ogChunk.mu.RLock()
+		defer ogChunk.mu.RUnlock()
 		chunkSource = ogChunk.source
 	}
 	newChunk, err = NewMmapFd(s.ctx, s.env, s.DataDir(), fd, int(size), offset, chunkSource, s.remoteInstanceName)

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -511,9 +511,7 @@ func (s *COWStore) initDirtyChunk(offset int64, size int64) (ogChunk *Mmap, newC
 				return nil, nil, err
 			}
 		}
-		ogChunk.mu.RLock()
 		chunkSource = ogChunk.source
-		ogChunk.mu.RUnlock()
 	}
 	newChunk, err = NewMmapFd(s.ctx, s.env, s.DataDir(), fd, int(size), offset, chunkSource, s.remoteInstanceName)
 	if err != nil {


### PR DESCRIPTION
There were two bugs related to copying unmapped chunks: 
1) There could be a race condition where thread A) is initializing a chunk in the background and setting the source field (to something like RemoteCache) and thread B) is copying an unmapped chunk to be dirtied and reading the source field (Unmapped) to copy it over to the new chunk
2) When we copy an unmapped chunk, we create a clone of the chunk (So the new chunk is also unmapped). When we try to copy over the source data using newChunk.Write(bufCopiedFromSrc) (pseudocode), it tries to initialize the new chunk from the cache because it's unmapped. We don't need to do this, because we're overwriting the chunk's data with the contents of the source chunk.

Both these problems can be fixed by just initializing the source chunk before copying it. We will always initialize the source chunk anyway, because we have to read from it to copy over the data to the dest