### PR TITLE
Show OS/Arch in workflow overview

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -699,7 +699,7 @@ export default class InvocationModel {
         return "k8";
       }
       if (this.workflowConfigured.os === "darwin" && this.workflowConfigured.arch === "amd64") {
-        return "darwin";
+        return "darwin_x86_64";
       }
       if (this.workflowConfigured.os === "darwin" && this.workflowConfigured.arch === "arm64") {
         return "darwin_arm64";

--- a/app/invocation/invocation_overview.tsx
+++ b/app/invocation/invocation_overview.tsx
@@ -188,12 +188,10 @@ export default class InvocationOverviewComponent extends React.Component<Props> 
               {format.formatWithCommas(this.props.model.getFetchURLs().length)} fetches
             </div>
           )}
-          {isBazelInvocation && (
-            <div className="detail">
-              <Cpu className="icon" />
-              {this.props.model.getCPU()}
-            </div>
-          )}
+          <div className="detail">
+            <Cpu className="icon" />
+            {this.props.model.getCPU()}
+          </div>
           {isBazelInvocation && (
             <div className="detail">
               <Zap className="icon" />


### PR DESCRIPTION
We already have the BES info needed to render it, so just show the detail chip.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3042
