### PR TITLE
Add comments for exported methods in RangeMap, and update some tests

### DIFF
--- a/server/util/rangemap/rangemap.go
+++ b/server/util/rangemap/rangemap.go
@@ -14,7 +14,8 @@ var (
 	RangeDoesNotExistError = errors.New("Range does not exist")
 )
 
-// Ranges are [inclusive,exclusive)
+// Range is a data structure that holds [start, end) (i.e. inclusive start and
+// exclusive end) and a value.
 type Range struct {
 	Start []byte
 	End   []byte
@@ -36,6 +37,8 @@ func (r *Range) Contains(key []byte) bool {
 	return contained
 }
 
+// RangeMap is an ordered map of ranges that supports add, remove, and look up
+// Ranges. The ranges in RangeMap are non-overlapping.
 type RangeMap struct {
 	ranges []*Range
 }
@@ -46,6 +49,8 @@ func New() *RangeMap {
 	}
 }
 
+// Add adds a range to RangeMap. Returns an error if the new range overlap with
+// existing ranges.
 func (rm *RangeMap) Add(start, end []byte, value interface{}) (*Range, error) {
 	insertIndex := sort.Search(len(rm.ranges), func(i int) bool {
 		//  0 if a==b, -1 if a < b, and +1 if a > b
@@ -79,6 +84,8 @@ func (rm *RangeMap) Add(start, end []byte, value interface{}) (*Range, error) {
 	return newRange, nil
 }
 
+// Remove removes a range with the specific start and end.
+// Returns RangeDoesNotExistError if the range is not found.
 func (rm *RangeMap) Remove(start, end []byte) error {
 	deleteIndex := -1
 	for i, r := range rm.ranges {
@@ -94,6 +101,8 @@ func (rm *RangeMap) Remove(start, end []byte) error {
 	return nil
 }
 
+// Get returns the range with the specific start and end. Returns nil if the
+// range is not found.
 func (rm *RangeMap) Get(start, end []byte) *Range {
 	if len(rm.ranges) == 0 {
 		return nil
@@ -122,6 +131,8 @@ func (rm *RangeMap) Get(start, end []byte) *Range {
 	return nil
 }
 
+// GetOverlapping returns a list of ranges overlapped witht the specific start
+// and end.
 func (rm *RangeMap) GetOverlapping(start, end []byte) []*Range {
 	if len(rm.ranges) == 0 {
 		return nil
@@ -152,6 +163,8 @@ func (rm *RangeMap) GetOverlapping(start, end []byte) []*Range {
 	return rm.ranges[startIndex:endIndex]
 }
 
+// Lookup looks up the range containing the key and returns the value of the
+// range.
 func (rm *RangeMap) Lookup(key []byte) interface{} {
 	if len(rm.ranges) == 0 {
 		return nil
@@ -189,6 +202,7 @@ func (rm *RangeMap) String() string {
 	return buf
 }
 
+// Ranges returns a list of ordered ranges that the RangeMap contains.
 func (rm *RangeMap) Ranges() []*Range {
 	return rm.ranges
 }

--- a/server/util/rangemap/rangemap.go
+++ b/server/util/rangemap/rangemap.go
@@ -131,7 +131,7 @@ func (rm *RangeMap) Get(start, end []byte) *Range {
 	return nil
 }
 
-// GetOverlapping returns a list of ranges overlapped witht the specific start
+// GetOverlapping returns a list of ranges overlapped with the specific start
 // and end.
 func (rm *RangeMap) GetOverlapping(start, end []byte) []*Range {
 	if len(rm.ranges) == 0 {

--- a/server/util/rangemap/rangemap_test.go
+++ b/server/util/rangemap/rangemap_test.go
@@ -17,24 +17,24 @@ func TestAddOrdering(t *testing.T) {
 
 	addRange("c", "d", 2)
 	addRange("a", "b", 1)
-	addRange("g", "h", 4)
-	addRange("m", "n", 7)
-	addRange("k", "l", 6)
-	addRange("e", "f", 3)
+	addRange("g", "h", 7)
+	addRange("m", "n", 4)
+	addRange("k", "l", 3)
+	addRange("e", "f", 6)
 	addRange("o", "pp", 8)
 	addRange("i", "j", 5)
 
 	ranges := r.Ranges()
 
 	require.Equal(t, 8, len(ranges))
-	require.Equal(t, ranges[0].Val, 1)
-	require.Equal(t, ranges[1].Val, 2)
-	require.Equal(t, ranges[2].Val, 3)
-	require.Equal(t, ranges[3].Val, 4)
-	require.Equal(t, ranges[4].Val, 5)
-	require.Equal(t, ranges[5].Val, 6)
-	require.Equal(t, ranges[6].Val, 7)
-	require.Equal(t, ranges[7].Val, 8)
+	require.Equal(t, ranges[0].Start, []byte("a"))
+	require.Equal(t, ranges[1].Start, []byte("c"))
+	require.Equal(t, ranges[2].Start, []byte("e"))
+	require.Equal(t, ranges[3].Start, []byte("g"))
+	require.Equal(t, ranges[4].Start, []byte("i"))
+	require.Equal(t, ranges[5].Start, []byte("k"))
+	require.Equal(t, ranges[6].Start, []byte("m"))
+	require.Equal(t, ranges[7].Start, []byte("o"))
 }
 
 func TestAddOverlapError(t *testing.T) {
@@ -158,6 +158,8 @@ func TestGet(t *testing.T) {
 	require.Equal(t, 1, r1.Val)
 	require.Equal(t, 2, r2.Val)
 	require.Nil(t, r.Get([]byte("ffff"), []byte("z")))
+	require.Nil(t, r.Get([]byte("aaad"), []byte("aaae")))
+	require.Nil(t, r.Get([]byte("aaae"), []byte("ffff")))
 }
 
 func TestGetOverlapping(t *testing.T) {
@@ -203,7 +205,7 @@ func TestRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	err = r.Remove([]byte("a"), []byte("z"))
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 	require.Equal(t, nil, r.Lookup([]byte("d")))
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
In TestAddOrdering, check the order of range.Start instead of range.Val, since we are ordering by the interval instead of value. 
In TestGet, add test cases where only one of start and end matches. 
