### PR TITLE
Remove Bazel flags enabled by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,11 +5,6 @@ common --enable_platform_specific_config=true
 # TODO(http://go/b/3325): re-enable after bazel 7.2.0
 common --experimental_worker_for_repo_fetching=off
 
-# Skymeld merges the analysis phase and execution phase.
-# This allows build and test executions to start before the analysis phase finishes,
-# thus speeding up the build overall .
-common:skymeld --experimental_merged_skyframe_analysis_execution
-
 # Build with --config=local to send build logs to your local server
 common:local --bes_results_url=http://localhost:8080/invocation/
 common:local --bes_backend=grpc://localhost:1985
@@ -42,8 +37,6 @@ common:remote-shared --jobs=100
 common:remote-shared --verbose_failures
 common:remote-shared --platforms=//platforms:linux_x86_64
 common:remote-shared --extra_execution_platforms=//platforms:linux_x86_64
-
-common --incompatible_enable_cc_toolchain_resolution
 
 # Build with --config=remote to use BuildBuddy RBE.
 common:remote --config=remote-shared


### PR DESCRIPTION
These flags are enabled by default in Bazel 7.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
