### PR TITLE
Trace viewer tweaks

### DIFF
--- a/app/trace/constants.ts
+++ b/app/trace/constants.ts
@@ -19,7 +19,7 @@ export const MOUSE_GRIDLINE_COLOR = "#B0BEC5";
 
 export const SECTION_LABEL_HEIGHT = 20;
 export const SECTION_LABEL_FONT_SIZE = "13px";
-export const SECTION_LABEL_FONT_COLOR = "black";
+export const SECTION_LABEL_FONT_COLOR = "#222";
 export const SECTION_LABEL_BG_COLOR = "#eee";
 export const SECTION_LABEL_BORDER_COLOR = "#E0E0E0";
 export const SECTION_LABEL_PADDING_BOTTOM = 1;
@@ -28,9 +28,9 @@ export const SECTION_PADDING_BOTTOM = 1;
 export const TRACK_HEIGHT = 16;
 export const TRACK_VERTICAL_GAP = 1;
 
-export const EVENT_HORIZONTAL_GAP = 1;
+export const EVENT_HORIZONTAL_GAP = 0.5;
 export const EVENT_LABEL_WIDTH_THRESHOLD = 20;
-export const EVENT_LABEL_FONT_SIZE = "12px";
+export const EVENT_LABEL_FONT_SIZE = "11px";
 export const EVENT_LABEL_FONT_COLOR = SECTION_LABEL_FONT_COLOR;
 
 export const TIME_SERIES_HEIGHT = 24;

--- a/app/trace/constants.ts
+++ b/app/trace/constants.ts
@@ -19,7 +19,7 @@ export const MOUSE_GRIDLINE_COLOR = "#B0BEC5";
 
 export const SECTION_LABEL_HEIGHT = 20;
 export const SECTION_LABEL_FONT_SIZE = "13px";
-export const SECTION_LABEL_FONT_COLOR = "#222";
+export const SECTION_LABEL_FONT_COLOR = "#212121";
 export const SECTION_LABEL_BG_COLOR = "#eee";
 export const SECTION_LABEL_BORDER_COLOR = "#E0E0E0";
 export const SECTION_LABEL_PADDING_BOTTOM = 1;

--- a/app/trace/trace_viewer.tsx
+++ b/app/trace/trace_viewer.tsx
@@ -188,7 +188,7 @@ export default class TraceViewer extends React.Component<TraceViewProps, {}> {
         data: { event: hoveredEvent, x: mouse.clientX, y: mouse.clientY },
       });
     }
-    document.body.style.cursor = hoveredEvent?.args.target ? "pointer" : "";
+    document.body.style.cursor = hoveredEvent?.args?.target ? "pointer" : "";
   }
 
   private onScroll(e: React.UIEvent<HTMLDivElement>, panelIndex: number) {

--- a/app/trace/trace_viewer_panel.ts
+++ b/app/trace/trace_viewer_panel.ts
@@ -139,8 +139,10 @@ export default class Panel {
     if (!track) return null;
 
     const modelMouse = this.getMouseModelCoordinates();
+
+    const onePx = 1 / this.canvasXPerModelX;
     for (const event of track.events) {
-      if (modelMouse.x >= event.ts && modelMouse.x <= event.ts + event.dur) {
+      if (modelMouse.x >= event.ts && modelMouse.x <= event.ts + Math.max(event.dur, onePx)) {
         return event;
       }
       if (event.ts > modelMouse.x) return null;
@@ -378,6 +380,7 @@ export default class Panel {
 
   private drawTrack(track: TrackModel, y: number, xMin: number, xMax: number) {
     let i = 0;
+    let lastEventRendered = false;
     for (; i < track.xs.length; i++) {
       let modelX = track.xs[i];
       if (modelX > xMax) break;
@@ -389,13 +392,22 @@ export default class Panel {
 
       this.ctx.fillStyle = color;
       // TODO: only apply the horizontal gap if there's an event just after us.
-      const width = modelWidth * this.canvasXPerModelX - constants.EVENT_HORIZONTAL_GAP;
-      if (width <= 0) continue;
+      let width = modelWidth * this.canvasXPerModelX - constants.EVENT_HORIZONTAL_GAP;
+      if (width <= 0) {
+        // If the event is less than 1px side, and less than 1px away from the previous
+        // event start that rendered, don't render it.
+        if (lastEventRendered && Math.abs(modelX - track.xs[i - 1]) * this.canvasXPerModelX <= 1) {
+          lastEventRendered = false;
+          continue;
+        }
+        width = 1;
+      }
       const x = modelX * this.canvasXPerModelX - this.scrollX;
       this.ctx.fillRect(x, y, width, constants.TRACK_HEIGHT);
+      lastEventRendered = true;
 
       const visibleWidth = width + Math.min(0, x);
-      if (visibleWidth > constants.EVENT_LABEL_WIDTH_THRESHOLD) {
+      if (visibleWidth >= constants.EVENT_LABEL_WIDTH_THRESHOLD) {
         let name = track.events[i].name;
         this.ctx.font = `${constants.EVENT_LABEL_FONT_SIZE} ${this.fontFamily}`;
         this.ctx.fillStyle = constants.EVENT_LABEL_FONT_COLOR;

--- a/app/trace/trace_viewer_panel.ts
+++ b/app/trace/trace_viewer_panel.ts
@@ -407,7 +407,7 @@ export default class Panel {
       lastEventRendered = true;
 
       const visibleWidth = width + Math.min(0, x);
-      if (visibleWidth >= constants.EVENT_LABEL_WIDTH_THRESHOLD) {
+      if (visibleWidth > constants.EVENT_LABEL_WIDTH_THRESHOLD) {
         let name = track.events[i].name;
         this.ctx.font = `${constants.EVENT_LABEL_FONT_SIZE} ${this.fontFamily}`;
         this.ctx.fillStyle = constants.EVENT_LABEL_FONT_COLOR;


### PR DESCRIPTION
- Use a slightly off black for text to make it a little less harsh
- Reduce horizontal whitespace between to half a pixel to reduce empty whitespace a bit
- Slightly reduce font size of labels by 1px
- Fix hovering of events without args (which I borked a bit in my previous PR)
- Make events less than 1px wide render as 1px wide if they don't have a rendered event starting less than 1px before it
- Bump hover target for events less than 1px wide up to 1px 

If you hate any of these changes, let me know and I'll revert them (this is your baby and I defer to you). If we end up not liking some of these changes in dev / or prod, we can always roll them back.

Before dense:
<img width="1616" alt="Screenshot 2023-11-21 at 1 18 27 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/4c446a77-6589-4b6f-a325-cc1194cef1e9">


After dense:
<img width="1616" alt="Screenshot 2023-11-21 at 1 17 28 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/28509f3e-89b4-4688-8a3c-61e4b39becb3">


Before remote threads:
<img width="1616" alt="Screenshot 2023-11-21 at 1 18 33 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/53a8e2db-5c31-4563-94df-e89d7f7c8dac">


After remote threads:
<img width="1616" alt="Screenshot 2023-11-21 at 1 17 39 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/67be9b4b-6d63-4d80-94ed-913458883b94">

