### PR TITLE
Fix bazel-bin references in docusaurus builds

### DIFF
--- a/rules/yarn/index.bzl
+++ b/rules/yarn/index.bzl
@@ -1,4 +1,6 @@
 DEFAULT_CMD_TPL = """
+# NOTE: BazelBinResolverPlugin in docusaurus.config.js depends on ROOTDIR being set
+# to the original execution working directory.
 export ROOTDIR=$$(pwd) &&
 export PACKAGEDIR=$$(dirname $(location {package})) &&
 export PATH=$$ROOTDIR/$$(dirname $(location {yarn})):$$ROOTDIR/$$(dirname $(location {node})):$$PATH &&

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "rootDirs": [
       ".",
       "bazel-bin",
+      // Keep the following in sync with website/docusaurus.config.js
       "bazel-out/k8-opt/bin",
       "bazel-out/k8-fastbuild/bin",
       "bazel-out/linux_x86_64-fastbuild/bin",


### PR DESCRIPTION
We were previously relying on `bazel` to create the `bazel-bin` dir for us, which is unsound because `bazel-bin` is only created after bazel successfully runs once. This means that `bazel clean && bazel build website` fails currently.

This PR adds a webpack resolver plugin to translate `bazel-bin` references to the real action input paths in the execroot. Basically, we want to do the same thing that we do in /tsconfig.json (listing out all the possible bazel-out/ paths), except docusaurus doesn't have a way to customize the tsconfig it uses, so instead we use a webpack plugin.

**Related issues**: N/A
