### PR TITLE
[ci_runner] Support passing arbitrary fetch options

### DIFF
--- a/docs/workflows-config.md
+++ b/docs/workflows-config.md
@@ -388,9 +388,9 @@ A named group of Bazel commands that run when triggered.
   environment (usually named `"buildbuddy"`). Note: some legacy workflows
   might still have `"root"` as the default user, but we are in the process
   of migrating all users to non-root by default.
-- **`git_fetch_filters`** (`string` list): list of [`--filter` option](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt-code--filtercodeemltfilter-specgtem)
-  values to the `git fetch` command used when fetching the git commits
-  to build. Defaults to `["blob:none"]`.
+- **`git_fetch_filters`** (`string` list): list of options to pass to
+  the `git fetch` command used when fetching the git commits
+  to build. Defaults to `["--filter=blob:none"]`.
 - **`git_fetch_depth`** (`int`): [`--depth` option](https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt---depthltdepthgt) value used when
   fetching the git commits to build. When using this option in combination
   with a `pull_request` trigger, it's recommended to set

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1837,7 +1837,11 @@ func (ws *workspace) fetch(ctx context.Context, remoteURL string, refs []string)
 	}
 	fetchArgs := []string{"fetch", "--force"}
 	for _, filter := range *gitFetchFilters {
-		fetchArgs = append(fetchArgs, "--filter="+filter)
+		// TODO(Maggie): Clean up once app changes have been rolled out to pass "--filter"
+		if !strings.HasPrefix(filter, "--") {
+			filter = "--filter=" + filter
+		}
+		fetchArgs = append(fetchArgs, filter)
 	}
 	if *gitFetchDepth > 0 {
 		fetchArgs = append(fetchArgs, fmt.Sprintf("--depth=%d", *gitFetchDepth))

--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -1163,7 +1163,7 @@ func TestFetchFilters(t *testing.T) {
 		"--commit_sha=" + headCommitSHA,
 		"--target_repo_url=file://" + repoPath,
 		"--target_branch=master",
-		"--git_fetch_filters=blob:none",
+		"--git_fetch_filters=--filter=blob:none",
 	}
 	runnerFlags = append(runnerFlags, app.BESBazelFlags()...)
 

--- a/enterprise/server/workflow/config/config.go
+++ b/enterprise/server/workflow/config/config.go
@@ -57,9 +57,10 @@ func (a *Action) GetTriggers() *Triggers {
 
 func (a *Action) GetGitFetchFilters() []string {
 	if a.GitFetchFilters == nil {
-		// Default to blob:none if unspecified.
+		// Default to --filter=blob:none if unspecified.
 		// TODO: this seems to increase fetch time in some cases;
 		// consider removing this as the default.
+		// TODO(Maggie): Add '--filter' once ci_runner changes have been rolled out
 		return []string{"blob:none"}
 	}
 	return a.GitFetchFilters

--- a/enterprise/server/workflow/config/config_test.go
+++ b/enterprise/server/workflow/config/config_test.go
@@ -99,8 +99,8 @@ func TestGetGitFetchFilters(t *testing.T) {
 		},
 		{
 			Name:    "NonEmptyList",
-			YAML:    `git_fetch_filters: ["tree:0"]`,
-			Filters: []string{"tree:0"},
+			YAML:    `git_fetch_filters: ["--filter=tree:0"]`,
+			Filters: []string{"--filter=tree:0"},
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {


### PR DESCRIPTION
This will make the flag more flexible. For example, a customer wants to pass custom fetch options to the ci_runner like `--no-show-forced-updates`

**Related issues**: N/A
