### PR TITLE
Make snaploader code more rollout safe before my proto change

### DIFF
--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -399,7 +399,7 @@ func (l *FileCacheLoader) getLocalManifest(ctx context.Context, key *fcpb.Snapsh
 
 func (l *FileCacheLoader) actionResultToManifest(ctx context.Context, remoteInstanceName string, snapshotActionResult *repb.ActionResult, tmpDir string, remoteEnabled bool) (*fcpb.SnapshotManifest, error) {
 	snapMetadata := snapshotActionResult.GetExecutionMetadata().GetAuxiliaryMetadata()
-	if len(snapMetadata) != 1 {
+	if len(snapMetadata) < 1 {
 		return nil, status.InternalErrorf("expected vm config in snapshot auxiliary metadata")
 	}
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

If we have to rollback https://github.com/buildbuddy-io/buildbuddy/pull/6341/files, any snapshots written in the meantime will break, because there will be two auxiliary metadata entries (the vm config + the new vm metadata). Add this first to make rollouts safer.

I'll cherry pick and deploy this before #6341 goes out.

**Related issues**: N/A
