### PR TITLE
Add a histogram for the delta between atime and current time for cache reads

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -835,6 +835,11 @@ func (p *PebbleCache) updateAtime(key filestore.PebbleKey) error {
 	}
 
 	atime := time.UnixMicro(md.GetLastAccessUsec())
+	metrics.PebbleCacheAtimeDeltaWhenRead.With(prometheus.Labels{
+		metrics.CacheNameLabel: p.name,
+		metrics.PartitionID:    md.GetFileRecord().GetIsolation().GetPartitionId(),
+	}).Observe(float64(time.Since(atime).Milliseconds()))
+
 	if !olderThanThreshold(atime, p.atimeUpdateThreshold) {
 		return nil
 	}

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -2263,6 +2263,35 @@ var (
 		CacheNameLabel,
 	})
 
+	PebbleCacheAtimeDeltaWhenRead = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "pebble_cache_atime_delta_when_read",
+		Buckets: customDurationMsecBuckets([]time.Duration{
+			1 * time.Minute,
+			5 * time.Minute,
+			10 * time.Minute,
+			30 * time.Minute,
+			1 * time.Hour,
+			3 * time.Hour,
+			6 * time.Hour,
+			12 * time.Hour,
+			1 * day,
+			2 * day,
+			3 * day,
+			4 * day,
+			5 * day,
+			6 * day,
+			7 * day,
+			14 * day,
+			21 * day,
+		}),
+		Help: "Previous atime of items in the cache when they are read, in msec",
+	}, []string{
+		PartitionID,
+		CacheNameLabel,
+	})
+
 	PebbleCacheEvictionSamplesChanSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: bbNamespace,
 		Subsystem: "remote_cache",


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
Will use this to get a rough idea of what % of digests are read "often" (i.e., inside the 3-hour atime update threshold) vs. not, as well as P(any read|not read in k days).  This might give some ideas for how to optimize a smaller cache across all apps.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
