### PR TITLE
benchmark block cache size

### DIFF
--- a/enterprise/server/test/performance/cache/BUILD
+++ b/enterprise/server/test/performance/cache/BUILD
@@ -10,6 +10,7 @@ go_test(
     deps = [
         "//enterprise/server/backends/distributed",
         "//enterprise/server/backends/pebble_cache",
+        "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/backends/disk_cache",
         "//server/backends/memory_cache",
@@ -20,6 +21,7 @@ go_test(
         "//server/testutil/testenv",
         "//server/testutil/testfs",
         "//server/testutil/testport",
+        "//server/util/compression",
         "//server/util/log",
         "//server/util/prefix",
     ],


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A

benchmark on vm when pebble root dir is set on standard ssd:

```
goos: linux
goarch: amd64
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
                                    │     1e9      │                 5e9                  │                 1e10                 │                 5e10                 │
                                    │    sec/op    │    sec/op     vs base                │    sec/op     vs base                │    sec/op     vs base                │
PebbleGet/size=10-16                  14.56µ ± ∞ ¹   15.68µ ± ∞ ¹       ~ (p=1.000 n=1) ²   15.82µ ± ∞ ¹       ~ (p=1.000 n=1) ²   15.92µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=100-16                 14.50µ ± ∞ ¹   15.79µ ± ∞ ¹       ~ (p=1.000 n=1) ²   15.88µ ± ∞ ¹       ~ (p=1.000 n=1) ²   16.14µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=1000-16                15.15µ ± ∞ ¹   16.24µ ± ∞ ¹       ~ (p=1.000 n=1) ²   16.08µ ± ∞ ¹       ~ (p=1.000 n=1) ²   16.31µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=10000-16               28.27µ ± ∞ ¹   28.44µ ± ∞ ¹       ~ (p=1.000 n=1) ²   29.04µ ± ∞ ¹       ~ (p=1.000 n=1) ²   28.28µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=100000-16              31.59µ ± ∞ ¹   32.81µ ± ∞ ¹       ~ (p=1.000 n=1) ²   32.71µ ± ∞ ¹       ~ (p=1.000 n=1) ²   32.69µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=1000000-16             61.90µ ± ∞ ¹   61.27µ ± ∞ ¹       ~ (p=1.000 n=1) ²   60.45µ ± ∞ ¹       ~ (p=1.000 n=1) ²   60.66µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=10000000-16            768.6µ ± ∞ ¹   824.0µ ± ∞ ¹       ~ (p=1.000 n=1) ²   809.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²   800.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=50000000-16            4.024m ± ∞ ¹   4.037m ± ∞ ¹       ~ (p=1.000 n=1) ²   4.348m ± ∞ ¹       ~ (p=1.000 n=1) ²   4.127m ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=100000000-16           8.247m ± ∞ ¹   8.258m ± ∞ ¹       ~ (p=1.000 n=1) ²   8.358m ± ∞ ¹       ~ (p=1.000 n=1) ²   8.217m ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=10-16             570.1µ ± ∞ ¹   565.3µ ± ∞ ¹       ~ (p=1.000 n=1) ²   561.3µ ± ∞ ¹       ~ (p=1.000 n=1) ²   575.5µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=100-16            571.7µ ± ∞ ¹   569.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²   558.5µ ± ∞ ¹       ~ (p=1.000 n=1) ²   562.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=1000-16           576.2µ ± ∞ ¹   569.2µ ± ∞ ¹       ~ (p=1.000 n=1) ²   565.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²   570.3µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=10000-16          1.179m ± ∞ ¹   1.157m ± ∞ ¹       ~ (p=1.000 n=1) ²   1.176m ± ∞ ¹       ~ (p=1.000 n=1) ²   1.170m ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=100000-16         1.221m ± ∞ ¹   1.211m ± ∞ ¹       ~ (p=1.000 n=1) ²   1.210m ± ∞ ¹       ~ (p=1.000 n=1) ²   1.214m ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=1000000-16        1.495m ± ∞ ¹   1.506m ± ∞ ¹       ~ (p=1.000 n=1) ²   1.503m ± ∞ ¹       ~ (p=1.000 n=1) ²   1.508m ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=10000000-16       34.46m ± ∞ ¹   33.36m ± ∞ ¹       ~ (p=1.000 n=1) ²   33.64m ± ∞ ¹       ~ (p=1.000 n=1) ²   35.07m ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=50000000-16       171.3m ± ∞ ¹   173.4m ± ∞ ¹       ~ (p=1.000 n=1) ²   170.3m ± ∞ ¹       ~ (p=1.000 n=1) ²   169.7m ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=100000000-16      348.8m ± ∞ ¹   330.2m ± ∞ ¹       ~ (p=1.000 n=1) ²   344.7m ± ∞ ¹       ~ (p=1.000 n=1) ²   340.2m ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=10-16          453.4µ ± ∞ ¹   446.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²   448.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²   442.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=100-16         453.0µ ± ∞ ¹   453.0µ ± ∞ ¹       ~ (p=1.000 n=1) ²   451.5µ ± ∞ ¹       ~ (p=1.000 n=1) ²   449.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=1000-16        463.6µ ± ∞ ¹   463.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²   462.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²   462.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=10000-16       462.0µ ± ∞ ¹   465.3µ ± ∞ ¹       ~ (p=1.000 n=1) ²   465.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²   466.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=100000-16      465.5µ ± ∞ ¹   469.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²   463.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²   459.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=1000000-16     478.5µ ± ∞ ¹   470.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²   467.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²   464.0µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=10000000-16    3.066m ± ∞ ¹   3.055m ± ∞ ¹       ~ (p=1.000 n=1) ²   3.072m ± ∞ ¹       ~ (p=1.000 n=1) ²   3.006m ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=50000000-16    14.09m ± ∞ ¹   14.02m ± ∞ ¹       ~ (p=1.000 n=1) ²   14.14m ± ∞ ¹       ~ (p=1.000 n=1) ²   13.91m ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=100000000-16   29.41m ± ∞ ¹   28.22m ± ∞ ¹       ~ (p=1.000 n=1) ²   30.05m ± ∞ ¹       ~ (p=1.000 n=1) ²   29.12m ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                               892.7µ         897.8µ        +0.56%                   902.7µ        +1.12%                   899.3µ        +0.74%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                 │      1e9      │                  5e9                  │                 1e10                  │                 5e10                  │
                                 │      B/s      │      B/s       vs base                │      B/s       vs base                │      B/s       vs base                │
PebbleGet/size=10-16               1.507Mi ± ∞ ¹   1.402Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   1.383Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   1.383Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=100-16              1.383Mi ± ∞ ¹   1.268Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   1.259Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   1.240Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=1000-16             2.766Mi ± ∞ ¹   2.642Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   2.670Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   2.689Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=10000-16            6.380Mi ± ∞ ¹   6.409Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   5.751Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   6.104Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=100000-16           31.59Mi ± ∞ ¹   29.91Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   30.12Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   30.39Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=1000000-16          256.5Mi ± ∞ ¹   186.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   230.7Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   263.3Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=10000000-16         240.5Mi ± ∞ ¹   215.8Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   217.6Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   206.2Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=50000000-16         231.1Mi ± ∞ ¹   239.8Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   221.6Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   232.1Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=100000000-16        232.7Mi ± ∞ ¹   233.8Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   236.1Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   240.6Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=10-16          1.926Mi ± ∞ ¹   1.936Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   1.955Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   1.907Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=100-16         1.755Mi ± ∞ ¹   1.755Mi ± ∞ ¹       ~ (p=1.000 n=1) ³   1.793Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   1.783Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=1000-16        3.452Mi ± ∞ ¹   3.586Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   3.576Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   3.490Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=10000-16       7.391Mi ± ∞ ¹   7.515Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   7.391Mi ± ∞ ¹       ~ (p=1.000 n=1) ³   7.410Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=100000-16      40.65Mi ± ∞ ¹   40.88Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   41.01Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   40.84Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=1000000-16     515.9Mi ± ∞ ¹   506.2Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   499.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   500.3Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=10000000-16    248.7Mi ± ∞ ¹   260.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   256.0Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   247.4Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=50000000-16    281.2Mi ± ∞ ¹   276.9Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   282.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   283.9Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=100000000-16   279.8Mi ± ∞ ¹   295.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   284.7Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   287.8Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                            28.31Mi         27.52Mi        -2.78%                   27.53Mi        -2.74%                   27.73Mi        -2.03%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
³ all samples are equal

                                    │      1e9      │                  5e9                  │                 1e10                  │                 5e10                  │
                                    │     B/op      │     B/op       vs base                │     B/op       vs base                │     B/op       vs base                │
PebbleGet/size=10-16                  4.229Ki ± ∞ ¹   4.220Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   4.222Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   4.221Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=100-16                 4.229Ki ± ∞ ¹   4.220Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   4.221Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   4.223Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=1000-16                4.257Ki ± ∞ ¹   4.244Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   4.246Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   4.246Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=10000-16               5.355Ki ± ∞ ¹   5.338Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   5.339Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   5.338Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=100000-16              8.011Ki ± ∞ ¹   7.999Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   7.997Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   8.001Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=1000000-16             78.93Ki ± ∞ ¹   76.54Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   75.22Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   75.81Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=10000000-16            1.402Mi ± ∞ ¹   1.440Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   1.427Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   1.431Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=50000000-16            7.695Mi ± ∞ ¹   7.705Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   7.698Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   7.683Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=100000000-16           19.14Mi ± ∞ ¹   19.10Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   18.98Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   19.01Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=10-16             154.1Ki ± ∞ ¹   154.1Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   154.1Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   154.2Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=100-16            154.1Ki ± ∞ ¹   154.1Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   154.1Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   154.2Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=1000-16           156.5Ki ± ∞ ¹   156.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   156.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   156.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=10000-16          218.2Ki ± ∞ ¹   218.1Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   218.1Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   218.2Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=100000-16         267.5Ki ± ∞ ¹   267.3Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   267.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   267.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=1000000-16        1.083Mi ± ∞ ¹   1.070Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   1.057Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   1.065Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=10000000-16       46.17Mi ± ∞ ¹   46.15Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   46.33Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   46.52Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=50000000-16       228.9Mi ± ∞ ¹   228.9Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   229.7Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   229.1Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=100000000-16      603.6Mi ± ∞ ¹   603.4Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   599.9Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   602.7Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=10-16          133.8Ki ± ∞ ¹   133.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   133.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   133.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=100-16         133.8Ki ± ∞ ¹   133.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   133.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   133.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=1000-16        135.0Ki ± ∞ ¹   134.9Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   135.0Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   135.0Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=10000-16       136.6Ki ± ∞ ¹   136.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   136.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   136.6Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=100000-16      136.5Ki ± ∞ ¹   136.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   136.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   136.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=1000000-16     136.6Ki ± ∞ ¹   136.6Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   136.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   136.6Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=10000000-16    869.5Ki ± ∞ ¹   869.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   870.7Ki ± ∞ ¹       ~ (p=1.000 n=1) ²   869.4Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=50000000-16    3.590Mi ± ∞ ¹   3.589Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   3.589Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   3.589Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=100000000-16   19.87Mi ± ∞ ¹   19.91Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   19.87Mi ± ∞ ¹       ~ (p=1.000 n=1) ²   20.11Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                               411.1Ki         410.6Ki        -0.11%                   410.0Ki        -0.26%                   410.5Ki        -0.13%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                    │     1e9      │                 5e9                  │                 1e10                 │                 5e10                 │
                                    │  allocs/op   │  allocs/op    vs base                │  allocs/op    vs base                │  allocs/op    vs base                │
PebbleGet/size=10-16                   85.00 ± ∞ ¹    85.00 ± ∞ ¹       ~ (p=1.000 n=1) ²    85.00 ± ∞ ¹       ~ (p=1.000 n=1) ²    85.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=100-16                  85.00 ± ∞ ¹    85.00 ± ∞ ¹       ~ (p=1.000 n=1) ²    85.00 ± ∞ ¹       ~ (p=1.000 n=1) ²    85.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=1000-16                 85.00 ± ∞ ¹    85.00 ± ∞ ¹       ~ (p=1.000 n=1) ²    85.00 ± ∞ ¹       ~ (p=1.000 n=1) ²    85.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=10000-16                95.00 ± ∞ ¹    95.00 ± ∞ ¹       ~ (p=1.000 n=1) ²    95.00 ± ∞ ¹       ~ (p=1.000 n=1) ²    95.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=100000-16               103.0 ± ∞ ¹    103.0 ± ∞ ¹       ~ (p=1.000 n=1) ²    103.0 ± ∞ ¹       ~ (p=1.000 n=1) ²    103.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGet/size=1000000-16              137.0 ± ∞ ¹    136.0 ± ∞ ¹       ~ (p=1.000 n=1) ³    136.0 ± ∞ ¹       ~ (p=1.000 n=1) ³    136.0 ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleGet/size=10000000-16            1.179k ± ∞ ¹   1.180k ± ∞ ¹       ~ (p=1.000 n=1) ³   1.181k ± ∞ ¹       ~ (p=1.000 n=1) ³   1.181k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleGet/size=50000000-16            5.255k ± ∞ ¹   5.259k ± ∞ ¹       ~ (p=1.000 n=1) ³   5.262k ± ∞ ¹       ~ (p=1.000 n=1) ³   5.262k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleGet/size=100000000-16           68.98k ± ∞ ¹   68.65k ± ∞ ¹       ~ (p=1.000 n=1) ³   66.53k ± ∞ ¹       ~ (p=1.000 n=1) ³   67.16k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleGetMulti/size=10-16             3.365k ± ∞ ¹   3.365k ± ∞ ¹       ~ (p=1.000 n=1) ²   3.366k ± ∞ ¹       ~ (p=1.000 n=1) ³   3.366k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleGetMulti/size=100-16            3.365k ± ∞ ¹   3.366k ± ∞ ¹       ~ (p=1.000 n=1) ³   3.366k ± ∞ ¹       ~ (p=1.000 n=1) ³   3.366k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleGetMulti/size=1000-16           3.366k ± ∞ ¹   3.366k ± ∞ ¹       ~ (p=1.000 n=1) ²   3.366k ± ∞ ¹       ~ (p=1.000 n=1) ²   3.366k ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleGetMulti/size=10000-16          3.868k ± ∞ ¹   3.868k ± ∞ ¹       ~ (p=1.000 n=1) ²   3.869k ± ∞ ¹       ~ (p=1.000 n=1) ³   3.870k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleGetMulti/size=100000-16         3.875k ± ∞ ¹   3.875k ± ∞ ¹       ~ (p=1.000 n=1) ²   3.876k ± ∞ ¹       ~ (p=1.000 n=1) ³   3.877k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleGetMulti/size=1000000-16        3.892k ± ∞ ¹   3.890k ± ∞ ¹       ~ (p=1.000 n=1) ³   3.894k ± ∞ ¹       ~ (p=1.000 n=1) ³   3.891k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleGetMulti/size=10000000-16       57.27k ± ∞ ¹   57.28k ± ∞ ¹       ~ (p=1.000 n=1) ³   57.32k ± ∞ ¹       ~ (p=1.000 n=1) ³   57.35k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleGetMulti/size=50000000-16       261.4k ± ∞ ¹   261.5k ± ∞ ¹       ~ (p=1.000 n=1) ³   261.5k ± ∞ ¹       ~ (p=1.000 n=1) ³   261.3k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleGetMulti/size=100000000-16      2.888M ± ∞ ¹   2.881M ± ∞ ¹       ~ (p=1.000 n=1) ³   2.814M ± ∞ ¹       ~ (p=1.000 n=1) ³   2.867M ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleFindMissing/size=10-16          3.012k ± ∞ ¹   3.012k ± ∞ ¹       ~ (p=1.000 n=1) ²   3.012k ± ∞ ¹       ~ (p=1.000 n=1) ²   3.012k ± ∞ ¹       ~ (p=1.000 n=1) ²
PebbleFindMissing/size=100-16         3.012k ± ∞ ¹   3.012k ± ∞ ¹       ~ (p=1.000 n=1) ²   3.012k ± ∞ ¹       ~ (p=1.000 n=1) ²   3.013k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleFindMissing/size=1000-16        3.012k ± ∞ ¹   3.012k ± ∞ ¹       ~ (p=1.000 n=1) ²   3.013k ± ∞ ¹       ~ (p=1.000 n=1) ³   3.013k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleFindMissing/size=10000-16       3.012k ± ∞ ¹   3.012k ± ∞ ¹       ~ (p=1.000 n=1) ²   3.012k ± ∞ ¹       ~ (p=1.000 n=1) ²   3.013k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleFindMissing/size=100000-16      3.012k ± ∞ ¹   3.012k ± ∞ ¹       ~ (p=1.000 n=1) ²   3.013k ± ∞ ¹       ~ (p=1.000 n=1) ³   3.013k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleFindMissing/size=1000000-16     3.012k ± ∞ ¹   3.012k ± ∞ ¹       ~ (p=1.000 n=1) ²   3.013k ± ∞ ¹       ~ (p=1.000 n=1) ³   3.013k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleFindMissing/size=10000000-16    18.94k ± ∞ ¹   18.94k ± ∞ ¹       ~ (p=1.000 n=1) ³   18.94k ± ∞ ¹       ~ (p=1.000 n=1) ³   18.94k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleFindMissing/size=50000000-16    79.14k ± ∞ ¹   79.14k ± ∞ ¹       ~ (p=1.000 n=1) ³   79.14k ± ∞ ¹       ~ (p=1.000 n=1) ³   79.15k ± ∞ ¹       ~ (p=1.000 n=1) ³
PebbleFindMissing/size=100000000-16   363.4k ± ∞ ¹   364.3k ± ∞ ¹       ~ (p=1.000 n=1) ³   363.4k ± ∞ ¹       ~ (p=1.000 n=1) ³   367.5k ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                               3.960k         3.959k        -0.04%                   3.951k        -0.23%                   3.957k        -0.08%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ need >= 4 samples to detect a difference at alpha level 0.05
```
The following results are from my own machine:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor            
                                    │     1e9      │                 5e9                 │                 1e10                  │                5e10                 │
                                    │    sec/op    │    sec/op     vs base               │    sec/op     vs base                 │    sec/op     vs base               │
PebbleGet/size=10-24                  8.967µ ± ∞ ¹   7.465µ ± ∞ ¹  -16.75% (p=0.029 n=4)   7.577µ ± ∞ ¹  -15.51% (p=0.029 n=4)     7.701µ ± ∞ ¹  -14.12% (p=0.029 n=4)
PebbleGet/size=100-24                 8.293µ ± ∞ ¹   7.459µ ± ∞ ¹  -10.06% (p=0.029 n=4)   7.790µ ± ∞ ¹   -6.06% (p=0.029 n=4)     7.544µ ± ∞ ¹        ~ (p=0.200 n=4)
PebbleGet/size=1000-24                8.801µ ± ∞ ¹   7.620µ ± ∞ ¹  -13.42% (p=0.029 n=4)   7.897µ ± ∞ ¹  -10.27% (p=0.029 n=4)     7.828µ ± ∞ ¹  -11.06% (p=0.029 n=4)
PebbleGet/size=10000-24               16.16µ ± ∞ ¹   15.00µ ± ∞ ¹   -7.15% (p=0.029 n=4)   14.72µ ± ∞ ¹        ~ (p=0.114 n=4+3)   15.47µ ± ∞ ¹        ~ (p=0.114 n=4)
PebbleGet/size=100000-24              19.34µ ± ∞ ¹   16.93µ ± ∞ ¹  -12.45% (p=0.029 n=4)   17.01µ ± ∞ ¹  -12.05% (p=0.029 n=4)     17.33µ ± ∞ ¹  -10.38% (p=0.029 n=4)
PebbleGet/size=1000000-24             31.79µ ± ∞ ¹   31.96µ ± ∞ ¹        ~ (p=1.000 n=4)   33.13µ ± ∞ ¹        ~ (p=0.057 n=4)     32.08µ ± ∞ ¹        ~ (p=0.886 n=4)
PebbleGet/size=10000000-24            455.0µ ± ∞ ¹   508.7µ ± ∞ ¹  +11.81% (p=0.029 n=4)   520.2µ ± ∞ ¹  +14.34% (p=0.029 n=4)     521.4µ ± ∞ ¹  +14.61% (p=0.029 n=4)
PebbleGet/size=50000000-24            2.097m ± ∞ ¹   2.122m ± ∞ ¹        ~ (p=0.343 n=4)   2.148m ± ∞ ¹   +2.43% (p=0.029 n=4)     2.181m ± ∞ ¹        ~ (p=0.114 n=4)
PebbleGet/size=100000000-24           4.223m ± ∞ ¹   4.270m ± ∞ ¹        ~ (p=0.486 n=4)   4.323m ± ∞ ¹        ~ (p=0.057 n=4)     4.355m ± ∞ ¹        ~ (p=0.114 n=4)
PebbleGetMulti/size=10-24             258.8µ ± ∞ ¹   259.9µ ± ∞ ¹        ~ (p=0.886 n=4)   267.1µ ± ∞ ¹        ~ (p=0.486 n=4)     261.0µ ± ∞ ¹        ~ (p=1.000 n=4)
PebbleGetMulti/size=100-24            258.9µ ± ∞ ¹   278.0µ ± ∞ ¹   +7.39% (p=0.029 n=4)   266.5µ ± ∞ ¹        ~ (p=0.343 n=4)     270.2µ ± ∞ ¹        ~ (p=0.343 n=4)
PebbleGetMulti/size=1000-24           272.7µ ± ∞ ¹   273.4µ ± ∞ ¹        ~ (p=0.886 n=4)   291.5µ ± ∞ ¹        ~ (p=0.200 n=4)     272.5µ ± ∞ ¹        ~ (p=0.886 n=4)
PebbleGetMulti/size=10000-24          646.4µ ± ∞ ¹   634.6µ ± ∞ ¹        ~ (p=0.343 n=4)   624.8µ ± ∞ ¹        ~ (p=0.114 n=4)     641.8µ ± ∞ ¹        ~ (p=0.686 n=4)
PebbleGetMulti/size=100000-24         661.5µ ± ∞ ¹   638.3µ ± ∞ ¹        ~ (p=0.343 n=4)   668.5µ ± ∞ ¹        ~ (p=0.686 n=4)     667.1µ ± ∞ ¹        ~ (p=0.686 n=4)
PebbleGetMulti/size=1000000-24        778.8µ ± ∞ ¹   805.8µ ± ∞ ¹        ~ (p=0.686 n=4)   820.5µ ± ∞ ¹        ~ (p=0.114 n=4)     800.4µ ± ∞ ¹        ~ (p=0.200 n=4)
PebbleGetMulti/size=10000000-24       19.19m ± ∞ ¹   19.46m ± ∞ ¹        ~ (p=0.886 n=4)   19.62m ± ∞ ¹        ~ (p=0.686 n=4)     19.69m ± ∞ ¹        ~ (p=0.886 n=4)
PebbleGetMulti/size=50000000-24       88.00m ± ∞ ¹   87.76m ± ∞ ¹        ~ (p=0.886 n=4)   90.11m ± ∞ ¹        ~ (p=0.486 n=4)     88.89m ± ∞ ¹        ~ (p=0.486 n=4)
PebbleGetMulti/size=100000000-24      173.8m ± ∞ ¹   169.4m ± ∞ ¹        ~ (p=1.000 n=4)   174.6m ± ∞ ¹        ~ (p=0.886 n=4)     184.0m ± ∞ ¹        ~ (p=0.200 n=4)
PebbleFindMissing/size=10-24          198.5µ ± ∞ ¹   205.6µ ± ∞ ¹        ~ (p=0.200 n=4)   209.1µ ± ∞ ¹        ~ (p=0.057 n=4)     202.7µ ± ∞ ¹        ~ (p=0.486 n=4)
PebbleFindMissing/size=100-24         203.8µ ± ∞ ¹   207.9µ ± ∞ ¹        ~ (p=0.486 n=4)   211.2µ ± ∞ ¹        ~ (p=0.343 n=4)     215.3µ ± ∞ ¹        ~ (p=0.343 n=4)
PebbleFindMissing/size=1000-24        212.5µ ± ∞ ¹   223.4µ ± ∞ ¹        ~ (p=0.886 n=4)   226.5µ ± ∞ ¹        ~ (p=0.886 n=4)     223.9µ ± ∞ ¹        ~ (p=0.886 n=4)
PebbleFindMissing/size=10000-24       221.5µ ± ∞ ¹   225.1µ ± ∞ ¹        ~ (p=0.686 n=4)   224.8µ ± ∞ ¹        ~ (p=0.686 n=4)     214.2µ ± ∞ ¹        ~ (p=0.486 n=4)
PebbleFindMissing/size=100000-24      219.6µ ± ∞ ¹   205.9µ ± ∞ ¹        ~ (p=0.486 n=4)   213.7µ ± ∞ ¹        ~ (p=0.486 n=4)     225.3µ ± ∞ ¹        ~ (p=0.686 n=4)
PebbleFindMissing/size=1000000-24     207.6µ ± ∞ ¹   228.0µ ± ∞ ¹        ~ (p=0.057 n=4)   220.5µ ± ∞ ¹        ~ (p=0.114 n=4)     220.8µ ± ∞ ¹        ~ (p=0.200 n=4)
PebbleFindMissing/size=10000000-24    1.512m ± ∞ ¹   1.663m ± ∞ ¹        ~ (p=0.057 n=4)   1.539m ± ∞ ¹        ~ (p=0.686 n=4)     1.546m ± ∞ ¹        ~ (p=0.686 n=4)
PebbleFindMissing/size=50000000-24    6.827m ± ∞ ¹   7.074m ± ∞ ¹        ~ (p=0.343 n=4)   6.700m ± ∞ ¹        ~ (p=0.886 n=4)     6.787m ± ∞ ¹        ~ (p=1.000 n=4)
PebbleFindMissing/size=100000000-24   13.95m ± ∞ ¹   13.36m ± ∞ ¹        ~ (p=0.343 n=4)   13.73m ± ∞ ¹        ~ (p=0.686 n=4)     13.55m ± ∞ ¹        ~ (p=0.686 n=4)
geomean                               455.0µ         451.4µ         -0.81%                 455.9µ         +0.18%                   455.7µ         +0.15%
¹ need >= 6 samples for confidence interval at level 0.95

                                 │      1e9      │                 5e9                  │                  1e10                  │                 5e10                 │
                                 │      B/s      │      B/s       vs base               │      B/s       vs base                 │      B/s       vs base               │
PebbleGet/size=10-24               2.446Mi ± ∞ ¹   2.937Mi ± ∞ ¹  +20.08% (p=0.029 n=4)   2.894Mi ± ∞ ¹  +18.32% (p=0.029 n=4)     2.847Mi ± ∞ ¹  +16.37% (p=0.029 n=4)
PebbleGet/size=100-24              2.413Mi ± ∞ ¹   2.685Mi ± ∞ ¹  +11.26% (p=0.029 n=4)   2.570Mi ± ∞ ¹   +6.52% (p=0.029 n=4)     2.656Mi ± ∞ ¹        ~ (p=0.171 n=4)
PebbleGet/size=1000-24             4.396Mi ± ∞ ¹   5.255Mi ± ∞ ¹        ~ (p=0.057 n=4)   5.417Mi ± ∞ ¹  +23.21% (p=0.029 n=4)     5.341Mi ± ∞ ¹  +21.48% (p=0.029 n=4)
PebbleGet/size=10000-24            10.76Mi ± ∞ ¹   11.26Mi ± ∞ ¹   +4.65% (p=0.029 n=4)   11.54Mi ± ∞ ¹        ~ (p=0.229 n=4+3)   11.32Mi ± ∞ ¹        ~ (p=0.114 n=4)
PebbleGet/size=100000-24           51.77Mi ± ∞ ¹   58.14Mi ± ∞ ¹  +12.31% (p=0.029 n=4)   58.21Mi ± ∞ ¹  +12.45% (p=0.029 n=4)     57.62Mi ± ∞ ¹  +11.30% (p=0.029 n=4)
PebbleGet/size=1000000-24          471.8Mi ± ∞ ¹   486.9Mi ± ∞ ¹        ~ (p=0.886 n=4)   492.3Mi ± ∞ ¹        ~ (p=0.886 n=4)     438.1Mi ± ∞ ¹        ~ (p=0.486 n=4)
PebbleGet/size=10000000-24         382.4Mi ± ∞ ¹   354.3Mi ± ∞ ¹   -7.35% (p=0.029 n=4)   337.5Mi ± ∞ ¹  -11.73% (p=0.029 n=4)     346.4Mi ± ∞ ¹        ~ (p=0.057 n=4)
PebbleGet/size=50000000-24         458.4Mi ± ∞ ¹   440.5Mi ± ∞ ¹        ~ (p=0.286 n=4)   450.1Mi ± ∞ ¹        ~ (p=0.600 n=4)     443.9Mi ± ∞ ¹        ~ (p=0.171 n=4)
PebbleGet/size=100000000-24        462.9Mi ± ∞ ¹   459.4Mi ± ∞ ¹        ~ (p=0.686 n=4)   450.9Mi ± ∞ ¹   -2.59% (p=0.029 n=4)     449.0Mi ± ∞ ¹        ~ (p=0.114 n=4)
PebbleGetMulti/size=10-24          4.239Mi ± ∞ ¹   4.220Mi ± ∞ ¹        ~ (p=0.829 n=4)   4.106Mi ± ∞ ¹        ~ (p=0.429 n=4)     4.201Mi ± ∞ ¹        ~ (p=1.000 n=4)
PebbleGetMulti/size=100-24         3.867Mi ± ∞ ¹   3.610Mi ± ∞ ¹   -6.66% (p=0.029 n=4)   3.757Mi ± ∞ ¹        ~ (p=0.343 n=4)     3.705Mi ± ∞ ¹        ~ (p=0.343 n=4)
PebbleGetMulti/size=1000-24        7.434Mi ± ∞ ¹   7.377Mi ± ∞ ¹        ~ (p=0.686 n=4)   6.886Mi ± ∞ ¹        ~ (p=0.114 n=4)     7.381Mi ± ∞ ¹        ~ (p=0.486 n=4)
PebbleGetMulti/size=10000-24       13.42Mi ± ∞ ¹   13.72Mi ± ∞ ¹        ~ (p=0.343 n=4)   13.88Mi ± ∞ ¹        ~ (p=0.057 n=4)     13.55Mi ± ∞ ¹        ~ (p=0.686 n=4)
PebbleGetMulti/size=100000-24      74.96Mi ± ∞ ¹   77.65Mi ± ∞ ¹        ~ (p=0.343 n=4)   74.22Mi ± ∞ ¹        ~ (p=0.686 n=4)     74.22Mi ± ∞ ¹        ~ (p=0.686 n=4)
PebbleGetMulti/size=1000000-24     957.6Mi ± ∞ ¹   941.3Mi ± ∞ ¹        ~ (p=0.686 n=4)   931.0Mi ± ∞ ¹        ~ (p=0.114 n=4)     939.8Mi ± ∞ ¹        ~ (p=0.486 n=4)
PebbleGetMulti/size=10000000-24    453.0Mi ± ∞ ¹   445.2Mi ± ∞ ¹        ~ (p=0.886 n=4)   443.1Mi ± ∞ ¹        ~ (p=0.686 n=4)     440.4Mi ± ∞ ¹        ~ (p=0.686 n=4)
PebbleGetMulti/size=50000000-24    547.5Mi ± ∞ ¹   548.6Mi ± ∞ ¹        ~ (p=0.886 n=4)   534.2Mi ± ∞ ¹        ~ (p=0.486 n=4)     541.6Mi ± ∞ ¹        ~ (p=0.486 n=4)
PebbleGetMulti/size=100000000-24   561.7Mi ± ∞ ¹   579.2Mi ± ∞ ¹        ~ (p=1.000 n=4)   561.1Mi ± ∞ ¹        ~ (p=0.886 n=4)     531.9Mi ± ∞ ¹        ~ (p=0.200 n=4)
geomean                            52.46Mi         53.97Mi         +2.89%                 53.37Mi         +1.74%                   53.02Mi         +1.08%
¹ need >= 6 samples for confidence interval at level 0.95

                                    │      1e9       │                 5e9                  │                 1e10                  │                 5e10                 │
                                    │      B/op      │      B/op       vs base              │     B/op       vs base                │      B/op       vs base              │
PebbleGet/size=10-24                   4.322Ki ± ∞ ¹    4.313Ki ± ∞ ¹  -0.19% (p=0.029 n=4)   4.314Ki ± ∞ ¹  -0.17% (p=0.029 n=4)      4.314Ki ± ∞ ¹  -0.17% (p=0.029 n=4)
PebbleGet/size=100-24                  4.322Ki ± ∞ ¹    4.314Ki ± ∞ ¹  -0.19% (p=0.029 n=4)   4.314Ki ± ∞ ¹  -0.18% (p=0.029 n=4)      4.314Ki ± ∞ ¹  -0.19% (p=0.029 n=4)
PebbleGet/size=1000-24                 4.347Ki ± ∞ ¹    4.337Ki ± ∞ ¹  -0.22% (p=0.029 n=4)   4.338Ki ± ∞ ¹  -0.20% (p=0.029 n=4)      4.339Ki ± ∞ ¹  -0.19% (p=0.029 n=4)
PebbleGet/size=10000-24                5.662Ki ± ∞ ¹    5.651Ki ± ∞ ¹  -0.19% (p=0.029 n=4)   5.650Ki ± ∞ ¹       ~ (p=0.057 n=4+3)    5.652Ki ± ∞ ¹  -0.17% (p=0.029 n=4)
PebbleGet/size=100000-24               8.325Ki ± ∞ ¹    8.309Ki ± ∞ ¹  -0.20% (p=0.029 n=4)   8.310Ki ± ∞ ¹  -0.19% (p=0.029 n=4)      8.311Ki ± ∞ ¹  -0.18% (p=0.029 n=4)
PebbleGet/size=1000000-24              76.79Ki ± ∞ ¹    77.86Ki ± ∞ ¹       ~ (p=0.686 n=4)   75.15Ki ± ∞ ¹       ~ (p=0.343 n=4)      76.14Ki ± ∞ ¹       ~ (p=0.486 n=4)
PebbleGet/size=10000000-24             1.435Mi ± ∞ ¹    1.433Mi ± ∞ ¹       ~ (p=0.686 n=4)   1.434Mi ± ∞ ¹       ~ (p=0.886 n=4)      1.431Mi ± ∞ ¹       ~ (p=0.200 n=4)
PebbleGet/size=50000000-24             9.601Mi ± ∞ ¹    9.606Mi ± ∞ ¹       ~ (p=1.000 n=4)   9.662Mi ± ∞ ¹       ~ (p=0.114 n=4)      9.589Mi ± ∞ ¹       ~ (p=0.886 n=4)
PebbleGet/size=100000000-24            19.30Mi ± ∞ ¹    19.52Mi ± ∞ ¹       ~ (p=0.114 n=4)   19.38Mi ± ∞ ¹       ~ (p=0.486 n=4)      19.33Mi ± ∞ ¹       ~ (p=0.886 n=4)
PebbleGetMulti/size=10-24              158.8Ki ± ∞ ¹    158.8Ki ± ∞ ¹       ~ (p=0.886 n=4)   158.8Ki ± ∞ ¹       ~ (p=0.686 n=4)      158.8Ki ± ∞ ¹       ~ (p=0.686 n=4)
PebbleGetMulti/size=100-24             158.8Ki ± ∞ ¹    158.8Ki ± ∞ ¹       ~ (p=0.600 n=4)   158.8Ki ± ∞ ¹       ~ (p=0.200 n=4)      158.8Ki ± ∞ ¹       ~ (p=0.200 n=4)
PebbleGetMulti/size=1000-24            161.2Ki ± ∞ ¹    161.2Ki ± ∞ ¹       ~ (p=0.343 n=4)   161.2Ki ± ∞ ¹       ~ (p=0.486 n=4)      161.2Ki ± ∞ ¹       ~ (p=0.057 n=4)
PebbleGetMulti/size=10000-24           233.8Ki ± ∞ ¹    233.8Ki ± ∞ ¹       ~ (p=0.886 n=4)   233.9Ki ± ∞ ¹       ~ (p=0.829 n=4)      233.9Ki ± ∞ ¹       ~ (p=0.114 n=4)
PebbleGetMulti/size=100000-24          282.9Ki ± ∞ ¹    283.0Ki ± ∞ ¹       ~ (p=0.686 n=4)   283.2Ki ± ∞ ¹       ~ (p=0.200 n=4)      283.2Ki ± ∞ ¹       ~ (p=0.057 n=4)
PebbleGetMulti/size=1000000-24         1.077Mi ± ∞ ¹    1.092Mi ± ∞ ¹       ~ (p=0.486 n=4)   1.090Mi ± ∞ ¹       ~ (p=0.486 n=4)      1.083Mi ± ∞ ¹       ~ (p=0.486 n=4)
PebbleGetMulti/size=10000000-24        46.32Mi ± ∞ ¹    46.24Mi ± ∞ ¹       ~ (p=0.686 n=4)   46.31Mi ± ∞ ¹       ~ (p=1.000 n=4)      46.21Mi ± ∞ ¹       ~ (p=0.343 n=4)
PebbleGetMulti/size=50000000-24        267.5Mi ± ∞ ¹    269.1Mi ± ∞ ¹       ~ (p=1.000 n=4)   269.7Mi ± ∞ ¹       ~ (p=0.686 n=4)      269.4Mi ± ∞ ¹       ~ (p=0.886 n=4)
PebbleGetMulti/size=100000000-24       620.9Mi ± ∞ ¹    616.2Mi ± ∞ ¹       ~ (p=0.686 n=4)   625.4Mi ± ∞ ¹       ~ (p=0.343 n=4)      633.2Mi ± ∞ ¹       ~ (p=0.343 n=4)
PebbleFindMissing/size=10-24           133.7Ki ± ∞ ¹    133.8Ki ± ∞ ¹       ~ (p=0.200 n=4)   133.8Ki ± ∞ ¹       ~ (p=0.114 n=4)      133.8Ki ± ∞ ¹       ~ (p=0.200 n=4)
PebbleFindMissing/size=100-24          133.8Ki ± ∞ ¹    133.8Ki ± ∞ ¹       ~ (p=0.486 n=4)   133.8Ki ± ∞ ¹       ~ (p=0.486 n=4)      133.8Ki ± ∞ ¹       ~ (p=0.200 n=4)
PebbleFindMissing/size=1000-24         135.0Ki ± ∞ ¹    135.0Ki ± ∞ ¹       ~ (p=1.000 n=4)   135.0Ki ± ∞ ¹       ~ (p=0.971 n=4)      135.0Ki ± ∞ ¹       ~ (p=0.886 n=4)
PebbleFindMissing/size=10000-24        136.5Ki ± ∞ ¹    136.5Ki ± ∞ ¹       ~ (p=0.343 n=4)   136.5Ki ± ∞ ¹       ~ (p=0.200 n=4)      136.5Ki ± ∞ ¹       ~ (p=0.886 n=4)
PebbleFindMissing/size=100000-24       136.5Ki ± ∞ ¹    136.5Ki ± ∞ ¹       ~ (p=1.000 n=4)   136.5Ki ± ∞ ¹       ~ (p=1.000 n=4)      136.5Ki ± ∞ ¹       ~ (p=0.686 n=4)
PebbleFindMissing/size=1000000-24      136.5Ki ± ∞ ¹    136.6Ki ± ∞ ¹       ~ (p=0.114 n=4)   136.5Ki ± ∞ ¹       ~ (p=0.200 n=4)      136.5Ki ± ∞ ¹       ~ (p=0.200 n=4)
PebbleFindMissing/size=10000000-24     869.1Ki ± ∞ ¹    869.1Ki ± ∞ ¹       ~ (p=0.686 n=4)   869.2Ki ± ∞ ¹       ~ (p=0.486 n=4)      869.1Ki ± ∞ ¹       ~ (p=0.886 n=4)
PebbleFindMissing/size=50000000-24    10.636Mi ± ∞ ¹   10.580Mi ± ∞ ¹       ~ (p=0.886 n=4)   9.994Mi ± ∞ ¹       ~ (p=0.343 n=4)     10.483Mi ± ∞ ¹       ~ (p=1.000 n=4)
PebbleFindMissing/size=100000000-24    21.44Mi ± ∞ ¹    20.95Mi ± ∞ ¹       ~ (p=0.200 n=4)   21.39Mi ± ∞ ¹       ~ (p=1.000 n=4)      20.66Mi ± ∞ ¹       ~ (p=0.486 n=4)
geomean                                441.7Ki          441.7Ki        -0.01%                 440.8Ki        -0.20%                    441.1Ki        -0.14%
¹ need >= 6 samples for confidence interval at level 0.95

                                    │     1e9      │                 5e9                  │                  1e10                  │                 5e10                 │
                                    │  allocs/op   │  allocs/op    vs base                │  allocs/op    vs base                  │  allocs/op    vs base                │
PebbleGet/size=10-24                   85.00 ± ∞ ¹    85.00 ± ∞ ¹       ~ (p=1.000 n=4) ²    85.00 ± ∞ ¹       ~ (p=1.000 n=4)   ²    85.00 ± ∞ ¹       ~ (p=1.000 n=4) ²
PebbleGet/size=100-24                  85.00 ± ∞ ¹    85.00 ± ∞ ¹       ~ (p=1.000 n=4) ²    85.00 ± ∞ ¹       ~ (p=1.000 n=4)   ²    85.00 ± ∞ ¹       ~ (p=1.000 n=4) ²
PebbleGet/size=1000-24                 85.00 ± ∞ ¹    85.00 ± ∞ ¹       ~ (p=1.000 n=4) ²    85.00 ± ∞ ¹       ~ (p=1.000 n=4)   ²    85.00 ± ∞ ¹       ~ (p=1.000 n=4) ²
PebbleGet/size=10000-24                95.00 ± ∞ ¹    95.00 ± ∞ ¹       ~ (p=1.000 n=4) ²    95.00 ± ∞ ¹       ~ (p=1.000 n=4+3) ²    95.00 ± ∞ ¹       ~ (p=1.000 n=4) ²
PebbleGet/size=100000-24               103.0 ± ∞ ¹    103.0 ± ∞ ¹       ~ (p=1.000 n=4) ²    103.0 ± ∞ ¹       ~ (p=1.000 n=4)   ²    103.0 ± ∞ ¹       ~ (p=1.000 n=4) ²
PebbleGet/size=1000000-24              136.0 ± ∞ ¹    136.0 ± ∞ ¹       ~ (p=1.000 n=4)      136.0 ± ∞ ¹       ~ (p=1.000 n=4)        136.0 ± ∞ ¹       ~ (p=1.000 n=4)
PebbleGet/size=10000000-24            1.179k ± ∞ ¹   1.180k ± ∞ ¹       ~ (p=0.114 n=4)     1.181k ± ∞ ¹  +0.17% (p=0.029 n=4)       1.182k ± ∞ ¹  +0.25% (p=0.029 n=4)
PebbleGet/size=50000000-24            36.29k ± ∞ ¹   36.55k ± ∞ ¹       ~ (p=1.000 n=4)     37.45k ± ∞ ¹       ~ (p=0.114 n=4)       36.20k ± ∞ ¹       ~ (p=0.886 n=4)
PebbleGet/size=100000000-24           71.70k ± ∞ ¹   75.38k ± ∞ ¹       ~ (p=0.114 n=4)     73.07k ± ∞ ¹       ~ (p=0.486 n=4)       72.34k ± ∞ ¹       ~ (p=0.886 n=4)
PebbleGetMulti/size=10-24             3.366k ± ∞ ¹   3.366k ± ∞ ¹       ~ (p=1.000 n=4)     3.367k ± ∞ ¹       ~ (p=0.114 n=4)       3.367k ± ∞ ¹       ~ (p=0.114 n=4)
PebbleGetMulti/size=100-24            3.366k ± ∞ ¹   3.366k ± ∞ ¹       ~ (p=0.286 n=4)     3.367k ± ∞ ¹       ~ (p=0.114 n=4)       3.367k ± ∞ ¹       ~ (p=0.114 n=4)
PebbleGetMulti/size=1000-24           3.366k ± ∞ ¹   3.367k ± ∞ ¹       ~ (p=0.143 n=4)     3.368k ± ∞ ¹       ~ (p=0.229 n=4)       3.368k ± ∞ ¹       ~ (p=0.143 n=4)
PebbleGetMulti/size=10000-24          3.870k ± ∞ ¹   3.871k ± ∞ ¹       ~ (p=0.314 n=4)     3.872k ± ∞ ¹       ~ (p=0.114 n=4)       3.873k ± ∞ ¹       ~ (p=0.114 n=4)
PebbleGetMulti/size=100000-24         3.876k ± ∞ ¹   3.878k ± ∞ ¹       ~ (p=0.371 n=4)     3.880k ± ∞ ¹       ~ (p=0.143 n=4)       3.881k ± ∞ ¹       ~ (p=0.143 n=4)
PebbleGetMulti/size=1000000-24        3.892k ± ∞ ¹   3.897k ± ∞ ¹       ~ (p=0.171 n=4)     3.898k ± ∞ ¹       ~ (p=0.114 n=4)       3.896k ± ∞ ¹       ~ (p=0.229 n=4)
PebbleGetMulti/size=10000000-24       57.31k ± ∞ ¹   57.33k ± ∞ ¹       ~ (p=0.486 n=4)     57.37k ± ∞ ¹       ~ (p=0.200 n=4)       57.39k ± ∞ ¹       ~ (p=0.200 n=4)
PebbleGetMulti/size=50000000-24       882.8k ± ∞ ¹   908.7k ± ∞ ¹       ~ (p=0.686 n=4)     920.5k ± ∞ ¹       ~ (p=0.686 n=4)       919.3k ± ∞ ¹       ~ (p=0.686 n=4)
PebbleGetMulti/size=100000000-24      3.162M ± ∞ ¹   3.084M ± ∞ ¹       ~ (p=0.686 n=4)     3.240M ± ∞ ¹       ~ (p=0.200 n=4)       3.365M ± ∞ ¹       ~ (p=0.343 n=4)
PebbleFindMissing/size=10-24          3.013k ± ∞ ¹   3.013k ± ∞ ¹       ~ (p=1.000 n=4)     3.014k ± ∞ ¹       ~ (p=0.143 n=4)       3.014k ± ∞ ¹       ~ (p=0.143 n=4)
PebbleFindMissing/size=100-24         3.013k ± ∞ ¹   3.013k ± ∞ ¹       ~ (p=1.000 n=4)     3.014k ± ∞ ¹       ~ (p=0.143 n=4)       3.014k ± ∞ ¹       ~ (p=0.143 n=4)
PebbleFindMissing/size=1000-24        3.013k ± ∞ ¹   3.014k ± ∞ ¹       ~ (p=0.143 n=4)     3.014k ± ∞ ¹       ~ (p=0.143 n=4)       3.014k ± ∞ ¹       ~ (p=0.229 n=4)
PebbleFindMissing/size=10000-24       3.013k ± ∞ ¹   3.014k ± ∞ ¹       ~ (p=0.486 n=4)     3.014k ± ∞ ¹       ~ (p=0.429 n=4)       3.014k ± ∞ ¹       ~ (p=0.400 n=4)
PebbleFindMissing/size=100000-24      3.013k ± ∞ ¹   3.013k ± ∞ ¹       ~ (p=1.000 n=4)     3.014k ± ∞ ¹       ~ (p=0.143 n=4)       3.014k ± ∞ ¹       ~ (p=0.229 n=4)
PebbleFindMissing/size=1000000-24     3.013k ± ∞ ¹   3.014k ± ∞ ¹       ~ (p=0.143 n=4)     3.014k ± ∞ ¹       ~ (p=0.143 n=4)       3.014k ± ∞ ¹       ~ (p=0.314 n=4)
PebbleFindMissing/size=10000000-24    18.94k ± ∞ ¹   18.95k ± ∞ ¹       ~ (p=0.171 n=4)     18.95k ± ∞ ¹       ~ (p=0.171 n=4)       18.95k ± ∞ ¹       ~ (p=0.229 n=4)
PebbleFindMissing/size=50000000-24    194.8k ± ∞ ¹   194.0k ± ∞ ¹       ~ (p=0.886 n=4)     184.3k ± ∞ ¹       ~ (p=0.343 n=4)       192.1k ± ∞ ¹       ~ (p=1.000 n=4)
PebbleFindMissing/size=100000000-24   389.1k ± ∞ ¹   381.5k ± ∞ ¹       ~ (p=0.343 n=4)     387.8k ± ∞ ¹       ~ (p=1.000 n=4)       376.4k ± ∞ ¹       ~ (p=0.486 n=4)
geomean                               4.634k         4.642k        +0.16%                   4.646k        +0.25%                     4.647k        +0.27%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
```