### PR TITLE
Nicer looking CSS shadows

### DIFF
--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -1126,7 +1126,6 @@ svg.invocation-query-graph .nodes rect {
   padding: 16px;
 
   border-radius: 4px;
-  border: 1px solid #eee;
   border-left: 4px solid var(--status-color);
 
   display: flex;

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -428,16 +428,11 @@ svg.icon.orange {
 body {
   /* Shadow stacks based on: https://twitter.com/pixeljanitor/status/1735758919509684360 */
   --shadow-2: 0 1px 2px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.05);
-  --shadow-4: 0px 0px 0px 1px rgba(0, 0, 0, 0.06),
-  0px 1px 1px -0.5px rgba(0, 0, 0, 0.06),
-  0px 3px 3px -1.5px rgba(0, 0, 0, 0.06),
-  0px 6px 6px -3px rgba(0, 0, 0, 0.06);
-  --shadow-6: 0px 0px 0px 1px rgba(0, 0, 0, 0.06),
-  0px 1px 1px -0.5px rgba(0, 0, 0, 0.06),
-  0px 3px 3px -1.5px rgba(0, 0, 0, 0.06),
-  0px 6px 6px -3px rgba(0, 0, 0, 0.06),
-  0px 8px 12px -6px rgba(0, 0, 0, 0.06),
-  0px 10px 24px -12px rgba(0, 0, 0, 0.06);
+  --shadow-4: 0px 0px 0px 1px rgba(0, 0, 0, 0.06), 0px 1px 1px -0.5px rgba(0, 0, 0, 0.06),
+    0px 3px 3px -1.5px rgba(0, 0, 0, 0.06), 0px 6px 6px -3px rgba(0, 0, 0, 0.06);
+  --shadow-6: 0px 0px 0px 1px rgba(0, 0, 0, 0.06), 0px 1px 1px -0.5px rgba(0, 0, 0, 0.06),
+    0px 3px 3px -1.5px rgba(0, 0, 0, 0.06), 0px 6px 6px -3px rgba(0, 0, 0, 0.06), 0px 8px 12px -6px rgba(0, 0, 0, 0.06),
+    0px 10px 24px -12px rgba(0, 0, 0, 0.06);
 }
 
 .card {

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -426,13 +426,18 @@ svg.icon.orange {
 /** Card **/
 
 body {
-  /* Note: Each shadow has two layers, "umbra" (darker, smaller layer) followed
-     by "penumbra" (lighter, more diffuse layer). Numbering is set according to
-     the blur value of the "umbra" part, which indicates roughly how "big" the
-     shadow is. */
+  /* Shadow stacks based on: https://twitter.com/pixeljanitor/status/1735758919509684360 */
   --shadow-2: 0 1px 2px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.05);
-  --shadow-4: 0px 1px 4px rgba(0, 0, 0, 0.1), 0px 1px 6px rgba(0, 0, 0, 0.05);
-  --shadow-6: 0px 2px 6px rgba(0, 0, 0, 0.1), 0px 1px 10px rgba(0, 0, 0, 0.05);
+  --shadow-4: 0px 0px 0px 1px rgba(0, 0, 0, 0.06),
+  0px 1px 1px -0.5px rgba(0, 0, 0, 0.06),
+  0px 3px 3px -1.5px rgba(0, 0, 0, 0.06),
+  0px 6px 6px -3px rgba(0, 0, 0, 0.06);
+  --shadow-6: 0px 0px 0px 1px rgba(0, 0, 0, 0.06),
+  0px 1px 1px -0.5px rgba(0, 0, 0, 0.06),
+  0px 3px 3px -1.5px rgba(0, 0, 0, 0.06),
+  0px 6px 6px -3px rgba(0, 0, 0, 0.06),
+  0px 8px 12px -6px rgba(0, 0, 0, 0.06),
+  0px 10px 24px -12px rgba(0, 0, 0, 0.06);
 }
 
 .card {


### PR DESCRIPTION
Based on the advice here: https://twitter.com/pixeljanitor/status/1735758919509684360

Our current shadows have always felt a little dull and amorphous.

With this change, they become a bit more crisp and defined - but remain subtle.

Before:
<img width="1402" alt="Screenshot 2023-12-20 at 8 36 12 AM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/7df6d290-6ea2-4703-aefe-7c5481c09f01">

After:
<img width="1402" alt="Screenshot 2023-12-20 at 8 35 14 AM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/f69f93c7-0cce-46e8-9091-afe67aeb6c21">
