### PR TITLE
CLI fix fixes

### DIFF
--- a/cli/add/add.go
+++ b/cli/add/add.go
@@ -30,7 +30,7 @@ Adds the given dependency to your WORKSPACE file.
 	footerTemplate = "###### End auto-generated section for %s ######"
 
 	headerRegex = regexp.MustCompile(`##### Begin auto-generated section for \[https://registry\.build/(.+?)@(.+?)\]`)
-	moduleRegex = regexp.MustCompile(`bazel_dep\(name = "([^"]+?)", version = "([^"]+?)"\)`)
+	moduleRegex = regexp.MustCompile(`bazel_dep\(name = "([^"]+?)", version = "([^"]+?)".*?\)`)
 )
 
 const (

--- a/cli/fix/fix.go
+++ b/cli/fix/fix.go
@@ -116,7 +116,7 @@ func runGazelle(repoRoot, baseFile string) error {
 		if err != nil {
 			return err
 		}
-		os.Args = append(os.Args, "-bzlmod", "-repo_config="+configPath)
+		os.Args = append(os.Args, "-bzlmod", "-repo_root="+repoRoot, "-repo_config="+configPath)
 	} else {
 		os.Args = append(os.Args, "-repo_root="+repoRoot, "-go_prefix=")
 	}


### PR DESCRIPTION
- Support searching for `bazel_deps` that contain repo_name (like ours do) ex:
```
bazel_dep(name = "rules_go", version = "0.47.1", repo_name = "io_bazel_rules_go")
```

- Add repo_root flag to gazelle invocations with bzlmod enabled (because gazelle has a hard time locating this repo root)

---

Still trying to understand / figure out a better solution for this gnarliness https://github.com/buildbuddy-io/buildbuddy/blob/master/cli/fix/fix.go#L76 which doesn't seem to work for me. But these two changes are nice to have regardless.
