### PR TITLE
Publish an error status when buildbuddy.yaml is invalid

### DIFF
--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -117,7 +117,7 @@ func convertToProdOrDie(ctx context.Context, env *real_environment.RealEnv) {
 	workflowService := workflow.NewWorkflowService(env)
 	env.SetWorkflowService(workflowService)
 	env.SetGitProviders([]interfaces.GitProvider{
-		github.NewProvider(),
+		github.NewProvider(env),
 		bitbucket.NewProvider(),
 	})
 	if err := githubapp.Register(env); err != nil {

--- a/enterprise/server/test/integration/workflow/BUILD
+++ b/enterprise/server/test/integration/workflow/BUILD
@@ -27,6 +27,7 @@ go_test(
         "//proto:invocation_status_go_proto",
         "//proto:user_id_go_proto",
         "//proto:workflow_go_proto",
+        "//server/backends/github",
         "//server/backends/repo_downloader",
         "//server/interfaces",
         "//server/testutil/testbazel",

--- a/enterprise/server/webhooks/bitbucket/bitbucket.go
+++ b/enterprise/server/webhooks/bitbucket/bitbucket.go
@@ -114,6 +114,10 @@ func (*bitbucketGitProvider) IsTrusted(ctx context.Context, accessToken, repoURL
 	return false, status.UnimplementedError("Not implemented")
 }
 
+func (*bitbucketGitProvider) CreateStatus(ctx context.Context, accessToken, repoURL, commitSHA string, payload any) error {
+	return status.UnimplementedError("Not implemented")
+}
+
 func unmarshalBody(r *http.Request, payload interface{}) error {
 	b, err := io.ReadAll(r.Body)
 	if err != nil {

--- a/enterprise/server/webhooks/github/BUILD
+++ b/enterprise/server/webhooks/github/BUILD
@@ -9,6 +9,8 @@ go_library(
     deps = [
         "//enterprise/server/util/fieldgetter",
         "//enterprise/server/webhooks/webhook_data",
+        "//server/backends/github",
+        "//server/environment",
         "//server/interfaces",
         "//server/util/git",
         "//server/util/status",
@@ -25,6 +27,7 @@ go_test(
         ":github",
         "//enterprise/server/webhooks/github/test_data",
         "//server/interfaces",
+        "//server/testutil/testenv",
         "@com_github_stretchr_testify//assert",
     ],
 )

--- a/enterprise/server/webhooks/github/github_test.go
+++ b/enterprise/server/webhooks/github/github_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/github"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/github/test_data"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,9 +23,10 @@ func webhookRequest(t *testing.T, eventType string, payload []byte) *http.Reques
 }
 
 func TestParseRequest_ValidPushEvent_Success(t *testing.T) {
+	env := testenv.GetTestEnv(t)
 	req := webhookRequest(t, "push", test_data.PushEvent)
 
-	data, err := github.NewProvider().ParseWebhookData(req)
+	data, err := github.NewProvider(env).ParseWebhookData(req)
 
 	assert.NoError(t, err)
 	assert.Equal(t, &interfaces.WebhookData{
@@ -39,9 +41,10 @@ func TestParseRequest_ValidPushEvent_Success(t *testing.T) {
 }
 
 func TestParseRequest_ValidPullRequestEvent_Success(t *testing.T) {
+	env := testenv.GetTestEnv(t)
 	req := webhookRequest(t, "pull_request", test_data.PullRequestEvent)
 
-	data, err := github.NewProvider().ParseWebhookData(req)
+	data, err := github.NewProvider(env).ParseWebhookData(req)
 
 	assert.NoError(t, err)
 	assert.Equal(t, &interfaces.WebhookData{
@@ -58,9 +61,10 @@ func TestParseRequest_ValidPullRequestEvent_Success(t *testing.T) {
 }
 
 func TestParseRequest_ValidPullRequestReviewEvent_Success(t *testing.T) {
+	env := testenv.GetTestEnv(t)
 	req := webhookRequest(t, "pull_request_review", test_data.PullRequestApprovedReviewEvent)
 
-	data, err := github.NewProvider().ParseWebhookData(req)
+	data, err := github.NewProvider(env).ParseWebhookData(req)
 
 	assert.NoError(t, err)
 	assert.Equal(t, &interfaces.WebhookData{
@@ -79,9 +83,10 @@ func TestParseRequest_ValidPullRequestReviewEvent_Success(t *testing.T) {
 }
 
 func TestParseRequest_InvalidEvent_Error(t *testing.T) {
+	env := testenv.GetTestEnv(t)
 	req := webhookRequest(t, "push", []byte{})
 
-	data, err := github.NewProvider().ParseWebhookData(req)
+	data, err := github.NewProvider(env).ParseWebhookData(req)
 
 	assert.Error(t, err)
 	assert.Nil(t, data)

--- a/enterprise/server/workflow/config/config_test.go
+++ b/enterprise/server/workflow/config/config_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/config"
@@ -33,6 +34,19 @@ func TestWorkflowConf_Parse_BasicConfig_Valid(t *testing.T) {
 			},
 		},
 	}, conf)
+}
+
+func TestWorkflowConf_Parse_InvalidConfig_Error(t *testing.T) {
+	// Unquoted bazel command
+	s := `
+actions:
+  - name: Test
+    bazel_commands:
+      - "test foo
+`
+	conf, err := config.NewConfig(strings.NewReader(s))
+	assert.Nil(t, conf)
+	assert.Error(t, err)
 }
 
 func TestMatchesAnyTrigger_SupportsBasicWildcard(t *testing.T) {

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -708,7 +708,11 @@ type GitProvider interface {
 	// repository.
 	IsTrusted(ctx context.Context, accessToken, repoURL, user string) (bool, error)
 
-	// TODO(bduffany): CreateStatus, ListRepos
+	// CreateStatus publishes a status payload to the given repo at the given
+	// commit SHA.
+	CreateStatus(ctx context.Context, accessToken, repoURL, commitSHA string, payload any) error
+
+	// TODO(bduffany): ListRepos
 }
 
 // WebhookData represents the data extracted from a Webhook event.


### PR DESCRIPTION
Example (the details link just goes to https://buildbuddy.io/docs/workflows-config for now. Later we could do something fancier, like link to a YAML editor in the Code UI, with some type of schema validation)

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/9c7c94d0-6fbe-4665-addb-5d7c9b8afef3)

Also fix logging to use `CtxErrorf` when we fail to start the workflow.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3115
