### PR TITLE
Don't pull image when resuming from rootfs snapshot

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2176,6 +2176,12 @@ func (c *FirecrackerContainer) PullImage(ctx context.Context, creds oci.Credenti
 	}
 	c.pulled = true
 
+	// If we're creating from a snapshot, we don't need to pull the base image
+	// since the rootfs image contains our full desired disk contents.
+	if c.createFromSnapshot && *EnableRootfs {
+		return nil
+	}
+
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 


### PR DESCRIPTION
This is mostly to make the logs a bit less confusing, but is also a minor optimization. I found it surprising/confusing that we were pulling the base containerfs snapshot when resuming from a rootfs snapshot, which should have the full disk contents that we need.

**Related issues**: N/A
