### PR TITLE
chore: cleanup TODOs related to package visibility

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -1,10 +1,8 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-# TODO(sluongng): ensure all //enterprise code are not dependency of FOSS code
-# gazelle:default_visibility //enterprise:__subpackages__,//server/static:__pkg__
+# gazelle:default_visibility //enterprise:__subpackages__
 package(default_visibility = [
     "//enterprise:__subpackages__",
-    "//server/static:__pkg__",
 ])
 
 go_library(

--- a/enterprise/server/util/vsock/BUILD
+++ b/enterprise/server/util/vsock/BUILD
@@ -1,7 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-# TODO(sluongng): ensure all //enterprise code are not dependency of FOSS code
-# gazelle:default_visibility //enterprise:__subpackages__
 package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(


### PR DESCRIPTION
These are no longer needed now that //server could be built
independently from //enterprise.

There are still some part of //cli that depend on //enterprise directly,
but we could address it separately.
