### PR TITLE
Enable mysql query interpolation.

### DIFF
--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -534,7 +534,7 @@ func openDB(ctx context.Context, dataSource string, advancedConfig *AdvancedConf
 	if *logQueries {
 		l.LogLevel = logger.Info
 	}
-	config := gorm.Config{Logger: l, SkipDefaultTransaction: true}
+	config := gorm.Config{Logger: l, SkipDefaultTransaction: true, PrepareStmt: true}
 	gdb, err := gorm.Open(dialector, &config)
 	if err != nil {
 		return nil, "", err

--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -534,10 +534,7 @@ func openDB(ctx context.Context, dataSource string, advancedConfig *AdvancedConf
 	if *logQueries {
 		l.LogLevel = logger.Info
 	}
-	config := gorm.Config{
-		Logger:                 l,
-		SkipDefaultTransaction: true,
-	}
+	config := gorm.Config{Logger: l, SkipDefaultTransaction: true}
 	gdb, err := gorm.Open(dialector, &config)
 	if err != nil {
 		return nil, "", err

--- a/server/util/db/db.go
+++ b/server/util/db/db.go
@@ -512,16 +512,19 @@ func openDB(ctx context.Context, dataSource string, advancedConfig *AdvancedConf
 	// connection.
 	db := sql.OpenDB(&connector{d: drv, ds: ds})
 
+	cachePreparedStatements := false
 	var dialector gorm.Dialector
 	switch ds.DriverName() {
 	case sqliteDriver:
 		dialector = sqlite.Dialector{Conn: db}
 	case mysqlDriver:
+		cachePreparedStatements = true
 		// Set default string size to 255 to avoid unnecessary schema modifications by GORM.
 		// Newer versions of GORM use a smaller default size (191) to account for InnoDB index limits
 		// that don't apply to modern MysQL installations.
 		dialector = mysql.New(mysql.Config{Conn: db, DefaultStringSize: 255})
 	case postgresDriver:
+		cachePreparedStatements = true
 		dialector = postgres.Dialector{Config: &postgres.Config{Conn: db}}
 	default:
 		return nil, "", fmt.Errorf("unsupported database driver %s", ds.DriverName())
@@ -534,7 +537,11 @@ func openDB(ctx context.Context, dataSource string, advancedConfig *AdvancedConf
 	if *logQueries {
 		l.LogLevel = logger.Info
 	}
-	config := gorm.Config{Logger: l, SkipDefaultTransaction: true, PrepareStmt: true}
+	config := gorm.Config{
+		Logger:                 l,
+		SkipDefaultTransaction: true,
+		PrepareStmt:            cachePreparedStatements,
+	}
 	gdb, err := gorm.Open(dialector, &config)
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
Turns out it was the MySQL driver that was falling back to prepared statements, not GORM.
If the MySQL driver received a query with arguments, it forced the caller to use a prepare/execute combination which requires two round trips. MySQL has an option called 'interpolateParams' that does the interpolation client side in the driver instead of relying on the server. 

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
