### PR TITLE
Disable git automatic gc

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -1851,6 +1851,9 @@ func (ws *workspace) config(ctx context.Context) error {
 		{"extensions.partialClone", "true"},
 		// Disable this check for `git fetch` performance improvements
 		{"fetch.showForcedUpdates", "false"},
+		// Disable automatic gc - it can interfere with running `rm -rf .git` in
+		// the case where we don't sync successfully.
+		{"gc.auto", "0"},
 	}
 	writeCommandSummary(ws.log, "Configuring repository...")
 	for _, kv := range cfg {


### PR DESCRIPTION
This seems to be causing `git gc --auto` to run in the background, which prevents us from running `rm -rf .git` in the case where we fail to sync the repository and need to sync from scratch.

If we need to run `git gc` in the future, we can run it manually after all actions complete.

Separately, https://github.com/buildbuddy-io/buildbuddy/pull/6756 should help us debug why the sync is failing in the first place.

**Related issues**: N/A
