### PR TITLE
[DNM] Test memory dirtying, more memory

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -575,7 +575,7 @@ func TestDirtyMemoryCDC(t *testing.T) {
 				ActionWorkingDirectory: workDir,
 				VMConfiguration: &fcpb.VMConfiguration{
 					NumCpus:            6,
-					MemSizeMb:          8000,
+					MemSizeMb:          10_000,
 					EnableNetworking:   true,
 					ScratchDiskSizeMb:  20_000,
 					KernelVersion:      cfg.KernelVersion,


### PR DESCRIPTION
For cache disk more memory (10_000MB)
Original cache size with snapshot: 12254MB
Cached "memory" in 32.103048409s - 5460 MB (1398 chunks) dirty
New cache size with snapshot: 17481 MB
Difference in cache size: 5226
