### PR TITLE
Add server support for `application/grpc+proto` over http

### DIFF
--- a/server/http/protolet/BUILD
+++ b/server/http/protolet/BUILD
@@ -8,6 +8,8 @@ go_library(
     deps = [
         "//server/util/request_context",
         "@io_opentelemetry_go_otel_trace//:trace",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
         "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//encoding/prototext",
         "@org_golang_google_protobuf//proto",

--- a/server/http/protolet/protolet.go
+++ b/server/http/protolet/protolet.go
@@ -206,6 +206,11 @@ func GenerateHTTPHandlers(servicePrefix, serviceName string, server interface{},
 			return
 		}
 
+		if method.Type().NumOut() != 2 {
+			http.Error(w, "Streaming not enabled.", http.StatusNotImplemented)
+			return
+		}
+
 		// If we know this is a protolet request and we expect to handle it,
 		// override the span name to something legible instead of the generic
 		// handled-path name. This means instead of the span appearing with a

--- a/server/http/protolet/protolet.go
+++ b/server/http/protolet/protolet.go
@@ -11,13 +11,14 @@ import (
 	"strconv"
 	"strings"
 
-	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
+
+	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
 )
 
 const (

--- a/server/http/protolet/protolet.go
+++ b/server/http/protolet/protolet.go
@@ -1,14 +1,20 @@
 package protolet
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"reflect"
+	"strconv"
+	"strings"
 
-	"github.com/buildbuddy-io/buildbuddy/server/util/request_context"
+	requestcontext "github.com/buildbuddy-io/buildbuddy/server/util/request_context"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
@@ -16,6 +22,17 @@ import (
 
 const (
 	contextProtoMessageKey = "protolet.requestMessage"
+	// GRPC over HTTP requires protobuf messages to be sent in a series of `Length-Prefixed-Message`s
+	// Here's what a Length-Prefixed-Message looks like:
+	// 		Length-Prefixed-Message → Compressed-Flag Message-Length Message
+	// 		Compressed-Flag → 0 / 1 # encoded as 1 byte unsigned integer
+	// 		Message-Length → {length of Message} # encoded as 4 byte unsigned integer (big endian)
+	// 		Message → *{binary octet}
+	// This means the actual proto we want to deserialize starts at byte 5 because there is 1
+	// byte that tells us whether or not the message is compressed, and then 4 bytes that tell
+	// us the length of the message.
+	// For more info, see: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+	messageByteOffset = 5
 )
 
 func isRPCMethod(m reflect.Method) bool {
@@ -42,6 +59,27 @@ func isRPCMethod(m reflect.Method) bool {
 	return true
 }
 
+func isStreamingRPCMethod(m reflect.Method) bool {
+	t := m.Type
+	if t.Kind() != reflect.Func {
+		return false
+	}
+	if t.NumIn() != 3 || t.NumOut() != 1 {
+		return false
+	}
+	if !t.In(1).Implements(reflect.TypeOf((*proto.Message)(nil)).Elem()) {
+		return false
+	}
+	if !t.In(2).Implements(reflect.TypeOf((*grpc.ServerStream)(nil)).Elem()) {
+		return false
+	}
+	if !t.Out(0).Implements(reflect.TypeOf((*error)(nil)).Elem()) {
+		return false
+	}
+	return true
+}
+
+
 func ReadRequestToProto(r *http.Request, req proto.Message) error {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -55,6 +93,9 @@ func ReadRequestToProto(r *http.Request, req proto.Message) error {
 		return proto.Unmarshal(body, req)
 	case "application/protobuf-text":
 		return prototext.Unmarshal(body, req)
+	case "application/grpc+proto":
+		r.Body = ioutil.NopCloser(bytes.NewReader(body))
+		return proto.Unmarshal(body[messageByteOffset:], req)
 	default:
 		return fmt.Errorf("Unknown Content-Type: %s, expected application/json or application/protobuf", ct)
 	}
@@ -101,7 +142,7 @@ type HTTPHandlers struct {
 	RequestHandler http.Handler
 }
 
-func GenerateHTTPHandlers(servicePrefix string, server interface{}) (*HTTPHandlers, error) {
+func GenerateHTTPHandlers(servicePrefix, serviceName string, server interface{}, grpcServer *grpc.Server) (*HTTPHandlers, error) {
 	if reflect.ValueOf(server).Type().Kind() != reflect.Ptr {
 		return nil, fmt.Errorf("GenerateHTTPHandlers must be called with a pointer to an RPC service implementation")
 	}
@@ -110,7 +151,7 @@ func GenerateHTTPHandlers(servicePrefix string, server interface{}) (*HTTPHandle
 	serverType := reflect.TypeOf(server)
 	for i := 0; i < serverType.NumMethod(); i++ {
 		method := serverType.Method(i)
-		if !isRPCMethod(method) {
+		if !isRPCMethod(method) && !isStreamingRPCMethod(method) {
 			continue
 		}
 		handlerFns[servicePrefix+method.Name] = method.Func
@@ -125,7 +166,13 @@ func GenerateHTTPHandlers(servicePrefix string, server interface{}) (*HTTPHandle
 			}
 
 			methodType := method.Type()
-			reqVal := reflect.New(methodType.In(2).Elem())
+			requestIndex := 2 
+			// If we're dealing with a streaming method, the request proto is the first input 
+			if method.Type().In(1).Implements(reflect.TypeOf((*proto.Message)(nil)).Elem()) {
+				requestIndex = 1
+			}
+
+			reqVal := reflect.New(methodType.In(requestIndex).Elem())
 			req := reqVal.Interface().(proto.Message)
 			if err := ReadRequestToProto(r, req); err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
@@ -143,6 +190,19 @@ func GenerateHTTPHandlers(servicePrefix string, server interface{}) (*HTTPHandle
 		method, ok := handlerFns[r.URL.Path]
 		if !ok {
 			http.Error(w, fmt.Sprintf("Method '%s' not found.", r.URL.Path), http.StatusNotFound)
+			return
+		}
+
+		// If we're getting a grpc+proto request over http, we rewrite the path to point at
+		// the grpc server's http handler endpoints and make the request look like an http2 request.
+		// We also wrap the ResponseWriter so we can return proper errors to the web front-end.
+		if r.Header.Get("content-type") == "application/grpc+proto" {
+			r.URL.Path = fmt.Sprintf("/%s/%s", serviceName, strings.TrimPrefix(r.URL.Path, servicePrefix))
+			r.ProtoMajor = 2
+			r.ProtoMinor = 0
+			wrapped := &wrappedResponse{w: w}
+			grpcServer.ServeHTTP(wrapped, r)
+			wrapped.sendErrorIfNeeded(r)
 			return
 		}
 
@@ -178,4 +238,52 @@ func GenerateHTTPHandlers(servicePrefix string, server interface{}) (*HTTPHandle
 		BodyParserMiddleware: bodyParserMiddleware,
 		RequestHandler:       requestHandler,
 	}, nil
+}
+
+type wrappedResponse struct {
+	w http.ResponseWriter
+	wroteHeader bool
+	wroteBody    bool
+}
+
+func (w *wrappedResponse) Header() http.Header {
+	return w.w.Header()
+}
+
+func (w *wrappedResponse) Write(b []byte) (int, error) {
+	w.wroteBody, w.wroteHeader = true, true
+	return w.w.Write(b)
+}
+
+func (w *wrappedResponse) WriteHeader(code int) {
+	w.wroteHeader = true
+	w.w.WriteHeader(code)
+}
+
+func (w *wrappedResponse) Flush() {
+	if !w.wroteHeader && !w.wroteBody {
+		return
+	}
+	if f, ok := w.w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (w *wrappedResponse) sendErrorIfNeeded(req *http.Request) {
+	if w.wroteHeader || w.wroteBody {
+		return
+	}
+	i, err := strconv.Atoi(w.Header().Get("grpc-status"))
+	if err != nil {
+		i = int(codes.Unknown)
+	}
+	if i == 0 {
+		w.WriteHeader(200)
+	}
+
+	// Match our current behavior where we return 500 for all errors and return the message in the response body
+	w.WriteHeader(500)
+	code := codes.Code(i).String()
+	w.Write([]byte(fmt.Sprintf("rpc error: code = %s desc = %s", code, w.Header().Get("grpc-message"))))
+	w.Flush()
 }

--- a/server/http/protolet/protolet.go
+++ b/server/http/protolet/protolet.go
@@ -79,7 +79,6 @@ func isStreamingRPCMethod(m reflect.Method) bool {
 	return true
 }
 
-
 func ReadRequestToProto(r *http.Request, req proto.Message) error {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -166,8 +165,8 @@ func GenerateHTTPHandlers(servicePrefix, serviceName string, server interface{},
 			}
 
 			methodType := method.Type()
-			requestIndex := 2 
-			// If we're dealing with a streaming method, the request proto is the first input 
+			requestIndex := 2
+			// If we're dealing with a streaming method, the request proto is the first input
 			if method.Type().In(1).Implements(reflect.TypeOf((*proto.Message)(nil)).Elem()) {
 				requestIndex = 1
 			}
@@ -241,9 +240,9 @@ func GenerateHTTPHandlers(servicePrefix, serviceName string, server interface{},
 }
 
 type wrappedResponse struct {
-	w http.ResponseWriter
+	w           http.ResponseWriter
 	wroteHeader bool
-	wroteBody    bool
+	wroteBody   bool
 }
 
 func (w *wrappedResponse) Header() http.Header {


### PR DESCRIPTION
This adds support for server-side streaming (and paves the way for client side streaming with websockets in the future if we want it).

If we end up using this for a bit and liking it, we could delete all of the gnarly reflection protolet.go and simplify that code a ton.

The concepts used here are losely based on https://github.com/improbable-eng/grpc-web/blob/master/go/grpcweb/wrapper.go - so they've been tested in a production environment, but have been greatly simplified.

**Overview** 

Here's how it works:
 - If the client sets the `application/grpc+proto` content type, we forward requests to the grpc server's `ServeHTTP` method.
 - In order to support local development, we spoof HTTP2 requests by setting ProtoMajor and ProtoMinor. This is what the improbable library does too, so there's some precedent here: https://github.com/improbable-eng/grpc-web/blob/master/go/grpcweb/wrapper.go#L279
 - When returning the http response, we wrap the `ResponseWriter` so we can set an http status and the error message in the response body (grpc and grpc-web always return a 200 success status and then include trailers that contain the status and status message). This matches our current protolet behavior.

**Binary format**

The biggest difference between this and what we're currently doing is that the grpc over http protocol (you can read about this here: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) expects data to be sent in the `Length-Prefixed-Message` format. Here's what that looks like
- Length-Prefixed-Message → Compressed-Flag Message-Length Message
  - Compressed-Flag → 0 / 1 # encoded as 1 byte unsigned integer
  - Message-Length → {length of Message} # encoded as 4 byte unsigned integer (big endian)
  - Message → *{binary octet}

Currently we only send the `Message` bit, so there are some places (like when parsing the request context) where we need to ignore those first 5 bytes. There's a separate PR that sets these 5 bytes on the client side when we're using this new content-type.

**Misc**

In order to support streaming responses, we need all of our `ResponseWriter`s to implement `http.Flusher` - this PR also adds that (happy to break that out into a separate PR if that helps).

The final little quirk in this PR is that we `GenerateHTTPHandlers` after the grpc services are registered because we forward requests to the grpcServer.