### PR TITLE
Disable Firecracker and soci-snapshotter on arm64 for now

### DIFF
--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -102,12 +102,15 @@ genrule(
 container_layer(
     name = "executor_tools",
     directory = "/usr/bin",
-    files = [
-        ":firecracker",
-        ":jailer",
-        "@com_github_buildbuddy_io_soci_snapshotter-soci-store-linux-amd64-race//file:soci-store-race",
-        "@com_github_buildbuddy_io_soci_snapshotter-soci-store-linux-amd64//file:soci-store",
-    ],
+    files = select({
+        "@platforms//cpu:x86_64": [
+            ":firecracker",
+            ":jailer",
+            "@com_github_buildbuddy_io_soci_snapshotter-soci-store-linux-amd64-race//file:soci-store-race",
+            "@com_github_buildbuddy_io_soci_snapshotter-soci-store-linux-amd64//file:soci-store",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 container_image(

--- a/enterprise/server/remote_execution/container/BUILD
+++ b/enterprise/server/remote_execution/container/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/util/oci",
+        "//proto:firecracker_go_proto",
         "//proto:remote_execution_go_proto",
         "//proto:runner_go_proto",
         "//server/environment",

--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	fcpb "github.com/buildbuddy-io/buildbuddy/proto/firecracker"
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
 )
@@ -232,6 +233,21 @@ type CommandContainer interface {
 	// If a container implementation does not support saving and restoring state
 	// across restarts, it can return UNIMPLEMENTED.
 	State(ctx context.Context) (*rnpb.ContainerState, error)
+}
+
+// VM is an interface implemented by containers backed by VMs (i.e. just
+// Firecracker). This just exists to avoid depending on the Firecracker package
+// on non-linux/amd64 platforms.
+type VM interface {
+	// SetTaskFileSystemLayout sets the VFS layout for use inside the guest.
+	SetTaskFileSystemLayout(layout *FileSystemLayout)
+
+	// SnapshotDebugString returns a string representing the cache key used for
+	// VM snapshots, if applicable.
+	SnapshotDebugString(ctx context.Context) string
+
+	// VMConfig returns the VM's initialization config.
+	VMConfig() *fcpb.VMConfiguration
 }
 
 // PullImageIfNecessary pulls the image configured for the container if it

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -16,6 +16,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/firecracker",
     target_compatible_with = [
         "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
     x_defs = {
         "initrdRunfilePath": "$(rlocationpath //enterprise/vmsupport/bin:initrd.cpio)",
@@ -80,6 +81,7 @@ genrule(
     cmd_bash = """sha256sum $(SRCS) | sha256sum | awk '{printf "%s", $$1}' > $@""",
     target_compatible_with = [
         "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
 )
 
@@ -104,6 +106,7 @@ go_test(
     ],
     target_compatible_with = [
         "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
     deps = [
         ":firecracker",
@@ -182,6 +185,7 @@ go_test(
     ],
     target_compatible_with = [
         "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
     deps = [
         ":firecracker",

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -551,6 +551,8 @@ type FirecrackerContainer struct {
 	cancelVmCtx context.CancelCauseFunc
 }
 
+var _ container.VM = (*FirecrackerContainer)(nil)
+
 func NewContainer(ctx context.Context, env environment.Env, task *repb.ExecutionTask, opts ContainerOpts) (*FirecrackerContainer, error) {
 	if *snaputil.EnableLocalSnapshotSharing && !(*enableVBD && *enableUFFD) {
 		return nil, status.FailedPreconditionError("executor configuration error: local snapshot sharing requires VBD and UFFD to be enabled")

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -363,8 +363,8 @@ func GetExecutorProperties() *ExecutorProperties {
 	}
 
 	if *EnableFirecracker {
-		if runtime.GOOS == "darwin" {
-			log.Warning("Firecracker was enabled, but is unsupported on darwin. Ignoring.")
+		if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
+			log.Warningf("Firecracker was enabled, but is unsupported on %s/%s. Ignoring.", runtime.GOOS, runtime.GOARCH)
 		} else {
 			p.SupportedIsolationTypes = append(p.SupportedIsolationTypes, FirecrackerContainerType)
 		}

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -8,6 +8,8 @@ go_library(
         "runner.go",
         "runner_darwin.go",
         "runner_linux.go",
+        "runner_linux_amd64.go",
+        "runner_linux_notamd64.go",
         "runner_windows.go",
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/runner",
@@ -55,13 +57,17 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "//enterprise/server/remote_execution/containers/bare",
             "//enterprise/server/remote_execution/containers/docker",
-            "//enterprise/server/remote_execution/containers/firecracker",
             "//enterprise/server/remote_execution/containers/podman",
             "//proto:vfs_go_proto",
             "@org_golang_google_grpc//:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:windows": [
             "//enterprise/server/remote_execution/containers/bare",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "//enterprise/server/remote_execution/containers/firecracker",
         ],
         "//conditions:default": [],
     }),

--- a/enterprise/server/remote_execution/runner/runner_linux_amd64.go
+++ b/enterprise/server/remote_execution/runner/runner_linux_amd64.go
@@ -1,0 +1,21 @@
+//go:build linux && amd64 && !android
+
+package runner
+
+import (
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/firecracker"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+)
+
+func (p *pool) registerFirecrackerProvider(providers map[platform.ContainerType]container.Provider, executor *platform.ExecutorProperties) error {
+	if executor.SupportsIsolation(platform.FirecrackerContainerType) {
+		p, err := firecracker.NewProvider(p.env, *rootDirectory)
+		if err != nil {
+			return status.FailedPreconditionErrorf("Failed to initialize firecracker container provider: %s", err)
+		}
+		providers[platform.FirecrackerContainerType] = p
+	}
+	return nil
+}

--- a/enterprise/server/remote_execution/runner/runner_linux_notamd64.go
+++ b/enterprise/server/remote_execution/runner/runner_linux_notamd64.go
@@ -1,0 +1,12 @@
+//go:build linux && !amd64 && !android
+
+package runner
+
+import (
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
+)
+
+func (p *pool) registerFirecrackerProvider(providers map[platform.ContainerType]container.Provider, executor *platform.ExecutorProperties) error {
+	return nil
+}

--- a/enterprise/server/remote_execution/soci_store/soci_store_linux.go
+++ b/enterprise/server/remote_execution/soci_store/soci_store_linux.go
@@ -198,6 +198,12 @@ func (s *SociStore) runWithRetries(ctx context.Context) {
 
 func Init(env environment.Env) (Store, error) {
 	if *imageStreamingEnabled {
+
+		if runtime.GOARCH != "amd64" {
+			log.Warningf("Podman image streaming was enabled, but is unsupported on %s. Ignoring.", runtime.GOARCH)
+			return &NoStore{}, nil
+		}
+
 		artifactStoreClient, err := intializeSociArtifactStoreClient(env, *artifactStoreTarget)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
We'll need arm64 builds of soci-snapshotter as well as vmlinux and firecracker/jailer before we can enable these. Would also be good to have CI tests for these to avoid breakage. Since this seems like significant work, disable these for now and avoid building / shipping them as part of the go binary / docker image.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
