### PR TITLE
Wait for leases when testing

### DIFF
--- a/enterprise/server/raft/rangelease/rangelease.go
+++ b/enterprise/server/raft/rangelease/rangelease.go
@@ -263,10 +263,6 @@ func (l *Lease) ensureValidLease(ctx context.Context, forceRenewal bool) (*rfpb.
 		}
 	}
 
-	if !alreadyValid {
-		l.log.Debugf("Acquired %s", l.string(l.rangeDescriptor, l.leaseRecord))
-	}
-
 	// We just renewed the lease. If there isn't already a background
 	// thread running to keep it renewed, start one now.
 	if l.stopped {

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -392,7 +392,7 @@ func (s *Store) updateUsages(r *replica.Replica) error {
 		return err
 	}
 	rangeID := usage.GetRangeId()
-	if !s.haveLease(rangeID) {
+	if !s.HaveLease(rangeID) {
 		s.usages.RemoveRange(rangeID)
 		return nil
 	}
@@ -535,11 +535,11 @@ func (s *Store) validatedRange(header *rfpb.Header) (*replica.Replica, *rfpb.Ran
 	return r, rd, nil
 }
 
-func (s *Store) haveLease(rangeID uint64) bool {
+func (s *Store) HaveLease(rangeID uint64) bool {
 	if r, err := s.GetReplica(rangeID); err == nil {
 		return s.leaseKeeper.HaveLease(r.ShardID)
 	}
-	s.log.Warningf("haveLease check for unheld range: %d", rangeID)
+	s.log.Warningf("HaveLease check for unheld range: %d", rangeID)
 	return false
 }
 
@@ -557,7 +557,7 @@ func (s *Store) LeasedRange(header *rfpb.Header) (*replica.Replica, error) {
 		return r, nil
 	}
 
-	if s.haveLease(header.GetRangeId()) {
+	if s.HaveLease(header.GetRangeId()) {
 		return r, nil
 	}
 	return nil, status.OutOfRangeErrorf("%s: no lease found for range: %d", constants.RangeLeaseInvalidMsg, header.GetRangeId())
@@ -1046,7 +1046,10 @@ func (s *Store) SplitRange(ctx context.Context, req *rfpb.SplitRangeRequest) (*r
 	if err := client.RunTxn(ctx, s.nodeHost, txn); err != nil {
 		return nil, err
 	}
-	return &rfpb.SplitRangeResponse{}, nil
+	return &rfpb.SplitRangeResponse{
+		Start: newSourceRange,
+		End:   destRange,
+	}, nil
 }
 
 func (s *Store) getLastAppliedIndex(header *rfpb.Header) (uint64, error) {

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -437,7 +437,7 @@ func TestSplitNonMetaRange(t *testing.T) {
 	require.NoError(t, err)
 
 	s := getStoreWithRangeLease(t, stores, 2)
-	rd := s1.GetRange(2)
+	rd := s.GetRange(2)
 	header := headerFromRangeDescriptor(rd)
 
 	// Attempting to Split an empty range will always fail. So write a
@@ -450,7 +450,7 @@ func TestSplitNonMetaRange(t *testing.T) {
 	require.NoError(t, err)
 
 	s = getStoreWithRangeLease(t, stores, 4)
-	rd = s1.GetRange(4)
+	rd = s.GetRange(4)
 	header = headerFromRangeDescriptor(rd)
 
 	// Expect that a new cluster was added with shardID = 4
@@ -528,7 +528,7 @@ func TestPostFactoSplit(t *testing.T) {
 	require.NoError(t, err)
 
 	s := getStoreWithRangeLease(t, stores, 2)
-	rd := s1.GetRange(2)
+	rd := s.GetRange(2)
 	header := headerFromRangeDescriptor(rd)
 
 	// Attempting to Split an empty range will always fail. So write a
@@ -623,7 +623,7 @@ func TestManySplits(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	waitForRangeLease(t, stores, 2)
+	s := getStoreWithRangeLease(t, stores, 2)
 
 	var written []*rfpb.FileRecord
 	for i := 0; i < 4; i++ {
@@ -646,9 +646,9 @@ func TestManySplits(t *testing.T) {
 			if shardID == 1 {
 				continue
 			}
-			rd := s1.GetRange(shardID)
+			rd := s.GetRange(shardID)
 			header := headerFromRangeDescriptor(rd)
-			rsp, err := s1.SplitRange(ctx, &rfpb.SplitRangeRequest{
+			rsp, err := s.SplitRange(ctx, &rfpb.SplitRangeRequest{
 				Header: header,
 				Range:  rd,
 			})


### PR DESCRIPTION
These changes have made the store tests more reliable:

```
tylerw@lunchbox:~/buildbuddy$ blaze test enterprise/server/raft/store:store_test  --cache_test_results=false  --config=remote --runs_per_test=100
INFO: Invocation ID: 34cf5647-2c2c-4935-a405-0577b5879a8d
INFO: Streaming build results to: https://buildbuddy.buildbuddy.io/invocation/34cf5647-2c2c-4935-a405-0577b5879a8d
INFO: Analyzed target //enterprise/server/raft/store:store_test (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //enterprise/server/raft/store:store_test up-to-date:
  bazel-bin/enterprise/server/raft/store/store_test_/store_test
INFO: Elapsed time: 53.755s, Critical Path: 39.96s
INFO: 806 processes: 1 internal, 805 remote.
//enterprise/server/raft/store:store_test                                PASSED in 30.8s
  Stats over 800 runs: max = 30.8s, min = 0.2s, avg = 2.3s, dev = 2.7s

Executed 1 out of 1 test: 1 test passes.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
INFO: Streaming build results to: https://buildbuddy.buildbuddy.io/invocation/34cf5647-2c2c-4935-a405-0577b5879a8d
INFO: Build completed successfully, 806 total actions
tylerw@lunchbox:~/buildbuddy$ blaze test enterprise/server/raft/store:store_test  --cache_test_results=false  --config=remote --runs_per_test=100
INFO: Invocation ID: 16a175cc-8cd8-4f97-a74f-7fb9c1a4c4c9
INFO: Streaming build results to: https://buildbuddy.buildbuddy.io/invocation/16a175cc-8cd8-4f97-a74f-7fb9c1a4c4c9
INFO: Analyzed target //enterprise/server/raft/store:store_test (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //enterprise/server/raft/store:store_test up-to-date:
  bazel-bin/enterprise/server/raft/store/store_test_/store_test
INFO: Elapsed time: 59.493s, Critical Path: 51.96s
INFO: 801 processes: 1 internal, 800 remote.
//enterprise/server/raft/store:store_test                                PASSED in 51.4s
  Stats over 800 runs: max = 51.4s, min = 0.2s, avg = 2.4s, dev = 3.4s

Executed 1 out of 1 test: 1 test passes.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
INFO: Streaming build results to: https://buildbuddy.buildbuddy.io/invocation/16a175cc-8cd8-4f97-a74f-7fb9c1a4c4c9
INFO: Build completed successfully, 801 total actions
tylerw@lunchbox:~/buildbuddy$
```