### PR TITLE
Try to only fetch a commit in the ci_runner if possible

### DIFF
--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -116,13 +116,11 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 		"--bes_backend=" + events_api_url.String(),
 		"--cache_backend=" + cache_api_url.String(),
 		"--bes_results_url=" + build_buddy_url.WithPath("/invocation/").String(),
-		"--target_repo_url=" + repoURL.String(),
 		"--pushed_repo_url=" + repoURL.String(),
 		"--pushed_branch=" + req.GetRepoState().GetBranch(),
 		"--bazel_sub_command=" + req.GetBazelCommand(),
 		"--invocation_id=" + invocationID,
 		"--commit_sha=" + req.GetRepoState().GetCommitSha(),
-		"--target_branch=" + req.GetRepoState().GetBranch(),
 	}
 	if !req.GetRunRemotely() && strings.HasPrefix(req.GetBazelCommand(), "run ") {
 		args = append(args, "--record_run_metadata")

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -766,8 +766,14 @@ actions:
 
 		// When invoked with the initial commit sha, should not contain the modified print statement
 		result = invokeRunner(t, runnerFlagsCommit1, []string{}, wsPath)
-		checkRunnerResult(t, result)
-		assert.Contains(t, result.Output, "args: {{ Hello world }}")
+		if !tc.setBranchName {
+			// Git does not support fetching non-HEAD commits by default.
+			// If pushed_branch is not set as a fallback, the fetch will fail.
+			require.NotEqual(t, 0, result.ExitCode)
+		} else {
+			checkRunnerResult(t, result)
+			assert.Contains(t, result.Output, "args: {{ Hello world }}")
+		}
 
 		// When invoked with the new commit sha, should contain the modified print statement
 		runnerFlagsCommit2 := append(baselineRunnerFlags, "--commit_sha="+newCommitSha)

--- a/enterprise/server/webhooks/bitbucket/bitbucket.go
+++ b/enterprise/server/webhooks/bitbucket/bitbucket.go
@@ -54,8 +54,6 @@ func (*bitbucketGitProvider) ParseWebhookData(r *http.Request) (*interfaces.Webh
 			EventName:     webhook_data.EventName.Push,
 			PushedRepoURL: v["Repository.Links.HTML.Href"],
 			PushedBranch:  branch,
-			TargetRepoURL: v["Repository.Links.HTML.Href"],
-			TargetBranch:  branch,
 			SHA:           v["Push.Changes.0.New.Target.Hash"],
 		}, nil
 	case "pullrequest:created", "pullrequest:updated":

--- a/enterprise/server/webhooks/bitbucket/bitbucket_test.go
+++ b/enterprise/server/webhooks/bitbucket/bitbucket_test.go
@@ -33,8 +33,6 @@ func TestParseRequest_ValidPushEvent_Success(t *testing.T) {
 		PushedRepoURL: "https://bitbucket.org/buildbuddy/buildbuddy-ci-playground",
 		PushedBranch:  "main",
 		SHA:           "f3307f36e35d1820c78b642cc8dfec6bf28a6230",
-		TargetRepoURL: "https://bitbucket.org/buildbuddy/buildbuddy-ci-playground",
-		TargetBranch:  "main",
 	}, data)
 }
 

--- a/enterprise/server/webhooks/github/github.go
+++ b/enterprise/server/webhooks/github/github.go
@@ -137,14 +137,11 @@ func ParseWebhookData(event interface{}) (*interfaces.WebhookData, error) {
 		}
 		branch := strings.TrimPrefix(v["Ref"], "refs/heads/")
 		return &interfaces.WebhookData{
-			EventName:               webhook_data.EventName.Push,
-			PushedRepoURL:           v["Repo.CloneURL"],
-			PushedBranch:            branch,
-			SHA:                     v["HeadCommit.ID"],
-			TargetRepoURL:           v["Repo.CloneURL"],
-			TargetRepoDefaultBranch: v["Repo.DefaultBranch"],
-			TargetBranch:            branch,
-			IsTargetRepoPublic:      v["Repo.Private"] == "false",
+			EventName:          webhook_data.EventName.Push,
+			PushedRepoURL:      v["Repo.CloneURL"],
+			PushedBranch:       branch,
+			SHA:                v["HeadCommit.ID"],
+			IsTargetRepoPublic: v["Repo.Private"] == "false",
 		}, nil
 
 	case *gh.PullRequestEvent:

--- a/enterprise/server/webhooks/github/github_test.go
+++ b/enterprise/server/webhooks/github/github_test.go
@@ -30,13 +30,10 @@ func TestParseRequest_ValidPushEvent_Success(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, &interfaces.WebhookData{
-		EventName:               "push",
-		PushedRepoURL:           "https://github.com/test/hello_bb_ci.git",
-		PushedBranch:            "main",
-		SHA:                     "258044d28288d5f6f1c5928b0e22580296fec666",
-		TargetRepoURL:           "https://github.com/test/hello_bb_ci.git",
-		TargetRepoDefaultBranch: "main",
-		TargetBranch:            "main",
+		EventName:     "push",
+		PushedRepoURL: "https://github.com/test/hello_bb_ci.git",
+		PushedBranch:  "main",
+		SHA:           "258044d28288d5f6f1c5928b0e22580296fec666",
 	}, data)
 }
 


### PR DESCRIPTION
Modify the default behavior of the ci_runner to only fetch 1 commit (`commit_sha` if passed explicitly, or the HEAD of the `pushed_branch`) to improve fetch performance.

Examples of customer threads reporting slow fetch performance:
https://buildbuddy-corp.slack.com/archives/C057TAUAQ7P/p1715890919620789
https://buildbuddy-corp.slack.com/archives/C057TAUAQ7P/p1713966865093979
