### PR TITLE
action_card: display output dirs as trees

### DIFF
--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -177,8 +177,13 @@
   gap: 4px;
 
   .icon {
+    opacity: 0.7;
     width: 18px;
     height: 18px;
+  }
+
+  .icon:hover {
+    opacity: 1;
   }
 }
 

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -171,7 +171,7 @@
   height: 18px;
 }
 
-.invocation-action-card .output-symlink {
+.invocation-action-card .tree-node-symlink {
   display: flex;
   align-items: center;
   gap: 4px;

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -568,7 +568,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
         {symlinks.length ? (
           <div className="action-list">
             {symlinks.map((symlink) => (
-              <div>
+              <div className="tree-node-symlink">
                 <span>
                   <FileSymlink className="icon symlink-icon" />
                 </span>{" "}

--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -416,24 +416,38 @@ export default class InvocationActionCardComponent extends React.Component<Props
       rpcService.downloadBytestreamFile(node.obj.name, dirUrl, this.props.model.getInvocationId());
       return;
     }
+
     rpcService
       .fetchBytestreamFile(dirUrl, this.props.model.getInvocationId(), "arraybuffer")
-      .then((buffer) => {
-        let dir = build.bazel.remote.execution.v2.Directory.decode(new Uint8Array(buffer));
+      .then((buffer: ArrayBuffer) => new Uint8Array(buffer))
+      .then((array: Uint8Array) =>
+        node.type == "tree"
+          ? build.bazel.remote.execution.v2.Tree.decode(array).root
+          : build.bazel.remote.execution.v2.Directory.decode(array)
+      )
+      .then((dir: build.bazel.remote.execution.v2.Directory | null | undefined) => {
+        if (!dir) {
+          return;
+        }
+
         this.state.treeShaToExpanded.set(digestString, true);
-        let directories: TreeNode[] = dir.directories.map((child) => ({
-          obj: child,
-          type: "dir",
-        }));
-        let files: TreeNode[] = dir.files.map((child) => ({
-          obj: child,
-          type: "file",
-        }));
-        let symlinks: TreeNode[] = dir.symlinks.map((child) => ({
-          obj: child,
-          type: "symlink",
-        }));
-        const nodes = [...directories, ...files, ...symlinks];
+        const nodes = dir.directories
+          .map<TreeNode>((node) => ({
+            obj: node,
+            type: "dir",
+          }))
+          .concat(
+            dir.files.map((node) => ({
+              obj: node,
+              type: "file",
+            }))
+          )
+          .concat(
+            dir.symlinks.map((node) => ({
+              obj: node,
+              type: "symlink",
+            }))
+          );
         this.state.treeShaToChildrenMap.set(digestString, nodes);
         this.forceUpdate();
       })
@@ -517,6 +531,32 @@ export default class InvocationActionCardComponent extends React.Component<Props
       });
   }
 
+  private renderOutputDirectories(actionsResult: build.bazel.remote.execution.v2.ActionResult) {
+    return (
+      <div className="action-section">
+        <div className="action-property-title">Output directories</div>
+        {actionsResult.outputDirectories.length ? (
+          <div className="action-list">
+            {actionsResult.outputDirectories.map((dir) => (
+              <TreeNodeComponent
+                node={{
+                  obj: new build.bazel.remote.execution.v2.DirectoryNode({ name: dir.path, digest: dir.treeDigest }),
+                  type: "tree",
+                }}
+                treeShaToExpanded={this.state.treeShaToExpanded}
+                treeShaToChildrenMap={this.state.treeShaToChildrenMap}
+                treeShaToTotalSizeMap={this.state.treeShaToTotalSizeMap}
+                handleFileClicked={this.handleFileClicked.bind(this)}
+              />
+            ))}
+          </div>
+        ) : (
+          <div>None</div>
+        )}
+      </div>
+    );
+  }
+
   private renderOutputSymlinks(actionsResult: build.bazel.remote.execution.v2.ActionResult) {
     const symlinks = actionsResult.outputSymlinks.length
       ? actionsResult.outputSymlinks
@@ -528,10 +568,14 @@ export default class InvocationActionCardComponent extends React.Component<Props
         {symlinks.length ? (
           <div className="action-list">
             {symlinks.map((symlink) => (
-              <div className="output-symlink">
-                <FileSymlink className="icon symlink-icon" />
-                <span>{symlink.path}</span>
-                <ArrowRight className="icon arrow-right-icon" />
+              <div>
+                <span>
+                  <FileSymlink className="icon symlink-icon" />
+                </span>{" "}
+                <span>{symlink.path}</span>{" "}
+                <span>
+                  <ArrowRight className="icon arrow-right-icon" />
+                </span>{" "}
                 <span>{symlink.target}</span>
               </div>
             ))}
@@ -811,20 +855,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
                           <div>None found</div>
                         )}
                       </div>
-                      <div className="action-section">
-                        <div className="action-property-title">Output directories</div>
-                        {this.state.actionResult.outputDirectories.length ? (
-                          <div className="action-list">
-                            {this.state.actionResult.outputDirectories.map((dir) => (
-                              <div>
-                                <span>{dir.path}</span>
-                              </div>
-                            ))}
-                          </div>
-                        ) : (
-                          <div>None</div>
-                        )}
-                      </div>
+                      {this.renderOutputDirectories(this.state.actionResult)}
                       {this.renderOutputSymlinks(this.state.actionResult)}
                       <div className="action-section">
                         <div className="action-property-title">Stderr</div>

--- a/app/invocation/invocation_action_tree_node.tsx
+++ b/app/invocation/invocation_action_tree_node.tsx
@@ -18,10 +18,19 @@ type FileNode = build.bazel.remote.execution.v2.FileNode;
 type DirectoryNode = build.bazel.remote.execution.v2.DirectoryNode;
 type SymlinkNode = build.bazel.remote.execution.v2.SymlinkNode;
 
-export interface TreeNode {
-  obj: FileNode | DirectoryNode | SymlinkNode;
-  type: "file" | "dir" | "symlink" | "tree";
-}
+export type TreeNode =
+  | {
+      type: "file";
+      obj: FileNode;
+    }
+  | {
+      type: "dir" | "tree";
+      obj: DirectoryNode;
+    }
+  | {
+      type: "symlink";
+      obj: SymlinkNode;
+    };
 
 function getChildCountText(childCount: Number) {
   if (childCount === 0) {
@@ -99,8 +108,8 @@ export default class TreeNodeComponent extends React.Component<Props, State> {
   }
 
   render() {
-    return "digest" in this.props.node.obj
-      ? this.renderFileOrDirectoryNode(this.props.node.obj)
-      : this.renderSymlinkNode(this.props.node.obj);
+    return this.props.node.type == "symlink"
+      ? this.renderSymlinkNode(this.props.node.obj)
+      : this.renderFileOrDirectoryNode(this.props.node.obj);
   }
 }

--- a/app/invocation/invocation_action_tree_node.tsx
+++ b/app/invocation/invocation_action_tree_node.tsx
@@ -20,7 +20,7 @@ type SymlinkNode = build.bazel.remote.execution.v2.SymlinkNode;
 
 export interface TreeNode {
   obj: FileNode | DirectoryNode | SymlinkNode;
-  type: "file" | "dir" | "symlink";
+  type: "file" | "dir" | "symlink" | "tree";
 }
 
 function getChildCountText(childCount: Number) {

--- a/app/invocation/invocation_action_tree_node.tsx
+++ b/app/invocation/invocation_action_tree_node.tsx
@@ -85,17 +85,15 @@ export default class TreeNodeComponent extends React.Component<Props, State> {
 
   renderSymlinkNode(node: SymlinkNode) {
     return (
-      <div className="input-tree-node">
-        <div className="input-tree-node-name">
-          <span>
-            <FileSymlink className="icon symlink-icon" />
-          </span>{" "}
-          <span className="input-tree-node-label">{node.name}</span>{" "}
-          <span>
-            <ArrowRight className="icon symlink-arrow-icon" />
-          </span>{" "}
-          <span className="input-tree-node-label">{node.target}</span>
-        </div>
+      <div className="tree-node-symlink">
+        <span>
+          <FileSymlink className="icon symlink-icon" />
+        </span>{" "}
+        <span className="input-tree-node-label">{node.name}</span>{" "}
+        <span>
+          <ArrowRight className="icon symlink-arrow-icon" />
+        </span>{" "}
+        <span className="input-tree-node-label">{node.target}</span>
       </div>
     );
   }


### PR DESCRIPTION
Render the output directories as expandable trees so that users could
explore their contents.

This PR is based on #6525 so we should only merge this PR after.