### PR TITLE
[FC] Fix early chroot cleanup in firecracker.Remove()

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2211,10 +2211,6 @@ func (c *FirecrackerContainer) remove(ctx context.Context) error {
 		c.rootStore = nil
 	}
 
-	if err := os.RemoveAll(filepath.Dir(c.getChroot())); err != nil {
-		log.CtxErrorf(ctx, "Error removing chroot: %s", err)
-		lastErr = err
-	}
 	if c.uffdHandler != nil {
 		if err := c.uffdHandler.Stop(); err != nil {
 			log.CtxErrorf(ctx, "Error stopping uffd handler: %s", err)
@@ -2225,6 +2221,10 @@ func (c *FirecrackerContainer) remove(ctx context.Context) error {
 	if c.memoryStore != nil {
 		c.memoryStore.Close()
 		c.memoryStore = nil
+	}
+	if err := os.RemoveAll(filepath.Dir(c.getChroot())); err != nil {
+		log.CtxErrorf(ctx, "Error removing chroot: %s", err)
+		lastErr = err
 	}
 	return lastErr
 }


### PR DESCRIPTION
This caused an error where we'd clean up the contents of the memory store before stopping the uffd handler, causing errors when the uffd handler tried to access the memory store.

This only happened on executor shut downs because in a typical case we'd call Pause() on the container first, which stops the uffd handler. During executor shut downs, we only call Remove(), so the uffd handler was still running when we clear chroot

**Related issues**: N/A
