### PR TITLE
Restrict group_id label cardinality

### DIFF
--- a/enterprise/server/remote_execution/executor/BUILD
+++ b/enterprise/server/remote_execution/executor/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//server/util/canary",
         "//server/util/disk",
         "//server/util/log",
+        "//server/util/metricsutil",
         "//server/util/status",
         "//server/util/tracing",
         "@com_github_prometheus_client_golang//prometheus",

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/canary"
 	"github.com/buildbuddy-io/buildbuddy/server/util/disk"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/metricsutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/tracing"
 	"github.com/prometheus/client_golang/prometheus"
@@ -359,7 +360,7 @@ func (m *ActionMetrics) Report(ctx context.Context) {
 		// Don't report metrics for cached actions for now.
 		return
 	}
-	groupID := interfaces.AuthAnonymousUser
+	groupID := ""
 	if u, err := auth.UserFromTrustedJWT(ctx); err == nil {
 		groupID = u.GetGroupID()
 	}
@@ -434,7 +435,7 @@ func observeStageDuration(groupID string, stage string, start *timestamppb.Times
 	}
 	duration := endTime.Sub(startTime)
 	metrics.RemoteExecutionExecutedActionMetadataDurationsUsec.With(prometheus.Labels{
-		metrics.GroupID:                  groupID,
+		metrics.GroupID:                  metricsutil.GroupIDLabel(groupID),
 		metrics.ExecutedActionStageLabel: stage,
 	}).Observe(float64(duration / time.Microsecond))
 }

--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -435,7 +435,7 @@ func observeStageDuration(groupID string, stage string, start *timestamppb.Times
 	}
 	duration := endTime.Sub(startTime)
 	metrics.RemoteExecutionExecutedActionMetadataDurationsUsec.With(prometheus.Labels{
-		metrics.GroupID:                  metricsutil.GroupIDLabel(groupID),
+		metrics.GroupID:                  metricsutil.FilteredGroupIDLabel(groupID),
 		metrics.ExecutedActionStageLabel: stage,
 	}).Observe(float64(duration / time.Microsecond))
 }

--- a/server/util/metricsutil/BUILD
+++ b/server/util/metricsutil/BUILD
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "metricsutil",
+    srcs = ["metricsutil.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/metricsutil",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/util/flag",
+    ],
+)

--- a/server/util/metricsutil/metricsutil.go
+++ b/server/util/metricsutil/metricsutil.go
@@ -10,9 +10,9 @@ var (
 	observedGroupIDs = flag.Slice("metrics.observed_group_ids", []string{}, "Group IDs allowed in group_id metrics labels. Groups not in this list will be labeled as 'ANON' if unauthenticated or 'other' if authenticated.")
 )
 
-// GroupIDLabel returns a value suitable for use with the GroupID label. It
-// restricts the observed group IDs to the allowed values configured by flag.
-func GroupIDLabel(groupID string) string {
+// FilteredGroupIDLabel returns a value suitable for use with the GroupID label.
+// It restricts the observed group IDs to the allowed values configured by flag.
+func FilteredGroupIDLabel(groupID string) string {
 	if groupID == "" || groupID == "ANON" {
 		return "ANON"
 	}

--- a/server/util/metricsutil/metricsutil.go
+++ b/server/util/metricsutil/metricsutil.go
@@ -1,0 +1,23 @@
+package metricsutil
+
+import (
+	"slices"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
+)
+
+var (
+	observedGroupIDs = flag.Slice("metrics.observed_group_ids", []string{}, "Group IDs allowed in group_id metrics labels. Groups not in this list will be labeled as 'ANON' if unauthenticated or 'other' if authenticated.")
+)
+
+// GroupIDLabel returns a value suitable for use with the GroupID label. It
+// restricts the observed group IDs to the allowed values configured by flag.
+func GroupIDLabel(groupID string) string {
+	if groupID == "" || groupID == "ANON" {
+		return "ANON"
+	}
+	if slices.Contains(*observedGroupIDs, groupID) {
+		return groupID
+	}
+	return "other"
+}


### PR DESCRIPTION
The "Action stage durations" chart cardinality is too high and makes it slow to load. A single query loads over 300K individual timeseries from the DB.

Restricting to just prober group IDs should fix this (we want to split out prober latency to keep the prober latency chart working). If we need to query by other group IDs, we can use Clickhouse instead.

**Related issues**: N/A
