### PR TITLE
Use executor host ID for task routing

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -961,8 +961,8 @@ func (s *ExecutionServer) markTaskComplete(ctx context.Context, taskID string, e
 	router := s.env.GetTaskRouter()
 	// Only update the router if a task was actually executed
 	if router != nil && !executeResponse.GetCachedResult() {
-		nodeID := executeResponse.GetResult().GetExecutionMetadata().GetExecutorId()
-		router.MarkComplete(ctx, cmd, actionResourceName.GetInstanceName(), nodeID)
+		executorHostID := executeResponse.GetResult().GetExecutionMetadata().GetWorker()
+		router.MarkComplete(ctx, cmd, actionResourceName.GetInstanceName(), executorHostID)
 	}
 
 	if sizer := s.env.GetTaskSizer(); sizer != nil {

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -479,6 +479,7 @@ func (h *executorHandle) startTaskReservationStreamer() {
 
 type executionNode struct {
 	executorID            string
+	executorHostID        string
 	assignableMemoryBytes int64
 	assignableMilliCpu    int64
 	// Optional host:port of the scheduler to which the executor is connected. Only set for executors connecting using
@@ -507,6 +508,10 @@ func (en *executionNode) String() string {
 
 func (en *executionNode) GetExecutorID() string {
 	return en.executorID
+}
+
+func (en *executionNode) GetExecutorHostID() string {
+	return en.executorHostID
 }
 
 func nodesThatFit(nodes []*executionNode, taskSize *scpb.TaskSize) []*executionNode {
@@ -611,6 +616,7 @@ func (np *nodePool) fetchExecutionNodes(ctx context.Context) ([]*executionNode, 
 
 		executors = append(executors, &executionNode{
 			executorID:            id,
+			executorHostID:        node.GetRegistration().GetExecutorHostId(),
 			schedulerHostPort:     node.GetSchedulerHostPort(),
 			assignableMemoryBytes: node.GetRegistration().GetAssignableMemoryBytes(),
 			assignableMilliCpu:    node.GetRegistration().GetAssignableMilliCpu(),

--- a/enterprise/server/scheduling/scheduler_server/scheduler_server.go
+++ b/enterprise/server/scheduling/scheduler_server/scheduler_server.go
@@ -478,7 +478,11 @@ func (h *executorHandle) startTaskReservationStreamer() {
 }
 
 type executionNode struct {
-	executorID            string
+	// Unique ID generated when the executor process starts.
+	executorID string
+
+	// ID of the host that the executor is running on, which persists across
+	// restarts.
 	executorHostID        string
 	assignableMemoryBytes int64
 	assignableMilliCpu    int64

--- a/enterprise/server/scheduling/task_router/BUILD
+++ b/enterprise/server/scheduling/task_router/BUILD
@@ -33,5 +33,6 @@ go_test(
         "//server/testutil/testauth",
         "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_exp//slices",
     ],
 )

--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -124,35 +124,41 @@ func (tr *taskRouter) RankNodes(ctx context.Context, cmd *repb.Command, remoteIn
 		return nonePreferred(nodes)
 	}
 
-	nodeByID := map[string]interfaces.ExecutionNode{}
+	nodeByExecutorID := map[string]interfaces.ExecutionNode{}
+	nodeByHostID := map[string]interfaces.ExecutionNode{}
 	for _, node := range nodes {
-		nodeByID[node.GetExecutorID()] = node
+		nodeByExecutorID[node.GetExecutorID()] = node
+		// Note: if multiple executors live on the same host, the last one in
+		// the list wins.
+		nodeByHostID[node.GetExecutorHostID()] = node
 	}
+
+	// Executor IDs of the nodes we've added to the front of the list so far.
 	preferredSet := map[string]struct{}{}
 	ranked := make([]interfaces.RankedExecutionNode, 0, len(nodes))
 
 	// Routing keys should be prioritized in the order they were returned
 	for _, routingKey := range routingKeys {
-		preferredNodeIDs, err := tr.rdb.LRange(ctx, routingKey, 0, -1).Result()
+		preferredHostIDs, err := tr.rdb.LRange(ctx, routingKey, 0, -1).Result()
 		if err != nil {
 			log.Errorf("Failed to rank nodes: redis LRANGE failed: %s", err)
 			return nonePreferred(nodes)
 		}
 
-		log.Debugf("Preferred executor IDs for %q: %v", routingKey, preferredNodeIDs)
+		log.Debugf("Preferred executor host IDs for %q: %v", routingKey, preferredHostIDs)
 
 		// Place all preferred nodes first.
 		// For each routing key, preferred nodes should be prioritized in the order
 		// they appear in the Redis list.
-		for _, id := range preferredNodeIDs[:min(preferredNodeLimit, len(preferredNodeIDs))] {
-			node := nodeByID[id]
+		for _, hostID := range preferredHostIDs[:min(preferredNodeLimit, len(preferredHostIDs))] {
+			node := nodeByHostID[hostID]
 			if node == nil {
 				continue
 			}
 			if _, ok := preferredSet[node.GetExecutorID()]; ok {
 				continue
 			}
-			preferredSet[id] = struct{}{}
+			preferredSet[node.GetExecutorID()] = struct{}{}
 			ranked = append(ranked, rankedExecutionNode{node: node, preferred: true})
 		}
 	}
@@ -171,7 +177,7 @@ func (tr *taskRouter) RankNodes(ctx context.Context, cmd *repb.Command, remoteIn
 // MarkComplete updates the routing table after a task is completed, so that
 // future tasks with those properties are more likely to be fulfilled by the
 // given node.
-func (tr *taskRouter) MarkComplete(ctx context.Context, cmd *repb.Command, remoteInstanceName, executorID string) {
+func (tr *taskRouter) MarkComplete(ctx context.Context, cmd *repb.Command, remoteInstanceName, executorHostID string) {
 	params := getRoutingParams(ctx, tr.env, cmd, remoteInstanceName)
 	strategy := tr.selectRouter(params)
 	if strategy == nil {
@@ -198,8 +204,8 @@ func (tr *taskRouter) MarkComplete(ctx context.Context, cmd *repb.Command, remot
 	// Push the node to the head of the list (but first remove it if already
 	// present to avoid dupes), trim to max length to prevent it from growing
 	// too large, and renew the TTL.
-	pipe.LRem(ctx, routingKey, 1, executorID)
-	pipe.LPush(ctx, routingKey, executorID)
+	pipe.LRem(ctx, routingKey, 1, executorHostID)
+	pipe.LPush(ctx, routingKey, executorHostID)
 	pipe.LTrim(ctx, routingKey, 0, int64(preferredNodeLimit)-1)
 	pipe.Expire(ctx, routingKey, routingPropsKeyTTL)
 	if _, err := pipe.Exec(ctx); err != nil {
@@ -207,7 +213,7 @@ func (tr *taskRouter) MarkComplete(ctx context.Context, cmd *repb.Command, remot
 		return
 	}
 
-	log.Debugf("Preferred executor %q added to %q", executorID, routingKey)
+	log.Debugf("Preferred executor host ID %q added to %q", executorHostID, routingKey)
 }
 
 // Contains the parameters required to make a routing decision.

--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -124,10 +124,8 @@ func (tr *taskRouter) RankNodes(ctx context.Context, cmd *repb.Command, remoteIn
 		return nonePreferred(nodes)
 	}
 
-	nodeByExecutorID := map[string]interfaces.ExecutionNode{}
 	nodeByHostID := map[string]interfaces.ExecutionNode{}
 	for _, node := range nodes {
-		nodeByExecutorID[node.GetExecutorID()] = node
 		// Note: if multiple executors live on the same host, the last one in
 		// the list wins.
 		nodeByHostID[node.GetExecutorHostID()] = node

--- a/enterprise/server/scheduling/task_router/task_router.go
+++ b/enterprise/server/scheduling/task_router/task_router.go
@@ -124,10 +124,14 @@ func (tr *taskRouter) RankNodes(ctx context.Context, cmd *repb.Command, remoteIn
 		return nonePreferred(nodes)
 	}
 
+	// Note: if multiple executors live on the same host, the last one in the
+	// list wins. For now, this is fine because we don't recommend running
+	// multiple executors on the same host. If this use case arises then we
+	// could instead route to the last executor to run the task (by exeucutor
+	// ID), or if that executor doesn't exist then fall back to an arbitrary
+	// executor on the same host.
 	nodeByHostID := map[string]interfaces.ExecutionNode{}
 	for _, node := range nodes {
-		// Note: if multiple executors live on the same host, the last one in
-		// the list wins.
 		nodeByHostID[node.GetExecutorHostID()] = node
 	}
 

--- a/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
+++ b/enterprise/server/test/integration/remote_execution/rbeclient/rbeclient.go
@@ -59,7 +59,6 @@ type CommandResult struct {
 	// Execution outcome.
 	ID           string
 	Err          error
-	Executor     string
 	ExitCode     int
 	ActionResult *repb.ActionResult
 
@@ -263,7 +262,6 @@ func (c *Command) processUpdatesAsync(ctx context.Context, stream repb.Execution
 		res := &CommandResult{
 			Stage:        repb.ExecutionStage_COMPLETED,
 			Err:          gstatus.ErrorProto(response.GetStatus()),
-			Executor:     response.GetResult().GetExecutionMetadata().GetWorker(),
 			ExitCode:     int(response.GetResult().GetExitCode()),
 			InstanceName: c.actionResourceName.GetInstanceName(),
 			ActionResult: response.GetResult(),

--- a/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
+++ b/enterprise/server/test/integration/remote_execution/rbetest/rbetest.go
@@ -816,7 +816,7 @@ func (r *Env) addExecutor(t testing.TB, options *ExecutorOptions) *Executor {
 	executorHostID := uuid.New()
 	if options.Name != "" {
 		executorID = options.Name
-		executorHostID = options.Name
+		executorHostID = options.Name + ".host"
 	}
 
 	runnerPool := NewTestRunnerPool(r.t, env, options.RunInterceptor)

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -1376,7 +1376,7 @@ func TestWorkSchedulingOnNewExecutor(t *testing.T) {
 
 	for i, cmd := range cmds {
 		res := cmd.Wait()
-		assert.Equal(t, "newExecutor", res.Executor, "[%s] should have been executed on new executor", cmd.Name)
+		assert.Equal(t, "newExecutor", res.ActionResult.GetExecutionMetadata().GetExecutorId(), "[%s] should have been executed on new executor", cmd.Name)
 		assert.Equal(t, 0, res.ExitCode, "exit code should be propagated")
 		assert.Equal(t, fmt.Sprintf("hello from command %d\n", i), res.Stdout, "stdout should be propagated")
 		assert.Equal(t, "", res.Stderr, "stderr should be empty")
@@ -1463,7 +1463,7 @@ func (f *fixedNodeTaskRouter) RankNodes(ctx context.Context, cmd *repb.Command, 
 	return out
 }
 
-func (f *fixedNodeTaskRouter) MarkComplete(ctx context.Context, cmd *repb.Command, remoteInstanceName, executorInstanceID string) {
+func (f *fixedNodeTaskRouter) MarkComplete(ctx context.Context, cmd *repb.Command, remoteInstanceName, executorHostID string) {
 }
 
 func (f *fixedNodeTaskRouter) UpdateSubset(executorIDs []string) {
@@ -1522,7 +1522,7 @@ func TestTaskReservationsNotLostOnExecutorShutdown(t *testing.T) {
 
 	for _, cmd := range cmds {
 		res := cmd.Wait()
-		assert.Equal(t, "newExecutor", res.Executor, "[%s] should have been executed on new executor", cmd.Name)
+		assert.Equal(t, "newExecutor", res.ActionResult.GetExecutionMetadata().GetExecutorId(), "[%s] should have been executed on new executor", cmd.Name)
 	}
 }
 

--- a/enterprise/tools/rbeperf/rbeperf.go
+++ b/enterprise/tools/rbeperf/rbeperf.go
@@ -616,7 +616,7 @@ func (w *rawResultsWriter) Write(res *rbeclient.CommandResult, remoteStats *remo
 
 	return w.csvWriter.Write([]string{
 		res.CommandName,
-		res.Executor,
+		res.ActionResult.GetExecutionMetadata().GetWorker(),
 		errorString,
 		strconv.FormatInt(res.LocalStats.ExecuteRPCStarted.Milliseconds(), 10),
 		strconv.FormatInt(res.LocalStats.TimeToAccepted.Milliseconds(), 10),

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -836,9 +836,13 @@ type RankedExecutionNode interface {
 }
 
 type ExecutionNode interface {
-	// GetExecutorID returns the ID for this execution node that uniquely identifies
-	// it within a node pool.
+	// GetExecutorID returns the ID for this execution node that uniquely
+	// identifies it within a node pool.
 	GetExecutorID() string
+
+	// GetExecutorHostID returns the executor host ID for this execution node,
+	// which persists across restarts of a given executor instance.
+	GetExecutorHostID() string
 }
 
 type ExecutionSearchService interface {


### PR DESCRIPTION
Depends on:
- https://github.com/buildbuddy-io/buildbuddy/pull/6156

When executors restart, all task routing info is effectively lost because we route by `executor_id`, which is set to a new UUID when the executor restarts. This PR makes it so we route by `executor_host_id` instead, which is preserved across restarts.

**Related issues**: N/A
