### PR TITLE
Use valyala zstd library

### DIFF
--- a/buildpatches/com_github_valyala_gozstd.patch
+++ b/buildpatches/com_github_valyala_gozstd.patch
@@ -1,0 +1,127 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 2f968a0..e90eb5d 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -1,69 +1,79 @@
+ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+ 
+-go_library(
+-    name = "gozstd",
+-    srcs = [
+-        "dict.go",
+-        "doc.go",
+-        "gozstd.go",
+-        "libzstd_darwin_amd64.go",
+-        "libzstd_darwin_arm64.go",
+-        "libzstd_freebsd_amd64.go",
+-        "libzstd_illumos_amd64.go",
+-        "libzstd_linux_amd64.go",
+-        "libzstd_linux_arm.go",
+-        "libzstd_linux_arm64.go",
+-        "libzstd_windows_amd64.go",
+-        "reader.go",
+-        "stream.go",
+-        "writer.go",
+-        "zdict.h",
+-        "zstd.h",
+-        "zstd_errors.h",
+-    ],
+-    cgo = True,
+-    clinkopts = select({
++cc_library(
++    name = "libzstd",
++    srcs = select({
+         "@io_bazel_rules_go//go/platform:android_amd64": [
+-            "./libzstd_linux_amd64.a",
++            "libzstd_linux_amd64.a",
+         ],
+         "@io_bazel_rules_go//go/platform:android_arm": [
+-            "./libzstd_linux_arm.a",
++            "libzstd_linux_arm.a",
+         ],
+         "@io_bazel_rules_go//go/platform:android_arm64": [
+-            "./libzstd_linux_arm64.a",
++            "libzstd_linux_arm64.a",
+         ],
+         "@io_bazel_rules_go//go/platform:darwin_amd64": [
+-            "./libzstd_darwin_amd64.a",
++            "libzstd_darwin_amd64.a",
+         ],
+         "@io_bazel_rules_go//go/platform:darwin_arm64": [
+-            "./libzstd_darwin_arm64.a",
++            "libzstd_darwin_arm64.a",
+         ],
+         "@io_bazel_rules_go//go/platform:freebsd_amd64": [
+-            "./libzstd_freebsd_amd64.a",
++            "libzstd_freebsd_amd64.a",
+         ],
+         "@io_bazel_rules_go//go/platform:illumos_amd64": [
+-            "./libzstd_illumos_amd64.a",
++            "libzstd_illumos_amd64.a",
+         ],
+         "@io_bazel_rules_go//go/platform:ios_amd64": [
+-            "./libzstd_darwin_amd64.a",
++            "libzstd_darwin_amd64.a",
+         ],
+         "@io_bazel_rules_go//go/platform:ios_arm64": [
+-            "./libzstd_darwin_arm64.a",
++            "libzstd_darwin_arm64.a",
+         ],
+         "@io_bazel_rules_go//go/platform:linux_amd64": [
+-            "./libzstd_linux_amd64.a",
++            "libzstd_linux_amd64.a",
+         ],
+         "@io_bazel_rules_go//go/platform:linux_arm": [
+-            "./libzstd_linux_arm.a",
++            "libzstd_linux_arm.a",
+         ],
+         "@io_bazel_rules_go//go/platform:linux_arm64": [
+-            "./libzstd_linux_arm64.a",
++            "libzstd_linux_arm64.a",
+         ],
+         "@io_bazel_rules_go//go/platform:windows_amd64": [
+-            "./libzstd_windows_amd64.a",
++            "libzstd_windows_amd64.a",
+         ],
+-        "//conditions:default": [],
++        "//conditions:default": ["UNSUPPORTED_PLATFORM"],
+     }),
++    hdrs = [
++        "zdict.h",
++        "zstd.h",
++        "zstd_errors.h",
++    ],
++)
++
++go_library(
++    name = "gozstd",
++    srcs = [
++        "dict.go",
++        "doc.go",
++        "gozstd.go",
++        "libzstd_darwin_amd64.go",
++        "libzstd_darwin_arm64.go",
++        "libzstd_freebsd_amd64.go",
++        "libzstd_illumos_amd64.go",
++        "libzstd_linux_amd64.go",
++        "libzstd_linux_arm.go",
++        "libzstd_linux_arm64.go",
++        "libzstd_windows_amd64.go",
++        "reader.go",
++        "stream.go",
++        "writer.go",
++        "zdict.h",
++        "zstd.h",
++        "zstd_errors.h",
++    ],
++    cdeps = [":libzstd"],
++    cgo = True,
+     copts = ["-O3"],
+     importpath = "github.com/valyala/gozstd",
+     visibility = ["//visibility:public"],
+@@ -88,3 +98,5 @@ go_test(
+     ],
+     embed = [":gozstd"],
+ )
++
++# gazelle:prefix github.com/valyala/gozstd

--- a/deps.bzl
+++ b/deps.bzl
@@ -5145,6 +5145,13 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
         version = "v1.2.2",
     )
     go_repository(
+        name = "com_github_valyala_gozstd",
+        importpath = "github.com/valyala/gozstd",
+        sum = "h1:xPnnnvjmaDDitMFfDxmQ4vpx0+3CdTg2o3lALvXTU/g=",
+        version = "v1.20.1",
+    )
+
+    go_repository(
         name = "com_github_valyala_histogram",
         importpath = "github.com/valyala/histogram",
         sum = "h1:wyYGAZZt3CpwUiIb9AU/Zbllg1llXyrtApRS815OLoQ=",

--- a/deps.bzl
+++ b/deps.bzl
@@ -5146,6 +5146,7 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     )
     go_repository(
         name = "com_github_valyala_gozstd",
+		build_file_generation = "on",
         importpath = "github.com/valyala/gozstd",
         sum = "h1:xPnnnvjmaDDitMFfDxmQ4vpx0+3CdTg2o3lALvXTU/g=",
         version = "v1.20.1",

--- a/deps.bzl
+++ b/deps.bzl
@@ -5146,8 +5146,9 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     )
     go_repository(
         name = "com_github_valyala_gozstd",
-		build_file_generation = "on",
         importpath = "github.com/valyala/gozstd",
+        patch_args = ["-p1"],
+        patches = ["//buildpatches:com_github_valyala_gozstd.patch"],
         sum = "h1:xPnnnvjmaDDitMFfDxmQ4vpx0+3CdTg2o3lALvXTU/g=",
         version = "v1.20.1",
     )

--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -51,7 +51,7 @@ go_library(
 go_binary(
     name = "ci_runner",
     embed = [":main"],
-    pure = "on",
+    #pure = "on",
     static = "on",
 )
 

--- a/go.mod
+++ b/go.mod
@@ -305,6 +305,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/valyala/fastrand v1.1.0 // indirect
+	github.com/valyala/gozstd v1.20.1 // indirect
 	github.com/valyala/histogram v1.2.0 // indirect
 	github.com/vbatts/tar-split v0.11.3 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2344,6 +2344,8 @@ github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBn
 github.com/valyala/fastrand v1.1.0 h1:f+5HkLW4rsgzdNoleUOB69hyT9IlD2ZQh9GyDMfb5G8=
 github.com/valyala/fastrand v1.1.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
+github.com/valyala/gozstd v1.20.1 h1:xPnnnvjmaDDitMFfDxmQ4vpx0+3CdTg2o3lALvXTU/g=
+github.com/valyala/gozstd v1.20.1/go.mod h1:y5Ew47GLlP37EkTB+B4s7r6A5rdaeB7ftbl9zoYiIPQ=
 github.com/valyala/histogram v1.2.0 h1:wyYGAZZt3CpwUiIb9AU/Zbllg1llXyrtApRS815OLoQ=
 github.com/valyala/histogram v1.2.0/go.mod h1:Hb4kBwb4UxsaNbbbh+RRz8ZR6pdodR57tzWUS3BUzXY=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=

--- a/server/util/compression/BUILD
+++ b/server/util/compression/BUILD
@@ -9,7 +9,7 @@ go_library(
         "//server/metrics",
         "//server/util/log",
         "@com_github_prometheus_client_golang//prometheus",
-        "@com_github_valyala_gozstd//:gozstd",
+        "@com_github_valyala_gozstd//:go_default_library",
     ],
 )
 

--- a/server/util/compression/BUILD
+++ b/server/util/compression/BUILD
@@ -9,7 +9,7 @@ go_library(
         "//server/metrics",
         "//server/util/log",
         "@com_github_prometheus_client_golang//prometheus",
-        "@com_github_valyala_gozstd//:go_default_library",
+        "@com_github_valyala_gozstd//:gozstd",
     ],
 )
 

--- a/server/util/compression/BUILD
+++ b/server/util/compression/BUILD
@@ -8,8 +8,8 @@ go_library(
     deps = [
         "//server/metrics",
         "//server/util/log",
-        "@com_github_klauspost_compress//zstd",
         "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_valyala_gozstd//:go_default_library",
     ],
 )
 

--- a/server/util/compression/compression.go
+++ b/server/util/compression/compression.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/klauspost/compress/zstd"
 	"github.com/prometheus/client_golang/prometheus"
+	zstd "github.com/valyala/gozstd"
 )
 
 var (


### PR DESCRIPTION
Below is the benchmark result. Result marked by "current" is ran from https://github.com/buildbuddy-io/buildbuddy/pull/5251
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor            
                               │   current    │               valyala                │
                               │    sec/op    │    sec/op      vs base               │
Set/Pebble10-24                  16.42µ ±  6%    23.08µ ±  9%  +40.56% (p=0.002 n=6)
Set/Pebble100-24                 16.36µ ±  4%    21.91µ ±  9%  +33.98% (p=0.002 n=6)
Set/Pebble1000-24                16.24µ ±  4%    22.69µ ±  2%  +39.74% (p=0.002 n=6)
Set/Pebble10000-24               93.63µ ±  6%   128.62µ ±  8%  +37.37% (p=0.002 n=6)
Set/Pebble100000-24              92.27µ ±  4%   123.17µ ±  2%  +33.49% (p=0.002 n=6)
Set/Pebble1000000-24             2.848m ± 12%    2.541m ±  6%  -10.78% (p=0.026 n=6)
Set/Pebble10000000-24            19.61m ±  7%    19.69m ±  3%        ~ (p=0.699 n=6)
Set/Pebble100000000-24           206.6m ±  8%    126.5m ±  5%  -38.80% (p=0.002 n=6)
Get/Pebble10-24                  7.157µ ±  8%   12.372µ ±  3%  +72.88% (p=0.002 n=6)
Get/Pebble100-24                 7.533µ ±  6%   12.523µ ±  5%  +66.24% (p=0.002 n=6)
Get/Pebble1000-24                8.217µ ±  5%   12.964µ ±  1%  +57.76% (p=0.002 n=6)
Get/Pebble10000-24               15.15µ ±  6%    24.62µ ±  1%  +62.53% (p=0.002 n=6)
Get/Pebble100000-24              17.54µ ±  6%    28.51µ ±  3%  +62.57% (p=0.002 n=6)
Get/Pebble1000000-24             32.14µ ±  2%    53.10µ ±  4%  +65.24% (p=0.002 n=6)
Get/Pebble10000000-24            471.5µ ±  1%    561.4µ ±  1%  +19.08% (p=0.002 n=6)
Get/Pebble100000000-24           4.555m ±  3%    4.473m ±  5%        ~ (p=0.132 n=6)
GetMulti/Pebble10-24             239.7µ ±  7%    426.0µ ±  4%  +77.71% (p=0.002 n=6)
GetMulti/Pebble100-24            252.7µ ±  6%    443.8µ ±  9%  +75.61% (p=0.002 n=6)
GetMulti/Pebble1000-24           284.6µ ±  7%    463.1µ ±  4%  +62.74% (p=0.002 n=6)
GetMulti/Pebble10000-24          629.0µ ±  5%   1038.0µ ±  2%  +65.03% (p=0.002 n=6)
GetMulti/Pebble100000-24         683.2µ ±  4%   1059.7µ ±  2%  +55.11% (p=0.002 n=6)
GetMulti/Pebble1000000-24        757.6µ ±  7%   1266.2µ ±  9%  +67.14% (p=0.002 n=6)
GetMulti/Pebble10000000-24       17.30m ±  8%    25.95m ±  5%  +50.06% (p=0.002 n=6)
GetMulti/Pebble100000000-24      168.1m ±  5%    241.7m ±  7%  +43.78% (p=0.002 n=6)
FindMissing/Pebble10-24          200.4µ ±  7%    349.1µ ±  3%  +74.18% (p=0.002 n=6)
FindMissing/Pebble100-24         211.6µ ±  5%    358.9µ ±  3%  +69.58% (p=0.002 n=6)
FindMissing/Pebble1000-24        221.7µ ±  9%    375.6µ ±  2%  +69.37% (p=0.002 n=6)
FindMissing/Pebble10000-24       215.5µ ±  8%    379.3µ ±  2%  +76.04% (p=0.002 n=6)
FindMissing/Pebble100000-24      248.8µ ±  7%    383.4µ ±  2%  +54.11% (p=0.002 n=6)
FindMissing/Pebble1000000-24     239.9µ ±  6%    384.4µ ±  1%  +60.27% (p=0.002 n=6)
FindMissing/Pebble10000000-24    1.680m ±  6%    2.746m ±  4%  +63.44% (p=0.002 n=6)
FindMissing/Pebble100000000-24   18.49m ± 12%    30.59m ± 12%  +65.45% (p=0.002 n=6)
geomean                          323.9µ          471.9µ        +45.67%

                            │    current     │               valyala                │
                            │      B/s       │      B/s       vs base               │
Set/Pebble10-24                595.7Ki ±  7%   424.8Ki ±  8%  -28.69% (p=0.002 n=6)
Set/Pebble100-24               5.832Mi ±  4%   4.354Mi ±  8%  -25.35% (p=0.002 n=6)
Set/Pebble1000-24              58.74Mi ±  4%   42.03Mi ±  2%  -28.44% (p=0.002 n=6)
Set/Pebble10000-24            101.89Mi ±  7%   74.19Mi ±  9%  -27.19% (p=0.002 n=6)
Set/Pebble100000-24           1033.7Mi ±  4%   774.3Mi ±  2%  -25.10% (p=0.002 n=6)
Set/Pebble1000000-24           334.8Mi ± 14%   375.3Mi ±  6%  +12.09% (p=0.026 n=6)
Set/Pebble10000000-24          486.4Mi ±  7%   484.5Mi ±  3%        ~ (p=0.699 n=6)
Set/Pebble100000000-24         461.6Mi ±  7%   754.2Mi ±  6%  +63.40% (p=0.002 n=6)
Get/Pebble10-24                3.066Mi ±  9%   1.464Mi ±  4%  -52.26% (p=0.002 n=6)
Get/Pebble100-24               2.661Mi ±  6%   1.292Mi ±  4%  -51.43% (p=0.002 n=6)
Get/Pebble1000-24              4.654Mi ± 15%   2.699Mi ±  9%  -42.01% (p=0.002 n=6)
Get/Pebble10000-24            11.363Mi ±  8%   5.698Mi ±  2%  -49.85% (p=0.002 n=6)
Get/Pebble100000-24            56.62Mi ±  6%   35.10Mi ±  2%  -38.01% (p=0.002 n=6)
Get/Pebble1000000-24           511.0Mi ± 28%   182.0Mi ±  5%  -64.38% (p=0.002 n=6)
Get/Pebble10000000-24          355.7Mi ± 11%   288.3Mi ± 40%  -18.96% (p=0.002 n=6)
Get/Pebble100000000-24         430.5Mi ±  4%   450.2Mi ±  6%   +4.59% (p=0.009 n=6)
GetMulti/Pebble10-24           4.578Mi ±  7%   2.127Mi ±  4%  -53.54% (p=0.002 n=6)
GetMulti/Pebble100-24          3.963Mi ±  6%   1.826Mi ± 10%  -53.91% (p=0.002 n=6)
GetMulti/Pebble1000-24         7.062Mi ±  7%   3.815Mi ±  4%  -45.98% (p=0.002 n=6)
GetMulti/Pebble10000-24       13.890Mi ±  5%   7.477Mi ±  5%  -46.17% (p=0.002 n=6)
GetMulti/Pebble100000-24       72.58Mi ±  4%   46.87Mi ±  2%  -35.43% (p=0.002 n=6)
GetMulti/Pebble1000000-24     1000.3Mi ±  7%   425.0Mi ±  5%  -57.51% (p=0.002 n=6)
GetMulti/Pebble10000000-24     502.7Mi ±  8%   307.4Mi ±  8%  -38.84% (p=0.002 n=6)
GetMulti/Pebble100000000-24    581.1Mi ±  6%   411.3Mi ±  6%  -29.22% (p=0.002 n=6)
geomean                        51.37Mi         33.51Mi        -34.76%

                               │    current     │               valyala               │
                               │      B/op      │     B/op      vs base               │
Set/Pebble10-24                   6.307Ki ±  6%   6.547Ki ± 4%        ~ (p=0.093 n=6)
Set/Pebble100-24                  6.375Ki ±  0%   6.484Ki ± 0%   +1.71% (p=0.002 n=6)
Set/Pebble1000-24                 7.312Ki ±  0%   7.425Ki ± 0%   +1.54% (p=0.002 n=6)
Set/Pebble10000-24                10.42Ki ±  0%   10.64Ki ± 0%   +2.16% (p=0.002 n=6)
Set/Pebble100000-24               10.45Ki ±  0%   10.70Ki ± 1%   +2.43% (p=0.002 n=6)
Set/Pebble1000000-24              5.003Mi ±  0%   5.359Mi ± 1%   +7.11% (p=0.002 n=6)
Set/Pebble10000000-24             14.09Mi ±  1%   16.42Mi ± 3%  +16.55% (p=0.002 n=6)
Set/Pebble100000000-24            106.9Mi ±  4%   105.2Mi ± 2%   -1.59% (p=0.009 n=6)
Get/Pebble10-24                   4.375Ki ±  1%   4.436Ki ± 1%   +1.37% (p=0.002 n=6)
Get/Pebble100-24                  4.407Ki ±  1%   4.499Ki ± 1%   +2.08% (p=0.002 n=6)
Get/Pebble1000-24                 4.462Ki ±  0%   4.551Ki ± 0%   +1.99% (p=0.002 n=6)
Get/Pebble10000-24                5.775Ki ±  0%   5.881Ki ± 0%   +1.83% (p=0.002 n=6)
Get/Pebble100000-24               8.496Ki ±  0%   8.658Ki ± 1%   +1.91% (p=0.002 n=6)
Get/Pebble1000000-24              77.48Ki ±  5%   57.73Ki ± 6%  -25.49% (p=0.002 n=6)
Get/Pebble10000000-24             1.446Mi ± 25%   1.070Mi ± 2%  -26.01% (p=0.002 n=6)
Get/Pebble100000000-24            19.46Mi ±  1%   14.10Mi ± 2%  -27.55% (p=0.002 n=6)
GetMulti/Pebble10-24              160.3Ki ±  1%   162.6Ki ± 2%   +1.46% (p=0.002 n=6)
GetMulti/Pebble100-24             161.9Ki ±  2%   165.7Ki ± 0%   +2.39% (p=0.002 n=6)
GetMulti/Pebble1000-24            167.4Ki ±  0%   171.4Ki ± 2%   +2.44% (p=0.002 n=6)
GetMulti/Pebble10000-24           240.0Ki ±  0%   243.2Ki ± 0%   +1.36% (p=0.002 n=6)
GetMulti/Pebble100000-24          289.2Ki ±  1%   293.7Ki ± 0%   +1.56% (p=0.002 n=6)
GetMulti/Pebble1000000-24        1123.5Ki ±  2%   855.5Ki ± 5%  -23.86% (p=0.002 n=6)
GetMulti/Pebble10000000-24        46.43Mi ±  1%   33.86Mi ± 2%  -27.07% (p=0.002 n=6)
GetMulti/Pebble100000000-24       613.7Mi ±  2%   444.8Mi ± 1%  -27.52% (p=0.002 n=6)
FindMissing/Pebble10-24           133.7Ki ±  0%   135.7Ki ± 0%   +1.51% (p=0.002 n=6)
FindMissing/Pebble100-24          133.8Ki ±  0%   135.8Ki ± 0%   +1.49% (p=0.002 n=6)
FindMissing/Pebble1000-24         135.0Ki ±  0%   136.9Ki ± 0%   +1.43% (p=0.002 n=6)
FindMissing/Pebble10000-24        136.5Ki ±  0%   138.6Ki ± 0%   +1.52% (p=0.002 n=6)
FindMissing/Pebble100000-24       136.6Ki ±  0%   138.7Ki ± 0%   +1.50% (p=0.002 n=6)
FindMissing/Pebble1000000-24      136.6Ki ±  0%   138.6Ki ± 0%   +1.44% (p=0.002 n=6)
FindMissing/Pebble10000000-24     868.7Ki ±  0%   881.4Ki ± 0%   +1.46% (p=0.002 n=6)
FindMissing/Pebble100000000-24    26.13Mi ±  9%   21.97Mi ± 8%  -15.94% (p=0.002 n=6)
geomean                           229.7Ki         219.9Ki        -4.27%

                               │    current    │               valyala                │
                               │   allocs/op   │  allocs/op   vs base                 │
Set/Pebble10-24                   117.0 ±   0%    117.0 ± 0%        ~ (p=1.000 n=6) ¹
Set/Pebble100-24                  116.0 ±   0%    116.0 ± 0%        ~ (p=1.000 n=6) ¹
Set/Pebble1000-24                 116.0 ±   0%    116.0 ± 0%        ~ (p=1.000 n=6) ¹
Set/Pebble10000-24                143.0 ±   0%    143.0 ± 0%        ~ (p=1.000 n=6) ¹
Set/Pebble100000-24               143.0 ±   0%    143.0 ± 0%        ~ (p=1.000 n=6) ¹
Set/Pebble1000000-24              200.0 ±   0%    215.0 ± 1%   +7.50% (p=0.002 n=6)
Set/Pebble10000000-24            1.071k ±   4%   1.115k ± 6%        ~ (p=0.165 n=6)
Set/Pebble100000000-24           11.77k ±  11%   11.79k ± 7%        ~ (p=0.240 n=6)
Get/Pebble10-24                   85.00 ±   0%    85.00 ± 0%        ~ (p=1.000 n=6) ¹
Get/Pebble100-24                  85.00 ±   0%    85.00 ± 0%        ~ (p=1.000 n=6) ¹
Get/Pebble1000-24                 85.00 ±   0%    85.00 ± 0%        ~ (p=1.000 n=6) ¹
Get/Pebble10000-24                95.00 ±   0%    95.00 ± 0%        ~ (p=1.000 n=6) ¹
Get/Pebble100000-24               103.0 ±   0%    103.0 ± 0%        ~ (p=1.000 n=6) ¹
Get/Pebble1000000-24              136.0 ±   1%    132.0 ± 1%   -2.94% (p=0.002 n=6)
Get/Pebble10000000-24            1.178k ± 548%   1.152k ± 0%   -2.21% (p=0.002 n=6)
Get/Pebble100000000-24           74.28k ±   3%   50.07k ± 4%  -32.60% (p=0.002 n=6)
GetMulti/Pebble10-24             3.364k ±   0%   3.364k ± 0%        ~ (p=0.455 n=6)
GetMulti/Pebble100-24            3.364k ±   0%   3.365k ± 0%   +0.03% (p=0.002 n=6)
GetMulti/Pebble1000-24           3.364k ±   0%   3.365k ± 0%   +0.03% (p=0.002 n=6)
GetMulti/Pebble10000-24          3.864k ±   0%   3.865k ± 0%   +0.03% (p=0.002 n=6)
GetMulti/Pebble100000-24         3.871k ±   0%   3.872k ± 0%   +0.03% (p=0.002 n=6)
GetMulti/Pebble1000000-24        3.887k ±   0%   3.891k ± 0%   +0.10% (p=0.002 n=6)
GetMulti/Pebble10000000-24       57.11k ±   0%   55.89k ± 0%   -2.14% (p=0.002 n=6)
GetMulti/Pebble100000000-24      3.043M ±   5%   2.448M ± 3%  -19.55% (p=0.002 n=6)
FindMissing/Pebble10-24          3.010k ±   0%   3.010k ± 0%        ~ (p=1.000 n=6) ¹
FindMissing/Pebble100-24         3.010k ±   0%   3.010k ± 0%        ~ (p=1.000 n=6) ¹
FindMissing/Pebble1000-24        3.010k ±   0%   3.010k ± 0%        ~ (p=1.000 n=6) ¹
FindMissing/Pebble10000-24       3.010k ±   0%   3.010k ± 0%        ~ (p=1.000 n=6) ¹
FindMissing/Pebble100000-24      3.010k ±   0%   3.010k ± 0%        ~ (p=1.000 n=6) ¹
FindMissing/Pebble1000000-24     3.010k ±   0%   3.010k ± 0%        ~ (p=1.000 n=6) ¹
FindMissing/Pebble10000000-24    18.92k ±   0%   18.92k ± 0%   +0.03% (p=0.002 n=6)
FindMissing/Pebble100000000-24   465.6k ±   8%   392.0k ± 7%  -15.80% (p=0.002 n=6)
geomean                          1.675k          1.636k        -2.29%
¹ all samples are equal
```