### PR TITLE
Use `git gc --auto` instead of `git maintenance`

### DIFF
--- a/enterprise/server/cmd/ci_runner/main.go
+++ b/enterprise/server/cmd/ci_runner/main.go
@@ -2345,10 +2345,9 @@ func reclaimDiskSpace(ctx context.Context, log *buildEventReporter) error {
 }
 
 func runGitMaintenance(ctx context.Context) error {
-	for _, task := range []string{"loose-objects", "incremental-repack", "pack-refs"} {
-		if _, err := git(ctx, os.Stderr, "maintenance", "run", "--task="+task); err != nil {
-			return fmt.Errorf("%s: %w", task, err)
-		}
+	// TODO: switch to git maintenance once it's more widely available.
+	if _, err := git(ctx, os.Stderr, "gc", "--auto"); err != nil {
+		return fmt.Errorf("git gc: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
The CI runner image doesn't have a recent enough version of `git`: https://buildbuddy.buildbuddy.dev/invocation/3e19735b-975c-4436-9129-cd009d836dc2?role=CI_RUNNER&days=7&branch=master

**Related issues**: N/A
