### PR TITLE
Editor tweaks

### DIFF
--- a/app/picker/picker.tsx
+++ b/app/picker/picker.tsx
@@ -79,11 +79,12 @@ export default class Picker extends React.Component<{}, State> {
   }
 
   async fetchOptions(search: string) {
+    this.setState({ search: search });
     let searchString = search.toLowerCase();
     let cachedValue = this.state.optionCache.get(searchString);
     if (cachedValue) {
       // If we have a cached option value, use it.
-      this.setState({ search: search, currentOptions: await cachedValue });
+      this.setState({ currentOptions: await cachedValue });
       return;
     }
 
@@ -91,13 +92,12 @@ export default class Picker extends React.Component<{}, State> {
     if (this.state.picker?.fetchOptions) {
       let results = this.state.picker.fetchOptions(searchString);
       this.state.optionCache.set(searchString, results);
-      this.setState({ search: search, currentOptions: await results });
+      this.setState({ currentOptions: await results });
       return;
     }
 
     // If we don't have cached options, or an options function - do a simple text search of the fixed options.
     this.setState({
-      search: search,
       currentOptions:
         this.state.picker?.options?.filter((o) => o.toLowerCase().includes(this.state.search.toLowerCase())) || [],
     });

--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -189,11 +189,12 @@ export default class CodeComponent extends React.Component<Props, State> {
     };
     if (capabilities.config.codesearchEnabled) {
       picker.fetchOptions = async (query) => {
-        // TODO: edit query to search only filenames, once supported
         // TODO: include repo info once supported
         // TODO: kick off indexing on page load
         return (
-          await rpcService.service.search(new search.SearchRequest({ query: new search.Query({ term: query }) }))
+          await rpcService.service.search(
+            new search.SearchRequest({ query: new search.Query({ term: `filepath:${query}` }) })
+          )
         ).results.map((r) => r.filename);
       };
     } else {

--- a/enterprise/app/org_picker/org_picker.css
+++ b/enterprise/app/org_picker/org_picker.css
@@ -248,6 +248,7 @@
   top: initial;
   right: initial;
   margin-right: 16px;
+  z-index: 6;
 }
 .org-picker-container.floating.inline .org-picker-profile-name {
   display: none;


### PR DESCRIPTION
Tweaks from playing around with quick picker with search in dev

1. Set input text before firing off search query for more responsive input bar
2. Prefix query with `filepath:` so we only search filenames
3. Fix a little z-index issue I found