### PR TITLE
[ci_runner] Explicitly pass --unshallow flag when attempting to fetch full git history

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1858,8 +1858,18 @@ func (ws *workspace) fetch(ctx context.Context, remoteURL string, refs []string,
 	for _, filter := range *gitFetchFilters {
 		fetchArgs = append(fetchArgs, "--filter="+filter)
 	}
+	// The --depth option is sticky when fetching the same branch. If --depth
+	// was set in a previous snapshot run, make sure to unset it if needed
 	if fetchDepth == 0 {
-		fetchArgs = append(fetchArgs, "--unshallow")
+		output, err := git(ctx, io.Discard, "rev-parse", "--is-shallow-repository")
+		if err != nil {
+			return err
+		}
+		// If you have never fetched a ref with limited depth, passing --unshallow
+		// will fail. By default, it will pull the complete git history.
+		if strings.Contains(output, "true") {
+			fetchArgs = append(fetchArgs, "--unshallow")
+		}
 	} else if fetchDepth > 0 {
 		fetchArgs = append(fetchArgs, fmt.Sprintf("--depth=%d", fetchDepth))
 	}

--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1858,7 +1858,9 @@ func (ws *workspace) fetch(ctx context.Context, remoteURL string, refs []string,
 	for _, filter := range *gitFetchFilters {
 		fetchArgs = append(fetchArgs, "--filter="+filter)
 	}
-	if fetchDepth > 0 {
+	if fetchDepth == 0 {
+		fetchArgs = append(fetchArgs, "--unshallow")
+	} else if fetchDepth > 0 {
 		fetchArgs = append(fetchArgs, fmt.Sprintf("--depth=%d", fetchDepth))
 	}
 	fetchArgs = append(fetchArgs, remoteName)


### PR DESCRIPTION
The `--depth` option is sticky across fetching the same branch. So if I fetch `master` in one snapshot run with `--depth=1`, in a future snapshot run I'll have to explicitly set `--unshallow` if I want it to fetch the whole git history. *shakes fist at git* 

**Related issues**: N/A
