### PR TITLE
use userID instead of groupID in userGroupPerm

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -203,7 +203,7 @@ func (s *ExecutionServer) insertExecution(ctx context.Context, executionID, invo
 	var permissions *perms.UserGroupPerm
 	if auth := s.env.GetAuthenticator(); auth != nil {
 		if u, err := auth.AuthenticatedUser(ctx); err == nil && u.GetGroupID() != "" {
-			permissions = perms.GroupAuthPermissions(u)
+			permissions = perms.DefaultPermissions(u)
 		}
 	}
 

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -203,7 +203,7 @@ func (s *ExecutionServer) insertExecution(ctx context.Context, executionID, invo
 	var permissions *perms.UserGroupPerm
 	if auth := s.env.GetAuthenticator(); auth != nil {
 		if u, err := auth.AuthenticatedUser(ctx); err == nil && u.GetGroupID() != "" {
-			permissions = perms.GroupAuthPermissions(u.GetGroupID())
+			permissions = perms.GroupAuthPermissions(u)
 		}
 	}
 

--- a/enterprise/server/remote_execution/execution_server/execution_server_test.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server_test.go
@@ -130,6 +130,7 @@ func TestDispatch(t *testing.T) {
 	rows := getExecutions(t, env)
 	require.Equal(t, 1, len(rows))
 	assert.Equal(t, taskID, rows[0].ExecutionID)
+	assert.Equal(t, "US1", rows[0].UserID)
 
 	sched := env.GetSchedulerService().(*schedulerServerMock)
 	require.Equal(t, 1, len(sched.scheduleReqs))

--- a/enterprise/server/secrets/secrets.go
+++ b/enterprise/server/secrets/secrets.go
@@ -140,7 +140,7 @@ func (s *SecretService) UpdateSecret(ctx context.Context, req *skpb.UpdateSecret
 		return nil, false, err
 	}
 
-	secretPerms := perms.GroupAuthPermissions(u.GetGroupID())
+	secretPerms := perms.GroupAuthPermissions(u)
 
 	// Before writing the secret to the database, verify that we can open
 	// the secret box using this group's public key.

--- a/enterprise/server/secrets/secrets.go
+++ b/enterprise/server/secrets/secrets.go
@@ -140,7 +140,7 @@ func (s *SecretService) UpdateSecret(ctx context.Context, req *skpb.UpdateSecret
 		return nil, false, err
 	}
 
-	secretPerms := perms.GroupAuthPermissions(u)
+	secretPerms := perms.DefaultPermissions(u)
 
 	// Before writing the secret to the database, verify that we can open
 	// the secret box using this group's public key.

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -268,7 +268,7 @@ func (ws *workflowService) CreateWorkflow(ctx context.Context, req *wfpb.CreateW
 	if err != nil {
 		return nil, err
 	}
-	permissions := perms.GroupAuthPermissions(groupID)
+	permissions := perms.GroupAuthPermissionsByGroupID(groupID)
 
 	u, err := gitutil.NormalizeRepoURL(repoReq.GetRepoUrl())
 	if err != nil {

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -268,7 +268,7 @@ func (ws *workflowService) CreateWorkflow(ctx context.Context, req *wfpb.CreateW
 	if err != nil {
 		return nil, err
 	}
-	permissions := perms.GroupAuthPermissionsByGroupID(groupID)
+	permissions := perms.GroupPermissionsDeprecated(groupID)
 
 	u, err := gitutil.NormalizeRepoURL(repoReq.GetRepoUrl())
 	if err != nil {

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -268,7 +268,7 @@ func (ws *workflowService) CreateWorkflow(ctx context.Context, req *wfpb.CreateW
 	if err != nil {
 		return nil, err
 	}
-	permissions := perms.GroupPermissionsDeprecated(groupID)
+	permissions := perms.DeprecatedGroupPermissions(groupID)
 
 	u, err := gitutil.NormalizeRepoURL(repoReq.GetRepoUrl())
 	if err != nil {

--- a/server/backends/invocationdb/BUILD
+++ b/server/backends/invocationdb/BUILD
@@ -63,8 +63,10 @@ go_test(
         ":invocationdb",
         "//proto:invocation_status_go_proto",
         "//server/tables",
+        "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/util/db",
+        "//server/util/prefix",
         "@com_github_stretchr_testify//require",
     ],
 )
@@ -90,8 +92,10 @@ go_test(
         ":invocationdb",
         "//proto:invocation_status_go_proto",
         "//server/tables",
+        "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/util/db",
+        "//server/util/prefix",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/backends/invocationdb/BUILD
+++ b/server/backends/invocationdb/BUILD
@@ -34,8 +34,10 @@ go_test(
         ":invocationdb",
         "//proto:invocation_status_go_proto",
         "//server/tables",
+        "//server/testutil/testauth",
         "//server/testutil/testenv",
         "//server/util/db",
+        "//server/util/prefix",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -184,7 +184,7 @@ func (t *TargetTracker) testTargetsInAtLeastState(state targetState) bool {
 func (t *TargetTracker) permissionsFromContext(ctx context.Context) (*perms.UserGroupPerm, error) {
 	if auth := t.env.GetAuthenticator(); auth != nil {
 		if u, err := auth.AuthenticatedUser(ctx); err == nil && u.GetGroupID() != "" {
-			return perms.GroupAuthPermissions(u), nil
+			return perms.DefaultPermissions(u), nil
 		}
 	}
 	return nil, status.UnauthenticatedError("Context did not contain auth information")

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -184,7 +184,7 @@ func (t *TargetTracker) testTargetsInAtLeastState(state targetState) bool {
 func (t *TargetTracker) permissionsFromContext(ctx context.Context) (*perms.UserGroupPerm, error) {
 	if auth := t.env.GetAuthenticator(); auth != nil {
 		if u, err := auth.AuthenticatedUser(ctx); err == nil && u.GetGroupID() != "" {
-			return perms.GroupAuthPermissions(u.GetGroupID()), nil
+			return perms.GroupAuthPermissions(u), nil
 		}
 	}
 	return nil, status.UnauthenticatedError("Context did not contain auth information")

--- a/server/util/perms/perms.go
+++ b/server/util/perms/perms.go
@@ -61,7 +61,7 @@ func DefaultPermissions(u interfaces.UserInfo) *UserGroupPerm {
 // and Workflows table itself is deprecated.
 //
 // Please use DefaultPermissions if possible.
-func GroupPermissionsDeprecated(groupID string) *UserGroupPerm {
+func DeprecatedGroupPermissions(groupID string) *UserGroupPerm {
 	return &UserGroupPerm{
 		UserID:  groupID,
 		GroupID: groupID,

--- a/server/util/perms/perms.go
+++ b/server/util/perms/perms.go
@@ -46,7 +46,7 @@ func AnonymousUserPermissions() *UserGroupPerm {
 	}
 }
 
-func GroupAuthPermissions(u interfaces.UserInfo) *UserGroupPerm {
+func DefaultPermissions(u interfaces.UserInfo) *UserGroupPerm {
 	return &UserGroupPerm{
 		UserID:  u.GetUserID(),
 		GroupID: u.GetGroupID(),
@@ -54,7 +54,14 @@ func GroupAuthPermissions(u interfaces.UserInfo) *UserGroupPerm {
 	}
 }
 
-func GroupAuthPermissionsByGroupID(groupID string) *UserGroupPerm {
+// Deprecated.
+// We used to use this function to set group permissions prior to introducing
+// user personal keys. Currently, this is only used when we insert into Workflows
+// table (https://github.com/buildbuddy-io/buildbuddy/blob/v2.38.0/enterprise/server/workflow/service/service.go#L271)
+// and Workflows table itself is deprecated.
+//
+// Please use DefaultPermissions if possible.
+func GroupPermissionsDeprecated(groupID string) *UserGroupPerm {
 	return &UserGroupPerm{
 		UserID:  groupID,
 		GroupID: groupID,
@@ -316,5 +323,5 @@ func ForAuthenticatedGroup(ctx context.Context, env environment.Env) (*UserGroup
 		return nil, status.PermissionDeniedErrorf("Anonymous access disabled, permission denied.")
 	}
 
-	return GroupAuthPermissions(u), nil
+	return DefaultPermissions(u), nil
 }

--- a/server/util/perms/perms.go
+++ b/server/util/perms/perms.go
@@ -46,7 +46,15 @@ func AnonymousUserPermissions() *UserGroupPerm {
 	}
 }
 
-func GroupAuthPermissions(groupID string) *UserGroupPerm {
+func GroupAuthPermissions(u interfaces.UserInfo) *UserGroupPerm {
+	return &UserGroupPerm{
+		UserID:  u.GetUserID(),
+		GroupID: u.GetGroupID(),
+		Perms:   GROUP_READ | GROUP_WRITE,
+	}
+}
+
+func GroupAuthPermissionsByGroupID(groupID string) *UserGroupPerm {
 	return &UserGroupPerm{
 		UserID:  groupID,
 		GroupID: groupID,
@@ -308,5 +316,5 @@ func ForAuthenticatedGroup(ctx context.Context, env environment.Env) (*UserGroup
 		return nil, status.PermissionDeniedErrorf("Anonymous access disabled, permission denied.")
 	}
 
-	return GroupAuthPermissions(u.GetGroupID()), nil
+	return GroupAuthPermissions(u), nil
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
This PR change the GroupAuthPermissions to take in interfaces.UserInfo instead
of groupID, and renamed it to DefaultPermissions. When a personal key is used, the user_id will be the real user ID; and empty otherwise.

As a result, we will associate user_id with invocations, executions, git repositories 

Added tests in invocationdb_test.go, execution_server_test.go and build_handler_event_test.go to make sure user_id is set.

I reserve the current implementation of perms.GroupAuthPermissions and name it perms.GroupPermissionsDeprecated. This currently is used in CreateWorkflow in enterprise/server/workflow/service/service.go. Since Workflow table is to be replaced with GitRepositories, I didn't bother to change the code to use the new DefaultPermissions. 
