### PR TITLE
Add a minimal webdriver test for the executions listing

### DIFF
--- a/enterprise/server/test/webdriver/invocation/BUILD
+++ b/enterprise/server/test/webdriver/invocation/BUILD
@@ -8,11 +8,12 @@ go_web_test_suite(
         # requires networking.
         "test.dockerNetwork": "bridge",
     },
-    shard_count = 2,
+    shard_count = 3,
     deps = [
         "//enterprise/server/testutil/buildbuddy_enterprise",
         "//server/testutil/testbazel",
         "//server/testutil/webtester",
+        "//server/util/uuid",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/testutil/webtester/webtester.go
+++ b/server/testutil/webtester/webtester.go
@@ -336,6 +336,15 @@ var (
 			fullCacheRadioButton.Click()
 		}
 	}
+
+	// WithEnableRemoteExecution is a setup page option that checks the "enable
+	// remote execution" checkbox.
+	WithEnableRemoteExecution SetupPageOption = func(wt *WebTester) {
+		checkbox := wt.Find("#execution")
+		if !checkbox.IsSelected() {
+			checkbox.Click()
+		}
+	}
 )
 
 // WithAPIKeySelection returns a setup page option that selects a given API key


### PR DESCRIPTION
For now, the test just navigates to the executions tab and makes sure an execution row shows up.

The execution row is currently in a weird state because there are no executors registered. In a later PR we can register a real executor and make sure the action gets executed.

**Related issues**: N/A
