### PR TITLE
Add some basic rendering for the execution log in the UI

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -311,15 +311,22 @@ ts_library(
     deps = [
         "//app/components/button",
         "//app/components/select",
+        "//app/errors:error_service",
         "//app/format",
+        "//app/invocation:invocation_exec_log_card",
         "//app/invocation:invocation_execution_table",
         "//app/invocation:invocation_execution_util",
         "//app/invocation:invocation_model",
         "//app/service:rpc_service",
+        "//proto:build_event_stream_ts_proto",
         "//proto:execution_stats_ts_proto",
         "//proto:remote_execution_ts_proto",
+        "//proto:spawn_ts_proto",
         "@npm//@types/react",
+        "@npm//@types/varint",
         "@npm//react",
+        "@npm//tslib",
+        "@npm//varint",
     ],
 )
 
@@ -608,7 +615,6 @@ ts_library(
     name = "invocation_timing_card",
     srcs = ["invocation_timing_card.tsx"],
     deps = [
-        "//app/capabilities",
         "//app/components/button",
         "//app/docs:setup_code",
         "//app/errors:error_service",
@@ -748,5 +754,30 @@ ts_library(
         "@npm//lucide-react",
         "@npm//react",
         "@npm//tslib",
+    ],
+)
+
+ts_library(
+    name = "invocation_exec_log_card",
+    srcs = ["invocation_exec_log_card.tsx"],
+    deps = [
+        "//app/components/button",
+        "//app/components/digest",
+        "//app/components/link",
+        "//app/components/select",
+        "//app/errors:error_service",
+        "//app/format",
+        "//app/invocation:invocation_model",
+        "//app/service:rpc_service",
+        "//app/util:cache",
+        "//proto:build_event_stream_ts_proto",
+        "//proto:remote_execution_ts_proto",
+        "//proto:spawn_ts_proto",
+        "@npm//@types/react",
+        "@npm//@types/varint",
+        "@npm//lucide-react",
+        "@npm//react",
+        "@npm//tslib",
+        "@npm//varint",
     ],
 )

--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -311,22 +311,16 @@ ts_library(
     deps = [
         "//app/components/button",
         "//app/components/select",
-        "//app/errors:error_service",
         "//app/format",
         "//app/invocation:invocation_exec_log_card",
         "//app/invocation:invocation_execution_table",
         "//app/invocation:invocation_execution_util",
         "//app/invocation:invocation_model",
         "//app/service:rpc_service",
-        "//proto:build_event_stream_ts_proto",
         "//proto:execution_stats_ts_proto",
         "//proto:remote_execution_ts_proto",
-        "//proto:spawn_ts_proto",
         "@npm//@types/react",
-        "@npm//@types/varint",
         "@npm//react",
-        "@npm//tslib",
-        "@npm//varint",
     ],
 )
 

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -951,7 +951,7 @@
   width: 16px;
   height: 16px;
   cursor: pointer;
-  color: #888
+  color: #888;
 }
 
 .metadata-title {

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -941,6 +941,19 @@
   grid-gap: 8px;
 }
 
+.invocation-content-header .title {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.download-exec-log-button {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  color: #888
+}
+
 .metadata-title {
   font-weight: 600;
   color: #212121;

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -421,6 +421,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
             denseMode={this.props.preferences.denseModeEnabled}
             role={this.state.model.getRole()}
             executionsEnabled={
+              this.state.model.getIsExecutionLogEnabled() ||
               this.state.model.getIsRBEEnabled() ||
               this.state.model.isWorkflowInvocation() ||
               this.state.model.isHostedBazelInvocation()

--- a/app/invocation/invocation_exec_log_card.tsx
+++ b/app/invocation/invocation_exec_log_card.tsx
@@ -214,7 +214,7 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
           !l.spawn?.args.join(" ").toLowerCase().includes(this.props.filter.toLowerCase()) &&
           !l.spawn?.digest?.hash.toLowerCase().includes(this.props.filter.toLowerCase())
         ) {
-          return;
+          return false;
         }
 
         return true;

--- a/app/invocation/invocation_exec_log_card.tsx
+++ b/app/invocation/invocation_exec_log_card.tsx
@@ -1,0 +1,321 @@
+import React from "react";
+import InvocationModel from "./invocation_model";
+import Select, { Option } from "../components/select/select";
+import { build } from "../../proto/remote_execution_ts_proto";
+import rpcService from "../service/rpc_service";
+import { OutlinedButton } from "../components/button/button";
+import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
+import { tools } from "../../proto/spawn_ts_proto";
+import format from "../format/format";
+import error_service from "../errors/error_service";
+import * as varint from "varint";
+import { AlertCircle, CheckCircle, Download } from "lucide-react";
+import DigestComponent from "../components/digest/digest";
+import Link from "../components/link/link";
+import { digestToString } from "../util/cache";
+
+interface Props {
+  inProgress: boolean;
+  model: InvocationModel;
+  search: URLSearchParams;
+  filter: string;
+}
+
+interface State {
+  loading: boolean;
+  sort: string;
+  direction: "asc" | "desc";
+  mnemonicFilter: string;
+  runnerFilter: string;
+  limit: number;
+  log: tools.protos.ExecLogEntry[] | undefined;
+}
+
+const ExecutionStage = build.bazel.remote.execution.v2.ExecutionStage;
+
+export default class InvocationExecLogCardComponent extends React.Component<Props, State> {
+  state: State = {
+    loading: true,
+    sort: "total-duration",
+    direction: "desc",
+    mnemonicFilter: "",
+    runnerFilter: "",
+    limit: 100,
+    log: undefined,
+  };
+
+  timeoutRef?: number;
+
+  componentDidMount() {
+    this.fetchLog();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.model !== prevProps.model) {
+      this.fetchLog();
+    }
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.timeoutRef);
+  }
+
+  getExecutionLogFile(): build_event_stream.File | undefined {
+    return this.props.model.buildToolLogs?.log.find(
+      (log: build_event_stream.File) =>
+        log.name == "execution.log" && log.uri && Boolean(log.uri.startsWith("bytestream://"))
+    );
+  }
+
+  fetchLog() {
+    if (!this.getExecutionLogFile()) {
+      this.setState({ loading: false });
+    }
+
+    // Already fetched
+    if (this.state.log) return;
+
+    let logFile = this.getExecutionLogFile();
+    if (!logFile?.uri) return;
+
+    const init = {
+      // Set the stored encoding header to prevent the server from double-compressing.
+      headers: { "X-Stored-Encoding-Hint": "zstd" },
+    };
+
+    this.setState({ loading: true });
+    rpcService
+      .fetchBytestreamFile(logFile.uri, this.props.model.getInvocationId(), "arraybuffer", { init })
+      .then(async (body) => {
+        if (body === null) throw new Error("response body is null");
+        let entries: tools.protos.ExecLogEntry[] = [];
+        let byteArray = new Uint8Array(body);
+        for (var offset = 0; offset < body.byteLength; ) {
+          let length = varint.decode(byteArray, offset);
+          let bytes = varint.decode.bytes || 0;
+          offset += bytes;
+          entries.push(tools.protos.ExecLogEntry.decode(byteArray.subarray(offset, offset + length)));
+          offset += length;
+        }
+        console.log(entries);
+        return entries;
+      })
+      .then((log) => this.setState({ log: log }))
+      .catch((e) => error_service.handleError(e))
+      .finally(() => this.setState({ loading: false }));
+  }
+
+  downloadLog() {
+    let profileFile = this.getExecutionLogFile();
+    if (!profileFile?.uri) {
+      return;
+    }
+
+    try {
+      rpcService.downloadBytestreamFile("execution.log", profileFile.uri, this.props.model.getInvocationId());
+    } catch {
+      console.error("Error downloading execution log");
+    }
+  }
+
+  sort(a: tools.protos.ExecLogEntry, b: tools.protos.ExecLogEntry): number {
+    let first = this.state.direction == "asc" ? a : b;
+    let second = this.state.direction == "asc" ? b : a;
+
+    switch (this.state.sort) {
+      case "total-duration":
+        if (+(first?.spawn?.metrics?.totalTime?.seconds || 0) == +(second?.spawn?.metrics?.totalTime?.seconds || 0)) {
+          return +(first?.spawn?.metrics?.totalTime?.nanos || 0) - +(second?.spawn?.metrics?.totalTime?.nanos || 0);
+        }
+        return +(first?.spawn?.metrics?.totalTime?.seconds || 0) - +(second?.spawn?.metrics?.totalTime?.seconds || 0);
+    }
+    return 0;
+  }
+
+  handleInputChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const target = event.target;
+    const name = target.name;
+    this.setState({
+      [name]: target.value,
+    } as Record<keyof State, any>);
+  }
+
+  handleSortChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    this.setState({
+      sort: event.target.value,
+    });
+  }
+
+  handleMnemonicFilterChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    this.setState({
+      mnemonicFilter: event.target.value,
+    });
+  }
+
+  handleRunnerFilterChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    this.setState({
+      runnerFilter: event.target.value,
+    });
+  }
+
+  handleMoreClicked() {
+    this.setState({ limit: this.state.limit + 100 });
+  }
+
+  handleAllClicked() {
+    this.setState({ limit: Number.MAX_SAFE_INTEGER });
+  }
+
+  getActionPageLink(entry: tools.protos.ExecLogEntry) {
+    const search = new URLSearchParams();
+    if (entry.spawn?.digest) {
+      search.set("actionDigest", digestToString(entry.spawn.digest));
+    }
+
+    return `/invocation/${this.props.model.getInvocationId()}?${search}#action`;
+  }
+
+  render() {
+    if (this.state.loading) {
+      return <div className="loading" />;
+    }
+    if (!this.state.log?.length) {
+      return (
+        <div className="invocation-execution-empty-state">
+          No execution log actions for this invocation{this.props.inProgress && <span> yet</span>}.
+        </div>
+      );
+    }
+
+    const mnemonics = new Set<string>();
+    const runners = new Set<string>();
+
+    const spawns = this.state.log
+      .filter((l) => {
+        if (l.spawn?.mnemonic) {
+          mnemonics.add(l.spawn.mnemonic);
+        }
+        if (l.spawn?.runner) {
+          runners.add(l.spawn.runner);
+        }
+        if (l.type != "spawn") {
+          return false;
+        }
+        if (this.state.mnemonicFilter != "" && l.spawn?.mnemonic != this.state.mnemonicFilter) {
+          return false;
+        }
+        if (this.state.runnerFilter != "" && l.spawn?.runner != this.state.runnerFilter) {
+          return false;
+        }
+        if (
+          this.props.filter != "" &&
+          !l.spawn?.targetLabel.toLowerCase().includes(this.props.filter.toLowerCase()) &&
+          !l.spawn?.mnemonic.toLowerCase().includes(this.props.filter.toLowerCase()) &&
+          !l.spawn?.args.join(" ").toLowerCase().includes(this.props.filter.toLowerCase()) &&
+          !l.spawn?.digest?.hash.toLowerCase().includes(this.props.filter.toLowerCase())
+        ) {
+          return;
+        }
+
+        return true;
+      })
+      .sort(this.sort.bind(this));
+
+    return (
+      <div>
+        <div className={`card expanded`}>
+          <div className="content">
+            <div className="invocation-content-header">
+              <div className="title">
+                Executed actions ({spawns.length}){" "}
+                <Download className="download-exec-log-button" onClick={() => this.downloadLog()} />
+              </div>
+              <div className="invocation-sort-controls">
+                <span className="invocation-filter-title">Mnemnonic</span>
+                <Select onChange={this.handleMnemonicFilterChange.bind(this)} value={this.state.mnemonicFilter}>
+                  <Option value="">All</Option>
+                  {[...mnemonics].map((m) => (
+                    <Option value={m}>{m}</Option>
+                  ))}
+                </Select>
+                <span className="invocation-sort-title">Runner</span>
+                <Select onChange={this.handleRunnerFilterChange.bind(this)} value={this.state.runnerFilter}>
+                  <Option value="">All</Option>
+                  {[...runners].map((m) => (
+                    <Option value={m}>{m}</Option>
+                  ))}
+                </Select>
+                <span className="invocation-sort-title">Sort by</span>
+                <Select onChange={this.handleSortChange.bind(this)} value={this.state.sort}>
+                  <Option value="total-duration">Total Duration</Option>
+                </Select>
+                <span className="group-container">
+                  <div>
+                    <input
+                      id="direction-asc"
+                      checked={this.state.direction == "asc"}
+                      onChange={this.handleInputChange.bind(this)}
+                      value="asc"
+                      name="direction"
+                      type="radio"
+                    />
+                    <label htmlFor="direction-asc">Asc</label>
+                  </div>
+                  <div>
+                    <input
+                      id="direction-desc"
+                      checked={this.state.direction == "desc"}
+                      onChange={this.handleInputChange.bind(this)}
+                      value="desc"
+                      name="direction"
+                      type="radio"
+                    />
+                    <label htmlFor="direction-desc">Desc</label>
+                  </div>
+                </span>
+              </div>
+            </div>
+            <div>
+              <div className="invocation-execution-table">
+                {spawns.slice(0, this.state.limit).map((spawn) => (
+                  <Link key={spawn.id} className="invocation-execution-row" href={this.getActionPageLink(spawn)}>
+                    <div className="invocation-execution-row-image">
+                      {spawn.spawn?.exitCode == 0 ? (
+                        <CheckCircle className="icon green" />
+                      ) : (
+                        <AlertCircle className="icon red" />
+                      )}
+                    </div>
+                    <div>
+                      <div className="invocation-execution-row-header">
+                        <span className="invocation-execution-row-header-status">{spawn.spawn?.targetLabel}</span>
+                        {spawn.spawn?.digest && <DigestComponent digest={spawn.spawn.digest} expanded={true} />}
+                      </div>
+                      <div>{spawn.spawn?.args.join(" ").slice(0, 200)}...</div>
+                      <div className="invocation-execution-row-stats">
+                        {spawn.spawn?.metrics?.totalTime && (
+                          <div>Duration: {format.durationProto(spawn.spawn.metrics.totalTime)}</div>
+                        )}
+                        <div>Mnemonic: {spawn.spawn?.mnemonic}</div>
+                        <div>Runner: {spawn.spawn?.runner}</div>
+                        <div>Remotable: {spawn.spawn?.remotable ? "true" : "false"}</div>
+                        <div>Cachable: {spawn.spawn?.cacheable ? "true" : "false"}</div>
+                        <div>Exit code: {spawn.spawn?.exitCode || 0}</div>
+                      </div>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+              {spawns.length > this.state.limit && (
+                <div className="more-buttons">
+                  <OutlinedButton onClick={this.handleMoreClicked.bind(this)}>See more executions</OutlinedButton>
+                  <OutlinedButton onClick={this.handleAllClicked.bind(this)}>See all executions</OutlinedButton>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/app/invocation/invocation_execution_card.tsx
+++ b/app/invocation/invocation_execution_card.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import InvocationModel from "./invocation_model";
 import InvocationExecutionTable from "./invocation_execution_table";
+import InvocationExecLogCardComponent from "./invocation_exec_log_card";
 import { execution_stats } from "../../proto/execution_stats_ts_proto";
 import Select, { Option } from "../components/select/select";
 import { build } from "../../proto/remote_execution_ts_proto";
@@ -189,9 +190,19 @@ export default class ExecutionCardComponent extends React.Component<Props, State
     }
     if (!this.state.executions.length) {
       return (
-        <div className="invocation-execution-empty-state">
-          No actions remotely executed by BuildBuddy RBE for this invocation{this.props.inProgress && <span> yet</span>}
-          .
+        <div>
+          {this.props.model.getIsExecutionLogEnabled() && (
+            <InvocationExecLogCardComponent
+              inProgress={this.props.inProgress}
+              model={this.props.model}
+              search={this.props.search}
+              filter={this.props.filter}
+            />
+          )}
+          <div className="invocation-execution-empty-state">
+            No actions remotely executed by BuildBuddy RBE for this invocation
+            {this.props.inProgress && <span> yet</span>}.
+          </div>
         </div>
       );
     }
@@ -223,6 +234,14 @@ export default class ExecutionCardComponent extends React.Component<Props, State
 
     return (
       <div>
+        {this.props.model.getIsExecutionLogEnabled() && (
+          <InvocationExecLogCardComponent
+            inProgress={this.props.inProgress}
+            model={this.props.model}
+            search={this.props.search}
+            filter={this.props.filter}
+          />
+        )}
         <div className={`card expanded`}>
           <div className="content">
             <div className="invocation-content-header">

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -457,6 +457,13 @@ export default class InvocationModel {
     return this.getIsRBEEnabled() ? "Remote execution on" : "Remote execution off";
   }
 
+  getIsExecutionLogEnabled() {
+    return (
+      this.buildToolLogs?.log.find((l) => l.name == "execution.log" && l.uri.startsWith("bytestream://")) &&
+      this.stringCommandLineOption("remote_build_event_upload") == "all"
+    );
+  }
+
   getFetchURLs() {
     return this.fetchEventURLs;
   }

--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -10,7 +10,6 @@ import format from "../format/format";
 import InvocationBreakdownCardComponent from "./invocation_breakdown_card";
 import { getTimingDataSuggestion, SuggestionComponent } from "./invocation_suggestion_card";
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
-import capabilities from "../capabilities/capabilities";
 import TraceViewer from "../trace/trace_viewer";
 
 interface Props {
@@ -75,7 +74,9 @@ export default class InvocationTimingCardComponent extends React.Component<Props
   }
 
   getProfileFile(): build_event_stream.File | undefined {
-    return this.props.model.buildToolLogs?.log.find((log: build_event_stream.File) => log.uri);
+    return this.props.model.buildToolLogs?.log.find(
+      (log: build_event_stream.File) => log.name != "execution.log" && log.uri
+    );
   }
 
   isTimingEnabled() {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/react-virtualized-auto-sizer": "^1.0.1",
     "@types/react-window": "^1.8.5",
     "@types/uuid": "^8.3.0",
+    "@types/varint": "^6.0.3",
     "d3-scale": "^4.0.2",
     "d3-time": "^3.0.0",
     "dagre-d3-react": "^0.2.4",
@@ -57,7 +58,8 @@
     "shlex": "^2.1.2",
     "tslib": "^2.1.0",
     "typescript": "^4.6.3",
-    "uuid": "^8.3.0"
+    "uuid": "^8.3.0",
+    "varint": "^6.0.0"
   },
   "resolutions": {
     "@types/react": "^16.8.17"

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -352,17 +352,6 @@ proto_library(
 )
 
 proto_library(
-    name = "workspace_proto",
-    srcs = [
-        "workspace.proto",
-    ],
-    deps = [
-        ":context_proto",
-        ":git_proto",
-    ],
-)
-
-proto_library(
     name = "runner_proto",
     srcs = [
         "runner.proto",
@@ -538,7 +527,6 @@ proto_library(
         ":usage_proto",
         ":user_proto",
         ":workflow_proto",
-        ":workspace_proto",
         ":zip_proto",
     ],
 )
@@ -1177,20 +1165,6 @@ go_proto_library(
 )
 
 go_proto_library(
-    name = "workspace_go_proto",
-    compilers = [
-        "@io_bazel_rules_go//proto:go_proto",
-        "//proto:vtprotobuf_compiler",
-    ],
-    importpath = "github.com/buildbuddy-io/buildbuddy/proto/workspace",
-    proto = ":workspace_proto",
-    deps = [
-        ":context_go_proto",
-        ":git_go_proto",
-    ],
-)
-
-go_proto_library(
     name = "raft_go_proto",
     compilers = [
         "@io_bazel_rules_go//proto:go_proto",
@@ -1372,7 +1346,6 @@ go_proto_library(
         ":usage_go_proto",
         ":user_go_proto",
         ":workflow_go_proto",
-        ":workspace_go_proto",
         ":zip_go_proto",
     ],
 )
@@ -1973,15 +1946,6 @@ ts_proto_library(
 )
 
 ts_proto_library(
-    name = "workspace_ts_proto",
-    proto = ":workspace_proto",
-    deps = [
-        ":context_ts_proto",
-        ":git_ts_proto",
-    ],
-)
-
-ts_proto_library(
     name = "command_line_ts_proto",
     proto = ":command_line_proto",
     deps = [
@@ -2205,7 +2169,6 @@ ts_proto_library(
         ":usage_ts_proto",
         ":user_ts_proto",
         ":workflow_ts_proto",
-        ":workspace_ts_proto",
         ":zip_ts_proto",
     ],
 )

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -352,6 +352,17 @@ proto_library(
 )
 
 proto_library(
+    name = "workspace_proto",
+    srcs = [
+        "workspace.proto",
+    ],
+    deps = [
+        ":context_proto",
+        ":git_proto",
+    ],
+)
+
+proto_library(
     name = "runner_proto",
     srcs = [
         "runner.proto",
@@ -527,6 +538,7 @@ proto_library(
         ":usage_proto",
         ":user_proto",
         ":workflow_proto",
+        ":workspace_proto",
         ":zip_proto",
     ],
 )
@@ -1165,6 +1177,20 @@ go_proto_library(
 )
 
 go_proto_library(
+    name = "workspace_go_proto",
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "//proto:vtprotobuf_compiler",
+    ],
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/workspace",
+    proto = ":workspace_proto",
+    deps = [
+        ":context_go_proto",
+        ":git_go_proto",
+    ],
+)
+
+go_proto_library(
     name = "raft_go_proto",
     compilers = [
         "@io_bazel_rules_go//proto:go_proto",
@@ -1346,6 +1372,7 @@ go_proto_library(
         ":usage_go_proto",
         ":user_go_proto",
         ":workflow_go_proto",
+        ":workspace_go_proto",
         ":zip_go_proto",
     ],
 )
@@ -1828,6 +1855,17 @@ ts_proto_library(
 )
 
 ts_proto_library(
+    name = "spawn_ts_proto",
+    proto = ":spawn_proto",
+    deps = [
+        ":context_ts_proto",
+        ":duration_ts_proto",
+        ":invocation_status_ts_proto",
+        ":stat_filter_ts_proto",
+    ],
+)
+
+ts_proto_library(
     name = "stat_filter_ts_proto",
     proto = ":stat_filter_proto",
 )
@@ -1931,6 +1969,15 @@ ts_proto_library(
         ":git_ts_proto",
         ":grpc_status_ts_proto",
         ":invocation_status_ts_proto",
+    ],
+)
+
+ts_proto_library(
+    name = "workspace_ts_proto",
+    proto = ":workspace_proto",
+    deps = [
+        ":context_ts_proto",
+        ":git_ts_proto",
     ],
 )
 
@@ -2158,6 +2205,7 @@ ts_proto_library(
         ":usage_ts_proto",
         ":user_ts_proto",
         ":workflow_ts_proto",
+        ":workspace_ts_proto",
         ":zip_ts_proto",
     ],
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -233,6 +233,13 @@
   dependencies:
     moment "*"
 
+"@types/node@*":
+  version "20.12.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.7.tgz#04080362fa3dd6c5822061aa3124f5c152cff384"
+  integrity sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==
+  dependencies:
+    undici-types "~5.26.4"
+
 "@types/node@>=13.7.0":
   version "18.6.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.3.tgz#4e4a95b6fe44014563ceb514b2598b3e623d1c98"
@@ -313,6 +320,13 @@
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
   integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
+"@types/varint@^6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@types/varint/-/varint-6.0.3.tgz#e00b00f94d497d7cbf0e9f391cbc7e8443ae2174"
+  integrity sha512-DHukoGWdJ2aYkveZJTB2rN2lp6m7APzVsoJQ7j/qy1fQxyamJTPD5xQzCMoJ2Qtgn0mE3wWeNOpbTyBFvF+dyA==
+  dependencies:
+    "@types/node" "*"
 
 "@xmldom/xmldom@^0.7.3":
   version "0.7.9"
@@ -1187,6 +1201,11 @@ typescript@^4.6.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
 uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
@@ -1200,6 +1219,11 @@ v8-to-istanbul@^7.1.0:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
+
+varint@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/varint/-/varint-6.0.0.tgz#9881eb0ce8feaea6512439d19ddf84bf551661d0"
+  integrity sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==
 
 victory-vendor@^36.6.8:
   version "36.6.8"


### PR DESCRIPTION
Renders the compact execution log on the `Executions` tab if the following Bazel flags are set:
```
--experimental_execution_log_compact_file
--remote_build_event_upload=all
```

Also adds a download button to the card title so users can easily download the file for their own analysis.

Kept the rendering basic to start. Currently renders most of the spawn details we get in a list, and each links to its corresponding action details card.

Added filtering by mnemonic and runner type, sorting by total duration asc / desc, and text filtering by target label, args, and digest.

I explicitly didn't touch any input / output file rendering / diffing / linking / graph creation - even though I think that's probably the most valuable thing we can do with this information. Just want to get something simple in to start.

Fixes https://github.com/buildbuddy-io/buildbuddy/issues/6446

cc @brentleyjones 