### PR TITLE
Normalize repo URL in trends queries

### DIFF
--- a/enterprise/server/invocation_stat_service/BUILD
+++ b/enterprise/server/invocation_stat_service/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//server/util/clickhouse",
         "//server/util/db",
         "//server/util/filter",
+        "//server/util/git",
         "//server/util/log",
         "//server/util/perms",
         "//server/util/query_builder",


### PR DESCRIPTION
Noticed while trying to filter for `github.com/buildbuddy-io/buildbuddy` that the results turn up empty.

**Related issues**: N/A
