### PR TITLE
Render workflow artifacts in the UI

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -401,7 +401,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
               <CacheRequestsCardComponent model={this.state.model} search={this.props.search} />
             )}
 
-          {isBazelInvocation && (activeTab === "all" || activeTab === "artifacts") && (
+          {(activeTab === "all" || activeTab === "artifacts") && (
             <ArtifactsCardComponent
               model={this.state.model}
               filter={this.props.search.get("artifactFilter") ?? ""}

--- a/app/invocation/invocation_tabs.tsx
+++ b/app/invocation/invocation_tabs.tsx
@@ -59,7 +59,7 @@ export default class InvocationTabsComponent extends React.Component<InvocationT
         {isBazelInvocation && this.renderTab("targets", { label: "Targets" })}
         {this.renderTab("log", { label: "Logs" })}
         {this.renderTab("details", { label: "Details" })}
-        {isBazelInvocation && this.renderTab("artifacts", { label: "Artifacts" })}
+        {this.renderTab("artifacts", { label: "Artifacts" })}
         {isBazelInvocation && this.renderTab("timing", { label: "Timing" })}
         {isBazelInvocation && this.renderTab("cache", { label: "Cache" })}
         {this.props.executionsEnabled && this.renderTab("execution", { label: "Executions" })}

--- a/enterprise/server/bes_artifacts/bes_artifacts.go
+++ b/enterprise/server/bes_artifacts/bes_artifacts.go
@@ -116,7 +116,12 @@ func (u *Uploader) uploadDirectory(namedSetID, root string) error {
 			return err
 		}
 		uri := fmt.Sprintf("%s/%s", u.bytestreamURIPrefix, rnString)
-		f := &bespb.File{Name: r.Name, File: &bespb.File_Uri{Uri: uri}}
+		f := &bespb.File{
+			Name:   r.Name,
+			File:   &bespb.File_Uri{Uri: uri},
+			Digest: rn.GetDigest().GetHash(),
+			Length: rn.GetDigest().GetSizeBytes(),
+		}
 		files = append(files, f)
 	}
 	if len(files) == 0 {


### PR DESCRIPTION
Render any artifacts which the user wrote to `BUILDBUDDY_ARTIFACTS_DIRECTORY`, such as the gRPC log.

Also fix a small issue that we weren't setting the digest/length metadata on the file, so the digest component appeared blank.

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/b6f6d9e4-6dbc-424c-a952-1197acf617a3)


**Related issues**: N/A
