### PR TITLE
Don't log stream error if context is canceled

### DIFF
--- a/enterprise/server/backends/pubsub/pubsub.go
+++ b/enterprise/server/backends/pubsub/pubsub.go
@@ -232,7 +232,9 @@ func (p *StreamPubSub) subscribe(ctx context.Context, psChannel *Channel, startF
 		if startFromTail {
 			msgs, err := p.rdb.XRevRangeN(ctx, psChannel.name, "+", "-", 1).Result()
 			if err != nil {
-				log.CtxErrorf(ctx, "Unable to retrieve last element of stream!!! %q: %s", psChannel.name, err)
+				if err != context.Canceled {
+					log.CtxErrorf(ctx, "Unable to retrieve last element of stream: %q: %s", psChannel.name, err)
+				}
 				msgChan <- &Message{Err: err}
 				return
 			}


### PR DESCRIPTION
When logging errors, ignore `context.Canceled` which also matches the error checks later on in the file.

**Related issues**: N/A
