### PR TITLE
use flags.Set(t,...) instead of flag.Set in tests

### DIFF
--- a/enterprise/server/composable_cache/BUILD
+++ b/enterprise/server/composable_cache/BUILD
@@ -29,6 +29,7 @@ go_test(
         "//server/remote_cache/digest",
         "//server/testutil/testdigest",
         "//server/util/prefix",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/composable_cache/composable_cache_test.go
+++ b/enterprise/server/composable_cache/composable_cache_test.go
@@ -2,7 +2,6 @@ package composable_cache_test
 
 import (
 	"context"
-	"flag"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/backends/redis_cache"
@@ -14,6 +13,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/require"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
@@ -53,11 +53,11 @@ func readAndVerifyDigest(ctx context.Context, t *testing.T, c interfaces.Cache, 
 
 func TestReadThrough(t *testing.T) {
 	env1, _ := testEnvAndContext(t)
-	flag.Set("cache.redis.max_value_size_bytes", "100")
+	flags.Set(t, "cache.redis.max_value_size_bytes", "100")
 	outer := redis_cache.NewCache(env1.GetDefaultRedisClient())
 
 	env2, ctx := testEnvAndContext(t)
-	flag.Set("cache.redis.max_value_size_bytes", "1000")
+	flags.Set(t, "cache.redis.max_value_size_bytes", "1000")
 	inner := redis_cache.NewCache(env2.GetDefaultRedisClient())
 
 	c := composable_cache.NewComposableCache(outer, inner, composable_cache.ModeReadThrough|composable_cache.ModeWriteThrough)

--- a/enterprise/server/composable_cache/composable_cache_test.go
+++ b/enterprise/server/composable_cache/composable_cache_test.go
@@ -53,11 +53,11 @@ func readAndVerifyDigest(ctx context.Context, t *testing.T, c interfaces.Cache, 
 
 func TestReadThrough(t *testing.T) {
 	env1, _ := testEnvAndContext(t)
-	flags.Set(t, "cache.redis.max_value_size_bytes", "100")
+	flags.Set(t, "cache.redis.max_value_size_bytes", 100)
 	outer := redis_cache.NewCache(env1.GetDefaultRedisClient())
 
 	env2, ctx := testEnvAndContext(t)
-	flags.Set(t, "cache.redis.max_value_size_bytes", "1000")
+	flags.Set(t, "cache.redis.max_value_size_bytes", 1000)
 	inner := redis_cache.NewCache(env2.GetDefaultRedisClient())
 
 	c := composable_cache.NewComposableCache(outer, inner, composable_cache.ModeReadThrough|composable_cache.ModeWriteThrough)

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -84,6 +84,7 @@ go_test(
         "//server/util/log",
         "//server/util/proto",
         "//server/util/status",
+        "//server/util/testing/flags",
         "@com_github_lni_dragonboat_v4//:dragonboat",
         "@com_github_lni_dragonboat_v4//config",
         "@com_github_lni_dragonboat_v4//raftio",

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -3,7 +3,6 @@ package store_test
 import (
 	"bytes"
 	"context"
-	"flag"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -31,6 +30,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/lni/dragonboat/v4"
 	"github.com/lni/dragonboat/v4/raftio"
 	"github.com/stretchr/testify/require"
@@ -225,7 +225,7 @@ func TestStartShard(t *testing.T) {
 }
 
 func TestCleanupZombieShards(t *testing.T) {
-	flag.Set("cache.raft.zombie_node_scan_interval", "100ms")
+	flags.Set(t, "cache.raft.zombie_node_scan_interval", "100ms")
 
 	sf := newStoreFactory(t)
 	s1, nh1 := sf.NewStore(t)
@@ -265,7 +265,7 @@ func TestCleanupZombieShards(t *testing.T) {
 }
 
 func TestCleanupZombieReplicas(t *testing.T) {
-	flag.Set("cache.raft.zombie_node_scan_interval", "100ms")
+	flags.Set(t, "cache.raft.zombie_node_scan_interval", "100ms")
 
 	sf := newStoreFactory(t)
 	s1, nh1 := sf.NewStore(t)
@@ -342,8 +342,8 @@ func TestCleanupZombieReplicas(t *testing.T) {
 }
 
 func TestAutomaticSplitting(t *testing.T) {
-	flag.Set("cache.raft.entries_between_usage_checks", "1")
-	flag.Set("cache.raft.max_range_size_bytes", "10000")
+	flags.Set(t, "cache.raft.entries_between_usage_checks", "1")
+	flags.Set(t, "cache.raft.max_range_size_bytes", "10000")
 
 	sf := newStoreFactory(t)
 	s1, nh1 := sf.NewStore(t)
@@ -535,7 +535,7 @@ func writeNRecords(ctx context.Context, t *testing.T, store *TestingStore, n int
 }
 
 func TestSplitMetaRange(t *testing.T) {
-	flag.Set("cache.raft.max_range_size_bytes", "0") // disable auto splitting
+	flags.Set(t, "cache.raft.max_range_size_bytes", "0") // disable auto splitting
 	sf := newStoreFactory(t)
 	s1, nh1 := sf.NewStore(t)
 	ctx := context.Background()
@@ -589,7 +589,7 @@ func waitForRangeLease(t testing.TB, stores []*TestingStore, rangeID uint64) {
 }
 
 func TestSplitNonMetaRange(t *testing.T) {
-	flag.Set("cache.raft.max_range_size_bytes", "0") // disable auto splitting
+	flags.Set(t, "cache.raft.max_range_size_bytes", "0") // disable auto splitting
 	sf := newStoreFactory(t)
 	s1, nh1 := sf.NewStore(t)
 	s2, nh2 := sf.NewStore(t)
@@ -782,7 +782,7 @@ func TestPostFactoSplit(t *testing.T) {
 }
 
 func TestManySplits(t *testing.T) {
-	flag.Set("cache.raft.max_range_size_bytes", "0") // disable auto splitting
+	flags.Set(t, "cache.raft.max_range_size_bytes", "0") // disable auto splitting
 	sf := newStoreFactory(t)
 	s1, nh1 := sf.NewStore(t)
 	ctx := context.Background()
@@ -841,7 +841,7 @@ func TestManySplits(t *testing.T) {
 }
 
 func TestSplitAcrossClusters(t *testing.T) {
-	flag.Set("cache.raft.max_range_size_bytes", "0") // disable auto splitting
+	flags.Set(t, "cache.raft.max_range_size_bytes", "0") // disable auto splitting
 	sf := newStoreFactory(t)
 	s1, nh1 := sf.NewStore(t)
 	s2, nh2 := sf.NewStore(t)

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -342,8 +342,8 @@ func TestCleanupZombieReplicas(t *testing.T) {
 }
 
 func TestAutomaticSplitting(t *testing.T) {
-	flags.Set(t, "cache.raft.entries_between_usage_checks", "1")
-	flags.Set(t, "cache.raft.max_range_size_bytes", "10000")
+	flags.Set(t, "cache.raft.entries_between_usage_checks", 1)
+	flags.Set(t, "cache.raft.max_range_size_bytes", 10000)
 
 	sf := newStoreFactory(t)
 	s1, nh1 := sf.NewStore(t)
@@ -535,7 +535,7 @@ func writeNRecords(ctx context.Context, t *testing.T, store *TestingStore, n int
 }
 
 func TestSplitMetaRange(t *testing.T) {
-	flags.Set(t, "cache.raft.max_range_size_bytes", "0") // disable auto splitting
+	flags.Set(t, "cache.raft.max_range_size_bytes", 0) // disable auto splitting
 	sf := newStoreFactory(t)
 	s1, nh1 := sf.NewStore(t)
 	ctx := context.Background()
@@ -589,7 +589,7 @@ func waitForRangeLease(t testing.TB, stores []*TestingStore, rangeID uint64) {
 }
 
 func TestSplitNonMetaRange(t *testing.T) {
-	flags.Set(t, "cache.raft.max_range_size_bytes", "0") // disable auto splitting
+	flags.Set(t, "cache.raft.max_range_size_bytes", 0) // disable auto splitting
 	sf := newStoreFactory(t)
 	s1, nh1 := sf.NewStore(t)
 	s2, nh2 := sf.NewStore(t)
@@ -782,7 +782,7 @@ func TestPostFactoSplit(t *testing.T) {
 }
 
 func TestManySplits(t *testing.T) {
-	flags.Set(t, "cache.raft.max_range_size_bytes", "0") // disable auto splitting
+	flags.Set(t, "cache.raft.max_range_size_bytes", 0) // disable auto splitting
 	sf := newStoreFactory(t)
 	s1, nh1 := sf.NewStore(t)
 	ctx := context.Background()
@@ -841,7 +841,7 @@ func TestManySplits(t *testing.T) {
 }
 
 func TestSplitAcrossClusters(t *testing.T) {
-	flags.Set(t, "cache.raft.max_range_size_bytes", "0") // disable auto splitting
+	flags.Set(t, "cache.raft.max_range_size_bytes", 0) // disable auto splitting
 	sf := newStoreFactory(t)
 	s1, nh1 := sf.NewStore(t)
 	s2, nh2 := sf.NewStore(t)

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -225,7 +225,7 @@ func TestStartShard(t *testing.T) {
 }
 
 func TestCleanupZombieShards(t *testing.T) {
-	flags.Set(t, "cache.raft.zombie_node_scan_interval", "100ms")
+	flags.Set(t, "cache.raft.zombie_node_scan_interval", 100*time.Millisecond)
 
 	sf := newStoreFactory(t)
 	s1, nh1 := sf.NewStore(t)
@@ -265,7 +265,7 @@ func TestCleanupZombieShards(t *testing.T) {
 }
 
 func TestCleanupZombieReplicas(t *testing.T) {
-	flags.Set(t, "cache.raft.zombie_node_scan_interval", "100ms")
+	flags.Set(t, "cache.raft.zombie_node_scan_interval", 100*time.Millisecond)
 
 	sf := newStoreFactory(t)
 	s1, nh1 := sf.NewStore(t)

--- a/enterprise/server/remote_execution/platform/BUILD
+++ b/enterprise/server/remote_execution/platform/BUILD
@@ -28,6 +28,7 @@ go_test(
         "//proto:remote_execution_go_proto",
         "//server/testutil/testenv",
         "//server/util/status",
+        "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//encoding/prototext",

--- a/enterprise/server/remote_execution/platform/platform_test.go
+++ b/enterprise/server/remote_execution/platform/platform_test.go
@@ -2,7 +2,6 @@ package platform
 
 import (
 	"encoding/base64"
-	"flag"
 	"fmt"
 	"strings"
 	"testing"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/prototext"
@@ -551,7 +551,7 @@ func TestForceNetworkIsolationType(t *testing.T) {
 			{Name: "workload-isolation-type", Value: testCase.workloadIsolationType},
 		}}
 
-		flag.Set("executor.forced_network_isolation_type", testCase.forcedNetworkIsolationType)
+		flags.Set(t, "executor.forced_network_isolation_type", testCase.forcedNetworkIsolationType)
 
 		platformProps, err := ParseProperties(&repb.ExecutionTask{Command: &repb.Command{Platform: plat}})
 		require.NoError(t, err)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3415
flag.Set doesn't restore the value to default while flags.Set does during
cleanup phase.
