### PR TITLE
buildpatches: replace module references with alias

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -7,6 +7,12 @@ load("//rules/go:index.bzl", "go_sdk_tool")
 
 package(default_visibility = ["//visibility:public"])
 
+alias(
+    name = "zlib",
+    actual = "@zlib",
+    tags = ["manual"],
+)
+
 # Rendered JSON result could be checked by doing:
 #   bazel build //:no_go_config
 #   cat bazel-bin/no_go_config.json | jq .

--- a/buildpatches/com_github_awslabs_soci_snapshotter.patch
+++ b/buildpatches/com_github_awslabs_soci_snapshotter.patch
@@ -7,7 +7,7 @@ index 0d10a4d..bca5dac 100644
      ],
      cgo = True,
 -    clinkopts = ["-Lztoc/compression/ztoc/out -l:libz.a"],
-+    cdeps = ["@zlib//:zlib"],
++    cdeps = ["@@//:zlib"],
 +    clinkopts = ["-Lztoc/compression/ztoc/out"],
      copts = ["-Iztoc/compression/ztoc/compression"],
      importpath = "github.com/awslabs/soci-snapshotter/ztoc/compression",

--- a/buildpatches/com_github_bojand_ghz.patch
+++ b/buildpatches/com_github_bojand_ghz.patch
@@ -1,0 +1,22 @@
+diff --git a/printer/BUILD.bazel b/printer/BUILD.bazel
+index dd57d0e..737aa59 100644
+--- a/printer/BUILD.bazel
++++ b/printer/BUILD.bazel
+@@ -13,7 +13,7 @@ go_library(
+     deps = [
+         "//runner",
+         "@com_github_alecthomas_template//:template",
+-        "@com_github_prometheus_client_model//go",
++        "@@//proto:prometheus_client_go_proto",
+         "@com_github_prometheus_common//expfmt",
+     ],
+ )
+@@ -33,7 +33,7 @@ go_test(
+     embed = [":printer"],
+     deps = [
+         "//runner",
+-        "@com_github_prometheus_client_model//go",
++        "@@//proto:prometheus_client_go_proto",
+         "@com_github_prometheus_common//expfmt",
+         "@com_github_stretchr_testify//assert",
+     ],

--- a/buildpatches/com_github_prometheus_client_golang.patch
+++ b/buildpatches/com_github_prometheus_client_golang.patch
@@ -1,0 +1,96 @@
+diff --git a/prometheus/BUILD.bazel b/prometheus/BUILD.bazel
+index 00668fa..d141081 100644
+--- a/prometheus/BUILD.bazel
++++ b/prometheus/BUILD.bazel
+@@ -39,7 +39,7 @@ go_library(
+         "//prometheus/internal",
+         "@com_github_beorn7_perks//quantile",
+         "@com_github_cespare_xxhash_v2//:xxhash",
+-        "@com_github_prometheus_client_model//go",
++        "@@//proto:prometheus_client_go_proto",
+         "@com_github_prometheus_common//expfmt",
+         "@com_github_prometheus_common//model",
+         "@org_golang_google_protobuf//proto",
+@@ -131,7 +131,7 @@ go_test(
+     deps = [
+         "//prometheus/internal",
+         "//prometheus/promhttp",
+-        "@com_github_prometheus_client_model//go",
++        "@@//proto:prometheus_client_go_proto",
+         "@com_github_prometheus_common//expfmt",
+         "@org_golang_google_protobuf//proto",
+         "@org_golang_google_protobuf//types/known/timestamppb",
+diff --git a/prometheus/graphite/BUILD.bazel b/prometheus/graphite/BUILD.bazel
+index 17685c8..28c7ccf 100644
+--- a/prometheus/graphite/BUILD.bazel
++++ b/prometheus/graphite/BUILD.bazel
+@@ -7,7 +7,7 @@ go_library(
+     visibility = ["//visibility:public"],
+     deps = [
+         "//prometheus",
+-        "@com_github_prometheus_client_model//go",
++        "@@//proto:prometheus_client_go_proto",
+         "@com_github_prometheus_common//expfmt",
+         "@com_github_prometheus_common//model",
+     ],
+diff --git a/prometheus/internal/BUILD.bazel b/prometheus/internal/BUILD.bazel
+index 0d0d51e..86b73d5 100644
+--- a/prometheus/internal/BUILD.bazel
++++ b/prometheus/internal/BUILD.bazel
+@@ -12,7 +12,7 @@ go_library(
+     importpath = "github.com/prometheus/client_golang/prometheus/internal",
+     visibility = ["//prometheus:__subpackages__"],
+     deps = [
+-        "@com_github_prometheus_client_model//go",
++        "@@//proto:prometheus_client_go_proto",
+         "@com_github_prometheus_common//model",
+     ],
+ )
+diff --git a/prometheus/promhttp/BUILD.bazel b/prometheus/promhttp/BUILD.bazel
+index 50fcf73..9c4f0d3 100644
+--- a/prometheus/promhttp/BUILD.bazel
++++ b/prometheus/promhttp/BUILD.bazel
+@@ -13,7 +13,7 @@ go_library(
+     visibility = ["//visibility:public"],
+     deps = [
+         "//prometheus",
+-        "@com_github_prometheus_client_model//go",
++        "@@//proto:prometheus_client_go_proto",
+         "@com_github_prometheus_common//expfmt",
+     ],
+ )
+@@ -36,7 +36,7 @@ go_test(
+     deps = [
+         "//prometheus",
+         "//prometheus/testutil",
+-        "@com_github_prometheus_client_model//go",
++        "@@//proto:prometheus_client_go_proto",
+         "@org_golang_google_protobuf//proto",
+     ],
+ )
+diff --git a/prometheus/testutil/BUILD.bazel b/prometheus/testutil/BUILD.bazel
+index e82b53e..05991dd 100644
+--- a/prometheus/testutil/BUILD.bazel
++++ b/prometheus/testutil/BUILD.bazel
+@@ -13,7 +13,7 @@ go_library(
+         "//prometheus/internal",
+         "//prometheus/testutil/promlint",
+         "@com_github_davecgh_go_spew//spew",
+-        "@com_github_prometheus_client_model//go",
++        "@@//proto:prometheus_client_go_proto",
+         "@com_github_prometheus_common//expfmt",
+     ],
+ )
+diff --git a/prometheus/testutil/promlint/BUILD.bazel b/prometheus/testutil/promlint/BUILD.bazel
+index d0e9972..770970e 100644
+--- a/prometheus/testutil/promlint/BUILD.bazel
++++ b/prometheus/testutil/promlint/BUILD.bazel
+@@ -6,7 +6,7 @@ go_library(
+     importpath = "github.com/prometheus/client_golang/prometheus/testutil/promlint",
+     visibility = ["//visibility:public"],
+     deps = [
+-        "@com_github_prometheus_client_model//go",
++        "@@//proto:prometheus_client_go_proto",
+         "@com_github_prometheus_common//expfmt",
+     ],
+ )

--- a/buildpatches/com_github_prometheus_common.patch
+++ b/buildpatches/com_github_prometheus_common.patch
@@ -1,0 +1,22 @@
+diff --git a/expfmt/BUILD.bazel b/expfmt/BUILD.bazel
+index 22dd614..66a6621 100644
+--- a/expfmt/BUILD.bazel
++++ b/expfmt/BUILD.bazel
+@@ -16,7 +16,7 @@ go_library(
+         "//internal/bitbucket.org/ww/goautoneg",
+         "//model",
+         "@com_github_matttproud_golang_protobuf_extensions//pbutil",
+-        "@com_github_prometheus_client_model//go",
++        "@@//proto:prometheus_client_go_proto",
+         "@org_golang_google_protobuf//encoding/prototext",
+         "@org_golang_google_protobuf//proto",
+     ],
+@@ -43,7 +43,7 @@ go_test(
+     deps = [
+         "//model",
+         "@com_github_matttproud_golang_protobuf_extensions//pbutil",
+-        "@com_github_prometheus_client_model//go",
++        "@@//proto:prometheus_client_go_proto",
+         "@org_golang_google_protobuf//proto",
+         "@org_golang_google_protobuf//types/known/timestamppb",
+     ],

--- a/buildpatches/googleapis.patch
+++ b/buildpatches/googleapis.patch
@@ -8,7 +8,7 @@ index 18835af..d24aeaf 100755
      name = "status_go_proto",
 +    compilers = [
 +        "@io_bazel_rules_go//proto:go_proto",
-+        "@com_github_planetscale_vtprotobuf//:vtprotobuf_compiler",
++        "@@//proto:vtprotobuf_compiler",
 +    ],
      importpath = "google.golang.org/genproto/googleapis/rpc/status",
      protos = [":status_proto"],

--- a/deps.bzl
+++ b/deps.bzl
@@ -596,10 +596,9 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     )
     go_repository(
         name = "com_github_bojand_ghz",
-        build_directives = [
-            "gazelle:resolve go github.com/prometheus/client_model/go @{}//proto:prometheus_client_go_proto".format(workspace_name),
-        ],
         importpath = "github.com/bojand/ghz",
+        patch_args = ["-p1"],
+        patches = ["@{}//buildpatches:com_github_bojand_ghz.patch".format(workspace_name)],
         sum = "h1:dTMxg+tUcLMw8BYi7vQPjXsrM2DJ20ns53hz1am1SbQ=",
         version = "v0.117.0",
     )
@@ -4201,10 +4200,9 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     )
     go_repository(
         name = "com_github_prometheus_client_golang",
-        build_directives = [
-            "gazelle:resolve go github.com/prometheus/client_model/go @{}//proto:prometheus_client_go_proto".format(workspace_name),
-        ],
         importpath = "github.com/prometheus/client_golang",
+        patch_args = ["-p1"],
+        patches = ["@{}//buildpatches:com_github_prometheus_client_golang.patch".format(workspace_name)],
         sum = "h1:yk/hx9hDbrGHovbci4BY+pRMfSuuat626eFsHb7tmT8=",
         version = "v1.16.0",
     )
@@ -4216,10 +4214,9 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
     )
     go_repository(
         name = "com_github_prometheus_common",
-        build_directives = [
-            "gazelle:resolve go github.com/prometheus/client_model/go @{}//proto:prometheus_client_go_proto".format(workspace_name),
-        ],
         importpath = "github.com/prometheus/common",
+        patch_args = ["-p1"],
+        patches = ["@{}//buildpatches:com_github_prometheus_common.patch".format(workspace_name)],
         sum = "h1:+5BrQJwiBB9xsMygAB3TNvpQKOwlkc25LbISbrdOOfY=",
         version = "v0.44.0",
     )


### PR DESCRIPTION
Because of the visibility issue in bzlmod (1), repos that are
generated from a module extension cannot depend on build targets in
first-level modules directly.

The workaround is to create an alias for these first-level module's
targets in the main repository, then use the special alias `@@` to refer
to the main repository.

We expect this issue to be fixed in Bazel 7.2.

(1): https://github.com/bazelbuild/bazel/issues/19301#issuecomment-1923527294
