### PR TITLE
Add step annotations to CI runner logs

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -174,12 +174,20 @@ export default class InvocationComponent extends React.Component<Props, State> {
   }
 
   getBuildLogs(model: InvocationModel): string {
+    let logs = "";
     if (!model.hasChunkedEventLogs()) {
       // Use the inlined console buffer if this invocation was created before
       // log chunking existed.
-      return model.invocation.consoleBuffer;
+      logs = model.invocation.consoleBuffer;
+    } else {
+      logs = this.logsModel?.getLogs() ?? "";
     }
-    return this.logsModel?.getLogs() ?? "";
+    if (this.state.model?.isWorkflowInvocation()) {
+      // Strip out in-band section annotations for now (these will be used for
+      // the proposed workflows "steps" UI)
+      logs = logs.replaceAll(/^@buildbuddy \{.*?\}$/gm, "");
+    }
+    return logs;
   }
 
   areBuildLogsLoading(model: InvocationModel) {


### PR DESCRIPTION
The plan for now is to parse these out of the outer/workflow invocation logs and use the parsed annotation data to split the top-level workflow logs into collapsible sections.

Printing these annotations to the logs seems a bit ugly, but the alternatives seem worse -

* _Why not store each section's logs using explicit BES streams? e.g. add a "section" property name to the Progress event?_ - we don't currently support multiple log streams for a single BES stream and this would likely add too much complexity to the BES handler.
* _Why not wrap each step in its own child invocation?_ - this seems overkill because then we'll have a lot of invocations for a single workflow invocation - the "outer" one, the ones for each step (which are purely for logging for each step), and any "child" invocations invoked by the user within the steps themselves

**Related issues**: N/A
