### PR TITLE
add a RBE build minutes chart to the trends page

### DIFF
--- a/enterprise/app/trends/trends.tsx
+++ b/enterprise/app/trends/trends.tsx
@@ -630,31 +630,55 @@ export default class TrendsComponent extends React.Component<Props, State> {
                 ticks={this.state.ticks}
               />
               {this.state.timeToExecutionStatMap.size > 0 && (
-                <PercentilesChartComponent
-                  title="Remote Execution Queue Duration"
-                  data={this.state.timeKeys}
-                  extractLabel={this.formatShortDate.bind(this)}
-                  ticks={this.state.ticks}
-                  formatHoverLabel={this.formatLongDate.bind(this)}
-                  extractP50={(tsMillis) =>
-                    +(this.getExecutionStat(tsMillis).queueDurationUsecP50 ?? 0) * SECONDS_PER_MICROSECOND
-                  }
-                  extractP75={(tsMillis) =>
-                    +(this.getExecutionStat(tsMillis).queueDurationUsecP75 ?? 0) * SECONDS_PER_MICROSECOND
-                  }
-                  extractP90={(tsMillis) =>
-                    +(this.getExecutionStat(tsMillis).queueDurationUsecP90 ?? 0) * SECONDS_PER_MICROSECOND
-                  }
-                  extractP95={(tsMillis) =>
-                    +(this.getExecutionStat(tsMillis).queueDurationUsecP95 ?? 0) * SECONDS_PER_MICROSECOND
-                  }
-                  extractP99={(tsMillis) =>
-                    +(this.getExecutionStat(tsMillis).queueDurationUsecP99 ?? 0) * SECONDS_PER_MICROSECOND
-                  }
-                  onZoomSelection={
-                    capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
-                  }
-                />
+                <>
+                  <TrendsChartComponent
+                    title="Remote Execution Build Time (minutes)"
+                    data={this.state.timeKeys}
+                    dataSeries={[
+                      {
+                        name: "build time (minutes)",
+                        extractValue: (tsMillis) =>
+                          +(+(this.getExecutionStat(tsMillis).totalBuildTimeUsec ?? 0) / 60e6).toPrecision(3),
+                        formatHoverValue: (value) => `${format.count(value || 0)} minutes of build time`,
+                      },
+                    ]}
+                    primaryYAxis={{
+                      formatTickValue: format.count,
+                      allowDecimals: false,
+                    }}
+                    formatXAxisLabel={this.formatShortDate.bind(this)}
+                    formatHoverXAxisLabel={this.formatLongDate.bind(this)}
+                    ticks={this.state.ticks}
+                    onZoomSelection={
+                      capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
+                    }
+                  />
+                  <PercentilesChartComponent
+                    title="Remote Execution Queue Duration"
+                    data={this.state.timeKeys}
+                    extractLabel={this.formatShortDate.bind(this)}
+                    ticks={this.state.ticks}
+                    formatHoverLabel={this.formatLongDate.bind(this)}
+                    extractP50={(tsMillis) =>
+                      +(this.getExecutionStat(tsMillis).queueDurationUsecP50 ?? 0) * SECONDS_PER_MICROSECOND
+                    }
+                    extractP75={(tsMillis) =>
+                      +(this.getExecutionStat(tsMillis).queueDurationUsecP75 ?? 0) * SECONDS_PER_MICROSECOND
+                    }
+                    extractP90={(tsMillis) =>
+                      +(this.getExecutionStat(tsMillis).queueDurationUsecP90 ?? 0) * SECONDS_PER_MICROSECOND
+                    }
+                    extractP95={(tsMillis) =>
+                      +(this.getExecutionStat(tsMillis).queueDurationUsecP95 ?? 0) * SECONDS_PER_MICROSECOND
+                    }
+                    extractP99={(tsMillis) =>
+                      +(this.getExecutionStat(tsMillis).queueDurationUsecP99 ?? 0) * SECONDS_PER_MICROSECOND
+                    }
+                    onZoomSelection={
+                      capabilities.config.trendsRangeSelectionEnabled ? this.onChartZoomed.bind(this, "") : undefined
+                    }
+                  />
+                </>
               )}
             </>
           )}

--- a/proto/stats.proto
+++ b/proto/stats.proto
@@ -8,7 +8,7 @@ import "google/protobuf/timestamp.proto";
 
 package stats;
 
-// Next tag: 8
+// Next tag: 9
 message ExecutionStat {
   // When specified, this contains the (local) date that these stats are
   // aggregated on in YYYY-MM-DD format.  This field will not be set when
@@ -26,6 +26,12 @@ message ExecutionStat {
   double queue_duration_usec_p90 = 3;
   double queue_duration_usec_p95 = 4;
   double queue_duration_usec_p99 = 5;
+
+  // The total amount of "build time" spent (this is a number we use for
+  // billing purposes).  This sums up the total time spent on builds on all RBE
+  // workers, ignoring how many cores were used (i.e., a task using 2 cores for
+  // one minute counts the same as a task using 1 core for one minute).
+  int64 total_build_time_usec = 8;
 }
 
 message TrendQuery {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
will add chart to usage page separately.

we could extract and add platform info (or really just OS) to the executions table + use that to display mac vs linux minutes, which would be better, but we have the data in this PR for (effectively) all time, so it's a good starting point.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
