### PR TITLE
Fix GH actions auth

### DIFF
--- a/enterprise/server/githubapp/BUILD
+++ b/enterprise/server/githubapp/BUILD
@@ -39,6 +39,7 @@ go_library(
         "@com_github_go_git_go_git_v5//plumbing/transport/http",
         "@com_github_golang_jwt_jwt//:jwt",
         "@com_github_google_go_github_v59//github",
+        "@org_golang_google_grpc//metadata",
         "@org_golang_google_protobuf//types/known/durationpb",
         "@org_golang_x_oauth2//:oauth2",
         "@org_golang_x_sync//errgroup",


### PR DESCRIPTION
Set an API key on GH actions runner executions.

This worked without an API key when I was testing locally because I was running the executor with `--debug_enable_anonymous_runner_recycling`, but in dev I got an error because runner recycling requires auth.

**Related issues**: N/A
