### PR TITLE
Improve "matched docs" interface (returning maps stinks)

### DIFF
--- a/codesearch/cmd/cli/cli.go
+++ b/codesearch/cmd/cli/cli.go
@@ -276,26 +276,26 @@ func handleSquery(args []string) {
 	defer db.Close()
 
 	ir := index.NewReader(db, getNamespace())
-	fieldMapPostings, err := ir.RawQuery(pat)
+	matches, err := ir.RawQuery(pat)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
 
 	allDocIDs := make([]uint64, 0)
-	for _, docIDs := range fieldMapPostings {
-		allDocIDs = append(allDocIDs, docIDs...)
+	for _, match := range matches {
+		allDocIDs = append(allDocIDs, match.Docid())
 	}
 	slices.Sort(allDocIDs)
 	docIDs := slices.Compact(allDocIDs)
 	numDocs := len(docIDs)
 
 	docFields := make(map[uint64][]string, numDocs)
-	for fieldName, docs := range fieldMapPostings {
-		if len(fieldName) == 0 {
-			continue
-		}
-		for _, docid := range docs {
-			docFields[docid] = append(docFields[docid], fieldName)
+	for _, match := range matches {
+		for _, fieldName := range match.FieldNames() {
+			if len(fieldName) == 0 {
+				continue
+			}
+			docFields[match.Docid()] = append(docFields[match.Docid()], fieldName)
 		}
 	}
 	for _, docID := range docIDs {

--- a/codesearch/index/BUILD
+++ b/codesearch/index/BUILD
@@ -17,7 +17,7 @@ go_library(
         "@com_github_google_uuid//:uuid",
         "@com_github_xiam_s_expr//ast",
         "@com_github_xiam_s_expr//parser",
-        "@org_golang_x_exp//slices",
+        "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -555,17 +555,18 @@ func (r *Reader) removeDeletedDocIDs(results posting.FieldMap) error {
 }
 
 type docMatch struct {
-     docid uint64
-     matchedPostings map[string]types.Posting
+	docid           uint64
+	matchedPostings map[string]types.Posting
 }
+
 func (dm *docMatch) FieldNames() []string {
-     return maps.Keys(dm.matchedPostings)
+	return maps.Keys(dm.matchedPostings)
 }
 func (dm *docMatch) Docid() uint64 {
-     return dm.docid
+	return dm.docid
 }
 func (dm *docMatch) Posting(fieldName string) types.Posting {
-     return dm.matchedPostings[fieldName]
+	return dm.matchedPostings[fieldName]
 }
 
 type lazyDoc struct {
@@ -596,8 +597,8 @@ func (d lazyDoc) Fields() []string {
 
 func (r *Reader) newLazyDoc(docid uint64) *lazyDoc {
 	return &lazyDoc{
-		r: r,
-		id: docid,
+		r:      r,
+		id:     docid,
 		fields: make(map[string]types.NamedField, 0),
 	}
 }
@@ -626,14 +627,14 @@ func (r *Reader) RawQuery(squery []byte) ([]types.DocumentMatch, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	fieldDocidMatches := bm.Map()
 	docMatches := make(map[uint64]*docMatch, 0)
 	for field, docids := range fieldDocidMatches {
 		for _, docid := range docids {
 			if _, ok := docMatches[docid]; !ok {
 				docMatches[docid] = &docMatch{
-					docid:docid,
+					docid:           docid,
 					matchedPostings: make(map[string]types.Posting),
 				}
 			}

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -634,7 +634,7 @@ func (r *Reader) RawQuery(squery []byte) ([]types.DocumentMatch, error) {
 				}
 			}
 			docMatch := docMatches[docid]
-			docMatch.matchedPostings[field] = nil
+			docMatch.matchedPostings[field] = nil // TODO(tylerw): fill in.
 		}
 	}
 

--- a/codesearch/index/index.go
+++ b/codesearch/index/index.go
@@ -376,12 +376,8 @@ func (r *Reader) getStoredFields(docID uint64, fieldNames ...string) (map[string
 	return fields, nil
 }
 
-func (r *Reader) GetStoredDocument(docID uint64, fieldNames ...string) (types.Document, error) {
-	fields, err := r.getStoredFields(docID, fieldNames...)
-	if err != nil {
-		return nil, err
-	}
-	return types.NewMapDocument(docID, fields), nil
+func (r *Reader) GetStoredDocument(docID uint64) (types.Document, error) {
+	return r.newLazyDoc(docID), nil
 }
 
 // postingList looks up the set of docIDs matching the provided ngram.
@@ -628,10 +624,9 @@ func (r *Reader) RawQuery(squery []byte) ([]types.DocumentMatch, error) {
 		return nil, err
 	}
 
-	fieldDocidMatches := bm.Map()
 	docMatches := make(map[uint64]*docMatch, 0)
-	for field, docids := range fieldDocidMatches {
-		for _, docid := range docids {
+	for field, pl := range bm {
+		for _, docid := range pl.ToArray() {
 			if _, ok := docMatches[docid]; !ok {
 				docMatches[docid] = &docMatch{
 					docid:           docid,

--- a/codesearch/index/index_test.go
+++ b/codesearch/index/index_test.go
@@ -3,6 +3,7 @@ package index
 import (
 	"fmt"
 	"hash/fnv"
+	"slices"
 	"testing"
 
 	"github.com/buildbuddy-io/buildbuddy/codesearch/types"
@@ -51,6 +52,10 @@ func extractFieldMatches(docMatches []types.DocumentMatch) map[string][]uint64 {
 		for _, fieldName := range docMatch.FieldNames() {
 			m[fieldName] = append(m[fieldName], docMatch.Docid())
 		}
+	}
+
+	for _, v := range m {
+		slices.Sort(v)
 	}
 	return m
 }

--- a/codesearch/index/index_test.go
+++ b/codesearch/index/index_test.go
@@ -45,6 +45,16 @@ func docWithIDAndText(id uint64, text string) types.Document {
 	)
 }
 
+func extractFieldMatches(docMatches []types.DocumentMatch) map[string][]uint64 {
+	m := make(map[string][]uint64)
+	for _, docMatch := range docMatches {
+		for _, fieldName := range docMatch.FieldNames() {
+			m[fieldName] = append(m[fieldName], docMatch.Docid())
+		}
+	}
+	return m
+}
+
 func TestInvalidFieldNames(t *testing.T) {
 	indexDir := testfs.MakeTempDir(t)
 	db, err := pebble.Open(indexDir, nil)
@@ -83,9 +93,9 @@ func TestDeletes(t *testing.T) {
 	require.NoError(t, w.Flush())
 
 	r := NewReader(db, "testing-namespace")
-	docIDs, err := r.RawQuery([]byte("(:all)"))
+	matches, err := r.RawQuery([]byte("(:all)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"name": {1, 2, 3}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"name": {1, 2, 3}}, extractFieldMatches(matches))
 
 	// Delete a doc
 	w, err = NewWriter(db, "testing-namespace")
@@ -96,9 +106,9 @@ func TestDeletes(t *testing.T) {
 	require.NoError(t, w.Flush())
 
 	r = NewReader(db, "testing-namespace")
-	docIDs, err = r.RawQuery([]byte("(:all)"))
+	matches, err = r.RawQuery([]byte("(:all)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"name": {1, 3}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"name": {1, 3}}, extractFieldMatches(matches))
 }
 
 func TestIncrementalIndexing(t *testing.T) {
@@ -119,9 +129,9 @@ func TestIncrementalIndexing(t *testing.T) {
 	require.NoError(t, w.Flush())
 
 	r := NewReader(db, "testing-namespace")
-	docIDs, err := r.RawQuery([]byte("(:eq text one)"))
+	matches, err := r.RawQuery([]byte("(:eq text one)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"text": {1}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {1}}, extractFieldMatches(matches))
 
 	// Now add some docs and delete others and ensure the returned results
 	// are as expected.
@@ -135,13 +145,13 @@ func TestIncrementalIndexing(t *testing.T) {
 	require.NoError(t, w.Flush())
 
 	r = NewReader(db, "testing-namespace")
-	docIDs, err = r.RawQuery([]byte("(:eq text one)"))
+	matches, err = r.RawQuery([]byte("(:eq text one)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"text": {5}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {5}}, extractFieldMatches(matches))
 
-	docIDs, err = r.RawQuery([]byte("(:all)"))
+	matches, err = r.RawQuery([]byte("(:all)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"text": {2, 3, 4, 5}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {2, 3, 4, 5}}, extractFieldMatches(matches))
 }
 
 func TestUnkonwnTokenType(t *testing.T) {
@@ -189,19 +199,19 @@ func TestStoredVsUnstoredFields(t *testing.T) {
 
 	// docs should be searchable by stored fields
 	r := NewReader(db, "testing-namespace")
-	docIDs, err := r.RawQuery([]byte(`(:eq field_a stored)`))
+	matches, err := r.RawQuery([]byte(`(:eq field_a stored)`))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"field_a": {1}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"field_a": {1}}, extractFieldMatches(matches))
 
 	// docs should be searchable by non-stored fields
-	docIDs, err = r.RawQuery([]byte(`(:eq field_b unstored)`))
+	matches, err = r.RawQuery([]byte(`(:eq field_b unstored)`))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"field_b": {1}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"field_b": {1}}, extractFieldMatches(matches))
 
 	// docs should be searchable by both stored and non-stored fields
-	docIDs, err = r.RawQuery([]byte(`(:or (:eq field_b unstored) (:eq field_a stored))`))
+	matches, err = r.RawQuery([]byte(`(:or (:eq field_b unstored) (:eq field_a stored))`))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"field_b": {1}, "field_a": {1}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"field_b": {1}, "field_a": {1}}, extractFieldMatches(matches))
 
 	// stored document should only contain stored fields
 	rdoc, err := r.GetStoredDocument(1)
@@ -237,22 +247,22 @@ func TestNamespaceSeparation(t *testing.T) {
 	require.NoError(t, w.Flush())
 
 	r := NewReader(db, "namespace-a")
-	docIDs, err := r.RawQuery([]byte("(:all)"))
+	matches, err := r.RawQuery([]byte("(:all)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"text": {1, 2, 3}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {1, 2, 3}}, extractFieldMatches(matches))
 
-	docIDs, err = r.RawQuery([]byte("(:eq text one)"))
+	matches, err = r.RawQuery([]byte("(:eq text one)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"text": {1}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {1}}, extractFieldMatches(matches))
 
 	r = NewReader(db, "namespace-b")
-	docIDs, err = r.RawQuery([]byte("(:all)"))
+	matches, err = r.RawQuery([]byte("(:all)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"text": {1, 2, 3, 4}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {1, 2, 3, 4}}, extractFieldMatches(matches))
 
-	docIDs, err = r.RawQuery([]byte("(:eq text pab)"))
+	matches, err = r.RawQuery([]byte("(:eq text pab)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"text": {4}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {4}}, extractFieldMatches(matches))
 }
 
 func TestSQuery(t *testing.T) {
@@ -272,29 +282,29 @@ func TestSQuery(t *testing.T) {
 	require.NoError(t, w.Flush())
 
 	r := NewReader(db, "testing-namespace")
-	docIDs, err := r.RawQuery([]byte("(:all)"))
+	matches, err := r.RawQuery([]byte("(:all)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"text": {1, 2, 3}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {1, 2, 3}}, extractFieldMatches(matches))
 
-	docIDs, err = r.RawQuery([]byte("(:none)"))
+	matches, err = r.RawQuery([]byte("(:none)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{}, docIDs)
+	assert.Equal(t, map[string][]uint64{}, extractFieldMatches(matches))
 
-	docIDs, err = r.RawQuery([]byte("(:eq text one)"))
+	matches, err = r.RawQuery([]byte("(:eq text one)"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"text": {1}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {1}}, extractFieldMatches(matches))
 
-	docIDs, err = r.RawQuery([]byte("(:or (:eq text one) (:eq text bar))"))
+	matches, err = r.RawQuery([]byte("(:or (:eq text one) (:eq text bar))"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"text": {1, 2}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {1, 2}}, extractFieldMatches(matches))
 
-	docIDs, err = r.RawQuery([]byte("(:eq text \" ba\")"))
+	matches, err = r.RawQuery([]byte("(:eq text \" ba\")"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"text": {2, 3}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {2, 3}}, extractFieldMatches(matches))
 
-	docIDs, err = r.RawQuery([]byte("(:and (:eq text \" ba\") (:eq text two))"))
+	matches, err = r.RawQuery([]byte("(:and (:eq text \" ba\") (:eq text two))"))
 	require.NoError(t, err)
-	assert.Equal(t, map[string][]uint64{"text": {2}}, docIDs)
+	assert.Equal(t, map[string][]uint64{"text": {2}}, extractFieldMatches(matches))
 
 	_, err = r.RawQuery([]byte("(:and (:)")) // invalid q
 	require.Error(t, err)

--- a/codesearch/posting/posting.go
+++ b/codesearch/posting/posting.go
@@ -168,13 +168,6 @@ func (fm *FieldMap) Remove(docid uint64) {
 		pl.Remove(docid)
 	}
 }
-func (fm *FieldMap) Map() map[string][]uint64 {
-	m := make(map[string][]uint64)
-	for f, pl := range *fm {
-		m[f] = pl.ToArray()
-	}
-	return m
-}
 
 type uint64PostingSet map[uint64]struct{}
 

--- a/codesearch/posting/posting_test.go
+++ b/codesearch/posting/posting_test.go
@@ -89,7 +89,7 @@ func TestClear(t *testing.T) {
 func TestFieldMap(t *testing.T) {
 	fm := posting.NewFieldMap()
 	fm.OrField("test", posting.NewList(1, 2, 3, 4, 5))
-	assert.Equal(t, map[string][]uint64{"test": []uint64{1, 2, 3, 4, 5}}, fm.Map())
+	assert.Equal(t, []uint64{1, 2, 3, 4, 5}, fm["test"].ToArray())
 }
 
 func TestFieldMapOr(t *testing.T) {
@@ -103,12 +103,9 @@ func TestFieldMapOr(t *testing.T) {
 	fm2.OrField("test3", posting.NewList(7, 8))
 	fm.Or(fm2)
 
-	want := map[string][]uint64{
-		"test":  []uint64{1, 2, 3, 4},
-		"test2": []uint64{3, 4, 5, 6},
-		"test3": []uint64{7, 8},
-	}
-	assert.Equal(t, want, fm.Map())
+	assert.Equal(t, []uint64{1, 2, 3, 4}, fm["test"].ToArray())
+	assert.Equal(t, []uint64{3, 4, 5, 6}, fm["test2"].ToArray())
+	assert.Equal(t, []uint64{7, 8}, fm["test3"].ToArray())
 }
 
 func TestFieldMapAnd(t *testing.T) {
@@ -119,9 +116,6 @@ func TestFieldMapAnd(t *testing.T) {
 	fm2.OrField("test2", posting.NewList(2, 4))
 	fm.And(fm2)
 
-	want := map[string][]uint64{
-		"test":  []uint64{2},
-		"test2": []uint64{2},
-	}
-	assert.Equal(t, want, fm.Map())
+	assert.Equal(t, []uint64{2}, fm["test"].ToArray())
+	assert.Equal(t, []uint64{2}, fm["test2"].ToArray())
 }

--- a/codesearch/query/regexp_query.go
+++ b/codesearch/query/regexp_query.go
@@ -74,7 +74,7 @@ func match(re *regexp.Regexp, buf []byte) []region {
 	return results
 }
 
-func (s *reScorer) Score(doc types.Document) float64 {
+func (s *reScorer) Score(docMatch types.DocumentMatch) float64 {
 	docScore := 0.0
 	for _, fieldName := range doc.Fields() {
 		re, ok := s.fieldMatchers[fieldName]

--- a/codesearch/query/regexp_query.go
+++ b/codesearch/query/regexp_query.go
@@ -74,9 +74,9 @@ func match(re *regexp.Regexp, buf []byte) []region {
 	return results
 }
 
-func (s *reScorer) Score(docMatch types.DocumentMatch) float64 {
+func (s *reScorer) Score(docMatch types.DocumentMatch, doc types.Document) float64 {
 	docScore := 0.0
-	for _, fieldName := range doc.Fields() {
+	for _, fieldName := range docMatch.FieldNames() {
 		re, ok := s.fieldMatchers[fieldName]
 		if !ok {
 			continue

--- a/codesearch/types/types.go
+++ b/codesearch/types/types.go
@@ -70,13 +70,13 @@ type IndexWriter interface {
 }
 
 type IndexReader interface {
-	GetStoredDocument(docID uint64, fieldNames ...string) (Document, error)
+	GetStoredDocument(docID uint64) (Document, error)
 	RawQuery(squery []byte) ([]DocumentMatch, error)
 }
 
 type Scorer interface {
 	Skip() bool
-	Score(docMatch DocumentMatch) float64
+	Score(docMatch DocumentMatch, doc Document) float64
 }
 
 type HighlightedRegion interface {

--- a/codesearch/types/types.go
+++ b/codesearch/types/types.go
@@ -46,6 +46,18 @@ type Token interface {
 	Position() uint64
 }
 
+type Posting interface {
+       Docid() uint64
+       Positions() []uint64
+       Merge(Posting)
+}
+
+type DocumentMatch interface {
+       Docid() uint64
+       FieldNames() []string
+       Posting(fieldName string) Posting
+}
+
 type Tokenizer interface {
 	Reset(io.Reader)
 	Next() (Token, error)
@@ -59,12 +71,12 @@ type IndexWriter interface {
 
 type IndexReader interface {
 	GetStoredDocument(docID uint64, fieldNames ...string) (Document, error)
-	RawQuery(squery []byte) (map[string][]uint64, error)
+	RawQuery(squery []byte) ([]DocumentMatch, error)
 }
 
 type Scorer interface {
 	Skip() bool
-	Score(doc Document) float64
+	Score(docMatch DocumentMatch) float64
 }
 
 type HighlightedRegion interface {

--- a/codesearch/types/types.go
+++ b/codesearch/types/types.go
@@ -47,15 +47,15 @@ type Token interface {
 }
 
 type Posting interface {
-       Docid() uint64
-       Positions() []uint64
-       Merge(Posting)
+	Docid() uint64
+	Positions() []uint64
+	Merge(Posting)
 }
 
 type DocumentMatch interface {
-       Docid() uint64
-       FieldNames() []string
-       Posting(fieldName string) Posting
+	Docid() uint64
+	FieldNames() []string
+	Posting(fieldName string) Posting
 }
 
 type Tokenizer interface {


### PR DESCRIPTION
Return a slice of DocumentMatch interfaces from IndexReader RawQuery.

Each DocumentMatch tells you the docID that was matched, which fields match, and (eventually) the posting with offsets for the matches. This allows for much faster scoring.