### PR TITLE
use vtproto in bazel_request.go

### DIFF
--- a/server/util/bazel_request/BUILD
+++ b/server/util/bazel_request/BUILD
@@ -7,9 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:remote_execution_go_proto",
+        "//server/util/proto",
         "//server/util/status",
         "@org_golang_google_grpc//metadata",
-        "@org_golang_google_protobuf//proto",
     ],
 )
 

--- a/server/util/bazel_request/bazel_request.go
+++ b/server/util/bazel_request/bazel_request.go
@@ -7,9 +7,9 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/protobuf/proto"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: 
Benchmark result shows vtproto is faster and no extra memory allocation.

```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor            
                                    │     Old     │                 New                  │
                                    │   sec/op    │    sec/op     vs base                │
Marshal/pbName=RequestMetadata-24     692.8n ± 8%   431.4n ±  3%  -37.72% (p=0.002 n=10)
Unmarshal/pbName=RequestMetadata-24   1.373µ ± 5%   1.083µ ± 16%  -21.16% (p=0.000 n=10)
geomean                               975.3n        683.4n        -29.93%

                                    │     Old      │                  New                  │
                                    │     B/s      │      B/s       vs base                │
Marshal/pbName=RequestMetadata-24     341.4Mi ± 9%   548.2Mi ±  3%  +60.56% (p=0.002 n=10)
Unmarshal/pbName=RequestMetadata-24   172.2Mi ± 5%   218.5Mi ± 19%  +26.85% (p=0.000 n=10)
geomean                               242.5Mi        346.1Mi        +42.71%

                                    │    Old     │                 New                 │
                                    │    B/op    │    B/op     vs base                 │
Marshal/pbName=RequestMetadata-24     256.0 ± 0%   256.0 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/pbName=RequestMetadata-24   592.0 ± 0%   592.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                               389.3        389.3       +0.00%
¹ all samples are equal

                                    │    Old     │                 New                 │
                                    │ allocs/op  │ allocs/op   vs base                 │
Marshal/pbName=RequestMetadata-24     1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/pbName=RequestMetadata-24   12.00 ± 0%   12.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                               3.464        3.464       +0.00%
¹ all samples are equal
```
