### PR TITLE
Fix workflow action result not being displayed in action page

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -215,8 +215,12 @@ export default class InvocationModel {
     for (let log of this.buildToolLogs?.log || []) {
       this.toolLogMap.set(log.name, new TextDecoder().decode(log.contents || new Uint8Array()));
     }
+    // Treat "canonical" command line as the source of truth if present,
+    // otherwise just use any command line (e.g. at the time of writing, for
+    // workflows we only send "original")
     let commandLine =
-      this.commandLineWithLabel("canonical") ?? this.commandLineWithLabel("original") ?? this.structuredCommandLine[0];
+      this.structuredCommandLine.find((commandLine) => commandLine.commandLineLabel === "canonical") ??
+      this.structuredCommandLine[0];
     if (commandLine) {
       for (let section of commandLine.sections || []) {
         for (let option of section.optionList?.option || []) {
@@ -237,10 +241,6 @@ export default class InvocationModel {
         }
       }
     }
-  }
-
-  private commandLineWithLabel(label: string): command_line.CommandLine | undefined {
-    return this.structuredCommandLine.find((commandLine) => commandLine.commandLineLabel === label);
   }
 
   getUser(possessive: boolean) {


### PR DESCRIPTION
* Workflow actions don't publish a `canonical` command line event. Update the logic from https://github.com/buildbuddy-io/buildbuddy/pull/5362 to prefer the canonical command line if present but fall back to the original command line otherwise. 
  * We could alternatively update workflows to send a `canonical` command line rather than an `original` one, but this approach feels more forgiving to BES clients in general.
* Fix `getCacheAddress()` incorrectly returning `address + instanceName` which results in bytestream URLs containing the instance name twice, like `grpc://remote.buildbuddy.io/instance-name/instance-name/...`

**Related issues**: N/A
