### PR TITLE
Allow assigning finer-grained capabilities to user API keys

### DIFF
--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -56,11 +56,6 @@ var (
 	defaultAPIKeyCapabilities = []akpb.ApiKey_Capability{
 		akpb.ApiKey_CACHE_WRITE_CAPABILITY,
 	}
-
-	// Capabilities assigned to user-owned API keys.
-	userAPIKeyCapabilities = []akpb.ApiKey_Capability{
-		akpb.ApiKey_CAS_WRITE_CAPABILITY,
-	}
 )
 
 func singleUserGroup(u *tables.User) (*tables.Group, error) {

--- a/enterprise/server/backends/userdb/userdb_test.go
+++ b/enterprise/server/backends/userdb/userdb_test.go
@@ -1135,11 +1135,14 @@ func TestUserOwnedKeys_CreateAndUpdateCapabilities(t *testing.T) {
 		// user-owned keys (for now, we only support setting cache capabilities
 		// on user-owned keys)
 		{Name: "Admin_OrgAdmin_Fail", Role: role.Admin, Capabilities: []akpb.ApiKey_Capability{akpb.ApiKey_ORG_ADMIN_CAPABILITY}, OK: false},
-		// TODO(bduffany): Figure out how these capabilities should work. For
-		// now, we just fail if they are assigned by these (role, capability)
-		// combinations. See http://go/b/3091#issuecomment-1932266337
-		{Name: "Writer_ACWrite_Fail", Role: role.Writer, Capabilities: []akpb.ApiKey_Capability{akpb.ApiKey_CACHE_WRITE_CAPABILITY}, OK: false},
+		// Readers and writers should be able to assign any capabilities
+		// within the max limits allowed by their role.
+		{Name: "Writer_NoCapabilities_OK", Role: role.Writer, Capabilities: nil, OK: true},
+		{Name: "Writer_CASWrite_OK", Role: role.Writer, Capabilities: []akpb.ApiKey_Capability{akpb.ApiKey_CAS_WRITE_CAPABILITY}, OK: true},
+		{Name: "Writer_ACWrite_OK", Role: role.Writer, Capabilities: []akpb.ApiKey_Capability{akpb.ApiKey_CACHE_WRITE_CAPABILITY}, OK: true},
+		{Name: "Reader_NoCapabilities_OK", Role: role.Reader, Capabilities: nil, OK: true},
 		{Name: "Reader_CASWrite_Fail", Role: role.Reader, Capabilities: []akpb.ApiKey_Capability{akpb.ApiKey_CAS_WRITE_CAPABILITY}, OK: false},
+		{Name: "Reader_ACWrite_Fail", Role: role.Reader, Capabilities: []akpb.ApiKey_Capability{akpb.ApiKey_CACHE_WRITE_CAPABILITY}, OK: false},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			ctx := context.Background()


### PR DESCRIPTION
Instead of allowing only admins to assign CACHE_WRITE capabilities (and restricting everyone else to just CAS_WRITE), allow any user to assign any capabilities as long as the capabilities are a subset of their authenticated User+Group capabilities

Concretely:
- Org admins can assign either CACHE_WRITE or CAS_WRITE (like they can today), because their effective capabilities are a subset of these (CACHE_WRITE|CAS_WRITE).
- Writers can assign either CACHE_WRITE or CAS_WRITE, too.
- Developers can only assign CAS_WRITE, since their role-based capabilities are limited to just CAS_WRITE.
- Readers cannot assign any capabilities, since their role-based capabilities are empty.

Note, we still do not allow REGISTER_EXECUTOR or ORG_ADMIN capabilities to be assigned to user-owned keys for now.

**Related issues**: N/A
