### PR TITLE
Also delete cache misses on cache stat clean-up

### DIFF
--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -715,4 +715,8 @@ func CleanupCacheStats(ctx context.Context, env environment.Env, iid string) {
 	if err := c.Delete(ctx, counterKey(iid)); err != nil {
 		log.Warningf("Failed to clean up cache stats for invocation %s: %s", iid, err)
 	}
+
+	if err := c.Delete(ctx, targetMissesKey(iid)); err != nil {
+		log.Warningf("Failed to clean up cache stats for invocation %s: %s", iid, err)
+	}
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

We also create `/misses` counts in the cache if we aren't using detailed stats, so clean those up as well.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
