### PR TITLE
Rename replicas => vnodes

### DIFF
--- a/server/util/consistent_hash/consistent_hash.go
+++ b/server/util/consistent_hash/consistent_hash.go
@@ -33,22 +33,29 @@ var (
 )
 
 type ConsistentHash struct {
-	ring        map[int]uint8
-	keys        []int
-	items       []string
-	numReplicas int
-	hashKey     HashFunction
-	mu          sync.RWMutex
-	replicaMu   sync.RWMutex
+	ring      map[int]uint8
+	keys      []int
+	items     []string
+	numVnodes int
+	hashKey   HashFunction
+	mu        sync.RWMutex
 }
 
-func NewConsistentHash(hashFunction HashFunction, numReplicas int) *ConsistentHash {
+// NewConsistentHash returns a new consistent hash ring.
+//
+// The given hash function is used to map vnodes and keys to positions on the
+// ring. Ideally, the hash function produces random-looking outputs for distinct
+// inputs.
+//
+// numVnodes decides how many copies of each server replica to place on the
+// ring. See https://en.wikipedia.org/wiki/Consistent_hashing#Variance_reduction
+func NewConsistentHash(hashFunction HashFunction, numVnodes int) *ConsistentHash {
 	return &ConsistentHash{
-		numReplicas: numReplicas,
-		hashKey:     hashFunction,
-		keys:        make([]int, 0),
-		ring:        make(map[int]uint8, 0),
-		items:       make([]string, 0),
+		numVnodes: numVnodes,
+		hashKey:   hashFunction,
+		keys:      make([]int, 0),
+		ring:      make(map[int]uint8, 0),
+		items:     make([]string, 0),
 	}
 }
 
@@ -71,7 +78,7 @@ func (c *ConsistentHash) Set(items ...string) error {
 	sort.Strings(c.items)
 
 	for itemIndex, key := range items {
-		for i := 0; i < c.numReplicas; i++ {
+		for i := 0; i < c.numVnodes; i++ {
 			h := c.hashKey(strconv.Itoa(i) + key)
 			c.keys = append(c.keys, h)
 			c.ring[h] = uint8(itemIndex)
@@ -99,7 +106,7 @@ func (c *ConsistentHash) Get(key string) string {
 	return r
 }
 
-func (c *ConsistentHash) lookupReplicas(idx int, fn func(replicaIndex uint8) bool) {
+func (c *ConsistentHash) lookupVnodes(idx int, fn func(vnodeIndex uint8) bool) {
 	done := false
 	for offset := 1; offset < len(c.keys) && !done; offset += 1 {
 		newIdx := (idx + offset) % len(c.keys)
@@ -125,8 +132,9 @@ func (c *ConsistentHash) GetAllReplicas(key string) []string {
 	replicas := make([]string, 0, len(c.items))
 	replicas = append(replicas, c.items[originalIndex])
 
-	c.lookupReplicas(idx, func(replicaIndex uint8) bool {
-		replica := c.items[replicaIndex]
+	c.lookupVnodes(idx, func(vnodeIndex uint8) bool {
+		replica := c.items[vnodeIndex]
+		// If we already visited this vnode's corresponding replica, skip.
 		for _, r := range replicas {
 			if r == replica {
 				return false
@@ -137,12 +145,11 @@ func (c *ConsistentHash) GetAllReplicas(key string) []string {
 	})
 
 	return replicas
-
 }
 
 // GetNReplicas returns the N "items" responsible for the specified key, in
-// order. It does this by walking the consistent hash ring, in order,
-// until N unique replicas have been found.
+// order. It does this by walking the vnodes in the consistent hash ring, in
+// order, until N unique replicas have been found.
 func (c *ConsistentHash) GetNReplicas(key string, n int) []string {
 	replicas := c.GetAllReplicas(key)
 	if len(replicas) < n {

--- a/server/util/consistent_hash/consistent_hash.go
+++ b/server/util/consistent_hash/consistent_hash.go
@@ -47,11 +47,11 @@ type ConsistentHash struct {
 // ring. Ideally, the hash function produces random-looking outputs for distinct
 // inputs.
 //
-// numVnodes decides how many copies of each server replica to place on the
-// ring. See https://en.wikipedia.org/wiki/Consistent_hashing#Variance_reduction
-func NewConsistentHash(hashFunction HashFunction, numVnodes int) *ConsistentHash {
+// vnodes decides how many copies of each server replica to place on the ring.
+// See https://en.wikipedia.org/wiki/Consistent_hashing#Variance_reduction
+func NewConsistentHash(hashFunction HashFunction, vnodes int) *ConsistentHash {
 	return &ConsistentHash{
-		numVnodes: numVnodes,
+		numVnodes: vnodes,
 		hashKey:   hashFunction,
 		keys:      make([]int, 0),
 		ring:      make(map[int]uint8, 0),

--- a/server/util/consistent_hash/consistent_hash_test.go
+++ b/server/util/consistent_hash/consistent_hash_test.go
@@ -17,13 +17,13 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-// Number of replicas serving as a reasonable default for testing purposes.
-const numReplicas = 100
+// Number of vnodes serving as a reasonable default for testing purposes.
+const numVnodes = 100
 
 func TestNodesetOrderIndependence(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	assert := assert.New(t)
-	ch := consistent_hash.NewConsistentHash(consistent_hash.CRC32, numReplicas)
+	ch := consistent_hash.NewConsistentHash(consistent_hash.CRC32, numVnodes)
 
 	hosts := make([]string, 0)
 	for i := 0; i < 10; i++ {
@@ -59,7 +59,7 @@ func TestNodesetOrderIndependence(t *testing.T) {
 func TestGetAllReplicas(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	assert := assert.New(t)
-	ch := consistent_hash.NewConsistentHash(consistent_hash.CRC32, numReplicas)
+	ch := consistent_hash.NewConsistentHash(consistent_hash.CRC32, numVnodes)
 
 	hosts := make([]string, 0)
 	for i := 0; i < 10; i++ {
@@ -117,15 +117,15 @@ func BenchmarkGetAllReplicas(b *testing.B) {
 	for _, test := range []struct {
 		Name         string
 		HashFunction consistent_hash.HashFunction
-		NumReplicas  int
+		NumVnodes    int
 	}{
-		{Name: "CRC32/100_Replicas", HashFunction: consistent_hash.CRC32, NumReplicas: 100},
-		{Name: "SHA256/10000_Replicas", HashFunction: consistent_hash.SHA256, NumReplicas: 10000},
+		{Name: "CRC32/100_vnodes", HashFunction: consistent_hash.CRC32, NumVnodes: 100},
+		{Name: "SHA256/10000_vnodes", HashFunction: consistent_hash.SHA256, NumVnodes: 10000},
 	} {
 		b.Run(test.Name, func(b *testing.B) {
 			rand.Seed(time.Now().UnixNano())
 			assert := assert.New(b)
-			ch := consistent_hash.NewConsistentHash(test.HashFunction, test.NumReplicas)
+			ch := consistent_hash.NewConsistentHash(test.HashFunction, test.NumVnodes)
 
 			hosts := make([]string, 0)
 			for i := 0; i < 10; i++ {


### PR DESCRIPTION
* Use "vnodes" instead of "replicas" to refer to the copies of each node placed around the ring
* Continue using "items" or "replicas" to refer to the nodes themselves

Context: https://github.com/buildbuddy-io/buildbuddy/pull/6091#discussion_r1516296223

**Related issues**: N/A
