### PR TITLE
Improve accuracy of CPU measurement on bare runner

### DIFF
--- a/enterprise/server/remote_execution/commandutil/BUILD
+++ b/enterprise/server/remote_execution/commandutil/BUILD
@@ -18,7 +18,14 @@ go_library(
         "//server/util/status",
         "@com_github_mitchellh_go_ps//:go-ps",
     ] + select({
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "//proto:execution_stats_go_proto",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//proto:execution_stats_go_proto",
+        ],
         "@io_bazel_rules_go//go/platform:windows": [
+            "//proto:execution_stats_go_proto",
             "@com_github_shirou_gopsutil_v3//process",
             "@org_golang_x_sys//windows",
         ],

--- a/enterprise/server/remote_execution/commandutil/commandutil_windows.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_windows.go
@@ -9,8 +9,10 @@ import (
 	"syscall"
 	"unsafe"
 
-	putil "github.com/shirou/gopsutil/v3/process"
 	"golang.org/x/sys/windows"
+
+	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
+	putil "github.com/shirou/gopsutil/v3/process"
 )
 
 const (
@@ -87,6 +89,12 @@ func (p *process) postStart() error {
 		return fmt.Errorf("failed to get process: %w", err)
 	}
 	return proc.ResumeWithContext(context.TODO())
+}
+
+func (p *process) wait() (*espb.Rusage, error) {
+	defer close(p.terminated)
+	err := p.cmd.Wait()
+	return nil, err
 }
 
 // killProcessTree kills the given pid as well as any descendant processes.


### PR DESCRIPTION
For bare runners (e.g. macos), instead of only relying on our polling goroutine which monitors stats from procfs stats, use `Rusage` as a secondary signal for CPU usage, and report whichever one is higher.

For most "normal" actions (which don't spawn a bunch of child processes) this fixes an issue where the last 1 second of CPU usage potentially goes unreported. More specifically, we use a backoff for polling that starts at 25ms and backs off to 1000ms. The amount of CPU usage that goes unreported depends on how long the action has run (i.e. how much backoff we've applied so far).

Tested with a C program that burns almost exactly 1000ms of CPU time by running ~3 billion NOP operations in a for-loop (found this value through a bunch of trial and error). Before this PR, when running this program on RBE, we would report 850ms of CPU usage on average (N=100 actions). Now on average we report 999.94ms (N=100 actions)

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3142
