### PR TITLE
Fix podman integration test and get it running on CI

### DIFF
--- a/enterprise/server/test/integration/podman/BUILD
+++ b/enterprise/server/test/integration/podman/BUILD
@@ -2,30 +2,26 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
-# To run this test with remote execution, add a test_tag_filter:
-# bazel test --config=remote --test_tag_filters=+bare \
-# //enterprise/server/test/integration/podman:podman_test
 go_test(
     name = "podman_test",
     size = "large",
     srcs = ["podman_test.go"],
     exec_properties = {
-        "test.Pool": "bare",
-        "test.use-self-hosted-executors": "true",
-        "test.container-image": "none",
+        "test.workload-isolation-type": "firecracker",
+        "test.EstimatedComputeUnits": "4",
+        "test.EstimatedFreeDiskBytes": "10GB",
+        # Use the executor image since it has podman installed.
+        "test.container-image": "docker://gcr.io/flame-public/buildbuddy-executor-enterprise:enterprise-v2.47.0",
+        # Enable runner recycling to cache test images.
+        "test.recycle-runner": "true",
     },
-    # Podman tests must run on the bare executors because podman-on-podman /
-    # podman-on-firecracker don't work due to issues running overlayfs on
-    # overlayfs.
-    # TODO(go/b/2944): move to firecracker once
-    # firecracker.enable_merged_rootfs works.
     tags = [
-        "bare",
         # TODO(go/b/2945): remove manual tag.
         "manual",
     ],
     target_compatible_with = ["@platforms//os:linux"],
     deps = [
+        "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/containers/docker",
         "//enterprise/server/remote_execution/containers/podman",

--- a/enterprise/server/test/integration/podman/BUILD
+++ b/enterprise/server/test/integration/podman/BUILD
@@ -15,10 +15,10 @@ go_test(
         # Enable runner recycling to cache test images.
         "test.recycle-runner": "true",
     },
-    tags = [
-        # TODO(go/b/2945): remove manual tag.
-        "manual",
-    ],
+    # TODO: set up build constraints for Firecracker so that this can be skipped
+    # locally but not when using --config=remote. For now just use the "docker"
+    # tag which we apply to tests that only run on CI.
+    tags = ["docker"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = [
         "//enterprise/server/remote_execution/commandutil",

--- a/enterprise/server/test/integration/podman/podman_test.go
+++ b/enterprise/server/test/integration/podman/podman_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -332,11 +331,6 @@ func TestIsImageCached(t *testing.T) {
 }
 
 func TestForceRoot(t *testing.T) {
-	// This test image doesn't have an arm64 variant yet; skip for now.
-	if runtime.GOARCH != "amd64" {
-		t.Skipf("test is currently only supported on arm64")
-	}
-
 	rootDir := testfs.MakeTempDir(t)
 	workDir := testfs.MakeDirAll(t, rootDir, "work")
 	ctx := context.Background()

--- a/enterprise/server/test/integration/podman/podman_test.go
+++ b/enterprise/server/test/integration/podman/podman_test.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"strconv"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/podman"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
@@ -42,6 +43,13 @@ func makeTempDirWithWorldTxt(t *testing.T) string {
 	return dir
 }
 
+func getTestEnv(t *testing.T) *testenv.TestEnv {
+	env := testenv.GetTestEnv(t)
+	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
+	env.SetCommandRunner(&commandutil.CommandRunner{})
+	return env
+}
+
 func TestRunHelloWorld(t *testing.T) {
 	ctx := context.Background()
 	rootDir := makeTempDirWithWorldTxt(t)
@@ -55,8 +63,7 @@ func TestRunHelloWorld(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	env := testenv.GetTestEnv(t)
-	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
+	env := getTestEnv(t)
 
 	provider, err := podman.NewProvider(env, rootDir)
 	require.NoError(t, err)
@@ -91,8 +98,7 @@ func TestHelloWorldExec(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	env := testenv.GetTestEnv(t)
-	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
+	env := getTestEnv(t)
 
 	provider, err := podman.NewProvider(env, rootDir)
 	require.NoError(t, err)
@@ -139,8 +145,7 @@ func TestExecStdio(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	env := testenv.GetTestEnv(t)
-	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
+	env := getTestEnv(t)
 
 	provider, err := podman.NewProvider(env, rootDir)
 	require.NoError(t, err)
@@ -184,8 +189,7 @@ func TestRun_Timeout(t *testing.T) {
 			sleep 100
 		`,
 	}}
-	env := testenv.GetTestEnv(t)
-	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
+	env := getTestEnv(t)
 
 	provider, err := podman.NewProvider(env, rootDir)
 	require.NoError(t, err)
@@ -236,8 +240,7 @@ func TestExec_Timeout(t *testing.T) {
 			sleep 100
 		`,
 	}}
-	env := testenv.GetTestEnv(t)
-	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
+	env := getTestEnv(t)
 
 	provider, err := podman.NewProvider(env, rootDir)
 	require.NoError(t, err)
@@ -283,8 +286,7 @@ func TestIsImageCached(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
-	env := testenv.GetTestEnv(t)
-	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
+	env := getTestEnv(t)
 
 	tests := []struct {
 		desc    string
@@ -330,13 +332,17 @@ func TestIsImageCached(t *testing.T) {
 }
 
 func TestForceRoot(t *testing.T) {
+	// This test image doesn't have an arm64 variant yet; skip for now.
+	if runtime.GOARCH != "amd64" {
+		t.Skipf("test is currently only supported on arm64")
+	}
+
 	rootDir := testfs.MakeTempDir(t)
-	testfs.MakeDirAll(t, rootDir, "work")
+	workDir := testfs.MakeDirAll(t, rootDir, "work")
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
-	env := testenv.GetTestEnv(t)
-	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
+	env := getTestEnv(t)
 	image := "gcr.io/flame-public/test-nonroot:test-enterprise-v1.5.4"
 
 	cmd := &repb.Command{
@@ -346,35 +352,36 @@ func TestForceRoot(t *testing.T) {
 	tests := []struct {
 		desc      string
 		forceRoot bool
-		wantUID   int
+		wantUID   string
 	}{
 		{
-			desc:      "forceRoot",
+			desc:      "ForceRoot=true",
 			forceRoot: true,
-			wantUID:   0,
+			wantUID:   "0",
 		},
 		{
-			desc:      "not forceRoot",
+			desc:      "ForceRoot=false",
 			forceRoot: false,
-			wantUID:   1000,
+			wantUID:   "1000",
 		},
 	}
 	for _, tc := range tests {
-		provider, err := podman.NewProvider(env, rootDir)
-		require.NoError(t, err)
-		props := platform.Properties{
-			ContainerImage:  image,
-			DockerForceRoot: tc.forceRoot,
-			DockerNetwork:   "off",
-		}
-		c, err := provider.New(ctx, &props, nil, nil, "")
-		require.NoError(t, err)
-		result := c.Run(ctx, cmd, "/work", oci.Credentials{})
-		uid, err := strconv.Atoi(strings.TrimSpace(string(result.Stdout)))
-		assert.NoError(t, err)
-		assert.Equal(t, tc.wantUID, uid)
-		assert.Empty(t, string(result.Stderr), "stderr should be empty")
-		assert.Equal(t, 0, result.ExitCode, "should exit with success")
+		t.Run(tc.desc, func(t *testing.T) {
+			provider, err := podman.NewProvider(env, rootDir)
+			require.NoError(t, err)
+			props := platform.Properties{
+				ContainerImage:  image,
+				DockerForceRoot: tc.forceRoot,
+				DockerNetwork:   "off",
+			}
+			c, err := provider.New(ctx, &props, nil, nil, "")
+			require.NoError(t, err)
+			result := c.Run(ctx, cmd, workDir, oci.Credentials{})
+			require.NoError(t, result.Error)
+			assert.Equal(t, tc.wantUID, strings.TrimSpace(string(result.Stdout)))
+			assert.Empty(t, string(result.Stderr), "stderr should be empty")
+			assert.Equal(t, 0, result.ExitCode, "should exit with success")
+		})
 	}
 }
 
@@ -385,8 +392,7 @@ func TestUser(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
-	env := testenv.GetTestEnv(t)
-	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
+	env := getTestEnv(t)
 	image := "docker.io/library/busybox"
 
 	tests := []struct {
@@ -459,8 +465,7 @@ func TestPodmanRun_LongRunningProcess_CanGetAllLogs(t *testing.T) {
 			echo "Hello again"
 		`},
 	}
-	env := testenv.GetTestEnv(t)
-	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
+	env := getTestEnv(t)
 
 	provider, err := podman.NewProvider(env, rootDir)
 	require.NoError(t, err)
@@ -500,8 +505,7 @@ func TestPodmanRun_RecordsStats(t *testing.T) {
 	cmd := &repb.Command{
 		Arguments: []string{"bash", "-c", "head -c 1000000000 /dev/urandom | sha256sum"},
 	}
-	env := testenv.GetTestEnv(t)
-	env.SetAuthenticator(testauth.NewTestAuthenticator(testauth.TestUsers("US1", "GR1")))
+	env := getTestEnv(t)
 
 	flags.Set(t, "executor.podman.enable_stats", true)
 	provider, err := podman.NewProvider(env, rootDir)


### PR DESCRIPTION
`podman_test` was not being run on CI because the target label was not referenced explicitly in the `Baremetal tests` workflow but the target is marked with `bare` and `manual` tags. Fix errors and get it running on CI.

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/2944
