### PR TITLE
exec_log_card: download execution log with ext

### DIFF
--- a/app/invocation/invocation_exec_log_card.tsx
+++ b/app/invocation/invocation_exec_log_card.tsx
@@ -63,7 +63,9 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
   getExecutionLogFile(): build_event_stream.File | undefined {
     return this.props.model.buildToolLogs?.log.find(
       (log: build_event_stream.File) =>
-        log.name == "execution.log" && log.uri && Boolean(log.uri.startsWith("bytestream://"))
+        (log.name == "execution.log" || log.name == "execution_log.binpb.zstd") &&
+        log.uri &&
+        Boolean(log.uri.startsWith("bytestream://"))
     );
   }
 
@@ -112,7 +114,11 @@ export default class InvocationExecLogCardComponent extends React.Component<Prop
     }
 
     try {
-      rpcService.downloadBytestreamFile("execution.log", profileFile.uri, this.props.model.getInvocationId());
+      rpcService.downloadBytestreamFile(
+        "execution_log.binpb.zstd",
+        profileFile.uri,
+        this.props.model.getInvocationId()
+      );
     } catch {
       console.error("Error downloading execution log");
     }

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -459,8 +459,9 @@ export default class InvocationModel {
 
   getIsExecutionLogEnabled() {
     return (
-      this.buildToolLogs?.log.find((l) => l.name == "execution.log" && l.uri.startsWith("bytestream://")) &&
-      this.stringCommandLineOption("remote_build_event_upload") == "all"
+      this.buildToolLogs?.log.find(
+        (l) => (l.name == "execution.log" || l.name == "execution_log.binpb.zstd") && l.uri.startsWith("bytestream://")
+      ) && this.stringCommandLineOption("remote_build_event_upload") == "all"
     );
   }
 


### PR DESCRIPTION
Let users download the compact execution log with the correct file
extension. This way users could immediately tell how to consume the
downloaded file.

Also support the new file name that was proposed in (1).

(1): https://github.com/bazelbuild/bazel/pull/22172
