### PR TITLE
[DNM] Test memory dirtying, COW chunk size

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -83,6 +83,8 @@ var workspaceDiskSlackSpaceMB = flag.Int64("executor.firecracker_workspace_disk_
 var healthCheckInterval = flag.Duration("executor.firecracker_health_check_interval", 10*time.Second, "How often to run VM health checks while tasks are executing.")
 var healthCheckTimeout = flag.Duration("executor.firecracker_health_check_timeout", 30*time.Second, "Timeout for VM health check requests.")
 
+var cowChunkSizePages = flag.Int64("executor.firecracker_cow_chunk_size_pages", 1000, "Size of copy on write chunks, reported in pages.")
+
 //go:embed guest_api_hash.sha256
 var GuestAPIHash string
 
@@ -160,9 +162,6 @@ const (
 	// minScratchDiskSizeBytes is the minimum size needed for the scratch disk.
 	// This is needed because the init binary needs some space to copy files around.
 	minScratchDiskSizeBytes = 64e6
-
-	// Chunk size to use when creating COW images from files.
-	cowChunkSizeInPages = 1000
 
 	// The containerfs drive ID.
 	containerFSName  = "containerfs.ext4"
@@ -1140,7 +1139,7 @@ func (c *FirecrackerContainer) convertToCOW(ctx context.Context, filePath, chunk
 }
 
 func cowChunkSizeBytes() int64 {
-	return int64(os.Getpagesize() * cowChunkSizeInPages)
+	return int64(os.Getpagesize()) * *cowChunkSizePages
 }
 
 // hotSwapWorkspace unmounts the workspace drive from a running firecracker


### PR DESCRIPTION
**Results: Decreasing chunk size reduces the amount of data dirtied, but negatively affects performance**

_Chunk size is in pages. 1 page = 4096B on my machine_

(chunk size = 125) Bazel build on a clean runner took 2m11.793702789s.
(chunk size=125) Bazel build (0% locally cached) took 26.894143164s. 100% artifacts fetched remotely.
Cached "memory" in 25.262725244s - 3890 MB (7968 chunks) dirty

(chunk size = 250) Bazel build on a clean runner took 2m11.577063289s.
(chunk size=250) Bazel build (0% locally cached) took 23.78735217s. 100% artifacts fetched remotely.
Cached "memory" in 32.136590517s - 4827 MB (4943 chunks) dirty

(chunk size = 500) Bazel build on a clean runner took 2m11.419227725s.
(chunk size=500) Bazel build (0% locally cached) took 20.929379663s. 100% artifacts fetched remotely.
Cached "memory" in 34.246755647s - 5144 MB (2634 chunks) dirty


(chunk size = 1000) Bazel build on a clean runner took 2m11.388927703s.
(chunk size=1000) Bazel build (0% locally cached) took 20.396638906s. 100% artifacts fetched remotely.
Cached "memory" in 44.300206772s - 5257 MB (1346 chunks) dirty

**More disk size breakdowns**

For cache disk with COW chunk size 512KB:
Original cache size with snapshot: 11827MB
Cached "memory" in 21.247242587s - 3486 MB (7140 chunks) dirty
New cache size with snapshot: 14955 MB
Difference in cache size: 3127
Cached "memory" in 13.702383962s - 0 MB (0 chunks) dirty

For cache disk with COW chunk size 1024KB:
Original cache size with snapshot: 11773MB
Cached "memory" in 16.229294966s - 3774 MB (3865 chunks) dirty
New cache size with snapshot: 15024 MB
Difference in cache size: 3250
Cached "memory" in 10.694527703s - 0 MB (0 chunks) dirty

For cache disk with COW chunk size 2MB:
Original cache size with snapshot: 12104MB
Cached "memory" in 17.725874328s - 4357 MB (2231 chunks) dirty
New cache size with snapshot: 15848 MB
Difference in cache size: 3744
Cached "memory" in 9.657158764s - 0 MB (0 chunks) dirty

For cache disk with COW chunk size 4MB:
Original cache size with snapshot: 12168MB
Cached "memory" in 33.835172608s - 4742 MB (1214 chunks) dirty
New cache size with snapshot: 16602 MB
Difference in cache size: 4433
