### PR TITLE
bazel: prepare for bazel 7

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,10 +1,11 @@
+build --noenable_bzlmod
+
 build --enable_platform_specific_config=true
 query --enable_platform_specific_config=true
 
 # Skymeld merges the analysis phase and execution phase.
 # This allows build and test executions to start before the analysis phase finishes,
 # thus speeding up the build overall .
-build:skymeld --experimental_skymeld_ui
 build:skymeld --experimental_merged_skyframe_analysis_execution
 
 # Build with --config=local to send build logs to your local server

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -427,9 +427,10 @@ swc_register_toolchains(
 
 http_archive(
     name = "io_bazel_rules_webtesting",
-    sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
+    sha256 = "3e25ac044ed409545214cf8b013fa7255ccf1d2fa027b0d57a3fcc7d732da667",
+    strip_prefix = "rules_webtesting-9e9361ba887a3b687f537c02409b690b62fecdfe",
     urls = [
-        "https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz",
+        "https://github.com/bazelbuild/rules_webtesting/archive/9e9361ba887a3b687f537c02409b690b62fecdfe.tar.gz",
     ],
 )
 

--- a/rules/yarn/index.bzl
+++ b/rules/yarn/index.bzl
@@ -27,7 +27,7 @@ def yarn(name, srcs, package, command = "build", deps = [], yarn = "@yarn//:yarn
         outs = [name + extension],
         cmd_bash = cmd,
         executable = executable,
-        exec_tools = [yarn, node],
+        tools = [yarn, node],
         local = 1,
         **kwargs
     )


### PR DESCRIPTION
Some minor changes that remove incompatible attributes and flags that
are going away in Bazel 7.

`rules_webtesting` was also upgraded to latest version with some
bug fixes in removing `browser_overrides` attributes in
`wrap_web_test_suite`.
