### PR TITLE
Revert "Upgrade firecracker to v1.8.0"

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6822,9 +6822,9 @@ def install_static_dependencies(workspace_name = "buildbuddy"):
             'package(default_visibility = ["//visibility:public"])',
             'filegroup(name = "firecracker", srcs = ["release-{release}/firecracker-{release}"])',
             'filegroup(name = "jailer", srcs = ["release-{release}/jailer-{release}"])',
-        ]).format(release = "v1.8.0-x86_64"),
-        sha256 = "bc899bdaef8d0aa7b0fafbf49a2bf647e0298558f4faee44970d87a1c6d1ae2d",
-        urls = ["https://github.com/firecracker-microvm/firecracker/releases/download/v1.8.0/firecracker-v1.8.0-x86_64.tgz"],
+        ]).format(release = "v1.7.0-x86_64"),
+        sha256 = "55bd3e6d599fdd108e36e52f9aee2319f06c18a90f2fa49b64e93fdf06f5ff53",
+        urls = ["https://github.com/firecracker-microvm/firecracker/releases/download/v1.7.0/firecracker-v1.7.0-x86_64.tgz"],
     )
     http_archive(
         name = "com_github_containerd_stargz_snapshotter-v0.11.4-linux-amd64",


### PR DESCRIPTION
Reverts buildbuddy-io/buildbuddy#7016

Dev probers are down - seeing a lot of "context deadline exceeded in the logs", "IP-Config: Unable to set interface netmask (-22)" in one kernel log