### PR TITLE
deflake TestWriteCancelBeforeCommit in pebble cache test

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -1003,7 +1003,7 @@ func TestWriteCancelBeforeCommit(t *testing.T) {
 		{
 			desc:                  "chunking turned on",
 			averageChunkSizeBytes: 64 * 4,
-			testSize:              256,
+			testSize:              1024,
 		},
 	}
 	for _, tc := range testCases {
@@ -1028,10 +1028,20 @@ func TestWriteCancelBeforeCommit(t *testing.T) {
 			_, err = wc.Write(buf)
 			require.NoError(t, err)
 			cancel()
-			err = wc.Commit()
-			require.ErrorContains(t, err, "context canceled")
+			commitErr := wc.Commit()
 			err = wc.Close()
 			require.NoError(t, err)
+
+			if commitErr == nil {
+				// Use Reader() to get the bytes from the cache.
+				reader, err := pc.Reader(ctx, rn, 0, 0)
+				require.NoError(t, err, "Error getting %q reader", rn.GetDigest().GetHash())
+				d2 := testdigest.ReadDigestAndClose(t, reader)
+				require.Equal(t, rn.GetDigest().GetHash(), d2.GetHash())
+			} else {
+				require.Error(t, commitErr, "context canceled")
+
+			}
 
 			err = pc.Stop()
 			require.NoError(t, err)

--- a/enterprise/server/backends/pebble_cache/pebble_cache_test.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache_test.go
@@ -1040,7 +1040,6 @@ func TestWriteCancelBeforeCommit(t *testing.T) {
 				require.Equal(t, rn.GetDigest().GetHash(), d2.GetHash())
 			} else {
 				require.Error(t, commitErr, "context canceled")
-
 			}
 
 			err = pc.Stop()


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3098
In TestWriteCancelBeforeCommit, we currently expect that commit return a context
cancel error. However, sometimes, it returns nil when chunker.Close is called
before the chunker receives the ctx.Done(). 

I think in these cases, it's ok for wc.Commit() to return nil; when 
all the goroutines have already finished writing chunks. The original intention of this
test is to make sure during context cancellation there is no data race and zero
chunk error. 
