### PR TITLE
Filter q and non-q results correctly

### DIFF
--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -242,6 +242,9 @@ func handleSearch(args []string) {
 			if region.Line() == lastLine && region.FieldName() == lastField {
 				continue
 			}
+			if region.FieldName() != "content" {
+				continue
+			}
 			dedupedRegions = append(dedupedRegions, region)
 			lastLine = region.Line()
 			lastField = region.FieldName()

--- a/codesearch/query/regexp_query.go
+++ b/codesearch/query/regexp_query.go
@@ -178,7 +178,7 @@ func (h *reHighlighter) Highlight(doc types.Document) []types.HighlightedRegion 
 	// HACK: if there are no matching regions, add a fake one that matches
 	// the first line of the file. This way filter-only queries will be able
 	// to display a highlighted region.
-	if len(results) == 0 {
+	if len(results) == 0 && h.fieldMatchers[contentField] == nil {
 		field := doc.Field(contentField)
 		results = append(results, types.HighlightedRegion(regionMatch{
 			field: field,

--- a/codesearch/searcher/searcher.go
+++ b/codesearch/searcher/searcher.go
@@ -55,15 +55,17 @@ func (c *CodeSearcher) scoreDocs(scorer types.Scorer, fieldDocidMatches map[stri
 		allDocIDs = append(allDocIDs, docIDs...)
 	}
 	slices.Sort(allDocIDs)
-
-	numDocs := len(allDocIDs)
 	docIDs := slices.Compact(allDocIDs)
+	numDocs := len(docIDs)
 
 	defer func() {
 		c.log.Infof("Scoring %d docs took %s", numDocs, time.Since(start))
 	}()
 
 	if scorer.Skip() {
+		if len(docIDs) > numResults {
+			docIDs = docIDs[:numResults]
+		}
 		return docIDs, nil
 	}
 


### PR DESCRIPTION
- don't display filename field matches in the CLI, it shows lots of duplicates
- don't insert a fake region match unless the content part of the query was empty
- limit results correctly even if scoring is a no-op