### PR TITLE
Make firecracker NAT a little smarter.

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -207,8 +207,8 @@ const (
 )
 
 var (
-	masqueradingOnce sync.Once
-	masqueradingErr  error
+	configureNATOnce sync.Once
+	natErr           error
 
 	vmIdx   int
 	vmIdxMu sync.Mutex
@@ -1684,12 +1684,12 @@ func (c *FirecrackerContainer) setupNetworking(ctx context.Context) error {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.End()
 
-	// Setup masquerading on the host if it isn't already.
-	masqueradingOnce.Do(func() {
-		masqueradingErr = networking.EnableNAT(ctx)
+	// Setup NAT on the host if it isn't already.
+	configureNATOnce.Do(func() {
+		natErr = networking.EnableNAT(ctx)
 	})
-	if masqueradingErr != nil {
-		return masqueradingErr
+	if natErr != nil {
+		return natErr
 	}
 
 	if err := networking.CreateNetNamespace(ctx, c.id); err != nil {

--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1686,7 +1686,7 @@ func (c *FirecrackerContainer) setupNetworking(ctx context.Context) error {
 
 	// Setup masquerading on the host if it isn't already.
 	masqueradingOnce.Do(func() {
-		masqueradingErr = networking.EnableMasquerading(ctx)
+		masqueradingErr = networking.EnableNAT(ctx)
 	})
 	if masqueradingErr != nil {
 		return masqueradingErr

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildbuddy-io/buildbuddy
 
-go 1.21.7
+go 1.22.4
 
 replace (
 	github.com/awslabs/soci-snapshotter => github.com/buildbuddy-io/soci-snapshotter v0.0.8 // keep in sync with buildpatches/com_github_awslabs_soci_snapshotter.patch


### PR DESCRIPTION
If the default route has a source IP, use that for NAT instead of letting the kernel pick the IP.

Our bare metal hosts have two IPs and without this change MASQUERADE would always pick the private IP which cannot talk to the internet.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
