### PR TITLE
Make the auth popup a little wider

### DIFF
--- a/app/util/popup.ts
+++ b/app/util/popup.ts
@@ -1,5 +1,5 @@
 export default {
-  open: (url: string, timeout = 360, width = 400, height = 600) => {
+  open: (url: string, timeout = 360, width = 432, height = 600) => {
     return new Promise<any>((resolve, reject) => {
       const left = window.screenX + (window.innerWidth - width) / 2;
       const top = window.screenY + (window.innerHeight - height) / 2;


### PR DESCRIPTION
On Linux, a scrollbar is rendered inside the window which consumes 15px, so the window winds up being effectively 385px wide, and it looks squished. Add a little more width so that the window doesn't need to scroll, and looks good on both Linux and macOS.

**Related issues**: N/A
