### PR TITLE
buildifier: upgrade to latest version

### DIFF
--- a/buildpatches/buildifier.patch
+++ b/buildpatches/buildifier.patch
@@ -1,9 +1,9 @@
 diff --git a/buildifier/BUILD.bazel b/buildifier/BUILD.bazel
-index 1209821..9237592 100644
+index 860cc7e..327f7b5 100644
 --- a/buildifier/BUILD.bazel
 +++ b/buildifier/BUILD.bazel
 @@ -76,7 +76,7 @@ go_library(
-     name = "go_default_library",
+     name = "buildifier_lib",
      srcs = ["buildifier.go"],
      importpath = "github.com/bazelbuild/buildtools/buildifier",
 -    visibility = ["//visibility:private"],
@@ -12,28 +12,26 @@ index 1209821..9237592 100644
          "main.buildVersion": "{STABLE_buildVersion}",
          "main.buildScmRevision": "{STABLE_buildScmRevision}",
 diff --git a/buildifier/buildifier.go b/buildifier/buildifier.go
-index 0a1b81a..1b4d9fb 100644
+index 9d0a677..ff49cc0 100644
 --- a/buildifier/buildifier.go
 +++ b/buildifier/buildifier.go
-@@ -114,6 +114,11 @@ Full list of flags with their defaults:
+@@ -95,6 +95,10 @@ with -config=off.
  }
-
+ 
  func main() {
-+       exitCode := Run()
-+       os.Exit(exitCode)
++	os.Exit(Run())
 +}
 +
 +func Run() int {
-        c := config.New()
-
-	      flags := c.FlagSet("buildifier", flag.ExitOnError)
-@@ -159,7 +164,7 @@ func main() {
-        b := buildifier{c, differ}
-	      exitCode := b.run(args)
-
--       os.Exit(exitCode)
-+       return exitCode
+ 	c := config.New()
+ 
+ 	flags := c.FlagSet("buildifier", flag.ExitOnError)
+@@ -159,7 +163,7 @@ func main() {
+ 	b := buildifier{c, differ}
+ 	exitCode := b.run(args)
+ 
+-	os.Exit(exitCode)
++	return exitCode
  }
-
+ 
  type buildifier struct {
-

--- a/deps.bzl
+++ b/deps.bzl
@@ -482,10 +482,9 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
         name = "com_github_bazelbuild_buildtools",
         importpath = "github.com/bazelbuild/buildtools",
         patch_args = ["-p1"],
-        patch_tool = "patch --ignore-whitespace",
         patches = ["@{}//buildpatches:buildifier.patch".format(workspace_name)],
-        sum = "h1:2Gc2Q6hVR1SJ8bBI9Ybzoggp8u/ED2WkM4MfvEIn9+c=",
-        version = "v0.0.0-20231115204819-d4c9dccdfbb1",
+        sum = "h1:Qo0AsLueoZhddfcCdxOOT0dlt3KOOuJodX8dw/f55I0=",
+        version = "v0.0.0-20240124160521-959427f9b6f0",
     )
     go_repository(
         name = "com_github_bazelbuild_rules_go",

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/awslabs/soci-snapshotter v0.1.0
 	github.com/bazelbuild/bazel-gazelle v0.31.1
 	github.com/bazelbuild/bazelisk v1.17.0
-	github.com/bazelbuild/buildtools v0.0.0-20231115204819-d4c9dccdfbb1
+	github.com/bazelbuild/buildtools v0.0.0-20240124160521-959427f9b6f0
 	github.com/bazelbuild/rules_go v0.40.1
 	github.com/bazelbuild/rules_webtesting v0.0.0-20210910170740-6b2ef24cfe95
 	github.com/bduffany/godemon v0.0.0-20221115232931-09721d48e30e

--- a/go.sum
+++ b/go.sum
@@ -819,8 +819,8 @@ github.com/bazelbuild/bazel-gazelle v0.31.1 h1:ROyUyUHzoEdvoOs1e0haxJx1l5EjZX6AO
 github.com/bazelbuild/bazel-gazelle v0.31.1/go.mod h1:Ul0pqz50f5wxz0QNzsZ+mrEu4AVAVJZEB5xLnHgIG9c=
 github.com/bazelbuild/bazelisk v1.17.0 h1:TDt+a1PYrnBF9on3WRJUisXXFhCMrhcNo8OebyS5Q34=
 github.com/bazelbuild/bazelisk v1.17.0/go.mod h1:nWNmVF7yKsUt3EWCBCrqUeMNQpbB+DAphHIeckV1ov4=
-github.com/bazelbuild/buildtools v0.0.0-20231115204819-d4c9dccdfbb1 h1:2Gc2Q6hVR1SJ8bBI9Ybzoggp8u/ED2WkM4MfvEIn9+c=
-github.com/bazelbuild/buildtools v0.0.0-20231115204819-d4c9dccdfbb1/go.mod h1:689QdV3hBP7Vo9dJMmzhoYIyo/9iMhEmHkJcnaPRCbo=
+github.com/bazelbuild/buildtools v0.0.0-20240124160521-959427f9b6f0 h1:Qo0AsLueoZhddfcCdxOOT0dlt3KOOuJodX8dw/f55I0=
+github.com/bazelbuild/buildtools v0.0.0-20240124160521-959427f9b6f0/go.mod h1:689QdV3hBP7Vo9dJMmzhoYIyo/9iMhEmHkJcnaPRCbo=
 github.com/bazelbuild/rules_go v0.40.1 h1:+JfzEgvtYJ/cQVPWPdyMEXheRaSb/zCKy/uHl5bPqwk=
 github.com/bazelbuild/rules_go v0.40.1/go.mod h1:TMHmtfpvyfsxaqfL9WnahCsXMWDMICTw7XeK9yVb+YU=
 github.com/bazelbuild/rules_webtesting v0.0.0-20210910170740-6b2ef24cfe95 h1:zmBkl2nxjRojoW9PtGVEtW/91kHieotlD7cL9vFq06c=


### PR DESCRIPTION
This fix is backported from #5792

Upgrade buildtools to latest version and ensure our patch have the right
indentation (Go uses tabs instead of spaces).
