### PR TITLE
Fix digest_function option parsing

### DIFF
--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -407,7 +407,7 @@ export default class InvocationModel {
     }
     const digestFnEnum =
       build.bazel.remote.execution.v2.DigestFunction.Value[
-        digestFnName as keyof typeof build.bazel.remote.execution.v2.DigestFunction.Value
+        digestFnName.toUpperCase() as keyof typeof build.bazel.remote.execution.v2.DigestFunction.Value
       ];
     return digestFnEnum || build.bazel.remote.execution.v2.DigestFunction.Value.SHA256;
   }


### PR DESCRIPTION
The UI was not correctly parsing the blake3 option and as a result it was incorrectly trying to fetching some artifacts using sha256 bytestream URLs.

**Related issues**: N/A
