### PR TITLE
[Raft] Fix store NewWithArgs hanging when there are >50 ranges

### DIFF
--- a/enterprise/server/raft/logger/logger.go
+++ b/enterprise/server/raft/logger/logger.go
@@ -32,7 +32,7 @@ func (l *dbCompatibleLogger) SetLevel(level logger.LogLevel) {}
 func init() {
 	logger.SetLoggerFactory(func(pkgName string) logger.ILogger {
 		switch pkgName {
-		case "rsm", "transport", "raftpb", "logdb":
+		case "dragonboat", "logdb", "raft", "raftpb", "rsm", "transport":
 			// Make the raft library be quieter.
 			return &nullLogger{}
 		default:

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -671,7 +671,6 @@ func (sm *Replica) loadInflightTransactions(db ReplicaReader) error {
 			return err
 		}
 	}
-	log.Debugf("replica(shardID=%d, replicaID=%d) loaded inflight transactions", sm.ShardID, sm.ReplicaID)
 	return nil
 }
 
@@ -686,7 +685,6 @@ func (sm *Replica) loadPartitionMetadata(db ReplicaReader) error {
 	for _, pm := range pms.GetMetadata() {
 		sm.partitionMetadata[pm.GetPartitionId()] = pm
 	}
-	log.Debugf("replica(shardID=%d, replicaID=%d) loaded partition metadata", sm.ShardID, sm.ReplicaID)
 	return nil
 }
 
@@ -697,7 +695,6 @@ func (sm *Replica) loadRangeDescriptor(db ReplicaReader) {
 		return
 	}
 	sm.setRange(constants.LocalRangeKey, buf)
-	log.Debugf("replica(shardID=%d, replicaID=%d) loaded range descriptor", sm.ShardID, sm.ReplicaID)
 }
 
 func (sm *Replica) loadRangeLease(db ReplicaReader) {
@@ -706,12 +703,10 @@ func (sm *Replica) loadRangeLease(db ReplicaReader) {
 		return
 	}
 	sm.setRangeLease(constants.LocalRangeLeaseKey, buf)
-	log.Debugf("replica(shardID=%d, replicaID=%d) loaded range lease", sm.ShardID, sm.ReplicaID)
 }
 
 // loadReplicaState loads any in-memory replica state from the DB.
 func (sm *Replica) loadReplicaState(db ReplicaReader) error {
-	log.Debugf("replica (shardID=%d, replicaID=%d) loadReplicaState started", sm.ShardID, sm.ReplicaID)
 	sm.loadRangeDescriptor(db)
 	sm.loadRangeLease(db)
 	if err := sm.loadPartitionMetadata(db); err != nil {
@@ -728,7 +723,6 @@ func (sm *Replica) loadReplicaState(db ReplicaReader) error {
 		return status.FailedPreconditionErrorf("last applied not moving forward: %d > %d", sm.lastAppliedIndex, lastStoredIndex)
 	}
 	sm.lastAppliedIndex = lastStoredIndex
-	log.Debugf("replica (shardID=%d, replicaID=%d) loadReplicaState finished", sm.ShardID, sm.ReplicaID)
 	return nil
 }
 

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -205,6 +205,10 @@ func NewWithArgs(env environment.Env, rootDir string, nodeHost *dragonboat.NodeH
 		s.grpcServer.Serve(lis)
 	}()
 
+	// Start the leaseKeeper before we rejoin configured clusters, otherwise,
+	// StartOnDiskReplica can be blocked when the the buffered leaderChangeListener channel is full.
+	s.leaseKeeper.Start()
+
 	// rejoin configured clusters
 	nodeHostInfo := nodeHost.GetNodeHostInfo(dragonboat.NodeHostInfoOption{})
 
@@ -393,8 +397,6 @@ func (s *Store) Start() error {
 		s.processSplitRequests(gctx)
 		return nil
 	})
-
-	s.leaseKeeper.Start()
 
 	return nil
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
When rejoining configured clusters in `NewWithArgs`, `StartOnDiskReplica` often hangs when there are more than ranges.

This happens because we didn't started processing LeaderUpdated events when we call `StartOnDiskReplica`, and when the channel for leader updated listener channel is full (after 10 occurences), it blocks LeaderUpdated API ([code](https://github.com/buildbuddy-io/buildbuddy/blob/41c76e7bb3c336e72e44450449f1a44b4e1212bf/enterprise/server/raft/listener/listener.go#L44)). Raft uses the same worker for handling system events and the leader updated queue,  (see [code](https://github.com/lni/dragonboat/blob/1d6e2d76cd5754dd27e83a8fac2600143a4b4fdc/nodehost.go#L1853)). As a result, when LeaderUpdated API is blocked, it causes the leader updated queue cannot be properly flushed. This, in turn, causes the [Publish](https://github.com/lni/dragonboat/blob/1d6e2d76cd5754dd27e83a8fac2600143a4b4fdc/event.go#L159) calls blocked. `Publish` is called in various stages when we start the cluster.
