### PR TITLE
call stop() when grpc-over-http is enabled

### DIFF
--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -176,7 +176,14 @@ func GRPCShutdown(ctx context.Context, grpcServer *grpc.Server) error {
 			grpcServer.Stop()
 		}
 	}()
-	grpcServer.GracefulStop()
+	if *gRPCOverHTTPPortEnabled {
+		// The transport returned by ServeHTTP() doesn't implement Drain()
+		// and if there are existing http connections during shutdown, it can
+		// cause panic.
+		grpcServer.Stop()
+	} else {
+		grpcServer.GracefulStop()
+	}
 	cancel()
 	return nil
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
When grpc over http is enabled, and if during shutdown there are existing http
connections, it can cause panic because Drain() is not implemented by the
transport returned by ServeHTTP()
