### PR TITLE
macos: rollback linkopt flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -199,14 +199,6 @@ common:macos --cxxopt=-std=c++17
 common:windows --host_cxxopt=/std:c++17
 common:windows --cxxopt=/std:c++17
 
-# Starting from Xcode 15, the linker will warn about duplicate flags.
-# This is currently not avoidable with the current way the local cc toolchain is configured
-# as well as how linkopts are propagated through the dependency graph between libraries.
-# This flag is a workaround to silence the linker warnings.
-# common:macos --linkopt="-Wl,-no_warn_duplicate_libraries"
-# common:macos --host_linkopt="-Wl,-no_warn_duplicate_libraries"
-common:macos --platform_mappings=platform_mapping
-
 # Ensure that we don't use the apple_support cc_toolchain
 common:macos --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
 

--- a/platform_mapping
+++ b/platform_mapping
@@ -1,4 +1,0 @@
-platforms:
-  @local_config_platform//:host
-    --linkopt="-Wl,-no_warn_duplicate_libraries"
-    --host_linkopt="-Wl,-no_warn_duplicate_libraries"


### PR DESCRIPTION
This change is incompatible with XCode 14 and lower.
Let's roll this back for now to unblock rollout.
