### PR TITLE
Basic CacheProxy Server

### DIFF
--- a/enterprise/server/action_cache_server_proxy/BUILD
+++ b/enterprise/server/action_cache_server_proxy/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "action_cache_server_proxy",
+    srcs = ["action_cache_server_proxy.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/action_cache_server_proxy",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/environment",
+        "//server/interfaces",
+        "//server/real_environment",
+        "//server/util/status",
+    ],
+)

--- a/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
+++ b/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
@@ -13,9 +13,9 @@ import (
 )
 
 type ActionCacheServerProxy struct {
-	env          environment.Env
-	local_cache  interfaces.Cache
-	remote_cache repb.ActionCacheClient
+	env         environment.Env
+	localCache  interfaces.Cache
+	remoteCache repb.ActionCacheClient
 }
 
 func Register(env *real_environment.RealEnv) error {
@@ -28,27 +28,27 @@ func Register(env *real_environment.RealEnv) error {
 }
 
 func NewActionCacheServerProxy(env environment.Env) (*ActionCacheServerProxy, error) {
-	local_cache := env.GetCache()
-	if local_cache == nil {
+	localCache := env.GetCache()
+	if localCache == nil {
 		return nil, fmt.Errorf("A cache is required to enable the ActionCacheServerProxy")
 	}
-	remote_cache := env.GetActionCacheClient()
-	if remote_cache == nil {
+	remoteCache := env.GetActionCacheClient()
+	if remoteCache == nil {
 		return nil, fmt.Errorf("An ActionCacheClient is required to enable the ActionCacheServerProxy")
 	}
 	return &ActionCacheServerProxy{
-		env:          env,
-		local_cache:  local_cache,
-		remote_cache: remote_cache,
+		env:         env,
+		localCache:  localCache,
+		remoteCache: remoteCache,
 	}, nil
 }
 
 // TODO(iain): don't cache these locally
 func (s *ActionCacheServerProxy) GetActionResult(ctx context.Context, req *repb.GetActionResultRequest) (*repb.ActionResult, error) {
-	return s.remote_cache.GetActionResult(ctx, req)
+	return s.remoteCache.GetActionResult(ctx, req)
 }
 
 // TODO(iain): don't cache these locally
 func (s *ActionCacheServerProxy) UpdateActionResult(ctx context.Context, req *repb.UpdateActionResultRequest) (*repb.ActionResult, error) {
-	return s.remote_cache.UpdateActionResult(ctx, req)
+	return s.remoteCache.UpdateActionResult(ctx, req)
 }

--- a/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
+++ b/enterprise/server/action_cache_server_proxy/action_cache_server_proxy.go
@@ -1,0 +1,54 @@
+package action_cache_server_proxy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+type ActionCacheServerProxy struct {
+	env          environment.Env
+	local_cache  interfaces.Cache
+	remote_cache repb.ActionCacheClient
+}
+
+func Register(env *real_environment.RealEnv) error {
+	actionCacheServer, err := NewActionCacheServerProxy(env)
+	if err != nil {
+		return status.InternalErrorf("Error initializing ActionCacheServerProxy: %s", err)
+	}
+	env.SetActionCacheServer(actionCacheServer)
+	return nil
+}
+
+func NewActionCacheServerProxy(env environment.Env) (*ActionCacheServerProxy, error) {
+	local_cache := env.GetCache()
+	if local_cache == nil {
+		return nil, fmt.Errorf("A cache is required to enable the ActionCacheServerProxy")
+	}
+	remote_cache := env.GetActionCacheClient()
+	if remote_cache == nil {
+		return nil, fmt.Errorf("An ActionCacheClient is required to enable the ActionCacheServerProxy")
+	}
+	return &ActionCacheServerProxy{
+		env:          env,
+		local_cache:  local_cache,
+		remote_cache: remote_cache,
+	}, nil
+}
+
+// TODO(iain): don't cache these locally
+func (s *ActionCacheServerProxy) GetActionResult(ctx context.Context, req *repb.GetActionResultRequest) (*repb.ActionResult, error) {
+	return s.remote_cache.GetActionResult(ctx, req)
+}
+
+// TODO(iain): don't cache these locally
+func (s *ActionCacheServerProxy) UpdateActionResult(ctx context.Context, req *repb.UpdateActionResultRequest) (*repb.ActionResult, error) {
+	return s.remote_cache.UpdateActionResult(ctx, req)
+}

--- a/enterprise/server/byte_stream_server_proxy/BUILD
+++ b/enterprise/server/byte_stream_server_proxy/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "byte_stream_server_proxy",
+    srcs = ["byte_stream_server_proxy.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/byte_stream_server_proxy",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/environment",
+        "//server/interfaces",
+        "//server/real_environment",
+        "//server/util/status",
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+    ],
+)

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -1,0 +1,95 @@
+package byte_stream_server_proxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	bspb "google.golang.org/genproto/googleapis/bytestream"
+)
+
+type ByteStreamServer struct {
+	env          environment.Env
+	local_cache  interfaces.Cache
+	remote_cache bspb.ByteStreamClient
+}
+
+func Register(env *real_environment.RealEnv) error {
+	byteStreamServer, err := NewByteStreamServer(env)
+	if err != nil {
+		return status.InternalErrorf("Error initializing ByteStreamServerProxy: %s", err)
+	}
+	env.SetByteStreamServer(byteStreamServer)
+	return nil
+}
+
+func NewByteStreamServer(env environment.Env) (*ByteStreamServer, error) {
+	local_cache := env.GetCache()
+	if local_cache == nil {
+		return nil, status.FailedPreconditionError("A cache is required to enable the ByteStreamServerProxy")
+	}
+	remote_cache := env.GetByteStreamClient()
+	if remote_cache == nil {
+		return nil, fmt.Errorf("A ByteStreamClient is required to enable ByteStreamServerProxy")
+	}
+	return &ByteStreamServer{
+		env:          env,
+		local_cache:  local_cache,
+		remote_cache: remote_cache,
+	}, nil
+}
+
+func (s *ByteStreamServer) Read(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) error {
+	remoteStream, err := s.remote_cache.Read(stream.Context(), req)
+	if err != nil {
+		return err
+	}
+	for {
+		rsp, err := remoteStream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		stream.Send(rsp)
+	}
+	return nil
+}
+
+func (s *ByteStreamServer) Write(stream bspb.ByteStream_WriteServer) error {
+	remote_stream, err := s.remote_cache.Write(stream.Context())
+	if err != nil {
+		return err
+	}
+	for {
+		req, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+		writeDone := req.GetFinishWrite()
+		if err := remote_stream.Send(req); err != nil {
+			if err == io.EOF {
+				writeDone = true
+			} else {
+				return err
+			}
+		}
+		if writeDone {
+			lastRsp, err := remote_stream.CloseAndRecv()
+			if err != nil {
+				return err
+			}
+			return stream.SendAndClose(lastRsp)
+		}
+	}
+}
+
+func (s *ByteStreamServer) QueryWriteStatus(ctx context.Context, req *bspb.QueryWriteStatusRequest) (*bspb.QueryWriteStatusResponse, error) {
+	return s.remote_cache.QueryWriteStatus(ctx, req)
+}

--- a/enterprise/server/capabilities_server_proxy/BUILD
+++ b/enterprise/server/capabilities_server_proxy/BUILD
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "capabilities_server_proxy",
+    srcs = ["capabilities_server_proxy.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/capabilities_server_proxy",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/environment",
+        "//server/real_environment",
+        "//server/util/status",
+    ],
+)

--- a/enterprise/server/capabilities_server_proxy/capabilities_server_proxy.go
+++ b/enterprise/server/capabilities_server_proxy/capabilities_server_proxy.go
@@ -1,0 +1,40 @@
+package capabilities_server_proxy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+type CapabilitiesServerProxy struct {
+	env    environment.Env
+	remote repb.CapabilitiesClient
+}
+
+func Register(env *real_environment.RealEnv) error {
+	capabilitiesServer, err := NewCapabilitiesServerProxy(env)
+	if err != nil {
+		return status.InternalErrorf("Error initializing CapabilitiesServerProxy: %s", err)
+	}
+	env.SetCapabilitiesServer(capabilitiesServer)
+	return nil
+}
+
+func NewCapabilitiesServerProxy(env environment.Env) (*CapabilitiesServerProxy, error) {
+	if env.GetCapabilitiesClient() == nil {
+		return nil, fmt.Errorf("A CapabilitiesClient is required to enable the CapabilitiesServerProxy")
+	}
+	return &CapabilitiesServerProxy{
+		env:    env,
+		remote: env.GetCapabilitiesClient(),
+	}, nil
+}
+
+func (s *CapabilitiesServerProxy) GetCapabilities(ctx context.Context, req *repb.GetCapabilitiesRequest) (*repb.ServerCapabilities, error) {
+	return s.remote.GetCapabilities(ctx, req)
+}

--- a/enterprise/server/cmd/cache_proxy/BUILD
+++ b/enterprise/server/cmd/cache_proxy/BUILD
@@ -1,0 +1,47 @@
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "cache_proxy_lib",
+    srcs = ["cache_proxy.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/cmd/cache_proxy",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//enterprise/server/action_cache_server_proxy",
+        "//enterprise/server/backends/configsecrets",
+        "//enterprise/server/backends/pebble_cache",
+        "//enterprise/server/byte_stream_server_proxy",
+        "//enterprise/server/capabilities_server_proxy",
+        "//enterprise/server/content_addressable_storage_server_proxy",
+        "//proto:remote_execution_go_proto",
+        "//server/config",
+        "//server/http/interceptors",
+        "//server/nullauth",
+        "//server/real_environment",
+        "//server/rpc/interceptors",
+        "//server/ssl",
+        "//server/util/grpc_client",
+        "//server/util/grpc_server",
+        "//server/util/healthcheck",
+        "//server/util/log",
+        "//server/util/monitoring",
+        "//server/util/tracing",
+        "//server/version",
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cache_proxy",
+    embed = [":cache_proxy_lib"],
+)
+
+container_image(
+    name = "base_image",
+    base = "@buildbuddy_go_image_base//image",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/action_cache_server_proxy"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/configsecrets"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pebble_cache"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/byte_stream_server_proxy"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/capabilities_server_proxy"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/content_addressable_storage_server_proxy"
+	"github.com/buildbuddy-io/buildbuddy/server/config"
+	"github.com/buildbuddy-io/buildbuddy/server/nullauth"
+	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/ssl"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
+	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/monitoring"
+	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
+	"github.com/buildbuddy-io/buildbuddy/server/version"
+	"google.golang.org/grpc"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	http_interceptors "github.com/buildbuddy-io/buildbuddy/server/http/interceptors"
+	"github.com/buildbuddy-io/buildbuddy/server/rpc/interceptors"
+	bspb "google.golang.org/genproto/googleapis/bytestream"
+)
+
+var (
+	listen           = flag.String("listen", "0.0.0.0", "The interface to listen on (default: 0.0.0.0)")
+	port             = flag.Int("port", 8080, "The port to listen for HTTP traffic on")
+	sslPort          = flag.Int("ssl_port", 8081, "The port to listen for HTTPS traffic on")
+	internalHTTPPort = flag.Int("internal_http_port", 0, "The port to listen for internal HTTP traffic")
+	monitoringPort   = flag.Int("monitoring_port", 9090, "The port to listen for monitoring traffic on")
+
+	serverType = flag.String("server_type", "cache-proxy", "The server type to match on health checks")
+
+	remoteCache = flag.String("cache_proxy.remote_cache", "grpcs://remote.buildbuddy.dev", "The backing remote cache.")
+)
+
+func main() {
+	version.Print()
+
+	// Flags must be parsed before config secrets integration is enabled since
+	// that feature itself depends on flag values.
+	flag.Parse()
+	if err := configsecrets.Configure(); err != nil {
+		log.Fatalf("Could not prepare config secrets provider: %s", err)
+	}
+	if err := config.Load(); err != nil {
+		log.Fatalf("Error loading config from file: %s", err)
+	}
+	config.ReloadOnSIGHUP()
+
+	if err := log.Configure(); err != nil {
+		fmt.Printf("Error configuring logging: %s", err)
+		os.Exit(1)
+	}
+
+	healthChecker := healthcheck.NewHealthChecker(*serverType)
+	env := real_environment.NewRealEnv(healthChecker)
+	env.SetMux(tracing.NewHttpServeMux(http.NewServeMux()))
+	env.SetInternalHTTPMux(tracing.NewHttpServeMux(http.NewServeMux()))
+	env.SetAuthenticator(&nullauth.NullAuthenticator{})
+
+	// Configure a local cache.
+	if err := pebble_cache.Register(env); err != nil {
+		log.Fatalf("%v", err)
+	}
+	if c := env.GetCache(); c == nil {
+		log.Fatalf("No local cache configured")
+	}
+
+	env.SetListenAddr(*listen)
+	if err := ssl.Register(env); err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	// Add the API-Key propagating interceptors.
+	// TODO(iain): improve auth story so we can run beyond dev.
+	grpcServerConfig := grpc_server.GRPCServerConfig{
+		ExtraChainedUnaryInterceptors:  []grpc.UnaryServerInterceptor{interceptors.PropagateAPIKeyUnaryInterceptor()},
+		ExtraChainedStreamInterceptors: []grpc.StreamServerInterceptor{interceptors.PropagateAPIKeyStreamInterceptor()},
+	}
+
+	if err := grpc_server.RegisterGRPCServer(env, grpcServerConfig, registerGRPCServices); err != nil {
+		log.Fatalf("%v", err)
+	}
+	if err := grpc_server.RegisterGRPCSServer(env, grpcServerConfig, registerGRPCServices); err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	monitoring.StartMonitoringHandler(env, fmt.Sprintf("%s:%d", *listen, *monitoringPort))
+	env.GetMux().Handle("/healthz", env.GetHealthChecker().LivenessHandler())
+	env.GetMux().Handle("/readyz", env.GetHealthChecker().ReadinessHandler())
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf("%s:%d", *listen, *port),
+		Handler: env.GetMux(),
+	}
+
+	env.GetHTTPServerWaitGroup().Add(1)
+	env.GetHealthChecker().RegisterShutdownFunction(func(ctx context.Context) error {
+		defer env.GetHTTPServerWaitGroup().Done()
+		err := server.Shutdown(ctx)
+		return err
+	})
+
+	if *internalHTTPPort != 0 {
+		addr := fmt.Sprintf("%s:%d", *listen, *internalHTTPPort)
+		lis, err := net.Listen("tcp", addr)
+		if err != nil {
+			log.Fatalf("could not listen on internal HTTP port: %s", err)
+		}
+
+		internalHTTPServer := &http.Server{
+			Handler: env.GetInternalHTTPMux(),
+		}
+
+		env.GetHealthChecker().RegisterShutdownFunction(func(ctx context.Context) error {
+			err := internalHTTPServer.Shutdown(ctx)
+			return err
+		})
+
+		go func() {
+			log.Debugf("Listening for internal HTTP traffic on %s", addr)
+			_ = internalHTTPServer.Serve(lis)
+		}()
+	}
+
+	if env.GetSSLService().IsEnabled() {
+		tlsConfig, sslHandler := env.GetSSLService().ConfigureTLS(server.Handler)
+		sslServer := &http.Server{
+			Addr:      fmt.Sprintf("%s:%d", *listen, *sslPort),
+			Handler:   server.Handler,
+			TLSConfig: tlsConfig,
+		}
+		go func() {
+			log.Debugf("Listening for HTTPS traffic on %s", sslServer.Addr)
+			sslServer.ListenAndServeTLS("", "")
+		}()
+		go func() {
+			addr := fmt.Sprintf("%s:%d", *listen, *port)
+			log.Debugf("Listening for HTTP traffic on %s", addr)
+			http.ListenAndServe(addr, http_interceptors.RedirectIfNotForwardedHTTPS(sslHandler))
+		}()
+	} else {
+		log.Debug("SSL Disabled")
+		// If no SSL is enabled, we'll just serve things as-is.
+		go func() {
+			log.Debugf("Listening for HTTP traffic on %s", server.Addr)
+			server.ListenAndServe()
+		}()
+	}
+
+	env.GetHealthChecker().WaitForGracefulShutdown()
+}
+
+func registerGRPCServices(grpcServer *grpc.Server, env *real_environment.RealEnv) {
+	// Connect to the remote cache and initialize gRPC clients.
+	conn, err := grpc_client.DialSimple(*remoteCache)
+	if err != nil {
+		log.Fatalf("Error dialing remote cache: %s", err.Error())
+	}
+	env.SetActionCacheClient(repb.NewActionCacheClient(conn))
+	env.SetCapabilitiesClient(repb.NewCapabilitiesClient(conn))
+	env.SetByteStreamClient(bspb.NewByteStreamClient(conn))
+	env.SetContentAddressableStorageClient(repb.NewContentAddressableStorageClient(conn))
+
+	// Configure gRPC services.
+	if err := capabilities_server_proxy.Register(env); err != nil {
+		log.Fatalf("%v", err)
+	}
+	if err := action_cache_server_proxy.Register(env); err != nil {
+		log.Fatalf("%v", err)
+	}
+	if err := byte_stream_server_proxy.Register(env); err != nil {
+		log.Fatalf("%v", err)
+	}
+	if err := content_addressable_storage_server_proxy.Register(env); err != nil {
+		log.Fatalf("%v", err)
+	}
+	repb.RegisterActionCacheServer(grpcServer, env.GetActionCacheServer())
+	bspb.RegisterByteStreamServer(grpcServer, env.GetByteStreamServer())
+	repb.RegisterContentAddressableStorageServer(grpcServer, env.GetCASServer())
+	repb.RegisterCapabilitiesServer(grpcServer, env.GetCapabilitiesServer())
+	log.Infof("Cache proxy proxying requests to %s", *remoteCache)
+}

--- a/enterprise/server/content_addressable_storage_server_proxy/BUILD
+++ b/enterprise/server/content_addressable_storage_server_proxy/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_library(
+    name = "content_addressable_storage_server_proxy",
+    srcs = ["content_addressable_storage_server_proxy.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/content_addressable_storage_server_proxy",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//server/environment",
+        "//server/interfaces",
+        "//server/real_environment",
+        "//server/util/status",
+    ],
+)

--- a/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
+++ b/enterprise/server/content_addressable_storage_server_proxy/content_addressable_storage_server_proxy.go
@@ -1,0 +1,75 @@
+package content_addressable_storage_server_proxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
+	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+)
+
+type CASServerProxy struct {
+	env          environment.Env
+	local_cache  interfaces.Cache
+	remote_cache repb.ContentAddressableStorageClient
+}
+
+func Register(env *real_environment.RealEnv) error {
+	casServer, err := NewCASServerProxy(env)
+	if err != nil {
+		return status.InternalErrorf("Error initializing ContentAddressableStorageServerProxy: %s", err)
+	}
+	env.SetCASServer(casServer)
+	return nil
+}
+
+func NewCASServerProxy(env environment.Env) (*CASServerProxy, error) {
+	local_cache := env.GetCache()
+	if local_cache == nil {
+		return nil, fmt.Errorf("A cache is required to enable the ContentAddressableStorageServerProxy")
+	}
+	remote_cache := env.GetContentAddressableStorageClient()
+	if remote_cache == nil {
+		return nil, fmt.Errorf("A ContentAddressableStorageClient is required to enable the ContentAddressableStorageServerProxy")
+	}
+	return &CASServerProxy{
+		env:          env,
+		local_cache:  local_cache,
+		remote_cache: remote_cache,
+	}, nil
+}
+
+func (s *CASServerProxy) FindMissingBlobs(ctx context.Context, req *repb.FindMissingBlobsRequest) (*repb.FindMissingBlobsResponse, error) {
+	return s.remote_cache.FindMissingBlobs(ctx, req)
+}
+
+func (s *CASServerProxy) BatchUpdateBlobs(ctx context.Context, req *repb.BatchUpdateBlobsRequest) (*repb.BatchUpdateBlobsResponse, error) {
+	return s.remote_cache.BatchUpdateBlobs(ctx, req)
+}
+
+func (s *CASServerProxy) BatchReadBlobs(ctx context.Context, req *repb.BatchReadBlobsRequest) (*repb.BatchReadBlobsResponse, error) {
+	return s.remote_cache.BatchReadBlobs(ctx, req)
+}
+
+func (s *CASServerProxy) GetTree(req *repb.GetTreeRequest, stream repb.ContentAddressableStorage_GetTreeServer) error {
+	remoteStream, err := s.remote_cache.GetTree(context.Background(), req)
+	if err != nil {
+		return err
+	}
+	for {
+		rsp, err := remoteStream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		stream.Send(rsp)
+	}
+	return nil
+}

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -219,7 +219,7 @@ func GetConfiguredEnvironmentOrDie(healthChecker *healthcheck.HealthChecker, app
 }
 
 func startInternalGRPCServers(env *real_environment.RealEnv) error {
-	b, err := grpc_server.New(env, grpc_server.InternalGRPCPort(), false /*=ssl*/)
+	b, err := grpc_server.New(env, grpc_server.InternalGRPCPort(), false /*=ssl*/, grpc_server.GRPCServerConfig{})
 	if err != nil {
 		return err
 	}
@@ -230,7 +230,7 @@ func startInternalGRPCServers(env *real_environment.RealEnv) error {
 	env.SetInternalGRPCServer(b.GetServer())
 
 	if env.GetSSLService().IsEnabled() {
-		sb, err := grpc_server.New(env, grpc_server.InternalGRPCSPort(), true /*=ssl*/)
+		sb, err := grpc_server.New(env, grpc_server.InternalGRPCSPort(), true /*=ssl*/, grpc_server.GRPCServerConfig{})
 		if err != nil {
 			return err
 		}
@@ -251,7 +251,7 @@ func registerInternalServices(env *real_environment.RealEnv, grpcServer *grpc.Se
 }
 
 func startGRPCServers(env *real_environment.RealEnv) error {
-	b, err := grpc_server.New(env, grpc_server.GRPCPort(), false /*=ssl*/)
+	b, err := grpc_server.New(env, grpc_server.GRPCPort(), false /*=ssl*/, grpc_server.GRPCServerConfig{})
 	if err != nil {
 		return err
 	}
@@ -263,7 +263,7 @@ func startGRPCServers(env *real_environment.RealEnv) error {
 	grpc_server.EnableGRPCOverHTTP(env, b.GetServer())
 
 	if env.GetSSLService().IsEnabled() {
-		sb, err := grpc_server.New(env, grpc_server.GRPCSPort(), true /*=ssl*/)
+		sb, err := grpc_server.New(env, grpc_server.GRPCSPort(), true /*=ssl*/, grpc_server.GRPCServerConfig{})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR introduces a new cache_proxy server (`//enterprise/server/cmd/cache_proxy`) that proxies the ActionCache, ByteStream, Capabilities, and ContentAddressableStorage services to the specified backend server. It authenticates with the backing cache by forwarding the provided API Key along. This server is currently running in dev at `grpcs://proxy.buildbudd.dev`, you can build against it by running something like:

```
bazel clean && bazel build --config=remote-dev --remote_cache=grpcs://proxy.buildbuddy.dev --remote_header=x-buildbuddy-api-key=[REDACTED] //server/util/status
```

Next steps are to add a local cache, better auth, and then try routing executor-to-app traffic through the proxy.

I went back and forth over whether to switch the gRPC server configuration to use the Builder pattern instead of just adding a new configuration option, but chose the latter because it's a little simpler.

**Related issues**: N/A
