### PR TITLE
Bring back `ClaimsCache` to reduce JWT parsing work

### DIFF
--- a/enterprise/server/oidc/oidc.go
+++ b/enterprise/server/oidc/oidc.go
@@ -571,8 +571,11 @@ func (a *OpenIDAuthenticator) authenticateGRPCRequest(ctx context.Context, accep
 	}
 
 	if acceptJWT {
-		// Check if we're already authenticated from incoming headers.
-		return claims.ClaimsFromContext(ctx)
+		// Internal RPCs will be authenticated via JWT, not API key. Parse the
+		// JWT here if present.
+		if tokenString, ok := ctx.Value(authutil.ContextTokenStringKey).(string); ok && tokenString != "" {
+			return a.parseClaims(tokenString)
+		}
 	}
 
 	return nil, authutil.AnonymousUserError("gRPC request is missing credentials.")

--- a/server/util/claims/claims.go
+++ b/server/util/claims/claims.go
@@ -290,6 +290,10 @@ func AuthContextFromClaims(ctx context.Context, c *Claims, err error) context.Co
 }
 
 func ClaimsFromContext(ctx context.Context) (*Claims, error) {
+	// TODO(http://go/b/3144): remove the JWT parsing from this func. Auth
+	// interceptors should store UserInfo into the ctx, and this func should
+	// directly return the stored UserInfo.
+
 	// If the context already contains trusted Claims, return them directly
 	// instead of re-parsing the JWT (which is expensive).
 	if claims, ok := ctx.Value(contextClaimsKey).(*Claims); ok && claims != nil {


### PR DESCRIPTION
It looks like [this change](https://github.com/buildbuddy-io/buildbuddy/commit/216dfe89879b04d356e8ffd800763c2b3571addc#diff-f9a06e832e7e443d9e2956af68a414f014011678f50c8859d8c4221936c87731R911) (need to click "load diff" on `auth.go`) changed the logic from `a.parseClaims()` which uses the `ClaimsCache`, to `claims.ParseClaims` which parses the claims unconditionally. This seems like it could have been unintentional but please let me know if it wasn't!

This should save about ~3-4% CPU in prod.

**Related issues**: N/A
