### PR TITLE
Apply workflow action env to CI runner env, not just bazel commands

### DIFF
--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1080,6 +1080,12 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 		{Name: "GIT_PR_NUMBER", Value: fmt.Sprintf("%d", wd.PullRequestNumber)},
 		{Name: "BUILDBUDDY_INVOCATION_ID", Value: invocationID},
 	}
+	for k, v := range workflowAction.Env {
+		envVars = append(envVars, &repb.Command_EnvironmentVariable{
+			Name:  k,
+			Value: v,
+		})
+	}
 	for k, v := range env {
 		envVars = append(envVars, &repb.Command_EnvironmentVariable{
 			Name:  k,


### PR DESCRIPTION
The workflow config schema supports an "env" section for passing arbitrary env vars but it was only being set for individual bazel commands. This PR makes it so we set the env at the action level, which allows passing env vars e.g. to git, like `GIT_TRACE2=1` or `GIT_CURL_VERBOSE=1`.

**Related issues**: N/A
