### PR TITLE
Add a filter to the timing profile

### DIFF
--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -199,7 +199,7 @@
 }
 
 .invocation .trace-viewer {
-  margin-top: 32px;
+  margin-top: 24px;
 }
 
 .cache-requests-card .action-id {

--- a/app/trace/BUILD
+++ b/app/trace/BUILD
@@ -17,6 +17,7 @@ ts_library(
     name = "trace_viewer",
     srcs = ["trace_viewer.tsx"],
     deps = [
+        "//app/components/filter_input",
         "//app/router",
         "//app/trace:constants",
         "//app/trace:event_hovercard",

--- a/app/trace/constants.ts
+++ b/app/trace/constants.ts
@@ -27,12 +27,12 @@ export const SECTION_PADDING_BOTTOM = 1;
 
 export const TRACK_HEIGHT = 16;
 export const TRACK_VERTICAL_GAP = 1;
-export const TRACK_FILTERED_OUT_COLOR = "#ddd";
 
 export const EVENT_HORIZONTAL_GAP = 0.5;
 export const EVENT_LABEL_WIDTH_THRESHOLD = 20;
 export const EVENT_LABEL_FONT_SIZE = "11px";
 export const EVENT_LABEL_FONT_COLOR = SECTION_LABEL_FONT_COLOR;
+export const EVENT_FILTERED_OUT_COLOR = "#ddd";
 
 export const TIME_SERIES_HEIGHT = 24;
 export const TIME_SERIES_POINT_RADIUS = 2;

--- a/app/trace/constants.ts
+++ b/app/trace/constants.ts
@@ -27,6 +27,7 @@ export const SECTION_PADDING_BOTTOM = 1;
 
 export const TRACK_HEIGHT = 16;
 export const TRACK_VERTICAL_GAP = 1;
+export const TRACK_FILTERED_OUT_COLOR = "#ddd";
 
 export const EVENT_HORIZONTAL_GAP = 0.5;
 export const EVENT_LABEL_WIDTH_THRESHOLD = 20;

--- a/app/trace/trace_viewer.css
+++ b/app/trace/trace_viewer.css
@@ -135,3 +135,7 @@
   border-top: 1px solid #eee;
   margin-bottom: 4px;
 }
+
+.trace-viewer .filter {
+  margin-bottom: 16px;
+}

--- a/app/trace/trace_viewer.tsx
+++ b/app/trace/trace_viewer.tsx
@@ -60,8 +60,6 @@ export default class TraceViewer extends React.Component<TraceViewProps, {}> {
   private mouseScrollTop = 0;
   private panning?: Panel | null;
 
-  private filterInputRef = React.createRef<HTMLInputElement>();
-
   private hovercardRef = React.createRef<EventHovercard>();
 
   private unobserveResize?: () => void;
@@ -88,10 +86,6 @@ export default class TraceViewer extends React.Component<TraceViewProps, {}> {
       panel.container.addEventListener("wheel", (e: WheelEvent) => this.onWheel(e), {
         passive: false,
       });
-    }
-    if (this.filterInputRef.current) {
-      this.filterInputRef.current.addEventListener("keyup", () => this.updateFilter());
-      this.filterInputRef.current.value = this.getFilter();
     }
   }
 
@@ -262,8 +256,8 @@ export default class TraceViewer extends React.Component<TraceViewProps, {}> {
     document.body.style.cursor = "";
   };
 
-  private updateFilter = () => {
-    router.setQueryParam(FILTER_URL_PARAM, this.filterInputRef.current?.value);
+  private updateFilter = (value: string) => {
+    router.setQueryParam(FILTER_URL_PARAM, value);
     this.update();
   };
 
@@ -294,7 +288,12 @@ export default class TraceViewer extends React.Component<TraceViewProps, {}> {
             "--scrollbar-size": `${constants.SCROLLBAR_SIZE}px`,
           } as CSSProperties),
         }}>
-        <FilterInput className="filter" ref={this.filterInputRef} placeholder="Filter..." />
+        <FilterInput
+          className="filter"
+          onChange={(e) => this.updateFilter(e.target.value)}
+          value={this.getFilter()}
+          placeholder="Filter..."
+        />
         {this.model.panels.map((panel, i) => (
           <div
             className="panel-container"

--- a/app/trace/trace_viewer_panel.ts
+++ b/app/trace/trace_viewer_panel.ts
@@ -402,7 +402,7 @@ export default class Panel {
       ) {
         this.ctx.fillStyle = color;
       } else {
-        this.ctx.fillStyle = constants.TRACK_FILTERED_OUT_COLOR;
+        this.ctx.fillStyle = constants.EVENT_FILTERED_OUT_COLOR;
       }
 
       // TODO: only apply the horizontal gap if there's an event just after us.

--- a/app/trace/trace_viewer_panel.ts
+++ b/app/trace/trace_viewer_panel.ts
@@ -32,6 +32,8 @@ export default class Panel {
   canvasWidth = 0;
   canvasHeight = 0;
 
+  filter = "";
+
   constructor(readonly model: PanelModel, readonly canvas: HTMLCanvasElement, private fontFamily: string) {
     this.ctx = canvas.getContext("2d")!;
     this.container = canvas.parentElement!;
@@ -390,7 +392,19 @@ export default class Panel {
 
       let color = track.colors[i];
 
-      this.ctx.fillStyle = color;
+      if (
+        this.filter == "" ||
+        track.events[i].name.toLowerCase().includes(this.filter.toLowerCase()) ||
+        track.events[i].cat.toLowerCase().includes(this.filter.toLowerCase()) ||
+        track.events[i].args?.target?.toLowerCase().includes(this.filter.toLowerCase()) ||
+        track.events[i].args?.mnemonic?.toLowerCase().includes(this.filter.toLowerCase()) ||
+        track.events[i].out?.toLowerCase().includes(this.filter.toLowerCase())
+      ) {
+        this.ctx.fillStyle = color;
+      } else {
+        this.ctx.fillStyle = constants.TRACK_FILTERED_OUT_COLOR;
+      }
+
       // TODO: only apply the horizontal gap if there's an event just after us.
       let width = modelWidth * this.canvasXPerModelX - constants.EVENT_HORIZONTAL_GAP;
       if (width <= 0) {


### PR DESCRIPTION
This allows you to search the timing profile by event name, target, mnemonic, category, or output name.

Event that match will be shown in color, while all other events will be greyed out.

Example:
<img width="1436" alt="Screenshot 2023-11-29 at 2 07 49 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/9db528d2-bfc3-4baf-b5e1-e33628884303">
