### PR TITLE
Don't make a full copy of metadata to extract a single key

### DIFF
--- a/server/rpc/interceptors/interceptors.go
+++ b/server/rpc/interceptors/interceptors.go
@@ -453,11 +453,8 @@ func setClientIdentityStreamClientInterceptor(env environment.Env) grpc.StreamCl
 
 func propagateMetadataFromIncomingToOutgoing(key string) func(context.Context) context.Context {
 	return func(ctx context.Context) context.Context {
-		if md, ok := metadata.FromIncomingContext(ctx); ok {
-			keys := md.Get(key)
-			if len(keys) > 0 {
-				ctx = metadata.AppendToOutgoingContext(ctx, key, keys[len(keys)-1])
-			}
+		if keys := metadata.ValueFromIncomingContext(ctx, key); len(keys) > 0 {
+			ctx = metadata.AppendToOutgoingContext(ctx, key, keys[len(keys)-1])
 		}
 		return ctx
 	}


### PR DESCRIPTION
Metadata can be large so copying the full thing can be costly. If we only need one key, we can just look for that key.