### PR TITLE
podman: make podman-static archive deterministic

### DIFF
--- a/enterprise/server/cmd/executor/BUILD
+++ b/enterprise/server/cmd/executor/BUILD
@@ -111,11 +111,13 @@ container_layer(
         ],
         "//conditions:default": [],
     }),
+    tags = ["manual"],
 )
 
 container_layer(
     name = "podman_static_layer",
     directory = "/",
+    tags = ["manual"],
     tars = ["//enterprise/server/remote_execution/containers/podman:podman-static.tar.gz"],
 )
 

--- a/enterprise/server/remote_execution/containers/podman/BUILD
+++ b/enterprise/server/remote_execution/containers/podman/BUILD
@@ -86,6 +86,12 @@ genrule(
         rm "$$TMPDIR/etc/containers/registries.conf"
         cp "$$REGISTRIES_CONF" "$$TMPDIR/etc/containers/registries.conf"
 
-        tar --create --gzip --file="$@" --directory="$$TMPDIR" .
+        tar --create --gzip --file="$@" --directory="$$TMPDIR" --mtime='1970-01-01 00:00:00' .
     """,
+    exec_compatible_with = [
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
 )


### PR DESCRIPTION
The action is poisoned by the creation date of the files on disk.
Fix this by adding `--mtime` to the `tar` packaging command.
Unfortunately this flag is only available on linux version of `tar`, so
restrict the target to only be executed on Linux.

Also ensure that the subsequent image layers are only built lazily to
avoid any extra downloads on our workflows runner.
