### PR TITLE
remove proto.UnmarshalOld

### DIFF
--- a/server/util/proto/proto.go
+++ b/server/util/proto/proto.go
@@ -8,7 +8,6 @@ var Size = gproto.Size
 var Merge = gproto.Merge
 var Equal = gproto.Equal
 var MarshalOld = gproto.Marshal
-var UnmarshalOld = gproto.Unmarshal
 
 var String = gproto.String
 var Float64 = gproto.Float64
@@ -39,7 +38,7 @@ func Unmarshal(b []byte, v Message) error {
 		return vt.UnmarshalVT(b)
 	}
 
-	return UnmarshalOld(b, v)
+	return gproto.Unmarshal(b, v)
 }
 
 func Clone(v Message) Message {

--- a/server/util/proto/proto_test.go
+++ b/server/util/proto/proto_test.go
@@ -181,7 +181,7 @@ func BenchmarkUnmarshal(b *testing.B) {
 			return proto.Unmarshal(buf, v)
 		},
 		"Old": func(buf []byte, v protoMessage) error {
-			return proto.UnmarshalOld(buf, v)
+			return gproto.Unmarshal(buf, v)
 		},
 	}
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Currently, there are no use cases to use Google Proto Library's Unmarshal. Remove the exported alias. 
