### PR TITLE
Fix local grafana dashboard k8s mode

### DIFF
--- a/tools/metrics/docker-compose.grafana.yml
+++ b/tools/metrics/docker-compose.grafana.yml
@@ -8,6 +8,7 @@ services:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Editor
       - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/buildbuddy.json
       - GF_DASHBOARDS_MIN_REFRESH_INTERVAL=1s
+      - GF_DATASOURCE_URL=${GF_DATASOURCE_URL}
     volumes:
       - ./grafana/provisioning/local:/etc/grafana/provisioning
       - ${DASHBOARDS_DIR}:/var/lib/grafana/dashboards

--- a/tools/metrics/grafana/grafana.go
+++ b/tools/metrics/grafana/grafana.go
@@ -28,8 +28,8 @@ var (
 	kube = flag.Bool("kube", false, "Use kubectl port-forward to point Grafana at real data.")
 
 	// Note: these flags only take effect when setting -kube=true:
-	namespace  = flag.String("namespace", "monitor-dev", "k8s namespace")
-	deployment = flag.String("deployment", "prometheus-global-server", "Prometheus server resource to port-forward to.")
+	namespace = flag.String("namespace", "monitor-dev", "k8s namespace")
+	service   = flag.String("service", "victoria-metrics-cluster-global-vmselect", "k8s VictoriaMetrics service name")
 )
 
 const (
@@ -40,7 +40,9 @@ const (
 
 	grafanaAPIURL = "http://admin:admin@localhost:4500/api"
 	grafanaUIURL  = "http://localhost:4500/d/1rsE5yoGz?orgId=1&refresh=5s"
-	prometheusURL = "http://localhost:9100/metrics"
+
+	victoriaMetricsLocalURL   = "http://localhost:8428"
+	victoriaMetricsClusterURL = "http://localhost:8481/select/0/prometheus"
 )
 
 func main() {
@@ -64,10 +66,11 @@ func run() error {
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		// Start docker-compose
+		os.Setenv("DASHBOARDS_DIR", filepath.Join(workspaceRoot, dashboardsDir))
+		os.Setenv("GF_DATASOURCE_URL", strings.Replace(datasourceURL(), "localhost", "host.docker.internal", 1))
 		args := []string{"--file", "docker-compose.grafana.yml"}
 		if !*kube {
 			args = append(args, "--file", "docker-compose.redis-exporter.yml")
-			os.Setenv("DASHBOARDS_DIR", filepath.Join(workspaceRoot, dashboardsDir))
 			args = append(args, "--file", "docker-compose.victoria-metrics.yml")
 		}
 		args = append(args, "up")
@@ -86,8 +89,8 @@ func run() error {
 		// Start kubectl port-forward
 		cmd := exec.CommandContext(
 			ctx, "kubectl", "--namespace", *namespace,
-			"port-forward", "deployment/"+*deployment,
-			"--address=0.0.0.0", "9100:9090")
+			"port-forward", "service/"+*service,
+			"--address=0.0.0.0", "8481:8481")
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
@@ -111,16 +114,21 @@ func run() error {
 				continue
 			}
 			var fileNames []string
+			var exportErr error
 			for _, d := range dashboards {
 				fileName, err := exportNormalizedDashboard(d)
 				if err != nil {
 					log.Printf("Failed to export dashboard: %s", err)
+					exportErr = err
+					continue
 				}
 				fileNames = append(fileNames, fileName)
 			}
-			slices.Sort(fileNames)
-			if err := writeDashboardsBzl(fileNames); err != nil {
-				log.Printf("Failed to write %s: %s", dashboardsBzl, err)
+			if exportErr == nil {
+				slices.Sort(fileNames)
+				if err := writeDashboardsBzl(fileNames); err != nil {
+					log.Printf("Failed to write %s: %s", dashboardsBzl, err)
+				}
 			}
 		}
 	})
@@ -132,10 +140,10 @@ func run() error {
 			case <-ctx.Done():
 				return nil
 			}
-			if _, err := httpGetBody(grafanaUIURL); err != nil {
+			if _, err := http.Head(grafanaUIURL); err != nil {
 				continue
 			}
-			if _, err := httpGetBody(prometheusURL); err != nil {
+			if _, err := http.Head(datasourceURL()); err != nil {
 				continue
 			}
 			_ = openInBrowser(grafanaUIURL)
@@ -143,6 +151,13 @@ func run() error {
 		}
 	})
 	return eg.Wait()
+}
+
+func datasourceURL() string {
+	if *kube {
+		return victoriaMetricsClusterURL
+	}
+	return victoriaMetricsLocalURL
 }
 
 type DashboardMetadata map[string]any

--- a/tools/metrics/grafana/provisioning/local/datasources/datasources.yml
+++ b/tools/metrics/grafana/provisioning/local/datasources/datasources.yml
@@ -5,8 +5,8 @@ datasources:
     type: prometheus
     access: proxy
     uid: vm
-    isDefault: false # TODO: make VM the default
-    url: http://host.docker.internal:8428
+    isDefault: true
+    url: ${GF_DATASOURCE_URL}
     version: 1
     editable: false
     jsonData:


### PR DESCRIPTION
When passing `-kube` we need to target VictoriaMetrics, not prometheus.

Also fix a few other small issues:
- Don't generate `dashboards.bzl` if there is an error processing dashboards (otherwise the file names list may be incomplete)
- Make VM the default datasource in the datasources config

**Related issues**: N/A
