### PR TITLE
Stream execution progress to the action page

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -119,6 +119,7 @@ ts_library(
     srcs = ["invocation_action_card.tsx"],
     deps = [
         "//app/alert:alert_service",
+        "//app/capabilities",
         "//app/components/button",
         "//app/components/dialog",
         "//app/components/digest",
@@ -126,6 +127,7 @@ ts_library(
         "//app/components/modal",
         "//app/errors:error_service",
         "//app/format",
+        "//app/invocation:execution_status",
         "//app/invocation:invocation_action_tree_node",
         "//app/invocation:invocation_model",
         "//app/preferences",
@@ -321,6 +323,7 @@ ts_library(
         "//app/invocation:invocation_execution_table",
         "//app/invocation:invocation_execution_util",
         "//app/invocation:invocation_model",
+        "//app/router",
         "//app/service:rpc_service",
         "//proto:execution_stats_ts_proto",
         "//proto:remote_execution_ts_proto",
@@ -348,6 +351,7 @@ ts_library(
     name = "invocation_execution_util",
     srcs = ["invocation_execution_util.tsx"],
     deps = [
+        "//app/util:cache",
         "//proto:execution_stats_ts_proto",
         "//proto:grpc_code_ts_proto",
         "//proto:remote_execution_ts_proto",
@@ -778,5 +782,15 @@ ts_library(
         "@npm//react",
         "@npm//tslib",
         "@npm//varint",
+    ],
+)
+
+ts_library(
+    name = "execution_status",
+    srcs = ["execution_status.tsx"],
+    deps = [
+        "//app/service:rpc_service",
+        "//proto:execution_stats_ts_proto",
+        "//proto:remote_execution_ts_proto",
     ],
 )

--- a/app/invocation/execution_status.tsx
+++ b/app/invocation/execution_status.tsx
@@ -45,14 +45,16 @@ export function executionStatusLabel(op: ExecuteOperation) {
     case ExecutionStage.QUEUED:
       return "Queued";
     case ExecutionStage.EXECUTING:
-      // Return fine-grained progress using BB-specific enum
-      break;
+      // Return fine-grained progress using BB-specific metadata
+      return executionProgressLabel(op);
     case ExecutionStage.COMPLETED:
       return "Completed";
     default:
       return "Unknown";
   }
+}
 
+function executionProgressLabel(op: ExecuteOperation) {
   switch (op.progress?.executionState) {
     case ExecutionState.PULLING_CONTAINER_IMAGE:
       return "Pulling container image";

--- a/app/invocation/execution_status.tsx
+++ b/app/invocation/execution_status.tsx
@@ -1,0 +1,104 @@
+import rpc_service, { ServerStreamHandler, ServerStream } from "../service/rpc_service";
+import { execution_stats } from "../../proto/execution_stats_ts_proto";
+import { build } from "../../proto/remote_execution_ts_proto";
+
+const ExecutionStage = build.bazel.remote.execution.v2.ExecutionStage.Value;
+const ExecutionState = build.bazel.remote.execution.v2.ExecutionProgress.ExecutionState;
+
+/**
+ * Live-streams execution updates using the WaitExecution API.
+ * Each operation is unpacked into a more usable format.
+ */
+export function waitExecution(
+  executionId: string,
+  handler: ServerStreamHandler<ExecuteOperation>
+): ServerStream<ExecuteOperation> {
+  return rpc_service.service.waitExecution(
+    { executionId },
+    {
+      next: (response) => {
+        const unpackedOperation = unpackResponse(response);
+        if (unpackedOperation) {
+          handler.next(unpackedOperation);
+        }
+      },
+      error: (e) => {
+        // TODO: if we disconnected from the app (e.g. app restart), don't
+        // bubble up the error, just transparently reconnect.
+        handler.error(e);
+      },
+      complete: () => {
+        handler.complete();
+      },
+    }
+  );
+}
+
+export function executionStatusLabel(op: ExecuteOperation) {
+  if (op.done) {
+    return "Completed";
+  }
+
+  switch (op.metadata?.stage) {
+    case ExecutionStage.CACHE_CHECK:
+      return "Checking cache";
+    case ExecutionStage.QUEUED:
+      return "Queued";
+    case ExecutionStage.EXECUTING:
+      // Return fine-grained progress using BB-specific enum
+      break;
+    case ExecutionStage.COMPLETED:
+      return "Completed";
+    default:
+      return "Unknown";
+  }
+
+  switch (op.progress?.executionState) {
+    case ExecutionState.PULLING_CONTAINER_IMAGE:
+      return "Pulling container image";
+    case ExecutionState.DOWNLOADING_INPUTS:
+      return "Downloading inputs";
+    case ExecutionState.EXECUTING_COMMAND:
+      return "Executing command";
+    case ExecutionState.UPLOADING_OUTPUTS:
+      return "Uploading outputs";
+    case ExecutionState.BOOTING_VM:
+      return "Booting VM";
+    case ExecutionState.RESUMING_VM:
+      return "Resuming VM snapshot";
+    default:
+      return "Executing";
+  }
+}
+
+/** Unpacked execute operation. */
+export type ExecuteOperation = {
+  metadata?: build.bazel.remote.execution.v2.ExecuteOperationMetadata;
+  progress?: build.bazel.remote.execution.v2.ExecutionProgress;
+  response?: build.bazel.remote.execution.v2.ExecuteResponse;
+  done: boolean;
+};
+
+function unpackResponse(response: execution_stats.WaitExecutionResponse): ExecuteOperation | null {
+  if (!response.operation) return null;
+  const unpacked: ExecuteOperation = {
+    done: response.operation.done,
+  };
+  if (response.operation.metadata) {
+    unpacked.metadata = build.bazel.remote.execution.v2.ExecuteOperationMetadata.decode(
+      response.operation.metadata.value
+    );
+  }
+  if (response.operation.response) {
+    unpacked.response = build.bazel.remote.execution.v2.ExecuteResponse.decode(response.operation.response.value);
+  }
+  // Unpack BuildBuddy auxiliary metadata
+  if (unpacked.metadata) {
+    for (const auxiliaryMetadata of unpacked.metadata?.partialExecutionMetadata?.auxiliaryMetadata ?? []) {
+      if (auxiliaryMetadata.typeUrl === build.bazel.remote.execution.v2.ExecutionProgress.getTypeUrl()) {
+        unpacked.progress = build.bazel.remote.execution.v2.ExecutionProgress.decode(auxiliaryMetadata.value);
+      }
+    }
+  }
+  return unpacked;
+}

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -197,6 +197,12 @@ export default class InvocationComponent extends React.Component<Props, State> {
       .catch((error: any) => {
         console.error(error);
         this.setState({ error: BuildBuddyError.parse(error) });
+
+        // To make manual testing easier, support a special 'retry' param that
+        // auto-reloads the page if there is an error.
+        if (this.props.search.get("retry") !== null) {
+          setTimeout(() => window.location.reload(), 500);
+        }
       })
       .finally(() => this.setState({ loading: false }));
   }

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -197,12 +197,6 @@ export default class InvocationComponent extends React.Component<Props, State> {
       .catch((error: any) => {
         console.error(error);
         this.setState({ error: BuildBuddyError.parse(error) });
-
-        // To make manual testing easier, support a special 'retry' param that
-        // auto-reloads the page if there is an error.
-        if (this.props.search.get("retry") !== null) {
-          setTimeout(() => window.location.reload(), 500);
-        }
       })
       .finally(() => this.setState({ loading: false }));
   }

--- a/app/invocation/invocation_execution_card.tsx
+++ b/app/invocation/invocation_execution_card.tsx
@@ -6,10 +6,12 @@ import { execution_stats } from "../../proto/execution_stats_ts_proto";
 import Select, { Option } from "../components/select/select";
 import { build } from "../../proto/remote_execution_ts_proto";
 import rpcService from "../service/rpc_service";
+import router from "../router/router";
 import { OutlinedButton } from "../components/button/button";
 import {
   downloadDuration,
   executionDuration,
+  getActionPageLink,
   getExecutionStatus,
   queuedDuration,
   subtractTimestamp,
@@ -72,6 +74,12 @@ export default class ExecutionCardComponent extends React.Component<Props, State
 
       if (inProgressBeforeRequestWasMade) {
         this.fetchUpdatedProgress();
+      }
+
+      // To help with manual testing, support a special "openFirst" URL param
+      // which automatically navigates to the first execution that we fetched.
+      if (new URLSearchParams(window.location.search).get("openFirst") !== null) {
+        router.replaceURL(getActionPageLink(this.props.model.getInvocationId(), response.execution[0]));
       }
 
       console.log(response);

--- a/app/invocation/invocation_execution_card.tsx
+++ b/app/invocation/invocation_execution_card.tsx
@@ -76,12 +76,6 @@ export default class ExecutionCardComponent extends React.Component<Props, State
         this.fetchUpdatedProgress();
       }
 
-      // To help with manual testing, support a special "openFirst" URL param
-      // which automatically navigates to the first execution that we fetched.
-      if (new URLSearchParams(window.location.search).get("openFirst") !== null) {
-        router.replaceURL(getActionPageLink(this.props.model.getInvocationId(), response.execution[0]));
-      }
-
       console.log(response);
     });
   }

--- a/app/invocation/invocation_execution_table.tsx
+++ b/app/invocation/invocation_execution_table.tsx
@@ -7,6 +7,7 @@ import {
   downloadDuration,
   executionDuration,
   uploadDuration,
+  getActionPageLink,
 } from "./invocation_execution_util";
 import { execution_stats } from "../../proto/execution_stats_ts_proto";
 import DigestComponent from "../components/digest/digest";
@@ -19,23 +20,6 @@ interface Props {
 }
 
 export default class InvocationExecutionTable extends React.Component<Props> {
-  getActionPageLink(execution: execution_stats.Execution) {
-    const search = new URLSearchParams();
-    if (execution.actionDigest) {
-      search.set("actionDigest", digestToString(execution.actionDigest));
-    }
-    // Prefer executeResponseDigest if present, since it represents the action
-    // response that was returned for this specific invocation, and also
-    // contains additional useful info such as gRPC status. Otherwise, try the
-    // (deprecated) actionResultDigest.
-    if (execution.executeResponseDigest) {
-      search.set("executeResponseDigest", digestToString(execution.executeResponseDigest));
-    } else if (execution.actionResultDigest) {
-      search.set("actionResultDigest", digestToString(execution.actionResultDigest));
-    }
-    return `/invocation/${this.props.invocationIdProvider(execution)}?${search}#action`;
-  }
-
   render() {
     return (
       <div className="invocation-execution-table">
@@ -45,7 +29,10 @@ export default class InvocationExecutionTable extends React.Component<Props> {
             return;
           }
           return (
-            <Link key={index} className="invocation-execution-row" href={this.getActionPageLink(execution)}>
+            <Link
+              key={index}
+              className="invocation-execution-row"
+              href={getActionPageLink(this.props.invocationIdProvider(execution), execution)}>
               <div className="invocation-execution-row-image">{status.icon}</div>
               <div>
                 <div className="invocation-execution-row-header">


### PR DESCRIPTION
Starting with the action page mostly as a proof of concept because it's easier to test than workflows and is maybe somewhat useful for larger actions. It will be more interesting to show this info on the queued invocation page (for workflow / remote bazel invocations).

Screen recording of an execution with an artificial 8s delay at the beginning of ExecuteTaskAndStreamResults + 750ms delay when transitioning between each execution state (otherwise the updates go by too quickly...) (also the "Unknown" execution status should probably be "Queued", need to fix that separately)

https://github.com/buildbuddy-io/buildbuddy/assets/2414826/d76dd269-d966-48a9-b51e-e30696f142be



**Related issues**: N/A
