### PR TITLE
Add command line tool for obtaining a SSH cert.

### DIFF
--- a/tools/bbcert/BUILD
+++ b/tools/bbcert/BUILD
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "bbcert_lib",
+    srcs = ["bbcert.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/tools/bbcert",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//proto:certgenerator_go_proto",
+        "//server/util/flag",
+        "//server/util/grpc_client",
+        "//server/util/log",
+    ],
+)
+
+go_binary(
+    name = "bbcert",
+    embed = [":bbcert_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/bbcert/bbcert.go
+++ b/tools/bbcert/bbcert.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+
+	cgpb "github.com/buildbuddy-io/buildbuddy/proto/certgenerator"
+)
+
+var (
+	server = flag.String("server", "", "gRPC target for the certificate server")
+)
+
+const (
+	sshDir = ".ssh"
+	// For now, assume user is using an RSA key.
+	defaultRSAPublicKeyFile   = "id_rsa.pub"
+	defaultRSACertificateFile = "id_rsa-cert.pub"
+)
+
+func main() {
+	flag.Parse()
+
+	conn, err := grpc_client.DialSimple(*server)
+	if err != nil {
+		log.Fatalf("Could not dial server: %s", err)
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("Could not determine home directory: %s", err)
+	}
+
+	publicKey := path.Join(homeDir, sshDir, defaultRSAPublicKeyFile)
+	log.Infof("Using public key %q.", publicKey)
+
+	pub, err := os.ReadFile(publicKey)
+	if err != nil {
+		log.Fatalf("Could not read public %q key: %s", publicKey, err)
+	}
+
+	ctx := context.Background()
+
+	log.Infof("Getting identity token from gcloud.")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := exec.CommandContext(ctx, "gcloud", "auth", "print-identity-token")
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("Could not get identity token from gcloud:\n%s", stderr.String())
+	}
+	token := stdout.String()
+
+	log.Infof("Requesting certificate from remote server.")
+
+	client := cgpb.NewCertGeneratorClient(conn)
+	req := &cgpb.GenerateRequest{
+		Token:        token,
+		SshPublicKey: string(pub),
+	}
+	resp, err := client.Generate(ctx, req)
+	if err != nil {
+		log.Fatalf("Could not generate certificate: %s", err)
+	}
+
+	certFile := path.Join(homeDir, sshDir, defaultRSACertificateFile)
+	if err := os.WriteFile(certFile, []byte(resp.GetSshCert()), 0644); err != nil {
+		log.Fatalf("Could not write certificate to %q: %s", certFile, err)
+	}
+
+	log.Infof("Wrote certificate to %q.", certFile)
+}


### PR DESCRIPTION
Obtains an OIDC token from gcloud, sends it to the remote server along with the SSH public key to be signed.

Once the cert is obtained, it's written to a location that ssh expects to find it.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
