### PR TITLE
[raft] add block-network tag to raft/store_test

### DIFF
--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -59,6 +59,7 @@ go_test(
     name = "store_test",
     srcs = ["store_test.go"],
     shard_count = 8,
+    tags = ["block-network"],
     deps = [
         ":store",
         "//enterprise/server/raft/bringup",
@@ -89,5 +90,4 @@ go_test(
         "@com_github_lni_dragonboat_v4//raftio",
         "@com_github_stretchr_testify//require",
     ],
-	tags=["block-network"],
 )

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -89,4 +89,5 @@ go_test(
         "@com_github_lni_dragonboat_v4//raftio",
         "@com_github_stretchr_testify//require",
     ],
+	tags=["block-network"],
 )


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3415

This fixed the "bind: address already in use" issue.
