### PR TITLE
Gracefully handle case where the user doesn't have any GCP projects

### DIFF
--- a/app/picker/picker.tsx
+++ b/app/picker/picker.tsx
@@ -96,7 +96,14 @@ export default class Picker extends React.Component<{}, State> {
                   {o}
                 </div>
               ))}
-              {!Boolean(this.matchingOptions()?.length) && <div className="picker-option">No matches found.</div>}
+              {!Boolean(this.matchingOptions()?.length) && (
+                <div className="picker-option">
+                  {this.state.picker?.emptyState ? this.state.picker.emptyState : <>No matches found.</>}
+                </div>
+              )}
+              {Boolean(this.matchingOptions()?.length) && this.state.picker?.footer && (
+                <div className="picker-option">{this.state.picker?.footer}</div>
+              )}
             </div>
           </div>
         </div>

--- a/app/picker/picker_service.ts
+++ b/app/picker/picker_service.ts
@@ -4,6 +4,8 @@ export type PickerModel = {
   title: string;
   placeholder: string;
   options: string[];
+  emptyState?: any;
+  footer?: any;
 };
 
 export class PickerService {

--- a/enterprise/app/repo/repo.css
+++ b/enterprise/app/repo/repo.css
@@ -279,6 +279,37 @@
   object-position: 0 50%;
 }
 
+.gcp-picker-footer,
+.gcp-picker-empty-state {
+  cursor: default;
+}
+
+.gcp-picker-footer {
+  border-top: 1px solid #eee;
+  padding-top: 16px;
+  margin-top: 10px;
+}
+
+.gcp-picker-footer a,
+.gcp-picker-empty-state a {
+  font-weight: bold;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.gcp-picker-footer button,
+.gcp-picker-empty-state button {
+  border: 0;
+  background: #eee;
+  font-family: inherit;
+  font-size: inherit;
+  padding: 12px;
+  width: 100%;
+  cursor: pointer;
+  border-radius: 8px;
+  font-weight: 600;
+}
+
 @media (max-width: 540px) {
   .create-repo-page .repo-picker {
     flex-direction: column;

--- a/enterprise/app/repo/repo.tsx
+++ b/enterprise/app/repo/repo.tsx
@@ -317,14 +317,44 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
   }
 
   async promptGCPProjectPicker() {
+    let picked = await this.showGCPProjectPicker();
+    await encryptAndUpdate(gcpProjectKey, picked);
+  }
+  async showGCPProjectPicker() {
     let resp = await rpc_service.service.getGCPProject({});
-    // TODO(siggisim): Handle the case where there aren't any GCP Projects.
-    let picked = await picker_service.show({
-      placeholder: "Pick a project or search...",
+    return await picker_service.show({
+      placeholder: "Pick a GCP project or search...",
       title: "Projects",
       options: resp.project.map((p) => p.id),
+      emptyState: (
+        <div className="gcp-picker-empty-state">
+          No Google Cloud Projects found!
+          <br />
+          <br />
+          <a href="https://console.cloud.google.com/projectcreate" target="_blank">
+            Click here to create a Google Cloud project
+          </a>
+          , and then click refresh below to update this list.
+          <br />
+          <br />
+          <button onClick={this.showGCPProjectPicker.bind(this)}>Refresh</button>
+        </div>
+      ),
+      footer: (
+        <div className="gcp-picker-footer">
+          Don't want to deploy to any of these projects?
+          <br />
+          <br />
+          <a href="https://console.cloud.google.com/projectcreate" target="_blank">
+            Click here to create a Google Cloud project
+          </a>
+          , and then click refresh below to update this list.
+          <br />
+          <br />
+          <button onClick={this.showGCPProjectPicker.bind(this)}>Refresh</button>
+        </div>
+      ),
     });
-    await encryptAndUpdate(gcpProjectKey, picked);
   }
 
   async handleDeployClicked(repoResponse: repo.CreateRepoResponse) {

--- a/enterprise/app/repo/repo.tsx
+++ b/enterprise/app/repo/repo.tsx
@@ -328,7 +328,7 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
       options: resp.project.map((p) => p.id),
       emptyState: (
         <div className="gcp-picker-empty-state">
-          No Google Cloud Projects found!
+          No Google Cloud projects found!
           <br />
           <br />
           <a href="https://console.cloud.google.com/projectcreate" target="_blank">


### PR DESCRIPTION
Shows this if the user doesn't have any GCP projects:
<img width="1477" alt="Screenshot 2023-11-15 at 4 10 37 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/a9c7738e-f9da-44ea-b002-f79cf6b815d6">

And this at the bottom if the user does have projects:
<img width="1449" alt="Screenshot 2023-11-15 at 4 04 20 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/49ca19ea-594f-402f-9a99-fb2549736299">
