### PR TITLE
WORKSPACE: rename workspace

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,5 @@
 workspace(
-    name = "buildbuddy",
+    name = "com_github_buildbuddy_io_buildbuddy",
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")

--- a/deps.bzl
+++ b/deps.bzl
@@ -2,7 +2,7 @@ load("@bazel_gazelle//:deps.bzl", "go_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 # bazelisk run //:gazelle -- update-repos -from_file=go.mod -to_macro=deps.bzl%install_go_mod_dependencies
-def install_go_mod_dependencies(workspace_name = "buildbuddy"):
+def install_go_mod_dependencies(workspace_name = "com_github_buildbuddy_io_buildbuddy"):
     go_repository(
         name = "cat_dario_mergo",
         importpath = "dario.cat/mergo",


### PR DESCRIPTION
This an alternative to https://github.com/buildbuddy-io/buildbuddy-internal/pull/3102.

In preparation for bzlmod migration, we will need a consistent workspace
name for 'internal' usage.  This affects the runfile path look up that
will be updated in #5812.
