### PR TITLE
Run RBE tests on linux-arm64

### DIFF
--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -41,7 +41,6 @@ jobs:
           [engine]
           cgroup_manager = "cgroupfs"
           '
-          mkdir -p ~/.local
           BUILD_FLAGS=(
             --config=cache
             --bes_backend=remote.buildbuddy.io

--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -1,0 +1,63 @@
+name: "Test linux/arm64 executor"
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04-16cpu-arm64
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # GitHub's arm64 runners do not have the same pre-installed software as
+      # the amd64 runners so we have to install a few things here.
+
+      - name: Install bazelisk
+        run: |
+          curl -L --output /tmp/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64
+          chmod +x /tmp/bazelisk
+          sudo mv /tmp/bazelisk /usr/bin/bazelisk
+          sudo ln -s /usr/bin/bazelisk /usr/bin/bazel
+
+      - name: Install apt packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc g++ podman
+
+      - name: Run tests
+        run: |
+          # Have podman use cgroupfs to prevent warnings like
+          # "The cgroupv2 manager is set to systemd but there is no systemd user session available"
+          # TODO: figure out why these warnings are happening
+          echo >/tmp/containers.conf '
+          [engine]
+          cgroup_manager = "cgroupfs"
+          '
+          mkdir -p ~/.local
+          BUILD_FLAGS=(
+            --config=cache
+            --bes_backend=remote.buildbuddy.io
+            --bes_results_url=https://app.buildbuddy.io/invocation/
+            --remote_cache=remote.buildbuddy.io
+            --flaky_test_attempts=2
+            --build_metadata=ROLE=CI
+            --color=yes
+            --test_env=CONTAINERS_CONF=/tmp/containers.conf
+          )
+          bazel test "${BUILD_FLAGS[@]}" \
+            //enterprise/server/remote_execution/... \
+            //enterprise/server/test/integration/remote_execution/...
+
+          # Run a separate bazel invocation to invoke tests with the "docker" tag.
+          # TODO: improve platform setup so that we can run this whenever the
+          # host has podman available.
+          bazel test "${BUILD_FLAGS[@]}" --test_tag_filters=+docker \
+            //enterprise/server/test/integration/podman:podman_test

--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -32,6 +32,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc g++ podman
 
+          echo "podman version:"
+          podman version
+
       - name: Run tests
         run: |
           # Have podman use cgroupfs to prevent warnings like

--- a/deps.bzl
+++ b/deps.bzl
@@ -6826,6 +6826,12 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/redis/redis-server-6.2.1-linux-x86_64"],
     )
     http_file(
+        name = "com_github_redis_redis-redis-server-v6.2.1-linux-arm64",
+        executable = True,
+        sha256 = "c381660c79dcbe4835a243bab8a0d3c3ee5dc502c1b4a47f1761bd8f9e7be240",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/redis/redis-server-6.2.1-linux-arm64"],
+    )
+    http_file(
         name = "com_github_redis_redis-redis-server-v6.2.6-darwin-arm64",
         executable = True,
         sha256 = "a70261f7a3f455a9a7c9d845299d487a86c1faef2af1605b94f39db44c098e69",
@@ -6850,6 +6856,12 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         urls = ["https://github.com/bazelbuild/bazel/releases/download/5.3.2/bazel-5.3.2-linux-x86_64"],
     )
     http_file(
+        name = "io_bazel_bazel-5.3.2-linux-arm64",
+        executable = True,
+        sha256 = "dcad413da286ac1d3f88e384ff05c2ed796f903be85b253591d170ce258db721",
+        urls = ["https://github.com/bazelbuild/bazel/releases/download/5.3.2/bazel-5.3.2-linux-arm64"],
+    )
+    http_file(
         name = "io_bazel_bazel-6.0.0-darwin-x86_64",
         executable = True,
         sha256 = "8e543c5c9f1c8c91df945cd2fb4c3b43587929a43044a0ed87d13da0d19f96e8",
@@ -6860,6 +6872,12 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         executable = True,
         sha256 = "f03d44ecaac3878e3d19489e37caa4ca1dc57427b686a78a85065ea3c27ebe68",
         urls = ["https://github.com/bazelbuild/bazel/releases/download/6.0.0/bazel-6.0.0-linux-x86_64"],
+    )
+    http_file(
+        name = "io_bazel_bazel-6.0.0-linux-arm64",
+        executable = True,
+        sha256 = "408c33a0edb8f31374da47e011eef88c360264f268e9a4e3d9e699fbd5e57ad3",
+        urls = ["https://github.com/bazelbuild/bazel/releases/download/6.0.0/bazel-6.0.0-linux-arm64"],
     )
     http_file(
         name = "io_bazel_bazel-6.5.0-darwin-x86_64",

--- a/enterprise/server/test/integration/podman/BUILD
+++ b/enterprise/server/test/integration/podman/BUILD
@@ -18,7 +18,11 @@ go_test(
     # TODO: set up build constraints for Firecracker so that this can be skipped
     # locally but not when using --config=remote. For now just use the "docker"
     # tag which we apply to tests that only run on CI.
-    tags = ["docker"],
+    tags = [
+        "docker",
+        # podman is not compatible with linux-sandbox
+        "no-sandbox",
+    ],
     target_compatible_with = ["@platforms//os:linux"],
     deps = [
         "//enterprise/server/remote_execution/commandutil",

--- a/enterprise/server/test/integration/podman/podman_test.go
+++ b/enterprise/server/test/integration/podman/podman_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -35,13 +36,6 @@ func writeFile(t *testing.T, parentDir, fileName, content string) {
 	}
 }
 
-func makeTempDirWithWorldTxt(t *testing.T) string {
-	dir := testfs.MakeTempDir(t)
-	workDir := testfs.MakeDirAll(t, dir, "work")
-	writeFile(t, workDir, "world.txt", "world")
-	return dir
-}
-
 func getTestEnv(t *testing.T) *testenv.TestEnv {
 	env := testenv.GetTestEnv(t)
 	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
@@ -51,7 +45,10 @@ func getTestEnv(t *testing.T) *testenv.TestEnv {
 
 func TestRunHelloWorld(t *testing.T) {
 	ctx := context.Background()
-	rootDir := makeTempDirWithWorldTxt(t)
+	buildRoot := testfs.MakeTempDir(t)
+	workDir := testfs.MakeDirAll(t, buildRoot, "work")
+	testfs.WriteAllFileContents(t, workDir, map[string]string{"world.txt": "world"})
+
 	cmd := &repb.Command{
 		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
 			&repb.Command_EnvironmentVariable{Name: "GREETING", Value: "Hello"},
@@ -64,7 +61,7 @@ func TestRunHelloWorld(t *testing.T) {
 
 	env := getTestEnv(t)
 
-	provider, err := podman.NewProvider(env, rootDir)
+	provider, err := podman.NewProvider(env, buildRoot)
 	require.NoError(t, err)
 	props := platform.Properties{
 		ContainerImage: "docker.io/library/busybox",
@@ -72,7 +69,7 @@ func TestRunHelloWorld(t *testing.T) {
 	}
 	c, err := provider.New(ctx, &props, nil, nil, "")
 	require.NoError(t, err)
-	result := c.Run(ctx, cmd, "/work", oci.Credentials{})
+	result := c.Run(ctx, cmd, workDir, oci.Credentials{})
 
 	require.NoError(t, result.Error)
 	assert.Regexp(t, "^(/usr)?/bin/podman\\s", result.CommandDebugString, "sanity check: command should be run bare")
@@ -86,7 +83,10 @@ func TestRunHelloWorld(t *testing.T) {
 
 func TestHelloWorldExec(t *testing.T) {
 	ctx := context.Background()
-	rootDir := makeTempDirWithWorldTxt(t)
+	buildRoot := testfs.MakeTempDir(t)
+	workDir := testfs.MakeDirAll(t, buildRoot, "work")
+	testfs.WriteAllFileContents(t, workDir, map[string]string{"world.txt": "world"})
+
 	cmd := &repb.Command{
 		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
 			&repb.Command_EnvironmentVariable{Name: "GREETING", Value: "Hello"},
@@ -99,7 +99,7 @@ func TestHelloWorldExec(t *testing.T) {
 
 	env := getTestEnv(t)
 
-	provider, err := podman.NewProvider(env, rootDir)
+	provider, err := podman.NewProvider(env, buildRoot)
 	require.NoError(t, err)
 	props := platform.Properties{
 		ContainerImage: "docker.io/library/busybox",
@@ -108,7 +108,7 @@ func TestHelloWorldExec(t *testing.T) {
 	c, err := provider.New(ctx, &props, nil, nil, "")
 	require.NoError(t, err)
 
-	err = c.Create(ctx, "/work")
+	err = c.Create(ctx, workDir)
 	require.NoError(t, err)
 
 	result := c.Exec(ctx, cmd, &interfaces.Stdio{})
@@ -128,7 +128,8 @@ func TestHelloWorldExec(t *testing.T) {
 
 func TestExecStdio(t *testing.T) {
 	ctx := context.Background()
-	rootDir := makeTempDirWithWorldTxt(t)
+	buildRoot := testfs.MakeTempDir(t)
+	workDir := testfs.MakeDirAll(t, buildRoot, "work")
 	cmd := &repb.Command{
 		Arguments: []string{"sh", "-c", `
 			if ! [ $(cat) = "TestInput" ]; then
@@ -146,7 +147,7 @@ func TestExecStdio(t *testing.T) {
 
 	env := getTestEnv(t)
 
-	provider, err := podman.NewProvider(env, rootDir)
+	provider, err := podman.NewProvider(env, buildRoot)
 	require.NoError(t, err)
 	props := platform.Properties{
 		ContainerImage: "docker.io/library/busybox",
@@ -155,7 +156,7 @@ func TestExecStdio(t *testing.T) {
 	c, err := provider.New(ctx, &props, nil, nil, "")
 	require.NoError(t, err)
 
-	err = c.Create(ctx, "/work")
+	err = c.Create(ctx, workDir)
 	require.NoError(t, err)
 
 	var stdout, stderr bytes.Buffer
@@ -253,8 +254,6 @@ func TestExec_Timeout(t *testing.T) {
 	// Ensure the image is cached
 	err = container.PullImageIfNecessary(ctx, env, c, oci.Credentials{}, "docker.io/library/busybox")
 	require.NoError(t, err)
-	err = c.Create(ctx, workDir)
-	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
@@ -331,6 +330,12 @@ func TestIsImageCached(t *testing.T) {
 }
 
 func TestForceRoot(t *testing.T) {
+	// The image used in this test doesn't have an arm64 variant yet; skip for
+	// now.
+	if runtime.GOARCH != "amd64" {
+		t.Skipf("test is currently only supported on amd64")
+	}
+
 	rootDir := testfs.MakeTempDir(t)
 	workDir := testfs.MakeDirAll(t, rootDir, "work")
 	ctx := context.Background()
@@ -380,9 +385,13 @@ func TestForceRoot(t *testing.T) {
 }
 
 func TestUser(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		// TODO: build podman ourselves, and remove this
+		t.Skipf("--passwd arg is not yet supported by podman version available on GitHub actions runner")
+	}
+
 	rootDir := testfs.MakeTempDir(t)
-	workDir := filepath.Join(rootDir, "work")
-	testfs.MakeDirAll(t, rootDir, "work")
+	workDir := testfs.MakeDirAll(t, rootDir, "work")
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()

--- a/enterprise/server/test/integration/podman/podman_test.go
+++ b/enterprise/server/test/integration/podman/podman_test.go
@@ -387,7 +387,7 @@ func TestForceRoot(t *testing.T) {
 func TestUser(t *testing.T) {
 	if runtime.GOARCH == "arm64" {
 		// TODO: build podman ourselves, and remove this
-		t.Skipf("--passwd arg is not yet supported by podman version available on GitHub actions runner")
+		t.Skipf("--passwd arg is not yet supported by podman 3.4.4 (the version available on GitHub actions runner)")
 	}
 
 	rootDir := testfs.MakeTempDir(t)

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -661,8 +661,10 @@ func TestSimpleCommandWithOSArchPool_CaseInsensitive(t *testing.T) {
 	platform := &repb.Platform{
 		Properties: []*repb.Platform_Property{
 			{Name: "Pool", Value: "FoO"},
-			{Name: "OSFamily", Value: "LiNuX"},
-			{Name: "Arch", Value: "AmD64"},
+			// GOOS / GOARCH are normally lowercase, make sure uppercase
+			// variants are treated equivalently.
+			{Name: "OSFamily", Value: strings.ToUpper(runtime.GOOS)},
+			{Name: "Arch", Value: strings.ToUpper(runtime.GOARCH)},
 		},
 	}
 
@@ -694,11 +696,19 @@ func TestSimpleCommand_DefaultWorkspacePermissions(t *testing.T) {
 		"output_file_parent", "input_dir",
 	}
 
+	platform := &repb.Platform{
+		Properties: []*repb.Platform_Property{
+			{Name: "OSFamily", Value: runtime.GOOS},
+			{Name: "Arch", Value: runtime.GOARCH},
+		},
+	}
+
 	cmd := rbe.Execute(&repb.Command{
 		// %a %n prints perms in octal followed by the file name.
 		Arguments:         append([]string{"stat", "--format", "%a %n"}, dirs...),
 		OutputDirectories: []string{"output_dir", "output_dir_parent/output_dir_child"},
 		OutputFiles:       []string{"output_file_parent/output.txt"},
+		Platform:          platform,
 	}, &rbetest.ExecuteOpts{InputRootDir: inputRoot})
 	res := cmd.Wait()
 

--- a/enterprise/server/testutil/testredis/BUILD
+++ b/enterprise/server/testutil/testredis/BUILD
@@ -27,6 +27,7 @@ genrule(
     name = "redis-server_crossplatform",
     srcs = select({
         "//platforms/configs:linux_x86_64": ["@com_github_redis_redis-redis-server-v6.2.1-linux-x86_64//file:downloaded"],
+        "//platforms/configs:linux_arm64": ["@com_github_redis_redis-redis-server-v6.2.1-linux-arm64//file:downloaded"],
         "//platforms/configs:macos_x86_64": ["@com_github_redis_redis-redis-server-v6.2.6-darwin-x86_64//file:downloaded"],
         "//platforms/configs:macos_arm64": ["@com_github_redis_redis-redis-server-v6.2.6-darwin-arm64//file:downloaded"],
     }),

--- a/enterprise/server/testutil/testredis/testredis.go
+++ b/enterprise/server/testutil/testredis/testredis.go
@@ -43,6 +43,7 @@ func (h *Handle) start() {
 	osArchKey := runtime.GOOS + "_" + runtime.GOARCH
 	switch osArchKey {
 	case "linux_amd64":
+	case "linux_arm64":
 	case "darwin_amd64":
 	case "darwin_arm64":
 	default:

--- a/platforms/configs/BUILD
+++ b/platforms/configs/BUILD
@@ -9,6 +9,14 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_arm64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
     name = "macos_x86_64",
     constraint_values = [
         "@platforms//os:macos",

--- a/server/util/bazel/defs.bzl
+++ b/server/util/bazel/defs.bzl
@@ -43,6 +43,7 @@ def bazel_pkg_tar(name, versions = [], **kwargs):
             name = "bazel-{}_crossplatform".format(version),
             srcs = select({
                 "@bazel_tools//src/conditions:darwin": ["@io_bazel_bazel-{}-darwin-x86_64//file:downloaded".format(version)],
+                "//platforms/configs:linux_arm64": ["@io_bazel_bazel-{}-linux-arm64//file:downloaded".format(version)],
                 "//conditions:default": ["@io_bazel_bazel-{}-linux-x86_64//file:downloaded".format(version)],
             }),
             outs = ["bazel-{}".format(version)],


### PR DESCRIPTION
Adds a GitHub workflow that runs applicable RBE tests on linux-arm64 runners.

**Related issues**: N/A
