### PR TITLE
Report usage stats from the whole VM, not just the exec'd process tree

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -102,7 +102,7 @@ const (
 	//
 	// NOTE: this is part of the snapshot cache key, so bumping this version
 	// will make existing cached snapshots unusable.
-	GuestAPIVersion = "2"
+	GuestAPIVersion = "3"
 
 	// How long to wait for the VMM to listen on the firecracker socket.
 	firecrackerSocketWaitTimeout = 3 * time.Second

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -128,8 +128,8 @@ func TestGuestAPIVersion(t *testing.T) {
 	// Note that if you go with option 1, ALL VM snapshots will be invalidated
 	// which will negatively affect customer experience. Be careful!
 	const (
-		expectedHash    = "cb6b9cd2728d6d73250f2af99ed96d9714822bee5c3110a8b146a8a3017690d4"
-		expectedVersion = "2"
+		expectedHash    = "ce69b4a932a47c8763a4390171eee6fdb6191920eab50fafe29a72f7d496ce38"
+		expectedVersion = "3"
 	)
 	assert.Equal(t, expectedHash, firecracker.GuestAPIHash)
 	assert.Equal(t, expectedVersion, firecracker.GuestAPIVersion)

--- a/enterprise/server/vmexec/BUILD
+++ b/enterprise/server/vmexec/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//server/util/log",
         "//server/util/status",
         "@com_github_elastic_gosigar//:gosigar",
+        "@com_github_tklauser_go_sysconf//:go-sysconf",
         "@com_github_vishvananda_netlink//:netlink",
         "@org_golang_google_grpc//status",
         "@org_golang_x_sys//unix",

--- a/go.mod
+++ b/go.mod
@@ -107,6 +107,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/tebeka/selenium v0.9.9
 	github.com/throttled/throttled/v2 v2.12.0
+	github.com/tklauser/go-sysconf v0.3.11
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	github.com/zeebo/blake3 v0.2.3
 	go.opentelemetry.io/contrib/detectors/gcp v1.20.0
@@ -302,7 +303,6 @@ require (
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/skeema/knownhosts v1.1.1 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
-	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/valyala/fastrand v1.1.0 // indirect
 	github.com/valyala/histogram v1.2.0 // indirect


### PR DESCRIPTION
This PR makes sure we report VM CPU / memory usage, not just the usage from the top level task. In particular, make sure we report CPU / memory from docker-in-firecracker containers.

This will make it easier to diagnose OOMs, and also let us gather more accurate usage numbers.

Verified using the vmstart tool:
* Added some temp logging in `vmexec` to print the current cpu/memory
* To verify CPU usage, ran `while true; do : ; done` and observed that CPU was steadily increasing by roughly 1000 CPU-ms per second.
* To verify memory usage, ran `VAL=$(cat /dev/random | head -c 500000); while true; do STR="$STR:$VAL" ; done` and verified that mem usage was steadily increasing by several MB per second.

**Related issues**: N/A
