### PR TITLE
[raft] move makeHeader function out from sender/store/txn.

### DIFF
--- a/enterprise/server/raft/header/BUILD
+++ b/enterprise/server/raft/header/BUILD
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "header",
+    srcs = ["header.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/header",
+    visibility = ["//visibility:public"],
+    deps = ["//proto:raft_go_proto"],
+)
+
+package(default_visibility = ["//enterprise:__subpackages__"])

--- a/enterprise/server/raft/header/header.go
+++ b/enterprise/server/raft/header/header.go
@@ -1,0 +1,21 @@
+package header
+
+import (
+	rfpb "github.com/buildbuddy-io/buildbuddy/proto/raft"
+)
+
+func New(rd *rfpb.RangeDescriptor, replicaIdx int, mode rfpb.Header_ConsistencyMode) *rfpb.Header {
+	return &rfpb.Header{
+		Replica:         rd.GetReplicas()[replicaIdx],
+		RangeId:         rd.GetRangeId(),
+		Generation:      rd.GetGeneration(),
+		ConsistencyMode: mode,
+	}
+}
+
+func NewWithoutRangeInfo(rd *rfpb.RangeDescriptor, replicaIdx int, mode rfpb.Header_ConsistencyMode) *rfpb.Header {
+	return &rfpb.Header{
+		Replica:         rd.GetReplicas()[replicaIdx],
+		ConsistencyMode: mode,
+	}
+}

--- a/enterprise/server/raft/sender/BUILD
+++ b/enterprise/server/raft/sender/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//enterprise/server/raft/client",
         "//enterprise/server/raft/constants",
+        "//enterprise/server/raft/header",
         "//enterprise/server/raft/keys",
         "//enterprise/server/raft/rangecache",
         "//enterprise/server/raft/rbuilder",

--- a/enterprise/server/raft/sender/sender.go
+++ b/enterprise/server/raft/sender/sender.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/client"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/constants"
+	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/header"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/keys"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rangecache"
 	"github.com/buildbuddy-io/buildbuddy/enterprise/server/raft/rbuilder"
@@ -37,15 +38,6 @@ func New(rangeCache *rangecache.RangeCache, apiClient *client.APIClient) *Sender
 	return &Sender{
 		rangeCache: rangeCache,
 		apiClient:  apiClient,
-	}
-}
-
-func makeHeader(rangeDescriptor *rfpb.RangeDescriptor, replicaIdx int, mode rfpb.Header_ConsistencyMode) *rfpb.Header {
-	return &rfpb.Header{
-		Replica:         rangeDescriptor.GetReplicas()[replicaIdx],
-		RangeId:         rangeDescriptor.GetRangeId(),
-		Generation:      rangeDescriptor.GetGeneration(),
-		ConsistencyMode: mode,
 	}
 }
 
@@ -148,7 +140,7 @@ type makeHeaderFunc func(rd *rfpb.RangeDescriptor, replicaIdx int) *rfpb.Header
 
 func (s *Sender) tryReplicas(ctx context.Context, rd *rfpb.RangeDescriptor, fn runFunc, mode rfpb.Header_ConsistencyMode) (int, error) {
 	return s.TryReplicas(ctx, rd, fn, func(rd *rfpb.RangeDescriptor, replicaIdx int) *rfpb.Header {
-		return makeHeader(rd, replicaIdx, mode)
+		return header.New(rd, replicaIdx, mode)
 	})
 }
 

--- a/enterprise/server/raft/store/BUILD
+++ b/enterprise/server/raft/store/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//enterprise/server/raft/constants",
         "//enterprise/server/raft/driver",
         "//enterprise/server/raft/events",
+        "//enterprise/server/raft/header",
         "//enterprise/server/raft/keys",
         "//enterprise/server/raft/leasekeeper",
         "//enterprise/server/raft/listener",

--- a/enterprise/server/raft/txn/BUILD
+++ b/enterprise/server/raft/txn/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//enterprise/server/raft/client",
         "//enterprise/server/raft/constants",
+        "//enterprise/server/raft/header",
         "//enterprise/server/raft/keys",
         "//enterprise/server/raft/rbuilder",
         "//enterprise/server/raft/sender",


### PR DESCRIPTION
also, set the correct replica when we are getting local applied index in GetReplicaStates. (I don't think it changes behavior: currently, we only use the shard id from the replica in the header)

<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
