### PR TITLE
Support more file operations

### DIFF
--- a/enterprise/app/code/code.css
+++ b/enterprise/app/code/code.css
@@ -198,6 +198,21 @@
   overflow: clip;
 }
 
+.code-diff-viewer-item-path.deleted,
+.code-sidebar-node-name.deleted {
+  color: #f44336;
+  text-decoration: line-through;
+}
+
+.code-diff-viewer-item-path.added,
+.code-sidebar-node-name.added {
+  color: #4caf50;
+}
+
+.code-sidebar-node-name.changed {
+  color: #ff9800;
+}
+
 /* Monaco overrides */
 
 .minimap-shadow-visible,

--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -41,13 +41,15 @@ interface State {
   repoResponse: github.GetGithubRepoResponse | undefined;
   treeResponse: github.GetGithubTreeResponse | undefined;
   installationsResponse: github.GetGithubUserInstallationsResponse | undefined;
-  treeShaToExpanded: Map<string, boolean>;
+  fullPathToExpanded: Map<string, boolean>;
+  fullPathToRenaming: Map<string, boolean>;
   treeShaToChildrenMap: Map<string, github.TreeNode[]>;
   fullPathToModelMap: Map<string, monaco.editor.ITextModel>;
   fullPathToDiffModelMap: Map<string, monaco.editor.IDiffEditorModel>;
   originalFileContents: Map<string, string>;
   /** Map of file path to patch contents, or null if the file is being deleted. */
   changes: Map<string, string | null>;
+  temporaryFiles: Map<string, github.TreeNode[]>;
   mergeConflicts: Map<string, string>;
   pathToIncludeChanges: Map<string, boolean>;
   prLink: string;
@@ -61,6 +63,7 @@ interface State {
   reviewRequestModalVisible: boolean;
   isBuilding: boolean;
 
+  showContextMenu?: boolean;
   contextMenuX?: number;
   contextMenuY?: number;
   contextMenuFullPath?: string;
@@ -80,12 +83,14 @@ export default class CodeComponent extends React.Component<Props, State> {
     repoResponse: undefined,
     treeResponse: undefined,
     installationsResponse: undefined,
-    treeShaToExpanded: new Map<string, boolean>(),
+    fullPathToExpanded: new Map<string, boolean>(),
+    fullPathToRenaming: new Map<string, boolean>(),
     treeShaToChildrenMap: new Map<string, Array<github.TreeNode>>(),
     fullPathToModelMap: new Map<string, monaco.editor.ITextModel>(),
     fullPathToDiffModelMap: new Map<string, monaco.editor.IDiffEditorModel>(),
     originalFileContents: new Map<string, string>(),
     changes: new Map<string, string>(),
+    temporaryFiles: new Map<string, github.TreeNode[]>(),
     mergeConflicts: new Map<string, string>(),
     pathToIncludeChanges: new Map<string, boolean>(),
     prLink: "",
@@ -144,6 +149,17 @@ export default class CodeComponent extends React.Component<Props, State> {
           break;
       }
     };
+  }
+
+  fetchContentForPath(path: string) {
+    return rpcService.service.getGithubContent(
+      new github.GetGithubContentRequest({
+        owner: this.currentOwner(),
+        repo: this.currentRepo(),
+        path: path,
+        ref: this.state.commitSHA || this.state.repoResponse?.defaultBranch,
+      })
+    );
   }
 
   fetchInitialContent() {
@@ -222,18 +238,9 @@ export default class CodeComponent extends React.Component<Props, State> {
 
     if (this.currentPath()) {
       if (!this.state.fullPathToModelMap.has(this.currentPath())) {
-        rpcService.service
-          .getGithubContent(
-            new github.GetGithubContentRequest({
-              owner: this.currentOwner(),
-              repo: this.currentRepo(),
-              path: this.currentPath(),
-              ref: this.state.commitSHA || this.state.repoResponse?.defaultBranch,
-            })
-          )
-          .then((response) => {
-            this.navigateToContent(this.currentPath(), response.content);
-          });
+        this.fetchContentForPath(this.currentPath()).then((response) => {
+          this.navigateToContent(this.currentPath(), response.content);
+        });
       }
 
       if (this.state.mergeConflicts.has(this.currentPath())) {
@@ -336,14 +343,33 @@ export default class CodeComponent extends React.Component<Props, State> {
       });
   }
 
+  isNewFile(node: github.TreeNode) {
+    return !node.sha;
+  }
+
+  isDirectory(node: github.TreeNode | undefined) {
+    return node?.type === "tree";
+  }
+
   // TODO(siggisim): Support moving files around
-  // TODO(siggisim): Support renaming files
   // TODO(siggisim): Support tabs
   handleFileClicked(node: github.TreeNode, fullPath: string) {
-    if (node.type === "tree") {
-      if (this.state.treeShaToExpanded.get(node.sha)) {
-        this.state.treeShaToExpanded.set(node.sha, false);
-        this.updateState({ treeShaToExpanded: this.state.treeShaToExpanded });
+    if (this.isNewFile(node)) {
+      if (this.isDirectory(node)) {
+        this.state.fullPathToExpanded.set(fullPath, !Boolean(this.state.fullPathToExpanded.get(fullPath)));
+        this.state.treeShaToChildrenMap.set(node.sha, []);
+      } else {
+        this.navigateToPath(fullPath);
+        this.editor?.setModel(this.state.fullPathToModelMap.get(fullPath) || null);
+      }
+      this.updateState({});
+      return;
+    }
+
+    if (this.isDirectory(node)) {
+      if (this.state.fullPathToExpanded.get(fullPath)) {
+        this.state.fullPathToExpanded.set(fullPath, false);
+        this.updateState({ fullPathToExpanded: this.state.fullPathToExpanded });
         return;
       }
 
@@ -356,7 +382,7 @@ export default class CodeComponent extends React.Component<Props, State> {
           })
         )
         .then((response) => {
-          this.state.treeShaToExpanded.set(node.sha, true);
+          this.state.fullPathToExpanded.set(fullPath, true);
           this.state.treeShaToChildrenMap.set(node.sha, response.nodes);
           this.updateState({
             treeShaToChildrenMap: this.state.treeShaToChildrenMap,
@@ -381,7 +407,7 @@ export default class CodeComponent extends React.Component<Props, State> {
       });
   }
 
-  navigateToContent(fullPath: string, content: Uint8Array) {
+  ensureModelExists(fullPath: string, content: Uint8Array) {
     let fileContents = textDecoder.decode(content);
     this.state.originalFileContents.set(fullPath, fileContents);
     this.updateState({
@@ -394,7 +420,11 @@ export default class CodeComponent extends React.Component<Props, State> {
       this.state.fullPathToModelMap.set(fullPath, model);
       this.updateState({ fullPathToModelMap: this.state.fullPathToModelMap });
     }
-    this.editor?.setModel(model);
+    return model;
+  }
+
+  navigateToContent(fullPath: string, content: Uint8Array) {
+    this.editor?.setModel(this.ensureModelExists(fullPath, content));
   }
 
   navigateToPath(path: string) {
@@ -549,39 +579,61 @@ export default class CodeComponent extends React.Component<Props, State> {
     this.updateState({ pathToIncludeChanges: this.state.pathToIncludeChanges });
   }
 
-  handleDeleteClicked(fullPath: string) {
-    this.state.changes.set(fullPath, null);
-    this.state.pathToIncludeChanges.set(fullPath, true);
+  handleDeleteClicked(fullPath: string, node: github.TreeNode) {
+    if (this.isDirectory(node)) {
+      error_service.handleError("Deleting directories is not yet supported");
+      return;
+    }
+    if (this.isNewFile(node)) {
+      this.state.changes.delete(fullPath);
+      this.state.pathToIncludeChanges.delete(fullPath);
+    } else {
+      this.state.changes.set(fullPath, null);
+      this.state.pathToIncludeChanges.set(fullPath, true);
+    }
+
     this.updateState({ changes: this.state.changes });
   }
 
-  handleNewFileClicked() {
-    let fileName = prompt(
-      "File name:",
-      (this.state.contextMenuFile?.type != "tree"
-        ? this.state.contextMenuFullPath?.substring(0, this.state.contextMenuFullPath?.lastIndexOf("/"))
-        : this.state.contextMenuFullPath) + "/"
-    );
-    if (fileName) {
-      let fileContents = "// Your code here";
-      let model = this.state.fullPathToModelMap.get(fileName);
-      if (!model) {
-        model = monaco.editor.createModel(fileContents, langFromPath(fileName), monaco.Uri.file(fileName));
-        this.state.fullPathToModelMap.set(fileName, model);
-      }
-      this.state.originalFileContents.set(fileName, "");
-      this.navigateToPath(fileName);
-      this.updateState(
-        {
-          originalFileContents: this.state.originalFileContents,
-          changes: this.state.changes,
-        },
-        () => {
-          this.editor?.setModel(model!);
-          this.handleContentChanged();
-        }
-      );
+  newFileWithContents(node: github.TreeNode, path: string, contents: string) {
+    let parent = this.getParent(path);
+    let tempFiles = this.state.temporaryFiles.get(parent);
+    if (tempFiles) {
+      tempFiles.splice(tempFiles.indexOf(node), 1);
+      this.state.temporaryFiles.set(parent, tempFiles);
     }
+
+    let model = this.state.fullPathToModelMap.get(path);
+    if (!model) {
+      model = monaco.editor.createModel(contents, langFromPath(path), monaco.Uri.file(path));
+      this.state.fullPathToModelMap.set(path, model);
+    }
+    this.navigateToPath(path);
+    this.updateState({}, () => {
+      this.editor?.setModel(model!);
+      this.handleContentChanged();
+    });
+  }
+
+  handleRenameClicked(fullPath: string) {
+    this.state.fullPathToRenaming.set(fullPath, true);
+    this.updateState({});
+  }
+
+  handleNewFileClicked(path: string) {
+    if (!this.state.temporaryFiles.has(path)) {
+      this.state.temporaryFiles.set(path, []);
+    }
+    this.state.temporaryFiles.get(path)!.push(new github.TreeNode({ path: "", type: "file" }));
+    this.updateState({ temporaryFiles: this.state.temporaryFiles });
+  }
+
+  handleNewFolderClicked(path: string) {
+    if (!this.state.temporaryFiles.has(path)) {
+      this.state.temporaryFiles.set(path, []);
+    }
+    this.state.temporaryFiles.get(path)!.push(new github.TreeNode({ path: "", type: "tree" }));
+    this.updateState({ temporaryFiles: this.state.temporaryFiles });
   }
 
   handleGitHubClicked() {
@@ -656,7 +708,9 @@ export default class CodeComponent extends React.Component<Props, State> {
 
   handleRevertClicked(path: string, event: React.MouseEvent<HTMLSpanElement, MouseEvent>) {
     this.state.changes.delete(path);
-    this.state.fullPathToModelMap.get(path)?.setValue(this.state.originalFileContents.get(path) || "");
+    if (this.state.originalFileContents.has(path)) {
+      this.state.fullPathToModelMap.get(path)?.setValue(this.state.originalFileContents.get(path) || "");
+    }
     this.updateState({ changes: this.state.changes, fullPathToModelMap: this.state.fullPathToModelMap });
     event.stopPropagation();
   }
@@ -807,8 +861,59 @@ export default class CodeComponent extends React.Component<Props, State> {
     this.updateState({ reviewRequestModalVisible: false });
   }
 
+  getParent(path: string) {
+    let lastSlashIndex = path.lastIndexOf("/");
+    if (lastSlashIndex == -1) {
+      lastSlashIndex = 0;
+    }
+    return path.substr(0, lastSlashIndex);
+  }
+
+  joinPath(paths: string[]) {
+    return paths.filter((p) => p).join("");
+  }
+
+  async handleRename(node: github.TreeNode, path: string, newValue: string, existingFile: boolean) {
+    if (!newValue) {
+      return;
+    }
+    this.state.fullPathToRenaming.set(path, false);
+    this.updateState({});
+
+    if (this.isDirectory(node)) {
+      if (existingFile) {
+        error_service.handleError("Renaming directories not yet supported!");
+      } else {
+        node.path = newValue;
+      }
+      return;
+    }
+
+    if (existingFile) {
+      let parent = this.getParent(path);
+      let newPath = this.joinPath([parent, newValue]);
+      if (newPath == path) {
+        return;
+      }
+
+      if (!this.state.fullPathToModelMap.has(path)) {
+        await this.fetchContentForPath(path).then((response) => {
+          return this.ensureModelExists(path, response.content);
+        });
+      }
+
+      this.newFileWithContents(node, newValue, this.state.fullPathToModelMap.get(path)?.getValue() || "");
+      this.handleDeleteClicked(path, node);
+      this.updateState({});
+      return;
+    }
+
+    this.newFileWithContents(node, path + newValue, "// Your code here");
+  }
+
   clearContextMenu() {
     this.setState({
+      showContextMenu: false,
       contextMenuX: undefined,
       contextMenuY: undefined,
       contextMenuFile: undefined,
@@ -817,7 +922,11 @@ export default class CodeComponent extends React.Component<Props, State> {
   }
 
   handleContextMenu(node: github.TreeNode | undefined, fullPath: string, event: React.MouseEvent) {
+    if (this.isDirectory(node)) {
+      this.state.fullPathToExpanded.set(fullPath, true);
+    }
     this.setState({
+      showContextMenu: true,
       contextMenuX: event.pageX,
       contextMenuY: event.pageY,
       contextMenuFile: node,
@@ -834,6 +943,31 @@ export default class CodeComponent extends React.Component<Props, State> {
         callback();
       }
     });
+  }
+
+  getFiles(nodes: github.TreeNode[], parent: string) {
+    // Add any temporary files
+    let files = new Map<string, github.TreeNode>();
+    for (let t of this.state.temporaryFiles.get(parent) || []) {
+      files.set(t.path, t);
+    }
+
+    // And any matching changed files, or paths leading up to changed files
+    for (let path of this.state.changes.keys()) {
+      let matchesRootDirectory = parent == "" && path.indexOf("/") == -1;
+      if (path.startsWith(parent + "/") || matchesRootDirectory) {
+        let remainder = parent == "" ? path : path.substr(parent.length + 1);
+        let dirs = remainder.split("/");
+        files.set(dirs[0], new github.TreeNode({ path: dirs[0], type: dirs.length > 1 ? "tree" : "file" }));
+      }
+    }
+
+    // And finally the original files from github
+    for (let o of nodes) {
+      files.set(o.path, o);
+    }
+
+    return Array.from(files.values());
   }
 
   // TODO(siggisim): Make the menu look nice
@@ -984,18 +1118,22 @@ export default class CodeComponent extends React.Component<Props, State> {
         <div className="code-main">
           {!this.isSingleFile() && (
             <div className="code-sidebar">
-              <div className="code-sidebar-tree" onContextMenu={(e) => this.handleContextMenu(undefined, "/", e)}>
+              <div className="code-sidebar-tree" onContextMenu={(e) => this.handleContextMenu(undefined, "", e)}>
                 {this.state.treeResponse &&
-                  this.state.treeResponse.nodes
+                  this.getFiles(this.state.treeResponse.nodes, "")
                     .sort(compareNodes)
                     .map((node) => (
                       <SidebarNodeComponent
                         node={node}
-                        treeShaToExpanded={this.state.treeShaToExpanded}
+                        getFiles={this.getFiles.bind(this)}
+                        changes={this.state.changes}
+                        fullPathToExpanded={this.state.fullPathToExpanded}
+                        fullPathToRenaming={this.state.fullPathToRenaming}
                         treeShaToChildrenMap={this.state.treeShaToChildrenMap}
                         handleFileClicked={this.handleFileClicked.bind(this)}
                         fullPath={node.path}
                         handleContextMenu={this.handleContextMenu.bind(this)}
+                        handleRename={this.handleRename.bind(this)}
                       />
                     ))}
               </div>
@@ -1042,8 +1180,16 @@ export default class CodeComponent extends React.Component<Props, State> {
                       onChange={(event) => this.handleCheckboxClicked(fullPath)}
                       type="checkbox"
                     />{" "}
-                    {fullPath}
-                    {this.state.changes.get(fullPath) === null && <> (deleted)</>}
+                    <div
+                      className={`code-diff-viewer-item-path${
+                        this.state.changes.get(fullPath) === null ? " deleted" : ""
+                      }${
+                        this.state.originalFileContents.has(fullPath) || this.state.changes.get(fullPath) === null
+                          ? ""
+                          : " added"
+                      }`}>
+                      {fullPath}
+                    </div>
                     {this.state.mergeConflicts.has(fullPath) && fullPath != this.currentPath() && (
                       <span
                         className="code-revert-button"
@@ -1076,16 +1222,19 @@ export default class CodeComponent extends React.Component<Props, State> {
           )}
           {this.editor && this.currentPath()?.endsWith(".bazelrc") && <BazelrcSidekick editor={this.editor} />}
         </div>
-        {this.state.contextMenuFullPath && (
+        {this.state.showContextMenu && (
           <div className="context-menu-container">
             <div
               className="context-menu"
               onClick={this.clearContextMenu.bind(this)}
               style={{ top: this.state.contextMenuY, left: this.state.contextMenuX }}>
-              <div onClick={() => this.handleNewFileClicked()}>New file</div>
-              {/* TODO <div>New folder</div> */}
-              {/* TODO <div>Rename</div> */}
-              <div onClick={() => this.handleDeleteClicked(this.state.contextMenuFullPath || "")}>Delete</div>
+              <div onClick={() => this.handleNewFileClicked(this.state.contextMenuFullPath!)}>New file</div>
+              <div onClick={() => this.handleNewFolderClicked(this.state.contextMenuFullPath!)}>New folder</div>
+              <div onClick={() => this.handleRenameClicked(this.state.contextMenuFullPath!)}>Rename</div>
+              <div
+                onClick={() => this.handleDeleteClicked(this.state.contextMenuFullPath!, this.state.contextMenuFile!)}>
+                Delete
+              </div>
             </div>
           </div>
         )}

--- a/enterprise/app/code/code_sidebar_node.tsx
+++ b/enterprise/app/code/code_sidebar_node.tsx
@@ -5,20 +5,34 @@ import { github } from "../../../proto/github_ts_proto";
 interface SidebarNodeProps {
   fullPath: string;
   node: github.TreeNode;
-  treeShaToExpanded: Map<string, boolean>;
+  fullPathToExpanded: Map<string, boolean>;
+  fullPathToRenaming: Map<string, boolean>;
   treeShaToChildrenMap: Map<string, any[]>;
+  changes: Map<string, string | null>;
+  getFiles: (originalFiles: github.TreeNode[], parent: string) => github.TreeNode[];
   handleFileClicked: (node: github.TreeNode, path: string) => void;
   handleContextMenu: (node: github.TreeNode, path: string, event: React.MouseEvent) => void;
+  handleRename: (node: github.TreeNode, path: string, newValue: string, alreadyExisted: boolean) => void;
   depth?: number;
 }
 
-export default class SidebarNodeComponent extends React.Component<SidebarNodeProps> {
+interface SidebarNodeState {
+  renameValue: string;
+}
+
+export default class SidebarNodeComponent extends React.Component<SidebarNodeProps, SidebarNodeState> {
+  state: SidebarNodeState = { renameValue: "" };
   render() {
     const depth = this.props.depth || 0;
-    const expanded = this.props.treeShaToExpanded.get(this.props.node.sha);
+    const expanded = this.props.fullPathToExpanded.get(this.props.fullPath);
+    const editing = this.props.fullPathToRenaming.get(this.props.fullPath) || false;
     let fileIcon = expanded ? <ChevronDown className="icon" /> : <ChevronRight className="icon" />;
     if (this.props.node.type != "tree") {
       fileIcon = <File className="icon" />;
+    }
+    let change = this.props.changes.get(this.props.fullPath);
+    if (change === null) {
+      return null; // Don't show deleted files in the sidebar.
     }
     return (
       <div
@@ -30,24 +44,59 @@ export default class SidebarNodeComponent extends React.Component<SidebarNodePro
           onClick={() => this.props.handleFileClicked(this.props.node, this.props.fullPath)}
           title={this.props.node.path}>
           {fileIcon}
-          <div className="code-sidebar-node-name">{this.props.node.path}</div>
+          <div
+            className={`code-sidebar-node-name${change === null ? " deleted" : ""}${
+              this.props.node.sha && change !== null && change !== undefined ? " changed" : ""
+            }${this.props.node.sha ? "" : " added"}`}>
+            {this.props.node.path && !editing ? (
+              this.props.node.path
+            ) : (
+              <input
+                defaultValue={this.props.node.path}
+                autoFocus={true}
+                onChange={(e) => this.setState({ renameValue: e.target.value })}
+                onBlur={() => this.handleRename()}
+                onKeyDown={(e) => {
+                  if (e.key == "Enter") {
+                    this.handleRename();
+                  }
+                }}
+              />
+            )}
+          </div>
         </div>
         {expanded && (
           <div className="code-sidebar-node-children">
-            {(this.props.treeShaToChildrenMap.get(this.props.node.sha) ?? []).sort(compareNodes).map((child: any) => (
-              <SidebarNodeComponent
-                node={child}
-                depth={depth + 1}
-                treeShaToExpanded={this.props.treeShaToExpanded}
-                treeShaToChildrenMap={this.props.treeShaToChildrenMap}
-                handleFileClicked={this.props.handleFileClicked}
-                fullPath={this.props.fullPath + "/" + child.path}
-                handleContextMenu={this.props.handleContextMenu}
-              />
-            ))}
+            {this.props
+              .getFiles(this.props.treeShaToChildrenMap.get(this.props.node.sha) || [], this.props.fullPath)
+              .sort(compareNodes)
+              .map((child: any) => (
+                <SidebarNodeComponent
+                  node={child}
+                  depth={depth + 1}
+                  getFiles={this.props.getFiles}
+                  changes={this.props.changes}
+                  fullPathToExpanded={this.props.fullPathToExpanded}
+                  fullPathToRenaming={this.props.fullPathToRenaming}
+                  treeShaToChildrenMap={this.props.treeShaToChildrenMap}
+                  handleFileClicked={this.props.handleFileClicked}
+                  fullPath={this.props.fullPath + "/" + child.path}
+                  handleContextMenu={this.props.handleContextMenu}
+                  handleRename={this.props.handleRename}
+                />
+              ))}
           </div>
         )}
       </div>
+    );
+  }
+
+  handleRename() {
+    this.props.handleRename(
+      this.props.node,
+      this.props.fullPath,
+      this.state.renameValue || this.props.node.path,
+      this.props.fullPathToRenaming.get(this.props.fullPath) || false
     );
   }
 }


### PR DESCRIPTION
- Shows edited / deleted / new status change drawer
- Shows new files and hides deleted files in sidebar
- Adds "New folder" context menu option
- Adds "Rename" context menu option
- Updates "New file" implementation to vscode-style inline input filename

Things not yet supported in this PR (shows a toast when attempted in UI):
- Renaming directories
- Deleting directories

I could probably split this up into a few PRs if it's overwhelming.