### PR TITLE
proto: handle go proto library deprecation

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -166,6 +166,10 @@ gazelle_binary(
 # gazelle:exclude **/node_modules/**
 # TODO(siggisim): remove once we support .css imports properly
 # gazelle:exclude website/**
+#
+# Make these the default compilers for proto rules.
+# See https://github.com/bazelbuild/rules_go/pull/3761 for more details
+# gazelle:go_grpc_compilers	@io_bazel_rules_go//proto:go_proto,@io_bazel_rules_go//proto:go_grpc_v2
 gazelle(
     name = "gazelle",
     gazelle = ":bb_gazelle_binary",

--- a/BUILD
+++ b/BUILD
@@ -169,7 +169,7 @@ gazelle_binary(
 #
 # Make these the default compilers for proto rules.
 # See https://github.com/bazelbuild/rules_go/pull/3761 for more details
-# gazelle:go_grpc_compilers	@io_bazel_rules_go//proto:go_proto,@io_bazel_rules_go//proto:go_grpc_v2
+# gazelle:go_proto_compilers	@io_bazel_rules_go//proto:go_proto,@io_bazel_rules_go//proto:go_grpc_v2
 gazelle(
     name = "gazelle",
     gazelle = ":bb_gazelle_binary",

--- a/enterprise/server/test/integration/remote_execution/proto/BUILD
+++ b/enterprise/server/test/integration/remote_execution/proto/BUILD
@@ -13,7 +13,10 @@ proto_library(
 
 go_proto_library(
     name = "remoteexecutiontest_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/test/integration/remote_execution/proto",
     proto = ":remoteexecutiontest_proto",
 )

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -772,7 +772,8 @@ go_proto_library(
 go_proto_library(
     name = "health_go_proto",
     compilers = [
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
         "//proto:vtprotobuf_compiler",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/health",
@@ -871,7 +872,8 @@ go_proto_library(
 go_proto_library(
     name = "publish_build_event_go_proto",
     compilers = [
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
         "//proto:vtprotobuf_compiler",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event",
@@ -941,7 +943,8 @@ go_proto_library(
 go_proto_library(
     name = "soci_go_proto",
     compilers = [
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
         "//proto:vtprotobuf_compiler",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/soci",
@@ -1018,7 +1021,8 @@ go_proto_library(
 go_proto_library(
     name = "vmexec_go_proto",
     compilers = [
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
         "//proto:vtprotobuf_compiler",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/vmexec",
@@ -1032,7 +1036,8 @@ go_proto_library(
 go_proto_library(
     name = "vmvfs_go_proto",
     compilers = [
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
         "//proto:vtprotobuf_compiler",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/vmvfs",
@@ -1046,7 +1051,8 @@ go_proto_library(
     name = "vfs_go_proto",
     compilers = [
         "//proto:vtprotobuf_compiler",
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/vfs",
     proto = ":vfs_proto",
@@ -1191,7 +1197,8 @@ go_proto_library(
 go_proto_library(
     name = "raft_service_go_proto",
     compilers = [
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
         "//proto:vtprotobuf_compiler",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/raft_service",
@@ -1204,7 +1211,8 @@ go_proto_library(
 go_proto_library(
     name = "ping_service_go_proto",
     compilers = [
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
         "//proto:vtprotobuf_compiler",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/ping_service",
@@ -1214,7 +1222,8 @@ go_proto_library(
 go_proto_library(
     name = "buildbuddy_service_go_proto",
     compilers = [
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
         "//proto:vtprotobuf_compiler",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service",
@@ -1261,7 +1270,8 @@ go_proto_library(
 go_proto_library(
     name = "sidecar_go_proto",
     compilers = [
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
         "//proto:vtprotobuf_compiler",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/sidecar",
@@ -1271,7 +1281,8 @@ go_proto_library(
 go_proto_library(
     name = "registry_go_proto",
     compilers = [
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
         "//proto:vtprotobuf_compiler",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/registry",
@@ -1365,7 +1376,8 @@ go_proto_library(
     name = "distributed_cache_go_proto",
     compilers = [
         "//proto:vtprotobuf_compiler",
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/distributed_cache",
     proto = ":distributed_cache_proto",
@@ -1379,7 +1391,8 @@ go_proto_library(
     name = "remote_asset_go_proto",
     compilers = [
         "//proto:vtprotobuf_compiler",
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/remote_asset",
     proto = ":remote_asset_proto",
@@ -1413,7 +1426,8 @@ go_proto_library(
     name = "remote_execution_go_proto",
     compilers = [
         "//proto:vtprotobuf_compiler",
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/remote_execution",
     proto = ":remote_execution_proto",
@@ -1443,7 +1457,8 @@ go_proto_library(
     name = "telemetry_go_proto",
     compilers = [
         "//proto:vtprotobuf_compiler",
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/telemetry",
     proto = ":telemetry_proto",
@@ -1456,7 +1471,8 @@ go_proto_library(
     name = "scheduler_go_proto",
     compilers = [
         "//proto:vtprotobuf_compiler",
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/scheduler",
     proto = ":scheduler_proto",
@@ -1472,7 +1488,8 @@ go_proto_library(
     name = "suggestion_go_proto",
     compilers = [
         "//proto:vtprotobuf_compiler",
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/suggestion",
     proto = ":suggestion_proto",
@@ -1485,7 +1502,8 @@ go_proto_library(
     name = "trace_go_proto",
     compilers = [
         "//proto:vtprotobuf_compiler",
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/trace",
     proto = ":trace_proto",
@@ -1494,8 +1512,8 @@ go_proto_library(
 go_proto_library(
     name = "worker_go_proto",
     compilers = [
-        "//proto:vtprotobuf_compiler",
-        "@io_bazel_rules_go//proto:go_grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/worker",
     proto = ":worker_proto",

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -1512,6 +1512,7 @@ go_proto_library(
 go_proto_library(
     name = "worker_go_proto",
     compilers = [
+        "//proto:vtprotobuf_compiler",
         "@io_bazel_rules_go//proto:go_proto",
         "@io_bazel_rules_go//proto:go_grpc_v2",
     ],

--- a/proto/api/v1/BUILD
+++ b/proto/api/v1/BUILD
@@ -55,7 +55,10 @@ proto_library(
 
 go_proto_library(
     name = "api_v1_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/api/v1",
     proto = ":api_v1_proto",
     visibility = ["//visibility:public"],

--- a/proto/jaeger/BUILD
+++ b/proto/jaeger/BUILD
@@ -18,7 +18,10 @@ proto_library(
 
 go_proto_library(
     name = "jaeger_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/jaeger",
     proto = ":jaeger_proto",
     deps = [


### PR DESCRIPTION
In https://github.com/bazelbuild/rules_go/pull/3761, rules_go started deprecating away
the usage of https://github.com/golang/protobuf in favor of a combination of
https://github.com/protocolbuffers/protobuf-go and https://github.com/grpc/grpc-go/blob/master/cmd/protoc-gen-go-grpc.

This results in `go_proto_library` requiring these 2 new compilers.
As an convinience, a `go_grpc_library` macro was introduced to wrap around `go_proto_library`
to ensure that these 2 compilers are set by default.

Effectively, in our `go_proto_library` targets, switch our usage of the old compiler to the new pair of compilers.
We are not using `go_grpc_library` yet because Gazelle has yet to support it. https://github.com/bazelbuild/bazel-gazelle/pull/1711


<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
