### PR TITLE
Add a platform property that lets the user delay execution of tasks scheduled on non-preferred nodes.

### DIFF
--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -65,27 +65,28 @@ const (
 	// empty or unset.
 	unsetContainerImageVal = "none"
 
-	RecycleRunnerPropertyName            = "recycle-runner"
-	AffinityRoutingPropertyName          = "affinity-routing"
-	preserveWorkspacePropertyName        = "preserve-workspace"
-	nonrootWorkspacePropertyName         = "nonroot-workspace"
-	cleanWorkspaceInputsPropertyName     = "clean-workspace-inputs"
-	persistentWorkerPropertyName         = "persistent-workers"
-	persistentWorkerKeyPropertyName      = "persistentWorkerKey"
-	persistentWorkerProtocolPropertyName = "persistentWorkerProtocol"
-	WorkflowIDPropertyName               = "workflow-id"
-	workloadIsolationPropertyName        = "workload-isolation-type"
-	initDockerdPropertyName              = "init-dockerd"
-	enableDockerdTCPPropertyName         = "enable-dockerd-tcp"
-	enableVFSPropertyName                = "enable-vfs"
-	HostedBazelAffinityKeyPropertyName   = "hosted-bazel-affinity-key"
-	useSelfHostedExecutorsPropertyName   = "use-self-hosted-executors"
-	disableMeasuredTaskSizePropertyName  = "debug-disable-measured-task-size"
-	disablePredictedTaskSizePropertyName = "debug-disable-predicted-task-size"
-	extraArgsPropertyName                = "extra-args"
-	EnvOverridesPropertyName             = "env-overrides"
-	EnvOverridesBase64PropertyName       = "env-overrides-base64"
-	IncludeSecretsPropertyName           = "include-secrets"
+	RecycleRunnerPropertyName             = "recycle-runner"
+	AffinityRoutingPropertyName           = "affinity-routing"
+	ColdRunnerSchedulingDelayPropertyName = "cold-runner-scheduling-delay-ms"
+	preserveWorkspacePropertyName         = "preserve-workspace"
+	nonrootWorkspacePropertyName          = "nonroot-workspace"
+	cleanWorkspaceInputsPropertyName      = "clean-workspace-inputs"
+	persistentWorkerPropertyName          = "persistent-workers"
+	persistentWorkerKeyPropertyName       = "persistentWorkerKey"
+	persistentWorkerProtocolPropertyName  = "persistentWorkerProtocol"
+	WorkflowIDPropertyName                = "workflow-id"
+	workloadIsolationPropertyName         = "workload-isolation-type"
+	initDockerdPropertyName               = "init-dockerd"
+	enableDockerdTCPPropertyName          = "enable-dockerd-tcp"
+	enableVFSPropertyName                 = "enable-vfs"
+	HostedBazelAffinityKeyPropertyName    = "hosted-bazel-affinity-key"
+	useSelfHostedExecutorsPropertyName    = "use-self-hosted-executors"
+	disableMeasuredTaskSizePropertyName   = "debug-disable-measured-task-size"
+	disablePredictedTaskSizePropertyName  = "debug-disable-predicted-task-size"
+	extraArgsPropertyName                 = "extra-args"
+	EnvOverridesPropertyName              = "env-overrides"
+	EnvOverridesBase64PropertyName        = "env-overrides-base64"
+	IncludeSecretsPropertyName            = "include-secrets"
 
 	OperatingSystemPropertyName = "OSFamily"
 	LinuxOperatingSystemName    = "linux"
@@ -144,6 +145,7 @@ type Properties struct {
 	DockerNetwork             string
 	RecycleRunner             bool
 	AffinityRouting           bool
+	ColdRunnerSchedulingDelay time.Duration
 	EnableVFS                 bool
 	IncludeSecrets            bool
 
@@ -269,6 +271,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		DockerNetwork:             stringProp(m, dockerNetworkPropertyName, ""),
 		RecycleRunner:             boolProp(m, RecycleRunnerPropertyName, false),
 		AffinityRouting:           boolProp(m, AffinityRoutingPropertyName, false),
+		ColdRunnerSchedulingDelay: durationProp(m, ColdRunnerSchedulingDelayPropertyName, 0*time.Second),
 		EnableVFS:                 vfsEnabled,
 		IncludeSecrets:            boolProp(m, IncludeSecretsPropertyName, false),
 		PreserveWorkspace:         boolProp(m, preserveWorkspacePropertyName, false),
@@ -574,6 +577,19 @@ func stringListProp(props map[string]string, name string) []string {
 		}
 	}
 	return vals
+}
+
+func durationProp(props map[string]string, name string, defaultValue time.Duration) time.Duration {
+	val := props[strings.ToLower(name)]
+	if val == "" {
+		return defaultValue
+	}
+	d, err := time.ParseDuration(val)
+	if err != nil {
+		log.Warningf("Could not parse platform property %q as duration: %s", name, err)
+		return defaultValue
+	}
+	return d
 }
 
 // FindValue scans the platform properties for the given property name (ignoring

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -65,28 +65,28 @@ const (
 	// empty or unset.
 	unsetContainerImageVal = "none"
 
-	RecycleRunnerPropertyName             = "recycle-runner"
-	AffinityRoutingPropertyName           = "affinity-routing"
-	ColdRunnerSchedulingDelayPropertyName = "cold-runner-scheduling-delay"
-	preserveWorkspacePropertyName         = "preserve-workspace"
-	nonrootWorkspacePropertyName          = "nonroot-workspace"
-	cleanWorkspaceInputsPropertyName      = "clean-workspace-inputs"
-	persistentWorkerPropertyName          = "persistent-workers"
-	persistentWorkerKeyPropertyName       = "persistentWorkerKey"
-	persistentWorkerProtocolPropertyName  = "persistentWorkerProtocol"
-	WorkflowIDPropertyName                = "workflow-id"
-	workloadIsolationPropertyName         = "workload-isolation-type"
-	initDockerdPropertyName               = "init-dockerd"
-	enableDockerdTCPPropertyName          = "enable-dockerd-tcp"
-	enableVFSPropertyName                 = "enable-vfs"
-	HostedBazelAffinityKeyPropertyName    = "hosted-bazel-affinity-key"
-	useSelfHostedExecutorsPropertyName    = "use-self-hosted-executors"
-	disableMeasuredTaskSizePropertyName   = "debug-disable-measured-task-size"
-	disablePredictedTaskSizePropertyName  = "debug-disable-predicted-task-size"
-	extraArgsPropertyName                 = "extra-args"
-	EnvOverridesPropertyName              = "env-overrides"
-	EnvOverridesBase64PropertyName        = "env-overrides-base64"
-	IncludeSecretsPropertyName            = "include-secrets"
+	RecycleRunnerPropertyName            = "recycle-runner"
+	AffinityRoutingPropertyName          = "affinity-routing"
+	RunnerRecyclingMaxWaitPropertyName   = "runner-recycling-max-wait"
+	preserveWorkspacePropertyName        = "preserve-workspace"
+	nonrootWorkspacePropertyName         = "nonroot-workspace"
+	cleanWorkspaceInputsPropertyName     = "clean-workspace-inputs"
+	persistentWorkerPropertyName         = "persistent-workers"
+	persistentWorkerKeyPropertyName      = "persistentWorkerKey"
+	persistentWorkerProtocolPropertyName = "persistentWorkerProtocol"
+	WorkflowIDPropertyName               = "workflow-id"
+	workloadIsolationPropertyName        = "workload-isolation-type"
+	initDockerdPropertyName              = "init-dockerd"
+	enableDockerdTCPPropertyName         = "enable-dockerd-tcp"
+	enableVFSPropertyName                = "enable-vfs"
+	HostedBazelAffinityKeyPropertyName   = "hosted-bazel-affinity-key"
+	useSelfHostedExecutorsPropertyName   = "use-self-hosted-executors"
+	disableMeasuredTaskSizePropertyName  = "debug-disable-measured-task-size"
+	disablePredictedTaskSizePropertyName = "debug-disable-predicted-task-size"
+	extraArgsPropertyName                = "extra-args"
+	EnvOverridesPropertyName             = "env-overrides"
+	EnvOverridesBase64PropertyName       = "env-overrides-base64"
+	IncludeSecretsPropertyName           = "include-secrets"
 
 	OperatingSystemPropertyName = "OSFamily"
 	LinuxOperatingSystemName    = "linux"
@@ -145,7 +145,7 @@ type Properties struct {
 	DockerNetwork             string
 	RecycleRunner             bool
 	AffinityRouting           bool
-	ColdRunnerSchedulingDelay time.Duration
+	RunnerRecyclingMaxWait    time.Duration
 	EnableVFS                 bool
 	IncludeSecrets            bool
 
@@ -271,7 +271,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		DockerNetwork:             stringProp(m, dockerNetworkPropertyName, ""),
 		RecycleRunner:             boolProp(m, RecycleRunnerPropertyName, false),
 		AffinityRouting:           boolProp(m, AffinityRoutingPropertyName, false),
-		ColdRunnerSchedulingDelay: durationProp(m, ColdRunnerSchedulingDelayPropertyName, 0*time.Second),
+		RunnerRecyclingMaxWait:    durationProp(m, RunnerRecyclingMaxWaitPropertyName, 0*time.Second),
 		EnableVFS:                 vfsEnabled,
 		IncludeSecrets:            boolProp(m, IncludeSecretsPropertyName, false),
 		PreserveWorkspace:         boolProp(m, preserveWorkspacePropertyName, false),

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -67,7 +67,7 @@ const (
 
 	RecycleRunnerPropertyName             = "recycle-runner"
 	AffinityRoutingPropertyName           = "affinity-routing"
-	ColdRunnerSchedulingDelayPropertyName = "cold-runner-scheduling-delay-ms"
+	ColdRunnerSchedulingDelayPropertyName = "cold-runner-scheduling-delay"
 	preserveWorkspacePropertyName         = "preserve-workspace"
 	nonrootWorkspacePropertyName          = "nonroot-workspace"
 	cleanWorkspaceInputsPropertyName      = "clean-workspace-inputs"

--- a/enterprise/server/remote_execution/platform/platform_test.go
+++ b/enterprise/server/remote_execution/platform/platform_test.go
@@ -255,14 +255,14 @@ func TestParse_Duration(t *testing.T) {
 		rawValue      string
 		expectedValue time.Duration
 	}{
-		{"cold-runner-scheduling-delay-ms", "", 0 * time.Second},
-		{"cold-runner-scheduling-delay-ms", "100", 0 * time.Second},
-		{"cold-runner-scheduling-delay-ms", "blah", 0 * time.Second},
-		{"cold-runner-scheduling-delay-ms", "10ms", 10 * time.Millisecond},
-		{"cold-runner-scheduling-delay-ms", "-20ms", -20 * time.Millisecond},
-		{"cold-runner-scheduling-delay-ms", "2s", 2 * time.Second},
-		{"cold-runner-scheduling-delay-ms", "4m", 4 * time.Minute},
-		{"cold-runner-scheduling-delay-ms", "-7m", -7 * time.Minute},
+		{"cold-runner-scheduling-delay", "", 0 * time.Second},
+		{"cold-runner-scheduling-delay", "100", 0 * time.Second},
+		{"cold-runner-scheduling-delay", "blah", 0 * time.Second},
+		{"cold-runner-scheduling-delay", "10ms", 10 * time.Millisecond},
+		{"cold-runner-scheduling-delay", "-20ms", -20 * time.Millisecond},
+		{"cold-runner-scheduling-delay", "2s", 2 * time.Second},
+		{"cold-runner-scheduling-delay", "4m", 4 * time.Minute},
+		{"cold-runner-scheduling-delay", "-7m", -7 * time.Minute},
 	} {
 		plat := &repb.Platform{Properties: []*repb.Platform_Property{
 			{Name: testCase.name, Value: testCase.rawValue},

--- a/enterprise/server/remote_execution/platform/platform_test.go
+++ b/enterprise/server/remote_execution/platform/platform_test.go
@@ -255,21 +255,21 @@ func TestParse_Duration(t *testing.T) {
 		rawValue      string
 		expectedValue time.Duration
 	}{
-		{"cold-runner-scheduling-delay", "", 0 * time.Second},
-		{"cold-runner-scheduling-delay", "100", 0 * time.Second},
-		{"cold-runner-scheduling-delay", "blah", 0 * time.Second},
-		{"cold-runner-scheduling-delay", "10ms", 10 * time.Millisecond},
-		{"cold-runner-scheduling-delay", "-20ms", -20 * time.Millisecond},
-		{"cold-runner-scheduling-delay", "2s", 2 * time.Second},
-		{"cold-runner-scheduling-delay", "4m", 4 * time.Minute},
-		{"cold-runner-scheduling-delay", "-7m", -7 * time.Minute},
+		{"runner-recycling-max-wait", "", 0 * time.Second},
+		{"runner-recycling-max-wait", "100", 0 * time.Second},
+		{"runner-recycling-max-wait", "blah", 0 * time.Second},
+		{"runner-recycling-max-wait", "10ms", 10 * time.Millisecond},
+		{"runner-recycling-max-wait", "-20ms", -20 * time.Millisecond},
+		{"runner-recycling-max-wait", "2s", 2 * time.Second},
+		{"runner-recycling-max-wait", "4m", 4 * time.Minute},
+		{"runner-recycling-max-wait", "-7m", -7 * time.Minute},
 	} {
 		plat := &repb.Platform{Properties: []*repb.Platform_Property{
 			{Name: testCase.name, Value: testCase.rawValue},
 		}}
 		platformProps, err := ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: plat}})
 		require.NoError(t, err)
-		assert.Equal(t, testCase.expectedValue, platformProps.ColdRunnerSchedulingDelay)
+		assert.Equal(t, testCase.expectedValue, platformProps.RunnerRecyclingMaxWait)
 	}
 }
 

--- a/enterprise/server/remote_execution/platform/platform_test.go
+++ b/enterprise/server/remote_execution/platform/platform_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -245,6 +246,30 @@ func TestParse_EstimatedMemory(t *testing.T) {
 		platformProps, err := ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: plat}})
 		require.NoError(t, err)
 		assert.Equal(t, testCase.expectedValue, platformProps.EstimatedMemoryBytes)
+	}
+}
+
+func TestParse_Duration(t *testing.T) {
+	for _, testCase := range []struct {
+		name          string
+		rawValue      string
+		expectedValue time.Duration
+	}{
+		{"cold-runner-scheduling-delay-ms", "", 0 * time.Second},
+		{"cold-runner-scheduling-delay-ms", "100", 0 * time.Second},
+		{"cold-runner-scheduling-delay-ms", "blah", 0 * time.Second},
+		{"cold-runner-scheduling-delay-ms", "10ms", 10 * time.Millisecond},
+		{"cold-runner-scheduling-delay-ms", "-20ms", -20 * time.Millisecond},
+		{"cold-runner-scheduling-delay-ms", "2s", 2 * time.Second},
+		{"cold-runner-scheduling-delay-ms", "4m", 4 * time.Minute},
+		{"cold-runner-scheduling-delay-ms", "-7m", -7 * time.Minute},
+	} {
+		plat := &repb.Platform{Properties: []*repb.Platform_Property{
+			{Name: testCase.name, Value: testCase.rawValue},
+		}}
+		platformProps, err := ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: plat}})
+		require.NoError(t, err)
+		assert.Equal(t, testCase.expectedValue, platformProps.ColdRunnerSchedulingDelay)
 	}
 }
 

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1,6 +1,7 @@
 package scheduler_server
 
 import (
+	"container/ring"
 	"context"
 	"flag"
 	"fmt"
@@ -68,6 +69,10 @@ const (
 	// this amount of time.
 	executorMaxRegistrationStaleness = 10 * time.Minute
 
+	// The maximum number of times the scheduler will attempt to enqueue a
+	// single task across the entire executor pool.
+	maxAttemptedEnqueueCount = 100
+
 	// The maximum number of times a task may be re-enqueued.
 	maxTaskAttemptCount = 5
 
@@ -107,6 +112,11 @@ const (
 
 	// Platform property value corresponding with the darwin (Mac) operating system.
 	darwinOperatingSystemName = "darwin"
+
+	// Upper bound on the scheduling delay applied for tasks scheduled on
+	// non-preferred execution nodes, to prevent indefinite scheduling delays.
+	maxPermittedSchedulingDelay = 15 * time.Minute
+	defaultSchedulingDelay      = 0 * time.Second
 )
 
 var (
@@ -487,6 +497,11 @@ type executionNode struct {
 	schedulingDelay time.Duration
 }
 
+type rankedExecutionNode struct {
+	node      *executionNode
+	preferred bool
+}
+
 func (en *executionNode) CanFit(size *scpb.TaskSize) bool {
 	return int64(float64(en.assignableMemoryBytes)*tasksize.MaxResourceCapacityRatio) >= size.GetEstimatedMemoryBytes() &&
 		int64(float64(en.assignableMilliCpu)*tasksize.MaxResourceCapacityRatio) >= size.GetEstimatedMilliCpu()
@@ -524,17 +539,17 @@ func toNodeInterfaces(nodes []*executionNode) []interfaces.ExecutionNode {
 	return out
 }
 
-func fromRankedNodeInterfaces(nodes []interfaces.RankedExecutionNode) ([]*executionNode, error) {
-	out := make([]*executionNode, 0, len(nodes))
+func toRankedNodeRing(nodes []interfaces.RankedExecutionNode) (*ring.Ring, error) {
+	nodeRing := ring.New(len(nodes))
 	for _, node := range nodes {
 		en, ok := node.GetExecutionNode().(*executionNode)
 		if !ok {
 			return nil, status.InternalError("failed to convert executionNode to interface; this should never happen")
 		}
-		out = append(out, en)
-		en.schedulingDelay = node.GetSchedulingDelay()
+		nodeRing.Value = rankedExecutionNode{node: en, preferred: node.IsPreferred()}
+		nodeRing = nodeRing.Next()
 	}
-	return out, nil
+	return nodeRing, nil
 }
 
 type nodePoolKey struct {
@@ -1647,10 +1662,10 @@ func (s *SchedulerServer) enqueueTaskReservations(ctx context.Context, enqueueRe
 	}
 
 	probeCount := min(opts.numReplicas, nodeCount)
-	probesSent := 0
+	var successfulReservations []string
+	scheduledOnPreferredNode := false
 
 	startTime := time.Now()
-	var successfulReservations []string
 	defer func() {
 		log.CtxInfof(ctx, "Enqueue task reservations took %s. Reservations: [%s]",
 			time.Since(startTime), strings.Join(successfulReservations, ", "))
@@ -1664,96 +1679,145 @@ func (s *SchedulerServer) enqueueTaskReservations(ctx context.Context, enqueueRe
 	// Note: preferredNode may be nil if the executor ID isn't specified or if
 	// the executor is no longer connected.
 	preferredNode := nodeBalancer.FindConnectedExecutorByID(enqueueRequest.GetExecutorId())
+	if preferredNode != nil {
+		enqueueStart := time.Now()
+		enqueued, err := s.enqueue(ctx, preferredNode, enqueueRequest, opts)
+		if err != nil {
+			return err
+		} else if enqueued {
+			scheduledOnPreferredNode = true
+			successfulReservations = append(successfulReservations, successfulReservation(preferredNode, enqueueStart))
+		}
+	}
+
+	nodes := nodeBalancer.GetNodes(opts.scheduleOnConnectedExecutors)
+	if len(nodes) == 0 {
+		return status.UnavailableErrorf("No registered executors in pool %q with os %q with arch %q.", pool, os, arch)
+	}
+	nodes = nodesThatFit(nodes, enqueueRequest.GetTaskSize())
+	if len(nodes) == 0 {
+		return status.UnavailableErrorf(
+			"No registered executors in pool %q with os %q with arch %q can fit a task with %d milli-cpu and %d bytes of memory.",
+			pool, os, arch,
+			enqueueRequest.GetTaskSize().GetEstimatedMilliCpu(),
+			enqueueRequest.GetTaskSize().GetEstimatedMemoryBytes())
+	}
+	rankedNodes := s.taskRouter.RankNodes(ctx, cmd, remoteInstanceName, toNodeInterfaces(nodes))
+	nodeRing, err := toRankedNodeRing(rankedNodes)
+	if err != nil {
+		return err
+	}
 
 	attempts := 0
-	var nodes []*executionNode
-	sampleIndex := 0
-	for probesSent < probeCount {
-		attempts++
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			break
+	nonPreferredDelay := getNonPreferredSchedulingDelay(cmd)
+	for ; len(successfulReservations) < probeCount; nodeRing = nodeRing.Next() {
+		rankedNode, ok := nodeRing.Value.(rankedExecutionNode)
+		if !ok {
+			return status.InternalError("failed to convert nodeRing to executionNode; this should never happen")
 		}
+		attempts++
 		if opts.maxAttempts > 0 && attempts > opts.maxAttempts {
 			return status.ResourceExhaustedErrorf("could not enqueue task reservation to executor")
 		}
-		if attempts > 100 {
+		if attempts > maxAttemptedEnqueueCount {
 			log.CtxWarningf(ctx, "Attempted to send probe %d times for task %q with pool key %+v. This should not happen.", attempts, enqueueRequest.GetTaskId(), key)
 		}
-		if sampleIndex == 0 {
-			if preferredNode != nil {
-				nodes = []*executionNode{preferredNode}
-				// Unset the preferred node so that we fall back to random sampling
-				// (in subsequent loop iterations) if the preferred node probe fails.
-				preferredNode = nil
-			} else {
-				nodes = nodeBalancer.GetNodes(opts.scheduleOnConnectedExecutors)
-				if len(nodes) == 0 {
-					return status.UnavailableErrorf("No registered executors in pool %q with os %q with arch %q.", pool, os, arch)
-				}
-				nodes = nodesThatFit(nodes, enqueueRequest.GetTaskSize())
-				if len(nodes) == 0 {
-					return status.UnavailableErrorf(
-						"No registered executors in pool %q with os %q with arch %q can fit a task with %d milli-cpu and %d bytes of memory.",
-						pool, os, arch,
-						enqueueRequest.GetTaskSize().GetEstimatedMilliCpu(),
-						enqueueRequest.GetTaskSize().GetEstimatedMemoryBytes())
-				}
-				rankedNodes := s.taskRouter.RankNodes(ctx, cmd, remoteInstanceName, toNodeInterfaces(nodes))
-				nodes, err = fromRankedNodeInterfaces(rankedNodes)
-				if err != nil {
-					return err
-				}
-			}
-		}
-		if sampleIndex >= len(nodes) {
-			return status.FailedPreconditionErrorf("sampleIndex %d >= %d", sampleIndex, len(nodes))
-		}
-		node := nodes[sampleIndex]
-		sampleIndex = (sampleIndex + 1) % len(nodes)
+
 		// Set the executor ID in case the node is owned by another scheduler, so
 		// that the scheduler can prefer this node for the probe.
-		enqueueRequest.ExecutorId = node.GetExecutorID()
-		if node.schedulingDelay > 0*time.Second {
-			enqueueRequest.Delay = durationpb.New(node.schedulingDelay)
-		}
+		enqueueRequest.ExecutorId = rankedNode.node.GetExecutorID()
 
 		enqueueStart := time.Now()
-		if opts.scheduleOnConnectedExecutors {
-			if node.handle == nil {
-				log.CtxErrorf(ctx, "nil handle for a local executor %q", node.GetExecutorID())
-				continue
-			}
-			_, err := node.handle.EnqueueTaskReservation(ctx, enqueueRequest)
-			if err != nil {
-				continue
-			}
+		if scheduledOnPreferredNode && !rankedNode.preferred && nonPreferredDelay > 0*time.Second {
+			enqueueRequest.Delay = durationpb.New(nonPreferredDelay)
 		} else {
-			if node.schedulerHostPort == "" {
-				log.CtxErrorf(ctx, "node %q has no scheduler host:port set", node.GetExecutorID())
-				continue
-			}
-
-			schedulerClient, err := s.schedulerClientCache.get(node.schedulerHostPort)
-			if err != nil {
-				log.CtxWarningf(ctx, "Could not get SchedulerClient for %q: %s", node.schedulerHostPort, err)
-				continue
-			}
-			rpcCtx, cancel := context.WithTimeout(ctx, schedulerEnqueueTaskReservationTimeout)
-			_, err = schedulerClient.EnqueueTaskReservation(rpcCtx, enqueueRequest)
-			cancel()
-			if err != nil {
-				log.CtxWarningf(ctx, "EnqueueTaskReservation via scheduler target %q failed: %s", node.schedulerHostPort, err)
-				time.Sleep(schedulerEnqueueTaskReservationFailureSleep)
-				continue
-			}
+			enqueueRequest.Delay = nil
 		}
-		successfulReservations = append(successfulReservations, fmt.Sprintf("%s [%s]", node.String(), time.Since(enqueueStart).String()))
-		probesSent++
+		enqueued, err := s.enqueue(ctx, rankedNode.node, enqueueRequest, opts)
+		if err != nil {
+			return err
+		} else if enqueued {
+			if rankedNode.preferred {
+				scheduledOnPreferredNode = true
+			}
+			successfulReservations = append(successfulReservations, successfulReservation(rankedNode.node, enqueueStart))
+		}
 	}
 	return nil
+}
+
+// Returns the delay that should be applied to executions scheduled on
+// non-preferred execution nodes.
+func getNonPreferredSchedulingDelay(cmd *repb.Command) time.Duration {
+	delayProperty := platform.FindValue(cmd.GetPlatform(), platform.ColdRunnerSchedulingDelayPropertyName)
+	if delayProperty == "" {
+		return defaultSchedulingDelay
+	}
+	d, err := time.ParseDuration(delayProperty)
+	if err != nil {
+		log.Warningf("Could not parse platform property %q as duration: %s", platform.ColdRunnerSchedulingDelayPropertyName, err)
+		return defaultSchedulingDelay
+	}
+	if d < 0*time.Second {
+		// It would be a huge performance win if this worked. Unfortunately we
+		// haven't figured out how to implement it yet :-(
+		return defaultSchedulingDelay
+	}
+	if d > maxPermittedSchedulingDelay {
+		return maxPermittedSchedulingDelay
+	}
+	return d
+}
+
+func successfulReservation(node *executionNode, enqueueStart time.Time) string {
+	return fmt.Sprintf("%s [%s]", node.String(), time.Since(enqueueStart).String())
+}
+
+func (s *SchedulerServer) enqueue(ctx context.Context, node *executionNode, request *scpb.EnqueueTaskReservationRequest, opts enqueueTaskReservationOpts) (bool, error) {
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	default:
+		break
+	}
+	enqueued := false
+	if opts.scheduleOnConnectedExecutors {
+		enqueued = enqueueOnConnectedExecutor(ctx, node, request)
+	} else {
+		enqueued = s.enqueueOnRemoteExecutor(ctx, node, request)
+	}
+	return enqueued, nil
+}
+
+func enqueueOnConnectedExecutor(ctx context.Context, node *executionNode, request *scpb.EnqueueTaskReservationRequest) bool {
+	if node.handle == nil {
+		log.CtxErrorf(ctx, "nil handle for a local executor %q", node.GetExecutorID())
+		return false
+	}
+	_, err := node.handle.EnqueueTaskReservation(ctx, request)
+	return err == nil
+}
+
+func (s *SchedulerServer) enqueueOnRemoteExecutor(ctx context.Context, node *executionNode, request *scpb.EnqueueTaskReservationRequest) bool {
+	if node.schedulerHostPort == "" {
+		log.CtxErrorf(ctx, "node %q has no scheduler host:port set", node.GetExecutorID())
+		return false
+	}
+
+	schedulerClient, err := s.schedulerClientCache.get(node.schedulerHostPort)
+	if err != nil {
+		log.CtxWarningf(ctx, "Could not get SchedulerClient for %q: %s", node.schedulerHostPort, err)
+		return false
+	}
+	rpcCtx, cancel := context.WithTimeout(ctx, schedulerEnqueueTaskReservationTimeout)
+	_, err = schedulerClient.EnqueueTaskReservation(rpcCtx, request)
+	cancel()
+	if err != nil {
+		log.CtxWarningf(ctx, "EnqueueTaskReservation via scheduler target %q failed: %s", node.schedulerHostPort, err)
+		time.Sleep(schedulerEnqueueTaskReservationFailureSleep)
+		return false
+	}
+	return true
 }
 
 func (s *SchedulerServer) ScheduleTask(ctx context.Context, req *scpb.ScheduleTaskRequest) (*scpb.ScheduleTaskResponse, error) {

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -493,8 +493,7 @@ type executionNode struct {
 	// the "task streaming" API.
 	schedulerHostPort string
 	// Optional handle for locally connected executor that can be used to enqueue task reservations.
-	handle          *executorHandle
-	schedulingDelay time.Duration
+	handle *executorHandle
 }
 
 type rankedExecutionNode struct {

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -268,6 +269,8 @@ type fakeExecutor struct {
 
 	ctx context.Context
 
+	unhealthy atomic.Bool
+
 	mu    sync.Mutex
 	tasks map[string]task
 }
@@ -288,22 +291,27 @@ func newFakeExecutorWithId(ctx context.Context, t *testing.T, id string, schedul
 	}
 }
 
+func (e *fakeExecutor) markUnhealthy() {
+	e.unhealthy.Store(true)
+}
+
 func (e *fakeExecutor) Register() {
 	stream, err := e.schedulerClient.RegisterAndStreamWork(e.ctx)
 	require.NoError(e.t, err)
+	err = stream.Send(&scpb.RegisterAndStreamWorkRequest{
+		RegisterExecutorRequest: &scpb.RegisterExecutorRequest{
+			Node: &scpb.ExecutionNode{
+				ExecutorId:            e.id,
+				Os:                    defaultOS,
+				Arch:                  defaultArch,
+				Host:                  "foo",
+				AssignableMemoryBytes: 1000000,
+				AssignableMilliCpu:    1000000,
+			}},
+	})
+	require.NoError(e.t, err)
+
 	go func() {
-		err = stream.Send(&scpb.RegisterAndStreamWorkRequest{
-			RegisterExecutorRequest: &scpb.RegisterExecutorRequest{
-				Node: &scpb.ExecutionNode{
-					ExecutorId:            e.id,
-					Os:                    defaultOS,
-					Arch:                  defaultArch,
-					Host:                  "foo",
-					AssignableMemoryBytes: 1000000,
-					AssignableMilliCpu:    1000000,
-				}},
-		})
-		require.NoError(e.t, err)
 		for {
 			req, err := stream.Recv()
 			if status.IsUnavailableError(err) {
@@ -311,18 +319,25 @@ func (e *fakeExecutor) Register() {
 			}
 			require.NoError(e.t, err)
 			log.Infof("received req: %+v", req)
-			err = stream.Send(&scpb.RegisterAndStreamWorkRequest{
-				EnqueueTaskReservationResponse: &scpb.EnqueueTaskReservationResponse{
-					TaskId: req.GetEnqueueTaskReservationRequest().GetTaskId(),
-				},
-			})
-			require.NoError(e.t, err)
-			e.mu.Lock()
-			log.Infof("got task %q", req.GetEnqueueTaskReservationRequest().GetTaskId())
-			e.tasks[req.GetEnqueueTaskReservationRequest().GetTaskId()] = task{delay: req.GetEnqueueTaskReservationRequest().GetDelay().AsDuration()}
-			e.mu.Unlock()
+			if e.unhealthy.Load() {
+				log.Infof("executor %s got task %q but is unhealthy -- ignoring so it times out", e.id, req.GetEnqueueTaskReservationRequest().GetTaskId())
+			} else {
+				err = stream.Send(&scpb.RegisterAndStreamWorkRequest{
+					EnqueueTaskReservationResponse: &scpb.EnqueueTaskReservationResponse{
+						TaskId: req.GetEnqueueTaskReservationRequest().GetTaskId(),
+					},
+				})
+				require.NoError(e.t, err)
+				e.mu.Lock()
+				log.Infof("executor %s got task %q with scheduling delay %s", e.id, req.GetEnqueueTaskReservationRequest().GetTaskId(), req.GetEnqueueTaskReservationRequest().GetDelay())
+				e.tasks[req.GetEnqueueTaskReservationRequest().GetTaskId()] = task{delay: req.GetEnqueueTaskReservationRequest().GetDelay().AsDuration()}
+				e.mu.Unlock()
+			}
 		}
 	}()
+
+	// Give the executor a moment to register with the scheduler.
+	time.Sleep(100 * time.Millisecond)
 }
 
 func (e *fakeExecutor) WaitForTask(taskID string) {
@@ -338,7 +353,7 @@ func (e *fakeExecutor) WaitForTaskWithDelay(taskID string, delay time.Duration) 
 			if task.delay == delay {
 				return
 			} else {
-				require.FailNowf(e.t, "executor received task with unexpected delay", "task %q expected delay: %s actual delay: %s", taskID, delay, task.delay)
+				require.FailNowf(e.t, "executor received task with unexpected delay", "executor %s task %q expected delay: %s actual delay: %s", e.id, taskID, delay, task.delay)
 			}
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -406,49 +421,38 @@ func (e *fakeExecutor) Claim(taskID string) *taskLease {
 }
 
 func scheduleTask(ctx context.Context, t *testing.T, env environment.Env, props map[string]string) string {
-	for i := 0; i < 5; i++ {
-		id, err := uuid.NewRandom()
-		require.NoError(t, err)
-		taskID := id.String()
+	id, err := uuid.NewRandom()
+	require.NoError(t, err)
+	taskID := id.String()
 
-		task := &repb.ExecutionTask{
-			ExecutionId: taskID,
-			Command: &repb.Command{
-				Platform: &repb.Platform{
-					Properties: []*repb.Platform_Property{},
-				},
+	task := &repb.ExecutionTask{
+		ExecutionId: taskID,
+		Command: &repb.Command{
+			Platform: &repb.Platform{
+				Properties: []*repb.Platform_Property{},
 			},
-		}
-		for k, v := range props {
-			task.Command.Platform.Properties = append(task.Command.Platform.Properties, &repb.Platform_Property{Name: k, Value: v})
-		}
-		taskBytes, err := proto.Marshal(task)
-		require.NoError(t, err)
-		_, err = env.GetSchedulerService().ScheduleTask(ctx, &scpb.ScheduleTaskRequest{
-			TaskId: taskID,
-			Metadata: &scpb.SchedulingMetadata{
-				Os:   defaultOS,
-				Arch: defaultArch,
-				TaskSize: &scpb.TaskSize{
-					EstimatedMemoryBytes:   100,
-					EstimatedMilliCpu:      100,
-					EstimatedFreeDiskBytes: 100,
-				},
-			},
-			SerializedTask: taskBytes,
-		})
-		// Allow time for executor to register.
-		if status.IsUnavailableError(err) {
-			time.Sleep(100 * time.Millisecond)
-			continue
-		}
-		require.NoError(t, err)
-		if err == nil {
-			return taskID
-		}
+		},
 	}
-	require.FailNow(t, "could not schedule task")
-	return ""
+	for k, v := range props {
+		task.Command.Platform.Properties = append(task.Command.Platform.Properties, &repb.Platform_Property{Name: k, Value: v})
+	}
+	taskBytes, err := proto.Marshal(task)
+	require.NoError(t, err)
+	_, err = env.GetSchedulerService().ScheduleTask(ctx, &scpb.ScheduleTaskRequest{
+		TaskId: taskID,
+		Metadata: &scpb.SchedulingMetadata{
+			Os:   defaultOS,
+			Arch: defaultArch,
+			TaskSize: &scpb.TaskSize{
+				EstimatedMemoryBytes:   100,
+				EstimatedMilliCpu:      100,
+				EstimatedFreeDiskBytes: 100,
+			},
+		},
+		SerializedTask: taskBytes,
+	})
+	require.NoError(t, err)
+	return taskID
 }
 
 func TestExecutorReEnqueue_NoLeaseID(t *testing.T) {
@@ -569,7 +573,7 @@ func TestSchedulingDelay_DelayTooSmall(t *testing.T) {
 	fe1.Register()
 	fe2.Register()
 
-	taskID := scheduleTask(ctx, t, env, map[string]string{"cold-runner-scheduling-delay": "-1s"})
+	taskID := scheduleTask(ctx, t, env, map[string]string{"runner-recycling-max-wait": "-1s"})
 
 	fe1.WaitForTaskWithDelay(taskID, 0*time.Second)
 	fe2.WaitForTaskWithDelay(taskID, 0*time.Second)
@@ -583,7 +587,7 @@ func TestSchedulingDelay_NoPreferredExecutors(t *testing.T) {
 	fe1.Register()
 	fe2.Register()
 
-	taskID := scheduleTask(ctx, t, env, map[string]string{"cold-runner-scheduling-delay": "5s"})
+	taskID := scheduleTask(ctx, t, env, map[string]string{"runner-recycling-max-wait": "5s"})
 
 	fe1.WaitForTaskWithDelay(taskID, 0*time.Second)
 	fe2.WaitForTaskWithDelay(taskID, 0*time.Second)
@@ -597,7 +601,7 @@ func TestSchedulingDelay_DelayTooLarge(t *testing.T) {
 	fe1.Register()
 	fe2.Register()
 
-	taskID := scheduleTask(ctx, t, env, map[string]string{"cold-runner-scheduling-delay": "1h"})
+	taskID := scheduleTask(ctx, t, env, map[string]string{"runner-recycling-max-wait": "1h"})
 
 	fe1.WaitForTaskWithDelay(taskID, 15*time.Minute)
 	fe2.WaitForTaskWithDelay(taskID, 0*time.Second)
@@ -611,8 +615,23 @@ func TestSchedulingDelay_OnePreferredExecutor(t *testing.T) {
 	fe1.Register()
 	fe2.Register()
 
-	taskID := scheduleTask(ctx, t, env, map[string]string{"cold-runner-scheduling-delay": "5s"})
+	taskID := scheduleTask(ctx, t, env, map[string]string{"runner-recycling-max-wait": "5s"})
 
 	fe1.WaitForTaskWithDelay(taskID, 5*time.Second)
 	fe2.WaitForTaskWithDelay(taskID, 0*time.Second)
+}
+
+func TestSchedulingDelay_PreferredExecutorUnhealthy(t *testing.T) {
+	env, ctx := getEnv(t, &schedulerOpts{preferredExecutors: []string{"2"}}, "user1")
+
+	fe1 := newFakeExecutorWithId(ctx, t, "1", env.GetSchedulerClient())
+	fe2 := newFakeExecutorWithId(ctx, t, "2", env.GetSchedulerClient())
+	fe1.Register()
+	fe2.Register()
+	fe2.markUnhealthy()
+
+	taskID := scheduleTask(ctx, t, env, map[string]string{"runner-recycling-max-wait": "5s"})
+
+	fe2.EnsureTaskNotReceived(taskID)
+	fe1.WaitForTaskWithDelay(taskID, 0*time.Second)
 }

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -1431,8 +1431,8 @@ func (n fakeRankedNode) GetExecutionNode() interfaces.ExecutionNode {
 	return n.node
 }
 
-func (_ fakeRankedNode) GetSchedulingDelay() time.Duration {
-	return 0 * time.Second
+func (_ fakeRankedNode) IsPreferred() bool {
+	return false
 }
 
 type fixedNodeTaskRouter struct {

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -1423,6 +1423,18 @@ func TestWaitExecution(t *testing.T) {
 	}
 }
 
+type fakeRankedNode struct {
+	node interfaces.ExecutionNode
+}
+
+func (n fakeRankedNode) GetExecutionNode() interfaces.ExecutionNode {
+	return n.node
+}
+
+func (_ fakeRankedNode) GetSchedulingDelay() time.Duration {
+	return 0 * time.Second
+}
+
 type fixedNodeTaskRouter struct {
 	mu          sync.Mutex
 	executorIDs map[string]struct{}
@@ -1436,13 +1448,13 @@ func newFixedNodeTaskRouter(executorIDs []string) *fixedNodeTaskRouter {
 	return &fixedNodeTaskRouter{executorIDs: idSet}
 }
 
-func (f *fixedNodeTaskRouter) RankNodes(ctx context.Context, cmd *repb.Command, remoteInstanceName string, nodes []interfaces.ExecutionNode) []interfaces.ExecutionNode {
+func (f *fixedNodeTaskRouter) RankNodes(ctx context.Context, cmd *repb.Command, remoteInstanceName string, nodes []interfaces.ExecutionNode) []interfaces.RankedExecutionNode {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	var out []interfaces.ExecutionNode
+	var out []interfaces.RankedExecutionNode
 	for _, n := range nodes {
 		if _, ok := f.executorIDs[n.GetExecutorID()]; ok {
-			out = append(out, n)
+			out = append(out, fakeRankedNode{node: n})
 		}
 	}
 	return out

--- a/enterprise/server/test/integration/task_router/task_router_test.go
+++ b/enterprise/server/test/integration/task_router/task_router_test.go
@@ -132,7 +132,7 @@ func TestTaskRouter_RankNodes_WithDelay(t *testing.T) {
 			Properties: []*repb.Platform_Property{
 				{Name: "recycle-runner", Value: "true"},
 				{Name: "workflow-id", Value: "WF1"},
-				{Name: "cold-runner-scheduling-delay-ms", Value: "2s"},
+				{Name: "cold-runner-scheduling-delay", Value: "2s"},
 			},
 		},
 	}

--- a/enterprise/server/test/integration/task_router/task_router_test.go
+++ b/enterprise/server/test/integration/task_router/task_router_test.go
@@ -51,8 +51,8 @@ func TestTaskRouter_RankNodes_Workflows_ReturnsMultipleRunnersThatExecutedWorkfl
 
 	ranked := router.RankNodes(ctx, cmd, instanceName, nodes)
 
-	require.ElementsMatch(t, nodes, ranked)
-	require.Equal(t, executorID1, ranked[0].GetExecutorID())
+	requireSameExecutionNodes(t, nodes, ranked)
+	require.Equal(t, executorID1, ranked[0].GetExecutionNode().GetExecutorID())
 
 	// The remaining nodes should be shuffled.
 	requireNonSequential(t, ranked[1:])
@@ -67,9 +67,9 @@ func TestTaskRouter_RankNodes_Workflows_ReturnsMultipleRunnersThatExecutedWorkfl
 
 	ranked = router.RankNodes(ctx, cmd, instanceName, nodes)
 
-	require.ElementsMatch(t, nodes, ranked)
-	require.Equal(t, executorID2, ranked[0].GetExecutorID())
-	require.Equal(t, executorID1, ranked[1].GetExecutorID())
+	requireSameExecutionNodes(t, nodes, ranked)
+	require.Equal(t, executorID2, ranked[0].GetExecutionNode().GetExecutorID())
+	require.Equal(t, executorID1, ranked[1].GetExecutionNode().GetExecutorID())
 	requireNonSequential(t, ranked[2:])
 }
 
@@ -96,8 +96,8 @@ func TestTaskRouter_RankNodes_DefaultNodeLimit_ReturnsOnlyLatestNodeMarkedComple
 
 	ranked := router.RankNodes(ctx, cmd, instanceName, nodes)
 
-	require.ElementsMatch(t, nodes, ranked)
-	require.Equal(t, executorID1, ranked[0].GetExecutorID())
+	requireSameExecutionNodes(t, nodes, ranked)
+	require.Equal(t, executorID1, ranked[0].GetExecutionNode().GetExecutorID())
 	requireNonSequential(t, ranked[1:])
 
 	// Mark the same task complete by executor 2 as well.
@@ -110,11 +110,69 @@ func TestTaskRouter_RankNodes_DefaultNodeLimit_ReturnsOnlyLatestNodeMarkedComple
 	// randomly, since we only store up to 1 recent executor for non-workflow
 	// tasks.
 
-	require.ElementsMatch(t, nodes, ranked)
-	require.Equal(t, executorID2, ranked[0].GetExecutorID())
+	requireSameExecutionNodes(t, nodes, ranked)
+	require.Equal(t, executorID2, ranked[0].GetExecutionNode().GetExecutorID())
 
 	requireNotAlwaysRanked(1, executorID1, t, router, ctx, cmd, instanceName)
 	requireNonSequential(t, ranked[1:])
+
+	// No nodes should have a scheduling delay as none was specified.
+	for i := 0; i < 100; i++ {
+		require.Equal(t, 0*time.Second, ranked[i].GetSchedulingDelay())
+	}
+}
+
+func TestTaskRouter_RankNodes_WithDelay(t *testing.T) {
+	// Mark a routable workflow task complete by executor 1.
+	env := newTestEnv(t)
+	router := newTaskRouter(t, env)
+	ctx := withAuthUser(t, context.Background(), env, "US1")
+	cmd := &repb.Command{
+		Platform: &repb.Platform{
+			Properties: []*repb.Platform_Property{
+				{Name: "recycle-runner", Value: "true"},
+				{Name: "workflow-id", Value: "WF1"},
+				{Name: "cold-runner-scheduling-delay-ms", Value: "2s"},
+			},
+		},
+	}
+	instanceName := "test-instance"
+
+	router.MarkComplete(ctx, cmd, instanceName, executorID1)
+
+	nodes := sequentiallyNumberedNodes(100)
+
+	// Task should now be routed to executor 1.
+
+	ranked := router.RankNodes(ctx, cmd, instanceName, nodes)
+
+	requireSameExecutionNodes(t, nodes, ranked)
+	require.Equal(t, executorID1, ranked[0].GetExecutionNode().GetExecutorID())
+
+	// The remaining nodes should be shuffled.
+	requireNonSequential(t, ranked[1:])
+
+	// Mark the same task complete by executor 2 as well.
+
+	router.MarkComplete(ctx, cmd, instanceName, executorID2)
+
+	// Task should now be routed to executor 2 then 1 in order, since executor 2
+	// ran the task more recently, and we memorize several recent executors for
+	// workflow tasks.
+
+	ranked = router.RankNodes(ctx, cmd, instanceName, nodes)
+
+	requireSameExecutionNodes(t, nodes, ranked)
+	require.Equal(t, executorID2, ranked[0].GetExecutionNode().GetExecutorID())
+	require.Equal(t, 0*time.Second, ranked[0].GetSchedulingDelay())
+	require.Equal(t, executorID1, ranked[1].GetExecutionNode().GetExecutorID())
+	require.Equal(t, 0*time.Second, ranked[1].GetSchedulingDelay())
+	requireNonSequential(t, ranked[2:])
+
+	// Non-preferred nodes should have the 2 second scheduling delay specified.
+	for i := 2; i < 100; i++ {
+		require.Equal(t, 2*time.Second, ranked[i].GetSchedulingDelay())
+	}
 }
 
 func TestTaskRouter_RankNodes_AffinityRouting(t *testing.T) {
@@ -160,8 +218,8 @@ func TestTaskRouter_RankNodes_AffinityRouting(t *testing.T) {
 	// Task should now be routed to executor 1.
 	ranked = router.RankNodes(ctx, secondCmd, instanceName, nodes)
 
-	require.ElementsMatch(t, nodes, ranked)
-	require.Equal(t, executorID1, ranked[0].GetExecutorID())
+	requireSameExecutionNodes(t, nodes, ranked)
+	require.Equal(t, executorID1, ranked[0].GetExecutionNode().GetExecutorID())
 	requireNonSequential(t, ranked[1:])
 
 	// Mark the task complete by executor 2 as well.
@@ -185,8 +243,8 @@ func TestTaskRouter_RankNodes_AffinityRouting(t *testing.T) {
 	ranked = router.RankNodes(ctx, thirdCmd, instanceName, nodes)
 
 	// Task should now be routed to executor 2, with executor 1 ranked randomly
-	require.ElementsMatch(t, nodes, ranked)
-	require.Equal(t, executorID2, ranked[0].GetExecutorID())
+	requireSameExecutionNodes(t, nodes, ranked)
+	require.Equal(t, executorID2, ranked[0].GetExecutionNode().GetExecutorID())
 	requireNonSequential(t, ranked[1:])
 
 	requireNotAlwaysRanked(1, executorID1, t, router, ctx, thirdCmd, instanceName)
@@ -226,7 +284,7 @@ func TestTaskRouter_RankNodes_AffinityRoutingNoOutputs(t *testing.T) {
 
 	// No nodes should be preferred as there are no outputs to route using.
 	ranked := router.RankNodes(ctx, cmd, instanceName, nodes)
-	require.ElementsMatch(t, nodes, ranked)
+	requireSameExecutionNodes(t, nodes, ranked)
 	requireNonSequential(t, ranked)
 	requireNotAlwaysRanked(0, executorID1, t, router, ctx, cmd, instanceName)
 }
@@ -253,7 +311,7 @@ func TestTaskRouter_RankNodes_AffinityRoutingDisabled(t *testing.T) {
 
 	// No nodes should be preferred as affinity routing is disabled.
 	ranked := router.RankNodes(ctx, cmd, instanceName, nodes)
-	require.ElementsMatch(t, nodes, ranked)
+	requireSameExecutionNodes(t, nodes, ranked)
 	requireNonSequential(t, ranked)
 	requireNotAlwaysRanked(0, executorID1, t, router, ctx, cmd, instanceName)
 }
@@ -292,8 +350,8 @@ func TestTaskRouter_RankNodes_RunnerRecyclingTakesPrecedence(t *testing.T) {
 	// routing should take priority
 	ranked := router.RankNodes(ctx, oaCmd, instanceName, nodes)
 
-	require.ElementsMatch(t, nodes, ranked)
-	require.Equal(t, executorID2, ranked[0].GetExecutorID())
+	requireSameExecutionNodes(t, nodes, ranked)
+	require.Equal(t, executorID2, ranked[0].GetExecutionNode().GetExecutorID())
 	requireNonSequential(t, ranked[1:])
 }
 
@@ -384,7 +442,7 @@ func TestTaskRouter_WorkflowGitRefRouting(t *testing.T) {
 	// executor1 should now be the preferred executor when running this workflow
 	// on the main branch.
 	ranked := router.RankNodes(ctx, mainBranchCmd, instanceName, nodes)
-	require.Equal(t, executorID1, ranked[0].GetExecutorID())
+	require.Equal(t, executorID1, ranked[0].GetExecutionNode().GetExecutorID())
 
 	// executor1 should not necessarily be preferred when running this workflow
 	// on a different branch.
@@ -401,6 +459,14 @@ func TestTaskRouter_WorkflowGitRefRouting(t *testing.T) {
 	requireNotAlwaysRanked(0, executorID1, t, router, ctx, prBranchCmd, instanceName)
 }
 
+func requireSameExecutionNodes(t *testing.T, nodes []interfaces.ExecutionNode, ranked []interfaces.RankedExecutionNode) {
+	rankedNodes := make([]interfaces.ExecutionNode, len(ranked))
+	for i, rankedNode := range ranked {
+		rankedNodes[i] = rankedNode.GetExecutionNode()
+	}
+	require.ElementsMatch(t, nodes, rankedNodes)
+}
+
 // requireNotAlwaysRanked requires that the task router does not
 // deterministically assign the given rank to the given executor ID.
 func requireNotAlwaysRanked(rank int, executorID string, t *testing.T, router interfaces.TaskRouter, ctx context.Context, cmd *repb.Command, instanceName string) {
@@ -410,7 +476,7 @@ func requireNotAlwaysRanked(rank int, executorID string, t *testing.T, router in
 		ranked := router.RankNodes(ctx, cmd, instanceName, nodes)
 
 		require.Equal(t, len(nodes), len(ranked))
-		if ranked[rank].GetExecutorID() != executorID {
+		if ranked[rank].GetExecutionNode().GetExecutorID() != executorID {
 			return
 		}
 	}
@@ -423,25 +489,25 @@ func requireNotAlwaysRanked(rank int, executorID string, t *testing.T, router in
 	)
 }
 
-func requireReordered(t *testing.T, nodes []interfaces.ExecutionNode, ranked []interfaces.ExecutionNode) {
-	require.ElementsMatch(t, nodes, ranked)
+func requireReordered(t *testing.T, nodes []interfaces.ExecutionNode, ranked []interfaces.RankedExecutionNode) {
+	requireSameExecutionNodes(t, nodes, ranked)
 
 	for i := range nodes {
-		if nodes[i] != ranked[i] {
+		if nodes[i].GetExecutorID() != ranked[i].GetExecutionNode().GetExecutorID() {
 			return
 		}
 	}
 	require.FailNow(t, "nodes were not reordered")
 }
 
-func requireNonSequential(t *testing.T, nodes []interfaces.ExecutionNode) {
+func requireNonSequential(t *testing.T, nodes []interfaces.RankedExecutionNode) {
 	if len(nodes) <= 1 {
 		require.FailNow(t, "slice too short to test for sequential order")
 	}
-	prev, err := strconv.Atoi(nodes[0].GetExecutorID())
+	prev, err := strconv.Atoi(nodes[0].GetExecutionNode().GetExecutorID())
 	require.NoError(t, err)
 	for i := 1; i < len(nodes); i++ {
-		cur, err := strconv.Atoi(nodes[i].GetExecutorID())
+		cur, err := strconv.Atoi(nodes[i].GetExecutionNode().GetExecutorID())
 		require.NoError(t, err)
 		if cur < prev {
 			return

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -740,9 +740,9 @@ type ExecutionService interface {
 type RankedExecutionNode interface {
 	GetExecutionNode() ExecutionNode
 
-	// Returns the delay which should be applied for tasks newly scheduled on
-	// this execution node.
-	GetSchedulingDelay() time.Duration
+	// Returns whether or not this node is "preferred" in ranking for the
+	// provided execution.
+	IsPreferred() bool
 }
 
 type ExecutionNode interface {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -736,6 +736,15 @@ type ExecutionService interface {
 	GetExecution(ctx context.Context, req *espb.GetExecutionRequest) (*espb.GetExecutionResponse, error)
 }
 
+// An ExecutionNode that has been ranked for scheduling.
+type RankedExecutionNode interface {
+	GetExecutionNode() ExecutionNode
+
+	// Returns the delay which should be applied for tasks newly scheduled on
+	// this execution node.
+	GetSchedulingDelay() time.Duration
+}
+
 type ExecutionNode interface {
 	// GetExecutorID returns the ID for this execution node that uniquely identifies
 	// it within a node pool.
@@ -759,7 +768,7 @@ type TaskRouter interface {
 	// suitability are returned in random order (for load balancing purposes).
 	//
 	// If an error occurs, the input nodes should be returned in random order.
-	RankNodes(ctx context.Context, cmd *repb.Command, remoteInstanceName string, nodes []ExecutionNode) []ExecutionNode
+	RankNodes(ctx context.Context, cmd *repb.Command, remoteInstanceName string, nodes []ExecutionNode) []RankedExecutionNode
 
 	// MarkComplete notifies the router that the command has been completed by the
 	// given executor instance. Subsequent calls to RankNodes may assign a higher


### PR DESCRIPTION
This is a customer feature request. I took the opportunity to refactor the `enqueueTaskReservations` function in `scheduler_server.go` and would appreciate a careful review!

**Related issues**: N/A
