### PR TITLE
Live-stream invocation logs

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -404,8 +404,10 @@ ts_library(
     name = "invocation_logs_model",
     srcs = ["invocation_logs_model.tsx"],
     deps = [
+        "//app/capabilities",
         "//app/errors:error_service",
         "//app/service:rpc_service",
+        "//app/util:rpc",
         "//proto:eventlog_ts_proto",
         "@npm//rxjs",
     ],

--- a/app/invocation/invocation_logs_model.tsx
+++ b/app/invocation/invocation_logs_model.tsx
@@ -1,7 +1,9 @@
 import { Subject, Subscription, from } from "rxjs";
 import { eventlog } from "../../proto/eventlog_ts_proto";
 import errorService from "../errors/error_service";
-import rpcService from "../service/rpc_service";
+import rpcService, { Cancelable } from "../service/rpc_service";
+import { streamWithRetry } from "../util/rpc";
+import capabilities from "../capabilities/capabilities";
 
 const POLL_TAIL_INTERVAL_MS = 3_000;
 // How many lines to request from the server on each chunk request.
@@ -16,18 +18,26 @@ export default class InvocationLogsModel {
   readonly onChange: Subject<undefined> = new Subject<undefined>();
 
   private logs = "";
-  private responseSubscription?: Subscription;
-  private pollTailTimeout?: number;
-
   // Length of the log prefix which has already been persisted. The remainder of
   // the log is considered "live" and may be updated on subsequent fetches.
   private stableLogLength = 0;
+
+  // Polling-based state
+  private responseSubscription?: Subscription;
+  private pollTailTimeout?: number;
+
+  // Server-stream based state
+  private stream?: Cancelable;
 
   constructor(private invocationId: string) {}
 
   startFetching() {
     this.stopFetching();
-    this.fetchTail();
+    if (capabilities.config.streamingHttpEnabled && capabilities.config.invocationLogStreamingEnabled) {
+      this.streamLogs();
+    } else {
+      this.fetchTail();
+    }
   }
 
   stopFetching() {
@@ -36,6 +46,9 @@ export default class InvocationLogsModel {
     }
     this.responseSubscription?.unsubscribe();
     this.responseSubscription = undefined;
+
+    this.stream?.cancel();
+    this.stream = undefined;
   }
 
   getLogs(): string {
@@ -44,6 +57,32 @@ export default class InvocationLogsModel {
 
   isFetching(): boolean {
     return Boolean(this.responseSubscription);
+  }
+
+  private streamLogs() {
+    let chunkId = "";
+    this.stream = streamWithRetry(
+      rpcService.service.getEventLog,
+      () => {
+        return new eventlog.GetEventLogChunkRequest({
+          invocationId: this.invocationId,
+          chunkId,
+          minLines: MIN_LINES,
+        });
+      },
+      {
+        next: (response) => {
+          this.handleResponse(response);
+          // Save the response chunk ID - if the stream is retried then we'll
+          // resume starting from this chunk.
+          chunkId = response.nextChunkId;
+        },
+        error: (e) => {
+          errorService.handleError(e, { ignoreErrorCodes: ["NotFound", "PermissionDenied", "Unauthenticated"] });
+        },
+        complete: () => {},
+      }
+    );
   }
 
   private fetchTail(chunkId = "") {
@@ -57,33 +96,13 @@ export default class InvocationLogsModel {
       )
     ).subscribe({
       next: (response) => {
-        this.logs = this.logs.slice(0, this.stableLogLength);
-        this.logs = this.logs + new TextDecoder().decode(response.buffer || new Uint8Array());
-        if (!response.live) {
-          this.stableLogLength = this.logs.length;
-        }
-
-        // Empty next chunk ID means the invocation is complete and we've reached
-        // the end of the log.
-        if (!response.nextChunkId) {
-          this.responseSubscription = undefined;
-          // Notify of change to `isFetching` state.
-          this.onChange.next();
-          return;
-        }
-
-        if (response.buffer?.length) {
-          // Notify of change to `logs` state.
-          this.onChange.next();
-        }
-
+        this.handleResponse(response);
         // Unchanged next chunk ID means the invocation is still in progress and
         // we should continue polling that chunk.
         if (response.nextChunkId === chunkId) {
           this.pollTailTimeout = window.setTimeout(() => this.fetchTail(chunkId), POLL_TAIL_INTERVAL_MS);
           return;
         }
-
         // New next chunk ID means we successfully fetched the requested
         // chunk, and more may be available. Try fetching it immediately.
         this.fetchTail(response.nextChunkId);
@@ -91,5 +110,27 @@ export default class InvocationLogsModel {
       error: (e) =>
         errorService.handleError(e, { ignoreErrorCodes: ["NotFound", "PermissionDenied", "Unauthenticated"] }),
     });
+  }
+
+  private handleResponse(response: eventlog.GetEventLogChunkResponse) {
+    this.logs = this.logs.slice(0, this.stableLogLength);
+    this.logs = this.logs + new TextDecoder().decode(response.buffer || new Uint8Array());
+    if (!response.live) {
+      this.stableLogLength = this.logs.length;
+    }
+
+    // Empty next chunk ID means the invocation is complete and we've reached
+    // the end of the log.
+    if (!response.nextChunkId) {
+      this.responseSubscription = undefined;
+      // Notify of change to `isFetching` state.
+      this.onChange.next();
+      return;
+    }
+
+    if (response.buffer?.length) {
+      // Notify of change to `logs` state.
+      this.onChange.next();
+    }
   }
 }

--- a/config/buildbuddy.local.yaml
+++ b/config/buildbuddy.local.yaml
@@ -1,5 +1,7 @@
 app:
   log_error_stack_traces: true
+  streaming_http_enabled: true
+  invocation_log_streaming_enabled: true
 storage:
   ttl_seconds: 86400 # One day in seconds.
   disk:

--- a/enterprise/config/buildbuddy.local.yaml
+++ b/enterprise/config/buildbuddy.local.yaml
@@ -6,6 +6,8 @@ app:
   default_redis_target: "localhost:6379"
   enable_target_tracking: true
   user_owned_keys_enabled: true
+  streaming_http_enabled: true
+  invocation_log_streaming_enabled: true
 database:
   data_source: "sqlite3:///tmp/${USER}-buildbuddy-enterprise.db"
 #olap_database:

--- a/enterprise/config/test/buildbuddy.noauth.yaml
+++ b/enterprise/config/test/buildbuddy.noauth.yaml
@@ -4,6 +4,8 @@ app:
   create_group_per_user: true
   add_user_to_domain_group: true
   enable_target_tracking: true
+  streaming_http_enabled: true
+  invocation_log_streaming_enabled: true
 database:
   data_source: "sqlite3:///tmp/buildbuddy-enterprise.db"
 storage:

--- a/enterprise/config/test/buildbuddy.selfauth.yaml
+++ b/enterprise/config/test/buildbuddy.selfauth.yaml
@@ -4,6 +4,8 @@ app:
   create_group_per_user: true
   add_user_to_domain_group: true
   enable_target_tracking: true
+  streaming_http_enabled: true
+  invocation_log_streaming_enabled: true
 database:
   data_source: "sqlite3:///tmp/buildbuddy-enterprise.db"
 storage:

--- a/enterprise/server/cmd/server/BUILD
+++ b/enterprise/server/cmd/server/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//enterprise/server/backends/migration_cache",
         "//enterprise/server/backends/pebble_cache",
         "//enterprise/server/backends/prom",
+        "//enterprise/server/backends/pubsub",
         "//enterprise/server/backends/redis_cache",
         "//enterprise/server/backends/redis_client",
         "//enterprise/server/backends/redis_execution_collector",

--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/migration_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pebble_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/prom"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/pubsub"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_cache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_client"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_execution_collector"
@@ -185,6 +186,9 @@ func main() {
 	}
 	if err := redis_client.RegisterDefault(realEnv); err != nil {
 		log.Fatalf("%v", err)
+	}
+	if realEnv.GetDefaultRedisClient() != nil {
+		realEnv.SetPubSub(pubsub.NewPubSub(realEnv.GetDefaultRedisClient()))
 	}
 	if err := server_notification.Register(realEnv, "app"); err != nil {
 		log.Fatalf("%v", err)

--- a/proto/buildbuddy_service.proto
+++ b/proto/buildbuddy_service.proto
@@ -177,6 +177,8 @@ service BuildBuddyService {
   // Eventlog API
   rpc GetEventLogChunk(eventlog.GetEventLogChunkRequest)
       returns (eventlog.GetEventLogChunkResponse);
+  rpc GetEventLog(eventlog.GetEventLogChunkRequest)
+      returns (stream eventlog.GetEventLogChunkResponse);
 
   // Usage API
   rpc GetUsage(usage.GetUsageRequest) returns (usage.GetUsageResponse);

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -153,6 +153,9 @@ message FrontendConfig {
 
   // Enables reader/writer roles in the UI.
   bool reader_writer_roles_enabled = 51;
+
+  // Whether to stream invocation logs.
+  bool invocation_log_streaming_enabled = 52;
 }
 
 message Region {

--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -1061,6 +1061,8 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 				e.ctx,
 				e.env.GetBlobstore(),
 				e.env.GetKeyValStore(),
+				e.env.GetPubSub(),
+				eventlog.GetEventLogPubSubChannel(iid),
 				eventlog.GetEventLogPathFromInvocationIdAndAttempt(iid, e.attempt),
 				numLinesToRetain,
 			)

--- a/server/buildbuddy_server/BUILD
+++ b/server/buildbuddy_server/BUILD
@@ -63,6 +63,7 @@ go_library(
         "//server/util/subdomain",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_protobuf//encoding/protojson",
+        "@org_golang_x_time//rate",
     ],
 )
 

--- a/server/capabilities_filter/capabilities_filter.go
+++ b/server/capabilities_filter/capabilities_filter.go
@@ -29,6 +29,7 @@ var (
 		// done purely using perms bits attached to each row.
 		"GetInvocation",
 		"GetEventLogChunk",
+		"GetEventLog",
 		"GetCacheScoreCard",
 		"GetCacheMetadata",
 		"GetTreeDirectorySizes",

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -125,4 +125,5 @@ type Env interface {
 	GetSnapshotService() interfaces.SnapshotService
 	GetAuthService() interfaces.AuthService
 	GetRegistryService() interfaces.RegistryService
+	GetPubSub() interfaces.PubSub
 }

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -125,6 +125,7 @@ type RealEnv struct {
 	snapshotService                  interfaces.SnapshotService
 	authService                      interfaces.AuthService
 	registryService                  interfaces.RegistryService
+	pubsub                           interfaces.PubSub
 }
 
 // NewRealEnv returns an environment for use in servers.
@@ -750,4 +751,11 @@ func (r *RealEnv) GetRegistryService() interfaces.RegistryService {
 }
 func (r *RealEnv) SetRegistryService(reg interfaces.RegistryService) {
 	r.registryService = reg
+}
+
+func (r *RealEnv) GetPubSub() interfaces.PubSub {
+	return r.pubsub
+}
+func (r *RealEnv) SetPubSub(value interfaces.PubSub) {
+	r.pubsub = value
 }

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -60,6 +60,7 @@ var (
 	codeSearchEnabled                      = flag.Bool("app.codesearch_enabled", false, "If set, show the code search UI.")
 	orgAdminApiKeyCreationEnabled          = flag.Bool("app.org_admin_api_key_creation_enabled", false, "If set, SCIM API keys will be able to be created in the UI.")
 	readerWriterRolesEnabled               = flag.Bool("app.reader_writer_roles_enabled", false, "If set, Reader/Writer roles will be enabled in the user management UI.")
+	invocationLogStreamingEnabled          = flag.Bool("app.invocation_log_streaming_enabled", false, "If set, the UI will stream invocation logs instead of polling.")
 
 	jsEntryPointPath = flag.String("js_entry_point_path", "/app/app_bundle/app.js?hash={APP_BUNDLE_HASH}", "Absolute URL path of the app JS entry point")
 	disableGA        = flag.Bool("disable_ga", false, "If true; ga will be disabled")
@@ -197,6 +198,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		CodeSearchEnabled:                      *codeSearchEnabled,
 		OrgAdminApiKeyCreationEnabled:          *orgAdminApiKeyCreationEnabled,
 		ReaderWriterRolesEnabled:               *readerWriterRolesEnabled,
+		InvocationLogStreamingEnabled:          *invocationLogStreamingEnabled,
 	}
 
 	configJSON, err := protojson.Marshal(&config)


### PR DESCRIPTION
- Publish a message on a pubsub channel (in Redis) whenever logs are updated
- Have clients read logs using the same 3s polling logic as today, except the polling happens on the server-side, and the server also subscribes to the pubsub channel (if available) to eagerly re-fetch the tail as soon as it is updated. The pubsub channel should be available except on OSS (for now) and possibly also during Redis restarts.

Demo (local terminal on right, BuildBuddy invocation page on left - note how the UI updates ~immediately)

https://github.com/buildbuddy-io/buildbuddy/assets/2414826/85056461-dcfb-43e0-b7c9-344531227076



**Related issues**: N/A
