### PR TITLE
Fix VM not being removed if Unpause fails during Create

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -205,7 +205,9 @@ type CommandContainer interface {
 	// Pause freezes a container so that it no longer consumes CPU resources.
 	Pause(ctx context.Context) error
 	// Remove kills any processes currently running inside the container and
-	// removes any resources associated with the container itself.
+	// removes any resources associated with the container itself. It is safe to
+	// call remove if Create has not been called. If Create has been called but
+	// failed, then Remove should remove any created resources if applicable.
 	Remove(ctx context.Context) error
 
 	// Stats returns the current resource usage of this container.

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -79,6 +79,7 @@ go_test(
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/remote_execution/workspace",
         "//enterprise/server/tasksize",
+        "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
         "//proto:runner_go_proto",
         "//proto:worker_go_proto",


### PR DESCRIPTION
Problem:
- [Here](https://github.com/buildbuddy-io/buildbuddy/blob/2fc2e2243e8a619474564995de6319341cd32fab/enterprise/server/remote_execution/runner/runner.go#L360-L365) `runner.Run()` calls `Create()`, then transitions the runner from `s.initial` => `s.ready` state _only if Create succeeds_
- When `Create()` fails, we wind up calling `TryRecycle` which should call `finalize()` then `Remove()` [here](https://github.com/buildbuddy-io/buildbuddy/blob/2fc2e2243e8a619474564995de6319341cd32fab/enterprise/server/remote_execution/runner/runner.go#L1347) since the task did not finish cleanly
- But [here](https://github.com/buildbuddy-io/buildbuddy/blob/2fc2e2243e8a619474564995de6319341cd32fab/enterprise/server/remote_execution/runner/runner.go#L427) we explicitly don't call `Remove()` if the state is still `initial`.
- This is particularly problematic for Firecracker snapshotting/copy-on-write, because we now call `Unpause()` during `Create()`, which is more likely to fail than just creating a new VM from scratch. If `Unpause()` fails, then the VM can be running, but we just failed to connect to it. Since we're never removing the VM, it stays running ~indefinitely.

Solution:
- Update the runner pool to call `Remove()` even if the container is in `initial` state.
- Clarify in the contract of `container.Remove` that it should work even if the container has not been fully created.
  - Verified that docker / podman adhere to this contract (they might attempt to do some `remove` operations which will fail but that's fine)

**Related issues**: N/A
