### PR TITLE
[raft] fix occasional timeout in store_test

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -445,7 +445,7 @@ func (s *Store) Start() error {
 	})
 	eg.Go(func() error {
 		if s.driverQueue != nil {
-			s.driverQueue.Start()
+			s.driverQueue.Start(gctx)
 		}
 		return nil
 	})
@@ -464,9 +464,6 @@ func (s *Store) Stop(ctx context.Context) error {
 		s.egCancel()
 		s.leaseKeeper.Stop()
 		s.liveness.Release()
-		if s.driverQueue != nil {
-			s.driverQueue.Stop()
-		}
 		s.eg.Wait()
 	}
 	s.updateTagsWorker.Stop()


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Occasionally, driverQueue.Start() is called after we call driverQueue.Stop().
When this happens, store.Stop() hangs s.eg.Wait() because driver.Start() doesn't
return. For example: https://buildbuddy.buildbuddy.io/invocation/a0dd0b7c-29f1-47ee-be81-dab38c3ac26c
