### PR TITLE
Make the snippets a little longer

### DIFF
--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"flag"
 	"fmt"
@@ -235,7 +236,10 @@ func handleSearch(args []string) {
 		}
 		fmt.Printf("%q [%d matches]\n", doc.Field("filename").Contents(), len(regions))
 		for _, region := range regions {
-			fmt.Print("  " + region.String())
+			scanner := bufio.NewScanner(strings.NewReader(region.String()))
+			for scanner.Scan() {
+				fmt.Print("  " + scanner.Text() + "\n")
+			}
 		}
 	}
 }

--- a/codesearch/query/regexp_query.go
+++ b/codesearch/query/regexp_query.go
@@ -27,9 +27,9 @@ const (
 var (
 	nl = []byte{'\n'}
 
-	_ types.Query = (*ReQuery)(nil)
+	_ types.Query             = (*ReQuery)(nil)
 	_ types.HighlightedRegion = (*regionMatch)(nil)
-	_ types.Scorer = (*reScorer)(nil)
+	_ types.Scorer            = (*reScorer)(nil)
 )
 
 func countNL(b []byte) int {
@@ -116,7 +116,7 @@ type reHighlighter struct {
 }
 
 type regionMatch struct {
-	field types.Field
+	field  types.Field
 	region region
 }
 
@@ -133,7 +133,7 @@ func (rm regionMatch) CustomSnippet(linesBefore, linesAfter int) string {
 	snippetText := ""
 
 	firstLine := max(lineNumber-linesBefore, 1)
-	lastLine := lineNumber+linesAfter
+	lastLine := lineNumber + linesAfter
 
 	for n := firstLine; n <= lastLine; n++ {
 		buf := extractLine(rm.field.Contents(), n)
@@ -160,7 +160,7 @@ func (h *reHighlighter) Highlight(doc types.Document) []types.HighlightedRegion 
 		for _, region := range match(matcher, field.Contents()) {
 			region := region
 			results = append(results, types.HighlightedRegion(regionMatch{
-				field: field,
+				field:  field,
 				region: region,
 			}))
 		}

--- a/codesearch/query/regexp_query.go
+++ b/codesearch/query/regexp_query.go
@@ -28,6 +28,8 @@ var (
 	nl = []byte{'\n'}
 
 	_ types.Query = (*ReQuery)(nil)
+	_ types.HighlightedRegion = (*regionMatch)(nil)
+	_ types.Scorer = (*reScorer)(nil)
 )
 
 func countNL(b []byte) int {
@@ -114,15 +116,37 @@ type reHighlighter struct {
 }
 
 type regionMatch struct {
-	fieldName string
-	snippet   string
+	field types.Field
+	region region
 }
 
 func (rm regionMatch) FieldName() string {
-	return rm.fieldName
+	return rm.field.Name()
 }
+
+func makeLine(line []byte, lineNumber int) string {
+	return fmt.Sprintf("%d: %s\n", lineNumber, line)
+}
+
+func (rm regionMatch) CustomSnippet(linesBefore, linesAfter int) string {
+	lineNumber := rm.region.lineNumber
+	snippetText := ""
+
+	firstLine := max(lineNumber-linesBefore, 1)
+	lastLine := lineNumber+linesAfter
+
+	for n := firstLine; n <= lastLine; n++ {
+		buf := extractLine(rm.field.Contents(), n)
+		if buf == nil {
+			continue
+		}
+		snippetText += makeLine(buf, n)
+	}
+	return snippetText
+}
+
 func (rm regionMatch) String() string {
-	return rm.snippet
+	return rm.CustomSnippet(0, 0)
 }
 
 func (h *reHighlighter) Highlight(doc types.Document) []types.HighlightedRegion {
@@ -134,10 +158,10 @@ func (h *reHighlighter) Highlight(doc types.Document) []types.HighlightedRegion 
 			continue
 		}
 		for _, region := range match(matcher, field.Contents()) {
-			line := extractLine(field.Contents(), region.lineNumber)
+			region := region
 			results = append(results, types.HighlightedRegion(regionMatch{
-				fieldName: fieldName,
-				snippet:   fmt.Sprintf("%d: %s\n", region.lineNumber, line),
+				field: field,
+				region: region,
 			}))
 		}
 	}

--- a/codesearch/server/server.go
+++ b/codesearch/server/server.go
@@ -218,7 +218,7 @@ func (css *codesearchServer) Search(ctx context.Context, req *srpb.SearchRequest
 		}
 		for _, region := range regions {
 			result.Snippets = append(result.Snippets, &srpb.Snippet{
-				Lines: region.String(),
+				Lines: region.CustomSnippet(1, 1),
 			})
 		}
 		rsp.Results = append(rsp.Results, result)

--- a/codesearch/types/types.go
+++ b/codesearch/types/types.go
@@ -68,6 +68,7 @@ type Scorer interface {
 type HighlightedRegion interface {
 	FieldName() string
 	String() string
+	CustomSnippet(linesBefore, linesAfter int) string
 }
 
 type Highlighter interface {


### PR DESCRIPTION
Adds a configurable CustomSnippet method and uses it in the server (but not the cli) to return more context (1 line in either direction) around match snippets.