### PR TITLE
impersonation: redirect to subdomain from invocations

### DIFF
--- a/app/invocation/invocation_not_found.tsx
+++ b/app/invocation/invocation_not_found.tsx
@@ -13,20 +13,51 @@ interface Props {
   user?: User;
 }
 
-export default class InvocationNotFoundComponent extends React.Component<Props> {
-  handleLoginClicked() {
-    authService.login();
+interface State {
+  impersonationGroupID?: string;
+}
+
+export default class InvocationNotFoundComponent extends React.Component<Props, State> {
+  state: State = {};
+
+  isPermissionDenied: boolean;
+  canImpersonate: boolean;
+
+  constructor(props: Props) {
+    super(props);
+    this.isPermissionDenied = props.error?.code === "PermissionDenied";
+    this.canImpersonate = props.user?.canCall("getInvocationOwner") || false;
   }
 
-  handleImpersonateClicked() {
+  componentDidMount() {
+    if (!this.isPermissionDenied || !this.canImpersonate) {
+      return;
+    }
+
     rpcService.service
       .getInvocationOwner(
         new invocation.GetInvocationOwnerRequest({
           invocationId: this.props.invocationId,
         })
       )
-      .then((response) => authService.enterImpersonationMode(response.groupId))
+      .then((response) => {
+        if (!capabilities.config.subdomainsEnabled || capabilities.config.customerSubdomain) {
+          this.setState({ impersonationGroupID: response.groupId });
+          return;
+        }
+
+        if (new URL(response.groupUrl).hostname != window.location.hostname) {
+          window.location.href =
+            response.groupUrl + window.location.pathname + window.location.search + window.location.hash;
+        } else {
+          this.setState({ impersonationGroupID: response.groupId });
+        }
+      })
       .catch((e) => errorService.handleError(BuildBuddyError.parse(e)));
+  }
+
+  handleImpersonateClicked() {
+    authService.enterImpersonationMode(this.state.impersonationGroupID!);
   }
 
   render() {
@@ -50,13 +81,13 @@ export default class InvocationNotFoundComponent extends React.Component<Props> 
                 <div className="details">Double check your invocation URL and try again.</div>
               </>
             )}
-            {this.props.error?.code === "PermissionDenied" && (
+            {this.isPermissionDenied && (
               <>
                 <div className="titles">
                   <div className="title">Permission denied</div>
                 </div>
                 <div className="details">You are not authorized to access this invocation.</div>
-                {this.props.user?.canCall("getInvocationOwner") && (
+                {this.state.impersonationGroupID && (
                   <div>
                     <FilledButton onClick={this.handleImpersonateClicked.bind(this)} className="impersonate-button">
                       Impersonate owner

--- a/proto/invocation.proto
+++ b/proto/invocation.proto
@@ -193,6 +193,11 @@ message GetInvocationOwnerResponse {
 
   // Group ID that owns the invocation.
   string group_id = 2;
+
+  // Default URL from the group. If custom subdomains are enabled this will
+  // reference the group subdomain, otherwise it will point to the default
+  // BuildBuddy URL.
+  string group_url = 3;
 }
 
 message UpdateInvocationRequest {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1119,7 +1119,14 @@ func (s *BuildBuddyServer) GetInvocationOwner(ctx context.Context, req *inpb.Get
 	if err != nil {
 		return nil, err
 	}
-	return &inpb.GetInvocationOwnerResponse{GroupId: gid}, nil
+	g, err := s.env.GetUserDB().GetGroupByID(ctx, gid)
+	if err != nil {
+		return nil, err
+	}
+	return &inpb.GetInvocationOwnerResponse{
+		GroupId:  gid,
+		GroupUrl: getGroupUrl(g),
+	}, nil
 }
 
 func (s *BuildBuddyServer) GetExecution(ctx context.Context, req *espb.GetExecutionRequest) (*espb.GetExecutionResponse, error) {


### PR DESCRIPTION
This will allow us to scope the impersonation cookie to the subdomain.

Part of addressing https://github.com/buildbuddy-io/buildbuddy-internal/issues/3079

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
