### PR TITLE
Ignore MODULE.bazel because bazel 7 is auto-generating one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ tramp
 # Bazel directories
 /bazel-*
 
+# MODULE.bazel stuff, for now
+MODULE.bazel
+MODULE.bazel.lock
+
 # Generated protos
 **/proto/**/*.pb.go
 **/proto/**/*_ts_proto.d.ts


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
