### PR TITLE
Order thread types in a more sane way

### DIFF
--- a/app/trace/trace_events.ts
+++ b/app/trace/trace_events.ts
@@ -159,6 +159,20 @@ function timeSeriesEventComparator(a: TraceEvent, b: TraceEvent) {
   return tsDiff;
 }
 
+const threadOrder: { [key: string]: number } = {
+  "critical path": 1,
+  "main thread": 2,
+  "notification thread": 3,
+  "skyframe evaluator execution": 4,
+  "skyframe evaluator": 5,
+  "skyframe evaluator cpu heavy": 6,
+  "remote executor": 7,
+};
+
+function normalizeThreadName(name: string) {
+  return name.toLowerCase().replaceAll("-", " ").trim();
+}
+
 function timelineComparator(a: ThreadTimeline, b: ThreadTimeline) {
   // Within numbered thread names (e.g. "skyframe evaluator 0", "grpc-command-0"), sort
   // numerically.
@@ -166,6 +180,16 @@ function timelineComparator(a: ThreadTimeline, b: ThreadTimeline) {
   const matchB = b.threadName.match(NUMBERED_THREAD_NAME_PATTERN)?.groups;
   if (matchA && matchB && matchA["prefix"] === matchB["prefix"]) {
     return Number(matchA["number"]) - Number(matchB["number"]);
+  }
+
+  // For known threads, show the most interesting ones first.
+  if (
+    matchA &&
+    matchB &&
+    threadOrder[normalizeThreadName(matchA["prefix"])] &&
+    threadOrder[normalizeThreadName(matchB["prefix"])]
+  ) {
+    return threadOrder[normalizeThreadName(matchA["prefix"])] - threadOrder[normalizeThreadName(matchB["prefix"])];
   }
 
   // Sort other timelines lexicographically by thread name.


### PR DESCRIPTION
In newer Bazel versions, we get these remote execution threads which are mostly useless to visualize:
<img width="1190" alt="Screenshot 2023-11-20 at 4 51 13 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/d37bb878-abd2-4119-9774-9dd2d3ac4c4b">

This change modifies the current alphabetical ordering, to best effort order threads in this order:
- "critical path"
- "main thread"
- "notification thread"
- "skyframe evaluator execution"
- "skyframe evaluator"
- "skyframe evaluator cpu heavy"
- "remote executor"

If a normalized thread name doesn't match one of those, they'll be sorted alphabetically.