### PR TITLE
[BR] Upgrade bazel remote runner to use ubuntu 20.04 image

### DIFF
--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -8,6 +8,7 @@ go_library(
         "//cli/arg",
         "//cli/log",
         "//enterprise/server/remote_execution/dirtools",
+        "//enterprise/server/remote_execution/platform",
         "//proto:build_event_stream_go_proto",
         "//proto:buildbuddy_service_go_proto",
         "//proto:eventlog_go_proto",

--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -8,7 +8,6 @@ go_library(
         "//cli/arg",
         "//cli/log",
         "//enterprise/server/remote_execution/dirtools",
-        "//enterprise/server/remote_execution/platform",
         "//proto:build_event_stream_go_proto",
         "//proto:buildbuddy_service_go_proto",
         "//proto:eventlog_go_proto",

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -54,7 +54,7 @@ const (
 var (
 	execOs            = flag.String("os", "linux", "If set, requests execution on a specific OS.")
 	execArch          = flag.String("arch", "amd64", "If set, requests execution on a specific CPU architecture.")
-	runnerImage       = flag.String("runner_image", "", "If set, requests execution on a specific runner image. Otherwise uses the default hosted runner version.")
+	containerImage    = flag.String("container_image", "", "If set, requests execution on a specific runner image. Otherwise uses the default hosted runner version. A `docker://` prefix is required.")
 	defaultBranchRefs = []string{"refs/heads/main", "refs/heads/master"}
 )
 
@@ -524,7 +524,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 		BazelCommand:       strings.Join(bazelArgs, " "),
 		Os:                 reqOS,
 		Arch:               reqArch,
-		Image:              *runnerImage,
+		ContainerImage:     *containerImage,
 	}
 
 	req.GetRepoState().Patch = append(req.GetRepoState().Patch, repoConfig.Patches...)

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -19,7 +19,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/dirtools"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
@@ -50,12 +49,14 @@ const (
 	gitConfigSection           = "buildbuddy"
 	gitConfigRemoteBazelRemote = "remote-bazel-remote-name"
 	defaultRemoteExecutionURL  = "remote.buildbuddy.io"
+
+	Ubuntu20_04WorkflowsImage = "gcr.io/flame-public/rbe-ubuntu20-04-workflows@sha256:271e5e3704d861159c75b8dd6713dbe5a12272ec8ee73d17f89ed7be8026553f"
 )
 
 var (
 	execOs            = flag.String("os", "linux", "If set, requests execution on a specific OS.")
 	execArch          = flag.String("arch", "amd64", "If set, requests execution on a specific CPU architecture.")
-	runnerImage       = flag.String("runner_image", "docker://"+platform.Ubuntu20_04WorkflowsImage, "If set, requests execution on a specific runner image.")
+	runnerImage       = flag.String("runner_image", "docker://"+Ubuntu20_04WorkflowsImage, "If set, requests execution on a specific runner image.")
 	defaultBranchRefs = []string{"refs/heads/main", "refs/heads/master"}
 )
 
@@ -503,7 +504,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 		reqArch = *execArch
 	}
 
-	image := "docker://" + platform.Ubuntu20_04WorkflowsImage
+	image := "docker://" + Ubuntu20_04WorkflowsImage
 	if *runnerImage != "" {
 		image = *runnerImage
 	}

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/dirtools"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/cachetools"
@@ -54,6 +55,7 @@ const (
 var (
 	execOs            = flag.String("os", "linux", "If set, requests execution on a specific OS.")
 	execArch          = flag.String("arch", "amd64", "If set, requests execution on a specific CPU architecture.")
+	runnerImage       = flag.String("runner_image", "docker://"+platform.Ubuntu20_04WorkflowsImage, "If set, requests execution on a specific runner image.")
 	defaultBranchRefs = []string{"refs/heads/main", "refs/heads/master"}
 )
 
@@ -501,6 +503,11 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 		reqArch = *execArch
 	}
 
+	image := "docker://" + platform.Ubuntu20_04WorkflowsImage
+	if *runnerImage != "" {
+		image = *runnerImage
+	}
+
 	fetchOutputs := false
 	runOutput := false
 	bazelArgs := arg.GetBazelArgs(opts.Args)
@@ -523,6 +530,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 		BazelCommand:       strings.Join(bazelArgs, " "),
 		Os:                 reqOS,
 		Arch:               reqArch,
+		Image:              image,
 	}
 
 	req.GetRepoState().Patch = append(req.GetRepoState().Patch, repoConfig.Patches...)

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -49,14 +49,12 @@ const (
 	gitConfigSection           = "buildbuddy"
 	gitConfigRemoteBazelRemote = "remote-bazel-remote-name"
 	defaultRemoteExecutionURL  = "remote.buildbuddy.io"
-
-	Ubuntu20_04WorkflowsImage = "gcr.io/flame-public/rbe-ubuntu20-04-workflows@sha256:271e5e3704d861159c75b8dd6713dbe5a12272ec8ee73d17f89ed7be8026553f"
 )
 
 var (
 	execOs            = flag.String("os", "linux", "If set, requests execution on a specific OS.")
 	execArch          = flag.String("arch", "amd64", "If set, requests execution on a specific CPU architecture.")
-	runnerImage       = flag.String("runner_image", "docker://"+Ubuntu20_04WorkflowsImage, "If set, requests execution on a specific runner image.")
+	runnerImage       = flag.String("runner_image", "", "If set, requests execution on a specific runner image. Otherwise uses the default hosted runner version.")
 	defaultBranchRefs = []string{"refs/heads/main", "refs/heads/master"}
 )
 
@@ -504,11 +502,6 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 		reqArch = *execArch
 	}
 
-	image := "docker://" + Ubuntu20_04WorkflowsImage
-	if *runnerImage != "" {
-		image = *runnerImage
-	}
-
 	fetchOutputs := false
 	runOutput := false
 	bazelArgs := arg.GetBazelArgs(opts.Args)
@@ -531,7 +524,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 		BazelCommand:       strings.Join(bazelArgs, " "),
 		Os:                 reqOS,
 		Arch:               reqArch,
-		Image:              image,
+		Image:              *runnerImage,
 	}
 
 	req.GetRepoState().Patch = append(req.GetRepoState().Patch, repoConfig.Patches...)

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	runnerPath           = "enterprise/server/cmd/ci_runner/buildbuddy_ci_runner"
-	RunnerContainerImage = "docker://" + platform.Ubuntu18_04WorkflowsImage
+	RunnerContainerImage = "docker://" + platform.Ubuntu20_04WorkflowsImage
 )
 
 type runnerService struct {

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -34,8 +34,8 @@ import (
 )
 
 const (
-	runnerPath           = "enterprise/server/cmd/ci_runner/buildbuddy_ci_runner"
-	RunnerContainerImage = "docker://" + platform.Ubuntu20_04WorkflowsImage
+	runnerPath                  = "enterprise/server/cmd/ci_runner/buildbuddy_ci_runner"
+	DefaultRunnerContainerImage = "docker://" + platform.Ubuntu20_04WorkflowsImage
 )
 
 type runnerService struct {
@@ -163,6 +163,11 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		affinityKey = repoURL.String()
 	}
 
+	image := DefaultRunnerContainerImage
+	if req.GetImage() != "" {
+		image = req.GetImage()
+	}
+
 	// Hosted Bazel shares the same pool with workflows.
 	cmd := &repb.Command{
 		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
@@ -175,7 +180,7 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 			Properties: []*repb.Platform_Property{
 				{Name: "Pool", Value: r.env.GetWorkflowService().WorkflowsPoolName()},
 				{Name: platform.HostedBazelAffinityKeyPropertyName, Value: affinityKey},
-				{Name: "container-image", Value: RunnerContainerImage},
+				{Name: "container-image", Value: image},
 				{Name: "recycle-runner", Value: "true"},
 				{Name: "workload-isolation-type", Value: "firecracker"},
 				{Name: platform.EstimatedComputeUnitsPropertyName, Value: "2"},

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -164,8 +164,8 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 	}
 
 	image := DefaultRunnerContainerImage
-	if req.GetImage() != "" {
-		image = req.GetImage()
+	if req.GetContainerImage() != "" {
+		image = req.GetContainerImage()
 	}
 
 	// Hosted Bazel shares the same pool with workflows.

--- a/proto/runner.proto
+++ b/proto/runner.proto
@@ -83,6 +83,9 @@ message RunRequest {
 
   // If true, start the runner but do not wait for the action to be scheduled.
   bool async = 9;
+
+  // Container image to run on. Defaults to the Ubuntu 20.04 Workflows image.
+  string image = 10;
 }
 
 message RunResponse {

--- a/proto/runner.proto
+++ b/proto/runner.proto
@@ -85,7 +85,9 @@ message RunRequest {
   bool async = 9;
 
   // Container image to run on. Defaults to the Ubuntu 20.04 Workflows image.
-  string image = 10;
+  // A `docker://` prefix is required.
+  // Ex. `docker://gcr.io/flame-public/rbe-ubuntu20-04`
+  string container_image = 10;
 }
 
 message RunResponse {


### PR DESCRIPTION
Seeing `GLIBC_2.28' not found` build errors on the 18.04 image
