### PR TITLE
deps.bzl: ensure external proto use latest compiler

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -672,6 +672,9 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     )
     go_repository(
         name = "com_github_buildbuddy_io_tensorflow_proto",
+        build_directives = [
+            "gazelle:go_grpc_compilers @io_bazel_rules_go//proto:go_proto,@io_bazel_rules_go//proto:go_grpc_v2",
+        ],
         importpath = "github.com/buildbuddy-io/tensorflow-proto",
         sum = "h1:LcKnQdAYrT3LOZt0mTgw6uiEi7QVkH75cCxPj+AbkLA=",
         version = "v0.0.0-20220908151343-929b41ab4dc6",


### PR DESCRIPTION
This is a follow-up for #5662.

Turn out our external dependencies also need some proto love

```bash
WARNING: /private/var/tmp/_bazel_sluongng/06e573a93bc2d6a9cad4ad41f00b4310/external/com_github_buildbuddy_io_tensorflow_proto/tensorflow_serving/apis/BUILD.bazel:27:17:
  in go_proto_library rule @@com_github_buildbuddy_io_tensorflow_proto//tensorflow_serving/apis:apis_go_proto:
    target '@@com_github_buildbuddy_io_tensorflow_proto//tensorflow_serving/apis:apis_go_proto'
    depends on deprecated target '@@io_bazel_rules_go//proto:go_grpc':
      Migrate to //proto:go_grpc_v2 compiler (which you'll get automatically if you use the go_grpc_library() rule).
```

Ensure that when Gazelle is run on external dependencies, the proper
directive is also applied so that the newer compilers are used.
