### PR TITLE
.bazelrc: ignore duplicate flags cont.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -202,6 +202,7 @@ common:windows --cxxopt=/std:c++17
 # as well as how linkopts are propagated through the dependency graph between libraries.
 # This flag is a workaround to silence the linker warnings.
 common:macos --linkopt="-Wl,-no_warn_duplicate_libraries"
+common:macos --host_linkopt="-Wl,-no_warn_duplicate_libraries"
 
 # Run Webdriver tests with --config=webdriver-debug to debug webdriver tests locally.
 # See server/testutil/webtester/webtester.go for more details.


### PR DESCRIPTION
This is a follow-up of #5663.

A binary is linked for toolchains, it will be using
`--host_linkopt` instead of `--linkopt`.
This results in the following being left over from previous PR.

```bash
INFO: From GoLink external/io_bazel_rules_webtesting/go/metadata/main/main_darwin_arm64 [for tool]:
ld: warning: ignoring duplicate libraries: '-lm'
INFO: From GoLink enterprise/server/backends/prom/generate_docs/generate_docs_/generate_docs [for tool]:
ld: warning: ignoring duplicate libraries: '-lm'
INFO: From GoLink enterprise/server/cmd/executor/yaml_doc/yaml_doc_/yaml_doc [for tool]:
ld: warning: ignoring duplicate libraries: '-lm'
INFO: From GoLink server/cmd/buildbuddy/yaml_doc/yaml_doc_/yaml_doc [for tool]:
ld: warning: ignoring duplicate libraries: '-lm'
INFO: From GoLink enterprise/server/cmd/server/yaml_doc/yaml_doc_/yaml_doc [for tool]:
ld: warning: ignoring duplicate libraries: '-lm'
```

note the `[for tool]` at the end of each target.

Ensure `--host_linkopt` is also set with the same value on MacOS.
