### PR TITLE
[pebble cache] export zombie table count and size to prometheus

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -3112,6 +3112,10 @@ func (p *PebbleCache) updatePebbleMetrics() error {
 	metrics.PebbleCacheWriteStallCount.With(nameLabel).Set(float64(count))
 	metrics.PebbleCacheWriteStallDurationUsec.With(nameLabel).Observe(float64(dur.Microseconds()))
 
+	// Zombie table metrics
+	metrics.PebbleCacheZombieTableCount.With(nameLabel).Set(float64(m.Table.ZombieCount))
+	metrics.PebbleCacheZombieTableSizeBytes.With(nameLabel).Set(float64(m.Table.ZombieSize))
+
 	p.oldMetrics = *m
 
 	return nil

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -2559,6 +2559,24 @@ var (
 		CacheNameLabel,
 	})
 
+	PebbleCacheZombieTableCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "pebble_cache_zombie_table_count",
+		Help:      "The number of zombie tables",
+	}, []string{
+		CacheNameLabel,
+	})
+
+	PebbleCacheZombieTableSizeBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_cache",
+		Name:      "pebble_cache_zombie_table_size_bytes",
+		Help:      "The size of zombie tables in bytes",
+	}, []string{
+		CacheNameLabel,
+	})
+
 	// Temporary metric to verify AC sampling behavior.
 	PebbleCacheGroupIDSampleCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: bbNamespace,


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
We are running into issues where zombie table size gets huge. This can make
monitoring this metric easier.
