### PR TITLE
buildfix.sh: use buildifier managed by Bazel

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,6 @@
 load("@bazel_gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load("@com_github_sluongng_nogo_analyzer//staticcheck:def.bzl", "ANALYZERS", "staticcheck_analyzers")
 load("@io_bazel_rules_go//go:def.bzl", "nogo")
 load("@npm//@bazel/typescript:index.bzl", "ts_config")
@@ -183,6 +184,10 @@ gazelle_binary(
 gazelle(
     name = "gazelle",
     gazelle = ":bb_gazelle_binary",
+)
+
+buildifier(
+    name = "buildifier",
 )
 
 go_sdk_tool(

--- a/buildfix.sh
+++ b/buildfix.sh
@@ -34,7 +34,7 @@ BAZEL_QUIET_FLAGS=(
 
 # buildifier format all BUILD files
 echo "Formatting WORKSPACE/BUILD files..."
-buildifier -r .
+bazel run "${BAZEL_QUIET_FLAGS[@]}" :buildifier
 
 echo "Building and running gofmt..."
 GO_SRCS=()
@@ -66,7 +66,7 @@ fi
 
 if ((GAZELLE)); then
   echo "Fixing BUILD deps with gazelle..."
-  CLI_VERSION="5.0.25" # Update this to latest version from `git tag -l 'cli-*' --sort=creatordate | tail -n1`
+  CLI_VERSION="5.0.75" # Update this to latest version from `git tag -l 'cli-*' --sort=creatordate | tail -n1`
   USE_BAZEL_VERSION="buildbuddy-io/$CLI_VERSION" bazel fix
 fi
 

--- a/tools/fix_go_deps.sh
+++ b/tools/fix_go_deps.sh
@@ -9,7 +9,7 @@ if [[ "$GAZELLE_PATH" ]]; then
   GAZELLE_COMMAND=("$GAZELLE_PATH")
 fi
 
-GO_COMMAND=(bazelisk run //:go --)
+GO_COMMAND=(bazelisk run --build_metadata=DISABLE_COMMIT_STATUS_REPORTING=true //:go --)
 if [[ "$GO_PATH" ]]; then
   GO_COMMAND=("$GO_PATH")
 fi


### PR DESCRIPTION
This switch our script to use buildifier managed by Bazel instead of
relying on users to install buildifier on their host machine.
