### PR TITLE
Use VTproto generated clone method

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -9,7 +9,7 @@ go_proto_compiler(
     name = "vtprotobuf_compiler",
     # marshal depends on size. Pool only generates code for messages with the
     # vtprotobuf mempool annotation.
-    options = ["features=marshal+unmarshal+size+pool"],
+    options = ["features=marshal+unmarshal+size+pool+clone"],
     plugin = "@com_github_planetscale_vtprotobuf//cmd/protoc-gen-go-vtproto",
     suffix = "_vtproto.pb.go",
     valid_archive = False,

--- a/server/util/proto/BUILD
+++ b/server/util/proto/BUILD
@@ -18,5 +18,6 @@ go_test(
         "//proto:raft_go_proto",
         "@com_github_go_faker_faker_v4//:faker",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//proto",
     ],
 )

--- a/server/util/proto/proto.go
+++ b/server/util/proto/proto.go
@@ -4,7 +4,6 @@ import (
 	gproto "google.golang.org/protobuf/proto"
 )
 
-var Clone = gproto.Clone
 var Size = gproto.Size
 var Merge = gproto.Merge
 var Equal = gproto.Equal
@@ -23,6 +22,7 @@ type MarshalOptions = gproto.MarshalOptions
 type vtprotoMessage interface {
 	MarshalVT() ([]byte, error)
 	UnmarshalVT([]byte) error
+	CloneMessageVT() Message
 }
 
 func Marshal(v Message) ([]byte, error) {
@@ -40,4 +40,12 @@ func Unmarshal(b []byte, v Message) error {
 	}
 
 	return UnmarshalOld(b, v)
+}
+
+func Clone(v Message) Message {
+	vt, ok := v.(vtprotoMessage)
+	if ok {
+		return vt.CloneMessageVT()
+	}
+	return gproto.Clone(v)
 }


### PR DESCRIPTION
This change will update all current uses of proto.Clone to use vtproto generated
Clone method. vtproto generated Clone method is faster in general, except for `ScoreCard`, which I suspect shares the same cause as in https://github.com/buildbuddy-io/buildbuddy-internal/issues/3018.

Here is the benchmark:
```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7900X 12-Core Processor            
                             │      Old      │                 New                  │
                             │    sec/op     │    sec/op     vs base                │
Clone/pbName=FileMetadata-24   14.708µ ± 18%   7.804µ ± 16%  -46.94% (p=0.000 n=10)
Clone/pbName=ScoreCard-24       1.268m ±  3%   1.299m ±  3%        ~ (p=0.063 n=10)
Clone/pbName=TreeCache-24       45.61m ±  1%   38.13m ±  2%  -16.39% (p=0.000 n=10)
Clone/pbName=ReadResponse-24    222.7n ± 41%   133.8n ± 46%  -39.91% (p=0.019 n=10)
geomean                         117.3µ         84.80µ        -27.71%

                             │      Old       │                  New                   │
                             │      B/s       │      B/s        vs base                │
Clone/pbName=FileMetadata-24   297.1Mi ±  59%   367.6Mi ±  77%        ~ (p=0.494 n=10)
Clone/pbName=ScoreCard-24      209.0Mi ± 121%   269.2Mi ±  82%        ~ (p=0.579 n=10)
Clone/pbName=TreeCache-24      479.5Mi ±  27%   504.4Mi ±  72%        ~ (p=0.796 n=10)
Clone/pbName=ReadResponse-24   281.4Mi ±  51%   427.7Mi ± 103%        ~ (p=0.218 n=10)
geomean                        302.5Mi          382.2Mi         +26.35%

                             │     Old      │                 New                  │
                             │     B/op     │     B/op      vs base                │
Clone/pbName=FileMetadata-24   9.688Ki ± 2%   8.961Ki ± 2%   -7.49% (p=0.000 n=10)
Clone/pbName=ScoreCard-24      843.7Ki ± 2%   853.1Ki ± 1%        ~ (p=0.143 n=10)
Clone/pbName=TreeCache-24      30.15Mi ± 1%   26.46Mi ± 3%  -12.24% (p=0.000 n=10)
Clone/pbName=ReadResponse-24     115.5 ± 1%     115.0 ± 1%        ~ (p=0.498 n=10)
geomean                        73.04Ki        69.45Ki        -4.92%

                             │     Old     │                 New                  │
                             │  allocs/op  │  allocs/op   vs base                 │
Clone/pbName=FileMetadata-24    127.0 ± 2%    121.5 ± 2%  -4.33% (p=0.000 n=10)
Clone/pbName=ScoreCard-24      11.38k ± 2%   11.52k ± 1%       ~ (p=0.143 n=10)
Clone/pbName=TreeCache-24      355.0k ± 1%   327.0k ± 3%  -7.89% (p=0.000 n=10)
Clone/pbName=ReadResponse-24    2.000 ± 0%    2.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                        1.007k         978.0       -2.83%
```