### PR TITLE
Subtract full-stall duration from exec wall time in milliCPU calculation

### DIFF
--- a/enterprise/server/tasksize/tasksize_test.go
+++ b/enterprise/server/tasksize/tasksize_test.go
@@ -3,6 +3,7 @@ package tasksize_test
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -145,6 +146,18 @@ func TestSizer_Get_ShouldReturnRecordedUsageStats(t *testing.T) {
 			// just returning the default estimates.
 			CpuNanos:        7.13 * 1e9,
 			PeakMemoryBytes: 917 * 1e6,
+			// The *sum* of all of the full-stall total durations should be
+			// subtracted from the execution duration for the purposes of the
+			// milliCPU calculation.
+			CpuPressure: &repb.PSI{
+				Full: &repb.PSI_Metrics{Total: 0.33 * 1e6 /*usec*/},
+			},
+			IoPressure: &repb.PSI{
+				Full: &repb.PSI_Metrics{Total: 0.21 * 1e6 /*usec*/},
+			},
+			MemoryPressure: &repb.PSI{
+				Full: &repb.PSI_Metrics{Total: 0.07 * 1e6 /*usec*/},
+			},
 		},
 		ExecutionStartTimestamp: timestamppb.New(execStart),
 		// Set the completed timestamp so that the exec duration is 2 seconds.
@@ -160,7 +173,7 @@ func TestSizer_Get_ShouldReturnRecordedUsageStats(t *testing.T) {
 		t, int64(917*1e6), ts.GetEstimatedMemoryBytes(),
 		"subsequent mem estimate should equal recorded peak mem usage")
 	assert.Equal(
-		t, int64(7.13/2*1000), ts.GetEstimatedMilliCpu(),
+		t, int64(math.Ceil(7.13/(2.0-(0.33+0.21+0.07))*1000.0)), ts.GetEstimatedMilliCpu(),
 		"subsequent milliCPU estimate should equal recorded milliCPU")
 }
 


### PR DESCRIPTION
When a task is fully-stalled on a resource according to cgroup PSI metrics, the task is trying to use that resource, but can't due to contention. This winds up increasing the execution duration, which decreases the calculated milli-CPU, since the execution duration is in the denominator in the milli-CPU calculation: `milliCPU = (cpuNanos / 1e6) / execDurationMicros`. This is not ideal, because it means that contention will cause us to size tasks smaller, which results in even more contention (a negative feedback cycle).

So, in order to improve the accuracy of our reported duration, we can subtract the full stall duration (wall time, in usec) from the denominator in the average milliCPU calculation (CPU-milliseconds used per second of execution wall time). More specifically, we subtract the _sum_ of the measured CPU, IO, and memory full-stall durations. This effectively changes the denominator from "execution wall time" to "_active_ execution wall time" - i.e. at least one thread in the task is making progress.

Note that it's valid to take the sum of these durations because they don't overlap, as tasks can only be stalled on one resource at a time. For example, if a task is fully stalled on IO, then all threads must be in IO wait state, which doesn't actively consume CPU. So that means that if all threads are stalled on IO, then no threads are stalled on CPU.

Also note that using only the "full" stall time is not perfect - for example, if 1 thread is stalled but another isn't, then we'll accumulate some inaccuracy. But this should at least yield more accurate task sizing info than what we have today.

**Related issues**: N/A
