### PR TITLE
Fix seek /dev/stdout: illegal seek error

### DIFF
--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -65,8 +65,7 @@ func getOutput() (io.WriteCloser, error) {
 	if *outputFile != "" {
 		return os.OpenFile(*outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	}
-	r := &newlineStdoutCloser{os.Stdout}
-	return r, nil
+	return &newlineStdoutCloser{os.Stdout}, nil
 }
 
 func printProtoToOutput(msg proto.Message, output io.Writer) error {

--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -51,21 +51,22 @@ Example of dumping a Command to a file:
 )
 
 type newlineStdoutCloser struct {
-	*os.File
+	io.WriteCloser
 }
 
 func (n *newlineStdoutCloser) Close() error {
-	if isatty.IsTerminal(n.File.Fd()) {
-		n.File.Write([]byte{'\n'})
+	if f, ok := n.WriteCloser.(*os.File); ok && isatty.IsTerminal(f.Fd()) {
+		n.WriteCloser.Write([]byte{'\n'})
 	}
-	return n.File.Close()
+	return n.WriteCloser.Close()
 }
 
 func getOutput() (io.WriteCloser, error) {
 	if *outputFile != "" {
 		return os.OpenFile(*outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	}
-	return &newlineStdoutCloser{os.Stdout}, nil
+	r := &newlineStdoutCloser{os.Stdout}
+	return r, nil
 }
 
 func printProtoToOutput(msg proto.Message, output io.Writer) error {


### PR DESCRIPTION
Without this fix, we may try to seek on stdout, which is not allowed.