### PR TITLE
Show executions tab in the UI for hosted bazel runs

### DIFF
--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -412,7 +412,11 @@ export default class InvocationComponent extends React.Component<Props, State> {
             tab={this.props.tab}
             denseMode={this.props.preferences.denseModeEnabled}
             role={this.state.model.getRole()}
-            executionsEnabled={this.state.model.getIsRBEEnabled() || this.state.model.isWorkflowInvocation()}
+            executionsEnabled={
+              this.state.model.getIsRBEEnabled() ||
+              this.state.model.isWorkflowInvocation() ||
+              this.state.model.isHostedBazelInvocation()
+            }
             hasSuggestions={suggestions.length > 0}
           />
 


### PR DESCRIPTION
Useful for debugging remote bazel invocations