### PR TITLE
Parse EstimatedComputeUnits as a float

### DIFF
--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -131,7 +131,7 @@ type Properties struct {
 	OS                        string
 	Arch                      string
 	Pool                      string
-	EstimatedComputeUnits     int64
+	EstimatedComputeUnits     float64
 	EstimatedMilliCPU         int64
 	EstimatedMemoryBytes      int64
 	EstimatedFreeDiskBytes    int64
@@ -255,7 +255,7 @@ func ParseProperties(task *repb.ExecutionTask) (*Properties, error) {
 		OS:                        strings.ToLower(stringProp(m, OperatingSystemPropertyName, defaultOperatingSystemName)),
 		Arch:                      strings.ToLower(stringProp(m, CPUArchitecturePropertyName, defaultCPUArchitecture)),
 		Pool:                      strings.ToLower(pool),
-		EstimatedComputeUnits:     int64Prop(m, EstimatedComputeUnitsPropertyName, 0),
+		EstimatedComputeUnits:     float64Prop(m, EstimatedComputeUnitsPropertyName, 0),
 		EstimatedMemoryBytes:      iecBytesProp(m, EstimatedMemoryPropertyName, 0),
 		EstimatedMilliCPU:         milliCPUProp(m, EstimatedCPUPropertyName, 0),
 		EstimatedFreeDiskBytes:    iecBytesProp(m, EstimatedFreeDiskPropertyName, 0),
@@ -523,6 +523,19 @@ func int64Prop(props map[string]string, name string, defaultValue int64) int64 {
 		return defaultValue
 	}
 	return i
+}
+
+func float64Prop(props map[string]string, name string, defaultValue float64) float64 {
+	val := props[strings.ToLower(name)]
+	if val == "" {
+		return defaultValue
+	}
+	f, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		log.Warningf("Could not parse platform property %q as float64: %s", name, err)
+		return defaultValue
+	}
+	return f
 }
 
 func iecBytesProp(props map[string]string, name string, defaultValue int64) int64 {

--- a/enterprise/server/remote_execution/platform/platform_test.go
+++ b/enterprise/server/remote_execution/platform/platform_test.go
@@ -160,14 +160,15 @@ func TestParse_EstimatedBCU(t *testing.T) {
 	for _, testCase := range []struct {
 		name          string
 		rawValue      string
-		expectedValue int64
+		expectedValue float64
 	}{
 		{"EstimatedComputeUnits", "", 0},
-		{"EstimatedComputeUnits", "NOT_AN_INT", 0},
+		{"EstimatedComputeUnits", "NOT_A_VALID_NUMBER", 0},
 		{"EstimatedComputeUnits", "0", 0},
 		{"EstimatedComputeUnits", "1", 1},
 		{"EstimatedComputeUnits", " 1 ", 1},
 		{"estimatedcomputeunits", "1", 1},
+		{"EstimatedComputeUnits", "0.5", 0.5},
 	} {
 		plat := &repb.Platform{Properties: []*repb.Platform_Property{
 			{Name: testCase.name, Value: testCase.rawValue},

--- a/enterprise/server/tasksize/tasksize.go
+++ b/enterprise/server/tasksize/tasksize.go
@@ -372,8 +372,8 @@ func Estimate(task *repb.ExecutionTask) *scpb.TaskSize {
 	}
 
 	if props.EstimatedComputeUnits > 0 {
-		cpuEstimate = props.EstimatedComputeUnits * ComputeUnitsToMilliCPU
-		memEstimate = props.EstimatedComputeUnits * ComputeUnitsToRAMBytes
+		cpuEstimate = int64(props.EstimatedComputeUnits * ComputeUnitsToMilliCPU)
+		memEstimate = int64(props.EstimatedComputeUnits * ComputeUnitsToRAMBytes)
 	}
 	if props.EstimatedMilliCPU > 0 {
 		cpuEstimate = props.EstimatedMilliCPU


### PR DESCRIPTION
We tried to set EstimatedComputeUnits to 0.8 today, but it was being treated as 0.

**Related issues**: N/A
