### PR TITLE
Add basic image support to OCI runtime isolation

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//server/util/disk",
         "//server/util/log",
         "//server/util/status",
+        "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_opencontainers_runtime_spec//specs-go",
         "@org_golang_x_sys//unix",
     ],
@@ -33,8 +34,11 @@ go_test(
     name = "ociruntime_test",
     srcs = ["ociruntime_test.go"],
     data = [":crun"],
+    exec_properties = {
+        "test.workload-isolation-type": "firecracker",
+        "test.EstimatedComputeUnits": "2",
+    },
     tags = [
-        "manual",
         "no-sandbox",
     ],
     target_compatible_with = ["@platforms//os:linux"],
@@ -44,6 +48,8 @@ go_test(
     deps = [
         ":ociruntime",
         "//enterprise/server/remote_execution/container",
+        "//enterprise/server/remote_execution/platform",
+        "//enterprise/server/util/oci",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/testutil/testenv",

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//server/util/status",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_opencontainers_runtime_spec//specs-go",
+        "@org_golang_x_sync//errgroup",
         "@org_golang_x_sys//unix",
     ],
 )

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -39,6 +39,9 @@ go_test(
         "test.EstimatedComputeUnits": "2",
     },
     tags = [
+        # TODO: remove manual tag once cgroup_v2_only flag is rolled out
+        # to executors. crun doesn't support cgroup v1+v2 "hybrid" mode.
+        "manual",
         "no-sandbox",
     ],
     target_compatible_with = ["@platforms//os:linux"],

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	ctr "github.com/google/go-containerregistry/pkg/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -40,7 +41,11 @@ const (
 	ociVersion = "1.1.0-rc.3" // matches podman
 
 	// Execution root directory path relative to the container rootfs directory.
-	execrootPath = "buildbuddy-execroot"
+	execrootPath = "/buildbuddy-execroot"
+
+	// Fake image ref indicating that busybox should be manually provisioned.
+	// TODO: get rid of this
+	TestBusyboxImageRef = "test.buildbuddy.io/busybox"
 )
 
 //go:embed seccomp.json
@@ -79,8 +84,20 @@ var (
 
 type provider struct {
 	// Root directory where all container runtime information will be located.
-	// Each directory corresponds to a created container instance.
+	// Each subdirectory corresponds to a created container instance.
 	containersRoot string
+
+	// Root directory where all image layer contents will be located.
+	// This directory is structured like the following:
+	//
+	// - {layersRoot}/
+	//   - {hashingAlgorithm}/
+	//     - {hash}/
+	//       - /bin/ # layer contents
+	//       - /usr/
+	//       - ...
+	layersRoot string
+
 	// Configured runtime path.
 	runtime string
 }
@@ -100,14 +117,19 @@ func NewProvider(env environment.Env, buildRoot string) (*provider, error) {
 		return nil, status.FailedPreconditionError("could not find a usable container runtime in PATH")
 	}
 
-	// TODO: make this configurable via flag
-	containersRoot := filepath.Join(buildRoot, "executor", "oci-run")
+	// TODO: make these root dirs configurable via flag
+	containersRoot := filepath.Join(buildRoot, "executor", "oci", "run")
 	if err := os.MkdirAll(containersRoot, 0755); err != nil {
+		return nil, err
+	}
+	layersRoot := filepath.Join(buildRoot, "executor", "oci", "layers")
+	if err := os.MkdirAll(layersRoot, 0755); err != nil {
 		return nil, err
 	}
 	return &provider{
 		runtime:        rt,
 		containersRoot: containersRoot,
+		layersRoot:     layersRoot,
 	}, nil
 }
 
@@ -115,15 +137,22 @@ func (p *provider) New(ctx context.Context, args *container.Init) (container.Com
 	return &ociContainer{
 		runtime:        p.runtime,
 		containersRoot: p.containersRoot,
+		layersRoot:     p.layersRoot,
+		imageRef:       args.Props.ContainerImage,
 	}, nil
 }
 
 type ociContainer struct {
 	runtime        string
 	containersRoot string
+	layersRoot     string
 
 	cid     string
 	workDir string
+
+	imageRef         string
+	layerDigests     []ctr.Hash
+	overlayfsMounted bool
 }
 
 // Returns the OCI bundle directory for the container.
@@ -134,6 +163,12 @@ func (c *ociContainer) bundlePath() string {
 // Returns the standard rootfs path expected by crun.
 func (c *ociContainer) rootfsPath() string {
 	return filepath.Join(c.bundlePath(), "rootfs")
+}
+
+// Returns the root path where overlay workdir and upperdir for this container
+// are stored.
+func (c *ociContainer) overlayTmpPath() string {
+	return c.workDir + ".overlay"
 }
 
 // Returns the standard config.json path expected by crun.
@@ -159,7 +194,7 @@ func (c *ociContainer) createBundle(ctx context.Context, cmd *repb.Command) erro
 		return fmt.Errorf("write hosts file: %w", err)
 	}
 
-	// Create rootfs - just busybox for now
+	// Create rootfs
 	if err := c.createRootfs(ctx); err != nil {
 		return fmt.Errorf("create rootfs: %w", err)
 	}
@@ -176,8 +211,6 @@ func (c *ociContainer) createBundle(ctx context.Context, cmd *repb.Command) erro
 	if err := os.WriteFile(c.configPath(), b, 0644); err != nil {
 		return err
 	}
-	os.Stderr.Write(b)
-	os.Stderr.WriteString("\n")
 
 	return nil
 }
@@ -191,7 +224,20 @@ func (c *ociContainer) IsImageCached(ctx context.Context) (bool, error) {
 }
 
 func (c *ociContainer) PullImage(ctx context.Context, creds oci.Credentials) error {
-	return nil // TODO: implement
+	layers, err := oci.Pull(ctx, c.layersRoot, c.imageRef, creds)
+	if err != nil {
+		return status.WrapError(err, "pull OCI image")
+	}
+	var layerDigests []ctr.Hash
+	for _, layer := range layers {
+		d, err := layer.Digest()
+		if err != nil {
+			return status.UnavailableErrorf("get layer digest: %s", err)
+		}
+		layerDigests = append(layerDigests, d)
+	}
+	c.layerDigests = layerDigests
+	return nil
 }
 
 func (c *ociContainer) Run(ctx context.Context, cmd *repb.Command, workDir string, creds oci.Credentials) *interfaces.CommandResult {
@@ -246,6 +292,7 @@ func (c *ociContainer) Unpause(ctx context.Context) error {
 	return nil // TODO: implement
 }
 
+//nolint:nilness
 func (c *ociContainer) Remove(ctx context.Context) error {
 	if c.cid == "" {
 		// We haven't created anything yet
@@ -254,12 +301,18 @@ func (c *ociContainer) Remove(ctx context.Context) error {
 
 	var firstErr error
 
-	if err := c.invokeRuntimeSimple(ctx, "delete", "--force", c.cid); err != nil {
-		firstErr = status.UnavailableErrorf("failed to delete container: %s", err)
+	if err := c.invokeRuntimeSimple(ctx, "delete", "--force", c.cid); err != nil && firstErr == nil {
+		firstErr = status.UnavailableErrorf("delete container: %s", err)
+	}
+
+	if c.overlayfsMounted {
+		if err := syscall.Unmount(c.rootfsPath(), syscall.MNT_FORCE); err != nil && firstErr == nil {
+			firstErr = status.UnavailableErrorf("unmount overlayfs: %s", err)
+		}
 	}
 
 	if err := os.RemoveAll(c.bundlePath()); err != nil && firstErr == nil {
-		firstErr = status.UnavailableErrorf("failed to remove bundle: %s", err)
+		firstErr = status.UnavailableErrorf("remove bundle: %s", err)
 	}
 
 	return firstErr
@@ -275,11 +328,45 @@ func (c *ociContainer) createRootfs(ctx context.Context) error {
 		return fmt.Errorf("create rootfs dir: %w", err)
 	}
 
-	// TODO: use container image
-	if err := installBusybox(c.rootfsPath()); err != nil {
-		return fmt.Errorf("install busybox: %w", err)
+	// For testing only, support a fake image ref that means "install busybox
+	// manually".
+	// TODO: improve testing setup and get rid of this
+	if c.imageRef == TestBusyboxImageRef {
+		return installBusybox(c.rootfsPath())
 	}
 
+	if c.imageRef == "" {
+		// No image specified (sandbox-only).
+		return nil
+	}
+
+	// Create an overlayfs with the pulled image layers.
+	var lowerDirs []string
+	for _, d := range c.layerDigests {
+		lowerDirs = append(lowerDirs, oci.LayerPath(c.layersRoot, d))
+	}
+	// Create workdir and upperdir.
+	workdir := filepath.Join(c.overlayTmpPath(), "work")
+	if err := os.MkdirAll(workdir, 0755); err != nil {
+		return fmt.Errorf("create overlay workdir: %w", err)
+	}
+	upperdir := filepath.Join(c.overlayTmpPath(), "upper")
+	if err := os.MkdirAll(upperdir, 0755); err != nil {
+		return fmt.Errorf("create overlay upperdir: %w", err)
+	}
+
+	// TODO: do this mount inside a namespace so that it gets removed even if
+	// the executor crashes (also needed for rootless support)
+
+	// - userxattr is needed for compatibility with older kernels
+	// - volatile disables fsync, as a performance optimization
+	options := fmt.Sprintf(
+		"lowerdir=%s,upperdir=%s,workdir=%s,userxattr,volatile",
+		strings.Join(lowerDirs, ":"), upperdir, workdir)
+	if err := syscall.Mount("none", c.rootfsPath(), "overlay", 0, options); err != nil {
+		return fmt.Errorf("mount overlayfs: %w", err)
+	}
+	c.overlayfsMounted = true
 	return nil
 }
 
@@ -344,10 +431,8 @@ func (c *ociContainer) createSpec(cmd *repb.Command) (*specs.Spec, error) {
 			ApparmorProfile: "",
 		},
 		Root: &specs.Root{
-			// TODO: container image FS
-			Path: c.rootfsPath(),
-			// TODO: not readonly
-			Readonly: true,
+			Path:     c.rootfsPath(),
+			Readonly: false,
 		},
 		Hostname: c.hostname(),
 		Mounts: []specs.Mount{
@@ -532,7 +617,10 @@ func (c *ociContainer) invokeRuntime(ctx context.Context, command *repb.Command,
 		// "strace", "-o", "/tmp/strace.log",
 		c.runtime,
 		"--log-format=json",
-		"--cgroup-manager=cgroupfs",
+	}
+	runtimeName := filepath.Base(c.runtime)
+	if runtimeName == "crun" {
+		globalArgs = append(globalArgs, "--cgroup-manager=cgroupfs")
 	}
 	if *runtimeRoot != "" {
 		globalArgs = append(globalArgs, "--root="+*runtimeRoot)

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -2,13 +2,19 @@ package ociruntime_test
 
 import (
 	"context"
+	"io/fs"
 	"log"
+	"os/exec"
+	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/ociruntime"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/util/oci"
 	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
 	"github.com/buildbuddy-io/buildbuddy/server/testutil/testfs"
@@ -30,7 +36,31 @@ func init() {
 	*ociruntime.Runtime = runtimePath
 }
 
+// Returns a special image ref indicating that a busybox-based rootfs should
+// be provisioned using the 'busybox' binary on the host machine.
+// Skips the test if busybox is not available.
+// TODO: use a static test binary + empty rootfs, instead of relying on busybox
+// for testing
+func manuallyProvisionedBusyboxImage(t *testing.T) string {
+	if _, err := exec.LookPath("busybox"); err != nil {
+		t.Skipf("skipping test due to missing busybox: %s", err)
+	}
+	return ociruntime.TestBusyboxImageRef
+}
+
+// Returns an image ref pointing to a remotely hosted busybox image.
+// Skips the test if we don't have mount permissions.
+// TODO: support rootless overlayfs mounts and get rid of this
+func realBusyboxImage(t *testing.T) string {
+	if !hasMountPermissions(t) {
+		t.Skipf("using a real container image with overlayfs requires mount permissions")
+	}
+	return "mirror.gcr.io/library/busybox"
+}
+
 func TestCreateExecRemove(t *testing.T) {
+	image := manuallyProvisionedBusyboxImage(t)
+
 	ctx := context.Background()
 	env := testenv.GetTestEnv(t)
 
@@ -43,8 +73,12 @@ func TestCreateExecRemove(t *testing.T) {
 	require.NoError(t, err)
 	wd := testfs.MakeDirAll(t, buildRoot, "work")
 
+	c, err := provider.New(ctx, &container.Init{Props: &platform.Properties{
+		ContainerImage: image,
+	}})
+	require.NoError(t, err)
+
 	// Create
-	c, err := provider.New(ctx, &container.Init{})
 	require.NoError(t, err)
 	err = c.Create(ctx, wd)
 	require.NoError(t, err)
@@ -66,7 +100,69 @@ func TestCreateExecRemove(t *testing.T) {
 	assert.Equal(t, "buildbuddy was here: /buildbuddy-execroot\n", string(res.Stdout))
 }
 
+func TestPullCreateExecRemove(t *testing.T) {
+	image := realBusyboxImage(t)
+
+	ctx := context.Background()
+	env := testenv.GetTestEnv(t)
+
+	runtimeRoot := testfs.MakeTempDir(t)
+	flags.Set(t, "executor.oci.runtime_root", runtimeRoot)
+
+	buildRoot := testfs.MakeTempDir(t)
+
+	provider, err := ociruntime.NewProvider(env, buildRoot)
+	require.NoError(t, err)
+	wd := testfs.MakeDirAll(t, buildRoot, "work")
+
+	c, err := provider.New(ctx, &container.Init{
+		Props: &platform.Properties{
+			ContainerImage: image,
+		},
+	})
+	require.NoError(t, err)
+
+	// Pull
+	err = c.PullImage(ctx, oci.Credentials{})
+	require.NoError(t, err)
+
+	// Create
+	require.NoError(t, err)
+	err = c.Create(ctx, wd)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err = c.Remove(ctx)
+		require.NoError(t, err)
+	})
+
+	// Exec
+	cmd := &repb.Command{Arguments: []string{"sh", "-ec", `
+		touch /bin/foo.txt
+		pwd
+	`}}
+	stdio := interfaces.Stdio{}
+	res := c.Exec(ctx, cmd, &stdio)
+	require.NoError(t, res.Error)
+
+	assert.Equal(t, 0, res.ExitCode)
+	assert.Empty(t, string(res.Stderr))
+	assert.Equal(t, "/buildbuddy-execroot\n", string(res.Stdout))
+
+	// Make sure the image layers were unmodified and that foo.txt was written
+	// to the upper dir in the overlayfs.
+	layersRoot := filepath.Join(buildRoot, "executor", "oci", "layers")
+	err = filepath.WalkDir(layersRoot, func(path string, entry fs.DirEntry, err error) error {
+		require.NoError(t, err)
+		assert.NotEqual(t, entry.Name(), "foo.txt")
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, testfs.Exists(t, "", filepath.Join(wd+".overlay", "upper", "bin", "foo.txt")))
+}
+
 func TestCreateFailureHasStderr(t *testing.T) {
+	image := manuallyProvisionedBusyboxImage(t)
+
 	ctx := context.Background()
 	env := testenv.GetTestEnv(t)
 
@@ -80,8 +176,23 @@ func TestCreateFailureHasStderr(t *testing.T) {
 	wd := testfs.MakeDirAll(t, buildRoot, "work")
 
 	// Create
-	c, err := provider.New(ctx, &container.Init{})
+	c, err := provider.New(ctx, &container.Init{
+		Props: &platform.Properties{
+			ContainerImage: image,
+		},
+	})
 	require.NoError(t, err)
 	err = c.Create(ctx, wd+"nonexistent")
 	require.ErrorContains(t, err, "nonexistent")
+}
+
+func hasMountPermissions(t *testing.T) bool {
+	dir1 := testfs.MakeTempDir(t)
+	dir2 := testfs.MakeTempDir(t)
+	if err := syscall.Mount(dir1, dir2, "", syscall.MS_BIND, ""); err != nil {
+		return false
+	}
+	err := syscall.Unmount(dir2, syscall.MNT_FORCE)
+	require.NoError(t, err, "unmount")
+	return true
 }

--- a/enterprise/server/util/oci/BUILD
+++ b/enterprise/server/util/oci/BUILD
@@ -21,6 +21,7 @@ go_library(
         "@com_github_google_go_containerregistry//pkg/v1/remote",
         "@com_github_google_go_containerregistry//pkg/v1/remote/transport",
         "@com_github_google_go_containerregistry//pkg/v1/types",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/enterprise/server/util/oci/BUILD
+++ b/enterprise/server/util/oci/BUILD
@@ -21,7 +21,6 @@ go_library(
         "@com_github_google_go_containerregistry//pkg/v1/remote",
         "@com_github_google_go_containerregistry//pkg/v1/remote/transport",
         "@com_github_google_go_containerregistry//pkg/v1/types",
-        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -1,16 +1,10 @@
 package oci
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"math/rand/v2"
 	"net/http"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"runtime"
-	"syscall"
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/server/util/flag"
@@ -24,7 +18,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
-	"golang.org/x/sync/errgroup"
 
 	rgpb "github.com/buildbuddy-io/buildbuddy/proto/registry"
 	ctrname "github.com/google/go-containerregistry/pkg/name"
@@ -193,86 +186,4 @@ func RuntimePlatform() *rgpb.Platform {
 		Arch: runtime.GOARCH,
 		Os:   runtime.GOOS,
 	}
-}
-
-// LayerPath returns where the extracted image layer with the given hash is
-// stored on disk.
-func LayerPath(layersDir string, hash v1.Hash) string {
-	return filepath.Join(layersDir, hash.Algorithm, hash.Hex)
-}
-
-// Pull downloads and extracts image layers to a directory.
-// Each layer is extracted to a subdirectory given by {algorithm}/{hash}, e.g.
-// "sha256/abc123".
-func Pull(ctx context.Context, layersDir, imageName string, creds Credentials) ([]v1.Layer, error) {
-	img, err := Resolve(ctx, imageName, RuntimePlatform(), creds)
-	if err != nil {
-		return nil, status.WrapError(err, "resolve image")
-	}
-	layers, err := img.Layers()
-	if err != nil {
-		return nil, status.UnavailableErrorf("get image layers: %s", err)
-	}
-
-	// Download and extract layers concurrently.
-	// TODO: dedupe layer pulls
-	var eg errgroup.Group
-	eg.SetLimit(min(8, runtime.NumCPU()))
-	for _, layer := range layers {
-		layer := layer
-		eg.Go(func() error {
-			d, err := layer.Digest()
-			if err != nil {
-				return status.UnavailableErrorf("get layer digest: %s", err)
-			}
-
-			destDir := LayerPath(layersDir, d)
-
-			// If the destination directory already exists then we can skip
-			// the download.
-			if _, err := os.Stat(destDir); err != nil {
-				if !os.IsNotExist(err) {
-					return status.UnavailableErrorf("stat layer directory: %s", err)
-				}
-			} else {
-				return nil
-			}
-
-			rc, err := layer.Compressed()
-			if err != nil {
-				return status.UnavailableErrorf("get layer reader: %s", err)
-			}
-			defer rc.Close()
-
-			tempUnpackDir := destDir + tmpSuffix()
-			if err := os.MkdirAll(tempUnpackDir, 0755); err != nil {
-				return status.UnavailableErrorf("create layer unpack dir: %s", err)
-			}
-			defer os.RemoveAll(tempUnpackDir)
-
-			// TODO: avoid tar command.
-			cmd := exec.CommandContext(ctx, "tar", "--no-same-owner", "--extract", "--gzip", "--directory", tempUnpackDir)
-			var stderr bytes.Buffer
-			cmd.Stdin = rc
-			cmd.Stderr = &stderr
-			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-			if err := cmd.Run(); err != nil {
-				return status.UnavailableErrorf("download and extract layer tarball: %s: %q", err, stderr.String())
-			}
-
-			if err := os.Rename(tempUnpackDir, destDir); err != nil {
-				return status.UnavailableErrorf("rename temp layer dir: %s", err)
-			}
-
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return nil, err
-	}
-	return layers, nil
-}
-
-func tmpSuffix() string {
-	return fmt.Sprintf(".%d.tmp", rand.Int64N(1e18))
 }

--- a/enterprise/server/util/oci/oci.go
+++ b/enterprise/server/util/oci/oci.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"os/exec"
@@ -274,5 +274,5 @@ func Pull(ctx context.Context, layersDir, imageName string, creds Credentials) (
 }
 
 func tmpSuffix() string {
-	return fmt.Sprintf(".%d.tmp", rand.Int63n(1e16))
+	return fmt.Sprintf(".%d.tmp", rand.Int64N(1e18))
 }


### PR DESCRIPTION
* Pull and extract image layers with `go-containerregistry`
  * Pull concurrently with up to 8 goroutines
  * For now, use `tar` to extract, using `--no-same-user` to avoid permissions issues
* Set up rootfs as an overlayfs mount

**Related issues**: N/A
