### PR TITLE
Add tabs to comparison view

### DIFF
--- a/app/compare/BUILD
+++ b/app/compare/BUILD
@@ -10,9 +10,7 @@ ts_library(
     deps = [
         "//app/auth:auth_service",
         "//app/components/button:checkbox_button",
-        "//app/components/button:link_button",
         "//app/invocation:invocation_model",
-        "//app/router",
         "//app/service:rpc_service",
         "//app/util:errors",
         "//proto:invocation_ts_proto",

--- a/app/compare/compare.css
+++ b/app/compare/compare.css
@@ -29,6 +29,10 @@
   }
 }
 
+.compare-invocations .tabs {
+  margin-top: 0;
+}
+
 .compare-invocations .error-container {
   background: #ffebee;
   padding: 16px;

--- a/app/compare/compare_invocations.tsx
+++ b/app/compare/compare_invocations.tsx
@@ -4,12 +4,9 @@ import React from "react";
 import { invocation } from "../../proto/invocation_ts_proto";
 import { User } from "../auth/auth_service";
 import CheckboxButton from "../components/button/checkbox_button";
-import router from "../router/router";
 import rpcService from "../service/rpc_service";
 import { BuildBuddyError } from "../util/errors";
-import { OutlinedLinkButton } from "../components/button/link_button";
 import InvocationModel from "../invocation/invocation_model";
-import CompareExecutionLogComponent from "./compare_execution_logs";
 
 export interface CompareInvocationsComponentProps {
   user?: User;

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -354,6 +354,7 @@ svg.icon.orange {
   font-weight: 600;
   text-transform: uppercase;
   user-select: none;
+  background: #fff;
 }
 
 .tab:hover {

--- a/app/root/root.tsx
+++ b/app/root/root.tsx
@@ -87,6 +87,7 @@ export default class RootComponent extends React.Component {
                 invocationAId={compareInvocationIds.a}
                 invocationBId={compareInvocationIds.b}
                 search={this.state.search}
+                tab={this.state.tab}
                 user={undefined}
               />
             )}

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -205,7 +205,7 @@ export default class EnterpriseRootComponent extends React.Component {
 
   render() {
     let invocationId = router.getInvocationId(this.state.path);
-    let compareInvocationIds = router.getInvocationIdsForCompare(this.state.path);
+    let compareInvocationIds = this.state.user && router.getInvocationIdsForCompare(this.state.path);
     let historyUser = this.state.user && router.getHistoryUser(this.state.path);
     let historyHost = this.state.user && router.getHistoryHost(this.state.path);
     let historyRepo = this.state.user && router.getHistoryRepo(this.state.path);
@@ -304,6 +304,7 @@ export default class EnterpriseRootComponent extends React.Component {
                         invocationAId={compareInvocationIds.a}
                         invocationBId={compareInvocationIds.b}
                         search={this.state.search}
+                        tab={this.state.tab}
                         user={this.state.user}
                       />
                     </Suspense>


### PR DESCRIPTION
Adds tabs to the comparison view (starting with just invocation details and flags).

Will add tabs execution log in a follow-up.

Also fixes up some minor issues I found while testing in dev.