### PR TITLE
Don't count short-circuited bytestream writes in remote executor upload stats

### DIFF
--- a/enterprise/server/remote_execution/dirtools/BUILD
+++ b/enterprise/server/remote_execution/dirtools/BUILD
@@ -39,6 +39,8 @@ go_test(
         "//proto:remote_execution_go_proto",
         "//proto:resource_go_proto",
         "//server/remote_cache/byte_stream_server",
+        "//server/remote_cache/cachetools",
+        "//server/remote_cache/capabilities_server",
         "//server/remote_cache/content_addressable_storage_server",
         "//server/remote_cache/digest",
         "//server/testutil/testdigest",

--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -369,7 +369,6 @@ func handleSymlink(dirHelper *DirHelper, rootDir string, cmd *repb.Command, acti
 }
 
 func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, instanceName string, digestFunction repb.DigestFunction_Value, rootDir string, cmd *repb.Command, actionResult *repb.ActionResult) (*TransferInfo, error) {
-	txInfo := &TransferInfo{}
 	startTime := time.Now()
 	treesToUpload := make([]string, 0)
 	filesToUpload := make([]*fileToUpload, 0)
@@ -424,8 +423,6 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 				if _, ok := dirHelper.FindParentOutputPath(fqfn); !ok && !isOutputPath {
 					continue
 				}
-				txInfo.FileCount += 1
-				txInfo.BytesTransferred += dirNode.GetDigest().GetSizeBytes()
 				directory.Directories = append(directory.Directories, dirNode)
 			} else if info.Mode().IsRegular() {
 				if !dirHelper.ShouldUploadFile(fqfn) {
@@ -435,9 +432,6 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 				if err != nil {
 					return nil, err
 				}
-
-				txInfo.FileCount += 1
-				txInfo.BytesTransferred += fileNode.GetDigest().GetSizeBytes()
 				directory.Files = append(directory.Files, fileNode)
 			} else if info.Mode()&os.ModeSymlink == os.ModeSymlink {
 				if err := handleSymlink(dirHelper, rootDir, cmd, actionResult, directory, fqfn); err != nil {
@@ -499,8 +493,12 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 		return nil, err
 	}
 	endTime := time.Now()
-	txInfo.TransferDuration = endTime.Sub(startTime)
-	return txInfo, nil
+	stats := uploader.Stats()
+	return &TransferInfo{
+		TransferDuration: endTime.Sub(startTime),
+		FileCount:        stats.BlobCount,
+		BytesTransferred: stats.ByteCount,
+	}, nil
 }
 
 type FilePointer struct {


### PR DESCRIPTION

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3479
