### PR TITLE
Enable golang static check analyzer S1028: 'Simplify error construction with fmt.Errorf'

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -108,7 +108,6 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/unusedresult",
         "@com_github_nishanths_exhaustive//:exhaustive",
     ] + staticcheck_analyzers(ANALYZERS + [
-        "-S1028",
         "-S1030",
         "-S1031",
         "-S1034",

--- a/enterprise/tools/check_metrics/check_metrics.go
+++ b/enterprise/tools/check_metrics/check_metrics.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -125,7 +124,7 @@ func main() {
 
 						if !metric.Secondary || len(failedMetrics) >= spec.MaxSecondaryMetricFailureCount {
 							failedMetricsStr := strings.Join(failedMetrics, ", ")
-							return errors.New(fmt.Sprintf("Metrics unhealthy: %s", failedMetricsStr))
+							return fmt.Errorf("Metrics unhealthy: %s", failedMetricsStr)
 						}
 						return nil
 					}


### PR DESCRIPTION
**Related issues**: N/A
