### PR TITLE
cli/printlog: provide a --raw flag to print compact exec log

### DIFF
--- a/cli/printlog/compact/BUILD
+++ b/cli/printlog/compact/BUILD
@@ -10,6 +10,7 @@ go_library(
     deps = [
         "//cli/log",
         "//proto:spawn_go_proto",
+        "//server/util/proto",
         "@com_github_klauspost_compress//zstd",
         "@org_golang_google_protobuf//encoding/protodelim",
         "@org_golang_google_protobuf//encoding/protojson",

--- a/cli/printlog/printlog.go
+++ b/cli/printlog/printlog.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	usage = `
-usage: bb print [--grpc_log=PATH] [--compact_execution_log=PATH] [--sort=true]
+usage: bb print [--grpc_log=PATH] [--compact_execution_log=PATH] [--sort=false] [--raw=false]
 
 Prints a human-readable representation of log files output by Bazel.
 
@@ -27,6 +27,7 @@ Currently supported log types:
   --grpc_log: Path to a file saved with --experimental_remote_grpc_log.
   --compact_execution_log: Path to a file saved with --experimental_execution_log_compact_file.
   --sort: Apply sorting to log output, only applicable with --compact_execution_log.
+  --raw: Don't convert the log entries to Bazel's Spawn, only applicable with --compact_execution_log.
 `
 )
 
@@ -35,6 +36,7 @@ var (
 	grpcLog        = flags.String("grpc_log", "", "gRPC log path.")
 	compactExecLog = flags.String("compact_execution_log", "", "compact execution log path.")
 	sort           = flags.Bool("sort", false, "apply sorting to log output, only applicable with --compact_execution_log")
+	raw            = flags.Bool("raw", false, "don't convert the log entries to Bazel's Spawn, only applicable with --compact_execution_log")
 )
 
 func HandlePrint(args []string) (int, error) {
@@ -52,7 +54,7 @@ func HandlePrint(args []string) (int, error) {
 		return 0, nil
 	}
 	if *compactExecLog != "" {
-		if err := compact.PrintCompactExecLog(*compactExecLog, *sort); err != nil {
+		if err := compact.PrintCompactExecLog(*compactExecLog, *raw, *sort); err != nil {
 			return -1, err
 		}
 		return 0, nil


### PR DESCRIPTION
Bazel team has commented that the compact log file format could be
unoptimized for `bazel test //...` where test targets could introduce a
lot of files which cannot be deduplicated.

Provide a flag to inspect the raw content of the compact exec log
to help aid development of this log format.
