### PR TITLE
[RB] Add a CI workflow using remote bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -123,7 +123,7 @@ common:deflake-go --test_arg=-test.failfast
 # Configuration used for Linux workflows
 common:linux-workflows --config=remote-shared
 common:linux-workflows --config=workflows
-common:linux-workflows --config=buildbuddy_remote_executor
+common:linux-workflows --remote_executor=grpcs://buildbuddy.buildbuddy.io
 common:linux-workflows --build_metadata=TAGS=linux-workflow
 
 # Configuration used for Mac workflows

--- a/.bazelrc
+++ b/.bazelrc
@@ -123,7 +123,7 @@ common:deflake-go --test_arg=-test.failfast
 # Configuration used for Linux workflows
 common:linux-workflows --config=remote-shared
 common:linux-workflows --config=workflows
-common:linux-workflows --remote_executor=grpcs://buildbuddy.buildbuddy.io
+common:linux-workflows --config=buildbuddy_remote_executor
 common:linux-workflows --build_metadata=TAGS=linux-workflow
 
 # Configuration used for Mac workflows

--- a/.github/workflows/remote-bazel-build.yaml
+++ b/.github/workflows/remote-bazel-build.yaml
@@ -1,0 +1,38 @@
+name: Remote bazel tests (prod)
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BUILDBUDDY_GITHUB_USER_TOKEN }}
+          # Fetch all branches so we can checkout the master branch
+          fetch-depth: 0
+
+      - name: Download bb cli
+        run: |
+          cli/install.sh
+
+      - name: Setup git env
+        run: |
+          # The cli reads the local git branches in order to determine the default branch
+          # Briefly checkout the master branch so it can find it
+          git checkout master
+          git checkout -
+
+      - name: Test
+        run: |
+          bb remote test //... \
+            --config=linux-workflows --config=race \
+            --remote_executor=grpcs://buildbuddy.buildbuddy.io \
+            --test_tag_filters=-performance,-webdriver,-docker,-bare \
+            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}

--- a/.github/workflows/remote-bazel-build.yaml
+++ b/.github/workflows/remote-bazel-build.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Test
         run: |
-          bb --verbose=1 remote test //... \
+          bb remote test //... \
             --config=linux-workflows --config=race \
             --remote_executor=grpcs://buildbuddy.buildbuddy.io \
             --test_tag_filters=-performance,-webdriver,-docker,-bare \

--- a/.github/workflows/remote-bazel-build.yaml
+++ b/.github/workflows/remote-bazel-build.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Test
         run: |
-          bb remote test //... \
+          bb --verbose=1 remote test //... \
             --config=linux-workflows --config=race \
             --remote_executor=grpcs://buildbuddy.buildbuddy.io \
             --test_tag_filters=-performance,-webdriver,-docker,-bare \

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -107,4 +107,3 @@ plugins:
   - path: cli/plugins/open-invocation
   - path: cli/plugins/notify
   - path: cli/example_plugins/go-highlight
-  - path: cli/example_plugins/ping-remote


### PR DESCRIPTION
Add a CI workflow using remote bazel so we can test it out more and compare it performance-wise to bb workflows. Run the same test command we have in our workflows config.

**Related issues**: N/A
