### PR TITLE
Clean up nil checks on `env.GetAuthenticator()`

### DIFF
--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -61,10 +61,6 @@ func NewAPIServer(env environment.Env) *APIServer {
 	}
 }
 
-func (s *APIServer) checkPreconditions(ctx context.Context) (interfaces.UserInfo, error) {
-	return s.env.GetAuthenticator().AuthenticatedUser(ctx)
-}
-
 func (s *APIServer) authorizeWrites(ctx context.Context) error {
 	canWrite, err := capabilities.IsGranted(ctx, s.env, akpb.ApiKey_CACHE_WRITE_CAPABILITY)
 	if err != nil {
@@ -77,7 +73,7 @@ func (s *APIServer) authorizeWrites(ctx context.Context) error {
 }
 
 func (s *APIServer) GetInvocation(ctx context.Context, req *apipb.GetInvocationRequest) (*apipb.GetInvocationResponse, error) {
-	user, err := s.checkPreconditions(ctx)
+	user, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +191,7 @@ func (s *APIServer) redisCachedTarget(ctx context.Context, userInfo interfaces.U
 }
 
 func (s *APIServer) GetTarget(ctx context.Context, req *apipb.GetTargetRequest) (*apipb.GetTargetResponse, error) {
-	userInfo, err := s.checkPreconditions(ctx)
+	userInfo, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +268,7 @@ func (s *APIServer) redisCachedActions(ctx context.Context, userInfo interfaces.
 }
 
 func (s *APIServer) GetAction(ctx context.Context, req *apipb.GetActionRequest) (*apipb.GetActionResponse, error) {
-	userInfo, err := s.checkPreconditions(ctx)
+	userInfo, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -328,8 +324,9 @@ func (s *APIServer) GetAction(ctx context.Context, req *apipb.GetActionRequest) 
 }
 
 func (s *APIServer) GetLog(ctx context.Context, req *apipb.GetLogRequest) (*apipb.GetLogResponse, error) {
-	// No need for user here because user filters will be applied by LookupInvocation.
-	if _, err := s.checkPreconditions(ctx); err != nil {
+	// Check whether the user is authenticated. No need for the returned user
+	// here, because user filters will be applied by LookupInvocation.
+	if _, err := s.env.GetAuthenticator().AuthenticatedUser(ctx); err != nil {
 		return nil, err
 	}
 
@@ -369,7 +366,7 @@ func (gfs *getFileWriter) Write(data []byte) (int, error) {
 
 func (s *APIServer) GetFile(req *apipb.GetFileRequest, server apipb.ApiService_GetFileServer) error {
 	ctx := server.Context()
-	if _, err := s.checkPreconditions(ctx); err != nil {
+	if _, err := s.env.GetAuthenticator().AuthenticatedUser(ctx); err != nil {
 		return err
 	}
 
@@ -393,7 +390,7 @@ func (s *APIServer) DeleteFile(ctx context.Context, req *apipb.DeleteFileRequest
 		return nil, err
 	}
 
-	if _, err = s.checkPreconditions(ctx); err != nil {
+	if _, err = s.env.GetAuthenticator().AuthenticatedUser(ctx); err != nil {
 		return nil, err
 	}
 	if err = s.authorizeWrites(ctx); err != nil {
@@ -437,7 +434,7 @@ func (s *APIServer) GetFileHandler() http.Handler {
 
 // Handle streaming http GetFile request since protolet doesn't handle streaming rpcs yet.
 func (s *APIServer) handleGetFileRequest(w http.ResponseWriter, r *http.Request) {
-	if _, err := s.checkPreconditions(r.Context()); err != nil {
+	if _, err := s.env.GetAuthenticator().AuthenticatedUser(r.Context()); err != nil {
 		http.Error(w, "Invalid API key", http.StatusUnauthorized)
 		return
 	}
@@ -466,7 +463,7 @@ func (s *APIServer) handleGetMetricsRequest(w http.ResponseWriter, r *http.Reque
 		http.Error(w, "API not enabled", http.StatusNotImplemented)
 		return
 	}
-	userInfo, err := s.checkPreconditions(r.Context())
+	userInfo, err := s.env.GetAuthenticator().AuthenticatedUser(r.Context())
 	if err != nil {
 		http.Error(w, "Invalid API key", http.StatusUnauthorized)
 		return
@@ -517,7 +514,7 @@ func actionMatchesActionSelector(action *apipb.Action, selector *apipb.ActionSel
 }
 
 func (s *APIServer) ExecuteWorkflow(ctx context.Context, req *apipb.ExecuteWorkflowRequest) (*apipb.ExecuteWorkflowResponse, error) {
-	user, err := s.checkPreconditions(ctx)
+	user, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -62,10 +62,6 @@ func NewAPIServer(env environment.Env) *APIServer {
 }
 
 func (s *APIServer) checkPreconditions(ctx context.Context) (interfaces.UserInfo, error) {
-	authenticator := s.env.GetAuthenticator()
-	if authenticator == nil {
-		return nil, status.FailedPreconditionErrorf("No authenticator configured")
-	}
 	return s.env.GetAuthenticator().AuthenticatedUser(ctx)
 }
 

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -1388,11 +1388,7 @@ func (p *PebbleCache) Statusz(ctx context.Context) string {
 }
 
 func (p *PebbleCache) userGroupID(ctx context.Context) string {
-	auth := p.env.GetAuthenticator()
-	if auth == nil {
-		return interfaces.AuthAnonymousUser
-	}
-	user, err := auth.AuthenticatedUser(ctx)
+	user, err := p.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return interfaces.AuthAnonymousUser
 	}
@@ -1410,11 +1406,7 @@ func (p *PebbleCache) lookupGroupAndPartitionID(ctx context.Context, remoteInsta
 }
 
 func (p *PebbleCache) encryptionEnabled(ctx context.Context) (bool, error) {
-	auth := p.env.GetAuthenticator()
-	if auth == nil {
-		return false, nil
-	}
-	u, err := auth.AuthenticatedUser(ctx)
+	u, err := p.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return false, nil
 	}

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -833,10 +833,6 @@ func (d *UserDB) GetUserByIDWithoutAuthCheck(ctx context.Context, id string) (*t
 }
 
 func (d *UserDB) GetUserByEmail(ctx context.Context, email string) (*tables.User, error) {
-	auth := d.env.GetAuthenticator()
-	if auth == nil {
-		return nil, status.InternalError("No auth configured on this BuildBuddy instance")
-	}
 	u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
@@ -866,10 +862,6 @@ func (d *UserDB) GetUserByEmail(ctx context.Context, email string) (*tables.User
 }
 
 func (d *UserDB) GetUser(ctx context.Context) (*tables.User, error) {
-	auth := d.env.GetAuthenticator()
-	if auth == nil {
-		return nil, status.InternalError("No auth configured on this BuildBuddy instance")
-	}
 	u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
@@ -920,10 +912,6 @@ func (d *UserDB) getUser(ctx context.Context, tx interfaces.DB, userID string) (
 }
 
 func (d *UserDB) GetImpersonatedUser(ctx context.Context) (*tables.User, error) {
-	auth := d.env.GetAuthenticator()
-	if auth == nil {
-		return nil, status.InternalError("No auth configured on this BuildBuddy instance")
-	}
 	u, err := d.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err

--- a/enterprise/server/raft/cache/cache.go
+++ b/enterprise/server/raft/cache/cache.go
@@ -288,11 +288,7 @@ func (rc *RaftCache) Check(ctx context.Context) error {
 }
 
 func (rc *RaftCache) lookupGroupAndPartitionID(ctx context.Context, remoteInstanceName string) (string, string, error) {
-	auth := rc.env.GetAuthenticator()
-	if auth == nil {
-		return interfaces.AuthAnonymousUser, DefaultPartitionID, nil
-	}
-	user, err := auth.AuthenticatedUser(ctx)
+	user, err := rc.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return interfaces.AuthAnonymousUser, DefaultPartitionID, nil
 	}

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -201,10 +201,8 @@ func (s *ExecutionServer) insertExecution(ctx context.Context, executionID, invo
 	}
 
 	var permissions *perms.UserGroupPerm
-	if auth := s.env.GetAuthenticator(); auth != nil {
-		if u, err := auth.AuthenticatedUser(ctx); err == nil && u.GetGroupID() != "" {
-			permissions = perms.DefaultPermissions(u)
-		}
+	if u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx); err == nil && u.GetGroupID() != "" {
+		permissions = perms.DefaultPermissions(u)
 	}
 
 	if permissions == nil && s.env.GetAuthenticator().AnonymousUsageEnabled(ctx) {

--- a/enterprise/server/saml/saml.go
+++ b/enterprise/server/saml/saml.go
@@ -204,7 +204,7 @@ type SAMLAuthenticator struct {
 }
 
 func IsEnabled(env environment.Env) bool {
-	if (*certFile == "" && *cert == "") || env.GetAuthenticator() == nil {
+	if *certFile == "" && *cert == "" {
 		return false
 	}
 	return true

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -252,15 +252,10 @@ func (h *executorHandle) authorize(ctx context.Context) (string, error) {
 	if !h.requireAuthorization {
 		return "", nil
 	}
-
-	auth := h.env.GetAuthenticator()
-	if auth == nil {
-		return "", status.FailedPreconditionError("executor authorization required, but authenticator is not set")
-	}
 	// We intentionally use AuthenticateGRPCRequest instead of AuthenticatedUser to ensure that we refresh the
 	// credentials to handle the case where the API key is deleted (or capabilities are updated) after the stream was
 	// created.
-	user, err := auth.AuthenticateGRPCRequest(ctx)
+	user, err := h.env.GetAuthenticator().AuthenticateGRPCRequest(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -242,9 +242,6 @@ func (ws *workflowService) checkPreconditions(ctx context.Context) error {
 	if ws.env.GetDBHandle() == nil {
 		return status.FailedPreconditionError("database not configured")
 	}
-	if ws.env.GetAuthenticator() == nil {
-		return status.FailedPreconditionError("anonymous workflow access is not supported")
-	}
 	if _, err := ws.env.GetAuthenticator().AuthenticatedUser(ctx); err != nil {
 		return err
 	}
@@ -1294,9 +1291,6 @@ func (ws *workflowService) gitProviderForRequest(r *http.Request) (interfaces.Gi
 func (ws *workflowService) checkStartWorkflowPreconditions(ctx context.Context) error {
 	if ws.env.GetDBHandle() == nil {
 		return status.FailedPreconditionError("database not configured")
-	}
-	if ws.env.GetAuthenticator() == nil {
-		return status.FailedPreconditionError("anonymous workflow access is not supported")
 	}
 	if ws.env.GetRemoteExecutionClient() == nil {
 		return status.UnavailableError("Remote execution not configured.")

--- a/server/backends/disk_cache/disk_cache.go
+++ b/server/backends/disk_cache/disk_cache.go
@@ -307,11 +307,7 @@ func (c *DiskCache) IsV2Layout() bool {
 }
 
 func (c *DiskCache) getPartition(ctx context.Context, remoteInstanceName string) (*partition, error) {
-	auth := c.env.GetAuthenticator()
-	if auth == nil {
-		return c.defaultPartition, nil
-	}
-	user, err := auth.AuthenticatedUser(ctx)
+	user, err := c.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return c.defaultPartition, nil
 	}

--- a/server/backends/github/github.go
+++ b/server/backends/github/github.go
@@ -561,13 +561,12 @@ func (c *GithubClient) fetchToken(ctx context.Context, ownerRepo string) error {
 		return nil
 	}
 
-	auth := c.env.GetAuthenticator()
 	dbHandle := c.env.GetDBHandle()
-	if auth == nil || dbHandle == nil {
+	if dbHandle == nil {
 		return nil
 	}
 
-	userInfo, err := auth.AuthenticatedUser(ctx)
+	userInfo, err := c.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if userInfo == nil || err != nil {
 		return nil
 	}

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -182,10 +182,8 @@ func (t *TargetTracker) testTargetsInAtLeastState(state targetState) bool {
 }
 
 func (t *TargetTracker) permissionsFromContext(ctx context.Context) (*perms.UserGroupPerm, error) {
-	if auth := t.env.GetAuthenticator(); auth != nil {
-		if u, err := auth.AuthenticatedUser(ctx); err == nil && u.GetGroupID() != "" {
-			return perms.DefaultPermissions(u), nil
-		}
+	if u, err := t.env.GetAuthenticator().AuthenticatedUser(ctx); err == nil && u.GetGroupID() != "" {
+		return perms.DefaultPermissions(u), nil
 	}
 	return nil, status.UnauthenticatedError("Context did not contain auth information")
 }

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -167,11 +167,7 @@ func (s *BuildBuddyServer) SearchInvocation(ctx context.Context, req *inpb.Searc
 }
 
 func (s *BuildBuddyServer) UpdateInvocation(ctx context.Context, req *inpb.UpdateInvocationRequest) (*inpb.UpdateInvocationResponse, error) {
-	auth := s.env.GetAuthenticator()
-	if auth == nil {
-		return nil, status.UnimplementedError("Not Implemented")
-	}
-	authenticatedUser, err := auth.AuthenticatedUser(ctx)
+	authenticatedUser, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -187,11 +183,7 @@ func (s *BuildBuddyServer) UpdateInvocation(ctx context.Context, req *inpb.Updat
 }
 
 func (s *BuildBuddyServer) DeleteInvocation(ctx context.Context, req *inpb.DeleteInvocationRequest) (*inpb.DeleteInvocationResponse, error) {
-	auth := s.env.GetAuthenticator()
-	if auth == nil {
-		return nil, status.UnimplementedError("Not Implemented")
-	}
-	authenticatedUser, err := auth.AuthenticatedUser(ctx)
+	authenticatedUser, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -306,10 +298,6 @@ func (s *BuildBuddyServer) GetUser(ctx context.Context, req *uspb.GetUserRequest
 		return nil, status.UnimplementedError("Not Implemented")
 	}
 
-	auth := s.env.GetAuthenticator()
-	if auth == nil {
-		return nil, status.InternalError("No auth configured on this BuildBuddy instance")
-	}
 	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
@@ -371,13 +359,12 @@ func (s *BuildBuddyServer) GetUser(ctx context.Context, req *uspb.GetUserRequest
 }
 
 func (s *BuildBuddyServer) CreateUser(ctx context.Context, req *uspb.CreateUserRequest) (*uspb.CreateUserResponse, error) {
-	auth := s.env.GetAuthenticator()
 	userDB := s.env.GetUserDB()
-	if auth == nil || userDB == nil {
+	if userDB == nil {
 		return nil, status.UnimplementedError("Not Implemented")
 	}
 	tu := &tables.User{}
-	if err := auth.FillUser(ctx, tu); err != nil {
+	if err := s.env.GetAuthenticator().FillUser(ctx, tu); err != nil {
 		return nil, err
 	}
 	if err := userDB.InsertUser(ctx, tu); err != nil {
@@ -514,9 +501,8 @@ func (s *BuildBuddyServer) CreateGroup(ctx context.Context, req *grpb.CreateGrou
 }
 
 func (s *BuildBuddyServer) UpdateGroup(ctx context.Context, req *grpb.UpdateGroupRequest) (*grpb.UpdateGroupResponse, error) {
-	auth := s.env.GetAuthenticator()
 	userDB := s.env.GetUserDB()
-	if auth == nil || userDB == nil {
+	if userDB == nil {
 		return nil, status.UnimplementedError("Not Implemented")
 	}
 	var group *tables.Group
@@ -564,9 +550,8 @@ func (s *BuildBuddyServer) UpdateGroup(ctx context.Context, req *grpb.UpdateGrou
 }
 
 func (s *BuildBuddyServer) JoinGroup(ctx context.Context, req *grpb.JoinGroupRequest) (*grpb.JoinGroupResponse, error) {
-	auth := s.env.GetAuthenticator()
 	userDB := s.env.GetUserDB()
-	if auth == nil || userDB == nil {
+	if userDB == nil {
 		return nil, status.UnimplementedError("Not Implemented")
 	}
 	if _, err := userDB.RequestToJoinGroup(ctx, req.GetId()); err != nil {
@@ -658,11 +643,7 @@ func (s *BuildBuddyServer) CreateApiKey(ctx context.Context, req *akpb.CreateApi
 }
 
 func (s *BuildBuddyServer) authorizeInvocationWrite(ctx context.Context, invocationID string) error {
-	auth := s.env.GetAuthenticator()
-	if auth == nil {
-		return status.UnimplementedError("Not Implemented")
-	}
-	authenticatedUser, err := auth.AuthenticatedUser(ctx)
+	authenticatedUser, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return err
 	}
@@ -973,10 +954,6 @@ func (s *BuildBuddyServer) getAPIKeysForAuthorizedGroup(ctx context.Context) ([]
 	if err := perms.AuthorizeGroupAccess(ctx, s.env, groupID); err != nil {
 		return nil, err
 	}
-	auth := s.env.GetAuthenticator()
-	if auth == nil {
-		return nil, status.UnimplementedError("Not Implemented")
-	}
 	authDB := s.env.GetAuthDB()
 	if authDB == nil {
 		return nil, status.UnimplementedError("Not Implemented")
@@ -1203,11 +1180,7 @@ func (s *BuildBuddyServer) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 		// Set the workflow ID if it's not on the request
 		// Note: This will only work for workflows created with the github app integration and not the legacy approach
 		if req.GetWorkflowId() == "" {
-			auth := s.env.GetAuthenticator()
-			if auth == nil {
-				return nil, status.UnimplementedError("Not Implemented")
-			}
-			authenticatedUser, err := auth.AuthenticatedUser(ctx)
+			authenticatedUser, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -383,11 +383,10 @@ func StartAndRunServices(env *real_environment.RealEnv) {
 	mux.Handle("/healthz", env.GetHealthChecker().LivenessHandler())
 	mux.Handle("/readyz", env.GetHealthChecker().ReadinessHandler())
 
-	if auth := env.GetAuthenticator(); auth != nil {
-		mux.Handle("/login/", interceptors.SetSecurityHeaders(interceptors.RedirectOnError(auth.Login)))
-		mux.Handle("/auth/", interceptors.SetSecurityHeaders(interceptors.RedirectOnError(auth.Auth)))
-		mux.Handle("/logout/", interceptors.SetSecurityHeaders(interceptors.RedirectOnError(auth.Logout)))
-	}
+	auth := env.GetAuthenticator()
+	mux.Handle("/login/", interceptors.SetSecurityHeaders(interceptors.RedirectOnError(auth.Login)))
+	mux.Handle("/auth/", interceptors.SetSecurityHeaders(interceptors.RedirectOnError(auth.Auth)))
+	mux.Handle("/logout/", interceptors.SetSecurityHeaders(interceptors.RedirectOnError(auth.Logout)))
 
 	if err := github.Register(env); err != nil {
 		log.Fatalf("%v", err)

--- a/server/remote_cache/capabilities_server/BUILD
+++ b/server/remote_cache/capabilities_server/BUILD
@@ -14,6 +14,5 @@ go_library(
         "//server/remote_cache/config",
         "//server/remote_cache/digest",
         "//server/util/bazel_request",
-        "//server/util/perms",
     ],
 )

--- a/server/remote_cache/capabilities_server/capabilities_server.go
+++ b/server/remote_cache/capabilities_server/capabilities_server.go
@@ -8,7 +8,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
-	"github.com/buildbuddy-io/buildbuddy/server/util/perms"
 
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -109,11 +108,7 @@ func (s *CapabilitiesServer) actionCacheUpdateEnabled(ctx context.Context) bool 
 	// making AC write requests that would just be dropped anyway. In other
 	// cases, we return true here and defer any auth error handling to the
 	// action cache server when the update is actually attempted.
-	auth := s.env.GetAuthenticator()
-	if auth == nil {
-		return true
-	}
-	u, err := perms.AuthenticatedUser(ctx, s.env)
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return true
 	}

--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -91,13 +91,11 @@ func contextReplacingUnaryClientInterceptor(ctxFn func(ctx context.Context) cont
 }
 
 func addAuthToContext(env environment.Env, ctx context.Context) context.Context {
-	if auth := env.GetAuthenticator(); auth != nil {
-		ctx = auth.AuthenticatedGRPCContext(ctx)
-		if c, err := claims.ClaimsFromContext(ctx); err == nil {
-			ctx = log.EnrichContext(ctx, "group_id", c.GetGroupID())
-			if c.GetUserID() != "" {
-				ctx = log.EnrichContext(ctx, "user_id", c.GetGroupID())
-			}
+	ctx = env.GetAuthenticator().AuthenticatedGRPCContext(ctx)
+	if c, err := claims.ClaimsFromContext(ctx); err == nil {
+		ctx = log.EnrichContext(ctx, "group_id", c.GetGroupID())
+		if c.GetUserID() != "" {
+			ctx = log.EnrichContext(ctx, "user_id", c.GetGroupID())
 		}
 	}
 	return ctx

--- a/server/target/target.go
+++ b/server/target/target.go
@@ -120,11 +120,7 @@ func ApplyToQuery(timestampField string, t *tppb.PaginationToken, q *query_build
 }
 
 func GetTargetHistory(ctx context.Context, env environment.Env, req *trpb.GetTargetHistoryRequest) (*trpb.GetTargetHistoryResponse, error) {
-	auth := env.GetAuthenticator()
-	if auth == nil {
-		return nil, status.UnimplementedError("Not Implemented")
-	}
-	_, err := auth.AuthenticatedUser(ctx)
+	_, err := env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/server/telemetry/BUILD
+++ b/server/telemetry/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//server/backends/blobstore",
         "//server/endpoint_urls/build_buddy_url",
         "//server/environment",
+        "//server/nullauth",
         "//server/remote_execution/config",
         "//server/util/grpc_client",
         "//server/util/log",

--- a/server/telemetry/telemetry_client.go
+++ b/server/telemetry/telemetry_client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/backends/blobstore"
 	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/build_buddy_url"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/nullauth"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/version"
@@ -203,13 +204,12 @@ func getHostname() string {
 
 func getFeatures(env environment.Env) *telpb.TelemetryFeature {
 	cache := env.GetCache()
-	authenticator := env.GetAuthenticator()
 	api := env.GetAPIService()
-
+	_, isNullAuth := env.GetAuthenticator().(*nullauth.NullAuthenticator)
 	return &telpb.TelemetryFeature{
 		CacheEnabled: cache != nil,
 		RbeEnabled:   remote_execution_config.RemoteExecutionEnabled(),
 		ApiEnabled:   api != nil,
-		AuthEnabled:  authenticator != nil,
+		AuthEnabled:  !isNullAuth,
 	}
 }

--- a/server/util/capabilities/capabilities.go
+++ b/server/util/capabilities/capabilities.go
@@ -72,9 +72,6 @@ func IsGranted(ctx context.Context, env environment.Env, cap akpb.ApiKey_Capabil
 
 func ForAuthenticatedUser(ctx context.Context, env environment.Env) ([]akpb.ApiKey_Capability, error) {
 	auth := env.GetAuthenticator()
-	if auth == nil {
-		return nil, status.UnimplementedError("Auth is not configured")
-	}
 	u, err := auth.AuthenticatedUser(ctx)
 	if err != nil {
 		if authutil.IsAnonymousUserError(err) && auth.AnonymousUsageEnabled(ctx) {
@@ -88,11 +85,7 @@ func ForAuthenticatedUser(ctx context.Context, env environment.Env) ([]akpb.ApiK
 // ForAuthenticatedUserGroup returns the authenticated user's capabilities
 // within the given group ID.
 func ForAuthenticatedUserGroup(ctx context.Context, env environment.Env, groupID string) ([]akpb.ApiKey_Capability, error) {
-	auth := env.GetAuthenticator()
-	if auth == nil {
-		return nil, status.UnimplementedError("Auth is not configured")
-	}
-	u, err := auth.AuthenticatedUser(ctx)
+	u, err := env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/server/util/perms/perms.go
+++ b/server/util/perms/perms.go
@@ -211,32 +211,31 @@ func GetPermissionsCheckClauses(ctx context.Context, env environment.Env, q *que
 	o.AddOr(fmt.Sprintf("(%sperms & ? != 0)", tablePrefix), OTHERS_READ)
 
 	hasUser := false
-	if auth := env.GetAuthenticator(); auth != nil {
-		if u, err := auth.AuthenticatedUser(ctx); err == nil {
-			hasUser = true
-			if u.GetUserID() != "" {
-				groupArgs := []interface{}{
-					GROUP_READ,
-				}
-				groupParams := make([]string, 0)
-				for _, groupID := range u.GetAllowedGroups() {
-					groupArgs = append(groupArgs, groupID)
-					groupParams = append(groupParams, "?")
-				}
-				groupParamString := "(" + strings.Join(groupParams, ", ") + ")"
-				groupQueryStr := fmt.Sprintf("(%sperms & ? != 0 AND %sgroup_id IN %s)", tablePrefix, tablePrefix, groupParamString)
-				o.AddOr(groupQueryStr, groupArgs...)
-				o.AddOr(fmt.Sprintf("(%sperms & ? != 0 AND %suser_id = ?)", tablePrefix, tablePrefix), OWNER_READ, u.GetUserID())
-			} else if u.GetGroupID() != "" {
-				groupArgs := []interface{}{
-					GROUP_READ,
-					u.GetGroupID(),
-				}
-				o.AddOr(fmt.Sprintf("(%sperms & ? != 0 AND %sgroup_id = ?)", tablePrefix, tablePrefix), groupArgs...)
+	auth := env.GetAuthenticator()
+	if u, err := auth.AuthenticatedUser(ctx); err == nil {
+		hasUser = true
+		if u.GetUserID() != "" {
+			groupArgs := []interface{}{
+				GROUP_READ,
 			}
-			if u.IsAdmin() {
-				o.AddOr(fmt.Sprintf("(%sperms & ? != 0)", tablePrefix), ALL)
+			groupParams := make([]string, 0)
+			for _, groupID := range u.GetAllowedGroups() {
+				groupArgs = append(groupArgs, groupID)
+				groupParams = append(groupParams, "?")
 			}
+			groupParamString := "(" + strings.Join(groupParams, ", ") + ")"
+			groupQueryStr := fmt.Sprintf("(%sperms & ? != 0 AND %sgroup_id IN %s)", tablePrefix, tablePrefix, groupParamString)
+			o.AddOr(groupQueryStr, groupArgs...)
+			o.AddOr(fmt.Sprintf("(%sperms & ? != 0 AND %suser_id = ?)", tablePrefix, tablePrefix), OWNER_READ, u.GetUserID())
+		} else if u.GetGroupID() != "" {
+			groupArgs := []interface{}{
+				GROUP_READ,
+				u.GetGroupID(),
+			}
+			o.AddOr(fmt.Sprintf("(%sperms & ? != 0 AND %sgroup_id = ?)", tablePrefix, tablePrefix), groupArgs...)
+		}
+		if u.IsAdmin() {
+			o.AddOr(fmt.Sprintf("(%sperms & ? != 0)", tablePrefix), ALL)
 		}
 	}
 
@@ -311,10 +310,6 @@ func AuthenticatedGroupID(ctx context.Context, env environment.Env) (string, err
 // or OTHERS_READ for anonymous users.
 func ForAuthenticatedGroup(ctx context.Context, env environment.Env) (*UserGroupPerm, error) {
 	auth := env.GetAuthenticator()
-	if auth == nil {
-		return nil, status.UnimplementedError("Auth is not configured")
-	}
-
 	u, err := auth.AuthenticatedUser(ctx)
 	if err != nil || u.GetGroupID() == "" {
 		if authutil.IsAnonymousUserError(err) && auth.AnonymousUsageEnabled(ctx) {


### PR DESCRIPTION
Follow-up from https://github.com/buildbuddy-io/buildbuddy/pull/5899#pullrequestreview-1878738508

The app binds a `NullAuthenticator` instance if auth is disabled, otherwise it binds a "real" authenticator, so `env.GetAuthenticator()` will never return `nil`. As a result, we can simplify any code that checks whether the authenticator is nil.

Also, some of our existing code was already not doing the nil checks, so if anything, this PR makes the nil checking consistent by removing it everywhere.

**Related issues**: N/A
