### PR TITLE
Stop suggesting `--remote_build_event_upload=minimal` on Bazel 7+

### DIFF
--- a/app/invocation/invocation_suggestion_card.tsx
+++ b/app/invocation/invocation_suggestion_card.tsx
@@ -294,8 +294,9 @@ const matchers: SuggestionMatcher[] = [
     if (model.optionsMap.get("remote_build_event_upload")) return null;
     if (model.optionsMap.get("experimental_remote_build_event_upload")) return null;
     const version = getBazelMajorVersion(model);
-    // Bazel pre-v6 doesn't support --experimental_remote_build_event_upload=minimal
-    if (version === null || version < 6) return null;
+    // Bazel pre-v6 doesn't support --experimental_remote_build_event_upload=minimal, and Bazel post-v6 default to the
+    // correct setting
+    if (version === null || version != 6) return null;
 
     return {
       level: SuggestionLevel.INFO,


### PR DESCRIPTION
This is now the default in Bazel 7, and can be confusing to users if we suggest setting it.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
