### PR TITLE
OCI runtime: fix env not being respected in some cases

### DIFF
--- a/dockerfiles/test_images/ociruntime_test/env_test_image/Dockerfile
+++ b/dockerfiles/test_images/ociruntime_test/env_test_image/Dockerfile
@@ -1,0 +1,7 @@
+FROM busybox@sha256:9ae97d36d26566ff84e8893c64a6dc4fe8ca6d1144bf5b87b2b85a32def253c7
+
+# Test setting env vars
+ENV TEST_ENV_VAR=foo
+
+# Test appending to existing env vars
+ENV PATH="$PATH:/test/bin"

--- a/enterprise/server/remote_execution/commandutil/commandutil.go
+++ b/enterprise/server/remote_execution/commandutil/commandutil.go
@@ -314,3 +314,21 @@ func EnvStringList(command *repb.Command) []string {
 	}
 	return env
 }
+
+// EnvProto returns the REAPI proto representation of the given env string list
+// (NAME=VALUE pairs). It returns an error if any string in the list does not
+// contain "=".
+func EnvProto(env []string) ([]*repb.Command_EnvironmentVariable, error) {
+	out := make([]*repb.Command_EnvironmentVariable, 0, len(env))
+	for _, pair := range env {
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) != 2 {
+			return nil, status.InvalidArgumentErrorf("invalid environment variable %q (expected NAME=VALUE)", pair)
+		}
+		out = append(out, &repb.Command_EnvironmentVariable{
+			Name:  parts[0],
+			Value: parts[1],
+		})
+	}
+	return out, nil
+}

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -225,7 +226,15 @@ func (c *ociContainer) createBundle(ctx context.Context, cmd *repb.Command) erro
 		return fmt.Errorf("create rootfs: %w", err)
 	}
 
-	// Create config.json
+	// Create config.json from the image config and command
+	image, ok := c.imageStore.CachedImage(c.imageRef)
+	if !ok {
+		return fmt.Errorf("image must be cached before creating OCI bundle")
+	}
+	cmd, err := withImageConfig(cmd, image)
+	if err != nil {
+		return fmt.Errorf("apply image config to command: %w", err)
+	}
 	spec, err := c.createSpec(cmd)
 	if err != nil {
 		return fmt.Errorf("create spec: %w", err)
@@ -246,7 +255,7 @@ func (c *ociContainer) IsolationType() string {
 }
 
 func (c *ociContainer) IsImageCached(ctx context.Context) (bool, error) {
-	_, ok := c.imageStore.CachedLayers(c.imageRef)
+	_, ok := c.imageStore.CachedImage(c.imageRef)
 	return ok, nil
 }
 
@@ -271,7 +280,6 @@ func (c *ociContainer) Run(ctx context.Context, cmd *repb.Command, workDir strin
 	if err := container.PullImageIfNecessary(ctx, c.env, c, creds, c.imageRef); err != nil {
 		return commandutil.ErrorResult(status.UnavailableErrorf("pull image: %s", err))
 	}
-
 	if err := c.createBundle(ctx, cmd); err != nil {
 		return commandutil.ErrorResult(status.UnavailableErrorf("create OCI bundle: %s", err))
 	}
@@ -394,16 +402,12 @@ func (c *ociContainer) createRootfs(ctx context.Context) error {
 
 	// Create an overlayfs with the pulled image layers.
 	var lowerDirs []string
-	layers, ok := c.imageStore.CachedLayers(c.imageRef)
+	image, ok := c.imageStore.CachedImage(c.imageRef)
 	if !ok {
 		return fmt.Errorf("bad state: attempted to create rootfs before pulling image")
 	}
-	for _, layer := range layers {
-		d, err := layer.Digest()
-		if err != nil {
-			return fmt.Errorf("get layer digest: %w", err)
-		}
-		path := layerPath(c.layersRoot, d)
+	for _, layer := range image.Layers {
+		path := layerPath(c.layersRoot, layer.Digest)
 		// Skip empty dirs - these can cause conflicts since they will always
 		// have the same digest, and also just add more overhead.
 		// TODO: precompute this
@@ -477,9 +481,7 @@ func installBusybox(path string) error {
 }
 
 func (c *ociContainer) createSpec(cmd *repb.Command) (*specs.Spec, error) {
-	// TODO: respect environment variables inside the container (ENV directives)
 	env := append([]string{
-		// TODO: make sure this PATH matches podman's behavior
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 	}, commandutil.EnvStringList(cmd)...)
 
@@ -821,13 +823,25 @@ type ImageStore struct {
 	pullGroup singleflight.Group
 
 	mu           sync.RWMutex
-	cachedLayers map[string][]ctr.Layer
+	cachedImages map[string]*Image
+}
+
+// Image represents a cached image, including all layer digests and image
+// configuration.
+type Image struct {
+	Layers []*ImageLayer
+	Env    []string
+}
+
+// ImageLayer represents a resolved image layer.
+type ImageLayer struct {
+	Digest ctr.Hash
 }
 
 func NewImageStore(layersDir string) *ImageStore {
 	return &ImageStore{
 		layersDir:    layersDir,
-		cachedLayers: map[string][]ctr.Layer{},
+		cachedImages: map[string]*Image{},
 	}
 }
 
@@ -837,7 +851,7 @@ func NewImageStore(layersDir string) *ImageStore {
 // Pull always re-authenticates the credentials with the image registry.
 // Each layer is extracted to a subdirectory given by {algorithm}/{hash}, e.g.
 // "sha256/abc123".
-func (s *ImageStore) Pull(ctx context.Context, imageName string, creds oci.Credentials) ([]ctr.Layer, error) {
+func (s *ImageStore) Pull(ctx context.Context, imageName string, creds oci.Credentials) (*Image, error) {
 	key := hash.Strings(imageName, creds.Username, creds.Password)
 	ch := s.pullGroup.DoChan(key, func() (any, error) {
 		// Use a background ctx to prevent ctx cancellation from one pull
@@ -845,16 +859,16 @@ func (s *ImageStore) Pull(ctx context.Context, imageName string, creds oci.Crede
 		// TODO: use something like github.com/janos/singleflight to ensure we
 		// cancel the download if all group member contexts are cancelled.
 		ctx := context.WithoutCancel(ctx)
-		layers, err := pull(ctx, s.layersDir, imageName, creds)
+		image, err := pull(ctx, s.layersDir, imageName, creds)
 		if err != nil {
 			return nil, err
 		}
 
 		s.mu.Lock()
-		s.cachedLayers[imageName] = layers
+		s.cachedImages[imageName] = image
 		s.mu.Unlock()
 
-		return layers, nil
+		return image, nil
 	})
 
 	select {
@@ -864,21 +878,28 @@ func (s *ImageStore) Pull(ctx context.Context, imageName string, creds oci.Crede
 		if res.Err != nil {
 			return nil, res.Err
 		}
-		return res.Val.([]ctr.Layer), nil
+		return res.Val.(*Image), nil
 	}
 }
 
 // CachedLayers returns references to the cached image layers if the image
 // has been pulled. The second return value indicates whether the image has
 // been pulled - if false, the returned slice of layers will be nil.
-func (s *ImageStore) CachedLayers(imageName string) (layers []ctr.Layer, ok bool) {
+func (s *ImageStore) CachedImage(imageName string) (image *Image, ok bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	layers, ok = s.cachedLayers[imageName]
-	return layers, ok
+
+	// TODO: make ImageStore a param of NewProvider and move this logic to a
+	// test image store
+	if imageName == TestBusyboxImageRef {
+		return &Image{}, true
+	}
+
+	image, ok = s.cachedImages[imageName]
+	return image, ok
 }
 
-func pull(ctx context.Context, layersDir, imageName string, creds oci.Credentials) ([]ctr.Layer, error) {
+func pull(ctx context.Context, layersDir, imageName string, creds oci.Credentials) (*Image, error) {
 	img, err := oci.Resolve(ctx, imageName, oci.RuntimePlatform(), creds)
 	if err != nil {
 		return nil, status.WrapError(err, "resolve image")
@@ -888,16 +909,23 @@ func pull(ctx context.Context, layersDir, imageName string, creds oci.Credential
 		return nil, status.UnavailableErrorf("get image layers: %s", err)
 	}
 
+	resolvedImage := &Image{
+		Layers: make([]*ImageLayer, 0, len(layers)),
+	}
+
 	// Download and extract layers concurrently.
 	var eg errgroup.Group
 	eg.SetLimit(min(8, runtime.NumCPU()))
 	for _, layer := range layers {
 		layer := layer
+		resolvedLayer := &ImageLayer{}
+		resolvedImage.Layers = append(resolvedImage.Layers, resolvedLayer)
 		eg.Go(func() error {
 			d, err := layer.Digest()
 			if err != nil {
 				return status.UnavailableErrorf("get layer digest: %s", err)
 			}
+			resolvedLayer.Digest = d
 
 			destDir := layerPath(layersDir, d)
 
@@ -940,10 +968,45 @@ func pull(ctx context.Context, layersDir, imageName string, creds oci.Credential
 			return nil
 		})
 	}
+	// Fetch image config file concurrently with layer downloads.
+	eg.Go(func() error {
+		f, err := img.ConfigFile()
+		if err != nil {
+			return status.UnavailableErrorf("get image config file: %s", err)
+		}
+		resolvedImage.Env = f.Config.Env
+		return nil
+	})
 	if err := eg.Wait(); err != nil {
 		return nil, err
 	}
-	return layers, nil
+	return resolvedImage, nil
+}
+
+func withImageConfig(cmd *repb.Command, image *Image) (*repb.Command, error) {
+	// Apply any env vars from the image which aren't overridden by the command
+	cmdVarNames := make(map[string]bool, len(cmd.EnvironmentVariables))
+	for _, cmdVar := range cmd.GetEnvironmentVariables() {
+		cmdVarNames[cmdVar.GetName()] = true
+	}
+	imageEnv, err := commandutil.EnvProto(image.Env)
+	if err != nil {
+		return nil, status.WrapError(err, "parse image env")
+	}
+	outEnv := slices.Clone(cmd.EnvironmentVariables)
+	for _, imageVar := range imageEnv {
+		if cmdVarNames[imageVar.GetName()] {
+			continue
+		}
+		outEnv = append(outEnv, imageVar)
+	}
+
+	// TODO: ENTRYPOINT, CMD
+
+	// Return a copy of the command but with the image config applied
+	out := cmd.CloneVT()
+	out.EnvironmentVariables = outEnv
+	return out, nil
 }
 
 func tmpSuffix() string {

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -335,11 +335,16 @@ func TestPullCreateExecRemove(t *testing.T) {
 	})
 
 	// Exec
-	cmd := &repb.Command{Arguments: []string{"sh", "-ec", `
-		touch /bin/foo.txt
-		pwd
-		env | grep -v HOSTNAME | sort
-	`}}
+	cmd := &repb.Command{
+		Arguments: []string{"sh", "-ec", `
+			touch /bin/foo.txt
+			pwd
+			env | grep -v HOSTNAME | sort
+		`},
+		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
+			{Name: "GREETING", Value: "Hello"},
+		},
+	}
 	stdio := interfaces.Stdio{}
 	res := c.Exec(ctx, cmd, &stdio)
 	require.NoError(t, res.Error)
@@ -347,6 +352,7 @@ func TestPullCreateExecRemove(t *testing.T) {
 	assert.Equal(t, 0, res.ExitCode)
 	assert.Empty(t, string(res.Stderr))
 	assert.Equal(t, `/buildbuddy-execroot
+GREETING=Hello
 HOME=/root
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/test/bin
 PWD=/buildbuddy-execroot

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -77,6 +77,14 @@ func realBusyboxImage(t *testing.T) string {
 	return "mirror.gcr.io/library/busybox"
 }
 
+// Returns a remote reference to the image in //dockerfiles/test_images/ociruntime_test/env_test_image
+func envTestImage(t *testing.T) string {
+	if !hasMountPermissions(t) {
+		t.Skipf("using a real container image with overlayfs requires mount permissions")
+	}
+	return "gcr.io/flame-public/env-test@sha256:e3e64513b41d429a60b0fb420afbecb5b36af11f6d6601ba8177e259d74e1514"
+}
+
 func TestRun(t *testing.T) {
 	image := manuallyProvisionedBusyboxImage(t)
 
@@ -154,7 +162,7 @@ func TestRunUsageStats(t *testing.T) {
 }
 
 func TestRunWithImage(t *testing.T) {
-	image := realBusyboxImage(t)
+	image := envTestImage(t)
 
 	ctx := context.Background()
 	env := testenv.GetTestEnv(t)
@@ -181,6 +189,7 @@ func TestRunWithImage(t *testing.T) {
 	cmd := &repb.Command{
 		Arguments: []string{"sh", "-c", `
 			echo "$GREETING world!"
+			env | grep -v 'HOSTNAME' | sort
 		`},
 		EnvironmentVariables: []*repb.Command_EnvironmentVariable{
 			{Name: "GREETING", Value: "Hello"},
@@ -188,7 +197,14 @@ func TestRunWithImage(t *testing.T) {
 	}
 	res := c.Run(ctx, cmd, wd, oci.Credentials{})
 	require.NoError(t, res.Error)
-	assert.Equal(t, "Hello world!\n", string(res.Stdout))
+	assert.Equal(t, `Hello world!
+GREETING=Hello
+HOME=/root
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/test/bin
+PWD=/buildbuddy-execroot
+SHLVL=1
+TEST_ENV_VAR=foo
+`, string(res.Stdout))
 	assert.Empty(t, "", string(res.Stderr))
 	assert.Equal(t, 0, res.ExitCode)
 }
@@ -279,7 +295,7 @@ func TestExecUsageStats(t *testing.T) {
 }
 
 func TestPullCreateExecRemove(t *testing.T) {
-	image := realBusyboxImage(t)
+	image := envTestImage(t)
 
 	ctx := context.Background()
 	env := testenv.GetTestEnv(t)
@@ -322,6 +338,7 @@ func TestPullCreateExecRemove(t *testing.T) {
 	cmd := &repb.Command{Arguments: []string{"sh", "-ec", `
 		touch /bin/foo.txt
 		pwd
+		env | grep -v HOSTNAME | sort
 	`}}
 	stdio := interfaces.Stdio{}
 	res := c.Exec(ctx, cmd, &stdio)
@@ -329,7 +346,13 @@ func TestPullCreateExecRemove(t *testing.T) {
 
 	assert.Equal(t, 0, res.ExitCode)
 	assert.Empty(t, string(res.Stderr))
-	assert.Equal(t, "/buildbuddy-execroot\n", string(res.Stdout))
+	assert.Equal(t, `/buildbuddy-execroot
+HOME=/root
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/test/bin
+PWD=/buildbuddy-execroot
+SHLVL=1
+TEST_ENV_VAR=foo
+`, string(res.Stdout))
 
 	// Make sure the image layers were unmodified and that foo.txt was written
 	// to the upper dir in the overlayfs.


### PR DESCRIPTION
- Respect image env (e.g. `ENV` directives in Dockerfile)
  - Change the `ImageStore` to represent images as a struct including both the layers and the image config (which includes the env), instead of just a list of layers
- Fix Action env variables not being respected by `Exec()`

**Related issues**: N/A
