### PR TITLE
filter samples by the right set of statuses.

### DIFF
--- a/server/target/target.go
+++ b/server/target/target.go
@@ -942,7 +942,7 @@ func GetTargetFlakeSamples(ctx context.Context, env environment.Env, req *trpb.G
 				PARTITION BY label
 				ORDER BY invocation_start_time_usec ASC
 				ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING))
-		WHERE (first_status BETWEEN 1 AND 2) AND (last_status BETWEEN 1 AND 2) AND status > 2))
+		WHERE (first_status BETWEEN 1 AND 2) AND (last_status BETWEEN 1 AND 2) AND status IN (3, 4)))
 	ORDER BY invocation_start_time_usec DESC LIMIT ? OFFSET ?`, innerWhereClause, innerWhereClause)
 
 	type queryOut struct {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
there will probably still be quirks involving missing logs but wanted to do this first.

See buildbuddy-io/buildbuddy-internal/issues/3543
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
