### PR TITLE
Don't call `testenv.LocalGRPCServer` in `testcache.Setup`

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -228,7 +228,7 @@ func getTestEnv(ctx context.Context, t *testing.T, opts envOpts) *testenv.TestEn
 	if err != nil {
 		t.Error(err)
 	}
-	grpcServer, runFunc := testenv.LocalGRPCServer(env)
+	grpcServer, runFunc := testenv.RegisterLocalGRPCServer(env)
 	repb.RegisterContentAddressableStorageServer(grpcServer, casServer)
 	repb.RegisterActionCacheServer(grpcServer, actionCacheServer)
 	bspb.RegisterByteStreamServer(grpcServer, byteStreamServer)

--- a/enterprise/server/remote_execution/dirtools/dirtools_test.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools_test.go
@@ -867,7 +867,7 @@ func testEnv(t *testing.T) (*testenv.TestEnv, context.Context) {
 	if err != nil {
 		t.Error(err)
 	}
-	grpcServer, runFunc := testenv.LocalGRPCServer(env)
+	grpcServer, runFunc := testenv.RegisterLocalGRPCServer(env)
 	repb.RegisterContentAddressableStorageServer(grpcServer, casServer)
 	bspb.RegisterByteStreamServer(grpcServer, byteStreamServer)
 	go runFunc()

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -65,7 +65,9 @@ func setupEnv(t *testing.T) *testenv.TestEnv {
 	scheduler := &schedulerServerMock{}
 	env.SetSchedulerService(scheduler)
 
+	_, run := testenv.RegisterLocalGRPCServer(env)
 	testcache.Setup(t, env)
+	go run()
 	tasksize.Register(env)
 
 	s, err := execution_server.NewExecutionServer(env)

--- a/enterprise/server/remote_execution/snaputil/snaputil_test.go
+++ b/enterprise/server/remote_execution/snaputil/snaputil_test.go
@@ -24,17 +24,25 @@ import (
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 )
 
+func setupEnv(t *testing.T) *testenv.TestEnv {
+	env := testenv.GetTestEnv(t)
+	fc, err := filecache.NewFileCache(testfs.MakeTempDir(t), 100_000, false)
+	require.NoError(t, err)
+	env.SetFileCache(fc)
+	_, run := testenv.RegisterLocalGRPCServer(env)
+	testcache.Setup(t, env)
+	go run()
+	return env
+}
+
 func TestCacheAndFetchArtifact(t *testing.T) {
 	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
 
-	env := testenv.GetTestEnv(t)
+	env := setupEnv(t)
 	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), env)
 	require.NoError(t, err)
 	tmpDir := testfs.MakeTempDir(t)
-
-	fc, err := filecache.NewFileCache(tmpDir, 100000, false)
-	require.NoError(t, err)
-	testcache.Setup(t, env)
+	fc := env.GetFileCache()
 
 	length := rand.Intn(1000)
 	randomStr, err := random.RandomString(length)
@@ -91,14 +99,11 @@ func TestCacheAndFetchArtifact(t *testing.T) {
 func TestCacheAndFetchArtifact_LocalOnly(t *testing.T) {
 	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
 
-	env := testenv.GetTestEnv(t)
+	env := setupEnv(t)
 	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), env)
 	require.NoError(t, err)
 	tmpDir := testfs.MakeTempDir(t)
-
-	fc, err := filecache.NewFileCache(tmpDir, 10000, false)
-	require.NoError(t, err)
-	testcache.Setup(t, env)
+	fc := env.GetFileCache()
 
 	length := rand.Intn(1000)
 	randomStr, err := random.RandomString(length)
@@ -129,14 +134,11 @@ func TestCacheAndFetchArtifact_LocalOnly(t *testing.T) {
 func TestCacheAndFetchBytes(t *testing.T) {
 	flags.Set(t, "executor.enable_remote_snapshot_sharing", true)
 
-	env := testenv.GetTestEnv(t)
+	env := setupEnv(t)
 	ctx, err := prefix.AttachUserPrefixToContext(context.Background(), env)
 	require.NoError(t, err)
 	tmpDir := testfs.MakeTempDir(t)
-
-	fc, err := filecache.NewFileCache(tmpDir, 100000, false)
-	require.NoError(t, err)
-	testcache.Setup(t, env)
+	fc := env.GetFileCache()
 
 	length := rand.Intn(1000)
 	randomStr, err := random.RandomString(length)

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -103,7 +103,7 @@ func getEnv(t *testing.T, opts *schedulerOpts, user string) (*testenv.TestEnv, c
 	require.NoError(t, err)
 	env.SetSchedulerService(s)
 
-	server, runFunc := testenv.LocalGRPCServer(env)
+	server, runFunc := testenv.RegisterLocalGRPCServer(env)
 	scpb.RegisterSchedulerServer(server, env.GetSchedulerService())
 	go runFunc()
 	t.Cleanup(func() { server.Stop() })

--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -103,7 +103,7 @@ func runBBServer(ctx context.Context, env *testenv.TestEnv, t *testing.T) *grpc.
 	bsServer, err := byte_stream_server.NewByteStreamServer(env)
 	require.NoError(t, err)
 
-	grpcServer, runFunc := testenv.LocalGRPCServer(env)
+	grpcServer, runFunc := testenv.RegisterLocalGRPCServer(env)
 	bbspb.RegisterBuildBuddyServiceServer(grpcServer, buildBuddyServer)
 	bspb.RegisterByteStreamServer(grpcServer, bsServer)
 

--- a/server/build_event_protocol/build_event_server/build_event_server_test.go
+++ b/server/build_event_protocol/build_event_server/build_event_server_test.go
@@ -16,7 +16,7 @@ func TestPublishBuildToolEventStream_NoEvents(t *testing.T) {
 	env := testenv.GetTestEnv(t)
 	server, err := build_event_server.NewBuildEventProtocolServer(env, false /*=synchronous*/)
 	require.NoError(t, err)
-	grpcServer, runServer := testenv.LocalGRPCServer(env)
+	grpcServer, runServer := testenv.RegisterLocalGRPCServer(env)
 	pepb.RegisterPublishBuildEventServer(grpcServer, server)
 	go runServer()
 	t.Cleanup(func() {

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -42,7 +42,7 @@ func runByteStreamServer(ctx context.Context, env *testenv.TestEnv, t *testing.T
 		t.Error(err)
 	}
 
-	grpcServer, runFunc := testenv.LocalGRPCServer(env)
+	grpcServer, runFunc := testenv.RegisterLocalGRPCServer(env)
 	bspb.RegisterByteStreamServer(grpcServer, byteStreamServer)
 
 	go runFunc()

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -47,7 +47,7 @@ func runCASServer(ctx context.Context, env *testenv.TestEnv, t *testing.T) *grpc
 		t.Error(err)
 	}
 
-	grpcServer, runFunc := testenv.LocalGRPCServer(env)
+	grpcServer, runFunc := testenv.RegisterLocalGRPCServer(env)
 	repb.RegisterContentAddressableStorageServer(grpcServer, casServer)
 	bspb.RegisterByteStreamServer(grpcServer, byteStreamServer)
 	go runFunc()

--- a/server/testutil/testcache/testcache.go
+++ b/server/testutil/testcache/testcache.go
@@ -14,8 +14,19 @@ import (
 )
 
 // Setup configures ActionCache, Bytestream, and ContentAddressableStorage
-// services in the given test env.
+// services in the given test env and registers them to the local gRPC server.
+// The gRPC server must be registered to the env before calling this func.
+//
+// Example:
+//
+//	srv, runServer := testenv.RegisterLocalGRPCServer(env)
+//	testcache.Setup(t, env)
+//	// Register more services to srv if needed...
+//	go runServer()
 func Setup(t *testing.T, env *testenv.TestEnv) {
+	require.NotNil(t, env.GetGRPCServer(), "GRPC server is missing from env. Call testenv.RegisterLocalGRPCServer first")
+	require.NotNil(t, env.GetLocalBufconnListener(), "Missing bufconn listener in env. Make sure you aren't calling SetGRPCServer in the test env, and call testenv.RegisterLocalGRPCServer instead")
+
 	ac, err := action_cache_server.NewActionCacheServer(env)
 	require.NoError(t, err)
 	bs, err := byte_stream_server.NewByteStreamServer(env)
@@ -23,12 +34,9 @@ func Setup(t *testing.T, env *testenv.TestEnv) {
 	cas, err := content_addressable_storage_server.NewContentAddressableStorageServer(env)
 	require.NoError(t, err)
 
-	srv, runFunc := testenv.LocalGRPCServer(env)
-	repb.RegisterActionCacheServer(srv, ac)
-	bspb.RegisterByteStreamServer(srv, bs)
-	repb.RegisterContentAddressableStorageServer(srv, cas)
-
-	go runFunc()
+	repb.RegisterActionCacheServer(env.GetGRPCServer(), ac)
+	bspb.RegisterByteStreamServer(env.GetGRPCServer(), bs)
+	repb.RegisterContentAddressableStorageServer(env.GetGRPCServer(), cas)
 
 	conn, err := testenv.LocalGRPCConn(env.GetServerContext(), env)
 	require.NoError(t, err)


### PR DESCRIPTION
TLDR don't call `testenv.LocalGRPCServer` in `testcache.Setup` - `testenv.LocalGRPCServer` is designed to be called at most once, and `testenv.LocalGRPCConn` is supposed to connect to the one server that was created. So, don't "hog" the server registration in `testcache.Setup` since the test setup code may want to register other services too. (Also, make it an error to call `LocalGRPCServer` more than once).

---

I ran into the following issue while adding a test case to `execution_server_test.go`:
- I needed to run an in-process gRPC server and register the ExecutionServer to it, so that I could make a real PublishOperation RPC in the test.
  - Normally I would just call the RPC method handler directly, but this is a pain for streaming RPCs - it's easier to invoke the method as an actual gRPC request.
- To run an in-process gRPC server, I tried using `testenv.LocalGRPCServer`.
- However, `testenv.LocalGRPCServer` was being called by this test already (indirectly, via `testcache.Setup`). This is problematic because `testenv.LocalGRPCServer` is only designed to be called once.
- Specifically, the problem I was seeing was that if more than one gRPC server is associated with the same `bufconn` listener, it appears that gRPC will randomly (?) select the server to dial. As a result, the test becomes flaky, because the server that the `bufconn` happens to pick may or may not have the desired service that we are trying to call.

To resolve this issue, this PR updates `testcache.Setup` to not create its own gRPC server, and instead use the one set up in the env. It also changes `testenv.LocalGRPCServer` to register the server in the env, and renames it to `testenv.RegisterLocalGRPCServer`.

**Related issues**: N/A
