### PR TITLE
Fix kythe workflow action

### DIFF
--- a/enterprise/server/webhooks/webhook_data/webhook_data.go
+++ b/enterprise/server/webhooks/webhook_data/webhook_data.go
@@ -9,14 +9,16 @@ import (
 var (
 	// EventName holds canonical webhook event name constants.
 	EventName struct {
-		Push        string
-		PullRequest string
+		Push           string
+		PullRequest    string
+		ManualDispatch string
 	}
 )
 
 func init() {
 	EventName.Push = "push"
 	EventName.PullRequest = "pull_request"
+	EventName.ManualDispatch = "manual_dispatch"
 }
 
 func DebugString(wd *interfaces.WebhookData) string {

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -200,9 +200,15 @@ func GetDefault(targetRepoDefaultBranch string) *BuildBuddyConfig {
 // MatchesAnyTrigger returns whether the action is triggered by the event
 // published to the given branch.
 func MatchesAnyTrigger(action *Action, event, branch string) bool {
+	// If user has manually requested action dispatch, always run it
+	if event == webhook_data.EventName.ManualDispatch {
+		return true
+	}
+
 	if action.Triggers == nil {
 		return false
 	}
+
 	if pushCfg := action.Triggers.Push; pushCfg != nil && event == webhook_data.EventName.Push {
 		return matchesAnyBranch(pushCfg.Branches, branch)
 	}

--- a/enterprise/server/workflow/service/BUILD
+++ b/enterprise/server/workflow/service/BUILD
@@ -61,6 +61,7 @@ go_test(
         ":service",
         "//enterprise/server/testutil/enterprise_testauth",
         "//enterprise/server/testutil/enterprise_testenv",
+        "//enterprise/server/workflow/config",
         "//proto:buildbuddy_service_go_proto",
         "//proto:git_go_proto",
         "//proto:remote_execution_go_proto",
@@ -88,5 +89,6 @@ go_test(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_protobuf//testing/protocmp",
+        "@org_golang_google_protobuf//types/known/anypb",
     ],
 )

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -557,24 +557,24 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 				return
 			}
 			invocationID = invocationUUID.String()
-			ctx = log.EnrichContext(ctx, log.InvocationIDKey, invocationID)
+			executionCtx := log.EnrichContext(ctx, log.InvocationIDKey, invocationID)
 
 			// The workflow execution is trusted since we're authenticated as a member of
 			// the BuildBuddy org that owns the workflow.
 			isTrusted := true
-			executionID, err := ws.executeWorkflowAction(ctx, apiKey, wf, wd, isTrusted, action, invocationID, extraCIRunnerArgs, req.GetEnv())
+			executionID, err := ws.executeWorkflowAction(executionCtx, apiKey, wf, wd, isTrusted, action, invocationID, extraCIRunnerArgs, req.GetEnv())
 			if err != nil {
 				statusErr = status.WrapErrorf(err, "failed to execute workflow action %q", action.Name)
-				log.CtxWarning(ctx, statusErr.Error())
+				log.CtxWarning(executionCtx, statusErr.Error())
 				return
 			}
-			ctx = log.EnrichContext(ctx, log.ExecutionIDKey, executionID)
+			executionCtx = log.EnrichContext(executionCtx, log.ExecutionIDKey, executionID)
 			if req.GetAsync() {
 				return
 			}
-			if err := ws.waitForWorkflowInvocationCreated(ctx, executionID, invocationID); err != nil {
+			if err := ws.waitForWorkflowInvocationCreated(executionCtx, executionID, invocationID); err != nil {
 				statusErr = err
-				log.CtxWarning(ctx, statusErr.Error())
+				log.CtxWarning(executionCtx, statusErr.Error())
 				return
 			}
 		}()

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/base64"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -509,6 +508,7 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 		TargetBranch:      req.GetTargetBranch(),
 		SHA:               req.GetCommitSha(),
 		PullRequestNumber: req.GetPullRequestNumber(),
+		EventName:         webhook_data.EventName.ManualDispatch,
 		// Don't set IsTargetRepoPublic here; instead set visibility directly
 		// from build metadata.
 	}
@@ -586,6 +586,8 @@ func (ws *workflowService) ExecuteWorkflow(ctx context.Context, req *wfpb.Execut
 	}, nil
 }
 
+// getActions fetches the workflow config (buildbuddy.yaml) and returns the list of
+// actions matching the webhook event
 func (ws *workflowService) getActions(ctx context.Context, wf *tables.Workflow, wd *interfaces.WebhookData, actionFilter []string) ([]*config.Action, error) {
 	// Fetch the workflow config
 	gitProvider, err := ws.providerForRepo(wd.PushedRepoURL)
@@ -594,22 +596,16 @@ func (ws *workflowService) getActions(ctx context.Context, wf *tables.Workflow, 
 	}
 	cfg, err := ws.fetchWorkflowConfig(ctx, gitProvider, wf, wd)
 	if err != nil {
-		return nil, err
-	}
-
-	addKythe, err := ws.enableExtraKytheIndexingAction(ctx)
-	if err != nil {
-		return nil, err
+		return nil, status.WrapError(err, "fetch workflow config")
 	}
 
 	var actions []*config.Action
 	for _, a := range cfg.Actions {
-		if len(actionFilter) == 0 || config.MatchesAnyActionName(a, actionFilter) {
+		matchesActionName := len(actionFilter) == 0 || config.MatchesAnyActionName(a, actionFilter)
+		matchesTrigger := config.MatchesAnyTrigger(a, wd.EventName, wd.TargetBranch)
+		if matchesActionName && matchesTrigger {
 			actions = append(actions, a)
 		}
-	}
-	if addKythe {
-		actions = append(actions, config.KytheIndexingAction(wd.TargetRepoDefaultBranch))
 	}
 	if len(actions) == 0 {
 		if len(actionFilter) == 0 {
@@ -685,15 +681,22 @@ func (ws *workflowService) InvalidateAllSnapshotsForRepo(ctx context.Context, re
 	return err
 }
 
-func (ws *workflowService) enableExtraKytheIndexingAction(ctx context.Context) (bool, error) {
+func (ws *workflowService) addDefaultConfigActions(ctx context.Context, c *config.BuildBuddyConfig, workflow *tables.Workflow, wd *interfaces.WebhookData) error {
+	enableKythe, err := ws.enableExtraKytheIndexingAction(ctx, workflow.GroupID)
+	if err != nil {
+		return err
+	}
+	if enableKythe {
+		c.Actions = append(c.Actions, config.KytheIndexingAction(wd.TargetRepoDefaultBranch))
+	}
+	return nil
+}
+
+func (ws *workflowService) enableExtraKytheIndexingAction(ctx context.Context, groupID string) (bool, error) {
 	if !*enableKytheIndexing {
 		return false, nil
 	}
-	u, err := ws.env.GetAuthenticator().AuthenticatedUser(ctx)
-	if err != nil {
-		return false, err
-	}
-	g, err := ws.env.GetUserDB().GetGroupByID(ctx, u.GetGroupID())
+	g, err := ws.env.GetUserDB().GetGroupByID(ctx, groupID)
 	if err != nil {
 		return false, err
 	}
@@ -1323,14 +1326,25 @@ func (ws *workflowService) fetchWorkflowConfig(ctx context.Context, gitProvider 
 		workflowRef = webhookData.PushedBranch
 	}
 
+	var c *config.BuildBuddyConfig
 	b, err := gitProvider.GetFileContents(ctx, workflow.AccessToken, webhookData.PushedRepoURL, config.FilePath, workflowRef)
-	if err != nil {
-		if status.IsNotFoundError(err) {
-			return config.GetDefault(webhookData.TargetRepoDefaultBranch), nil
+	if err == nil {
+		c, err = config.NewConfig(bytes.NewReader(b))
+		if err != nil {
+			return nil, err
 		}
+	} else {
+		if status.IsNotFoundError(err) {
+			c = config.GetDefault(webhookData.TargetRepoDefaultBranch)
+		} else {
+			return nil, err
+		}
+	}
+
+	if err := ws.addDefaultConfigActions(ctx, c, workflow, webhookData); err != nil {
 		return nil, err
 	}
-	return config.NewConfig(bytes.NewReader(b))
+	return c, nil
 }
 
 func (ws *workflowService) isTrustedCommit(ctx context.Context, gitProvider interfaces.GitProvider, wf *tables.Workflow, wd *interfaces.WebhookData) (bool, error) {
@@ -1407,23 +1421,20 @@ func (ws *workflowService) startWorkflow(ctx context.Context, gitProvider interf
 	if err != nil {
 		return err
 	}
-	// Fetch the workflow config (buildbuddy.yaml) and start a CI runner execution
-	// for each action matching the webhook event.
-	cfg, err := ws.fetchWorkflowConfig(ctx, gitProvider, wf, wd)
+
+	actions, err := ws.getActions(ctx, wf, wd, nil /*actionFilter*/)
 	if err != nil {
-		if err := ws.createWorkflowConfigErrorStatus(ctx, wf, wd); err != nil {
-			log.CtxWarningf(ctx, "Failed to create workflow config error status: %s", err)
+		if strings.Contains(err.Error(), "fetch workflow config") {
+			if err := ws.createWorkflowConfigErrorStatus(ctx, wf, wd); err != nil {
+				log.CtxWarningf(ctx, "Failed to create workflow config error status: %s", err)
+			}
 		}
 		return err
 	}
+
 	var wg sync.WaitGroup
-	for _, action := range cfg.Actions {
+	for _, action := range actions {
 		action := action
-		if !config.MatchesAnyTrigger(action, wd.EventName, wd.TargetBranch) {
-			jt, _ := json.Marshal(action.Triggers)
-			log.CtxDebugf(ctx, "Action %s not matched, triggers=%s", action.Name, string(jt))
-			continue
-		}
 		invocationUUID, err := guuid.NewRandom()
 		if err != nil {
 			return err

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -681,7 +681,7 @@ func (ws *workflowService) InvalidateAllSnapshotsForRepo(ctx context.Context, re
 	return err
 }
 
-func (ws *workflowService) addDefaultConfigActions(ctx context.Context, c *config.BuildBuddyConfig, workflow *tables.Workflow, wd *interfaces.WebhookData) error {
+func (ws *workflowService) addKytheActionIfEnabled(ctx context.Context, c *config.BuildBuddyConfig, workflow *tables.Workflow, wd *interfaces.WebhookData) error {
 	enableKythe, err := ws.enableExtraKytheIndexingAction(ctx, workflow.GroupID)
 	if err != nil {
 		return err
@@ -1341,7 +1341,7 @@ func (ws *workflowService) fetchWorkflowConfig(ctx context.Context, gitProvider 
 		}
 	}
 
-	if err := ws.addDefaultConfigActions(ctx, c, workflow, webhookData); err != nil {
+	if err := ws.addKytheActionIfEnabled(ctx, c, workflow, webhookData); err != nil {
 		return nil, err
 	}
 	return c, nil

--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testauth"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/testutil/enterprise_testenv"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/config"
 	"github.com/buildbuddy-io/buildbuddy/server/backends/repo_downloader"
 	"github.com/buildbuddy-io/buildbuddy/server/buildbuddy_server"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -31,6 +32,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	workflow "github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/service"
 	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
@@ -199,10 +201,20 @@ func (c *fakeExecutionClient) NextExecuteRequest() *executeRequest {
 	return <-c.executeRequests
 }
 
+func (c *fakeExecutionClient) WaitExecution(ctx context.Context, req *repb.WaitExecutionRequest, opts ...grpc.CallOption) (repb.Execution_WaitExecutionClient, error) {
+	return &fakeExecuteStream{}, nil
+}
+
 type fakeExecuteStream struct{ grpc.ClientStream }
 
 func (*fakeExecuteStream) Recv() (*longrunning.Operation, error) {
-	return &longrunning.Operation{Name: "fake-operation-name"}, nil
+	metadata, err := anypb.New(&repb.ExecuteOperationMetadata{
+		Stage: repb.ExecutionStage_COMPLETED,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &longrunning.Operation{Name: "fake-operation-name", Metadata: metadata}, nil
 }
 
 func authenticate(t *testing.T, ctx context.Context, env environment.Env) (authCtx context.Context, uid, gid string) {
@@ -688,4 +700,95 @@ func TestWebhook_TrustedPush_StartsTrustedWorkflow(t *testing.T) {
 		`BUILDBUDDY_API_KEY=[\w]+,REPO_USER=,REPO_TOKEN=`,
 		execReq.Metadata["x-buildbuddy-platform.env-overrides"],
 		"API key should be set via env-overrides")
+}
+
+func TestActionFiltering(t *testing.T) {
+	ctx := context.Background()
+	u, lis := testhttp.NewServer(t)
+	flags.Set(t, "app.build_buddy_url", *u)
+	flags.Set(t, "remote_execution.enable_remote_exec", true)
+	flags.Set(t, "remote_execution.enable_kythe_indexing", true)
+
+	te := newTestEnv(t)
+	ctx, uid, gid := authenticate(t, ctx, te)
+	execClient := te.GetRemoteExecutionClient().(*fakeExecutionClient)
+	te.SetRemoteExecutionClient(execClient)
+	go http.Serve(lis, te.GetWorkflowService())
+	_ = setupFakeGitProvider(t, te)
+	repoURL := makeTempRepo(t)
+	clientConn := runBBServer(ctx, te, t)
+	bbClient := bbspb.NewBuildBuddyServiceClient(clientConn)
+	reqCtx := testauth.RequestContext(uid, gid)
+	req := &wfpb.CreateWorkflowRequest{
+		RequestContext: reqCtx,
+		GitRepo:        &gitpb.GitRepo{RepoUrl: repoURL},
+	}
+	wfRes, err := bbClient.CreateWorkflow(ctx, req)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name            string
+		actionFilter    []string
+		kytheEnabled    bool
+		expectedActions []string
+	}{
+		{
+			name:            "no action filter, kythe disabled",
+			actionFilter:    nil,
+			kytheEnabled:    false,
+			expectedActions: []string{"Test all targets"},
+		},
+		{
+			name:            "no action filter, kythe enabled",
+			actionFilter:    nil,
+			kytheEnabled:    true,
+			expectedActions: []string{"Test all targets", config.KytheActionName},
+		},
+		{
+			name:            "action filter, kythe disabled",
+			actionFilter:    []string{"Test all targets"},
+			kytheEnabled:    false,
+			expectedActions: []string{"Test all targets"},
+		},
+		{
+			name:            "action filter, kythe enabled",
+			actionFilter:    []string{"Test all targets"},
+			kytheEnabled:    true,
+			expectedActions: []string{"Test all targets"},
+		},
+		{
+			name:            "kythe action filter",
+			actionFilter:    []string{config.KytheActionName},
+			kytheEnabled:    true,
+			expectedActions: []string{config.KytheActionName},
+		},
+	}
+
+	for _, tc := range testCases {
+		g, err := te.GetUserDB().GetGroupByID(ctx, gid)
+		require.NoError(t, err)
+		g.URLIdentifier = "mustbeset"
+		g.CodeSearchEnabled = tc.kytheEnabled
+		_, err = te.GetUserDB().UpdateGroup(ctx, g)
+		require.NoError(t, err)
+
+		rsp, err := bbClient.ExecuteWorkflow(ctx, &wfpb.ExecuteWorkflowRequest{
+			RequestContext: reqCtx,
+			WorkflowId:     wfRes.Id,
+			CommitSha:      "c04d68571cb519e095772c865847007ed3e7fea9",
+			PushedRepoUrl:  "https://github.com/acme-inc/acme",
+			PushedBranch:   "main",
+			ActionNames:    tc.actionFilter,
+		})
+		require.NoError(t, err, tc.name)
+		executedActionNames := make([]string, 0, len(rsp.ActionStatuses))
+		for _, a := range rsp.ActionStatuses {
+			executedActionNames = append(executedActionNames, a.ActionName)
+		}
+		require.ElementsMatch(t, tc.expectedActions, executedActionNames, tc.name)
+
+		for range tc.expectedActions {
+			_ = execClient.NextExecuteRequest()
+		}
+	}
 }

--- a/enterprise/server/workflow/service/service_test.go
+++ b/enterprise/server/workflow/service/service_test.go
@@ -702,7 +702,7 @@ func TestWebhook_TrustedPush_StartsTrustedWorkflow(t *testing.T) {
 		"API key should be set via env-overrides")
 }
 
-func TestActionFiltering(t *testing.T) {
+func TestAPIDispatch_ActionFiltering(t *testing.T) {
 	ctx := context.Background()
 	u, lis := testhttp.NewServer(t)
 	flags.Set(t, "app.build_buddy_url", *u)


### PR DESCRIPTION
Currently, the kythe workflow action is only running for the ExecuteWorkflow API and not when a webhook triggers the workflow service. My understanding is the opposite should be happening

Consolidate the code where we match workflow actions to prevent this from happening in the future.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
