### PR TITLE
Allow Developer role to view and execute workflows

### DIFF
--- a/app/router/router.tsx
+++ b/app/router/router.tsx
@@ -380,13 +380,8 @@ class Router {
     return capabilities.usage && Boolean(user?.canCall("getUsage"));
   }
 
-  canAccessWorkflowsPage(user?: User) {
-    const workflowsAdmin = capabilities.workflows && Boolean(user?.canCall("createWorkflow"));
-    const workflowsUser =
-      capabilities.workflows &&
-      capabilities.config.workflowHistoryEnabled &&
-      Boolean(user?.canCall("getWorkflowHistory"));
-    return workflowsAdmin || workflowsUser;
+  canAccessWorkflowsPage() {
+    return capabilities.config.workflowsEnabled;
   }
 
   canAccessOrgDetailsPage(user?: User) {
@@ -489,7 +484,7 @@ class Router {
     if (path === Path.executorsPath && !this.canAccessExecutorsPage(user)) {
       return Path.home;
     }
-    if (path === Path.workflowsPath && !this.canAccessWorkflowsPage(user)) {
+    if (path === Path.workflowsPath && !this.canAccessWorkflowsPage()) {
       return Path.home;
     }
     if (path === Path.usagePath && !this.canAccessUsagePage(user)) {

--- a/enterprise/app/sidebar/sidebar.tsx
+++ b/enterprise/app/sidebar/sidebar.tsx
@@ -178,7 +178,7 @@ export default class SidebarComponent extends React.Component<Props, State> {
               <span className="sidebar-item-text">Executors</span>
             </SidebarLink>
           )}
-          {capabilities.config.workflowsEnabled && (
+          {router.canAccessWorkflowsPage() && (
             <SidebarLink selected={this.isWorkflowsSelected()} href={Path.workflowsPath} title="Workflows">
               <PlayCircle className="icon" />
               <span className="sidebar-item-text">Workflows</span>

--- a/enterprise/app/sidebar/sidebar.tsx
+++ b/enterprise/app/sidebar/sidebar.tsx
@@ -178,7 +178,7 @@ export default class SidebarComponent extends React.Component<Props, State> {
               <span className="sidebar-item-text">Executors</span>
             </SidebarLink>
           )}
-          {router.canAccessWorkflowsPage(this.props.user) && (
+          {capabilities.config.workflowsEnabled && (
             <SidebarLink selected={this.isWorkflowsSelected()} href={Path.workflowsPath} title="Workflows">
               <PlayCircle className="icon" />
               <span className="sidebar-item-text">Workflows</span>

--- a/enterprise/app/workflows/workflows.tsx
+++ b/enterprise/app/workflows/workflows.tsx
@@ -471,6 +471,19 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
   }
 
   render() {
+    const menuItems = [];
+    if (this.props.webhookUrl) {
+      menuItems.push(<MenuItem onClick={this.onClickCopyWebhookUrl.bind(this)}>Copy webhook URL</MenuItem>);
+    }
+    if (this.props.user?.canCall("unlinkGitHubRepo")) {
+      menuItems.push(<MenuItem onClick={this.onClickUnlinkMenuItem.bind(this)}>Unlink repository</MenuItem>);
+    }
+    if (this.props.user?.canCall("invalidateAllSnapshotsForRepo") && this.props.onClickInvalidateAllItem) {
+      menuItems.push(
+        <MenuItem onClick={this.onClickInvalidateAllMenuItem.bind(this)}>Invalidate all workflow VM snapshots</MenuItem>
+      );
+    }
+
     return (
       <div className="workflow-item container">
         <div className="workflow-item-row">
@@ -490,41 +503,39 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
               </div>
             </div>
           </div>
-          {this.props.user?.isGroupAdmin() && (
-            <div className="workflow-item-column workflow-buttons-container">
-              <div className="workflow-item-row">
-                {/* The Run Workflow button is only supported for workflows configured with the Github App, not legacy workflows */}
-                {!this.props.webhookUrl && (
-                  <div className="workflow-button-container">
-                    <OutlinedButton
-                      className="run-workflow-button"
-                      onClick={this.showRunWorkflowInput.bind(this)}
-                      disabled={this.state.isWorkflowRunning}>
-                      {this.state.isWorkflowRunning && <Spinner />}
-                      <span>Run workflow</span>
-                    </OutlinedButton>
-                    <Popup
-                      isOpen={this.state.showRunWorkflowInput}
-                      onRequestClose={this.onCloseMenu.bind(this)}
-                      className="run-workflow-input">
-                      <div className="title">Run workflow from branch:</div>
-                      <TextInput
-                        placeholder={"e.g. main"}
-                        onChange={(e) => this.setState({ runWorkflowBranch: e.target.value })}
-                      />
-                      <div className="title">Visibility metadata:</div>
-                      <TextInput
-                        placeholder={"e.g. PUBLIC (optional)"}
-                        onChange={(e) => this.setState({ runWorkflowVisibility: e.target.value })}
-                      />
-                      <FilledButton
-                        onClick={this.runWorkflow.bind(this)}
-                        disabled={this.state.runWorkflowBranch === ""}>
-                        Run
-                      </FilledButton>
-                    </Popup>
-                  </div>
-                )}
+          <div className="workflow-item-column workflow-buttons-container">
+            <div className="workflow-item-row">
+              {/* The Run Workflow button is only supported for workflows configured with the Github App, not legacy workflows */}
+              {!this.props.webhookUrl && (
+                <div className="workflow-button-container">
+                  <OutlinedButton
+                    className="run-workflow-button"
+                    onClick={this.showRunWorkflowInput.bind(this)}
+                    disabled={this.state.isWorkflowRunning}>
+                    {this.state.isWorkflowRunning && <Spinner />}
+                    <span>Run workflow</span>
+                  </OutlinedButton>
+                  <Popup
+                    isOpen={this.state.showRunWorkflowInput}
+                    onRequestClose={this.onCloseMenu.bind(this)}
+                    className="run-workflow-input">
+                    <div className="title">Run workflow from branch:</div>
+                    <TextInput
+                      placeholder={"e.g. main"}
+                      onChange={(e) => this.setState({ runWorkflowBranch: e.target.value })}
+                    />
+                    <div className="title">Visibility metadata:</div>
+                    <TextInput
+                      placeholder={"e.g. PUBLIC (optional)"}
+                      onChange={(e) => this.setState({ runWorkflowVisibility: e.target.value })}
+                    />
+                    <FilledButton onClick={this.runWorkflow.bind(this)} disabled={this.state.runWorkflowBranch === ""}>
+                      Run
+                    </FilledButton>
+                  </Popup>
+                </div>
+              )}
+              {menuItems.length > 0 && (
                 <div className="workflow-button-container">
                   <OutlinedButton
                     title="Workflow options"
@@ -533,22 +544,12 @@ class RepoItem extends React.Component<RepoItemProps, RepoItemState> {
                     <MoreVertical />
                   </OutlinedButton>
                   <Popup isOpen={this.state.isMenuOpen} onRequestClose={this.onCloseMenu.bind(this)}>
-                    <Menu className="workflow-dropdown-menu">
-                      {this.props.webhookUrl && (
-                        <MenuItem onClick={this.onClickCopyWebhookUrl.bind(this)}>Copy webhook URL</MenuItem>
-                      )}
-                      <MenuItem onClick={this.onClickUnlinkMenuItem.bind(this)}>Unlink repository</MenuItem>
-                      {this.props.onClickInvalidateAllItem && (
-                        <MenuItem onClick={this.onClickInvalidateAllMenuItem.bind(this)}>
-                          Invalidate all workflow VM snapshots
-                        </MenuItem>
-                      )}
-                    </Menu>
+                    <Menu className="workflow-dropdown-menu">{menuItems}</Menu>
                   </Popup>
                 </div>
-              </div>
+              )}
             </div>
-          )}
+          </div>
         </div>
         {this.state.runWorkflowActionStatuses && (
           <div className="run-results history">


### PR DESCRIPTION
- Render workflows page in the sidebar for all users, not just admins (if workflows are enabled)
- In the workflow listing, show the "Run workflow" button for developers but hide the 3-dot menu (which allows unlinking the repo / invalidating all snaphots for the repo)

Note, role-based capabilities are already set up for this to work - users can already view the workflow listing + workflow history, as well as run workflows.

Also note, the zero-state page already had some logic to show "Contact your administrator to set up workflows" instead of the setup button, so no changes were needed there.

**Related issues**: Fixes https://github.com/buildbuddy-io/buildbuddy-internal/issues/3628
