### PR TITLE
Don't re-verify cached trees at read time

### DIFF
--- a/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
+++ b/server/remote_cache/content_addressable_storage_server/content_addressable_storage_server.go
@@ -597,18 +597,11 @@ func (s *ContentAddressableStorageServer) GetTree(req *repb.GetTreeRequest, stre
 			if blob, err := s.cache.Get(ctx, treeCacheRN); err == nil {
 				treeCache := &capb.TreeCache{}
 				if err := proto.Unmarshal(blob, treeCache); err == nil {
-					if isComplete(treeCache.GetChildren()) {
-						metrics.TreeCacheLookupCount.With(prometheus.Labels{
-							metrics.TreeCacheLookupStatus: "hit",
-							metrics.TreeCacheLookupLevel:  levelLabel,
-						}).Inc()
-						return treeCache.GetChildren(), nil
-					} else {
-						metrics.TreeCacheLookupCount.With(prometheus.Labels{
-							metrics.TreeCacheLookupStatus: "invalid_entry",
-							metrics.TreeCacheLookupLevel:  levelLabel,
-						}).Inc()
-					}
+					metrics.TreeCacheLookupCount.With(prometheus.Labels{
+						metrics.TreeCacheLookupStatus: "hit",
+						metrics.TreeCacheLookupLevel:  levelLabel,
+					}).Inc()
+					return treeCache.GetChildren(), nil
 				}
 			} else if status.IsNotFoundError(err) {
 				metrics.TreeCacheLookupCount.With(prometheus.Labels{


### PR DESCRIPTION
We did this originally because there were bad trees cached. I've verified that we don't see any metrics with invalid_entry, so this seems safe to remove now, and will save some CPU being spent on proto serialization.