### PR TITLE
use time.Ticker in loopAfterTimeout in execution_server

### DIFF
--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -789,13 +789,15 @@ func (s *ExecutionServer) waitExecution(ctx context.Context, req *repb.WaitExecu
 }
 
 func loopAfterTimeout(ctx context.Context, timeout time.Duration, f func()) {
+	ticker := time.NewTicker(timeout)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			{
 				return
 			}
-		case <-time.After(timeout):
+		case <-ticker.C:
 			{
 				f()
 			}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3588
Currently, we are allocating time.Timer in the for loop in loopAfterTimeout. 