### PR TITLE
And query terms

### DIFF
--- a/codesearch/query/regexp_query.go
+++ b/codesearch/query/regexp_query.go
@@ -311,7 +311,7 @@ func NewReQuery(q string, numResults int) (*ReQuery, error) {
 	if len(sQueries) == 1 {
 		squery = sQueries[0]
 	} else if len(sQueries) > 1 {
-		squery = "(:or " + strings.Join(sQueries, " ") + ")"
+		squery = "(:and " + strings.Join(sQueries, " ") + ")"
 	}
 
 	if len(requiredSClauses) > 0 {

--- a/codesearch/query/regexp_query_test.go
+++ b/codesearch/query/regexp_query_test.go
@@ -78,3 +78,29 @@ func TestFileAtom(t *testing.T) {
 	fieldMatchers := q.TestOnlyFieldMatchers()
 	require.NotContains(t, fieldMatchers, "content")
 }
+
+func TestGroupedTerms(t *testing.T) {
+	q, err := NewReQuery(`"grp trm" case:y`, 1)
+	require.NoError(t, err)
+
+	squery := string(q.SQuery())
+	assert.Contains(t, squery, `(:eq * "grp")`)
+	assert.Contains(t, squery, `(:eq * "trm")`)
+	assert.Contains(t, squery, `(:eq * "p t")`)
+
+	fieldMatchers := q.TestOnlyFieldMatchers()
+	require.Contains(t, fieldMatchers, "content")
+	assert.Contains(t, fieldMatchers["content"].String(), "(grp trm)")
+}
+
+func TestUngroupedTerms(t *testing.T) {
+	q, err := NewReQuery("grp trm case:y", 1)
+	require.NoError(t, err)
+
+	squery := string(q.SQuery())
+	assert.Contains(t, squery, `(:and (:eq * grp) (:eq * trm))`)
+
+	fieldMatchers := q.TestOnlyFieldMatchers()
+	require.Contains(t, fieldMatchers, "content")
+	assert.Contains(t, fieldMatchers["content"].String(), "(grp)|(trm)")
+}

--- a/codesearch/searcher/searcher.go
+++ b/codesearch/searcher/searcher.go
@@ -43,7 +43,7 @@ func (c *CodeSearcher) retrieveDocs(candidateDocIDs []uint64) ([]types.Document,
 	if err := g.Wait(); err != nil {
 		return nil, err
 	}
-	c.log.Infof("Fetching docs took %s", time.Since(start))
+	c.log.Infof("Fetching %d docs took %s", len(candidateDocIDs), time.Since(start))
 	return docs, nil
 }
 


### PR DESCRIPTION
If you query for [Hello World case:y], we want to match docs that contain both "Hello" and "World".

If you query for ["Hello World" case:y], we want to match docs that contain the string "Hello World".