### PR TITLE
Fix CLI release missing GH token

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -198,5 +198,7 @@ jobs:
     needs: [push-tag, sync-plugins, build-artifacts]
     steps:
       - name: Publish release
+        env:
+          GITHUB_TOKEN: ${{ secrets.BUILDBUDDY_GITHUB_USER_TOKEN }}
         run: |
           gh release edit ${{ needs.push-tag.outputs.version }} --draft=false --repo=buildbuddy-io/bazel


### PR DESCRIPTION
Test run at this PR branch (this created v5.0.36): https://github.com/buildbuddy-io/buildbuddy/actions/runs/8288445823

**Related issues**: N/A
