### PR TITLE
Keep runners' local resource claims held while pausing

### DIFF
--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -213,7 +213,10 @@ func (s *Executor) ExecuteTaskAndStreamResults(ctx context.Context, st *repb.Sch
 	actionMetrics.Isolation = r.GetIsolationType()
 	finishedCleanly := false
 	defer func() {
-		go s.runnerPool.TryRecycle(ctx, r, finishedCleanly)
+		// Note: recycling is done in the foreground here in order to ensure
+		// that the runner is fully cleaned up (if applicable) before its
+		// resource claims are freed up by the priority_task_scheduler.
+		s.runnerPool.TryRecycle(ctx, r, finishedCleanly)
 	}()
 
 	log.CtxInfof(ctx, "Preparing runner for task.")


### PR DESCRIPTION
We are seeing a bunch of firecracker processes taking up lots of memory while they are pausing. This resource usage is untracked by the priority_task_scheduler, which is likely contributing to overscheduling and executor restarts. So we should make sure to keep the resource claims held until the pause is complete.

One small consideration here: because priority_task_scheduler is currently responsible for keeping the lease, this means we're unnecessarily keeping the lease held while we're pausing. This increases the chances slightly of retrying the task unnecessarily. This would be mostly solved by our recent discussions around having LeaseTask + PublishOperation be the same stream, so that a task can't be re-leased if we've already published the COMPLETED operation on the stream. We could also solve this by restructuring the code so that we finalize the lease before trying to pause.

**Related issues**: N/A
