### PR TITLE
In Cache Proxy, start a local CASServer on the internal gRPC port

### DIFF
--- a/enterprise/server/cmd/cache_proxy/BUILD
+++ b/enterprise/server/cmd/cache_proxy/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//server/http/interceptors",
         "//server/real_environment",
         "//server/remote_cache/byte_stream_server",
+        "//server/remote_cache/content_addressable_storage_server",
         "//server/rpc/interceptors",
         "//server/ssl",
         "//server/util/grpc_client",

--- a/enterprise/server/cmd/cache_proxy/cache_proxy.go
+++ b/enterprise/server/cmd/cache_proxy/cache_proxy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/config"
 	"github.com/buildbuddy-io/buildbuddy/server/real_environment"
 	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/byte_stream_server"
+	"github.com/buildbuddy-io/buildbuddy/server/remote_cache/content_addressable_storage_server"
 	"github.com/buildbuddy-io/buildbuddy/server/ssl"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_client"
 	"github.com/buildbuddy-io/buildbuddy/server/util/grpc_server"
@@ -225,5 +226,11 @@ func registerInternalGRPCServices(grpcServer *grpc.Server, env *real_environment
 		return status.InternalErrorf("CacheProxy: error starting local bytestream server: %s", err.Error())
 	}
 	bspb.RegisterByteStreamServer(grpcServer, localBSS)
+
+	localCAS, err := content_addressable_storage_server.NewContentAddressableStorageServer(env)
+	if err != nil {
+		return status.InternalErrorf("CacheProxy: error starting local contentaddressablestorage server: %s", err.Error())
+	}
+	repb.RegisterContentAddressableStorageServer(grpcServer, localCAS)
 	return nil
 }

--- a/server/environment/environment.go
+++ b/server/environment/environment.go
@@ -95,6 +95,7 @@ type Env interface {
 	GetSSLService() interfaces.SSLService
 	GetBuildEventServer() pepb.PublishBuildEventServer
 	GetGitHubStatusService() interfaces.GitHubStatusService
+	GetLocalCASClient() repb.ContentAddressableStorageClient
 	GetCASServer() repb.ContentAddressableStorageServer
 	GetLocalByteStreamClient() bspb.ByteStreamClient
 	GetByteStreamServer() bspb.ByteStreamServer

--- a/server/real_environment/real_environment.go
+++ b/server/real_environment/real_environment.go
@@ -93,6 +93,7 @@ type RealEnv struct {
 	sslService                       interfaces.SSLService
 	quotaManager                     interfaces.QuotaManager
 	buildEventServer                 pepb.PublishBuildEventServer
+	localCASClient                   repb.ContentAddressableStorageClient
 	casServer                        repb.ContentAddressableStorageServer
 	localByteStreamClient            bspb.ByteStreamClient
 	byteStreamServer                 bspb.ByteStreamServer
@@ -536,6 +537,13 @@ func (r *RealEnv) GetBuildEventServer() pepb.PublishBuildEventServer {
 
 func (r *RealEnv) SetBuildEventServer(buildEventServer pepb.PublishBuildEventServer) {
 	r.buildEventServer = buildEventServer
+}
+
+func (r *RealEnv) GetLocalCASClient() repb.ContentAddressableStorageClient {
+	return r.localCASClient
+}
+func (r *RealEnv) SetLocalCASClient(localCASClient repb.ContentAddressableStorageClient) {
+	r.localCASClient = localCASClient
 }
 
 func (r *RealEnv) GetCASServer() repb.ContentAddressableStorageServer {

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -121,10 +121,6 @@ func LocalInternalGRPCConn(ctx context.Context, te *real_environment.RealEnv, op
 	return localGRPCConn(ctx, te.GetInternalLocalBufconnListenerForTesting(), opts...)
 }
 
-func LocalInternalGRPCConn(ctx context.Context, te *real_environment.RealEnv, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	return localGRPCConn(ctx, te.GetInternalLocalBufconnListenerForTesting(), opts...)
-}
-
 func localGRPCConn(ctx context.Context, lis *bufconn.Listener, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	bufDialer := func(context.Context, string) (net.Conn, error) {
 		return lis.Dial()

--- a/server/testutil/testenv/testenv.go
+++ b/server/testutil/testenv/testenv.go
@@ -121,6 +121,10 @@ func LocalInternalGRPCConn(ctx context.Context, te *real_environment.RealEnv, op
 	return localGRPCConn(ctx, te.GetInternalLocalBufconnListenerForTesting(), opts...)
 }
 
+func LocalInternalGRPCConn(ctx context.Context, te *real_environment.RealEnv, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return localGRPCConn(ctx, te.GetInternalLocalBufconnListenerForTesting(), opts...)
+}
+
 func localGRPCConn(ctx context.Context, lis *bufconn.Listener, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	bufDialer := func(context.Context, string) (net.Conn, error) {
 		return lis.Dial()


### PR DESCRIPTION
This PR includes / is based off https://github.com/buildbuddy-io/buildbuddy/pull/7048. Please review that one first.

**Related issues**: N/A
