### PR TITLE
Add group setting to disable in-app user management.

### DIFF
--- a/enterprise/app/org/BUILD
+++ b/enterprise/app/org/BUILD
@@ -92,6 +92,7 @@ ts_library(
     deps = [
         "//app/alert:alert_service",
         "//app/auth:auth_service",
+        "//app/components/banner",
         "//app/components/button",
         "//app/components/button:checkbox_button",
         "//app/components/checkbox",

--- a/enterprise/app/org/join_org.tsx
+++ b/enterprise/app/org/join_org.tsx
@@ -126,6 +126,13 @@ export default class JoinOrgComponent extends React.Component<JoinOrgComponentPr
       case "READY":
       case "JOINING_GROUP":
         if (!org) throw new Error("Invalid state: org is undefined.");
+        if (org.externalUserManagement) {
+          return (
+              <div className="organization-join-page">
+                <div>Please contact your organization administrators to join.</div>
+              </div>
+          )
+        }
         return (
           <div className="organization-join-page">
             <img className="illustration" src="/image/join-org-illustration.png"></img>

--- a/enterprise/app/org/org.css
+++ b/enterprise/app/org/org.css
@@ -269,7 +269,6 @@
 }
 
 .org-members .org-members-list-item {
-  cursor: pointer;
   user-select: none;
   display: flex;
   align-items: center;
@@ -281,12 +280,16 @@
   transition: background-color 100ms ease-out;
 }
 
-.org-members .org-members-list-item:first-child {
-  border-top: 1px solid #eee;
+.org-members .org-members-list-item.editable {
+  cursor: pointer;
 }
 
-.org-members .org-members-list-item:hover {
+.org-members .org-members-list-item.editable:hover {
   background-color: #fafafa;
+}
+
+.org-members .org-members-list-item:first-child {
+  border-top: 1px solid #eee;
 }
 
 .org-members .org-members-list-item.selected {

--- a/enterprise/app/org/org_members.tsx
+++ b/enterprise/app/org/org_members.tsx
@@ -18,6 +18,7 @@ import Dialog, {
 import Select, { Option } from "../../../app/components/select/select";
 import { user_id } from "../../../proto/user_id_ts_proto";
 import Spinner from "../../../app/components/spinner/spinner";
+import Banner from "../../../app/components/banner/banner";
 
 export type OrgMembersProps = {
   user: User;
@@ -75,6 +76,9 @@ export default class OrgMembersComponent extends React.Component<OrgMembersProps
   }
 
   private onClickRow(userID: string) {
+    if (this.props.user.selectedGroup.externalUserManagement) {
+      return;
+    }
     const clone = new Set(this.state.selectedUserIds);
     if (clone.has(userID)) {
       clone.delete(userID);
@@ -242,38 +246,50 @@ export default class OrgMembersComponent extends React.Component<OrgMembersProps
     return (
       <div className="org-members">
         <div className="org-members-list-controls">
-          <CheckboxButton
-            className="select-all-button"
-            checked={this.state.isSelectingAll}
-            onClick={this.onClickSelectAllToggle.bind(this)}
-            checkboxOnLeft>
-            Select all
-          </CheckboxButton>
-
-          <Button onClick={this.onClickEditRole.bind(this)} disabled={isSelectionEmpty}>
-            Edit role
-          </Button>
-          <Button
-            onClick={this.onClickRemove.bind(this)}
-            disabled={isSelectionEmpty}
-            className="destructive org-member-remove-button">
-            Remove
-          </Button>
+          {this.props.user.selectedGroup.externalUserManagement && (
+            <div>
+              <Banner type="warning" className="user-management-warning">
+                Users are being managed via an external system. All changes must be made there.
+              </Banner>
+            </div>
+          )}
+          {!this.props.user.selectedGroup.externalUserManagement && (
+            <>
+              <CheckboxButton
+                className="select-all-button"
+                checked={this.state.isSelectingAll}
+                onClick={this.onClickSelectAllToggle.bind(this)}
+                checkboxOnLeft>
+                Select all
+              </CheckboxButton>
+              <Button onClick={this.onClickEditRole.bind(this)} disabled={isSelectionEmpty}>
+                Edit role
+              </Button>
+              <Button
+                onClick={this.onClickRemove.bind(this)}
+                disabled={isSelectionEmpty}
+                className="destructive org-member-remove-button">
+                Remove
+              </Button>
+            </>
+          )}
         </div>
         <div className="org-members-list">
           {this.state.response.user.map((member) => (
             <div
               className={`org-members-list-item ${
                 this.state.selectedUserIds.has(member?.user?.userId?.id || "") ? "selected" : ""
-              }`}
+              } ${!this.props.user.selectedGroup.externalUserManagement ? "editable" : ""}`}
               onClick={() => this.onClickRow(member?.user?.userId?.id || "")}>
-              <div>
-                <Checkbox
-                  title={`Select ${member?.user?.email || member?.user?.name?.full}`}
-                  className="org-member-checkbox"
-                  checked={this.state.selectedUserIds.has(member?.user?.userId?.id || "")}
-                />
-              </div>
+              {!this.props.user.selectedGroup.externalUserManagement && (
+                <div>
+                  <Checkbox
+                    title={`Select ${member?.user?.email || member?.user?.name?.full}`}
+                    className="org-member-checkbox"
+                    checked={this.state.selectedUserIds.has(member?.user?.userId?.id || "")}
+                  />
+                </div>
+              )}
               <div className="org-member-email">{member?.user?.email || member?.user?.name?.full}</div>
               <div className="org-member-role">{ROLE_LABELS[member?.role || 0]}</div>
             </div>

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -884,6 +884,7 @@ func fillUserGroups(ctx context.Context, tx interfaces.DB, user *tables.User) er
 			g.saml_idp_metadata_url,
 			g.suggestion_preference,
 			g.restrict_clean_workflow_runs_to_admins,
+			g.external_user_management,
 			ug.role
 		FROM "Groups" as g
 		JOIN "UserGroups" as ug
@@ -912,6 +913,7 @@ func fillUserGroups(ctx context.Context, tx interfaces.DB, user *tables.User) er
 			&gr.Group.SamlIdpMetadataUrl,
 			&gr.Group.SuggestionPreference,
 			&gr.Group.RestrictCleanWorkflowRunsToAdmins,
+			&gr.Group.ExternalUserManagement,
 			&gr.Role,
 		)
 		if err != nil {
@@ -973,7 +975,8 @@ func (d *UserDB) GetImpersonatedUser(ctx context.Context) (*tables.User, error) 
 				cache_encryption_enabled,
 				saml_idp_metadata_url,
 				suggestion_preference,
-				restrict_clean_workflow_runs_to_admins
+				restrict_clean_workflow_runs_to_admins,
+				external_user_management
 			FROM "Groups"
 			WHERE group_id = ?
 		`, u.GetGroupID())
@@ -995,6 +998,7 @@ func (d *UserDB) GetImpersonatedUser(ctx context.Context) (*tables.User, error) 
 				&gr.Group.SamlIdpMetadataUrl,
 				&gr.Group.SuggestionPreference,
 				&gr.Group.RestrictCleanWorkflowRunsToAdmins,
+				&gr.Group.ExternalUserManagement,
 			)
 			if err != nil {
 				return err

--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -79,6 +79,10 @@ message Group {
 
   // Whether IP rules are being enforced for this organization.
   bool enforce_ip_rules = 14;
+
+  // Whether users are being managed by an external system using the SCIM API.
+  // Disables in-app user management.
+  bool external_user_management = 17;
 }
 
 message JoinGroupRequest {
@@ -133,6 +137,9 @@ message GetGroupResponse {
   // reference the group subdomain, otherwise it will point to the default
   // BuildBuddy URL.
   string url = 6;
+
+  // True if the group users are being managed by an external system.
+  bool external_user_management = 7;
 }
 
 message GetGroupUsersRequest {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -269,6 +269,7 @@ func makeGroups(groupRoles []*tables.GroupRole) []*grpb.Group {
 			EnforceIpRules:                    g.EnforceIPRules,
 			SuggestionPreference:              g.SuggestionPreference,
 			Url:                               getGroupUrl(&gr.Group),
+			ExternalUserManagement:            g.ExternalUserManagement,
 		})
 	}
 	return r
@@ -432,10 +433,11 @@ func (s *BuildBuddyServer) GetGroup(ctx context.Context, req *grpb.GetGroupReque
 		Id: group.GroupID,
 		// NOTE: this RPC does not require authentication, so sensitive group
 		// info should not be exposed here.
-		Name:        group.Name,
-		OwnedDomain: group.OwnedDomain,
-		SsoEnabled:  group.SamlIdpMetadataUrl != nil && *group.SamlIdpMetadataUrl != "",
-		Url:         getGroupUrl(group),
+		Name:                   group.Name,
+		OwnedDomain:            group.OwnedDomain,
+		SsoEnabled:             group.SamlIdpMetadataUrl != nil && *group.SamlIdpMetadataUrl != "",
+		Url:                    getGroupUrl(group),
+		ExternalUserManagement: group.ExternalUserManagement,
 	}, nil
 }
 

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -225,6 +225,7 @@ type Group struct {
 	BotSuggestionsEnabled             bool `gorm:"not null;default:1"`
 	DeveloperOrgCreationEnabled       bool `gorm:"not null;default:1"`
 	RestrictCleanWorkflowRunsToAdmins bool `gorm:"not null;default:0"`
+	ExternalUserManagement            bool `gorm:"not null;default:0"`
 
 	// If enabled, builds for this group will always use their own executors instead of the installation-wide shared
 	// executors.


### PR DESCRIPTION
If a customer enables SCIM user management, we can block off in-app user modifications using this setting.

This PR updates the UI to disallow user management operations when this setting is enabled. I will send a separate PR to enforce this on the backend.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
