### PR TITLE
Add two new metrics for tracking estimated RAM/CPU usage queued or executing

### DIFF
--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//enterprise/server/remote_execution/platform",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
+        "//proto:scheduler_go_proto",
         "//server/environment",
         "//server/interfaces",
         "//server/metrics",

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -188,7 +188,7 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 		DoNotCache:           task.GetAction().GetDoNotCache(),
 	}
 
-	stage := &stagedGauge{size: md.EstimatedTaskSize}
+	stage := &stagedGauge{estimatedSize: md.EstimatedTaskSize}
 	defer stage.End()
 
 	if !req.GetSkipCacheLookup() {
@@ -445,8 +445,8 @@ func observeStageDuration(groupID string, stage string, start *timestamppb.Times
 // ensuring that the gauge counts are correctly updated on each stage
 // transition.
 type stagedGauge struct {
-	stage string
-	size  *scpb.TaskSize
+	stage         string
+	estimatedSize *scpb.TaskSize
 }
 
 func (g *stagedGauge) Set(stage string) {
@@ -454,19 +454,19 @@ func (g *stagedGauge) Set(stage string) {
 		metrics.RemoteExecutionTasksExecuting.
 			With(prometheus.Labels{metrics.ExecutedActionStageLabel: prev}).
 			Dec()
-		metrics.RemoteExecutionAssignedOrQueuedMilliCPU.
-			Sub(float64(g.size.EstimatedMilliCpu))
-		metrics.RemoteExecutionAssignedOrQueuedRAMBytes.
-			Sub(float64(g.size.EstimatedMemoryBytes))
+		metrics.RemoteExecutionAssignedOrQueuedEstimatedMilliCPU.
+			Sub(float64(g.estimatedSize.EstimatedMilliCpu))
+		metrics.RemoteExecutionAssignedOrQueuedEstimatedRAMBytes.
+			Sub(float64(g.estimatedSize.EstimatedMemoryBytes))
 	}
 	if stage != "" {
 		metrics.RemoteExecutionTasksExecuting.
 			With(prometheus.Labels{metrics.ExecutedActionStageLabel: stage}).
 			Inc()
-		metrics.RemoteExecutionAssignedOrQueuedMilliCPU.
-			Add(float64(g.size.EstimatedMilliCpu))
-		metrics.RemoteExecutionAssignedOrQueuedRAMBytes.
-			Add(float64(g.size.EstimatedMemoryBytes))
+		metrics.RemoteExecutionAssignedOrQueuedEstimatedMilliCPU.
+			Add(float64(g.estimatedSize.EstimatedMilliCpu))
+		metrics.RemoteExecutionAssignedOrQueuedEstimatedRAMBytes.
+			Add(float64(g.estimatedSize.EstimatedMemoryBytes))
 	}
 	g.stage = stage
 }

--- a/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
+++ b/enterprise/server/scheduling/priority_task_scheduler/priority_task_scheduler.go
@@ -104,9 +104,9 @@ func (t *taskQueue) Enqueue(req *scpb.EnqueueTaskReservationRequest) {
 	t.numTasks++
 	metrics.RemoteExecutionQueueLength.With(prometheus.Labels{metrics.GroupID: taskGroupID}).Set(float64(pq.Len()))
 	if req.GetSchedulingMetadata().GetTrackQueuedTaskSize() {
-		metrics.RemoteExecutionAssignedOrQueuedMilliCPU.
+		metrics.RemoteExecutionAssignedOrQueuedEstimatedMilliCPU.
 			Add(float64(req.TaskSize.EstimatedMilliCpu))
-		metrics.RemoteExecutionAssignedOrQueuedRAMBytes.
+		metrics.RemoteExecutionAssignedOrQueuedEstimatedRAMBytes.
 			Add(float64(req.TaskSize.EstimatedMemoryBytes))
 	}
 }
@@ -135,9 +135,9 @@ func (t *taskQueue) Dequeue() *scpb.EnqueueTaskReservationRequest {
 	t.numTasks--
 	metrics.RemoteExecutionQueueLength.With(prometheus.Labels{metrics.GroupID: req.GetSchedulingMetadata().GetTaskGroupId()}).Set(float64(pq.Len()))
 	if req.GetSchedulingMetadata().GetTrackQueuedTaskSize() {
-		metrics.RemoteExecutionAssignedOrQueuedMilliCPU.
+		metrics.RemoteExecutionAssignedOrQueuedEstimatedMilliCPU.
 			Sub(float64(req.TaskSize.EstimatedMilliCpu))
-		metrics.RemoteExecutionAssignedOrQueuedRAMBytes.
+		metrics.RemoteExecutionAssignedOrQueuedEstimatedRAMBytes.
 			Sub(float64(req.TaskSize.EstimatedMemoryBytes))
 	}
 	return req

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1735,6 +1735,10 @@ func (s *SchedulerServer) enqueueTaskReservations(ctx context.Context, enqueueRe
 			}
 		}
 
+		// Tell the executor to add queued task sizes to system-wide metrics
+		// only once, for the first probe.
+		enqueueRequest.SchedulingMetadata.TrackQueuedTaskSize = (probesSent == 0)
+
 		enqueueStart := time.Now()
 		if opts.scheduleOnConnectedExecutors {
 			if node.handle == nil {

--- a/proto/scheduler.proto
+++ b/proto/scheduler.proto
@@ -131,6 +131,15 @@ message SchedulingMetadata {
   string executor_group_id = 5;
   // Group ID of the user that issued the Execute request.
   string task_group_id = 6;
+
+  // A signal to the executor that the size of this queued task should be
+  // tracked as part of the queued-or-assigned size metrics. This is necessary
+  // because tasks may be scheduled on multiple executors, but should only
+  // contributed to this system-wide metric once, so the scheduler must inform
+  // exactly one of the executors to perform the queued task size tracking.
+  // This is for metrics purposes only and shouldn't affect the behavior of the
+  // scheduler or the executor.
+  bool track_queued_task_size = 9;
 }
 
 message ScheduleTaskRequest {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -898,7 +898,7 @@ var (
 	RemoteExecutionAssignedOrQueuedEstimatedMilliCPU = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",
-		Name:      "assigned_and_queued_estimated)milli_cpu",
+		Name:      "assigned_and_queued_estimated_milli_cpu",
 		Help:      "Estimated CPU time on the executor that is currently allocated for queued or executing tasks, in **milliCPU** (CPU-milliseconds per second). Note that this is a fuzzy estimate because there's no guarantee that tasks queued on a machine will be handled by that machine.",
 	})
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -874,6 +874,13 @@ var (
 		Help:      "Estimated RAM on the executor that is currently allocated for task execution, in **bytes**.",
 	})
 
+	RemoteExecutionAssignedOrQueuedRAMBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "assigned_and_queued_ram_bytes",
+		Help:      "Estimated RAM on the executor that is currently allocated for queued or executing tasks, in **bytes**. Note that this is a fuzzy estimate because there's no guarantee that tasks queued on a machine will be handled by that machine.",
+	})
+
 	RemoteExecutionAssignableRAMBytes = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",
@@ -886,6 +893,13 @@ var (
 		Subsystem: "remote_execution",
 		Name:      "assigned_milli_cpu",
 		Help:      "Estimated CPU time on the executor that is currently allocated for task execution, in **milliCPU** (CPU-milliseconds per second).",
+	})
+
+	RemoteExecutionAssignedOrQueuedMilliCPU = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "assigned_and_queued_milli_cpu",
+		Help:      "Estimated CPU time on the executor that is currently allocated for queued or executing tasks, in **milliCPU** (CPU-milliseconds per second). Note that this is a fuzzy estimate because there's no guarantee that tasks queued on a machine will be handled by that machine.",
 	})
 
 	RemoteExecutionAssignableMilliCPU = promauto.NewGauge(prometheus.GaugeOpts{

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -874,10 +874,10 @@ var (
 		Help:      "Estimated RAM on the executor that is currently allocated for task execution, in **bytes**.",
 	})
 
-	RemoteExecutionAssignedOrQueuedRAMBytes = promauto.NewGauge(prometheus.GaugeOpts{
+	RemoteExecutionAssignedOrQueuedEstimatedRAMBytes = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",
-		Name:      "assigned_and_queued_ram_bytes",
+		Name:      "assigned_and_queued_estimated_ram_bytes",
 		Help:      "Estimated RAM on the executor that is currently allocated for queued or executing tasks, in **bytes**. Note that this is a fuzzy estimate because there's no guarantee that tasks queued on a machine will be handled by that machine.",
 	})
 
@@ -895,10 +895,10 @@ var (
 		Help:      "Estimated CPU time on the executor that is currently allocated for task execution, in **milliCPU** (CPU-milliseconds per second).",
 	})
 
-	RemoteExecutionAssignedOrQueuedMilliCPU = promauto.NewGauge(prometheus.GaugeOpts{
+	RemoteExecutionAssignedOrQueuedEstimatedMilliCPU = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",
-		Name:      "assigned_and_queued_milli_cpu",
+		Name:      "assigned_and_queued_estimated)milli_cpu",
 		Help:      "Estimated CPU time on the executor that is currently allocated for queued or executing tasks, in **milliCPU** (CPU-milliseconds per second). Note that this is a fuzzy estimate because there's no guarantee that tasks queued on a machine will be handled by that machine.",
 	})
 


### PR DESCRIPTION
I'm planning to take a look at how this fares in dev for a little while, compared to the current autoscaler metric of queued tasks, and then explore autoscaling off this instead.

**Related issues**: N/A
