### PR TITLE
[raft] return Unavailable error when there is no ready connection in the pool

### DIFF
--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -171,7 +171,7 @@ func (s *Sender) tryReplicas(ctx context.Context, rd *rfpb.RangeDescriptor, fn r
 		client, err := s.connectionForReplicaDescriptor(ctx, replica)
 		if err != nil {
 			if status.IsUnavailableError(err) {
-				log.Infof("tryReplicas: replica %+v is unavailable: %s", replica, err)
+				log.Debugf("tryReplicas: replica %+v is unavailable: %s", replica, err)
 				// try a different replica if the current replica is not available.
 				continue
 			}
@@ -190,14 +190,14 @@ func (s *Sender) tryReplicas(ctx context.Context, rd *rfpb.RangeDescriptor, fn r
 				log.Debugf("out of range: %s (skipping rangecache)", m)
 				return 0, err
 			case strings.HasPrefix(m, constants.RangeNotLeasedMsg), strings.HasPrefix(m, constants.RangeLeaseInvalidMsg):
-				log.Debugf("out of range: %s (skipping replica %d)", m, replica.GetReplicaId())
+				log.Debugf("out of range: %s (skipping replica %+v)", m, replica)
 				continue
 			default:
 				break
 			}
 		}
 		if status.IsUnavailableError(err) {
-			log.Infof("replica %+v is unavailable: %s", replica, err)
+			log.Debugf("replica %+v is unavailable: %s", replica, err)
 			// try a different replica if the current replica is not available.
 			continue
 		}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Borrowed from `buildbuddy/enterprise/server/util/cacheproxy
/cacheproxy.go`

Fail fast when there are no ready connections from the connection pool and we
can try another replica.
