### PR TITLE
Fix short-circuit logic

### DIFF
--- a/enterprise/server/oidc/oidc.go
+++ b/enterprise/server/oidc/oidc.go
@@ -576,6 +576,7 @@ func (a *OpenIDAuthenticator) authenticateGRPCRequest(ctx context.Context, accep
 		if tokenString, ok := ctx.Value(authutil.ContextTokenStringKey).(string); ok && tokenString != "" {
 			return a.parseClaims(tokenString)
 		}
+		return nil, authutil.AnonymousUserError(authutil.UserNotFoundMsg)
 	}
 
 	return nil, authutil.AnonymousUserError("gRPC request is missing credentials.")


### PR DESCRIPTION
The PR https://github.com/buildbuddy-io/buildbuddy/pull/6066 changed the logic so that we fall through in the case where a JWT is missing, returning `"gRPC request is missing credentials"` instead of `authutil.UserNotFoundMsg` like we were before. This seems OK, but the logic in `auth.AuthenticatedUser` [here](https://github.com/buildbuddy-io/buildbuddy/blob/a8703506971adab680d4b0711f2fe1fcb483532b/enterprise/server/auth/auth.go#L163) depends on the error containing the string `authutil.UserNotFoundMsg` to know whether to short-circuit, or to move on to the next authenticator in the chain. This PR brings back that old logic to return `UserNotFoundMsg` just to ensure that we short-circuit like we were doing before (although I think the lack of short-circuiting is probably fine, I didn't intend to make that change originally).

**Related issues**: N/A
