### PR TITLE
pebble cache: add a flag to enable bloom filter creation.

### DIFF
--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -501,7 +501,7 @@ func defaultPebbleOptions(el *pebbleEventListener) *pebble.Options {
 			DiskSlow:        el.DiskSlow,
 		},
 	}
-	if *enableBloomFilter {
+	if *enableTableBloomFilter {
 		opts.Levels = []pebble.LevelOptions{
 			pebble.LevelOptions{
 				FilterPolicy: pebble.BloomFilterPolicy(10),

--- a/enterprise/server/backends/pebble_cache/pebble_cache.go
+++ b/enterprise/server/backends/pebble_cache/pebble_cache.go
@@ -83,6 +83,7 @@ var (
 	evictionRateLimit         = flag.Int("cache.pebble.eviction_rate_limit", 300, "Maximum number of entries to evict per second (per partition).")
 	copyPartition             = flag.String("cache.pebble.copy_partition_data", "", "If set, all data will be copied from the source partition to the destination partition on startup. The cache will not serve data while the copy is in progress. Specified in format source_partition_id:destination_partition_id,")
 	includeMetadataSize       = flag.Bool("cache.pebble.include_metadata_size", false, "If true, include metadata size")
+	enableTableBloomFilter    = flag.Bool("cache.pebble.enable_table_bloom_filter", false, "If true, write bloom filter data with pebble SSTables.")
 
 	activeKeyVersion  = flag.Int64("cache.pebble.active_key_version", int64(filestore.UnspecifiedKeyVersion), "The key version new data will be written with. If negative, will write to the highest existing version in the database, or the highest known version if a new database is created.")
 	migrationQPSLimit = flag.Int("cache.pebble.migration_qps_limit", 50, "QPS limit for data version migration")
@@ -499,6 +500,13 @@ func defaultPebbleOptions(el *pebbleEventListener) *pebble.Options {
 			WriteStallEnd:   el.WriteStallEnd,
 			DiskSlow:        el.DiskSlow,
 		},
+	}
+	if *enableBloomFilter {
+		opts.Levels = []pebble.LevelOptions{
+			pebble.LevelOptions{
+				FilterPolicy: pebble.BloomFilterPolicy(10),
+			},
+		}
 	}
 
 	// The threshold of L0 read-amplification at which compaction concurrency

--- a/enterprise/server/util/pebble/BUILD
+++ b/enterprise/server/util/pebble/BUILD
@@ -12,6 +12,7 @@ go_library(
         "//server/util/proto",
         "//server/util/status",
         "@com_github_cockroachdb_pebble//:pebble",
+        "@com_github_cockroachdb_pebble//bloom",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_prometheus_client_golang//prometheus",
     ],

--- a/enterprise/server/util/pebble/pebble.go
+++ b/enterprise/server/util/pebble/pebble.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/util/proto"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/bloom"
 )
 
 var (
@@ -38,6 +39,8 @@ var DefaultFS = vfs.Default
 
 type Options = pebble.Options
 type IterOptions = pebble.IterOptions
+type LevelOptions = pebble.LevelOptions
+type BloomFilterPolicy = bloom.FilterPolicy
 type Snapshot = pebble.Snapshot
 type Metrics = pebble.Metrics
 type EventListener = pebble.EventListener


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->
It's kinda tough to get a read on how much of a difference this makes in a real-ish environment.

I ran a little test harness where I hacked up cacheload to:

- write a few million 500-1000 byte entries to the pebble cache
- call findmissing with random (i.e., near-certain miss) digests as fast as possible

CPU profiles showed table read CPU decreasing by ~33% on FindMissing misses (so, disk reads and table loads decreased) in exchange for essentially-zero (<.1%) CPU hit on checking bloom filters.

qps perf, on the other hand, was pretty variable. i won't pretend to have a meaningful read on it; in both cases my load test environment came up with something like 30-40k read qps (single process requesting + receiving).  Performance across runs wasn't consistent enough to pretend i'm not being influenced by my machine conditions.  It ~ felt ~ like the fastest runs were with bloom filters on, but some bloom filter runs were slower than the fastest no-filter runs.

There's some memory overhead from having the bloom filters for each sstable loaded up, but that's kinda tough to judge given that my load test is ~bogus.  The documentation says the bloom.FilterPolicy(10) should take "approximately" 10 bits per key, which is perfectly fine for us assuming it's accurate.

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
