### PR TITLE
Reduce allocations when extracting invocation ID

### DIFF
--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -139,7 +139,7 @@ func copyHeadersToContext(ctx context.Context) context.Context {
 			ctx = context.WithValue(ctx, contextKey, hdrs[0])
 		}
 	}
-	ctx = bazel_request.ExtractValuesIntoContext(ctx)
+	ctx = bazel_request.ParseRequestMetadataOnce(ctx)
 	return ctx
 }
 

--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -279,6 +279,8 @@ func subdomainUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 }
 
 func addInvocationIdToLog(ctx context.Context) context.Context {
+	ctx = bazel_request.ExtractValuesIntoContext(ctx)
+
 	if iid := bazel_request.GetInvocationID(ctx); iid != "" {
 		return log.EnrichContext(ctx, log.InvocationIDKey, iid)
 	}

--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -139,7 +139,7 @@ func copyHeadersToContext(ctx context.Context) context.Context {
 			ctx = context.WithValue(ctx, contextKey, hdrs[0])
 		}
 	}
-
+	ctx = bazel_request.ExtractValuesIntoContext(ctx)
 	return ctx
 }
 
@@ -279,8 +279,6 @@ func subdomainUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 }
 
 func addInvocationIdToLog(ctx context.Context) context.Context {
-	ctx = bazel_request.ExtractValuesIntoContext(ctx)
-
 	if iid := bazel_request.GetInvocationID(ctx); iid != "" {
 		return log.EnrichContext(ctx, log.InvocationIDKey, iid)
 	}

--- a/server/util/bazel_request/BUILD
+++ b/server/util/bazel_request/BUILD
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
-        "//server/util/pbwireutil",
         "//server/util/status",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_protobuf//proto",

--- a/server/util/bazel_request/BUILD
+++ b/server/util/bazel_request/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
+        "//server/util/log",
         "//server/util/pbwireutil",
         "//server/util/status",
         "@org_golang_google_grpc//metadata",

--- a/server/util/bazel_request/BUILD
+++ b/server/util/bazel_request/BUILD
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
-        "//server/util/log",
         "//server/util/pbwireutil",
         "//server/util/status",
         "@org_golang_google_grpc//metadata",

--- a/server/util/bazel_request/bazel_request.go
+++ b/server/util/bazel_request/bazel_request.go
@@ -75,9 +75,11 @@ func GetInvocationID(ctx context.Context) string {
 	if iid, ok := ctx.Value(invocationIDContextKey).(string); ok {
 		return iid
 	}
-
 	const toolInvocationIDFieldNumber = 3
 	b := GetRequestMetadataBytes(ctx)
+	if len(b) == 0 {
+		return ""
+	}
 	value, _ := pbwireutil.ConsumeFirstString(b, toolInvocationIDFieldNumber)
 	return value
 }

--- a/server/util/bazel_request/bazel_request.go
+++ b/server/util/bazel_request/bazel_request.go
@@ -24,7 +24,6 @@ const (
 	RequestMetadataKey = "build.bazel.remote.execution.v2.requestmetadata-bin"
 
 	requestMetadataContextKey = "bazel_request.request_metadata"
-	invocationIDContextKey    = "bazel_request.invocation_id"
 )
 
 func GetRequestMetadataBytes(ctx context.Context) []byte {

--- a/server/util/usageutil/BUILD
+++ b/server/util/usageutil/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//server/tables",
         "//server/util/bazel_request",
-        "//server/util/pbwireutil",
         "@org_golang_google_grpc//metadata",
     ],
 )

--- a/server/util/usageutil/usageutil.go
+++ b/server/util/usageutil/usageutil.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
-	"github.com/buildbuddy-io/buildbuddy/server/util/pbwireutil"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -76,25 +75,9 @@ func clientLabel(ctx context.Context) string {
 	if len(vals) > 0 {
 		return vals[0]
 	}
-
-	// Note: we avoid deserializing the RequestMetadata proto here since
-	// proto deserialization is too expensive to run on every request.
-	b := bazel_request.GetRequestMetadataBytes(ctx)
-	if len(b) == 0 {
-		return ""
+	toolName := bazel_request.GetToolName(ctx)
+	if toolName == "bazel" {
+		return bazelClientLabel
 	}
-	const (
-		mdToolDetailsFieldNumber       = 1
-		toolDetailsToolNameFieldNumber = 1
-	)
-	toolDetailsBytes, _ := pbwireutil.ConsumeFirstBytes(b, mdToolDetailsFieldNumber)
-	if len(toolDetailsBytes) > 0 {
-		toolName, _ := pbwireutil.ConsumeFirstString(toolDetailsBytes, toolDetailsToolNameFieldNumber)
-		if toolName == "bazel" {
-			return bazelClientLabel
-		}
-		return ""
-	}
-
 	return ""
 }


### PR DESCRIPTION
just by doing a normal build I see this has a significant impact in reducing allocations because we're not re-extracting that metadata proto over and over again.