### PR TITLE
[ci_runner] Fix using incorrect url to report github statuses for

### DIFF
--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1574,16 +1574,16 @@ func (ws *workflowService) createQueuedStatus(ctx context.Context, wf *tables.Wo
 	}
 	invocationURL += "?queued=true"
 	status := github.NewGithubStatusPayload(actionName, invocationURL, "Queued...", github.PendingState)
-	baseURL := getBaseURL(wd)
-	provider, err := ws.providerForRepo(baseURL)
+	statusReportingURL := getStatusReportingURL(wd)
+	provider, err := ws.providerForRepo(statusReportingURL)
 	if err != nil {
 		return err
 	}
-	return provider.CreateStatus(ctx, wf.AccessToken, baseURL, wd.SHA, status)
+	return provider.CreateStatus(ctx, wf.AccessToken, statusReportingURL, wd.SHA, status)
 }
 
-// getBaseURL returns the primary URL the workflow should be attributed to.
-func getBaseURL(wd *interfaces.WebhookData) string {
+// getStatusReportingURL returns the URL the workflow should report statuses to
+func getStatusReportingURL(wd *interfaces.WebhookData) string {
 	// If the workflow was triggered by a pull request from a fork, statuses should
 	// be reported to the target repo (the repo the fork will be merged into)
 	if isFork(wd) {
@@ -1606,12 +1606,12 @@ func (ws *workflowService) createWorkflowConfigErrorStatus(ctx context.Context, 
 		"https://buildbuddy.io/docs/workflows-config",
 		"Invalid buildbuddy.yaml",
 		github.ErrorState)
-	baseURL := getBaseURL(wd)
-	provider, err := ws.providerForRepo(baseURL)
+	statusReportingURL := getStatusReportingURL(wd)
+	provider, err := ws.providerForRepo(statusReportingURL)
 	if err != nil {
 		return err
 	}
-	return provider.CreateStatus(ctx, wf.AccessToken, baseURL, wd.SHA, status)
+	return provider.CreateStatus(ctx, wf.AccessToken, statusReportingURL, wd.SHA, status)
 }
 
 func isGitHubURL(s string) bool {

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1372,8 +1372,7 @@ func (ws *workflowService) fetchWorkflowConfig(ctx context.Context, gitProvider 
 func (ws *workflowService) isTrustedCommit(ctx context.Context, gitProvider interfaces.GitProvider, wf *tables.Workflow, wd *interfaces.WebhookData) (bool, error) {
 	// If the commit was pushed directly to the target repo then the commit must
 	// already be trusted.
-	isFork := wd.PushedRepoURL != wd.TargetRepoURL
-	if !isFork {
+	if !isFork(wd) {
 		return true, nil
 	}
 	if wd.PullRequestAuthor == "" {
@@ -1575,11 +1574,28 @@ func (ws *workflowService) createQueuedStatus(ctx context.Context, wf *tables.Wo
 	}
 	invocationURL += "?queued=true"
 	status := github.NewGithubStatusPayload(actionName, invocationURL, "Queued...", github.PendingState)
-	provider, err := ws.providerForRepo(wd.TargetRepoURL)
+	baseURL := getBaseURL(wd)
+	provider, err := ws.providerForRepo(baseURL)
 	if err != nil {
 		return err
 	}
-	return provider.CreateStatus(ctx, wf.AccessToken, wd.TargetRepoURL, wd.SHA, status)
+	return provider.CreateStatus(ctx, wf.AccessToken, baseURL, wd.SHA, status)
+}
+
+// getBaseURL returns the primary URL the workflow should be attributed to.
+func getBaseURL(wd *interfaces.WebhookData) string {
+	// If the workflow was triggered by a pull request from a fork, statuses should
+	// be reported to the target repo (the repo the fork will be merged into)
+	if isFork(wd) {
+		return wd.TargetRepoURL
+	}
+	// If there was not a fork, TargetRepoURL will not be set, or TargetRepoURL
+	// and PushedRepoURL will be equal
+	return wd.PushedRepoURL
+}
+
+func isFork(wd *interfaces.WebhookData) bool {
+	return wd.TargetRepoURL != "" && wd.PushedRepoURL != wd.TargetRepoURL
 }
 
 func (ws *workflowService) createWorkflowConfigErrorStatus(ctx context.Context, wf *tables.Workflow, wd *interfaces.WebhookData) error {
@@ -1590,11 +1606,12 @@ func (ws *workflowService) createWorkflowConfigErrorStatus(ctx context.Context, 
 		"https://buildbuddy.io/docs/workflows-config",
 		"Invalid buildbuddy.yaml",
 		github.ErrorState)
-	provider, err := ws.providerForRepo(wd.TargetRepoURL)
+	baseURL := getBaseURL(wd)
+	provider, err := ws.providerForRepo(baseURL)
 	if err != nil {
 		return err
 	}
-	return provider.CreateStatus(ctx, wf.AccessToken, wd.TargetRepoURL, wd.SHA, status)
+	return provider.CreateStatus(ctx, wf.AccessToken, baseURL, wd.SHA, status)
 }
 
 func isGitHubURL(s string) bool {


### PR DESCRIPTION
The "target repo" terminology doesn't make sense for the ExecuteWorkflow API or remote bazel, so I removed it from the ExecuteWorkflow API. I forgot to update these references to use the pushed repo URL instead

**Related issues**: N/A
