### PR TITLE
podman: determine cgroup paths automatically

### DIFF
--- a/enterprise/server/remote_execution/cgroup/BUILD
+++ b/enterprise/server/remote_execution/cgroup/BUILD
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "cgroup",
+    srcs = ["cgroup.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/cgroup",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/util/log",
+        "//server/util/status",
+    ],
+)
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/remote_execution/cgroup/cgroup.go
+++ b/enterprise/server/remote_execution/cgroup/cgroup.go
@@ -1,0 +1,189 @@
+package cgroup
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+const (
+	// Standard path where cgroupfs is expected to be mounted.
+	cgroupfsPath = "/sys/fs/cgroup"
+
+	// Placeholder value representing the container ID in cgroup path templates.
+	cidPlaceholder = "{{.ContainerID}}"
+)
+
+// Paths holds cgroup path templates that map a container ID to their cgroupfs
+// file paths.
+//
+// A single instance should be shared across all containers of the same
+// isolation type, since the first call to Stats() walks the cgroupfs tree in
+// order to discover the cgroup path locations.
+type Paths struct {
+	mu sync.RWMutex
+
+	// MemoryTemplate is the path template for the cgroupfs file containing
+	// current memory usage.
+	MemoryTemplate string
+	// CPUPathTemplate is the path template for the cgroupsfs file containing
+	// cumulative CPU usage.
+	CPUTemplate string
+}
+
+func (p *Paths) Stats(ctx context.Context, cid string) (*repb.UsageStats, error) {
+	if err := p.find(ctx, cid); err != nil {
+		return nil, err
+	}
+
+	memUsagePath := strings.ReplaceAll(p.MemoryTemplate, cidPlaceholder, cid)
+	cpuUsagePath := strings.ReplaceAll(p.CPUTemplate, cidPlaceholder, cid)
+
+	memUsageBytes, err := readInt64FromFile(memUsagePath)
+	if err != nil {
+		return nil, err
+	}
+	var cpuNanos int64
+	if p.CgroupVersion() == 1 {
+		// cgroup v1: /cpuacct.usage file contains just the CPU usage in ns.
+		cpuNanos, err = readInt64FromFile(cpuUsagePath)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// cgroup v2: /cpu.stat file contains a line like "usage_usec <N>" It
+		// contains other lines like user_usec, system_usec etc. but we just
+		// report the total for now.
+		cpuMicros, err := readCgroupInt64Field(cpuUsagePath, "usage_usec")
+		if err != nil {
+			return nil, err
+		}
+		cpuNanos = cpuMicros * 1e3
+	}
+	return &repb.UsageStats{
+		MemoryBytes: memUsageBytes,
+		CpuNanos:    cpuNanos,
+	}, nil
+}
+
+func (p *Paths) CgroupVersion() int {
+	if p.CPUTemplate == "" || p.MemoryTemplate == "" {
+		// Not fully initialized.
+		return 0
+	} else if strings.HasSuffix(p.CPUTemplate, "/cpuacct.usage") {
+		return 1
+	} else {
+		return 2
+	}
+}
+
+// find locates cgroup path templates. For this to work, the container must be
+// started (i.e. `podman create` does not set up the cgroups; `podman start`
+// does). We use this walking approach because the logic for figuring out the
+// actual cgroup paths depends on the system setup and is pretty complicated.
+func (p *Paths) find(ctx context.Context, cid string) error {
+	// If already initialized, do nothing.
+	p.mu.RLock()
+	v := p.CgroupVersion()
+	p.mu.RUnlock()
+	if v != 0 {
+		return nil
+	}
+
+	// Walk the cgroupfs tree.
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Re-check whether we're initialized since we released the lock for a brief
+	// period.
+	if p.CgroupVersion() != 0 {
+		return nil
+	}
+	start := time.Now()
+	// Sentinel error value to short-circuit the walk
+	stop := fmt.Errorf("stop walk")
+	err := filepath.WalkDir(cgroupfsPath, func(path string, dir fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if !strings.Contains(path, cid) {
+			return nil
+		}
+		if strings.HasSuffix(path, "/memory.usage_in_bytes") || strings.HasSuffix(path, "/memory.current") {
+			p.MemoryTemplate = strings.ReplaceAll(path, cid, cidPlaceholder)
+		} else if strings.HasSuffix(path, "/cpu.stat") || strings.HasSuffix(path, "/cpuacct.usage") {
+			p.CPUTemplate = strings.ReplaceAll(path, cid, cidPlaceholder)
+		}
+		if p.MemoryTemplate != "" && p.CPUTemplate != "" {
+			return stop
+		}
+		return nil
+	})
+	if err != nil && err != stop {
+		return err
+	}
+	if p.MemoryTemplate == "" {
+		return status.InternalErrorf("failed to locate memory cgroup file under %s", cgroupfsPath)
+	}
+	if p.CPUTemplate == "" {
+		return status.InternalErrorf("failed to locate CPU cgroup file under %s", cgroupfsPath)
+	}
+	log.CtxInfof(ctx, "Initialized cgroup path templates (%s): mem=%s, cpu=%s", time.Since(start), p.MemoryTemplate, p.CPUTemplate)
+	return nil
+}
+
+// readInt64FromFile reads a file expected to contain a single int64.
+func readInt64FromFile(path string) (int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// readCgroupInt64Field reads a cgroupfs file containing a list of lines like
+// "field_name <int64_value>" and returns the value of the given field name.
+func readCgroupInt64Field(path, fieldName string) (int64, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) != 2 || fields[0] != fieldName {
+			continue
+		}
+		val, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return val, nil
+	}
+	return 0, status.NotFoundErrorf("could not find field %q in %s", fieldName, path)
+}

--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["podman.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/podman",
     deps = [
+        "//enterprise/server/remote_execution/cgroup",
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/platform",
@@ -46,13 +47,6 @@ go_library(
 go_test(
     name = "podman_test",
     srcs = ["podman_test.go"],
-    args = [
-        # Note: these are used only for the Stats tests, which require running as root.
-        # These paths were tested on Ubuntu 20.04 + podman 3.4.2, but may be different for other setups.
-        # See the comment in podman.go for more info.
-        "--executor.podman.memory_usage_path_template=/sys/fs/cgroup/memory/machine.slice/libpod-{{.ContainerID}}.scope/memory.usage_in_bytes",
-        "--executor.podman.cpu_usage_path_template=/sys/fs/cgroup/cpu,cpuacct/machine.slice/libpod-{{.ContainerID}}.scope/cpuacct.usage",
-    ],
     tags = [
         "manual",
         "no-sandbox",


### PR DESCRIPTION
* Move all the cgroup stuff from `podman.go` to a new package `cgroup.go` since it's growing a bit, and we also want to use this for Docker.
* Instead of requiring the cgroup flags, walk the /sys/fs/cgroup tree, searching for the cid in the path, and determine mem/cpu paths from that.
  * The dir scanning approach is used because there are several different variables that determine what the paths will actually be - whether systemd is used or not, whether we're on cgroup v1 or v2, whether podman is running rootless or not... maybe other stuff (that may possibly change in the future?) I figured it was too complicated and error-prone to try and take all of these things into account.
  * In terms of performance, it takes 8ms to scan the cgroupfs tree (tested on a GCP VM). It succeeds very quickly and manages to init the cgroup paths on the first try, even when running a NOP task (/bin/true). We only do the scan once, so this overhead is incurred only on the first task executed.

**Related issues**: N/A
