### PR TITLE
Don't return a failure to github if no tests were found

### DIFF
--- a/server/build_event_protocol/build_status_reporter/build_status_reporter.go
+++ b/server/build_event_protocol/build_status_reporter/build_status_reporter.go
@@ -212,7 +212,7 @@ func (r *BuildStatusReporter) githubPayloadFromFinishedEvent(event *build_event_
 	if !startTime.IsZero() && endTime.After(startTime) {
 		description = fmt.Sprintf("%s in %s", description, timeutil.ShortFormatDuration(endTime.Sub(startTime)))
 	}
-	if finished.ExitCode.Code == 0 {
+	if finished.ExitCode.Code == 0 || finished.ExitCode.Name == "NO_TESTS_FOUND" {
 		return github.NewGithubStatusPayload(r.invocationLabel(), r.invocationURL(), description, github.SuccessState)
 	}
 


### PR DESCRIPTION
Doesn't really feel like it should be a failure (we do a weird hack internally where we create a dummy //:pass test to work around this currently).