### PR TITLE
Render action timeout in action page

### DIFF
--- a/app/format/BUILD
+++ b/app/format/BUILD
@@ -6,6 +6,8 @@ ts_library(
     name = "format",
     srcs = ["format.tsx"],
     deps = [
+        "//app/util:proto",
+        "//proto:duration_ts_proto",
         "@npm//@types/long",
         "@npm//@types/moment",
         "@npm//date-fns",

--- a/app/format/format.tsx
+++ b/app/format/format.tsx
@@ -1,10 +1,16 @@
 import Long from "long";
 import moment from "moment";
 import { isSameDay } from "date-fns";
+import { google as google_duration } from "../../proto/duration_ts_proto";
+import { durationToMillis } from "../util/proto";
 
 export function percent(percent: number | Long) {
   if (!percent) return "0";
   return `${(+percent * 100).toFixed(0)}`;
+}
+
+export function durationProto(duration: google_duration.protobuf.IDuration) {
+  return durationMillis(durationToMillis(duration));
 }
 
 export function durationUsec(duration: number | Long) {
@@ -387,6 +393,7 @@ export function enumLabel(e: string) {
 export default {
   compactDurationSec,
   durationSec,
+  durationProto,
   roundedDurationSec,
   durationMillis,
   durationUsec,

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -10,7 +10,7 @@ import rpcService from "../service/rpc_service";
 import DigestComponent from "../components/digest/digest";
 import { TextLink } from "../components/link/link";
 import TerminalComponent from "../terminal/terminal";
-import { parseDigest, parseActionDigest, digestToString } from "../util/cache";
+import { parseActionDigest, digestToString } from "../util/cache";
 import UserPreferences from "../preferences/preferences";
 import alert_service from "../alert/alert_service";
 
@@ -458,10 +458,6 @@ export default class InvocationActionCardComponent extends React.Component<Props
                       <div className="action-property-title">Digest</div>
                       <DigestComponent digest={digest} expanded={true} />
                     </div>
-                    <div className="action-section">
-                      <div className="action-property-title">Cacheable</div>
-                      <div>{!this.state.action.doNotCache ? "True" : "False"}</div>
-                    </div>
                     {this.state.action.inputRootDigest && (
                       <div className="action-section">
                         <div className="action-property-title">Input root digest</div>
@@ -470,22 +466,6 @@ export default class InvocationActionCardComponent extends React.Component<Props
                         </div>
                       </div>
                     )}
-                    <div className="action-section">
-                      <div
-                        title="List of required supported NodeProperty [build.bazel.remote.execution.v2.NodeProperty] keys."
-                        className="action-property-title">
-                        Output node properties
-                      </div>
-                      {this.state.action.outputNodeProperties.length ? (
-                        <div>
-                          {this.state.action.outputNodeProperties.map((outputNodeProperty) => (
-                            <div className="output-node">{outputNodeProperty}</div>
-                          ))}
-                        </div>
-                      ) : (
-                        <div>Default</div>
-                      )}
-                    </div>
                     <div className="action-section">
                       <div className="action-property-title">Input files</div>
                       {this.state.inputDirs.length ? (
@@ -503,6 +483,14 @@ export default class InvocationActionCardComponent extends React.Component<Props
                       ) : (
                         <div>None found</div>
                       )}
+                    </div>
+                    <div className="action-section">
+                      <div className="action-property-title">Cacheable</div>
+                      <div>{!this.state.action.doNotCache ? "Yes" : "No"}</div>
+                    </div>
+                    <div className="action-section">
+                      <div className="action-property-title">Timeout</div>
+                      <div>{this.state.action.timeout ? format.durationProto(this.state.action.timeout) : "None"}</div>
                     </div>
                   </div>
                   <div className="action-line">


### PR DESCRIPTION
Also tidy up action details.

Before:

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/fb5f6026-8edc-48ed-a1db-753e6ab8d6f8)

After:

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/00493582-b66e-45be-ac94-202deb544b14)

- Moved "cacheable" towards the end since it's less interesting than inputs and causes a visual break between the 2 digest components
- Removed output node properties since these are always unset from what I've seen and also have been removed from the upstream proto (if there are some old bazel versions where this is useful, we can always add it back, but it seems unlikely)

**Related issues**: N/A
