### PR TITLE
SCIM: refactor user operations to operate by SubID instead of relying on group auth.

### DIFF
--- a/enterprise/server/backends/authdb/BUILD
+++ b/enterprise/server/backends/authdb/BUILD
@@ -8,7 +8,6 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/authdb",
     deps = [
         "//proto:api_key_go_proto",
-        "//proto:group_go_proto",
         "//proto:user_id_go_proto",
         "//server/environment",
         "//server/interfaces",

--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -28,7 +28,6 @@ import (
 	"golang.org/x/crypto/chacha20"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
-	grpb "github.com/buildbuddy-io/buildbuddy/proto/group"
 	uidpb "github.com/buildbuddy-io/buildbuddy/proto/user_id"
 )
 
@@ -423,35 +422,6 @@ func (d *AuthDB) GetAPIKeyGroupFromAPIKeyID(ctx context.Context, apiKeyID string
 		d.apiKeyGroupCache.Add(cacheKey, akg)
 	}
 	return akg, nil
-}
-
-func (d *AuthDB) LookupUserFromSubID(ctx context.Context, subID string) (*tables.User, error) {
-	user := &tables.User{}
-	err := d.h.TransactionWithOptions(ctx, db.Opts().WithStaleReads(), func(tx interfaces.DB) error {
-		rq := tx.NewQuery(ctx, "authdb_lookup_user_from_subid").Raw(
-			`SELECT * FROM "Users" WHERE sub_id = ? ORDER BY user_id ASC`, subID)
-		if err := rq.Take(user); err != nil {
-			return err
-		}
-		rq = tx.NewQuery(ctx, "authdb_lookup_user_groups").Raw(`
-			SELECT g.*, ug.role
-			FROM "Groups" AS g, "UserGroups" AS ug
-			WHERE g.group_id = ug.group_group_id
-			AND ug.membership_status = ?
-			AND ug.user_user_id = ?
-			`, int32(grpb.GroupMembershipStatus_MEMBER), user.UserID,
-		)
-		gs, err := db.ScanAll(rq, &tables.GroupRole{})
-		if err != nil {
-			return err
-		}
-		user.Groups = gs
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return user, nil
 }
 
 func (d *AuthDB) newAPIKeyGroupQuery(subDomain string, allowUserOwnedKeys bool) *query_builder.Query {

--- a/enterprise/server/backends/authdb/authdb_test.go
+++ b/enterprise/server/backends/authdb/authdb_test.go
@@ -301,32 +301,6 @@ func TestGetAPIKeyGroup_UserOwnedKeys(t *testing.T) {
 	assert.Equal(t, false, akg.GetUseGroupOwnedExecutors())
 }
 
-func TestLookupUserFromSubID(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
-	ctx := context.Background()
-	env := setupEnv(t)
-	adb := env.GetAuthDB()
-
-	users := enterprise_testauth.CreateRandomGroups(t, env)
-	randUser := users[rand.Intn(len(users))]
-
-	u, err := adb.LookupUserFromSubID(ctx, randUser.SubID)
-	require.NoError(t, err)
-	require.Equal(t, randUser, u)
-
-	// Using empty or invalid values should produce an error
-	u, err = adb.LookupUserFromSubID(ctx, "")
-	require.Nil(t, u)
-	require.Truef(
-		t, db.IsRecordNotFound(err),
-		"expected RecordNotFound error; got: %v", err)
-	u, err = adb.LookupUserFromSubID(ctx, "INVALID")
-	require.Nil(t, u)
-	require.Truef(
-		t, db.IsRecordNotFound(err),
-		"expected RecordNotFound error; got: %v", err)
-}
-
 func newFakeUser(userID, domain string) *tables.User {
 	return &tables.User{
 		UserID:    userID,

--- a/enterprise/server/backends/userdb/userdb_test.go
+++ b/enterprise/server/backends/userdb/userdb_test.go
@@ -193,7 +193,7 @@ func TestInsertUser(t *testing.T) {
 	}
 }
 
-func TestGetUserByEmail(t *testing.T) {
+func TestGetUserBySubID(t *testing.T) {
 	env := newTestEnv(t)
 	udb := env.GetUserDB()
 	ctx := context.Background()
@@ -205,32 +205,26 @@ func TestGetUserByEmail(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Insert another user with the same e-mail address but different SubID.
 	err = udb.InsertUser(ctx, &tables.User{
 		UserID: "US2",
 		SubID:  "SubID2",
-		Email:  "user2@org2.io",
-	})
-	require.NoError(t, err, "inserting multiple users should succeed")
-
-	userCtx := authUserCtx(ctx, env, t, "US1")
-	takeOwnershipOfDomain(t, userCtx, env, "US1")
-	u, err := udb.GetUserByEmail(userCtx, "user1@org1.io")
-	require.NoError(t, err)
-	require.Equal(t, "US1", u.UserID)
-
-	// Should not be able to look up user in a different group.
-	_, err = udb.GetUserByEmail(userCtx, "user2@org2.io")
-	require.True(t, status.IsNotFoundError(err))
-
-	// Insert another user with the same e-mail as the first user.
-	err = udb.InsertUser(ctx, &tables.User{
-		UserID: "US3",
-		SubID:  "SubID3",
 		Email:  "user1@org1.io",
 	})
 	require.NoError(t, err)
-	_, err = udb.GetUserByEmail(userCtx, "user1@org1.io")
-	require.True(t, status.IsFailedPreconditionError(err))
+
+	userCtx := authUserCtx(ctx, env, t, "US1")
+	takeOwnershipOfDomain(t, userCtx, env, "US1")
+	u, err := udb.GetUserBySubIDWithoutAuthCheck(userCtx, "SubID1")
+	require.NoError(t, err)
+	require.Equal(t, "US1", u.UserID)
+
+	u, err = udb.GetUserBySubIDWithoutAuthCheck(userCtx, "SubID2")
+	require.NoError(t, err)
+	require.Equal(t, "US2", u.UserID)
+
+	_, err = udb.GetUserBySubIDWithoutAuthCheck(userCtx, "INVALID")
+	require.Truef(t, status.IsNotFoundError(err), "error: %s", err)
 }
 
 func TestDeleteUserGitHubToken(t *testing.T) {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -433,7 +433,6 @@ type AuthDB interface {
 	ClearSession(ctx context.Context, sessionID string) error
 	GetAPIKeyGroupFromAPIKey(ctx context.Context, apiKey string) (APIKeyGroup, error)
 	GetAPIKeyGroupFromAPIKeyID(ctx context.Context, apiKeyID string) (APIKeyGroup, error)
-	LookupUserFromSubID(ctx context.Context, subID string) (*tables.User, error)
 
 	// GetAPIKeyForInternalUseOnly returns any group-level API key for the
 	// group. It is only to be used in situations where the user has a
@@ -499,16 +498,11 @@ type UserDB interface {
 	GetUser(ctx context.Context) (*tables.User, error)
 	GetUserByID(ctx context.Context, id string) (*tables.User, error)
 	GetUserByIDWithoutAuthCheck(ctx context.Context, id string) (*tables.User, error)
-	// GetUserByEmail lookups a user with the given e-mail address within the
-	// currently authenticated group.
-	//
-	// An error will be returned if there are multiple users with the same
-	// e-mail address. Normally this should not be the case, but it can occur
-	// if a user transitions between auth providers (e.g. oidc to saml).
-	GetUserByEmail(ctx context.Context, email string) (*tables.User, error)
-	UpdateUser(ctx context.Context, u *tables.User) error
-	// DeleteUser deletes a user and associated data.
-	DeleteUser(ctx context.Context, id string) error
+	GetUserBySubIDWithoutAuthCheck(ctx context.Context, subID string) (*tables.User, error)
+	GetUsersBySubIDPrefixWithoutAuthCheck(ctx context.Context, subIDPrefix string) ([]*tables.User, error)
+	UpdateUserWithoutAuthCheck(ctx context.Context, u *tables.User) error
+	// DeleteUserWithoutAuthCheck deletes a user and associated data.
+	DeleteUserWithoutAuthCheck(ctx context.Context, id string) error
 	// GetImpersonatedUser will return the authenticated user's information
 	// with a single group membership corresponding to the group they are trying
 	// to impersonate. It requires that the authenticated user has impersonation

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -167,11 +167,11 @@ func APIKeyGroupClaims(akg interfaces.APIKeyGroup) *Claims {
 }
 
 func ClaimsFromSubID(ctx context.Context, env environment.Env, subID string) (*Claims, error) {
-	authDB := env.GetAuthDB()
-	if authDB == nil {
-		return nil, status.FailedPreconditionError("AuthDB not configured")
+	userDB := env.GetUserDB()
+	if userDB == nil {
+		return nil, status.FailedPreconditionError("UserDB not configured")
 	}
-	u, err := authDB.LookupUserFromSubID(ctx, subID)
+	u, err := userDB.GetUserBySubIDWithoutAuthCheck(ctx, subID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows users to be synced via SCIM w/o having to add the users to a group first.

The users can then be added separately to different groups via group SCIM ops.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
