### PR TITLE
fetch_server: support http proxy

### DIFF
--- a/server/remote_asset/fetch_server/fetch_server.go
+++ b/server/remote_asset/fetch_server/fetch_server.go
@@ -91,6 +91,7 @@ func timeoutHTTPClient(ctx context.Context, protoTimeout *durationpb.Duration) *
 			Timeout: timeout,
 		}).Dial,
 		TLSHandshakeTimeout: timeout,
+		Proxy:               http.ProxyFromEnvironment,
 	}
 
 	return &http.Client{


### PR DESCRIPTION
As we start to set

```golang
&http.Transport{
    ...
    Proxy: http.ProxyFromEnvironment,
}
```

It's worth to note that http.ProxyFromEnvironment is initialized only
once and store the proxy result in the package level without a way to
reset it.

So testing this in fetch_server_test.go was not possible, unless we
write our test func at the very top of the file, or shard the test
enough so that each test func gets their own shard.

Instead, implement the test in our integration test setup.

Closes #6966

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
