### PR TITLE
Populate `use_repo` in MODULE.bazel with `bb fix`

### DIFF
--- a/cli/fix/golang/BUILD
+++ b/cli/fix/golang/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//cli/log",
         "//cli/workspace",
+        "@bazel_gazelle//label:go_default_library",
         "@bazel_gazelle//language:go_default_library",
         "@bazel_gazelle//language/go:go_default_library",
         "@org_golang_x_mod//modfile",

--- a/cli/fix/language.go
+++ b/cli/fix/language.go
@@ -9,4 +9,6 @@ type Language interface {
 	IsDepFile(path string) bool
 	// Gives the language an opportunity to consolidate multiple dep files before update-repos is called.
 	ConsolidateDepFiles(deps map[string][]string) map[string][]string
+	// Allows the language to register any dependencies in the module file.
+	RegisterDeps(path string, modulePath string)
 }


### PR DESCRIPTION
Right now only populates it if it doesn't exist in the MODULE.bazel file already. In the future we can improve this to merge with existing `use_repo` rules.