### PR TITLE
[raft] clean up expired sessions

### DIFF
--- a/enterprise/server/raft/client/BUILD
+++ b/enterprise/server/raft/client/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -14,6 +14,7 @@ go_library(
         "//server/environment",
         "//server/util/canary",
         "//server/util/grpc_client",
+        "//server/util/lockmap",
         "//server/util/log",
         "//server/util/proto",
         "//server/util/status",
@@ -24,5 +25,21 @@ go_library(
         "@com_github_lni_dragonboat_v4//statemachine",
         "@org_golang_google_genproto_googleapis_rpc//status",
         "@org_golang_google_grpc//status",
+    ],
+)
+
+go_test(
+    name = "client_test",
+    srcs = ["client_test.go"],
+    deps = [
+        ":client",
+        "//enterprise/server/raft/logger",
+        "//enterprise/server/raft/rbuilder",
+        "//enterprise/server/raft/testutil",
+        "//proto:raft_go_proto",
+        "//server/util/random",
+        "@com_github_jonboulle_clockwork//:clockwork",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -330,3 +330,7 @@ func SyncReadLocalBatch(ctx context.Context, nodehost *dragonboat.NodeHost, shar
 	}
 	return rbuilder.NewBatchResponseFromProto(rsp), nil
 }
+
+func SessionLifetime() time.Duration {
+	return *sessionLifetime
+}

--- a/enterprise/server/raft/client/client_test.go
+++ b/enterprise/server/raft/client/client_test.go
@@ -1,0 +1,130 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/client"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/testutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/random"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	_ "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/logger"
+	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+)
+
+func newTestingProposal(t testing.TB, shardID uint64) *testutil.TestingProposer {
+	r := testutil.NewTestingReplica(t, shardID, 1)
+	require.NotNil(t, r)
+	randID, err := random.RandomString(10)
+	require.NoError(t, err)
+	p := testutil.NewTestingProposer(t, randID, r.Replica)
+	require.NotNil(t, p)
+	return p
+}
+
+func increment(t testing.TB, ctx context.Context, shardID uint64, p *testutil.TestingProposer, session *client.Session, expectedValue int64) {
+	req, err := rbuilder.NewBatchBuilder().Add(&rfpb.IncrementRequest{
+		Key:   []byte(fmt.Sprintf("shard%d", shardID)),
+		Delta: 1,
+	}).ToProto()
+	require.NoError(t, err)
+	rsp, err := session.SyncProposeLocal(ctx, p, shardID, req)
+	require.NoError(t, err)
+	incrBatch := rbuilder.NewBatchResponseFromProto(rsp)
+	incrRsp, err := incrBatch.IncrementResponse(0)
+	require.NoError(t, err)
+	require.EqualValues(t, expectedValue, incrRsp.GetValue())
+}
+
+func TestSession(t *testing.T) {
+	tp1 := newTestingProposal(t, 1)
+	tp2 := newTestingProposal(t, 2)
+	ctx := context.Background()
+
+	session := client.NewSession()
+
+	increment(t, ctx, 1, tp1, session, 1)
+	increment(t, ctx, 2, tp2, session, 1)
+	increment(t, ctx, 1, tp1, session, 2)
+}
+
+func TestSessionInParallel(t *testing.T) {
+	proposers := make([]*testutil.TestingProposer, 0, 5)
+	for i := 1; i <= 5; i++ {
+		tp := newTestingProposal(t, uint64(i))
+		proposers = append(proposers, tp)
+	}
+
+	session := client.NewSession()
+
+	ctx := context.Background()
+	eg, egCtx := errgroup.WithContext(ctx)
+	for i := 1; i <= 5; i++ {
+		i := i
+		eg.Go(func() error {
+			increment(t, egCtx, uint64(i), proposers[i-1], session, 1)
+			increment(t, egCtx, uint64(i), proposers[i-1], session, 2)
+			return nil
+		})
+	}
+	err := eg.Wait()
+	require.NoError(t, err)
+}
+
+func TestRefreshSession(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	proposers := make([]*testutil.TestingProposer, 0, 3)
+	for i := 1; i <= 3; i++ {
+		tp := newTestingProposal(t, uint64(i))
+		proposers = append(proposers, tp)
+	}
+
+	session := client.NewSessionWithClock(clock)
+
+	// advance the clock to trigger a refresh
+	clock.Advance(90 * time.Minute)
+
+	ctx := context.Background()
+	eg, egCtx := errgroup.WithContext(ctx)
+	for i := 1; i <= 3; i++ {
+		i := i
+		eg.Go(func() error {
+			increment(t, egCtx, uint64(i), proposers[i-1], session, 1)
+			increment(t, egCtx, uint64(i), proposers[i-1], session, 2)
+			return nil
+		})
+	}
+	err := eg.Wait()
+
+	require.NoError(t, err)
+}
+
+func BenchmarkSession(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		proposers := make([]*testutil.TestingProposer, 0, 5)
+		for i := 1; i <= 5; i++ {
+			tp := newTestingProposal(b, uint64(i))
+			proposers = append(proposers, tp)
+		}
+		session := client.NewSession()
+		ctx := context.Background()
+		eg, egCtx := errgroup.WithContext(ctx)
+		b.StartTimer()
+		for i := 1; i <= 5; i++ {
+			i := i
+			eg.Go(func() error {
+				increment(b, egCtx, uint64(i), proposers[i-1], session, 1)
+				increment(b, egCtx, uint64(i), proposers[i-1], session, 2)
+				return nil
+			})
+		}
+		eg.Wait()
+	}
+}

--- a/enterprise/server/raft/leasekeeper/leasekeeper.go
+++ b/enterprise/server/raft/leasekeeper/leasekeeper.go
@@ -70,12 +70,12 @@ type LeaseKeeper struct {
 	nodeLivenessUpdates <-chan *rfpb.NodeLivenessRecord
 }
 
-func New(nodeHost *dragonboat.NodeHost, log log.Logger, liveness *nodeliveness.Liveness, listener *listener.RaftListener, broadcast chan<- events.Event) *LeaseKeeper {
+func New(nodeHost *dragonboat.NodeHost, log log.Logger, liveness *nodeliveness.Liveness, listener *listener.RaftListener, broadcast chan<- events.Event, session *client.Session) *LeaseKeeper {
 	return &LeaseKeeper{
 		nodeHost:            nodeHost,
 		log:                 log,
 		liveness:            liveness,
-		session:             client.NewSession(),
+		session:             session,
 		listener:            listener,
 		broadcast:           broadcast,
 		mu:                  sync.Mutex{},

--- a/enterprise/server/raft/replica/replica_test.go
+++ b/enterprise/server/raft/replica/replica_test.go
@@ -368,7 +368,7 @@ func TestSessionIndexMismatchError(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(writeRsp))
 
-	session.Index = 3
+	session.Index = 0
 	entry = em.makeEntry(rbuilder.NewBatchBuilder().SetSession(session).Add(&rfpb.IncrementRequest{
 		Key:   []byte("incr-key"),
 		Delta: 1,

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -52,6 +52,7 @@ go_library(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//reflection",
         "@org_golang_x_sync//errgroup",
+        "@org_golang_x_time//rate",
     ],
 )
 

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -50,6 +50,7 @@ import (
 	"github.com/lni/dragonboat/v4/raftio"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
@@ -65,8 +66,13 @@ var (
 	zombieNodeScanInterval = flag.Duration("cache.raft.zombie_node_scan_interval", 10*time.Second, "Check if one replica is a zombie every this often. 0 to disable.")
 	zombieMinDuration      = flag.Duration("cache.raft.zombie_min_duration", 1*time.Minute, "The minimum duration a replica must remain in a zombie state to be considered a zombie.")
 	replicaScanInterval    = flag.Duration("cache.raft.replica_scan_interval", 1*time.Minute, "The interval we wait to check if the replicas need to be queued for replication")
+	clientSessionTTL       = flag.Duration("cache.raft.client_session_ttl", 24*time.Hour, "The duration we keep the sessions stored.")
 	maxRangeSizeBytes      = flag.Int64("cache.raft.max_range_size_bytes", 1e8, "If set to a value greater than 0, ranges will be split until smaller than this size")
 	enableDriver           = flag.Bool("cache.raft.enable_driver", true, "If true, enable placement driver")
+)
+
+const (
+	deleteSessionsRateLimit = 1
 )
 
 type Store struct {
@@ -111,7 +117,8 @@ type Store struct {
 	updateTagsWorker *updateTagsWorker
 	txnCoordinator   *txn.Coordinator
 
-	driverQueue *driver.Queue
+	driverQueue         *driver.Queue
+	deleteSessionWorker *deleteSessionWorker
 
 	clock clockwork.Clock
 }
@@ -222,6 +229,7 @@ func NewWithArgs(env environment.Env, rootDir string, nodeHost *dragonboat.NodeH
 	if *enableDriver {
 		s.driverQueue = driver.NewQueue(s, gossipManager)
 	}
+	s.deleteSessionWorker = newDeleteSessionsWorker(clock, s)
 
 	if err != nil {
 		return nil, err
@@ -449,13 +457,17 @@ func (s *Store) Start() error {
 		return nil
 	})
 	eg.Go(func() error {
-		s.scan(gctx)
+		s.scanReplicas(gctx)
 		return nil
 	})
 	eg.Go(func() error {
 		if s.driverQueue != nil {
 			s.driverQueue.Start(gctx)
 		}
+		return nil
+	})
+	eg.Go(func() error {
+		s.deleteSessionWorker.Start(gctx)
 		return nil
 	})
 
@@ -1355,6 +1367,90 @@ func (w *updateTagsWorker) updateTags() error {
 	return err
 }
 
+type deleteSessionWorker struct {
+	rateLimiter       *rate.Limiter
+	lastExecutionTime sync.Map // map of uint64 rangeID -> the timestamp we last delete sessions
+	session           *client.Session
+	clock             clockwork.Clock
+	store             *Store
+	deleteChan        chan *replica.Replica
+}
+
+func newDeleteSessionsWorker(clock clockwork.Clock, store *Store) *deleteSessionWorker {
+	return &deleteSessionWorker{
+		rateLimiter:       rate.NewLimiter(rate.Limit(deleteSessionsRateLimit), 1),
+		store:             store,
+		lastExecutionTime: sync.Map{},
+		session:           client.NewSessionWithClock(clock),
+		clock:             clock,
+		deleteChan:        make(chan *replica.Replica, 10000),
+	}
+}
+
+func (w *deleteSessionWorker) Enqueue(repl *replica.Replica) {
+	select {
+	case w.deleteChan <- repl:
+		break
+	default:
+		log.Warning("deleteSessionWorker queue full")
+	}
+}
+
+func (w *deleteSessionWorker) Start(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			for len(w.deleteChan) > 0 {
+				<-w.deleteChan
+			}
+			return
+		case repl := <-w.deleteChan:
+			w.deleteSessions(ctx, repl)
+		}
+	}
+}
+
+func (w *deleteSessionWorker) deleteSessions(ctx context.Context, repl *replica.Replica) error {
+	rd := repl.RangeDescriptor()
+	lastExecutionTimeI, found := w.lastExecutionTime.Load(rd.GetRangeId())
+	if found {
+		lastExecutionTime, ok := lastExecutionTimeI.(time.Time)
+		if ok {
+			if w.clock.Since(lastExecutionTime) <= client.SessionLifetime() {
+				// There are probably no client sessions to delete.
+				return nil
+			}
+		}
+
+		return status.InternalErrorf("unable to delete sessions for rangeID=%d: unable to parse lastExecutionTime", rd.GetRangeId())
+	}
+
+	if !w.store.HaveLease(rd.GetRangeId()) {
+		log.Infof("skip because the store doesn't have lease for range ID:= %d", rd.GetRangeId())
+		// The replica doesn't have the lease right now. skip.
+		return nil
+	}
+
+	if err := w.rateLimiter.Wait(ctx); err != nil {
+		return err
+	}
+	now := w.clock.Now()
+	request, err := rbuilder.NewBatchBuilder().Add(
+		&rfpb.DeleteSessionsRequest{
+			CreatedAtUsec: now.Add(-*clientSessionTTL).UnixMicro(),
+		}).ToProto()
+	if err != nil {
+		return status.InternalErrorf("unable to delete sessions for rangeID=%d: unable to build request: %s", rd.GetRangeId(), err)
+	}
+	rsp, err := w.session.SyncProposeLocal(ctx, w.store.NodeHost(), repl.ShardID(), request)
+	if err != nil {
+		return status.InternalErrorf("unable to delete sessions for rangeID=%d: SyncProposeLocal fails: %s", rd.GetRangeId(), err)
+	}
+	w.lastExecutionTime.Store(rd.GetRangeId(), now)
+	_, err = rbuilder.NewBatchResponseFromProto(rsp).DeleteSessionsResponse(0)
+	return status.InternalErrorf("unable to delete sessions for rangeID=%d: DeleteSessions fails: %s", rd.GetRangeId(), err)
+}
+
 func (s *Store) SplitRange(ctx context.Context, req *rfpb.SplitRangeRequest) (*rfpb.SplitRangeResponse, error) {
 	startTime := time.Now()
 	leftRange := req.GetRange()
@@ -1927,10 +2023,7 @@ func (s *Store) removeReplicaFromRangeDescriptor(ctx context.Context, shardID, r
 	return newDescriptor, nil
 }
 
-func (store *Store) scan(ctx context.Context) {
-	if store.driverQueue == nil {
-		return
-	}
+func (store *Store) scanReplicas(ctx context.Context) {
 	scanDelay := store.clock.NewTicker(*replicaScanInterval)
 	for {
 		select {
@@ -1940,7 +2033,10 @@ func (store *Store) scan(ctx context.Context) {
 		}
 		replicas := store.getLeasedReplicas()
 		for _, repl := range replicas {
-			store.driverQueue.MaybeAdd(repl)
+			if store.driverQueue != nil {
+				store.driverQueue.MaybeAdd(repl)
+			}
+			store.deleteSessionWorker.Enqueue(repl)
 		}
 	}
 }

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -737,7 +737,3 @@ func TestSplitAcrossClusters(t *testing.T) {
 		readRecord(ctx, t, s1, fr)
 	}
 }
-
-func BenchmarkDirectWrite(b *testing.B) {
-	flags.Set(b, "cache.raft.max_range_size_bytes", 0) // disable auto splitting
-}

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -81,11 +81,11 @@ func TestAddGetRemoveRange(t *testing.T) {
 
 func TestCleanupZombieShards(t *testing.T) {
 	clock := clockwork.NewFakeClock()
-	sf := testutil.NewStoreFactory(t)
-	s1 := sf.NewStoreWithClock(t, clock)
+	sf := testutil.NewStoreFactoryWithClock(t, clock)
+	s1 := sf.NewStore(t)
 	ctx := context.Background()
 
-	testutil.StartShard(t, ctx, s1)
+	sf.StartShard(t, ctx, s1)
 
 	stores := []*testutil.TestingStore{s1}
 	waitForRangeLease(t, stores, 2)
@@ -117,13 +117,13 @@ func TestCleanupZombieShards(t *testing.T) {
 func TestCleanupZombieReplicas(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
-	sf := testutil.NewStoreFactory(t)
-	s1 := sf.NewStoreWithClock(t, clock)
-	s2 := sf.NewStoreWithClock(t, clock)
+	sf := testutil.NewStoreFactoryWithClock(t, clock)
+	s1 := sf.NewStore(t)
+	s2 := sf.NewStore(t)
 	ctx := context.Background()
 
 	stores := []*testutil.TestingStore{s1, s2}
-	testutil.StartShard(t, ctx, stores...)
+	sf.StartShard(t, ctx, stores...)
 
 	waitForRangeLease(t, stores, 2)
 
@@ -200,7 +200,7 @@ func TestAutomaticSplitting(t *testing.T) {
 	ctx := context.Background()
 
 	stores := []*testutil.TestingStore{s1}
-	testutil.StartShard(t, ctx, stores...)
+	sf.StartShard(t, ctx, stores...)
 
 	waitForRangeLease(t, stores, 2)
 	writeNRecords(ctx, t, s1, 15) // each write is 1000 bytes
@@ -214,7 +214,7 @@ func TestAddNodeToCluster(t *testing.T) {
 	s2 := sf.NewStore(t)
 	ctx := context.Background()
 
-	testutil.StartShard(t, ctx, s1)
+	sf.StartShard(t, ctx, s1)
 
 	stores := []*testutil.TestingStore{s1, s2}
 	s := getStoreWithRangeLease(t, stores, 2)
@@ -264,7 +264,7 @@ func TestRemoveNodeFromCluster(t *testing.T) {
 	ctx := context.Background()
 
 	stores := []*testutil.TestingStore{s1, s2}
-	testutil.StartShard(t, ctx, stores...)
+	sf.StartShard(t, ctx, stores...)
 
 	s := getStoreWithRangeLease(t, stores, 2)
 
@@ -377,7 +377,7 @@ func TestSplitMetaRange(t *testing.T) {
 	s1 := sf.NewStore(t)
 	ctx := context.Background()
 
-	testutil.StartShard(t, ctx, s1)
+	sf.StartShard(t, ctx, s1)
 
 	rd := s1.GetRange(1)
 
@@ -431,7 +431,7 @@ func TestSplitNonMetaRange(t *testing.T) {
 	ctx := context.Background()
 
 	stores := []*testutil.TestingStore{s1, s2, s3}
-	testutil.StartShard(t, ctx, stores...)
+	sf.StartShard(t, ctx, stores...)
 
 	s := getStoreWithRangeLease(t, stores, 2)
 	rd := s.GetRange(2)
@@ -501,7 +501,7 @@ func TestListReplicas(t *testing.T) {
 	ctx := context.Background()
 
 	stores := []*testutil.TestingStore{s1, s2, s3}
-	testutil.StartShard(t, ctx, stores...)
+	sf.StartShard(t, ctx, stores...)
 	waitForRangeLease(t, stores, 2)
 
 	list, err := s1.ListReplicas(ctx, &rfpb.ListReplicasRequest{})
@@ -516,7 +516,7 @@ func TestPostFactoSplit(t *testing.T) {
 	ctx := context.Background()
 
 	stores := []*testutil.TestingStore{s1, s2}
-	testutil.StartShard(t, ctx, s1)
+	sf.StartShard(t, ctx, s1)
 
 	s := getStoreWithRangeLease(t, stores, 2)
 	rd := s.GetRange(2)
@@ -605,7 +605,7 @@ func TestManySplits(t *testing.T) {
 	ctx := context.Background()
 	stores := []*testutil.TestingStore{s1}
 
-	testutil.StartShard(t, ctx, stores...)
+	sf.StartShard(t, ctx, stores...)
 	s := getStoreWithRangeLease(t, stores, 2)
 
 	var written []*rfpb.FileRecord
@@ -670,7 +670,7 @@ func TestSplitAcrossClusters(t *testing.T) {
 			Generation: 1,
 		},
 	}
-	testutil.StartShardWithRanges(t, ctx, startingRanges, s1)
+	sf.StartShardWithRanges(t, ctx, startingRanges, s1)
 	waitForRangeLease(t, stores, 1)
 
 	// Bringup new peers.

--- a/enterprise/server/raft/store/store_test.go
+++ b/enterprise/server/raft/store/store_test.go
@@ -737,3 +737,7 @@ func TestSplitAcrossClusters(t *testing.T) {
 		readRecord(ctx, t, s1, fr)
 	}
 }
+
+func BenchmarkDirectWrite(b *testing.B) {
+	flags.Set(b, "cache.raft.max_range_size_bytes", 0) // disable auto splitting
+}

--- a/enterprise/server/raft/testutil/BUILD
+++ b/enterprise/server/raft/testutil/BUILD
@@ -40,5 +40,8 @@ package(default_visibility = ["//enterprise:__subpackages__"])
 go_test(
     name = "testutil_test",
     srcs = ["testutil_test.go"],
-    deps = [":testutil"],
+    deps = [
+        ":testutil",
+        "@com_github_jonboulle_clockwork//:clockwork",
+    ],
 )

--- a/enterprise/server/raft/testutil/testutil_test.go
+++ b/enterprise/server/raft/testutil/testutil_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/testutil"
+	"github.com/jonboulle/clockwork"
 )
 
 func TestStartShard(t *testing.T) {
-	sf := testutil.NewStoreFactory(t)
+	sf := testutil.NewStoreFactoryWithClock(t, clockwork.NewRealClock())
 	s1 := sf.NewStore(t)
 	ctx := context.Background()
 
-	testutil.StartShard(t, ctx, s1)
+	sf.StartShard(t, ctx, s1)
 }

--- a/enterprise/server/raft/txn/txn_test.go
+++ b/enterprise/server/raft/txn/txn_test.go
@@ -33,7 +33,7 @@ func TestRollbackPendingTxn(t *testing.T) {
 	sf := testutil.NewStoreFactory(t)
 	store := sf.NewStore(t)
 	ctx := context.Background()
-	testutil.StartShard(t, ctx, store)
+	sf.StartShard(t, ctx, store)
 
 	{ // Do a DirectWrite.
 		key := []byte("foo")
@@ -137,7 +137,7 @@ func TestCommitPreparedTxn(t *testing.T) {
 	sf := testutil.NewStoreFactory(t)
 	store := sf.NewStore(t)
 	ctx := context.Background()
-	testutil.StartShard(t, ctx, store)
+	sf.StartShard(t, ctx, store)
 
 	{ // Do a DirectWrite.
 		key := []byte("foo")
@@ -246,7 +246,7 @@ func TestFetchTxnRecordsSkipRecent(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	store := sf.NewStore(t)
 	ctx := context.Background()
-	testutil.StartShard(t, ctx, store)
+	sf.StartShard(t, ctx, store)
 	tc := txn.NewCoordinator(store, store.APIClient(), clock)
 
 	err := tc.WriteTxnRecord(ctx, &rfpb.TxnRecord{
@@ -286,7 +286,7 @@ func TestRunTxn(t *testing.T) {
 	s2 := sf.NewStore(t)
 	s3 := sf.NewStore(t)
 	ctx := context.Background()
-	testutil.StartShard(t, ctx, s1, s2, s3)
+	sf.StartShard(t, ctx, s1, s2, s3)
 
 	batch := rbuilder.NewBatchBuilder().Add(&rfpb.DirectWriteRequest{
 		Kv: &rfpb.KV{


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: buildbuddy-io/buildbuddy-internal#3452
Initiate cleanup sessions in raft/store.

Use the current goroutine that scans the leased replica, and queue tasks to
delete sessions.

Use a rate limiter to make sure we are not delete sessions for all replicas at
once.

Record the time when we last delete the sessions and skip if we deleted the
sessions within SessionLifetime().
