### PR TITLE
Fix build errors from unused import

### DIFF
--- a/enterprise/server/remote_execution/containers/sandbox/BUILD
+++ b/enterprise/server/remote_execution/containers/sandbox/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//enterprise/server/remote_execution/container",
         "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
-        "//proto:runner_go_proto",
         "//server/interfaces",
         "//server/util/log",
         "//server/util/status",

--- a/enterprise/server/remote_execution/containers/sandbox/sandbox.go
+++ b/enterprise/server/remote_execution/containers/sandbox/sandbox.go
@@ -19,7 +19,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
-	rnpb "github.com/buildbuddy-io/buildbuddy/proto/runner"
 )
 
 const (


### PR DESCRIPTION
The mac builds are failing : https://buildbuddy.buildbuddy.io/invocation/54310d19-fbf3-416b-9405-8b419fb7eeab

<!-- 
Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
