### PR TITLE
reapply: build bazelisk from source

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6737,24 +6737,6 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         urls = ["https://github.com/bazelbuild/bazel/releases/download/6.0.0/bazel-6.0.0-linux-x86_64"],
     )
     http_file(
-        name = "io_bazel_bazelisk-1.17.0-darwin-amd64",
-        executable = True,
-        sha256 = "3cf03dab8f5ef7c29e354b8e9293c82098ace3634253f9c660c26168b9e34720",
-        urls = ["https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-darwin-amd64"],
-    )
-    http_file(
-        name = "io_bazel_bazelisk-1.17.0-darwin-arm64",
-        executable = True,
-        sha256 = "2d4c66d428176b6c65e284ff74951b074846f15d324b099959483c175dec5728",
-        urls = ["https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-darwin-arm64"],
-    )
-    http_file(
-        name = "io_bazel_bazelisk-1.17.0-linux-amd64",
-        executable = True,
-        sha256 = "61699e22abb2a26304edfa1376f65ad24191f94a4ffed68a58d42b6fee01e124",
-        urls = ["https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-amd64"],
-    )
-    http_file(
         name = "org_kernel_git_linux_kernel-vmlinux",
         executable = True,
         sha256 = "4582d9c5d572c0449f55cc1cf317bf154dc0ff25df97378991f7c5bc9554f14e",

--- a/server/util/bazelisk/BUILD
+++ b/server/util/bazelisk/BUILD
@@ -1,13 +1,13 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 genrule(
-    name = "bazelisk-1.17.0_crossplatform",
+    name = "bazelisk-binary",
     srcs = select({
-        "@bazel_tools//src/conditions:darwin_x86_64": ["@io_bazel_bazelisk-1.17.0-darwin-amd64//file:downloaded"],
-        "@bazel_tools//src/conditions:darwin_arm64": ["@io_bazel_bazelisk-1.17.0-darwin-arm64//file:downloaded"],
-        "//conditions:default": ["@io_bazel_bazelisk-1.17.0-linux-amd64//file:downloaded"],
+        "@bazel_tools//src/conditions:darwin_x86_64": ["@com_github_bazelbuild_bazelisk//:bazelisk-darwin-amd64"],
+        "@bazel_tools//src/conditions:darwin_arm64": ["@com_github_bazelbuild_bazelisk//:bazelisk-darwin-arm64"],
+        "//conditions:default": ["@com_github_bazelbuild_bazelisk//:bazelisk-linux-amd64"],
     }),
-    outs = ["bazelisk-1.17.0"],
+    outs = ["bazelisk-bin"],
     cmd_bash = "cp $(SRCS) $@",
     visibility = ["//visibility:public"],
 )
@@ -15,7 +15,7 @@ genrule(
 go_library(
     name = "bazelisk",
     srcs = ["bazelisk.go"],
-    embedsrcs = [":bazelisk-1.17.0"],  # keep
+    embedsrcs = [":bazelisk-bin"],  # keep
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/bazelisk",
     visibility = ["//visibility:public"],
 )

--- a/server/util/bazelisk/bazelisk.go
+++ b/server/util/bazelisk/bazelisk.go
@@ -9,5 +9,5 @@ import (
 var embedFS embed.FS
 
 func Open() (fs.File, error) {
-	return embedFS.Open("bazelisk-1.17.0")
+	return embedFS.Open("bazelisk-bin")
 }


### PR DESCRIPTION
Same approach as before, but ensure we use the release binary target instead of the default target.

This helps apply the needed transitions on top of the binary to force Pure Go (no CGO) compilation and avoid depending on GLIBC.