### PR TITLE
Handle port numbers in `GetDomain`

### DIFF
--- a/server/util/urlutil/BUILD
+++ b/server/util/urlutil/BUILD
@@ -1,8 +1,17 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "urlutil",
     srcs = ["urlutil.go"],
     importpath = "github.com/buildbuddy-io/buildbuddy/server/util/urlutil",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "urlutil_test",
+    srcs = ["urlutil_test.go"],
+    deps = [
+        ":urlutil",
+        "@com_github_stretchr_testify//assert",
+    ],
 )

--- a/server/util/urlutil/urlutil.go
+++ b/server/util/urlutil/urlutil.go
@@ -14,15 +14,19 @@ func SameHostname(urlStringA, urlStringB string) bool {
 	return false
 }
 
-// GetDomain returns the domain portion of the passed host name.
-// e.g. app.buildbuddy.io will return buildbuddy.io
+// GetDomain returns the domain portion of the passed host, with any port
+// number removed.
+// e.g. app.buildbuddy.io:80 will return buildbuddy.io
 //
 // N.B. This does not generalize to all domains. Don't use this if you need
 // something that works for arbitrary domains.
-func GetDomain(hostname string) string {
-	pts := strings.Split(hostname, ".")
+func GetDomain(host string) string {
+	// If there is a port number, remove it.
+	host, _, _ = strings.Cut(host, ":")
+
+	pts := strings.Split(host, ".")
 	if len(pts) < 2 {
-		return hostname
+		return host
 	}
 	return strings.Join(pts[len(pts)-2:], ".")
 }

--- a/server/util/urlutil/urlutil_test.go
+++ b/server/util/urlutil/urlutil_test.go
@@ -1,0 +1,20 @@
+package urlutil_test
+
+import (
+	"testing"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/urlutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDomain(t *testing.T) {
+	for _, test := range []struct {
+		host, domain string
+	}{
+		{host: "app.buildbuddy.io", domain: "buildbuddy.io"},
+		{host: "app.localhost.io:8080", domain: "localhost.io"},
+	} {
+		domain := urlutil.GetDomain(test.host)
+		assert.Equal(t, test.domain, domain, "GetDomain(%q)", test.host)
+	}
+}


### PR DESCRIPTION
I am testing subdomains locally by setting up some entries in my `/etc/hosts` file like `app.localhost.io`, `customer.localhost.io` etc. and hit an issue where subdomain matching wasn't working properly - so directly navigating to `customer.localhost.io` via the address bar wouldn't navigate to the `customer` group.

The root issue was that the check [here](https://github.com/buildbuddy-io/buildbuddy/blob/2f35de7d46427aaa70a6aa5f91f904578d67f5c4/server/util/subdomain/subdomain.go#L35) was comparing `"localhost.io:8080"` (computed from `req.Host`) to `"localhost.io"` (computed from the `Hostname()` of the configured BB URL). `Hostname()` strips the port while `req.Host` includes the port, but `urlutil.GetDomain()` preserves the port, resulting in different domains being compared.

The fix in this PR is to have `urlutil.GetDomain()` strip the port from the host. It was already assuming that a `hostname` (with no port) was being passed in, and all callsites except the subdomain interceptor were already passing in a `hostname`. This fix just makes it slightly more relaxed, so that it can accept a `host` in addition to a `hostname`.

**Related issues**: N/A
