### PR TITLE
Fix uid/gid errors from podman tar command

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -78,7 +78,7 @@ genrule(
         SRCS=($(SRCS))
         PODMAN_ARCHIVE=$${SRCS[0]}
         REGISTRIES_CONF=$${SRCS[1]}
-        tar --extract --file="$$PODMAN_ARCHIVE" --strip-components=1 --directory="$$TMPDIR"
+        tar --extract --file="$$PODMAN_ARCHIVE" --strip-components=1 --directory="$$TMPDIR" --no-same-owner
 
         # Remove README.md (not needed)
         rm "$$TMPDIR/README.md"


### PR DESCRIPTION
`tar` is trying to preserve the file permissions on the original artifact stored in GH actions but this is causing some issues for some workflows: https://buildbuddy.buildbuddy.dev/invocation/9727fbf8-e397-4a4c-a15f-4a3ec519231a?role=CI_RUNNER&days=7&branch=master

We don't need to preserve the exact owner from the release archive so just set `--no-same-owner` as a fix for now.

**Related issues**: N/A
