### PR TITLE
bazelrc: silence invalid warnings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -158,7 +158,7 @@ common:windows --workspace_status_command="bash workspace_status.sh"
 
 # Misc remote cache/BES optimizations
 common --experimental_remote_cache_async
-common --experimental_remote_build_event_upload=minimal
+common --remote_build_event_upload=minimal
 common --nolegacy_important_outputs
 
 # Use a static PATH variable to prevent unnecessary rebuilds of dependencies like protobuf.
@@ -196,6 +196,12 @@ common:macos --host_cxxopt=-std=c++17
 common:macos --cxxopt=-std=c++17
 common:windows --host_cxxopt=/std:c++17
 common:windows --cxxopt=/std:c++17
+
+# Starting from Xcode 15, the linker will warn about duplicate flags.
+# This is currently not avoidable with the current way the local cc toolchain is configured
+# as well as how linkopts are propagated through the dependency graph between libraries.
+# This flag is a workaround to silence the linker warnings.
+common:macos --linkopt="-Wl,-no_warn_duplicate_libraries"
 
 # Run Webdriver tests with --config=webdriver-debug to debug webdriver tests locally.
 # See server/testutil/webtester/webtester.go for more details.


### PR DESCRIPTION
Since we are now using Bazel 7, we could replace the usage of
experimental_remote_build_event_upload with remote_build_event_upload.

The recent changes in the local MacOS LLVM toolchain made it so that the
compiler would be a lot noisier when the duplicate flag is given.
In our case, we see this in the form of 2 warnings below:

    ```bash
    # GoLink
    ld: warning: ignoring duplicate libraries: '-lm'

    # CppLink
    ld: warning: ignoring duplicate libraries: '-lm', '-lpthread'
    ```

For GoLink, our action currently looks like this:

    ```bash
    bazel-out/.../builder
    -param=bazel-out/.../vet_actual_/vet_actual-0.params
    --
    -extld
    external/local_config_cc/cc_wrapper.sh
    -buildid=redacted
    -s
    -w
    -extldflags
    -mmacos-version-min=10.11 -no-canonical-prefixes -fobjc-link-runtime -headerpad_max_install_names -Wl,-dead_strip -lm
    ```

where the rules_go's `builder` wrapper binary will invoke the linker in
cc toolchain with duplicated `-lm` params. (1)

For CppLink, our action looks like this:

    ```bash
    external/local_config_cc/cc_wrapper.sh
    @bazel-out/darwin_arm64-opt-exec/bin/external/com_google_protobuf/protoc-2.params

    # content of protoc-2.params
    -o
    bazel-out/darwin_arm64-opt-exec/bin/external/com_google_protobuf/protoc
    <... redacted for brevity>
    bazel-out/darwin_arm64-opt-exec/bin/external/com_google_absl/absl/base/liblog_severity.a
    -Wl,-S
    -mmacos-version-min=10.11
    -no-canonical-prefixes
    -fobjc-link-runtime
    -headerpad_max_install_names
    -Wl,-dead_strip
    -lpthread
    -lm
    -framework
    CoreFoundation
    -lpthread
    -lm
    -framework
    CoreFoundation
    -lpthread
    -lm
    -framework
    CoreFoundation
    -lpthread
    -lm
    -framework
    CoreFoundation
    -lpthread
    -lm
    -framework
    CoreFoundation
    -pthread
    -pthread
    -pthread
    -Wl,-framework,CoreFoundation
    -lc++
    -lm
    ```

where the `-lm -lpthread` are accumulated through multiple transitive
libraries each setting linkopts individually. (2)

(1): https://buildbuddy.buildbuddy.io/invocation/73740f87-1d3d-4359-be29-129a3b401bbb?actionDigest=015c2117e01ac061714a741da4cf9eefc169fb37b4b0d29435c094f6daeba9ad#action
(2): https://buildbuddy.buildbuddy.io/invocation/73740f87-1d3d-4359-be29-129a3b401bbb?actionDigest=06aa456cf511fa9f85f335fc037a6c795788cf4968abc73ff018044ec4e7c418#action

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
