### PR TITLE
Make version number in footer link to Github release

### DIFF
--- a/app/footer/footer.tsx
+++ b/app/footer/footer.tsx
@@ -14,8 +14,13 @@ export default class FooterComponent extends React.Component {
           Privacy
         </a>
         <a href="https://buildbuddy.io" target="_blank">
-          BuildBuddy {capabilities.version != "unknown" && capabilities.version}
+          BuildBuddy
         </a>
+        {capabilities.version != "unknown" && (
+          <a href={`https://github.com/buildbuddy-io/buildbuddy/releases/tag/${capabilities.version}`} target="_blank">
+            {capabilities.version}
+          </a>
+        )}
         <a href="mailto:hello@buildbuddy.io" target="_blank">
           Contact us
         </a>


### PR DESCRIPTION
Allows you to quickly see release notes for the current release by clicking this guy:
<img width="1416" alt="Screenshot 2023-11-15 at 6 20 36 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/a0fab110-4376-4688-aa65-d541f333c513">
