### PR TITLE
workflows: allow customizing git fetch

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1648,11 +1648,6 @@ func (ws *workspace) sync(ctx context.Context) error {
 		return err
 	}
 	merge := action.GetTriggers().GetPullRequestTrigger().GetMergeWithBase()
-	if *gitFetchDepth > 0 {
-		// If not fetching the full commit history, then we might not have the
-		// merge-base commit available, so we can't reliably merge.
-		merge = false
-	}
 	// If enabled by the config, merge the target branch (if different from the
 	// pushed branch) so that the workflow can pick up any changes not yet
 	// incorporated into the pushed branch.

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -972,7 +972,6 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 		artifactsDir := artifactsPathForCommand(ws, i)
 		namedSetID := filepath.Base(artifactsDir)
 
-		// Note: we don't use ar.action.Env here because it's already
 		runErr := runCommand(ctx, *bazelCommand, expandEnv(args), nil, action.BazelWorkspaceDir, ar.reporter)
 		exitCode := getExitCode(runErr)
 		ar.reporter.Publish(&bespb.BuildEvent{

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -151,6 +151,8 @@ var (
 	patchURIs          = flag.Slice("patch_uri", []string{}, "URIs of patches to apply to the repo after checkout. Can be specified multiple times to apply multiple patches.")
 	recordRunMetadata  = flag.Bool("record_run_metadata", false, "Instead of running a target, extract metadata about it and report it in the build event stream.")
 	gitCleanExclude    = flag.Slice("git_clean_exclude", []string{}, "Directories to exclude from `git clean` while setting up the repo.")
+	gitFetchFilters    = flag.Slice("git_fetch_filters", []string{}, "Filters to apply to `git fetch` commands.")
+	gitFetchDepth      = flag.Int("git_fetch_depth", 0, "Depth to use for `git fetch` commands.")
 
 	shutdownAndExit = flag.Bool("shutdown_and_exit", false, "If set, runs bazel shutdown with the configured bazel_command, and exits. No other commands are run.")
 
@@ -970,7 +972,8 @@ func (ar *actionRunner) Run(ctx context.Context, ws *workspace) error {
 		artifactsDir := artifactsPathForCommand(ws, i)
 		namedSetID := filepath.Base(artifactsDir)
 
-		runErr := runCommand(ctx, *bazelCommand, expandEnv(args), action.Env, action.BazelWorkspaceDir, ar.reporter)
+		// Note: we don't use ar.action.Env here because it's already
+		runErr := runCommand(ctx, *bazelCommand, expandEnv(args), nil, action.BazelWorkspaceDir, ar.reporter)
 		exitCode := getExitCode(runErr)
 		ar.reporter.Publish(&bespb.BuildEvent{
 			Id: &bespb.BuildEventId{Id: &bespb.BuildEventId_TargetCompleted{
@@ -1533,7 +1536,7 @@ func (ws *workspace) setup(ctx context.Context) error {
 	if err := os.Chdir(repoDirName); err != nil {
 		return status.WrapErrorf(err, "cd %q", repoDirName)
 	}
-	if err := ws.clone(ctx, *targetRepoURL); err != nil {
+	if err := ws.init(ctx); err != nil {
 		return err
 	}
 	if err := ws.config(ctx); err != nil {
@@ -1646,6 +1649,11 @@ func (ws *workspace) sync(ctx context.Context) error {
 		return err
 	}
 	merge := action.GetTriggers().GetPullRequestTrigger().GetMergeWithBase()
+	if *gitFetchDepth > 0 {
+		// If not fetching the full commit history, then we might not have the
+		// merge-base commit available, so we can't reliably merge.
+		merge = false
+	}
 	// If enabled by the config, merge the target branch (if different from the
 	// pushed branch) so that the workflow can pick up any changes not yet
 	// incorporated into the pushed branch.
@@ -1687,6 +1695,10 @@ func (ws *workspace) config(ctx context.Context) error {
 		{"user.email", "ci-runner@buildbuddy.io"},
 		{"user.name", "BuildBuddy"},
 		{"advice.detachedHead", "false"},
+		// With the version of git that we have installed in the CI runner
+		// image, --filter=blob:none requires the partialClone extension to be
+		// enabled.
+		{"extensions.partialClone", "true"},
 	}
 	writeCommandSummary(ws.log, "Configuring repository...")
 	for _, kv := range cfg {
@@ -1713,16 +1725,9 @@ func (ws *workspace) config(ctx context.Context) error {
 	return nil
 }
 
-func (ws *workspace) clone(ctx context.Context, remoteURL string) error {
-	authURL, err := gitutil.AuthRepoURL(remoteURL, os.Getenv(repoUserEnvVarName), os.Getenv(repoTokenEnvVarName))
-	if err != nil {
-		return err
-	}
-	writeCommandSummary(ws.log, "Cloning target repo...")
-	// Don't show command since the URL may contain the repo access token.
-	args := []string{"clone", "--config=credential.helper=", "--filter=blob:none", "--no-checkout", authURL, "."}
-	if err := runCommand(ctx, "git", args, map[string]string{}, "" /*=dir*/, ws.log); err != nil {
-		return status.UnknownError("Command `git clone --filter=blob:none --no-checkout <url>` failed.")
+func (ws *workspace) init(ctx context.Context) error {
+	if _, err := git(ctx, ws.log, "init"); err != nil {
+		return status.UnknownError("git init failed")
 	}
 	return nil
 }
@@ -1751,7 +1756,15 @@ func (ws *workspace) fetch(ctx context.Context, remoteURL string, branches []str
 			return status.UnknownErrorf("Command `git remote add %q <url>` failed.", remoteName)
 		}
 	}
-	fetchArgs := append([]string{"-c", "credential.helper=", "fetch", "--filter=blob:none", "--force", remoteName}, branches...)
+	fetchArgs := []string{"-c", "credential.helper=", "fetch", "--force"}
+	for _, filter := range *gitFetchFilters {
+		fetchArgs = append(fetchArgs, "--filter="+filter)
+	}
+	if *gitFetchDepth > 0 {
+		fetchArgs = append(fetchArgs, fmt.Sprintf("--depth=%d", *gitFetchDepth))
+	}
+	fetchArgs = append(fetchArgs, remoteName)
+	fetchArgs = append(fetchArgs, branches...)
 	if _, err := git(ctx, ws.log, fetchArgs...); err != nil {
 		return err
 	}

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -193,6 +193,22 @@ actions:
 `,
 	}
 
+	workspaceContentsWithExitScriptAndGitFetchDepth = map[string]string{
+		"WORKSPACE": `workspace(name = "test")`,
+		"BUILD":     `sh_binary(name = "exit", srcs = ["exit.sh"])`,
+		"exit.sh":   `exit "$1"`,
+		"buildbuddy.yaml": `
+actions:
+  - name: "Test"
+    triggers:
+      pull_request: { branches: [ master ] }
+      push: { branches: [ master ] }
+    git_fetch_depth: 1
+    bazel_commands:
+      - run :exit -- 0
+`,
+	}
+
 	invocationIDPattern = regexp.MustCompile(`Invocation URL:\s+.*?/invocation/([a-f0-9-]+)`)
 )
 
@@ -1015,6 +1031,29 @@ func TestFailedGitSetup_StillPublishesBuildMetadata(t *testing.T) {
 		"should publish workflow invocation metadata to BES despite failed repo setup")
 }
 
+func TestFetchFilters(t *testing.T) {
+	wsPath := testfs.MakeTempDir(t)
+	repoPath, headCommitSHA := makeGitRepo(t, workspaceContentsWithBazelVersionAction)
+	app := buildbuddy.Run(t)
+
+	runnerFlags := []string{
+		"--workflow_id=test-workflow",
+		"--action_name=Show bazel version",
+		"--trigger_event=push",
+		"--pushed_repo_url=file://" + repoPath,
+		"--pushed_branch=master",
+		"--commit_sha=" + headCommitSHA,
+		"--target_repo_url=file://" + repoPath,
+		"--target_branch=master",
+		"--git_fetch_filters=blob:none",
+	}
+	runnerFlags = append(runnerFlags, app.BESBazelFlags()...)
+
+	result := invokeRunner(t, runnerFlags, []string{}, wsPath)
+
+	checkRunnerResult(t, result)
+}
+
 func TestDisableBaseBranchMerging(t *testing.T) {
 	wsPath := testfs.MakeTempDir(t)
 	repoPath, headCommitSHA := makeGitRepo(t, workspaceContentsWithExitScriptAndMergeDisabled)
@@ -1040,6 +1079,43 @@ func TestDisableBaseBranchMerging(t *testing.T) {
 		"--commit_sha=" + headCommitSHA,
 		"--target_repo_url=file://" + repoPath,
 		"--target_branch=master",
+	}
+	app := buildbuddy.Run(t)
+	runnerFlags = append(runnerFlags, app.BESBazelFlags()...)
+
+	result := invokeRunner(t, runnerFlags, nil, wsPath)
+	checkRunnerResult(t, result)
+}
+
+func TestFetchDepth1(t *testing.T) {
+	wsPath := testfs.MakeTempDir(t)
+	repoPath, headCommitSHA := makeGitRepo(t, workspaceContentsWithExitScriptAndGitFetchDepth)
+	testshell.Run(t, repoPath, `
+		# Create a PR branch
+		git checkout -b pr-branch
+
+		# Add a bad commit to the master branch;
+		# since we're fetching with --depth=1 this should disable
+		# the merge-with-base behavior, so this change should not break our
+		# CI run on the PR branch which doesn't have this change yet.
+		git checkout master
+		echo 'exit 1' > exit.sh
+		git add .
+		git commit -m "Fail"
+	`)
+
+	runnerFlags := []string{
+		"--workflow_id=test-workflow",
+		"--action_name=Test",
+		"--trigger_event=pull_request",
+		"--pushed_repo_url=file://" + repoPath,
+		"--pushed_branch=pr-branch",
+		"--commit_sha=" + headCommitSHA,
+		"--target_repo_url=file://" + repoPath,
+		"--target_branch=master",
+		// Need to set the fetch_depth flag even though it's set in the config,
+		// since this is required in order to fetch the config.
+		"--git_fetch_depth=1",
 	}
 	app := buildbuddy.Run(t)
 	runnerFlags = append(runnerFlags, app.BESBazelFlags()...)

--- a/enterprise/server/workflow/config/BUILD
+++ b/enterprise/server/workflow/config/BUILD
@@ -20,5 +20,6 @@ go_test(
         ":config",
         "//enterprise/server/workflow/config/test_data",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -35,6 +35,8 @@ type Action struct {
 	ResourceRequests  ResourceRequests  `yaml:"resource_requests"`
 	User              string            `yaml:"user"`
 	GitCleanExclude   []string          `yaml:"git_clean_exclude"`
+	GitFetchFilters   []string          `yaml:"git_fetch_filters"`
+	GitFetchDepth     int               `yaml:"git_fetch_depth"`
 	BazelWorkspaceDir string            `yaml:"bazel_workspace_dir"`
 	Env               map[string]string `yaml:"env"`
 	BazelCommands     []string          `yaml:"bazel_commands"`
@@ -46,6 +48,16 @@ func (a *Action) GetTriggers() *Triggers {
 		return &Triggers{}
 	}
 	return a.Triggers
+}
+
+func (a *Action) GetGitFetchFilters() []string {
+	if a.GitFetchFilters == nil {
+		// Default to blob:none if unspecified.
+		// TODO: this seems to increase fetch time in some cases;
+		// consider removing this as the default.
+		return []string{"blob:none"}
+	}
+	return a.GitFetchFilters
 }
 
 type Triggers struct {


### PR DESCRIPTION
* Instead of `git clone`, do a `git init` which doesn't fetch anything.
* Allow customizing the `git fetch` via two new workflow config options `git_fetch_filters` and `git_fetch_depth`. `git_fetch_filters` defaults to `["blob:none"]` to match what we have today, and `git_fetch_depth` defaults to `0` (equivalent to not being set).

**Related issues**: N/A
