### PR TITLE
[Raft] When addresses change, update the registry

### DIFF
--- a/enterprise/server/raft/registry/registry.go
+++ b/enterprise/server/raft/registry/registry.go
@@ -151,18 +151,10 @@ func (n *StaticRegistry) AddNode(target, raftAddress, grpcAddress string) {
 		return
 	}
 	if raftAddress != "" {
-		r, ok := n.targetRafts.LoadOrStore(target, raftAddress)
-		if ok && r.(string) != raftAddress {
-			log.Errorf("inconsistent raft for %s:%s", r, target)
-			return
-		}
+		n.targetRafts.Store(target, raftAddress)
 	}
 	if grpcAddress != "" {
-		g, ok := n.targetGrpcs.LoadOrStore(target, grpcAddress)
-		if ok && g.(string) != grpcAddress {
-			log.Errorf("inconsistent grpc for %s:%s", g, target)
-			return
-		}
+		n.targetGrpcs.Store(target, grpcAddress)
 	}
 }
 

--- a/enterprise/server/raft/registry/registry_test.go
+++ b/enterprise/server/raft/registry/registry_test.go
@@ -46,14 +46,14 @@ func requireError(t testing.TB, dnr registry.NodeRegistry, shardID, replicaID ui
 	addr, key, err := dnr.Resolve(shardID, replicaID)
 	require.Equal(t, "", addr)
 	require.Equal(t, "", key)
-	require.NotNil(t, err)
-	require.Equal(t, err.Error(), expectedErr.Error())
+	require.NoError(t, err)
+	require.ErrorIs(t, err, expectedErr)
 
 	addr, key, err = dnr.ResolveGRPC(shardID, replicaID)
 	require.Equal(t, "", addr)
 	require.Equal(t, "", key)
-	require.NotNil(t, err)
-	require.Equal(t, err.Error(), expectedErr.Error())
+	require.NoError(t, err)
+	require.ErrorIs(t, err, expectedErr)
 }
 
 func TestStaticRegistryAdd(t *testing.T) {

--- a/enterprise/server/raft/registry/registry_test.go
+++ b/enterprise/server/raft/registry/registry_test.go
@@ -70,6 +70,11 @@ func TestDynamicRegistryAdd(t *testing.T) {
 	dnr.Add(1, 1, "nhid-1")
 	dnr.AddNode("nhid-1", "raftaddress:1", "grpcaddress:1")
 	requireResolves(t, dnr, 1, 1, "raftaddress:1", "grpcaddress:1")
+
+	// When the target changes addresses, the registry should resolve the target
+	// to the new address.
+	dnr.AddNode("nhid-1", "raftaddress:2", "grpcaddress:2")
+	requireResolves(t, dnr, 1, 1, "raftaddress:2", "grpcaddress:2")
 }
 
 func TestDynamicRegistryResolution(t *testing.T) {


### PR DESCRIPTION
Currently, we call `LoadOrStore` when we call `AddNode`. If the target's raft or
gRPC addresses change, we don't store the new addresses. 

This PR 
- changes `LoarOrStore` to `Store`.
- adds a registry test where we add the same target twice with different addresses.
- in `registry_test.go`, use `require.NoError` and `require.ErrorIs` for error assertion. 

Tested locally by running smash against a raft cluster. Bring down a raft node, 
change its grpc port and bring it back. 
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
https://github.com/buildbuddy-io/buildbuddy-internal/issues/3125
