### PR TITLE
Improve chunk prioritization for eager fetching

### DIFF
--- a/enterprise/server/remote_execution/copy_on_write/BUILD
+++ b/enterprise/server/remote_execution/copy_on_write/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//server/remote_cache/digest",
         "//server/resources",
         "//server/util/alert",
+        "//server/util/boundedstack",
         "//server/util/lockmap",
         "//server/util/log",
         "//server/util/lru",

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write.go
@@ -655,8 +655,7 @@ func (s *COWStore) eagerFetchChunksInBackground() {
 			return
 		}
 		eg.Go(func() error {
-			err := s.fetchChunk(offset)
-			if err != nil {
+			if err := s.fetchChunk(offset); err != nil {
 				log.CtxWarningf(s.ctx, "COWStore eager fetch chunk failed with: %s", err)
 			}
 			return nil

--- a/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
+++ b/enterprise/server/remote_execution/copy_on_write/copy_on_write_test.go
@@ -388,45 +388,6 @@ func TestCOW_MmapLRUDoesNotDeadlock(t *testing.T) {
 	require.Equal(t, float64(0), n)
 }
 
-func TestBoundedStack_FillAndDrain(t *testing.T) {
-	s, err := copy_on_write.NewBoundedStack[int](2 /*=capacity*/)
-	require.NoError(t, err)
-
-	s.Push(1)
-	s.Push(2)
-	<-s.C
-	n, ok := s.Pop()
-	require.True(t, ok)
-	require.Equal(t, 2, n)
-	<-s.C
-	n, ok = s.Pop()
-	require.True(t, ok)
-	require.Equal(t, 1, n)
-
-	_, ok = s.Pop()
-	require.False(t, ok)
-}
-
-func TestBoundedStack_OverfillAndDrain(t *testing.T) {
-	s, err := copy_on_write.NewBoundedStack[int](2 /*=capacity*/)
-	require.NoError(t, err)
-
-	s.Push(1)
-	s.Push(2)
-	s.Push(3) // should evict 1
-	<-s.C
-	n, ok := s.Pop()
-	require.True(t, ok)
-	require.Equal(t, 3, n)
-	<-s.C
-	n, ok = s.Pop()
-	require.True(t, ok)
-	require.Equal(t, 2, n)
-
-	_, ok = s.Pop()
-	require.False(t, ok)
-}
-
 func BenchmarkCOW_ReadWritePerformance(b *testing.B) {
 	flags.Set(b, "app.log_level", "error")
 	log.Configure()

--- a/server/util/boundedstack/BUILD
+++ b/server/util/boundedstack/BUILD
@@ -13,8 +13,8 @@ go_library(
 go_test(
     name = "boundedstack_test",
     srcs = ["boundedstack_test.go"],
+    embed = [":boundedstack"],
     deps = [
-        ":boundedstack",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/util/boundedstack/BUILD
+++ b/server/util/boundedstack/BUILD
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "boundedstack",
+    srcs = ["boundedstack.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/boundedstack",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/util/status",
+    ],
+)
+
+go_test(
+    name = "boundedstack_test",
+    srcs = ["boundedstack_test.go"],
+    deps = [
+        ":boundedstack",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/server/util/boundedstack/boundedstack.go
+++ b/server/util/boundedstack/boundedstack.go
@@ -59,12 +59,12 @@ func (s *BoundedStack[T]) Push(item T) {
 	}
 }
 
-// Pop returns the top element of the stack. The second return value indicates
+// pop returns the top element of the stack. The second return value indicates
 // whether the returned item is valid; it will be false if and only if the stack
 // was empty.
 //
 // Pop does not block. Recv can be used to block until an item is available.
-func (c *BoundedStack[T]) Pop() (item T, ok bool) {
+func (c *BoundedStack[T]) pop() (item T, ok bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.size == 0 {
@@ -92,7 +92,7 @@ func (s *BoundedStack[T]) Recv(ctx context.Context) (item T, err error) {
 			var zero T
 			return zero, ctx.Err()
 		case <-s.recvNotify:
-			item, ok := s.Pop()
+			item, ok := s.pop()
 			if !ok {
 				// This can potentially happen if more pushes happened after the
 				// recv call and then other goroutines woke up and consumed the

--- a/server/util/boundedstack/boundedstack.go
+++ b/server/util/boundedstack/boundedstack.go
@@ -1,0 +1,100 @@
+package boundedstack
+
+import (
+	"sync"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+)
+
+// BoundedStack is a concurrency-safe stack with bounded size: when the capacity
+// of the stack is exceeded, the least recently added item ("bottom") of the
+// stack is removed.
+//
+// Its intended usage is to prioritize the most recently added items for eager
+// chunk fetching.
+//
+// It exposes a channel C which streams a value whenever a value is pushed on
+// the stack.
+//
+// IMPORTANT: after receiving a message from C, make sure to always call Pop.
+// Otherwise, the stack item corresponding to the notification on C may be
+// dropped unnecessarily.
+//
+// Example code for a goroutine that processes the latest items pushed to the
+// stack:
+//
+//	for range stack.C {
+//		val, ok := stack.Pop()
+//		if !ok {
+//			// A receive from C normally guarantees that a value is ready,
+//			// but it's best to always check `ok` when popping from the stack.
+//			continue
+//		}
+//		// Do something with val...
+//	}
+type BoundedStack[T any] struct {
+	// C is a notification channel which allows goroutines to listen for values
+	// being pushed to the stack.
+	//
+	// After a goroutine receives from C, it must call Pop - otherwise the stack
+	// item corresponding to the notification on C may be dropped unnecessarily.
+	C chan struct{}
+
+	mu     sync.Mutex
+	buffer []T
+	top    int
+	size   int
+}
+
+func New[T any](capacity int) (*BoundedStack[T], error) {
+	if capacity <= 0 {
+		return nil, status.InvalidArgumentError("bounded stack capacity must be > 0")
+	}
+	return &BoundedStack[T]{
+		C:      make(chan struct{}, capacity),
+		buffer: make([]T, capacity),
+	}, nil
+}
+
+// Push adds an item to the top of the stack, evicting the bottom item of the
+// stack if the stack is full.
+func (s *BoundedStack[T]) Push(item T) {
+	s.push(item)
+	// Notify the channel that a new item was pushed.
+	select {
+	case s.C <- struct{}{}:
+	default:
+		// If the channel buffer is full then it just means that the goroutines
+		// processing values from this stack aren't keeping up; this is fine.
+	}
+}
+
+func (s *BoundedStack[T]) push(item T) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.top = (s.top + 1) % len(s.buffer)
+	s.buffer[s.top] = item
+	s.size = min(s.size+1, len(s.buffer))
+}
+
+// Pop returns the top element of the stack. The second return value indicates
+// whether the returned item is valid; it will be false if and only if the stack
+// was empty.
+func (c *BoundedStack[T]) Pop() (item T, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.size == 0 {
+		var zero T
+		return zero, false
+	}
+	item = c.buffer[c.top]
+	// Zero out the item from the buffer to avoid keeping unnecessary references
+	// to any values transitively referenced by T (so that they can be
+	// garbage-collected).
+	var zero T
+	c.buffer[c.top] = zero
+
+	c.top = (c.top - 1 + len(c.buffer)) % len(c.buffer)
+	c.size--
+	return item, true
+}

--- a/server/util/boundedstack/boundedstack_test.go
+++ b/server/util/boundedstack/boundedstack_test.go
@@ -22,6 +22,9 @@ func TestBoundedStack_FillAndDrain(t *testing.T) {
 	n, err = s.Recv(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
+
+	_, ok := s.Pop()
+	require.False(t, ok, "stack should be empty")
 }
 
 func TestBoundedStack_OverfillAndDrain(t *testing.T) {
@@ -39,4 +42,7 @@ func TestBoundedStack_OverfillAndDrain(t *testing.T) {
 	n, err = s.Recv(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 2, n)
+
+	_, ok := s.Pop()
+	require.False(t, ok, "stack should be empty")
 }

--- a/server/util/boundedstack/boundedstack_test.go
+++ b/server/util/boundedstack/boundedstack_test.go
@@ -1,16 +1,15 @@
-package boundedstack_test
+package boundedstack
 
 import (
 	"context"
 	"testing"
 
-	"github.com/buildbuddy-io/buildbuddy/server/util/boundedstack"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBoundedStack_FillAndDrain(t *testing.T) {
 	ctx := context.Background()
-	s, err := boundedstack.New[int](2 /*=capacity*/)
+	s, err := New[int](2 /*=capacity*/)
 	require.NoError(t, err)
 
 	s.Push(1)
@@ -23,13 +22,13 @@ func TestBoundedStack_FillAndDrain(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
 
-	_, ok := s.Pop()
+	_, ok := s.pop()
 	require.False(t, ok, "stack should be empty")
 }
 
 func TestBoundedStack_OverfillAndDrain(t *testing.T) {
 	ctx := context.Background()
-	s, err := boundedstack.New[int](2 /*=capacity*/)
+	s, err := New[int](2 /*=capacity*/)
 	require.NoError(t, err)
 
 	s.Push(1)
@@ -43,6 +42,6 @@ func TestBoundedStack_OverfillAndDrain(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, n)
 
-	_, ok := s.Pop()
+	_, ok := s.pop()
 	require.False(t, ok, "stack should be empty")
 }

--- a/server/util/boundedstack/boundedstack_test.go
+++ b/server/util/boundedstack/boundedstack_test.go
@@ -1,0 +1,59 @@
+package boundedstack_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/boundedstack"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoundedStack_FillAndDrain(t *testing.T) {
+	s, err := boundedstack.New[int](2 /*=capacity*/)
+	require.NoError(t, err)
+
+	s.Push(1)
+	s.Push(2)
+
+	<-s.C
+	n, ok := s.Pop()
+	require.True(t, ok)
+	require.Equal(t, 2, n)
+	<-s.C
+	n, ok = s.Pop()
+	require.True(t, ok)
+	require.Equal(t, 1, n)
+
+	select {
+	case <-s.C:
+		require.FailNow(t, "channel should be drained")
+	default:
+	}
+	_, ok = s.Pop()
+	require.False(t, ok)
+}
+
+func TestBoundedStack_OverfillAndDrain(t *testing.T) {
+	s, err := boundedstack.New[int](2 /*=capacity*/)
+	require.NoError(t, err)
+
+	s.Push(1)
+	s.Push(2)
+	s.Push(3) // should evict 1
+
+	<-s.C
+	n, ok := s.Pop()
+	require.True(t, ok)
+	require.Equal(t, 3, n)
+	<-s.C
+	n, ok = s.Pop()
+	require.True(t, ok)
+	require.Equal(t, 2, n)
+
+	select {
+	case <-s.C:
+		require.FailNow(t, "channel should be drained")
+	default:
+	}
+	_, ok = s.Pop()
+	require.False(t, ok)
+}


### PR DESCRIPTION
My hypothesis that motivated this PR was that when the `eagerFetchChan` is saturated we'll spend less time fetching newer/more important chunks and more time fetching older/less important chunks.

This PR changes the data structure for the eager fetch list from a buffered `chan` to a new `BoundedStack` data structure, so that new chunks can always be added to the list of chunks to be eagerly fetched, evicting the oldest chunk when the stack's capacity is exceeded. Under the hood, the `BoundedStack` is backed by a ring buffer, and it also exposes a channel that receives a value whenever an item is pushed (so that the eager fetch goroutines can be notified whenever it's safe to `pop`).

Did some testing, comparing `master` to this PR branch (`eager-fetch-prio`). Alternated between the two branches, clearing filecache then running vmstart to load a remote snapshot (from prod), and appended the `LoadSnapshot` duration to a file. Then generated a summary of the durations in the file.

Results (the stack-based approach reduces LoadSnapshot duration by about 25%):

```
Durations summary for eager-fetch-prio.log (n=10):
Mean: 10.915s
0.25 quartile: 10.294s
0.50 quartile (median): 10.684s
0.75 quartile: 11.424s

Durations summary for master.log (n=10):
Mean: 13.774s
0.25 quartile: 13.476s
0.50 quartile (median): 13.973s
0.75 quartile: 14.258s
```

**Related issues**: N/A
