### PR TITLE
Tweaks to vmexec client tool

### DIFF
--- a/enterprise/tools/vmexec/BUILD
+++ b/enterprise/tools/vmexec/BUILD
@@ -3,15 +3,17 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_binary(
-    name = "vmexec_client",
-    embed = [":vmexec_client_lib"],
+    name = "vmexec",
+    embed = [":vmexec_lib"],
+    pure = "on",
+    static = "on",
     visibility = ["//visibility:public"],
 )
 
 go_library(
-    name = "vmexec_client_lib",
-    srcs = ["vmexec_client.go"],
-    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/tools/vmexec_client",
+    name = "vmexec_lib",
+    srcs = ["vmexec.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/tools/vmexec",
     visibility = ["//visibility:private"],
     deps = [
         "//enterprise/server/util/vsock",

--- a/enterprise/tools/vmexec/vmexec.go
+++ b/enterprise/tools/vmexec/vmexec.go
@@ -1,11 +1,22 @@
-// vmexec_client connects over the specified VSock and sends commands to the listening vmexec server.
+// vmexec connects over the specified VSock and sends commands to the listening vmexec server.
+//
+// To run it on a live executor pod:
+//
+// $ bazel build enterprise/tools/vmexec
+// $ kubectl cp ./bazel-bin/tools/vmexec/vmexec_/vmexec executor-prod/executor-abc-123:/usr/local/bin/vmexec
+// $ kubectl exec -n executor-prod executor-abc-123 -- bash
+// # vmexec -sock=/buildbuddy/remotebuilds/firecracker/{vmid}/root/run/v.sock sh -c 'echo hello'
+//
+// To see the VMIDs of all currently running VMs, run:
+// $ ps aux | grep /firecracker
+//
+// The "--id" arg in the firecracker process command line is the VM ID.
 package main
 
 import (
 	"context"
 	"flag"
 	"os"
-	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/vsock"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -15,7 +26,6 @@ import (
 
 var (
 	sock             = flag.String("sock", "", "Vsock host socket path")
-	cmd              = flag.String("cmd", "pwd", "Command to run")
 	path             = flag.String("path", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "The path to use when executing cmd")
 	workingDirectory = flag.String("working_directory", "/", "Working directory to run command from")
 )
@@ -23,6 +33,10 @@ var (
 func main() {
 	ctx := context.Background()
 	flag.Parse()
+
+	if len(flag.Args()) == 0 {
+		log.Fatalf("Missing command. Example: vmexec -sock=/path/to/v.sock sh -c 'echo hello'")
+	}
 
 	conn, err := vsock.SimpleGRPCDial(ctx, *sock, vsock.VMExecPort)
 	if err != nil {
@@ -32,7 +46,7 @@ func main() {
 
 	execClient := vmxpb.NewExecClient(conn)
 	rsp, err := execClient.Exec(ctx, &vmxpb.ExecRequest{
-		Arguments:        strings.Split(*cmd, " "),
+		Arguments:        flag.Args(),
 		WorkingDirectory: *workingDirectory,
 		EnvironmentVariables: []*vmxpb.ExecRequest_EnvironmentVariable{
 			{


### PR DESCRIPTION
- Make it statically linked so we can easily copy it to the executor pod
- Add comments about how to use it to debug a live executor pod
- Shorten the name to `vmexec` - feels a bit more convenient when running it at the command line
- Improve arg parsing to allow running shell scripts

**Related issues**: N/A
