### PR TITLE
Add WaitExecution to BuildBuddyService

### DIFF
--- a/enterprise/server/execution_service/BUILD
+++ b/enterprise/server/execution_service/BUILD
@@ -8,7 +8,9 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/execution_service",
     deps = [
         "//enterprise/server/util/execution",
+        "//proto:buildbuddy_service_go_proto",
         "//proto:execution_stats_go_proto",
+        "//proto:remote_execution_go_proto",
         "//server/environment",
         "//server/tables",
         "//server/util/db",

--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -2,6 +2,7 @@ package execution_service
 
 import (
 	"context"
+	"io"
 	"sort"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/execution"
@@ -14,7 +15,9 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"golang.org/x/sync/errgroup"
 
+	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
 	espb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 )
 
 type ExecutionService struct {
@@ -105,4 +108,32 @@ func (es *ExecutionService) GetExecution(ctx context.Context, req *espb.GetExecu
 		}
 	}
 	return rsp, nil
+}
+
+func (es *ExecutionService) WaitExecution(req *espb.WaitExecutionRequest, stream bbspb.BuildBuddyService_WaitExecutionServer) error {
+	if es.env.GetRemoteExecutionClient() == nil {
+		return status.UnimplementedError("not implemented")
+	}
+	client, err := es.env.GetRemoteExecutionClient().WaitExecution(stream.Context(), &repb.WaitExecutionRequest{
+		Name: req.GetExecutionId(),
+	})
+	if err != nil {
+		return status.WrapError(err, "create WaitExecution stream")
+	}
+	// Directly forward stream messages back to the Web client stream. Note: we
+	// don't try to automatically reconnect here, since the client has to handle
+	// disconnects regardless (to deal with the current server going away).
+	for {
+		op, err := client.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		err = stream.Send(&espb.WaitExecutionResponse{Operation: op})
+		if err != nil {
+			return status.WrapError(err, "send")
+		}
+	}
 }

--- a/enterprise/server/execution_service/execution_service.go
+++ b/enterprise/server/execution_service/execution_service.go
@@ -122,7 +122,7 @@ func (es *ExecutionService) WaitExecution(req *espb.WaitExecutionRequest, stream
 	}
 	// Directly forward stream messages back to the Web client stream. Note: we
 	// don't try to automatically reconnect here, since the client has to handle
-	// disconnects regardless (to deal with the current server going away).
+	// disconnects anyway (to deal with the current server going away).
 	for {
 		op, err := client.Recv()
 		if err == io.EOF {
@@ -131,8 +131,8 @@ func (es *ExecutionService) WaitExecution(req *espb.WaitExecutionRequest, stream
 		if err != nil {
 			return err
 		}
-		err = stream.Send(&espb.WaitExecutionResponse{Operation: op})
-		if err != nil {
+		res := &espb.WaitExecutionResponse{Operation: op}
+		if err = stream.Send(res); err != nil {
 			return status.WrapError(err, "send")
 		}
 	}

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -1,6 +1,6 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:compiler.bzl", "go_proto_compiler")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load(":defs.bzl", "ts_proto_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -171,6 +171,7 @@ proto_library(
         ":scheduler_proto",
         ":stat_filter_proto",
         "@com_google_protobuf//:timestamp_proto",
+        "@googleapis//google/longrunning:operations_proto",
         "@googleapis//google/rpc:status_proto",
     ],
 )
@@ -866,6 +867,7 @@ go_proto_library(
         ":resource_go_proto",
         ":scheduler_go_proto",
         ":stat_filter_go_proto",
+        "@com_google_cloud_go_longrunning//autogen/longrunningpb",
         "@org_golang_google_genproto_googleapis_rpc//status",
     ],
 )
@@ -1784,6 +1786,7 @@ ts_proto_library(
     deps = [
         ":acl_ts_proto",
         ":context_ts_proto",
+        ":google_longrunning_ts_proto",
         ":grpc_status_ts_proto",
         ":invocation_status_ts_proto",
         ":remote_execution_ts_proto",

--- a/proto/buildbuddy_service.proto
+++ b/proto/buildbuddy_service.proto
@@ -104,6 +104,8 @@ service BuildBuddyService {
   // Execution API
   rpc GetExecution(execution_stats.GetExecutionRequest)
       returns (execution_stats.GetExecutionResponse);
+  rpc WaitExecution(execution_stats.WaitExecutionRequest)
+      returns (stream execution_stats.WaitExecutionResponse);
   rpc GetExecutionNodes(scheduler.GetExecutionNodesRequest)
       returns (scheduler.GetExecutionNodesResponse);
   rpc SearchExecution(execution_stats.SearchExecutionRequest)

--- a/proto/execution_stats.proto
+++ b/proto/execution_stats.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "google/longrunning/operations.proto";
 import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
 import "proto/acl.proto";
@@ -147,6 +148,18 @@ message GetExecutionResponse {
   context.ResponseContext response_context = 1;
 
   repeated Execution execution = 2;
+}
+
+message WaitExecutionRequest {
+  context.RequestContext request_context = 1;
+
+  string execution_id = 2;
+}
+
+message WaitExecutionResponse {
+  context.ResponseContext response_context = 1;
+
+  google.longrunning.Operation operation = 2;
 }
 
 message ExecutionQuery {

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//proto:api_key_go_proto",
         "//proto:auditlog_go_proto",
         "//proto:bazel_config_go_proto",
+        "//proto:buildbuddy_service_go_proto",
         "//proto:cache_go_proto",
         "//proto:encryption_go_proto",
         "//proto:eventlog_go_proto",

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -44,6 +44,7 @@ import (
 	akpb "github.com/buildbuddy-io/buildbuddy/proto/api_key"
 	alpb "github.com/buildbuddy-io/buildbuddy/proto/auditlog"
 	bzpb "github.com/buildbuddy-io/buildbuddy/proto/bazel_config"
+	bbspb "github.com/buildbuddy-io/buildbuddy/proto/buildbuddy_service"
 	capb "github.com/buildbuddy-io/buildbuddy/proto/cache"
 	enpb "github.com/buildbuddy-io/buildbuddy/proto/encryption"
 	elpb "github.com/buildbuddy-io/buildbuddy/proto/eventlog"
@@ -1113,6 +1114,13 @@ func (s *BuildBuddyServer) GetExecution(ctx context.Context, req *espb.GetExecut
 		return es.GetExecution(ctx, req)
 	}
 	return nil, status.UnimplementedError("Not implemented")
+}
+
+func (s *BuildBuddyServer) WaitExecution(req *espb.WaitExecutionRequest, stream bbspb.BuildBuddyService_WaitExecutionServer) error {
+	if es := s.env.GetExecutionService(); es != nil {
+		return es.WaitExecution(req, stream)
+	}
+	return status.UnimplementedError("Not implemented")
 }
 
 func (s *BuildBuddyServer) GetTreeDirectorySizes(ctx context.Context, req *capb.GetTreeDirectorySizesRequest) (*capb.GetTreeDirectorySizesResponse, error) {

--- a/server/capabilities_filter/BUILD
+++ b/server/capabilities_filter/BUILD
@@ -26,5 +26,6 @@ go_test(
         "//server/testutil/testauth",
         "//server/testutil/testenv",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/server/capabilities_filter/capabilities_filter.go
+++ b/server/capabilities_filter/capabilities_filter.go
@@ -35,6 +35,7 @@ var (
 		"GetTarget",
 		"GetTargetHistory",
 		"GetExecution",
+		"WaitExecution",
 		"GetZipManifest",
 		// Users do not need any particular role within their current group to be
 		// able to create another group or request to join an existing group.

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -837,6 +837,7 @@ type PoolInfo struct {
 
 type ExecutionService interface {
 	GetExecution(ctx context.Context, req *espb.GetExecutionRequest) (*espb.GetExecutionResponse, error)
+	WaitExecution(req *espb.WaitExecutionRequest, stream bbspb.BuildBuddyService_WaitExecutionServer) error
 }
 
 // An ExecutionNode that has been ranked for scheduling.


### PR DESCRIPTION
This will allow us to show live execution progress which is especially nice for workflow executions, where we'd like to show progress like "Resuming VM", "Executing" etc.

The RPC is purely a passthrough to the `Execution.WaitExecution` RPC.

**Related issues**: N/A
