### PR TITLE
Don't show experimental flag suggestions in Bazel 7.0

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -306,7 +306,10 @@ export default class InvocationModel {
   }
 
   isCacheCompressionEnabled() {
-    return this.optionsMap.get("experimental_remote_cache_compression") === "1";
+    return (
+      this.optionsMap.get("experimental_remote_cache_compression") === "1" ||
+      this.optionsMap.get("remote_cache_compression") === "1"
+    );
   }
 
   getTargetConfiguredCount() {

--- a/app/invocation/invocation_suggestion_card.tsx
+++ b/app/invocation/invocation_suggestion_card.tsx
@@ -240,6 +240,7 @@ const matchers: SuggestionMatcher[] = [
     if (!capabilities.config.expandedSuggestionsEnabled) return null;
     if (!model.isBazelInvocation()) return null;
 
+    if (model.optionsMap.get("remote_cache_compression")) return null;
     if (model.optionsMap.get("experimental_remote_cache_compression")) return null;
     if (!model.optionsMap.get("remote_cache") && !model.optionsMap.get("remote_executor")) return null;
     const version = getBazelMajorVersion(model);
@@ -289,6 +290,7 @@ const matchers: SuggestionMatcher[] = [
     if (!model.isBazelInvocation()) return null;
 
     if (!model.optionsMap.get("remote_cache")) return null;
+    if (model.optionsMap.get("remote_build_event_upload")) return null;
     if (model.optionsMap.get("experimental_remote_build_event_upload")) return null;
     const version = getBazelMajorVersion(model);
     // Bazel pre-v6 doesn't support --experimental_remote_build_event_upload=minimal


### PR DESCRIPTION
In Bazel 7.0 `experimental_remote_cache_compression` and `experimental_remote_build_event_upload` will lose their `experimental_` prefix (though they'll still be accepted with prefix).

Let's not show the flag suggestions if we see the flags set without the `experimental_` prefix (which I think Bazel automatically strips when normalizing flags).