### PR TITLE
runfiles refactoring

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,6 +19,11 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_go",
+    patch_args = ["-p1"],
+    patches = [
+        # TODO(sluongng): remove this patch when we upgrade to v0.46.0
+        "//buildpatches:rules_go_x_defs_go_test.patch",
+    ],
     sha256 = "6734a719993b1ba4ebe9806e853864395a8d3968ad27f9dd759c196b3eb3abe8",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.45.1/rules_go-v0.45.1.zip",

--- a/buildpatches/rules_go_x_defs_go_test.patch
+++ b/buildpatches/rules_go_x_defs_go_test.patch
@@ -1,0 +1,137 @@
+commit 07317c7ce2ae6e6cda269c0c3ec7eac171363936
+Author: Son Luong Ngoc <sluongng@gmail.com>
+Date:   Tue Feb 6 15:17:25 2024 +0100
+
+    go_test: ensure external source compilation has data (#3848)
+    
+    * go_test: ensure external source compilation has data
+    
+    go_test is split into 2 compilation actions, one for internal test,
+    where package name of the test is the same with library package.
+    
+    ```bash
+    package foo
+    
+    package foo
+    ```
+    
+    and external test where the package name is different.
+    ```bash
+    package foo
+    
+    package foo_test
+    ```
+    
+    Ensure that the compilation for external test has access to go_test's
+    data attribute.
+    
+    * add test
+
+diff --git a/go/private/rules/test.bzl b/go/private/rules/test.bzl
+index 1283776a..2eb50941 100644
+--- a/go/private/rules/test.bzl
++++ b/go/private/rules/test.bzl
+@@ -74,6 +74,7 @@ def _go_test_impl(ctx):
+     )
+     external_source = go.library_to_source(go, struct(
+         srcs = [struct(files = go_srcs)],
++        data = ctx.attr.data,
+         embedsrcs = [struct(files = internal_source.embedsrcs)],
+         deps = internal_archive.direct + [internal_archive],
+         x_defs = ctx.attr.x_defs,
+diff --git a/tests/core/go_test/x_defs/BUILD.bazel b/tests/core/go_test/x_defs/BUILD.bazel
+index 7edc4885..5d86aac3 100644
+--- a/tests/core/go_test/x_defs/BUILD.bazel
++++ b/tests/core/go_test/x_defs/BUILD.bazel
+@@ -49,22 +49,36 @@ go_library(
+     x_defs = {"Qux": "Qux"},
+ )
+ 
++genrule(
++    name = "data_dep",
++    outs = ["data_dep.txt"],
++    cmd = "touch $@",
++)
++
+ go_library(
+     name = "x_defs_lib",
+     srcs = ["x_defs_lib.go"],
+-    data = ["x_defs_lib.go"],
++    data = [
++        "data_dep.txt",
++        "x_defs_lib.go",
++    ],
+     importpath = "github.com/bazelbuild/rules_go/tests/core/go_test/x_defs/x_defs_lib",
+     x_defs = {
+         "LibGo": "$(rlocationpath x_defs_lib.go)",
++        "DataDep": "$(rlocationpath :data_dep.txt)",
+     },
+ )
+ 
+ go_test(
+     name = "x_defs_test",
+     srcs = ["x_defs_test.go"],
+-    data = ["x_defs_test.go"],
++    data = [
++        "data_dep.txt",
++        "x_defs_test.go",
++    ],
+     x_defs = {
+         "BinGo": "$(rlocationpath x_defs_test.go)",
++        "DataDep": "$(rlocationpath :data_dep.txt)",
+     },
+     deps = [
+         ":x_defs_lib",
+diff --git a/tests/core/go_test/x_defs/x_defs_lib.go b/tests/core/go_test/x_defs/x_defs_lib.go
+index e7794b33..811f51e2 100644
+--- a/tests/core/go_test/x_defs/x_defs_lib.go
++++ b/tests/core/go_test/x_defs/x_defs_lib.go
+@@ -1,3 +1,5 @@
+ package x_defs_lib
+ 
+ var LibGo = "not set"
++
++var DataDep = "not set"
+diff --git a/tests/core/go_test/x_defs/x_defs_test.go b/tests/core/go_test/x_defs/x_defs_test.go
+index 0832c247..35b7ba95 100644
+--- a/tests/core/go_test/x_defs/x_defs_test.go
++++ b/tests/core/go_test/x_defs/x_defs_test.go
+@@ -11,6 +11,8 @@ import (
+ 
+ var BinGo = "not set"
+ 
++var DataDep = "not set"
++
+ func TestLibGoPath(t *testing.T) {
+ 	libGoPath, err := runfiles.Rlocation(x_defs_lib.LibGo)
+ 	if err != nil {
+@@ -20,6 +22,15 @@ func TestLibGoPath(t *testing.T) {
+ 	if err != nil {
+ 		t.Fatal(err)
+ 	}
++
++	dataPath, err := runfiles.Rlocation(x_defs_lib.DataDep)
++	if err != nil {
++		t.Fatal(err)
++	}
++	_, err = os.Stat(dataPath)
++	if err != nil {
++		t.Fatal(err)
++	}
+ }
+ 
+ func TestBinGoPath(t *testing.T) {
+@@ -31,4 +42,13 @@ func TestBinGoPath(t *testing.T) {
+ 	if err != nil {
+ 		t.Fatal(err)
+ 	}
++
++	dataPath, err := runfiles.Rlocation(DataDep)
++	if err != nil {
++		t.Fatal(err)
++	}
++	_, err = os.Stat(dataPath)
++	if err != nil {
++		t.Fatal(err)
++	}
+ }

--- a/cli/testutil/testcli/BUILD
+++ b/cli/testutil/testcli/BUILD
@@ -7,6 +7,9 @@ go_library(
     data = ["//cli/cmd/bb"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/testutil/testcli",
     visibility = ["//visibility:public"],
+    x_defs = {
+        "bbRunfilePath": "$(rlocationpath //cli/cmd/bb)",
+    },
     deps = [
         "//cli/storage",
         "//server/testutil/testbazel",

--- a/cli/testutil/testcli/testcli.go
+++ b/cli/testutil/testcli/testcli.go
@@ -25,6 +25,9 @@ import (
 )
 
 var (
+	// Set by x_defs in BUILD file
+	bbRunfilePath string
+
 	streamOutputs = flag.Bool("test_stream_cli_output", false, "Show live CLI output during test execution.")
 	verbose       = flag.Bool("test_cli_verbose", false, "Whether to add --verbose=1 to the CLI.")
 
@@ -33,7 +36,7 @@ var (
 
 // BinaryPath returns the path to the CLI binary.
 func BinaryPath(t *testing.T) string {
-	return testfs.RunfilePath(t, "buildbuddy/cli/cmd/bb/bb_/bb")
+	return testfs.RunfilePath(t, bbRunfilePath)
 }
 
 // Command returns an *exec.Cmd for the CLI binary.

--- a/cli/testutil/testcli/testcli.go
+++ b/cli/testutil/testcli/testcli.go
@@ -33,7 +33,7 @@ var (
 
 // BinaryPath returns the path to the CLI binary.
 func BinaryPath(t *testing.T) string {
-	return testfs.RunfilePath(t, "cli/cmd/bb/bb_/bb")
+	return testfs.RunfilePath(t, "buildbuddy/cli/cmd/bb/bb_/bb")
 }
 
 // Command returns an *exec.Cmd for the CLI binary.

--- a/enterprise/config/BUILD
+++ b/enterprise/config/BUILD
@@ -10,7 +10,7 @@ filegroup(
             "buildbuddy.release.yaml",
             "executor.release.yaml",
         ],
-        "//conditions:default": glob(["**"]),
+        "//conditions:default": glob(["*.yaml"]),
     }),
 )
 

--- a/enterprise/config/test/BUILD
+++ b/enterprise/config/test/BUILD
@@ -1,0 +1,1 @@
+exports_files(glob(["*.yaml"]))

--- a/enterprise/server/hostedrunner/BUILD
+++ b/enterprise/server/hostedrunner/BUILD
@@ -7,6 +7,9 @@ go_library(
     srcs = ["hostedrunner.go"],
     data = ["//enterprise/server/cmd/ci_runner:buildbuddy_ci_runner"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/hostedrunner",
+    x_defs = {
+        "runnerRunfilePath": "$(rlocationpath //enterprise/server/cmd/ci_runner:buildbuddy_ci_runner)",
+    },
     deps = [
         "//enterprise/server/cmd/ci_runner/bundle",
         "//enterprise/server/remote_execution/operation",

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -35,9 +35,11 @@ import (
 )
 
 const (
-	runnerPath                  = "buildbuddy/enterprise/server/cmd/ci_runner/buildbuddy_ci_runner"
 	DefaultRunnerContainerImage = "docker://" + platform.Ubuntu20_04WorkflowsImage
 )
+
+// set by x_defs in BUILD file
+var runnerRunfilePath string
 
 type runnerService struct {
 	env              environment.Env
@@ -45,7 +47,7 @@ type runnerService struct {
 }
 
 func New(env environment.Env) (*runnerService, error) {
-	f, err := ci_runner_bundle.Get().Open(runnerPath)
+	f, err := ci_runner_bundle.Get().Open(runnerRunfilePath)
 	if err != nil {
 		return nil, status.FailedPreconditionErrorf("could not open runner binary runfile: %s", err)
 	}
@@ -77,7 +79,7 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 	if cache == nil {
 		return nil, status.UnavailableError("No cache configured.")
 	}
-	binaryBlob, err := fs.ReadFile(ci_runner_bundle.Get(), runnerPath)
+	binaryBlob, err := fs.ReadFile(ci_runner_bundle.Get(), runnerRunfilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +88,7 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		return nil, err
 	}
 	// Save this to use when constructing the command to run below.
-	runnerName := filepath.Base(runnerPath)
+	runnerName := filepath.Base(runnerRunfilePath)
 	dir := &repb.Directory{
 		Files: []*repb.FileNode{{
 			Name:         runnerName,

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	runnerPath                  = "enterprise/server/cmd/ci_runner/buildbuddy_ci_runner"
+	runnerPath                  = "buildbuddy/enterprise/server/cmd/ci_runner/buildbuddy_ci_runner"
 	DefaultRunnerContainerImage = "docker://" + platform.Ubuntu20_04WorkflowsImage
 )
 

--- a/enterprise/server/remote_execution/commandutil/BUILD
+++ b/enterprise/server/remote_execution/commandutil/BUILD
@@ -38,6 +38,12 @@ go_test(
         "@io_bazel_rules_go//go/platform:windows": [],
         "//conditions:default": ["//enterprise/server/remote_execution/commandutil/test_binary"],
     }),
+    x_defs = select({
+        "@io_bazel_rules_go//go/platform:windows": {},
+        "//conditions:default": {
+            "testBinaryRunfilePath": "$(rlocationpath //enterprise/server/remote_execution/commandutil/test_binary)",
+        },
+    }),
     deps = [
         ":commandutil",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/remote_execution/commandutil/commandutil_unix_test.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_unix_test.go
@@ -21,6 +21,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// set by x_defs in BUILD file
+var testBinaryRunfilePath string
+
 func TestRun_NormalExit_NoError(t *testing.T) {
 	ctx := context.Background()
 
@@ -208,7 +211,7 @@ func TestRun_SubprocessInOwnProcessGroup_Timeout(t *testing.T) {
 		// Spawn a nested process inside the shell which becomes its own process group leader.
 		// Using a go binary here because sh does not have a straightforward
 		// way to make the setpgid system call.
-		testfs.RunfilePath(t, "buildbuddy/enterprise/server/remote_execution/commandutil/test_binary/test_binary_/test_binary"),
+		testfs.RunfilePath(t, testBinaryRunfilePath),
 	}}
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()

--- a/enterprise/server/remote_execution/commandutil/commandutil_unix_test.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_unix_test.go
@@ -208,7 +208,7 @@ func TestRun_SubprocessInOwnProcessGroup_Timeout(t *testing.T) {
 		// Spawn a nested process inside the shell which becomes its own process group leader.
 		// Using a go binary here because sh does not have a straightforward
 		// way to make the setpgid system call.
-		testfs.RunfilePath(t, "enterprise/server/remote_execution/commandutil/test_binary/test_binary_/test_binary"),
+		testfs.RunfilePath(t, "buildbuddy/enterprise/server/remote_execution/commandutil/test_binary/test_binary_/test_binary"),
 	}}
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -74,6 +74,9 @@ go_test(
     srcs = ["runner_test.go"],
     data = ["//enterprise/server/remote_execution/runner/testworker"],
     embed = [":runner"],
+    x_defs = {
+        "testworkerRunfilePath": "$(rlocationpath //enterprise/server/remote_execution/runner/testworker)",
+    },
     deps = [
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/containers/bare",

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -45,6 +45,9 @@ const (
 )
 
 var (
+	// set by x_defs in BUILD file
+	testworkerRunfilePath string
+
 	defaultCfg = &RunnerPoolOptions{
 		MaxRunnerCount:            *maxRunnerCount,
 		MaxRunnerDiskSizeBytes:    *maxRunnerDiskSizeBytes,
@@ -642,7 +645,7 @@ func TestRunnerPool_TaskSize(t *testing.T) {
 }
 
 func newPersistentRunnerTask(t *testing.T, key, arg, protocol string, resp *wkpb.WorkResponse) *repb.ScheduledTask {
-	workerPath := testfs.RunfilePath(t, "buildbuddy/enterprise/server/remote_execution/runner/testworker/testworker_/testworker")
+	workerPath := testfs.RunfilePath(t, testworkerRunfilePath)
 	task := &repb.ExecutionTask{
 		Command: &repb.Command{
 			Arguments: []string{

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -642,7 +642,7 @@ func TestRunnerPool_TaskSize(t *testing.T) {
 }
 
 func newPersistentRunnerTask(t *testing.T, key, arg, protocol string, resp *wkpb.WorkResponse) *repb.ScheduledTask {
-	workerPath := testfs.RunfilePath(t, "enterprise/server/remote_execution/runner/testworker/testworker_/testworker")
+	workerPath := testfs.RunfilePath(t, "buildbuddy/enterprise/server/remote_execution/runner/testworker/testworker_/testworker")
 	task := &repb.ExecutionTask{
 		Command: &repb.Command{
 			Arguments: []string{

--- a/enterprise/server/remote_execution/workspace/BUILD
+++ b/enterprise/server/remote_execution/workspace/BUILD
@@ -7,6 +7,9 @@ go_library(
     srcs = ["workspace.go"],
     data = ["//enterprise/server/cmd/ci_runner:buildbuddy_ci_runner"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/workspace",
+    x_defs = {
+        "ciRunnerRunfilePath": "$(rlocationpath //enterprise/server/cmd/ci_runner:buildbuddy_ci_runner)",
+    },
     deps = [
         "//enterprise/server/cmd/ci_runner/bundle",
         "//enterprise/server/remote_execution/dirtools",

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -31,6 +31,8 @@ import (
 )
 
 var (
+	// set by x_defs in BUILD file
+	ciRunnerRunfilePath string
 	// WorkspaceMarkedForRemovalError is returned from workspace operations
 	// whenever Remove was previously called on the workspace.
 	WorkspaceMarkedForRemovalError = status.UnavailableError("workspace is marked for removal")
@@ -188,7 +190,7 @@ func (ws *Workspace) AddCIRunner(ctx context.Context) error {
 	// TODO(bduffany): Consider doing a fastcopy here instead of a normal copy.
 	// The CI runner binary may be on a different device than the runner workspace
 	// so we'd have to put it somewhere on the same device before fastcopying.
-	srcFile, err := ci_runner_bundle.Get().Open("buildbuddy/enterprise/server/cmd/ci_runner/buildbuddy_ci_runner")
+	srcFile, err := ci_runner_bundle.Get().Open(ciRunnerRunfilePath)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -188,7 +188,7 @@ func (ws *Workspace) AddCIRunner(ctx context.Context) error {
 	// TODO(bduffany): Consider doing a fastcopy here instead of a normal copy.
 	// The CI runner binary may be on a different device than the runner workspace
 	// so we'd have to put it somewhere on the same device before fastcopying.
-	srcFile, err := ci_runner_bundle.Get().Open("enterprise/server/cmd/ci_runner/buildbuddy_ci_runner")
+	srcFile, err := ci_runner_bundle.Get().Open("buildbuddy/enterprise/server/cmd/ci_runner/buildbuddy_ci_runner")
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -38,7 +38,7 @@ go_test(
         "@com_github_google_uuid//:uuid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+        "@io_bazel_rules_go//go/runfiles:go_default_library",
         "@org_golang_google_protobuf//encoding/protodelim",
     ],
 )

--- a/enterprise/server/test/integration/ci_runner/BUILD
+++ b/enterprise/server/test/integration/ci_runner/BUILD
@@ -21,6 +21,9 @@ go_test(
         "test.dockerNetwork": "bridge",
     },
     shard_count = 13,
+    x_defs = {
+        "ciRunnerRunfilePath": "$(rlocationpath //enterprise/server/cmd/ci_runner)",
+    },
     deps = [
         "//proto:build_event_stream_go_proto",
         "//proto:eventlog_go_proto",

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protodelim"
 
-	bazelgo "github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/bazelbuild/rules_go/go/runfiles"
 	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	elpb "github.com/buildbuddy-io/buildbuddy/proto/eventlog"
 	inpb "github.com/buildbuddy-io/buildbuddy/proto/invocation"
@@ -207,11 +207,11 @@ type result struct {
 }
 
 func invokeRunner(t *testing.T, args []string, env []string, workDir string) *result {
-	binPath, err := bazelgo.Runfile("enterprise/server/cmd/ci_runner/ci_runner_/ci_runner")
+	binPath, err := runfiles.Rlocation("buildbuddy/enterprise/server/cmd/ci_runner/ci_runner_/ci_runner")
 	if err != nil {
 		t.Fatal(err)
 	}
-	bazelPath, err := bazelgo.Runfile(testbazel.BazelBinaryPath)
+	bazelPath, err := runfiles.Rlocation(testbazel.BazelBinaryPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -47,6 +47,9 @@ const (
 )
 
 var (
+	// set by x_defs in BUILD file
+	ciRunnerRunfilePath string
+
 	workspaceContentsWithBazelVersionAction = map[string]string{
 		"WORKSPACE": `workspace(name = "test")`,
 		"buildbuddy.yaml": `
@@ -207,7 +210,7 @@ type result struct {
 }
 
 func invokeRunner(t *testing.T, args []string, env []string, workDir string) *result {
-	binPath, err := runfiles.Rlocation("buildbuddy/enterprise/server/cmd/ci_runner/ci_runner_/ci_runner")
+	binPath, err := runfiles.Rlocation(ciRunnerRunfilePath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/server/test/integration/remote_execution/BUILD
+++ b/enterprise/server/test/integration/remote_execution/BUILD
@@ -10,9 +10,6 @@ go_test(
     timeout = "long",
     srcs = ["remote_execution_test.go"],
     args = ["--test.v"],
-    data = [
-        "//enterprise/server/test/integration/remote_execution/command:testcommand",
-    ],
     shard_count = 11,
     deps = [
         "//enterprise/server/build_event_publisher",

--- a/enterprise/server/test/integration/remote_execution/rbetest/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbetest/BUILD
@@ -6,7 +6,13 @@ go_library(
     name = "rbetest",
     testonly = 1,
     srcs = ["rbetest.go"],
+    data = [
+        "//enterprise/server/test/integration/remote_execution/command:testcommand",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/test/integration/remote_execution/rbetest",
+    x_defs = {
+        "testCommandBinaryRunfilePath": "$(rlocationpath //enterprise/server/test/integration/remote_execution/command:testcommand)",
+    },
     deps = [
         "//enterprise/server/backends/redis_execution_collector",
         "//enterprise/server/remote_execution/execution_server",

--- a/enterprise/server/test/integration/remote_execution/rbetest/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbetest/BUILD
@@ -64,7 +64,7 @@ go_library(
         "@com_github_google_uuid//:uuid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+        "@io_bazel_rules_go//go/runfiles:go_default_library",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//metadata",

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_execution_collector"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/execution_server"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/executor"
@@ -83,7 +83,7 @@ import (
 )
 
 const (
-	testCommandBinaryRunfilePath = "enterprise/server/test/integration/remote_execution/command/testcommand_/testcommand"
+	testCommandBinaryRunfilePath = "buildbuddy/enterprise/server/test/integration/remote_execution/command/testcommand_/testcommand"
 	testCommandBinaryName        = "testcommand"
 
 	// We are currently not testing non-default instances, but we should at some point.
@@ -201,7 +201,7 @@ func (r *Env) uploadInputRoot(ctx context.Context, rootDir string) *repb.Digest 
 }
 
 func (r *Env) setupRootDirectoryWithTestCommandBinary(ctx context.Context) *repb.Digest {
-	rfp, err := bazel.Runfile(testCommandBinaryRunfilePath)
+	rfp, err := runfiles.Rlocation(testCommandBinaryRunfilePath)
 	if err != nil {
 		assert.FailNow(r.t, "unable to find test binary in runfiles", err.Error())
 	}

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -83,14 +83,16 @@ import (
 )
 
 const (
-	testCommandBinaryRunfilePath = "buildbuddy/enterprise/server/test/integration/remote_execution/command/testcommand_/testcommand"
-	testCommandBinaryName        = "testcommand"
+	testCommandBinaryName = "testcommand"
 
 	// We are currently not testing non-default instances, but we should at some point.
 	defaultInstanceName = ""
 
 	defaultWaitTimeout = 60 * time.Second
 )
+
+// set by x_defs in BUILD file
+var testCommandBinaryRunfilePath string
 
 func init() {
 	// Set umask to match the executor process.

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -1578,9 +1578,11 @@ func TestRedisRestart(t *testing.T) {
 	}
 	app := buildbuddy_enterprise.RunWithConfig(t, buildbuddy_enterprise.DefaultAppConfig(t), buildbuddy_enterprise.NoAuthConfig, args...)
 
-	_ = testexecutor.Run(t,
-		"buildbuddy/enterprise/server/cmd/executor/executor_/executor",
-		[]string{"--executor.app_target=" + app.GRPCAddress()})
+	_ = testexecutor.Run(
+		t,
+		testexecutor.ExecutorRunfilePath,
+		[]string{"--executor.app_target=" + app.GRPCAddress()},
+	)
 
 	ctx := context.Background()
 	ws := testbazel.MakeTempWorkspace(t, workspaceContents)

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -1579,7 +1579,7 @@ func TestRedisRestart(t *testing.T) {
 	app := buildbuddy_enterprise.RunWithConfig(t, buildbuddy_enterprise.DefaultAppConfig(t), buildbuddy_enterprise.NoAuthConfig, args...)
 
 	_ = testexecutor.Run(t,
-		"enterprise/server/cmd/executor/executor_/executor",
+		"buildbuddy/enterprise/server/cmd/executor/executor_/executor",
 		[]string{"--executor.app_target=" + app.GRPCAddress()})
 
 	ctx := context.Background()

--- a/enterprise/server/testutil/buildbuddy_enterprise/BUILD
+++ b/enterprise/server/testutil/buildbuddy_enterprise/BUILD
@@ -7,10 +7,16 @@ go_library(
     testonly = 1,
     srcs = ["buildbuddy_enterprise.go"],
     data = [
-        "//enterprise/config:config_files",
+        "//enterprise/config/test:buildbuddy.noauth.yaml",
+        "//enterprise/config/test:buildbuddy.selfauth.yaml",
         "//enterprise/server/cmd/server:buildbuddy",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/buildbuddy_enterprise",
+    x_defs = {
+        "DefaultConfig": "$(rlocationpaths //enterprise/config/test:buildbuddy.selfauth.yaml)",
+        "NoAuthConfig": "$(rlocationpaths //enterprise/config/test:buildbuddy.noauth.yaml)",
+        "buildbuddyRunfilePath": "$(rlocationpaths //enterprise/server/cmd/server:buildbuddy)",
+    },
     deps = [
         "//enterprise/server/testutil/testredis",
         "//proto:context_go_proto",

--- a/enterprise/server/testutil/buildbuddy_enterprise/buildbuddy_enterprise.go
+++ b/enterprise/server/testutil/buildbuddy_enterprise/buildbuddy_enterprise.go
@@ -28,9 +28,11 @@ var (
 	remoteSSOSlug     = flag.String("remote_sso_slug", "", "For remote targets, the SSO slug to login. Self-auth must be enabled for these targets.")
 )
 
-const (
-	DefaultConfig = "buildbuddy/enterprise/config/test/buildbuddy.selfauth.yaml"
-	NoAuthConfig  = "buildbuddy/enterprise/config/test/buildbuddy.noauth.yaml"
+var (
+	// set by x_defs in BUILD file
+	DefaultConfig         string
+	NoAuthConfig          string
+	buildbuddyRunfilePath string
 )
 
 func Run(t *testing.T, args ...string) *app.App {
@@ -48,7 +50,7 @@ func RunWithConfig(t *testing.T, appConfig *app.App, configPath string, args ...
 	return app.RunWithApp(
 		t,
 		appConfig,
-		/* commandPath= */ "buildbuddy/enterprise/server/cmd/server/buildbuddy_/buildbuddy",
+		/* commandPath= */ buildbuddyRunfilePath,
 		commandArgs,
 		/* configPath= */ configPath,
 	)

--- a/enterprise/server/testutil/buildbuddy_enterprise/buildbuddy_enterprise.go
+++ b/enterprise/server/testutil/buildbuddy_enterprise/buildbuddy_enterprise.go
@@ -29,8 +29,8 @@ var (
 )
 
 const (
-	DefaultConfig = "enterprise/config/test/buildbuddy.selfauth.yaml"
-	NoAuthConfig  = "enterprise/config/test/buildbuddy.noauth.yaml"
+	DefaultConfig = "buildbuddy/enterprise/config/test/buildbuddy.selfauth.yaml"
+	NoAuthConfig  = "buildbuddy/enterprise/config/test/buildbuddy.noauth.yaml"
 )
 
 func Run(t *testing.T, args ...string) *app.App {
@@ -48,7 +48,7 @@ func RunWithConfig(t *testing.T, appConfig *app.App, configPath string, args ...
 	return app.RunWithApp(
 		t,
 		appConfig,
-		/* commandPath= */ "enterprise/server/cmd/server/buildbuddy_/buildbuddy",
+		/* commandPath= */ "buildbuddy/enterprise/server/cmd/server/buildbuddy_/buildbuddy",
 		commandArgs,
 		/* configPath= */ configPath,
 	)

--- a/enterprise/server/testutil/testexecutor/BUILD
+++ b/enterprise/server/testutil/testexecutor/BUILD
@@ -9,6 +9,9 @@ go_library(
         "//enterprise/server/cmd/executor",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testexecutor",
+    x_defs = {
+        "ExecutorRunfilePath": "$(rlocationpath //enterprise/server/cmd/executor)",
+    },
     deps = [
         "//server/testutil/testport",
         "//server/testutil/testserver",

--- a/enterprise/server/testutil/testexecutor/testexecutor.go
+++ b/enterprise/server/testutil/testexecutor/testexecutor.go
@@ -14,6 +14,9 @@ type Executor struct {
 	monitoringPort int
 }
 
+// set by x_defs in BUILD file
+var ExecutorRunfilePath string
+
 // Run a local BuildBuddy executor for the scope of the given test case.
 //
 // The given command path and config file path refer to the workspace-relative runfile
@@ -31,7 +34,7 @@ func Run(t *testing.T, commandPath string, commandArgs []string) *Executor {
 	args = append(args, commandArgs...)
 
 	testserver.Run(t, &testserver.Opts{
-		BinaryPath:            commandPath,
+		BinaryRunfilePath:     commandPath,
 		Args:                  args,
 		HTTPPort:              e.httpPort,
 		HealthCheckServerType: "prod-buildbuddy-executor",

--- a/enterprise/server/testutil/testredis/BUILD
+++ b/enterprise/server/testutil/testredis/BUILD
@@ -16,7 +16,7 @@ go_library(
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+        "@io_bazel_rules_go//go/runfiles:go_default_library",
     ],
 )
 

--- a/enterprise/server/testutil/testredis/BUILD
+++ b/enterprise/server/testutil/testredis/BUILD
@@ -8,6 +8,9 @@ go_library(
     srcs = ["testredis.go"],
     data = [":redis-server_crossplatform"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/testredis",
+    x_defs = {
+        "redisBinRunfilePath": "$(rlocationpath :redis-server_crossplatform)",
+    },
     deps = [
         "//enterprise/server/util/redisutil",
         "//server/testutil/testfs",

--- a/enterprise/server/testutil/testredis/testredis.go
+++ b/enterprise/server/testutil/testredis/testredis.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redisutil"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	redisBinRunfilePath = "enterprise/server/testutil/testredis/redis-server"
+	redisBinRunfilePath = "buildbuddy/enterprise/server/testutil/testredis/redis-server"
 
 	startupTimeout      = 10 * time.Second
 	startupPingInterval = 5 * time.Millisecond
@@ -51,7 +51,7 @@ func (h *Handle) start() {
 		return
 	}
 
-	redisBinPath, err := bazel.Runfile(redisBinRunfilePath)
+	redisBinPath, err := runfiles.Rlocation(redisBinRunfilePath)
 	if err != nil {
 		assert.FailNow(h.t, "redis binary not found in runfiles", err.Error())
 	}

--- a/enterprise/server/testutil/testredis/testredis.go
+++ b/enterprise/server/testutil/testredis/testredis.go
@@ -21,11 +21,12 @@ import (
 )
 
 const (
-	redisBinRunfilePath = "buildbuddy/enterprise/server/testutil/testredis/redis-server"
-
 	startupTimeout      = 10 * time.Second
 	startupPingInterval = 5 * time.Millisecond
 )
+
+// set by x_defs in BUILD file
+var redisBinRunfilePath string
 
 type Handle struct {
 	Target     string

--- a/enterprise/server/workflow/service/BUILD
+++ b/enterprise/server/workflow/service/BUILD
@@ -46,7 +46,7 @@ go_library(
         "@com_github_google_go_github_v43//github",
         "@com_github_google_uuid//:uuid",
         "@com_github_prometheus_client_golang//prometheus",
-        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+        "@io_bazel_rules_go//go/runfiles:go_default_library",
         "@org_golang_google_genproto//googleapis/longrunning",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//types/known/durationpb",

--- a/enterprise/server/workflow/service/BUILD
+++ b/enterprise/server/workflow/service/BUILD
@@ -46,7 +46,6 @@ go_library(
         "@com_github_google_go_github_v43//github",
         "@com_github_google_uuid//:uuid",
         "@com_github_prometheus_client_golang//prometheus",
-        "@io_bazel_rules_go//go/runfiles:go_default_library",
         "@org_golang_google_genproto//googleapis/longrunning",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//types/known/durationpb",

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/operation"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/webhook_data"
@@ -53,7 +54,6 @@ import (
 	"google.golang.org/genproto/googleapis/longrunning"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	bazelgo "github.com/bazelbuild/rules_go/go/tools/bazel"
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
 	inspb "github.com/buildbuddy-io/buildbuddy/proto/invocation_status"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -1277,7 +1277,7 @@ func (ws *workflowService) ciRunnerBazelCommand() string {
 }
 
 func runnerBinaryFile() (*os.File, error) {
-	path, err := bazelgo.Runfile("enterprise/server/cmd/ci_runner/ci_runner_/ci_runner")
+	path, err := runfiles.Rlocation("buildbuddy/enterprise/server/cmd/ci_runner/ci_runner_/ci_runner")
 	if err != nil {
 		return nil, status.FailedPreconditionErrorf("could not find runner binary runfile: %s", err)
 	}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -19,7 +18,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/operation"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/webhook_data"
@@ -1274,14 +1272,6 @@ func (ws *workflowService) ciRunnerBazelCommand() string {
 		return ""
 	}
 	return *workflowsCIRunnerBazelCommand
-}
-
-func runnerBinaryFile() (*os.File, error) {
-	path, err := runfiles.Rlocation("buildbuddy/enterprise/server/cmd/ci_runner/ci_runner_/ci_runner")
-	if err != nil {
-		return nil, status.FailedPreconditionErrorf("could not find runner binary runfile: %s", err)
-	}
-	return os.Open(path)
 }
 
 func (ws *workflowService) apiKeyForWorkflow(ctx context.Context, wf *tables.Workflow) (*tables.APIKey, error) {

--- a/server/remote_cache/byte_stream_client/BUILD
+++ b/server/remote_cache/byte_stream_client/BUILD
@@ -35,6 +35,11 @@ go_test(
         "too_many_files.zip",
     ],
     embed = [":byte_stream_client"],
+    x_defs = {
+        "noFilesRunfilePath": "$(rlocationpath no_files.zip)",
+        "someFilesRunfilePath": "$(rlocationpath some_files.zip)",
+        "tooManyFilesRunfilePath": "$(rlocationpath too_many_files.zip)",
+    },
     deps = [
         "//proto:zip_go_proto",
         "//server/util/proto",

--- a/server/remote_cache/byte_stream_client/BUILD
+++ b/server/remote_cache/byte_stream_client/BUILD
@@ -38,6 +38,7 @@ go_test(
     deps = [
         "//proto:zip_go_proto",
         "//server/util/proto",
-        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+        "@com_github_stretchr_testify//assert",
+        "@io_bazel_rules_go//go/runfiles:go_default_library",
     ],
 )

--- a/server/remote_cache/byte_stream_client/byte_stream_client_test.go
+++ b/server/remote_cache/byte_stream_client/byte_stream_client_test.go
@@ -16,6 +16,12 @@ import (
 	zipb "github.com/buildbuddy-io/buildbuddy/proto/zip"
 )
 
+var (
+	someFilesRunfilePath    string
+	noFilesRunfilePath      string
+	tooManyFilesRunfilePath string
+)
+
 func TestManifest_SomeFilesZip(t *testing.T) {
 	expected := &zipb.Manifest{
 		Entry: []*zipb.ManifestEntry{
@@ -44,7 +50,7 @@ func TestManifest_SomeFilesZip(t *testing.T) {
 			},
 		},
 	}
-	path, err := runfiles.Rlocation("buildbuddy/server/remote_cache/byte_stream_client/some_files.zip")
+	path, err := runfiles.Rlocation(someFilesRunfilePath)
 	assert.NoError(t, err)
 	bytes, err := os.ReadFile(path)
 	assert.NoError(t, err)
@@ -57,7 +63,7 @@ func TestManifest_SomeFilesZip(t *testing.T) {
 
 func TestManifest_NoFilesZip(t *testing.T) {
 	expected := &zipb.Manifest{}
-	path, err := runfiles.Rlocation("buildbuddy/server/remote_cache/byte_stream_client/no_files.zip")
+	path, err := runfiles.Rlocation(noFilesRunfilePath)
 	assert.NoError(t, err)
 	bytes, err := os.ReadFile(path)
 	assert.NoError(t, err)
@@ -69,7 +75,7 @@ func TestManifest_NoFilesZip(t *testing.T) {
 }
 
 func TestManifest_TooManyFilesZip(t *testing.T) {
-	path, err := runfiles.Rlocation("buildbuddy/server/remote_cache/byte_stream_client/too_many_files.zip")
+	path, err := runfiles.Rlocation(tooManyFilesRunfilePath)
 	assert.NoError(t, err)
 	bytes, err := os.ReadFile(path)
 	assert.NoError(t, err)
@@ -102,7 +108,7 @@ func validateZipContents(t *testing.T, ctx context.Context, entry *zipb.Manifest
 }
 
 func TestReadZipFileContents(t *testing.T) {
-	path, err := runfiles.Rlocation("buildbuddy/server/remote_cache/byte_stream_client/some_files.zip")
+	path, err := runfiles.Rlocation(someFilesRunfilePath)
 	assert.NoError(t, err)
 	b, err := os.ReadFile(path)
 	assert.NoError(t, err)

--- a/server/testutil/app/BUILD
+++ b/server/testutil/app/BUILD
@@ -12,7 +12,7 @@ go_library(
         "//server/testutil/testfs",
         "//server/testutil/testport",
         "//server/testutil/testserver",
-        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+        "@io_bazel_rules_go//go/runfiles:go_default_library",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:go_default_library",
     ],

--- a/server/testutil/app/app.go
+++ b/server/testutil/app/app.go
@@ -61,7 +61,7 @@ func RunWithApp(t *testing.T, app *App, commandPath string, commandArgs []string
 	args = append(args, commandArgs...)
 
 	testserver.Run(t, &testserver.Opts{
-		BinaryPath:            commandPath,
+		BinaryRunfilePath:     commandPath,
 		Args:                  args,
 		HTTPPort:              app.HttpPort,
 		HealthCheckServerType: "buildbuddy-server",

--- a/server/testutil/app/app.go
+++ b/server/testutil/app/app.go
@@ -5,12 +5,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testport"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testserver"
 	"google.golang.org/grpc"
 
-	bazelgo "github.com/bazelbuild/rules_go/go/tools/bazel"
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
 	pepb "github.com/buildbuddy-io/buildbuddy/proto/publish_build_event"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
@@ -136,7 +136,7 @@ func (a *App) ByteStreamClient(t *testing.T) bspb.ByteStreamClient {
 }
 
 func runfile(t *testing.T, path string) string {
-	resolvedPath, err := bazelgo.Runfile(path)
+	resolvedPath, err := runfiles.Rlocation(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/testutil/buildbuddy/BUILD
+++ b/server/testutil/buildbuddy/BUILD
@@ -10,5 +10,9 @@ go_library(
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/buildbuddy",
     visibility = ["//visibility:public"],
+    x_defs = {
+        "buildbuddyRunfilePath": "$(rlocationpath //server/cmd/buildbuddy)",
+        "localConfigRunfilePath": "$(rlocationpath //config:buildbuddy.local.yaml)",
+    },
     deps = ["//server/testutil/app"],
 )

--- a/server/testutil/buildbuddy/buildbuddy.go
+++ b/server/testutil/buildbuddy/buildbuddy.go
@@ -10,8 +10,8 @@ import (
 func Run(t *testing.T, args ...string) *app.App {
 	return app.Run(
 		t,
-		/* commandPath= */ "server/cmd/buildbuddy/buildbuddy_/buildbuddy",
+		/* commandPath= */ "buildbuddy/server/cmd/buildbuddy/buildbuddy_/buildbuddy",
 		/* commandArgs= */ args,
-		/* configPath= */ "config/buildbuddy.local.yaml",
+		/* configPath= */ "buildbuddy/config/buildbuddy.local.yaml",
 	)
 }

--- a/server/testutil/buildbuddy/buildbuddy.go
+++ b/server/testutil/buildbuddy/buildbuddy.go
@@ -6,12 +6,18 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/app"
 )
 
+var (
+	// set by x_defs in BUILD file
+	buildbuddyRunfilePath  string
+	localConfigRunfilePath string
+)
+
 // Run a local BuildBuddy server for the scope of the given test case.
 func Run(t *testing.T, args ...string) *app.App {
 	return app.Run(
 		t,
-		/* commandPath= */ "buildbuddy/server/cmd/buildbuddy/buildbuddy_/buildbuddy",
+		/* commandPath= */ buildbuddyRunfilePath,
 		/* commandArgs= */ args,
-		/* configPath= */ "buildbuddy/config/buildbuddy.local.yaml",
+		/* configPath= */ localConfigRunfilePath,
 	)
 }

--- a/server/testutil/testbazel/BUILD
+++ b/server/testutil/testbazel/BUILD
@@ -10,10 +10,15 @@ go_library(
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/testbazel",
     visibility = ["//visibility:public"],
+    x_defs = {
+        "Version": "5.3.2",
+        "BazelBinaryPath": "$(rlocationpath //server/util/bazel:bazel-5.3.2_crossplatform)",
+        "installBasePath": "$(rlocationpath //server/util/bazel:bazel-5.3.2_extract_installation)",
+    },
     deps = [
         "//server/testutil/testfs",
         "//server/util/bazel",
         "@com_github_stretchr_testify//require",
-        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+        "@io_bazel_rules_go//go/runfiles:go_default_library",
     ],
 )

--- a/server/testutil/testbazel/testbazel.go
+++ b/server/testutil/testbazel/testbazel.go
@@ -13,23 +13,25 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel"
 	"github.com/stretchr/testify/require"
 
-	bazelgo "github.com/bazelbuild/rules_go/go/tools/bazel"
-)
-
-const (
-	// Version is the bazel version of the embedded test bazel binary.
-	Version = "5.3.2"
-
-	// BazelBinaryPath specifies the path to the bazel binary used for
-	// invocations. Must match the path in the build rule.
-	BazelBinaryPath = "server/util/bazel/bazel-" + Version
-
-	// installBasePath is the path to the pre-extracted Bazel installation
-	// relative to the runfiles dir.
-	installBasePath = "server/util/bazel/bazel-" + Version + "_install"
+	"github.com/bazelbuild/rules_go/go/runfiles"
 )
 
 var (
+	// Version is the bazel version of the embedded test bazel binary.
+	//
+	// Injected via x_defs.
+	Version string
+	// BazelBinaryPath specifies the path to the bazel binary used for
+	// invocations. Must match the path in the build rule.
+	//
+	// Injected via x_defs.
+	BazelBinaryPath string
+	// InstallBasePath is the path to the pre-extracted Bazel installation
+	// relative to the runfiles dir.
+	//
+	// Injected via x_defs.
+	installBasePath string
+
 	initOnce sync.Once
 )
 
@@ -38,7 +40,7 @@ func BinaryPath(t *testing.T) string {
 	// Write an entrypoint script that runs bazel with --install_base.
 	entrypoint := filepath.Join(os.Getenv("TEST_TMPDIR"), "bazel-"+Version+"_test_entrypoint.sh")
 	initOnce.Do(func() {
-		path, err := bazelgo.Runfile(BazelBinaryPath)
+		path, err := runfiles.Rlocation(BazelBinaryPath)
 		require.NoError(t, err, "look up bazel binary path")
 		installBase := initInstallBase(t)
 		script := "#!/usr/bin/env sh\n"
@@ -50,7 +52,7 @@ func BinaryPath(t *testing.T) string {
 }
 
 func initInstallBase(t *testing.T) string {
-	path, err := bazelgo.Runfile(installBasePath)
+	path, err := runfiles.Rlocation(installBasePath)
 	require.NoError(t, err)
 	// Make a physical copy of the install dir (if it's symlinked via bazel
 	// sandboxing) and set file mtimes to be in the future so that bazel sees it

--- a/server/testutil/testbazelisk/BUILD
+++ b/server/testutil/testbazelisk/BUILD
@@ -9,6 +9,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_stretchr_testify//require",
-        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+        "@io_bazel_rules_go//go/runfiles:go_default_library",
     ],
 )

--- a/server/testutil/testbazelisk/testbazelisk.go
+++ b/server/testutil/testbazelisk/testbazelisk.go
@@ -3,14 +3,13 @@ package testbazelisk
 import (
 	"testing"
 
+	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/stretchr/testify/require"
-
-	bazelgo "github.com/bazelbuild/rules_go/go/tools/bazel"
 )
 
 // BinaryPath returns the path to bazelisk in runfiles.
 func BinaryPath(t *testing.T) string {
-	path, err := bazelgo.Runfile("external/com_github_bazelbuild_bazelisk/bazelisk_/bazelisk")
+	path, err := runfiles.Rlocation("com_github_bazelbuild_bazelisk/bazelisk_/bazelisk")
 	require.NoError(t, err, "failed to locate bazelisk")
 	return path
 }

--- a/server/testutil/testfs/BUILD
+++ b/server/testutil/testfs/BUILD
@@ -9,6 +9,6 @@ go_library(
         "//server/util/random",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+        "@io_bazel_rules_go//go/runfiles:go_default_library",
     ],
 )

--- a/server/testutil/testfs/testfs.go
+++ b/server/testutil/testfs/testfs.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,7 +16,7 @@ import (
 
 // RunfilePath returns the path to the given bazel runfile.
 func RunfilePath(t testing.TB, path string) string {
-	path, err := bazel.Runfile(path)
+	path, err := runfiles.Rlocation(path)
 	require.NoError(t, err)
 	return path
 }

--- a/server/testutil/testserver/BUILD
+++ b/server/testutil/testserver/BUILD
@@ -5,5 +5,5 @@ go_library(
     srcs = ["testserver.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/testutil/testserver",
     visibility = ["//visibility:public"],
-    deps = ["@io_bazel_rules_go//go/tools/bazel:go_default_library"],
+    deps = ["@io_bazel_rules_go//go/runfiles:go_default_library"],
 )

--- a/server/testutil/testserver/testserver.go
+++ b/server/testutil/testserver/testserver.go
@@ -41,7 +41,7 @@ func runfile(t *testing.T, path string) string {
 }
 
 type Opts struct {
-	BinaryPath            string
+	BinaryRunfilePath     string
 	Args                  []string
 	HTTPPort              int
 	HealthCheckServerType string
@@ -53,7 +53,7 @@ func Run(t *testing.T, opts *Opts) *Server {
 		healthCheckServerType: opts.HealthCheckServerType,
 	}
 
-	cmd := exec.Command(runfile(t, opts.BinaryPath), opts.Args...)
+	cmd := exec.Command(runfile(t, opts.BinaryRunfilePath), opts.Args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {

--- a/server/testutil/testserver/testserver.go
+++ b/server/testutil/testserver/testserver.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	bazelgo "github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/bazelbuild/rules_go/go/runfiles"
 )
 
 const (
@@ -33,7 +33,7 @@ type Server struct {
 }
 
 func runfile(t *testing.T, path string) string {
-	resolvedPath, err := bazelgo.Runfile(path)
+	resolvedPath, err := runfiles.Rlocation(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/util/fileresolver/BUILD
+++ b/server/util/fileresolver/BUILD
@@ -5,7 +5,7 @@ go_library(
     srcs = ["fileresolver.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/fileresolver",
     visibility = ["//visibility:public"],
-    deps = ["@io_bazel_rules_go//go/tools/bazel:go_default_library"],
+    deps = ["@io_bazel_rules_go//go/runfiles:go_default_library"],
 )
 
 go_test(

--- a/server/util/fileresolver/fileresolver.go
+++ b/server/util/fileresolver/fileresolver.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	bazelgo "github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/bazelbuild/rules_go/go/runfiles"
 )
 
 type fileResolver struct {
@@ -29,7 +29,7 @@ func (r *fileResolver) Open(name string) (fs.File, error) {
 		}
 	}
 
-	runfilePath, err := bazelgo.Runfile(name)
+	runfilePath, err := runfiles.Rlocation(name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR is structured in multiple sets of commits for easier review.
All of these changes are refactoring and thus, there is no functional change expected.

* Commit 1: `patch rules_go`
  As part of working on this PR, an issue was found with rules_go's go_test not including sufficient `data` targets while compiling the `external` test package. A patch was created and merged in rules_go to fix this. However, because these has been no new release, export the patch from rules_go to use it in our repo.

* Commit 2: `s/bazel(|go).Runfile/runfiles.Rlocation/`
  Refactor usage of the deprecated Runfile API with the newer Rlocation calls.
  Runfiles paths are updated to add the needed repo prefix `buildbuddy/`.

* Commit 3-15: use `$(rlocationpath ...)`
  This series of patches moved the hardcoded `buildbuddy/...` runfile paths to variables.
  The variables are set at build time via rules_go's `x_defs` attribute.
  The values are generated from `$(rlocationpath <target>)` of Bazel.
  Included minor cleanups to ensure `data` is declared in the right package.

This unblocks the bzlmod migration in #5792