### PR TITLE
Fix populating the version tag in github release workflows

### DIFF
--- a/.github/workflows/release-m1.yaml
+++ b/.github/workflows/release-m1.yaml
@@ -51,6 +51,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.vars.outputs.ref }}
+          # We need to fetch git tags to obtain the latest version tag to report
+          # the version of the running binary.
+          fetch-depth: 0
 
       - name: Install bazelisk
         run: |

--- a/.github/workflows/release-mac.yaml
+++ b/.github/workflows/release-mac.yaml
@@ -40,6 +40,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.vars.outputs.ref }}
+          # We need to fetch git tags to obtain the latest version tag to report
+          # the version of the running binary.
+          fetch-depth: 0
 
       - name: Install bazelisk
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.vars.outputs.ref }}
+          # We need to fetch git tags to obtain the latest version tag to report
+          # the version of the running binary.
+          fetch-depth: 0
 
       - name: Install bazelisk
         run: |


### PR DESCRIPTION
This will fix populating the version tag when we manually trigger the github release upload. [(Slack thread)
](https://buildbuddy-corp.slack.com/archives/C0495TM9UUE/p1702561546424619)
**Related issues**: N/A
