### PR TITLE
Upgrade git version in ubuntu 20.04 image

### DIFF
--- a/dockerfiles/rbe-ubuntu20-04/Dockerfile
+++ b/dockerfiles/rbe-ubuntu20-04/Dockerfile
@@ -32,6 +32,11 @@ RUN apt-get update && \
 # Misc. utils
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+      software-properties-common \
+      && \
+    add-apt-repository ppa:git-core/ppa && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
       ed \
       curl \
       file \

--- a/enterprise/dockerfiles/rbe-ubuntu20-04-workflows/Dockerfile
+++ b/enterprise/dockerfiles/rbe-ubuntu20-04-workflows/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/flame-public/rbe-ubuntu20-04@sha256:036ae8c90876fa22da9ace6f8218e614f4cd500a154fc162973fff691e72d28e
+FROM gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622
 
 # Install bazelisk
 RUN curl -Lo /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-amd64 && \

--- a/enterprise/server/remote_execution/platform/platform.go
+++ b/enterprise/server/remote_execution/platform/platform.go
@@ -39,10 +39,10 @@ var (
 
 const (
 	Ubuntu16_04Image = "gcr.io/flame-public/executor-docker-default:enterprise-v1.6.0"
-	Ubuntu20_04Image = "gcr.io/flame-public/rbe-ubuntu20-04@sha256:036ae8c90876fa22da9ace6f8218e614f4cd500a154fc162973fff691e72d28e"
+	Ubuntu20_04Image = "gcr.io/flame-public/rbe-ubuntu20-04@sha256:09261f2019e9baa7482f7742cdee8e9972a3971b08af27363a61816b2968f622"
 
 	Ubuntu18_04WorkflowsImage = "gcr.io/flame-public/buildbuddy-ci-runner@sha256:8cf614fc4695789bea8321446402e7d6f84f6be09b8d39ec93caa508fa3e3cfc"
-	Ubuntu20_04WorkflowsImage = "gcr.io/flame-public/rbe-ubuntu20-04-workflows@sha256:271e5e3704d861159c75b8dd6713dbe5a12272ec8ee73d17f89ed7be8026553f"
+	Ubuntu20_04WorkflowsImage = "gcr.io/flame-public/rbe-ubuntu20-04-workflows@sha256:c5092c8cb94471bb7c7fbd046cd80cb596dcc508f0833a748c035a1ba41f1681"
 
 	Ubuntu20_04GitHubActionsImage = "gcr.io/flame-public/rbe-ubuntu20-04-github-actions@sha256:2a3b50fa1aafcb8446c94ab5707270f92fa91abd64a0e049312d4a086d0abb1c"
 


### PR DESCRIPTION
This seems to fix git-lfs hanging issues. Also makes sure that the git version in this image is at least as new as the one in the 18.04 workflows image (previously, the 18.04 image had a newer git version than the ubuntu 20.04 image).

**Related issues**: N/A
