### PR TITLE
bazelrc: introduce --config=with-glibc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -164,15 +164,20 @@ common:auto-release --@io_bazel_rules_go//go/config:pgoprofile=enterprise/tools/
 # Static build configuration. MacOS is currently unsupported.
 # On multi-user machines, specify HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX in your
 # repo_env in user.bazelrc to avoid permissions errors.
-common:static --repo_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+common:zig-shared --repo_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 # Workaround for Bazel 7.
 # See https://github.com/uber/hermetic_cc_toolchain/releases/tag/v3.0.1 for more details
-common:static --sandbox_add_mount_pair=/tmp
-common:static --extra_toolchains=@zig_sdk//toolchain:linux_amd64_musl
+common:zig-shared --sandbox_add_mount_pair=/tmp
+
+common:static --config=zig-shared
 # arm64 is not yet tested, so we leave this toolchain commented out for now.
 # common:static --extra_toolchains=@zig_sdk//toolchain:linux_arm64_musl
+common:static --extra_toolchains=@zig_sdk//toolchain:linux_amd64_musl
 common:static --@io_bazel_rules_go//go/config:static=true
 common:static --copt=-fPIC
+
+common:with-glibc --config=zig-shared
+common:with-glibc --extra_toolchains=@zig_sdk//toolchain:x86_64-linux-gnu.2.31
 
 # By default, build logs get sent to the production server
 common --bes_results_url=https://app.buildbuddy.io/invocation/


### PR DESCRIPTION
Introduce --config=with-glibc so that we can build our binary with a
Bazel-managed glibc instead of the host's glibc.

Glibc 2.31 was selected because it's what we have available on our
container images.

  ```bash
  # App
  > docker run --rm -it --entrypoint="" gcr.io/flame-public/buildbuddy-app-enterprise:latest /lib/x86_64-linux-gnu/libc.so.6
  GNU C Library (Debian GLIBC 2.31-13+deb11u5) stable release version 2.31.
  Copyright (C) 2020 Free Software Foundation, Inc.
  This is free software; see the source for copying conditions.
  There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
  PARTICULAR PURPOSE.
  Compiled by GNU CC version 10.2.1 20210110.
  libc ABIs: UNIQUE IFUNC ABSOLUTE
  For bug reporting instructions, please see:
  <http://www.debian.org/Bugs/>.

  # Executor
  > docker run --rm -it --entrypoint="" gcr.io/flame-public/buildbuddy-executor-enterprise:latest /lib/x86_64-linux-gnu/libc.so.6
  GNU C Library (Debian GLIBC 2.31-13+deb11u3) stable release version 2.31.
  Copyright (C) 2020 Free Software Foundation, Inc.
  This is free software; see the source for copying conditions.
  There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
  PARTICULAR PURPOSE.
  Compiled by GNU CC version 10.2.1 20210110.
  libc ABIs: UNIQUE IFUNC ABSOLUTE
  For bug reporting instructions, please see:
  <http://www.debian.org/Bugs/>.
  ```
