### PR TITLE
Deflake TestAppShutdownDuringExecution_LeaseTaskRetried

### DIFF
--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -1808,7 +1808,6 @@ func TestAppShutdownDuringExecution_LeaseTaskRetried(t *testing.T) {
 
 	app1 := rbe.AddBuildBuddyServer()
 	app2 := rbe.AddBuildBuddyServer()
-	rbe.AddExecutor(t)
 
 	// Set up a custom proxy director that makes sure we choose app1 for the
 	// initial LeaseTask request, so that we can test stopping app1 while
@@ -1837,6 +1836,9 @@ func TestAppShutdownDuringExecution_LeaseTaskRetried(t *testing.T) {
 		return ctx, conn, nil
 	}
 	rbe.AppProxy.Director = director
+
+	// Add the executor after the proxy so the executor registers with app 1.
+	rbe.AddExecutor(t)
 
 	var cmds []*rbetest.ControlledCommand
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
Per https://buildbuddy-corp.slack.com/archives/C0694U6QC30/p1704394946753449 if the executor is added before the app proxy, it may register with app 1 and then be removed from the node pool when app 1 is shut down, causing the commands to fail. By registering it after the app proxy is installed, it always registers with app 2.

**Related issues**: [3004](https://github.com/buildbuddy-io/buildbuddy-internal/issues/3004)
