### PR TITLE
Remove rlimit log message

### DIFF
--- a/server/util/rlimit/rlimit.go
+++ b/server/util/rlimit/rlimit.go
@@ -20,7 +20,6 @@ func MaxRLimit() error {
 		limit.Max = 10240
 	}
 	if limit.Cur < limit.Max {
-		log.Infof("Increasing open files limit %d => %d", limit.Cur, limit.Max)
 		limit.Cur = limit.Max
 		if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 			return fmt.Errorf("Error increasing open files limit: %s", err.Error())


### PR DESCRIPTION
This gets logged every time I run `bb` and feels a bit unnecessary.

**Related issues**: N/A
