### PR TITLE
Consolidate invocation metadata logic

### DIFF
--- a/server/build_event_protocol/build_event_handler/build_event_handler_test.go
+++ b/server/build_event_protocol/build_event_handler/build_event_handler_test.go
@@ -1323,33 +1323,32 @@ func TestBuildStatusReporting(t *testing.T) {
 				},
 			},
 		},
-		// TODO: this test fails - fix
-		// {
-		// 	name: "WorkspaceStatusThenBuildMetadata",
-		// 	metadataEvents: []*bspb.BuildEvent{
-		// 		&bspb.BuildEvent{
-		// 			Id: &bspb.BuildEventId{Id: &bspb.BuildEventId_Pattern{Pattern: &bspb.BuildEventId_PatternExpandedId{
-		// 				Pattern: []string{"//..."},
-		// 			}}},
-		// 		},
-		// 		&bspb.BuildEvent{
-		// 			Id: &bspb.BuildEventId{Id: &bspb.BuildEventId_WorkspaceStatus{}},
-		// 			Payload: &bspb.BuildEvent_WorkspaceStatus{WorkspaceStatus: &bspb.WorkspaceStatus{
-		// 				Item: []*bspb.WorkspaceStatus_Item{
-		// 					{Key: "REPO_URL", Value: "https://github.com/testowner/testrepo.git"},
-		// 					{Key: "COMMIT_SHA", Value: "0c894fe31c2e91d59cb1a59bb25aaa78089919c2"},
-		// 				},
-		// 			}},
-		// 		},
-		// 		&bspb.BuildEvent{
-		// 			Id: &bspb.BuildEventId{Id: &bspb.BuildEventId_BuildMetadata{}},
-		// 			Payload: &bspb.BuildEvent_BuildMetadata{BuildMetadata: &bspb.BuildMetadata{
-		// 				// Status reporting is only enabled for CI builds.
-		// 				Metadata: map[string]string{"ROLE": "CI"},
-		// 			}},
-		// 		},
-		// 	},
-		// },
+		{
+			name: "WorkspaceStatusThenBuildMetadata",
+			metadataEvents: []*bspb.BuildEvent{
+				&bspb.BuildEvent{
+					Id: &bspb.BuildEventId{Id: &bspb.BuildEventId_Pattern{Pattern: &bspb.BuildEventId_PatternExpandedId{
+						Pattern: []string{"//..."},
+					}}},
+				},
+				&bspb.BuildEvent{
+					Id: &bspb.BuildEventId{Id: &bspb.BuildEventId_WorkspaceStatus{}},
+					Payload: &bspb.BuildEvent_WorkspaceStatus{WorkspaceStatus: &bspb.WorkspaceStatus{
+						Item: []*bspb.WorkspaceStatus_Item{
+							{Key: "REPO_URL", Value: "https://github.com/testowner/testrepo.git"},
+							{Key: "COMMIT_SHA", Value: "0c894fe31c2e91d59cb1a59bb25aaa78089919c2"},
+						},
+					}},
+				},
+				&bspb.BuildEvent{
+					Id: &bspb.BuildEventId{Id: &bspb.BuildEventId_BuildMetadata{}},
+					Payload: &bspb.BuildEvent_BuildMetadata{BuildMetadata: &bspb.BuildMetadata{
+						// Status reporting is only enabled for CI builds.
+						Metadata: map[string]string{"ROLE": "CI"},
+					}},
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			te := testenv.GetTestEnv(t)

--- a/server/build_event_protocol/target_tracker/target_tracker_test.go
+++ b/server/build_event_protocol/target_tracker/target_tracker_test.go
@@ -116,11 +116,7 @@ func (a *fakeAccumulator) ActionName() string {
 	return ""
 }
 
-func (a *fakeAccumulator) WorkspaceIsLoaded() bool {
-	return true
-}
-
-func (a *fakeAccumulator) BuildMetadataIsLoaded() bool {
+func (a *fakeAccumulator) MetadataIsLoaded() bool {
 	return true
 }
 


### PR DESCRIPTION
In https://github.com/buildbuddy-io/buildbuddy-internal/issues/3579 we were reporting incorrect statuses to GitHub after a seemingly harmless change to change the order of build events.

The root issue was that the build status reporter was only reporting a status once the WorkspaceStatus event was loaded, instead of waiting for _all_ declared metadata events.

The "quick fix" was to simply change the order of events so that we publish WorkspaceStatus last. This PR implements a more comprehensive fix, which is to improve how we check whether metadata is fully loaded. Specifically, this PR refactors the build status reporter to use the same logic that we use in the build event handler to decide whether the invocation metadata is ready to be flushed to the DB. This refactor involved moving the "unprocessedStartingEvents" logic into the accumulator so that the build status reporter can access it.

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3579
