### PR TITLE
Don't put branch in cache key

### DIFF
--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -319,7 +319,7 @@ export default class CodeComponent extends React.Component<Props, State> {
   }
 
   getStateCacheKey() {
-    return `${LOCAL_STORAGE_STATE_KEY}/${this.currentOwner()}/${this.currentRepo()}/${this.getBranch()}`;
+    return `${LOCAL_STORAGE_STATE_KEY}/${this.currentOwner()}/${this.currentRepo()}`;
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
I added this a couple of PRs ago, but turns out it was a mistake.

We don't always know the branch, leading to pulling the wrong state in those cases.

We'll have to handle switching between branches in another way once we add that functionality.