### PR TITLE
Add bootArgs to VMConfiguration

### DIFF
--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -129,6 +129,10 @@ const (
 	workflowClientIdentityTokenLifetime = 12 * time.Hour
 )
 
+func VFSEnabled() bool {
+	return *enableVFS
+}
+
 // Properties represents the platform properties parsed from a command.
 type Properties struct {
 	OS                        string

--- a/proto/firecracker.proto
+++ b/proto/firecracker.proto
@@ -23,6 +23,9 @@ message VMConfiguration {
   string firecracker_version = 9;
   string guest_api_version = 10;
 
+  // Guest kernel boot args.
+  string boot_args = 11;
+
   // TODO: add container_image here?
 }
 


### PR DESCRIPTION
This will ensure that if we change boot args, we invalidate old snapshots and start using the new boot args immediately. There are pros and cons to this, but I think it would make our lives easier and save a lot of debugging time / confusion if boot args were to propagate immediately.

**Related issues**: N/A
