### PR TITLE
Fix release.py running docker images instead of just building

### DIFF
--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -1,6 +1,6 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 # gazelle:default_visibility //enterprise:__subpackages__,@buildbuddy_internal//:__subpackages__
 package(default_visibility = [
@@ -109,11 +109,19 @@ container_image(
     tags = ["manual"],
 )
 
-# Build a docker image similar to the go_binary above, but use the "go_image"
-# rule from @io_bazel_rules_docker instead, which creates a docker image.
+# The go_image below can be used to build and run the server image.
+# The container_image target just builds and tags the image without running it.
+
 go_image(
-    name = "buildbuddy_image",
+    name = "buildbuddy_go_image",
     base = ":base_image",
     binary = ":buildbuddy",
     tags = ["manual"],
+)
+
+container_image(
+    name = "buildbuddy_image",
+    base = ":buildbuddy_go_image",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
 )

--- a/server/BUILD
+++ b/server/BUILD
@@ -13,7 +13,7 @@ alias(
     tags = ["manual"],
 ) for t in [
     "base_image",  # container_image
-    "buildbuddy_image",  # go_image
+    "buildbuddy_image",  # container_image
 ]]
 
 alias(

--- a/server/cmd/buildbuddy/BUILD
+++ b/server/cmd/buildbuddy/BUILD
@@ -1,6 +1,6 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 # Use the go_binary rule to create an executable from our main file. Depend on
 # the static_content we created above so they are included.
@@ -40,10 +40,20 @@ container_image(
     visibility = ["//visibility:public"],
 )
 
+# The go_image below can be used to build and run the server image.
+# The container_image target just builds and tags the image without running it.
+
 go_image(
-    name = "buildbuddy_image",
+    name = "buildbuddy_go_image",
     base = ":base_image",
     binary = ":buildbuddy",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "buildbuddy_image",
+    base = ":buildbuddy_go_image",
     tags = ["manual"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy/pull/6416 changed the behavior of `release.py` to build the docker images with `bazel run` but then push them with the `docker` CLI, rather than using the `container_push` targets.

When calling `bazel run` on the BuildBuddy server `go_image` targets though, it actually runs the server image after building it. This differs from `container_image` which just builds and tags the image. This behavior causes `release.py` to get stuck running the server.

To fix this issue, this PR changes the `buildbuddy_image` server targets (OSS and enterprise) to be `container_image` targets rather than `go_image` targets.

**Related issues**: N/A
