### PR TITLE
Revert task_leaser debug logs

### DIFF
--- a/enterprise/server/scheduling/task_leaser/task_leaser.go
+++ b/enterprise/server/scheduling/task_leaser/task_leaser.go
@@ -61,9 +61,6 @@ func (t *TaskLeaser) sendRequest(req *scpb.LeaseTaskRequest) (*scpb.LeaseTaskRes
 }
 
 func (t *TaskLeaser) pingServer(ctx context.Context) (b []byte, err error) {
-	log.CtxDebugf(ctx, "Pinging scheduler")
-	defer func() { log.CtxDebugf(ctx, "Ping done, err=%v", err) }()
-
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	req := &scpb.LeaseTaskRequest{


### PR DESCRIPTION
These add a lot of noise, and the logs being added in https://github.com/buildbuddy-io/buildbuddy/pull/5284 are probably more actionable.

**Related issues**: N/A
