### PR TITLE
Move the //server/cache_proxy creation of a local bufconn gRPC server to a place where it can be re-used.

### DIFF
--- a/server/cache_proxy/BUILD
+++ b/server/cache_proxy/BUILD
@@ -15,11 +15,11 @@ go_library(
         "//server/remote_cache/content_addressable_storage_server",
         "//server/remote_cache/digest",
         "//server/util/log",
+        "//server/util/proxyutil",
         "//server/util/status",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//metadata",
-        "@org_golang_google_grpc//test/bufconn",
         "@org_golang_google_protobuf//encoding/protojson",
     ],
 )

--- a/server/util/proxyutil/BUILD
+++ b/server/util/proxyutil/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "proxyutil",
+    srcs = ["proxyutil.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/proxyutil",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/util/log",
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//test/bufconn",
+    ],
+)

--- a/server/util/proxyutil/proxyutil.go
+++ b/server/util/proxyutil/proxyutil.go
@@ -1,0 +1,44 @@
+package proxyutil
+
+import (
+	"context"
+	"net"
+
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+
+	bspb "google.golang.org/genproto/googleapis/bytestream"
+)
+
+const (
+	// TODO(iain): make this configurable
+	bufferSizeBytes = 10 * 1024 * 1024
+)
+
+// StartBufConnServer starts a gRPC server that listens to a bufconn (in-memory
+// connection), and registers the provided ByteStreamServer to that gRPC
+// server. It returns a grpc.ClientConn to the newly-started gRPC server.
+// The server is shutdown when the provided context is canelled.
+//
+// TODO(iain): refactor to support registering other types of servers too.
+func StartBufConnServer(ctx context.Context, localBSS bspb.ByteStreamServer) (*grpc.ClientConn, error) {
+	listener := bufconn.Listen(bufferSizeBytes)
+	localGRPCServer := grpc.NewServer()
+	bspb.RegisterByteStreamServer(localGRPCServer, localBSS)
+	go func() {
+		if err := localGRPCServer.Serve(listener); err != nil {
+			log.Errorf("error serving locally: %s", err.Error())
+		}
+		listener.Close()
+		localGRPCServer.Stop()
+	}()
+
+	conn, err := grpc.DialContext(ctx, "", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return listener.Dial()
+	}), grpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+	return conn, nil
+}


### PR DESCRIPTION
In https://github.com/buildbuddy-io/buildbuddy/pull/6946 I want to start a local ByteStream gRPC server on a bufconn connection so that the running server can call it. I found this code that already does this, so moving it to a util package.

**Related issues**: N/A
