### PR TITLE
Do not copy metadata proto when extracting headers

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -247,11 +247,8 @@ func (c *Cache) recvHeartbeatCallback(ctx context.Context, peer string) {
 	pi := &peerInfo{
 		lastContact: time.Now(),
 	}
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		zoneVals := md.Get(resources.ZoneHeader)
-		if len(zoneVals) == 1 {
-			pi.zone = zoneVals[0]
-		}
+	if zoneVals := metadata.ValueFromIncomingContext(ctx, resources.ZoneHeader); len(zoneVals) == 1 {
+		pi.zone = zoneVals[0]
 	}
 	c.heartbeatMu.Lock()
 	c.peerMetadata[peer] = pi

--- a/server/remote_cache/digest/digest.go
+++ b/server/remote_cache/digest/digest.go
@@ -481,12 +481,9 @@ func blobTypeSegment(compressor repb.Compressor_Value) string {
 }
 
 func IsCacheDebuggingEnabled(ctx context.Context) bool {
-	if grpcMD, ok := gmetadata.FromIncomingContext(ctx); ok {
-		debugCacheHitsValue := grpcMD["debug-cache-hits"]
-		if len(debugCacheHitsValue) == 1 {
-			if strings.ToLower(strings.TrimSpace(debugCacheHitsValue[0])) == "true" {
-				return true
-			}
+	if hdrs := gmetadata.ValueFromIncomingContext(ctx, "debug-cache-hits"); len(hdrs) > 0 {
+		if strings.ToLower(strings.TrimSpace(hdrs[0])) == "true" {
+			return true
 		}
 	}
 	return false

--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -103,17 +103,12 @@ func addRequestIdToContext(ctx context.Context) context.Context {
 }
 
 func addClientIPToContext(ctx context.Context) context.Context {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return ctx
-	}
-
-	hdrs := md.Get("X-Forwarded-For")
+	hdrs := metadata.ValueFromIncomingContext(ctx, "X-Forwarded-For")
 	if len(hdrs) == 0 {
 		return ctx
 	}
 
-	ctx, ok = clientip.SetFromXForwardedForHeader(ctx, hdrs[0])
+	ctx, ok := clientip.SetFromXForwardedForHeader(ctx, hdrs[0])
 	if ok {
 		return ctx
 	}
@@ -131,11 +126,7 @@ func addClientIPToContext(ctx context.Context) context.Context {
 }
 
 func addSubdomainToContext(ctx context.Context) context.Context {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return ctx
-	}
-	hdrs := md.Get(":authority")
+	hdrs := metadata.ValueFromIncomingContext(ctx, ":authority")
 	if len(hdrs) == 0 {
 		return ctx
 	}
@@ -143,11 +134,9 @@ func addSubdomainToContext(ctx context.Context) context.Context {
 }
 
 func copyHeadersToContext(ctx context.Context) context.Context {
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		for headerName, contextKey := range headerContextKeys {
-			if headerVals := md.Get(headerName); len(headerVals) > 0 {
-				ctx = context.WithValue(ctx, contextKey, headerVals[0])
-			}
+	for headerName, contextKey := range headerContextKeys {
+		if hdrs := metadata.ValueFromIncomingContext(ctx, headerName); len(hdrs) > 0 {
+			ctx = context.WithValue(ctx, contextKey, hdrs[0])
 		}
 	}
 

--- a/server/util/tracing/tracing.go
+++ b/server/util/tracing/tracing.go
@@ -83,13 +83,8 @@ func (s *fractionSampler) checkForcedTrace(parameters sdktrace.SamplingParameter
 	if s.ignoreForcedTracingHeader {
 		return false
 	}
-	md, ok := metadata.FromIncomingContext(parameters.ParentContext)
-	if !ok {
-		// Not an incoming gRPC request
-		return false
-	}
-	hdrs, ok := md[traceHeader]
-	forced := ok && len(hdrs) > 0 && hdrs[0] == forceTraceHeaderValue
+	hdrs := metadata.ValueFromIncomingContext(parameters.ParentContext, traceHeader)
+	forced := len(hdrs) > 0 && hdrs[0] == forceTraceHeaderValue
 	return forced
 }
 


### PR DESCRIPTION
Reduce allocations (~6%) by extracting just the value we need from grpc metadata, rather than copying all of it.

<img width="1512" alt="image" src="https://github.com/buildbuddy-io/buildbuddy/assets/141737/b7619cef-758e-40c0-9efc-329223f69824">
