### PR TITLE
remove transactions surrounding single queries

### DIFF
--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -341,36 +341,35 @@ func (d *UserDB) InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (stri
 		return "", err
 	}
 
-	err = d.h.Transaction(ctx, func(tx interfaces.DB) error {
-		return tx.NewQuery(ctx, "userdb_update_group").Raw(`
-			UPDATE "Groups" SET
-				name = ?,
-				url_identifier = ?,
-				owned_domain = ?,
-				sharing_enabled = ?,
-				user_owned_keys_enabled = ?,
-				bot_suggestions_enabled = ?,
-				developer_org_creation_enabled = ?,
-				use_group_owned_executors = ?,
-				cache_encryption_enabled = ?,
-				suggestion_preference = ?,
-				restrict_clean_workflow_runs_to_admins = ?,
-				enforce_ip_rules = ?
-			WHERE group_id = ?`,
-			g.Name,
-			g.URLIdentifier,
-			g.OwnedDomain,
-			g.SharingEnabled,
-			g.UserOwnedKeysEnabled,
-			g.BotSuggestionsEnabled,
-			g.DeveloperOrgCreationEnabled,
-			g.UseGroupOwnedExecutors,
-			g.CacheEncryptionEnabled,
-			g.SuggestionPreference,
-			g.RestrictCleanWorkflowRunsToAdmins,
-			g.EnforceIPRules,
-			g.GroupID).Exec().Error
-	})
+	err = d.h.NewQuery(ctx, "userdb_update_group").Raw(`
+		UPDATE "Groups" SET
+			name = ?,
+			url_identifier = ?,
+			owned_domain = ?,
+			sharing_enabled = ?,
+			user_owned_keys_enabled = ?,
+			bot_suggestions_enabled = ?,
+			developer_org_creation_enabled = ?,
+			use_group_owned_executors = ?,
+			cache_encryption_enabled = ?,
+			suggestion_preference = ?,
+			restrict_clean_workflow_runs_to_admins = ?,
+			enforce_ip_rules = ?
+		WHERE group_id = ?`,
+		g.Name,
+		g.URLIdentifier,
+		g.OwnedDomain,
+		g.SharingEnabled,
+		g.UserOwnedKeysEnabled,
+		g.BotSuggestionsEnabled,
+		g.DeveloperOrgCreationEnabled,
+		g.UseGroupOwnedExecutors,
+		g.CacheEncryptionEnabled,
+		g.SuggestionPreference,
+		g.RestrictCleanWorkflowRunsToAdmins,
+		g.EnforceIPRules,
+		g.GroupID,
+	).Exec().Error
 	if err != nil {
 		return "", err
 	}
@@ -666,9 +665,7 @@ func (d *UserDB) CreateDefaultGroup(ctx context.Context) error {
 		return err
 	}
 
-	return d.h.Transaction(ctx, func(tx interfaces.DB) error {
-		return tx.GORM(ctx, "userdb_update_existing_group").Model(&tables.Group{}).Where("group_id = ?", DefaultGroupID).Updates(d.getDefaultGroupConfig()).Error
-	})
+	return d.h.GORM(ctx, "userdb_update_existing_group").Model(&tables.Group{}).Where("group_id = ?", DefaultGroupID).Updates(d.getDefaultGroupConfig()).Error
 }
 
 func (d *UserDB) getDefaultGroupConfig() *tables.Group {

--- a/enterprise/server/telemetry/telemetry_server.go
+++ b/enterprise/server/telemetry/telemetry_server.go
@@ -91,9 +91,7 @@ func (t *TelemetryServer) insertLogIfNotExists(ctx context.Context, telemetryLog
 		"installation_uuid = ? AND instance_uuid = ? AND telemetry_log_uuid = ?",
 		telemetryLog.InstallationUUID, telemetryLog.InstanceUUID, telemetryLog.TelemetryLogUUID).First(&existing).Error
 	if db.IsRecordNotFound(err) {
-		return t.h.Transaction(ctx, func(tx interfaces.DB) error {
-			return tx.NewQuery(ctx, "telemetry_server_create_log").Create(telemetryLog)
-		})
+		return t.h.NewQuery(ctx, "telemetry_server_create_log").Create(telemetryLog)
 	}
 	return err
 }

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -316,27 +316,25 @@ func (ws *workflowService) CreateWorkflow(ctx context.Context, req *wfpb.CreateW
 	}
 	rsp.WebhookRegistered = (providerWebhookID != "")
 
-	err = ws.env.GetDBHandle().Transaction(ctx, func(tx interfaces.DB) error {
-		workflowID, err := tables.PrimaryKeyForTable("Workflows")
-		if err != nil {
-			return status.InternalError(err.Error())
-		}
-		rsp.Id = workflowID
-		rsp.WebhookUrl = webhookURL
-		wf := &tables.Workflow{
-			WorkflowID:           workflowID,
-			UserID:               permissions.UserID,
-			GroupID:              permissions.GroupID,
-			Perms:                permissions.Perms,
-			Name:                 req.GetName(),
-			RepoURL:              repoURL,
-			Username:             username,
-			AccessToken:          accessToken,
-			WebhookID:            webhookID,
-			GitProviderWebhookID: providerWebhookID,
-		}
-		return tx.NewQuery(ctx, "workflow_service_insert_workflow").Create(wf)
-	})
+	workflowID, err := tables.PrimaryKeyForTable("Workflows")
+	if err != nil {
+		return nil, status.InternalError(err.Error())
+	}
+	rsp.Id = workflowID
+	rsp.WebhookUrl = webhookURL
+	wf := &tables.Workflow{
+		WorkflowID:           workflowID,
+		UserID:               permissions.UserID,
+		GroupID:              permissions.GroupID,
+		Perms:                permissions.Perms,
+		Name:                 req.GetName(),
+		RepoURL:              repoURL,
+		Username:             username,
+		AccessToken:          accessToken,
+		WebhookID:            webhookID,
+		GitProviderWebhookID: providerWebhookID,
+	}
+	err = ws.env.GetDBHandle().NewQuery(ctx, "workflow_service_insert_workflow").Create(wf)
 	if err != nil {
 		return nil, err
 	}

--- a/server/backends/invocationdb/invocationdb.go
+++ b/server/backends/invocationdb/invocationdb.go
@@ -111,12 +111,10 @@ func (d *InvocationDB) UpdateInvocation(ctx context.Context, ti *tables.Invocati
 	updated := false
 	var err error
 	for r := retry.DefaultWithContext(ctx); r.Next(); {
-		err = d.h.Transaction(ctx, func(tx interfaces.DB) error {
-			result := tx.GORM(ctx, "invocationdb_update_invocation").Where(
-				"invocation_id = ? AND attempt = ?", ti.InvocationID, ti.Attempt).Updates(ti)
-			updated = result.RowsAffected > 0
-			return result.Error
-		})
+		result := d.h.GORM(ctx, "invocationdb_update_invocation").Where(
+			"invocation_id = ? AND attempt = ?", ti.InvocationID, ti.Attempt).Updates(ti)
+		updated = result.RowsAffected > 0
+		err := result.Error
 		if d.h.IsDeadlockError(err) {
 			log.Warningf("Encountered deadlock when attempting to update invocation table for invocation %s, attempt %d of %d", ti.InvocationID, r.AttemptNumber(), r.MaxAttempts())
 			continue

--- a/server/build_event_protocol/target_tracker/BUILD
+++ b/server/build_event_protocol/target_tracker/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//proto/api/v1:common_go_proto",
         "//server/build_event_protocol/accumulator",
         "//server/environment",
-        "//server/interfaces",
         "//server/tables",
         "//server/util/background",
         "//server/util/clickhouse/schema",

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -12,7 +12,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	"github.com/buildbuddy-io/buildbuddy/server/build_event_protocol/accumulator"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
-	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/background"
 	"github.com/buildbuddy-io/buildbuddy/server/util/clickhouse/schema"
@@ -502,10 +501,8 @@ func updateTargets(ctx context.Context, env environment.Env, targets []*tables.T
 			"target_id = ?", t.TargetID).First(&existing).Error; err != nil {
 			return err
 		}
-		err := env.GetDBHandle().Transaction(ctx, func(tx interfaces.DB) error {
-			return tx.GORM(ctx, "target_tracker_update_target").Model(&existing).Where(
-				"target_id = ?", t.TargetID).Updates(t).Error
-		})
+		err := env.GetDBHandle().GORM(ctx, "target_tracker_update_target").Model(&existing).Where(
+			"target_id = ?", t.TargetID).Updates(t).Error
 		if err != nil {
 			return err
 		}
@@ -534,10 +531,8 @@ func insertTargets(ctx context.Context, env environment.Env, targets []*tables.T
 			valueArgs = append(valueArgs, nowUsec)
 			valueArgs = append(valueArgs, nowUsec)
 		}
-		err := env.GetDBHandle().Transaction(ctx, func(tx interfaces.DB) error {
-			stmt := fmt.Sprintf(`INSERT INTO "Targets" (repo_url, target_id, user_id, group_id, perms, label, rule_type, created_at_usec, updated_at_usec) VALUES %s`, strings.Join(valueStrings, ","))
-			return tx.NewQuery(ctx, "target_tracker_insert_targets").Raw(stmt, valueArgs...).Exec().Error
-		})
+		stmt := fmt.Sprintf(`INSERT INTO "Targets" (repo_url, target_id, user_id, group_id, perms, label, rule_type, created_at_usec, updated_at_usec) VALUES %s`, strings.Join(valueStrings, ","))
+		err := env.GetDBHandle().NewQuery(ctx, "target_tracker_insert_targets").Raw(stmt, valueArgs...).Exec().Error
 		if err != nil {
 			return err
 		}
@@ -576,10 +571,8 @@ func insertOrUpdateTargetStatuses(ctx context.Context, env environment.Env, stat
 			valueArgs = append(valueArgs, nowUsec)
 			valueArgs = append(valueArgs, nowUsec)
 		}
-		err := env.GetDBHandle().Transaction(ctx, func(tx interfaces.DB) error {
-			stmt := fmt.Sprintf(`INSERT INTO "TargetStatuses" (target_id, invocation_uuid, target_type, test_size, status, start_time_usec, duration_usec, created_at_usec, updated_at_usec) VALUES %s`, strings.Join(valueStrings, ","))
-			return tx.NewQuery(ctx, "target_tracker_insert_target_statuses").Raw(stmt, valueArgs...).Exec().Error
-		})
+		stmt := fmt.Sprintf(`INSERT INTO "TargetStatuses" (target_id, invocation_uuid, target_type, test_size, status, start_time_usec, duration_usec, created_at_usec, updated_at_usec) VALUES %s`, strings.Join(valueStrings, ","))
+		err := env.GetDBHandle().NewQuery(ctx, "target_tracker_insert_target_statuses").Raw(stmt, valueArgs...).Exec().Error
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

If a single query fails, it does not need to be rolled back, so there is no reason to surround it with a transaction.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
