### PR TITLE
Add docs for exported prometheus metrics for cloud users

### DIFF
--- a/docs/prometheus-metrics-for-cloud.mdx
+++ b/docs/prometheus-metrics-for-cloud.mdx
@@ -1,0 +1,33 @@
+---
+id: prometheus-metrics-for-cloud
+title: Prometheus Metrics For Cloud Users
+sidebar_label: Prometheus Metrics For Cloud
+---
+
+import Metrics from "../bazel-bin/enterprise/server/backends/prom/generate_docs/docs.mdx";
+
+
+For cloud users, BuildBuddy exposes [Prometheus](https://prometheus.io) metrics 
+to monitor and alert on their usage.
+
+In order to fetch Prometheus metrics, you can add the following [scrape config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) in
+your Prometheus configuration:
+```
+global:
+  scrape_interval: 30s
+scrape_configs
+  - job_name: buildbuddy
+    scheme: https
+    authorization:
+      type: "x-buildbuddy-api-key"
+      credentials: "<buildbuddy_api_key>"
+    metrics_path: "/api/v1/metrics"
+    static_configs:
+      - targets: ["app.buildbuddy.io"]
+```
+
+
+To view these metrics in a live-updating dashboard, we recommend using a tool
+like [Grafana](https://grafana.com).
+
+<Metrics />

--- a/docs/prometheus-metrics-on-prem.mdx
+++ b/docs/prometheus-metrics-on-prem.mdx
@@ -1,7 +1,7 @@
 ---
-id: prometheus-metrics
-title: Prometheus Metrics
-sidebar_label: Prometheus Metrics
+id: prometheus-metrics-on-prem
+title: Prometheus Metrics for On-prem Users
+sidebar_label: Prometheus Metrics On-prem
 ---
 
 import Metrics from "../bazel-bin/server/metrics/docs.mdx";

--- a/enterprise/server/backends/prom/generate_docs/BUILD
+++ b/enterprise/server/backends/prom/generate_docs/BUILD
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "generate_docs_lib",
+    srcs = ["generate_docs.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/prom/generate_docs",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//enterprise/server/backends/prom",
+        "@org_golang_x_text//cases",
+        "@org_golang_x_text//language",
+    ],
+)
+
+go_binary(
+    name = "generate_docs",
+    embed = [":generate_docs_lib"],
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "generate_mdx",
+    outs = ["docs.mdx"],
+    cmd_bash = """
+    ./$(location :generate_docs) -output_path="$@"
+    """,
+    tools = [
+        ":generate_docs",
+    ],
+    visibility = [
+        "//website:__pkg__",
+    ],
+)
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/backends/prom/generate_docs/generate_docs.go
+++ b/enterprise/server/backends/prom/generate_docs/generate_docs.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/prom"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+var (
+	outputPath = flag.String("output_path", "", "Path to generated markdown file")
+	labelFile  = flag.String("label_file", "", "Path to the file defining labels")
+)
+
+const docTemplateContents = "\n" +
+	"### ** `{{.Name}}`** ({{.Type}})\n" +
+	`{{.Help}}
+{{with .LabelNames}}
+#### Labels
+{{range .}}
+- **{{.}}**
+{{end}}
+{{end}}
+{{with .Examples}}
+#### Examples
+
+` + "```promql\n{{.}}\n```\n{{end}}"
+
+var docTemplate = template.Must(template.New("docs").Parse(docTemplateContents))
+
+func generateDoc(w io.Writer, m *prom.MetricConfig) error {
+	caser := cases.Title(language.English)
+
+	data := struct {
+		Name       string
+		Type       string
+		Help       string
+		LabelNames []string
+		Examples   string
+	}{
+		Name:       m.ExportedFamily.GetName(),
+		Type:       caser.String(strings.ToLower(m.ExportedFamily.GetType().String())),
+		Help:       m.ExportedFamily.GetHelp(),
+		LabelNames: m.LabelNames,
+		Examples:   m.Examples,
+	}
+
+	return docTemplate.Execute(w, data)
+}
+
+func main() {
+	flag.Parse()
+
+	f, err := os.Create(*outputPath)
+	defer f.Close()
+	if err != nil {
+		fmt.Printf("failed to create file %q %s\n", *outputPath, err)
+		return
+	}
+	for _, m := range prom.MetricConfigs {
+		generateDoc(f, m)
+	}
+}

--- a/website/BUILD.bazel
+++ b/website/BUILD.bazel
@@ -13,6 +13,7 @@ SRCS = glob([
     "//server/cmd/buildbuddy/yaml_doc:generate_mdx",
     "//server/metrics:generate_mdx",
     "//enterprise/server/cmd/server/yaml_doc:generate_mdx",
+    "//enterprise/server/backends/prom/generate_docs:generate_mdx",
     "//enterprise/server/cmd/executor/yaml_doc:generate_mdx",
 ]
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -24,7 +24,10 @@ module.exports = {
       "enterprise-mac-rbe",
       "enterprise-api",
     ],
-    Monitoring: ["prometheus-metrics"],
+    Monitoring: [
+	  "prometheus-metrics-on-prem",
+	  "prometheus-metrics-for-cloud"
+	],
     Architecture: [
       "architecture-overview",
       "architecture-data-storage",


### PR DESCRIPTION
1. I added a doc for prometheus metrics for cloud users that includes
   - how to set up the scrape config on prometheus,
   - the exported metrics and how they can be used.
2. Add a tool to auto-generate docs for metrics defined in prom.go
  - Most of the format should be similar to generate_docs.py. However,
    I didn't exported comments for the labels b/c they are defined in
    metrics.go and it's quite difficult to parse the label comments.
  - I added a field MetricConfig for examples.
3. I renamed the existing prometheus-metrics doc to "Prometheus Metrics
   On-prem" to differienate it with the new doc I added.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
