### PR TITLE
Show invocation type in breadcrumb

### DIFF
--- a/app/invocation/invocation_overview.tsx
+++ b/app/invocation/invocation_overview.tsx
@@ -81,6 +81,16 @@ export default class InvocationOverviewComponent extends React.Component<Props> 
     window.open(this.props.model.getBuildkiteUrl(), "_blank");
   }
 
+  invocationType() {
+    if (this.props.model.isWorkflowInvocation()) {
+      return "Workflow";
+    }
+    if (this.props.model.isHostedBazelInvocation()) {
+      return "Remote Bazel";
+    }
+    return "Invocation";
+  }
+
   render() {
     const ownerGroup = this.props.model.findOwnerGroup(this.props.user?.groups);
     const isBazelInvocation = this.props.model.isBazelInvocation();
@@ -103,7 +113,9 @@ export default class InvocationOverviewComponent extends React.Component<Props> 
                 {parentWorkflowId ? "Workflow" : "Bazel invocation"} {parentInvocationId}
               </Link>
             )}
-            <span>Invocation {this.props.model.getInvocationId()}</span>
+            <span>
+              {this.invocationType()} {this.props.model.getInvocationId()}
+            </span>
           </div>
           <InvocationButtons model={this.props.model} user={this.props.user} />
         </div>


### PR DESCRIPTION
Right now when you view an invocation that's the child of a workflow, you breadcrumb looks like this:
`BuildBuddy > Builds > Workflow X > Invocation Y`

When you click on `Workflow X` you're taken to a workflow page that looks like this:
`BuildBuddy > Builds > Invocation X`

With this change, you'll get taken to a workflow page that looks like this instead:
`BuildBuddy > Builds > Workflow X`
