### PR TITLE
Rework flag tags to allow for easier extensibility

### DIFF
--- a/server/config/BUILD
+++ b/server/config/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//server/util/flag",
         "//server/util/flagutil",
         "//server/util/flagutil/common",
-        "//server/util/flagutil/types",
         "//server/util/flagutil/yaml",
         "//server/util/log",
         "//server/util/status",

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -12,7 +12,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
-	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
@@ -70,7 +69,7 @@ func LoadFromData(data string) error {
 	}
 	var lastErr error
 	common.DefaultFlagSet.VisitAll(func(f *flag.Flag) {
-		if err := types.Expand(f.Value, expandStringValue); err != nil {
+		if err := flagutil.Expand(f.Value, expandStringValue); err != nil {
 			lastErr = err
 		}
 	})

--- a/server/util/flag/BUILD
+++ b/server/util/flag/BUILD
@@ -8,5 +8,6 @@ go_library(
     deps = [
         "//server/util/flagutil/common",
         "//server/util/flagutil/types/autoflags",
+        "//server/util/flagutil/types/autoflags/tags",
     ],
 )

--- a/server/util/flag/flag.go
+++ b/server/util/flag/flag.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types/autoflags"
+
+	flagtags "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types/autoflags/tags"
 )
 
-var Secret = autoflags.SecretTag
-var Deprecated = autoflags.DeprecatedTag
-var YAMLIgnore = autoflags.YAMLIgnoreTag
+var Secret = flagtags.SecretTag
+var Deprecated = flagtags.DeprecatedTag
+var YAMLIgnore = flagtags.YAMLIgnoreTag
 
 var NewFlagSet = flag.NewFlagSet
 var ContinueOnError = flag.ContinueOnError
@@ -23,7 +25,7 @@ var Args = flag.Args
 type Flag = flag.Flag
 type FlagSet = flag.FlagSet
 
-func New[T any](flagset *flag.FlagSet, name string, defaultValue T, usage string, tags ...autoflags.Taggable) *T {
+func New[T any](flagset *flag.FlagSet, name string, defaultValue T, usage string, tags ...flagtags.Taggable) *T {
 	return autoflags.New[T](flagset, name, defaultValue, usage, tags...)
 }
 
@@ -31,39 +33,39 @@ func Parse() {
 	flag.Parse()
 }
 
-func String(name string, value string, usage string, tags ...autoflags.Taggable) *string {
+func String(name string, value string, usage string, tags ...flagtags.Taggable) *string {
 	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
-func Bool(name string, value bool, usage string, tags ...autoflags.Taggable) *bool {
+func Bool(name string, value bool, usage string, tags ...flagtags.Taggable) *bool {
 	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
-func Int(name string, value int, usage string, tags ...autoflags.Taggable) *int {
+func Int(name string, value int, usage string, tags ...flagtags.Taggable) *int {
 	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
-func Int64(name string, value int64, usage string, tags ...autoflags.Taggable) *int64 {
+func Int64(name string, value int64, usage string, tags ...flagtags.Taggable) *int64 {
 	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
-func UInt(name string, value uint, usage string, tags ...autoflags.Taggable) *uint {
+func UInt(name string, value uint, usage string, tags ...flagtags.Taggable) *uint {
 	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
-func UInt64(name string, value uint64, usage string, tags ...autoflags.Taggable) *uint64 {
+func UInt64(name string, value uint64, usage string, tags ...flagtags.Taggable) *uint64 {
 	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
-func Float64(name string, value float64, usage string, tags ...autoflags.Taggable) *float64 {
+func Float64(name string, value float64, usage string, tags ...flagtags.Taggable) *float64 {
 	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
-func Duration(name string, value time.Duration, usage string, tags ...autoflags.Taggable) *time.Duration {
+func Duration(name string, value time.Duration, usage string, tags ...flagtags.Taggable) *time.Duration {
 	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
-func URL(name string, value string, usage string, tags ...autoflags.Taggable) *url.URL {
+func URL(name string, value string, usage string, tags ...flagtags.Taggable) *url.URL {
 	u, err := url.Parse(value)
 	if err != nil {
 		log.Fatalf("Error parsing default URL value '%s' for flag: %v", value, err)
@@ -72,10 +74,10 @@ func URL(name string, value string, usage string, tags ...autoflags.Taggable) *u
 	return autoflags.New(common.DefaultFlagSet, name, *u, usage, tags...)
 }
 
-func Slice[T any](name string, value []T, usage string, tags ...autoflags.Taggable) *[]T {
+func Slice[T any](name string, value []T, usage string, tags ...flagtags.Taggable) *[]T {
 	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }
 
-func Struct[T any](name string, value T, usage string, tags ...autoflags.Taggable) *T {
+func Struct[T any](name string, value T, usage string, tags ...flagtags.Taggable) *T {
 	return autoflags.New(common.DefaultFlagSet, name, value, usage, tags...)
 }

--- a/server/util/flagutil/common/common.go
+++ b/server/util/flagutil/common/common.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	// Used for type conversions between flags and normal go types
-	flagTypeMap = map[reflect.Type]reflect.Type{
+	flagTypeToGoTypeMap = map[reflect.Type]reflect.Type{
 		flagTypeFromFlagFuncName("Bool"):     reflect.TypeOf((*bool)(nil)),
 		flagTypeFromFlagFuncName("Duration"): reflect.TypeOf((*time.Duration)(nil)),
 		flagTypeFromFlagFuncName("Float64"):  reflect.TypeOf((*float64)(nil)),
@@ -21,6 +21,7 @@ var (
 		flagTypeFromFlagFuncName("Uint64"):   reflect.TypeOf((*uint64)(nil)),
 		flagTypeFromFlagFuncName("String"):   reflect.TypeOf((*string)(nil)),
 	}
+	goTypeToFlagTypeMap = invertMap(flagTypeToGoTypeMap)
 
 	// Change only for testing purposes
 	DefaultFlagSet = flag.CommandLine
@@ -37,12 +38,36 @@ func flagTypeFromFlagFuncName(name string) reflect.Type {
 	return reflect.TypeOf(fs.Lookup("").Value)
 }
 
+func invertMap[K comparable, V comparable](m map[K]V) map[V]K {
+	inverse := make(map[V]K, len(m))
+	for k, v := range m {
+		inverse[v] = k
+	}
+	return inverse
+}
+
+func ZeroFlagValueFromType[T any]() flag.Value {
+	t, ok := goTypeToFlagTypeMap[reflect.TypeOf(Zero[T]())]
+	if !ok || t.Kind() != reflect.Pointer {
+		return nil
+	}
+	zero, ok := reflect.New(t.Elem()).Interface().(flag.Value)
+	if !ok {
+		return nil
+	}
+	return zero
+}
+
 type TypeAliased interface {
 	// AliasedType returns the type this flag.Value aliases.
 	AliasedType() reflect.Type
 }
 
-type IsNameAliasing interface {
+type NameAliasable interface {
+	// IsNameAliasing returns whether or not this flag.Value is aliasing another
+	// flag.
+	IsNameAliasing() bool
+
 	// AliasedName returns the flag name this flag.Value aliases.
 	AliasedName() string
 }
@@ -87,7 +112,7 @@ func GetTypeForFlagValue(value flag.Value) (reflect.Type, error) {
 	if v, ok := value.(WrappingValue); ok {
 		return GetTypeForFlagValue(v.WrappedValue())
 	}
-	if t, ok := flagTypeMap[reflect.TypeOf(value)]; ok {
+	if t, ok := flagTypeToGoTypeMap[reflect.TypeOf(value)]; ok {
 		return t, nil
 	} else if v, ok := value.(TypeAliased); ok {
 		return v.AliasedType(), nil
@@ -160,7 +185,7 @@ type SetValueForIndirectFxn func(flagset *flag.FlagSet, flagValue flag.Value, na
 // are not slices. setHooks is a slice of functions to call in order if the
 // flag.Value will be set.
 func SetValueWithCustomIndirectBehavior(flagset *flag.FlagSet, flagValue flag.Value, name string, newValue any, setFlags map[string]struct{}, appendSlice bool, setValueForIndirect SetValueForIndirectFxn, setHooks ...func()) error {
-	if v, ok := flagValue.(IsNameAliasing); ok {
+	if v, ok := flagValue.(NameAliasable); ok && v.IsNameAliasing() {
 		aliasedFlag := flagset.Lookup(v.AliasedName())
 		if aliasedFlag == nil {
 			return status.NotFoundErrorf("Flag %s aliases undefined flag: %s", name, v.AliasedName())
@@ -213,8 +238,11 @@ func GetDereferencedValue[T any](flagset *flag.FlagSet, name string) (T, error) 
 }
 
 func getDereferencedValueFrom[T any](flagset *flag.FlagSet, value flag.Value, name string) (T, error) {
-	if v, ok := value.(IsNameAliasing); ok {
-		return GetDereferencedValue[T](flagset, v.AliasedName())
+	for v, ok := value.(WrappingValue); ok; v, ok = value.(WrappingValue) {
+		if a, ok := v.(NameAliasable); ok && a.IsNameAliasing() {
+			return GetDereferencedValue[T](flagset, a.AliasedName())
+		}
+		value = v.WrappedValue()
 	}
 	converted, err := ConvertFlagValue(value)
 	if err != nil {
@@ -335,5 +363,5 @@ func Expand(v flag.Value, mapper func(string) (string, error)) error {
 // AddTestFlagTypeForTesting adds a type correspondence to the internal
 // flagTypeMap.
 func AddTestFlagTypeForTesting(flagValue, value any) {
-	flagTypeMap[reflect.TypeOf(flagValue)] = reflect.TypeOf(value)
+	flagTypeToGoTypeMap[reflect.TypeOf(flagValue)] = reflect.TypeOf(value)
 }

--- a/server/util/flagutil/common/common.go
+++ b/server/util/flagutil/common/common.go
@@ -314,6 +314,24 @@ func setWithOverride(flagset *flag.FlagSet, flagValue flag.Value, name, newValue
 	return nil
 }
 
+// Expand updates the flag value to replace any placeholders in format ${FOO}
+// with the content of calling the mapper function with the placeholder name.
+func Expand(v flag.Value, mapper func(string) (string, error)) error {
+	// If the flag type wants to handle expansion, let it.
+	if r, ok := v.(Expandable); ok {
+		if err := r.Expand(mapper); err != nil {
+			return err
+		}
+		return nil
+	}
+	// Otherwise, expand directly using String/Set.
+	exp, err := mapper(v.String())
+	if err != nil {
+		return err
+	}
+	return v.Set(exp)
+}
+
 // AddTestFlagTypeForTesting adds a type correspondence to the internal
 // flagTypeMap.
 func AddTestFlagTypeForTesting(flagValue, value any) {

--- a/server/util/flagutil/flagutil.go
+++ b/server/util/flagutil/flagutil.go
@@ -1,6 +1,8 @@
 package flagutil
 
 import (
+	"flag"
+
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
 )
 
@@ -33,4 +35,10 @@ func ResetFlags() error {
 // a given flag name.
 func GetDereferencedValue[T any](name string) (T, error) {
 	return common.GetDereferencedValue[T](common.DefaultFlagSet, name)
+}
+
+// Expand updates the flag value to replace any placeholders in format ${FOO}
+// with the content of calling the mapper function with the placeholder name.
+func Expand(v flag.Value, mapper func(string) (string, error)) error {
+	return common.Expand(v, mapper)
 }

--- a/server/util/flagutil/types/BUILD
+++ b/server/util/flagutil/types/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//server/util/alert",
         "//server/util/flagutil/common",
+        "//server/util/flagutil/types/autoflags/tags",
         "//server/util/log",
         "//server/util/status",
         "@in_gopkg_yaml_v3//:yaml_v3",
@@ -21,6 +22,7 @@ go_test(
     embed = [":types"],
     deps = [
         "//server/util/flagutil/common",
+        "//server/util/flagutil/types/autoflags/tags",
         "//server/util/flagutil/yaml",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/server/util/flagutil/types/autoflags/BUILD
+++ b/server/util/flagutil/types/autoflags/BUILD
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//server/util/flagutil/types",
         "//server/util/flagutil/types/autoflags/tags",
-        "//server/util/flagutil/yaml",
         "//server/util/log",
     ],
 )
@@ -23,6 +22,7 @@ go_test(
     deps = [
         "//server/util/flagutil/common",
         "//server/util/flagutil/types",
+        "//server/util/flagutil/types/autoflags/tags",
         "//server/util/flagutil/yaml",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/server/util/flagutil/types/autoflags/BUILD
+++ b/server/util/flagutil/types/autoflags/BUILD
@@ -10,7 +10,9 @@ go_library(
     ],
     deps = [
         "//server/util/flagutil/types",
+        "//server/util/flagutil/types/autoflags/tags",
         "//server/util/flagutil/yaml",
+        "//server/util/log",
     ],
 )
 

--- a/server/util/flagutil/types/autoflags/autoflags.go
+++ b/server/util/flagutil/types/autoflags/autoflags.go
@@ -10,23 +10,7 @@ import (
 
 	flagtypes "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types"
 	flagtags "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types/autoflags/tags"
-	flagyaml "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/yaml"
 )
-
-type Taggable flagtags.Taggable
-
-var SecretTag = flagtags.SecretTag
-
-var DeprecatedTag = flagtags.DeprecatedTag
-
-type yamlIgnoreTag struct{}
-
-func (_ *yamlIgnoreTag) Tag(flagset *flag.FlagSet, name string, f flagtags.Tagged) flag.Value {
-	flagyaml.IgnoreFlagForYAML(name)
-	return nil
-}
-
-var YAMLIgnoreTag = &yamlIgnoreTag{}
 
 // New declares a new flag named `name` with the specified value `defaultValue`
 // of type `T` and the help text `usage`. It returns a pointer to where the
@@ -34,7 +18,7 @@ var YAMLIgnoreTag = &yamlIgnoreTag{}
 // `SecretTag` to mark a flag that contains a secret that should be redacted in
 // output, or use `DeprecatedTag(migrationPlan)` to mark a flag that has been
 // deprecated and provide its migration plan.
-func New[T any](flagset *flag.FlagSet, name string, defaultValue T, usage string, tags ...Taggable) *T {
+func New[T any](flagset *flag.FlagSet, name string, defaultValue T, usage string, tags ...flagtags.Taggable) *T {
 	value := reflect.New(reflect.TypeOf((*T)(nil)).Elem()).Interface().(*T)
 	Var(flagset, value, name, defaultValue, usage, tags...)
 	return value
@@ -46,7 +30,7 @@ func New[T any](flagset *flag.FlagSet, name string, defaultValue T, usage string
 // contains a secret that should be redacted in output, or use
 // `DeprecatedTag(migrationPlan)` to mark a flag that has been deprecated and
 // provide its migration plan.
-func Var[T any](flagset *flag.FlagSet, value *T, name string, defaultValue T, usage string, tags ...Taggable) {
+func Var[T any](flagset *flag.FlagSet, value *T, name string, defaultValue T, usage string, tags ...flagtags.Taggable) {
 	switch v := any(value).(type) {
 	case *bool:
 		flagset.BoolVar(v, name, any(defaultValue).(bool), usage)
@@ -93,7 +77,7 @@ func Var[T any](flagset *flag.FlagSet, value *T, name string, defaultValue T, us
 	}
 }
 
-func Tag[T any, FV flag.Value](flagset *flag.FlagSet, name string, tags ...Taggable) {
+func Tag[T any, FV flag.Value](flagset *flag.FlagSet, name string, tags ...flagtags.Taggable) {
 	for _, tg := range tags {
 		flagtags.Tag[T, FV](flagset, name, tg)
 	}

--- a/server/util/flagutil/types/autoflags/autoflags_test.go
+++ b/server/util/flagutil/types/autoflags/autoflags_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	flagtypes "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types"
+	flagtags "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types/autoflags/tags"
 	flagyaml "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/yaml"
 )
 
@@ -208,7 +209,7 @@ func TestNew(t *testing.T) {
 func TestYAMLIgnoreTag(t *testing.T) {
 	flags := replaceFlagsForTesting(t)
 	_ = replaceIgnoreSetForTesting(t)
-	flagBool := New(flags, "bool", false, "", YAMLIgnoreTag)
+	flagBool := New(flags, "bool", false, "", flagtags.YAMLIgnoreTag)
 
 	yamlData := `
 	bool: true

--- a/server/util/flagutil/types/autoflags/tags/BUILD
+++ b/server/util/flagutil/types/autoflags/tags/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "tags",
+    srcs = ["tags.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types/autoflags/tags",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/util/flagutil/common",
+        "//server/util/log",
+    ],
+)

--- a/server/util/flagutil/types/autoflags/tags/BUILD
+++ b/server/util/flagutil/types/autoflags/tags/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/util/flagutil/common",
+        "//server/util/flagutil/yaml",
         "//server/util/log",
     ],
 )

--- a/server/util/flagutil/types/autoflags/tags/tags.go
+++ b/server/util/flagutil/types/autoflags/tags/tags.go
@@ -1,0 +1,200 @@
+package tags
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+)
+
+type Tagged interface {
+	Value() flag.Value
+	Zero() string
+
+	// from flag.Value
+	SetFunc(func(value string) error)
+	StringFunc(func() string)
+
+	// from WrappingValue
+	WrappedValueFunc(func() flag.Value)
+
+	// from Expandable
+	ExpandFunc(func(mapping func(string) (string, error)) error )
+
+	// from Secretable
+	IsSecretFunc(func() bool)
+
+	// from SetValueForFlagNameHooked
+	SetValueForFlagNameHookFunc(func())
+
+	// from YAMLSetValueHooked
+	YAMLSetValueHookFunc(func())
+}
+
+type Taggable interface {
+	Tag(flagset *flag.FlagSet, name string, f Tagged)
+}
+
+type TagFlag[T any] struct {
+	value flag.Value
+
+	setFunc func(value string) error
+	stringFunc func() string
+	wrappedValueFunc func() flag.Value
+	expandFunc func(mapping func(string) (string, error)) error 
+	isSecretFunc func() bool
+	setValueForFlagNameHookFunc func()
+	yamlSetValueHookFunc func()
+}
+
+func (t *TagFlag[T]) Value() flag.Value {
+	return t.value
+}
+
+func (_ *TagFlag[T]) Zero() string {
+	return fmt.Sprint(common.Zero[T]())
+}
+
+func (t *TagFlag[T]) SetFunc(setFunc func(string) error) {
+	t.setFunc = setFunc
+}
+
+func (t *TagFlag[T]) Set(value string) error {
+	if t.setFunc != nil {
+		return t.setFunc(value)
+	}
+	return t.Value().Set(value)
+}
+
+func (t *TagFlag[T]) StringFunc(stringFunc func() string) {
+	t.stringFunc = stringFunc
+}
+
+func (t *TagFlag[T]) String() string {
+	if t == nil {
+		return t.Zero()
+	}
+	if t.stringFunc != nil {
+		return t.stringFunc()
+	}
+	if t.Value() == nil {
+		return t.Zero()
+	}
+	return t.Value().String()
+}
+
+func (t *TagFlag[T]) WrappedValueFunc(wrappedValueFunc func() flag.Value) {
+	t.wrappedValueFunc = wrappedValueFunc
+}
+
+func (t *TagFlag[T]) WrappedValue() flag.Value {
+	if t.wrappedValueFunc != nil {
+		return t.wrappedValueFunc()
+	}
+	return t.Value()
+}
+
+func (t *TagFlag[T]) ExpandFunc(expandFunc func(func(string) (string, error)) error) {
+	t.expandFunc = expandFunc
+}
+
+func (t *TagFlag[T]) Expand(mapping func(string) (string, error)) error {
+	if t.expandFunc != nil {
+		return t.expandFunc(mapping)
+	}
+	return common.Expand(t.Value(), mapping)
+}
+
+func (t *TagFlag[T]) IsSecretFunc(isSecretFunc func() bool) {
+	t.isSecretFunc = isSecretFunc
+}
+
+func (t *TagFlag[T]) IsSecret() bool {
+	if t.isSecretFunc != nil {
+		return t.isSecretFunc()
+	}
+	return false
+}
+
+func (t *TagFlag[T]) SetValueForFlagNameHookFunc(setValueForFlagNameHookFunc func()) {
+	t.setValueForFlagNameHookFunc = setValueForFlagNameHookFunc
+}
+
+func (t *TagFlag[T]) SetValueForFlagNameHook() {
+	if t.setValueForFlagNameHookFunc != nil {
+		t.setValueForFlagNameHookFunc()
+	}
+}
+
+func (t *TagFlag[T]) YAMLSetValueHookFunc(yamlSetValueHookFunc func()) {
+	t.yamlSetValueHookFunc = yamlSetValueHookFunc
+}
+
+func (t *TagFlag[T]) YAMLSetValueHook() {
+	if t.yamlSetValueHookFunc != nil {
+		t.yamlSetValueHookFunc()
+	}
+}
+
+// Tag wraps the flag specified by name in a TagFlag[T] and passes it to the
+// Tag method of the passed Taggable.
+func Tag[T any](flagset *flag.FlagSet, name string, t Taggable) {
+	flg := flagset.Lookup(name)
+	converted, err := common.ConvertFlagValue(flg.Value)
+	if err != nil {
+		log.Fatalf("Error creating TagFlag[%T] for flag %s: %v", common.Zero[T](), name, err)
+	} else if _, ok := converted.(*T); !ok {
+		log.Fatalf("Error creating TagFlag[%T] for flag %s: could not coerce flag of type %T to type %T.", common.Zero[T](), name, converted, (*T)(nil))
+	}
+	tf := &TagFlag[T]{
+		value: flg.Value,
+	}
+	flg.Value = tf
+	t.Tag(flagset, name, tf)
+}
+
+type deprecatedTag struct {
+	migrationPlan string
+}
+
+func (d *deprecatedTag) Tag(flagset *flag.FlagSet, name string, tagged Tagged) {
+	flg := flagset.Lookup(name)
+	flg.Usage = flg.Usage + " **DEPRECATED** " + d.migrationPlan
+
+	tagged.SetFunc(func(value string) error {
+		log.Warningf(
+			"Flag \"%s\" was set on the command line but has been deprecated: %s",
+			name,
+			d.migrationPlan,
+		)
+		return tagged.Value().Set(value)
+	})
+	tagged.SetValueForFlagNameHookFunc(func() {
+		log.Warningf(
+			"Flag \"%s\" was set programmatically by name but has been deprecated: %s",
+			name,
+			d.migrationPlan,
+		)
+	})
+	tagged.YAMLSetValueHookFunc(func() {
+		log.Warningf(
+			"Flag \"%s\" was set through the YAML config but has been deprecated: %s",
+			name,
+			d.migrationPlan,
+		)
+	})
+}
+
+func DeprecatedTag(migrationPlan string) Taggable {
+	return &deprecatedTag{migrationPlan: migrationPlan}
+}
+
+
+type secretTag struct{}
+
+func (_ *secretTag) Tag(flagset *flag.FlagSet, name string, tagged Tagged) {
+	tagged.IsSecretFunc(func() bool { return true })
+}
+
+var SecretTag = &secretTag{}

--- a/server/util/flagutil/types/autoflags/tags/tags.go
+++ b/server/util/flagutil/types/autoflags/tags/tags.go
@@ -20,7 +20,7 @@ type Tagged interface {
 	WrappedValueFunc(func() flag.Value)
 
 	// from Expandable
-	ExpandFunc(func(mapping func(string) (string, error)) error )
+	ExpandFunc(func(mapping func(string) (string, error)) error)
 
 	// from Secretable
 	IsSecretFunc(func() bool)
@@ -39,13 +39,13 @@ type Taggable interface {
 type TagFlag[T any] struct {
 	value flag.Value
 
-	setFunc func(value string) error
-	stringFunc func() string
-	wrappedValueFunc func() flag.Value
-	expandFunc func(mapping func(string) (string, error)) error 
-	isSecretFunc func() bool
+	setFunc                     func(value string) error
+	stringFunc                  func() string
+	wrappedValueFunc            func() flag.Value
+	expandFunc                  func(mapping func(string) (string, error)) error
+	isSecretFunc                func() bool
 	setValueForFlagNameHookFunc func()
-	yamlSetValueHookFunc func()
+	yamlSetValueHookFunc        func()
 }
 
 func (t *TagFlag[T]) Value() flag.Value {
@@ -189,7 +189,6 @@ func (d *deprecatedTag) Tag(flagset *flag.FlagSet, name string, tagged Tagged) {
 func DeprecatedTag(migrationPlan string) Taggable {
 	return &deprecatedTag{migrationPlan: migrationPlan}
 }
-
 
 type secretTag struct{}
 

--- a/server/util/flagutil/types/autoflags/tags/tags.go
+++ b/server/util/flagutil/types/autoflags/tags/tags.go
@@ -3,40 +3,90 @@ package tags
 import (
 	"flag"
 	"fmt"
+	"reflect"
+	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 )
 
+// Tagged exists as an interface to provide an abstraction of
+// `TaggedFlagValue[T any, FV flag.Value]` that can allow a non-parameterized
+//
+//	struct implementing `Taggable` to modify the behavior of the methods of a
+//
+// `flag.Value` while still preserving its ability to return the correct string
+// when `String()` is called on a zero-value of the flag.Value, which is only
+// possible if the wrapped type is contained in a type parameter. This allows
+// for the creation of flags using the following form:
+//
+// var foo = flag.Struct("foo", Foo{}, "A foo", flag.SecretTag)
+//
+// or:
+//
+// var foo = flag.Struct("foo", Foo{}, "A foo", flag.SecretTag())
+//
+// whereas otherwise we would be forced to use the form:
+//
+// var foo = flag.Struct("foo", Foo{}, "A foo", &flag.SecretTag[Foo]{})
+//
+// or:
+//
+// var foo = flag.Struct("foo", Foo{}, "A foo", flag.SecretTag[Foo]())
+//
+// which makes tags less readable / easy to use.
+// This design also means that when new tags are created, they only need
+// implement `Taggable` and, within that method, modify the functions that need
+// to change, as opposed to needing to correctly implement, for example,
+// `String()` (specifically in the zero case, especially) or `WrappedValue()`.
+// "Designate" is used instead of the more common and less verbose "Set" to
+// avoid awkward / potentially confusing names like `SetSetFunc`.
+// `Value()` is provided to give access to the underlying value.
+// `Zero()` is provided as a convenience function so that it is easier to handle
+// the zero-value case when designating a new `String` func.
 type Tagged interface {
 	Value() flag.Value
 	Zero() string
 
+	Set(string) error
+	String() string
+
 	// from flag.Value
-	SetFunc(func(value string) error)
-	StringFunc(func() string)
+	DesignateSetFunc(func(value string) error)
+	DesignateStringFunc(func() string)
 
 	// from WrappingValue
-	WrappedValueFunc(func() flag.Value)
+	DesignateWrappedValueFunc(func() flag.Value)
 
 	// from Expandable
-	ExpandFunc(func(mapping func(string) (string, error)) error)
+	DesignateExpandFunc(func(mapping func(string) (string, error)) error)
 
 	// from Secretable
-	IsSecretFunc(func() bool)
+	DesignateIsSecretFunc(func() bool)
+
+	// from NameAliasable
+	DesignateIsNameAliasingFunc(func() bool)
+	DesignateAliasedNameFunc(func() string)
 
 	// from SetValueForFlagNameHooked
-	SetValueForFlagNameHookFunc(func())
+	DesignateSetValueForFlagNameHookFunc(func())
 
 	// from YAMLSetValueHooked
-	YAMLSetValueHookFunc(func())
+	DesignateYAMLSetValueHookFunc(func())
 }
 
 type Taggable interface {
-	Tag(flagset *flag.FlagSet, name string, f Tagged)
+	// Tag returns the new flag.Value that should be set to the flag at name,
+	// or nil if no change should occur.
+	Tag(flagset *flag.FlagSet, name string, f Tagged) flag.Value
 }
 
-type TagFlag[T any] struct {
+// TaggedFlagValue exists to let us modify functions of a flag.Value in a `Tag`
+// function.
+// We need T and FV because flag types from the `flag` library are private, so
+// to locate them we need to know it's a native flag type (denoted by FV being
+// literally `flag.Value`) and we need the underlying type.
+type TaggedFlagValue[T any, FV flag.Value] struct {
 	value flag.Value
 
 	setFunc                     func(value string) error
@@ -44,125 +94,203 @@ type TagFlag[T any] struct {
 	wrappedValueFunc            func() flag.Value
 	expandFunc                  func(mapping func(string) (string, error)) error
 	isSecretFunc                func() bool
+	isNameAliasingFunc          func() bool
+	aliasedNameFunc             func() string
 	setValueForFlagNameHookFunc func()
 	yamlSetValueHookFunc        func()
 }
 
-func (t *TagFlag[T]) Value() flag.Value {
+func (t *TaggedFlagValue[T, FV]) Value() flag.Value {
 	return t.value
 }
 
-func (_ *TagFlag[T]) Zero() string {
-	return fmt.Sprint(common.Zero[T]())
+func (_ *TaggedFlagValue[T, FV]) Zero() string {
+	if reflect.TypeOf(common.Zero[FV]()) == reflect.TypeOf((flag.Value)(nil)) {
+		if zero := common.ZeroFlagValueFromType[T](); zero != nil {
+			return zero.String()
+		}
+		// fallback to the default string representation of T
+		return fmt.Sprint(common.Zero[T]())
+	}
+	return reflect.New(reflect.TypeOf(common.Zero[FV]()).Elem()).Interface().(flag.Value).String()
 }
 
-func (t *TagFlag[T]) SetFunc(setFunc func(string) error) {
+func (t *TaggedFlagValue[T, FV]) DesignateSetFunc(setFunc func(string) error) {
 	t.setFunc = setFunc
 }
 
-func (t *TagFlag[T]) Set(value string) error {
+func (t *TaggedFlagValue[T, FV]) Set(value string) error {
 	if t.setFunc != nil {
 		return t.setFunc(value)
 	}
-	return t.Value().Set(value)
+	return t.WrappedValue().Set(value)
 }
 
-func (t *TagFlag[T]) StringFunc(stringFunc func() string) {
+func (t *TaggedFlagValue[T, FV]) DesignateStringFunc(stringFunc func() string) {
 	t.stringFunc = stringFunc
 }
 
-func (t *TagFlag[T]) String() string {
+func (t *TaggedFlagValue[T, FV]) String() string {
 	if t == nil {
 		return t.Zero()
 	}
 	if t.stringFunc != nil {
 		return t.stringFunc()
 	}
-	if t.Value() == nil {
-		return t.Zero()
+	if t.WrappedValue() != nil {
+		return t.WrappedValue().String()
 	}
-	return t.Value().String()
+	return t.Zero()
 }
 
-func (t *TagFlag[T]) WrappedValueFunc(wrappedValueFunc func() flag.Value) {
+func (t *TaggedFlagValue[T, FV]) DesignateWrappedValueFunc(wrappedValueFunc func() flag.Value) {
 	t.wrappedValueFunc = wrappedValueFunc
 }
 
-func (t *TagFlag[T]) WrappedValue() flag.Value {
+func (t *TaggedFlagValue[T, FV]) WrappedValue() flag.Value {
 	if t.wrappedValueFunc != nil {
 		return t.wrappedValueFunc()
 	}
 	return t.Value()
 }
 
-func (t *TagFlag[T]) ExpandFunc(expandFunc func(func(string) (string, error)) error) {
+func (t *TaggedFlagValue[T, FV]) DesignateExpandFunc(expandFunc func(func(string) (string, error)) error) {
 	t.expandFunc = expandFunc
 }
 
-func (t *TagFlag[T]) Expand(mapping func(string) (string, error)) error {
+func (t *TaggedFlagValue[T, FV]) Expand(mapping func(string) (string, error)) error {
 	if t.expandFunc != nil {
 		return t.expandFunc(mapping)
 	}
-	return common.Expand(t.Value(), mapping)
+	return common.Expand(t.WrappedValue(), mapping)
 }
 
-func (t *TagFlag[T]) IsSecretFunc(isSecretFunc func() bool) {
+func (t *TaggedFlagValue[T, FV]) DesignateIsSecretFunc(isSecretFunc func() bool) {
 	t.isSecretFunc = isSecretFunc
 }
 
-func (t *TagFlag[T]) IsSecret() bool {
+func (t *TaggedFlagValue[T, FV]) IsSecret() bool {
 	if t.isSecretFunc != nil {
 		return t.isSecretFunc()
 	}
 	return false
 }
 
-func (t *TagFlag[T]) SetValueForFlagNameHookFunc(setValueForFlagNameHookFunc func()) {
+func (t *TaggedFlagValue[T, FV]) DesignateIsNameAliasingFunc(isNameAliasingFunc func() bool) {
+	t.isNameAliasingFunc = isNameAliasingFunc
+}
+
+func (t *TaggedFlagValue[T, FV]) IsNameAliasing() bool {
+	if t.isNameAliasingFunc != nil {
+		return t.isNameAliasingFunc()
+	}
+	return false
+}
+
+func (t *TaggedFlagValue[T, FV]) DesignateAliasedNameFunc(aliasedNameFunc func() string) {
+	t.aliasedNameFunc = aliasedNameFunc
+}
+
+func (t *TaggedFlagValue[T, FV]) AliasedName() string {
+	if t.aliasedNameFunc != nil {
+		return t.aliasedNameFunc()
+	}
+	return ""
+}
+
+func (t *TaggedFlagValue[T, FV]) DesignateSetValueForFlagNameHookFunc(setValueForFlagNameHookFunc func()) {
 	t.setValueForFlagNameHookFunc = setValueForFlagNameHookFunc
 }
 
-func (t *TagFlag[T]) SetValueForFlagNameHook() {
+func (t *TaggedFlagValue[T, FV]) SetValueForFlagNameHook() {
 	if t.setValueForFlagNameHookFunc != nil {
 		t.setValueForFlagNameHookFunc()
 	}
 }
 
-func (t *TagFlag[T]) YAMLSetValueHookFunc(yamlSetValueHookFunc func()) {
+func (t *TaggedFlagValue[T, FV]) DesignateYAMLSetValueHookFunc(yamlSetValueHookFunc func()) {
 	t.yamlSetValueHookFunc = yamlSetValueHookFunc
 }
 
-func (t *TagFlag[T]) YAMLSetValueHook() {
+func (t *TaggedFlagValue[T, FV]) YAMLSetValueHook() {
 	if t.yamlSetValueHookFunc != nil {
 		t.yamlSetValueHookFunc()
 	}
 }
 
-// Tag wraps the flag specified by name in a TagFlag[T] and passes it to the
-// Tag method of the passed Taggable.
-func Tag[T any](flagset *flag.FlagSet, name string, t Taggable) {
+// Tag wraps the flag specified by name in a TaggedFlagValue[T] and passes it
+// to the Tag method of the passed Taggable. It returns a pointer to the data
+// the flag Value contains, converted to the same type as is returned when
+// defining the flag initially
+func Tag[T any, FV flag.Value](flagset *flag.FlagSet, name string, t Taggable) *T {
 	flg := flagset.Lookup(name)
 	converted, err := common.ConvertFlagValue(flg.Value)
 	if err != nil {
-		log.Fatalf("Error creating TagFlag[%T] for flag %s: %v", common.Zero[T](), name, err)
-	} else if _, ok := converted.(*T); !ok {
-		log.Fatalf("Error creating TagFlag[%T] for flag %s: could not coerce flag of type %T to type %T.", common.Zero[T](), name, converted, (*T)(nil))
+		log.Fatalf("Error creating TaggedFlagValue[%T] when applying tag %v for flag %s: %v", common.Zero[T](), t, name, err)
 	}
-	tf := &TagFlag[T]{
+	data, ok := converted.(*T)
+	if !ok {
+		log.Fatalf("Error creating TaggedFlagValue[%T] for flag %s: could not coerce flag of type %T to type %T when applying tag %v.", common.Zero[T](), name, converted, (*T)(nil), t)
+	}
+	tf := &TaggedFlagValue[T, FV]{
 		value: flg.Value,
 	}
-	flg.Value = tf
-	t.Tag(flagset, name, tf)
+	if v := t.Tag(flagset, name, tf); v != nil {
+		flg.Value = v
+	}
+	return data
+}
+
+type aliasTag struct {
+	names []string
+}
+
+func (a *aliasTag) Tag(flagset *flag.FlagSet, name string, tagged Tagged) flag.Value {
+	if len(a.names) == 0 {
+		return nil
+	}
+	tagged.DesignateIsNameAliasingFunc(func() bool { return true })
+	tagged.DesignateAliasedNameFunc(func() string { return name })
+	tagged.DesignateSetFunc(func(value string) error { return flagset.Set(name, value) })
+
+	tagged.DesignateWrappedValueFunc(func() flag.Value {
+		if flagset == nil {
+			return nil
+		}
+		flg := flagset.Lookup(name)
+		if flg == nil {
+			return nil
+		}
+		return flg.Value
+	})
+
+	var flg *flag.Flag
+	for wrapper, ok := tagged.(common.WrappingValue); ok; wrapper, ok = wrapper.WrappedValue().(common.WrappingValue) {
+		if aliaser, ok := wrapper.(common.NameAliasable); ok && aliaser.IsNameAliasing() {
+			if flg = flagset.Lookup(aliaser.AliasedName()); flg == nil {
+				log.Fatalf("Error aliasing flag %s as %s: flag %s does not exist.", name, strings.Join(a.names, ", "), aliaser.AliasedName())
+			}
+		}
+	}
+	for _, newName := range a.names {
+		flagset.Var(tagged, newName, "Alias for "+name)
+	}
+	return nil
+}
+
+func AliasTag(names ...string) Taggable {
+	return &aliasTag{names: names}
 }
 
 type deprecatedTag struct {
 	migrationPlan string
 }
 
-func (d *deprecatedTag) Tag(flagset *flag.FlagSet, name string, tagged Tagged) {
+func (d *deprecatedTag) Tag(flagset *flag.FlagSet, name string, tagged Tagged) flag.Value {
 	flg := flagset.Lookup(name)
 	flg.Usage = flg.Usage + " **DEPRECATED** " + d.migrationPlan
 
-	tagged.SetFunc(func(value string) error {
+	tagged.DesignateSetFunc(func(value string) error {
 		log.Warningf(
 			"Flag \"%s\" was set on the command line but has been deprecated: %s",
 			name,
@@ -170,20 +298,21 @@ func (d *deprecatedTag) Tag(flagset *flag.FlagSet, name string, tagged Tagged) {
 		)
 		return tagged.Value().Set(value)
 	})
-	tagged.SetValueForFlagNameHookFunc(func() {
+	tagged.DesignateSetValueForFlagNameHookFunc(func() {
 		log.Warningf(
 			"Flag \"%s\" was set programmatically by name but has been deprecated: %s",
 			name,
 			d.migrationPlan,
 		)
 	})
-	tagged.YAMLSetValueHookFunc(func() {
+	tagged.DesignateYAMLSetValueHookFunc(func() {
 		log.Warningf(
 			"Flag \"%s\" was set through the YAML config but has been deprecated: %s",
 			name,
 			d.migrationPlan,
 		)
 	})
+	return tagged
 }
 
 func DeprecatedTag(migrationPlan string) Taggable {
@@ -192,8 +321,9 @@ func DeprecatedTag(migrationPlan string) Taggable {
 
 type secretTag struct{}
 
-func (_ *secretTag) Tag(flagset *flag.FlagSet, name string, tagged Tagged) {
-	tagged.IsSecretFunc(func() bool { return true })
+func (_ *secretTag) Tag(flagset *flag.FlagSet, name string, tagged Tagged) flag.Value {
+	tagged.DesignateIsSecretFunc(func() bool { return true })
+	return tagged
 }
 
 var SecretTag = &secretTag{}

--- a/server/util/flagutil/types/autoflags/tags/tags.go
+++ b/server/util/flagutil/types/autoflags/tags/tags.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+
+	flagyaml "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/yaml"
 )
 
 // Tagged exists as an interface to provide an abstraction of
@@ -327,3 +329,12 @@ func (_ *secretTag) Tag(flagset *flag.FlagSet, name string, tagged Tagged) flag.
 }
 
 var SecretTag = &secretTag{}
+
+type yamlIgnoreTag struct{}
+
+func (_ *yamlIgnoreTag) Tag(flagset *flag.FlagSet, name string, f Tagged) flag.Value {
+	flagyaml.IgnoreFlagForYAML(name)
+	return nil
+}
+
+var YAMLIgnoreTag = &yamlIgnoreTag{}

--- a/server/util/flagutil/types/types.go
+++ b/server/util/flagutil/types/types.go
@@ -473,7 +473,6 @@ func Deprecate[T any](flagset *flag.FlagSet, name, migrationPlan string) {
 	tags.Tag[T](flagset, name, tags.DeprecatedTag(migrationPlan))
 }
 
-
 func Secret[T any](flagset *flag.FlagSet, name string) {
 	tags.Tag[T](flagset, name, tags.SecretTag)
 }

--- a/server/util/flagutil/types/types_test.go
+++ b/server/util/flagutil/types/types_test.go
@@ -207,9 +207,10 @@ func TestFlagAlias(t *testing.T) {
 	flags.Lookup("string_alias_alias").Value.Set("meow")
 	assert.Equal(t, *s, "meow")
 
-	asf := flags.Lookup("string_alias").Value.(*FlagAlias[string])
+	asf := flags.Lookup("string_alias").Value
 	assert.Equal(t, "meow", asf.String())
-	assert.Equal(t, "string", asf.AliasedName())
+	assert.True(t, asf.(common.NameAliasable).IsNameAliasing())
+	assert.Equal(t, "string", asf.(common.NameAliasable).AliasedName())
 	asfType, err := common.GetTypeForFlagValue(asf)
 	require.NoError(t, err)
 	assert.Equal(t, reflect.TypeOf((*string)(nil)), asfType)
@@ -217,9 +218,10 @@ func TestFlagAlias(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, reflect.TypeOf((*string)(nil)), asfYAMLType)
 
-	aasf := flags.Lookup("string_alias").Value.(*FlagAlias[string])
+	aasf := flags.Lookup("string_alias").Value
 	assert.Equal(t, "meow", aasf.String())
-	assert.Equal(t, "string", aasf.AliasedName())
+	assert.True(t, aasf.(common.NameAliasable).IsNameAliasing())
+	assert.Equal(t, "string", aasf.(common.NameAliasable).AliasedName())
 	aasfType, err := common.GetTypeForFlagValue(asf)
 	require.NoError(t, err)
 	assert.Equal(t, reflect.TypeOf((*string)(nil)), aasfType)
@@ -417,8 +419,18 @@ string_alias: "meow"
 	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}}, structSlice)
 
 	// `String` should not panic on zero-constructed flag
-	assert.Equal(t, "[]", reflect.New(reflect.TypeOf((*FlagAlias[[]testStruct])(nil)).Elem()).Interface().(flag.Value).String())
-	assert.Equal(t, "", reflect.New(reflect.TypeOf((*FlagAlias[string])(nil)).Elem()).Interface().(flag.Value).String())
+	flags = replaceFlagsForTesting(t) //nolint:SA4006
+	JSONStruct(flags, "struct", testStruct{Field: 1}, "")
+	JSONSlice(flags, "struct_slice", []testStruct{{Field: 1}, {Field: 2}}, "")
+	StringSlice(flags, "string_slice", []string{"1", "2"}, "")
+
+	Alias[testStruct](flags, "struct", "struct_alias")
+	Alias[[]testStruct](flags, "struct_slice", "struct_slice_alias")
+	Alias[[]string](flags, "string_slice", "string_slice_alias")
+
+	assert.Equal(t, "{}", reflect.New(reflect.TypeOf(flags.Lookup("struct_alias").Value).Elem()).Interface().(flag.Value).String())
+	assert.Equal(t, "[]", reflect.New(reflect.TypeOf(flags.Lookup("struct_slice_alias").Value).Elem()).Interface().(flag.Value).String())
+	assert.Equal(t, "", reflect.New(reflect.TypeOf(flags.Lookup("string_slice_alias").Value).Elem()).Interface().(flag.Value).String())
 }
 
 func TestDeprecatedVar(t *testing.T) {
@@ -466,7 +478,7 @@ deprecated_string_slice:
 	require.NoError(t, err)
 	assert.Equal(t, testStringSlice, []string{"hi", "hello", "hey"})
 
-	d := any(&tags.TagFlag[struct{}]{})
+	d := any(&tags.TaggedFlagValue[struct{}, *JSONStructFlag[struct{}]]{})
 	_, ok := d.(common.WrappingValue)
 	assert.True(t, ok)
 	_, ok = d.(common.SetValueForFlagNameHooked)
@@ -475,16 +487,17 @@ deprecated_string_slice:
 	assert.True(t, ok)
 
 	// `String` should not panic on zero-constructed flag
-	assert.Equal(t, "[]", reflect.New(reflect.TypeOf((*tags.TagFlag[[]testStruct])(nil)).Elem()).Interface().(flag.Value).String())
-	assert.Equal(t, "", reflect.New(reflect.TypeOf((*tags.TagFlag[string])(nil)).Elem()).Interface().(flag.Value).String())
+	assert.Equal(t, "[]", reflect.New(reflect.TypeOf((*tags.TaggedFlagValue[[]testStruct, *JSONSliceFlag[[]testStruct]])(nil)).Elem()).Interface().(flag.Value).String())
+	assert.Equal(t, "{}", reflect.New(reflect.TypeOf((*tags.TaggedFlagValue[struct{}, *JSONStructFlag[struct{}]])(nil)).Elem()).Interface().(flag.Value).String())
+	assert.Equal(t, "", reflect.New(reflect.TypeOf((*tags.TaggedFlagValue[string, flag.Value])(nil)).Elem()).Interface().(flag.Value).String())
 }
 
 func TestDeprecate(t *testing.T) {
 	flags := replaceFlagsForTesting(t)
 	flagInt := flags.Int("deprecated_int", 5, "some usage text")
-	Deprecate[int](flags, "deprecated_int", "migration plan")
+	Deprecate[int, flag.Value](flags, "deprecated_int", "migration plan")
 	flagStringSlice := StringSlice(flags, "deprecated_string_slice", []string{"hi"}, "")
-	Deprecate[[]string](flags, "deprecated_string_slice", "migration plan")
+	Deprecate[[]string, *StringSliceFlag](flags, "deprecated_string_slice", "migration plan")
 	assert.Equal(t, *flagInt, 5)
 	assert.Equal(t, *flagStringSlice, []string{"hi"})
 	flags.Set("deprecated_int", "7")
@@ -502,9 +515,9 @@ func TestDeprecate(t *testing.T) {
 	flags = replaceFlagsForTesting(t)
 
 	flagInt = flags.Int("deprecated_int", 5, "some usage text")
-	Deprecate[int](flags, "deprecated_int", "migration plan")
+	Deprecate[int, flag.Value](flags, "deprecated_int", "migration plan")
 	flagString := flags.String("deprecated_string", "", "")
-	Deprecate[string](flags, "deprecated_string", "migration plan")
+	Deprecate[string, flag.Value](flags, "deprecated_string", "migration plan")
 	flagStringSlice = DeprecatedVar[[]string](flags, NewStringSliceFlag(&[]string{"hi"}), "deprecated_string_slice", "", "migration plan")
 	flags.Set("deprecated_int", "7")
 	flags.Set("deprecated_string_slice", "hello")

--- a/server/util/flagutil/types/types_test.go
+++ b/server/util/flagutil/types/types_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types/autoflags/tags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -465,7 +466,7 @@ deprecated_string_slice:
 	require.NoError(t, err)
 	assert.Equal(t, testStringSlice, []string{"hi", "hello", "hey"})
 
-	d := any(&DeprecatedFlag[struct{}]{})
+	d := any(&tags.TagFlag[struct{}]{})
 	_, ok := d.(common.WrappingValue)
 	assert.True(t, ok)
 	_, ok = d.(common.SetValueForFlagNameHooked)
@@ -474,8 +475,8 @@ deprecated_string_slice:
 	assert.True(t, ok)
 
 	// `String` should not panic on zero-constructed flag
-	assert.Equal(t, "[]", reflect.New(reflect.TypeOf((*DeprecatedFlag[[]testStruct])(nil)).Elem()).Interface().(flag.Value).String())
-	assert.Equal(t, "", reflect.New(reflect.TypeOf((*DeprecatedFlag[string])(nil)).Elem()).Interface().(flag.Value).String())
+	assert.Equal(t, "[]", reflect.New(reflect.TypeOf((*tags.TagFlag[[]testStruct])(nil)).Elem()).Interface().(flag.Value).String())
+	assert.Equal(t, "", reflect.New(reflect.TypeOf((*tags.TagFlag[string])(nil)).Elem()).Interface().(flag.Value).String())
 }
 
 func TestDeprecate(t *testing.T) {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

Make tags extensible without needing to special-case each new tag type that needs to modify methods.

Go `flag.Value`s need to be able to produce accurate string forms of their zero values even when the instance is nil because of how they are used in `flagset.Usage`:

https://cs.opensource.google/go/go/+/refs/tags/go1.22.1:src/flag/flag.go;l=642-644

This means if we are wrapping a value, we need to capture the type of the value in a type parameter of the wrapping type. Unfortunately, that means that if we want the `Tag` function of a tag we pass in to the `New` or `Var` functions would need to have a type parameter as well if we needed them to wrap the flag value themselves, resulting in the awkward and repetitive:

```go
var foo = autoflags.New(flag.CommandLine, "foo", Foo{}, flagutil.SecretTag[Foo]{})
```

where `SecretTag[T any]` would have a `Tag` method that would wrap the flag in question in a `SecretFlag[T]`.

To avoid this, I had been custom-recognizing the tag types that need to wrap flags inside of `Var[T]` and just ignoring their tag methods and doing the wrapping there. However, ideally creating a new tag doesn't require this weird special-casing. To that end, I have created `TagFlag[T]` which can be created by the `Tag[T]` function to wrap flag values and then be passed to the `Tag` method of a tag as a `Tagged`. The method can then freely modify the functions by using `Tagged`'s interface to set functions without needing to parameterize the type of the tag or create `flag.Value`s that cannot satisfy the requirement of producing valid strings when nil.

I did all this when I was adding a new `Hidden` flag tag for buildbuddy-io/buildbuddy-internal#2804 and then realized I was going to have to add yet another special case to the tag for loop in `Var[T]`.

This also prevents duplication of code and boilerplate for every tag-flag-value-type, as can be seen with how it allows `Secret` and `Deprecate` to both be defined using TagFlag. It should, generally, also make it easier to define new tags without touching `flagutil` at all.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
