### PR TITLE
.github/workflows: use the pre-installed bazelisk

### DIFF
--- a/.github/workflows/build-linux-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-github-release-artifacts.yaml
@@ -35,18 +35,11 @@ jobs:
           # the version of the running binary.
           fetch-depth: 0
 
-      - name: Install bazelisk
-        run: |
-          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64"
-          mkdir -p "${GITHUB_WORKSPACE}/bin/"
-          mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
-          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
-
       - name: Build and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" build --config=release --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //server/cmd/buildbuddy:buildbuddy //enterprise/server/cmd/server:buildbuddy //enterprise/server/cmd/executor:executor
+          bazelisk build --config=release --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //server/cmd/buildbuddy:buildbuddy //enterprise/server/cmd/server:buildbuddy //enterprise/server/cmd/executor:executor
           cp bazel-bin/server/cmd/**/**/buildbuddy buildbuddy-linux-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/buildbuddy buildbuddy-enterprise-linux-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-linux-amd64

--- a/.github/workflows/build-mac-intel-github-release-artifacts.yaml
+++ b/.github/workflows/build-mac-intel-github-release-artifacts.yaml
@@ -35,19 +35,12 @@ jobs:
           # the version of the running binary.
           fetch-depth: 0
 
-      - name: Install bazelisk
-        run: |
-          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-darwin-amd64"
-          mkdir -p "${GITHUB_WORKSPACE}/bin/"
-          mv bazelisk-darwin-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
-          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
-
       - name: Build and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEVELOPER_DIR: /Library/Developer/CommandLineTools
         run: |
-          export DEVELOPER_DIR=/Library/Developer/CommandLineTools
-          "${GITHUB_WORKSPACE}/bin/bazel" build --config=release-mac --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //server/cmd/buildbuddy:buildbuddy //enterprise/server/cmd/server:buildbuddy //enterprise/server/cmd/executor:executor
+          bazelisk build --config=release-mac --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //server/cmd/buildbuddy:buildbuddy //enterprise/server/cmd/server:buildbuddy //enterprise/server/cmd/executor:executor
           cp bazel-bin/server/cmd/**/**/buildbuddy buildbuddy-darwin-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/buildbuddy buildbuddy-enterprise-darwin-amd64
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-darwin-amd64

--- a/.github/workflows/build-mac-m1-github-release-artifacts.yaml
+++ b/.github/workflows/build-mac-m1-github-release-artifacts.yaml
@@ -46,18 +46,11 @@ jobs:
           # the version of the running binary.
           fetch-depth: 0
 
-      - name: Install bazelisk
-        run: |
-          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-darwin-arm64"
-          mkdir -p "${GITHUB_WORKSPACE}/bin/"
-          mv bazelisk-darwin-arm64 "${GITHUB_WORKSPACE}/bin/bazel"
-          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
-
       - name: Build and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEVELOPER_DIR: /Library/Developer/CommandLineTools
         run: |
-          export DEVELOPER_DIR=/Library/Developer/CommandLineTools
-          "${GITHUB_WORKSPACE}/bin/bazel" build --config=release-m1 --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
+          bazelisk build --config=release-m1 --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-darwin-arm64
           gh release upload ${{ inputs.version_tag }} executor-enterprise-darwin-arm64 --clobber

--- a/.github/workflows/build-windows-github-release-artifacts.yaml
+++ b/.github/workflows/build-windows-github-release-artifacts.yaml
@@ -35,15 +35,11 @@ jobs:
           # the version of the running binary.
           fetch-depth: 0
 
-      - name: Install bazelisk
-        run: |
-          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-windows-amd64.exe" -o bazel.exe
-
       - name: Build and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          bazel.exe --output_user_root=D:/0 build --config=release-windows --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
+          bazelisk --output_user_root=D:/0 build --config=release-windows --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
           $execution_root = bazel.exe --output_user_root=D:/0 info execution_root
           $artifact_rel_path = bazel.exe --output_user_root=D:/0 cquery --config=release-windows --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} --output=files //enterprise/server/cmd/executor:executor
           $artifact_abs_path = "${execution_root}\${artifact_rel_path}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,23 +23,16 @@ jobs:
           path: "/home/runner/repo-cache/"
           key: repo-cache
 
-      - name: Install bazelisk
-        run: |
-          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64"
-          mkdir -p "${GITHUB_WORKSPACE}/bin/"
-          mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
-          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
-
       - name: Build
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" build \
+          bazelisk build \
               --config=ci \
               --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
               //...
 
       - name: Test
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" test \
+          bazelisk test \
               --config=ci \
               --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
               //...

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,17 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install bazelisk
-        run: |
-          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.1.0/bazelisk-linux-amd64"
-          mkdir -p "${GITHUB_WORKSPACE}/bin/"
-          mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
-          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
-
       - name: Build
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" build --config=untrusted-ci //...
+          bazelisk build --config=untrusted-ci //...
 
       - name: Test
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" test --config=untrusted-ci //...
+          bazelisk test --config=untrusted-ci //...


### PR DESCRIPTION
The github runners images come with Bazelisk by default and is more
up-to-date than our self-managed 'Install bazelisk' job.

Switch to the pre-installed bazelisk to simplify our pipeline.
