### PR TITLE
Don't use `sqlite3://:memory:`

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -72,8 +72,7 @@ actions:
           - "*"
     bazel_commands:
       # TODO(http://go/b/958): See if we can remove --remote_download_outputs=toplevel
-      # TODO(http://go/b/1575): De-flake, and remove --flaky_test_attempts
-      - test //... --config=linux-workflows --config=race --remote_download_outputs=toplevel --test_tag_filters=+webdriver --flaky_test_attempts=4
+      - test //... --config=linux-workflows --config=race --remote_download_outputs=toplevel --test_tag_filters=+webdriver
   # TODO(bduffany): Move docker tests to the Test workflow when they are fast enough.
   - name: Docker tests
     container_image: ubuntu-20.04

--- a/server/testutil/app/app.go
+++ b/server/testutil/app/app.go
@@ -54,7 +54,7 @@ func RunWithApp(t *testing.T, app *App, commandPath string, commandArgs []string
 		"--static_directory=static",
 		"--app_directory=/app",
 		fmt.Sprintf("--app.build_buddy_url=http://localhost:%d", app.HttpPort),
-		"--database.data_source=sqlite3://:memory:",
+		fmt.Sprintf("--database.data_source=sqlite3://%s", filepath.Join(dataDir, "buildbuddy.db")),
 		fmt.Sprintf("--storage.disk.root_directory=%s", filepath.Join(dataDir, "storage")),
 		fmt.Sprintf("--cache.disk.root_directory=%s", filepath.Join(dataDir, "cache")),
 	}

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"net"
+	"path/filepath"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/server/backends/blobstore"
@@ -53,8 +54,6 @@ type ConfigTemplateParams struct {
 const testConfigData string = `
 app:
   build_buddy_url: "http://localhost:8080"
-database:
-  data_source: "sqlite3://:memory:"
 storage:
   enable_chunked_event_logs: true
 cache:
@@ -148,7 +147,7 @@ func GetTestEnv(t testing.TB) *real_environment.RealEnv {
 
 	switch *databaseType {
 	case "sqlite":
-		// do nothing, this is the default
+		flags.Set(t, "database.data_source", fmt.Sprintf("sqlite3://%s", filepath.Join(testRootDir, "test.db")))
 	case "mysql":
 		flags.Set(t, "database.data_source", testmysql.GetOrStart(t, *reuseServer))
 	case "postgres":


### PR DESCRIPTION
`sqlite3://:memory:` has some gotchas which I think were causing the issues with flaky webdriver tests in which tables were suddenly disappearing in the middle of the test.

I randomly stumbled across this HN comment which mentioned the same symptom we were seeing (tables randomly disappearing): https://news.ycombinator.com/item?id=39956165

Also see the linked FAQ here: https://github.com/mattn/go-sqlite3?tab=readme-ov-file#faq

Specifically

> Why I'm getting no such table error?

> Why is it racy if I use a sql.Open("sqlite3", ":memory:") database?

> Each connection to ":memory:" opens a brand new in-memory sql database, so if the stdlib's sql engine happens to open another connection and you've only specified ":memory:", that connection will see a brand new database.

**Related issues**: N/A
