### PR TITLE
firecracker: mount only cgroup v2 in the guest instead of hybrid v1+v2

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker_test.go
@@ -136,8 +136,8 @@ func TestGuestAPIVersion(t *testing.T) {
 	// Note that if you go with option 1, ALL VM snapshots will be invalidated
 	// which will negatively affect customer experience. Be careful!
 	const (
-		expectedHash    = "662d84be177d232e856f0942584563bb79194d95fbaa7760756194ec107bbb4c"
-		expectedVersion = "10"
+		expectedHash    = "2b869dd271a3bbcf19b13f383b3864de9eb836f16bf8f01aa388d863dda16f53"
+		expectedVersion = "11"
 	)
 	assert.Equal(t, expectedHash, firecracker.GuestAPIHash)
 	assert.Equal(t, expectedVersion, firecracker.GuestAPIVersion)
@@ -1336,6 +1336,7 @@ func TestFirecrackerRunWithDockerOverUDS(t *testing.T) {
 		t.Skip()
 	}
 
+	flags.Set(t, "executor.firecracker_guest_cgroup_v2_only", true)
 	ctx := context.Background()
 	env := getTestEnv(ctx, t, envOpts{})
 	rootDir := testfs.MakeTempDir(t)
@@ -1393,6 +1394,7 @@ func TestFirecrackerRunWithDockerOverTCP(t *testing.T) {
 		t.Skip()
 	}
 
+	flags.Set(t, "executor.firecracker_guest_cgroup_v2_only", true)
 	ctx := context.Background()
 	env := getTestEnv(ctx, t, envOpts{})
 	rootDir := testfs.MakeTempDir(t)
@@ -1443,6 +1445,7 @@ func TestFirecrackerRunWithDockerOverTCPDisabled(t *testing.T) {
 		t.Skip()
 	}
 
+	flags.Set(t, "executor.firecracker_guest_cgroup_v2_only", true)
 	ctx := context.Background()
 	env := getTestEnv(ctx, t, envOpts{})
 	rootDir := testfs.MakeTempDir(t)

--- a/proto/firecracker.proto
+++ b/proto/firecracker.proto
@@ -23,6 +23,7 @@ message VMConfiguration {
   string firecracker_version = 9;
   string guest_api_version = 10;
   bool enable_logging = 12;
+  bool cgroup_v2_only = 13;
 
   // Guest kernel boot args.
   string boot_args = 11;


### PR DESCRIPTION
`crun` doesn't appear to be fully compatible with a "hybrid" cgroup setup (v1+v2) - when running the OCI runtime tests on Firecracker, I'm getting the error `cgroups in hybrid mode not supported` ([invocation link](https://buildbuddy.buildbuddy.io/invocation/a3f929c0-f756-4cf0-89a7-ddb9e37b6407?target=%2F%2Fenterprise%2Fserver%2Fremote_execution%2Fcontainers%2Fociruntime%3Aociruntime_test&targetStatus=6)) which comes from the code [here](https://github.com/containers/crun/blob/f44da38333321335611d45638401e99f5f9548f2/src/libcrun/cgroup.c#L314-L326)

This PR adds a flag to only enable cgroup2 within the guest. Since modern distros have ditched the hybrid setup in favor of v2-only, I would like to enable this everywhere after some testing in dev with docker-in-firecracker, so I went with an executor-level flag rather than a platform property.

**Related issues**: N/A
