### PR TITLE
Add diagnostics and safeguards for high CPU estimates

### DIFF
--- a/enterprise/server/tasksize_model/tasksize_model.go
+++ b/enterprise/server/tasksize_model/tasksize_model.go
@@ -41,6 +41,10 @@ const (
 	// Predict().
 	minMilliCPUPrediction = 1 // 1ms
 
+	// maxMilliCPUPrediction is the maximum CPU value to be returned from
+	// Predict().
+	maxMilliCPUPrediction = 8_000
+
 	// How much time to allow for initializing the model (connecting to the
 	// TF server and making a test prediction).
 	initTimeout = 10 * time.Second
@@ -262,6 +266,10 @@ func (m *Model) predict(ctx context.Context, task *repb.ExecutionTask) (*scpb.Ta
 	}
 	if size.EstimatedMilliCpu < minMilliCPUPrediction {
 		size.EstimatedMilliCpu = minMilliCPUPrediction
+	}
+	if size.EstimatedMilliCpu > maxMilliCPUPrediction {
+		log.CtxInfof(ctx, "Limiting task size milli-CPU prediction %d to %d", size.EstimatedMilliCpu, maxMilliCPUPrediction)
+		size.EstimatedMilliCpu = maxMilliCPUPrediction
 	}
 	return size, nil
 }


### PR DESCRIPTION
* Have the TF model limit its CPU predictions to 8 CPU cores. Since the model is not super accurate, CPU estimates higher than 8 CPU cores aren't really warranted.
* When we compute a milliCPU estimate that exceeds 16 CPU cores, log an info message that should help us understand why the computed value is so high, so we know what tweaks to make.

**Related issues**: N/A
