### PR TITLE
Style error messages a little nicer

### DIFF
--- a/app/invocation/invocation_error_card.tsx
+++ b/app/invocation/invocation_error_card.tsx
@@ -5,6 +5,9 @@ import { failure_details } from "../../proto/failure_details_ts_proto";
 import TerminalComponent from "../terminal/terminal";
 import rpc_service from "../service/rpc_service";
 
+
+const debugMessage =
+  "Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging";
 interface Props {
   model: InvocationModel;
 }
@@ -33,6 +36,14 @@ export default class ErrorCardComponent extends React.Component<Props, State> {
     }
   }
 
+  prettyPrintedStdErr() {
+    if (!this.state.stdErr) {
+      return "";
+    }
+
+    return "\n\n" + this.state.stdErr.replaceAll(/([^\s]*:\d+:\d+)/g, "\x1b[1;4m$1\x1b[0m");
+  }
+
   render() {
     let title = "";
     let description = "";
@@ -50,6 +61,8 @@ export default class ErrorCardComponent extends React.Component<Props, State> {
       return null;
     }
 
+    description = description.replaceAll(debugMessage, `\x1b[90m${debugMessage}\x1b[0m\n \n`);
+
     return (
       <div className="invocation-error-card card card-failure">
         <AlertCircle className="icon red" />
@@ -57,8 +70,13 @@ export default class ErrorCardComponent extends React.Component<Props, State> {
           <div className="title">{title}</div>
           <div className="subtitle">{this.props.model.failedAction?.action?.label}</div>
           <div className="details">
-            <pre className="error-contents">{description}</pre>
-            {this.state.stdErr && <TerminalComponent value={this.state.stdErr} lightTheme />}
+            <TerminalComponent
+              value={"\x1b[1;31m" + description + "\x1b[0m" + this.prettyPrintedStdErr()}
+              lightTheme
+              scrollTop
+              bottomControls
+              defaultWrapped
+            />
           </div>
         </div>
       </div>

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -517,12 +517,7 @@ body {
 }
 
 .card.light-terminal {
-  background-color: #fafafa;
-  box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.2), 0px 1px 6px rgba(0, 0, 0, 0.1);
-}
-
-.card.light-terminal:hover {
-  box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.2), 0px 1px 10px rgba(0, 0, 0, 0.1);
+  background-color: #fff;
 }
 
 .dense .card.light-terminal:hover {

--- a/app/target/action_card.tsx
+++ b/app/target/action_card.tsx
@@ -137,6 +137,7 @@ export default class ActionCardComponent extends React.Component<Props, State> {
                   loading={this.state.loadingStderr}
                   value={this.state.stdErr || "Empty log"}
                   lightTheme={!this.props.dark}
+                  scrollTop
                 />
               )}
             </div>

--- a/app/terminal/terminal.css
+++ b/app/terminal/terminal.css
@@ -1,9 +1,10 @@
 .terminal {
   --scrollbar-width: 8px;
   background: #212121;
+  display: flex;
 }
 .terminal.light-terminal {
-  background: #fafafa;
+  background: #fff;
 }
 
 .terminal .terminal-search {
@@ -31,6 +32,8 @@
 .terminal .terminal-search-input {
   height: 32px;
   max-width: 180px;
+  border: 1px solid #eee;
+  border-radius: 8px;
 }
 
 .terminal .terminal-text {
@@ -41,7 +44,6 @@
 .terminal .terminal-top-bar {
   display: flex;
   padding-right: var(--scrollbar-width);
-  padding-bottom: 4px;
 }
 
 .terminal .terminal-titles {

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -27,6 +27,9 @@ export interface TerminalProps {
 
   title?: React.ReactNode;
 
+  scrollTop?: boolean;
+  bottomControls?: boolean;
+  defaultWrapped?: boolean;
   lightTheme?: boolean;
   fullLogsFetcher?: () => void;
 }
@@ -194,6 +197,9 @@ export default class TerminalComponent extends React.Component<TerminalProps, St
   private memoizedGetContent = memoizeOne(getContent);
 
   private getWrapPreference(): boolean {
+    if (localStorage.getItem(WRAP_LOCAL_STORAGE_KEY) === null) {
+      return this.props.defaultWrapped || false;
+    }
     return localStorage.getItem(WRAP_LOCAL_STORAGE_KEY) === WRAP_LOCAL_STORAGE_VALUE;
   }
   private updateLineLengthLimit(): void {
@@ -264,6 +270,9 @@ export default class TerminalComponent extends React.Component<TerminalProps, St
   }
 
   private scrollToEnd() {
+    if (this.props.scrollTop) {
+      return;
+    }
     let lineNumber = router.getLineNumber();
     if (lineNumber) {
       this.scrollToRow(lineNumber - 1);
@@ -322,10 +331,11 @@ export default class TerminalComponent extends React.Component<TerminalProps, St
 
     return (
       <div
+        style={{ flexDirection: this.props.bottomControls ? "column-reverse" : "column" }}
         className={`terminal ${this.props.lightTheme ? "light-terminal" : ""}`}
         onMouseEnter={this.onMouseEnter.bind(this)}
         onMouseLeave={this.onMouseLeave.bind(this)}>
-        <div className="terminal-top-bar">
+        <div className="terminal-top-bar" style={{ padding: this.props.bottomControls ? "4px 0 0 0" : "0 0 4px 0" }}>
           {this.props.title && <div className="terminal-titles">{this.props.title}</div>}
           <div className="terminal-actions">
             <div className="terminal-search">
@@ -389,7 +399,10 @@ export default class TerminalComponent extends React.Component<TerminalProps, St
             </button>
           </div>
         </div>
-        <div className="terminal-text" ref={this.terminalRef}>
+        <div
+          className="terminal-text"
+          ref={this.terminalRef}
+          style={{ height: `${content.rows.length ? Math.min(ROW_HEIGHT_PX * content.rows.length + 8, 400) : 400}px` }}>
           {this.props.loading ? (
             <div className={`loading ${this.props.lightTheme ? "" : "loading-dark-terminal"}`} />
           ) : (


### PR DESCRIPTION
Before
<img width="1499" alt="Screenshot 2024-03-08 at 4 34 48 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/fe2be49a-75b1-4fe6-b936-90833a3c3798">

After
<img width="1402" alt="Screenshot 2024-03-08 at 4 31 49 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/e5a1bf94-e147-4c95-865f-bc2be96d5756">
