### PR TITLE
website: enable legacy OpenSSL provider

### DIFF
--- a/rules/yarn/index.bzl
+++ b/rules/yarn/index.bzl
@@ -19,7 +19,7 @@ def yarn(name, srcs, package, command = "build", deps = [], yarn = "@yarn//:yarn
     """ % (package, yarn, node, command)
 
     if executable:
-        cmd = "echo \"cd $$(dirname $(location %s)) && yarn install && yarn %s\" > $@" % (package, command)
+        cmd = "echo \"cd $$(dirname $(location %s)) && yarn install && NODE_OPTIONS=--openssl-legacy-provider yarn %s\" > $@" % (package, command)
 
     native.genrule(
         name = name,


### PR DESCRIPTION
Make sure that `:start` and `:serve` starts the node server with the
correct parameters.

References:
- https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported
