### PR TITLE
Use "..." for truncated execution status messages

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -241,7 +241,7 @@ func (s *ExecutionServer) insertInvocationLinkInRedis(ctx context.Context, execu
 
 func trimStatus(statusMessage string) string {
 	if len(statusMessage) > 255 {
-		return statusMessage[:255]
+		return statusMessage[:252] + "..."
 	}
 	return statusMessage
 }


### PR DESCRIPTION
Truncate the `Execution` table `status_message` column with ellipsis (it currently looks a little awkward when rendered in the UI).

**Related issues**: N/A
