### PR TITLE
.bazelrc: test go tests to be more verbose

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -174,6 +174,11 @@ common:macos --enable_runfiles
 # Need to work around M1 Mac browser test issue https://github.com/bazelbuild/rules_webtesting/issues/438
 common --experimental_inprocess_symlink_creation
 
+# Add `-test.v` to all Go tests so that each test func is reported as a separate test case
+# in the XML output.  This allows our webUI to display the run time of each test case
+# separately and let us know which tests is slow.
+common --test_env=GO_TEST_WRAP_TESTV=1
+
 # Workaround for Bazel 7:
 # rules_docker (archived) defines a transition that helps ensure building containers with binary would use the same platform for both.
 # Reference: https://github.com/bazelbuild/rules_docker/pull/1963


### PR DESCRIPTION
By default, go_test would not run the test binary with `-test.v`.
This effectively creates a relatively empty XML output, with only the
target as the top level "testsuite".

```xml
<testsuites>
    <testsuite errors="0" failures="0" skipped="0" tests="0" time="0.004" name="github.com/buildbuddy-io/buildbuddy/cli/arg">
    </testsuite>
</testsuites>
```

This behavior could be overriden as stated in (1) so that the XML output
is decorated with smaller testcase, each representing a Go test func.

```xml
<testsuites>
  <testsuite errors="0" failures="0" skipped="0" tests="2" time="10.834" name="enterprise/server/test/integration/ci_runner/ci_runner_test">
    <testcase classname="ci_runner_test" name="TestCIRunner_Push_WorkspaceWithCustomConfig_RunsAndUploadsResultsToBES" time="3.020">
    </testcase>
    <testcase classname="ci_runner_test" name="TestLocalEnvironmentalError" time="7.790">
    </testcase>
  </testsuite>
</testsuites>
```

Since our UI can display separate `testcase` in the XML output, we would
be able to see detail runtime for each test. This should help us
identify slower test func(s) easier in a big go_test target.
Additionally, we could tell how sharded go_test targets divided the
funcs to each shard.

(1): https://github.com/bazelbuild/rules_go/issues/2364
