### PR TITLE
Add usage column for memory usage

### DIFF
--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -585,6 +585,9 @@ func countsToMap(tu *tables.UsageCounts) (map[string]int64, error) {
 	if tu.CPUNanos > 0 {
 		counts["cpu_nanos"] = tu.CPUNanos
 	}
+	if tu.MemoryGBUsec > 0 {
+		counts["memory_gb_usec"] = tu.MemoryGBUsec
+	}
 	return counts, nil
 }
 
@@ -609,5 +612,6 @@ func stringMapToCounts(h map[string]string) (*tables.UsageCounts, error) {
 		TotalUploadSizeBytes:       hInt64["total_upload_size_bytes"],
 		TotalCachedActionExecUsec:  hInt64["total_cached_action_exec_usec"],
 		CPUNanos:                   hInt64["cpu_nanos"],
+		MemoryGBUsec:               hInt64["memory_gb_usec"],
 	}, nil
 }

--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -645,6 +645,7 @@ type UsageCounts struct {
 	TotalUploadSizeBytes       int64 `gorm:"not null;default:0"`
 	TotalCachedActionExecUsec  int64 `gorm:"not null;default:0"`
 	CPUNanos                   int64 `gorm:"not null;default:0"`
+	MemoryGBUsec               int64 `gorm:"not null;default:0"`
 }
 
 type UsageLabels struct {


### PR DESCRIPTION
Went with GB-usec as the units which will let us represent 2.5 million GB-hours for each usage row, which seems plenty.

**Related issues**: N/A
