### PR TITLE
[raft] write some tests; fix some bugs

### DIFF
--- a/enterprise/server/raft/client/BUILD
+++ b/enterprise/server/raft/client/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -14,6 +14,7 @@ go_library(
         "//server/environment",
         "//server/util/canary",
         "//server/util/grpc_client",
+        "//server/util/lockmap",
         "//server/util/log",
         "//server/util/proto",
         "//server/util/status",
@@ -24,5 +25,21 @@ go_library(
         "@com_github_lni_dragonboat_v4//statemachine",
         "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_grpc//status",
+    ],
+)
+
+go_test(
+    name = "client_test",
+    srcs = ["client_test.go"],
+    deps = [
+        ":client",
+        "//enterprise/server/raft/logger",
+        "//enterprise/server/raft/rbuilder",
+        "//enterprise/server/raft/testutil",
+        "//proto:raft_go_proto",
+        "//server/util/random",
+        "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/enterprise/server/raft/client/client_test.go
+++ b/enterprise/server/raft/client/client_test.go
@@ -1,0 +1,130 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/client"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/testutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/random"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	_ "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/logger"
+	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+)
+
+func newTestingProposal(t testing.TB, shardID uint64) *testutil.TestingProposer {
+	r := testutil.NewTestingReplica(t, shardID, 1)
+	require.NotNil(t, r)
+	randID, err := random.RandomString(10)
+	require.NoError(t, err)
+	p := testutil.NewTestingProposer(t, randID, r.Replica)
+	require.NotNil(t, p)
+	return p
+}
+
+func increment(t testing.TB, ctx context.Context, shardID uint64, p *testutil.TestingProposer, session *client.Session, expectedValue int64) {
+	req, err := rbuilder.NewBatchBuilder().Add(&rfpb.IncrementRequest{
+		Key:   []byte(fmt.Sprintf("shard%d", shardID)),
+		Delta: 1,
+	}).ToProto()
+	require.NoError(t, err)
+	rsp, err := session.SyncProposeLocal(ctx, p, shardID, req)
+	require.NoError(t, err)
+	incrBatch := rbuilder.NewBatchResponseFromProto(rsp)
+	incrRsp, err := incrBatch.IncrementResponse(0)
+	require.NoError(t, err)
+	require.EqualValues(t, expectedValue, incrRsp.GetValue())
+}
+
+func TestSession(t *testing.T) {
+	tp1 := newTestingProposal(t, 1)
+	tp2 := newTestingProposal(t, 2)
+	ctx := context.Background()
+
+	session := client.NewSession()
+
+	increment(t, ctx, 1, tp1, session, 1)
+	increment(t, ctx, 2, tp2, session, 1)
+	increment(t, ctx, 1, tp1, session, 2)
+}
+
+func TestSessionInParallel(t *testing.T) {
+	proposers := make([]*testutil.TestingProposer, 0, 5)
+	for i := 1; i <= 5; i++ {
+		tp := newTestingProposal(t, uint64(i))
+		proposers = append(proposers, tp)
+	}
+
+	session := client.NewSession()
+
+	ctx := context.Background()
+	eg, egCtx := errgroup.WithContext(ctx)
+	for i := 1; i <= 5; i++ {
+		i := i
+		eg.Go(func() error {
+			increment(t, egCtx, uint64(i), proposers[i-1], session, 1)
+			increment(t, egCtx, uint64(i), proposers[i-1], session, 2)
+			return nil
+		})
+	}
+	err := eg.Wait()
+	require.NoError(t, err)
+}
+
+func TestRefreshSession(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	proposers := make([]*testutil.TestingProposer, 0, 3)
+	for i := 1; i <= 3; i++ {
+		tp := newTestingProposal(t, uint64(i))
+		proposers = append(proposers, tp)
+	}
+
+	session := client.NewSessionWithClock(clock)
+
+	// advance the clock to trigger a refresh
+	clock.Advance(90 * time.Minute)
+
+	ctx := context.Background()
+	eg, egCtx := errgroup.WithContext(ctx)
+	for i := 1; i <= 3; i++ {
+		i := i
+		eg.Go(func() error {
+			increment(t, egCtx, uint64(i), proposers[i-1], session, 1)
+			increment(t, egCtx, uint64(i), proposers[i-1], session, 2)
+			return nil
+		})
+	}
+	err := eg.Wait()
+
+	require.NoError(t, err)
+}
+
+func BenchmarkSession(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		proposers := make([]*testutil.TestingProposer, 0, 5)
+		for i := 1; i <= 5; i++ {
+			tp := newTestingProposal(b, uint64(i))
+			proposers = append(proposers, tp)
+		}
+		session := client.NewSession()
+		ctx := context.Background()
+		eg, egCtx := errgroup.WithContext(ctx)
+		b.StartTimer()
+		for i := 1; i <= 5; i++ {
+			i := i
+			eg.Go(func() error {
+				increment(b, egCtx, uint64(i), proposers[i-1], session, 1)
+				increment(b, egCtx, uint64(i), proposers[i-1], session, 2)
+				return nil
+			})
+		}
+		eg.Wait()
+	}
+}

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -368,7 +368,7 @@ func TestSessionIndexMismatchError(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(writeRsp))
 
-	session.Index = 3
+	session.Index = 0
 	entry = em.makeEntry(rbuilder.NewBatchBuilder().SetSession(session).Add(&rfpb.IncrementRequest{
 		Key:   []byte("incr-key"),
 		Delta: 1,

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -737,7 +737,3 @@ func TestSplitAcrossClusters(t *testing.T) {
 		readRecord(ctx, t, s1, fr)
 	}
 }
-
-func BenchmarkDirectWrite(b *testing.B) {
-	flags.Set(b, "cache.raft.max_range_size_bytes", 0) // disable auto splitting
-}

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -737,3 +737,7 @@ func TestSplitAcrossClusters(t *testing.T) {
 		readRecord(ctx, t, s1, fr)
 	}
 }
+
+func BenchmarkDirectWrite(b *testing.B) {
+	flags.Set(b, "cache.raft.max_range_size_bytes", 0) // disable auto splitting
+}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3452

write tests for session, and fix a few things:
- Before -> After when check whether to refresh
- stockSession.index + 1 == reqSession.index is too strong a condition. When a session is shared by multiple ranges, this cannot be guaranteed. Relax this check
- Relax the mutex in SyncProposeLocal. We only need to make sure that one SyncProposeLocal is run per range per session at the same time; instead of one SyncProposeLocal globally. Performance improvement goes from 347409 ns / op -> 210624 ns/op


