### PR TITLE
[SS] Fix rootfs file path and name

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1143,7 +1143,7 @@ func (c *FirecrackerContainer) initScratchImage(ctx context.Context, path string
 
 // initRootfsStore creates the initial rootfs chunk layout in the chroot.
 func (c *FirecrackerContainer) initRootfsStore(ctx context.Context) error {
-	cowChunkDir := filepath.Join(c.getChroot(), rootDriveID)
+	cowChunkDir := filepath.Join(c.getChroot(), rootFSName)
 	if err := os.MkdirAll(cowChunkDir, 0755); err != nil {
 		return status.InternalErrorf("failed to create rootfs chunk dir: %s", err)
 	}


### PR DESCRIPTION
I noticed in the metrics that we have files named "rootfs" and "rootfs.ext4". We pull the store name from the path, and I realized we are naming the path different things at different points. This pr consolidates the path names.

This wasn't causing issues because the different names were used when we create a new store from scratch, vs when we're unpausing a snapshot. As long as we were consistent within each case, there was no problem

**Related issues**: N/A
