### PR TITLE
Rename protoutil to proto

### DIFF
--- a/server/util/proto/BUILD
+++ b/server/util/proto/BUILD
@@ -1,23 +1,22 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "protoutil",
-    srcs = ["protoutil.go"],
-    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/protoutil",
+    name = "proto",
+    srcs = ["proto.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/proto",
     visibility = ["//visibility:public"],
     deps = ["@org_golang_google_protobuf//proto"],
 )
 
 go_test(
-    name = "protoutil_test",
-    srcs = ["protoutil_test.go"],
+    name = "proto_test",
+    srcs = ["proto_test.go"],
     deps = [
-        ":protoutil",
+        ":proto",
         "//proto:cache_go_proto",
         "//proto:distributed_cache_go_proto",
         "//proto:raft_go_proto",
         "@com_github_go_faker_faker_v4//:faker",
         "@com_github_stretchr_testify//require",
-        "@org_golang_google_protobuf//proto",
     ],
 )

--- a/server/util/proto/proto.go
+++ b/server/util/proto/proto.go
@@ -24,11 +24,11 @@ func Marshal(v interface{}) ([]byte, error) {
 		return vt.MarshalVT()
 	}
 
-	msg, ok := v.(gproto.Message)
+	msg, ok := v.(Message)
 	if !ok {
 		return nil, fmt.Errorf("failed to marshal, message is %T, want proto.Message", v)
 	}
-	return gproto.Marshal(msg)
+	return MarshalOld(msg)
 }
 
 func Unmarshal(b []byte, v interface{}) error {
@@ -37,9 +37,9 @@ func Unmarshal(b []byte, v interface{}) error {
 		return vt.UnmarshalVT(b)
 	}
 
-	msg, ok := v.(gproto.Message)
+	msg, ok := v.(Message)
 	if !ok {
 		return fmt.Errorf("failed to unmarshal, message is %T, want proto.Message", v)
 	}
-	return gproto.Unmarshal(b, msg)
+	return UnmarshalOld(b, msg)
 }

--- a/server/util/proto/proto.go
+++ b/server/util/proto/proto.go
@@ -1,13 +1,17 @@
-package protoutil
+package proto
 
 import (
 	"fmt"
 
-	"google.golang.org/protobuf/proto"
+	gproto "google.golang.org/protobuf/proto"
 )
 
-var Clone = proto.Clone
-var Size = proto.Size
+var Clone = gproto.Clone
+var Size = gproto.Size
+var MarshalOld = gproto.Marshal
+var UnmarshalOld = gproto.Unmarshal
+
+type Message = gproto.Message
 
 type vtprotoMessage interface {
 	MarshalVT() ([]byte, error)
@@ -20,11 +24,11 @@ func Marshal(v interface{}) ([]byte, error) {
 		return vt.MarshalVT()
 	}
 
-	msg, ok := v.(proto.Message)
+	msg, ok := v.(gproto.Message)
 	if !ok {
 		return nil, fmt.Errorf("failed to marshal, message is %T, want proto.Message", v)
 	}
-	return proto.Marshal(msg)
+	return gproto.Marshal(msg)
 }
 
 func Unmarshal(b []byte, v interface{}) error {
@@ -33,9 +37,9 @@ func Unmarshal(b []byte, v interface{}) error {
 		return vt.UnmarshalVT(b)
 	}
 
-	msg, ok := v.(proto.Message)
+	msg, ok := v.(gproto.Message)
 	if !ok {
 		return fmt.Errorf("failed to unmarshal, message is %T, want proto.Message", v)
 	}
-	return proto.Unmarshal(b, msg)
+	return gproto.Unmarshal(b, msg)
 }

--- a/server/util/proto/proto_test.go
+++ b/server/util/proto/proto_test.go
@@ -120,10 +120,10 @@ func benchmarkUnmarshal(b *testing.B, unmarshalFn unmarshalFunc, providerFn prov
 
 func BenchmarkMarshal(b *testing.B) {
 	marshalFns := map[string]marshalFunc{
-		"MarshalOld": func(v protoMessage) ([]byte, error) {
+		"Old": func(v protoMessage) ([]byte, error) {
 			return proto.MarshalOld(v)
 		},
-		"Marshal": func(v protoMessage) ([]byte, error) {
+		"New": func(v protoMessage) ([]byte, error) {
 			return proto.Marshal(v)
 		},
 	}
@@ -140,10 +140,10 @@ func BenchmarkMarshal(b *testing.B) {
 
 func BenchmarkUnmarshal(b *testing.B) {
 	unmarshalFns := map[string]unmarshalFunc{
-		"Unmarshal": func(buf []byte, v protoMessage) error {
+		"New": func(buf []byte, v protoMessage) error {
 			return proto.Unmarshal(buf, v)
 		},
-		"UnmarshalOld": func(buf []byte, v protoMessage) error {
+		"Old": func(buf []byte, v protoMessage) error {
 			return proto.UnmarshalOld(buf, v)
 		},
 	}

--- a/server/util/protoutil/protoutil.go
+++ b/server/util/protoutil/protoutil.go
@@ -6,6 +6,9 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+var Clone = proto.Clone
+var Size = proto.Size
+
 type vtprotoMessage interface {
 	MarshalVT() ([]byte, error)
 	UnmarshalVT([]byte) error


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
The intention is to replace "google.golang.org/protobuf/proto" with our own
proto package. 
