### PR TITLE
Bust local snapshot cache to fix fastcopy_test

### DIFF
--- a/server/util/fastcopy/BUILD
+++ b/server/util/fastcopy/BUILD
@@ -30,7 +30,7 @@ go_test(
     exec_properties = {
         "test.workload-isolation-type": "firecracker",
         "test.recycle-runner": "true",
-        "test.runner-recycling-key": "fastcopy_test",
+        "test.runner-recycling-key": "fastcopy_test/1",
     },
     tags = ["docker"],
     deps = [


### PR DESCRIPTION
VM seems to have gotten into a bad state: https://buildbuddy.buildbuddy.io/invocation/7f05de69-ac23-4481-9f2e-e0fe6b6806b0?target=%2F%2Fserver%2Futil%2Ffastcopy%3Afastcopy_test&targetStatus=6

**Related issues**: N/A
