### PR TITLE
[SS] Always set boot arg lapic=notscdeadline in firecracker to prevent stalling

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -61,7 +61,6 @@ go_library(
         "@com_github_firecracker_microvm_firecracker_go_sdk//client/models",
         "@com_github_firecracker_microvm_firecracker_go_sdk//client/operations",
         "@com_github_google_uuid//:uuid",
-        "@com_github_klauspost_cpuid//:cpuid",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_sirupsen_logrus//:logrus",
         "@io_bazel_rules_go//go/runfiles:go_default_library",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -53,7 +53,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/firecracker-microvm/firecracker-go-sdk/client/operations"
 	"github.com/google/uuid"
-	"github.com/klauspost/cpuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -1393,14 +1392,13 @@ func (c *FirecrackerContainer) getConfig(ctx context.Context, rootFS, containerF
 		netNS = networking.NetNamespacePath(c.id)
 	}
 
-	// On AMD CPUs, disabling the LAPIC TSC-Deadline feature works around an
+	// Disabling the LAPIC TSC-Deadline feature works around an
 	// issue where processes occasionally freeze up after being resumed from
 	// snapshot.
-	// TODO(https://github.com/firecracker-microvm/firecracker/issues/4099):
+	// TODO(https://github.com/firecracker-microvm/firecracker/issues/4099 &
+	//  https://github.com/buildbuddy-io/buildbuddy-internal/issues/3255):
 	// remove this workaround.
-	if cpuid.CPU.VendorID == cpuid.AMD {
-		bootArgs += " lapic=notscdeadline"
-	}
+	bootArgs += " lapic=notscdeadline"
 
 	// Pass some flags to the init script.
 	//

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,6 @@ require (
 	github.com/jotfs/fastcdc-go v0.2.0
 	github.com/jsimonetti/rtnetlink v1.3.3
 	github.com/klauspost/compress v1.17.2
-	github.com/klauspost/cpuid v1.2.1
 	github.com/lestrrat-go/jwx v1.2.29
 	github.com/lni/dragonboat/v4 v4.0.0-00010101000000-000000000000
 	github.com/lni/goutils v1.3.1-0.20220604063047-388d67b4dbc4

--- a/go.sum
+++ b/go.sum
@@ -1836,7 +1836,6 @@ github.com/klauspost/compress v1.15.15/go.mod h1:ZcK2JAFqKOpnBlxcLsJzYfrS9X1akm9
 github.com/klauspost/compress v1.16.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/compress v1.17.2 h1:RlWWUY/Dr4fL8qk9YG7DTZ7PDgME2V4csBXA8L/ixi4=
 github.com/klauspost/compress v1.17.2/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
-github.com/klauspost/cpuid v1.2.1 h1:vJi+O/nMdFt0vqm8NZBI6wzALWdA2X+egi0ogNyrC/w=
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=


### PR DESCRIPTION
Fixes errors concerning `rcu_sched detected stalls`. 

More context in this [doc](https://docs.google.com/document/d/1vyIpf093zKjz-nJdYJeL944pRT5LpsxsjyypuYdbXK0/edit) and this [thread](https://buildbuddy-corp.slack.com/archives/C01D5GHRJ59/p1711413814105089).

**Related issues**: N/A
