### PR TITLE
[RB] Remove session affinity key because it prevents snapshot sharing

### DIFF
--- a/.github/workflows/remote-bazel-build.yaml
+++ b/.github/workflows/remote-bazel-build.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Download bb cli
         run: |
-          cli/install.sh
+          bazel build cli
 
       - name: Setup git env
         run: |
@@ -31,7 +31,7 @@ jobs:
 
       - name: Test
         run: |
-          bb remote test //... \
+          $PWD/bazel-bin/cli/cmd/bb/bb_/bb remote test //... \
             --config=linux-workflows --config=race \
             --remote_executor=grpcs://buildbuddy.buildbuddy.io \
             --test_tag_filters=-performance,-webdriver,-docker,-bare \

--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -29,7 +29,6 @@ go_library(
         "@com_github_alecaivazis_survey_v2//:survey",
         "@com_github_go_git_go_git_v5//:go-git",
         "@com_github_go_git_go_git_v5//plumbing",
-        "@com_github_google_uuid//:uuid",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//metadata",
         "@org_golang_x_sys//unix",


### PR DESCRIPTION
I noticed that in a github workflow using remote bazel, the snapshots were never recycled. There is no guarantee that workflows will be run on stable machines with stable node IDs and dir structure. The SessionAffinityKey is set as a platform prop, which is hashed for the snapshot key, so the changing value was causing snapshot misses.

**Related issues**: buildbuddy-io/buildbuddy-internal#3140
