### PR TITLE
counting tree uploads

### DIFF
--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -489,6 +489,8 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 		if err != nil {
 			return nil, err
 		}
+		txInfo.FileCount += 1
+		txInfo.BytesTransferred += td.GetSizeBytes()
 		actionResult.OutputDirectories = append(actionResult.OutputDirectories, &repb.OutputDirectory{
 			Path:       filepath.ToSlash(trimPathPrefix(fullFilePath, rootDir)),
 			TreeDigest: td,

--- a/enterprise/server/remote_execution/dirtools/dirtools.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools.go
@@ -453,7 +453,9 @@ func UploadTree(ctx context.Context, env environment.Env, dirHelper *DirHelper, 
 		if err != nil {
 			return nil, err
 		}
-		filesToUpload = append(filesToUpload, uploadableDir)
+		if dirHelper.IsOutputPath(fullPath) || len(entries) == 0 {
+			filesToUpload = append(filesToUpload, uploadableDir)
+		}
 		return uploadableDir.DirNode(), nil
 	}
 	if _, err := uploadDirFn(rootDir, ""); err != nil {

--- a/enterprise/server/remote_execution/dirtools/dirtools_test.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools_test.go
@@ -113,8 +113,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        3,
+				BytesTransferred: 169,
 			},
 		},
 		{
@@ -282,8 +282,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        3,
+				BytesTransferred: 169,
 			},
 		},
 		{
@@ -336,8 +336,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        3,
+				BytesTransferred: 169,
 			},
 		},
 		{
@@ -388,8 +388,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        3,
+				BytesTransferred: 169,
 			},
 		},
 		{
@@ -426,8 +426,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 104,
+				FileCount:        3,
+				BytesTransferred: 209,
 			},
 		},
 		{
@@ -533,9 +533,10 @@ func TestUploadTree(t *testing.T) {
 				//   Dir:  a/b/e
 				//   Dir:  a/b/e/g
 				//   File: a/b/c/fileA.txt
+				//   Tree: a/b
 				//
-				FileCount:        6,
-				BytesTransferred: 381,
+				FileCount:        7,
+				BytesTransferred: 773,
 			},
 		},
 		{
@@ -571,8 +572,8 @@ func TestUploadTree(t *testing.T) {
 				},
 			},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        2,
-				BytesTransferred: 84,
+				FileCount:        3,
+				BytesTransferred: 169,
 			},
 		},
 		{

--- a/enterprise/server/remote_execution/dirtools/dirtools_test.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools_test.go
@@ -50,8 +50,8 @@ func TestUploadTree(t *testing.T) {
 			symlinkPaths:   map[string]string{},
 			expectedResult: &repb.ActionResult{},
 			expectedInfo: &dirtools.TransferInfo{
-				FileCount:        0,
-				BytesTransferred: 0,
+				FileCount:        1,
+				BytesTransferred: 6,
 			},
 		},
 		{
@@ -114,7 +114,7 @@ func TestUploadTree(t *testing.T) {
 			},
 			expectedInfo: &dirtools.TransferInfo{
 				FileCount:        3,
-				BytesTransferred: 169,
+				BytesTransferred: 109,
 			},
 		},
 		{
@@ -283,7 +283,7 @@ func TestUploadTree(t *testing.T) {
 			},
 			expectedInfo: &dirtools.TransferInfo{
 				FileCount:        3,
-				BytesTransferred: 169,
+				BytesTransferred: 109,
 			},
 		},
 		{
@@ -337,7 +337,7 @@ func TestUploadTree(t *testing.T) {
 			},
 			expectedInfo: &dirtools.TransferInfo{
 				FileCount:        3,
-				BytesTransferred: 169,
+				BytesTransferred: 109,
 			},
 		},
 		{
@@ -389,7 +389,7 @@ func TestUploadTree(t *testing.T) {
 			},
 			expectedInfo: &dirtools.TransferInfo{
 				FileCount:        3,
-				BytesTransferred: 169,
+				BytesTransferred: 109,
 			},
 		},
 		{
@@ -427,7 +427,7 @@ func TestUploadTree(t *testing.T) {
 			},
 			expectedInfo: &dirtools.TransferInfo{
 				FileCount:        3,
-				BytesTransferred: 209,
+				BytesTransferred: 142,
 			},
 		},
 		{
@@ -556,35 +556,8 @@ func TestUploadTree(t *testing.T) {
 							Children: []*repb.Directory{
 								// d
 								{},
-								// c
-								{
-									Files: []*repb.FileNode{
-										{
-											Name: "fileA.txt",
-											Digest: &repb.Digest{
-												Hash:      hash.String("a"),
-												SizeBytes: 1,
-											},
-										},
-									},
-									Directories: []*repb.DirectoryNode{
-										{
-											Name:   "d",
-											Digest: getDigestForMsg(t, &repb.Directory{}),
-										},
-									},
-								},
 								// g
 								{},
-								// e
-								{
-									Directories: []*repb.DirectoryNode{
-										{
-											Name:   "g",
-											Digest: getDigestForMsg(t, &repb.Directory{}),
-										},
-									},
-								},
 							},
 						}),
 					},
@@ -594,15 +567,13 @@ func TestUploadTree(t *testing.T) {
 				// This should includes:
 				//
 				//   Dir:  a/b
-				//   Dir:  a/b/c
 				//   Dir:  a/b/c/d
-				//   Dir:  a/b/e
 				//   Dir:  a/b/e/g
 				//   File: a/b/c/fileA.txt
 				//   Tree: a/b
 				//
-				FileCount:        7,
-				BytesTransferred: 773,
+				FileCount:        5,
+				BytesTransferred: 195,
 			},
 		},
 		{
@@ -639,7 +610,7 @@ func TestUploadTree(t *testing.T) {
 			},
 			expectedInfo: &dirtools.TransferInfo{
 				FileCount:        3,
-				BytesTransferred: 169,
+				BytesTransferred: 109,
 			},
 		},
 		{

--- a/enterprise/server/remote_execution/dirtools/dirtools_test.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools_test.go
@@ -517,10 +517,76 @@ func TestUploadTree(t *testing.T) {
 				OutputDirectories: []*repb.OutputDirectory{
 					{
 						Path: "a/b",
-						TreeDigest: &repb.Digest{
-							SizeBytes: 392,
-							Hash:      "59620196c9761b313ff20ed0dfb06bf81b824afe2bf7046ce49949ab51605b6b",
-						},
+						TreeDigest: getDigestForMsg(t, &repb.Tree{
+							Root: &repb.Directory{
+								Directories: []*repb.DirectoryNode{
+									{
+										Name: "c",
+										Digest: getDigestForMsg(t, &repb.Directory{
+											Directories: []*repb.DirectoryNode{
+												{
+													Name:   "d",
+													Digest: getDigestForMsg(t, &repb.Directory{}),
+												},
+											},
+											Files: []*repb.FileNode{
+												{
+													Name: "fileA.txt",
+													Digest: &repb.Digest{
+														SizeBytes: 1,
+														Hash:      hash.String("a"),
+													},
+												},
+											},
+										}),
+									},
+									{
+										Name: "e",
+										Digest: getDigestForMsg(t, &repb.Directory{
+											Directories: []*repb.DirectoryNode{
+												{
+													Name:   "g",
+													Digest: getDigestForMsg(t, &repb.Directory{}),
+												},
+											},
+										}),
+									},
+								},
+							},
+							Children: []*repb.Directory{
+								// d
+								{},
+								// c
+								{
+									Files: []*repb.FileNode{
+										{
+											Name: "fileA.txt",
+											Digest: &repb.Digest{
+												Hash:      hash.String("a"),
+												SizeBytes: 1,
+											},
+										},
+									},
+									Directories: []*repb.DirectoryNode{
+										{
+											Name:   "d",
+											Digest: getDigestForMsg(t, &repb.Directory{}),
+										},
+									},
+								},
+								// g
+								{},
+								// e
+								{
+									Directories: []*repb.DirectoryNode{
+										{
+											Name:   "g",
+											Digest: getDigestForMsg(t, &repb.Directory{}),
+										},
+									},
+								},
+							},
+						}),
 					},
 				},
 			},


### PR DESCRIPTION
Start counting Tree objects toward the upload statistic of each execution.

Also improved the test setup for the "LotsOfNesting" case to lay out the tree shape.
Expect this to help us troubleshoot issues with Directory and Tree content easier in the future.