### PR TITLE
Another attempt to deflake arm64 tests

### DIFF
--- a/.github/workflows/test-executor-linux-arm64.yaml
+++ b/.github/workflows/test-executor-linux-arm64.yaml
@@ -39,7 +39,8 @@ jobs:
             --bes_backend=remote.buildbuddy.io
             --bes_results_url=https://app.buildbuddy.io/invocation/
             --remote_cache=remote.buildbuddy.io
-            --flaky_test_attempts=2
+            --flaky_test_attempts=3
+            --local_test_jobs=8
             --build_metadata=ROLE=CI
             --color=yes
           )

--- a/enterprise/server/test/integration/remote_execution/BUILD
+++ b/enterprise/server/test/integration/remote_execution/BUILD
@@ -11,7 +11,6 @@ go_test(
     srcs = ["remote_execution_test.go"],
     args = ["--test.v"],
     shard_count = 11,
-    tags = ["cpu:4"],
     deps = [
         "//enterprise/server/build_event_publisher",
         "//enterprise/server/remote_execution/commandutil",


### PR DESCRIPTION
* Reduce the effective `--local_test_jobs` from 16 to 8 - seems like remote_execution_test keeps crashing due to running too many jobs locally. We're already setting `size = "enormous"` so I'm not sure there's anything else we can do to reduce the local test concurrency, short of setting `tags = ["exclusive"]` which we don't really want since the individual test shards take kind of a long time :/
* Increase flaky_test_attempts from 2 to 3
* Remove `cpu:4` tag - I found this on stackoverflow or something a while back, but when testing it out it doesn't seem like it actually does anything in this case. In the timing profile, I was seeing 16 test actions running concurrently which wouldn't make sense if this actually worked, since the arm64 runner only has 16 cores.

**Related issues**: N/A
