### PR TITLE
[raft] driver test: add tests for finding replicas to remove

### DIFF
--- a/enterprise/server/raft/driver/BUILD
+++ b/enterprise/server/raft/driver/BUILD
@@ -24,10 +24,12 @@ go_test(
     srcs = ["driver_test.go"],
     embed = [":driver"],
     deps = [
+        "//enterprise/server/raft/constants",
         "//enterprise/server/raft/storemap",
         "//proto:raft_go_proto",
         "//server/util/log",
         "//server/util/proto",
+        "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/server/raft/driver/driver_test.go
+++ b/enterprise/server/raft/driver/driver_test.go
@@ -4,14 +4,45 @@ import (
 	"math/rand"
 	"slices"
 	"testing"
+	"time"
 
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/storemap"
 	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
 )
+
+type testStoreMap struct {
+	usages map[string]*rfpb.StoreUsage
+}
+
+func newTestStoreMap(usages []*rfpb.StoreUsage) *testStoreMap {
+	m := make(map[string]*rfpb.StoreUsage)
+	for _, su := range usages {
+		m[su.GetNode().GetNhid()] = su
+	}
+	return &testStoreMap{usages: m}
+}
+
+func (tsm *testStoreMap) GetStoresWithStats() *storemap.StoresWithStats { return nil }
+
+func (tsm *testStoreMap) GetStoresWithStatsFromIDs(nhids []string) *storemap.StoresWithStats {
+	usages := make([]*rfpb.StoreUsage, 0, len(nhids))
+	for _, nhid := range nhids {
+		if su, ok := tsm.usages[nhid]; ok {
+			usages = append(usages, su)
+		}
+	}
+	return storemap.CreateStoresWithStats(usages)
+}
+
+func (tsm *testStoreMap) DivideByStatus(repls []*rfpb.ReplicaDescriptor) *storemap.ReplicasByStatus {
+	return nil
+}
 
 func TestCandidateComparison(t *testing.T) {
 	expected := []*candidate{
@@ -20,66 +51,83 @@ func TestCandidateComparison(t *testing.T) {
 			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-1"}},
 			fullDisk:              true,
 			replicaCountMeanLevel: aboveMean,
+			replicaCount:          1010,
+		},
+		{
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-2"}},
+			fullDisk:              true,
+			replicaCountMeanLevel: aboveMean,
 			replicaCount:          1000,
 		},
 		// Candidate with range count far above the mean
 		{
-			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-2"}},
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-3"}},
 			fullDisk:              false,
 			replicaCountMeanLevel: aboveMean,
 			replicaCount:          1000,
 		},
 		{
-			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-3"}},
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-4"}},
 			fullDisk:              false,
 			replicaCountMeanLevel: aboveMean,
 			replicaCount:          990,
 		},
 		// Candidate with range count around the mean
 		{
-			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-4"}},
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-5"}},
 			fullDisk:              false,
 			replicaCountMeanLevel: aroundMean,
 			replicaCount:          810,
 		},
 		{
-			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-5"}},
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-6"}},
 			fullDisk:              false,
 			replicaCountMeanLevel: aroundMean,
 			replicaCount:          800,
 		},
 		{
-			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-6"}},
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-7"}},
 			fullDisk:              false,
 			replicaCountMeanLevel: aroundMean,
 			replicaCount:          790,
 		},
 		// Candidate with range count far below the mean
 		{
-			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-7"}},
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-8"}},
 			fullDisk:              false,
 			replicaCountMeanLevel: belowMean,
 			replicaCount:          500,
 		},
 		{
-			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-8"}},
+			usage:                 &rfpb.StoreUsage{Node: &rfpb.NodeDescriptor{Nhid: "nhid-9"}},
 			fullDisk:              false,
 			replicaCountMeanLevel: belowMean,
 			replicaCount:          400,
 		},
 	}
 
-	candidates := make([]*candidate, 0, len(expected))
-	copy(expected, candidates)
+	candidates := make([]*candidate, len(expected))
+	copy(candidates, expected)
+
 	rand.Shuffle(len(candidates), func(i, j int) {
 		candidates[i], candidates[j] = candidates[j], candidates[i]
 	})
 
+	require.Equal(t, len(expected), len(candidates))
+
 	slices.SortFunc(candidates, compareByScore)
 
-	for i, c := range candidates {
-		require.EqualExportedValuesf(t, expected[i], c, "candidates[%d] should match expected[%d]")
+	expectedOrder := make([]string, 0, len(expected))
+	for _, c := range expected {
+		expectedOrder = append(expectedOrder, c.usage.GetNode().GetNhid())
 	}
+	actualOrder := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		actualOrder = append(actualOrder, c.usage.GetNode().GetNhid())
+	}
+
+	require.Equal(t, expectedOrder, actualOrder)
+
 }
 
 func TestFindNodeForAllocation(t *testing.T) {
@@ -202,9 +250,198 @@ func TestFindNodeForAllocation(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			rq := &Queue{log: log.Logger{}}
+			rq := &Queue{log: log.NamedSubLogger("test")}
 			storesWithStats := storemap.CreateStoresWithStats(tc.usages)
 			actual := rq.findNodeForAllocation(tc.rd, storesWithStats)
+			require.EqualExportedValues(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestFindReplicaForRemoval(t *testing.T) {
+	localReplicaID := uint64(1)
+	clock := clockwork.NewFakeClock()
+	now := clock.Now()
+	withinGracePeriodTS := now.Add(-3 * time.Minute).UnixMicro()
+	outsideGracePeriodTS := now.Add(-10 * time.Minute).UnixMicro()
+	tests := []struct {
+		desc            string
+		rd              *rfpb.RangeDescriptor
+		replicaStateMap map[uint64]constants.ReplicaState
+		usages          []*rfpb.StoreUsage
+		expected        *rfpb.ReplicaDescriptor
+	}{
+		{
+			// 4 replicas and 2 of them are current, so we can only delete replicas
+			// that are behind; but we don't want to consider the newly added
+			// replica within the grace period as behind.
+			desc: "do-not-delete-newly-added-replica",
+			rd: &rfpb.RangeDescriptor{
+				RangeId:                1,
+				LastAddedReplicaId:     proto.Uint64(4),
+				LastReplicaAddedAtUsec: proto.Int64(withinGracePeriodTS),
+				Replicas: []*rfpb.ReplicaDescriptor{
+					{ShardId: 1, ReplicaId: 1, Nhid: proto.String("nhid-1")}, // local
+					{ShardId: 1, ReplicaId: 2, Nhid: proto.String("nhid-2")},
+					{ShardId: 1, ReplicaId: 3, Nhid: proto.String("nhid-3")},
+					{ShardId: 1, ReplicaId: 4, Nhid: proto.String("nhid-4")},
+				},
+			},
+			replicaStateMap: map[uint64]constants.ReplicaState{
+				1: constants.ReplicaStateCurrent,
+				2: constants.ReplicaStateCurrent,
+				3: constants.ReplicaStateBehind,
+				4: constants.ReplicaStateBehind,
+			},
+			usages: []*rfpb.StoreUsage{
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-1"},
+					ReplicaCount:   10,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-2"},
+					ReplicaCount:   10,
+					TotalBytesUsed: 990,
+					TotalBytesFree: 10,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-3"},
+					ReplicaCount:   5,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-4"},
+					ReplicaCount:   3,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+			},
+			expected: &rfpb.ReplicaDescriptor{
+				ShardId:   1,
+				ReplicaId: 3,
+				Nhid:      proto.String("nhid-3"),
+			},
+		},
+		{
+			// 4 replicas that are all current, we can delete any of them; but
+			// we prefer to delete the one with full disk. When there are multiple
+			// nodes with full disk, we choose one with higher replica count, even
+			// if this is a newly added replica.
+			desc: "delete-replica-with-full-disk",
+			rd: &rfpb.RangeDescriptor{
+				RangeId:                1,
+				LastAddedReplicaId:     proto.Uint64(4),
+				LastReplicaAddedAtUsec: proto.Int64(outsideGracePeriodTS),
+				Replicas: []*rfpb.ReplicaDescriptor{
+					{ShardId: 1, ReplicaId: 1, Nhid: proto.String("nhid-1")}, // local
+					{ShardId: 1, ReplicaId: 2, Nhid: proto.String("nhid-2")},
+					{ShardId: 1, ReplicaId: 3, Nhid: proto.String("nhid-3")},
+					{ShardId: 1, ReplicaId: 4, Nhid: proto.String("nhid-4")},
+				},
+			},
+			replicaStateMap: map[uint64]constants.ReplicaState{
+				1: constants.ReplicaStateCurrent,
+				2: constants.ReplicaStateCurrent,
+				3: constants.ReplicaStateCurrent,
+				4: constants.ReplicaStateCurrent,
+			},
+			usages: []*rfpb.StoreUsage{
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-1"},
+					ReplicaCount:   10,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-2"},
+					ReplicaCount:   10,
+					TotalBytesUsed: 955,
+					TotalBytesFree: 45,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-3"},
+					ReplicaCount:   5,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-4"},
+					ReplicaCount:   12,
+					TotalBytesUsed: 960,
+					TotalBytesFree: 40,
+				},
+			},
+			expected: &rfpb.ReplicaDescriptor{
+				ShardId:   1,
+				ReplicaId: 4,
+				Nhid:      proto.String("nhid-4"),
+			},
+		},
+		{
+			// Newly added replica will be considered behind if grace period passed
+			// and it is still behind.
+			// 4 replicas and 2 of them are current, so we can only delete replicas
+			// that are behind, which is replica 3 and 4. In this case, we want
+			// to delete replica 4 because it's far above mean replica count.
+			desc: "newly-added-replica-grace-period-pass",
+			rd: &rfpb.RangeDescriptor{
+				RangeId:                1,
+				LastAddedReplicaId:     proto.Uint64(4),
+				LastReplicaAddedAtUsec: proto.Int64(outsideGracePeriodTS),
+				Replicas: []*rfpb.ReplicaDescriptor{
+					{ShardId: 1, ReplicaId: 1, Nhid: proto.String("nhid-1")}, // local
+					{ShardId: 1, ReplicaId: 2, Nhid: proto.String("nhid-2")},
+					{ShardId: 1, ReplicaId: 3, Nhid: proto.String("nhid-3")},
+					{ShardId: 1, ReplicaId: 4, Nhid: proto.String("nhid-4")},
+				},
+			},
+			replicaStateMap: map[uint64]constants.ReplicaState{
+				1: constants.ReplicaStateCurrent,
+				2: constants.ReplicaStateCurrent,
+				3: constants.ReplicaStateBehind,
+				4: constants.ReplicaStateBehind,
+			},
+			usages: []*rfpb.StoreUsage{
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-1"},
+					ReplicaCount:   10,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-2"},
+					ReplicaCount:   11,
+					TotalBytesUsed: 955,
+					TotalBytesFree: 45,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-3"},
+					ReplicaCount:   5,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+				{
+					Node:           &rfpb.NodeDescriptor{Nhid: "nhid-4"},
+					ReplicaCount:   14,
+					TotalBytesUsed: 100,
+					TotalBytesFree: 900,
+				},
+			},
+			expected: &rfpb.ReplicaDescriptor{
+				ShardId:   1,
+				ReplicaId: 4,
+				Nhid:      proto.String("nhid-4"),
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			storeMap := newTestStoreMap(tc.usages)
+			rq := &Queue{log: log.NamedSubLogger("test"), clock: clock, storeMap: storeMap}
+			actual := rq.findReplicaForRemoval(tc.rd, tc.replicaStateMap, localReplicaID)
 			require.EqualExportedValues(t, tc.expected, actual)
 		})
 	}

--- a/enterprise/server/raft/storemap/storemap.go
+++ b/enterprise/server/raft/storemap/storemap.go
@@ -31,6 +31,12 @@ const (
 	storeStatusSuspect
 )
 
+type IStoreMap interface {
+	GetStoresWithStats() *StoresWithStats
+	GetStoresWithStatsFromIDs(nhids []string) *StoresWithStats
+	DivideByStatus(repls []*rfpb.ReplicaDescriptor) *ReplicasByStatus
+}
+
 type StoreDetail struct {
 	usage             *rfpb.StoreUsage
 	lastUnavailableAt time.Time
@@ -47,7 +53,7 @@ type StoreMap struct {
 	clock     clockwork.Clock
 }
 
-func New(gossipManager interfaces.GossipService, clock clockwork.Clock) *StoreMap {
+func New(gossipManager interfaces.GossipService, clock clockwork.Clock) IStoreMap {
 	sm := &StoreMap{
 		mu:            &sync.RWMutex{},
 		startTime:     time.Now(),
@@ -209,6 +215,7 @@ func (sm *StoreMap) GetStoresWithStats() *StoresWithStats {
 	return CreateStoresWithStats(alive)
 }
 
+// Returns stores with stats that are not dead (include both alive and suspect).
 func (sm *StoreMap) GetStoresWithStatsFromIDs(nhids []string) *StoresWithStats {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: 
1. Add an interface IStoreMap, so I can fake it in the test for removal.
2. fix bugs in TestCandidateComparison
3. Fix bugs in compare method: 
- candidate with full disk is worse not better than candidate w/o full disk; should return negative number. 
- when the diff is relatively small compared to range count, return a positive/negative number instead of 0.
4. fix a bug when handling brand new replica id
