### PR TITLE
SCIM user deletion support.

### DIFF
--- a/enterprise/server/scim/BUILD
+++ b/enterprise/server/scim/BUILD
@@ -33,6 +33,7 @@ go_test(
         "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/testutil/testhttp",
+        "//server/util/status",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -501,6 +501,8 @@ type UserDB interface {
 	// e-mail address. Normally this should not be the case, but it can occur
 	// if a user transitions between auth providers (e.g. oidc to saml).
 	GetUserByEmail(ctx context.Context, email string) (*tables.User, error)
+	// DeleteUser deletes a user and associated data.
+	DeleteUser(ctx context.Context, id string) error
 	// GetImpersonatedUser will return the authenticated user's information
 	// with a single group membership corresponding to the group they are trying
 	// to impersonate. It requires that the authenticated user has impersonation


### PR DESCRIPTION
For now, we support the minimum required by Okta:
 - PATCH is only used for de-activation requests
 - PUT is used for de-activation and other attribute updates (next PR)

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
