### PR TITLE
no err returned

### DIFF
--- a/enterprise/server/raft/client/BUILD
+++ b/enterprise/server/raft/client/BUILD
@@ -7,7 +7,9 @@ go_library(
     srcs = ["client.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/client",
     deps = [
+        "//enterprise/server/raft/constants",
         "//enterprise/server/raft/rbuilder",
+        "//proto:grpc_status_go_proto",
         "//proto:raft_go_proto",
         "//proto:raft_service_go_proto",
         "//server/environment",
@@ -19,5 +21,6 @@ go_library(
         "@com_github_lni_dragonboat_v4//:dragonboat",
         "@com_github_lni_dragonboat_v4//client",
         "@com_github_lni_dragonboat_v4//statemachine",
+        "@org_golang_google_grpc//status",
     ],
 )

--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -17,11 +17,11 @@ import (
 	"github.com/lni/dragonboat/v4"
 	"github.com/lni/dragonboat/v4/client"
 
-	statuspb "google.golang.org/genproto/googleapis/rpc/status"
-	gstatus "google.golang.org/grpc/status"
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
 	rfspb "github.com/buildbuddy-io/buildbuddy/proto/raft_service"
 	dbsm "github.com/lni/dragonboat/v4/statemachine"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
+	gstatus "google.golang.org/grpc/status"
 )
 
 // A default timeout that can be applied to raft requests that do not have one

--- a/enterprise/server/raft/constants/constants.go
+++ b/enterprise/server/raft/constants/constants.go
@@ -47,6 +47,8 @@ const (
 	MetaRangeID      = 1
 
 	UnsplittableMaxByte = systemMaxByte
+
+	EntryErrorValue = 0
 )
 
 const CASErrorMessage = "CAS expected value did not match"

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -351,7 +351,11 @@ func (s *Sender) RunMultiKey(ctx context.Context, keys []*KeyMeta, fn runMultiKe
 
 func (s *Sender) SyncPropose(ctx context.Context, key []byte, batchCmd *rfpb.BatchCmdRequest) (*rfpb.BatchCmdResponse, error) {
 	var rsp *rfpb.SyncProposeResponse
+	customHeader := batchCmd.Header
 	err := s.Run(ctx, key, func(c rfspb.ApiClient, h *rfpb.Header) error {
+		if customHeader == nil {
+			batchCmd.Header = h
+		}
 		r, err := c.SyncPropose(ctx, &rfpb.SyncProposeRequest{
 			Header: h,
 			Batch:  batchCmd,


### PR DESCRIPTION
Don't return an error from SyncPropose (my bad, I forgot); it will result in a panic. SyncRead is fine tho.

Because header is not blindly copied from request -> batch in SyncPropose, ensure that it's being set if it's not set already, in the client. And ensure that it will be updated if it happens to change between subsequent retries.
