### PR TITLE
Don't allow funky agg types

### DIFF
--- a/enterprise/server/invocation_stat_service/invocation_stat_service.go
+++ b/enterprise/server/invocation_stat_service/invocation_stat_service.go
@@ -57,28 +57,27 @@ func NewInvocationStatService(env environment.Env, dbh interfaces.DBHandle, olap
 	}
 }
 
-func (i *InvocationStatService) getAggColumn(reqCtx *ctxpb.RequestContext, aggType inpb.AggType) string {
+func (i *InvocationStatService) getAggColumn(reqCtx *ctxpb.RequestContext, aggType inpb.AggType) (string, error) {
 	switch aggType {
 	case inpb.AggType_USER_AGGREGATION_TYPE:
-		return "user"
+		return "user", nil
 	case inpb.AggType_HOSTNAME_AGGREGATION_TYPE:
-		return "host"
+		return "host", nil
 	case inpb.AggType_GROUP_ID_AGGREGATION_TYPE:
-		return "group_id"
+		return "group_id", nil
 	case inpb.AggType_REPO_URL_AGGREGATION_TYPE:
-		return "repo_url"
+		return "repo_url", nil
 	case inpb.AggType_COMMIT_SHA_AGGREGATION_TYPE:
-		return "commit_sha"
+		return "commit_sha", nil
 	case inpb.AggType_DATE_AGGREGATION_TYPE:
 		// TODO(jdhollen): Nobody is using this and we should probably just remove it.
-		return i.dbh.DateFromUsecTimestamp("updated_at_usec", reqCtx.GetTimezoneOffsetMinutes())
+		return i.dbh.DateFromUsecTimestamp("updated_at_usec", reqCtx.GetTimezoneOffsetMinutes()), nil
 	case inpb.AggType_BRANCH_AGGREGATION_TYPE:
-		return "branch_name"
+		return "branch_name", nil
 	case inpb.AggType_PATTERN_AGGREGATION_TYPE:
-		return "pattern"
+		return "pattern", nil
 	default:
-		log.Errorf("Unknown or unsupported aggregation column type: %s", aggType)
-		return ""
+		return "", status.InvalidArgumentErrorf("Unknown or unsupported aggregation column type: %s", aggType)
 	}
 }
 
@@ -1016,7 +1015,10 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 		limit = l
 	}
 
-	aggColumn := i.getAggColumn(req.GetRequestContext(), req.AggregationType)
+	aggColumn, err := i.getAggColumn(req.GetRequestContext(), req.AggregationType)
+	if err != nil {
+		return nil, err
+	}
 	q := query_builder.NewQuery(i.GetInvocationStatBaseQuery(aggColumn))
 
 	if req.AggregationType != inpb.AggType_DATE_AGGREGATION_TYPE {
@@ -1097,7 +1099,6 @@ func (i *InvocationStatService) GetInvocationStat(ctx context.Context, req *inpb
 
 	qStr, qArgs := q.Build()
 	var rows *sql.Rows
-	var err error
 	if i.isOLAPDBEnabled() {
 		rows, err = i.olapdbh.RawWithOptions(ctx, clickhouse.Opts().WithQueryName("query_invocation_stats"), qStr, qArgs...).Rows()
 	} else {


### PR DESCRIPTION
Flagged during a pentest, we were swallowing these errors and breaking the sql query. Instead, just return an error.