### PR TITLE
Add `--registry_mirror=` which defaults to `mirror.gcr.io`

### DIFF
--- a/enterprise/server/cmd/goinit/main.go
+++ b/enterprise/server/cmd/goinit/main.go
@@ -58,6 +58,7 @@ var (
 	initDockerd             = flag.Bool("init_dockerd", false, "If true, init dockerd before accepting exec requests. Requires docker to be installed.")
 	enableDockerdTCP        = flag.Bool("enable_dockerd_tcp", false, "If true, dockerd will listen to for tcp traffic on port 2375.")
 	gRPCMaxRecvMsgSizeBytes = flag.Int("grpc_max_recv_msg_size_bytes", 50000000, "Configures the max GRPC receive message size [bytes]")
+	registryMirror          = flag.String("registry_mirror", "", "The docker image registry mirror to pull through.")
 
 	isVMExec = flag.Bool("vmexec", false, "Whether to run as the vmexec server.")
 	isVMVFS  = flag.Bool("vmvfs", false, "Whether to run as the vmvfs binary.")
@@ -177,6 +178,10 @@ func startDockerd(ctx context.Context) error {
 	args := []string{}
 	if *enableDockerdTCP {
 		args = append(args, "--host=unix:///var/run/docker.sock", "--host=tcp://0.0.0.0:2375", "--tls=false")
+	}
+
+	if *registryMirror != "" {
+		args = append(args, "--registry-mirror="+*registryMirror)
 	}
 
 	cmd := exec.CommandContext(ctx, "dockerd", args...)

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -82,6 +82,7 @@ var dieOnFirecrackerFailure = flag.Bool("executor.die_on_firecracker_failure", f
 var workspaceDiskSlackSpaceMB = flag.Int64("executor.firecracker_workspace_disk_slack_space_mb", 2_000, "Extra space to allocate to firecracker workspace disks, in megabytes. ** Experimental **")
 var healthCheckInterval = flag.Duration("executor.firecracker_health_check_interval", 10*time.Second, "How often to run VM health checks while tasks are executing.")
 var healthCheckTimeout = flag.Duration("executor.firecracker_health_check_timeout", 30*time.Second, "Timeout for VM health check requests.")
+var registryMirror = flag.String("executor.registry_mirror", "mirror.gcr.io", "The docker image registry mirror to pull through.")
 
 //go:embed guest_api_hash.sha256
 var GuestAPIHash string
@@ -1291,6 +1292,9 @@ func (c *FirecrackerContainer) getConfig(ctx context.Context, rootFS, containerF
 	}
 	if *EnableRootfs {
 		bootArgs = "-enable_rootfs " + bootArgs
+	}
+	if *registryMirror != "" {
+		bootArgs = fmt.Sprintf("-registry_mirror=%s ", *registryMirror) + bootArgs
 	}
 	cgroupVersion, err := getCgroupVersion()
 	if err != nil {


### PR DESCRIPTION
We already use this registry mirror when pulling images through GKE. This adds the mirror to the docker daemon that gets started inside of firecracker VMs.

Longer term, we could potentially host our own mirror here instead.

Need to do some performance testing first to make sure this actually speeds things up.