### PR TITLE
use vtproto (un)marshal in paging

### DIFF
--- a/server/util/paging/BUILD
+++ b/server/util/paging/BUILD
@@ -7,8 +7,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:pagination_go_proto",
+        "//server/util/proto",
         "//server/util/status",
-        "@org_golang_google_protobuf//proto",
     ],
 )
 

--- a/server/util/paging/paging.go
+++ b/server/util/paging/paging.go
@@ -3,8 +3,8 @@ package paging
 import (
 	"encoding/base64"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	"google.golang.org/protobuf/proto"
 
 	pgpb "github.com/buildbuddy-io/buildbuddy/proto/pagination"
 )


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

Benchmark:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor            
                                │     Old      │                 New                  │
                                │    sec/op    │    sec/op     vs base                │
Marshal/pbName=OffsetLimit-24     282.5n ± 17%   190.7n ±  4%  -32.48% (p=0.001 n=10)
Unmarshal/pbName=OffsetLimit-24   377.2n ± 15%   252.5n ± 30%  -33.07% (p=0.001 n=10)
geomean                           326.4n         219.4n        -32.78%

                                │      Old      │                  New                  │
                                │      B/s      │      B/s       vs base                │
Marshal/pbName=OffsetLimit-24     13.50Mi ± 21%   20.01Mi ±  4%  +48.20% (p=0.001 n=10)
Unmarshal/pbName=OffsetLimit-24   10.11Mi ± 18%   15.11Mi ± 23%  +49.36% (p=0.001 n=10)
geomean                           11.69Mi         17.39Mi        +48.78%

                                │    Old     │                 New                 │
                                │    B/op    │    B/op     vs base                 │
Marshal/pbName=OffsetLimit-24     16.00 ± 0%   16.00 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/pbName=OffsetLimit-24   64.00 ± 0%   64.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                           32.00        32.00       +0.00%
¹ all samples are equal

                                │    Old     │                 New                 │
                                │ allocs/op  │ allocs/op   vs base                 │
Marshal/pbName=OffsetLimit-24     1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/pbName=OffsetLimit-24   1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                           1.000        1.000       +0.00%
¹ all samples are equal

```