### PR TITLE
Export remote build duration to customers

### DIFF
--- a/enterprise/server/backends/prom/prom.go
+++ b/enterprise/server/backends/prom/prom.go
@@ -94,6 +94,17 @@ sum(increase(exported_buildbuddy_remote_cache_download_size_bytes[1w]))`,
 			Examples: `# Number of bytes uploaded as measured over the last week
 sum(increase(exported_buildbuddy_remote_cache_upload_size_bytes[1w]))`,
 		},
+		{
+			sourceMetricName: "buildbuddy_remote_execution_duration_usec_exported",
+			LabelNames:       []string{metrics.OS},
+			ExportedFamily: &dto.MetricFamily{
+				Name: proto.String("exported_buildbuddy_remote_execution_duration_usec"),
+				Help: proto.String("The total duration of remote execution, in **microseconds**."),
+				Type: dto.MetricType_HISTOGRAM.Enum(),
+			},
+			Examples: `# The total duration of remote execution as measured over the last week
+sum by (os) (rate(exported_buildbuddy_remote_execution_duration_usec_exported[1w]))`,
+		},
 	}
 )
 

--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["usage.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/usage",
     deps = [
+        "//enterprise/server/remote_execution/platform",
         "//enterprise/server/usage/config",
         "//enterprise/server/util/redisutil",
         "//server/environment",

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redisutil"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -181,6 +182,14 @@ func (ut *tracker) emitMetrics(groupID string, uc *tables.UsageCounts) {
 	if uc.ActionCacheHits > 0 {
 		hitLabels := prometheus.Labels{metrics.GroupID: groupID, metrics.CacheTypeLabel: "action"}
 		metrics.CacheNumHitsExported.With(hitLabels).Add(float64(uc.ActionCacheHits))
+	}
+	if uc.LinuxExecutionDurationUsec > 0 {
+		execLabels := prometheus.Labels{metrics.GroupID: groupID, metrics.OS: platform.LinuxOperatingSystemName}
+		metrics.RemoteExecutionDurationUsecExported.With(execLabels).Observe(float64(uc.LinuxExecutionDurationUsec))
+	}
+	if uc.MacExecutionDurationUsec > 0 {
+		execLabels := prometheus.Labels{metrics.GroupID: groupID, metrics.OS: platform.DarwinOperatingSystemName}
+		metrics.RemoteExecutionDurationUsecExported.With(execLabels).Observe(float64(uc.MacExecutionDurationUsec))
 	}
 }
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -721,6 +721,17 @@ var (
 		GroupID,
 	})
 
+	RemoteExecutionDurationUsecExported = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "duration_usec_exported",
+		Buckets:   durationUsecBuckets(1*time.Microsecond, 1*day, 5),
+		Help:      "Time spent in remote execution, in **microseconds**. ",
+	}, []string{
+		OS,
+		GroupID,
+	})
+
 	// #### Examples
 	//
 	// ```promql


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Customers want to monitor and/or alert on their remote build usage. 

This PR created a new metric in metrics.go to capture the linux and mac remote
execution duration; and added a new exported metric in prom.go
