### PR TITLE
Disable BES progress buffering (for our repo only) to fix curses output rendered in the UI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -245,6 +245,11 @@ common:webdriver-debug --test_output=streamed
 #   $ open cover/index.html
 common --combined_report=lcov
 
+# Disable BES progress event buffering.
+# When buffering progress events, the relative ordering between stdout and
+# stderr can be lost, resulting in the terminal output appearing garbled.
+common --bes_outerr_buffer_size=0
+
 # Use BLAKE3 digest function.
 startup --digest_function=BLAKE3
 # Bazel doesn't track the contents of source directories by default, which can result


### PR DESCRIPTION
Occasionally we get build logs that look like this when rendered in the UI:

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/1c5ce1d7-3eb8-4e04-b1ee-3bfb148e08ce)

Note how the progress output like `[ 203 / 1,001 ] ...` is interleaved with the build output. This is not supposed to happen - the progress output should be "pinned" to the tail of the log, resulting in the same nice UI that we see when building locally. Instead, we get this garbled output which is hard to read. Here is how it looks in my local terminal:

![image](https://github.com/buildbuddy-io/buildbuddy/assets/2414826/01019b12-1bb4-4a6c-b93c-227cf9f65c90)

The root cause of the garbled output is Bazel's progress event buffering. When `--bes_outerr_buffer_size` is non-zero (it defaults to `10240` bytes), `stdout` and `stderr` are buffered into a single progress event as two *independent* string buffers, until either the configured buffer size is reached (for either of the buffers) or the configured `progress_report_interval` is reached. The problem with the current buffering implementation is that it is "lossy:" because the streams are buffered independently, we lose information about the relative ordering between the writes to stdout and stderr.

So in practice, what happens is one of two things:
- If curses is not enabled (which is the default when building non-interactively, e.g. GitHub Actions), the worst that happens is that some log output renders slightly out of order. This is a bit confusing, but not too terrible in practice.
- If curses is enabled (which is the case by default when building locally as well as on BB workflows), the terminal output can appear totally garbled like it does in this screenshot, since the ANSI escape sequences used to implement the curses rendering rely on the correct relative ordering of stdout and stderr.

So, the fix in this PR is to disable progress event buffering. This means that each write to stdout / stderr results in a Progress event being immediately published. So effectively, the relative ordering of stdout / stderr is preserved.

Setting this buffer size to 0 does significantly increase the number of Progress events that are published in my testing, but this is not necessarily horrible. Here are the downsides that I can think of:
- More progress events means greater client overhead (more events to publish) and more server overhead (more progress events to ACK). However, I don't think this overhead will be that bad, mostly due to buffering in the transport layer -- IIUC, gRPC can batch multiple messages together in a single write.
- It will probably increase the size of `--build_event_json_file` file if people are using it. It's unclear to me whether this will be a major issue in practice.
- It will slightly increase the amount of build event data that is stored in blobstore. Note that we don't store the full log output in blobstore when chunked event logs are enabled, so in practice this just means that we'd be storing more of the "framing" surrounding the progress events such as the event ID etc. - note that we store blobs gzipped though, and I suspect that these runs of progress events will compress very well.
- It will increase the number of writes that we do to Redis for writing the invocation log tail, since we'll be getting events more frequently. I think this is fine though, since writing to Redis is cheap. If it does become a major issue, then we can throttle the writes to Redis. A throttling approach would be like doing the buffering on the server-side, preserving ordering information, rather than buffering on the client side.

The alternative is adding support to the BEP + Bazel to preserve ordering information between `stdout` and `stderr`. I am hesitant to propose this change to Bazel, because doing the implementation in a backwards-compatible way would be somewhat complicated, and it's unclear whether disabling buffering is a "good enough" solution in practice. My thinking is that we can try disabling buffering, and if it causes too many problems, then we'll have the data + experience to support a proposed change to the BEP.

**Related issues**: N/A
