### PR TITLE
Small tweaks to firecracker cleanup script

### DIFF
--- a/tools/firecracker_clean_networking.sh
+++ b/tools/firecracker_clean_networking.sh
@@ -6,22 +6,13 @@ if [[ "$(id -u)" != 0 ]]; then
   exit 1
 fi
 
+echo >&2 "Cleaning up any running firecracker processes"
+killall -KILL firecracker || true
+
 echo >&2 "Cleaning up network namespaces"
 ip netns list | awk '{ print $1 }' | while read -r netns; do
   [[ "$netns" == bb-executor-* ]] && (
     set -x
     ip netns delete "$netns"
   )
-done
-
-IPTABLES=$(iptables-save)
-BACKUP_FILE=$(mktemp --suffix .iptables.bak)
-cat <<<"$IPTABLES" >"$BACKUP_FILE"
-echo >&2 "Created iptables backup at $BACKUP_FILE"
-echo >&2 "Restore backup with: sudo iptables-restore < $BACKUP_FILE"
-
-echo >&2 "Cleaning up iptables veth* rules"
-grep -vP '\bveth' <<<"$IPTABLES" | uniq | iptables-restore
-
-echo >&2 "Cleaning up any remaining firecracker processes"
-killall firecracker
+done || true


### PR DESCRIPTION
- Kill firecracker processes first (before removing network resources that may be in use)
- Kill with SIGKILL so firecracker exits immediately
- Don't fail if there are no firecracker processes
- Don't fail if there are no net namespaces to clean up
- Get rid of iptables clean up (pretty sure this is not needed - our networking cleanup in Go code doesn't do this)
- Rename to `firecracker_clean` since it cleans processes too (not just networking)

**Related issues**: N/A
