### PR TITLE
[raft] retry when one replica is unavailable

### DIFF
--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -189,7 +189,7 @@ func (s *Sender) tryReplicas(ctx context.Context, rd *rfpb.RangeDescriptor, fn r
 			}
 		}
 		if status.IsUnavailableError(err) {
-			//try a different replica if the current replica is not available.
+			// try a different replica if the current replica is not available.
 			continue
 		}
 		return 0, err


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3125
