### PR TITLE
show outgoing reviews that havent received a review yet

### DIFF
--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -1702,6 +1702,9 @@ func (a *GitHubApp) populatePRMetadata(ctx context.Context, client *github.Clien
 			}
 			for _, r := range *reviews {
 				prsMu.Lock()
+				if _, ok := prs[i.GetNodeID()]; !ok {
+					return nil
+				}
 				review, ok := prs[i.GetNodeID()].Reviews[r.GetUser().GetLogin()]
 				if !ok {
 					review = &ghpb.Review{}

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -1462,11 +1462,7 @@ func (a *GitHubApp) GetGithubPullRequest(ctx context.Context, req *ghpb.GetGithu
 		resp.Outgoing = append(resp.Outgoing, pr)
 	}
 	for _, i := range incoming.Issues {
-		pr := prs[i.GetNodeID()]
-		if len(pr.Reviews) == 0 {
-			continue
-		}
-		resp.Incoming = append(resp.Incoming, pr)
+		resp.Incoming = append(resp.Incoming, prs[i.GetNodeID()])
 	}
 	return resp, nil
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
i imagine this was done because it shows reviews with no reviewers? if so, i can try to address that separately, but this state is more annoying imo.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
