### PR TITLE
gazelle: add GOPROXY

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -113,7 +113,11 @@ go_register_toolchains(
     nogo = "@//:vet",
 )
 
-gazelle_dependencies()
+gazelle_dependencies(
+    go_env = {
+        "GOPROXY": "https://proxy.golang.org|direct",
+    },
+)
 
 http_archive(
     name = "googleapis",


### PR DESCRIPTION
Switch from the default

```
GOPROXY=https://proxy.golang.org,direct
```

to use `|` separator so that we fall back on `direct` download when
`proxy.golang.org` has issues (TLS handshake or 500 error).
