### PR TITLE
disable raft/txn:txn_test on mac CI

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -49,6 +49,7 @@ actions:
         //...
         -//server/backends/disk_cache:all
         -//enterprise/server/backends/pebble_cache:all
+        -//enterprise/server/raft/txn:all
         -//enterprise/server/raft/store:all
         -//enterprise/server/remote_execution/commandutil:all
         -//enterprise/server/remote_execution/runner:all


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3480
