### PR TITLE
Redirect to current URL after Github login

### DIFF
--- a/enterprise/app/login/login.tsx
+++ b/enterprise/app/login/login.tsx
@@ -83,7 +83,9 @@ export default class LoginComponent extends React.Component<Props, State> {
   }
 
   handleGithubClicked() {
-    const url = "/login/github/";
+    const url = `/login/github/?${new URLSearchParams({
+      redirect_url: window.location.href,
+    })}`;
     if (capabilities.config.popupAuthEnabled) {
       popup
         .open(url)


### PR DESCRIPTION
This fixes an issue where we can't post messages between pages on different subdomains when doing a GitHub login from an org-specific subdomain. We already do this for non-GitHub logins.