### PR TITLE
mac-release: fix Bazel 7 compatibility

### DIFF
--- a/.github/workflows/release-mac.yaml
+++ b/.github/workflows/release-mac.yaml
@@ -54,9 +54,8 @@ jobs:
       - name: Build and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          USE_BAZEL_VERSION: 6.4.0
+          XCODE_VERSION: 12.4
         run: |
-          export DEVELOPER_DIR=/Applications/Xcode_12.4.app/Contents/Developer
           "${GITHUB_WORKSPACE}/bin/bazel" build --config=release-mac --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //server/cmd/buildbuddy:buildbuddy //enterprise/server/cmd/server:buildbuddy //enterprise/server/cmd/executor:executor
           cp bazel-bin/server/cmd/**/**/buildbuddy buildbuddy-darwin-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/buildbuddy buildbuddy-enterprise-darwin-amd64


### PR DESCRIPTION
It seems like the older versions are not compatible with Bazel 7.

Use of `XCODE_VERSION` instead of `DEVELOPER_DIR` for accurate
autoxcode_config result.
