### PR TITLE
windows: don't depend on Bash

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -185,7 +185,6 @@ common --noremote_upload_local_results # Uploads logs & artifacts without writin
 # Populate workspace info like commit sha and repo name to your invocation.
 common:linux --workspace_status_command=$(pwd)/workspace_status.sh
 common:macos --workspace_status_command=$(pwd)/workspace_status.sh
-common:windows --workspace_status_command="bash workspace_status.sh"
 
 # Misc remote cache/BES optimizations
 common --experimental_remote_cache_async

--- a/enterprise/server/cmd/ci_runner/bundle/BUILD
+++ b/enterprise/server/cmd/ci_runner/bundle/BUILD
@@ -12,6 +12,7 @@ genrule(
     srcs = ["//enterprise/server/cmd/ci_runner"],
     outs = ["buildbuddy_ci_runner"],
     cmd_bash = "cp $(SRCS) $@",
+    cmd_ps = "Copy-Item -Path $(SRCS) -Destination $@",
 )
 
 go_library(

--- a/enterprise/server/cmd/github_actions_runner/bundle/BUILD
+++ b/enterprise/server/cmd/github_actions_runner/bundle/BUILD
@@ -7,6 +7,7 @@ genrule(
     srcs = ["//enterprise/server/cmd/github_actions_runner"],
     outs = [":buildbuddy_github_actions_runner"],
     cmd_bash = "cp $(SRCS) $@",
+    cmd_ps = "Copy-Item -Path $(SRCS) -Destination $@",
 )
 
 # Gazelle does not handle generated embedsrcs properly; ignore this target for now.

--- a/server/util/bazelisk/BUILD
+++ b/server/util/bazelisk/BUILD
@@ -9,6 +9,7 @@ genrule(
     }),
     outs = ["bazelisk-1.17.0"],
     cmd_bash = "cp $(SRCS) $@",
+    cmd_ps = "Copy-Item -Path $(SRCS) -Destination $@",
     visibility = ["//visibility:public"],
 )
 

--- a/server/version/BUILD
+++ b/server/version/BUILD
@@ -10,6 +10,7 @@ genrule(
             printf '%s' $$version > $@;
         """,
     }),
+    cmd_ps = "echo $$null >> $@",
     stamp = 1,
 )
 
@@ -23,6 +24,7 @@ genrule(
             printf '%s' $$commit > $@;
         """,
     }),
+    cmd_ps = "echo $$null >> $@",
     stamp = 1,
 )
 


### PR DESCRIPTION
On Windows, `bash` is available through WSL. However WSL is only
available on host machines with Hyper-V and Virtualization enabled.

Instead of relying on `bash` to be available for our Windows build,
simply use PowerShell wherever possible.
