### PR TITLE
Add a basic tool to fetch and print jaeger trace stats.

### DIFF
--- a/proto/jaeger/BUILD
+++ b/proto/jaeger/BUILD
@@ -1,0 +1,27 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "jaeger_proto",
+    srcs = [
+        "model.proto",
+        "query.proto",
+    ],
+    deps = [
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@googleapis//google/api:annotations_proto",
+    ],
+)
+
+go_proto_library(
+    name = "jaeger_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/jaeger",
+    proto = ":jaeger_proto",
+    deps = [
+        "@org_golang_google_genproto_googleapis_api//annotations",
+    ],
+)

--- a/proto/jaeger/model.proto
+++ b/proto/jaeger/model.proto
@@ -1,0 +1,112 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package jaeger.api_v2;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+
+// TODO: document all types and fields
+
+// TODO: once this moves to jaeger-idl repo, we may want to change Go pkg to
+// api_v2 and rewrite it to model only in this repo. That should make it easier
+// to generate classes in other languages.
+option java_package = "io.jaegertracing.api_v2";
+
+enum ValueType {
+  STRING = 0;
+  BOOL = 1;
+  INT64 = 2;
+  FLOAT64 = 3;
+  BINARY = 4;
+};
+
+message KeyValue {
+  string key = 1;
+  ValueType v_type = 2;
+  string v_str = 3;
+  bool v_bool = 4;
+  int64 v_int64 = 5;
+  double v_float64 = 6;
+  bytes v_binary = 7;
+}
+
+message Log {
+  google.protobuf.Timestamp timestamp = 1;
+  repeated KeyValue fields = 2;
+}
+
+enum SpanRefType {
+  CHILD_OF = 0;
+  FOLLOWS_FROM = 1;
+};
+
+message SpanRef {
+  bytes trace_id = 1;
+  bytes span_id = 2;
+  SpanRefType ref_type = 3;
+}
+
+message Process {
+  string service_name = 1;
+  repeated KeyValue tags = 2;
+}
+
+message Span {
+  bytes trace_id = 1;
+  bytes span_id = 2;
+  string operation_name = 3;
+  repeated SpanRef references = 4;
+  uint32 flags = 5;
+  google.protobuf.Timestamp start_time = 6;
+  google.protobuf.Duration duration = 7;
+  repeated KeyValue tags = 8;
+  repeated Log logs = 9;
+  Process process = 10;
+  string process_id = 11;
+  repeated string warnings = 12;
+}
+
+message Trace {
+  message ProcessMapping {
+    string process_id = 1;
+    Process process = 2;
+  }
+  repeated Span spans = 1;
+  repeated ProcessMapping process_map = 2;
+  repeated string warnings = 3;
+}
+
+// Note that both Span and Batch may contain a Process.
+// This is different from the Thrift model which was only used
+// for transport, because Proto model is also used by the backend
+// as the domain model, where once a batch is received it is split
+// into individual spans which are all processed independently,
+// and therefore they all need a Process. As far as on-the-wire
+// semantics, both Batch and Spans in the same message may contain
+// their own instances of Process, with span.Process taking priority
+// over batch.Process.
+message Batch {
+  repeated Span spans = 1;
+  Process process = 2;
+}
+
+message DependencyLink {
+  string parent = 1;
+  string child = 2;
+  uint64 call_count = 3;
+  string source = 4;
+}

--- a/proto/jaeger/query.proto
+++ b/proto/jaeger/query.proto
@@ -1,0 +1,147 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package jaeger.api_v2;
+
+import "proto/jaeger/model.proto";
+import "google/api/annotations.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+
+option java_package = "io.jaegertracing.api_v2";
+
+message GetTraceRequest {
+  bytes trace_id = 1;
+  // Optional. The start time to search trace ID.
+  google.protobuf.Timestamp start_time = 2;
+  // Optional. The end time to search trace ID.
+  google.protobuf.Timestamp end_time = 3;
+}
+
+message SpansResponseChunk {
+  repeated jaeger.api_v2.Span spans = 1;
+}
+
+message ArchiveTraceRequest {
+  bytes trace_id = 1;
+  // Optional. The start time to search trace ID.
+  google.protobuf.Timestamp start_time = 2;
+  // Optional. The end time to search trace ID.
+  google.protobuf.Timestamp end_time = 3;
+}
+
+message ArchiveTraceResponse {}
+
+// Query parameters to find traces. Except for num_traces, all fields should be
+// treated as forming a conjunction, e.g., "service_name='X' AND
+// operation_name='Y' AND ...". All fields are matched against individual spans,
+// not at the trace level. The returned results contain traces where at least
+// one span matches the conditions. When num_traces results in fewer traces
+// returned, there is no required ordering.
+//
+// Note: num_traces should restrict the number of traces returned, but not all
+// backends interpret it this way. For instance, in Cassandra this limits the
+// number of _spans_ that match the conditions, and the resulting number of
+// traces can be less.
+//
+// Note: some storage implementations do not guarantee the correct
+// implementation of all parameters.
+//
+message TraceQueryParameters {
+  string service_name = 1;
+  string operation_name = 2;
+  map<string, string> tags = 3;
+  google.protobuf.Timestamp start_time_min = 4;
+  google.protobuf.Timestamp start_time_max = 5;
+  google.protobuf.Duration duration_min = 6;
+  google.protobuf.Duration duration_max = 7;
+  int32 search_depth = 8;
+}
+
+message FindTracesRequest {
+  TraceQueryParameters query = 1;
+}
+
+message GetServicesRequest {}
+
+message GetServicesResponse {
+  repeated string services = 1;
+}
+
+message GetOperationsRequest {
+  string service = 1;
+  string span_kind = 2;
+}
+
+message Operation {
+  string name = 1;
+  string span_kind = 2;
+}
+
+message GetOperationsResponse {
+  repeated string operationNames = 1;  // deprecated
+  repeated Operation operations = 2;
+}
+
+message GetDependenciesRequest {
+  google.protobuf.Timestamp start_time = 1;
+  google.protobuf.Timestamp end_time = 2;
+}
+
+message GetDependenciesResponse {
+  repeated jaeger.api_v2.DependencyLink dependencies = 1;
+}
+
+service QueryService {
+  rpc GetTrace(GetTraceRequest) returns (stream SpansResponseChunk) {
+    option (google.api.http) = {
+      get: "/traces/{trace_id}"
+    };
+  }
+
+  rpc ArchiveTrace(ArchiveTraceRequest) returns (ArchiveTraceResponse) {
+    option (google.api.http) = {
+      post: "/archive/{trace_id}"
+    };
+  }
+
+  rpc FindTraces(FindTracesRequest) returns (stream SpansResponseChunk) {
+    option (google.api.http) = {
+      post: "/search"
+      body: "*"
+    };
+  }
+
+  rpc GetServices(GetServicesRequest) returns (GetServicesResponse) {
+    option (google.api.http) = {
+      get: "/services"
+    };
+  }
+
+  rpc GetOperations(GetOperationsRequest) returns (GetOperationsResponse) {
+    option (google.api.http) = {
+      get: "/operations"
+    };
+  }
+
+  rpc GetDependencies(GetDependenciesRequest)
+      returns (GetDependenciesResponse) {
+    option (google.api.http) = {
+      get: "/dependencies"
+    };
+  }
+}

--- a/tools/jaegerquery/BUILD
+++ b/tools/jaegerquery/BUILD
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "jaegerquery_lib",
+    srcs = ["jaegerquery.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/tools/jaegerquery",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//proto/jaeger:jaeger_go_proto",
+        "//server/util/flag",
+        "//server/util/grpc_client",
+        "//server/util/log",
+        "@org_golang_google_protobuf//types/known/timestamppb",
+        "@org_golang_x_exp//maps",
+    ],
+)
+
+go_binary(
+    name = "jaegerquery",
+    embed = [":jaegerquery_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/jaegerquery/jaegerquery.go
+++ b/tools/jaegerquery/jaegerquery.go
@@ -1,0 +1,115 @@
+// CLI for jaeger FindTraces API, which supports basic aggregation/analysis of
+// the fetched spans. Currently, it just prints average duration of the spans
+// across all fetched traces.
+//
+// Basic usage: set up port-forwarding to jaeger on port 16685, then run:
+//
+//	$ bazel run -- tools/jaegerquery --service=app --tag=invocation_id=abc-123 --operation=build.bazel.remote.execution.v2.Execution/Execute
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"golang.org/x/exp/maps"
+
+	jaegerpb "github.com/buildbuddy-io/buildbuddy/proto/jaeger"
+	tspb "google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var (
+	target        = flag.String("target", "grpc://localhost:16685", "jaeger.api_v2.QueryService gRPC target")
+	serviceName   = flag.String("service", "", "Service name (value of --app.trace_service_name)")
+	operationName = flag.String("operation", "", "Operation name (required)")
+	tags          = flag.Slice("tag", []string{}, "Tag specified as a `NAME=VALUE pair`. Can be set more than once.")
+	limit         = flag.Int("limit", 100, "Max number of operations to fetch")
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err.Error())
+	}
+}
+
+func run() error {
+	flag.Parse()
+
+	if err := os.Chdir(os.Getenv("BUILD_WORKSPACE_DIRECTORY")); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	tagsMap := map[string]string{}
+	for _, t := range *tags {
+		parts := strings.SplitN(t, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid tag %q (expected NAME=VALUE)", t)
+		}
+		tagsMap[parts[0]] = parts[1]
+	}
+
+	conn, err := grpc_client.DialSimple(*target)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	jaeger := jaegerpb.NewQueryServiceClient(conn)
+	stream, err := jaeger.FindTraces(ctx, &jaegerpb.FindTracesRequest{
+		Query: &jaegerpb.TraceQueryParameters{
+			ServiceName:   *serviceName,
+			OperationName: *operationName,
+			Tags:          tagsMap,
+			StartTimeMax:  tspb.Now(),
+			StartTimeMin:  tspb.New(time.Now().Add(-1 * time.Hour)),
+			SearchDepth:   int32(*limit),
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Track unique trace IDs since this determines the number of results that
+	// were actually fetched (which may be less than the limit).
+	traceIDs := map[string]struct{}{}
+	totalDurations := map[string]time.Duration{}
+	for {
+		chunk, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		for _, span := range chunk.Spans {
+			traceIDs[string(span.TraceId)] = struct{}{}
+			totalDurations[span.OperationName] += span.Duration.AsDuration()
+		}
+	}
+
+	// Sort by total duration, greatest to least
+	operations := maps.Keys(totalDurations)
+	sort.Slice(operations, func(i, j int) bool {
+		return totalDurations[operations[i]] > totalDurations[operations[j]]
+	})
+	fmt.Printf("AVG_MS\tOP\n")
+	for _, op := range operations {
+		dur := totalDurations[op]
+		fmt.Printf("%.02f\t%s\n", float64(dur.Milliseconds())/float64(len(traceIDs)), op)
+	}
+
+	return nil
+}


### PR DESCRIPTION
A small tool to help us measure remote execution performance by printing aggregated trace stats instead of having to view individual traces and/or add prometheus metrics in a ton of places just to get finer-grained metrics.

Example usage:

```
# Generate an invocation_id that all traces should be grouped under
$ IID=$(uuidgen | tee /dev/stderr)
eddea668-aa9e-4d89-9473-858578d364cc

# Run some executions with tracing enabled, tagging them with this invocation ID
$ for _ in $(seq 100); do
      bb execute --invocation_id=$IID \
        --remote_header=x-buildbuddy-trace=force \
        --exec_properties=dockerNetwork=off \
        --remote_executor=grpcs://remote.buildbuddy.dev \
        -- \
        true
  done

# Port-forward to jaeger
$ kubectl port-forward --namespace=monitor-dev statefulset/jaeger 16685:16685

# Fetch traces
$ bazel run -- tools/jaegerquery \
      --service=app --tag=invocation_id=$IID --operation=build.bazel.remote.execution.v2.Execution/Execute
...
AVG_MS  OP
722.61  scheduler.Scheduler/LeaseTask
696.73  build.bazel.remote.execution.v2.Execution/PublishOperation
468.39  build.bazel.remote.execution.v2.Execution/Execute
377.77  xread
285.67  executor.(*Executor).ExecuteTaskAndStreamResults
147.33  container.(*TracedCommandContainer).Run
147.27  podman.runPodman
130.24  container.PullImageIfNecessary
130.19  container.(*TracedCommandContainer).PullImage
90.67   execution_server.(*ExecutionServer).Dispatch
15.25   distributed_cache.DistributedCache/Read
13.39   scheduler.Scheduler/EnqueueTaskReservation
11.33   distributed_cache.DistributedCache/Write
10.42   build.bazel.remote.execution.v2.ActionCache/UpdateActionResult
10.15   execution_server.(*ExecutionServer).insertExecution
8.67    workspace.(*Workspace).UploadOutputs
8.08    build.bazel.remote.execution.v2.Capabilities/GetCapabilities
7.96    execution_server.(*ExecutionServer).insertInvocationLink
5.30    gorm:create
4.14    build.bazel.remote.execution.v2.ContentAddressableStorage/BatchUpdateBlobs
3.66    build.bazel.remote.execution.v2.ContentAddressableStorage/GetTree
3.62    workspace.(*Workspace).DownloadInputs
3.08    gorm:query
...
```

**Related issues**: N/A
