### PR TITLE
Add target to Execution

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -358,9 +358,12 @@ func (s *ExecutionServer) recordExecution(ctx context.Context, executionID strin
 	if err != nil {
 		return status.InternalErrorf("failed to get invocations for execution %q: %s", executionID, err)
 	}
-
+	rmd := bazel_request.GetRequestMetadata(ctx)
 	for _, link := range links {
 		executionProto := execution.TableExecToProto(&executionPrimaryDB, link)
+		if rmd != nil {
+			executionProto.TargetLabel = rmd.GetTargetId()
+		}
 		inv, err := s.env.GetExecutionCollector().GetInvocation(ctx, link.GetInvocationId())
 		if err != nil {
 			log.CtxErrorf(ctx, "failed to get invocation %q from ExecutionCollector: %s", link.GetInvocationId(), err)

--- a/proto/remote_execution.proto
+++ b/proto/remote_execution.proto
@@ -2391,4 +2391,7 @@ message StoredExecution {
 
   string output_path = 31;
   string status_message = 32;
+
+  // TODO(sluongng): add mnemonic and configuration.
+  string target_label = 33;
 }

--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -234,6 +234,7 @@ func buildExecution(in *repb.StoredExecution, inv *sipb.StoredInvocation) *schem
 		Success:                            inv.GetSuccess(),
 		InvocationStatus:                   inv.GetInvocationStatus(),
 		Tags:                               invocation_format.ConvertDBTagsToOLAP(inv.GetTags()),
+		TargetLabel:                        in.GetTargetLabel(),
 	}
 }
 

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -159,6 +159,9 @@ type Execution struct {
 
 	Stage int64
 
+	// RequestMetadata
+	TargetLabel string
+
 	// IOStats
 	FileDownloadCount        int64
 	FileDownloadSizeBytes    int64
@@ -244,6 +247,7 @@ func (e *Execution) AdditionalFields() []string {
 		"InvocationLinkType",
 		"Tags",
 		"OutputPath",
+		"TargetLabel",
 	}
 }
 


### PR DESCRIPTION
Each Execution is often corresponding to a Bazel's Action, but end users
don't often think of Execution or Action because Bazel's build rules
system often abstract that away from them.

Instead, folks often think of Bazel build targets.
Each targets uses a build rule, in combination with a build
configuration, to create multiple actions. Usually each of these actions
are created with a unique mnemonic to help identify them a bit easier
(note that this is not always the case).

Capture the target label from Executor's RequestMetadata when record the
Execution into OLAPDB. We will evaluate adding mnemonic and
configuration at a later stage.
