### PR TITLE
Add linux-arm64 release binaries

### DIFF
--- a/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-amd64-github-release-artifacts.yaml
@@ -1,4 +1,4 @@
-name: "Build Linux Github Release Artifacts"
+name: "Build Linux amd64 Github Release Artifacts"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
@@ -55,8 +55,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          bazelisk build --config=release --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //server/cmd/buildbuddy:buildbuddy //enterprise/server/cmd/server:buildbuddy //enterprise/server/cmd/executor:executor
-          cp bazel-bin/server/cmd/**/**/buildbuddy buildbuddy-linux-arm64
-          cp bazel-bin/enterprise/server/cmd/**/**/buildbuddy buildbuddy-enterprise-linux-arm64
+          bazelisk build --config=release --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //enterprise/server/cmd/executor:executor
           cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-linux-arm64
-          gh release upload ${{ inputs.version_tag }} buildbuddy-linux-arm64 buildbuddy-enterprise-linux-arm64 executor-enterprise-linux-arm64 --clobber
+          gh release upload ${{ inputs.version_tag }} executor-enterprise-linux-arm64 --clobber

--- a/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
+++ b/.github/workflows/build-linux-arm64-github-release-artifacts.yaml
@@ -1,0 +1,62 @@
+name: "Build Linux arm64 Github Release Artifacts"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: "Git branch to checkout."
+        required: true
+        default: "master"
+        type: string
+      version_tag:
+        description: "Version to tag release artifacts."
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      release_branch:
+        description: "Git branch to checkout."
+        required: true
+        type: string
+      version_tag:
+        description: "Version to tag release artifacts."
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04-16cpu-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.release_branch }}
+          # We need to fetch git tags to obtain the latest version tag to report
+          # the version of the running binary.
+          fetch-depth: 0
+
+      # GitHub's arm64 runners do not have the same pre-installed software as
+      # the amd64 runners so we have to install a few things here.
+      - name: Install bazelisk
+        run: |
+          curl -L --output /tmp/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64
+          chmod +x /tmp/bazelisk
+          sudo mv /tmp/bazelisk /usr/bin/bazelisk
+
+      - name: Install GitHub CLI
+        run: |
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+          && sudo apt update \
+          && sudo apt install gh -y
+
+      - name: Build and Upload Artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bazelisk build --config=release --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //server/cmd/buildbuddy:buildbuddy //enterprise/server/cmd/server:buildbuddy //enterprise/server/cmd/executor:executor
+          cp bazel-bin/server/cmd/**/**/buildbuddy buildbuddy-linux-arm64
+          cp bazel-bin/enterprise/server/cmd/**/**/buildbuddy buildbuddy-enterprise-linux-arm64
+          cp bazel-bin/enterprise/server/cmd/**/**/executor executor-enterprise-linux-arm64
+          gh release upload ${{ inputs.version_tag }} buildbuddy-linux-arm64 buildbuddy-enterprise-linux-arm64 executor-enterprise-linux-arm64 --clobber

--- a/.github/workflows/create-github-release.yaml
+++ b/.github/workflows/create-github-release.yaml
@@ -20,8 +20,17 @@ jobs:
           prerelease: false
           draft: true
 
-  build-linux-artifacts:
-    uses: ./.github/workflows/build-linux-github-release-artifacts.yaml
+  build-linux-amd64-artifacts:
+    uses: ./.github/workflows/build-linux-amd64-github-release-artifacts.yaml
+    if: "!contains(github.event.head_commit.message, 'release skip')"
+    needs: create-release
+    with:
+      release_branch: ${{ github.ref }}
+      version_tag: ${{ github.ref_name }}
+    secrets: inherit
+
+  build-linux-arm64-artifacts:
+    uses: ./.github/workflows/build-linux-arm64-github-release-artifacts.yaml
     if: "!contains(github.event.head_commit.message, 'release skip')"
     needs: create-release
     with:

--- a/tools/check_release_assets_uploaded.py
+++ b/tools/check_release_assets_uploaded.py
@@ -6,14 +6,13 @@ import sys
 import time
 
 EXPECTED_ASSETS = [
+    # enterprise app
     "buildbuddy-enterprise-darwin-amd64",
     "buildbuddy-enterprise-linux-amd64",
-    "buildbuddy-enterprise-linux-arm64",
-
-    "buildbuddy-darwin-amd64"
+    # OSS app
+    "buildbuddy-darwin-amd64",
     "buildbuddy-linux-amd64",
-    "buildbuddy-linux-arm64",
-
+    # executor
     "executor-enterprise-darwin-amd64",
     "executor-enterprise-darwin-arm64",
     "executor-enterprise-linux-amd64",

--- a/tools/check_release_assets_uploaded.py
+++ b/tools/check_release_assets_uploaded.py
@@ -6,14 +6,19 @@ import sys
 import time
 
 EXPECTED_ASSETS = [
-    "executor-enterprise-darwin-arm64",
-    "buildbuddy-enterprise-linux-amd64",
-    "buildbuddy-linux-amd64",
-    "executor-enterprise-linux-amd64",
     "buildbuddy-enterprise-darwin-amd64",
-    "executor-enterprise-darwin-amd64",
-    "executor-enterprise-windows-amd64-beta.exe",
+    "buildbuddy-enterprise-linux-amd64",
+    "buildbuddy-enterprise-linux-arm64",
+
     "buildbuddy-darwin-amd64"
+    "buildbuddy-linux-amd64",
+    "buildbuddy-linux-arm64",
+
+    "executor-enterprise-darwin-amd64",
+    "executor-enterprise-darwin-arm64",
+    "executor-enterprise-linux-amd64",
+    "executor-enterprise-linux-arm64",
+    "executor-enterprise-windows-amd64-beta.exe",
 ]
 
 def die(message):


### PR DESCRIPTION
Test build (tested everything except the `gh release upload` command): https://github.com/buildbuddy-io/buildbuddy/actions/runs/7993652037/job/21829927623?pr=5960.

I ran `which gh` to sanity check that `gh` was installed. Looks like it is not yet installed by default on the arm64 runners, so I added an installation step for that.

We probably also should add docker image builds - can do that in a separate PR.

**Related issues**: N/A
