### PR TITLE
Add flags to make metrics collector expiries configurable

### DIFF
--- a/enterprise/server/backends/redis_metrics_collector/BUILD
+++ b/enterprise/server/backends/redis_metrics_collector/BUILD
@@ -8,9 +8,8 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_metrics_collector",
     deps = [
         "//enterprise/server/util/redisutil",
+        "//server/cache/config",
         "//server/real_environment",
-        "//server/remote_cache/hit_tracker",
-        "//server/util/flagutil/types",
         "@com_github_go_redis_redis_v8//:redis",
     ],
 )

--- a/enterprise/server/backends/redis_metrics_collector/BUILD
+++ b/enterprise/server/backends/redis_metrics_collector/BUILD
@@ -9,6 +9,8 @@ go_library(
     deps = [
         "//enterprise/server/util/redisutil",
         "//server/real_environment",
+        "//server/remote_cache/hit_tracker",
+        "//server/util/flagutil/types",
         "@com_github_go_redis_redis_v8//:redis",
     ],
 )

--- a/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector.go
+++ b/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector.go
@@ -2,7 +2,6 @@ package redis_metrics_collector
 
 import (
 	"context"
-	"flag"
 	"strconv"
 	"time"
 
@@ -10,12 +9,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/go-redis/redis/v8"
 
-	_ "github.com/buildbuddy-io/buildbuddy/server/remote_cache/hit_tracker"
-	flagtypes "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types"
-)
-
-var (
-	countExpiration = flagtypes.Alias[time.Duration](flag.CommandLine, "cache.count_ttl")
+	cache_config "github.com/buildbuddy-io/buildbuddy/server/cache/config"
 )
 
 type collector struct {
@@ -56,7 +50,7 @@ func (c *collector) IncrementCountsWithExpiry(ctx context.Context, key string, c
 }
 
 func (c *collector) IncrementCounts(ctx context.Context, key string, counts map[string]int64) error {
-	return c.IncrementCountsWithExpiry(ctx, key, counts, *countExpiration)
+	return c.IncrementCountsWithExpiry(ctx, key, counts, cache_config.CountTTL())
 }
 
 func (c *collector) IncrementCountWithExpiry(ctx context.Context, key, field string, n int64, expiry time.Duration) error {
@@ -70,7 +64,7 @@ func (c *collector) IncrementCountWithExpiry(ctx context.Context, key, field str
 }
 
 func (c *collector) IncrementCount(ctx context.Context, key, field string, n int64) error {
-	return c.IncrementCountWithExpiry(ctx, key, field, n, *countExpiration)
+	return c.IncrementCountWithExpiry(ctx, key, field, n, cache_config.CountTTL())
 }
 
 func (c *collector) SetAddWithExpiry(ctx context.Context, key string, expiry time.Duration, members ...string) error {
@@ -88,7 +82,7 @@ func (c *collector) SetAddWithExpiry(ctx context.Context, key string, expiry tim
 }
 
 func (c *collector) SetAdd(ctx context.Context, key string, members ...string) error {
-	return c.SetAddWithExpiry(ctx, key, *countExpiration, members...)
+	return c.SetAddWithExpiry(ctx, key, cache_config.CountTTL(), members...)
 }
 
 func (c *collector) SetGetMembers(ctx context.Context, key string) ([]string, error) {

--- a/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector.go
+++ b/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector.go
@@ -2,17 +2,20 @@ package redis_metrics_collector
 
 import (
 	"context"
+	"flag"
 	"strconv"
 	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/redisutil"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/go-redis/redis/v8"
+
+	_ "github.com/buildbuddy-io/buildbuddy/server/remote_cache/hit_tracker"
+	flagtypes "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types"
 )
 
-const (
-	// How long until counts expire from Redis.
-	countExpiration = 1 * 24 * time.Hour
+var (
+	countExpiration = flagtypes.Alias[time.Duration](flag.CommandLine, "cache.count_expiration")
 )
 
 type collector struct {
@@ -53,7 +56,7 @@ func (c *collector) IncrementCountsWithExpiry(ctx context.Context, key string, c
 }
 
 func (c *collector) IncrementCounts(ctx context.Context, key string, counts map[string]int64) error {
-	return c.IncrementCountsWithExpiry(ctx, key, counts, countExpiration)
+	return c.IncrementCountsWithExpiry(ctx, key, counts, *countExpiration)
 }
 
 func (c *collector) IncrementCountWithExpiry(ctx context.Context, key, field string, n int64, expiry time.Duration) error {
@@ -67,7 +70,7 @@ func (c *collector) IncrementCountWithExpiry(ctx context.Context, key, field str
 }
 
 func (c *collector) IncrementCount(ctx context.Context, key, field string, n int64) error {
-	return c.IncrementCountWithExpiry(ctx, key, field, n, countExpiration)
+	return c.IncrementCountWithExpiry(ctx, key, field, n, *countExpiration)
 }
 
 func (c *collector) SetAddWithExpiry(ctx context.Context, key string, expiry time.Duration, members ...string) error {
@@ -85,7 +88,7 @@ func (c *collector) SetAddWithExpiry(ctx context.Context, key string, expiry tim
 }
 
 func (c *collector) SetAdd(ctx context.Context, key string, members ...string) error {
-	return c.SetAddWithExpiry(ctx, key, countExpiration, members...)
+	return c.SetAddWithExpiry(ctx, key, *countExpiration, members...)
 }
 
 func (c *collector) SetGetMembers(ctx context.Context, key string) ([]string, error) {

--- a/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector.go
+++ b/enterprise/server/backends/redis_metrics_collector/redis_metrics_collector.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	countExpiration = flagtypes.Alias[time.Duration](flag.CommandLine, "cache.count_expiration")
+	countExpiration = flagtypes.Alias[time.Duration](flag.CommandLine, "cache.count_ttl")
 )
 
 type collector struct {

--- a/server/cache/config/config.go
+++ b/server/cache/config/config.go
@@ -1,9 +1,19 @@
 package config
 
-import "flag"
+import (
+	"flag"
+	"time"
+)
 
-var cacheMaxSizeBytes = flag.Int64("cache.max_size_bytes", 10_000_000_000 /* 10 GB */, "How big to allow the cache to be (in bytes).")
+var (
+	cacheMaxSizeBytes = flag.Int64("cache.max_size_bytes", 10_000_000_000 /* 10 GB */, "How big to allow the cache to be (in bytes).")
+	countTTL          = flag.Duration("cache.count_ttl", 24*time.Hour, "How long to go without receiving any cache requests for an invocation before deleting the invocation's counts from the metrics collector.")
+)
 
 func MaxSizeBytes() int64 {
 	return *cacheMaxSizeBytes
+}
+
+func CountTTL() time.Duration {
+	return *countTTL
 }

--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -30,9 +30,8 @@ import (
 )
 
 var (
-	detailedStatsEnabled       = flag.Bool("cache.detailed_stats_enabled", false, "Whether to enable detailed stats recording for all cache requests.")
-	scorecardResultsExpiration = flag.Duration("cache.detailed_stats_ttl", 3*time.Hour, "How long to go without receiving any cache requests for an invocation before deleting the invocation's detailed results from the metrics collector. Has no effect if cache.detailed_stats_enabled is not set.")
-	countExpiration            = flag.Duration("cache.count_ttl", 24*time.Hour, "How long to go without receiving any cache requests for an invocation before deleting the invocation's counts from the metrics collector.")
+	detailedStatsEnabled = flag.Bool("cache.detailed_stats_enabled", false, "Whether to enable detailed stats recording for all cache requests.")
+	scorecardResultsTTL  = flag.Duration("cache.detailed_stats_ttl", 3*time.Hour, "How long to go without receiving any cache requests for an invocation before deleting the invocation's detailed results from the metrics collector. Has no effect if cache.detailed_stats_enabled is not set.")
 
 	// Example: "GoLink(//merger:merger_test)/16f1152b7b260f690ea06f8b938a1b60712b5ee41a1c125ecad8ed9416481fbb"
 	actionRegexp = regexp.MustCompile(`^(?P<action_mnemonic>[[:alnum:]]*)\((?P<target_id>.+)\)/(?P<action_id>[[:alnum:]]+)$`)
@@ -325,7 +324,7 @@ func (h *HitTracker) recordDetailedStats(d *repb.Digest, stats *detailedStats) e
 	if err := h.c.ListAppend(h.ctx, key, string(b)); err != nil {
 		return err
 	}
-	if err := h.c.Expire(h.ctx, key, *scorecardResultsExpiration); err != nil {
+	if err := h.c.Expire(h.ctx, key, *scorecardResultsTTL); err != nil {
 		return err
 	}
 	return nil

--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -31,8 +31,8 @@ import (
 
 var (
 	detailedStatsEnabled       = flag.Bool("cache.detailed_stats_enabled", false, "Whether to enable detailed stats recording for all cache requests.")
-	scorecardResultsExpiration = flag.Duration("cache.detailed_stats_expiration", 3*time.Hour, "How long to go without receiving any cache requests for an invocation before deleting the invocation's detailed results from the metrics collector. Has no effect if cache.detailed_stats_enabled is not set.")
-	countExpiration            = flag.Duration("cache.count_expiration", 24*time.Hour, "How long to go without receiving any cache requests for an invocation before deleting the invocation's counts from the metrics collector.")
+	scorecardResultsExpiration = flag.Duration("cache.detailed_stats_ttl", 3*time.Hour, "How long to go without receiving any cache requests for an invocation before deleting the invocation's detailed results from the metrics collector. Has no effect if cache.detailed_stats_enabled is not set.")
+	countExpiration            = flag.Duration("cache.count_ttl", 24*time.Hour, "How long to go without receiving any cache requests for an invocation before deleting the invocation's counts from the metrics collector.")
 
 	// Example: "GoLink(//merger:merger_test)/16f1152b7b260f690ea06f8b938a1b60712b5ee41a1c125ecad8ed9416481fbb"
 	actionRegexp = regexp.MustCompile(`^(?P<action_mnemonic>[[:alnum:]]*)\((?P<target_id>.+)\)/(?P<action_id>[[:alnum:]]+)$`)

--- a/server/remote_cache/hit_tracker/hit_tracker.go
+++ b/server/remote_cache/hit_tracker/hit_tracker.go
@@ -30,9 +30,9 @@ import (
 )
 
 var (
-	detailedStatsEnabled = flag.Bool("cache.detailed_stats_enabled", false, "Whether to enable detailed stats recording for all cache requests.")
-	scorecardResultsExpiration = flag.Duration("cache.detailed_stats_expiration", 3 * time.Hour, "How long to go without receiving any cache requests for an invocation before deleting the invocation's detailed results from the metrics collector. Has no effect if cache.detailed_stats_enabled is not set.")
-	countExpiration = flag.Duration("cache.count_expiration", 24 * time.Hour, "How long to go without receiving any cache requests for an invocation before deleting the invocation's counts from the metrics collector.")
+	detailedStatsEnabled       = flag.Bool("cache.detailed_stats_enabled", false, "Whether to enable detailed stats recording for all cache requests.")
+	scorecardResultsExpiration = flag.Duration("cache.detailed_stats_expiration", 3*time.Hour, "How long to go without receiving any cache requests for an invocation before deleting the invocation's detailed results from the metrics collector. Has no effect if cache.detailed_stats_enabled is not set.")
+	countExpiration            = flag.Duration("cache.count_expiration", 24*time.Hour, "How long to go without receiving any cache requests for an invocation before deleting the invocation's counts from the metrics collector.")
 
 	// Example: "GoLink(//merger:merger_test)/16f1152b7b260f690ea06f8b938a1b60712b5ee41a1c125ecad8ed9416481fbb"
 	actionRegexp = regexp.MustCompile(`^(?P<action_mnemonic>[[:alnum:]]*)\((?P<target_id>.+)\)/(?P<action_id>[[:alnum:]]+)$`)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

The current default expiration times for the metrics collector are extremely generous, and can result in us getting alerts about redis cache usage. This happens especially when users are running a lot of invocations that only use us as the cache without sending us build events, as we can't manage the lifetime of those scorecards and counts in any way other than by allowing them to expire when they hit their ttl, since we have no idea when the related invocation is over.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
