### PR TITLE
action card: fix negative timeline duration

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -940,7 +940,7 @@ function computeMilliCpu(result: build.bazel.remote.execution.v2.ActionResult): 
 }
 
 function durationSeconds(t1: ITimestamp, t2: ITimestamp): number {
-  return timestampToUnixSeconds(t2) - timestampToUnixSeconds(t1);
+  return Math.max(0, timestampToUnixSeconds(t2) - timestampToUnixSeconds(t1));
 }
 
 function timestampToUnixSeconds(timestamp: ITimestamp): number {


### PR DESCRIPTION
The queue timestamp could be after the initialization timestamp when the
Executor experience local clock drift vs the scheduler.
For this reason, some of our action timeline duration has been showing
up as negative value when we take the difference between 2 phases
timestamps that were taken on 2 different machines.

With the negative duration, our rendering would try to create elements
with this CSS.

```javascript
style: {
  flex: `${negativeValue} 0 0`,
  backgroundColor: "rgba(0, 0, 0, .1)"
}
```

which is an invalid initial value for `flex`. Because of this, React
rendered the element without `flex`, which result in wrong offset being
shown in the Action's timeline.

Ensure that duration values never goes negative to avoid this rendering
issue.

Closes https://github.com/buildbuddy-io/buildbuddy-internal/issues/3377.
