### PR TITLE
Fix an issue with range-specific-key suffixing

### DIFF
--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -364,14 +364,14 @@ func (lk *LeaseKeeper) HaveLease(shard uint64) bool {
 
 		shouldHaveLease := leader && open
 		if shouldHaveLease && !valid {
-			lk.log.Errorf("HaveLease range: %d valid: %t, should have lease: %t", shard, valid, shouldHaveLease)
+			lk.log.Warningf("HaveLease range: %d valid: %t, should have lease: %t", shard, valid, shouldHaveLease)
 			la.queueInstruction(leaseInstruction{
 				shard:  shardID(shard),
 				reason: "should have range",
 				action: Acquire,
 			})
 		} else if !shouldHaveLease && valid {
-			lk.log.Errorf("HaveLease range: %d valid: %t, should have lease: %t", shard, valid, shouldHaveLease)
+			lk.log.Warningf("HaveLease range: %d valid: %t, should have lease: %t", shard, valid, shouldHaveLease)
 			la.queueInstruction(leaseInstruction{
 				shard:  shardID(shard),
 				reason: "should not have range",

--- a/enterprise/server/raft/sender/BUILD
+++ b/enterprise/server/raft/sender/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//proto:raft_service_go_proto",
         "//server/util/log",
         "//server/util/proto",
+        "//server/util/rangemap",
         "//server/util/retry",
         "//server/util/status",
         "@org_golang_google_grpc//status",

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/registry"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
+	"github.com/buildbuddy-io/buildbuddy/server/util/rangemap"
 	"github.com/buildbuddy-io/buildbuddy/server/util/retry"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
@@ -144,6 +145,10 @@ func (s *Sender) LookupRangeDescriptor(ctx context.Context, key []byte, skipCach
 		}
 		s.rangeCache.UpdateRange(rd)
 		rangeDescriptor = rd
+	}
+	r := rangemap.Range{Start: rangeDescriptor.GetStart(), End: rangeDescriptor.GetEnd()}
+	if !r.Contains(key) {
+		log.Fatalf("Found range %+v that doesn't contain key: %q", rangeDescriptor, string(key))
 	}
 	return rangeDescriptor, nil
 }


### PR DESCRIPTION
Scan was broken because we we're including a suffix on keys.

This made them appear lexicagraphically AFTER a key. For example:
   start:         "\x02\x04\x00"
   appeared before "\x02\x04-c0001n0001"
when in fact it should not include the suffix and "\x02\x04\x00" should come *after* "\x02\x04". 

This change fixes this issue by instead making the range-specific-ident a prefix.
