### PR TITLE
Use vtproto Unmarshal and mempooling for zip.ManifiestEntry in buildbuddy_server.go

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -92,6 +92,7 @@ proto_library(
         ":context_proto",
         ":remote_execution_proto",
         ":resource_proto",
+        "@com_github_planetscale_vtprotobuf//include/github.com/planetscale/vtprotobuf/vtproto:vtproto_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:field_mask_proto",
         "@com_google_protobuf//:timestamp_proto",
@@ -635,6 +636,7 @@ proto_library(
     deps = [
         ":context_proto",
         ":remote_execution_proto",
+        "@com_github_planetscale_vtprotobuf//include/github.com/planetscale/vtprotobuf/vtproto:vtproto_proto",
     ],
 )
 
@@ -1326,6 +1328,7 @@ go_proto_library(
         ":context_go_proto",
         ":remote_execution_go_proto",
         ":resource_go_proto",
+        "@com_github_planetscale_vtprotobuf//include/github.com/planetscale/vtprotobuf/vtproto:vtproto_go_proto",
         "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )
@@ -1517,6 +1520,7 @@ go_proto_library(
     deps = [
         ":context_go_proto",
         ":remote_execution_go_proto",
+        "@com_github_planetscale_vtprotobuf//include/github.com/planetscale/vtprotobuf/vtproto:vtproto_go_proto",
     ],
 )
 
@@ -1921,6 +1925,12 @@ ts_proto_library(
 )
 
 ts_proto_library(
+    name = "vtproto_ts_proto",
+    proto = "@com_github_planetscale_vtprotobuf//include/github.com/planetscale/vtprotobuf/vtproto:vtproto_proto",
+    deps = ["descriptor_ts_proto"],
+)
+
+ts_proto_library(
     name = "cache_ts_proto",
     proto = ":cache_proto",
     deps = [
@@ -1931,6 +1941,7 @@ ts_proto_library(
         ":remote_execution_ts_proto",
         ":resource_ts_proto",
         ":timestamp_ts_proto",
+        ":vtproto_ts_proto",
     ],
 )
 
@@ -2036,5 +2047,8 @@ ts_proto_library(
 ts_proto_library(
     name = "zip_ts_proto",
     proto = ":zip_proto",
-    deps = [":context_ts_proto"],
+    deps = [
+        ":context_ts_proto",
+        ":vtproto_ts_proto",
+    ],
 )

--- a/proto/zip.proto
+++ b/proto/zip.proto
@@ -1,10 +1,12 @@
 syntax = "proto3";
 
 import "proto/context.proto";
+import "github.com/planetscale/vtprotobuf/vtproto/ext.proto";
 
 package zip;
 
 message ManifestEntry {
+  option (vtproto.mempool) = true;
   // The full path of the file as specified in the archive.
   string name = 1;
 

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -54,13 +54,13 @@ go_library(
         "//server/util/log",
         "//server/util/perms",
         "//server/util/prefix",
+        "//server/util/proto",
         "//server/util/request_context",
         "//server/util/role",
         "//server/util/status",
         "//server/util/subdomain",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_protobuf//encoding/protojson",
-        "@org_golang_google_protobuf//proto",
     ],
 )
 

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -34,12 +34,12 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
+	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/role"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/subdomain"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
 	alpb "github.com/buildbuddy-io/buildbuddy/proto/auditlog"
@@ -1674,7 +1674,8 @@ func (s *BuildBuddyServer) serveBytestream(ctx context.Context, w http.ResponseW
 			log.Warningf("Error downloading file: %s", err)
 			return http.StatusBadRequest, status.FailedPreconditionErrorf("\"%s\" is an invalid base64 string.", zipReference)
 		}
-		entry := &zipb.ManifestEntry{}
+		entry := zipb.ManifestEntryFromVTPool()
+		defer entry.ReturnToVTPool()
 		if err := proto.Unmarshal(b, entry); err != nil {
 			log.Warningf("Failed to unmarshal ManifestEntry: %s", err)
 			return http.StatusBadRequest, status.FailedPreconditionErrorf("\"%s\" does not represent a valid ManifestEntry proto when base64 decoded.", zipReference)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
ManifestEntry is a good candidate for mempooling since Unmarshal with the pool is 50% faster, compared to 34% faster without the pool. Also, we don't need to create a ManifestEntry for each http request. 
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor            
                                  │     Old      │                 New                 │                WithPool                │
                                  │    sec/op    │   sec/op     vs base                │    sec/op     vs base                  │
Marshal/pbName=ManifestEntry-24     388.3n ± 44%   242.0n ± 9%        ~ (p=0.105 n=10)
Unmarshal/pbName=ManifestEntry-24   546.9n ± 25%   383.6n ± 4%  -29.85% (p=0.002 n=10)   271.9n ± 35%  -50.29% (p=0.000 n=10)
geomean                             460.8n         304.7n       -33.87%                  271.9n        -50.29%                ¹
¹ benchmark set differs from baseline; geomeans may not be comparable

                                  │      Old      │                  New                  │                 WithPool                  │
                                  │      B/s      │      B/s       vs base                │      B/s        vs base                   │
Marshal/pbName=ManifestEntry-24     95.80Mi ± 80%   153.69Mi ± 8%        ~ (p=0.105 n=10)
Unmarshal/pbName=ManifestEntry-24   68.01Mi ± 34%    96.96Mi ± 4%  +42.56% (p=0.002 n=10)   136.82Mi ± 26%  +101.17% (p=0.000 n=10)
geomean                             80.72Mi          122.1Mi       +51.24%                   136.8Mi        +101.17%                ¹
¹ benchmark set differs from baseline; geomeans may not be comparable

                                  │     Old     │                 New                  │               WithPool               │
                                  │    B/op     │    B/op      vs base                 │    B/op     vs base                  │
Marshal/pbName=ManifestEntry-24      48.00 ± 0%    48.00 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/pbName=ManifestEntry-24   128.00 ± 0%   128.00 ± 0%       ~ (p=1.000 n=10) ¹   32.00 ± 0%  -75.00% (p=0.000 n=10)
geomean                              78.38         78.38       +0.00%                    32.00       -75.00%                ²
¹ all samples are equal
² benchmark set differs from baseline; geomeans may not be comparable

                                  │    Old     │                 New                 │               WithPool               │
                                  │ allocs/op  │ allocs/op   vs base                 │ allocs/op   vs base                  │
Marshal/pbName=ManifestEntry-24     1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/pbName=ManifestEntry-24   2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹   1.000 ± 0%  -50.00% (p=0.000 n=10)
geomean                             1.414        1.414       +0.00%                    1.000       -50.00%                ²
¹ all samples are equal
² benchmark set differs from baseline; geomeans may not be comparable
```
