### PR TITLE
add server-side support for identifying moved files.

### DIFF
--- a/enterprise/server/githubapp/githubapp.go
+++ b/enterprise/server/githubapp/githubapp.go
@@ -2193,6 +2193,12 @@ func FileStatusToChangeType(status string) ghpb.FileChangeType {
 		return ghpb.FileChangeType_FILE_CHANGE_TYPE_REMOVED
 	} else if status == "changed" || status == "modified" {
 		return ghpb.FileChangeType_FILE_CHANGE_TYPE_MODIFIED
+	} else if status == "renamed" {
+		return ghpb.FileChangeType_FILE_CHANGE_TYPE_RENAMED
+	} else if status == "copied" {
+		return ghpb.FileChangeType_FILE_CHANGE_TYPE_COPIED
+	} else if status == "unchanged" {
+		return ghpb.FileChangeType_FILE_CHANGE_TYPE_UNCHANGED
 	}
 	return ghpb.FileChangeType_FILE_CHANGE_TYPE_UNKNOWN
 }
@@ -2312,8 +2318,10 @@ func (a *GitHubApp) GetGithubPullRequestDetails(ctx context.Context, req *ghpb.G
 		if ref == "" {
 			return nil, status.InternalErrorf("Couldn't find SHA for file.")
 		}
-		// TODO(jdhollen): Put original filename here for moves.
-		summary.OriginalName = f.GetFilename()
+		summary.OriginalName = f.GetPreviousFilename()
+		if summary.OriginalName == "" {
+			summary.OriginalName = summary.Name
+		}
 		summary.OriginalCommitSha = pr.BaseRefOid
 		summary.ModifiedCommitSha = pr.HeadRefOid
 		fileSummaries = append(fileSummaries, summary)

--- a/proto/github.proto
+++ b/proto/github.proto
@@ -523,7 +523,9 @@ enum FileChangeType {
   FILE_CHANGE_TYPE_ADDED = 1;
   FILE_CHANGE_TYPE_REMOVED = 2;
   FILE_CHANGE_TYPE_MODIFIED = 3;
-  // TODO(jdhollen): support more change types.
+  FILE_CHANGE_TYPE_RENAMED = 4;
+  FILE_CHANGE_TYPE_COPIED = 5;
+  FILE_CHANGE_TYPE_UNCHANGED = 6;
 }
 
 // A summary of the changes to a file contained in a PR.


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
