### PR TITLE
Enable golang static check analyzer S1031: 'Omit redundant nil check around loop'

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -110,7 +110,6 @@ nogo(
     ] + staticcheck_analyzers(ANALYZERS + [
         "-S1028",
         "-S1030",
-        "-S1031",
         "-S1034",
         "-S1024",
         "-SA1019",

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -248,10 +248,8 @@ func invokeRunner(t *testing.T, args []string, env []string, workDir string) *re
 
 	invocationIDs := []string{}
 	iidMatches := invocationIDPattern.FindAllStringSubmatch(output, -1)
-	if iidMatches != nil {
-		for _, m := range iidMatches {
-			invocationIDs = append(invocationIDs, m[1])
-		}
+	for _, m := range iidMatches {
+		invocationIDs = append(invocationIDs, m[1])
 	}
 	return &result{
 		Output:        output,


### PR DESCRIPTION
**Related issues**: N/A
