### PR TITLE
[FC] Remove lapic=notscdeadline bootarg

### DIFF
--- a/enterprise/server/remote_execution/containers/firecracker/firecracker.go
+++ b/enterprise/server/remote_execution/containers/firecracker/firecracker.go
@@ -1372,13 +1372,6 @@ func getBootArgs(vmConfig *fcpb.VMConfiguration) string {
 		"i8042.dumbkbd",
 		"tsc=reliable",
 		"ipv6.disable=1",
-		// Disabling the LAPIC TSC-Deadline feature works around an
-		// issue where processes occasionally freeze up after being resumed from
-		// snapshot.
-		// TODO(https://github.com/firecracker-microvm/firecracker/issues/4099 &
-		//  https://github.com/buildbuddy-io/buildbuddy-internal/issues/3255):
-		// remove this workaround.
-		"lapic=notscdeadline",
 	}
 	if vmConfig.EnableNetworking {
 		kernelArgs = append(kernelArgs, machineIPBootArgs)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

The corresponding bug has been fix in firecracker v1.8 🎉 

As a note, I'm planning to release each of these firecracker config changes independently and with some time between so it will be easier to debug if there are problems

**Related issues**: N/A
