### PR TITLE
Fix prettier for zsh

### DIFF
--- a/tools/prettier/prettier.sh
+++ b/tools/prettier/prettier.sh
@@ -39,7 +39,10 @@ function paths_to_format() {
   git diff --name-only --diff-filter=AMRCT "$DIFF_BASE" -- "${GIT_FILE_PATTERNS[@]}"
 }
 
-mapfile -t paths < <(paths_to_format)
+paths=()
+while read -r path; do
+  paths+=("$path")
+done < <(paths_to_format)
 
 if [[ -z "${paths[*]}" ]]; then
   exit 0


### PR DESCRIPTION
I use zsh as a shell, and it does not have the mapfile command 

**Related issues**: N/A
