### PR TITLE
Attempt to track compression ratio in a more accurate way

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -2259,6 +2259,12 @@ func (p *PebbleCache) writeMetadata(ctx context.Context, db pebble.IPebbleDB, ke
 		return err
 	}
 
+	if md.GetFileRecord().GetCompressor() == repb.Compressor_ZSTD {
+		labels := prometheus.Labels{metrics.CacheNameLabel: p.name, metrics.CompressionType: "zstd"}
+		metrics.CompressedBlobSizeWrite.With(labels).Add(float64(md.GetStoredSizeBytes()))
+		metrics.DecompressedBlobSizeWrite.With(labels).Add(float64(md.GetFileRecord().GetDigest().GetSizeBytes()))
+	}
+
 	unlockFn := p.locker.Lock(key.LockID())
 	defer unlockFn()
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -1974,6 +1974,30 @@ var (
 		CompressionType,
 	})
 
+	// Taken together, CompressedBlobSize and DecompressedBlobSize allow
+	// determining the average overall compression ratio of items written to
+	// the cache. This is an alternative to CompressionRatio (above) which
+	// is skewed because it weights blobs of different sizes equally. These
+	// values only track the blob size of blobs *written* to the cache.
+	CompressedBlobSizeWrite = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "compressor",
+		Name:      "compressed_blob_size_write",
+		Help:      "The number of compressed bytes in all blobs",
+	}, []string{
+		CacheNameLabel,
+		CompressionType,
+	})
+	DecompressedBlobSizeWrite = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: bbNamespace,
+		Subsystem: "compressor",
+		Name:      "decompressed_blob_size_write",
+		Help:      "The number of decompressed bytes in all blobs",
+	}, []string{
+		CacheNameLabel,
+		CompressionType,
+	})
+
 	// #### Examples
 	//
 	// ```promql


### PR DESCRIPTION
On write, in pebble cache, record the compressed size and uncompressed size of blobs.

Having both counters separately should allow us to track overall compression ratio in a more accurate way.