### PR TITLE
Add support for retrying locked database errors for more exit codes

### DIFF
--- a/enterprise/server/remote_execution/containers/podman/podman.go
+++ b/enterprise/server/remote_execution/containers/podman/podman.go
@@ -785,7 +785,10 @@ func runPodman(ctx context.Context, commandRunner interfaces.CommandRunner, podm
 
 	// If the disk is under heavy load, podman may fail with "database is
 	// locked". Detect these and return a retryable error.
-	if result.ExitCode == podmanCommandNotRunnableExitCode && databaseLockedRegexp.Match(result.Stderr) {
+	if (result.ExitCode == podmanCommandNotRunnableExitCode ||
+		result.ExitCode == podmanInternalExitCode ||
+		result.ExitCode == podmanCommandNotFoundExitCode) &&
+		databaseLockedRegexp.Match(result.Stderr) {
 		result.ExitCode = commandutil.NoExitCode
 		result.Error = status.UnavailableErrorf("podman failed: %q", strings.TrimSpace(string(result.Stderr)))
 	}


### PR DESCRIPTION
Looks like these "database is locked" can surface through multiple different podman exit codes.

This PR adds support for two more that we've witnessed in the wild, 125 and 127 (we previously only retried 126).