### PR TITLE
Use Bazel 6.4.0 for non-m1 mac release for now.

### DIFF
--- a/.github/workflows/release-mac.yaml
+++ b/.github/workflows/release-mac.yaml
@@ -54,6 +54,7 @@ jobs:
       - name: Build and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          USE_BAZEL_VERSION: 6.4.0
         run: |
           export DEVELOPER_DIR=/Applications/Xcode_12.4.app/Contents/Developer
           "${GITHUB_WORKSPACE}/bin/bazel" build --config=release-mac --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //server/cmd/buildbuddy:buildbuddy //enterprise/server/cmd/server:buildbuddy //enterprise/server/cmd/executor:executor


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
