### PR TITLE
[raft] Add DeleteSessions raft command

### DIFF
--- a/enterprise/server/raft/bringup/bringup.go
+++ b/enterprise/server/raft/bringup/bringup.go
@@ -54,7 +54,7 @@ func New(grpcAddr string, gossipMan interfaces.GossipService, store IStore) *Clu
 	joinList := gossipMan.JoinList()
 	cs := &ClusterStarter{
 		store:         store,
-		session:       client.NewDefaultSession(),
+		session:       client.NewSession(),
 		grpcAddr:      grpcAddr,
 		listenAddr:    gossipMan.ListenAddr(),
 		join:          joinList,

--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -75,7 +75,7 @@ func New(nodeHost *dragonboat.NodeHost, log log.Logger, liveness *nodeliveness.L
 		nodeHost:            nodeHost,
 		log:                 log,
 		liveness:            liveness,
-		session:             client.NewDefaultSession(),
+		session:             client.NewSession(),
 		listener:            listener,
 		broadcast:           broadcast,
 		mu:                  sync.Mutex{},

--- a/enterprise/server/raft/rangelease/rangelease_test.go
+++ b/enterprise/server/raft/rangelease/rangelease_test.go
@@ -149,7 +149,7 @@ func TestAcquireAndRelease(t *testing.T) {
 
 	proposer, sender, rep := newTestingProposerAndSenderAndReplica(t)
 	liveness := nodeliveness.New("replicaID-1", sender)
-	session := client.NewDefaultSession()
+	session := client.NewSession()
 
 	rd := &rfpb.RangeDescriptor{
 		Start:   []byte("a"),
@@ -188,7 +188,7 @@ func TestAcquireAndReleaseMetaRange(t *testing.T) {
 
 	proposer, sender, rep := newTestingProposerAndSenderAndReplica(t)
 	liveness := nodeliveness.New("replicaID-2", sender)
-	session := client.NewDefaultSession()
+	session := client.NewSession()
 
 	rd := &rfpb.RangeDescriptor{
 		Start:   keys.MinByte,
@@ -227,7 +227,7 @@ func TestMetaRangeLeaseKeepalive(t *testing.T) {
 
 	proposer, sender, rep := newTestingProposerAndSenderAndReplica(t)
 	liveness := nodeliveness.New("replicaID-3", sender)
-	session := client.NewDefaultSession()
+	session := client.NewSession()
 
 	rd := &rfpb.RangeDescriptor{
 		Start:   keys.MinByte,
@@ -274,7 +274,7 @@ func TestNodeEpochInvalidation(t *testing.T) {
 
 	proposer, sender, rep := newTestingProposerAndSenderAndReplica(t)
 	liveness := nodeliveness.New("replicaID-4", sender)
-	session := client.NewDefaultSession()
+	session := client.NewSession()
 
 	rd := &rfpb.RangeDescriptor{
 		Start:   []byte("a"),

--- a/enterprise/server/raft/rbuilder/rbuilder.go
+++ b/enterprise/server/raft/rbuilder/rbuilder.go
@@ -91,6 +91,10 @@ func (bb *BatchBuilder) Add(m proto.Message) *BatchBuilder {
 		req.Value = &rfpb.RequestUnion_UpdateAtime{
 			UpdateAtime: value,
 		}
+	case *rfpb.DeleteSessionsRequest:
+		req.Value = &rfpb.RequestUnion_DeleteSessions{
+			DeleteSessions: value,
+		}
 	default:
 		bb.setErr(status.FailedPreconditionErrorf("BatchBuilder.Add handling for %+v not implemented.", m))
 		return bb
@@ -316,6 +320,14 @@ func (br *BatchResponse) UpdateAtimeResponse(n int) (*rfpb.UpdateAtimeResponse, 
 	}
 	u := br.cmd.GetUnion()[n]
 	return u.GetUpdateAtime(), br.unionError(u)
+}
+func (br *BatchResponse) DeleteSessionsResponse(n int) (*rfpb.DeleteSessionsResponse, error) {
+	br.checkIndex(n)
+	if br.err != nil {
+		return nil, br.err
+	}
+	u := br.cmd.GetUnion()[n]
+	return u.GetDeleteSessions(), br.unionError(u)
 }
 
 type txnStatement struct {

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -161,7 +161,7 @@ func New(env environment.Env, rootDir, raftAddress, grpcAddr string, partitions 
 	}
 	leaser := pebble.NewDBLeaser(db)
 	clock := clockwork.NewRealClock()
-	session := client.NewSession(clock, client.SessionLifetime())
+	session := client.NewSessionWithClock(clock)
 
 	return NewWithArgs(env, rootDir, nodeHost, gossipManager, sender, registry, raftListener, apiClient, grpcAddr, partitions, db, leaser, clock, session)
 }

--- a/enterprise/server/raft/testutil/testutil.go
+++ b/enterprise/server/raft/testutil/testutil.go
@@ -125,7 +125,7 @@ func (sf *StoreFactory) NewStoreWithClock(t *testing.T, clock clockwork.Clock) *
 	require.NoError(t, err)
 	ts.db = db
 	leaser := pebble.NewDBLeaser(db)
-	store, err := store.NewWithArgs(te, ts.RootDir, nodeHost, gm, s, reg, raftListener, apiClient, ts.GRPCAddress, partitions, db, leaser, clock, client.NewDefaultSession())
+	store, err := store.NewWithArgs(te, ts.RootDir, nodeHost, gm, s, reg, raftListener, apiClient, ts.GRPCAddress, partitions, db, leaser, clock, client.NewSession())
 	require.NoError(t, err)
 	require.NotNil(t, store)
 	store.Start()
@@ -166,12 +166,12 @@ func (ts *TestingStore) NewReplica(shardID, replicaID uint64) *replica.Replica {
 
 func StartShard(t *testing.T, ctx context.Context, stores ...*TestingStore) {
 	require.Greater(t, len(stores), 0)
-	err := bringup.SendStartShardRequests(ctx, client.NewDefaultSession(), stores[0].NodeHost(), stores[0].APIClient(), MakeNodeGRPCAddressesMap(stores...))
+	err := bringup.SendStartShardRequests(ctx, client.NewSession(), stores[0].NodeHost(), stores[0].APIClient(), MakeNodeGRPCAddressesMap(stores...))
 	require.NoError(t, err)
 }
 
 func StartShardWithRanges(t *testing.T, ctx context.Context, startingRanges []*rfpb.RangeDescriptor, stores ...*TestingStore) {
 	require.Greater(t, len(stores), 0)
-	err := bringup.SendStartShardRequestsWithRanges(ctx, client.NewDefaultSession(), stores[0].NodeHost(), stores[0].APIClient(), MakeNodeGRPCAddressesMap(stores...), startingRanges)
+	err := bringup.SendStartShardRequestsWithRanges(ctx, client.NewSession(), stores[0].NodeHost(), stores[0].APIClient(), MakeNodeGRPCAddressesMap(stores...), startingRanges)
 	require.NoError(t, err)
 }

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -199,8 +199,8 @@ message FindSplitPointResponse {
 }
 
 message DeleteSessionsRequest {
-	// Delete all client sessions created before created_at_usec;
-	int64 created_at_usec = 1;
+  // Delete all client sessions created before created_at_usec;
+  int64 created_at_usec = 1;
 }
 
 message DeleteSessionsResponse {}
@@ -217,7 +217,7 @@ message RequestUnion {
     ScanRequest scan = 4;
     CASRequest cas = 5;
     FindSplitPointRequest find_split_point = 14;
-	DeleteSessionsRequest delete_sessions = 16;
+    DeleteSessionsRequest delete_sessions = 16;
 
     // The following operations are for getting and setting FileMetadata blobs.
     GetRequest get = 7;
@@ -246,7 +246,7 @@ message ResponseUnion {
     ScanResponse scan = 5;
     CASResponse cas = 6;
     FindSplitPointResponse find_split_point = 15;
-	DeleteSessionsResponse delete_sessions = 17;
+    DeleteSessionsResponse delete_sessions = 17;
 
     // The following operations are for getting and setting FileMetadata blobs.
     GetResponse get = 8;

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -198,6 +198,13 @@ message FindSplitPointResponse {
   bytes split_key = 1;
 }
 
+message DeleteSessionsRequest {
+	// Delete all client sessions created before created_at_usec;
+	int64 created_at_usec = 1;
+}
+
+message DeleteSessionsResponse {}
+
 // Raft CMD API, used to encode raft commands that are replicated via raft and
 // written to a log. Everything written via SyncPropose must be a RequestUnion
 // wrapped in a BatchCmdRequest..
@@ -210,6 +217,7 @@ message RequestUnion {
     ScanRequest scan = 4;
     CASRequest cas = 5;
     FindSplitPointRequest find_split_point = 14;
+	DeleteSessionsRequest delete_sessions = 16;
 
     // The following operations are for getting and setting FileMetadata blobs.
     GetRequest get = 7;
@@ -238,6 +246,7 @@ message ResponseUnion {
     ScanResponse scan = 5;
     CASResponse cas = 6;
     FindSplitPointResponse find_split_point = 15;
+	DeleteSessionsResponse delete_sessions = 17;
 
     // The following operations are for getting and setting FileMetadata blobs.
     GetResponse get = 8;

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -304,9 +304,8 @@ message Session {
   // monotonically increasing.
   // Example: 1717100891000000000
   uint64 index = 2;
-  // A timestamp when the session will be cleaned up; and when the state machine
-  // can safely clean up the entry.
-  int64 expiry_usec = 3;
+  // The timestamp when the session is created.
+  int64 created_at_usec = 5;
 
   // Optional. The response associated with the command associated with the
   // index.


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3452
Add DeleteSessions Request to delete all sessions created before a timestamp.

raft.Store can send a sync propose at an interval to delete sessions created
before a timestamp. 

We can achieve the same thing by using a scan + direct
delete, but the downside is that scanRsp can potentially return a lot of
entries; and there is one more round trip.
