### PR TITLE
Fix nil pointer ref in vbd

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1273,10 +1273,11 @@ func (c *FirecrackerContainer) hotSwapWorkspace(ctx context.Context, execClient 
 			return status.InternalErrorf("failed to stub out workspace drive: %s", err)
 		}
 		if c.workspaceVBD != nil {
-			if err := c.workspaceVBD.Unmount(ctx); err != nil {
+			err := c.workspaceVBD.Unmount(ctx)
+			c.workspaceVBD = nil
+			if err != nil {
 				return status.WrapError(err, "unmount workspace vbd")
 			}
-			c.workspaceVBD = nil
 		}
 		if c.workspaceStore != nil {
 			c.workspaceStore.Close()

--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -141,6 +141,10 @@ func (f *FS) Unmount(ctx context.Context) error {
 }
 
 func (f *FS) unmount(ctx context.Context) error {
+	if f.server == nil {
+		return nil
+	}
+
 	err := f.server.Unmount()
 	f.server.Wait()
 	f.server = nil

--- a/enterprise/server/remote_execution/vbd/vbd.go
+++ b/enterprise/server/remote_execution/vbd/vbd.go
@@ -141,10 +141,6 @@ func (f *FS) Unmount(ctx context.Context) error {
 }
 
 func (f *FS) unmount(ctx context.Context) error {
-	if f.server == nil {
-		return nil
-	}
-
 	err := f.server.Unmount()
 	f.server.Wait()
 	f.server = nil


### PR DESCRIPTION
Error: https://buildbuddy-corp.slack.com/files/USLACKBOT/F06QSAARCAU/new_error_in_flame-build_executor_executor-54df5bd945-dkck9

We unmount vbd in the background, which [sets f.server=nil when it's complete](https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/remote_execution/vbd/vbd.go#L146). We also may [return early from the Unmount call if the context is cancelled](https://github.com/buildbuddy-io/buildbuddy/blob/master/enterprise/server/remote_execution/vbd/vbd.go#L137), and we don't wait for the background unmount process to complete. If we don't set the vbd=nil, when we're cleaning up the VM we might try to unmount again, which will cause a nil pointer ref