### PR TITLE
[ci_runner] Add support to pass flags directly to the runner

### DIFF
--- a/enterprise/server/hostedrunner/hostedrunner.go
+++ b/enterprise/server/hostedrunner/hostedrunner.go
@@ -133,6 +133,7 @@ func (r *runnerService) createAction(ctx context.Context, req *rnpb.RunRequest, 
 	for _, patchURI := range patchURIs {
 		args = append(args, "--patch_uri="+patchURI)
 	}
+	args = append(args, req.GetRunnerFlags()...)
 
 	affinityKey := req.GetSessionAffinityKey()
 	if affinityKey == "" {

--- a/proto/runner.proto
+++ b/proto/runner.proto
@@ -60,6 +60,9 @@ message RunRequest {
   // remotely. If false or unset, run metadata (runtime flags, files, etc) will
   // be collected so the binary can be run elsewhere.
   bool run_remotely = 14;
+
+  // Flags to pass directly to the runner.
+  repeated string runner_flags = 15;
 }
 
 message RunResponse {


### PR DESCRIPTION
This will make it easier to add support to the remote runner API for new flags that are added to the ci_runner (Ex. `git_fetch_depth` or `git_fetch_depth`). Currently, we have been adding an explicit field to the RunnerRequest for each field

**Related issues**: N/A
