### PR TITLE
Remove perms.DeprecatedGroupPermissions

### DIFF
--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -266,7 +266,11 @@ func (ws *workflowService) CreateWorkflow(ctx context.Context, req *wfpb.CreateW
 	if err != nil {
 		return nil, err
 	}
-	permissions := perms.DeprecatedGroupPermissions(groupID)
+	permissions := &perms.UserGroupPerm{
+		UserID:  groupID,
+		GroupID: groupID,
+		Perms:   perms.GROUP_READ | perms.GROUP_WRITE,
+	}
 
 	u, err := gitutil.NormalizeRepoURL(repoReq.GetRepoUrl())
 	if err != nil {

--- a/server/util/perms/perms.go
+++ b/server/util/perms/perms.go
@@ -54,21 +54,6 @@ func DefaultPermissions(u interfaces.UserInfo) *UserGroupPerm {
 	}
 }
 
-// Deprecated.
-// We used to use this function to set group permissions prior to introducing
-// user personal keys. Currently, this is only used when we insert into Workflows
-// table (https://github.com/buildbuddy-io/buildbuddy/blob/v2.38.0/enterprise/server/workflow/service/service.go#L271)
-// and Workflows table itself is deprecated.
-//
-// Please use DefaultPermissions if possible.
-func DeprecatedGroupPermissions(groupID string) *UserGroupPerm {
-	return &UserGroupPerm{
-		UserID:  groupID,
-		GroupID: groupID,
-		Perms:   GROUP_READ | GROUP_WRITE,
-	}
-}
-
 func ToACLProto(userID *uidpb.UserId, groupID string, perms int32) *aclpb.ACL {
 	return &aclpb.ACL{
 		UserId:  userID,


### PR DESCRIPTION
Inline it at the callsite so we can remove it.

Note: this code is not be getting called anymore anyway, since we've enabled the new GitHub App-based workflows. The last time we created a legacy Workflow row in the DB was in April of 2023.

**Related issues**: N/A
