### PR TITLE
OCI runtime: add standard image pull optimizations

### DIFF
--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -22,11 +22,13 @@ go_library(
         "//server/environment",
         "//server/interfaces",
         "//server/util/disk",
+        "//server/util/hash",
         "//server/util/log",
         "//server/util/status",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_opencontainers_runtime_spec//specs-go",
         "@org_golang_x_sync//errgroup",
+        "@org_golang_x_sync//singleflight",
         "@org_golang_x_sys//unix",
     ],
 )

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -793,7 +793,10 @@ type ImageStore struct {
 }
 
 func NewImageStore(layersDir string) *ImageStore {
-	return &ImageStore{layersDir: layersDir}
+	return &ImageStore{
+		layersDir:    layersDir,
+		cachedLayers: map[string][]ctr.Layer{},
+	}
 }
 
 // Pull downloads and extracts image layers to a directory, skipping layers

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -220,6 +220,11 @@ func TestPullCreateExecRemove(t *testing.T) {
 	err = c.PullImage(ctx, oci.Credentials{})
 	require.NoError(t, err)
 
+	// Ensure cached
+	cached, err := c.IsImageCached(ctx)
+	require.NoError(t, err)
+	assert.True(t, cached, "IsImageCached")
+
 	// Create
 	require.NoError(t, err)
 	err = c.Create(ctx, wd)


### PR DESCRIPTION
Adds the usual optimizations to avoid excessive requests to the remote image registry:
* Implement `IsImageCached` so that `container.PullImageIfNecessary` can skip the call to `Pull` most of the time
* Dedupe pulls for the same image ref, since the executor would otherwise be making an excessive amount of requests to the registry when assigned several actions that need the same image within a short duration

**Related issues**: N/A
