### PR TITLE
Don't show `Access denied` page if the user isn't a member of any orgs

### DIFF
--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -69,6 +69,7 @@ class Router {
     //    IP rules.
     if (
       this.user &&
+      this.user.groups.length > 0 &&
       this.user.selectedGroupAccess != user_proto.SelectedGroup.Access.ALLOWED &&
       // A user may have access to an invocation w/o having access to group.
       !path.startsWith(Path.invocationPath) &&

--- a/enterprise/app/org/create_org.tsx
+++ b/enterprise/app/org/create_org.tsx
@@ -46,7 +46,13 @@ export default class CreateOrgComponent extends OrgForm<grp.CreateGroupRequest> 
         <div className="container">
           <div className="organization-page-title">Create organization</div>
           {this.props.user && !Boolean(this.props.user.groups?.length) && (
-            <Banner type="info">You are logged in, but not part of any organization. Create one to continue.</Banner>
+            <Banner type="info">
+              You are logged in, but not part of any organization. Create one to continue or{" "}
+              <a className="organization-page-link" href="/logout/">
+                click here to Logout
+              </a>
+              .
+            </Banner>
           )}
           <form autoComplete="off" className="organization-form" onSubmit={this.onSubmit.bind(this)}>
             {this.renderFields()}

--- a/enterprise/app/org/create_org.tsx
+++ b/enterprise/app/org/create_org.tsx
@@ -49,7 +49,7 @@ export default class CreateOrgComponent extends OrgForm<grp.CreateGroupRequest> 
             <Banner type="info">
               You are logged in, but not part of any organization. Create one to continue or{" "}
               <a className="organization-page-link" href="/logout/">
-                click here to Logout
+                click here to log out
               </a>
               .
             </Banner>

--- a/enterprise/app/org/org.css
+++ b/enterprise/app/org/org.css
@@ -10,6 +10,11 @@
   margin-bottom: 32px;
 }
 
+.organization-page-link {
+  font-weight: 600;
+  text-decoration: underline;
+}
+
 .organization-page .banner {
   margin: 16px 0;
 }


### PR DESCRIPTION
With this change, it will show this page instead:

<img width="1402" alt="Screenshot 2023-11-21 at 11 33 35 AM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/b4b02a4d-320d-4965-ab05-e9a210930be7">
