### PR TITLE
event_index: drop Fetch event

### DIFF
--- a/server/build_event_protocol/event_index/event_index.go
+++ b/server/build_event_protocol/event_index/event_index.go
@@ -171,6 +171,9 @@ func (idx *Index) Add(event *inpb.InvocationEvent) {
 	case *bespb.BuildEvent_Progress:
 		// Drop progress events
 		return
+	case *bespb.BuildEvent_Fetch:
+		// Drop fetch events
+		return
 	default:
 		idx.TopLevelEvents = append(idx.TopLevelEvents, event)
 	}


### PR DESCRIPTION
Folks who are interested in Fetch information don't simply want a binary
success/fail status, but they also want to check the execution of the
related Bazel repository rules as a whole.

Since that information is often available via the Timing profile with
great resolution, displaying this event in RAW tab is a waste of space.
