### PR TITLE
Only perform the select to determine if there is no related execution row after attempting an update

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -310,15 +310,20 @@ func (s *ExecutionServer) updateExecution(ctx context.Context, executionID strin
 		}
 	}
 
-	var dbErr error
-	var existing tables.Execution
-	// TODO(zoey): This select seems unnecessary, should revisit it
-	if err := s.env.GetDBHandle().GORM(ctx, "execution_server_get_execution_for_update").Where(
-		"execution_id = ?", executionID).First(&existing).Error; err != nil {
-		dbErr = err
-	} else {
-		dbErr = s.env.GetDBHandle().GORM(ctx, "execution_server_update_execution").Model(&existing).Where(
-			"execution_id = ? AND stage != ?", executionID, repb.ExecutionStage_COMPLETED).Updates(execution).Error
+	result := s.env.GetDBHandle().GORM(ctx, "execution_server_update_execution").Where(
+		"execution_id = ? AND stage != ?", executionID, repb.ExecutionStage_COMPLETED).Updates(execution)
+	dbErr := result.Error
+	if dbErr == nil && result.RowsAffected == 0 {
+		// We want to return an error if the execution simply doesn't exist, but
+		// we want to ignore any attempts to update a cancelled execution.
+		var count int64
+		if err := s.env.GetDBHandle().GORM(
+			ctx,
+			"execution_server_check_after_noop_update").Where("execution_id = ?", executionID).Count(&count).Error; err != nil {
+			dbErr = err
+		} else if count == 0 {
+			dbErr = status.NotFoundErrorf("Unable to update execution; no execution exists with id %s.", executionID)
+		}
 	}
 
 	if stage == repb.ExecutionStage_COMPLETED {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

This makes our most-common codepath only use one query instead of two

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
