### PR TITLE
Remove "long" timeout from remote_execution_test

### DIFF
--- a/enterprise/server/test/integration/remote_execution/BUILD
+++ b/enterprise/server/test/integration/remote_execution/BUILD
@@ -5,9 +5,6 @@ package(default_visibility = ["//enterprise:__subpackages__"])
 go_test(
     name = "remote_execution_test",
     size = "small",
-    # TODO(https://github.com/buildbuddy-io/buildbuddy-internal/issues/2379):
-    # make these tests run faster
-    timeout = "long",
     srcs = ["remote_execution_test.go"],
     args = ["--test.v"],
     data = [


### PR DESCRIPTION
Seems to be running a bit smoother for me these days, so I'd like to give this a try.

Clean run with `--runs_per_test=100`: https://buildbuddy.buildbuddy.io/invocation/197b56df-7439-49ba-abed-ef919ebcdb75

**Related issues**: N/A
