### PR TITLE
Upgrade executor podman version to v4.8.0

### DIFF
--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y umoci iproute2 amazon-ecr-credential-he
 # Install podman and skopeo
 RUN echo 'deb https://downloadcontent.opensuse.org/repositories/home:/alvistack/Debian_11/ /' >> /etc/apt/sources.list.d/home:alvistack.list && \
     curl -fsSL https://download.opensuse.org/repositories/home:/alvistack/Debian_11/Release.key | gpg --dearmor >> /etc/apt/trusted.gpg.d/home_alvistack_debian11.gpg && \
-    apt-get update && apt-get -y upgrade && apt-get install -y podman=100:4.7.2-1 skopeo=100:1.13.3-1 && \
+    apt-get update && apt-get -y upgrade && apt-get install -y podman=100:4.8.0-1 skopeo=100:1.13.3-1 && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy podman registries configuration.

--- a/enterprise/server/test/integration/podman/BUILD
+++ b/enterprise/server/test/integration/podman/BUILD
@@ -19,7 +19,11 @@ go_test(
     # overlayfs.
     # TODO(go/b/2944): move to firecracker once
     # firecracker.enable_merged_rootfs works.
-    tags = ["bare"],
+    tags = [
+        "bare",
+        # TODO(go/b/2945): remove manual tag.
+        "manual",
+    ],
     target_compatible_with = ["@platforms//os:linux"],
     deps = [
         "//enterprise/server/remote_execution/commandutil",


### PR DESCRIPTION
The previous attempt (https://github.com/buildbuddy-io/buildbuddy/pull/5431) had the wrong default storage driver name ("overlayfs" instead of "overlay"): https://cloudlogging.app.goo.gl/hDFLo8hJBYnDC4do6

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/2932