### PR TITLE
[raft] store_test: use require.Failf instead of t.Fatalf

### DIFF
--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -412,7 +412,7 @@ func getStoreWithRangeLease(t testing.TB, stores []*testutil.TestingStore, range
 		}
 	}
 
-	t.Fatalf("No store found holding rangelease for range: %d", rangeID)
+	require.Failf(t, "getStoreWithRangeLease failed", "No store found holding rangelease for range: %d", rangeID)
 	return nil
 }
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
When using t.Failf, it's hard to locate the failure message in test log.
