### PR TITLE
start monitoring handler earlier during server startup

### DIFF
--- a/enterprise/server/cmd/server/main.go
+++ b/enterprise/server/cmd/server/main.go
@@ -173,6 +173,8 @@ func main() {
 	// Setup the prod fanciness in our environment
 	convertToProdOrDie(rootContext, realEnv)
 
+	libmain.StartMonitoringHandler(realEnv)
+
 	if err := gcs_cache.Register(realEnv); err != nil {
 		log.Fatal(err.Error())
 	}

--- a/server/cmd/buildbuddy/main.go
+++ b/server/cmd/buildbuddy/main.go
@@ -48,5 +48,6 @@ func main() {
 	cleanupService.Start()
 	defer cleanupService.Stop()
 
+	libmain.StartMonitoringHandler(env)
 	libmain.StartAndRunServices(env) // Does not return
 }

--- a/server/libmain/libmain.go
+++ b/server/libmain/libmain.go
@@ -337,15 +337,17 @@ func registerLocalGRPCClients(env *real_environment.RealEnv) error {
 	return nil
 }
 
-func StartAndRunServices(env *real_environment.RealEnv) {
+func StartMonitoringHandler(env *real_environment.RealEnv) {
 	env.SetListenAddr(*listen)
+	runtime.SetMutexProfileFraction(*mutexProfileFraction)
+	runtime.SetBlockProfileRate(*blockProfileRate)
+	monitoring.StartMonitoringHandler(env, fmt.Sprintf("%s:%d", *listen, *monitoringPort))
+}
 
+func StartAndRunServices(env *real_environment.RealEnv) {
 	if err := rlimit.MaxRLimit(); err != nil {
 		log.Printf("Error raising open files limit: %s", err)
 	}
-
-	runtime.SetMutexProfileFraction(*mutexProfileFraction)
-	runtime.SetBlockProfileRate(*blockProfileRate)
 
 	appBundleHash, err := static.AppBundleHash(env.GetAppFilesystem())
 	if err != nil {
@@ -370,8 +372,6 @@ func StartAndRunServices(env *real_environment.RealEnv) {
 	if err := buildbuddy_server.Register(env); err != nil {
 		log.Fatalf("%v", err)
 	}
-
-	monitoring.StartMonitoringHandler(env, fmt.Sprintf("%s:%d", *listen, *monitoringPort))
 
 	if err := build_event_server.Register(env); err != nil {
 		log.Fatalf("%v", err)


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
This can allows us to grab go profiles during server start-up.
