### PR TITLE
Make action-merging more resilient to dying apps/executors

### DIFF
--- a/enterprise/server/remote_execution/action_merger/BUILD
+++ b/enterprise/server/remote_execution/action_merger/BUILD
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "action_merger",
+    srcs = ["action_merger.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/action_merger",
+    deps = [
+        "//server/interfaces",
+        "//server/remote_cache/digest",
+        "//server/util/log",
+        "//server/util/prefix",
+        "@com_github_go_redis_redis_v8//:redis",
+    ],
+)

--- a/enterprise/server/remote_execution/action_merger/action_merger.go
+++ b/enterprise/server/remote_execution/action_merger/action_merger.go
@@ -14,10 +14,13 @@ import (
 )
 
 const (
-	// TTL for keys used to track pending executions for action merging.
-	// TODO(iain): change these values
-	queuedExecutionTTL  = 1 * time.Hour
-	claimedExecutionTTL = 1 * time.Minute
+	// TTL for action-merging data about queued executions.
+	queuedExecutionTTL = 1 * time.Hour
+
+	// TTL for action-merging data about claimed executions. This is set to
+	// twice the length of `remote_execution.lease_duration` to give a short
+	// grace period in the event of missed leases.
+	claimedExecutionTTL = 20 * time.Second
 )
 
 var (
@@ -40,7 +43,22 @@ func redisKeyForPendingExecutionDigest(executionID string) string {
 	return fmt.Sprintf("pendingExecutionDigest/%s", executionID)
 }
 
-// TODO(iain): comment
+// Action merging is an optimization that detects when an execution is
+// requested for an action that is in-flight, but not yet in the action cache.
+// This optimization is particularly helpful for preventing duplicate work for
+// long-running actions. It is implemented as a pair of entries in redis, one
+// from the action digest to the execution ID (the forward mapping), and one
+// from the execution ID to the action digest (the reverse mapping). These two
+// entries are added to Redis at different times, the reverse entry is added
+// when an execution is enqueued and has no effect, it is just there so the app
+// can determine the action digest for an execution ID later. The forward entry
+// is added when an execution is claimed, and subsequent actions will be merged
+// against this execution once this entry is present. While this two-phase
+// approach creates a window (during queueing) during which duplicate actions
+// can run concurrently, it is necessary to prevent actions which are queued
+// but never run from blocking subsequent actions.
+//
+// This function records a queued execution in Redis.
 func RecordQueuedExecution(ctx context.Context, rdb redis.UniversalClient, executionID string, adResource *digest.ResourceName) error {
 	if !*enableActionMerging {
 		return nil
@@ -51,44 +69,17 @@ func RecordQueuedExecution(ctx context.Context, rdb redis.UniversalClient, execu
 		return err
 	}
 	reverseKey := redisKeyForPendingExecutionDigest(executionID)
-	// TODO(iain): do we still need to use txpipeline here and below?
-	pipe := rdb.TxPipeline()
-	//pipe.Set(ctx, forwardKey, executionID, pendingExecutionTTL)
-	log.Debugf("Recording queued execution %s ==> %s", reverseKey, forwardKey)
-	pipe.Set(ctx, reverseKey, forwardKey, queuedExecutionTTL)
-	_, err = pipe.Exec(ctx)
-	return err
+	return rdb.Set(ctx, reverseKey, forwardKey, queuedExecutionTTL).Err()
 }
 
-// TODO(iain): comment
+// This function records a claimed execution in Redis.
 func RecordClaimedExecution(ctx context.Context, rdb redis.UniversalClient, executionID string) error {
 	if !*enableActionMerging {
 		return nil
 	}
 
-	reverseKey := redisKeyForPendingExecutionDigest(executionID)
-	forwardKey, err := rdb.Get(ctx, reverseKey).Result()
-	if err == redis.Nil {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-
-	pipe := rdb.TxPipeline()
-	log.Debugf("Recording claimed execution %s ==> %s", forwardKey, executionID)
-	pipe.Set(ctx, forwardKey, executionID, claimedExecutionTTL)
-	pipe.Set(ctx, reverseKey, forwardKey, claimedExecutionTTL)
-	_, err = pipe.Exec(ctx)
-	return err
-}
-
-// TODO(iain): comment
-func ExtendLeasedExecution(ctx context.Context, rdb redis.UniversalClient, executionID string) error {
-	if !*enableActionMerging {
-		return nil
-	}
-
+	// Use the execution ID to lookup the action digest and insert the forward
+	// entry (from action digest to execution ID).
 	reverseKey := redisKeyForPendingExecutionDigest(executionID)
 	forwardKey, err := rdb.Get(ctx, reverseKey).Result()
 	if err == redis.Nil {
@@ -105,7 +96,9 @@ func ExtendLeasedExecution(ctx context.Context, rdb redis.UniversalClient, execu
 	return err
 }
 
-// TODO(iain): comment
+// Returns the execution ID of a pending execution working on the action with
+// the provided action digest, or an empty string and possibly an error if no
+// pending execution was found.
 func FindPendingExecution(ctx context.Context, rdb redis.UniversalClient, schedulerService interfaces.SchedulerService, adResource *digest.ResourceName) (string, error) {
 	if !*enableActionMerging {
 		return "", nil
@@ -147,7 +140,7 @@ func FindPendingExecution(ctx context.Context, rdb redis.UniversalClient, schedu
 	return executionID, nil
 }
 
-// TODO(iain): comment
+// Deletes the pending execution with the provided execution ID.
 func DeletePendingExecution(ctx context.Context, rdb redis.UniversalClient, executionID string) error {
 	if !*enableActionMerging {
 		return nil

--- a/enterprise/server/remote_execution/action_merger/action_merger.go
+++ b/enterprise/server/remote_execution/action_merger/action_merger.go
@@ -1,0 +1,171 @@
+package action_merger
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
+	"github.com/go-redis/redis/v8"
+)
+
+const (
+	// TTL for keys used to track pending executions for action merging.
+	// TODO(iain): change these values
+	queuedExecutionTTL  = 1 * time.Hour
+	claimedExecutionTTL = 1 * time.Minute
+)
+
+var (
+	enableActionMerging = flag.Bool("remote_execution.enable_action_merging", true, "If enabled, identical actions being executed concurrently are merged into a single execution.")
+)
+
+func redisKeyForPendingExecutionID(ctx context.Context, adResource *digest.ResourceName) (string, error) {
+	userPrefix, err := prefix.UserPrefixFromContext(ctx)
+	if err != nil {
+		return "", err
+	}
+	downloadString, err := adResource.DownloadString()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("pendingExecution/%s%s", userPrefix, downloadString), nil
+}
+
+func redisKeyForPendingExecutionDigest(executionID string) string {
+	return fmt.Sprintf("pendingExecutionDigest/%s", executionID)
+}
+
+// TODO(iain): comment
+func RecordQueuedExecution(ctx context.Context, rdb redis.UniversalClient, executionID string, adResource *digest.ResourceName) error {
+	if !*enableActionMerging {
+		return nil
+	}
+
+	forwardKey, err := redisKeyForPendingExecutionID(ctx, adResource)
+	if err != nil {
+		return err
+	}
+	reverseKey := redisKeyForPendingExecutionDigest(executionID)
+	// TODO(iain): do we still need to use txpipeline here and below?
+	pipe := rdb.TxPipeline()
+	//pipe.Set(ctx, forwardKey, executionID, pendingExecutionTTL)
+	log.Debugf("Recording queued execution %s ==> %s", reverseKey, forwardKey)
+	pipe.Set(ctx, reverseKey, forwardKey, queuedExecutionTTL)
+	_, err = pipe.Exec(ctx)
+	return err
+}
+
+// TODO(iain): comment
+func RecordClaimedExecution(ctx context.Context, rdb redis.UniversalClient, executionID string) error {
+	if !*enableActionMerging {
+		return nil
+	}
+
+	reverseKey := redisKeyForPendingExecutionDigest(executionID)
+	forwardKey, err := rdb.Get(ctx, reverseKey).Result()
+	if err == redis.Nil {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	pipe := rdb.TxPipeline()
+	log.Debugf("Recording claimed execution %s ==> %s", forwardKey, executionID)
+	pipe.Set(ctx, forwardKey, executionID, claimedExecutionTTL)
+	pipe.Set(ctx, reverseKey, forwardKey, claimedExecutionTTL)
+	_, err = pipe.Exec(ctx)
+	return err
+}
+
+// TODO(iain): comment
+func ExtendLeasedExecution(ctx context.Context, rdb redis.UniversalClient, executionID string) error {
+	if !*enableActionMerging {
+		return nil
+	}
+
+	reverseKey := redisKeyForPendingExecutionDigest(executionID)
+	forwardKey, err := rdb.Get(ctx, reverseKey).Result()
+	if err == redis.Nil {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	pipe := rdb.TxPipeline()
+	pipe.Set(ctx, forwardKey, executionID, claimedExecutionTTL)
+	pipe.Set(ctx, reverseKey, forwardKey, claimedExecutionTTL)
+	_, err = pipe.Exec(ctx)
+	return err
+}
+
+// TODO(iain): comment
+func FindPendingExecution(ctx context.Context, rdb redis.UniversalClient, schedulerService interfaces.SchedulerService, adResource *digest.ResourceName) (string, error) {
+	if !*enableActionMerging {
+		return "", nil
+	}
+
+	executionIDKey, err := redisKeyForPendingExecutionID(ctx, adResource)
+	if err != nil {
+		return "", err
+	}
+	executionID, err := rdb.Get(ctx, executionIDKey).Result()
+	if err == redis.Nil {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	// Validate that the reverse mapping exists as well. The reverse mapping is
+	// used to delete the pending task information when the task is done.
+	// Bail out if it doesn't exist.
+	err = rdb.Get(ctx, redisKeyForPendingExecutionDigest(executionID)).Err()
+	if err == redis.Nil {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	// Finally, confirm this execution exists in the scheduler and hasn't been
+	// lost somehow.
+	ok, err := schedulerService.ExistsTask(ctx, executionID)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		log.CtxWarningf(ctx, "Pending execution %q does not exist in the scheduler", executionID)
+		return "", nil
+	}
+	return executionID, nil
+}
+
+// TODO(iain): comment
+func DeletePendingExecution(ctx context.Context, rdb redis.UniversalClient, executionID string) error {
+	if !*enableActionMerging {
+		return nil
+	}
+
+	pendingExecutionDigestKey := redisKeyForPendingExecutionDigest(executionID)
+	pendingExecutionKey, err := rdb.Get(ctx, pendingExecutionDigestKey).Result()
+	if err == redis.Nil {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := rdb.Del(ctx, pendingExecutionKey).Err(); err != nil {
+		log.CtxWarningf(ctx, "could not delete pending execution key %q: %s", pendingExecutionKey, err)
+	}
+	if err := rdb.Del(ctx, pendingExecutionDigestKey).Err(); err != nil {
+		log.CtxWarningf(ctx, "could not delete pending execution digest key %q: %s", pendingExecutionDigestKey, err)
+	}
+	return nil
+}

--- a/enterprise/server/remote_execution/execution_server/BUILD
+++ b/enterprise/server/remote_execution/execution_server/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//enterprise/server/backends/pubsub",
         "//enterprise/server/gcplink",
+        "//enterprise/server/remote_execution/action_merger",
         "//enterprise/server/remote_execution/operation",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/tasksize",

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -544,7 +544,7 @@ func (s *ExecutionServer) Dispatch(ctx context.Context, req *repb.ExecuteRequest
 	}
 
 	if err := action_merger.RecordQueuedExecution(ctx, s.rdb, executionID, r); err != nil {
-		log.CtxWarningf(ctx, "could not recording pending execution %q: %s", executionID, err)
+		log.CtxWarningf(ctx, "could not record queued pending execution %q: %s", executionID, err)
 	}
 
 	if _, err := scheduler.ScheduleTask(ctx, scheduleReq); err != nil {

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pubsub"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/gcplink"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/action_merger"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/operation"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/tasksize"
@@ -51,8 +52,6 @@ import (
 )
 
 const (
-	// TTL for keys used to track pending executions for action merging.
-	pendingExecutionTTL    = 8 * time.Hour
 	updateExecutionTimeout = 15 * time.Second
 
 	// When an action finishes, schedule the corresponding pubsub channel to
@@ -63,7 +62,6 @@ const (
 
 var (
 	enableRedisAvailabilityMonitoring = flag.Bool("remote_execution.enable_redis_availability_monitoring", false, "If enabled, the execution server will detect if Redis has lost state and will ask Bazel to retry executions.")
-	enableActionMerging               = flag.Bool("remote_execution.enable_action_merging", true, "If enabled, identical actions being executed concurrently are merged into a single execution.")
 )
 
 func fillExecutionFromActionMetadata(md *repb.ExecutedActionMetadata, execution *tables.Execution) {
@@ -118,22 +116,6 @@ func redisKeyForMonitoredTaskStatusStream(taskID string) string {
 	// We choose taskID as the hash input for Redis sharding so that both the PubSub streams and task information for
 	// a single task is placed on the same shard.
 	return fmt.Sprintf("taskStatusStream/{%s}", taskID)
-}
-
-func redisKeyForPendingExecutionID(ctx context.Context, adResource *digest.ResourceName) (string, error) {
-	userPrefix, err := prefix.UserPrefixFromContext(ctx)
-	if err != nil {
-		return "", err
-	}
-	downloadString, err := adResource.DownloadString()
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("pendingExecution/%s%s", userPrefix, downloadString), nil
-}
-
-func redisKeyForPendingExecutionDigest(executionID string) string {
-	return fmt.Sprintf("pendingExecutionDigest/%s", executionID)
 }
 
 type ExecutionServer struct {
@@ -304,8 +286,8 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 		}
 	}
 
-	if *enableActionMerging && stage == repb.ExecutionStage_COMPLETED {
-		if err := s.deletePendingExecution(ctx, executionID); err != nil {
+	if stage == repb.ExecutionStage_COMPLETED {
+		if err := action_merger.DeletePendingExecution(ctx, s.rdb, executionID); err != nil {
 			log.CtxWarningf(ctx, "could not delete pending execution %q: %s", executionID, err)
 		}
 	}
@@ -561,85 +543,18 @@ func (s *ExecutionServer) Dispatch(ctx context.Context, req *repb.ExecuteRequest
 		SerializedTask: serializedTask,
 	}
 
-	if err := s.recordPendingExecution(ctx, executionID, r); err != nil {
+	if err := action_merger.RecordQueuedExecution(ctx, s.rdb, executionID, r); err != nil {
 		log.CtxWarningf(ctx, "could not recording pending execution %q: %s", executionID, err)
 	}
 
 	if _, err := scheduler.ScheduleTask(ctx, scheduleReq); err != nil {
 		ctx, cancel := background.ExtendContextForFinalization(ctx, 10*time.Second)
 		defer cancel()
-		_ = s.deletePendingExecution(ctx, executionID)
+		_ = action_merger.DeletePendingExecution(ctx, s.rdb, executionID)
 		return "", status.UnavailableErrorf("Error scheduling execution task %q: %s", executionID, err)
 	}
 
 	return executionID, nil
-}
-
-// findExistingExecution looks for an identical action that is already pending
-// execution.
-func (s *ExecutionServer) findPendingExecution(ctx context.Context, adResource *digest.ResourceName) (string, error) {
-	executionIDKey, err := redisKeyForPendingExecutionID(ctx, adResource)
-	if err != nil {
-		return "", err
-	}
-	executionID, err := s.rdb.Get(ctx, executionIDKey).Result()
-	if err == redis.Nil {
-		return "", nil
-	}
-	if err != nil {
-		return "", err
-	}
-
-	// Validate that the reverse mapping exists as well. The reverse mapping is
-	// used to delete the pending task information when the task is done.
-	// Bail out if it doesn't exist.
-	err = s.rdb.Get(ctx, redisKeyForPendingExecutionDigest(executionID)).Err()
-	if err == redis.Nil {
-		return "", nil
-	}
-	if err != nil {
-		return "", err
-	}
-	ok, err := s.env.GetSchedulerService().ExistsTask(ctx, executionID)
-	if err != nil {
-		return "", err
-	}
-	if !ok {
-		log.CtxWarningf(ctx, "Pending execution %q does not exist in the scheduler", executionID)
-		return "", nil
-	}
-	return executionID, nil
-}
-
-func (s *ExecutionServer) recordPendingExecution(ctx context.Context, executionID string, adResource *digest.ResourceName) error {
-	forwardKey, err := redisKeyForPendingExecutionID(ctx, adResource)
-	if err != nil {
-		return err
-	}
-	reverseKey := redisKeyForPendingExecutionDigest(executionID)
-	pipe := s.rdb.TxPipeline()
-	pipe.Set(ctx, forwardKey, executionID, pendingExecutionTTL)
-	pipe.Set(ctx, reverseKey, forwardKey, pendingExecutionTTL)
-	_, err = pipe.Exec(ctx)
-	return err
-}
-
-func (s *ExecutionServer) deletePendingExecution(ctx context.Context, executionID string) error {
-	pendingExecutionDigestKey := redisKeyForPendingExecutionDigest(executionID)
-	pendingExecutionKey, err := s.rdb.Get(ctx, pendingExecutionDigestKey).Result()
-	if err == redis.Nil {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	if err := s.rdb.Del(ctx, pendingExecutionKey).Err(); err != nil {
-		log.CtxWarningf(ctx, "could not delete pending execution key %q: %s", pendingExecutionKey, err)
-	}
-	if err := s.rdb.Del(ctx, pendingExecutionDigestKey).Err(); err != nil {
-		log.CtxWarningf(ctx, "could not delete pending execution digest key %q: %s", pendingExecutionDigestKey, err)
-	}
-	return nil
 }
 
 func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) error {
@@ -672,24 +587,22 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 			return nil
 		}
 
-		if *enableActionMerging {
-			// Check if there's already an identical action pending execution.
-			// If so wait on the result of that execution instead of starting a new
-			// one.
-			ee, err := s.findPendingExecution(ctx, adInstanceDigest)
-			if err != nil {
-				log.CtxWarningf(ctx, "could not check for existing execution: %s", err)
-			}
-			if ee != "" {
-				ctx = log.EnrichContext(ctx, log.ExecutionIDKey, ee)
-				log.CtxInfof(ctx, "Reusing execution %q for execution request %q for invocation %q", ee, downloadString, invocationID)
-				executionID = ee
-				tracing.AddStringAttributeToCurrentSpan(ctx, "execution_result", "merged")
-				tracing.AddStringAttributeToCurrentSpan(ctx, "execution_id", executionID)
-				metrics.RemoteExecutionMergedActions.With(prometheus.Labels{metrics.GroupID: s.getGroupIDForMetrics(ctx)}).Inc()
-				if err := s.insertInvocationLink(ctx, ee, invocationID, sipb.StoredInvocationLink_MERGED); err != nil {
-					return err
-				}
+		// Check if there's already an identical action pending execution. If
+		// so, wait on the result of that execution instead of starting a new
+		// one.
+		ee, err := action_merger.FindPendingExecution(ctx, s.rdb, s.env.GetSchedulerService(), adInstanceDigest)
+		if err != nil {
+			log.CtxWarningf(ctx, "could not check for existing execution: %s", err)
+		}
+		if ee != "" {
+			ctx = log.EnrichContext(ctx, log.ExecutionIDKey, ee)
+			log.CtxInfof(ctx, "Reusing execution %q for execution request %q for invocation %q", ee, downloadString, invocationID)
+			executionID = ee
+			tracing.AddStringAttributeToCurrentSpan(ctx, "execution_result", "merged")
+			tracing.AddStringAttributeToCurrentSpan(ctx, "execution_id", executionID)
+			metrics.RemoteExecutionMergedActions.With(prometheus.Labels{metrics.GroupID: s.getGroupIDForMetrics(ctx)}).Inc()
+			if err := s.insertInvocationLink(ctx, ee, invocationID, sipb.StoredInvocationLink_MERGED); err != nil {
+				return err
 			}
 		}
 	}

--- a/enterprise/server/scheduling/scheduler_server/BUILD
+++ b/enterprise/server/scheduling/scheduler_server/BUILD
@@ -10,6 +10,7 @@ go_library(
     srcs = ["scheduler_server.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/scheduling/scheduler_server",
     deps = [
+        "//enterprise/server/remote_execution/action_merger",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/tasksize",
         "//proto:api_key_go_proto",

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -1255,8 +1255,6 @@ func (s *SchedulerServer) unclaimTask(ctx context.Context, taskID, leaseID, reco
 	}
 	log.CtxDebugf(ctx, "Released task claim in Redis (reconnecting=%t)", reconnectToken != "")
 
-	action_merger.DeletePendingExecution(ctx, s.rdb, taskID)
-
 	return nil
 }
 

--- a/enterprise/server/test/integration/remote_execution/BUILD
+++ b/enterprise/server/test/integration/remote_execution/BUILD
@@ -39,6 +39,7 @@ go_test(
         "//server/util/proto",
         "//server/util/status",
         "//server/util/testing/flags",
+        "@com_github_go_redis_redis_v8//:redis",
         "@com_github_google_uuid//:uuid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/test/integration/remote_execution/rbetest/BUILD
+++ b/enterprise/server/test/integration/remote_execution/rbetest/BUILD
@@ -61,6 +61,7 @@ go_library(
         "//server/util/status",
         "//server/util/testing/flags",
         "//server/xcode",
+        "@com_github_go_redis_redis_v8//:redis",
         "@com_github_google_uuid//:uuid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -104,8 +104,7 @@ type Env struct {
 	rbeClient                     *rbeclient.Client
 	redisTarget                   string
 	rootDataDir                   string
-	buildBuddyServers             []*BuildBuddyServer
-	buildBuddyServerTargets       []string
+	buildBuddyServers             map[*BuildBuddyServer]struct{}
 	shutdownBuildBuddyServersOnce sync.Once
 	executors                     map[string]*Executor
 	testCommandController         *testCommandController
@@ -150,7 +149,11 @@ func (r *Env) GetActionResultStorageClient() repb.ActionCacheClient {
 }
 
 func (r *Env) GetOLAPDBHandle() *testolapdb.Handle {
-	return r.buildBuddyServers[rand.Intn(len(r.buildBuddyServers))].olapDBHandle
+	servers := make([]*BuildBuddyServer, 0, len(r.buildBuddyServers))
+	for server := range r.buildBuddyServers {
+		servers = append(servers, server)
+	}
+	return servers[rand.Intn(len(servers))].olapDBHandle
 }
 
 func (r *Env) ShutdownBuildBuddyServers() {
@@ -160,7 +163,7 @@ func (r *Env) ShutdownBuildBuddyServers() {
 func (r *Env) shutdownBuildBuddyServers() {
 	log.Info("Waiting for buildbuddy servers to shutdown")
 	var wg sync.WaitGroup
-	for _, app := range r.buildBuddyServers {
+	for app := range r.buildBuddyServers {
 		app := app
 		app.env.GetHealthChecker().Shutdown()
 		wg.Add(1)
@@ -256,16 +259,17 @@ func NewRBETestEnv(t *testing.T) *Env {
 	// func below), since test cleanup funcs are run in LIFO order.
 	rootDataDir := testfs.MakeTempDir(t)
 	rbe := &Env{
-		testEnv:     testEnv,
-		t:           t,
-		redisTarget: redisTarget,
-		executors:   make(map[string]*Executor),
-		envOpts:     envOpts,
-		UserID1:     userID,
-		GroupID1:    groupID,
-		APIKey1:     key.Value,
-		rootDataDir: rootDataDir,
-		AppProxy:    testgrpc.StartProxy(t, nil /*=director*/),
+		testEnv:           testEnv,
+		t:                 t,
+		redisTarget:       redisTarget,
+		buildBuddyServers: make(map[*BuildBuddyServer]struct{}),
+		executors:         make(map[string]*Executor),
+		envOpts:           envOpts,
+		UserID1:           userID,
+		GroupID1:          groupID,
+		APIKey1:           key.Value,
+		rootDataDir:       rootDataDir,
+		AppProxy:          testgrpc.StartProxy(t),
 	}
 	rbe.testCommandController = newTestCommandController(t, testEnv)
 	rbe.rbeClient = rbeclient.New(rbe)
@@ -683,11 +687,27 @@ func (r *Env) AddBuildBuddyServerWithOptions(opts *BuildBuddyServerOptions) *Bui
 	env.SetInvocationDB(r.testEnv.GetInvocationDB())
 
 	server := newBuildBuddyServer(r.t, env, opts)
-	r.buildBuddyServers = append(r.buildBuddyServers, server)
-	r.buildBuddyServerTargets = append(r.buildBuddyServerTargets, server.GRPCAddress())
-	// Update the proxy to know about the new set of app targets.
-	r.AppProxy.Director = testgrpc.RandomDialer(r.buildBuddyServerTargets...)
+	r.buildBuddyServers[server] = struct{}{}
+	r.updateAppProxy()
 	return server
+}
+
+func (r *Env) RemoveBuildBuddyServer(server *BuildBuddyServer) {
+	server.env.GetHealthChecker().Shutdown()
+	server.env.GetHealthChecker().WaitForGracefulShutdown()
+	delete(r.buildBuddyServers, server)
+	r.updateAppProxy()
+}
+
+// Updates the app proxy to route requests to a random, running app.
+func (r *Env) updateAppProxy() {
+	targets := make([]string, 0, len(r.buildBuddyServers))
+	for server := range r.buildBuddyServers {
+		targets = append(targets, server.GRPCAddress())
+	}
+	r.AppProxy.SetDirector(testgrpc.RandomDialer(targets))
+	r.appProxyConn = r.AppProxy.Dial()
+	r.waitForExecutorRegistration()
 }
 
 // AddExecutorWithOptions brings up an executor with custom options.

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -64,6 +64,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/buildbuddy-io/buildbuddy/server/xcode"
+	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -154,6 +155,10 @@ func (r *Env) GetOLAPDBHandle() *testolapdb.Handle {
 		servers = append(servers, server)
 	}
 	return servers[rand.Intn(len(servers))].olapDBHandle
+}
+
+func (r *Env) GetRedisClient() redis.UniversalClient {
+	return r.testEnv.GetDefaultRedisClient()
 }
 
 func (r *Env) ShutdownBuildBuddyServers() {


### PR DESCRIPTION
The current implementation of action merging:
1. Checks Redis for a pending execution ID for a given action digest when an Execute request is received, reusing the pending execution ID if one is found, or
2. Writes two entries in Redis bidirectionally mapping action IDs to/from execution IDs with an 8 hour TTL for scheduled executions, and finally
3. Deletes this bidirectional map when the execution completes.

This is not resilient to unexpected failures in the app during execution, or cases where all of the executors simultaneously exit unhealthily. If either of these things happen, the action-merging entries written in step 2 can persist, because step 3 never happens. These "stuck" action merging entries block subsequent execution requests for that action, as alluded to in the linked bug.

This PR changes the implementation to make action merging recover from these failures more quickly by:
1. Recording the action merging information in Redis when the execution is queued, but with a 10 minute TTL instead of an 8 hour TTL.
2. Bumping the TTL of the action-merging Redis entries by 20 seconds every time a LeaseTask request bumping an executor's lease on an execution is healthily processed in the streaming LeaseTask RPC server. This should happen about every 10 seconds during normal operation.
3. Removing both of these action-merging Redis entries when an execution is unclaimed in the LeastTask RPC handler.

These changes should help address the hung action-merging bugs we've seen over the past few months. The window for stuck actions decreases from 8 hours to 10 minutes in the event queued executions are lost, and decreases it further to 20 seconds in the event live executions are lost. This should make manual intervention to clean up stuck actions unnecessary, although the 10 minute window is still a bit painful.

I also added a test for the dead-app case which necessitated some changes in the testing code to support removing apps. This new test fails at head, but passes at this PR. I also added another test for the TTL bumping. And finally, I extracted the logic for working with action-merging entries in Redis into its own package.

**Related issues**: [2860](https://github.com/buildbuddy-io/buildbuddy-internal/issues/2860)
