### PR TITLE
Use vtproto in tasksize

### DIFF
--- a/enterprise/server/tasksize/BUILD
+++ b/enterprise/server/tasksize/BUILD
@@ -21,10 +21,10 @@ go_library(
         "//server/util/authutil",
         "//server/util/log",
         "//server/util/perms",
+        "//server/util/proto",
         "//server/util/status",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_prometheus_client_golang//prometheus",
-        "@org_golang_google_protobuf//proto",
     ],
 )
 

--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -16,10 +16,10 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
+	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/go-redis/redis/v8"
 	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/protobuf/proto"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->
Marshal for repb.Command is 47.21% faster
Marshal for scpb.TaskSize is 34.05% faster
Unmarshal for scpb.TaskSize is 47.21% faster
```
benchstat -col /name ~/benchmark-proto-taskSize.log.                                                                                                                                                                                         15s
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor            
                             │      Old      │                 New                 │
                             │    sec/op     │   sec/op     vs base                │
Marshal/pbName=TaskSize-24      287.8n ± 44%   189.8n ± 6%        ~ (p=0.239 n=10)
Marshal/pbName=Command-24      13.129µ ±  3%   6.931µ ± 2%  -47.21% (p=0.000 n=10)
Unmarshal/pbName=TaskSize-24    371.3n ±  9%   243.9n ± 6%  -34.30% (p=0.002 n=10)
Unmarshal/pbName=Command-24     40.12µ ±  3%   31.69µ ± 4%  -21.00% (p=0.000 n=10)
geomean                         2.739µ         1.786µ       -34.80%

                             │      Old      │                  New                  │
                             │      B/s      │      B/s       vs base                │
Marshal/pbName=TaskSize-24     19.88Mi ± 79%    30.15Mi ± 6%        ~ (p=0.247 n=10)
Marshal/pbName=Command-24      960.6Mi ±  3%   1819.7Mi ± 2%  +89.44% (p=0.000 n=10)
Unmarshal/pbName=TaskSize-24   15.41Mi ± 10%    23.46Mi ± 5%  +52.20% (p=0.002 n=10)
Unmarshal/pbName=Command-24    371.3Mi ±  3%    470.0Mi ± 4%  +26.59% (p=0.000 n=10)
geomean                        102.2Mi          156.8Mi       +53.38%

                             │     Old      │                  New                  │
                             │     B/op     │     B/op      vs base                 │
Marshal/pbName=TaskSize-24       16.00 ± 0%     16.00 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/pbName=Command-24      12.65Ki ± 0%   12.65Ki ± 0%       ~ (p=1.000 n=10)
Unmarshal/pbName=TaskSize-24     64.00 ± 0%     64.00 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/pbName=Command-24    33.42Ki ± 0%   33.42Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                          820.9          820.9       +0.00%
¹ all samples are equal

                             │    Old     │                 New                 │
                             │ allocs/op  │ allocs/op   vs base                 │
Marshal/pbName=TaskSize-24     1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/pbName=Command-24      1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/pbName=TaskSize-24   1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/pbName=Command-24    560.0 ± 0%   560.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                        4.865        4.865       +0.00%
¹ all samples are equal
```
