### PR TITLE
Fix bug in redis cleanup logic

### DIFF
--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -96,7 +96,7 @@ const (
 
 	// How long any given job can hold the usage lock for, before it expires
 	// and other jobs may try to acquire it.
-	redisUsageLockExpiry = 45 * time.Second
+	redisUsageLockExpiry = 50 * time.Second
 
 	// How often to wake up and attempt to flush usage data from Redis to the DB.
 	flushInterval = periodDuration
@@ -282,7 +282,16 @@ func (ut *tracker) flushToDB(ctx context.Context) error {
 	// Don't run for longer than we have the Redis lock. This is mostly just to
 	// avoid situations where multiple apps are trying to write usage data to the
 	// DB at once while it is already under high load.
-	ctx, cancel := context.WithTimeout(ctx, redisUsageLockExpiry)
+	deadline := time.Now().Add(redisUsageLockExpiry)
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	// Reserve some of the context duration for cleanup. If a DB flush succeeds,
+	// then we want to make sure we have a little more time to clean up the
+	// Redis data corresponding to the flushed row while we still have the Redis
+	// lock held.
+	redisCleanupCtx := ctx
+	ctx, cancel = context.WithDeadline(ctx, deadline.Add(-5*time.Second))
 	defer cancel()
 
 	// Loop through usage periods starting from the oldest period
@@ -291,8 +300,8 @@ func (ut *tracker) flushToDB(ctx context.Context) error {
 	oldestPeriod := ut.oldestWritablePeriod()
 	for p := oldestPeriod; ut.isSettled(p); p = p.Next() {
 		// Read collections (JSON-serialized Collection structs)
-		gk := collectionsRedisKey(p)
-		encodedCollections, err := ut.rdb.SMembers(ctx, gk).Result()
+		collectionsKey := collectionsRedisKey(p)
+		encodedCollections, err := ut.rdb.SMembers(ctx, collectionsKey).Result()
 		if err != nil {
 			return err
 		}
@@ -323,13 +332,13 @@ func (ut *tracker) flushToDB(ctx context.Context) error {
 				return status.WrapError(err, "decode collection")
 			}
 			// Read usage counts from Redis
-			ck := countsRedisKey(p, encodedCollection)
-			h, err := ut.rdb.HGetAll(ctx, ck).Result()
+			countsKey := countsRedisKey(p, encodedCollection)
+			h, err := ut.rdb.HGetAll(ctx, countsKey).Result()
 			if err != nil {
 				return err
 			}
 			if len(h) == 0 {
-				alert.UnexpectedEvent("usage_unexpected_empty_hash_in_redis", "Usage counts in Redis are unexpectedly empty for key %q", ck)
+				alert.UnexpectedEvent("usage_unexpected_empty_hash_in_redis", "Usage counts in Redis are unexpectedly empty for key %q", countsKey)
 				continue
 			}
 			counts, err := stringMapToCounts(h)
@@ -340,17 +349,14 @@ func (ut *tracker) flushToDB(ctx context.Context) error {
 			if err := ut.flushCounts(ctx, collection.GroupID, p, &collection.UsageLabels, counts); err != nil {
 				return err
 			}
-			// Clean up the counts from Redis. Don't delete the collection JSON
-			// content though, since those aren't specific to collection periods
-			// and they might still be needed. Instead, just let those expire.
-			if _, err := ut.rdb.Del(ctx, ck).Result(); err != nil {
+			// Remove the collection data from Redis now that it has been
+			// flushed to the DB.
+			pipe := ut.rdb.TxPipeline()
+			pipe.SRem(redisCleanupCtx, collectionsKey, encodedCollection)
+			pipe.Del(redisCleanupCtx, countsKey)
+			if _, err := pipe.Exec(redisCleanupCtx); err != nil {
 				return err
 			}
-		}
-
-		// Delete the Redis data for the groups.
-		if _, err := ut.rdb.Del(ctx, gk).Result(); err != nil {
-			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
Let's say we have the following usage data in Redis that we want to flush to the DB:

| Key | Value |
| --- | --- |
| usage/collections/{period1} | Set{ "group_id=GR1", "group_id=GR2&origin=internal" } |
| usage/counts/{period1}/group_id=GR1 | Hash{ "invocations": "1" } |
| usage/counts/{period1}/group_id=GR2&origin=internal |  Hash{ "invocations": "2" } |

Currently, our flush procedure looks like this:
- Flush GR1 counts to the DB
- Delete GR1 counts
- Flush GR2 counts to the DB
- Delete GR2 counts
- Delete the collections set containing GR1 and GR2

This has a problem though: if we flush GR1 successfully, but then the flush for GR2 times out, the collections set entry will still contain GR1 on the next flush. So, the next time we try to flush, we'll try to flush the GR1 collection again, which will result in empty counts being read from Redis.

This PR just makes it so we do the following instead:
- Flush GR1 counts to the DB
- Delete GR1 counts and remove GR1 from the collections set
- Flush GR2 counts to the DB
- Delete GR2 counts and remove GR2 from the collections set (Redis also deletes the collections set entry here, since it has no more entries)


**Related issues**: N/A
