### PR TITLE
Repo flow tweaks

### DIFF
--- a/enterprise/app/repo/repo.css
+++ b/enterprise/app/repo/repo.css
@@ -189,23 +189,21 @@
 }
 
 .create-repo-page .deployment-configs {
-  display: table;
-  border-spacing: 16px;
   width: 100%;
 }
 
 .create-repo-page .deployment-config {
-  display: table-row;
   align-items: center;
-  gap: 16px;
+  margin-bottom: 16px;
 }
 
 .create-repo-page .deployment-config div {
-  display: table-cell;
 }
 
 .create-repo-page .deployment-config div:first-of-type {
   font-family: monospace;
+  font-weight: 700;
+  margin-bottom: 8px;
 }
 
 .create-repo-page .template {

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -727,7 +727,7 @@ func cloneTemplate(email, tmpDirName, token, srcURL, destURL, srcDir, destDir st
 		}
 	}
 	// Initialize or clone the destination repo
-	gitRepo, err := initOrClone(needsInit, destDir, destURL, auth)
+	gitRepo, err := initOrClone(needsInit, newPath, destURL, auth)
 	if err != nil {
 		return err
 	}
@@ -754,7 +754,13 @@ func cloneTemplate(email, tmpDirName, token, srcURL, destURL, srcDir, destDir st
 	if err != nil {
 		return err
 	}
-	_, err = gitWorkTree.Commit("Initial commit", &git.CommitOptions{All: true, Author: &gitobject.Signature{
+
+	commitMessage := "Initial commit"
+	if !needsInit {
+		commitMessage = "Update"
+	}
+
+	_, err = gitWorkTree.Commit(commitMessage, &git.CommitOptions{All: true, Author: &gitobject.Signature{
 		Email: email,
 		When:  time.Now(),
 	}})


### PR DESCRIPTION
- Add UI support for template variables
- Minor styling tweaks
- Switch from `GCP_PROJECT` environment variable to `CLOUDSDK_CORE_PROJECT` which the gcloud CLI uses without the need for any special handling from us https://cloud.google.com/compute/docs/gcloud-compute#default_project
- Add UI support for destination directories
- Remove unused repository hook permission check
- Fix commit message when not initializing a new repo
- Fix use of wrong path when copying a template to a new repo