### PR TITLE
Fix UnpackContainerImage always converting image to COW

### DIFF
--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -854,6 +854,7 @@ func UnpackContainerImage(ctx context.Context, l *FileCacheLoader, imageRef, ima
 	opts := &CacheSnapshotOptions{
 		ChunkedFiles: map[string]*copy_on_write.COWStore{rootfsFileName: cow},
 		Recycled:     false,
+		Remote:       *snaputil.EnableRemoteSnapshotSharing,
 	}
 	if err := l.CacheSnapshot(ctx, key.GetBranchKey(), opts); err != nil {
 		return nil, status.WrapError(err, "cache containerfs snapshot")


### PR DESCRIPTION
This is causing about 2-3 seconds of delay for every firecracker action w/ COW enabled and also lots of disk I/O.

**Related issues**: N/A
