### PR TITLE
esbuild.config: use "buildbuddy" as external repo name

### DIFF
--- a/enterprise/app/esbuild.config.mjs
+++ b/enterprise/app/esbuild.config.mjs
@@ -10,7 +10,7 @@ let browserifyPathPlugin = {
     // detect if we are building from buildbuddy-internal repo and
     // adjust 'node_modules' path accordingly
     if (!existsSync(entry)) {
-      entry = path.join(process.cwd(), "external/com_github_buildbuddy_io_buildbuddy", "node_modules");
+      entry = path.join(process.cwd(), "external/buildbuddy", "node_modules");
     }
     build.onResolve({ filter: /^path$/ }, () => ({
       // Note: the plugin API currently doesn't have a way to just replace


### PR DESCRIPTION
See https://github.com/buildbuddy-io/buildbuddy-internal/pull/3102 for
more details.
