### PR TITLE
[raft] pass fake clock in test

### DIFF
--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -86,6 +86,7 @@ go_test(
         "//server/util/proto",
         "//server/util/status",
         "//server/util/testing/flags",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_lni_dragonboat_v4//:dragonboat",
         "@com_github_lni_dragonboat_v4//config",
         "@com_github_lni_dragonboat_v4//raftio",

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/jonboulle/clockwork"
 	"github.com/lni/dragonboat/v4"
 	"github.com/lni/dragonboat/v4/raftio"
 	"github.com/stretchr/testify/require"
@@ -95,6 +96,10 @@ func (ts *TestingStore) NewReplica(shardID, replicaID uint64) *replica.Replica {
 }
 
 func (sf *storeFactory) NewStore(t *testing.T) *TestingStore {
+	return sf.NewStoreWithClock(t, clockwork.NewRealClock())
+}
+
+func (sf *storeFactory) NewStoreWithClock(t *testing.T, clock clockwork.Clock) *TestingStore {
 	nodeAddr := localAddr(t)
 	gm := newGossipManager(t, nodeAddr, sf.gossipAddrs)
 	sf.gossipAddrs = append(sf.gossipAddrs, nodeAddr)
@@ -144,7 +149,7 @@ func (sf *storeFactory) NewStore(t *testing.T) *TestingStore {
 	db, err := pebble.Open(ts.RootDir, "raft_store", &pebble.Options{})
 	require.NoError(t, err)
 	leaser := pebble.NewDBLeaser(db)
-	s, err := store.NewWithArgs(te, ts.RootDir, nodeHost, gm, ts.Sender, reg, raftListener, apiClient, ts.GRPCAddress, partitions, db, leaser)
+	s, err := store.NewWithArgs(te, ts.RootDir, nodeHost, gm, ts.Sender, reg, raftListener, apiClient, ts.GRPCAddress, partitions, db, leaser, clock)
 	require.NoError(t, err)
 	require.NotNil(t, s)
 	s.Start()
@@ -228,10 +233,9 @@ func TestStartShard(t *testing.T) {
 }
 
 func TestCleanupZombieShards(t *testing.T) {
-	flags.Set(t, "cache.raft.zombie_node_scan_interval", 100*time.Millisecond)
-
+	clock := clockwork.NewFakeClock()
 	sf := newStoreFactory(t)
-	s1 := sf.NewStore(t)
+	s1 := sf.NewStoreWithClock(t, clock)
 	ctx := context.Background()
 
 	err := bringup.SendStartShardRequests(ctx, s1.NodeHost, s1.APIClient, makeNodeGRPCAddressesMap(s1))
@@ -255,22 +259,22 @@ func TestCleanupZombieShards(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < 30; i++ {
+		clock.Advance(11 * time.Second)
 		list, err := s1.ListReplicas(ctx, &rfpb.ListReplicasRequest{})
 		require.NoError(t, err)
 		if len(list.GetReplicas()) == 1 {
 			return
 		}
-		time.Sleep(time.Second)
 	}
-	t.Fatalf("Zombie killer never cleaned up zombie range 2")
+	require.Fail(t, "Zombie killer never cleaned up zombie range 2")
 }
 
 func TestCleanupZombieReplicas(t *testing.T) {
-	flags.Set(t, "cache.raft.zombie_node_scan_interval", 100*time.Millisecond)
+	clock := clockwork.NewFakeClock()
 
 	sf := newStoreFactory(t)
-	s1 := sf.NewStore(t)
-	s2 := sf.NewStore(t)
+	s1 := sf.NewStoreWithClock(t, clock)
+	s2 := sf.NewStoreWithClock(t, clock)
 	ctx := context.Background()
 
 	err := bringup.SendStartShardRequests(ctx, s1.NodeHost, s1.APIClient, makeNodeGRPCAddressesMap(s1, s2))
@@ -313,10 +317,10 @@ func TestCleanupZombieReplicas(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < 30; i++ {
+		clock.Advance(11 * time.Second)
 		list, err := s1.ListReplicas(ctx, &rfpb.ListReplicasRequest{})
 		require.NoError(t, err)
 		if len(list.GetReplicas()) == 1 {
-			log.Debugf("listReplicas: %+v", list)
 			repl := list.GetReplicas()[0]
 			// nh1 only has shard 1
 			require.Equal(t, uint64(1), repl.GetShardId())
@@ -326,7 +330,6 @@ func TestCleanupZombieReplicas(t *testing.T) {
 			require.True(t, status.IsOutOfRangeError(err))
 			return
 		}
-		time.Sleep(time.Second)
 	}
 	// verify that the range and replica is not removed from s2
 	list, err := s2.ListReplicas(ctx, &rfpb.ListReplicasRequest{})
@@ -336,7 +339,7 @@ func TestCleanupZombieReplicas(t *testing.T) {
 	_, err = s2.GetReplica(2)
 	require.NoError(t, err)
 
-	t.Fatalf("Zombie killer never cleaned up zombie range 2")
+	require.Fail(t, "Zombie killer never cleaned up zombie range 2")
 }
 
 func TestAutomaticSplitting(t *testing.T) {

--- a/enterprise/server/raft/txn/txn_test.go
+++ b/enterprise/server/raft/txn/txn_test.go
@@ -111,7 +111,7 @@ func newFakeStore(t *testing.T, rootDir string) *fakeStore {
 			MaxSizeBytes: int64(1_000_000_000), // 1G
 		},
 	}
-	s, err := store.NewWithArgs(te, rootDir, nodeHost, gm, fs.sender, reg, raftListener, apiClient, grpcAddress, partitions, db, fs.leaser)
+	s, err := store.NewWithArgs(te, rootDir, nodeHost, gm, fs.sender, reg, raftListener, apiClient, grpcAddress, partitions, db, fs.leaser, clockwork.NewRealClock())
 	require.NoError(t, err)
 	fs.Store = s
 	t.Cleanup(func() {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
We set the zombie scan interval to 100ms when testing zombie clean up logic.
This can cause the test to be flaky because the zombie detector comes along when
we are in the middle of starting the shards in the test.
