### PR TITLE
[DEFLAKE] Loosen up version restriction in version test

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2232,15 +2232,14 @@ func TestSpecifiedActiveKeyVersion_ExistingDatabase(t *testing.T) {
 	}
 
 	// Re-open the database with version 3 as the active key version and
-	// confirm the version metadata is [2, 3]. Don't write anything though, to
-	// avoid migrating the data.
+	// confirm the version metadata is [2, 3].
 	{
 		activeKeyVersion := int64(filestore.Version3)
 		options.ActiveKeyVersion = &activeKeyVersion
 		pc := openPebbleCache(ctx, t, te, options, []string{})
 		versionMetadata, err := pc.DatabaseVersionMetadata()
 		require.NoError(t, err)
-		require.Equal(t, int64(filestore.Version2), versionMetadata.MinVersion)
+		require.GreaterOrEqual(t, int64(filestore.Version3), versionMetadata.MinVersion)
 		require.Equal(t, int64(filestore.Version3), versionMetadata.MaxVersion)
 
 		require.NoError(t, pc.Stop())
@@ -2250,19 +2249,6 @@ func TestSpecifiedActiveKeyVersion_ExistingDatabase(t *testing.T) {
 	// confirm the version metadata is [1, 3].
 	{
 		activeKeyVersion := int64(filestore.Version1)
-		options.ActiveKeyVersion = &activeKeyVersion
-		pc := openPebbleCache(ctx, t, te, options, []string{})
-		versionMetadata, err := pc.DatabaseVersionMetadata()
-		require.NoError(t, err)
-		require.Equal(t, int64(filestore.Version1), versionMetadata.MinVersion)
-		require.Equal(t, int64(filestore.Version3), versionMetadata.MaxVersion)
-
-		require.NoError(t, pc.Stop())
-	}
-
-	// Finally, open again with version 2 as the active key version.
-	{
-		activeKeyVersion := int64(filestore.Version2)
 		options.ActiveKeyVersion = &activeKeyVersion
 		pc := openPebbleCache(ctx, t, te, options, []string{})
 		versionMetadata, err := pc.DatabaseVersionMetadata()

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2232,14 +2232,16 @@ func TestSpecifiedActiveKeyVersion_ExistingDatabase(t *testing.T) {
 	}
 
 	// Re-open the database with version 3 as the active key version and
-	// confirm the version metadata is [2, 3].
+	// confirm the version metadata's max version is bumped to 3.
 	{
 		activeKeyVersion := int64(filestore.Version3)
 		options.ActiveKeyVersion = &activeKeyVersion
 		pc := openPebbleCache(ctx, t, te, options, []string{})
 		versionMetadata, err := pc.DatabaseVersionMetadata()
 		require.NoError(t, err)
+		// The migrator may run, so the minimum version may be 2 or 3.
 		require.GreaterOrEqual(t, int64(filestore.Version3), versionMetadata.MinVersion)
+		require.LessOrEqual(t, int64(filestore.Version2), versionMetadata.MinVersion)
 		require.Equal(t, int64(filestore.Version3), versionMetadata.MaxVersion)
 
 		require.NoError(t, pc.Stop())


### PR DESCRIPTION
```
INFO: Elapsed time: 6.113s, Critical Path: 3.47s
INFO: 401 processes: 1 internal, 400 linux-sandbox.
//enterprise/server/backends/pebble_cache:pebble_cache_test              PASSED in 3.5s
  Stats over 400 runs: max = 3.5s, min = 0.0s, avg = 0.3s, dev = 0.6s
```