### PR TITLE
Fix vmstart remote snapshot fetching

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -82,6 +82,7 @@ var dieOnFirecrackerFailure = flag.Bool("executor.die_on_firecracker_failure", f
 var workspaceDiskSlackSpaceMB = flag.Int64("executor.firecracker_workspace_disk_slack_space_mb", 2_000, "Extra space to allocate to firecracker workspace disks, in megabytes. ** Experimental **")
 var healthCheckInterval = flag.Duration("executor.firecracker_health_check_interval", 10*time.Second, "How often to run VM health checks while tasks are executing.")
 var healthCheckTimeout = flag.Duration("executor.firecracker_health_check_timeout", 30*time.Second, "Timeout for VM health check requests.")
+var forceRemoteSnapshotting = flag.Bool("debug_force_remote_snapshots", false, "When remote snapshotting is enabled, force remote snapshotting even for tasks which otherwise wouldn't support it.")
 
 //go:embed guest_api_hash.sha256
 var GuestAPIHash string
@@ -571,7 +572,7 @@ func NewContainer(ctx context.Context, env environment.Env, task *repb.Execution
 		c.vmIdx = opts.ForceVMIdx
 	}
 
-	c.supportsRemoteSnapshots = platform.IsCIRunner(task.GetCommand().GetArguments()) && *snaputil.EnableRemoteSnapshotSharing
+	c.supportsRemoteSnapshots = *snaputil.EnableRemoteSnapshotSharing && (platform.IsCIRunner(task.GetCommand().GetArguments()) || *forceRemoteSnapshotting)
 
 	if opts.SavedState == nil {
 		c.vmConfig.DebugMode = *debugTerminal

--- a/enterprise/tools/vmstart/vmstart.go
+++ b/enterprise/tools/vmstart/vmstart.go
@@ -216,7 +216,10 @@ func run(ctx context.Context, env environment.Env) error {
 
 	var c *firecracker.FirecrackerContainer
 	if *remoteSnapshotKeyJSON != "" {
-		// Runner recycling is needed to allow starting from snapshot.
+		// Force remote snapshotting to make sure we consult the remote cache
+		// instead of just local filecache.
+		flagutil.SetValueForFlagName("debug_force_remote_snapshots", true, nil, false)
+		// Runner recycling is also needed to allow starting from snapshot.
 		p, err := rexec.MakePlatform("recycle-runner=true")
 		if err != nil {
 			return status.WrapError(err, "make platform")


### PR DESCRIPTION
- Add a flag to make it easier to test remote snapshotting with ad-hoc actions (I've been having to hard-code `supportsRemoteSnapshots` to true, because now we check arg0 == ./buildbuddy_ci_runner instead of checking workflow ID - with workflow ID I could fake it a bit more easily)
- Set this flag to true in `vmstart` to fix remote snapshot fetching.

**Related issues**: N/A
