### PR TITLE
Add "load all" targets button and fix up copy behavior 

### DIFF
--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -1283,3 +1283,18 @@ svg.invocation-query-graph .nodes rect {
     margin-right: 0;
   }
 }
+
+.target-more-buttons {
+  display: flex;
+  gap: 16px;
+}
+
+.target-more-buttons div {
+  display: flex;
+  align-items: center;
+}
+
+.target-more-buttons svg {
+ height: 16px;
+ color: rgba(0, 0, 0, 0.5)
+}

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -1295,6 +1295,6 @@ svg.invocation-query-graph .nodes rect {
 }
 
 .target-more-buttons svg {
- height: 16px;
- color: rgba(0, 0, 0, 0.5)
+  height: 16px;
+  color: rgba(0, 0, 0, 0.5);
 }

--- a/app/invocation/invocation_target_group_card.tsx
+++ b/app/invocation/invocation_target_group_card.tsx
@@ -3,8 +3,11 @@ import { target } from "../../proto/target_ts_proto";
 import { api as api_common } from "../../proto/api/v1/common_ts_proto";
 import {
   ArrowDownCircle,
+  Check,
   CheckCircle,
+  ChevronDown,
   ChevronRight,
+  ChevronsDown,
   Clock,
   Copy,
   FileCode,
@@ -32,6 +35,7 @@ interface State {
   loading: boolean;
   fetchedTargets: target.Target[];
   nextPageToken: string | null;
+  copied: boolean;
 }
 
 const Status = api_common.v1.Status;
@@ -45,6 +49,7 @@ export default class TargetGroupCard extends React.Component<TargetGroupCardProp
     loading: false,
     fetchedTargets: [],
     nextPageToken: null,
+    copied: false,
   };
 
   private fetchRPC?: CancelablePromise;
@@ -64,7 +69,7 @@ export default class TargetGroupCard extends React.Component<TargetGroupCardProp
     return Boolean(this.nextPageToken());
   }
 
-  private loadMore() {
+  private loadMore(all?: boolean, callback?: () => void) {
     this.fetchRPC?.cancel();
     this.setState({ loading: true });
     rpc_service.service
@@ -76,11 +81,23 @@ export default class TargetGroupCard extends React.Component<TargetGroupCardProp
       })
       .then((response) => {
         const page = response.targetGroups[0];
-        if (!page) return;
-        this.setState({
-          fetchedTargets: [...this.state.fetchedTargets, ...page.targets],
-          nextPageToken: page.nextPageToken,
-        });
+        if (!page) {
+          callback && callback();
+          return;
+        }
+        this.setState(
+          {
+            fetchedTargets: [...this.state.fetchedTargets, ...page.targets],
+            nextPageToken: page.nextPageToken,
+          },
+          () => {
+            if (all && page.nextPageToken) {
+              this.loadMore(true, callback);
+            } else {
+              callback && callback();
+            }
+          }
+        );
       })
       .catch((e) => error_service.handleError(e))
       .finally(() => this.setState({ loading: false }));
@@ -103,6 +120,19 @@ export default class TargetGroupCard extends React.Component<TargetGroupCardProp
       bytestream_url: file.uri,
       filename: file.name,
     })}`;
+  }
+
+  onCopyClicked() {
+    let callback = () => {
+      let targets = this.props.group.targets.concat(this.state.fetchedTargets);
+      copyToClipboard(targets.map((target) => target.metadata?.label ?? "").join(" "));
+      this.setState({ copied: true });
+    };
+    if (this.hasMoreTargets()) {
+      this.loadMore(true, callback);
+      return;
+    }
+    callback();
   }
 
   render() {
@@ -173,10 +203,11 @@ export default class TargetGroupCard extends React.Component<TargetGroupCardProp
           <div className="title">
             {format.formatWithCommas(this.props.group.totalCount)}
             {this.props.filter ? " matching" : ""} {pastVerb}{" "}
-            <Copy
-              className="copy-icon"
-              onClick={() => copyToClipboard(targets.map((target) => target.metadata?.label ?? "").join(" "))}
-            />
+            {this.state.copied ? (
+              <Check className="copy-icon green" onClick={() => this.onCopyClicked()} />
+            ) : (
+              <Copy className="copy-icon" onClick={() => this.onCopyClicked()} />
+            )}
           </div>
           <div className="details">
             {this.props.group.status !== 0 && (
@@ -223,11 +254,18 @@ export default class TargetGroupCard extends React.Component<TargetGroupCardProp
                 </div>
               ))}
           </div>
-          {this.hasMoreTargets() && !this.state.loading && (
-            <div className="more" onClick={() => this.loadMore()}>
-              Load more {presentVerb}
-            </div>
-          )}
+          <div className="target-more-buttons">
+            {this.hasMoreTargets() && !this.state.loading && (
+              <div className="more" onClick={() => this.loadMore()}>
+                <ChevronDown /> Load more {presentVerb}
+              </div>
+            )}
+            {this.hasMoreTargets() && !this.state.loading && (
+              <div className="more" onClick={() => this.loadMore(true)}>
+                <ChevronsDown /> Load all {presentVerb}
+              </div>
+            )}
+          </div>
           {this.state.loading && (
             <div className="more-loading">
               Load more {presentVerb} <Spinner className="small-spinner" />

--- a/app/invocation/invocation_target_group_card.tsx
+++ b/app/invocation/invocation_target_group_card.tsx
@@ -85,19 +85,14 @@ export default class TargetGroupCard extends React.Component<TargetGroupCardProp
           callback && callback();
           return;
         }
-        this.setState(
-          {
-            fetchedTargets: [...this.state.fetchedTargets, ...page.targets],
-            nextPageToken: page.nextPageToken,
-          },
-          () => {
-            if (all && page.nextPageToken) {
-              this.loadMore(true, callback);
-            } else {
-              callback && callback();
-            }
-          }
-        );
+        this.state.fetchedTargets = [...this.state.fetchedTargets, ...page.targets];
+        this.state.nextPageToken = page.nextPageToken;
+        if (all && page.nextPageToken) {
+          this.loadMore(true, callback);
+          return;
+        }
+        this.forceUpdate();
+        callback && callback();
       })
       .catch((e) => error_service.handleError(e))
       .finally(() => this.setState({ loading: false }));

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1900,7 +1900,7 @@ code .comment {
 }
 
 .copy-icon.green {
-  color: #4CAF50;
+  color: #4caf50;
 }
 
 .coverage-source {

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1899,6 +1899,10 @@ code .comment {
   margin-left: 0.2em;
 }
 
+.copy-icon.green {
+  color: #4CAF50;
+}
+
 .coverage-source {
   font-weight: 600;
 }


### PR DESCRIPTION
This changes adds a "load all" button to the targets card.

It also improves copy targets behavior in two ways:
1. It shows a confirmation checkbox icon when copy is complete
2. It calls "load all" before initiating the copy so all targets are copied (not just the ones visible on the first page).