### PR TITLE
proto: sync from Bazel @ 5ee3ddce

### DIFF
--- a/proto/action_cache.proto
+++ b/proto/action_cache.proto
@@ -55,5 +55,9 @@ message ActionCacheStatistics {
   // Breakdown of the cache misses based on the reasons behind them.
   repeated MissDetail miss_details = 5;
 
-  // NEXT TAG: 6
+  // Time it took to load the action cache from disk. Reported as 0 if the
+  // action cache has not been loaded in this invocation.
+  uint64 load_time_in_ms = 6;
+
+  // NEXT TAG: 7
 }

--- a/proto/build_event_stream.proto
+++ b/proto/build_event_stream.proto
@@ -633,7 +633,11 @@ message ActionExecuted {
   // End of action execution, after all attempted execution completes.
   google.protobuf.Timestamp end_time = 13;
 
-  // Additional details about action execution supplied by any/all strategies.
+  // Additional details about action execution supplied by strategies. Bazel
+  // options will determine which strategy details are included when multiple
+  // strategies are involved in a single action's execution.
+  //
+  // The default type will be `tools.proto.SpawnExec` found in `spawn.proto`.
   repeated google.protobuf.Any strategy_details = 14;
 }
 
@@ -1177,11 +1181,34 @@ message BuildMetrics {
     bool is_multiplex = 4;
     // Using worker sandbox file system or not.
     bool is_sandbox = 5;
-    // Shows is worker stats measured at the end of invocation.
+    // TODO(b/300067854): Deprecate since all worker metrics should have their
+    // WorkerStats set.
     bool is_measurable = 6;
     // Hash value of worker key. Needed to distinguish worker pools with same
     // menmonic but with different worker keys.
     int64 worker_key_hash = 9;
+
+    WorkerStatus worker_status = 10;
+
+    enum WorkerStatus {
+      // Used to indicate a worker instance where the process has not been
+      // created yet. In reality this isn't logged, but leaving this here as a
+      // possible option in the future.
+      NOT_STARTED = 0;
+      ALIVE = 1;
+      KILLED_DUE_TO_MEMORY_PRESSURE = 2;
+      // Indicates that the worker process was killed due to a reason unknown to
+      // Bazel at the point of measurement; if a known cause (below) comes along
+      // later on, this field will be updated.
+      KILLED_UNKNOWN = 3;
+      KILLED_DUE_TO_INTERRUPTED_EXCEPTION = 4;
+      KILLED_DUE_TO_IO_EXCEPTION = 5;
+      KILLED_DUE_TO_USER_EXEC_EXCEPTION = 6;
+    }
+
+    optional failure_details.Worker.Code code = 12;
+
+    int64 actions_executed = 11;
 
     // Information collected from worker at some point.
     message WorkerStats {
@@ -1245,6 +1272,12 @@ message BuildMetrics {
       int64 destroyed_count = 4;
       // Number of workers evicted during a build.
       int64 evicted_count = 5;
+      // Number of workers destroyed due to UserExecExceptions.
+      int64 user_exec_exception_destroyed_count = 6;
+      // Number of workers destroyed due to IoExceptions.
+      int64 io_exception_destroyed_count = 7;
+      // Number of workers destroyed due to InterruptedExceptions.
+      int64 interrupted_exception_destroyed_count = 8;
     }
   }
 

--- a/proto/failure_details.proto
+++ b/proto/failure_details.proto
@@ -528,6 +528,7 @@ message ExecutionOptions {
         [(metadata) = { exit_code: 2 }];
     STRATEGY_NOT_FOUND = 9 [(metadata) = { exit_code: 2 }];
     DYNAMIC_STRATEGY_NOT_SANDBOXED = 10 [(metadata) = { exit_code: 2 }];
+    MULTIPLE_EXECUTION_LOG_FORMATS = 11 [(metadata) = { exit_code: 2 }];
 
     reserved 1, 2;  // For internal use
   }


### PR DESCRIPTION
Quick recap:

```bash
> export OLD_COMMIT=76117b4a43b552c681dcf841704fedfd60d3e37b
> export LATEST_COMMIT=5ee3ddce8653263d8280ce0163062cb7f5f9d8d4

> git log --stat --oneline "$OLD_COMMIT...$LATEST_COMMIT" -- **/*.proto

5ee3ddce86 Log WorkerMetrics of killed workers in the BEP and why they were killed. Also include the number of actions executed of each worker process.
 src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto | 32 +++++++++++++++++++++++++++++++-
 1 file changed, 31 insertions(+), 1 deletion(-)

6fb551f04e Add load time of action cache to statistics.
 src/main/protobuf/action_cache.proto | 6 +++++-
 1 file changed, 5 insertions(+), 1 deletion(-)

4b7c808ec9 Forbid simultaneously requesting both a JSON and binary execution log.
 src/main/protobuf/failure_details.proto | 1 +
 1 file changed, 1 insertion(+)

# Some spawn.proto, cache_salt.proto and bazel_flags.proto changes
# only affects the local cache.
3e68f74f6f ...
fa2fd237b9 ...
3b0b6ed419 ...
d1c923f249 ...
718f400c61 ...
40d6780e2f ...

b940a3a94a Add support for serializing Any types to BEP's JSON transport.
 src/main/java/com/google/devtools/build/lib/buildeventstream/proto/build_event_stream.proto | 6 +++++-
 1 file changed, 5 insertions(+), 1 deletion(-)


```

Changes are synced from
https://github.com/bazelbuild/bazel/commit/5ee3ddce8653263d8280ce0163062cb7f5f9d8d4
