### PR TITLE
CDC Optimization: Don't use Get in newChunkedReader

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -3146,12 +3146,9 @@ func (p *PebbleCache) newChunkedReader(ctx context.Context, chunkedMD *rfpb.Stor
 			rc, err := p.Reader(ctx, rn, 0, 0)
 			if err != nil {
 				pw.CloseWithError(err)
-			}
-			defer rc.Close()
-			if err != nil {
-				pw.CloseWithError(err)
 				return
 			}
+			defer rc.Close()
 			if _, err = io.Copy(pw, rc); err != nil {
 				pw.CloseWithError(err)
 				return

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -3143,12 +3143,16 @@ func (p *PebbleCache) newChunkedReader(ctx context.Context, chunkedMD *rfpb.Stor
 			if shouldDecompress && rn.GetCompressor() == repb.Compressor_ZSTD {
 				rn.Compressor = repb.Compressor_IDENTITY
 			}
-			buf, err := p.Get(ctx, rn)
+			rc, err := p.Reader(ctx, rn, 0, 0)
+			if err != nil {
+				pw.CloseWithError(err)
+			}
+			defer rc.Close()
 			if err != nil {
 				pw.CloseWithError(err)
 				return
 			}
-			if _, err := pw.Write(buf); err != nil {
+			if _, err = io.Copy(pw, rc); err != nil {
 				pw.CloseWithError(err)
 				return
 			}


### PR DESCRIPTION
Optimize newChunkedReader to directly copy data to piped writer instead of using
a temporary bytes.Buffer in (Get()).

Below is the benchmark result. Note CDC was enabled when the size is 0.5MB. 
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor            
                             │ /home/lulu/baseline-cdc-get.log │  /home/lulu/benchmark-cdc-get.log  │
                             │             sec/op              │   sec/op     vs base               │
Get/Pebble/size=10-24                             9.088µ ±  8%   9.072µ ± 7%        ~ (p=0.699 n=6)
Get/Pebble/size=100-24                            9.603µ ±  6%   9.567µ ± 2%        ~ (p=0.485 n=6)
Get/Pebble/size=1000-24                           9.840µ ±  5%   9.914µ ± 2%        ~ (p=0.420 n=6)
Get/Pebble/size=10000-24                          17.06µ ±  6%   17.06µ ± 3%        ~ (p=0.937 n=6)
Get/Pebble/size=100000-24                         19.22µ ±  5%   19.78µ ± 3%   +2.91% (p=0.026 n=6)
Get/Pebble/size=1000000-24                        24.55µ ±  4%   24.61µ ± 3%        ~ (p=0.818 n=6)
Get/Pebble/size=10000000-24                       346.1µ ±  8%   264.2µ ± 9%  -23.68% (p=0.002 n=6)
Get/Pebble/size=50000000-24                       1.555m ± 12%   1.312m ± 8%  -15.61% (p=0.002 n=6)
Get/Pebble/size=100000000-24                      3.289m ±  6%   2.609m ± 6%  -20.67% (p=0.002 n=6)
geomean                                           61.30µ         57.11µ        -6.84%

                             │ /home/lulu/baseline-cdc-get.log │   /home/lulu/benchmark-cdc-get.log   │
                             │               B/s               │      B/s       vs base               │
Get/Pebble/size=10-24                            2.418Mi ±  7%   2.418Mi ±  7%        ~ (p=0.621 n=6)
Get/Pebble/size=100-24                           2.084Mi ±  5%   2.093Mi ±  3%        ~ (p=0.394 n=6)
Get/Pebble/size=1000-24                          4.072Mi ±  8%   4.039Mi ± 14%        ~ (p=0.677 n=6)
Get/Pebble/size=10000-24                         10.18Mi ±  6%   10.03Mi ±  8%        ~ (p=0.240 n=6)
Get/Pebble/size=100000-24                        52.17Mi ±  6%   50.08Mi ±  3%   -4.00% (p=0.041 n=6)
Get/Pebble/size=1000000-24                       589.5Mi ±  9%   598.7Mi ± 29%        ~ (p=0.937 n=6)
Get/Pebble/size=10000000-24                      489.7Mi ± 12%   655.0Mi ± 18%  +33.74% (p=0.002 n=6)
Get/Pebble/size=50000000-24                      623.9Mi ± 11%   737.3Mi ±  6%  +18.17% (p=0.002 n=6)
Get/Pebble/size=100000000-24                     595.9Mi ±  8%   750.3Mi ±  6%  +25.91% (p=0.002 n=6)
geomean                                          47.23Mi         50.73Mi         +7.42%

                             │ /home/lulu/baseline-cdc-get.log │   /home/lulu/benchmark-cdc-get.log   │
                             │              B/op               │     B/op       vs base               │
Get/Pebble/size=10-24                            5.448Ki ±  1%   5.448Ki ±  1%        ~ (p=0.786 n=6)
Get/Pebble/size=100-24                           5.512Ki ±  1%   5.510Ki ±  1%        ~ (p=0.470 n=6)
Get/Pebble/size=1000-24                          5.567Ki ±  0%   5.567Ki ±  0%        ~ (p=0.974 n=6)
Get/Pebble/size=10000-24                         6.977Ki ±  0%   6.978Ki ±  0%        ~ (p=1.000 n=6)
Get/Pebble/size=100000-24                        9.537Ki ±  1%   9.542Ki ±  0%        ~ (p=0.121 n=6)
Get/Pebble/size=1000000-24                       54.41Ki ±  8%   55.03Ki ±  9%        ~ (p=0.485 n=6)
Get/Pebble/size=10000000-24                     1094.0Ki ± 25%   721.4Ki ± 28%  -34.06% (p=0.002 n=6)
Get/Pebble/size=50000000-24                      6.150Mi ±  2%   4.062Mi ±  2%  -33.95% (p=0.002 n=6)
Get/Pebble/size=100000000-24                    12.448Mi ±  3%   8.186Mi ±  2%  -34.24% (p=0.002 n=6)
geomean                                          72.18Ki         62.90Ki        -12.86%

                             │ /home/lulu/baseline-cdc-get.log │    /home/lulu/benchmark-cdc-get.log    │
                             │            allocs/op            │   allocs/op    vs base                 │
Get/Pebble/size=10-24                             88.00 ±   0%    88.00 ±   0%        ~ (p=1.000 n=6) ¹
Get/Pebble/size=100-24                            88.00 ±   0%    88.00 ±   0%        ~ (p=1.000 n=6) ¹
Get/Pebble/size=1000-24                           88.00 ±   0%    88.00 ±   0%        ~ (p=1.000 n=6) ¹
Get/Pebble/size=10000-24                          100.0 ±   0%    100.0 ±   0%        ~ (p=1.000 n=6) ¹
Get/Pebble/size=100000-24                         108.0 ±   1%    108.5 ±   0%        ~ (p=1.000 n=6)
Get/Pebble/size=1000000-24                        126.0 ±   1%    126.0 ±   1%        ~ (p=1.000 n=6)
Get/Pebble/size=10000000-24                      1104.0 ± 428%    950.0 ± 344%  -13.95% (p=0.024 n=6)
Get/Pebble/size=50000000-24                      26.08k ±   9%   22.12k ±   7%  -15.17% (p=0.002 n=6)
Get/Pebble/size=100000000-24                     54.27k ±  12%   44.79k ±   7%  -17.46% (p=0.002 n=6)
geomean                                           483.7           457.4          -5.43%
¹ all samples are equal

```