### PR TITLE
create iterator after lock in pebble cache

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1758,7 +1758,7 @@ func (p *PebbleCache) deleteMetadataOnly(ctx context.Context, key filestore.Pebb
 	}
 	defer db.Close()
 
-	unlockFn := p.locker.RLock(key.lockID())
+	unlockFn := p.locker.RLock(key.LockID())
 
 	iter := db.NewIter(nil /*default iterOptions*/)
 	defer iter.Close()

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1758,8 +1758,6 @@ func (p *PebbleCache) deleteMetadataOnly(ctx context.Context, key filestore.Pebb
 	}
 	defer db.Close()
 
-	unlockFn := p.locker.RLock(key.LockID())
-
 	iter := db.NewIter(nil /*default iterOptions*/)
 	defer iter.Close()
 
@@ -1767,7 +1765,6 @@ func (p *PebbleCache) deleteMetadataOnly(ctx context.Context, key filestore.Pebb
 	fileMetadata := rfpb.FileMetadataFromVTPool()
 	defer fileMetadata.ReturnToVTPool()
 	version, err := p.lookupFileMetadataAndVersion(ctx, iter, key, fileMetadata)
-	unlockFn()
 
 	if err != nil {
 		return err

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1751,6 +1751,7 @@ func (p *PebbleCache) sendAtimeUpdate(key filestore.PebbleKey, lastAccessUsec in
 	}
 }
 
+// The key should be locked before calling this function.
 func (p *PebbleCache) deleteMetadataOnly(ctx context.Context, key filestore.PebbleKey) error {
 	db, err := p.leaser.DB()
 	if err != nil {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
In Metadata function(), we currently create the iterator before we lock, which
can cause race condition described in https://github.com/buildbuddy-io/buildbuddy/pull/4460

In deleteMetadataOnly(), I added a comment stating the the key should be locked prior to calling this function. 

For FindMissing, I addressed the issue in https://github.com/buildbuddy-io/buildbuddy/pull/5851
