### PR TITLE
use Copy instead of ReadAll in pebble_cache.Get()

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1639,7 +1639,9 @@ func (p *PebbleCache) Get(ctx context.Context, r *rspb.ResourceName) ([]byte, er
 		return nil, err
 	}
 	defer rc.Close()
-	return io.ReadAll(rc)
+	var buffer bytes.Buffer
+	_, err = io.Copy(&buffer, rc)
+	return buffer.Bytes(), err
 }
 
 func (p *PebbleCache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {


### PR DESCRIPTION
io.Copy() perform better than io.ReadAll when reading big inputs:

Here is the benchmark for PebbleCache.Get (cdc disabled)
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor            
                             │ /home/lulu/baseline_readall_nocdc.log │ /home/lulu/benchmark_copy_nocdc.log │
                             │                sec/op                 │    sec/op     vs base               │
Get/Pebble/size=10-24                                    8.290µ ± 5%   9.132µ ±  3%  +10.16% (p=0.002 n=6)
Get/Pebble/size=100-24                                   8.753µ ± 4%   9.545µ ±  5%   +9.05% (p=0.004 n=6)
Get/Pebble/size=1000-24                                  8.889µ ± 4%   9.777µ ±  6%  +10.00% (p=0.002 n=6)
Get/Pebble/size=10000-24                                 16.22µ ± 4%   17.14µ ±  8%   +5.68% (p=0.026 n=6)
Get/Pebble/size=100000-24                                19.23µ ± 2%   19.85µ ±  3%   +3.25% (p=0.009 n=6)
Get/Pebble/size=1000000-24                               31.98µ ± 2%   25.31µ ±  4%  -20.88% (p=0.002 n=6)
Get/Pebble/size=10000000-24                             123.77µ ± 8%   79.70µ ±  7%  -35.61% (p=0.002 n=6)
Get/Pebble/size=50000000-24                              531.5µ ± 6%   261.4µ ± 11%  -50.82% (p=0.002 n=6)
Get/Pebble/size=100000000-24                             902.8µ ± 3%   472.8µ ±  2%  -47.63% (p=0.002 n=6)
geomean                                                  41.71µ        34.67µ        -16.89%

                             │ /home/lulu/baseline_readall_nocdc.log │  /home/lulu/benchmark_copy_nocdc.log  │
                             │                  B/s                  │      B/s       vs base                │
Get/Pebble/size=10-24                                  2.646Mi ±  5%   2.403Mi ±  3%    -9.19% (p=0.002 n=6)
Get/Pebble/size=100-24                                 2.289Mi ±  5%   2.098Mi ±  5%    -8.33% (p=0.004 n=6)
Get/Pebble/size=1000-24                                4.358Mi ±  7%   4.172Mi ± 17%         ~ (p=0.180 n=6)
Get/Pebble/size=10000-24                               10.83Mi ±  6%   10.05Mi ± 10%    -7.22% (p=0.011 n=6)
Get/Pebble/size=100000-24                              51.49Mi ±  3%   49.98Mi ±  3%    -2.94% (p=0.009 n=6)
Get/Pebble/size=1000000-24                             521.1Mi ± 11%   573.6Mi ± 33%         ~ (p=0.093 n=6)
Get/Pebble/size=10000000-24                            1.359Gi ± 11%   2.077Gi ± 13%   +52.77% (p=0.002 n=6)
Get/Pebble/size=50000000-24                            1.766Gi ±  4%   3.558Gi ±  8%  +101.47% (p=0.002 n=6)
Get/Pebble/size=100000000-24                           2.132Gi ±  2%   4.057Gi ±  2%   +90.29% (p=0.002 n=6)
geomean                                                70.34Mi         83.39Mi         +18.55%

                             │ /home/lulu/baseline_readall_nocdc.log │ /home/lulu/benchmark_copy_nocdc.log  │
                             │                 B/op                  │     B/op       vs base               │
Get/Pebble/size=10-24                                   4.399Ki ± 1%   5.449Ki ±  1%  +23.88% (p=0.002 n=6)
Get/Pebble/size=100-24                                  4.462Ki ± 1%   5.511Ki ±  1%  +23.49% (p=0.002 n=6)
Get/Pebble/size=1000-24                                 4.519Ki ± 0%   5.568Ki ±  0%  +23.22% (p=0.002 n=6)
Get/Pebble/size=10000-24                                5.926Ki ± 0%   6.976Ki ±  0%  +17.71% (p=0.002 n=6)
Get/Pebble/size=100000-24                               8.743Ki ± 1%   9.535Ki ±  1%   +9.06% (p=0.002 n=6)
Get/Pebble/size=1000000-24                              77.92Ki ± 4%   54.66Ki ±  5%  -29.85% (p=0.002 n=6)
Get/Pebble/size=10000000-24                             877.2Ki ± 9%   519.4Ki ± 12%  -40.79% (p=0.002 n=6)
Get/Pebble/size=50000000-24                             5.314Mi ± 1%   2.181Mi ±  3%  -58.96% (p=0.002 n=6)
Get/Pebble/size=100000000-24                           10.600Mi ± 0%   4.529Mi ±  5%  -57.28% (p=0.002 n=6)
geomean                                                 64.21Ki        52.95Ki        -17.54%

                             │ /home/lulu/baseline_readall_nocdc.log │ /home/lulu/benchmark_copy_nocdc.log  │
                             │               allocs/op               │   allocs/op    vs base               │
Get/Pebble/size=10-24                                   86.00 ±   0%    88.00 ±   0%   +2.33% (p=0.002 n=6)
Get/Pebble/size=100-24                                  86.00 ±   0%    88.00 ±   0%   +2.33% (p=0.002 n=6)
Get/Pebble/size=1000-24                                 86.00 ±   0%    88.00 ±   0%   +2.33% (p=0.002 n=6)
Get/Pebble/size=10000-24                                98.00 ±   0%   100.00 ±   0%   +2.04% (p=0.002 n=6)
Get/Pebble/size=100000-24                               108.0 ±   0%    108.0 ±   1%        ~ (p=0.455 n=6)
Get/Pebble/size=1000000-24                              150.0 ±   1%    125.5 ±   0%  -16.33% (p=0.002 n=6)
Get/Pebble/size=10000000-24                             192.0 ± 761%    144.0 ± 705%        ~ (p=0.084 n=6)
Get/Pebble/size=50000000-24                            5.271k ±  11%   3.025k ±  12%  -42.62% (p=0.002 n=6)
Get/Pebble/size=100000000-24                           8.328k ±   5%   5.240k ±  19%  -37.07% (p=0.002 n=6)
geomean                                                 273.3           234.1         -14.36%

```

Same when cdc is enabled:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor            
                             │ /home/lulu/baseline_readall.log │    /home/lulu/benchmark_copy.log    │
                             │             sec/op              │    sec/op     vs base               │
Get/Pebble/size=10-24                              8.356µ ± 7%   9.137µ ±  8%   +9.35% (p=0.026 n=6)
Get/Pebble/size=100-24                             8.652µ ± 3%   9.441µ ±  5%   +9.11% (p=0.002 n=6)
Get/Pebble/size=1000-24                            9.187µ ± 6%   9.776µ ±  5%   +6.41% (p=0.015 n=6)
Get/Pebble/size=10000-24                           16.28µ ± 2%   17.33µ ±  2%   +6.48% (p=0.002 n=6)
Get/Pebble/size=100000-24                          19.14µ ± 4%   19.56µ ±  4%        ~ (p=0.563 n=6)
Get/Pebble/size=1000000-24                         32.46µ ± 4%   24.55µ ±  4%  -24.37% (p=0.002 n=6)
Get/Pebble/size=10000000-24                        478.4µ ± 2%   317.6µ ±  7%  -33.61% (p=0.002 n=6)
Get/Pebble/size=50000000-24                        2.265m ± 3%   1.544m ± 10%  -31.86% (p=0.002 n=6)
Get/Pebble/size=100000000-24                       4.693m ± 1%   3.376m ±  8%  -28.06% (p=0.002 n=6)
geomean                                            68.72µ        60.96µ        -11.30%

                             │ /home/lulu/baseline_readall.log │    /home/lulu/benchmark_copy.log     │
                             │               B/s               │      B/s       vs base               │
Get/Pebble/size=10-24                            2.623Mi ±  7%   2.403Mi ±  9%   -8.36% (p=0.024 n=6)
Get/Pebble/size=100-24                           2.313Mi ±  3%   2.122Mi ±  5%   -8.25% (p=0.002 n=6)
Get/Pebble/size=1000-24                          4.334Mi ± 15%   4.096Mi ± 13%   -5.50% (p=0.026 n=6)
Get/Pebble/size=10000-24                         10.77Mi ±  3%   10.04Mi ±  3%   -6.78% (p=0.002 n=6)
Get/Pebble/size=100000-24                        51.84Mi ±  5%   50.41Mi ±  5%        ~ (p=0.485 n=6)
Get/Pebble/size=1000000-24                       439.5Mi ± 25%   663.4Mi ± 11%  +50.95% (p=0.002 n=6)
Get/Pebble/size=10000000-24                      352.6Mi ±  5%   537.8Mi ±  9%  +52.55% (p=0.002 n=6)
Get/Pebble/size=50000000-24                      433.0Mi ±  7%   621.6Mi ±  7%  +43.57% (p=0.002 n=6)
Get/Pebble/size=100000000-24                     418.8Mi ±  3%   581.8Mi ±  8%  +38.93% (p=0.002 n=6)
geomean                                          42.06Mi         48.04Mi        +14.22%

                             │ /home/lulu/baseline_readall.log │    /home/lulu/benchmark_copy.log    │
                             │              B/op               │     B/op      vs base               │
Get/Pebble/size=10-24                             4.400Ki ± 1%   5.450Ki ± 1%  +23.85% (p=0.002 n=6)
Get/Pebble/size=100-24                            4.463Ki ± 1%   5.512Ki ± 1%  +23.50% (p=0.002 n=6)
Get/Pebble/size=1000-24                           4.519Ki ± 0%   5.567Ki ± 0%  +23.20% (p=0.002 n=6)
Get/Pebble/size=10000-24                          5.929Ki ± 0%   6.977Ki ± 0%  +17.67% (p=0.002 n=6)
Get/Pebble/size=100000-24                         8.746Ki ± 1%   9.529Ki ± 1%   +8.96% (p=0.002 n=6)
Get/Pebble/size=1000000-24                        76.73Ki ± 4%   56.27Ki ± 8%  -26.66% (p=0.002 n=6)
Get/Pebble/size=10000000-24                       1.434Mi ± 2%   1.051Mi ± 1%  -26.70% (p=0.002 n=6)
Get/Pebble/size=50000000-24                       9.654Mi ± 1%   6.154Mi ± 2%  -36.25% (p=0.002 n=6)
Get/Pebble/size=100000000-24                      19.49Mi ± 1%   12.56Mi ± 2%  -35.57% (p=0.002 n=6)
geomean                                           77.62Ki        72.39Ki        -6.74%

                             │ /home/lulu/baseline_readall.log │    /home/lulu/benchmark_copy.log     │
                             │            allocs/op            │  allocs/op   vs base                 │
Get/Pebble/size=10-24                               86.00 ± 0%    88.00 ± 0%   +2.33% (p=0.002 n=6)
Get/Pebble/size=100-24                              86.00 ± 0%    88.00 ± 0%   +2.33% (p=0.002 n=6)
Get/Pebble/size=1000-24                             86.00 ± 0%    88.00 ± 0%   +2.33% (p=0.002 n=6)
Get/Pebble/size=10000-24                            98.00 ± 0%   100.00 ± 0%   +2.04% (p=0.002 n=6)
Get/Pebble/size=100000-24                           108.0 ± 0%    108.0 ± 0%        ~ (p=1.000 n=6) ¹
Get/Pebble/size=1000000-24                          149.5 ± 0%    126.0 ± 1%  -15.72% (p=0.002 n=6)
Get/Pebble/size=10000000-24                        1.263k ± 0%   1.103k ± 0%  -12.71% (p=0.002 n=6)
Get/Pebble/size=50000000-24                        37.30k ± 4%   26.26k ± 8%  -29.61% (p=0.002 n=6)
Get/Pebble/size=100000000-24                       74.95k ± 5%   55.47k ± 7%  -26.00% (p=0.002 n=6)
geomean                                             534.4         485.2        -9.21%
¹ all samples are equal
```