### PR TITLE
Add skopeo back to executor image

### DIFF
--- a/dockerfiles/executor_image/Dockerfile
+++ b/dockerfiles/executor_image/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
 # Install skopeo and umoci which we use to unpack OCI images when we're not using docker.
 # Install iproute2 ("ip" command) to configure networking on host.
 RUN apt-get update && \
-    apt-get install -y umoci iproute2 amazon-ecr-credential-helper && \
+    apt-get install -y skopeo umoci iproute2 amazon-ecr-credential-helper && \
     rm -rf /var/lib/apt/lists/* && apt-get clean
 
 # Install podman.


### PR DESCRIPTION
I think I accidentally removed this while resolving a merge conflict. This is causing the baremetal tests to fail in dev, because it is unable to convert OCI images to EXT4 which requires skopeo.

**Related issues**: N/A
