### PR TITLE
[raft] check meta range when determine whether a node is a zombie

### DIFF
--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -332,7 +332,7 @@ func TestCleanupZombieReplicas(t *testing.T) {
 	// verify that the range and replica is not removed from s2
 	list, err := s2.ListReplicas(ctx, &rfpb.ListReplicasRequest{})
 	require.NoError(t, err)
-	require.Equal(t, 2, list.GetReplicas())
+	require.Equal(t, 2, len(list.GetReplicas()))
 	require.NotNil(t, s2.GetRange(2))
 	_, err = s2.GetReplica(2)
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
When we decide whether a node is a zombie or not in raft store, currently we
only check whether this node is a member of the cluster and whether there is
a range on the store. 

It misses a case where when a replica is removed from raft
cluster when the store is offline; so when the store restarted, the range
descriptor it loaded from the store is out of date and it cannot get the udpated
info from raft cluster because it's not longer a member of the cluster. 

In order to clean up this type of zombie nodes, we need to consult meta range 
through the sender; and if range descriptor from the meta range doesn't contain 
the replica, we will then clean it up.

Added a unit test to test the zombie node is cleaned up for the above scenario.
