### PR TITLE
update flake-related target queries to what we actually need.

### DIFF
--- a/proto/buildbuddy_service.proto
+++ b/proto/buildbuddy_service.proto
@@ -125,6 +125,8 @@ service BuildBuddyService {
       returns (target.GetTargetHistoryResponse);
   rpc GetTargetStats(target.GetTargetStatsRequest)
       returns (target.GetTargetStatsResponse);
+  rpc GetDailyTargetStats(target.GetDailyTargetStatsRequest)
+      returns (target.GetDailyTargetStatsResponse);
   rpc GetTargetFlakeSamples(target.GetTargetFlakeSamplesRequest)
       returns (target.GetTargetFlakeSamplesResponse);
 

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -156,6 +156,9 @@ message FrontendConfig {
 
   // Whether to stream invocation logs.
   bool invocation_log_streaming_enabled = 52;
+
+  // Enables fancy features for seeing recent flakes by target.
+  bool target_flakes_ui_enabled = 53;
 }
 
 message Region {

--- a/proto/target.proto
+++ b/proto/target.proto
@@ -224,14 +224,11 @@ message GetTargetStatsRequest {
   // flakiest tests in the last 30 days.
   repeated string labels = 2;
 
-  // If many/all labels are requested, there may be multiple pages of results.
-  string page_token = 3;
+  // If specified, stats will be restricted to invocations in this repo.
+  string repo = 3;
 }
 
-message TargetStats {
-  // The target label that these stats are for.
-  string label = 1;
-
+message TargetStatsData {
   // The total number of runs of this target. This number will equal
   // successful_runs + flaky_runs + failed_runs.
   int64 total_runs = 2;
@@ -249,17 +246,51 @@ message TargetStats {
   int64 failed_runs = 6;
 }
 
+message AggregateTargetStats {
+  // The target label that these stats are for.
+  string label = 1;
+
+  TargetStatsData data = 2;
+}
+
 message GetTargetStatsResponse {
   context.ResponseContext response_context = 1;
   // Per-target stats on observed flakes.  Currently, flakes are computed based
   // on CI runs on master--it's difficult to assert "sequentialness" of non-CI
   // runs, and moreover, individual users can cause random weird-looking
   // failures locally all the time.
-  repeated TargetStats stats = 2;
+  repeated AggregateTargetStats stats = 2;
+}
 
-  // If the user didn't specify a set of targets to fetch, there may be multiple
-  // pages of results.
-  string next_page_token = 3;
+message GetDailyTargetStatsRequest {
+  context.RequestContext request_context = 1;
+
+  // If specified, a list of targets for which we should fetch flake data.
+  // Daily stats will be aggregated over this set of targets--if no targets are
+  // specified, total stats for all
+  repeated string labels = 2;
+
+  // If specified, stats will be restricted to invocations in this repo.
+  string repo = 3;
+
+  // If many/all labels are requested, there may be multiple pages of results.
+  string page_token = 4;
+}
+
+message DailyTargetStats {
+  // YYYY-MM-DD
+  string date = 1;
+
+  TargetStatsData data = 2;
+}
+
+message GetDailyTargetStatsResponse {
+  context.ResponseContext response_context = 1;
+  // Per-target stats on observed flakes.  Currently, flakes are computed based
+  // on CI runs on master--it's difficult to assert "sequentialness" of non-CI
+  // runs, and moreover, individual users can cause random weird-looking
+  // failures locally all the time.
+  repeated DailyTargetStats stats = 2;
 }
 
 // Fetches examples of flaky runs for a single target in the last seven days.
@@ -269,8 +300,11 @@ message GetTargetFlakeSamplesRequest {
   // The target label for which we'd like to see flaky runs.
   string label = 2;
 
+  // If specified, all flaky invocations must match this repo.
+  string repo = 3;
+
   // A token for fetching another page of flaky runs.
-  string page_token = 3;
+  string page_token = 4;
 }
 
 message FlakeSample {
@@ -286,6 +320,13 @@ message FlakeSample {
 
   // The invocation ID that the flake was in, so that we can link to it.
   string invocation_id = 3;
+
+  // The start time of the invocation (just as a hint for the user).
+  int64 invocation_start_time_usec = 4;
+
+  // The build event (a TestResult) corresponding to the failure that generated
+  // the flake.
+  build_event_stream.BuildEvent event = 5;
 }
 
 message GetTargetFlakeSamplesResponse {

--- a/server/buildbuddy_server/buildbuddy_server.go
+++ b/server/buildbuddy_server/buildbuddy_server.go
@@ -1158,6 +1158,10 @@ func (s *BuildBuddyServer) GetTargetStats(ctx context.Context, req *trpb.GetTarg
 	return target.GetTargetStats(ctx, s.env, req)
 }
 
+func (s *BuildBuddyServer) GetDailyTargetStats(ctx context.Context, req *trpb.GetDailyTargetStatsRequest) (*trpb.GetDailyTargetStatsResponse, error) {
+	return target.GetDailyTargetStats(ctx, s.env, req)
+}
+
 func (s *BuildBuddyServer) GetTargetFlakeSamples(ctx context.Context, req *trpb.GetTargetFlakeSamplesRequest) (*trpb.GetTargetFlakeSamplesResponse, error) {
 	return target.GetTargetFlakeSamples(ctx, s.env, req)
 }

--- a/server/capabilities_filter/capabilities_filter.go
+++ b/server/capabilities_filter/capabilities_filter.go
@@ -92,6 +92,7 @@ var (
 		"GetSuggestion",
 		"SearchExecution",
 		"GetTargetStats",
+		"GetDailyTargetStats",
 		"GetTargetFlakeSamples",
 		// Workflow configuration and history (read-only).
 		"GetWorkflows",

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -61,6 +61,7 @@ var (
 	orgAdminApiKeyCreationEnabled          = flag.Bool("app.org_admin_api_key_creation_enabled", false, "If set, SCIM API keys will be able to be created in the UI.")
 	readerWriterRolesEnabled               = flag.Bool("app.reader_writer_roles_enabled", false, "If set, Reader/Writer roles will be enabled in the user management UI.")
 	invocationLogStreamingEnabled          = flag.Bool("app.invocation_log_streaming_enabled", false, "If set, the UI will stream invocation logs instead of polling.")
+	targetFlakesUIEnabled                  = flag.Bool("app.target_flakes_ui_enabled", false, "If set, show some fancy new features for analyzing flakes.")
 
 	jsEntryPointPath = flag.String("js_entry_point_path", "/app/app_bundle/app.js?hash={APP_BUNDLE_HASH}", "Absolute URL path of the app JS entry point")
 	disableGA        = flag.Bool("disable_ga", false, "If true; ga will be disabled")
@@ -199,6 +200,7 @@ func serveIndexTemplate(ctx context.Context, env environment.Env, tpl *template.
 		OrgAdminApiKeyCreationEnabled:          *orgAdminApiKeyCreationEnabled,
 		ReaderWriterRolesEnabled:               *readerWriterRolesEnabled,
 		InvocationLogStreamingEnabled:          *invocationLogStreamingEnabled,
+		TargetFlakesUiEnabled:                  *targetFlakesUIEnabled && env.GetOLAPDBHandle() != nil,
 	}
 
 	configJSON, err := protojson.Marshal(&config)


### PR DESCRIPTION
- add a time series query for target flake stats
- remove pagination from target stats query (just not worth it for now since the query already sorts)
- add repo param so that two repos can have the same targets without us getting crossed up.
- add a few extra pieces of info to flake samples.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
