### PR TITLE
Reduce findmissing fanout

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -731,8 +731,8 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 	// For every digest we found, if we did not find it
 	// on the first peer in our list, we want to backfill it.
 	backfills := make([]*backfillOrder, 0)
-	for h, present := range foundMap {
-		if !present {
+	for h, foundOnPeer := range foundMap {
+		if !foundOnPeer {
 			continue
 		}
 		r := hashResources[h][0]

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -706,8 +706,8 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 				}
 				for _, r := range resources {
 					hash := r.GetDigest().GetHash()
-					_, ok := peerMissingHashes[hash]
-					foundMap[hash] = !ok
+					_, missing := peerMissingHashes[hash]
+					foundMap[hash] = !missing
 				}
 				return nil
 			})
@@ -725,21 +725,6 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 			// If we've tried everything, we can exit now.
 			break
 		}
-	}
-
-	// For every digest we found, if we did not find it
-	// on the first peer in our list, we want to backfill it.
-	backfills := make([]*backfillOrder, 0)
-	for h, foundOnPeer := range foundMap {
-		if !foundOnPeer {
-			continue
-		}
-		r := hashResources[h][0]
-		ps := peerMap[h]
-		backfills = append(backfills, c.getBackfillOrders(r, ps)...)
-	}
-	if err := c.backfillPeers(ctx, backfills); err != nil {
-		c.log.CtxDebugf(ctx, "Error backfilling peers: %s", err)
 	}
 
 	var missing []*repb.Digest

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -721,10 +721,13 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 			}
 			continue
 		}
-		if len(foundMap) == len(hashResources) {
-			// If we've found everything, we can exit now.
-			break
-		}
+
+		// It's possible that a file exists on a non-primary shard,
+		// but we report it as missing. This might trigger a very small
+		// number of duplicate writes (which get short-circuited anyway)
+		// but it should drastically reduce the fanout necessary to
+		// serve FindMissing calls.
+		break
 	}
 
 	// For every digest we found, if we did not find it

--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -706,9 +706,8 @@ func (c *Cache) FindMissing(ctx context.Context, resources []*rspb.ResourceName)
 				}
 				for _, r := range resources {
 					hash := r.GetDigest().GetHash()
-					if _, ok := peerMissingHashes[hash]; !ok {
-						foundMap[hash] = true
-					}
+					_, ok := peerMissingHashes[hash]
+					foundMap[hash] = !ok
 				}
 				return nil
 			})


### PR DESCRIPTION
We discussed over lunch the idea of reducing FindMissing fanout. This change limits the number of nodes contacted for each digest in a FindMissing call to 1 at the risk of returning false-positive responses in FindMissing (basically: saying something is missing when really we have it).

We don't believe this should cause issues because the cases where digests are not on the correct replica are rare and if they are encountered we'll possibly trigger an extra write