### PR TITLE
[raft] create a worker to handle update tags tasks and skip update tags when necessary

### DIFF
--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -180,9 +180,9 @@ func (sm *Replica) replicaLocalKey(key []byte) []byte {
 }
 
 func (sm *Replica) Usage() (*rfpb.ReplicaUsage, error) {
-	sm.rangeMu.Lock()
+	sm.rangeMu.RLock()
 	rd := sm.rangeDescriptor
-	sm.rangeMu.Unlock()
+	sm.rangeMu.RUnlock()
 
 	ru := &rfpb.ReplicaUsage{
 		Replica: &rfpb.ReplicaDescriptor{
@@ -212,9 +212,9 @@ func (sm *Replica) Usage() (*rfpb.ReplicaUsage, error) {
 }
 
 func (sm *Replica) String() string {
-	sm.rangeMu.Lock()
+	sm.rangeMu.RLock()
 	rd := sm.rangeDescriptor
-	sm.rangeMu.Unlock()
+	sm.rangeMu.RUnlock()
 
 	return fmt.Sprintf("Replica c%dn%d %s", sm.ShardID, sm.ReplicaID, rdString(rd))
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Fix https://github.com/buildbuddy-io/buildbuddy-internal/issues/3266. Right now,
everytime we call `AddRange` we launch a goroutine to update tags. Each updateTags
call will grab `gm.mu`. This causes `gossipManager.AddListener` to be blocked in
`NewWithArgs`, because `AddListener` needs to wait for `gm.mu` to be unlocked. 

In this PR, I created a worker to handle updateTags tasks, and will skip
updateTags if the task createdAt is before the lastExecutedAt. When I tested in
dev, we skipped update tags 813 times and only ran updateTags for 17 times.
`NewWithArgs` finished in 11 seconds.
