### PR TITLE
Deflake arm64 RBE tests

### DIFF
--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -54,7 +54,7 @@ jobs:
             --color=yes
             --test_env=CONTAINERS_CONF=/tmp/containers.conf
           )
-          bazel test "${BUILD_FLAGS[@]}" \
+          bazel test "${BUILD_FLAGS[@]}" --test_tag_filters=-performance,-docker \
             //enterprise/server/remote_execution/... \
             //enterprise/server/test/integration/remote_execution/...
 

--- a/enterprise/server/remote_execution/commandutil/BUILD
+++ b/enterprise/server/remote_execution/commandutil/BUILD
@@ -45,6 +45,7 @@ go_test(
         "@io_bazel_rules_go//go/platform:windows": [],
         "//conditions:default": ["//enterprise/server/remote_execution/commandutil/test_binary"],
     }),
+    tags = ["cpu:4"],
     x_defs = select({
         "@io_bazel_rules_go//go/platform:windows": {},
         "//conditions:default": {

--- a/enterprise/server/test/integration/remote_execution/BUILD
+++ b/enterprise/server/test/integration/remote_execution/BUILD
@@ -4,13 +4,14 @@ package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_test(
     name = "remote_execution_test",
-    size = "small",
+    size = "enormous",
     # TODO(https://github.com/buildbuddy-io/buildbuddy-internal/issues/2379):
     # make these tests run faster
     timeout = "long",
     srcs = ["remote_execution_test.go"],
     args = ["--test.v"],
     shard_count = 11,
+    tags = ["cpu:4"],
     deps = [
         "//enterprise/server/build_event_publisher",
         "//enterprise/server/remote_execution/commandutil",


### PR DESCRIPTION
Increase local CPU resources to 4 and set size="enormous" (which IIUC just increases memory to 800MB) on some tests to prevent too many expensive local test actions from running concurrently on the arm64 runner, which was causing OOMs. Also disable benchmark tests which can consume an inordinate amount of resources.

**Related issues**: N/A
