### PR TITLE
GetTree: skip TreeCache lookups for levels that aren't cached

### DIFF
--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -580,7 +580,8 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 		if err != nil {
 			return nil, err
 		}
-		if *enableTreeCaching {
+		// TODO: change > to >= here and update flag settings to match.
+		if level > *minTreeCacheLevel && *enableTreeCaching {
 			// Limit cardinality of level label.
 			levelLabel := fmt.Sprintf("%d", min(level, 12))
 			treeCacheRN := digest.NewResourceName(treeCacheDigest, req.GetInstanceName(), rspb.CacheType_AC, req.GetDigestFunction()).ToProto()
@@ -640,6 +641,7 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 			return nil, err
 		}
 
+		// TODO: change > to >= here and update flag settings to match.
 		if level > *minTreeCacheLevel && len(allDescendents) > *minTreeCacheDescendents && *enableTreeCaching {
 			cacheTreeNode(treeCacheDigest, allDescendents)
 		}

--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -581,7 +581,7 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 			return nil, err
 		}
 		// TODO: change > to >= here and update flag settings to match.
-		if level > *minTreeCacheLevel && *enableTreeCaching {
+		if *enableTreeCaching && level > *minTreeCacheLevel {
 			// Limit cardinality of level label.
 			levelLabel := fmt.Sprintf("%d", min(level, 12))
 			treeCacheRN := digest.NewResourceName(treeCacheDigest, req.GetInstanceName(), rspb.CacheType_AC, req.GetDigestFunction()).ToProto()
@@ -642,7 +642,7 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 		}
 
 		// TODO: change > to >= here and update flag settings to match.
-		if level > *minTreeCacheLevel && len(allDescendents) > *minTreeCacheDescendents && *enableTreeCaching {
+		if *enableTreeCaching && level > *minTreeCacheLevel && len(allDescendents) > *minTreeCacheDescendents {
 			cacheTreeNode(treeCacheDigest, allDescendents)
 		}
 		return allDescendents, nil


### PR DESCRIPTION
The idea here is that we can reduce the amount of TreeCache AC lookups by respecting `minTreeCacheLevel` not only for cache writes but for cache reads as well.

Here is the intuition for this change: directories usually appear at the same "level" across builds. If we have a directory nested 3 levels deep under the root dir ("L3"), usually we won't see those exact directory contents re-appear at a higher level in a different build (specifically, at L0 or L1). For example, most inputs in the build will appear under `/bazel-out/{config}` or `/external/{repo_name}`, and it's unlikely that we'd see a directory like `/external/bazel_tools/blah` reappear as `/blah` in a subsequent build. So, we are likely spending a lot of time doing TreeCache lookups for levels which will almost always result in cache misses.

The new metrics in dev support this as well - we are getting 0 TreeCache hits at L0, which is roughly expected because we don't cache L0 dirs. So it should be safe to skip L0 TreeCache lookups. The vast majority of hits are appearing at L5, L2, and L4. We are getting some L1 TreeCache hits (I'm not exactly sure why, yet - the min_level in dev is 1 so we should only be caching levels >= 2) - but the number of L1 TreeCache hits is much lower than the number of hits at L5+L2+L4.

In a local experiment alternating between having this change enabled and disabled, with a pre-warmed app + executor cache, doing a clean bazel build of `//server/util/git` remotely (with `--noremote_accept_cached` to force execution of the full action graph), and recording totals across N=10 runs, this reduces the amount of `cache.Get` calls done in `GetTree` by about 37%. The E2E build time savings are not significant - the main goal here was just to reduce the work done in `GetTree`.

```
+-------------------------+---------------+------------+----------+-------------------+
| RespectMinLevelForReads | DurationSec   | FetchCount | DirCount | TreeCacheGetCount |
+-------------------------+---------------+------------+----------+-------------------+
| False                   | 2.722         | 17000      | 342420   | 26930             |
+-------------------------+---------------+------------+----------+-------------------+
| True                    | 2.407         | 16815      | 342420   | 16881             |
+-------------------------+---------------+------------+----------+-------------------+
```

**Related issues**: N/A
