### PR TITLE
Less coffee time for Lulu

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -1253,8 +1253,10 @@ func TestCompression(t *testing.T) {
 		compressedRN.Compressor = repb.Compressor_ZSTD
 
 		for _, tc := range testCases {
+			tc := tc
 			desc := fmt.Sprintf("%s_%s", tp.desc, tc.name)
 			t.Run(desc, func(t *testing.T) {
+				t.Parallel()
 				opts := &pebble_cache.Options{
 					RootDirectory:          testfs.MakeTempDir(t),
 					MaxSizeBytes:           maxSizeBytes,
@@ -1740,7 +1742,9 @@ func TestLRU(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
 			te := testenv.GetTestEnv(t)
 			te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
 			ctx := getAnonContext(t, te)

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -1749,7 +1749,7 @@ func TestLRU(t *testing.T) {
 			te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
 			ctx := getAnonContext(t, te)
 
-			numDigests := 10
+			numDigests := 50
 			activeKeyVersion := int64(5)
 			maxSizeBytes := int64(math.Ceil( // account for integer rounding
 				float64(numDigests) * float64(tc.digestSize) * (1 / pebble_cache.JanitorCutoffThreshold))) // account for .9 evictor cutoff

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -1253,10 +1253,8 @@ func TestCompression(t *testing.T) {
 		compressedRN.Compressor = repb.Compressor_ZSTD
 
 		for _, tc := range testCases {
-			tc := tc
 			desc := fmt.Sprintf("%s_%s", tp.desc, tc.name)
 			t.Run(desc, func(t *testing.T) {
-				t.Parallel()
 				opts := &pebble_cache.Options{
 					RootDirectory:          testfs.MakeTempDir(t),
 					MaxSizeBytes:           maxSizeBytes,
@@ -1742,9 +1740,7 @@ func TestLRU(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			t.Parallel()
 			te := testenv.GetTestEnv(t)
 			te.SetAuthenticator(testauth.NewTestAuthenticator(emptyUserMap))
 			ctx := getAnonContext(t, te)


### PR DESCRIPTION
Remove some duplicate test cases and ship a little less data around.

Is faster:

```
//enterprise/server/backends/pebble_cache:pebble_cache_test              PASSED in 7.6s
  Stats over 8 runs: max = 7.6s, min = 1.5s, avg = 3.7s, dev = 1.9s
```

Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/3035.