### PR TITLE
[SS] Fix hard coded remote enabled value

### DIFF
--- a/enterprise/tools/upload_local_snapshot/upload_local_snapshot.go
+++ b/enterprise/tools/upload_local_snapshot/upload_local_snapshot.go
@@ -161,7 +161,7 @@ func getAllDigestsFromSnapshotManifest(ctx context.Context, loader *snaploader.F
 		digests = append(digests, chunkedFileMetadata.GetTreeDigest())
 
 		// Add digests for chunked file chunks
-		tree, err := loader.ChunkedFileTree(ctx, remoteInstanceName, chunkedFileMetadata, tmpDir)
+		tree, err := loader.ChunkedFileTree(ctx, remoteInstanceName, chunkedFileMetadata, tmpDir, false /*remoteEnabled*/)
 		if err != nil {
 			log.Fatalf("Failed to process chunked file tree: %s", err)
 		}


### PR DESCRIPTION
It seems wrong that we search for the chunked file tree in the remote cache, even for local-only snapshots 

(As a reminder, in order to translate a chunked file into an action cache result, we create a *repb.Tree object representing each chunked file. In the action cache result we store the digests of the *repb.Trees, and then we also cache each *repb.Tree in the CAS, which contains the list of chunks.)
