### PR TITLE
[raft] check whether a node is zombie again after a minute before removal

### DIFF
--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1092,7 +1092,6 @@ func (s *Store) cleanupZombieNodes(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-timer.Chan():
-			s.log.Info("timer chan received")
 			if idx == len(nInfo.ShardInfoList) {
 				idx = 0
 				nInfo = s.nodeHost.GetNodeHostInfo(dragonboat.NodeHostInfoOption{SkipLogInfo: true})
@@ -1105,7 +1104,6 @@ func (s *Store) cleanupZombieNodes(ctx context.Context) {
 				s.log.Debugf("Found a potential Zombie: %+v", sInfo)
 				potentialZombie := sInfo
 				deleteTimer := s.clock.AfterFunc(*zombieMinDuration, func() {
-					s.log.Debugf("deleteTimer run: %+v", sInfo)
 					if !s.isZombieNode(ctx, potentialZombie) {
 						return
 					}

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1123,7 +1123,6 @@ func (s *Store) cleanupZombieNodes(ctx context.Context) {
 				})
 				defer deleteTimer.Stop()
 			}
-
 		}
 	}
 }

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -63,7 +63,7 @@ import (
 
 var (
 	zombieNodeScanInterval = flag.Duration("cache.raft.zombie_node_scan_interval", 10*time.Second, "Check if one replica is a zombie every this often. 0 to disable.")
-	zombieMinDuration      = flag.Duration("cache.raft.zombie_min_duration", 1*time.Minute, "The minimum duration a replica remain in a zombie state to be considered a zombie.")
+	zombieMinDuration      = flag.Duration("cache.raft.zombie_min_duration", 1*time.Minute, "The minimum duration a replica must remain in a zombie state to be considered a zombie.")
 	replicaScanInterval    = flag.Duration("cache.raft.replica_scan_interval", 1*time.Minute, "The interval we wait to check if the replicas need to be queued for replication")
 	maxRangeSizeBytes      = flag.Int64("cache.raft.max_range_size_bytes", 1e8, "If set to a value greater than 0, ranges will be split until smaller than this size")
 	enableDriver           = flag.Bool("cache.raft.enable_driver", true, "If true, enable placement driver")

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -63,6 +63,7 @@ import (
 
 var (
 	zombieNodeScanInterval = flag.Duration("cache.raft.zombie_node_scan_interval", 10*time.Second, "Check if one replica is a zombie every this often. 0 to disable.")
+	zombieMinDuration      = flag.Duration("cache.raft.zombie_min_duration", 1*time.Minute, "The minimum duration a replica remain in a zombie state to be considered a zombie.")
 	replicaScanInterval    = flag.Duration("cache.raft.replica_scan_interval", 1*time.Minute, "The interval we wait to check if the replicas need to be queued for replication")
 	maxRangeSizeBytes      = flag.Int64("cache.raft.max_range_size_bytes", 1e8, "If set to a value greater than 0, ranges will be split until smaller than this size")
 	enableDriver           = flag.Bool("cache.raft.enable_driver", true, "If true, enable placement driver")
@@ -1091,6 +1092,7 @@ func (s *Store) cleanupZombieNodes(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-timer.Chan():
+			s.log.Info("timer chan received")
 			if idx == len(nInfo.ShardInfoList) {
 				idx = 0
 				nInfo = s.nodeHost.GetNodeHostInfo(dragonboat.NodeHostInfoOption{SkipLogInfo: true})
@@ -1100,20 +1102,30 @@ func (s *Store) cleanupZombieNodes(ctx context.Context) {
 			idx += 1
 
 			if s.isZombieNode(ctx, sInfo) {
-				s.log.Debugf("Removing zombie node: %+v...", sInfo)
-				if err := s.nodeHost.StopReplica(sInfo.ShardID, sInfo.ReplicaID); err != nil {
-					s.log.Errorf("Error stopping zombie replica: %s", err)
-				} else {
-					if _, err := s.RemoveData(ctx, &rfpb.RemoveDataRequest{
-						ShardId:   sInfo.ShardID,
-						ReplicaId: sInfo.ReplicaID,
-					}); err != nil {
-						s.log.Errorf("Error removing zombie replica data: %s", err)
-					} else {
-						s.log.Infof("Successfully removed zombie node: %+v", sInfo)
+				s.log.Debugf("Found a potential Zombie: %+v", sInfo)
+				potentialZombie := sInfo
+				deleteTimer := s.clock.AfterFunc(*zombieMinDuration, func() {
+					s.log.Debugf("deleteTimer run: %+v", sInfo)
+					if !s.isZombieNode(ctx, potentialZombie) {
+						return
 					}
-				}
+					s.log.Debugf("Removing zombie node: %+v...", potentialZombie)
+					if err := s.nodeHost.StopReplica(potentialZombie.ShardID, potentialZombie.ReplicaID); err != nil {
+						s.log.Errorf("Error stopping zombie replica: %s", err)
+					} else {
+						if _, err := s.RemoveData(ctx, &rfpb.RemoveDataRequest{
+							ShardId:   potentialZombie.ShardID,
+							ReplicaId: potentialZombie.ReplicaID,
+						}); err != nil {
+							s.log.Errorf("Error removing zombie replica data: %s", err)
+						} else {
+							s.log.Infof("Successfully removed zombie node: %+v", potentialZombie)
+						}
+					}
+				})
+				defer deleteTimer.Stop()
 			}
+
 		}
 	}
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
If zombie detector runs in the middle of bringup.StartShard(..) it can
incorrectly delete a shard. To avoid this problem, we only delete the node if it
is dead for a certain period of time.
