### PR TITLE
[ci_runner] Modify Linux workflows to download the binary from the cache, rather than using the binary provisioned on the executors

### DIFF
--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -306,6 +306,8 @@ func (r *taskRunner) DownloadInputs(ctx context.Context, ioStats *repb.IOStats) 
 	if err != nil {
 		return err
 	}
+	// TODO(Maggie): Do not do this on Linux after we start uploading/downloading
+	// the binary from the cache
 	if r.PlatformProperties.WorkflowID != "" {
 		if err := r.Workspace.AddCIRunner(ctx); err != nil {
 			return err

--- a/enterprise/server/test/integration/workflow/workflow_test.go
+++ b/enterprise/server/test/integration/workflow/workflow_test.go
@@ -99,13 +99,14 @@ func setup(t *testing.T, gp interfaces.GitProvider) (*rbetest.Env, interfaces.Wo
 	var workflowService interfaces.WorkflowService
 
 	bbServer := env.AddBuildBuddyServerWithOptions(&rbetest.BuildBuddyServerOptions{
-		EnvModifier: func(env *testenv.TestEnv) {
-			env.SetRepoDownloader(repo_downloader.NewRepoDownloader())
-			env.SetGitProviders([]interfaces.GitProvider{gp})
-			workflowService = service.NewWorkflowService(env)
-			env.SetWorkflowService(workflowService)
-			iss := invocation_search_service.NewInvocationSearchService(env, env.GetDBHandle(), env.GetOLAPDBHandle())
-			env.SetInvocationSearchService(iss)
+		EnvModifier: func(e *testenv.TestEnv) {
+			e.SetRepoDownloader(repo_downloader.NewRepoDownloader())
+			e.SetGitProviders([]interfaces.GitProvider{gp})
+			workflowService = service.NewWorkflowService(e)
+			e.SetWorkflowService(workflowService)
+			iss := invocation_search_service.NewInvocationSearchService(e, e.GetDBHandle(), e.GetOLAPDBHandle())
+			e.SetInvocationSearchService(iss)
+			e.SetByteStreamClient(env.GetByteStreamClient())
 		},
 	})
 

--- a/enterprise/server/workflow/service/BUILD
+++ b/enterprise/server/workflow/service/BUILD
@@ -7,6 +7,7 @@ go_library(
     srcs = ["service.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/workflow/service",
     deps = [
+        "//enterprise/server/cmd/ci_runner/bundle",
         "//enterprise/server/remote_execution/operation",
         "//enterprise/server/remote_execution/platform",
         "//enterprise/server/webhooks/webhook_data",

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1163,7 +1163,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 	// NOTE: For non-Linux workflows, the executor is responsible for ensuring the
 	// buildbuddy_ci_runner binary exists at the workspace root when it sees
 	// the `workflow-id` platform property.
-	inputRootDigest, err := digest.ComputeForMessage(&repb.Directory{}, repb.DigestFunction_BLAKE3)
+	inputRootDigest, err := digest.ComputeForMessage(&repb.Directory{}, repb.DigestFunction_SHA256)
 	if err != nil {
 		return nil, err
 	}
@@ -1171,7 +1171,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 		// On Linux, because we can build the binary with the apps with the right architecture,
 		// upload the ci_runner binary to the cache to ensure the executors are using
 		// the most up-to-date version of the binary
-		runnerBinDigest, err := cachetools.UploadBlobToCAS(ctx, ws.env.GetByteStreamClient(), instanceName, repb.DigestFunction_BLAKE3, ci_runner_bundle.CiRunnerBytes)
+		runnerBinDigest, err := cachetools.UploadBlobToCAS(ctx, ws.env.GetByteStreamClient(), instanceName, repb.DigestFunction_SHA256, ci_runner_bundle.CiRunnerBytes)
 		if err != nil {
 			return nil, status.WrapError(err, "upload runner bin")
 		}
@@ -1183,7 +1183,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 				IsExecutable: true,
 			}},
 		}
-		inputRootDigest, err = cachetools.UploadProtoToCAS(ctx, cache, instanceName, repb.DigestFunction_BLAKE3, dir)
+		inputRootDigest, err = cachetools.UploadProtoToCAS(ctx, cache, instanceName, repb.DigestFunction_SHA256, dir)
 		if err != nil {
 			return nil, status.WrapError(err, "upload input root")
 		}
@@ -1281,7 +1281,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 			Value: "true",
 		})
 	}
-	cmdDigest, err := cachetools.UploadProtoToCAS(ctx, cache, instanceName, repb.DigestFunction_BLAKE3, cmd)
+	cmdDigest, err := cachetools.UploadProtoToCAS(ctx, cache, instanceName, repb.DigestFunction_SHA256, cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -1296,7 +1296,7 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 		Timeout: durationpb.New(timeout + timeoutGracePeriod),
 	}
 
-	actionDigest, err := cachetools.UploadProtoToCAS(ctx, cache, instanceName, repb.DigestFunction_BLAKE3, action)
+	actionDigest, err := cachetools.UploadProtoToCAS(ctx, cache, instanceName, repb.DigestFunction_SHA256, action)
 	return actionDigest, err
 }
 

--- a/enterprise/server/workflow/service/service.go
+++ b/enterprise/server/workflow/service/service.go
@@ -1160,15 +1160,15 @@ func (ws *workflowService) createActionForWorkflow(ctx context.Context, wf *tabl
 		}
 	}
 
-	// NOTE: For non-Linux workflows, the executor is responsible for ensuring the
+	// NOTE: By default, the executor is responsible for ensuring the
 	// buildbuddy_ci_runner binary exists at the workspace root when it sees
 	// the `workflow-id` platform property.
 	inputRootDigest, err := digest.ComputeForMessage(&repb.Directory{}, repb.DigestFunction_SHA256)
 	if err != nil {
 		return nil, err
 	}
-	if os == "" || os == platform.LinuxOperatingSystemName {
-		// On Linux, because we can build the binary with the apps with the right architecture,
+	if (os == "" || os == platform.LinuxOperatingSystemName) && (workflowAction.Arch == "" || workflowAction.Arch == "amd64") {
+		// Because the apps are built for linux/amd64, in these cases we can have the apps
 		// upload the ci_runner binary to the cache to ensure the executors are using
 		// the most up-to-date version of the binary
 		runnerBinDigest, err := cachetools.UploadBlobToCAS(ctx, ws.env.GetByteStreamClient(), instanceName, repb.DigestFunction_SHA256, ci_runner_bundle.CiRunnerBytes)


### PR DESCRIPTION
This will make it easier to ship ci_runner changes to customers with self-hosted executors

**Related issues**: N/A
