### PR TITLE
nogo: enable SA1024

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -127,7 +127,6 @@ nogo(
         "@com_github_nishanths_exhaustive//:exhaustive",
     ] + staticcheck_analyzers(ANALYZERS + [
         "-SA1019",
-        "-SA1024",
         "-SA1029",
         "-SA4009",
         "-SA4010",

--- a/server/xcode/xcode_darwin.go
+++ b/server/xcode/xcode_darwin.go
@@ -107,7 +107,7 @@ func versionMap(urlRefs []C.CFURLRef) map[string]*xcodeVersion {
 	defaultDeveloperDir := xcodeSelectDeveloperDir()
 	versionMap := make(map[string]*xcodeVersion)
 	for _, urlRef := range urlRefs {
-		path := "/" + strings.TrimLeft(stringFromCFString(C.CFURLGetString(C.CFURLRef(urlRef))), filePrefix)
+		path := "/" + strings.TrimPrefix(stringFromCFString(C.CFURLGetString(C.CFURLRef(urlRef))), filePrefix)
 		xcodePlist, err := xcodePlistForPath(path + versionPlistPath)
 		if err != nil {
 			log.Warningf("Error reading plist for Xcode: %s", err.Error())


### PR DESCRIPTION
This helps us identify `strings.TrimLeft` and `strings.TrimRight` miss
uses.

Reference: https://staticcheck.io/docs/checks/#SA1024
