### PR TITLE
[raft] refactor: move pass db and leaser into NewWithArgs

### DIFF
--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -70,6 +70,7 @@ go_test(
         "//enterprise/server/raft/registry",
         "//enterprise/server/raft/replica",
         "//enterprise/server/raft/sender",
+        "//enterprise/server/util/pebble",
         "//proto:raft_go_proto",
         "//server/gossip",
         "//server/testutil/testdigest",


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Move db, leaser creation out of NewWithArgs, so in tests we are able to write stuff to pebble. 

also flush the db and close the leaser on stop()

