### PR TITLE
event parsing: only use 'canonical' StructuredCommandLine event

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -214,6 +214,9 @@ export default class InvocationModel {
       this.toolLogMap.set(log.name, new TextDecoder().decode(log.contents || new Uint8Array()));
     }
     for (let commandLine of this.structuredCommandLine) {
+      if (commandLine.commandLineLabel != "canonical") {
+        continue;
+      }
       for (let section of commandLine.sections || []) {
         for (let option of section.optionList?.option || []) {
           this.optionsMap.set(option.optionName, option.optionValue);

--- a/server/build_event_protocol/event_parser/BUILD
+++ b/server/build_event_protocol/event_parser/BUILD
@@ -25,6 +25,7 @@ go_test(
         "//proto:command_line_go_proto",
         "//proto:invocation_go_proto",
         "//proto:invocation_status_go_proto",
+        "//proto:option_filters_go_proto",
         "@com_github_stretchr_testify//assert",
         "@org_golang_google_protobuf//types/known/timestamppb",
     ],

--- a/server/build_event_protocol/event_parser/event_parser.go
+++ b/server/build_event_protocol/event_parser/event_parser.go
@@ -15,6 +15,12 @@ import (
 )
 
 const (
+	StructuredCommandLineLabelCanonical string = "canonical"
+	StructuredCommandLineLabelOriginal  string = "original"
+	StructuredCommandLineLabelTool      string = "tool"
+)
+
+const (
 	envVarOptionName = "client_env"
 	envVarSeparator  = "="
 )
@@ -230,6 +236,10 @@ func (sep *StreamingEventParser) ParseEvent(event *build_event_stream.BuildEvent
 }
 
 func (sep *StreamingEventParser) fillInvocationFromStructuredCommandLine(commandLine *command_line.CommandLine) {
+	if commandLine.CommandLineLabel != StructuredCommandLineLabelCanonical {
+		return
+	}
+
 	priority := envPriority
 	commandLineOptions := parseCommandLine(commandLine)
 	envVarMap := commandLineOptions.envVarMap


### PR DESCRIPTION

Bazel sends multiple command line events to the BES server:
- `original`
- `canonical`

Where the `canonical` event is the effective one while the `original`
event is algamation of command line flags and `.bazelrc` configs.
Additionally, users may specify `--experimental_tool_command_line` to
send the command line from layers of Bazel wrappers.

Let's filter for `canonical` command line event to parse since it's the
most accurate one. The other 2 events are still available via raw bep
JSON and could be inspected accordingly from our UI (if they are not
empty).

References:
- https://cs.opensource.google/bazel/bazel/+/master:src/main/java/com/google/devtools/build/lib/runtime/CommandLineEvent.java;drc=dab6383ecef2d3996a67b2b1e4760369abc08de7
