### PR TITLE
Support passing a commit sha in the ExecuteWorkflow API

### DIFF
--- a/docs/enterprise-api.md
+++ b/docs/enterprise-api.md
@@ -788,23 +788,24 @@ rpc ExecuteWorkflow(ExecuteWorkflowRequest) returns (ExecuteWorkflowResponse);
 ### Example cURL request
 
 ```bash
-# Execute workflow on tip of main branch with env vars set
+# Execute workflow on commit abc123 on branch cool-feature with env vars set
 curl -d '{
   "repo_url": "https://github.com/buildbuddy-io/buildbuddy-ci-playground",
-  "branch": "main",
-  "action_names": ["Build and test (Mac M1)"],
+  "branch": "cool-feature",
+  "commit_sha": "abc123",
+  "action_names": ["Test"],
   "env": {"USE_BAZEL_VERSION": "6.4.0"}
 }' \
 -H "x-buildbuddy-api-key: YOUR_BUILDBUDDY_API_KEY" \
 -H 'Content-Type: application/json' \
 https://app.buildbuddy.io/api/v1/ExecuteWorkflow
 
-# Execute workflow on commit abc123 on branch cool-feature
+# Example populating `branch` and `commit_sha` from a Github Actions workflow
 curl -d '{
   "repo_url": "https://github.com/buildbuddy-io/buildbuddy-ci-playground",
-  "branch": "cool-feature",
-  "commit_sha": "abc123",
-  "action_names": ["Build and test (Mac M1)"],
+  "branch": ${{ github.ref_name }},
+  "commit_sha": ${{ github.sha }},
+  "action_names": ["Test"],
 }' \
 -H "x-buildbuddy-api-key: YOUR_BUILDBUDDY_API_KEY" \
 -H 'Content-Type: application/json' \
@@ -818,7 +819,7 @@ message ExecuteWorkflowRequest {
   // URL of the repo the workflow is running for
   // Ex. "https://github.com/some-user/acme"
   string repo_url = 1;
-  // Reference for where the workflow should be run (at least one of `branch` or
+  // Git refs at which the workflow should be run (at least one of `branch` or
   // `commit_sha` must be set). If only `branch` is set, will run from the tip
   // of the branch. If only `commit_sha` is set, reporting will not contain the
   // branch name.

--- a/docs/enterprise-api.md
+++ b/docs/enterprise-api.md
@@ -803,8 +803,8 @@ https://app.buildbuddy.io/api/v1/ExecuteWorkflow
 # Example populating `branch` and `commit_sha` from a Github Actions workflow
 curl -d '{
   "repo_url": "https://github.com/buildbuddy-io/buildbuddy-ci-playground",
-  "branch": ${{ github.ref_name }},
-  "commit_sha": ${{ github.sha }},
+  "branch": "${{ github.ref_name }}",
+  "commit_sha": "${{ github.sha }}",
   "action_names": ["Test"],
 }' \
 -H "x-buildbuddy-api-key: YOUR_BUILDBUDDY_API_KEY" \

--- a/docs/enterprise-api.md
+++ b/docs/enterprise-api.md
@@ -767,7 +767,7 @@ message DeleteFileResponse {}
 
 ## ExecuteWorkflow
 
-The `ExecuteWorkflow` endpoint lets you trigger a Buildbuddy Workflow for the given repository and branch.
+The `ExecuteWorkflow` endpoint lets you trigger a Buildbuddy Workflow for the given repository and branch/commit.
 
 Note: Github App authentication is required. The API does not support running legacy workflows. See
 https://www.buildbuddy.io/docs/workflows-setup/ for more information on how to setup workflows with
@@ -788,11 +788,23 @@ rpc ExecuteWorkflow(ExecuteWorkflowRequest) returns (ExecuteWorkflowResponse);
 ### Example cURL request
 
 ```bash
+# Execute workflow on tip of main branch with env vars set
 curl -d '{
   "repo_url": "https://github.com/buildbuddy-io/buildbuddy-ci-playground",
-  "ref": "main",
+  "branch": "main",
   "action_names": ["Build and test (Mac M1)"],
   "env": {"USE_BAZEL_VERSION": "6.4.0"}
+}' \
+-H "x-buildbuddy-api-key: YOUR_BUILDBUDDY_API_KEY" \
+-H 'Content-Type: application/json' \
+https://app.buildbuddy.io/api/v1/ExecuteWorkflow
+
+# Execute workflow on commit abc123 on branch cool-feature
+curl -d '{
+  "repo_url": "https://github.com/buildbuddy-io/buildbuddy-ci-playground",
+  "branch": "cool-feature",
+  "commit_sha": "abc123",
+  "action_names": ["Build and test (Mac M1)"],
 }' \
 -H "x-buildbuddy-api-key: YOUR_BUILDBUDDY_API_KEY" \
 -H 'Content-Type: application/json' \
@@ -806,9 +818,12 @@ message ExecuteWorkflowRequest {
   // URL of the repo the workflow is running for
   // Ex. "https://github.com/some-user/acme"
   string repo_url = 1;
-  // Reference for where the workflow should be run (currently only branch names
-  // are supported) Ex. "cool-feature" or "main"
-  string ref = 2;
+  // Reference for where the workflow should be run (at least one of `branch` or
+  // `commit_sha` must be set). If only `branch` is set, will run from the tip
+  // of the branch. If only `commit_sha` is set, reporting will not contain the
+  // branch name.
+  string branch = 8;
+  string commit_sha = 9;
 
   // OPTIONAL FIELDS
 

--- a/enterprise/server/api/api_server.go
+++ b/enterprise/server/api/api_server.go
@@ -526,14 +526,19 @@ func (s *APIServer) ExecuteWorkflow(ctx context.Context, req *apipb.ExecuteWorkf
 	requestCtx := requestcontext.ProtoRequestContextFromContext(ctx)
 
 	wfID := wfs.GetLegacyWorkflowIDForGitRepository(user.GetGroupID(), req.GetRepoUrl())
+	branch := req.GetBranch()
+	if branch == "" && req.GetCommitSha() == "" {
+		// For backwards compatibility, set branch from `ref` if neither `branch`
+		// or `commit_sha` are set
+		branch = req.GetRef()
+	}
 	r := &workflow.ExecuteWorkflowRequest{
 		RequestContext: requestCtx,
 		WorkflowId:     wfID,
 		ActionNames:    req.GetActionNames(),
 		PushedRepoUrl:  req.GetRepoUrl(),
-		PushedBranch:   req.GetRef(),
-		TargetRepoUrl:  req.GetRepoUrl(),
-		TargetBranch:   req.GetRef(),
+		PushedBranch:   branch,
+		CommitSha:      req.GetCommitSha(),
 		Visibility:     req.GetVisibility(),
 		Async:          req.GetAsync(),
 		Env:            req.GetEnv(),

--- a/proto/api/v1/workflow.proto
+++ b/proto/api/v1/workflow.proto
@@ -9,7 +9,7 @@ message ExecuteWorkflowRequest {
   // Ex. "https://github.com/some-user/acme"
   string repo_url = 1;
 
-  // Reference for where the workflow should be run (at least one of `branch` or
+  // Git refs at which the workflow should be run (at least one of `branch` or
   // `commit_sha` must be set). If only `branch` is set, will run from the tip
   // of the branch. If only `commit_sha` is set, reporting will not contain the
   // branch name.

--- a/proto/api/v1/workflow.proto
+++ b/proto/api/v1/workflow.proto
@@ -8,9 +8,13 @@ message ExecuteWorkflowRequest {
   // URL of the repo the workflow is running for
   // Ex. "https://github.com/some-user/acme"
   string repo_url = 1;
-  // Reference for where the workflow should be run (currently only branch names
-  // are supported) Ex. "cool-feature"
-  string ref = 2;
+
+  // Reference for where the workflow should be run (at least one of `branch` or
+  // `commit_sha` must be set). If only `branch` is set, will run from the tip
+  // of the branch. If only `commit_sha` is set, reporting will not contain the
+  // branch name.
+  string branch = 8;
+  string commit_sha = 9;
 
   // OPTIONAL FIELDS
 
@@ -34,6 +38,9 @@ message ExecuteWorkflowRequest {
   // overrides will take precedence. Otherwise all env vars set in
   // buildbuddy.yaml will still apply.
   map<string, string> env = 7;
+
+  // DEPRECATED: Use `branch` and/or `commit_sha` instead.
+  string ref = 2 [deprecated = true];
 }
 
 message ExecuteWorkflowResponse {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: This PR must be rolled out first: https://github.com/buildbuddy-io/buildbuddy/pull/6519
