### PR TITLE
Fix non-hermeticity with rules_nodejs' directory inputs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -261,6 +261,9 @@ common --combined_report=lcov
 
 # Use BLAKE3 digest function.
 startup --digest_function=BLAKE3
+# Bazel doesn't track the contents of source directories by default, which can result
+# in non-hermeticity.
+startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
 
 # Include target names in timing profile so it's clickable.
 common --experimental_profile_include_target_label


### PR DESCRIPTION
Fixes warnings such as:
```
WARNING: /private/var/tmp/_bazel_fmeum/412888b82b4f18156bc415025cb8faa1/external/npm_fast-glob-3.2.7/BUILD.bazel:6:10: input 'extract_tmp/package' to @@npm_fast-glob-3.2.7//:_npm_fast-glob-3.2.7 is a directory; dependency checking of directories is unsound
```

**Related issues**: N/A
