### PR TITLE
shrink transactions with initial non-locking reads and single terminating writes

### DIFF
--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -227,6 +227,7 @@ func (g *apiKeyGroup) GetEnforceIPRules() bool {
 
 func (d *AuthDB) InsertOrUpdateUserSession(ctx context.Context, sessionID string, session *tables.Session) error {
 	session.SessionID = sessionID
+	// TODO(zoey): this select seems unnecessary, revisit it.
 	var existing tables.Session
 	rq := d.h.NewQuery(ctx, "authdb_get_existing_session").Raw(`
 		SELECT * FROM "Sessions" WHERE session_id = ?
@@ -863,6 +864,7 @@ func (d *AuthDB) authorizeAPIKeyWrite(ctx context.Context, h interfaces.DB, apiK
 }
 
 func (d *AuthDB) UpdateAPIKey(ctx context.Context, key *tables.APIKey) error {
+	// TODO (zoey): could make this one query
 	if key == nil {
 		return status.InvalidArgumentError("API key cannot be nil.")
 	}
@@ -896,6 +898,7 @@ func (d *AuthDB) UpdateAPIKey(ctx context.Context, key *tables.APIKey) error {
 }
 
 func (d *AuthDB) DeleteAPIKey(ctx context.Context, apiKeyID string) error {
+	// TODO (zoey): could make this one query
 	if _, err := d.authorizeAPIKeyWrite(ctx, d.h, apiKeyID); err != nil {
 		return err
 	}

--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -234,7 +234,9 @@ func (d *AuthDB) InsertOrUpdateUserSession(ctx context.Context, sessionID string
 			`, sessionID)
 	if err := rq.Take(&existing); err != nil {
 		if db.IsRecordNotFound(err) {
-			return d.h.NewQuery(ctx, "authdb_create_session").Create(session)
+			return d.h.Transaction(ctx, func(tx interfaces.DB) error {
+				return tx.NewQuery(ctx, "authdb_create_session").Create(session)
+			})
 		}
 		return err
 	}

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -395,20 +395,20 @@ func (a *GitHubApp) UnlinkGitHubAppInstallation(ctx context.Context, req *ghpb.U
 		return nil, status.FailedPreconditionError("missing installation_id")
 	}
 	dbh := a.env.GetDBHandle()
+	var ti tables.GitHubAppInstallation
+	err = dbh.NewQuery(ctx, "githubapp_get_installation_for_unlink").Raw(`
+		SELECT *
+		FROM "GitHubAppInstallations"
+		WHERE installation_id = ?
+		`+dbh.SelectForUpdateModifier()+`
+	`, req.GetInstallationId()).Take(&ti)
+	if err != nil {
+		return nil, err
+	}
+	if err := authutil.AuthorizeOrgAdmin(u, ti.GroupID); err != nil {
+		return err
+	}
 	err = dbh.Transaction(ctx, func(tx interfaces.DB) error {
-		var ti tables.GitHubAppInstallation
-		err := tx.NewQuery(ctx, "githubapp_get_installation_for_unlink").Raw(`
-			SELECT *
-			FROM "GitHubAppInstallations"
-			WHERE installation_id = ?
-			`+dbh.SelectForUpdateModifier()+`
-		`, req.GetInstallationId()).Take(&ti)
-		if err != nil {
-			return err
-		}
-		if err := authutil.AuthorizeOrgAdmin(u, ti.GroupID); err != nil {
-			return err
-		}
 		return tx.NewQuery(ctx, "githubapp_unlink_installation").Raw(`
 			DELETE FROM "GitHubAppInstallations"
 			WHERE installation_id = ?

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -394,21 +394,22 @@ func (a *GitHubApp) UnlinkGitHubAppInstallation(ctx context.Context, req *ghpb.U
 	if req.GetInstallationId() == 0 {
 		return nil, status.FailedPreconditionError("missing installation_id")
 	}
+	// TODO(zoey): Could make this one query
 	dbh := a.env.GetDBHandle()
-	var ti tables.GitHubAppInstallation
-	err = dbh.NewQuery(ctx, "githubapp_get_installation_for_unlink").Raw(`
-		SELECT *
-		FROM "GitHubAppInstallations"
-		WHERE installation_id = ?
-		`+dbh.SelectForUpdateModifier()+`
-	`, req.GetInstallationId()).Take(&ti)
-	if err != nil {
-		return nil, err
-	}
-	if err := authutil.AuthorizeOrgAdmin(u, ti.GroupID); err != nil {
-		return err
-	}
 	err = dbh.Transaction(ctx, func(tx interfaces.DB) error {
+		var ti tables.GitHubAppInstallation
+		err := tx.NewQuery(ctx, "githubapp_get_installation_for_unlink").Raw(`
+			SELECT *
+			FROM "GitHubAppInstallations"
+			WHERE installation_id = ?
+			`+dbh.SelectForUpdateModifier()+`
+		`, req.GetInstallationId()).Take(&ti)
+		if err != nil {
+			return err
+		}
+		if err := authutil.AuthorizeOrgAdmin(u, ti.GroupID); err != nil {
+			return err
+		}
 		return tx.NewQuery(ctx, "githubapp_unlink_installation").Raw(`
 			DELETE FROM "GitHubAppInstallations"
 			WHERE installation_id = ?

--- a/enterprise/server/quota/quota_manager.go
+++ b/enterprise/server/quota/quota_manager.go
@@ -417,51 +417,45 @@ func (qm *QuotaManager) ApplyBucket(ctx context.Context, req *qpb.ApplyBucketReq
 	}
 
 	dbh := qm.env.GetDBHandle()
-	// apply_bucket
-	row := &struct{ Count int64 }{}
-	err := dbh.NewQuery(ctx, "quota_manager_get_num_buckets").Raw(
-		`SELECT COUNT(*) AS count FROM "QuotaBuckets" WHERE namespace = ? AND name = ?`, req.GetNamespace(), req.GetBucketName(),
-	).Take(row)
-	if err != nil {
-		return nil, err
-	}
-	if row.Count == 0 && req.GetBucketName() != defaultBucketName {
-		return nil, status.FailedPreconditionErrorf("namespace(%q) and bucket_name(%q) doesn't exist", req.GetNamespace(), req.GetBucketName())
-	}
-
-	quotaGroup := &tables.QuotaGroup{
-		Namespace:  req.GetNamespace(),
-		QuotaKey:   quotaKey,
-		BucketName: req.GetBucketName(),
-	}
-	var existing tables.QuotaGroup
-	if err := dbh.GORM(ctx, "quota_manager_get_existing_quota_group").Where(
-		"namespace = ? AND quota_key = ?", req.GetNamespace(), quotaKey).First(&existing).Error; err != nil {
-		if !db.IsRecordNotFound(err) || req.GetBucketName() == defaultBucketName {
-			return nil, err
-		}
-		err := dbh.Transaction(ctx, func(tx interfaces.DB) error {
-			return tx.NewQuery(ctx, "quota_manager_create_quota_group").Create(quotaGroup)
-		})
+	err := dbh.Transaction(ctx, func(tx interfaces.DB) error {
+		// apply_bucket
+		row := &struct{ Count int64 }{}
+		err := tx.NewQuery(ctx, "quota_manager_get_num_buckets").Raw(
+			`SELECT COUNT(*) AS count FROM "QuotaBuckets" WHERE namespace = ? AND name = ?`, req.GetNamespace(), req.GetBucketName(),
+		).Take(row)
 		if err != nil {
-			return nil, err
+			return err
 		}
-	} else if req.GetBucketName() == defaultBucketName {
-		err := dbh.Transaction(ctx, func(tx interfaces.DB) error {
+		if row.Count == 0 && req.GetBucketName() != defaultBucketName {
+			return status.FailedPreconditionErrorf("namespace(%q) and bucket_name(%q) doesn't exist", req.GetNamespace(), req.GetBucketName())
+		}
+
+		quotaGroup := &tables.QuotaGroup{
+			Namespace:  req.GetNamespace(),
+			QuotaKey:   quotaKey,
+			BucketName: req.GetBucketName(),
+		}
+		var existing tables.QuotaGroup
+		if err := tx.GORM(ctx, "quota_manager_get_existing_quota_group").Where(
+			"namespace = ? AND quota_key = ?", req.GetNamespace(), quotaKey).First(&existing).Error; err != nil {
+			if db.IsRecordNotFound(err) {
+				if req.GetBucketName() == defaultBucketName {
+					return nil
+				}
+				return tx.NewQuery(ctx, "quota_manager_create_quota_group").Create(quotaGroup)
+			}
+			return err
+		}
+		if req.GetBucketName() == defaultBucketName {
 			return tx.NewQuery(ctx, "quota_manager_apply_bucket_delete_key").Raw(
 				`DELETE FROM "QuotaGroups" WHERE namespace = ? AND quota_key = ?`, req.GetNamespace(), quotaKey).Exec().Error
-		})
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		err := dbh.Transaction(ctx, func(tx interfaces.DB) error {
+		} else {
 			return tx.GORM(ctx, "quota_manager_apply_bucket_update_group").Model(&existing).Where(
 				"namespace = ? AND quota_key = ?", req.GetNamespace(), quotaKey).Updates(quotaGroup).Error
-		})
-		if err != nil {
-			return nil, err
 		}
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	qm.notifyListeners()

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -314,15 +314,17 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 		}
 	}
 
-	dbErr := s.env.GetDBHandle().Transaction(ctx, func(tx interfaces.DB) error {
-		var existing tables.Execution
-		if err := tx.GORM(ctx, "execution_server_get_execution_for_update").Where(
-			"execution_id = ?", executionID).First(&existing).Error; err != nil {
-			return err
-		}
-		return tx.GORM(ctx, "execution_server_update_execution").Model(&existing).Where(
-			"execution_id = ? AND stage != ?", executionID, repb.ExecutionStage_COMPLETED).Updates(execution).Error
-	})
+	var dbErr error
+	var existing tables.Execution
+	if err := s.env.GetDBHandle().GORM(ctx, "execution_server_get_execution_for_update").Where(
+		"execution_id = ?", executionID).First(&existing).Error; err != nil {
+		dbErr = err
+	} else {
+		dbErr = s.env.GetDBHandle().Transaction(ctx, func(tx interfaces.DB) error {
+			return tx.GORM(ctx, "execution_server_update_execution").Model(&existing).Where(
+				"execution_id = ? AND stage != ?", executionID, repb.ExecutionStage_COMPLETED).Updates(execution).Error
+		})
+	}
 
 	if stage == repb.ExecutionStage_COMPLETED {
 		if err := s.recordExecution(ctx, executionID); err != nil {

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -316,6 +316,7 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 
 	var dbErr error
 	var existing tables.Execution
+	// TODO(zoey): This select seems unnecessary, should revisit it
 	if err := s.env.GetDBHandle().GORM(ctx, "execution_server_get_execution_for_update").Where(
 		"execution_id = ?", executionID).First(&existing).Error; err != nil {
 		dbErr = err

--- a/enterprise/server/telemetry/telemetry_server.go
+++ b/enterprise/server/telemetry/telemetry_server.go
@@ -85,19 +85,16 @@ func (t *TelemetryServer) LogTelemetry(ctx context.Context, req *telpb.LogTeleme
 }
 
 func (t *TelemetryServer) insertLogIfNotExists(ctx context.Context, telemetryLog *tables.TelemetryLog) error {
-	return t.h.Transaction(ctx, func(tx interfaces.DB) error {
-		var existing tables.TelemetryLog
-		err := tx.GORM(ctx, "telemetry_server_get_existing_log").Where(
-			"installation_uuid = ? AND instance_uuid = ? AND telemetry_log_uuid = ?",
-			telemetryLog.InstallationUUID, telemetryLog.InstanceUUID, telemetryLog.TelemetryLogUUID).First(&existing).Error
-		if err == nil {
-			return nil
-		}
-		if db.IsRecordNotFound(err) {
+	var existing tables.TelemetryLog
+	err := t.h.GORM(ctx, "telemetry_server_get_existing_log").Where(
+		"installation_uuid = ? AND instance_uuid = ? AND telemetry_log_uuid = ?",
+		telemetryLog.InstallationUUID, telemetryLog.InstanceUUID, telemetryLog.TelemetryLogUUID).First(&existing).Error
+	if db.IsRecordNotFound(err) {
+		return t.h.Transaction(ctx, func(tx interfaces.DB) error {
 			return tx.NewQuery(ctx, "telemetry_server_create_log").Create(telemetryLog)
-		}
-		return err
-	})
+		})
+	}
+	return err
 }
 
 func recordFromLogProto(logProto *telpb.TelemetryLog) *tables.TelemetryLog {

--- a/enterprise/server/telemetry/telemetry_server.go
+++ b/enterprise/server/telemetry/telemetry_server.go
@@ -86,6 +86,7 @@ func (t *TelemetryServer) LogTelemetry(ctx context.Context, req *telpb.LogTeleme
 
 func (t *TelemetryServer) insertLogIfNotExists(ctx context.Context, telemetryLog *tables.TelemetryLog) error {
 	var existing tables.TelemetryLog
+	// TODO(zoey): this can be done in one query with an insert that does nothing on conflict
 	err := t.h.GORM(ctx, "telemetry_server_get_existing_log").Where(
 		"installation_uuid = ? AND instance_uuid = ? AND telemetry_log_uuid = ?",
 		telemetryLog.InstallationUUID, telemetryLog.InstanceUUID, telemetryLog.TelemetryLogUUID).First(&existing).Error

--- a/server/backends/invocationdb/invocationdb.go
+++ b/server/backends/invocationdb/invocationdb.go
@@ -131,24 +131,24 @@ func (d *InvocationDB) UpdateInvocationACL(ctx context.Context, authenticatedUse
 	if err != nil {
 		return err
 	}
-	return d.h.Transaction(ctx, func(tx interfaces.DB) error {
-		var in tables.Invocation
-		if err := tx.NewQuery(ctx, "invocationdb_get_invocation_for_update_acl").Raw(
-			`SELECT user_id, group_id, perms FROM "Invocations" WHERE invocation_id = ?`, invocationID).Take(&in); err != nil {
-			return err
-		}
-		var group tables.Group
-		if err := tx.NewQuery(ctx, "invocationdb_get_group_for_update_acl").Raw(
-			`SELECT sharing_enabled FROM "Groups" WHERE group_id = ?`, in.GroupID).Take(&group); err != nil {
-			return err
-		}
-		if !group.SharingEnabled {
-			return status.PermissionDeniedError("Your organization does not allow this action.")
-		}
+	var in tables.Invocation
+	if err := d.h.NewQuery(ctx, "invocationdb_get_invocation_for_update_acl").Raw(
+		`SELECT user_id, group_id, perms FROM "Invocations" WHERE invocation_id = ?`, invocationID).Take(&in); err != nil {
+		return err
+	}
+	var group tables.Group
+	if err := d.h.NewQuery(ctx, "invocationdb_get_group_for_update_acl").Raw(
+		`SELECT sharing_enabled FROM "Groups" WHERE group_id = ?`, in.GroupID).Take(&group); err != nil {
+		return err
+	}
+	if !group.SharingEnabled {
+		return status.PermissionDeniedError("Your organization does not allow this action.")
+	}
 
-		if err := perms.AuthorizeWrite(authenticatedUser, getACL(&in)); err != nil {
-			return err
-		}
+	if err := perms.AuthorizeWrite(authenticatedUser, getACL(&in)); err != nil {
+		return err
+	}
+	return d.h.Transaction(ctx, func(tx interfaces.DB) error {
 		if err := tx.NewQuery(ctx, "invocationdb_update_invocation_acl").Raw(
 			`UPDATE "Invocations" SET perms = ? WHERE invocation_id = ?`, p, invocationID).Exec().Error; err != nil {
 			return err
@@ -238,16 +238,16 @@ func (d *InvocationDB) DeleteInvocation(ctx context.Context, invocationID string
 }
 
 func (d *InvocationDB) DeleteInvocationWithPermsCheck(ctx context.Context, authenticatedUser *interfaces.UserInfo, invocationID string) error {
+	var in tables.Invocation
+	if err := d.h.NewQuery(ctx, "invocationdb_get_invocation_for_delete").Raw(
+		`SELECT user_id, group_id, perms FROM "Invocations" WHERE invocation_id = ?`, invocationID).Take(&in); err != nil {
+		return err
+	}
+	acl := perms.ToACLProto(&uidpb.UserId{Id: in.UserID}, in.GroupID, in.Perms)
+	if err := perms.AuthorizeWrite(authenticatedUser, acl); err != nil {
+		return err
+	}
 	return d.h.Transaction(ctx, func(tx interfaces.DB) error {
-		var in tables.Invocation
-		if err := tx.NewQuery(ctx, "invocationdb_get_invocation_for_delete").Raw(
-			`SELECT user_id, group_id, perms FROM "Invocations" WHERE invocation_id = ?`, invocationID).Take(&in); err != nil {
-			return err
-		}
-		acl := perms.ToACLProto(&uidpb.UserId{Id: in.UserID}, in.GroupID, in.Perms)
-		if err := perms.AuthorizeWrite(authenticatedUser, acl); err != nil {
-			return err
-		}
 		return d.deleteInvocation(ctx, tx, invocationID)
 	})
 }

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -496,6 +496,7 @@ func updateTargets(ctx context.Context, env environment.Env, targets []*tables.T
 		return status.FailedPreconditionError("database not configured")
 	}
 	for _, t := range targets {
+		// TODO(zoey): Could make this one query
 		var existing tables.Target
 		if err := env.GetDBHandle().GORM(ctx, "target_tracker_get_target").Where(
 			"target_id = ?", t.TargetID).First(&existing).Error; err != nil {

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -496,12 +496,12 @@ func updateTargets(ctx context.Context, env environment.Env, targets []*tables.T
 		return status.FailedPreconditionError("database not configured")
 	}
 	for _, t := range targets {
+		var existing tables.Target
+		if err := env.GetDBHandle().GORM(ctx, "target_tracker_get_target").Where(
+			"target_id = ?", t.TargetID).First(&existing).Error; err != nil {
+			return err
+		}
 		err := env.GetDBHandle().Transaction(ctx, func(tx interfaces.DB) error {
-			var existing tables.Target
-			if err := tx.GORM(ctx, "target_tracker_get_target").Where(
-				"target_id = ?", t.TargetID).First(&existing).Error; err != nil {
-				return err
-			}
 			return tx.GORM(ctx, "target_tracker_update_target").Model(&existing).Where(
 				"target_id = ?", t.TargetID).Updates(t).Error
 		})


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

Non-locking reads have no effects to rollback and do not lock rows for future queries, and thus are superfluous to include at the beginning of a transaction.

This reduces some transactions to single queries, which means those transactions can be removed in a future PR, but that is outside of the scope of this PR.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
