### PR TITLE
[FC] Remove noapic kernel boot arg

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1361,7 +1361,6 @@ func getBootArgs(vmConfig *fcpb.VMConfiguration) string {
 	kernelArgs := []string{
 		"ro",
 		"console=ttyS0",
-		"noapic",
 		"reboot=k",
 		"panic=1",
 		"pci=off",


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

Firecracker no longer recommends this boot arg, and mentions that it hurts performance: https://github.com/firecracker-microvm/firecracker/pull/392

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
