### PR TITLE
Upgrade podman to 4.7.2

### DIFF
--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y umoci iproute2 amazon-ecr-credential-he
 # Install podman and skopeo
 RUN echo 'deb https://downloadcontent.opensuse.org/repositories/home:/alvistack/Debian_11/ /' >> /etc/apt/sources.list.d/home:alvistack.list && \
     curl -fsSL https://download.opensuse.org/repositories/home:/alvistack/Debian_11/Release.key | gpg --dearmor >> /etc/apt/trusted.gpg.d/home_alvistack_debian11.gpg && \
-    apt-get update && apt-get -y upgrade && apt-get install -y podman=100:4.6.2-1 skopeo=100:1.13.3-1 && \
+    apt-get update && apt-get -y upgrade && apt-get install -y podman=100:4.7.2-1 skopeo=100:1.13.3-1 && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy podman registries configuration.


### PR DESCRIPTION
4.6.2 was removed from the repo we're using.

Tested in dev. Sanity-checked perf, running `podman run --rm --net=none --transient-store ubuntu:22.04 true` still takes around 170ms.

**Related issues**: N/A
