### PR TITLE
Upgrade executors to podman 4.8.0

### DIFF
--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y umoci iproute2 amazon-ecr-credential-he
 # Install podman and skopeo
 RUN echo 'deb https://downloadcontent.opensuse.org/repositories/home:/alvistack/Debian_11/ /' >> /etc/apt/sources.list.d/home:alvistack.list && \
     curl -fsSL https://download.opensuse.org/repositories/home:/alvistack/Debian_11/Release.key | gpg --dearmor >> /etc/apt/trusted.gpg.d/home_alvistack_debian11.gpg && \
-    apt-get update && apt-get -y upgrade && apt-get install -y podman=100:4.7.2-1 skopeo=100:1.13.3-1 && \
+    apt-get update && apt-get -y upgrade && apt-get install -y podman=100:4.8.0-1 skopeo=100:1.13.3-1 && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy podman registries configuration.

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -60,10 +60,11 @@ var (
 
 	pullTimeout = flag.Duration("executor.podman.pull_timeout", 10*time.Minute, "Timeout for image pulls.")
 
-	podmanRuntime     = flag.String("executor.podman.runtime", "", "Enables running podman with other runtimes, like gVisor (runsc).")
-	podmanEnableStats = flag.Bool("executor.podman.enable_stats", false, "Whether to enable cgroup-based podman stats.")
-	transientStore    = flag.Bool("executor.podman.transient_store", false, "Enables --transient-store for podman commands.", flag.Deprecated("--transient-store is now always applied if the podman version supports it"))
-	podmanDNS         = flag.String("executor.podman.dns", "8.8.8.8", "Specifies a custom DNS server for podman to use. Defaults to 8.8.8.8. If set to empty, no --dns= flag will be passed to podman.")
+	podmanRuntime       = flag.String("executor.podman.runtime", "", "Enables running podman with other runtimes, like gVisor (runsc).")
+	podmanStorageDriver = flag.String("executor.podman.storage_driver", "overlayfs", "The podman storage driver to use.")
+	podmanEnableStats   = flag.Bool("executor.podman.enable_stats", false, "Whether to enable cgroup-based podman stats.")
+	transientStore      = flag.Bool("executor.podman.transient_store", false, "Enables --transient-store for podman commands.", flag.Deprecated("--transient-store is now always applied if the podman version supports it"))
+	podmanDNS           = flag.String("executor.podman.dns", "8.8.8.8", "Specifies a custom DNS server for podman to use. Defaults to 8.8.8.8. If set to empty, no --dns= flag will be passed to podman.")
 
 	// Additional time used to kill the container if the command doesn't exit cleanly
 	containerFinalizationTimeout = 10 * time.Second
@@ -155,7 +156,7 @@ func NewProvider(env environment.Env, buildRoot string) (*Provider, error) {
 
 var getPodmanVersion = sync.OnceValues(func() (*semver.Version, error) {
 	var stdout, stderr bytes.Buffer
-	cmd := exec.Command("podman", "version", "--format={{.Client.Version}}")
+	cmd := exec.Command("podman", "version", fmt.Sprintf("--storage-driver=%s", *podmanStorageDriver), "--format={{.Client.Version}}")
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -763,6 +764,7 @@ func runPodman(ctx context.Context, subCommand string, stdio *commandutil.Stdio,
 		// See https://github.com/containers/podman/issues/19824
 		command = append(command, "--transient-store")
 	}
+	command = append(command, fmt.Sprintf("--storage-driver=%s", *podmanStorageDriver))
 	command = append(command, subCommand)
 	command = append(command, args...)
 	// Note: we don't collect stats on the podman process, and instead use

--- a/enterprise/server/test/integration/podman/BUILD
+++ b/enterprise/server/test/integration/podman/BUILD
@@ -19,7 +19,11 @@ go_test(
     # overlayfs.
     # TODO(go/b/2944): move to firecracker once
     # firecracker.enable_merged_rootfs works.
-    tags = ["bare"],
+    tags = [
+        "bare",
+        # TODO(go/b/2945): remove manual tag.
+        "manual",
+    ],
     target_compatible_with = ["@platforms//os:linux"],
     deps = [
         "//enterprise/server/remote_execution/commandutil",


### PR DESCRIPTION
The issue was a combination of: inconsistent selection of the storage-driver between our code and the podman code between the `podman version` (which has an empty storage driver) call and the first `podman image exists` call (which uses the overlayfs storage driver in dev), and a [bug](https://github.com/containers/podman/issues/20731) in the new sqlite database they're using. I expect this will be fixed in 4.8.1 or 4.8.2, but it's probably wise to explicitly specify the storage driver for all podman commands anyways.

I have aspirations to refactor our podman command-running logic and add some tests, but will save those for another PR.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/2932