### PR TITLE
Add `ResourceName.address` field

### DIFF
--- a/proto/resource.proto
+++ b/proto/resource.proto
@@ -33,6 +33,12 @@ message ResourceName {
   // that this is only correct for the following digest types:
   // MD5, MURMUR3, SHA1, SHA256, SHA384, SHA512, VSO.
   build.bazel.remote.execution.v2.DigestFunction.Value digest_function = 5;
+
+  // The hostname or hostname:port of the cache service. If not present, the
+  // rest of the values in the resource name refer to the local service address,
+  // similar to how a URL consisting only of a path is relative to the current
+  // domain.
+  string address = 6;
 }
 
 // CacheType represents the type of cache being written to.


### PR DESCRIPTION
This will be helpful for a UI refactor that aims to reduce the number of places where we manually construct bytestream:// and actioncache:// URLs (https://github.com/buildbuddy-io/buildbuddy/pull/5634)

I found myself writing a function in JS like

```
function bytestreamURL(address: string, resourceName: ResourceName): string { ... }
```

but I realized that it makes more sense for the `address` field to just be another field of `ResourceName`. A raw (string) resource name roughly follows this schema:

```
bytestream://{address}/{instance_name}/compressed-blobs/{compressor}/{digest_function}/{digest}
```

so it makes sense that `address` should be part of the structured form of this resource name string.

**Related issues**: N/A
