### PR TITLE
[raft] pass context into nodeliveness.ensureValidLease()

### DIFF
--- a/enterprise/server/raft/nodeliveness/nodeliveness_test.go
+++ b/enterprise/server/raft/nodeliveness/nodeliveness_test.go
@@ -83,9 +83,10 @@ func (tp *testingProposer) SyncRead(ctx context.Context, _ []byte, batch *rfpb.B
 func TestAcquireAndRelease(t *testing.T) {
 	proposer := newTestingProposer(t)
 	liveness := nodeliveness.New("replicaID-1", proposer)
+	ctx := context.Background()
 
 	// Should be able to lease a liveness record.
-	err := liveness.Lease()
+	err := liveness.Lease(ctx)
 	require.NoError(t, err)
 
 	// Liveness record should be valid.
@@ -106,9 +107,10 @@ func TestKeepalive(t *testing.T) {
 	leaseDuration := 100 * time.Millisecond
 	gracePeriod := 50 * time.Millisecond
 	liveness := nodeliveness.New("replicaID-2", proposer).WithTimeouts(leaseDuration, gracePeriod)
+	ctx := context.Background()
 
 	// Should be able to lease a liveness record.
-	err := liveness.Lease()
+	err := liveness.Lease(ctx)
 	require.NoError(t, err)
 
 	// Liveness record should be valid.
@@ -126,9 +128,10 @@ func TestKeepalive(t *testing.T) {
 func TestEpochChangeOnLease(t *testing.T) {
 	proposer := newTestingProposer(t)
 	liveness := nodeliveness.New("replicaID-3", proposer)
+	ctx := context.Background()
 
 	// Should be able to lease a liveness record.
-	err := liveness.Lease()
+	err := liveness.Lease(ctx)
 	require.NoError(t, err)
 
 	// Liveness record should be valid.
@@ -136,7 +139,7 @@ func TestEpochChangeOnLease(t *testing.T) {
 	require.True(t, valid)
 
 	// Get the epoch of the liveness record.
-	nl, err := liveness.BlockingGetCurrentNodeLiveness()
+	nl, err := liveness.BlockingGetCurrentNodeLiveness(ctx)
 	require.NoError(t, err)
 	require.Equal(t, int64(0), nl.GetEpoch())
 
@@ -148,14 +151,14 @@ func TestEpochChangeOnLease(t *testing.T) {
 	// the same stored data.
 	liveness2 := nodeliveness.New("replicaID-3", proposer)
 
-	err = liveness2.Lease()
+	err = liveness2.Lease(ctx)
 	require.NoError(t, err)
 
 	valid = liveness2.Valid()
 	require.True(t, valid)
 
 	// Ensure that epoch has been incremented.
-	nl, err = liveness2.BlockingGetCurrentNodeLiveness()
+	nl, err = liveness2.BlockingGetCurrentNodeLiveness(ctx)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), nl.GetEpoch())
 }

--- a/enterprise/server/raft/rangelease/rangelease_test.go
+++ b/enterprise/server/raft/rangelease/rangelease_test.go
@@ -65,7 +65,7 @@ func newTestingProposerAndSenderAndReplica(t testing.TB) (*testutil.TestingPropo
 }
 
 func TestAcquireAndRelease(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	proposer, sender, rep := newTestingProposerAndSenderAndReplica(t)
@@ -89,17 +89,17 @@ func TestAcquireAndRelease(t *testing.T) {
 	require.NoError(t, err)
 
 	// Rangelease should be valid.
-	valid := l.Valid()
+	valid := l.Valid(ctx)
 	require.True(t, valid)
 
-	log.Printf("RangeLease: %s", l)
+	log.Printf("RangeLease: %s", l.Desc(ctx))
 
 	// Should be able to release a rangelease.
 	err = l.Release(ctx)
 	require.NoError(t, err)
 
 	// Rangelease should be invalid after release.
-	valid = l.Valid()
+	valid = l.Valid(ctx)
 	require.False(t, valid)
 }
 
@@ -128,17 +128,17 @@ func TestAcquireAndReleaseMetaRange(t *testing.T) {
 	require.NoError(t, err)
 
 	// Rangelease should be valid.
-	valid := l.Valid()
+	valid := l.Valid(ctx)
 	require.True(t, valid)
 
-	log.Printf("RangeLease: %s", l)
+	log.Printf("RangeLease: %s", l.Desc(ctx))
 
 	// Should be able to release a rangelease.
 	err = l.Release(ctx)
 	require.NoError(t, err)
 
 	// Rangelease should be invalid after release.
-	valid = l.Valid()
+	valid = l.Valid(ctx)
 	require.False(t, valid)
 }
 
@@ -169,15 +169,15 @@ func TestMetaRangeLeaseKeepalive(t *testing.T) {
 	require.NoError(t, err)
 
 	// Rangelease should be valid.
-	valid := l.Valid()
+	valid := l.Valid(ctx)
 	require.True(t, valid)
 
-	log.Printf("RangeLease: %s", l)
+	log.Printf("RangeLease: %s", l.Desc(ctx))
 	time.Sleep(2 * leaseDuration)
-	log.Printf("RangeLease: %s", l)
+	log.Printf("RangeLease: %s", l.Desc(ctx))
 
 	// Rangelease should have auto-renewed itself and should still be valid.
-	valid = l.Valid()
+	valid = l.Valid(ctx)
 	require.True(t, valid)
 
 	// Should be able to release a rangelease.
@@ -185,7 +185,7 @@ func TestMetaRangeLeaseKeepalive(t *testing.T) {
 	require.NoError(t, err)
 
 	// Rangelease should be invalid after release.
-	valid = l.Valid()
+	valid = l.Valid(ctx)
 	require.False(t, valid)
 }
 
@@ -214,17 +214,17 @@ func TestNodeEpochInvalidation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Rangelease should be valid.
-	valid := l.Valid()
+	valid := l.Valid(ctx)
 	require.True(t, valid)
 
-	log.Printf("RangeLease: %s", l)
+	log.Printf("RangeLease: %s", l.Desc(ctx))
 
 	err = liveness.Release()
 	require.NoError(t, err)
 
 	// Rangelease should be invalid after the nodeliveness record it's
 	// dependent on is released.
-	valid = l.Valid()
+	valid = l.Valid(ctx)
 	require.False(t, valid)
 
 	// Should be able to re-lease it again.
@@ -232,6 +232,6 @@ func TestNodeEpochInvalidation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Rangelease should be valid again.
-	valid = l.Valid()
+	valid = l.Valid(ctx)
 	require.True(t, valid)
 }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3496
Sometimes liveliness.ensureValidLease got stuck, and as a result it makes
liveliness.Release stuck waiting for ensureValidLease release the lock
