### PR TITLE
Fix double passing bb cli commands to handlers 

### DIFF
--- a/cli/ask/ask.go
+++ b/cli/ask/ask.go
@@ -65,7 +65,7 @@ func HandleAsk(args []string) (int, error) {
 
 	apiKey, err := storage.ReadRepoConfig("api-key")
 	if err != nil {
-		exitCode, err := login.HandleLogin([]string{"login"})
+		exitCode, err := login.HandleLogin([]string{})
 		if exitCode > 0 || err != nil {
 			return exitCode, err
 		}

--- a/cli/fix/fix.go
+++ b/cli/fix/fix.go
@@ -130,7 +130,7 @@ func walk() error {
 	for l := range foundLanguages {
 		for _, d := range l.Deps() {
 			log.Debugf("Adding %s", d)
-			_, err := add.HandleAdd([]string{"add", d})
+			_, err := add.HandleAdd([]string{d})
 			if err != nil {
 				log.Debugf("Failed adding %s: %s", d, err)
 			}

--- a/cli/version/version_test.go
+++ b/cli/version/version_test.go
@@ -19,7 +19,7 @@ func TestHandleVersion(t *testing.T) {
 	require.NoError(t, err)
 	os.Stdout = w
 
-	exitCode, err := version.HandleVersion([]string{"version", "--cli"})
+	exitCode, err := version.HandleVersion([]string{"--cli"})
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode)
 


### PR DESCRIPTION
With the cli refactor, we no longer need to pass the command name to the handler because we parse it upfront in bb.go