### PR TITLE
[SS] Add performance metrics for snapshotted VM startup time

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2226,6 +2226,9 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 	if c.memoryStore != nil {
 		c.memoryStore.EmitUsageMetrics("init")
 	}
+	if c.uffdHandler != nil {
+		c.uffdHandler.EmitSummaryMetrics("init")
+	}
 	if c.rootStore != nil {
 		c.rootStore.EmitUsageMetrics("init")
 	}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -2222,6 +2222,17 @@ func (c *FirecrackerContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 		}
 	}()
 
+	// Emit metrics to track time spent preparing VM to execute a command
+	if c.memoryStore != nil {
+		c.memoryStore.EmitUsageMetrics("init")
+	}
+	if c.rootStore != nil {
+		c.rootStore.EmitUsageMetrics("init")
+	}
+	if c.workspaceStore != nil {
+		c.workspaceStore.EmitUsageMetrics("init")
+	}
+
 	result = c.SendExecRequestToGuest(ctx, cmd, workDir, stdio)
 	close(execDone)
 

--- a/enterprise/server/remote_execution/copy_on_write/BUILD
+++ b/enterprise/server/remote_execution/copy_on_write/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//server/util/log",
         "//server/util/lru",
         "//server/util/status",
-        "//server/util/tracing",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",

--- a/enterprise/server/remote_execution/copy_on_write/BUILD
+++ b/enterprise/server/remote_execution/copy_on_write/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//server/util/log",
         "//server/util/lru",
         "//server/util/status",
+        "//server/util/tracing",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -717,7 +717,7 @@ func (l *FileCacheLoader) unpackCOW(ctx context.Context, file *fcpb.ChunkedFile,
 		}
 		chunks = append(chunks, c)
 	}
-	cow, err := copy_on_write.NewCOWStore(ctx, l.env, chunks, file.GetChunkSize(), file.GetSize(), dataDir, remoteInstanceName, remoteEnabled)
+	cow, err := copy_on_write.NewCOWStore(ctx, l.env, file.GetName(), chunks, file.GetChunkSize(), file.GetSize(), dataDir, remoteInstanceName, remoteEnabled)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/remote_execution/uffd/BUILD
+++ b/enterprise/server/remote_execution/uffd/BUILD
@@ -12,8 +12,10 @@ go_library(
     deps = select({
         "@io_bazel_rules_go//go/platform:linux": [
             "//enterprise/server/remote_execution/copy_on_write",
+            "//server/metrics",
             "//server/util/log",
             "//server/util/status",
+            "@com_github_prometheus_client_golang//prometheus",
             "@org_golang_x_sys//unix",
         ],
         "//conditions:default": [],

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1135,6 +1135,37 @@ var (
 		FileName,
 	})
 
+	COWSnapshotInitChunkDurationUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "firecracker",
+		Name:      "cow_snapshot_init_chunk_duration_usec",
+		Help:      "For a COW snapshot, time to initialize one chunk.",
+	}, []string{
+		ChunkSource,
+	})
+
+	COWSnapshotChunkOperationTotalDurationUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "firecracker",
+		Name:      "cow_snapshot_chunk_operation_duration_usec",
+		Help:      "For a COW snapshot, cumulative time spent on an operation type.",
+	}, []string{
+		FileName,
+		EventName,
+		Stage,
+	})
+
+	COWSnapshotChunkOperationCount = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "firecracker",
+		Name:      "cow_snapshot_chunk_operation_count",
+		Help:      "For a COW snapshot, number of times a chunk operation was executed.",
+	}, []string{
+		FileName,
+		EventName,
+		Stage,
+	})
+
 	MaxRecyclableResourceUsageEvent = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_execution",

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1135,6 +1135,24 @@ var (
 		FileName,
 	})
 
+	COWSnapshotPageFaultCount = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "firecracker",
+		Name:      "cow_snapshot_page_fault_count",
+		Help:      "For a snapshotted VM, number of page faults.",
+	}, []string{
+		Stage,
+	})
+
+	COWSnapshotPageFaultTotalDurationUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "firecracker",
+		Name:      "cow_snapshot_page_fault_total_duration_usec",
+		Help:      "For a snapshotted VM, total time spent fulfilling page faults.",
+	}, []string{
+		Stage,
+	})
+
 	COWSnapshotInitChunkDurationUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: bbNamespace,
 		Subsystem: "firecracker",


### PR DESCRIPTION
The goal of this PR is to better understand performance bottlenecks when initializing a firecracker VM (i.e. before we can execute a command). So for now, only emitting these metrics before `SendExecRequestToGuest`. Because exec requests can take very different amounts of time, it feels less helpful to emit metrics for them.

* Add metrics for time spent on various COWStore operations
* Add metrics for page fault handling

As added context, [p95 to dial the vm exec server ](https://metrics.buildbuddy.dev/d/KI6NxDWSk/workflow-snapshotting?orgId=1&refresh=1m&viewPanel=19)frequently spikes to 20s. I want to better understand what part of the VM initialization is so spiky/slow

**Related issues**: N/A
