### PR TITLE
cli/storage: fix login with git-worktree

### DIFF
--- a/cli/storage/BUILD
+++ b/cli/storage/BUILD
@@ -4,7 +4,6 @@ go_library(
     name = "storage",
     srcs = ["storage.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/cli/storage",
-    deps = ["//cli/workspace"],
 )
 
 package(default_visibility = ["//cli:__subpackages__"])


### PR DESCRIPTION
Instead of detecting for WORKSPACE and check for `.git` directory,
leverage `git` to detect the root of the repo.
This location should be ideal to read/write git config to local config
file.

Closes #6282.
