### PR TITLE
Include writer.Close() time in gcs tracing

### DIFF
--- a/server/backends/blobstore/gcs/gcs.go
+++ b/server/backends/blobstore/gcs/gcs.go
@@ -131,11 +131,11 @@ func (g *GCSBlobStore) WriteBlob(ctx context.Context, blobName string, data []by
 	start := time.Now()
 	ctx, spn := tracing.StartSpan(ctx) // nolint:SA4006
 	n, err := writer.Write(compressedData)
-	if closeErr := write.Close(); err == nil && closeErr != nil {
+	if closeErr := writer.Close(); err == nil && closeErr != nil {
 		err = closeErr
 	}
 	spn.End()
-	util.RecordWriteMetrics(gcsLabel, start, n, writeErr)
+	util.RecordWriteMetrics(gcsLabel, start, n, err)
 	return n, err
 }
 


### PR DESCRIPTION
I was really impressed with GCS upload time until I realized because of the defer, we're only recording how long it takes to write to a pipe; not to actually complete the write on GCS.

Fix that.