### PR TITLE
Lower ttl for cache stats

### DIFF
--- a/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector.go
+++ b/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// How long until counts expire from Redis.
-	countExpiration = 1 * 24 * time.Hour
+	countExpiration = 6 * time.Hour
 )
 
 type collector struct {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

We only allow retries of invocations for four hours, so 24 hours is an excessive TTL for cache stats. Lower it to four.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
