### PR TITLE
Share write buffers (to reduce allocs)

### DIFF
--- a/server/util/grpc_client/grpc_client.go
+++ b/server/util/grpc_client/grpc_client.go
@@ -200,6 +200,7 @@ func CommonGRPCClientOptions() []grpc.DialOption {
 		interceptors.GetStreamClientInterceptor(),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32)),
 		grpc.WithRecvBufferPool(grpc.NewSharedBufferPool()),
+		grpc.WithSharedWriteBuffer(true),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			// After a duration of this time if the client doesn't see any activity it
 			// pings the server to see if the transport is still alive.


### PR DESCRIPTION
Before:

<img width="1511" alt="image" src="https://github.com/buildbuddy-io/buildbuddy/assets/141737/c9dd72aa-42a8-4f72-ba14-dd58a2d3dc64">


After:

<img width="1508" alt="image" src="https://github.com/buildbuddy-io/buildbuddy/assets/141737/fae2c7ba-a710-4a0b-b1ee-ee90a06c3dd2">


Delta: (718713265-123938889)/718713265 = 82% fewer allocs?