### PR TITLE
Add instance name back to snapshot-specific key

### DIFF
--- a/enterprise/server/remote_execution/snaploader/snaploader.go
+++ b/enterprise/server/remote_execution/snaploader/snaploader.go
@@ -678,7 +678,10 @@ func (l *FileCacheLoader) cacheActionResult(ctx context.Context, key *fcpb.Snaps
 		// Cache snapshot manifest for this specific snapshot ID
 		if opts.VMMetadata.GetSnapshotId() != "" {
 			snapshotID := opts.VMMetadata.SnapshotId
-			snapshotSpecificKey := &fcpb.SnapshotKey{SnapshotId: snapshotID}
+			snapshotSpecificKey := &fcpb.SnapshotKey{
+				InstanceName: key.InstanceName,
+				SnapshotId:   snapshotID,
+			}
 			snapshotSpecificManifestKey, err := RemoteManifestKey(snapshotSpecificKey)
 			if err != nil {
 				log.Warningf("Failed to generate snapshot specific remote manifest key for snapshot ID %s: %s", snapshotID, err)
@@ -712,7 +715,10 @@ func (l *FileCacheLoader) cacheActionResult(ctx context.Context, key *fcpb.Snaps
 	// Cache snapshot manifest for this specific snapshot ID
 	if opts.VMMetadata.GetSnapshotId() != "" {
 		snapshotID := opts.VMMetadata.GetSnapshotId()
-		snapshotSpecificKey := &fcpb.SnapshotKey{SnapshotId: snapshotID}
+		snapshotSpecificKey := &fcpb.SnapshotKey{
+			InstanceName: key.InstanceName,
+			SnapshotId:   snapshotID,
+		}
 
 		snapshotSpecificManifestKey, err := LocalManifestKey(gid, snapshotSpecificKey)
 		if err != nil {


### PR DESCRIPTION
We probably should remove `instance_name` from the snapshot key proto, since the key is basically the "digest" part of the resource name, and the instance name is normally separate from the digest. But that will be a pretty big refactor, so just add the instance name back to the snapshot-specific key to hold us over until then.

**Related issues**: N/A
