### PR TITLE
Update RPC service to support server-streaming RPCs

### DIFF
--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -462,8 +462,10 @@ type CancelableService<Service extends protobufjs.rpc.Service> = protobufjs.rpc.
       infer Request,
       infer Response
     >
-      ? UnaryRpcMethod<Request, Response>
-      : Service[MethodName];
+      ? /* Unary RPC: transform the generated method's return type from Promise to CancelablePromise. */
+        UnaryRpcMethod<Request, Response>
+      : /* Server-streaming RPC: keep the original method as-is. */
+        Service[MethodName];
   };
 
 type FetchPromiseType<T extends FetchResponseType> = T extends ""

--- a/app/service/rpc_service.ts
+++ b/app/service/rpc_service.ts
@@ -1,11 +1,21 @@
 import { Subject } from "rxjs";
-import { buildbuddy } from "../../proto/buildbuddy_service_ts_proto";
+import { buildbuddy, $stream } from "../../proto/buildbuddy_service_ts_proto";
 import { context } from "../../proto/context_ts_proto";
 import { CancelablePromise } from "../util/async";
 import * as protobufjs from "protobufjs";
 import capabilities from "../capabilities/capabilities";
 
+/** Return type for unary RPCs. */
 export { CancelablePromise } from "../util/async";
+
+/** Return type for server-streaming RPCs. */
+export type ServerStream<T> = $stream.ServerStream<T>;
+
+/** Return type common to both unary and server-streaming RPCs. */
+export type Cancelable = CancelablePromise<any> | ServerStream<any>;
+
+/** Stream handler params passed when calling a server-streaming RPC. */
+export type ServerStreamHandler<T> = $stream.ServerStreamHandler<T>;
 
 /**
  * ExtendedBuildBuddyService is an extended version of BuildBuddyService with
@@ -13,6 +23,9 @@ export { CancelablePromise } from "../util/async";
  *
  * - The `requestContext` field is automatically set on each request.
  * - All RPC methods return a `CancelablePromise` instead of a `Promise`.
+ *
+ * TODO(bduffany): allow customizing the codegen to provide this extended functionality
+ * instead of trying to transform the service types / classes like this.
  */
 type ExtendedBuildBuddyService = CancelableService<buildbuddy.service.BuildBuddyService>;
 
@@ -173,25 +186,46 @@ class RpcService {
     }
   }
 
-  async rpc(server: string, method: any, requestData: any, callback: any) {
+  async rpc(
+    server: string,
+    method: { name: string; serverStreaming?: boolean },
+    requestData: Uint8Array,
+    callback: (error: any, data?: Uint8Array) => void,
+    streamParams?: $stream.StreamingRPCParams
+  ): Promise<void> {
     const url = `${server || ""}/rpc/BuildBuddyService/${method.name}`;
     const init: RequestInit = { method: "POST", body: requestData };
     if (capabilities.config.regions?.map((r) => r.server).includes(server)) {
       init.credentials = "include";
     }
     init.headers = { "Content-Type": "application/proto" };
-    try {
-      if (capabilities.config.streamingHttpEnabled) {
-        init.headers["Content-Type"] = "application/proto+prefixed";
-        init.body = lengthPrefixMessage(requestData);
+    // Set the signal to allow canceling the underlying fetch, if applicable.
+    if (streamParams?.signal) {
+      init.signal = streamParams.signal;
+    }
 
-        const reader = (await this.fetch(url, "stream", init))?.getReader();
-        return transformLengthPrefixedReaderStreamToProtoMessageBytes(reader, (error, bytes) => {
+    if (method.serverStreaming && !capabilities.config.streamingHttpEnabled) {
+      console.error("Attempted to call server-streaming RPC, but streaming HTTP is disabled");
+      return;
+    }
+
+    if (capabilities.config.streamingHttpEnabled) {
+      init.headers["Content-Type"] = "application/proto+prefixed";
+      init.body = lengthPrefixMessage(requestData);
+      try {
+        const response = await this.fetch(url, "stream", init);
+        await readLengthPrefixedStream(response!.getReader(), (messageBytes) => {
           this.events.next(method.name);
-          callback(error, bytes);
+          callback(null, messageBytes);
         });
+        streamParams?.complete?.();
+      } catch (e) {
+        callback(e);
       }
+      return;
+    }
 
+    try {
       const arrayBuffer = await this.fetch(url, "arraybuffer", init);
       callback(null, new Uint8Array(arrayBuffer));
       this.events.next(method.name);
@@ -204,12 +238,20 @@ class RpcService {
   private getExtendedService(service: buildbuddy.service.BuildBuddyService): ExtendedBuildBuddyService {
     const extendedService = Object.create(service);
     for (const rpcName of getRpcMethodNames(buildbuddy.service.BuildBuddyService)) {
-      extendedService[rpcName] = (request: Record<string, any>) => {
+      const method = (request: Record<string, any>, subscriber?: any) => {
         if (this.requestContext && !request.requestContext) {
           request.requestContext = this.requestContext;
         }
-        return new CancelablePromise((service as any)[rpcName](request));
+        const originalMethod = (service as any)[rpcName] as BaseRpcMethod<any, any>;
+        if (originalMethod.serverStreaming) {
+          // ServerStream method already supports cancel function.
+          return originalMethod.call(service, request, subscriber);
+        } else {
+          // Wrap with our CancelablePromise util.
+          return new CancelablePromise(originalMethod.call(service, request));
+        }
       };
+      extendedService[rpcName] = method;
     }
     return extendedService;
   }
@@ -241,10 +283,15 @@ interface Value {
   done: boolean;
 }
 
-async function transformLengthPrefixedReaderStreamToProtoMessageBytes(
-  reader: ReadableStreamDefaultReader | undefined,
-  callback: (e: Error | null, b: Uint8Array) => void
-) {
+/**
+ * Reads length-prefixed message payloads from the stream and invokes the given
+ * callback for each one.
+ *
+ * The returned promise completes when all messages are successfully read from
+ * the stream. It resolves with an error if reading from the stream fails or if
+ * it contains malformed data.
+ */
+async function readLengthPrefixedStream(reader: ReadableStreamDefaultReader, callback: (b: Uint8Array) => void) {
   let streamState: StreamState = {
     buffer: new Uint8Array(),
     bufferedLength: 0,
@@ -273,7 +320,7 @@ async function transformLengthPrefixedReaderStreamToProtoMessageBytes(
 
     // We've got a full message, flush it to the callback so the full proto can be parsed.
     if (streamState.bufferedLength >= streamState.messageExpectedLength) {
-      callback(null, streamState.buffer);
+      callback(streamState.buffer);
     }
 
     // If the stream closed with no more data, we're done.
@@ -323,10 +370,10 @@ function consumeMessageChunk(streamState: StreamState, value: Value) {
   return { value: value.value.slice(streamState.messageExpectedLength - streamState.bufferedLength), done: value.done };
 }
 
-async function readAtLeastNBytes(value: Value, reader: ReadableStreamDefaultReader | undefined, n: number) {
+async function readAtLeastNBytes(value: Value, reader: ReadableStreamDefaultReader, n: number) {
   let done = false;
   while (value.value.length < n) {
-    let r = await reader?.read();
+    let r = await reader.read();
     if (r?.value?.length) {
       value.value = mergeBuffers(value.value, r.value);
     }
@@ -367,23 +414,56 @@ function getRpcMethodNames(serviceClass: Function) {
   return new Set(Object.keys(serviceClass.prototype).filter((key) => key !== "constructor"));
 }
 
-type Rpc<Request, Response> = (request: Request) => Promise<Response>;
-
-export type CancelableRpc<Request, Response> = (request: Request) => CancelablePromise<Response>;
-
-type RpcMethodNames<Service> = keyof Omit<Service, keyof protobufjs.rpc.Service>;
+/**
+ * Type of a unary RPC method on the originally generated service type,
+ * before wrapping with our ExtendedBuildBuddyService functionality.
+ */
+type BaseUnaryRpcMethod<Request, Response> = ((request: Request) => Promise<Response>) & {
+  name: string;
+  serverStreaming: false;
+};
 
 /**
- * Utility type that adapts a `PromiseBasedService` so that `CancelablePromise` is
- * returned from all methods, instead of `Promise`.
+ * Type of a unary RPC method on the ExtendedBuildBuddyService.
+ */
+export type UnaryRpcMethod<Request, Response> = (request: Request) => CancelablePromise<Response>;
+
+/**
+ * Type of a server-streaming RPC method.
+ */
+export type ServerStreamingRpcMethod<Request, Response> = ((
+  request: Request,
+  handler: $stream.ServerStreamHandler<Response>
+) => $stream.ServerStream<Response>) & {
+  name: string;
+  serverStreaming: true;
+};
+
+export type RpcMethod<Request, Response> =
+  | UnaryRpcMethod<Request, Response>
+  | ServerStreamingRpcMethod<Request, Response>;
+
+type BaseRpcMethod<Request, Response> =
+  | BaseUnaryRpcMethod<Request, Response>
+  | ServerStreamingRpcMethod<Request, Response>;
+
+type RpcMethodNames<Service extends protobufjs.rpc.Service> = keyof Omit<Service, keyof protobufjs.rpc.Service>;
+
+/**
+ * Utility type that adapts a generated service class so that
+ * `CancelablePromise` is returned from all unary RPC methods instead of
+ * `Promise`.
  */
 type CancelableService<Service extends protobufjs.rpc.Service> = protobufjs.rpc.Service &
   {
     // Loop over all methods in the service, except for the ones inherited from the base
     // service (we don't want to modify those at all).
-    [MethodName in RpcMethodNames<Service>]: Service[MethodName] extends Rpc<infer Request, infer Response>
-      ? CancelableRpc<Request, Response>
-      : never;
+    [MethodName in RpcMethodNames<Service>]: Service[MethodName] extends BaseUnaryRpcMethod<
+      infer Request,
+      infer Response
+    >
+      ? UnaryRpcMethod<Request, Response>
+      : Service[MethodName];
   };
 
 type FetchPromiseType<T extends FetchResponseType> = T extends ""

--- a/deps.bzl
+++ b/deps.bzl
@@ -6808,8 +6808,8 @@ def install_go_mod_dependencies(workspace_name = "buildbuddy"):
 def install_static_dependencies(workspace_name = "buildbuddy"):
     http_archive(
         name = "com_github_buildbuddy_io_protoc_gen_protobufjs",
-        sha256 = "d6d2dfb28c569ba3e4965acb54ddcccb85d5c55b03e4abf0d0e7df17f2656ee6",
-        urls = ["https://github.com/buildbuddy-io/protoc-gen-protobufjs/releases/download/v0.0.11/protoc-gen-protobufjs-v0.0.11.tar.gz"],
+        sha256 = "81ce501fdcc10a08c84b8c9d9d1900ca35b62f581deaba8168bed2b96e7696b0",
+        urls = ["https://github.com/buildbuddy-io/protoc-gen-protobufjs/releases/download/v0.0.12/protoc-gen-protobufjs-v0.0.12.tar.gz"],
     )
 
     http_archive(

--- a/enterprise/app/api_keys/api_keys.tsx
+++ b/enterprise/app/api_keys/api_keys.tsx
@@ -16,7 +16,7 @@ import Modal from "../../../app/components/modal/modal";
 import alert_service from "../../../app/alert/alert_service";
 import { copyToClipboard } from "../../../app/util/clipboard";
 import errorService from "../../../app/errors/error_service";
-import { CancelableRpc } from "../../../app/service/rpc_service";
+import { UnaryRpcMethod } from "../../../app/service/rpc_service";
 import { BuildBuddyError } from "../../../app/util/errors";
 import { api_key } from "../../../proto/api_key_ts_proto";
 import rpcService from "../../../app/service/rpc_service";
@@ -28,10 +28,10 @@ export interface ApiKeysComponentProps {
   /** Whether to show only user-owned keys. */
   userOwnedOnly?: boolean;
 
-  get: CancelableRpc<api_key.GetApiKeysRequest, api_key.GetApiKeysResponse>;
-  create: CancelableRpc<api_key.CreateApiKeyRequest, api_key.CreateApiKeyResponse>;
-  update: CancelableRpc<api_key.UpdateApiKeyRequest, api_key.UpdateApiKeyResponse>;
-  delete: CancelableRpc<api_key.DeleteApiKeyRequest, api_key.DeleteApiKeyResponse>;
+  get: UnaryRpcMethod<api_key.GetApiKeysRequest, api_key.GetApiKeysResponse>;
+  create: UnaryRpcMethod<api_key.CreateApiKeyRequest, api_key.CreateApiKeyResponse>;
+  update: UnaryRpcMethod<api_key.UpdateApiKeyRequest, api_key.UpdateApiKeyResponse>;
+  delete: UnaryRpcMethod<api_key.DeleteApiKeyRequest, api_key.DeleteApiKeyResponse>;
 }
 
 interface State {


### PR DESCRIPTION
Allows defining server-streaming RPC methods, and calling them like this:

```typescript
const stream = rpc_service.service.waitExecution(
  // First argument: provide the request message object or fields (same as calling a unary RPC)
  { executionId },

  // Second argument (new): provide stream handlers.
  // All handlers are required
  {
    // Handle response message
    next: (response) => { /* handle response */ },

    // Handle error
    // In most cases, we should check for network errors here and retry the stream w/ exponential backoff,
    // in case of app restarts or a flaky network connection. In a later PR we can probably add some utils
    // to make this easier.
    error: (e) => { /* ... */ },

    // Handle EOF (no more data on stream).
    complete: () => { /* ... */ },
  },
);

// ... later, e.g. componentWillUnmount():

// Cancels the underlying fetch. The error/complete callbacks will not be invoked.
stream.cancel();
```

This API is defined by https://github.com/buildbuddy-io/protoc-gen-protobufjs so if there's anything about this API you don't like, LMK - it's pretty easy to change it upstream since nothing is using this yet. The naming of `next` / `error` / `complete` is inspired by `rxjs` (but the generated code does not use rxjs, just vanilla JS + the existing protobufjs deps).

I tested this E2E in a WIP branch, calling `WaitExecution` and streaming real-time execution state to the UI.

**Related issues**: N/A
