### PR TITLE
Use block-based size for filecache entry size

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -1021,7 +1021,7 @@ func TestFirecrackerComplexFileMapping(t *testing.T) {
 		}
 	}
 
-	workspaceDirSize, err := disk.DirSize(rootDir)
+	workspaceDirSize, err := ext4.DiskSizeBytes(ctx, rootDir)
 	require.NoError(t, err)
 
 	cmd := &repb.Command{

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -258,14 +258,14 @@ func (c *fileCache) addFileToGroup(groupID string, node *repb.FileNode, existing
 	// which is not good.
 	k := groupSpecificKey(groupID, node)
 
-	sizeOnDisk := node.GetDigest().GetSizeBytes()
 	info, err := os.Stat(existingFilePath)
 	if err != nil {
 		return status.WrapError(err, "stat")
 	}
-	// Stat always returns number of 512 byte blocks, regardless of the FS
-	// settings.
-	sizeOnDisk = info.Sys().(*syscall.Stat_t).Blocks * 512
+	sizeOnDisk, err := disk.EstimatedFileDiskUsage(info)
+	if err != nil {
+		return status.WrapError(err, "estimate disk usage")
+	}
 
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/enterprise/server/remote_execution/filecache/filecache.go
+++ b/enterprise/server/remote_execution/filecache/filecache.go
@@ -164,24 +164,21 @@ func (c *fileCache) nodeFromPathAndSize(fullPath string, sizeBytes int64) (strin
 }
 
 func (c *fileCache) scanDir() {
-	scanCount := 0
+	dirCount := 0
+	fileCount := 0
 	scanStart := time.Now()
 	walkFn := func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		scanCount += 1
 		if d.IsDir() {
+			dirCount += 1
 			return nil
 		}
-		info, err := d.Info()
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return err
-		}
-		groupID, node, err := c.nodeFromPathAndSize(path, info.Size())
+		fileCount += 1
+		// addFileToGroup uses the physical size, not the digest size, so just
+		// pass 0 for size here.
+		groupID, node, err := c.nodeFromPathAndSize(path, 0)
 		if err != nil {
 			return err
 		}
@@ -194,7 +191,7 @@ func (c *fileCache) scanDir() {
 	lruSize := c.l.Size()
 	c.lock.Unlock()
 
-	log.Infof("filecache(%q) scanned %d files in %s. Total tracked bytes: %d", c.rootDir, scanCount, time.Since(scanStart), lruSize)
+	log.Infof("filecache(%q) scanned %d dirs, %d files in %s. Total tracked bytes: %d", c.rootDir, dirCount, fileCount, time.Since(scanStart), lruSize)
 	close(c.dirScanDone)
 }
 
@@ -261,6 +258,15 @@ func (c *fileCache) addFileToGroup(groupID string, node *repb.FileNode, existing
 	// which is not good.
 	k := groupSpecificKey(groupID, node)
 
+	sizeOnDisk := node.GetDigest().GetSizeBytes()
+	info, err := os.Stat(existingFilePath)
+	if err != nil {
+		return status.WrapError(err, "stat")
+	}
+	// Stat always returns number of 512 byte blocks, regardless of the FS
+	// settings.
+	sizeOnDisk = info.Sys().(*syscall.Stat_t).Blocks * 512
+
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -276,7 +282,7 @@ func (c *fileCache) addFileToGroup(groupID string, node *repb.FileNode, existing
 	}
 	e := &entry{
 		addedAtUsec: time.Now().UnixMicro(),
-		sizeBytes:   node.GetDigest().GetSizeBytes(),
+		sizeBytes:   sizeOnDisk,
 		value:       fp,
 	}
 	metrics.FileCacheAddedFileSizeBytes.Observe(float64(e.sizeBytes))

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -333,7 +333,9 @@ func BenchmarkFilecacheLink(b *testing.B) {
 			tmp := fc.TempDir()
 
 			// Create 1K small files. Use UniformRandomGenerator to ensure
-			// uniqueness.
+			// uniqueness, otherwise Add() may result in temporary eviction
+			// which can cause the test to fail. (In practice, this eviction is
+			// fine/expected).
 			g := digest.UniformRandomGenerator(0)
 			var nodes []*repb.FileNode
 			for i := 0; i < test.Ops; i++ {

--- a/enterprise/server/remote_execution/filecache/filecache_test.go
+++ b/enterprise/server/remote_execution/filecache/filecache_test.go
@@ -239,6 +239,79 @@ func TestFileCacheOverwrite(t *testing.T) {
 	}
 }
 
+func TestFileCacheEviction(t *testing.T) {
+	ctx := context.Background()
+	// For now just assume the disk block size is 4096
+	const fsBlockSize = 4096
+	// Create a filecache that can only fit 1 physical block
+	filecacheRoot := testfs.MakeTempDir(t)
+	fc, err := filecache.NewFileCache(filecacheRoot, fsBlockSize, false)
+	require.NoError(t, err)
+	fc.WaitForDirectoryScanToComplete()
+	tempDir := fc.TempDir()
+
+	node1 := nodeFromString("A", false)
+	node2 := nodeFromString("B", false)
+	// Write a file that takes up 1 block, containing 1 byte
+	{
+		writeFileContent(t, tempDir, "file1", "A", false)
+		err := fc.AddFile(ctx, node1, filepath.Join(tempDir, "file1"))
+		require.NoError(t, err)
+		linked := fc.FastLinkFile(ctx, node1, filepath.Join(tempDir, "file1-link1"))
+		require.True(t, linked)
+	}
+	// Write a different file that takes up 1 block, containing 1 byte
+	{
+		writeFileContent(t, tempDir, "file2", "B", false)
+		err := fc.AddFile(ctx, node2, filepath.Join(tempDir, "file2"))
+		require.NoError(t, err)
+		linked := fc.FastLinkFile(ctx, node2, filepath.Join(tempDir, "file2-link1"))
+		require.True(t, linked)
+	}
+	// The first file should now be evicted, so linking it should fail.
+	{
+		linked := fc.FastLinkFile(ctx, node1, filepath.Join(tempDir, "file1-link2"))
+		require.False(t, linked)
+	}
+}
+
+func TestFileCacheEvictionAfterStartupScan(t *testing.T) {
+	ctx := context.Background()
+	// For now just assume the disk block size is 4096
+	const fsBlockSize = 4096
+	// Create a filecache that can fit 1 physical block plus one byte.
+	// Initialize it with a file that takes up 1 block, containing 1 byte.
+	filecacheRoot := testfs.MakeTempDir(t)
+	writeFileContent(t, filecacheRoot, "ANON/"+hash.String("A"), "A", false)
+	fc, err := filecache.NewFileCache(filecacheRoot, fsBlockSize+1, false)
+	require.NoError(t, err)
+	fc.WaitForDirectoryScanToComplete()
+	tempDir := fc.TempDir()
+
+	node1 := nodeFromString("A", false)
+	node2 := nodeFromString("B", false)
+	// Linking node1 should succeed
+	{
+		linked := fc.FastLinkFile(ctx, node1, filepath.Join(tempDir, "file1-link1"))
+		require.True(t, linked)
+	}
+	// Write a different file that takes up 1 block, containing 1 byte
+	{
+		writeFileContent(t, tempDir, "file2", "B", false)
+		err := fc.AddFile(ctx, node2, filepath.Join(tempDir, "file2"))
+		require.NoError(t, err)
+		linked := fc.FastLinkFile(ctx, node2, filepath.Join(tempDir, "file2-link1"))
+		require.True(t, linked)
+	}
+	// The first file should now be evicted, so linking it should fail. If the
+	// startup scan incorrectly used content size rather than size on disk, this
+	// test would fail, since the cache has 4097 bytes of capacity.
+	{
+		linked := fc.FastLinkFile(ctx, node1, filepath.Join(tempDir, "file1-link2"))
+		require.False(t, linked)
+	}
+}
+
 func BenchmarkFilecacheLink(b *testing.B) {
 	ctx := context.TODO()
 	flags.Set(b, "app.log_level", "warn")
@@ -249,23 +322,24 @@ func BenchmarkFilecacheLink(b *testing.B) {
 		Ops          int
 		ReadFraction float64
 	}{
-		{Name: "100%Link/0%Add/5K", Ops: 5000, ReadFraction: 1},
-		{Name: "95%Link/5%Add/5K", Ops: 5000, ReadFraction: 0.95},
+		{Name: "100%Link/0%Add/1K", Ops: 1000, ReadFraction: 1},
+		{Name: "95%Link/5%Add/1K", Ops: 1000, ReadFraction: 0.95},
 	} {
 		b.Run(test.Name, func(b *testing.B) {
 			root := testfs.MakeTempDir(b)
-			fc, err := filecache.NewFileCache(root, 1_000_000, false /*=delete*/)
+			fc, err := filecache.NewFileCache(testfs.MakeDirAll(b, root, "cache"), 100_000_000, false /*=delete*/)
 			require.NoError(b, err)
 			fc.WaitForDirectoryScanToComplete()
 			tmp := fc.TempDir()
 
-			// Create 1K small files
-			g := digest.RandomGenerator(0)
+			// Create 1K small files. Use UniformRandomGenerator to ensure
+			// uniqueness.
+			g := digest.UniformRandomGenerator(0)
 			var nodes []*repb.FileNode
 			for i := 0; i < test.Ops; i++ {
 				d, buf, err := g.RandomDigestBuf(20)
 				require.NoError(b, err)
-				name := fmt.Sprint(i)
+				name := fmt.Sprintf("file_%d", i)
 				path := filepath.Join(tmp, name)
 				err = os.WriteFile(path, buf, 0644)
 				require.NoError(b, err)
@@ -278,10 +352,15 @@ func BenchmarkFilecacheLink(b *testing.B) {
 				require.NoError(b, err)
 			}
 
+			var outDirs []string
+			for i := 0; i < b.N; i++ {
+				outDirs = append(outDirs, testfs.MakeDirAll(b, root, fmt.Sprintf("outdir_%d", i)))
+			}
+
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				// Fast link all of the files we created
-				out := testfs.MakeTempDir(b)
+				out := outDirs[i]
 				eg := &errgroup.Group{}
 				eg.SetLimit(100)
 				for _, node := range nodes {
@@ -290,7 +369,7 @@ func BenchmarkFilecacheLink(b *testing.B) {
 						if rand.Float64() > test.ReadFraction {
 							err := fc.AddFile(ctx, node, filepath.Join(tmp, node.GetName()))
 							if err != nil {
-								require.FailNowf(b, "fast link failed", "%s", err)
+								require.FailNowf(b, "add failed", "%s", err)
 							}
 							return nil
 						}
@@ -301,6 +380,9 @@ func BenchmarkFilecacheLink(b *testing.B) {
 						}
 						return nil
 					})
+					if b.Failed() {
+						break
+					}
 				}
 				eg.Wait()
 			}

--- a/server/util/disk/disk_windows.go
+++ b/server/util/disk/disk_windows.go
@@ -4,7 +4,9 @@ package disk
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"golang.org/x/sys/windows"
 )
 
@@ -24,4 +26,14 @@ func GetDirUsage(path string) (*DirUsage, error) {
 		FreeBytes:  totalNumberOfFreeBytes,
 		AvailBytes: freeBytesAvailableToCaller,
 	}, nil
+}
+
+// EstimatedFileDiskUsage returns an estimate of the disk usage required for
+// the given regular file info.
+func EstimatedFileDiskUsage(info os.FileInfo) (int64, error) {
+	if !info.Mode().IsRegular() {
+		return 0, status.InvalidArgumentError("not a regular file")
+	}
+	// TODO: figure out something better for Windows.
+	return info.Size(), nil
 }


### PR DESCRIPTION
When calling `AddFile`, stat the file to get the number of blocks consumed by the file, and compute the size based on the number of blocks consumed, rather than the content stored in the blocks. The extra `stat()` syscall does not significantly affect performance according to benchmarks:

```
goos: linux
goarch: amd64
cpu: AMD Ryzen 9 7950X 16-Core Processor            
                                   │ /tmp/bench_false.txt │        /tmp/bench_true.txt         │
                                   │        sec/op        │   sec/op     vs base               │
FilecacheLink/100%Link/0%Add/1K-32            15.52m ± 1%   15.57m ± 1%       ~ (p=0.631 n=10)
FilecacheLink/95%Link/5%Add/1K-32             14.77m ± 2%   14.75m ± 3%       ~ (p=0.436 n=10)
geomean                                       15.14m        15.15m       +0.07%
```

A future improvement could be to also account for the file metadata, not just the file contents. But just computing the block-based size should be good enough for now.

**Related issues**:
* Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/3300
* Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/3248
