### PR TITLE
Fix retry test flakiness.

### DIFF
--- a/server/util/retry/BUILD
+++ b/server/util/retry/BUILD
@@ -17,6 +17,7 @@ go_test(
     srcs = ["retry_test.go"],
     deps = [
         ":retry",
+        "//server/util/status",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/server/util/retry/retry_test.go
+++ b/server/util/retry/retry_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/retry"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -156,11 +157,13 @@ func TestRetryWithFixedDelay(t *testing.T) {
 }
 
 func TestRetryDoWithExpiredContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	// Immediately cancel the context.
-	cancel()
-	_, err := retry.Do(ctx, retry.DefaultOptions(), func(ctx context.Context) (int, error) {
-		return 1, nil
-	})
-	require.Error(t, err)
+	for i := 0; i < 100; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		// Immediately cancel the context.
+		cancel()
+		_, err := retry.Do(ctx, retry.DefaultOptions(), func(ctx context.Context) (int, error) {
+			return 0, status.InternalError("oh oh")
+		})
+		require.Error(t, err)
+	}
 }


### PR DESCRIPTION
Whether the timer or context done channel is selected is non-deterministic so it's not guaranteed that the function is not run.

Have the test function return an error and verify that an error is always returned, regardless of whether the function is run or not.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
