### PR TITLE
Enable grpc over http by default

### DIFF
--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	gRPCOverHTTPPortEnabled = flag.Bool("app.grpc_over_http_port_enabled", true, "Cloud-Only")
+	gRPCOverHTTPPortEnabled = flag.Bool("app.grpc_over_http_port_enabled", true, "Enables grpc traffic to be served over the http port.")
 
 	// Support large BEP messages: https://github.com/bazelbuild/bazel/issues/12050
 	gRPCMaxRecvMsgSizeBytes           = flag.Int("grpc_max_recv_msg_size_bytes", 50_000_000, "Configures the max GRPC receive message size [bytes]")

--- a/server/util/grpc_server/grpc_server.go
+++ b/server/util/grpc_server/grpc_server.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	gRPCOverHTTPPortEnabled = flag.Bool("app.grpc_over_http_port_enabled", false, "Cloud-Only")
+	gRPCOverHTTPPortEnabled = flag.Bool("app.grpc_over_http_port_enabled", true, "Cloud-Only")
 
 	// Support large BEP messages: https://github.com/bazelbuild/bazel/issues/12050
 	gRPCMaxRecvMsgSizeBytes           = flag.Int("grpc_max_recv_msg_size_bytes", 50_000_000, "Configures the max GRPC receive message size [bytes]")


### PR DESCRIPTION
We've been running with this in production for a long while now, and it simplifies on-prem setup as well (only DNS entry / load balancer endpoint needed).