### PR TITLE
Report github statuses with subdomain links if available

### DIFF
--- a/server/build_event_protocol/build_status_reporter/BUILD
+++ b/server/build_event_protocol/build_status_reporter/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//server/tables",
         "//server/util/git",
         "//server/util/log",
+        "//server/util/subdomain",
         "//server/util/timeutil",
     ],
 )

--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
 	"github.com/buildbuddy-io/buildbuddy/server/util/timeutil"
 
 	gitutil "github.com/buildbuddy-io/buildbuddy/server/util/git"
@@ -116,7 +117,7 @@ func (r *BuildStatusReporter) flushPayloadsIfWorkspaceLoaded(ctx context.Context
 		r.githubClient = r.initGHClient(ctx)
 	}
 
-	if r.subdomain == "" {
+	if r.subdomain == "" && subdomain.Enabled() {
 		r.subdomain = r.subdomainFromContext(ctx)
 	}
 

--- a/server/endpoint_urls/build_buddy_url/build_buddy_url.go
+++ b/server/endpoint_urls/build_buddy_url/build_buddy_url.go
@@ -15,6 +15,21 @@ func WithPath(path string) *url.URL {
 	return buildBuddyURL.ResolveReference(&url.URL{Path: path})
 }
 
+func WithSubdomainAndPath(identifier string, path string) *url.URL {
+	bURL := *buildBuddyURL
+	if identifier == "" {
+		return bURL.ResolveReference(&url.URL{Path: path})
+	}
+
+	domain := urlutil.GetDomain(bURL.Hostname())
+	newHost := identifier + "." + domain
+	if bURL.Port() != "" {
+		newHost += ":" + bURL.Port()
+	}
+	bURL.Host = newHost
+	return bURL.ResolveReference(&url.URL{Path: path})
+}
+
 func String() string {
 	return buildBuddyURL.String()
 }


### PR DESCRIPTION
Currently when reporting github statuses, we always use `app.buildbuddy.io` for the details links.

With this change we'll use `acme.buildbuddy.io` if the organization has configured a url identifier and subdomains are enabled.