### PR TITLE
Prevent bazel from generating MODULE.bazel file

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-build --noenable_bzlmod
+common --noenable_bzlmod
 
 build --enable_platform_specific_config=true
 query --enable_platform_specific_config=true


### PR DESCRIPTION
Bazel keeps trying to generate `MODULE.bazel` and `MODULE.bazel.lock` when I run certain commands. This seems to fix it.

**Related issues**: N/A
