### PR TITLE
Make workflow load balancing a bit more sane

### DIFF
--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -39,7 +39,7 @@ const (
 	// workflow tasks to hit a node with a warm bazel workspace, but it is
 	// set less than the number of probes so that we can autoscale the workflow
 	// executor pool effectively.
-	workflowsPreferredNodeLimit = 2
+	workflowsPreferredNodeLimit = 1
 )
 
 type taskRouter struct {

--- a/enterprise/server/test/integration/task_router/task_router_test.go
+++ b/enterprise/server/test/integration/task_router/task_router_test.go
@@ -26,7 +26,7 @@ const (
 	executorID2 = "42"
 )
 
-func TestTaskRouter_RankNodes_Workflows_ReturnsMultipleRunnersThatExecutedWorkflow(t *testing.T) {
+func TestTaskRouter_RankNodes_Workflows_ReturnsLatestRunnerThatExecutedWorkflow(t *testing.T) {
 	// Mark a routable workflow task complete by executor 1.
 
 	env := newTestEnv(t)
@@ -61,15 +61,13 @@ func TestTaskRouter_RankNodes_Workflows_ReturnsMultipleRunnersThatExecutedWorkfl
 
 	router.MarkComplete(ctx, cmd, instanceName, executorID2)
 
-	// Task should now be routed to executor 2 then 1 in order, since executor 2
-	// ran the task more recently, and we memorize several recent executors for
-	// workflow tasks.
+	// Task should now be routed to executor 2, since executor 2 ran the task
+	// more recently.
 
 	ranked = router.RankNodes(ctx, cmd, instanceName, nodes)
 
 	requireSameExecutionNodes(t, nodes, ranked)
 	require.Equal(t, executorID2, ranked[0].GetExecutionNode().GetExecutorID())
-	require.Equal(t, executorID1, ranked[1].GetExecutionNode().GetExecutorID())
 	requireNonSequential(t, ranked[2:])
 }
 

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -74,6 +74,7 @@ var (
 	workflowsCIRunnerBazelCommand = flag.String("remote_execution.workflows_ci_runner_bazel_command", "", "Bazel command to be used by the CI runner.")
 	workflowsLinuxComputeUnits    = flag.Int("remote_execution.workflows_linux_compute_units", 3, "Number of BuildBuddy compute units (BCU) to reserve for Linux workflow actions.")
 	workflowsMacComputeUnits      = flag.Int("remote_execution.workflows_mac_compute_units", 3, "Number of BuildBuddy compute units (BCU) to reserve for Mac workflow actions.")
+	workflowsRunnerMaxWait        = flag.Duration("remote_execution.workflows_runner_recycling_max_wait", 3*time.Second, "Max duration that a workflow task should wait for a warm runner before running on a potentially cold runner.")
 
 	workflowURLMatcher = regexp.MustCompile(`^.*/webhooks/workflow/(?P<instance_name>.*)$`)
 
@@ -1189,6 +1190,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 				// possible, and also keep the git repo around so it doesn't need to be
 				// re-cloned each time.
 				{Name: "recycle-runner", Value: "true"},
+				{Name: "runner-recycling-max-wait", Value: (*workflowsRunnerMaxWait).String()},
 				{Name: "preserve-workspace", Value: "true"},
 				{Name: "use-self-hosted-executors", Value: useSelfHostedExecutors},
 				// Pass the workflow ID to the executor so that it can try to assign


### PR DESCRIPTION
With 2 equally preferred nodes, we can potentially hit a situation where workflows are "bouncing" back and forth between the 2 preferred nodes.

To make things a bit easier to reason about, only use 1 preferred workflow node and add a small scheduling delay to increase the chances that we will use that node, so that instead of "bouncing" we just choose a new node which then becomes the preferred node.

**Related issues**: N/A
