### PR TITLE
Add service for generating short-lived user certificates.

### DIFF
--- a/enterprise/server/certgenerator/BUILD
+++ b/enterprise/server/certgenerator/BUILD
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "certgenerator_lib",
+    srcs = ["certgenerator.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/certgenerator",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//enterprise/server/auth",
+        "//enterprise/server/backends/configsecrets",
+        "//proto:certgenerator_go_proto",
+        "//server/config",
+        "//server/real_environment",
+        "//server/ssl",
+        "//server/util/flag",
+        "//server/util/grpc_server",
+        "//server/util/healthcheck",
+        "//server/util/log",
+        "//server/util/status",
+        "//server/util/tracing",
+        "@com_github_coreos_go_oidc//:go-oidc",
+        "@org_golang_x_crypto//ssh",
+    ],
+)
+
+go_binary(
+    name = "certgenerator",
+    embed = [":certgenerator_lib"],
+    visibility = ["//visibility:public"],
+)
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/certgenerator/certgenerator.go
+++ b/enterprise/server/certgenerator/certgenerator.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/auth"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/configsecrets"
+	"github.com/buildbuddy-io/buildbuddy/server/config"
+	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/ssl"
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
+	"github.com/buildbuddy-io/buildbuddy/server/util/healthcheck"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
+	"github.com/coreos/go-oidc"
+	"golang.org/x/crypto/ssh"
+
+	cgpb "github.com/buildbuddy-io/buildbuddy/proto/certgenerator"
+)
+
+var (
+	serverType = flag.String("server_type", "certgenerator-server", "The server type to match on health checks")
+
+	tokenIssuer   = flag.String("certgenerator.token.issuer", "", "Issuer of the OIDC token against which it will be validated.")
+	tokenClientID = flag.String("certgenerator.token.client_id", "", "When verifying the OIDC token, only tokens for this client ID will be accepted.")
+	domain        = flag.String("certgenerator.token.domain", "", "When verifying the OIDC token, only tokens for this domain will be accepted.")
+
+	sshCertDuration   = flag.Duration("certgenerator.ssh.validity", 12*time.Hour, "How long the generated certificate will be valid.")
+	sshCertPrincipals = flag.String("certgenerator.ssh.principals", "", "Comma separated list of principals to include in the generated certificate.")
+
+	caKeyFile = flag.String("certgenerator.ca_key_file", "", "Path to a PEM encoded certificate authority key file used to issue temporary user certificates.")
+	caKey     = flag.String("certgenerator.ca_key", "", "PEM encoded certificate authority key used to issue temporary user certificates.", flag.Secret)
+)
+
+const (
+	// Allow user to get an interactive prompt when using SSH.
+	allowPty = "permit-pty"
+)
+
+type generator struct {
+	verifier *oidc.IDTokenVerifier
+
+	sshSigner ssh.Signer
+}
+
+func (g *generator) Generate(ctx context.Context, req *cgpb.GenerateRequest) (*cgpb.GenerateResponse, error) {
+	idToken, err := g.verifier.Verify(ctx, req.GetToken())
+	if err != nil {
+		return nil, status.PermissionDeniedErrorf("invalid token: %s", err)
+	}
+	claims := struct {
+		Subject       string `json:"sub"`
+		Domain        string `json:"hd"`
+		Email         string `json:"email"`
+		EmailVerified bool   `json:"email_verified"`
+	}{}
+	if err := idToken.Claims(&claims); err != nil {
+		return nil, status.PermissionDeniedErrorf("could not parse claims: %s", err)
+	}
+	if claims.Domain != *domain {
+		return nil, status.PermissionDeniedErrorf("invalid domain %q", claims.Domain)
+	}
+	if !claims.EmailVerified {
+		return nil, status.PermissionDeniedError("email not verified")
+	}
+
+	pk, _, _, _, err := ssh.ParseAuthorizedKey([]byte(req.GetSshPublicKey()))
+	if err != nil {
+		return nil, status.InvalidArgumentErrorf("could not parse public key: %s", err)
+	}
+
+	log.Infof("Generating certificate for: %+v", claims)
+
+	cert := ssh.Certificate{
+		Key:             pk,
+		CertType:        ssh.UserCert,
+		KeyId:           claims.Email,
+		ValidPrincipals: strings.Split(*sshCertPrincipals, ","),
+		ValidAfter:      uint64(time.Now().Unix()),
+		ValidBefore:     uint64(time.Now().Add(*sshCertDuration).Unix()),
+	}
+	cert.Permissions.Extensions = map[string]string{allowPty: ""}
+	if err := cert.SignCert(rand.Reader, g.sshSigner); err != nil {
+		return nil, err
+	}
+
+	return &cgpb.GenerateResponse{
+		SshCert: string(ssh.MarshalAuthorizedKey(&cert)),
+	}, nil
+}
+
+func newGenerator(ctx context.Context) (*generator, error) {
+	provider, err := oidc.NewProvider(ctx, *tokenIssuer)
+	if err != nil {
+		return nil, status.UnavailableErrorf("could not create OIDC provider: %s", err)
+	}
+	key, err := ssl.LoadCertificateKey(*caKeyFile, *caKey)
+	if err != nil {
+		return nil, status.FailedPreconditionErrorf("could not load CA certificate: %s", err)
+	}
+	s, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		return nil, err
+	}
+	g := &generator{
+		verifier:  provider.Verifier(&oidc.Config{ClientID: *tokenClientID}),
+		sshSigner: s,
+	}
+	return g, nil
+}
+
+func main() {
+	flag.Parse()
+	if err := configsecrets.Configure(); err != nil {
+		log.Fatalf("Could not prepare config secrets provider: %s", err)
+	}
+	if err := config.Load(); err != nil {
+		log.Fatalf("Error loading config from file: %s", err)
+	}
+	if err := log.Configure(); err != nil {
+		fmt.Printf("Error configuring logging: %s", err)
+		os.Exit(1)
+	}
+	healthChecker := healthcheck.NewHealthChecker(*serverType)
+	env := real_environment.NewRealEnv(healthChecker)
+	env.SetMux(tracing.NewHttpServeMux(http.NewServeMux()))
+	if err := auth.RegisterNullAuth(env); err != nil {
+		log.Fatalf("Could not configure auth: %s", err)
+	}
+
+	if err := ssl.Register(env); err != nil {
+		log.Fatalf("Could not enable SSL: %s", err)
+	}
+
+	ctx := context.Background()
+	gen, err := newGenerator(ctx)
+	if err != nil {
+		log.Fatalf("Could not create generator: %s", err)
+	}
+
+	s, err := grpc_server.New(env, grpc_server.GRPCPort(), false /*=ssl*/, grpc_server.GRPCServerConfig{})
+	if err != nil {
+		log.Fatalf("Could not create gRPC server: %s", err)
+	}
+	cgpb.RegisterCertGeneratorServer(s.GetServer(), gen)
+	if err := s.Start(); err != nil {
+		log.Fatalf("Could not start gRPC server: %s", err)
+	}
+
+	if env.GetSSLService().IsEnabled() {
+		s, err := grpc_server.New(env, grpc_server.GRPCSPort(), true /*=ssl*/, grpc_server.GRPCServerConfig{})
+		if err != nil {
+			log.Fatalf("Could not create gRPC server: %s", err)
+		}
+		cgpb.RegisterCertGeneratorServer(s.GetServer(), gen)
+		if err := s.Start(); err != nil {
+			log.Fatalf("Could not start gRPC server: %s", err)
+		}
+	}
+
+	healthChecker.WaitForGracefulShutdown()
+}

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -110,6 +110,13 @@ proto_library(
 )
 
 proto_library(
+    name = "certgenerator_proto",
+    srcs = [
+        "certgenerator.proto",
+    ],
+)
+
+proto_library(
     name = "config_proto",
     srcs = [
         "config.proto",
@@ -1438,6 +1445,19 @@ go_proto_library(
         ":remote_execution_go_proto",
         ":resource_go_proto",
         "@org_golang_google_genproto_googleapis_rpc//status",
+    ],
+)
+
+go_proto_library(
+    name = "certgenerator_go_proto",
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@io_bazel_rules_go//proto:go_grpc_v2",
+        "//proto:vtprotobuf_compiler",
+    ],
+    importpath = "github.com/buildbuddy-io/buildbuddy/proto/certgenerator",
+    proto = ":certgenerator_proto",
+    deps = [
     ],
 )
 

--- a/proto/certgenerator.proto
+++ b/proto/certgenerator.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package certgenerator;
+
+message GenerateRequest {
+  // OIDC token user to verify the caller's identity.
+  string token = 1;
+  // The SSH public key to be signed, in OpenSSH format.
+  string ssh_public_key = 2;
+}
+
+message GenerateResponse {
+  // Signed SSH certificate, in OpenSSH format.
+  string ssh_cert = 1;
+}
+
+// Services responsible for generating short-lived user certificates.
+service CertGenerator {
+  rpc Generate(GenerateRequest) returns (GenerateResponse);
+}

--- a/proto/certgenerator.proto
+++ b/proto/certgenerator.proto
@@ -14,7 +14,7 @@ message GenerateResponse {
   string ssh_cert = 1;
 }
 
-// Services responsible for generating short-lived user certificates.
+// Service responsible for generating short-lived user certificates.
 service CertGenerator {
   rpc Generate(GenerateRequest) returns (GenerateResponse);
 }

--- a/server/http/interceptors/interceptors.go
+++ b/server/http/interceptors/interceptors.go
@@ -273,10 +273,10 @@ func (w *instrumentedResponseWriter) Flush() {
 	}
 }
 
-func alertOnPanic() {
+func alertOnPanic(err any) {
 	buf := make([]byte, 1<<20)
 	n := runtime.Stack(buf, true)
-	alert.UnexpectedEvent("recovered_panic", buf[:n])
+	alert.UnexpectedEvent("recovered_panic", "%v\n%s", err, buf[:n])
 }
 
 func RecoverAndAlert(next http.Handler) http.Handler {
@@ -284,7 +284,7 @@ func RecoverAndAlert(next http.Handler) http.Handler {
 		defer func() {
 			if panicErr := recover(); panicErr != nil {
 				http.Error(w, "A panic occurred", http.StatusInternalServerError)
-				alertOnPanic()
+				alertOnPanic(panicErr)
 			}
 		}()
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
The initial use case is for SSH certificates.

The user will present an OIDC token and a public key. After validating the token, the server will sign the public key and return the signed key back to the user.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
