### PR TITLE
Refactor container provider args

### DIFF
--- a/enterprise/server/remote_execution/container/BUILD
+++ b/enterprise/server/remote_execution/container/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["container.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container",
     deps = [
+        "//enterprise/server/remote_execution/operation",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/util/oci",
         "//proto:firecracker_go_proto",

--- a/enterprise/server/remote_execution/containers/bare/BUILD
+++ b/enterprise/server/remote_execution/containers/bare/BUILD
@@ -9,7 +9,6 @@ go_library(
     deps = [
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
-        "//enterprise/server/remote_execution/platform",
         "//enterprise/server/util/oci",
         "//enterprise/server/util/procstats",
         "//proto:remote_execution_go_proto",

--- a/enterprise/server/remote_execution/containers/bare/bare.go
+++ b/enterprise/server/remote_execution/containers/bare/bare.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/procstats"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
@@ -33,7 +32,7 @@ type Opts struct {
 type Provider struct {
 }
 
-func (p *Provider) New(ctx context.Context, props *platform.Properties, _ *repb.ScheduledTask, _ *rnpb.RunnerState, _ string) (container.CommandContainer, error) {
+func (p *Provider) New(ctx context.Context, _ *container.Init) (container.CommandContainer, error) {
 	opts := &Opts{
 		EnableStats: *bareEnableStats,
 	}

--- a/enterprise/server/remote_execution/containers/docker/docker.go
+++ b/enterprise/server/remote_execution/containers/docker/docker.go
@@ -115,12 +115,12 @@ func NewProvider(env environment.Env, hostBuildRoot string) (*Provider, error) {
 	}, nil
 }
 
-func (p *Provider) New(ctx context.Context, props *platform.Properties, task *repb.ScheduledTask, state *rnpb.RunnerState, workingDir string) (container.CommandContainer, error) {
+func (p *Provider) New(ctx context.Context, args *container.Init) (container.CommandContainer, error) {
 	opts := &DockerOptions{
-		ForceRoot:               props.DockerForceRoot,
-		DockerInit:              props.DockerInit,
-		DockerUser:              props.DockerUser,
-		DockerNetwork:           props.DockerNetwork,
+		ForceRoot:               args.Props.DockerForceRoot,
+		DockerInit:              args.Props.DockerInit,
+		DockerUser:              args.Props.DockerUser,
+		DockerNetwork:           args.Props.DockerNetwork,
 		Socket:                  platform.DockerSocket(),
 		EnableSiblingContainers: *dockerSiblingContainers,
 		UseHostNetwork:          *dockerNetHost,
@@ -131,7 +131,7 @@ func (p *Provider) New(ctx context.Context, props *platform.Properties, task *re
 		Volumes:                 *dockerVolumes,
 		InheritUserIDs:          *dockerInheritUserIDs,
 	}
-	return NewDockerContainer(p.env, p.client, props.ContainerImage, p.buildRoot, opts), nil
+	return NewDockerContainer(p.env, p.client, args.Props.ContainerImage, p.buildRoot, opts), nil
 }
 
 type DockerOptions struct {

--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//enterprise/server/remote_execution/cgroup",
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
-        "//enterprise/server/remote_execution/platform",
         "//enterprise/server/remote_execution/soci_store",
         "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
@@ -41,6 +40,7 @@ go_test(
     srcs = ["podman_test.go"],
     deps = [
         ":podman",
+        "//enterprise/server/remote_execution/container",
         "//enterprise/server/remote_execution/containers/docker",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/util/oci",

--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -18,7 +18,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/cgroup"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/soci_store"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci"
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
@@ -183,8 +182,8 @@ func getPodmanVersion(ctx context.Context, commandRunner interfaces.CommandRunne
 	return semver.NewVersion(strings.TrimSpace(stdout.String()))
 }
 
-func (p *Provider) New(ctx context.Context, props *platform.Properties, _ *repb.ScheduledTask, _ *rnpb.RunnerState, _ string) (container.CommandContainer, error) {
-	imageIsPublic := props.ContainerRegistryUsername == "" && props.ContainerRegistryPassword == ""
+func (p *Provider) New(ctx context.Context, args *container.Init) (container.CommandContainer, error) {
+	imageIsPublic := args.Props.ContainerRegistryUsername == "" && args.Props.ContainerRegistryPassword == ""
 	imageIsStreamable := (imageIsPublic || *privateImageStreamingEnabled)
 	if imageIsStreamable {
 		if err := p.sociStore.WaitUntilReady(); err != nil {
@@ -215,16 +214,16 @@ func (p *Provider) New(ctx context.Context, props *platform.Properties, _ *repb.
 		env:               p.env,
 		podmanVersion:     p.podmanVersion,
 		cgroupPaths:       p.cgroupPaths,
-		image:             props.ContainerImage,
+		image:             args.Props.ContainerImage,
 		imageIsStreamable: imageIsStreamable,
 		sociStore:         p.sociStore,
 		imageExistsCache:  p.imageExistsCache,
 		buildRoot:         p.buildRoot,
 		options: &PodmanOptions{
-			ForceRoot:          props.DockerForceRoot,
-			Init:               props.DockerInit,
-			User:               props.DockerUser,
-			Network:            props.DockerNetwork,
+			ForceRoot:          args.Props.DockerForceRoot,
+			Init:               args.Props.DockerInit,
+			User:               args.Props.DockerUser,
+			Network:            args.Props.DockerNetwork,
 			DefaultNetworkMode: networkMode,
 			CapAdd:             capAdd,
 			Devices:            devices,

--- a/enterprise/server/remote_execution/containers/podman/podman_test.go
+++ b/enterprise/server/remote_execution/containers/podman/podman_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/podman"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci"
@@ -42,11 +43,11 @@ func TestPullsNotDeduped(t *testing.T) {
 	provider, err := podman.NewProvider(env, dir)
 	require.NoError(t, err)
 
-	props := platform.Properties{
+	props := &platform.Properties{
 		ContainerImage: "docker.io/library/busybox",
 		DockerNetwork:  "off",
 	}
-	container, err := provider.New(ctx, &props, nil, nil, "")
+	container, err := provider.New(ctx, &container.Init{Props: props})
 	require.NoError(t, err)
 
 	eg := errgroup.Group{}
@@ -82,11 +83,11 @@ func TestImageExists(t *testing.T) {
 	provider, err := podman.NewProvider(env, dir)
 	require.NoError(t, err)
 
-	props := platform.Properties{
+	props := &platform.Properties{
 		ContainerImage: "docker.io/library/busybox",
 		DockerNetwork:  "off",
 	}
-	container, err := provider.New(ctx, &props, nil, nil, "")
+	container, err := provider.New(ctx, &container.Init{Props: props})
 	require.NoError(t, err)
 
 	exitCode = 1

--- a/enterprise/server/remote_execution/containers/sandbox/BUILD
+++ b/enterprise/server/remote_execution/containers/sandbox/BUILD
@@ -12,7 +12,6 @@ go_library(
     deps = [
         "//enterprise/server/remote_execution/commandutil",
         "//enterprise/server/remote_execution/container",
-        "//enterprise/server/remote_execution/platform",
         "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
         "//proto:runner_go_proto",

--- a/enterprise/server/remote_execution/containers/sandbox/sandbox.go
+++ b/enterprise/server/remote_execution/containers/sandbox/sandbox.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
-	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
@@ -265,9 +264,9 @@ type Options struct {
 
 type Provider struct{}
 
-func (p *Provider) New(ctx context.Context, props *platform.Properties, _ *repb.ScheduledTask, _ *rnpb.RunnerState, _ string) (container.CommandContainer, error) {
+func (p *Provider) New(ctx context.Context, args *container.Init) (container.CommandContainer, error) {
 	opts := &Options{
-		Network: props.DockerNetwork,
+		Network: args.Props.DockerNetwork,
 	}
 	return New(opts), nil
 }

--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -90,7 +90,6 @@ go_test(
         "//enterprise/server/tasksize",
         "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
-        "//proto:runner_go_proto",
         "//proto:worker_go_proto",
         "//server/real_environment",
         "//server/testutil/testauth",

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -1031,9 +1031,11 @@ func (p *pool) newRunner(ctx context.Context, props *platform.Properties, st *re
 }
 
 func (p *pool) newContainer(ctx context.Context, props *platform.Properties, task *repb.ScheduledTask, state *rnpb.RunnerState, workingDir string) (*container.TracedCommandContainer, error) {
+	args := &container.Init{Props: props, Task: task, State: state, WorkDir: workingDir}
+
 	// Overriding in tests.
 	if p.overrideProvider != nil {
-		c, err := p.overrideProvider.New(ctx, props, task, state, workingDir)
+		c, err := p.overrideProvider.New(ctx, args)
 		if err != nil {
 			return nil, err
 		}
@@ -1050,7 +1052,7 @@ func (p *pool) newContainer(ctx context.Context, props *platform.Properties, tas
 		return nil, status.UnimplementedErrorf("no container provider registered for %q isolation", isolationType)
 	}
 
-	c, err := containerProvider.New(ctx, props, task, state, workingDir)
+	c, err := containerProvider.New(ctx, args)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -453,10 +453,10 @@ func TestRunnerPool_DefaultSystemBasedLimits_CanAddAtLeastOneRunner(t *testing.T
 	assert.Equal(t, 1, pool.PausedRunnerCount())
 }
 
-type providerFunc func(ctx context.Context, props *platform.Properties, task *repb.ScheduledTask, state *rnpb.RunnerState, workspaceRoot string) (container.CommandContainer, error)
+type providerFunc func(ctx context.Context, args *container.Init) (container.CommandContainer, error)
 
-func (f providerFunc) New(ctx context.Context, props *platform.Properties, task *repb.ScheduledTask, state *rnpb.RunnerState, workspaceRoot string) (container.CommandContainer, error) {
-	return f(ctx, props, task, state, workspaceRoot)
+func (f providerFunc) New(ctx context.Context, args *container.Init) (container.CommandContainer, error) {
+	return f(ctx, args)
 }
 
 // Returns containers that only consume disk resources when paused (like firecracker).
@@ -813,7 +813,7 @@ func TestRunnerPool_RecycleAfterCreateFailed_CallsRemove(t *testing.T) {
 	// Set up a fake command container that always returns a fixed error
 	// when calling Create().
 	fakeCreateError := fmt.Errorf("test-create-error")
-	cfg.ContainerProvider = providerFunc(func(ctx context.Context, props *platform.Properties, task *repb.ScheduledTask, state *rnpb.RunnerState, workspaceRoot string) (container.CommandContainer, error) {
+	cfg.ContainerProvider = providerFunc(func(ctx context.Context, args *container.Init) (container.CommandContainer, error) {
 		ctr = NewFakeContainer()
 		ctr.CreateError = fakeCreateError
 		return ctr, nil

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -462,7 +462,7 @@ func (f providerFunc) New(ctx context.Context, props *platform.Properties, task 
 // Returns containers that only consume disk resources when paused (like firecracker).
 type DiskOnlyContainerProvider struct{}
 
-func (*DiskOnlyContainerProvider) New(ctx context.Context, props *platform.Properties, task *repb.ScheduledTask, state *rnpb.RunnerState, workspaceRoot string) (container.CommandContainer, error) {
+func (*DiskOnlyContainerProvider) New(ctx context.Context, args *container.Init) (container.CommandContainer, error) {
 	fc := newFakeFirecrackerContainer()
 	return container.NewTracedCommandContainer(fc), nil
 }

--- a/enterprise/server/remote_execution/runner/runner_test.go
+++ b/enterprise/server/remote_execution/runner/runner_test.go
@@ -33,7 +33,6 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
 	wkpb "github.com/buildbuddy-io/buildbuddy/proto/worker"
 )
 

--- a/enterprise/server/test/integration/podman/podman_test.go
+++ b/enterprise/server/test/integration/podman/podman_test.go
@@ -143,11 +143,11 @@ func TestRunHelloWorld(t *testing.T) {
 
 	provider, err := podman.NewProvider(env, buildRoot)
 	require.NoError(t, err)
-	props := platform.Properties{
+	props := &platform.Properties{
 		ContainerImage: "docker.io/library/busybox",
 		DockerNetwork:  "off",
 	}
-	c, err := provider.New(ctx, &props, nil, nil, "")
+	c, err := provider.New(ctx, &container.Init{Props: props})
 	require.NoError(t, err)
 	result := c.Run(ctx, cmd, workDir, oci.Credentials{})
 
@@ -180,11 +180,11 @@ func TestHelloWorldExec(t *testing.T) {
 
 	provider, err := podman.NewProvider(env, buildRoot)
 	require.NoError(t, err)
-	props := platform.Properties{
+	props := &platform.Properties{
 		ContainerImage: "docker.io/library/busybox",
 		DockerNetwork:  "off",
 	}
-	c, err := provider.New(ctx, &props, nil, nil, "")
+	c, err := provider.New(ctx, &container.Init{Props: props})
 	require.NoError(t, err)
 
 	err = c.Create(ctx, workDir)
@@ -227,11 +227,11 @@ func TestExecStdio(t *testing.T) {
 
 	provider, err := podman.NewProvider(env, buildRoot)
 	require.NoError(t, err)
-	props := platform.Properties{
+	props := &platform.Properties{
 		ContainerImage: "docker.io/library/busybox",
 		DockerNetwork:  "off",
 	}
-	c, err := provider.New(ctx, &props, nil, nil, "")
+	c, err := provider.New(ctx, &container.Init{Props: props})
 	require.NoError(t, err)
 
 	err = c.Create(ctx, workDir)
@@ -271,11 +271,11 @@ func TestRun_Timeout(t *testing.T) {
 
 	provider, err := podman.NewProvider(env, rootDir)
 	require.NoError(t, err)
-	props := platform.Properties{
+	props := &platform.Properties{
 		ContainerImage: "docker.io/library/busybox",
 		DockerNetwork:  "off",
 	}
-	c, err := provider.New(ctx, &props, nil, nil, "")
+	c, err := provider.New(ctx, &container.Init{Props: props})
 	require.NoError(t, err)
 
 	// Ensure the image is cached
@@ -322,11 +322,11 @@ func TestExec_Timeout(t *testing.T) {
 
 	provider, err := podman.NewProvider(env, rootDir)
 	require.NoError(t, err)
-	props := platform.Properties{
+	props := &platform.Properties{
 		ContainerImage: "docker.io/library/busybox",
 		DockerNetwork:  "off",
 	}
-	c, err := provider.New(ctx, &props, nil, nil, "")
+	c, err := provider.New(ctx, &container.Init{Props: props})
 	require.NoError(t, err)
 
 	// Ensure the image is cached
@@ -387,11 +387,11 @@ func TestIsImageCached(t *testing.T) {
 	for _, tc := range tests {
 		provider, err := podman.NewProvider(env, rootDir)
 		require.NoError(t, err)
-		props := platform.Properties{
+		props := &platform.Properties{
 			ContainerImage: tc.image,
 			DockerNetwork:  "off",
 		}
-		c, err := provider.New(ctx, &props, nil, nil, "")
+		c, err := provider.New(ctx, &container.Init{Props: props})
 		require.NoError(t, err)
 		if tc.want {
 			err := c.PullImage(ctx, oci.Credentials{})
@@ -446,12 +446,12 @@ func TestForceRoot(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			provider, err := podman.NewProvider(env, rootDir)
 			require.NoError(t, err)
-			props := platform.Properties{
+			props := &platform.Properties{
 				ContainerImage:  image,
 				DockerForceRoot: tc.forceRoot,
 				DockerNetwork:   "off",
 			}
-			c, err := provider.New(ctx, &props, nil, nil, "")
+			c, err := provider.New(ctx, &container.Init{Props: props})
 			require.NoError(t, err)
 			result := c.Run(ctx, cmd, workDir, oci.Credentials{})
 			require.NoError(t, result.Error)
@@ -494,12 +494,12 @@ func TestUser(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			provider, err := podman.NewProvider(env, rootDir)
 			require.NoError(t, err)
-			props := platform.Properties{
+			props := &platform.Properties{
 				ContainerImage: image,
 				DockerUser:     tc.user,
 				DockerNetwork:  "off",
 			}
-			c, err := provider.New(ctx, &props, nil, nil, "")
+			c, err := provider.New(ctx, &container.Init{Props: props})
 			require.NoError(t, err)
 			result := c.Run(ctx, &repb.Command{
 				Arguments: []string{"id", "-u", "-n"},
@@ -545,11 +545,11 @@ func TestPodmanRun_LongRunningProcess_CanGetAllLogs(t *testing.T) {
 
 	provider, err := podman.NewProvider(env, rootDir)
 	require.NoError(t, err)
-	props := platform.Properties{
+	props := &platform.Properties{
 		ContainerImage: "docker.io/library/busybox",
 		DockerNetwork:  "off",
 	}
-	c, err := provider.New(ctx, &props, nil, nil, "")
+	c, err := provider.New(ctx, &container.Init{Props: props})
 	require.NoError(t, err)
 
 	res := c.Run(ctx, cmd, workDir, oci.Credentials{})
@@ -586,11 +586,11 @@ func TestPodmanRun_RecordsStats(t *testing.T) {
 	flags.Set(t, "executor.podman.enable_stats", true)
 	provider, err := podman.NewProvider(env, rootDir)
 	require.NoError(t, err)
-	props := platform.Properties{
+	props := &platform.Properties{
 		ContainerImage: "docker.io/library/ubuntu:20.04",
 		DockerNetwork:  "off",
 	}
-	c, err := provider.New(ctx, &props, nil, nil, "")
+	c, err := provider.New(ctx, &container.Init{Props: props})
 	require.NoError(t, err)
 
 	res := c.Run(ctx, cmd, workDir, oci.Credentials{})


### PR DESCRIPTION
Refactor container provider args so that we can add new optional params without every container implementation having to handle the new params. (I want to add `*operation.Publisher` to these args, but only Firecracker will be using it). 

These args are all truly optional so a struct seems better than using required positional args here (which force callers to consider the new args). For example, the Bare container implementation doesn't look at any of these struct fields.

**Related issues**: N/A
