### PR TITLE
Fix raft atime update bug

### DIFF
--- a/enterprise/config/buildbuddy.raft.yaml
+++ b/enterprise/config/buildbuddy.raft.yaml
@@ -13,6 +13,10 @@ storage:
     root_directory: /tmp/buildbuddy_enterprise
 gossip:
   join: ["127.0.0.1:9201", "127.0.0.1:9202", "127.0.0.1:9203"]
+cache:
+  raft:
+    max_range_size_bytes: 1000000
+    atime_update_threshold: 1m
 auth:
   enable_anonymous_usage: true
   enable_self_auth: true


### PR DESCRIPTION
fix a bug in updating atime: need to create the batch in the function that
passes into RunMultiKey. 

Also, set split range and atime_update_threshold smaller locally

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
