### PR TITLE
Fix missing workflow action name for in-progress workflows

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler.go
@@ -982,6 +982,8 @@ func (e *EventChannel) handleEvent(event *pepb.PublishBuildToolEventStreamReques
 				e.unprocessedStartingEvents[child.String()] = struct{}{}
 			case *build_event_stream.BuildEventId_UnstructuredCommandLine:
 				e.unprocessedStartingEvents[child.String()] = struct{}{}
+			case *build_event_stream.BuildEventId_WorkflowConfigured:
+				e.unprocessedStartingEvents[child.String()] = struct{}{}
 			}
 		}
 	}


### PR DESCRIPTION
In-progress workflow invocations are rendering with a blank invocation title (i.e. missing the workflow action name) because we don't explicitly mark WorkflowConfigured as one of the required "starting" build events before writing the invocation metadata row to the DB. This PR fixes that.

This bug was introduced by https://github.com/buildbuddy-io/buildbuddy/pull/6691 which moved the WorkspaceStatus event earlier in the build event stream. Turns out we are unintentionally depending on WorkspaceStatus to be published after the WorkflowConfigured event.

**Related issues**: N/A
