### PR TITLE
[SS] Use finer-grained locking in COWStore

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/BUILD
+++ b/enterprise/server/remote_execution/copy_on_write/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//server/environment",
         "//server/interfaces",
         "//server/remote_cache/digest",
+        "//server/util/lockmap",
         "//server/util/log",
         "//server/util/status",
         "@org_golang_x_exp//maps",

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/lockmap"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"golang.org/x/exp/maps"
@@ -61,7 +62,14 @@ type COWStore struct {
 	// in addition to local caching
 	remoteEnabled bool
 
-	mu sync.RWMutex // Protects chunks and dirty
+	// storeLock locks the entire store.
+	// It can be used to prevent concurrent map access of chunks and dirty.
+	// storeLock has worse performance, so use chunkLock when possible.
+	storeLock sync.RWMutex
+	// chunkLock can be used to lock a single chunk, to synchronize simultaneous
+	// access on that chunk (i.e. two goroutines trying to initialize and copy a chunk
+	// at the same time).
+	chunkLock lockmap.Locker
 
 	// chunks is a mapping of chunk offset to the backing data store
 	chunks map[int64]*Mmap
@@ -111,6 +119,7 @@ func NewCOWStore(ctx context.Context, env environment.Env, chunks []*Mmap, chunk
 		env:                env,
 		remoteInstanceName: remoteInstanceName,
 		remoteEnabled:      remoteEnabled,
+		chunkLock:          lockmap.New(),
 		chunks:             chunkMap,
 		dirty:              make(map[int64]bool, 0),
 		dataDir:            dataDir,
@@ -177,15 +186,18 @@ func (c *COWStore) GetPageAddress(offset uintptr, write bool) (uintptr, error) {
 
 	c.eagerFetchNextChunks(chunkStartOffset)
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	if write {
 		if err := c.copyChunkIfNotDirty(chunkStartOffset); err != nil {
 			return 0, status.WrapError(err, "copy chunk")
 		}
 	}
 
+	chunkUnlockFn := c.chunkLock.RLock(fmt.Sprintf("%d", chunkStartOffset))
+	defer chunkUnlockFn()
+
+	c.storeLock.RLock()
 	chunk := c.chunks[chunkStartOffset]
+	c.storeLock.RUnlock()
 	if chunk == nil {
 		// No data (yet); map into our static zero-filled buf. Note that this
 		// can only happen for reads, since for writes we call copyChunkIfNotDirty above.
@@ -203,9 +215,9 @@ func (c *COWStore) GetPageAddress(offset uintptr, write bool) (uintptr, error) {
 
 // SortedChunks returns all chunks sorted by offset.
 func (c *COWStore) SortedChunks() []*Mmap {
-	c.mu.RLock()
+	c.storeLock.RLock()
 	chunks := maps.Values(c.chunks)
-	c.mu.RUnlock()
+	c.storeLock.RUnlock()
 
 	sort.Slice(chunks, func(i, j int) bool {
 		return chunks[i].Offset < chunks[j].Offset
@@ -229,9 +241,6 @@ func (c *COWStore) ReadAt(p []byte, off int64) (int, error) {
 
 	c.eagerFetchNextChunks(chunkOffset)
 
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
 	for len(p) > 0 {
 		chunkRelativeOffset := off % c.chunkSizeBytes
 		chunkCalculatedSize := c.calculateChunkSize(chunkOffset)
@@ -239,51 +248,11 @@ func (c *COWStore) ReadAt(p []byte, off int64) (int, error) {
 		if readSize > len(p) {
 			readSize = len(p)
 		}
-		chunk := c.chunks[chunkOffset]
-		if chunk == nil {
-			// No chunk at this index yet; write all 0s.
-			copy(p[:readSize], c.zeroBuf)
-		} else {
-			// chunkActualSize will be different than chunkCalculatedSize only
-			// if this chunk was the last chunk when we called Resize(). This is
-			// because Resize() does not actually resize the chunk itself - it
-			// is a lazy operation that "virtually" right-pads the COWStore with
-			// 0s. So in this case, we need to limit the amount of data
-			// requested from the chunk (readSize) to the amount of data that's
-			// actually remaining in the chunk (remainingDataSize), then fill
-			// the remainder with zeroes.
-			//
-			// For example, let's say we have the following chunks, before
-			// resizing:
-			//     [1111]  [1]
-			//     c1      c2
-			// Now let's say we Resize, increasing the COW's total size by 4
-			// bytes. (Bytes between "[]"" are physically present in the chunk,
-			// while other bytes are "virtual")
-			//     [1111]  [1]000  0
-			//     c1      c2      c3
-			// Now, the chunkActualSize of c2 will still be 1, while the
-			// chunkCalculatedSize will be 4. So when reading from c2, we need
-			// to make sure that we zero-pad when reading offset >= 1.
 
-			chunkActualSize, err := chunk.SizeBytes()
-			if err != nil {
-				return n, err
-			}
-			// Chunk might have less data available than the calculated size
-			// if this was the last chunk when we resized. If so then fill
-			// the range from [dataSize, readSize) with 0s.
-			dataSize := int64(readSize)
-			if remainder := chunkActualSize - chunkRelativeOffset; readSize > int(remainder) {
-				dataSize = max(0, remainder)
-			}
-			if dataSize > 0 {
-				if _, err := readFullAt(chunk, p[:dataSize], chunkRelativeOffset); err != nil {
-					return n, err
-				}
-			}
-			copy(p[dataSize:readSize], c.zeroBuf)
+		if err := c.readChunk(p, chunkRelativeOffset, chunkOffset, readSize); err != nil {
+			return n, err
 		}
+
 		n += readSize
 		p = p[readSize:]
 		off += int64(readSize)
@@ -292,6 +261,61 @@ func (c *COWStore) ReadAt(p []byte, off int64) (int, error) {
 	return n, nil
 }
 
+func (c *COWStore) readChunk(p []byte, readRelativeOffset int64, chunkStartOffset int64, readSize int) error {
+	chunkUnlockFn := c.chunkLock.RLock(fmt.Sprintf("%d", chunkStartOffset))
+	defer chunkUnlockFn()
+
+	c.storeLock.RLock()
+	chunk := c.chunks[chunkStartOffset]
+	c.storeLock.RUnlock()
+	if chunk == nil {
+		// No chunk at this index yet; write all 0s.
+		copy(p[:readSize], c.zeroBuf)
+		return nil
+	}
+
+	// chunkActualSize will be different than chunkCalculatedSize only
+	// if this chunk was the last chunk when we called Resize(). This is
+	// because Resize() does not actually resize the chunk itself - it
+	// is a lazy operation that "virtually" right-pads the COWStore with
+	// 0s. So in this case, we need to limit the amount of data
+	// requested from the chunk (readSize) to the amount of data that's
+	// actually remaining in the chunk (remainingDataSize), then fill
+	// the remainder with zeroes.
+	//
+	// For example, let's say we have the following chunks, before
+	// resizing:
+	//     [1111]  [1]
+	//     c1      c2
+	// Now let's say we Resize, increasing the COW's total size by 4
+	// bytes. (Bytes between "[]"" are physically present in the chunk,
+	// while other bytes are "virtual")
+	//     [1111]  [1]000  0
+	//     c1      c2      c3
+	// Now, the chunkActualSize of c2 will still be 1, while the
+	// chunkCalculatedSize will be 4. So when reading from c2, we need
+	// to make sure that we zero-pad when reading offset >= 1.
+
+	chunkActualSize, err := chunk.SizeBytes()
+	if err != nil {
+		return err
+	}
+	// Chunk might have less data available than the calculated size
+	// if this was the last chunk when we resized. If so then fill
+	// the range from [dataSize, readSize) with 0s.
+	dataSize := int64(readSize)
+	if remainder := chunkActualSize - readRelativeOffset; readSize > int(remainder) {
+		dataSize = max(0, remainder)
+	}
+	if dataSize > 0 {
+		_, err = readFullAt(chunk, p[:dataSize], readRelativeOffset)
+		if err != nil {
+			return err
+		}
+	}
+	copy(p[dataSize:readSize], c.zeroBuf)
+	return nil
+}
 func (c *COWStore) WriteAt(p []byte, off int64) (int, error) {
 	if err := checkBounds("write", c.totalSizeBytes, p, off); err != nil {
 		return 0, err
@@ -301,9 +325,6 @@ func (c *COWStore) WriteAt(p []byte, off int64) (int, error) {
 	n := 0
 
 	c.eagerFetchNextChunks(chunkOffset)
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	for len(p) > 0 {
 		// On each iteration, write to one chunk, first copying the readonly
@@ -317,17 +338,32 @@ func (c *COWStore) WriteAt(p []byte, off int64) (int, error) {
 		if writeSize > len(p) {
 			writeSize = len(p)
 		}
-		chunk := c.chunks[chunkOffset]
-		nw, err := chunk.WriteAt(p[:writeSize], chunkRelativeOffset)
+
+		nw, err := c.writeToChunk(p, chunkRelativeOffset, chunkOffset, writeSize)
 		n += nw
 		if err != nil {
 			return n, err
 		}
-		if nw != writeSize {
-			return n, io.ErrShortWrite
-		}
 		p = p[writeSize:]
 		chunkOffset += c.chunkSizeBytes
+	}
+	return n, nil
+}
+
+func (c *COWStore) writeToChunk(p []byte, writeRelativeOffset int64, chunkStartOffset int64, writeSize int) (int, error) {
+	chunkUnlockFn := c.chunkLock.Lock(fmt.Sprintf("%d", chunkStartOffset))
+	defer chunkUnlockFn()
+
+	c.storeLock.RLock()
+	chunk := c.chunks[chunkStartOffset]
+	c.storeLock.RUnlock()
+
+	n, err := chunk.WriteAt(p[:writeSize], writeRelativeOffset)
+	if err != nil {
+		return n, err
+	}
+	if n != writeSize {
+		return n, io.ErrShortWrite
 	}
 	return n, nil
 }
@@ -367,8 +403,8 @@ func (s *COWStore) SizeBytes() (int64, error) {
 
 // Dirty returns whether the chunk at the given offset is dirty.
 func (s *COWStore) Dirty(chunkOffset int64) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.storeLock.RLock()
+	defer s.storeLock.RUnlock()
 	return s.dirty[chunkOffset]
 }
 
@@ -436,9 +472,14 @@ func (s *COWStore) calculateChunkSize(startOffset int64) int64 {
 	return size
 }
 
-// NOTE: This function should be executed atomically. Callers should manage locking
 func (s *COWStore) copyChunkIfNotDirty(chunkStartOffset int64) (err error) {
-	if s.dirty[chunkStartOffset] {
+	chunkUnlockFn := s.chunkLock.Lock(fmt.Sprintf("%d", chunkStartOffset))
+	defer chunkUnlockFn()
+
+	s.storeLock.RLock()
+	dirty := s.dirty[chunkStartOffset]
+	s.storeLock.RUnlock()
+	if dirty {
 		// Chunk is already dirty - no need to copy
 		return nil
 	}
@@ -508,7 +549,9 @@ func (s *COWStore) initDirtyChunk(offset int64, size int64) (ogChunk *Mmap, newC
 		return nil, nil, err
 	}
 
+	s.storeLock.RLock()
 	ogChunk = s.chunks[offset]
+	s.storeLock.RUnlock()
 	chunkSource := snaputil.ChunkSourceHole
 	if ogChunk != nil {
 		if !ogChunk.safeReadMapped() {
@@ -523,8 +566,10 @@ func (s *COWStore) initDirtyChunk(offset int64, size int64) (ogChunk *Mmap, newC
 		return nil, nil, err
 	}
 
+	s.storeLock.Lock()
 	s.chunks[offset] = newChunk
 	s.dirty[offset] = true
+	s.storeLock.Unlock()
 
 	return ogChunk, newChunk, nil
 }
@@ -579,9 +624,12 @@ func (s *COWStore) eagerFetchChunksInBackground() {
 }
 
 func (s *COWStore) fetchChunk(offset int64) error {
-	s.mu.RLock()
+	chunkUnlockFn := s.chunkLock.Lock(fmt.Sprintf("%d", offset))
+	defer chunkUnlockFn()
+
+	s.storeLock.RLock()
 	c := s.chunks[offset]
-	s.mu.RUnlock()
+	s.storeLock.RUnlock()
 
 	// Skip holes
 	if c == nil {


### PR DESCRIPTION
In the COWStore, we need locking to prevent concurrent access of maps, and also to synchronize simultaneous actions on a chunk - in particular when we're copying a chunk. We copy chunks when they are written to. When copying, we first initialize an empty chunk, and then copy over the original data to it. We need to make sure concurrent goroutines don't try to read from the empty new chunk, or write to the outdated old chunk for example.

Our hypothesis (validated below) is that locking in this second case hurts performance, because it's wrapped around a large and slow chunk of code that includes copying the data over. This PR adds a finer grained lock in this case, so we can just lock access to that chunk and not the entire store.

Testing PR: #5334 

For an incremental build on gazelle repo: 

On master:
For store memory, total lock time is 45684 (ms)

With this PR:
For store memory, total lock time is 15 (ms)


**Related issues**: More convo in #4920 
