### PR TITLE
Send `action_id` with `replay_action`

### DIFF
--- a/enterprise/tools/replay_action/replay_action.go
+++ b/enterprise/tools/replay_action/replay_action.go
@@ -255,8 +255,9 @@ func main() {
 }
 
 func execute(ctx context.Context, execClient repb.ExecutionClient, bsClient bspb.ByteStreamClient, i int, rn *digest.ResourceName, req *repb.ExecuteRequest) {
+	actionId := rn.GetDigest().GetHash()
 	iid := uuid.New()
-	rmd := &repb.RequestMetadata{ToolInvocationId: iid}
+	rmd := &repb.RequestMetadata{ActionId: actionId, ToolInvocationId: iid}
 	ctx, err := bazel_request.WithRequestMetadata(ctx, rmd)
 	if err != nil {
 		log.Fatalf("Could not set request metadata: %s", err)


### PR DESCRIPTION
Can be useful to have once we have `action_id` tagging (#5515), as another way to group and compare tracing results.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
