### PR TITLE
Don't use io.ReadAll in distributed.go

### DIFF
--- a/enterprise/server/backends/distributed/distributed.go
+++ b/enterprise/server/backends/distributed/distributed.go
@@ -1080,7 +1080,9 @@ func (c *Cache) Get(ctx context.Context, rn *rspb.ResourceName) ([]byte, error) 
 		return nil, err
 	}
 	defer r.Close()
-	return io.ReadAll(r)
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(r)
+	return buf.Bytes(), err
 }
 
 func (c *Cache) GetMulti(ctx context.Context, resources []*rspb.ResourceName) (map[*repb.Digest][]byte, error) {


### PR DESCRIPTION
I noticed io.ReadAll in a heap trace and I think it's possible that we're over-allocating when reading a Reader into a []byte buf in the cache.Get call.

<img width="195" alt="image" src="https://github.com/user-attachments/assets/49185037-27f1-4173-9654-de8bcf2872eb">

[io.ReadAll](https://cs.opensource.google/go/go/+/master:src/io/io.go;l=710?q=io.ReadAll) internally allocates a 512 byte buffer for performing the copy

[byte.Buffer](https://cs.opensource.google/go/go/+/master:src/bytes/buffer.go;l=16?q=bytes.Buffer) internally allocates a 64 byte buffer and grows it as needed. I believe that for small blobs, this should be more efficient.