### PR TITLE
Render IOStats in action page

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -124,6 +124,7 @@ ts_library(
         "//app/service:rpc_service",
         "//app/terminal",
         "//app/util:cache",
+        "//app/util:proto",
         "//proto:grpc_code_ts_proto",
         "//proto:remote_execution_ts_proto",
         "//proto:timestamp_ts_proto",

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -13,6 +13,7 @@ import TerminalComponent from "../terminal/terminal";
 import { parseDigest, parseActionDigest, digestToString } from "../util/cache";
 import UserPreferences from "../preferences/preferences";
 import alert_service from "../alert/alert_service";
+import { durationToMillis } from "../util/proto";
 
 type Timestamp = google_timestamp.protobuf.Timestamp;
 type ITimestamp = google_timestamp.protobuf.ITimestamp;
@@ -623,6 +624,44 @@ export default class InvocationActionCardComponent extends React.Component<Props
                                     MilliCPU:{" "}
                                     {this.state.actionResult.executionMetadata.estimatedTaskSize.estimatedMilliCpu}
                                   </div>
+                                </div>
+                              </>
+                            )}
+                            {this.state.actionResult.executionMetadata.ioStats && (
+                              <>
+                                <div className="metadata-title">IO stats</div>
+                                <div>
+                                  File download count:{" "}
+                                  {this.state.actionResult.executionMetadata.ioStats.fileDownloadCount ?? 0}
+                                </div>
+                                <div>
+                                  File download size:{" "}
+                                  {format.bytes(
+                                    this.state.actionResult.executionMetadata.ioStats.fileDownloadSizeBytes ?? 0
+                                  )}
+                                </div>
+                                <div>
+                                  Local file cache hits:{" "}
+                                  {this.state.actionResult.executionMetadata.ioStats.localCacheHits ?? 0}
+                                </div>
+                                <div>
+                                  Local file cache file creation time:{" "}
+                                  {format.durationMillis(
+                                    durationToMillis(
+                                      this.state.actionResult.executionMetadata.ioStats.localCacheDuration ?? {}
+                                    )
+                                  )}{" "}
+                                  (total across all threads)
+                                </div>
+                                <div>
+                                  File upload count:{" "}
+                                  {this.state.actionResult.executionMetadata.ioStats.fileUploadCount ?? 0}
+                                </div>
+                                <div>
+                                  File upload size:{" "}
+                                  {format.bytes(
+                                    this.state.actionResult.executionMetadata.ioStats.fileUploadSizeBytes ?? 0
+                                  )}
                                 </div>
                               </>
                             )}

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2173,6 +2173,13 @@ message IOStats {
   // The time taken to download the tree.
   int64 file_download_duration_usec = 3;
 
+  // Total number of inputs that were provisioned from the local cache rather
+  // than downloading from the remote cache.
+  int64 local_cache_hits = 7;
+
+  // Total time spent linking inputs from local cache, across all threads.
+  google.protobuf.Duration local_cache_duration = 8;
+
   // The number of files uploaded in this tree.
   int64 file_upload_count = 4;
 


### PR DESCRIPTION
Renders the existing fields as well as the new filecache fields added in https://github.com/buildbuddy-io/buildbuddy/pull/5994. The existing fields were shown in the executions page but not when drilling down to the action page.

---

Screenshot:

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/e8015611-d9bc-44a7-aec0-932be15357da)

---

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3142
