### PR TITLE
Handle timeouts with ExecuteWorkflow API better

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -149,6 +149,7 @@ var (
 	visibility         = flag.String("visibility", "", "If set, use the specified value for VISIBILITY build metadata for the workflow invocation.")
 	bazelSubCommand    = flag.String("bazel_sub_command", "", "If set, run the bazel command specified by these args and ignore all triggering and configured actions.")
 	recordRunMetadata  = flag.Bool("record_run_metadata", false, "Instead of running a target, extract metadata about it and report it in the build event stream.")
+	timeout            = flag.Duration("timeout", 100*time.Hour, "Timeout before all commands will be canceled automatically.")
 
 	// Flags to configure setting up git repo
 	triggerEvent    = flag.String("trigger_event", "", "Event type that triggered the action runner.")
@@ -569,8 +570,13 @@ func run() error {
 	if ci := os.Getenv(clientIdentityEnvVar); ci != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, clientidentity.IdentityHeaderName, ci)
 	}
+	contextWithoutTimeout := ctx
+	ctx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
 
-	buildEventReporter, err := newBuildEventReporter(ctx, *besBackend, ws.buildbuddyAPIKey, *invocationID, *workflowID != "" /*=isWorkflow*/)
+	// Use a context without a timeout for the build event reporter, so that even
+	// if the `timeout` is reached, any events will finish getting published
+	buildEventReporter, err := newBuildEventReporter(contextWithoutTimeout, *besBackend, ws.buildbuddyAPIKey, *invocationID, *workflowID != "" /*=isWorkflow*/)
 	if err != nil {
 		return err
 	}
@@ -2025,6 +2031,10 @@ func runCommand(ctx context.Context, executable string, args []string, env map[s
 	}()
 	err = cmd.Wait()
 	<-copyOutputDone
+
+	if ctxErr := ctx.Err(); ctxErr == context.DeadlineExceeded {
+		_, _ = outputSink.Write([]byte(fmt.Sprintf("Remote run exceeded timeout (%s). Aborting...", timeout.String())))
+	}
 	return err
 }
 

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1174,6 +1174,9 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 		args = append(args, "--install_kythe=true")
 	}
 
+	if workflowAction.Timeout != nil {
+		args = append(args, "--timeout="+workflowAction.Timeout.String())
+	}
 	for _, filter := range workflowAction.GetGitFetchFilters() {
 		args = append(args, "--git_fetch_filters="+filter)
 	}
@@ -1234,10 +1237,6 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 		CommandDigest:   cmdDigest,
 		InputRootDigest: inputRootDigest,
 		DoNotCache:      true,
-	}
-
-	if workflowAction.Timeout != nil {
-		action.Timeout = durationpb.New(*workflowAction.Timeout)
 	}
 
 	actionDigest, err := cachetools.UploadProtoToCAS(ctx, cache, instanceName, repb.DigestFunction_SHA256, action)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/3332#event-12660456383

![Screenshot 2024-05-13 at 11 24 43 AM](https://github.com/buildbuddy-io/buildbuddy/assets/13951661/b3009faa-cd87-4495-b2db-d682c5e5140c)
![Screenshot 2024-05-13 at 11 24 51 AM](https://github.com/buildbuddy-io/buildbuddy/assets/13951661/482c7826-dd39-4782-a895-8d86872d6222)

