### PR TITLE
remove listener from raft store

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -72,7 +72,6 @@ type Store struct {
 	gossipManager interfaces.GossipService
 	sender        *sender.Sender
 	registry      registry.NodeRegistry
-	listener      *listener.RaftListener
 	grpcServer    *grpc.Server
 	apiClient     *client.APIClient
 	liveness      *nodeliveness.Liveness
@@ -159,7 +158,6 @@ func NewWithArgs(env environment.Env, rootDir string, nodeHost *dragonboat.NodeH
 		gossipManager: gossipManager,
 		sender:        sender,
 		registry:      registry,
-		listener:      listener,
 		apiClient:     apiClient,
 		liveness:      nodeLiveness,
 		log:           nhLog,


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
The listener is passed to nodehost config and to the lease keeper, but we never
call store.listener.
