### PR TITLE
Add a couple of new action-merging metrics

### DIFF
--- a/enterprise/server/remote_execution/action_merger/BUILD
+++ b/enterprise/server/remote_execution/action_merger/BUILD
@@ -8,9 +8,11 @@ go_library(
     importpath = "github.com/buildbuddy-io/buildbuddy/enterprise/server/remote_execution/action_merger",
     deps = [
         "//server/interfaces",
+        "//server/metrics",
         "//server/remote_cache/digest",
         "//server/util/log",
         "//server/util/prefix",
         "@com_github_go_redis_redis_v8//:redis",
+        "@com_github_prometheus_client_golang//prometheus",
     ],
 )

--- a/enterprise/server/remote_execution/action_merger/action_merger.go
+++ b/enterprise/server/remote_execution/action_merger/action_merger.go
@@ -167,11 +167,11 @@ func recordMetrics(ctx context.Context, rdb redis.UniversalClient, key string, g
 	if err := hash.Err(); err != nil {
 		log.Debugf("Error reading action-merging state from Redis: %s", err)
 	}
-	recordCountMetrics(ctx, hash, groupIdForMetrics)
+	recordCountMetric(ctx, hash, groupIdForMetrics)
 	recordSubmitTimeOffsetMetric(ctx, hash, groupIdForMetrics)
 }
 
-func recordCountMetrics(ctx context.Context, hash *redis.StringStringMapCmd, groupIdForMetrics string) {
+func recordCountMetric(ctx context.Context, hash *redis.StringStringMapCmd, groupIdForMetrics string) {
 	rawCount, ok := hash.Val()[actionCountKey]
 	if !ok {
 		return

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -642,6 +642,7 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 
 	// Create a new execution unless we found an existing identical action we
 	// can wait on.
+	mergedExecution := executionID != ""
 	if executionID == "" {
 		log.CtxInfof(ctx, "Scheduling new execution for %q for invocation %q", downloadString, invocationID)
 		newExecutionID, err := s.Dispatch(ctx, req)
@@ -658,13 +659,16 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 	// If the action_merger said to hedge this action, run another execution
 	// in the background.
 	if hedge {
-		action_merger.RecordHedgedExecution(ctx, s.rdb, adInstanceDigest)
+		action_merger.RecordHedgedExecution(ctx, s.rdb, adInstanceDigest, s.getGroupIDForMetrics(ctx))
 		hedgedExecutionID, err := s.dispatchHedge(ctx, req)
 		if err != nil {
 			log.CtxWarningf(ctx, "Error dispatching execution for action %q and invocation %q: %s", downloadString, invocationID, err)
 			return err
 		}
 		log.CtxInfof(ctx, "Dispatched new hedged execution %q for action %q and invocation %q", hedgedExecutionID, downloadString, invocationID)
+	}
+	if mergedExecution {
+		action_merger.RecordMergedExecution(ctx, s.rdb, adInstanceDigest, s.getGroupIDForMetrics(ctx))
 	}
 
 	waitReq := repb.WaitExecutionRequest{

--- a/enterprise/server/remote_execution/execution_server/execution_server.go
+++ b/enterprise/server/remote_execution/execution_server/execution_server.go
@@ -668,7 +668,10 @@ func (s *ExecutionServer) execute(req *repb.ExecuteRequest, stream streamLike) e
 		log.CtxInfof(ctx, "Dispatched new hedged execution %q for action %q and invocation %q", hedgedExecutionID, downloadString, invocationID)
 	}
 	if mergedExecution {
-		action_merger.RecordMergedExecution(ctx, s.rdb, adInstanceDigest, s.getGroupIDForMetrics(ctx))
+		err = action_merger.RecordMergedExecution(ctx, s.rdb, adInstanceDigest, s.getGroupIDForMetrics(ctx))
+		if err != nil {
+			log.Debugf("Error recording merged execution in Redis: %s", err)
+		}
 	}
 
 	waitReq := repb.WaitExecutionRequest{

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -897,6 +897,26 @@ var (
 		GroupID,
 	})
 
+	RemoteExecutionMergedActionsPerExecution = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "merged_actions_per_execution",
+		Buckets:   []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100},
+		Help:      "Distribution of how many actions were submitted and merged against a single, canonical execution over the lifetime of that canonical execution. Note that this metric is recorded once per merged-action, so distribution values are cumulative, or recorded n-times per canonical execution.",
+	}, []string{
+		GroupID,
+	})
+
+	RemoteExecutionMergedActionSubmitTimeOffsetUsec = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: bbNamespace,
+		Subsystem: "remote_execution",
+		Name:      "merged_action_submit_time_offset_usec",
+		Buckets:   durationUsecBuckets(1*time.Millisecond, 1*day, 10),
+		Help:      "The offset, in microseconds of wall-time, between the time when a merged action was submitted to the execution server and when the original action was submitted to the execution server.",
+	}, []string{
+		GroupID,
+	})
+
 	// #### Examples
 	//
 	// ```promql


### PR DESCRIPTION
This PR adds two new metrics that track action-merging performance:
- `buildbuddy_remote_execution_merged_actions_per_execution`: a distribution tracking the number of merged actions per execution.
- `buildbuddy_remote_execution_merged_action_submit_time_offset_usec`: a distribution tracking the "submit time offset" for merged actions. The "submit time offset" is the wall time at which an action that is merged was submitted to the execution server minus the wall time at which the original execution it was merged against was submitted to the execution server. In a [previous PR](https://github.com/buildbuddy-io/buildbuddy/pull/6630) I called this the "time saved" due to action merging, but that's not really correct.

I'd like to add these as prometheus metrics because Siggi suggested that the current action-merging hedging implementation is a bit too eager in running hedges, and that I explore only running hedged executions when the original execution has been running for a little while, or only after a few other actions have been submitted (i.e. hedge every 5th submitted action). I looked into figuring out what those values should be by querying the Executions table in Clickhouse, but this: 1. requires running a kind of tricky query, 2. against a modifiable production database and 3. requires a bit of effort to keep up-to-date on, so I'd prefer to keep track of these basic metrics instead.

There are a couple of caveats with this PR. First, because we're writing to and reading from Redis for merged actions as well as executed actions, this will increase the load on Redis by about the rate of merged actions. This is about 10-50 QPS at peak (The query is `rate(sum(buildbuddy_remote_execution_merged_actions{region="${region}"}))`), and because we'll write and read, it'll be close to 100QPS extra at peak. This seems fine because we do 100k-150k QPS to Redis at peak, almost 50k of which are hash writes.

Second, the `buildbuddy_remote_execution_merged_actions_per_execution` metric is recorded once per submitted action, or many times per merged-against execution. This is a little bit awkward, and I thought about recording it on execution finalization so only the final value is recorded, but that would miss recording values if the merged-against execution doesn't finish correctly, for example because it times out, so I think the over-recording is worth it in this case.
 
**Related issues**: N/A