### PR TITLE
Add filecache metrics to IOStats proto

### DIFF
--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2177,7 +2177,9 @@ message IOStats {
   // than downloading from the remote cache.
   int64 local_cache_hits = 7;
 
-  // Total time spent linking inputs from local cache, across all threads.
+  // Time spent linking inputs from local cache, totalled across all threads.
+  // For example, if 8 concurrent threads each spend 2ms of execution time
+  // hardlinking files, this will be 16ms.
   google.protobuf.Duration local_cache_duration = 8;
 
   // The number of files uploaded in this tree.

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2173,6 +2173,13 @@ message IOStats {
   // The time taken to download the tree.
   int64 file_download_duration_usec = 3;
 
+  // Total number of inputs that were provisioned from the local cache rather
+  // than downloading from the remote cache.
+  int64 local_cache_hits = 7;
+
+  // Total time spent linking inputs from local cache, across all threads.
+  google.protobuf.Duration local_cache_duration = 8;
+
   // The number of files uploaded in this tree.
   int64 file_upload_count = 4;
 

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2177,10 +2177,10 @@ message IOStats {
   // than downloading from the remote cache.
   int64 local_cache_hits = 7;
 
-  // Time spent linking inputs from local cache, totalled across all threads.
-  // For example, if 8 concurrent threads each spend 2ms of execution time
-  // hardlinking files, this will be 16ms.
-  google.protobuf.Duration local_cache_duration = 8;
+  // Wall time spent linking inputs from local cache. More precisely, this
+  // measures the duration between the start time of the first link operation to
+  // the end time of the last link operation.
+  google.protobuf.Duration local_cache_link_duration = 8;
 
   // The number of files uploaded in this tree.
   int64 file_upload_count = 4;


### PR DESCRIPTION
This should provide a little more insight into input fetch times in the case where 0 files are downloaded from remote cache.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3142
