### PR TITLE
Don't register container providers that are not enabled

### DIFF
--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -210,6 +210,15 @@ type ExecutorProperties struct {
 	DefaultXcodeVersion     string
 }
 
+func (p *ExecutorProperties) SupportsIsolation(c ContainerType) bool {
+	for _, s := range p.SupportedIsolationTypes {
+		if s == c {
+			return true
+		}
+	}
+	return false
+}
+
 // ParseProperties parses the client provided properties into a struct.
 // Before use, the returned platform.Properties object *must* have
 // executor-specific overrides applied via the ApplyOverrides function.
@@ -362,15 +371,6 @@ func GetExecutorProperties() *ExecutorProperties {
 	return p
 }
 
-func contains(haystack []ContainerType, needle ContainerType) bool {
-	for _, s := range haystack {
-		if s == needle {
-			return true
-		}
-	}
-	return false
-}
-
 // ApplyOverrides modifies the platformProps and command as needed to match the
 // locally configured executor properties.
 func ApplyOverrides(env environment.Env, executorProps *ExecutorProperties, platformProps *Properties, command *repb.Command) error {
@@ -394,7 +394,7 @@ func ApplyOverrides(env environment.Env, executorProps *ExecutorProperties, plat
 	}
 
 	// Check that the selected isolation type is supported by this executor.
-	if !contains(executorProps.SupportedIsolationTypes, ContainerType(platformProps.WorkloadIsolationType)) {
+	if !executorProps.SupportsIsolation(ContainerType(platformProps.WorkloadIsolationType)) {
 		return status.InvalidArgumentErrorf("The requested workload isolation type %q is unsupported by this executor. Supported types: %s)", platformProps.WorkloadIsolationType, executorProps.SupportedIsolationTypes)
 	}
 

--- a/enterprise/server/remote_execution/runner/runner_darwin.go
+++ b/enterprise/server/remote_execution/runner/runner_darwin.go
@@ -11,12 +11,15 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 )
 
-func (p *pool) initContainerProviders() error {
-	providers := make(map[platform.ContainerType]container.Provider)
-	providers[platform.SandboxContainerType] = &sandbox.Provider{}
-	providers[platform.BareContainerType] = &bare.Provider{}
+func (p *pool) registerContainerProviders(providers map[platform.ContainerType]container.Provider, executor *platform.ExecutorProperties) error {
+	if executor.SupportsIsolation(platform.SandboxContainerType) {
+		providers[platform.SandboxContainerType] = &sandbox.Provider{}
+	}
 
-	p.containerProviders = providers
+	if executor.SupportsIsolation(platform.BareContainerType) {
+		providers[platform.BareContainerType] = &bare.Provider{}
+	}
+
 	return nil
 }
 

--- a/enterprise/server/remote_execution/runner/runner_windows.go
+++ b/enterprise/server/remote_execution/runner/runner_windows.go
@@ -10,10 +10,10 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 )
 
-func (p *pool) initContainerProviders() error {
-	providers := make(map[platform.ContainerType]container.Provider)
-	providers[platform.BareContainerType] = &bare.Provider{}
-	p.containerProviders = providers
+func (p *pool) registerContainerProviders(providers map[platform.ContainerType]container.Provider, executor *platform.ExecutorProperties) error {
+	if executor.SupportsIsolation(platform.BareContainerType) {
+		providers[platform.BareContainerType] = &bare.Provider{}
+	}
 
 	return nil
 }


### PR DESCRIPTION
Before this PR, we would call `podman.NewProvider()` regardless of whether podman was enabled (same for docker, bare, and sandbox). This is causing problems for https://github.com/buildbuddy-io/buildbuddy/pull/5207, which attempts to run the `podman` command within the `NewProvider()` func. If podman is not available (e.g. in tests), we'll fail to run podman to detect the version.

**Related issues**: N/A
