### PR TITLE
Add flag to write bare runner output to temp log files for debugging

### DIFF
--- a/enterprise/server/remote_execution/containers/bare/BUILD
+++ b/enterprise/server/remote_execution/containers/bare/BUILD
@@ -28,6 +28,7 @@ go_test(
         "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
         "//server/testutil/testfs",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
     ],
 )

--- a/enterprise/server/remote_execution/containers/bare/bare.go
+++ b/enterprise/server/remote_execution/containers/bare/bare.go
@@ -1,8 +1,11 @@
 package bare
 
 import (
+	"bytes"
 	"context"
 	"flag"
+	"io"
+	"os"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
@@ -18,6 +21,7 @@ import (
 
 var (
 	bareEnableStats = flag.Bool("executor.bare.enable_stats", false, "Whether to enable stats for bare command execution.")
+	enableLogFiles  = flag.Bool("executor.bare.enable_log_files", false, "Whether to send bare runner output to log files for debugging. These files are stored adjacent to the task directory and are deleted when the task is complete.")
 )
 
 type Opts struct {
@@ -64,7 +68,7 @@ func (c *bareCommandContainer) Exec(ctx context.Context, cmd *repb.Command, stdi
 	return c.exec(ctx, cmd, c.WorkDir, stdio)
 }
 
-func (c *bareCommandContainer) exec(ctx context.Context, cmd *repb.Command, workDir string, stdio *interfaces.Stdio) *interfaces.CommandResult {
+func (c *bareCommandContainer) exec(ctx context.Context, cmd *repb.Command, workDir string, stdio *interfaces.Stdio) (result *interfaces.CommandResult) {
 	var statsListener procstats.Listener
 	if c.opts.EnableStats {
 		defer container.Metrics.Unregister(c)
@@ -72,6 +76,45 @@ func (c *bareCommandContainer) exec(ctx context.Context, cmd *repb.Command, work
 			container.Metrics.Observe(c, stats)
 		}
 	}
+
+	if *enableLogFiles {
+		stdoutPath := workDir + ".stdout"
+		stdoutFile, err := os.Create(stdoutPath)
+		if err != nil {
+			return commandutil.ErrorResult(status.UnavailableErrorf("create stdout log file: %s", err))
+		}
+		defer stdoutFile.Close()
+		defer os.Remove(stdoutPath)
+
+		stderrPath := workDir + ".stderr"
+		stderrFile, err := os.Create(stderrPath)
+		if err != nil {
+			return commandutil.ErrorResult(status.UnavailableErrorf("create stderr log file: %s", err))
+		}
+		defer stderrFile.Close()
+		defer os.Remove(stderrPath)
+
+		if stdio == nil {
+			stdio = &interfaces.Stdio{}
+		}
+		// We want to set stdio.{Stdout,Stderr} in order to write to log files.
+		// But setting stdout/stderr disables the default buffering behavior
+		// (into the CommandResult Stdout/Stderr fields). So we need to manually
+		// buffer stdout/stderr here.
+		if stdio.Stdout == nil {
+			stdoutBuf := &bytes.Buffer{}
+			stdio.Stdout = stdoutBuf
+			defer func() { result.Stdout = stdoutBuf.Bytes() }()
+		}
+		if stdio.Stderr == nil {
+			stderrBuf := &bytes.Buffer{}
+			stdio.Stderr = stderrBuf
+			defer func() { result.Stderr = stderrBuf.Bytes() }()
+		}
+		stdio.Stdout = io.MultiWriter(stdio.Stdout, stdoutFile)
+		stdio.Stderr = io.MultiWriter(stdio.Stderr, stderrFile)
+	}
+
 	return commandutil.Run(ctx, cmd, workDir, statsListener, stdio)
 }
 


### PR DESCRIPTION
With `podman` we can run `podman logs` to see the output from a running container so we can debug it if it's stuck. This PR adds a similar capability to `bare` runners by writing command logs to a file while they are running (behind a flag).

Planning to enable these on mac workflow executors so that we can debug stuck workflow tasks.

**Related issues**: N/A
