### PR TITLE
Roll-forward "Fix ext4 DirectoryToImageAutoSize not working for some images (#6380)"

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1220,7 +1220,7 @@ func (c *FirecrackerContainer) createWorkspaceImage(ctx context.Context, workspa
 			return err
 		}
 	} else {
-		workspaceSizeBytes, err := disk.DirSize(workspaceDir)
+		workspaceSizeBytes, err := ext4.DiskSizeBytes(ctx, workspaceDir)
 		if err != nil {
 			return err
 		}

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -1089,10 +1089,12 @@ func TestFirecrackerComplexFileMapping(t *testing.T) {
 			10_000_000,
 			"used workspace disk size")
 		expectedTotalSize := ext4.MinDiskImageSizeBytes + workspaceDirSize + workspaceDiskSlackSpaceBytes
+		// 5% of blocks are reserved.
+		expectedTotalSize = int64(float64(expectedTotalSize) * 0.95)
 		assert.InDelta(
 			t, expectedTotalSize, workspaceFSU.GetTotalBytes(),
-			60_000_000,
-			"total workspace disk size")
+			40_000_000,
+			"total workspace disk size (expected %d)", expectedTotalSize)
 	}
 	if rootFSU == nil {
 		assert.Fail(t, "root (/) disk usage was not reported")

--- a/enterprise/server/util/ext4/BUILD
+++ b/enterprise/server/util/ext4/BUILD
@@ -20,7 +20,6 @@ go_library(
 go_test(
     name = "ext4_test",
     srcs = ["ext4_test.go"],
-    tags = ["manual"],  # This won't work on mac.
     target_compatible_with = ["@platforms//os:linux"],
     deps = select({
         "@io_bazel_rules_go//go/platform:linux": [
@@ -30,6 +29,7 @@ go_test(
             "//server/testutil/testdigest",
             "//server/testutil/testfs",
             "//server/util/disk",
+            "@com_github_stretchr_testify//require",
         ],
         "//conditions:default": [],
     }),

--- a/enterprise/server/util/ext4/BUILD
+++ b/enterprise/server/util/ext4/BUILD
@@ -6,23 +6,31 @@ go_library(
     name = "ext4",
     srcs = ["ext4.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ext4",
-    deps = [
-        "//server/util/log",
-        "//server/util/status",
-        "//server/util/tracing",
-    ],
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//server/util/log",
+            "//server/util/status",
+            "//server/util/tracing",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 go_test(
     name = "ext4_test",
     srcs = ["ext4_test.go"],
     tags = ["manual"],  # This won't work on mac.
-    deps = [
-        ":ext4",
-        "//proto:remote_execution_go_proto",
-        "//server/remote_cache/digest",
-        "//server/testutil/testdigest",
-        "//server/testutil/testfs",
-        "//server/util/disk",
-    ],
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:linux": [
+            ":ext4",
+            "//proto:remote_execution_go_proto",
+            "//server/remote_cache/digest",
+            "//server/testutil/testdigest",
+            "//server/testutil/testfs",
+            "//server/util/disk",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/enterprise/server/util/ext4/ext4.go
+++ b/enterprise/server/util/ext4/ext4.go
@@ -1,13 +1,16 @@
+//go:build linux && !android
+
 package ext4
 
 import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
-	"strconv"
-	"strings"
+	"path/filepath"
+	"syscall"
 
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
@@ -18,10 +21,13 @@ const (
 	// MinDiskImageSizeBytes is the approximate minimum size needed for an ext4
 	// image. The functions in this package which create disk images will fail
 	// if the provided size is any smaller.
-	MinDiskImageSizeBytes = 225e3
+	MinDiskImageSizeBytes = 225 * iecKilobyte
 
 	// The number of bytes in one IEC kilobyte (K).
 	iecKilobyte = 1024
+
+	// FS block size that we always use when creating ext4 images.
+	blockSize = 4096
 )
 
 // DirectoryToImage creates an ext4 image of the specified size from inputDir
@@ -42,10 +48,10 @@ func DirectoryToImage(ctx context.Context, inputDir, outputFile string, sizeByte
 		"-d", inputDir,
 		"-m", "5",
 		"-r", "1",
-		"-b", "4096",
+		"-b", fmt.Sprintf("%d", blockSize),
 		"-t", "ext4",
 		outputFile,
-		fmt.Sprintf("%dK", sizeBytes/1e3),
+		fmt.Sprintf("%dK", sizeBytes/iecKilobyte),
 	}
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -72,10 +78,10 @@ func MakeEmptyImage(ctx context.Context, outputFile string, sizeBytes int64) err
 		"-O", "^64bit",
 		"-m", "5",
 		"-r", "1",
-		"-b", "4096",
+		"-b", fmt.Sprintf("%d", blockSize),
 		"-t", "ext4",
 		outputFile,
-		fmt.Sprintf("%dK", sizeBytes/1e3),
+		fmt.Sprintf("%dK", sizeBytes/iecKilobyte),
 	}
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -98,23 +104,31 @@ func checkImageOutputPath(path string) error {
 	return nil
 }
 
-// DiskSizeBytes returns the size in bytes of a directory according to "du -sk".
-// It can be used when creating ext4 images -- to ensure they are large enough.
+// DiskSizeBytes returns the disk space required to create an ext4 image from
+// the given directory.
 func DiskSizeBytes(ctx context.Context, inputDir string) (int64, error) {
-	out, err := exec.CommandContext(ctx, "du", "-sk", inputDir).CombinedOutput()
+	// Some images like alpine include a lot of symbolic links which `du`
+	// does not report. So we calculate the size ourselves here.
+	var total int64
+	err := filepath.WalkDir(inputDir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		// stat() does not account for file or symlink metadata, so add an extra
+		// disk block for each entry as a rough way to offset this. Also note
+		// that stat() blocks are always 512 bytes regardless of the FS
+		// settings.
+		total += blockSize + info.Sys().(*syscall.Stat_t).Blocks*512
+		return nil
+	})
 	if err != nil {
-		return 0, status.InternalErrorf("%s: %s", err, out)
+		return 0, err
 	}
-
-	parts := strings.Split(string(out), "\t")
-	if len(parts) != 2 {
-		return 0, status.InternalErrorf("du output %q did not match 'SIZE  /file/path'", out)
-	}
-	s, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return 0, status.InternalErrorf("du output %q did not match 'SIZE  /file/path': %s", out, err)
-	}
-	return int64(s * iecKilobyte), nil
+	return total, nil
 }
 
 // DirectoryToImageAutoSize is like DirectoryToImage, but it will attempt to

--- a/enterprise/server/util/ext4/ext4_test.go
+++ b/enterprise/server/util/ext4/ext4_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
+	"github.com/stretchr/testify/require"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
@@ -80,4 +81,25 @@ func TestE2E(t *testing.T) {
 			t.Fatalf("File content mismatch: %q != %q, %q", d.GetHash(), hash, newPath)
 		}
 	}
+}
+
+func TestDirectoryToImageAutoSize_NonExistentDir(t *testing.T) {
+	ctx := context.Background()
+	root := testfs.MakeTempDir(t)
+
+	err := ext4.DirectoryToImageAutoSize(ctx, "/does/not/exist", filepath.Join(root, "/image.ext4"))
+
+	require.Error(t, err)
+}
+
+func TestDirectoryToImageAutoSize_DanglingSymlink(t *testing.T) {
+	ctx := context.Background()
+	root := testfs.MakeTempDir(t)
+	workspace := testfs.MakeDirAll(t, root, "workspace")
+	err := os.Symlink("/does/not/exist", filepath.Join(workspace, "a"))
+	require.NoError(t, err)
+
+	err = ext4.DirectoryToImageAutoSize(ctx, workspace, filepath.Join(root, "workspace.ext4"))
+
+	require.NoError(t, err)
 }

--- a/enterprise/server/util/ext4/ext4_test.go
+++ b/enterprise/server/util/ext4/ext4_test.go
@@ -1,3 +1,5 @@
+//go:build linux && !android
+
 package ext4_test
 
 import (

--- a/enterprise/server/util/ociconv/BUILD
+++ b/enterprise/server/util/ociconv/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -16,5 +16,24 @@ go_library(
         "//server/util/status",
         "@com_github_docker_docker//client",
         "@org_golang_x_sync//singleflight",
+    ],
+)
+
+go_test(
+    name = "ociconv_test",
+    srcs = ["ociconv_test.go"],
+    # TODO: remove skopeo dep and run on default pool.
+    exec_properties = {
+        "test.Pool": "bare",
+        "test.use-self-hosted-executors": "true",
+        "test.container-image": "none",
+    },
+    tags = ["bare"],
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        ":ociconv",
+        "//enterprise/server/util/oci",
+        "//server/testutil/testfs",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/util/ociconv/ociconv_test.go
+++ b/enterprise/server/util/ociconv/ociconv_test.go
@@ -15,6 +15,14 @@ func TestOciconv(t *testing.T) {
 	ctx := context.Background()
 	root := testfs.MakeTempDir(t)
 	os.Setenv("REGISTRY_AUTH_FILE", "_null")
-	_, err := ociconv.CreateDiskImage(ctx, nil /*=docker*/, root, "gcr.io/flame-public/test-alpine@sha256:6457d53fb065d6f250e1504b9bc42d5b6c65941d57532c072d929dd0628977d0", oci.Credentials{})
-	require.NoError(t, err)
+
+	for _, img := range []string{
+		"gcr.io/flame-public/test-alpine@sha256:6457d53fb065d6f250e1504b9bc42d5b6c65941d57532c072d929dd0628977d0",
+		"mirror.gcr.io/ubuntu:22.04",
+	} {
+		t.Run("image="+img, func(t *testing.T) {
+			_, err := ociconv.CreateDiskImage(ctx, nil /*=docker*/, root, img, oci.Credentials{})
+			require.NoError(t, err)
+		})
+	}
 }

--- a/enterprise/server/util/ociconv/ociconv_test.go
+++ b/enterprise/server/util/ociconv/ociconv_test.go
@@ -1,0 +1,20 @@
+package ociconv_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/ociconv"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOciconv(t *testing.T) {
+	ctx := context.Background()
+	root := testfs.MakeTempDir(t)
+	os.Setenv("REGISTRY_AUTH_FILE", "_null")
+	_, err := ociconv.CreateDiskImage(ctx, nil /*=docker*/, root, "gcr.io/flame-public/test-alpine@sha256:6457d53fb065d6f250e1504b9bc42d5b6c65941d57532c072d929dd0628977d0", oci.Credentials{})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Original PR https://github.com/buildbuddy-io/buildbuddy/pull/6380

The fixes are in [this commit](https://github.com/buildbuddy-io/buildbuddy/commit/rollforward-disksize)

* Use `lstat` instead of `stat` since `stat` can fail on "dangling" symlinks (symlink with a target that does not exist)
* Fix a bug which existed before the original PR: in `DirectoryToImageAutoSize`, `if err != nil { return nil }` should be `if err != nil { return err }`
* Make sure `ext4_test` runs on CI and add regression tests for both of the above issues
* Increase minimum disk size to fix the alpine image conversion test

**Related issues**: N/A
