### PR TITLE
docs: update olap docs

### DIFF
--- a/docs/config-olap-databases.md
+++ b/docs/config-olap-databases.md
@@ -11,7 +11,7 @@ To speed up the analysis of historical build event data, BuildBuddy can be confi
 Setting up ClickHouse is completely optional when using BuildBuddy.
 BuildBuddy does not require ClickHouse for its core features, including the build results UI, remote cache, and remote execution system.
 
-However, some UI features, such as Trends, do require ClickHouse.
+However, some UI features, such as Trends, Drilldown, and Test Grid, Tags filtering, Audit Logging do require ClickHouse.
 Without a configured ClickHouse instance, these features will either be missing from the UI, or will be missing some features and may not scale to larger amounts of data.
 
 ## Options

--- a/docs/config-olap-databases.md
+++ b/docs/config-olap-databases.md
@@ -11,7 +11,7 @@ To speed up the analysis of historical build event data, BuildBuddy can be confi
 Setting up ClickHouse is completely optional when using BuildBuddy.
 BuildBuddy does not require ClickHouse for its core features, including the build results UI, remote cache, and remote execution system.
 
-However, some UI features, such as Trends, Drilldown, and Test Grid, Tags filtering, Audit Logging do require ClickHouse.
+However, some UI features, such as Trends, Drilldown, Test Grid, Tags filtering, and Audit Logging, may require ClickHouse.
 Without a configured ClickHouse instance, these features will either be missing from the UI, or will be missing some features and may not scale to larger amounts of data.
 
 ## Options

--- a/docs/config-olap-databases.md
+++ b/docs/config-olap-databases.md
@@ -4,26 +4,38 @@ title: OLAP Database Configuration
 sidebar_label: OLAP Database
 ---
 
-## Section
+## Introduction
 
-`olap_database:` The OLAP (online analytical processing) database section configures the OLAP database that BuildBuddy uses to enable the Trends page. **Optional**
+To speed up the analysis of historical build event data, BuildBuddy relies on ClickHouse, an OLAP database solution.
 
-Note: in order to use OLAP database for the Trends page, `app.enable_read_from_olap_db` and
-`app.enable_write_to_olap_db` needs to be set to `true`
+Deploying ClickHouse is optional when using BuildBuddy
+BuildBuddy does not require ClickHouse for its core features, such as Build Event Service, Remote Cache, and Remote Execution.
+
+However, some UI features, such as Trends, Drilldown, and Test Grid, do rely on ClickHouse.
+Without a configured ClickHouse instance, these features will either not be displayed on our UI or will operate in a different mode.
 
 ## Options
 
 **Optional**
 
+`olap_database:` The OLAP (online analytical processing) database section configures the OLAP database that BuildBuddy uses to enable the Trends page. **Optional**
+
 - `data_source` This is a connection string used by the database driver to connect to the database. ClickHouse database is supported.
-- `enable_data_replication` If true, data replication is enabled.
+
+- `enable_data_replication` If ClickHouse is using a [Cluster Deployment](https://clickhouse.com/docs/en/architecture/cluster-deployment), this will enable data replication within the cluster.
 
 ## Example sections
 
+Example single instance clickhouse configuration
+
 ```
-app:
-  enable_read_from_olap_db: true
-  enable_write_to_olap_db: true
+olap_database:
+  data_source: "clickhouse://buildbuddy_user:pAsSwOrD@12.34.56.78:9000/buildbuddy_db"
+```
+
+Example cluster clickhouse configuration
+
+```
 olap_database:
   data_source: "clickhouse://buildbuddy_user:pAsSwOrD@12.34.56.78:9000/buildbuddy_db"
   enable_data_replication: true

--- a/docs/config-olap-databases.md
+++ b/docs/config-olap-databases.md
@@ -6,13 +6,13 @@ sidebar_label: OLAP Database
 
 ## Introduction
 
-To speed up the analysis of historical build event data, BuildBuddy relies on ClickHouse, an OLAP database solution.
+To speed up the analysis of historical build event data, BuildBuddy can be configured to use ClickHouse as an OLAP database, in addition to the primary SQL database required for core functionality.
 
-Deploying ClickHouse is optional when using BuildBuddy
-BuildBuddy does not require ClickHouse for its core features, such as Build Event Service, Remote Cache, and Remote Execution.
+Setting up ClickHouse is completely optional when using BuildBuddy.
+BuildBuddy does not require ClickHouse for its core features, including the build results UI, remote cache, and remote execution system.
 
-However, some UI features, such as Trends, Drilldown, and Test Grid, do rely on ClickHouse.
-Without a configured ClickHouse instance, these features will either not be displayed on our UI or will operate in a different mode.
+However, some UI features, such as Trends, do require ClickHouse.
+Without a configured ClickHouse instance, these features will either be missing from the UI, or will be missing some features and may not scale to larger amounts of data.
 
 ## Options
 
@@ -22,20 +22,20 @@ Without a configured ClickHouse instance, these features will either not be disp
 
 - `data_source` This is a connection string used by the database driver to connect to the database. ClickHouse database is supported.
 
-- `enable_data_replication` If ClickHouse is using a [Cluster Deployment](https://clickhouse.com/docs/en/architecture/cluster-deployment), this will enable data replication within the cluster.
+- `enable_data_replication` If ClickHouse is using a [cluster deployment](https://clickhouse.com/docs/en/architecture/cluster-deployment), this will enable data replication within the cluster.
 
 ## Example sections
 
-Example single instance clickhouse configuration
+Example single-instance ClickHouse configuration:
 
-```
+```yaml
 olap_database:
   data_source: "clickhouse://buildbuddy_user:pAsSwOrD@12.34.56.78:9000/buildbuddy_db"
 ```
 
-Example cluster clickhouse configuration
+Example ClickHouse cluster configuration:
 
-```
+```yaml
 olap_database:
   data_source: "clickhouse://buildbuddy_user:pAsSwOrD@12.34.56.78:9000/buildbuddy_db"
   enable_data_replication: true

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -40,6 +40,7 @@ module.exports = {
       "config-samples",
       "config-app",
       "config-database",
+      "config-olap-database",
       "config-storage",
       "config-cache",
       "config-github",


### PR DESCRIPTION
Our OLAP configuration doc was hidden from the world because it was not
added to the sidebars. Only keen users could find it from our doc search
results.

Remove the app.* flags as they have all been defaulted to true.
Users who setup clickhouse will get those features immediately.

Adjust the wording to highlight that ClickHouse is completely optional.
Also provided separate configuration example for clickhouse singleton vs
cluster deployment.
