### PR TITLE
Update mmap to support memory limit changes

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -977,10 +977,6 @@ func (m *Mmap) Unmap() error {
 	metrics.COWSnapshotMemoryMappedBytes.Set(float64(
 		atomic.AddInt64(&mmappedBytes, int64(-n)),
 	))
-	// TODO: this causes issues because when we unmap then remap due to LRU
-	// eviction, we lose the remote/filecache source information, since Fetch()
-	// won't be called again. Is it safe to just delete this line?
-	// m.source = snaputil.ChunkSourceUnmapped
 	return nil
 }
 

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
@@ -72,7 +72,7 @@ func TestMmap_Concurrency(t *testing.T) {
 	s, _ := newMmap(t)
 
 	eg := &errgroup.Group{}
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 100; i++ {
 		eg.Go(func() error {
 			buf := make([]byte, 100)
 			_, err := rand.Read(buf)
@@ -97,6 +97,14 @@ func TestMmap_Concurrency(t *testing.T) {
 		eg.Go(func() error {
 			_, err := s.StartAddress()
 			return err
+		})
+		eg.Go(func() error {
+			return s.Fetch()
+		})
+		eg.Go(func() error {
+			// Should be safe to call Unmap at any time. ReadAt / WriteAt should
+			// re-map if needed.
+			return s.Unmap()
 		})
 	}
 	err := eg.Wait()
@@ -519,7 +527,8 @@ func newMmap(t *testing.T) (*copy_on_write.Mmap, string) {
 	env := testenv.GetTestEnv(t)
 
 	root := testfs.MakeTempDir(t)
-	path := filepath.Join(root, "f")
+	const offset = 0
+	path := filepath.Join(root, fmt.Sprintf("%d", offset))
 	err := os.WriteFile(path, make([]byte, backingFileSizeBytes), 0644)
 	require.NoError(t, err, "write empty file")
 
@@ -529,7 +538,7 @@ func newMmap(t *testing.T) (*copy_on_write.Mmap, string) {
 	s, err := f.Stat()
 	require.NoError(t, err)
 
-	mmap, err := copy_on_write.NewMmapFd(ctx, env, root, int(f.Fd()), int(s.Size()), 0, snaputil.ChunkSourceLocalFile, "", false)
+	mmap, err := copy_on_write.NewMmapFd(ctx, env, root, false /*=dirty*/, int(f.Fd()), int(s.Size()), offset, snaputil.ChunkSourceLocalFile, "", false)
 	require.NoError(t, err)
 	return mmap, path
 }

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
@@ -74,6 +74,10 @@ func TestMmap_Concurrency(t *testing.T) {
 	eg := &errgroup.Group{}
 	for i := 0; i < 100; i++ {
 		eg.Go(func() error {
+			s.Source()
+			return nil
+		})
+		eg.Go(func() error {
 			buf := make([]byte, 100)
 			_, err := rand.Read(buf)
 			if err != nil {


### PR DESCRIPTION
* Add a concurrency-safe `Unmap` function to allow safely unmapping chunks at any time. The plan is to call this from an LRU `OnEvict` callback, which will unmap the least recently used chunk in order to save memory.
* Add a concurrency-safe `Fetch` function and call this function when eager-fetching, instead of calling `initMap`. This makes sure that we don't `mmap` unless the chunk is actually needed, since `mmap` incurs extra memory usage and causes extra churn on the LRU if the chunk is not actually used.
* Now that `Unmap` can be called at any time, fix a concurrency issue in certain mmap operations where we momentarily releasing the lock after calling `initMap`. During this time that we're not holding the lock, it is valid for `Unmap` to be called, which would result in a panic when we try to access `data`.
* When converting a file to COW, don't eagerly `mmap` it. This should save a significant amount of memory usage today, and also reduce LRU churn once the LRU is implemented.

**Related issues**: N/A
