### PR TITLE
Log OCI => EXT4 conversions

### DIFF
--- a/enterprise/server/util/ociconv/ociconv.go
+++ b/enterprise/server/util/ociconv/ociconv.go
@@ -139,6 +139,12 @@ func CreateDiskImage(ctx context.Context, dockerClient *dockerclient.Client, wor
 		return existingPath, nil
 	}
 
+	log.CtxInfof(ctx, "Downloading image %s and converting to ext4 format", containerImage)
+	start := time.Now()
+	defer func() {
+		log.CtxInfof(ctx, "Converted %s to ext4 format in %s", containerImage, time.Since(start))
+	}()
+
 	// Dedupe image conversion operations, which are disk IO-heavy. Note, we
 	// convert the image in the background so that one client's ctx timeout does
 	// not affect other clients. We do apply a timeout to the background


### PR DESCRIPTION
These conversions take a long time - log a message before/after conversion associated with the task context so we can understand a little bit more easily why a task is spending so long in "preparing runner for task".

**Related issues**: N/A
