### PR TITLE
Fix incorrect mediaType in arm64 executor image layers

### DIFF
--- a/deployment/BUILD
+++ b/deployment/BUILD
@@ -1,8 +1,6 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
-load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
 load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
-load("@io_bazel_rules_docker//container:push.bzl", "container_push")
 load("//rules/flags:index.bzl", "write_flag_to_file")
 
 # TODO(tylerw): break depoloyment.yaml apart.
@@ -40,19 +38,4 @@ write_flag_to_file(
     out = "image_tag_file",
     flag = ":image_tag",
     visibility = ["//visibility:public"],
-)
-
-# Definition for uploading new releases of the on_prem docker image.
-# Running this? You may want to update the onprem image version configured in
-# deployment/buildbuddy-app.onprem.yaml so on-prem users actually get your
-# new version!
-container_push(
-    name = "release_onprem",
-    format = "Docker",
-    image = "//server:buildbuddy_image",
-    registry = "gcr.io",
-    repository = "flame-public/buildbuddy-app-onprem",
-    # Set the image tag with the bazel run flag "--//deployment:image_tag=TAG"
-    tag_file = "//deployment:image_tag_file",
-    tags = ["manual"],  # Don't include this target in wildcard patterns
 )

--- a/enterprise/deployment/BUILD
+++ b/enterprise/deployment/BUILD
@@ -2,32 +2,6 @@ load("@io_bazel_rules_docker//container:push.bzl", "container_push")
 
 # Release
 
-# Definition for uploading new releases of the on_prem docker image.
-
-container_push(
-    name = "release_enterprise",
-    format = "Docker",
-    image = "//enterprise/server/cmd/server:buildbuddy_image",
-    registry = "gcr.io",
-    repository = "flame-public/buildbuddy-app-enterprise",
-    # Set the image tag with the bazel run flag "--//deployment:image_tag=TAG"
-    tag_file = "//deployment:image_tag_file",
-    tags = ["manual"],  # Don't include this target in wildcard patterns
-)
-
-# Definition for uploading new releases of the on_prem executor docker image.
-
-container_push(
-    name = "release_executor_enterprise",
-    format = "Docker",
-    image = "//enterprise/server/cmd/executor:executor_image",
-    registry = "gcr.io",
-    repository = "flame-public/buildbuddy-executor-enterprise",
-    # Set the image tag with the bazel run flag "--//deployment:image_tag=TAG"
-    tag_file = "//deployment:image_tag_file",
-    tags = ["manual"],  # Don't include this target in wildcard patterns
-)
-
 # Definitions for uploading new default base docker image.
 container_push(
     name = "executor_docker_default",


### PR DESCRIPTION
The `container_push` rule from `rules_docker` seems to have a bug where it builds some (but not all) image layers with mediaType `application/vnd.oci.image.layer.v1.tar` rather than `application/vnd.docker.image.rootfs.diff.tar.gzip`, even though we're setting `format = "Docker"`. (This only seems to happen on arm64 for some reason, but it could possibly just be because the linux arm64 runners are on ubuntu 22.04 and might have a newer version of dockerd). containerd and podman do not seem to support the `oci` format, or at least they don't support mixing both types of image layers in the same manifest.

I didn't see a straightforward way to customize the mediaType in any of the `rules_docker` rules, so the fix in this PR is to build the image via the `container_image` target but then push the image with `docker tag && docker push` instead of running the `container_push` target. Tested this by running the workflow manually and confirming that the arm64 image no longer has OCI-format layers.

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/3316
