### PR TITLE
Refactor pebble cache benchmark test

### DIFF
--- a/enterprise/server/backends/pebble_cache/BUILD
+++ b/enterprise/server/backends/pebble_cache/BUILD
@@ -72,6 +72,7 @@ go_test(
         "//server/util/status",
         "//server/util/testing/flags",
         "@com_github_cockroachdb_pebble//:pebble",
+        "@com_github_docker_go_units//:go-units",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//proto",

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/cockroachdb/pebble"
+	"github.com/docker/go-units"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -2812,27 +2813,10 @@ func TestEncryptionAndCompression(t *testing.T) {
 	}
 }
 
-func BenchmarkGetMulti(b *testing.B) {
-	*log.LogLevel = "error"
-	*log.IncludeShortFileName = true
-	log.Configure()
-
-	te := testenv.GetTestEnv(b)
-	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
-	ctx := getAnonContext(b, te)
-
-	maxSizeBytes := int64(100_000_000)
-	rootDir := testfs.MakeTempDir(b)
-	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{RootDirectory: rootDir, MaxSizeBytes: maxSizeBytes})
-	if err != nil {
-		b.Fatal(err)
-	}
-	pc.Start()
-	defer pc.Stop()
-
+func benchmarkGetMulti(b *testing.B, pc *pebble_cache.PebbleCache, ctx context.Context, digestSizeBytes int64) {
 	digestKeys := make([]*rspb.ResourceName, 0, 100000)
 	for i := 0; i < 100; i++ {
-		r, buf := newResourceAndBuf(b, 1000, rspb.CacheType_CAS, "" /*instanceName*/)
+		r, buf := newResourceAndBuf(b, digestSizeBytes, rspb.CacheType_CAS, "" /*instanceName*/)
 		digestKeys = append(digestKeys, r)
 		if err := pc.Set(ctx, r, buf); err != nil {
 			b.Fatalf("Error setting %q in cache: %s", r.GetDigest().GetHash(), err.Error())
@@ -2865,7 +2849,11 @@ func BenchmarkGetMulti(b *testing.B) {
 	}
 }
 
-func BenchmarkFindMissing(b *testing.B) {
+func BenchmarkGetMulti(b *testing.B) {
+	*log.LogLevel = "error"
+	*log.IncludeShortFileName = true
+	log.Configure()
+
 	te := testenv.GetTestEnv(b)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
 	ctx := getAnonContext(b, te)
@@ -2879,9 +2867,19 @@ func BenchmarkFindMissing(b *testing.B) {
 	pc.Start()
 	defer pc.Stop()
 
+	sizes := []int64{1024, 1024 * 1024, 10 * 1024 * 1042}
+	for _, size := range sizes {
+		name := fmt.Sprintf("size=%s", units.BytesSize(float64(size)))
+		b.Run(name, func(b *testing.B) {
+			benchmarkGetMulti(b, pc, ctx, size)
+		})
+	}
+}
+
+func benchmarkFindMissing(b *testing.B, pc *pebble_cache.PebbleCache, ctx context.Context, digestSizeBytes int64) {
 	digestKeys := make([]*rspb.ResourceName, 0, 100000)
 	for i := 0; i < 100; i++ {
-		r, buf := newCASResourceBuf(b, 1000)
+		r, buf := newCASResourceBuf(b, digestSizeBytes)
 		digestKeys = append(digestKeys, r)
 		if err := pc.Set(ctx, r, buf); err != nil {
 			b.Fatalf("Error setting %q in cache: %s", r.GetDigest().GetHash(), err.Error())
@@ -2914,7 +2912,10 @@ func BenchmarkFindMissing(b *testing.B) {
 	}
 }
 
-func BenchmarkContains1(b *testing.B) {
+func BenchmarkFindMissing(b *testing.B) {
+	*log.LogLevel = "error"
+	*log.IncludeShortFileName = true
+	log.Configure()
 	te := testenv.GetTestEnv(b)
 	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
 	ctx := getAnonContext(b, te)
@@ -2928,54 +2929,54 @@ func BenchmarkContains1(b *testing.B) {
 	pc.Start()
 	defer pc.Stop()
 
-	digestKeys := make([]*rspb.ResourceName, 0, 100000)
-	for i := 0; i < 100; i++ {
-		r, buf := newCASResourceBuf(b, 1000)
-		digestKeys = append(digestKeys, r)
-		if err := pc.Set(ctx, r, buf); err != nil {
-			b.Fatalf("Error setting %q in cache: %s", r.GetDigest().GetHash(), err.Error())
-		}
+	sizes := []int64{1024, 1024 * 1024, 10 * 1024 * 1042}
+	for _, size := range sizes {
+		name := fmt.Sprintf("size=%s", units.BytesSize(float64(size)))
+		b.Run(name, func(b *testing.B) {
+			benchmarkFindMissing(b, pc, ctx, size)
+		})
 	}
 
-	b.ReportAllocs()
-	b.StopTimer()
-	for n := 0; n < b.N; n++ {
-		b.StartTimer()
-		found, err := pc.Contains(ctx, digestKeys[rand.Intn(len(digestKeys))])
-		b.StopTimer()
-		if err != nil {
-			b.Fatal(err)
-		}
-		if !found {
-			b.Fatalf("All digests should be present")
-		}
-	}
 }
 
-func BenchmarkSet(b *testing.B) {
-	te := testenv.GetTestEnv(b)
-	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
-	ctx := getAnonContext(b, te)
-
-	maxSizeBytes := int64(100_000_000)
-	rootDir := testfs.MakeTempDir(b)
-	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{RootDirectory: rootDir, MaxSizeBytes: maxSizeBytes})
-	if err != nil {
-		b.Fatal(err)
-	}
-	pc.Start()
-	defer pc.Stop()
-
+func benchmarkSet(b *testing.B, pc *pebble_cache.PebbleCache, ctx context.Context, digestSizeBytes int64) {
 	b.ReportAllocs()
 	b.StopTimer()
 	for n := 0; n < b.N; n++ {
-		r, buf := newCASResourceBuf(b, 1000)
+		r, buf := newCASResourceBuf(b, digestSizeBytes)
 		b.StartTimer()
 		err := pc.Set(ctx, r, buf)
 		b.StopTimer()
 		if err != nil {
 			b.Fatalf("Error setting %q in cache: %s", r.GetDigest().GetHash(), err.Error())
 		}
+	}
+}
+
+func BenchmarkSet(b *testing.B) {
+	*log.LogLevel = "error"
+	*log.IncludeShortFileName = true
+	log.Configure()
+
+	te := testenv.GetTestEnv(b)
+	te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
+	ctx := getAnonContext(b, te)
+
+	maxSizeBytes := int64(100_000_000)
+	rootDir := testfs.MakeTempDir(b)
+	pc, err := pebble_cache.NewPebbleCache(te, &pebble_cache.Options{RootDirectory: rootDir, MaxSizeBytes: maxSizeBytes})
+	if err != nil {
+		b.Fatal(err)
+	}
+	pc.Start()
+	defer pc.Stop()
+
+	sizes := []int64{1024, 1024 * 1024, 10 * 1024 * 1042}
+	for _, size := range sizes {
+		name := fmt.Sprintf("size=%s", units.BytesSize(float64(size)))
+		b.Run(name, func(b *testing.B) {
+			benchmarkSet(b, pc, ctx, size)
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
1. add different sizes to benchmark tests
2. remove Contain benchmark test (Contain is calling FindMissing)
3. increase log levels in benchmark tests
