### PR TITLE
[raft] stop liveness.renewLease() on context cancel

### DIFF
--- a/enterprise/server/raft/nodeliveness/nodeliveness_test.go
+++ b/enterprise/server/raft/nodeliveness/nodeliveness_test.go
@@ -82,8 +82,8 @@ func (tp *testingProposer) SyncRead(ctx context.Context, _ []byte, batch *rfpb.B
 
 func TestAcquireAndRelease(t *testing.T) {
 	proposer := newTestingProposer(t)
-	liveness := nodeliveness.New("replicaID-1", proposer)
 	ctx := context.Background()
+	liveness := nodeliveness.New(ctx, "replicaID-1", proposer)
 
 	// Should be able to lease a liveness record.
 	err := liveness.Lease(ctx)
@@ -106,8 +106,8 @@ func TestKeepalive(t *testing.T) {
 	proposer := newTestingProposer(t)
 	leaseDuration := 100 * time.Millisecond
 	gracePeriod := 50 * time.Millisecond
-	liveness := nodeliveness.New("replicaID-2", proposer).WithTimeouts(leaseDuration, gracePeriod)
 	ctx := context.Background()
+	liveness := nodeliveness.New(ctx, "replicaID-2", proposer).WithTimeouts(leaseDuration, gracePeriod)
 
 	// Should be able to lease a liveness record.
 	err := liveness.Lease(ctx)
@@ -127,8 +127,8 @@ func TestKeepalive(t *testing.T) {
 
 func TestEpochChangeOnLease(t *testing.T) {
 	proposer := newTestingProposer(t)
-	liveness := nodeliveness.New("replicaID-3", proposer)
 	ctx := context.Background()
+	liveness := nodeliveness.New(ctx, "replicaID-3", proposer)
 
 	// Should be able to lease a liveness record.
 	err := liveness.Lease(ctx)
@@ -149,7 +149,7 @@ func TestEpochChangeOnLease(t *testing.T) {
 
 	// Re-acquire it, using a new nodeliveness object, but
 	// the same stored data.
-	liveness2 := nodeliveness.New("replicaID-3", proposer)
+	liveness2 := nodeliveness.New(ctx, "replicaID-3", proposer)
 
 	err = liveness2.Lease(ctx)
 	require.NoError(t, err)

--- a/enterprise/server/raft/rangelease/rangelease_test.go
+++ b/enterprise/server/raft/rangelease/rangelease_test.go
@@ -65,11 +65,12 @@ func newTestingProposerAndSenderAndReplica(t testing.TB) (*testutil.TestingPropo
 }
 
 func TestAcquireAndRelease(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	bgCtx := context.Background()
+	ctx, cancel := context.WithTimeout(bgCtx, 3*time.Second)
 	defer cancel()
 
 	proposer, sender, rep := newTestingProposerAndSenderAndReplica(t)
-	liveness := nodeliveness.New("replicaID-1", sender)
+	liveness := nodeliveness.New(bgCtx, "replicaID-1", sender)
 	session := client.NewSession()
 
 	rd := &rfpb.RangeDescriptor{
@@ -104,11 +105,12 @@ func TestAcquireAndRelease(t *testing.T) {
 }
 
 func TestAcquireAndReleaseMetaRange(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
+	bgCtx := context.Background()
+	ctx, cancel := context.WithTimeout(bgCtx, 3*time.Second)
 	defer cancel()
 
 	proposer, sender, rep := newTestingProposerAndSenderAndReplica(t)
-	liveness := nodeliveness.New("replicaID-2", sender)
+	liveness := nodeliveness.New(bgCtx, "replicaID-2", sender)
 	session := client.NewSession()
 
 	rd := &rfpb.RangeDescriptor{
@@ -143,11 +145,12 @@ func TestAcquireAndReleaseMetaRange(t *testing.T) {
 }
 
 func TestMetaRangeLeaseKeepalive(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
+	bgCtx := context.Background()
+	ctx, cancel := context.WithTimeout(bgCtx, 3*time.Second)
 	defer cancel()
 
 	proposer, sender, rep := newTestingProposerAndSenderAndReplica(t)
-	liveness := nodeliveness.New("replicaID-3", sender)
+	liveness := nodeliveness.New(bgCtx, "replicaID-3", sender)
 	session := client.NewSession()
 
 	rd := &rfpb.RangeDescriptor{
@@ -190,11 +193,12 @@ func TestMetaRangeLeaseKeepalive(t *testing.T) {
 }
 
 func TestNodeEpochInvalidation(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
+	bgCtx := context.Background()
+	ctx, cancel := context.WithTimeout(bgCtx, 3*time.Second)
 	defer cancel()
 
 	proposer, sender, rep := newTestingProposerAndSenderAndReplica(t)
-	liveness := nodeliveness.New("replicaID-4", sender)
+	liveness := nodeliveness.New(bgCtx, "replicaID-4", sender)
 	session := client.NewSession()
 
 	rd := &rfpb.RangeDescriptor{

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -172,7 +172,7 @@ func New(env environment.Env, rootDir, raftAddress, grpcAddr string, partitions 
 }
 
 func NewWithArgs(env environment.Env, rootDir string, nodeHost *dragonboat.NodeHost, gossipManager interfaces.GossipService, sender *sender.Sender, registry registry.NodeRegistry, listener *listener.RaftListener, apiClient *client.APIClient, grpcAddress string, partitions []disk.Partition, db pebble.IPebbleDB, leaser pebble.Leaser, clock clockwork.Clock) (*Store, error) {
-	nodeLiveness := nodeliveness.New(nodeHost.ID(), sender)
+	nodeLiveness := nodeliveness.New(env.GetServerContext(), nodeHost.ID(), sender)
 
 	nhLog := log.NamedSubLogger(nodeHost.ID())
 	eventsChan := make(chan events.Event, 100)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3496
On shutdown, liveness.Release() got stuck because liveness.ensureValidLease()
kept the lock and stuck in the renew loop; but ensureValidLease() could not
finish b/c two other stores are already shut down.
