### PR TITLE
FindSplitPoint does not need to block state machine

### DIFF
--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -247,3 +247,15 @@ func SyncProposeLocalBatchNoRsp(ctx context.Context, nodehost *dragonboat.NodeHo
 	}
 	return rspBatch.AnyError()
 }
+
+func SyncReadLocalBatch(ctx context.Context, nodehost *dragonboat.NodeHost, shardID uint64, builder *rbuilder.BatchBuilder) (*rbuilder.BatchResponse, error) {
+	batch, err := builder.ToProto()
+	if err != nil {
+		return nil, err
+	}
+	rsp, err := SyncReadLocal(ctx, nodehost, shardID, batch)
+	if err != nil {
+		return nil, err
+	}
+	return rbuilder.NewBatchResponseFromProto(rsp), nil
+}

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1185,12 +1185,6 @@ func (sm *Replica) handlePropose(wb pebble.Batch, req *rfpb.RequestUnion) *rfpb.
 			UpdateAtime: r,
 		}
 		rsp.Status = statusProto(err)
-	case *rfpb.RequestUnion_FindSplitPoint:
-		r, err := sm.findSplitPoint()
-		rsp.Value = &rfpb.ResponseUnion_FindSplitPoint{
-			FindSplitPoint: r,
-		}
-		rsp.Status = statusProto(err)
 	default:
 		rsp.Status = statusProto(status.UnimplementedErrorf("SyncPropose handling for %+v not implemented.", req))
 	}
@@ -1230,6 +1224,12 @@ func (sm *Replica) handleRead(db ReplicaReader, req *rfpb.RequestUnion) *rfpb.Re
 		r, err := sm.find(db, value.Find)
 		rsp.Value = &rfpb.ResponseUnion_Find{
 			Find: r,
+		}
+		rsp.Status = statusProto(err)
+	case *rfpb.RequestUnion_FindSplitPoint:
+		r, err := sm.findSplitPoint()
+		rsp.Value = &rfpb.ResponseUnion_FindSplitPoint{
+			FindSplitPoint: r,
 		}
 		rsp.Status = statusProto(err)
 	default:

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1120,7 +1120,7 @@ func (s *Store) SplitRange(ctx context.Context, req *rfpb.SplitRangeRequest) (*r
 
 	// Find Split Point.
 	fsp := rbuilder.NewBatchBuilder().Add(&rfpb.FindSplitPointRequest{})
-	fspRsp, err := client.SyncProposeLocalBatch(ctx, s.nodeHost, shardID, fsp)
+	fspRsp, err := client.SyncReadLocalBatch(ctx, s.nodeHost, shardID, fsp)
 	if err != nil {
 		return nil, status.InternalErrorf("find split point err: %s", err)
 	}


### PR DESCRIPTION
Previously this method was happening via SyncPropose, which blocks the state machine from handling other writes. Because FindSplitPoint needs to scan the entire range, this can be slow. Instead, handle this method via SyncRead, which does not block the statemachine.