### PR TITLE
[raft] fix a regression when aggregating errors

### DIFF
--- a/enterprise/server/raft/client/client.go
+++ b/enterprise/server/raft/client/client.go
@@ -131,6 +131,8 @@ func (e *aggErr) err() error {
 
 	if e.lastErr == dragonboat.ErrShardNotFound {
 		return e.lastErr
+	} else if status.IsOutOfRangeError(e.lastErr) {
+		return e.lastErr
 	} else if e.lastErr == e.lastNonTimeoutErr {
 		return fmt.Errorf("last error: %s, errors encountered: %+v", e.lastErr, e.errCount)
 	} else {


### PR DESCRIPTION
<!-- Optional: Provide additional context (beyond the PR title). -->

<!-- Optional: link a GitHub issue.
     Example: "Fixes #123" will auto-close #123 when the PR is merged. -->

**Related issues**: N/A
Fix a regression introduced in
https://github.com/buildbuddy-io/buildbuddy/pull/7032, as a result, we are not retrying OutOfRange errors from SyncPropose.
This caused RemoveDeadReplica test to be flaky.
