### PR TITLE
Remove unused and no longer needed `--remote_download_minimal` suggestion

### DIFF
--- a/app/invocation/invocation_suggestion_card.tsx
+++ b/app/invocation/invocation_suggestion_card.tsx
@@ -315,35 +315,6 @@ const matchers: SuggestionMatcher[] = [
   },
   // Suggest timing profile flags
   getTimingDataSuggestion,
-  // Suggest using remote_download_minimal
-  ({ model }) => {
-    // TODO(https://github.com/bazelbuild/bazel/issues/10880):
-    // Show once BwtB issues are fixed.
-    return null;
-
-    if (!capabilities.config.expandedSuggestionsEnabled) return null;
-    if (!model.isBazelInvocation()) return null;
-
-    if (!model.optionsMap.get("remote_cache") && !model.optionsMap.get("remote_executor")) return null;
-    if (model.optionsMap.get("remote_download_outputs")) return null;
-
-    return {
-      level: SuggestionLevel.INFO,
-      message: (
-        <>
-          Consider adding the Bazel flag <BazelFlag>--remote_download_minimal</BazelFlag> or{" "}
-          <BazelFlag>--remote_download_toplevel</BazelFlag>, which can significantly improve performance for builds with
-          a large number of intermediate results.
-        </>
-      ),
-      reason: (
-        <>
-          Shown because this build is cache-enabled and the flag{" "}
-          <span className="inline-code">--remote_download_outputs</span> is not explicitly set.
-        </>
-      ),
-    };
-  },
   // Suggest --nolegacy_important_outputs
   ({ model }) => {
     if (!capabilities.config.expandedSuggestionsEnabled) return null;


### PR DESCRIPTION
As of Bazel 7 the BwtB issues are fixed, but the default is also now what we would suggest.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
