### PR TITLE
Don't show "Ask Buddy" for workflow invocations

### DIFF
--- a/app/invocation/suggestion_button.tsx
+++ b/app/invocation/suggestion_button.tsx
@@ -77,6 +77,7 @@ export default class SuggestionButton extends React.Component<SuggestionButtonPr
       !capabilities.config.botSuggestionsEnabled ||
       !this.props.user ||
       !this.props.user?.selectedGroup?.botSuggestionsEnabled ||
+      !this.props.model.isBazelInvocation() ||
       this.props.model.invocation.bazelExitCode == "SUCCESS"
     ) {
       return <></>;


### PR DESCRIPTION
We currently show it for passing & failing workflows (because there's no bazel exit code) and the results aren't very good.