### PR TITLE
Fix confusing snapshot logging and hit rate metric

### DIFF
--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -180,6 +180,10 @@ type Snapshot struct {
 	remoteEnabled bool
 }
 
+func (s *Snapshot) GetKey() *fcpb.SnapshotKey {
+	return proto.Clone(s.key).(*fcpb.SnapshotKey)
+}
+
 func (s *Snapshot) GetVMConfiguration() *fcpb.VMConfiguration {
 	return s.manifest.GetVmConfiguration()
 }
@@ -282,11 +286,6 @@ func (l *FileCacheLoader) GetSnapshot(ctx context.Context, keys *fcpb.SnapshotKe
 		if err != nil {
 			lastErr = err
 			continue
-		}
-		if key == keys.GetBranchKey() {
-			log.CtxInfof(ctx, "Found preferred snapshot ref=%q in cache", key.GetRef())
-		} else {
-			log.CtxInfof(ctx, "Found fallback snapshot ref=%q in cache", key.GetRef())
 		}
 		return &Snapshot{
 			key:           key,


### PR DESCRIPTION
* `GetSnapshot()` logs hits/misses for the containerfs snapshot which is confusing because without more context, it looks like the hit/miss is referring to the whole VM snapshot. This PR makes it so we only log for the whole VM snapshot.
* The hit rate metric has an issue that I introduced when attempting to fix a different issue - if `createFromSnapshot` is false then we won't call `LoadSnapshot()` and record the miss. So I think we'll effectively always report a 100% hit rate. Fixed in this PR

**Related issues**: N/A
