### PR TITLE
cli: add version to tool_tag

### DIFF
--- a/cli/tooltag/tooltag.go
+++ b/cli/tooltag/tooltag.go
@@ -11,8 +11,12 @@ import (
 func ConfigureToolTag(args []string) []string {
 	log.Debugf("BuildBuddy CLI version %s invoked as %s", version.String(), os.Args[0])
 
+	v := "unknown"
+	if version.String() != "" {
+		v = version.String()
+	}
 	if arg.GetCommand(args) != "" && !arg.Has(args, "tool_tag") {
-		return append(args, "--tool_tag=buildbuddy-cli")
+		return append(args, "--tool_tag=buildbuddy-cli-"+v)
 	}
 	return args
 }

--- a/cli/tooltag/tooltag.go
+++ b/cli/tooltag/tooltag.go
@@ -11,7 +11,7 @@ import (
 func ConfigureToolTag(args []string) []string {
 	log.Debugf("BuildBuddy CLI version %s invoked as %s", version.String(), os.Args[0])
 
-	v := "unknown"
+	v := "development"
 	if version.String() != "" {
 		v = version.String()
 	}


### PR DESCRIPTION
This would let us know which version of BB was used via BES and help
troubleshooting issues easier.
