### PR TITLE
Add protos for fine-grained execution progress

### DIFF
--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2232,6 +2232,43 @@ message UsageStats {
   repeated FileSystemUsage peak_file_system_usage = 4;
 }
 
+// BuildBuddy-specific auxiliary execution metadata containing fine-grained
+// execution progress. These will be published in partial_execution_metadata in
+// the ExecuteOperation stream.
+message ExecutionProgress {
+  // Executor timestamp at which the progress message was created.
+  google.protobuf.Timestamp timestamp = 1;
+
+  // Fine-grained execution state.
+  ExecutionState execution_state = 2;
+
+  // Fine-grained execution state for an action. Not all of these statuses are
+  // guaranteed to be published for every action, for example if there is an
+  // error that causes the action to exit early, or if the status requires using
+  // a certain isolation type.
+  enum ExecutionState {
+    UNKNOWN_EXECUTION_STATE = 0;
+
+    // Pulling the OCI image for the action.
+    PULLING_CONTAINER_IMAGE = 1;
+
+    // Downloading action inputs.
+    DOWNLOADING_INPUTS = 2;
+
+    // Booting a new VM.
+    BOOTING_VM = 4;
+
+    // Resuming a VM from snapshot.
+    RESUMING_VM = 5;
+
+    // Executing the command for the action.
+    EXECUTING_COMMAND = 6;
+
+    // Uploading action outputs.
+    UPLOADING_OUTPUTS = 7; 
+  }
+}
+
 // Proto representation of the Execution stored in OLAP DB. Only used in
 // backends.
 message StoredExecution {


### PR DESCRIPTION
The motivation for this PR is that when running a workflow we just show "Invocation is waiting for an available worker." This message is sort of misleading - often, the workflow action will be dequeued quickly, but then most of the time is spent booting or resuming the workflow VM.

But today, we don't really have a good way to display a more accurate message about what the task is currently doing. We do have ExecutionStage, but it only has "QUEUED" and "EXECUTING" stages, which are pretty coarse grained. If we were to use this data, we'd likely be in a similar position that we're in today, just showing "Invocation is executing" instead of "Invocation is waiting for an available worker", which doesn't feel much better.

This PR proposes a general way to communicate finer-grained progress about an execution, and for all actions, not just workflows.

The remote execution API supports publishing [`partial_execution_metadata`](https://github.com/buildbuddy-io/buildbuddy/blob/2c7302627852389b484c47f27f10c37ce33a87d2/proto/remote_execution.proto#L1550) which contains an `auxiliary_metadata` field that lets us pass arbitrary data (`Any`). To get finer-grained progress, all we need to do is set this field to what is basically a `{timestamp, status}` message. Then, we should be able to read this progress from the operation streams that we already have in Redis.

To make use of this API:
- On the executor, we can create a status publisher interface that we can pass around during task execution, and let each container type publish any relevant status messages that are applicable to the isolation type.
- On the frontend, we can call `WaitExecution` which would make use of the new frontend gRPC streaming capabilities.

**Related issues**: N/A
