### PR TITLE
Proto changes for showing ExecuteResponse in the UI

### DIFF
--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -87,6 +87,15 @@ message Execution {
   // doesn't.
   build.bazel.remote.execution.v2.Digest action_result_digest = 9;
 
+  // A digest used to retrieve the
+  // [build.bazel.remote.execution.v2.ExecuteResponse] produced by the executor
+  // for the latest attempt of this execution.
+  //
+  // This digest can be used to fetch a specially formatted ActionResult from
+  // the Action Cache. In particular, the ActionResult's stdout_raw field is set
+  // to the marshaled ExecuteResponse bytes.
+  build.bazel.remote.execution.v2.Digest execute_response_digest = 12;
+
   // The stage this execution is currently in.
   build.bazel.remote.execution.v2.ExecutionStage.Value stage = 2;
 


### PR DESCRIPTION
This PR adds the proto changes needed to show `ExecuteResponse` in the action page instead of `ActionResult`. Showing `ExecuteResponse` has two advantages:
* It means we'll show the actual `ExecuteResponse` for the execution ID, rather than the latest `ActionResult` associated with the action digest. The latter is inaccurate/incorrect and often confusing.
* The `ExecuteResponse` contains a superset of info, such as:
  * The `status` field (execution error details when the task either fails to start, or terminates abnormally), which is not representable by an ActionResult.
  * An optional `server_logs` field which allows attaching arbitrary logs. We can use this for attaching firecracker VM logs.

Note, this does **NOT** take any steps towards addressing https://github.com/buildbuddy-io/buildbuddy-internal/issues/2918 which is a bit more involved as it will likely involve DB schema changes.

**Related issues**:
* https://github.com/buildbuddy-io/buildbuddy-internal/issues/2774
* https://github.com/buildbuddy-io/buildbuddy-internal/issues/1203
