### PR TITLE
look up target objects for tracking by label instead of using parent event

### DIFF
--- a/server/build_event_protocol/target_tracker/BUILD
+++ b/server/build_event_protocol/target_tracker/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//server/util/status",
         "//server/util/timeutil",
         "//server/util/uuid",
-        "@org_golang_google_protobuf//encoding/prototext",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -165,7 +165,7 @@ func (t *TargetTracker) handleEvent(event *build_event_stream.BuildEvent) {
 		return
 	}
 	target, ok := t.targets[label]
-	if (!ok) {
+	if !ok {
 		return
 	}
 	target.updateFromEvent(event)

--- a/server/build_event_protocol/target_tracker/target_tracker.go
+++ b/server/build_event_protocol/target_tracker/target_tracker.go
@@ -23,7 +23,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/timeutil"
 	"github.com/buildbuddy-io/buildbuddy/server/util/uuid"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/protobuf/encoding/prototext"
 
 	cmpb "github.com/buildbuddy-io/buildbuddy/proto/api/v1/common"
 )
@@ -113,9 +112,18 @@ func (t *target) updateFromEvent(event *build_event_stream.BuildEvent) {
 	}
 }
 
-func protoID(beid *build_event_stream.BuildEventId) string {
-	out, _ := (&prototext.MarshalOptions{Multiline: false}).Marshal(beid)
-	return string(out)
+func getLabelFromEventId(beid *build_event_stream.BuildEventId) string {
+	switch beid.Id.(type) {
+	case *build_event_stream.BuildEventId_TargetConfigured:
+		return beid.GetTargetConfigured().GetLabel()
+	case *build_event_stream.BuildEventId_TargetCompleted:
+		return beid.GetTargetCompleted().GetLabel()
+	case *build_event_stream.BuildEventId_TestResult:
+		return beid.GetTestResult().GetLabel()
+	case *build_event_stream.BuildEventId_TestSummary:
+		return beid.GetTestSummary().GetLabel()
+	}
+	return ""
 }
 
 func targetTypeFromRuleType(ruleType string) cmpb.TargetType {
@@ -140,7 +148,6 @@ type TargetTracker struct {
 	env                   environment.Env
 	buildEventAccumulator accumulator.Accumulator
 	targets               map[string]*target
-	openClosures          map[string]targetClosure
 	errGroup              *errgroup.Group
 }
 
@@ -149,21 +156,19 @@ func NewTargetTracker(env environment.Env, buildEventAccumulator accumulator.Acc
 		env:                   env,
 		buildEventAccumulator: buildEventAccumulator,
 		targets:               make(map[string]*target, 0),
-		openClosures:          make(map[string]targetClosure, 0),
 	}
 }
 
 func (t *TargetTracker) handleEvent(event *build_event_stream.BuildEvent) {
-	id := protoID(event.GetId())
-	openClosure, ok := t.openClosures[id]
-	if !ok {
+	label := getLabelFromEventId(event.GetId())
+	if label == "" {
 		return
 	}
-	delete(t.openClosures, id)
-	openClosure(event)
-	for _, child := range event.GetChildren() {
-		t.openClosures[protoID(child)] = openClosure
+	target, ok := t.targets[label]
+	if (!ok) {
+		return
 	}
+	target.updateFromEvent(event)
 }
 
 func isTest(t *target) bool {
@@ -368,7 +373,7 @@ func (t *TargetTracker) TrackTargetsForEvent(ctx context.Context, event *build_e
 	case *build_event_stream.BuildEvent_Configured:
 		t.handleEvent(event)
 	case *build_event_stream.BuildEvent_WorkspaceStatus:
-		t.handleWorkspaceStatusEvent(ctx, event)
+		t.handleWorkspaceStatusEvent(ctx)
 	case *build_event_stream.BuildEvent_Completed:
 		t.handleEvent(event)
 	case *build_event_stream.BuildEvent_TestResult:
@@ -380,8 +385,7 @@ func (t *TargetTracker) TrackTargetsForEvent(ctx context.Context, event *build_e
 	}
 
 	if event.GetLastMessage() {
-		// Handle last message
-		t.handleLastEvent(ctx, event)
+		t.handleLastEvent(ctx)
 	}
 }
 
@@ -393,11 +397,10 @@ func (t *TargetTracker) handleExpandedEvent(event *build_event_stream.BuildEvent
 		label := child.GetTargetConfigured().GetLabel()
 		childTarget := newTarget(label)
 		t.targets[label] = childTarget
-		t.openClosures[protoID(child)] = childTarget.updateFromEvent
 	}
 }
 
-func (t *TargetTracker) handleWorkspaceStatusEvent(ctx context.Context, event *build_event_stream.BuildEvent) {
+func (t *TargetTracker) handleWorkspaceStatusEvent(ctx context.Context) {
 	ctx = log.EnrichContext(ctx, log.InvocationIDKey, t.invocationID())
 	if !t.testTargetsInAtLeastState(targetStateConfigured) {
 		// This should not happen, but it seems it can happen with certain targets.
@@ -428,7 +431,7 @@ func (t *TargetTracker) handleWorkspaceStatusEvent(ctx context.Context, event *b
 	t.errGroup.Go(func() error { return t.writeTestTargets(gctx, permissions) })
 }
 
-func (t *TargetTracker) handleLastEvent(ctx context.Context, event *build_event_stream.BuildEvent) {
+func (t *TargetTracker) handleLastEvent(ctx context.Context) {
 	ctx = log.EnrichContext(ctx, log.InvocationIDKey, t.invocationID())
 	if !isTestCommand(t.buildEventAccumulator.Invocation().GetCommand()) {
 		log.Debugf("Not tracking targets statuses for %q because it's not a test", t.invocationID())

--- a/server/build_event_protocol/target_tracker/target_tracker_test.go
+++ b/server/build_event_protocol/target_tracker/target_tracker_test.go
@@ -314,9 +314,6 @@ func runTrackTargetsForEventsTest(t *testing.T) {
 			Children: []*build_event_stream.BuildEventId{
 				testResultId("//server:bar_test"),
 				testSummaryId("//server:bar_test"),
-				// Having these events as children shouldn't break target tracking.
-				testResultId("//server:baz_test"),
-				testSummaryId("//server:baz_test"),
 			},
 			Payload: &build_event_stream.BuildEvent_Completed{
 				Completed: &build_event_stream.TargetComplete{},

--- a/server/build_event_protocol/target_tracker/target_tracker_test.go
+++ b/server/build_event_protocol/target_tracker/target_tracker_test.go
@@ -314,6 +314,9 @@ func runTrackTargetsForEventsTest(t *testing.T) {
 			Children: []*build_event_stream.BuildEventId{
 				testResultId("//server:bar_test"),
 				testSummaryId("//server:bar_test"),
+				// Having these events as children shouldn't break target tracking.
+				testResultId("//server:baz_test"),
+				testSummaryId("//server:baz_test"),
 			},
 			Payload: &build_event_stream.BuildEvent_Completed{
 				Completed: &build_event_stream.TargetComplete{},

--- a/server/build_event_protocol/target_tracker/target_tracker_test.go
+++ b/server/build_event_protocol/target_tracker/target_tracker_test.go
@@ -473,6 +473,159 @@ func runTrackTargetsForEventsTest(t *testing.T) {
 	}
 }
 
+func TestTargetTracking_BuildGraphIsADag(t *testing.T) {
+	te := testenv.GetTestEnv(t)
+	ta := testauth.NewTestAuthenticator(testauth.TestUsers("USER1", "GROUP1"))
+	te.SetAuthenticator(ta)
+	flags.Set(t, "app.enable_target_tracking", true)
+
+	ctx, err := ta.WithAuthenticatedUser(context.Background(), "USER1")
+	require.NoError(t, err)
+
+	testUUID, err := uuid.NewRandom()
+	require.NoError(t, err)
+
+	accumulator := newFakeAccumulator(t, testUUID.String())
+	tracker := target_tracker.NewTargetTracker(te, accumulator)
+
+	events := []*build_event_stream.BuildEvent{
+		&build_event_stream.BuildEvent{
+			Children: []*build_event_stream.BuildEventId{
+				targetConfiguredId("//server:baz_test"),
+				targetConfiguredId("//server:bar_test"),
+			},
+			Payload: &build_event_stream.BuildEvent_Expanded{},
+		},
+		// Configured Events
+		&build_event_stream.BuildEvent{
+			Id: targetConfiguredId("//server:baz_test"),
+			Children: []*build_event_stream.BuildEventId{
+				targetCompletedId("//server:baz_test"),
+			},
+			Payload: &build_event_stream.BuildEvent_Configured{
+				Configured: &build_event_stream.TargetConfigured{
+					TargetKind: "go_test rule",
+					TestSize:   build_event_stream.TestSize_SMALL,
+				},
+			},
+		},
+		&build_event_stream.BuildEvent{
+			Id: targetConfiguredId("//server:bar_test"),
+			Children: []*build_event_stream.BuildEventId{
+				targetCompletedId("//server:bar_test"),
+			},
+			Payload: &build_event_stream.BuildEvent_Configured{
+				Configured: &build_event_stream.TargetConfigured{
+					TargetKind: "go_test rule",
+					TestSize:   build_event_stream.TestSize_SMALL,
+				},
+			},
+		},
+		// WorkspaceStatus Event
+		&build_event_stream.BuildEvent{
+			Payload: &build_event_stream.BuildEvent_WorkspaceStatus{},
+		},
+		// Completed Events
+		&build_event_stream.BuildEvent{
+			Id: targetCompletedId("//server:baz_test"),
+			Children: []*build_event_stream.BuildEventId{
+				testResultId("//server:baz_test"),
+				testSummaryId("//server:baz_test"),
+			},
+			Payload: &build_event_stream.BuildEvent_Completed{
+				Completed: &build_event_stream.TargetComplete{
+					Success: true,
+				},
+			},
+		},
+		&build_event_stream.BuildEvent{
+			Id: targetCompletedId("//server:bar_test"),
+			Children: []*build_event_stream.BuildEventId{
+				testResultId("//server:bar_test"),
+				testSummaryId("//server:bar_test"),
+				// Having these events as children shouldn't break target tracking.
+				testResultId("//server:baz_test"),
+				testSummaryId("//server:baz_test"),
+			},
+			Payload: &build_event_stream.BuildEvent_Completed{
+				Completed: &build_event_stream.TargetComplete{},
+			},
+		},
+		&build_event_stream.BuildEvent{
+			Id: testResultId("//server:bar_test"),
+			Payload: &build_event_stream.BuildEvent_TestResult{
+				TestResult: &build_event_stream.TestResult{
+					Status: build_event_stream.TestStatus_PASSED,
+				},
+			},
+		},
+		&build_event_stream.BuildEvent{
+			Id: testResultId("//server:baz_test"),
+			Payload: &build_event_stream.BuildEvent_TestResult{
+				TestResult: &build_event_stream.TestResult{
+					Status: build_event_stream.TestStatus_FAILED,
+				},
+			},
+		},
+		&build_event_stream.BuildEvent{
+			Id: testSummaryId("//server:bar_test"),
+			Payload: &build_event_stream.BuildEvent_TestSummary{
+				TestSummary: &build_event_stream.TestSummary{
+					OverallStatus: build_event_stream.TestStatus_PASSED,
+				},
+			},
+		},
+		&build_event_stream.BuildEvent{
+			Id: testSummaryId("//server:baz_test"),
+			Payload: &build_event_stream.BuildEvent_TestSummary{
+				TestSummary: &build_event_stream.TestSummary{
+					OverallStatus: build_event_stream.TestStatus_FAILED,
+				},
+			},
+		},
+		// Last Event
+		&build_event_stream.BuildEvent{
+			LastMessage: true,
+		},
+	}
+
+	for _, e := range events {
+		tracker.TrackTargetsForEvent(ctx, e)
+	}
+
+	expected := []Row{
+		{
+			Role:       "CI",
+			GroupID:    "GROUP1",
+			CommitSHA:  "abcdef",
+			Command:    "test",
+			RuleType:   "go_test rule",
+			Label:      "//server:baz_test",
+			RepoURL:    "bb/foo",
+			TestSize:   int32(cmpb.TestSize_SMALL),
+			Status:     int32(build_event_stream.TestStatus_FAILED),
+			TargetType: int32(cmpb.TargetType_TEST),
+		},
+		{
+			Role:       "CI",
+			GroupID:    "GROUP1",
+			CommitSHA:  "abcdef",
+			Command:    "test",
+			RuleType:   "go_test rule",
+			Label:      "//server:bar_test",
+			RepoURL:    "bb/foo",
+			TestSize:   int32(cmpb.TestSize_SMALL),
+			Status:     int32(build_event_stream.TestStatus_PASSED),
+			TargetType: int32(cmpb.TargetType_TEST),
+		},
+	}
+	if tracker.WriteToOLAPDBEnabled() {
+		assertTestTargetStatusesMatchOLAPDB(t, te, expected)
+	} else {
+		assertTestTargetStatusesMatchPrimaryDB(t, ctx, te, testUUID, expected)
+	}
+}
+
 func TestTrackTargetsForEventsAborted(t *testing.T) {
 	te := testenv.GetTestEnv(t)
 	user := &testauth.TestUser{


### PR DESCRIPTION
this map is getting created no matter what--we can get the target from all the events we care about.

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
