### PR TITLE
Add trace span in podman.pullImage()

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -625,6 +625,8 @@ func (c *podmanCommandContainer) getCID(ctx context.Context) (string, error) {
 }
 
 func (c *podmanCommandContainer) pullImage(ctx context.Context, creds oci.Credentials) error {
+	ctx, span := tracing.StartSpan(ctx)
+	defer span.End()
 	podmanArgs := make([]string, 0, 2)
 
 	if c.imageIsStreamable {


### PR DESCRIPTION
Per my most recent comment in https://github.com/buildbuddy-io/buildbuddy-internal/issues/2844 we can lose some time in `podman.PullImage` due to the locking behavior. This span should measure when we start and for how long we're actually pulling the image, as opposed to messing around with locks, which will be basically the difference between `podman.PullImage` and `podman.pullImage`.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/2844