### PR TITLE
Add workaround for VMs freezing after resuming from snapshot on AMD CPUs

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -58,6 +58,7 @@ go_library(
         "@com_github_firecracker_microvm_firecracker_go_sdk//client/models",
         "@com_github_firecracker_microvm_firecracker_go_sdk//client/operations",
         "@com_github_google_uuid//:uuid",
+        "@com_github_klauspost_cpuid//:cpuid",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_sirupsen_logrus//:logrus",
         "@org_golang_google_grpc//:go_default_library",

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/jotfs/fastcdc-go v0.2.0
 	github.com/jsimonetti/rtnetlink v1.3.3
 	github.com/klauspost/compress v1.17.2
+	github.com/klauspost/cpuid v1.2.1
 	github.com/lestrrat-go/jwx v1.2.26
 	github.com/lni/dragonboat/v4 v4.0.0-00010101000000-000000000000
 	github.com/lni/goutils v1.3.1-0.20220604063047-388d67b4dbc4

--- a/go.sum
+++ b/go.sum
@@ -1816,6 +1816,7 @@ github.com/klauspost/compress v1.15.15/go.mod h1:ZcK2JAFqKOpnBlxcLsJzYfrS9X1akm9
 github.com/klauspost/compress v1.16.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/compress v1.17.2 h1:RlWWUY/Dr4fL8qk9YG7DTZ7PDgME2V4csBXA8L/ixi4=
 github.com/klauspost/compress v1.17.2/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/cpuid v1.2.1 h1:vJi+O/nMdFt0vqm8NZBI6wzALWdA2X+egi0ogNyrC/w=
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=


### PR DESCRIPTION
This PR sets the kernel boot option `lapic=notscdeadline` on AMD host CPUs only. I don't fully understand what this does but it allows `TestFirecrackerStressIO` to pass on my AMD machine if I set `maxRunsPerVM = 20`.

I read that LAPIC TSC deadline is meant to improve performance, so disabling it could potentially be bad - but I haven't noticed any performance degradation e.g. when trying a Python app that does 4 hot-loops in separate CPU cores using `multiprocessing`. But anyway, we're only disabling it on AMD which for now only affects local development. I'd rather have the tests pass with some slight performance degradation, than have it be flaky on our dev machines.

I left a TODO for us to remove this flag if the Firecracker folks sort out the root cause of the freezing.

**Related issues**: N/A
