### PR TITLE
Don't revive loading state from storage

### DIFF
--- a/enterprise/app/code/code.tsx
+++ b/enterprise/app/code/code.tsx
@@ -1628,6 +1628,9 @@ function getOrCreateModel(url: string, value: string) {
 
 // This revives any non-serializable objects in state from their seralized form.
 function stateReviver(key: string, value: any) {
+  if (key == "loading") {
+    return false;
+  }
   if (typeof value === "object" && value !== null) {
     if (value.dataType === "Map") {
       return new Map(value.value);


### PR DESCRIPTION
If you leave the page mid-loading, you don't want that loading state to be popped out of local storage the next time you visit the page.