### PR TITLE
schema changes to store whether or not a test target was cached

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -530,6 +530,7 @@ type TargetStatus struct {
 	InvocationUUID []byte `gorm:"primaryKey;autoIncrement:false;size:16;index:target_status_invocation_uuid_idx"`
 	TargetType     int32
 	TestSize       int32
+	Cached         bool `gorm:"not null;default:0"`
 	Status         int32
 	StartTimeUsec  int64
 	DurationUsec   int64

--- a/server/util/clickhouse/schema/schema.go
+++ b/server/util/clickhouse/schema/schema.go
@@ -256,6 +256,7 @@ type TestTargetStatus struct {
 	TargetType    int32
 	TestSize      int32
 	Status        int32
+	Cached        bool
 	StartTimeUsec int64
 	DurationUsec  int64
 


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
default value is false (i.e., not cached), which is effectively a no-op with prod.  there isn't a reasonable backfill path.
<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
