### PR TITLE
Increase runner recycle timeout, so we can save snapshots with large resource requests

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -91,7 +91,7 @@ const (
 	// How long to spend waiting for a runner to be removed before giving up.
 	runnerCleanupTimeout = 30 * time.Second
 	// Allowed time to spend trying to pause a runner and add it to the pool.
-	runnerRecycleTimeout = 3 * time.Minute
+	runnerRecycleTimeout = 10 * time.Minute
 	// How long to spend waiting for a persistent worker process to terminate
 	// after we send the shutdown signal before giving up.
 	persistentWorkerShutdownTimeout = 10 * time.Second


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://buildbuddy-corp.slack.com/archives/C0495TM9UUE/p1715892089321979
