### PR TITLE
replay_action: log warning instead of failing when target_api_key is unset

### DIFF
--- a/enterprise/tools/replay_action/replay_action.go
+++ b/enterprise/tools/replay_action/replay_action.go
@@ -149,7 +149,7 @@ func contextWithTargetAPIKey(ctx context.Context) context.Context {
 		return metadata.AppendToOutgoingContext(ctx, "x-buildbuddy-api-key", *targetAPIKey)
 	}
 	if *sourceAPIKey != "" {
-		log.Fatalf("--target_api_key is required when --source_api_key is set")
+		log.Warningf("--target_api_key is not set, but --source_api_key was set. Replaying as anonymous user.")
 	}
 	return ctx
 }


### PR DESCRIPTION
This is a bit more convenient, especially when SSH'd into a GCP VM where setting up auth is a pain.

**Related issues**: N/A
