### PR TITLE
Support hedging merged actions

### DIFF
--- a/enterprise/server/remote_execution/action_merger/action_merger.go
+++ b/enterprise/server/remote_execution/action_merger/action_merger.go
@@ -27,6 +27,12 @@ const (
 	// execution count.
 	executionIDKey    = "execution-id"
 	executionCountKey = "execution-count"
+
+	// The redis keys storing action merging data are versioned to support
+	// making backwards-incompatible changes to the storage representation.
+	// Increment this version to cycle to new keys (and discard all old
+	// action-merging data) during the next rollout.
+	keyVersion = 1
 )
 
 var (
@@ -46,11 +52,11 @@ func redisKeyForPendingExecutionID(ctx context.Context, adResource *digest.Resou
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("pendingExecution/%s%s", userPrefix, downloadString), nil
+	return fmt.Sprintf("pendingExecution/%d/%s%s", keyVersion, userPrefix, downloadString), nil
 }
 
 func redisKeyForPendingExecutionDigest(executionID string) string {
-	return fmt.Sprintf("pendingExecutionDigest/%s", executionID)
+	return fmt.Sprintf("pendingExecutionDigest/%d/%s", keyVersion, executionID)
 }
 
 // Action merging is an optimization that detects when an execution is

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -647,13 +647,12 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 	// in the background.
 	if hedge {
 		action_merger.RecordHedgedExecution(ctx, s.rdb, adInstanceDigest)
-		log.CtxInfof(ctx, "Scheduling new hedged execution for %q for invocation %q", downloadString, invocationID)
 		hedgedExecutionID, err := s.Dispatch(ctx, req)
 		if err != nil {
-			log.CtxWarningf(ctx, "Error dispatching execution for %q: %s", downloadString, err)
+			log.CtxWarningf(ctx, "Error dispatching execution for action %q and invocation %q: %s", downloadString, invocationID, err)
 			return err
 		}
-		go s.waitExecution(ctx, &repb.WaitExecutionRequest{Name: hedgedExecutionID}, dummyStream{}, waitOpts{isExecuteRequest: true})
+		log.CtxInfof(ctx, "Dispatched new hedged execution %q for action %q and invocation %q", hedgedExecutionID, downloadString, invocationID)
 	}
 
 	waitReq := repb.WaitExecutionRequest{


### PR DESCRIPTION
This PR adds a flag, `remote_execution.action_merging_hedge_count` that causes the execution server to execute actions additionally in the background when new execution requests are received and merged against pending executions, up to a limited number of total in-fight executions. This is done by tracking the number of in-flight executions per action in Redis alongside the other action-merging data, and making the execution server spawn additional executions in the background when actions are hedge-able. A few notes:
- When hedging is enabled, there will be 1 execution spawned per execution request up to `remote_execution.action_merging_hedge_count+1`.
- When hedge executions are run, the ExecutionServer will still return the merged-against execution ID to the client. If that execution is stuck, subsequent executions will be stuck too. The behavior change is that if the first execution is stuck, but a hedged execution succeeds, executions submitted after that success will be able to use the cached result instead of blocking on the stuck execution.
- The default value of `remote_execution.action_merging_hedge_count` is 0, which is the same, no-hedging behavior as we have today. 

There's also a new test in `remote_execution_test` that demonstrates that if an execution is submitted which blocks for a long time, hedged executions will unblock later executions.

**Related issues**: N/A
