### PR TITLE
some performance improvements to diff rendering--not perfect but way better

### DIFF
--- a/enterprise/app/review/file_content_monaco.tsx
+++ b/enterprise/app/review/file_content_monaco.tsx
@@ -274,7 +274,7 @@ class AutoZone {
     this.editor = editor;
   }
 
-  updateHeight() {
+  updateSize() {
     if (!this.editor) {
       return;
     }
@@ -350,8 +350,11 @@ class MonacoDiffViewerComponent extends React.Component<
 > {
   monacoElement: React.RefObject<HTMLDivElement> = React.createRef();
 
+  // If true, we've set a timer and will resize the editor when the timer fires.
   resizeUpdateScheduled: boolean = false;
-  heightUpdateInProgress: boolean = false;
+  // If true, we're actively updating the editor size (prevents loops).
+  sizeUpdateInProgress: boolean = false;
+
   currentContentHeight: number = -1;
   currentContentWidth: number = -1;
   resizeListener?: any;
@@ -375,10 +378,10 @@ class MonacoDiffViewerComponent extends React.Component<
   performSizeUpdate() {
     const editor = this.state.editor;
     const container = this.monacoElement.current;
-    if (this.heightUpdateInProgress || !editor || !container) {
+    if (this.sizeUpdateInProgress || !editor || !container) {
       return;
     }
-    this.heightUpdateInProgress = true;
+    this.sizeUpdateInProgress = true;
     try {
       const contentHeight = Math.max(
         editor.getOriginalEditor().getContentHeight(),
@@ -395,8 +398,8 @@ class MonacoDiffViewerComponent extends React.Component<
 
       container.style.height = `${contentHeight}px`;
       if (widthChanged) {
-        this.state.originalEditorThreadZones.forEach((z) => z.updateHeight());
-        this.state.modifiedEditorThreadZones.forEach((z) => z.updateHeight());
+        this.state.originalEditorThreadZones.forEach((z) => z.updateSize());
+        this.state.modifiedEditorThreadZones.forEach((z) => z.updateSize());
       }
 
       editor.getModifiedEditor().layout({ width: contentWidth / 2, height: contentHeight });
@@ -406,7 +409,7 @@ class MonacoDiffViewerComponent extends React.Component<
       // please don't.
       editor.layout();
     } finally {
-      this.heightUpdateInProgress = false;
+      this.sizeUpdateInProgress = false;
     }
   }
 
@@ -515,8 +518,8 @@ class MonacoDiffViewerComponent extends React.Component<
   }
 
   componentDidUpdate() {
-    this.state.originalEditorThreadZones.forEach((z) => z.updateHeight());
-    this.state.modifiedEditorThreadZones.forEach((z) => z.updateHeight());
+    this.state.originalEditorThreadZones.forEach((z) => z.updateSize());
+    this.state.modifiedEditorThreadZones.forEach((z) => z.updateSize());
   }
 
   componentWillUnmount(): void {

--- a/enterprise/app/review/review.css
+++ b/enterprise/app/review/review.css
@@ -102,6 +102,7 @@
 .pr-view {
   padding: 0;
   font-size: 14px;
+  height: 100vh;
 }
 
 .pr-view .summary-section {
@@ -506,8 +507,15 @@
 
 .pr-view .monaco-thread {
   box-sizing: border-box;
-  padding: 12px 2px 12px 50px;
   width: 100%;
+}
+
+.pr-view .original .monaco-thread {
+  padding: 12px 4px 12px 66px;
+}
+
+.pr-view .monaco-thread {
+  padding: 12px 4px 12px 48px;
 }
 
 .pr-view .monaco-editor .cursors-layer > .cursor {

--- a/enterprise/app/review/review.css
+++ b/enterprise/app/review/review.css
@@ -507,15 +507,12 @@
 
 .pr-view .monaco-thread {
   box-sizing: border-box;
+  padding: 12px 4px 12px 48px;
   width: 100%;
 }
 
 .pr-view .original .monaco-thread {
   padding: 12px 4px 12px 66px;
-}
-
-.pr-view .monaco-thread {
-  padding: 12px 4px 12px 48px;
 }
 
 .pr-view .monaco-editor .cursors-layer > .cursor {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
- Don't re-render when size hasn't changed.
- Debounce resize events instead of relying on Monaco to do it.
- Dispose editor when component is unmounted (preventing attempts to re-render)
- Corresponding hacks and nonsense to make things work clean.
- A random bug fix where zones were being accounted to the wrong editor.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
