### PR TITLE
Fix container stats baseline for recycled runners

### DIFF
--- a/enterprise/server/remote_execution/container/container.go
+++ b/enterprise/server/remote_execution/container/container.go
@@ -213,14 +213,13 @@ type UsageStats struct {
 	baselineCPUPressure, baselineMemoryPressure, baselineIOPressure *repb.PSI
 }
 
-// Reset resets resource usage counters in preparation for a new task, so that
-// the new task's resource usage can be accounted for. It should be called
-// at the beginning of Exec() in the container lifecycle.
-func (s *UsageStats) Reset() {
-	if s.last == nil {
-		// No observations yet; nothing to do.
-		return
-	}
+// SetBaseline records the current stats readings just before executing a new
+// task. It should be called at the beginning of Exec() in the container
+// lifecycle to ensure that the reported stats are only accounting for the
+// container's resource usage during the Exec() call itself.
+func (s *UsageStats) SetBaseline(lifetimeStats *repb.UsageStats) {
+	s.Update(lifetimeStats)
+
 	s.last.MemoryBytes = 0
 	s.baselineCPUNanos = s.last.GetCpuNanos()
 	s.baselineCPUPressure = s.last.GetCpuPressure()

--- a/enterprise/server/remote_execution/container/container_test.go
+++ b/enterprise/server/remote_execution/container/container_test.go
@@ -266,7 +266,7 @@ func TestUsageStats(t *testing.T) {
 	s := &container.UsageStats{}
 	require.Empty(t, cmp.Diff(&repb.UsageStats{}, s.TaskStats(), protocmp.Transform()))
 
-	s.Reset()
+	s.SetBaseline(&repb.UsageStats{})
 	require.Empty(t, cmp.Diff(&repb.UsageStats{}, s.TaskStats(), protocmp.Transform()))
 
 	// Observe some cgroup usage.
@@ -306,10 +306,16 @@ func TestUsageStats(t *testing.T) {
 		IoPressure:      makePSI(30_000, 3_000),
 	}, s.TaskStats(), protocmp.Transform()))
 
-	// Start a new task, using the same UsageStats instance. The cgroup
-	// accumulated CPU etc. will not be reset, but the metrics that we report
-	// should appear as though they were.
-	s.Reset()
+	// Start a new task, setting the baseline to the last observed stats. The
+	// cgroup accumulated CPU etc. will not be reset, but the metrics that we
+	// report should appear as though they were.
+	s.SetBaseline(&repb.UsageStats{
+		CpuNanos:       2e9,
+		MemoryBytes:    45 * 1024 * 1024,
+		CpuPressure:    makePSI(150, 10),
+		MemoryPressure: makePSI(2_000, 200),
+		IoPressure:     makePSI(30_000, 3_000),
+	})
 	require.Empty(t, cmp.Diff(&repb.UsageStats{
 		CpuPressure:    makePSI(0, 0),
 		MemoryPressure: makePSI(0, 0),

--- a/enterprise/server/remote_execution/containers/ociruntime/BUILD
+++ b/enterprise/server/remote_execution/containers/ociruntime/BUILD
@@ -46,7 +46,12 @@ go_test(
     tags = [
         "no-sandbox",
     ],
-    target_compatible_with = ["@platforms//os:linux"],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        # TODO: GitHub Actions arm runners are running into cgroup-related issues;
+        # fix and re-enable on arm64.
+        "@platforms//cpu:x86_64",
+    ],
     x_defs = {
         "crunRlocationpath": "$(rlocationpath :crun)",
     },

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime.go
@@ -330,8 +330,14 @@ func (c *ociContainer) Create(ctx context.Context, workDir string) error {
 }
 
 func (c *ociContainer) Exec(ctx context.Context, cmd *repb.Command, stdio *interfaces.Stdio) *interfaces.CommandResult {
-	// Reset CPU usage and peak memory since we're starting a new task.
-	c.stats.Reset()
+	// Set the baseline for stats to ensure that we only report the usage
+	// incurred during this Exec() call.
+	s, err := c.Stats(ctx)
+	if err != nil {
+		return commandutil.ErrorResult(status.UnavailableErrorf("failed to get baseline stats for execution: %s", err))
+	}
+	c.stats.SetBaseline(s)
+
 	args := []string{"exec", "--cwd=" + execrootPath}
 	// Respect command env. Note, when setting any --env vars at all, it
 	// completely overrides the env from the bundle, rather than just adding
@@ -344,7 +350,7 @@ func (c *ociContainer) Exec(ctx context.Context, cmd *repb.Command, stdio *inter
 	if !ok {
 		return commandutil.ErrorResult(status.UnavailableError("exec called before pulling image"))
 	}
-	cmd, err := withImageConfig(cmd, image)
+	cmd, err = withImageConfig(cmd, image)
 	if err != nil {
 		return commandutil.ErrorResult(status.UnavailableErrorf("apply image config: %s", err))
 	}

--- a/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
+++ b/enterprise/server/remote_execution/containers/ociruntime/ociruntime_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -373,12 +372,6 @@ TEST_ENV_VAR=foo
 }
 
 func TestCreateExecPauseUnpause(t *testing.T) {
-	if runtime.GOARCH == "arm64" {
-		// TODO: fix test on arm64. It fails due to some issue with cgroups on
-		// the GH Actions runners.
-		t.Skipf("test is skipped on arm64")
-	}
-
 	image := manuallyProvisionedBusyboxImage(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
The current call to `Reset()` sets the stats baseline to the last observed value, but if a runner has background processes running, then the last observed value won't account for any usage from background processes since the last call to `Exec()` finished.

There is some evidence that this is causing task sizes to be inflated - some tasks with runner recycling enabled have very high pressure stall times which are close to or exceed the task's execution duration, which doesn't make much sense. But this could be explained by the fact that the current `Reset()` implementation ignores any resource usage since the previous task finished its `Exec()` call (e.g. while it was uploading outputs).

**Related issues**: N/A
