### PR TITLE
Clean up lockmap gc goroutine in PebbleCache

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -3368,7 +3368,15 @@ func (p *PebbleCache) Stop() error {
 	}
 	log.Infof("Pebble Cache [%s]: db flushed again", p.name)
 
-	return p.db.Close()
+	if err := p.db.Close(); err != nil {
+		return err
+	}
+
+	if err := p.locker.Close(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (p *PebbleCache) SupportsEncryption(ctx context.Context) bool {


### PR DESCRIPTION
This is not strictly necessary in practice since we only have one lockmap per app instance, but it's nice to clean up the lockmap for testing purposes.

**Related issues**: N/A
