### PR TITLE
[DNM] Test memory dirtying, drop kernel page cache

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -515,6 +515,8 @@ func TestDirtyMemoryCDC(t *testing.T) {
 		# See https://github.com/bazelbuild/bazelisk/issues/220
 		echo "USE_BAZEL_VERSION=6.4.0rc1" > .bazeliskrc
 		bazelisk build //...
+		# Drop kernel page cache and free slab objects
+		echo 3 > /proc/sys/vm/drop_caches
 `
 	commands = append(commands, CommandTC{command: bazelCommand, name: "bazel build"})
 


### PR DESCRIPTION
**Did not seem to have any effect in decreasing memory dirtied**

For cache disk after drop page cache:
Original cache size with snapshot: 12297MB
Cached "memory" in 29.042633882s - 4394 MB (1125 chunks) dirty
New cache size with snapshot: 16477 MB
Difference in cache size: 4180
