### PR TITLE
Support deprecation warnings in the console

### DIFF
--- a/server/remote_cache/byte_stream_server/BUILD
+++ b/server/remote_cache/byte_stream_server/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//server/remote_cache/config",
         "//server/remote_cache/digest",
         "//server/remote_cache/hit_tracker",
+        "//server/util/bazel_deprecation",
         "//server/util/bazel_request",
         "//server/util/bytebufferpool",
         "//server/util/capabilities",

--- a/server/util/bazel_deprecation/BUILD
+++ b/server/util/bazel_deprecation/BUILD
@@ -9,7 +9,6 @@ go_library(
         "//server/environment",
         "//server/util/bazel_request",
         "//server/util/claims",
-        "//server/util/log",
         "//server/util/status",
     ],
 )

--- a/server/util/bazel_deprecation/BUILD
+++ b/server/util/bazel_deprecation/BUILD
@@ -9,6 +9,8 @@ go_library(
         "//server/environment",
         "//server/util/bazel_request",
         "//server/util/claims",
+        "//server/util/flag",
         "//server/util/status",
+        "@com_github_logrusorgru_aurora//:aurora",
     ],
 )

--- a/server/util/bazel_deprecation/BUILD
+++ b/server/util/bazel_deprecation/BUILD
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "bazel_deprecation",
+    srcs = ["bazel_deprecation.go"],
+    importpath = "github.com/buildbuddy-io/buildbuddy/server/util/bazel_deprecation",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//server/environment",
+        "//server/util/bazel_request",
+        "//server/util/claims",
+        "//server/util/log",
+        "//server/util/status",
+    ],
+)

--- a/server/util/bazel_deprecation/bazel_deprecation.go
+++ b/server/util/bazel_deprecation/bazel_deprecation.go
@@ -6,7 +6,6 @@ import (
 	"github.com/buildbuddy-io/buildbuddy/server/environment"
 	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
 	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
-	"github.com/buildbuddy-io/buildbuddy/server/util/log"
 	"github.com/buildbuddy-io/buildbuddy/server/util/status"
 )
 
@@ -39,7 +38,6 @@ func (w *Warner) getWarningCount(ctx context.Context) int64 {
 
 	countKey := warningMetricPrefix + bazel_request.GetInvocationID(ctx)
 	read, err := m.ReadCounts(ctx, countKey)
-	log.Printf("warning count: %+v", read)
 	if err == nil {
 		return read[warningKey]
 	}

--- a/server/util/bazel_deprecation/bazel_deprecation.go
+++ b/server/util/bazel_deprecation/bazel_deprecation.go
@@ -1,0 +1,74 @@
+package bazel_deprecation
+
+import (
+	"context"
+
+	"github.com/buildbuddy-io/buildbuddy/server/environment"
+	"github.com/buildbuddy-io/buildbuddy/server/util/bazel_request"
+	"github.com/buildbuddy-io/buildbuddy/server/util/claims"
+	"github.com/buildbuddy-io/buildbuddy/server/util/log"
+	"github.com/buildbuddy-io/buildbuddy/server/util/status"
+)
+
+const (
+	bazelToolName   = "bazel"
+	profileActionID = "bes-upload"
+
+	warningMetricPrefix = "warning-"
+	warningKey          = "warnings"
+)
+
+func isAnonymousBuild(ctx context.Context) bool {
+	_, err := claims.ClaimsFromContext(ctx)
+	return status.IsUnauthenticatedError(err)
+}
+
+type Warner struct {
+	env environment.Env
+}
+
+func NewWarner(env environment.Env) *Warner {
+	return &Warner{env: env}
+}
+
+func (w *Warner) getWarningCount(ctx context.Context) int64 {
+	m := w.env.GetMetricsCollector()
+	if m == nil {
+		return 0
+	}
+
+	countKey := warningMetricPrefix + bazel_request.GetInvocationID(ctx)
+	read, err := m.ReadCounts(ctx, countKey)
+	log.Printf("warning count: %+v", read)
+	if err == nil {
+		return read[warningKey]
+	}
+	return 0
+}
+
+func (w *Warner) incrementWarningCount(ctx context.Context) {
+	m := w.env.GetMetricsCollector()
+	if m == nil {
+		return
+	}
+	countKey := warningMetricPrefix + bazel_request.GetInvocationID(ctx)
+	m.IncrementCount(ctx, countKey, warningKey, 1)
+}
+
+func (w *Warner) Warn(ctx context.Context) error {
+	canWarn := bazel_request.GetToolName(ctx) == bazelToolName && bazel_request.GetActionID(ctx) == profileActionID
+	if !canWarn {
+		return nil
+	}
+
+	if w.getWarningCount(ctx) >= 1 {
+		// Already warned.
+		return nil
+	}
+
+	if isAnonymousBuild(ctx) {
+		defer w.incrementWarningCount(ctx)
+		return status.FailedPreconditionError("Anonymous access is deprecated; please create an account at https://app.buildbuddy.io/")
+	}
+	return nil
+}

--- a/server/util/bazel_deprecation/bazel_deprecation.go
+++ b/server/util/bazel_deprecation/bazel_deprecation.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	deprecateAnonymousAccess = flag.Bool("app.deprecate_anonymous_access", true, "If true, log a warning in the bazel console when clients are unauthenticated")
+	deprecateAnonymousAccess = flag.Bool("app.deprecate_anonymous_access", false, "If true, log a warning in the bazel console when clients are unauthenticated")
 )
 
 const (


### PR DESCRIPTION
Big ups @fmeum for the help :)

Allow for publishing a deprecation warning in the bazel console when a request uses some feature that we're planning to drop. Do this by returning an error in the bytestream.Write call of the profile -- but still let that upload succeed so we don't impact profile uploads.