### PR TITLE
remove transactions surrounding exclusively non-locking reads

### DIFF
--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -358,25 +358,30 @@ func (d *AuthDB) GetAPIKeyGroupFromAPIKey(ctx context.Context, apiKey string) (i
 	}
 
 	akg := &apiKeyGroup{}
-	err := d.h.TransactionWithOptions(ctx, db.Opts().WithStaleReads(), func(tx interfaces.DB) error {
-		qb := d.newAPIKeyGroupQuery(sd, true /*=allowUserOwnedKeys*/)
-		keyClauses := query_builder.OrClauses{}
-		if !*encryptOldKeys {
-			keyClauses.AddOr("ak.value = ?", apiKey)
+	qb := d.newAPIKeyGroupQuery(sd, true /*=allowUserOwnedKeys*/)
+	keyClauses := query_builder.OrClauses{}
+	if !*encryptOldKeys {
+		keyClauses.AddOr("ak.value = ?", apiKey)
+	}
+	if d.apiKeyEncryptionKey != nil {
+		encryptedAPIKey, err := d.encryptAPIKey(apiKey)
+		if err != nil {
+			return nil, err
 		}
-		if d.apiKeyEncryptionKey != nil {
-			encryptedAPIKey, err := d.encryptAPIKey(apiKey)
-			if err != nil {
-				return err
-			}
-			keyClauses.AddOr("ak.encrypted_value = ?", encryptedAPIKey)
-		}
-		keyQuery, keyArgs := keyClauses.Build()
-		qb.AddWhereClause(keyQuery, keyArgs...)
-		q, args := qb.Build()
-		rq := tx.NewQuery(ctx, "authdb_get_api_key_group_by_key").Raw(q, args...)
-		return rq.Take(akg)
-	})
+		keyClauses.AddOr("ak.encrypted_value = ?", encryptedAPIKey)
+	}
+	keyQuery, keyArgs := keyClauses.Build()
+	qb.AddWhereClause(keyQuery, keyArgs...)
+	q, args := qb.Build()
+
+	err := d.h.NewQueryWithOpts(
+		ctx,
+		"authdb_get_api_key_group_by_key",
+		db.Opts().WithStaleReads(),
+	).Raw(
+		q, args...,
+	).Take(akg)
+
 	if err != nil {
 		if db.IsRecordNotFound(err) {
 			if d.apiKeyGroupCache != nil {
@@ -406,13 +411,19 @@ func (d *AuthDB) GetAPIKeyGroupFromAPIKeyID(ctx context.Context, apiKeyID string
 		}
 	}
 	akg := &apiKeyGroup{}
-	err := d.h.TransactionWithOptions(ctx, db.Opts().WithStaleReads(), func(tx interfaces.DB) error {
-		qb := d.newAPIKeyGroupQuery(sd, true /*=allowUserOwnedKeys*/)
-		qb.AddWhereClause(`ak.api_key_id = ?`, apiKeyID)
-		q, args := qb.Build()
-		rq := tx.NewQuery(ctx, "authdb_get_api_key_group_by_id").Raw(q, args...)
-		return rq.Take(akg)
-	})
+	qb := d.newAPIKeyGroupQuery(sd, true /*=allowUserOwnedKeys*/)
+	qb.AddWhereClause(`ak.api_key_id = ?`, apiKeyID)
+	q, args := qb.Build()
+
+	err := d.h.NewQueryWithOpts(
+		ctx,
+		"authdb_get_api_key_group_by_id",
+		db.Opts().WithStaleReads(),
+	).Raw(
+		q,
+		args...,
+	).Take(akg)
+
 	if err != nil {
 		if db.IsRecordNotFound(err) {
 			return nil, status.UnauthenticatedErrorf("Invalid API key ID %q", redactInvalidAPIKey(apiKeyID))
@@ -427,6 +438,7 @@ func (d *AuthDB) GetAPIKeyGroupFromAPIKeyID(ctx context.Context, apiKeyID string
 
 func (d *AuthDB) LookupUserFromSubID(ctx context.Context, subID string) (*tables.User, error) {
 	user := &tables.User{}
+	// TODO(zoey): switch this to JOIN
 	err := d.h.TransactionWithOptions(ctx, db.Opts().WithStaleReads(), func(tx interfaces.DB) error {
 		rq := tx.NewQuery(ctx, "authdb_lookup_user_from_subid").Raw(
 			`SELECT * FROM "Users" WHERE sub_id = ? ORDER BY user_id ASC`, subID)
@@ -720,11 +732,11 @@ func (d *AuthDB) CreateUserAPIKey(ctx context.Context, groupID, label string, ca
 	return createdKey, nil
 }
 
-func (d *AuthDB) getAPIKey(ctx context.Context, tx interfaces.DB, apiKeyID string) (*tables.APIKey, error) {
+func (d *AuthDB) getAPIKey(ctx context.Context, h interfaces.DB, apiKeyID string) (*tables.APIKey, error) {
 	if apiKeyID == "" {
 		return nil, status.InvalidArgumentError("API key ID cannot be empty.")
 	}
-	rq := tx.NewQuery(ctx, "authdb_get_api_key_by_id").Raw(
+	rq := h.NewQuery(ctx, "authdb_get_api_key_by_id").Raw(
 		`SELECT * FROM "APIKeys" WHERE api_key_id = ? AND (expiry_usec = 0 OR expiry_usec > ?)`, apiKeyID, time.Now().UnixMicro())
 	key := &tables.APIKey{}
 	if err := rq.Take(key); err != nil {
@@ -823,7 +835,7 @@ func (d *AuthDB) GetAPIKeys(ctx context.Context, groupID string) ([]*tables.APIK
 	return keys, err
 }
 
-func (d *AuthDB) authorizeAPIKeyWrite(ctx context.Context, tx interfaces.DB, apiKeyID string) (*tables.APIKey, error) {
+func (d *AuthDB) authorizeAPIKeyWrite(ctx context.Context, h interfaces.DB, apiKeyID string) (*tables.APIKey, error) {
 	if apiKeyID == "" {
 		return nil, status.InvalidArgumentError("API key ID is required")
 	}
@@ -831,7 +843,7 @@ func (d *AuthDB) authorizeAPIKeyWrite(ctx context.Context, tx interfaces.DB, api
 	if err != nil {
 		return nil, err
 	}
-	key, err := d.getAPIKey(ctx, tx, apiKeyID)
+	key, err := d.getAPIKey(ctx, h, apiKeyID)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -794,8 +794,11 @@ func (d *UserDB) InsertUser(ctx context.Context, u *tables.User) error {
 func (d *UserDB) GetUserByID(ctx context.Context, id string) (*tables.User, error) {
 	var user *tables.User
 	err := d.h.Transaction(ctx, func(tx interfaces.DB) error {
-		var err error
-		user, err = d.getUser(ctx, tx, id)
+		u, err := d.getUser(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		user = u
 		return err
 	})
 	if err != nil {
@@ -817,8 +820,11 @@ func (d *UserDB) GetUserByID(ctx context.Context, id string) (*tables.User, erro
 func (d *UserDB) GetUserByIDWithoutAuthCheck(ctx context.Context, id string) (*tables.User, error) {
 	var user *tables.User
 	err := d.h.Transaction(ctx, func(tx interfaces.DB) error {
-		var err error
-		user, err = d.getUser(ctx, tx, id)
+		u, err := d.getUser(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		user = u
 		return err
 	})
 	return user, err

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -97,11 +97,11 @@ func (d *UserDB) GetGroupByID(ctx context.Context, groupID string) (*tables.Grou
 	return d.getGroupByID(ctx, d.h, groupID)
 }
 
-func (d *UserDB) getGroupByID(ctx context.Context, tx interfaces.DB, groupID string) (*tables.Group, error) {
+func (d *UserDB) getGroupByID(ctx context.Context, h interfaces.DB, groupID string) (*tables.Group, error) {
 	if groupID == "" {
 		return nil, status.InvalidArgumentError("Group ID cannot be empty.")
 	}
-	rq := tx.NewQuery(ctx, "userdb_get_group_by_id").Raw(
+	rq := h.NewQuery(ctx, "userdb_get_group_by_id").Raw(
 		`SELECT * FROM "Groups" AS g WHERE g.group_id = ?`, groupID)
 	group := &tables.Group{}
 	if err := rq.Take(group); err != nil {
@@ -114,23 +114,18 @@ func (d *UserDB) getGroupByID(ctx context.Context, tx interfaces.DB, groupID str
 }
 
 func (d *UserDB) GetGroupByURLIdentifier(ctx context.Context, urlIdentifier string) (*tables.Group, error) {
-	var group *tables.Group
-	err := d.h.Transaction(ctx, func(tx interfaces.DB) error {
-		g, err := d.getGroupByURLIdentifier(ctx, tx, urlIdentifier)
-		if err != nil {
-			return err
-		}
-		group = g
-		return nil
-	})
+	group, err := d.getGroupByURLIdentifier(ctx, d.h, urlIdentifier)
+	if err != nil {
+		return nil, err
+	}
 	return group, err
 }
 
-func (d *UserDB) getGroupByURLIdentifier(ctx context.Context, tx interfaces.DB, urlIdentifier string) (*tables.Group, error) {
+func (d *UserDB) getGroupByURLIdentifier(ctx context.Context, h interfaces.DB, urlIdentifier string) (*tables.Group, error) {
 	if urlIdentifier == "" {
 		return nil, status.InvalidArgumentError("URL identifier cannot be empty.")
 	}
-	rq := tx.NewQuery(ctx, "userdb_get_group_by_identifier").Raw(
+	rq := h.NewQuery(ctx, "userdb_get_group_by_identifier").Raw(
 		`SELECT * FROM "Groups" AS g WHERE g.url_identifier = ?`, urlIdentifier)
 	group := &tables.Group{}
 	if err := rq.Take(group); err != nil {
@@ -173,11 +168,14 @@ func isInOwnedDomainBlocklist(email string) bool {
 	return false
 }
 
-func (d *UserDB) getDomainOwnerGroup(ctx context.Context, tx interfaces.DB, domain string) (*tables.Group, error) {
+func (d *UserDB) getDomainOwnerGroup(ctx context.Context, h interfaces.DB, domain string) (*tables.Group, error) {
 	tg := &tables.Group{}
-	rq := tx.NewQuery(ctx, "userdb_get_domain_owner_group").Raw(
-		`SELECT * FROM "Groups" as g WHERE g.owned_domain = ?`, domain)
-	err := rq.Take(tg)
+
+	err := h.NewQuery(ctx, "userdb_get_domain_owner_group").Raw(
+		`SELECT * FROM "Groups" as g WHERE g.owned_domain = ?`,
+		domain,
+	).Take(tg)
+
 	if db.IsRecordNotFound(err) {
 		return nil, nil
 	} else if err != nil {
@@ -186,9 +184,9 @@ func (d *UserDB) getDomainOwnerGroup(ctx context.Context, tx interfaces.DB, doma
 	return tg, nil
 }
 
-func getUserGroup(ctx context.Context, tx interfaces.DB, userID string, groupID string) (*tables.UserGroup, error) {
+func getUserGroup(ctx context.Context, h interfaces.DB, userID string, groupID string) (*tables.UserGroup, error) {
 	userGroup := &tables.UserGroup{}
-	rq := tx.NewQuery(ctx, "userdb_get_user_group").Raw(
+	rq := h.NewQuery(ctx, "userdb_get_user_group").Raw(
 		`SELECT * FROM "UserGroups" AS ug WHERE ug.user_user_id = ? AND ug.group_group_id = ?`, userID, groupID)
 	if err := rq.Take(userGroup); err != nil {
 		if db.IsRecordNotFound(err) {
@@ -796,11 +794,8 @@ func (d *UserDB) InsertUser(ctx context.Context, u *tables.User) error {
 func (d *UserDB) GetUserByID(ctx context.Context, id string) (*tables.User, error) {
 	var user *tables.User
 	err := d.h.Transaction(ctx, func(tx interfaces.DB) error {
-		u, err := d.getUser(ctx, tx, id)
-		if err != nil {
-			return err
-		}
-		user = u
+		var err error
+		user, err = d.getUser(ctx, tx, id)
 		return err
 	})
 	if err != nil {
@@ -822,11 +817,8 @@ func (d *UserDB) GetUserByID(ctx context.Context, id string) (*tables.User, erro
 func (d *UserDB) GetUserByIDWithoutAuthCheck(ctx context.Context, id string) (*tables.User, error) {
 	var user *tables.User
 	err := d.h.Transaction(ctx, func(tx interfaces.DB) error {
-		u, err := d.getUser(ctx, tx, id)
-		if err != nil {
-			return err
-		}
-		user = u
+		var err error
+		user, err = d.getUser(ctx, tx, id)
 		return err
 	})
 	return user, err
@@ -841,6 +833,7 @@ func (d *UserDB) GetUserByEmail(ctx context.Context, email string) (*tables.User
 	if err != nil {
 		return nil, err
 	}
+	// TODO(zoey): switch this to JOIN
 	rq := d.h.NewQuery(ctx, "userdb_get_user_by_email").Raw(`
 		SELECT * 
 		FROM "Users" u 
@@ -885,16 +878,17 @@ func (d *UserDB) GetUser(ctx context.Context) (*tables.User, error) {
 	return user, err
 }
 
-func fillUserGroups(ctx context.Context, tx interfaces.DB, user *tables.User) error {
-	q := `
-		SELECT g.*, ug.role
-		FROM "Groups" as g
-		JOIN "UserGroups" as ug
-		ON g.group_id = ug.group_group_id
-		WHERE ug.user_user_id = ? AND ug.membership_status = ?
-	`
-	rq := tx.NewQuery(ctx, "userdb_get_user_groups").Raw(
-		q, user.UserID, int32(grpb.GroupMembershipStatus_MEMBER))
+func fillUserGroups(ctx context.Context, h interfaces.DB, user *tables.User) error {
+	rq := h.NewQuery(ctx, "userdb_get_user_groups").Raw(`
+			SELECT g.*, ug.role
+			FROM "Groups" as g
+			JOIN "UserGroups" as ug
+			ON g.group_id = ug.group_group_id
+			WHERE ug.user_user_id = ? AND ug.membership_status = ?
+		`,
+		user.UserID,
+		int32(grpb.GroupMembershipStatus_MEMBER),
+	)
 	gs, err := db.ScanAll(rq, &tables.GroupRole{})
 	if err != nil {
 		return err
@@ -904,10 +898,13 @@ func fillUserGroups(ctx context.Context, tx interfaces.DB, user *tables.User) er
 }
 
 func (d *UserDB) getUser(ctx context.Context, tx interfaces.DB, userID string) (*tables.User, error) {
+	// TODO(zoey): switch this to JOIN
 	user := &tables.User{}
-	rq := tx.NewQuery(ctx, "userdb_get_user").Raw(
-		`SELECT * FROM "Users" WHERE user_id = ?`, userID)
-	if err := rq.Take(user); err != nil {
+	err := tx.NewQuery(ctx, "userdb_get_user").Raw(
+		`SELECT * FROM "Users" WHERE user_id = ?`,
+		userID,
+	).Take(user)
+	if err != nil {
 		if db.IsRecordNotFound(err) {
 			return nil, status.NotFoundError("user not found")
 		}
@@ -932,28 +929,28 @@ func (d *UserDB) GetImpersonatedUser(ctx context.Context) (*tables.User, error) 
 		return nil, status.PermissionDeniedError("Authenticated user does not have permissions to impersonate a user.")
 	}
 	user := &tables.User{}
-	err = d.h.Transaction(ctx, func(tx interfaces.DB) error {
-		rq := tx.NewQuery(ctx, "userdb_impersonation_get_user").Raw(
-			`SELECT * FROM "Users" WHERE user_id = ?`, u.GetUserID())
-		if err := rq.Take(user); err != nil {
-			return err
-		}
-		rq = tx.NewQuery(ctx, "userdb_impersonation_get_group").Raw(`
+	err = d.h.NewQuery(ctx, "userdb_impersonation_get_user").Raw(
+		`SELECT * FROM "Users" WHERE user_id = ?`,
+		u.GetUserID(),
+	).Take(user)
+	if err != nil {
+		return nil, err
+	}
+	gr := &tables.GroupRole{}
+	err = d.h.NewQuery(ctx, "userdb_impersonation_get_group").Raw(`
 			SELECT *
 			FROM "Groups"
 			WHERE group_id = ?
-		`, u.GetGroupID())
-		gr := &tables.GroupRole{}
-		err := rq.Take(gr)
-		if err != nil {
-			return err
-		}
-		// Grant admin role within the impersonated group.
-		gr.Role = uint32(role.Admin)
-		user.Groups = []*tables.GroupRole{gr}
-		return nil
-	})
-	return user, err
+		`,
+		u.GetGroupID(),
+	).Take(gr)
+	if err != nil {
+		return nil, err
+	}
+	// Grant admin role within the impersonated group.
+	gr.Role = uint32(role.Admin)
+	user.Groups = []*tables.GroupRole{gr}
+	return user, nil
 }
 
 func (d *UserDB) DeleteUser(ctx context.Context, userID string) error {

--- a/enterprise/server/quota/quota_manager.go
+++ b/enterprise/server/quota/quota_manager.go
@@ -105,6 +105,7 @@ func fetchConfigFromDB(env environment.Env, namespace string) (map[string]*names
 	}
 	ctx := env.GetServerContext()
 	config := make(map[string]*namespaceConfig)
+	// TODO(zoey): use JOIN for this
 	err := env.GetDBHandle().Transaction(ctx, func(tx interfaces.DB) error {
 		q := query_builder.NewQuery(`SELECT * FROM "QuotaBuckets"`)
 		if namespace != "" {

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -449,22 +449,20 @@ func (ws *workflowService) GetWorkflows(ctx context.Context) (*wfpb.GetWorkflows
 	}
 	q.SetOrderBy("created_at_usec" /*ascending=*/, true)
 	qStr, qArgs := q.Build()
-	err = ws.env.GetDBHandle().Transaction(ctx, func(tx interfaces.DB) error {
-		rq := tx.NewQuery(ctx, "workflow_get_workflows").Raw(qStr, qArgs...)
-		rsp.Workflow = make([]*wfpb.GetWorkflowsResponse_Workflow, 0)
-		return db.ScanEach(rq, func(ctx context.Context, tw *tables.Workflow) error {
-			u, err := ws.getWebhookURL(tw.WebhookID)
-			if err != nil {
-				return err
-			}
-			rsp.Workflow = append(rsp.Workflow, &wfpb.GetWorkflowsResponse_Workflow{
-				Id:         tw.WorkflowID,
-				Name:       tw.Name,
-				RepoUrl:    tw.RepoURL,
-				WebhookUrl: u,
-			})
-			return nil
+	rq := ws.env.GetDBHandle().NewQuery(ctx, "workflow_get_workflows").Raw(qStr, qArgs...)
+	rsp.Workflow = make([]*wfpb.GetWorkflowsResponse_Workflow, 0)
+	err = db.ScanEach(rq, func(ctx context.Context, tw *tables.Workflow) error {
+		u, err := ws.getWebhookURL(tw.WebhookID)
+		if err != nil {
+			return err
+		}
+		rsp.Workflow = append(rsp.Workflow, &wfpb.GetWorkflowsResponse_Workflow{
+			Id:         tw.WorkflowID,
+			Name:       tw.Name,
+			RepoUrl:    tw.RepoURL,
+			WebhookUrl: u,
 		})
+		return nil
 	})
 	if err != nil {
 		return nil, err

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -467,31 +467,19 @@ func isTestCommand(command string) bool {
 	return command == "test" || command == "coverage"
 }
 
-func readRepoTargetsWithTx(ctx context.Context, env environment.Env, repoURL string, tx interfaces.DB) ([]*tables.Target, error) {
+func readRepoTargets(ctx context.Context, env environment.Env, repoURL string) ([]*tables.Target, error) {
+	if env.GetDBHandle() == nil {
+		return nil, status.FailedPreconditionError("database not configured")
+	}
+	var err error
 	q := query_builder.NewQuery(`SELECT * FROM "Targets" as t`)
 	q = q.AddWhereClause(`t.repo_url = ?`, repoURL)
 	if err := perms.AddPermissionsCheckToQueryWithTableAlias(ctx, env, q, "t"); err != nil {
 		return nil, err
 	}
 	queryStr, args := q.Build()
-	rq := tx.NewQuery(ctx, "target_tracker_get_targets_by_url").Raw(queryStr, args...)
+	rq := env.GetDBHandle().NewQuery(ctx, "target_tracker_get_targets_by_url").Raw(queryStr, args...)
 	rsp, err := db.ScanAll(rq, &tables.Target{})
-	if err != nil {
-		return nil, err
-	}
-	return rsp, nil
-}
-
-func readRepoTargets(ctx context.Context, env environment.Env, repoURL string) ([]*tables.Target, error) {
-	if env.GetDBHandle() == nil {
-		return nil, status.FailedPreconditionError("database not configured")
-	}
-	var err error
-	rsp := make([]*tables.Target, 0)
-	err = env.GetDBHandle().Transaction(ctx, func(tx interfaces.DB) error {
-		rsp, err = readRepoTargetsWithTx(ctx, env, repoURL, tx)
-		return err
-	})
 	if err != nil {
 		return nil, err
 	}

--- a/server/target/BUILD
+++ b/server/target/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//proto/api/v1:common_go_proto",
         "//server/build_event_protocol/event_index",
         "//server/environment",
-        "//server/interfaces",
         "//server/util/db",
         "//server/util/git",
         "//server/util/log",

--- a/server/target/target.go
+++ b/server/target/target.go
@@ -12,7 +12,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/event_index"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
-	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/paging"
@@ -548,37 +547,35 @@ func fetchTargetsFromPrimaryDB(ctx context.Context, env environment.Env, q *quer
 		Status        int32
 	}
 
-	err := env.GetDBHandle().Transaction(ctx, func(tx interfaces.DB) error {
-		rq := tx.NewQuery(ctx, "target_get_target_history").Raw(queryStr, args...)
-		return db.ScanEach(rq, func(ctx context.Context, row *target) error {
-			targetID := fmt.Sprintf("%d", row.TargetID)
-			if _, ok := seenTargets[targetID]; !ok {
-				seenTargets[targetID] = struct{}{}
-				targets = append(targets, &trpb.TargetMetadata{
-					Id:         targetID,
-					Label:      row.Label,
-					RuleType:   row.RuleType,
-					TargetType: cmpb.TargetType(row.TargetType),
-					TestSize:   cmpb.TestSize(row.TestSize),
-				})
-			}
-
-			statuses[targetID] = append(statuses[targetID], &trpb.TargetStatus{
-				InvocationId: row.InvocationID,
-				CommitSha:    row.CommitSHA,
-				Status:       convertToCommonStatus(build_event_stream.TestStatus(row.Status)),
-				Timing: &cmpb.Timing{
-					StartTime: timestamppb.New(time.UnixMicro(row.StartTimeUsec)),
-					Duration:  durationpb.New(time.Microsecond * time.Duration(row.DurationUsec)),
-				},
-				InvocationCreatedAtUsec: row.CreatedAtUsec,
+	rq := env.GetDBHandle().NewQuery(ctx, "target_get_target_history").Raw(queryStr, args...)
+	err := db.ScanEach(rq, func(ctx context.Context, row *target) error {
+		targetID := fmt.Sprintf("%d", row.TargetID)
+		if _, ok := seenTargets[targetID]; !ok {
+			seenTargets[targetID] = struct{}{}
+			targets = append(targets, &trpb.TargetMetadata{
+				Id:         targetID,
+				Label:      row.Label,
+				RuleType:   row.RuleType,
+				TargetType: cmpb.TargetType(row.TargetType),
+				TestSize:   cmpb.TestSize(row.TestSize),
 			})
-			created_at_usec := commitTimestamps[row.CommitSHA]
-			if row.CreatedAtUsec > created_at_usec {
-				commitTimestamps[row.CommitSHA] = row.CreatedAtUsec
-			}
-			return nil
+		}
+
+		statuses[targetID] = append(statuses[targetID], &trpb.TargetStatus{
+			InvocationId: row.InvocationID,
+			CommitSha:    row.CommitSHA,
+			Status:       convertToCommonStatus(build_event_stream.TestStatus(row.Status)),
+			Timing: &cmpb.Timing{
+				StartTime: timestamppb.New(time.UnixMicro(row.StartTimeUsec)),
+				Duration:  durationpb.New(time.Microsecond * time.Duration(row.DurationUsec)),
+			},
+			InvocationCreatedAtUsec: row.CreatedAtUsec,
 		})
+		created_at_usec := commitTimestamps[row.CommitSHA]
+		if row.CreatedAtUsec > created_at_usec {
+			commitTimestamps[row.CommitSHA] = row.CreatedAtUsec
+		}
+		return nil
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

Non-locking reads have no effects to rollback and do not lock rows during the transaction, so there is no need to wrap them in a transaction.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
