### PR TITLE
Removes unnecessary select and fixes potential time-of-check, time-of-use problem

### DIFF
--- a/enterprise/server/backends/authdb/BUILD
+++ b/enterprise/server/backends/authdb/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//server/util/status",
         "//server/util/subdomain",
         "@com_github_prometheus_client_golang//prometheus",
+        "@io_gorm_gorm//clause",
         "@org_golang_x_crypto//chacha20",
     ],
 )


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

Rather than first performing a select to determine if we should insert or update, we can attempt an insert which does nothing on conflict and then update if the query executes without error but affects no rows.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
