### PR TITLE
Bump soci-store binary version dependency to 0.0.15

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6839,16 +6839,16 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         name = "com_github_buildbuddy_io_soci_snapshotter-soci-store-linux-amd64",
         downloaded_file_path = "soci-store",
         executable = True,
-        sha256 = "2dd49ce3bcdd0f4d75c6bd427162c9e9a8dde7430f71df095e698347141d3e53",
-        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-store-v0.0.14-linux-amd64"],
+        sha256 = "0896b1df3dccd97895a5fde4bfbde47f1e533753113e39634261e2e035c9e6a3",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-store-v0.0.15-linux-amd64"],
     )
 
     http_file(
         name = "com_github_buildbuddy_io_soci_snapshotter-soci-store-linux-amd64-race",
         downloaded_file_path = "soci-store-race",
         executable = True,
-        sha256 = "46a7a65d23477c6e177292ab0a8a3bf8617e9d7a290e55e27bc55896e4a504a5",
-        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-store-v0.0.14-linux-amd64-race"],
+        sha256 = "8b420b9e94433f7fe74f71a26a34ee2c0bed6535bdb4c2176a91611e4054d0d0",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/soci-snapshotter/soci-store-v0.0.15-linux-amd64-race"],
     )
 
     http_file(


### PR DESCRIPTION
This new version of soci-store contains a couple of commits that I hope will address [ino reuse in newInodeWithID](https://github.com/containerd/stargz-snapshotter/issues/1594)
- go-fuse: [Add inode.Initialized() for checking if an inode has been initialized](https://github.com/hanwen/go-fuse/commit/dfe6a153c480d3f50af926ff9305ab34b123573c)
- soci-snapshotter: [Only reuse inos for nodes that are forgotten and initialized (actually).] (https://github.com/buildbuddy-io/soci-snapshotter/commit/a09a8130be41fc0d56b9a86bf69c8d850c2b2e59)

**Related issues**: N/A
