### PR TITLE
remove regex flags

### DIFF
--- a/enterprise/app/codesearch/codesearch.tsx
+++ b/enterprise/app/codesearch/codesearch.tsx
@@ -98,8 +98,8 @@ export default class CodeSearchComponent extends React.Component<Props, State> {
       );
     }
 
-    const parsedQuery = this.state.response.parsedQuery?.parsedQuery ?? "";
-    const highlight = new RegExp(parsedQuery, "igmd");
+    let parsedQuery = this.state.response.parsedQuery?.parsedQuery ?? "";
+    const highlight = new RegExp(parsedQuery.replace(/\(\?[a-z]+\)/g, ""), "igmd");
     return (
       <div>
         {this.state.response.results.map((result) => (

--- a/enterprise/app/codesearch/codesearch.tsx
+++ b/enterprise/app/codesearch/codesearch.tsx
@@ -99,7 +99,7 @@ export default class CodeSearchComponent extends React.Component<Props, State> {
     }
 
     let parsedQuery = this.state.response.parsedQuery?.parsedQuery ?? "";
-    const highlight = new RegExp(parsedQuery.replace(/\(\?[a-z]+\)/g, ""), "igmd");
+    const highlight = new RegExp(parsedQuery.replace(/\(\?[imsU]+\)/g, ""), "igmd");
     return (
       <div>
         {this.state.response.results.map((result) => (


### PR DESCRIPTION
The parsedQuery field returned from the server contains the flags set on the regex. Because the regex formats are different between go and js, remove the go flags (since we set the js ones manually).