### PR TITLE
Show account type icons next to emails in members list

### DIFF
--- a/enterprise/app/org/BUILD
+++ b/enterprise/app/org/BUILD
@@ -102,6 +102,8 @@ ts_library(
         "//app/components/select",
         "//app/components/spinner",
         "//app/errors:error_service",
+        "//app/icons:github",
+        "//app/icons:google",
         "//app/service:rpc_service",
         "//proto:group_ts_proto",
         "//proto:user_id_ts_proto",

--- a/enterprise/app/org/org.css
+++ b/enterprise/app/org/org.css
@@ -298,6 +298,14 @@
 
 .org-members .org-member-email {
   font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.org-members .org-member-email svg {
+  width: 16px;
+  height: 16px;
 }
 
 .org-members .org-member-role {
@@ -360,6 +368,13 @@
 .org-members-edit-modal .affected-users-list-item {
   display: flex;
   padding: 8px;
+  gap: 8px;
+  align-items: center;
+}
+
+.org-members-edit-modal .affected-users-list-item svg {
+  width: 16px;
+  height: 16px;
 }
 
 .org-members-edit-modal .affected-users-list > :not(:last-child) {

--- a/enterprise/app/org/org_members.tsx
+++ b/enterprise/app/org/org_members.tsx
@@ -20,7 +20,9 @@ import { user_id } from "../../../proto/user_id_ts_proto";
 import Spinner from "../../../app/components/spinner/spinner";
 import Banner from "../../../app/components/banner/banner";
 import capabilities from "../../../app/capabilities/capabilities";
-import { CheckCircle, XCircle } from "lucide-react";
+import { CheckCircle, Github, HelpCircle, ShieldCheck, UserCircle, XCircle } from "lucide-react";
+import { GoogleIcon } from "../../../app/icons/google";
+import { GithubIcon } from "../../../app/icons/github";
 
 export type OrgMembersProps = {
   user: User;
@@ -40,6 +42,21 @@ type State = {
   isRemoveModalVisible?: boolean;
   isRemoveLoading?: boolean;
 };
+
+function iconFromAccountType(accountType: user_id.AccountType | undefined) {
+  switch (accountType) {
+    case user_id.AccountType.GOOGLE:
+      return <GoogleIcon />;
+    case user_id.AccountType.GITHUB:
+      return <GithubIcon />;
+    case user_id.AccountType.SAML:
+      return <ShieldCheck />;
+    case user_id.AccountType.OIDC:
+      return <UserCircle />;
+    default:
+      return <HelpCircle />;
+  }
+}
 
 function getRoleLabel(role: grp.Group.Role): string {
   switch (role) {
@@ -233,7 +250,7 @@ export default class OrgMembersComponent extends React.Component<OrgMembersProps
         <div className="affected-users-list">
           {selectedMembers.map((member) => (
             <div className={`affected-users-list-item ${this.isLoggedInUser(member) ? "flagged-self-user" : ""}`}>
-              {member.user?.email || member.user?.name?.full}
+              {member?.user?.email || member?.user?.name?.full} {iconFromAccountType(member.user?.accountType)}
             </div>
           ))}
         </div>
@@ -353,7 +370,9 @@ export default class OrgMembersComponent extends React.Component<OrgMembersProps
                   />
                 </div>
               )}
-              <div className="org-member-email">{member?.user?.email || member?.user?.name?.full}</div>
+              <div className="org-member-email">
+                {member?.user?.email || member?.user?.name?.full} {iconFromAccountType(member.user?.accountType)}
+              </div>
               <div className="org-member-role">{getRoleLabel(member?.role || 0)}</div>
             </div>
           ))}

--- a/enterprise/server/backends/userdb/userdb.go
+++ b/enterprise/server/backends/userdb/userdb.go
@@ -495,7 +495,7 @@ func (d *UserDB) GetGroupUsers(ctx context.Context, groupID string, statuses []g
 	users := make([]*grpb.GetGroupUsersResponse_GroupUser, 0)
 
 	q := query_builder.NewQuery(`
-			SELECT u.user_id, u.email, u.first_name, u.last_name, ug.membership_status, ug.role
+			SELECT u.user_id, u.email, u.first_name, u.last_name, u.sub_id, ug.membership_status, ug.role
 			FROM "Users" AS u JOIN "UserGroups" AS ug ON u.user_id = ug.user_user_id`)
 	q = q.AddWhereClause(`ug.group_group_id = ?`, groupID)
 
@@ -518,7 +518,7 @@ func (d *UserDB) GetGroupUsers(ctx context.Context, groupID string, statuses []g
 		user := &tables.User{}
 		var groupRole uint32
 		err := row.Scan(
-			&user.UserID, &user.Email, &user.FirstName, &user.LastName,
+			&user.UserID, &user.Email, &user.FirstName, &user.LastName, &user.SubID,
 			&groupUser.GroupMembershipStatus, &groupRole,
 		)
 		if err != nil {

--- a/proto/user_id.proto
+++ b/proto/user_id.proto
@@ -22,4 +22,13 @@ message DisplayUser {
   Name name = 2;
   string profile_image_url = 3;
   string email = 4;
+  AccountType account_type = 5;
+}
+
+enum AccountType {
+  UNKNOWN_USER_TYPE = 0;
+  GOOGLE = 1;
+  GITHUB = 2;
+  SAML = 3;
+  OIDC = 4;
 }

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -311,7 +311,22 @@ func (u *User) ToProto() *uspb.DisplayUser {
 		},
 		ProfileImageUrl: u.ImageURL,
 		Email:           u.Email,
+		AccountType:     subIDToAccountType(u.SubID),
 	}
+}
+
+func subIDToAccountType(s string) uspb.AccountType {
+	log.Printf(s)
+	if strings.HasPrefix(s, "https://accounts.google.com/") {
+		return uspb.AccountType_GOOGLE
+	}
+	if strings.HasPrefix(s, "https://app.buildbuddy.io/saml/") {
+		return uspb.AccountType_SAML
+	}
+	if strings.HasPrefix(s, "https://github.com/") {
+		return uspb.AccountType_GITHUB
+	}
+	return uspb.AccountType_OIDC
 }
 
 type Token struct {


### PR DESCRIPTION
This helps distinguish between Google / Github accounts and SAML accounts when migrating org auth provides.

This makes it easy to identify remove any members not using a preferred auth method.

Without these icons, it's impossible to distinguish between two accounts with the same email address from different providers in the UI.

Example:
<img width="918" alt="Screenshot 2024-02-29 at 2 40 02 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/ca9de14e-f0da-4753-a9b5-dc80ee7768bb">
