### PR TITLE
Set cmd.SysProcAttr before using

### DIFF
--- a/enterprise/server/remote_execution/soci_store/soci_store_linux.go
+++ b/enterprise/server/remote_execution/soci_store/soci_store_linux.go
@@ -175,7 +175,7 @@ func (s *SociStore) runWithRetries(ctx context.Context) {
 		}
 		args = append(args, s.path)
 		cmd := exec.CommandContext(ctx, *binary, args...)
-		cmd.SysProcAttr.Setpgid = true
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		logWriter := log.Writer("[socistore] ")
 		cmd.Stderr = logWriter
 		cmd.Stdout = logWriter


### PR DESCRIPTION
It's nil by default because it's a pointer not an embedded struct.

**Related issues**: [2901](https://github.com/buildbuddy-io/buildbuddy-internal/issues/2901)
