### PR TITLE
invocation suggestion: add compression threshold

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,14 +18,16 @@ common:cache-dev --bes_results_url=https://buildbuddy.buildbuddy.dev/invocation/
 common:cache-dev --bes_backend=grpcs://buildbuddy.buildbuddy.dev
 common:cache-dev --remote_cache=grpcs://buildbuddy.buildbuddy.dev
 common:cache-dev --remote_upload_local_results
-common:cache-dev --experimental_remote_cache_compression
+common:cache-dev --remote_cache_compression
+common:cache-dev --experimental_remote_cache_compression_threshold=100
 
 # Build with --config=cache to send build logs to the production server with cache
 common:cache --bes_results_url=https://buildbuddy.buildbuddy.io/invocation/
 common:cache --bes_backend=grpcs://buildbuddy.buildbuddy.io
 common:cache --remote_cache=grpcs://buildbuddy.buildbuddy.io
 common:cache --remote_upload_local_results
-common:cache --experimental_remote_cache_compression
+common:cache --remote_cache_compression
+common:cache --experimental_remote_cache_compression_threshold=100
 
 # Flags shared across remote configs
 common:remote-shared --remote_upload_local_results
@@ -80,11 +82,13 @@ common:untrusted-ci-windows --flaky_test_attempts=2
 common:untrusted-ci-windows --bes_results_url=https://app.buildbuddy.io/invocation/
 common:untrusted-ci-windows --bes_backend=grpcs://remote.buildbuddy.io
 common:untrusted-ci-windows --remote_cache=grpcs://remote.buildbuddy.io
-common:untrusted-ci-windows --experimental_remote_cache_compression
+common:untrusted-ci-windows --remote_cache_compression
+common:untrusted-ci-windows --experimental_remote_cache_compression_threshold=100
 common:untrusted-ci-windows --remote_upload_local_results
 
 # Configuration used for all BuildBuddy workflows
-common:workflows --experimental_remote_cache_compression
+common:workflows --remote_cache_compression
+common:workflows --experimental_remote_cache_compression_threshold=100
 common:workflows --build_metadata=ROLE=CI
 common:workflows --build_metadata=VISIBILITY=PUBLIC
 common:workflows --remote_instance_name=buildbuddy-io/buildbuddy/workflows

--- a/app/invocation/invocation_suggestion_card.tsx
+++ b/app/invocation/invocation_suggestion_card.tsx
@@ -328,11 +328,11 @@ ${yamlSuggestions.map((s) => `      ${s}`).join("\n")}`}
     if (model.optionsMap.get("experimental_remote_cache_compression")) return null;
     if (!model.optionsMap.get("remote_cache") && !model.optionsMap.get("remote_executor")) return null;
 
-    const versions = getBazelVersion(model);
+    const version = getBazelVersion(model);
     // Bazel pre-v5 doesn't support compression.
-    if (versions === null || versions.major < 5) return null;
+    if (version === null || version.major < 5) return null;
 
-    const flag = versions.major >= 7 ? "--experimental_remote_cache_compression" : "--remote_cache_compression";
+    const flag = version.major >= 7 ? "--experimental_remote_cache_compression" : "--remote_cache_compression";
 
     return {
       level: SuggestionLevel.INFO,
@@ -409,10 +409,10 @@ ${yamlSuggestions.map((s) => `      ${s}`).join("\n")}`}
     if (!model.optionsMap.get("remote_cache")) return null;
     if (model.optionsMap.get("remote_build_event_upload")) return null;
     if (model.optionsMap.get("experimental_remote_build_event_upload")) return null;
-    const versions = getBazelVersion(model);
+    const version = getBazelVersion(model);
     // Bazel pre-v6 doesn't support --experimental_remote_build_event_upload=minimal, and Bazel post-v6 default to the
     // correct setting
-    if (versions === null || versions.major != 6) return null;
+    if (version === null || version.major != 6) return null;
 
     return {
       level: SuggestionLevel.INFO,

--- a/app/invocation/invocation_suggestion_card.tsx
+++ b/app/invocation/invocation_suggestion_card.tsx
@@ -327,23 +327,56 @@ ${yamlSuggestions.map((s) => `      ${s}`).join("\n")}`}
     if (model.optionsMap.get("remote_cache_compression")) return null;
     if (model.optionsMap.get("experimental_remote_cache_compression")) return null;
     if (!model.optionsMap.get("remote_cache") && !model.optionsMap.get("remote_executor")) return null;
-    const version = getBazelMajorVersion(model);
+
+    const versions = getBazelVersion(model);
     // Bazel pre-v5 doesn't support compression.
-    if (version === null || version < 5) return null;
+    if (versions === null || versions.major < 5) return null;
+
+    const flag = versions.major >= 7 ? "--experimental_remote_cache_compression" : "--remote_cache_compression";
 
     return {
       level: SuggestionLevel.INFO,
       message: (
         <>
-          Consider adding the Bazel flag <BazelFlag>--experimental_remote_cache_compression</BazelFlag> to improve
-          remote cache throughput.
+          Consider adding the Bazel flag <BazelFlag>{flag}</BazelFlag> to improve remote cache throughput.
         </>
       ),
       reason: (
         <>
-          Shown because this build is cache-enabled but{" "}
-          <span className="inline-code">--experimental_remote_cache_compression</span> is neither enabled nor explicitly
-          disabled.
+          Shown because this build is cache-enabled but <span className="inline-code">{flag}</span> is neither enabled
+          nor explicitly disabled.
+        </>
+      ),
+    };
+  },
+  ({ model }) => {
+    if (!capabilities.config.expandedSuggestionsEnabled) return null;
+    if (!model.isBazelInvocation()) return null;
+
+    if (model.optionsMap.get("experimental_remote_cache_compression_threshold")) return null;
+    if (
+      !model.optionsMap.get("remote_cache_compression") &&
+      !model.optionsMap.get("experimental_remote_cache_compression")
+    )
+      return null;
+    if (!model.optionsMap.get("remote_cache") && !model.optionsMap.get("remote_executor")) return null;
+
+    const versions = getBazelVersion(model);
+    // threshold flag is available from Bazel 7.1 forward
+    if (versions === null || versions.major < 7 || versions.minor < 1) return null;
+
+    return {
+      level: SuggestionLevel.INFO,
+      message: (
+        <>
+          Consider adding the Bazel flag <BazelFlag>--experimental_remote_cache_compression_threshold=100</BazelFlag> to
+          avoid inflating blobs smaller than 100 bytes with ZSTD compression.
+        </>
+      ),
+      reason: (
+        <>
+          Shown because this build is cache-enabled with <span className="inline-code">--remote_cache_compression</span>{" "}
+          set without <span className="inline-code">--experimental_remote_cache_compression_threshold</span> set.
         </>
       ),
     };
@@ -376,10 +409,10 @@ ${yamlSuggestions.map((s) => `      ${s}`).join("\n")}`}
     if (!model.optionsMap.get("remote_cache")) return null;
     if (model.optionsMap.get("remote_build_event_upload")) return null;
     if (model.optionsMap.get("experimental_remote_build_event_upload")) return null;
-    const version = getBazelMajorVersion(model);
+    const versions = getBazelVersion(model);
     // Bazel pre-v6 doesn't support --experimental_remote_build_event_upload=minimal, and Bazel post-v6 default to the
     // correct setting
-    if (version === null || version != 6) return null;
+    if (versions === null || versions.major != 6) return null;
 
     return {
       level: SuggestionLevel.INFO,
@@ -689,10 +722,14 @@ function InlineProseList({ items }: { items: React.ReactNode[] }) {
   return <>{out}</>;
 }
 
-function getBazelMajorVersion(model: InvocationModel): number | null {
+// getBazelVersion returns the major and minor version of Bazel from BES event.
+//
+// The version could contain rc version in the patch number, such as "7.2.1rc1".
+function getBazelVersion(model: InvocationModel): { major: number; minor: number } | null {
   const version = model.started?.buildToolVersion;
   if (!version) return null;
   const segments = version.split(".").map(Number);
-  if (isNaN(segments[0])) return null;
-  return segments[0];
+  if (segments.length < 2) return null;
+  if (segments.slice(0, 2).some(isNaN)) return null;
+  return { major: segments[0], minor: segments[1] };
 }

--- a/app/invocation/invocation_suggestion_card.tsx
+++ b/app/invocation/invocation_suggestion_card.tsx
@@ -361,9 +361,9 @@ ${yamlSuggestions.map((s) => `      ${s}`).join("\n")}`}
       return null;
     if (!model.optionsMap.get("remote_cache") && !model.optionsMap.get("remote_executor")) return null;
 
-    const versions = getBazelVersion(model);
+    const version = getBazelVersion(model);
     // threshold flag is available from Bazel 7.1 forward
-    if (versions === null || versions.major < 7 || versions.minor < 1) return null;
+    if (version === null || version.major < 7 || version.minor < 1) return null;
 
     return {
       level: SuggestionLevel.INFO,


### PR DESCRIPTION
Reported in https://github.com/bazelbuild/bazel/issues/18997.
Using ZSTD often increases blob size when the blob is smaller than
100 bytes.

Suggest our users to set the threshold to 100 bytes when compression
is enabled.

This flag is only available since 7.1 so refactor getBazelMajorVersion
to emit minor version as well.
