### PR TITLE
Move output_paths migration boilerplate to NewDirHelper, instead of its caller

### DIFF
--- a/enterprise/server/remote_execution/dirtools/dirtools_test.go
+++ b/enterprise/server/remote_execution/dirtools/dirtools_test.go
@@ -612,13 +612,7 @@ func TestUploadTree(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			outputDirs := []string{}
-			outputPaths := tc.cmd.GetOutputPaths()
-			if len(outputPaths) == 0 {
-				outputDirs = tc.cmd.GetOutputDirectories()
-				outputPaths = append(tc.cmd.GetOutputFiles(), tc.cmd.GetOutputDirectories()...)
-			}
-			dirHelper := dirtools.NewDirHelper(rootDir, outputDirs, outputPaths, fs.FileMode(0o755))
+			dirHelper := dirtools.NewDirHelper(rootDir, tc.cmd, fs.FileMode(0o755))
 
 			actionResult := &repb.ActionResult{}
 			txInfo, err := dirtools.UploadTree(ctx, env, dirHelper, "", repb.DigestFunction_SHA256, rootDir, tc.cmd, actionResult)

--- a/enterprise/server/remote_execution/workspace/workspace.go
+++ b/enterprise/server/remote_execution/workspace/workspace.go
@@ -133,13 +133,7 @@ func (ws *Workspace) SetTask(ctx context.Context, task *repb.ExecutionTask) {
 	log.CtxDebugf(ctx, "Assigned task %s to workspace at %q", task.GetExecutionId(), ws.rootDir)
 	ws.task = task
 	cmd := task.GetCommand()
-	outputDirs := make([]string, 0)
-	outputPaths := cmd.GetOutputPaths()
-	if len(outputPaths) == 0 {
-		outputDirs = cmd.GetOutputDirectories()
-		outputPaths = append(cmd.GetOutputFiles(), cmd.GetOutputDirectories()...)
-	}
-	ws.dirHelper = dirtools.NewDirHelper(ws.inputRoot(), outputDirs, outputPaths, ws.dirPerms)
+	ws.dirHelper = dirtools.NewDirHelper(ws.inputRoot(), cmd, ws.dirPerms)
 }
 
 // CommandWorkingDirectory returns the absolute path to the working directory


### PR DESCRIPTION
While looking at `NewDirHelper` constructor, it took me a while to figure out that the `outputDirectories` and `outputPaths` parameters are not just direct passthroughs from `command.GetOutputDirectories()` and `command.GetOutputPaths()` respectively.

Instead, every caller of `NewDirHelper` is expected to write some boilerplate code to adapt the old-style `output_directories`/`output_files` into a new-style `output_paths` input.

It took me a while to realize this, and I spent a lot of time confused about why we only needed to call `IsOutputPath` in order to determine whether a directory needed to be uploaded, rather than `IsOutputPath || IsOutputDirectory || IsOutputFile`.

So, instead of having the caller adapt these fields, do it internally. To me, this is a lot more clear, since it keeps all the details of the `output_paths` migration in one place. It also helps simplify the calling code and reduce the possibility for errors.

**Related issues**: N/A
