### PR TITLE
cli/fix: support bzlmod

### DIFF
--- a/cli/add/BUILD
+++ b/cli/add/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/add",
     deps = [
         "//cli/arg",
+        "//cli/bzlmod",
         "//cli/log",
         "//cli/terminal",
         "//cli/workspace",

--- a/cli/add/add.go
+++ b/cli/add/add.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/bzlmod"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/terminal"
 	"github.com/buildbuddy-io/buildbuddy/cli/workspace"
@@ -275,7 +276,12 @@ func showPicker(modules []Disambiguation) (string, error) {
 }
 
 func openOrCreateWorkspaceFile() (*os.File, error) {
-	workspacePath, basename, err := workspace.CreateWorkspaceIfNotExists()
+	useModules, err := bzlmod.UseModules()
+	if err != nil {
+		return nil, err
+	}
+
+	workspacePath, basename, err := workspace.CreateWorkspaceIfNotExists(useModules)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/add/add.go
+++ b/cli/add/add.go
@@ -276,12 +276,12 @@ func showPicker(modules []Disambiguation) (string, error) {
 }
 
 func openOrCreateWorkspaceFile() (*os.File, error) {
-	useModules, err := bzlmod.UseModules()
+	bzlmodEnabled, err := bzlmod.Enabled()
 	if err != nil {
 		return nil, err
 	}
 
-	workspacePath, basename, err := workspace.CreateWorkspaceIfNotExists(useModules)
+	workspacePath, basename, err := workspace.CreateWorkspaceIfNotExists(bzlmodEnabled)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/bazelisk/bazelisk.go
+++ b/cli/bazelisk/bazelisk.go
@@ -74,7 +74,7 @@ func BazelInfo(requestInfos []string) (map[string]string, error) {
 	}
 	// Prevent Bazelisk `log.Printf` call to write directly to stderr
 	oldWriter := log.Writer()
-	log.SetOutput(stdout)
+	log.SetOutput(stderr)
 	defer log.SetOutput(oldWriter)
 
 	_, err := Run(bazelArgs, opts)

--- a/cli/bazelisk/bazelisk.go
+++ b/cli/bazelisk/bazelisk.go
@@ -66,12 +66,14 @@ func Run(args []string, opts *RunOpts) (exitCode int, err error) {
 func BazelInfo(requestInfos []string) (map[string]string, error) {
 	bazelArgs := append([]string{"info"}, requestInfos...)
 	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
 	opts := &RunOpts{
 		Stdout: stdout,
+		Stderr: stderr,
 	}
 	_, err := Run(bazelArgs, opts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to run `bazel info`: %w", err)
+		return nil, fmt.Errorf("failed to run `bazel info`: %w %s", err, stderr.String())
 	}
 
 	result := make(map[string]string, len(requestInfos))

--- a/cli/bzlmod/BUILD
+++ b/cli/bzlmod/BUILD
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "bzlmod",
+    srcs = ["bzlmod.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/cli/bzlmod",
+    visibility = ["//visibility:public"],
+    deps = ["//cli/bazelisk"],
+)
+
+package(default_visibility = ["//cli:__subpackages__"])

--- a/cli/bzlmod/bzlmod.go
+++ b/cli/bzlmod/bzlmod.go
@@ -4,45 +4,67 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
 )
 
+var (
+	once       sync.Once
+	useModules bool
+	infoErr    error
+)
+
 func UseModules() (bool, error) {
-	infos, err := bazelisk.BazelInfo([]string{"release", "starlark-semantics"})
-	if err != nil {
-		return false, fmt.Errorf("could not run bazel info: %w", err)
-	}
-	starlarkSemantics, ok := infos["starlark-semantics"]
-	if !ok {
-		return false, fmt.Errorf("could not find `starlark-semantics` in `bazel info` result: %v", infos)
-	}
+	once.Do(func() {
+		infos, err := bazelisk.BazelInfo([]string{"release", "starlark-semantics"})
+		if err != nil {
+			useModules = false
+			infoErr = fmt.Errorf("could not run bazel info: %w", err)
+			return
+		}
+		starlarkSemantics, ok := infos["starlark-semantics"]
+		if !ok {
+			useModules = false
+			infoErr = fmt.Errorf("could not find `starlark-semantics` in `bazel info` result: %v", infos)
+			return
+		}
 
-	// It's possible that bzlmod is enabled/disabled explicitly inside a bazelrc file.
-	// If that's the case, starlark-semantics should show the status if the value is not the default value
-	if strings.Contains(starlarkSemantics, "enable_bzlmod=true") {
-		return true, nil
-	}
-	if strings.Contains(starlarkSemantics, "enable_bzlmod=false") {
-		return false, nil
-	}
+		// It's possible that bzlmod is enabled/disabled explicitly inside a bazelrc file.
+		// If that's the case, starlark-semantics should show the status if the value is not the default value
+		if strings.Contains(starlarkSemantics, "enable_bzlmod=true") {
+			useModules = true
+			return
+		}
+		if strings.Contains(starlarkSemantics, "enable_bzlmod=false") {
+			useModules = false
+			return
+		}
 
-	release, ok := infos["release"]
-	if !ok {
-		return false, fmt.Errorf("could not find `release` in `bazel info` result: %v", infos)
-	}
-	version := strings.TrimLeft(release, "release ")
-	versionParts := strings.Split(version, ".")
-	majorVersion, err := strconv.Atoi(versionParts[0])
-	if err != nil {
-		return false, fmt.Errorf("could not parse Bazel release version: %v", err)
-	}
+		release, ok := infos["release"]
+		if !ok {
+			useModules = false
+			infoErr = fmt.Errorf("could not find `release` in `bazel info` result: %v", infos)
+			return
+		}
+		version := strings.TrimLeft(release, "release ")
+		versionParts := strings.Split(version, ".")
+		majorVersion, err := strconv.Atoi(versionParts[0])
+		if err != nil {
+			useModules = false
+			infoErr = fmt.Errorf("could not parse Bazel release version: %v", err)
+			return
+		}
 
-	// From Bazel 7 on-ward, bzlmod is enabled by default and will not be shown
-	// in starlark-semantics setting.
-	if majorVersion <= 6 {
-		// If current version is before Bazel 7, then bzlmod is disabled by default.
-		return false, nil
-	}
-	return true, nil
+		// From Bazel 7 on-ward, bzlmod is enabled by default and will not be shown
+		// in starlark-semantics setting.
+		if majorVersion <= 6 {
+			// If current version is before Bazel 7, then bzlmod is disabled by default.
+			useModules = false
+			return
+		}
+		useModules = true
+	})
+
+	return useModules, infoErr
 }

--- a/cli/bzlmod/bzlmod.go
+++ b/cli/bzlmod/bzlmod.go
@@ -9,62 +9,41 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
 )
 
-var (
-	once       sync.Once
-	useModules bool
-	infoErr    error
-)
+var Enabled = sync.OnceValues(func() (bool, error) {
+	infos, err := bazelisk.BazelInfo([]string{"release", "starlark-semantics"})
+	if err != nil {
+		return false, fmt.Errorf("could not run bazel info: %w", err)
+	}
+	starlarkSemantics, ok := infos["starlark-semantics"]
+	if !ok {
+		return false, fmt.Errorf("could not find `starlark-semantics` in `bazel info` result: %v", infos)
+	}
 
-func UseModules() (bool, error) {
-	once.Do(func() {
-		infos, err := bazelisk.BazelInfo([]string{"release", "starlark-semantics"})
-		if err != nil {
-			useModules = false
-			infoErr = fmt.Errorf("could not run bazel info: %w", err)
-			return
-		}
-		starlarkSemantics, ok := infos["starlark-semantics"]
-		if !ok {
-			useModules = false
-			infoErr = fmt.Errorf("could not find `starlark-semantics` in `bazel info` result: %v", infos)
-			return
-		}
+	// It's possible that bzlmod is enabled/disabled explicitly inside a bazelrc file.
+	// If that's the case, starlark-semantics should show the status if the value is not the default value
+	if strings.Contains(starlarkSemantics, "enable_bzlmod=true") {
+		return true, nil
+	}
+	if strings.Contains(starlarkSemantics, "enable_bzlmod=false") {
+		return false, nil
+	}
 
-		// It's possible that bzlmod is enabled/disabled explicitly inside a bazelrc file.
-		// If that's the case, starlark-semantics should show the status if the value is not the default value
-		if strings.Contains(starlarkSemantics, "enable_bzlmod=true") {
-			useModules = true
-			return
-		}
-		if strings.Contains(starlarkSemantics, "enable_bzlmod=false") {
-			useModules = false
-			return
-		}
+	release, ok := infos["release"]
+	if !ok {
+		return false, fmt.Errorf("could not find `release` in `bazel info` result: %v", infos)
+	}
+	version := strings.TrimLeft(release, "release ")
+	versionParts := strings.Split(version, ".")
+	majorVersion, err := strconv.Atoi(versionParts[0])
+	if err != nil {
+		return false, fmt.Errorf("could not parse Bazel release version: %v", err)
+	}
 
-		release, ok := infos["release"]
-		if !ok {
-			useModules = false
-			infoErr = fmt.Errorf("could not find `release` in `bazel info` result: %v", infos)
-			return
-		}
-		version := strings.TrimLeft(release, "release ")
-		versionParts := strings.Split(version, ".")
-		majorVersion, err := strconv.Atoi(versionParts[0])
-		if err != nil {
-			useModules = false
-			infoErr = fmt.Errorf("could not parse Bazel release version: %v", err)
-			return
-		}
+	// From Bazel 7 on-ward, bzlmod is enabled by default and will not be shown
+	// in starlark-semantics setting.
+	if majorVersion <= 6 {
+		return false, nil
+	}
 
-		// From Bazel 7 on-ward, bzlmod is enabled by default and will not be shown
-		// in starlark-semantics setting.
-		if majorVersion <= 6 {
-			// If current version is before Bazel 7, then bzlmod is disabled by default.
-			useModules = false
-			return
-		}
-		useModules = true
-	})
-
-	return useModules, infoErr
-}
+	return true, nil
+})

--- a/cli/bzlmod/bzlmod.go
+++ b/cli/bzlmod/bzlmod.go
@@ -1,0 +1,48 @@
+package bzlmod
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
+)
+
+func UseModules() (bool, error) {
+	infos, err := bazelisk.BazelInfo([]string{"release", "starlark-semantics"})
+	if err != nil {
+		return false, fmt.Errorf("could not run bazel info: %w", err)
+	}
+	starlarkSemantics, ok := infos["starlark-semantics"]
+	if !ok {
+		return false, fmt.Errorf("could not find `starlark-semantics` in `bazel info` result: %v", infos)
+	}
+
+	// It's possible that bzlmod is enabled/disabled explicitly inside a bazelrc file.
+	// If that's the case, starlark-semantics should show the status if the value is not the default value
+	if strings.Contains(starlarkSemantics, "enable_bzlmod=true") {
+		return true, nil
+	}
+	if strings.Contains(starlarkSemantics, "enable_bzlmod=false") {
+		return false, nil
+	}
+
+	release, ok := infos["release"]
+	if !ok {
+		return false, fmt.Errorf("could not find `release` in `bazel info` result: %v", infos)
+	}
+	version := strings.TrimLeft(release, "release ")
+	versionParts := strings.Split(version, ".")
+	majorVersion, err := strconv.Atoi(versionParts[0])
+	if err != nil {
+		return false, fmt.Errorf("could not parse Bazel release version: %v", err)
+	}
+
+	// From Bazel 7 on-ward, bzlmod is enabled by default and will not be shown
+	// in starlark-semantics setting.
+	if majorVersion <= 6 {
+		// If current version is before Bazel 7, then bzlmod is disabled by default.
+		return false, nil
+	}
+	return true, nil
+}

--- a/cli/fix/BUILD
+++ b/cli/fix/BUILD
@@ -11,6 +11,7 @@ go_library(
         ":language",
         "//cli/add",
         "//cli/arg",
+        "//cli/bazelisk",
         "//cli/log",
         "//cli/translate",
         "//cli/workspace",

--- a/cli/fix/BUILD
+++ b/cli/fix/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//cli/add",
         "//cli/arg",
         "//cli/bazelisk",
+        "//cli/bzlmod",
         "//cli/log",
         "//cli/translate",
         "//cli/workspace",

--- a/cli/fix/fix.go
+++ b/cli/fix/fix.go
@@ -51,11 +51,11 @@ func HandleFix(args []string) (exitCode int, err error) {
 		return -1, err
 	}
 
-	useModules, err := bzlmod.UseModules()
+	bzlmodEnabled, err := bzlmod.Enabled()
 	if err != nil {
 		return 1, err
 	}
-	path, baseFile, err := workspace.CreateWorkspaceIfNotExists(useModules)
+	path, baseFile, err := workspace.CreateWorkspaceIfNotExists(bzlmodEnabled)
 	if err != nil {
 		return 1, err
 	}

--- a/cli/fix/fix.go
+++ b/cli/fix/fix.go
@@ -1,6 +1,7 @@
 package fix
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/cli/add"
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
+	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
 	"github.com/buildbuddy-io/buildbuddy/cli/fix/language"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/translate"
@@ -48,35 +50,81 @@ func HandleFix(args []string) (exitCode int, err error) {
 		return -1, err
 	}
 
-	path, _, err := workspace.CreateWorkspaceIfNotExists()
+	path, baseFile, err := workspace.CreateWorkspaceIfNotExists()
 	if err != nil {
 		return 1, err
 	}
 
-	err = walk()
-	if err != nil {
+	// don't run update-repos in bzlmod
+	updateRepos := baseFile != workspace.ModuleFileName
+	if err := walk(updateRepos); err != nil {
 		log.Printf("Error fixing: %s", err)
 	}
 
-	runGazelle(path)
+	if err := runGazelle(path, baseFile); err != nil {
+		return 1, err
+	}
 
 	return 0, nil
 }
 
-func runGazelle(repoRoot string) {
+const goRepositoryConfigLocation = "@@gazelle~override~go_deps~bazel_gazelle_go_repository_config//:WORKSPACE"
+
+func gazelleConfig() (string, error) {
+	// we intentionally skip stderr here for both
+	// bazelisk and bazel to avoid failing checkstyle.sh
+	bazelArgs := []string{
+		"query",
+		"--ui_event_filters=-info,-debug,-warning,-stderr",
+		"--noshow_progress",
+		"--logging=0",
+		"--output=location",
+		goRepositoryConfigLocation,
+	}
+	stdout := &bytes.Buffer{}
+	opts := &bazelisk.RunOpts{
+		Stdout: stdout,
+	}
+	_, err := bazelisk.Run(bazelArgs, opts)
+	if err != nil {
+		return "", err
+	}
+
+	// output will be in the form of
+	//   /some/path/config/WORKSPACE:1:1 source file <target>
+	// extract `/some/path/config/WORKSPACE` from that.
+	out := stdout.String()
+	fragments := strings.Split(out, " ")
+	locations := strings.Split(fragments[0], ":")
+	return locations[0], nil
+}
+
+func runGazelle(repoRoot, baseFile string) error {
 	originalArgs := os.Args
 	defer func() {
 		os.Args = originalArgs
 	}()
-	os.Args = []string{"gazelle", "-repo_root=" + repoRoot, "--go_prefix="}
+
+	os.Args = []string{"gazelle"}
+	if baseFile == workspace.ModuleFileName {
+		configPath, err := gazelleConfig()
+		if err != nil {
+			return err
+		}
+		os.Args = append(os.Args, "-bzlmod", "-repo_config="+configPath)
+	} else {
+		os.Args = append(os.Args, "-repo_root="+repoRoot, "-go_prefix=")
+	}
+
 	if *diff {
 		os.Args = append(os.Args, "-mode=diff")
 	}
 	log.Debugf("Calling gazelle with args: %+v", os.Args)
 	gazelle.Run()
+	return nil
 }
 
-func walk() error {
+func walk(updateRepos bool) error {
 	languages := getLanguages()
 	foundLanguages := map[language.Language]bool{}
 	depFiles := map[string][]string{}
@@ -144,10 +192,12 @@ func walk() error {
 		}
 	}
 
-	// Run update-repos on any dependency files we found.
-	for _, paths := range depFiles {
-		for _, p := range paths {
-			runUpdateRepos(p)
+	if updateRepos {
+		// Run update-repos on any dependency files we found.
+		for _, paths := range depFiles {
+			for _, p := range paths {
+				runUpdateRepos(p)
+			}
 		}
 	}
 
@@ -156,10 +206,9 @@ func walk() error {
 
 // Collect the languages that support auto-generating WORKSPACE files.
 func getLanguages() []language.Language {
-	languages := make([]language.Language, 0)
+	var languages []language.Language
 	for _, l := range langs.Languages {
-		l, ok := l.(language.Language)
-		if ok {
+		if l, ok := l.(language.Language); ok {
 			languages = append(languages, l)
 		}
 	}

--- a/cli/fix/fix.go
+++ b/cli/fix/fix.go
@@ -11,6 +11,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/cli/add"
 	"github.com/buildbuddy-io/buildbuddy/cli/arg"
 	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
+	"github.com/buildbuddy-io/buildbuddy/cli/bzlmod"
 	"github.com/buildbuddy-io/buildbuddy/cli/fix/language"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/cli/translate"
@@ -50,7 +51,11 @@ func HandleFix(args []string) (exitCode int, err error) {
 		return -1, err
 	}
 
-	path, baseFile, err := workspace.CreateWorkspaceIfNotExists()
+	useModules, err := bzlmod.UseModules()
+	if err != nil {
+		return 1, err
+	}
+	path, baseFile, err := workspace.CreateWorkspaceIfNotExists(useModules)
 	if err != nil {
 		return 1, err
 	}

--- a/cli/fix/fix.go
+++ b/cli/fix/fix.go
@@ -110,7 +110,7 @@ func runGazelle(repoRoot, baseFile string) error {
 		os.Args = originalArgs
 	}()
 
-	os.Args = []string{"gazelle"}
+	os.Args = []string{"gazelle", "update"}
 	if baseFile == workspace.ModuleFileName {
 		configPath, err := gazelleConfig()
 		if err != nil {

--- a/cli/workspace/BUILD
+++ b/cli/workspace/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = ["workspace.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/workspace",
     deps = [
+        "//cli/bazelisk",
         "//cli/log",
         "//server/util/disk",
     ],

--- a/cli/workspace/BUILD
+++ b/cli/workspace/BUILD
@@ -5,7 +5,6 @@ go_library(
     srcs = ["workspace.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/workspace",
     deps = [
-        "//cli/bazelisk",
         "//cli/log",
         "//server/util/disk",
     ],

--- a/cli/workspace/workspace.go
+++ b/cli/workspace/workspace.go
@@ -72,7 +72,7 @@ func SetForTest(path string) {
 	pathVal, pathErr = path, nil
 }
 
-func CreateWorkspaceIfNotExists(useModules bool) (string, string, error) {
+func CreateWorkspaceIfNotExists(bzlmodEnabled bool) (string, string, error) {
 	log.Debugf("Checking if workspace file exists")
 	path, base, err := PathAndBasename()
 	if err == nil {
@@ -80,7 +80,7 @@ func CreateWorkspaceIfNotExists(useModules bool) (string, string, error) {
 	}
 
 	fileName := ModuleFileName
-	if !useModules {
+	if !bzlmodEnabled {
 		fileName = WorkspaceFileName // gazelle doesn't like WORKSPACE.bazel...
 	}
 
@@ -96,7 +96,7 @@ func CreateWorkspaceIfNotExists(useModules bool) (string, string, error) {
 		return "", "", err
 	}
 	contents := ""
-	if useModules {
+	if bzlmodEnabled {
 		contents = `module(name = "` + filepath.Base(workspacePath) + `")` + "\n"
 	} else {
 		contents = `workspace(name = "` + filepath.Base(workspacePath) + `")` + "\n"

--- a/cli/workspace/workspace.go
+++ b/cli/workspace/workspace.go
@@ -1,16 +1,12 @@
 package workspace
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"sync"
 
-	"github.com/buildbuddy-io/buildbuddy/cli/bazelisk"
 	"github.com/buildbuddy-io/buildbuddy/cli/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 )
@@ -76,16 +72,11 @@ func SetForTest(path string) {
 	pathVal, pathErr = path, nil
 }
 
-func CreateWorkspaceIfNotExists() (string, string, error) {
+func CreateWorkspaceIfNotExists(useModules bool) (string, string, error) {
 	log.Debugf("Checking if workspace file exists")
 	path, base, err := PathAndBasename()
 	if err == nil {
 		return path, base, nil
-	}
-
-	useModules, err := useModules()
-	if err != nil {
-		return "", "", err
 	}
 
 	fileName := ModuleFileName
@@ -118,55 +109,6 @@ func CreateWorkspaceIfNotExists() (string, string, error) {
 	pathErr = nil
 	log.Debugf("Created %s file at %s/%s", fileName, pathVal, basename)
 	return pathVal, basename, nil
-}
-
-func useModules() (bool, error) {
-	bazelArgs := []string{"info", "release", "starlark-semantics"}
-	stdout := &bytes.Buffer{}
-	opts := &bazelisk.RunOpts{
-		Stdout: stdout,
-	}
-	_, err := bazelisk.Run(bazelArgs, opts)
-	if err != nil {
-		return false, fmt.Errorf("could not run bazel info: %w", err)
-	}
-
-	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
-	var release, starlarkSemantics string
-	for _, line := range lines {
-		halves := strings.Split(line, ": ")
-		if halves[0] == "release" {
-			release = halves[1]
-			continue
-		}
-		if halves[0] == "starlark-semantics" {
-			starlarkSemantics = halves[1]
-		}
-	}
-
-	// It's possible that bzlmod is enabled/disabled explicitly inside a bazelrc file.
-	// If that's the case, starlark-semantics should show the status if the value is not the default value
-	if strings.Contains(starlarkSemantics, "enable_bzlmod=true") {
-		return true, nil
-	}
-	if strings.Contains(starlarkSemantics, "enable_bzlmod=false") {
-		return false, nil
-	}
-
-	version := strings.TrimLeft(release, "release ")
-	versionParts := strings.Split(version, ".")
-	majorVersion, err := strconv.Atoi(versionParts[0])
-	if err != nil {
-		return false, fmt.Errorf("could not parse Bazel release version: %v", err)
-	}
-
-	// From Bazel 7 on-ward, bzlmod is enabled by default and will not be shown
-	// in starlark-semantics setting.
-	if majorVersion <= 6 {
-		// If current version is before Bazel 7, then bzlmod is disabled by default.
-		return false, nil
-	}
-	return true, nil
 }
 
 func GetBuildFileContents(dir string) (string, string) {


### PR DESCRIPTION
Ensure that bzlmod is correctly detected.

In case bzlmod is used, we need to query for the location of

```
  @@gazelle~override~go_deps~bazel_gazelle_go_repository_config//:WORKSPACE
```

so that we could feed it to Gazelle to generate BUILD files with correct
import.
