### PR TITLE
[ociruntime] Fix stderr/stdout/stdin handling

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -41,6 +41,7 @@ go_test(
         ":ociruntime",
         "//enterprise/server/remote_execution/container",
         "//proto:remote_execution_go_proto",
+        "//server/interfaces",
         "//server/testutil/testenv",
         "//server/testutil/testfs",
         "//server/util/testing/flags",

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -52,3 +52,23 @@ func TestCreateExecRemove(t *testing.T) {
 	assert.Empty(t, string(res.Stderr))
 	assert.Equal(t, "buildbuddy was here: /buildbuddy-execroot\n", string(res.Stdout))
 }
+
+func TestCreateFailureHasStderr(t *testing.T) {
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+
+	runtimeRoot := testfs.MakeTempDir(t)
+	flags.Set(t, "executor.oci.runtime_root", runtimeRoot)
+
+	buildRoot := testfs.MakeTempDir(t)
+
+	provider, err := ociruntime.NewProvider(env, buildRoot)
+	require.NoError(t, err)
+	wd := testfs.MakeDirAll(t, buildRoot, "work")
+
+	// Create
+	c, err := provider.New(ctx, &container.Init{})
+	require.NoError(t, err)
+	err = c.Create(ctx, wd+"nonexistent")
+	require.ErrorContains(t, err, "nonexistent")
+}

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -2,13 +2,12 @@ package ociruntime_test
 
 import (
 	"context"
-	"os"
-	"runtime"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/ociruntime"
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
@@ -42,12 +41,14 @@ func TestCreateExecRemove(t *testing.T) {
 	})
 
 	// Exec
-	cmd := &repb.Command{Arguments: []string{"pwd"}}
-	res := c.Exec(ctx, cmd, nil /*=stdio*/)
+	cmd := &repb.Command{Arguments: []string{"sh", "-c", "cat && pwd"}}
+	stdio := interfaces.Stdio{
+		Stdin: strings.NewReader("buildbuddy was here: "),
+	}
+	res := c.Exec(ctx, cmd, &stdio)
 	require.NoError(t, res.Error)
 
 	assert.Equal(t, 0, res.ExitCode)
-	// TODO: get stdout/stderr working
-	// assert.Empty(t, string(res.Stderr))
-	// assert.Equal(t, "/buildbuddy-execroot\n", string(res.Stdout))
+	assert.Empty(t, string(res.Stderr))
+	assert.Equal(t, "buildbuddy was here: /buildbuddy-execroot\n", string(res.Stdout))
 }


### PR DESCRIPTION
Wire up `interfaces.Stdio` with the option of discarding all output, which is prevents hanging in `create` as `sleep` never closes its inherited stdout/stderr.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
