### PR TITLE
[SS] Fix buckets for firecracker stage metrics

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2534,17 +2534,11 @@ func (c *FirecrackerContainer) observeStageDuration(ctx context.Context, taskSta
 		groupID = u.GetGroupID()
 	}
 
-	snapshotSharingStatus := "disabled"
-	if *snaputil.EnableLocalSnapshotSharing {
-		snapshotSharingStatus = "local_sharing_enabled"
-	}
-
 	metrics.FirecrackerStageDurationUsec.With(prometheus.Labels{
 		metrics.Stage:                    taskStage,
 		metrics.StatusHumanReadableLabel: taskStatus,
 		metrics.RecycledRunnerStatus:     recycleStatus,
 		metrics.GroupID:                  groupID,
-		metrics.SnapshotSharingStatus:    snapshotSharingStatus,
 	}).Observe(float64(durationUsec))
 }
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -986,14 +986,42 @@ var (
 		Namespace: bbNamespace,
 		Subsystem: "firecracker",
 		Name:      "stage_duration_usec",
-		Buckets:   durationUsecBuckets(1*time.Millisecond, 1*day, 10),
-		Help:      "The total duration of each firecracker stage, in microseconds",
+		Buckets: customDurationMsecBuckets([]time.Duration{
+			100 * time.Millisecond,
+			500 * time.Millisecond,
+			1 * time.Second,
+			3 * time.Second,
+			5 * time.Second,
+			10 * time.Second,
+			15 * time.Second,
+			20 * time.Second,
+			30 * time.Second,
+			45 * time.Second,
+			1 * time.Minute,
+			90 * time.Second,
+			2 * time.Minute,
+			3 * time.Minute,
+			5 * time.Minute,
+			8 * time.Minute,
+			15 * time.Minute,
+			30 * time.Minute,
+			45 * time.Minute,
+			1 * time.Hour,
+			3 * time.Hour,
+			5 * time.Hour,
+			8 * time.Hour,
+			15 * time.Hour,
+			24 * time.Hour,
+		}),
+		Help: "The total duration of each firecracker stage, in microseconds. " +
+			"NOTE: Remember that these durations represent the upper bounds of " +
+			"histogram buckets. Data points fall within pre-defined buckets," +
+			" and don't represent the actual duration of each event.",
 	}, []string{
 		Stage,
 		StatusHumanReadableLabel,
 		RecycledRunnerStatus,
 		GroupID,
-		SnapshotSharingStatus,
 	})
 
 	// #### Stage label values

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -987,8 +987,11 @@ var (
 		Subsystem: "firecracker",
 		Name:      "stage_duration_usec",
 		Buckets: customDurationMsecBuckets([]time.Duration{
+			25 * time.Millisecond,
+			50 * time.Millisecond,
 			100 * time.Millisecond,
 			500 * time.Millisecond,
+			750 * time.Millisecond,
 			1 * time.Second,
 			3 * time.Second,
 			5 * time.Second,


### PR DESCRIPTION
Oops! The previous buckets were (in minutes):  {0.0016, 0.016, 0.16, 1.6, 16.6, 166.6}, which explains why the graphs made workflows seem suspiciously slow and all taking around 16 min.

Add more granularity into the buckets, and also a reminder to the help section that the values in the graphs don't represent the actual durations, but upper bounds of buckets. 

Open to suggestions for better buckets. I'm assuming there will be a lot of variation in the duration of workflows between different customers.