### PR TITLE
ci_main: fix cred helper handle 'store'

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -673,12 +673,6 @@ func parseFlags() error {
 
 	unparsedArgs := os.Args[1:]
 	for len(unparsedArgs) > 0 {
-		// Handle special case for credential helper using a subcommand
-		//   ./ci_runner --credential_helper get
-		if len(unparsedArgs) == 1 && unparsedArgs[0] == "get" {
-			break
-		}
-
 		err := flagset.Parse(unparsedArgs)
 		// Ignore undefined flag errors. The flag package will automatically print
 		// a warning error message.

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -513,8 +514,12 @@ func main() {
 }
 
 func run() error {
-	if err := parseFlags(); err != nil {
-		return err
+	if slices.Contains(os.Args, "--credential_helper") {
+		flag.Parse()
+	} else {
+		if err := parseFlags(); err != nil {
+			return err
+		}
 	}
 	if *credentialHelper {
 		return runCredentialHelper()


### PR DESCRIPTION
In a previous change, we managed to detect when the credential helper
was invoked by `git` with the `get` operation and provide a special
espcape hatch for it.

However, `get` is not the only operation that `git` will call us with.
The other operations include `store` and `erase` in the current
git-credentials spec.

Adjust the credential helper detection when parsing flags to make sure
we don't run into infinite loop with `store` and `erase` operations
(or future new operations).
