### PR TITLE
Log action resource name in bb execute debug logs

### DIFF
--- a/cli/execute/execute.go
+++ b/cli/execute/execute.go
@@ -149,6 +149,8 @@ func execute(cmdArgs []string) error {
 		return err
 	}
 	log.Debugf("Uploaded inputs in %s", time.Since(stageStart))
+	actionStr, _ := digest.ResourceNameFromProto(arn).DownloadString()
+	log.Debugf("Uploaded action resource name: %s", actionStr)
 	stageStart = time.Now()
 	log.Debug("Starting /Execute request")
 	stream, err := rexec.Start(ctx, env, arn)

--- a/cli/execute/execute.go
+++ b/cli/execute/execute.go
@@ -149,8 +149,12 @@ func execute(cmdArgs []string) error {
 		return err
 	}
 	log.Debugf("Uploaded inputs in %s", time.Since(stageStart))
-	actionStr, _ := digest.ResourceNameFromProto(arn).DownloadString()
-	log.Debugf("Uploaded action resource name: %s", actionStr)
+	actionStr, err := digest.ResourceNameFromProto(arn).DownloadString()
+	if err != nil {
+		log.Debugf("Failed to compute action resource name: %s", err)
+	} else {
+		log.Debugf("Action resource name: %s", actionStr)
+	}
 	stageStart = time.Now()
 	log.Debug("Starting /Execute request")
 	stream, err := rexec.Start(ctx, env, arn)


### PR DESCRIPTION
This is useful to be able to debug the action afterwards (e.g. fetch the full ActionResult from AC using `tools/cas`).

**Related issues**: N/A
