### PR TITLE
preserve filter state when going to trends page from history page

### DIFF
--- a/enterprise/app/history/history.tsx
+++ b/enterprise/app/history/history.tsx
@@ -536,17 +536,17 @@ export default class HistoryComponent extends React.Component<Props, State> {
                 {this.props.username && (
                   <span>
                     <span className="history-title">{this.props.username}'s builds</span>
-                    <a className="history-button" href={`/trends/?user=${this.props.username}`}>
+                    <Link className="history-button" href={`/trends/?user=${this.props.username}`}>
                       <BarChart2 /> View trends
-                    </a>
+                    </Link>
                   </span>
                 )}
                 {this.props.hostname && (
                   <span>
                     <span className="history-title">Builds on {this.props.hostname}</span>
-                    <a className="history-button" href={`/trends/?host=${this.props.hostname}`}>
+                    <Link className="history-button" href={`/trends/?host=${this.props.hostname}`}>
                       <BarChart2 /> View trends
-                    </a>
+                    </Link>
                   </span>
                 )}
                 {this.props.repo && !this.isFilteredToWorkflows() && (
@@ -557,9 +557,9 @@ export default class HistoryComponent extends React.Component<Props, State> {
                         <Github /> View repo
                       </a>
                     )}
-                    <a className="history-button" href={`/trends/?repo=${this.props.repo}`}>
+                    <Link className="history-button" href={`/trends/?repo=${this.props.repo}`}>
                       <BarChart2 /> View trends
-                    </a>
+                    </Link>
                   </>
                 )}
                 {this.props.repo && this.isFilteredToWorkflows() && (
@@ -580,9 +580,9 @@ export default class HistoryComponent extends React.Component<Props, State> {
                         <GitBranch /> View branch
                       </a>
                     )}
-                    <a className="history-button" href={`/trends/?branch=${this.props.branch}`}>
+                    <Link className="history-button" href={`/trends/?branch=${this.props.branch}`}>
                       <BarChart2 /> View trends
-                    </a>
+                    </Link>
                   </>
                 )}
                 {this.props.commit && (
@@ -595,9 +595,9 @@ export default class HistoryComponent extends React.Component<Props, State> {
                         <GitCommit /> View commit
                       </a>
                     )}
-                    <a className="history-button" href={`/trends/?commit=${this.props.commit}`}>
+                    <Link className="history-button" href={`/trends/?commit=${this.props.commit}`}>
                       <BarChart2 /> View trends
-                    </a>
+                    </Link>
                   </span>
                 )}
                 {!this.props.hostname &&


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
