### PR TITLE
use proto.Marshal instead of proto.MarshalOld for BatchCmdResponse

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1577,9 +1577,7 @@ func (sm *Replica) singleUpdate(db pebble.IPebbleDB, entry dbsm.Entry) (dbsm.Ent
 		}
 	}
 
-	// BatchCMDResponse.MarshalVT() is slower than standard marshal(). See
-	// https://github.com/buildbuddy-io/buildbuddy-internal/issues/3018
-	rspBuf, err := proto.MarshalOld(batchRsp)
+	rspBuf, err := proto.Marshal(batchRsp)
 	if err != nil {
 		return entry, err
 	}
@@ -1672,7 +1670,7 @@ func (sm *Replica) Lookup(key interface{}) (interface{}, error) {
 		return nil, err
 	}
 
-	rspBuf, err := proto.MarshalOld(batchRsp)
+	rspBuf, err := proto.Marshal(batchRsp)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Not that we generate vtproto for grpc status, BatchCmdResponse is 21% faster with MarshalVT.  