### PR TITLE
Add a test that illustrates failing cross-cluster txn issue.

### DIFF
--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -362,7 +362,10 @@ func SendStartShardRequests(ctx context.Context, nodeHost *dragonboat.NodeHost, 
 			Generation: 1,
 		},
 	}
+	return SendStartShardRequestsWithRanges(ctx, nodeHost, apiClient, nodeGrpcAddrs, startingRanges)
+}
 
+func SendStartShardRequestsWithRanges(ctx context.Context, nodeHost *dragonboat.NodeHost, apiClient *client.APIClient, nodeGrpcAddrs map[string]string, startingRanges []*rfpb.RangeDescriptor) error {
 	shardID := uint64(constants.InitialShardID)
 	replicaID := uint64(constants.InitialReplicaID)
 	rangeID := uint64(constants.InitialRangeID)

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -60,6 +60,7 @@ go_test(
         "//enterprise/server/raft/client",
         "//enterprise/server/raft/constants",
         "//enterprise/server/raft/filestore",
+        "//enterprise/server/raft/keys",
         "//enterprise/server/raft/listener",
         "//enterprise/server/raft/logger",
         "//enterprise/server/raft/rangecache",


### PR DESCRIPTION
When running with real data and shards moving between nodes, I noticed that split transactions would fail after a while. This happened because the transaction being run to update range descriptors was taking place on nodes that did not hold the metarange. This meant that the SyncProposeLocal would fail, because that range was not held locally.

Working on a fix but wanted to add a failing test first.