### PR TITLE
Apply timeout to vmexec stream recv

### DIFF
--- a/enterprise/server/remote_execution/vmexec_client/BUILD
+++ b/enterprise/server/remote_execution/vmexec_client/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//server/interfaces",
         "//server/util/background",
         "//server/util/log",
+        "//server/util/rpcutil",
         "//server/util/status",
         "//server/util/tracing",
         "@org_golang_google_grpc//status",


### PR DESCRIPTION
If we stop receiving messages on the vmexec stream, it means we somehow got into a bad state, because we should be sending status updates once every 250ms during normal operation.

This PR adds a timeout to detect when the stream is stuck - conservatively just set to 1 minute for now because we don't have the data as to how high the recv interval is in practice.

**Related issues**: N/A
