### PR TITLE
Remove global admin group logic

### DIFF
--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -108,11 +108,6 @@ type UserInfo interface {
 	GetGroupMemberships() []*GroupMembership
 	// GetCapabilities returns the user's capabilities.
 	GetCapabilities() []akpb.ApiKey_Capability
-	// IsAdmin returns whether this user is a global administrator, meaning
-	// they can access data across groups. This is not to be confused with the
-	// concept of group admin, which grants full access only within a single
-	// group.
-	IsAdmin() bool
 	HasCapability(akpb.ApiKey_Capability) bool
 	GetUseGroupOwnedExecutors() bool
 	GetCacheEncryptionEnabled() bool

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -82,15 +82,6 @@ func (c *Claims) GetCapabilities() []akpb.ApiKey_Capability {
 	return c.Capabilities
 }
 
-func (c *Claims) IsAdmin() bool {
-	for _, groupID := range c.AllowedGroups {
-		if groupID == "admin" {
-			return true
-		}
-	}
-	return false
-}
-
 func (c *Claims) HasCapability(cap akpb.ApiKey_Capability) bool {
 	for _, cc := range c.Capabilities {
 		if cap&cc > 0 {

--- a/server/util/perms/perms.go
+++ b/server/util/perms/perms.go
@@ -114,7 +114,7 @@ func AuthorizeRead(u interfaces.UserInfo, acl *aclpb.ACL) error {
 		return err
 	}
 
-	if perms&OTHERS_READ != 0 || u.IsAdmin() {
+	if perms&OTHERS_READ != 0 {
 		return nil
 	}
 	isOwner := u.GetUserID() == acl.GetUserId().GetId()
@@ -209,9 +209,6 @@ func GetPermissionsCheckClauses(ctx context.Context, env environment.Env, q *que
 				u.GetGroupID(),
 			}
 			o.AddOr(fmt.Sprintf("(%sperms & ? != 0 AND %sgroup_id = ?)", tablePrefix, tablePrefix), groupArgs...)
-		}
-		if u.IsAdmin() {
-			o.AddOr(fmt.Sprintf("(%sperms & ? != 0)", tablePrefix), ALL)
 		}
 	}
 


### PR DESCRIPTION
This "admin" group is no longer used since we added proper impersonation. Checked in the DB, and no users are a member of the "admin" group ID according to the UserGroups table.

**Related issues**: N/A
