### PR TITLE
Disable integration tests on mac workflows

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -52,9 +52,7 @@ actions:
         -//enterprise/server/raft/store:all
         -//enterprise/server/remote_execution/commandutil:all
         -//enterprise/server/remote_execution/runner:all
-        -//enterprise/server/test/integration/ci_runner:all
-        -//enterprise/server/test/integration/remote_execution:all
-        -//enterprise/server/test/integration/workflow:all
+        -//enterprise/server/test/integration/...
   - name: Benchmark
     container_image: ubuntu-20.04
     triggers:


### PR DESCRIPTION
They have been timing out and we don't have a super strong need to run these on macOS as part of CI (Linux should be enough)

**Related issues**: N/A
