### PR TITLE
.bazelignore: add .git

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,4 @@
+.git
 bazel-bin
 bazel-buildbuddy
 bazel-out


### PR DESCRIPTION
Turn out, if you just tail Bazel java log, it just scans everything.
Removing .git directory from scanning helps speed things up slightly.
