### PR TITLE
Get TreeCache and DirectoryWithDigest from VTPool

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -102,11 +102,11 @@ proto_library(
         ":context_proto",
         ":remote_execution_proto",
         ":resource_proto",
+        "@com_github_planetscale_vtprotobuf//include/github.com/planetscale/vtprotobuf/vtproto:vtproto_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:field_mask_proto",
         "@com_google_protobuf//:timestamp_proto",
         "@googleapis//google/rpc:status_proto",
-        "@com_github_planetscale_vtprotobuf//include/github.com/planetscale/vtprotobuf/vtproto:vtproto_proto",
     ],
 )
 
@@ -1390,8 +1390,8 @@ go_proto_library(
         ":context_go_proto",
         ":remote_execution_go_proto",
         ":resource_go_proto",
-        "@org_golang_google_genproto_googleapis_rpc//status",
         "@com_github_planetscale_vtprotobuf//include/github.com/planetscale/vtprotobuf/vtproto:vtproto_go_proto",
+        "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )
 

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -106,6 +106,7 @@ proto_library(
         "@com_google_protobuf//:field_mask_proto",
         "@com_google_protobuf//:timestamp_proto",
         "@googleapis//google/rpc:status_proto",
+        "@com_github_planetscale_vtprotobuf//include/github.com/planetscale/vtprotobuf/vtproto:vtproto_proto",
     ],
 )
 
@@ -1390,6 +1391,7 @@ go_proto_library(
         ":remote_execution_go_proto",
         ":resource_go_proto",
         "@org_golang_google_genproto_googleapis_rpc//status",
+        "@com_github_planetscale_vtprotobuf//include/github.com/planetscale/vtprotobuf/vtproto:vtproto_go_proto",
     ],
 )
 
@@ -2051,6 +2053,7 @@ ts_proto_library(
         ":remote_execution_ts_proto",
         ":resource_ts_proto",
         ":timestamp_ts_proto",
+        ":vtproto_ts_proto",
     ],
 )
 

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -248,6 +248,7 @@ message GetCacheMetadataResponse {
 
 // Used to cache GetTree responses.
 message DirectoryWithDigest {
+  option (vtproto.mempool) = true;
   reserved 2;
 
   build.bazel.remote.execution.v2.Directory directory = 1;

--- a/proto/cache.proto
+++ b/proto/cache.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package cache;
 
+import "github.com/planetscale/vtprotobuf/vtproto/ext.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
@@ -254,6 +255,7 @@ message DirectoryWithDigest {
 }
 
 message TreeCache {
+  option (vtproto.mempool) = true;
   repeated DirectoryWithDigest children = 1;
 }
 

--- a/server/remote_cache/content_addressable_storage_server/BUILD
+++ b/server/remote_cache/content_addressable_storage_server/BUILD
@@ -53,6 +53,7 @@ go_test(
         "//server/testutil/testenv",
         "//server/util/bazel_request",
         "//server/util/compression",
+        "//server/util/log",
         "//server/util/prefix",
         "//server/util/testing/flags",
         "@com_github_google_uuid//:uuid",

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -552,7 +552,10 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 				return nil
 			}
 			buf, err := proto.Marshal(treeCache)
-			//treeCache.ReturnToVTPool()
+			// Set the children to nil so that ReturnToVTPool don't reset all the
+			// children
+			treeCache.Children = nil
+			treeCache.ReturnToVTPool()
 			if err != nil {
 				return err
 			}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -646,12 +646,6 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 	rootDirWithDigest.Directory = rootDir
 	rootDirWithDigest.ResourceName = rootDirRN.ToProto()
 	allDirs, err := fetch(ctx, rootDirWithDigest, 0)
-	defer func() {
-		for _, dir := range allDirs {
-			dir.ReturnToVTPool()
-		}
-		rootDirWithDigest.ReturnToVTPool()
-	}()
 	if err != nil {
 		return err
 	}
@@ -674,6 +668,11 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 		log.Warningf("Error populating tree cache: %s", err)
 	}
 
+	// We can only clean the directories up after the eg are finished
+	for _, dir := range allDirs {
+		dir.ReturnToVTPool()
+	}
+	rootDirWithDigest.ReturnToVTPool()
 	return nil
 }
 

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -541,9 +541,8 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 	defer cacheCancel(context.Canceled)
 	eg, gCtx := errgroup.WithContext(cacheCtx)
 	cacheTreeNode := func(d *repb.Digest, descendents []*capb.DirectoryWithDigest) {
-		treeCache := &capb.TreeCache{
-			Children: make([]*capb.DirectoryWithDigest, len(descendents)),
-		}
+		treeCache := capb.TreeCacheFromVTPool()
+		treeCache.Children = make([]*capb.DirectoryWithDigest, len(descendents))
 		copy(treeCache.Children, descendents)
 		treeCacheDigest := d.CloneVT()
 
@@ -553,6 +552,7 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 				return nil
 			}
 			buf, err := proto.Marshal(treeCache)
+			treeCache.ReturnToVTPool()
 			if err != nil {
 				return err
 			}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -552,7 +552,7 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 				return nil
 			}
 			buf, err := proto.Marshal(treeCache)
-			treeCache.ReturnToVTPool()
+			//treeCache.ReturnToVTPool()
 			if err != nil {
 				return err
 			}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -534,8 +534,8 @@ func TestGetTree(t *testing.T) {
 		return makeTree(ctx, t, bsClient, instanceName, depth, branchingFactor)
 	}
 
-	child1Digest, child1Files := uploadDirWithFiles(2, 1)
-	child2Digest, child2Files := uploadDirWithFiles(2, 1)
+	child1Digest, child1Files := uploadDirWithFiles(4, 1)
+	child2Digest, child2Files := uploadDirWithFiles(4, 1)
 
 	// Upload a root directory containing both child directories.
 	rootDir := &repb.Directory{

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -534,7 +534,7 @@ func TestGetTree(t *testing.T) {
 	}
 
 	child1Digest, child1Files := uploadDirWithFiles(4, 1)
-	child2Digest, child2Files := uploadDirWithFiles(4, 1)
+	child2Digest, child2Files := uploadDirWithFiles(2, 3)
 
 	// Upload a root directory containing both child directories.
 	rootDir := &repb.Directory{

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -724,7 +724,6 @@ func BenchmarkGetTree(b *testing.B) {
 			b.Run(fmt.Sprintf("depth-%d-branchingFactor-%d", d, f), func(b *testing.B) {
 				rootDigests := make([]*repb.Digest, 0, b.N)
 				for n := 0; n < b.N; n++ {
-					b.StopTimer()
 					child1Digest, _ := uploadDirWithFiles(d, f)
 					child2Digest, _ := uploadDirWithFiles(d, f)
 
@@ -746,8 +745,8 @@ func BenchmarkGetTree(b *testing.B) {
 					rootDigests = append(rootDigests, rootDigest)
 				}
 
-				b.ReportAllocs()
 				b.ResetTimer()
+				b.ReportAllocs()
 				for n := 0; n < b.N; n++ {
 					_ = readTree(ctx, b, casClient, instanceName, rootDigests[n])
 				}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server_test.go
@@ -718,15 +718,15 @@ func BenchmarkGetTree(b *testing.B) {
 	}
 
 	depths := []int{2, 4}
-	branchingFactors := []int{1, 2}
+	branchingFactors := []int{1, 2, 3}
 
 	for _, d := range depths {
 		for _, f := range branchingFactors {
 			b.Run(fmt.Sprintf("depth-%d-branchingFactor-%d", d, f), func(b *testing.B) {
 				b.ReportAllocs()
 				b.ResetTimer()
-				b.StopTimer()
 				for n := 0; n < b.N; n++ {
+					b.StopTimer()
 					child1Digest, _ := uploadDirWithFiles(d, f)
 					child2Digest, _ := uploadDirWithFiles(d, f)
 


### PR DESCRIPTION
Add pooling for TreeCache and DirectoryWithDigest

Add benchmark test
Change TestGetTree depth and branchingFactor to parameters that caused nil
pointer in development.
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A

