### PR TITLE
Fix visibility modal in the UI

### DIFF
--- a/app/invocation/invocation_share_button.tsx
+++ b/app/invocation/invocation_share_button.tsx
@@ -123,7 +123,9 @@ export default class InvocationShareButtonComponent extends React.Component<
     }
     const owningGroup = this.props.model.findOwnerGroup(this.props.user?.groups);
     const isEnabledByOrg = Boolean(owningGroup?.sharingEnabled);
-    const isUnauthenticatedBuild = Boolean(!this.props.model.invocation.acl?.userId?.id);
+    const isUnauthenticatedBuild = Boolean(
+      !this.props.model.invocation.acl?.userId?.id && !this.props.model.invocation.acl?.groupId
+    );
     const canChangePermissions = isEnabledByOrg && !isUnauthenticatedBuild;
 
     const visibility: VisibilitySelection = this.state.acl?.othersPermissions?.read ? "public" : "group";


### PR DESCRIPTION
The UI was only looking at whether or not a user id was present on an invocation to determine whether or not to disable the visibility modal.

After this change https://github.com/buildbuddy-io/buildbuddy/pull/5778/files we don't set a user id if an organization-level API key is used.

This makes the visibility dropdown disabled in some cases where it shouldn't be.

This PR updates the UI to check for a group id as well when trying to determine if the invocation is an authenticated build.