### PR TITLE
[ci_runner] Rename commit field to ref to be more generic

### DIFF
--- a/enterprise/server/test/integration/ci_runner/ci_runner_test.go
+++ b/enterprise/server/test/integration/ci_runner/ci_runner_test.go
@@ -712,7 +712,7 @@ actions:
 		"--trigger_event=pull_request",
 		"--pushed_repo_url=file://" + repoPath,
 		"--pushed_branch=feature",
-		"--merge_commit_sha=" + mergeCommitSHA,
+		"--merge_commit_ref=" + mergeCommitSHA,
 		"--target_repo_url=file://" + repoPath,
 		"--target_branch=master",
 		// Disable clean checkout fallback for this test since we expect to sync

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1183,7 +1183,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 		"--pull_request_number=" + fmt.Sprintf("%d", wd.PullRequestNumber),
 		"--target_repo_url=" + targetRepoURL,
 		"--target_branch=" + targetBranch,
-		"--merge_commit_sha=" + mergeCommitSHA,
+		"--merge_commit_ref=" + mergeCommitSHA,
 		"--visibility=" + visibility,
 		"--workflow_id=" + wf.WorkflowID,
 		"--trigger_event=" + wd.EventName,


### PR DESCRIPTION
Sorry I'd written a TODO in my notes to do this and forgot to add it in the last PR.

I figured this might be helpful, because bitbucket exposes a merge branch, but not a merge commit SHA.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
