### PR TITLE
Serialize the existence check and image pull in PullImageIfNecessary

### DIFF
--- a/enterprise/server/remote_execution/container/BUILD
+++ b/enterprise/server/remote_execution/container/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//server/environment",
         "//server/interfaces",
         "//server/metrics",
+        "//server/util/alert",
         "//server/util/authutil",
         "//server/util/flag",
         "//server/util/log",
@@ -40,5 +41,6 @@ go_test(
         "//server/util/status",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/enterprise/server/remote_execution/container/BUILD
+++ b/enterprise/server/remote_execution/container/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//server/util/alert",
         "//server/util/authutil",
         "//server/util/flag",
+        "//server/util/hash",
         "//server/util/log",
         "//server/util/perms",
         "//server/util/status",

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -252,8 +252,8 @@ func PullImageIfNecessary(ctx context.Context, env environment.Env, ctr CommandC
 	}
 
 	// TODO(iain): the auth/existence/pull synchronization is getting unruly.
-	unsafemu, _ := pullOperations.LoadOrStore(ctr.IsolationType()+imageRef, &sync.Mutex{})
-	mu, ok := unsafemu.(*sync.Mutex)
+	uncastmu, _ := pullOperations.LoadOrStore(ctr.IsolationType()+imageRef, &sync.Mutex{})
+	mu, ok := uncastmu.(*sync.Mutex)
 	if !ok {
 		alert.UnexpectedEvent("psi cannot be cast to *pullStatus")
 		return status.InternalError("PullImage failed: cannot get pull status")

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -255,8 +255,8 @@ func PullImageIfNecessary(ctx context.Context, env environment.Env, ctr CommandC
 	uncastmu, _ := pullOperations.LoadOrStore(ctr.IsolationType()+imageRef, &sync.Mutex{})
 	mu, ok := uncastmu.(*sync.Mutex)
 	if !ok {
-		alert.UnexpectedEvent("psi cannot be cast to *pullStatus")
-		return status.InternalError("PullImage failed: cannot get pull status")
+		alert.UnexpectedEvent("loaded mutex from sync.map that isn't a mutex!")
+		return status.InternalError("PullImageIfNecessary failed: cannot obtain mutex")
 	}
 	mu.Lock()
 	defer mu.Unlock()

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -367,6 +367,10 @@ type TracedCommandContainer struct {
 	Delegate CommandContainer
 }
 
+func (t *TracedCommandContainer) IsolationType() string {
+	return t.Delegate.IsolationType()
+}
+
 func (t *TracedCommandContainer) Run(ctx context.Context, command *repb.Command, workingDir string, creds oci.Credentials) *interfaces.CommandResult {
 	ctx, span := tracing.StartSpan(ctx, trace.WithAttributes(t.implAttr))
 	defer span.End()

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -55,7 +55,8 @@ var (
 
 	slowPullWarnOnce sync.Once
 
-	// A map from image name to pull status. This is used to avoid parallel pulling of the same image.
+	// A map from isolation type + image name to a mutex that serializes
+	// existence checks and image pulls.
 	pullOperations sync.Map
 )
 

--- a/enterprise/server/remote_execution/container/container_test.go
+++ b/enterprise/server/remote_execution/container/container_test.go
@@ -146,7 +146,7 @@ func TestPullImageIfNecessary_ParallelCallsSerialized(t *testing.T) {
 		eg.Go(func() error { return container.PullImageIfNecessary(ctx, env, c, oci.Credentials{}, imageRef) })
 	}
 	require.NoError(t, eg.Wait())
-	assert.Equal(t, 1, c.PullCount, "should pull the image if credentials are valid")
+	assert.Equal(t, 1, c.PullCount, "image should only be pulled once")
 }
 
 func TestImageCacheAuthenticator(t *testing.T) {

--- a/enterprise/server/remote_execution/container/container_test.go
+++ b/enterprise/server/remote_execution/container/container_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
@@ -21,8 +22,12 @@ import (
 type FakeContainer struct {
 	RequiredPullCredentials oci.Credentials
 	PullCount               int
+	pullDelay               time.Duration
 }
 
+func (c *FakeContainer) IsolationType() string {
+	return "fake"
+}
 func (c *FakeContainer) Run(context.Context, *repb.Command, string, oci.Credentials) *interfaces.CommandResult {
 	return nil
 }
@@ -30,6 +35,9 @@ func (c *FakeContainer) IsImageCached(context.Context) (bool, error) {
 	return c.PullCount > 0, nil
 }
 func (c *FakeContainer) PullImage(ctx context.Context, creds oci.Credentials) error {
+	if c.pullDelay > 0*time.Second {
+		time.Sleep(c.pullDelay)
+	}
 	if creds != c.RequiredPullCredentials {
 		return status.PermissionDeniedError("Permission denied: wrong pull credentials")
 	}
@@ -121,6 +129,24 @@ func TestPullImageIfNecessary_InvalidCredentials_PermissionDenied(t *testing.T) 
 	err = container.PullImageIfNecessary(ctx, env, c, goodCreds, imageRef)
 
 	require.NoError(t, err, "good creds should still work after previous incorrect attempts")
+}
+
+func TestPullImageIfNecessary_ParallelCallsSerialized(t *testing.T) {
+	env := testenv.GetTestEnv(t)
+	ta := testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1", "US2", "GR2"))
+	env.SetAuthenticator(ta)
+	env.SetImageCacheAuthenticator(container.NewImageCacheAuthenticator(container.ImageCacheAuthenticatorOpts{}))
+	imageRef := "docker.io/some-org/some-image:v1.0.0"
+	ctx := userCtx(t, ta, "US1")
+	c := &FakeContainer{pullDelay: time.Second}
+
+	assert.Equal(t, 0, c.PullCount, "sanity check: pull count should be 0 initially")
+	eg := errgroup.Group{}
+	for i := 0; i < 20; i++ {
+		eg.Go(func() error { return container.PullImageIfNecessary(ctx, env, c, oci.Credentials{}, imageRef) })
+	}
+	require.NoError(t, eg.Wait())
+	assert.Equal(t, 1, c.PullCount, "should pull the image if credentials are valid")
 }
 
 func TestImageCacheAuthenticator(t *testing.T) {

--- a/enterprise/server/remote_execution/containers/bare/bare.go
+++ b/enterprise/server/remote_execution/containers/bare/bare.go
@@ -47,6 +47,10 @@ func NewBareCommandContainer(opts *Opts) container.CommandContainer {
 	return &bareCommandContainer{opts: opts}
 }
 
+func (c *bareCommandContainer) IsolationType() string {
+	return "bare"
+}
+
 func (c *bareCommandContainer) Run(ctx context.Context, command *repb.Command, workDir string, creds oci.Credentials) *interfaces.CommandResult {
 	return c.exec(ctx, command, workDir, nil /*=stdio*/)
 }

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -189,6 +189,10 @@ const (
 	ctrDidNotExitCleanly
 )
 
+func (c *dockerCommandContainer) IsolationType() string {
+	return "docker"
+}
+
 func (r *dockerCommandContainer) Run(ctx context.Context, command *repb.Command, workDir string, creds oci.Credentials) *interfaces.CommandResult {
 	result := &interfaces.CommandResult{
 		CommandDebugString: fmt.Sprintf("(docker) %s", command.GetArguments()),

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1775,6 +1775,10 @@ func (c *FirecrackerContainer) SetTaskFileSystemLayout(fsLayout *container.FileS
 	c.fsLayout = fsLayout
 }
 
+func (c *FirecrackerContainer) IsolationType() string {
+	return "firecracker"
+}
+
 // Run the given command within the container and remove the container after
 // it is done executing.
 //

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -356,6 +356,10 @@ func (c *podmanCommandContainer) getPodmanRunArgs(workDir string) []string {
 	return args
 }
 
+func (c *podmanCommandContainer) IsolationType() string {
+	return "podman"
+}
+
 func (c *podmanCommandContainer) Run(ctx context.Context, command *repb.Command, workDir string, creds oci.Credentials) *interfaces.CommandResult {
 	c.workDir = workDir
 	defer os.RemoveAll(c.cidFilePath())

--- a/enterprise/server/remote_execution/containers/sandbox/sandbox.go
+++ b/enterprise/server/remote_execution/containers/sandbox/sandbox.go
@@ -314,6 +314,10 @@ func (c *sandbox) runCmdInSandbox(ctx context.Context, command *repb.Command, wo
 	return result
 }
 
+func (c *sandbox) IsolationType() string {
+	return "sandbox"
+}
+
 func (c *sandbox) Run(ctx context.Context, command *repb.Command, workDir string, _ oci.Credentials) *interfaces.CommandResult {
 	return c.runCmdInSandbox(ctx, command, workDir, &interfaces.Stdio{})
 }

--- a/enterprise/server/util/ociconv/ociconv.go
+++ b/enterprise/server/util/ociconv/ociconv.go
@@ -143,7 +143,7 @@ func CreateDiskImage(ctx context.Context, dockerClient *dockerclient.Client, wor
 	// convert the image in the background so that one client's ctx timeout does
 	// not affect other clients. We do apply a timeout to the background
 	// conversion though to prevent it from running forever.
-	conversionOpKey := singleflightKey(
+	conversionOpKey := hash.Strings(
 		workspaceDir, containerImage, creds.Username, creds.Password,
 	)
 	resultChan := conversionGroup.DoChan(conversionOpKey, func() (interface{}, error) {
@@ -301,14 +301,4 @@ func convertContainerToExt4FS(ctx context.Context, dockerClient *dockerclient.Cl
 	}
 	log.Debugf("Wrote container %q to image file: %q", containerImage, imageFile)
 	return imageFile, nil
-}
-
-// singleflightKey returns a key that can be used to dedupe a function whose
-// output depends solely on the given args.
-func singleflightKey(args ...string) string {
-	h := ""
-	for _, s := range args {
-		h += hash.String(s)
-	}
-	return hash.String(h)
 }

--- a/server/util/hash/hash.go
+++ b/server/util/hash/hash.go
@@ -15,6 +15,14 @@ func String(input string) string {
 	return Bytes([]byte(input))
 }
 
+func Strings(input ...string) string {
+	h := ""
+	for _, s := range input {
+		h += String(s)
+	}
+	return String(h)
+}
+
 //go:noescape
 //go:linkname memhash runtime.memhash
 func memhash(p unsafe.Pointer, h, s uintptr) uintptr

--- a/server/util/hash/hash_test.go
+++ b/server/util/hash/hash_test.go
@@ -23,6 +23,45 @@ func TestHashString(t *testing.T) {
 	assert.Equal(t, "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae", fooHash)
 }
 
+func TestHashStrings(t *testing.T) {
+	cases := []struct {
+		inputs       []string
+		expectedHash string
+	}{
+		{
+			inputs:       []string{""},
+			expectedHash: "cd372fb85148700fa88095e3492d3f9f5beb43e555e5ff26d95f5a6adc36f8e6",
+		},
+		{
+			inputs:       []string{"foo"},
+			expectedHash: "505221025f9701f8a05cc22cbafeec897598b2924a9d665cbc10f0073d66da20",
+		},
+		{
+			inputs:       []string{"bar"},
+			expectedHash: "bd142ccf5968384068077c58de4d3ad833204a151d3e9f1182703f07b69125b8",
+		},
+		{
+			inputs:       []string{"foo", "bar"},
+			expectedHash: "ec321de56af3b66fb49e89cfe346562388af387db689165d6f662a3950286a57",
+		},
+		{
+			inputs:       []string{"bar", "foo"},
+			expectedHash: "ec5134518944504462951c1e23b4728a144542776bc9477d785d2fd3064aaf76",
+		},
+		{
+			inputs:       []string{"foo", "bar", "baz"},
+			expectedHash: "9462ae47a25296a8341fb0bf14a52a0cedfcecaf9d75b33f8a1e9d61d4e1b6d2",
+		},
+		{
+			inputs:       []string{"baz", "bar", "foo"},
+			expectedHash: "3745ceb009bd639f22c207acaa86e78221465c71dd46c7c5c91b4449a321c8f2",
+		},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.expectedHash, hash.Strings(tc.inputs...))
+	}
+}
+
 func TestMemHash(t *testing.T) {
 	bytesHash := hash.MemHash([]byte{'b', 'y', 't', 'e'})
 	assert.Greater(t, bytesHash, uint64(0))


### PR DESCRIPTION
This should fix the serial-image-pulling bug described [here](https://github.com/buildbuddy-io/buildbuddy-internal/issues/2844#issuecomment-1868007914). This is kinda gross, but a more correct fix that simplifies locking in container implementations and moves some of the auth-checking logic into container.go is quite a bit more involved, so I figured this was a good first step.

**Related issues**: [2844](https://github.com/buildbuddy-io/buildbuddy-internal/issues/2844#issuecomment-1868007914)
