### PR TITLE
Set text-underline-offset on links

### DIFF
--- a/app/root/root.css
+++ b/app/root/root.css
@@ -45,6 +45,12 @@ a {
   text-decoration: none;
   color: inherit;
   outline: 0;
+  /*
+    If we do set an underline, offset it.
+    We often render underscores in links, and the underscores
+    are not clearly visible unless we offset the underline.
+  */
+  text-underline-offset: 4px;
 }
 
 button {


### PR DESCRIPTION
Makes underscores more clearly visible. Also makes things feel more cozy/legible (the underline no longer intersects with the descenders, e.g. the tail of the `y` / `p`).

Before:

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/a6339414-65eb-40c1-b898-41dc7fd12f7d)

After:

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/17bebf16-b0d9-46fb-94b0-0ce24afe1ea8)


**Related issues**: N/A
