### PR TITLE
Don't fetch zstd artifacts from cache download endpoint in the UI

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -419,8 +419,9 @@ export default class InvocationModel {
   private getCacheBaseResourceName(): resource.IResourceName {
     return {
       instanceName: this.getRemoteInstanceName(),
-      compressor: this.getCompressor(),
       digestFunction: this.getDigestFunction(),
+      // Note: we don't set compressor for now because the UI cannot decompress
+      // zstd blobs.
     };
   }
 


### PR DESCRIPTION
The UI cannot handle zstd-compressed blobs, so always fetch using the `.../blobs/...` bytestream URL rather than `.../compressed-blobs/zstd/...`

**Related issues**: N/A
