### PR TITLE
Use normalized repo URL for token check

### DIFF
--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//server/remote_cache/digest",
         "//server/util/bazel",
         "//server/util/flag",
+        "//server/util/git",
         "//server/util/grpc_client",
         "//server/util/healthcheck",
         "//server/util/rexec",

--- a/cli/remotebazel/remotebazel.go
+++ b/cli/remotebazel/remotebazel.go
@@ -46,6 +46,7 @@ import (
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
 	bbflag "github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	gitutil "github.com/buildbuddy-io/buildbuddy/server/util/git"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
@@ -643,7 +644,7 @@ func Run(ctx context.Context, opts RunOpts, repoConfig *RepoConfig) (int, error)
 	}
 
 	gitToken := ""
-	if strings.Contains(repoConfig.URL, "github.com") {
+	if u, err := gitutil.NormalizeRepoURL(repoConfig.URL); err == nil && u.Hostname() == "github.com" {
 		gitToken = os.Getenv("GITHUB_TOKEN")
 	}
 


### PR DESCRIPTION
`strings.Contains()` can have false positives - not a big deal but gives a little more peace of mind

**Related issues**: N/A
