### PR TITLE
Fix and re-enable `init-dockerd` in workflow tasks

### DIFF
--- a/enterprise/dockerfiles/ci_runner_image/Dockerfile
+++ b/enterprise/dockerfiles/ci_runner_image/Dockerfile
@@ -40,7 +40,8 @@ RUN apt-get update && \
 
 # Provision a non-root user named "buildbuddy" and set up passwordless sudo.
 # Non-root users are needed for some bazel toolchains, such as hermetic python.
+# Also add them to the docker group so they can use docker.
 RUN apt-get update && apt-get install -y sudo && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN useradd --create-home buildbuddy --groups sudo && \
+RUN useradd --create-home buildbuddy --groups sudo,docker && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/enterprise/dockerfiles/rbe-ubuntu20-04-workflows/Dockerfile
+++ b/enterprise/dockerfiles/rbe-ubuntu20-04-workflows/Dockerfile
@@ -10,7 +10,8 @@ RUN USE_BAZEL_VERSION=6.0.0 bazelisk version
 
 # Provision a non-root user named "buildbuddy" and set up passwordless sudo.
 # Non-root users are needed for some bazel toolchains, such as hermetic python.
+# Also add them to the docker group so they can use docker.
 RUN apt-get update && apt-get install -y sudo && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN useradd --create-home buildbuddy --groups sudo && \
+RUN useradd --create-home buildbuddy --groups sudo,docker && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -39,8 +39,8 @@ const (
 	Ubuntu16_04Image = "gcr.io/flame-public/executor-docker-default:enterprise-v1.6.0"
 	Ubuntu20_04Image = "gcr.io/flame-public/rbe-ubuntu20-04@sha256:036ae8c90876fa22da9ace6f8218e614f4cd500a154fc162973fff691e72d28e"
 
-	Ubuntu18_04WorkflowsImage = "gcr.io/flame-public/buildbuddy-ci-runner@sha256:6381c06bee2910e66903784b4a90cb9ff08823686da46cf6874902c9f8428e69"
-	Ubuntu20_04WorkflowsImage = "gcr.io/flame-public/rbe-ubuntu20-04-workflows@sha256:eb81189af1cec44b5348751f75ec7aea516d0de675b8461235f4cc4e553a34b5"
+	Ubuntu18_04WorkflowsImage = "gcr.io/flame-public/buildbuddy-ci-runner@sha256:8cf614fc4695789bea8321446402e7d6f84f6be09b8d39ec93caa508fa3e3cfc"
+	Ubuntu20_04WorkflowsImage = "gcr.io/flame-public/rbe-ubuntu20-04-workflows@sha256:271e5e3704d861159c75b8dd6713dbe5a12272ec8ee73d17f89ed7be8026553f"
 
 	// overrideHeaderPrefix is a prefix used to override platform props via
 	// remote headers. The property name immediately follows the prefix in the

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1200,7 +1200,14 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 			},
 		},
 	}
-	if !isSharedFirecrackerWorkflow {
+	if isSharedFirecrackerWorkflow {
+		// For firecracker workflows, init dockerd in case local actions or
+		// setup scripts want to use it.
+		cmd.Platform.Properties = append(cmd.Platform.Properties, &repb.Platform_Property{
+			Name:  "init-dockerd",
+			Value: "true",
+		})
+	} else {
 		// For docker/podman workflows, run with `--init` so that the bazel
 		// process can be reaped.
 		cmd.Platform.Properties = append(cmd.Platform.Properties, &repb.Platform_Property{


### PR DESCRIPTION
There were two issues:
* The `buildbuddy` user was not part of the `docker` group (fixed in this PR)
* Supplementary group memberships (such as `docker`) were not taking effect when running commands - fixed in https://github.com/buildbuddy-io/buildbuddy/pull/5273/files

**Related issues**: N/A
