### PR TITLE
cli/printlog: improve compact exec log

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -268,8 +268,8 @@ common --experimental_profile_include_primary_output
 common --noslim_profile
 # Include compact execution log
 # TODO(sluongng): make Bazel writes this to output_base automatically
-common:linux --experimental_execution_log_compact_file=/tmp/bazel_compact_exec_log.bin
-common:macos --experimental_execution_log_compact_file=/tmp/bazel_compact_exec_log.bin
+common:linux --experimental_execution_log_compact_file=/tmp/bazel_compact_exec_log.binpb.zstd
+common:macos --experimental_execution_log_compact_file=/tmp/bazel_compact_exec_log.binpb.zstd
 
 # Try importing a user specific .bazelrc
 # You can create your own by copying and editing the template-user.bazelrc template:

--- a/cli/printlog/printlog.go
+++ b/cli/printlog/printlog.go
@@ -91,6 +91,8 @@ func printCompactExecLog(path string) error {
 	}
 }
 
+// SpawnLogReconstructor reconstructs "compact execution log" format back to the original format.
+// As of Bazel 7.1, this is the recommended way to consume the new compact format.
 type SpawnLogReconstructor struct {
 	input *bufio.Reader
 
@@ -203,6 +205,7 @@ func (slr *SpawnLogReconstructor) reconstructSpawn(s *spb.ExecLogEntry_Spawn) (*
 	}
 	se.ListedOutputs = listedOutputs
 	se.ActualOutputs = actualOutputs
+
 	return se, nil
 }
 
@@ -253,7 +256,7 @@ func (slr *SpawnLogReconstructor) reconstructInputs(setID int32) map[string]*spb
 }
 
 func reconstructDir(d *spb.ExecLogEntry_Directory) *reconstructedDir {
-	filesInDir := make([]*spb.File, len(d.GetFiles()))
+	filesInDir := make([]*spb.File, 0, len(d.GetFiles()))
 	for _, file := range d.GetFiles() {
 		filesInDir = append(filesInDir, reconstructFile(d, file))
 	}


### PR DESCRIPTION
Fixed an issue in `reconstructDir()` where the filesInDir slice was
initiated with nil entries.

Rename the compact log file to have the right extension.
