### PR TITLE
gcplink: move exported funcs to GCPService interface

### DIFF
--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -37,6 +37,7 @@ go_library(
         "//enterprise/server/crypter_service",
         "//enterprise/server/execution_search_service",
         "//enterprise/server/execution_service",
+        "//enterprise/server/gcplink",
         "//enterprise/server/githubapp",
         "//enterprise/server/hostedrunner",
         "//enterprise/server/invocation_search_service",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/crypter_service"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/execution_search_service"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/execution_service"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/gcplink"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/githubapp"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/hostedrunner"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/invocation_search_service"
@@ -86,6 +87,7 @@ func convertToProdOrDie(ctx context.Context, env *real_environment.RealEnv) {
 		}
 		log.Warningf("No authentication will be configured: %s", err)
 	}
+	gcplink.Register(env)
 
 	userDB, err := userdb.NewUserDB(env, env.GetDBHandle())
 	if err != nil {

--- a/enterprise/server/oidc/oidc.go
+++ b/enterprise/server/oidc/oidc.go
@@ -873,7 +873,7 @@ func (a *OpenIDAuthenticator) Auth(w http.ResponseWriter, r *http.Request) error
 		if !ok {
 			return status.PermissionDeniedError("Refresh token not present in auth response")
 		}
-		return gcplink.LinkForGroup(a.env, w, r, refreshToken)
+		return a.env.GetGCPService().LinkForGroup(w, r, refreshToken)
 	}
 
 	guid, err := uuid.NewRandom()

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//enterprise/server/auditlog",
-        "//enterprise/server/gcplink",
         "//proto:api_key_go_proto",
         "//proto:auditlog_go_proto",
         "//proto:bazel_config_go_proto",

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/auditlog"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/gcplink"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/chunkstore"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/build_event_handler"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/event_index"
@@ -2014,5 +2013,10 @@ func (s *BuildBuddyServer) DeleteIPRule(ctx context.Context, request *irpb.Delet
 }
 
 func (s *BuildBuddyServer) GetGCPProject(ctx context.Context, request *gcpb.GetGCPProjectRequest) (*gcpb.GetGCPProjectResponse, error) {
-	return gcplink.GetGCPProject(s.env, ctx, request)
+	gcpService := s.env.GetGCPService()
+	if gcpService == nil {
+		return nil, status.FailedPreconditionError("GCP service not enabled")
+	}
+
+	return gcpService.GetGCPProject(ctx, request)
 }

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -167,4 +167,6 @@ type Env interface {
 	SetImageCacheAuthenticator(interfaces.ImageCacheAuthenticator)
 	GetServerNotificationService() interfaces.ServerNotificationService
 	SetServerNotificationService(service interfaces.ServerNotificationService)
+	GetGCPService() interfaces.GCPService
+	SetGCPService(service interfaces.GCPService)
 }

--- a/server/interfaces/BUILD
+++ b/server/interfaces/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//proto:buildbuddy_service_go_proto",
         "//proto:encryption_go_proto",
         "//proto:execution_stats_go_proto",
+        "//proto:gcp_go_proto",
         "//proto:github_go_proto",
         "//proto:group_go_proto",
         "//proto:health_go_proto",

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -23,6 +23,7 @@ import (
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
 	enpb "github.com/buildbuddy-io/buildbuddy/proto/encryption"
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
+	gcpb "github.com/buildbuddy-io/buildbuddy/proto/gcp"
 	ghpb "github.com/buildbuddy-io/buildbuddy/proto/github"
 	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
 	hlpb "github.com/buildbuddy-io/buildbuddy/proto/health"
@@ -572,6 +573,11 @@ type GitHubApp interface {
 
 type RunnerService interface {
 	Run(ctx context.Context, req *rnpb.RunRequest) (*rnpb.RunResponse, error)
+}
+
+type GCPService interface {
+	LinkForGroup(w http.ResponseWriter, r *http.Request, refreshToken string) error
+	GetGCPProject(ctx context.Context, request *gcpb.GetGCPProjectRequest) (*gcpb.GetGCPProjectResponse, error)
 }
 
 type GitProviders []GitProvider

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -114,6 +114,7 @@ type RealEnv struct {
 	serverIdentityService            interfaces.ClientIdentityService
 	imageCacheAuthenticator          interfaces.ImageCacheAuthenticator
 	serverNotificationService        interfaces.ServerNotificationService
+	gcpService                       interfaces.GCPService
 }
 
 // NewRealEnv returns an environment for use in servers.
@@ -667,4 +668,12 @@ func (r *RealEnv) GetServerNotificationService() interfaces.ServerNotificationSe
 
 func (r *RealEnv) SetServerNotificationService(service interfaces.ServerNotificationService) {
 	r.serverNotificationService = service
+}
+
+func (r *RealEnv) GetGCPService() interfaces.GCPService {
+	return r.gcpService
+}
+
+func (r *RealEnv) SetGCPService(service interfaces.GCPService) {
+	r.gcpService = service
 }


### PR DESCRIPTION
Introduce a GCPService interface to help decouple GCPLink logic.
This helps us remove a direct link between buildbuddy_server and
//enterprise package.
