### PR TITLE
Enable grpc encoder with pooling

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -2117,8 +2117,8 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     go_repository(
         name = "com_github_golang_glog",
         importpath = "github.com/golang/glog",
-        sum = "h1:DVjP2PbBOzHyzA+dn3WhHIq4NdVu3Q+pvivFICf/7fo=",
-        version = "v1.1.2",
+        sum = "h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=",
+        version = "v1.1.0",
     )
     go_repository(
         name = "com_github_golang_groupcache",
@@ -6379,8 +6379,9 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
         # server gracefully, it's safe for us to allow gRPC to wait for all
         # ongoing requests to finish.
         patches = ["@{}//buildpatches:org_golang_google_grpc_remove_drain_panic.patch".format(workspace_name)],
-        sum = "h1:Z5Iec2pjwb+LEOqzpB2MR12/eKFhDPhuqW91O+4bwUk=",
-        version = "v1.59.0",
+        replace = "github.com/buildbuddy-io/grpc-go",
+        sum = "h1:iveMKv2sUWZ+ok88rGpK51nowFGasqF/M0oW6VQ1Erw=",
+        version = "v1.59.0-rc",
     )
     go_repository(
         name = "org_golang_google_grpc_cmd_protoc_gen_go_grpc",

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ replace (
 	github.com/jotfs/fastcdc-go v0.2.0 => github.com/buildbuddy-io/fastcdc-go v0.2.0-rc2
 	github.com/lni/dragonboat/v4 => github.com/tylerwilliams/dragonboat/v4 v4.0.0-pre1
 	github.com/throttled/throttled/v2 => github.com/buildbuddy-io/throttled/v2 v2.9.1-rc2
+	google.golang.org/grpc v1.59.0 => github.com/buildbuddy-io/grpc-go v1.59.0-rc
 )
 
 require (

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -229,6 +229,7 @@ func CommonGRPCServerOptions(env environment.Env) []grpc.ServerOption {
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
 		grpc.RecvBufferPool(grpc.NewSharedBufferPool()),
 		grpc.MaxRecvMsgSize(*gRPCMaxRecvMsgSizeBytes),
+		grpc.ServerEncoderBufferPool(grpc.NewSharedBufferPool()),
 		KeepaliveEnforcementPolicy(),
 	}
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

Benchmark distributed read: (The test is added in PR https://github.com/buildbuddy-io/buildbuddy/pull/5487)
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor            
                    │ /home/lulu/benchmark-distributed-read-bs.log │ /home/lulu/benchmark-distributed-read-marshal-pool.log │
                    │                    sec/op                    │             sec/op               vs base               │
Read/digest128B-24                                     171.9µ ± 3%                       173.0µ ± 4%       ~ (p=0.796 n=10)
Read/digest16KiB-24                                    237.6µ ± 5%                       236.3µ ± 5%       ~ (p=0.165 n=10)
Read/digest16MiB-24                                    31.01m ± 5%                       29.35m ± 4%  -5.35% (p=0.005 n=10)
geomean                                                1.082m                            1.063m       -1.79%

                    │ /home/lulu/benchmark-distributed-read-bs.log │ /home/lulu/benchmark-distributed-read-marshal-pool.log │
                    │                     B/op                     │              B/op               vs base                │
Read/digest128B-24                                    52.35Ki ± 2%                    52.43Ki ±  2%        ~ (p=0.631 n=10)
Read/digest16KiB-24                                   86.58Ki ± 2%                    69.04Ki ±  2%  -20.26% (p=0.000 n=10)
Read/digest16MiB-24                                   38.93Mi ± 4%                    32.62Mi ± 12%  -16.21% (p=0.000 n=10)
geomean                                               565.3Ki                         494.5Ki        -12.53%

                    │ /home/lulu/benchmark-distributed-read-bs.log │ /home/lulu/benchmark-distributed-read-marshal-pool.log │
                    │                  allocs/op                   │            allocs/op             vs base               │
Read/digest128B-24                                      354.0 ± 0%                        356.0 ± 0%  +0.56% (p=0.000 n=10)
Read/digest16KiB-24                                     361.5 ± 0%                        364.0 ± 1%  +0.69% (p=0.000 n=10)
Read/digest16MiB-24                                    2.002k ± 5%                       2.018k ± 7%       ~ (p=0.481 n=10)
geomean                                                 635.1                             639.5       +0.69%
```
