### PR TITLE
Bump GuestAPIVersion

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -102,7 +102,7 @@ const (
 	//
 	// NOTE: this is part of the snapshot cache key, so bumping this version
 	// will make existing cached snapshots unusable.
-	GuestAPIVersion = "1"
+	GuestAPIVersion = "2"
 
 	// How long to wait for the VMM to listen on the firecracker socket.
 	firecrackerSocketWaitTimeout = 3 * time.Second

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -128,8 +128,8 @@ func TestGuestAPIVersion(t *testing.T) {
 	// Note that if you go with option 1, ALL VM snapshots will be invalidated
 	// which will negatively affect customer experience. Be careful!
 	const (
-		expectedHash    = "e8295ea74955ce9572251d95564e04ecaac4e18f8c2756c1516c0c7c5ee401d4"
-		expectedVersion = "1"
+		expectedHash    = "cb6b9cd2728d6d73250f2af99ed96d9714822bee5c3110a8b146a8a3017690d4"
+		expectedVersion = "2"
 	)
 	assert.Equal(t, expectedHash, firecracker.GuestAPIHash)
 	assert.Equal(t, expectedVersion, firecracker.GuestAPIVersion)


### PR DESCRIPTION
Bumping version to pick up https://github.com/buildbuddy-io/buildbuddy/pull/5216 and updating the hash to fix the test.

(The test failed on that PR, but had auto-merge enabled :sweat_smile: )

**Related issues**: N/A
