### PR TITLE
Use the Xcode command-line tools instead of Xcode in Mac release workflows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -163,8 +163,8 @@ common --nolegacy_important_outputs
 
 # Use a static PATH variable to prevent unnecessary rebuilds of dependencies like protobuf.
 common --incompatible_strict_action_env
-common --action_env=DEVELOPER_DIR
-common --host_action_env=DEVELOPER_DIR
+common:macos --action_env=DEVELOPER_DIR
+common:macos --host_action_env=DEVELOPER_DIR
 
 # rules_nodejs needs runfiles to be explicitly enabled.
 common:linux --enable_runfiles

--- a/.bazelrc
+++ b/.bazelrc
@@ -163,6 +163,8 @@ common --nolegacy_important_outputs
 
 # Use a static PATH variable to prevent unnecessary rebuilds of dependencies like protobuf.
 common --incompatible_strict_action_env
+common --action_env=DEVELOPER_DIR
+common --host_action_env=DEVELOPER_DIR
 
 # rules_nodejs needs runfiles to be explicitly enabled.
 common:linux --enable_runfiles
@@ -202,6 +204,9 @@ common:windows --cxxopt=/std:c++17
 # as well as how linkopts are propagated through the dependency graph between libraries.
 # This flag is a workaround to silence the linker warnings.
 common:macos --linkopt="-Wl,-no_warn_duplicate_libraries"
+
+# Ensure that we don't use the apple_support cc_toolchain
+common:macos --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
 
 # Run Webdriver tests with --config=webdriver-debug to debug webdriver tests locally.
 # See server/testutil/webtester/webtester.go for more details.

--- a/.github/workflows/release-m1.yaml
+++ b/.github/workflows/release-m1.yaml
@@ -66,7 +66,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          export DEVELOPER_DIR=/Applications/Xcode_12.4.app/Contents/Developer
+          export DEVELOPER_DIR=/Library/Developer/CommandLineTools
           "${GITHUB_WORKSPACE}/bin/bazel" build --config=release-m1 --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-darwin-arm64
           gh release upload ${{ steps.vars.outputs.tag }} executor-enterprise-darwin-arm64 --clobber

--- a/.github/workflows/release-mac.yaml
+++ b/.github/workflows/release-mac.yaml
@@ -54,8 +54,8 @@ jobs:
       - name: Build and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          XCODE_VERSION: 12.4
         run: |
+          export DEVELOPER_DIR=/Library/Developer/CommandLineTools
           "${GITHUB_WORKSPACE}/bin/bazel" build --config=release-mac --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //server/cmd/buildbuddy:buildbuddy //enterprise/server/cmd/server:buildbuddy //enterprise/server/cmd/executor:executor
           cp bazel-bin/server/cmd/**/**/buildbuddy buildbuddy-darwin-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/buildbuddy buildbuddy-enterprise-darwin-amd64


### PR DESCRIPTION
As of Bazel 7.0 we aren’t using the apple_support cc_toolchain. Only `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk` is included in `builtin_include_directories`. If we have `DEVELOPER_DIR` set to something else we can see errors like following:

```
ERROR: /private/var/tmp/_bazel_brentley/7e5d3aaeb704234ad9b80179b286c374/external/com_google_absl/absl/base/BUILD.bazel:95:11: Compiling absl/base/internal/spinlock_wait.cc [for tool] failed: absolute path inclusion(s) found in rule '@@com_google_absl//absl/base:spinlock_wait':
the source file 'absl/base/internal/spinlock_wait.cc' includes the following non-builtin files with absolute paths (if these are builtin files, make sure these paths are in your toolchain):
  '/Applications/Xcode-15.1.0-Release.Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/atomic'
```

Setting `DEVELOPER_DIR` in our GitHub release workflows ensures that we use the command-line tools rather than whatever is installed on the runner. We also needed to set `--{host,}action_env=DEVELOPER_DIR` to prevent a mismatch between the version of `DEVELOPER_DIR` that Bazel itself sees and what actions/repos see. Finally, I added `BAZEL_NO_APPLE_CPP_TOOLCHAIN=1` to make 100% sure we don’t use the apple_support cc_toolchain.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
