### PR TITLE
Patch out panic from gRPC Drain when handling grpc-over-http requests.

### DIFF
--- a/buildpatches/org_golang_google_grpc_remove_drain_panic.patch
+++ b/buildpatches/org_golang_google_grpc_remove_drain_panic.patch
@@ -1,0 +1,12 @@
+diff --git a/internal/transport/handler_server.go b/internal/transport/handler_server.go
+index 17f7a21b..93523d73 100644
+--- a/internal/transport/handler_server.go
++++ b/internal/transport/handler_server.go
+@@ -457,7 +457,6 @@ func (ht *serverHandlerTransport) IncrMsgSent() {}
+ func (ht *serverHandlerTransport) IncrMsgRecv() {}
+ 
+ func (ht *serverHandlerTransport) Drain(debugData string) {
+-	panic("Drain() is not implemented")
+ }
+ 
+ // mapRecvMsgError returns the non-nil err into the appropriate

--- a/deps.bzl
+++ b/deps.bzl
@@ -6762,6 +6762,15 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "org_golang_google_grpc",
         build_file_proto_mode = "disable",
+        # Remove panic() from serverHandlerTransport.Drain
+        # gRPC GracefulStop stops accepting new requests and lets any existing
+        # requests finish. For "grpc-over-http" requests, gRPC does not control
+        # the connection lifetime so they choose to panic in Drain if there are
+        # inflight "grpc-over-http" requests. Since we also shutdown the HTTP
+        # server gracefully, it's safe for us to allow gRPC to wait for all
+        # ongoing requests to finish.
+        patches = ["@{}//buildpatches:org_golang_google_grpc_remove_drain_panic.patch".format(workspace_name)],
+        patch_args = ["-p1"],
         importpath = "google.golang.org/grpc",
         sum = "h1:Z5Iec2pjwb+LEOqzpB2MR12/eKFhDPhuqW91O+4bwUk=",
         version = "v1.59.0",

--- a/deps.bzl
+++ b/deps.bzl
@@ -6762,6 +6762,8 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "org_golang_google_grpc",
         build_file_proto_mode = "disable",
+        importpath = "google.golang.org/grpc",
+        patch_args = ["-p1"],
         # Remove panic() from serverHandlerTransport.Drain
         # gRPC GracefulStop stops accepting new requests and lets any existing
         # requests finish. For "grpc-over-http" requests, gRPC does not control
@@ -6770,8 +6772,6 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
         # server gracefully, it's safe for us to allow gRPC to wait for all
         # ongoing requests to finish.
         patches = ["@{}//buildpatches:org_golang_google_grpc_remove_drain_panic.patch".format(workspace_name)],
-        patch_args = ["-p1"],
-        importpath = "google.golang.org/grpc",
         sum = "h1:Z5Iec2pjwb+LEOqzpB2MR12/eKFhDPhuqW91O+4bwUk=",
         version = "v1.59.0",
     )


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
