### PR TITLE
Install API-Key propagating interceptor prior to auth interceptor

### DIFF
--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -129,11 +129,16 @@ func main() {
 }
 
 func startGRPCServers(env *real_environment.RealEnv) error {
-	// Add the API-Key propagating interceptors.
-	// TODO(iain): improve auth story so we can run beyond dev.
+	// Add the API-Key and JWT propagating interceptors.
 	grpcServerConfig := grpc_server.GRPCServerConfig{
-		ExtraChainedUnaryInterceptors:  []grpc.UnaryServerInterceptor{interceptors.PropagateAPIKeyUnaryInterceptor()},
-		ExtraChainedStreamInterceptors: []grpc.StreamServerInterceptor{interceptors.PropagateAPIKeyStreamInterceptor()},
+		ExtraChainedUnaryInterceptors: []grpc.UnaryServerInterceptor{
+			interceptors.PropagateAPIKeyUnaryInterceptor(),
+			interceptors.PropagateJWTUnaryInterceptor(),
+		},
+		ExtraChainedStreamInterceptors: []grpc.StreamServerInterceptor{
+			interceptors.PropagateAPIKeyStreamInterceptor(),
+			interceptors.PropagateJWTStreamInterceptor(),
+		},
 	}
 
 	s, err := grpc_server.New(env, grpc_server.GRPCPort(), false, grpcServerConfig)

--- a/server/rpc/interceptors/BUILD
+++ b/server/rpc/interceptors/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//server/environment",
         "//server/metrics",
         "//server/util/alert",
+        "//server/util/authutil",
         "//server/util/bazel_request",
         "//server/util/claims",
         "//server/util/clientip",


### PR DESCRIPTION
https://github.com/buildbuddy-io/buildbuddy/pull/6788 adds a new authenticator that remotely authenticates gRPC requests. But that relies on the auth headers being present in the outgoing RPC context at the time that the authenticator is invoked, which is not the case with the way this code is currently written. This PR re-shuffles the extra-interceptors installation so that these interceptors are run before the auth interceptor. It also adds a JWT-propagating interceptor so that executors can remotely authenticate using the remote authenticator.

Ultimately, we should probably switch this to something fancier like a builder, but for now this should suffice.

**Related issues**: N/A
