### PR TITLE
Remove domain restriction from SCIM user creation.

### DIFF
--- a/enterprise/server/scim/scim.go
+++ b/enterprise/server/scim/scim.go
@@ -366,13 +366,6 @@ func (s *SCIMServer) createUser(ctx context.Context, r *http.Request, g *tables.
 	if err := json.Unmarshal(req, &ur); err != nil {
 		return nil, err
 	}
-	emailParts := strings.Split(ur.UserName, "@")
-	if len(emailParts) != 2 {
-		return nil, status.InvalidArgumentErrorf("invalid username %q", ur.UserName)
-	}
-	if emailParts[1] != g.OwnedDomain {
-		return nil, status.InvalidArgumentErrorf("username domain %q does not match group domain %q", ur.UserName, g.OwnedDomain)
-	}
 
 	pk, err := tables.PrimaryKeyForTable("Users")
 	if err != nil {


### PR DESCRIPTION
The owned domain value is currently tied to automatically adding users by domain which users may want to disable.

This means that SCIM API could be used to create a user with any e-mail, but this is fine because:
 - The user Sub ID will be tied to the SAML login for the org so the created user won't be usable outside that org
 - The user will only belong to the group being administered

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
