### PR TITLE
Add little digest widgets next to artifacts

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -148,6 +148,7 @@ ts_library(
     name = "invocation_artifacts_card",
     srcs = ["invocation_artifacts_card.tsx"],
     deps = [
+        "//app/components/digest",
         "//app/format",
         "//app/invocation:invocation_model",
         "//app/invocation:invocation_target_group_card",
@@ -675,6 +676,7 @@ ts_library(
     name = "invocation_target_group_card",
     srcs = ["invocation_target_group_card.tsx"],
     deps = [
+        "//app/components/digest",
         "//app/components/link",
         "//app/components/spinner",
         "//app/errors:error_service",

--- a/app/invocation/invocation_artifacts_card.tsx
+++ b/app/invocation/invocation_artifacts_card.tsx
@@ -6,6 +6,7 @@ import { target } from "../../proto/target_ts_proto";
 import { ArrowDownCircle, FileCode } from "lucide-react";
 import TargetGroupCard from "./invocation_target_group_card";
 import format from "../format/format";
+import DigestComponent from "../components/digest/digest";
 
 interface Props {
   model: InvocationModel;
@@ -155,6 +156,7 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
                           <FileCode /> View
                         </a>
                       )}
+                      <DigestComponent digest={{ hash: output.digest, sizeBytes: output.length }} />
                     </div>
                   ))}
                   {target.hiddenOutputCount > 0 && (

--- a/app/invocation/invocation_target_group_card.tsx
+++ b/app/invocation/invocation_target_group_card.tsx
@@ -20,6 +20,7 @@ import error_service from "../errors/error_service";
 import Spinner from "../components/spinner/spinner";
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
 import format from "../format/format";
+import DigestComponent from "../components/digest/digest";
 
 export interface TargetGroupCardProps {
   invocationId: string;
@@ -215,6 +216,7 @@ export default class TargetGroupCard extends React.Component<TargetGroupCardProp
                             <FileCode className="icon" /> View
                           </a>
                         )}
+                        <DigestComponent digest={{ hash: output.digest, sizeBytes: output.length }} />
                       </div>
                     ))}
                   </div>

--- a/app/target/BUILD
+++ b/app/target/BUILD
@@ -46,6 +46,7 @@ ts_library(
     srcs = ["target_artifacts_card.tsx"],
     deps = [
         "//app/capabilities",
+        "//app/components/digest",
         "//app/service:rpc_service",
         "//proto:build_event_stream_ts_proto",
         "//proto:zip_ts_proto",

--- a/app/target/target_artifacts_card.tsx
+++ b/app/target/target_artifacts_card.tsx
@@ -5,6 +5,7 @@ import { zip } from "../../proto/zip_ts_proto";
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
 import capabilities from "../capabilities/capabilities";
 import rpcService from "../service/rpc_service";
+import DigestComponent from "../components/digest/digest";
 
 interface Props {
   name: string;
@@ -143,6 +144,7 @@ export default class TargetArtifactsCardComponent extends React.Component<Props,
                       <FileCode /> View
                     </a>
                   )}
+                  <DigestComponent digest={{ hash: output.digest, sizeBytes: output.length }} />
                 </div>
                 {output.name === TargetArtifactsCardComponent.ZIPPED_OUTPUTS_FILE &&
                   this.state.manifest &&


### PR DESCRIPTION
This makes it easier to compare the digests & sizes against cache requests / other invocations, etc.

<img width="1402" alt="Screenshot 2023-11-20 at 4 49 14 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/318271dc-fccd-4b8e-9656-e5c9e116dd7e">
