### PR TITLE
Add NHID to replica descriptor

### DIFF
--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -272,6 +272,7 @@ func MakeBootstrapInfo(shardID, firstReplicaID uint64, nodeGrpcAddrs map[string]
 		bi.Replicas = append(bi.Replicas, &rfpb.ReplicaDescriptor{
 			ShardId:   shardID,
 			ReplicaId: replicaID,
+			Nhid:      proto.String(nhid),
 		})
 		bi.initialMembers[replicaID] = nhid
 		i += 1

--- a/enterprise/server/raft/rangelease/rangelease_test.go
+++ b/enterprise/server/raft/rangelease/rangelease_test.go
@@ -39,7 +39,7 @@ func (fs *fakeStore) AddPeer(ctx context.Context, sourceShardID, newShardID uint
 func (fs *fakeStore) SnapshotCluster(ctx context.Context, shardID uint64) error {
 	return nil
 }
-func newTestReplica(t testing.TB, rootDir string, shardID, replicaID uint64, store replica.IStore) *replica.Replica {
+func newTestReplica(t testing.TB, rootDir string, shardID, replicaID uint64, store replica.IStore) (*replica.Replica, pebble.IPebbleDB) {
 	db, err := pebble.Open(rootDir, "test", &pebble.Options{})
 	require.NoError(t, err)
 
@@ -49,7 +49,7 @@ func newTestReplica(t testing.TB, rootDir string, shardID, replicaID uint64, sto
 		db.Close()
 	})
 
-	return replica.New(leaser, shardID, replicaID, store, nil /*=usageUpdates=*/)
+	return replica.New(leaser, shardID, replicaID, "" /*=NHID=*/, store, nil /*=usageUpdates=*/), db
 }
 
 const shardID = 1
@@ -129,7 +129,7 @@ func (t *testingSender) SyncRead(ctx context.Context, key []byte, batch *rfpb.Ba
 func newTestingProposerAndSenderAndReplica(t testing.TB) (*testingProposer, *testingSender, *replica.Replica) {
 	rootDir := testfs.MakeTempDir(t)
 	store := &fakeStore{}
-	r := newTestReplica(t, rootDir, 1, 1, store)
+	r, _ := newTestReplica(t, rootDir, 1, 1, store)
 	require.NotNil(t, r)
 
 	randID, err := random.RandomString(10)

--- a/enterprise/server/raft/rangelease/rangelease_test.go
+++ b/enterprise/server/raft/rangelease/rangelease_test.go
@@ -39,7 +39,10 @@ func (fs *fakeStore) AddPeer(ctx context.Context, sourceShardID, newShardID uint
 func (fs *fakeStore) SnapshotCluster(ctx context.Context, shardID uint64) error {
 	return nil
 }
-func newTestReplica(t testing.TB, rootDir string, shardID, replicaID uint64, store replica.IStore) (*replica.Replica, pebble.IPebbleDB) {
+func (fs *fakeStore) NHID() string {
+	return ""
+}
+func newTestReplica(t testing.TB, rootDir string, shardID, replicaID uint64, store replica.IStore) *replica.Replica {
 	db, err := pebble.Open(rootDir, "test", &pebble.Options{})
 	require.NoError(t, err)
 
@@ -49,7 +52,7 @@ func newTestReplica(t testing.TB, rootDir string, shardID, replicaID uint64, sto
 		db.Close()
 	})
 
-	return replica.New(leaser, shardID, replicaID, "" /*=NHID=*/, store, nil /*=usageUpdates=*/), db
+	return replica.New(leaser, shardID, replicaID, store, nil /*=usageUpdates=*/)
 }
 
 const shardID = 1
@@ -129,7 +132,7 @@ func (t *testingSender) SyncRead(ctx context.Context, key []byte, batch *rfpb.Ba
 func newTestingProposerAndSenderAndReplica(t testing.TB) (*testingProposer, *testingSender, *replica.Replica) {
 	rootDir := testfs.MakeTempDir(t)
 	store := &fakeStore{}
-	r, _ := newTestReplica(t, rootDir, 1, 1, store)
+	r := newTestReplica(t, rootDir, 1, 1, store)
 	require.NotNil(t, r)
 
 	randID, err := random.RandomString(10)

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -82,6 +82,8 @@ type Replica struct {
 	fileDir   string
 	ShardID   uint64
 	ReplicaID uint64
+	// The ID of the node where this replica resided.
+	NHID string
 
 	store               IStore
 	lastAppliedIndex    uint64
@@ -188,6 +190,7 @@ func (sm *Replica) Usage() (*rfpb.ReplicaUsage, error) {
 		Replica: &rfpb.ReplicaDescriptor{
 			ShardId:   sm.ShardID,
 			ReplicaId: sm.ReplicaID,
+			Nhid:      proto.String(sm.NHID),
 		},
 		RangeId: rd.GetRangeId(),
 	}
@@ -2074,10 +2077,11 @@ func (sm *Replica) Close() error {
 }
 
 // New creates a new Replica, an on-disk state machine.
-func New(leaser pebble.Leaser, shardID, replicaID uint64, store IStore, broadcast chan<- events.Event) *Replica {
+func New(leaser pebble.Leaser, shardID, replicaID uint64, nhid string, store IStore, broadcast chan<- events.Event) *Replica {
 	return &Replica{
 		ShardID:             shardID,
 		ReplicaID:           replicaID,
+		NHID:                nhid,
 		store:               store,
 		leaser:              leaser,
 		partitionMetadata:   make(map[string]*rfpb.PartitionMetadata),

--- a/enterprise/server/raft/replica/replica.go
+++ b/enterprise/server/raft/replica/replica.go
@@ -71,6 +71,7 @@ type IStore interface {
 	Sender() *sender.Sender
 	AddPeer(ctx context.Context, sourceShardID, newShardID uint64) error
 	SnapshotCluster(ctx context.Context, shardID uint64) error
+	NHID() string
 }
 
 // Replica implements the interface IOnDiskStateMachine. More details of
@@ -2077,11 +2078,11 @@ func (sm *Replica) Close() error {
 }
 
 // New creates a new Replica, an on-disk state machine.
-func New(leaser pebble.Leaser, shardID, replicaID uint64, nhid string, store IStore, broadcast chan<- events.Event) *Replica {
+func New(leaser pebble.Leaser, shardID, replicaID uint64, store IStore, broadcast chan<- events.Event) *Replica {
 	return &Replica{
 		ShardID:             shardID,
 		ReplicaID:           replicaID,
-		NHID:                nhid,
+		NHID:                store.NHID(),
 		store:               store,
 		leaser:              leaser,
 		partitionMetadata:   make(map[string]*rfpb.PartitionMetadata),

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -668,7 +668,7 @@ func (s *Store) LeasedRange(header *rfpb.Header) (*replica.Replica, error) {
 }
 
 func (s *Store) ReplicaFactoryFn(shardID, replicaID uint64) dbsm.IOnDiskStateMachine {
-	r := replica.New(s.leaser, shardID, replicaID, s.nodeHost.ID(), s, s.events)
+	r := replica.New(s.leaser, shardID, replicaID, s, s.events)
 	return r
 }
 
@@ -686,6 +686,10 @@ func (s *Store) ConfiguredClusters() int {
 
 func (s *Store) NodeHost() *dragonboat.NodeHost {
 	return s.nodeHost
+}
+
+func (s *Store) NHID() string {
+	return s.nodeHost.ID()
 }
 
 func (s *Store) NodeDescriptor() *rfpb.NodeDescriptor {

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -446,6 +446,9 @@ message NodeDescriptor {
 message ReplicaDescriptor {
   uint64 shard_id = 1;
   uint64 replica_id = 2;
+
+  // The identifier of the node the replica resided.
+  optional string nhid = 3;
 }
 
 message Header {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Store the nhid in ReplicaDesciptor. This enables us to tell which store has
a particular range by looking at the rangeDescriptor which contains a list of 
ReplicaDescriptors.
