### PR TITLE
Patch firecracker to ignore unknown ioctl flags

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6828,11 +6828,11 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
         name = "com_github_firecracker_microvm_firecracker",
         build_file_content = "\n".join([
             'package(default_visibility = ["//visibility:public"])',
-            'filegroup(name = "firecracker", srcs = ["release-{release}/firecracker-{release}"])',
-            'filegroup(name = "jailer", srcs = ["release-{release}/jailer-{release}"])',
+            'filegroup(name = "firecracker", srcs = ["firecracker-v1.7.0-20240614-406a20b92a743a17cc30dec5c01d6063378e67a8"])',
+            'filegroup(name = "jailer", srcs = ["jailer-v1.7.0-20240614-406a20b92a743a17cc30dec5c01d6063378e67a8"])',
         ]).format(release = "v1.7.0-x86_64"),
-        sha256 = "55bd3e6d599fdd108e36e52f9aee2319f06c18a90f2fa49b64e93fdf06f5ff53",
-        urls = ["https://github.com/firecracker-microvm/firecracker/releases/download/v1.7.0/firecracker-v1.7.0-x86_64.tgz"],
+        sha256 = "86232bc568073e35b5317ff1e063652c12bc28ab040dfc38512ff229448e54bd",
+        urls = ["https://storage.googleapis.com/buildbuddy-tools/binaries/firecracker/firecracker-v1.7.0-20240614-406a20b92a743a17cc30dec5c01d6063378e67a8.tgz"],
     )
     http_archive(
         name = "com_github_containerd_stargz_snapshotter-v0.11.4-linux-amd64",


### PR DESCRIPTION
The diff that was applied on top of firecracker tag v1.7.0: https://github.com/firecracker-microvm/firecracker/compare/v1.7.0...maggie-lou:firecracker:patch_uffd?expand=1

Newer Kernel versions added a new IOCTL flag, [which causes Firecracker to fail.](https://github.com/bytecodealliance/userfaultfd-rs/issues/61). [Userfaultfd-rs was patched to ignore unknown flags](https://github.com/bytecodealliance/userfaultfd-rs/pull/62). [Firecracker upgraded uffd-rs](https://github.com/firecracker-microvm/firecracker/pull/4578), but it hasn't made it into a new release yet. In the meantime, patch firecracker so that we can run it on our shiny new executors with upgraded kernel

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
