### PR TITLE
Tweaks to workspace proto

### DIFF
--- a/proto/workspace.proto
+++ b/proto/workspace.proto
@@ -77,9 +77,6 @@ message GetWorkspaceFileRequest {
 
   // The file node being requested.
   Node file = 4;
-
-  // If true, gets the original file from source control instead of including any workspace changes.
-  bool original = 5;
 }
 
 message GetWorkspaceFileResponse {

--- a/proto/workspace.proto
+++ b/proto/workspace.proto
@@ -77,14 +77,17 @@ message GetWorkspaceFileRequest {
 
   // The file node being requested.
   Node file = 4;
+
+  // If true, gets the original file from source control instead of including any workspace changes.
+  bool original = 5;
 }
 
 message GetWorkspaceFileResponse {
   // The response context.
   context.ResponseContext response_context = 1;
 
-  // The contents of the file node being requested.
-  bytes content = 5;
+  // The file node that was requested, with populated file content.
+  Node file = 2;
 }
 
 message Workspace {
@@ -126,6 +129,13 @@ message Node {
   // The new contents of the file (if any). Only populated for `SaveWorkspace`
   // requests. For read requests, use the `GetWorkspaceFile` endpoint.
   bytes content = 5;
+
+  // The original sha of the node without any workspace modifications.
+  string original_sha = 6;
+
+  // If this file has an unresolved merge conflict after syncing the workspace,
+  // this points to the SHA of the updated file from source control.
+  string merge_conflict_sha = 7;
 }
 
 // The type of node.


### PR DESCRIPTION
Enabled fetching of "original" file that doesn't contain any changes from this workspace.

This is useful for showing file diff views, generating patch files, etc.

Also adds metadata for tracking merge conflicts when syncing a workspace to a newer base commit.

Finally, returns a Node instead of just bytes from GetWorkspaceFileResponse so we can retrieve this additional metadata.