### PR TITLE
enterprise/server: log OLAPDB is used

### DIFF
--- a/server/util/clickhouse/clickhouse.go
+++ b/server/util/clickhouse/clickhouse.go
@@ -354,5 +354,6 @@ func Register(env *real_environment.RealEnv) error {
 	}
 
 	env.SetOLAPDBHandle(dbh)
+	log.Info("Successfully configured OLAP database.")
 	return nil
 }


### PR DESCRIPTION
Currently our main DB would leave a log like this after successfully
configured:

```
  Successfully configured sqlite database
```

Provide the same for OLAP DB
