### PR TITLE
[RB] Stop explicitly expanding bazelrcs and running plugins

### DIFF
--- a/cli/remotebazel/BUILD
+++ b/cli/remotebazel/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//cli/log",
         "//cli/login",
         "//cli/parser",
-        "//cli/setup",
         "//cli/storage",
         "//cli/terminal",
         "//enterprise/server/remote_execution/dirtools",

--- a/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
+++ b/enterprise/server/test/integration/remote_bazel/remote_bazel_test.go
@@ -140,7 +140,7 @@ func TestWithPrivateRepo(t *testing.T) {
 		// to setup than a firecracker runner
 		"--runner_exec_properties=workload-isolation-type=none",
 		"--runner_exec_properties=container-image=",
-		"run",
+		"build",
 		":hello_world",
 		"--noenable_bzlmod",
 		fmt.Sprintf("--remote_header=x-buildbuddy-api-key=%s", env.APIKey1)})
@@ -169,7 +169,7 @@ func TestWithPrivateRepo(t *testing.T) {
 		MinLines:     math.MaxInt32,
 	})
 	require.NoError(t, err)
-	require.Contains(t, string(logResp.GetBuffer()), "FUTURE OF BUILDS!")
+	require.Contains(t, string(logResp.GetBuffer()), "Build completed successfully")
 }
 
 func runLocalServerAndExecutor(t *testing.T, githubToken string) (*rbetest.Env, *rbetest.BuildBuddyServer, *rbetest.Executor) {


### PR DESCRIPTION
Processing bazelrcs and running plugins should happen on the remote runner, not locally

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
