### PR TITLE
Fix release workflows

### DIFF
--- a/.github/workflows/release-m1.yaml
+++ b/.github/workflows/release-m1.yaml
@@ -36,7 +36,7 @@ jobs:
         id: vars
         run: |
           # Configure repo based on pushed tag if set
-          if [ -z "${GITHUB_REF}" ]; then
+          if [ ${{ github.event_name }} = 'push' ]; then
             ref="${GITHUB_REF}"
             tag=${GITHUB_REF/refs\/tags\//}
           else

--- a/.github/workflows/release-mac.yaml
+++ b/.github/workflows/release-mac.yaml
@@ -25,7 +25,7 @@ jobs:
         id: vars
         run: |
           # Configure repo based on pushed tag if set
-          if [ -z "${GITHUB_REF}" ]; then
+          if [ ${{ github.event_name }} = 'push' ]; then
             ref="${GITHUB_REF}"
             tag=${GITHUB_REF/refs\/tags\//}
           else

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
         id: vars
         run: |
           # Configure repo based on pushed tag if set
-          if [ -z "${GITHUB_REF}" ]; then
+          if [ ${{ github.event_name }} = 'push' ]; then
             ref="${GITHUB_REF}"
             tag=${GITHUB_REF/refs\/tags\//}
           else


### PR DESCRIPTION
I realized that GITHUB_REF is always set, even if the workflow was not triggered by a push event. 
