### PR TITLE
[DNM] Test memory dirtying, force garbage collection

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -515,6 +515,8 @@ func TestDirtyMemoryCDC(t *testing.T) {
 		# See https://github.com/bazelbuild/bazelisk/issues/220
 		echo "USE_BAZEL_VERSION=6.4.0rc1" > .bazeliskrc
 		bazelisk build //...
+		# Force garbage collection in jvm
+		jcmd $(pgrep java) GC.run
 `
 	commands = append(commands, CommandTC{command: bazelCommand, name: "bazel build"})
 


### PR DESCRIPTION
**Did not seem to have any effect in decreasing memory dirtied**

For cache disk after force gc:
Original cache size with snapshot: 12078MB
Cached "memory" in 30.003659814s - 4609 MB (1180 chunks) dirty
New cache size with snapshot: 16305 MB
Difference in cache size: 4226
