### PR TITLE
Only return EOF in cache proxy if a more descriptive error is not available

### DIFF
--- a/enterprise/server/util/cacheproxy/cacheproxy.go
+++ b/enterprise/server/util/cacheproxy/cacheproxy.go
@@ -633,7 +633,7 @@ func (wc *streamWriteCloser) Commit() error {
 	if status.IsAlreadyExistsError(err) {
 		return nil
 	}
-	if sendErr != nil {
+	if err == nil && sendErr != nil {
 		return sendErr
 	}
 	return err


### PR DESCRIPTION
If we enter this if block, sendErr will always be `EOF` (due to the block at L629). There may be a more descriptive error in `err` which we should return instead

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: Came upon this debugging https://github.com/buildbuddy-io/buildbuddy-internal/issues/3263
