### PR TITLE
cli: bump open file limit for all commands

### DIFF
--- a/cli/cmd/bb/BUILD
+++ b/cli/cmd/bb/BUILD
@@ -34,6 +34,7 @@ go_library(
         "//cli/upload",
         "//cli/version",
         "//cli/watcher",
+        "//server/util/rlimit",
         "//server/util/status",
     ],
 )

--- a/cli/cmd/bb/bb.go
+++ b/cli/cmd/bb/bb.go
@@ -29,6 +29,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/upload"
 	"github.com/buildbuddy-io/buildbuddy/cli/version"
 	"github.com/buildbuddy-io/buildbuddy/cli/watcher"
+	"github.com/buildbuddy-io/buildbuddy/server/util/rlimit"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	sidecarmain "github.com/buildbuddy-io/buildbuddy/cli/cmd/sidecar"
@@ -63,6 +64,11 @@ func run() (exitCode int, err error) {
 	log.Debugf("env: BB_USE_BAZEL_VERSION=%s", os.Getenv("BB_USE_BAZEL_VERSION"))
 
 	bazelisk.ResolveVersion()
+
+	err = rlimit.MaxRLimit()
+	if err != nil {
+		log.Printf("Failed to bump open file limits: %s", err)
+	}
 
 	// Make sure startup args are always in the format --foo=bar.
 	args, err = parser.CanonicalizeStartupArgs(args)

--- a/cli/watcher/BUILD
+++ b/cli/watcher/BUILD
@@ -8,7 +8,6 @@ go_library(
         "//cli/arg",
         "//cli/log",
         "//cli/workspace",
-        "//server/util/rlimit",
         "//server/util/status",
         "@com_github_bduffany_godemon//:godemon",
         "@com_github_google_shlex//:shlex",

--- a/cli/watcher/watcher.go
+++ b/cli/watcher/watcher.go
@@ -9,7 +9,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
-	"github.com/buildbuddy-io/buildbuddy/server/util/rlimit"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/google/shlex"
 )
@@ -30,11 +29,6 @@ func Watch() (exitCode int, err error) {
 		return -1, nil
 	}
 	args = append(args[:idx], args[idx+1:]...)
-
-	err = rlimit.MaxRLimit()
-	if err != nil {
-		log.Printf("Failed to bump open file limits: %s", err)
-	}
 
 	// Allow specifying --watcher_flags to forward args to the watcher.
 	// Mostly useful for debugging, e.g. --watcher_flags='--verbose'


### PR DESCRIPTION
Previously we only bump open file limit for `bb watch`.

Let's apply it to every commands.

Close #5465.
