### PR TITLE
Better support for filter-only queries

### DIFF
--- a/codesearch/searcher/searcher.go
+++ b/codesearch/searcher/searcher.go
@@ -59,6 +59,14 @@ func (c *CodeSearcher) scoreDocs(scorer types.Scorer, fieldDocidMatches map[stri
 	numDocs := len(allDocIDs)
 	docIDs := slices.Compact(allDocIDs)
 
+	defer func() {
+		c.log.Infof("Scoring %d docs took %s", numDocs, time.Since(start))
+	}()
+
+	if scorer.Skip() {
+		return docIDs, nil
+	}
+
 	scoreMap := make(map[uint64]float64, numDocs)
 	var mu sync.Mutex
 
@@ -102,7 +110,6 @@ func (c *CodeSearcher) scoreDocs(scorer types.Scorer, fieldDocidMatches map[stri
 		docIDs = docIDs[:numResults]
 	}
 
-	c.log.Infof("Scoring %d docs took %s", numDocs, time.Since(start))
 	return docIDs, nil
 }
 

--- a/codesearch/types/types.go
+++ b/codesearch/types/types.go
@@ -62,6 +62,7 @@ type IndexReader interface {
 }
 
 type Scorer interface {
+	Skip() bool
 	Score(doc Document) float64
 }
 


### PR DESCRIPTION
Ensure that there are snippets present, even for filter-only queries like `[lang:go]`. Also, make scoring of these queries faster by not doing wasted work.

