### PR TITLE
Support using github as a module backend

### DIFF
--- a/enterprise/server/registry/BUILD
+++ b/enterprise/server/registry/BUILD
@@ -4,7 +4,10 @@ package(default_visibility = ["//enterprise:__subpackages__"])
 
 go_library(
     name = "registry",
-    srcs = ["registry_server.go"],
+    srcs = [
+        "github_registry.go",
+        "registry_server.go",
+    ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/registry",
     deps = [
         "//server/environment",

--- a/enterprise/server/registry/github_registry.go
+++ b/enterprise/server/registry/github_registry.go
@@ -1,0 +1,67 @@
+package registry
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+)
+
+func handleGitHub(w http.ResponseWriter, req *http.Request) {
+	urlParts := strings.Split(req.URL.Path, "/")
+
+	switch urlParts[len(urlParts)-1] {
+	case "MODULE.bazel":
+		githubModule(w, req)
+	case "source.json":
+		githubSource(w, req)
+	}
+}
+
+func parseGithubRequest(req *http.Request) (string, string, string, string) {
+	urlParts := strings.Split(req.URL.Path, "/")
+	repo := urlParts[2]
+	version := urlParts[3]
+	versionParts := strings.Split(version, "+")
+	owner := strings.TrimPrefix(versionParts[0], "github.")
+	tag := "master"
+	if len(versionParts) > 1 {
+		tag = versionParts[1]
+	}
+	return repo, owner, version, tag
+}
+
+func githubModule(w http.ResponseWriter, req *http.Request) {
+	repo, owner, version, tag := parseGithubRequest(req)
+	moduleRegex := regexp.MustCompile(`(?s)module\(.*?\)`)
+	body, status, err := request("https://raw.githubusercontent.com/" + owner + "/" + repo + "/" + tag + "/MODULE.bazel")
+	if err != nil {
+		log.Errorf("%s", err)
+		w.WriteHeader(status)
+		return
+	}
+	if status > 300 {
+		w.WriteHeader(status)
+		return
+	}
+
+	moduleSnippet := []byte(`module(name="` + repo + `", version="` + version + `")`)
+
+	if moduleRegex.Match(body) {
+		moduleSnippet = moduleRegex.ReplaceAll(body, moduleSnippet)
+	} else {
+		moduleSnippet = append(moduleSnippet, []byte("\n\n")...)
+		moduleSnippet = append(moduleSnippet, body...)
+	}
+	w.Write(moduleSnippet)
+}
+
+func githubSource(w http.ResponseWriter, req *http.Request) {
+	repo, owner, _, tag := parseGithubRequest(req)
+	w.Write([]byte(`{
+		"integrity": "",
+		"strip_prefix": "` + repo + `-` + tag + `",
+		"url": "https://github.com/` + owner + `/` + repo + `/archive/` + tag + `.zip"
+	}`))
+}


### PR DESCRIPTION
This allows you to use a github repo directly as a module provided it has a `MODULE.bazel` file (we could even lift that restriction, but keeping it simple for now).

Depending on the BuildBuddy repo at a commit sha (recommended, since the others can get stale):
```
bazel_dep(name = "buildbuddy", version = "github.buildbuddy-io+3b0abcc3d478b7a29ee7550eab36271076fff40c")
```

Depending on a tag:
```
bazel_dep(name = "buildbuddy", version = "github.buildbuddy-io+v1.0.0")
```

Depending on a branch:
```
bazel_dep(name = "buildbuddy", version = "github.buildbuddy-io+release_123")
```

Depending on head:
```
bazel_dep(name = "buildbuddy", version = "github.buildbuddy-io")
```