### PR TITLE
Remove confusing logic in release.py

### DIFF
--- a/release.py
+++ b/release.py
@@ -204,15 +204,13 @@ def main():
     old_version = get_latest_remote_version()
     is_old_version_published = is_published_release(old_version)
 
-    skip_version_bump = args.skip_version_bump
     if not is_old_version_published and not args.force:
-        print(f"Skipping version bump.\nThe latest tag {old_version} does not correspond to a published github release." +
+        die(f"The latest tag {old_version} does not correspond to a published github release." +
         " It may be a draft release or it may have never been created." +
         " If you still want to upgrade the version, rerun the script with --force.")
-        skip_version_bump = True
 
     new_version = old_version
-    if not skip_version_bump:
+    if not args.skip_version_bump:
         if args.bump_version_type == 'patch':
             new_version = bump_patch_version(old_version)
         elif args.bump_version_type == 'minor':


### PR DESCRIPTION
The release.py script starts by pulling the latest version tag, and plans to bump it for the new release. Previously, if that version tag didn't correspond to a published github release however, we'd reuse that version tag instead of bumping it. This logic was originally added so that if rerun release.py (Ex. if we fail to upload some docker images for example and someone reruns the release workflow) it won’t bump the version tag again. This behavior is confuisng and error-prone though. If the latest tag doesn't correspond to a published release, we should fail the script because it indicates something fishy going on. You can force it to still run by passing the --force flag. Or you can pass the --skip_version_bump flag explicitly.
