### PR TITLE
Collect VM stats when command terminates

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -103,7 +103,7 @@ const (
 	//
 	// NOTE: this is part of the snapshot cache key, so bumping this version
 	// will make existing cached snapshots unusable.
-	GuestAPIVersion = "4"
+	GuestAPIVersion = "5"
 
 	// How long to wait when dialing the vmexec server inside the VM.
 	vSocketDialTimeout = 60 * time.Second

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -139,8 +139,8 @@ func TestGuestAPIVersion(t *testing.T) {
 	// Note that if you go with option 1, ALL VM snapshots will be invalidated
 	// which will negatively affect customer experience. Be careful!
 	const (
-		expectedHash    = "8d400293c54b55f326a03f60d8877d692cfddb98f57d7648b0e12f19c9827156"
-		expectedVersion = "4"
+		expectedHash    = "dba052af79775a1d586dfcd32c4b841a4ccb363139bf8469c5706a66d91700f4"
+		expectedVersion = "5"
 	)
 	assert.Equal(t, expectedHash, firecracker.GuestAPIHash)
 	assert.Equal(t, expectedVersion, firecracker.GuestAPIVersion)

--- a/enterprise/server/vmexec/vmexec.go
+++ b/enterprise/server/vmexec/vmexec.go
@@ -347,10 +347,11 @@ func (c *command) Run(ctx context.Context, msgs chan *message) (*vmxpb.ExecStrea
 	go func() {
 		defer close(statsDone)
 		delay := initialStatsPollInterval
-		for {
+		for done := false; !done; {
 			select {
 			case <-commandDone:
-				return
+				// Collect stats one more time, then terminate the loop.
+				done = true
 			case <-time.After(delay):
 			}
 			delay = min(maxStatsPollInterval, time.Duration(float64(delay)*statsPollBackoff))


### PR DESCRIPTION
Collect stats when the command terminates. This does two things:
* Guarantees that we report stats at least once for each command.
* Ensures that the last reported stats are accurate. Otherwise, we are potentially not accounting for the last several ms of command execution.
  * The stats collection is polling based - it starts with a 10ms poll rate then exponentially backs off up to 250ms - so in the worst case we are ignoring the last 250ms of command execution

**Related issues**: N/A
