### PR TITLE
Remove FailedPrecondition error logic

### DIFF
--- a/enterprise/server/remote_execution/executor/executor.go
+++ b/enterprise/server/remote_execution/executor/executor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"strings"
 	"syscall"
 	"time"
 
@@ -410,15 +409,6 @@ func incompleteExecutionError(ctx context.Context, exitCode int, err error) erro
 		}
 		alert.UnexpectedEvent("unknown_context_error", "Unknown context error: %s", ctxErr)
 		return status.UnknownError(ctxErr.Error())
-	}
-	// Ensure that if the command was not found, we return FAILED_PRECONDITION,
-	// per RBE protocol. This is done because container/command implementations
-	// don't really have a good way to distinguish this error from other types of
-	// errors anyway (this is true for at least the bare and docker
-	// implementations at time of writing)
-	msg := status.Message(err)
-	if strings.Contains(msg, "no such file or directory") {
-		return status.FailedPreconditionError(msg)
 	}
 	return err
 }

--- a/enterprise/server/test/integration/remote_execution/remote_execution_test.go
+++ b/enterprise/server/test/integration/remote_execution/remote_execution_test.go
@@ -191,23 +191,6 @@ func TestSimpleCommand_Timeout_StdoutStderrStillVisible(t *testing.T) {
 		"failed action result should match what was sent in the ExecuteResponse")
 }
 
-func TestSimpleCommand_CommandNotFound_FailedPrecondition(t *testing.T) {
-	rbe := rbetest.NewRBETestEnv(t)
-	rbe.AddBuildBuddyServer()
-	rbe.AddExecutor(t)
-	initialTaskCount := testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount)
-
-	cmd := rbe.ExecuteCustomCommand("/COMMAND_THAT_DOES_NOT_EXIST")
-	res := cmd.MustTerminateAbnormally()
-	err := res.Err
-
-	require.Error(t, err)
-	assert.True(t, status.IsFailedPreconditionError(err))
-	assert.Contains(t, status.Message(err), "no such file or directory")
-	taskCount := testmetrics.CounterValue(t, metrics.RemoteExecutionTasksStartedCount)
-	assert.Equal(t, 1, int(taskCount-initialTaskCount), "unexpected number of tasks started")
-}
-
 func TestSimpleCommand_Abort_ReturnsExecutionError(t *testing.T) {
 	rbe := rbetest.NewRBETestEnv(t)
 	rbe.AddBuildBuddyServer()


### PR DESCRIPTION
This is causing some errors to not be retried even though they should be.

I think this logic is actually not needed. The protocol says:

```
  // * `FAILED_PRECONDITION`: One or more errors occurred in setting up the
  //   action requested, such as a missing input or command or no worker being
  //   available. The client may be able to fix the errors and retry.
```

I think by "missing [...] command" they mean that the `Command` proto is missing or expired from cache, given the context clues of the sentence. The `Action` consists of `input_root_digest` and `command_digest`, which are both downloaded from cache. I think that's what they meant here, not the command's executable (arg0) not being found on disk after we successfully downloaded the inputs and command.

**Related issues**: N/A
