### PR TITLE
Fix displayed execution status when we have an execute response but not a live-streamed update

### DIFF
--- a/app/invocation/invocation_action_card.tsx
+++ b/app/invocation/invocation_action_card.tsx
@@ -803,7 +803,13 @@ export default class InvocationActionCardComponent extends React.Component<Props
                     </div>
                     <div className="action-section">
                       <div className="action-property-title">Stage</div>
-                      <div>{this.state.lastOperation ? executionStatusLabel(this.state.lastOperation) : "Unknown"}</div>
+                      <div>
+                        {this.state.executeResponse
+                          ? "Completed"
+                          : this.state.lastOperation
+                          ? executionStatusLabel(this.state.lastOperation)
+                          : "Unknown"}
+                      </div>
                     </div>
                     {this.state.executeResponse && (
                       <>


### PR DESCRIPTION
If we don't have `lastOperation` (the last live-streamed update) but we do have an ExecuteResponse (the final response fetched from cache) then we can safely say that the execution is "Completed" rather than "Unknown."

**Related issues**: N/A
