### PR TITLE
Short circuit distributed writes without calling FindMissing.

### DIFF
--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -351,7 +351,7 @@ func (c *CacheProxy) Write(stream dcpb.DistributedCache_WriteServer) error {
 			return err
 		}
 		rn := getResource(req.GetResource(), req.GetIsolation(), req.GetKey())
-		if rn.GetCacheType() == rspb.CacheType_CAS && req.GetAllowAlreadyExists() {
+		if rn.GetCacheType() == rspb.CacheType_CAS && req.GetCheckAlreadyExists() {
 			missing, err := c.cache.FindMissing(ctx, []*rspb.ResourceName{rn})
 			if err == nil && len(missing) == 0 {
 				return status.AlreadyExistsError("CAS digest already exists")
@@ -593,7 +593,7 @@ func (wc *streamWriteCloser) Write(data []byte) (int, error) {
 		Key:                wc.key,
 		Data:               data,
 		FinishWrite:        false,
-		AllowAlreadyExists: true,
+		CheckAlreadyExists: true,
 		HandoffPeer:        wc.handoffPeer,
 		Resource:           wc.r,
 	}
@@ -621,7 +621,7 @@ func (wc *streamWriteCloser) Commit() error {
 		Isolation:          wc.isolation,
 		Key:                wc.key,
 		FinishWrite:        true,
-		AllowAlreadyExists: true,
+		CheckAlreadyExists: true,
 		HandoffPeer:        wc.handoffPeer,
 		Resource:           wc.r,
 	}

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -351,7 +351,7 @@ func (c *CacheProxy) Write(stream dcpb.DistributedCache_WriteServer) error {
 			return err
 		}
 		rn := getResource(req.GetResource(), req.GetIsolation(), req.GetKey())
-		if rn.GetCacheType() == rspb.CacheType_CAS {
+		if rn.GetCacheType() == rspb.CacheType_CAS && req.GetAllowAlreadyExists() {
 			missing, err := c.cache.FindMissing(ctx, []*rspb.ResourceName{rn})
 			if err == nil && len(missing) == 0 {
 				return status.AlreadyExistsError("CAS digest already exists")
@@ -593,6 +593,7 @@ func (wc *streamWriteCloser) Write(data []byte) (int, error) {
 		Key:         wc.key,
 		Data:        data,
 		FinishWrite: false,
+		AllowAlreadyExists: true,
 		HandoffPeer: wc.handoffPeer,
 		Resource:    wc.r,
 	}
@@ -620,6 +621,7 @@ func (wc *streamWriteCloser) Commit() error {
 		Isolation:   wc.isolation,
 		Key:         wc.key,
 		FinishWrite: true,
+		AllowAlreadyExists: true,
 		HandoffPeer: wc.handoffPeer,
 		Resource:    wc.r,
 	}

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -589,13 +589,13 @@ func (wc *streamWriteCloser) Write(data []byte) (int, error) {
 		return len(data), nil
 	}
 	req := &dcpb.WriteRequest{
-		Isolation:   wc.isolation,
-		Key:         wc.key,
-		Data:        data,
-		FinishWrite: false,
+		Isolation:          wc.isolation,
+		Key:                wc.key,
+		Data:               data,
+		FinishWrite:        false,
 		AllowAlreadyExists: true,
-		HandoffPeer: wc.handoffPeer,
-		Resource:    wc.r,
+		HandoffPeer:        wc.handoffPeer,
+		Resource:           wc.r,
 	}
 	err := wc.stream.Send(req)
 	if err == io.EOF {
@@ -618,12 +618,12 @@ func (wc *streamWriteCloser) Commit() error {
 	}
 
 	req := &dcpb.WriteRequest{
-		Isolation:   wc.isolation,
-		Key:         wc.key,
-		FinishWrite: true,
+		Isolation:          wc.isolation,
+		Key:                wc.key,
+		FinishWrite:        true,
 		AllowAlreadyExists: true,
-		HandoffPeer: wc.handoffPeer,
-		Resource:    wc.r,
+		HandoffPeer:        wc.handoffPeer,
+		Resource:           wc.r,
 	}
 	if err := wc.stream.Send(req); err != nil {
 		return err

--- a/enterprise/server/util/cacheproxy/cacheproxy_test.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy_test.go
@@ -36,9 +36,9 @@ import (
 const (
 	noHandoff = ""
 
-        // Keep under the limit of ~4MB (save 256KB).
-        // (Match the readBufSizeBytes in byte_stream_server.go)
-        readBufSizeBytes = (1024 * 1024 * 4) - (1024 * 256)
+	// Keep under the limit of ~4MB (save 256KB).
+	// (Match the readBufSizeBytes in byte_stream_server.go)
+	readBufSizeBytes = (1024 * 1024 * 4) - (1024 * 256)
 )
 
 var (

--- a/enterprise/server/util/cacheproxy/cacheproxy_test.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy_test.go
@@ -35,6 +35,10 @@ import (
 
 const (
 	noHandoff = ""
+
+        // Keep under the limit of ~4MB (save 256KB).
+        // (Match the readBufSizeBytes in byte_stream_server.go)
+        readBufSizeBytes = (1024 * 1024 * 4) - (1024 * 256)
 )
 
 var (
@@ -78,8 +82,13 @@ func waitUntilServerIsAlive(addr string) {
 }
 
 func copyAndClose(wc interfaces.CommittedWriteCloser, r io.Reader) error {
-	if _, err := io.Copy(wc, r); err != nil {
-		return err
+	for {
+		if _, err := io.CopyN(wc, r, readBufSizeBytes); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
 	}
 	if err := wc.Commit(); err != nil {
 		return err

--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -29,9 +29,11 @@ message ReadResponse {
   bytes data = 1;
 }
 
+// Next Tag: 9
 message WriteRequest {
   reserved 1;
   bool finish_write = 3;
+  bool allow_already_exists = 8;
   bytes data = 4;
   resource.ResourceName resource = 7;
 

--- a/proto/distributed_cache.proto
+++ b/proto/distributed_cache.proto
@@ -33,7 +33,10 @@ message ReadResponse {
 message WriteRequest {
   reserved 1;
   bool finish_write = 3;
-  bool allow_already_exists = 8;
+
+  // If check_already_exists, the server should return an ALREADY_EXISTS error
+  // for CAS blobs (not AC!) that already exist in the cache.
+  bool check_already_exists = 8;
   bytes data = 4;
   resource.ResourceName resource = 7;
 


### PR DESCRIPTION
When doing a new CAS write today, we're running 6 find-missing calls beforehand: 3 in bytestream (which calls cache.FindMissing) and 3 in cache_proxy, which does the same for CAS objects.

This CL removes the extra FindMissing calls happening in cacheproxy, and instead swallows the error if the server returns `ALREADY_EXISTS` for a CAS blob.

At the time I originally wrote this, I did not fully appreciate how many small writes we get, and thought preventing a large write was a good tradeoff. I no longer believe that: the extra cost of so many extra FindMissing calls is harmful, especially given the number of small writes we handle.