### PR TITLE
Fix invalid usage of uuid in firecracker code

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1328,14 +1328,18 @@ func nonCmdExit(ctx context.Context, err error) *interfaces.CommandResult {
 func (c *FirecrackerContainer) newID(ctx context.Context) error {
 	vmIdxMu.Lock()
 	defer vmIdxMu.Unlock()
-	u, err := uuid.NewRandom()
+	u1, err := uuid.NewRandom()
+	if err != nil {
+		return err
+	}
+	u2, err := uuid.NewRandom()
 	if err != nil {
 		return err
 	}
 	vmIdx += 1
-	log.CtxDebugf(ctx, "Container id changing from %q (%d) to %q (%d)", c.id, c.vmIdx, u.String(), vmIdx)
-	c.id = u.String()
-	c.snapshotID = u.String()
+	log.CtxDebugf(ctx, "Container id changing from %q (%d) to %q (%d)", c.id, c.vmIdx, u1.String(), vmIdx)
+	c.id = u1.String()
+	c.snapshotID = u2.String()
 	c.vmIdx = vmIdx
 
 	if vmIdx > maxVMSPerHost {


### PR DESCRIPTION
I realized that u.String() will always return the same value, when I intended for it to generate a new value.

I will refactor vmID and snapshotID in a follow up, so it's more clear that snapshotID is a unique per-run value, and vmID should only be generated at the beginning of a VM's lifecycle.
