### PR TITLE
.bazelrc: write exec log on Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -256,8 +256,7 @@ common --experimental_profile_include_primary_output
 common --noslim_profile
 # Include compact execution log
 # TODO(sluongng): make Bazel writes this to output_base automatically
-common:linux --experimental_execution_log_compact_file=bazel_compact_exec_log.binpb.zstd
-common:macos --experimental_execution_log_compact_file=bazel_compact_exec_log.binpb.zstd
+common --experimental_execution_log_compact_file=bazel_compact_exec_log.binpb.zst
 
 # Try importing a user specific .bazelrc
 # You can create your own by copying and editing the template-user.bazelrc template:


### PR DESCRIPTION
This was previously disabled on Windows because we were writing it to
`/tmp` and on Windows, there is not a fixed tmp path.

We have since switched the log path to our workspace and thus,
compatible with Windows.

Also changed the log to use the correct ZSTD extension, which is `.zst`.
