### PR TITLE
use server/util/proto library in prom.go

### DIFF
--- a/enterprise/server/backends/prom/BUILD
+++ b/enterprise/server/backends/prom/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//server/metrics",
         "//server/real_environment",
         "//server/util/log",
+        "//server/util/proto",
         "//server/util/status",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_prometheus_client_golang//api",
@@ -17,7 +18,6 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_model//go",
         "@com_github_prometheus_common//model",
-        "@org_golang_google_protobuf//proto",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/enterprise/server/backends/prom/prom.go
+++ b/enterprise/server/backends/prom/prom.go
@@ -14,13 +14,13 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/go-redis/redis/v8"
 	"github.com/prometheus/client_golang/api"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/protobuf/proto"
 
 	mpb "github.com/buildbuddy-io/buildbuddy/proto/metrics"
 	promapi "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -463,7 +463,7 @@ func (q *promQuerier) setMetrics(ctx context.Context, groupID string, metricFami
 		return nil
 	}
 	key := getExportedMetricsKey(groupID)
-	b, err := proto.Marshal(metricFamilies)
+	b, err := proto.MarshalOld(metricFamilies)
 	if err != nil {
 		return status.InternalErrorf("failed to marshal json: %s", err)
 	}

--- a/enterprise/server/backends/prom/prom.go
+++ b/enterprise/server/backends/prom/prom.go
@@ -463,6 +463,7 @@ func (q *promQuerier) setMetrics(ctx context.Context, groupID string, metricFami
 		return nil
 	}
 	key := getExportedMetricsKey(groupID)
+	// MarshalVT() is slower than regular Marshal for proto mpb.Metrics.
 	b, err := proto.MarshalOld(metricFamilies)
 	if err != nil {
 		return status.InternalErrorf("failed to marshal json: %s", err)

--- a/server/util/proto/proto.go
+++ b/server/util/proto/proto.go
@@ -8,8 +8,13 @@ import (
 
 var Clone = gproto.Clone
 var Size = gproto.Size
+var Merge = gproto.Merge
 var MarshalOld = gproto.Marshal
 var UnmarshalOld = gproto.Unmarshal
+
+var String = gproto.String
+var Float64 = gproto.Float64
+var Uint64 = gproto.Uint64
 
 type Message = gproto.Message
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Add a few method alias in proto.go

Use MarshalOld instead of Marshal b/c MarshalVT() is slower and uses more memory than standard Marshal for mdb.Metrics
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor            
                            │     Old     │                 New                 │
                            │   sec/op    │   sec/op     vs base                │
Marshal/pbName=Metrics-24     4.853m ± 4%   5.904m ± 1%  +21.67% (p=0.000 n=10)
Unmarshal/pbName=Metrics-24   8.796m ± 2%   8.705m ± 2%        ~ (p=0.218 n=10)
geomean                       6.533m        7.169m        +9.74%

                            │     Old      │                 New                  │
                            │     B/s      │     B/s       vs base                │
Marshal/pbName=Metrics-24     476.8Mi ± 4%   391.8Mi ± 1%  -17.81% (p=0.000 n=10)
Unmarshal/pbName=Metrics-24   251.9Mi ± 2%   254.5Mi ± 2%        ~ (p=0.218 n=10)
geomean                       346.6Mi        315.8Mi        -8.87%

                            │     Old      │                  New                  │
                            │     B/op     │     B/op      vs base                 │
Marshal/pbName=Metrics-24     2.839Mi ± 0%   5.682Mi ± 0%  +100.13% (p=0.000 n=10)
Unmarshal/pbName=Metrics-24   8.750Mi ± 0%   8.750Mi ± 0%         ~ (p=0.314 n=10)
geomean                       4.984Mi        7.051Mi        +41.47%

                            │     Old     │                  New                   │
                            │  allocs/op  │  allocs/op   vs base                   │
Marshal/pbName=Metrics-24      1.000 ± 0%    5.000 ± 0%  +400.00% (p=0.000 n=10)
Unmarshal/pbName=Metrics-24   255.3k ± 0%   255.3k ± 0%         ~ (p=1.000 n=10) ¹
geomean                        505.3        1.130k       +123.61%
¹ all samples are equal


```