### PR TITLE
[raft] When adding a replica, add the node as a non voter first

### DIFF
--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -552,6 +552,10 @@ message StartShardRequest {
 
   // Don't mark self as ready until this index has been applied.
   uint64 last_applied_index = 6;
+
+  // If true, we will start this shard as a non-voter; otherwise, we will start
+  // it as a voter.
+  bool is_non_voting = 7;
 }
 
 message StartShardResponse {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
When we are adding a new replica, we first add it as a non-voter, and when the
node catches up with other replcias, we promote it as a voter.


