### PR TITLE
Optimize blobstore ReadBlobs

### DIFF
--- a/server/backends/blobstore/aws/aws.go
+++ b/server/backends/blobstore/aws/aws.go
@@ -175,20 +175,18 @@ func (a *AwsS3BlobStore) createBucketIfNotExists(ctx context.Context, bucketName
 	return nil
 }
 
-func (a *AwsS3BlobStore) ReadBlob(ctx context.Context, blobName string) ([]byte, error) {
+func (a *AwsS3BlobStore) ReadBlob(ctx context.Context, blobName string) (rb []byte, retErr error) {
 	start := time.Now()
 	b, err := a.download(ctx, blobName)
 	duration := time.Since(start)
-	// We update the err later on, so we need to wrap RecordReadMetrics in a func.
 	defer func() {
-		util.RecordReadMetrics(awsS3Label, duration, int64(len(b)), err)
+		util.RecordReadMetrics(awsS3Label, duration, int64(len(b)), retErr)
 	}()
 	if err != nil {
 		return b, err
 	}
 	rd := bytes.NewReader(b)
-	bytes, err := util.Decompress(rd)
-	return bytes, err
+	return util.Decompress(rd)
 }
 
 func (a *AwsS3BlobStore) download(ctx context.Context, blobName string) ([]byte, error) {

--- a/server/backends/blobstore/disk/BUILD
+++ b/server/backends/blobstore/disk/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//server/util/disk",
         "//server/util/ioutil",
         "//server/util/log",
+        "//server/util/status",
         "//server/util/tracing",
     ],
 )

--- a/server/backends/blobstore/disk/disk.go
+++ b/server/backends/blobstore/disk/disk.go
@@ -76,7 +76,7 @@ func (d *DiskBlobStore) WriteBlob(ctx context.Context, blobName string, data []b
 	return n, err
 }
 
-func (d *DiskBlobStore) ReadBlob(ctx context.Context, blobName string) ([]byte, error) {
+func (d *DiskBlobStore) ReadBlob(ctx context.Context, blobName string) (rb []byte, retError error) {
 	fullPath, err := d.blobPath(blobName)
 	if err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func (d *DiskBlobStore) ReadBlob(ctx context.Context, blobName string) ([]byte, 
 		if spn.IsRecording() {
 			spn.End()
 		}
-		util.RecordReadMetrics(diskLabel, duration, counter.Count(), err)
+		util.RecordReadMetrics(diskLabel, duration, counter.Count(), retError)
 	}()
 
 	if os.IsNotExist(err) {
@@ -105,9 +105,7 @@ func (d *DiskBlobStore) ReadBlob(ctx context.Context, blobName string) ([]byte, 
 	defer f.Close()
 	reader := io.TeeReader(f, counter)
 	duration = time.Since(start)
-	bytes, err := util.Decompress(reader)
-	util.RecordReadMetrics(diskLabel, duration, counter.Count(), err)
-	return bytes, err
+	return util.Decompress(reader)
 }
 
 func (d *DiskBlobStore) DeleteBlob(ctx context.Context, blobName string) error {

--- a/server/backends/blobstore/util/BUILD
+++ b/server/backends/blobstore/util/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//server/interfaces",
         "//server/metrics",
+        "//server/util/ioutil",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_grpc//status",
     ],

--- a/server/backends/blobstore/util/util.go
+++ b/server/backends/blobstore/util/util.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
+	"github.com/buildbuddy-io/buildbuddy/server/util/ioutil"
 	"github.com/prometheus/client_golang/prometheus"
 
 	gstatus "google.golang.org/grpc/status"
@@ -27,35 +28,22 @@ func NewCompressReader(r io.Reader) (io.ReadCloser, error) {
 	return gzip.NewReader(r)
 }
 
-func Decompress(in []byte, err error) ([]byte, error) {
+func Decompress(r io.Reader) ([]byte, error) {
+	var wrappedReader io.Reader
+	zr, err := NewCompressReader(r)
 	if err != nil {
-		return in, err
-	}
-
-	var buf bytes.Buffer
-	// Write instead of using NewBuffer because if this is not a gzip file
-	// we want to return "in" directly later, and NewBuffer would take
-	// ownership of it.
-	if _, err := buf.Write(in); err != nil {
-		return nil, err
-	}
-	zr, err := NewCompressReader(&buf)
-	if err == gzip.ErrHeader {
+		if err != gzip.ErrHeader {
+			return nil, err
+		}
 		// Compatibility hack: if we got a header error it means this
 		// is probably an uncompressed record written before we were
 		// compressing. Just read it as-is.
-		return in, nil
-	}
-	if err != nil {
-		return nil, err
+		wrappedReader = r
+	} else {
+		wrappedReader = zr
 	}
 	defer zr.Close()
-	var buffer bytes.Buffer
-	_, err = io.Copy(&buffer, zr)
-	if err != nil {
-		return nil, err
-	}
-	return buffer.Bytes(), nil
+	return ioutil.ReadAll(wrappedReader)
 }
 
 func Compress(in []byte) ([]byte, error) {
@@ -133,9 +121,7 @@ func RecordWriteMetrics(typeLabel string, startTime time.Time, size int, err err
 	}).Observe(float64(size))
 }
 
-func RecordReadMetrics(typeLabel string, startTime time.Time, b []byte, err error) {
-	duration := time.Since(startTime)
-	size := len(b)
+func RecordReadMetrics(typeLabel string, duration time.Duration, size int64, err error) {
 	metrics.BlobstoreReadCount.With(prometheus.Labels{
 		metrics.StatusLabel:        fmt.Sprintf("%d", gstatus.Code(err)),
 		metrics.BlobstoreTypeLabel: typeLabel,

--- a/server/util/ioutil/ioutil.go
+++ b/server/util/ioutil/ioutil.go
@@ -126,7 +126,10 @@ func ReadTryFillBuffer(r io.Reader, buf []byte) (int, error) {
 	return n, err
 }
 
-// io.Copy performs better than io.ReadAll in terms of cpu and memory allocation.
+// io.Copy performs better than io.ReadAll in terms of cpu and memory allocation
+// because io.ReadAll uses append to resize its buffer, and bytes.Buffer.grow
+// uses a more efficient algorithm.
+// See https://github.com/golang/go/issues/50774.
 // Some benchmark results can be found at
 // https://github.com/buildbuddy-io/buildbuddy/pull/5394 and
 // https://github.com/buildbuddy-io/buildbuddy/pull/5374

--- a/server/util/ioutil/ioutil.go
+++ b/server/util/ioutil/ioutil.go
@@ -1,6 +1,7 @@
 package ioutil
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -123,4 +124,17 @@ func ReadTryFillBuffer(r io.Reader, buf []byte) (int, error) {
 		return n, nil
 	}
 	return n, err
+}
+
+// io.Copy performs better than io.ReadAll in terms of cpu and memory allocation.
+// Some benchmark results can be found at
+// https://github.com/buildbuddy-io/buildbuddy/pull/5394 and
+// https://github.com/buildbuddy-io/buildbuddy/pull/5374
+func ReadAll(r io.Reader) ([]byte, error) {
+	var buffer bytes.Buffer
+	_, err := io.Copy(&buffer, r)
+	if err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Refactor util.Decompress() so that it takes in a reader instead of bytes.
Currently, in ReadBlobs we call io.ReadAll(..) and then in util.Decompress(..)
we construct a bytes.Buffer as a reader to pass in NewCompressReader. All of
these seem unnecessary to me.

The benchmark showed smaller allocations for disk blob store. The result is as follows:
```
                         │ /home/lulu/benchmark-read-baseline.log │ /home/lulu/benchmark-read-opt.log │
                          │                 sec/op                 │   sec/op     vs base              │
ReadBlob/size=10-24                                    22.52µ ± 3%   23.11µ ± 4%  +2.62% (p=0.004 n=6)
ReadBlob/size=1000-24                                  27.66µ ± 9%   28.28µ ± 3%  +2.24% (p=0.041 n=6)
ReadBlob/size=10000-24                                 70.60µ ± 1%   71.61µ ± 2%       ~ (p=0.180 n=6)
ReadBlob/size=100000-24                                407.4µ ± 1%   414.7µ ± 5%       ~ (p=0.485 n=6)
ReadBlob/size=1000000-24                               2.545m ± 4%   2.466m ± 4%       ~ (p=0.132 n=6)
WriteBlob/size=10-24                                   292.2µ ± 1%   292.3µ ± 2%       ~ (p=0.937 n=6)
WriteBlob/size=1000-24                                 343.4µ ± 0%   347.8µ ± 2%       ~ (p=0.065 n=6)
WriteBlob/size=10000-24                                437.2µ ± 1%   436.2µ ± 1%       ~ (p=0.818 n=6)
WriteBlob/size=100000-24                               1.253m ± 3%   1.244m ± 3%       ~ (p=0.818 n=6)
WriteBlob/size=1000000-24                              6.202m ± 3%   6.146m ± 3%       ~ (p=0.699 n=6)
geomean                                                330.5µ        331.9µ       +0.43%

                          │ /home/lulu/benchmark-read-baseline.log │  /home/lulu/benchmark-read-opt.log  │
                          │                  B/s                   │      B/s       vs base              │
ReadBlob/size=10-24                                  429.7Ki ±  5%   419.9Ki ±  5%  -2.27% (p=0.011 n=6)
ReadBlob/size=1000-24                                34.48Mi ± 10%   33.72Mi ±  3%  -2.19% (p=0.041 n=6)
ReadBlob/size=10000-24                               135.1Mi ±  1%   133.2Mi ±  2%       ~ (p=0.180 n=6)
ReadBlob/size=100000-24                              234.1Mi ±  1%   229.9Mi ±  5%       ~ (p=0.485 n=6)
ReadBlob/size=1000000-24                             374.8Mi ±  4%   386.7Mi ±  5%       ~ (p=0.132 n=6)
WriteBlob/size=10-24                                 29.30Ki ±  0%   29.30Ki ± 33%       ~ (p=1.000 n=6)
WriteBlob/size=1000-24                               2.775Mi ±  1%   2.742Mi ±  2%       ~ (p=0.063 n=6)
WriteBlob/size=10000-24                              21.82Mi ±  1%   21.86Mi ±  1%       ~ (p=0.818 n=6)
WriteBlob/size=100000-24                             76.10Mi ±  3%   76.66Mi ±  3%       ~ (p=0.734 n=6)
WriteBlob/size=1000000-24                            153.8Mi ±  3%   155.2Mi ±  3%       ~ (p=0.699 n=6)
geomean                                              17.95Mi         17.88Mi        -0.39%

                          │ /home/lulu/benchmark-read-baseline.log │  /home/lulu/benchmark-read-opt.log  │
                          │                  B/op                  │     B/op      vs base               │
ReadBlob/size=10-24                                   43.57Ki ± 0%   46.67Ki ± 0%   +7.10% (p=0.002 n=6)
ReadBlob/size=1000-24                                 44.90Ki ± 0%   47.67Ki ± 0%   +6.17% (p=0.002 n=6)
ReadBlob/size=10000-24                                81.21Ki ± 0%   77.89Ki ± 0%   -4.09% (p=0.002 n=6)
ReadBlob/size=100000-24                               371.8Ki ± 0%   302.0Ki ± 0%  -18.75% (p=0.002 n=6)
ReadBlob/size=1000000-24                              2.679Mi ± 0%   2.048Mi ± 0%  -23.55% (p=0.002 n=6)
WriteBlob/size=10-24                                  799.6Ki ± 0%   799.6Ki ± 0%        ~ (p=0.846 n=6)
WriteBlob/size=1000-24                                800.2Ki ± 0%   800.2Ki ± 0%        ~ (p=0.134 n=6)
WriteBlob/size=10000-24                               806.9Ki ± 0%   806.9Ki ± 0%        ~ (p=0.236 n=6)
WriteBlob/size=100000-24                              891.5Ki ± 0%   906.8Ki ± 0%   +1.71% (p=0.002 n=6)
WriteBlob/size=1000000-24                             1.779Mi ± 0%   1.779Mi ± 0%        ~ (p=0.509 n=6)
geomean                                               410.5Ki        395.5Ki        -3.66%

                          │ /home/lulu/benchmark-read-baseline.log │ /home/lulu/benchmark-read-opt.log  │
                          │               allocs/op                │ allocs/op   vs base                │
ReadBlob/size=10-24                                     32.00 ± 0%   29.00 ± 0%  -9.38% (p=0.002 n=6)
ReadBlob/size=1000-24                                   33.00 ± 0%   30.00 ± 0%  -9.09% (p=0.002 n=6)
ReadBlob/size=10000-24                                  41.00 ± 0%   38.00 ± 0%  -7.32% (p=0.002 n=6)
ReadBlob/size=100000-24                                 44.00 ± 0%   41.00 ± 0%  -6.82% (p=0.002 n=6)
ReadBlob/size=1000000-24                                89.00 ± 0%   85.00 ± 1%  -4.49% (p=0.002 n=6)
WriteBlob/size=10-24                                    55.00 ± 0%   55.00 ± 0%       ~ (p=1.000 n=6) ¹
WriteBlob/size=1000-24                                  57.00 ± 0%   57.00 ± 0%       ~ (p=1.000 n=6) ¹
WriteBlob/size=10000-24                                 59.00 ± 0%   59.00 ± 0%       ~ (p=1.000 n=6) ¹
WriteBlob/size=100000-24                                62.00 ± 0%   62.50 ± 1%       ~ (p=0.182 n=6)
WriteBlob/size=1000000-24                               66.00 ± 0%   66.00 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                 51.38        49.48       -3.71%
¹ all samples are equal

```