### PR TITLE
Debugging improvements for local snapshots

### DIFF
--- a/enterprise/tools/upload_local_snapshot/BUILD
+++ b/enterprise/tools/upload_local_snapshot/BUILD
@@ -29,10 +29,10 @@ go_library(
         "//server/util/claims",
         "//server/util/flagutil",
         "//server/util/grpc_client",
-        "//server/util/healthcheck",
         "//server/util/log",
         "//server/util/status",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_protobuf//encoding/protojson",
+        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/enterprise/tools/vmstart/BUILD
+++ b/enterprise/tools/vmstart/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//proto:vmvfs_go_proto",
         "//server/environment",
         "//server/interfaces",
+        "//server/nullauth",
         "//server/real_environment",
         "//server/remote_cache/cachetools",
         "//server/remote_cache/digest",


### PR DESCRIPTION
* Disable workspace sync when using vmstart to start a snapshot (use the workspace from the snapshot instead of a local empty dir). This will let us debug the snapshotted workspace contents.
* In upload_local_snapshot, make it harder to forget setting executor_id in the `--file_cache_dir` flag (I got stuck on this for a few min because I only saw the default flag definition and not the comment that mentions setting host_id)
* Upload artifacts in parallel using errgroup, and clean up temp files created by uploads. Also allow pressing Ctrl+C to cancel the script (healthchecker prevents this from happening - use NewBatchEnv instead).
* Fix auth error due to missing authenticator in env

**Related issues**: N/A
