### PR TITLE
Tune eager fetching to speed up LoadSnapshot

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -45,14 +45,14 @@ const (
 	// If we access a chunk, we will queue this number of contiguous chunks
 	// to be eagerly fetched in the background, anticipating that they will
 	// also be accessed
-	numChunksToEagerFetch = 4
+	numChunksToEagerFetch = 32
 
 	// Number of goroutines to run concurrently to convert a file to a COWStore.
 	fileConversionConcurrency = 8
 )
 
 var maxEagerFetchesPerSec = flag.Int("executor.snaploader_max_eager_fetches_per_sec", 1000, "Max number of chunks snaploader can eagerly fetch in the background per second.")
-var eagerFetchConcurrency = flag.Int("executor.snaploader_eager_fetch_concurrency", 8, "Max number of goroutines allowed to run concurrently when eagerly fetching chunks.")
+var eagerFetchConcurrency = flag.Int("executor.snaploader_eager_fetch_concurrency", 32, "Max number of goroutines allowed to run concurrently when eagerly fetching chunks.")
 
 // Total number of mmapped bytes by file name. The map value is an int64 pointer
 // which should be atomically updated. This backs the mapped bytes gauge vector


### PR DESCRIPTION
`Unpause` is a bottleneck for workflow performance - p90 Unpause time is about 25s according to metrics. For users, this means that 1 in 10 workflows spend about 25s in the "Invocation is waiting for available worker" state in the UI before they even start executing.

This PR reduces this latency by tuning the eager fetching parameters. Tested on some production snapshots - this reduces the LoadSnapshot duration from ~20-27s (~1.8 Gbps peak RX throughput, measured with `iftop`) to about 10.4s (~5 Gbps peak throughput).

**Related issues**: N/A
