### PR TITLE
googleapis: build status_go_proto with vtprotobuf compiler

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,6 +116,10 @@ gazelle_dependencies()
 
 http_archive(
     name = "googleapis",
+    patch_args = ["-p1"],
+    patches = [
+        "//buildpatches:googleapis.patch",
+    ],
     sha256 = "14d4698e15d7341162363bfaed05995cca692f469c3c4710596aeecbcf44dcf2",
     strip_prefix = "googleapis-c20f392efc5c9e4f16b37002996607c4cdde4dd3",
     urls = [

--- a/buildpatches/googleapis.patch
+++ b/buildpatches/googleapis.patch
@@ -1,0 +1,15 @@
+diff --git a/google/rpc/BUILD.bazel b/google/rpc/BUILD.bazel
+index 18835af..d24aeaf 100755
+--- a/google/rpc/BUILD.bazel
++++ b/google/rpc/BUILD.bazel
+@@ -79,6 +79,10 @@ go_proto_library(
+ 
+ go_proto_library(
+     name = "status_go_proto",
++    compilers = [
++        "@io_bazel_rules_go//proto:go_proto",
++        "@com_github_planetscale_vtprotobuf//:vtprotobuf_compiler",
++    ],
+     importpath = "google.golang.org/genproto/googleapis/rpc/status",
+     protos = [":status_proto"],
+ )

--- a/deps.bzl
+++ b/deps.bzl
@@ -1442,9 +1442,6 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     )
     go_repository(
         name = "com_github_envoyproxy_go_control_plane",
-        build_directives = [
-            "gazelle:resolve go google.golang.org/genproto/googleapis/rpc/status @{}//proto:grpc_status_go_proto".format(workspace_name),
-        ],
         importpath = "github.com/envoyproxy/go-control-plane",
         sum = "h1:wSUXTlLfiAQRWs2F+p+EKOY9rUyis1MyGqJ2DIk5HpM=",
         version = "v0.11.1",
@@ -5478,18 +5475,12 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     )
     go_repository(
         name = "com_google_cloud_go_logging",
-        build_directives = [
-            "gazelle:resolve go google.golang.org/genproto/googleapis/rpc/status @{}//proto:grpc_status_go_proto".format(workspace_name),
-        ],
         importpath = "cloud.google.com/go/logging",
         sum = "h1:26skQWPeYhvIasWKm48+Eq7oUqdcdbwsCVwz5Ys0FvU=",
         version = "v1.8.1",
     )
     go_repository(
         name = "com_google_cloud_go_longrunning",
-        build_directives = [
-            "gazelle:resolve go google.golang.org/genproto/googleapis/rpc/status @{}//proto:grpc_status_go_proto".format(workspace_name),
-        ],
         importpath = "cloud.google.com/go/longrunning",
         sum = "h1:w8xEcbZodnA2BbW6sVirkkoC+1gP8wS57EUUgGS0GVg=",
         version = "v0.5.4",
@@ -6368,9 +6359,6 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     )
     go_repository(
         name = "org_golang_google_genproto_googleapis_api",
-        build_directives = [
-            "gazelle:resolve go google.golang.org/genproto/googleapis/rpc/status @{}//proto:grpc_status_go_proto".format(workspace_name),
-        ],
         importpath = "google.golang.org/genproto/googleapis/api",
         sum = "h1:HJMDndgxest5n2y77fnErkM62iUsptE/H8p0dC2Huo4=",
         version = "v0.0.0-20231030173426-d783a09b4405",
@@ -6383,9 +6371,6 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     )
     go_repository(
         name = "org_golang_google_genproto_googleapis_rpc",
-        build_directives = [
-            "gazelle:resolve go google.golang.org/genproto/googleapis/rpc/status @{}//proto:grpc_status_go_proto".format(workspace_name),
-        ],
         importpath = "google.golang.org/genproto/googleapis/rpc",
         sum = "h1:ultW7fxlIvee4HYrtnaRPon9HpEgFk5zYpmfMgtKB5I=",
         version = "v0.0.0-20231120223509-83a465c0220f",
@@ -6394,9 +6379,6 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     # gRPC
     go_repository(
         name = "org_golang_google_grpc",
-        build_directives = [
-            "gazelle:resolve go google.golang.org/genproto/googleapis/rpc/status @{}//proto:grpc_status_go_proto".format(workspace_name),
-        ],
         build_file_proto_mode = "disable",
         importpath = "google.golang.org/grpc",
         patch_args = ["-p1"],

--- a/enterprise/server/raft/client/BUILD
+++ b/enterprise/server/raft/client/BUILD
@@ -9,7 +9,6 @@ go_library(
     deps = [
         "//enterprise/server/raft/constants",
         "//enterprise/server/raft/rbuilder",
-        "//proto:grpc_status_go_proto",
         "//proto:raft_go_proto",
         "//proto:raft_service_go_proto",
         "//server/environment",
@@ -21,6 +20,7 @@ go_library(
         "@com_github_lni_dragonboat_v4//:dragonboat",
         "@com_github_lni_dragonboat_v4//client",
         "@com_github_lni_dragonboat_v4//statemachine",
+        "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_grpc//status",
     ],
 )

--- a/enterprise/server/raft/nodeliveness/BUILD
+++ b/enterprise/server/raft/nodeliveness/BUILD
@@ -27,10 +27,10 @@ go_test(
         ":nodeliveness",
         "//enterprise/server/raft/constants",
         "//enterprise/server/raft/sender",
-        "//proto:grpc_status_go_proto",
         "//proto:raft_go_proto",
         "//server/util/status",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_grpc//status",
     ],
 )

--- a/enterprise/server/raft/replica/BUILD
+++ b/enterprise/server/raft/replica/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//enterprise/server/raft/rbuilder",
         "//enterprise/server/raft/sender",
         "//enterprise/server/util/pebble",
-        "//proto:grpc_status_go_proto",
         "//proto:raft_go_proto",
         "//proto:raft_service_go_proto",
         "//server/metrics",
@@ -27,6 +26,7 @@ go_library(
         "//server/util/status",
         "@com_github_lni_dragonboat_v4//statemachine",
         "@com_github_prometheus_client_golang//prometheus",
+        "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_grpc//status",
     ],
 )

--- a/enterprise/server/telemetry/BUILD
+++ b/enterprise/server/telemetry/BUILD
@@ -7,7 +7,6 @@ go_library(
     srcs = ["telemetry_server.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/telemetry",
     deps = [
-        "//proto:grpc_status_go_proto",
         "//proto:telemetry_go_proto",
         "//server/environment",
         "//server/interfaces",
@@ -16,6 +15,7 @@ go_library(
         "//server/util/db",
         "//server/util/log",
         "@com_github_grpc_ecosystem_go_grpc_prometheus//:go-grpc-prometheus",
+        "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
     ],

--- a/enterprise/server/util/dsingleflight/BUILD
+++ b/enterprise/server/util/dsingleflight/BUILD
@@ -5,12 +5,12 @@ go_library(
     srcs = ["dsingleflight.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/dsingleflight",
     deps = [
-        "//proto:grpc_status_go_proto",
         "//server/real_environment",
         "//server/util/log",
         "//server/util/proto",
         "//server/util/status",
         "@com_github_go_redis_redis_v8//:redis",
+        "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_grpc//status",
     ],
 )

--- a/enterprise/server/util/execution/BUILD
+++ b/enterprise/server/util/execution/BUILD
@@ -7,12 +7,12 @@ go_library(
     visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//proto:execution_stats_go_proto",
-        "//proto:grpc_status_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:stored_invocation_go_proto",
         "//server/remote_cache/digest",
         "//server/tables",
         "//server/util/status",
+        "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -695,16 +695,6 @@ proto_library(
 
 # Go proto rules below here
 go_proto_library(
-    name = "grpc_status_go_proto",
-    compilers = [
-        "@io_bazel_rules_go//proto:go_proto",
-        "//proto:vtprotobuf_compiler",
-    ],
-    importpath = "google.golang.org/genproto/googleapis/rpc/status",
-    proto = "@googleapis//google/rpc:status_proto",
-)
-
-go_proto_library(
     name = "prometheus_client_go_proto",
     compilers = [
         "@io_bazel_rules_go//proto:go_proto",
@@ -846,12 +836,12 @@ go_proto_library(
     deps = [
         ":acl_go_proto",
         ":context_go_proto",
-        ":grpc_status_go_proto",
         ":invocation_status_go_proto",
         ":remote_execution_go_proto",
         ":resource_go_proto",
         ":scheduler_go_proto",
         ":stat_filter_go_proto",
+        "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )
 
@@ -1083,8 +1073,8 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/vmexec",
     proto = ":vmexec_proto",
     deps = [
-        ":grpc_status_go_proto",
         ":remote_execution_go_proto",
+        "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )
 
@@ -1123,8 +1113,8 @@ go_proto_library(
     proto = ":workflow_proto",
     deps = [
         ":context_go_proto",
-        ":grpc_status_go_proto",
         ":invocation_status_go_proto",
+        "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )
 
@@ -1137,10 +1127,10 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/raft",
     proto = ":raft_proto",
     deps = [
-        ":grpc_status_go_proto",
         ":remote_execution_go_proto",
         ":resource_go_proto",
         "@com_github_planetscale_vtprotobuf//include/github.com/planetscale/vtprotobuf/vtproto:vtproto_go_proto",
+        "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )
 
@@ -1395,9 +1385,9 @@ go_proto_library(
     proto = ":cache_proto",
     deps = [
         ":context_go_proto",
-        ":grpc_status_go_proto",
         ":remote_execution_go_proto",
         ":resource_go_proto",
+        "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )
 
@@ -1453,11 +1443,11 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/remote_asset",
     proto = ":remote_asset_proto",
     deps = [
-        ":grpc_status_go_proto",
         ":remote_execution_go_proto",
         ":semver_go_proto",
         "@com_google_cloud_go_longrunning//autogen/longrunningpb",
         "@org_golang_google_genproto_googleapis_api//annotations",
+        "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )
 
@@ -1470,11 +1460,11 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/remote_execution_log",
     proto = ":remote_execution_log_proto",
     deps = [
-        ":grpc_status_go_proto",
         ":remote_execution_go_proto",
         "@com_google_cloud_go_longrunning//autogen/longrunningpb",
         "@org_golang_google_genproto_googleapis_api//annotations",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )
 
@@ -1488,11 +1478,11 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/remote_execution",
     proto = ":remote_execution_proto",
     deps = [
-        ":grpc_status_go_proto",
         ":scheduler_go_proto",
         ":semver_go_proto",
         "@com_google_cloud_go_longrunning//autogen/longrunningpb",
         "@org_golang_google_genproto_googleapis_api//annotations",
+        "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )
 
@@ -1519,7 +1509,7 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/telemetry",
     proto = ":telemetry_proto",
     deps = [
-        ":grpc_status_go_proto",
+        "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )
 
@@ -1535,8 +1525,8 @@ go_proto_library(
     deps = [
         ":acl_go_proto",
         ":context_go_proto",
-        ":grpc_status_go_proto",
         ":trace_go_proto",
+        "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )
 

--- a/proto/api/v1/BUILD
+++ b/proto/api/v1/BUILD
@@ -64,6 +64,6 @@ go_proto_library(
     visibility = ["//visibility:public"],
     deps = [
         ":common_go_proto",
-        "//proto:grpc_status_go_proto",
+        "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )

--- a/server/remote_asset/fetch_server/BUILD
+++ b/server/remote_asset/fetch_server/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/server/remote_asset/fetch_server",
     visibility = ["//visibility:public"],
     deps = [
-        "//proto:grpc_status_go_proto",
         "//proto:remote_asset_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
@@ -19,6 +18,7 @@ go_library(
         "//server/util/scratchspace",
         "//server/util/status",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_protobuf//types/known/durationpb",
     ],

--- a/server/remote_cache/content_addressable_storage_server/BUILD
+++ b/server/remote_cache/content_addressable_storage_server/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//proto:api_key_go_proto",
         "//proto:cache_go_proto",
-        "//proto:grpc_status_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/environment",
@@ -27,6 +26,7 @@ go_library(
         "//server/util/proto",
         "//server/util/status",
         "@com_github_prometheus_client_golang//prometheus",
+        "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
         "@org_golang_x_sync//errgroup",

--- a/server/remote_cache/hit_tracker/BUILD
+++ b/server/remote_cache/hit_tracker/BUILD
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:cache_go_proto",
-        "//proto:grpc_status_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/environment",
@@ -21,6 +20,7 @@ go_library(
         "//server/util/status",
         "//server/util/usageutil",
         "@com_github_prometheus_client_golang//prometheus",
+        "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_protobuf//types/known/durationpb",
         "@org_golang_google_protobuf//types/known/timestamppb",

--- a/server/remote_cache/scorecard/BUILD
+++ b/server/remote_cache/scorecard/BUILD
@@ -25,7 +25,6 @@ go_test(
     deps = [
         ":scorecard",
         "//proto:cache_go_proto",
-        "//proto:grpc_status_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/interfaces",
@@ -35,6 +34,7 @@ go_test(
         "//server/util/status",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_protobuf//encoding/prototext",
         "@org_golang_google_protobuf//types/known/durationpb",


### PR DESCRIPTION
Instead of maintaining our own status_go_proto, let's patch the
existing target inside googleapis and use it.

This let us remove custom Gazelle directives in our go_repository.
