### PR TITLE
make tasks running chart only show tasks for the pool being viewed

### DIFF
--- a/tools/metrics/grafana/dashboards/buildbuddy.json
+++ b/tools/metrics/grafana/dashboards/buildbuddy.json
@@ -11220,7 +11220,7 @@
                 "uid": "prom"
               },
               "editorMode": "code",
-              "expr": "sum(buildbuddy_remote_execution_tasks_executing{region=\"${region}\"})",
+              "expr": "sum(buildbuddy_remote_execution_tasks_executing{region=\"${region}\", job=\"${pool}\"})",
               "hide": false,
               "instant": false,
               "legendFormat": "Tasks running",


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
it's currently showing all tasks for all executor types.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
