### PR TITLE
bazel: Add a musl cross toolchain targetting Linux amd64/arm64

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -156,8 +156,8 @@ common:auto-release -c opt
 common:auto-release --@io_bazel_rules_go//go/config:pgoprofile=enterprise/tools/pgo:prod.pprof
 
 # Build fully static binaries linked against musl on Linux or macOS.
-common:static --platforms=//:linux_x86_64_musl
-common:static-arm64 --platforms=//:linux_arm64_musl
+common:static --platforms=//platforms:linux_x86_64_musl
+common:static-arm64 --platforms=//platforms:linux_arm64_musl
 
 # By default, build logs get sent to the production server
 common --bes_results_url=https://app.buildbuddy.io/invocation/

--- a/.bazelrc
+++ b/.bazelrc
@@ -155,18 +155,9 @@ common:auto-release --remote_instance_name=buildbuddy-io/buildbuddy/auto-release
 common:auto-release -c opt
 common:auto-release --@io_bazel_rules_go//go/config:pgoprofile=enterprise/tools/pgo:prod.pprof
 
-# Static build configuration. MacOS is currently unsupported.
-# On multi-user machines, specify HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX in your
-# repo_env in user.bazelrc to avoid permissions errors.
-common:static --repo_env BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-# Workaround for Bazel 7.
-# See https://github.com/uber/hermetic_cc_toolchain/releases/tag/v3.0.1 for more details
-common:static --sandbox_add_mount_pair=/tmp
-common:static --extra_toolchains=@zig_sdk//toolchain:linux_amd64_musl
-# arm64 is not yet tested, so we leave this toolchain commented out for now.
-# common:static --extra_toolchains=@zig_sdk//toolchain:linux_arm64_musl
-common:static --@io_bazel_rules_go//go/config:static=true
-common:static --copt=-fPIC
+# Build fully static binaries linked against musl on Linux or macOS.
+common:static --platforms=//:linux_x86_64_musl
+common:static-arm64 --platforms=//:linux_arm64_musl
 
 # By default, build logs get sent to the production server
 common --bes_results_url=https://app.buildbuddy.io/invocation/

--- a/BUILD
+++ b/BUILD
@@ -294,22 +294,3 @@ platform(
         "container-image": "docker://gcr.io/flame-public/iain-test:latest",
     },
 )
-
-# Target these platforms with --platforms for a static build linked against musl libc.
-platform(
-    name = "linux_x86_64_musl",
-    constraint_values = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:linux",
-        "//toolchains:musl_on",
-    ],
-)
-
-platform(
-    name = "linux_arm64_musl",
-    constraint_values = [
-        "@platforms//cpu:arm64",
-        "@platforms//os:linux",
-        "//toolchains:musl_on",
-    ],
-)

--- a/BUILD
+++ b/BUILD
@@ -294,3 +294,22 @@ platform(
         "container-image": "docker://gcr.io/flame-public/iain-test:latest",
     },
 )
+
+# Target these platforms with --platforms for a static build linked against musl libc.
+platform(
+    name = "linux_x86_64_musl",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+        "//toolchains:musl_on",
+    ],
+)
+
+platform(
+    name = "linux_arm64_musl",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:linux",
+        "//toolchains:musl_on",
+    ],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,6 +3,7 @@ module(name = "buildbuddy")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_proto", version = "6.0.0")
+bazel_dep(name = "toolchains_musl", version = "0.1.15")
 
 # Needed for com_google_protobuf
 bazel_dep(name = "rules_python", version = "0.31.0")
@@ -304,3 +305,8 @@ node.toolchain(
 use_repo(node, "nodejs_toolchains")
 
 register_toolchains("@nodejs_toolchains//:all")
+
+toolchains_musl = use_extension("@toolchains_musl//:toolchains_musl.bzl", "toolchains_musl", dev_dependency = True)
+toolchains_musl.config(
+    extra_target_compatible_with = ["//toolchains:musl_on"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -511,3 +511,21 @@ register_toolchains(
     "//toolchains:sh_toolchain",
     "//toolchains:ubuntu_cc_toolchain",
 )
+
+http_archive(
+    name = "musl_toolchains",
+    sha256 = "26cacffab74e10f0840c83b0be9193dc6deccfbc8ec1cf6f8362dc61d0057fa1",
+    url = "https://github.com/bazel-contrib/musl-toolchain/releases/download/v0.1.15/musl_toolchain-v0.1.15.tar.gz",
+)
+
+load("@musl_toolchains//:repositories.bzl", "load_musl_toolchains")
+
+load_musl_toolchains(
+    extra_target_compatible_with = [
+        "@//toolchains:musl_on",
+    ],
+)
+
+load("@musl_toolchains//:toolchains.bzl", "register_musl_toolchains")
+
+register_musl_toolchains()

--- a/enterprise/server/remote_execution/containers/firecracker/BUILD
+++ b/enterprise/server/remote_execution/containers/firecracker/BUILD
@@ -77,7 +77,15 @@ genrule(
         "//enterprise/server/vmexec:vmexec.go",
     ],
     outs = ["guest_api_hash.sha256"],
-    cmd_bash = """sha256sum $(SRCS) | sha256sum | awk '{printf "%s", $$1}' > $@""",
+    cmd_bash = """
+    if type sha256sum &>/dev/null; then
+      # Linux
+      sha256sum $(SRCS) | sha256sum | awk '{printf "%s", $$1}' > $@
+    else
+      # macOS
+      shasum -a 256 $(SRCS) | shasum -a 256 | awk '{printf "%s", $$1}' > $@
+    fi
+    """,
     target_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -59,3 +59,22 @@ platform(
     constraint_values = HOST_CONSTRAINTS,
     parents = [get_parent_from_constraints(HOST_CONSTRAINTS)],
 )
+
+# Target these platforms with --platforms for a static build linked against musl libc.
+platform(
+    name = "linux_x86_64_musl",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+        "//toolchains:musl_on",
+    ],
+)
+
+platform(
+    name = "linux_arm64_musl",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:linux",
+        "//toolchains:musl_on",
+    ],
+)

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -60,7 +60,8 @@ platform(
     parents = [get_parent_from_constraints(HOST_CONSTRAINTS)],
 )
 
-# Target these platforms with --platforms for a static build linked against musl libc.
+# Target this platforms with --platforms for a static build linked against musl libc.
+# Only meant to be used as a target platform.
 platform(
     name = "linux_x86_64_musl",
     constraint_values = [
@@ -70,6 +71,8 @@ platform(
     ],
 )
 
+# Target this platforms with --platforms for a static build linked against musl libc.
+# Only meant to be used as a target platform.
 platform(
     name = "linux_arm64_musl",
     constraint_values = [

--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -36,3 +36,27 @@ toolchain(
     toolchain = "@buildbuddy_toolchain//:ubuntu_local_cc_toolchain",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
+
+constraint_setting(
+    name = "use_musl",
+    default_constraint_value = ":musl_off",
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+constraint_value(
+    name = "musl_on",
+    constraint_setting = ":use_musl",
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+constraint_value(
+    name = "musl_off",
+    constraint_setting = ":use_musl",
+    visibility = [
+        "//visibility:public",
+    ],
+)


### PR DESCRIPTION
The new toolchain produces binaries statically linked against musl.

Tested on `//cli` and `//enterprise/server/cmd/executor` from macOS.
