### PR TITLE
Suppress scrape errors when not running certain scrape targets locally

### DIFF
--- a/tools/metrics/docker-compose.victoria-metrics.yml
+++ b/tools/metrics/docker-compose.victoria-metrics.yml
@@ -6,6 +6,9 @@ services:
       - ${PWD}/victoria-metrics/scrape.yml:/etc/victoria-metrics/scrape.yml
     command:
       - "--promscrape.config=/etc/victoria-metrics/scrape.yml"
+      # Don't log scrape errors as often, since not all the scrape targets are
+      # expected to be running during local development (e.g. executor)
+      - "--promscrape.suppressScrapeErrorsDelay=1m"
     ports:
       - "8428:8428"
     extra_hosts:


### PR DESCRIPTION
Instead of logging an error every time scraping fails, only log once every minute. This way the logs are not as noisy, but we still get feedback as to whether VictoriaMetrics thinks the scrape targets are up or not.

**Related issues**: N/A
