### PR TITLE
Don't fail buildfix on gofmt errors

### DIFF
--- a/buildfix.sh
+++ b/buildfix.sh
@@ -40,7 +40,7 @@ echo "Building and running gofmt..."
 GO_SRCS=()
 while IFS= read -r line; do
     GO_SRCS+=("$line")
-done <<< "$(git ls-files '*.go')"
+done < <(git ls-files '*.go')
 bazel run "${BAZEL_QUIET_FLAGS[@]}" //:gofmt -- -w "${GO_SRCS[@]}"
 
 if which clang-format &>/dev/null; then

--- a/buildfix.sh
+++ b/buildfix.sh
@@ -37,7 +37,11 @@ echo "Formatting WORKSPACE/BUILD files..."
 buildifier -r .
 
 echo "Building and running gofmt..."
-bazel run "${BAZEL_QUIET_FLAGS[@]}" //:gofmt -- -w .
+gofmt_exit_code=$(bazel run "${BAZEL_QUIET_FLAGS[@]}" //:gofmt -- -w . || echo $?)
+
+if [ "$gofmt_exit_code" -ne 0 ]; then
+  echo "Error occurred during gofmt, but continuing..."
+fi
 
 if which clang-format &>/dev/null; then
   echo "Formatting .proto files..."

--- a/buildfix.sh
+++ b/buildfix.sh
@@ -37,11 +37,11 @@ echo "Formatting WORKSPACE/BUILD files..."
 buildifier -r .
 
 echo "Building and running gofmt..."
-gofmt_exit_code=$(bazel run "${BAZEL_QUIET_FLAGS[@]}" //:gofmt -- -w . || echo $?)
-
-if [ "$gofmt_exit_code" -ne 0 ]; then
-  echo "Error occurred during gofmt, but continuing..."
-fi
+GO_SRCS=()
+while IFS= read -r line; do
+    GO_SRCS+=("$line")
+done <<< "$(git ls-files '*.go')"
+bazel run "${BAZEL_QUIET_FLAGS[@]}" //:gofmt -- -w "${GO_SRCS[@]}"
 
 if which clang-format &>/dev/null; then
   echo "Formatting .proto files..."


### PR DESCRIPTION
Gofmt will sometimes fail on proto symlink errors. Don't fail the rest of the buildfix script in these cases.

**Related issues**: N/A
