### PR TITLE
[Raft] flush the batch more frequently when recovering from snapshot

### DIFF
--- a/enterprise/server/raft/replica/BUILD
+++ b/enterprise/server/raft/replica/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//server/util/qps",
         "//server/util/rangemap",
         "//server/util/status",
+        "@com_github_docker_go_units//:go-units",
         "@com_github_lni_dragonboat_v4//statemachine",
         "@com_github_prometheus_client_golang//prometheus",
         "@org_golang_google_genproto_googleapis_rpc//status",

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -30,6 +30,8 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/qps"
 	"github.com/buildbuddy-io/buildbuddy/server/util/rangemap"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	"github.com/docker/go-units"
 	"github.com/prometheus/client_golang/prometheus"
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
@@ -44,6 +46,7 @@ const (
 	// flushing any atime updates in an incomplete batch (that have not
 	// already been flushed due to throughput)
 	atimeFlushPeriod = 10 * time.Second
+	gb               = 1 << 30
 )
 
 var (
@@ -1818,11 +1821,23 @@ func (sm *Replica) saveRangeLocalData(w io.Writer, snap *pebble.Snapshot) error 
 	return nil
 }
 
+func flushBatch(wb pebble.Batch) error {
+	if wb.Empty() {
+		return nil
+	}
+	if err := wb.Commit(pebble.Sync); err != nil {
+		return err
+	}
+	wb.Reset()
+	return nil
+}
+
 func (sm *Replica) ApplySnapshotFromReader(r io.Reader, db ReplicaWriter) error {
 	wb := db.NewBatch()
 	defer wb.Close()
 
 	readBuf := bufio.NewReader(r)
+	batchSize := 0
 	for {
 		r, count, err := readDataFromReader(readBuf)
 		if err != nil {
@@ -1849,11 +1864,18 @@ func (sm *Replica) ApplySnapshotFromReader(r io.Reader, db ReplicaWriter) error 
 		if err := wb.Set(kv.Key, kv.Value, nil); err != nil {
 			return err
 		}
+		batchSize += n
+		if batchSize > 1*gb {
+			// Pebble panics when the batch is greater than ~4GB (or 2GB on 32-bit systems)
+			log.Debugf("ApplySnapshotFromReader: flushed batch of size %s", units.BytesSize(float64(batchSize)))
+			if err = flushBatch(wb); err != nil {
+				return err
+			}
+			batchSize = 0
+		}
 	}
-	if err := db.Apply(wb, pebble.Sync); err != nil {
-		return err
-	}
-	return nil
+	log.Debugf("ApplySnapshotFromReader: flushed batch of size %s", units.BytesSize(float64(batchSize)))
+	return flushBatch(wb)
 }
 
 // SaveSnapshot saves the point in time state of the IOnDiskStateMachine

--- a/enterprise/server/util/pebble/pebble.go
+++ b/enterprise/server/util/pebble/pebble.go
@@ -145,6 +145,9 @@ type Batch interface {
 	// Empty returns true if the batch is empty, and false otherwise.
 	Empty() bool
 
+	// Returns the current size of the batch.
+	Len() int
+
 	Reader() pebble.BatchReader
 
 	Reset()
@@ -252,6 +255,10 @@ func (ib *instrumentedBatch) Count() uint32 {
 
 func (ib *instrumentedBatch) Empty() bool {
 	return ib.batch.Empty()
+}
+
+func (ib *instrumentedBatch) Len() int {
+	return ib.batch.Len()
 }
 
 func (ib *instrumentedBatch) NewIter(o *pebble.IterOptions) Iterator {

--- a/enterprise/server/util/pebble/pebble.go
+++ b/enterprise/server/util/pebble/pebble.go
@@ -142,6 +142,9 @@ type Batch interface {
 	// operations with the except of LogData increment this count.
 	Count() uint32
 
+	// Empty returns true if the batch is empty, and false otherwise.
+	Empty() bool
+
 	Reader() pebble.BatchReader
 
 	Reset()
@@ -245,6 +248,10 @@ func (ib *instrumentedBatch) Commit(o *pebble.WriteOptions) error {
 
 func (ib *instrumentedBatch) Count() uint32 {
 	return ib.batch.Count()
+}
+
+func (ib *instrumentedBatch) Empty() bool {
+	return ib.batch.Empty()
 }
 
 func (ib *instrumentedBatch) NewIter(o *pebble.IterOptions) Iterator {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**:
https://github.com/buildbuddy-io/buildbuddy-internal/issues/3153


