### PR TITLE
Upgrade protoc-gen-protobufjs to get server-streaming support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -397,13 +397,6 @@ http_archive(
     urls = ["https://github.com/google/cloudprober/releases/download/v0.11.2/cloudprober-v0.11.2-ubuntu-x86_64.zip"],
 )
 
-# protoc-gen-protobufjs (for .proto to .js codegen)
-http_archive(
-    name = "com_github_buildbuddy_io_protoc_gen_protobufjs",
-    sha256 = "ef3f8fb9a417fa7c1e2fe53003221f118214cf014294bfbc5dcfbb2ed1560e83",
-    urls = ["https://github.com/buildbuddy-io/protoc-gen-protobufjs/releases/download/v0.0.9/protoc-gen-protobufjs-v0.0.9.tar.gz"],
-)
-
 # esbuild (for bundling JS)
 
 load("@build_bazel_rules_nodejs//toolchains/esbuild:esbuild_repositories.bzl", "esbuild_repositories")

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -276,13 +276,6 @@ http_archive(
     urls = ["https://github.com/google/cloudprober/releases/download/v0.11.2/cloudprober-v0.11.2-ubuntu-x86_64.zip"],
 )
 
-# protoc-gen-protobufjs (for .proto to .js codegen)
-http_archive(
-    name = "com_github_buildbuddy_io_protoc_gen_protobufjs",
-    sha256 = "ef3f8fb9a417fa7c1e2fe53003221f118214cf014294bfbc5dcfbb2ed1560e83",
-    urls = ["https://github.com/buildbuddy-io/protoc-gen-protobufjs/releases/download/v0.0.9/protoc-gen-protobufjs-v0.0.9.tar.gz"],
-)
-
 # esbuild (for bundling JS)
 
 load("@build_bazel_rules_nodejs//toolchains/esbuild:esbuild_repositories.bzl", "esbuild_repositories")

--- a/deps.bzl
+++ b/deps.bzl
@@ -6807,6 +6807,12 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
 # Manually created
 def install_static_dependencies(workspace_name = "buildbuddy"):
     http_archive(
+        name = "com_github_buildbuddy_io_protoc_gen_protobufjs",
+        sha256 = "d6d2dfb28c569ba3e4965acb54ddcccb85d5c55b03e4abf0d0e7df17f2656ee6",
+        urls = ["https://github.com/buildbuddy-io/protoc-gen-protobufjs/releases/download/v0.0.11/protoc-gen-protobufjs-v0.0.11.tar.gz"],
+    )
+
+    http_archive(
         name = "com_github_firecracker_microvm_firecracker",
         build_file_content = "\n".join([
             'package(default_visibility = ["//visibility:public"])',


### PR DESCRIPTION
Added streaming codegen support in https://github.com/buildbuddy-io/protoc-gen-protobufjs/commit/51f3bb3b644b7306bb1c670a0089ee65c2f07154

(Also, feel free to leave comments on that commit if you don't like the generated API - will be happy to address them)

**Related issues**: N/A
