### PR TITLE
macos: make --config=remote work again

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -203,8 +203,9 @@ common:windows --cxxopt=/std:c++17
 # This is currently not avoidable with the current way the local cc toolchain is configured
 # as well as how linkopts are propagated through the dependency graph between libraries.
 # This flag is a workaround to silence the linker warnings.
-common:macos --linkopt="-Wl,-no_warn_duplicate_libraries"
-common:macos --host_linkopt="-Wl,-no_warn_duplicate_libraries"
+# common:macos --linkopt="-Wl,-no_warn_duplicate_libraries"
+# common:macos --host_linkopt="-Wl,-no_warn_duplicate_libraries"
+common:macos --platform_mappings=platform_mapping
 
 # Ensure that we don't use the apple_support cc_toolchain
 common:macos --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1

--- a/platform_mapping
+++ b/platform_mapping
@@ -1,0 +1,4 @@
+platforms:
+  @local_config_platform//:host
+    --linkopt="-Wl,-no_warn_duplicate_libraries"
+    --host_linkopt="-Wl,-no_warn_duplicate_libraries"


### PR DESCRIPTION
In a previous change, we introduced --linkopt unconditionally on MacOS.
This cause remote builds with `--config=remote` to include those linker
flags in our Linux actions. And `ld.gold` did not like these Xcode 15
only flags.

Fix this by making sure that the linker flags are only applied when this
combination happen:
- We are building on MacOS. This is done by using the `common:macos`
  profile that is automatically included by Bazel's
  `--enable_platform_specific_config` flag.

- We are targeting the local MacOS platform. The local platform is
  `@local_config_platform//:host`. We leverage Bazel's platform_mapping
  feature to achieve this.
