### PR TITLE
Make Ctrl+F target editor even if not focused

### DIFF
--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -132,6 +132,17 @@ export default class CodeComponent extends React.Component<Props, State> {
     if (this.state.repoResponse || this.isSingleFile()) {
       this.fetchInitialContent();
     }
+
+    document.onkeydown = (e) => {
+      switch (e.keyCode) {
+        case 70: // Meta + F
+          if (!e.metaKey) break;
+          this.editor?.focus();
+          this.editor?.trigger("find", "editor.actions.findWithArgs", { searchString: "" });
+          e.preventDefault();
+          break;
+      }
+    };
   }
 
   fetchInitialContent() {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lucide-react": "^0.241.0",
     "memoize-one": "^6.0.0",
     "moment": "^2.29.4",
-    "monaco-editor": "^0.25.2",
+    "monaco-editor": "0.46.0",
     "path-browserify": "^1.0.1",
     "prettier": "^2.1.1",
     "protobufjs": "^7.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -780,10 +780,10 @@ moment@*, moment@^2.29.4:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
-monaco-editor@^0.25.2:
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.25.2.tgz#119e2b15bbd968a1a99c03cac9c329316d7c37e9"
-  integrity sha512-5iylzSJevCnzJn9UVsW8yOZ3yHjmAs4TfvH3zsbftKiFKmHG0xirGN6DK9Kk04VSWxYCZZAIafYJoNJJMAU1KA==
+monaco-editor@0.46.0:
+  version "0.46.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.46.0.tgz#013e453fd2408997e4fe0bf67b36a80a24bc7bcc"
+  integrity sha512-ADwtLIIww+9FKybWscd7OCfm9odsFYHImBRI1v9AviGce55QY8raT+9ihH8jX/E/e6QVSGM+pKj4jSUSRmALNQ==
 
 object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
Requires a monaco editor upgrade.

Addresses bullet 4 from https://github.com/buildbuddy-io/buildbuddy-internal/issues/1176