### PR TITLE
shade comments lighter when the current user has already replied

### DIFF
--- a/enterprise/app/review/review.css
+++ b/enterprise/app/review/review.css
@@ -352,8 +352,16 @@
   box-shadow: 0 0 4px #ccc;
 }
 
+.pr-view .thread.user-replied {
+  background-color: #fff8e1;
+}
+
 .pr-view .thread.resolved {
   background-color: #e0e0e0;
+}
+
+.pr-view .thread.resolved.user-replied {
+  background-color: #eee;
 }
 
 .pr-view .resolution-pill-box {
@@ -370,9 +378,17 @@
   font-weight: 600;
 }
 
+.pr-view .user-replied .resolution-pill {
+  background-color: #ffe082;
+}
+
 .pr-view .resolution-pill.resolved {
   background-color: #bdbdbd;
   color: #616161;
+}
+
+.pr-view .user-replied .resolution-pill.resolved {
+  background-color: #e0e0e0;
 }
 
 .pr-view .thread-comment {

--- a/enterprise/app/review/review_thread.tsx
+++ b/enterprise/app/review/review_thread.tsx
@@ -70,15 +70,19 @@ export default class ReviewThreadComponent extends React.Component<ReviewThreadC
       comments.push(draft);
     }
 
-    if (comments.length == 0 && !draft) {
+    if (comments.length === 0 && !draft) {
       // Shouldn't happen, but fine.
       return <></>;
     }
 
     const isBot = Boolean(comments.length === 1 && comments[0].isBot());
+    let classNames = "thread";
+    if (draft || (comments.length > 0 && comments[comments.length - 1].getCommenter() === this.props.activeUsername)) {
+      classNames += " user-replied";
+    }
 
     return (
-      <div className="thread">
+      <div className={classNames}>
         {comments.map((c) => {
           return (
             <>


### PR DESCRIPTION
I don't think this is an *exact* match to the "familiar" behavior, but it seems close enough.

I'll be adding text to the file list about the number of unaddressed comments (when the author is viewing) + draft comments (everyone) in a separate PR.

Fixes buildbuddy-io/buildbuddy-internal/issues/3324 (this is the last issue i'll address as part of that bug, let's file individual bugs from now on, i'll add a tag)

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
