### PR TITLE
Fix some bugs with VM network setup

### DIFF
--- a/server/util/networking/BUILD
+++ b/server/util/networking/BUILD
@@ -19,9 +19,12 @@ go_library(
 go_test(
     name = "networking_test",
     srcs = ["networking_test.go"],
+    tags = ["no-sandbox"],
     deps = [
         ":networking",
+        "//server/util/uuid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_sync//errgroup",
     ],
 )


### PR DESCRIPTION
* Ensure that the veth pair is deleted synchronously. We were previously relying on it to be cleaned up as part of `RemoveNetNamespace`, but it turns out that `ip netns delete` only deletes the namespace itself synchronously - the resources in the namespace are cleaned up in the background.
* For the namespaced end of the veth pair, use `netIdx` (the locked index) instead of `vmIdx`. The comment `// Can be anything because it's in a namespace` was inaccurate - the IP address of the namespaced side of the veth pair is reachable from the host, so it must also be unique on the host. This can be verified by hard-coding `vmIdx` to 0 which causes the test to fail.
  * In a follow-up PR I would like to get rid of `vmIdx` entirely - it's not really needed now that we have the separate `netIdx` concept. The network allocator can keep the index counter internally.
* Remove `routeExists` logic, since it can paper over potential bugs with networking cleanup.

**Related issues**: N/A
