### PR TITLE
Add query support to code editor

### DIFF
--- a/enterprise/app/code/code.css
+++ b/enterprise/app/code/code.css
@@ -461,3 +461,8 @@
   top: calc(50% - 32px);
   left: calc(50% - 32px);
 }
+
+.code-query-highlight {
+  font-weight: 600;
+  background-color: #FFE0B2;
+}

--- a/enterprise/app/code/code.css
+++ b/enterprise/app/code/code.css
@@ -464,5 +464,5 @@
 
 .code-query-highlight {
   font-weight: 600;
-  background-color: #FFE0B2;
+  background-color: #ffe0b2;
 }


### PR DESCRIPTION
Highlights query from url parameter.

Adds support for `commit` query parameter.

Makes the editor read only if url param is set. (We could change this later, or add an edit button to switch to edit mode).

Hides some unnecessary UI if query is set - like changes view & open PR button.