### PR TITLE
Fix zombie process reaping not keeping up

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -102,7 +102,7 @@ const (
 	//
 	// NOTE: this is part of the snapshot cache key, so bumping this version
 	// will make existing cached snapshots unusable.
-	GuestAPIVersion = "3"
+	GuestAPIVersion = "4"
 
 	// How long to wait when dialing the vmexec server inside the VM.
 	vSocketDialTimeout = 60 * time.Second

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -139,8 +139,8 @@ func TestGuestAPIVersion(t *testing.T) {
 	// Note that if you go with option 1, ALL VM snapshots will be invalidated
 	// which will negatively affect customer experience. Be careful!
 	const (
-		expectedHash    = "ce69b4a932a47c8763a4390171eee6fdb6191920eab50fafe29a72f7d496ce38"
-		expectedVersion = "3"
+		expectedHash    = "8d400293c54b55f326a03f60d8877d692cfddb98f57d7648b0e12f19c9827156"
+		expectedVersion = "4"
 	)
 	assert.Equal(t, expectedHash, firecracker.GuestAPIHash)
 	assert.Equal(t, expectedVersion, firecracker.GuestAPIVersion)


### PR DESCRIPTION
While doing some stress testing, the VM was consistently getting into a state where zombie processes would keep getting accumulated (i.e. never reaped, and kept building up even after VM restarts). Example output:

```
=== ZOMBIES ===
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root       849  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1036 12.6  0.0      0     0 ?        Zs   21:26   0:17 [java] <defunct>
root      1243  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1244  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1245  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1248  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1250  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1252  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1255  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1257  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1259  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1260  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1263  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1270  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1273  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1282  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1290  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
root      1294  0.0  0.0      0     0 ?        Z    21:26   0:00 [linux-sandbox] <defunct>
```

 Sometimes, Bazel would be one of these processes (e.g. the `java` process in that output), and we'd get stuck in that state where Bazel can't start because it's waiting for the previous server to go away.

Apparently, SIGCHLD signals can be coalesced. So our current approach of doing a single `wait4` syscall for each SIGCHLD doesn't necessarily work. Instead, we can call `wait4` in loop until it fails, then wait for the next SIGCHLD before we attempt to reap again. I tried this locally, and it made the zombie process issue go away.

**Related issues**: N/A
