### PR TITLE
Client side support for http streaming

### DIFF
--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -171,7 +171,7 @@ class RpcService {
         while (true) {
           let result = await reader?.read();
           if (result?.done) {
-            break;
+            return;
           }
 
           // Ignore the first 5 byte length-prefix, see the comment for lengthPrefixMessage for more info.

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -175,6 +175,8 @@ class RpcService {
           }
 
           // Ignore the first 5 byte length-prefix, see the comment for lengthPrefixMessage for more info.
+          // TODO(siggisim): Support messages that come across flushes, though I'm not sure if this will
+          // happen much (if at all) in practice.
           let value = result?.value.slice(5) || new Uint8Array();
           callback(null, value);
           this.events.next(method.name);

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -163,6 +163,24 @@ class RpcService {
     }
     init.headers = { "Content-Type": "application/proto" };
     try {
+      if (capabilities.config.streamingHttpEnabled) {
+        init.headers["Content-Type"] = "application/grpc+proto";
+        init.body = lengthPrefixMessage(requestData);
+
+        const reader = (await this.fetch(url, "stream", init))?.getReader();
+        while (true) {
+          let result = await reader?.read();
+          if (result?.done) {
+            break;
+          }
+
+          // Ignore the first 5 byte length-prefix, see the comment for lengthPrefixMessage for more info.
+          let value = result?.value.slice(5) || new Uint8Array();
+          callback(null, value);
+          this.events.next(method.name);
+        }
+      }
+
       const arrayBuffer = await this.fetch(url, "arraybuffer", init);
       callback(null, new Uint8Array(arrayBuffer));
       this.events.next(method.name);
@@ -184,6 +202,20 @@ class RpcService {
     }
     return extendedService;
   }
+}
+
+// GRPC over HTTP requires protobuf messages to be sent in a series of `Length-Prefixed-Message`s
+// Here's what a Length-Prefixed-Message looks like:
+// 		Length-Prefixed-Message → Compressed-Flag Message-Length Message
+// 		Compressed-Flag → 0 / 1 # encoded as 1 byte unsigned integer
+// 		Message-Length → {length of Message} # encoded as 4 byte unsigned integer (big endian)
+// 		Message → *{binary octet}
+// For more info, see: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+function lengthPrefixMessage(requestData: Uint8Array) {
+  const frame = new ArrayBuffer(requestData.byteLength + 5);
+  new DataView(frame, 1, 4).setUint32(0, requestData.length, false /* big endian */);
+  new Uint8Array(frame, 5).set(requestData);
+  return new Uint8Array(frame);
 }
 
 function uint8ArrayToBase64(array: Uint8Array): string {

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -139,6 +139,9 @@ message FrontendConfig {
 
   // Whether popup windows should be used for authentication.
   bool popup_auth_enabled = 46;
+
+  // Whether the server supports streaming http requests from the web UI.
+  bool streaming_http_enabled = 47;
 }
 
 message Region {

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -56,6 +56,7 @@ var (
 	ipRulesUIEnabled                       = flag.Bool("app.ip_rules_ui_enabled", false, "If set, show the IP rules tab in settings page.")
 	traceViewerEnabled                     = flag.Bool("app.trace_viewer_enabled", false, "Whether the new trace viewer is enabled.")
 	popupAuthEnabled                       = flag.Bool("app.popup_auth_enabled", false, "Whether popup windows should be used for authentication.")
+	streamingHTTPEnabled                   = flag.Bool("app.streaming_http_enabled", false, "Whether to support server-streaming http requests between server and web UI.")
 
 	jsEntryPointPath = flag.String("js_entry_point_path", "/app/app_bundle/app.js?hash={APP_BUNDLE_HASH}", "Absolute URL path of the app JS entry point")
 	disableGA        = flag.Bool("disable_ga", false, "If true; ga will be disabled")
@@ -191,6 +192,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		Regions:                                region.Protos(),
 		TraceViewerEnabled:                     *traceViewerEnabled,
 		PopupAuthEnabled:                       *popupAuthEnabled,
+		StreamingHttpEnabled:                   *streamingHTTPEnabled,
 	}
 
 	configJSON, err := protojson.Marshal(&config)


### PR DESCRIPTION
Client side support for server-side grpc streaming over http.

This is behind a `app.streaming_http_enabled` flag.

If that flag is enabled, we'll do three things: 
- We'll change our content-type from `application/proto` to `application/grpc+proto`
- We'll send proto messages as `Length-Prefixed-Message`s (see https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md)
- We'll read the response as a stream rather than just a single arraybuffer.

There is a TODO in there to support messages that come across chunks. This should be relatively straightforward to implement, but I haven't run into it in my testing - and would like to run into it before fixing.

Depends on: https://github.com/buildbuddy-io/buildbuddy/pull/5505