### PR TITLE
Use a simpler key for snapshot-specific AC entries

### DIFF
--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -678,8 +678,7 @@ func (l *FileCacheLoader) cacheActionResult(ctx context.Context, key *fcpb.Snaps
 		// Cache snapshot manifest for this specific snapshot ID
 		if opts.VMMetadata.GetSnapshotId() != "" {
 			snapshotID := opts.VMMetadata.SnapshotId
-			snapshotSpecificKey := key.CloneVT()
-			snapshotSpecificKey.SnapshotId = snapshotID
+			snapshotSpecificKey := &fcpb.SnapshotKey{SnapshotId: snapshotID}
 			snapshotSpecificManifestKey, err := RemoteManifestKey(snapshotSpecificKey)
 			if err != nil {
 				log.Warningf("Failed to generate snapshot specific remote manifest key for snapshot ID %s: %s", snapshotID, err)
@@ -713,8 +712,7 @@ func (l *FileCacheLoader) cacheActionResult(ctx context.Context, key *fcpb.Snaps
 	// Cache snapshot manifest for this specific snapshot ID
 	if opts.VMMetadata.GetSnapshotId() != "" {
 		snapshotID := opts.VMMetadata.GetSnapshotId()
-		snapshotSpecificKey := key.CloneVT()
-		snapshotSpecificKey.SnapshotId = snapshotID
+		snapshotSpecificKey := &fcpb.SnapshotKey{SnapshotId: snapshotID}
 
 		snapshotSpecificManifestKey, err := LocalManifestKey(gid, snapshotSpecificKey)
 		if err != nil {

--- a/enterprise/server/remote_execution/snaploader/snaploader_test.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader_test.go
@@ -274,8 +274,7 @@ func TestNonMasterSnapshotsWithSnapshotID(t *testing.T) {
 
 		// Start VM D from a snapshot key for VM A - should be valid, even though
 		// the master key is pointing to VM B
-		keyA := masterKey.GetBranchKey()
-		keyA.SnapshotId = "snapshot-id-a"
+		keyA := &fcpb.SnapshotKey{SnapshotId: "snapshot-id-a"}
 		workDirD := testfs.MakeDirAll(t, workDir, "VM-D")
 		mustUnpack(t, ctx, loader, &fcpb.SnapshotKeySet{
 			BranchKey: keyA,

--- a/proto/firecracker.proto
+++ b/proto/firecracker.proto
@@ -45,6 +45,15 @@ message SnapshotKeySet {
 }
 
 message SnapshotKey {
+  // If set, this key corresponds to a specific snapshot instance, and should
+  // never be overwritten by other snapshot manifests. Because the snapshot ID
+  // uniquely identifies a snapshot, all other fields should be unset when using
+  // this field.
+  //
+  // If not set, this key corresponds to the newest snapshot matching the other
+  // parameters.
+  string snapshot_id = 6;
+
   // Remote instance name associated with the snapshot.
   string instance_name = 1;
 
@@ -62,11 +71,6 @@ message SnapshotKey {
   // Git ref associated with the snapshot. For workflows, this represents the
   // branch that was checked out when running the workflow.
   string ref = 5;
-
-  // If set, this key corresponds to a specific snapshot run.
-  // If not set, this key should fetch the newest snapshot matching the other
-  // parameters.
-  string snapshot_id = 6;
 
   // If set, corresponds to a specific version of the snapshot. Updating this
   // can be used to invalidate earlier snapshots (Ex. you may want to do this


### PR DESCRIPTION
For snapshot-specific keys, _only_ include the snapshot ID in the key, leaving all other fields blank. This will make it possible to have a `--snapshot_id` arg to vmstart, which we can easily copy-paste from the UI, instead of needing to dig through executor logs.