### PR TITLE
Clean up deprecated remote_execution.VMMetadata field

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -399,7 +399,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
   private getFirecrackerVMMetadata(): firecracker.VMMetadata | null | undefined {
     const auxiliaryMetadata = this.state.actionResult?.executionMetadata?.auxiliaryMetadata;
     if (!auxiliaryMetadata || auxiliaryMetadata.length == 0) {
-      return this.getDeprecatedFirecrackerVMMetadata();
+      return null;
     }
     for (const metadata of auxiliaryMetadata) {
       if (metadata.typeUrl === "type.googleapis.com/firecracker.VMMetadata") {
@@ -407,19 +407,6 @@ export default class InvocationActionCardComponent extends React.Component<Props
       }
     }
     return null;
-  }
-
-  // TODO(Maggie): Clean up after #6341 has been rolled out
-  private getDeprecatedFirecrackerVMMetadata(): firecracker.VMMetadata | null | undefined {
-    const deprecatedVMMetadata = this.state.actionResult?.executionMetadata?.vmMetadata;
-    if (!deprecatedVMMetadata) {
-      return null;
-    }
-    const vmMetadata = new firecracker.VMMetadata();
-    vmMetadata.vmId = deprecatedVMMetadata?.vmId;
-    vmMetadata.snapshotId = deprecatedVMMetadata.snapshotId;
-    vmMetadata.lastExecutedTask = deprecatedVMMetadata.lastExecutedTask;
-    return vmMetadata;
   }
 
   private getVMPreviousTaskHref(): string {

--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -458,31 +458,11 @@ func (l *FileCacheLoader) actionResultToManifest(ctx context.Context, remoteInst
 		return nil, status.WrapErrorf(err, "unmarshall vm config")
 	}
 
-	// TODO(Maggie): Clean this up after #6341 has been rolled out
 	var vmMetadata *fcpb.VMMetadata
 	if len(snapMetadata) == 2 {
 		vmMetadata = &fcpb.VMMetadata{}
 		if err := snapMetadata[1].UnmarshalTo(vmMetadata); err != nil {
 			return nil, status.WrapErrorf(err, "unmarshall vm metadata")
-		}
-	} else {
-		reMetadata := snapshotActionResult.GetExecutionMetadata().GetVmMetadata()
-		if reMetadata != nil {
-			var lastTask *fcpb.VMMetadata_VMTask
-			if reMetadata.LastExecutedTask != nil {
-				lastTask = &fcpb.VMMetadata_VMTask{
-					InvocationId:          reMetadata.LastExecutedTask.InvocationId,
-					ExecutionId:           reMetadata.LastExecutedTask.ExecutionId,
-					ActionDigest:          reMetadata.LastExecutedTask.ActionDigest,
-					ExecuteResponseDigest: reMetadata.LastExecutedTask.ExecuteResponseDigest,
-					SnapshotId:            reMetadata.LastExecutedTask.SnapshotId,
-				}
-			}
-			vmMetadata = &fcpb.VMMetadata{
-				VmId:             reMetadata.VmId,
-				LastExecutedTask: lastTask,
-				SnapshotId:       reMetadata.SnapshotId,
-			}
 		}
 	}
 

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -1057,9 +1057,7 @@ message ExecutedActionMetadata {
   // Whether the executed Action was marked with `do_not_cache`.
   bool do_not_cache = 1004;
 
-  // TODO(Maggie): Deprecate after #6341 goes out
-  // Metadata associated with the VM that this action was executed on.
-  VMMetadata vm_metadata = 1005;
+  reserved 1005;
 }
 
 // An ActionResult represents the result of an
@@ -2278,44 +2276,4 @@ message StoredExecution {
   
   int32 status_code = 29;
   int32 exit_code = 30;
-}
-
-// TODO(Maggie): Deprecate after #6341 goes out
-// Metadata associated with a firecracker VM.
-message VMMetadata {
-  // A UUID assigned to the VM upon creation which is preserved across
-  // snapshots.
-  string vm_id = 1;
-
-  // Represents a task executed on this VM.
-  message VMTask {
-    // The task's invocation ID. If multiple invocations are associated with the
-    // task (via action merging) then this will be the first invocation to have
-    // requested execution of this task.
-    string invocation_id = 1;
-
-    // The task's execution ID.
-    string execution_id = 2;
-
-    // The action digest associated with the task. The digest function used to
-    // compute the digest should match the one associated with the invocation.
-    Digest action_digest = 3;
-
-    // The digest of the execution ID, used as the AC key for the stored
-    // ExecuteResponse. The digest function used to compute the digest should
-    // match the one associated with the invocation.
-    Digest execute_response_digest = 4;
-
-    // A unique UUID assigned each time a snapshot is used.
-    // For example, even if the same execution is retried multiple times using
-    // the same snapshot key, each run will have a unqiue snapshot_id.
-    string snapshot_id = 5;
-  }
-
-  // The last task to execute on this VM. When resuming from snapshot, this
-  // represents the task which created the snapshot.
-  VMTask last_executed_task = 2;
-
-  // The snapshot ID of the task that is currently executing.
-  string snapshot_id = 3;
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy/pull/6341
