### PR TITLE
Use postings throughout

### DIFF
--- a/codesearch/posting/BUILD
+++ b/codesearch/posting/BUILD
@@ -5,7 +5,10 @@ go_library(
     srcs = ["posting.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/codesearch/posting",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_x_exp//maps"],
+    deps = [
+        "//codesearch/types",
+        "@org_golang_x_exp//maps",
+    ],
 )
 
 go_test(

--- a/codesearch/posting/posting_test.go
+++ b/codesearch/posting/posting_test.go
@@ -7,67 +7,76 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func docidArray(pl posting.List) []uint64 {
+	arr := pl.ToArray()
+	docids := make([]uint64, len(arr))
+	for i, p := range arr {
+		docids[i] = p.Docid()
+	}
+	return docids
+}
+
 func TestAdd(t *testing.T) {
 	pl := posting.NewList()
-	pl.Add(3)
-	pl.Add(3)
-	pl.Add(3)
-	pl.Add(1)
-	pl.Add(2)
-	pl.Add(2)
+	pl.Add(posting.New(3))
+	pl.Add(posting.New(3))
+	pl.Add(posting.New(3))
+	pl.Add(posting.New(1))
+	pl.Add(posting.New(2))
+	pl.Add(posting.New(2))
 
-	assert.Equal(t, []uint64{1, 2, 3}, pl.ToArray())
+	assert.Equal(t, []uint64{1, 2, 3}, docidArray(pl))
 }
 
 func TestOr(t *testing.T) {
 	pl := posting.NewList()
-	pl.Add(1)
-	pl.Add(2)
+	pl.Add(posting.New(1))
+	pl.Add(posting.New(2))
 
 	pl2 := posting.NewList()
-	pl2.Add(3)
-	pl2.Add(4)
+	pl2.Add(posting.New(3))
+	pl2.Add(posting.New(4))
 
 	pl.Or(pl2)
-	assert.Equal(t, []uint64{1, 2, 3, 4}, pl.ToArray())
+	assert.Equal(t, []uint64{1, 2, 3, 4}, docidArray(pl))
 }
 
 func TestAnd(t *testing.T) {
 	pl := posting.NewList()
-	pl.Add(1)
-	pl.Add(2)
-	pl.Add(3)
+	pl.Add(posting.New(1))
+	pl.Add(posting.New(2))
+	pl.Add(posting.New(3))
 
 	pl2 := posting.NewList()
-	pl2.Add(3)
-	pl2.Add(4)
-	pl2.Add(5)
+	pl2.Add(posting.New(3))
+	pl2.Add(posting.New(4))
+	pl2.Add(posting.New(5))
 
 	pl.And(pl2)
-	assert.Equal(t, []uint64{3}, pl.ToArray())
+	assert.Equal(t, []uint64{3}, docidArray(pl))
 }
 
 func TestRemove(t *testing.T) {
 	pl := posting.NewList()
-	pl.Add(1)
-	pl.Add(2)
-	pl.Add(3)
-	pl.Add(4)
-	pl.Add(5)
+	pl.Add(posting.New(1))
+	pl.Add(posting.New(2))
+	pl.Add(posting.New(3))
+	pl.Add(posting.New(4))
+	pl.Add(posting.New(5))
 	pl.Remove(3)
 
-	assert.Equal(t, []uint64{1, 2, 4, 5}, pl.ToArray())
+	assert.Equal(t, []uint64{1, 2, 4, 5}, docidArray(pl))
 }
 
 func TestAddMany(t *testing.T) {
-	pl := posting.NewList(3, 4, 5)
-	pl.Add(1)
-	pl.Add(2)
-	assert.Equal(t, []uint64{1, 2, 3, 4, 5}, pl.ToArray())
+	pl := posting.NewList(posting.New(3), posting.New(4), posting.New(5))
+	pl.Add(posting.New(1))
+	pl.Add(posting.New(2))
+	assert.Equal(t, []uint64{1, 2, 3, 4, 5}, docidArray(pl))
 }
 
 func TestMarshal(t *testing.T) {
-	pl := posting.NewList(1, 2, 3, 4, 5)
+	pl := posting.NewList(posting.New(1), posting.New(2), posting.New(3), posting.New(4), posting.New(5))
 	buf, err := pl.Marshal()
 	assert.NoError(t, err)
 
@@ -75,47 +84,48 @@ func TestMarshal(t *testing.T) {
 	_, err = pl2.Unmarshal(buf)
 	assert.NoError(t, err)
 
-	assert.Equal(t, []uint64{1, 2, 3, 4, 5}, pl.ToArray())
-	assert.Equal(t, []uint64{1, 2, 3, 4, 5}, pl2.ToArray())
+	assert.Equal(t, []uint64{1, 2, 3, 4, 5}, docidArray(pl))
+	assert.Equal(t, []uint64{1, 2, 3, 4, 5}, docidArray(pl2))
 }
 
 func TestClear(t *testing.T) {
-	pl := posting.NewList(1, 2, 3, 4, 5)
-	assert.Equal(t, []uint64{1, 2, 3, 4, 5}, pl.ToArray())
+	pl := posting.NewList(posting.New(1), posting.New(2), posting.New(3), posting.New(4), posting.New(5))
+	assert.Equal(t, []uint64{1, 2, 3, 4, 5}, docidArray(pl))
 	pl.Clear()
-	assert.Equal(t, []uint64{}, pl.ToArray())
+	assert.Equal(t, []uint64{}, docidArray(pl))
 }
 
 func TestFieldMap(t *testing.T) {
 	fm := posting.NewFieldMap()
-	fm.OrField("test", posting.NewList(1, 2, 3, 4, 5))
-	assert.Equal(t, []uint64{1, 2, 3, 4, 5}, fm["test"].ToArray())
+	pl := posting.NewList(posting.New(1), posting.New(2), posting.New(3), posting.New(4), posting.New(5))
+	fm.OrField("test", pl)
+	assert.Equal(t, []uint64{1, 2, 3, 4, 5}, docidArray(fm["test"]))
 }
 
 func TestFieldMapOr(t *testing.T) {
 	fm := posting.NewFieldMap()
-	fm.OrField("test", posting.NewList(1, 2))
-	fm.OrField("test2", posting.NewList(3, 4))
+	fm.OrField("test", posting.NewList(posting.New(1), posting.New(2)))
+	fm.OrField("test2", posting.NewList(posting.New(3), posting.New(4)))
 
 	fm2 := posting.NewFieldMap()
-	fm2.OrField("test", posting.NewList(3, 4))
-	fm2.OrField("test2", posting.NewList(5, 6))
-	fm2.OrField("test3", posting.NewList(7, 8))
+	fm2.OrField("test", posting.NewList(posting.New(3), posting.New(4)))
+	fm2.OrField("test2", posting.NewList(posting.New(5), posting.New(6)))
+	fm2.OrField("test3", posting.NewList(posting.New(7), posting.New(8)))
 	fm.Or(fm2)
 
-	assert.Equal(t, []uint64{1, 2, 3, 4}, fm["test"].ToArray())
-	assert.Equal(t, []uint64{3, 4, 5, 6}, fm["test2"].ToArray())
-	assert.Equal(t, []uint64{7, 8}, fm["test3"].ToArray())
+	assert.Equal(t, []uint64{1, 2, 3, 4}, docidArray(fm["test"]))
+	assert.Equal(t, []uint64{3, 4, 5, 6}, docidArray(fm["test2"]))
+	assert.Equal(t, []uint64{7, 8}, docidArray(fm["test3"]))
 }
 
 func TestFieldMapAnd(t *testing.T) {
 	fm := posting.NewFieldMap()
-	fm.OrField("test", posting.NewList(1, 2))
+	fm.OrField("test", posting.NewList(posting.New(1), posting.New(2)))
 
 	fm2 := posting.NewFieldMap()
-	fm2.OrField("test2", posting.NewList(2, 4))
+	fm2.OrField("test2", posting.NewList(posting.New(2), posting.New(4)))
 	fm.And(fm2)
 
-	assert.Equal(t, []uint64{2}, fm["test"].ToArray())
-	assert.Equal(t, []uint64{2}, fm["test2"].ToArray())
+	assert.Equal(t, []uint64{2}, docidArray(fm["test"]))
+	assert.Equal(t, []uint64{2}, docidArray(fm["test2"]))
 }


### PR DESCRIPTION
Replace `[]uint64` with `[]Posting` throughout -- this allows tracking positions alongside docids. The value is:

1. we can avoid scoring docs with few positions, they wont rank higher than docs with many positions
2. we can limit the amount of bytes that need to be run through a regex, which is a bottleneck today