### PR TITLE
Enable golang static check analyzer SA9001: Defers in range loops may not run when you expect them to

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -134,7 +134,6 @@ nogo(
     ] + staticcheck_analyzers(ANALYZERS + [
         "-SA1019",
         "-SA1029",
-        "-SA9001",
         "-ST1000",
         "-ST1003",
         "-ST1005",

--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -213,8 +213,9 @@ func (cs *ClusterStarter) attemptQueryAndBringupOnce() error {
 		bootstrapInfo[br.GetNhid()] = br.GetGrpcAddress()
 		if len(bootstrapInfo) == len(cs.join) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			return SendStartShardRequests(ctx, nodeHost, apiClient, bootstrapInfo)
+			err = SendStartShardRequests(ctx, nodeHost, apiClient, bootstrapInfo)
+			cancel()
+			return err
 		}
 	}
 	return status.FailedPreconditionErrorf("Unable to find other join nodes: %+s", bootstrapInfo)


### PR DESCRIPTION
**Related issues**: N/A
