### PR TITLE
Remove perms.AuthenticatedUser

### DIFF
--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -567,7 +567,7 @@ func newAPIKeyToken() (string, error) {
 }
 
 func (d *AuthDB) authorizeGroupAdminRole(ctx context.Context, groupID string) error {
-	u, err := perms.AuthenticatedUser(ctx, d.env)
+	u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return err
 	}
@@ -599,7 +599,7 @@ func (d *AuthDB) CreateImpersonationAPIKey(ctx context.Context, groupID string) 
 		return nil, status.InvalidArgumentError("Group ID cannot be nil.")
 	}
 
-	u, err := perms.AuthenticatedUser(ctx, d.env)
+	u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -676,7 +676,7 @@ func (d *AuthDB) CreateUserAPIKey(ctx context.Context, groupID, label string, ca
 		return nil, err
 	}
 
-	u, err := perms.AuthenticatedUser(ctx, d.env)
+	u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -736,7 +736,7 @@ func (d *AuthDB) getAPIKey(ctx context.Context, tx interfaces.DB, apiKeyID strin
 }
 
 func (d *AuthDB) GetAPIKey(ctx context.Context, apiKeyID string) (*tables.APIKey, error) {
-	user, err := perms.AuthenticatedUser(ctx, d.env)
+	user, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -791,7 +791,7 @@ func (d *AuthDB) GetAPIKeys(ctx context.Context, groupID string) ([]*tables.APIK
 	if groupID == "" {
 		return nil, status.InvalidArgumentError("Group ID cannot be empty.")
 	}
-	u, err := perms.AuthenticatedUser(ctx, d.env)
+	u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -826,7 +826,7 @@ func (d *AuthDB) authorizeAPIKeyWrite(ctx context.Context, tx interfaces.DB, api
 	if apiKeyID == "" {
 		return nil, status.InvalidArgumentError("API key ID is required")
 	}
-	user, err := perms.AuthenticatedUser(ctx, d.env)
+	user, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -897,7 +897,7 @@ func (d *AuthDB) GetUserAPIKeys(ctx context.Context, groupID string) ([]*tables.
 	if groupID == "" {
 		return nil, status.InvalidArgumentError("Group ID cannot be empty.")
 	}
-	u, err := perms.AuthenticatedUser(ctx, d.env)
+	u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/backends/userdb/BUILD
+++ b/enterprise/server/backends/userdb/BUILD
@@ -47,7 +47,6 @@ go_test(
         "//server/testutil/testenv",
         "//server/util/capabilities",
         "//server/util/claims",
-        "//server/util/perms",
         "//server/util/role",
         "//server/util/status",
         "//server/util/testing/flags",

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -143,7 +143,7 @@ func (d *UserDB) getGroupByURLIdentifier(ctx context.Context, tx interfaces.DB, 
 }
 
 func (d *UserDB) DeleteUserGitHubToken(ctx context.Context) error {
-	u, err := perms.AuthenticatedUser(ctx, d.env)
+	u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return err
 	}
@@ -157,7 +157,7 @@ func (d *UserDB) DeleteUserGitHubToken(ctx context.Context) error {
 }
 
 func (d *UserDB) authorizeGroupAdminRole(ctx context.Context, groupID string) error {
-	u, err := perms.AuthenticatedUser(ctx, d.env)
+	u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return err
 	}
@@ -229,7 +229,7 @@ func (d *UserDB) validateURLIdentifier(ctx context.Context, groupID string, urlI
 }
 
 func (d *UserDB) CreateGroup(ctx context.Context, g *tables.Group) (string, error) {
-	u, err := perms.AuthenticatedUser(ctx, d.env)
+	u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -298,7 +298,7 @@ func (d *UserDB) createGroup(ctx context.Context, tx interfaces.DB, userID strin
 }
 
 func (d *UserDB) InsertOrUpdateGroup(ctx context.Context, g *tables.Group) (string, error) {
-	u, err := perms.AuthenticatedUser(ctx, d.env)
+	u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -426,7 +426,7 @@ func (d *UserDB) addUserToGroup(ctx context.Context, tx interfaces.DB, userID, g
 }
 
 func (d *UserDB) RequestToJoinGroup(ctx context.Context, groupID string) (grpb.GroupMembershipStatus, error) {
-	u, err := perms.AuthenticatedUser(ctx, d.env)
+	u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -807,7 +807,7 @@ func (d *UserDB) GetUserByID(ctx context.Context, id string) (*tables.User, erro
 		return nil, err
 	}
 
-	authUser, err := perms.AuthenticatedUser(ctx, d.env)
+	authUser, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/backends/userdb/userdb_test.go
+++ b/enterprise/server/backends/userdb/userdb_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/capabilities"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/role"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
@@ -1665,7 +1664,7 @@ func TestCapabilitiesForUserRole(t *testing.T) {
 			require.NoError(t, err)
 			// Re-authenticate with the new role
 			userCtx = authUserCtx(ctx, env, t, "US1")
-			u, err := perms.AuthenticatedUser(userCtx, env)
+			u, err := env.GetAuthenticator().AuthenticatedUser(userCtx)
 			require.NoError(t, err)
 
 			require.Equal(t, test.ExpectedCapabilities, u.GetCapabilities())

--- a/enterprise/server/execution_search_service/execution_search_service.go
+++ b/enterprise/server/execution_search_service/execution_search_service.go
@@ -102,7 +102,7 @@ func (s *ExecutionSearchService) SearchExecutions(ctx context.Context, req *expb
 	if s.oh == nil {
 		return nil, status.UnavailableError("An OLAP DB is required to search executions.")
 	}
-	u, err := perms.AuthenticatedUser(ctx, s.env)
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/gcplink/BUILD
+++ b/enterprise/server/gcplink/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//server/environment",
         "//server/real_environment",
         "//server/util/cookie",
-        "//server/util/perms",
         "//server/util/random",
         "//server/util/request_context",
         "//server/util/status",

--- a/enterprise/server/gcplink/gcplink.go
+++ b/enterprise/server/gcplink/gcplink.go
@@ -15,7 +15,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/cookie"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/coreos/go-oidc"
@@ -259,7 +258,7 @@ type accessTokenResponse struct {
 }
 
 func (g *GCPService) GetGCPProject(ctx context.Context, request *gcpb.GetGCPProjectRequest) (*gcpb.GetGCPProjectResponse, error) {
-	u, err := perms.AuthenticatedUser(ctx, g.env)
+	u, err := g.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -291,7 +291,7 @@ func (a *GitHubApp) GetRepositoryInstallationToken(ctx context.Context, repo *ta
 }
 
 func (a *GitHubApp) GetGitHubAppInstallations(ctx context.Context, req *ghpb.GetAppInstallationsRequest) (*ghpb.GetAppInstallationsResponse, error) {
-	u, err := perms.AuthenticatedUser(ctx, a.env)
+	u, err := a.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +318,7 @@ func (a *GitHubApp) GetGitHubAppInstallations(ctx context.Context, req *ghpb.Get
 }
 
 func (a *GitHubApp) LinkGitHubAppInstallation(ctx context.Context, req *ghpb.LinkAppInstallationRequest) (*ghpb.LinkAppInstallationResponse, error) {
-	u, err := perms.AuthenticatedUser(ctx, a.env)
+	u, err := a.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -333,7 +333,7 @@ func (a *GitHubApp) LinkGitHubAppInstallation(ctx context.Context, req *ghpb.Lin
 }
 
 func (a *GitHubApp) linkInstallation(ctx context.Context, installation *github.Installation, groupID string) error {
-	u, err := perms.AuthenticatedUser(ctx, a.env)
+	u, err := a.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return err
 	}
@@ -387,7 +387,7 @@ func (a *GitHubApp) createInstallation(ctx context.Context, in *tables.GitHubApp
 }
 
 func (a *GitHubApp) UnlinkGitHubAppInstallation(ctx context.Context, req *ghpb.UnlinkAppInstallationRequest) (*ghpb.UnlinkAppInstallationResponse, error) {
-	u, err := perms.AuthenticatedUser(ctx, a.env)
+	u, err := a.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -421,7 +421,7 @@ func (a *GitHubApp) UnlinkGitHubAppInstallation(ctx context.Context, req *ghpb.U
 }
 
 func (a *GitHubApp) GetInstallationByOwner(ctx context.Context, owner string) (*tables.GitHubAppInstallation, error) {
-	u, err := perms.AuthenticatedUser(ctx, a.env)
+	u, err := a.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -441,7 +441,7 @@ func (a *GitHubApp) GetInstallationByOwner(ctx context.Context, owner string) (*
 }
 
 func (a *GitHubApp) GetLinkedGitHubRepos(ctx context.Context) (*ghpb.GetLinkedReposResponse, error) {
-	u, err := perms.AuthenticatedUser(ctx, a.env)
+	u, err := a.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -485,7 +485,7 @@ func (a *GitHubApp) LinkGitHubRepo(ctx context.Context, req *ghpb.LinkRepoReques
 		return nil, err
 	}
 
-	if _, err := perms.AuthenticatedUser(ctx, a.env); err != nil {
+	if _, err := a.env.GetAuthenticator().AuthenticatedUser(ctx); err != nil {
 		return nil, err
 	}
 	p, err := perms.ForAuthenticatedGroup(ctx, a.env)
@@ -522,7 +522,7 @@ func (a *GitHubApp) UnlinkGitHubRepo(ctx context.Context, req *ghpb.UnlinkRepoRe
 		return nil, status.InvalidArgumentErrorf("failed to parse repo URL: %s", err)
 	}
 	req.RepoUrl = norm.String()
-	u, err := perms.AuthenticatedUser(ctx, a.env)
+	u, err := a.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/hostedrunner/BUILD
+++ b/enterprise/server/hostedrunner/BUILD
@@ -23,7 +23,6 @@ go_library(
         "//server/util/bazel_request",
         "//server/util/git",
         "//server/util/log",
-        "//server/util/perms",
         "//server/util/prefix",
         "//server/util/status",
         "@com_github_google_uuid//:uuid",

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -20,7 +20,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
 	"github.com/buildbuddy-io/buildbuddy/server/util/git"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/google/uuid"
@@ -218,7 +217,7 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 }
 
 func (r *runnerService) withCredentials(ctx context.Context, req *rnpb.RunRequest) (context.Context, error) {
-	u, err := perms.AuthenticatedUser(ctx, r.env)
+	u, err := r.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/invocation_search_service/invocation_search_service.go
+++ b/enterprise/server/invocation_search_service/invocation_search_service.go
@@ -62,7 +62,7 @@ func (s *InvocationSearchService) hydrateInvocationsFromDB(ctx context.Context, 
 	q := query_builder.NewQuery(`SELECT * FROM "Invocations" as i`)
 	q.AddWhereClause("i.invocation_id IN ?", invocationIds)
 	addOrderBy(sort, q)
-	u, err := perms.AuthenticatedUser(ctx, s.env)
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +215,7 @@ func (s *InvocationSearchService) buildPrimaryQuery(ctx context.Context, fields 
 	if err := s.checkPreconditions(req); err != nil {
 		return "", nil, err
 	}
-	u, err := perms.AuthenticatedUser(ctx, s.env)
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return "", nil, err
 	}

--- a/enterprise/server/iprules/BUILD
+++ b/enterprise/server/iprules/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//server/util/db",
         "//server/util/log",
         "//server/util/lru",
-        "//server/util/perms",
         "//server/util/status",
         "@com_github_prometheus_client_golang//prometheus",
     ],

--- a/enterprise/server/iprules/iprules.go
+++ b/enterprise/server/iprules/iprules.go
@@ -22,7 +22,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/db"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/lru"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -230,7 +229,7 @@ func (s *Service) authorize(ctx context.Context, groupID string) error {
 }
 
 func (s *Service) AuthorizeGroup(ctx context.Context, groupID string) error {
-	u, err := perms.AuthenticatedUser(ctx, s.env)
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return err
 	}
@@ -251,7 +250,7 @@ func (s *Service) AuthorizeGroup(ctx context.Context, groupID string) error {
 }
 
 func (s *Service) Authorize(ctx context.Context) error {
-	u, err := perms.AuthenticatedUser(ctx, s.env)
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		// If auth failed we don't need to (and can't) apply IP rules.
 		return nil
@@ -306,7 +305,7 @@ func (s *Service) AuthorizeHTTPRequest(ctx context.Context, r *http.Request) err
 }
 
 func (s *Service) checkAccess(ctx context.Context, groupID string) error {
-	u, err := perms.AuthenticatedUser(ctx, s.env)
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return err
 	}

--- a/enterprise/server/remote_execution/container/BUILD
+++ b/enterprise/server/remote_execution/container/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//server/util/flag",
         "//server/util/hash",
         "//server/util/log",
-        "//server/util/perms",
         "//server/util/status",
         "//server/util/tracing",
         "@io_opentelemetry_go_otel//attribute",

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -16,7 +16,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/hash"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"go.opentelemetry.io/otel/attribute"
@@ -292,7 +291,7 @@ func PullImageIfNecessary(ctx context.Context, env environment.Env, ctr CommandC
 // same token is always returned.
 func NewImageCacheToken(ctx context.Context, env environment.Env, creds oci.Credentials, imageRef string) (interfaces.ImageCacheToken, error) {
 	groupID := ""
-	u, err := perms.AuthenticatedUser(ctx, env)
+	u, err := env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		if !authutil.IsAnonymousUserError(err) {
 			return interfaces.ImageCacheToken{}, err

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -49,7 +49,6 @@ go_library(
         "//server/util/disk",
         "//server/util/log",
         "//server/util/networking",
-        "//server/util/perms",
         "//server/util/status",
         "//server/util/tracing",
         "@com_github_armon_circbuf//:circbuf",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -48,7 +48,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/networking"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/firecracker-microvm/firecracker-go-sdk/client/operations"
@@ -2630,7 +2629,7 @@ func (c *FirecrackerContainer) observeStageDuration(ctx context.Context, taskSta
 	}
 
 	var groupID string
-	u, err := perms.AuthenticatedUser(ctx, c.env)
+	u, err := c.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err == nil {
 		groupID = u.GetGroupID()
 	}

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -495,7 +495,7 @@ func (s *ExecutionServer) Dispatch(ctx context.Context, req *repb.ExecuteRequest
 	}
 
 	taskGroupID := interfaces.AuthAnonymousUser
-	if user, err := perms.AuthenticatedUser(ctx, s.env); err == nil {
+	if user, err := s.env.GetAuthenticator().AuthenticatedUser(ctx); err == nil {
 		taskGroupID = user.GetGroupID()
 	}
 

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -58,7 +58,6 @@ go_library(
             "//enterprise/server/remote_execution/containers/firecracker",
             "//enterprise/server/remote_execution/containers/podman",
             "//proto:vfs_go_proto",
-            "//server/util/perms",
             "@org_golang_google_grpc//:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:windows": [

--- a/enterprise/server/remote_execution/runner/runner_linux.go
+++ b/enterprise/server/remote_execution/runner/runner_linux.go
@@ -19,7 +19,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/vfs_server"
 	"github.com/buildbuddy-io/buildbuddy/server/metrics"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
@@ -162,7 +161,7 @@ func (r *taskRunner) hasMaxResourceUtilization(ctx context.Context, usageStats *
 
 		if maxedOutStr != "" {
 			var groupID string
-			u, err := perms.AuthenticatedUser(ctx, r.env)
+			u, err := r.env.GetAuthenticator().AuthenticatedUser(ctx)
 			if err == nil {
 				groupID = u.GetGroupID()
 			}

--- a/enterprise/server/remote_execution/snaploader/BUILD
+++ b/enterprise/server/remote_execution/snaploader/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//server/util/authutil",
         "//server/util/hash",
         "//server/util/log",
-        "//server/util/perms",
         "//server/util/proto",
         "//server/util/status",
         "//server/util/tracing",

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -21,7 +21,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/hash"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
@@ -823,7 +822,7 @@ func hashStrings(strs ...string) string {
 
 func groupID(ctx context.Context, env environment.Env) (string, error) {
 	var gid string
-	u, err := perms.AuthenticatedUser(ctx, env)
+	u, err := env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err == nil {
 		gid = u.GetGroupID()
 	} else if err != nil && !authutil.IsAnonymousUserError(err) && !*container.DebugEnableAnonymousRecycling {

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -977,7 +977,7 @@ func (s *SchedulerServer) GetPoolInfo(ctx context.Context, os, requestedPool, wo
 		return sharedPool, nil
 	}
 
-	user, err := perms.AuthenticatedUser(ctx, s.env)
+	user, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		if s.env.GetAuthenticator().AnonymousUsageEnabled(ctx) {
 			if s.forceUserOwnedDarwinExecutors && os == darwinOperatingSystemName {
@@ -1924,7 +1924,7 @@ func (s *SchedulerServer) ReEnqueueTask(ctx context.Context, req *scpb.ReEnqueue
 }
 
 func (s *SchedulerServer) getExecutionNodesFromRedis(ctx context.Context, groupID string) ([]*scpb.ExecutionNode, error) {
-	user, err := perms.AuthenticatedUser(ctx, s.env)
+	user, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1978,7 +1978,7 @@ func (s *SchedulerServer) GetExecutionNodes(ctx context.Context, req *scpb.GetEx
 		userOwnedExecutorsEnabled = false
 	}
 
-	u, err := perms.AuthenticatedUser(ctx, s.env)
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/scheduling/task_router/BUILD
+++ b/enterprise/server/scheduling/task_router/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//server/real_environment",
         "//server/util/hash",
         "//server/util/log",
-        "//server/util/perms",
         "//server/util/proto",
         "//server/util/status",
         "@com_github_go_redis_redis_v8//:redis",

--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -13,7 +13,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/hash"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/go-redis/redis/v8"
@@ -202,7 +201,7 @@ type routingParams struct {
 
 func getRoutingParams(ctx context.Context, env environment.Env, cmd *repb.Command, remoteInstanceName string) routingParams {
 	groupID := interfaces.AuthAnonymousUser
-	if u, err := perms.AuthenticatedUser(ctx, env); err == nil {
+	if u, err := env.GetAuthenticator().AuthenticatedUser(ctx); err == nil {
 		groupID = u.GetGroupID()
 	}
 	return routingParams{cmd: cmd, remoteInstanceName: remoteInstanceName, groupID: groupID}

--- a/enterprise/server/secrets/secrets.go
+++ b/enterprise/server/secrets/secrets.go
@@ -48,7 +48,7 @@ func Register(env *real_environment.RealEnv) error {
 }
 
 func (s *SecretService) GetPublicKey(ctx context.Context, req *skpb.GetPublicKeyRequest) (*skpb.GetPublicKeyResponse, error) {
-	u, err := perms.AuthenticatedUser(ctx, s.env)
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (s *SecretService) GetPublicKey(ctx context.Context, req *skpb.GetPublicKey
 }
 
 func (s *SecretService) listSecretsIncludingValues(ctx context.Context) (*skpb.ListSecretsResponse, error) {
-	u, err := perms.AuthenticatedUser(ctx, s.env)
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func (s *SecretService) ListSecrets(ctx context.Context, req *skpb.ListSecretsRe
 }
 
 func (s *SecretService) UpdateSecret(ctx context.Context, req *skpb.UpdateSecretRequest) (*skpb.UpdateSecretResponse, bool, error) {
-	u, err := perms.AuthenticatedUser(ctx, s.env)
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, false, err
 	}
@@ -193,7 +193,7 @@ func (s *SecretService) UpdateSecret(ctx context.Context, req *skpb.UpdateSecret
 }
 
 func (s *SecretService) DeleteSecret(ctx context.Context, req *skpb.DeleteSecretRequest) (*skpb.DeleteSecretResponse, error) {
-	u, err := perms.AuthenticatedUser(ctx, s.env)
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/tasksize/BUILD
+++ b/enterprise/server/tasksize/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//server/real_environment",
         "//server/util/authutil",
         "//server/util/log",
-        "//server/util/perms",
         "//server/util/proto",
         "//server/util/status",
         "@com_github_go_redis_redis_v8//:redis",

--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -15,7 +15,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/go-redis/redis/v8"
@@ -275,7 +274,7 @@ func (s *taskSizer) taskSizeKey(ctx context.Context, cmd *repb.Command) (string,
 }
 
 func (s *taskSizer) groupKey(ctx context.Context) (string, error) {
-	u, err := perms.AuthenticatedUser(ctx, s.env)
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		if authutil.IsAnonymousUserError(err) && s.env.GetAuthenticator().AnonymousUsageEnabled(ctx) {
 			return "ANON", nil

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -432,7 +432,7 @@ func (ws *workflowService) GetWorkflows(ctx context.Context) (*wfpb.GetWorkflows
 		return nil, err
 	}
 
-	u, err := perms.AuthenticatedUser(ctx, ws.env)
+	u, err := ws.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -490,7 +490,7 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 	}
 
 	// Authenticate
-	user, err := perms.AuthenticatedUser(ctx, ws.env)
+	user, err := ws.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -672,7 +672,7 @@ func (ws *workflowService) GetLegacyWorkflowIDForGitRepository(groupID string, r
 }
 
 func (ws *workflowService) checkCleanWorkflowPermissions(ctx context.Context, wf *tables.Workflow) error {
-	u, err := perms.AuthenticatedUser(ctx, ws.env)
+	u, err := ws.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return err
 	}

--- a/server/backends/github/BUILD
+++ b/server/backends/github/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//server/util/cookie",
         "//server/util/flag",
         "//server/util/log",
-        "//server/util/perms",
         "//server/util/random",
         "//server/util/status",
         "@com_github_google_go_github_v43//github",

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -21,7 +21,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/cookie"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/random"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/google/go-github/v43/github"
@@ -253,7 +252,7 @@ func (c *OAuthHandler) StartAuthFlow(w http.ResponseWriter, r *http.Request, red
 }
 
 func (c *OAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	_, err := perms.AuthenticatedUser(r.Context(), c.env)
+	_, err := c.env.GetAuthenticator().AuthenticatedUser(r.Context())
 	if err != nil {
 		// If not logged in to the app (e.g. when installing directly from
 		// GitHub), redirect to the account creation flow.
@@ -330,7 +329,7 @@ func (c *OAuthHandler) requestAccessToken(r *http.Request, code string) error {
 	userID := getState(r, userIDCookieName)
 	groupID := getState(r, groupIDCookieName)
 
-	u, err := perms.AuthenticatedUser(ctx, c.env)
+	u, err := c.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return err
 	}

--- a/server/backends/invocationdb/invocationdb.go
+++ b/server/backends/invocationdb/invocationdb.go
@@ -168,7 +168,7 @@ func (d *InvocationDB) LookupInvocation(ctx context.Context, invocationID string
 		return nil, err
 	}
 	if ti.Perms&perms.OTHERS_READ == 0 {
-		u, err := perms.AuthenticatedUser(ctx, d.env)
+		u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -384,7 +384,7 @@ func (s *BuildBuddyServer) GetGroup(ctx context.Context, req *grpb.GetGroupReque
 	var group *tables.Group
 	if req.GetGroupId() != "" {
 		// Looking up by group ID is restricted to server admins.
-		u, err := perms.AuthenticatedUser(ctx, s.env)
+		u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -983,7 +983,7 @@ func (s *BuildBuddyServer) GetBazelConfig(ctx context.Context, req *bzpb.GetBaze
 
 	var g *tables.Group
 	if subdomain.Enabled() {
-		u, err := perms.AuthenticatedUser(ctx, s.env)
+		u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -1209,7 +1209,7 @@ func (s *BuildBuddyServer) UnlinkGitHubAccount(ctx context.Context, req *ghpb.Un
 	if udb == nil {
 		return nil, status.UnimplementedError("Not implemented")
 	}
-	u, err := perms.AuthenticatedUser(ctx, s.env)
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/server/capabilities_filter/BUILD
+++ b/server/capabilities_filter/BUILD
@@ -9,7 +9,6 @@ go_library(
         "//proto:api_key_go_proto",
         "//server/environment",
         "//server/util/capabilities",
-        "//server/util/perms",
         "//server/util/status",
     ],
 )

--- a/server/capabilities_filter/capabilities_filter.go
+++ b/server/capabilities_filter/capabilities_filter.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/capabilities"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
@@ -243,7 +242,7 @@ func AuthorizeRPC(ctx context.Context, env environment.Env, rpcName string) erro
 	rpcName = path.Base(rpcName)
 
 	var groupID string
-	u, err := perms.AuthenticatedUser(ctx, env)
+	u, err := env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err == nil {
 		groupID = u.GetGroupID()
 	}
@@ -256,7 +255,7 @@ func AuthorizeRPC(ctx context.Context, env environment.Env, rpcName string) erro
 }
 
 func authorizeServerAdmin(ctx context.Context, env environment.Env) error {
-	u, err := perms.AuthenticatedUser(ctx, env)
+	u, err := env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return err
 	}

--- a/server/util/perms/perms.go
+++ b/server/util/perms/perms.go
@@ -101,14 +101,6 @@ func FromACL(acl *aclpb.ACL) (int32, error) {
 	return p, nil
 }
 
-func AuthenticatedUser(ctx context.Context, env environment.Env) (interfaces.UserInfo, error) {
-	auth := env.GetAuthenticator()
-	if auth == nil {
-		return nil, status.UnimplementedError("Not implemented")
-	}
-	return auth.AuthenticatedUser(ctx)
-}
-
 func AuthorizeRead(u interfaces.UserInfo, acl *aclpb.ACL) error {
 	if u == nil {
 		return status.InvalidArgumentError("user cannot be nil.")
@@ -234,7 +226,7 @@ func AuthorizeGroupAccess(ctx context.Context, env environment.Env, groupID stri
 	if groupID == "" {
 		return status.InvalidArgumentError("group ID is required")
 	}
-	user, err := AuthenticatedUser(ctx, env)
+	user, err := env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return err
 	}

--- a/server/util/subdomain/BUILD
+++ b/server/util/subdomain/BUILD
@@ -11,7 +11,6 @@ go_library(
         "//server/tables",
         "//server/util/alert",
         "//server/util/flag",
-        "//server/util/perms",
         "//server/util/urlutil",
     ],
 )

--- a/server/util/subdomain/subdomain.go
+++ b/server/util/subdomain/subdomain.go
@@ -10,7 +10,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/tables"
 	"github.com/buildbuddy-io/buildbuddy/server/util/alert"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 	"github.com/buildbuddy-io/buildbuddy/server/util/urlutil"
 )
 
@@ -70,7 +69,7 @@ func ReplaceURLSubdomain(ctx context.Context, env environment.Env, rawURL string
 		return rawURL, nil
 	}
 
-	u, err := perms.AuthenticatedUser(ctx, env)
+	u, err := env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Background: we have two packages `perms` and `authutil` and it's somewhat confusing what should go in which package, as both seem to contain broadly useful auth utilities. Ideally, `perms` would only have utils relating to our unix-ish Perms that we store in the DB (i.e. read/write/execute bit-fiddling stuff), and `authutil` would contain more broadly useful auth utils.

This PR kicks off this effort by removing the `perms.AuthenticatedUser` func. This utility function is not really needed - all it does is check whether `env.GetAuthenticator()` is `nil`, and if it's not, it calls `GetAuthenticatedUser()` on it. `GetAuthenticator()` should never return `nil` though, because we always either bind the real authenticator, or a non-`nil` instance of `nullauth.NullAuthenticator`. So instead, just replace all existing call sites with `env.GetAuthenticator().AuthenticatedUser(ctx)`.

**Related issues**: N/A
