### PR TITLE
Minor tweaks to improve codesearch indexing performance a lot

### DIFF
--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -45,7 +45,7 @@ var (
 )
 
 const (
-	maxFileLen = 1 << 30
+	maxFileLen = 10_000_000
 
 	// The maximum amount of bytes from a file to use for language and
 	// mimetype detection.

--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -46,6 +46,10 @@ var (
 
 const (
 	maxFileLen = 1 << 30
+
+	// The maximum amount of bytes from a file to use for language and
+	// mimetype detection.
+	detectionBufferSize = 1000
 )
 
 func printMainHelpAndDie() {
@@ -131,14 +135,21 @@ func makeDoc(name string) (types.Document, error) {
 	// Compute a hash of the file.
 	docID := xxhash.Sum64(buf)
 
+	var shortBuf []byte
+	if len(buf) > detectionBufferSize {
+		shortBuf = buf[:detectionBufferSize]
+	} else {
+		shortBuf = buf
+	}
+
 	// Check the mimetype and skip if bad.
-	mtype, err := mimetype.DetectReader(bytes.NewReader(buf))
+	mtype, err := mimetype.DetectReader(bytes.NewReader(shortBuf))
 	if err == nil && skipMime.MatchString(mtype.String()) {
 		return nil, fmt.Errorf("%q: skipping (invalid mime type: %q)", name, mtype.String())
 	}
 
 	// Compute filetype
-	lang := strings.ToLower(enry.GetLanguage(filepath.Base(name), buf))
+	lang := strings.ToLower(enry.GetLanguage(filepath.Base(name), shortBuf))
 	doc := types.NewMapDocument(
 		docID,
 		map[string]types.NamedField{

--- a/codesearch/index/BUILD
+++ b/codesearch/index/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//server/util/status",
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_google_uuid//:uuid",
-        "@com_github_roaringbitmap_roaring//:roaring",
         "@com_github_xiam_s_expr//ast",
         "@com_github_xiam_s_expr//parser",
         "@org_golang_x_exp//slices",

--- a/codesearch/index/token.go
+++ b/codesearch/index/token.go
@@ -14,6 +14,9 @@ type Set struct {
 	sparse []uint32
 }
 
+// This is sparse.Set from:
+// https://github.com/google/codesearch/blob/master/sparse/set.go
+//
 // NewSet returns a new Set with a given maximum size.
 // The set can contain numbers in [0, max-1].
 func NewSet(max uint32) *Set {

--- a/codesearch/index/token.go
+++ b/codesearch/index/token.go
@@ -3,12 +3,64 @@ package index
 import (
 	"bufio"
 	"fmt"
+	"io"
 
-	"github.com/RoaringBitmap/roaring"
 	"github.com/buildbuddy-io/buildbuddy/codesearch/types"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
-	"io"
 )
+
+type Set struct {
+	dense  []uint32
+	sparse []uint32
+}
+
+// NewSet returns a new Set with a given maximum size.
+// The set can contain numbers in [0, max-1].
+func NewSet(max uint32) *Set {
+	return &Set{
+		sparse: make([]uint32, max),
+	}
+}
+
+// Init initializes a Set to have a given maximum size.
+// The set can contain numbers in [0, max-1].
+func (s *Set) Init(max uint32) {
+	s.sparse = make([]uint32, max)
+}
+
+// Reset clears (empties) the set.
+func (s *Set) Reset() {
+	s.dense = s.dense[:0]
+}
+
+// Add adds x to the set if it is not already there.
+func (s *Set) Add(x uint32) {
+	v := s.sparse[x]
+	if v < uint32(len(s.dense)) && s.dense[v] == x {
+		return
+	}
+	n := len(s.dense)
+	s.sparse[x] = uint32(n)
+	s.dense = append(s.dense, x)
+}
+
+// Has reports whether x is in the set.
+func (s *Set) Has(x uint32) bool {
+	v := s.sparse[x]
+	return v < uint32(len(s.dense)) && s.dense[v] == x
+}
+
+// Dense returns the values in the set.
+// The values are listed in the order in which they
+// were inserted.
+func (s *Set) Dense() []uint32 {
+	return s.dense
+}
+
+// Len returns the number of values in the set.
+func (s *Set) Len() int {
+	return len(s.dense)
+}
 
 type byteToken struct {
 	fieldType types.FieldType
@@ -55,7 +107,7 @@ func trigramToBytes(tv uint32) []byte {
 type TrigramTokenizer struct {
 	r io.ByteReader
 
-	trigrams *roaring.Bitmap
+	trigrams *Set
 	buf      []byte
 
 	n  int64
@@ -64,7 +116,7 @@ type TrigramTokenizer struct {
 
 func NewTrigramTokenizer() *TrigramTokenizer {
 	return &TrigramTokenizer{
-		trigrams: roaring.New(),
+		trigrams: NewSet(1 << 24),
 		buf:      make([]byte, 16384),
 	}
 }
@@ -75,7 +127,7 @@ func (tt *TrigramTokenizer) Reset(r io.Reader) {
 	} else {
 		tt.r = bufio.NewReader(r)
 	}
-	tt.trigrams.Clear()
+	tt.trigrams.Reset()
 	tt.buf = tt.buf[:0]
 	tt.n = 0
 	tt.tv = 0
@@ -96,7 +148,7 @@ func (tt *TrigramTokenizer) Next() (types.Token, error) {
 			continue
 		}
 
-		alreadySeen := tt.trigrams.Contains(tt.tv)
+		alreadySeen := tt.trigrams.Has(tt.tv)
 		if !alreadySeen && tt.tv != 1<<24-1 {
 			tt.trigrams.Add(tt.tv)
 			return newByteToken(types.TrigramField, trigramToBytes(tt.tv)), nil

--- a/codesearch/server/server.go
+++ b/codesearch/server/server.go
@@ -32,7 +32,7 @@ import (
 var skipMime = regexp.MustCompile(`^audio/.*|video/.*|image/.*$`)
 
 const (
-	maxFileLen = 1 << 30
+	maxFileLen = 10_000_000
 
 	// The maximum amount of bytes from a file to use for language and
 	// mimetype detection.

--- a/codesearch/server/server.go
+++ b/codesearch/server/server.go
@@ -34,6 +34,10 @@ var skipMime = regexp.MustCompile(`^audio/.*|video/.*|image/.*$`)
 const (
 	maxFileLen = 1 << 30
 
+	// The maximum amount of bytes from a file to use for language and
+	// mimetype detection.
+	detectionBufferSize = 1000
+
 	// The following field names are used in the indexed docs.
 	filenameField = "filename"
 	contentField  = "content"
@@ -74,14 +78,21 @@ func makeDoc(name, repo, commitSha string, buf []byte) (types.Document, error) {
 	// Compute a hash of the file.
 	docID := xxhash.Sum64(buf)
 
+	var shortBuf []byte
+	if len(buf) > detectionBufferSize {
+		shortBuf = buf[:detectionBufferSize]
+	} else {
+		shortBuf = buf
+	}
+
 	// Check the mimetype and skip if bad.
-	mtype, err := mimetype.DetectReader(bytes.NewReader(buf))
+	mtype, err := mimetype.DetectReader(bytes.NewReader(shortBuf))
 	if err == nil && skipMime.MatchString(mtype.String()) {
 		return nil, fmt.Errorf("%q: skipping (invalid mime type: %q)", name, mtype.String())
 	}
 
 	// Compute filetype
-	lang := strings.ToLower(enry.GetLanguage(filepath.Base(name), buf))
+	lang := strings.ToLower(enry.GetLanguage(filepath.Base(name), shortBuf))
 	doc := types.NewMapDocument(
 		docID,
 		map[string]types.NamedField{


### PR DESCRIPTION
- Perf: Use sparse set for trigrams and smaller buffers for lang/mimetype detection
- Tweak max file length down
