### PR TITLE
UI for finding example flakes, flake history, etc.

### DIFF
--- a/app/invocation/BUILD
+++ b/app/invocation/BUILD
@@ -723,6 +723,7 @@ ts_library(
     name = "invocation_target_group_card",
     srcs = ["invocation_target_group_card.tsx"],
     deps = [
+        "//app/capabilities",
         "//app/components/digest",
         "//app/components/link",
         "//app/components/spinner",
@@ -730,6 +731,7 @@ ts_library(
         "//app/format",
         "//app/invocation:target_util",
         "//app/service:rpc_service",
+        "//app/target:flaky_target_chip",
         "//app/util:clipboard",
         "//proto:build_event_stream_ts_proto",
         "//proto:target_ts_proto",

--- a/app/invocation/invocation.css
+++ b/app/invocation/invocation.css
@@ -164,6 +164,12 @@
   color: #757575;
 }
 
+.invocation-flaky-chip-alignment-hack {
+  display: inline-block;
+  vertical-align: top;
+  margin-top: -10px;
+}
+
 .invocation-action-card .icon.file-icon,
 .invocation-action-card .icon.folder-icon,
 .invocation-action-card .icon.file-question-icon {

--- a/app/invocation/invocation_artifacts_card.tsx
+++ b/app/invocation/invocation_artifacts_card.tsx
@@ -84,7 +84,12 @@ export default class ArtifactsCardComponent extends React.Component<Props, State
 
       const group = this.state.searchResponse?.targetGroups[0] ?? artifactListingGroup;
       return (
-        <TargetGroupCard invocationId={this.props.model.getInvocationId()} group={group} filter={this.props.filter} />
+        <TargetGroupCard
+          invocationId={this.props.model.getInvocationId()}
+          repo={this.props.model.getRepo()}
+          group={group}
+          filter={this.props.filter}
+        />
       );
     }
 

--- a/app/invocation/invocation_targets.tsx
+++ b/app/invocation/invocation_targets.tsx
@@ -73,7 +73,12 @@ export default class TargetsComponent extends React.Component<Props, State> {
 
   private renderTargetGroup(group: target.TargetGroup) {
     return (
-      <TargetGroupCard invocationId={this.props.model.getInvocationId()} group={group} filter={this.props.filter} />
+      <TargetGroupCard
+        invocationId={this.props.model.getInvocationId()}
+        repo={this.props.model.getRepo()}
+        group={group}
+        filter={this.props.filter}
+      />
     );
   }
 

--- a/app/root/root.css
+++ b/app/root/root.css
@@ -1255,6 +1255,12 @@ code .comment {
   gap: 8px;
 }
 
+.flaky-target-chip {
+  display: flex;
+  margin-left: 8px;
+  gap: 8px;
+}
+
 .test-subtitle {
   margin-bottom: 8px;
   color: #aaa;

--- a/app/target/BUILD
+++ b/app/target/BUILD
@@ -28,6 +28,21 @@ ts_library(
 )
 
 ts_library(
+    name = "flaky_target_chip",
+    srcs = ["flaky_target_chip.tsx"],
+    deps = [
+        "//app/components/button:link_button",
+        "//app/router",
+        "//app/service:rpc_service",
+        "//proto:target_ts_proto",
+        "@npm//@types/react",
+        "@npm//lucide-react",
+        "@npm//react",
+        "@npm//tslib",
+    ],
+)
+
+ts_library(
     name = "action_card",
     srcs = ["action_card.tsx"],
     deps = [
@@ -73,7 +88,7 @@ ts_library(
     srcs = ["target_test_cases_card.tsx"],
     deps = [
         "//app/format",
-        "//app/terminal",
+        "//app/target:target_test_suite",
         "//app/util:proto",
         "//proto:build_event_stream_ts_proto",
         "@npm//@types/react",
@@ -112,6 +127,24 @@ ts_library(
 )
 
 ts_library(
+    name = "target_flaky_test_card",
+    srcs = ["target_flaky_test_card.tsx"],
+    deps = [
+        "//app/components/link",
+        "//app/format",
+        "//app/router",
+        "//app/target:target_test_suite",
+        "//app/util:proto",
+        "//proto:build_event_stream_ts_proto",
+        "@npm//@types/moment",
+        "@npm//@types/react",
+        "@npm//lucide-react",
+        "@npm//moment",
+        "@npm//react",
+    ],
+)
+
+ts_library(
     name = "target_test_coverage_card",
     srcs = ["target_test_coverage_card.tsx"],
     deps = [
@@ -127,6 +160,16 @@ ts_library(
 )
 
 ts_library(
+    name = "target_test_suite",
+    srcs = ["target_test_suite.tsx"],
+    deps = [
+        "//app/terminal",
+        "@npm//@types/react",
+        "@npm//react",
+    ],
+)
+
+ts_library(
     name = "target_v2",
     srcs = ["target_v2.tsx"],
     deps = [
@@ -134,7 +177,6 @@ ts_library(
         "//app/auth:auth_service",
         "//app/capabilities",
         "//app/components/button:link_button",
-        "//app/errors:error_service",
         "//app/format",
         "//app/invocation:cache_requests_card",
         "//app/invocation:invocation_model",
@@ -142,6 +184,7 @@ ts_library(
         "//app/router",
         "//app/service:rpc_service",
         "//app/target:action_card",
+        "//app/target:flaky_target_chip",
         "//app/target:target_artifacts_card",
         "//app/target:target_test_coverage_card",
         "//app/target:target_test_document_card",
@@ -149,7 +192,6 @@ ts_library(
         "//app/util:clipboard",
         "//app/util:proto",
         "//proto:build_event_stream_ts_proto",
-        "//proto:invocation_ts_proto",
         "//proto:target_ts_proto",
         "//proto/api/v1:common_ts_proto",
         "@npm//@types/react",

--- a/app/target/flaky_target_chip.tsx
+++ b/app/target/flaky_target_chip.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { target } from "../../proto/target_ts_proto";
+import rpc_service from "../service/rpc_service";
+import { Path } from "../router/router";
+import { OutlinedLinkButton } from "../components/button/link_button";
+import { HelpCircle } from "lucide-react";
+
+interface Props {
+  repo: string;
+  labels: string[];
+}
+
+interface State {
+  loading: boolean;
+  response?: target.GetTargetStatsResponse;
+}
+
+export default class FlakyTargetChipComponent extends React.Component<Props, State> {
+  state: State = { loading: true };
+
+  componentDidMount() {
+    rpc_service.service
+      .getTargetStats({ repo: this.props.repo, labels: this.props.labels })
+      .then((r) => this.setState({ response: r }))
+      .finally(() => this.setState({ loading: false }));
+  }
+  render() {
+    if (this.state.loading) {
+      return (
+        <OutlinedLinkButton
+          href={"javascript:;"}
+          title={"Determining whether or not this test has been previously flaky."}
+          className="flaky-target-chip">
+          <HelpCircle className="icon orange" /> Checking flakes...
+        </OutlinedLinkButton>
+      );
+    }
+
+    const flakes = this.state.response?.stats
+      .filter((v) => v.data?.flakyRuns || v.data?.likelyFlakyRuns)
+      .map((v) => v.label);
+    if (flakes && flakes.length > 0) {
+      const targets = flakes.join(" ");
+      const title =
+        this.props.labels.length === 1
+          ? "This target was recently flaky--click to see samples."
+          : "Some failed targets were recently flaky--click to see samples.";
+      const href =
+        this.props.labels.length === 1
+          ? `${Path.tapPath}?target=${encodeURIComponent(targets)}#flakes`
+          : `${Path.tapPath}?targetFilter=${encodeURIComponent(targets)}#flakes`;
+      return (
+        <OutlinedLinkButton href={href} title={title} className="flaky-target-chip">
+          <HelpCircle className="icon orange" /> Recently flaky
+        </OutlinedLinkButton>
+      );
+    }
+
+    // Didn't find flakes, hide the chip.
+    return <></>;
+  }
+}

--- a/app/target/target_flaky_test_card.tsx
+++ b/app/target/target_flaky_test_card.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import format from "../format/format";
+import { AlertCircle, XCircle, HelpCircle } from "lucide-react";
+import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
+import { durationToMillisWithFallback } from "../util/proto";
+import moment from "moment";
+import router from "../router/router";
+import Link from "../components/link/link";
+import TargetTestSuiteComponent from "./target_test_suite";
+
+interface Props {
+  invocationId: string;
+  invocationStartTimeUsec: number;
+  target: string;
+  buildEvent: build_event_stream.BuildEvent;
+  testSuite: Element;
+  status: string;
+}
+
+export default class TargetFlakyTestCardComponent extends React.Component<Props> {
+  getStatusTitle() {
+    switch (this.props.status) {
+      case "error":
+        return "Errored";
+      case "flaky":
+        return "Flaky";
+      default:
+        return "Failed";
+    }
+  }
+
+  renderStatusIcon() {
+    switch (this.props.status) {
+      case "error":
+        return <AlertCircle className="icon black" />;
+      case "flaky":
+        return <HelpCircle className="icon orange" />;
+      default:
+        return <XCircle className="icon red" />;
+    }
+  }
+
+  getCardClass() {
+    switch (this.props.status) {
+      case "flaky":
+        return "card-flaky";
+      case "error":
+        return "card-broken";
+      default:
+        return "card-failure";
+    }
+  }
+
+  render() {
+    let testCases = Array.from(this.props.testSuite.getElementsByTagName("testcase")).filter(
+      (testCase) => testCase.getElementsByTagName("failure").length > 0
+    );
+
+    return (
+      testCases.length > 0 && (
+        <div className={`card artifacts ${this.getCardClass()}`}>
+          {this.renderStatusIcon()}
+          <div className="content">
+            <Link
+              href={
+                router.getInvocationUrl(this.props.invocationId) + "?target=" + encodeURIComponent(this.props.target)
+              }>
+              <div className="title">
+                {this.getStatusTitle()}: {this.props.testSuite.getAttribute("name")}
+              </div>
+              <div className="test-subtitle">
+                {testCases.length} {testCases.length == 1 ? "test" : "tests"} failed in{" "}
+                {this.props.testSuite.getAttribute("time")
+                  ? `${this.props.testSuite.getAttribute("time")} s`
+                  : format.durationMillis(
+                      durationToMillisWithFallback(
+                        this.props.buildEvent?.testResult?.testAttemptDuration,
+                        this.props.buildEvent?.testResult?.testAttemptDurationMillis || 0
+                      )
+                    )}{" "}
+                <span title={format.formatTimestampUsec(this.props.invocationStartTimeUsec)}>
+                  ({moment(this.props.invocationStartTimeUsec / 1000).fromNow()})
+                </span>
+              </div>
+            </Link>
+            <TargetTestSuiteComponent testCases={testCases} dark={true}></TargetTestSuiteComponent>
+          </div>
+        </div>
+      )
+    );
+  }
+}

--- a/app/target/target_flaky_test_card.tsx
+++ b/app/target/target_flaky_test_card.tsx
@@ -15,6 +15,7 @@ interface Props {
   buildEvent: build_event_stream.BuildEvent;
   testSuite: Element;
   status: string;
+  dark: boolean;
 }
 
 export default class TargetFlakyTestCardComponent extends React.Component<Props> {
@@ -83,7 +84,7 @@ export default class TargetFlakyTestCardComponent extends React.Component<Props>
                 </span>
               </div>
             </Link>
-            <TargetTestSuiteComponent testCases={testCases} dark={true}></TargetTestSuiteComponent>
+            <TargetTestSuiteComponent testCases={testCases} dark={this.props.dark}></TargetTestSuiteComponent>
           </div>
         </div>
       )

--- a/app/target/target_test_cases_card.tsx
+++ b/app/target/target_test_cases_card.tsx
@@ -3,7 +3,7 @@ import format from "../format/format";
 import { AlertCircle, XCircle, PlayCircle, CheckCircle } from "lucide-react";
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
 import { durationToMillisWithFallback } from "../util/proto";
-import TerminalComponent from "../terminal/terminal";
+import TargetTestSuiteComponent from "./target_test_suite";
 
 interface Props {
   buildEvent?: build_event_stream.BuildEvent;
@@ -75,41 +75,7 @@ export default class TargetTestCasesCardComponent extends React.Component<Props>
                     )
                   )}
             </div>
-            <div className="test-document">
-              <div className="test-suite">
-                <div className="test-cases">
-                  {testCases.map((testCase) => (
-                    <div className="test-case-container">
-                      <div className="test-case">
-                        <div className="test-case-name">
-                          {testCase.getAttribute("classname") && (
-                            <span className="test-class">{testCase.getAttribute("classname")}.</span>
-                          )}
-                          {testCase.getAttribute("name")}
-                        </div>
-                        <div className="test-case-time">{testCase.getAttribute("time")} s</div>
-                      </div>
-                      {Array.from(testCase.children).map((child) => (
-                        <div className="test-case-info">
-                          <div className="test-case-message">
-                            {child.getAttribute("message")} {child.getAttribute("type")}
-                          </div>
-                          {!!child.textContent?.trim() && (
-                            <TerminalComponent
-                              value={child.textContent
-                                .replaceAll(`�[`, `\u001b[`)
-                                .replaceAll(`#x1b[`, `\u001b[`)
-                                .replaceAll(`#x1B[`, `\u001b[`)}
-                              lightTheme={!this.props.dark}
-                            />
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
+            <TargetTestSuiteComponent testCases={testCases} dark={this.props.dark ?? false}></TargetTestSuiteComponent>
           </div>
         </div>
       )

--- a/app/target/target_test_suite.tsx
+++ b/app/target/target_test_suite.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import TerminalComponent from "../terminal/terminal";
+
+interface Props {
+  testCases: Element[];
+  tagName?: string;
+  dark: boolean;
+}
+
+export default class TargetTestSuiteComponent extends React.Component<Props> {
+  render() {
+    return (
+      <div className="test-document">
+        <div className="test-suite">
+          <div className="test-cases">
+            {this.props.testCases.map((testCase) => (
+              <div className="test-case-container">
+                <div className="test-case">
+                  <div className="test-case-name">
+                    {testCase.getAttribute("classname") && (
+                      <span className="test-class">{testCase.getAttribute("classname")}.</span>
+                    )}
+                    {testCase.getAttribute("name")}
+                  </div>
+                  <div className="test-case-time">{testCase.getAttribute("time")} s</div>
+                </div>
+                {Array.from(testCase.children).map((child) => (
+                  <div className="test-case-info">
+                    <div className="test-case-message">
+                      {child.getAttribute("message")} {child.getAttribute("type")}
+                    </div>
+                    {!!child.textContent?.trim() && (
+                      <TerminalComponent
+                        value={child.textContent
+                          .replaceAll(`�[`, `\u001b[`)
+                          .replaceAll(`#x1b[`, `\u001b[`)
+                          .replaceAll(`#x1B[`, `\u001b[`)}
+                        lightTheme={!this.props.dark}
+                      />
+                    )}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/app/target/target_v2.tsx
+++ b/app/target/target_v2.tsx
@@ -8,7 +8,6 @@ import router from "../router/router";
 import format from "../format/format";
 import { User } from "../auth/auth_service";
 import { Hash, Target, Box, SkipForward, CheckCircle, XCircle, HelpCircle, Clock, Copy, History } from "lucide-react";
-import { invocation } from "../../proto/invocation_ts_proto";
 import { build_event_stream } from "../../proto/build_event_stream_ts_proto";
 import { copyToClipboard } from "../util/clipboard";
 import alert_service from "../alert/alert_service";
@@ -17,11 +16,11 @@ import { OutlinedLinkButton } from "../components/button/link_button";
 import { target } from "../../proto/target_ts_proto";
 import { api as api_common } from "../../proto/api/v1/common_ts_proto";
 import rpc_service from "../service/rpc_service";
-import error_service from "../errors/error_service";
 import { renderTestSize } from "../invocation/target_util";
 import capabilities from "../capabilities/capabilities";
 import CacheRequestsCardComponent from "../invocation/cache_requests_card";
 import InvocationModel from "../invocation/invocation_model";
+import FlakyTargetChipComponent from "./flaky_target_chip";
 
 const Status = api_common.v1.Status;
 
@@ -274,6 +273,13 @@ export default class TargetV2Component extends React.Component<TargetProps, Stat
                   <span>Target history</span>
                 </OutlinedLinkButton>
               )}
+              {capabilities.config.targetFlakesUiEnabled &&
+                this.props.repo &&
+                isPotentialFailureOrFlakeStatus(this.props.status) && (
+                  <FlakyTargetChipComponent
+                    labels={[this.props.label]}
+                    repo={this.props.repo}></FlakyTargetChipComponent>
+                )}
             </div>
             <div className="details">
               {Boolean(target?.status) && (
@@ -378,5 +384,18 @@ export default class TargetV2Component extends React.Component<TargetProps, Stat
         </div>
       </div>
     );
+  }
+}
+
+function isPotentialFailureOrFlakeStatus(s: api_common.v1.Status): boolean {
+  switch (s) {
+    case Status.BUILDING:
+    case Status.BUILT:
+    case Status.TESTING:
+    case Status.PASSED:
+    case Status.SKIPPED:
+      return false;
+    default:
+      return true;
   }
 }

--- a/enterprise/app/root/root.tsx
+++ b/enterprise/app/root/root.tsx
@@ -364,7 +364,12 @@ export default class EnterpriseRootComponent extends React.Component {
                   {orgAccessDenied && this.state.user && <OrgAccessDeniedComponent user={this.state.user} />}
                   {tests && this.state.user && (
                     <Suspense fallback={<div className="loading" />}>
-                      <TapComponent user={this.state.user} search={this.state.search} tab={this.state.tab} />
+                      <TapComponent
+                        user={this.state.user}
+                        search={this.state.search}
+                        tab={this.state.tab}
+                        dark={this.state.preferences?.lightTerminalEnabled ?? true}
+                      />
                     </Suspense>
                   )}
                   {trends && this.state.user && (

--- a/enterprise/app/tap/BUILD
+++ b/enterprise/app/tap/BUILD
@@ -10,18 +10,48 @@ ts_library(
     deps = [
         "//app/auth:auth_service",
         "//app/capabilities",
-        "//app/components/button",
-        "//app/components/filter_input",
         "//app/components/select",
-        "//app/components/spinner",
         "//app/errors:error_service",
         "//app/format",
         "//app/router",
         "//app/service:rpc_service",
         "//app/util:git",
-        "//app/util:math",
-        "//proto:duration_ts_proto",
+        "//enterprise/app/tap:flakes",
+        "//enterprise/app/tap:grid",
+        "//enterprise/app/tap:grid_sort_controls",
         "//proto:invocation_ts_proto",
+        "@npm//@types/react",
+        "@npm//react",
+    ],
+)
+
+ts_library(
+    name = "tap_empty_state",
+    srcs = ["tap_empty_state.tsx"],
+    deps = [
+        "@npm//@types/react",
+        "@npm//lucide-react",
+        "@npm//react",
+    ],
+)
+
+ts_library(
+    name = "grid",
+    srcs = ["grid.tsx"],
+    deps = [
+        "//app/auth:auth_service",
+        "//app/capabilities",
+        "//app/components/button",
+        "//app/components/filter_input",
+        "//app/components/spinner",
+        "//app/errors:error_service",
+        "//app/format",
+        "//app/router",
+        "//app/service:rpc_service",
+        "//app/util:math",
+        "//enterprise/app/tap:grid_common",
+        "//enterprise/app/tap:tap_empty_state",
+        "//proto:duration_ts_proto",
         "//proto:target_ts_proto",
         "//proto/api/v1:common_ts_proto",
         "@npm//@types/long",
@@ -34,6 +64,49 @@ ts_library(
         "@npm//react",
         "@npm//react-dom",
         "@npm//rxjs",
+        "@npm//tslib",
+    ],
+)
+
+ts_library(
+    name = "grid_common",
+    srcs = ["grid_common.ts"],
+)
+
+ts_library(
+    name = "grid_sort_controls",
+    srcs = ["grid_sort_controls.tsx"],
+    deps = [
+        "//app/components/select",
+        "//app/router",
+        "//enterprise/app/tap:grid_common",
+        "@npm//@types/react",
+        "@npm//react",
+    ],
+)
+
+ts_library(
+    name = "flakes",
+    srcs = ["flakes.tsx"],
+    deps = [
+        "//app/components/banner",
+        "//app/components/filter_input",
+        "//app/components/link",
+        "//app/components/select",
+        "//app/format",
+        "//app/router",
+        "//app/service:rpc_service",
+        "//app/target:target_flaky_test_card",
+        "//app/util:async",
+        "//enterprise/app/tap:tap_empty_state",
+        "//enterprise/app/trends:trends_chart",
+        "//proto:target_ts_proto",
+        "//proto/api/v1:common_ts_proto",
+        "@npm//@types/moment",
+        "@npm//@types/react",
+        "@npm//lucide-react",
+        "@npm//moment",
+        "@npm//react",
         "@npm//tslib",
     ],
 )

--- a/enterprise/app/tap/flakes.tsx
+++ b/enterprise/app/tap/flakes.tsx
@@ -19,6 +19,7 @@ import TargetFlakyTestCardComponent from "../../../app/target/target_flaky_test_
 interface Props {
   search: URLSearchParams;
   repo: string;
+  dark: boolean;
 }
 
 interface TestXmlOrError {
@@ -381,7 +382,7 @@ export default class FlakesComponent extends React.Component<Props, State> {
                         testSuite={testSuite}
                         buildEvent={s.event!}
                         status={status}
-                        dark={true}></TargetFlakyTestCardComponent>
+                        dark={this.props.dark}></TargetFlakyTestCardComponent>
                     );
                   });
               }

--- a/enterprise/app/tap/flakes.tsx
+++ b/enterprise/app/tap/flakes.tsx
@@ -1,0 +1,399 @@
+import React from "react";
+import { CancelablePromise } from "../../../app/util/async";
+import { target } from "../../../proto/target_ts_proto";
+import { api as api_common } from "../../../proto/api/v1/common_ts_proto";
+import rpc_service from "../../../app/service/rpc_service";
+import TrendsChartComponent from "../trends/trends_chart";
+import moment from "moment";
+import { ChartColor } from "../trends/trends_chart";
+import format, { count } from "../../../app/format/format";
+import { FilterInput } from "../../../app/components/filter_input/filter_input";
+import Link from "../../../app/components/link/link";
+import { Target } from "lucide-react";
+import router from "../../../app/router/router";
+import Select, { Option } from "../../../app/components/select/select";
+import TapEmptyStateComponent from "./tap_empty_state";
+import Banner from "../../../app/components/banner/banner";
+import TargetFlakyTestCardComponent from "../../../app/target/target_flaky_test_card";
+
+interface Props {
+  search: URLSearchParams;
+  repo: string;
+}
+
+interface TestXmlOrError {
+  errorMessage?: string;
+  testXmlDocument?: Document;
+}
+
+type TableSort = "Flaky %" | "Flakes + Likely flakes" | "Flakes";
+const TableSortValues: TableSort[] = ["Flaky %", "Flakes + Likely flakes", "Flakes"];
+
+interface State {
+  pendingChartRequest?: CancelablePromise<target.GetDailyTargetStatsResponse>;
+  chartData?: target.GetDailyTargetStatsResponse;
+  pendingTableRequest?: CancelablePromise<target.GetTargetStatsResponse>;
+  tableData?: target.GetTargetStatsResponse;
+  tableSort: TableSort;
+  pendingFlakeSamplesRequest?: CancelablePromise<target.GetTargetFlakeSamplesResponse>;
+  flakeSamples?: target.GetTargetFlakeSamplesResponse;
+  flakeTestXmlDocs: Map<string, TestXmlOrError>;
+  error?: string;
+}
+
+export default class FlakesComponent extends React.Component<Props, State> {
+  state: State = {
+    flakeTestXmlDocs: new Map(),
+    tableSort: "Flaky %",
+  };
+
+  componentDidMount(): void {
+    this.fetch();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    const currentTarget = this.props.search.get("target") ?? "";
+    const prevTarget = prevProps.search.get("target") ?? "";
+    if (currentTarget !== prevTarget) {
+      this.fetch();
+    }
+  }
+
+  fetch() {
+    const label = this.props.search.get("target");
+    const labels = label ? [label] : [];
+
+    this.state.pendingChartRequest?.cancel();
+    this.state.pendingTableRequest?.cancel();
+    this.state.pendingFlakeSamplesRequest?.cancel();
+
+    this.setState({
+      pendingChartRequest: undefined,
+      pendingTableRequest: undefined,
+      pendingFlakeSamplesRequest: undefined,
+      error: undefined,
+    });
+
+    const chartRequest = rpc_service.service.getDailyTargetStats({ labels, repo: this.props.repo });
+    const tableRequest = rpc_service.service.getTargetStats({ labels, repo: this.props.repo });
+    this.setState({ pendingChartRequest: chartRequest, pendingTableRequest: tableRequest });
+
+    chartRequest
+      .then((r) => this.setState({ pendingChartRequest: undefined, chartData: r }))
+      .catch(() => {
+        this.setState({
+          pendingChartRequest: undefined,
+          error: "Failed to load flakes data.  Please try again later.",
+        });
+      });
+    tableRequest
+      .then((r) => {
+        console.log(r);
+        this.setState({ pendingTableRequest: undefined, tableData: r });
+      })
+      .catch(() => {
+        this.setState({
+          pendingTableRequest: undefined,
+          error: "Failed to load flakes data.  Please try again later.",
+        });
+      });
+
+    if (label) {
+      const flakeSamplesRequest = rpc_service.service.getTargetFlakeSamples({ label, repo: this.props.repo });
+      this.setState({ pendingFlakeSamplesRequest: flakeSamplesRequest });
+
+      flakeSamplesRequest.then((r) => {
+        console.log(r);
+        this.setState({ pendingFlakeSamplesRequest: undefined, flakeSamples: r });
+        r.samples.forEach((s) => {
+          this.fetchTestXml(s);
+        });
+      });
+    }
+  }
+
+  fetchTestXml(sample: target.FlakeSample) {
+    rpc_service
+      .fetchBytestreamFile(sample.testXmlFileUri, sample.invocationId)
+      .then((contents: string) => {
+        let parser = new DOMParser();
+        let xmlDoc = parser.parseFromString(contents, "text/xml");
+        this.setState((s) => {
+          const newMap = new Map(s.flakeTestXmlDocs);
+          newMap.set(sample.testXmlFileUri, { testXmlDocument: xmlDoc });
+          return { flakeTestXmlDocs: newMap };
+        });
+      })
+      .catch(() => {
+        this.setState((s) => {
+          const newMap = new Map(s.flakeTestXmlDocs);
+          newMap.set(sample.testXmlFileUri, {
+            errorMessage: "Failed to load test results (cache expired or invalid test xml?)",
+          });
+          return { flakeTestXmlDocs: newMap };
+        });
+      });
+  }
+
+  loadMoreSamples() {
+    const label = this.props.search.get("target");
+    if (!label || !this.state.flakeSamples?.nextPageToken) {
+      // Shouldn't actually happen, just making TS happy.
+      return;
+    }
+
+    const flakeSamplesRequest = rpc_service.service.getTargetFlakeSamples({
+      label,
+      repo: this.props.repo,
+      pageToken: this.state.flakeSamples.nextPageToken,
+    });
+
+    this.setState({ pendingFlakeSamplesRequest: flakeSamplesRequest });
+
+    const previousSamples = this.state.flakeSamples.samples;
+
+    flakeSamplesRequest.then((r) => {
+      console.log(r);
+      r.samples.forEach((s) => {
+        this.fetchTestXml(s);
+      });
+
+      r.samples = previousSamples.concat(r.samples);
+      this.setState({ pendingFlakeSamplesRequest: undefined, flakeSamples: r });
+    });
+  }
+
+  getChartData(start: number): target.TargetStatsData {
+    const date = moment.unix(start).format("YYYY-MM-DD");
+    return this.state.chartData?.stats.find((v) => v.date === date)?.data ?? new target.TargetStatsData({});
+  }
+
+  handleStatsFilterChange(newValue: string) {
+    router.updateParams({ targetFilter: newValue.trim() });
+  }
+
+  handleTableSortChange(tableSortString: string) {
+    const tableSort: TableSort = TableSortValues.find((v) => v === tableSortString) ?? "Flaky %";
+    this.setState({ tableSort });
+  }
+
+  renderFlakePercent(stats: target.TargetStatsData | null | undefined): string {
+    if (!stats) {
+      return "0%";
+    }
+    const totalFlakes = (+stats.flakyRuns ?? 0) + (+stats.likelyFlakyRuns ?? 0);
+    if (totalFlakes === 0) {
+      return "0%";
+    }
+    const percent = format.percent(totalFlakes / (+stats.totalRuns ?? 1));
+
+    return percent === "0" ? "<1%" : percent + "%";
+  }
+
+  renderPluralName(value: number, label: string) {
+    return label + (value !== 1 ? "s" : "");
+  }
+
+  renderPluralCount(value: number | undefined, label: string) {
+    const val = value ?? 0;
+    return `${val} ${this.renderPluralName(val, label)}`;
+  }
+
+  render() {
+    if (this.state.pendingChartRequest || this.state.pendingTableRequest) {
+      return <div className="loading"></div>;
+    }
+    if (this.state.error) {
+      return (
+        <div className="container">
+          <Banner type="warning">{this.state.error}</Banner>
+        </div>
+      );
+    }
+
+    const singleTarget = this.props.search.get("target");
+    console.log(singleTarget);
+
+    let tableData = singleTarget ? [] : this.state.tableData?.stats ?? [];
+    let sortFn: (a: target.AggregateTargetStats, b: target.AggregateTargetStats) => number;
+    if (this.state.tableSort === "Flakes") {
+      sortFn = (a, b) => {
+        const aFlakes = +(a.data?.flakyRuns ?? 0);
+        const bFlakes = +(b.data?.flakyRuns ?? 0);
+
+        return bFlakes - aFlakes;
+      };
+    } else if (this.state.tableSort === "Flakes + Likely flakes") {
+      sortFn = (a, b) => {
+        const aFlakes = +(a.data?.flakyRuns ?? 0);
+        const aLikelyFlakes = +(a.data?.likelyFlakyRuns ?? 0);
+        const bFlakes = +(b.data?.flakyRuns ?? 0);
+        const bLikelyFlakes = +(b.data?.likelyFlakyRuns ?? 0);
+
+        return bFlakes + bLikelyFlakes - (aFlakes + aLikelyFlakes);
+      };
+    } else {
+      sortFn = (a, b) => {
+        const aFlakes = +(a.data?.flakyRuns ?? 0);
+        const aLikelyFlakes = +(a.data?.likelyFlakyRuns ?? 0);
+        const bFlakes = +(b.data?.flakyRuns ?? 0);
+        const bLikelyFlakes = +(b.data?.likelyFlakyRuns ?? 0);
+        const aTotal = +(a.data?.totalRuns ?? 1);
+        const bTotal = +(b.data?.totalRuns ?? 1);
+
+        return (bFlakes + bLikelyFlakes) / bTotal - (aFlakes + aLikelyFlakes) / aTotal;
+      };
+    }
+
+    let filteredTableData = tableData;
+    const tableFilters = (this.props.search.get("targetFilter") ?? "").split(" ").filter((f) => f.length > 0);
+    if (tableFilters.length > 0) {
+      filteredTableData = filteredTableData.filter((v) => tableFilters.find((f) => v.label.includes(f)));
+    }
+    filteredTableData.sort(sortFn);
+
+    let dates: number[] = [];
+    let currentDay = moment().startOf("day");
+    for (let i = 0; i < 7; i++) {
+      dates = [currentDay.unix(), ...dates];
+      currentDay = currentDay.subtract(1, "day");
+    }
+
+    const isEmpty = this.state.tableData && this.state.tableData.stats.length === 0;
+
+    if (isEmpty) {
+      return (
+        <TapEmptyStateComponent
+          title="No flakes found in the last week!"
+          message="Wow! Either you have no flaky CI tests, or no CI test data all. To see CI test data, make sure your CI tests are configured as follows:"
+          showV2Instructions={true}></TapEmptyStateComponent>
+      );
+    }
+
+    return (
+      <div>
+        <div className="container">
+          <h3 className="flakes-chart-header">{`Daily flakes ${
+            singleTarget ? `for ${singleTarget} ` : ""
+          }(last 7 days)`}</h3>
+          <div className="card chart-card">
+            <TrendsChartComponent
+              title=""
+              standaloneChart={true}
+              data={dates}
+              dataSeries={[
+                {
+                  name: "flakes",
+                  extractValue: (ts) => +(this.getChartData(ts).flakyRuns ?? 0),
+                  formatHoverValue: (value) => this.renderPluralCount(value, "flake"),
+                  stackId: "flakes",
+                  color: ChartColor.ORANGE,
+                },
+                {
+                  name: "likely flakes",
+                  extractValue: (ts) => +(this.getChartData(ts).likelyFlakyRuns ?? 0),
+                  formatHoverValue: (value) => this.renderPluralCount(value, "likely flake"),
+                  stackId: "flakes",
+                  color: ChartColor.RED,
+                },
+              ]}
+              primaryYAxis={{
+                formatTickValue: count,
+                allowDecimals: false,
+              }}
+              formatXAxisLabel={(ts) => moment.unix(ts).format("MMM D")}
+              formatHoverXAxisLabel={(ts) => moment.unix(ts).format("dddd, MMMM Do YYYY")}
+              ticks={[]}></TrendsChartComponent>
+          </div>
+        </div>
+        {tableData.length > 0 && (
+          <div className="container">
+            <h3 className="flakes-list-header">Flaky targets (last 7 days)</h3>
+
+            <div className="card">
+              <div className="content">
+                <div className="flake-table-header">
+                  <FilterInput onChange={(e) => this.handleStatsFilterChange(e.target.value)}></FilterInput>
+                  <div className="flake-table-sort-controls">
+                    <span className="invocation-sort-title">Sort by</span>
+                    <Select onChange={(e) => this.handleTableSortChange(e.target.value)} value={this.state.tableSort}>
+                      <Option value="Flaky %">Flaky %</Option>
+                      <Option value="Flakes">Flakes</Option>
+                      <Option value="Flakes + Likely Flakes">Flakes + Likely Flakes</Option>
+                    </Select>
+                  </div>
+                </div>
+                <div className="flake-table">
+                  {filteredTableData.map((s, index) => {
+                    return (
+                      <Link key={index} className="flake-table-row" href={`/tests/?target=${s.label}#flakes`}>
+                        <div className="flake-table-row-image">
+                          <Target className="icon"></Target>
+                        </div>
+                        <div className="flake-table-row-content">
+                          <div className="flake-table-row-header">{s.label}</div>
+                          <div className="flake-table-row-stats">
+                            <div className="flake-stat">
+                              <span className="flake-stat-value">{this.renderFlakePercent(s.data)}</span> flaky
+                            </div>
+                            <div className="flake-stat">
+                              <span className="flake-stat-value">{s.data?.flakyRuns ?? 0}</span>{" "}
+                              {this.renderPluralName(+(s.data?.flakyRuns ?? 0), "flake")}
+                            </div>
+                            <div className="flake-stat">
+                              <span className="flake-stat-value">{s.data?.likelyFlakyRuns ?? 0}</span>{" "}
+                              {this.renderPluralName(+(s.data?.likelyFlakyRuns ?? 0), "likely flake")}
+                            </div>
+                            <div className="flake-stat">
+                              <span className="flake-stat-value">{s.data?.totalRuns ?? 0}</span> total runs
+                            </div>
+                          </div>
+                        </div>
+                      </Link>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+        {singleTarget && this.state.tableData && <div></div>}
+        {singleTarget && this.state.tableData && this.state.flakeSamples && (
+          <div className="container">
+            <h3 className="flakes-list-header">Sample flakes for {singleTarget}</h3>
+            {this.state.flakeSamples.samples.map((s) => {
+              const status = s.status === api_common.v1.Status.FLAKY ? "flaky" : "failure";
+              const testXmlDoc = this.state.flakeTestXmlDocs.get(s.testXmlFileUri);
+              if (!testXmlDoc) {
+                return <div className="loading"></div>;
+              } else if (testXmlDoc.errorMessage) {
+                return <div>{testXmlDoc.errorMessage}</div>;
+              } else if (testXmlDoc.testXmlDocument) {
+                return Array.from(testXmlDoc.testXmlDocument.getElementsByTagName("testsuite"))
+                  .filter((testSuite) => testSuite.getElementsByTagName("testcase").length > 0)
+                  .sort((a, b) => +(b.getAttribute("failures") || 0) - +(a.getAttribute("failures") || 0))
+                  .map((testSuite) => {
+                    return (
+                      <TargetFlakyTestCardComponent
+                        invocationId={s.invocationId}
+                        invocationStartTimeUsec={+s.invocationStartTimeUsec}
+                        target={singleTarget}
+                        testSuite={testSuite}
+                        buildEvent={s.event!}
+                        status={status}
+                        dark={true}></TargetFlakyTestCardComponent>
+                    );
+                  });
+              }
+            })}
+            {this.state.flakeSamples.nextPageToken && (
+              <button className="load-more" onClick={() => this.loadMoreSamples()}>
+                Load more samples
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+}

--- a/enterprise/app/tap/grid.tsx
+++ b/enterprise/app/tap/grid.tsx
@@ -1,0 +1,726 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import Long from "long";
+import moment from "moment";
+import rpcService, { CancelablePromise } from "../../../app/service/rpc_service";
+import { User } from "../../../app/auth/auth_service";
+import { api } from "../../../proto/api/v1/common_ts_proto";
+import { target } from "../../../proto/target_ts_proto";
+import { Subscription } from "rxjs";
+import router from "../../../app/router/router";
+import { google as google_duration } from "../../../proto/duration_ts_proto";
+import format from "../../../app/format/format";
+import { clamp } from "../../../app/util/math";
+import { FilterInput } from "../../../app/components/filter_input/filter_input";
+import Spinner from "../../../app/components/spinner/spinner";
+import {
+  Activity,
+  AlarmClock,
+  AlertTriangle,
+  Check,
+  ChevronsRight,
+  Clock,
+  Hammer,
+  HelpCircle,
+  SkipForward,
+  Slash,
+  Snowflake,
+  Wrench,
+  X,
+} from "lucide-react";
+import capabilities from "../../../app/capabilities/capabilities";
+import FilledButton from "../../../app/components/button/button";
+import errorService from "../../../app/errors/error_service";
+import {
+  COLOR_MODE_PARAM,
+  ColorMode,
+  SORT_DIRECTION_PARAM,
+  SORT_MODE_PARAM,
+  SortDirection,
+  SortMode,
+} from "./grid_common";
+import TapEmptyStateComponent from "./tap_empty_state";
+
+interface Props {
+  user: User;
+  search: URLSearchParams;
+  repo: string;
+}
+
+interface State extends CommitGrouping {
+  targetHistory: target.TargetHistory[];
+  nextPageToken: string;
+  loading: boolean;
+  targetLimit: number;
+  invocationLimit: number;
+  stats: Map<string, Stat>;
+  maxInvocations: number;
+  maxDuration: number;
+}
+
+interface CommitGrouping {
+  commits: string[] | null;
+  commitToMaxInvocationCreatedAtUsec: Map<string, number> | null;
+  commitToTargetLabelToStatuses: Map<string, Map<string, target.ITargetStatus[]>> | null;
+}
+
+interface CommitStatus {
+  commitSha: string;
+  statuses: target.ITargetStatus[] | null;
+}
+
+interface Stat {
+  count: number;
+  pass: number;
+  totalDuration: number;
+  maxDuration: number;
+  avgDuration: number;
+  flake: number;
+}
+
+const Status = api.v1.Status;
+
+const MIN_OPACITY = 0.1;
+const DAYS_OF_DATA_TO_FETCH = 7;
+
+export default class TestGridComponent extends React.Component<Props, State> {
+  state: State = {
+    targetHistory: [],
+    nextPageToken: "",
+    commits: null,
+    commitToTargetLabelToStatuses: null,
+    commitToMaxInvocationCreatedAtUsec: null,
+    loading: true,
+    targetLimit: 100,
+    invocationLimit: capabilities.config.testGridV2Enabled
+      ? Number.MAX_SAFE_INTEGER
+      : Math.min(100, Math.max(20, (window.innerWidth - 312) / 34)),
+    stats: new Map<string, Stat>(),
+    maxInvocations: 0,
+    maxDuration: 1,
+  };
+
+  isV2 = Boolean(capabilities.config.testGridV2Enabled);
+
+  subscription?: Subscription;
+  targetsRPC?: CancelablePromise;
+
+  componentWillMount() {
+    document.title = `Tests | BuildBuddy`;
+
+    this.fetchTargets(/*initial=*/ true);
+
+    this.subscription = rpcService.events.subscribe({
+      next: (name) => name == "refresh" && this.fetchTargets(/*initial=*/ true),
+    });
+  }
+
+  componentWillUnmount() {
+    this.subscription?.unsubscribe();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.repo !== prevProps.repo) {
+      // Repo-changed; re-fetch targets starting from scratch.
+      this.fetchTargets(/*initial=*/ true);
+    }
+  }
+
+  /**
+   * Fetches targets. If `initial`, clear any existing target history and fetch
+   * from scratch. Otherwise, append the fetched history to the existing
+   * history.
+   */
+  fetchTargets(initial: boolean) {
+    this.targetsRPC?.cancel();
+    this.setState({ loading: false });
+
+    const repoUrl = this.props.repo;
+    if (!repoUrl) {
+      this.updateState(new target.GetTargetHistoryResponse(), initial);
+      return;
+    }
+
+    let request = new target.GetTargetHistoryRequest();
+
+    request.startTimeUsec = Long.fromNumber(moment().subtract(DAYS_OF_DATA_TO_FETCH, "day").utc().valueOf() * 1000);
+    request.endTimeUsec = Long.fromNumber(moment().utc().valueOf() * 1000);
+    request.serverSidePagination = this.isV2;
+    request.pageToken = initial ? "" : this.state.nextPageToken;
+    if (this.isV2) {
+      request.query = target.TargetQuery.create({ repoUrl });
+    }
+
+    this.setState({ loading: true });
+    this.targetsRPC = rpcService.service
+      .getTargetHistory(request)
+      .then((response) => {
+        this.updateState(response, initial);
+      })
+      .catch((e) => errorService.handleError(e))
+      .finally(() => this.setState({ loading: false }));
+  }
+
+  updateState(response: target.GetTargetHistoryResponse, initial: boolean) {
+    this.state.stats.clear();
+
+    let histories = response.invocationTargets;
+    if (this.isV2 && !initial) {
+      histories = mergeHistories(this.state.targetHistory, response.invocationTargets);
+    }
+
+    let maxInvocations = 0;
+    let maxDuration = 1;
+    for (let targetHistory of histories) {
+      let stats: Stat = { count: 0, pass: 0, totalDuration: 0, maxDuration: 0, avgDuration: 0, flake: 0 };
+      for (let status of targetHistory.targetStatus) {
+        stats.count += 1;
+        let duration = this.durationToNum(status.timing?.duration || undefined);
+        stats.totalDuration += duration;
+        stats.maxDuration = Math.max(stats.maxDuration, duration);
+        if (status.status == Status.PASSED) {
+          stats.pass += 1;
+        } else if (status.status == Status.FLAKY) {
+          stats.flake += 1;
+        }
+      }
+      stats.avgDuration = stats.totalDuration / stats.count;
+      maxInvocations = Math.max(maxInvocations, stats.count);
+      maxDuration = Math.max(maxDuration, stats.maxDuration);
+      this.state.stats.set(targetHistory.target?.label || "undefined", stats);
+    }
+
+    this.setState({
+      loading: false,
+      targetHistory: histories,
+      nextPageToken: response.nextPageToken,
+      stats: this.state.stats,
+      maxInvocations: maxInvocations,
+      maxDuration: maxDuration,
+    });
+    if (this.isV2) {
+      this.setState({
+        ...this.groupByCommit(histories),
+      });
+    }
+  }
+
+  groupByCommit(targetHistories: target.ITargetHistory[]): CommitGrouping {
+    const commitToMaxInvocationCreatedAtUsec = new Map<string, number>();
+    const commitToTargetLabelToStatuses = new Map<string, Map<string, target.ITargetStatus[]>>();
+
+    for (const history of targetHistories) {
+      for (const targetStatus of history.targetStatus || []) {
+        const timestamp = Number(targetStatus.invocationCreatedAtUsec);
+        const commitMaxTimestamp = commitToMaxInvocationCreatedAtUsec.get(targetStatus.commitSha) || 0;
+        if (timestamp > commitMaxTimestamp) {
+          commitToMaxInvocationCreatedAtUsec.set(targetStatus.commitSha, timestamp);
+        }
+
+        let targetLabelToStatus = commitToTargetLabelToStatuses.get(targetStatus.commitSha);
+        if (!targetLabelToStatus) {
+          targetLabelToStatus = new Map<string, target.ITargetStatus[]>();
+          commitToTargetLabelToStatuses.set(targetStatus.commitSha, targetLabelToStatus);
+        }
+
+        if (history.target) {
+          const existing = targetLabelToStatus.get(history.target!.label);
+          if (existing) {
+            existing.push(targetStatus);
+          } else {
+            targetLabelToStatus.set(history.target!.label, [targetStatus]);
+          }
+        }
+      }
+    }
+    const commits = [...commitToMaxInvocationCreatedAtUsec.keys()].sort(
+      (a, b) => commitToMaxInvocationCreatedAtUsec.get(b)! - commitToMaxInvocationCreatedAtUsec.get(a)!
+    );
+
+    return { commits, commitToMaxInvocationCreatedAtUsec, commitToTargetLabelToStatuses };
+  }
+
+  navigateTo(destination: string, event: React.MouseEvent) {
+    event.preventDefault();
+    router.navigateTo(destination);
+  }
+
+  handleFilterChange(event: React.ChangeEvent<HTMLInputElement>) {
+    router.setQueryParam("filter", event.target.value);
+  }
+
+  durationToNum(duration?: google_duration.protobuf.Duration) {
+    if (!duration) {
+      return 0;
+    }
+    return +duration.seconds + +duration.nanos / 1000000000;
+  }
+
+  statusToString(s: api.v1.Status) {
+    switch (s) {
+      case Status.STATUS_UNSPECIFIED:
+        return "Unknown";
+      case Status.BUILDING:
+        return "Building";
+      case Status.BUILT:
+        return "Built";
+      case Status.FAILED_TO_BUILD:
+        return "Failed to build";
+      case Status.TESTING:
+        return "Testing";
+      case Status.PASSED:
+        return "Passed";
+      case Status.FAILED:
+        return "Failed";
+      case Status.TIMED_OUT:
+        return "Timed out";
+      case Status.CANCELLED:
+        return "Cancelled";
+      case Status.TOOL_FAILED:
+        return "Tool failed";
+      case Status.INCOMPLETE:
+        return "Incomplete";
+      case Status.FLAKY:
+        return "Flaky";
+      case Status.UNKNOWN:
+        return "Unknown";
+      case Status.SKIPPED:
+        return "Skipped";
+    }
+  }
+
+  statusToIcon(s: api.v1.Status) {
+    switch (s) {
+      case Status.STATUS_UNSPECIFIED:
+        return <HelpCircle />;
+      case Status.BUILDING:
+        return <Clock />;
+      case Status.BUILT:
+        return <Hammer />;
+      case Status.FAILED_TO_BUILD:
+        return <AlertTriangle />;
+      case Status.TESTING:
+        return <Clock />;
+      case Status.PASSED:
+        return <Check />;
+      case Status.FAILED:
+        return <X />;
+      case Status.TIMED_OUT:
+        return <AlarmClock />;
+      case Status.CANCELLED:
+        return <Slash />;
+      case Status.TOOL_FAILED:
+        return <Wrench />;
+      case Status.INCOMPLETE:
+        return <Activity />;
+      case Status.FLAKY:
+        return <Snowflake />;
+      case Status.UNKNOWN:
+        return <HelpCircle />;
+      case Status.SKIPPED:
+        return <SkipForward />;
+    }
+  }
+
+  loadMoreTargets() {
+    this.setState({ targetLimit: this.state.targetLimit + 50 });
+  }
+
+  loadMoreInvocations() {
+    if (this.isV2) {
+      this.fetchTargets(/*initial=*/ false);
+      return;
+    }
+
+    this.setState({ invocationLimit: this.state.invocationLimit + 50 });
+  }
+
+  handleSortChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    router.setQueryParam("sort", event.target.value);
+  }
+
+  handleDirectionChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    router.setQueryParam("direction", event.target.value);
+  }
+
+  handleColorChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    router.setQueryParam("color", event.target.value);
+  }
+
+  getSortMode(): SortMode {
+    return (this.props.search.get(SORT_MODE_PARAM) as SortMode) || "pass";
+  }
+
+  getSortDirection(): SortDirection {
+    return (this.props.search.get(SORT_DIRECTION_PARAM) as SortDirection) || "asc";
+  }
+
+  getColorMode(): ColorMode {
+    return (this.props.search.get(COLOR_MODE_PARAM) as ColorMode) || "status";
+  }
+
+  sort(a: target.ITargetHistory, b: target.ITargetHistory) {
+    let first = this.getSortDirection() == "asc" ? a : b;
+    let second = this.getSortDirection() == "asc" ? b : a;
+
+    let firstTarget = first.target;
+    let secondTarget = second.target;
+
+    if (this.getSortMode() == "target") {
+      if (!firstTarget && !secondTarget) {
+        return 0;
+      } else if (!firstTarget) {
+        return 1;
+      } else if (!secondTarget) {
+        return -1;
+      } else {
+        return firstTarget!.label.localeCompare(secondTarget!.label);
+      }
+    }
+
+    let firstStats = this.state.stats.get(first?.target?.label || "");
+    let secondStats = this.state.stats.get(second?.target?.label || "");
+
+    if (!firstStats && !secondStats) {
+      return 0;
+    } else if (!firstStats) {
+      return 1;
+    } else if (!secondStats) {
+      return -1;
+    }
+
+    switch (this.getSortMode()) {
+      case "count":
+        return firstStats!.count - secondStats!.count;
+      case "pass":
+        return firstStats!.pass / firstStats!.count - secondStats!.pass / secondStats!.count;
+      case "avgDuration":
+        return firstStats!.avgDuration - secondStats!.avgDuration;
+      case "maxDuration":
+        return firstStats!.maxDuration - secondStats!.maxDuration;
+      case "flake":
+        return firstStats!.flake / firstStats!.count - secondStats!.flake / secondStats!.count;
+    }
+    return 0;
+  }
+
+  getTargetStatuses(history: target.ITargetHistory): CommitStatus[] {
+    if (!this.isV2) {
+      return (
+        history.targetStatus?.map((status) => ({ commitSha: status.commitSha, statuses: [status], count: 1 })) || []
+      );
+    }
+    // For test grid V2, ignore the incoming history (for now) and use the indexes we
+    // built to order by commit.
+    return (
+      this.state.commits?.map((commitSha) => ({
+        commitSha,
+        statuses: this.state.commitToTargetLabelToStatuses?.get(commitSha)?.get(history.target?.label || "") || null,
+      })) || []
+    );
+  }
+
+  render() {
+    if (this.state.loading && !this.state.targetHistory?.length) {
+      return <div className="loading"></div>;
+    }
+
+    if (!this.state.targetHistory.length) {
+      return (
+        <TapEmptyStateComponent
+          title="No CI tests found in the last week!"
+          message="To see a CI test grid, make sure your CI tests are configured as follows:"
+          showV2Instructions={this.isV2}></TapEmptyStateComponent>
+      );
+    }
+
+    let filter: string = this.props.search.get("filter") || "";
+
+    const showMoreInvocationsButton = this.isV2
+      ? this.state.nextPageToken
+      : this.state.maxInvocations > this.state.invocationLimit;
+    const moreInvocationsButton = (
+      <>
+        {showMoreInvocationsButton && (
+          <FilledButton
+            className="more-invocations-button"
+            onClick={this.loadMoreInvocations.bind(this)}
+            disabled={this.state.loading}>
+            <span>Load more</span>
+            {this.state.loading ? <Spinner className="white" /> : <ChevronsRight className="icon white" />}
+          </FilledButton>
+        )}
+      </>
+    );
+
+    const filteredTargets = this.state.targetHistory
+      .filter((targetHistory) => (filter ? targetHistory.target?.label.includes(filter) : true))
+      .sort(this.sort.bind(this));
+
+    return (
+      <>
+        <div className="container">
+          <div className="target-controls">
+            <FilterInput value={filter} placeholder="Filter..." onChange={this.handleFilterChange.bind(this)} />
+            {!this.isV2 && moreInvocationsButton}
+          </div>
+        </div>
+
+        <div className="container tap-grid-container">
+          {this.isV2 && (
+            <InnerTopBar
+              commits={this.state.commits || []}
+              commitToMaxInvocationCreatedAtUsec={
+                this.state.commitToMaxInvocationCreatedAtUsec || new Map<string, number>()
+              }
+              moreInvocationsButton={moreInvocationsButton}
+            />
+          )}
+          {filteredTargets.slice(0, this.state.targetLimit).map((targetHistory) => {
+            let targetParts = targetHistory.target?.label.split(":") || [];
+            let targetPath = targetParts.length > 0 ? targetParts[0] : "";
+            let targetName = targetParts.length > 1 ? targetParts[1] : "";
+            let stats = this.state.stats.get(targetHistory.target?.label || "");
+            return (
+              <React.Fragment key={targetHistory.target?.label || ""}>
+                <div title={targetHistory.target?.ruleType || ""} className="tap-target-label">
+                  <span className="tap-target-path">{targetPath}</span>:
+                  <span className="tap-target-name">{targetName}</span>
+                  <span className="tap-target-stats">
+                    ({format.formatWithCommas(stats?.count || 0)} invocations,{" "}
+                    {format.percent((stats?.pass || 0) / (stats?.count || Number.MAX_VALUE))}% pass,{" "}
+                    {format.percent((stats?.flake || 0) / (stats?.count || Number.MAX_VALUE))}% flaky,{" "}
+                    {format.durationSec(stats?.avgDuration || 0)} avg, {format.durationSec(stats?.maxDuration || 0)}{" "}
+                    max)
+                  </span>
+                </div>
+                <div className="tap-row">
+                  {this.getTargetStatuses(targetHistory)
+                    .slice(0, this.state.invocationLimit)
+                    .map((commitStatus: CommitStatus) => {
+                      let statuses = commitStatus.statuses?.sort(
+                        (a, b) => Number(b.invocationCreatedAtUsec) - Number(a.invocationCreatedAtUsec)
+                      );
+                      if (!statuses || statuses.length == 0) {
+                        // For V2, null means the target was not run for this commit.
+                        return (
+                          <div className="tap-commit-container">
+                            <div
+                              className="tap-block no-status"
+                              title={
+                                commitStatus.commitSha
+                                  ? `Target status not reported at commit ${commitStatus.commitSha}`
+                                  : "No status reported"
+                              }
+                            />
+                          </div>
+                        );
+                      }
+                      return (
+                        <div className="tap-commit-container">
+                          {statuses.map((status) => {
+                            let destinationUrl = `/invocation/${status.invocationId}?${new URLSearchParams({
+                              target: targetHistory.target?.label || "",
+                              targetStatus: String(status),
+                            })}`;
+                            let title =
+                              this.getColorMode() == "timing"
+                                ? `${this.durationToNum(status.timing?.duration || undefined).toFixed(2)}s`
+                                : this.statusToString(status.status || Status.STATUS_UNSPECIFIED);
+                            if (this.isV2 && commitStatus.commitSha) {
+                              title += ` at commit ${commitStatus.commitSha}`;
+                            }
+
+                            return (
+                              <a
+                                key={targetHistory.target?.label || "" + status.invocationId}
+                                href={destinationUrl}
+                                onClick={this.navigateTo.bind(this, destinationUrl)}
+                                title={title}
+                                style={{
+                                  opacity:
+                                    this.getColorMode() == "timing"
+                                      ? Math.max(
+                                          MIN_OPACITY,
+                                          (1.0 * this.durationToNum(status.timing?.duration || undefined)) /
+                                            (stats?.maxDuration || 1)
+                                        )
+                                      : undefined,
+                                }}
+                                className={`tap-block ${
+                                  this.getColorMode() == "status" ? `status-${status.status}` : "timing"
+                                } clickable`}>
+                                {this.statusToIcon(status.status || Status.STATUS_UNSPECIFIED)}
+                              </a>
+                            );
+                          })}
+                        </div>
+                      );
+                    })}
+                </div>
+              </React.Fragment>
+            );
+          })}
+          {filteredTargets.length > this.state.targetLimit && (
+            <FilledButton className="more-targets-button" onClick={this.loadMoreTargets.bind(this)}>
+              Load more targets
+            </FilledButton>
+          )}
+        </div>
+      </>
+    );
+  }
+}
+
+interface InnerTopBarProps {
+  commits: string[];
+  commitToMaxInvocationCreatedAtUsec: Map<string, number>;
+  moreInvocationsButton: JSX.Element;
+}
+
+interface InnerTopBarState {
+  hoveredCommit: CommitTimestamp | null;
+}
+
+interface CommitTimestamp {
+  commitSha: string;
+  timestampUsec: number;
+}
+
+/**
+ * Top bar that sticks to the top of the scrollable area, containing the commit
+ * timeline.
+ */
+class InnerTopBar extends React.Component<InnerTopBarProps, InnerTopBarState> {
+  state: InnerTopBarState = {
+    hoveredCommit: null,
+  };
+
+  private commitTimeline = React.createRef<HTMLDivElement>();
+  private hoveredCommitRow = React.createRef<HTMLDivElement>();
+  private hoveredCommitInfo = React.createRef<HTMLDivElement>();
+  private hoveredCommitPointer = React.createRef<HTMLDivElement>();
+  // TODO(bduffany): Use a generic tooltip component.
+  private tooltipPortal?: HTMLDivElement;
+
+  componentWillMount() {
+    const tooltipPortal = document.createElement("div");
+    tooltipPortal.style.position = "fixed";
+    tooltipPortal.style.zIndex = "1";
+    tooltipPortal.style.opacity = "0";
+    document.body.appendChild(tooltipPortal);
+    this.tooltipPortal = tooltipPortal;
+  }
+
+  componentWillUnmount() {
+    this.tooltipPortal!.remove();
+  }
+
+  onMouseLeaveCommitTimeline(event: React.MouseEvent) {
+    this.setState({ hoveredCommit: null });
+    this.tooltipPortal!.style.opacity = "0";
+  }
+
+  onMouseOverCommit(commitSha: string, event: React.MouseEvent) {
+    this.setState({
+      hoveredCommit: {
+        commitSha,
+        timestampUsec: this.props.commitToMaxInvocationCreatedAtUsec.get(commitSha) || 0,
+      },
+    });
+
+    const hoveredElement = event.target as HTMLElement;
+    setTimeout(() => this.centerHoveredCommitWith(hoveredElement));
+  }
+
+  onClickCommitLink(event: React.MouseEvent) {
+    event.preventDefault();
+    const link = event.target as HTMLAnchorElement;
+    if (link.getAttribute("href")) {
+      router.navigateTo(link.getAttribute("href")!);
+    }
+  }
+
+  centerHoveredCommitWith(element: HTMLElement) {
+    const hoveredCommit = this.hoveredCommitInfo.current;
+    if (!hoveredCommit) return;
+
+    const hoveredCommitPointer = this.hoveredCommitPointer.current!;
+    const hoveredCommitRow = this.hoveredCommitRow.current!;
+
+    const screenCenterX = element.getBoundingClientRect().left + element.clientWidth / 2;
+    const maxScreenLeftX = window.innerWidth - hoveredCommit.clientWidth;
+    const screenLeftX = clamp(screenCenterX - hoveredCommit.clientWidth / 2, 0, maxScreenLeftX);
+    const screenTop = hoveredCommitRow.getBoundingClientRect().top;
+    const screenBottom = screenTop + hoveredCommitRow.clientHeight;
+
+    hoveredCommit.style.left = `${screenLeftX}px`;
+    hoveredCommit.style.top = `${screenTop}px`;
+    hoveredCommitPointer.style.left = `${screenCenterX}px`;
+    hoveredCommitPointer.style.top = `${screenBottom}px`;
+    this.tooltipPortal!.style.opacity = "1";
+  }
+
+  render() {
+    return (
+      <>
+        <div className="inner-top-bar-underlay" />
+        <div className="commit-timeline-label">Commits (most recent first)</div>
+        <div className="inner-top-bar">
+          <div className="hovered-commit-row" ref={this.hoveredCommitRow}>
+            {this.state.hoveredCommit &&
+              ReactDOM.createPortal(
+                <>
+                  <div className="tap-hovered-commit-pointer" ref={this.hoveredCommitPointer} />
+                  <div className="tap-hovered-commit-info" ref={this.hoveredCommitInfo}>
+                    {format.formatTimestampUsec(this.state.hoveredCommit.timestampUsec)}, commit{" "}
+                    {this.state.hoveredCommit.commitSha.substring(0, 6)}
+                  </div>
+                </>,
+                this.tooltipPortal!
+              )}
+          </div>
+          <div
+            className="commit-timeline"
+            onMouseLeave={this.onMouseLeaveCommitTimeline.bind(this)}
+            ref={this.commitTimeline}>
+            <div className="commits-list">
+              {this.props.commits.map((commitSha) => (
+                <a
+                  className="commit-link"
+                  href={`/history/commit/${commitSha}`}
+                  onClick={this.onClickCommitLink.bind(this)}
+                  onMouseOver={this.onMouseOverCommit.bind(this, commitSha)}
+                />
+              ))}
+            </div>
+            {this.props.moreInvocationsButton}
+          </div>
+        </div>
+      </>
+    );
+  }
+}
+
+/**
+ * Merges two lists of target histories into a single list with the joined target histories.
+ *
+ * This operation may mutate h1, so callers shouldn't rely on the value of h1 after this is
+ * called.
+ */
+function mergeHistories(h1: target.TargetHistory[], h2: target.TargetHistory[]): target.TargetHistory[] {
+  const targetLabelToHistory = new Map<string, target.TargetHistory>();
+  for (const history of h1) {
+    targetLabelToHistory.set(history.target?.label || "undefined", history);
+  }
+  for (const history of h2) {
+    const h1History = targetLabelToHistory.get(history.target?.label || "undefined");
+    if (!h1History) {
+      targetLabelToHistory.set(history.target?.label || "undefined", history);
+      h1.push(history);
+      continue;
+    }
+    h1History.targetStatus = h1History.targetStatus.concat(history.targetStatus);
+  }
+  return h1;
+}

--- a/enterprise/app/tap/grid_common.ts
+++ b/enterprise/app/tap/grid_common.ts
@@ -1,0 +1,9 @@
+export const SORT_MODE_PARAM = "sort";
+export const SORT_DIRECTION_PARAM = "direction";
+export const COLOR_MODE_PARAM = "color";
+
+export type ColorMode = "status" | "timing";
+
+export type SortMode = "target" | "count" | "pass" | "avgDuration" | "maxDuration" | "flake";
+
+export type SortDirection = "asc" | "desc";

--- a/enterprise/app/tap/grid_sort_controls.tsx
+++ b/enterprise/app/tap/grid_sort_controls.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import Select, { Option } from "../../../app/components/select/select";
+import router from "../../../app/router/router";
+import {
+  COLOR_MODE_PARAM,
+  ColorMode,
+  SORT_DIRECTION_PARAM,
+  SORT_MODE_PARAM,
+  SortDirection,
+  SortMode,
+} from "./grid_common";
+
+interface Props {
+  search: URLSearchParams;
+}
+
+export default class GridSortControlsComponent extends React.Component<Props> {
+  handleSortChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    router.setQueryParam(SORT_MODE_PARAM, event.target.value);
+  }
+
+  handleDirectionChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    router.setQueryParam(SORT_DIRECTION_PARAM, event.target.value);
+  }
+
+  handleColorChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    router.setQueryParam(COLOR_MODE_PARAM, event.target.value);
+  }
+
+  getSortMode(): SortMode {
+    return (this.props.search.get(SORT_MODE_PARAM) as SortMode) || "pass";
+  }
+
+  getSortDirection(): SortDirection {
+    return (this.props.search.get(SORT_DIRECTION_PARAM) as SortDirection) || "asc";
+  }
+
+  getColorMode(): ColorMode {
+    return (this.props.search.get(COLOR_MODE_PARAM) as ColorMode) || "status";
+  }
+
+  render() {
+    return (
+      <div className="tap-sort-controls">
+        <div className="tap-sort-control">
+          <span className="tap-sort-title">Sort by</span>
+          <Select onChange={this.handleSortChange.bind(this)} value={this.getSortMode()}>
+            <Option value="target">Target name</Option>
+            <Option value="count">Invocation count</Option>
+            <Option value="pass">Pass percentage</Option>
+            <Option value="avgDuration">Average duration</Option>
+            <Option value="maxDuration">Max duration</Option>
+            <Option value="flake">Flake percentage</Option>
+          </Select>
+        </div>
+        <div className="tap-sort-control">
+          <span className="tap-sort-title">Direction</span>
+          <Select onChange={this.handleDirectionChange.bind(this)} value={this.getSortDirection()}>
+            <Option value="asc">Asc</Option>
+            <Option value="desc">Desc</Option>
+          </Select>
+        </div>
+        <div className="tap-sort-control">
+          <span className="tap-sort-title">Color</span>
+          <Select onChange={this.handleColorChange.bind(this)} value={this.getColorMode()}>
+            <Option value="status">Status</Option>
+            <Option value="timing">Duration</Option>
+          </Select>
+        </div>
+      </div>
+    );
+  }
+}

--- a/enterprise/app/tap/tap.css
+++ b/enterprise/app/tap/tap.css
@@ -23,16 +23,18 @@
 }
 
 .tap .tap-top-bar {
-  padding: 32px 0;
+  padding: 32px 0 0;
   border-bottom: 1px solid #eee;
   flex-shrink: 0;
-  position: sticky;
   top: 0;
+}
+
+.tap .tap-top-bar.stick {
+  position: sticky;
 }
 
 .tap.v2 .tap-top-bar {
   border-bottom: none;
-  padding-bottom: 8px;
 }
 
 .tap .inner-top-bar-underlay {
@@ -71,10 +73,19 @@
   display: flex;
   gap: 16px;
   align-items: center;
+  padding-bottom: 32px;
+}
+
+.tap.v2 .target-controls {
+  padding-bottom: 8px;
 }
 
 .tap .repo-picker {
   max-width: 300px;
+}
+
+.tap .tap-header-group {
+  margin-bottom: 16px;
 }
 
 .tap .tap-header {
@@ -83,13 +94,16 @@
   gap: 16px;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 16px;
 }
 
 .tap-title {
   font-size: 32px;
   font-weight: 700;
   flex-shrink: 0;
+}
+
+.tap .tabs {
+  margin-top: 8px;
 }
 
 .tap .inner-top-bar {
@@ -466,4 +480,75 @@ SKIPPED = 13;
   display: flex;
   align-items: center;
   margin-left: 8px;
+}
+
+.tap .chart-card {
+  margin-top: 0;
+  display: block;
+}
+
+.tap .flakes-chart-header {
+  margin: 0 0 16px;
+}
+
+.tap .flakes-list-header {
+  margin: 16px 0;
+}
+
+.tap .flake-table {
+  margin-top: 16px;
+}
+
+.tap .flake-table-row {
+  display: flex;
+  border-top: 1px solid #eee;
+  padding: 16px 0;
+}
+
+.tap .flake-table-row:last-child {
+  border-bottom: 1px solid #eee;
+}
+
+.tap .flake-table-row:hover {
+  background: #fafafa;
+}
+
+.tap .flake-table-row-image {
+  margin-left: 4px;
+  margin-right: 16px;
+}
+
+.tap .flake-table-row-header {
+  font-weight: 600;
+}
+
+.tap .flake-table-row-content {
+  flex-grow: 1;
+}
+
+.tap .flake-table-row-stats {
+  display: flex;
+  justify-content: space-between;
+}
+
+.tap .flake-stat {
+  width: 160px;
+  margin: 8px 0;
+  font-size: 16px;
+}
+
+.tap .flake-stat-value {
+  font-size: 20px;
+}
+
+.tap .flake-table-header {
+  display: flex;
+  justify-content: space-between;
+  grid-gap: 8px;
+}
+
+.tap .flake-table-sort-controls {
+  display: flex;
+  align-items: center;
+  min-width: 300px;
 }

--- a/enterprise/app/tap/tap.tsx
+++ b/enterprise/app/tap/tap.tsx
@@ -101,7 +101,7 @@ export default class TapComponent extends React.Component<Props, State> {
     let tabContent;
     const repo = this.selectedRepo();
     if (tab === "flakes") {
-      tabContent = <FlakesComponent repo={repo} search={this.props.search} dark={}></FlakesComponent>;
+      tabContent = <FlakesComponent repo={repo} search={this.props.search} dark={this.props.dark}></FlakesComponent>;
     } else {
       tabContent = (
         <TestGridComponent repo={repo} search={this.props.search} user={this.props.user}></TestGridComponent>

--- a/enterprise/app/tap/tap.tsx
+++ b/enterprise/app/tap/tap.tsx
@@ -16,6 +16,7 @@ interface Props {
   user: User;
   tab: string;
   search: URLSearchParams;
+  dark: boolean;
 }
 
 interface State {
@@ -100,7 +101,7 @@ export default class TapComponent extends React.Component<Props, State> {
     let tabContent;
     const repo = this.selectedRepo();
     if (tab === "flakes") {
-      tabContent = <FlakesComponent repo={repo} search={this.props.search}></FlakesComponent>;
+      tabContent = <FlakesComponent repo={repo} search={this.props.search} dark={}></FlakesComponent>;
     } else {
       tabContent = (
         <TestGridComponent repo={repo} search={this.props.search} user={this.props.user}></TestGridComponent>

--- a/enterprise/app/tap/tap.tsx
+++ b/enterprise/app/tap/tap.tsx
@@ -1,40 +1,16 @@
 import React from "react";
-import ReactDOM from "react-dom";
-import Long from "long";
-import moment from "moment";
-import rpcService, { CancelablePromise } from "../../../app/service/rpc_service";
+import rpcService from "../../../app/service/rpc_service";
 import { User } from "../../../app/auth/auth_service";
-import { api } from "../../../proto/api/v1/common_ts_proto";
 import { invocation } from "../../../proto/invocation_ts_proto";
-import { target } from "../../../proto/target_ts_proto";
-import { Subscription } from "rxjs";
-import router from "../../../app/router/router";
-import { google as google_duration } from "../../../proto/duration_ts_proto";
+import router, { Path } from "../../../app/router/router";
 import format from "../../../app/format/format";
-import { clamp } from "../../../app/util/math";
-import { FilterInput } from "../../../app/components/filter_input/filter_input";
 import Select, { Option } from "../../../app/components/select/select";
-import Spinner from "../../../app/components/spinner/spinner";
-import {
-  Activity,
-  AlarmClock,
-  AlertTriangle,
-  Check,
-  ChevronRight,
-  ChevronsRight,
-  Clock,
-  Hammer,
-  HelpCircle,
-  SkipForward,
-  Slash,
-  Snowflake,
-  Wrench,
-  X,
-} from "lucide-react";
 import capabilities from "../../../app/capabilities/capabilities";
-import FilledButton from "../../../app/components/button/button";
 import errorService from "../../../app/errors/error_service";
 import { normalizeRepoURL } from "../../../app/util/git";
+import TestGridComponent from "./grid";
+import FlakesComponent from "./flakes";
+import GridSortControlsComponent from "./grid_sort_controls";
 
 interface Props {
   user: User;
@@ -42,96 +18,40 @@ interface Props {
   search: URLSearchParams;
 }
 
-interface State extends CommitGrouping {
+interface State {
+  selectedRepo?: string;
   repos: string[];
-  targetHistory: target.TargetHistory[];
-  nextPageToken: string;
-  loading: boolean;
-  targetLimit: number;
-  invocationLimit: number;
-  stats: Map<string, Stat>;
-  maxInvocations: number;
-  maxDuration: number;
 }
 
-type ColorMode = "status" | "timing";
+type Tab = "grid" | "flakes";
 
-type SortMode = "target" | "count" | "pass" | "avgDuration" | "maxDuration" | "flake";
-
-type SortDirection = "asc" | "desc";
-
-interface CommitGrouping {
-  commits: string[] | null;
-  commitToMaxInvocationCreatedAtUsec: Map<string, number> | null;
-  commitToTargetLabelToStatuses: Map<string, Map<string, target.ITargetStatus[]>> | null;
-}
-
-interface CommitStatus {
-  commitSha: string;
-  statuses: target.ITargetStatus[] | null;
-}
-
-interface Stat {
-  count: number;
-  pass: number;
-  totalDuration: number;
-  maxDuration: number;
-  avgDuration: number;
-  flake: number;
-}
-
-const Status = api.v1.Status;
-
-const MIN_OPACITY = 0.1;
-const DAYS_OF_DATA_TO_FETCH = 7;
 const LAST_SELECTED_REPO_LOCALSTORAGE_KEY = "tests__last_selected_repo";
-const SORT_MODE_PARAM = "sort";
-const SORT_DIRECTION_PARAM = "direction";
-const COLOR_MODE_PARAM = "color";
 
 export default class TapComponent extends React.Component<Props, State> {
   state: State = {
     repos: [],
-    targetHistory: [],
-    nextPageToken: "",
-    commits: null,
-    commitToTargetLabelToStatuses: null,
-    commitToMaxInvocationCreatedAtUsec: null,
-    loading: true,
-    targetLimit: 100,
-    invocationLimit: capabilities.config.testGridV2Enabled
-      ? Number.MAX_SAFE_INTEGER
-      : Math.min(100, Math.max(20, (window.innerWidth - 312) / 34)),
-    stats: new Map<string, Stat>(),
-    maxInvocations: 0,
-    maxDuration: 1,
   };
 
   isV2 = Boolean(capabilities.config.testGridV2Enabled);
 
-  subscription?: Subscription;
-  targetsRPC?: CancelablePromise;
-
   componentWillMount() {
     document.title = `Tests | BuildBuddy`;
-
-    this.fetchRepos().then(() => this.fetchTargets(/*initial=*/ true));
-
-    this.subscription = rpcService.events.subscribe({
-      next: (name) => name == "refresh" && this.fetchTargets(/*initial=*/ true),
-    });
+    this.fetchRepos();
   }
 
-  componentWillUnmount() {
-    this.subscription?.unsubscribe();
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    if (this.props.search.get("repo") !== prevProps.search.get("repo")) {
-      // Repo-changed; re-fetch targets starting from scratch.
-      this.fetchTargets(/*initial=*/ true);
-    }
+  componentDidUpdate() {
     localStorage[LAST_SELECTED_REPO_LOCALSTORAGE_KEY] = this.selectedRepo();
+  }
+
+  getSelectedTab(): Tab {
+    if (capabilities.config.targetFlakesUiEnabled && this.props.tab === "#flakes") {
+      return "flakes";
+    }
+    return "grid";
+  }
+
+  updateSelectedTab(tab: Tab) {
+    router.navigateTo(Path.tapPath + "#" + tab);
   }
 
   fetchRepos(): Promise<void> {
@@ -170,698 +90,71 @@ export default class TapComponent extends React.Component<Props, State> {
     return this.state?.repos[0] || "";
   }
 
-  /**
-   * Fetches targets. If `initial`, clear any existing target history and fetch
-   * from scratch. Otherwise, append the fetched history to the existing
-   * history.
-   */
-  fetchTargets(initial: boolean) {
-    this.targetsRPC?.cancel();
-    this.setState({ loading: false });
-
-    const repoUrl = this.selectedRepo();
-    if (!repoUrl) {
-      this.updateState(new target.GetTargetHistoryResponse(), initial);
-      return;
-    }
-
-    let request = new target.GetTargetHistoryRequest();
-
-    request.startTimeUsec = Long.fromNumber(moment().subtract(DAYS_OF_DATA_TO_FETCH, "day").utc().valueOf() * 1000);
-    request.endTimeUsec = Long.fromNumber(moment().utc().valueOf() * 1000);
-    request.serverSidePagination = this.isV2;
-    request.pageToken = initial ? "" : this.state.nextPageToken;
-    if (this.isV2) {
-      request.query = target.TargetQuery.create({ repoUrl });
-    }
-
-    this.setState({ loading: true });
-    this.targetsRPC = rpcService.service
-      .getTargetHistory(request)
-      .then((response) => {
-        this.updateState(response, initial);
-      })
-      .catch((e) => errorService.handleError(e))
-      .finally(() => this.setState({ loading: false }));
-  }
-
-  updateState(response: target.GetTargetHistoryResponse, initial: boolean) {
-    this.state.stats.clear();
-
-    let histories = response.invocationTargets;
-    if (this.isV2 && !initial) {
-      histories = mergeHistories(this.state.targetHistory, response.invocationTargets);
-    }
-
-    let maxInvocations = 0;
-    let maxDuration = 1;
-    for (let targetHistory of histories) {
-      let stats: Stat = { count: 0, pass: 0, totalDuration: 0, maxDuration: 0, avgDuration: 0, flake: 0 };
-      for (let status of targetHistory.targetStatus) {
-        stats.count += 1;
-        let duration = this.durationToNum(status.timing?.duration || undefined);
-        stats.totalDuration += duration;
-        stats.maxDuration = Math.max(stats.maxDuration, duration);
-        if (status.status == Status.PASSED) {
-          stats.pass += 1;
-        } else if (status.status == Status.FLAKY) {
-          stats.flake += 1;
-        }
-      }
-      stats.avgDuration = stats.totalDuration / stats.count;
-      maxInvocations = Math.max(maxInvocations, stats.count);
-      maxDuration = Math.max(maxDuration, stats.maxDuration);
-      this.state.stats.set(targetHistory.target?.label || "undefined", stats);
-    }
-
-    this.setState({
-      loading: false,
-      targetHistory: histories,
-      nextPageToken: response.nextPageToken,
-      stats: this.state.stats,
-      maxInvocations: maxInvocations,
-      maxDuration: maxDuration,
-    });
-    if (this.isV2) {
-      this.setState({
-        ...this.groupByCommit(histories),
-      });
-    }
-  }
-
-  groupByCommit(targetHistories: target.ITargetHistory[]): CommitGrouping {
-    const commitToMaxInvocationCreatedAtUsec = new Map<string, number>();
-    const commitToTargetLabelToStatuses = new Map<string, Map<string, target.ITargetStatus[]>>();
-
-    for (const history of targetHistories) {
-      for (const targetStatus of history.targetStatus || []) {
-        const timestamp = Number(targetStatus.invocationCreatedAtUsec);
-        const commitMaxTimestamp = commitToMaxInvocationCreatedAtUsec.get(targetStatus.commitSha) || 0;
-        if (timestamp > commitMaxTimestamp) {
-          commitToMaxInvocationCreatedAtUsec.set(targetStatus.commitSha, timestamp);
-        }
-
-        let targetLabelToStatus = commitToTargetLabelToStatuses.get(targetStatus.commitSha);
-        if (!targetLabelToStatus) {
-          targetLabelToStatus = new Map<string, target.ITargetStatus[]>();
-          commitToTargetLabelToStatuses.set(targetStatus.commitSha, targetLabelToStatus);
-        }
-
-        if (history.target) {
-          const existing = targetLabelToStatus.get(history.target!.label);
-          if (existing) {
-            existing.push(targetStatus);
-          } else {
-            targetLabelToStatus.set(history.target!.label, [targetStatus]);
-          }
-        }
-      }
-    }
-    const commits = [...commitToMaxInvocationCreatedAtUsec.keys()].sort(
-      (a, b) => commitToMaxInvocationCreatedAtUsec.get(b)! - commitToMaxInvocationCreatedAtUsec.get(a)!
-    );
-
-    return { commits, commitToMaxInvocationCreatedAtUsec, commitToTargetLabelToStatuses };
-  }
-
-  navigateTo(destination: string, event: React.MouseEvent) {
-    event.preventDefault();
-    router.navigateTo(destination);
-  }
-
-  handleFilterChange(event: React.ChangeEvent<HTMLInputElement>) {
-    router.setQueryParam("filter", event.target.value);
-  }
-
-  durationToNum(duration?: google_duration.protobuf.Duration) {
-    if (!duration) {
-      return 0;
-    }
-    return +duration.seconds + +duration.nanos / 1000000000;
-  }
-
-  statusToString(s: api.v1.Status) {
-    switch (s) {
-      case Status.STATUS_UNSPECIFIED:
-        return "Unknown";
-      case Status.BUILDING:
-        return "Building";
-      case Status.BUILT:
-        return "Built";
-      case Status.FAILED_TO_BUILD:
-        return "Failed to build";
-      case Status.TESTING:
-        return "Testing";
-      case Status.PASSED:
-        return "Passed";
-      case Status.FAILED:
-        return "Failed";
-      case Status.TIMED_OUT:
-        return "Timed out";
-      case Status.CANCELLED:
-        return "Cancelled";
-      case Status.TOOL_FAILED:
-        return "Tool failed";
-      case Status.INCOMPLETE:
-        return "Incomplete";
-      case Status.FLAKY:
-        return "Flaky";
-      case Status.UNKNOWN:
-        return "Unknown";
-      case Status.SKIPPED:
-        return "Skipped";
-    }
-  }
-
-  statusToIcon(s: api.v1.Status) {
-    switch (s) {
-      case Status.STATUS_UNSPECIFIED:
-        return <HelpCircle />;
-      case Status.BUILDING:
-        return <Clock />;
-      case Status.BUILT:
-        return <Hammer />;
-      case Status.FAILED_TO_BUILD:
-        return <AlertTriangle />;
-      case Status.TESTING:
-        return <Clock />;
-      case Status.PASSED:
-        return <Check />;
-      case Status.FAILED:
-        return <X />;
-      case Status.TIMED_OUT:
-        return <AlarmClock />;
-      case Status.CANCELLED:
-        return <Slash />;
-      case Status.TOOL_FAILED:
-        return <Wrench />;
-      case Status.INCOMPLETE:
-        return <Activity />;
-      case Status.FLAKY:
-        return <Snowflake />;
-      case Status.UNKNOWN:
-        return <HelpCircle />;
-      case Status.SKIPPED:
-        return <SkipForward />;
-    }
-  }
-
-  loadMoreTargets() {
-    this.setState({ targetLimit: this.state.targetLimit + 50 });
-  }
-
-  loadMoreInvocations() {
-    if (this.isV2) {
-      this.fetchTargets(/*initial=*/ false);
-      return;
-    }
-
-    this.setState({ invocationLimit: this.state.invocationLimit + 50 });
-  }
-
   handleRepoChange(event: React.ChangeEvent<HTMLSelectElement>) {
     const repo = event.target.value;
     router.replaceParams({ repo });
   }
 
-  handleSortChange(event: React.ChangeEvent<HTMLSelectElement>) {
-    router.setQueryParam("sort", event.target.value);
-  }
-
-  handleDirectionChange(event: React.ChangeEvent<HTMLSelectElement>) {
-    router.setQueryParam("direction", event.target.value);
-  }
-
-  handleColorChange(event: React.ChangeEvent<HTMLSelectElement>) {
-    router.setQueryParam("color", event.target.value);
-  }
-
-  getSortMode(): SortMode {
-    return (this.props.search.get(SORT_MODE_PARAM) as SortMode) || "pass";
-  }
-
-  getSortDirection(): SortDirection {
-    return (this.props.search.get(SORT_DIRECTION_PARAM) as SortDirection) || "asc";
-  }
-
-  getColorMode(): ColorMode {
-    return (this.props.search.get(COLOR_MODE_PARAM) as ColorMode) || "status";
-  }
-
-  sort(a: target.ITargetHistory, b: target.ITargetHistory) {
-    let first = this.getSortDirection() == "asc" ? a : b;
-    let second = this.getSortDirection() == "asc" ? b : a;
-
-    let firstTarget = first.target;
-    let secondTarget = second.target;
-
-    if (this.getSortMode() == "target") {
-      if (!firstTarget && !secondTarget) {
-        return 0;
-      } else if (!firstTarget) {
-        return 1;
-      } else if (!secondTarget) {
-        return -1;
-      } else {
-        return firstTarget!.label.localeCompare(secondTarget!.label);
-      }
-    }
-
-    let firstStats = this.state.stats.get(first?.target?.label || "");
-    let secondStats = this.state.stats.get(second?.target?.label || "");
-
-    if (!firstStats && !secondStats) {
-      return 0;
-    } else if (!firstStats) {
-      return 1;
-    } else if (!secondStats) {
-      return -1;
-    }
-
-    switch (this.getSortMode()) {
-      case "count":
-        return firstStats!.count - secondStats!.count;
-      case "pass":
-        return firstStats!.pass / firstStats!.count - secondStats!.pass / secondStats!.count;
-      case "avgDuration":
-        return firstStats!.avgDuration - secondStats!.avgDuration;
-      case "maxDuration":
-        return firstStats!.maxDuration - secondStats!.maxDuration;
-      case "flake":
-        return firstStats!.flake / firstStats!.count - secondStats!.flake / secondStats!.count;
-    }
-    return 0;
-  }
-
-  getTargetStatuses(history: target.ITargetHistory): CommitStatus[] {
-    if (!this.isV2) {
-      return (
-        history.targetStatus?.map((status) => ({ commitSha: status.commitSha, statuses: [status], count: 1 })) || []
-      );
-    }
-    // For test grid V2, ignore the incoming history (for now) and use the indexes we
-    // built to order by commit.
-    return (
-      this.state.commits?.map((commitSha) => ({
-        commitSha,
-        statuses: this.state.commitToTargetLabelToStatuses?.get(commitSha)?.get(history.target?.label || "") || null,
-      })) || []
-    );
-  }
-
   render() {
-    if (this.state.loading && !this.state.targetHistory?.length) {
-      return <div className="loading"></div>;
-    }
-
-    const headerLeftSection = (
-      <div className="tap-header-left-section">
-        <div className="tap-title">Test grid</div>
-        {this.isV2 && this.state.repos.length > 0 && (
-          <Select onChange={this.handleRepoChange.bind(this)} value={this.selectedRepo()} className="repo-picker">
-            {this.state.repos.map((repo) => (
-              <Option key={repo} value={repo}>
-                {format.formatGitUrl(repo)}
-              </Option>
-            ))}
-          </Select>
-        )}
-      </div>
-    );
-
-    if (!this.state.targetHistory.length) {
-      return (
-        <div className="tap">
-          <div className="tap-top-bar">
-            <div className="container narrow">
-              <div className="tap-header">{headerLeftSection}</div>
-            </div>
-          </div>
-          <div className="container narrow">
-            <div className="empty-state history">
-              <h2>No CI tests found in the last week!</h2>
-              {this.isV2 ? (
-                <p>
-                  To see a CI test grid, make sure your CI tests are configured as follows:
-                  <ul>
-                    <li>
-                      Add <code className="inline-code">--build_metadata=ROLE=CI</code> to your CI bazel test command.
-                    </li>
-                    <li>
-                      Provide a{" "}
-                      <a target="_blank" href="https://www.buildbuddy.io/docs/guide-metadata/#commit-sha">
-                        commit SHA
-                      </a>{" "}
-                      and{" "}
-                      <a target="_blank" href="https://www.buildbuddy.io/docs/guide-metadata/#repository-url">
-                        repository URL
-                      </a>
-                      .
-                    </li>
-                  </ul>
-                </p>
-              ) : (
-                <p>
-                  Seems like you haven't done any builds marked as CI. Add <b>--build_metadata=ROLE=CI</b> to your
-                  builds to see a CI test grid. You'll likely also want to provide a commit SHA and optionally a git
-                  repo url.
-                </p>
-              )}
-              <p>Check out the Build Metadata Guide below for more information on configuring these.</p>
-              <p>
-                <a className="button" target="_blank" href="https://buildbuddy.io/docs/guide-metadata">
-                  Build Metadata Guide <ChevronRight />
-                </a>
-              </p>
-            </div>
-          </div>
-        </div>
+    const tab = this.getSelectedTab();
+    let tabContent;
+    const repo = this.selectedRepo();
+    if (tab === "flakes") {
+      tabContent = <FlakesComponent repo={repo} search={this.props.search}></FlakesComponent>;
+    } else {
+      tabContent = (
+        <TestGridComponent repo={repo} search={this.props.search} user={this.props.user}></TestGridComponent>
       );
     }
 
-    let filter: string = this.props.search.get("filter") || "";
-
-    const showMoreInvocationsButton = this.isV2
-      ? this.state.nextPageToken
-      : this.state.maxInvocations > this.state.invocationLimit;
-    const moreInvocationsButton = (
-      <>
-        {showMoreInvocationsButton && (
-          <FilledButton
-            className="more-invocations-button"
-            onClick={this.loadMoreInvocations.bind(this)}
-            disabled={this.state.loading}>
-            <span>Load more</span>
-            {this.state.loading ? <Spinner className="white" /> : <ChevronsRight className="icon white" />}
-          </FilledButton>
-        )}
-      </>
-    );
-
-    const filteredTargets = this.state.targetHistory
-      .filter((targetHistory) => (filter ? targetHistory.target?.label.includes(filter) : true))
-      .sort(this.sort.bind(this));
+    const title = capabilities.config.targetFlakesUiEnabled ? "Test history" : "Test grid";
 
     return (
       <div className={`tap ${this.isV2 ? "v2" : ""}`}>
-        <div className="tap-top-bar">
+        <div className={`tap-top-bar  ${tab !== "flakes" ? "stick" : ""}`}>
           <div className="container">
-            <div className="tap-header">
-              {headerLeftSection}
-
-              <div className="controls">
-                <div className="tap-sort-controls">
-                  <div className="tap-sort-control">
-                    <span className="tap-sort-title">Sort by</span>
-                    <Select onChange={this.handleSortChange.bind(this)} value={this.getSortMode()}>
-                      <Option value="target">Target name</Option>
-                      <Option value="count">Invocation count</Option>
-                      <Option value="pass">Pass percentage</Option>
-                      <Option value="avgDuration">Average duration</Option>
-                      <Option value="maxDuration">Max duration</Option>
-                      <Option value="flake">Flake percentage</Option>
+            <div className="tap-header-group">
+              <div className="tap-header">
+                <div className="tap-header-left-section">
+                  <div className="tap-title">{title}</div>
+                  {this.isV2 && this.state.repos.length > 0 && (
+                    <Select
+                      onChange={this.handleRepoChange.bind(this)}
+                      value={this.selectedRepo()}
+                      className="repo-picker">
+                      {this.state.repos.map((repo) => (
+                        <Option key={repo} value={repo}>
+                          {format.formatGitUrl(repo)}
+                        </Option>
+                      ))}
                     </Select>
+                  )}
+                </div>
+                {tab === "grid" && (
+                  <div className="controls">
+                    <GridSortControlsComponent search={this.props.search}></GridSortControlsComponent>
                   </div>
-                  <div className="tap-sort-control">
-                    <span className="tap-sort-title">Direction</span>
-                    <Select onChange={this.handleDirectionChange.bind(this)} value={this.getSortDirection()}>
-                      <Option value="asc">Asc</Option>
-                      <Option value="desc">Desc</Option>
-                    </Select>
+                )}
+              </div>
+              {capabilities.config.targetFlakesUiEnabled && (
+                <div className="tabs">
+                  <div
+                    onClick={() => this.updateSelectedTab("grid")}
+                    className={`tab ${this.getSelectedTab() === "grid" ? "selected" : ""}`}>
+                    Test Grid
                   </div>
-                  <div className="tap-sort-control">
-                    <span className="tap-sort-title">Color</span>
-                    <Select onChange={this.handleColorChange.bind(this)} value={this.getColorMode()}>
-                      <Option value="status">Status</Option>
-                      <Option value="timing">Duration</Option>
-                    </Select>
+                  <div
+                    onClick={() => this.updateSelectedTab("flakes")}
+                    className={`tab ${this.getSelectedTab() === "flakes" ? "selected" : ""}`}>
+                    Flakes
                   </div>
                 </div>
-              </div>
-            </div>
-
-            <div className="target-controls">
-              <FilterInput value={filter} placeholder="Filter..." onChange={this.handleFilterChange.bind(this)} />
-              {!this.isV2 && moreInvocationsButton}
+              )}
             </div>
           </div>
         </div>
-
-        <div className="container tap-grid-container">
-          {this.isV2 && (
-            <InnerTopBar
-              commits={this.state.commits || []}
-              commitToMaxInvocationCreatedAtUsec={
-                this.state.commitToMaxInvocationCreatedAtUsec || new Map<string, number>()
-              }
-              moreInvocationsButton={moreInvocationsButton}
-            />
-          )}
-          {filteredTargets.slice(0, this.state.targetLimit).map((targetHistory) => {
-            let targetParts = targetHistory.target?.label.split(":") || [];
-            let targetPath = targetParts.length > 0 ? targetParts[0] : "";
-            let targetName = targetParts.length > 1 ? targetParts[1] : "";
-            let stats = this.state.stats.get(targetHistory.target?.label || "");
-            return (
-              <React.Fragment key={targetHistory.target?.label || ""}>
-                <div title={targetHistory.target?.ruleType || ""} className="tap-target-label">
-                  <span className="tap-target-path">{targetPath}</span>:
-                  <span className="tap-target-name">{targetName}</span>
-                  <span className="tap-target-stats">
-                    ({format.formatWithCommas(stats?.count || 0)} invocations,{" "}
-                    {format.percent((stats?.pass || 0) / (stats?.count || Number.MAX_VALUE))}% pass,{" "}
-                    {format.percent((stats?.flake || 0) / (stats?.count || Number.MAX_VALUE))}% flaky,{" "}
-                    {format.durationSec(stats?.avgDuration || 0)} avg, {format.durationSec(stats?.maxDuration || 0)}{" "}
-                    max)
-                  </span>
-                </div>
-                <div className="tap-row">
-                  {this.getTargetStatuses(targetHistory)
-                    .slice(0, this.state.invocationLimit)
-                    .map((commitStatus: CommitStatus) => {
-                      let statuses = commitStatus.statuses?.sort(
-                        (a, b) => Number(b.invocationCreatedAtUsec) - Number(a.invocationCreatedAtUsec)
-                      );
-                      if (!statuses || statuses.length == 0) {
-                        // For V2, null means the target was not run for this commit.
-                        return (
-                          <div className="tap-commit-container">
-                            <div
-                              className="tap-block no-status"
-                              title={
-                                commitStatus.commitSha
-                                  ? `Target status not reported at commit ${commitStatus.commitSha}`
-                                  : "No status reported"
-                              }
-                            />
-                          </div>
-                        );
-                      }
-                      return (
-                        <div className="tap-commit-container">
-                          {statuses.map((status) => {
-                            let destinationUrl = `/invocation/${status.invocationId}?${new URLSearchParams({
-                              target: targetHistory.target?.label || "",
-                              targetStatus: String(status),
-                            })}`;
-                            let title =
-                              this.getColorMode() == "timing"
-                                ? `${this.durationToNum(status.timing?.duration || undefined).toFixed(2)}s`
-                                : this.statusToString(status.status || Status.STATUS_UNSPECIFIED);
-                            if (this.isV2 && commitStatus.commitSha) {
-                              title += ` at commit ${commitStatus.commitSha}`;
-                            }
-
-                            return (
-                              <a
-                                key={targetHistory.target?.label || "" + status.invocationId}
-                                href={destinationUrl}
-                                onClick={this.navigateTo.bind(this, destinationUrl)}
-                                title={title}
-                                style={{
-                                  opacity:
-                                    this.getColorMode() == "timing"
-                                      ? Math.max(
-                                          MIN_OPACITY,
-                                          (1.0 * this.durationToNum(status.timing?.duration || undefined)) /
-                                            (stats?.maxDuration || 1)
-                                        )
-                                      : undefined,
-                                }}
-                                className={`tap-block ${
-                                  this.getColorMode() == "status" ? `status-${status.status}` : "timing"
-                                } clickable`}>
-                                {this.statusToIcon(status.status || Status.STATUS_UNSPECIFIED)}
-                              </a>
-                            );
-                          })}
-                        </div>
-                      );
-                    })}
-                </div>
-              </React.Fragment>
-            );
-          })}
-          {filteredTargets.length > this.state.targetLimit && (
-            <FilledButton className="more-targets-button" onClick={this.loadMoreTargets.bind(this)}>
-              Load more targets
-            </FilledButton>
-          )}
-        </div>
+        {tabContent}
       </div>
     );
   }
-}
-
-interface InnerTopBarProps {
-  commits: string[];
-  commitToMaxInvocationCreatedAtUsec: Map<string, number>;
-  moreInvocationsButton: JSX.Element;
-}
-
-interface InnerTopBarState {
-  hoveredCommit: CommitTimestamp | null;
-}
-
-interface CommitTimestamp {
-  commitSha: string;
-  timestampUsec: number;
-}
-
-/**
- * Top bar that sticks to the top of the scrollable area, containing the commit
- * timeline.
- */
-class InnerTopBar extends React.Component<InnerTopBarProps, InnerTopBarState> {
-  state: InnerTopBarState = {
-    hoveredCommit: null,
-  };
-
-  private commitTimeline = React.createRef<HTMLDivElement>();
-  private hoveredCommitRow = React.createRef<HTMLDivElement>();
-  private hoveredCommitInfo = React.createRef<HTMLDivElement>();
-  private hoveredCommitPointer = React.createRef<HTMLDivElement>();
-  // TODO(bduffany): Use a generic tooltip component.
-  private tooltipPortal?: HTMLDivElement;
-
-  componentWillMount() {
-    const tooltipPortal = document.createElement("div");
-    tooltipPortal.style.position = "fixed";
-    tooltipPortal.style.zIndex = "1";
-    tooltipPortal.style.opacity = "0";
-    document.body.appendChild(tooltipPortal);
-    this.tooltipPortal = tooltipPortal;
-  }
-
-  componentWillUnmount() {
-    this.tooltipPortal!.remove();
-  }
-
-  onMouseLeaveCommitTimeline(event: React.MouseEvent) {
-    this.setState({ hoveredCommit: null });
-    this.tooltipPortal!.style.opacity = "0";
-  }
-
-  onMouseOverCommit(commitSha: string, event: React.MouseEvent) {
-    this.setState({
-      hoveredCommit: {
-        commitSha,
-        timestampUsec: this.props.commitToMaxInvocationCreatedAtUsec.get(commitSha) || 0,
-      },
-    });
-
-    const hoveredElement = event.target as HTMLElement;
-    setTimeout(() => this.centerHoveredCommitWith(hoveredElement));
-  }
-
-  onClickCommitLink(event: React.MouseEvent) {
-    event.preventDefault();
-    const link = event.target as HTMLAnchorElement;
-    if (link.getAttribute("href")) {
-      router.navigateTo(link.getAttribute("href")!);
-    }
-  }
-
-  centerHoveredCommitWith(element: HTMLElement) {
-    const hoveredCommit = this.hoveredCommitInfo.current;
-    if (!hoveredCommit) return;
-
-    const hoveredCommitPointer = this.hoveredCommitPointer.current!;
-    const hoveredCommitRow = this.hoveredCommitRow.current!;
-
-    const screenCenterX = element.getBoundingClientRect().left + element.clientWidth / 2;
-    const maxScreenLeftX = window.innerWidth - hoveredCommit.clientWidth;
-    const screenLeftX = clamp(screenCenterX - hoveredCommit.clientWidth / 2, 0, maxScreenLeftX);
-    const screenTop = hoveredCommitRow.getBoundingClientRect().top;
-    const screenBottom = screenTop + hoveredCommitRow.clientHeight;
-
-    hoveredCommit.style.left = `${screenLeftX}px`;
-    hoveredCommit.style.top = `${screenTop}px`;
-    hoveredCommitPointer.style.left = `${screenCenterX}px`;
-    hoveredCommitPointer.style.top = `${screenBottom}px`;
-    this.tooltipPortal!.style.opacity = "1";
-  }
-
-  render() {
-    return (
-      <>
-        <div className="inner-top-bar-underlay" />
-        <div className="commit-timeline-label">Commits (most recent first)</div>
-        <div className="inner-top-bar">
-          <div className="hovered-commit-row" ref={this.hoveredCommitRow}>
-            {this.state.hoveredCommit &&
-              ReactDOM.createPortal(
-                <>
-                  <div className="tap-hovered-commit-pointer" ref={this.hoveredCommitPointer} />
-                  <div className="tap-hovered-commit-info" ref={this.hoveredCommitInfo}>
-                    {format.formatTimestampUsec(this.state.hoveredCommit.timestampUsec)}, commit{" "}
-                    {this.state.hoveredCommit.commitSha.substring(0, 6)}
-                  </div>
-                </>,
-                this.tooltipPortal!
-              )}
-          </div>
-          <div
-            className="commit-timeline"
-            onMouseLeave={this.onMouseLeaveCommitTimeline.bind(this)}
-            ref={this.commitTimeline}>
-            <div className="commits-list">
-              {this.props.commits.map((commitSha) => (
-                <a
-                  className="commit-link"
-                  href={`/history/commit/${commitSha}`}
-                  onClick={this.onClickCommitLink.bind(this)}
-                  onMouseOver={this.onMouseOverCommit.bind(this, commitSha)}
-                />
-              ))}
-            </div>
-            {this.props.moreInvocationsButton}
-          </div>
-        </div>
-      </>
-    );
-  }
-}
-
-/**
- * Merges two lists of target histories into a single list with the joined target histories.
- *
- * This operation may mutate h1, so callers shouldn't rely on the value of h1 after this is
- * called.
- */
-function mergeHistories(h1: target.TargetHistory[], h2: target.TargetHistory[]): target.TargetHistory[] {
-  const targetLabelToHistory = new Map<string, target.TargetHistory>();
-  for (const history of h1) {
-    targetLabelToHistory.set(history.target?.label || "undefined", history);
-  }
-  for (const history of h2) {
-    const h1History = targetLabelToHistory.get(history.target?.label || "undefined");
-    if (!h1History) {
-      targetLabelToHistory.set(history.target?.label || "undefined", history);
-      h1.push(history);
-      continue;
-    }
-    h1History.targetStatus = h1History.targetStatus.concat(history.targetStatus);
-  }
-  return h1;
 }

--- a/enterprise/app/tap/tap_empty_state.tsx
+++ b/enterprise/app/tap/tap_empty_state.tsx
@@ -1,0 +1,52 @@
+import { ChevronRight } from "lucide-react";
+import React from "react";
+
+interface Props {
+  title: string;
+  message: string;
+  showV2Instructions: boolean;
+}
+
+export default class TapEmptyStateComponent extends React.Component<Props> {
+  render() {
+    return (
+      <div className="container narrow">
+        <div className="empty-state history">
+          <h2>{this.props.title}</h2>
+          {this.props.showV2Instructions ? (
+            <p>
+              {this.props.message}
+              <ul>
+                <li>
+                  Add <code className="inline-code">--build_metadata=ROLE=CI</code> to your CI bazel test command.
+                </li>
+                <li>
+                  Provide a{" "}
+                  <a target="_blank" href="https://www.buildbuddy.io/docs/guide-metadata/#commit-sha">
+                    commit SHA
+                  </a>{" "}
+                  and{" "}
+                  <a target="_blank" href="https://www.buildbuddy.io/docs/guide-metadata/#repository-url">
+                    repository URL
+                  </a>
+                  .
+                </li>
+              </ul>
+            </p>
+          ) : (
+            <p>
+              Seems like you haven't done any builds marked as CI. Add <b>--build_metadata=ROLE=CI</b> to your builds to
+              see a CI test grid. You'll likely also want to provide a commit SHA and optionally a git repo url.
+            </p>
+          )}
+          <p>Check out the Build Metadata Guide below for more information on configuring these.</p>
+          <p>
+            <a className="button" target="_blank" href="https://buildbuddy.io/docs/guide-metadata">
+              Build Metadata Guide <ChevronRight />
+            </a>
+          </p>
+        </div>
+      </div>
+    );
+  }
+}

--- a/enterprise/app/trends/trends.css
+++ b/enterprise/app/trends/trends.css
@@ -71,6 +71,10 @@
   fill: #e57373;
 }
 
+.trends-clickable-bar.orange:hover {
+  fill: #ff8f00;
+}
+
 .trends-clickable-bar.grey:hover {
   fill: #ccc;
 }

--- a/enterprise/app/trends/trends_chart.tsx
+++ b/enterprise/app/trends/trends_chart.tsx
@@ -63,6 +63,7 @@ interface TrendsChartTooltipProps extends TooltipProps<any, any> {
 export enum ChartColor {
   GREEN = "#8BC34A",
   RED = "#F44336",
+  ORANGE = "#FF6F00",
   BLUE = "#03A9F4",
   GREY = "#AAAAAA",
 }
@@ -75,6 +76,8 @@ function chartColorToCssClass(c: ChartColor): string {
       return "grey";
     case ChartColor.RED:
       return "red";
+    case ChartColor.ORANGE:
+      return "orange";
     case ChartColor.GREEN:
       return "green";
   }


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
- a page over by the test grid ui to see a table of flaky targets from the last 7 days.
- a click-through to a specific target to see sample flakes for that target
- a link on the target page to see recent flakes of a failing tests.
- a link on the invocation page to see recent flakes of any failing tests that are recently flaky

styles need a bit of love but geez this change is big and i'd rather get it on in dev before fixing it up.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
