### PR TITLE
Make upload_local_snapshot statically linked

### DIFF
--- a/enterprise/tools/upload_local_snapshot/BUILD
+++ b/enterprise/tools/upload_local_snapshot/BUILD
@@ -5,6 +5,9 @@ package(default_visibility = ["//enterprise:__subpackages__"])
 go_binary(
     name = "upload_local_snapshot",
     embed = [":upload_local_snapshot_lib"],
+    pure = "on",
+    static = "on",
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 go_library(


### PR DESCRIPTION
This lets us `scp` it to the node without hitting a GLIBC error

**Related issues**: N/A
