### PR TITLE
Reduce CI runner progress event throttling

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -115,7 +115,7 @@ const (
 
 	// progressFlushInterval specifies how often we should flush
 	// each Bazel command's output while it is running.
-	progressFlushInterval = 1 * time.Second
+	progressFlushInterval = 200 * time.Millisecond
 	// progressFlushThresholdBytes specifies how full the log buffer
 	// should be before we force a flush, regardless of the flush interval.
 	progressFlushThresholdBytes = 1_000


### PR DESCRIPTION
Now that we have live-streaming invocation logs, it'll be nicer to flush these a little more frequently, so that both the "outer" and "inner" invocations can live-update.

**Related issues**: N/A
