### PR TITLE
[RB] Fix parsing flags that do not require a value to be set in cli

### DIFF
--- a/cli/parser/parser.go
+++ b/cli/parser/parser.go
@@ -74,7 +74,7 @@ var (
 	bazelFlagHelpPattern = regexp.MustCompile(`` +
 		`^\s+--` + // Each flag help line begins with "  --"
 		`(?P<no>\[no\])?` + // then the optional string "[no]"
-		`(?P<name>\w+)\s+` + // then a flag name like "compilation_mode"
+		`(?P<name>\w+)\s*` + // then a flag name like "compilation_mode"
 		`(\[-(?P<short_name>\w+)\]\s+)?` + // then an optional short name like "[-c]"
 		`(\((?P<description>.*)\))?` + // then an optional description like "(some help text)"
 		`$`)
@@ -282,7 +282,7 @@ func parseHelpLine(line, topic string) *Option {
 		Name:      name,
 		ShortName: shortName,
 		Multi:     multi,
-		BoolLike:  no != "",
+		BoolLike:  no != "" || description == "",
 	}
 }
 

--- a/cli/parser/parser_test.go
+++ b/cli/parser/parser_test.go
@@ -61,6 +61,8 @@ build:workspace_status_with_space --workspace_status_command="bash workspace_sta
 common --noverbose_test_summary
 test --config=bar
 
+build:no_value_flag --remote_download_minimal
+
 import     %workspace%/import.bazelrc
 try-import %workspace%/NONEXISTENT.bazelrc
 `,
@@ -239,6 +241,23 @@ try-import %workspace%/NONEXISTENT.bazelrc
 				"--build_metadata=VALID_COMMON_FLAG=2",
 				"--build_flag_1",
 				"--workspace_status_command=bash workspace_status.sh",
+			},
+		},
+		// Test parsing flags that do not require a value to be set, like
+		// --remote_download_minimal or --java_debug
+		{
+			[]string{
+				"build",
+				"--config=no_value_flag",
+			},
+			[]string{
+				"--startup_flag_1",
+				"--ignore_all_rc_files",
+				"build",
+				"--build_metadata=VALID_COMMON_FLAG=1",
+				"--build_metadata=VALID_COMMON_FLAG=2",
+				"--build_flag_1",
+				"--remote_download_minimal",
 			},
 		},
 	} {


### PR DESCRIPTION
Here's sample output from `bazel help build`, which we use to determine what flags are valid:

 --propeller_optimize_absolute_ld_profile (a string; default: see description)
  --remote_download_all
  --remote_download_minimal
  --remote_download_outputs (all, minimal or toplevel; default: "toplevel")
  --remote_download_symlink_template (a string; default: "")

