### PR TITLE
Handle case:n and fix case expansion

### DIFF
--- a/codesearch/query/regexp.go
+++ b/codesearch/query/regexp.go
@@ -6,7 +6,6 @@ package query
 
 import (
 	"fmt"
-	"log"
 	"regexp/syntax"
 	"sort"
 	"strconv"
@@ -299,7 +298,6 @@ func (q *Query) andTrigrams(t stringSet) *Query {
 }
 
 func (q *Query) String() string {
-	log.Printf("q: %#v", q)
 	if q == nil {
 		return "?"
 	}
@@ -335,12 +333,7 @@ func (q *Query) String() string {
 		}
 		s += strconv.Quote(t)
 	}
-	for _, sq := range q.Sub {
-		log.Printf("subQ: %#v", sq)
-	}
-
 	if len(q.Sub) > 0 {
-
 		if len(q.Trigram) > 0 {
 			s += sjoin
 		}

--- a/codesearch/query/regexp_query_test.go
+++ b/codesearch/query/regexp_query_test.go
@@ -24,12 +24,12 @@ func TestCaseInsensitive(t *testing.T) {
 	require.NoError(t, err)
 
 	squery := string(q.SQuery())
-	assert.Contains(t, squery, "(:eq * foo)")
+	assert.Contains(t, squery, `(:eq * "foo")`)
 
 	fieldMatchers := q.TestOnlyFieldMatchers()
 	require.Contains(t, fieldMatchers, "content")
 	assert.Contains(t, fieldMatchers["content"].String(), "foo")
-	assert.Contains(t, fieldMatchers["content"].String(), "(?i)")
+	assert.Contains(t, fieldMatchers["content"].String(), "(?mi)")
 }
 
 func TestLangAtom(t *testing.T) {

--- a/codesearch/query/regexp_query_test.go
+++ b/codesearch/query/regexp_query_test.go
@@ -25,6 +25,8 @@ func TestCaseInsensitive(t *testing.T) {
 
 	squery := string(q.SQuery())
 	assert.Contains(t, squery, `(:eq * "foo")`)
+	assert.Contains(t, squery, `(:eq * "FOO")`)
+	assert.Contains(t, squery, `(:eq * "fOo")`)
 
 	fieldMatchers := q.TestOnlyFieldMatchers()
 	require.Contains(t, fieldMatchers, "content")

--- a/codesearch/query/regexp_query_test.go
+++ b/codesearch/query/regexp_query_test.go
@@ -34,6 +34,21 @@ func TestCaseInsensitive(t *testing.T) {
 	assert.Contains(t, fieldMatchers["content"].String(), "(?mi)")
 }
 
+func TestCaseNo(t *testing.T) {
+	q, err := NewReQuery("foo case:no", 1)
+	require.NoError(t, err)
+
+	squery := string(q.SQuery())
+	assert.Contains(t, squery, `(:eq * "foo")`)
+	assert.Contains(t, squery, `(:eq * "FOO")`)
+	assert.Contains(t, squery, `(:eq * "fOo")`)
+
+	fieldMatchers := q.TestOnlyFieldMatchers()
+	require.Contains(t, fieldMatchers, "content")
+	assert.Contains(t, fieldMatchers["content"].String(), "foo")
+	assert.Contains(t, fieldMatchers["content"].String(), "(?mi)")
+}
+
 func TestLangAtom(t *testing.T) {
 	q, err := NewReQuery("lang:java foo", 1)
 	require.NoError(t, err)


### PR DESCRIPTION
Previously we were not expanding case (I broke this in a refactor). Fix this, and ensure it's tested.

Also, it was confusing that only "case:y" was a supported query atom but not "case:n" (the default). So if "case:(n|no)" is passed, handle that correctly, and add a test for this.

Also, remove some old debug logs.