### PR TITLE
Handle grpc stream EOFs correctly

### DIFF
--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -627,7 +627,7 @@ func (wc *streamWriteCloser) Commit() error {
 	}
 	sendErr := wc.stream.Send(req)
 	if sendErr != nil && sendErr != io.EOF {
-		return err
+		return sendErr
 	}
 	_, err := wc.stream.CloseAndRecv()
 	if status.IsAlreadyExistsError(err) {

--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -625,12 +625,16 @@ func (wc *streamWriteCloser) Commit() error {
 		HandoffPeer:        wc.handoffPeer,
 		Resource:           wc.r,
 	}
-	if err := wc.stream.Send(req); err != nil {
+	sendErr := wc.stream.Send(req)
+	if sendErr != nil && sendErr != io.EOF {
 		return err
 	}
 	_, err := wc.stream.CloseAndRecv()
 	if status.IsAlreadyExistsError(err) {
 		return nil
+	}
+	if sendErr != nil {
+		return sendErr
 	}
 	return err
 }


### PR DESCRIPTION
Streams are async so the Send in Write might not return an EOF even tho an ALREADY_EXISTS error has been returned. 

In that case the EOF can be hit in Commit(), so if that happens, attempt to call CloseAndRecv to check for an ALREADY_EXISTS before returning any error.