### PR TITLE
Better empty states in codesearch UI

### DIFF
--- a/enterprise/app/codesearch/codesearch.css
+++ b/enterprise/app/codesearch/codesearch.css
@@ -82,3 +82,35 @@
   border: 1px solid gray;
   border-radius: 2px;
 }
+
+.code-search .no-results {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.code-search .icon {
+  width: 180px;
+  height: 180px;
+}
+
+.code-search .circle {
+  width: 400px;
+  height: 400px;
+  background-color: rgba(255, 255, 255, 0.95);
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.code-search ul {
+  list-style: initial;
+  margin: 16px 0;
+  list-style-type: none;
+}
+
+.code-search ul li {
+  margin-bottom: 16px;
+}

--- a/enterprise/app/codesearch/codesearch.css
+++ b/enterprise/app/codesearch/codesearch.css
@@ -99,7 +99,6 @@
 .code-search .circle {
   width: 400px;
   height: 400px;
-  background-color: rgba(255, 255, 255, 0.95);
   display: inline-flex;
   flex-direction: column;
   align-items: center;

--- a/enterprise/app/codesearch/codesearch.tsx
+++ b/enterprise/app/codesearch/codesearch.tsx
@@ -31,7 +31,6 @@ export default class CodeSearchComponent extends React.Component<Props, State> {
   search() {
     router.setQueryParam("q", this.query);
     if (!this.query) {
-      this.setState({ response: undefined });
       return;
     }
     const query = this.query;

--- a/enterprise/app/codesearch/codesearch.tsx
+++ b/enterprise/app/codesearch/codesearch.tsx
@@ -8,6 +8,7 @@ import { FilterInput } from "../../../app/components/filter_input/filter_input";
 import TextInput from "../../../app/components/input/input";
 import FilledButton from "../../../app/components/button/button";
 import router from "../../../app/router/router";
+import { Bird, Search } from "lucide-react";
 
 interface State {
   lastQuery: string;
@@ -28,7 +29,9 @@ export default class CodeSearchComponent extends React.Component<Props, State> {
   };
 
   search() {
+    router.setQueryParam("q", this.query);
     if (!this.query) {
+      this.setState({ response: undefined });
       return;
     }
     const query = this.query;
@@ -37,9 +40,6 @@ export default class CodeSearchComponent extends React.Component<Props, State> {
     rpcService.service
       .search(new search.SearchRequest({ query: new search.Query({ term: query }) }))
       .then((response) => {
-        if (response.results.length === 0) {
-          throw new Error("Server did not return any search results.");
-        }
         this.setState({ response: response });
       })
       .catch((e) => errorService.handleError(e))
@@ -48,7 +48,6 @@ export default class CodeSearchComponent extends React.Component<Props, State> {
 
   handleQueryChange(event: React.ChangeEvent<HTMLInputElement>) {
     this.query = event.target.value;
-    router.setQueryParam("q", this.query);
   }
 
   componentDidMount() {
@@ -71,7 +70,6 @@ export default class CodeSearchComponent extends React.Component<Props, State> {
 
   renderSnippet(snippet: search.Snippet) {
     const lines = snippet.lines.split("\n");
-    console.log("ello");
     return <div className="snippet">{lines.map((line) => this.renderLine(line))}</div>;
   }
 
@@ -94,11 +92,46 @@ export default class CodeSearchComponent extends React.Component<Props, State> {
     if (this.state.loading) {
       return undefined;
     }
+
+    // Show some helpful examples if the query was empty.
+    if (!this.query) {
+      return (
+        <div className="no-results">
+          <div className="circle">
+            <Search className="icon gray" />
+            <h2>Empty Query</h2>
+            <p>
+              To see results, try entering a query. Here are some examples:
+              <ul>
+                <li>
+                  <code className="inline-code">case:yes Hello World</code>
+                </li>
+                <li>
+                  <code className="inline-code">lang:css padding-(left|right)</code>
+                </li>
+                <li>
+                  <code className="inline-code">lang:go flag.String</code>
+                </li>
+              </ul>
+            </p>
+          </div>
+        </div>
+      );
+    }
+
     if (!this.state.response) {
       return undefined;
     }
+
     if (this.state.response.results.length === 0) {
-      return <div>NO RESULTS.</div>;
+      return (
+        <div className="no-results">
+          <div className="circle">
+            <Bird className="icon gray" />
+            <h2>No results found</h2>
+          </div>
+        </div>
+      );
     }
     return <div>{this.state.response.results.map((result) => this.renderResult(result))}</div>;
   }


### PR DESCRIPTION
- stop showing the annoying error when no results are found
- show a placeholder if query is empty with some example searches
- show a chill no results found page if no results are found
- stop updating the q param on every keypress; only set it on search