### PR TITLE
Upgrade zig toolchain to 3.0.1

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -165,6 +165,9 @@ common:auto-release --@io_bazel_rules_go//go/config:pgoprofile=enterprise/tools/
 # On multi-user machines, specify HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX in your
 # repo_env in user.bazelrc to avoid permissions errors.
 common:static --repo_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+# Workaround for Bazel 7.
+# See https://github.com/uber/hermetic_cc_toolchain/releases/tag/v3.0.1 for more details
+common:static --sandbox_add_mount_pair=/tmp
 common:static --extra_toolchains=@zig_sdk//toolchain:linux_amd64_musl
 # arm64 is not yet tested, so we leave this toolchain commented out for now.
 # common:static --extra_toolchains=@zig_sdk//toolchain:linux_arm64_musl

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -475,11 +475,11 @@ rules_proto_dependencies()
 
 rules_proto_toolchains()
 
-HERMETIC_CC_TOOLCHAIN_VERSION = "v2.1.2"
+HERMETIC_CC_TOOLCHAIN_VERSION = "v3.0.1"
 
 http_archive(
     name = "hermetic_cc_toolchain",
-    sha256 = "28fc71b9b3191c312ee83faa1dc65b38eb70c3a57740368f7e7c7a49bedf3106",
+    sha256 = "3bc6ec127622fdceb4129cb06b6f7ab098c4d539124dde96a6318e7c32a53f7a",
     urls = [
         "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
         "https://github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),


### PR DESCRIPTION
Upgrade Zig toolchain to the latest release to start trying out other toolchains with a fixed version of glibc included.