### PR TITLE
auditlog: move helper functions to server/auditlog_util

### DIFF
--- a/enterprise/server/auditlog/auditlog.go
+++ b/enterprise/server/auditlog/auditlog.go
@@ -159,7 +159,7 @@ func (l *Logger) Log(ctx context.Context, resource *alpb.ResourceID, action alpb
 	}
 }
 
-func (l *Logger) LogWithGroup(ctx context.Context, groupID string, action alpb.Action, request proto.Message) {
+func (l *Logger) LogForGroup(ctx context.Context, groupID string, action alpb.Action, request proto.Message) {
 	r := &alpb.ResourceID{
 		Type: alpb.ResourceType_GROUP,
 		Id:   groupID,
@@ -167,7 +167,7 @@ func (l *Logger) LogWithGroup(ctx context.Context, groupID string, action alpb.A
 	l.Log(ctx, r, action, request)
 }
 
-func (l *Logger) LogWithInvocation(ctx context.Context, invocationID string, action alpb.Action, request proto.Message) {
+func (l *Logger) LogForInvocation(ctx context.Context, invocationID string, action alpb.Action, request proto.Message) {
 	r := &alpb.ResourceID{
 		Type: alpb.ResourceType_INVOCATION,
 		Id:   invocationID,
@@ -175,7 +175,7 @@ func (l *Logger) LogWithInvocation(ctx context.Context, invocationID string, act
 	l.Log(ctx, r, action, request)
 }
 
-func (l *Logger) LogWithSecret(ctx context.Context, secretName string, action alpb.Action, request proto.Message) {
+func (l *Logger) LogForSecret(ctx context.Context, secretName string, action alpb.Action, request proto.Message) {
 	r := &alpb.ResourceID{
 		Type: alpb.ResourceType_SECRET,
 		Id:   secretName,

--- a/enterprise/server/auditlog/auditlog.go
+++ b/enterprise/server/auditlog/auditlog.go
@@ -41,27 +41,6 @@ type Logger struct {
 	payloadTypes map[protoreflect.MessageDescriptor]protoreflect.FieldDescriptor
 }
 
-func GroupResourceID(id string) *alpb.ResourceID {
-	return &alpb.ResourceID{
-		Type: alpb.ResourceType_GROUP,
-		Id:   id,
-	}
-}
-
-func SecretResourceID(secretName string) *alpb.ResourceID {
-	return &alpb.ResourceID{
-		Type: alpb.ResourceType_SECRET,
-		Id:   secretName,
-	}
-}
-
-func InvocationResourceID(id string) *alpb.ResourceID {
-	return &alpb.ResourceID{
-		Type: alpb.ResourceType_INVOCATION,
-		Id:   id,
-	}
-}
-
 func Register(env environment.Env) error {
 	if !*auditLogsEnabled {
 		return nil
@@ -178,6 +157,30 @@ func (l *Logger) Log(ctx context.Context, resource *alpb.ResourceID, action alpb
 	if err := l.insertLog(ctx, resource, action, request); err != nil {
 		log.Warningf("could not insert audit log: %s", err)
 	}
+}
+
+func (l *Logger) LogWithGroup(ctx context.Context, groupID string, action alpb.Action, request proto.Message) {
+	r := &alpb.ResourceID{
+		Type: alpb.ResourceType_GROUP,
+		Id:   groupID,
+	}
+	l.Log(ctx, r, action, request)
+}
+
+func (l *Logger) LogWithInvocation(ctx context.Context, invocationID string, action alpb.Action, request proto.Message) {
+	r := &alpb.ResourceID{
+		Type: alpb.ResourceType_INVOCATION,
+		Id:   invocationID,
+	}
+	l.Log(ctx, r, action, request)
+}
+
+func (l *Logger) LogWithSecret(ctx context.Context, secretName string, action alpb.Action, request proto.Message) {
+	r := &alpb.ResourceID{
+		Type: alpb.ResourceType_SECRET,
+		Id:   secretName,
+	}
+	l.Log(ctx, r, action, request)
 }
 
 // cleanRequest clears out redundant noise from the requests.

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/buildbuddy_server",
     visibility = ["//visibility:public"],
     deps = [
-        "//enterprise/server/auditlog",
         "//proto:api_key_go_proto",
         "//proto:auditlog_go_proto",
         "//proto:bazel_config_go_proto",

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/auditlog"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/chunkstore"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_handler"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/event_index"
@@ -182,7 +181,7 @@ func (s *BuildBuddyServer) UpdateInvocation(ctx context.Context, req *inpb.Updat
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.Log(ctx, auditlog.InvocationResourceID(req.GetInvocationId()), alpb.Action_UPDATE, req)
+		al.LogWithInvocation(ctx, req.GetInvocationId(), alpb.Action_UPDATE, req)
 	}
 	return &inpb.UpdateInvocationResponse{}, nil
 }
@@ -464,7 +463,7 @@ func (s *BuildBuddyServer) UpdateGroupUsers(ctx context.Context, req *grpb.Updat
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.Log(ctx, auditlog.GroupResourceID(req.GetRequestContext().GetGroupId()), alpb.Action_UPDATE_MEMBERSHIP, req)
+		al.LogWithGroup(ctx, req.GetRequestContext().GetGroupId(), alpb.Action_UPDATE_MEMBERSHIP, req)
 	}
 	return &grpb.UpdateGroupUsersResponse{}, nil
 }
@@ -562,7 +561,7 @@ func (s *BuildBuddyServer) UpdateGroup(ctx context.Context, req *grpb.UpdateGrou
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.Log(ctx, auditlog.GroupResourceID(req.GetRequestContext().GetGroupId()), alpb.Action_UPDATE, req)
+		al.LogWithGroup(ctx, req.GetRequestContext().GetGroupId(), alpb.Action_UPDATE, req)
 	}
 	return &grpb.UpdateGroupResponse{}, nil
 }
@@ -742,7 +741,7 @@ func (s *BuildBuddyServer) CreateImpersonationApiKey(ctx context.Context, req *a
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.Log(ctx, auditlog.GroupResourceID(req.GetRequestContext().GetGroupId()), alpb.Action_CREATE_IMPERSONATION_API_KEY, req)
+		al.LogWithGroup(ctx, req.GetRequestContext().GetGroupId(), alpb.Action_CREATE_IMPERSONATION_API_KEY, req)
 	}
 	return &akpb.CreateImpersonationApiKeyResponse{
 		ApiKey: &akpb.ApiKey{
@@ -1243,7 +1242,7 @@ func (s *BuildBuddyServer) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 			req.WorkflowId = wfs.GetLegacyWorkflowIDForGitRepository(authenticatedUser.GetGroupID(), req.GetTargetRepoUrl())
 		}
 		if al := s.env.GetAuditLogger(); al != nil && req.GetClean() {
-			al.Log(ctx, auditlog.GroupResourceID(req.GetRequestContext().GetGroupId()), alpb.Action_EXECUTE_CLEAN_WORKFLOW, req)
+			al.LogWithGroup(ctx, req.GetRequestContext().GetGroupId(), alpb.Action_EXECUTE_CLEAN_WORKFLOW, req)
 		}
 		return wfs.ExecuteWorkflow(ctx, req)
 	}
@@ -1352,7 +1351,7 @@ func (s *BuildBuddyServer) LinkGitHubRepo(ctx context.Context, req *ghpb.LinkRep
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.Log(ctx, auditlog.GroupResourceID(req.GetRequestContext().GroupId), alpb.Action_LINK_GITHUB_REPO, req)
+		al.LogWithGroup(ctx, req.GetRequestContext().GroupId, alpb.Action_LINK_GITHUB_REPO, req)
 	}
 	return rsp, nil
 }
@@ -1366,7 +1365,7 @@ func (s *BuildBuddyServer) UnlinkGitHubRepo(ctx context.Context, req *ghpb.Unlin
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.Log(ctx, auditlog.GroupResourceID(req.GetRequestContext().GroupId), alpb.Action_UNLINK_GITHUB_REPO, req)
+		al.LogWithGroup(ctx, req.GetRequestContext().GroupId, alpb.Action_UNLINK_GITHUB_REPO, req)
 	}
 	return rsp, nil
 }
@@ -1468,7 +1467,7 @@ func (s *BuildBuddyServer) UpdateSecret(ctx context.Context, req *skpb.UpdateSec
 				action = alpb.Action_CREATE
 			}
 			req.GetSecret().Value = ""
-			al.Log(ctx, auditlog.SecretResourceID(req.GetSecret().GetName()), action, req)
+			al.LogWithSecret(ctx, req.GetSecret().GetName(), action, req)
 		}
 		return rsp, err
 	}
@@ -1744,7 +1743,7 @@ func (s *BuildBuddyServer) SetEncryptionConfig(ctx context.Context, request *enp
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.Log(ctx, auditlog.GroupResourceID(request.GetRequestContext().GetGroupId()), alpb.Action_UPDATE_ENCRYPTION_CONFIG, request)
+		al.LogWithGroup(ctx, request.GetRequestContext().GetGroupId(), alpb.Action_UPDATE_ENCRYPTION_CONFIG, request)
 	}
 	return rsp, nil
 }
@@ -1919,7 +1918,7 @@ func (s *BuildBuddyServer) SetIPRulesConfig(ctx context.Context, request *irpb.S
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.Log(ctx, auditlog.GroupResourceID(request.GetRequestContext().GetGroupId()), alpb.Action_UPDATE_IP_RULES_CONFIG, request)
+		al.LogWithGroup(ctx, request.GetRequestContext().GetGroupId(), alpb.Action_UPDATE_IP_RULES_CONFIG, request)
 	}
 	return rsp, err
 }

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -181,7 +181,7 @@ func (s *BuildBuddyServer) UpdateInvocation(ctx context.Context, req *inpb.Updat
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.LogWithInvocation(ctx, req.GetInvocationId(), alpb.Action_UPDATE, req)
+		al.LogForInvocation(ctx, req.GetInvocationId(), alpb.Action_UPDATE, req)
 	}
 	return &inpb.UpdateInvocationResponse{}, nil
 }
@@ -463,7 +463,7 @@ func (s *BuildBuddyServer) UpdateGroupUsers(ctx context.Context, req *grpb.Updat
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.LogWithGroup(ctx, req.GetRequestContext().GetGroupId(), alpb.Action_UPDATE_MEMBERSHIP, req)
+		al.LogForGroup(ctx, req.GetRequestContext().GetGroupId(), alpb.Action_UPDATE_MEMBERSHIP, req)
 	}
 	return &grpb.UpdateGroupUsersResponse{}, nil
 }
@@ -561,7 +561,7 @@ func (s *BuildBuddyServer) UpdateGroup(ctx context.Context, req *grpb.UpdateGrou
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.LogWithGroup(ctx, req.GetRequestContext().GetGroupId(), alpb.Action_UPDATE, req)
+		al.LogForGroup(ctx, req.GetRequestContext().GetGroupId(), alpb.Action_UPDATE, req)
 	}
 	return &grpb.UpdateGroupResponse{}, nil
 }
@@ -741,7 +741,7 @@ func (s *BuildBuddyServer) CreateImpersonationApiKey(ctx context.Context, req *a
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.LogWithGroup(ctx, req.GetRequestContext().GetGroupId(), alpb.Action_CREATE_IMPERSONATION_API_KEY, req)
+		al.LogForGroup(ctx, req.GetRequestContext().GetGroupId(), alpb.Action_CREATE_IMPERSONATION_API_KEY, req)
 	}
 	return &akpb.CreateImpersonationApiKeyResponse{
 		ApiKey: &akpb.ApiKey{
@@ -1242,7 +1242,7 @@ func (s *BuildBuddyServer) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 			req.WorkflowId = wfs.GetLegacyWorkflowIDForGitRepository(authenticatedUser.GetGroupID(), req.GetTargetRepoUrl())
 		}
 		if al := s.env.GetAuditLogger(); al != nil && req.GetClean() {
-			al.LogWithGroup(ctx, req.GetRequestContext().GetGroupId(), alpb.Action_EXECUTE_CLEAN_WORKFLOW, req)
+			al.LogForGroup(ctx, req.GetRequestContext().GetGroupId(), alpb.Action_EXECUTE_CLEAN_WORKFLOW, req)
 		}
 		return wfs.ExecuteWorkflow(ctx, req)
 	}
@@ -1351,7 +1351,7 @@ func (s *BuildBuddyServer) LinkGitHubRepo(ctx context.Context, req *ghpb.LinkRep
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.LogWithGroup(ctx, req.GetRequestContext().GroupId, alpb.Action_LINK_GITHUB_REPO, req)
+		al.LogForGroup(ctx, req.GetRequestContext().GroupId, alpb.Action_LINK_GITHUB_REPO, req)
 	}
 	return rsp, nil
 }
@@ -1365,7 +1365,7 @@ func (s *BuildBuddyServer) UnlinkGitHubRepo(ctx context.Context, req *ghpb.Unlin
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.LogWithGroup(ctx, req.GetRequestContext().GroupId, alpb.Action_UNLINK_GITHUB_REPO, req)
+		al.LogForGroup(ctx, req.GetRequestContext().GroupId, alpb.Action_UNLINK_GITHUB_REPO, req)
 	}
 	return rsp, nil
 }
@@ -1467,7 +1467,7 @@ func (s *BuildBuddyServer) UpdateSecret(ctx context.Context, req *skpb.UpdateSec
 				action = alpb.Action_CREATE
 			}
 			req.GetSecret().Value = ""
-			al.LogWithSecret(ctx, req.GetSecret().GetName(), action, req)
+			al.LogForSecret(ctx, req.GetSecret().GetName(), action, req)
 		}
 		return rsp, err
 	}
@@ -1743,7 +1743,7 @@ func (s *BuildBuddyServer) SetEncryptionConfig(ctx context.Context, request *enp
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.LogWithGroup(ctx, request.GetRequestContext().GetGroupId(), alpb.Action_UPDATE_ENCRYPTION_CONFIG, request)
+		al.LogForGroup(ctx, request.GetRequestContext().GetGroupId(), alpb.Action_UPDATE_ENCRYPTION_CONFIG, request)
 	}
 	return rsp, nil
 }
@@ -1918,7 +1918,7 @@ func (s *BuildBuddyServer) SetIPRulesConfig(ctx context.Context, request *irpb.S
 		return nil, err
 	}
 	if al := s.env.GetAuditLogger(); al != nil {
-		al.LogWithGroup(ctx, request.GetRequestContext().GetGroupId(), alpb.Action_UPDATE_IP_RULES_CONFIG, request)
+		al.LogForGroup(ctx, request.GetRequestContext().GetGroupId(), alpb.Action_UPDATE_IP_RULES_CONFIG, request)
 	}
 	return rsp, err
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1214,9 +1214,9 @@ type ConfigSecretProvider interface {
 
 type AuditLogger interface {
 	Log(ctx context.Context, resource *alpb.ResourceID, action alpb.Action, request proto.Message)
-	LogWithGroup(ctx context.Context, groupID string, action alpb.Action, request proto.Message)
-	LogWithInvocation(ctx context.Context, invocationID string, action alpb.Action, request proto.Message)
-	LogWithSecret(ctx context.Context, secretName string, action alpb.Action, request proto.Message)
+	LogForGroup(ctx context.Context, groupID string, action alpb.Action, request proto.Message)
+	LogForInvocation(ctx context.Context, invocationID string, action alpb.Action, request proto.Message)
+	LogForSecret(ctx context.Context, secretName string, action alpb.Action, request proto.Message)
 	GetLogs(ctx context.Context, req *alpb.GetAuditLogsRequest) (*alpb.GetAuditLogsResponse, error)
 }
 

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1214,6 +1214,9 @@ type ConfigSecretProvider interface {
 
 type AuditLogger interface {
 	Log(ctx context.Context, resource *alpb.ResourceID, action alpb.Action, request proto.Message)
+	LogWithGroup(ctx context.Context, groupID string, action alpb.Action, request proto.Message)
+	LogWithInvocation(ctx context.Context, invocationID string, action alpb.Action, request proto.Message)
+	LogWithSecret(ctx context.Context, secretName string, action alpb.Action, request proto.Message)
 	GetLogs(ctx context.Context, req *alpb.GetAuditLogsRequest) (*alpb.GetAuditLogsResponse, error)
 }
 

--- a/server/testutil/testauditlog/testauditlog.go
+++ b/server/testutil/testauditlog/testauditlog.go
@@ -48,7 +48,7 @@ func (f *FakeAuditLog) Log(ctx context.Context, resource *alpb.ResourceID, actio
 	})
 }
 
-func (l *FakeAuditLog) LogWithGroup(ctx context.Context, groupID string, action alpb.Action, request proto.Message) {
+func (l *FakeAuditLog) LogForGroup(ctx context.Context, groupID string, action alpb.Action, request proto.Message) {
 	r := &alpb.ResourceID{
 		Type: alpb.ResourceType_GROUP,
 		Id:   groupID,
@@ -56,7 +56,7 @@ func (l *FakeAuditLog) LogWithGroup(ctx context.Context, groupID string, action 
 	l.Log(ctx, r, action, request)
 }
 
-func (l *FakeAuditLog) LogWithInvocation(ctx context.Context, invocationID string, action alpb.Action, request proto.Message) {
+func (l *FakeAuditLog) LogForInvocation(ctx context.Context, invocationID string, action alpb.Action, request proto.Message) {
 	r := &alpb.ResourceID{
 		Type: alpb.ResourceType_INVOCATION,
 		Id:   invocationID,
@@ -64,7 +64,7 @@ func (l *FakeAuditLog) LogWithInvocation(ctx context.Context, invocationID strin
 	l.Log(ctx, r, action, request)
 }
 
-func (l *FakeAuditLog) LogWithSecret(ctx context.Context, secretName string, action alpb.Action, request proto.Message) {
+func (l *FakeAuditLog) LogForSecret(ctx context.Context, secretName string, action alpb.Action, request proto.Message) {
 	r := &alpb.ResourceID{
 		Type: alpb.ResourceType_SECRET,
 		Id:   secretName,

--- a/server/testutil/testauditlog/testauditlog.go
+++ b/server/testutil/testauditlog/testauditlog.go
@@ -48,6 +48,30 @@ func (f *FakeAuditLog) Log(ctx context.Context, resource *alpb.ResourceID, actio
 	})
 }
 
+func (l *FakeAuditLog) LogWithGroup(ctx context.Context, groupID string, action alpb.Action, request proto.Message) {
+	r := &alpb.ResourceID{
+		Type: alpb.ResourceType_GROUP,
+		Id:   groupID,
+	}
+	l.Log(ctx, r, action, request)
+}
+
+func (l *FakeAuditLog) LogWithInvocation(ctx context.Context, invocationID string, action alpb.Action, request proto.Message) {
+	r := &alpb.ResourceID{
+		Type: alpb.ResourceType_INVOCATION,
+		Id:   invocationID,
+	}
+	l.Log(ctx, r, action, request)
+}
+
+func (l *FakeAuditLog) LogWithSecret(ctx context.Context, secretName string, action alpb.Action, request proto.Message) {
+	r := &alpb.ResourceID{
+		Type: alpb.ResourceType_SECRET,
+		Id:   secretName,
+	}
+	l.Log(ctx, r, action, request)
+}
+
 func (f *FakeAuditLog) GetLogs(ctx context.Context, req *alpb.GetAuditLogsRequest) (*alpb.GetAuditLogsResponse, error) {
 	return nil, status.UnimplementedError("not implemented")
 }


### PR DESCRIPTION
This allows us to build //server/buildbuddy_server with one fewer
//enterprise dependency.
