### PR TITLE
[raft] driver: add tests to choose and compare candidates, and fix a bug in compare

### DIFF
--- a/enterprise/server/raft/driver/BUILD
+++ b/enterprise/server/raft/driver/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "driver",
@@ -18,3 +18,16 @@ go_library(
 )
 
 package(default_visibility = ["//enterprise:__subpackages__"])
+
+go_test(
+    name = "driver_test",
+    srcs = ["driver_test.go"],
+    embed = [":driver"],
+    deps = [
+        "//enterprise/server/raft/storemap",
+        "//proto:raft_go_proto",
+        "//server/util/log",
+        "//server/util/proto",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/server/raft/driver/driver_test.go
+++ b/enterprise/server/raft/driver/driver_test.go
@@ -1,0 +1,211 @@
+package driver
+
+import (
+	"math/rand"
+	"slices"
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/storemap"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
+	"github.com/stretchr/testify/require"
+
+	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+)
+
+func TestCandidateComparison(t *testing.T) {
+	expected := []*candidate{
+		// Candidate with full disk
+		{
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-1"}},
+			fullDisk:              true,
+			replicaCountMeanLevel: aboveMean,
+			replicaCount:          1000,
+		},
+		// Candidate with range count far above the mean
+		{
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-2"}},
+			fullDisk:              false,
+			replicaCountMeanLevel: aboveMean,
+			replicaCount:          1000,
+		},
+		{
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-3"}},
+			fullDisk:              false,
+			replicaCountMeanLevel: aboveMean,
+			replicaCount:          990,
+		},
+		// Candidate with range count around the mean
+		{
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-4"}},
+			fullDisk:              false,
+			replicaCountMeanLevel: aroundMean,
+			replicaCount:          810,
+		},
+		{
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-5"}},
+			fullDisk:              false,
+			replicaCountMeanLevel: aroundMean,
+			replicaCount:          800,
+		},
+		{
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-6"}},
+			fullDisk:              false,
+			replicaCountMeanLevel: aroundMean,
+			replicaCount:          790,
+		},
+		// Candidate with range count far below the mean
+		{
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-7"}},
+			fullDisk:              false,
+			replicaCountMeanLevel: belowMean,
+			replicaCount:          500,
+		},
+		{
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-8"}},
+			fullDisk:              false,
+			replicaCountMeanLevel: belowMean,
+			replicaCount:          400,
+		},
+	}
+
+	candidates := make([]*candidate, 0, len(expected))
+	copy(expected, candidates)
+	rand.Shuffle(len(candidates), func(i, j int) {
+		candidates[i], candidates[j] = candidates[j], candidates[i]
+	})
+
+	slices.SortFunc(candidates, compareByScore)
+
+	for i, c := range candidates {
+		require.EqualExportedValuesf(t, expected[i], c, "candidates[%d] should match expected[%d]")
+	}
+}
+
+func TestFindNodeForAllocation(t *testing.T) {
+	tests := []struct {
+		desc     string
+		usages   []*rfpb.StoreUsage
+		rd       *rfpb.RangeDescriptor
+		expected *rfpb.NodeDescriptor
+	}{
+		{
+			desc: "skip-node-with-range",
+			usages: []*rfpb.StoreUsage{
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-1"},
+					ReplicaCount:   10,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-2"},
+					ReplicaCount:   1,
+					TotalBytesUsed: 5,
+					TotalBytesFree: 990,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-3"},
+					ReplicaCount:   4,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-4"},
+					ReplicaCount:   3,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+			},
+			rd: &rfpb.RangeDescriptor{
+				RangeId: 1,
+				Replicas: []*rfpb.ReplicaDescriptor{
+					{ShardId: 1, ReplicaId: 1, Nhid: proto.String("nhid-1")},
+					{ShardId: 1, ReplicaId: 2, Nhid: proto.String("nhid-2")},
+					{ShardId: 1, ReplicaId: 3, Nhid: proto.String("nhid-3")},
+				},
+			},
+			expected: &rfpb.NodeDescriptor{Nhid: "nhid-4"},
+		},
+		{
+			desc: "skip-node-with-full-disk",
+			usages: []*rfpb.StoreUsage{
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-1"},
+					ReplicaCount:   10,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-2"},
+					ReplicaCount:   1,
+					TotalBytesUsed: 990,
+					TotalBytesFree: 10,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-3"},
+					ReplicaCount:   4,
+					TotalBytesUsed: 960,
+					TotalBytesFree: 10,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-4"},
+					ReplicaCount:   3,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+			},
+			rd: &rfpb.RangeDescriptor{
+				RangeId: 1,
+				Replicas: []*rfpb.ReplicaDescriptor{
+					{ShardId: 1, ReplicaId: 1, Nhid: proto.String("nhid-1")},
+				},
+			},
+			expected: &rfpb.NodeDescriptor{Nhid: "nhid-4"},
+		},
+		{
+			desc: "find-node-with-least-ranges",
+			usages: []*rfpb.StoreUsage{
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-1"},
+					ReplicaCount:   10,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-2"},
+					ReplicaCount:   10,
+					TotalBytesUsed: 990,
+					TotalBytesFree: 10,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-3"},
+					ReplicaCount:   5,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-4"},
+					ReplicaCount:   3,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+			},
+			rd: &rfpb.RangeDescriptor{
+				RangeId: 1,
+				Replicas: []*rfpb.ReplicaDescriptor{
+					{ShardId: 1, ReplicaId: 1, Nhid: proto.String("nhid-1")},
+				},
+			},
+			expected: &rfpb.NodeDescriptor{Nhid: "nhid-4"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			rq := &Queue{log: log.Logger{}}
+			storesWithStats := storemap.CreateStoresWithStats(tc.usages)
+			actual := rq.findNodeForAllocation(tc.rd, storesWithStats)
+			require.EqualExportedValues(t, tc.expected, actual)
+		})
+	}
+}

--- a/enterprise/server/raft/storemap/storemap.go
+++ b/enterprise/server/raft/storemap/storemap.go
@@ -181,7 +181,7 @@ type StoresWithStats struct {
 	TotalBytesUsed Stat
 }
 
-func createStoresWithStats(usages []*rfpb.StoreUsage) *StoresWithStats {
+func CreateStoresWithStats(usages []*rfpb.StoreUsage) *StoresWithStats {
 	res := &StoresWithStats{}
 	for _, usage := range usages {
 		res.Usages = append(res.Usages, usage.CloneVT())
@@ -206,7 +206,7 @@ func (sm *StoreMap) GetStoresWithStats() *StoresWithStats {
 			alive = append(alive, sd.usage)
 		}
 	}
-	return createStoresWithStats(alive)
+	return CreateStoresWithStats(alive)
 }
 
 func (sm *StoreMap) GetStoresWithStatsFromIDs(nhids []string) *StoresWithStats {
@@ -224,5 +224,5 @@ func (sm *StoreMap) GetStoresWithStatsFromIDs(nhids []string) *StoresWithStats {
 			alive = append(alive, sd.usage)
 		}
 	}
-	return createStoresWithStats(alive)
+	return CreateStoresWithStats(alive)
 }


### PR DESCRIPTION
It's difficult to set up different scenerios in store_test to test
driver logic. Therefore, we will use store_test to test the interaction
between the store and the queue, and basic placement logic.

Since it's complicated to choose and compare candidates, it's worthwhile
to test these logic seperately.

1. export storemap.CreateStoresWithStats
2. create two versions of compare functions: compare by score and
   compare by score and id. We will use compareByStoreAndID when
   sorting. In rebalancing, we need compareByScore.
3. change the return type of compare to int instead of float64 to make
   things easier
4. add test to compare method and findNodeForAllocation and fix a bug in
   compare method

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
