### PR TITLE
at least dont crash when loading diffs for binary files

### DIFF
--- a/enterprise/app/review/view_pull_request.tsx
+++ b/enterprise/app/review/view_pull_request.tsx
@@ -459,6 +459,9 @@ export default class ViewPullRequestComponent extends React.Component<ViewPullRe
   }
 
   getDiffLines(patch: string, path: string, commitSha: string, comments: github.Comment[]): JSX.Element[] {
+    if (patch.length === 0) {
+      return [<div>No diff info available (binary file?)</div>];
+    }
     const out: JSX.Element[] = [];
 
     const patchLines = patch.split("\n");


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
