### PR TITLE
Remove janky focus outline transition

### DIFF
--- a/app/components/button/button.css
+++ b/app/components/button/button.css
@@ -17,6 +17,7 @@
   align-self: center;
   display: inline-flex;
   align-items: center;
+  outline: 2px solid transparent;
 }
 
 .filled-button {


### PR DESCRIPTION
Outline thickness is one of those CSS properties that doesn't get smoothly animated. Set a default 2px transparent outline so that when the focus outline does come in, it just fades in smoothly instead of jankily expanding. Note that this 2px area is not hoverable, so it shouldn't change behavior.

**Related issues**: N/A
