### PR TITLE
Show logged-in user's email when hovering over name

### DIFF
--- a/enterprise/app/org/org_members.tsx
+++ b/enterprise/app/org/org_members.tsx
@@ -373,7 +373,9 @@ export default class OrgMembersComponent extends React.Component<OrgMembersProps
               <div className="org-member-email">
                 {member?.user?.email || member?.user?.name?.full} {iconFromAccountType(member.user?.accountType)}
               </div>
-              <div className="org-member-role">{getRoleLabel(member?.role || 0)}</div>
+              <div className="org-member-role">
+                {getRoleLabel(member?.role || 0)} {this.isLoggedInUser(member) && <>(You)</>}
+              </div>
             </div>
           ))}
         </div>

--- a/enterprise/app/org_picker/org_picker.tsx
+++ b/enterprise/app/org_picker/org_picker.tsx
@@ -118,7 +118,7 @@ export default class OrgPicker extends React.Component<Props, State> {
               }`}
               src={this.props.user?.displayUser?.profileImageUrl || "/image/user-regular.svg"}
             />
-            <div className="org-picker-profile-name">
+            <div className="org-picker-profile-name" title={this.props.user?.displayUser?.email}>
               <div className="org-picker-profile-user">{name}</div>
               {name != this.props.user?.selectedGroupName() && (
                 <div className="org-picker-profile-org">{this.props.user?.selectedGroupName()}</div>

--- a/enterprise/app/settings/settings.tsx
+++ b/enterprise/app/settings/settings.tsx
@@ -162,7 +162,9 @@ export default class SettingsComponent extends React.Component<SettingsProps> {
               </div>
               <div className="settings-tab-group-header">
                 <div className="settings-tab-group-title">Personal settings</div>
-                <div className="settings-tab-group-subtitle">{this.props.user.displayUser.name?.full}</div>
+                <div className="settings-tab-group-subtitle" title={this.props.user.displayUser.email}>
+                  {this.props.user.displayUser.name?.full}
+                </div>
               </div>
               <div className="settings-tab-group">
                 <SettingsTab id={TabId.PersonalPreferences} activeTabId={activeTabId} debugId="personal-preferences">


### PR DESCRIPTION
Makes it a little easier to figure out what email address you're logged in with.

Also adds a little `(You)` call-out in the org members list.