### PR TITLE
gosdk: upgrade to 1.22.4

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,7 +32,7 @@ archive_override(
 )
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.22.3")
+go_sdk.download(version = "1.22.4")
 go_sdk.nogo(nogo = "@//:vet")
 use_repo(
     go_sdk,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,7 +61,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchai
 
 go_rules_dependencies()
 
-GO_SDK_VERSION = "1.22.3"
+GO_SDK_VERSION = "1.22.4"
 
 # Register multiple Go SDKs so that we can perform cross-compilation remotely.
 # i.e. We might want to trigger a Linux AMD64 Go build remotely from a MacOS ARM64 laptop.


### PR DESCRIPTION
go1.22.4 (released 2024-06-04) includes security fixes to the archive/zip and net/netip packages, as well as bug fixes to the compiler, the go command, the linker, the runtime, and the os package. See the [Go 1.22.4 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.22.4+label%3ACherryPickApproved) on our issue tracker for details.