### PR TITLE
Tweak CLI release workflow name

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -1,4 +1,4 @@
-name: "release-cli"
+name: "Release CLI"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
The current name looks like a workflow job ID rather than a workflow name, which had me confused for a second

**Related issues**: N/A
