### PR TITLE
Implement workspace service backend

### DIFF
--- a/enterprise/server/workspace/BUILD
+++ b/enterprise/server/workspace/BUILD
@@ -7,9 +7,17 @@ go_library(
     srcs = ["workspace_service.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/workspace",
     deps = [
+        "//proto:github_go_proto",
+        "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
         "//proto:workspace_go_proto",
         "//server/environment",
         "//server/real_environment",
+        "//server/remote_cache/digest",
+        "//server/util/git",
+        "//server/util/hash",
+        "//server/util/prefix",
+        "//server/util/proto",
         "//server/util/status",
     ],
 )

--- a/enterprise/server/workspace/workspace_service.go
+++ b/enterprise/server/workspace/workspace_service.go
@@ -2,17 +2,30 @@ package workspace
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"flag"
+	"path/filepath"
+	"strings"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/util/git"
+	"github.com/buildbuddy-io/buildbuddy/server/util/hash"
+	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
+	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
+	ghpb "github.com/buildbuddy-io/buildbuddy/proto/github"
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
 	wspb "github.com/buildbuddy-io/buildbuddy/proto/workspace"
 )
 
 var (
 	enabled = flag.Bool("workspace.enabled", false, "If true, enable workspaces.")
+	useBlobstore = flag.Bool("workspace.use_blobstore", true, "If true, use blobstore to store workspaces. Otherwise the cache will be used")
 )
 
 type workspaceService struct {
@@ -33,17 +46,375 @@ func New(env environment.Env) *workspaceService {
 }
 
 func (s *workspaceService) GetWorkspace(ctx context.Context, req *wspb.GetWorkspaceRequest) (*wspb.GetWorkspaceResponse, error) {
-	return nil, status.UnimplementedError("Not implemented")
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, s.env)
+	if err != nil {
+		return nil, err
+	}
+	
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if u.GetGroupID() == "" {
+		return nil, status.InternalErrorf("authenticated user's group ID is empty")
+	}
+	ws, err := s.getWorkspace(ctx, u.GetGroupID(), req.GetName())
+	if err != nil {
+		return nil, err
+	}
+	return &wspb.GetWorkspaceResponse{
+		Workspace: ws,
+	}, nil
+}
+
+func (s *workspaceService) getWorkspace(ctx context.Context, groupID, name string) (*wspb.Workspace, error) {
+	var workspaceBytes []byte
+	if *useBlobstore {
+		b, err := s.env.GetBlobstore().ReadBlob(ctx, workspaceMetadataPath(groupID, name))
+		if err != nil {
+			return nil, err
+		}
+		workspaceBytes = b
+	} else {
+		b, err := s.env.GetCache().Get(ctx, resourceNameForWorkspace(name))
+		if err != nil {
+			return nil, err
+		}
+		workspaceBytes = b
+	}
+	var ws wspb.Workspace
+	err := proto.Unmarshal(workspaceBytes, &ws)
+	if err != nil {
+		return nil, err
+	}
+	return &ws, nil
 }
 
 func (s *workspaceService) SaveWorkspace(ctx context.Context, req *wspb.SaveWorkspaceRequest) (*wspb.SaveWorkspaceResponse, error) {
-	return nil, status.UnimplementedError("Not implemented")
-}
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, s.env)
+	if err != nil {
+		return nil, err
+	}
+	
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if u.GetGroupID() == "" {
+		return nil, status.InternalErrorf("authenticated user's group ID is empty")
+	}
 
-func (s *workspaceService) GetWorkspaceDirectory(ctx context.Context, req *wspb.GetWorkspaceDirectoryRequest) (*wspb.GetWorkspaceDirectoryResponse, error) {
-	return nil, status.UnimplementedError("Not implemented")
+	ws := req.GetWorkspace()
+
+	for _, change := range ws.GetChanges() {
+		if change.Content != nil {
+			blobPath := workspaceFilePath(u.GetGroupID(), req.GetWorkspace(), change.GetPath())
+			
+			h := sha1.New()
+			h.Write(change.Content)	
+			change.Sha = hex.EncodeToString(h.Sum(nil))
+
+			if *useBlobstore {
+				// TODO(siggisim): Consider putting a TTL on these (though the volume should be pretty low). Would need
+				// to add support for TTLs to the blobstore API.
+				_, err = s.env.GetBlobstore().WriteBlob(ctx, blobPath, change.Content)
+				if err != nil {
+					return nil, err
+				}						
+			} else {
+				if err := s.env.GetCache().Set(ctx, resourceNameForNode(req.GetWorkspace().GetName(), change), change.Content); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		change.Content = nil // Clear out file content since we wrote it in a separate blob
+	}
+
+	protoBytes, err := proto.Marshal(ws)
+	if err != nil {
+		return nil, err
+	}
+
+	if *useBlobstore {
+		if _, err := s.env.GetBlobstore().WriteBlob(ctx, workspaceMetadataPath(u.GetGroupID(), ws.GetName()), protoBytes); err != nil {
+			return nil, err
+		}	
+	} else {
+		if s.env.GetCache().Set(ctx, resourceNameForWorkspace(ws.GetName()), protoBytes) != nil {
+			return nil, err
+		}	
+	}
+	return &wspb.SaveWorkspaceResponse{ Workspace: req.GetWorkspace().GetName() }, nil
 }
 
 func (s *workspaceService) GetWorkspaceFile(ctx context.Context, req *wspb.GetWorkspaceFileRequest) (*wspb.GetWorkspaceFileResponse, error) {
-	return nil, status.UnimplementedError("Not implemented")
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, s.env)
+	if err != nil {
+		return nil, err
+	}
+	
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if u.GetGroupID() == "" {
+		return nil, status.InternalErrorf("authenticated user's group ID is empty")
+	}
+
+	ws, err := s.getWorkspace(ctx, u.GetGroupID(), req.GetWorkspace())
+	if err == nil {
+		for _, change := range ws.GetChanges() {
+			if req.GetFile().GetPath() != change.GetPath() {
+				continue
+			}
+			return s.getFile(ctx, u.GetGroupID(), ws, change)
+		}
+	}
+
+	// TODO(siggisim): Fire off background request to upload github repo to cache (under SHA1) on page load, and check 
+	// there first for faster performance.
+
+	if req.GetFile().GetSha() != "" {
+		return s.getGithubFileFromSha(ctx, req.GetRepo().GetRepoUrl(), req.GetFile().GetSha())
+	}
+
+	return s.getGithubFileFromPath(ctx, req.GetRepo().GetRepoUrl(), req.GetRepo().GetCommitSha(), req.GetFile().GetPath())
+}
+
+func (s *workspaceService) getFile(ctx context.Context, groupID string, workspace *wspb.Workspace, file *wspb.Node) (*wspb.GetWorkspaceFileResponse, error) {
+	if *useBlobstore {
+		blobPath := workspaceFilePath(groupID, workspace, file.GetPath())
+		content, err := s.env.GetBlobstore().ReadBlob(ctx, blobPath)
+		if err != nil {
+			return nil, err
+		}
+		return &wspb.GetWorkspaceFileResponse{
+			Content: content,
+		}, nil
+	}
+	
+	content, err := s.env.GetCache().Get(ctx, resourceNameForNode(workspace.GetName(), file))
+	if err != nil {
+		return nil, err
+	}
+	return &wspb.GetWorkspaceFileResponse{
+		Content: content,
+	}, nil
+}
+
+func (s *workspaceService) GetWorkspaceDirectory(ctx context.Context, req *wspb.GetWorkspaceDirectoryRequest) (*wspb.GetWorkspaceDirectoryResponse, error) {
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, s.env)
+	if err != nil {
+		return nil, err
+	}
+	
+	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if u.GetGroupID() == "" {
+		return nil, status.InternalErrorf("authenticated user's group ID is empty")
+	}
+
+	directory := req.GetDirectory()
+
+	ref := directory.GetSha()
+	if directory.GetPath() == "" && ref == "" {
+		ref = req.GetRepo().GetCommitSha()
+		if ref == "" {
+			ref = req.GetRepo().GetBranch()
+		}
+	}
+
+	nodes := []*wspb.Node{}
+	sha := directory.GetSha()
+	if ref != "" {
+		nodes, sha, err = s.nodesFromGitHub(ctx, req.GetRepo().GetRepoUrl(), ref)
+		if err != nil {
+			return nil, err
+		}
+	}
+	directory.Sha = sha
+
+	res := &wspb.GetWorkspaceDirectoryResponse{
+		Directory: directory,
+		ChildNodes:    nodes,
+	}
+
+	ws, err := s.getWorkspace(ctx, u.GetGroupID(), req.GetWorkspace())
+	if err != nil {
+		return res, nil
+	}
+
+	res.ChildNodes = s.addNodesFromWorkspace(res.ChildNodes, ws, directory.GetPath())
+
+	return res, nil
+}
+
+func (s *workspaceService) addNodesFromWorkspace(nodes []*wspb.Node, ws *wspb.Workspace, requestedPath string) []*wspb.Node {
+	for _, change := range ws.GetChanges() {
+		requestedPathParts := strings.Split(requestedPath, "/")
+		if requestedPath == "" {
+			requestedPathParts = []string{}
+		}
+		pathParts := strings.Split(change.GetPath(), "/")
+		if len(requestedPathParts) > len(pathParts) {
+			continue
+		}
+		match := true
+		for i := range requestedPathParts {
+			if requestedPathParts[i] != pathParts[i] {
+				match = false
+			}
+		}
+		if !match {
+			continue
+		}
+
+		if len(requestedPathParts) != len(pathParts)-1 {
+			nodes = append(nodes, &wspb.Node{
+				Path: pathParts[len(requestedPathParts)],
+				NodeType: wspb.NodeType_DIRECTORY,
+			})
+			continue
+		}
+
+		change.NodeType = wspb.NodeType_FILE
+
+		if change.ChangeType == wspb.ChangeType_ADDED {
+			nodes = append(nodes, change)
+		}
+
+		if change.ChangeType == wspb.ChangeType_DELETED {
+			for i, node := range nodes {
+				if node.Path != pathParts[len(requestedPathParts)] {
+					continue
+				}
+				nodes = append(nodes[:i], nodes[i+1:]...)
+			}
+		}
+	}
+	return nodes
+}
+
+func (s *workspaceService) nodesFromGitHub(ctx context.Context, githubRepo, ref string) ([]*wspb.Node, string, error) {
+	a := s.env.GetGitHubApp()
+	if a == nil {
+		return nil, "", status.UnimplementedError("No GitHub app configured")
+	}
+
+	repo, err := git.ParseGitHubRepoURL(githubRepo)
+	if err != nil {
+		return nil, "", err
+	}
+
+	ghReq := &ghpb.GetGithubTreeRequest{
+		Owner: repo.Owner,
+		Repo:  repo.Repo,
+		Ref:   ref,
+	}
+
+	ghRes, err := a.GetGithubTree(ctx, ghReq)
+	if err != nil {
+		return nil, "", err
+	}
+
+	nodes := []*wspb.Node{}
+	for _, node := range ghRes.GetNodes() {
+		nodeType := wspb.NodeType_FILE
+		if node.Type == "tree" {
+			nodeType = wspb.NodeType_DIRECTORY
+		}
+		nodes = append(nodes, &wspb.Node{
+			Path: node.Path,
+			Sha:  node.Sha,
+			NodeType: nodeType,
+		})
+	}
+
+	return nodes, ghRes.Sha, nil
+}
+
+// Blobstore
+
+func workspaceMetadataPath(groupID, name string) string {
+	return filepath.Join("workspace", groupID, filepath.Clean("/"+name), "metadata")
+}
+
+func workspaceFilePath(groupID string, workspace *wspb.Workspace, path string) string {
+	return filepath.Join("workspace", groupID, filepath.Clean("/"+workspace.GetName()), "file", filepath.Clean("/"+path))
+}
+
+// Cache
+
+func resourceNameForWorkspace(workspaceName string) *rspb.ResourceName {
+	d := &repb.Digest{
+		Hash:      hash.String("workspace"),
+		SizeBytes: 1,
+	}
+	return digest.NewResourceName(d, workspaceName, rspb.CacheType_AC, repb.DigestFunction_SHA1).ToProto()
+}
+
+func resourceNameForNode(workspaceName string, node *wspb.Node) *rspb.ResourceName {
+	d := &repb.Digest{
+		Hash:      node.Sha,
+		SizeBytes: 1,
+	}
+	return digest.NewResourceName(d, workspaceName, rspb.CacheType_CAS, repb.DigestFunction_SHA1).ToProto()
+}
+
+// Github
+
+func (s *workspaceService) getGithubFileFromSha(ctx context.Context, githubRepo, sha string) (*wspb.GetWorkspaceFileResponse, error) {
+	a := s.env.GetGitHubApp()
+	if a == nil {
+		return nil, status.UnimplementedError("No GitHub app configured")
+	}
+
+	repo, err := git.ParseGitHubRepoURL(githubRepo)
+	if err != nil {
+		return nil, err
+	}
+
+	ghReq := &ghpb.GetGithubBlobRequest{
+		Owner: repo.Owner,
+		Repo:  repo.Repo,
+		Sha:   sha,
+	}
+
+	ghRes, err := a.GetGithubBlob(ctx, ghReq)
+	if err != nil {
+		return nil, err
+	}
+	return &wspb.GetWorkspaceFileResponse{
+		Content: ghRes.Content,
+	}, nil
+}
+
+func (s *workspaceService) getGithubFileFromPath(ctx context.Context, githubRepo, ref, path string) (*wspb.GetWorkspaceFileResponse, error) {
+	a := s.env.GetGitHubApp()
+	if a == nil {
+		return nil, status.UnimplementedError("No GitHub app configured")
+	}
+
+	repo, err := git.ParseGitHubRepoURL(githubRepo)
+	if err != nil {
+		return nil, err
+	}
+
+	ghReq := &ghpb.GetGithubContentRequest{
+		Owner: repo.Owner,
+		Repo:  repo.Repo,
+		Path:  path,
+		Ref:   ref,
+	}
+
+	ghRes, err := a.GetGithubContent(ctx, ghReq)
+	if err != nil {
+		return nil, err
+	}
+	return &wspb.GetWorkspaceFileResponse{
+		Content: ghRes.Content,
+	}, nil
 }

--- a/enterprise/server/workspace/workspace_service.go
+++ b/enterprise/server/workspace/workspace_service.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	enabled = flag.Bool("workspace.enabled", false, "If true, enable workspaces.")
+	enabled      = flag.Bool("workspace.enabled", false, "If true, enable workspaces.")
 	useBlobstore = flag.Bool("workspace.use_blobstore", true, "If true, use blobstore to store workspaces. Otherwise the cache will be used")
 )
 
@@ -50,7 +50,7 @@ func (s *workspaceService) GetWorkspace(ctx context.Context, req *wspb.GetWorksp
 	if err != nil {
 		return nil, err
 	}
-	
+
 	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func (s *workspaceService) SaveWorkspace(ctx context.Context, req *wspb.SaveWork
 	if err != nil {
 		return nil, err
 	}
-	
+
 	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
@@ -109,9 +109,9 @@ func (s *workspaceService) SaveWorkspace(ctx context.Context, req *wspb.SaveWork
 	for _, change := range ws.GetChanges() {
 		if change.Content != nil {
 			blobPath := workspaceFilePath(u.GetGroupID(), req.GetWorkspace(), change.GetPath())
-			
+
 			h := sha1.New()
-			h.Write(change.Content)	
+			h.Write(change.Content)
 			change.Sha = hex.EncodeToString(h.Sum(nil))
 
 			if *useBlobstore {
@@ -120,7 +120,7 @@ func (s *workspaceService) SaveWorkspace(ctx context.Context, req *wspb.SaveWork
 				_, err = s.env.GetBlobstore().WriteBlob(ctx, blobPath, change.Content)
 				if err != nil {
 					return nil, err
-				}						
+				}
 			} else {
 				if err := s.env.GetCache().Set(ctx, resourceNameForNode(req.GetWorkspace().GetName(), change), change.Content); err != nil {
 					return nil, err
@@ -139,13 +139,13 @@ func (s *workspaceService) SaveWorkspace(ctx context.Context, req *wspb.SaveWork
 	if *useBlobstore {
 		if _, err := s.env.GetBlobstore().WriteBlob(ctx, workspaceMetadataPath(u.GetGroupID(), ws.GetName()), protoBytes); err != nil {
 			return nil, err
-		}	
+		}
 	} else {
 		if s.env.GetCache().Set(ctx, resourceNameForWorkspace(ws.GetName()), protoBytes) != nil {
 			return nil, err
-		}	
+		}
 	}
-	return &wspb.SaveWorkspaceResponse{ Workspace: req.GetWorkspace().GetName() }, nil
+	return &wspb.SaveWorkspaceResponse{Workspace: req.GetWorkspace().GetName()}, nil
 }
 
 func (s *workspaceService) GetWorkspaceFile(ctx context.Context, req *wspb.GetWorkspaceFileRequest) (*wspb.GetWorkspaceFileResponse, error) {
@@ -153,7 +153,7 @@ func (s *workspaceService) GetWorkspaceFile(ctx context.Context, req *wspb.GetWo
 	if err != nil {
 		return nil, err
 	}
-	
+
 	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
@@ -172,7 +172,7 @@ func (s *workspaceService) GetWorkspaceFile(ctx context.Context, req *wspb.GetWo
 		}
 	}
 
-	// TODO(siggisim): Fire off background request to upload github repo to cache (under SHA1) on page load, and check 
+	// TODO(siggisim): Fire off background request to upload github repo to cache (under SHA1) on page load, and check
 	// there first for faster performance.
 
 	if req.GetFile().GetSha() != "" {
@@ -193,7 +193,7 @@ func (s *workspaceService) getFile(ctx context.Context, groupID string, workspac
 			Content: content,
 		}, nil
 	}
-	
+
 	content, err := s.env.GetCache().Get(ctx, resourceNameForNode(workspace.GetName(), file))
 	if err != nil {
 		return nil, err
@@ -208,7 +208,7 @@ func (s *workspaceService) GetWorkspaceDirectory(ctx context.Context, req *wspb.
 	if err != nil {
 		return nil, err
 	}
-	
+
 	u, err := s.env.GetAuthenticator().AuthenticatedUser(ctx)
 	if err != nil {
 		return nil, err
@@ -238,8 +238,8 @@ func (s *workspaceService) GetWorkspaceDirectory(ctx context.Context, req *wspb.
 	directory.Sha = sha
 
 	res := &wspb.GetWorkspaceDirectoryResponse{
-		Directory: directory,
-		ChildNodes:    nodes,
+		Directory:  directory,
+		ChildNodes: nodes,
 	}
 
 	ws, err := s.getWorkspace(ctx, u.GetGroupID(), req.GetWorkspace())
@@ -274,7 +274,7 @@ func (s *workspaceService) addNodesFromWorkspace(nodes []*wspb.Node, ws *wspb.Wo
 
 		if len(requestedPathParts) != len(pathParts)-1 {
 			nodes = append(nodes, &wspb.Node{
-				Path: pathParts[len(requestedPathParts)],
+				Path:     pathParts[len(requestedPathParts)],
 				NodeType: wspb.NodeType_DIRECTORY,
 			})
 			continue
@@ -327,8 +327,8 @@ func (s *workspaceService) nodesFromGitHub(ctx context.Context, githubRepo, ref 
 			nodeType = wspb.NodeType_DIRECTORY
 		}
 		nodes = append(nodes, &wspb.Node{
-			Path: node.Path,
-			Sha:  node.Sha,
+			Path:     node.Path,
+			Sha:      node.Sha,
 			NodeType: nodeType,
 		})
 	}


### PR DESCRIPTION
Implemented it with a `workspace.use_blobstore` flag that allows you to chose if you want to use blobstore or the cache as a backend to prove (to both you and myself) that the API works with either backend.

My ideal longer term set up is:
- Workspace proto and current set of just workspace changes in blobstore
- Unchanged files from cache (with fallback to GitHub if not present in cache)

I looked into adding support for a TTL for the blobstore backend, but would need to make some blobstore API changes there - so added it as a TODO.