### PR TITLE
Fix .zst file extension in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ buildbuddy-key.pem
 enterprise/config/user-configs
 
 # Bazel compact execution log
-/bazel_compact_exec_log.binpb.zstd
+/bazel_compact_exec_log.binpb.zst


### PR DESCRIPTION
The file extension was changed in https://github.com/buildbuddy-io/buildbuddy/pull/6937/files

**Related issues**: N/A
