### PR TITLE
Code editor build button tweaks

### DIFF
--- a/app/components/popup/popup.css
+++ b/app/components/popup/popup.css
@@ -5,14 +5,14 @@
   right: 0;
   bottom: 0;
   background-color: rgba(0, 0, 0, 0.1);
-  z-index: 2;
+  z-index: 6;
 }
 
 .popup {
   position: absolute;
   top: 100%;
 
-  z-index: 2;
+  z-index: 6;
 
   border-radius: 4px;
   background: white;

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1027,7 +1027,7 @@ code .comment {
 
 .build-logs-card {
   position: relative;
-  padding-bottom: 16px;
+  padding-bottom: 24px;
 }
 
 .inline-code {

--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -523,7 +523,6 @@ export default class CodeComponent extends React.Component<Props, State> {
     newCommands.unshift(args);
     // Limit the number of commands.
     newCommands = newCommands.slice(0, 10);
-    this.setState({ commands: newCommands }, this.saveState.bind(this));
 
     let request = new runner.RunRequest();
     request.gitRepo = new runner.RunRequest.GitRepo();
@@ -535,7 +534,7 @@ export default class CodeComponent extends React.Component<Props, State> {
       new build.bazel.remote.execution.v2.Platform.Property({ name: "include-secrets", value: "true" }),
     ];
 
-    this.updateState({ isBuilding: true });
+    this.updateState({ isBuilding: true, commands: newCommands });
     rpcService.service
       .run(request)
       .then((response: runner.RunResponse) => {

--- a/enterprise/app/code/code_build_button.tsx
+++ b/enterprise/app/code/code_build_button.tsx
@@ -6,70 +6,55 @@ import Popup, { PopupContainer } from "../../../app/components/popup/popup";
 import Spinner from "../../../app/components/spinner/spinner";
 import { ChevronDown, PlayCircle } from "lucide-react";
 
-const LOCAL_STORAGE_STATE_KEY = "code-button-commands";
-const MAX_COMMANDS = 10;
-
 export interface CodeBuildButtonProps {
   onCommandClicked: (args: string) => void;
+  onDefaultConfig: (config: string) => void;
   isLoading: boolean;
   project: string;
+  commands: string[];
+  defaultConfig: string;
 }
 
 type State = {
   isMenuOpen: boolean;
-  commands: string[];
 };
 
 export default class CodeBuildButton extends React.Component<CodeBuildButtonProps, State> {
-  state: State = this.getSavedState()
-    ? (JSON.parse(this.getSavedState()) as State)
-    : {
-        isMenuOpen: false,
-        commands: ["build //...", "test //..."],
-      };
-
-  private getSavedState() {
-    return localStorage[this.localStorageKey()];
-  }
-
-  private saveState() {
-    localStorage[this.localStorageKey()] = JSON.stringify(this.state);
-  }
-
-  private localStorageKey() {
-    return LOCAL_STORAGE_STATE_KEY + this.props.project;
-  }
+  state: State = {
+    isMenuOpen: false,
+  };
 
   private onOpenMenu() {
-    this.setState({ isMenuOpen: true }, this.saveState.bind(this));
+    this.setState({ isMenuOpen: true });
   }
   private onCloseMenu() {
-    this.setState({ isMenuOpen: false }, this.saveState.bind(this));
+    this.setState({ isMenuOpen: false });
   }
 
   private handleCommandClicked(args: string) {
     this.onCloseMenu();
-    let newCommands = this.state.commands;
-    // Remove if it already exists.
-    const index = newCommands.indexOf(args);
-    if (index > -1) {
-      newCommands.splice(index, 1);
-    }
-    // Place it at the front.
-    newCommands.unshift(args);
-    // Limit the number of commands.
-    newCommands = newCommands.slice(0, MAX_COMMANDS);
-    this.setState({ commands: newCommands }, this.saveState.bind(this));
     this.props.onCommandClicked(args);
   }
 
-  private handleCustomClicked() {
+  private handleCustomClicked(defaultValue: string) {
     this.onCloseMenu();
-    let customArgs = prompt("bazel");
+    let customArgs = prompt("bazel", defaultValue);
     if (!customArgs) {
       return;
     }
+    if (customArgs.startsWith("bazel ")) {
+      customArgs.replace("bazel ", "");
+    }
     this.handleCommandClicked(customArgs);
+  }
+
+  private handleDefaultConfigClicked() {
+    this.onCloseMenu();
+    this.props.onDefaultConfig(prompt("config") || "");
+  }
+
+  private getConfig() {
+    return this.props.defaultConfig ? ` --config=${this.props.defaultConfig}` : "";
   }
 
   render() {
@@ -78,9 +63,12 @@ export default class CodeBuildButton extends React.Component<CodeBuildButtonProp
         <OutlinedButtonGroup>
           <OutlinedButton
             className="workflow-rerun-button"
-            onClick={this.handleCommandClicked.bind(this, this.state.commands[0])}>
+            onClick={this.handleCommandClicked.bind(this, this.props.commands[0])}>
             {this.props.isLoading ? <Spinner /> : <PlayCircle className="icon green" />}
-            <span>{this.state.commands[0]}</span>
+            <span>
+              {this.props.commands[0]}
+              {this.getConfig()}
+            </span>
           </OutlinedButton>
           <OutlinedButton className="icon-button" onClick={this.onOpenMenu.bind(this)}>
             <ChevronDown />
@@ -88,10 +76,15 @@ export default class CodeBuildButton extends React.Component<CodeBuildButtonProp
         </OutlinedButtonGroup>
         <Popup isOpen={this.state.isMenuOpen} onRequestClose={this.onCloseMenu.bind(this)} anchor="right">
           <Menu>
-            {this.state.commands.slice(1).map((command) => (
-              <MenuItem onClick={this.handleCommandClicked.bind(this, command)}>{command}</MenuItem>
+            {this.props.commands.slice(1).map((command) => (
+              <MenuItem onClick={this.handleCommandClicked.bind(this, command)}>
+                {command}
+                {this.getConfig()}
+              </MenuItem>
             ))}
-            <MenuItem onClick={this.handleCustomClicked.bind(this, undefined)}>Custom...</MenuItem>
+            <MenuItem onClick={this.handleDefaultConfigClicked.bind(this, undefined)}>Set default config...</MenuItem>
+            <MenuItem onClick={this.handleCustomClicked.bind(this, this.props.commands[0])}>Edit...</MenuItem>
+            <MenuItem onClick={this.handleCustomClicked.bind(this, "")}>New...</MenuItem>
           </Menu>
         </Popup>
       </PopupContainer>

--- a/enterprise/app/code/code_build_button.tsx
+++ b/enterprise/app/code/code_build_button.tsx
@@ -43,7 +43,7 @@ export default class CodeBuildButton extends React.Component<CodeBuildButtonProp
       return;
     }
     if (customArgs.startsWith("bazel ")) {
-      customArgs.replace("bazel ", "");
+      customArgs = customArgs.replace("bazel ", "");
     }
     this.handleCommandClicked(customArgs);
   }


### PR DESCRIPTION
Some tweaks to the code editor build button based on my experience using it:
1) Fix z-indexes that clash with monaco
2) Move the command state out of the button and into the editor component - this makes it so if you trigger a build through other means (like a sidekick), the command still gets added to your command history so it's easy to run again
3) Adds a button to edit the current command, instead of always having to create a new one
4) Adds the option to set a default config (this makes things like the sidekick more useful when you need to always add a config like --config=remote)


Included a couple of small unrelated changes that I'm happy to break out if you'd like:
1) Add a 8px more padding to the bottom of the build logs card to match the top
2) Fix new file / new folder when not clicking on a node