### PR TITLE
Fix more typos in github release workflow

### DIFF
--- a/.github/workflows/create-github-release.yaml
+++ b/.github/workflows/create-github-release.yaml
@@ -25,8 +25,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'release skip')"
     needs: create-release
     with:
-      release_branch: ${GITHUB_REF}
-      version_tag: ${GITHUB_REF/refs\/tags\//}
+      release_branch: ${{ github.ref }}
+      version_tag: ${{ github.ref_name }}
     secrets: inherit
 
   build-mac-intel-artifacts:
@@ -34,8 +34,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'release skip')"
     needs: create-release
     with:
-      release_branch: ${GITHUB_REF}
-      version_tag: ${GITHUB_REF/refs\/tags\//}
+      release_branch: ${{ github.ref }}
+      version_tag: ${{ github.ref_name }}
     secrets: inherit
 
   build-mac-m1-artifacts:
@@ -43,8 +43,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'release skip')"
     needs: create-release
     with:
-      release_branch: ${GITHUB_REF}
-      version_tag: ${GITHUB_REF/refs\/tags\//}
+      release_branch: ${{ github.ref }}
+      version_tag: ${{ github.ref_name }}
     secrets: inherit
 
   slack_on_failure:


### PR DESCRIPTION
Grrr github does not make writing these yamls easy...

From the github docs:

Because default environment variables are set by GitHub and not defined in a workflow, they are not accessible through the env context. However, most of the default variables have a corresponding, and similarly named, context property. For example, the value of the GITHUB_REF variable can be read during workflow processing using the ${{ github.ref }} context property.
