### PR TITLE
Rename InputNodeComponent to NodeComponent

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -123,12 +123,10 @@ ts_library(
         "//app/components/dialog",
         "//app/components/digest",
         "//app/components/link",
-        "//app/components/menu",
         "//app/components/modal",
-        "//app/components/popup",
         "//app/errors:error_service",
         "//app/format",
-        "//app/invocation:invocation_action_input_node",
+        "//app/invocation:invocation_action_tree_node",
         "//app/invocation:invocation_model",
         "//app/preferences",
         "//app/service:rpc_service",
@@ -147,8 +145,8 @@ ts_library(
 )
 
 ts_library(
-    name = "invocation_action_input_node",
-    srcs = ["invocation_action_input_node.tsx"],
+    name = "invocation_action_tree_node",
+    srcs = ["invocation_action_tree_node.tsx"],
     deps = [
         "//app/components/digest",
         "//app/format",

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -146,7 +146,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
       .fetchBytestreamFile(inputRootURL, this.props.model.getInvocationId(), "arraybuffer")
       .then((buffer) => {
         let inputRoot = build.bazel.remote.execution.v2.Directory.decode(new Uint8Array(buffer));
-        let inputNodes: TreeNode[] = inputRoot.directories.map((node) => ({
+        let inputDirectories: TreeNode[] = inputRoot.directories.map((node) => ({
           obj: node,
           type: "dir",
         }));
@@ -421,7 +421,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
       .then((buffer) => {
         let dir = build.bazel.remote.execution.v2.Directory.decode(new Uint8Array(buffer));
         this.state.treeShaToExpanded.set(digestString, true);
-        let nodes: TreeNode[] = dir.directories.map((child) => ({
+        let directories: TreeNode[] = dir.directories.map((child) => ({
           obj: child,
           type: "dir",
         }));
@@ -429,7 +429,6 @@ export default class InvocationActionCardComponent extends React.Component<Props
           obj: child,
           type: "file",
         }));
-        nodes.push(...files);
         let symlinks: TreeNode[] = dir.symlinks.map((child) => ({
           obj: child,
           type: "symlink",

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -154,7 +154,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
           obj: node,
           type: "symlink",
         }));
-        inputNodes.push(...inputSymlinks);
+        const inputNodes = [...inputDirectories, ...inputSymlinks];
         this.setState({ inputRoot, inputNodes });
       })
       .catch((e) => console.error("Failed to fetch input root:", e));
@@ -434,7 +434,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
           obj: child,
           type: "symlink",
         }));
-        nodes.push(...symlinks);
+        const nodes = [...directories, ...files, ...symlinks];
         this.state.treeShaToChildrenMap.set(digestString, nodes);
         this.forceUpdate();
       })

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import format from "../format/format";
 import InvocationModel from "./invocation_model";
-import { Download, Info, MoreVertical } from "lucide-react";
+import { Download, Info } from "lucide-react";
 import { build } from "../../proto/remote_execution_ts_proto";
 import { firecracker } from "../../proto/firecracker_ts_proto";
 import { google as google_timestamp } from "../../proto/timestamp_ts_proto";
 import { google as google_grpc_code } from "../../proto/grpc_code_ts_proto";
-import InputNodeComponent, { InputNode } from "./invocation_action_input_node";
+import TreeNodeComponent, { TreeNode } from "./invocation_action_tree_node";
 import rpcService from "../service/rpc_service";
 import DigestComponent from "../components/digest/digest";
 import { TextLink } from "../components/link/link";
@@ -14,8 +14,6 @@ import TerminalComponent from "../terminal/terminal";
 import { parseActionDigest, digestToString } from "../util/cache";
 import UserPreferences from "../preferences/preferences";
 import alert_service from "../alert/alert_service";
-import Popup from "../components/popup/popup";
-import Menu, { MenuItem } from "../components/menu/menu";
 import { workflow } from "../../proto/workflow_ts_proto";
 import errorService from "../errors/error_service";
 import Dialog, {
@@ -47,11 +45,11 @@ interface State {
   command?: build.bazel.remote.execution.v2.Command;
   error?: string;
   inputRoot?: build.bazel.remote.execution.v2.Directory;
-  inputDirs: InputNode[];
+  inputNodes: TreeNode[];
   isMenuOpen: boolean;
   showInvalidateSnapshotModal: boolean;
   treeShaToExpanded: Map<string, boolean>;
-  treeShaToChildrenMap: Map<string, InputNode[]>;
+  treeShaToChildrenMap: Map<string, TreeNode[]>;
   stderr?: string;
   stdout?: string;
   serverLogs?: ServerLog[];
@@ -65,10 +63,10 @@ interface ServerLog {
 export default class InvocationActionCardComponent extends React.Component<Props, State> {
   state: State = {
     treeShaToExpanded: new Map<string, boolean>(),
-    treeShaToChildrenMap: new Map<string, InputNode[]>(),
+    treeShaToChildrenMap: new Map<string, TreeNode[]>(),
     treeShaToTotalSizeMap: new Map<string, [Number, Number]>(),
     serverLogs: [],
-    inputDirs: [],
+    inputNodes: [],
     loadingAction: true,
     isMenuOpen: false,
     showInvalidateSnapshotModal: false,
@@ -86,7 +84,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
     }
   }
 
-  componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<State>, snapshot?: any): void {
+  componentDidUpdate(prevProps: Readonly<Props>): void {
     if (prevProps.search.get("actionDigest") != this.props.search.get("actionDigest")) {
       this.fetchAction();
       if (!this.props.search.has("executeResponseDigest")) {
@@ -137,7 +135,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
         });
         this.setState({ treeShaToTotalSizeMap: sizes });
       })
-      .catch((e) => {
+      .catch(() => {
         this.setState({ treeShaToTotalSizeMap: new Map<string, [Number, Number]>() });
       });
   }
@@ -148,11 +146,16 @@ export default class InvocationActionCardComponent extends React.Component<Props
       .fetchBytestreamFile(inputRootURL, this.props.model.getInvocationId(), "arraybuffer")
       .then((buffer) => {
         let inputRoot = build.bazel.remote.execution.v2.Directory.decode(new Uint8Array(buffer));
-        let inputDirs: InputNode[] = inputRoot.directories.map((node) => ({
+        let inputNodes: TreeNode[] = inputRoot.directories.map((node) => ({
           obj: node,
           type: "dir",
         }));
-        this.setState({ inputRoot, inputDirs });
+        let inputSymlinks: TreeNode[] = inputRoot.symlinks.map((node) => ({
+          obj: node,
+          type: "symlink",
+        }));
+        inputNodes.push(...inputSymlinks);
+        this.setState({ inputRoot, inputNodes });
       })
       .catch((e) => console.error("Failed to fetch input root:", e));
   }
@@ -398,7 +401,8 @@ export default class InvocationActionCardComponent extends React.Component<Props
     );
   }
 
-  handleFileClicked(node: InputNode) {
+  handleFileClicked(node: TreeNode) {
+    if (!("digest" in node.obj)) return;
     if (!node.obj?.digest) return;
 
     let dirUrl = this.props.model.getBytestreamURL(node.obj.digest);
@@ -417,15 +421,21 @@ export default class InvocationActionCardComponent extends React.Component<Props
       .then((buffer) => {
         let dir = build.bazel.remote.execution.v2.Directory.decode(new Uint8Array(buffer));
         this.state.treeShaToExpanded.set(digestString, true);
-        let dirs: InputNode[] = dir.directories.map((child) => ({
+        let nodes: TreeNode[] = dir.directories.map((child) => ({
           obj: child,
           type: "dir",
         }));
-        let files: InputNode[] = dir.files.map((child) => ({
+        let files: TreeNode[] = dir.files.map((child) => ({
           obj: child,
           type: "file",
         }));
-        this.state.treeShaToChildrenMap.set(digestString, dirs.concat(files));
+        nodes.push(...files);
+        let symlinks: TreeNode[] = dir.symlinks.map((child) => ({
+          obj: child,
+          type: "symlink",
+        }));
+        nodes.push(...symlinks);
+        this.state.treeShaToChildrenMap.set(digestString, nodes);
         this.forceUpdate();
       })
       .catch((e) => console.error(e));
@@ -541,10 +551,10 @@ export default class InvocationActionCardComponent extends React.Component<Props
                     )}
                     <div className="action-section">
                       <div className="action-property-title">Input files</div>
-                      {this.state.inputDirs.length ? (
+                      {this.state.inputNodes.length ? (
                         <div className="input-tree">
-                          {this.state.inputDirs.map((node) => (
-                            <InputNodeComponent
+                          {this.state.inputNodes.map((node) => (
+                            <TreeNodeComponent
                               node={node}
                               treeShaToExpanded={this.state.treeShaToExpanded}
                               treeShaToChildrenMap={this.state.treeShaToChildrenMap}

--- a/app/invocation/invocation_action_tree_node.tsx
+++ b/app/invocation/invocation_action_tree_node.tsx
@@ -33,7 +33,7 @@ function getChildCountText(childCount: Number) {
 }
 
 export default class TreeNodeComponent extends React.Component<Props, State> {
-  renderDigestNode(node: FileNode | DirectoryNode) {
+  renderFileOrDirectoryNode(node: FileNode | DirectoryNode) {
     const digestString = node.digest?.hash ?? "";
     const sizeInfo = this.props.treeShaToTotalSizeMap.get(digestString);
     const expanded = this.props.treeShaToExpanded.get(digestString);
@@ -102,7 +102,7 @@ export default class TreeNodeComponent extends React.Component<Props, State> {
 
   render() {
     return "digest" in this.props.node.obj
-      ? this.renderDigestNode(this.props.node.obj)
+      ? this.renderFileOrDirectoryNode(this.props.node.obj)
       : this.renderSymlinkNode(this.props.node.obj);
   }
 }

--- a/app/invocation/invocation_action_tree_node.tsx
+++ b/app/invocation/invocation_action_tree_node.tsx
@@ -86,7 +86,7 @@ export default class TreeNodeComponent extends React.Component<Props, State> {
   renderSymlinkNode(node: SymlinkNode) {
     return (
       <div className="input-tree-node">
-        <div className={"input-tree-node-name"}>
+        <div className="input-tree-node-name">
           <span>
             <FileSymlink className="icon symlink-icon" />
           </span>{" "}

--- a/app/invocation/invocation_action_tree_node.tsx
+++ b/app/invocation/invocation_action_tree_node.tsx
@@ -1,22 +1,26 @@
 import React from "react";
 import { build } from "../../proto/remote_execution_ts_proto";
-import { Download, FolderMinus, FolderPlus } from "lucide-react";
+import { ArrowRight, Download, FileSymlink, FolderMinus, FolderPlus } from "lucide-react";
 import DigestComponent from "../components/digest/digest";
 import format from "../format/format";
 
 interface Props {
-  node: InputNode;
+  node: TreeNode;
   treeShaToExpanded: Map<string, boolean>;
-  treeShaToChildrenMap: Map<string, InputNode[]>;
+  treeShaToChildrenMap: Map<string, TreeNode[]>;
   treeShaToTotalSizeMap: Map<string, [Number, Number]>;
   handleFileClicked: any;
 }
 
 interface State {}
 
-export interface InputNode {
-  obj: build.bazel.remote.execution.v2.FileNode | build.bazel.remote.execution.v2.DirectoryNode;
-  type: "file" | "dir";
+type FileNode = build.bazel.remote.execution.v2.FileNode;
+type DirectoryNode = build.bazel.remote.execution.v2.DirectoryNode;
+type SymlinkNode = build.bazel.remote.execution.v2.SymlinkNode;
+
+export interface TreeNode {
+  obj: FileNode | DirectoryNode | SymlinkNode;
+  type: "file" | "dir" | "symlink";
 }
 
 function getChildCountText(childCount: Number) {
@@ -28,11 +32,12 @@ function getChildCountText(childCount: Number) {
   return format.formatWithCommas(childCount) + " children";
 }
 
-export default class InputNodeComponent extends React.Component<Props, State> {
-  render() {
-    const digestString = this.props.node.obj.digest?.hash ?? "";
+export default class TreeNodeComponent extends React.Component<Props, State> {
+  renderDigestNode(node: FileNode | DirectoryNode) {
+    const digestString = node.digest?.hash ?? "";
     const sizeInfo = this.props.treeShaToTotalSizeMap.get(digestString);
     const expanded = this.props.treeShaToExpanded.get(digestString);
+
     return (
       <div className="input-tree-node">
         <div
@@ -51,7 +56,7 @@ export default class InputNodeComponent extends React.Component<Props, State> {
               </>
             )}
           </span>{" "}
-          <span className="input-tree-node-label">{this.props.node.obj.name}</span>
+          <span className="input-tree-node-label">{node.name}</span>
           {sizeInfo ? (
             <span className="input-tree-node-size">{`${format.bytes(+sizeInfo[0])} (${getChildCountText(
               sizeInfo[1]
@@ -59,12 +64,12 @@ export default class InputNodeComponent extends React.Component<Props, State> {
           ) : (
             ""
           )}
-          {this.props.node.obj?.digest && <DigestComponent digest={this.props.node.obj.digest} />}
+          {node.digest && <DigestComponent digest={node.digest} />}
         </div>
         {expanded && (
           <div className="input-tree-node-children">
-            {this.props.treeShaToChildrenMap.get(digestString)?.map((child: any) => (
-              <InputNodeComponent
+            {this.props.treeShaToChildrenMap.get(digestString)?.map((child: TreeNode) => (
+              <TreeNodeComponent
                 node={child}
                 treeShaToExpanded={this.props.treeShaToExpanded}
                 treeShaToChildrenMap={this.props.treeShaToChildrenMap}
@@ -76,5 +81,28 @@ export default class InputNodeComponent extends React.Component<Props, State> {
         )}
       </div>
     );
+  }
+
+  renderSymlinkNode(node: SymlinkNode) {
+    return (
+      <div className="input-tree-node">
+        <div className={"input-tree-node-name"}>
+          <span>
+            <FileSymlink className="icon symlink-icon" />
+          </span>{" "}
+          <span className="input-tree-node-label">{node.name}</span>{" "}
+          <span>
+            <ArrowRight className="icon symlink-arrow-icon" />
+          </span>{" "}
+          <span className="input-tree-node-label">{node.target}</span>
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    return "digest" in this.props.node.obj
+      ? this.renderDigestNode(this.props.node.obj)
+      : this.renderSymlinkNode(this.props.node.obj);
   }
 }


### PR DESCRIPTION
Refactor InputNodeComponent:

- Rename to TreeNodeComponent in prepare for later reuse in the Output tree.

- Add support for SymlinkNode. <img width="1501" alt="image" src="https://github.com/buildbuddy-io/buildbuddy/assets/26684313/25757475-3d79-4fb0-b442-85958c75f7e2">
