### PR TITLE
Set DirectMountStrict in VBD/VFS to prevent deadlocks

### DIFF
--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -95,9 +95,11 @@ func (f *FS) Mount(ctx context.Context, path string) error {
 			// Debug:         true,
 			DisableXAttrs: true,
 			// Don't depend on `fusermount`.
-			DirectMount: true,
-			FsName:      "vbd",
-			MaxWrite:    fuse.MAX_KERNEL_WRITE,
+			// Disable fallback to fusermount as well, since it can cause
+			// deadlocks. See https://github.com/hanwen/go-fuse/issues/506
+			DirectMountStrict: true,
+			FsName:            "vbd",
+			MaxWrite:          fuse.MAX_KERNEL_WRITE,
 		},
 	}
 	nodeFS := fusefs.NewNodeFS(f.root, opts)

--- a/enterprise/server/remote_execution/vfs/vfs_unix.go
+++ b/enterprise/server/remote_execution/vfs/vfs_unix.go
@@ -110,11 +110,13 @@ func (vfs *VFS) Mount() error {
 			AllowOther:    true,
 			Debug:         vfs.logFUSEOps,
 			DisableXAttrs: true,
-			// Don't depend on the `fusermount` binary to make things simpler under Firecracker.
-			DirectMount: true,
-			FsName:      "bbvfs",
-			MaxWrite:    fuse.MAX_KERNEL_WRITE,
-			EnableLocks: true,
+			// Don't depend on `fusermount`.
+			// Disable fallback to fusermount as well, since it can cause
+			// deadlocks. See https://github.com/hanwen/go-fuse/issues/506
+			DirectMountStrict: true,
+			FsName:            "bbvfs",
+			MaxWrite:          fuse.MAX_KERNEL_WRITE,
+			EnableLocks:       true,
 		},
 	}
 	nodeFS := fs.NewNodeFS(vfs.root, opts)


### PR DESCRIPTION
See https://github.com/hanwen/go-fuse/issues/506

If direct mounting fails, don't fall back to `fusermount`, since it can cause deadlocks. Direct-mounting should work in most cases without needing to fall back to `fusermount` since we run the executor as root. The `fusermount` fallback mostly seems needed for cases where the user is not root and direct mounting doesn't work.

This may or may not be the root cause of the VBD deadlocks we are seeing. If VBD mounts occasionally fail in prod, then they would fall back to using `fusermount` ([regardless of error code](https://github.com/hanwen/go-fuse/blob/e9e7c22af17af4611b5783a16458647088cc8dec/fuse/mount_linux.go#L142-L150)), which can potentially deadlock. However, we don't know if this fallback is actually happening or not, because it happens silently.

It would be better to return an error in this case, rather than fall back to something that might sometimes succeed, but other times can cause a deadlock. If we do start seeing occasional VBD mount errors after this PR, then it means we were triggering the `fusermount` fallback which could possibly have been the source of deadlocks.

**Related issues**: N/A
