### PR TITLE
2PC: allow setting a txn id

### DIFF
--- a/enterprise/server/raft/constants/constants.go
+++ b/enterprise/server/raft/constants/constants.go
@@ -80,6 +80,9 @@ var (
 
 	// When this local range was set up.
 	LocalRangeSetupTimeKey = keys.MakeKey(LocalPrefix, []byte("range_initialization_time"))
+
+	// A prefix to prepend to transactions.
+	LocalTransactionPrefix = keys.MakeKey(LocalPrefix, []byte("txn-"))
 )
 
 // Error constants -- sender recognizes these errors.

--- a/enterprise/server/raft/rbuilder/rbuilder.go
+++ b/enterprise/server/raft/rbuilder/rbuilder.go
@@ -95,6 +95,16 @@ func (bb *BatchBuilder) Add(m proto.Message) *BatchBuilder {
 	return bb
 }
 
+func (bb *BatchBuilder) SetTransactionId(txid []byte) *BatchBuilder {
+	bb.cmd.TransactionId = txid
+	return bb
+}
+
+func (bb *BatchBuilder) SetFinalizeOperation(op rfpb.FinalizeOperation) *BatchBuilder {
+	bb.cmd.FinalizeOperation = &op
+	return bb
+}
+
 func (bb *BatchBuilder) ToProto() (*rfpb.BatchCmdRequest, error) {
 	if bb.err != nil {
 		return nil, bb.err

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1552,10 +1552,11 @@ func (sm *Replica) singleUpdate(db pebble.IPebbleDB, entry dbsm.Entry) (dbsm.Ent
 			for _, union := range batchReq.GetUnion() {
 				batchRsp.Union = append(batchRsp.Union, sm.handlePropose(wb, union))
 			}
+			if err := sm.checkLocks(wb, nil); err != nil {
+				batchRsp.Status = statusProto(err)
+				wb.Reset() // don't commit if conflict.
+			}
 		}
-	}
-	if err := sm.checkLocks(wb, nil); err != nil {
-		batchRsp.Status = statusProto(err)
 	}
 	rspBuf, err := proto.Marshal(batchRsp)
 	if err != nil {

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -122,6 +122,9 @@ type Replica struct {
 
 	readQPS        *qps.Counter
 	raftProposeQPS *qps.Counter
+
+	lockedKeys map[string][]byte       // key => txid
+	prepared   map[string]pebble.Batch // string(txid) => prepared batch.
 }
 
 func uint64ToBytes(i uint64) []byte {
@@ -240,7 +243,6 @@ func rdString(rd *rfpb.RangeDescriptor) string {
 
 func (sm *Replica) notifyListenersOfUsage(rd *rfpb.RangeDescriptor, usage *rfpb.ReplicaUsage) {
 	if sm.broadcast == nil {
-		log.Errorf("broadcast is nil")
 		return
 	}
 	up := events.RangeUsageEvent{
@@ -467,6 +469,175 @@ type ReplicaWriter interface {
 	NewSnapshot() *pebble.Snapshot
 }
 
+// checkLocks checks if any keys in this batch are already locked and returns an
+// error if so: the txn must abort.
+func (sm *Replica) checkLocks(wb pebble.Batch, txid []byte) error {
+	batchReader := wb.Reader()
+	for len(batchReader) > 0 {
+		_, ukey, _, _ := batchReader.Next()
+		keyString := string(ukey)
+		lockingTxid, ok := sm.lockedKeys[keyString]
+		if ok && !bytes.Equal(txid, lockingTxid) {
+			return status.UnavailableErrorf("Conflict on key %q", keyString)
+		}
+	}
+	return nil
+}
+
+// acquireLocks locks all of the keys in batch `wb`.
+func (sm *Replica) acquireLocks(wb pebble.Batch, txid []byte) {
+	batchReader := wb.Reader()
+	for len(batchReader) > 0 {
+		_, ukey, _, _ := batchReader.Next()
+		keyString := string(ukey)
+		sm.lockedKeys[keyString] = txid
+	}
+}
+
+// releaseLocks unlocks all the keys in the batch `wb` locked with `txid`. If a
+// row in `wb` is locked by another transaction, an error is logged and the row
+// lock is left unchanged.
+func (sm *Replica) releaseLocks(wb pebble.Batch, txid []byte) {
+	// Unlock all the keys in this batch.
+	batchReader := wb.Reader()
+	for len(batchReader) > 0 {
+		_, ukey, _, _ := batchReader.Next()
+		keyString := string(ukey)
+		lockingTxid, ok := sm.lockedKeys[keyString]
+		if !ok || !bytes.Equal(txid, lockingTxid) {
+			log.Errorf("Key %q was not locked by %q; should have been", keyString, string(txid))
+		} else {
+			delete(sm.lockedKeys, keyString)
+		}
+	}
+}
+
+func (sm *Replica) loadTxnIntoMemory(txid []byte, batchReq *rfpb.BatchCmdRequest) (*rfpb.BatchCmdResponse, error) {
+	db, err := sm.leaser.DB()
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	txn := db.NewBatch()
+
+	// Ensure the txn is cleaned up if not prepared succesfully.
+	loaded := false
+	defer func() {
+		if !loaded {
+			txn.Close()
+		}
+	}()
+
+	// Run all the propose commands against the txn batch.
+	batchRsp := &rfpb.BatchCmdResponse{}
+	for _, union := range batchReq.GetUnion() {
+		batchRsp.Union = append(batchRsp.Union, sm.handlePropose(txn, union))
+	}
+
+	// Check if there are any locked keys conflicting.
+	if err := sm.checkLocks(txn, txid); err != nil {
+		return nil, err
+	}
+
+	// If not, acquire locks for all changed keys.
+	sm.acquireLocks(txn, txid)
+
+	// Save the txn batch in memory.
+	sm.prepared[string(txid)] = txn
+	loaded = true
+	return batchRsp, nil
+}
+
+// PrepareTransaction processes all of the writes from `req` into a new batch
+// and attempts to lock all keys modified in the batch. If any error is
+// encountered, an error is returned; otherwise the batch is retained in memory
+// so it can be applied or reverted via CommitTransaction or
+// RollbackTransaction.
+func (sm *Replica) PrepareTransaction(wb pebble.Batch, txid []byte, batchReq *rfpb.BatchCmdRequest) (*rfpb.BatchCmdResponse, error) {
+	// Save the txn batch in memory and acquire locks.
+	batchRsp, err := sm.loadTxnIntoMemory(txid, batchReq)
+	if err != nil {
+		return nil, err
+	}
+
+	buf, err := proto.Marshal(batchReq)
+	if err != nil {
+		return nil, err
+	}
+
+	// Save the txn batch on-disk in case of a restart.
+	txKey := keys.MakeKey(constants.LocalTransactionPrefix, txid)
+	wb.Set(sm.replicaLocalKey(txKey), buf, nil /*ignored write options*/)
+
+	return batchRsp, nil
+}
+
+func (sm *Replica) CommitTransaction(txid []byte) error {
+	txn, ok := sm.prepared[string(txid)]
+	if !ok {
+		return status.NotFoundErrorf("Transaction %q not found", string(txid))
+	}
+	defer txn.Close()
+	delete(sm.prepared, string(txid))
+
+	sm.releaseLocks(txn, txid)
+
+	txKey := keys.MakeKey(constants.LocalTransactionPrefix, txid)
+	txn.Delete(sm.replicaLocalKey(txKey), nil /*ignore write options*/)
+
+	return txn.Commit(pebble.Sync)
+}
+
+func (sm *Replica) RollbackTransaction(txid []byte) error {
+	txn, ok := sm.prepared[string(txid)]
+	if !ok {
+		return status.NotFoundErrorf("Transaction %q not found", string(txid))
+	}
+	defer txn.Close()
+	delete(sm.prepared, string(txid))
+
+	sm.releaseLocks(txn, txid)
+
+	txn.Reset()
+	txKey := keys.MakeKey(constants.LocalTransactionPrefix, txid)
+	txn.Delete(sm.replicaLocalKey(txKey), nil /*ignore write options*/)
+
+	return txn.Commit(pebble.Sync)
+}
+
+func (sm *Replica) loadInflightTransactions(db ReplicaReader) error {
+	iterOpts := &pebble.IterOptions{
+		LowerBound: constants.LocalPrefix,
+		UpperBound: constants.MetaRangePrefix,
+	}
+	iter := db.NewIter(iterOpts)
+	defer iter.Close()
+
+	suffix := sm.replicaSuffix()
+	for iter.First(); iter.Valid(); iter.Next() {
+		if !bytes.HasSuffix(iter.Key(), suffix) {
+			// Skip keys that are not ours.
+			continue
+		}
+		if !bytes.HasPrefix(iter.Key(), constants.LocalTransactionPrefix) {
+			// Skip non-inflight-transactions
+			continue
+		}
+
+		key := iter.Key()[:len(iter.Key())-len(suffix)]
+		txid := key[len(constants.LocalTransactionPrefix):]
+
+		batchReq := &rfpb.BatchCmdRequest{}
+		if err := proto.Unmarshal(iter.Value(), batchReq); err != nil {
+			return err
+		}
+		if _, err := sm.loadTxnIntoMemory(txid, batchReq); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (sm *Replica) loadPartitionMetadata(db ReplicaReader) error {
 	pms, err := sm.getPartitionMetadatas(db)
 	if err != nil {
@@ -494,6 +665,9 @@ func (sm *Replica) loadRangeDescriptor(db ReplicaReader) {
 func (sm *Replica) loadReplicaState(db ReplicaReader) error {
 	sm.loadRangeDescriptor(db)
 	if err := sm.loadPartitionMetadata(db); err != nil {
+		return err
+	}
+	if err := sm.loadInflightTransactions(db); err != nil {
 		return err
 	}
 	lastStoredIndex, err := sm.getLastAppliedIndex(db)
@@ -615,7 +789,7 @@ func absInt(i int64) int64 {
 	return i
 }
 
-func (sm *Replica) findSplitPoint() ([]byte, error) {
+func (sm *Replica) findSplitPoint() (*rfpb.FindSplitPointResponse, error) {
 	sm.rangeMu.Lock()
 	rangeDescriptor := sm.rangeDescriptor
 	sm.rangeMu.Unlock()
@@ -687,7 +861,9 @@ func (sm *Replica) findSplitPoint() ([]byte, error) {
 		return nil, status.NotFoundErrorf("Could not find split point. (Total size: %d, start split size: %d", totalSize, leftSize)
 	}
 	sm.log.Debugf("Cluster %d found split @ %q start rows: %d, size: %d, end rows: %d, size: %d", sm.ShardID, splitKey, splitRows, splitSize, totalRows-splitRows, totalSize-splitSize)
-	return splitKey, nil
+	return &rfpb.FindSplitPointResponse{
+		SplitKey: splitKey,
+	}, nil
 }
 
 func canSplitKeys(startKey, endKey []byte) bool {
@@ -735,10 +911,11 @@ func (sm *Replica) printRange(r pebble.Reader, iterOpts *pebble.IterOptions, tag
 func (sm *Replica) simpleSplit(wb pebble.Batch, req *rfpb.SimpleSplitRequest) (*rfpb.SimpleSplitResponse, error) {
 	ctx := context.Background()
 
-	splitKey, err := sm.findSplitPoint()
+	splitRsp, err := sm.findSplitPoint()
 	if err != nil {
 		return nil, err
 	}
+	splitKey := splitRsp.GetSplitKey()
 
 	sm.rangeMu.RLock()
 	rd := sm.rangeDescriptor
@@ -958,7 +1135,9 @@ func statusProto(err error) *statuspb.Status {
 	return s.Proto()
 }
 
-func (sm *Replica) handlePropose(wb pebble.Batch, req *rfpb.RequestUnion, rsp *rfpb.ResponseUnion) {
+func (sm *Replica) handlePropose(wb pebble.Batch, req *rfpb.RequestUnion) *rfpb.ResponseUnion {
+	rsp := &rfpb.ResponseUnion{}
+
 	switch value := req.Value.(type) {
 	case *rfpb.RequestUnion_DirectWrite:
 		r, err := sm.directWrite(wb, value.DirectWrite)
@@ -1002,9 +1181,22 @@ func (sm *Replica) handlePropose(wb pebble.Batch, req *rfpb.RequestUnion, rsp *r
 			UpdateAtime: r,
 		}
 		rsp.Status = statusProto(err)
+	case *rfpb.RequestUnion_FindSplitPoint:
+		r, err := sm.findSplitPoint()
+		rsp.Value = &rfpb.ResponseUnion_FindSplitPoint{
+			FindSplitPoint: r,
+		}
+		rsp.Status = statusProto(err)
 	default:
 		rsp.Status = statusProto(status.UnimplementedErrorf("SyncPropose handling for %+v not implemented.", req))
 	}
+
+	if req.GetCas() == nil && rsp.GetStatus().GetCode() != 0 {
+		// Log Update() errors (except Compare-And-Set) errors.
+		sm.log.Errorf("error processing update %+v: %s", req, rsp.GetStatus())
+	}
+
+	return rsp
 }
 
 func (sm *Replica) handleRead(db ReplicaReader, req *rfpb.RequestUnion) *rfpb.ResponseUnion {
@@ -1333,16 +1525,37 @@ func (sm *Replica) singleUpdate(db pebble.IPebbleDB, entry dbsm.Entry) (dbsm.Ent
 		batchRsp.Status = statusProto(headerErr)
 	}
 	if headerErr == nil {
-		for _, union := range batchReq.GetUnion() {
-			rsp := &rfpb.ResponseUnion{}
-			sm.handlePropose(wb, union, rsp)
-			if union.GetCas() == nil && rsp.GetStatus().GetCode() != 0 {
-				// Log Update() errors (except Compare-And-Set)
-				// errors.
-				sm.log.Errorf("error processing update %+v: %s", union, rsp.GetStatus())
+		if txid := batchReq.GetTransactionId(); len(txid) > 0 {
+			// Check that request is not malformed.
+			if len(batchReq.GetUnion()) > 0 && batchReq.GetFinalizeOperation() != rfpb.FinalizeOperation_UNKNOWN_OPERATION {
+				batchRsp.Status = statusProto(status.InvalidArgumentErrorf("Batch must be empty when finalizing transaction"))
 			}
-			batchRsp.Union = append(batchRsp.Union, rsp)
+
+			switch batchReq.GetFinalizeOperation() {
+			case rfpb.FinalizeOperation_COMMIT:
+				if err := sm.CommitTransaction(txid); err != nil {
+					batchRsp.Status = statusProto(err)
+				}
+			case rfpb.FinalizeOperation_ROLLBACK:
+				if err := sm.RollbackTransaction(txid); err != nil {
+					batchRsp.Status = statusProto(err)
+				}
+			default:
+				txnRsp, err := sm.PrepareTransaction(wb, txid, batchReq)
+				if err != nil {
+					batchRsp.Status = statusProto(err)
+				} else {
+					batchRsp = txnRsp
+				}
+			}
+		} else {
+			for _, union := range batchReq.GetUnion() {
+				batchRsp.Union = append(batchRsp.Union, sm.handlePropose(wb, union))
+			}
 		}
+	}
+	if err := sm.checkLocks(wb, nil); err != nil {
+		batchRsp.Status = statusProto(err)
 	}
 	rspBuf, err := proto.Marshal(batchRsp)
 	if err != nil {
@@ -1785,5 +1998,7 @@ func New(leaser pebble.Leaser, shardID, replicaID uint64, store IStore, broadcas
 		readQPS:             qps.NewCounter(1 * time.Minute),
 		raftProposeQPS:      qps.NewCounter(1 * time.Minute),
 		broadcast:           broadcast,
+		lockedKeys:          make(map[string][]byte),
+		prepared:            make(map[string]pebble.Batch),
 	}
 }

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -731,3 +731,176 @@ func TestUsage(t *testing.T) {
 		}
 	}
 }
+
+func TestTransactionPrepareAndCommit(t *testing.T) {
+	rootDir := testfs.MakeTempDir(t)
+	db, err := pebble.Open(rootDir, "test", &pebble.Options{})
+	require.NoError(t, err)
+
+	leaser := pebble.NewDBLeaser(db)
+	t.Cleanup(func() {
+		leaser.Close()
+		db.Close()
+	})
+
+	store := &fakeStore{}
+	repl := replica.New(leaser, 1, 1, store, nil /*=usageUpdates=*/)
+	require.NotNil(t, repl)
+
+	stopc := make(chan struct{})
+	_, err = repl.Open(stopc)
+	require.NoError(t, err)
+
+	em := newEntryMaker(t)
+	writeDefaultRangeDescriptor(t, em, repl)
+
+	wb := db.NewBatch()
+	txid := []byte("TX1")
+	cmd, _ := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   []byte("foo"),
+			Value: []byte("bar"),
+		},
+	}).ToProto()
+	_, err = repl.PrepareTransaction(wb, txid, cmd)
+	require.NoError(t, err)
+
+	require.NoError(t, wb.Commit(pebble.Sync))
+	require.NoError(t, wb.Close())
+
+	wb = db.NewBatch()
+	txid2 := []byte("TX2")
+	badCmd, _ := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   []byte("foo"),
+			Value: []byte("baz"),
+		},
+	}).ToProto()
+	_, err = repl.PrepareTransaction(wb, txid2, badCmd)
+	require.Error(t, err)
+	require.NoError(t, wb.Close())
+
+	// Do a DirectWrite.
+	entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   []byte("foo"),
+			Value: []byte("just-an-innocent-write"),
+		},
+	}))
+	entries := []dbsm.Entry{entry}
+	rsp, err := repl.Update(entries)
+	require.NoError(t, err)
+	require.Error(t, rbuilder.NewBatchResponse(rsp[0].Result.Data).AnyError())
+
+	err = repl.CommitTransaction(txid)
+	require.NoError(t, err)
+
+	buf, closer, err := db.Get([]byte("foo"))
+	require.NoError(t, err)
+	defer closer.Close()
+	require.Equal(t, []byte("bar"), buf)
+}
+
+func TestTransactionPrepareAndRollback(t *testing.T) {
+	rootDir := testfs.MakeTempDir(t)
+	db, err := pebble.Open(rootDir, "test", &pebble.Options{})
+	require.NoError(t, err)
+
+	leaser := pebble.NewDBLeaser(db)
+	t.Cleanup(func() {
+		leaser.Close()
+		db.Close()
+	})
+
+	store := &fakeStore{}
+	repl := replica.New(leaser, 1, 1, store, nil /*=usageUpdates=*/)
+	require.NotNil(t, repl)
+
+	stopc := make(chan struct{})
+	_, err = repl.Open(stopc)
+	require.NoError(t, err)
+
+	em := newEntryMaker(t)
+	writeDefaultRangeDescriptor(t, em, repl)
+
+	wb := db.NewBatch()
+	txid := []byte("TX1")
+	cmd, _ := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+		Kv: &rfpb.KV{
+			Key:   []byte("foo"),
+			Value: []byte("bar"),
+		},
+	}).ToProto()
+	_, err = repl.PrepareTransaction(wb, txid, cmd)
+	require.NoError(t, err)
+
+	require.NoError(t, wb.Commit(pebble.Sync))
+	require.NoError(t, wb.Close())
+
+	err = repl.RollbackTransaction(txid)
+	require.NoError(t, err)
+
+	buf, _, err := db.Get([]byte("foo"))
+	require.Error(t, err)
+	require.Nil(t, buf)
+}
+
+func TestTransactionsSurviveRestart(t *testing.T) {
+	rootDir := testfs.MakeTempDir(t)
+	db, err := pebble.Open(rootDir, "test", &pebble.Options{})
+	require.NoError(t, err)
+
+	leaser := pebble.NewDBLeaser(db)
+	t.Cleanup(func() {
+		leaser.Close()
+		db.Close()
+	})
+
+	store := &fakeStore{}
+	txid := []byte("TX1")
+
+	{
+		repl := replica.New(leaser, 1, 1, store, nil /*=usageUpdates=*/)
+		require.NotNil(t, repl)
+
+		stopc := make(chan struct{})
+		_, err = repl.Open(stopc)
+		require.NoError(t, err)
+
+		em := newEntryMaker(t)
+		writeDefaultRangeDescriptor(t, em, repl)
+
+		wb := db.NewBatch()
+		cmd, _ := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+			Kv: &rfpb.KV{
+				Key:   []byte("foo"),
+				Value: []byte("bar"),
+			},
+		}).ToProto()
+		_, err = repl.PrepareTransaction(wb, txid, cmd)
+		require.NoError(t, err)
+
+		require.NoError(t, wb.Commit(pebble.Sync))
+		require.NoError(t, wb.Close())
+
+		err = repl.Close()
+		require.NoError(t, err)
+	}
+
+	{
+		repl := replica.New(leaser, 1, 1, store, nil /*=usageUpdates=*/)
+		require.NotNil(t, repl)
+
+		stopc := make(chan struct{})
+		_, err = repl.Open(stopc)
+		require.NoError(t, err)
+
+		err = repl.CommitTransaction(txid)
+		require.NoError(t, err)
+
+		buf, closer, err := db.Get([]byte("foo"))
+		require.NoError(t, err)
+		defer closer.Close()
+		require.Equal(t, []byte("bar"), buf)
+	}
+}

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -904,3 +904,110 @@ func TestTransactionsSurviveRestart(t *testing.T) {
 		require.Equal(t, []byte("bar"), buf)
 	}
 }
+
+func TestBatchTransaction(t *testing.T) {
+	rootDir := testfs.MakeTempDir(t)
+	db, err := pebble.Open(rootDir, "test", &pebble.Options{})
+	require.NoError(t, err)
+
+	leaser := pebble.NewDBLeaser(db)
+	t.Cleanup(func() {
+		leaser.Close()
+		db.Close()
+	})
+
+	store := &fakeStore{}
+	repl := replica.New(leaser, 1, 1, store, nil /*=usageUpdates=*/)
+	require.NotNil(t, repl)
+
+	stopc := make(chan struct{})
+	_, err = repl.Open(stopc)
+	require.NoError(t, err)
+
+	em := newEntryMaker(t)
+	writeDefaultRangeDescriptor(t, em, repl)
+
+	txid := []byte("test-txid")
+
+	{ // Do a DirectWrite.
+		entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+			Kv: &rfpb.KV{
+				Key:   []byte("foo"),
+				Value: []byte("bar"),
+			},
+		}))
+		entries := []dbsm.Entry{entry}
+		rsp, err := repl.Update(entries)
+		require.NoError(t, err)
+		require.NoError(t, rbuilder.NewBatchResponse(rsp[0].Result.Data).AnyError())
+	}
+	{ // Prepare a transaction
+		entry := em.makeEntry(rbuilder.NewBatchBuilder().SetTransactionId(txid).Add(&rfpb.DirectWriteRequest{
+			Kv: &rfpb.KV{
+				Key:   []byte("foo"),
+				Value: []byte("transaction-succeeded"),
+			},
+		}))
+		entries := []dbsm.Entry{entry}
+		rsp, err := repl.Update(entries)
+		require.NoError(t, err)
+		require.NoError(t, rbuilder.NewBatchResponse(rsp[0].Result.Data).AnyError())
+	}
+	{ // Attempt another direct write (should fail b/c of pending txn).
+		entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+			Kv: &rfpb.KV{
+				Key:   []byte("foo"),
+				Value: []byte("boop"),
+			},
+		}))
+		entries := []dbsm.Entry{entry}
+		rsp, err := repl.Update(entries)
+		require.NoError(t, err)
+		require.Error(t, rbuilder.NewBatchResponse(rsp[0].Result.Data).AnyError())
+	}
+	{ // Do a DirectRead and verify the value is still `bar`.
+		buf, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectReadRequest{
+			Key: []byte("foo"),
+		}).ToBuf()
+		require.NoError(t, err)
+		readRsp, err := repl.Lookup(buf)
+		require.NoError(t, err)
+
+		readBatch := rbuilder.NewBatchResponse(readRsp)
+		directRead, err := readBatch.DirectReadResponse(0)
+		require.NoError(t, err)
+		require.Equal(t, []byte("bar"), directRead.GetKv().GetValue())
+	}
+	{ // Commit the transaction
+		entry := em.makeEntry(rbuilder.NewBatchBuilder().SetTransactionId(txid).SetFinalizeOperation(rfpb.FinalizeOperation_COMMIT))
+		entries := []dbsm.Entry{entry}
+		rsp, err := repl.Update(entries)
+		require.NoError(t, err)
+		require.NoError(t, rbuilder.NewBatchResponse(rsp[0].Result.Data).AnyError())
+	}
+	{ // Do a DirectRead and verify the value was updated by the txn.
+		buf, err := rbuilder.NewBatchBuilder().Add(&rfpb.DirectReadRequest{
+			Key: []byte("foo"),
+		}).ToBuf()
+		require.NoError(t, err)
+		readRsp, err := repl.Lookup(buf)
+		require.NoError(t, err)
+
+		readBatch := rbuilder.NewBatchResponse(readRsp)
+		directRead, err := readBatch.DirectReadResponse(0)
+		require.NoError(t, err)
+		require.Equal(t, []byte("transaction-succeeded"), directRead.GetKv().GetValue())
+	}
+	{ // Value should be direct writable again (no more pending txns)
+		entry := em.makeEntry(rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
+			Kv: &rfpb.KV{
+				Key:   []byte("foo"),
+				Value: []byte("bar"),
+			},
+		}))
+		entries := []dbsm.Entry{entry}
+		rsp, err := repl.Update(entries)
+		require.NoError(t, err)
+		require.NoError(t, rbuilder.NewBatchResponse(rsp[0].Result.Data).AnyError())
+	}
+}

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -185,6 +185,11 @@ message CASResponse {
   KV kv = 1;
 }
 
+message FindSplitPointRequest {}
+message FindSplitPointResponse {
+  bytes split_key = 1;
+}
+
 message SimpleSplitRequest {
   uint64 source_range_id = 1;
   uint64 new_shard_id = 2;
@@ -207,6 +212,7 @@ message RequestUnion {
     ScanRequest scan = 4;
     CASRequest cas = 5;
     SimpleSplitRequest simple_split = 6;
+    FindSplitPointRequest find_split_point = 14;
 
     // The following operations are for getting and setting FileMetadata blobs.
     GetRequest get = 7;
@@ -234,6 +240,7 @@ message ResponseUnion {
     ScanResponse scan = 5;
     CASResponse cas = 6;
     SimpleSplitResponse simple_split = 7;
+    FindSplitPointResponse find_split_point = 15;
 
     // The following operations are for getting and setting FileMetadata blobs.
     GetResponse get = 8;
@@ -247,11 +254,39 @@ message ResponseUnion {
   }
 }
 
-message BatchCmdRequest {
-  repeated RequestUnion union = 1;
+message TxnRequest {
+  optional bytes transaction_id = 1;
+  message Statement {
+    uint64 shard_id = 1;
+    repeated RequestUnion union = 2;
+  }
+  repeated Statement statements = 2;
+}
 
+message TxnResponse {
+  repeated BatchCmdResponse responses = 1;
+}
+
+enum FinalizeOperation {
+  UNKNOWN_OPERATION = 0;
+  ROLLBACK = 1;
+  COMMIT = 2;
+}
+
+message BatchCmdRequest {
   // Header will be validated by the state machine if set.
-  Header header = 2;
+  Header header = 1;
+
+  // RequestUnion contains the union of reads/writes to process in this request.
+  repeated RequestUnion union = 2;
+
+  // If a transaction_id is set and finalize_operation is unset, then the ops
+  // in union will be PREPARED and locks will be acquired on any written rows.
+  optional bytes transaction_id = 3;
+
+  // If finalize_operation is set, a previously created transaction can be
+  // COMMITTED or ROLLED BACK. When this field is set, union must be unset.
+  optional FinalizeOperation finalize_operation = 4;
 }
 
 message BatchCmdResponse {


### PR DESCRIPTION
Sometimes, like during a split or merge, you want to make changes that apply to multiple ranges and those changes should apply as a unit.

To support this, add a transaction_id that batches a request in-memory and locks the keys in that batch. This allows us to implement 2PC so we can Prepare a bunch of changes against different ranges and then Commit them or Roll them back together.
