### PR TITLE
Ignore error during network cleanup if the route doesn't exist

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1836,6 +1836,7 @@ func (c *FirecrackerContainer) cleanupNetworking(ctx context.Context) error {
 			log.Warningf("Networking cleanup failure. CleanupVethPair for vm id %s failed with: %s", c.id, err)
 			lastErr = err
 		}
+		c.cleanupVethPair = nil
 	}
 	// TODO: move namespace creation into the veth pair networking setup, and
 	// clean it up as part of cleanupVethPair above.

--- a/server/util/networking/networking.go
+++ b/server/util/networking/networking.go
@@ -435,7 +435,9 @@ func SetupVethPair(ctx context.Context, netNamespace, vmIP string, vmIdx int) (_
 	exists, err := routeExists(ctx, cloneIP, cloneEndpointAddr)
 	if err != nil {
 		return nil, err
-	} else if !exists {
+	} else if exists {
+		return nil, status.UnavailableErrorf("ip route %s via %s already exists", cloneIP, cloneEndpointAddr)
+	} else {
 		err = runCommand(ctx, "ip", "route", "add", cloneIP, "via", cloneEndpointAddr)
 		if err != nil {
 			return nil, err
@@ -447,8 +449,6 @@ func SetupVethPair(ctx context.Context, netNamespace, vmIP string, vmIdx int) (_
 			}
 			return nil
 		})
-	} else {
-		log.Debugf("ip route %s via %s already exists", cloneIP, cloneEndpointAddr)
 	}
 
 	if IsSecondaryNetworkEnabled() {

--- a/server/util/networking/networking.go
+++ b/server/util/networking/networking.go
@@ -441,7 +441,11 @@ func SetupVethPair(ctx context.Context, netNamespace, vmIP string, vmIdx int) (_
 			return nil, err
 		}
 		cleanupStack = append(cleanupStack, func(ctx context.Context) error {
-			return runCommand(ctx, "ip", "route", "delete", cloneIP)
+			err := runCommand(ctx, "ip", "route", "delete", cloneIP)
+			if err != nil && !strings.Contains(err.Error(), "No such process") {
+				return err
+			}
+			return nil
 		})
 	} else {
 		log.Debugf("ip route %s via %s already exists", cloneIP, cloneEndpointAddr)


### PR DESCRIPTION
We are getting  vm_network_cleanup_failed alerts because of this

**Related issues**: Example https://buildbuddy-corp.slack.com/archives/C0154UFBCJ2/p1720610696894509
