### PR TITLE
[raft] try replicas in txn

### DIFF
--- a/enterprise/server/raft/rbuilder/rbuilder.go
+++ b/enterprise/server/raft/rbuilder/rbuilder.go
@@ -331,8 +331,8 @@ func (br *BatchResponse) DeleteSessionsResponse(n int) (*rfpb.DeleteSessionsResp
 }
 
 type txnStatement struct {
-	replicaDescriptor *rfpb.ReplicaDescriptor
-	rawBatch          *BatchBuilder
+	rangeDescriptor *rfpb.RangeDescriptor
+	rawBatch        *BatchBuilder
 }
 
 type TxnBuilder struct {
@@ -345,10 +345,10 @@ func NewTxn() *TxnBuilder {
 	}
 }
 
-func (tb *TxnBuilder) AddStatement(replica *rfpb.ReplicaDescriptor, batch *BatchBuilder) *TxnBuilder {
+func (tb *TxnBuilder) AddStatement(rd *rfpb.RangeDescriptor, batch *BatchBuilder) *TxnBuilder {
 	tb.statements = append(tb.statements, txnStatement{
-		replicaDescriptor: replica,
-		rawBatch:          batch,
+		rangeDescriptor: rd,
+		rawBatch:        batch,
 	})
 	return tb
 }
@@ -369,7 +369,7 @@ func (tb *TxnBuilder) ToProto() (*rfpb.TxnRequest, error) {
 			return nil, err
 		}
 		req.Statements = append(req.Statements, &rfpb.TxnRequest_Statement{
-			Replica:  statement.replicaDescriptor,
+			Range:    statement.rangeDescriptor,
 			RawBatch: batchProto,
 		})
 	}

--- a/enterprise/server/raft/store/store.go
+++ b/enterprise/server/raft/store/store.go
@@ -1564,9 +1564,9 @@ func (s *Store) SplitRange(ctx context.Context, req *rfpb.SplitRangeRequest) (*r
 		return nil, err
 	}
 	mrd := s.sender.GetMetaRangeDescriptor()
-	txn := rbuilder.NewTxn().AddStatement(leftRange.GetReplicas()[0], leftBatch)
-	txn = txn.AddStatement(newRightRange.GetReplicas()[0], rightBatch)
-	txn = txn.AddStatement(mrd.GetReplicas()[0], metaBatch)
+	txn := rbuilder.NewTxn().AddStatement(leftRange, leftBatch)
+	txn = txn.AddStatement(newRightRange, rightBatch)
+	txn = txn.AddStatement(mrd, metaBatch)
 	if err := s.txnCoordinator.RunTxn(ctx, txn); err != nil {
 		return nil, err
 	}
@@ -2000,12 +2000,12 @@ func (s *Store) updateRangeDescriptor(ctx context.Context, shardID uint64, old, 
 	txn := rbuilder.NewTxn()
 	if newReplica.GetShardId() == metaReplica.GetShardId() {
 		localBatch.Add(metaRangeCasReq)
-		txn.AddStatement(newReplica, localBatch)
+		txn.AddStatement(mrd, localBatch)
 	} else {
 		metaRangeBatch := rbuilder.NewBatchBuilder()
 		metaRangeBatch.Add(metaRangeCasReq)
-		txn.AddStatement(newReplica, localBatch)
-		txn = txn.AddStatement(metaReplica, metaRangeBatch)
+		txn.AddStatement(new, localBatch)
+		txn = txn.AddStatement(mrd, metaRangeBatch)
 	}
 	return s.txnCoordinator.RunTxn(ctx, txn)
 }

--- a/enterprise/server/raft/txn/BUILD
+++ b/enterprise/server/raft/txn/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//enterprise/server/raft/rbuilder",
         "//enterprise/server/raft/sender",
         "//proto:raft_go_proto",
+        "//proto:raft_service_go_proto",
         "//server/util/log",
         "//server/util/proto",
         "//server/util/status",

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -269,9 +269,9 @@ message PostCommitHook {
 message TxnRequest {
   optional bytes transaction_id = 1;
   message Statement {
-	reserved 1;
+    reserved 1;
     BatchCmdRequest raw_batch = 2;
-	RangeDescriptor range = 3;
+    RangeDescriptor range = 3;
   }
   repeated Statement statements = 2;
 }

--- a/proto/raft.proto
+++ b/proto/raft.proto
@@ -269,8 +269,9 @@ message PostCommitHook {
 message TxnRequest {
   optional bytes transaction_id = 1;
   message Statement {
-    ReplicaDescriptor replica = 1;
+	reserved 1;
     BatchCmdRequest raw_batch = 2;
+	RangeDescriptor range = 3;
   }
   repeated Statement statements = 2;
 }
@@ -293,7 +294,8 @@ message TxnRecord {
   TxnState txn_state = 2;
   // When is this record first created
   int64 created_at_usec = 3;
-  repeated ReplicaDescriptor prepared = 4;
+  reserved 4;
+  repeated RangeDescriptor prepared = 6;
   FinalizeOperation op = 5;
 }
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3537
1. Pass RangeDescriptor instead of ReplicaDescriptor in txn statement. This allows us to try different replicas in txn.
2. Expose TryReplicas from sender, but allow the caller to specify how to make the header. In sender, we pass the range info into the header but in txn we just need to pass the replica.
3. Un-expose FinalizeTxn and DeleteTxn: they are only used internally. 