### PR TITLE
raft: fix a bug in AddReplica when we want to up-replicate meta range

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1464,21 +1464,21 @@ func (s *Store) AddReplica(ctx context.Context, req *rfpb.AddReplicaRequest) (*r
 	// Reserve a new node ID for the node about to be added.
 	replicaIDs, err := s.reserveReplicaIDs(ctx, 1)
 	if err != nil {
-		return nil, err
+		return nil, status.InternalErrorf("AddReplica failed to reserveReplicaIDs: %s", err)
 	}
 	newReplicaID := replicaIDs[0]
 
 	// Get the config change index for this cluster.
 	configChangeID, err := s.getConfigChangeID(ctx, shardID)
 	if err != nil {
-		return nil, err
+		return nil, status.InternalErrorf("AddReplica failed to get config change ID: %s", err)
 	}
 	lastAppliedIndex, err := s.getLastAppliedIndex(&rfpb.Header{
 		RangeId:    rd.GetRangeId(),
 		Generation: rd.GetGeneration(),
 	})
 	if err != nil {
-		return nil, err
+		return nil, status.InternalErrorf("AddReplica failed to get last applied index: %s", err)
 	}
 
 	// Gossip the address of the node that is about to be added.
@@ -1490,13 +1490,13 @@ func (s *Store) AddReplica(ctx context.Context, req *rfpb.AddReplicaRequest) (*r
 		return s.nodeHost.SyncRequestAddReplica(ctx, shardID, newReplicaID, node.GetNhid(), configChangeID)
 	})
 	if err != nil {
-		return nil, err
+		return nil, status.InternalErrorf("AddReplica failed to call nodeHost.SyncRequestAddReplica: %s", err)
 	}
 
 	// Start the cluster on the newly added node.
 	c, err := s.apiClient.Get(ctx, node.GetGrpcAddress())
 	if err != nil {
-		return nil, err
+		return nil, status.InternalErrorf("AddReplica failed to get the client for the node: %s", err)
 	}
 	_, err = c.StartShard(ctx, &rfpb.StartShardRequest{
 		ShardId:          shardID,
@@ -1505,14 +1505,14 @@ func (s *Store) AddReplica(ctx context.Context, req *rfpb.AddReplicaRequest) (*r
 		LastAppliedIndex: lastAppliedIndex,
 	})
 	if err != nil {
-		return nil, err
+		return nil, status.InternalErrorf("AddReplica failed to start shard: %s", err)
 	}
 
 	// Finally, update the range descriptor information to reflect the
 	// membership of this new node in the range.
 	rd, err = s.addReplicaToRangeDescriptor(ctx, shardID, newReplicaID, node.GetNhid(), rd)
 	if err != nil {
-		return nil, err
+		return nil, status.InternalErrorf("AddReplica failed to add replica to range descriptor: %s", err)
 	}
 	metrics.RaftMoves.With(prometheus.Labels{
 		metrics.RaftNodeHostIDLabel: s.nodeHost.ID(),
@@ -1754,12 +1754,24 @@ func (s *Store) updateRangeDescriptor(ctx context.Context, shardID uint64, old, 
 		},
 		ExpectedValue: oldBuf,
 	}
+
 	metaRangeBatch := rbuilder.NewBatchBuilder()
 	metaRangeBatch.Add(metaRangeCasReq)
 
 	mrd := s.sender.GetMetaRangeDescriptor()
-	txn := rbuilder.NewTxn().AddStatement(new.GetReplicas()[0], localBatch)
-	txn = txn.AddStatement(mrd.GetReplicas()[0], metaRangeBatch)
+	newReplica := new.GetReplicas()[0]
+	metaReplica := mrd.GetReplicas()[0]
+
+	txn := rbuilder.NewTxn()
+	if newReplica.GetShardId() == metaReplica.GetShardId() {
+		localBatch.Add(metaRangeCasReq)
+		txn.AddStatement(newReplica, localBatch)
+	} else {
+		metaRangeBatch := rbuilder.NewBatchBuilder()
+		metaRangeBatch.Add(metaRangeCasReq)
+		txn.AddStatement(newReplica, localBatch)
+		txn = txn.AddStatement(metaReplica, metaRangeBatch)
+	}
 	return s.txnCoordinator.RunTxn(ctx, txn)
 }
 

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -316,6 +316,26 @@ func TestAddNodeToCluster(t *testing.T) {
 	s = getStoreWithRangeLease(t, stores, 2)
 	rd = s.GetRange(2)
 	require.Equal(t, 2, len(rd.GetReplicas()))
+
+	// Add Replica for meta range
+	mrd := s.GetRange(1)
+	_, err = s.AddReplica(ctx, &rfpb.AddReplicaRequest{
+		Range: mrd,
+		Node: &rfpb.NodeDescriptor{
+			Nhid:        nh2.ID(),
+			RaftAddress: s2.RaftAddress,
+			GrpcAddress: s2.GRPCAddress,
+		},
+	})
+	require.NoError(t, err)
+
+	replicas, err = s.getMembership(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(replicas))
+
+	s = getStoreWithRangeLease(t, stores, 1)
+	rd = s.GetRange(1)
+	require.Equal(t, 2, len(rd.GetReplicas()))
 }
 
 func TestRemoveNodeFromCluster(t *testing.T) {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
When we are up-replicating meta range, we only want to add 1 statement instead
of 2 in AddReplica. 
Also, Add some contexts when returning error in AddReplica.

