### PR TITLE
Update Grafana setup for VictoriaMetrics

### DIFF
--- a/tools/metrics/BUILD
+++ b/tools/metrics/BUILD
@@ -1,0 +1,1 @@
+exports_files(["process_dashboard.py"])

--- a/tools/metrics/docker-compose.grafana.yml
+++ b/tools/metrics/docker-compose.grafana.yml
@@ -10,7 +10,7 @@ services:
       - GF_DASHBOARDS_MIN_REFRESH_INTERVAL=1s
     volumes:
       - ./grafana/provisioning/local:/etc/grafana/provisioning
-      - ./grafana/dashboards:/var/lib/grafana/dashboards
+      - ${DASHBOARDS_DIR}:/var/lib/grafana/dashboards
     ports:
       - "4500:4500"
     extra_hosts:

--- a/tools/metrics/docker-compose.victoria-metrics.yml
+++ b/tools/metrics/docker-compose.victoria-metrics.yml
@@ -1,0 +1,12 @@
+version: "3.3"
+services:
+  victoria-metrics:
+    image: victoriametrics/victoria-metrics:v1.100.1
+    volumes:
+      - ${PWD}/victoria-metrics/scrape.yml:/etc/victoria-metrics/scrape.yml
+    command:
+      - "--promscrape.config=/etc/victoria-metrics/scrape.yml"
+    ports:
+      - "8428:8428"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/tools/metrics/grafana/BUILD
+++ b/tools/metrics/grafana/BUILD
@@ -7,6 +7,7 @@ exports_files(glob(["**/*"]))
 go_library(
     name = "grafana_lib",
     srcs = ["grafana.go"],
+    data = ["//tools/metrics/grafana/dashboards-vm:dashboard_files"],
     importpath = "github.com/buildbuddy-io/buildbuddy/tools/metrics/grafana",
     deps = ["@org_golang_x_sync//errgroup"],
 )

--- a/tools/metrics/grafana/dashboards-vm/BUILD
+++ b/tools/metrics/grafana/dashboards-vm/BUILD
@@ -1,0 +1,24 @@
+load("//tools/metrics/grafana:dashboards.bzl", "DASHBOARD_NAMES")
+
+# Generate VictoriaMetrics dashboards in this package for each
+# dashboard under ../dashboards.
+
+package(default_visibility = ["//visibility:public"])
+
+[
+    genrule(
+        name = "%s.json__gen" % name,
+        srcs = ["//tools/metrics/grafana:dashboards/%s.json" % name],
+        outs = ["%s.json" % name],
+        cmd_bash = """
+            python3 $(location //tools/metrics:process_dashboard.py) --data_source_uid=vm <$(SRCS) >$@
+        """,
+        tools = ["//tools/metrics:process_dashboard.py"],
+    )
+    for name in DASHBOARD_NAMES
+]
+
+filegroup(
+    name = "dashboard_files",
+    srcs = [":%s.json" % name for name in DASHBOARD_NAMES],
+)

--- a/tools/metrics/grafana/dashboards.bzl
+++ b/tools/metrics/grafana/dashboards.bzl
@@ -1,0 +1,11 @@
+# This file is automatically updated by grafana.go - DO NOT EDIT
+DASHBOARD_NAMES = [
+    "buildbuddy",
+    "cache",
+    "clickhouse",
+    "jaeger",
+    "mac",
+    "nodes",
+    "rbeperf",
+    "workflow",
+]

--- a/tools/metrics/grafana/provisioning/deploy/datasources/datasources.yml
+++ b/tools/metrics/grafana/provisioning/deploy/datasources/datasources.yml
@@ -9,3 +9,12 @@ datasources:
     url: http://prometheus-global-server.monitor-%{ENV}
     version: 1
     editable: false
+  - name: VictoriaMetrics
+    type: prometheus
+    access: proxy
+    uid: vm
+    isDefault: false # TODO: make VM the default
+    # TODO: use global cluster
+    url: http://victoria-metrics-cluster-regional-vmselect.monitor-%{ENV}:8481/select/0/prometheus
+    version: 1
+    editable: false

--- a/tools/metrics/grafana/provisioning/local/datasources/datasources.yml
+++ b/tools/metrics/grafana/provisioning/local/datasources/datasources.yml
@@ -11,3 +11,13 @@ datasources:
     editable: false
     jsonData:
       timeInterval: 1s
+  - name: VictoriaMetrics
+    type: prometheus
+    access: proxy
+    uid: vm
+    isDefault: false # TODO: make VM the default
+    url: http://host.docker.internal:8428
+    version: 1
+    editable: false
+    jsonData:
+      timeInterval: 1s

--- a/tools/metrics/victoria-metrics/scrape.yml
+++ b/tools/metrics/victoria-metrics/scrape.yml
@@ -1,8 +1,7 @@
-# Keep in sync with tools/metrics/victoria-metrics/scrape.yml
+# Keep in sync with tools/metrics/prometheus/prometheus.yml
 
 global:
   scrape_interval: 1s
-  evaluation_interval: 1s
 
 scrape_configs:
   - job_name: buildbuddy-app


### PR DESCRIPTION
* Add a `--vm` arg to `tools/metrics/grafana` to use VictoriaMetrics as the datasource
* Auto-generate VictoriaMetrics versions of our current prometheus grafana dashboards

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3294
