### PR TITLE
bazelrc: write exec log to local repo

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -270,8 +270,8 @@ common --experimental_profile_include_primary_output
 common --noslim_profile
 # Include compact execution log
 # TODO(sluongng): make Bazel writes this to output_base automatically
-common:linux --experimental_execution_log_compact_file=/tmp/bazel_compact_exec_log.binpb.zstd
-common:macos --experimental_execution_log_compact_file=/tmp/bazel_compact_exec_log.binpb.zstd
+common:linux --experimental_execution_log_compact_file=bazel_compact_exec_log.binpb.zstd
+common:macos --experimental_execution_log_compact_file=bazel_compact_exec_log.binpb.zstd
 
 # Try importing a user specific .bazelrc
 # You can create your own by copying and editing the template-user.bazelrc template:

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ buildbuddy-key.pem
 
 # User specific config files
 enterprise/config/user-configs
+
+# Bazel compact execution log
+/bazel_compact_exec_log.binpb.zstd


### PR DESCRIPTION
In a shared environment, the file under `/tmp` could be written by
another user, thus cause a permission conflict.

Let's write it to user's local repo to avoid this issue.
