### PR TITLE
Revert "bazelisk: use Bazelisk built from source (#5748)"

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6737,6 +6737,24 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         urls = ["https://github.com/bazelbuild/bazel/releases/download/6.0.0/bazel-6.0.0-linux-x86_64"],
     )
     http_file(
+        name = "io_bazel_bazelisk-1.17.0-darwin-amd64",
+        executable = True,
+        sha256 = "3cf03dab8f5ef7c29e354b8e9293c82098ace3634253f9c660c26168b9e34720",
+        urls = ["https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-darwin-amd64"],
+    )
+    http_file(
+        name = "io_bazel_bazelisk-1.17.0-darwin-arm64",
+        executable = True,
+        sha256 = "2d4c66d428176b6c65e284ff74951b074846f15d324b099959483c175dec5728",
+        urls = ["https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-darwin-arm64"],
+    )
+    http_file(
+        name = "io_bazel_bazelisk-1.17.0-linux-amd64",
+        executable = True,
+        sha256 = "61699e22abb2a26304edfa1376f65ad24191f94a4ffed68a58d42b6fee01e124",
+        urls = ["https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-amd64"],
+    )
+    http_file(
         name = "org_kernel_git_linux_kernel-vmlinux",
         executable = True,
         sha256 = "4582d9c5d572c0449f55cc1cf317bf154dc0ff25df97378991f7c5bc9554f14e",

--- a/server/util/bazelisk/BUILD
+++ b/server/util/bazelisk/BUILD
@@ -1,17 +1,21 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 genrule(
-    name = "bazelisk-binary",
-    srcs = ["@com_github_bazelbuild_bazelisk//:bazelisk"],
-    outs = ["bazelisk-bin"],
-    cmd = "cp $(SRCS) $@",
+    name = "bazelisk-1.17.0_crossplatform",
+    srcs = select({
+        "@bazel_tools//src/conditions:darwin_x86_64": ["@io_bazel_bazelisk-1.17.0-darwin-amd64//file:downloaded"],
+        "@bazel_tools//src/conditions:darwin_arm64": ["@io_bazel_bazelisk-1.17.0-darwin-arm64//file:downloaded"],
+        "//conditions:default": ["@io_bazel_bazelisk-1.17.0-linux-amd64//file:downloaded"],
+    }),
+    outs = ["bazelisk-1.17.0"],
+    cmd_bash = "cp $(SRCS) $@",
     visibility = ["//visibility:public"],
 )
 
 go_library(
     name = "bazelisk",
     srcs = ["bazelisk.go"],
-    embedsrcs = [":bazelisk-bin"],  #keep
+    embedsrcs = [":bazelisk-1.17.0"],  # keep
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/bazelisk",
     visibility = ["//visibility:public"],
 )

--- a/server/util/bazelisk/bazelisk.go
+++ b/server/util/bazelisk/bazelisk.go
@@ -5,9 +5,9 @@ import (
 	"io/fs"
 )
 
-//go:embed bazelisk-bin
+//go:embed *
 var embedFS embed.FS
 
 func Open() (fs.File, error) {
-	return embedFS.Open("bazelisk-bin")
+	return embedFS.Open("bazelisk-1.17.0")
 }


### PR DESCRIPTION
Getting this error when running workflows in firecracker locally:

/root/workspace/bazelisk: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /root/workspace/bazelisk)

The error goes away with the revert applied.

The bazelisk we were previously using was statically linked. Based on the error, it looks like it's no longer getting statically linked when building from source, so we run into glibc versioning issues :/

**Related issues**: N/A
