### PR TITLE
Switch to new AWS RDS CA bundle.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -457,8 +457,8 @@ web_test_go_repositories()
 http_file(
     name = "aws_rds_certs",
     downloaded_file_path = "rds-combined-ca-bundle.pem",
-    sha256 = "6a8ba1c9f858386edba0ea82b7bf8168ef513d1eb0df3a08cc7cf4bb89f856d0",
-    url = "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem",
+    sha256 = "51b107da46717aed974d97464b63f7357b220fe8737969db1492d1cae74b3947",
+    url = "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem",
 )
 
 # Proto rules

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -330,7 +330,7 @@ web_test_go_repositories()
 http_file(
     name = "aws_rds_certs",
     downloaded_file_path = "rds-combined-ca-bundle.pem",
-    sha256 = "6a8ba1c9f858386edba0ea82b7bf8168ef513d1eb0df3a08cc7cf4bb89f856d0",
+    sha256 = "51b107da46717aed974d97464b63f7357b220fe8737969db1492d1cae74b3947",
     url = "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem",
 )
 

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -331,7 +331,7 @@ http_file(
     name = "aws_rds_certs",
     downloaded_file_path = "rds-combined-ca-bundle.pem",
     sha256 = "6a8ba1c9f858386edba0ea82b7bf8168ef513d1eb0df3a08cc7cf4bb89f856d0",
-    url = "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem",
+    url = "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem",
 )
 
 HERMETIC_CC_TOOLCHAIN_VERSION = "v3.0.1"


### PR DESCRIPTION
This bundle is a superset of the previous bundle with CA certs that expire far into the future.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
