### PR TITLE
Add a 2PC txn runner

### DIFF
--- a/enterprise/server/raft/rbuilder/BUILD
+++ b/enterprise/server/raft/rbuilder/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//proto:raft_go_proto",
         "//server/util/status",
+        "@com_github_google_uuid//:uuid",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//encoding/prototext",
         "@org_golang_google_protobuf//proto",

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -942,7 +942,7 @@ func TestBatchTransaction(t *testing.T) {
 		require.NoError(t, rbuilder.NewBatchResponse(rsp[0].Result.Data).AnyError())
 	}
 	{ // Prepare a transaction
-		entry := em.makeEntry(rbuilder.NewBatchBuilder().SetTransactionId(txid).Add(&rfpb.DirectWriteRequest{
+		entry := em.makeEntry(rbuilder.NewBatchBuilder().SetTransactionID(txid).Add(&rfpb.DirectWriteRequest{
 			Kv: &rfpb.KV{
 				Key:   []byte("foo"),
 				Value: []byte("transaction-succeeded"),
@@ -979,7 +979,7 @@ func TestBatchTransaction(t *testing.T) {
 		require.Equal(t, []byte("bar"), directRead.GetKv().GetValue())
 	}
 	{ // Commit the transaction
-		entry := em.makeEntry(rbuilder.NewBatchBuilder().SetTransactionId(txid).SetFinalizeOperation(rfpb.FinalizeOperation_COMMIT))
+		entry := em.makeEntry(rbuilder.NewBatchBuilder().SetTransactionID(txid).SetFinalizeOperation(rfpb.FinalizeOperation_COMMIT))
 		entries := []dbsm.Entry{entry}
 		rsp, err := repl.Update(entries)
 		require.NoError(t, err)

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -56,6 +56,7 @@ func makeHeader(rangeDescriptor *rfpb.RangeDescriptor, replicaIdx int, mode rfpb
 func (s *Sender) grpcAddrForReplicaDescriptor(rd *rfpb.ReplicaDescriptor) (string, error) {
 	addr, _, err := s.nodeRegistry.ResolveGRPC(rd.GetShardId(), rd.GetReplicaId())
 	if err != nil {
+		log.Errorf("Error resolving GRPC addr of c%dn%d", rd.GetShardId(), rd.GetReplicaId())
 		return "", err
 	}
 	return addr, nil

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -56,7 +56,6 @@ func makeHeader(rangeDescriptor *rfpb.RangeDescriptor, replicaIdx int, mode rfpb
 func (s *Sender) grpcAddrForReplicaDescriptor(rd *rfpb.ReplicaDescriptor) (string, error) {
 	addr, _, err := s.nodeRegistry.ResolveGRPC(rd.GetShardId(), rd.GetReplicaId())
 	if err != nil {
-		log.Errorf("Error resolving GRPC addr of c%dn%d", rd.GetShardId(), rd.GetReplicaId())
 		return "", err
 	}
 	return addr, nil


### PR DESCRIPTION
The txn runner can be used to apply statements that cross shard boundaries. Example usage:

```
        txn := rbuilder.NewTxn().AddStatement(shardID, leftBatch)
	txn = txn.AddStatement(newShardID, rightBatch)
        txn = txn.AddStatement(metaRangeShardID, metaBatch)
        if err := client.RunTxn(ctx, s.nodeHost, txnReq); err != nil {
                return nil, err
        }
```