### PR TITLE
Extend finalization deadline for pausing firecracker VMs

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -91,7 +91,7 @@ const (
 	// How long to spend waiting for a runner to be removed before giving up.
 	runnerCleanupTimeout = 30 * time.Second
 	// Allowed time to spend trying to pause a runner and add it to the pool.
-	runnerRecycleTimeout = 30 * time.Second
+	runnerRecycleTimeout = 3 * time.Minute
 	// How long to spend waiting for a persistent worker process to terminate
 	// after we send the shutdown signal before giving up.
 	persistentWorkerShutdownTimeout = 10 * time.Second


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

#6345 fixed a bug where in many cases, ExtendContextForFinalization would extend the context deadline ~indefinitely (7 days, to be specific). Now that it's fixed, certain code paths are failing because the finalization deadlines we'd set are too short

P99 to pause a firecracker VM takes 1.5min. Setting the deadline to 3min to be safe (P95 frequently reaches 1.5min as well)

**Related issues**: N/A
