### PR TITLE
Upload fewer dirs

### DIFF
--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -418,6 +418,9 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 				if err != nil {
 					return nil, err
 				}
+				if !dirHelper.IsOutputPath(fqfn) {
+					continue
+				}
 				txInfo.FileCount += 1
 				txInfo.BytesTransferred += dirNode.GetDigest().GetSizeBytes()
 				directory.Directories = append(directory.Directories, dirNode)

--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -411,14 +411,15 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 				if !dirHelper.ShouldUploadAnythingInDir(fqfn) {
 					continue
 				}
-				if dirHelper.IsOutputPath(fqfn) {
+				isOutputPath := dirHelper.IsOutputPath(fqfn)
+				if isOutputPath {
 					treesToUpload = append(treesToUpload, fqfn)
 				}
 				dirNode, err := uploadDirFn(fullPath, info.Name())
 				if err != nil {
 					return nil, err
 				}
-				if !dirHelper.IsOutputPath(fqfn) {
+				if _, ok := dirHelper.FindParentOutputPath(fqfn); !ok && !isOutputPath {
 					continue
 				}
 				txInfo.FileCount += 1

--- a/enterprise/server/remote_execution/dirtools/dirtools_test.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools_test.go
@@ -429,6 +429,69 @@ func TestUploadTree(t *testing.T) {
 			},
 		},
 		{
+			name: "SomeNestedFile",
+			cmd: &repb.Command{
+				OutputFiles: []string{"foo/bar/baz/fileA.txt"},
+			},
+			directoryPaths: []string{},
+			fileContents: map[string]string{
+				"foo/bar/baz/fileA.txt": "a",
+			},
+			symlinkPaths: map[string]string{},
+			expectedResult: &repb.ActionResult{
+				OutputFiles: []*repb.OutputFile{
+					{
+						Path: "foo/bar/baz/fileA.txt",
+						Digest: &repb.Digest{
+							SizeBytes: 1,
+							Hash:      hash.String("a"),
+						},
+					},
+				},
+			},
+			expectedInfo: &dirtools.TransferInfo{
+				FileCount:        1,
+				BytesTransferred: 1,
+			},
+		},
+		{
+			name: "NestedOutputDirectory",
+			cmd: &repb.Command{
+				OutputDirectories: []string{"a/b/c"},
+			},
+			directoryPaths: []string{
+				"a/b/c",
+			},
+			fileContents: map[string]string{
+				"a/b/c/fileA.txt": "a",
+			},
+			symlinkPaths: map[string]string{},
+			expectedResult: &repb.ActionResult{
+				OutputDirectories: []*repb.OutputDirectory{
+					{
+						Path: "a/b/c",
+						TreeDigest: &repb.Digest{
+							SizeBytes: 85,
+							Hash:      "895545df6841b7efb2e9cc903a4eac7a60c645199be059f6056817ae6feb071d",
+						},
+					},
+				},
+				OutputFiles: []*repb.OutputFile{
+					{
+						Path: "a/b/c/fileA.txt",
+						Digest: &repb.Digest{
+							SizeBytes: 1,
+							Hash:      hash.String("a"),
+						},
+					},
+				},
+			},
+			expectedInfo: &dirtools.TransferInfo{
+				FileCount:        2,
+				BytesTransferred: 84,
+			},
+		},
+		{
 			name: "DanglingSymlinkInOutputPaths",
 			cmd: &repb.Command{
 				OutputPaths: []string{"a"},


### PR DESCRIPTION
If uploading a file like /foo/bar/baz/file.txt, don't upload directory entries for 'baz', 'bar', and 'foo', only upload 'file.txt'.