### PR TITLE
Add flag to skip Contains() check in bytestream.Write if file is small.

### DIFF
--- a/server/remote_cache/byte_stream_server/BUILD
+++ b/server/remote_cache/byte_stream_server/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//server/util/bytebufferpool",
         "//server/util/capabilities",
         "//server/util/compression",
+        "//server/util/flag",
         "//server/util/ioutil",
         "//server/util/log",
         "//server/util/prefix",

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"runtime/debug"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -35,7 +35,7 @@ const (
 
 var (
 	bazel5_1_0             = bazel_request.MustParseVersion("5.1.0")
-	maxSizeForDirectWrites = flag.Int64("cache.max_direct_write_size", 0, "For bytestream requests smaller than this size, write straight to the cache without checking if the entry already exists.")
+	maxDirectWriteSizeBytes = flag.Int64("cache.max_direct_write_size_bytes", 0, "For bytestream requests smaller than this size, write straight to the cache without checking if the entry already exists.")
 )
 
 type ByteStreamServer struct {
@@ -259,7 +259,7 @@ func (s *ByteStreamServer) initStreamState(ctx context.Context, req *bspb.WriteR
 		casRN.SetCompressor(r.GetCompressor())
 	}
 
-	if r.GetDigest().GetSizeBytes() >= *maxSizeForDirectWrites {
+	if r.GetDigest().GetSizeBytes() >= *maxDirectWriteSizeBytes {
 		// The protocol says it is *optional* to allow overwriting, but does
 		// not specify what errors should be returned in that case. We would
 		// like to return an "AlreadyExists" error here, but it causes errors

--- a/server/remote_cache/byte_stream_server/byte_stream_server.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server.go
@@ -34,7 +34,7 @@ const (
 )
 
 var (
-	bazel5_1_0             = bazel_request.MustParseVersion("5.1.0")
+	bazel5_1_0              = bazel_request.MustParseVersion("5.1.0")
 	maxDirectWriteSizeBytes = flag.Int64("cache.max_direct_write_size_bytes", 0, "For bytestream requests smaller than this size, write straight to the cache without checking if the entry already exists.")
 )
 

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -196,7 +196,7 @@ func TestRPCWrite(t *testing.T) {
 }
 
 func TestRPCWriteWithDirectWrite(t *testing.T) {
-	flags.Set(t, "cache.max_direct_write_size", 1024)
+	flags.Set(t, "cache.max_direct_write_size_bytes", 1024)
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)
 	clientConn := runByteStreamServer(ctx, te, t)

--- a/server/remote_cache/byte_stream_server/byte_stream_server_test.go
+++ b/server/remote_cache/byte_stream_server/byte_stream_server_test.go
@@ -195,6 +195,26 @@ func TestRPCWrite(t *testing.T) {
 	}
 }
 
+func TestRPCWriteWithDirectWrite(t *testing.T) {
+	flags.Set(t, "cache.max_direct_write_size", 1024)
+	ctx := context.Background()
+	te := testenv.GetTestEnv(t)
+	clientConn := runByteStreamServer(ctx, te, t)
+	bsClient := bspb.NewByteStreamClient(clientConn)
+
+	// This file is small enough that we'll skip the Contains check.
+	d, readSeeker := testdigest.NewRandomDigestReader(t, 1000)
+	instanceNameDigest := digest.NewResourceName(d, "", rspb.CacheType_CAS, repb.DigestFunction_SHA256)
+	_, err := cachetools.UploadFromReader(ctx, bsClient, instanceNameDigest, readSeeker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = cachetools.UploadFromReader(ctx, bsClient, instanceNameDigest, readSeeker)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRPCMalformedWrite(t *testing.T) {
 	ctx := context.Background()
 	te := testenv.GetTestEnv(t)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
When writes are small, traces look like this:
![image](https://github.com/buildbuddy-io/buildbuddy/assets/10570856/aad1548c-e90c-4d63-952d-41e88773ac40)
small writes (which are most writes) should get a 75% drop in latency, and current AlreadyExists rates imply this shouldn't increase load.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
