### PR TITLE
Fill out the JWT field in AuthenticateResponse

### DIFF
--- a/enterprise/server/auth_service/BUILD
+++ b/enterprise/server/auth_service/BUILD
@@ -8,7 +8,10 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/auth_service",
     deps = [
         "//proto:auth_go_proto",
+        "//server/interfaces",
         "//server/real_environment",
+        "//server/util/authutil",
+        "//server/util/status",
     ],
 )
 
@@ -19,6 +22,10 @@ go_test(
     embed = [":auth_service"],
     deps = [
         "//proto:auth_go_proto",
+        "//server/testutil/testauth",
+        "//server/util/authutil",
+        "//server/util/status",
         "@com_github_stretchr_testify//assert",
+        "@org_golang_google_grpc//metadata",
     ],
 )

--- a/enterprise/server/auth_service/auth_service.go
+++ b/enterprise/server/auth_service/auth_service.go
@@ -3,18 +3,31 @@ package auth_service
 import (
 	"context"
 
+	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	authpb "github.com/buildbuddy-io/buildbuddy/proto/auth"
 )
 
 type AuthService struct {
+	authenticator interfaces.GRPCAuthenticator
 }
 
 func Register(env *real_environment.RealEnv) {
-	env.SetAuthService(AuthService{})
+	env.SetAuthService(AuthService{authenticator: env.GetAuthenticator()})
 }
 
 func (a AuthService) Authenticate(ctx context.Context, req *authpb.AuthenticateRequest) (*authpb.AuthenticateResponse, error) {
-	return &authpb.AuthenticateResponse{}, nil
+	ctx = a.authenticator.AuthenticatedGRPCContext(ctx)
+	err, found := authutil.AuthErrorFromContext(ctx)
+	if found {
+		return nil, err
+	}
+	jwt, ok := ctx.Value(authutil.ContextTokenStringKey).(string)
+	if ok {
+		return &authpb.AuthenticateResponse{Jwt: &jwt}, nil
+	}
+	return nil, status.UnauthenticatedError("Authentication failed")
 }

--- a/enterprise/server/auth_service/auth_service_test.go
+++ b/enterprise/server/auth_service/auth_service_test.go
@@ -4,13 +4,40 @@ import (
 	"context"
 	"testing"
 
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testauth"
+	"github.com/buildbuddy-io/buildbuddy/server/util/authutil"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
 
 	authpb "github.com/buildbuddy-io/buildbuddy/proto/auth"
 )
 
-func TestAuthenticate(t *testing.T) {
-	service := AuthService{}
+func contextWithApiKey(t *testing.T, key string) context.Context {
+	ctx := metadata.AppendToOutgoingContext(context.Background(), authutil.APIKeyHeader, key)
+	outgoingMD, ok := metadata.FromOutgoingContext(ctx)
+	assert.True(t, ok)
+	// Simulate an RPC by creating a new context with the incoming
+	// metadata set to the previously applied outgoing metadata.
+	ctx = context.Background()
+	return metadata.NewIncomingContext(ctx, outgoingMD)
+}
+
+func TestAuthenticateNoCreds(t *testing.T) {
+	service := AuthService{authenticator: testauth.NewTestAuthenticator(testauth.TestUsers("foo", "bar"))}
 	_, err := service.Authenticate(context.Background(), &authpb.AuthenticateRequest{})
+	assert.True(t, status.IsUnauthenticatedError(err))
+}
+
+func TestAuthenticate(t *testing.T) {
+	service := AuthService{authenticator: testauth.NewTestAuthenticator(testauth.TestUsers("foo", "bar"))}
+	resp, err := service.Authenticate(contextWithApiKey(t, "foo"), &authpb.AuthenticateRequest{})
 	assert.NoError(t, err)
+	assert.NotEqual(t, 0, len(*resp.Jwt))
+}
+
+func TestAuthenticateWrongCreds(t *testing.T) {
+	service := AuthService{authenticator: testauth.NewTestAuthenticator(testauth.TestUsers("foo", "bar"))}
+	_, err := service.Authenticate(contextWithApiKey(t, "baz"), &authpb.AuthenticateRequest{})
+	assert.True(t, status.IsUnauthenticatedError(err))
 }


### PR DESCRIPTION
For the period where we're just running the cache-proxy within our own GCP deployment or other deployments that we're comfortable sharing the JWT key with, we can use this to support remotely authenticating. At some point we will probably want to sign these differently, probably using RSA public/private keys, but I'll address that later.

**Related issues**: N/A