### PR TITLE
Render server_logs field from ExecuteResponse

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -130,6 +130,7 @@ ts_library(
         "@npm//@types/react",
         "@npm//lucide-react",
         "@npm//react",
+        "@npm//tslib",
     ],
 )
 

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -556,6 +556,10 @@
   color: #d32f2f;
 }
 
+.action-section .server-log-title {
+  align-self: center;
+}
+
 .cache-sections {
   display: flex;
   flex-wrap: wrap;

--- a/app/terminal/terminal.css
+++ b/app/terminal/terminal.css
@@ -46,6 +46,11 @@
 
 .terminal .terminal-titles {
   display: flex;
+  color: white;
+}
+
+.terminal.light-terminal .terminal-titles {
+  color: black;
 }
 
 .terminal .terminal-actions {

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -25,7 +25,7 @@ export interface TerminalProps {
   value?: string;
   loading?: boolean;
 
-  title?: JSX.Element;
+  title?: React.ReactNode;
 
   lightTheme?: boolean;
   fullLogsFetcher?: () => void;


### PR DESCRIPTION
Now that we render `ExecuteResponse` instead of `ActionResult`, we can show `server_logs`. https://github.com/buildbuddy-io/buildbuddy/pull/5647 adds the VM log tail to `server_logs`.

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/5722743e-db3c-4801-9093-4a08d4917df9)


**Related issues**: N/A
