### PR TITLE
.github: add windows release workflow for executor

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -128,6 +128,11 @@ common:release-mac --config=release-shared
 # Configuration used for release-m1 workflow
 common:release-m1 --config=release-shared
 
+# Configuration used for release-windows workflow
+common:release-windows --config=release-shared
+common:release-windows --config=cache
+common:release --remote_instance_name=buildbuddy-io/buildbuddy/release-windows
+
 # Configuration used for Buildbuddy auto-release
 common:auto-release --config=remote
 common:auto-release --remote_instance_name=buildbuddy-io/buildbuddy/auto-release

--- a/.github/workflows/build-windows-github-release-artifacts.yaml
+++ b/.github/workflows/build-windows-github-release-artifacts.yaml
@@ -1,0 +1,51 @@
+name: "Build Windows Github Release Artifacts"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: "Git branch to checkout."
+        required: true
+        default: "master"
+        type: string
+      version_tag:
+        description: "Version to tag release artifacts."
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      release_branch:
+        description: "Git branch to checkout."
+        required: true
+        type: string
+      version_tag:
+        description: "Version to tag release artifacts."
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_branch }}
+          # We need to fetch git tags to obtain the latest version tag to report
+          # the version of the running binary.
+          fetch-depth: 0
+
+      - name: Install bazelisk
+        run: |
+          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-windows-amd64.exe" -o bazel.exe
+
+      - name: Build and Upload Artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bazel.exe --output_user_root=D:/0 build --config=release-windows --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
+          $execution_root = bazel.exe --output_user_root=D:/0 info execution_root
+          $artifact_rel_path = bazel.exe --output_user_root=D:/0 cquery --config=release-windows --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} --output=files //enterprise/server/cmd/executor:executor
+          $artifact_abs_path = "${execution_root}\${artifact_rel_path}"
+          Copy-Item -Path $artifact_abs_path -Destination executor-enterprise-windows-amd64-beta.exe
+          gh release upload ${{ inputs.version_tag }} executor-enterprise-windows-amd64-beta.exe --clobber

--- a/.github/workflows/create-github-release.yaml
+++ b/.github/workflows/create-github-release.yaml
@@ -47,6 +47,15 @@ jobs:
       version_tag: ${{ github.ref_name }}
     secrets: inherit
 
+  build-windows-artifacts:
+    uses: ./.github/workflows/build-windows-github-release-artifacts.yaml
+    if: "!contains(github.event.head_commit.message, 'release skip')"
+    needs: create-release
+    with:
+      release_branch: ${{ github.ref }}
+      version_tag: ${{ github.ref_name }}
+    secrets: inherit
+
   slack_on_failure:
     runs-on: ubuntu-latest
     needs: [create-release, build-linux-artifacts, build-mac-intel-artifacts, build-mac-m1-artifacts]

--- a/tools/check_release_assets_uploaded.py
+++ b/tools/check_release_assets_uploaded.py
@@ -12,6 +12,7 @@ EXPECTED_ASSETS = [
     "executor-enterprise-linux-amd64",
     "buildbuddy-enterprise-darwin-amd64",
     "executor-enterprise-darwin-amd64",
+    "executor-enterprise-windows-amd64-beta.exe",
     "buildbuddy-darwin-amd64"
 ]
 


### PR DESCRIPTION
This should help us to start releasing Windows executor artifacts to our Github Release.