### PR TITLE
Fix creating repos under non-organizations

### DIFF
--- a/enterprise/app/repo/repo.tsx
+++ b/enterprise/app/repo/repo.tsx
@@ -254,6 +254,7 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
     if (selectedInstallation) {
       r.owner = selectedInstallation.login;
       r.installationId = selectedInstallation.id;
+      r.installationTargetType = selectedInstallation.targetType;
     }
 
     if (update) {
@@ -262,9 +263,6 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
       r.templateVariables = Object.fromEntries(this.state.vars.entries());
     }
 
-    if (selectedInstallation?.targetType == "Organization") {
-      r.isOrganization = true;
-    }
     return rpc_service.service.createRepo(r);
   }
 

--- a/enterprise/app/repo/repo.tsx
+++ b/enterprise/app/repo/repo.tsx
@@ -250,6 +250,12 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
     r.template = this.state.template;
     r.templateDirectory = this.state.templateDirectory;
     r.destinationDirectory = this.state.destinationDirectory;
+
+    if (selectedInstallation) {
+      r.owner = selectedInstallation.login;
+      r.installationId = selectedInstallation.id;
+    }
+
     if (update) {
       r.skipRepo = true;
       r.skipLink = true;
@@ -257,8 +263,7 @@ export default class RepoComponent extends React.Component<RepoComponentProps, R
     }
 
     if (selectedInstallation?.targetType == "Organization") {
-      r.installationId = selectedInstallation.id;
-      r.organization = selectedInstallation.login;
+      r.isOrganization = true;
     }
     return rpc_service.service.createRepo(r);
   }

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -781,7 +781,7 @@ func (a *GitHubApp) CreateRepo(ctx context.Context, req *rppb.CreateRepoRequest)
 	// Pick the right client based on the request (organization or user).
 	var githubClient *github.Client
 	var token = tu.GithubToken
-	if req.InstallationTargetType != "Organization"  {
+	if req.InstallationTargetType != "Organization" {
 		githubClient, err = a.newAuthenticatedClient(ctx, token)
 	} else {
 		githubClient, token, err = a.newInstallationClient(ctx, token, req.InstallationId)

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -781,7 +781,7 @@ func (a *GitHubApp) CreateRepo(ctx context.Context, req *rppb.CreateRepoRequest)
 	// Pick the right client based on the request (organization or user).
 	var githubClient *github.Client
 	var token = tu.GithubToken
-	if req.Organization == "" {
+	if !req.IsOrganization {
 		githubClient, err = a.newAuthenticatedClient(ctx, token)
 	} else {
 		githubClient, token, err = a.newInstallationClient(ctx, token, req.InstallationId)
@@ -790,11 +790,15 @@ func (a *GitHubApp) CreateRepo(ctx context.Context, req *rppb.CreateRepoRequest)
 		return nil, err
 	}
 
-	repoURL := fmt.Sprintf("https://github.com/%s/%s", req.Organization, req.Name)
+	repoURL := fmt.Sprintf("https://github.com/%s/%s", req.Owner, req.Name)
 
 	// Create a new repository on github, if requested
 	if !req.SkipRepo {
-		_, _, err := githubClient.Repositories.Create(ctx, req.Organization, &github.Repository{
+		organization := ""
+		if req.IsOrganization {
+			organization = req.Owner
+		}
+		_, _, err := githubClient.Repositories.Create(ctx, organization, &github.Repository{
 			Name:        github.String(req.Name),
 			Description: github.String(req.Description),
 			Private:     github.Bool(req.Private),

--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -781,7 +781,7 @@ func (a *GitHubApp) CreateRepo(ctx context.Context, req *rppb.CreateRepoRequest)
 	// Pick the right client based on the request (organization or user).
 	var githubClient *github.Client
 	var token = tu.GithubToken
-	if !req.IsOrganization {
+	if req.InstallationTargetType != "Organization"  {
 		githubClient, err = a.newAuthenticatedClient(ctx, token)
 	} else {
 		githubClient, token, err = a.newInstallationClient(ctx, token, req.InstallationId)
@@ -795,7 +795,7 @@ func (a *GitHubApp) CreateRepo(ctx context.Context, req *rppb.CreateRepoRequest)
 	// Create a new repository on github, if requested
 	if !req.SkipRepo {
 		organization := ""
-		if req.IsOrganization {
+		if req.InstallationTargetType == "Organization" {
 			organization = req.Owner
 		}
 		_, _, err := githubClient.Repositories.Create(ctx, organization, &github.Repository{

--- a/proto/repo.proto
+++ b/proto/repo.proto
@@ -14,9 +14,6 @@ message CreateRepoRequest {
   // The owner that of the github repo ex. "buildbuddy-io".
   string owner = 3;
 
-  // True if this repo should belong to an organization.
-  bool is_organization = 14;
-
   // A short description of the repo, ex. "BuildBuddy is an open source Bazel
   // build event viewer, result store, remote caching, and remote build
   // execution platform."
@@ -45,6 +42,9 @@ message CreateRepoRequest {
   // The Github app installation id that should be used to create the
   // repository. Only required for repositories that are hosted on Github.
   int64 installation_id = 8;
+
+  // The target for this installation, for example "Organization".
+  string installation_target_type = 14;
 
   // If set, the template will be copied into the given directory in the
   // newly created repo.

--- a/proto/repo.proto
+++ b/proto/repo.proto
@@ -11,10 +11,11 @@ message CreateRepoRequest {
   // The name of the repo, i.e. "buildbuddy".
   string name = 2;
 
-  // The organization that the repo should be created under ex. "buildbuddy-io".
-  // If this is empty, the repo will be created under the authenticated Github
-  // User's account.
-  string organization = 3;
+  // The owner that of the github repo ex. "buildbuddy-io".
+  string owner = 3;
+
+  // True if this repo should belong to an organization.
+  bool is_organization = 14;
 
   // A short description of the repo, ex. "BuildBuddy is an open source Bazel
   // build event viewer, result store, remote caching, and remote build


### PR DESCRIPTION
We used to implicitly rely on the presence of the `organization` string to determine if a repo should live under an organization or not (because this is how the golang github library we're using did it).

This means we didn't have owner information when creating non-organization repos, causing workflow linking to fail.

This PR fixes that by making the API explicit about whether or not the repo is being created under an organization, and always taking an `owner` field instead of an `organization` field.