### PR TITLE
New features for repo flow

### DIFF
--- a/enterprise/server/githubapp/BUILD
+++ b/enterprise/server/githubapp/BUILD
@@ -31,6 +31,7 @@ go_library(
         "@com_github_go_git_go_git_v5//config",
         "@com_github_go_git_go_git_v5//plumbing",
         "@com_github_go_git_go_git_v5//plumbing/object",
+        "@com_github_go_git_go_git_v5//plumbing/transport",
         "@com_github_go_git_go_git_v5//plumbing/transport/http",
         "@com_github_golang_jwt_jwt//:jwt",
         "@com_github_google_go_github_v43//github",

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -735,7 +735,7 @@ func cloneTemplate(email, tmpDirName, token, srcURL, destURL, srcDir, destDir st
 	if err != nil {
 		return err
 	}
-	// Copy template files into the destination repo
+	// Move template files into the destination repo
 	for _, file := range fileInfo {
 		old := filepath.Join(path, file.Name())
 		new := filepath.Join(newPath, file.Name())
@@ -789,6 +789,8 @@ func initOrClone(init bool, dir, url string, auth transport.AuthMethod) (*git.Re
 	return gitRepo, err
 }
 
+// Walks the given directory and performs a find and replace in all file contents.
+// All instance of the keys in the replacements map are replaced by the values in the map.
 func replace(dir string, replacements map[string]string) error {
 	return filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -1,6 +1,7 @@
 package githubapp
 
 import (
+	"bytes"
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
@@ -8,6 +9,8 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"io/fs"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -33,6 +36,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/golang-jwt/jwt"
 	"github.com/google/go-github/v43/github"
 	"golang.org/x/oauth2"
@@ -612,59 +616,64 @@ func (a *GitHubApp) CreateRepo(ctx context.Context, req *rppb.CreateRepoRequest)
 		return nil, err
 	}
 
-	// Create a new repository on github
-	repo, _, err := githubClient.Repositories.Create(ctx, req.Organization, &github.Repository{
-		Name:        github.String(req.Name),
-		Description: github.String(req.Description),
-		Private:     github.Bool(req.Private),
-	})
-	if err != nil {
-		return nil, err
-	}
+	repoURL := fmt.Sprintf("https://github.com/%s/%s", req.Organization, req.Name)
 
-	// If we have a template, copy the template contents to the new repo
-	if req.Template != "" {
-		tmpDirName := fmt.Sprintf("template-repo-%d-%s-*", req.InstallationId, req.Name)
-		err = cloneTemplate(tu.Email, tmpDirName, token, req.Template, *repo.CloneURL, req.TemplateDirectory)
+	// Create a new repository on github, if requested
+	if !req.SkipRepo {
+		_, _, err := githubClient.Repositories.Create(ctx, req.Organization, &github.Repository{
+			Name:        github.String(req.Name),
+			Description: github.String(req.Description),
+			Private:     github.Bool(req.Private),
+		})
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	// Link new repository to enable workflows
-	wfs := a.env.GetWorkflowService()
-	if wfs == nil {
-		return nil, status.UnimplementedErrorf("no workflow service configured")
+	// If we have a template, copy the template contents to the new repo
+	if req.Template != "" {
+		tmpDirName := fmt.Sprintf("template-repo-%d-%s-*", req.InstallationId, req.Name)
+		err = cloneTemplate(tu.Email, tmpDirName, token, req.Template, repoURL+".git", req.TemplateDirectory, req.DestinationDirectory, req.TemplateVariables, !req.SkipRepo)
+		if err != nil {
+			return nil, err
+		}
 	}
-	_, err = a.LinkGitHubRepo(ctx, &ghpb.LinkRepoRequest{
-		RequestContext: req.RequestContext,
-		RepoUrl:        *repo.HTMLURL,
-	})
-	if err != nil {
-		return nil, err
+
+	// Link new repository to enable workflows, if requested
+	if !req.SkipLink {
+		wfs := a.env.GetWorkflowService()
+		if wfs == nil {
+			return nil, status.UnimplementedErrorf("no workflow service configured")
+		}
+		_, err = a.LinkGitHubRepo(ctx, &ghpb.LinkRepoRequest{
+			RequestContext: req.RequestContext,
+			RepoUrl:        repoURL,
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &rppb.CreateRepoResponse{
-		RepoUrl: repo.GetHTMLURL(),
+		RepoUrl: repoURL,
 	}, nil
 }
 
 // TODO(siggisim): consider moving template cloning to a remote action if it causes us troubles doing this on apps.
-func cloneTemplate(email, tmpDirName, token, srcURL, destURL, srcDir string) error {
+func cloneTemplate(email, tmpDirName, token, srcURL, destURL, srcDir, destDir string, templateVariables map[string]string, needsInit bool) error {
 	// Make a temporary directory for the template
-	tmpDir, err := scratchspace.MkdirTemp(tmpDirName)
+	templateTmpDir, err := scratchspace.MkdirTemp(tmpDirName + "-template")
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpDir)
+	defer os.RemoveAll(templateTmpDir)
 
 	// Clone the template into the directory
 	auth := &githttp.BasicAuth{
 		Username: "github",
 		Password: token,
 	}
-
-	_, err = git.PlainClone(tmpDir, false, &git.CloneOptions{
+	_, err = git.PlainClone(templateTmpDir, false, &git.CloneOptions{
 		URL:  srcURL,
 		Auth: auth,
 	})
@@ -672,31 +681,70 @@ func cloneTemplate(email, tmpDirName, token, srcURL, destURL, srcDir string) err
 		return err
 	}
 	// Remove existing git information so we can create a single initial commit
-	err = os.RemoveAll(filepath.Join(tmpDir, ".git"))
+	err = os.RemoveAll(filepath.Join(templateTmpDir, ".git"))
 	if err != nil {
 		return err
 	}
 	// Remove any github workflows directories, because we won't have permission to create them
-	err = os.RemoveAll(filepath.Join(tmpDir, ".github/workflows"))
+	err = os.RemoveAll(filepath.Join(templateTmpDir, ".github/workflows"))
 	if err != nil {
 		return err
 	}
-	// Don't allow paths with dots or other non alphanumeric path components
+	// Don't allow template paths with dots or other non alphanumeric path components
 	if !validPathRegex.MatchString(srcDir) {
 		return status.FailedPreconditionErrorf("invalid template path: %q", srcDir)
 	}
-	path := filepath.Join(tmpDir, srcDir)
+	path := filepath.Join(templateTmpDir, srcDir)
 	// Intentionally using Lstat to avoid following symlinks
 	if fileInfo, err := os.Lstat(path); err != nil || !fileInfo.IsDir() {
 		return status.FailedPreconditionErrorf("not a valid directory: %q", srcDir)
 	}
-	gitRepo, err := git.PlainInit(path, false)
+	// Replace any template variables
+	if len(templateVariables) > 0 {
+		replace(path, templateVariables)
+	}
+	// Make a temporary directory for the new repo
+	repoTmpDir, err := scratchspace.MkdirTemp(tmpDirName + "-repo")
 	if err != nil {
 		return err
 	}
-	err = gitRepo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Main))
+	defer os.RemoveAll(repoTmpDir)
+
+	newPath := repoTmpDir
+
+	// If we have a destination directory that's not the repo root, update the path
+	if destDir != "" {
+		// Don't allow destinationPath paths with dots or other non alphanumeric path components
+		if !validPathRegex.MatchString(destDir) {
+			return status.FailedPreconditionErrorf("invalid destination path: %q", destDir)
+		}
+		if err := os.RemoveAll(newPath); err != nil {
+			return err
+		}
+		newPath = filepath.Join(repoTmpDir, destDir)
+		if err := os.MkdirAll(newPath, os.ModePerm); err != nil {
+			return err
+		}
+	}
+	// Initialize or clone the destination repo
+	gitRepo, err := initOrClone(needsInit, destDir, destURL, auth)
 	if err != nil {
 		return err
+	}
+	fileInfo, err := ioutil.ReadDir(path)
+	if err != nil {
+		return err
+	}
+	// Copy template files into the destination repo
+	for _, file := range fileInfo {
+		old := filepath.Join(path, file.Name())
+		new := filepath.Join(newPath, file.Name())
+		if err := os.RemoveAll(new); err != nil {
+			return err
+		}
+		if err := os.Rename(old, new); err != nil {
+			return err
+		}
 	}
 	gitWorkTree, err := gitRepo.Worktree()
 	if err != nil {
@@ -713,19 +761,50 @@ func cloneTemplate(email, tmpDirName, token, srcURL, destURL, srcDir string) err
 	if err != nil {
 		return err
 	}
-
-	// Create a new remote and push to it
-	remote, err := gitRepo.CreateRemote(&config.RemoteConfig{
-		Name: git.DefaultRemoteName,
-		URLs: []string{destURL},
-	})
-	if err != nil {
-		return err
-	}
-	return remote.Push(&git.PushOptions{
+	return gitRepo.Push(&git.PushOptions{
 		RemoteName: git.DefaultRemoteName,
 		Auth:       auth,
 		Force:      true,
+	})
+}
+
+func initOrClone(init bool, dir, url string, auth transport.AuthMethod) (*git.Repository, error) {
+	if !init {
+		return git.PlainClone(dir, false, &git.CloneOptions{
+			URL:  url,
+			Auth: auth,
+		})
+	}
+	gitRepo, err := git.PlainInit(dir, false)
+	if err != nil {
+		return nil, err
+	}
+	if err := gitRepo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Main)); err != nil {
+		return nil, err
+	}
+	_, err = gitRepo.CreateRemote(&config.RemoteConfig{
+		Name: git.DefaultRemoteName,
+		URLs: []string{url},
+	})
+	return gitRepo, err
+}
+
+func replace(dir string, replacements map[string]string) error {
+	return filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		contents, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for k, v := range replacements {
+			contents = bytes.Replace(contents, []byte(k), []byte(v), -1)
+		}
+		return ioutil.WriteFile(path, contents, os.ModePerm)
 	})
 }
 

--- a/proto/repo.proto
+++ b/proto/repo.proto
@@ -30,7 +30,7 @@ message CreateRepoRequest {
   // If unset, the root of the template repo will be used.
   string template_directory = 9;
 
-  // Variables that should be replaced in the template, mapped to the values 
+  // Variables that should be replaced in the template, mapped to the values
   // they should be replaced with.
   map<string, string> template_variables = 10;
 
@@ -46,11 +46,11 @@ message CreateRepoRequest {
   int64 installation_id = 8;
 
   // If set, the template will be copied into the given directory in the
-  // newly created repo. 
+  // newly created repo.
   // If unset, the root of the destination repo will be used.
   string destination_directory = 11;
 
-  // If true, a GitHub repo will not be created and the template (if provided) 
+  // If true, a GitHub repo will not be created and the template (if provided)
   // will be initialized into the given repository which is assumed to exist.
   bool skip_repo = 12;
 

--- a/proto/repo.proto
+++ b/proto/repo.proto
@@ -30,6 +30,10 @@ message CreateRepoRequest {
   // If unset, the root of the template repo will be used.
   string template_directory = 9;
 
+  // Variables that should be replaced in the template, mapped to the values 
+  // they should be replaced with.
+  map<string, string> template_variables = 10;
+
   // If true, the repository will be created as a private repo.
   bool private = 6;
 
@@ -40,6 +44,18 @@ message CreateRepoRequest {
   // The Github app installation id that should be used to create the
   // repository. Only required for repositories that are hosted on Github.
   int64 installation_id = 8;
+
+  // If set, the template will be copied into the given directory in the
+  // newly created repo. 
+  // If unset, the root of the destination repo will be used.
+  string destination_directory = 11;
+
+  // If true, a GitHub repo will not be created and the template (if provided) 
+  // will be initialized into the given repository which is assumed to exist.
+  bool skip_repo = 12;
+
+  // If true, we will not attempt to link the repo for use in workflows.
+  bool skip_link = 13;
 }
 
 // The platform on which the repository should be hosted.


### PR DESCRIPTION
New features:
- Adds the ability to find & replace variables in templates
- Adds the ability to specify a destination directory that the template should be copied into in the new repo
- Adds the option to skip GitHub repo creation, allowing you to copy templates into existing repos
- Adds the option to skip workflow linking

I can break this out into 3-4 PRs if that's easier, but I don't think the changes are too crazy.