### PR TITLE
use proto.Message instead of interface in Marshal/Unmarshal

### DIFF
--- a/server/util/proto/proto.go
+++ b/server/util/proto/proto.go
@@ -1,8 +1,6 @@
 package proto
 
 import (
-	"fmt"
-
 	gproto "google.golang.org/protobuf/proto"
 )
 
@@ -27,28 +25,19 @@ type vtprotoMessage interface {
 	UnmarshalVT([]byte) error
 }
 
-func Marshal(v interface{}) ([]byte, error) {
+func Marshal(v Message) ([]byte, error) {
 	vt, ok := v.(vtprotoMessage)
 	if ok {
 		return vt.MarshalVT()
 	}
-
-	msg, ok := v.(Message)
-	if !ok {
-		return nil, fmt.Errorf("failed to marshal, message is %T, want proto.Message", v)
-	}
-	return MarshalOld(msg)
+	return MarshalOld(v)
 }
 
-func Unmarshal(b []byte, v interface{}) error {
+func Unmarshal(b []byte, v Message) error {
 	vt, ok := v.(vtprotoMessage)
 	if ok {
 		return vt.UnmarshalVT(b)
 	}
 
-	msg, ok := v.(Message)
-	if !ok {
-		return fmt.Errorf("failed to unmarshal, message is %T, want proto.Message", v)
-	}
-	return UnmarshalOld(b, msg)
+	return UnmarshalOld(b, v)
 }

--- a/server/util/proto/proto_test.go
+++ b/server/util/proto/proto_test.go
@@ -87,6 +87,33 @@ func generateBytes(t testing.TB, protos []protoMessage) [][]byte {
 type marshalFunc func(v protoMessage) ([]byte, error)
 type unmarshalFunc func([]byte, protoMessage) error
 
+func TestMarshal(t *testing.T) {
+	md := &rfpb.FileMetadata{}
+	err := faker.FakeData(md)
+	require.NoError(t, err, "unable to fake data")
+
+	actual, err := proto.Marshal(md)
+	require.NoError(t, err)
+	expected, err := proto.MarshalOld(md)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func TestUnmarshal(t *testing.T) {
+	md := &rfpb.FileMetadata{}
+	err := faker.FakeData(md)
+	require.NoError(t, err, "unable to fake data")
+
+	data, err := proto.MarshalOld(md)
+	require.NoError(t, err)
+
+	actual := &rfpb.FileMetadata{}
+	err = proto.Unmarshal(data, actual)
+	require.NoError(t, err)
+
+	require.True(t, proto.Equal(md, actual))
+}
+
 func benchmarkMarshal(b *testing.B, marshalFn marshalFunc, data []protoMessage) {
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/server/util/vtprotocodec/vtprotocodec.go
+++ b/server/util/vtprotocodec/vtprotocodec.go
@@ -1,6 +1,8 @@
 package vtprotocodec
 
 import (
+	"fmt"
+
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 
 	"google.golang.org/grpc/encoding"
@@ -13,12 +15,25 @@ const Name = "proto"
 // proto messages.
 type vtprotoCodec struct{}
 
+type vtprotoMessage interface {
+	MarshalVT() ([]byte, error)
+	UnmarshalVT([]byte) error
+}
+
 func (vtprotoCodec) Marshal(v any) ([]byte, error) {
-	return proto.Marshal(v)
+	vv, ok := v.(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("failed to marshal, message is %T, want proto.Message", v)
+	}
+	return proto.Marshal(vv)
 }
 
 func (vtprotoCodec) Unmarshal(data []byte, v any) error {
-	return proto.Unmarshal(data, v)
+	vv, ok := v.(proto.Message)
+	if !ok {
+		return fmt.Errorf("failed to unmarshal, message is %T, want proto.Message", v)
+	}
+	return proto.Unmarshal(data, vv)
 }
 
 func (vtprotoCodec) Name() string {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Make proto.Marshal / Unmarshal signature the same as google's proto lib. 
It's going to be safer since it's going to return a compiler time error instead
of a runtime error when we try to marshal something other than a proto message.
