### PR TITLE
Don't skip deleting counters when detailed stats are enabled

### DIFF
--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -709,7 +709,6 @@ func CleanupCacheStats(ctx context.Context, env environment.Env, iid string) {
 		if err := c.Delete(ctx, resultsKey(iid)); err != nil {
 			log.Warningf("Failed to clean up scorecard for invocation %s: %s", iid, err)
 		}
-		return
 	}
 
 	if err := c.Delete(ctx, counterKey(iid)); err != nil {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

This removes a return that prevents us cleaning up counters when detailed stats are enabled (as they are in prod).

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
