### PR TITLE
invocation_logs_model: handle fetchTail base case

### DIFF
--- a/app/invocation/invocation_logs_model.tsx
+++ b/app/invocation/invocation_logs_model.tsx
@@ -97,6 +97,9 @@ export default class InvocationLogsModel {
     ).subscribe({
       next: (response) => {
         this.handleResponse(response);
+        if (response.nextChunkId === "") {
+          return;
+        }
         // Unchanged next chunk ID means the invocation is still in progress and
         // we should continue polling that chunk.
         if (response.nextChunkId === chunkId) {


### PR DESCRIPTION
In some special cases, the server could send response without
next_chunk_id field set and cause our UI to trigger an infinite
recursion loop.

Handle the base case to break the loop early.
