### PR TITLE
Separate `gplink` from `oidc.go`

### DIFF
--- a/enterprise/app/repo/repo.tsx
+++ b/enterprise/app/repo/repo.tsx
@@ -366,8 +366,7 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
 
   linkGoogleCloud() {
     return popup.open(
-      `/login/?${new URLSearchParams({
-        issuer_url: "https://accounts.google.com",
+      `/auth/gcp/link/?${new URLSearchParams({
         link_gcp_for_group: this.props.user?.selectedGroup.id || "",
         redirect_url: window.location.href,
       })}`

--- a/enterprise/server/gcplink/BUILD
+++ b/enterprise/server/gcplink/BUILD
@@ -11,11 +11,15 @@ go_library(
         "//proto:gcp_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:secrets_go_proto",
+        "//server/endpoint_urls/build_buddy_url",
         "//server/environment",
         "//server/util/cookie",
         "//server/util/perms",
+        "//server/util/random",
         "//server/util/request_context",
         "//server/util/status",
+        "@com_github_coreos_go_oidc//:go-oidc",
+        "@org_golang_x_oauth2//:oauth2",
     ],
 )
 

--- a/enterprise/server/gcplink/gcplink.go
+++ b/enterprise/server/gcplink/gcplink.go
@@ -97,7 +97,7 @@ func (g *GCPService) Link(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	
+
 	return nil
 }
 
@@ -129,7 +129,7 @@ func (g *GCPService) handleAuthRedirect(w http.ResponseWriter, r *http.Request) 
 	if r.FormValue("state") != cookie.GetCookie(r, stateCookie) {
 		return status.PermissionDeniedErrorf("state mismatch: %s != %s", r.FormValue("state"), cookie.GetCookie(r, stateCookie))
 	}
-	
+
 	authError := r.URL.Query().Get("error")
 	if authError != "" {
 		return status.PermissionDeniedErrorf("Authenticator returned error: %s (%s %s)", authError, r.URL.Query().Get("error_desc"), r.URL.Query().Get("error_description"))

--- a/enterprise/server/gcplink/gcplink.go
+++ b/enterprise/server/gcplink/gcplink.go
@@ -8,14 +8,17 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/keystore"
+	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/cookie"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
+	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/coreos/go-oidc"
+	"golang.org/x/oauth2"
 
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
 	gcpb "github.com/buildbuddy-io/buildbuddy/proto/gcp"
@@ -25,10 +28,13 @@ import (
 )
 
 const (
-	Issuer         = "https://accounts.google.com"
-	scope          = "https://www.googleapis.com/auth/cloud-platform"
-	linkParamName  = "link_gcp_for_group"
-	linkCookieName = "link-gcp-for-group"
+	Issuer            = "https://accounts.google.com"
+	scope             = "https://www.googleapis.com/auth/cloud-platform"
+	linkParamName     = "link_gcp_for_group"
+	linkCookieName    = "link-gcp-for-group"
+	authRedirectParam = "redirect_url"
+	stateCookie       = "GCP-State-Token"
+
 	cookieDuration = 1 * time.Hour
 	// Refresh token secret that's exchanged for an auth token in workflows
 	refreshTokenEnvVariableName = "CLOUDSDK_AUTH_REFRESH_TOKEN"
@@ -37,6 +43,7 @@ const (
 	accessTokenEnvVariableName = "CLOUDSDK_AUTH_ACCESS_TOKEN"
 	authTokenURL               = "https://accounts.google.com/o/oauth2/token"
 	projectSearchURL           = "https://cloudresourcemanager.googleapis.com/v3/projects:search"
+	linkURL                    = "/auth/gcp/link/"
 )
 
 var (
@@ -44,30 +51,121 @@ var (
 	gcpClientSecret = flag.String("gcp.client_secret", "", "The client secret to use for GCP linking.")
 )
 
-// Returns true if the request contains either a gcp link url param or cookie.
-func IsLinkRequest(r *http.Request) bool {
-	return r.URL.Query().Get(linkParamName) != "" || cookie.GetCookie(r, linkCookieName) != ""
-}
-
-// Redirects the user to the auth flow with a request for the GCP scope.
-func RequestAccess(w http.ResponseWriter, r *http.Request, authUrl string) {
-	authUrl = strings.ReplaceAll(authUrl, "scope=", fmt.Sprintf("scope=%s+", scope))
-	cookie.SetCookie(w, linkCookieName, r.URL.Query().Get(linkParamName), time.Now().Add(cookieDuration), true)
-	http.Redirect(w, r, authUrl, http.StatusTemporaryRedirect)
-}
-
 type GCPService struct {
-	env environment.Env
+	env      environment.Env
+	provider *oidc.Provider
+	config   *oauth2.Config
+	options  []oauth2.AuthCodeOption
 }
 
-func Register(env environment.Env) {
+func Register(env environment.Env) error {
+	provider, err := oidc.NewProvider(context.TODO(), Issuer)
+	if err != nil {
+		return err
+	}
+	config := &oauth2.Config{
+		ClientID:     *gcpClientId,
+		ClientSecret: *gcpClientSecret,
+		RedirectURL:  build_buddy_url.WithPath(linkURL).String(),
+		Endpoint:     provider.Endpoint(),
+		Scopes:       []string{oidc.ScopeOpenID, "profile", "email", scope},
+	}
+	options := []oauth2.AuthCodeOption{
+		oauth2.AccessTypeOffline,
+		oauth2.ApprovalForce,
+	}
+
 	env.SetGCPService(&GCPService{
-		env: env,
+		env:      env,
+		provider: provider,
+		config:   config,
+		options:  options,
 	})
+
+	return nil
+}
+
+func (g *GCPService) Link(w http.ResponseWriter, r *http.Request) error {
+	if r.FormValue("state") == "" {
+		err := g.startAuthFlow(w, r)
+		if err != nil {
+			return err
+		}
+	}
+
+	err := g.handleAuthRedirect(w, r)
+	if err != nil {
+		return err
+	}
+	
+	return nil
+}
+
+func (g *GCPService) startAuthFlow(w http.ResponseWriter, r *http.Request) error {
+	// Set the "state" cookie which will be returned to us by the authentication
+	// provider in the URL. We verify that it matches.
+	state := fmt.Sprintf("%d", random.RandUint64())
+	cookie.SetCookie(w, stateCookie, state, time.Now().Add(cookieDuration), true /* httpOnly= */)
+
+	redirectURL := r.URL.Query().Get(authRedirectParam)
+	if err := build_buddy_url.ValidateRedirect(redirectURL); err != nil {
+		return err
+	}
+
+	// Redirect to the login provider (and ask for a refresh token).
+	authURL := g.config.AuthCodeURL(state, g.options...)
+
+	// Set the redirection URL in a cookie so we can use it after validating
+	// the user in our /auth callback.
+	cookie.SetCookie(w, cookie.RedirCookie, redirectURL, time.Now().Add(cookieDuration), true /* httpOnly= */)
+
+	cookie.SetCookie(w, linkCookieName, r.URL.Query().Get(linkParamName), time.Now().Add(cookieDuration), true)
+	http.Redirect(w, r, authURL, http.StatusTemporaryRedirect)
+	return nil
+}
+
+func (g *GCPService) handleAuthRedirect(w http.ResponseWriter, r *http.Request) error {
+	// Verify "state" cookie match.
+	if r.FormValue("state") != cookie.GetCookie(r, stateCookie) {
+		return status.PermissionDeniedErrorf("state mismatch: %s != %s", r.FormValue("state"), cookie.GetCookie(r, stateCookie))
+	}
+	
+	authError := r.URL.Query().Get("error")
+	if authError != "" {
+		return status.PermissionDeniedErrorf("Authenticator returned error: %s (%s %s)", authError, r.URL.Query().Get("error_desc"), r.URL.Query().Get("error_description"))
+	}
+
+	code := r.URL.Query().Get("code")
+	oauth2Token, err := g.config.Exchange(r.Context(), code, g.options...)
+	if err != nil {
+		return status.PermissionDeniedErrorf("Error exchanging code for auth token: %s", code)
+	}
+
+	// Extract the ID Token (JWT) from OAuth2 token.
+	jwt, ok := oauth2Token.Extra("id_token").(string)
+	if !ok {
+		return status.PermissionDeniedError("ID Token not present in auth response")
+	}
+
+	c := &oidc.Config{
+		ClientID:        *gcpClientId,
+		SkipExpiryCheck: false,
+	}
+
+	_, err = g.provider.Verifier(c).Verify(r.Context(), jwt)
+	if err != nil {
+		return err
+	}
+
+	refreshToken, ok := oauth2Token.Extra("refresh_token").(string)
+	if !ok {
+		return status.PermissionDeniedError("Refresh token not present in auth response")
+	}
+	return linkForGroup(g.env, w, r, refreshToken)
 }
 
 // Accepts the redirect from the auth provider and stores the results as secrets.
-func (g *GCPService) LinkForGroup(w http.ResponseWriter, r *http.Request, refreshToken string) error {
+func linkForGroup(env environment.Env, w http.ResponseWriter, r *http.Request, refreshToken string) error {
 	if refreshToken == "" {
 		return status.PermissionDeniedErrorf("Empty refresh token")
 	}
@@ -76,8 +174,8 @@ func (g *GCPService) LinkForGroup(w http.ResponseWriter, r *http.Request, refres
 	}
 	cookie.ClearCookie(w, linkCookieName)
 	ctx := requestcontext.ContextWithProtoRequestContext(r.Context(), rc)
-	ctx = g.env.GetAuthenticator().AuthenticatedHTTPContext(w, r.WithContext(ctx))
-	secretResponse, err := g.env.GetSecretService().GetPublicKey(ctx, &skpb.GetPublicKeyRequest{
+	ctx = env.GetAuthenticator().AuthenticatedHTTPContext(w, r.WithContext(ctx))
+	secretResponse, err := env.GetSecretService().GetPublicKey(ctx, &skpb.GetPublicKeyRequest{
 		RequestContext: rc,
 	})
 	if err != nil {
@@ -87,7 +185,7 @@ func (g *GCPService) LinkForGroup(w http.ResponseWriter, r *http.Request, refres
 	if err != nil {
 		return status.PermissionDeniedErrorf("Error sealing box: %s", err)
 	}
-	_, _, err = g.env.GetSecretService().UpdateSecret(ctx, &skpb.UpdateSecretRequest{
+	_, _, err = env.GetSecretService().UpdateSecret(ctx, &skpb.UpdateSecretRequest{
 		RequestContext: rc,
 		Secret: &skpb.Secret{
 			Name:  refreshTokenEnvVariableName,

--- a/enterprise/server/oidc/BUILD
+++ b/enterprise/server/oidc/BUILD
@@ -7,7 +7,6 @@ go_library(
     srcs = ["oidc.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/oidc",
     deps = [
-        "//enterprise/server/gcplink",
         "//enterprise/server/selfauth",
         "//server/endpoint_urls/build_buddy_url",
         "//server/environment",

--- a/enterprise/server/oidc/oidc.go
+++ b/enterprise/server/oidc/oidc.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/gcplink"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/selfauth"
 	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -437,7 +436,7 @@ func (a *OpenIDAuthenticator) getAuthCodeOptions(r *http.Request) []oauth2.AuthC
 	}
 	sessionID := cookie.GetCookie(r, cookie.SessionIDCookie)
 	// If a session doesn't already exist, force a consent screen (so the user can select between multiple accounts) if enabled.
-	if (sessionID == "" && *forceApproval) || r.URL.Query().Get("show_picker") == "true" || gcplink.IsLinkRequest(r) {
+	if (sessionID == "" && *forceApproval) || r.URL.Query().Get("show_picker") == "true" {
 		options = append(options, oauth2.ApprovalForce)
 	}
 	return options
@@ -786,11 +785,6 @@ func (a *OpenIDAuthenticator) Login(w http.ResponseWriter, r *http.Request) erro
 	// the user in our /auth callback.
 	cookie.SetCookie(w, cookie.RedirCookie, redirectURL, time.Now().Add(tempCookieDuration), true /* httpOnly= */)
 
-	if gcplink.IsLinkRequest(r) {
-		gcplink.RequestAccess(w, r, u)
-		return nil
-	}
-
 	// Set the issuer cookie so we remember which issuer to use when exchanging
 	// a token later in our /auth callback.
 	cookie.SetCookie(w, cookie.AuthIssuerCookie, issuer, time.Now().Add(tempCookieDuration), true /* httpOnly= */)
@@ -841,9 +835,6 @@ func (a *OpenIDAuthenticator) Auth(w http.ResponseWriter, r *http.Request) error
 
 	// Lookup issuer from the cookie we set in /login.
 	issuer := cookie.GetCookie(r, cookie.AuthIssuerCookie)
-	if gcplink.IsLinkRequest(r) {
-		issuer = gcplink.Issuer
-	}
 	auth := a.getAuthConfig(issuer)
 	if auth == nil {
 		return status.PermissionDeniedErrorf("No config found for issuer: %s", issuer)
@@ -864,14 +855,6 @@ func (a *OpenIDAuthenticator) Auth(w http.ResponseWriter, r *http.Request) error
 	ut, err := auth.verifyTokenAndExtractUser(ctx, jwt /*checkExpiry=*/, true)
 	if err != nil {
 		return err
-	}
-
-	if gcplink.IsLinkRequest(r) {
-		refreshToken, ok := oauth2Token.Extra("refresh_token").(string)
-		if !ok {
-			return status.PermissionDeniedError("Refresh token not present in auth response")
-		}
-		return a.env.GetGCPService().LinkForGroup(w, r, refreshToken)
 	}
 
 	guid, err := uuid.NewRandom()

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -58,7 +58,7 @@ const (
 )
 
 func AuthEnabled(env environment.Env) bool {
-	return env.GetGitHubApp() != nil && *JwtKey != ""
+	return *JwtKey != ""
 }
 
 // State represents a status value that GitHub's statuses API understands.

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -576,7 +576,7 @@ type RunnerService interface {
 }
 
 type GCPService interface {
-	LinkForGroup(w http.ResponseWriter, r *http.Request, refreshToken string) error
+	Link(w http.ResponseWriter, r *http.Request) error
 	GetGCPProject(ctx context.Context, request *gcpb.GetGCPProjectRequest) (*gcpb.GetGCPProjectResponse, error)
 }
 

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -395,6 +395,10 @@ func StartAndRunServices(env environment.Env) {
 		mux.Handle("/auth/github/app/link/", interceptors.WrapAuthenticatedExternalHandler(env, gha.OAuthHandler()))
 	}
 
+	if gcp := env.GetGCPService(); gcp != nil {
+		mux.Handle("/auth/gcp/link/", interceptors.WrapAuthenticatedExternalHandler(env, interceptors.RedirectOnError(gcp.Link)))
+	}
+
 	if sp := env.GetSplashPrinter(); sp != nil {
 		sp.PrintSplashScreen(bburl.WithPath("").Hostname(), *port, grpc_server.GRPCPort())
 	}


### PR DESCRIPTION
Adds a new endpoint `/auth/gcp/link/` that sends folks through the Google Cloud scope acceptance flow (rather than hijacking the `/login/` and `/auth/` flow).

This also fixes the issue where we'd use a different gcp client for linking vs exchanging auth tokens.