### PR TITLE
[CLI ] Add support for MODULE.bazel files

### DIFF
--- a/cli/add/add.go
+++ b/cli/add/add.go
@@ -29,6 +29,7 @@ Adds the given dependency to your WORKSPACE file.
 	footerTemplate = "###### End auto-generated section for %s ######"
 
 	headerRegex = regexp.MustCompile(`##### Begin auto-generated section for \[https://registry\.build/(.+?)@(.+?)\]`)
+	moduleRegex = regexp.MustCompile(`bazel_dep\(name = "([^"]+?)", version = "([^"]+?)"\)`)
 )
 
 const (
@@ -58,7 +59,13 @@ func HandleAdd(args []string) (int, error) {
 		return 1, nil
 	}
 
-	module, version, resp, err := FetchModuleOrDisambiguate(flags.Args()[0])
+	input := flags.Args()[0]
+	transitive := strings.HasPrefix(input, "~")
+	if transitive {
+		input = strings.TrimPrefix(input, "~")
+	}
+
+	module, version, resp, err := FetchModuleOrDisambiguate(input)
 	if err != nil {
 		return 1, err
 	}
@@ -67,16 +74,32 @@ func HandleAdd(args []string) (int, error) {
 		version = resp.LatestReleaseWithWorkspaceSnippet
 	}
 
-	// TODO(siggisim): Support MODULE.bazel
 	f, err := openOrCreateWorkspaceFile()
 	if err != nil {
 		return 1, err
 	}
 	defer f.Close()
 
+	if strings.HasPrefix(strings.ToUpper(filepath.Base(f.Name())), "MODULE") {
+		if transitive {
+			return 0, nil
+		}
+		if err := addToModule(f, module, version, resp); err != nil {
+			return 1, err
+		}	
+	} else {
+		if err := addToWorkspace(f, module, version, resp); err != nil {
+			return 1, err
+		}	
+	}
+
+	return 0, nil
+}
+
+func addToWorkspace(f *os.File, module, version string, resp *RegistryResponse) error {
 	contents, err := io.ReadAll(f)
 	if err != nil {
-		return 1, err
+		return err
 	}
 
 	matches := headerRegex.FindAllStringSubmatch(string(contents), -1)
@@ -84,31 +107,65 @@ func HandleAdd(args []string) (int, error) {
 		existingModule := m[1]
 		existingVersion := m[2]
 		if module == existingModule && version == existingVersion {
-			return 1, fmt.Errorf("WORKSPACE already contains %s at the requested version (%s)",
+			return fmt.Errorf("WORKSPACE already contains %s at the requested version (%s)",
 				existingModule, existingVersion)
 		}
 		if module == existingModule {
-			return 1, fmt.Errorf("WORKSPACE already contains %s at version %s (the requested version is %s)",
+			return fmt.Errorf("WORKSPACE already contains %s at version %s (the requested version is %s)",
 				existingModule, existingVersion, version)
 		}
 	}
 	if strings.Contains(string(contents), resp.Repo.FullName) {
-		return 1, fmt.Errorf("WORKSPACE already contains %s which is likely %s manually installed",
+		return fmt.Errorf("WORKSPACE already contains %s which is likely %s manually installed",
 			resp.Repo.FullName, module)
 	}
 
-	addition := GenerateSnippet(module, version, resp)
+	addition := GenerateWorkspaceSnippet(module, version, resp)
 
 	if _, err := f.WriteString(addition); err != nil {
-		return 1, err
+		return err
 	}
 
-	log.Debugf("Added the following snippet to WORKSPACE:\n%s\n\n", addition)
-
-	return 0, nil
+	log.Debugf("Added the following snippet to %s:\n%s\n\n", filepath.Base(f.Name()), addition)
+	return nil
 }
 
-// TODO(siggisim): Support specifying a version.
+func addToModule(f *os.File, module, version string, resp *RegistryResponse) error {
+	contents, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	moduleSnippet := GenerateModuleSnippet(module, version, resp)
+	registryMatches := moduleRegex.FindStringSubmatch(moduleSnippet)
+	if registryMatches == nil {
+		return fmt.Errorf("MODULE %s not found: %s", module, moduleSnippet)
+	}
+	newModule := registryMatches[1]
+	newVersion := registryMatches[2]
+
+	matches := moduleRegex.FindAllStringSubmatch(string(contents), -1)
+	for _, m := range matches {
+		existingModule := m[1]
+		existingVersion := m[2]
+		if newModule == existingModule && newVersion == existingVersion {
+			return fmt.Errorf("MODULE already contains %s at the requested version (%s)",
+				existingModule, existingVersion)
+		}
+		if newModule == existingModule {
+			return fmt.Errorf("MODULE already contains %s at version %s (the requested version is %s)",
+				existingModule, existingVersion, newVersion)
+		}
+	}
+
+	if _, err := f.WriteString(moduleSnippet); err != nil {
+		return err
+	}
+
+	log.Debugf("Added the following snippet to %s:\n%s\n\n", filepath.Base(f.Name()), moduleSnippet)
+	return nil
+}
+
 func FetchModuleOrDisambiguate(moduleInput string) (string, string, *RegistryResponse, error) {
 	moduleAndVersion := strings.Replace(moduleInput, "https://", "", 1)
 	moduleAndVersion = strings.Replace(moduleAndVersion, "github.com/", "github/", 1)
@@ -147,7 +204,7 @@ func FetchModuleOrDisambiguate(moduleInput string) (string, string, *RegistryRes
 	return moduleName, moduleVersion, res, nil
 }
 
-func GenerateSnippet(module, version string, resp *RegistryResponse) string {
+func GenerateWorkspaceSnippet(module, version string, resp *RegistryResponse) string {
 	versionKey := fmt.Sprintf("[https://registry.build/%s@%s]", module, version)
 	header := fmt.Sprintf(headerTemplate, versionKey)
 	footer := fmt.Sprintf(footerTemplate, versionKey)
@@ -159,6 +216,11 @@ func GenerateSnippet(module, version string, resp *RegistryResponse) string {
 		}
 	}
 	return fmt.Sprintf("\n%s\n\n%+v\n\n%s\n", header, strings.TrimSpace(snippet), footer)
+}
+
+func GenerateModuleSnippet(module, version string, resp *RegistryResponse) string {
+	snippet := resp.ModuleSnippet
+	return fmt.Sprintf("%s\n", snippet)
 }
 
 func fetch(module string) (*RegistryResponse, error) {
@@ -222,7 +284,7 @@ func showPicker(modules []Disambiguation) (string, error) {
 }
 
 func openOrCreateWorkspaceFile() (*os.File, error) {
-	workspacePath, basename, err := workspace.CreateWorkspaceFileIfNotExists()
+	workspacePath, basename, err := workspace.CreateWorkspaceIfNotExists()
 	if err != nil {
 		return nil, err
 	}

--- a/cli/add/add.go
+++ b/cli/add/add.go
@@ -86,11 +86,11 @@ func HandleAdd(args []string) (int, error) {
 		}
 		if err := addToModule(f, module, version, resp); err != nil {
 			return 1, err
-		}	
+		}
 	} else {
 		if err := addToWorkspace(f, module, version, resp); err != nil {
 			return 1, err
-		}	
+		}
 	}
 
 	return 0, nil

--- a/cli/fix/fix.go
+++ b/cli/fix/fix.go
@@ -78,7 +78,7 @@ func runGazelle(repoRoot string) {
 	defer func() {
 		os.Args = originalArgs
 	}()
-	os.Args = []string{"gazelle", "-repo_root="+repoRoot, "--go_prefix="}
+	os.Args = []string{"gazelle", "-repo_root=" + repoRoot, "--go_prefix="}
 	if *diff {
 		os.Args = append(os.Args, "-mode=diff")
 	}

--- a/cli/fix/fix.go
+++ b/cli/fix/fix.go
@@ -58,7 +58,7 @@ func HandleFix(args []string) (exitCode int, err error) {
 		return -1, err
 	}
 
-	_, _, err = workspace.CreateWorkspaceFileIfNotExists()
+	path, _, err := workspace.CreateWorkspaceIfNotExists()
 	if err != nil {
 		return 1, err
 	}
@@ -68,17 +68,17 @@ func HandleFix(args []string) (exitCode int, err error) {
 		log.Printf("Error fixing: %s", err)
 	}
 
-	runGazelle()
+	runGazelle(path)
 
 	return 0, nil
 }
 
-func runGazelle() {
+func runGazelle(repoRoot string) {
 	originalArgs := os.Args
 	defer func() {
 		os.Args = originalArgs
 	}()
-	os.Args = []string{"gazelle"}
+	os.Args = []string{"gazelle", "-repo_root="+repoRoot, "--go_prefix="}
 	if *diff {
 		os.Args = append(os.Args, "-mode=diff")
 	}
@@ -114,7 +114,7 @@ func walk() error {
 				depFiles[fileName] = append(depFiles[fileName], path)
 			}
 			fileNameRoot := strings.TrimSuffix(fileName, filepath.Ext(fileName))
-			if fileNameRoot != "BUILD" && fileNameRoot != "WORKSPACE" {
+			if fileNameRoot != "BUILD" && fileNameRoot != "WORKSPACE" && fileNameRoot != "MODULE" {
 				return nil
 			}
 			fileToFormat, err := translate.Translate(path)

--- a/cli/fix/golang/golang.go
+++ b/cli/fix/golang/golang.go
@@ -48,7 +48,7 @@ func NewLanguage() language.Language {
 func (g *Golang) Deps() []string {
 	return []string{
 		"github/bazelbuild/rules_go@" + defaultRulesGoVersion,
-		"~github/bazelbuild/bazel-gazelle@" + defaultGazelleVersion, // Transitive
+		"~github/bazelbuild/bazel-gazelle@" + defaultGazelleVersion,  // Transitive
 		"~github/bazelbuild/rules_proto@" + defaultRulesProtoVersion, // Transitive
 	}
 }

--- a/cli/fix/golang/golang.go
+++ b/cli/fix/golang/golang.go
@@ -48,8 +48,8 @@ func NewLanguage() language.Language {
 func (g *Golang) Deps() []string {
 	return []string{
 		"github/bazelbuild/rules_go@" + defaultRulesGoVersion,
-		"github/bazelbuild/bazel-gazelle@" + defaultGazelleVersion,
-		"github/bazelbuild/rules_proto@" + defaultRulesProtoVersion,
+		"~github/bazelbuild/bazel-gazelle@" + defaultGazelleVersion, // Transitive
+		"~github/bazelbuild/rules_proto@" + defaultRulesProtoVersion, // Transitive
 	}
 }
 

--- a/cli/workspace/workspace.go
+++ b/cli/workspace/workspace.go
@@ -114,7 +114,6 @@ func useModules() bool {
 	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
 	version := lines[len(lines)-1]
 
-	log.Printf(version)
 	if version == "" || version == "latest" {
 		return true
 	}

--- a/cli/workspace/workspace.go
+++ b/cli/workspace/workspace.go
@@ -70,7 +70,7 @@ func CreateWorkspaceIfNotExists() (string, string, error) {
 	if err == nil {
 		return path, base, nil
 	}
-	
+
 	useModules := useModules()
 
 	fileName := "MODULE.bazel"
@@ -92,7 +92,7 @@ func CreateWorkspaceIfNotExists() (string, string, error) {
 	contents := ""
 	if useModules {
 		contents = `module(name = "` + filepath.Base(workspacePath) + `")` + "\n"
-	} else {		
+	} else {
 		contents = `workspace(name = "` + filepath.Base(workspacePath) + `")` + "\n"
 	}
 	if _, err := f.WriteString(contents); err != nil {
@@ -112,7 +112,7 @@ func useModules() bool {
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-	version := lines[len(lines) - 1] 
+	version := lines[len(lines)-1]
 
 	log.Printf(version)
 	if version == "" || version == "latest" {

--- a/cli/workspace/workspace.go
+++ b/cli/workspace/workspace.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
@@ -19,7 +21,7 @@ var (
 )
 
 // Path returns the current Bazel workspace path by traversing upwards until
-// we see a WORKSPACE or WORKSPACE.bazel file.
+// we see a WORKSPACE, WORKSPACE.bazel, MODULE, or MODULE.bazel file.
 func Path() (string, error) {
 	pathOnce.Do(func() {
 		pathVal, basename, pathErr = path()
@@ -38,7 +40,7 @@ func path() (string, string, error) {
 		return "", "", err
 	}
 	for {
-		for _, basename := range []string{"WORKSPACE", "WORKSPACE.bazel"} {
+		for _, basename := range []string{"WORKSPACE", "WORKSPACE.bazel", "MODULE", "MODULE.bazel"} {
 			ex, err := disk.FileExists(context.TODO(), filepath.Join(dir, basename))
 			if err != nil {
 				return "", "", err
@@ -50,7 +52,7 @@ func path() (string, string, error) {
 		next := filepath.Dir(dir)
 		if dir == next {
 			// We've reached the root dir without finding a WORKSPACE file
-			return "", "", fmt.Errorf("not within a bazel workspace (could not find WORKSPACE or WORKSPACE.bazel file)")
+			return "", "", fmt.Errorf("not within a bazel workspace (could not find WORKSPACE, WORKSPACE.bazel, MODULE, or MODULE.bazel file)")
 		}
 		dir = next
 	}
@@ -62,14 +64,22 @@ func SetForTest(path string) {
 	pathVal, pathErr = path, nil
 }
 
-func CreateWorkspaceFileIfNotExists() (string, string, error) {
+func CreateWorkspaceIfNotExists() (string, string, error) {
 	log.Debugf("Checking if workspace file exists")
 	path, base, err := PathAndBasename()
 	if err == nil {
 		return path, base, nil
 	}
-	log.Debugf("Creating workspace file")
-	fileName := "WORKSPACE" // gazelle doesn't like WORKSPACE.bazel...
+	
+	useModules := useModules()
+
+	fileName := "MODULE.bazel"
+	if !useModules {
+		fileName = "WORKSPACE" // gazelle doesn't like WORKSPACE.bazel...
+	}
+
+	log.Debugf("Creating %s file", fileName)
+
 	f, err := os.OpenFile(fileName, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
 	if err != nil {
 		return "", "", err
@@ -79,14 +89,51 @@ func CreateWorkspaceFileIfNotExists() (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	if _, err := f.WriteString(`workspace(name = "` + filepath.Base(workspacePath) + `")` + "\n"); err != nil {
+	contents := ""
+	if useModules {
+		contents = `module(name = "` + filepath.Base(workspacePath) + `")` + "\n"
+	} else {		
+		contents = `workspace(name = "` + filepath.Base(workspacePath) + `")` + "\n"
+	}
+	if _, err := f.WriteString(contents); err != nil {
 		return "", "", err
 	}
 	pathVal = workspacePath
 	basename = fileName
 	pathErr = nil
-	log.Debugf("Created workspace file at %s/%s", pathVal, basename)
+	log.Debugf("Created %s file at %s/%s", fileName, pathVal, basename)
 	return pathVal, basename, nil
+}
+
+func useModules() bool {
+	data, err := os.ReadFile(".bazelversion")
+	if err != nil {
+		return true
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	version := lines[len(lines) - 1] 
+
+	log.Printf(version)
+	if version == "" || version == "latest" {
+		return true
+	}
+	versionParts := strings.Split(version, ".")
+	majorVersion, err := strconv.Atoi(versionParts[0])
+	if err != nil {
+		return true
+	}
+
+	if len(versionParts) == 1 {
+		return majorVersion > 6
+	}
+
+	minorVersion, err := strconv.Atoi(versionParts[1])
+	if err != nil {
+		return true
+	}
+
+	return majorVersion > 6 || (majorVersion == 6 && minorVersion >= 4)
 }
 
 func GetBuildFileContents(dir string) (string, string) {

--- a/docs/cli-plugins.md
+++ b/docs/cli-plugins.md
@@ -327,7 +327,7 @@ The CLI exposes certain environment variables to your plugins.
 #### $BUILD_WORKSPACE_DIRECTORY
 
 This is the path to the Bazel workspace in which the CLI is run. It is the
-root path, containing the bazel `WORKSPACE` or `WORKSPACE.bazel` file.
+root path, containing the bazel `WORKSPACE`, `WORKSPACE.bazel`, `MODULE`, or `MODULE.bazel` file.
 
 #### $PLUGIN_TEMPDIR
 

--- a/server/util/bazel/bazel.go
+++ b/server/util/bazel/bazel.go
@@ -71,7 +71,7 @@ func Invoke(ctx context.Context, bazelBinary string, workspaceDir string, subCom
 	}
 }
 
-// FindWorkspaceFile finds the location of the Bazel workspace file (either WORKSPACE.bazel, WORKSPACE, MODULE, or 
+// FindWorkspaceFile finds the location of the Bazel workspace file (either WORKSPACE.bazel, WORKSPACE, MODULE, or
 // MODULE.bazel) in which the startDir is located.
 func FindWorkspaceFile(startDir string) (string, error) {
 	path, err := filepath.Abs(startDir)

--- a/server/util/bazel/bazel.go
+++ b/server/util/bazel/bazel.go
@@ -71,15 +71,15 @@ func Invoke(ctx context.Context, bazelBinary string, workspaceDir string, subCom
 	}
 }
 
-// FindWorkspaceFile finds the location of the Bazel workspace file (either WORKSPACE.bazel or WORKSPACE) in which the
-// startDir is located.
+// FindWorkspaceFile finds the location of the Bazel workspace file (either WORKSPACE.bazel, WORKSPACE, MODULE, or 
+// MODULE.bazel) in which the startDir is located.
 func FindWorkspaceFile(startDir string) (string, error) {
 	path, err := filepath.Abs(startDir)
 	if err != nil {
 		return "", nil
 	}
 	for path != "/" {
-		for _, wsFilename := range []string{"WORKSPACE.bazel", "WORKSPACE"} {
+		for _, wsFilename := range []string{"WORKSPACE.bazel", "WORKSPACE", "MODULE", "MODULE.bazel"} {
 			wsFilePath := filepath.Join(path, wsFilename)
 			_, err := os.Stat(wsFilePath)
 			if err == nil {
@@ -92,5 +92,5 @@ func FindWorkspaceFile(startDir string) (string, error) {
 		}
 		path = filepath.Dir(path)
 	}
-	return "", status.NotFoundError("could not detect workspace root (WORKSPACE.bazel or WORKSPACE file not found)")
+	return "", status.NotFoundError("could not detect workspace root (WORKSPACE.bazel, WORKSPACE, MODULE, MODULE.bazel file not found)")
 }


### PR DESCRIPTION
This adds support for MODULE.bazel files in the CLI in a few places:
- When trying to find the workspace root when there is no WORKSPACE file present
- When auto-generating a MODULE.bazel file in Bazel 6.4 or later when bootstrapping a non-bazel repository
- When running `bb add` for example `bb add rules_go` when a MODULE.bazel file exists
- When converting from a MODULE.yaml => MODULE.bazel file