### PR TITLE
Fix blank action page when navigating from cache requests card

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -416,7 +416,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
   }
 
   render() {
-    const digest = parseDigest(this.props.search.get("actionDigest") ?? "");
+    const digest = parseActionDigest(this.props.search.get("actionDigest") ?? "");
 
     return (
       <div className="invocation-action-card">


### PR DESCRIPTION
Use the `parseActionDigest` func which allows the `/size` suffix to be omitted (size is optional for AC)

**Related issues**: N/A
