### PR TITLE
Move registry server to our standard http mux

### DIFF
--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -284,6 +284,9 @@ func main() {
 	if err := codesearch.Register(realEnv); err != nil {
 		log.Fatalf("%v", err)
 	}
+	if err := registry.Register(realEnv); err != nil {
+		log.Fatalf("%v", err)
+	}
 
 	executionService := execution_service.NewExecutionService(realEnv)
 	realEnv.SetExecutionService(executionService)
@@ -293,9 +296,6 @@ func main() {
 
 	telemetryServer := telserver.NewTelemetryServer(realEnv, realEnv.GetDBHandle())
 	telemetryServer.StartOrDieIfEnabled()
-
-	registryServer := registry.NewRegistryServer(realEnv, realEnv.GetDBHandle())
-	registryServer.Start()
 
 	telemetryClient := telemetry.NewTelemetryClient(realEnv)
 	telemetryClient.Start()

--- a/enterprise/server/registry/BUILD
+++ b/enterprise/server/registry/BUILD
@@ -11,8 +11,8 @@ go_library(
     ],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/registry",
     deps = [
-        "//server/environment",
         "//server/interfaces",
+        "//server/real_environment",
         "//server/util/log",
     ],
 )

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -124,4 +124,5 @@ type Env interface {
 	GetCodesearchService() interfaces.CodesearchService
 	GetSnapshotService() interfaces.SnapshotService
 	GetAuthService() interfaces.AuthService
+	GetRegistryService() interfaces.RegistryService
 }

--- a/server/interfaces/interfaces.go
+++ b/server/interfaces/interfaces.go
@@ -1515,3 +1515,7 @@ type CodesearchService interface {
 type AuthService interface {
 	Authenticate(ctx context.Context, req *authpb.AuthenticateRequest) (*authpb.AuthenticateResponse, error)
 }
+
+type RegistryService interface {
+	RegisterHandlers(mux HttpServeMux)
+}

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -451,6 +451,10 @@ func StartAndRunServices(env *real_environment.RealEnv) {
 		scim.RegisterHandlers(mux)
 	}
 
+	if reg := env.GetRegistryService(); reg != nil {
+		reg.RegisterHandlers(mux)
+	}
+
 	if wfs := env.GetWorkflowService(); wfs != nil {
 		mux.Handle("/webhooks/workflow/", interceptors.WrapExternalHandler(env, wfs))
 	}

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -124,6 +124,7 @@ type RealEnv struct {
 	codesearchService                interfaces.CodesearchService
 	snapshotService                  interfaces.SnapshotService
 	authService                      interfaces.AuthService
+	registryService                  interfaces.RegistryService
 }
 
 // NewRealEnv returns an environment for use in servers.
@@ -742,4 +743,11 @@ func (r *RealEnv) GetAuthService() interfaces.AuthService {
 }
 func (r *RealEnv) SetAuthService(auths interfaces.AuthService) {
 	r.authService = auths
+}
+
+func (r *RealEnv) GetRegistryService() interfaces.RegistryService {
+	return r.registryService
+}
+func (r *RealEnv) SetRegistryService(reg interfaces.RegistryService) {
+	r.registryService = reg
 }


### PR DESCRIPTION
This makes things easier, because if we don't run it on its own port - we can use use the same endpoints we use for all of our other services instead of having to set up a new ingress, etc just for this.