### PR TITLE
Fix bb remote on macos

### DIFF
--- a/enterprise/server/hostedrunner/BUILD
+++ b/enterprise/server/hostedrunner/BUILD
@@ -7,7 +7,6 @@ go_library(
     srcs = ["hostedrunner.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/hostedrunner",
     deps = [
-        "//enterprise/server/cmd/ci_runner/bundle",
         "//enterprise/server/remote_execution/operation",
         "//enterprise/server/remote_execution/platform",
         "//proto:remote_execution_go_proto",
@@ -25,6 +24,7 @@ go_library(
         "//server/util/git",
         "//server/util/log",
         "//server/util/prefix",
+        "//server/util/rexec",
         "//server/util/status",
         "@com_github_google_uuid//:uuid",
         "@org_golang_google_genproto//googleapis/longrunning",

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -306,7 +306,7 @@ func (r *taskRunner) DownloadInputs(ctx context.Context, ioStats *repb.IOStats) 
 	if err != nil {
 		return err
 	}
-	if r.PlatformProperties.WorkflowID != "" {
+	if platform.IsCICommand(r.task.GetCommand()) {
 		if err := r.Workspace.AddCIRunner(ctx); err != nil {
 			return err
 		}


### PR DESCRIPTION
This will allow using `bb remote --os=darwin` to target mac workflow executors. Today we have to run `bb remote --os=darwin --runner_exec_properties=workload-isolation-type=none --runner_exec_properties=container-image=` and it fails with "exec format error" since we're provisioning the CI runner from the Linux build bundled with the app.

* Provision the ci_runner from the executor instead of the Linux build bundled with the app, so that we get the correct architecture. This matches what we do for workflows.
* When setting `bb remote --os=darwin`, don't set container-image and set workload-isolation-type=none (instead of firecracker).

**Related issues**: N/A
