### PR TITLE
Require `http(s)://` prefix to render links

### DIFF
--- a/app/terminal/ansi.tsx
+++ b/app/terminal/ansi.tsx
@@ -153,7 +153,7 @@ export default function parseAnsi(text: string): AnsiTextSpan[] {
   return linkSpans;
 }
 
-const LINK_REGEX = /(http(s)?:\/\/)?(www\.)?([-a-zA-Z0-9@:%._\+~#=]{2,256})(\.[a-z]{2,6}|:[0-9]+)\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g;
+const LINK_REGEX = /(http(s)?:\/\/)(www\.)?([-a-zA-Z0-9@:%._\+~#=]{2,256})(\.[a-z]{2,6}|:[0-9]+)\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g;
 
 function parseLinks(span: AnsiTextSpan): AnsiTextSpan[] {
   let matches = [...span.text.matchAll(LINK_REGEX)];


### PR DESCRIPTION
We can relax this later, but the current regex is a bit too lenient and is rendering links all over the place.