### PR TITLE
Fix jvm.out error logging

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -980,8 +980,6 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 		if *workflowID != "" && (exitCode == bazelOOMErrorExitCode || exitCode == bazelInternalErrorExitCode) {
 			jvmOutPath := filepath.Join(ar.rootDir, outputBaseDirName, "server/jvm.out")
 			if err := os.Link(jvmOutPath, filepath.Join(artifactsDir, "jvm.out")); err != nil {
-				ar.reporter.Printf("%sjvm.out preserved%s\n", ansiGray, ansiReset)
-			} else {
 				ar.reporter.Printf("%sfailed to preserve jvm.out: %s\n", ansiGray, err, ansiReset)
 			}
 		}


### PR DESCRIPTION
my suggestion [here](https://github.com/buildbuddy-io/buildbuddy/pull/5806#discussion_r1476859302) was wrong lol

(Also, removed the logging in the success case, because we already have a log message for each file that's uploaded, which displays at the end of the workflow run)

**Related issues**: N/A
