### PR TITLE
close db and leaser after nodehost.Close() is called

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -443,6 +443,9 @@ func (s *Store) Stop(ctx context.Context) error {
 	}
 	s.updateTagsWorker.Stop()
 
+	s.log.Info("Store: waitgroups finished")
+	s.nodeHost.Close()
+
 	if err := s.db.Flush(); err != nil {
 		return err
 	}
@@ -450,10 +453,6 @@ func (s *Store) Stop(ctx context.Context) error {
 
 	// Wait for all active requests to be finished.
 	s.leaser.Close()
-
-	s.log.Info("Store: waitgroups finished")
-	s.nodeHost.Close()
-
 	return grpc_server.GRPCShutdown(ctx, s.grpcServer)
 }
 

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -445,6 +445,7 @@ func (s *Store) Stop(ctx context.Context) error {
 
 	s.log.Info("Store: waitgroups finished")
 	s.nodeHost.Close()
+	s.log.Info("Store: nodeHost closed")
 
 	if err := s.db.Flush(); err != nil {
 		return err
@@ -453,6 +454,7 @@ func (s *Store) Stop(ctx context.Context) error {
 
 	// Wait for all active requests to be finished.
 	s.leaser.Close()
+	log.Info("Store: leaser closed")
 	return grpc_server.GRPCShutdown(ctx, s.grpcServer)
 }
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
nodehost.Close() might invoke some tasks that require the db such as save
snapshot. close db before nodehost.Close can cause panic.
