### PR TITLE
Small clean-up of build event handler logic

### DIFF
--- a/server/build_event_protocol/build_event_server/build_event_server.go
+++ b/server/build_event_protocol/build_event_server/build_event_server.go
@@ -159,7 +159,7 @@ func (s *BuildEventProtocolServer) PublishBuildToolEventStream(stream pepb.Publi
 				streamID = in.OrderedBuildEvent.StreamId
 				ctx = log.EnrichContext(ctx, log.InvocationIDKey, streamID.InvocationId)
 				channel = s.env.GetBuildEventHandler().OpenChannel(ctx, streamID.InvocationId)
-				log.CtxInfof(ctx, "Opened a channel for stream ID %s.", streamID)
+				log.CtxInfo(ctx, "Opened invocation channel")
 				channelDone = channel.Context().Done()
 				defer channel.Close()
 			}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

Small refactor primarily to try to improve readability.

- Added some logging.

- Did a small refactor to not attempt to process an empty channel.

- Removed an error case that cannot occur (there is no way that we can return `AlreadyExistsError` from `HandleEvent`).

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
