### PR TITLE
Enable local caching in byte_stream_server_proxy

### DIFF
--- a/enterprise/server/byte_stream_server_proxy/BUILD
+++ b/enterprise/server/byte_stream_server_proxy/BUILD
@@ -34,7 +34,7 @@ go_test(
         "//server/util/prefix",
         "//server/util/status",
         "//server/util/testing/flags",
-        "@com_github_google_uuid//:uuid",
+        "//server/util/uuid",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",

--- a/enterprise/server/byte_stream_server_proxy/BUILD
+++ b/enterprise/server/byte_stream_server_proxy/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 package(default_visibility = ["//enterprise:__subpackages__"])
 
@@ -9,9 +9,35 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//server/environment",
-        "//server/interfaces",
         "//server/real_environment",
+        "//server/util/log",
         "//server/util/status",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+    ],
+)
+
+go_test(
+    name = "byte_stream_server_proxy_test",
+    size = "small",
+    srcs = ["byte_stream_server_proxy_test.go"],
+    embed = [":byte_stream_server_proxy"],
+    deps = [
+        "//proto:remote_execution_go_proto",
+        "//proto:resource_go_proto",
+        "//server/remote_cache/byte_stream_server",
+        "//server/remote_cache/digest",
+        "//server/testutil/byte_stream",
+        "//server/testutil/testcompression",
+        "//server/testutil/testdigest",
+        "//server/testutil/testenv",
+        "//server/util/compression",
+        "//server/util/prefix",
+        "//server/util/status",
+        "//server/util/testing/flags",
+        "@com_github_google_uuid//:uuid",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//status",
     ],
 )

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy.go
@@ -6,56 +6,139 @@ import (
 	"io"
 
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
-	"github.com/buildbuddy-io/buildbuddy/server/interfaces"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 )
 
 type ByteStreamServerProxy struct {
-	env         environment.Env
-	localCache  interfaces.Cache
-	remoteCache bspb.ByteStreamClient
+	env    environment.Env
+	local  bspb.ByteStreamClient
+	remote bspb.ByteStreamClient
 }
 
 func Register(env *real_environment.RealEnv) error {
-	byteStreamServer, err := NewByteStreamServerProxy(env)
+	proxy, err := New(env)
 	if err != nil {
 		return status.InternalErrorf("Error initializing ByteStreamServerProxy: %s", err)
 	}
-	env.SetByteStreamServer(byteStreamServer)
+	env.SetByteStreamServer(proxy)
 	return nil
 }
 
-func NewByteStreamServerProxy(env environment.Env) (*ByteStreamServerProxy, error) {
-	localCache := env.GetCache()
-	if localCache == nil {
-		return nil, status.FailedPreconditionError("A cache is required to enable the ByteStreamServerProxy")
+func New(env environment.Env) (*ByteStreamServerProxy, error) {
+	local := env.GetLocalByteStreamClient()
+	if local == nil {
+		return nil, fmt.Errorf("A local ByteStreamClient is required to enable ByteStreamServerProxy")
 	}
-	remoteCache := env.GetByteStreamClient()
-	if remoteCache == nil {
-		return nil, fmt.Errorf("A ByteStreamClient is required to enable ByteStreamServerProxy")
+	remote := env.GetByteStreamClient()
+	if remote == nil {
+		return nil, fmt.Errorf("A remote ByteStreamClient is required to enable ByteStreamServerProxy")
 	}
 	return &ByteStreamServerProxy{
-		env:         env,
-		localCache:  localCache,
-		remoteCache: remoteCache,
+		env:    env,
+		local:  local,
+		remote: remote,
 	}, nil
 }
 
 func (s *ByteStreamServerProxy) Read(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) error {
-	remoteStream, err := s.remoteCache.Read(stream.Context(), req)
+	localReadStream, err := s.local.Read(stream.Context(), req)
 	if err != nil {
-		return err
+		return s.readRemote(req, stream)
 	}
+	responseSent := false
 	for {
-		rsp, err := remoteStream.Recv()
+		rsp, err := localReadStream.Recv()
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
+			// If some responses were streamed to the client, just return the
+			// error. Otherwise, fall-back to remote.
+			if responseSent {
+				return err
+			} else {
+				return s.readRemote(req, stream)
+			}
+		}
+
+		stream.Send(rsp)
+		responseSent = true
+	}
+	return nil
+}
+
+// The Write() RPC requires the client keep track of some state. This struct
+// and its methods take care of that.
+type localWriter struct {
+	ctx          context.Context
+	local        bspb.ByteStream_WriteClient
+	resourceName string
+	initialized  bool
+	offset       int64
+}
+
+func (s *localWriter) send(data []byte) error {
+	req := &bspb.WriteRequest{WriteOffset: s.offset, Data: data}
+	if !s.initialized {
+		// Read resources have a different name format than written resources
+		// Re-write the resource name with a fake execution ID so it passes
+		// the write regex.
+		req.ResourceName = "/uploads/00000000-0000-0000-0000-000000000000" + s.resourceName
+		s.initialized = true
+	}
+	s.offset += int64(len(data))
+	return s.local.Send(req)
+}
+
+func (s *localWriter) close() error {
+	if err := s.local.Send(&bspb.WriteRequest{WriteOffset: s.offset, FinishWrite: true}); err != nil {
+		return err
+	}
+	// Ignore the local response (but not the error)
+	_, err := s.local.CloseAndRecv()
+	return err
+}
+
+func (s *ByteStreamServerProxy) readRemote(req *bspb.ReadRequest, stream bspb.ByteStream_ReadServer) error {
+	remoteReadStream, err := s.remote.Read(stream.Context(), req)
+	if err != nil {
+		return err
+	}
+
+	var localWriteStream *localWriter = nil
+	if req.ReadOffset == 0 {
+		localStream, err := s.local.Write(stream.Context())
+		if err != nil {
+			log.Warningf("error writing to local bytestream server: %s", err)
+			localWriteStream = nil
+		}
+		localWriteStream = &localWriter{
+			ctx:          stream.Context(),
+			local:        localStream,
+			resourceName: req.ResourceName,
+			initialized:  false,
+			offset:       int64(0),
+		}
+	}
+
+	for {
+		rsp, err := remoteReadStream.Recv()
+		if err == io.EOF {
+			if localWriteStream != nil {
+				localWriteStream.close()
+			}
+			break
+		}
+		if err != nil {
 			return err
+		}
+
+		if localWriteStream != nil {
+			localWriteStream.send(rsp.Data)
 		}
 		if err = stream.Send(rsp); err != nil {
 			return err
@@ -65,33 +148,67 @@ func (s *ByteStreamServerProxy) Read(req *bspb.ReadRequest, stream bspb.ByteStre
 }
 
 func (s *ByteStreamServerProxy) Write(stream bspb.ByteStream_WriteServer) error {
-	remoteStream, err := s.remoteCache.Write(stream.Context())
+	local, err := s.local.Write(stream.Context())
+	if err != nil {
+		local = nil
+	}
+	remote, err := s.remote.Write(stream.Context())
 	if err != nil {
 		return err
 	}
+
 	for {
 		req, err := stream.Recv()
 		if err != nil {
 			return err
 		}
-		writeDone := req.GetFinishWrite()
-		if err := remoteStream.Send(req); err != nil {
+
+		// Send to the local ByteStreamServer (if it hasn't errored)
+		localDone := req.GetFinishWrite()
+		if local != nil {
+			if err := local.Send(req); err != nil {
+				if err == io.EOF {
+					localDone = true
+				} else {
+					log.Infof("error writing to local bytestream server: %s", err)
+				}
+				local = nil
+			}
+		}
+
+		// Send to the remote ByteStreamServer
+		done := req.GetFinishWrite()
+		if err := remote.Send(req); err != nil {
 			if err == io.EOF {
-				writeDone = true
+				done = true
 			} else {
 				return err
 			}
 		}
-		if writeDone {
-			lastRsp, err := remoteStream.CloseAndRecv()
+
+		// If the client or the remote server told us the write is done, send the
+		// response to the client.
+		if done {
+			if local != nil {
+				if !localDone {
+					log.Info("remote write done but local write is not")
+				}
+				_, err := local.CloseAndRecv()
+				if err != nil {
+					log.Infof("error closing local write stream: %s", err)
+				}
+			}
+			resp, err := remote.CloseAndRecv()
 			if err != nil {
 				return err
 			}
-			return stream.SendAndClose(lastRsp)
+			return stream.SendAndClose(resp)
+		} else if localDone {
+			log.Info("local write done but remote write is not")
 		}
 	}
 }
 
 func (s *ByteStreamServerProxy) QueryWriteStatus(ctx context.Context, req *bspb.QueryWriteStatusRequest) (*bspb.QueryWriteStatusResponse, error) {
-	return s.remoteCache.QueryWriteStatus(ctx, req)
+	return s.remote.QueryWriteStatus(ctx, req)
 }

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -1,0 +1,335 @@
+package byte_stream_server_proxy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/byte_stream_server"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/digest"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/byte_stream"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testcompression"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testdigest"
+	"github.com/buildbuddy-io/buildbuddy/server/testutil/testenv"
+	"github.com/buildbuddy-io/buildbuddy/server/util/compression"
+	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
+	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
+	guuid "github.com/google/uuid"
+	bspb "google.golang.org/genproto/googleapis/bytestream"
+	gstatus "google.golang.org/grpc/status"
+)
+
+type remoteReadExpectation int
+
+const (
+	never remoteReadExpectation = iota
+	once
+	always
+)
+
+func requestCountingInterceptor(count *atomic.Int32) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		count.Add(1)
+		return streamer(ctx, desc, cc, method, opts...)
+	}
+}
+
+func runRemoteBSS(ctx context.Context, env *testenv.TestEnv, t *testing.T) (bspb.ByteStreamClient, *atomic.Int32) {
+	server, err := byte_stream_server.NewByteStreamServer(env)
+	require.NoError(t, err)
+	grpcServer, runFunc := testenv.RegisterLocalGRPCServer(t, env)
+	bspb.RegisterByteStreamServer(grpcServer, server)
+	go runFunc()
+	streamRequestCounter := atomic.Int32{}
+	conn, err := testenv.LocalGRPCConn(ctx, env,
+		grpc.WithStreamInterceptor(requestCountingInterceptor(&streamRequestCounter)))
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	return bspb.NewByteStreamClient(conn), &streamRequestCounter
+}
+
+func runLocalBSS(ctx context.Context, env *testenv.TestEnv, t *testing.T) bspb.ByteStreamClient {
+	server, err := byte_stream_server.NewByteStreamServer(env)
+	require.NoError(t, err)
+	grpcServer, runFunc := testenv.RegisterLocalInternalGRPCServer(t, env)
+	bspb.RegisterByteStreamServer(grpcServer, server)
+	go runFunc()
+	conn, err := testenv.LocalInternalGRPCConn(ctx, env)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	return bspb.NewByteStreamClient(conn)
+}
+
+func runBSProxy(ctx context.Context, client bspb.ByteStreamClient, env *testenv.TestEnv, t *testing.T) bspb.ByteStreamClient {
+	env.SetByteStreamClient(client)
+	env.SetLocalByteStreamClient(runLocalBSS(ctx, env, t))
+	byteStreamServer, err := New(env)
+	require.NoError(t, err)
+	grpcServer, runFunc := testenv.RegisterLocalGRPCServer(t, env)
+	bspb.RegisterByteStreamServer(grpcServer, byteStreamServer)
+	go runFunc()
+	conn, err := testenv.LocalGRPCConn(ctx, env)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	return bspb.NewByteStreamClient(conn)
+}
+
+func waitContains(ctx context.Context, env *testenv.TestEnv, rn *rspb.ResourceName) error {
+	for i := 1; i <= 100; i++ {
+		found, err := env.GetCache().Contains(ctx, rn)
+		if err != nil {
+			return err
+		}
+		if found {
+			return nil
+		}
+		time.Sleep(time.Duration(i) * time.Millisecond)
+	}
+	s, err := digest.ResourceNameFromProto(rn).DownloadString()
+	if err != nil {
+		return err
+	}
+	return status.NotFoundErrorf("Timed out waiting for cache to contain %s", s)
+}
+
+func TestRead(t *testing.T) {
+	ctx := context.Background()
+	remoteEnv := testenv.GetTestEnv(t)
+	localEnv := testenv.GetTestEnv(t)
+	bs, requestCounter := runRemoteBSS(ctx, remoteEnv, t)
+	proxy := runBSProxy(ctx, bs, localEnv, t)
+
+	cases := []struct {
+		wantError error
+		cacheType rspb.CacheType
+		size      int64
+		offset    int64
+		remotes   remoteReadExpectation
+	}{
+		{ // Simple Read
+			wantError: nil,
+			cacheType: rspb.CacheType_CAS,
+			size:      1234,
+			offset:    0,
+			remotes:   once,
+		},
+		{ // Large Read
+			wantError: nil,
+			cacheType: rspb.CacheType_CAS,
+			size:      1000 * 1000 * 100,
+			offset:    0,
+			remotes:   once,
+		},
+		{ // 0 length read
+			wantError: nil,
+			cacheType: rspb.CacheType_CAS,
+			size:      0,
+			offset:    0,
+			remotes:   never,
+		},
+		{ // Offset
+			wantError: nil,
+			cacheType: rspb.CacheType_CAS,
+			size:      1234,
+			offset:    1,
+			remotes:   always,
+		},
+		{ // Max offset
+			wantError: nil,
+			cacheType: rspb.CacheType_CAS,
+			size:      1234,
+			offset:    1234,
+			remotes:   always,
+		},
+	}
+
+	ctx, err := prefix.AttachUserPrefixToContext(ctx, localEnv)
+	if err != nil {
+		t.Errorf("error attaching user prefix: %v", err)
+	}
+
+	for _, tc := range cases {
+		rn, data := testdigest.NewRandomResourceAndBuf(t, tc.size, tc.cacheType, "")
+		// Set the value in the remote cache.
+		err := remoteEnv.GetCache().Set(ctx, rn, data)
+		require.NoError(t, err)
+
+		// Read it through the proxied bytestream API several times, ensuring
+		// it's only read from the remote byestream server the first time.
+		for i := 1; i < 4; i++ {
+			var buf bytes.Buffer
+			gotErr := byte_stream.ReadBlob(ctx, proxy, digest.ResourceNameFromProto(rn), &buf, tc.offset)
+			if gstatus.Code(gotErr) != gstatus.Code(tc.wantError) {
+				t.Errorf("got %v; want %v", gotErr, tc.wantError)
+			}
+			got := buf.String()
+			if got != string(data[tc.offset:]) {
+				t.Errorf("got %.100s; want %.100s", got, data)
+			}
+
+			switch tc.remotes {
+			case never:
+				require.Equal(t, int32(0), requestCounter.Load())
+			case once:
+				require.Equal(t, int32(1), requestCounter.Load())
+			case always:
+				require.Equal(t, int32(i), requestCounter.Load())
+			}
+
+			// offset and 0-sized reads are not cached in the proxy.
+			if tc.offset == 0 && tc.size > 0 {
+				require.NoError(t, waitContains(ctx, localEnv, rn))
+			}
+		}
+		requestCounter.Store(0)
+	}
+}
+
+func TestWrite(t *testing.T) {
+	// Make blob big enough to require multiple chunks to upload
+	rn, blob := testdigest.RandomCompressibleCASResourceBuf(t, 5e6, "" /*instanceName*/)
+	compressedBlob := compression.CompressZstd(nil, blob)
+	require.NotEqual(t, blob, compressedBlob, "sanity check: blob != compressedBlob")
+
+	// Note: Digest is of uncompressed contents
+	d := rn.GetDigest()
+
+	testCases := []struct {
+		name                        string
+		uploadResourceName          string
+		uploadBlob                  []byte
+		downloadResourceName        string
+		expectedDownloadCompression repb.Compressor_Value
+		bazelVersion                string
+	}{
+		{
+			name:                        "Write compressed, read compressed",
+			uploadResourceName:          fmt.Sprintf("uploads/%s/compressed-blobs/zstd/%s/%d", newUUID(t), d.Hash, d.SizeBytes),
+			uploadBlob:                  compressedBlob,
+			downloadResourceName:        fmt.Sprintf("compressed-blobs/zstd/%s/%d", d.Hash, d.SizeBytes),
+			expectedDownloadCompression: repb.Compressor_ZSTD,
+		},
+		{
+			name:                        "Write compressed, read decompressed",
+			uploadResourceName:          fmt.Sprintf("uploads/%s/compressed-blobs/zstd/%s/%d", newUUID(t), d.Hash, d.SizeBytes),
+			uploadBlob:                  compressedBlob,
+			downloadResourceName:        fmt.Sprintf("blobs/%s/%d", d.Hash, d.SizeBytes),
+			expectedDownloadCompression: repb.Compressor_IDENTITY,
+		},
+		{
+			name:                        "Write decompressed, read decompressed",
+			uploadResourceName:          fmt.Sprintf("uploads/%s/blobs/%s/%d", newUUID(t), d.Hash, d.SizeBytes),
+			uploadBlob:                  blob,
+			downloadResourceName:        fmt.Sprintf("blobs/%s/%d", d.Hash, d.SizeBytes),
+			expectedDownloadCompression: repb.Compressor_IDENTITY,
+		},
+		{
+			name:                        "Write decompressed, read compressed",
+			uploadResourceName:          fmt.Sprintf("uploads/%s/blobs/%s/%d", newUUID(t), d.Hash, d.SizeBytes),
+			uploadBlob:                  blob,
+			downloadResourceName:        fmt.Sprintf("compressed-blobs/zstd/%s/%d", d.Hash, d.SizeBytes),
+			expectedDownloadCompression: repb.Compressor_ZSTD,
+		},
+	}
+	for _, tc := range testCases {
+		run := func(t *testing.T) {
+			remoteEnv := testenv.GetTestEnv(t)
+			localEnv := testenv.GetTestEnv(t)
+			ctx := byte_stream.WithBazelVersion(t, context.Background(), tc.bazelVersion)
+
+			// Enable compression
+			flags.Set(t, "cache.zstd_transcoding_enabled", true)
+			localEnv.SetCache(&testcompression.CompressionCache{Cache: localEnv.GetCache()})
+
+			ctx, err := prefix.AttachUserPrefixToContext(ctx, localEnv)
+			require.NoError(t, err)
+			bs, requestCounter := runRemoteBSS(ctx, remoteEnv, t)
+			proxy := runBSProxy(ctx, bs, localEnv, t)
+
+			// Upload the blob
+			byte_stream.MustUploadChunked(t, ctx, proxy, tc.bazelVersion, tc.uploadResourceName, tc.uploadBlob, true)
+			require.NoError(t, waitContains(ctx, localEnv, rn))
+
+			// Read back the blob we just uploaded
+			downloadBuf := []byte{}
+			downloadStream, err := proxy.Read(ctx, &bspb.ReadRequest{
+				ResourceName: tc.downloadResourceName,
+			})
+			require.NoError(t, err, tc.name)
+			for {
+				res, err := downloadStream.Recv()
+				if err == io.EOF {
+					break
+				}
+				require.NoError(t, err, tc.name)
+				downloadBuf = append(downloadBuf, res.Data...)
+			}
+
+			if tc.expectedDownloadCompression == repb.Compressor_IDENTITY {
+				require.Equal(t, blob, downloadBuf, tc.name)
+			} else if tc.expectedDownloadCompression == repb.Compressor_ZSTD {
+				decompressedDownloadBuf, err := compression.DecompressZstd(nil, downloadBuf)
+				require.NoError(t, err, tc.name)
+				require.Equal(t, blob, decompressedDownloadBuf, tc.name)
+			}
+
+			// There should've been 1 request from the proxy to the backing cache.
+			require.Equal(t, int32(1), requestCounter.Load())
+
+			// Now try uploading a duplicate. The duplicate upload should not fail,
+			// and we should still be able to read the blob.
+			byte_stream.MustUploadChunked(t, ctx, proxy, tc.bazelVersion, tc.uploadResourceName, tc.uploadBlob, false)
+
+			downloadBuf = []byte{}
+			downloadStream, err = proxy.Read(ctx, &bspb.ReadRequest{
+				ResourceName: tc.downloadResourceName,
+			})
+			require.NoError(t, err, tc.name)
+			for {
+				res, err := downloadStream.Recv()
+				if err == io.EOF {
+					break
+				}
+				require.NoError(t, err, tc.name)
+				downloadBuf = append(downloadBuf, res.Data...)
+			}
+
+			if tc.expectedDownloadCompression == repb.Compressor_IDENTITY {
+				require.Equal(t, blob, downloadBuf, tc.name)
+			} else if tc.expectedDownloadCompression == repb.Compressor_ZSTD {
+				decompressedDownloadBuf, err := compression.DecompressZstd(nil, downloadBuf)
+				require.NoError(t, err, tc.name)
+				require.Equal(t, blob, decompressedDownloadBuf, tc.name)
+			}
+
+			// There should've been 1 more request from the proxy to the backing cache.
+			require.Equal(t, int32(2), requestCounter.Load())
+
+		}
+
+		// Run all tests for both bazel 5.0.0 (which introduced compression) and
+		// 5.1.0 (which added support for short-circuiting duplicate compressed
+		// uploads)
+		tc.bazelVersion = "5.0.0"
+		t.Run(tc.name+", bazel "+tc.bazelVersion, run)
+
+		tc.bazelVersion = "5.1.0"
+		t.Run(tc.name+", bazel "+tc.bazelVersion, run)
+	}
+}
+
+func newUUID(t *testing.T) string {
+	uuid, err := guuid.NewRandom()
+	require.NoError(t, err)
+	return uuid.String()
+}

--- a/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
+++ b/enterprise/server/byte_stream_server_proxy/byte_stream_server_proxy_test.go
@@ -19,12 +19,12 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/prefix"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/buildbuddy-io/buildbuddy/server/util/testing/flags"
+	"github.com/buildbuddy-io/buildbuddy/server/util/uuid"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	repb "github.com/buildbuddy-io/buildbuddy/proto/remote_execution"
 	rspb "github.com/buildbuddy-io/buildbuddy/proto/resource"
-	guuid "github.com/google/uuid"
 	bspb "google.golang.org/genproto/googleapis/bytestream"
 	gstatus "google.golang.org/grpc/status"
 )
@@ -214,28 +214,28 @@ func TestWrite(t *testing.T) {
 	}{
 		{
 			name:                        "Write compressed, read compressed",
-			uploadResourceName:          fmt.Sprintf("uploads/%s/compressed-blobs/zstd/%s/%d", newUUID(t), d.Hash, d.SizeBytes),
+			uploadResourceName:          fmt.Sprintf("uploads/%s/compressed-blobs/zstd/%s/%d", uuid.New(), d.Hash, d.SizeBytes),
 			uploadBlob:                  compressedBlob,
 			downloadResourceName:        fmt.Sprintf("compressed-blobs/zstd/%s/%d", d.Hash, d.SizeBytes),
 			expectedDownloadCompression: repb.Compressor_ZSTD,
 		},
 		{
 			name:                        "Write compressed, read decompressed",
-			uploadResourceName:          fmt.Sprintf("uploads/%s/compressed-blobs/zstd/%s/%d", newUUID(t), d.Hash, d.SizeBytes),
+			uploadResourceName:          fmt.Sprintf("uploads/%s/compressed-blobs/zstd/%s/%d", uuid.New(), d.Hash, d.SizeBytes),
 			uploadBlob:                  compressedBlob,
 			downloadResourceName:        fmt.Sprintf("blobs/%s/%d", d.Hash, d.SizeBytes),
 			expectedDownloadCompression: repb.Compressor_IDENTITY,
 		},
 		{
 			name:                        "Write decompressed, read decompressed",
-			uploadResourceName:          fmt.Sprintf("uploads/%s/blobs/%s/%d", newUUID(t), d.Hash, d.SizeBytes),
+			uploadResourceName:          fmt.Sprintf("uploads/%s/blobs/%s/%d", uuid.New(), d.Hash, d.SizeBytes),
 			uploadBlob:                  blob,
 			downloadResourceName:        fmt.Sprintf("blobs/%s/%d", d.Hash, d.SizeBytes),
 			expectedDownloadCompression: repb.Compressor_IDENTITY,
 		},
 		{
 			name:                        "Write decompressed, read compressed",
-			uploadResourceName:          fmt.Sprintf("uploads/%s/blobs/%s/%d", newUUID(t), d.Hash, d.SizeBytes),
+			uploadResourceName:          fmt.Sprintf("uploads/%s/blobs/%s/%d", uuid.New(), d.Hash, d.SizeBytes),
 			uploadBlob:                  blob,
 			downloadResourceName:        fmt.Sprintf("compressed-blobs/zstd/%s/%d", d.Hash, d.SizeBytes),
 			expectedDownloadCompression: repb.Compressor_ZSTD,
@@ -326,10 +326,4 @@ func TestWrite(t *testing.T) {
 		tc.bazelVersion = "5.1.0"
 		t.Run(tc.name+", bazel "+tc.bazelVersion, run)
 	}
-}
-
-func newUUID(t *testing.T) string {
-	uuid, err := guuid.NewRandom()
-	require.NoError(t, err)
-	return uuid.String()
 }


### PR DESCRIPTION
This PR contains the changes in https://github.com/buildbuddy-io/buildbuddy/pull/7048 -- review that one first.

This PR makes `byte_stream_server_proxy` use the `byte_stream_server` installed in the environment by `cache_proxy` in https://github.com/buildbuddy-io/buildbuddy/pull/7048 for caching data locally. It attempts to serve reads out of the local bytestreamserver, when the data is available, and writes data that's read through the proxy to the local bytestreamserver. There is a bit of a hack that converts downloaded resource names into uploaded resource names, but otherwise it's mostly just manipulating gRPC streams.

Note that the test is largely copied from `server/remote_cache/byte_stream_server/byte_stream_server_test.go` because that test has pretty good coverage of compression cases that I wanted to keep. I factored out some common code into a testutil.

**Related issues**: N/A
