### PR TITLE
use time.Ticker instead of time.After in a loop

### DIFF
--- a/enterprise/server/scheduling/task_leaser/task_leaser.go
+++ b/enterprise/server/scheduling/task_leaser/task_leaser.go
@@ -127,11 +127,13 @@ func (t *TaskLeaser) reEnqueueTask(ctx context.Context, reason string) error {
 
 func (t *TaskLeaser) keepLease(ctx context.Context) {
 	go func() {
+		ticker := time.NewTicker(t.ttl)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-t.quit:
 				return
-			case <-time.After(t.ttl):
+			case <-ticker.C:
 				if _, err := t.pingServer(ctx); err != nil {
 					log.CtxWarningf(ctx, "Error updating lease for task: %q: %s", t.taskID, err.Error())
 					t.cancelFunc()

--- a/enterprise/server/scheduling/task_leaser/task_leaser.go
+++ b/enterprise/server/scheduling/task_leaser/task_leaser.go
@@ -127,13 +127,11 @@ func (t *TaskLeaser) reEnqueueTask(ctx context.Context, reason string) error {
 
 func (t *TaskLeaser) keepLease(ctx context.Context) {
 	go func() {
-		ticker := time.NewTicker(t.ttl)
-		defer ticker.Stop()
 		for {
 			select {
 			case <-t.quit:
 				return
-			case <-ticker.C:
+			case <-time.After(t.ttl):
 				if _, err := t.pingServer(ctx); err != nil {
 					log.CtxWarningf(ctx, "Error updating lease for task: %q: %s", t.taskID, err.Error())
 					t.cancelFunc()

--- a/enterprise/server/usage/usage.go
+++ b/enterprise/server/usage/usage.go
@@ -237,9 +237,11 @@ func (ut *tracker) Increment(ctx context.Context, labels *tables.UsageLabels, uc
 func (ut *tracker) StartDBFlush() {
 	go func() {
 		ctx := context.Background()
+		ticker := time.NewTicker(flushInterval)
+		defer ticker.Stop()
 		for {
 			select {
-			case <-time.After(flushInterval):
+			case <-ticker.C:
 				if err := ut.FlushToDB(ctx); err != nil {
 					alert.UnexpectedEvent("usage_data_flush_failed", "Error flushing usage data to DB: %s", err)
 				}

--- a/enterprise/server/util/heartbeat/heartbeat.go
+++ b/enterprise/server/util/heartbeat/heartbeat.go
@@ -77,11 +77,13 @@ func (c *Channel) StartAdvertising() {
 	close(c.quit)
 	c.quit = make(chan struct{})
 	go func() {
+		ticker := time.NewTicker(c.Period)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-c.quit:
 				return
-			case <-time.After(c.Period):
+			case <-ticker.C:
 				c.sendHeartbeat(context.Background())
 			}
 		}

--- a/enterprise/server/util/redisutil/redisutil.go
+++ b/enterprise/server/util/redisutil/redisutil.go
@@ -511,11 +511,13 @@ func (c *CommandBuffer) StartPeriodicFlush(ctx context.Context) {
 
 	c.stopFlush = make(chan struct{})
 	go func() {
+		ticker := time.NewTicker(*commandBufferFlushPeriod)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-c.stopFlush:
 				return
-			case <-time.After(*commandBufferFlushPeriod):
+			case <-ticker.C:
 				if err := c.Flush(ctx); err != nil {
 					log.Errorf("Failed to flush Redis command buffer: %s", err)
 				}

--- a/server/util/approxlru/approxlru.go
+++ b/server/util/approxlru/approxlru.go
@@ -363,11 +363,13 @@ func (l *LRU[T]) ttl() error {
 }
 
 func (l *LRU[T]) evictor() {
+	ticker := time.NewTicker(evictCheckPeriod)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-l.ctx.Done():
 			return
-		case <-time.After(evictCheckPeriod):
+		case <-ticker.C:
 			if err := l.ttl(); err != nil {
 				log.Warningf("could not evict: %s", err)
 			}

--- a/server/util/healthcheck/healthcheck.go
+++ b/server/util/healthcheck/healthcheck.go
@@ -74,11 +74,13 @@ func NewHealthChecker(serverType string) *HealthChecker {
 	signal.Notify(sigTerm, os.Interrupt, syscall.SIGTERM)
 	go hc.handleShutdownFuncs()
 	go func() {
+		ticker := time.NewTicker(healthCheckPeriod)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-hc.quit:
 				return
-			case <-time.After(healthCheckPeriod):
+			case <-ticker.C:
 				hc.runHealthChecks(context.Background())
 			}
 		}


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: https://github.com/buildbuddy-io/buildbuddy-internal/issues/3588
to avoid unnecessary time.Timer allocations in background. 