### PR TITLE
Respect GitHub token expiration when publishing statuses

### DIFF
--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -243,7 +243,7 @@ func (a *GitHubApp) handleWorkflowEvent(ctx context.Context, eventType string, e
 		ctx, row.GitRepository, wd, tok.GetToken())
 }
 
-func (a *GitHubApp) GetInstallationTokenForStatusReportingOnly(ctx context.Context, owner string) (string, error) {
+func (a *GitHubApp) GetInstallationTokenForStatusReportingOnly(ctx context.Context, owner string) (*github.InstallationToken, error) {
 	var installation tables.GitHubAppInstallation
 	err := a.env.GetDBHandle().NewQuery(ctx, "githubapp_get_installation_token_for_status").Raw(`
 		SELECT *
@@ -252,15 +252,15 @@ func (a *GitHubApp) GetInstallationTokenForStatusReportingOnly(ctx context.Conte
 	`, owner).Take(&installation)
 	if err != nil {
 		if db.IsRecordNotFound(err) {
-			return "", status.NotFoundErrorf("failed to look up GitHub app installation: %s", err)
+			return nil, status.NotFoundErrorf("failed to look up GitHub app installation: %s", err)
 		}
-		return "", err
+		return nil, err
 	}
 	tok, err := a.createInstallationToken(ctx, installation.InstallationID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return tok.GetToken(), nil
+	return tok, nil
 }
 
 func (a *GitHubApp) GetRepositoryInstallationToken(ctx context.Context, repo *tables.GitRepository) (string, error) {

--- a/server/backends/github/BUILD
+++ b/server/backends/github/BUILD
@@ -18,5 +18,6 @@ go_library(
         "//server/util/random",
         "//server/util/role",
         "//server/util/status",
+        "@com_github_google_go_github_v43//github",
     ],
 )

--- a/server/interfaces/BUILD
+++ b/server/interfaces/BUILD
@@ -40,6 +40,7 @@ go_library(
         "//server/util/proto",
         "//server/util/role",
         "@com_github_golang_jwt_jwt//:jwt",
+        "@com_github_google_go_github_v43//github",
         "@com_github_hashicorp_serf//serf",
         "@com_github_prometheus_client_model//go",
         "@io_gorm_gorm//:gorm",

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/role"
 	"github.com/golang-jwt/jwt"
+	"github.com/google/go-github/v43/github"
 	"github.com/hashicorp/serf/serf"
 	"google.golang.org/grpc/credentials"
 	"gorm.io/gorm"
@@ -627,7 +628,7 @@ type GitHubApp interface {
 	// for the installation associated with the given installation owner (GitHub
 	// username or org name). It does not authorize the authenticated group ID,
 	// so should be used for status reporting only.
-	GetInstallationTokenForStatusReportingOnly(ctx context.Context, owner string) (string, error)
+	GetInstallationTokenForStatusReportingOnly(ctx context.Context, owner string) (*github.InstallationToken, error)
 
 	// GetRepositoryInstallationToken returns an installation token for the given
 	// GitRepository.


### PR DESCRIPTION
If an invocation takes longer than an hour, the GitHub installation token can expire. Respect the expiration time and re-fetch if the token is nearly expired.

**Related issues**: N/A
