### PR TITLE
Add trace span annotation showing result of execution_server.execute()

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -663,7 +663,7 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 	executionID := ""
 	if !req.GetSkipCacheLookup() {
 		if actionResult, err := s.getActionResultFromCache(ctx, adInstanceDigest); err == nil {
-			tracing.AddStringAttributeToCurrentSpan(ctx, "task_id", "cached")
+			tracing.AddStringAttributeToCurrentSpan(ctx, "execute_result", "cached")
 
 			r := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName(), rspb.CacheType_CAS, req.GetDigestFunction())
 			executionID, err := r.UploadString()
@@ -688,7 +688,7 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 			if ee != "" {
 				ctx = log.EnrichContext(ctx, log.ExecutionIDKey, ee)
 				log.CtxInfof(ctx, "Reusing execution %q for execution request %q for invocation %q", ee, downloadString, invocationID)
-				tracing.AddStringAttributeToCurrentSpan(ctx, "task_id", "merged against "+ee)
+				tracing.AddStringAttributeToCurrentSpan(ctx, "execute_result", "merged")
 				executionID = ee
 				metrics.RemoteExecutionMergedActions.With(prometheus.Labels{metrics.GroupID: s.getGroupIDForMetrics(ctx)}).Inc()
 				if err := s.insertInvocationLink(ctx, ee, invocationID, sipb.StoredInvocationLink_MERGED); err != nil {
@@ -702,6 +702,7 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 	// can wait on.
 	if executionID == "" {
 		log.CtxInfof(ctx, "Scheduling new execution for %q for invocation %q", downloadString, invocationID)
+		tracing.AddStringAttributeToCurrentSpan(ctx, "execute_result", "executed")
 		newExecutionID, err := s.Dispatch(ctx, req)
 		if err != nil {
 			log.CtxWarningf(ctx, "Error dispatching execution for %q: %s", downloadString, err)

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -663,7 +663,7 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 	executionID := ""
 	if !req.GetSkipCacheLookup() {
 		if actionResult, err := s.getActionResultFromCache(ctx, adInstanceDigest); err == nil {
-			tracing.AddStringAttributeToCurrentSpan(ctx, "execute_result", "cached")
+			tracing.AddStringAttributeToCurrentSpan(ctx, "task_id", "cached")
 
 			r := digest.NewResourceName(req.GetActionDigest(), req.GetInstanceName(), rspb.CacheType_CAS, req.GetDigestFunction())
 			executionID, err := r.UploadString()
@@ -688,7 +688,7 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 			if ee != "" {
 				ctx = log.EnrichContext(ctx, log.ExecutionIDKey, ee)
 				log.CtxInfof(ctx, "Reusing execution %q for execution request %q for invocation %q", ee, downloadString, invocationID)
-				tracing.AddStringAttributeToCurrentSpan(ctx, "execute_result", "merged")
+				tracing.AddStringAttributeToCurrentSpan(ctx, "task_id", "merged against "+ee)
 				executionID = ee
 				metrics.RemoteExecutionMergedActions.With(prometheus.Labels{metrics.GroupID: s.getGroupIDForMetrics(ctx)}).Inc()
 				if err := s.insertInvocationLink(ctx, ee, invocationID, sipb.StoredInvocationLink_MERGED); err != nil {
@@ -702,7 +702,6 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 	// can wait on.
 	if executionID == "" {
 		log.CtxInfof(ctx, "Scheduling new execution for %q for invocation %q", downloadString, invocationID)
-		tracing.AddStringAttributeToCurrentSpan(ctx, "execute_result", "executed")
 		newExecutionID, err := s.Dispatch(ctx, req)
 		if err != nil {
 			log.CtxWarningf(ctx, "Error dispatching execution for %q: %s", downloadString, err)


### PR DESCRIPTION
**Related issues**: [2997](https://github.com/buildbuddy-io/buildbuddy-internal/issues/2997)