### PR TITLE
Report podman overhead in execution stats

### DIFF
--- a/enterprise/server/remote_execution/commandutil/BUILD
+++ b/enterprise/server/remote_execution/commandutil/BUILD
@@ -12,20 +12,14 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/commandutil",
     deps = [
         "//enterprise/server/util/procstats",
+        "//proto:execution_stats_go_proto",
         "//proto:remote_execution_go_proto",
         "//server/interfaces",
         "//server/util/log",
         "//server/util/status",
         "@com_github_mitchellh_go_ps//:go-ps",
     ] + select({
-        "@io_bazel_rules_go//go/platform:darwin": [
-            "//proto:execution_stats_go_proto",
-        ],
-        "@io_bazel_rules_go//go/platform:linux": [
-            "//proto:execution_stats_go_proto",
-        ],
         "@io_bazel_rules_go//go/platform:windows": [
-            "//proto:execution_stats_go_proto",
             "@com_github_shirou_gopsutil_v3//process",
             "@org_golang_x_sys//windows",
         ],

--- a/enterprise/server/test/integration/podman/BUILD
+++ b/enterprise/server/test/integration/podman/BUILD
@@ -43,7 +43,6 @@ go_test(
         "//server/testutil/testenv",
         "//server/testutil/testfs",
         "//server/util/status",
-        "//server/util/testing/flags",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_bazel_rules_go//go/runfiles:go_default_library",


### PR DESCRIPTION
Make sure that the reported CPU time includes the CPU time spent in the `podman run` command itself, and not just the child processes in the spawned container. On my local machine this adds about 60ms of additional reported CPU time for each command. This should significantly improve the task sizing accuracy for commands where podman itself accounts for most of the runtime.

**Related issues**: N/A
