### PR TITLE
Use a more stable selector for code blocks

### DIFF
--- a/website/src/css/markdown.css
+++ b/website/src/css/markdown.css
@@ -67,7 +67,7 @@ a code {
   margin-bottom: 1em;
 }
 
-div.codeBlockTitle_node_modules-\@docusaurus-theme-classic-lib-theme-CodeBlock-Content-styles-module {
+.theme-code-block > div {
   color: #aaa;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  border-bottom-color: rgba(255, 255, 255, 0.2);
 }

--- a/website/theme/BlogPostItem/styles.module.css
+++ b/website/theme/BlogPostItem/styles.module.css
@@ -2,6 +2,7 @@ h1,
 .blogPostTitle {
   font-size: 56px;
   line-height: 64px;
+  text-wrap: pretty;
 }
 
 h1 {


### PR DESCRIPTION
The old one got mangled in the release processes css obfuscation.

Also add a nice little improvement for wrapping blog post titles.