### PR TITLE
Remove Group ID utils from perms package

### DIFF
--- a/enterprise/server/usage/BUILD
+++ b/enterprise/server/usage/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//server/util/authutil",
         "//server/util/db",
         "//server/util/log",
-        "//server/util/perms",
         "//server/util/status",
         "//server/util/timeutil",
         "@com_github_go_redis_redis_v8//:redis",

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -262,10 +262,11 @@ func (ws *workflowService) CreateWorkflow(ctx context.Context, req *wfpb.CreateW
 	}
 
 	// Ensure the request is authenticated so some group can own this workflow.
-	groupID, err := perms.AuthenticateSelectedGroupID(ctx, ws.env, req.GetRequestContext())
+	user, err := ws.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
+	groupID := user.GetGroupID()
 	permissions := &perms.UserGroupPerm{
 		UserID:  groupID,
 		GroupID: groupID,
@@ -1006,11 +1007,11 @@ func (ws *workflowService) gitHubTokenForAuthorizedGroup(ctx context.Context, re
 	if d == nil {
 		return "", status.FailedPreconditionError("Missing UserDB")
 	}
-	groupID, err := perms.AuthenticateSelectedGroupID(ctx, ws.env, reqCtx)
+	u, err := ws.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return "", err
 	}
-	g, err := d.GetGroupByID(ctx, groupID)
+	g, err := d.GetGroupByID(ctx, u.GetGroupID())
 	if err != nil {
 		return "", err
 	}

--- a/server/util/authutil/authutil.go
+++ b/server/util/authutil/authutil.go
@@ -82,11 +82,11 @@ func AnonymousUserErrorf(format string, args ...any) error {
 }
 
 // IsAnonymousUserError can be used to check whether an error returned by
-// functions which return the authenticated user (such as AuthenticatedUser or
-// AuthenticateSelectedGroupID) is due to an anonymous user accessing the
-// service. This is useful for allowing anonymous users to proceed, in cases
-// where anonymous usage is explicitly enabled in the app config, and we support
-// anonymous usage for the part of the service where this is used.
+// functions which return the authenticated user (such as AuthenticatedUser) is
+// due to an anonymous user accessing the service. This is useful for allowing
+// anonymous users to proceed, in cases where anonymous usage is explicitly
+// enabled in the app config, and we support anonymous usage for the part of the
+// service where this is used.
 func IsAnonymousUserError(err error) bool {
 	for _, detail := range gstatus.Convert(err).Proto().GetDetails() {
 		info := &errdetails.ErrorInfo{}

--- a/server/util/perms/BUILD
+++ b/server/util/perms/BUILD
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto:acl_go_proto",
-        "//proto:context_go_proto",
         "//proto:user_id_go_proto",
         "//server/environment",
         "//server/interfaces",

--- a/server/util/perms/perms.go
+++ b/server/util/perms/perms.go
@@ -14,7 +14,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	aclpb "github.com/buildbuddy-io/buildbuddy/proto/acl"
-	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
 	uidpb "github.com/buildbuddy-io/buildbuddy/proto/user_id"
 )
 
@@ -256,40 +255,6 @@ func AuthorizeGroupAccessForStats(ctx context.Context, env environment.Env, grou
 		return status.ResourceExhaustedError("Too many rows.")
 	}
 	return nil
-}
-
-// AuthenticateSelectedGroupID returns the group ID selected by the user in the
-// UI (determined via the proto request context), returning an error if the user
-// does not have access to the selected group.
-func AuthenticateSelectedGroupID(ctx context.Context, env environment.Env, protoCtx *ctxpb.RequestContext) (string, error) {
-	if protoCtx == nil {
-		return "", status.InvalidArgumentError("request_context field is required")
-	}
-	groupID := protoCtx.GetGroupId()
-	if groupID == "" {
-		return "", status.InvalidArgumentError("request_context.group_id field is required")
-	}
-	if err := AuthorizeGroupAccess(ctx, env, groupID); err != nil {
-		return "", err
-	}
-	return groupID, nil
-}
-
-// AuthenticatedGroupID returns the authenticated group ID from the given
-// context. This is preferred for API requests, since the group ID can be
-// determined directly from the API key. UI requests should instead use
-// `AuthenticateSelectedGroupID`, since the API key is not available, and the
-// user's selected group ID needs to be taken into account.
-func AuthenticatedGroupID(ctx context.Context, env environment.Env) (string, error) {
-	u, err := AuthenticatedUser(ctx, env)
-	if err != nil {
-		return "", err
-	}
-	groupID := u.GetGroupID()
-	if groupID == "" {
-		return "", status.FailedPreconditionError("Authenticated user does not have an associated group ID")
-	}
-	return groupID, nil
 }
 
 // ForAuthenticatedGroup returns GROUP_READ|GROUP_WRITE permissions for authenticated groups,


### PR DESCRIPTION
A while back, we updated the implementations of `interfaces.UserInfo.GetGroupID()` so that it always returns the correct value of the user's authenticated selected group ID (either the group ID from the API key in the gRPC auth case, or the authenticated selected group ID from the proto request context sent by the UI). So these util funcs are no longer needed; we can just call `GetGroupID` directly now.

**Related issues**: N/A
