### PR TITLE
Add user config files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ buildbuddy-key.pem
 
 # genhtml coverage outputs
 /cover
+
+# User specific config files
+enterprise/config/user-configs


### PR DESCRIPTION
I find myself wasting a lot of time setting the same config options when doing local testing. Add a user-configs dir to .gitignore, so I can maintain a set of configs that I like to use.
