### PR TITLE
Revert "timing_card: get profile from structured flag"

### DIFF
--- a/app/invocation/invocation_timing_card.tsx
+++ b/app/invocation/invocation_timing_card.tsx
@@ -74,14 +74,8 @@ export default class InvocationTimingCardComponent extends React.Component<Props
   }
 
   getProfileFile(): build_event_stream.File | undefined {
-    const profileName =
-      this.props.model.structuredCommandLine
-        ?.find((scl) => scl.commandLineLabel == "canonical")
-        ?.sections?.find((s) => s.sectionLabel == "command options")
-        ?.optionList?.option?.find((o) => o.optionName == "profile")?.optionValue ?? "command.profile.gz";
-
     return this.props.model.buildToolLogs?.log.find(
-      (log: build_event_stream.File) => log.name == profileName && log.uri
+      (log: build_event_stream.File) => log.name != "execution.log" && log.uri
     );
   }
 


### PR DESCRIPTION
Suspected to break timing profiles for invocations with `--profile`.

Reverts buildbuddy-io/buildbuddy#6465