### PR TITLE
Don't show error in the UI when execution stream is not found

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -135,6 +135,7 @@ ts_library(
         "//app/service:rpc_service",
         "//app/terminal",
         "//app/util:cache",
+        "//app/util:rpc",
         "//proto:firecracker_ts_proto",
         "//proto:grpc_code_ts_proto",
         "//proto:remote_execution_ts_proto",

--- a/app/util/BUILD
+++ b/app/util/BUILD
@@ -164,5 +164,7 @@ ts_library(
         "//app/service:rpc_service",
         "//app/util:errors",
         "//proto:grpc_code_ts_proto",
+        "//proto:grpc_error_details_ts_proto",
+        "//proto:grpc_status_ts_proto",
     ],
 )

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -2082,6 +2082,15 @@ ts_proto_library(
 )
 
 ts_proto_library(
+    name = "grpc_error_details_ts_proto",
+    proto = "@googleapis//google/rpc:error_details_proto",
+    deps = [
+        ":any_ts_proto",
+        ":duration_ts_proto",
+    ],
+)
+
+ts_proto_library(
     name = "google_api_annotations_ts_proto",
     proto = "@googleapis//google/api:annotations_proto",
     deps = [

--- a/server/util/status/BUILD
+++ b/server/util/status/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_pkg_errors//:errors",
+        "@org_golang_google_genproto_googleapis_rpc//errdetails",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
     ],


### PR DESCRIPTION
If an execution stream no longer exists (e.g. if the execution happened a long time ago), then `WaitExecution` returns a pubsub error saying that the stream is not found. Check for this error in the UI and just ignore it, displaying an "Unknown" execution status instead (or the status from the cached ExecuteResponse if it hasn't expired from cache yet).

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/3473
