### PR TITLE
Use pointer instead of struct for left joined tables

### DIFF
--- a/enterprise/server/backends/authdb/authdb.go
+++ b/enterprise/server/backends/authdb/authdb.go
@@ -460,8 +460,8 @@ func (d *AuthDB) LookupUserFromSubID(ctx context.Context, subID string) (*tables
 	)
 	ugr, err := db.ScanAll(rq, &struct {
 		tables.User
-		tables.Group
-		tables.UserGroup
+		*tables.Group
+		*tables.UserGroup
 	}{})
 	if err != nil {
 		return nil, err
@@ -470,17 +470,17 @@ func (d *AuthDB) LookupUserFromSubID(ctx context.Context, subID string) (*tables
 		return nil, status.NotFoundErrorf("Sub id %s was not found in LookupUserFromSubID.", subID)
 	}
 	user := &ugr[0].User
-	if ugr[0].UserGroup.UserUserID == "" {
+	if ugr[0].UserGroup == nil {
 		// no user groups matched this user ID
 		return user, nil
 	}
 	for _, v := range ugr {
-		if v.Group.GroupID == "" {
+		if v.Group == nil {
 			// no group matched the user group (this shouldn't really happen)
 			log.CtxWarningf(ctx, "In LookupUserFromSubID, the UserGroup row User: %s Group %s did not match a group with that ID.", v.UserGroup.UserUserID, v.UserGroup.GroupGroupID)
 			continue
 		}
-		user.Groups = append(user.Groups, &tables.GroupRole{Group: v.Group, Role: v.UserGroup.Role})
+		user.Groups = append(user.Groups, &tables.GroupRole{Group: *v.Group, Role: v.UserGroup.Role})
 	}
 	return user, nil
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

@bduffany pointed out that this was a better way to do `LEFT JOIN`s. Should make it more clear what's happening in the query and remove the possibility of actual empty fields being mistaken for missing rows (even though that's very unlikely here).

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
