### PR TITLE
Rework invocation error card and render more types of errors

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -296,6 +296,8 @@ ts_library(
         "//app/invocation:invocation_model",
         "//app/service:rpc_service",
         "//app/terminal",
+        "//app/util:exit_codes",
+        "//proto:build_event_stream_ts_proto",
         "//proto:failure_details_ts_proto",
         "@npm//@types/react",
         "@npm//lucide-react",

--- a/app/invocation/invocation_error_card.tsx
+++ b/app/invocation/invocation_error_card.tsx
@@ -3,75 +3,174 @@ import React from "react";
 import InvocationModel from "./invocation_model";
 import { failure_details } from "../../proto/failure_details_ts_proto";
 import TerminalComponent from "../terminal/terminal";
-import rpc_service from "../service/rpc_service";
+import rpc_service, { CancelablePromise } from "../service/rpc_service";
+import { exitCode } from "../util/exit_codes";
+import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
 
 const debugMessage =
   "Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging";
+
 interface Props {
   model: InvocationModel;
 }
 
 interface State {
-  stdErr: string;
+  model?: CardModel;
 }
+
+type CardModel = {
+  errors: ErrorData[];
+};
+
+type ErrorData = {
+  action?: build_event_stream.ActionExecuted;
+  actionStderr?: string;
+  actionStdout?: string;
+
+  aborted?: build_event_stream.BuildEvent;
+
+  finished?: build_event_stream.BuildFinished;
+};
 
 /**
  * Displays a card containing the main reason that an invocation failed.
  */
 export default class ErrorCardComponent extends React.Component<Props, State> {
-  state: State = {
-    stdErr: "",
-  };
+  state: State = {};
 
   componentDidMount() {
-    if (this.props.model.failedAction?.action?.stderr?.uri) {
-      rpc_service
-        .fetchBytestreamFile(
-          this.props.model.failedAction?.action.stderr?.uri,
-          this.props.model.getInvocationId(),
-          "text"
-        )
-        .then((resp) => this.setState({ stdErr: resp }));
+    this.fetchModelData(this.getModel());
+  }
+
+  componentDidUpdate(prevProps: Props): void {
+    const model = this.getModel(this.props);
+    if (!modelsEqual(this.getModel(this.props), this.getModel(prevProps))) {
+      this.fetchModelData(model);
     }
   }
 
-  prettyPrintedStdErr() {
-    if (!this.state.stdErr) {
-      return "";
+  getModel(props = this.props): CardModel {
+    const model: CardModel = { errors: [] };
+    if (props.model.failedAction?.action?.failureDetail?.message) {
+      model.errors.push({ action: props.model.failedAction.action });
     }
-    // Style file names like "/path/to/file.go:10:20" in bold+underline
-    return "\n\n" + this.state.stdErr.replaceAll(/([^\s]*:\d+:\d+)/g, "\x1b[1;4m$1\x1b[0m");
+    for (const event of props.model.aborted) {
+      if (!event.aborted) continue;
+      model.errors.push({ aborted: event });
+    }
+    if (props.model.finished?.failureDetail?.message) {
+      model.errors.push({ finished: props.model.finished });
+    }
+    return model;
+  }
+
+  inFlightFetch: CancelablePromise | null = null;
+  fetchModelData(model: CardModel) {
+    this.inFlightFetch?.cancel();
+
+    const promises: Promise<any>[] = [];
+    for (const error of model.errors) {
+      if (error.action?.stderr?.uri) {
+        promises.push(
+          rpc_service
+            .fetchBytestreamFile(error.action?.stderr?.uri, this.props.model.getInvocationId(), "text")
+            .then((stderr) => {
+              error.actionStderr = stderr;
+            })
+            .catch((e) => console.error("Failed to fetch failed action stderr:", e))
+        );
+      }
+      if (error.action?.stdout?.uri) {
+        promises.push(
+          rpc_service
+            .fetchBytestreamFile(error.action?.stdout?.uri, this.props.model.getInvocationId(), "text")
+            .then((stdout) => {
+              error.actionStdout = stdout;
+            })
+            .catch((e) => console.error("Failed to fetch failed action stdout:", e))
+        );
+      }
+    }
+
+    this.inFlightFetch = new CancelablePromise(Promise.all(promises));
+    this.inFlightFetch.then(() => this.setState({ model }));
+  }
+
+  getTitle(model: CardModel) {
+    // If there was a failed action with a non-zero exit code, use that as the title.
+    for (const error of model.errors) {
+      if ((error.action?.exitCode ?? 0) !== 0) {
+        return `${this.props.model.failedAction?.action?.type} action failed with exit code ${this.props.model.failedAction?.action?.exitCode}`;
+      }
+    }
+    // If the finished event exists and there's a non-zero exit code, use that as the card title.
+    for (const error of model.errors) {
+      if ((error.finished?.exitCode ?? 0) !== 0) {
+        return exitCode(error.finished?.exitCode?.name ?? "");
+      }
+    }
+    // If there was an aborted event, use a generic "aborted" title.
+    for (const error of model.errors) {
+      if (error.aborted) return "Build aborted";
+    }
+    return "Build failed";
+  }
+
+  getBodyText(model: CardModel) {
+    const lines: string[] = [];
+    const errorPrefix = "\x1b[1;91mERROR:\x1b[m ";
+    for (const error of model.errors) {
+      if (error.aborted?.aborted?.reason) {
+        lines.push(
+          errorPrefix +
+            joinNonEmpty(
+              [
+                error.aborted.id?.configuredLabel?.label ?? "",
+                error.aborted.id?.targetConfigured?.label ?? "",
+                naiveFormatEnum(build_event_stream.Aborted.AbortReason[error.aborted?.aborted?.reason] ?? ""),
+                error.aborted?.aborted?.description,
+              ],
+              ": "
+            )
+        );
+      }
+      if (error.action) {
+        if (error.action.failureDetail) {
+          lines.push(errorPrefix + formatFailureDescription(error.action.failureDetail));
+        }
+        if (error.actionStderr) {
+          lines.push("\x1b[1m" + error.actionStderr + "\x1b[m");
+        }
+        if (error.actionStdout) {
+          lines.push("\x1b[1m" + error.actionStdout + "\x1b[m");
+        }
+      }
+      if (error.finished) {
+        if (error.finished.failureDetail) {
+          lines.push(errorPrefix + formatFailureDescription(error.finished.failureDetail));
+        }
+      }
+    }
+    let text = lines.join("\n");
+    text = deemphasizeSandboxDebug(text);
+    text = underlineFileNames(text);
+    return text;
   }
 
   render() {
-    let title = "";
-    let description = "";
-    if (this.props.model.failedAction?.action?.failureDetail?.message) {
-      title = `${this.props.model.failedAction?.action?.type} action failed with exit code ${this.props.model.failedAction?.action?.exitCode}`;
-      description = this.props.model.failedAction.action.failureDetail.message;
-      const spawnCode = this.props.model.failedAction?.action?.failureDetail?.spawn?.code;
-      if (spawnCode) {
-        title += ` (${failure_details.Spawn.Code[spawnCode]})`;
-      }
-    } else if (this.props.model.aborted?.aborted?.description) {
-      title = "Build aborted";
-      description = this.props.model.aborted.aborted.description;
-    } else {
+    if (!this.state.model?.errors?.length) {
       return null;
     }
-
-    // De-emphasize the "--sandbox_debug" message.
-    description = description.replaceAll(debugMessage, `\x1b[90m${debugMessage}\x1b[0m\n \n`);
 
     return (
       <div className="invocation-error-card card card-failure">
         <AlertCircle className="icon red" />
         <div className="content">
-          <div className="title">{title}</div>
+          <div className="title">{this.getTitle(this.state.model)}</div>
           <div className="subtitle">{this.props.model.failedAction?.action?.label}</div>
           <div className="details">
             <TerminalComponent
-              value={"\x1b[1;31m" + description + "\x1b[0m" + this.prettyPrintedStdErr()}
+              value={this.getBodyText(this.state.model)}
               lightTheme
               scrollTop
               bottomControls
@@ -82,4 +181,49 @@ export default class ErrorCardComponent extends React.Component<Props, State> {
       </div>
     );
   }
+}
+
+function formatFailureDescription(failureDetail: failure_details.IFailureDetail): string {
+  let message = failureDetail.message;
+  let code = "";
+  if (failureDetail.spawn) {
+    code = failure_details.Spawn.Code[failureDetail.spawn.code];
+  } else if (failureDetail.execution) {
+    code = failure_details.Execution.Code[failureDetail.execution.code];
+  } else if (failureDetail.targetPatterns) {
+    code = failure_details.TargetPatterns.Code[failureDetail.targetPatterns.code];
+  }
+  // TODO: handle other FailureDetail fields
+
+  return joinNonEmpty([naiveFormatEnum(code), message ?? ""], ": ");
+}
+
+function joinNonEmpty(parts: string[], join: string) {
+  return parts.filter((x) => x).join(join);
+}
+
+function modelsEqual(a: CardModel, b: CardModel): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Styles file names like "/path/to/file.go:10:20" in bold+underline
+ */
+function underlineFileNames(text: string): string {
+  return text.replaceAll(/([^\s]*:\d+:\d+)/g, "\x1b[1;4m$1\x1b[0m");
+}
+
+/**
+ * De-emphasizes the "--sandbox_debug" message.
+ */
+function deemphasizeSandboxDebug(text: string): string {
+  return text.replaceAll(debugMessage, `\x1b[90m${debugMessage}\x1b[0m\n \n`);
+}
+
+/**
+ * Naive enum formatter which just makes the enum lowercase
+ * and replaces underscores with spaces.
+ */
+function naiveFormatEnum(text: string): string {
+  return text.toLowerCase().replaceAll("_", " ");
 }

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -47,7 +47,7 @@ export default class InvocationModel {
   timeoutTest: build_event_stream.BuildEvent[] = [];
   structuredCommandLine: command_line.CommandLine[] = [];
   finished?: build_event_stream.BuildFinished;
-  aborted?: build_event_stream.BuildEvent;
+  aborted: build_event_stream.BuildEvent[] = [];
   failedAction?: build_event_stream.BuildEvent;
   workflowConfigured?: build_event_stream.WorkflowConfigured;
   childInvocationsConfigured?: build_event_stream.ChildInvocationsConfigured;
@@ -132,7 +132,7 @@ export default class InvocationModel {
           this.skippedMap.set(buildEvent.id.targetCompleted.label, event as invocation.InvocationEvent);
         }
       } else if (buildEvent.aborted) {
-        this.aborted = buildEvent as build_event_stream.BuildEvent;
+        this.aborted.push(buildEvent);
       }
       if (buildEvent.workspaceStatus) {
         this.workspaceStatus = buildEvent.workspaceStatus as build_event_stream.WorkspaceStatus;
@@ -563,7 +563,10 @@ export default class InvocationModel {
 
   getAllPatterns(patternLimit?: number) {
     let patterns =
-      this.invocation.pattern || this.expanded?.id?.pattern?.pattern || this.aborted?.id?.pattern?.pattern || [];
+      this.invocation.pattern ||
+      this.expanded?.id?.pattern?.pattern ||
+      this.aborted?.[this.aborted.length - 1]?.id?.pattern?.pattern ||
+      [];
     if (patternLimit && patterns.length > patternLimit) {
       return `${patterns.slice(0, patternLimit).join(", ")} and ${patterns.length - 3} more`;
     }


### PR DESCRIPTION
* Structure errors as a list rather than trying to pick out a single error from the build
* Support rendering more types of errors
* Fetch failed action stdout (not just stderr) - e.g. TypeScript actions put their errors on stdout. So now we show typecheck errors directly in this card

---

Before:
![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/bcd7a142-7e92-46b6-811e-bec14b115660)

After:
![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/5113127c-4f58-4ec3-a8ec-12be7a2c3430)

---

Before:
![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/471b80ba-40e2-417c-96aa-36a128454be5)

After:
![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/c7684e16-385a-4db3-8292-dd7669999af6)

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy/issues/6404
