### PR TITLE
Add self-hosted execution duration usage columns

### DIFF
--- a/server/tables/tables.go
+++ b/server/tables/tables.go
@@ -641,12 +641,14 @@ type UsageCounts struct {
 	// NOTE: New fields added here should be annotated with
 	// `gorm:"not null;default:0"`
 
-	LinuxExecutionDurationUsec int64 `gorm:"not null;default:0"`
-	MacExecutionDurationUsec   int64 `gorm:"not null;default:0"`
-	TotalUploadSizeBytes       int64 `gorm:"not null;default:0"`
-	TotalCachedActionExecUsec  int64 `gorm:"not null;default:0"`
-	CPUNanos                   int64 `gorm:"not null;default:0"`
-	MemoryGBUsec               int64 `gorm:"not null;default:0"`
+	LinuxExecutionDurationUsec           int64 `gorm:"not null;default:0"`
+	MacExecutionDurationUsec             int64 `gorm:"not null;default:0"`
+	SelfHostedLinuxExecutionDurationUsec int64 `gorm:"not null;default:0"`
+	SelfHostedMacExecutionDurationUsec   int64 `gorm:"not null;default:0"`
+	TotalUploadSizeBytes                 int64 `gorm:"not null;default:0"`
+	TotalCachedActionExecUsec            int64 `gorm:"not null;default:0"`
+	CPUNanos                             int64 `gorm:"not null;default:0"`
+	MemoryGBUsec                         int64 `gorm:"not null;default:0"`
 }
 
 type UsageLabels struct {


### PR DESCRIPTION
This is a little silly but probably better than adding more usage labels for now. In "Usage V2" we can plan to collapse all 4 of these columns into a single "ExecutionDuration" column, and have the labels represented in a more compact way (e.g. a foreign key reference to a separate Labels table)

**Related issues**: N/A
