### PR TITLE
[RB] Clean up having to checkout default branch in remote bazel workflow

### DIFF
--- a/.github/workflows/remote-bazel-build.yaml
+++ b/.github/workflows/remote-bazel-build.yaml
@@ -15,19 +15,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.BUILDBUDDY_GITHUB_USER_TOKEN }}
-          # Fetch all branches so we can checkout the master branch
-          fetch-depth: 0
 
       - name: Download bb cli
         run: |
           cli/install.sh
-
-      - name: Setup git env
-        run: |
-          # The cli reads the local git branches in order to determine the default branch
-          # Briefly checkout the master branch so it can find it
-          git checkout master
-          git checkout -
 
       - name: Test
         run: |


### PR DESCRIPTION
** PENDING: Need to upgrade cli after I merge #6031 , before I can merge this

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3141
