### PR TITLE
format: render 0.100KB as 100B

### DIFF
--- a/app/format/format.tsx
+++ b/app/format/format.tsx
@@ -166,7 +166,7 @@ function truncateDecimalZeroes(numString: string): string {
 
 export function bytes(bytes: number | Long) {
   bytes = +bytes;
-  if (bytes < 100) {
+  if (bytes < 1e3) {
     return bytes + "B";
   }
   if (bytes < 1e6) {

--- a/app/format/format_test.ts
+++ b/app/format/format_test.ts
@@ -110,7 +110,7 @@ describe("bytes", () => {
   it("should abbreviate large numbers", () => {
     expect(format.bytes(0)).toEqual("0B");
     expect(format.bytes(99)).toEqual("99B");
-    expect(format.bytes(100)).toEqual("0.1KB");
+    expect(format.bytes(100)).toEqual("100B");
     expect(format.bytes(1020)).toEqual("1.02KB");
     expect(format.bytes(1023)).toEqual("1.023KB");
     expect(format.bytes(1e6 - 1)).toEqual("1000KB");


### PR DESCRIPTION
This should help avoid things being rendered as `0.543KB`.
