### PR TITLE
tools/cas: fallback to use api key from git config

### DIFF
--- a/cli/BUILD
+++ b/cli/BUILD
@@ -1,3 +1,6 @@
+# gazelle:default_visibility //cli:__subpackages__
+package(default_visibility = ["//cli:__subpackages__"])
+
 alias(
     name = "cli",
     actual = "//cli/cmd/bb",
@@ -6,6 +9,3 @@ alias(
 exports_files(
     srcs = ["install.sh"],
 )
-
-# gazelle:default_visibility //cli:__subpackages__
-package(default_visibility = ["//cli:__subpackages__"])

--- a/cli/storage/BUILD
+++ b/cli/storage/BUILD
@@ -1,10 +1,14 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+# gazelle:default_visibility //cli:__subpackages__,//tools:__subpackages__
+package(default_visibility = [
+    "//cli:__subpackages__",
+    "//tools:__subpackages__",
+])
+
 go_library(
     name = "storage",
     srcs = ["storage.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/storage",
     deps = ["//cli/workspace"],
 )
-
-package(default_visibility = ["//cli:__subpackages__"])

--- a/tools/cas/BUILD
+++ b/tools/cas/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/tools/cas",
     visibility = ["//visibility:private"],
     deps = [
+        "//cli/storage",
         "//proto:buildbuddy_service_go_proto",
         "//proto:cache_go_proto",
         "//proto:remote_execution_go_proto",


### PR DESCRIPTION
When use tools/cas, it's easy to leak API key to BES.

For example:
`bazel run tools/cas -- -api_key=foobar`
would send the `-api_key=foobar` over the wire to the server side for
display.

A good workaround to this is to make sure BES is not used during `bazel
run`:

```

run --bes_results_url=
run --bes_backend=
```

However it would be good to not having to set the API key manually at
all. Since our `bb` CLI is already setting the API key inside
`.git/config` in a dedicated `buildbuddy` section, let's re-use that.
