### PR TITLE
Add a simple BUILD file sidekick

### DIFF
--- a/enterprise/app/BUILD.bazel
+++ b/enterprise/app/BUILD.bazel
@@ -58,6 +58,7 @@ genrule(
         "//enterprise/app/sidebar:sidebar.css",
         "//enterprise/app/sidekick/bazelrc:bazelrc.css",
         "//enterprise/app/sidekick/bazelversion:bazelversion.css",
+        "//enterprise/app/sidekick/buildfile:buildfile.css",
         "//enterprise/app/sidekick/module:module.css",
         "//enterprise/app/tap:tap.css",
         "//enterprise/app/trends:trends.css",

--- a/enterprise/app/code/BUILD
+++ b/enterprise/app/code/BUILD
@@ -26,6 +26,7 @@ ts_library(
         "//enterprise/app/code:code_sidebar_node",
         "//enterprise/app/sidekick/bazelrc",
         "//enterprise/app/sidekick/bazelversion",
+        "//enterprise/app/sidekick/buildfile",
         "//enterprise/app/sidekick/module",
         "//proto:github_ts_proto",
         "//proto:runner_ts_proto",

--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -28,6 +28,7 @@ import Long from "long";
 import ModuleSidekick from "../sidekick/module/module";
 import BazelVersionSidekick from "../sidekick/bazelversion/bazelversion";
 import BazelrcSidekick from "../sidekick/bazelrc/bazelrc";
+import BuildFileSidekick from "../sidekick/buildfile/buildfile";
 import error_service from "../../../app/errors/error_service";
 
 interface Props {
@@ -1273,6 +1274,9 @@ export default class CodeComponent extends React.Component<Props, State> {
           </div>
           {this.editor && (this.currentPath()?.endsWith("MODULE.bazel") || this.currentPath()?.endsWith("MODULE")) && (
             <ModuleSidekick editor={this.editor} />
+          )}
+          {this.editor && (this.currentPath()?.endsWith("BUILD.bazel") || this.currentPath()?.endsWith("BUILD")) && (
+            <BuildFileSidekick editor={this.editor} onBazelCommand={(c) => this.handleBuildClicked(c)} />
           )}
           {this.editor && this.currentPath()?.endsWith(".bazelversion") && (
             <BazelVersionSidekick editor={this.editor} />

--- a/enterprise/app/sidekick/buildfile/BUILD
+++ b/enterprise/app/sidekick/buildfile/BUILD
@@ -1,0 +1,17 @@
+load("//rules/typescript:index.bzl", "ts_library")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+exports_files(glob(["*.css"]))
+
+ts_library(
+    name = "buildfile",
+    srcs = ["buildfile.tsx"],
+    deps = [
+        "//app/components/select",
+        "@npm//@types/react",
+        "@npm//monaco-editor",
+        "@npm//react",
+        "@npm//tslib",
+    ],
+)

--- a/enterprise/app/sidekick/buildfile/BUILD
+++ b/enterprise/app/sidekick/buildfile/BUILD
@@ -8,8 +8,8 @@ ts_library(
     name = "buildfile",
     srcs = ["buildfile.tsx"],
     deps = [
-        "//app/components/select",
         "@npm//@types/react",
+        "@npm//lucide-react",
         "@npm//monaco-editor",
         "@npm//react",
         "@npm//tslib",

--- a/enterprise/app/sidekick/buildfile/buildfile.css
+++ b/enterprise/app/sidekick/buildfile/buildfile.css
@@ -1,0 +1,25 @@
+.buildfile-sidekick h1 {
+  margin-bottom: 16px;
+}
+
+.buildfile-command-group {
+  margin-bottom: 16px;
+}
+
+.buildfile-command-item {
+  cursor: pointer;
+  margin-bottom: 4px;
+  background-color: transparent;
+  display: flex;
+  gap: 4px;
+  border: 1px solid #eee;
+  border-radius: 4px;
+  padding: 4px 8px;
+  align-items: center;
+}
+
+.buildfile-command-item svg {
+  color: #8bc34a;
+  width: 12px;
+  height: 12px;
+}

--- a/enterprise/app/sidekick/buildfile/buildfile.tsx
+++ b/enterprise/app/sidekick/buildfile/buildfile.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import * as monaco from "monaco-editor";
+import { PlayCircle } from "lucide-react";
+
+interface Props {
+  editor: monaco.editor.IStandaloneCodeEditor;
+  onBazelCommand: (c: string) => void;
+}
+interface State {}
+
+const commands = ["build", "test", "run"];
+export default class BuildFileSidekick extends React.Component<Props, State> {
+  state = {};
+
+  render() {
+    // TODO(siggisim): this hueristic for finding target names is janky, do something more clever here.
+    let targetNames = this.props.editor.getValue().matchAll(/\bname\s*=\s*"(?<name>[^"]*)"/g);
+    let path = this.getBuildPath(this.props.editor.getModel()?.uri.path || "");
+    return (
+      <div className="sidekick buildfile-sidekick">
+        <h1>Targets</h1>
+        {[...targetNames].map((t) => {
+          return (
+            <ul className="buildfile-command-group">
+              {commands.map((c) => {
+                let bazelCommand = `${c} ${path}:${t.groups?.name}`;
+                return (
+                  <li>
+                    <button className="buildfile-command-item" onClick={() => this.props.onBazelCommand(bazelCommand)}>
+                      <PlayCircle /> bazel {bazelCommand}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          );
+        })}
+      </div>
+    );
+  }
+
+  getBuildPath(path: string) {
+    let lastSlashIndex = path.lastIndexOf("/");
+    if (lastSlashIndex == -1) {
+      lastSlashIndex = 0;
+    }
+    let firstSlashIndex = 0;
+    if (path.startsWith("/")) {
+      firstSlashIndex = 1;
+    }
+    return path.substr(firstSlashIndex, lastSlashIndex - 1);
+  }
+}


### PR DESCRIPTION
Adds a little sidekick that allows you to quickly build/run/test any target in the BUILD files.

This could get a lot fancier, but just want to start simple.

<img width="511" alt="Screenshot 2024-02-28 at 2 31 15 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/6e5e1272-b91b-4e16-a153-1dac868e5040">
