### PR TITLE
add more context in error message to make debugging easier

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -1606,7 +1606,7 @@ func (sm *Replica) Update(entries []dbsm.Entry) ([]dbsm.Entry, error) {
 	for i, entry := range entries {
 		e, err := sm.singleUpdate(db, entry)
 		if err != nil {
-			return nil, status.InternalErrorf("failed to singleUpdate:%s", err)
+			return nil, status.InternalErrorf("failed to singleUpdate: %s", err)
 		}
 		entries[i] = e
 	}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Raft libraries calls replica.Update in goroutines; and it can panic if Update
returns error, e.g. https://github.com/buildbuddy-io/buildbuddy-internal/issues/3165

Adding some context in the error message can make it easier to debug.
