### PR TITLE
Don't treat no-op group update as error.

### DIFF
--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -376,9 +376,6 @@ func (d *UserDB) InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (stri
 		if res.Error != nil {
 			return res.Error
 		}
-		if res.RowsAffected == 0 {
-			return status.NotFoundErrorf("Group %s not found", groupID)
-		}
 		return nil
 	})
 	return groupID, err


### PR DESCRIPTION
If you make a no-op update via the UI, it currently displays a "Group not found" error.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
