### PR TITLE
ci runner: try to reclaim disk space when usage is high

### DIFF
--- a/enterprise/server/cmd/ci_runner/BUILD
+++ b/enterprise/server/cmd/ci_runner/BUILD
@@ -1,6 +1,6 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 # gazelle:default_visibility //enterprise:__subpackages__
 package(
@@ -40,6 +40,7 @@ go_library(
         "//server/util/status",
         "@com_github_creack_pty//:pty",
         "@com_github_docker_go_units//:go-units",
+        "@com_github_elastic_gosigar//:gosigar",
         "@com_github_google_shlex//:shlex",
         "@com_github_google_uuid//:uuid",
         "@com_github_logrusorgru_aurora//:aurora",


### PR DESCRIPTION
After running the action (and publishing the success/failure status for the outer invocation), attempt to save disk space by running `git gc` if disk usage exceeds 90%.

**Related issues**: N/A
