### PR TITLE
action card timing: ensure the min css value

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -374,7 +374,7 @@ export default class InvocationActionCardComponent extends React.Component<Props
       color: string;
       timestamp: Timestamp;
     };
-    let filteredEvents: FilteredTimelineEvent[] = events
+    const filteredEvents: FilteredTimelineEvent[] = events
       .filter((event): event is FilteredTimelineEvent => event.timestamp != null)
       .map((event, i, events) => {
         if (i == events.length - 1) return event;
@@ -415,11 +415,11 @@ export default class InvocationActionCardComponent extends React.Component<Props
               title={`Total: (${format.durationSec(totalDuration)}, 100%)`}
               style={{ flex: `1 0 0`, backgroundColor: "green" }}></div>
           </div>
-          {filteredEvents.map((event, i) => {
+          {filteredEvents.map((event, i, events) => {
             // Don't render the end marker.
-            if (i == filteredEvents.length - 1) return null;
+            if (i == events.length - 1) return null;
 
-            const next = filteredEvents[i + 1];
+            const next = events[i + 1];
             const duration = durationSeconds(event.timestamp!, next.timestamp!);
             const weight = duration / totalDuration;
 


### PR DESCRIPTION
In #6576, we made sure that all duration in the Timeline phases are
non-negative when time drift happens.

However, because the total duration is still being calculated by taking
the difference between the first event and last event, which is
inaccurate because the first event timestamp could be after the second
event timestamp due to drift. As the total duration is shorter than it
should be, it's possible for the `offset% + event%` value to be
higher than the actual total duration (100%). This causes the last bar of
the timeline, which is calculated with `100% - (offset% + event%)`, to
have a negative value. This prevents `flex` from not being rendered in
the div's style due to invalid initial value, causing strange offset.

Apply several fixes to mitigate the issue:

- Fix total duration calculation by taking the difference between
  the smallest timestamp and the longest timestamp.

- Refactor the code to only add to offset after the flex initial values
  are calculated.

- Ensure that flex initial values cannot goes below zero.

- Fix "Timeline" still being rendered when no event is available.

Closes https://github.com/buildbuddy-io/buildbuddy-internal/issues/3377
