### PR TITLE
style check tooling: minor fixes

### DIFF
--- a/buildfix.sh
+++ b/buildfix.sh
@@ -66,7 +66,7 @@ fi
 
 if ((GAZELLE)); then
   echo "Fixing BUILD deps with gazelle..."
-  CLI_VERSION="5.0.25" # Update this to latest version from `git tag -l 'cli-*' --sort=committerdate | tail -n1`
+  CLI_VERSION="5.0.25" # Update this to latest version from `git tag -l 'cli-*' --sort=creatordate | tail -n1`
   USE_BAZEL_VERSION="buildbuddy-io/$CLI_VERSION" bazel fix
 fi
 

--- a/buildfix.sh
+++ b/buildfix.sh
@@ -66,7 +66,7 @@ fi
 
 if ((GAZELLE)); then
   echo "Fixing BUILD deps with gazelle..."
-  CLI_VERSION="5.0.25" # Update this to latest version from `git lag -l | grep cli-`
+  CLI_VERSION="5.0.25" # Update this to latest version from `git tag -l 'cli-*' --sort=committerdate | tail -n1`
   USE_BAZEL_VERSION="buildbuddy-io/$CLI_VERSION" bazel fix
 fi
 

--- a/buildfix.sh
+++ b/buildfix.sh
@@ -66,7 +66,7 @@ fi
 
 if ((GAZELLE)); then
   echo "Fixing BUILD deps with gazelle..."
-  CLI_VERSION="5.0.21" # keep in sync with checkstyle.yaml
+  CLI_VERSION="5.0.25" # Update this to latest version from `git lag -l | grep cli-`
   USE_BAZEL_VERSION="buildbuddy-io/$CLI_VERSION" bazel fix
 fi
 

--- a/tools/fix_go_deps.sh
+++ b/tools/fix_go_deps.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 : "${GO_PATH:=}"
 : "${GAZELLE_PATH:=}"
 
-GAZELLE_COMMAND=(bazelisk run //:gazelle --)
+GAZELLE_COMMAND=(bazelisk run --build_metadata=DISABLE_COMMIT_STATUS_REPORTING=true //:gazelle --)
 if [[ "$GAZELLE_PATH" ]]; then
   GAZELLE_COMMAND=("$GAZELLE_PATH")
 fi


### PR DESCRIPTION
Upgrade our `bb` CLI used in ./buildfix.sh to latest version.

Also ensure that the `bazel run //:gazelle` does not show up as a
separate PR check in CI..
