### PR TITLE
Fix containerfs snapshot chunks missing in snapshot

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1086,7 +1086,7 @@ func (c *FirecrackerContainer) initRootfsStore(ctx context.Context) error {
 		return status.InternalErrorf("failed to create rootfs chunk dir: %s", err)
 	}
 	containerExt4Path := filepath.Join(c.getChroot(), containerFSName)
-	cf, err := snaploader.UnpackContainerImage(c.vmCtx, c.loader, c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes())
+	cf, err := snaploader.UnpackContainerImage(c.vmCtx, c.loader, c.snapshotKeySet.GetBranchKey().GetInstanceName(), c.containerImage, containerExt4Path, cowChunkDir, cowChunkSizeBytes())
 	if err != nil {
 		return status.WrapError(err, "unpack container image")
 	}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -785,6 +785,81 @@ func TestFirecracker_RemoteSnapshotSharing(t *testing.T) {
 	require.Equal(t, "Base\nFork remote fetch\n", string(res.Stdout))
 }
 
+func TestFirecracker_RemoteSnapshotSharing_RemoteInstanceName(t *testing.T) {
+	if !*snaputil.EnableRemoteSnapshotSharing {
+		t.Skip("Snapshot sharing is not enabled")
+	}
+
+	ctx := context.Background()
+	env := getTestEnv(ctx, t, envOpts{})
+	cfg := getExecutorConfig(t)
+	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
+
+	// Set up a task with remote snapshot sharing enabled.
+	task := &repb.ExecutionTask{
+		ExecuteRequest: &repb.ExecuteRequest{
+			InstanceName: "",
+		},
+		Command: &repb.Command{
+			// Enable remote snapshotting
+			Arguments: []string{"./buildbuddy_ci_runner"},
+			Platform: &repb.Platform{Properties: []*repb.Platform_Property{
+				{Name: "recycle-runner", Value: "true"},
+			}},
+		},
+	}
+	workdir := testfs.MakeTempDir(t)
+	opts := firecracker.ContainerOpts{
+		ExecutorConfig: cfg,
+		// The image name here matters - the issue which originally prompted
+		// this test didn't reproduce on busybox, likely because the image is
+		// smaller and disk chunks were more likely to be dirtied.
+		ContainerImage: platform.Ubuntu20_04WorkflowsImage,
+		VMConfiguration: &fcpb.VMConfiguration{
+			NumCpus:           1,
+			MemSizeMb:         minMemSizeMB,
+			ScratchDiskSizeMb: 100,
+		},
+		ActionWorkingDirectory: workdir,
+	}
+
+	// This command just increments the current value in a counter file
+	// "/root/attempts" (if missing, defaults to 0), then prints the new value.
+	cmd := &repb.Command{Arguments: []string{"sh", "-c", `
+cd /root
+ATTEMPT_NUMBER=$(cat ./attempts 2>/dev/null || echo 0)
+ATTEMPT_NUMBER=$(( ATTEMPT_NUMBER + 1 ))
+printf '%s' $ATTEMPT_NUMBER | tee ./attempts
+`}}
+
+	run := func(instanceName string, expectedLogs string) {
+		log.Debugf("\n\n\n=== run: instance=%q expectedLogs=%q ===", instanceName, expectedLogs)
+
+		task.ExecuteRequest.InstanceName = instanceName
+		c, err := firecracker.NewContainer(ctx, env, task, opts)
+		require.NoError(t, err)
+		container.PullImageIfNecessary(ctx, env, c, oci.Credentials{}, opts.ContainerImage)
+		err = c.Create(ctx, workdir)
+		require.NoError(t, err)
+		res := c.Exec(ctx, cmd, nil)
+		// Make sure we pause before doing any other assertions,
+		// since this also cleans up the VM.
+		{
+			err = c.Pause(ctx)
+			require.NoError(t, err)
+		}
+		require.Empty(t, string(res.Stderr))
+		require.Equal(t, 0, res.ExitCode)
+		require.NoError(t, res.Error)
+		assert.Equal(t, expectedLogs, string(res.Stdout))
+		log.Debugf("=== output: %q ===", string(res.Stdout))
+	}
+
+	run("", "1")  // Should start clean
+	run("A", "1") // New instance name "A"; should start clean
+	run("A", "2") // Should resume from previous, and increment the counter
+}
+
 func TestFirecrackerSnapshotVersioning(t *testing.T) {
 	if !*snaputil.EnableLocalSnapshotSharing {
 		t.SkipNow()

--- a/enterprise/server/remote_execution/snaputil/snaputil.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -50,6 +51,23 @@ const (
 	ChunkSourceRemoteCache
 )
 
+func (s ChunkSource) String() string {
+	switch s {
+	case ChunkSourceUnmapped:
+		return "Unmapped"
+	case ChunkSourceHole:
+		return "Hole"
+	case ChunkSourceLocalFile:
+		return "LocalFile"
+	case ChunkSourceLocalFilecache:
+		return "LocalFilecache"
+	case ChunkSourceRemoteCache:
+		return "RemoteCache"
+	default:
+		return ""
+	}
+}
+
 func GetArtifact(ctx context.Context, localCache interfaces.FileCache, bsClient bytestream.ByteStreamClient, remoteEnabled bool, d *repb.Digest, instanceName string, outputPath string) (ChunkSource, error) {
 	node := &repb.FileNode{Digest: d}
 	fetchedLocally := localCache.FastLinkFile(ctx, node, outputPath)
@@ -63,7 +81,7 @@ func GetArtifact(ctx context.Context, localCache interfaces.FileCache, bsClient 
 
 	if *VerboseLogging {
 		start := time.Now()
-		log.CtxDebugf(ctx, "Fetching remote snapshot artifact...")
+		log.CtxDebugf(ctx, "Fetching snapshot artifact: instance=%q file=%s hash=%s", instanceName, StripChroot(outputPath), d.GetHash())
 		defer func() { log.CtxDebugf(ctx, "Fetched remote snapshot artifact in %s", time.Since(start)) }()
 	}
 
@@ -115,7 +133,7 @@ func Cache(ctx context.Context, localCache interfaces.FileCache, bsClient bytest
 
 	if *VerboseLogging {
 		start := time.Now()
-		log.CtxDebugf(ctx, "Uploading snapshot artifact...")
+		log.CtxDebugf(ctx, "Uploading snapshot artifact: instance=%q file=%s hash=%s", remoteInstanceName, StripChroot(path), d.GetHash())
 		defer func() { log.CtxDebugf(ctx, "Uploaded snapshot artifact in %s", time.Since(start)) }()
 	}
 
@@ -149,6 +167,15 @@ func CacheBytes(ctx context.Context, localCache interfaces.FileCache, bsClient b
 	}()
 
 	return Cache(ctx, localCache, bsClient, remoteEnabled, d, remoteInstanceName, tmpPath)
+}
+
+var chrootPrefix = regexp.MustCompile("^.*/firecracker/[^/]+/root/")
+
+// StripChroot removes the jailer chroot directory from a given snapshot
+// artifact path. Intended only for debugging purposes (to make paths more
+// readable).
+func StripChroot(path string) string {
+	return chrootPrefix.ReplaceAllLiteralString(path, "")
 }
 
 // cacheLocally copies the data at `path` to the local filecache with


### PR DESCRIPTION
We were noticing an issue that we'd unexpectedly fail to fetch certain snapshot chunks, particularly from the rootfs. This PR adds a test that reproduces the issue and also fixes the issue.

To understand the issue, here are the logs relevant to just the file that is missing from the snapshot that we expect to fetch:

```
=== run: instance="" expectedLogs="1" ===
Uploading snapshot artifact: instance="" file=rootfs/151552000 hash=780a5fa563249d8182133e1fd3d0cfc0a4f14b23d216e0c26d7dd49ea4e6364e
Uploading snapshot artifact: instance="" file=rootfs/151552000 hash=780a5fa563249d8182133e1fd3d0cfc0a4f14b23d216e0c26d7dd49ea4e6364e
=== output: "1" ===
=== run: instance="A" expectedLogs="1" ===
Not caching snapshot artifact: dirty=false src=unmapped file=rootfs/rootfs.ext4 hash=780a5fa563249d8182133e1fd3d0cfc0a4f14b23d216e0c26d7dd49ea4e6364e
=== output: "1" ===
=== run: instance="A" expectedLogs="2" ===
Failed to fetch remote snapshot manifest: rpc error: code = NotFound desc = ActionResult (hash:"2bb19e330adba4175fcfba6881e5a9e306bde613c970f3bdce5f44dad7bcb0e9"  size_bytes:1) not found: rpc error: code = NotFound desc = ActionResult output file: 'hash:"780a5fa563249d8182133e1fd3d0cfc0a4f14b23d216e0c26d7dd49ea4e6364e"  size_bytes:4096000' not found in cache
Failed to get VM snapshot: rpc error: code = NotFound desc = fetch remote manifest: rpc error: code = NotFound desc = ActionResult (hash:"2bb19e330adba4175fcfba6881e5a9e306bde613c970f3bdce5f44dad7bcb0e9"  size_bytes:1) not found: rpc error: code = NotFound desc = ActionResult output file: 'hash:"780a5fa563249d8182133e1fd3d0cfc0a4f14b23d216e0c26d7dd49ea4e6364e"  size_bytes:4096000' not found in cache
Not caching snapshot artifact: dirty=false src=unmapped file=rootfs/rootfs.ext4 hash=780a5fa563249d8182133e1fd3d0cfc0a4f14b23d216e0c26d7dd49ea4e6364e
=== output: "1" ===
```

Summarizing:
- Run 1, instance="" : we upload that containerfs chunk, but with instance="".
- Run 2, instance="A" : we fail to fetch a snapshot, because this is a new instance name. We download that containerfs snapshot, because we're hard-coding instance="", and we should have uploaded it in Run 1. However, when saving the snapshot don't upload some chunks back to cache, in particular when dirty=false and src=unmapped (i.e. we never accessed the chunk). So that chunk now does not exist in cache with instance_name="A"
- Run 3, instance="A" : when we try to fetch the snapshot, it fails, because we never uploaded that chunk for instance_name="A".

So the fix in this PR is to plumb the instance name through UnpackContainerImage , so that "Run 2" doesn't get a cache hit for the chunks from Run 1 and incorrectly think that it doesn't need to upload them back to instance name "A". The downside is that we'll have to re-chunk and-reupload the image whenever the instance name changes, but I think this isn't too bad

**Related issues**: N/A
