### PR TITLE
Make cache usage graph more readable

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -4249,10 +4249,14 @@
           "id": 1338,
           "options": {
             "legend": {
-              "calcs": [],
-              "displayMode": "list",
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": false
             },
             "tooltip": {
               "mode": "single",
@@ -13062,7 +13066,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 34
       },
       "id": 8,
       "panels": [
@@ -13294,7 +13298,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 35
       },
       "id": 1346,
       "panels": [
@@ -13808,7 +13812,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 36
       },
       "id": 5641,
       "panels": [

--- a/tools/metrics/grafana/dashboards/cache.json
+++ b/tools/metrics/grafana/dashboards/cache.json
@@ -80,7 +80,6 @@
                 }
               },
               "mappings": [],
-              "max": 1,
               "min": 0,
               "thresholds": {
                 "mode": "absolute",

--- a/tools/metrics/grafana/dashboards/cache.json
+++ b/tools/metrics/grafana/dashboards/cache.json
@@ -107,8 +107,10 @@
           "id": 2370,
           "options": {
             "legend": {
-              "calcs": [],
-              "displayMode": "list",
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
               "placement": "bottom",
               "showLegend": true
             },
@@ -406,7 +408,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 1
       },
       "id": 3104,
       "panels": [
@@ -820,7 +822,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 2
       },
       "id": 5799,
       "panels": [


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

This PR changes how we display the legends for Grafana cache usage and disk cache
filesystem usage graph. It show labels with their last non-null values directly 
in table mode.

I find it difficult to figure out which apps uses >90% cache when all the lines
are clustered together when I hover over the graph. The table mode allows me to
sort by values and make it easier to identify the hot apps.

Also, there are times when the partition usage > 100%; and we are not showing them on the graph.
