### PR TITLE
make grpc use RecvBufferPools

### DIFF
--- a/server/util/grpc_client/grpc_client.go
+++ b/server/util/grpc_client/grpc_client.go
@@ -199,6 +199,7 @@ func CommonGRPCClientOptions() []grpc.DialOption {
 		interceptors.GetUnaryClientInterceptor(),
 		interceptors.GetStreamClientInterceptor(),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32)),
+		grpc.WithRecvBufferPool(grpc.NewSharedBufferPool()),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			// After a duration of this time if the client doesn't see any activity it
 			// pings the server to see if the transport is still alive.

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -218,6 +218,7 @@ func CommonGRPCServerOptions(env environment.Env) []grpc.ServerOption {
 		grpc.ChainStreamInterceptor(otelgrpc.StreamServerInterceptor(), propagateInvocationIDToSpanStreamServerInterceptor()),
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
+		grpc.RecvBufferPool(grpc.NewSharedBufferPool()),
 		grpc.MaxRecvMsgSize(*gRPCMaxRecvMsgSizeBytes),
 		KeepaliveEnforcementPolicy(),
 	}


### PR DESCRIPTION
Allocs before (3 runs of smash.go):
<img width="1608" alt="Screenshot 2023-11-14 at 11 37 10 AM" src="https://github.com/buildbuddy-io/buildbuddy/assets/10570856/5eeda01b-d456-40ca-bf1d-002eb899c14a">

Allocs after (also 3 runs of smash.go):
<img width="1567" alt="Screenshot 2023-11-14 at 11 37 39 AM" src="https://github.com/buildbuddy-io/buildbuddy/assets/10570856/6483cabb-1e1b-44ce-be49-e76d2d4c862b">

This claims ~40% reduction in allocations (2G vs 3.7G) for bytestream reads (and about a 80% decrease in allocations on the actual path that allocates the recv buffer in this toy harness), and doesn't seem to have a meaningful impact on request latency, so hopefully it will help with GC pressure.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
