### PR TITLE
Increase rbetest command wait timeout

### DIFF
--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -89,7 +89,7 @@ const (
 	// We are currently not testing non-default instances, but we should at some point.
 	defaultInstanceName = ""
 
-	defaultWaitTimeout = 20 * time.Second
+	defaultWaitTimeout = 60 * time.Second
 )
 
 func init() {


### PR DESCRIPTION
`cmd.Wait()` times out when the executors are under high load. Increase the timeout to reduce flakes.

**Related issues**: N/A
