### PR TITLE
queue update usage tags task at the end of new with args

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -248,6 +248,11 @@ func NewWithArgs(env environment.Env, rootDir string, nodeHost *dragonboat.NodeH
 	gossipManager.AddListener(s)
 	statusz.AddSection("raft_store", "Store", s)
 
+	// Whenever we bring up a brand new store with no ranges, we need to inform
+	// other stores about its existence using store_usage tag, in order to make
+	// it a potentia replication target.
+	updateTagsWorker.Enqueue()
+
 	return s, nil
 }
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
When a new store is created without any ranges. It is not known to other stores
by store_usage tag; and thus in my placement driver prototype, https://github.com/buildbuddy-io/buildbuddy/pull/6515,
the new store was not detected by other stores as a valid replication target.
