### PR TITLE
Fix GitHub Actions runner workflow

### DIFF
--- a/.github/workflows/buildbuddy-actions-runner-pr.yaml
+++ b/.github/workflows/buildbuddy-actions-runner-pr.yaml
@@ -52,6 +52,7 @@ jobs:
 
       - name: "Test"
         run: |
+          cd buildbuddy
           # Setting RUNNER_TRACKING_ID prevents the runner from
           # killing the bazel server at the end of the job.
           # See https://github.com/actions/runner/issues/598


### PR DESCRIPTION
Accidentally broke this while cleaning up some debug prints just before merging

**Related issues**: N/A
