### PR TITLE
actually log access time delta for case where atime wont be updated

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -835,10 +835,6 @@ func (p *PebbleCache) updateAtime(key filestore.PebbleKey) error {
 	}
 
 	atime := time.UnixMicro(md.GetLastAccessUsec())
-	metrics.PebbleCacheAtimeDeltaWhenRead.With(prometheus.Labels{
-		metrics.CacheNameLabel: p.name,
-		metrics.PartitionID:    md.GetFileRecord().GetIsolation().GetPartitionId(),
-	}).Observe(float64(time.Since(atime).Milliseconds()))
 
 	if !olderThanThreshold(atime, p.atimeUpdateThreshold) {
 		return nil
@@ -1713,6 +1709,11 @@ func (p *PebbleCache) sendSizeUpdate(partID string, cacheType rspb.CacheType, op
 
 func (p *PebbleCache) sendAtimeUpdate(key filestore.PebbleKey, lastAccessUsec int64) {
 	atime := time.UnixMicro(lastAccessUsec)
+
+	metrics.PebbleCacheAtimeDeltaWhenRead.With(prometheus.Labels{
+		metrics.CacheNameLabel: p.name,
+	}).Observe(float64(time.Since(atime).Milliseconds()))
+
 	if !olderThanThreshold(atime, p.atimeUpdateThreshold) {
 		return
 	}

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -2249,7 +2249,6 @@ var (
 		}),
 		Help: "Previous atime of items in the cache when they are read, in msec",
 	}, []string{
-		PartitionID,
 		CacheNameLabel,
 	})
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
sigh.  races between apps to update atime made me think this was working right in dev, but i somehow missed a short circuit right before the channel _write_ (we short circuit updating atime in two places)
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
