### PR TITLE
Fix incorrect credential helper path

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -578,6 +578,14 @@ func run() error {
 	ws.log = buildEventReporter
 	ws.hostname, ws.username = getHostAndUserName()
 
+	// Set BUILDBUDDY_CI_RUNNER_ABSPATH so that we can re-invoke ourselves
+	// as the git credential helper reliably, even after chdir.
+	absPath, err := filepath.Abs(os.Args[0])
+	if err != nil {
+		return status.WrapError(err, "compute CI runner binary abspath")
+	}
+	os.Setenv("BUILDBUDDY_CI_RUNNER_ABSPATH", absPath)
+
 	// Change the current working directory to respect WORKDIR_OVERRIDE, if set.
 	if wd := os.Getenv("WORKDIR_OVERRIDE"); wd != "" {
 		if err := os.MkdirAll(wd, 0755); err != nil {
@@ -593,14 +601,6 @@ func run() error {
 		return err
 	}
 	ws.rootDir = rootDir
-
-	// Set BUILDBUDDY_CI_RUNNER_ABSPATH so that we can re-invoke ourselves
-	// as the git credential helper reliably, even after chdir.
-	absPath, err := filepath.Abs(os.Args[0])
-	if err != nil {
-		return status.WrapError(err, "compute CI runner binary abspath")
-	}
-	os.Setenv("BUILDBUDDY_CI_RUNNER_ABSPATH", absPath)
 
 	// Bazel needs a HOME dir; ensure that one is set.
 	if err := ensureHomeDir(); err != nil {


### PR DESCRIPTION
Fixes the error

```
/root/workspace/buildbuddy_ci_runner --credential_helper store: 1: /root/workspace/buildbuddy_ci_runner: not found
```

e.g. from this invocation: https://buildbuddy.buildbuddy.dev/invocation/9727fbf8-e397-4a4c-a15f-4a3ec519231a?actionDigest=6f58d2073848230084b1eedb848c1d1c593187c13f5457a41a1814245b4885d0%2F141&executeResponseDigest=c09bb1611a6ccc9e18ba4d038b0515d8926ab476f0305428e03c76929b781d31%2F184&role=CI_RUNNER&days=7&branch=master

The buildbuddy_ci_runner binary is stored in `/workspace`, but we change to `/root/workspace` before running workflows so that the workflow outputs don't wind up in the action working dir (to avoid expensive workspace syncing). We need to compute the CI runner's absolute path before changing to this dir.

I'm not sure how this ever worked :thinking: still looking into it.

**Related issues**: N/A
