### PR TITLE
Add option to set env vars to ExecuteWorkflow api

### DIFF
--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -534,16 +534,17 @@ func (s *APIServer) ExecuteWorkflow(ctx context.Context, req *apipb.ExecuteWorkf
 
 	wfID := wfs.GetLegacyWorkflowIDForGitRepository(user.GetGroupID(), req.GetRepoUrl())
 	r := &workflow.ExecuteWorkflowRequest{
-		RequestContext: requestCtx,
-		WorkflowId:     wfID,
-		ActionNames:    req.GetActionNames(),
-		PushedRepoUrl:  req.GetRepoUrl(),
-		PushedBranch:   req.GetRef(),
-		TargetRepoUrl:  req.GetRepoUrl(),
-		TargetBranch:   req.GetRef(),
-		Clean:          req.GetClean(),
-		Visibility:     req.GetVisibility(),
-		Async:          req.GetAsync(),
+		RequestContext:  requestCtx,
+		WorkflowId:      wfID,
+		ActionNames:     req.GetActionNames(),
+		PushedRepoUrl:   req.GetRepoUrl(),
+		PushedBranch:    req.GetRef(),
+		TargetRepoUrl:   req.GetRepoUrl(),
+		TargetBranch:    req.GetRef(),
+		Clean:           req.GetClean(),
+		Visibility:      req.GetVisibility(),
+		Async:           req.GetAsync(),
+		EnvVarOverrides: req.GetEnvVarOverrides(),
 	}
 	rsp, err := wfs.ExecuteWorkflow(ctx, r)
 	if err != nil {

--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -534,17 +534,17 @@ func (s *APIServer) ExecuteWorkflow(ctx context.Context, req *apipb.ExecuteWorkf
 
 	wfID := wfs.GetLegacyWorkflowIDForGitRepository(user.GetGroupID(), req.GetRepoUrl())
 	r := &workflow.ExecuteWorkflowRequest{
-		RequestContext:  requestCtx,
-		WorkflowId:      wfID,
-		ActionNames:     req.GetActionNames(),
-		PushedRepoUrl:   req.GetRepoUrl(),
-		PushedBranch:    req.GetRef(),
-		TargetRepoUrl:   req.GetRepoUrl(),
-		TargetBranch:    req.GetRef(),
-		Clean:           req.GetClean(),
-		Visibility:      req.GetVisibility(),
-		Async:           req.GetAsync(),
-		EnvVarOverrides: req.GetEnvVarOverrides(),
+		RequestContext: requestCtx,
+		WorkflowId:     wfID,
+		ActionNames:    req.GetActionNames(),
+		PushedRepoUrl:  req.GetRepoUrl(),
+		PushedBranch:   req.GetRef(),
+		TargetRepoUrl:  req.GetRepoUrl(),
+		TargetBranch:   req.GetRef(),
+		Clean:          req.GetClean(),
+		Visibility:     req.GetVisibility(),
+		Async:          req.GetAsync(),
+		Env:            req.GetEnv(),
 	}
 	rsp, err := wfs.ExecuteWorkflow(ctx, r)
 	if err != nil {

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -150,6 +151,7 @@ var (
 	patchURIs          = flag.Slice("patch_uri", []string{}, "URIs of patches to apply to the repo after checkout. Can be specified multiple times to apply multiple patches.")
 	recordRunMetadata  = flag.Bool("record_run_metadata", false, "Instead of running a target, extract metadata about it and report it in the build event stream.")
 	gitCleanExclude    = flag.Slice("git_clean_exclude", []string{}, "Directories to exclude from `git clean` while setting up the repo.")
+	envVarOverrideStr  = flag.String("env_var_overrides", "", "These env vars should take precedence over any set on the command or in buildbuddy.yaml.")
 
 	shutdownAndExit = flag.Bool("shutdown_and_exit", false, "If set, runs bazel shutdown with the configured bazel_command, and exits. No other commands are run.")
 
@@ -936,6 +938,18 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 
 		artifactsDir := artifactsPathForCommand(ws, i)
 		namedSetID := filepath.Base(artifactsDir)
+
+		var envVarOverrides map[string]string
+		err = json.Unmarshal([]byte(*envVarOverrideStr), &envVarOverrides)
+		if err != nil {
+			return err
+		}
+		if action.Env == nil {
+			action.Env = map[string]string{}
+		}
+		for k, v := range envVarOverrides {
+			action.Env[k] = v
+		}
 
 		runErr := runCommand(ctx, *bazelCommand, expandEnv(args), action.Env, action.BazelWorkspaceDir, ar.reporter)
 		exitCode := getExitCode(runErr)

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -939,16 +939,18 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 		artifactsDir := artifactsPathForCommand(ws, i)
 		namedSetID := filepath.Base(artifactsDir)
 
-		var envVarOverrides map[string]string
-		err = json.Unmarshal([]byte(*envVarOverrideStr), &envVarOverrides)
-		if err != nil {
-			return err
-		}
-		if action.Env == nil {
-			action.Env = map[string]string{}
-		}
-		for k, v := range envVarOverrides {
-			action.Env[k] = v
+		if *envVarOverrideStr != "" {
+			var envVarOverrides map[string]string
+			err = json.Unmarshal([]byte(*envVarOverrideStr), &envVarOverrides)
+			if err != nil {
+				return err
+			}
+			if action.Env == nil {
+				action.Env = map[string]string{}
+			}
+			for k, v := range envVarOverrides {
+				action.Env[k] = v
+			}
 		}
 
 		runErr := runCommand(ctx, *bazelCommand, expandEnv(args), action.Env, action.BazelWorkspaceDir, ar.reporter)

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -151,7 +151,7 @@ var (
 	patchURIs          = flag.Slice("patch_uri", []string{}, "URIs of patches to apply to the repo after checkout. Can be specified multiple times to apply multiple patches.")
 	recordRunMetadata  = flag.Bool("record_run_metadata", false, "Instead of running a target, extract metadata about it and report it in the build event stream.")
 	gitCleanExclude    = flag.Slice("git_clean_exclude", []string{}, "Directories to exclude from `git clean` while setting up the repo.")
-	envVarOverrideStr  = flag.String("env_var_overrides", "", "These env vars should take precedence over any set on the command or in buildbuddy.yaml.")
+	envOverrideStr     = flag.String("env_overrides", "", "These env vars should take precedence over any set on the command or in buildbuddy.yaml.")
 
 	shutdownAndExit = flag.Bool("shutdown_and_exit", false, "If set, runs bazel shutdown with the configured bazel_command, and exits. No other commands are run.")
 
@@ -939,16 +939,16 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 		artifactsDir := artifactsPathForCommand(ws, i)
 		namedSetID := filepath.Base(artifactsDir)
 
-		if *envVarOverrideStr != "" {
-			var envVarOverrides map[string]string
-			err = json.Unmarshal([]byte(*envVarOverrideStr), &envVarOverrides)
+		if *envOverrideStr != "" {
+			var envOverrides map[string]string
+			err = json.Unmarshal([]byte(*envOverrideStr), &envOverrides)
 			if err != nil {
 				return err
 			}
 			if action.Env == nil {
 				action.Env = map[string]string{}
 			}
-			for k, v := range envVarOverrides {
+			for k, v := range envOverrides {
 				action.Env[k] = v
 			}
 		}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -139,11 +139,10 @@ func instanceName(wf *tables.Workflow, wd *interfaces.WebhookData, workflowActio
 // in the HTTP response to the webhook sender, in particular when there are
 // spikes in CAS or Execution service latency.
 type startWorkflowTask struct {
-	ctx             context.Context
-	gitProvider     interfaces.GitProvider
-	webhookData     *interfaces.WebhookData
-	workflow        *tables.Workflow
-	envVarOverrides map[string]string
+	ctx         context.Context
+	gitProvider interfaces.GitProvider
+	webhookData *interfaces.WebhookData
+	workflow    *tables.Workflow
 }
 
 type workflowService struct {
@@ -543,7 +542,6 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 	actionStatuses := make([]*wfpb.ExecuteWorkflowResponse_ActionStatus, 0, len(actions))
 	for _, action := range actions {
 		action := action
-
 		actionStatus := &wfpb.ExecuteWorkflowResponse_ActionStatus{
 			ActionName: action.Name,
 		}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1190,7 +1190,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 	}
 	// See https://github.com/buildbuddy-io/buildbuddy-internal/issues/3101
 	// for more info on why we don't want to pass empty flags
-	if len(string(envJson)) > 0 {
+	if len(env) > 0 {
 		cmd.Arguments = append(cmd.Arguments, "--env_overrides="+string(envJson))
 	}
 	if isSharedFirecrackerWorkflow {

--- a/proto/api/v1/workflow.proto
+++ b/proto/api/v1/workflow.proto
@@ -32,6 +32,10 @@ message ExecuteWorkflowRequest {
   string visibility = 5;
   // If true, start the workflow but do not wait for the status to be returned.
   bool async = 6;
+  // These env vars will be applied to each action that is run. If there is a
+  // conflict between an env var set here and in buildbuddy.yaml, these overrides will
+  // take precedence. Otherwise all env vars set in buildbuddy.yaml will still apply.
+  map<string, string> env_var_overrides = 7;
 }
 
 message ExecuteWorkflowResponse {

--- a/proto/api/v1/workflow.proto
+++ b/proto/api/v1/workflow.proto
@@ -33,8 +33,9 @@ message ExecuteWorkflowRequest {
   // If true, start the workflow but do not wait for the status to be returned.
   bool async = 6;
   // These env vars will be applied to each action that is run. If there is a
-  // conflict between an env var set here and in buildbuddy.yaml, these overrides will
-  // take precedence. Otherwise all env vars set in buildbuddy.yaml will still apply.
+  // conflict between an env var set here and in buildbuddy.yaml, these
+  // overrides will take precedence. Otherwise all env vars set in
+  // buildbuddy.yaml will still apply.
   map<string, string> env_var_overrides = 7;
 }
 

--- a/proto/api/v1/workflow.proto
+++ b/proto/api/v1/workflow.proto
@@ -36,7 +36,7 @@ message ExecuteWorkflowRequest {
   // conflict between an env var set here and in buildbuddy.yaml, these
   // overrides will take precedence. Otherwise all env vars set in
   // buildbuddy.yaml will still apply.
-  map<string, string> env_var_overrides = 7;
+  map<string, string> env = 7;
 }
 
 message ExecuteWorkflowResponse {

--- a/proto/workflow.proto
+++ b/proto/workflow.proto
@@ -239,6 +239,11 @@ message ExecuteWorkflowRequest {
 
   // If true, start the workflow but do not wait for the status to be returned.
   bool async = 14;
+
+  // These env vars will be applied to each action that is run. If there is a
+  // conflict between an env var set here and in buildbuddy.yaml, these overrides will
+  // take precedence. Otherwise all env vars set in buildbuddy.yaml will still apply.
+  map<string, string> env_var_overrides = 15;
 }
 
 message ExecuteWorkflowResponse {

--- a/proto/workflow.proto
+++ b/proto/workflow.proto
@@ -241,8 +241,9 @@ message ExecuteWorkflowRequest {
   bool async = 14;
 
   // These env vars will be applied to each action that is run. If there is a
-  // conflict between an env var set here and in buildbuddy.yaml, these overrides will
-  // take precedence. Otherwise all env vars set in buildbuddy.yaml will still apply.
+  // conflict between an env var set here and in buildbuddy.yaml, these
+  // overrides will take precedence. Otherwise all env vars set in
+  // buildbuddy.yaml will still apply.
   map<string, string> env_var_overrides = 15;
 }
 

--- a/proto/workflow.proto
+++ b/proto/workflow.proto
@@ -244,7 +244,7 @@ message ExecuteWorkflowRequest {
   // conflict between an env var set here and in buildbuddy.yaml, these
   // overrides will take precedence. Otherwise all env vars set in
   // buildbuddy.yaml will still apply.
-  map<string, string> env_var_overrides = 15;
+  map<string, string> env = 15;
 }
 
 message ExecuteWorkflowResponse {


### PR DESCRIPTION
Customers were requesting this in the context of passing short-lived aws tokens to workflows. 

As a follow up, I plan on adding support for setting env vars to remote bazel