### PR TITLE
buildbuddy.yaml: add workflow to validate FOSS build

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -10,6 +10,18 @@ actions:
           - "*"
     bazel_commands:
       - test //... --config=linux-workflows --config=race --test_tag_filters=-performance,-webdriver,-docker,-bare
+  - name: Test FOSS build
+    container_image: ubuntu-20.04
+    triggers:
+      push:
+        branches:
+          - "master"
+      pull_request:
+        branches:
+          - "*"
+    bazel_commands:
+      - run --config=linux-workflows --config=race //tools:rm-enterprise
+      - build --config=linux-workflows --config=race //server
   - name: Test with static
     container_image: ubuntu-20.04
     triggers:

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,1 +1,13 @@
 package(default_visibility = ["//visibility:public"])
+
+genrule(
+    name = "rm-enterprise",
+    outs = ["rm-enterprise.sh"],
+    cmd = """
+    cat <<'EOF' > $@
+#!/bin/bash
+rm -rf $$BUILD_WORKING_DIRECTORY/enterprise
+EOF
+""",
+    executable = True,
+)


### PR DESCRIPTION
We should be able to build FOSS successfully without depending on
//enterprise.
