### PR TITLE
[SS] Fix firecracker tests

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_performance_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_performance_test.go
@@ -102,6 +102,7 @@ func TestFirecracker_RemoteSnapshotSharing_ManualBenchmarking(t *testing.T) {
 				// Note: platform must match in order to share snapshots
 				Platform: &repb.Platform{Properties: []*repb.Platform_Property{
 					{Name: "recycle-runner", Value: "true"},
+					{Name: platform.WorkflowIDPropertyName, Value: "workflow"},
 				}},
 			},
 		}


### PR DESCRIPTION
Some of our recent changes have broken the remote snapshot sharing related tests: 
1. NewContainer now mutates the opts to set executor config fields. If you try to use the original opts to load a snapshot, the digests won't match
2. You must have a workflow ID set to enable remote SS 