### PR TITLE
Support partial client-side stream reads

### DIFF
--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -250,8 +250,8 @@ async function transformLengthPrefixedReaderStreamToProtoMessageBytes(
     // Start with any leftovers from the last turn.
     let value: Uint8Array | undefined = streamState.leftovers;
 
-    // If we don't have any leftovers, read at least 5 bytes from the stream so we have at least a length prefix.
-    if (streamState.leftovers.length == 0) {
+    // If we don't have any (or enough) leftovers, read at least 5 bytes from the stream so we have at least a length prefix.
+    if (streamState.leftovers.length < 5) {
       value = await readAtLeastNBytes(value, reader, 5);
     }
 

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -268,7 +268,7 @@ async function transformLengthPrefixedReaderStreamToProtoMessageBytes(
     // Read the rest of the bytes into the buffer until it's full, saving any leftovers.
     consumeMessageChunk(streamState, value);
 
-    // If we still haven't receieve the full message, loop again and read more until we do.
+    // If we still haven't receive the full message, loop again and read more until we do.
     if (streamState.bufferedLength < streamState.messageExpectedLength) {
       continue;
     }


### PR DESCRIPTION
I managed to reproduce the case where the server flushes a proto response without the full proto message.

This seems to happen when a single proto message is larger than ~4kb.

This PR handles this on the client side (and completes the TODO) by:
- Reading the length-prefix at the beginning of the `Length-Prefixed-Message`
- If we get a stream read that is smaller than length of the message, create a Uint8Array that we can use to buffer the message until we've got the full thing
- Append to that buffer until we've got a full message
- Call the callback with the full buffer, and reset the buffer