### PR TITLE
buildpatches: minor fixes to patch files

### DIFF
--- a/buildpatches/com_github_awslabs_soci_snapshotter.patch
+++ b/buildpatches/com_github_awslabs_soci_snapshotter.patch
@@ -1,23 +1,3 @@
-diff --git a/MODULE.bazel b/MODULE.bazel
-new file mode 100644
-index 0000000..7ab2087
---- /dev/null
-+++ b/MODULE.bazel
-@@ -0,0 +1,6 @@
-+module(
-+    name = "soci_snapshotter",
-+    version = "0.0.8",
-+)
-+
-+bazel_dep(name = "zlib", version = "1.3")
-diff --git a/WORKSPACE.bzlmod b/WORKSPACE.bzlmod
-new file mode 100644
-index 0000000..fafa28d
---- /dev/null
-+++ b/WORKSPACE.bzlmod
-@@ -0,0 +1,2 @@
-+# When Bzlmod is enabled, this file replaces the content of the original WORKSPACE
-+# and makes sure no WORKSPACE prefix or suffix are added when Bzlmod is enabled.
 diff --git a/ztoc/compression/BUILD.bazel b/ztoc/compression/BUILD.bazel
 index 0d10a4d..bca5dac 100644
 --- a/ztoc/compression/BUILD.bazel

--- a/buildpatches/vtprotobuf.patch
+++ b/buildpatches/vtprotobuf.patch
@@ -6,7 +6,7 @@ index 418af2e..f356ce6 100644
      srcs = ["ext.proto"],
      visibility = ["//visibility:public"],
      deps = ["@com_google_protobuf//:descriptor_proto"],
-+	strip_import_prefix = "/include"
++    strip_import_prefix = "/include",
  )
  
  go_proto_library(


### PR DESCRIPTION
These fixes are backport from #5792. Expect no-ops.

soci_snapshotter should not need the MODULE.bazel and WORKSPACE.bzlmod
file to build under bzlmod. Removing the hunks to simplify the patch.

Fix space identation in vtprotobuf patch.
