### PR TITLE
Fix executable diagnostics

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -106,7 +106,7 @@ const (
 	//
 	// NOTE: this is part of the snapshot cache key, so bumping this version
 	// will make existing cached snapshots unusable.
-	GuestAPIVersion = "7"
+	GuestAPIVersion = "8"
 
 	// How long to wait when dialing the vmexec server inside the VM.
 	vSocketDialTimeout = 60 * time.Second

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -139,8 +139,8 @@ func TestGuestAPIVersion(t *testing.T) {
 	// Note that if you go with option 1, ALL VM snapshots will be invalidated
 	// which will negatively affect customer experience. Be careful!
 	const (
-		expectedHash    = "1ae2b2ee4347de4d9f7292254c999518ad783d5a5862b9f896e1ba6aa08f7640"
-		expectedVersion = "7"
+		expectedHash    = "0a4d754cb1b71a32c7f1bea13ac4a69c2e4f045ccf08e44ff08157dc0bdd9a35"
+		expectedVersion = "8"
 	)
 	assert.Equal(t, expectedHash, firecracker.GuestAPIHash)
 	assert.Equal(t, expectedVersion, firecracker.GuestAPIVersion)


### PR DESCRIPTION
Also log the first 1K bytes of the executable (I realized that if there is corruption, just knowing the digest of the corrupted contents will not be super helpful)

**Related issues**: N/A
