### PR TITLE
Add `userxattr` to overlayfs mount to support more kernels

### DIFF
--- a/enterprise/server/remote_execution/overlayfs/overlayfs_linux.go
+++ b/enterprise/server/remote_execution/overlayfs/overlayfs_linux.go
@@ -56,7 +56,7 @@ func Convert(ctx context.Context, path string, opts Opts) (*Overlay, error) {
 			return nil, status.WrapError(err, "create overlay directory")
 		}
 	}
-	args := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", fs.LowerDir, fs.UpperDir, fs.WorkDir)
+	args := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s,userxattr", fs.LowerDir, fs.UpperDir, fs.WorkDir)
 	if err := syscall.Mount("", fs.MountDir, "overlay", syscall.MS_RELATIME, args); err != nil {
 		return nil, status.WrapError(err, "mount overlayfs")
 	}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

The overlayfs tests were failing locally for me (on Debian bookworm), and this was the change suggested by dmesg.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
