### PR TITLE
Use actual workflow name for YAML suggestion

### DIFF
--- a/app/invocation/invocation_suggestion_card.tsx
+++ b/app/invocation/invocation_suggestion_card.tsx
@@ -222,7 +222,7 @@ const matchers: SuggestionMatcher[] = [
           <code>
             <pre>
               {`actions:
-  - name: Test all targets
+  - name: ${model.workflowConfigured?.actionName || "..."}
     # ...
     resource_requests:
 ${yamlSuggestions.map((s) => `      - ${s}`).join("\n")}`}


### PR DESCRIPTION
Forgot to make this change before merging https://github.com/buildbuddy-io/buildbuddy/pull/6248. We know the actual workflow name, so it's probably more helpful to show this name in the YAML suggestion instead of a generic one.

**Related issues**: N/A
