### PR TITLE
Wire up OCI runtime to executor

### DIFF
--- a/enterprise/server/remote_execution/runner/BUILD
+++ b/enterprise/server/remote_execution/runner/BUILD
@@ -56,6 +56,7 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "//enterprise/server/remote_execution/containers/bare",
             "//enterprise/server/remote_execution/containers/docker",
+            "//enterprise/server/remote_execution/containers/ociruntime",
             "//enterprise/server/remote_execution/containers/podman",
             "//proto:vfs_go_proto",
             "@org_golang_google_grpc//:grpc",

--- a/enterprise/server/remote_execution/runner/runner.go
+++ b/enterprise/server/remote_execution/runner/runner.go
@@ -1017,6 +1017,21 @@ func (p *pool) newContainer(ctx context.Context, props *platform.Properties, tas
 	}
 
 	isolationType := platform.ContainerType(props.WorkloadIsolationType)
+
+	// For now, fall back to podman or docker if the action requests both OCI
+	// isolation and networking, since we don't yet have networking support
+	// for OCI isolation.
+	if isolationType == platform.OCIContainerType && props.DockerNetwork != "off" {
+		ex := platform.GetExecutorProperties()
+		if ex.SupportsIsolation(platform.PodmanContainerType) {
+			isolationType = platform.PodmanContainerType
+		} else if ex.SupportsIsolation(platform.DockerContainerType) {
+			isolationType = platform.DockerContainerType
+		} else {
+			return nil, status.UnimplementedErrorf("networking is not yet supported for %s isolation", isolationType)
+		}
+	}
+
 	containerProvider, ok := p.containerProviders[isolationType]
 	if !ok {
 		return nil, status.UnimplementedErrorf("no container provider registered for %q isolation", isolationType)

--- a/enterprise/server/remote_execution/runner/runner_linux.go
+++ b/enterprise/server/remote_execution/runner/runner_linux.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/container"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/bare"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/docker"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/ociruntime"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/containers/podman"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/platform"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/vfs"
@@ -49,6 +50,14 @@ func (p *pool) registerContainerProviders(providers map[platform.ContainerType]c
 
 	if executor.SupportsIsolation(platform.BareContainerType) {
 		providers[platform.BareContainerType] = &bare.Provider{}
+	}
+
+	if executor.SupportsIsolation(platform.OCIContainerType) {
+		p, err := ociruntime.NewProvider(p.env, p.buildRoot)
+		if err != nil {
+			return status.FailedPreconditionErrorf("Failed to initialize OCI container provider: %s", err)
+		}
+		providers[platform.OCIContainerType] = p
 	}
 
 	return nil


### PR DESCRIPTION
* Support `workload-isolation-type: oci`, behind flag `--executor.oci_enabled`
* For now, fall back to podman or docker if the action requires networking (`dockerNetwork != "off"`), since we don't yet have networking implemented. Once we implement networking, we can remove this fallback
* Was able to build the BB repo (after some small bugfixes, to come in a follow-up PR). It's very fast :fire: 

**Related issues**: N/A
