### PR TITLE
Fix workflow hit rate metric

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -940,6 +940,13 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 	log.CtxDebugf(ctx, "Command: %v", reflect.Indirect(reflect.Indirect(reflect.ValueOf(machine)).FieldByName("cmd")).FieldByName("Args"))
 
 	snap, err := c.loader.GetSnapshot(ctx, c.snapshotKeySet, c.supportsRemoteSnapshots)
+	label := metrics.HitStatusLabel
+	if err != nil {
+		label = metrics.MissStatusLabel
+	}
+	metrics.RecycleRunnerRequests.With(prometheus.Labels{
+		metrics.RecycleRunnerRequestStatusLabel: label,
+	}).Inc()
 	if err != nil {
 		return status.WrapError(err, "failed to get snapshot")
 	}

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -327,18 +327,8 @@ func (l *FileCacheLoader) fetchRemoteManifest(ctx context.Context, key *fcpb.Sna
 	rn := digest.NewResourceName(d, key.InstanceName, rspb.CacheType_AC, repb.DigestFunction_BLAKE3)
 	acResult, err := cachetools.GetActionResult(ctx, l.env.GetActionCacheClient(), rn)
 	if err != nil {
-		if status.IsNotFoundError(err) {
-			metrics.RecycleRunnerRequests.With(prometheus.Labels{
-				metrics.RecycleRunnerRequestStatusLabel: metrics.MissStatusLabel,
-			}).Inc()
-		}
 		return nil, err
 	}
-
-	metrics.RecycleRunnerRequests.With(prometheus.Labels{
-		metrics.RecycleRunnerRequestStatusLabel: metrics.HitStatusLabel,
-	}).Inc()
-
 	tmpDir := l.env.GetFileCache().TempDir()
 	return l.actionResultToManifest(ctx, key.InstanceName, acResult, tmpDir)
 }


### PR DESCRIPTION
`loader.GetSnapshot` is used by `UnpackContainerImage` so we're incorrectly recording runner hits/misses when calling that `UnpackContainerImage`. We want the hit rate to apply to the whole VM snapshot, not the containerfs snapshot.

Side note, a containerfs hit/miss is not a huge deal since we can just chunk up the local containerfs on disk into a COW which only takes a few seconds. So we probably don't need a separate metric for this for now.

**Related issues**: N/A
