### PR TITLE
timing_card: get profile from structured flag

### DIFF
--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -74,11 +74,10 @@ export default class InvocationTimingCardComponent extends React.Component<Props
   }
 
   getProfileFile(): build_event_stream.File | undefined {
-    const profileOption = this.props.model
-      .structuredCommandLine!.find((scl) => scl.commandLineLabel == "canonical")!
-      .sections.find((s) => s.sectionLabel == "command options")!
-      .optionList!.option.find((o) => o.optionName == "profile");
-    const profileName = profileOption ? profileOption.optionValue : "command.profile.gz";
+    const profileName = this.props.model
+      .structuredCommandLine?.find((scl) => scl.commandLineLabel == "canonical")?
+      .sections?.find((s) => s.sectionLabel == "command options")?
+      .optionList?.option?.find((o) => o.optionName == "profile")?.optionValue ?? "command.profile.gz";
 
     return this.props.model.buildToolLogs?.log.find(
       (log: build_event_stream.File) => log.name == profileName && log.uri

--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -74,10 +74,11 @@ export default class InvocationTimingCardComponent extends React.Component<Props
   }
 
   getProfileFile(): build_event_stream.File | undefined {
-    const profileName = this.props.model
-      .structuredCommandLine?.find((scl) => scl.commandLineLabel == "canonical")?
-      .sections?.find((s) => s.sectionLabel == "command options")?
-      .optionList?.option?.find((o) => o.optionName == "profile")?.optionValue ?? "command.profile.gz";
+    const profileName =
+      this.props.model.structuredCommandLine
+        ?.find((scl) => scl.commandLineLabel == "canonical")
+        ?.sections?.find((s) => s.sectionLabel == "command options")
+        ?.optionList?.option?.find((o) => o.optionName == "profile")?.optionValue ?? "command.profile.gz";
 
     return this.props.model.buildToolLogs?.log.find(
       (log: build_event_stream.File) => log.name == profileName && log.uri

--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -74,8 +74,14 @@ export default class InvocationTimingCardComponent extends React.Component<Props
   }
 
   getProfileFile(): build_event_stream.File | undefined {
+    const profileOption = this.props.model
+      .structuredCommandLine!.find((scl) => scl.commandLineLabel == "canonical")!
+      .sections.find((s) => s.sectionLabel == "command options")!
+      .optionList!.option.find((o) => o.optionName == "profile");
+    const profileName = profileOption ? profileOption.optionValue : "command.profile.gz";
+
     return this.props.model.buildToolLogs?.log.find(
-      (log: build_event_stream.File) => log.name != "execution.log" && log.uri
+      (log: build_event_stream.File) => log.name == profileName && log.uri
     );
   }
 


### PR DESCRIPTION
Currently we are assuming that the BuildToolLogs event will have
relatively small amount of files that are uploaded via bytestream API.
Using that assumption, we guessed that the build timing profile must be
one of the 2 files referenced in this event, and differentiate them
based on their file name.

Detect the actual timing profile name by searching through canonical
command line for a `--profile=` flag. If the user does not specify a
custom profile name, assume the default `command.profile.gz` name.
