### PR TITLE
Have ExtendContextForFinalization respect the parent context's cancelation

### DIFF
--- a/server/util/background/BUILD
+++ b/server/util/background/BUILD
@@ -1,8 +1,21 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "background",
     srcs = ["background.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/background",
     visibility = ["//visibility:public"],
+    deps = [
+        "//server/util/log",
+        "//server/util/timeutil",
+    ],
+)
+
+go_test(
+    name = "background_test",
+    srcs = ["background_test.go"],
+    deps = [
+        ":background",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/server/util/background/BUILD
+++ b/server/util/background/BUILD
@@ -5,10 +5,7 @@ go_library(
     srcs = ["background.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/background",
     visibility = ["//visibility:public"],
-    deps = [
-        "//server/util/log",
-        "//server/util/timeutil",
-    ],
+    deps = ["//server/util/log"],
 )
 
 go_test(

--- a/server/util/background/background.go
+++ b/server/util/background/background.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
-	"github.com/buildbuddy-io/buildbuddy/server/util/timeutil"
 )
 
 type disconnectedContext struct {
@@ -82,7 +81,7 @@ func ExtendContextForFinalization(parent context.Context, timeout time.Duration)
 		case <-parent.Done():
 		}
 		t := time.NewTimer(timeout)
-		defer timeutil.StopAndDrainTimer(t)
+		defer t.Stop()
 		select {
 		case <-ctx.Done():
 			return // cancelled manually

--- a/server/util/background/background_test.go
+++ b/server/util/background/background_test.go
@@ -1,0 +1,61 @@
+package background_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/background"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtendContextForFinalization_CancelContextBeforeExtending(t *testing.T) {
+	ctx := context.Background()
+
+	// Set a deadline ~infinitely far in the future
+	ctx, cancel := context.WithTimeout(ctx, 1e6*time.Hour)
+	defer cancel()
+
+	// Cancel the original context before the timeout has been reached
+	cancel()
+
+	// Extend the canceled context with a very short grace period
+	ctx, cancel = background.ExtendContextForFinalization(ctx, 1*time.Nanosecond)
+	defer cancel()
+
+	<-ctx.Done() // should return ~immediately
+	require.Equal(t, ctx.Err(), context.DeadlineExceeded)
+}
+
+func TestExtendContextForFinalization_CancelContextAfterExtending(t *testing.T) {
+	ctx := context.Background()
+
+	// Set a deadline ~infinitely far in the future
+	ctx, cancel := context.WithTimeout(ctx, 1e6*time.Hour)
+	defer cancel()
+	cancelOriginal := cancel
+
+	// Extend the canceled context with a very short grace period
+	ctx, cancel = background.ExtendContextForFinalization(ctx, 1*time.Nanosecond)
+	defer cancel()
+
+	// Cancel the original context; deadline extension starts now.
+	cancelOriginal()
+
+	<-ctx.Done() // should return ~immediately
+	require.Equal(t, ctx.Err(), context.DeadlineExceeded)
+}
+
+func TestExtendContextForFinalization_ManualCancel(t *testing.T) {
+	ctx := context.Background()
+
+	// Extend the deadline ~infinitely
+	ctx, cancel := background.ExtendContextForFinalization(ctx, 1e6*time.Hour)
+	defer cancel()
+
+	// Cancel the extended context manually
+	cancel()
+
+	<-ctx.Done() // should return ~immediately
+	require.Equal(t, ctx.Err(), context.Canceled)
+}


### PR DESCRIPTION
If the parent context has the default action timeout (7 days) and gets canceled (either before or after calling ExtendContextForFinalization), then the context returned by ExtendContextForFinalization will have a deadline that is 7 days + 15s in the future, rather than 15s starting from the time of cancellation like we would expect.

This PR changes the implementation to match the expected behavior in this case, which is to apply a deadline that is `<whenever the parent context gets canceled, either via deadline or manual cancel>` + 15s.

**Related issues**: N/A
