### PR TITLE
Revert "Nodeliveness needs only nodehost; not sender"

### DIFF
--- a/enterprise/server/raft/constants/constants.go
+++ b/enterprise/server/raft/constants/constants.go
@@ -46,8 +46,6 @@ const (
 	InitialRangeID   = 1
 
 	UnsplittableMaxByte = systemMaxByte
-
-	MetaRangeShardID = 1
 )
 
 const CASErrorMessage = "CAS expected value did not match"

--- a/enterprise/server/raft/nodeliveness/BUILD
+++ b/enterprise/server/raft/nodeliveness/BUILD
@@ -7,10 +7,10 @@ go_library(
     srcs = ["nodeliveness.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/nodeliveness",
     deps = [
-        "//enterprise/server/raft/client",
         "//enterprise/server/raft/constants",
         "//enterprise/server/raft/keys",
         "//enterprise/server/raft/rbuilder",
+        "//enterprise/server/raft/sender",
         "//proto:raft_go_proto",
         "//server/util/log",
         "//server/util/status",
@@ -26,15 +26,11 @@ go_test(
     deps = [
         ":nodeliveness",
         "//enterprise/server/raft/constants",
+        "//enterprise/server/raft/sender",
         "//proto:raft_go_proto",
         "//server/util/status",
-        "@com_github_lni_dragonboat_v4//:dragonboat",
-        "@com_github_lni_dragonboat_v4//client",
-        "@com_github_lni_dragonboat_v4//statemachine",
-        "@com_github_lni_goutils//random",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_grpc//status",
-        "@org_golang_google_protobuf//proto",
     ],
 )

--- a/enterprise/server/raft/nodeliveness/nodeliveness.go
+++ b/enterprise/server/raft/nodeliveness/nodeliveness.go
@@ -8,10 +8,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/client"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/hashicorp/serf/serf"
@@ -29,7 +29,7 @@ const (
 )
 
 type Liveness struct {
-	nodeHost      client.NodeHost
+	sender        sender.ISender
 	nhid          []byte
 	clock         *serf.LamportClock
 	leaseDuration time.Duration
@@ -44,10 +44,10 @@ type Liveness struct {
 	livenessListeners []chan<- *rfpb.NodeLivenessRecord
 }
 
-func New(nodehostID string, nodeHost client.NodeHost) *Liveness {
+func New(nodehostID string, sender sender.ISender) *Liveness {
 	return &Liveness{
 		nhid:                  []byte(nodehostID),
-		nodeHost:              nodeHost,
+		sender:                sender,
 		clock:                 &serf.LamportClock{},
 		leaseDuration:         defaultLeaseDuration,
 		gracePeriod:           defaultGracePeriod,
@@ -230,8 +230,9 @@ func (h *Liveness) sendCasRequest(ctx context.Context, expectedValue, newVal []b
 	if err != nil {
 		return nil, err
 	}
-	rsp, err := client.SyncProposeLocal(ctx, h.nodeHost, constants.MetaRangeShardID, casRequest)
+	rsp, err := h.sender.SyncPropose(ctx, leaseKey, casRequest)
 	if err != nil {
+		// This indicates a communication error proposing the message.
 		return nil, err
 	}
 	casResponse, err := rbuilder.NewBatchResponseFromProto(rsp).CASResponse(0)

--- a/enterprise/server/raft/nodeliveness/nodeliveness_test.go
+++ b/enterprise/server/raft/nodeliveness/nodeliveness_test.go
@@ -7,15 +7,11 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/nodeliveness"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/sender"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	"github.com/lni/dragonboat/v4"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
-	dbcl "github.com/lni/dragonboat/v4/client"
-	sm "github.com/lni/dragonboat/v4/statemachine"
-	dbrd "github.com/lni/goutils/random"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	gstatus "google.golang.org/grpc/status"
 )
@@ -37,8 +33,8 @@ func statusProto(err error) *statuspb.Status {
 	return s.Proto()
 }
 
-func (tp *testingProposer) cmdResponse(kv *rfpb.KV, err error) sm.Result {
-	p := &rfpb.BatchCmdResponse{
+func (tp *testingProposer) cmdResponse(kv *rfpb.KV, err error) *rfpb.BatchCmdResponse {
+	return &rfpb.BatchCmdResponse{
 		Union: []*rfpb.ResponseUnion{{
 			Status: statusProto(err),
 			Value: &rfpb.ResponseUnion_Cas{
@@ -48,24 +44,9 @@ func (tp *testingProposer) cmdResponse(kv *rfpb.KV, err error) sm.Result {
 			},
 		}},
 	}
-	buf, err := proto.Marshal(p)
-	require.NoError(tp.t, err)
-	return sm.Result{Data: buf}
 }
 
-func (tp *testingProposer) ID() string {
-	return ""
-}
-
-func (tp *testingProposer) GetNoOPSession(shardID uint64) *dbcl.Session {
-	return dbcl.NewNoOPSession(shardID, dbrd.LockGuardedRand)
-}
-
-func (tp *testingProposer) SyncPropose(ctx context.Context, session *dbcl.Session, cmd []byte) (sm.Result, error) {
-	batch := &rfpb.BatchCmdRequest{}
-	if err := proto.Unmarshal(cmd, batch); err != nil {
-		return sm.Result{}, err
-	}
+func (tp *testingProposer) SyncPropose(ctx context.Context, _ []byte, batch *rfpb.BatchCmdRequest) (*rfpb.BatchCmdResponse, error) {
 	// This is "fake" sender that only supports CAS values and stores them in a local map for ease of testing.
 	if len(batch.GetUnion()) != 1 {
 		tp.t.Fatal("Only one cmd at a time is allowed.")
@@ -92,19 +73,10 @@ func (tp *testingProposer) SyncPropose(ctx context.Context, session *dbcl.Sessio
 		}
 	}
 	tp.t.Fatal("unsupported batch cmd value was provided.")
-	return sm.Result{}, nil
+	return nil, nil
 }
 
-func (tp *testingProposer) SyncRead(ctx context.Context, shardID uint64, query interface{}) (interface{}, error) {
-	return nil, status.UnimplementedError("not implemented in testingProposer")
-}
-func (tp *testingProposer) ReadIndex(shardID uint64, timeout time.Duration) (*dragonboat.RequestState, error) {
-	return nil, status.UnimplementedError("not implemented in testingProposer")
-}
-func (tp *testingProposer) ReadLocalNode(rs *dragonboat.RequestState, query interface{}) (interface{}, error) {
-	return nil, status.UnimplementedError("not implemented in testingProposer")
-}
-func (tp *testingProposer) StaleRead(shardID uint64, query interface{}) (interface{}, error) {
+func (tp *testingProposer) SyncRead(ctx context.Context, _ []byte, batch *rfpb.BatchCmdRequest, mods ...sender.Option) (*rfpb.BatchCmdResponse, error) {
 	return nil, status.UnimplementedError("not implemented in testingProposer")
 }
 

--- a/enterprise/server/raft/rangelease/rangelease_test.go
+++ b/enterprise/server/raft/rangelease/rangelease_test.go
@@ -140,7 +140,7 @@ func (t *testingSender) SyncRead(ctx context.Context, key []byte, batch *rfpb.Ba
 	return nil, status.UnimplementedError("not implemented in testingSender")
 }
 
-func newTestingProposer(t testing.TB) *testingProposer {
+func newTestingProposerAndSender(t testing.TB) (*testingProposer, *testingSender) {
 	randID, err := random.RandomString(10)
 	require.NoError(t, err)
 	p := &testingProposer{
@@ -148,15 +148,15 @@ func newTestingProposer(t testing.TB) *testingProposer {
 		id:   randID,
 		Data: make(map[string]string),
 	}
-	return p
+	return p, &testingSender{p}
 }
 
 func TestAcquireAndRelease(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
 	defer cancel()
 
-	proposer := newTestingProposer(t)
-	liveness := nodeliveness.New("replicaID-1", proposer)
+	proposer, sender := newTestingProposerAndSender(t)
+	liveness := nodeliveness.New("replicaID-1", sender)
 
 	rd := &rfpb.RangeDescriptor{
 		Start:   []byte("a"),
@@ -193,8 +193,8 @@ func TestAcquireAndReleaseMetaRange(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
 	defer cancel()
 
-	proposer := newTestingProposer(t)
-	liveness := nodeliveness.New("replicaID-2", proposer)
+	proposer, sender := newTestingProposerAndSender(t)
+	liveness := nodeliveness.New("replicaID-2", sender)
 
 	rd := &rfpb.RangeDescriptor{
 		Start:   keys.MinByte,
@@ -231,8 +231,8 @@ func TestMetaRangeLeaseKeepalive(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
 	defer cancel()
 
-	proposer := newTestingProposer(t)
-	liveness := nodeliveness.New("replicaID-3", proposer)
+	proposer, sender := newTestingProposerAndSender(t)
+	liveness := nodeliveness.New("replicaID-3", sender)
 
 	rd := &rfpb.RangeDescriptor{
 		Start:   keys.MinByte,
@@ -277,8 +277,8 @@ func TestNodeEpochInvalidation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
 	defer cancel()
 
-	proposer := newTestingProposer(t)
-	liveness := nodeliveness.New("replicaID-4", proposer)
+	proposer, sender := newTestingProposerAndSender(t)
+	liveness := nodeliveness.New("replicaID-4", sender)
 
 	rd := &rfpb.RangeDescriptor{
 		Start:   []byte("a"),

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -102,7 +102,7 @@ type Store struct {
 }
 
 func New(env environment.Env, rootDir string, nodeHost *dragonboat.NodeHost, gossipManager *gossip.GossipManager, sender *sender.Sender, registry registry.NodeRegistry, listener *listener.RaftListener, apiClient *client.APIClient, grpcAddress string, partitions []disk.Partition) (*Store, error) {
-	nodeLiveness := nodeliveness.New(nodeHost.ID(), nodeHost)
+	nodeLiveness := nodeliveness.New(nodeHost.ID(), sender)
 
 	nhLog := log.NamedSubLogger(nodeHost.ID())
 	eventsChan := make(chan events.Event, 100)


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#5406

I was too hasty; this works great in tests but not in real usage. Will fix in a different way.