### PR TITLE
Revert scheduler_server refactor

### DIFF
--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -63,6 +63,5 @@ go_test(
         "@com_github_google_uuid//:uuid",
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//require",
-        "@org_golang_google_protobuf//types/known/durationpb",
     ],
 )

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1,7 +1,6 @@
 package scheduler_server
 
 import (
-	"container/ring"
 	"context"
 	"flag"
 	"fmt"
@@ -72,10 +71,6 @@ const (
 
 	// The maximum number of times a task may be re-enqueued.
 	maxTaskAttemptCount = 5
-
-	// The maximum number of times the scheduler will attempt to enqueue a
-	// single task across the entire executor pool.
-	maxAttemptedEnqueueCount = 100
 
 	// Number of unclaimed tasks to try to assign to a node that newly joined.
 	tasksToEnqueueOnJoin = 20
@@ -539,17 +534,16 @@ func toNodeInterfaces(nodes []*executionNode) []interfaces.ExecutionNode {
 	return out
 }
 
-func toRankedNodeRing(nodes []interfaces.RankedExecutionNode) (*ring.Ring, error) {
-	nodeRing := ring.New(len(nodes))
+func fromNodeInterfaces(nodes []interfaces.RankedExecutionNode) ([]*rankedExecutionNode, error) {
+	out := make([]*rankedExecutionNode, 0, len(nodes))
 	for _, node := range nodes {
 		en, ok := node.GetExecutionNode().(*executionNode)
 		if !ok {
 			return nil, status.InternalError("failed to convert executionNode to interface; this should never happen")
 		}
-		nodeRing.Value = rankedExecutionNode{node: en, preferred: node.IsPreferred()}
-		nodeRing = nodeRing.Next()
+		out = append(out, &rankedExecutionNode{node: en, preferred: node.IsPreferred()})
 	}
-	return nodeRing, nil
+	return out, nil
 }
 
 type nodePoolKey struct {
@@ -1662,6 +1656,7 @@ func (s *SchedulerServer) enqueueTaskReservations(ctx context.Context, enqueueRe
 	}
 
 	probeCount := min(opts.numReplicas, nodeCount)
+	probesSent := 0
 	scheduledOnPreferredNode := false
 
 	startTime := time.Now()
@@ -1679,76 +1674,106 @@ func (s *SchedulerServer) enqueueTaskReservations(ctx context.Context, enqueueRe
 	// Note: preferredNode may be nil if the executor ID isn't specified or if
 	// the executor is no longer connected.
 	preferredNode := nodeBalancer.FindConnectedExecutorByID(enqueueRequest.GetExecutorId())
-	if preferredNode != nil {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			break
-		}
-		enqueueStart := time.Now()
-		if s.enqueue(ctx, preferredNode, enqueueRequest, opts) {
-			scheduledOnPreferredNode = true
-			successfulReservations = append(successfulReservations, successfulReservation(preferredNode, enqueueStart))
-		}
-	}
-
-	nodes := nodeBalancer.GetNodes(opts.scheduleOnConnectedExecutors)
-	if len(nodes) == 0 {
-		return status.UnavailableErrorf("No registered executors in pool %q with os %q with arch %q.", pool, os, arch)
-	}
-	nodes = nodesThatFit(nodes, enqueueRequest.GetTaskSize())
-	if len(nodes) == 0 {
-		return status.UnavailableErrorf(
-			"No registered executors in pool %q with os %q with arch %q can fit a task with %d milli-cpu and %d bytes of memory.",
-			pool, os, arch,
-			enqueueRequest.GetTaskSize().GetEstimatedMilliCpu(),
-			enqueueRequest.GetTaskSize().GetEstimatedMemoryBytes())
-	}
-	rankedNodes := s.taskRouter.RankNodes(ctx, cmd, remoteInstanceName, toNodeInterfaces(nodes))
-	nodeRing, err := toRankedNodeRing(rankedNodes)
-	if err != nil {
-		return err
-	}
 
 	attempts := 0
+	var rankedNodes []*rankedExecutionNode
+	sampleIndex := 0
 	nonPreferredDelay := getNonPreferredSchedulingDelay(cmd)
-	delayable := enqueueRequest.GetDelay() == nil
-	for ; len(successfulReservations) < probeCount; nodeRing = nodeRing.Next() {
+	delaySpecified := enqueueRequest.GetDelay() != nil
+	for probesSent < probeCount {
+		attempts++
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
 			break
 		}
-
-		rankedNode, ok := nodeRing.Value.(rankedExecutionNode)
-		if !ok {
-			return status.InternalError("failed to convert nodeRing to executionNode; this should never happen")
-		}
-		attempts++
 		if opts.maxAttempts > 0 && attempts > opts.maxAttempts {
 			return status.ResourceExhaustedErrorf("could not enqueue task reservation to executor")
 		}
-		if attempts > maxAttemptedEnqueueCount {
+		if attempts > 100 {
 			log.CtxWarningf(ctx, "Attempted to send probe %d times for task %q with pool key %+v. This should not happen.", attempts, enqueueRequest.GetTaskId(), key)
 		}
+		if sampleIndex == 0 {
+			if preferredNode != nil {
+				rankedNodes = []*rankedExecutionNode{&rankedExecutionNode{node: preferredNode, preferred: true}}
+				// Unset the preferred node so that we fall back to random sampling
+				// (in subsequent loop iterations) if the preferred node probe fails.
+				preferredNode = nil
+			} else {
+				candidateNodes := nodeBalancer.GetNodes(opts.scheduleOnConnectedExecutors)
+				if len(candidateNodes) == 0 {
+					return status.UnavailableErrorf("No registered executors in pool %q with os %q with arch %q.", pool, os, arch)
+				}
+				candidateNodes = nodesThatFit(candidateNodes, enqueueRequest.GetTaskSize())
+				if len(candidateNodes) == 0 {
+					return status.UnavailableErrorf(
+						"No registered executors in pool %q with os %q with arch %q can fit a task with %d milli-cpu and %d bytes of memory.",
+						pool, os, arch,
+						enqueueRequest.GetTaskSize().GetEstimatedMilliCpu(),
+						enqueueRequest.GetTaskSize().GetEstimatedMemoryBytes())
+				}
+				rankedNodes, err = fromNodeInterfaces(s.taskRouter.RankNodes(ctx, cmd, remoteInstanceName, toNodeInterfaces(candidateNodes)))
+				if err != nil {
+					return err
+				}
+			}
+		}
+		if sampleIndex >= len(rankedNodes) {
+			return status.FailedPreconditionErrorf("sampleIndex %d >= %d", sampleIndex, len(rankedNodes))
+		}
 
+		rankedNode := rankedNodes[sampleIndex]
+		node := rankedNode.node
+		sampleIndex = (sampleIndex + 1) % len(rankedNodes)
 		// Set the executor ID in case the node is owned by another scheduler, so
 		// that the scheduler can prefer this node for the probe.
-		enqueueRequest.ExecutorId = rankedNode.node.GetExecutorID()
-		enqueueStart := time.Now()
-		if delayable && scheduledOnPreferredNode && !rankedNode.preferred && nonPreferredDelay > 0*time.Second {
-			enqueueRequest.Delay = durationpb.New(nonPreferredDelay)
-		} else if delayable {
-			enqueueRequest.Delay = nil
+		enqueueRequest.ExecutorId = node.GetExecutorID()
+		if !delaySpecified {
+			// This function is re-entrant, don't delete caller-set delays.
+			if scheduledOnPreferredNode && !rankedNode.preferred && nonPreferredDelay > 0*time.Second {
+				enqueueRequest.Delay = durationpb.New(nonPreferredDelay)
+			} else {
+				enqueueRequest.Delay = nil
+			}
 		}
-		if s.enqueue(ctx, rankedNode.node, enqueueRequest, opts) {
-			if rankedNode.preferred {
+
+		enqueueStart := time.Now()
+		if opts.scheduleOnConnectedExecutors {
+			if node.handle == nil {
+				log.CtxErrorf(ctx, "nil handle for a local executor %q", node.GetExecutorID())
+				continue
+			}
+			_, err := node.handle.EnqueueTaskReservation(ctx, enqueueRequest)
+			if err != nil {
+				continue
+			} else if rankedNode.preferred {
 				scheduledOnPreferredNode = true
 			}
-			successfulReservations = append(successfulReservations, successfulReservation(rankedNode.node, enqueueStart))
+		} else {
+			if node.schedulerHostPort == "" {
+				log.CtxErrorf(ctx, "node %q has no scheduler host:port set", node.GetExecutorID())
+				continue
+			}
+
+			schedulerClient, err := s.schedulerClientCache.get(node.schedulerHostPort)
+			if err != nil {
+				log.CtxWarningf(ctx, "Could not get SchedulerClient for %q: %s", node.schedulerHostPort, err)
+				continue
+			}
+			rpcCtx, cancel := context.WithTimeout(ctx, schedulerEnqueueTaskReservationTimeout)
+			_, err = schedulerClient.EnqueueTaskReservation(rpcCtx, enqueueRequest)
+			cancel()
+			if err != nil {
+				log.CtxWarningf(ctx, "EnqueueTaskReservation via scheduler target %q failed: %s", node.schedulerHostPort, err)
+				time.Sleep(schedulerEnqueueTaskReservationFailureSleep)
+				continue
+			} else if rankedNode.preferred {
+				scheduledOnPreferredNode = true
+			}
 		}
+		successfulReservations = append(successfulReservations, fmt.Sprintf("%s [%s]", node.String(), time.Since(enqueueStart).String()))
+		probesSent++
 	}
 	return nil
 }
@@ -1774,52 +1799,6 @@ func getNonPreferredSchedulingDelay(cmd *repb.Command) time.Duration {
 		return maxPermittedSchedulingDelay
 	}
 	return d
-}
-
-func successfulReservation(node *executionNode, enqueueStart time.Time) string {
-	return fmt.Sprintf("%s [%s]", node.String(), time.Since(enqueueStart).String())
-}
-
-func (s *SchedulerServer) enqueue(ctx context.Context, node *executionNode, request *scpb.EnqueueTaskReservationRequest, opts enqueueTaskReservationOpts) bool {
-	if opts.scheduleOnConnectedExecutors {
-		return enqueueOnConnectedExecutor(ctx, node, request)
-	} else {
-		return s.enqueueOnRemoteExecutor(ctx, node, request)
-	}
-}
-
-func enqueueOnConnectedExecutor(ctx context.Context, node *executionNode, request *scpb.EnqueueTaskReservationRequest) bool {
-	if node.handle == nil {
-		log.CtxErrorf(ctx, "nil handle for a local executor %q", node.GetExecutorID())
-		return false
-	}
-	_, err := node.handle.EnqueueTaskReservation(ctx, request)
-	if err != nil {
-		log.Infof("failed to enqueue task on connected executor: %s", err)
-	}
-	return err == nil
-}
-
-func (s *SchedulerServer) enqueueOnRemoteExecutor(ctx context.Context, node *executionNode, request *scpb.EnqueueTaskReservationRequest) bool {
-	if node.schedulerHostPort == "" {
-		log.CtxErrorf(ctx, "node %q has no scheduler host:port set", node.GetExecutorID())
-		return false
-	}
-
-	schedulerClient, err := s.schedulerClientCache.get(node.schedulerHostPort)
-	if err != nil {
-		log.CtxWarningf(ctx, "Could not get SchedulerClient for %q: %s", node.schedulerHostPort, err)
-		return false
-	}
-	rpcCtx, cancel := context.WithTimeout(ctx, schedulerEnqueueTaskReservationTimeout)
-	_, err = schedulerClient.EnqueueTaskReservation(rpcCtx, request)
-	cancel()
-	if err != nil {
-		log.CtxWarningf(ctx, "EnqueueTaskReservation via scheduler target %q failed: %s", node.schedulerHostPort, err)
-		time.Sleep(schedulerEnqueueTaskReservationFailureSleep)
-		return false
-	}
-	return true
 }
 
 func (s *SchedulerServer) ScheduleTask(ctx context.Context, req *scpb.ScheduleTaskRequest) (*scpb.ScheduleTaskResponse, error) {

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	scpb "github.com/buildbuddy-io/buildbuddy/proto/scheduler"
@@ -456,34 +455,6 @@ func scheduleTask(ctx context.Context, t *testing.T, env environment.Env, props 
 	return taskID
 }
 
-func enqueueTaskReservation(ctx context.Context, t *testing.T, env environment.Env, delay time.Duration) string {
-	id, err := uuid.NewRandom()
-	require.NoError(t, err)
-	taskID := id.String()
-
-	require.NoError(t, err)
-	_, err = env.GetSchedulerService().EnqueueTaskReservation(ctx, &scpb.EnqueueTaskReservationRequest{
-		TaskId: taskID,
-		TaskSize: &scpb.TaskSize{
-			EstimatedMemoryBytes:   100,
-			EstimatedMilliCpu:      100,
-			EstimatedFreeDiskBytes: 100,
-		},
-		SchedulingMetadata: &scpb.SchedulingMetadata{
-			Os:   defaultOS,
-			Arch: defaultArch,
-			TaskSize: &scpb.TaskSize{
-				EstimatedMemoryBytes:   100,
-				EstimatedMilliCpu:      100,
-				EstimatedFreeDiskBytes: 100,
-			},
-		},
-		Delay: durationpb.New(delay),
-	})
-	require.NoError(t, err)
-	return taskID
-}
-
 func TestExecutorReEnqueue_NoLeaseID(t *testing.T) {
 	env, ctx := getEnv(t, &schedulerOpts{}, "user1")
 
@@ -663,15 +634,4 @@ func TestSchedulingDelay_PreferredExecutorUnhealthy(t *testing.T) {
 
 	fe2.EnsureTaskNotReceived(taskID)
 	fe1.WaitForTaskWithDelay(taskID, 0*time.Second)
-}
-
-func TestEnqueueTaskReservation_DoesntOverwriteDelay(t *testing.T) {
-	env, ctx := getEnv(t, &schedulerOpts{}, "user1")
-
-	fe1 := newFakeExecutorWithId(ctx, t, "1", env.GetSchedulerClient())
-	fe1.Register()
-
-	taskID := enqueueTaskReservation(ctx, t, env, 3*time.Second)
-
-	fe1.WaitForTaskWithDelay(taskID, 3*time.Second)
 }


### PR DESCRIPTION
Causes https://buildbuddy-corp.slack.com/archives/C01D5GHRJ59/p1704318477269539 due to not refreshing nodes upon fully circling the nodering

**Related issues**: N/A
