### PR TITLE
Return all fields for (:all)

### DIFF
--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -234,6 +234,7 @@ func handleSearch(args []string) {
 	for _, doc := range docs {
 		regions := highlighter.Highlight(doc)
 		if len(regions) == 0 {
+			log.Warningf("Skipping %q, no regions!!!", doc.Field("filename").Contents())
 			continue
 		}
 

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -307,17 +307,22 @@ func (r *Reader) allDocIDs() (posting.FieldMap, error) {
 	defer iter.Close()
 	resultSet := posting.NewList()
 	k := key{}
+
+	fieldSet := make(map[string]struct{})
 	for iter.First(); iter.Valid(); iter.Next() {
 		if err := k.FromBytes(iter.Key()); err != nil {
 			return nil, err
 		}
+		fieldSet[k.field] = struct{}{}
 		if k.keyType == docField && k.field == types.DocIDField {
 			resultSet.Add(BytesToUint64(iter.Value()))
 		}
 		continue
 	}
 	fm := posting.NewFieldMap()
-	fm.OrField("", resultSet)
+	for fieldName := range fieldSet {
+		fm.OrField(fieldName, resultSet)
+	}
 	return fm, nil
 }
 

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -313,9 +313,10 @@ func (r *Reader) allDocIDs() (posting.FieldMap, error) {
 		if err := k.FromBytes(iter.Key()); err != nil {
 			return nil, err
 		}
-		fieldSet[k.field] = struct{}{}
 		if k.keyType == docField && k.field == types.DocIDField {
 			resultSet.Add(BytesToUint64(iter.Value()))
+		} else {
+			fieldSet[k.field] = struct{}{}
 		}
 		continue
 	}

--- a/codesearch/index/index_test.go
+++ b/codesearch/index/index_test.go
@@ -85,7 +85,7 @@ func TestDeletes(t *testing.T) {
 	r := NewReader(db, "testing-namespace")
 	docIDs, err := r.RawQuery([]byte("(:all)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"": {1, 2, 3}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"name": {1, 2, 3}}, docIDs)
 
 	// Delete a doc
 	w, err = NewWriter(db, "testing-namespace")
@@ -98,7 +98,7 @@ func TestDeletes(t *testing.T) {
 	r = NewReader(db, "testing-namespace")
 	docIDs, err = r.RawQuery([]byte("(:all)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"": {1, 3}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"name": {1, 3}}, docIDs)
 }
 
 func TestIncrementalIndexing(t *testing.T) {
@@ -141,7 +141,7 @@ func TestIncrementalIndexing(t *testing.T) {
 
 	docIDs, err = r.RawQuery([]byte("(:all)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"": {2, 3, 4, 5}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {2, 3, 4, 5}}, docIDs)
 }
 
 func TestUnkonwnTokenType(t *testing.T) {
@@ -239,7 +239,7 @@ func TestNamespaceSeparation(t *testing.T) {
 	r := NewReader(db, "namespace-a")
 	docIDs, err := r.RawQuery([]byte("(:all)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"": {1, 2, 3}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {1, 2, 3}}, docIDs)
 
 	docIDs, err = r.RawQuery([]byte("(:eq text one)"))
 	require.NoError(t, err)
@@ -248,7 +248,7 @@ func TestNamespaceSeparation(t *testing.T) {
 	r = NewReader(db, "namespace-b")
 	docIDs, err = r.RawQuery([]byte("(:all)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"": {1, 2, 3, 4}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {1, 2, 3, 4}}, docIDs)
 
 	docIDs, err = r.RawQuery([]byte("(:eq text pab)"))
 	require.NoError(t, err)
@@ -274,7 +274,7 @@ func TestSQuery(t *testing.T) {
 	r := NewReader(db, "testing-namespace")
 	docIDs, err := r.RawQuery([]byte("(:all)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"": {1, 2, 3}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {1, 2, 3}}, docIDs)
 
 	docIDs, err = r.RawQuery([]byte("(:none)"))
 	require.NoError(t, err)


### PR DESCRIPTION
Before this CL,  a query which triggered the (:all) squery like [s3] would not return matches. This is because while the docs were returned, they had no field matches, so were not scored.

This CL fixes that.