### PR TITLE
Dedupe region matches by line number

### DIFF
--- a/codesearch/query/regexp_query.go
+++ b/codesearch/query/regexp_query.go
@@ -128,6 +128,10 @@ func makeLine(line []byte, lineNumber int) string {
 	return fmt.Sprintf("%d: %s\n", lineNumber, line)
 }
 
+func (rm regionMatch) Line() int {
+	return rm.region.lineNumber
+}
+
 func (rm regionMatch) CustomSnippet(linesBefore, linesAfter int) string {
 	lineNumber := rm.region.lineNumber
 	snippetText := ""

--- a/codesearch/types/types.go
+++ b/codesearch/types/types.go
@@ -68,6 +68,7 @@ type Scorer interface {
 type HighlightedRegion interface {
 	FieldName() string
 	String() string
+	Line() int
 	CustomSnippet(linesBefore, linesAfter int) string
 }
 


### PR DESCRIPTION
Prevent displaying the same line twice.