### PR TITLE
Persist clickhouse data dir when running tools/clickhouse

### DIFF
--- a/tools/clickhouse
+++ b/tools/clickhouse
@@ -26,7 +26,7 @@ if ! command -v "$docker" &>/dev/null; then
 fi
 
 start_clickhouse() {
-  "$docker" run --rm --detach --name=bb-clickhouse-local --publish="$BB_CLICKHOUSE_PORT:9000" --volume="/tmp/${USER}_clickhouse_data_dir:/var/lib/clickhouse" "$BB_CLICKHOUSE_IMAGE"
+  "$docker" run --rm --detach --name=bb-clickhouse-local --publish="$BB_CLICKHOUSE_PORT:9000" --volume="/tmp/${USER}_clickhouse_data:/var/lib/clickhouse" "$BB_CLICKHOUSE_IMAGE"
 }
 
 if ! "$docker" inspect bb-clickhouse-local &>/dev/null; then

--- a/tools/clickhouse
+++ b/tools/clickhouse
@@ -26,7 +26,7 @@ if ! command -v "$docker" &>/dev/null; then
 fi
 
 start_clickhouse() {
-  "$docker" run --rm --detach --name=bb-clickhouse-local --publish="$BB_CLICKHOUSE_PORT:9000" "$BB_CLICKHOUSE_IMAGE"
+  "$docker" run --rm --detach --name=bb-clickhouse-local --publish="$BB_CLICKHOUSE_PORT:9000" --volume="/tmp/${USER}_clickhouse_data_dir:/var/lib/clickhouse" "$BB_CLICKHOUSE_IMAGE"
 }
 
 if ! "$docker" inspect bb-clickhouse-local &>/dev/null; then


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Create a clickhouse data dir in /tmp. When we stop the docker clickhouse
container and start a new container, the data can be persisted. This will be
helpful when we are testing newer clickhouse versions locally.
