### PR TITLE
Add .bazelrc config for deflaking tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -109,6 +109,17 @@ common:race --@io_bazel_rules_go//go/config:race
 
 common:performance --compilation_mode=opt
 
+# Configuration used to deflake tests
+common:deflake --config=remote
+common:deflake --runs_per_test=100
+common:deflake --test_output=errors
+common:deflake --notest_keep_going
+
+# Configuration used to deflake Go tests
+common:deflake-go --config=race
+common:deflake-go --config=deflake
+common:deflake-go --test_arg=-test.failfast
+
 # Configuration used for Linux workflows
 common:linux-workflows --config=remote-shared
 common:linux-workflows --config=workflows


### PR DESCRIPTION
I have this config in my `user.bazelrc` but it will be helpful to have a common config that we can mention in "flaky test" bug reports instead of having to list out all the bazel flags we're using.

e.g. "I can no longer repro the flakiness with `bazel test //target --config=deflake-go` so I'm closing this bug"

**Related issues**: N/A
