### PR TITLE
fix a pebble race condition

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -2319,7 +2319,7 @@ func TestMigrateVersions(t *testing.T) {
 
 			exists, err := pc2.Contains(ctx, resourceName)
 			require.NoError(t, err)
-			require.True(t, exists)
+			require.True(t, exists, "digest %v is expected to exist, but not", resourceName.GetDigest())
 
 			rbuf, err := pc2.Get(ctx, resourceName)
 			require.NoError(t, err)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3098
In FindMissing, we locked the keys after creating the iterator. This can cause
race condition and is also manifested in the flakiness TestMigrateVersions.

In this PR, I locked all the keys present in the request prior to creating the iterator.  When CDC is enabled, I created a new iterator after I locked all the keys in the chunked metadata.
