### PR TITLE
Add temp debug logging for server-side lease timeout issue

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1454,7 +1454,7 @@ func (s *SchedulerServer) LeaseTask(stream scpb.Scheduler_LeaseTaskServer) error
 			err = msg.err
 		case <-livenessTicker.Chan():
 			if s.clock.Since(lastCheckin) > (*leaseInterval + *leaseGracePeriod) {
-				err = status.DeadlineExceededError("lease was not renewed by executor and expired")
+				err = status.DeadlineExceededErrorf("lease was not renewed by executor and expired (last renewal: %s)", lastCheckin)
 			} else {
 				continue
 			}

--- a/enterprise/server/scheduling/task_leaser/task_leaser.go
+++ b/enterprise/server/scheduling/task_leaser/task_leaser.go
@@ -60,7 +60,10 @@ func (t *TaskLeaser) sendRequest(req *scpb.LeaseTaskRequest) (*scpb.LeaseTaskRes
 	return t.stream.Recv()
 }
 
-func (t *TaskLeaser) pingServer(ctx context.Context) ([]byte, error) {
+func (t *TaskLeaser) pingServer(ctx context.Context) (b []byte, err error) {
+	log.CtxDebugf(ctx, "Pinging scheduler")
+	defer func() { log.CtxDebugf(ctx, "Ping done, err=%v", err) }()
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	req := &scpb.LeaseTaskRequest{


### PR DESCRIPTION
We are seeing the new server-side lease timeout getting triggered for some workflow actions in dev. This PR adds a little bit of debug logging to try and diagnose the issue.

**Related issues**: N/A
