### PR TITLE
Enable streaming HTTP everywhere

### DIFF
--- a/server/static/static.go
+++ b/server/static/static.go
@@ -55,7 +55,7 @@ var (
 	ipRulesUIEnabled                       = flag.Bool("app.ip_rules_ui_enabled", false, "If set, show the IP rules tab in settings page.")
 	traceViewerEnabled                     = flag.Bool("app.trace_viewer_enabled", false, "Whether the new trace viewer is enabled.")
 	popupAuthEnabled                       = flag.Bool("app.popup_auth_enabled", false, "Whether popup windows should be used for authentication.")
-	streamingHTTPEnabled                   = flag.Bool("app.streaming_http_enabled", false, "Whether to support server-streaming http requests between server and web UI.")
+	streamingHTTPEnabled                   = flag.Bool("app.streaming_http_enabled", true, "Whether to support server-streaming http requests between server and web UI.")
 	codeReviewEnabled                      = flag.Bool("app.code_review_enabled", false, "If set, show the code review UI.")
 	codeSearchEnabled                      = flag.Bool("app.codesearch_enabled", false, "If set, show the code search UI.")
 	orgAdminApiKeyCreationEnabled          = flag.Bool("app.org_admin_api_key_creation_enabled", false, "If set, SCIM API keys will be able to be created in the UI.")


### PR DESCRIPTION
It's been enabled in dev for a while and I haven't noticed any issues with it.

**Related issues**: N/A
