### PR TITLE
[raft] skip the cache to get the up-to-data meta range when determine if a node is a zombie

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1056,7 +1056,7 @@ func (s *Store) isZombieNode(ctx context.Context, shardInfo dragonboat.ShardInfo
 	// when this node is dead. When this node restarted, the range descriptor is
 	// behind, but it cannot get updates from other nodes b/c it was removed from the
 	// cluster.
-	updatedRD, err := s.Sender().LookupRangeDescriptor(ctx, rd.GetStart(), false /*skip Cache */)
+	updatedRD, err := s.Sender().LookupRangeDescriptor(ctx, rd.GetStart(), true /*skip Cache */)
 	if err != nil {
 		log.Errorf("failed to look up range descriptor: %s", err)
 		return false


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3409
