### PR TITLE
One thread per rangelease

### DIFF
--- a/enterprise/server/raft/nodeliveness/BUILD
+++ b/enterprise/server/raft/nodeliveness/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//enterprise/server/raft/keys",
         "//enterprise/server/raft/rbuilder",
         "//proto:raft_go_proto",
+        "//server/util/canary",
         "//server/util/log",
         "//server/util/status",
         "@com_github_hashicorp_serf//serf",

--- a/enterprise/server/raft/nodeliveness/BUILD
+++ b/enterprise/server/raft/nodeliveness/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//enterprise/server/raft/keys",
         "//enterprise/server/raft/rbuilder",
         "//proto:raft_go_proto",
-        "//server/util/canary",
         "//server/util/log",
         "//server/util/status",
         "@com_github_hashicorp_serf//serf",

--- a/enterprise/server/raft/nodeliveness/nodeliveness.go
+++ b/enterprise/server/raft/nodeliveness/nodeliveness.go
@@ -113,12 +113,12 @@ func (h *Liveness) AddListener() (<-chan *rfpb.NodeLivenessRecord, func()) {
 	h.livenessListeners = append(h.livenessListeners, ch)
 	closeFunc := func() {
 		h.mu.Lock()
-		defer h.mu.Unlock()
 		for i, l := range h.livenessListeners {
 			if l == ch {
 				h.livenessListeners = append(h.livenessListeners[:i], h.livenessListeners[:i+1]...)
 			}
 		}
+		h.mu.Unlock()
 	}
 	if err := h.verifyLease(h.lastLivenessRecord); err == nil {
 		ch <- h.lastLivenessRecord
@@ -338,8 +338,7 @@ func (h *Liveness) string(replicaID []byte, llr *rfpb.NodeLivenessRecord) string
 }
 
 func (h *Liveness) String() string {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	return h.string(h.nhid, h.lastLivenessRecord)
 }


### PR DESCRIPTION
rangelease acquisition is driven by raft leadership changes, ranges being added or removed, or node liveness state changes. Race conditions were possible in the previous code because multiple differing requests could simultaneously be pending to update a lease.

this change fixes those race conditions by running a single goroutine per rangelease, and only allowing it to process one range lease instruction at a time.