### PR TITLE
Use Linux namespaces to allow vbd_test to run as non-root user

### DIFF
--- a/enterprise/server/remote_execution/vbd/BUILD
+++ b/enterprise/server/remote_execution/vbd/BUILD
@@ -26,6 +26,7 @@ go_test(
     ],
     deps = [
         ":vbd",
+        "//server/testutil/testfs",
         "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
Applying some learnings from hackathon :)

This makes it so that `bazel test //enterprise/server/remote_execution/vbd:vbd_test` no longer requires root to run it locally. It does this by using a `TestMain()` function which executes the test as a new child process in a "pseudo-root" container. The container gets its own mount namespace and user namespace, with the host uid/gid mapped to 0:0 (root). See `man 7 namespaces` for more info on namespaces.

We can likely also use this trick to run `firecracker_test` as non-root, and get rid of the `test.sh` script. Will try that in a separate PR

**Related issues**: N/A
