### PR TITLE
remove intermediate prom metrics from docs

### DIFF
--- a/server/metrics/generate_docs.py
+++ b/server/metrics/generate_docs.py
@@ -134,6 +134,10 @@ class DocsGenerator(object):
 
     def flush_metric(self):
         metric = self.metric
+        if metric.get("name").endswith("_exported"):
+            # Skip exported metrics
+            self.metric = {}
+            return
         (help_main, *help_details) = metric["help"].split(". ")
         metric_name = "_".join(
             [

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -277,6 +277,16 @@ var (
 		BazelCommand,
 	})
 
+	// #### Examples
+	//
+	// ```promql
+	// # Median invocation duration in the past 5 minutes
+	// histogram_quantile(
+	//   0.5,
+	//   sum(rate(buildbuddy_invocation_duration_usec_bucket[5m])) by (le)
+	// )
+	// ```
+
 	// InvocationDurationUsExported is a simplified version of
 	// InvocationDurationUs which is exported to customers.
 	InvocationDurationUsExported = promauto.NewHistogramVec(prometheus.HistogramOpts{
@@ -289,16 +299,6 @@ var (
 		InvocationStatusLabel,
 		GroupID,
 	})
-
-	// #### Examples
-	//
-	// ```promql
-	// # Median invocation duration in the past 5 minutes
-	// histogram_quantile(
-	//   0.5,
-	//   sum(rate(buildbuddy_invocation_duration_usec_bucket[5m])) by (le)
-	// )
-	// ```
 
 	BuildEventCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
buildbuddy_*_exported metrics are created as intermediate metrics so that we can 
export to cloud customers prometheus metrics. Cloud customers are supposed to 
use exported_buildbuddy_* metrics for monitoring. I think exposing the
intermediate metrics in docs create more confusion.

I plan to write a seperate doc for prometheus exporters for cloud runners.

Also, moved a metric definition after "Example" comment in metrics.go
