### PR TITLE
Optimize ReadBlob and WriteBlob

### DIFF
--- a/server/backends/blobstore/disk/BUILD
+++ b/server/backends/blobstore/disk/BUILD
@@ -22,6 +22,7 @@ go_test(
     deps = [
         "//server/backends/blobstore/util",
         "//server/interfaces",
+        "//server/testutil/testdigest",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/backends/blobstore/disk/disk_test.go
+++ b/server/backends/blobstore/disk/disk_test.go
@@ -2,11 +2,14 @@ package disk
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
 	"path/filepath"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/backends/blobstore/util"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,6 +101,60 @@ func TestDiskBlobStore(t *testing.T) {
 			exist, err = bs.BlobExists(ctx, tc.blobName)
 			require.NoError(t, err)
 			require.False(t, exist)
+		})
+	}
+}
+
+type namedBlob struct {
+	name string
+	buf  []byte
+}
+
+func getBlobs(t testing.TB, num int, sizeBytes int64) []*namedBlob {
+	blobs := make([]*namedBlob, 0, num)
+	for i := 0; i < num; i++ {
+		d, b := testdigest.RandomCASResourceBuf(t, sizeBytes)
+		blobs = append(blobs, &namedBlob{
+			name: d.GetDigest().GetHash(),
+			buf:  b,
+		})
+	}
+	return blobs
+}
+
+func writeBlobs(t testing.TB, ctx context.Context, bs interfaces.Blobstore, blobs []*namedBlob) {
+	for _, b := range blobs {
+		if _, err := bs.WriteBlob(ctx, b.name, b.buf); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkReadBlob(b *testing.B) {
+	originalRootDir := *rootDirectory
+	*rootDirectory = b.TempDir()
+	b.Cleanup(func() {
+		*rootDirectory = originalRootDir
+	})
+	var bs interfaces.Blobstore
+	bs, err := NewDiskBlobStore()
+	ctx := context.Background()
+	require.NoError(b, err)
+	for _, size := range []int64{10, 1e3, 1e4, 1e5, 1e6} {
+		blobs := getBlobs(b, 100, size)
+		writeBlobs(b, ctx, bs, blobs)
+		name := fmt.Sprintf("size=%d", size)
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				namedBlob := blobs[rand.Intn(len(blobs))]
+				b.SetBytes(int64(len(namedBlob.buf)))
+				_, err = bs.ReadBlob(ctx, namedBlob.name)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
 		})
 	}
 }

--- a/server/backends/blobstore/util/util.go
+++ b/server/backends/blobstore/util/util.go
@@ -49,14 +49,15 @@ func Decompress(in []byte, err error) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	rsp, err := io.ReadAll(zr)
+	var buffer bytes.Buffer
+	_, err = io.Copy(&buffer, zr)
 	if err != nil {
 		return nil, err
 	}
 	if err := zr.Close(); err != nil {
 		return nil, err
 	}
-	return rsp, nil
+	return buffer.Bytes(), nil
 }
 
 func Compress(in []byte) ([]byte, error) {

--- a/server/backends/blobstore/util/util.go
+++ b/server/backends/blobstore/util/util.go
@@ -49,12 +49,10 @@ func Decompress(in []byte, err error) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer zr.Close()
 	var buffer bytes.Buffer
 	_, err = io.Copy(&buffer, zr)
 	if err != nil {
-		return nil, err
-	}
-	if err := zr.Close(); err != nil {
 		return nil, err
 	}
 	return buffer.Bytes(), nil
@@ -69,7 +67,8 @@ func Compress(in []byte) ([]byte, error) {
 	if err := zr.Close(); err != nil {
 		return nil, err
 	}
-	return io.ReadAll(&buf)
+
+	return buf.Bytes(), nil
 }
 
 // prefixBlobstore implements interfaces.Blobstore, is a wrapper around


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
1. Add a benchmark test for ReadBlob and WriteBlob
2. use io.Copy in util.Decompress
3. use buf.Bytes instead of io.ReadAll in util.Compress

Our current blob write size is the median is 5K, 95% is 800K. Here's the benchmark result after the change:
```
                          │ /home/lulu/benchmark-rw-baseline.log │  /home/lulu/benchmark-rw-after.log  │
                          │                sec/op                │    sec/op     vs base               │
ReadBlob/size=10-24                                 22.81µ ± 11%   21.72µ ± 14%        ~ (p=0.180 n=6)
ReadBlob/size=1000-24                               28.10µ ± 14%   27.44µ ±  2%        ~ (p=0.065 n=6)
ReadBlob/size=10000-24                              75.63µ ±  1%   71.12µ ±  6%   -5.97% (p=0.002 n=6)
ReadBlob/size=100000-24                             441.4µ ±  3%   411.1µ ±  3%   -6.86% (p=0.002 n=6)
ReadBlob/size=1000000-24                            3.187m ±  6%   2.434m ±  6%  -23.64% (p=0.002 n=6)
WriteBlob/size=10-24                                289.3µ ±  3%   286.5µ ±  2%        ~ (p=0.589 n=6)
WriteBlob/size=1000-24                              346.4µ ±  2%   349.4µ ±  1%        ~ (p=0.240 n=6)
WriteBlob/size=10000-24                             442.3µ ±  7%   434.6µ ±  1%        ~ (p=0.180 n=6)
WriteBlob/size=100000-24                            1.287m ±  3%   1.248m ±  7%   -2.96% (p=0.015 n=6)
WriteBlob/size=1000000-24                           6.677m ±  3%   6.203m ±  5%   -7.09% (p=0.002 n=6)
geomean                                             347.9µ         327.7µ         -5.80%

                          │ /home/lulu/benchmark-rw-baseline.log │  /home/lulu/benchmark-rw-after.log   │
                          │                 B/s                  │      B/s       vs base               │
ReadBlob/size=10-24                                429.7Ki ± 14%   449.2Ki ± 15%        ~ (p=0.173 n=6)
ReadBlob/size=1000-24                              33.94Mi ± 16%   34.75Mi ±  2%        ~ (p=0.065 n=6)
ReadBlob/size=10000-24                             126.1Mi ±  1%   134.1Mi ±  6%   +6.35% (p=0.002 n=6)
ReadBlob/size=100000-24                            216.1Mi ±  3%   232.0Mi ±  3%   +7.36% (p=0.002 n=6)
ReadBlob/size=1000000-24                           299.2Mi ±  6%   391.9Mi ±  6%  +30.96% (p=0.002 n=6)
WriteBlob/size=10-24                               29.30Ki ± 33%   34.18Ki ± 14%        ~ (p=0.545 n=6)
WriteBlob/size=1000-24                             2.751Mi ±  2%   2.732Mi ±  1%        ~ (p=0.249 n=6)
WriteBlob/size=10000-24                            21.56Mi ±  8%   21.95Mi ±  1%        ~ (p=0.180 n=6)
WriteBlob/size=100000-24                           74.13Mi ±  3%   76.39Mi ±  8%   +3.06% (p=0.015 n=6)
WriteBlob/size=1000000-24                          142.8Mi ±  3%   153.7Mi ±  6%   +7.64% (p=0.002 n=6)
geomean                                            17.06Mi         18.37Mi         +7.67%

                          │ /home/lulu/benchmark-rw-baseline.log │  /home/lulu/benchmark-rw-after.log  │
                          │                 B/op                 │     B/op      vs base               │
ReadBlob/size=10-24                                 43.53Ki ± 0%   43.57Ki ± 0%   +0.11% (p=0.002 n=6)
ReadBlob/size=1000-24                               46.10Ki ± 0%   44.90Ki ± 0%   -2.61% (p=0.002 n=6)
ReadBlob/size=10000-24                              94.74Ki ± 0%   81.18Ki ± 0%  -14.32% (p=0.002 n=6)
ReadBlob/size=100000-24                             618.4Ki ± 0%   370.2Ki ± 0%  -40.13% (p=0.002 n=6)
ReadBlob/size=1000000-24                            5.678Mi ± 0%   2.677Mi ± 0%  -52.85% (p=0.002 n=6)
WriteBlob/size=10-24                                800.1Ki ± 0%   799.6Ki ± 0%   -0.06% (p=0.002 n=6)
WriteBlob/size=1000-24                              800.7Ki ± 0%   800.2Ki ± 0%   -0.06% (p=0.002 n=6)
WriteBlob/size=10000-24                             818.6Ki ± 0%   806.9Ki ± 0%   -1.43% (p=0.002 n=6)
WriteBlob/size=100000-24                           1052.4Ki ± 0%   902.8Ki ± 0%  -14.22% (p=0.002 n=6)
WriteBlob/size=1000000-24                           3.246Mi ± 0%   1.779Mi ± 0%  -45.19% (p=0.002 n=6)
geomean                                             512.7Ki        410.8Ki       -19.87%

                          │ /home/lulu/benchmark-rw-baseline.log │  /home/lulu/benchmark-rw-after.log  │
                          │              allocs/op               │ allocs/op   vs base                 │
ReadBlob/size=10-24                                   31.00 ± 0%   32.00 ± 0%   +3.23% (p=0.002 n=6)
ReadBlob/size=1000-24                                 33.00 ± 0%   33.00 ± 0%        ~ (p=1.000 n=6) ¹
ReadBlob/size=10000-24                                44.00 ± 0%   41.00 ± 0%   -6.82% (p=0.002 n=6)
ReadBlob/size=100000-24                               52.00 ± 0%   44.00 ± 0%  -15.38% (p=0.002 n=6)
ReadBlob/size=1000000-24                             103.00 ± 1%   89.00 ± 0%  -13.59% (p=0.002 n=6)
WriteBlob/size=10-24                                  56.00 ± 0%   55.00 ± 0%   -1.79% (p=0.002 n=6)
WriteBlob/size=1000-24                                58.00 ± 0%   57.00 ± 0%   -1.72% (p=0.002 n=6)
WriteBlob/size=10000-24                               65.00 ± 0%   59.00 ± 0%   -9.23% (p=0.002 n=6)
WriteBlob/size=100000-24                              76.00 ± 0%   62.00 ± 0%  -18.42% (p=0.002 n=6)
WriteBlob/size=1000000-24                             88.00 ± 0%   66.00 ± 0%  -25.00% (p=0.002 n=6)
geomean                                               56.65        51.38        -9.29%
¹ all samples are equal
```
