### PR TITLE
xcode: fix TrimLeft to TrimPrefix

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -127,7 +127,6 @@ nogo(
         "@com_github_nishanths_exhaustive//:exhaustive",
     ] + staticcheck_analyzers(ANALYZERS + [
         "-SA1019",
-        "-SA1024",
         "-SA1029",
         "-SA9001",
         "-ST1000",

--- a/server/xcode/BUILD
+++ b/server/xcode/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "xcode",
@@ -20,6 +20,19 @@ go_library(
             "//server/util/log",
             "//server/util/status",
             "@com_github_groob_plist//:plist",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+go_test(
+    name = "xcode_test",
+    srcs = ["xcode_darwin_test.go"],
+    embed = [":xcode"],
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "@com_github_stretchr_testify//assert",
         ],
         "//conditions:default": [],
     }),

--- a/server/xcode/xcode_darwin.go
+++ b/server/xcode/xcode_darwin.go
@@ -107,7 +107,7 @@ func versionMap(urlRefs []C.CFURLRef) map[string]*xcodeVersion {
 	defaultDeveloperDir := xcodeSelectDeveloperDir()
 	versionMap := make(map[string]*xcodeVersion)
 	for _, urlRef := range urlRefs {
-		path := "/" + strings.TrimLeft(stringFromCFString(C.CFURLGetString(C.CFURLRef(urlRef))), filePrefix)
+		path := strings.TrimPrefix(stringFromCFString(C.CFURLGetString(C.CFURLRef(urlRef))), filePrefix)
 		xcodePlist, err := xcodePlistForPath(path + versionPlistPath)
 		if err != nil {
 			log.Warningf("Error reading plist for Xcode: %s", err.Error())

--- a/server/xcode/xcode_darwin_test.go
+++ b/server/xcode/xcode_darwin_test.go
@@ -1,0 +1,25 @@
+//go:build darwin && !ios
+
+package xcode
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestXcodeLocator(t *testing.T) {
+	xl := NewXcodeLocator()
+	for k, v := range xl.versions {
+		t.Run(k, func(t *testing.T) {
+			assert.False(
+				t,
+				strings.HasPrefix(v.developerDirPath, "//"),
+				fmt.Sprintf("developerDirPath of Xcode version %q should not has '//' prefix: %q", k, v.developerDirPath),
+			)
+			assert.DirExists(t, v.developerDirPath)
+		})
+	}
+}


### PR DESCRIPTION
The previous usage of TrimLeft yielded an unexpected result, so to
compensate for it, we added a "/" prefix to the result developerDirPath.

Change this to TrimPrefix requires us from removing that forward-slash
compenstation.

Provide a test to demonstrate the issue.
