### PR TITLE
Run a kythe workflow if codesearch is enabled

### DIFF
--- a/enterprise/server/workflow/config/BUILD
+++ b/enterprise/server/workflow/config/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/config",
     deps = [
         "//enterprise/server/webhooks/webhook_data",
+        "//server/endpoint_urls/cache_api_url",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/webhooks/webhook_data"
+	"github.com/buildbuddy-io/buildbuddy/server/endpoint_urls/cache_api_url"
 	"gopkg.in/yaml.v2"
 )
 
@@ -21,7 +22,7 @@ const (
 
 	// KytheActionName is the name used for actions automatically
 	// run by us if code search is enabled.
-	KytheActionName = "AutoKythe"
+	KytheActionName = "Generate CodeSearch Index"
 )
 
 type BuildBuddyConfig struct {
@@ -153,13 +154,18 @@ func KytheIndexingAction(targetRepoDefaultBranch string) *Action {
 	if targetRepoDefaultBranch != "" {
 		pushTriggerBranches = append(pushTriggerBranches, targetRepoDefaultBranch)
 	}
+
+	cmd := "build --override_repository kythe_release=$KYTHE_DIR"
+	cmd += " --remote_cache=" + cache_api_url.String()
+	cmd += " //..."
+
 	return &Action{
 		Name: KytheActionName,
 		Triggers: &Triggers{
 			Push: &PushTrigger{Branches: pushTriggerBranches},
 		},
 		// Note: default Bazel flags are written by the runner to ~/.bazelrc
-		BazelCommands: []string{"build --override_repository kythe_release=$KYTHE_DIR //..."},
+		BazelCommands: []string{cmd},
 	}
 }
 

--- a/enterprise/server/workflow/service/BUILD
+++ b/enterprise/server/workflow/service/BUILD
@@ -45,6 +45,7 @@ go_library(
         "@com_github_google_go_github_v59//github",
         "@com_github_google_uuid//:uuid",
         "@com_github_prometheus_client_golang//prometheus",
+        "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_google_genproto//googleapis/longrunning",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//types/known/durationpb",

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -50,6 +51,7 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/genproto/googleapis/longrunning"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"gopkg.in/yaml.v2"
 
 	ctxpb "github.com/buildbuddy-io/buildbuddy/proto/context"
 	inspb "github.com/buildbuddy-io/buildbuddy/proto/invocation_status"
@@ -609,13 +611,20 @@ func (ws *workflowService) getActions(ctx context.Context, wf *tables.Workflow, 
 		return nil, err
 	}
 
+	addKythe, err := ws.enableExtraKytheIndexingAction(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	var actions []*config.Action
 	for _, a := range cfg.Actions {
 		if len(actionFilter) == 0 || config.MatchesAnyActionName(a, actionFilter) {
 			actions = append(actions, a)
 		}
 	}
-
+	if addKythe {
+		actions = append(actions, config.KytheIndexingAction(wd.TargetRepoDefaultBranch))
+	}
 	if len(actions) == 0 {
 		if len(actionFilter) == 0 {
 			return nil, status.NotFoundError("no workflow actions found")
@@ -688,6 +697,18 @@ func (ws *workflowService) InvalidateAllSnapshotsForRepo(ctx context.Context, re
 	).Exec().Error
 
 	return err
+}
+
+func (ws *workflowService) enableExtraKytheIndexingAction(ctx context.Context) (bool, error) {
+	u, err := ws.env.GetAuthenticator().AuthenticatedUser(ctx)
+	if err != nil {
+		return false, err
+	}
+	g, err := ws.env.GetUserDB().GetGroupByID(ctx, u.GetGroupID())
+	if err != nil {
+		return false, err
+	}
+	return g.CodeSearchEnabled, nil
 }
 
 // TODO(Maggie): Delete useCleanWorkflow and checkCleanWorkflowPermissions after
@@ -1196,6 +1217,19 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 		"--bazel_command=" + ws.ciRunnerBazelCommand(),
 		"--debug=" + fmt.Sprintf("%v", ws.ciRunnerDebugMode()),
 	}
+
+	// HACK: Kythe requires some special args, so if the name of this action
+	// indicates it's a Kythe action, add those args.
+	if workflowAction.Name == config.KytheActionName {
+		yamlBytes, err := yaml.Marshal(workflowAction)
+		if err != nil {
+			return nil, err
+		}
+		serializedAction := base64.StdEncoding.EncodeToString(yamlBytes)
+		args = append(args, "--bazel_startup_flags=--bazelrc=$KYTHE_DIR/extractors.bazelrc")
+		args = append(args, "--serialized_action="+serializedAction)
+	}
+
 	for _, filter := range workflowAction.GetGitFetchFilters() {
 		args = append(args, "--git_fetch_filters="+filter)
 	}

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1228,6 +1228,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 		serializedAction := base64.StdEncoding.EncodeToString(yamlBytes)
 		args = append(args, "--bazel_startup_flags=--bazelrc=$KYTHE_DIR/extractors.bazelrc")
 		args = append(args, "--serialized_action="+serializedAction)
+		args = append(args, "--install_kythe=true")
 	}
 
 	for _, filter := range workflowAction.GetGitFetchFilters() {


### PR DESCRIPTION
If enabled, automatically insert a custom workflow which will effectively run:
```bash
blaze build --override_repository kythe_release=$KYTHE_DIR --bazelrc=$KYTHE_DIR/extractors.bazelrc //...
```
only when the default branch is Pushed.