### PR TITLE
Don't update picker with old results

### DIFF
--- a/app/picker/picker.tsx
+++ b/app/picker/picker.tsx
@@ -81,18 +81,28 @@ export default class Picker extends React.Component<{}, State> {
   async fetchOptions(search: string) {
     this.setState({ search: search });
     let searchString = search.toLowerCase();
-    let cachedValue = this.state.optionCache.get(searchString);
-    if (cachedValue) {
+    let cachedValuePromise = this.state.optionCache.get(searchString);
+    if (cachedValuePromise) {
       // If we have a cached option value, use it.
-      this.setState({ currentOptions: await cachedValue });
+      let cachedValue = await cachedValuePromise;
+      if (search != this.state.search) {
+        // If the search query has changed since we kicked off the request, don't update the state
+        return;
+      }
+      this.setState({ currentOptions: cachedValue });
       return;
     }
 
     // If we have an options function, use that.
     if (this.state.picker?.fetchOptions) {
-      let results = this.state.picker.fetchOptions(searchString);
-      this.state.optionCache.set(searchString, results);
-      this.setState({ currentOptions: await results });
+      let resultsPromise = this.state.picker.fetchOptions(searchString);
+      this.state.optionCache.set(searchString, resultsPromise);
+      let results = await resultsPromise;
+      if (search != this.state.search) {
+        // If the search query has changed since we kicked off the request, don't update the state
+        return;
+      }
+      this.setState({ currentOptions: results });
       return;
     }
 


### PR DESCRIPTION
If we've fired off a search request, and the search query changes before the results come back (because the user is typing quickly) - cache those (now irrelevant) results, but don't update state to display them (they might clobber the correct results which may have come back sooner).