### PR TITLE
Fix link in how-bazel-7-0-makes-your-builds-faster

### DIFF
--- a/website/blog/how-bazel-7-0-makes-your-builds-faster.md
+++ b/website/blog/how-bazel-7-0-makes-your-builds-faster.md
@@ -53,7 +53,7 @@ and [`--persistent_android_dex_desugar`][persistent_android_dex_desugar] flags.
 [experimental_persistent_aar_extractor]: https://bazel.build/versions/7.0.0/reference/command-line-reference#flag--experimental_persistent_aar_extractor
 [persistent_android_resource_processor]: https://bazel.build/versions/7.0.0/reference/command-line-reference#flag--persistent_android_resource_processor
 [persistent_android_dex_desugar]: https://bazel.build/versions/7.0.0/reference/command-line-reference#flag--persistent_android_dex_desugar
-[reuse_sandbox_directories]: https://bazel.build/versions/7.0.0/reference/command-line-reference#flag--experimental_circuit_breaker_strategy
+[reuse_sandbox_directories]: https://bazel.build/versions/7.0.0/reference/command-line-reference#flag--reuse_sandbox_directories
 
 ## Skymeld
 


### PR DESCRIPTION
The blog post how-bazel-7-0-makes-your-builds-faster contained a link `--reuse_sandbox_directories` that pointed to the documentation for `--experimental_circuit_breaker_strategy`. This PR corrects the link.
