### PR TITLE
echo comment info from github back when creating new comments.

### DIFF
--- a/proto/github.proto
+++ b/proto/github.proto
@@ -589,6 +589,7 @@ message CreateGithubPullRequestCommentResponse {
   context.ResponseContext response_context = 1;
   string review_id = 2;
   string comment_id = 3;
+  Comment comment = 4;
 }
 
 message UpdateGithubPullRequestCommentRequest {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
this makes it a little easier to write code that cares about the review id, thread id, final comment position, "real" comment id, yada yada.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
