### PR TITLE
[raft] increase the event channel size

### DIFF
--- a/enterprise/server/raft/events/events.go
+++ b/enterprise/server/raft/events/events.go
@@ -80,7 +80,7 @@ func (u RangeUsageEvent) EventType() EventType {
 func (u RangeUsageEvent) String() string {
 	switch u.Type {
 	case EventRangeUsageUpdated:
-		return "range-usage-updated"
+		return fmt.Sprintf("range-usage-updated for range ID %d", u.RangeDescriptor.GetRangeId())
 	default:
 		return fmt.Sprintf("unknown event type: %d", u.Type)
 	}

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -355,7 +355,7 @@ func (s *Store) AddEventListener() <-chan events.Event {
 	s.eventsMu.Lock()
 	defer s.eventsMu.Unlock()
 
-	ch := make(chan events.Event, 10)
+	ch := make(chan events.Event, 100)
 	s.eventListeners = append(s.eventListeners, ch)
 	return ch
 }

--- a/enterprise/server/raft/usagetracker/usagetracker.go
+++ b/enterprise/server/raft/usagetracker/usagetracker.go
@@ -203,7 +203,7 @@ func (pu *partitionUsage) sample(ctx context.Context, n int) ([]*approxlru.Sampl
 
 	if totalCount <= 0 {
 		if totalCount < 0 {
-			log.Warningf("partitionUsage TotalCount (%d) is negative", totalCount)
+			log.Warningf("partitionUsage (id=%s) TotalCount (%d) is negative", pu.id, totalCount)
 		}
 		return nil, status.FailedPreconditionError("cannot sample empty partition")
 	}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
We are dropping range usage events, and this might cause total count to be
negative. increase the event channel size to 100.

Also add more details to the logs when we drop the range usage event.
