### PR TITLE
Proto changes for new role-based user API key capabilities

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -455,6 +455,7 @@ proto_library(
         "grp.proto",
     ],
     deps = [
+        ":api_key_proto",
         ":context_proto",
         ":user_id_proto",
     ],
@@ -1370,6 +1371,7 @@ go_proto_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/proto/group",
     proto = ":group_proto",
     deps = [
+        ":api_key_go_proto",
         ":context_go_proto",
         ":user_id_go_proto",
     ],
@@ -1955,6 +1957,7 @@ ts_proto_library(
     name = "group_ts_proto",
     proto = ":group_proto",
     deps = [
+        ":api_key_ts_proto",
         ":context_ts_proto",
         ":user_id_ts_proto",
     ],

--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -96,7 +96,9 @@ message Group {
   bool external_user_management = 17;
 
   // Maximum set of allowed capabilities that the user can assign to a user API
-  // key created within this group.
+  // key created within this group. Note that these are specific to the
+  // currently authenticated user, not to
+  // the group as a whole.
   repeated api_key.ApiKey.Capability allowed_user_api_key_capabilities = 18;
 }
 

--- a/proto/grp.proto
+++ b/proto/grp.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
+import "proto/api_key.proto";
 import "proto/context.proto";
 import "proto/user_id.proto";
 
 package grp;
 
 // Group represents a group that a user is a member of.
-// Next tag: 10
 message Group {
   reserved 8;
 
@@ -94,6 +94,10 @@ message Group {
   // Whether users are being managed by an external system using the SCIM API.
   // Disables in-app user management.
   bool external_user_management = 17;
+
+  // Maximum set of allowed capabilities that the user can assign to a user API
+  // key created within this group.
+  repeated api_key.ApiKey.Capability allowed_user_api_key_capabilities = 18;
 }
 
 message JoinGroupRequest {


### PR DESCRIPTION
Currently, the "Personal API keys" UI allows admin users to assign arbitrary capabilities to their API keys, and developers always get CAS_WRITE keys (they cannot customize the capabilities). This logic is hard-coded in the frontend code, and the server validates the capabilities requested via the API.

However, now that we've defined a concrete role => capabilities mapping, the server can send up the explicit list of capabilities that the user is allowed to assign. This will make it so that the frontend does not have to duplicate the role => capabilities mapping that we already have on the server, which will make the code simpler and easier to maintain now that we're adding new roles.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3091
