### PR TITLE
Enable golang static checks S1019, S1023, and S1025

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -108,8 +108,8 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/unusedresult",
         "@com_github_nishanths_exhaustive//:exhaustive",
     ] + staticcheck_analyzers(ANALYZERS + [
-        "-S1019",  # Uninteresting: omit default arguments to 'make()'.
-        "-S1023",  # Uninteresting:  "unnecessary" but reachable returns/breaks.
+        "-S1019",  # Uninteresting: Simplify make call by omitting redundant arguments.
+        "-S1023",  # Uninteresting:  Omit redundant control flow.
         "-S1028",
         "-S1030",
         "-S1031",

--- a/BUILD
+++ b/BUILD
@@ -108,9 +108,8 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/unusedresult",
         "@com_github_nishanths_exhaustive//:exhaustive",
     ] + staticcheck_analyzers(ANALYZERS + [
-        "-S1019",
-        "-S1023",
-        "-S1025",
+        "-S1019",  # Uninteresting: omit default arguments to 'make()'.
+        "-S1023",  # Uninteresting:  "unnecessary" but reachable returns/breaks.
         "-S1028",
         "-S1030",
         "-S1031",

--- a/BUILD
+++ b/BUILD
@@ -108,8 +108,6 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/unusedresult",
         "@com_github_nishanths_exhaustive//:exhaustive",
     ] + staticcheck_analyzers(ANALYZERS + [
-        "-S1019",  # Uninteresting: Simplify make call by omitting redundant arguments.
-        "-S1023",  # Uninteresting:  Omit redundant control flow.
         "-S1028",
         "-S1030",
         "-S1031",

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -328,7 +328,7 @@ func (c *Cache) StartListening() {
 	if !c.finishedShutdown {
 		return
 	}
-	c.shutDownChan = make(chan struct{}, 0)
+	c.shutDownChan = make(chan struct{})
 	go c.heartbeatPeers(c.shutDownChan)
 	go func() {
 		log.Infof("Distributed cache listening on %q", c.config.ListenAddr)

--- a/enterprise/server/backends/migration_cache/migration_cache.go
+++ b/enterprise/server/backends/migration_cache/migration_cache.go
@@ -664,7 +664,7 @@ func (mc *MigrationCache) Reader(ctx context.Context, r *rspb.ResourceName, unco
 		pw:           pw,
 		pr:           pr,
 		mu:           sync.Mutex{},
-		done:         make(chan struct{}, 0),
+		done:         make(chan struct{}),
 	}
 
 	if shouldDecompressAndVerify {
@@ -1002,7 +1002,7 @@ func cacheTypeLabel(ct rspb.CacheType) string {
 }
 
 func (mc *MigrationCache) Start() error {
-	mc.quitChan = make(chan struct{}, 0)
+	mc.quitChan = make(chan struct{})
 	mc.eg.Go(func() error {
 		mc.copyDataInBackground()
 		return nil

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1302,7 +1302,6 @@ func (p *PebbleCache) backgroundRepairPartition(db pebble.IPebbleDB, evictor *pa
 	if opts.deleteEntriesWithMissingFiles {
 		log.Infof("Pebble Cache [%s]: backgroundRepair for %q deleted %d keys with missing files", p.name, partitionID, missingFiles)
 	}
-	return
 }
 
 func (p *PebbleCache) backgroundRepairIteration(quitChan chan struct{}, opts *repairOpts) error {
@@ -2876,7 +2875,6 @@ func (e *partitionEvictor) doEvict(sample *approxlru.Sample[*evictionKey]) {
 	metrics.DiskCacheBytesEvicted.With(lbls).Add(float64(sample.SizeBytes))
 	metrics.DiskCacheEvictionAgeMsec.With(lbls).Observe(float64(age.Milliseconds()))
 	metrics.DiskCacheLastEvictionAgeUsec.With(lbls).Set(float64(age.Microseconds()))
-	return
 }
 
 func (e *partitionEvictor) sample(ctx context.Context, k int) ([]*approxlru.Sample[*evictionKey], error) {
@@ -3263,7 +3261,7 @@ func (p *PebbleCache) reader(ctx context.Context, db pebble.IPebbleDB, r *rspb.R
 }
 
 func (p *PebbleCache) Start() error {
-	p.quitChan = make(chan struct{}, 0)
+	p.quitChan = make(chan struct{})
 	for _, evictor := range p.evictors {
 		evictor := evictor
 		p.eg.Go(func() error {

--- a/enterprise/server/raft/registry/registry.go
+++ b/enterprise/server/raft/registry/registry.go
@@ -92,12 +92,10 @@ func (n *StaticRegistry) getConnectionKey(addr string, shardID uint64) string {
 
 // Remove removes a remote from the node registry.
 func (n *StaticRegistry) Remove(shardID uint64, replicaID uint64) {
-	return
 }
 
 // RemoveCluster removes all nodes info associated with the specified cluster
 func (n *StaticRegistry) RemoveShard(shardID uint64) {
-	return
 }
 
 func (n *StaticRegistry) Resolve(shardID uint64, replicaID uint64) (string, string, error) {
@@ -344,12 +342,10 @@ func (d *DynamicNodeRegistry) Add(shardID uint64, replicaID uint64, target strin
 
 // Remove removes a remote from the node registry.
 func (d *DynamicNodeRegistry) Remove(shardID uint64, replicaID uint64) {
-	return
 }
 
 // RemoveCluster removes all nodes info associated with the specified cluster
 func (d *DynamicNodeRegistry) RemoveShard(shardID uint64) {
-	return
 }
 
 func (d *DynamicNodeRegistry) Resolve(shardID uint64, replicaID uint64) (string, string, error) {

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -121,7 +121,7 @@ func NewCOWStore(ctx context.Context, env environment.Env, chunks []*Mmap, chunk
 		ioBlockSize:    int64(stat.Sys().(*syscall.Stat_t).Blksize),
 		eagerFetchChan: make(chan *eagerFetchData, eagerFetchChanSize),
 		eagerFetchEg:   &errgroup.Group{},
-		quitChan:       make(chan struct{}, 0),
+		quitChan:       make(chan struct{}),
 	}
 
 	s.eagerFetchEg.Go(func() error {

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -364,9 +364,7 @@ func (r *commandRunner) Run(ctx context.Context) *interfaces.CommandResult {
 		r.p.mu.Lock()
 		r.state = ready
 		r.p.mu.Unlock()
-		break
 	case ready:
-		break
 	case removed:
 		return commandutil.ErrorResult(status.UnavailableErrorf("Not starting new task since executor is shutting down"))
 	default:

--- a/enterprise/server/remote_execution/uffd/uffd.go
+++ b/enterprise/server/remote_execution/uffd/uffd.go
@@ -113,7 +113,7 @@ func (h *Handler) Start(ctx context.Context, socketPath string, memoryStore *cop
 	h.stoppedChan = make(chan struct{})
 	// Stop() will wait until this is closed to verify the handler has completed
 	// handling open requests
-	h.handleDoneChan = make(chan struct{}, 0)
+	h.handleDoneChan = make(chan struct{})
 
 	// Create a FD that can be used to terminate Poll early
 	pipeRead, pipeWrite, err := os.Pipe()

--- a/enterprise/server/util/chunker/chunker.go
+++ b/enterprise/server/util/chunker/chunker.go
@@ -50,7 +50,7 @@ func New(ctx context.Context, averageSize int, writeChunkFn WriteFunc) (*Chunker
 		ctx:          ctx,
 		pr:           pr,
 		pw:           pw,
-		done:         make(chan struct{}, 0),
+		done:         make(chan struct{}),
 		writeChunkFn: writeChunkFn,
 	}
 	cdcOpts := fastcdc.Options{

--- a/server/backends/slack/slack.go
+++ b/server/backends/slack/slack.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -109,7 +108,7 @@ func (w *SlackWebhook) slackPayloadFromInvocation(invocation *inpb.Invocation) *
 	} else {
 		statusText = "❌ Failed"
 	}
-	durationString := fmt.Sprintf("%s", time.Duration(invocation.DurationUsec)*time.Microsecond)
+	durationString := (time.Duration(invocation.DurationUsec) * time.Microsecond).String()
 	a.AddField(Field{
 		Title: "Status",
 		Value: statusText,

--- a/server/util/redact/redact.go
+++ b/server/util/redact/redact.go
@@ -499,7 +499,6 @@ func (r *StreamingRedactor) RedactMetadata(event *bespb.BuildEvent) {
 		{
 		}
 	}
-	return
 }
 
 func (r *StreamingRedactor) RedactAPIKey(ctx context.Context, event *bespb.BuildEvent) error {


### PR DESCRIPTION
* S1019:  Simplify make call by omitting redundant arguments.
* S1023: Omit redundant control flow.
* S1025: Don’t use fmt.Sprintf(%s, x) unnecessarily.

**Related issues**: N/A
