### PR TITLE
Add hidden tag for flags

### DIFF
--- a/server/util/flag/flag.go
+++ b/server/util/flag/flag.go
@@ -15,7 +15,7 @@ import (
 var Secret = flagtags.SecretTag
 var Deprecated = flagtags.DeprecatedTag
 var YAMLIgnore = flagtags.YAMLIgnoreTag
-var Hidden = flagtags.HiddenTag
+var Internal = flagtags.InternalTag
 
 var NewFlagSet = flag.NewFlagSet
 var ContinueOnError = flag.ContinueOnError

--- a/server/util/flag/flag.go
+++ b/server/util/flag/flag.go
@@ -15,6 +15,7 @@ import (
 var Secret = flagtags.SecretTag
 var Deprecated = flagtags.DeprecatedTag
 var YAMLIgnore = flagtags.YAMLIgnoreTag
+var Hidden = flagtags.HiddenTag
 
 var NewFlagSet = flag.NewFlagSet
 var ContinueOnError = flag.ContinueOnError

--- a/server/util/flagutil/common/common.go
+++ b/server/util/flagutil/common/common.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"flag"
+	"fmt"
 	"reflect"
 	"time"
 
@@ -25,6 +26,8 @@ var (
 
 	// Change only for testing purposes
 	DefaultFlagSet = flag.CommandLine
+
+	usageSubstitutions = make(map[*flag.FlagSet]*func())
 )
 
 func flagTypeFromFlagFuncName(name string) reflect.Type {
@@ -90,6 +93,10 @@ type Expandable interface {
 
 type Secretable interface {
 	IsSecret() bool
+}
+
+type Hideable interface {
+	Hidden() bool
 }
 
 type DocumentNodeOption interface {
@@ -358,6 +365,38 @@ func Expand(v flag.Value, mapper func(string) (string, error)) error {
 		return err
 	}
 	return v.Set(exp)
+}
+
+// SubstituteUsage substitutes flagutil's custom Usage function for the current
+// one in the given flagset, or performing a no-op if the custom Usage function
+// is already present. It returns whether or not it performed the substitution.
+func SubstituteUsage(flagset *flag.FlagSet) bool {
+	if usage, ok := usageSubstitutions[flagset]; !ok {
+		flagset.Usage = func() {
+			// This Usage function is patterned off of flag.FlagSet.defaultUsage(),
+			// but uses a FlagSet that has had any hidden flags filtered out.
+			if flagset.Name() == "" {
+				fmt.Fprintf(flagset.Output(), "Usage:\n")
+			} else {
+				fmt.Fprintf(flagset.Output(), "Usage of %s:\n", flagset.Name())
+			}
+			filtered := flag.NewFlagSet(flagset.Name(), flagset.ErrorHandling())
+			flagset.VisitAll(func(f *flag.Flag) {
+				if h, ok := f.Value.(Hideable); ok && h.Hidden() {
+					return
+				}
+				filtered.Var(f.Value, f.Name, f.Usage)
+			})
+			filtered.PrintDefaults()
+		}
+		usageSubstitutions[flagset] = &flagset.Usage
+		return true
+	} else if &flagset.Usage != usage {
+		flagset.Usage = *usageSubstitutions[flagset]
+		usageSubstitutions[flagset] = &flagset.Usage
+		return true
+	}
+	return false
 }
 
 // AddTestFlagTypeForTesting adds a type correspondence to the internal

--- a/server/util/flagutil/common/common.go
+++ b/server/util/flagutil/common/common.go
@@ -95,8 +95,8 @@ type Secretable interface {
 	IsSecret() bool
 }
 
-type Hideable interface {
-	Hidden() bool
+type MaybeInternal interface {
+	Internal() bool
 }
 
 type DocumentNodeOption interface {
@@ -374,7 +374,7 @@ func SubstituteUsage(flagset *flag.FlagSet) bool {
 	if usage, ok := usageSubstitutions[flagset]; !ok {
 		flagset.Usage = func() {
 			// This Usage function is patterned off of flag.FlagSet.defaultUsage(),
-			// but uses a FlagSet that has had any hidden flags filtered out.
+			// but uses a FlagSet that has had any internal flags filtered out.
 			if flagset.Name() == "" {
 				fmt.Fprintf(flagset.Output(), "Usage:\n")
 			} else {
@@ -382,7 +382,7 @@ func SubstituteUsage(flagset *flag.FlagSet) bool {
 			}
 			filtered := flag.NewFlagSet(flagset.Name(), flagset.ErrorHandling())
 			flagset.VisitAll(func(f *flag.Flag) {
-				if h, ok := f.Value.(Hideable); ok && h.Hidden() {
+				if h, ok := f.Value.(MaybeInternal); ok && h.Internal() {
 					return
 				}
 				filtered.Var(f.Value, f.Name, f.Usage)

--- a/server/util/flagutil/types/autoflags/BUILD
+++ b/server/util/flagutil/types/autoflags/BUILD
@@ -22,8 +22,6 @@ go_test(
     deps = [
         "//server/util/flagutil/common",
         "//server/util/flagutil/types",
-        "//server/util/flagutil/types/autoflags/tags",
-        "//server/util/flagutil/yaml",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/server/util/flagutil/types/autoflags/autoflags_test.go
+++ b/server/util/flagutil/types/autoflags/autoflags_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	flagtypes "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types"
-	flagtags "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/types/autoflags/tags"
-	flagyaml "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/yaml"
 )
 
 type unsupportedFlagValue struct{}
@@ -33,17 +31,6 @@ func replaceFlagsForTesting(t *testing.T) *flag.FlagSet {
 	})
 
 	return flags
-}
-
-func replaceIgnoreSetForTesting(t *testing.T) map[string]struct{} {
-	oldIgnoreSet := flagyaml.IgnoreSet
-	flagyaml.IgnoreSet = make(map[string]struct{})
-
-	t.Cleanup(func() {
-		flagyaml.IgnoreSet = oldIgnoreSet
-	})
-
-	return flagyaml.IgnoreSet
 }
 
 func TestNew(t *testing.T) {
@@ -204,16 +191,4 @@ func TestNew(t *testing.T) {
 	err = common.SetValueForFlagName(flags, "struct_slice", []testStruct{{Field: 3}}, map[string]struct{}{"struct_slice": {}}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []testStruct{{Field: 1}, {Field: 2}}, *structSlice)
-}
-
-func TestYAMLIgnoreTag(t *testing.T) {
-	flags := replaceFlagsForTesting(t)
-	_ = replaceIgnoreSetForTesting(t)
-	flagBool := New(flags, "bool", false, "", flagtags.YAMLIgnoreTag)
-
-	yamlData := `
-	bool: true
-`
-	flagyaml.PopulateFlagsFromData(yamlData)
-	assert.Equal(t, false, *flagBool)
 }

--- a/server/util/flagutil/types/autoflags/tags/BUILD
+++ b/server/util/flagutil/types/autoflags/tags/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "tags",
@@ -9,5 +9,18 @@ go_library(
         "//server/util/flagutil/common",
         "//server/util/flagutil/yaml",
         "//server/util/log",
+    ],
+)
+
+go_test(
+    name = "tags_test",
+    srcs = ["tags_test.go"],
+    embed = [":tags"],
+    deps = [
+        "//server/util/flagutil/common",
+        "//server/util/flagutil/yaml",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )

--- a/server/util/flagutil/types/autoflags/tags/tags.go
+++ b/server/util/flagutil/types/autoflags/tags/tags.go
@@ -66,6 +66,9 @@ type Tagged interface {
 	// from Secretable
 	DesignateIsSecretFunc(func() bool)
 
+	// from Hideable
+	DesignateHiddenFunc(func() bool)
+
 	// from NameAliasable
 	DesignateIsNameAliasingFunc(func() bool)
 	DesignateAliasedNameFunc(func() string)
@@ -96,6 +99,7 @@ type TaggedFlagValue[T any, FV flag.Value] struct {
 	wrappedValueFunc            func() flag.Value
 	expandFunc                  func(mapping func(string) (string, error)) error
 	isSecretFunc                func() bool
+	hiddenFunc                  func() bool
 	isNameAliasingFunc          func() bool
 	aliasedNameFunc             func() string
 	setValueForFlagNameHookFunc func()
@@ -175,6 +179,39 @@ func (t *TaggedFlagValue[T, FV]) IsSecret() bool {
 	if t.isSecretFunc != nil {
 		return t.isSecretFunc()
 	}
+	v := t.WrappedValue()
+	for {
+		if secretable, ok := v.(common.Secretable); ok {
+			return secretable.IsSecret()
+		}
+		if wrapping, ok := v.(common.WrappingValue); ok {
+			v = wrapping.WrappedValue()
+		} else {
+			break
+		}
+	}
+	return false
+}
+
+func (t *TaggedFlagValue[T, FV]) DesignateHiddenFunc(hiddenFunc func() bool) {
+	t.hiddenFunc = hiddenFunc
+}
+
+func (t *TaggedFlagValue[T, FV]) Hidden() bool {
+	if t.hiddenFunc != nil {
+		return t.hiddenFunc()
+	}
+	v := t.WrappedValue()
+	for {
+		if hideable, ok := v.(common.Hideable); ok {
+			return hideable.Hidden()
+		}
+		if wrapping, ok := v.(common.WrappingValue); ok {
+			v = wrapping.WrappedValue()
+		} else {
+			break
+		}
+	}
 	return false
 }
 
@@ -226,6 +263,10 @@ func (t *TaggedFlagValue[T, FV]) YAMLSetValueHook() {
 // defining the flag initially
 func Tag[T any, FV flag.Value](flagset *flag.FlagSet, name string, t Taggable) *T {
 	flg := flagset.Lookup(name)
+	if flg == nil {
+		log.Fatalf("Error creating TaggedFlagValue[%T] when applying tag %v for flag %s: flag was nil.", common.Zero[T](), t, name)
+		return nil
+	}
 	converted, err := common.ConvertFlagValue(flg.Value)
 	if err != nil {
 		log.Fatalf("Error creating TaggedFlagValue[%T] when applying tag %v for flag %s: %v", common.Zero[T](), t, name, err)
@@ -329,6 +370,16 @@ func (_ *secretTag) Tag(flagset *flag.FlagSet, name string, tagged Tagged) flag.
 }
 
 var SecretTag = &secretTag{}
+
+type hiddenTag struct{}
+
+func (_ *hiddenTag) Tag(flagset *flag.FlagSet, name string, f Tagged) flag.Value {
+	f.DesignateHiddenFunc(func() bool { return true })
+	common.SubstituteUsage(flagset)
+	return f
+}
+
+var HiddenTag = &hiddenTag{}
 
 type yamlIgnoreTag struct{}
 

--- a/server/util/flagutil/types/autoflags/tags/tags_test.go
+++ b/server/util/flagutil/types/autoflags/tags/tags_test.go
@@ -4,13 +4,12 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
-	flagyaml "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/yaml"
-
 	"gopkg.in/yaml.v3"
+
+	flagyaml "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/yaml"
 )
 
 func replaceFlagsForTesting(t *testing.T) *flag.FlagSet {
@@ -102,11 +101,11 @@ func TestSecret(t *testing.T) {
 	assert.Empty(t, len(m))
 }
 
-func TestHidden(t *testing.T) {
+func TestInternal(t *testing.T) {
 	flagset := replaceFlagsForTesting(t)
 
 	v1 := flagset.String("t", "default", "test usage")
-	Tag[string, flag.Value](flagset, "t", HiddenTag)
+	Tag[string, flag.Value](flagset, "t", InternalTag)
 
 	f1 := flagset.Lookup("t")
 	require.NotNil(t, f1)
@@ -114,14 +113,14 @@ func TestHidden(t *testing.T) {
 	assert.EqualValues(t, v1, common.UnwrapFlagValue(f1.Value))
 
 	v2 := flagset.String("structured.t", "default2", "test usage")
-	Tag[string, flag.Value](flagset, "structured.t", HiddenTag)
+	Tag[string, flag.Value](flagset, "structured.t", InternalTag)
 
 	f2 := flagset.Lookup("structured.t")
 	require.NotNil(t, f2)
 
 	assert.EqualValues(t, v2, common.UnwrapFlagValue(f2.Value))
 
-	_ = flagset.String("not_hidden", "", "test usage")
+	_ = flagset.String("not_internal", "", "test usage")
 
 	common.DefaultFlagSet = flagset
 	text, err := flagyaml.SplitDocumentedYAMLFromFlags()
@@ -153,11 +152,11 @@ func TestYAMLIgnoreTag(t *testing.T) {
 	assert.Equal(t, "default", *v)
 }
 
-func TestHiddenAndSecret(t *testing.T) {
+func TestInternalAndSecret(t *testing.T) {
 	flagset := replaceFlagsForTesting(t)
 
 	v1 := flagset.String("t1", "default", "test usage")
-	Tag[string, flag.Value](flagset, "t1", HiddenTag)
+	Tag[string, flag.Value](flagset, "t1", InternalTag)
 	Tag[string, flag.Value](flagset, "t1", SecretTag)
 
 	f1 := flagset.Lookup("t1")
@@ -167,14 +166,14 @@ func TestHiddenAndSecret(t *testing.T) {
 
 	v2 := flagset.String("structured.t", "default2", "test usage")
 	Tag[string, flag.Value](flagset, "structured.t", SecretTag)
-	Tag[string, flag.Value](flagset, "structured.t", HiddenTag)
+	Tag[string, flag.Value](flagset, "structured.t", InternalTag)
 
 	f2 := flagset.Lookup("structured.t")
 	require.NotNil(t, f2)
 
 	assert.EqualValues(t, v2, common.UnwrapFlagValue(f2.Value))
 
-	_ = flagset.String("not_hidden_or_secret", "", "test usage")
+	_ = flagset.String("not_internal_or_secret", "", "test usage")
 
 	common.DefaultFlagSet = flagset
 	text, err := flagyaml.SplitDocumentedYAMLFromFlags()

--- a/server/util/flagutil/types/autoflags/tags/tags_test.go
+++ b/server/util/flagutil/types/autoflags/tags/tags_test.go
@@ -265,7 +265,7 @@ func TestDeprecatedAndSecret(t *testing.T) {
 	assert.Empty(t, len(m))
 }
 
-func TestYAMLIgnoreAndSecret(t * testing.T) {
+func TestYAMLIgnoreAndSecret(t *testing.T) {
 	flagset := replaceFlagsForTesting(t)
 
 	v1 := flagset.String("t1", "default", "test usage")

--- a/server/util/flagutil/types/autoflags/tags/tags_test.go
+++ b/server/util/flagutil/types/autoflags/tags/tags_test.go
@@ -1,0 +1,307 @@
+package tags
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/flagutil/common"
+	flagyaml "github.com/buildbuddy-io/buildbuddy/server/util/flagutil/yaml"
+
+	"gopkg.in/yaml.v3"
+)
+
+func replaceFlagsForTesting(t *testing.T) *flag.FlagSet {
+	flags := flag.NewFlagSet("test", flag.ContinueOnError)
+	common.DefaultFlagSet = flags
+
+	t.Cleanup(func() {
+		common.DefaultFlagSet = flag.CommandLine
+	})
+
+	return flags
+}
+
+func replaceIgnoreSetForTesting(t *testing.T) map[string]struct{} {
+	oldIgnoreSet := flagyaml.IgnoreSet
+	flagyaml.IgnoreSet = make(map[string]struct{})
+
+	t.Cleanup(func() {
+		flagyaml.IgnoreSet = oldIgnoreSet
+	})
+
+	return flagyaml.IgnoreSet
+}
+
+func TestAlias(t *testing.T) {
+	flagset := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	v := flagset.String("t", "default", "test usage")
+	Tag[string, flag.Value](flagset, "t", AliasTag("t1", "t2"))
+
+	f := flagset.Lookup("t")
+	require.NotNil(t, f)
+
+	assert.EqualValues(t, v, f.Value)
+	assert.Equal(t, "test usage", f.Usage)
+
+	f1 := flagset.Lookup("t1")
+	require.NotNil(t, f1)
+
+	f2 := flagset.Lookup("t2")
+	require.NotNil(t, f2)
+
+	assert.EqualValues(t, v, common.UnwrapFlagValue(f1.Value))
+	assert.EqualValues(t, v, common.UnwrapFlagValue(f2.Value))
+
+	assert.Equal(t, "Alias for t", f1.Usage)
+	assert.Equal(t, "Alias for t", f2.Usage)
+
+}
+
+func TestDeprecated(t *testing.T) {
+	flagset := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	v := flagset.String("t", "default", "test usage")
+	Tag[string, flag.Value](flagset, "t", DeprecatedTag("migrate pls"))
+
+	f := flagset.Lookup("t")
+	require.NotNil(t, f)
+
+	assert.EqualValues(t, v, common.UnwrapFlagValue(f.Value))
+	assert.Equal(t, "test usage **DEPRECATED** migrate pls", f.Usage)
+}
+
+func TestSecret(t *testing.T) {
+	flagset := replaceFlagsForTesting(t)
+
+	v1 := flagset.String("t1", "default", "test usage")
+	Tag[string, flag.Value](flagset, "t1", SecretTag)
+
+	f1 := flagset.Lookup("t1")
+	require.NotNil(t, f1)
+
+	assert.EqualValues(t, v1, common.UnwrapFlagValue(f1.Value))
+
+	v2 := flagset.String("structured.t", "default2", "test usage")
+	Tag[string, flag.Value](flagset, "structured.t", SecretTag)
+
+	f2 := flagset.Lookup("structured.t")
+	require.NotNil(t, f2)
+
+	assert.EqualValues(t, v2, common.UnwrapFlagValue(f2.Value))
+
+	common.DefaultFlagSet = flagset
+	text, err := flagyaml.SplitDocumentedYAMLFromFlags(flagyaml.RedactSecrets)
+	require.NoError(t, err)
+
+	m := make(map[string]any)
+	require.NoError(t, yaml.Unmarshal(text, m))
+	assert.Empty(t, len(m))
+}
+
+func TestHidden(t *testing.T) {
+	flagset := replaceFlagsForTesting(t)
+
+	v1 := flagset.String("t", "default", "test usage")
+	Tag[string, flag.Value](flagset, "t", HiddenTag)
+
+	f1 := flagset.Lookup("t")
+	require.NotNil(t, f1)
+
+	assert.EqualValues(t, v1, common.UnwrapFlagValue(f1.Value))
+
+	v2 := flagset.String("structured.t", "default2", "test usage")
+	Tag[string, flag.Value](flagset, "structured.t", HiddenTag)
+
+	f2 := flagset.Lookup("structured.t")
+	require.NotNil(t, f2)
+
+	assert.EqualValues(t, v2, common.UnwrapFlagValue(f2.Value))
+
+	_ = flagset.String("not_hidden", "", "test usage")
+
+	common.DefaultFlagSet = flagset
+	text, err := flagyaml.SplitDocumentedYAMLFromFlags()
+	require.NoError(t, err)
+
+	m := make(map[string]any)
+	require.NoError(t, yaml.Unmarshal(text, m))
+	assert.Len(t, m, 1)
+
+	assert.NotNil(t, flagset.Usage)
+}
+
+func TestYAMLIgnoreTag(t *testing.T) {
+	flagset := replaceFlagsForTesting(t)
+	_ = replaceIgnoreSetForTesting(t)
+
+	v := flagset.String("t", "default", "test usage")
+	Tag[string, flag.Value](flagset, "t", YAMLIgnoreTag)
+
+	f := flagset.Lookup("t")
+	require.NotNil(t, f)
+
+	assert.EqualValues(t, v, common.UnwrapFlagValue(f.Value))
+
+	yamlData := `
+	t: newValue
+`
+	flagyaml.PopulateFlagsFromData(yamlData)
+	assert.Equal(t, "default", *v)
+}
+
+func TestHiddenAndSecret(t *testing.T) {
+	flagset := replaceFlagsForTesting(t)
+
+	v1 := flagset.String("t1", "default", "test usage")
+	Tag[string, flag.Value](flagset, "t1", HiddenTag)
+	Tag[string, flag.Value](flagset, "t1", SecretTag)
+
+	f1 := flagset.Lookup("t1")
+	require.NotNil(t, f1)
+
+	assert.EqualValues(t, v1, common.UnwrapFlagValue(f1.Value))
+
+	v2 := flagset.String("structured.t", "default2", "test usage")
+	Tag[string, flag.Value](flagset, "structured.t", SecretTag)
+	Tag[string, flag.Value](flagset, "structured.t", HiddenTag)
+
+	f2 := flagset.Lookup("structured.t")
+	require.NotNil(t, f2)
+
+	assert.EqualValues(t, v2, common.UnwrapFlagValue(f2.Value))
+
+	_ = flagset.String("not_hidden_or_secret", "", "test usage")
+
+	common.DefaultFlagSet = flagset
+	text, err := flagyaml.SplitDocumentedYAMLFromFlags()
+	require.NoError(t, err)
+
+	m := make(map[string]any)
+	require.NoError(t, yaml.Unmarshal(text, m))
+	assert.Len(t, m, 1)
+
+	assert.NotNil(t, flagset.Usage)
+}
+
+func TestAliasAndSecret(t *testing.T) {
+	flagset := replaceFlagsForTesting(t)
+
+	v1 := flagset.String("t", "default", "test usage")
+	Tag[string, flag.Value](flagset, "t", AliasTag("t_alias"))
+	Tag[string, flag.Value](flagset, "t", SecretTag)
+
+	f1 := flagset.Lookup("t")
+	require.NotNil(t, f1)
+
+	assert.EqualValues(t, v1, common.UnwrapFlagValue(f1.Value))
+	assert.Equal(t, "test usage", f1.Usage)
+
+	v2 := flagset.String("structured.t", "default2", "test usage")
+	Tag[string, flag.Value](flagset, "structured.t", SecretTag)
+	Tag[string, flag.Value](flagset, "structured.t", AliasTag("structured.t_alias"))
+
+	f2 := flagset.Lookup("structured.t")
+	require.NotNil(t, f2)
+
+	assert.EqualValues(t, v2, common.UnwrapFlagValue(f2.Value))
+	assert.Equal(t, "test usage", f2.Usage)
+
+	common.DefaultFlagSet = flagset
+	text, err := flagyaml.SplitDocumentedYAMLFromFlags(flagyaml.RedactSecrets)
+	require.NoError(t, err)
+
+	m := make(map[string]any)
+	require.NoError(t, yaml.Unmarshal(text, m))
+	assert.Empty(t, m)
+
+	assert.NotNil(t, flagset.Usage)
+
+	f1Alias := flagset.Lookup("t_alias")
+	require.NotNil(t, f1Alias)
+
+	f2Alias := flagset.Lookup("structured.t_alias")
+	require.NotNil(t, f2Alias)
+
+	assert.EqualValues(t, v1, common.UnwrapFlagValue(f1Alias.Value))
+	assert.EqualValues(t, v2, common.UnwrapFlagValue(f2Alias.Value))
+
+	assert.Equal(t, "Alias for t", f1Alias.Usage)
+	assert.Equal(t, "Alias for structured.t", f2Alias.Usage)
+}
+
+func TestDeprecatedAndSecret(t *testing.T) {
+	flagset := replaceFlagsForTesting(t)
+
+	v1 := flagset.String("t1", "default", "test usage")
+	Tag[string, flag.Value](flagset, "t1", SecretTag)
+	Tag[string, flag.Value](flagset, "t1", DeprecatedTag("migrate pls"))
+
+	f1 := flagset.Lookup("t1")
+	require.NotNil(t, f1)
+
+	assert.EqualValues(t, v1, common.UnwrapFlagValue(f1.Value))
+	assert.Equal(t, "test usage **DEPRECATED** migrate pls", f1.Usage)
+
+	v2 := flagset.String("structured.t", "default2", "test usage")
+	Tag[string, flag.Value](flagset, "structured.t", DeprecatedTag("migrate pls"))
+	Tag[string, flag.Value](flagset, "structured.t", SecretTag)
+
+	f2 := flagset.Lookup("structured.t")
+	require.NotNil(t, f2)
+
+	assert.EqualValues(t, v2, common.UnwrapFlagValue(f2.Value))
+	assert.Equal(t, "test usage **DEPRECATED** migrate pls", f2.Usage)
+
+	common.DefaultFlagSet = flagset
+	text, err := flagyaml.SplitDocumentedYAMLFromFlags(flagyaml.RedactSecrets)
+	require.NoError(t, err)
+
+	m := make(map[string]any)
+	require.NoError(t, yaml.Unmarshal(text, m))
+	assert.Empty(t, len(m))
+}
+
+func TestYAMLIgnoreAndSecret(t * testing.T) {
+	flagset := replaceFlagsForTesting(t)
+
+	v1 := flagset.String("t1", "default", "test usage")
+	Tag[string, flag.Value](flagset, "t1", SecretTag)
+	Tag[string, flag.Value](flagset, "t1", YAMLIgnoreTag)
+
+	f1 := flagset.Lookup("t1")
+	require.NotNil(t, f1)
+
+	assert.EqualValues(t, v1, common.UnwrapFlagValue(f1.Value))
+
+	v2 := flagset.String("structured.t", "default2", "test usage")
+	Tag[string, flag.Value](flagset, "structured.t", YAMLIgnoreTag)
+	Tag[string, flag.Value](flagset, "structured.t", SecretTag)
+
+	f2 := flagset.Lookup("structured.t")
+	require.NotNil(t, f2)
+
+	assert.EqualValues(t, v2, common.UnwrapFlagValue(f2.Value))
+
+	common.DefaultFlagSet = flagset
+	text, err := flagyaml.SplitDocumentedYAMLFromFlags(flagyaml.RedactSecrets)
+	require.NoError(t, err)
+
+	m := make(map[string]any)
+	require.NoError(t, yaml.Unmarshal(text, m))
+	assert.Empty(t, len(m))
+
+	_ = replaceIgnoreSetForTesting(t)
+
+	yamlData := `
+	t: newValue
+	structured:
+	  t: newValue2
+`
+	flagyaml.PopulateFlagsFromData(yamlData)
+	assert.Equal(t, "default", *v1)
+	assert.Equal(t, "default2", *v2)
+}

--- a/server/util/flagutil/yaml/yaml.go
+++ b/server/util/flagutil/yaml/yaml.go
@@ -81,10 +81,10 @@ func UnstructuredFilter(flg *flag.Flag) bool {
 	return !StructuredFilter(flg)
 }
 
-// HiddenFilter is a filter that filters out hidden flags.
-func HiddenFilter(flg *flag.Flag) bool {
-	if h, ok := flg.Value.(common.Hideable); ok {
-		return !h.Hidden()
+// InternalFilter is a filter that filters out internal flags.
+func InternalFilter(flg *flag.Flag) bool {
+	if maybeInternal, ok := flg.Value.(common.MaybeInternal); ok {
+		return !maybeInternal.Internal()
 	}
 	return true
 }
@@ -485,7 +485,7 @@ func SplitDocumentedYAMLFromFlags(opts ...common.DocumentNodeOption) ([]byte, er
 		GenerateDocumentedMarshalerFromFlag,
 		UnstructuredFilter,
 		IgnoreFilter,
-		HiddenFilter,
+		InternalFilter,
 	)
 	if err != nil {
 		return nil, err
@@ -511,7 +511,7 @@ func SplitDocumentedYAMLFromFlags(opts ...common.DocumentNodeOption) ([]byte, er
 		GenerateDocumentedMarshalerFromFlag,
 		StructuredFilter,
 		IgnoreFilter,
-		HiddenFilter,
+		InternalFilter,
 	)
 	if err != nil {
 		return nil, err

--- a/server/util/flagutil/yaml/yaml.go
+++ b/server/util/flagutil/yaml/yaml.go
@@ -81,6 +81,14 @@ func UnstructuredFilter(flg *flag.Flag) bool {
 	return !StructuredFilter(flg)
 }
 
+// HiddenFilter is a filter that filters out hidden flags.
+func HiddenFilter(flg *flag.Flag) bool {
+	if h, ok := flg.Value.(common.Hideable); ok {
+		return !h.Hidden()
+	}
+	return true
+}
+
 type YAMLTypeAliasable interface {
 	// YAMLTypeAlias returns the type alias we use in YAML for this flag.Value.
 	// Only necessary if the type used for YAML is not the type returned by
@@ -215,12 +223,8 @@ type redactSecrets struct{}
 
 func (r *redactSecrets) Transform(in any, n *yaml.Node, flg *flag.Flag) (*yaml.Node, error) {
 	if flg != nil {
-		flagValue := flg.Value
-		for v, ok := flagValue.(common.WrappingValue); ok; v, ok = flagValue.(common.WrappingValue) {
-			if secretable, ok := flagValue.(common.Secretable); ok && secretable.IsSecret() {
-				return nil, nil
-			}
-			flagValue = v.WrappedValue()
+		if s, ok := flg.Value.(common.Secretable); ok && s.IsSecret() {
+			return nil, nil
 		}
 	}
 
@@ -477,50 +481,61 @@ func GenerateDocumentedMarshalerFromFlag(flg *flag.Flag) (DocumentedMarshaler, e
 func SplitDocumentedYAMLFromFlags(opts ...common.DocumentNodeOption) ([]byte, error) {
 	b := bytes.NewBuffer([]byte{})
 
-	if _, err := b.Write([]byte("# Unstructured settings\n\n")); err != nil {
-		return nil, err
-	}
 	um, err := GenerateYAMLMapWithValuesFromFlags(
 		GenerateDocumentedMarshalerFromFlag,
 		UnstructuredFilter,
 		IgnoreFilter,
+		HiddenFilter,
 	)
 	if err != nil {
 		return nil, err
 	}
-	un, err := DocumentedNode(um, opts...)
-	if err != nil {
-		return nil, err
-	}
-	ub, err := yaml.Marshal(un)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := b.Write(ub); err != nil {
-		return nil, err
+	if len(um) != 0 {
+		un, err := DocumentedNode(um, opts...)
+		if err != nil {
+			return nil, err
+		}
+		ub, err := yaml.Marshal(un)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := b.Write([]byte("# Unstructured settings\n\n")); err != nil {
+			return nil, err
+		}
+		if _, err := b.Write(ub); err != nil {
+			return nil, err
+		}
 	}
 
-	if _, err := b.Write([]byte("\n# Structured settings\n\n")); err != nil {
-		return nil, err
-	}
 	sm, err := GenerateYAMLMapWithValuesFromFlags(
 		GenerateDocumentedMarshalerFromFlag,
 		StructuredFilter,
 		IgnoreFilter,
+		HiddenFilter,
 	)
 	if err != nil {
 		return nil, err
 	}
-	sn, err := DocumentedNode(sm, opts...)
-	if err != nil {
-		return nil, err
-	}
-	sb, err := yaml.Marshal(sn)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := b.Write(sb); err != nil {
-		return nil, err
+	if len(sm) != 0 {
+		sn, err := DocumentedNode(sm, opts...)
+		if err != nil {
+			return nil, err
+		}
+		sb, err := yaml.Marshal(sn)
+		if err != nil {
+			return nil, err
+		}
+		if len(um) != 0 {
+			if _, err := b.Write([]byte("\n")); err != nil {
+				return nil, err
+			}
+		}
+		if _, err := b.Write([]byte("# Structured settings\n\n")); err != nil {
+			return nil, err
+		}
+		if _, err := b.Write(sb); err != nil {
+			return nil, err
+		}
 	}
 
 	return b.Bytes(), nil


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

Added a `Hidden` tag for flags, allowing us to specify flags that will not show up in docs or usage for our internal use only.

As the way we handle the `Hidden` tag closely mirrors the `Secret` tag, it made sense to change both of them to be easier to use (specifically, handling unwrapping within the TaggedFlagValue instead of wherever we want to test to see if a flag value is secret or hidden.

Added tests.

The tests revealed that empty maps caused problems with the yaml marshalling (specifically, we could end up with a pair of empty curly braces). This made the `Hidden` tests fail, so adjusted how we handle empty maps in `yaml.go`.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: Fixes buildbuddy-io/buildbuddy-internal#2804
