### PR TITLE
Add simple invocation-level coverage tab / report

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -19,6 +19,7 @@ ts_library(
         "//app/invocation:invocation_bot_card",
         "//app/invocation:invocation_build_logs_card",
         "//app/invocation:invocation_cache_card",
+        "//app/invocation:invocation_coverage_card",
         "//app/invocation:invocation_details_card",
         "//app/invocation:invocation_error_card",
         "//app/invocation:invocation_execution_card",
@@ -797,5 +798,26 @@ ts_library(
         "//app/util:rpc",
         "//proto:execution_stats_ts_proto",
         "//proto:remote_execution_ts_proto",
+    ],
+)
+
+ts_library(
+    name = "invocation_coverage_card",
+    srcs = ["invocation_coverage_card.tsx"],
+    deps = [
+        "//app/components/button",
+        "//app/docs:setup_code",
+        "//app/errors:error_service",
+        "//app/format",
+        "//app/invocation:invocation_model",
+        "//app/invocation:invocation_suggestion_card",
+        "//app/service:rpc_service",
+        "//app/util:color",
+        "//app/util:lcov",
+        "//proto:build_event_stream_ts_proto",
+        "@npm//@types/react",
+        "@npm//lucide-react",
+        "@npm//react",
+        "@npm//tslib",
     ],
 )

--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -810,7 +810,6 @@ ts_library(
         "//app/errors:error_service",
         "//app/format",
         "//app/invocation:invocation_model",
-        "//app/invocation:invocation_suggestion_card",
         "//app/service:rpc_service",
         "//app/util:color",
         "//app/util:lcov",

--- a/app/invocation/invocation.tsx
+++ b/app/invocation/invocation.tsx
@@ -44,6 +44,7 @@ import { InvocationBotCard } from "./invocation_bot_card";
 import TargetV2Component from "../target/target_v2";
 import { ExecuteOperation, ExecutionStage, executionStatusLabel, waitExecution } from "./execution_status";
 import { PlayCircle, PlayCircleIcon } from "lucide-react";
+import InvocationCoverageCardComponent from "./invocation_coverage_card";
 
 interface State {
   loading: boolean;
@@ -485,6 +486,7 @@ export default class InvocationComponent extends React.Component<Props, State> {
               this.state.model.isWorkflowInvocation() ||
               this.state.model.isHostedBazelInvocation()
             }
+            hasCoverage={this.state.model.hasCoverage()}
             hasSuggestions={suggestions.length > 0}
           />
 
@@ -580,6 +582,8 @@ export default class InvocationComponent extends React.Component<Props, State> {
           )}
 
           {activeTab === "timing" && <TimingCardComponent model={this.state.model} />}
+
+          {activeTab === "coverage" && <InvocationCoverageCardComponent model={this.state.model} />}
 
           {activeTab === "action" && (
             <InvocationActionCardComponent

--- a/app/invocation/invocation_coverage_card.tsx
+++ b/app/invocation/invocation_coverage_card.tsx
@@ -1,0 +1,196 @@
+import React from "react";
+import SetupCodeComponent from "../docs/setup_code";
+import rpcService from "../service/rpc_service";
+import InvocationModel from "./invocation_model";
+import Button from "../components/button/button";
+import { Clock, ListChecks } from "lucide-react";
+import errorService from "../errors/error_service";
+import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
+import { parseLcov } from "../util/lcov";
+import format from "../format/format";
+import { percentageColor } from "../util/color";
+
+interface Props {
+  model: InvocationModel;
+}
+
+interface State {
+  report: any[] | null;
+  loading: boolean;
+}
+
+export default class InvocationCoverageCardComponent extends React.Component<Props, State> {
+  state: State = {
+    report: null,
+    loading: true,
+  };
+
+  componentDidMount() {
+    this.fetchProfile();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.model !== prevProps.model) {
+      this.fetchProfile();
+    }
+  }
+
+  getReportFile(): build_event_stream.File | undefined {
+    return this.props.model.buildToolLogs?.log.find(
+      (log: build_event_stream.File) => log.name == "coverage_report.lcov" && log.uri
+    );
+  }
+
+  isCoverageEnabled() {
+    return Boolean(this.getReportFile()?.uri?.startsWith("bytestream://"));
+  }
+
+  fetchProfile() {
+    if (!this.isCoverageEnabled()) {
+      this.setState({ loading: false });
+    }
+
+    // Already fetched
+    if (this.state.report) return;
+
+    let profileFile = this.getReportFile();
+    if (!profileFile?.uri) return;
+
+    this.setState({ loading: true });
+
+    rpcService
+      .fetchBytestreamFile(profileFile.uri, this.props.model.getInvocationId(), "text")
+      .then((response) => {
+        this.setState({ report: parseLcov(response) });
+      })
+      .catch((e) => errorService.handleError(e))
+      .finally(() => this.setState({ loading: false }));
+  }
+
+  downloadReport() {
+    let profileFile = this.getReportFile();
+    if (!profileFile?.uri) {
+      return;
+    }
+
+    try {
+      rpcService.downloadBytestreamFile("coverage_report.lcov", profileFile.uri, this.props.model.getInvocationId());
+    } catch {
+      console.error("Error downloading bytestream coverage report");
+    }
+  }
+
+  renderEmptyState() {
+    if (this.state.loading) {
+      return (
+        <div>
+          <div className="loading" />
+        </div>
+      );
+    }
+
+    if (!this.props.model.buildToolLogs) {
+      return <>Build is in progress...</>;
+    }
+
+    // Note: This profile file should be present even if remote cache is disabled,
+    // so enabling remote cache won't fix a missing profile. Show a special message
+    // for this case.
+    if (!this.getReportFile()) {
+      return (
+        <>
+          Could not find coverage report. This might be because Bazel was invoked without the --combined_report=lcov
+          flag.
+        </>
+      );
+    }
+
+    return (
+      <>
+        <p>Coverage isn't enabled for this invocation. To enable coverage you must add gRPC remote caching.</p>
+        <SetupCodeComponent
+          requireCacheEnabled
+          instructionsHeader={
+            <p>
+              To enable remote caching, check <b>Enable cache</b> below, update your <b>.bazelrc</b> accordingly, and
+              re-run your invocation:
+            </p>
+          }
+        />
+      </>
+    );
+  }
+
+  render() {
+    if (!this.state.report) {
+      return (
+        <div className="card">
+          <ListChecks className="icon" />
+          <div className="content">
+            <div className="header">
+              <div className="title">Coverage</div>
+            </div>
+            <div className="empty-state">{this.renderEmptyState()}</div>
+          </div>
+        </div>
+      );
+    }
+
+    let testCoverageUrl = this.getReportFile()?.uri;
+
+    let repoPath = "";
+    if (this.props.model.getRepo()?.includes("github.com")) {
+      repoPath = `/code/${format.formatGitUrl(this.props.model.getRepo())}/`;
+    }
+
+    return (
+      <>
+        <div className="card">
+          <ListChecks className="icon" />
+          <div className="content">
+            <div className="header">
+              <div className="title">Coverage</div>
+              {Boolean(this.getReportFile()?.uri) && (
+                <div className="button">
+                  <Button className="download-gz-file" onClick={this.downloadReport.bind(this)}>
+                    Download coverage report
+                  </Button>
+                </div>
+              )}
+            </div>
+
+            <div className="details">
+              {this.state.report &&
+                this.state.report.length > 0 &&
+                this.state.report
+                  .filter((record) => Boolean(record.sourceFile))
+                  .map((record) => {
+                    const percent = (record.numLinesHit * 1.0) / record.numLinesFound;
+                    return (
+                      <div className="coverage-record">
+                        <a
+                          href={
+                            repoPath
+                              ? `${repoPath}${
+                                  record.sourceFile
+                                }?lcov=${testCoverageUrl}&invocation_id=${this.props.model.getInvocationId()}&commit=${this.props.model.getCommit()}`
+                              : "#"
+                          }>
+                          <span className="coverage-source">{record.sourceFile}</span>:{" "}
+                          <span className="coverage-percent" style={{ color: percentageColor(percent) }}>
+                            {format.percent(percent)}%
+                          </span>{" "}
+                          <span className="coverage-details">
+                            ({record.numLinesHit} hits / {record.numLinesFound} lines)
+                          </span>
+                        </a>
+                      </div>
+                    );
+                  })}
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  }
+}

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -458,11 +458,12 @@ export default class InvocationModel {
   }
 
   getIsExecutionLogEnabled() {
-    return (
-      this.buildToolLogs?.log.find(
-        (l) => (l.name == "execution.log" || l.name == "execution_log.binpb.zst") && l.uri.startsWith("bytestream://")
-      ) && this.stringCommandLineOption("remote_build_event_upload") == "all"
-    );
+    return Boolean(this.buildToolLogs?.log.find(
+        (l: any) => (l.name == "execution.log" || l.name == "execution_log.binpb.zst") && l.uri.startsWith("bytestream://")));
+  }
+
+  hasCoverage() {
+    return this.getCommand() == "coverage" && Boolean(this.buildToolLogs?.log.find((l: any) => l.name == "coverage_report.lcov" && l.uri.startsWith("bytestream://")));
   }
 
   getFetchURLs() {

--- a/app/invocation/invocation_model.tsx
+++ b/app/invocation/invocation_model.tsx
@@ -458,12 +458,21 @@ export default class InvocationModel {
   }
 
   getIsExecutionLogEnabled() {
-    return Boolean(this.buildToolLogs?.log.find(
-        (l: any) => (l.name == "execution.log" || l.name == "execution_log.binpb.zst") && l.uri.startsWith("bytestream://")));
+    return Boolean(
+      this.buildToolLogs?.log.find(
+        (l: any) =>
+          (l.name == "execution.log" || l.name == "execution_log.binpb.zst") && l.uri.startsWith("bytestream://")
+      )
+    );
   }
 
   hasCoverage() {
-    return this.getCommand() == "coverage" && Boolean(this.buildToolLogs?.log.find((l: any) => l.name == "coverage_report.lcov" && l.uri.startsWith("bytestream://")));
+    return (
+      this.getCommand() == "coverage" &&
+      Boolean(
+        this.buildToolLogs?.log.find((l: any) => l.name == "coverage_report.lcov" && l.uri.startsWith("bytestream://"))
+      )
+    );
   }
 
   getFetchURLs() {

--- a/app/invocation/invocation_tabs.tsx
+++ b/app/invocation/invocation_tabs.tsx
@@ -13,6 +13,7 @@ export type TabsContext = {
   role: string;
   executionsEnabled?: boolean;
   hasSuggestions?: boolean;
+  hasCoverage?: boolean;
 };
 
 export type TabId =
@@ -27,6 +28,7 @@ export type TabId =
   | "raw"
   | "execution"
   | "fetches"
+  | "coverage"
   | "action";
 
 export function getTabId(tab: string): TabId {
@@ -62,6 +64,7 @@ export default class InvocationTabsComponent extends React.Component<InvocationT
         {this.renderTab("artifacts", { label: "Artifacts" })}
         {isBazelInvocation && this.renderTab("timing", { label: "Timing" })}
         {isBazelInvocation && this.renderTab("cache", { label: "Cache" })}
+        {this.props.hasCoverage && this.renderTab("coverage", { label: "Coverage" })}
         {this.props.executionsEnabled && this.renderTab("execution", { label: "Executions" })}
         {this.props.hasSuggestions && this.renderTab("suggestions", { label: "Suggestions" })}
         {this.renderTab("raw", { label: "Raw" })}


### PR DESCRIPTION
We can get fancier with the rendering later.

Screenshot:

<img width="1489" alt="Screenshot 2024-06-11 at 1 44 20 PM" src="https://github.com/buildbuddy-io/buildbuddy/assets/1704556/355c76bc-0a92-445f-bf29-03074132c3fe">
