### PR TITLE
Add `CppArchive` to `IOS_EXECUTION_FILTER`

### DIFF
--- a/app/invocation/invocation_suggestion_card.tsx
+++ b/app/invocation/invocation_suggestion_card.tsx
@@ -47,6 +47,7 @@ const IOS_EXECUTION_FILTER = {
     "DsymLipo",
     "GenerateAppleSymbolsFile",
     "ObjcBinarySymbolStrip",
+    "CppArchive",
     "CppLink",
     "ObjcLink",
     "ProcessAndSign",


### PR DESCRIPTION
`CppLink` was split in two, so we need to include `CppArchive` as well.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
