### PR TITLE
Correctly show successful workflows as "Succeeded"

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -557,7 +557,7 @@ export default class InvocationModel {
   getStatus() {
     switch (this.invocation.invocationStatus) {
       case InvocationStatus.COMPLETE_INVOCATION_STATUS:
-        return exitCode(this.invocation.bazelExitCode);
+        return this.invocation.success ? "Succeeded" : exitCode(this.invocation.bazelExitCode);
       case InvocationStatus.PARTIAL_INVOCATION_STATUS:
         return "In progress...";
       case InvocationStatus.DISCONNECTED_INVOCATION_STATUS:

--- a/enterprise/app/history/history_invocation_card.tsx
+++ b/enterprise/app/history/history_invocation_card.tsx
@@ -151,7 +151,7 @@ export default class HistoryInvocationCardComponent extends React.Component<Prop
     if (this.isDisconnected()) {
       return "Disconnected";
     }
-    return exitCode(this.props.invocation.bazelExitCode);
+    return this.props.invocation.success ? "Succeeded" : exitCode(this.props.invocation.bazelExitCode);
   }
 
   private getTitleForWorkflow() {


### PR DESCRIPTION
This change https://github.com/buildbuddy-io/buildbuddy/pull/5170 broke workflow status rendering because workflows don't report a bazel exit code so they hit this case in the switch statement: https://github.com/buildbuddy-io/buildbuddy/pull/5170/files#diff-d02509013b3d6d63733e2a920b9661f301cb4e1f154fbb778735705b4657ce20R40

This change fixes that by checking the invocation status first.