### PR TITLE
Add bazel-6.5.0 and bazel-7.1.0 to //server/util/bazel:bazel_binaries.tar

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6747,6 +6747,30 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         urls = ["https://github.com/bazelbuild/bazel/releases/download/6.0.0/bazel-6.0.0-linux-x86_64"],
     )
     http_file(
+        name = "io_bazel_bazel-6.5.0-darwin-x86_64",
+        executable = True,
+        sha256 = "bbf9c2c03bac48e0514f46db0295027935535d91f6d8dcd960c53393559eab29",
+        urls = ["https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-darwin-x86_64"],
+    )
+    http_file(
+        name = "io_bazel_bazel-6.5.0-linux-x86_64",
+        executable = True,
+        sha256 = "a40ac69263440761199fcb8da47ad4e3f328cbe79ffbf4ecc14e5ba252857307",
+        urls = ["https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-linux-x86_64"],
+    )
+    http_file(
+        name = "io_bazel_bazel-7.1.0-darwin-x86_64",
+        executable = True,
+        sha256 = "52ad8d57c22e4f873c724473a09ecfd98966c3a2950e102a7bd7e8c612b8001c",
+        urls = ["https://github.com/bazelbuild/bazel/releases/download/7.1.0/bazel-7.1.0-darwin-x86_64"],
+    )
+    http_file(
+        name = "io_bazel_bazel-7.1.0-linux-x86_64",
+        executable = True,
+        sha256 = "62d62c699c1eb9f9be6a88030912a54d19fe45ae29329c7e5c53aba787492522",
+        urls = ["https://github.com/bazelbuild/bazel/releases/download/7.1.0/bazel-7.1.0-linux-x86_64"],
+    )
+    http_file(
         name = "io_bazel_bazelisk-1.17.0-darwin-amd64",
         executable = True,
         sha256 = "3cf03dab8f5ef7c29e354b8e9293c82098ace3634253f9c660c26168b9e34720",

--- a/server/util/bazel/BUILD
+++ b/server/util/bazel/BUILD
@@ -6,6 +6,8 @@ bazel_pkg_tar(
     versions = [
         "5.3.2",
         "6.0.0",
+        "6.5.0",
+        "7.1.0",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
I'll remove the old versions once probers are updated.

**Related issues**: [3209](https://github.com/buildbuddy-io/buildbuddy-internal/issues/3209)