### PR TITLE
Lock VM host network IP ranges while in use

### DIFF
--- a/server/util/networking/BUILD
+++ b/server/util/networking/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "networking",
@@ -10,5 +10,15 @@ go_library(
         "//server/util/random",
         "//server/util/status",
         "@org_golang_x_sys//unix",
+    ],
+)
+
+go_test(
+    name = "networking_test",
+    srcs = ["networking_test.go"],
+    deps = [
+        ":networking",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/util/networking/networking_test.go
+++ b/server/util/networking/networking_test.go
@@ -1,0 +1,51 @@
+package networking_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/networking"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostNetAllocator(t *testing.T) {
+	const n = 1000
+	a := &networking.HostNetAllocator{}
+	var nets [n]*networking.HostNet
+	var err error
+	uniqueCIDRs := map[string]struct{}{}
+
+	// Reserve all possible CIDRs
+	for vmIdx := 0; vmIdx < n; vmIdx++ {
+		nets[vmIdx], err = a.Get(vmIdx)
+		require.NoError(t, err, "Get(%d)", vmIdx)
+		uniqueCIDRs[nets[vmIdx].String()] = struct{}{}
+	}
+
+	// All CIDRs should be unique
+	require.Equal(t, n, len(uniqueCIDRs))
+
+	// Spot check some CIDRs for expected values
+	assert.Equal(t, "192.168.0.5/30", nets[0].String())
+	assert.Equal(t, "192.168.0.13/30", nets[1].String())
+	assert.Equal(t, "192.168.33.69/30", nets[n-2].String())
+	assert.Equal(t, "192.168.33.77/30", nets[n-1].String())
+
+	// Attempting to get a new host net should now fail
+	for vmIdx := 0; vmIdx < n; vmIdx++ {
+		net, err := a.Get(vmIdx)
+		require.Error(t, err)
+		require.Nil(t, net)
+	}
+
+	// Unlock an arbitrary network - subsequent Get() for any index should then
+	// return the newly unlocked address
+	vmIdx := rand.Intn(n)
+	unlockedAddr := nets[vmIdx].String()
+	nets[vmIdx].Unlock()
+
+	net, err := a.Get(rand.Intn(n))
+	require.NoError(t, err)
+	require.Equal(t, unlockedAddr, net.String())
+}


### PR DESCRIPTION
This just locks IP ranges within a single executor process for now - a future improvement would be to lock across executors as well so that we can run VM networking tests in parallel.

**Related issues**: N/A
