### PR TITLE
Remove Bazel 6.0.0 binaries from deps.bzl

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6894,24 +6894,6 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         urls = ["https://github.com/bazelbuild/bazel/releases/download/5.3.2/bazel-5.3.2-linux-arm64"],
     )
     http_file(
-        name = "io_bazel_bazel-6.0.0-darwin-x86_64",
-        executable = True,
-        sha256 = "8e543c5c9f1c8c91df945cd2fb4c3b43587929a43044a0ed87d13da0d19f96e8",
-        urls = ["https://github.com/bazelbuild/bazel/releases/download/6.0.0/bazel-6.0.0-darwin-x86_64"],
-    )
-    http_file(
-        name = "io_bazel_bazel-6.0.0-linux-x86_64",
-        executable = True,
-        sha256 = "f03d44ecaac3878e3d19489e37caa4ca1dc57427b686a78a85065ea3c27ebe68",
-        urls = ["https://github.com/bazelbuild/bazel/releases/download/6.0.0/bazel-6.0.0-linux-x86_64"],
-    )
-    http_file(
-        name = "io_bazel_bazel-6.0.0-linux-arm64",
-        executable = True,
-        sha256 = "408c33a0edb8f31374da47e011eef88c360264f268e9a4e3d9e699fbd5e57ad3",
-        urls = ["https://github.com/bazelbuild/bazel/releases/download/6.0.0/bazel-6.0.0-linux-arm64"],
-    )
-    http_file(
         name = "io_bazel_bazel-6.5.0-darwin-x86_64",
         executable = True,
         sha256 = "bbf9c2c03bac48e0514f46db0295027935535d91f6d8dcd960c53393559eab29",

--- a/deps.bzl
+++ b/deps.bzl
@@ -6906,6 +6906,12 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         urls = ["https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-linux-x86_64"],
     )
     http_file(
+        name = "io_bazel_bazel-6.5.0-linux-arm64",
+        executable = True,
+        sha256 = "5afe973cadc036496cac66f1414ca9be36881423f576db363d83afc9084c0c2f",
+        urls = ["https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-linux-arm64"],
+    )
+    http_file(
         name = "io_bazel_bazel-7.1.0-darwin-x86_64",
         executable = True,
         sha256 = "52ad8d57c22e4f873c724473a09ecfd98966c3a2950e102a7bd7e8c612b8001c",

--- a/deps.bzl
+++ b/deps.bzl
@@ -6906,12 +6906,6 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         urls = ["https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-linux-x86_64"],
     )
     http_file(
-        name = "io_bazel_bazel-6.5.0-linux-arm64",
-        executable = True,
-        sha256 = "5afe973cadc036496cac66f1414ca9be36881423f576db363d83afc9084c0c2f",
-        urls = ["https://github.com/bazelbuild/bazel/releases/download/6.5.0/bazel-6.5.0-linux-arm64"],
-    )
-    http_file(
         name = "io_bazel_bazel-7.1.0-darwin-x86_64",
         executable = True,
         sha256 = "52ad8d57c22e4f873c724473a09ecfd98966c3a2950e102a7bd7e8c612b8001c",

--- a/server/util/bazel/BUILD
+++ b/server/util/bazel/BUILD
@@ -5,7 +5,6 @@ bazel_pkg_tar(
     name = "bazel_binaries_tar",
     versions = [
         "5.3.2",
-        "6.0.0",
         "6.5.0",
         "7.1.0",
     ],


### PR DESCRIPTION
These were use for old probers that I deleted a while ago.

**Related issues**: N/A
