### PR TITLE
disable gorm default transactions

### DIFF
--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -534,7 +534,7 @@ func openDB(ctx context.Context, dataSource string, advancedConfig *AdvancedConf
 	if *logQueries {
 		l.LogLevel = logger.Info
 	}
-	config := gorm.Config{Logger: l}
+	config := gorm.Config{Logger: l, SkipDefaultTransaction: true}
 	gdb, err := gorm.Open(dialector, &config)
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

By default, gorm wraps every call in a transaction. Since we don't use gorm to do more than a single query at a time, this is unnecessary and adds bloat to our qps.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

fixes buildbuddy-io/buildbuddy-internal#3083

