### PR TITLE
Use CtxError for runner_maxed_out log

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -409,7 +409,7 @@ func (r *commandRunner) Run(ctx context.Context) *interfaces.CommandResult {
 			}
 
 			alert.UnexpectedEvent("runner_maxed_out", errStr)
-			log.Errorf("%s", errStr)
+			log.CtxError(ctx, errStr)
 		}
 	}
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
