### PR TITLE
Add missing 't' argument to testenv.RegisterLocalGRPCServer

### DIFF
--- a/enterprise/server/remoteauth/remoteauth_test.go
+++ b/enterprise/server/remoteauth/remoteauth_test.go
@@ -61,7 +61,7 @@ func (a *fakeAuthService) Authenticate(ctx context.Context, req *authpb.Authenti
 func setup(t *testing.T) (interfaces.Authenticator, *fakeAuthService) {
 	fakeAuthService := fakeAuthService{}
 	te := testenv.GetTestEnv(t)
-	grpcServer, runServer := testenv.RegisterLocalGRPCServer(te)
+	grpcServer, runServer := testenv.RegisterLocalGRPCServer(t, te)
 	authpb.RegisterAuthServiceServer(grpcServer, &fakeAuthService)
 	go runServer()
 	conn, err := testenv.LocalGRPCConn(context.Background(), te)


### PR DESCRIPTION
**Related issues**: N/A
