### PR TITLE
Handle already-existing symlinks without error

### DIFF
--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -844,6 +844,16 @@ func DirMapFromTree(tree *repb.Tree, digestFunction repb.DigestFunction_Value) (
 	return rootDigest, dirMap, nil
 }
 
+// To be used when a symlink exists and an Exists error has been returned, but
+// the caller wants to ensure the *correct* file has been linked.
+func checkSymlink(oldName, newName string) bool {
+       pointee, err := os.Readlink(newName)
+       if err != nil {
+               return false
+       }
+       return pointee == oldName
+}
+
 type DownloadTreeOpts struct {
 	// NonrootWritable specifies whether directories should be made writable
 	// by users other than root. Does not affect file permissions.
@@ -929,6 +939,9 @@ func DownloadTree(ctx context.Context, env environment.Env, instanceName string,
 			nodeAbsPath := filepath.Join(parentDir, symlinkNode.GetName())
 			if err := os.Symlink(symlinkNode.GetTarget(), nodeAbsPath); err != nil {
 				if os.IsExist(err) {
+					if checkSymlink(symlinkNode.GetTarget(), nodeAbsPath) {
+						continue
+					}
 					// Attempt to blow away the existing
 					// file(s) at that location and re-link.
 					if err := os.RemoveAll(nodeAbsPath); err != nil {

--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -847,11 +847,11 @@ func DirMapFromTree(tree *repb.Tree, digestFunction repb.DigestFunction_Value) (
 // To be used when a symlink exists and an Exists error has been returned, but
 // the caller wants to ensure the *correct* file has been linked.
 func checkSymlink(oldName, newName string) bool {
-       pointee, err := os.Readlink(newName)
-       if err != nil {
-               return false
-       }
-       return pointee == oldName
+	pointee, err := os.Readlink(newName)
+	if err != nil {
+		return false
+	}
+	return pointee == oldName
 }
 
 type DownloadTreeOpts struct {

--- a/enterprise/server/remote_execution/dirtools/dirtools_test.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools_test.go
@@ -722,6 +722,180 @@ func TestDownloadTreeEmptyDigest(t *testing.T) {
 	assert.FileExists(t, filepath.Join(tmpDir, "file_notempty.txt"), "file_notempty.txt should exist")
 }
 
+func TestDownloadTreeExistingCorrectSymlink(t *testing.T) {
+	env, ctx := testEnv(t)
+	tmpDir := testfs.MakeTempDir(t)
+	instanceName := "foo"
+	fileADigest := setFile(t, env, ctx, instanceName, "mytestdataA")
+	fileBDigest := setFile(t, env, ctx, instanceName, "mytestdataB")
+
+	childDir := &repb.Directory{
+		Files: []*repb.FileNode{
+			&repb.FileNode{
+				Name:   "fileA.txt",
+				Digest: fileADigest,
+			},
+		},
+		Symlinks: []*repb.SymlinkNode{
+			&repb.SymlinkNode{
+				Name:   "fileA.symlink",
+				Target: "./fileA.txt",
+			},
+		},
+	}
+
+	childDigest, err := digest.ComputeForMessage(childDir, repb.DigestFunction_SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	directory := &repb.Tree{
+		Root: &repb.Directory{
+			Files: []*repb.FileNode{
+				&repb.FileNode{
+					Name:   "fileB.txt",
+					Digest: fileBDigest,
+				},
+			},
+			Directories: []*repb.DirectoryNode{
+				&repb.DirectoryNode{
+					Name:   "my-directory",
+					Digest: childDigest,
+				},
+			},
+		},
+		Children: []*repb.Directory{
+			childDir,
+		},
+	}
+	info, err := dirtools.DownloadTree(ctx, env, "", repb.DigestFunction_SHA256, directory, tmpDir, &dirtools.DownloadTreeOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, info, "transfers are not nil")
+	assert.Equal(t, int64(2), info.FileCount, "two files were transferred")
+	assert.DirExists(t, filepath.Join(tmpDir, "my-directory"), "my-directory should exist")
+	assert.FileExists(t, filepath.Join(tmpDir, "my-directory/fileA.txt"), "fileA.txt should exist")
+	assert.FileExists(t, filepath.Join(tmpDir, "fileB.txt"), "fileB.txt should exist")
+	target, err := os.Readlink(filepath.Join(tmpDir, "my-directory/fileA.symlink"))
+	assert.NoError(t, err, "should be able to read symlink target")
+	assert.Equal(t, "./fileA.txt", target)
+	targetContents, err := os.ReadFile(filepath.Join(tmpDir, "my-directory/fileA.symlink"))
+	assert.NoError(t, err)
+	assert.Equal(t, "mytestdataA", string(targetContents), "symlinked file contents should match target file")
+
+	info, err = dirtools.DownloadTree(ctx, env, "", repb.DigestFunction_SHA256, directory, tmpDir, &dirtools.DownloadTreeOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, info, "transfers are not nil")
+	assert.Equal(t, int64(0), info.FileCount, "zero files were transferred")
+	assert.DirExists(t, filepath.Join(tmpDir, "my-directory"), "my-directory should exist")
+	assert.FileExists(t, filepath.Join(tmpDir, "my-directory/fileA.txt"), "fileA.txt should exist")
+	assert.FileExists(t, filepath.Join(tmpDir, "fileB.txt"), "fileB.txt should exist")
+}
+
+func TestDownloadTreeExistingIncorrectSymlink(t *testing.T) {
+	env, ctx := testEnv(t)
+	tmpDir := testfs.MakeTempDir(t)
+	instanceName := "foo"
+	fileADigest := setFile(t, env, ctx, instanceName, "mytestdataA")
+	fileBDigest := setFile(t, env, ctx, instanceName, "mytestdataB")
+
+	childDir := &repb.Directory{
+		Files: []*repb.FileNode{
+			&repb.FileNode{
+				Name:   "fileA.txt",
+				Digest: fileADigest,
+			},
+		},
+		Symlinks: []*repb.SymlinkNode{
+			&repb.SymlinkNode{
+				Name:   "fileA.symlink",
+				Target: "./fileA.txt",
+			},
+		},
+	}
+
+	childDigest, err := digest.ComputeForMessage(childDir, repb.DigestFunction_SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	directory := &repb.Tree{
+		Root: &repb.Directory{
+			Files: []*repb.FileNode{
+				&repb.FileNode{
+					Name:   "fileB.txt",
+					Digest: fileBDigest,
+				},
+			},
+			Directories: []*repb.DirectoryNode{
+				&repb.DirectoryNode{
+					Name:   "my-directory",
+					Digest: childDigest,
+				},
+			},
+		},
+		Children: []*repb.Directory{
+			childDir,
+		},
+	}
+	_, err = dirtools.DownloadTree(ctx, env, "", repb.DigestFunction_SHA256, directory, tmpDir, &dirtools.DownloadTreeOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	childDir = &repb.Directory{
+		Files: []*repb.FileNode{
+			&repb.FileNode{
+				Name:   "fileB.txt",
+				Digest: fileBDigest,
+			},
+		},
+		Symlinks: []*repb.SymlinkNode{
+			&repb.SymlinkNode{
+				Name:   "fileA.symlink",
+				Target: "./fileB.txt",
+			},
+		},
+	}
+
+	childDigest, err = digest.ComputeForMessage(childDir, repb.DigestFunction_SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	directory = &repb.Tree{
+		Root: &repb.Directory{
+			Files: []*repb.FileNode{
+				&repb.FileNode{
+					Name:   "fileB.txt",
+					Digest: fileBDigest,
+				},
+			},
+			Directories: []*repb.DirectoryNode{
+				&repb.DirectoryNode{
+					Name:   "my-directory",
+					Digest: childDigest,
+				},
+			},
+		},
+		Children: []*repb.Directory{
+			childDir,
+		},
+	}
+	info, err := dirtools.DownloadTree(ctx, env, "", repb.DigestFunction_SHA256, directory, tmpDir, &dirtools.DownloadTreeOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, info, "transfers are not nil")
+	assert.Equal(t, int64(0), info.FileCount, "zero files were transferred")
+	assert.DirExists(t, filepath.Join(tmpDir, "my-directory"), "my-directory should exist")
+	assert.FileExists(t, filepath.Join(tmpDir, "my-directory/fileA.txt"), "fileA.txt should exist")
+	assert.FileExists(t, filepath.Join(tmpDir, "fileB.txt"), "fileB.txt should exist")
+}
+
 func testEnv(t *testing.T) (*testenv.TestEnv, context.Context) {
 	env := testenv.GetTestEnv(t)
 	ctx := context.Background()


### PR DESCRIPTION
If a symlink exists with the correct target; use it, and if the target is incorrect, attempt to remove it and recreate.
