### PR TITLE
Use VM ctx for VBD mount

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1293,7 +1293,7 @@ func (c *FirecrackerContainer) hotSwapWorkspace(ctx context.Context, execClient 
 			return err
 		}
 		mountPath := filepath.Join(c.getChroot(), workspaceDriveID+vbdMountDirSuffix)
-		if err := d.Mount(mountPath); err != nil {
+		if err := d.Mount(c.vmCtx, mountPath); err != nil {
 			return status.WrapError(err, "mount workspace VBD")
 		}
 		c.workspaceVBD = d
@@ -1742,7 +1742,7 @@ func (c *FirecrackerContainer) setupVBDMounts(ctx context.Context) error {
 			return nil, err
 		}
 		mountPath := filepath.Join(c.getChroot(), driveID+vbdMountDirSuffix)
-		if err := d.Mount(mountPath); err != nil {
+		if err := d.Mount(c.vmCtx, mountPath); err != nil {
 			return nil, err
 		}
 		log.CtxDebugf(ctx, "Mounted %s VBD FUSE filesystem to %s", driveID, mountPath)

--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -64,7 +64,7 @@ func (f *FS) SetFile(file BlockDevice) {
 
 // Mount mounts the FS to the given directory path.
 // It exposes a single file "store" which points to the backing store.
-func (f *FS) Mount(path string) error {
+func (f *FS) Mount(ctx context.Context, path string) error {
 	if f.mountPath != "" {
 		return status.InternalErrorf("vbd is already mounted")
 	}
@@ -115,7 +115,7 @@ func (f *FS) Mount(path string) error {
 
 	attr := fusefs.StableAttr{Mode: fuse.S_IFREG}
 	child := &Node{fs: f, file: f.store}
-	inode := f.root.NewPersistentInode(context.TODO(), child, attr)
+	inode := f.root.NewPersistentInode(ctx, child, attr)
 	f.root.AddChild(FileName, inode, false /*=overwrite*/)
 
 	return nil

--- a/enterprise/server/remote_execution/vbd/vbd_test.go
+++ b/enterprise/server/remote_execution/vbd/vbd_test.go
@@ -2,6 +2,7 @@ package vbd_test
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"math/rand"
 	"os"
@@ -46,6 +47,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestVBD(t *testing.T) {
+	ctx := context.Background()
 	root := testfs.MakeTempDir(t)
 
 	// Set up backing file
@@ -63,7 +65,7 @@ func TestVBD(t *testing.T) {
 	require.NoError(t, err)
 	dir, err := os.MkdirTemp(root, "mount-*")
 	require.NoError(t, err)
-	err = v.Mount(dir)
+	err = v.Mount(ctx, dir)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := v.Unmount()


### PR DESCRIPTION
Instead of `context.TODO()`, use the VM context so we get proper cancellation and log labels.

**Related issues**: N/A
