### PR TITLE
SCIM: allow changing username (email)

### DIFF
--- a/enterprise/server/scim/scim.go
+++ b/enterprise/server/scim/scim.go
@@ -44,6 +44,7 @@ const (
 	ActiveAttribute     = "active"
 	GivenNameAttribute  = "name.givenName"
 	FamilyNameAttribute = "name.familyName"
+	UserNameAttribute   = "userName"
 	RoleAttribute       = `roles[primary eq "True"].value`
 )
 
@@ -495,8 +496,14 @@ func (s *SCIMServer) patchUser(ctx context.Context, r *http.Request, g *tables.G
 				return status.InvalidArgumentErrorf("expected string attribute for role but got %T", value)
 			}
 			newRole = &v
+		case UserNameAttribute:
+			v, ok := value.(string)
+			if !ok {
+				return status.InvalidArgumentErrorf("expected string attribute for username but got %T", value)
+			}
+			u.Email = v
 		default:
-			return status.InvalidArgumentErrorf("unsupported attribute %q", value)
+			return status.InvalidArgumentErrorf("unsupported attribute %q", name)
 		}
 		return nil
 	}

--- a/enterprise/server/scim/scim_test.go
+++ b/enterprise/server/scim/scim_test.go
@@ -598,6 +598,11 @@ func TestUpdateUser(t *testing.T) {
 				Path:  scim.GivenNameAttribute,
 				Value: "Gov",
 			},
+			{
+				Op:    "replace",
+				Path:  scim.UserNameAttribute,
+				Value: "somenewemail@example.domain",
+			},
 		},
 		Schemas: []string{scim.PatchResourceSchema},
 	}
@@ -611,6 +616,7 @@ func TestUpdateUser(t *testing.T) {
 	require.True(t, updatedUser.Active)
 	require.Equal(t, "Gov", updatedUser.Name.GivenName)
 	require.Equal(t, "Fam", updatedUser.Name.FamilyName)
+	require.Equal(t, "somenewemail@example.domain", updatedUser.UserName)
 
 	// Look up patched user.
 	code, body = tc.Get(baseURL + "/scim/Users/US100")
@@ -621,6 +627,7 @@ func TestUpdateUser(t *testing.T) {
 	require.True(t, updatedUser.Active)
 	require.Equal(t, "Gov", updatedUser.Name.GivenName)
 	require.Equal(t, "Fam", updatedUser.Name.FamilyName)
+	require.Equal(t, "somenewemail@example.domain", updatedUser.UserName)
 	verifyRole(t, updatedUser, scim.DeveloperRole)
 
 	// Promote user to admin.


### PR DESCRIPTION
Azure AD changes the username when de-activating a user.

Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/3093

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
