### PR TITLE
cli: add capabilities client

### DIFF
--- a/cli/execute/execute.go
+++ b/cli/execute/execute.go
@@ -117,6 +117,7 @@ func execute(cmdArgs []string) error {
 	env.SetByteStreamClient(bspb.NewByteStreamClient(conn))
 	env.SetContentAddressableStorageClient(repb.NewContentAddressableStorageClient(conn))
 	env.SetRemoteExecutionClient(repb.NewExecutionClient(conn))
+	env.SetCapabilitiesClient(repb.NewCapabilitiesClient(conn))
 
 	environ, err := rexec.MakeEnv(*actionEnv...)
 	if err != nil {


### PR DESCRIPTION
Fixes a warning message saying that cache compression is enabled but the env is missing a capabilities client.

**Related issues**: N/A
