### PR TITLE
[RB] Try to set default branch env var for better snapshot matching

### DIFF
--- a/.github/workflows/remote-bazel-build.yaml
+++ b/.github/workflows/remote-bazel-build.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Test
         run: |
-          bb remote test //... \
+          bb remote --env=GIT_REPO_DEFAULT_BRANCH=master test //... \
             --config=linux-workflows --config=race \
             --remote_executor=grpcs://buildbuddy.buildbuddy.io \
             --test_tag_filters=-performance,-webdriver,-docker,-bare \

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -151,7 +151,9 @@ var (
 	patchURIs          = flag.Slice("patch_uri", []string{}, "URIs of patches to apply to the repo after checkout. Can be specified multiple times to apply multiple patches.")
 	recordRunMetadata  = flag.Bool("record_run_metadata", false, "Instead of running a target, extract metadata about it and report it in the build event stream.")
 	gitCleanExclude    = flag.Slice("git_clean_exclude", []string{}, "Directories to exclude from `git clean` while setting up the repo.")
-	envOverrideStr     = flag.String("env_overrides", "", "These env vars should take precedence over any set on the command or in buildbuddy.yaml.")
+
+	// TODO(Maggie): Clean up in a rollout-safe way
+	envOverrideStr = flag.String("env_overrides", "", "These env vars should take precedence over any set on the command or in buildbuddy.yaml.")
 
 	shutdownAndExit = flag.Bool("shutdown_and_exit", false, "If set, runs bazel shutdown with the configured bazel_command, and exits. No other commands are run.")
 

--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -2,7 +2,6 @@ package hostedrunner
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"io/fs"
 	"path/filepath"
@@ -121,11 +120,6 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		return nil, err
 	}
 
-	envJson, err := json.Marshal(req.GetEnv())
-	if err != nil {
-		return nil, err
-	}
-
 	// NOTE: Be cautious when adding new flags. See
 	// https://github.com/buildbuddy-io/buildbuddy-internal/issues/3101
 	args := []string{
@@ -138,9 +132,6 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		"--invocation_id=" + invocationID,
 		"--commit_sha=" + req.GetRepoState().GetCommitSha(),
 		"--target_branch=" + req.GetRepoState().GetBranch(),
-	}
-	if len(string(envJson)) > 0 {
-		args = append(args, "--env_overrides="+string(envJson))
 	}
 	if strings.HasPrefix(req.GetBazelCommand(), "run ") {
 		args = append(args, "--record_run_metadata")
@@ -194,6 +185,13 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		cmd.Platform.Properties = append(cmd.Platform.Properties, &repb.Platform_Property{
 			Name:  platform.CPUArchitecturePropertyName,
 			Value: req.GetArch(),
+		})
+	}
+
+	for k, v := range req.GetEnv() {
+		cmd.EnvironmentVariables = append(cmd.EnvironmentVariables, &repb.Command_EnvironmentVariable{
+			Name:  k,
+			Value: v,
 		})
 	}
 

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1082,6 +1082,12 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 		{Name: "GIT_REPO_DEFAULT_BRANCH", Value: wd.TargetRepoDefaultBranch},
 		{Name: "GIT_PR_NUMBER", Value: fmt.Sprintf("%d", wd.PullRequestNumber)},
 	}
+	for k, v := range env {
+		envVars = append(envVars, &repb.Command_EnvironmentVariable{
+			Name:  k,
+			Value: v,
+		})
+	}
 	containerImage := ""
 	isolationType := ""
 	os := strings.ToLower(workflowAction.OS)
@@ -1122,10 +1128,6 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 		useSelfHostedExecutors = "true"
 	}
 	besResultsURL, err := ws.createBBURL(ctx, "/invocation/")
-	if err != nil {
-		return nil, err
-	}
-	envJson, err := json.Marshal(env)
 	if err != nil {
 		return nil, err
 	}
@@ -1184,11 +1186,6 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 				{Name: platform.EstimatedCPUPropertyName, Value: workflowAction.ResourceRequests.GetEstimatedCPU()},
 			},
 		},
-	}
-	// See https://github.com/buildbuddy-io/buildbuddy-internal/issues/3101
-	// for more info on why we don't want to pass empty flags
-	if len(env) > 0 {
-		cmd.Arguments = append(cmd.Arguments, "--env_overrides="+string(envJson))
 	}
 	if isSharedFirecrackerWorkflow {
 		// For firecracker workflows, init dockerd in case local actions or


### PR DESCRIPTION
The snapshot key is based off the git branch. If we do not have a snapshot for a branch, we support falling back to snapshots for default branches, as specified in the `GIT_REPO_DEFAULT_BRANCH` and `GIT_BASE_BRANCH` env vars.
This change will enable more snapshot hits.

**Related issues**: N/A
