### PR TITLE
Upgrade firecracker to v1.7.0

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6676,10 +6676,14 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
 # Manually created
 def install_static_dependencies(workspace_name = "buildbuddy"):
     http_archive(
-        name = "com_github_buildbuddy_io_firecracker_firecracker-v1.4.0-20230720-cf5f56f",
-        build_file_content = 'exports_files(["firecracker-v1.4.0-20230720-cf5f56f", "jailer-v1.4.0-20230720-cf5f56f"])',
-        sha256 = "b36d9ad62ca467d2794635c4f19b0993c11bb46ed3b575037287964f9c82cc9b",
-        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/firecracker/firecracker-v1.4.0-20230720-cf5f56f.tgz"],
+        name = "com_github_firecracker_microvm_firecracker",
+        build_file_content = "\n".join([
+            'package(default_visibility = ["//visibility:public"])',
+            'filegroup(name = "firecracker", srcs = ["release-{release}/firecracker-{release}"])',
+            'filegroup(name = "jailer", srcs = ["release-{release}/jailer-{release}"])',
+        ]).format(release = "v1.7.0-x86_64"),
+        sha256 = "55bd3e6d599fdd108e36e52f9aee2319f06c18a90f2fa49b64e93fdf06f5ff53",
+        urls = ["https://github.com/firecracker-microvm/firecracker/releases/download/v1.7.0/firecracker-v1.7.0-x86_64.tgz"],
     )
     http_archive(
         name = "com_github_containerd_stargz_snapshotter-v0.11.4-linux-amd64",

--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -1,6 +1,6 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_layer")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -87,14 +87,14 @@ go_binary(
 
 genrule(
     name = "firecracker_rename",
-    srcs = ["@com_github_buildbuddy_io_firecracker_firecracker-v1.4.0-20230720-cf5f56f//:firecracker-v1.4.0-20230720-cf5f56f"],
+    srcs = ["@com_github_firecracker_microvm_firecracker//:firecracker"],
     outs = ["firecracker"],
     cmd = "cp $(SRCS) $@",
 )
 
 genrule(
     name = "jailer_rename",
-    srcs = ["@com_github_buildbuddy_io_firecracker_firecracker-v1.4.0-20230720-cf5f56f//:jailer-v1.4.0-20230720-cf5f56f"],
+    srcs = ["@com_github_firecracker_microvm_firecracker//:jailer"],
     outs = ["jailer"],
     cmd = "cp $(SRCS) $@",
 )

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1025,7 +1025,7 @@ func (c *FirecrackerContainer) LoadSnapshot(ctx context.Context) error {
 
 	var snapOpt fcclient.Opt
 	if *enableUFFD {
-		uffdType := fcclient.MemoryBackendType(fcmodels.MemoryBackendBackendTypeUffdPrivileged)
+		uffdType := fcclient.MemoryBackendType(fcmodels.MemoryBackendBackendTypeUffd)
 		snapOpt = fcclient.WithSnapshot(uffdSockName, vmStateSnapshotName, uffdType)
 	} else {
 		snapOpt = fcclient.WithSnapshot(fullMemSnapshotName, vmStateSnapshotName)


### PR DESCRIPTION
* Upgrade to v1.7.0 (latest release)
* Refactor so that we only have to update `deps.bzl` when upgrading and not the genrule targets as well. (Some tweaking here was also necessary because they introduced a new top-level `release-*` directory in the tar archive which contains the firecracker/jailer binaries, rather than the binaries just being in the top-level of the archive)
* Remove `UffdPrivileged` (not supported by upstream firecracker, and seems to not be needed anymore. The tests pass, at least)
* Note: this will invalidate all cached snapshots since `firecracker_version` is part of the VmConfiguration for now, which is part of the snapshot cache key.

The baremetal tests aren't exercising the new version yet because they use the firecracker binary from the currently deployed executor image, but I ran the baremetal tests locally and they are passing.

**Related issues**: N/A
