### PR TITLE
set total bytes free in store.Usage

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1109,7 +1109,6 @@ func (s *Store) Usage() *rfpb.StoreUsage {
 		}
 		su.ReadQps += ru.GetReadQps()
 		su.RaftProposeQps += ru.GetRaftProposeQps()
-		su.TotalBytesUsed += ru.GetEstimatedDiskBytesUsed()
 		return true
 	})
 
@@ -1123,6 +1122,12 @@ func (s *Store) Usage() *rfpb.StoreUsage {
 		return nil
 	}
 	su.TotalBytesUsed = int64(diskEstimateBytes)
+
+	capacity := int64(0)
+	for _, p := range s.partitions {
+		capacity += p.MaxSizeBytes
+	}
+	su.TotalBytesFree = capacity - su.TotalBytesUsed
 	return su
 }
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A

Also remove calculating totalBytesUsed in the replicas.Range loop since it was overwritten later by diskEstimateBytes

