### PR TITLE
Add rusage to UsageStats proto

### DIFF
--- a/enterprise/server/remote_execution/commandutil/BUILD
+++ b/enterprise/server/remote_execution/commandutil/BUILD
@@ -18,14 +18,7 @@ go_library(
         "//server/util/status",
         "@com_github_mitchellh_go_ps//:go-ps",
     ] + select({
-        "@io_bazel_rules_go//go/platform:darwin": [
-            "//proto:execution_stats_go_proto",
-        ],
-        "@io_bazel_rules_go//go/platform:linux": [
-            "//proto:execution_stats_go_proto",
-        ],
         "@io_bazel_rules_go//go/platform:windows": [
-            "//proto:execution_stats_go_proto",
             "@com_github_shirou_gopsutil_v3//process",
             "@org_golang_x_sys//windows",
         ],

--- a/enterprise/server/remote_execution/commandutil/commandutil_unix.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_unix.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
-	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
 type process struct {
@@ -27,7 +27,7 @@ func (p *process) postStart() error {
 	return nil
 }
 
-func (p *process) wait() (*espb.Rusage, error) {
+func (p *process) wait() (*repb.Rusage, error) {
 	defer close(p.terminated)
 	err := p.cmd.Wait()
 	if p.cmd.ProcessState == nil {
@@ -37,7 +37,7 @@ func (p *process) wait() (*espb.Rusage, error) {
 	if !ok {
 		return nil, err
 	}
-	return &espb.Rusage{
+	return &repb.Rusage{
 		UserCpuTimeUsec:            rusage.Utime.Nano() / 1e3,
 		SysCpuTimeUsec:             rusage.Stime.Nano() / 1e3,
 		MaxResidentSetSizeBytes:    rusage.Maxrss,

--- a/enterprise/server/remote_execution/commandutil/commandutil_windows.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil_windows.go
@@ -11,7 +11,7 @@ import (
 
 	"golang.org/x/sys/windows"
 
-	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	putil "github.com/shirou/gopsutil/v3/process"
 )
 
@@ -91,7 +91,7 @@ func (p *process) postStart() error {
 	return proc.ResumeWithContext(context.TODO())
 }
 
-func (p *process) wait() (*espb.Rusage, error) {
+func (p *process) wait() (*repb.Rusage, error) {
 	defer close(p.terminated)
 	err := p.cmd.Wait()
 	return nil, err

--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -11,49 +11,6 @@ import "proto/stat_filter.proto";
 
 package execution_stats;
 
-// Proto representation of the rusage struct used in the Linux/BSD getrusage()
-// system call.
-message Rusage {
-  // ru_utime: Amount of CPU time in seconds spent in userspace.
-  int64 user_cpu_time_usec = 1;
-
-  // ru_stime: Amount of CPU time in seconds spent in kernelspace.
-  int64 sys_cpu_time_usec = 2;
-
-  // ru_maxrss: Maximum amount of resident memory in bytes.
-  int64 max_resident_set_size_bytes = 3;
-
-  // ru_minflt: Page reclaims.
-  int64 page_reclaims = 4;
-
-  // ru_majflt: Page faults.
-  int64 page_faults = 5;
-
-  // ru_nswap: Number of swaps.
-  int64 swaps = 6;
-
-  // ru_inblock: Block input operations.
-  int64 block_input_operations = 7;
-
-  // ru_oublock: Block output operations.
-  int64 block_output_operations = 8;
-
-  // ru_msgsnd: Messages sent.
-  int64 messages_sent = 9;
-
-  // ru_msgrcv: Messages received.
-  int64 messages_received = 10;
-
-  // ru_nsignals: Signals received.
-  int64 signals_received = 11;
-
-  // ru_nvcsw: Voluntary context switches.
-  int64 voluntary_context_switches = 12;
-
-  // ru_nivcsw: Involuntary context switches.
-  int64 involuntary_context_switches = 13;
-}
-
 // TODO(http://go/b/1451): remove this; stats have been moved to
 // ExecutedActionMetadata. Next tag: 12
 message ExecutionSummary {

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2222,6 +2222,59 @@ message UsageStats {
 
   // Peak file system usage, for each mounted file system.
   repeated FileSystemUsage peak_file_system_usage = 4;
+
+  // Result of rusage for the top-level process returned by the wait4 system
+  // call (unix-like platforms only). See `man 2 wait4` and `man 2 getrusage`
+  // for details.
+  //
+  // The limitations mentioned in the manual pages also apply here: usage is
+  // only reported for the top-level process, not any forked child processes.
+  // This is often an acceptable limitation, since many actions use threads to
+  // achieve concurrency rather than processes.
+  Rusage rusage = 5;
+}
+
+// Proto representation of the rusage struct used in the Linux/BSD getrusage()
+// system call.
+message Rusage {
+  // ru_utime: Amount of CPU time in seconds spent in userspace.
+  int64 user_cpu_time_usec = 1;
+
+  // ru_stime: Amount of CPU time in seconds spent in kernelspace.
+  int64 sys_cpu_time_usec = 2;
+
+  // ru_maxrss: Maximum amount of resident memory in bytes.
+  int64 max_resident_set_size_bytes = 3;
+
+  // ru_minflt: Page reclaims.
+  int64 page_reclaims = 4;
+
+  // ru_majflt: Page faults.
+  int64 page_faults = 5;
+
+  // ru_nswap: Number of swaps.
+  int64 swaps = 6;
+
+  // ru_inblock: Block input operations.
+  int64 block_input_operations = 7;
+
+  // ru_oublock: Block output operations.
+  int64 block_output_operations = 8;
+
+  // ru_msgsnd: Messages sent.
+  int64 messages_sent = 9;
+
+  // ru_msgrcv: Messages received.
+  int64 messages_received = 10;
+
+  // ru_nsignals: Signals received.
+  int64 signals_received = 11;
+
+  // ru_nvcsw: Voluntary context switches.
+  int64 voluntary_context_switches = 12;
+
+  // ru_nivcsw: Involuntary context switches.
+  int64 involuntary_context_switches = 13;
 }
 
 // Proto representation of the Execution stored in OLAP DB. Only used in


### PR DESCRIPTION
The IO stats (`inblock` / `outblock`) seem to be somewhat reasonable:

```
---
Command: yes | head -c $(( 512 * 1000 )) > /tmp/yes.txt; sync /tmp/yes.txt
Inblock: 496
Oublock: 1000
---
Command: echo 3 > /proc/sys/vm/drop_caches; cat <<<'' 
Inblock: 2312
Oublock: 0
---
Command: echo 3 > /proc/sys/vm/drop_caches; cat /tmp/yes.txt | cat
Inblock: 4104
Oublock: 0
```

**Related issues**: N/A
