### PR TITLE
Fix grafana dashboards saving as unexpected file name

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -14281,9 +14281,10 @@
   ],
   "refresh": "1m",
   "schemaVersion": 38,
-  "slug": "buildbuddy",
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "file:buildbuddy.json"
+  ],
   "templating": {
     "list": [
       {

--- a/tools/metrics/grafana/dashboards/cache.json
+++ b/tools/metrics/grafana/dashboards/cache.json
@@ -1451,9 +1451,10 @@
   ],
   "refresh": "1m",
   "schemaVersion": 38,
-  "slug": "cache",
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "file:cache.json"
+  ],
   "templating": {
     "list": [
       {

--- a/tools/metrics/grafana/dashboards/clickhouse.json
+++ b/tools/metrics/grafana/dashboards/clickhouse.json
@@ -3825,10 +3825,9 @@
   ],
   "refresh": "1m",
   "schemaVersion": 33,
-  "slug": "clickhouse",
   "style": "dark",
   "tags": [
-    "clickhouse"
+    "file:clickhouse.json"
   ],
   "templating": {
     "list": [

--- a/tools/metrics/grafana/dashboards/mac.json
+++ b/tools/metrics/grafana/dashboards/mac.json
@@ -4154,9 +4154,10 @@
   ],
   "refresh": "1m",
   "schemaVersion": 37,
-  "slug": "mac",
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "file:mac.json"
+  ],
   "templating": {
     "list": [
       {

--- a/tools/metrics/grafana/dashboards/nodes.json
+++ b/tools/metrics/grafana/dashboards/nodes.json
@@ -768,9 +768,10 @@
   ],
   "refresh": "1m",
   "schemaVersion": 37,
-  "slug": "nodes",
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "file:nodes.json"
+  ],
   "templating": {
     "list": [
       {

--- a/tools/metrics/grafana/dashboards/rbeperf.json
+++ b/tools/metrics/grafana/dashboards/rbeperf.json
@@ -386,7 +386,9 @@
   "schemaVersion": 26,
   "slug": "rbeperf",
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "file:rbeperf.json"
+  ],
   "templating": {
     "list": [
       {

--- a/tools/metrics/grafana/dashboards/workflow.json
+++ b/tools/metrics/grafana/dashboards/workflow.json
@@ -492,9 +492,10 @@
   ],
   "refresh": "1m",
   "schemaVersion": 37,
-  "slug": "workflow",
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "file:workflow.json"
+  ],
   "templating": {
     "list": []
   },


### PR DESCRIPTION
Store the filename as a "file:" tag rather than slug. The slug apparently gets overwritten by grafana when re-saving the dashboard, while the tags remain stable.

**Related issues**: N/A
