### PR TITLE
Display `testSuite` time when parsing `test.xml` if populated

### DIFF
--- a/app/target/target_test_cases_card.tsx
+++ b/app/target/target_test_cases_card.tsx
@@ -66,12 +66,14 @@ export default class TargetTestCasesCardComponent extends React.Component<Props>
             <div className="title">{this.props.testSuite.getAttribute("name")}</div>
             <div className="test-subtitle">
               {testCases.length} {testCases.length == 1 ? "test" : "tests"} {this.getStatusTitle()} in{" "}
-              {format.durationMillis(
-                durationToMillisWithFallback(
-                  this.props.buildEvent?.testResult?.testAttemptDuration,
-                  this.props.buildEvent?.testResult?.testAttemptDurationMillis || 0
-                )
-              )}
+              {this.props.testSuite.getAttribute("time")
+                ? `${this.props.testSuite.getAttribute("time")} s`
+                : format.durationMillis(
+                    durationToMillisWithFallback(
+                      this.props.buildEvent?.testResult?.testAttemptDuration,
+                      this.props.buildEvent?.testResult?.testAttemptDurationMillis || 0
+                    )
+                  )}
             </div>
             <div className="test-document">
               <div className="test-suite">


### PR DESCRIPTION
If not populated, fallback to the overall test time like we currently do.