### PR TITLE
Use `application/proto+prefixed` content type

### DIFF
--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -182,7 +182,7 @@ class RpcService {
     init.headers = { "Content-Type": "application/proto" };
     try {
       if (capabilities.config.streamingHttpEnabled) {
-        init.headers["Content-Type"] = "application/grpc+proto";
+        init.headers["Content-Type"] = "application/proto+prefixed";
         init.body = lengthPrefixMessage(requestData);
 
         const reader = (await this.fetch(url, "stream", init))?.getReader();


### PR DESCRIPTION
This makes a bit more sense because the client is not really sending a grpc request. It's sending a `Length-Prefixed-Proto` request. The fact that we're passing this to the grpc server behind the scenes is more of just a server-side implementation detail that the client shouldn't need to know about.

This also avoids other systems (and other parts of our system) from trying to interpret and route these requests as if they were real grpc requests (for example this code https://github.com/buildbuddy-io/buildbuddy/blob/master/server/util/grpc_server/grpc_server.go#L268).