### PR TITLE
Allow moving mouse outside heatmap while making selection

### DIFF
--- a/enterprise/app/trends/BUILD
+++ b/enterprise/app/trends/BUILD
@@ -126,6 +126,7 @@ ts_library(
     srcs = ["heatmap.tsx"],
     deps = [
         "//app/components/tooltip",
+        "//app/util:math",
         "//proto:stats_ts_proto",
         "@npm//@types/d3-scale",
         "@npm//@types/long",


### PR DESCRIPTION
A small itch I've wanted to scratch for a while. I find this a bit easier to use because it means I don't have to keep my mouse perfectly within the chart bounds while making a selection (this gets more difficult when the selection is close to the edge of the chart), but lmk if you think the old behavior is better and I'd be fine closing this

Screenshot (shows current behavior first, then new behavior)

https://github.com/buildbuddy-io/buildbuddy/assets/2414826/1a733863-62bd-4430-9440-ad746f0eb83d



**Related issues**: N/A
